### PR TITLE
feat(ingest): add abstract Ingestor base class with shared utilities (#6)

### DIFF
--- a/creek-tools/creek/ingest/__init__.py
+++ b/creek-tools/creek/ingest/__init__.py
@@ -1,0 +1,32 @@
+"""Creek ingest package — registry of available ingestors and base classes.
+
+This package provides the abstract ``Ingestor`` base class and shared
+utilities for building source-specific ingestors. Concrete ingestor
+implementations register themselves in the ``INGESTOR_REGISTRY`` dict.
+
+Exports:
+    INGESTOR_REGISTRY: A dict mapping ingestor names to their classes.
+    RawDocument: Pydantic model for raw document data.
+    ParsedFragment: Pydantic model for parsed fragment data.
+    IngestResult: Pydantic model for ingest pipeline results.
+    Ingestor: Abstract base class for all ingestors.
+"""
+
+from creek.ingest.base import Ingestor, IngestResult, ParsedFragment, RawDocument
+
+INGESTOR_REGISTRY: dict[str, type[Ingestor]] = {}
+"""Registry mapping ingestor names to their concrete classes.
+
+Concrete ingestors should register themselves here upon import, e.g.::
+
+    from creek.ingest import INGESTOR_REGISTRY
+    INGESTOR_REGISTRY["claude"] = ClaudeIngestor
+"""
+
+__all__ = [
+    "INGESTOR_REGISTRY",
+    "IngestResult",
+    "Ingestor",
+    "ParsedFragment",
+    "RawDocument",
+]

--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -1,0 +1,507 @@
+"""Abstract Ingestor base class and shared utilities for the Creek ingest pipeline.
+
+This module provides:
+
+- **Pydantic models**: ``RawDocument``, ``ParsedFragment``, ``ProvenanceEntry``,
+  and ``IngestResult`` for structured data flow through the ingest pipeline.
+- **Utility functions**: ``normalize_encoding``, ``normalize_timestamp``,
+  ``generate_fragment_id``, and ``create_provenance_entry`` for common
+  ingest operations.
+- **Abstract base class**: ``Ingestor`` defining the four-stage pipeline
+  (discover, parse, convert, frontmatter) with a concrete ``ingest()``
+  orchestrator.
+"""
+
+from __future__ import annotations
+
+import abc
+import hashlib
+import logging
+from datetime import UTC, datetime
+from pathlib import Path  # noqa: TC003 — needed at runtime by Pydantic
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import chardet
+from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
+
+# ---- Constants ----
+
+LA_TZ = ZoneInfo("America/Los_Angeles")
+"""Target timezone for all normalized timestamps."""
+
+# ---- Pydantic Models ----
+
+
+class RawDocument(BaseModel):
+    """A raw document discovered by an ingestor before parsing.
+
+    Holds the file path, raw byte content, arbitrary metadata, and the
+    detected character encoding.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    path: Path
+    """Filesystem path to the source file."""
+
+    content: bytes
+    """Raw byte content of the file."""
+
+    metadata: dict[str, Any]
+    """Arbitrary metadata attached during discovery."""
+
+    detected_encoding: str
+    """Character encoding detected or declared for this document."""
+
+
+class ParsedFragment(BaseModel):
+    """A structured content fragment extracted from a raw document.
+
+    Represents one logical unit of content after parsing, with its
+    source provenance and timestamp.
+    """
+
+    content: str
+    """The extracted text content."""
+
+    metadata: dict[str, Any]
+    """Arbitrary metadata from parsing (e.g., headers, tags)."""
+
+    source_path: str
+    """Path to the original source file."""
+
+    timestamp: datetime
+    """Timestamp associated with this fragment."""
+
+
+class ProvenanceEntry(BaseModel):
+    """A structured provenance record for auditing ingest operations.
+
+    Tracks which ingestor processed which source file, when, and whether
+    the operation succeeded.
+    """
+
+    source_path: str
+    """Path to the source file that was ingested."""
+
+    ingestor_name: str
+    """Name of the ingestor class that processed this file."""
+
+    timestamp: datetime
+    """When the ingest operation occurred."""
+
+    fragment_id: str
+    """The generated fragment ID for this entry."""
+
+    status: str
+    """Status of the ingest operation (e.g., 'success', 'error', 'skipped')."""
+
+
+class IngestResult(BaseModel):
+    """Result of a complete ingest pipeline run.
+
+    Collects all parsed fragments, provenance entries, and any error
+    messages produced during the ingest process.
+    """
+
+    fragments: list[ParsedFragment] = Field(default_factory=list)
+    """Parsed fragments produced by the ingest pipeline."""
+
+    provenance: list[ProvenanceEntry] = Field(default_factory=list)
+    """Provenance records for auditing."""
+
+    errors: list[str] = Field(default_factory=list)
+    """Error messages collected during ingest."""
+
+
+# ---- Shared Utility Functions ----
+
+
+def normalize_encoding(raw_bytes: bytes) -> tuple[str, str]:
+    """Detect the encoding of raw bytes and convert to UTF-8 text.
+
+    Uses ``chardet`` for encoding detection. Empty input returns an
+    empty string with ``"utf-8"`` as the detected encoding.
+
+    Args:
+        raw_bytes: The raw bytes to detect and decode.
+
+    Returns:
+        A tuple of ``(decoded_text, detected_encoding)``.
+    """
+    if not raw_bytes:
+        return "", "utf-8"
+
+    detection = chardet.detect(raw_bytes)
+    encoding = detection.get("encoding") or "utf-8"
+
+    text = raw_bytes.decode(encoding, errors="replace")
+    return text, encoding
+
+
+def normalize_timestamp(ts_string: str, source_tz: str | None) -> datetime:
+    """Parse a timestamp string and normalize to America/Los_Angeles.
+
+    Supports ISO 8601 formats, date-only strings, and common datetime
+    formats. If the timestamp is naive (no timezone info), ``source_tz``
+    is used to localize it; if ``source_tz`` is also ``None``, UTC is
+    assumed.
+
+    Args:
+        ts_string: The timestamp string to parse.
+        source_tz: Optional IANA timezone name for naive timestamps.
+
+    Returns:
+        A timezone-aware ``datetime`` in America/Los_Angeles.
+
+    Raises:
+        ValueError: If the timestamp string cannot be parsed.
+    """
+    parsed = _parse_timestamp_string(ts_string)
+    localized = _localize_naive_timestamp(parsed, source_tz)
+    return localized.astimezone(LA_TZ)
+
+
+def _parse_timestamp_string(ts_string: str) -> datetime:
+    """Parse a timestamp string into a datetime object.
+
+    Tries ISO 8601 format first, then falls back to common formats.
+
+    Args:
+        ts_string: The timestamp string to parse.
+
+    Returns:
+        A datetime object (may be naive or aware).
+
+    Raises:
+        ValueError: If none of the known formats match.
+    """
+    # Try ISO 8601 first (handles timezone offsets)
+    try:
+        return datetime.fromisoformat(ts_string)
+    except ValueError:
+        pass
+
+    # Try common formats
+    formats = [
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M",
+        "%Y-%m-%d",
+        "%m/%d/%Y %H:%M:%S",
+        "%m/%d/%Y",
+    ]
+    for fmt in formats:
+        try:
+            return datetime.strptime(ts_string, fmt)
+        except ValueError:
+            continue
+
+    msg = f"Unable to parse timestamp: {ts_string}"
+    raise ValueError(msg)
+
+
+def _localize_naive_timestamp(dt: datetime, source_tz: str | None) -> datetime:
+    """Attach timezone info to a naive datetime.
+
+    If the datetime is already timezone-aware, returns it unchanged.
+    If naive, uses ``source_tz`` or defaults to UTC.
+
+    Args:
+        dt: The datetime to localize.
+        source_tz: Optional IANA timezone name.
+
+    Returns:
+        A timezone-aware datetime.
+    """
+    if dt.tzinfo is not None:
+        return dt
+
+    tz = ZoneInfo(source_tz) if source_tz is not None else UTC
+    return dt.replace(tzinfo=tz)
+
+
+def generate_fragment_id(source: str, timestamp: datetime, content: str) -> str:
+    """Generate a deterministic fragment ID from source, timestamp, and content.
+
+    Computes a SHA-256 hash of the concatenated inputs and returns the
+    first 12 hex characters prefixed with ``frag-``.
+
+    Args:
+        source: The source identifier (e.g., file path).
+        timestamp: The fragment timestamp.
+        content: The fragment text content.
+
+    Returns:
+        A deterministic ID string in the format ``frag-XXXXXXXXXXXX``.
+    """
+    hash_input = f"{source}:{timestamp.isoformat()}:{content}"
+    digest = hashlib.sha256(hash_input.encode()).hexdigest()[:12]
+    return f"frag-{digest}"
+
+
+def create_provenance_entry(
+    source_path: str,
+    ingestor_name: str,
+    timestamp: datetime,
+    fragment_id: str,
+    status: str,
+) -> ProvenanceEntry:
+    """Create a structured provenance record for an ingest operation.
+
+    Args:
+        source_path: Path to the source file.
+        ingestor_name: Name of the ingestor class.
+        timestamp: When the operation occurred.
+        fragment_id: The generated fragment ID.
+        status: Operation status (e.g., 'success', 'error', 'skipped').
+
+    Returns:
+        A ``ProvenanceEntry`` instance.
+    """
+    return ProvenanceEntry(
+        source_path=source_path,
+        ingestor_name=ingestor_name,
+        timestamp=timestamp,
+        fragment_id=fragment_id,
+        status=status,
+    )
+
+
+# ---- Abstract Base Class ----
+
+
+class Ingestor(abc.ABC):
+    """Abstract base class for all Creek ingestors.
+
+    Defines the four-stage ingest pipeline:
+
+    1. **discover** — find all files/records at a source path
+    2. **parse** — extract structured content from a raw document
+    3. **convert_to_markdown** — convert a parsed fragment to clean Markdown
+    4. **generate_frontmatter** — produce YAML frontmatter metadata
+
+    The concrete ``ingest()`` method orchestrates these stages and collects
+    results, provenance, and errors into an ``IngestResult``.
+
+    Subclasses must implement all four abstract methods.
+    """
+
+    @abc.abstractmethod
+    def discover(self, source_path: Path) -> list[RawDocument]:
+        """Find all files or records at the given source path.
+
+        Args:
+            source_path: The directory or file path to search.
+
+        Returns:
+            A list of ``RawDocument`` objects found at the source.
+        """
+
+    @abc.abstractmethod
+    def parse(self, raw: RawDocument) -> list[ParsedFragment]:
+        """Extract structured content from a raw document.
+
+        Args:
+            raw: The raw document to parse.
+
+        Returns:
+            A list of ``ParsedFragment`` objects extracted from the document.
+        """
+
+    @abc.abstractmethod
+    def convert_to_markdown(self, fragment: ParsedFragment) -> str:
+        """Convert a parsed fragment to clean Markdown.
+
+        Args:
+            fragment: The parsed fragment to convert.
+
+        Returns:
+            A Markdown-formatted string.
+        """
+
+    @abc.abstractmethod
+    def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
+        """Generate YAML frontmatter metadata for a parsed fragment.
+
+        Args:
+            fragment: The parsed fragment.
+
+        Returns:
+            A dict of frontmatter key-value pairs.
+        """
+
+    def ingest(self, source_path: Path) -> IngestResult:
+        """Orchestrate the full ingest pipeline: discover, parse, convert, frontmatter.
+
+        Calls ``discover()`` to find documents, then for each document calls
+        ``parse()`` to extract fragments. For each fragment, calls
+        ``convert_to_markdown()`` and ``generate_frontmatter()``. Collects
+        all results into an ``IngestResult``, handling errors gracefully.
+
+        Args:
+            source_path: The directory or file path to ingest from.
+
+        Returns:
+            An ``IngestResult`` containing fragments, provenance, and errors.
+        """
+        result = IngestResult()
+        ingestor_name = type(self).__name__
+        now = datetime.now(tz=LA_TZ)
+
+        # Stage 1: Discover
+        raw_docs = self._discover_safe(source_path, result)
+
+        # Stages 2-4: Parse, Convert, Frontmatter
+        for raw_doc in raw_docs:
+            self._process_document(raw_doc, result, ingestor_name, now)
+
+        return result
+
+    def _discover_safe(
+        self, source_path: Path, result: IngestResult
+    ) -> list[RawDocument]:
+        """Safely call discover(), catching and logging errors.
+
+        Args:
+            source_path: The path to discover documents at.
+            result: The IngestResult to append errors to.
+
+        Returns:
+            A list of discovered RawDocuments, or empty on error.
+        """
+        try:
+            return self.discover(source_path)
+        except Exception as exc:
+            result.errors.append(f"discover error: {exc}")
+            logger.exception("Error during discover for %s", source_path)
+            return []
+
+    def _process_document(
+        self,
+        raw_doc: RawDocument,
+        result: IngestResult,
+        ingestor_name: str,
+        now: datetime,
+    ) -> None:
+        """Process a single raw document through parse, convert, and frontmatter.
+
+        Args:
+            raw_doc: The raw document to process.
+            result: The IngestResult to collect into.
+            ingestor_name: The class name of this ingestor.
+            now: The current timestamp for provenance.
+        """
+        fragments = self._parse_safe(raw_doc, result)
+        for fragment in fragments:
+            self._process_fragment(fragment, result, ingestor_name, now)
+
+    def _parse_safe(
+        self, raw_doc: RawDocument, result: IngestResult
+    ) -> list[ParsedFragment]:
+        """Safely call parse(), catching and logging errors.
+
+        Args:
+            raw_doc: The raw document to parse.
+            result: The IngestResult to append errors to.
+
+        Returns:
+            A list of parsed fragments, or empty on error.
+        """
+        try:
+            return self.parse(raw_doc)
+        except Exception as exc:
+            result.errors.append(f"parse error for {raw_doc.path}: {exc}")
+            logger.exception("Error parsing %s", raw_doc.path)
+            return []
+
+    def _process_fragment(
+        self,
+        fragment: ParsedFragment,
+        result: IngestResult,
+        ingestor_name: str,
+        now: datetime,
+    ) -> None:
+        """Process a single fragment through convert and frontmatter stages.
+
+        Args:
+            fragment: The parsed fragment to process.
+            result: The IngestResult to collect into.
+            ingestor_name: The class name of this ingestor.
+            now: The current timestamp for provenance.
+        """
+        frag_id = generate_fragment_id(
+            fragment.source_path, fragment.timestamp, fragment.content
+        )
+
+        # Stage 3: Convert to markdown
+        markdown = self._convert_safe(fragment, result)
+
+        # Stage 4: Generate frontmatter
+        frontmatter = self._frontmatter_safe(fragment, result)
+
+        if markdown is not None and frontmatter is not None:
+            fragment.metadata["markdown"] = markdown
+            fragment.metadata["frontmatter"] = frontmatter
+            result.fragments.append(fragment)
+            result.provenance.append(
+                create_provenance_entry(
+                    source_path=fragment.source_path,
+                    ingestor_name=ingestor_name,
+                    timestamp=now,
+                    fragment_id=frag_id,
+                    status="success",
+                )
+            )
+        else:
+            result.provenance.append(
+                create_provenance_entry(
+                    source_path=fragment.source_path,
+                    ingestor_name=ingestor_name,
+                    timestamp=now,
+                    fragment_id=frag_id,
+                    status="error",
+                )
+            )
+
+    def _convert_safe(
+        self, fragment: ParsedFragment, result: IngestResult
+    ) -> str | None:
+        """Safely call convert_to_markdown(), catching errors.
+
+        Args:
+            fragment: The fragment to convert.
+            result: The IngestResult to append errors to.
+
+        Returns:
+            The markdown string, or None on error.
+        """
+        try:
+            return self.convert_to_markdown(fragment)
+        except Exception as exc:
+            result.errors.append(f"convert error for {fragment.source_path}: {exc}")
+            logger.exception("Error converting %s to markdown", fragment.source_path)
+            return None
+
+    def _frontmatter_safe(
+        self, fragment: ParsedFragment, result: IngestResult
+    ) -> dict[str, Any] | None:
+        """Safely call generate_frontmatter(), catching errors.
+
+        Args:
+            fragment: The fragment to generate frontmatter for.
+            result: The IngestResult to append errors to.
+
+        Returns:
+            The frontmatter dict, or None on error.
+        """
+        try:
+            return self.generate_frontmatter(fragment)
+        except Exception as exc:
+            result.errors.append(f"frontmatter error for {fragment.source_path}: {exc}")
+            logger.exception(
+                "Error generating frontmatter for %s", fragment.source_path
+            )
+            return None

--- a/creek-tools/requirements.txt
+++ b/creek-tools/requirements.txt
@@ -4,3 +4,4 @@ rich>=13.0.0
 pydantic>=2.0.0
 pydantic-settings>=2.0.0
 pyyaml>=6.0.0
+chardet>=5.0.0

--- a/creek-tools/tests/test_ingest.py
+++ b/creek-tools/tests/test_ingest.py
@@ -1,0 +1,763 @@
+"""Tests for creek.ingest — abstract Ingestor base class and shared utilities.
+
+Covers encoding normalization, timestamp normalization, fragment ID generation,
+provenance creation, Pydantic models (RawDocument, ParsedFragment, IngestResult),
+the Ingestor ABC contract enforcement, and the concrete ``ingest()`` orchestrator.
+"""
+
+import abc
+import hashlib
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from creek.ingest.base import (
+    Ingestor,
+    IngestResult,
+    ParsedFragment,
+    ProvenanceEntry,
+    RawDocument,
+    create_provenance_entry,
+    generate_fragment_id,
+    normalize_encoding,
+    normalize_timestamp,
+)
+
+# ---- Fixtures ----
+
+LA_TZ = ZoneInfo("America/Los_Angeles")
+
+
+class _ConcreteIngestor(Ingestor):
+    """A minimal concrete implementation of Ingestor for testing.
+
+    Implements all abstract methods with simple, predictable behavior.
+    """
+
+    def discover(self, source_path: Path) -> list[RawDocument]:
+        """Return a single RawDocument for any source path.
+
+        Args:
+            source_path: The path to search for documents.
+
+        Returns:
+            A list with a single RawDocument.
+        """
+        return [
+            RawDocument(
+                path=source_path / "test.txt",
+                content=b"hello world",
+                metadata={"source_type": "test"},
+                detected_encoding="utf-8",
+            )
+        ]
+
+    def parse(self, raw: RawDocument) -> list[ParsedFragment]:
+        """Parse a RawDocument into a single ParsedFragment.
+
+        Args:
+            raw: The raw document to parse.
+
+        Returns:
+            A list with a single ParsedFragment.
+        """
+        return [
+            ParsedFragment(
+                content=raw.content.decode(raw.detected_encoding),
+                metadata=raw.metadata,
+                source_path=str(raw.path),
+                timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ),
+            )
+        ]
+
+    def convert_to_markdown(self, fragment: ParsedFragment) -> str:
+        """Convert a ParsedFragment to markdown.
+
+        Args:
+            fragment: The parsed fragment to convert.
+
+        Returns:
+            The content as markdown.
+        """
+        return f"# Fragment\n\n{fragment.content}"
+
+    def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
+        """Generate YAML frontmatter for a ParsedFragment.
+
+        Args:
+            fragment: The parsed fragment.
+
+        Returns:
+            A dict of frontmatter fields.
+        """
+        return {
+            "title": "Test Fragment",
+            "source": fragment.source_path,
+            "created": fragment.timestamp.isoformat(),
+        }
+
+
+class _PartialIngestor(Ingestor):
+    """An incomplete Ingestor that only implements some abstract methods.
+
+    Used to verify that ABC enforcement works correctly.
+    """
+
+    def discover(self, source_path: Path) -> list[RawDocument]:
+        """Discover documents (the only implemented abstract method).
+
+        Args:
+            source_path: The path to search for documents.
+
+        Returns:
+            An empty list.
+        """
+        return []
+
+    def parse(self, raw: RawDocument) -> list[ParsedFragment]:
+        """Parse a raw document.
+
+        Args:
+            raw: The raw document.
+
+        Returns:
+            An empty list.
+        """
+        return []
+
+    # Missing: convert_to_markdown and generate_frontmatter
+
+
+# ---- RawDocument Model Tests ----
+
+
+class TestRawDocument:
+    """Tests for the RawDocument Pydantic model."""
+
+    def test_creation_with_required_fields(self) -> None:
+        """RawDocument should be creatable with all required fields."""
+        doc = RawDocument(
+            path=Path("/fake/test.txt"),
+            content=b"hello",
+            metadata={},
+            detected_encoding="utf-8",
+        )
+        assert doc.path == Path("/fake/test.txt")
+        assert doc.content == b"hello"
+        assert doc.metadata == {}
+        assert doc.detected_encoding == "utf-8"
+
+    def test_metadata_dict_values(self) -> None:
+        """RawDocument metadata should accept arbitrary string keys."""
+        doc = RawDocument(
+            path=Path("/fake/doc.md"),
+            content=b"content",
+            metadata={"author": "test", "version": "1.0"},
+            detected_encoding="utf-8",
+        )
+        assert doc.metadata["author"] == "test"
+        assert doc.metadata["version"] == "1.0"
+
+    def test_bytes_content(self) -> None:
+        """RawDocument content should accept arbitrary bytes."""
+        raw_bytes = b"\xff\xfe\x00\x01"
+        doc = RawDocument(
+            path=Path("/fake/binary.bin"),
+            content=raw_bytes,
+            metadata={},
+            detected_encoding="utf-8",
+        )
+        assert doc.content == raw_bytes
+
+    def test_model_dump(self) -> None:
+        """RawDocument model_dump should produce a serializable dict."""
+        doc = RawDocument(
+            path=Path("/fake/test.txt"),
+            content=b"test",
+            metadata={"key": "value"},
+            detected_encoding="utf-8",
+        )
+        dump = doc.model_dump()
+        assert isinstance(dump, dict)
+        assert dump["detected_encoding"] == "utf-8"
+
+
+# ---- ParsedFragment Model Tests ----
+
+
+class TestParsedFragment:
+    """Tests for the ParsedFragment Pydantic model."""
+
+    def test_creation_with_required_fields(self) -> None:
+        """ParsedFragment should be creatable with all required fields."""
+        now = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        frag = ParsedFragment(
+            content="Hello world",
+            metadata={},
+            source_path="/fake/test.txt",
+            timestamp=now,
+        )
+        assert frag.content == "Hello world"
+        assert frag.metadata == {}
+        assert frag.source_path == "/fake/test.txt"
+        assert frag.timestamp == now
+
+    def test_metadata_accepts_arbitrary_values(self) -> None:
+        """ParsedFragment metadata should accept various value types."""
+        frag = ParsedFragment(
+            content="test",
+            metadata={"count": 42, "tags": ["a", "b"]},
+            source_path="/fake/doc.md",
+            timestamp=datetime(2024, 6, 1, tzinfo=LA_TZ),
+        )
+        assert frag.metadata["count"] == 42
+        assert frag.metadata["tags"] == ["a", "b"]
+
+    def test_model_dump(self) -> None:
+        """ParsedFragment model_dump should produce a serializable dict."""
+        frag = ParsedFragment(
+            content="test",
+            metadata={},
+            source_path="/fake/doc.md",
+            timestamp=datetime(2024, 6, 1, tzinfo=LA_TZ),
+        )
+        dump = frag.model_dump()
+        assert isinstance(dump, dict)
+        assert dump["content"] == "test"
+
+
+# ---- ProvenanceEntry Model Tests ----
+
+
+class TestProvenanceEntry:
+    """Tests for the ProvenanceEntry Pydantic model."""
+
+    def test_creation(self) -> None:
+        """ProvenanceEntry should be creatable with all fields."""
+        now = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        entry = ProvenanceEntry(
+            source_path="/fake/test.txt",
+            ingestor_name="TestIngestor",
+            timestamp=now,
+            fragment_id="frag-abc123def456",
+            status="success",
+        )
+        assert entry.source_path == "/fake/test.txt"
+        assert entry.ingestor_name == "TestIngestor"
+        assert entry.timestamp == now
+        assert entry.fragment_id == "frag-abc123def456"
+        assert entry.status == "success"
+
+    def test_model_dump(self) -> None:
+        """ProvenanceEntry model_dump should produce a serializable dict."""
+        entry = ProvenanceEntry(
+            source_path="/fake/test.txt",
+            ingestor_name="TestIngestor",
+            timestamp=datetime(2024, 1, 15, tzinfo=LA_TZ),
+            fragment_id="frag-abc123def456",
+            status="success",
+        )
+        dump = entry.model_dump()
+        assert isinstance(dump, dict)
+        assert dump["status"] == "success"
+
+
+# ---- IngestResult Model Tests ----
+
+
+class TestIngestResult:
+    """Tests for the IngestResult Pydantic model."""
+
+    def test_creation_with_defaults(self) -> None:
+        """IngestResult should be creatable with default empty lists."""
+        result = IngestResult()
+        assert result.fragments == []
+        assert result.provenance == []
+        assert result.errors == []
+
+    def test_creation_with_data(self) -> None:
+        """IngestResult should accept lists of fragments, provenance, and errors."""
+        frag = ParsedFragment(
+            content="test",
+            metadata={},
+            source_path="/fake/doc.md",
+            timestamp=datetime(2024, 6, 1, tzinfo=LA_TZ),
+        )
+        prov = ProvenanceEntry(
+            source_path="/fake/doc.md",
+            ingestor_name="TestIngestor",
+            timestamp=datetime(2024, 6, 1, tzinfo=LA_TZ),
+            fragment_id="frag-abc123def456",
+            status="success",
+        )
+        result = IngestResult(
+            fragments=[frag],
+            provenance=[prov],
+            errors=["warning: something minor"],
+        )
+        assert len(result.fragments) == 1
+        assert len(result.provenance) == 1
+        assert len(result.errors) == 1
+        assert result.errors[0] == "warning: something minor"
+
+    def test_model_dump(self) -> None:
+        """IngestResult model_dump should produce a serializable dict."""
+        result = IngestResult()
+        dump = result.model_dump()
+        assert isinstance(dump, dict)
+        assert dump["fragments"] == []
+        assert dump["provenance"] == []
+        assert dump["errors"] == []
+
+
+# ---- normalize_encoding Tests ----
+
+
+class TestNormalizeEncoding:
+    """Tests for the normalize_encoding utility function."""
+
+    def test_utf8_passthrough(self) -> None:
+        """UTF-8 encoded bytes should decode correctly."""
+        text, encoding = normalize_encoding(b"hello world")
+        assert text == "hello world"
+        # chardet may detect pure ASCII as "ascii" which is a subset of UTF-8
+        assert encoding.lower() in ("utf-8", "ascii", "utf8")
+
+    def test_latin1_detection(self) -> None:
+        """Latin-1 (ISO-8859-1) bytes should be detected and decoded."""
+        raw = "caf\u00e9".encode("latin-1")
+        text, _encoding = normalize_encoding(raw)
+        assert "caf" in text
+
+    def test_utf16_detection(self) -> None:
+        """UTF-16 encoded bytes with BOM should be detected and decoded."""
+        raw = "hello".encode("utf-16")
+        text, _encoding = normalize_encoding(raw)
+        assert "hello" in text
+
+    def test_empty_bytes(self) -> None:
+        """Empty bytes should return an empty string."""
+        text, encoding = normalize_encoding(b"")
+        assert text == ""
+        assert isinstance(encoding, str)
+
+    def test_ascii_content(self) -> None:
+        """Pure ASCII content should be detected and decoded."""
+        raw = b"plain ascii text"
+        text, _encoding = normalize_encoding(raw)
+        assert text == "plain ascii text"
+
+    def test_return_type(self) -> None:
+        """normalize_encoding should return a tuple of (str, str)."""
+        result = normalize_encoding(b"test")
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        assert isinstance(result[0], str)
+        assert isinstance(result[1], str)
+
+
+# ---- normalize_timestamp Tests ----
+
+
+class TestNormalizeTimestamp:
+    """Tests for the normalize_timestamp utility function."""
+
+    def test_iso_format_with_timezone(self) -> None:
+        """ISO format timestamp with timezone should normalize to LA time."""
+        result = normalize_timestamp("2024-01-15T18:30:00+00:00", None)
+        assert result.tzinfo is not None
+        assert str(result.tzinfo) == "America/Los_Angeles"
+        # 18:30 UTC = 10:30 PST (UTC-8 in January)
+        assert result.hour == 10
+        assert result.minute == 30
+
+    def test_iso_format_without_timezone(self) -> None:
+        """ISO format without timezone should use source_tz if provided."""
+        result = normalize_timestamp("2024-01-15T10:30:00", "America/New_York")
+        assert result.tzinfo is not None
+        assert str(result.tzinfo) == "America/Los_Angeles"
+        # 10:30 ET = 07:30 PT in January
+        assert result.hour == 7
+        assert result.minute == 30
+
+    def test_naive_timestamp_defaults_to_utc(self) -> None:
+        """Naive timestamp without source_tz should default to UTC."""
+        result = normalize_timestamp("2024-01-15T18:30:00", None)
+        assert result.tzinfo is not None
+        assert str(result.tzinfo) == "America/Los_Angeles"
+        # 18:30 UTC = 10:30 PST
+        assert result.hour == 10
+
+    def test_date_only_format(self) -> None:
+        """Date-only string should be parsed as midnight UTC."""
+        result = normalize_timestamp("2024-01-15", None)
+        assert result.tzinfo is not None
+        assert result.year == 2024
+        assert result.month == 1
+
+    def test_common_date_format(self) -> None:
+        """Common date format 'YYYY-MM-DD HH:MM:SS' should parse correctly."""
+        result = normalize_timestamp("2024-06-15 14:30:00", None)
+        assert result.tzinfo is not None
+        assert result.year == 2024
+        assert result.month == 6
+        assert result.day == 15
+
+    def test_result_always_has_la_timezone(self) -> None:
+        """Result should always be in America/Los_Angeles timezone."""
+        result = normalize_timestamp("2024-01-15T10:00:00+05:30", None)
+        assert str(result.tzinfo) == "America/Los_Angeles"
+
+    def test_source_tz_parameter(self) -> None:
+        """Source timezone should be used to interpret naive timestamps."""
+        result = normalize_timestamp("2024-07-15T12:00:00", "Europe/London")
+        assert str(result.tzinfo) == "America/Los_Angeles"
+        # 12:00 BST (UTC+1 in July) = 04:00 PDT (UTC-7 in July)
+        assert result.hour == 4
+
+    def test_invalid_timestamp_raises(self) -> None:
+        """Invalid timestamp string should raise ValueError."""
+        with pytest.raises(ValueError, match="Unable to parse timestamp"):
+            normalize_timestamp("not-a-timestamp", None)
+
+
+# ---- generate_fragment_id Tests ----
+
+
+class TestGenerateFragmentId:
+    """Tests for the generate_fragment_id utility function."""
+
+    def test_id_starts_with_frag_prefix(self) -> None:
+        """Generated ID should start with 'frag-' prefix."""
+        ts = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        frag_id = generate_fragment_id("source.txt", ts, "content")
+        assert frag_id.startswith("frag-")
+
+    def test_id_has_correct_length(self) -> None:
+        """Generated ID should be 'frag-' + 12 hex chars = 17 chars total."""
+        ts = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        frag_id = generate_fragment_id("source.txt", ts, "content")
+        assert len(frag_id) == 17  # "frag-" (5) + 12 hex chars
+
+    def test_id_hex_portion_is_valid_hex(self) -> None:
+        """The hex portion of the ID should be valid hexadecimal."""
+        ts = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        frag_id = generate_fragment_id("source.txt", ts, "content")
+        hex_part = frag_id[5:]
+        int(hex_part, 16)  # Should not raise
+
+    def test_deterministic(self) -> None:
+        """Same inputs should produce the same ID (deterministic)."""
+        ts = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        id1 = generate_fragment_id("source.txt", ts, "content")
+        id2 = generate_fragment_id("source.txt", ts, "content")
+        assert id1 == id2
+
+    def test_different_source_produces_different_id(self) -> None:
+        """Different source should produce a different ID."""
+        ts = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        id1 = generate_fragment_id("source_a.txt", ts, "content")
+        id2 = generate_fragment_id("source_b.txt", ts, "content")
+        assert id1 != id2
+
+    def test_different_timestamp_produces_different_id(self) -> None:
+        """Different timestamp should produce a different ID."""
+        ts1 = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        ts2 = datetime(2024, 1, 15, 11, 0, 0, tzinfo=LA_TZ)
+        id1 = generate_fragment_id("source.txt", ts1, "content")
+        id2 = generate_fragment_id("source.txt", ts2, "content")
+        assert id1 != id2
+
+    def test_different_content_produces_different_id(self) -> None:
+        """Different content should produce a different ID."""
+        ts = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        id1 = generate_fragment_id("source.txt", ts, "content A")
+        id2 = generate_fragment_id("source.txt", ts, "content B")
+        assert id1 != id2
+
+    def test_uses_sha256(self) -> None:
+        """ID should match SHA-256 of the expected input string."""
+        ts = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        source = "source.txt"
+        content = "content"
+        expected_hash = hashlib.sha256(
+            f"{source}:{ts.isoformat()}:{content}".encode()
+        ).hexdigest()[:12]
+        expected_id = f"frag-{expected_hash}"
+        actual_id = generate_fragment_id(source, ts, content)
+        assert actual_id == expected_id
+
+
+# ---- create_provenance_entry Tests ----
+
+
+class TestCreateProvenanceEntry:
+    """Tests for the create_provenance_entry utility function."""
+
+    def test_creates_valid_entry(self) -> None:
+        """Should create a ProvenanceEntry with all fields set."""
+        now = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        entry = create_provenance_entry(
+            source_path="/fake/test.txt",
+            ingestor_name="TestIngestor",
+            timestamp=now,
+            fragment_id="frag-abc123def456",
+            status="success",
+        )
+        assert isinstance(entry, ProvenanceEntry)
+        assert entry.source_path == "/fake/test.txt"
+        assert entry.ingestor_name == "TestIngestor"
+        assert entry.timestamp == now
+        assert entry.fragment_id == "frag-abc123def456"
+        assert entry.status == "success"
+
+    def test_error_status(self) -> None:
+        """Should allow 'error' status."""
+        entry = create_provenance_entry(
+            source_path="/fake/test.txt",
+            ingestor_name="TestIngestor",
+            timestamp=datetime(2024, 1, 15, tzinfo=LA_TZ),
+            fragment_id="frag-abc123def456",
+            status="error",
+        )
+        assert entry.status == "error"
+
+    def test_skipped_status(self) -> None:
+        """Should allow 'skipped' status."""
+        entry = create_provenance_entry(
+            source_path="/fake/test.txt",
+            ingestor_name="TestIngestor",
+            timestamp=datetime(2024, 1, 15, tzinfo=LA_TZ),
+            fragment_id="frag-abc123def456",
+            status="skipped",
+        )
+        assert entry.status == "skipped"
+
+
+# ---- Ingestor ABC Tests ----
+
+
+class TestIngestorABC:
+    """Tests for the Ingestor abstract base class contract."""
+
+    def test_cannot_instantiate_directly(self) -> None:
+        """Ingestor ABC should not be instantiable directly."""
+        with pytest.raises(TypeError, match="abstract method"):
+            Ingestor()  # type: ignore[abstract]
+
+    def test_concrete_implementation_instantiates(self) -> None:
+        """A fully concrete implementation should instantiate without error."""
+        ingestor = _ConcreteIngestor()
+        assert isinstance(ingestor, Ingestor)
+
+    def test_is_abstract_base_class(self) -> None:
+        """Ingestor should be an ABC."""
+        assert issubclass(Ingestor, abc.ABC)
+
+    def test_abstract_methods_defined(self) -> None:
+        """Ingestor should define the four required abstract methods."""
+        abstract_methods = getattr(Ingestor, "__abstractmethods__", set())
+        assert "discover" in abstract_methods
+        assert "parse" in abstract_methods
+        assert "convert_to_markdown" in abstract_methods
+        assert "generate_frontmatter" in abstract_methods
+
+    def test_ingest_is_concrete(self) -> None:
+        """The ingest() method should be concrete (not abstract)."""
+        abstract_methods = getattr(Ingestor, "__abstractmethods__", set())
+        assert "ingest" not in abstract_methods
+
+    def test_partial_implementation_fails(self) -> None:
+        """Partial implementation missing abstract methods should fail."""
+        with pytest.raises(TypeError, match="abstract method"):
+            _PartialIngestor()  # type: ignore[abstract]
+
+
+# ---- Ingestor.ingest() Orchestration Tests ----
+
+
+class TestIngestOrchestration:
+    """Tests for the concrete ingest() orchestration method."""
+
+    def test_ingest_returns_ingest_result(self) -> None:
+        """ingest() should return an IngestResult."""
+        ingestor = _ConcreteIngestor()
+        result = ingestor.ingest(Path("/fake/source"))
+        assert isinstance(result, IngestResult)
+
+    def test_ingest_populates_fragments(self) -> None:
+        """ingest() should populate fragments from discover -> parse pipeline."""
+        ingestor = _ConcreteIngestor()
+        result = ingestor.ingest(Path("/fake/source"))
+        assert len(result.fragments) > 0
+        assert result.fragments[0].content == "hello world"
+
+    def test_ingest_populates_provenance(self) -> None:
+        """ingest() should populate provenance entries."""
+        ingestor = _ConcreteIngestor()
+        result = ingestor.ingest(Path("/fake/source"))
+        assert len(result.provenance) > 0
+
+    def test_ingest_calls_discover(self) -> None:
+        """ingest() should call discover() with the source path."""
+        ingestor = _ConcreteIngestor()
+        source = Path("/fake/source")
+        with patch.object(
+            ingestor, "discover", wraps=ingestor.discover
+        ) as mock_discover:
+            ingestor.ingest(source)
+            mock_discover.assert_called_once_with(source)
+
+    def test_ingest_calls_parse_for_each_document(self) -> None:
+        """ingest() should call parse() for each discovered RawDocument."""
+        ingestor = _ConcreteIngestor()
+        with patch.object(ingestor, "parse", wraps=ingestor.parse) as mock_parse:
+            ingestor.ingest(Path("/fake/source"))
+            assert mock_parse.call_count == 1  # _ConcreteIngestor returns 1 doc
+
+    def test_ingest_calls_convert_to_markdown(self) -> None:
+        """ingest() should call convert_to_markdown() for each fragment."""
+        ingestor = _ConcreteIngestor()
+        with patch.object(
+            ingestor, "convert_to_markdown", wraps=ingestor.convert_to_markdown
+        ) as mock_convert:
+            ingestor.ingest(Path("/fake/source"))
+            assert mock_convert.call_count == 1
+
+    def test_ingest_calls_generate_frontmatter(self) -> None:
+        """ingest() should call generate_frontmatter() for each fragment."""
+        ingestor = _ConcreteIngestor()
+        with patch.object(
+            ingestor, "generate_frontmatter", wraps=ingestor.generate_frontmatter
+        ) as mock_frontmatter:
+            ingestor.ingest(Path("/fake/source"))
+            assert mock_frontmatter.call_count == 1
+
+    def test_ingest_handles_discover_error(self) -> None:
+        """ingest() should handle errors during discover gracefully."""
+        ingestor = _ConcreteIngestor()
+        with patch.object(
+            ingestor, "discover", side_effect=OSError("Permission denied")
+        ):
+            result = ingestor.ingest(Path("/fake/source"))
+            assert isinstance(result, IngestResult)
+            assert len(result.errors) > 0
+            assert "Permission denied" in result.errors[0]
+
+    def test_ingest_handles_parse_error(self) -> None:
+        """ingest() should handle errors during parse gracefully."""
+        ingestor = _ConcreteIngestor()
+        with patch.object(ingestor, "parse", side_effect=ValueError("Bad content")):
+            result = ingestor.ingest(Path("/fake/source"))
+            assert isinstance(result, IngestResult)
+            assert len(result.errors) > 0
+            assert "Bad content" in result.errors[0]
+
+    def test_ingest_handles_convert_error(self) -> None:
+        """ingest() should handle errors during convert_to_markdown gracefully."""
+        ingestor = _ConcreteIngestor()
+        with patch.object(
+            ingestor, "convert_to_markdown", side_effect=RuntimeError("Convert failed")
+        ):
+            result = ingestor.ingest(Path("/fake/source"))
+            assert isinstance(result, IngestResult)
+            assert len(result.errors) > 0
+
+    def test_ingest_handles_frontmatter_error(self) -> None:
+        """ingest() should handle errors during generate_frontmatter gracefully."""
+        ingestor = _ConcreteIngestor()
+        with patch.object(
+            ingestor,
+            "generate_frontmatter",
+            side_effect=RuntimeError("Frontmatter failed"),
+        ):
+            result = ingestor.ingest(Path("/fake/source"))
+            assert isinstance(result, IngestResult)
+            assert len(result.errors) > 0
+
+    def test_ingest_empty_discover(self) -> None:
+        """ingest() should handle discover returning an empty list."""
+        ingestor = _ConcreteIngestor()
+        with patch.object(ingestor, "discover", return_value=[]):
+            result = ingestor.ingest(Path("/fake/source"))
+            assert isinstance(result, IngestResult)
+            assert len(result.fragments) == 0
+
+    def test_ingest_multiple_documents(self) -> None:
+        """ingest() should process multiple documents from discover."""
+        ingestor = _ConcreteIngestor()
+        docs = [
+            RawDocument(
+                path=Path("/fake/a.txt"),
+                content=b"doc a",
+                metadata={},
+                detected_encoding="utf-8",
+            ),
+            RawDocument(
+                path=Path("/fake/b.txt"),
+                content=b"doc b",
+                metadata={},
+                detected_encoding="utf-8",
+            ),
+        ]
+        with patch.object(ingestor, "discover", return_value=docs):
+            result = ingestor.ingest(Path("/fake/source"))
+            assert len(result.fragments) == 2
+
+    def test_ingest_multiple_fragments_from_one_document(self) -> None:
+        """ingest() should handle parse returning multiple fragments."""
+        ingestor = _ConcreteIngestor()
+        multi_frags = [
+            ParsedFragment(
+                content="frag 1",
+                metadata={},
+                source_path="/fake/test.txt",
+                timestamp=datetime(2024, 1, 15, tzinfo=LA_TZ),
+            ),
+            ParsedFragment(
+                content="frag 2",
+                metadata={},
+                source_path="/fake/test.txt",
+                timestamp=datetime(2024, 1, 15, tzinfo=LA_TZ),
+            ),
+        ]
+        with patch.object(ingestor, "parse", return_value=multi_frags):
+            result = ingestor.ingest(Path("/fake/source"))
+            assert len(result.fragments) == 2
+
+
+# ---- Ingest Package __init__ Tests ----
+
+
+class TestIngestPackage:
+    """Tests for the creek.ingest package __init__.py."""
+
+    def test_registry_exists(self) -> None:
+        """The ingest package should export a registry of ingestors."""
+        from creek.ingest import INGESTOR_REGISTRY
+
+        assert isinstance(INGESTOR_REGISTRY, dict)
+
+    def test_registry_initially_empty(self) -> None:
+        """The registry should be empty initially (no concrete ingestors yet)."""
+        from creek.ingest import INGESTOR_REGISTRY
+
+        assert len(INGESTOR_REGISTRY) == 0
+
+    def test_base_classes_importable(self) -> None:
+        """Core classes should be importable from creek.ingest."""
+        from creek.ingest import (
+            Ingestor,
+            IngestResult,
+            ParsedFragment,
+            RawDocument,
+        )
+
+        assert RawDocument is not None
+        assert ParsedFragment is not None
+        assert IngestResult is not None
+        assert Ingestor is not None


### PR DESCRIPTION
## Summary
- Add `creek/ingest/` package with abstract Ingestor base class
- `RawDocument`, `ParsedFragment`, `IngestResult`, `ProvenanceEntry` Pydantic models
- Shared utilities: `normalize_encoding` (chardet), `normalize_timestamp` (timezone-aware), `generate_fragment_id` (deterministic SHA-256)
- `Ingestor` ABC with discover/parse/convert/frontmatter abstract methods and concrete `ingest()` orchestrator
- Graceful error handling at each pipeline stage
- `INGESTOR_REGISTRY` for registering concrete implementations
- 60 new tests in `tests/test_ingest.py`

## Test plan
- [x] All 186 tests pass (126 existing + 60 new)
- [x] 99.64% branch coverage (100% for creek/ingest/)
- [x] MyPy strict passes
- [x] Bandit, Ruff zero issues
- [x] Cyclomatic complexity all A-rated
- [x] ABC cannot be instantiated directly
- [x] Encoding normalization tested (UTF-8, Latin-1, UTF-16)
- [x] Timestamp normalization tested (ISO, naive, timezone-aware)
- [x] Fragment ID determinism and uniqueness tested

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)