### PR TITLE
refactor(classify): deduplicate scoring logic in RuleClassifier (#95)

### DIFF
--- a/creek-tools/tests/test_generate.py
+++ b/creek-tools/tests/test_generate.py
@@ -180,9 +180,9 @@ class TestGenerateFrequencyIndexes:
             content = path.read_text(encoding="utf-8")
             # Extract the frequency code from the parent directory name
             freq_code = path.parent.name.split("-")[0]  # e.g., "F1"
-            assert (
-                f'"{freq_code}"' in content
-            ), f"Query should reference {freq_code}: {path}"
+            assert f'"{freq_code}"' in content, (
+                f"Query should reference {freq_code}: {path}"
+            )
 
     def test_dataview_queries_reference_fragments_folder(
         self, generator: IndexGenerator

--- a/creek-tools/tests/test_redact.py
+++ b/creek-tools/tests/test_redact.py
@@ -45,9 +45,9 @@ class TestRedactionPatterns:
     def test_patterns_are_compiled_regex(self) -> None:
         """Each pattern value should be a compiled regex."""
         for name, pattern in REDACTION_PATTERNS.items():
-            assert isinstance(
-                pattern, re.Pattern
-            ), f"Pattern '{name}' is not a compiled regex"
+            assert isinstance(pattern, re.Pattern), (
+                f"Pattern '{name}' is not a compiled regex"
+            )
 
     def test_api_key_pattern_matches(self) -> None:
         """api_key pattern should match common API key formats."""
@@ -128,9 +128,9 @@ class TestRedactionMatch:
         fields = RedactionMatch.model_fields
         forbidden = {"matched_text", "text", "value", "content", "raw", "match_text"}
         for field_name in forbidden:
-            assert (
-                field_name not in fields
-            ), f"RedactionMatch must NOT store matched text (found '{field_name}')"
+            assert field_name not in fields, (
+                f"RedactionMatch must NOT store matched text (found '{field_name}')"
+            )
 
     def test_serializable(self) -> None:
         """RedactionMatch should be JSON-serializable."""
@@ -880,9 +880,9 @@ class TestPatternInfo:
         from creek.redact.patterns import _VALID_SEVERITIES, PATTERN_METADATA
 
         for name, info in PATTERN_METADATA.items():
-            assert (
-                info.severity in _VALID_SEVERITIES
-            ), f"Invalid severity '{info.severity}' for {name}"
+            assert info.severity in _VALID_SEVERITIES, (
+                f"Invalid severity '{info.severity}' for {name}"
+            )
 
     def test_metadata_has_description(self) -> None:
         """All pattern metadata should have non-empty descriptions."""


### PR DESCRIPTION
## Summary
- Generalize `_score_signals` with `TypeVar` to accept any enum key type (Frequency, Phase, Mode, VoiceRegister, Confidence)
- Rewrite `_match_voice_register` and `_match_confidence` to use shared `_score_signals` instead of duplicate scoring loops
- Narrow `_pick_primary_secondary` parameter type from `dict[Frequency | Phase | Mode, int]` to `dict[Frequency, int]`
- Extract confidence score magic weights to class constants (`CONFIDENCE_MATCH_WEIGHT`, `CONFIDENCE_DIMENSION_WEIGHT`, `CONFIDENCE_GAP_WEIGHT`)
- 3 new tests verifying generalized scoring and weight constants

## Test plan
- [x] `_score_signals` works with `VOICE_REGISTER_SIGNALS` dict
- [x] `_score_signals` works with `CONFIDENCE_SIGNALS` dict
- [x] Confidence weights sum to 1.0 and are class constants
- [x] All 67 existing classify tests unaffected
- [x] 798 tests pass, 97.78% coverage
- [x] `./scripts/check-all.sh` passes (all 7 checks green)

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)