### PR TITLE
feat(redact): implement creek redact CLI with scan/apply/review (#16)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -67,6 +67,11 @@ def _dispatch_redact(
 ) -> None:
     """Route the ``redact`` command to the selected mode handler.
 
+    The caller (:func:`redact`) guarantees that exactly one of ``scan``,
+    ``apply``, or ``review`` is ``True`` before invocation, so the final
+    ``review`` branch is reached by elimination. The invariant is
+    re-asserted defensively below to keep the coupling explicit.
+
     Args:
         scan: ``--scan`` flag.
         apply: ``--apply`` flag.
@@ -78,14 +83,19 @@ def _dispatch_redact(
         verbose: ``--verbose`` flag.
         assume_yes: ``--yes`` flag (apply).
     """
-    from creek.redact.cli_commands import run_apply, run_review, run_scan
+    from creek.redact.cli_commands import (
+        require_flag,
+        run_apply,
+        run_review,
+        run_scan,
+    )
 
     if scan:
-        src = _require_flag(source, "--scan", "--source")
+        src = require_flag(source, "--scan", "--source", console)
         run_scan(src, report=report, verbose=verbose, console=console)
         return
     if apply:
-        src = _require_flag(source, "--apply", "--source")
+        src = require_flag(source, "--apply", "--source", console)
         run_apply(
             src,
             dry_run=dry_run,
@@ -94,28 +104,13 @@ def _dispatch_redact(
             console=console,
         )
         return
-    vlt = _require_flag(vault, "--review", "--vault")
+    # Invariant: redact() rejects any flag combination where review is
+    # not the sole mode flag, so reaching this branch implies review=True.
+    if not review:  # pragma: no cover — defence in depth
+        msg = "dispatch reached without a mode flag"
+        raise RuntimeError(msg)
+    vlt = require_flag(vault, "--review", "--vault", console)
     run_review(vlt, verbose=verbose, console=console)
-
-
-def _require_flag(value: Path | None, mode: str, flag: str) -> Path:
-    """Return *value* or abort when a required flag is missing.
-
-    Args:
-        value: Candidate path.
-        mode: Mode flag that triggered the requirement (e.g. ``--scan``).
-        flag: Required flag name (e.g. ``--source``).
-
-    Returns:
-        The validated path.
-
-    Raises:
-        typer.Exit: When *value* is ``None``.
-    """
-    if value is None:
-        console.print(f"[red]{mode} requires {flag}[/red]")
-        raise typer.Exit(code=2)
-    return value
 
 
 @app.command()

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -53,20 +53,114 @@ def ingest(
     )
 
 
+def _dispatch_redact(
+    *,
+    scan: bool,
+    apply: bool,
+    review: bool,
+    source: Path | None,
+    vault: Path | None,
+    report: bool,
+    dry_run: bool,
+    verbose: bool,
+    assume_yes: bool,
+) -> None:
+    """Route the ``redact`` command to the selected mode handler.
+
+    Args:
+        scan: ``--scan`` flag.
+        apply: ``--apply`` flag.
+        review: ``--review`` flag.
+        source: ``--source`` path (scan/apply).
+        vault: ``--vault`` path (review).
+        report: ``--report`` flag (scan).
+        dry_run: ``--dry-run`` flag (apply).
+        verbose: ``--verbose`` flag.
+        assume_yes: ``--yes`` flag (apply).
+    """
+    from creek.redact.cli_commands import run_apply, run_review, run_scan
+
+    if scan:
+        src = _require_flag(source, "--scan", "--source")
+        run_scan(src, report=report, verbose=verbose, console=console)
+        return
+    if apply:
+        src = _require_flag(source, "--apply", "--source")
+        run_apply(
+            src,
+            dry_run=dry_run,
+            verbose=verbose,
+            assume_yes=assume_yes,
+            console=console,
+        )
+        return
+    vlt = _require_flag(vault, "--review", "--vault")
+    run_review(vlt, verbose=verbose, console=console)
+
+
+def _require_flag(value: Path | None, mode: str, flag: str) -> Path:
+    """Return *value* or abort when a required flag is missing.
+
+    Args:
+        value: Candidate path.
+        mode: Mode flag that triggered the requirement (e.g. ``--scan``).
+        flag: Required flag name (e.g. ``--source``).
+
+    Returns:
+        The validated path.
+
+    Raises:
+        typer.Exit: When *value* is ``None``.
+    """
+    if value is None:
+        console.print(f"[red]{mode} requires {flag}[/red]")
+        raise typer.Exit(code=2)
+    return value
+
+
 @app.command()
 def redact(
-    scan: bool = typer.Option(False, help="Scan for sensitive content"),
-    apply: bool = typer.Option(False, help="Apply redactions"),
-    review: bool = typer.Option(False, help="Review redactions"),
-    source: Path | None = typer.Option(None, help="Source path"),
-    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
-    report: bool = typer.Option(False, help="Generate redaction report"),
+    scan: bool = typer.Option(False, "--scan", help="Scan for sensitive content"),
+    apply: bool = typer.Option(
+        False, "--apply", help="Apply redactions to matched files"
+    ),
+    review: bool = typer.Option(
+        False, "--review", help="Render the review queue for a vault"
+    ),
+    source: Path | None = typer.Option(
+        None, "--source", help="Source path (scan/apply)"
+    ),
+    vault: Path | None = typer.Option(None, "--vault", help="Vault path (review)"),
+    report: bool = typer.Option(
+        False, "--report", help="Include the detailed markdown report (scan)"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Scan but do not modify files (apply)"
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Show per-match details"
+    ),
+    assume_yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip the confirmation prompt (apply)"
+    ),
 ) -> None:
-    """Scan, apply, or review redactions."""
-    console.print(
-        f"[bold green]Would redact: scan={scan}, apply={apply}, "
-        f"review={review}, source={source}, vault={vault}, "
-        f"report={report}[/bold green]"
+    """Scan for sensitive data, apply redactions, or review the queue.
+
+    Exactly one of ``--scan``, ``--apply``, or ``--review`` must be given.
+    """
+    if sum([scan, apply, review]) != 1:
+        console.print("[red]Specify exactly one of --scan, --apply, --review.[/red]")
+        raise typer.Exit(code=2)
+    _dispatch_redact(
+        scan=scan,
+        apply=apply,
+        review=review,
+        source=source,
+        vault=vault,
+        report=report,
+        dry_run=dry_run,
+        verbose=verbose,
+        assume_yes=assume_yes,
     )
 
 

--- a/creek-tools/creek/redact/cli_commands.py
+++ b/creek-tools/creek/redact/cli_commands.py
@@ -11,6 +11,10 @@ command registration and keeps :mod:`creek.cli` focused on routing.
 
 from __future__ import annotations
 
+import os
+import tempfile
+from collections import Counter
+from pathlib import Path
 from typing import TYPE_CHECKING, NoReturn
 
 import typer
@@ -24,13 +28,9 @@ from creek.redact.redactor import Redactor
 from creek.redact.scanner import RedactionScanner, ScanSummary
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from pathlib import Path
-
     from rich.console import Console
 
     from creek.config import CreekConfig
-    from creek.redact.scanner import RedactionMatch
 
 
 # ---------------------------------------------------------------------------
@@ -74,26 +74,6 @@ def _style_for(severity: str) -> str:
     return _SEVERITY_STYLES.get(severity, "white")
 
 
-def _count_by(
-    matches: list[RedactionMatch],
-    key_fn: Callable[[RedactionMatch], str],
-) -> dict[str, int]:
-    """Count matches by a derived key.
-
-    Args:
-        matches: Redaction matches to aggregate.
-        key_fn: Function extracting the grouping key from a match.
-
-    Returns:
-        Mapping from key to count.
-    """
-    counts: dict[str, int] = {}
-    for match in matches:
-        key = key_fn(match)
-        counts[key] = counts.get(key, 0) + 1
-    return counts
-
-
 # ---------------------------------------------------------------------------
 # Display helpers
 # ---------------------------------------------------------------------------
@@ -123,7 +103,7 @@ def _render_severity_table(summary: ScanSummary, console: Console) -> None:
         summary: Scan summary to render.
         console: Rich console sink.
     """
-    by_sev = _count_by(summary.matches, lambda m: _severity(m.match_type))
+    by_sev: Counter[str] = Counter(_severity(m.match_type) for m in summary.matches)
     table = Table(title="Findings by Severity")
     table.add_column("Severity", style="bold")
     table.add_column("Count", justify="right")
@@ -140,7 +120,7 @@ def _render_type_table(summary: ScanSummary, console: Console) -> None:
         summary: Scan summary to render.
         console: Rich console sink.
     """
-    by_type = _count_by(summary.matches, lambda m: m.match_type)
+    by_type: Counter[str] = Counter(m.match_type for m in summary.matches)
     table = Table(title="Findings by Type")
     table.add_column("Type", style="bold")
     table.add_column("Severity", style="bold")
@@ -252,6 +232,34 @@ def _require_existing(console: Console, path: Path, label: str) -> None:
         _error_exit(console, f"{label} not found: {path}")
 
 
+def require_flag(
+    value: Path | None,
+    mode: str,
+    flag: str,
+    console: Console,
+) -> Path:
+    """Return *value* or abort when a required CLI flag is missing.
+
+    Shared helper so that :mod:`creek.cli` and the handlers in this
+    module emit identical, consistently styled error messages.
+
+    Args:
+        value: Candidate path from the CLI.
+        mode: Mode flag that triggered the requirement (e.g. ``--scan``).
+        flag: Required flag name (e.g. ``--source``).
+        console: Rich console sink.
+
+    Returns:
+        The validated, non-``None`` path.
+
+    Raises:
+        typer.Exit: When *value* is ``None``.
+    """
+    if value is None:
+        _error_exit(console, f"{mode} requires {flag}")
+    return value
+
+
 # ---------------------------------------------------------------------------
 # Mode: scan
 # ---------------------------------------------------------------------------
@@ -311,6 +319,38 @@ def _files_from_summary(summary: ScanSummary) -> list[Path]:
     return ordered
 
 
+def _atomic_write(file_path: Path, content: str) -> None:
+    """Atomically replace *file_path*'s content.
+
+    Writes to a same-directory temporary file first, then swaps it into
+    place with :func:`os.replace`. The swap is atomic on POSIX and best
+    effort on Windows. If any step fails the temp file is unlinked so
+    the original on-disk file is left untouched.
+
+    Args:
+        file_path: Destination path to rewrite.
+        content: New file contents.
+
+    Raises:
+        OSError: Propagated from filesystem primitives. The original
+            file is never observed in a half-written state.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{file_path.name}.",
+        suffix=".redact-tmp",
+        dir=file_path.parent,
+        text=True,
+    )
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            tmp_file.write(content)
+        os.replace(tmp_path, file_path)
+    except OSError:
+        tmp_path.unlink(missing_ok=True)
+        raise
+
+
 def _apply_redactions(
     redactor: Redactor,
     files: list[Path],
@@ -318,16 +358,36 @@ def _apply_redactions(
 ) -> None:
     """Rewrite each file in place with sensitive data replaced.
 
+    Each file is rewritten atomically via :func:`_atomic_write`, so a
+    mid-loop failure cannot leave any single file half-written. If an
+    :class:`OSError` interrupts the batch, already-redacted files keep
+    their redactions and the remaining files remain untouched — the
+    partial progress is reported and the error is surfaced as a
+    non-zero exit code.
+
     Args:
         redactor: Configured :class:`Redactor`.
         files: Files to rewrite.
-        console: Rich console sink for the completion banner.
+        console: Rich console sink for progress and error messages.
+
+    Raises:
+        typer.Exit: With code ``1`` when the batch is interrupted by an
+            I/O failure after reporting how many files were completed.
     """
-    for file_path in files:
-        text = file_path.read_text(encoding="utf-8", errors="replace")
-        redacted = redactor.redact_content(text)
-        file_path.write_text(redacted, encoding="utf-8")
-    console.print(f"[green]Applied redactions to {len(files)} file(s).[/green]")
+    completed = 0
+    try:
+        for file_path in files:
+            text = file_path.read_text(encoding="utf-8", errors="replace")
+            redacted = redactor.redact_content(text)
+            _atomic_write(file_path, redacted)
+            completed += 1
+    except OSError as exc:
+        console.print(
+            f"[red]I/O error after redacting {completed} of "
+            f"{len(files)} file(s): {exc}[/red]"
+        )
+        raise typer.Exit(code=1) from exc
+    console.print(f"[green]Applied redactions to {completed} file(s).[/green]")
 
 
 def _confirm_apply(

--- a/creek-tools/creek/redact/cli_commands.py
+++ b/creek-tools/creek/redact/cli_commands.py
@@ -1,0 +1,421 @@
+"""Command handlers for the ``creek redact`` CLI.
+
+Provides the three user-facing redaction modes — :func:`run_scan`,
+:func:`run_apply`, and :func:`run_review` — together with Rich-based
+display helpers that render colorized summary tables, per-match
+listings, and markdown review queues.
+
+Keeping these helpers in a dedicated module isolates them from Typer
+command registration and keeps :mod:`creek.cli` focused on routing.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NoReturn
+
+import typer
+from rich.markdown import Markdown
+from rich.table import Table
+from rich.text import Text
+
+from creek.config import load_config
+from creek.redact.patterns import PATTERN_METADATA
+from creek.redact.redactor import Redactor
+from creek.redact.scanner import RedactionScanner, ScanSummary
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from rich.console import Console
+
+    from creek.config import CreekConfig
+    from creek.redact.scanner import RedactionMatch
+
+
+# ---------------------------------------------------------------------------
+# Severity styling
+# ---------------------------------------------------------------------------
+
+_SEVERITY_STYLES: dict[str, str] = {
+    "critical": "bold red",
+    "high": "red",
+    "medium": "yellow",
+    "low": "cyan",
+    "unknown": "white",
+}
+
+_SEVERITY_ORDER: tuple[str, ...] = ("critical", "high", "medium", "low", "unknown")
+
+
+def _severity(match_type: str) -> str:
+    """Look up the severity of a pattern by name.
+
+    Args:
+        match_type: Pattern name as recorded on a :class:`RedactionMatch`.
+
+    Returns:
+        The severity string, or ``"unknown"`` when the pattern has no
+        metadata entry.
+    """
+    info = PATTERN_METADATA.get(match_type)
+    return info.severity if info else "unknown"
+
+
+def _style_for(severity: str) -> str:
+    """Return the Rich style string for a given severity level.
+
+    Args:
+        severity: Severity string.
+
+    Returns:
+        A Rich style spec (falls back to ``"white"`` for unknown levels).
+    """
+    return _SEVERITY_STYLES.get(severity, "white")
+
+
+def _count_by(
+    matches: list[RedactionMatch],
+    key_fn: Callable[[RedactionMatch], str],
+) -> dict[str, int]:
+    """Count matches by a derived key.
+
+    Args:
+        matches: Redaction matches to aggregate.
+        key_fn: Function extracting the grouping key from a match.
+
+    Returns:
+        Mapping from key to count.
+    """
+    counts: dict[str, int] = {}
+    for match in matches:
+        key = key_fn(match)
+        counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+# ---------------------------------------------------------------------------
+# Display helpers
+# ---------------------------------------------------------------------------
+
+
+def _render_stats_table(summary: ScanSummary, console: Console) -> None:
+    """Render the headline statistics block.
+
+    Args:
+        summary: Scan summary to render.
+        console: Rich console sink.
+    """
+    stats = Table(title="Redaction Scan Summary", show_header=False)
+    stats.add_column("Metric", style="bold")
+    stats.add_column("Value", justify="right")
+    stats.add_row("Files scanned", str(summary.files_scanned))
+    stats.add_row("Files skipped (binary)", str(summary.files_skipped_binary))
+    stats.add_row("Files skipped (extension)", str(summary.files_skipped_extension))
+    stats.add_row("Total findings", str(len(summary.matches)))
+    console.print(stats)
+
+
+def _render_severity_table(summary: ScanSummary, console: Console) -> None:
+    """Render the severity breakdown table when findings exist.
+
+    Args:
+        summary: Scan summary to render.
+        console: Rich console sink.
+    """
+    by_sev = _count_by(summary.matches, lambda m: _severity(m.match_type))
+    table = Table(title="Findings by Severity")
+    table.add_column("Severity", style="bold")
+    table.add_column("Count", justify="right")
+    for sev in _SEVERITY_ORDER:
+        if sev in by_sev:
+            table.add_row(Text(sev, style=_style_for(sev)), str(by_sev[sev]))
+    console.print(table)
+
+
+def _render_type_table(summary: ScanSummary, console: Console) -> None:
+    """Render the match-type breakdown table when findings exist.
+
+    Args:
+        summary: Scan summary to render.
+        console: Rich console sink.
+    """
+    by_type = _count_by(summary.matches, lambda m: m.match_type)
+    table = Table(title="Findings by Type")
+    table.add_column("Type", style="bold")
+    table.add_column("Severity", style="bold")
+    table.add_column("Count", justify="right")
+    for mtype, count in sorted(by_type.items()):
+        sev = _severity(mtype)
+        table.add_row(mtype, Text(sev, style=_style_for(sev)), str(count))
+    console.print(table)
+
+
+def render_summary(summary: ScanSummary, console: Console) -> None:
+    """Render the full summary: statistics plus severity and type tables.
+
+    Args:
+        summary: Scan summary to render.
+        console: Rich console sink.
+    """
+    _render_stats_table(summary, console)
+    if not summary.matches:
+        return
+    _render_severity_table(summary, console)
+    _render_type_table(summary, console)
+
+
+def render_matches(summary: ScanSummary, console: Console) -> None:
+    """Render a colorized per-match table, sorted by file and line.
+
+    Args:
+        summary: Scan summary whose matches should be listed.
+        console: Rich console sink.
+    """
+    if not summary.matches:
+        return
+    table = Table(title="Matches")
+    table.add_column("File", style="dim")
+    table.add_column("Line", justify="right")
+    table.add_column("Type")
+    table.add_column("Severity")
+    sorted_matches = sorted(
+        summary.matches,
+        key=lambda m: (str(m.file_path), m.line_number),
+    )
+    for match in sorted_matches:
+        sev = _severity(match.match_type)
+        table.add_row(
+            str(match.file_path),
+            str(match.line_number),
+            match.match_type,
+            Text(sev, style=_style_for(sev)),
+        )
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# Scan orchestration
+# ---------------------------------------------------------------------------
+
+
+def _scan_source(
+    source: Path,
+    config: CreekConfig,
+) -> tuple[RedactionScanner, ScanSummary]:
+    """Scan *source* (file or directory) and return the scanner + summary.
+
+    Args:
+        source: File or directory to scan.
+        config: Loaded Creek configuration.
+
+    Returns:
+        Tuple of ``(scanner, summary)``. The scanner is returned so that
+        the caller can reuse its session salt for redaction or review.
+    """
+    scanner = RedactionScanner(config=config.redaction)
+    if source.is_file():
+        matches = scanner.scan_file(source)
+        summary = ScanSummary(matches=matches, files_scanned=1)
+    else:
+        summary = scanner.scan_batch(source, progress=True)
+    return scanner, summary
+
+
+def _error_exit(console: Console, message: str, *, code: int = 2) -> NoReturn:
+    """Print a red error message and raise ``typer.Exit``.
+
+    Args:
+        console: Rich console sink.
+        message: Human-readable error message.
+        code: Process exit code (defaults to ``2``).
+
+    Raises:
+        typer.Exit: Always — this helper never returns.
+    """
+    console.print(f"[red]{message}[/red]")
+    raise typer.Exit(code=code)
+
+
+def _require_existing(console: Console, path: Path, label: str) -> None:
+    """Abort unless *path* exists on disk.
+
+    Args:
+        console: Rich console sink.
+        path: Path to verify.
+        label: Human-readable label used in the error message.
+
+    Raises:
+        typer.Exit: When *path* does not exist.
+    """
+    if not path.exists():
+        _error_exit(console, f"{label} not found: {path}")
+
+
+# ---------------------------------------------------------------------------
+# Mode: scan
+# ---------------------------------------------------------------------------
+
+
+def run_scan(
+    source: Path,
+    *,
+    report: bool,
+    verbose: bool,
+    console: Console,
+) -> ScanSummary:
+    """Scan *source* for sensitive data and render a report.
+
+    Args:
+        source: File or directory to scan.
+        report: When ``True``, render the detailed markdown report.
+        verbose: When ``True``, also list every individual match.
+        console: Rich console sink.
+
+    Returns:
+        The :class:`ScanSummary` produced by the scanner.
+    """
+    _require_existing(console, source, "Source path")
+    config = load_config()
+    scanner, summary = _scan_source(source, config)
+    render_summary(summary, console)
+    if verbose:
+        render_matches(summary, console)
+    if report:
+        console.print(Markdown(scanner.generate_markdown_summary(summary)))
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Mode: apply
+# ---------------------------------------------------------------------------
+
+
+def _files_from_summary(summary: ScanSummary) -> list[Path]:
+    """Return the unique file paths referenced by *summary*'s matches.
+
+    Preserves first-seen order for stable reporting.
+
+    Args:
+        summary: Scan summary whose matches name the files to redact.
+
+    Returns:
+        Ordered list of unique file paths.
+    """
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+    for match in summary.matches:
+        if match.file_path not in seen:
+            seen.add(match.file_path)
+            ordered.append(match.file_path)
+    return ordered
+
+
+def _apply_redactions(
+    redactor: Redactor,
+    files: list[Path],
+    console: Console,
+) -> None:
+    """Rewrite each file in place with sensitive data replaced.
+
+    Args:
+        redactor: Configured :class:`Redactor`.
+        files: Files to rewrite.
+        console: Rich console sink for the completion banner.
+    """
+    for file_path in files:
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+        redacted = redactor.redact_content(text)
+        file_path.write_text(redacted, encoding="utf-8")
+    console.print(f"[green]Applied redactions to {len(files)} file(s).[/green]")
+
+
+def _confirm_apply(
+    files: list[Path],
+    *,
+    assume_yes: bool,
+    console: Console,
+) -> bool:
+    """Ask the user to confirm applying redactions.
+
+    Args:
+        files: Files that will be modified.
+        assume_yes: Skip the prompt when ``True``.
+        console: Rich console sink for the abort banner.
+
+    Returns:
+        ``True`` if the caller should proceed, ``False`` to abort.
+    """
+    if assume_yes:
+        return True
+    if typer.confirm(f"Apply redactions to {len(files)} file(s)?"):
+        return True
+    console.print("[yellow]Aborted — no files modified.[/yellow]")
+    return False
+
+
+def run_apply(
+    source: Path,
+    *,
+    dry_run: bool,
+    verbose: bool,
+    assume_yes: bool,
+    console: Console,
+) -> None:
+    """Scan *source*, obtain consent, and redact files in place.
+
+    Args:
+        source: File or directory to scan and redact.
+        dry_run: When ``True``, scan but never modify files.
+        verbose: When ``True``, render the per-match table.
+        assume_yes: Skip the interactive confirmation prompt.
+        console: Rich console sink.
+    """
+    _require_existing(console, source, "Source path")
+    config = load_config()
+    scanner, summary = _scan_source(source, config)
+    render_summary(summary, console)
+    if verbose:
+        render_matches(summary, console)
+
+    if not summary.matches:
+        console.print("[green]No findings — nothing to redact.[/green]")
+        return
+
+    if dry_run:
+        console.print("[yellow]Dry run: no files modified.[/yellow]")
+        return
+
+    files = _files_from_summary(summary)
+    if not _confirm_apply(files, assume_yes=assume_yes, console=console):
+        return
+
+    redactor = Redactor(config=config.redaction, salt=scanner.salt)
+    _apply_redactions(redactor, files, console)
+
+
+# ---------------------------------------------------------------------------
+# Mode: review
+# ---------------------------------------------------------------------------
+
+
+def run_review(
+    vault: Path,
+    *,
+    verbose: bool,
+    console: Console,
+) -> None:
+    """Re-scan *vault* and render the markdown review queue.
+
+    Args:
+        vault: Vault root (or any directory) to re-scan.
+        verbose: When ``True``, also list every individual match.
+        console: Rich console sink.
+    """
+    _require_existing(console, vault, "Vault path")
+    config = load_config()
+    scanner, summary = _scan_source(vault, config)
+    render_summary(summary, console)
+    if verbose:
+        render_matches(summary, console)
+    console.print(Markdown(scanner.generate_review_queue(summary)))

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -79,42 +79,44 @@ def test_redact_help() -> None:
     assert "redact" in result.output.lower()
 
 
-def test_redact_scan() -> None:
+def test_redact_scan(tmp_path: Path) -> None:
     """Test that redact command runs with --scan flag."""
+    source = tmp_path / "src"
+    source.mkdir()
     result = runner.invoke(
         app,
-        ["redact", "--scan", "--source", "/fake/src", "--vault", "/fake/vault"],
+        ["redact", "--scan", "--source", str(source)],
     )
     assert result.exit_code == 0
 
 
-def test_redact_apply() -> None:
+def test_redact_apply(tmp_path: Path) -> None:
     """Test that redact command runs with --apply flag."""
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "ok.md").write_text("nothing interesting\n", encoding="utf-8")
     result = runner.invoke(
         app,
-        ["redact", "--apply", "--source", "/fake/src", "--vault", "/fake/vault"],
+        ["redact", "--apply", "--source", str(source)],
     )
     assert result.exit_code == 0
 
 
-def test_redact_review() -> None:
+def test_redact_review(tmp_path: Path) -> None:
     """Test that redact command runs with --review flag."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
     result = runner.invoke(
         app,
-        [
-            "redact",
-            "--review",
-            "--source",
-            "/fake/src",
-            "--vault",
-            "/fake/vault",
-        ],
+        ["redact", "--review", "--vault", str(vault)],
     )
     assert result.exit_code == 0
 
 
-def test_redact_report() -> None:
+def test_redact_report(tmp_path: Path) -> None:
     """Test that redact command runs with --report flag."""
+    source = tmp_path / "src"
+    source.mkdir()
     result = runner.invoke(
         app,
         [
@@ -122,9 +124,7 @@ def test_redact_report() -> None:
             "--scan",
             "--report",
             "--source",
-            "/fake/src",
-            "--vault",
-            "/fake/vault",
+            str(source),
         ],
     )
     assert result.exit_code == 0

--- a/creek-tools/tests/test_cli_redact.py
+++ b/creek-tools/tests/test_cli_redact.py
@@ -1,0 +1,338 @@
+"""Tests for the ``creek redact`` CLI command.
+
+Exercises all three redaction modes (``--scan``, ``--apply``, ``--review``)
+together with the supporting flags (``--report``, ``--dry-run``,
+``--verbose``, ``--yes``) and the consent prompt behaviour.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from creek.cli import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_sensitive_source(tmp_path: Path) -> Path:
+    """Create a source directory containing files with sensitive data.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Returns:
+        Path to the populated source directory.
+    """
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "leak.env").write_text(
+        "password=hunter2\nAPI_KEY=sk-abcdefghijklmnopqrstuvwx\n",
+        encoding="utf-8",
+    )
+    (source / "notes.md").write_text(
+        "Contact: alice@example.com\nSSN: 123-45-6789\n",
+        encoding="utf-8",
+    )
+    (source / "safe.md").write_text(
+        "nothing interesting here\n",
+        encoding="utf-8",
+    )
+    return source
+
+
+def _write_empty_source(tmp_path: Path) -> Path:
+    """Create a source directory containing a single non-sensitive file.
+
+    Args:
+        tmp_path: Pytest-provided temporary directory.
+
+    Returns:
+        Path to the populated source directory.
+    """
+    source = tmp_path / "clean_source"
+    source.mkdir()
+    (source / "ok.md").write_text("hello world\n", encoding="utf-8")
+    return source
+
+
+# ---------------------------------------------------------------------------
+# Mode validation
+# ---------------------------------------------------------------------------
+
+
+def test_redact_requires_exactly_one_mode() -> None:
+    """Invoking redact without a mode flag should error out."""
+    result = runner.invoke(app, ["redact"])
+    assert result.exit_code != 0
+    assert "exactly one" in result.output.lower()
+
+
+def test_redact_rejects_multiple_modes(tmp_path: Path) -> None:
+    """Two mode flags at once should error out."""
+    source = _write_empty_source(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "redact",
+            "--scan",
+            "--apply",
+            "--source",
+            str(source),
+        ],
+    )
+    assert result.exit_code != 0
+    assert "exactly one" in result.output.lower()
+
+
+def test_redact_scan_requires_source() -> None:
+    """--scan without --source should error out."""
+    result = runner.invoke(app, ["redact", "--scan"])
+    assert result.exit_code != 0
+    assert "--source" in result.output
+
+
+def test_redact_apply_requires_source() -> None:
+    """--apply without --source should error out."""
+    result = runner.invoke(app, ["redact", "--apply"])
+    assert result.exit_code != 0
+    assert "--source" in result.output
+
+
+def test_redact_review_requires_vault() -> None:
+    """--review without --vault should error out."""
+    result = runner.invoke(app, ["redact", "--review"])
+    assert result.exit_code != 0
+    assert "--vault" in result.output
+
+
+def test_redact_scan_missing_source(tmp_path: Path) -> None:
+    """--scan on a non-existent path should exit with an error."""
+    missing = tmp_path / "does-not-exist"
+    result = runner.invoke(
+        app,
+        ["redact", "--scan", "--source", str(missing)],
+    )
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# --scan
+# ---------------------------------------------------------------------------
+
+
+def test_redact_scan_finds_sensitive_data(tmp_path: Path) -> None:
+    """--scan prints a summary showing the sensitive findings."""
+    source = _write_sensitive_source(tmp_path)
+    result = runner.invoke(
+        app,
+        ["redact", "--scan", "--source", str(source)],
+    )
+    assert result.exit_code == 0
+    assert "Redaction Scan Summary" in result.output
+    assert "Total findings" in result.output
+
+
+def test_redact_scan_empty_directory(tmp_path: Path) -> None:
+    """--scan on a directory with no sensitive data reports zero findings."""
+    source = _write_empty_source(tmp_path)
+    result = runner.invoke(
+        app,
+        ["redact", "--scan", "--source", str(source)],
+    )
+    assert result.exit_code == 0
+    assert "Total findings" in result.output
+
+
+def test_redact_scan_single_file(tmp_path: Path) -> None:
+    """--scan accepts a single file path, not only directories."""
+    target = tmp_path / "one.md"
+    target.write_text("password=leaked123\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["redact", "--scan", "--source", str(target)],
+    )
+    assert result.exit_code == 0
+    assert "Total findings" in result.output
+
+
+def test_redact_scan_report_prints_markdown(tmp_path: Path) -> None:
+    """--scan --report prints the detailed markdown summary."""
+    source = _write_sensitive_source(tmp_path)
+    result = runner.invoke(
+        app,
+        ["redact", "--scan", "--source", str(source), "--report"],
+    )
+    assert result.exit_code == 0
+    # Markdown summary renders the "Findings by File" heading.
+    assert "Findings by File" in result.output
+
+
+def test_redact_scan_verbose_lists_matches(tmp_path: Path) -> None:
+    """--verbose emits a match-level table in scan mode."""
+    source = _write_sensitive_source(tmp_path)
+    result = runner.invoke(
+        app,
+        ["redact", "--scan", "--source", str(source), "--verbose"],
+    )
+    assert result.exit_code == 0
+    # The per-match table title from the CLI helper.
+    assert "Matches" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --apply
+# ---------------------------------------------------------------------------
+
+
+def _leak_path(source: Path) -> Path:
+    """Return the path of the .env leak file used by the sensitive fixture.
+
+    Args:
+        source: Source directory created by :func:`_write_sensitive_source`.
+
+    Returns:
+        Path to the leak file inside *source*.
+    """
+    return source / "leak.env"
+
+
+def test_redact_apply_confirmed_modifies_files(tmp_path: Path) -> None:
+    """Confirming the prompt redacts sensitive data in-place."""
+    source = _write_sensitive_source(tmp_path)
+    leak = _leak_path(source)
+    original = leak.read_text(encoding="utf-8")
+    assert "hunter2" in original
+
+    result = runner.invoke(
+        app,
+        ["redact", "--apply", "--source", str(source)],
+        input="y\n",
+    )
+    assert result.exit_code == 0
+    modified = leak.read_text(encoding="utf-8")
+    assert "hunter2" not in modified
+    assert "[REDACTED:" in modified
+
+
+def test_redact_apply_declined_leaves_files_untouched(tmp_path: Path) -> None:
+    """Declining the prompt should leave source files unchanged."""
+    source = _write_sensitive_source(tmp_path)
+    leak = _leak_path(source)
+    original = leak.read_text(encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["redact", "--apply", "--source", str(source)],
+        input="n\n",
+    )
+    assert result.exit_code == 0
+    assert "Aborted" in result.output
+    assert leak.read_text(encoding="utf-8") == original
+
+
+def test_redact_apply_dry_run_preserves_files(tmp_path: Path) -> None:
+    """--dry-run must never modify the source tree."""
+    source = _write_sensitive_source(tmp_path)
+    leak = _leak_path(source)
+    original = leak.read_text(encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["redact", "--apply", "--source", str(source), "--dry-run"],
+    )
+    assert result.exit_code == 0
+    assert "Dry run" in result.output
+    assert leak.read_text(encoding="utf-8") == original
+
+
+def test_redact_apply_yes_skips_confirmation(tmp_path: Path) -> None:
+    """--yes bypasses the confirmation prompt and applies redactions."""
+    source = _write_sensitive_source(tmp_path)
+    leak = _leak_path(source)
+    assert "hunter2" in leak.read_text(encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["redact", "--apply", "--source", str(source), "--yes"],
+    )
+    assert result.exit_code == 0
+    modified = leak.read_text(encoding="utf-8")
+    assert "hunter2" not in modified
+
+
+def test_redact_apply_no_findings_short_circuits(tmp_path: Path) -> None:
+    """--apply on a clean tree reports nothing to do and never prompts."""
+    source = _write_empty_source(tmp_path)
+    result = runner.invoke(
+        app,
+        ["redact", "--apply", "--source", str(source)],
+    )
+    assert result.exit_code == 0
+    assert "nothing to redact" in result.output.lower()
+
+
+def test_redact_apply_verbose_lists_matches(tmp_path: Path) -> None:
+    """--verbose in apply mode surfaces the per-match table."""
+    source = _write_sensitive_source(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "redact",
+            "--apply",
+            "--source",
+            str(source),
+            "--dry-run",
+            "--verbose",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Matches" in result.output
+
+
+# ---------------------------------------------------------------------------
+# --review
+# ---------------------------------------------------------------------------
+
+
+def test_redact_review_renders_queue(tmp_path: Path) -> None:
+    """--review on a vault prints the markdown review queue."""
+    vault = _write_sensitive_source(tmp_path)
+    result = runner.invoke(
+        app,
+        ["redact", "--review", "--vault", str(vault)],
+    )
+    assert result.exit_code == 0
+    assert "Redaction Review Queue" in result.output
+
+
+def test_redact_review_empty_vault(tmp_path: Path) -> None:
+    """--review on an empty vault prints a no-findings banner."""
+    vault = _write_empty_source(tmp_path)
+    result = runner.invoke(
+        app,
+        ["redact", "--review", "--vault", str(vault)],
+    )
+    assert result.exit_code == 0
+    assert "No findings" in result.output
+
+
+def test_redact_review_missing_vault(tmp_path: Path) -> None:
+    """--review with a missing vault path errors out."""
+    missing = tmp_path / "no-vault"
+    result = runner.invoke(
+        app,
+        ["redact", "--review", "--vault", str(missing)],
+    )
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()

--- a/creek-tools/tests/test_cli_redact.py
+++ b/creek-tools/tests/test_cli_redact.py
@@ -7,6 +7,7 @@ together with the supporting flags (``--report``, ``--dry-run``,
 
 from __future__ import annotations
 
+import os as real_os
 from typing import TYPE_CHECKING
 
 from typer.testing import CliRunner
@@ -15,6 +16,8 @@ from creek.cli import app
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    import pytest
 
 runner = CliRunner()
 
@@ -280,6 +283,53 @@ def test_redact_apply_no_findings_short_circuits(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0
     assert "nothing to redact" in result.output.lower()
+
+
+def test_redact_apply_partial_io_failure_preserves_integrity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An I/O error mid-batch must never leave a file half-written.
+
+    Simulates ``os.replace`` failing on the second file. The first file
+    is expected to be redacted, the second file must retain its
+    original, un-redacted content (i.e. not be a half-written temp
+    file or empty), and no stray temp files may be left behind.
+    """
+    source = _write_sensitive_source(tmp_path)
+    leak = source / "leak.env"
+    notes = source / "notes.md"
+    original_notes = notes.read_text(encoding="utf-8")
+
+    real_replace = real_os.replace
+    call_count = {"n": 0}
+
+    def flaky_replace(src: object, dst: object) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 2:
+            msg = "simulated disk full"
+            raise OSError(msg)
+        real_replace(src, dst)
+
+    monkeypatch.setattr(
+        "creek.redact.cli_commands.os.replace",
+        flaky_replace,
+    )
+
+    result = runner.invoke(
+        app,
+        ["redact", "--apply", "--source", str(source), "--yes"],
+    )
+
+    assert result.exit_code != 0
+    assert "I/O error" in result.output
+    # First file was redacted atomically and committed.
+    assert "hunter2" not in leak.read_text(encoding="utf-8")
+    # Second file is exactly as it started — not empty, not partial.
+    assert notes.read_text(encoding="utf-8") == original_notes
+    # No stray temp files left in the source directory.
+    assert not list(source.glob("*.redact-tmp"))
+    assert not list(source.glob(".*.redact-tmp"))
 
 
 def test_redact_apply_verbose_lists_matches(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #16. Replaces the `creek redact` stub with a real command that wires the existing `RedactionScanner` and `Redactor` into three mutually-exclusive modes:

- `creek redact --scan --source PATH [--report] [--verbose]` — dry-run scan with Rich summary tables; `--report` adds the full markdown summary.
- `creek redact --apply --source PATH [--dry-run] [--verbose] [--yes]` — scan, prompt with `typer.confirm()`, then rewrite files in place. `--dry-run` and `--yes` cover automation + safety needs.
- `creek redact --review --vault PATH [--verbose]` — re-scan a vault and render the markdown review queue (checkboxes + context).

Command logic lives in `creek/redact/cli_commands.py` so that `creek/cli.py` stays focused on flag validation and dispatch. Severity is colorized via Rich styles; progress is shown via the scanner's existing tqdm integration.

## Test plan

- [x] `tests/test_cli_redact.py` covers mode validation (mutex, required flags, missing paths), `--scan` with directory/single file/`--report`/`--verbose`, `--apply` with confirm/decline/dry-run/yes/no-findings/verbose, and `--review` with findings/empty vault/missing vault.
- [x] Existing `tests/test_cli.py` redact smoke tests updated to use real `tmp_path` fixtures now that the command does real work.
- [x] `./scripts/check-all.sh`: 1829 tests pass, coverage 94.98% (above the 90% threshold), lint clean, format clean, bandit clean, complexity green. The two unrelated failures (mypy missing rich/typer stubs, pip-audit CVEs in system deps) reproduce on a clean baseline and are not introduced by this PR.

https://claude.ai/code/session_01SvTDw3Q5GbsZVhEU41km9a