### PR TITLE
feat(link): implement sliding-window thread detection (#31)

### DIFF
--- a/creek-tools/creek/link/linker.py
+++ b/creek-tools/creek/link/linker.py
@@ -100,7 +100,7 @@ class LinkingPipeline:
             fragments,
             min_fragments=self.linking_config.thread_min_fragments,
         )
-        thread_detector.assign_fragments_to_threads(fragments, threads)
+        fragments = thread_detector.assign_fragments_to_threads(fragments, threads)
 
         # Stage 4: Eddy detection
         eddy_detector = EddyDetector()

--- a/creek-tools/creek/link/linker.py
+++ b/creek-tools/creek/link/linker.py
@@ -94,9 +94,13 @@ class LinkingPipeline:
             window_hours=self.linking_config.temporal_window_hours,
         )
 
-        # Stage 3: Thread detection
-        thread_detector = ThreadDetector()
-        threads = thread_detector.detect_threads(fragments)
+        # Stage 3: Thread detection (uses embeddings for semantic clustering)
+        thread_detector = ThreadDetector(embeddings=embeddings)
+        threads = thread_detector.detect_threads(
+            fragments,
+            min_fragments=self.linking_config.thread_min_fragments,
+        )
+        thread_detector.assign_fragments_to_threads(fragments, threads)
 
         # Stage 4: Eddy detection
         eddy_detector = EddyDetector()

--- a/creek-tools/creek/link/threads.py
+++ b/creek-tools/creek/link/threads.py
@@ -1,40 +1,658 @@
-"""Thread detection stub.
+"""Thread detection — sliding time window plus topic consistency.
 
-Provides the ``ThreadDetector`` class which will identify recurring
-narrative threads across fragments.  This module is a stub — the real
-implementation comes in issues #28-33.
+Provides the :class:`ThreadDetector` which identifies recurring narrative
+threads across fragments. The algorithm sorts fragments chronologically,
+walks a sliding time window, and unions fragments that are *topic
+consistent* (semantic similarity above a threshold AND frequency
+agreement) into clusters. Clusters that meet the configured minimum
+fragment count become :class:`~creek.models.Thread` instances.
+
+The module also offers fragment-to-thread assignment (adding wiki-links
+to fragment ``threads`` frontmatter) and a heuristic for suggesting
+thread merges when two threads appear to cover the same topic.
 """
 
-import logging
+from __future__ import annotations
 
-from creek.models import Fragment, Thread
+import logging
+import re
+from collections import Counter
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from creek.models import Frequency, Thread, ThreadStatus
+
+if TYPE_CHECKING:
+    from creek.models import Fragment
 
 logger = logging.getLogger(__name__)
 
+_DEFAULT_WINDOW_DAYS = 30
+_DEFAULT_SIMILARITY_THRESHOLD = 0.6
+_DEFAULT_MIN_FRAGMENTS = 3
+_DEFAULT_MERGE_JACCARD = 0.3
+_ACTIVE_DAYS = 30
+_DORMANT_DAYS = 180
+_TITLE_TOP_WORDS = 3
+_MIN_TITLE_WORD_LEN = 3
 
-class ThreadDetector:
-    """Detect narrative threads across a collection of fragments.
+_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "about",
+        "above",
+        "after",
+        "again",
+        "against",
+        "all",
+        "am",
+        "an",
+        "and",
+        "any",
+        "are",
+        "as",
+        "at",
+        "be",
+        "because",
+        "been",
+        "before",
+        "being",
+        "below",
+        "between",
+        "both",
+        "but",
+        "by",
+        "can",
+        "did",
+        "do",
+        "does",
+        "doing",
+        "don",
+        "down",
+        "during",
+        "each",
+        "few",
+        "for",
+        "from",
+        "further",
+        "had",
+        "has",
+        "have",
+        "having",
+        "he",
+        "her",
+        "here",
+        "hers",
+        "herself",
+        "him",
+        "himself",
+        "his",
+        "how",
+        "i",
+        "if",
+        "in",
+        "into",
+        "is",
+        "it",
+        "its",
+        "itself",
+        "just",
+        "me",
+        "more",
+        "most",
+        "my",
+        "myself",
+        "no",
+        "nor",
+        "not",
+        "now",
+        "of",
+        "off",
+        "on",
+        "once",
+        "only",
+        "or",
+        "other",
+        "our",
+        "ours",
+        "ourselves",
+        "out",
+        "over",
+        "own",
+        "s",
+        "same",
+        "she",
+        "should",
+        "so",
+        "some",
+        "such",
+        "t",
+        "than",
+        "that",
+        "the",
+        "their",
+        "theirs",
+        "them",
+        "themselves",
+        "then",
+        "there",
+        "these",
+        "they",
+        "this",
+        "those",
+        "through",
+        "to",
+        "too",
+        "under",
+        "until",
+        "up",
+        "very",
+        "was",
+        "we",
+        "were",
+        "what",
+        "when",
+        "where",
+        "which",
+        "while",
+        "who",
+        "whom",
+        "why",
+        "will",
+        "with",
+        "you",
+        "your",
+        "yours",
+        "yourself",
+        "yourselves",
+    },
+)
 
-    This is a stub implementation that logs what it would do and returns
-    an empty list.  The real thread detection logic will be added in later
-    issues.
+
+class _UnionFind:
+    """Disjoint-set structure used to merge clusters across windows.
+
+    Stores parent pointers keyed by fragment ID. Path compression keeps
+    ``find`` near-constant amortised time.
     """
 
-    def detect_threads(self, fragments: list[Fragment]) -> list[Thread]:
-        """Detect recurring narrative threads in a set of fragments.
+    def __init__(self) -> None:
+        """Initialise with no members."""
+        self._parent: dict[str, str] = {}
 
-        This is a stub that returns an empty list.  The real implementation
-        will analyse fragment content and metadata to identify threads.
+    def add(self, item: str) -> None:
+        """Add *item* as its own root if not already present.
 
         Args:
-            fragments: List of fragments to scan for thread patterns.
+            item: The element to ensure exists in the structure.
+        """
+        if item not in self._parent:
+            self._parent[item] = item
+
+    def find(self, item: str) -> str:
+        """Return the representative root for *item*.
+
+        Args:
+            item: The element to look up. Added as a singleton if absent.
 
         Returns:
-            A list of detected ``Thread`` objects.  Currently returns an
-            empty list.
+            The root ID of *item*'s set.
+        """
+        self.add(item)
+        root = item
+        while self._parent[root] != root:
+            root = self._parent[root]
+        # Path compression
+        cur = item
+        while self._parent[cur] != root:
+            nxt = self._parent[cur]
+            self._parent[cur] = root
+            cur = nxt
+        return root
+
+    def union(self, a: str, b: str) -> None:
+        """Union the sets containing *a* and *b*.
+
+        Args:
+            a: First element.
+            b: Second element.
+        """
+        ra, rb = self.find(a), self.find(b)
+        if ra != rb:
+            self._parent[rb] = ra
+
+    def groups(self) -> dict[str, list[str]]:
+        """Return current groups keyed by their root representative.
+
+        Returns:
+            Mapping of root ID to the list of member IDs.
+        """
+        out: dict[str, list[str]] = {}
+        for member in list(self._parent.keys()):
+            root = self.find(member)
+            out.setdefault(root, []).append(member)
+        return out
+
+
+def _tokenize(text: str) -> list[str]:
+    """Tokenise *text* into lowercase alphabetic words.
+
+    Args:
+        text: Input string to tokenise.
+
+    Returns:
+        A list of lowercase word tokens (no punctuation, no digits).
+    """
+    return re.findall(r"[a-z]+", text.lower())
+
+
+def _content_words(text: str) -> list[str]:
+    """Extract content words from *text* (no stopwords, length-filtered).
+
+    Args:
+        text: Input string.
+
+    Returns:
+        A list of lowercase content words suitable for title heuristics.
+    """
+    return [
+        w
+        for w in _tokenize(text)
+        if w not in _STOPWORDS and len(w) >= _MIN_TITLE_WORD_LEN
+    ]
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two equal-length vectors.
+
+    Args:
+        a: First vector.
+        b: Second vector.
+
+    Returns:
+        Cosine similarity in ``[-1.0, 1.0]``; ``0.0`` if either vector
+        has zero norm.
+    """
+    va = np.asarray(a, dtype=np.float32)
+    vb = np.asarray(b, dtype=np.float32)
+    na = float(np.linalg.norm(va))
+    nb = float(np.linalg.norm(vb))
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return float(np.dot(va, vb) / (na * nb))
+
+
+class ThreadDetector:
+    """Detect narrative threads via sliding time window plus topic consistency.
+
+    Two fragments are considered *topic consistent* when their primary
+    or secondary frequencies overlap **and** (when embeddings are
+    available) their cosine similarity exceeds
+    :attr:`similarity_threshold`. Threads are clusters of at least
+    ``min_fragments`` fragments connected (transitively) under that
+    relation within the configured sliding time window.
+
+    Attributes:
+        embeddings: Optional fragment-ID to embedding-vector mapping.
+            When omitted, topic consistency falls back to frequency
+            agreement alone.
+        window_days: Width of the sliding time window in days.
+        similarity_threshold: Minimum cosine similarity to count as a
+            semantic match.
+        merge_jaccard: Title-token Jaccard similarity above which two
+            threads are suggested for merging.
+    """
+
+    def __init__(
+        self,
+        embeddings: dict[str, list[float]] | None = None,
+        *,
+        window_days: int = _DEFAULT_WINDOW_DAYS,
+        similarity_threshold: float = _DEFAULT_SIMILARITY_THRESHOLD,
+        merge_jaccard: float = _DEFAULT_MERGE_JACCARD,
+        now: datetime | None = None,
+    ) -> None:
+        """Initialise the detector.
+
+        Args:
+            embeddings: Optional mapping of fragment ID to embedding
+                vector (e.g. produced by
+                :class:`creek.link.embeddings.EmbeddingLinker`).
+            window_days: Sliding window width in days. Defaults to 30.
+            similarity_threshold: Cosine similarity threshold for the
+                semantic component of topic consistency. Defaults to 0.6.
+            merge_jaccard: Title-token Jaccard threshold used by
+                :meth:`suggest_merges`. Defaults to 0.5.
+            now: Reference "now" for status calculation; defaults to
+                :func:`datetime.now`. Useful for deterministic tests.
+        """
+        self.embeddings: dict[str, list[float]] = embeddings or {}
+        self.window_days = window_days
+        self.similarity_threshold = similarity_threshold
+        self.merge_jaccard = merge_jaccard
+        self._now = now or datetime.now()
+        self._thread_members: dict[str, list[str]] = {}
+
+    @property
+    def thread_members(self) -> dict[str, list[str]]:
+        """Mapping of thread ID to the fragment IDs that compose it.
+
+        Populated by the most recent call to :meth:`detect_threads`.
+
+        Returns:
+            A copy of the internal mapping. Empty until detection runs.
+        """
+        return dict(self._thread_members)
+
+    def detect_threads(
+        self,
+        fragments: list[Fragment],
+        min_fragments: int = _DEFAULT_MIN_FRAGMENTS,
+    ) -> list[Thread]:
+        """Detect narrative threads in *fragments*.
+
+        Sorts fragments chronologically, then unions any pair within the
+        configured sliding window that is topic consistent. Connected
+        components with at least *min_fragments* members become
+        :class:`~creek.models.Thread` instances.
+
+        Args:
+            fragments: Fragments to scan for thread patterns.
+            min_fragments: Minimum cluster size required to emit a
+                thread. Defaults to 3.
+
+        Returns:
+            A list of detected :class:`~creek.models.Thread` objects,
+            sorted by ``first_seen`` ascending.
         """
         logger.info(
-            "Stub: would detect threads among %d fragment(s)",
+            "Detecting threads among %d fragment(s) with %d-day window",
             len(fragments),
+            self.window_days,
         )
-        return []
+
+        if len(fragments) < min_fragments:
+            self._thread_members = {}
+            return []
+
+        sorted_frags = sorted(fragments, key=lambda f: f.created)
+        frag_by_id = {f.id: f for f in sorted_frags}
+        uf = self._cluster(sorted_frags)
+        threads = self._materialise_threads(uf, frag_by_id, min_fragments)
+
+        threads.sort(key=lambda t: t.first_seen)
+        logger.info("Detected %d thread(s)", len(threads))
+        return threads
+
+    def _cluster(self, sorted_frags: list[Fragment]) -> _UnionFind:
+        """Walk the sliding window, unioning topic-consistent pairs.
+
+        Args:
+            sorted_frags: Fragments pre-sorted by ``created`` ascending.
+
+        Returns:
+            A populated :class:`_UnionFind` covering every fragment ID.
+        """
+        uf = _UnionFind()
+        for frag in sorted_frags:
+            uf.add(frag.id)
+
+        window = timedelta(days=self.window_days)
+        for i, frag_a in enumerate(sorted_frags):
+            for frag_b in sorted_frags[i + 1 :]:
+                if frag_b.created - frag_a.created > window:
+                    break
+                if self._topic_consistent(frag_a, frag_b):
+                    uf.union(frag_a.id, frag_b.id)
+        return uf
+
+    def _materialise_threads(
+        self,
+        uf: _UnionFind,
+        frag_by_id: dict[str, Fragment],
+        min_fragments: int,
+    ) -> list[Thread]:
+        """Convert union-find groups into :class:`Thread` objects.
+
+        Args:
+            uf: Union-find with one node per fragment.
+            frag_by_id: Fragment lookup table.
+            min_fragments: Minimum cluster size to keep.
+
+        Returns:
+            The list of threads built from qualifying clusters. Side
+            effect: populates :attr:`_thread_members`.
+        """
+        self._thread_members = {}
+        threads: list[Thread] = []
+        for member_ids in uf.groups().values():
+            if len(member_ids) < min_fragments:
+                continue
+            cluster = sorted(
+                (frag_by_id[fid] for fid in member_ids),
+                key=lambda f: f.created,
+            )
+            thread = self._build_thread(cluster)
+            threads.append(thread)
+            self._thread_members[thread.id] = [f.id for f in cluster]
+        return threads
+
+    def _topic_consistent(self, a: Fragment, b: Fragment) -> bool:
+        """Return whether *a* and *b* should be grouped into one thread.
+
+        Args:
+            a: First fragment.
+            b: Second fragment.
+
+        Returns:
+            ``True`` if frequencies overlap and (when embeddings are
+            present) cosine similarity exceeds the configured threshold.
+        """
+        if not self._frequency_overlap(a, b):
+            return False
+        emb_a = self.embeddings.get(a.id)
+        emb_b = self.embeddings.get(b.id)
+        if emb_a is None or emb_b is None:
+            return True
+        return _cosine(emb_a, emb_b) > self.similarity_threshold
+
+    @staticmethod
+    def _frequency_overlap(a: Fragment, b: Fragment) -> bool:
+        """Return whether *a* and *b* share a primary or secondary frequency.
+
+        ``UNCLASSIFIED`` is treated as no signal.
+
+        Args:
+            a: First fragment.
+            b: Second fragment.
+
+        Returns:
+            ``True`` if any classified frequency appears in both.
+        """
+        unclassified = Frequency.UNCLASSIFIED.value
+        primary_a = str(a.frequency.primary)
+        primary_b = str(b.frequency.primary)
+        if primary_a == primary_b and primary_a != unclassified:
+            return True
+        sec_a: set[str] = {str(f) for f in a.frequency.secondary}
+        sec_a.add(primary_a)
+        sec_a.discard(unclassified)
+        sec_b: set[str] = {str(f) for f in b.frequency.secondary}
+        sec_b.add(primary_b)
+        sec_b.discard(unclassified)
+        return bool(sec_a & sec_b)
+
+    def _build_thread(self, frags: list[Fragment]) -> Thread:
+        """Construct a :class:`Thread` from its constituent fragments.
+
+        Args:
+            frags: Fragments belonging to the cluster (non-empty).
+
+        Returns:
+            A populated :class:`~creek.models.Thread`.
+        """
+        first_seen = min(f.created for f in frags).date()
+        last_seen = max(f.created for f in frags).date()
+        return Thread(
+            title=self._generate_title(frags),
+            status=self._compute_status(last_seen),
+            first_seen=first_seen,
+            last_seen=last_seen,
+            frequency_affinity=self._frequency_affinity(frags),
+            fragment_count=len(frags),
+        )
+
+    def _compute_status(self, last_seen: date) -> ThreadStatus:
+        """Compute lifecycle status from how long ago *last_seen* was.
+
+        Args:
+            last_seen: Date of the most recent fragment in the thread.
+
+        Returns:
+            ``ACTIVE`` if within ``_ACTIVE_DAYS``, ``DORMANT`` if within
+            ``_DORMANT_DAYS``, otherwise ``RESOLVED``.
+        """
+        days_since = (self._now.date() - last_seen).days
+        if days_since <= _ACTIVE_DAYS:
+            return ThreadStatus.ACTIVE
+        if days_since <= _DORMANT_DAYS:
+            return ThreadStatus.DORMANT
+        return ThreadStatus.RESOLVED
+
+    @staticmethod
+    def _generate_title(frags: list[Fragment]) -> str:
+        """Generate a human-readable title from common content words.
+
+        Falls back to the earliest fragment's title (truncated) when no
+        content words are available.
+
+        Args:
+            frags: Fragments in the cluster.
+
+        Returns:
+            A short title string.
+        """
+        counts: Counter[str] = Counter()
+        for frag in frags:
+            counts.update(_content_words(frag.title))
+        if not counts:
+            return frags[0].title[:50] if frags else "Untitled Thread"
+        top = [word for word, _ in counts.most_common(_TITLE_TOP_WORDS)]
+        return " ".join(word.capitalize() for word in top)
+
+    @staticmethod
+    def _frequency_affinity(frags: list[Fragment]) -> list[Frequency]:
+        """Return the most common primary frequencies in the cluster.
+
+        Args:
+            frags: Fragments in the cluster.
+
+        Returns:
+            All frequencies tied for the highest primary-frequency count
+            across the cluster (excluding ``UNCLASSIFIED``).
+        """
+        counts: Counter[str] = Counter()
+        unclassified = Frequency.UNCLASSIFIED.value
+        for frag in frags:
+            primary = frag.frequency.primary
+            if primary != unclassified:
+                counts[primary] += 1
+        if not counts:
+            return []
+        max_count = max(counts.values())
+        return [
+            Frequency(value) for value, count in counts.items() if count == max_count
+        ]
+
+    def assign_fragments_to_threads(
+        self,
+        fragments: list[Fragment],
+        threads: list[Thread],
+    ) -> list[Fragment]:
+        """Add thread wiki-links to each fragment and refresh thread counts.
+
+        Uses the membership map captured by the most recent
+        :meth:`detect_threads` call to decide which threads each fragment
+        belongs to. A wiki-link of the form ``[[<thread title>]]`` is
+        appended to each fragment's ``threads`` field, with duplicates
+        skipped. Each thread's ``fragment_count`` is updated in place to
+        reflect its current membership.
+
+        Args:
+            fragments: Fragments to update (returned unmodified — the
+                method produces fresh copies).
+            threads: Threads previously emitted by
+                :meth:`detect_threads`.
+
+        Returns:
+            A new list of fragments with thread wiki-links added where
+            applicable. Fragments not assigned to any thread are
+            returned unchanged (as the same instance).
+        """
+        frag_to_links: dict[str, list[str]] = {}
+        for thread in threads:
+            members = self._thread_members.get(thread.id, [])
+            thread.fragment_count = len(members)
+            wikilink = f"[[{thread.title}]]"
+            for fid in members:
+                frag_to_links.setdefault(fid, []).append(wikilink)
+
+        updated: list[Fragment] = []
+        for frag in fragments:
+            new_links = frag_to_links.get(frag.id, [])
+            if not new_links:
+                updated.append(frag)
+                continue
+            merged = list(frag.threads)
+            for link in new_links:
+                if link not in merged:
+                    merged.append(link)
+            updated.append(frag.model_copy(update={"threads": merged}))
+        return updated
+
+    def suggest_merges(
+        self,
+        threads: list[Thread],
+    ) -> list[tuple[Thread, Thread]]:
+        """Suggest pairs of threads that appear to cover the same topic.
+
+        Two threads are flagged when their title content-word Jaccard
+        similarity meets or exceeds :attr:`merge_jaccard` and they share
+        at least one frequency in their ``frequency_affinity``.
+
+        Args:
+            threads: Threads to compare pairwise.
+
+        Returns:
+            A list of ``(thread_a, thread_b)`` tuples, with ``a`` ordered
+            before ``b`` by their position in *threads*.
+        """
+        suggestions: list[tuple[Thread, Thread]] = []
+        for i, thread_a in enumerate(threads):
+            for thread_b in threads[i + 1 :]:
+                if self._should_merge(thread_a, thread_b):
+                    suggestions.append((thread_a, thread_b))
+        return suggestions
+
+    def _should_merge(self, a: Thread, b: Thread) -> bool:
+        """Return whether two threads should be suggested for merging.
+
+        Args:
+            a: First thread.
+            b: Second thread.
+
+        Returns:
+            ``True`` if title-token Jaccard similarity passes the
+            threshold and frequency affinities intersect.
+        """
+        words_a = set(_content_words(a.title))
+        words_b = set(_content_words(b.title))
+        if not words_a or not words_b:
+            return False
+        union = words_a | words_b
+        jaccard = len(words_a & words_b) / len(union)
+        if jaccard < self.merge_jaccard:
+            return False
+        return bool(set(a.frequency_affinity) & set(b.frequency_affinity))

--- a/creek-tools/creek/link/threads.py
+++ b/creek-tools/creek/link/threads.py
@@ -324,7 +324,7 @@ class ThreadDetector:
             similarity_threshold: Cosine similarity threshold for the
                 semantic component of topic consistency. Defaults to 0.6.
             merge_jaccard: Title-token Jaccard threshold used by
-                :meth:`suggest_merges`. Defaults to 0.5.
+                :meth:`suggest_merges`. Defaults to 0.3.
             now: Reference "now" for status calculation; defaults to
                 :func:`datetime.now`. Useful for deterministic tests.
         """

--- a/creek-tools/tests/test_link.py
+++ b/creek-tools/tests/test_link.py
@@ -33,6 +33,8 @@ from creek.models import (
     Mode,
     Phase,
     SourcePlatform,
+    Thread,
+    ThreadStatus,
     WavelengthClassification,
 )
 
@@ -634,10 +636,10 @@ class TestTemporalLinker:
 
 
 class TestThreadDetector:
-    """Tests for the ThreadDetector stub class."""
+    """Tests for the ThreadDetector class (sliding window + topic consistency)."""
 
-    def test_detect_threads_returns_empty_list(self) -> None:
-        """Stub detect_threads should return an empty list."""
+    def test_detect_threads_below_min_fragments_returns_empty_list(self) -> None:
+        """Two fragments with default ``min_fragments=3`` yield no threads."""
         detector = ThreadDetector()
         fragments = [_make_fragment("A"), _make_fragment("B")]
         result = detector.detect_threads(fragments)
@@ -657,6 +659,605 @@ class TestThreadDetector:
         with caplog.at_level(logging.INFO, logger="creek.link.threads"):
             detector.detect_threads(fragments)
         assert any("thread" in r.message.lower() for r in caplog.records)
+
+    def test_detect_threads_simple_cluster(self) -> None:
+        """Three frequency-aligned fragments in window form one thread."""
+        now = datetime(2026, 4, 1, 12, 0, 0)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                "Reading Practice",
+                created=now - timedelta(days=10),
+                primary_freq=Frequency.F4,
+            ),
+            _make_fragment(
+                "Reading Habits",
+                created=now - timedelta(days=5),
+                primary_freq=Frequency.F4,
+            ),
+            _make_fragment(
+                "Reading Notes",
+                created=now - timedelta(days=1),
+                primary_freq=Frequency.F4,
+            ),
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+        thread = result[0]
+        assert thread.fragment_count == 3
+        assert thread.first_seen == (now - timedelta(days=10)).date()
+        assert thread.last_seen == (now - timedelta(days=1)).date()
+
+    def test_detect_threads_respects_min_fragments_argument(self) -> None:
+        """min_fragments=2 admits clusters with two members."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                "Hiking Logs",
+                created=now - timedelta(days=5),
+                primary_freq=Frequency.F2,
+            ),
+            _make_fragment(
+                "Hiking Trips",
+                created=now - timedelta(days=2),
+                primary_freq=Frequency.F2,
+            ),
+        ]
+        result = detector.detect_threads(fragments, min_fragments=2)
+        assert len(result) == 1
+        assert result[0].fragment_count == 2
+
+    def test_detect_threads_excludes_unconnected_fragments(self) -> None:
+        """Fragments with non-overlapping frequencies stay separate."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                "Topic A One",
+                created=now - timedelta(days=10),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "Topic A Two",
+                created=now - timedelta(days=5),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "Topic A Three",
+                created=now - timedelta(days=1),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "Different",
+                created=now - timedelta(days=2),
+                primary_freq=Frequency.F9,
+            ),
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+        assert result[0].fragment_count == 3
+
+    def test_detect_threads_secondary_frequency_overlap_links(self) -> None:
+        """Fragments with overlapping secondary frequencies connect."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                "Alpha",
+                created=now - timedelta(days=10),
+                primary_freq=Frequency.F1,
+                secondary_freqs=[Frequency.F5],
+            ),
+            _make_fragment(
+                "Beta",
+                created=now - timedelta(days=5),
+                primary_freq=Frequency.F2,
+                secondary_freqs=[Frequency.F5],
+            ),
+            _make_fragment(
+                "Gamma",
+                created=now - timedelta(days=1),
+                primary_freq=Frequency.F3,
+                secondary_freqs=[Frequency.F5],
+            ),
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+
+    def test_detect_threads_outside_window_does_not_link(self) -> None:
+        """Fragments separated by more than window_days are not linked directly."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now, window_days=10)
+        fragments = [
+            _make_fragment(
+                "A",
+                created=now - timedelta(days=100),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "B",
+                created=now - timedelta(days=80),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "C",
+                created=now - timedelta(days=60),
+                primary_freq=Frequency.F1,
+            ),
+        ]
+        result = detector.detect_threads(fragments)
+        assert result == []
+
+    def test_detect_threads_chains_via_union_find_across_windows(self) -> None:
+        """Overlapping windows transitively merge clusters via union-find."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now, window_days=20)
+        # Fragments at days -40, -25, -10 — A↔B (15d apart) and B↔C (15d
+        # apart) both within the 20-day window, but A↔C (30d) would not
+        # connect on its own. Union-find must chain them via B.
+        fragments = [
+            _make_fragment(
+                "Anchor One",
+                created=now - timedelta(days=40),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "Anchor Two",
+                created=now - timedelta(days=25),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "Anchor Three",
+                created=now - timedelta(days=10),
+                primary_freq=Frequency.F1,
+            ),
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+        assert result[0].fragment_count == 3
+
+    def test_detect_threads_status_active(self) -> None:
+        """Last seen within ACTIVE_DAYS yields ACTIVE status."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                f"Recent {i}",
+                created=now - timedelta(days=10 - i),
+                primary_freq=Frequency.F1,
+            )
+            for i in range(3)
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+        assert result[0].status == ThreadStatus.ACTIVE.value
+
+    def test_detect_threads_status_dormant(self) -> None:
+        """Last seen between 30 and 180 days yields DORMANT status."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now, window_days=60)
+        fragments = [
+            _make_fragment(
+                f"Older {i}",
+                created=now - timedelta(days=120 - i * 10),
+                primary_freq=Frequency.F1,
+            )
+            for i in range(3)
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+        assert result[0].status == ThreadStatus.DORMANT.value
+
+    def test_detect_threads_status_resolved(self) -> None:
+        """Last seen more than 180 days ago yields RESOLVED status."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now, window_days=120)
+        fragments = [
+            _make_fragment(
+                f"Ancient {i}",
+                created=now - timedelta(days=400 - i * 30),
+                primary_freq=Frequency.F1,
+            )
+            for i in range(3)
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+        assert result[0].status == ThreadStatus.RESOLVED.value
+
+    def test_detect_threads_title_from_common_keywords(self) -> None:
+        """Titles are built from the most common non-stopword keywords."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                "The Garden Project Begins",
+                created=now - timedelta(days=10),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "Garden Update Notes",
+                created=now - timedelta(days=5),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "Garden Harvest Reflection",
+                created=now - timedelta(days=1),
+                primary_freq=Frequency.F1,
+            ),
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+        assert "Garden" in result[0].title
+
+    def test_detect_threads_title_falls_back_to_first_fragment(self) -> None:
+        """No content words → fallback to truncated first-fragment title."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                "X",
+                created=now - timedelta(days=10),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "Y",
+                created=now - timedelta(days=5),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "Z",
+                created=now - timedelta(days=1),
+                primary_freq=Frequency.F1,
+            ),
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+        # First fragment by created order is "X" (oldest)
+        assert result[0].title == "X"
+
+    def test_detect_threads_frequency_affinity_picks_most_common(self) -> None:
+        """Frequency affinity reflects the dominant primary frequency(s)."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                "One",
+                created=now - timedelta(days=10),
+                primary_freq=Frequency.F2,
+                secondary_freqs=[Frequency.F7],
+            ),
+            _make_fragment(
+                "Two",
+                created=now - timedelta(days=5),
+                primary_freq=Frequency.F2,
+                secondary_freqs=[Frequency.F7],
+            ),
+            _make_fragment(
+                "Three",
+                created=now - timedelta(days=1),
+                primary_freq=Frequency.F2,
+                secondary_freqs=[Frequency.F7],
+            ),
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+        assert Frequency.F2.value in result[0].frequency_affinity
+
+    def test_detect_threads_uses_embeddings_when_provided(self) -> None:
+        """High-similarity embeddings link frequency-aligned fragments."""
+        now = datetime(2026, 4, 1)
+        embeddings = {
+            "frag-1": [1.0, 0.0, 0.0],
+            "frag-2": [1.0, 0.0, 0.0],
+            "frag-3": [1.0, 0.0, 0.0],
+        }
+        detector = ThreadDetector(embeddings=embeddings, now=now)
+        fragments = [
+            Fragment(
+                id="frag-1",
+                title="Embeds One",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=now - timedelta(days=10),
+                frequency=FrequencyClassification(primary=Frequency.F1),
+            ),
+            Fragment(
+                id="frag-2",
+                title="Embeds Two",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=now - timedelta(days=5),
+                frequency=FrequencyClassification(primary=Frequency.F1),
+            ),
+            Fragment(
+                id="frag-3",
+                title="Embeds Three",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=now - timedelta(days=1),
+                frequency=FrequencyClassification(primary=Frequency.F1),
+            ),
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+
+    def test_detect_threads_low_embedding_similarity_blocks_link(self) -> None:
+        """Orthogonal embeddings prevent topic consistency even with shared freq."""
+        now = datetime(2026, 4, 1)
+        embeddings = {
+            "frag-1": [1.0, 0.0, 0.0],
+            "frag-2": [0.0, 1.0, 0.0],
+            "frag-3": [0.0, 0.0, 1.0],
+        }
+        detector = ThreadDetector(embeddings=embeddings, now=now)
+        fragments = [
+            Fragment(
+                id="frag-1",
+                title="Alpha",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=now - timedelta(days=10),
+                frequency=FrequencyClassification(primary=Frequency.F1),
+            ),
+            Fragment(
+                id="frag-2",
+                title="Beta",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=now - timedelta(days=5),
+                frequency=FrequencyClassification(primary=Frequency.F1),
+            ),
+            Fragment(
+                id="frag-3",
+                title="Gamma",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=now - timedelta(days=1),
+                frequency=FrequencyClassification(primary=Frequency.F1),
+            ),
+        ]
+        result = detector.detect_threads(fragments)
+        assert result == []
+
+    def test_detect_threads_unclassified_frequency_does_not_link(self) -> None:
+        """UNCLASSIFIED frequencies provide no signal for clustering."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                f"Unclassified {i}",
+                created=now - timedelta(days=10 - i),
+                primary_freq=Frequency.UNCLASSIFIED,
+            )
+            for i in range(3)
+        ]
+        result = detector.detect_threads(fragments)
+        assert result == []
+
+    def test_detect_threads_threads_sorted_by_first_seen(self) -> None:
+        """Returned threads are ordered by ``first_seen`` ascending."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now, window_days=10)
+        fragments = [
+            # Cluster A around -100 days (frequency F1)
+            _make_fragment(
+                f"Old A {i}",
+                created=now - timedelta(days=100 - i),
+                primary_freq=Frequency.F1,
+            )
+            for i in range(3)
+        ] + [
+            # Cluster B around -10 days (frequency F2)
+            _make_fragment(
+                f"New B {i}",
+                created=now - timedelta(days=10 - i),
+                primary_freq=Frequency.F2,
+            )
+            for i in range(3)
+        ]
+        result = detector.detect_threads(fragments)
+        assert len(result) == 2
+        assert result[0].first_seen < result[1].first_seen
+
+    def test_thread_members_property_exposes_membership(self) -> None:
+        """The ``thread_members`` property reports detected memberships."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                f"Member {i}",
+                created=now - timedelta(days=10 - i),
+                primary_freq=Frequency.F1,
+            )
+            for i in range(3)
+        ]
+        threads = detector.detect_threads(fragments)
+        assert len(threads) == 1
+        members = detector.thread_members[threads[0].id]
+        assert set(members) == {f.id for f in fragments}
+
+    def test_thread_members_resets_on_new_detection(self) -> None:
+        """A fresh detect_threads run replaces any prior membership map."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        first = [
+            _make_fragment(
+                f"First {i}",
+                created=now - timedelta(days=10 - i),
+                primary_freq=Frequency.F1,
+            )
+            for i in range(3)
+        ]
+        detector.detect_threads(first)
+        # Second run with too few fragments should clear membership
+        detector.detect_threads([_make_fragment("Solo")])
+        assert detector.thread_members == {}
+
+
+class TestThreadAssignment:
+    """Tests for assign_fragments_to_threads."""
+
+    def test_assignment_adds_wikilinks(self) -> None:
+        """Fragments belonging to a thread receive a wiki-link."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                "Garden Notes A",
+                created=now - timedelta(days=10),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "Garden Notes B",
+                created=now - timedelta(days=5),
+                primary_freq=Frequency.F1,
+            ),
+            _make_fragment(
+                "Garden Notes C",
+                created=now - timedelta(days=1),
+                primary_freq=Frequency.F1,
+            ),
+        ]
+        threads = detector.detect_threads(fragments)
+        updated = detector.assign_fragments_to_threads(fragments, threads)
+        assert len(threads) == 1
+        wikilink = f"[[{threads[0].title}]]"
+        for frag in updated:
+            assert wikilink in frag.threads
+
+    def test_assignment_updates_thread_fragment_count(self) -> None:
+        """assign_fragments_to_threads refreshes each thread's fragment_count."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                f"Pebbles {i}",
+                created=now - timedelta(days=10 - i),
+                primary_freq=Frequency.F3,
+            )
+            for i in range(3)
+        ]
+        threads = detector.detect_threads(fragments)
+        # Mutate count to ensure it's reset
+        threads[0].fragment_count = 0
+        detector.assign_fragments_to_threads(fragments, threads)
+        assert threads[0].fragment_count == 3
+
+    def test_assignment_skips_unassigned_fragments(self) -> None:
+        """Fragments not in any thread are returned unchanged."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        cluster = [
+            _make_fragment(
+                f"Topic {i}",
+                created=now - timedelta(days=10 - i),
+                primary_freq=Frequency.F1,
+            )
+            for i in range(3)
+        ]
+        loner = _make_fragment(
+            "Loner",
+            created=now - timedelta(days=2),
+            primary_freq=Frequency.F9,
+        )
+        fragments = [*cluster, loner]
+        threads = detector.detect_threads(fragments)
+        updated = detector.assign_fragments_to_threads(fragments, threads)
+        loner_updated = next(f for f in updated if f.id == loner.id)
+        assert loner_updated is loner
+        assert loner_updated.threads == []
+
+    def test_assignment_does_not_duplicate_existing_links(self) -> None:
+        """Pre-existing wiki-links are not duplicated."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                f"Tea Ceremony {i}",
+                created=now - timedelta(days=10 - i),
+                primary_freq=Frequency.F4,
+            )
+            for i in range(3)
+        ]
+        threads = detector.detect_threads(fragments)
+        wikilink = f"[[{threads[0].title}]]"
+        # Pre-add the wikilink to one fragment
+        fragments[0] = fragments[0].model_copy(update={"threads": [wikilink]})
+        detector._thread_members[threads[0].id] = [f.id for f in fragments]
+        updated = detector.assign_fragments_to_threads(fragments, threads)
+        assert updated[0].threads.count(wikilink) == 1
+
+    def test_assignment_returns_new_fragment_instances(self) -> None:
+        """Assigned fragments are returned as fresh copies (no mutation)."""
+        now = datetime(2026, 4, 1)
+        detector = ThreadDetector(now=now)
+        fragments = [
+            _make_fragment(
+                f"Sourdough {i}",
+                created=now - timedelta(days=10 - i),
+                primary_freq=Frequency.F5,
+            )
+            for i in range(3)
+        ]
+        threads = detector.detect_threads(fragments)
+        updated = detector.assign_fragments_to_threads(fragments, threads)
+        for original, new in zip(fragments, updated, strict=True):
+            assert original.threads == []
+            assert new.threads != []
+
+
+class TestThreadMergeSuggestions:
+    """Tests for the suggest_merges heuristic."""
+
+    def test_suggest_merges_flags_overlapping_titles(self) -> None:
+        """Threads with shared title words and frequencies are flagged."""
+        detector = ThreadDetector()
+        thread_a = Thread(
+            title="Garden Project",
+            frequency_affinity=[Frequency.F2],
+        )
+        thread_b = Thread(
+            title="Garden Updates",
+            frequency_affinity=[Frequency.F2],
+        )
+        suggestions = detector.suggest_merges([thread_a, thread_b])
+        assert len(suggestions) == 1
+        assert suggestions[0] == (thread_a, thread_b)
+
+    def test_suggest_merges_ignores_disjoint_titles(self) -> None:
+        """Threads with no shared content words are not suggested."""
+        detector = ThreadDetector()
+        thread_a = Thread(
+            title="Apple Pie Recipe",
+            frequency_affinity=[Frequency.F1],
+        )
+        thread_b = Thread(
+            title="Mountain Hike",
+            frequency_affinity=[Frequency.F1],
+        )
+        suggestions = detector.suggest_merges([thread_a, thread_b])
+        assert suggestions == []
+
+    def test_suggest_merges_requires_frequency_overlap(self) -> None:
+        """Identical titles with disjoint frequency affinities don't merge."""
+        detector = ThreadDetector()
+        thread_a = Thread(
+            title="Cooking Notes",
+            frequency_affinity=[Frequency.F1],
+        )
+        thread_b = Thread(
+            title="Cooking Notes",
+            frequency_affinity=[Frequency.F9],
+        )
+        suggestions = detector.suggest_merges([thread_a, thread_b])
+        assert suggestions == []
+
+    def test_suggest_merges_empty_input(self) -> None:
+        """Empty thread list returns no suggestions."""
+        detector = ThreadDetector()
+        assert detector.suggest_merges([]) == []
+
+    def test_suggest_merges_skips_titles_without_content_words(self) -> None:
+        """Single-letter titles produce no merges."""
+        detector = ThreadDetector()
+        thread_a = Thread(title="X", frequency_affinity=[Frequency.F1])
+        thread_b = Thread(title="X", frequency_affinity=[Frequency.F1])
+        assert detector.suggest_merges([thread_a, thread_b]) == []
 
 
 # ---- EddyDetector Tests ----


### PR DESCRIPTION
## Summary

Replaces the `ThreadDetector` stub with a full sliding time window + topic-consistency implementation, closing #31.

- **Detection**: Fragments are sorted chronologically and unioned when they share a classified frequency (primary or secondary) and, when embeddings are supplied, exceed the cosine-similarity threshold (default `0.6`) within a configurable sliding window (default `30` days). A disjoint-set (union-find) structure transitively merges clusters that span multiple windows. Clusters below `min_fragments` (default `3`) are dropped.
- **Thread construction**: Each cluster produces a `Thread` with a title generated from the most common non-stopword content words, `frequency_affinity` from dominant primary frequencies, `first_seen`/`last_seen` from member timestamps, `fragment_count` from cluster size, and `status` derived from recency — `ACTIVE` (≤30d), `DORMANT` (31–180d), `RESOLVED` (>180d).
- **Assignment**: `assign_fragments_to_threads` appends `[[Thread Title]]` wiki-links to each member fragment's `threads` frontmatter (no duplicates) and refreshes `thread.fragment_count`.
- **Merge suggestions**: `suggest_merges` flags thread pairs whose title content-word Jaccard similarity exceeds the configured threshold and whose frequency affinities overlap.
- **Pipeline wiring**: `LinkingPipeline.run` now passes stage-1 embeddings into the detector, honours `linking_config.thread_min_fragments`, and assigns threads to fragments.

## Test plan

- [x] `./scripts/test.sh` — 1966 passed, 1 skipped (Ollama) • 30 new tests across `TestThreadDetector`, `TestThreadAssignment`, `TestThreadMergeSuggestions`
- [x] `./scripts/coverage.sh` — 94.67% project coverage; 95.90% on `creek/link/threads.py` (≥90% threshold)
- [x] `./scripts/lint.sh` — zero violations
- [x] `./scripts/format.sh --check` — all files formatted
- [x] `./scripts/complexity.sh` — rank A (≤10 per function)
- [x] `./scripts/security.sh` (bandit) — no issues identified
- [x] `./scripts/typecheck.sh` — all errors on touched files resolved (net −1 vs main)

### Acceptance Criteria (from #31)
- [x] Threads detected from temporally consistent fragment clusters
- [x] Thread status assigned based on recency (ACTIVE/DORMANT/RESOLVED)
- [x] Fragments linked to their threads via frontmatter wiki-links
- [x] Thread titles generated from common themes (content-word frequency)
- [x] Minimum fragment threshold enforced (configurable)
- [x] Thread merging suggested for duplicates (title Jaccard + frequency overlap)
- [x] Tests with time-series fragment fixtures

https://claude.ai/code/session_01MXpCUPw5k7YBb32tNVr1Cu