### PR TITLE
feat(link): add linking pipeline stubs (#10)

### DIFF
--- a/creek-tools/creek/link/__init__.py
+++ b/creek-tools/creek/link/__init__.py
@@ -1,0 +1,28 @@
+"""Creek linking pipeline — stubs for embedding, temporal, thread, and eddy linkers.
+
+This package provides stub implementations for the four linking stages
+of the Creek pipeline.  Real implementations will be added in issues #28-33.
+
+Public API:
+    - ``EmbeddingLinker`` — generate embeddings and find semantic resonances
+    - ``TemporalLinker`` — find temporal proximity links
+    - ``ThreadDetector`` — detect narrative threads
+    - ``EddyDetector`` — detect topic cluster eddies
+    - ``LinkingResult`` — Pydantic model for pipeline result counts
+    - ``LinkingPipeline`` — orchestrate all four linking stages
+"""
+
+from creek.link.eddies import EddyDetector
+from creek.link.embeddings import EmbeddingLinker
+from creek.link.linker import LinkingPipeline, LinkingResult
+from creek.link.temporal import TemporalLinker
+from creek.link.threads import ThreadDetector
+
+__all__ = [
+    "EddyDetector",
+    "EmbeddingLinker",
+    "LinkingPipeline",
+    "LinkingResult",
+    "TemporalLinker",
+    "ThreadDetector",
+]

--- a/creek-tools/creek/link/eddies.py
+++ b/creek-tools/creek/link/eddies.py
@@ -1,0 +1,40 @@
+"""Eddy detection stub.
+
+Provides the ``EddyDetector`` class which will identify topic clusters
+(eddies) where multiple threads converge.  This module is a stub — the
+real implementation comes in issues #28-33.
+"""
+
+import logging
+
+from creek.models import Eddy, Fragment
+
+logger = logging.getLogger(__name__)
+
+
+class EddyDetector:
+    """Detect topic cluster eddies across a collection of fragments.
+
+    This is a stub implementation that logs what it would do and returns
+    an empty list.  The real eddy detection logic will be added in later
+    issues.
+    """
+
+    def detect_eddies(self, fragments: list[Fragment]) -> list[Eddy]:
+        """Detect topic cluster eddies in a set of fragments.
+
+        This is a stub that returns an empty list.  The real implementation
+        will analyse fragment relationships to identify convergence points.
+
+        Args:
+            fragments: List of fragments to scan for eddy patterns.
+
+        Returns:
+            A list of detected ``Eddy`` objects.  Currently returns an
+            empty list.
+        """
+        logger.info(
+            "Stub: would detect eddies among %d fragment(s)",
+            len(fragments),
+        )
+        return []

--- a/creek-tools/creek/link/embeddings.py
+++ b/creek-tools/creek/link/embeddings.py
@@ -1,0 +1,76 @@
+"""Embedding-based fragment linker stub.
+
+Provides the ``EmbeddingLinker`` class which will generate vector embeddings
+for fragments and find semantic resonances between them.  This module is a
+stub — the real implementation comes in issues #28-33.
+"""
+
+import logging
+
+from creek.config import EmbeddingsConfig
+from creek.models import Fragment
+
+logger = logging.getLogger(__name__)
+
+
+class EmbeddingLinker:
+    """Generate embeddings and find semantic resonances between fragments.
+
+    This is a stub implementation that logs what it would do and returns
+    empty results.  The real embedding logic will be added in later issues.
+
+    Attributes:
+        config: The embeddings configuration specifying model and threshold.
+    """
+
+    def __init__(self, config: EmbeddingsConfig) -> None:
+        """Initialise the EmbeddingLinker with the given configuration.
+
+        Args:
+            config: Embeddings configuration with model name and
+                similarity threshold.
+        """
+        self.config = config
+
+    def generate_embeddings(self, fragments: list[Fragment]) -> dict[str, list[float]]:
+        """Generate vector embeddings for a list of fragments.
+
+        This is a stub that returns an empty dict.  The real implementation
+        will use the configured embedding model to vectorise each fragment.
+
+        Args:
+            fragments: List of fragments to generate embeddings for.
+
+        Returns:
+            A mapping of fragment IDs to their embedding vectors.
+            Currently returns an empty dict.
+        """
+        logger.info(
+            "Stub: would generate embeddings for %d fragment(s) using model '%s'",
+            len(fragments),
+            self.config.model,
+        )
+        return {}
+
+    def find_resonances(
+        self, embeddings: dict[str, list[float]]
+    ) -> list[tuple[str, str, float]]:
+        """Find semantic resonances between fragments via cosine similarity.
+
+        This is a stub that returns an empty list.  The real implementation
+        will compute pairwise similarity and filter by the configured
+        threshold.
+
+        Args:
+            embeddings: Mapping of fragment IDs to their embedding vectors.
+
+        Returns:
+            A list of ``(fragment_id_a, fragment_id_b, similarity)`` tuples
+            for each resonance found.  Currently returns an empty list.
+        """
+        logger.info(
+            "Stub: would find resonances among %d embedding(s) with threshold %.2f",
+            len(embeddings),
+            self.config.similarity_threshold,
+        )
+        return []

--- a/creek-tools/creek/link/linker.py
+++ b/creek-tools/creek/link/linker.py
@@ -1,0 +1,144 @@
+"""Linking pipeline orchestrator.
+
+Provides ``LinkingResult`` (a Pydantic model capturing link counts) and
+``LinkingPipeline`` which sequences all four linker stages: embeddings,
+temporal, threads, and eddies.
+"""
+
+import logging
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from creek.config import EmbeddingsConfig, LinkingConfig
+from creek.link.eddies import EddyDetector
+from creek.link.embeddings import EmbeddingLinker
+from creek.link.temporal import TemporalLinker
+from creek.link.threads import ThreadDetector
+from creek.models import Fragment
+
+logger = logging.getLogger(__name__)
+
+
+class LinkingResult(BaseModel):
+    """Result of a linking pipeline run, capturing counts per link type.
+
+    Attributes:
+        resonance_count: Number of semantic resonances found.
+        temporal_count: Number of temporal proximity links found.
+        thread_count: Number of narrative threads detected.
+        eddy_count: Number of topic cluster eddies detected.
+    """
+
+    resonance_count: int
+    temporal_count: int
+    thread_count: int
+    eddy_count: int
+
+
+class LinkingPipeline:
+    """Orchestrate the full linking pipeline across all four linker stages.
+
+    The pipeline sequences: embeddings -> temporal -> threads -> eddies,
+    collecting results from each stage into a ``LinkingResult``.
+
+    Attributes:
+        config: Embeddings configuration for the embedding linker.
+        linking_config: Linking configuration for temporal window and
+            minimum fragment thresholds.
+    """
+
+    def __init__(self, config: EmbeddingsConfig, linking_config: LinkingConfig) -> None:
+        """Initialise the LinkingPipeline with both configuration objects.
+
+        Args:
+            config: Embeddings configuration with model name and
+                similarity threshold.
+            linking_config: Linking configuration with temporal window
+                and minimum fragment counts.
+        """
+        self.config = config
+        self.linking_config = linking_config
+
+    def run(self, fragments: list[Fragment], vault_path: Path) -> LinkingResult:
+        """Run all four linking stages in sequence and return the result.
+
+        Stages are executed in order:
+        1. Generate embeddings and find resonances
+        2. Find temporal proximity links
+        3. Detect narrative threads
+        4. Detect topic cluster eddies
+
+        Args:
+            fragments: List of fragments to process through the pipeline.
+            vault_path: Path to the Obsidian vault (used for future I/O).
+
+        Returns:
+            A ``LinkingResult`` with counts from each linking stage.
+        """
+        logger.info(
+            "Starting linking pipeline for %d fragment(s) in vault '%s'",
+            len(fragments),
+            vault_path,
+        )
+
+        # Stage 1: Embeddings and resonances
+        embedding_linker = EmbeddingLinker(config=self.config)
+        embeddings = embedding_linker.generate_embeddings(fragments)
+        resonances = embedding_linker.find_resonances(embeddings)
+
+        # Stage 2: Temporal proximity
+        temporal_linker = TemporalLinker()
+        temporal_links = temporal_linker.find_temporal_links(
+            fragments,
+            window_hours=self.linking_config.temporal_window_hours,
+        )
+
+        # Stage 3: Thread detection
+        thread_detector = ThreadDetector()
+        threads = thread_detector.detect_threads(fragments)
+
+        # Stage 4: Eddy detection
+        eddy_detector = EddyDetector()
+        eddies = eddy_detector.detect_eddies(fragments)
+
+        result = LinkingResult(
+            resonance_count=len(resonances),
+            temporal_count=len(temporal_links),
+            thread_count=len(threads),
+            eddy_count=len(eddies),
+        )
+
+        logger.info(
+            "Linking pipeline complete: %d resonances, %d temporal, "
+            "%d threads, %d eddies",
+            result.resonance_count,
+            result.temporal_count,
+            result.thread_count,
+            result.eddy_count,
+        )
+
+        return result
+
+    def add_wikilinks(self, fragment: Fragment, links: list[str]) -> Fragment:
+        """Add wikilinks to a fragment's threads list without duplicates.
+
+        Creates a new ``Fragment`` with the links appended to the threads
+        list.  Does not mutate the original fragment.
+
+        Args:
+            fragment: The fragment to add wikilinks to.
+            links: List of wikilink strings (e.g. ``["[[Thread A]]"]``)
+                to add to the fragment's threads.
+
+        Returns:
+            A new ``Fragment`` with the links added to its threads list.
+        """
+        existing = set(fragment.threads)
+        new_threads = list(fragment.threads)
+        for link in links:
+            if link not in existing:
+                new_threads.append(link)
+                existing.add(link)
+
+        return fragment.model_copy(update={"threads": new_threads})

--- a/creek-tools/creek/link/temporal.py
+++ b/creek-tools/creek/link/temporal.py
@@ -1,0 +1,47 @@
+"""Temporal proximity linker stub.
+
+Provides the ``TemporalLinker`` class which will find fragments created
+within a configurable time window of each other.  This module is a stub —
+the real implementation comes in issues #28-33.
+"""
+
+import logging
+
+from creek.models import Fragment
+
+logger = logging.getLogger(__name__)
+
+
+class TemporalLinker:
+    """Find temporal proximity links between fragments.
+
+    This is a stub implementation that logs what it would do and returns
+    an empty list.  The real temporal linking logic will be added in later
+    issues.
+    """
+
+    def find_temporal_links(
+        self, fragments: list[Fragment], window_hours: int
+    ) -> list[tuple[str, str]]:
+        """Find fragment pairs created within a time window of each other.
+
+        This is a stub that returns an empty list.  The real implementation
+        will compare creation timestamps and return pairs within the
+        configured window.
+
+        Args:
+            fragments: List of fragments to check for temporal proximity.
+            window_hours: Maximum hours between creation times to consider
+                fragments temporally linked.
+
+        Returns:
+            A list of ``(fragment_id_a, fragment_id_b)`` tuples for each
+            temporal link found.  Currently returns an empty list.
+        """
+        logger.info(
+            "Stub: would find temporal links among %d fragment(s) "
+            "within %d-hour window",
+            len(fragments),
+            window_hours,
+        )
+        return []

--- a/creek-tools/creek/link/threads.py
+++ b/creek-tools/creek/link/threads.py
@@ -1,0 +1,40 @@
+"""Thread detection stub.
+
+Provides the ``ThreadDetector`` class which will identify recurring
+narrative threads across fragments.  This module is a stub — the real
+implementation comes in issues #28-33.
+"""
+
+import logging
+
+from creek.models import Fragment, Thread
+
+logger = logging.getLogger(__name__)
+
+
+class ThreadDetector:
+    """Detect narrative threads across a collection of fragments.
+
+    This is a stub implementation that logs what it would do and returns
+    an empty list.  The real thread detection logic will be added in later
+    issues.
+    """
+
+    def detect_threads(self, fragments: list[Fragment]) -> list[Thread]:
+        """Detect recurring narrative threads in a set of fragments.
+
+        This is a stub that returns an empty list.  The real implementation
+        will analyse fragment content and metadata to identify threads.
+
+        Args:
+            fragments: List of fragments to scan for thread patterns.
+
+        Returns:
+            A list of detected ``Thread`` objects.  Currently returns an
+            empty list.
+        """
+        logger.info(
+            "Stub: would detect threads among %d fragment(s)",
+            len(fragments),
+        )
+        return []

--- a/creek-tools/tests/test_link.py
+++ b/creek-tools/tests/test_link.py
@@ -1,0 +1,422 @@
+"""Tests for creek.link module — linking pipeline stubs.
+
+Tests cover EmbeddingLinker, TemporalLinker, ThreadDetector, EddyDetector,
+LinkingResult, and LinkingPipeline orchestration.
+"""
+
+import logging
+from pathlib import Path
+
+from creek.config import EmbeddingsConfig, LinkingConfig
+from creek.link import (
+    EddyDetector,
+    EmbeddingLinker,
+    LinkingPipeline,
+    LinkingResult,
+    TemporalLinker,
+    ThreadDetector,
+)
+from creek.link.eddies import EddyDetector as EddyDetectorDirect
+from creek.link.embeddings import EmbeddingLinker as EmbeddingLinkerDirect
+from creek.link.linker import LinkingPipeline as LinkingPipelineDirect
+from creek.link.linker import LinkingResult as LinkingResultDirect
+from creek.link.temporal import TemporalLinker as TemporalLinkerDirect
+from creek.link.threads import ThreadDetector as ThreadDetectorDirect
+from creek.models import Fragment, FragmentSource, SourcePlatform
+
+
+def _make_fragment(title: str = "Test Fragment") -> Fragment:
+    """Create a minimal Fragment for testing."""
+    return Fragment(
+        title=title,
+        source=FragmentSource(platform=SourcePlatform.CLAUDE),
+    )
+
+
+# ---- Package __init__ re-exports ----
+
+
+class TestPackageExports:
+    """Tests that creek.link.__init__ re-exports all public classes."""
+
+    def test_embedding_linker_reexported(self) -> None:
+        """EmbeddingLinker should be importable from creek.link."""
+        assert EmbeddingLinker is EmbeddingLinkerDirect
+
+    def test_temporal_linker_reexported(self) -> None:
+        """TemporalLinker should be importable from creek.link."""
+        assert TemporalLinker is TemporalLinkerDirect
+
+    def test_thread_detector_reexported(self) -> None:
+        """ThreadDetector should be importable from creek.link."""
+        assert ThreadDetector is ThreadDetectorDirect
+
+    def test_eddy_detector_reexported(self) -> None:
+        """EddyDetector should be importable from creek.link."""
+        assert EddyDetector is EddyDetectorDirect
+
+    def test_linking_result_reexported(self) -> None:
+        """LinkingResult should be importable from creek.link."""
+        assert LinkingResult is LinkingResultDirect
+
+    def test_linking_pipeline_reexported(self) -> None:
+        """LinkingPipeline should be importable from creek.link."""
+        assert LinkingPipeline is LinkingPipelineDirect
+
+
+# ---- EmbeddingLinker Tests ----
+
+
+class TestEmbeddingLinker:
+    """Tests for the EmbeddingLinker stub class."""
+
+    def test_init_stores_config(self) -> None:
+        """EmbeddingLinker should store the provided EmbeddingsConfig."""
+        config = EmbeddingsConfig(model="test-model", similarity_threshold=0.8)
+        linker = EmbeddingLinker(config=config)
+        assert linker.config is config
+
+    def test_generate_embeddings_returns_empty_dict(self) -> None:
+        """Stub generate_embeddings should return an empty dict."""
+        config = EmbeddingsConfig()
+        linker = EmbeddingLinker(config=config)
+        fragments = [_make_fragment("A"), _make_fragment("B")]
+        result = linker.generate_embeddings(fragments)
+        assert result == {}
+        assert isinstance(result, dict)
+
+    def test_generate_embeddings_empty_input(self) -> None:
+        """generate_embeddings with empty list should return empty dict."""
+        config = EmbeddingsConfig()
+        linker = EmbeddingLinker(config=config)
+        result = linker.generate_embeddings([])
+        assert result == {}
+
+    def test_find_resonances_returns_empty_list(self) -> None:
+        """Stub find_resonances should return an empty list."""
+        config = EmbeddingsConfig()
+        linker = EmbeddingLinker(config=config)
+        embeddings: dict[str, list[float]] = {
+            "frag-1": [0.1, 0.2],
+            "frag-2": [0.3, 0.4],
+        }
+        result = linker.find_resonances(embeddings)
+        assert result == []
+        assert isinstance(result, list)
+
+    def test_find_resonances_empty_input(self) -> None:
+        """find_resonances with empty dict should return empty list."""
+        config = EmbeddingsConfig()
+        linker = EmbeddingLinker(config=config)
+        result = linker.find_resonances({})
+        assert result == []
+
+    def test_generate_embeddings_logs_message(self, caplog) -> None:
+        """generate_embeddings should log an info message."""
+        config = EmbeddingsConfig()
+        linker = EmbeddingLinker(config=config)
+        fragments = [_make_fragment("A")]
+        with caplog.at_level(logging.INFO, logger="creek.link.embeddings"):
+            linker.generate_embeddings(fragments)
+        assert any("embedding" in r.message.lower() for r in caplog.records)
+
+    def test_find_resonances_logs_message(self, caplog) -> None:
+        """find_resonances should log an info message."""
+        config = EmbeddingsConfig()
+        linker = EmbeddingLinker(config=config)
+        with caplog.at_level(logging.INFO, logger="creek.link.embeddings"):
+            linker.find_resonances({"frag-1": [0.1]})
+        assert any("resonance" in r.message.lower() for r in caplog.records)
+
+
+# ---- TemporalLinker Tests ----
+
+
+class TestTemporalLinker:
+    """Tests for the TemporalLinker stub class."""
+
+    def test_find_temporal_links_returns_empty_list(self) -> None:
+        """Stub find_temporal_links should return an empty list."""
+        linker = TemporalLinker()
+        fragments = [_make_fragment("A"), _make_fragment("B")]
+        result = linker.find_temporal_links(fragments, window_hours=168)
+        assert result == []
+        assert isinstance(result, list)
+
+    def test_find_temporal_links_empty_input(self) -> None:
+        """find_temporal_links with empty list should return empty list."""
+        linker = TemporalLinker()
+        result = linker.find_temporal_links([], window_hours=24)
+        assert result == []
+
+    def test_find_temporal_links_custom_window(self) -> None:
+        """find_temporal_links should accept custom window_hours."""
+        linker = TemporalLinker()
+        fragments = [_make_fragment("A")]
+        result = linker.find_temporal_links(fragments, window_hours=48)
+        assert result == []
+
+    def test_find_temporal_links_logs_message(self, caplog) -> None:
+        """find_temporal_links should log an info message."""
+        linker = TemporalLinker()
+        fragments = [_make_fragment("A")]
+        with caplog.at_level(logging.INFO, logger="creek.link.temporal"):
+            linker.find_temporal_links(fragments, window_hours=168)
+        assert any("temporal" in r.message.lower() for r in caplog.records)
+
+
+# ---- ThreadDetector Tests ----
+
+
+class TestThreadDetector:
+    """Tests for the ThreadDetector stub class."""
+
+    def test_detect_threads_returns_empty_list(self) -> None:
+        """Stub detect_threads should return an empty list."""
+        detector = ThreadDetector()
+        fragments = [_make_fragment("A"), _make_fragment("B")]
+        result = detector.detect_threads(fragments)
+        assert result == []
+        assert isinstance(result, list)
+
+    def test_detect_threads_empty_input(self) -> None:
+        """detect_threads with empty list should return empty list."""
+        detector = ThreadDetector()
+        result = detector.detect_threads([])
+        assert result == []
+
+    def test_detect_threads_logs_message(self, caplog) -> None:
+        """detect_threads should log an info message."""
+        detector = ThreadDetector()
+        fragments = [_make_fragment("A")]
+        with caplog.at_level(logging.INFO, logger="creek.link.threads"):
+            detector.detect_threads(fragments)
+        assert any("thread" in r.message.lower() for r in caplog.records)
+
+
+# ---- EddyDetector Tests ----
+
+
+class TestEddyDetector:
+    """Tests for the EddyDetector stub class."""
+
+    def test_detect_eddies_returns_empty_list(self) -> None:
+        """Stub detect_eddies should return an empty list."""
+        detector = EddyDetector()
+        fragments = [_make_fragment("A"), _make_fragment("B")]
+        result = detector.detect_eddies(fragments)
+        assert result == []
+        assert isinstance(result, list)
+
+    def test_detect_eddies_empty_input(self) -> None:
+        """detect_eddies with empty list should return empty list."""
+        detector = EddyDetector()
+        result = detector.detect_eddies([])
+        assert result == []
+
+    def test_detect_eddies_logs_message(self, caplog) -> None:
+        """detect_eddies should log an info message."""
+        detector = EddyDetector()
+        fragments = [_make_fragment("A")]
+        with caplog.at_level(logging.INFO, logger="creek.link.eddies"):
+            detector.detect_eddies(fragments)
+        assert any("edd" in r.message.lower() for r in caplog.records)
+
+
+# ---- LinkingResult Tests ----
+
+
+class TestLinkingResult:
+    """Tests for the LinkingResult Pydantic model."""
+
+    def test_creation_with_all_fields(self) -> None:
+        """LinkingResult should accept all four count fields."""
+        result = LinkingResult(
+            resonance_count=5,
+            temporal_count=3,
+            thread_count=2,
+            eddy_count=1,
+        )
+        assert result.resonance_count == 5
+        assert result.temporal_count == 3
+        assert result.thread_count == 2
+        assert result.eddy_count == 1
+
+    def test_zero_counts(self) -> None:
+        """LinkingResult should work with all zero counts."""
+        result = LinkingResult(
+            resonance_count=0,
+            temporal_count=0,
+            thread_count=0,
+            eddy_count=0,
+        )
+        assert result.resonance_count == 0
+        assert result.temporal_count == 0
+        assert result.thread_count == 0
+        assert result.eddy_count == 0
+
+    def test_model_dump(self) -> None:
+        """LinkingResult model_dump should produce a serializable dict."""
+        result = LinkingResult(
+            resonance_count=1,
+            temporal_count=2,
+            thread_count=3,
+            eddy_count=4,
+        )
+        dump = result.model_dump()
+        assert dump == {
+            "resonance_count": 1,
+            "temporal_count": 2,
+            "thread_count": 3,
+            "eddy_count": 4,
+        }
+
+
+# ---- LinkingPipeline Tests ----
+
+
+class TestLinkingPipeline:
+    """Tests for the LinkingPipeline orchestrator class."""
+
+    def test_init_stores_configs(self) -> None:
+        """LinkingPipeline should store both config objects."""
+        emb_config = EmbeddingsConfig()
+        link_config = LinkingConfig()
+        pipeline = LinkingPipeline(config=emb_config, linking_config=link_config)
+        assert pipeline.config is emb_config
+        assert pipeline.linking_config is link_config
+
+    def test_run_returns_linking_result(self) -> None:
+        """Pipeline.run should return a LinkingResult instance."""
+        pipeline = LinkingPipeline(
+            config=EmbeddingsConfig(),
+            linking_config=LinkingConfig(),
+        )
+        fragments = [_make_fragment("A"), _make_fragment("B")]
+        result = pipeline.run(
+            fragments=fragments,
+            vault_path=Path("/fake/vault"),
+        )
+        assert isinstance(result, LinkingResult)
+
+    def test_run_returns_zero_counts_for_stubs(self) -> None:
+        """Pipeline.run with stubs should return all zero counts."""
+        pipeline = LinkingPipeline(
+            config=EmbeddingsConfig(),
+            linking_config=LinkingConfig(),
+        )
+        fragments = [_make_fragment("A")]
+        result = pipeline.run(
+            fragments=fragments,
+            vault_path=Path("/fake/vault"),
+        )
+        assert result.resonance_count == 0
+        assert result.temporal_count == 0
+        assert result.thread_count == 0
+        assert result.eddy_count == 0
+
+    def test_run_empty_fragments(self) -> None:
+        """Pipeline.run with empty fragment list should succeed."""
+        pipeline = LinkingPipeline(
+            config=EmbeddingsConfig(),
+            linking_config=LinkingConfig(),
+        )
+        result = pipeline.run(
+            fragments=[],
+            vault_path=Path("/fake/vault"),
+        )
+        assert isinstance(result, LinkingResult)
+        assert result.resonance_count == 0
+
+    def test_run_logs_pipeline_stages(self, caplog) -> None:
+        """Pipeline.run should log info about each stage."""
+        pipeline = LinkingPipeline(
+            config=EmbeddingsConfig(),
+            linking_config=LinkingConfig(),
+        )
+        fragments = [_make_fragment("A")]
+        with caplog.at_level(logging.INFO):
+            pipeline.run(
+                fragments=fragments,
+                vault_path=Path("/fake/vault"),
+            )
+        messages = " ".join(r.message.lower() for r in caplog.records)
+        assert "embedding" in messages
+        assert "temporal" in messages
+        assert "thread" in messages
+        assert "edd" in messages
+
+    def test_add_wikilinks_to_threads(self) -> None:
+        """add_wikilinks should add links to fragment threads list."""
+        pipeline = LinkingPipeline(
+            config=EmbeddingsConfig(),
+            linking_config=LinkingConfig(),
+        )
+        fragment = _make_fragment("Test")
+        assert fragment.threads == []
+        updated = pipeline.add_wikilinks(
+            fragment=fragment,
+            links=["[[Thread A]]", "[[Thread B]]"],
+        )
+        assert "[[Thread A]]" in updated.threads
+        assert "[[Thread B]]" in updated.threads
+
+    def test_add_wikilinks_preserves_existing(self) -> None:
+        """add_wikilinks should preserve existing thread entries."""
+        pipeline = LinkingPipeline(
+            config=EmbeddingsConfig(),
+            linking_config=LinkingConfig(),
+        )
+        fragment = Fragment(
+            title="Test",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+            threads=["existing-thread"],
+        )
+        updated = pipeline.add_wikilinks(
+            fragment=fragment,
+            links=["[[New Link]]"],
+        )
+        assert "existing-thread" in updated.threads
+        assert "[[New Link]]" in updated.threads
+
+    def test_add_wikilinks_empty_links(self) -> None:
+        """add_wikilinks with empty links list should return fragment unchanged."""
+        pipeline = LinkingPipeline(
+            config=EmbeddingsConfig(),
+            linking_config=LinkingConfig(),
+        )
+        fragment = _make_fragment("Test")
+        updated = pipeline.add_wikilinks(fragment=fragment, links=[])
+        assert updated.threads == fragment.threads
+
+    def test_add_wikilinks_no_duplicates(self) -> None:
+        """add_wikilinks should not add duplicate links."""
+        pipeline = LinkingPipeline(
+            config=EmbeddingsConfig(),
+            linking_config=LinkingConfig(),
+        )
+        fragment = Fragment(
+            title="Test",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+            threads=["[[Existing]]"],
+        )
+        updated = pipeline.add_wikilinks(
+            fragment=fragment,
+            links=["[[Existing]]", "[[New]]"],
+        )
+        assert updated.threads.count("[[Existing]]") == 1
+        assert "[[New]]" in updated.threads
+
+    def test_add_wikilinks_returns_new_fragment(self) -> None:
+        """add_wikilinks should return a new Fragment, not mutate the original."""
+        pipeline = LinkingPipeline(
+            config=EmbeddingsConfig(),
+            linking_config=LinkingConfig(),
+        )
+        fragment = _make_fragment("Test")
+        updated = pipeline.add_wikilinks(
+            fragment=fragment,
+            links=["[[Link]]"],
+        )
+        assert fragment.threads == []
+        assert "[[Link]]" in updated.threads


### PR DESCRIPTION
## Summary
- Add `creek/link/` package with four linking stage stubs
- `EmbeddingLinker` — stub for semantic similarity via embeddings
- `TemporalLinker` — stub for temporal proximity linking
- `ThreadDetector` — stub for narrative thread detection
- `EddyDetector` — stub for topic cluster (eddy) formation
- `LinkingPipeline` — orchestrator that sequences all four stages
- `LinkingResult` — Pydantic model for counts of each link type
- Wiki-link addition to fragment frontmatter (immutable updates)
- 36 new tests in `tests/test_link.py`

## Test plan
- [x] All 162 tests pass (126 existing + 36 new)
- [x] 99.58% branch coverage
- [x] MyPy strict passes (0 issues)
- [x] Interrogate 100% docstring coverage
- [x] Ruff, Bandit all pass
- [x] All stubs callable and return correct types
- [x] Pipeline orchestration tested
- [x] Wikilink addition tested (immutability, deduplication)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)