### PR TITLE
feat(generate): add decision context gathering with guardrails (#45)

### DIFF
--- a/creek-tools/creek/generate/__init__.py
+++ b/creek-tools/creek/generate/__init__.py
@@ -1,6 +1,13 @@
 """Creek generate package — index and note generation for the Creek vault."""
 
-from creek.generate.decisions import DECISION_KEYWORDS, DecisionDetector
+from creek.generate.decisions import (
+    DECISION_KEYWORDS,
+    PRACTICE_MAP,
+    DecisionContext,
+    DecisionContextGatherer,
+    DecisionDetector,
+    decision_from_note,
+)
 from creek.generate.indexes import FREQUENCY_COLORS, FREQUENCY_NAMES, IndexGenerator
 from creek.generate.tags import TagGardenGenerator, TagScanResult
 
@@ -8,8 +15,12 @@ __all__ = [
     "DECISION_KEYWORDS",
     "FREQUENCY_COLORS",
     "FREQUENCY_NAMES",
+    "PRACTICE_MAP",
+    "DecisionContext",
+    "DecisionContextGatherer",
     "DecisionDetector",
     "IndexGenerator",
     "TagGardenGenerator",
     "TagScanResult",
+    "decision_from_note",
 ]

--- a/creek-tools/creek/generate/decisions.py
+++ b/creek-tools/creek/generate/decisions.py
@@ -1,23 +1,29 @@
-"""Decision detection — flag decision-relevant fragments.
+"""Decision detection and context gathering for Creek decisions.
 
 Detects decision-relevant content in Creek fragments using keyword matching
 and frequency/confidence pattern analysis, generates draft Decision notes
-in the vault, and manages decision phase transitions between Active and
-Archive folders.
+in the vault, manages decision phase transitions between Active and
+Archive folders, and gathers cross-vault context (related threads, past
+decisions, current wavelength, praxis, interventions) for active Decision
+notes while enforcing the anti-manipulation guardrails from Section 12.4
+of the Creek Ontology.
 """
 
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass, field
 from datetime import date
 from typing import TYPE_CHECKING
 
 import frontmatter
 
 from creek.models import (
+    Decision,
     DecisionCandidate,
     DecisionStatus,
     Frequency,
+    Phase,
     PraxisPotential,
     _generate_decision_id,
 )
@@ -335,3 +341,654 @@ class DecisionDetector:
                 if post.get("id") == decision_id:
                     return md_file
         return None
+
+
+# ---- Decision Context Gathering (Section 12.3 - 12.5) ----
+
+
+_FREQUENCY_COLOR: dict[str, str] = {
+    Frequency.F1: "beige",
+    Frequency.F2: "purple",
+    Frequency.F3: "red",
+    Frequency.F4: "blue",
+    Frequency.F5: "orange",
+    Frequency.F6: "green",
+    Frequency.F7: "yellow",
+    Frequency.F8: "teal",
+    Frequency.F9: "ultraviolet",
+    Frequency.F10: "clear_light",
+}
+"""Canonical mapping from APTITUDE frequency codes to ontology color names."""
+
+
+PRACTICE_MAP: dict[tuple[str, str], tuple[str, ...]] = {
+    ("beige", "rising"): ("Cold Shower",),
+    ("purple", "bottoming_out"): ("Listening to Music",),
+    ("red", "bottoming_out"): ("Pranayama (Lion's Breath)",),
+    ("blue", "rising"): ("Metta Meditation",),
+    ("orange", "rising"): ("Pranayama (Wim Hof)",),
+    ("green", "rising"): ("Yoga", "Creative Writing"),
+    ("yellow", "peaking"): ("Samatha Vipassana",),
+    ("teal", "peaking"): ("Magick",),
+    ("ultraviolet", "peaking"): ("Meditation Retreats",),
+    ("green", "diminishing"): ("Journaling",),
+    ("teal", "bottoming_out"): ("Baby Waterfall Conventions",),
+}
+"""Phase x Frequency intervention map (Ontology Section 12.5).
+
+Keys are ``(frequency_color, phase_value)`` pairs; values are tuples of
+practice names mapped by the Archetypal Wavelength framework as useful in
+that territory. Loaded at module import time; see
+:func:`DecisionContextGatherer.interventions_lookup`.
+"""
+
+
+_DIRECTIVE_REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"\byou should\b", re.IGNORECASE), "one option is to"),
+    (re.compile(r"\byou need to\b", re.IGNORECASE), "one possibility is to"),
+    (re.compile(r"\byou must\b", re.IGNORECASE), "one possibility is to"),
+    (re.compile(r"\bthe best option\b", re.IGNORECASE), "one option"),
+    (re.compile(r"\bthe right choice\b", re.IGNORECASE), "one possibility"),
+    (re.compile(r"\bit'?s clear that\b", re.IGNORECASE), "one reading is that"),
+    (re.compile(r"\bobviously\b", re.IGNORECASE), "from one perspective"),
+    (re.compile(r"\bact now\b", re.IGNORECASE), "act when it feels right"),
+    (
+        re.compile(r"\bbefore it'?s too late\b", re.IGNORECASE),
+        "when the moment feels right",
+    ),
+    (re.compile(r"\blast chance\b", re.IGNORECASE), "a moment that is present"),
+    (
+        re.compile(r"\bthis is permanent\b", re.IGNORECASE),
+        "some considerations include",
+    ),
+    (
+        re.compile(r"\bthis is irreversible\b", re.IGNORECASE),
+        "some considerations include",
+    ),
+)
+"""Directive/urgency/scarcity patterns replaced by descriptive language.
+
+Section 12.4 of the Ontology prohibits the decision layer from recommending
+options, weighting rationality over felt sense, or using urgency/scarcity
+framing. The patterns above are scrubbed by
+:meth:`DecisionContextGatherer.apply_guardrails`.
+"""
+
+
+_MIN_HISTORY_FOR_ADVISORY = 2
+"""Minimum past-decision count required to surface a wavelength advisory."""
+
+
+@dataclass
+class DecisionContext:
+    """Aggregated cross-vault context for a single Decision note.
+
+    Attributes:
+        decision_id: The ID of the decision this context is for.
+        decision_title: The title of the decision this context is for.
+        related_threads: IDs of threads semantically related to the decision.
+        related_decisions: IDs of past decisions with similar themes.
+        current_wavelength: Current wavelength phase of the human.
+        relevant_praxis: IDs of praxis notes applicable to this decision.
+        frequency_affinity: Frequency codes most active in this decision.
+        interventions: Suggested practices from the Phase x Frequency map.
+    """
+
+    decision_id: str
+    decision_title: str
+    related_threads: list[str] = field(default_factory=list)
+    related_decisions: list[str] = field(default_factory=list)
+    current_wavelength: str = ""
+    relevant_praxis: list[str] = field(default_factory=list)
+    frequency_affinity: list[str] = field(default_factory=list)
+    interventions: list[str] = field(default_factory=list)
+
+
+def _tokenize(text: str) -> set[str]:
+    """Tokenise text into a lowercase word set, dropping short stopwords.
+
+    Args:
+        text: Raw text to tokenise.
+
+    Returns:
+        Set of tokens with length >= 3, lowercased.
+    """
+    return {tok for tok in re.findall(r"[a-zA-Z]+", text.lower()) if len(tok) >= 3}
+
+
+def _jaccard(a: set[str], b: set[str]) -> float:
+    """Compute Jaccard similarity between two sets.
+
+    Args:
+        a: First set.
+        b: Second set.
+
+    Returns:
+        Ratio of intersection size to union size, or ``0.0`` if both
+        sets are empty.
+    """
+    if not a and not b:
+        return 0.0
+    union = a | b
+    if not union:
+        return 0.0
+    return len(a & b) / len(union)
+
+
+def _load_post(path: Path) -> frontmatter.Post | None:
+    """Safely load a frontmatter post from disk.
+
+    Args:
+        path: The markdown file path.
+
+    Returns:
+        Loaded post, or ``None`` if the file cannot be parsed.
+    """
+    try:
+        return frontmatter.load(str(path))
+    except (OSError, ValueError):
+        return None
+
+
+def _listify(value: object) -> list[str]:
+    """Coerce a frontmatter value into a list of strings.
+
+    Args:
+        value: Raw value from a frontmatter field.
+
+    Returns:
+        A list of strings, empty if the input is falsy or unsupported.
+    """
+    if not value:
+        return []
+    if isinstance(value, list):
+        return [str(v) for v in value]
+    if isinstance(value, str):
+        return [value]
+    return []
+
+
+class DecisionContextGatherer:
+    """Gather cross-vault context for Decision notes.
+
+    Walks the vault to find related threads, past decisions, relevant
+    praxis, and the current wavelength phase, then renders a Markdown
+    ``## Context`` section. All generated text is passed through
+    :meth:`apply_guardrails` to enforce the Section 12.4 anti-manipulation
+    rules (no recommendations, no urgency/scarcity framing, no prescriptive
+    language).
+
+    Attributes:
+        similarity_threshold: Minimum Jaccard similarity (0-1) for a
+            thread or decision to count as related.
+    """
+
+    def __init__(self, similarity_threshold: float = 0.1) -> None:
+        """Initialise the gatherer.
+
+        Args:
+            similarity_threshold: Minimum Jaccard similarity for
+                related-thread and related-decision matching.
+        """
+        self.similarity_threshold = similarity_threshold
+
+    # ---- Public API ----
+
+    def gather_context(
+        self,
+        decision: Decision,
+        vault_path: Path,
+    ) -> DecisionContext:
+        """Gather cross-vault context for a Decision.
+
+        Args:
+            decision: The Decision to gather context for.
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            A DecisionContext with related threads, decisions, praxis,
+            current wavelength, frequency affinity, and interventions.
+        """
+        tokens = _tokenize(decision.title)
+        freqs = [str(f) for f in decision.frequency_context]
+
+        related_threads = self._find_related_threads(vault_path, tokens, freqs)
+        related_decisions = self._find_related_decisions(
+            vault_path,
+            decision.id,
+            tokens,
+            freqs,
+        )
+        relevant_praxis = self._find_relevant_praxis(vault_path, freqs)
+        current_wavelength = self._current_wavelength(
+            vault_path,
+            fallback=decision.wavelength_phase_at_opening,
+        )
+        affinity = self._frequency_affinity(decision, relevant_praxis, vault_path)
+        interventions = self._gather_interventions(affinity, current_wavelength)
+
+        return DecisionContext(
+            decision_id=decision.id,
+            decision_title=decision.title,
+            related_threads=related_threads,
+            related_decisions=related_decisions,
+            current_wavelength=current_wavelength,
+            relevant_praxis=relevant_praxis,
+            frequency_affinity=affinity,
+            interventions=interventions,
+        )
+
+    def generate_context_section(self, context: DecisionContext) -> str:
+        """Render a Markdown ``## Context`` section for the decision.
+
+        The generated text is passed through :meth:`apply_guardrails`
+        before return to enforce the Section 12.4 anti-manipulation rules.
+
+        Args:
+            context: Context to render.
+
+        Returns:
+            A Markdown section body (no trailing newline).
+        """
+        lines: list[str] = ["## Context", ""]
+        lines.extend(self._render_threads(context.related_threads))
+        lines.extend(self._render_decisions(context.related_decisions))
+        lines.extend(self._render_praxis(context.relevant_praxis))
+        lines.extend(self._render_frequency_affinity(context.frequency_affinity))
+        lines.extend(
+            self._render_wavelength(
+                context.current_wavelength,
+                len(context.related_decisions),
+            ),
+        )
+        lines.extend(self._render_interventions(context.interventions))
+        return self.apply_guardrails("\n".join(lines).rstrip() + "\n")
+
+    def apply_guardrails(self, context_text: str) -> str:
+        """Scrub directive, urgency, and permanence framing from text.
+
+        Replaces patterns like "you should", "the best option", "act now",
+        and "this is permanent" with descriptive, option-surfacing language.
+
+        Args:
+            context_text: Input Markdown text.
+
+        Returns:
+            Text with directive language replaced by descriptive phrasing.
+        """
+        result = context_text
+        for pattern, replacement in _DIRECTIVE_REPLACEMENTS:
+            result = pattern.sub(replacement, result)
+        return result
+
+    def interventions_lookup(
+        self,
+        frequency: str,
+        phase: str,
+    ) -> list[str]:
+        """Look up practices mapped to a (frequency, phase) pair.
+
+        The frequency argument may be either a Frequency code (``"F6"``) or
+        a color name (``"green"``). Phase accepts any
+        :class:`~creek.models.Phase` value.
+
+        Args:
+            frequency: APTITUDE frequency code or color name.
+            phase: Archetypal wavelength phase.
+
+        Returns:
+            List of practice names from the Phase x Frequency map
+            (Section 12.5). Empty list if no practices are mapped.
+        """
+        color = _FREQUENCY_COLOR.get(frequency, frequency).lower()
+        phase_key = phase.lower()
+        return list(PRACTICE_MAP.get((color, phase_key), ()))
+
+    def append_context_section(
+        self,
+        decision_path: Path,
+        context_section: str,
+    ) -> Path:
+        """Append a generated context section to a Decision note.
+
+        If the note already contains a ``## Context`` section, the
+        existing section is replaced; otherwise the new section is
+        appended after the body.
+
+        Args:
+            decision_path: Path to the decision note.
+            context_section: The generated Markdown context section.
+
+        Returns:
+            The path that was updated.
+        """
+        post = frontmatter.load(str(decision_path))
+        body = post.content
+        existing = re.search(r"\n## Context\b.*", body, flags=re.DOTALL)
+        new_section = context_section.rstrip() + "\n"
+        if existing:
+            post.content = body[: existing.start()].rstrip() + "\n\n" + new_section
+        else:
+            post.content = body.rstrip() + "\n\n" + new_section
+        decision_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return decision_path
+
+    # ---- Related-thread / decision / praxis lookup ----
+
+    def _find_related_threads(
+        self,
+        vault_path: Path,
+        title_tokens: set[str],
+        freqs: list[str],
+    ) -> list[str]:
+        """Find IDs of threads related by token overlap or frequency."""
+        results: list[tuple[float, str]] = []
+        for md_file in self._iter_markdown(vault_path / "02-Threads"):
+            scored = self._score_thread(md_file, title_tokens, freqs)
+            if scored is not None:
+                results.append(scored)
+        return [tid for _, tid in sorted(results, key=lambda r: -r[0])]
+
+    def _score_thread(
+        self,
+        md_file: Path,
+        title_tokens: set[str],
+        freqs: list[str],
+    ) -> tuple[float, str] | None:
+        """Score a single thread file and return ``(score, id)`` if related."""
+        post = _load_post(md_file)
+        if post is None:
+            return None
+        thread_id = str(post.get("id") or "")
+        if not thread_id:
+            return None
+        thread_tokens = _tokenize(
+            str(post.get("title") or "") + " " + str(post.get("description") or ""),
+        )
+        score = _jaccard(title_tokens, thread_tokens)
+        thread_freqs = _listify(post.get("frequency_affinity"))
+        if any(f in thread_freqs for f in freqs):
+            score = max(score, self.similarity_threshold)
+        if score < self.similarity_threshold:
+            return None
+        return (score, thread_id)
+
+    def _find_related_decisions(
+        self,
+        vault_path: Path,
+        exclude_id: str,
+        title_tokens: set[str],
+        freqs: list[str],
+    ) -> list[str]:
+        """Find IDs of past decisions with similar themes or stakes."""
+        decisions_dir = vault_path / "08-Decisions"
+        results: list[tuple[float, str]] = []
+        for subfolder in ("Active", "Archive"):
+            for md_file in self._iter_markdown(decisions_dir / subfolder):
+                scored = self._score_decision(
+                    md_file,
+                    exclude_id,
+                    title_tokens,
+                    freqs,
+                )
+                if scored is not None:
+                    results.append(scored)
+        return [did for _, did in sorted(results, key=lambda r: -r[0])]
+
+    def _score_decision(
+        self,
+        md_file: Path,
+        exclude_id: str,
+        title_tokens: set[str],
+        freqs: list[str],
+    ) -> tuple[float, str] | None:
+        """Score a single decision file and return ``(score, id)`` if related."""
+        post = _load_post(md_file)
+        if post is None:
+            return None
+        did = str(post.get("id") or "")
+        if not did or did == exclude_id:
+            return None
+        their_tokens = _tokenize(str(post.get("title") or ""))
+        score = _jaccard(title_tokens, their_tokens)
+        their_freqs = _listify(post.get("frequency_context"))
+        if any(f in their_freqs for f in freqs):
+            score = max(score, self.similarity_threshold)
+        if score < self.similarity_threshold:
+            return None
+        return (score, did)
+
+    def _find_relevant_praxis(
+        self,
+        vault_path: Path,
+        freqs: list[str],
+    ) -> list[str]:
+        """Find IDs of praxis notes whose frequencies overlap the decision."""
+        praxis_dir = vault_path / "04-Praxis"
+        results: list[str] = []
+        for md_file in self._iter_markdown(praxis_dir):
+            post = _load_post(md_file)
+            if post is None:
+                continue
+            pid = str(post.get("id") or "")
+            if not pid:
+                continue
+            praxis_freqs = _listify(post.get("frequency"))
+            if not freqs or any(f in praxis_freqs for f in freqs):
+                results.append(pid)
+        return results
+
+    # ---- Wavelength + frequency affinity ----
+
+    def _current_wavelength(self, vault_path: Path, fallback: str) -> str:
+        """Determine current wavelength phase.
+
+        Reads the most recent WavelengthObservation note from
+        ``05-Wavelength/Observations/`` (by ``date`` field). Falls back
+        to the value carried on the decision if no observation is found.
+
+        Args:
+            vault_path: Vault root.
+            fallback: Phase string to use when no observation is available.
+
+        Returns:
+            A phase value (e.g. ``"rising"``), or the fallback.
+        """
+        obs_dir = vault_path / "05-Wavelength" / "Observations"
+        most_recent: tuple[str, str] | None = None
+        for md_file in self._iter_markdown(obs_dir):
+            post = _load_post(md_file)
+            if post is None:
+                continue
+            date_str = str(post.get("date") or "")
+            phase_val = str(post.get("phase") or "")
+            if not date_str or not phase_val:
+                continue
+            if most_recent is None or date_str > most_recent[0]:
+                most_recent = (date_str, phase_val)
+        return most_recent[1] if most_recent else fallback
+
+    def _frequency_affinity(
+        self,
+        decision: Decision,
+        relevant_praxis_ids: list[str],
+        vault_path: Path,
+    ) -> list[str]:
+        """Rank frequencies by prevalence across decision and praxis.
+
+        Args:
+            decision: The source decision.
+            relevant_praxis_ids: IDs of related praxis notes.
+            vault_path: Vault root (used to inspect praxis frequencies).
+
+        Returns:
+            Ordered list of frequency codes, most-active first.
+        """
+        counts: dict[str, int] = {}
+        for decision_freq in decision.frequency_context:
+            key = str(decision_freq)
+            counts[key] = counts.get(key, 0) + 2
+        for md_file in self._iter_markdown(vault_path / "04-Praxis"):
+            post = _load_post(md_file)
+            if post is None:
+                continue
+            if str(post.get("id") or "") not in relevant_praxis_ids:
+                continue
+            for praxis_freq in _listify(post.get("frequency")):
+                counts[praxis_freq] = counts.get(praxis_freq, 0) + 1
+        return [f for f, _ in sorted(counts.items(), key=lambda item: -item[1])]
+
+    def _gather_interventions(
+        self,
+        affinity: list[str],
+        phase: str,
+    ) -> list[str]:
+        """Collect unique interventions for the active frequencies+phase."""
+        if not phase:
+            return []
+        seen: list[str] = []
+        for freq in affinity:
+            for practice in self.interventions_lookup(freq, phase):
+                if practice not in seen:
+                    seen.append(practice)
+        return seen
+
+    # ---- Markdown rendering helpers ----
+
+    @staticmethod
+    def _render_threads(threads: list[str]) -> list[str]:
+        """Render the ``### Related Threads`` section."""
+        if not threads:
+            return ["### Related Threads", "", "_No related threads surfaced._", ""]
+        lines = ["### Related Threads", ""]
+        lines.extend(f"- [[{tid}]]" for tid in threads)
+        lines.append("")
+        return lines
+
+    @staticmethod
+    def _render_decisions(decisions: list[str]) -> list[str]:
+        """Render the ``### Related Past Decisions`` section."""
+        if not decisions:
+            return [
+                "### Related Past Decisions",
+                "",
+                "_No comparable past decisions surfaced._",
+                "",
+            ]
+        lines = ["### Related Past Decisions", ""]
+        lines.extend(f"- [[{did}]]" for did in decisions)
+        lines.append("")
+        return lines
+
+    @staticmethod
+    def _render_praxis(praxis: list[str]) -> list[str]:
+        """Render the ``### Relevant Praxis`` section."""
+        if not praxis:
+            return ["### Relevant Praxis", "", "_No praxis notes surfaced._", ""]
+        lines = ["### Relevant Praxis", ""]
+        lines.extend(f"- [[{pid}]]" for pid in praxis)
+        lines.append("")
+        return lines
+
+    @staticmethod
+    def _render_frequency_affinity(affinity: list[str]) -> list[str]:
+        """Render the ``### Frequency Affinity`` section."""
+        lines = ["### Frequency Affinity", ""]
+        if affinity:
+            lines.append(
+                "Most active frequencies in this decision: "
+                + ", ".join(affinity)
+                + ".",
+            )
+        else:
+            lines.append("_Frequency affinity is not yet established._")
+        lines.append("")
+        return lines
+
+    @staticmethod
+    def _render_wavelength(phase: str, past_decision_count: int) -> list[str]:
+        """Render the ``### Current Wavelength`` section and advisory."""
+        lines = ["### Current Wavelength", ""]
+        if not phase:
+            lines.append("_Current wavelength phase is unknown._")
+            lines.append("")
+            return lines
+        lines.append(f"You are currently in the **{phase}** phase.")
+        if past_decision_count >= _MIN_HISTORY_FOR_ADVISORY:
+            lines.append("")
+            lines.append(
+                f"Historically, decisions made during {phase} have had "
+                "a pattern worth noticing; review the related past "
+                "decisions above.",
+            )
+        lines.append("")
+        return lines
+
+    @staticmethod
+    def _render_interventions(interventions: list[str]) -> list[str]:
+        """Render the ``### Interventions Surfaced`` section."""
+        if not interventions:
+            return []
+        lines = ["### Interventions Surfaced", ""]
+        lines.append(
+            "Practices that have been mapped as useful in this territory:",
+        )
+        lines.append("")
+        lines.extend(f"- {practice}" for practice in interventions)
+        lines.append("")
+        return lines
+
+    @staticmethod
+    def _iter_markdown(directory: Path) -> list[Path]:
+        """List markdown files in a directory, safely handling absence."""
+        if not directory.exists():
+            return []
+        return sorted(directory.glob("*.md"))
+
+
+def _coerce_phase(raw: object) -> str:
+    """Coerce a raw phase value to a known Phase string or empty."""
+    value = str(raw or "")
+    valid = {p.value for p in Phase}
+    return value if value == "" or value in valid else ""
+
+
+def _coerce_opened(raw: object) -> date | None:
+    """Coerce a raw ``opened`` value to a date, or ``None`` if unparseable."""
+    if isinstance(raw, date):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            return date.fromisoformat(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def decision_from_note(note_path: Path) -> Decision:
+    """Load a Decision Pydantic model from a note file.
+
+    Args:
+        note_path: Path to a Decision markdown note.
+
+    Returns:
+        A :class:`~creek.models.Decision` built from the note's
+        frontmatter. Missing fields fall back to the model defaults.
+    """
+    post = frontmatter.load(str(note_path))
+    metadata = dict(post.metadata)
+    metadata["title"] = metadata.get("title") or note_path.stem
+    metadata["id"] = metadata.get("id") or _generate_decision_id()
+    valid_freqs = {freq.value for freq in Frequency}
+    metadata["frequency_context"] = [
+        f for f in _listify(metadata.get("frequency_context")) if f in valid_freqs
+    ]
+    metadata["wavelength_phase_at_opening"] = _coerce_phase(
+        metadata.get("wavelength_phase_at_opening"),
+    )
+    opened = _coerce_opened(metadata.get("opened"))
+    if opened is not None:
+        metadata["opened"] = opened
+    else:
+        metadata.pop("opened", None)
+    return Decision(**metadata)

--- a/creek-tools/tests/test_decision_context.py
+++ b/creek-tools/tests/test_decision_context.py
@@ -1,0 +1,656 @@
+"""Tests for DecisionContextGatherer — Section 12.3-12.5 context gathering.
+
+Covers cross-vault context aggregation, anti-manipulation guardrails, the
+Phase x Frequency Practice Map, and appending context sections to existing
+Decision notes.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.generate.decisions import (
+    PRACTICE_MAP,
+    DecisionContext,
+    DecisionContextGatherer,
+    decision_from_note,
+)
+from creek.models import (
+    Decision,
+    DecisionStatus,
+    Frequency,
+    Phase,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture()
+def vault_path(tmp_path: Path) -> Path:
+    """Create a vault scaffolding with all relevant subdirectories."""
+    dirs = [
+        "02-Threads",
+        "04-Praxis",
+        "05-Wavelength/Observations",
+        "08-Decisions/Active",
+        "08-Decisions/Archive",
+        "09-Reference",
+    ]
+    for d in dirs:
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+@pytest.fixture()
+def gatherer() -> DecisionContextGatherer:
+    """Return a DecisionContextGatherer with default similarity threshold."""
+    return DecisionContextGatherer()
+
+
+@pytest.fixture()
+def sample_decision() -> Decision:
+    """Return a Decision model about changing careers."""
+    return Decision(
+        id="decision-career01",
+        title="Change careers from engineering to teaching",
+        status=DecisionStatus.SENSING,
+        opened=date(2025, 3, 10),
+        frequency_context=[Frequency.F1, Frequency.F5],
+        wavelength_phase_at_opening="rising",
+        tags=["career"],
+    )
+
+
+def _write_post(path: Path, **fields: object) -> None:
+    """Write a frontmatter post with the given metadata to ``path``."""
+    body = str(fields.pop("content", ""))
+    post = frontmatter.Post(content=body, **fields)
+    path.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+@pytest.fixture()
+def seeded_vault(vault_path: Path) -> Path:
+    """Populate the vault with threads, praxis, decisions, and observations."""
+    _write_post(
+        vault_path / "02-Threads" / "career-thread.md",
+        type="thread",
+        id="thread-career",
+        title="Career direction and meaningful work",
+        description="Ongoing exploration of engineering, teaching, and craft.",
+        frequency_affinity=["F1", "F5"],
+    )
+    _write_post(
+        vault_path / "02-Threads" / "cooking-thread.md",
+        type="thread",
+        id="thread-cooking",
+        title="Weeknight cooking",
+        description="Recipes for busy evenings.",
+        frequency_affinity=["F2"],
+    )
+    _write_post(
+        vault_path / "04-Praxis" / "goal-setting.md",
+        type="praxis",
+        id="praxis-goals",
+        title="Quarterly goal setting",
+        frequency=["F1", "F5"],
+    )
+    _write_post(
+        vault_path / "04-Praxis" / "morning-pages.md",
+        type="praxis",
+        id="praxis-pages",
+        title="Morning pages",
+        frequency=["F2"],
+    )
+    _write_post(
+        vault_path / "08-Decisions" / "Archive" / "2024-04-01-prior-job.md",
+        type="decision",
+        id="decision-prior01",
+        title="Should I change jobs this year",
+        status="enacted",
+        opened=date(2024, 4, 1).isoformat(),
+        wavelength_phase_at_opening="rising",
+        frequency_context=["F1", "F5"],
+    )
+    _write_post(
+        vault_path / "08-Decisions" / "Archive" / "2023-11-15-teach-class.md",
+        type="decision",
+        id="decision-prior02",
+        title="Teaching a one-off class",
+        status="enacted",
+        opened=date(2023, 11, 15).isoformat(),
+        wavelength_phase_at_opening="peaking",
+        frequency_context=["F5"],
+    )
+    _write_post(
+        vault_path / "05-Wavelength" / "Observations" / "2025-03-09.md",
+        type="wavelength_observation",
+        id="wave-0309",
+        date=date(2025, 3, 9).isoformat(),
+        phase="peaking",
+    )
+    _write_post(
+        vault_path / "05-Wavelength" / "Observations" / "2025-03-01.md",
+        type="wavelength_observation",
+        id="wave-0301",
+        date=date(2025, 3, 1).isoformat(),
+        phase="rising",
+    )
+    return vault_path
+
+
+# ---- PRACTICE_MAP Tests ----
+
+
+class TestPracticeMap:
+    """Tests for the module-level PRACTICE_MAP constant."""
+
+    def test_is_nonempty(self) -> None:
+        """PRACTICE_MAP should have canonical entries from Section 12.5."""
+        assert len(PRACTICE_MAP) >= 10
+
+    def test_keys_are_tuple_of_str(self) -> None:
+        """Keys should be (color, phase) tuples of strings."""
+        for key in PRACTICE_MAP:
+            assert isinstance(key, tuple)
+            assert len(key) == 2
+            assert all(isinstance(p, str) for p in key)
+
+    def test_values_are_string_tuples(self) -> None:
+        """Values should be tuples of practice names."""
+        for value in PRACTICE_MAP.values():
+            assert isinstance(value, tuple)
+            assert all(isinstance(p, str) for p in value)
+
+    def test_contains_core_interventions(self) -> None:
+        """Spot check the canonical interventions from the ontology."""
+        assert "Cold Shower" in PRACTICE_MAP[("beige", "rising")]
+        assert "Yoga" in PRACTICE_MAP[("green", "rising")]
+        assert "Journaling" in PRACTICE_MAP[("green", "diminishing")]
+
+
+# ---- interventions_lookup Tests ----
+
+
+class TestInterventionsLookup:
+    """Tests for DecisionContextGatherer.interventions_lookup."""
+
+    def test_by_color_and_phase(self, gatherer: DecisionContextGatherer) -> None:
+        """Color + phase returns the mapped practices."""
+        assert "Cold Shower" in gatherer.interventions_lookup("beige", "rising")
+
+    def test_by_frequency_code(self, gatherer: DecisionContextGatherer) -> None:
+        """Frequency code arg is translated to color before lookup."""
+        assert "Metta Meditation" in gatherer.interventions_lookup("F4", "rising")
+
+    def test_returns_empty_for_unmapped(
+        self,
+        gatherer: DecisionContextGatherer,
+    ) -> None:
+        """Unknown (frequency, phase) pairs return an empty list."""
+        assert gatherer.interventions_lookup("beige", "peaking") == []
+
+    def test_case_insensitive_phase(self, gatherer: DecisionContextGatherer) -> None:
+        """Phase matching should be case-insensitive."""
+        assert gatherer.interventions_lookup("beige", "RISING")
+
+    def test_unknown_frequency_falls_through(
+        self,
+        gatherer: DecisionContextGatherer,
+    ) -> None:
+        """Unknown frequency string without a color mapping returns []."""
+        assert gatherer.interventions_lookup("magenta", "rising") == []
+
+
+# ---- gather_context Tests ----
+
+
+class TestGatherContext:
+    """Tests for DecisionContextGatherer.gather_context."""
+
+    def test_returns_decision_context(
+        self,
+        gatherer: DecisionContextGatherer,
+        seeded_vault: Path,
+        sample_decision: Decision,
+    ) -> None:
+        """gather_context should return a DecisionContext dataclass."""
+        result = gatherer.gather_context(sample_decision, seeded_vault)
+        assert isinstance(result, DecisionContext)
+
+    def test_finds_related_threads(
+        self,
+        gatherer: DecisionContextGatherer,
+        seeded_vault: Path,
+        sample_decision: Decision,
+    ) -> None:
+        """Related threads by semantic similarity and frequency overlap."""
+        ctx = gatherer.gather_context(sample_decision, seeded_vault)
+        assert "thread-career" in ctx.related_threads
+        assert "thread-cooking" not in ctx.related_threads
+
+    def test_finds_past_decisions(
+        self,
+        gatherer: DecisionContextGatherer,
+        seeded_vault: Path,
+        sample_decision: Decision,
+    ) -> None:
+        """Past decisions with overlapping frequency are surfaced."""
+        ctx = gatherer.gather_context(sample_decision, seeded_vault)
+        assert "decision-prior01" in ctx.related_decisions
+
+    def test_excludes_self_from_related_decisions(
+        self,
+        gatherer: DecisionContextGatherer,
+        vault_path: Path,
+        sample_decision: Decision,
+    ) -> None:
+        """A decision should never cite itself as related."""
+        _write_post(
+            vault_path / "08-Decisions" / "Active" / "self.md",
+            type="decision",
+            id=sample_decision.id,
+            title=sample_decision.title,
+            frequency_context=["F1", "F5"],
+        )
+        ctx = gatherer.gather_context(sample_decision, vault_path)
+        assert sample_decision.id not in ctx.related_decisions
+
+    def test_surfaces_relevant_praxis(
+        self,
+        gatherer: DecisionContextGatherer,
+        seeded_vault: Path,
+        sample_decision: Decision,
+    ) -> None:
+        """Praxis with overlapping frequencies are surfaced."""
+        ctx = gatherer.gather_context(sample_decision, seeded_vault)
+        assert "praxis-goals" in ctx.relevant_praxis
+        assert "praxis-pages" not in ctx.relevant_praxis
+
+    def test_current_wavelength_uses_most_recent_observation(
+        self,
+        gatherer: DecisionContextGatherer,
+        seeded_vault: Path,
+        sample_decision: Decision,
+    ) -> None:
+        """Most recent observation by date wins (2025-03-09 -> peaking)."""
+        ctx = gatherer.gather_context(sample_decision, seeded_vault)
+        assert ctx.current_wavelength == "peaking"
+
+    def test_current_wavelength_falls_back(
+        self,
+        gatherer: DecisionContextGatherer,
+        vault_path: Path,
+        sample_decision: Decision,
+    ) -> None:
+        """With no observations, falls back to decision's opening phase."""
+        ctx = gatherer.gather_context(sample_decision, vault_path)
+        assert ctx.current_wavelength == "rising"
+
+    def test_frequency_affinity_ranks_decision_first(
+        self,
+        gatherer: DecisionContextGatherer,
+        seeded_vault: Path,
+        sample_decision: Decision,
+    ) -> None:
+        """Frequencies from the decision should lead the affinity list."""
+        ctx = gatherer.gather_context(sample_decision, seeded_vault)
+        assert set(ctx.frequency_affinity[:2]) == {"F1", "F5"}
+
+    def test_interventions_match_phase_and_frequency(
+        self,
+        gatherer: DecisionContextGatherer,
+        seeded_vault: Path,
+        sample_decision: Decision,
+    ) -> None:
+        """Interventions reflect current phase (peaking) and affinity."""
+        ctx = gatherer.gather_context(sample_decision, seeded_vault)
+        # F5 -> orange; no mapped practice at peaking. F1 -> beige; none.
+        # Add F7 (yellow) to activate a peaking intervention.
+        enriched = sample_decision.model_copy(
+            update={"frequency_context": [Frequency.F7, Frequency.F1]},
+        )
+        ctx = gatherer.gather_context(enriched, seeded_vault)
+        assert "Samatha Vipassana" in ctx.interventions
+
+
+# ---- generate_context_section Tests ----
+
+
+class TestGenerateContextSection:
+    """Tests for DecisionContextGatherer.generate_context_section."""
+
+    def test_returns_string(self, gatherer: DecisionContextGatherer) -> None:
+        """generate_context_section should return a string."""
+        ctx = DecisionContext(
+            decision_id="decision-x",
+            decision_title="t",
+            current_wavelength="rising",
+        )
+        assert isinstance(gatherer.generate_context_section(ctx), str)
+
+    def test_includes_context_heading(
+        self,
+        gatherer: DecisionContextGatherer,
+    ) -> None:
+        """Result should start with '## Context'."""
+        ctx = DecisionContext(decision_id="decision-x", decision_title="t")
+        section = gatherer.generate_context_section(ctx)
+        assert section.startswith("## Context")
+
+    def test_includes_related_thread_links(
+        self,
+        gatherer: DecisionContextGatherer,
+    ) -> None:
+        """Related threads appear as Obsidian wiki links."""
+        ctx = DecisionContext(
+            decision_id="d",
+            decision_title="t",
+            related_threads=["thread-career"],
+        )
+        section = gatherer.generate_context_section(ctx)
+        assert "[[thread-career]]" in section
+
+    def test_includes_related_decision_links(
+        self,
+        gatherer: DecisionContextGatherer,
+    ) -> None:
+        """Past decisions appear as Obsidian wiki links."""
+        ctx = DecisionContext(
+            decision_id="d",
+            decision_title="t",
+            related_decisions=["decision-prior01"],
+        )
+        section = gatherer.generate_context_section(ctx)
+        assert "[[decision-prior01]]" in section
+
+    def test_wavelength_advisory_when_history_sufficient(
+        self,
+        gatherer: DecisionContextGatherer,
+    ) -> None:
+        """Advisory surfaces only when past-decision history is sufficient."""
+        ctx = DecisionContext(
+            decision_id="d",
+            decision_title="t",
+            current_wavelength="peaking",
+            related_decisions=["d1", "d2"],
+        )
+        section = gatherer.generate_context_section(ctx)
+        assert "Historically" in section
+        assert "peaking" in section
+
+    def test_no_advisory_when_history_insufficient(
+        self,
+        gatherer: DecisionContextGatherer,
+    ) -> None:
+        """Advisory must NOT surface when we lack comparable history."""
+        ctx = DecisionContext(
+            decision_id="d",
+            decision_title="t",
+            current_wavelength="rising",
+            related_decisions=[],
+        )
+        section = gatherer.generate_context_section(ctx)
+        assert "Historically" not in section
+
+    def test_no_prescriptive_language(
+        self,
+        gatherer: DecisionContextGatherer,
+    ) -> None:
+        """Generated output must not contain prescriptive language."""
+        ctx = DecisionContext(
+            decision_id="d",
+            decision_title="t",
+            current_wavelength="rising",
+        )
+        section = gatherer.generate_context_section(ctx)
+        for banned in ("you should", "you need to", "the best option"):
+            assert banned.lower() not in section.lower()
+
+    def test_interventions_labelled_as_mapped(
+        self,
+        gatherer: DecisionContextGatherer,
+    ) -> None:
+        """Intervention section should use non-prescriptive framing."""
+        ctx = DecisionContext(
+            decision_id="d",
+            decision_title="t",
+            interventions=["Yoga"],
+        )
+        section = gatherer.generate_context_section(ctx)
+        assert "mapped as useful" in section
+        assert "Yoga" in section
+
+
+# ---- apply_guardrails Tests ----
+
+
+class TestApplyGuardrails:
+    """Tests for DecisionContextGatherer.apply_guardrails."""
+
+    def test_strips_you_should(self, gatherer: DecisionContextGatherer) -> None:
+        """'you should' becomes descriptive framing."""
+        out = gatherer.apply_guardrails("You should take the job.")
+        assert "you should" not in out.lower()
+        assert "one option" in out.lower()
+
+    def test_strips_best_option(self, gatherer: DecisionContextGatherer) -> None:
+        """'the best option' is neutralised."""
+        out = gatherer.apply_guardrails("The best option is X.")
+        assert "best option" not in out.lower()
+
+    def test_strips_urgency(self, gatherer: DecisionContextGatherer) -> None:
+        """'act now' urgency framing is removed."""
+        out = gatherer.apply_guardrails("Act now before it's too late.")
+        assert "act now" not in out.lower()
+        assert "too late" not in out.lower()
+
+    def test_strips_permanence(self, gatherer: DecisionContextGatherer) -> None:
+        """'this is permanent' is neutralised."""
+        out = gatherer.apply_guardrails("This is permanent, choose wisely.")
+        assert "permanent" not in out.lower()
+
+    def test_preserves_neutral_text(
+        self,
+        gatherer: DecisionContextGatherer,
+    ) -> None:
+        """Neutral descriptive text passes through unchanged."""
+        msg = "## Context\n\n- [[thread-career]]\n"
+        assert gatherer.apply_guardrails(msg) == msg
+
+    def test_case_insensitive_replacement(
+        self,
+        gatherer: DecisionContextGatherer,
+    ) -> None:
+        """Guardrail patterns match regardless of case."""
+        out = gatherer.apply_guardrails("YOU SHOULD decide.")
+        assert "should" not in out.lower() or "option" in out.lower()
+
+
+# ---- append_context_section Tests ----
+
+
+class TestAppendContextSection:
+    """Tests for DecisionContextGatherer.append_context_section."""
+
+    @pytest.fixture()
+    def existing_decision(self, vault_path: Path) -> Path:
+        """Create a decision note without any context section yet."""
+        note_path = vault_path / "08-Decisions" / "Active" / "2025-03-10-choice.md"
+        _write_post(
+            note_path,
+            content="## Options\n\n- _A_\n- _B_\n",
+            type="decision",
+            id="decision-choice01",
+            title="Choice",
+            status="sensing",
+            opened=date(2025, 3, 10).isoformat(),
+            wavelength_phase_at_opening="rising",
+        )
+        return note_path
+
+    def test_appends_new_section(
+        self,
+        gatherer: DecisionContextGatherer,
+        existing_decision: Path,
+    ) -> None:
+        """Appending should add the Context section to the body."""
+        gatherer.append_context_section(
+            existing_decision,
+            "## Context\n\n_nothing yet_\n",
+        )
+        content = existing_decision.read_text(encoding="utf-8")
+        assert "## Options" in content
+        assert "## Context" in content
+
+    def test_replaces_existing_section(
+        self,
+        gatherer: DecisionContextGatherer,
+        existing_decision: Path,
+    ) -> None:
+        """An existing Context section should be replaced, not duplicated."""
+        gatherer.append_context_section(
+            existing_decision,
+            "## Context\n\nold content\n",
+        )
+        gatherer.append_context_section(
+            existing_decision,
+            "## Context\n\nnew content\n",
+        )
+        content = existing_decision.read_text(encoding="utf-8")
+        assert content.count("## Context") == 1
+        assert "new content" in content
+        assert "old content" not in content
+
+    def test_preserves_frontmatter(
+        self,
+        gatherer: DecisionContextGatherer,
+        existing_decision: Path,
+    ) -> None:
+        """Appending must not destroy the note's YAML frontmatter."""
+        gatherer.append_context_section(
+            existing_decision,
+            "## Context\n\nbody\n",
+        )
+        post = frontmatter.load(str(existing_decision))
+        assert post["id"] == "decision-choice01"
+        assert post["status"] == "sensing"
+
+
+# ---- decision_from_note Tests ----
+
+
+class TestDecisionFromNote:
+    """Tests for the decision_from_note helper."""
+
+    def test_reads_basic_fields(self, vault_path: Path) -> None:
+        """Helper reads id, title, and frequency context from frontmatter."""
+        note = vault_path / "08-Decisions" / "Active" / "2025-03-10-x.md"
+        _write_post(
+            note,
+            type="decision",
+            id="decision-xyz",
+            title="X decision",
+            status="sensing",
+            opened=date(2025, 3, 10).isoformat(),
+            wavelength_phase_at_opening="rising",
+            frequency_context=["F1", "F5"],
+        )
+        decision = decision_from_note(note)
+        assert decision.id == "decision-xyz"
+        assert decision.title == "X decision"
+        assert Frequency.F1 in decision.frequency_context
+        assert decision.wavelength_phase_at_opening == "rising"
+
+    def test_skips_unknown_frequencies(self, vault_path: Path) -> None:
+        """Unknown frequency codes are dropped silently."""
+        note = vault_path / "08-Decisions" / "Active" / "2025-03-10-y.md"
+        _write_post(
+            note,
+            type="decision",
+            id="decision-abc",
+            title="Y decision",
+            status="sensing",
+            opened=date(2025, 3, 10).isoformat(),
+            frequency_context=["F1", "F99"],
+        )
+        decision = decision_from_note(note)
+        assert decision.frequency_context == [Frequency.F1]
+
+    def test_coerces_phase_enum(self, vault_path: Path) -> None:
+        """Unknown phases collapse to an empty string (model default)."""
+        note = vault_path / "08-Decisions" / "Active" / "2025-03-10-z.md"
+        _write_post(
+            note,
+            type="decision",
+            id="decision-def",
+            title="Z decision",
+            status="sensing",
+            opened=date(2025, 3, 10).isoformat(),
+            wavelength_phase_at_opening="not-a-phase",
+        )
+        decision = decision_from_note(note)
+        assert decision.wavelength_phase_at_opening == ""
+
+    def test_accepts_valid_phase(self, vault_path: Path) -> None:
+        """Valid phase strings are preserved."""
+        note = vault_path / "08-Decisions" / "Active" / "2025-03-10-w.md"
+        _write_post(
+            note,
+            type="decision",
+            id="decision-www",
+            title="W decision",
+            status="sensing",
+            opened=date(2025, 3, 10).isoformat(),
+            wavelength_phase_at_opening=Phase.PEAKING.value,
+        )
+        decision = decision_from_note(note)
+        assert decision.wavelength_phase_at_opening == "peaking"
+
+
+# ---- Integration: gather -> render -> append end-to-end ----
+
+
+class TestEndToEnd:
+    """End-to-end flow for context gathering on a real vault."""
+
+    def test_full_flow(
+        self,
+        gatherer: DecisionContextGatherer,
+        seeded_vault: Path,
+        sample_decision: Decision,
+    ) -> None:
+        """gather -> generate -> append produces a valid updated note."""
+        note_path = seeded_vault / "08-Decisions" / "Active" / "2025-03-10.md"
+        _write_post(
+            note_path,
+            content="## Source Fragments\n\n- frag-01\n",
+            type="decision",
+            id=sample_decision.id,
+            title=sample_decision.title,
+            status="sensing",
+            opened=sample_decision.opened.isoformat(),
+            wavelength_phase_at_opening=sample_decision.wavelength_phase_at_opening,
+            frequency_context=[str(f) for f in sample_decision.frequency_context],
+        )
+
+        ctx = gatherer.gather_context(sample_decision, seeded_vault)
+        section = gatherer.generate_context_section(ctx)
+        gatherer.append_context_section(note_path, section)
+
+        content = note_path.read_text(encoding="utf-8")
+        assert "## Context" in content
+        assert "[[thread-career]]" in content
+        assert "[[praxis-goals]]" in content
+        assert "[[decision-prior01]]" in content
+        assert "peaking" in content
+        # Never contains recommendation language:
+        for banned in ("you should", "best option", "you need to"):
+            assert banned not in content.lower()


### PR DESCRIPTION
Closes #45.

## Summary

Implements the Decision Context Gathering layer from Ontology Sections 12.3–12.5, extending `creek-tools/creek/generate/decisions.py` with cross-vault context aggregation, anti-manipulation guardrails, and the canonical Phase × Frequency Practice Map.

- **`DecisionContext`** dataclass: holds related threads, past decisions, current wavelength, relevant praxis, frequency affinity, and mapped interventions for one Decision.
- **`DecisionContextGatherer`**:
  - `gather_context(decision, vault_path)` walks `02-Threads/`, `04-Praxis/`, `05-Wavelength/Observations/`, and `08-Decisions/{Active,Archive}/`, scoring relatedness via token Jaccard similarity + frequency overlap. Current wavelength prefers the most recent observation, falling back to the decision's opening phase.
  - `generate_context_section(context)` renders a Markdown `## Context` block with Obsidian wiki links. A wavelength advisory surfaces only once there are ≥2 comparable past decisions.
  - `apply_guardrails(text)` scrubs directive/urgency/scarcity/permanence framing ("you should", "the best option", "act now", "this is permanent", …) per Section 12.4 — it surfaces context, it does not prescribe.
  - `interventions_lookup(frequency, phase)` reads the canonical `PRACTICE_MAP` (Section 12.5) by color or frequency code.
  - `append_context_section(decision_path, section)` idempotently updates an existing Decision note, replacing a prior `## Context` section rather than duplicating it.
- **`decision_from_note`** helper materialises a Pydantic `Decision` from a vault note's frontmatter, validating phase/frequency/opened fields.

## Acceptance criteria mapping

- [x] Related threads found by semantic similarity (token Jaccard + frequency)
- [x] Past decisions found by theme matching (title tokens + frequency context, excluding self)
- [x] Current wavelength phase detected and reported (most recent observation, with fallback)
- [x] Relevant praxis notes surfaced (frequency overlap)
- [x] Anti-manipulation guardrails enforced — generated output never recommends, never uses urgency/permanence framing
- [x] Interventions from Phase × Frequency Practice Map surfaced (non-prescriptive framing)
- [x] Tests verify context gathering and guardrail enforcement (40 new tests in `tests/test_decision_context.py`)

## Test plan

- [x] `pytest tests/test_decision_context.py` — 40/40 pass
- [x] Full suite: `pytest` — 1849/1850 pass (1 pre-existing skip for Ollama)
- [x] `./scripts/lint.sh` — clean
- [x] `./scripts/format.sh --check` — clean
- [x] `./scripts/complexity.sh` — all blocks rank A/B
- [x] Coverage 94.67% (≥90% threshold met)
- [x] Docstring coverage 100% for new code

https://claude.ai/code/session_01RCvXxVKopq68dJjG5Aa9Nf