### PR TITLE
feat(fragment): add fragmentation engine for document splitting and grouping (#22)

### DIFF
--- a/creek-tools/creek/fragment.py
+++ b/creek-tools/creek/fragment.py
@@ -317,19 +317,28 @@ class FragmentationEngine:
     ) -> bool:
         """Check if a fragment can extend the current group.
 
+        A fragment can extend when it is short, shares the same source,
+        and falls within the configured time window of the last fragment.
+
         Args:
             group: Current accumulator of short fragments.
             frag: Candidate fragment.
 
         Returns:
-            True if the fragment is short and shares the source.
+            True if the fragment is short, same source, and within time window.
         """
         if not group:
             return _word_count(frag.content) < self.config.min_words
 
+        time_delta = abs(
+            (frag.timestamp - group[-1].timestamp).total_seconds(),
+        )
+        max_gap = self.config.group_time_window_minutes * 60
+
         return (
             frag.source_path == group[0].source_path
             and _word_count(frag.content) < self.config.min_words
+            and time_delta <= max_gap
         )
 
     def _flush_group(

--- a/creek-tools/tests/test_fragment.py
+++ b/creek-tools/tests/test_fragment.py
@@ -204,6 +204,20 @@ class TestGrouping:
         ]
         assert engine.should_group(frags) is False
 
+    def test_should_not_group_outside_time_window(self) -> None:
+        """Fragments outside time window should not be grouped."""
+        engine = FragmentationEngine(
+            FragmentationConfig(min_words=50, group_time_window_minutes=5),
+        )
+        t1 = datetime(2025, 1, 1, 12, 0, tzinfo=UTC)
+        t2 = datetime(2025, 1, 1, 13, 0, tzinfo=UTC)  # 1 hour apart
+        frags = [
+            _make_parsed(content="Short.", source_path="a.md", timestamp=t1),
+            _make_parsed(content="Short.", source_path="a.md", timestamp=t2),
+        ]
+        result = engine.fragment(frags)
+        assert len(result) == 2  # not grouped
+
     def test_group_merges_content(self) -> None:
         """Grouped fragments should have combined content."""
         engine = FragmentationEngine()


### PR DESCRIPTION
## Summary
- Add `FragmentationEngine` in `creek/fragment.py` for splitting long documents and grouping short fragments
- Section-based splitting at configurable heading level (default `##`)
- Length-based splitting at paragraph boundaries when sections are still too long
- Time-proximity grouping for consecutive short fragments from the same source
- Parent-child relationships maintained via `parent_id` in metadata
- `FragmentationConfig` Pydantic model with configurable thresholds (max_words, min_words, section_split_level, group_time_window_minutes)
- 24 tests across 6 test classes

## Test plan
- [x] `should_split` correctly identifies long vs short content
- [x] `split_by_sections` splits at H2 boundaries and preserves metadata
- [x] `split_by_length` splits at paragraph boundaries
- [x] `should_group` identifies groupable short fragments from same source
- [x] `group_fragments` merges content and preserves earliest timestamp
- [x] End-to-end `fragment()` splits long, groups short, passes through medium
- [x] Parent-child IDs maintained in split fragments
- [x] 819 tests pass, 97.94% coverage
- [x] `./scripts/check-all.sh` passes (all 7 checks green)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)