### PR TITLE
feat(classify): Anthropic cloud provider for LLM classification (#25)

### DIFF
--- a/creek-tools/creek/classify/__init__.py
+++ b/creek-tools/creek/classify/__init__.py
@@ -1,17 +1,19 @@
-"""Creek classification pipeline — rules, LLM stub, and review queue.
+"""Creek classification pipeline — rules, LLM providers, and review queue.
 
 This package provides the classification subsystem for the Creek pipeline:
 
 - **RuleClassifier**: Keyword/pattern-based frequency, phase, and mode classification.
-- **LLMClassifier**: Stub for future LLM-powered classification.
+- **LLMClassifier**: LLM-powered classification via Ollama or Anthropic.
+- **AnthropicProvider**: Opt-in cloud classification provider (Anthropic API).
 - **ReviewQueueGenerator**: Generates a markdown review queue for uncertain fragments.
 """
 
-from creek.classify.llm import LLMClassifier
+from creek.classify.llm import AnthropicProvider, LLMClassifier
 from creek.classify.review import ReviewQueueGenerator
 from creek.classify.rules import RuleClassifier
 
 __all__ = [
+    "AnthropicProvider",
     "LLMClassifier",
     "ReviewQueueGenerator",
     "RuleClassifier",

--- a/creek-tools/creek/classify/llm.py
+++ b/creek-tools/creek/classify/llm.py
@@ -1,22 +1,38 @@
-"""LLM-based classification for Creek fragments via Ollama.
+"""LLM-based classification for Creek fragments via Ollama or Anthropic.
 
-Provides an LLM classifier that calls a local Ollama instance to classify
-fragments along frequency, wavelength, and voice dimensions.  Falls back
-gracefully when Ollama is unreachable, returning fragments unchanged.
+Provides an ``LLMClassifier`` that delegates fragment classification to
+either a local Ollama instance (default) or the Anthropic cloud API
+(opt-in).  Falls back gracefully when the configured provider is
+unavailable, returning fragments unchanged.
+
+The Anthropic provider requires two environment variables to be set:
+
+- ``ANTHROPIC_API_KEY``: The API key is **never** stored in the
+  configuration file, logs, or error messages.
+- ``CREEK_ANTHROPIC_CONSENT``: Must be ``"1"`` (or ``"true"`` / ``"yes"``)
+  to acknowledge that fragment content will be sent to Anthropic's
+  servers.
 """
 
+from __future__ import annotations
+
 import logging
+import os
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from enum import StrEnum
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import httpx
 import yaml
 from tqdm import tqdm
 
-from creek.config import LLMConfig
+if TYPE_CHECKING:
+    import anthropic
+
+    from creek.config import LLMConfig
+
 from creek.models import (
     Confidence,
     Dosage,
@@ -190,12 +206,154 @@ def _strip_code_fences(text: str) -> str:
     return "\n".join(filtered)
 
 
-class LLMClassifier:
-    """LLM classifier for Creek fragments using a local Ollama instance.
+ANTHROPIC_CLOUD_WARNING: str = (
+    "WARNING: Cloud classification enabled. "
+    "Fragment content will be sent to Anthropic's servers."
+)
+"""Warning displayed when the Anthropic cloud provider is selected."""
 
-    Sends fragments to Ollama for classification along frequency,
-    wavelength, and voice dimensions.  Falls back gracefully when
-    Ollama is unreachable, returning fragments unchanged with a warning.
+
+class AnthropicProvider:
+    """Anthropic API provider for cloud-based fragment classification.
+
+    Sends classification prompts to the Anthropic ``messages`` API using
+    the official Python SDK.  The API key is read exclusively from the
+    ``ANTHROPIC_API_KEY`` environment variable and is never stored in
+    the configuration file, logs, or error messages.
+
+    Attributes:
+        config: The LLM configuration specifying model, batch size, etc.
+    """
+
+    DEFAULT_MODEL: str = "claude-sonnet-4-5-20250929"
+    """Default Anthropic model when the config does not override it."""
+
+    API_KEY_ENV: str = "ANTHROPIC_API_KEY"
+    """Environment variable name for the Anthropic API key."""
+
+    CONSENT_ENV: str = "CREEK_ANTHROPIC_CONSENT"
+    """Environment variable name for cloud-classification consent."""
+
+    CONSENT_TRUTHY: frozenset[str] = frozenset({"1", "true", "yes"})
+    """String values accepted as affirmative consent."""
+
+    MAX_TOKENS: int = 1024
+    """Maximum tokens requested from the Anthropic API per call."""
+
+    _OLLAMA_DEFAULT_MODEL: str = "mistral"
+    """The ``LLMConfig`` default model name (indicates no Anthropic override)."""
+
+    def __init__(self, config: LLMConfig) -> None:
+        """Validate environment prerequisites and prepare the client.
+
+        The SDK client itself is instantiated lazily on first use to
+        avoid unnecessary network/imports during construction.
+
+        Args:
+            config: LLM provider configuration.
+
+        Raises:
+            RuntimeError: If the API key or consent environment
+                variables are not set.
+        """
+        self.config = config
+        if not os.environ.get(self.API_KEY_ENV, "").strip():
+            msg = (
+                f"{self.API_KEY_ENV} environment variable is not set; "
+                "required for the Anthropic provider."
+            )
+            raise RuntimeError(msg)
+        consent = os.environ.get(self.CONSENT_ENV, "").strip().lower()
+        if consent not in self.CONSENT_TRUTHY:
+            msg = (
+                "Anthropic cloud classification requires explicit consent. "
+                f"Set {self.CONSENT_ENV}=1 to confirm that fragment content "
+                "may be sent to Anthropic's servers."
+            )
+            raise RuntimeError(msg)
+        self._client: anthropic.Anthropic | None = None
+
+    @property
+    def model(self) -> str:
+        """The Anthropic model identifier to use for API calls.
+
+        Falls back to :attr:`DEFAULT_MODEL` when ``config.model`` still
+        holds the Ollama default (``"mistral"``) or is empty.
+
+        Returns:
+            The resolved model identifier.
+        """
+        model = (self.config.model or "").strip()
+        if not model or model == self._OLLAMA_DEFAULT_MODEL:
+            return self.DEFAULT_MODEL
+        return model
+
+    @property
+    def client(self) -> anthropic.Anthropic:
+        """The lazily-initialised Anthropic SDK client.
+
+        Returns:
+            An ``anthropic.Anthropic`` client instance.
+        """
+        if self._client is None:
+            import anthropic
+
+            self._client = anthropic.Anthropic()
+        return self._client
+
+    def call(self, prompt: str) -> str:
+        """Send a classification prompt to the Anthropic API.
+
+        Args:
+            prompt: The fully-formatted classification prompt.
+
+        Returns:
+            The concatenated text content of the API response.
+
+        Raises:
+            RuntimeError: If the SDK raises any ``AnthropicError``; the
+                original exception is re-raised as ``RuntimeError`` with
+                its type name to avoid leaking sensitive request state.
+        """
+        import anthropic
+
+        try:
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=self.MAX_TOKENS,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except anthropic.AnthropicError as exc:
+            msg = f"Anthropic API call failed: {type(exc).__name__}"
+            raise RuntimeError(msg) from None
+        return _extract_anthropic_text(response)
+
+
+def _extract_anthropic_text(response: object) -> str:
+    """Concatenate the textual blocks from an Anthropic API response.
+
+    Args:
+        response: A ``messages.create`` response object.
+
+    Returns:
+        The joined ``text`` attributes of each content block.
+    """
+    content = getattr(response, "content", None) or []
+    parts: list[str] = []
+    for block in content:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            parts.append(text)
+    return "".join(parts)
+
+
+class LLMClassifier:
+    """LLM classifier for Creek fragments.
+
+    Dispatches classification requests to either a local Ollama instance
+    (default) or the Anthropic cloud API (``config.provider ==
+    "anthropic"``).  Falls back gracefully when the configured provider
+    is unreachable, returning fragments unchanged with a warning.
 
     Attributes:
         config: The LLM configuration specifying provider, model, etc.
@@ -216,34 +374,51 @@ class LLMClassifier:
     AVAILABILITY_TIMEOUT: float = 5.0
     """Timeout for the Ollama health check."""
 
+    ANTHROPIC_PROVIDER: str = "anthropic"
+    """Provider identifier for the Anthropic cloud API."""
+
     def __init__(self, config: LLMConfig) -> None:
         """Initialize the LLM classifier.
 
-        Ollama availability is checked lazily on first use.
+        Provider availability is checked lazily on first use.  When the
+        Anthropic provider is selected, a warning is logged immediately
+        so operators see it even before the first classification call.
 
         Args:
             config: LLM provider configuration (provider, model, URL, etc.).
         """
         self.config = config
         self._available: bool | None = None
+        self._anthropic: AnthropicProvider | None = None
+        if config.provider == self.ANTHROPIC_PROVIDER:
+            logger.warning(ANTHROPIC_CLOUD_WARNING)
 
     @property
     def available(self) -> bool:
-        """Whether Ollama is reachable at the configured URL.
+        """Whether the configured LLM provider is reachable.
+
+        For Ollama, checks the HTTP health endpoint; for Anthropic,
+        validates that the required environment variables are present.
 
         Returns:
-            ``True`` if Ollama responded successfully.
+            ``True`` if the provider responded successfully.
         """
         if self._available is None:
             self._available = self._check_availability()
         return self._available
 
     def _check_availability(self) -> bool:
-        """Check if Ollama is reachable at the configured URL.
+        """Check if the configured LLM provider is reachable.
+
+        For the Anthropic provider this validates that the required
+        environment variables are present.  For Ollama it issues a
+        health-check HTTP request against ``/api/tags``.
 
         Returns:
-            ``True`` if Ollama responded with HTTP 200.
+            ``True`` if the provider is ready to service requests.
         """
+        if self.config.provider == self.ANTHROPIC_PROVIDER:
+            return self._check_anthropic_availability()
         try:
             with httpx.Client(
                 timeout=self.AVAILABILITY_TIMEOUT,
@@ -260,6 +435,42 @@ class LLMClassifier:
             self.config.ollama_url,
         )
         return False
+
+    def _check_anthropic_availability(self) -> bool:
+        """Validate that the Anthropic provider can be constructed.
+
+        Returns:
+            ``True`` when the provider initialises successfully.
+        """
+        try:
+            self._get_anthropic_provider()
+        except RuntimeError as exc:
+            logger.warning("Anthropic provider not available: %s", exc)
+            return False
+        return True
+
+    def _get_anthropic_provider(self) -> AnthropicProvider:
+        """Lazily instantiate the :class:`AnthropicProvider`.
+
+        Returns:
+            The cached ``AnthropicProvider`` instance.
+        """
+        if self._anthropic is None:
+            self._anthropic = AnthropicProvider(self.config)
+        return self._anthropic
+
+    def _invoke_llm(self, prompt: str) -> str:
+        """Dispatch a prompt to the configured provider.
+
+        Args:
+            prompt: The fully-formatted classification prompt.
+
+        Returns:
+            Raw response text from the provider.
+        """
+        if self.config.provider == self.ANTHROPIC_PROVIDER:
+            return self._get_anthropic_provider().call(prompt)
+        return self._call_ollama(prompt)
 
     def _build_prompt(
         self,
@@ -354,11 +565,12 @@ class LLMClassifier:
         fragment: Fragment,
         content: str = "",
     ) -> Fragment:
-        """Classify a fragment using the Ollama LLM.
+        """Classify a fragment using the configured LLM provider.
 
-        Builds a prompt, calls Ollama, parses the YAML response, and
-        updates the fragment.  Retries on failure up to ``MAX_RETRIES``
-        times.  Returns the fragment unchanged if Ollama is unavailable
+        Builds a prompt, dispatches it to the configured provider (Ollama
+        or Anthropic), parses the YAML response, and updates the
+        fragment.  Retries on failure up to ``MAX_RETRIES`` times.
+        Returns the fragment unchanged if the provider is unavailable
         or all retries are exhausted.
 
         Args:
@@ -370,7 +582,7 @@ class LLMClassifier:
         """
         if not self.available:
             logger.warning(
-                "Ollama unavailable — returning fragment '%s' unchanged",
+                "LLM provider unavailable — returning fragment '%s' unchanged",
                 fragment.title,
             )
             return fragment
@@ -379,11 +591,12 @@ class LLMClassifier:
 
         for attempt in range(self.MAX_RETRIES):
             try:
-                raw = self._call_ollama(prompt)
+                raw = self._invoke_llm(prompt)
                 data = self.validate_response(raw)
                 return self._apply_classification(fragment, data)
             except (
                 httpx.HTTPError,
+                RuntimeError,
                 ValueError,
                 yaml.YAMLError,
             ) as exc:
@@ -412,7 +625,7 @@ class LLMClassifier:
     ) -> list[Fragment]:
         """Classify a batch of fragments with concurrency and progress.
 
-        Uses a thread pool for concurrent Ollama requests, a tqdm bar
+        Uses a thread pool for concurrent provider requests, a tqdm bar
         for visual feedback, and rate limiting between submissions.
         Logs aggregated statistics on completion.
 
@@ -428,7 +641,7 @@ class LLMClassifier:
 
         if not self.available:
             logger.warning(
-                "Ollama unavailable — returning %d fragments unchanged",
+                "LLM provider unavailable — returning %d fragments unchanged",
                 len(fragments),
             )
             return list(fragments)

--- a/creek-tools/requirements.txt
+++ b/creek-tools/requirements.txt
@@ -13,3 +13,4 @@ httpx>=0.27.0
 tqdm>=4.66.0
 sentence-transformers>=2.2.0
 numpy>=1.24.0
+anthropic>=0.40.0

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -14,7 +14,9 @@ from creek.classify import (
     RuleClassifier,
 )
 from creek.classify.llm import (
+    ANTHROPIC_CLOUD_WARNING,
     CLASSIFICATION_PROMPT,
+    AnthropicProvider,
     BatchStats,
     _parse_dosage,
     _parse_enum,
@@ -898,6 +900,423 @@ class TestBatchStats:
         assert stats.total == 10
         assert stats.classified == 8
         assert stats.failed == 2
+
+
+# ---- AnthropicProvider ----
+
+
+def _set_anthropic_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set the ANTHROPIC_API_KEY and CREEK_ANTHROPIC_CONSENT env vars.
+
+    Args:
+        monkeypatch: Pytest monkeypatch fixture.
+    """
+    monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+    monkeypatch.setenv(AnthropicProvider.CONSENT_ENV, "1")
+
+
+def _make_mock_anthropic_client(response_text: str) -> MagicMock:
+    """Build a mock anthropic.Anthropic client returning *response_text*.
+
+    Args:
+        response_text: The text to embed in a single content block.
+
+    Returns:
+        A ``MagicMock`` whose ``messages.create`` returns a response.
+    """
+    mock_block = MagicMock()
+    mock_block.text = response_text
+    mock_response = MagicMock()
+    mock_response.content = [mock_block]
+    mock_client = MagicMock()
+    mock_client.messages.create.return_value = mock_response
+    return mock_client
+
+
+class TestAnthropicProviderInit:
+    """Tests for AnthropicProvider initialization."""
+
+    def test_raises_when_api_key_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """__init__ raises when ANTHROPIC_API_KEY is not set."""
+        monkeypatch.delenv(AnthropicProvider.API_KEY_ENV, raising=False)
+        monkeypatch.setenv(AnthropicProvider.CONSENT_ENV, "1")
+        config = LLMConfig(provider="anthropic")
+        with pytest.raises(RuntimeError, match=AnthropicProvider.API_KEY_ENV):
+            AnthropicProvider(config)
+
+    def test_raises_when_api_key_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """__init__ raises when ANTHROPIC_API_KEY is whitespace only."""
+        monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "   ")
+        monkeypatch.setenv(AnthropicProvider.CONSENT_ENV, "1")
+        config = LLMConfig(provider="anthropic")
+        with pytest.raises(RuntimeError, match=AnthropicProvider.API_KEY_ENV):
+            AnthropicProvider(config)
+
+    def test_raises_when_consent_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """__init__ raises when CREEK_ANTHROPIC_CONSENT is not set."""
+        monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+        monkeypatch.delenv(AnthropicProvider.CONSENT_ENV, raising=False)
+        config = LLMConfig(provider="anthropic")
+        with pytest.raises(RuntimeError, match="consent"):
+            AnthropicProvider(config)
+
+    def test_raises_when_consent_not_truthy(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """__init__ raises when consent is set to a falsy value."""
+        monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+        monkeypatch.setenv(AnthropicProvider.CONSENT_ENV, "no")
+        config = LLMConfig(provider="anthropic")
+        with pytest.raises(RuntimeError, match="consent"):
+            AnthropicProvider(config)
+
+    def test_succeeds_with_valid_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """__init__ stores the config when env vars are set."""
+        _set_anthropic_env(monkeypatch)
+        config = LLMConfig(provider="anthropic")
+        provider = AnthropicProvider(config)
+        assert provider.config is config
+
+    def test_accepts_true_as_consent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Consent value ``true`` should be accepted."""
+        monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+        monkeypatch.setenv(AnthropicProvider.CONSENT_ENV, "TRUE")
+        AnthropicProvider(LLMConfig(provider="anthropic"))
+
+    def test_accepts_yes_as_consent(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Consent value ``yes`` should be accepted."""
+        monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+        monkeypatch.setenv(AnthropicProvider.CONSENT_ENV, "yes")
+        AnthropicProvider(LLMConfig(provider="anthropic"))
+
+    def test_sdk_client_not_built_on_init(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The SDK client should be created lazily on first use."""
+        _set_anthropic_env(monkeypatch)
+        provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+        assert provider._client is None
+
+
+class TestAnthropicProviderModel:
+    """Tests for AnthropicProvider.model resolution."""
+
+    def test_defaults_when_config_uses_ollama_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The Ollama default ``mistral`` should fall back to Anthropic default."""
+        _set_anthropic_env(monkeypatch)
+        provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+        assert provider.model == AnthropicProvider.DEFAULT_MODEL
+
+    def test_uses_config_model_when_set(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An explicit config model value should be honoured."""
+        _set_anthropic_env(monkeypatch)
+        config = LLMConfig(provider="anthropic", model="claude-custom-model")
+        provider = AnthropicProvider(config)
+        assert provider.model == "claude-custom-model"
+
+    def test_default_model_is_claude_sonnet_4_5(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The default model should be the documented Claude Sonnet 4.5."""
+        _set_anthropic_env(monkeypatch)
+        assert AnthropicProvider.DEFAULT_MODEL == "claude-sonnet-4-5-20250929"
+
+
+class TestAnthropicProviderCall:
+    """Tests for AnthropicProvider.call with a mocked SDK."""
+
+    def test_call_uses_sdk_messages_create(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """call should invoke ``client.messages.create`` with the prompt."""
+        _set_anthropic_env(monkeypatch)
+        mock_client = _make_mock_anthropic_client(_VALID_YAML_RESPONSE)
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+            result = provider.call("hello prompt")
+        assert result == _VALID_YAML_RESPONSE
+        mock_client.messages.create.assert_called_once()
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs["model"] == AnthropicProvider.DEFAULT_MODEL
+        assert kwargs["max_tokens"] == AnthropicProvider.MAX_TOKENS
+        assert kwargs["messages"] == [
+            {"role": "user", "content": "hello prompt"},
+        ]
+
+    def test_call_concatenates_multiple_text_blocks(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Multiple content blocks should be concatenated in order."""
+        _set_anthropic_env(monkeypatch)
+        block_a = MagicMock()
+        block_a.text = "part-a"
+        block_b = MagicMock()
+        block_b.text = "part-b"
+        response = MagicMock()
+        response.content = [block_a, block_b]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = response
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+            result = provider.call("prompt")
+        assert result == "part-apart-b"
+
+    def test_call_ignores_non_text_blocks(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Blocks without a string ``text`` attribute should be skipped."""
+        _set_anthropic_env(monkeypatch)
+        text_block = MagicMock()
+        text_block.text = "keep"
+        tool_block = MagicMock(spec=[])  # no text attribute
+        response = MagicMock()
+        response.content = [tool_block, text_block]
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = response
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+            result = provider.call("prompt")
+        assert result == "keep"
+
+    def test_call_honours_custom_model(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An explicit config.model value should reach the SDK."""
+        _set_anthropic_env(monkeypatch)
+        mock_client = _make_mock_anthropic_client(_VALID_YAML_RESPONSE)
+        config = LLMConfig(provider="anthropic", model="my-claude-variant")
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            AnthropicProvider(config).call("prompt")
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs["model"] == "my-claude-variant"
+
+    def test_call_wraps_sdk_errors_without_leaking_key(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """SDK errors should raise RuntimeError with no API key exposure."""
+        import anthropic
+
+        _set_anthropic_env(monkeypatch)
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = anthropic.APIError(
+            message="boom",
+            request=MagicMock(),
+            body=None,
+        )
+        with (
+            patch("anthropic.Anthropic", return_value=mock_client),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+            provider.call("prompt")
+        assert "sk-test-not-real" not in str(exc_info.value)
+
+    def test_client_cached_across_calls(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The SDK client should only be instantiated once."""
+        _set_anthropic_env(monkeypatch)
+        mock_client = _make_mock_anthropic_client(_VALID_YAML_RESPONSE)
+        with patch("anthropic.Anthropic", return_value=mock_client) as mock_ctor:
+            provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+            provider.call("p1")
+            provider.call("p2")
+        assert mock_ctor.call_count == 1
+
+
+# ---- LLMClassifier with Anthropic provider ----
+
+
+class TestLLMClassifierAnthropicDispatch:
+    """Tests for provider dispatching in LLMClassifier."""
+
+    def test_init_logs_warning_when_provider_is_anthropic(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Selecting the anthropic provider should log the cloud warning."""
+        _set_anthropic_env(monkeypatch)
+        with caplog.at_level(logging.WARNING):
+            LLMClassifier(config=LLMConfig(provider="anthropic"))
+        assert any(
+            "anthropic" in r.message.lower() and "cloud" in r.message.lower()
+            for r in caplog.records
+        )
+
+    def test_init_does_not_warn_for_ollama(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Default ollama provider should not emit the cloud warning."""
+        with caplog.at_level(logging.WARNING):
+            LLMClassifier(config=LLMConfig())
+        assert all(ANTHROPIC_CLOUD_WARNING not in r.message for r in caplog.records)
+
+    def test_available_true_when_anthropic_env_ready(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """available should be True when both env vars are present."""
+        _set_anthropic_env(monkeypatch)
+        classifier = LLMClassifier(config=LLMConfig(provider="anthropic"))
+        assert classifier.available is True
+
+    def test_available_false_when_api_key_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """available should be False when the API key is absent."""
+        monkeypatch.delenv(AnthropicProvider.API_KEY_ENV, raising=False)
+        monkeypatch.setenv(AnthropicProvider.CONSENT_ENV, "1")
+        classifier = LLMClassifier(config=LLMConfig(provider="anthropic"))
+        assert classifier.available is False
+
+    def test_available_false_when_consent_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """available should be False when consent is not granted."""
+        monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+        monkeypatch.delenv(AnthropicProvider.CONSENT_ENV, raising=False)
+        classifier = LLMClassifier(config=LLMConfig(provider="anthropic"))
+        assert classifier.available is False
+
+    def test_classify_dispatches_to_anthropic(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """classify should route to the anthropic provider when selected."""
+        _set_anthropic_env(monkeypatch)
+        mock_client = _make_mock_anthropic_client(_VALID_YAML_RESPONSE)
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            classifier = LLMClassifier(
+                config=LLMConfig(provider="anthropic"),
+            )
+            result = classifier.classify(_make_fragment(title="Test"))
+        assert result.frequency.primary == Frequency.F3
+        mock_client.messages.create.assert_called_once()
+
+    def test_classify_uses_same_prompt_for_both_providers(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Anthropic path should send CLASSIFICATION_PROMPT-formatted text."""
+        _set_anthropic_env(monkeypatch)
+        mock_client = _make_mock_anthropic_client(_VALID_YAML_RESPONSE)
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            classifier = LLMClassifier(
+                config=LLMConfig(provider="anthropic"),
+            )
+            classifier.classify(
+                _make_fragment(title="My Title"),
+                content="Body text",
+            )
+        kwargs = mock_client.messages.create.call_args.kwargs
+        prompt = kwargs["messages"][0]["content"]
+        assert "My Title" in prompt
+        assert "Body text" in prompt
+        assert "Frequency" in prompt
+
+    def test_classify_batch_dispatches_to_anthropic(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """classify_batch should call the anthropic SDK for each fragment."""
+        _set_anthropic_env(monkeypatch)
+        mock_client = _make_mock_anthropic_client(_VALID_YAML_RESPONSE)
+        with (
+            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("creek.classify.llm.time.sleep"),
+        ):
+            classifier = LLMClassifier(
+                config=LLMConfig(provider="anthropic"),
+            )
+            frags = [_make_fragment(title=f"F{i}") for i in range(3)]
+            results = classifier.classify_batch(frags, progress=False)
+        assert len(results) == 3
+        assert mock_client.messages.create.call_count == 3
+        for res in results:
+            assert res.frequency.primary == Frequency.F3
+
+    def test_classify_retries_on_runtime_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """classify should retry when the provider raises RuntimeError."""
+        _set_anthropic_env(monkeypatch)
+        mock_client = MagicMock()
+        good_block = MagicMock()
+        good_block.text = _VALID_YAML_RESPONSE
+        good_response = MagicMock()
+        good_response.content = [good_block]
+        import anthropic
+
+        mock_client.messages.create.side_effect = [
+            anthropic.APIError(
+                message="rate limited",
+                request=MagicMock(),
+                body=None,
+            ),
+            good_response,
+        ]
+        with (
+            patch("anthropic.Anthropic", return_value=mock_client),
+            patch("creek.classify.llm.time.sleep"),
+        ):
+            classifier = LLMClassifier(
+                config=LLMConfig(provider="anthropic"),
+            )
+            result = classifier.classify(_make_fragment())
+        assert result.frequency.primary == Frequency.F3
+        assert mock_client.messages.create.call_count == 2
+
+    def test_ollama_path_unchanged_by_anthropic_changes(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Default ollama provider continues to use _call_ollama."""
+        with patch.object(
+            LLMClassifier, "_call_ollama", return_value=_VALID_YAML_RESPONSE
+        ) as mock_call:
+            classifier = _make_classifier_available(
+                LLMClassifier(config=LLMConfig()),
+            )
+            classifier.classify(_make_fragment())
+        mock_call.assert_called_once()
 
 
 # ---- Integration test (requires running Ollama) ----


### PR DESCRIPTION
## Summary

Implements Issue #25: LLM-assisted classification via the Anthropic API as an opt-in cloud alternative to the local Ollama provider.

- New `AnthropicProvider` class in `creek/classify/llm.py` wrapping `anthropic.Anthropic().messages.create(...)` with the shared `CLASSIFICATION_PROMPT` and YAML response parsing.
- Provider selection in `LLMClassifier` via `config.llm.provider`:
  - `"ollama"` (default) — unchanged local path
  - `"anthropic"` — routes prompts to the Anthropic API
- Default model `claude-sonnet-4-5-20250929`, overridable via `config.llm.model`.
- **Security controls**:
  - API key read only from `ANTHROPIC_API_KEY` env var; never written to config, logs, or error messages.
  - SDK exceptions are wrapped in `RuntimeError` with only the exception class name to prevent accidental leakage.
  - Explicit consent required: `CREEK_ANTHROPIC_CONSENT=1` must be set before classify will run against Anthropic — otherwise availability returns `False` with a warning.
  - A prominent `WARNING: Cloud classification enabled...` log is emitted on construction whenever the anthropic provider is selected.
- Shares batching, retry, and error-handling behavior with the existing Ollama path.
- `anthropic>=0.40.0` added to `requirements.txt`.

## Test plan

- [x] Unit suite green locally (`1836 passed, 1 skipped`) with 95.08% coverage
- [x] `scripts/lint.sh`, `scripts/format.sh --check`, complexity checks all green
- [x] New `TestAnthropicProviderInit`, `TestAnthropicProviderModel`, `TestAnthropicProviderCall`, `TestLLMClassifierAnthropicDispatch` classes cover:
  - API key / consent validation (missing, empty, falsy values)
  - Default vs. configured model resolution
  - `client.messages.create` invocation with correct model/max_tokens/messages
  - Multi-block text extraction, tool-block skipping
  - SDK errors re-raised as `RuntimeError` without exposing the fake API key
  - `LLMClassifier` warning log, availability routing, single/batch dispatch
  - Retry-on-`RuntimeError` behavior
  - Ollama path continues to use `_call_ollama` unchanged
- [ ] CI green on all jobs

### Notes on pre-existing CI items

`./scripts/check-all.sh` reports two pre-existing failures that are present on `main` and untouched by this PR:
- Type checker: 3 errors in `creek/generate/decisions.py` and `creek/link/embeddings.py`.
- `pip-audit`: CVEs in system packages (`cryptography`, `pip`, `setuptools`, `wheel`, `pyjwt`).

Closes #25.

https://claude.ai/code/session_01UY7m28efmyDVumw8g8zxEh