### PR TITLE
feat(generate): synchronicity detection for cross-source resonances (#39)

### DIFF
--- a/creek-tools/creek/generate/__init__.py
+++ b/creek-tools/creek/generate/__init__.py
@@ -9,10 +9,17 @@ from creek.generate.decisions import (
     decision_from_note,
 )
 from creek.generate.indexes import FREQUENCY_COLORS, FREQUENCY_NAMES, IndexGenerator
+from creek.generate.synchronicity import (
+    DEFAULT_MIN_TIME_GAP_DAYS,
+    DEFAULT_SIMILARITY_THRESHOLD,
+    SynchronicityDetector,
+)
 from creek.generate.tags import TagGardenGenerator, TagScanResult
 
 __all__ = [
     "DECISION_KEYWORDS",
+    "DEFAULT_MIN_TIME_GAP_DAYS",
+    "DEFAULT_SIMILARITY_THRESHOLD",
     "FREQUENCY_COLORS",
     "FREQUENCY_NAMES",
     "PRACTICE_MAP",
@@ -20,6 +27,7 @@ __all__ = [
     "DecisionContextGatherer",
     "DecisionDetector",
     "IndexGenerator",
+    "SynchronicityDetector",
     "TagGardenGenerator",
     "TagScanResult",
     "decision_from_note",

--- a/creek-tools/creek/generate/synchronicity.py
+++ b/creek-tools/creek/generate/synchronicity.py
@@ -1,0 +1,275 @@
+"""Synchronicity detection — flag surprising cross-source resonances.
+
+Section 10.3 of the Creek Ontology describes *synchronicities* as
+meaningful coincidences: fragments from very different sources and times
+that arrive at near-identical meaning.  The linking pass already surfaces
+resonance pairs via cosine similarity; this module filters those
+resonances against four criteria and, when a pair qualifies, writes a
+reflection note to ``10-Liminal/Synchronicities/``.
+
+The criteria are deliberately strict:
+
+1. Semantic similarity strictly greater than 0.9.
+2. The two fragments come from *different* source platforms.
+3. Their creation timestamps are separated by more than 30 days.
+4. The pair is not obviously about the same project/task (status-update
+   phrases and shared proper-noun project names are filtered out).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.models import Synchronicity
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from creek.models import Fragment
+
+DEFAULT_SIMILARITY_THRESHOLD: float = 0.9
+"""Cosine similarity must exceed this value to qualify as a synchronicity."""
+
+DEFAULT_MIN_TIME_GAP_DAYS: int = 30
+"""Fragments must be separated by more than this many days."""
+
+_STATUS_UPDATE_PHRASES: tuple[str, ...] = (
+    "still working on",
+    "progress on",
+    "update on",
+)
+"""Phrases that mark a fragment as a status update rather than a synchronicity."""
+
+_PROPER_NOUN_PATTERN = re.compile(r"(?<!^)\b([A-Z][a-zA-Z0-9]{2,})\b")
+"""Match proper-noun-like tokens that are not at the start of the string."""
+
+_REFLECTION_PROMPT = (
+    "These fragments emerged independently but echo each other. "
+    "What pattern is trying to surface?"
+)
+
+
+def _extract_proper_nouns(title: str) -> set[str]:
+    """Return proper-noun-like tokens from *title*.
+
+    A proper noun is approximated as a capitalised word of three or more
+    characters that does not sit at the start of the string.  The
+    sentence-initial guard prevents ordinary titles (``"Forgiveness keeps
+    arriving"``) from being treated as shared project names.
+
+    Args:
+        title: The fragment title to scan.
+
+    Returns:
+        A set of candidate proper-noun tokens in their original casing.
+    """
+    return {match.group(1) for match in _PROPER_NOUN_PATTERN.finditer(title)}
+
+
+def _has_status_update_phrase(title: str) -> bool:
+    """Return ``True`` if *title* contains a status-update phrase."""
+    lowered = title.lower()
+    return any(phrase in lowered for phrase in _STATUS_UPDATE_PHRASES)
+
+
+def _share_project(title_a: str, title_b: str) -> bool:
+    """Return ``True`` if the two titles share a proper-noun project name."""
+    return bool(_extract_proper_nouns(title_a) & _extract_proper_nouns(title_b))
+
+
+class SynchronicityDetector:
+    """Filter resonances down to meaningful cross-source synchronicities.
+
+    Attributes:
+        similarity_threshold: Minimum cosine similarity (strictly greater
+            than) required.  Defaults to :data:`DEFAULT_SIMILARITY_THRESHOLD`.
+        min_time_gap_days: Minimum number of days between the two
+            fragments' creation timestamps (strictly greater than).
+            Defaults to :data:`DEFAULT_MIN_TIME_GAP_DAYS`.
+    """
+
+    def __init__(
+        self,
+        similarity_threshold: float = DEFAULT_SIMILARITY_THRESHOLD,
+        min_time_gap_days: int = DEFAULT_MIN_TIME_GAP_DAYS,
+    ) -> None:
+        """Initialise the detector with optional threshold overrides.
+
+        Args:
+            similarity_threshold: Minimum cosine similarity (exclusive).
+            min_time_gap_days: Minimum creation-time gap in days (exclusive).
+        """
+        self.similarity_threshold = similarity_threshold
+        self.min_time_gap_days = min_time_gap_days
+
+    def detect_synchronicities(
+        self,
+        resonances: list[tuple[str, str, float]],
+        fragments: dict[str, Fragment],
+    ) -> list[Synchronicity]:
+        """Filter *resonances* into :class:`Synchronicity` records.
+
+        Args:
+            resonances: Tuples of ``(fragment_id_a, fragment_id_b,
+                similarity)`` as emitted by
+                :class:`~creek.link.embeddings.EmbeddingLinker`.
+            fragments: Mapping of fragment ID to :class:`Fragment` used
+                to inspect metadata.  Resonances referencing unknown IDs
+                are silently skipped.
+
+        Returns:
+            A list of :class:`Synchronicity` objects, one per qualifying
+            resonance, with the earlier fragment stored in
+            ``fragment_a_id``.
+        """
+        results: list[Synchronicity] = []
+        for frag_a_id, frag_b_id, similarity in resonances:
+            frag_a = fragments.get(frag_a_id)
+            frag_b = fragments.get(frag_b_id)
+            if frag_a is None or frag_b is None:
+                continue
+            sync = self._evaluate_pair(frag_a, frag_b, similarity)
+            if sync is not None:
+                results.append(sync)
+        return results
+
+    def _evaluate_pair(
+        self,
+        frag_a: Fragment,
+        frag_b: Fragment,
+        similarity: float,
+    ) -> Synchronicity | None:
+        """Return a :class:`Synchronicity` if the pair passes every criterion.
+
+        Args:
+            frag_a: First fragment in the resonance pair.
+            frag_b: Second fragment in the resonance pair.
+            similarity: Cosine similarity score for the pair.
+
+        Returns:
+            A :class:`Synchronicity` record, or ``None`` if any criterion
+            fails.
+        """
+        if similarity <= self.similarity_threshold:
+            return None
+        if frag_a.source.platform == frag_b.source.platform:
+            return None
+
+        earlier, later = self._chronological_pair(frag_a, frag_b)
+        gap_days = (later.created - earlier.created).days
+        if gap_days <= self.min_time_gap_days:
+            return None
+
+        if _has_status_update_phrase(earlier.title) or _has_status_update_phrase(
+            later.title,
+        ):
+            return None
+        if _share_project(earlier.title, later.title):
+            return None
+
+        return Synchronicity(
+            fragment_a_id=earlier.id,
+            fragment_b_id=later.id,
+            similarity=similarity,
+            time_gap_days=gap_days,
+            source_a=earlier.source.platform,
+            source_b=later.source.platform,
+        )
+
+    @staticmethod
+    def _chronological_pair(
+        frag_a: Fragment,
+        frag_b: Fragment,
+    ) -> tuple[Fragment, Fragment]:
+        """Return the pair ordered ``(earlier, later)`` by creation time."""
+        if frag_a.created <= frag_b.created:
+            return frag_a, frag_b
+        return frag_b, frag_a
+
+    def create_synchronicity_note(
+        self,
+        sync: Synchronicity,
+        fragments: dict[str, Fragment],
+        vault_path: Path,
+    ) -> Path:
+        """Write a synchronicity reflection note to the vault.
+
+        The note lives at ``{vault_path}/10-Liminal/Synchronicities/`` and
+        carries YAML frontmatter describing the pair plus a body with
+        fragment excerpts, the similarity score, the time gap, and the
+        reflection prompt from Section 10.3 of the ontology.
+
+        Args:
+            sync: The synchronicity to serialise.
+            fragments: Mapping that must contain both referenced fragments.
+            vault_path: Root of the Obsidian vault.
+
+        Returns:
+            Path to the written markdown file.
+
+        Raises:
+            KeyError: If either referenced fragment is missing from
+                *fragments*.
+        """
+        frag_a = fragments[sync.fragment_a_id]
+        frag_b = fragments[sync.fragment_b_id]
+
+        target_dir = vault_path / "10-Liminal" / "Synchronicities"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        note_path = target_dir / f"{sync.id}.md"
+
+        body = self._render_body(sync, frag_a, frag_b)
+
+        post = frontmatter.Post(
+            content=body,
+            type="synchronicity",
+            id=sync.id,
+            fragments=[f"[[{frag_a.id}]]", f"[[{frag_b.id}]]"],
+            similarity=round(sync.similarity, 4),
+            time_gap_days=sync.time_gap_days,
+            sources=[str(sync.source_a), str(sync.source_b)],
+            tags=list(sync.tags),
+        )
+        note_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return note_path
+
+    @staticmethod
+    def _render_body(
+        sync: Synchronicity,
+        frag_a: Fragment,
+        frag_b: Fragment,
+    ) -> str:
+        """Render the markdown body for a synchronicity note.
+
+        Args:
+            sync: The synchronicity being documented.
+            frag_a: Earlier fragment in the pair.
+            frag_b: Later fragment in the pair.
+
+        Returns:
+            A markdown string with fragment excerpts, numeric details,
+            the reflection prompt, and the ``#synchronicity`` tag.
+        """
+        lines = [
+            "## Fragment excerpts",
+            "",
+            f"- **{frag_a.source.platform}** ({frag_a.created.date().isoformat()}): "
+            f"{frag_a.title}",
+            f"- **{frag_b.source.platform}** ({frag_b.created.date().isoformat()}): "
+            f"{frag_b.title}",
+            "",
+            "## Details",
+            "",
+            f"- Similarity: {sync.similarity:.4f}",
+            f"- Time gap: {sync.time_gap_days} days",
+            "",
+            "## Reflection prompt",
+            "",
+            _REFLECTION_PROMPT,
+            "",
+            "#synchronicity",
+        ]
+        return "\n".join(lines)

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -245,6 +245,11 @@ def _generate_wave_id() -> str:
     return f"wave-{uuid.uuid4().hex[:8]}"
 
 
+def _generate_sync_id() -> str:
+    """Generate a unique synchronicity ID with prefix 'sync-'."""
+    return f"sync-{uuid.uuid4().hex[:8]}"
+
+
 # ---- Nested Models ----
 
 
@@ -450,3 +455,38 @@ class WavelengthObservation(BaseModel):
     notes: str = ""
     fragment_refs: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
+
+
+class Synchronicity(BaseModel):
+    """A meaningful coincidence between two cross-source fragments.
+
+    Synchronicities surface when the linking pass discovers fragments from
+    very different sources and times that are semantically near-identical.
+    They live in ``10-Liminal/Synchronicities/`` and are intended as
+    reflective prompts rather than firm knowledge links.
+
+    Attributes:
+        id: Unique identifier prefixed ``sync-``.
+        fragment_a_id: ID of the earlier fragment in the pair.
+        fragment_b_id: ID of the later fragment in the pair.
+        similarity: Cosine similarity score between the two fragments
+            (must be > 0.9 to qualify as a synchronicity).
+        time_gap_days: Absolute gap in days between the fragments'
+            creation timestamps.
+        source_a: Source platform of the first fragment.
+        source_b: Source platform of the second fragment (must differ
+            from ``source_a``).
+        tags: Obsidian tags applied to the synchronicity note.
+    """
+
+    model_config = ConfigDict(use_enum_values=True)
+
+    type: str = "synchronicity"
+    id: str = Field(default_factory=_generate_sync_id)
+    fragment_a_id: str
+    fragment_b_id: str
+    similarity: float
+    time_gap_days: int
+    source_a: SourcePlatform
+    source_b: SourcePlatform
+    tags: list[str] = Field(default_factory=lambda: ["synchronicity"])

--- a/creek-tools/tests/test_synchronicity.py
+++ b/creek-tools/tests/test_synchronicity.py
@@ -1,0 +1,653 @@
+"""Tests for creek.generate.synchronicity — synchronicity detection.
+
+Tests cover the SynchronicityDetector class and its two public methods:
+detect_synchronicities (filtering resonances against synchronicity criteria)
+and create_synchronicity_note (writing reflection notes to
+``10-Liminal/Synchronicities/``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.generate.synchronicity import (
+    DEFAULT_MIN_TIME_GAP_DAYS,
+    DEFAULT_SIMILARITY_THRESHOLD,
+    SynchronicityDetector,
+)
+from creek.models import (
+    Fragment,
+    FragmentSource,
+    SourcePlatform,
+    Synchronicity,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---- Fixtures ----
+
+
+@pytest.fixture()
+def vault_path(tmp_path: Path) -> Path:
+    """Create a minimal vault structure with the Liminal folder."""
+    (tmp_path / "10-Liminal" / "Synchronicities").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+@pytest.fixture()
+def detector() -> SynchronicityDetector:
+    """Create a SynchronicityDetector instance with default thresholds."""
+    return SynchronicityDetector()
+
+
+def _make_fragment(
+    *,
+    frag_id: str,
+    title: str,
+    platform: SourcePlatform,
+    created: datetime,
+) -> Fragment:
+    """Construct a test Fragment with the given identifying fields."""
+    return Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=platform),
+        created=created,
+    )
+
+
+@pytest.fixture()
+def cross_source_pair() -> dict[str, Fragment]:
+    """Return two fragments on different platforms separated by >30 days."""
+    return {
+        "frag-a": _make_fragment(
+            frag_id="frag-a",
+            title="the river remembers every stone it has touched",
+            platform=SourcePlatform.DISCORD,
+            created=datetime(2025, 1, 5, 10, 0, 0),
+        ),
+        "frag-b": _make_fragment(
+            frag_id="frag-b",
+            title="the river remembers every stone it has touched",
+            platform=SourcePlatform.JOURNAL,
+            created=datetime(2025, 4, 20, 10, 0, 0),
+        ),
+    }
+
+
+@pytest.fixture()
+def same_source_pair() -> dict[str, Fragment]:
+    """Return two fragments on the same platform."""
+    return {
+        "frag-a": _make_fragment(
+            frag_id="frag-a",
+            title="the river remembers every stone",
+            platform=SourcePlatform.JOURNAL,
+            created=datetime(2025, 1, 5, 10, 0, 0),
+        ),
+        "frag-b": _make_fragment(
+            frag_id="frag-b",
+            title="the river remembers every stone",
+            platform=SourcePlatform.JOURNAL,
+            created=datetime(2025, 4, 20, 10, 0, 0),
+        ),
+    }
+
+
+@pytest.fixture()
+def close_time_pair() -> dict[str, Fragment]:
+    """Return cross-source fragments less than 30 days apart."""
+    return {
+        "frag-a": _make_fragment(
+            frag_id="frag-a",
+            title="forgiveness keeps arriving unannounced",
+            platform=SourcePlatform.DISCORD,
+            created=datetime(2025, 1, 5, 10, 0, 0),
+        ),
+        "frag-b": _make_fragment(
+            frag_id="frag-b",
+            title="forgiveness keeps arriving unannounced",
+            platform=SourcePlatform.JOURNAL,
+            created=datetime(2025, 1, 20, 10, 0, 0),
+        ),
+    }
+
+
+# ---- Module Constants ----
+
+
+class TestConstants:
+    """Tests for module-level threshold constants."""
+
+    def test_similarity_threshold_is_point_nine(self) -> None:
+        """Threshold sits at 0.9; detector accepts strictly greater values."""
+        assert pytest.approx(0.9) == DEFAULT_SIMILARITY_THRESHOLD
+
+    def test_time_gap_default_is_30_days(self) -> None:
+        """Default minimum gap between fragments is 30 days."""
+        assert DEFAULT_MIN_TIME_GAP_DAYS == 30
+
+
+# ---- Detector Init ----
+
+
+class TestSynchronicityDetectorInit:
+    """Tests for SynchronicityDetector.__init__."""
+
+    def test_defaults(self) -> None:
+        """Default constructor uses module-level thresholds."""
+        det = SynchronicityDetector()
+        assert det.similarity_threshold == DEFAULT_SIMILARITY_THRESHOLD
+        assert det.min_time_gap_days == DEFAULT_MIN_TIME_GAP_DAYS
+
+    def test_accepts_overrides(self) -> None:
+        """Constructor should accept threshold overrides."""
+        det = SynchronicityDetector(
+            similarity_threshold=0.95,
+            min_time_gap_days=60,
+        )
+        assert det.similarity_threshold == pytest.approx(0.95)
+        assert det.min_time_gap_days == 60
+
+
+# ---- detect_synchronicities ----
+
+
+class TestDetectSynchronicities:
+    """Tests for SynchronicityDetector.detect_synchronicities."""
+
+    def test_empty_resonances_returns_empty(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """Empty resonance list yields no synchronicities."""
+        assert detector.detect_synchronicities([], {}) == []
+
+    def test_missing_fragment_lookup_skipped(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """Resonances referencing unknown fragment IDs are skipped."""
+        resonances = [("frag-a", "frag-b", 0.95)]
+        result = detector.detect_synchronicities(resonances, {})
+        assert result == []
+
+    def test_detects_valid_cross_source_pair(
+        self,
+        detector: SynchronicityDetector,
+        cross_source_pair: dict[str, Fragment],
+    ) -> None:
+        """Cross-source, >30 day, >0.9 similarity pair is a synchronicity."""
+        resonances = [("frag-a", "frag-b", 0.95)]
+        result = detector.detect_synchronicities(resonances, cross_source_pair)
+        assert len(result) == 1
+        sync = result[0]
+        assert isinstance(sync, Synchronicity)
+        assert sync.similarity == pytest.approx(0.95)
+
+    def test_records_time_gap(
+        self,
+        detector: SynchronicityDetector,
+        cross_source_pair: dict[str, Fragment],
+    ) -> None:
+        """Detected synchronicity records absolute gap in days."""
+        resonances = [("frag-a", "frag-b", 0.95)]
+        result = detector.detect_synchronicities(resonances, cross_source_pair)
+        # 2025-01-05 -> 2025-04-20 = 105 days
+        assert result[0].time_gap_days == 105
+
+    def test_time_gap_is_absolute(
+        self,
+        detector: SynchronicityDetector,
+        cross_source_pair: dict[str, Fragment],
+    ) -> None:
+        """Time gap is always non-negative regardless of argument order."""
+        resonances = [("frag-b", "frag-a", 0.95)]
+        result = detector.detect_synchronicities(resonances, cross_source_pair)
+        assert result[0].time_gap_days == 105
+
+    def test_orders_fragments_chronologically(
+        self,
+        detector: SynchronicityDetector,
+        cross_source_pair: dict[str, Fragment],
+    ) -> None:
+        """Synchronicity stores earlier fragment as ``fragment_a_id``."""
+        resonances = [("frag-b", "frag-a", 0.95)]
+        result = detector.detect_synchronicities(resonances, cross_source_pair)
+        assert result[0].fragment_a_id == "frag-a"
+        assert result[0].fragment_b_id == "frag-b"
+
+    def test_filters_low_similarity(
+        self,
+        detector: SynchronicityDetector,
+        cross_source_pair: dict[str, Fragment],
+    ) -> None:
+        """Resonances below 0.9 are filtered out."""
+        resonances = [("frag-a", "frag-b", 0.85)]
+        result = detector.detect_synchronicities(resonances, cross_source_pair)
+        assert result == []
+
+    def test_boundary_similarity_excluded(
+        self,
+        detector: SynchronicityDetector,
+        cross_source_pair: dict[str, Fragment],
+    ) -> None:
+        """Exactly 0.9 does not qualify — threshold is strict > 0.9."""
+        resonances = [("frag-a", "frag-b", 0.9)]
+        result = detector.detect_synchronicities(resonances, cross_source_pair)
+        assert result == []
+
+    def test_filters_same_source(
+        self,
+        detector: SynchronicityDetector,
+        same_source_pair: dict[str, Fragment],
+    ) -> None:
+        """Fragments from the same source platform are not synchronicities."""
+        resonances = [("frag-a", "frag-b", 0.95)]
+        result = detector.detect_synchronicities(resonances, same_source_pair)
+        assert result == []
+
+    def test_filters_close_in_time(
+        self,
+        detector: SynchronicityDetector,
+        close_time_pair: dict[str, Fragment],
+    ) -> None:
+        """Fragments less than 30 days apart are filtered out."""
+        resonances = [("frag-a", "frag-b", 0.95)]
+        result = detector.detect_synchronicities(resonances, close_time_pair)
+        assert result == []
+
+    def test_filters_status_update_phrases(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """Fragments containing status-update phrases are filtered out."""
+        fragments = {
+            "frag-a": _make_fragment(
+                frag_id="frag-a",
+                title="still working on the migration plan",
+                platform=SourcePlatform.DISCORD,
+                created=datetime(2025, 1, 1, 10, 0, 0),
+            ),
+            "frag-b": _make_fragment(
+                frag_id="frag-b",
+                title="still working on the migration plan",
+                platform=SourcePlatform.JOURNAL,
+                created=datetime(2025, 4, 1, 10, 0, 0),
+            ),
+        }
+        resonances = [("frag-a", "frag-b", 0.95)]
+        assert detector.detect_synchronicities(resonances, fragments) == []
+
+    def test_filters_progress_update_phrase(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """The ``progress on`` phrase also counts as status noise."""
+        fragments = {
+            "frag-a": _make_fragment(
+                frag_id="frag-a",
+                title="progress on the onboarding doc",
+                platform=SourcePlatform.DISCORD,
+                created=datetime(2025, 1, 1, 10, 0, 0),
+            ),
+            "frag-b": _make_fragment(
+                frag_id="frag-b",
+                title="progress on the onboarding doc",
+                platform=SourcePlatform.JOURNAL,
+                created=datetime(2025, 4, 1, 10, 0, 0),
+            ),
+        }
+        resonances = [("frag-a", "frag-b", 0.95)]
+        assert detector.detect_synchronicities(resonances, fragments) == []
+
+    def test_filters_shared_project_proper_noun(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """Shared proper-noun project names filter out the pair."""
+        fragments = {
+            "frag-a": _make_fragment(
+                frag_id="frag-a",
+                title="ideas for Mycelium launch",
+                platform=SourcePlatform.DISCORD,
+                created=datetime(2025, 1, 1, 10, 0, 0),
+            ),
+            "frag-b": _make_fragment(
+                frag_id="frag-b",
+                title="more thoughts on Mycelium scope",
+                platform=SourcePlatform.JOURNAL,
+                created=datetime(2025, 4, 1, 10, 0, 0),
+            ),
+        }
+        resonances = [("frag-a", "frag-b", 0.95)]
+        assert detector.detect_synchronicities(resonances, fragments) == []
+
+    def test_allows_shared_common_words(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """Shared common (non-proper-noun) words do not trigger the filter."""
+        fragments = {
+            "frag-a": _make_fragment(
+                frag_id="frag-a",
+                title="the light moves through the water slowly",
+                platform=SourcePlatform.DISCORD,
+                created=datetime(2025, 1, 1, 10, 0, 0),
+            ),
+            "frag-b": _make_fragment(
+                frag_id="frag-b",
+                title="the light moves through the water slowly",
+                platform=SourcePlatform.JOURNAL,
+                created=datetime(2025, 4, 1, 10, 0, 0),
+            ),
+        }
+        resonances = [("frag-a", "frag-b", 0.95)]
+        result = detector.detect_synchronicities(resonances, fragments)
+        assert len(result) == 1
+
+    def test_ignores_sentence_initial_capitals(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """A capital at sentence start is not treated as a proper-noun match."""
+        fragments = {
+            "frag-a": _make_fragment(
+                frag_id="frag-a",
+                title="Forgiveness keeps arriving",
+                platform=SourcePlatform.DISCORD,
+                created=datetime(2025, 1, 1, 10, 0, 0),
+            ),
+            "frag-b": _make_fragment(
+                frag_id="frag-b",
+                title="Forgiveness keeps arriving",
+                platform=SourcePlatform.JOURNAL,
+                created=datetime(2025, 4, 1, 10, 0, 0),
+            ),
+        }
+        resonances = [("frag-a", "frag-b", 0.95)]
+        result = detector.detect_synchronicities(resonances, fragments)
+        assert len(result) == 1
+
+    def test_multiple_resonances_detected_independently(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """Each qualifying resonance produces exactly one synchronicity."""
+        fragments = {
+            "frag-a": _make_fragment(
+                frag_id="frag-a",
+                title="the river holds everything",
+                platform=SourcePlatform.DISCORD,
+                created=datetime(2025, 1, 1, 10, 0, 0),
+            ),
+            "frag-b": _make_fragment(
+                frag_id="frag-b",
+                title="the river holds everything",
+                platform=SourcePlatform.JOURNAL,
+                created=datetime(2025, 4, 1, 10, 0, 0),
+            ),
+            "frag-c": _make_fragment(
+                frag_id="frag-c",
+                title="silence has a shape",
+                platform=SourcePlatform.EMAIL,
+                created=datetime(2025, 1, 2, 10, 0, 0),
+            ),
+            "frag-d": _make_fragment(
+                frag_id="frag-d",
+                title="silence has a shape",
+                platform=SourcePlatform.ESSAY,
+                created=datetime(2025, 5, 1, 10, 0, 0),
+            ),
+        }
+        resonances = [
+            ("frag-a", "frag-b", 0.95),
+            ("frag-c", "frag-d", 0.96),
+        ]
+        result = detector.detect_synchronicities(resonances, fragments)
+        assert len(result) == 2
+
+    def test_sources_recorded_from_fragments(
+        self,
+        detector: SynchronicityDetector,
+        cross_source_pair: dict[str, Fragment],
+    ) -> None:
+        """Synchronicity records the source platform of each fragment."""
+        resonances = [("frag-a", "frag-b", 0.95)]
+        result = detector.detect_synchronicities(resonances, cross_source_pair)
+        sync = result[0]
+        # Chronological order: frag-a (Discord) first, frag-b (Journal) second
+        assert sync.source_a == SourcePlatform.DISCORD
+        assert sync.source_b == SourcePlatform.JOURNAL
+
+
+# ---- create_synchronicity_note ----
+
+
+@pytest.fixture()
+def sample_sync_pair() -> tuple[Synchronicity, dict[str, Fragment]]:
+    """Return a sample synchronicity with its source fragments."""
+    fragments = {
+        "frag-a": _make_fragment(
+            frag_id="frag-a",
+            title="the river remembers every stone",
+            platform=SourcePlatform.DISCORD,
+            created=datetime(2025, 1, 5, 10, 0, 0),
+        ),
+        "frag-b": _make_fragment(
+            frag_id="frag-b",
+            title="the river remembers every stone",
+            platform=SourcePlatform.JOURNAL,
+            created=datetime(2025, 4, 20, 10, 0, 0),
+        ),
+    }
+    sync = Synchronicity(
+        id="sync-testnote",
+        fragment_a_id="frag-a",
+        fragment_b_id="frag-b",
+        similarity=0.95,
+        time_gap_days=105,
+        source_a=SourcePlatform.DISCORD,
+        source_b=SourcePlatform.JOURNAL,
+    )
+    return sync, fragments
+
+
+class TestCreateSynchronicityNote:
+    """Tests for SynchronicityDetector.create_synchronicity_note."""
+
+    def test_writes_file(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Note should be written to disk."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        assert note_path.exists()
+
+    def test_writes_to_liminal_synchronicities(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Note lives under ``10-Liminal/Synchronicities/``."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        rel = note_path.relative_to(vault_path)
+        assert rel.parts[0] == "10-Liminal"
+        assert rel.parts[1] == "Synchronicities"
+
+    def test_creates_target_dir_if_missing(
+        self,
+        detector: SynchronicityDetector,
+        tmp_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Target directory is created when it does not exist."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, tmp_path)
+        assert note_path.exists()
+
+    def test_frontmatter_has_type(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Frontmatter contains ``type: synchronicity``."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        post = frontmatter.load(str(note_path))
+        assert post["type"] == "synchronicity"
+
+    def test_frontmatter_has_fragment_links(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Frontmatter lists both fragment IDs as links."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        post = frontmatter.load(str(note_path))
+        links = post["fragments"]
+        assert isinstance(links, list)
+        assert any("frag-a" in link for link in links)
+        assert any("frag-b" in link for link in links)
+
+    def test_frontmatter_has_similarity(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Frontmatter includes the similarity score."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        post = frontmatter.load(str(note_path))
+        assert post["similarity"] == pytest.approx(0.95)
+
+    def test_frontmatter_has_time_gap_days(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Frontmatter records the time gap in days."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        post = frontmatter.load(str(note_path))
+        assert post["time_gap_days"] == 105
+
+    def test_frontmatter_has_sources(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Frontmatter enumerates both source platforms."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        post = frontmatter.load(str(note_path))
+        sources = post["sources"]
+        assert isinstance(sources, list)
+        assert "discord" in sources
+        assert "journal" in sources
+
+    def test_body_contains_excerpts(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Body contains an excerpt from each fragment."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        post = frontmatter.load(str(note_path))
+        body = post.content
+        assert "the river remembers every stone" in body
+
+    def test_body_contains_similarity_score(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Body displays the numeric similarity score."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        post = frontmatter.load(str(note_path))
+        assert "0.95" in post.content
+
+    def test_body_contains_time_gap(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Body mentions the time gap in days."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        post = frontmatter.load(str(note_path))
+        assert "105" in post.content
+
+    def test_body_contains_reflection_prompt(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Body includes the reflection prompt from the ontology spec."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        post = frontmatter.load(str(note_path))
+        assert "pattern is trying to surface" in post.content
+
+    def test_body_tags_with_synchronicity(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """The literal ``#synchronicity`` tag appears in the note body."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        post = frontmatter.load(str(note_path))
+        assert "#synchronicity" in post.content
+
+    def test_filename_uses_sync_id(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+        sample_sync_pair: tuple[Synchronicity, dict[str, Fragment]],
+    ) -> None:
+        """Filename embeds the synchronicity ID for uniqueness."""
+        sync, fragments = sample_sync_pair
+        note_path = detector.create_synchronicity_note(sync, fragments, vault_path)
+        assert sync.id in note_path.name
+        assert note_path.suffix == ".md"
+
+    def test_missing_fragment_raises(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+    ) -> None:
+        """Creating a note requires both referenced fragments to be present."""
+        sync = Synchronicity(
+            fragment_a_id="frag-a",
+            fragment_b_id="frag-b",
+            similarity=0.95,
+            time_gap_days=100,
+            source_a=SourcePlatform.DISCORD,
+            source_b=SourcePlatform.JOURNAL,
+        )
+        with pytest.raises(KeyError):
+            detector.create_synchronicity_note(sync, {}, vault_path)


### PR DESCRIPTION
## Summary

Implements Section 10.3 of the Creek Ontology: surface _synchronicities_ —
meaningful coincidences where fragments from different sources and times arrive
at near-identical meaning — from the resonance pairs already emitted by the
linking pass. Closes #39.

- New `creek/generate/synchronicity.py` with `SynchronicityDetector` exposing
  `detect_synchronicities` and `create_synchronicity_note`.
- Filters resonances against all four criteria: strictly > 0.9 similarity,
  different source platforms, > 30-day gap, and not a shared project/task
  (status-update phrases + shared proper-noun project names).
- New `Synchronicity` Pydantic model (with `sync-` ID prefix) carrying
  similarity, time gap, and both source platforms.
- Notes emitted to `10-Liminal/Synchronicities/{sync-id}.md` with
  frontmatter (`type`, `fragments`, `similarity`, `time_gap_days`, `sources`,
  `tags`) and a body containing fragment excerpts, the numeric details,
  the reflection prompt, and the `#synchronicity` tag.

## Acceptance criteria

- [x] Synchronicities detected from high-similarity cross-source resonances
- [x] Time gap and source diversity requirements enforced
- [x] Project/task noise filtered out (status-update phrases + proper-noun overlap)
- [x] Synchronicity notes created with excerpts and reflection prompt
- [x] Tests with synthetic fragment pairs meeting/failing each criterion

## Test plan

- [x] `python -m pytest tests/test_synchronicity.py` — 36/36 green
- [x] `./scripts/check-all.sh` — full suite 2020/2020 green, coverage 94.68%
  (new module 96.74%, missed lines are the `TYPE_CHECKING` block)
- [x] `./scripts/lint.sh` — no violations introduced
- [x] `./scripts/typecheck.sh` — no new mypy errors in changed files
- [x] `./scripts/security.sh` — bandit clean (remaining pip-audit findings are
  pre-existing system-dep vulnerabilities)