### PR TITLE
feat(purge): implement `creek purge` right-to-be-forgotten CLI (#46)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1,6 +1,7 @@
 """Creek CLI -- command-line interface for the Creek knowledge organization pipeline."""
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
@@ -9,9 +10,17 @@ from rich.table import Table
 from creek.config import load_config
 from creek.pipeline import Pipeline
 
+if TYPE_CHECKING:
+    from creek.purge import PurgeEngine, PurgeResult
+
 app = typer.Typer(name="creek", help="Creek knowledge organization pipeline")
 clean_app = typer.Typer(name="clean", help="Vault hygiene commands")
+purge_app = typer.Typer(
+    name="purge",
+    help="Right-to-be-forgotten deletion operations",
+)
 app.add_typer(clean_app, name="clean")
+app.add_typer(purge_app, name="purge")
 console = Console()
 
 
@@ -123,17 +132,6 @@ def review(
 ) -> None:
     """Interactive review queue for fragments."""
     console.print(f"[bold green]Would review: vault={vault}[/bold green]")
-
-
-@app.command()
-def purge(
-    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
-    target: str | None = typer.Option(None, help="Target to purge"),
-) -> None:
-    """Delete fragments or classifications."""
-    console.print(
-        f"[bold green]Would purge: vault={vault}, target={target}[/bold green]"
-    )
 
 
 @app.command()
@@ -331,3 +329,213 @@ def clean_report(
     if output is not None:
         reporter.write_markdown(hygiene_report, output)
         console.print(f"\n[green]Report written to {output}[/green]")
+
+
+# ---------------------------------------------------------------------------
+# Purge subcommands
+# ---------------------------------------------------------------------------
+
+
+def _render_purge_result(result: "PurgeResult") -> None:
+    """Render a purge result as a rich table.
+
+    Args:
+        result: The completed purge result.
+    """
+    mode = "[yellow]DRY-RUN[/yellow]" if result.dry_run else "[red]APPLY[/red]"
+    console.print(f"\n[bold]Purge {result.operation}[/bold] ({mode})")
+    console.print(f"Target: {result.target}")
+    console.print(f"Fragments affected: {result.fragments_affected}")
+    console.print(f"Wiki-links removed: {result.wikilinks_removed}")
+    console.print(f"Threads updated: {result.threads_updated}")
+    console.print(f"Eddies updated: {result.eddies_updated}")
+    if result.classifications_reset:
+        console.print(
+            f"Classifications reset: {result.classifications_reset}",
+        )
+
+    if result.deleted_files:
+        table = Table(title="Deleted files")
+        table.add_column("Path", style="dim")
+        for path in result.deleted_files:
+            table.add_row(path)
+        console.print(table)
+
+
+def _confirm(message: str, *, assume_yes: bool) -> bool:
+    """Prompt the user for confirmation unless ``assume_yes`` is set.
+
+    Args:
+        message: Confirmation message to display.
+        assume_yes: If ``True``, skip the prompt and return ``True``.
+
+    Returns:
+        Whether the user confirmed the operation.
+    """
+    if assume_yes:
+        return True
+    return typer.confirm(message, default=False)
+
+
+def _build_engine(
+    vault: Path | None,
+    *,
+    dry_run: bool,
+) -> "PurgeEngine":
+    """Construct a :class:`PurgeEngine` rooted at the resolved vault.
+
+    Args:
+        vault: Optional explicit vault override.
+        dry_run: Whether to preview changes only.
+
+    Returns:
+        A ready-to-use :class:`PurgeEngine`.
+    """
+    from creek.purge import PurgeEngine as _Engine
+
+    vault_path = _resolve_vault(vault)
+    return _Engine(vault_path, dry_run=dry_run)
+
+
+@purge_app.command(name="fragment")
+def purge_fragment(
+    fragment_id: str = typer.Argument(..., help="Fragment ID to purge"),
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    dry_run: bool = typer.Option(False, help="Preview changes without deleting"),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip interactive confirmation",
+    ),
+) -> None:
+    """Delete a fragment and scrub every reference to it."""
+    engine = _build_engine(vault, dry_run=dry_run)
+    if not dry_run and not _confirm(
+        f"Purge fragment {fragment_id!r} and all references?",
+        assume_yes=yes,
+    ):
+        console.print("[yellow]Aborted.[/yellow]")
+        return
+    result = engine.purge_fragment(fragment_id)
+    _render_purge_result(result)
+
+
+@purge_app.command(name="source")
+def purge_source(
+    source_type: str = typer.Argument(
+        ...,
+        help="Source platform (e.g. claude, discord)",
+    ),
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    dry_run: bool = typer.Option(False, help="Preview changes without deleting"),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip interactive confirmation",
+    ),
+) -> None:
+    """Delete every fragment ingested from a given source."""
+    engine = _build_engine(vault, dry_run=dry_run)
+    count = engine.count_fragments_from_source(source_type)
+    console.print(
+        f"[bold]This will delete {count} fragments from {source_type!r}.[/bold]",
+    )
+    if not dry_run and not _confirm("Continue?", assume_yes=yes):
+        console.print("[yellow]Aborted.[/yellow]")
+        return
+    result = engine.purge_source(source_type)
+    _render_purge_result(result)
+
+
+@purge_app.command(name="classifications")
+def purge_classifications(
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    dry_run: bool = typer.Option(False, help="Preview changes without deleting"),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip interactive confirmation",
+    ),
+) -> None:
+    """Reset classification fields on every fragment to unclassified."""
+    engine = _build_engine(vault, dry_run=dry_run)
+    if not dry_run and not _confirm(
+        "Reset classifications on every fragment?",
+        assume_yes=yes,
+    ):
+        console.print("[yellow]Aborted.[/yellow]")
+        return
+    result = engine.purge_classifications()
+    _render_purge_result(result)
+
+
+@purge_app.command(name="daterange")
+def purge_daterange(
+    start: str = typer.Argument(..., help="Start date (YYYY-MM-DD, inclusive)"),
+    end: str = typer.Argument(..., help="End date (YYYY-MM-DD, inclusive)"),
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    dry_run: bool = typer.Option(False, help="Preview changes without deleting"),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip interactive confirmation",
+    ),
+) -> None:
+    """Delete fragments created within a date range."""
+    from datetime import date as _date
+
+    try:
+        start_date = _date.fromisoformat(start)
+        end_date = _date.fromisoformat(end)
+    except ValueError as exc:
+        console.print(f"[red]Invalid date: {exc}[/red]")
+        raise typer.Exit(code=2) from exc
+
+    engine = _build_engine(vault, dry_run=dry_run)
+    if not dry_run and not _confirm(
+        f"Delete fragments created between {start_date} and {end_date}?",
+        assume_yes=yes,
+    ):
+        console.print("[yellow]Aborted.[/yellow]")
+        return
+    result = engine.purge_daterange(start_date, end_date)
+    _render_purge_result(result)
+
+
+@purge_app.command(name="vault")
+def purge_vault(
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    dry_run: bool = typer.Option(False, help="Preview changes without deleting"),
+    confirm_text: str = typer.Option(
+        "",
+        help=(
+            "Must equal 'I understand this is irreversible' "
+            "to bypass interactive prompt."
+        ),
+    ),
+) -> None:
+    """Destroy every fragment, thread, and eddy (nuclear option)."""
+    from creek.purge.engine import VAULT_PURGE_CONFIRMATION
+
+    engine = _build_engine(vault, dry_run=dry_run)
+    phrase = confirm_text
+    if not dry_run and phrase != VAULT_PURGE_CONFIRMATION:
+        console.print(
+            "[bold red]This will destroy the entire vault contents.[/bold red]",
+        )
+        phrase = typer.prompt(
+            f"Type exactly {VAULT_PURGE_CONFIRMATION!r} to continue",
+            default="",
+            show_default=False,
+        )
+    try:
+        supplied = VAULT_PURGE_CONFIRMATION if dry_run else phrase
+        result = engine.purge_vault(supplied)
+    except ValueError as exc:
+        console.print(f"[red]Aborted: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    _render_purge_result(result)

--- a/creek-tools/creek/purge/__init__.py
+++ b/creek-tools/creek/purge/__init__.py
@@ -1,0 +1,17 @@
+"""Creek purge module — right-to-be-forgotten operations for vault content.
+
+Provides the :class:`PurgeEngine` for deleting fragments, wiping
+classifications, and destroying vault content, along with an
+:class:`PurgeAuditLog` that records every purge operation to
+``00-Creek-Meta/Processing-Log/purge-log.json``.
+"""
+
+from creek.purge.audit import PurgeAuditEntry, PurgeAuditLog
+from creek.purge.engine import PurgeEngine, PurgeResult
+
+__all__ = [
+    "PurgeAuditEntry",
+    "PurgeAuditLog",
+    "PurgeEngine",
+    "PurgeResult",
+]

--- a/creek-tools/creek/purge/audit.py
+++ b/creek-tools/creek/purge/audit.py
@@ -1,0 +1,121 @@
+"""Audit log for purge operations.
+
+Records every purge operation — including dry runs — to a JSON log at
+``00-Creek-Meta/Processing-Log/purge-log.json``. Each entry captures the
+timestamp, operation, target, affected count, operator, and dry-run flag.
+
+The log is a JSON array; new entries are appended. If the file does not
+exist it is created. Malformed existing logs are rebuilt from scratch
+rather than losing new entries.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_OPERATOR = "human via CLI"
+
+
+class PurgeAuditEntry(BaseModel):
+    """A single purge audit log entry.
+
+    Attributes:
+        timestamp: UTC ISO-format datetime of the purge.
+        operation: Operation name (``fragment``, ``source``,
+            ``classifications``, ``daterange``, ``vault``).
+        target: The purge target (fragment ID, source type, etc.).
+        count: Number of affected files or fragments.
+        operator: Who performed the purge (default ``"human via CLI"``).
+        dry_run: Whether the purge was a dry-run preview.
+    """
+
+    timestamp: str = Field(
+        default_factory=lambda: datetime.now(tz=UTC).isoformat(),
+    )
+    operation: str
+    target: str
+    count: int
+    operator: str = _DEFAULT_OPERATOR
+    dry_run: bool = False
+
+
+class PurgeAuditLog:
+    """Append-only JSON audit log for purge operations.
+
+    Args:
+        vault_path: Root of the Obsidian vault. The log file lives at
+            ``{vault_path}/00-Creek-Meta/Processing-Log/purge-log.json``.
+    """
+
+    def __init__(self, vault_path: Path) -> None:
+        """Initialise the audit log with the target vault path.
+
+        Args:
+            vault_path: Root of the Obsidian vault.
+        """
+        self.vault_path = vault_path
+        self.log_path = (
+            vault_path / "00-Creek-Meta" / "Processing-Log" / "purge-log.json"
+        )
+
+    def append(self, entry: PurgeAuditEntry) -> None:
+        """Append a new entry to the audit log.
+
+        Creates the log directory and file if missing. If the existing
+        log is malformed, it is replaced with a fresh log containing
+        only the new entry.
+
+        Args:
+            entry: The audit entry to append.
+        """
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        entries = self._read_entries()
+        entries.append(entry.model_dump(mode="json"))
+        self.log_path.write_text(
+            json.dumps(entries, indent=2),
+            encoding="utf-8",
+        )
+
+    def read(self) -> list[PurgeAuditEntry]:
+        """Read all entries from the audit log.
+
+        Returns:
+            List of parsed :class:`PurgeAuditEntry` objects. Empty list
+            if the log does not exist or is malformed.
+        """
+        entries = self._read_entries()
+        return [PurgeAuditEntry.model_validate(e) for e in entries]
+
+    def _read_entries(self) -> list[dict[str, object]]:
+        """Read raw entry dicts from the log file.
+
+        Returns:
+            List of raw entry dicts. Empty list if the log is missing
+            or unreadable.
+        """
+        if not self.log_path.exists():
+            return []
+        try:
+            raw = self.log_path.read_text(encoding="utf-8")
+            if not raw.strip():
+                return []
+            data = json.loads(raw)
+        except (OSError, json.JSONDecodeError):
+            logger.warning(
+                "Purge log at %s is unreadable — starting fresh.",
+                self.log_path,
+            )
+            return []
+        if not isinstance(data, list):
+            return []
+        return [item for item in data if isinstance(item, dict)]

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -1,0 +1,605 @@
+"""Purge engine — right-to-be-forgotten deletion operations.
+
+Implements the five purge operations required by issue #46:
+
+- **purge_fragment**: delete a single fragment and clean all references.
+- **purge_source**: delete every fragment from a given source platform.
+- **purge_classifications**: reset classification fields to unclassified.
+- **purge_daterange**: delete fragments created within a date range.
+- **purge_vault**: destroy all vault content, preserving folder structure.
+
+Every operation supports a dry-run mode that previews changes without
+writing to disk, and writes an entry to the
+:class:`~creek.purge.audit.PurgeAuditLog` recording what happened.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+from pydantic import BaseModel, Field
+
+from creek.purge.audit import PurgeAuditEntry, PurgeAuditLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_VAULT_CONTENT_FOLDERS: tuple[str, ...] = (
+    "01-Fragments",
+    "02-Threads",
+    "03-Eddies",
+    "04-Praxis",
+    "05-Wavelength",
+    "06-Frequencies",
+    "07-Voice",
+    "08-Decisions",
+    "09-Reference",
+    "10-Liminal",
+)
+"""Top-level vault folders whose contents can be purged by ``purge_vault``."""
+
+VAULT_PURGE_CONFIRMATION = "I understand this is irreversible"
+"""Exact phrase required to confirm a full-vault purge."""
+
+_CLASSIFICATION_RESET_FIELDS: tuple[str, ...] = (
+    "frequency",
+    "wavelength",
+    "voice",
+)
+"""Frontmatter fields wiped by ``purge_classifications``."""
+
+
+class PurgeResult(BaseModel):
+    """Outcome of a single purge operation.
+
+    Attributes:
+        operation: Name of the operation (``fragment``, ``source``, ...).
+        target: The purge target (fragment id, source type, date range, ...).
+        dry_run: Whether deletions were only previewed.
+        deleted_files: Paths of files deleted (or that would be deleted).
+        fragments_affected: Number of fragments directly affected.
+        wikilinks_removed: Number of wiki-link references scrubbed.
+        threads_updated: Thread files whose metadata changed.
+        eddies_updated: Eddy files whose metadata changed.
+        classifications_reset: Fragments whose classifications were wiped.
+    """
+
+    operation: str
+    target: str
+    dry_run: bool = False
+    deleted_files: list[str] = Field(default_factory=list)
+    fragments_affected: int = 0
+    wikilinks_removed: int = 0
+    threads_updated: int = 0
+    eddies_updated: int = 0
+    classifications_reset: int = 0
+
+
+class PurgeEngine:
+    """Execute right-to-be-forgotten deletions against a vault.
+
+    Every public method returns a :class:`PurgeResult` summarising what
+    changed (or would change, when ``dry_run=True``) and appends an
+    entry to the audit log.
+
+    Args:
+        vault_path: Path to the Obsidian vault root.
+        dry_run: When ``True``, no filesystem writes occur; results
+            describe the hypothetical outcome.
+    """
+
+    def __init__(self, vault_path: Path, *, dry_run: bool = False) -> None:
+        """Initialise the engine with the target vault path.
+
+        Args:
+            vault_path: Path to the Obsidian vault root.
+            dry_run: If ``True``, preview changes without applying them.
+        """
+        self.vault_path = vault_path
+        self.dry_run = dry_run
+        self.audit_log = PurgeAuditLog(vault_path)
+
+    # -- Fragment purge ---------------------------------------------------
+
+    def purge_fragment(self, fragment_id: str) -> PurgeResult:
+        """Delete a fragment and remove every reference to it.
+
+        Searches ``01-Fragments/`` for a markdown file whose frontmatter
+        ``id`` matches ``fragment_id``. If found, the file is deleted,
+        all wiki-links pointing at its title are scrubbed from every
+        markdown file in the vault, and the ``fragment_count`` on any
+        thread/eddy listed in its frontmatter is decremented.
+
+        Args:
+            fragment_id: The fragment's unique ID (e.g. ``frag-abc123``).
+
+        Returns:
+            A :class:`PurgeResult` describing the deletion.
+        """
+        result = PurgeResult(
+            operation="fragment",
+            target=fragment_id,
+            dry_run=self.dry_run,
+        )
+        frag_file, post = self._find_fragment_by_id(fragment_id)
+        if frag_file is None or post is None:
+            self._write_audit(result)
+            return result
+
+        title = str(post.get("title", frag_file.stem))
+        thread_ids = [str(t) for t in post.get("threads", []) or []]
+        eddy_ids = [str(e) for e in post.get("eddies", []) or []]
+
+        result.deleted_files.append(str(frag_file))
+        result.fragments_affected = 1
+        result.wikilinks_removed = self._scrub_wikilinks(title, exclude=frag_file)
+        result.threads_updated = self._decrement_counts(
+            "02-Threads",
+            thread_ids,
+        )
+        result.eddies_updated = self._decrement_counts(
+            "03-Eddies",
+            eddy_ids,
+        )
+
+        if not self.dry_run:
+            frag_file.unlink()
+
+        self._write_audit(result)
+        return result
+
+    # -- Source purge -----------------------------------------------------
+
+    def purge_source(self, source_type: str) -> PurgeResult:
+        """Delete every fragment ingested from a given source platform.
+
+        Args:
+            source_type: Source platform identifier
+                (e.g. ``claude``, ``discord``).
+
+        Returns:
+            A :class:`PurgeResult` summarising the deletions.
+        """
+        result = PurgeResult(
+            operation="source",
+            target=source_type,
+            dry_run=self.dry_run,
+        )
+        matches = self._fragments_from_source(source_type)
+        for frag_file, post in matches:
+            self._purge_single(frag_file, post, result)
+        self._write_audit(result)
+        return result
+
+    def count_fragments_from_source(self, source_type: str) -> int:
+        """Count fragments currently attributed to a source platform.
+
+        Args:
+            source_type: Source platform identifier.
+
+        Returns:
+            Number of matching fragment files.
+        """
+        return len(self._fragments_from_source(source_type))
+
+    # -- Classifications purge -------------------------------------------
+
+    def purge_classifications(self) -> PurgeResult:
+        """Reset classification fields on every fragment to unclassified.
+
+        Preserves source metadata, timestamps, threads, eddies, and body
+        content; only ``frequency``, ``wavelength``, and ``voice``
+        frontmatter blocks are reset to defaults.
+
+        Returns:
+            A :class:`PurgeResult` recording how many fragments changed.
+        """
+        result = PurgeResult(
+            operation="classifications",
+            target="all",
+            dry_run=self.dry_run,
+        )
+        for frag_file in self._list_fragment_files():
+            post = self._load_frontmatter(frag_file)
+            if post is None:
+                continue
+            if self._reset_classifications(post):
+                result.classifications_reset += 1
+                if not self.dry_run:
+                    frag_file.write_text(
+                        frontmatter.dumps(post),
+                        encoding="utf-8",
+                    )
+        result.fragments_affected = result.classifications_reset
+        self._write_audit(result)
+        return result
+
+    # -- Daterange purge -------------------------------------------------
+
+    def purge_daterange(
+        self,
+        start: date,
+        end: date,
+    ) -> PurgeResult:
+        """Delete fragments whose ``created`` date falls within a range.
+
+        Args:
+            start: Inclusive start date (UTC).
+            end: Inclusive end date (UTC).
+
+        Returns:
+            A :class:`PurgeResult` summarising the deletions.
+
+        Raises:
+            ValueError: If ``end`` is before ``start``.
+        """
+        if end < start:
+            msg = f"End date {end} is before start date {start}"
+            raise ValueError(msg)
+
+        target = f"{start.isoformat()}..{end.isoformat()}"
+        result = PurgeResult(
+            operation="daterange",
+            target=target,
+            dry_run=self.dry_run,
+        )
+        for frag_file in self._list_fragment_files():
+            post = self._load_frontmatter(frag_file)
+            if post is None:
+                continue
+            created = _coerce_date(post.get("created"))
+            if created is None or not (start <= created <= end):
+                continue
+            self._purge_single(frag_file, post, result)
+        self._write_audit(result)
+        return result
+
+    # -- Vault purge ------------------------------------------------------
+
+    def purge_vault(self, confirmation: str) -> PurgeResult:
+        """Destroy every fragment, thread, eddy, and related file.
+
+        Folder structure is preserved; only the *contents* of the
+        top-level vault content folders are removed. The purge log
+        itself is preserved.
+
+        Args:
+            confirmation: Must equal :data:`VAULT_PURGE_CONFIRMATION`
+                exactly.
+
+        Returns:
+            A :class:`PurgeResult` describing the destruction.
+
+        Raises:
+            ValueError: If ``confirmation`` does not match.
+        """
+        if confirmation != VAULT_PURGE_CONFIRMATION:
+            msg = (
+                f"Vault purge requires explicit confirmation text: "
+                f"{VAULT_PURGE_CONFIRMATION!r}"
+            )
+            raise ValueError(msg)
+
+        result = PurgeResult(
+            operation="vault",
+            target="entire vault",
+            dry_run=self.dry_run,
+        )
+        for folder in _VAULT_CONTENT_FOLDERS:
+            folder_path = self.vault_path / folder
+            if not folder_path.is_dir():
+                continue
+            self._wipe_folder_contents(folder_path, result)
+        result.fragments_affected = len(result.deleted_files)
+        self._write_audit(result)
+        return result
+
+    # -- Private helpers -------------------------------------------------
+
+    def _purge_single(
+        self,
+        frag_file: Path,
+        post: frontmatter.Post,
+        result: PurgeResult,
+    ) -> None:
+        """Apply a single-fragment purge to a result accumulator.
+
+        Args:
+            frag_file: Fragment file to remove.
+            post: Parsed frontmatter of ``frag_file``.
+            result: Result object being accumulated.
+        """
+        title = str(post.get("title", frag_file.stem))
+        thread_ids = [str(t) for t in post.get("threads", []) or []]
+        eddy_ids = [str(e) for e in post.get("eddies", []) or []]
+
+        result.deleted_files.append(str(frag_file))
+        result.fragments_affected += 1
+        result.wikilinks_removed += self._scrub_wikilinks(
+            title,
+            exclude=frag_file,
+        )
+        result.threads_updated += self._decrement_counts(
+            "02-Threads",
+            thread_ids,
+        )
+        result.eddies_updated += self._decrement_counts(
+            "03-Eddies",
+            eddy_ids,
+        )
+        if not self.dry_run:
+            frag_file.unlink()
+
+    def _find_fragment_by_id(
+        self,
+        fragment_id: str,
+    ) -> tuple[Path | None, frontmatter.Post | None]:
+        """Locate a fragment markdown file by its frontmatter ID.
+
+        Args:
+            fragment_id: The fragment ID to locate.
+
+        Returns:
+            Tuple of ``(path, post)`` or ``(None, None)`` if not found.
+        """
+        for frag_file in self._list_fragment_files():
+            post = self._load_frontmatter(frag_file)
+            if post is not None and post.get("id") == fragment_id:
+                return frag_file, post
+        return None, None
+
+    def _fragments_from_source(
+        self,
+        source_type: str,
+    ) -> list[tuple[Path, frontmatter.Post]]:
+        """List all fragment files whose source platform matches.
+
+        Args:
+            source_type: Source platform identifier.
+
+        Returns:
+            List of ``(path, post)`` pairs.
+        """
+        matches: list[tuple[Path, frontmatter.Post]] = []
+        for frag_file in self._list_fragment_files():
+            post = self._load_frontmatter(frag_file)
+            if post is None:
+                continue
+            if _extract_source_platform(post) == source_type:
+                matches.append((frag_file, post))
+        return matches
+
+    def _list_fragment_files(self) -> list[Path]:
+        """Return every ``.md`` file under ``01-Fragments``.
+
+        Returns:
+            Sorted list of fragment markdown paths.
+        """
+        fragments_dir = self.vault_path / "01-Fragments"
+        if not fragments_dir.is_dir():
+            return []
+        return sorted(fragments_dir.rglob("*.md"))
+
+    def _list_vault_md_files(self) -> list[Path]:
+        """Return every ``.md`` file anywhere in the vault.
+
+        Returns:
+            Sorted list of markdown paths.
+        """
+        if not self.vault_path.is_dir():
+            return []
+        return sorted(self.vault_path.rglob("*.md"))
+
+    def _load_frontmatter(self, path: Path) -> frontmatter.Post | None:
+        """Read a frontmatter post from disk, tolerating bad files.
+
+        Args:
+            path: Path to a markdown file.
+
+        Returns:
+            Parsed :class:`frontmatter.Post`, or ``None`` on failure.
+        """
+        try:
+            return frontmatter.load(str(path))
+        except Exception:
+            logger.debug("Unable to parse frontmatter in %s", path)
+            return None
+
+    def _scrub_wikilinks(self, title: str, *, exclude: Path) -> int:
+        """Remove all ``[[title]]`` wiki-links from every vault file.
+
+        Args:
+            title: The target title whose links should be removed.
+            exclude: Path to skip (typically the file being deleted).
+
+        Returns:
+            Total number of wiki-link occurrences removed.
+        """
+        if not title:
+            return 0
+        pattern = _build_wikilink_pattern(title)
+        total_removed = 0
+        for md_file in self._list_vault_md_files():
+            if md_file == exclude:
+                continue
+            total_removed += self._scrub_file(md_file, pattern)
+        return total_removed
+
+    def _scrub_file(self, md_file: Path, pattern: re.Pattern[str]) -> int:
+        """Remove wiki-link occurrences from a single file.
+
+        Args:
+            md_file: File to modify.
+            pattern: Regex pattern matching the wiki-link.
+
+        Returns:
+            Number of occurrences removed in this file.
+        """
+        try:
+            text = md_file.read_text(encoding="utf-8")
+        except OSError:
+            return 0
+        new_text, count = pattern.subn("", text)
+        if count and not self.dry_run:
+            md_file.write_text(new_text, encoding="utf-8")
+        return count
+
+    def _decrement_counts(
+        self,
+        subfolder: str,
+        ids: list[str],
+    ) -> int:
+        """Decrement ``fragment_count`` on thread/eddy files.
+
+        Args:
+            subfolder: ``02-Threads`` or ``03-Eddies``.
+            ids: IDs of files whose counts should decrement.
+
+        Returns:
+            Number of files updated.
+        """
+        if not ids:
+            return 0
+        folder = self.vault_path / subfolder
+        if not folder.is_dir():
+            return 0
+        id_set = set(ids)
+        updated = 0
+        for md_file in folder.rglob("*.md"):
+            post = self._load_frontmatter(md_file)
+            if post is None or post.get("id") not in id_set:
+                continue
+            current = int(post.get("fragment_count", 0) or 0)
+            post["fragment_count"] = max(0, current - 1)
+            updated += 1
+            if not self.dry_run:
+                md_file.write_text(
+                    frontmatter.dumps(post),
+                    encoding="utf-8",
+                )
+        return updated
+
+    def _reset_classifications(self, post: frontmatter.Post) -> bool:
+        """Reset classification fields on a frontmatter post.
+
+        Args:
+            post: Frontmatter to mutate in-place.
+
+        Returns:
+            True if any classification field was actually changed.
+        """
+        changed = False
+        for field_name in _CLASSIFICATION_RESET_FIELDS:
+            default = _CLASSIFICATION_DEFAULTS[field_name]
+            if post.get(field_name) != default:
+                post[field_name] = default
+                changed = True
+        return changed
+
+    def _wipe_folder_contents(
+        self,
+        folder_path: Path,
+        result: PurgeResult,
+    ) -> None:
+        """Remove every file/subdirectory inside a vault folder.
+
+        Args:
+            folder_path: Folder whose contents should be removed.
+            result: Result accumulator to update with deleted paths.
+        """
+        for entry in sorted(folder_path.iterdir()):
+            result.deleted_files.append(str(entry))
+            if self.dry_run:
+                continue
+            if entry.is_dir():
+                shutil.rmtree(entry)
+            else:
+                entry.unlink()
+
+    def _write_audit(self, result: PurgeResult) -> None:
+        """Append a :class:`PurgeAuditEntry` for a completed purge.
+
+        Args:
+            result: The result whose metadata should be logged.
+        """
+        entry = PurgeAuditEntry(
+            operation=result.operation,
+            target=result.target,
+            count=result.fragments_affected,
+            dry_run=result.dry_run,
+        )
+        self.audit_log.append(entry)
+
+
+_CLASSIFICATION_DEFAULTS: dict[str, dict[str, object]] = {
+    "frequency": {"primary": "unclassified", "secondary": []},
+    "wavelength": {
+        "phase": "unclassified",
+        "mode": "unclassified",
+        "orientation": "unclassified",
+        "dosage": "unclassified",
+        "color": "unclassified",
+        "descriptor": "",
+    },
+    "voice": {"voice_register": None, "confidence": None},
+}
+"""Default values applied to classification fields during reset."""
+
+
+def _extract_source_platform(post: frontmatter.Post) -> str | None:
+    """Extract the ``source.platform`` string from frontmatter.
+
+    Args:
+        post: Parsed frontmatter post.
+
+    Returns:
+        The source platform identifier, or ``None`` when missing.
+    """
+    source = post.get("source")
+    if isinstance(source, dict):
+        platform = source.get("platform")
+        return str(platform) if platform is not None else None
+    return None
+
+
+def _build_wikilink_pattern(title: str) -> re.Pattern[str]:
+    """Build a regex matching ``[[title]]`` and ``[[title|alias]]``.
+
+    Args:
+        title: The target title to match exactly.
+
+    Returns:
+        A compiled regex pattern.
+    """
+    escaped = re.escape(title)
+    return re.compile(rf"\[\[{escaped}(?:\|[^\]]*)?\]\]")
+
+
+def _coerce_date(value: object) -> date | None:
+    """Coerce a frontmatter value into a date, if possible.
+
+    Accepts :class:`datetime`, :class:`date`, or ISO-format strings.
+
+    Args:
+        value: Frontmatter value to coerce.
+
+    Returns:
+        A ``date``, or ``None`` if ``value`` cannot be coerced.
+    """
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value).replace(tzinfo=UTC).date()
+        except ValueError:
+            return None
+    return None

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -220,19 +220,10 @@ def test_review_command() -> None:
 
 
 def test_purge_help() -> None:
-    """Test that purge --help shows subcommand help."""
+    """Test that purge --help shows subcommand group help."""
     result = runner.invoke(app, ["purge", "--help"])
     assert result.exit_code == 0
     assert "purge" in result.output.lower()
-
-
-def test_purge_command() -> None:
-    """Test that purge command runs with required args."""
-    result = runner.invoke(
-        app,
-        ["purge", "--vault", "/fake/vault", "--target", "fragments"],
-    )
-    assert result.exit_code == 0
 
 
 def test_gdrive_help() -> None:

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -1,0 +1,895 @@
+"""Tests for the creek purge module.
+
+Covers both the :class:`creek.purge.PurgeEngine` directly (fragment,
+source, classifications, daterange, vault) and the ``creek purge``
+CLI subcommands. Uses fixture vaults seeded with small fragment
+corpora per test.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.purge import PurgeAuditEntry, PurgeAuditLog, PurgeEngine, PurgeResult
+from creek.purge.engine import VAULT_PURGE_CONFIRMATION
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+# ---------------------------------------------------------------------------
+# Vault fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Create a minimal vault with the directories purge needs.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+
+    Returns:
+        The vault root path.
+    """
+    vault = tmp_path / "vault"
+    for d in [
+        "00-Creek-Meta/Processing-Log",
+        "01-Fragments/Conversations",
+        "01-Fragments/Messages",
+        "02-Threads/Active",
+        "03-Eddies",
+        "04-Praxis",
+    ]:
+        (vault / d).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _write_fragment(
+    vault: Path,
+    frag_id: str,
+    title: str,
+    *,
+    platform: str = "claude",
+    subfolder: str = "Conversations",
+    created: datetime | None = None,
+    threads: list[str] | None = None,
+    eddies: list[str] | None = None,
+    body: str = "Some body content.",
+    frequency_primary: str = "F3",
+) -> Path:
+    """Write a fragment markdown file.
+
+    Args:
+        vault: Vault root.
+        frag_id: Fragment ID.
+        title: Fragment title.
+        platform: Source platform.
+        subfolder: Subfolder under 01-Fragments/.
+        created: Optional creation datetime.
+        threads: Optional list of thread IDs the fragment belongs to.
+        eddies: Optional list of eddy IDs.
+        body: Markdown body content.
+        frequency_primary: Primary frequency classification value.
+
+    Returns:
+        Path to the written fragment file.
+    """
+    target = vault / "01-Fragments" / subfolder / f"{title}.md"
+    metadata: dict[str, object] = {
+        "id": frag_id,
+        "title": title,
+        "type": "fragment",
+        "source": {"platform": platform, "original_file": f"{frag_id}.json"},
+        "threads": threads or [],
+        "eddies": eddies or [],
+        "frequency": {"primary": frequency_primary, "secondary": []},
+        "wavelength": {
+            "phase": "rising",
+            "mode": "inhabit",
+            "orientation": "do",
+            "dosage": "medicine",
+            "color": "orange",
+            "descriptor": "bright",
+        },
+        "voice": {"voice_register": "analytical", "confidence": "settled"},
+    }
+    if created is not None:
+        metadata["created"] = created.isoformat()
+    post = frontmatter.Post(content=body, **metadata)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+def _write_thread(
+    vault: Path,
+    thread_id: str,
+    title: str,
+    *,
+    fragment_count: int = 1,
+) -> Path:
+    """Write a thread markdown file.
+
+    Args:
+        vault: Vault root.
+        thread_id: Thread ID.
+        title: Thread title.
+        fragment_count: Initial fragment count.
+
+    Returns:
+        Path to the thread file.
+    """
+    target = vault / "02-Threads" / "Active" / f"{title}.md"
+    post = frontmatter.Post(
+        content="",
+        id=thread_id,
+        title=title,
+        type="thread",
+        status="active",
+        fragment_count=fragment_count,
+    )
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+def _write_eddy(
+    vault: Path,
+    eddy_id: str,
+    title: str,
+    *,
+    fragment_count: int = 1,
+) -> Path:
+    """Write an eddy markdown file.
+
+    Args:
+        vault: Vault root.
+        eddy_id: Eddy ID.
+        title: Eddy title.
+        fragment_count: Initial fragment count.
+
+    Returns:
+        Path to the eddy file.
+    """
+    target = vault / "03-Eddies" / f"{title}.md"
+    post = frontmatter.Post(
+        content="",
+        id=eddy_id,
+        title=title,
+        type="eddy",
+        fragment_count=fragment_count,
+    )
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+# ---------------------------------------------------------------------------
+# Engine tests — purge_fragment
+# ---------------------------------------------------------------------------
+
+
+def test_fragment_purge_removes_file(tmp_path: Path) -> None:
+    """Purging a fragment deletes the underlying markdown file."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-A")
+
+    assert result.fragments_affected == 1
+    assert str(frag) in result.deleted_files
+    assert not frag.exists()
+
+
+def test_fragment_purge_missing_returns_empty(tmp_path: Path) -> None:
+    """Purging a nonexistent fragment is a no-op with a clean result."""
+    vault = _make_vault(tmp_path)
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-missing")
+
+    assert result.fragments_affected == 0
+    assert result.deleted_files == []
+
+
+def test_fragment_purge_removes_wikilinks(tmp_path: Path) -> None:
+    """Wiki-links pointing at the purged title are scrubbed from other files."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    linker = _write_fragment(
+        vault,
+        "frag-B",
+        "Beta",
+        body="See [[Alpha]] and [[Alpha|alias]] and [[Beta]].",
+    )
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-A")
+
+    assert result.wikilinks_removed == 2
+    post = frontmatter.load(str(linker))
+    assert "[[Alpha]]" not in post.content
+    assert "[[Alpha|alias]]" not in post.content
+    assert "[[Beta]]" in post.content
+
+
+def test_fragment_purge_decrements_thread_counts(tmp_path: Path) -> None:
+    """Threads referenced in the fragment have fragment_count decremented."""
+    vault = _make_vault(tmp_path)
+    _write_thread(vault, "thread-1", "Waves", fragment_count=3)
+    _write_fragment(vault, "frag-A", "Alpha", threads=["thread-1"])
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-A")
+
+    assert result.threads_updated == 1
+    thread_post = frontmatter.load(str(vault / "02-Threads/Active/Waves.md"))
+    assert thread_post["fragment_count"] == 2
+
+
+def test_fragment_purge_decrements_eddy_counts(tmp_path: Path) -> None:
+    """Eddies referenced in the fragment have fragment_count decremented."""
+    vault = _make_vault(tmp_path)
+    _write_eddy(vault, "eddy-1", "Whirl", fragment_count=2)
+    _write_fragment(vault, "frag-A", "Alpha", eddies=["eddy-1"])
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-A")
+
+    assert result.eddies_updated == 1
+    eddy_post = frontmatter.load(str(vault / "03-Eddies/Whirl.md"))
+    assert eddy_post["fragment_count"] == 1
+
+
+def test_fragment_purge_dry_run_preserves_everything(tmp_path: Path) -> None:
+    """Dry-run records intended actions without touching disk."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+    linker = _write_fragment(vault, "frag-B", "Beta", body="[[Alpha]]")
+    engine = PurgeEngine(vault, dry_run=True)
+
+    result = engine.purge_fragment("frag-A")
+
+    assert result.dry_run is True
+    assert result.fragments_affected == 1
+    assert result.wikilinks_removed == 1
+    assert frag.exists()
+    assert "[[Alpha]]" in linker.read_text(encoding="utf-8")
+
+
+def test_fragment_purge_writes_audit(tmp_path: Path) -> None:
+    """A purge_fragment call appends exactly one audit entry."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault)
+
+    engine.purge_fragment("frag-A")
+
+    entries = PurgeAuditLog(vault).read()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.operation == "fragment"
+    assert entry.target == "frag-A"
+    assert entry.count == 1
+    assert entry.operator == "human via CLI"
+    assert entry.dry_run is False
+
+
+# ---------------------------------------------------------------------------
+# Engine tests — purge_source
+# ---------------------------------------------------------------------------
+
+
+def test_source_purge_removes_matching_fragments(tmp_path: Path) -> None:
+    """Every fragment from the named source is deleted."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha", platform="claude")
+    _write_fragment(
+        vault,
+        "frag-B",
+        "Bravo",
+        platform="discord",
+        subfolder="Messages",
+    )
+    _write_fragment(vault, "frag-C", "Charlie", platform="claude")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source("claude")
+
+    assert result.fragments_affected == 2
+    remaining = list((vault / "01-Fragments").rglob("*.md"))
+    assert len(remaining) == 1
+    assert remaining[0].name == "Bravo.md"
+
+
+def test_source_count_matches(tmp_path: Path) -> None:
+    """count_fragments_from_source returns the expected number."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha", platform="claude")
+    _write_fragment(vault, "frag-B", "Bravo", platform="claude")
+    _write_fragment(
+        vault,
+        "frag-C",
+        "Charlie",
+        platform="discord",
+        subfolder="Messages",
+    )
+    engine = PurgeEngine(vault)
+
+    assert engine.count_fragments_from_source("claude") == 2
+    assert engine.count_fragments_from_source("discord") == 1
+    assert engine.count_fragments_from_source("gdrive") == 0
+
+
+# ---------------------------------------------------------------------------
+# Engine tests — purge_classifications
+# ---------------------------------------------------------------------------
+
+
+def test_classifications_purge_resets_fields(tmp_path: Path) -> None:
+    """Classification fields reset to unclassified; metadata preserved."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_classifications()
+
+    assert result.classifications_reset == 1
+    post = frontmatter.load(str(frag))
+    assert post["frequency"] == {"primary": "unclassified", "secondary": []}
+    assert post["wavelength"]["phase"] == "unclassified"
+    assert post["voice"]["voice_register"] is None
+    # Source + timestamps preserved
+    assert post["source"]["platform"] == "claude"
+    assert post["title"] == "Alpha"
+
+
+def test_classifications_purge_skips_already_clean(tmp_path: Path) -> None:
+    """Fragments already at defaults are not reported as reset."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha", frequency_primary="unclassified")
+    # Manually overwrite with all defaults so reset is a no-op
+    path = vault / "01-Fragments/Conversations/Alpha.md"
+    post = frontmatter.load(str(path))
+    post["frequency"] = {"primary": "unclassified", "secondary": []}
+    post["wavelength"] = {
+        "phase": "unclassified",
+        "mode": "unclassified",
+        "orientation": "unclassified",
+        "dosage": "unclassified",
+        "color": "unclassified",
+        "descriptor": "",
+    }
+    post["voice"] = {"voice_register": None, "confidence": None}
+    path.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    engine = PurgeEngine(vault)
+    result = engine.purge_classifications()
+
+    assert result.classifications_reset == 0
+
+
+def test_classifications_dry_run_no_writes(tmp_path: Path) -> None:
+    """Dry-run reports resets without modifying fragment files."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+    before = frag.read_text(encoding="utf-8")
+    engine = PurgeEngine(vault, dry_run=True)
+
+    result = engine.purge_classifications()
+
+    assert result.classifications_reset == 1
+    assert frag.read_text(encoding="utf-8") == before
+
+
+# ---------------------------------------------------------------------------
+# Engine tests — purge_daterange
+# ---------------------------------------------------------------------------
+
+
+def test_daterange_purge_deletes_in_range(tmp_path: Path) -> None:
+    """Only fragments within [start, end] are deleted."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(
+        vault,
+        "frag-old",
+        "Old",
+        created=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    _write_fragment(
+        vault,
+        "frag-mid",
+        "Mid",
+        created=datetime(2024, 6, 1, tzinfo=UTC),
+    )
+    _write_fragment(
+        vault,
+        "frag-new",
+        "New",
+        created=datetime(2025, 1, 1, tzinfo=UTC),
+    )
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_daterange(date(2024, 5, 1), date(2024, 12, 31))
+
+    assert result.fragments_affected == 1
+    remaining = {p.name for p in (vault / "01-Fragments").rglob("*.md")}
+    assert remaining == {"Old.md", "New.md"}
+
+
+def test_daterange_purge_invalid_range(tmp_path: Path) -> None:
+    """End before start raises ValueError."""
+    vault = _make_vault(tmp_path)
+    engine = PurgeEngine(vault)
+
+    with pytest.raises(ValueError, match="before start date"):
+        engine.purge_daterange(date(2024, 6, 1), date(2024, 1, 1))
+
+
+# ---------------------------------------------------------------------------
+# Engine tests — purge_vault
+# ---------------------------------------------------------------------------
+
+
+def test_vault_purge_requires_confirmation(tmp_path: Path) -> None:
+    """Missing/incorrect confirmation raises ValueError."""
+    vault = _make_vault(tmp_path)
+    engine = PurgeEngine(vault)
+
+    with pytest.raises(ValueError, match="explicit confirmation"):
+        engine.purge_vault("wrong phrase")
+
+
+def test_vault_purge_deletes_content_preserves_structure(
+    tmp_path: Path,
+) -> None:
+    """Vault contents are removed but folder structure stays intact."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    _write_thread(vault, "thread-1", "Waves")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_vault(VAULT_PURGE_CONFIRMATION)
+
+    assert result.fragments_affected >= 1
+    # Top-level content folders still exist
+    assert (vault / "01-Fragments").is_dir()
+    assert (vault / "02-Threads").is_dir()
+    assert (vault / "03-Eddies").is_dir()
+    # But are empty
+    assert list((vault / "01-Fragments").iterdir()) == []
+    assert list((vault / "02-Threads").iterdir()) == []
+
+
+def test_vault_purge_dry_run_preserves(tmp_path: Path) -> None:
+    """Dry-run vault purge removes nothing."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault, dry_run=True)
+
+    result = engine.purge_vault(VAULT_PURGE_CONFIRMATION)
+
+    assert result.dry_run is True
+    assert result.fragments_affected >= 1
+    assert frag.exists()
+
+
+# ---------------------------------------------------------------------------
+# Audit log tests
+# ---------------------------------------------------------------------------
+
+
+def test_audit_log_appends_entries(tmp_path: Path) -> None:
+    """Multiple append() calls accumulate in the log file."""
+    vault = _make_vault(tmp_path)
+    log = PurgeAuditLog(vault)
+
+    log.append(
+        PurgeAuditEntry(operation="fragment", target="frag-A", count=1),
+    )
+    log.append(
+        PurgeAuditEntry(operation="source", target="claude", count=3),
+    )
+
+    entries = log.read()
+    assert len(entries) == 2
+    assert entries[0].target == "frag-A"
+    assert entries[1].target == "claude"
+
+
+def test_audit_log_path_location(tmp_path: Path) -> None:
+    """Audit log lives at 00-Creek-Meta/Processing-Log/purge-log.json."""
+    vault = _make_vault(tmp_path)
+    log = PurgeAuditLog(vault)
+    log.append(PurgeAuditEntry(operation="vault", target="x", count=0))
+
+    expected = vault / "00-Creek-Meta" / "Processing-Log" / "purge-log.json"
+    assert expected.exists()
+    data = json.loads(expected.read_text(encoding="utf-8"))
+    assert isinstance(data, list)
+    assert data[0]["operation"] == "vault"
+
+
+def test_audit_log_recovers_from_corruption(tmp_path: Path) -> None:
+    """Malformed log is rebuilt when appending a new entry."""
+    vault = _make_vault(tmp_path)
+    log = PurgeAuditLog(vault)
+    log.log_path.parent.mkdir(parents=True, exist_ok=True)
+    log.log_path.write_text("{not valid json", encoding="utf-8")
+
+    log.append(
+        PurgeAuditEntry(operation="fragment", target="frag-A", count=1),
+    )
+
+    entries = log.read()
+    assert len(entries) == 1
+
+
+def test_audit_log_read_missing_returns_empty(tmp_path: Path) -> None:
+    """read() on a missing log returns an empty list."""
+    vault = _make_vault(tmp_path)
+    log = PurgeAuditLog(vault)
+    assert log.read() == []
+
+
+# ---------------------------------------------------------------------------
+# PurgeResult model
+# ---------------------------------------------------------------------------
+
+
+def test_purge_result_defaults() -> None:
+    """Default PurgeResult has zero counts and empty lists."""
+    result = PurgeResult(operation="fragment", target="frag-A")
+    assert result.deleted_files == []
+    assert result.fragments_affected == 0
+    assert result.wikilinks_removed == 0
+    assert result.dry_run is False
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+def test_cli_purge_help() -> None:
+    """`creek purge --help` lists the five subcommands."""
+    result = runner.invoke(app, ["purge", "--help"])
+    assert result.exit_code == 0
+    assert "fragment" in result.output
+    assert "source" in result.output
+    assert "classifications" in result.output
+    assert "daterange" in result.output
+    assert "vault" in result.output
+
+
+def test_cli_purge_fragment_dry_run(tmp_path: Path) -> None:
+    """`creek purge fragment --dry-run` previews but preserves."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+
+    result = runner.invoke(
+        app,
+        [
+            "purge",
+            "fragment",
+            "frag-A",
+            "--vault",
+            str(vault),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "DRY-RUN" in result.output
+    assert frag.exists()
+
+
+def test_cli_purge_fragment_apply(tmp_path: Path) -> None:
+    """`creek purge fragment --yes` deletes the fragment."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+
+    result = runner.invoke(
+        app,
+        ["purge", "fragment", "frag-A", "--vault", str(vault), "--yes"],
+    )
+
+    assert result.exit_code == 0
+    assert "APPLY" in result.output
+    assert not frag.exists()
+
+
+def test_cli_purge_fragment_interactive_decline(tmp_path: Path) -> None:
+    """Declining the interactive prompt aborts the purge."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+
+    result = runner.invoke(
+        app,
+        ["purge", "fragment", "frag-A", "--vault", str(vault)],
+        input="n\n",
+    )
+
+    assert result.exit_code == 0
+    assert "Aborted" in result.output
+    assert frag.exists()
+
+
+def test_cli_purge_source_shows_count(tmp_path: Path) -> None:
+    """`creek purge source` prints the count and purges on confirm."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha", platform="claude")
+    _write_fragment(vault, "frag-B", "Bravo", platform="claude")
+
+    result = runner.invoke(
+        app,
+        ["purge", "source", "claude", "--vault", str(vault), "--yes"],
+    )
+
+    assert result.exit_code == 0
+    assert "2" in result.output
+    assert not (vault / "01-Fragments/Conversations/Alpha.md").exists()
+    assert not (vault / "01-Fragments/Conversations/Bravo.md").exists()
+
+
+def test_cli_purge_classifications_runs(tmp_path: Path) -> None:
+    """`creek purge classifications --yes` resets fields."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+
+    result = runner.invoke(
+        app,
+        ["purge", "classifications", "--vault", str(vault), "--yes"],
+    )
+
+    assert result.exit_code == 0
+    post = frontmatter.load(str(frag))
+    assert post["frequency"]["primary"] == "unclassified"
+
+
+def test_cli_purge_daterange_invalid(tmp_path: Path) -> None:
+    """Invalid ISO date exits with code 2."""
+    vault = _make_vault(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "purge",
+            "daterange",
+            "not-a-date",
+            "2024-12-31",
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 2
+
+
+def test_cli_purge_daterange_applies(tmp_path: Path) -> None:
+    """`creek purge daterange` removes fragments in range."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(
+        vault,
+        "frag-old",
+        "Old",
+        created=datetime.now(tz=UTC) - timedelta(days=400),
+    )
+    keeper = _write_fragment(
+        vault,
+        "frag-new",
+        "New",
+        created=datetime.now(tz=UTC),
+    )
+    start = (datetime.now(tz=UTC) - timedelta(days=500)).date()
+    end = (datetime.now(tz=UTC) - timedelta(days=300)).date()
+
+    result = runner.invoke(
+        app,
+        [
+            "purge",
+            "daterange",
+            start.isoformat(),
+            end.isoformat(),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert not (vault / "01-Fragments/Conversations/Old.md").exists()
+    assert keeper.exists()
+
+
+def test_cli_purge_vault_rejects_bad_confirm(tmp_path: Path) -> None:
+    """Wrong confirmation text aborts with non-zero exit code."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+
+    result = runner.invoke(
+        app,
+        [
+            "purge",
+            "vault",
+            "--vault",
+            str(vault),
+            "--confirm-text",
+            "maybe",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert frag.exists()
+
+
+def test_cli_purge_vault_accepts_exact_confirm(tmp_path: Path) -> None:
+    """Correct confirmation text purges the vault."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+
+    result = runner.invoke(
+        app,
+        [
+            "purge",
+            "vault",
+            "--vault",
+            str(vault),
+            "--confirm-text",
+            VAULT_PURGE_CONFIRMATION,
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert not frag.exists()
+
+
+def test_cli_purge_vault_dry_run(tmp_path: Path) -> None:
+    """Dry-run vault purge preserves the vault contents."""
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha")
+
+    result = runner.invoke(
+        app,
+        ["purge", "vault", "--vault", str(vault), "--dry-run"],
+    )
+
+    assert result.exit_code == 0
+    assert "DRY-RUN" in result.output
+    assert frag.exists()
+
+
+# ---------------------------------------------------------------------------
+# Edge case coverage
+# ---------------------------------------------------------------------------
+
+
+def test_fragment_purge_empty_title_skips_scrub(tmp_path: Path) -> None:
+    """A fragment with an empty title skips wiki-link scrubbing."""
+    vault = _make_vault(tmp_path)
+    frag = vault / "01-Fragments" / "Conversations" / "notitle.md"
+    post = frontmatter.Post(
+        content="body",
+        id="frag-NT",
+        title="",
+        type="fragment",
+        source={"platform": "claude"},
+        threads=[],
+        eddies=[],
+    )
+    frag.write_text(frontmatter.dumps(post), encoding="utf-8")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-NT")
+
+    assert result.fragments_affected == 1
+    assert result.wikilinks_removed == 0
+
+
+def test_fragment_purge_missing_vault_dir(tmp_path: Path) -> None:
+    """Purge against a vault with no 01-Fragments directory is a no-op."""
+    vault = tmp_path / "empty"
+    vault.mkdir()
+    (vault / "00-Creek-Meta" / "Processing-Log").mkdir(parents=True)
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-X")
+
+    assert result.fragments_affected == 0
+
+
+def test_decrement_counts_skips_missing_folder(tmp_path: Path) -> None:
+    """Decrement is a no-op when the thread folder doesn't exist."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta" / "Processing-Log").mkdir(parents=True)
+    (vault / "01-Fragments").mkdir()
+    engine = PurgeEngine(vault)
+    frag = vault / "01-Fragments" / "solo.md"
+    frag.write_text(
+        frontmatter.dumps(
+            frontmatter.Post(
+                content="",
+                id="frag-S",
+                title="Solo",
+                threads=["thread-missing"],
+                eddies=[],
+                source={"platform": "claude"},
+            ),
+        ),
+        encoding="utf-8",
+    )
+
+    result = engine.purge_fragment("frag-S")
+
+    assert result.fragments_affected == 1
+    assert result.threads_updated == 0
+
+
+def test_load_frontmatter_handles_unreadable_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When frontmatter.load raises, the file is silently skipped."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault)
+
+    def _raise(_path: str) -> None:
+        raise OSError("simulated")
+
+    monkeypatch.setattr("creek.purge.engine.frontmatter.load", _raise)
+
+    result = engine.purge_classifications()
+    assert result.classifications_reset == 0
+
+
+def test_source_platform_helper_missing_source() -> None:
+    """_extract_source_platform returns None for non-dict source."""
+    from creek.purge.engine import _extract_source_platform
+
+    post = frontmatter.Post(content="", source="string-not-dict")
+    assert _extract_source_platform(post) is None
+
+
+def test_coerce_date_accepts_date_instance() -> None:
+    """Plain date values are returned as-is."""
+    from creek.purge.engine import _coerce_date
+
+    today = date(2024, 3, 14)
+    assert _coerce_date(today) == today
+
+
+def test_coerce_date_rejects_invalid_string() -> None:
+    """Unparseable strings produce None."""
+    from creek.purge.engine import _coerce_date
+
+    assert _coerce_date("never") is None
+    assert _coerce_date(42) is None
+
+
+def test_audit_log_empty_file_is_treated_as_empty(tmp_path: Path) -> None:
+    """An empty audit log file is treated as zero entries."""
+    vault = _make_vault(tmp_path)
+    log = PurgeAuditLog(vault)
+    log.log_path.parent.mkdir(parents=True, exist_ok=True)
+    log.log_path.write_text("", encoding="utf-8")
+
+    assert log.read() == []
+
+
+def test_audit_log_non_list_json_is_discarded(tmp_path: Path) -> None:
+    """A top-level non-list JSON value is discarded on read."""
+    vault = _make_vault(tmp_path)
+    log = PurgeAuditLog(vault)
+    log.log_path.parent.mkdir(parents=True, exist_ok=True)
+    log.log_path.write_text('{"not": "a list"}', encoding="utf-8")
+
+    assert log.read() == []


### PR DESCRIPTION
Closes #46.

## Summary

Implements the `creek purge` command group — the right-to-be-forgotten implementation called for by Section 13.4 of the ontology. Five new subcommands back a new `creek.purge` module with an append-only audit log.

```
creek purge fragment FRAGMENT_ID [--dry-run] [--yes]
creek purge source SOURCE_TYPE   [--dry-run] [--yes]
creek purge classifications       [--dry-run] [--yes]
creek purge daterange START END   [--dry-run] [--yes]
creek purge vault --confirm-text "I understand this is irreversible"
```

## What's in the box

- **`creek/purge/engine.py`** — `PurgeEngine` with one method per operation and a shared `PurgeResult` model capturing deleted files, affected counts, scrubbed wiki-links, and updated thread/eddy counts.
- **`creek/purge/audit.py`** — `PurgeAuditLog` writes every purge (including dry runs) to `00-Creek-Meta/Processing-Log/purge-log.json` with timestamp, operation, target, count, operator (`"human via CLI"`), and `dry_run` flag. Tolerates corrupt/empty logs by rebuilding.
- **`creek/cli.py`** — `purge_app` typer sub-app with confirmation prompts, `--dry-run`, `--yes`/`-y`, and rich table rendering of results. Vault purge demands the exact phrase *"I understand this is irreversible"*.

## Behaviour highlights

- **Fragment purge** deletes the file, scrubs `[[title]]` + `[[title|alias]]` wiki-links from every markdown file in the vault, and decrements `fragment_count` on any thread/eddy referenced in the fragment's frontmatter.
- **Source purge** previews the affected count (`"This will delete N fragments from 'claude'."`) before confirmation.
- **Classification purge** resets `frequency`, `wavelength`, and `voice` frontmatter blocks to unclassified while preserving source metadata, timestamps, threads, eddies, and body content.
- **Daterange purge** validates that `end >= start` and filters by frontmatter `created` (tolerates `datetime`, `date`, and ISO-format strings).
- **Vault purge** preserves the top-level folder structure but wipes the *contents* of `01-Fragments` through `10-Liminal`. Raises `ValueError` without the exact phrase.

## Test plan

- [x] `./scripts/test.sh --coverage` — 1850 passed, 1 pre-existing skip; overall 94.87% coverage
- [x] `./scripts/lint.sh` — clean
- [x] `./scripts/format.sh --check` — clean
- [x] `./scripts/complexity.sh` — clean (A grade across the board)
- [x] 42 new tests in `tests/test_purge.py` cover every purge type, dry-run, audit log write/read/recovery, CLI confirmation flows, edge cases (missing vault dir, empty title, corrupt frontmatter), and `--confirm-text` handling
- [x] `creek/purge/engine.py` branch coverage: 93.73%; `creek/purge/audit.py`: 96.08%

## Pre-existing issues (not introduced here)

- `./scripts/typecheck.sh` reports one pre-existing error in `creek/generate/decisions.py:163` (`frequency_context` type mismatch). Verified unchanged from `main` via `git stash`.
- `./scripts/security.sh` bandit is clean; `pip-audit` flags CVEs in environment-level packages (`cryptography`, `pip`, `pyjwt`, `setuptools`, `wheel`) unrelated to this PR.

https://claude.ai/code/session_01CpFn5oc8grgpngzR8sFhoF