### PR TITLE
feat(ingest): add Discord message ingestor (#19)

### DIFF
--- a/creek-tools/creek/ingest/__init__.py
+++ b/creek-tools/creek/ingest/__init__.py
@@ -13,8 +13,11 @@ Exports:
 """
 
 from creek.ingest.base import Ingestor, IngestResult, ParsedFragment, RawDocument
+from creek.ingest.discord import DiscordIngestor
 
-INGESTOR_REGISTRY: dict[str, type[Ingestor]] = {}
+INGESTOR_REGISTRY: dict[str, type[Ingestor]] = {
+    "discord": DiscordIngestor,
+}
 """Registry mapping ingestor names to their concrete classes.
 
 Concrete ingestors should register themselves here upon import, e.g.::
@@ -25,6 +28,7 @@ Concrete ingestors should register themselves here upon import, e.g.::
 
 __all__ = [
     "INGESTOR_REGISTRY",
+    "DiscordIngestor",
     "IngestResult",
     "Ingestor",
     "ParsedFragment",

--- a/creek-tools/creek/ingest/discord.py
+++ b/creek-tools/creek/ingest/discord.py
@@ -1,0 +1,627 @@
+"""Discord message ingestor — data package to fragments with context.
+
+This module implements the ``DiscordIngestor`` class, which processes Discord
+data exports (per-channel JSON files) into Creek fragments. Messages are
+grouped by conversational context: reply chains and time-proximity blocks
+(same author within 5 minutes). Channel metadata provides context headers.
+
+Discord data package structure::
+
+    messages/{channel_id}/messages.json — message array
+    messages/{channel_id}/channel.json — channel metadata
+
+Each message object::
+
+    {
+        "id": "...",
+        "timestamp": "ISO8601",
+        "content": "...",
+        "author": {"name": "..."},
+        "reference": {"messageId": "..."}
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from creek.ingest.base import (
+    Ingestor,
+    ParsedFragment,
+    RawDocument,
+    normalize_timestamp,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---- Constants ----
+
+TIME_PROXIMITY_MINUTES = 5
+"""Maximum gap (minutes) between messages from the same author to group."""
+
+_SPOILER_PATTERN = re.compile(r"\|\|(.+?)\|\|")
+"""Regex pattern matching Discord spoiler tags ``||content||``."""
+
+
+# ---- Helper data structures ----
+
+
+class _MessageGroup:
+    """A group of temporally or reply-linked Discord messages.
+
+    Attributes:
+        channel_name: The name of the source Discord channel.
+        messages: Ordered list of message dicts in this group.
+        channel_id: The Discord channel ID string.
+    """
+
+    def __init__(
+        self,
+        channel_name: str,
+        messages: list[dict[str, Any]],
+        channel_id: str,
+    ) -> None:
+        """Initialise a message group.
+
+        Args:
+            channel_name: The display name of the channel.
+            messages: The list of message dicts in this group.
+            channel_id: The Discord channel ID string.
+        """
+        self.channel_name = channel_name
+        self.messages = messages
+        self.channel_id = channel_id
+
+
+# ---- Discord formatting helpers ----
+
+
+def _format_discord_content(content: str) -> str:
+    """Convert Discord-specific formatting to Markdown equivalents.
+
+    Handles spoiler tags by converting ``||text||`` to ``>!text!<`` style,
+    and preserves standard Markdown formatting that Discord shares
+    (bold, italic, code blocks, etc.).
+
+    Args:
+        content: The raw Discord message content string.
+
+    Returns:
+        The content with Discord formatting converted to Markdown.
+    """
+    # Convert spoiler tags: ||spoiler|| -> [SPOILER: spoiler]
+    result = _SPOILER_PATTERN.sub(r"[SPOILER: \1]", content)
+    return result
+
+
+def _format_reply_context(parent_msg: dict[str, Any]) -> str:
+    """Format a parent message as a quoted reply context block.
+
+    Args:
+        parent_msg: The parent message dict being replied to.
+
+    Returns:
+        A Markdown-formatted quote block with author attribution.
+    """
+    author = _safe_author_name(parent_msg)
+    content = parent_msg.get("content", "")
+    return f"> **{author}**: {content}"
+
+
+def _safe_author_name(msg: dict[str, Any]) -> str:
+    """Safely extract the author name from a message dict.
+
+    Args:
+        msg: A Discord message dict.
+
+    Returns:
+        The author name, or ``"Unknown"`` if missing.
+    """
+    author = msg.get("author")
+    if isinstance(author, dict):
+        return str(author.get("name", "Unknown"))
+    return "Unknown"
+
+
+def _safe_timestamp(msg: dict[str, Any]) -> str:
+    """Safely extract the timestamp string from a message dict.
+
+    Args:
+        msg: A Discord message dict.
+
+    Returns:
+        The ISO 8601 timestamp string, or an empty string if missing.
+    """
+    return str(msg.get("timestamp", ""))
+
+
+def _parse_msg_timestamp(msg: dict[str, Any]) -> datetime | None:
+    """Parse the timestamp from a message dict into a datetime.
+
+    Args:
+        msg: A Discord message dict.
+
+    Returns:
+        A timezone-aware datetime, or ``None`` if parsing fails.
+    """
+    ts_str = _safe_timestamp(msg)
+    if not ts_str:
+        return None
+    try:
+        return datetime.fromisoformat(ts_str)
+    except ValueError:
+        return None
+
+
+# ---- Grouping logic ----
+
+
+def _build_message_index(messages: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Build a lookup index from message ID to message dict.
+
+    Args:
+        messages: The list of message dicts.
+
+    Returns:
+        A dict mapping message ID strings to their message dicts.
+    """
+    return {str(msg.get("id", "")): msg for msg in messages if msg.get("id")}
+
+
+def _get_reference_id(msg: dict[str, Any]) -> str | None:
+    """Extract the referenced (replied-to) message ID, if present.
+
+    Args:
+        msg: A Discord message dict.
+
+    Returns:
+        The referenced message ID string, or ``None``.
+    """
+    ref = msg.get("reference")
+    if isinstance(ref, dict):
+        mid = ref.get("messageId")
+        if mid is not None:
+            return str(mid)
+    return None
+
+
+def _group_messages(
+    messages: list[dict[str, Any]],
+) -> list[list[dict[str, Any]]]:
+    """Group messages by reply chains and time proximity.
+
+    Messages are processed in chronological order. A message joins the
+    current group if:
+
+    1. It is a reply to a message already in the current group, OR
+    2. It is from the same author as the last message and within
+       5 minutes (time proximity).
+
+    Otherwise, a new group is started.
+
+    Args:
+        messages: A chronologically sorted list of message dicts.
+
+    Returns:
+        A list of message groups, each group being a list of message dicts.
+    """
+    if not messages:
+        return []
+
+    groups: list[list[dict[str, Any]]] = []
+    current_group: list[dict[str, Any]] = [messages[0]]
+    current_group_ids: set[str] = {str(messages[0].get("id", ""))}
+
+    for msg in messages[1:]:
+        if _should_join_group(msg, current_group, current_group_ids):
+            current_group.append(msg)
+            msg_id = str(msg.get("id", ""))
+            if msg_id:
+                current_group_ids.add(msg_id)
+        else:
+            groups.append(current_group)
+            current_group = [msg]
+            current_group_ids = {str(msg.get("id", ""))}
+
+    groups.append(current_group)
+    return groups
+
+
+def _should_join_group(
+    msg: dict[str, Any],
+    current_group: list[dict[str, Any]],
+    current_group_ids: set[str],
+) -> bool:
+    """Determine whether a message should join the current group.
+
+    Args:
+        msg: The message to evaluate.
+        current_group: The current group of messages.
+        current_group_ids: Set of message IDs in the current group.
+
+    Returns:
+        ``True`` if the message should join the current group.
+    """
+    # Check reply chain: does this message reply to one in the group?
+    ref_id = _get_reference_id(msg)
+    if ref_id is not None and ref_id in current_group_ids:
+        return True
+
+    # Check time proximity: same author within 5 minutes of last message
+    last_msg = current_group[-1]
+    return _is_time_proximate(msg, last_msg)
+
+
+def _is_time_proximate(msg: dict[str, Any], last_msg: dict[str, Any]) -> bool:
+    """Check if two messages are from the same author within time threshold.
+
+    Args:
+        msg: The candidate message.
+        last_msg: The last message in the current group.
+
+    Returns:
+        ``True`` if same author and within the time proximity threshold.
+    """
+    msg_author = _safe_author_name(msg)
+    last_author = _safe_author_name(last_msg)
+    if msg_author != last_author:
+        return False
+
+    msg_ts = _parse_msg_timestamp(msg)
+    last_ts = _parse_msg_timestamp(last_msg)
+    if msg_ts is None or last_ts is None:
+        return False
+
+    delta = abs(msg_ts - last_ts)
+    return delta <= timedelta(minutes=TIME_PROXIMITY_MINUTES)
+
+
+# ---- DiscordIngestor ----
+
+
+class DiscordIngestor(Ingestor):
+    """Ingestor for Discord data export packages.
+
+    Processes per-channel ``messages.json`` and ``channel.json`` files
+    from Discord data exports. Groups messages by reply chains and
+    time proximity, then converts each group into a Creek fragment.
+    """
+
+    def discover(self, source_path: Path) -> list[RawDocument]:
+        """Find all ``messages.json`` files within channel directories.
+
+        Expects the Discord export structure::
+
+            source_path/messages/{channel_id}/messages.json
+            source_path/messages/{channel_id}/channel.json
+
+        Args:
+            source_path: Root directory of the Discord data export.
+
+        Returns:
+            A list of ``RawDocument`` objects, one per channel.
+        """
+        docs: list[RawDocument] = []
+        messages_dir = source_path / "messages"
+        if not messages_dir.is_dir():
+            return docs
+
+        for channel_dir in sorted(messages_dir.iterdir()):
+            if not channel_dir.is_dir():
+                continue
+            messages_file = channel_dir / "messages.json"
+            if not messages_file.is_file():
+                continue
+
+            raw_bytes = messages_file.read_bytes()
+            metadata = self._load_channel_metadata(channel_dir)
+            metadata["channel_dir"] = str(channel_dir)
+
+            docs.append(
+                RawDocument(
+                    path=messages_file,
+                    content=raw_bytes,
+                    metadata=metadata,
+                    detected_encoding="utf-8",
+                )
+            )
+
+        return docs
+
+    def _load_channel_metadata(self, channel_dir: Path) -> dict[str, Any]:
+        """Load channel metadata from ``channel.json`` if it exists.
+
+        Args:
+            channel_dir: The directory containing channel files.
+
+        Returns:
+            A dict of channel metadata, or defaults if file is missing.
+        """
+        channel_file = channel_dir / "channel.json"
+        if channel_file.is_file():
+            try:
+                data = json.loads(channel_file.read_bytes())
+                return {
+                    "channel_id": str(data.get("id", channel_dir.name)),
+                    "channel_name": str(data.get("name", channel_dir.name)),
+                    "channel_type": str(data.get("type", "text")),
+                }
+            except (json.JSONDecodeError, OSError):
+                logger.warning("Failed to parse channel.json in %s", channel_dir)
+
+        return {
+            "channel_id": channel_dir.name,
+            "channel_name": channel_dir.name,
+            "channel_type": "unknown",
+        }
+
+    def parse(self, raw: RawDocument) -> list[ParsedFragment]:
+        """Extract message groups as fragments from a channel's messages.
+
+        Groups messages by reply chains and time proximity, then creates
+        one ``ParsedFragment`` per group.
+
+        Args:
+            raw: The raw document containing messages JSON.
+
+        Returns:
+            A list of ``ParsedFragment`` objects, one per message group.
+        """
+        text = raw.content.decode(raw.detected_encoding, errors="replace")
+        messages = self._parse_messages_json(text, raw.path)
+        if not messages:
+            return []
+
+        msg_index = _build_message_index(messages)
+        groups = _group_messages(messages)
+        channel_name = raw.metadata.get("channel_name", "unknown")
+        channel_id = raw.metadata.get("channel_id", "unknown")
+
+        fragments: list[ParsedFragment] = []
+        for group in groups:
+            fragment = self._group_to_fragment(
+                group=group,
+                msg_index=msg_index,
+                channel_name=channel_name,
+                channel_id=channel_id,
+                source_path=str(raw.path),
+            )
+            if fragment is not None:
+                fragments.append(fragment)
+
+        return fragments
+
+    def _parse_messages_json(self, text: str, path: Path) -> list[dict[str, Any]]:
+        """Parse the messages JSON text, handling both array and object formats.
+
+        Supports two formats:
+
+        1. A bare JSON array of messages: ``[{...}, ...]``
+        2. An object with a ``"messages"`` key: ``{"messages": [{...}, ...]}``
+
+        Args:
+            text: The JSON text content.
+            path: The file path (for error messages).
+
+        Returns:
+            A list of message dicts, or empty list on parse failure.
+        """
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse messages JSON at %s", path)
+            return []
+
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict) and "messages" in data:
+            msgs = data["messages"]
+            if isinstance(msgs, list):
+                return msgs
+        return []
+
+    def _group_to_fragment(
+        self,
+        group: list[dict[str, Any]],
+        msg_index: dict[str, dict[str, Any]],
+        channel_name: str,
+        channel_id: str,
+        source_path: str,
+    ) -> ParsedFragment | None:
+        """Convert a message group into a ParsedFragment.
+
+        Args:
+            group: The list of message dicts in this group.
+            msg_index: Lookup index for all messages (for reply context).
+            channel_name: The channel display name.
+            channel_id: The channel ID string.
+            source_path: Path to the source file.
+
+        Returns:
+            A ``ParsedFragment``, or ``None`` if the group has no content.
+        """
+        content_parts: list[str] = []
+        authors: set[str] = set()
+
+        for msg in group:
+            part = self._format_message(msg, msg_index)
+            if part:
+                content_parts.append(part)
+            authors.add(_safe_author_name(msg))
+
+        if not content_parts:
+            return None
+
+        content = "\n\n".join(content_parts)
+        first_ts = _safe_timestamp(group[0])
+        timestamp = self._resolve_timestamp(first_ts)
+
+        return ParsedFragment(
+            content=content,
+            metadata={
+                "channel_name": channel_name,
+                "channel_id": channel_id,
+                "authors": sorted(authors),
+                "message_count": len(group),
+                "message_ids": [str(m.get("id", "")) for m in group],
+            },
+            source_path=source_path,
+            timestamp=timestamp,
+        )
+
+    def _format_message(
+        self,
+        msg: dict[str, Any],
+        msg_index: dict[str, dict[str, Any]],
+    ) -> str:
+        """Format a single Discord message as Markdown text.
+
+        Includes reply context (quoted parent) if the message is a reply.
+
+        Args:
+            msg: The message dict to format.
+            msg_index: Lookup index for resolving reply parents.
+
+        Returns:
+            A formatted Markdown string for this message.
+        """
+        parts: list[str] = []
+
+        # Add reply context if this is a reply
+        ref_id = _get_reference_id(msg)
+        if ref_id is not None and ref_id in msg_index:
+            parts.append(_format_reply_context(msg_index[ref_id]))
+            parts.append("")  # blank line after quote
+
+        author = _safe_author_name(msg)
+        content = _format_discord_content(msg.get("content", ""))
+
+        parts.append(f"**{author}**: {content}")
+
+        # Handle embeds
+        embeds = msg.get("embeds")
+        if isinstance(embeds, list):
+            for embed in embeds:
+                embed_text = self._format_embed(embed)
+                if embed_text:
+                    parts.append(embed_text)
+
+        # Handle reactions
+        reactions = msg.get("reactions")
+        if isinstance(reactions, list) and reactions:
+            reaction_text = self._format_reactions(reactions)
+            if reaction_text:
+                parts.append(reaction_text)
+
+        return "\n".join(parts)
+
+    def _format_embed(self, embed: Any) -> str:
+        """Format a Discord embed as Markdown.
+
+        Args:
+            embed: The embed object (expected to be a dict).
+
+        Returns:
+            A Markdown-formatted string, or empty string if not a dict.
+        """
+        if not isinstance(embed, dict):
+            return ""
+
+        parts: list[str] = []
+        title = embed.get("title")
+        if title:
+            parts.append(f"  *[Embed: {title}]*")
+        description = embed.get("description")
+        if description:
+            parts.append(f"  > {description}")
+        url = embed.get("url")
+        if url:
+            parts.append(f"  Link: {url}")
+
+        return "\n".join(parts)
+
+    def _format_reactions(self, reactions: list[Any]) -> str:
+        """Format message reactions as a compact text line.
+
+        Args:
+            reactions: List of reaction objects.
+
+        Returns:
+            A formatted reactions line, or empty string if none valid.
+        """
+        parts: list[str] = []
+        for reaction in reactions:
+            if not isinstance(reaction, dict):
+                continue
+            emoji = reaction.get("emoji", {})
+            name = emoji.get("name", "?") if isinstance(emoji, dict) else str(emoji)
+            count = reaction.get("count", 1)
+            parts.append(f"{name} x{count}")
+
+        if not parts:
+            return ""
+        return f"Reactions: {', '.join(parts)}"
+
+    def _resolve_timestamp(self, ts_str: str) -> datetime:
+        """Resolve a timestamp string to a normalized datetime.
+
+        Falls back to epoch if parsing fails.
+
+        Args:
+            ts_str: The ISO 8601 timestamp string.
+
+        Returns:
+            A timezone-aware datetime in the configured timezone.
+        """
+        if not ts_str:
+            return normalize_timestamp("1970-01-01T00:00:00Z", None)
+        try:
+            return normalize_timestamp(ts_str, None)
+        except ValueError:
+            return normalize_timestamp("1970-01-01T00:00:00Z", None)
+
+    def convert_to_markdown(self, fragment: ParsedFragment) -> str:
+        """Convert a parsed Discord fragment to clean Markdown.
+
+        Adds the channel name as a header and preserves the formatted
+        message content.
+
+        Args:
+            fragment: The parsed fragment to convert.
+
+        Returns:
+            A Markdown-formatted string with channel header.
+        """
+        channel = fragment.metadata.get("channel_name", "unknown")
+        header = f"# #{channel}\n\n"
+        return header + fragment.content
+
+    def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
+        """Generate YAML frontmatter metadata for a Discord fragment.
+
+        Produces frontmatter with source platform, channel, timestamps,
+        and participant information.
+
+        Args:
+            fragment: The parsed fragment.
+
+        Returns:
+            A dict of frontmatter key-value pairs.
+        """
+        return {
+            "source": {
+                "platform": "discord",
+                "channel": fragment.metadata.get("channel_name", "unknown"),
+                "channel_id": fragment.metadata.get("channel_id", "unknown"),
+            },
+            "created": fragment.timestamp.isoformat(),
+            "authors": fragment.metadata.get("authors", []),
+            "message_count": fragment.metadata.get("message_count", 0),
+        }

--- a/creek-tools/tests/test_discord_ingest.py
+++ b/creek-tools/tests/test_discord_ingest.py
@@ -1,0 +1,1101 @@
+"""Tests for creek.ingest.discord — Discord message ingestor.
+
+Covers discovery of channel directories, message parsing and grouping,
+reply chain context, time-proximity grouping, markdown conversion,
+frontmatter generation, edge cases (empty channels, missing fields,
+custom emoji), and full pipeline integration.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from creek.ingest.base import ParsedFragment, RawDocument
+from creek.ingest.discord import (
+    DiscordIngestor,
+    _build_message_index,
+    _format_discord_content,
+    _format_reply_context,
+    _get_reference_id,
+    _group_messages,
+    _is_time_proximate,
+    _parse_msg_timestamp,
+    _safe_author_name,
+    _safe_timestamp,
+)
+
+LA_TZ = ZoneInfo("America/Los_Angeles")
+
+
+# ---- Fixture helpers ----
+
+
+def _make_msg(
+    msg_id: str = "msg-001",
+    author: str = "Alice",
+    content: str = "Hello world",
+    timestamp: str = "2024-11-10T14:00:00Z",
+    reference_id: str | None = None,
+    embeds: list[dict[str, Any]] | None = None,
+    reactions: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Create a Discord message dict for testing.
+
+    Args:
+        msg_id: The message ID.
+        author: The author display name.
+        content: The message text content.
+        timestamp: ISO 8601 timestamp string.
+        reference_id: Optional ID of the replied-to message.
+        embeds: Optional list of embed dicts.
+        reactions: Optional list of reaction dicts.
+
+    Returns:
+        A message dict matching Discord export format.
+    """
+    msg: dict[str, Any] = {
+        "id": msg_id,
+        "author": {"id": f"user-{author.lower()}", "name": author},
+        "content": content,
+        "timestamp": timestamp,
+    }
+    if reference_id is not None:
+        msg["reference"] = {"messageId": reference_id}
+    if embeds is not None:
+        msg["embeds"] = embeds
+    if reactions is not None:
+        msg["reactions"] = reactions
+    return msg
+
+
+def _create_channel_dir(
+    tmp_path: Path,
+    channel_id: str = "123456",
+    channel_name: str = "general",
+    messages: list[dict[str, Any]] | None = None,
+    channel_meta: dict[str, Any] | None = None,
+    skip_channel_json: bool = False,
+) -> Path:
+    """Create a Discord channel directory with messages.json and channel.json.
+
+    Args:
+        tmp_path: The temporary directory root.
+        channel_id: The channel directory name / ID.
+        channel_name: The channel display name.
+        messages: List of message dicts to write to messages.json.
+        channel_meta: Optional channel metadata override.
+        skip_channel_json: If True, do not create channel.json.
+
+    Returns:
+        The path to the created channel directory.
+    """
+    channel_dir = tmp_path / "messages" / channel_id
+    channel_dir.mkdir(parents=True, exist_ok=True)
+
+    if messages is None:
+        messages = []
+    messages_file = channel_dir / "messages.json"
+    messages_file.write_text(json.dumps(messages), encoding="utf-8")
+
+    if not skip_channel_json:
+        if channel_meta is None:
+            channel_meta = {
+                "id": channel_id,
+                "name": channel_name,
+                "type": "text",
+            }
+        channel_file = channel_dir / "channel.json"
+        channel_file.write_text(json.dumps(channel_meta), encoding="utf-8")
+
+    return channel_dir
+
+
+# ---- Helper function tests ----
+
+
+class TestSafeAuthorName:
+    """Tests for the _safe_author_name helper."""
+
+    def test_normal_author(self) -> None:
+        """Should extract author name from a well-formed message."""
+        msg = _make_msg(author="Alice")
+        assert _safe_author_name(msg) == "Alice"
+
+    def test_missing_author_key(self) -> None:
+        """Should return 'Unknown' when author key is missing."""
+        msg: dict[str, Any] = {"id": "1", "content": "test"}
+        assert _safe_author_name(msg) == "Unknown"
+
+    def test_author_not_dict(self) -> None:
+        """Should return 'Unknown' when author is not a dict."""
+        msg: dict[str, Any] = {"id": "1", "author": "just-a-string"}
+        assert _safe_author_name(msg) == "Unknown"
+
+    def test_author_missing_name(self) -> None:
+        """Should return 'Unknown' when author dict lacks name key."""
+        msg: dict[str, Any] = {"id": "1", "author": {"id": "user-1"}}
+        assert _safe_author_name(msg) == "Unknown"
+
+
+class TestSafeTimestamp:
+    """Tests for the _safe_timestamp helper."""
+
+    def test_normal_timestamp(self) -> None:
+        """Should extract timestamp from a well-formed message."""
+        msg = _make_msg(timestamp="2024-11-10T14:00:00Z")
+        assert _safe_timestamp(msg) == "2024-11-10T14:00:00Z"
+
+    def test_missing_timestamp(self) -> None:
+        """Should return empty string when timestamp is missing."""
+        msg: dict[str, Any] = {"id": "1", "content": "test"}
+        assert _safe_timestamp(msg) == ""
+
+
+class TestParseMsgTimestamp:
+    """Tests for the _parse_msg_timestamp helper."""
+
+    def test_valid_iso_timestamp(self) -> None:
+        """Should parse a valid ISO 8601 timestamp."""
+        msg = _make_msg(timestamp="2024-11-10T14:00:00+00:00")
+        result = _parse_msg_timestamp(msg)
+        assert result is not None
+        assert result.year == 2024
+        assert result.month == 11
+
+    def test_invalid_timestamp(self) -> None:
+        """Should return None for an unparseable timestamp."""
+        msg: dict[str, Any] = {"id": "1", "timestamp": "not-a-date"}
+        assert _parse_msg_timestamp(msg) is None
+
+    def test_missing_timestamp(self) -> None:
+        """Should return None when timestamp is missing."""
+        msg: dict[str, Any] = {"id": "1"}
+        assert _parse_msg_timestamp(msg) is None
+
+
+class TestGetReferenceId:
+    """Tests for the _get_reference_id helper."""
+
+    def test_with_reference(self) -> None:
+        """Should extract messageId from reference dict."""
+        msg = _make_msg(reference_id="msg-parent")
+        assert _get_reference_id(msg) == "msg-parent"
+
+    def test_without_reference(self) -> None:
+        """Should return None when no reference key exists."""
+        msg = _make_msg()
+        assert _get_reference_id(msg) is None
+
+    def test_reference_not_dict(self) -> None:
+        """Should return None when reference is not a dict."""
+        msg: dict[str, Any] = {"id": "1", "reference": "just-a-string"}
+        assert _get_reference_id(msg) is None
+
+    def test_reference_missing_message_id(self) -> None:
+        """Should return None when reference dict lacks messageId."""
+        msg: dict[str, Any] = {"id": "1", "reference": {"channelId": "ch-1"}}
+        assert _get_reference_id(msg) is None
+
+
+class TestBuildMessageIndex:
+    """Tests for the _build_message_index helper."""
+
+    def test_builds_index(self) -> None:
+        """Should build a dict mapping message IDs to message dicts."""
+        messages = [_make_msg(msg_id="a"), _make_msg(msg_id="b")]
+        index = _build_message_index(messages)
+        assert "a" in index
+        assert "b" in index
+        assert index["a"]["id"] == "a"
+
+    def test_skips_messages_without_id(self) -> None:
+        """Should skip messages that lack an id key."""
+        messages: list[dict[str, Any]] = [
+            {"content": "no id"},
+            _make_msg(msg_id="valid"),
+        ]
+        index = _build_message_index(messages)
+        assert len(index) == 1
+        assert "valid" in index
+
+    def test_empty_list(self) -> None:
+        """Should return empty dict for empty message list."""
+        assert _build_message_index([]) == {}
+
+
+class TestFormatDiscordContent:
+    """Tests for the _format_discord_content helper."""
+
+    def test_spoiler_tags(self) -> None:
+        """Should convert spoiler tags to readable format."""
+        result = _format_discord_content("This is ||spoiler text|| here")
+        assert result == "This is [SPOILER: spoiler text] here"
+
+    def test_multiple_spoilers(self) -> None:
+        """Should convert multiple spoiler tags."""
+        result = _format_discord_content("||a|| and ||b||")
+        assert result == "[SPOILER: a] and [SPOILER: b]"
+
+    def test_no_formatting(self) -> None:
+        """Should return plain text unchanged."""
+        result = _format_discord_content("plain text")
+        assert result == "plain text"
+
+    def test_empty_string(self) -> None:
+        """Should handle empty string input."""
+        assert _format_discord_content("") == ""
+
+
+class TestFormatReplyContext:
+    """Tests for the _format_reply_context helper."""
+
+    def test_formats_reply(self) -> None:
+        """Should format parent message as a blockquote with author."""
+        parent = _make_msg(author="Bob", content="Original message")
+        result = _format_reply_context(parent)
+        assert result == "> **Bob**: Original message"
+
+    def test_missing_content(self) -> None:
+        """Should handle parent with missing content."""
+        parent: dict[str, Any] = {"author": {"name": "Bob"}}
+        result = _format_reply_context(parent)
+        assert result == "> **Bob**: "
+
+
+class TestIsTimeProximate:
+    """Tests for the _is_time_proximate helper."""
+
+    def test_same_author_within_threshold(self) -> None:
+        """Should return True for same author within 5 minutes."""
+        msg1 = _make_msg(author="Alice", timestamp="2024-11-10T14:00:00Z")
+        msg2 = _make_msg(author="Alice", timestamp="2024-11-10T14:03:00Z")
+        assert _is_time_proximate(msg2, msg1) is True
+
+    def test_same_author_at_boundary(self) -> None:
+        """Should return True for same author exactly at 5-minute boundary."""
+        msg1 = _make_msg(author="Alice", timestamp="2024-11-10T14:00:00Z")
+        msg2 = _make_msg(author="Alice", timestamp="2024-11-10T14:05:00Z")
+        assert _is_time_proximate(msg2, msg1) is True
+
+    def test_same_author_over_threshold(self) -> None:
+        """Should return False for same author beyond 5 minutes."""
+        msg1 = _make_msg(author="Alice", timestamp="2024-11-10T14:00:00Z")
+        msg2 = _make_msg(author="Alice", timestamp="2024-11-10T14:06:00Z")
+        assert _is_time_proximate(msg2, msg1) is False
+
+    def test_different_author_within_threshold(self) -> None:
+        """Should return False for different authors even within threshold."""
+        msg1 = _make_msg(author="Alice", timestamp="2024-11-10T14:00:00Z")
+        msg2 = _make_msg(author="Bob", timestamp="2024-11-10T14:01:00Z")
+        assert _is_time_proximate(msg2, msg1) is False
+
+    def test_missing_timestamps(self) -> None:
+        """Should return False when timestamps cannot be parsed."""
+        msg1: dict[str, Any] = {"author": {"name": "Alice"}}
+        msg2: dict[str, Any] = {"author": {"name": "Alice"}}
+        assert _is_time_proximate(msg2, msg1) is False
+
+
+# ---- Grouping tests ----
+
+
+class TestGroupMessages:
+    """Tests for the _group_messages function."""
+
+    def test_single_message(self) -> None:
+        """Single message should form one group."""
+        messages = [_make_msg()]
+        groups = _group_messages(messages)
+        assert len(groups) == 1
+        assert len(groups[0]) == 1
+
+    def test_time_proximity_grouping(self) -> None:
+        """Messages from same author within 5 min should group together."""
+        messages = [
+            _make_msg(msg_id="1", author="Alice", timestamp="2024-11-10T14:00:00Z"),
+            _make_msg(msg_id="2", author="Alice", timestamp="2024-11-10T14:02:00Z"),
+            _make_msg(msg_id="3", author="Alice", timestamp="2024-11-10T14:04:00Z"),
+        ]
+        groups = _group_messages(messages)
+        assert len(groups) == 1
+        assert len(groups[0]) == 3
+
+    def test_different_authors_separate_groups(self) -> None:
+        """Messages from different authors should form separate groups."""
+        messages = [
+            _make_msg(msg_id="1", author="Alice", timestamp="2024-11-10T14:00:00Z"),
+            _make_msg(msg_id="2", author="Bob", timestamp="2024-11-10T14:01:00Z"),
+        ]
+        groups = _group_messages(messages)
+        assert len(groups) == 2
+
+    def test_reply_chain_grouping(self) -> None:
+        """Reply to a message in the current group should stay in group."""
+        messages = [
+            _make_msg(msg_id="1", author="Alice", timestamp="2024-11-10T14:00:00Z"),
+            _make_msg(
+                msg_id="2",
+                author="Bob",
+                timestamp="2024-11-10T14:01:00Z",
+                reference_id="1",
+            ),
+        ]
+        groups = _group_messages(messages)
+        assert len(groups) == 1
+        assert len(groups[0]) == 2
+
+    def test_time_gap_creates_new_group(self) -> None:
+        """Messages separated by more than 5 min from same author split."""
+        messages = [
+            _make_msg(msg_id="1", author="Alice", timestamp="2024-11-10T14:00:00Z"),
+            _make_msg(msg_id="2", author="Alice", timestamp="2024-11-10T14:10:00Z"),
+        ]
+        groups = _group_messages(messages)
+        assert len(groups) == 2
+
+    def test_empty_messages(self) -> None:
+        """Empty message list should return empty groups."""
+        assert _group_messages([]) == []
+
+    def test_mixed_conversation(self) -> None:
+        """Mixed conversation with replies and time gaps groups correctly."""
+        messages = [
+            _make_msg(
+                msg_id="1",
+                author="Alice",
+                content="Question?",
+                timestamp="2024-11-10T14:00:00Z",
+            ),
+            _make_msg(
+                msg_id="2",
+                author="Bob",
+                content="Answer!",
+                timestamp="2024-11-10T14:01:00Z",
+                reference_id="1",
+            ),
+            _make_msg(
+                msg_id="3",
+                author="Charlie",
+                content="New topic",
+                timestamp="2024-11-10T15:00:00Z",
+            ),
+        ]
+        groups = _group_messages(messages)
+        assert len(groups) == 2
+        assert len(groups[0]) == 2  # Alice + Bob reply
+        assert len(groups[1]) == 1  # Charlie's new topic
+
+
+# ---- DiscordIngestor.discover() tests ----
+
+
+class TestDiscordIngestorDiscover:
+    """Tests for DiscordIngestor.discover()."""
+
+    def test_discover_finds_channels(self, tmp_path: Path) -> None:
+        """Should find messages.json files in channel directories."""
+        _create_channel_dir(
+            tmp_path,
+            channel_id="ch-1",
+            channel_name="general",
+            messages=[_make_msg()],
+        )
+        ingestor = DiscordIngestor()
+        docs = ingestor.discover(tmp_path)
+        assert len(docs) == 1
+        assert docs[0].path.name == "messages.json"
+
+    def test_discover_multiple_channels(self, tmp_path: Path) -> None:
+        """Should find messages.json in multiple channel directories."""
+        _create_channel_dir(tmp_path, channel_id="ch-1", channel_name="general")
+        _create_channel_dir(tmp_path, channel_id="ch-2", channel_name="random")
+        ingestor = DiscordIngestor()
+        docs = ingestor.discover(tmp_path)
+        assert len(docs) == 2
+
+    def test_discover_no_messages_dir(self, tmp_path: Path) -> None:
+        """Should return empty list when messages/ directory doesn't exist."""
+        ingestor = DiscordIngestor()
+        docs = ingestor.discover(tmp_path)
+        assert docs == []
+
+    def test_discover_empty_messages_dir(self, tmp_path: Path) -> None:
+        """Should return empty list when messages/ has no channel dirs."""
+        (tmp_path / "messages").mkdir()
+        ingestor = DiscordIngestor()
+        docs = ingestor.discover(tmp_path)
+        assert docs == []
+
+    def test_discover_skips_non_directories(self, tmp_path: Path) -> None:
+        """Should skip non-directory entries in messages/."""
+        messages_dir = tmp_path / "messages"
+        messages_dir.mkdir()
+        (messages_dir / "stray_file.txt").write_text("not a channel")
+        ingestor = DiscordIngestor()
+        docs = ingestor.discover(tmp_path)
+        assert docs == []
+
+    def test_discover_skips_channel_without_messages_json(self, tmp_path: Path) -> None:
+        """Should skip channel dirs that lack messages.json."""
+        channel_dir = tmp_path / "messages" / "ch-1"
+        channel_dir.mkdir(parents=True)
+        (channel_dir / "channel.json").write_text("{}")
+        ingestor = DiscordIngestor()
+        docs = ingestor.discover(tmp_path)
+        assert docs == []
+
+    def test_discover_loads_channel_metadata(self, tmp_path: Path) -> None:
+        """Should populate metadata from channel.json."""
+        _create_channel_dir(
+            tmp_path,
+            channel_id="ch-1",
+            channel_name="knowledge-sharing",
+            messages=[_make_msg()],
+        )
+        ingestor = DiscordIngestor()
+        docs = ingestor.discover(tmp_path)
+        assert docs[0].metadata["channel_name"] == "knowledge-sharing"
+        assert docs[0].metadata["channel_id"] == "ch-1"
+
+    def test_discover_missing_channel_json(self, tmp_path: Path) -> None:
+        """Should use directory name as fallback when channel.json is absent."""
+        _create_channel_dir(
+            tmp_path,
+            channel_id="ch-fallback",
+            messages=[_make_msg()],
+            skip_channel_json=True,
+        )
+        ingestor = DiscordIngestor()
+        docs = ingestor.discover(tmp_path)
+        assert docs[0].metadata["channel_name"] == "ch-fallback"
+        assert docs[0].metadata["channel_type"] == "unknown"
+
+    def test_discover_malformed_channel_json(self, tmp_path: Path) -> None:
+        """Should fall back to defaults when channel.json is malformed."""
+        channel_dir = tmp_path / "messages" / "ch-bad"
+        channel_dir.mkdir(parents=True)
+        (channel_dir / "messages.json").write_text("[]")
+        (channel_dir / "channel.json").write_text("not valid json {{{")
+        ingestor = DiscordIngestor()
+        docs = ingestor.discover(tmp_path)
+        assert docs[0].metadata["channel_name"] == "ch-bad"
+
+
+# ---- DiscordIngestor.parse() tests ----
+
+
+class TestDiscordIngestorParse:
+    """Tests for DiscordIngestor.parse()."""
+
+    def _raw_doc(
+        self,
+        messages: list[dict[str, Any]],
+        channel_name: str = "general",
+    ) -> RawDocument:
+        """Create a RawDocument from a message list.
+
+        Args:
+            messages: List of message dicts.
+            channel_name: Channel name for metadata.
+
+        Returns:
+            A RawDocument with the serialized messages as content.
+        """
+        return RawDocument(
+            path=Path("/fake/messages.json"),
+            content=json.dumps(messages).encode("utf-8"),
+            metadata={
+                "channel_name": channel_name,
+                "channel_id": "ch-1",
+                "channel_type": "text",
+            },
+            detected_encoding="utf-8",
+        )
+
+    def test_parse_single_message(self) -> None:
+        """Should create one fragment from a single message."""
+        messages = [_make_msg()]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        assert len(fragments) == 1
+        assert "Alice" in fragments[0].content
+        assert "Hello world" in fragments[0].content
+
+    def test_parse_grouped_messages(self) -> None:
+        """Should group time-proximate messages into one fragment."""
+        messages = [
+            _make_msg(msg_id="1", author="Alice", timestamp="2024-11-10T14:00:00Z"),
+            _make_msg(
+                msg_id="2",
+                author="Alice",
+                content="Follow-up",
+                timestamp="2024-11-10T14:02:00Z",
+            ),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        assert len(fragments) == 1
+        assert "Follow-up" in fragments[0].content
+
+    def test_parse_multiple_groups(self) -> None:
+        """Should create separate fragments for different groups."""
+        messages = [
+            _make_msg(msg_id="1", author="Alice", timestamp="2024-11-10T14:00:00Z"),
+            _make_msg(msg_id="2", author="Bob", timestamp="2024-11-10T15:00:00Z"),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        assert len(fragments) == 2
+
+    def test_parse_reply_includes_context(self) -> None:
+        """Reply messages should include quoted parent context."""
+        messages = [
+            _make_msg(
+                msg_id="1",
+                author="Alice",
+                content="Original",
+                timestamp="2024-11-10T14:00:00Z",
+            ),
+            _make_msg(
+                msg_id="2",
+                author="Bob",
+                content="Reply",
+                timestamp="2024-11-10T14:01:00Z",
+                reference_id="1",
+            ),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        assert len(fragments) == 1
+        content = fragments[0].content
+        assert "> **Alice**: Original" in content
+        assert "**Bob**: Reply" in content
+
+    def test_parse_empty_messages(self) -> None:
+        """Should return no fragments for empty message list."""
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc([]))
+        assert fragments == []
+
+    def test_parse_invalid_json(self) -> None:
+        """Should return no fragments when messages.json is not valid JSON."""
+        raw = RawDocument(
+            path=Path("/fake/messages.json"),
+            content=b"not json {{{",
+            metadata={"channel_name": "general", "channel_id": "ch-1"},
+            detected_encoding="utf-8",
+        )
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(raw)
+        assert fragments == []
+
+    def test_parse_object_format_with_messages_key(self) -> None:
+        """Should handle object format with a 'messages' key."""
+        data = {"messages": [_make_msg()]}
+        raw = RawDocument(
+            path=Path("/fake/messages.json"),
+            content=json.dumps(data).encode("utf-8"),
+            metadata={"channel_name": "general", "channel_id": "ch-1"},
+            detected_encoding="utf-8",
+        )
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 1
+
+    def test_parse_preserves_metadata(self) -> None:
+        """Should populate fragment metadata with channel and author info."""
+        messages = [_make_msg(author="Alice")]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages, channel_name="test-chan"))
+        frag = fragments[0]
+        assert frag.metadata["channel_name"] == "test-chan"
+        assert "Alice" in frag.metadata["authors"]
+        assert frag.metadata["message_count"] == 1
+
+    def test_parse_message_with_embeds(self) -> None:
+        """Should format embed content in parsed output."""
+        messages = [
+            _make_msg(
+                embeds=[
+                    {
+                        "title": "Cool Link",
+                        "description": "A description",
+                        "url": "https://example.com",
+                    }
+                ],
+            ),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        content = fragments[0].content
+        assert "Embed: Cool Link" in content
+        assert "A description" in content
+        assert "https://example.com" in content
+
+    def test_parse_message_with_reactions(self) -> None:
+        """Should format reactions in parsed output."""
+        messages = [
+            _make_msg(
+                reactions=[
+                    {"emoji": {"name": "thumbsup"}, "count": 3},
+                    {"emoji": {"name": "heart"}, "count": 1},
+                ],
+            ),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        content = fragments[0].content
+        assert "thumbsup x3" in content
+        assert "heart x1" in content
+
+    def test_parse_message_with_spoilers(self) -> None:
+        """Should convert spoiler formatting in parsed output."""
+        messages = [
+            _make_msg(content="This is ||secret|| content"),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        assert "[SPOILER: secret]" in fragments[0].content
+
+    def test_parse_timestamp_normalization(self) -> None:
+        """Should normalize timestamp to configured timezone."""
+        messages = [
+            _make_msg(timestamp="2024-11-10T20:00:00+00:00"),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        ts = fragments[0].timestamp
+        assert str(ts.tzinfo) == "America/Los_Angeles"
+
+    def test_parse_missing_message_fields(self) -> None:
+        """Should handle messages with missing fields gracefully."""
+        messages: list[dict[str, Any]] = [
+            {"id": "1", "timestamp": "2024-11-10T14:00:00Z"},
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        # Should still produce a fragment (with Unknown author, empty content)
+        assert len(fragments) == 1
+
+    def test_parse_object_format_without_messages_key(self) -> None:
+        """Should return empty list for object format without messages key."""
+        data = {"something_else": []}
+        raw = RawDocument(
+            path=Path("/fake/messages.json"),
+            content=json.dumps(data).encode("utf-8"),
+            metadata={"channel_name": "general", "channel_id": "ch-1"},
+            detected_encoding="utf-8",
+        )
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(raw)
+        assert fragments == []
+
+    def test_parse_custom_emoji_in_reactions(self) -> None:
+        """Should handle custom emoji format in reactions."""
+        messages = [
+            _make_msg(
+                reactions=[
+                    {"emoji": {"name": "custom_emoji", "id": "12345"}, "count": 2},
+                ],
+            ),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        assert "custom_emoji x2" in fragments[0].content
+
+    def test_parse_embed_without_title(self) -> None:
+        """Should handle embeds that lack a title."""
+        messages = [
+            _make_msg(
+                embeds=[{"description": "Just a description"}],
+            ),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        content = fragments[0].content
+        assert "Just a description" in content
+
+    def test_parse_non_dict_embed(self) -> None:
+        """Should skip embeds that are not dicts."""
+        messages = [
+            _make_msg(embeds=["not-a-dict"]),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        # Should still produce a fragment without embed text
+        assert len(fragments) == 1
+
+    def test_parse_non_dict_reaction(self) -> None:
+        """Should skip reactions that are not dicts."""
+        messages = [
+            _make_msg(reactions=["not-a-dict"]),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        # Should still produce a fragment (reactions line skipped)
+        assert len(fragments) == 1
+
+    def test_parse_emoji_not_dict(self) -> None:
+        """Should handle emoji field that is not a dict."""
+        messages = [
+            _make_msg(
+                reactions=[{"emoji": "simple_emoji_string", "count": 1}],
+            ),
+        ]
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(self._raw_doc(messages))
+        assert "simple_emoji_string x1" in fragments[0].content
+
+    def test_parse_messages_key_not_list(self) -> None:
+        """Should return empty when messages key is not a list."""
+        data = {"messages": "not-a-list"}
+        raw = RawDocument(
+            path=Path("/fake/messages.json"),
+            content=json.dumps(data).encode("utf-8"),
+            metadata={"channel_name": "general", "channel_id": "ch-1"},
+            detected_encoding="utf-8",
+        )
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(raw)
+        assert fragments == []
+
+
+# ---- DiscordIngestor.convert_to_markdown() tests ----
+
+
+class TestDiscordIngestorConvertToMarkdown:
+    """Tests for DiscordIngestor.convert_to_markdown()."""
+
+    def _fragment(
+        self,
+        content: str = "message content",
+        channel_name: str = "general",
+    ) -> ParsedFragment:
+        """Create a ParsedFragment for testing.
+
+        Args:
+            content: The fragment content.
+            channel_name: The channel name in metadata.
+
+        Returns:
+            A ParsedFragment with the given content and channel.
+        """
+        return ParsedFragment(
+            content=content,
+            metadata={"channel_name": channel_name},
+            source_path="/fake/messages.json",
+            timestamp=datetime(2024, 11, 10, 14, 0, 0, tzinfo=LA_TZ),
+        )
+
+    def test_includes_channel_header(self) -> None:
+        """Should include channel name as H1 header."""
+        ingestor = DiscordIngestor()
+        md = ingestor.convert_to_markdown(self._fragment(channel_name="general"))
+        assert md.startswith("# #general\n\n")
+
+    def test_includes_content(self) -> None:
+        """Should include the fragment content after the header."""
+        ingestor = DiscordIngestor()
+        md = ingestor.convert_to_markdown(
+            self._fragment(content="Hello world", channel_name="test")
+        )
+        assert "Hello world" in md
+
+    def test_missing_channel_name(self) -> None:
+        """Should use 'unknown' when channel_name is missing from metadata."""
+        frag = ParsedFragment(
+            content="content",
+            metadata={},
+            source_path="/fake/messages.json",
+            timestamp=datetime(2024, 11, 10, 14, 0, 0, tzinfo=LA_TZ),
+        )
+        ingestor = DiscordIngestor()
+        md = ingestor.convert_to_markdown(frag)
+        assert "# #unknown" in md
+
+
+# ---- DiscordIngestor.generate_frontmatter() tests ----
+
+
+class TestDiscordIngestorGenerateFrontmatter:
+    """Tests for DiscordIngestor.generate_frontmatter()."""
+
+    def _fragment(self) -> ParsedFragment:
+        """Create a ParsedFragment with typical Discord metadata.
+
+        Returns:
+            A ParsedFragment for testing frontmatter generation.
+        """
+        return ParsedFragment(
+            content="test content",
+            metadata={
+                "channel_name": "knowledge-sharing",
+                "channel_id": "ch-123",
+                "authors": ["Alice", "Bob"],
+                "message_count": 3,
+            },
+            source_path="/fake/messages.json",
+            timestamp=datetime(2024, 11, 10, 14, 0, 0, tzinfo=LA_TZ),
+        )
+
+    def test_source_platform(self) -> None:
+        """Should set source.platform to 'discord'."""
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(self._fragment())
+        assert fm["source"]["platform"] == "discord"
+
+    def test_source_channel(self) -> None:
+        """Should set source.channel from metadata."""
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(self._fragment())
+        assert fm["source"]["channel"] == "knowledge-sharing"
+
+    def test_source_channel_id(self) -> None:
+        """Should set source.channel_id from metadata."""
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(self._fragment())
+        assert fm["source"]["channel_id"] == "ch-123"
+
+    def test_created_timestamp(self) -> None:
+        """Should include an ISO 8601 created timestamp."""
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(self._fragment())
+        assert "created" in fm
+        # Should be parseable as ISO 8601
+        datetime.fromisoformat(fm["created"])
+
+    def test_authors_list(self) -> None:
+        """Should include sorted authors list."""
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(self._fragment())
+        assert fm["authors"] == ["Alice", "Bob"]
+
+    def test_message_count(self) -> None:
+        """Should include message count."""
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(self._fragment())
+        assert fm["message_count"] == 3
+
+    def test_missing_metadata_uses_defaults(self) -> None:
+        """Should use default values when metadata keys are missing."""
+        frag = ParsedFragment(
+            content="test",
+            metadata={},
+            source_path="/fake/messages.json",
+            timestamp=datetime(2024, 11, 10, 14, 0, 0, tzinfo=LA_TZ),
+        )
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(frag)
+        assert fm["source"]["channel"] == "unknown"
+        assert fm["source"]["channel_id"] == "unknown"
+        assert fm["authors"] == []
+        assert fm["message_count"] == 0
+
+
+# ---- Registry tests ----
+
+
+class TestDiscordIngestorRegistry:
+    """Tests for DiscordIngestor registration in INGESTOR_REGISTRY."""
+
+    def test_registered(self) -> None:
+        """DiscordIngestor should be registered as 'discord'."""
+        from creek.ingest import INGESTOR_REGISTRY
+
+        assert "discord" in INGESTOR_REGISTRY
+        assert INGESTOR_REGISTRY["discord"] is DiscordIngestor
+
+    def test_is_ingestor_subclass(self) -> None:
+        """DiscordIngestor should be a subclass of Ingestor."""
+        from creek.ingest.base import Ingestor
+
+        assert issubclass(DiscordIngestor, Ingestor)
+
+
+# ---- Full pipeline integration test ----
+
+
+class TestDiscordIngestorPipeline:
+    """Integration tests for the full DiscordIngestor pipeline."""
+
+    def test_full_pipeline(self, tmp_path: Path) -> None:
+        """Full ingest pipeline should discover, parse, and produce results."""
+        messages = [
+            _make_msg(
+                msg_id="1",
+                author="Alice",
+                content="Has anyone tried Obsidian?",
+                timestamp="2024-11-10T14:00:00Z",
+            ),
+            _make_msg(
+                msg_id="2",
+                author="Bob",
+                content="Yes, the linking is powerful.",
+                timestamp="2024-11-10T14:02:00Z",
+                reference_id="1",
+            ),
+            _make_msg(
+                msg_id="3",
+                author="Alice",
+                content="The graph view sounds interesting.",
+                timestamp="2024-11-10T14:05:00Z",
+            ),
+        ]
+        _create_channel_dir(
+            tmp_path,
+            channel_id="ch-1",
+            channel_name="knowledge-sharing",
+            messages=messages,
+        )
+
+        ingestor = DiscordIngestor()
+        result = ingestor.ingest(tmp_path)
+
+        assert len(result.errors) == 0
+        assert len(result.fragments) > 0
+        assert len(result.provenance) > 0
+
+        # Verify provenance
+        for prov in result.provenance:
+            assert prov.status == "success"
+            assert prov.ingestor_name == "DiscordIngestor"
+
+    def test_pipeline_multi_channel(self, tmp_path: Path) -> None:
+        """Pipeline should process fragments from multiple channels."""
+        _create_channel_dir(
+            tmp_path,
+            channel_id="ch-1",
+            channel_name="general",
+            messages=[_make_msg(msg_id="1", author="Alice")],
+        )
+        _create_channel_dir(
+            tmp_path,
+            channel_id="ch-2",
+            channel_name="random",
+            messages=[_make_msg(msg_id="2", author="Bob")],
+        )
+
+        ingestor = DiscordIngestor()
+        result = ingestor.ingest(tmp_path)
+
+        assert len(result.errors) == 0
+        assert len(result.fragments) == 2
+
+    def test_pipeline_empty_export(self, tmp_path: Path) -> None:
+        """Pipeline should handle an empty export gracefully."""
+        ingestor = DiscordIngestor()
+        result = ingestor.ingest(tmp_path)
+        assert result.fragments == []
+        assert result.errors == []
+
+    def test_pipeline_empty_channel(self, tmp_path: Path) -> None:
+        """Pipeline should handle a channel with no messages."""
+        _create_channel_dir(
+            tmp_path,
+            channel_id="ch-empty",
+            channel_name="empty-channel",
+            messages=[],
+        )
+        ingestor = DiscordIngestor()
+        result = ingestor.ingest(tmp_path)
+        assert result.fragments == []
+        assert result.errors == []
+
+    def test_pipeline_fragment_markdown_and_frontmatter(self, tmp_path: Path) -> None:
+        """Fragments should have markdown and frontmatter in metadata."""
+        _create_channel_dir(
+            tmp_path,
+            channel_id="ch-1",
+            channel_name="test",
+            messages=[_make_msg(content="Test message")],
+        )
+        ingestor = DiscordIngestor()
+        result = ingestor.ingest(tmp_path)
+        frag = result.fragments[0]
+
+        assert "markdown" in frag.metadata
+        assert "# #test" in frag.metadata["markdown"]
+        assert "frontmatter" in frag.metadata
+        assert frag.metadata["frontmatter"]["source"]["platform"] == "discord"
+
+    def test_resolve_timestamp_fallback(self) -> None:
+        """Should fall back to epoch for empty or invalid timestamps."""
+        ingestor = DiscordIngestor()
+        ts = ingestor._resolve_timestamp("")
+        assert ts.year == 1969 or ts.year == 1970  # depends on LA offset
+
+        ts2 = ingestor._resolve_timestamp("not-a-date")
+        assert ts2.year == 1969 or ts2.year == 1970
+
+
+class TestDiscordIngestorEdgeCases:
+    """Edge case tests for DiscordIngestor."""
+
+    def test_reply_to_message_outside_group(self) -> None:
+        """Reply to a message not in current group should start new group."""
+        messages = [
+            _make_msg(msg_id="1", author="Alice", timestamp="2024-11-10T14:00:00Z"),
+            _make_msg(
+                msg_id="2",
+                author="Bob",
+                content="Unrelated",
+                timestamp="2024-11-10T15:00:00Z",
+            ),
+            _make_msg(
+                msg_id="3",
+                author="Charlie",
+                content="Reply to old msg",
+                timestamp="2024-11-10T15:01:00Z",
+                reference_id="1",
+            ),
+        ]
+        groups = _group_messages(messages)
+        # msg 1 alone, then msg 2 + msg 3 (msg 3 replies to msg 1
+        # which is NOT in the current group, so it doesn't join;
+        # but it's different author from Bob, so separate group)
+        assert len(groups) == 3
+
+    def test_message_ids_in_fragment_metadata(self) -> None:
+        """Fragment metadata should contain message IDs."""
+        messages = [_make_msg(msg_id="msg-42")]
+        raw = RawDocument(
+            path=Path("/fake/messages.json"),
+            content=json.dumps(messages).encode("utf-8"),
+            metadata={"channel_name": "general", "channel_id": "ch-1"},
+            detected_encoding="utf-8",
+        )
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(raw)
+        assert "msg-42" in fragments[0].metadata["message_ids"]
+
+    def test_embed_with_only_url(self) -> None:
+        """Should format embed with only a URL field."""
+        messages = [
+            _make_msg(embeds=[{"url": "https://example.com"}]),
+        ]
+        raw = RawDocument(
+            path=Path("/fake/messages.json"),
+            content=json.dumps(messages).encode("utf-8"),
+            metadata={"channel_name": "general", "channel_id": "ch-1"},
+            detected_encoding="utf-8",
+        )
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(raw)
+        assert "https://example.com" in fragments[0].content
+
+    def test_empty_reactions_list(self) -> None:
+        """Should handle empty reactions list without adding reactions line."""
+        messages = [_make_msg(reactions=[])]
+        raw = RawDocument(
+            path=Path("/fake/messages.json"),
+            content=json.dumps(messages).encode("utf-8"),
+            metadata={"channel_name": "general", "channel_id": "ch-1"},
+            detected_encoding="utf-8",
+        )
+        ingestor = DiscordIngestor()
+        fragments = ingestor.parse(raw)
+        assert "Reactions:" not in fragments[0].content

--- a/creek-tools/tests/test_ingest.py
+++ b/creek-tools/tests/test_ingest.py
@@ -742,11 +742,11 @@ class TestIngestPackage:
 
         assert isinstance(INGESTOR_REGISTRY, dict)
 
-    def test_registry_initially_empty(self) -> None:
-        """The registry should be empty initially (no concrete ingestors yet)."""
+    def test_registry_contains_discord(self) -> None:
+        """The registry should contain the Discord ingestor."""
         from creek.ingest import INGESTOR_REGISTRY
 
-        assert len(INGESTOR_REGISTRY) == 0
+        assert "discord" in INGESTOR_REGISTRY
 
     def test_base_classes_importable(self) -> None:
         """Core classes should be importable from creek.ingest."""


### PR DESCRIPTION
## Summary
- Add `DiscordIngestor` in `creek/ingest/discord.py` that parses Discord data package exports into Creek fragments
- Supports reply chain reconstruction and time-proximity message grouping (same author within 5 minutes)
- Converts Discord formatting: spoiler tags, embeds with title/description/URL, reactions
- Preserves channel context in frontmatter (channel name, channel ID, authors list)
- Registers as `"discord"` in `INGESTOR_REGISTRY`
- 85 tests across 15 test classes, 98.57% overall coverage (96.58% for discord.py)

Closes #19

## Test plan
- [x] 556 tests pass (85 new Discord-specific tests)
- [x] 98.57% branch coverage (threshold: 90%)
- [x] MyPy strict: zero errors
- [x] Ruff: zero violations
- [x] Bandit security scan: clean
- [x] Radon complexity: all functions ≤10 CC
- [ ] CI green on Python 3.11, 3.12, 3.13
- [ ] Claude review LGTM

🤖 Generated with [Claude Code](https://claude.com/claude-code)