### PR TITLE
feat(generate): implement Unnamed weekly digest generator (#37)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -208,6 +208,24 @@ def report(
         generator = TagGardenGenerator(vault_path=vault_path)
         path = generator.generate_garden()
         console.print(f"[bold green]Tag Garden generated: {path}[/bold green]")
+    elif type == "unnamed":
+        from datetime import date as _date
+        from datetime import timedelta as _timedelta
+
+        from creek.generate.unnamed import UnnamedDigestGenerator
+        from creek.link.embeddings import EmbeddingLinker
+
+        linker = EmbeddingLinker(config=config.embeddings)
+        digest_generator = UnnamedDigestGenerator(embedding_linker=linker)
+        today = _date.today()
+        week_start = today - _timedelta(days=today.weekday())
+        digest_path = digest_generator.generate_weekly_digest(
+            vault_path,
+            week_start,
+        )
+        console.print(
+            f"[bold green]Unnamed digest generated: {digest_path}[/bold green]",
+        )
     else:
         console.print(
             f"[bold green]Would report: type={type}, "

--- a/creek-tools/creek/generate/unnamed.py
+++ b/creek-tools/creek/generate/unnamed.py
@@ -1,0 +1,618 @@
+"""Unnamed weekly digest generator.
+
+Section 10.1 of the Creek ontology marks ``10-Liminal/Unnamed/`` as the
+most important research site in the vault: fragments that resist all
+classification. This module surfaces those fragments every week as a
+single reflection note.
+
+The :class:`UnnamedDigestGenerator`:
+
+- Collects fragments created within a seven-day window under
+  ``10-Liminal/Unnamed/`` (skipping the ``Digests/`` subfolder).
+- Clusters them via cosine similarity over sentence-transformer
+  embeddings, using a deliberately loose threshold (default ``0.7``)
+  so that even faint patterns surface.
+- Writes a markdown digest at
+  ``10-Liminal/Unnamed/Digests/<iso-year>-W<week>.md`` containing a
+  fragment list with excerpts, cluster sections when similarity emerges,
+  an open-ended reflection prompt, and week-over-week growth stats.
+- Persists a history record at
+  ``00-Creek-Meta/Processing-Log/unnamed-history.json`` so subsequent
+  runs can report growth deltas.
+
+The digest prompt is intentionally non-prescriptive — it asks what the
+clustered fragments share that the current ontology cannot yet express,
+honouring the ontology's stance that the Unnamed is a generative edge,
+not an error to be corrected.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import frontmatter
+from pydantic import ValidationError
+
+from creek.models import Fragment
+
+if TYPE_CHECKING:
+    from datetime import date
+    from pathlib import Path
+
+    from creek.link.embeddings import EmbeddingLinker
+
+logger = logging.getLogger(__name__)
+
+_UNNAMED_SUBPATH = ("10-Liminal", "Unnamed")
+_DIGESTS_SUBFOLDER = "Digests"
+_HISTORY_SUBPATH = ("00-Creek-Meta", "Processing-Log", "unnamed-history.json")
+_DEFAULT_SIMILARITY_THRESHOLD = 0.7
+_EXCERPT_MAX_CHARS = 200
+_WEEK_LENGTH_DAYS = 7
+_REFLECTION_PROMPT = (
+    "What do these have in common that the current ontology can't express?"
+)
+
+
+@dataclass(frozen=True)
+class _HistoryEntry:
+    """Single history record persisted per digest run.
+
+    Attributes:
+        week_start: ISO week-start date string.
+        fragment_count: Number of unnamed fragments observed that week.
+        total_unnamed: Total unnamed fragments in the vault at run time.
+        cluster_count: Number of similarity clusters detected that week.
+    """
+
+    week_start: str
+    fragment_count: int
+    total_unnamed: int
+    cluster_count: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the entry as a JSON-serialisable dict.
+
+        Returns:
+            Dictionary with all history entry fields.
+        """
+        return {
+            "week_start": self.week_start,
+            "fragment_count": self.fragment_count,
+            "total_unnamed": self.total_unnamed,
+            "cluster_count": self.cluster_count,
+            "generated_at": datetime.now(tz=UTC).isoformat(),
+        }
+
+
+class UnnamedDigestGenerator:
+    """Generate weekly digest notes for the ``10-Liminal/Unnamed/`` folder.
+
+    Each run collects the fragments created within the target week,
+    clusters them via embedding similarity, and writes a markdown
+    reflection note plus a history record.
+
+    Attributes:
+        embedding_linker: Linker used to embed fragments for clustering.
+        similarity_threshold: Cosine similarity cutoff for grouping
+            fragments into a cluster. Defaults to ``0.7`` per the
+            ontology's "loose threshold" guidance.
+    """
+
+    def __init__(
+        self,
+        embedding_linker: EmbeddingLinker,
+        similarity_threshold: float = _DEFAULT_SIMILARITY_THRESHOLD,
+    ) -> None:
+        """Initialise the generator.
+
+        Args:
+            embedding_linker: Linker used to produce embeddings.
+            similarity_threshold: Cosine-similarity cutoff for cluster
+                membership. Lower values surface looser patterns.
+        """
+        self.embedding_linker = embedding_linker
+        self.similarity_threshold = similarity_threshold
+
+    # ---- Public API ----
+
+    def generate_weekly_digest(self, vault_path: Path, week_start: date) -> Path:
+        """Generate the weekly Unnamed digest note.
+
+        Orchestrates fragment collection, clustering, digest rendering,
+        and history persistence.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+            week_start: Monday of the target ISO week (inclusive). The
+                window runs through ``week_start + 6`` days, also
+                inclusive.
+
+        Returns:
+            Path to the generated digest markdown file.
+        """
+        all_unnamed = self.load_unnamed_fragments(vault_path)
+        this_week = self.filter_fragments_in_week(all_unnamed, week_start)
+        clusters = self.detect_unnamed_clusters(this_week)
+        previous = self._load_history(vault_path)
+        body = self._render_body(
+            vault_path,
+            this_week,
+            clusters,
+            week_start,
+            previous=previous,
+        )
+        digest_path = self._write_digest(vault_path, week_start, body)
+        self._append_history(
+            vault_path,
+            _HistoryEntry(
+                week_start=week_start.isoformat(),
+                fragment_count=len(this_week),
+                total_unnamed=len(all_unnamed),
+                cluster_count=len(clusters),
+            ),
+        )
+        logger.info(
+            "Generated unnamed digest for week %s at %s",
+            week_start.isoformat(),
+            digest_path,
+        )
+        return digest_path
+
+    def load_unnamed_fragments(self, vault_path: Path) -> list[Fragment]:
+        """Load every Fragment stored under ``10-Liminal/Unnamed/``.
+
+        Skips the ``Digests/`` subdirectory and any markdown files that
+        cannot be parsed as a :class:`Fragment`.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            List of Fragment objects parsed from the vault.
+        """
+        unnamed_dir = vault_path.joinpath(*_UNNAMED_SUBPATH)
+        if not unnamed_dir.is_dir():
+            return []
+
+        fragments: list[Fragment] = []
+        for md_file in sorted(unnamed_dir.rglob("*.md")):
+            if _DIGESTS_SUBFOLDER in md_file.relative_to(unnamed_dir).parts:
+                continue
+            fragment = _load_fragment(md_file)
+            if fragment is not None:
+                fragments.append(fragment)
+        return fragments
+
+    @staticmethod
+    def filter_fragments_in_week(
+        fragments: list[Fragment],
+        week_start: date,
+    ) -> list[Fragment]:
+        """Return the subset of *fragments* created within the target week.
+
+        The window is ``[week_start, week_start + 7)`` days, matching the
+        standard ISO-week convention (Monday inclusive, next Monday
+        exclusive).
+
+        Args:
+            fragments: Candidate fragments.
+            week_start: Monday of the target ISO week.
+
+        Returns:
+            Fragments whose ``created`` date falls in the window.
+        """
+        week_end = week_start + timedelta(days=_WEEK_LENGTH_DAYS)
+        return [f for f in fragments if week_start <= f.created.date() < week_end]
+
+    def detect_unnamed_clusters(
+        self,
+        fragments: list[Fragment],
+    ) -> list[list[Fragment]]:
+        """Cluster fragments via cosine similarity over their embeddings.
+
+        Uses a union-find over pairs whose cosine similarity meets
+        :attr:`similarity_threshold`. Clusters of size 1 are filtered
+        out (a cluster implies at least one shared neighbour).
+
+        Args:
+            fragments: Fragments to cluster. Must be a list; empty
+                input returns an empty list.
+
+        Returns:
+            Clusters as a list of fragment lists. Each cluster
+            preserves input order. Outer list is sorted by descending
+            cluster size, then by the first member's ID for stability.
+        """
+        if len(fragments) < 2:
+            return []
+
+        embeddings = self.embedding_linker.generate_embeddings(fragments)
+        resonant_pairs = self._resonant_pairs(embeddings)
+        components = _connected_components(len(fragments), resonant_pairs)
+        clusters = [
+            [fragments[idx] for idx in sorted(component)]
+            for component in components
+            if len(component) > 1
+        ]
+        clusters.sort(key=lambda c: (-len(c), c[0].id))
+        return clusters
+
+    # ---- Private helpers ----
+
+    def _resonant_pairs(
+        self,
+        embeddings: dict[str, list[float]],
+    ) -> list[tuple[int, int]]:
+        """Return index pairs whose embeddings meet the similarity threshold.
+
+        Args:
+            embeddings: Mapping of fragment ID to embedding vector, in
+                insertion order matching the original fragment list.
+
+        Returns:
+            List of ``(i, j)`` index pairs with ``i < j``.
+        """
+        ids = list(embeddings)
+        id_to_index = {fid: i for i, fid in enumerate(ids)}
+        linker = self.embedding_linker
+        original_threshold = linker.config.similarity_threshold
+        try:
+            linker.config.similarity_threshold = self.similarity_threshold
+            resonances = linker.find_resonances(embeddings)
+        finally:
+            linker.config.similarity_threshold = original_threshold
+        return [(id_to_index[a], id_to_index[b]) for a, b, _ in resonances]
+
+    def _render_body(
+        self,
+        vault_path: Path,
+        fragments: list[Fragment],
+        clusters: list[list[Fragment]],
+        week_start: date,
+        *,
+        previous: _HistoryEntry | None,
+    ) -> str:
+        """Render the complete markdown body for the digest.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+            fragments: Fragments observed this week.
+            clusters: Similarity clusters detected this week.
+            week_start: Monday of the target ISO week.
+            previous: Previous history entry, or ``None`` when no prior
+                run has been recorded.
+
+        Returns:
+            The markdown body (without frontmatter).
+        """
+        week_end = week_start + timedelta(days=_WEEK_LENGTH_DAYS - 1)
+        excerpts = _build_excerpt_map(vault_path, fragments)
+        sections = [
+            f"# Unnamed Digest — {week_start.isoformat()} to {week_end.isoformat()}\n",
+            _render_fragments_section(fragments, excerpts),
+            _render_clusters_section(clusters),
+            _render_prompt_section(),
+            _render_growth_section(len(fragments), previous),
+        ]
+        return "\n".join(sections)
+
+    def _write_digest(
+        self,
+        vault_path: Path,
+        week_start: date,
+        body: str,
+    ) -> Path:
+        """Serialise the digest note with frontmatter and write it to disk.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+            week_start: Monday of the target ISO week.
+            body: Rendered markdown body.
+
+        Returns:
+            Path to the written digest file.
+        """
+        digests_dir = vault_path.joinpath(*_UNNAMED_SUBPATH, _DIGESTS_SUBFOLDER)
+        digests_dir.mkdir(parents=True, exist_ok=True)
+        iso_year, iso_week, _ = week_start.isocalendar()
+        filename = f"{iso_year}-W{iso_week:02d}.md"
+        week_end = week_start + timedelta(days=_WEEK_LENGTH_DAYS - 1)
+        front_lines = [
+            "---",
+            "type: unnamed-digest",
+            f"week_start: {week_start.isoformat()}",
+            f"week_end: {week_end.isoformat()}",
+            f"generated: {datetime.now(tz=UTC).isoformat()}",
+            "---",
+            "",
+        ]
+        digest_path = digests_dir / filename
+        digest_path.write_text(
+            "\n".join(front_lines) + body,
+            encoding="utf-8",
+        )
+        return digest_path
+
+    @staticmethod
+    def _history_path(vault_path: Path) -> Path:
+        """Return the path to the unnamed-history JSON file.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            Path to the JSON history file.
+        """
+        return vault_path.joinpath(*_HISTORY_SUBPATH)
+
+    def _load_history(self, vault_path: Path) -> _HistoryEntry | None:
+        """Load the most recent history entry, if any.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            The last recorded :class:`_HistoryEntry`, or ``None`` when
+            the history file is missing or empty.
+        """
+        path = self._history_path(vault_path)
+        if not path.exists():
+            return None
+        raw = path.read_text(encoding="utf-8").strip()
+        if not raw:
+            return None
+        entries = json.loads(raw)
+        if not entries:
+            return None
+        last = entries[-1]
+        return _HistoryEntry(
+            week_start=str(last.get("week_start", "")),
+            fragment_count=int(last.get("fragment_count", 0)),
+            total_unnamed=int(last.get("total_unnamed", 0)),
+            cluster_count=int(last.get("cluster_count", 0)),
+        )
+
+    def _append_history(
+        self,
+        vault_path: Path,
+        entry: _HistoryEntry,
+    ) -> None:
+        """Append *entry* to the history log.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+            entry: History record to persist.
+        """
+        path = self._history_path(vault_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        entries: list[dict[str, object]] = []
+        if path.exists():
+            raw = path.read_text(encoding="utf-8").strip()
+            if raw:
+                entries = json.loads(raw)
+        entries.append(entry.to_dict())
+        path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+
+
+# ---- Module-level helpers ----
+
+
+def _load_fragment(md_file: Path) -> Fragment | None:
+    """Parse a markdown file into a :class:`Fragment`, or ``None`` on failure.
+
+    Args:
+        md_file: Path to the markdown file.
+
+    Returns:
+        The parsed Fragment, or ``None`` when the file is not a valid
+        fragment record.
+    """
+    try:
+        post = frontmatter.load(str(md_file))
+    except (OSError, ValueError):
+        logger.debug("Skipping unreadable markdown file: %s", md_file)
+        return None
+    metadata = dict(post.metadata)
+    if metadata.get("type") != "fragment":
+        return None
+    try:
+        return Fragment.model_validate(metadata)
+    except ValidationError:
+        logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
+        return None
+
+
+def _connected_components(
+    node_count: int,
+    edges: list[tuple[int, int]],
+) -> list[list[int]]:
+    """Compute connected components via union-find.
+
+    Args:
+        node_count: Total number of nodes.
+        edges: Undirected edges as ``(u, v)`` pairs.
+
+    Returns:
+        Components as lists of node indices, ordered by ascending root.
+    """
+    parent = list(range(node_count))
+
+    def find(node: int) -> int:
+        while parent[node] != node:
+            parent[node] = parent[parent[node]]
+            node = parent[node]
+        return node
+
+    for u, v in edges:
+        root_u = find(u)
+        root_v = find(v)
+        if root_u != root_v:
+            parent[root_u] = root_v
+
+    buckets: dict[int, list[int]] = {}
+    for node in range(node_count):
+        buckets.setdefault(find(node), []).append(node)
+    return [buckets[root] for root in sorted(buckets)]
+
+
+def _excerpt_from_file(fragment_path: Path | None) -> str:
+    """Read a short excerpt from the fragment's markdown body.
+
+    Args:
+        fragment_path: Path to the fragment file, or ``None`` when
+            unavailable.
+
+    Returns:
+        A trimmed excerpt of at most :data:`_EXCERPT_MAX_CHARS`
+        characters; empty string when no body is present.
+    """
+    if fragment_path is None or not fragment_path.exists():
+        return ""
+    post = frontmatter.load(str(fragment_path))
+    body = (post.content or "").strip().replace("\n", " ")
+    if not body:
+        return ""
+    if len(body) <= _EXCERPT_MAX_CHARS:
+        return body
+    return body[: _EXCERPT_MAX_CHARS - 1].rstrip() + "…"
+
+
+def _find_fragment_file(vault_path: Path, fragment_id: str) -> Path | None:
+    """Locate the markdown file for a fragment by ID, under 10-Liminal/Unnamed/.
+
+    Args:
+        vault_path: Path to the root of the Obsidian vault.
+        fragment_id: Fragment ID to find.
+
+    Returns:
+        The matching markdown path, or ``None`` if not found.
+    """
+    unnamed_dir = vault_path.joinpath(*_UNNAMED_SUBPATH)
+    if not unnamed_dir.is_dir():
+        return None
+    for md_file in unnamed_dir.rglob("*.md"):
+        if _DIGESTS_SUBFOLDER in md_file.relative_to(unnamed_dir).parts:
+            continue
+        post = frontmatter.load(str(md_file))
+        if post.get("id") == fragment_id:
+            return md_file
+    return None
+
+
+def _render_fragments_section(
+    fragments: list[Fragment],
+    excerpts: dict[str, str],
+) -> str:
+    """Render the per-fragment listing section.
+
+    Args:
+        fragments: Fragments observed this week.
+        excerpts: Mapping of fragment ID to a short body excerpt.
+
+    Returns:
+        Markdown string for the Fragments section.
+    """
+    lines = ["## Fragments This Week\n"]
+    if not fragments:
+        lines.append("No unnamed fragments recorded this week.\n")
+        return "\n".join(lines) + "\n"
+    for frag in fragments:
+        created = frag.created.date().isoformat()
+        lines.append(f"### {frag.title}\n")
+        lines.append(f"- Link: [[{frag.id}]]")
+        lines.append(f"- Created: {created}")
+        excerpt = excerpts.get(frag.id, "")
+        if excerpt:
+            lines.append(f"- Excerpt: {excerpt}")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def _build_excerpt_map(
+    vault_path: Path,
+    fragments: list[Fragment],
+) -> dict[str, str]:
+    """Build a mapping of fragment ID to a short markdown body excerpt.
+
+    Args:
+        vault_path: Path to the root of the Obsidian vault.
+        fragments: Fragments whose excerpts to resolve.
+
+    Returns:
+        Mapping of fragment ID to excerpt string.
+    """
+    excerpts: dict[str, str] = {}
+    for frag in fragments:
+        path = _find_fragment_file(vault_path, frag.id)
+        excerpts[frag.id] = _excerpt_from_file(path)
+    return excerpts
+
+
+def _render_clusters_section(clusters: list[list[Fragment]]) -> str:
+    """Render the Similarity Clusters section.
+
+    Args:
+        clusters: Detected clusters.
+
+    Returns:
+        Markdown string for the Similarity Clusters section.
+    """
+    lines = ["## Similarity Clusters\n"]
+    if not clusters:
+        lines.append("No similarity clusters emerged this week.\n")
+        return "\n".join(lines) + "\n"
+    for index, cluster in enumerate(clusters, start=1):
+        lines.append(f"### Cluster {index}\n")
+        for frag in cluster:
+            lines.append(f"- [[{frag.id}]] — {frag.title}")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def _render_prompt_section() -> str:
+    """Render the open-ended reflection prompt section.
+
+    Returns:
+        Markdown string for the Reflection Prompt section.
+    """
+    return (
+        "## Reflection Prompt\n\n"
+        f"> {_REFLECTION_PROMPT}\n\n"
+        "What is the Unnamed asking of the ontology?\n\n"
+    )
+
+
+def _render_growth_section(
+    this_week_count: int,
+    previous: _HistoryEntry | None,
+) -> str:
+    """Render the Week-over-Week Growth section.
+
+    Args:
+        this_week_count: Number of unnamed fragments this week.
+        previous: Previous history entry, or ``None`` when this is the
+            first run.
+
+    Returns:
+        Markdown string for the growth section.
+    """
+    lines = ["## Week-over-Week Growth\n"]
+    lines.append(f"- This week: {this_week_count} unnamed fragment(s)")
+    if previous is None:
+        lines.append("- Previous week: (no prior digest recorded)")
+        lines.append("")
+        return "\n".join(lines) + "\n"
+    delta = this_week_count - previous.fragment_count
+    sign = "+" if delta >= 0 else ""
+    lines.append(
+        f"- Previous week ({previous.week_start}): {previous.fragment_count}"
+        f" unnamed fragment(s)",
+    )
+    lines.append(f"- Change: {sign}{delta}")
+    lines.append("")
+    return "\n".join(lines) + "\n"

--- a/creek-tools/creek/generate/unnamed.py
+++ b/creek-tools/creek/generate/unnamed.py
@@ -28,6 +28,7 @@ not an error to be corrected.
 
 from __future__ import annotations
 
+import itertools
 import json
 import logging
 from dataclasses import dataclass
@@ -35,6 +36,7 @@ from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import frontmatter
+import numpy as np
 from pydantic import ValidationError
 
 from creek.models import Fragment
@@ -129,8 +131,10 @@ class UnnamedDigestGenerator:
         Args:
             vault_path: Path to the root of the Obsidian vault.
             week_start: Monday of the target ISO week (inclusive). The
-                window runs through ``week_start + 6`` days, also
-                inclusive.
+                window is ``[week_start, week_start + 7 days)`` in
+                date terms, which equals ``week_start`` through
+                ``week_start + 6`` days inclusive — the convention also
+                reflected in the rendered ``week_end`` frontmatter.
 
         Returns:
             Path to the generated digest markdown file.
@@ -250,6 +254,10 @@ class UnnamedDigestGenerator:
     ) -> list[tuple[int, int]]:
         """Return index pairs whose embeddings meet the similarity threshold.
 
+        Computes cosine similarity inline rather than delegating to
+        :meth:`EmbeddingLinker.find_resonances` to avoid mutating the
+        linker's shared configuration.
+
         Args:
             embeddings: Mapping of fragment ID to embedding vector, in
                 insertion order matching the original fragment list.
@@ -258,15 +266,18 @@ class UnnamedDigestGenerator:
             List of ``(i, j)`` index pairs with ``i < j``.
         """
         ids = list(embeddings)
-        id_to_index = {fid: i for i, fid in enumerate(ids)}
-        linker = self.embedding_linker
-        original_threshold = linker.config.similarity_threshold
-        try:
-            linker.config.similarity_threshold = self.similarity_threshold
-            resonances = linker.find_resonances(embeddings)
-        finally:
-            linker.config.similarity_threshold = original_threshold
-        return [(id_to_index[a], id_to_index[b]) for a, b, _ in resonances]
+        if len(ids) < 2:
+            return []
+        vectors = np.array([embeddings[fid] for fid in ids], dtype=np.float32)
+        norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+        norms = np.maximum(norms, 1e-10)
+        normalized = vectors / norms
+        similarity_matrix = normalized @ normalized.T
+        pairs: list[tuple[int, int]] = []
+        for i, j in itertools.combinations(range(len(ids)), 2):
+            if float(similarity_matrix[i, j]) >= self.similarity_threshold:
+                pairs.append((i, j))
+        return pairs
 
     def _render_body(
         self,
@@ -309,6 +320,9 @@ class UnnamedDigestGenerator:
     ) -> Path:
         """Serialise the digest note with frontmatter and write it to disk.
 
+        Uses :func:`frontmatter.dumps` for consistency with
+        :class:`creek.vault.writer.VaultWriter`.
+
         Args:
             vault_path: Path to the root of the Obsidian vault.
             week_start: Monday of the target ISO week.
@@ -322,20 +336,15 @@ class UnnamedDigestGenerator:
         iso_year, iso_week, _ = week_start.isocalendar()
         filename = f"{iso_year}-W{iso_week:02d}.md"
         week_end = week_start + timedelta(days=_WEEK_LENGTH_DAYS - 1)
-        front_lines = [
-            "---",
-            "type: unnamed-digest",
-            f"week_start: {week_start.isoformat()}",
-            f"week_end: {week_end.isoformat()}",
-            f"generated: {datetime.now(tz=UTC).isoformat()}",
-            "---",
-            "",
-        ]
-        digest_path = digests_dir / filename
-        digest_path.write_text(
-            "\n".join(front_lines) + body,
-            encoding="utf-8",
+        post = frontmatter.Post(
+            content=body,
+            type="unnamed-digest",
+            week_start=week_start.isoformat(),
+            week_end=week_end.isoformat(),
+            generated=datetime.now(tz=UTC).isoformat(),
         )
+        digest_path = digests_dir / filename
+        digest_path.write_text(frontmatter.dumps(post), encoding="utf-8")
         return digest_path
 
     @staticmethod
@@ -366,7 +375,14 @@ class UnnamedDigestGenerator:
         raw = path.read_text(encoding="utf-8").strip()
         if not raw:
             return None
-        entries = json.loads(raw)
+        try:
+            entries = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning(
+                "Corrupt unnamed history at %s; treating as no prior data",
+                path,
+            )
+            return None
         if not entries:
             return None
         last = entries[-1]
@@ -394,7 +410,14 @@ class UnnamedDigestGenerator:
         if path.exists():
             raw = path.read_text(encoding="utf-8").strip()
             if raw:
-                entries = json.loads(raw)
+                try:
+                    entries = json.loads(raw)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Corrupt unnamed history at %s; overwriting with fresh log",
+                        path,
+                    )
+                    entries = []
         entries.append(entry.to_dict())
         path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
 

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -189,6 +189,33 @@ def test_report_help() -> None:
     assert "report" in result.output.lower()
 
 
+def test_report_unnamed_command(tmp_path: Path) -> None:
+    """Test that report --type unnamed generates a digest."""
+    vault = tmp_path / "vault"
+    for d in (
+        "00-Creek-Meta",
+        "00-Creek-Meta/Processing-Log",
+        "01-Fragments",
+        "10-Liminal",
+        "10-Liminal/Unnamed",
+    ):
+        (vault / d).mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "--type",
+            "unnamed",
+            "--vault",
+            str(vault),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Unnamed digest generated" in result.output
+    assert (vault / "10-Liminal" / "Unnamed" / "Digests").is_dir()
+
+
 def test_report_command() -> None:
     """Test that report command runs with required args."""
     result = runner.invoke(

--- a/creek-tools/tests/test_unnamed_digest.py
+++ b/creek-tools/tests/test_unnamed_digest.py
@@ -24,7 +24,6 @@ from creek.models import Fragment, FragmentSource, SourcePlatform
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from unittest.mock import MagicMock
 
 
 # ---- Fixtures ----
@@ -265,11 +264,16 @@ class TestDetectUnnamedClusters:
         )
         assert gen.detect_unnamed_clusters([frag_a, frag_b]) == []
 
-    def test_distinct_fragments_do_not_cluster(
-        self, mock_sentence_transformer: MagicMock, linker: EmbeddingLinker
-    ) -> None:
-        """Fragments with unrelated titles produce no cluster above 0.7."""
-        del mock_sentence_transformer
+    def test_distinct_fragments_do_not_cluster(self, linker: EmbeddingLinker) -> None:
+        """Unrelated titles produce no cluster at a near-unit threshold.
+
+        The autouse ``mock_sentence_transformer`` fixture returns a
+        deterministic random vector per input string; distinct strings
+        therefore hash to near-orthogonal 384-dim vectors whose cosine
+        similarity is nowhere near ``0.99``. Setting the threshold that
+        high asserts the clustering path is actually evaluating pair
+        similarity (not blindly grouping).
+        """
         gen = UnnamedDigestGenerator(embedding_linker=linker, similarity_threshold=0.99)
         frag_a = Fragment(
             title="alpha",
@@ -329,7 +333,11 @@ class TestGenerateWeeklyDigest:
         generator: UnnamedDigestGenerator,
         vault: Path,
     ) -> None:
-        """Digest frontmatter includes type, week_start, and week_end."""
+        """Digest frontmatter includes type, week_start, and week_end.
+
+        Parses via :mod:`frontmatter` so the assertions are insensitive
+        to the library's quoting style.
+        """
         week_start = _week_start()
         _write_unnamed_fragment(
             vault,
@@ -337,11 +345,10 @@ class TestGenerateWeeklyDigest:
             created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
         )
         path = generator.generate_weekly_digest(vault, week_start)
-        content = path.read_text(encoding="utf-8")
-        assert content.startswith("---\n")
-        assert "type: unnamed-digest" in content
-        assert f"week_start: {week_start.isoformat()}" in content
-        assert f"week_end: {(week_start + timedelta(days=6)).isoformat()}" in content
+        post = frontmatter.load(str(path))
+        assert post.get("type") == "unnamed-digest"
+        assert post.get("week_start") == week_start.isoformat()
+        assert post.get("week_end") == (week_start + timedelta(days=6)).isoformat()
 
     def test_digest_lists_fragments_with_excerpts(
         self,
@@ -535,6 +542,29 @@ class TestGenerateWeeklyDigest:
         assert "Previous week" in content
         # Previous week: 1 fragment, this week: 2 fragments, delta: +1
         assert "Change: +1" in content
+
+    def test_corrupt_history_does_not_abort_generation(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """A corrupt unnamed-history.json is tolerated; the digest still writes."""
+        history_path = (
+            vault / "00-Creek-Meta" / "Processing-Log" / "unnamed-history.json"
+        )
+        history_path.write_text("{ not json", encoding="utf-8")
+        week_start = _week_start()
+        _write_unnamed_fragment(
+            vault,
+            "alpha",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        assert path.exists()
+        # History is overwritten with a valid JSON array containing this run.
+        history = json.loads(history_path.read_text(encoding="utf-8"))
+        assert len(history) == 1
+        assert history[0]["week_start"] == week_start.isoformat()
 
     def test_rerun_on_same_week_replaces_digest(
         self,

--- a/creek-tools/tests/test_unnamed_digest.py
+++ b/creek-tools/tests/test_unnamed_digest.py
@@ -1,0 +1,561 @@
+"""Tests for creek.generate.unnamed — Unnamed weekly digest generator.
+
+Tests cover the ``UnnamedDigestGenerator`` class:
+
+- Collecting fragments from ``10-Liminal/Unnamed/`` in a target week
+- Clustering unnamed fragments via embedding similarity
+- Rendering the weekly digest markdown note with all required sections
+- Tracking week-over-week growth in a JSON history file
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.config import EmbeddingsConfig
+from creek.generate.unnamed import UnnamedDigestGenerator
+from creek.link.embeddings import EmbeddingLinker
+from creek.models import Fragment, FragmentSource, SourcePlatform
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from unittest.mock import MagicMock
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    """Create a mock vault directory structure including 10-Liminal/Unnamed/."""
+    for folder in (
+        "00-Creek-Meta",
+        "00-Creek-Meta/Processing-Log",
+        "01-Fragments",
+        "10-Liminal",
+        "10-Liminal/Unnamed",
+    ):
+        (tmp_path / folder).mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+@pytest.fixture()
+def linker() -> EmbeddingLinker:
+    """Create an EmbeddingLinker backed by the autouse mock model."""
+    return EmbeddingLinker(config=EmbeddingsConfig())
+
+
+@pytest.fixture()
+def generator(linker: EmbeddingLinker) -> UnnamedDigestGenerator:
+    """Create a default UnnamedDigestGenerator for testing."""
+    return UnnamedDigestGenerator(embedding_linker=linker)
+
+
+def _week_start(year: int = 2026, month: int = 2, day: int = 9) -> date:
+    """Return a canonical Monday for deterministic week boundaries."""
+    return date(year, month, day)
+
+
+def _write_unnamed_fragment(
+    vault: Path,
+    name: str,
+    *,
+    title: str | None = None,
+    created: datetime,
+    frag_id: str | None = None,
+) -> Path:
+    """Write an Unnamed fragment markdown file with full frontmatter.
+
+    Args:
+        vault: Root vault path.
+        name: Filename stem (without extension).
+        title: Fragment title; defaults to *name*.
+        created: Creation timestamp used for the ``created`` field.
+        frag_id: Fragment ID; defaults to ``frag-<name>``.
+
+    Returns:
+        Path to the written markdown file.
+    """
+    fragment = Fragment(
+        id=frag_id or f"frag-{name}",
+        title=title or name,
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        created=created,
+        ingested=created,
+    )
+    data = fragment.model_dump(mode="json")
+    post = frontmatter.Post(content=f"Body content for {name}.", **data)
+    path = vault / "10-Liminal" / "Unnamed" / f"{name}.md"
+    path.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return path
+
+
+# ---- Init Tests ----
+
+
+class TestInit:
+    """Tests for UnnamedDigestGenerator.__init__."""
+
+    def test_stores_linker(self, linker: EmbeddingLinker) -> None:
+        """Init stores the provided embedding linker."""
+        gen = UnnamedDigestGenerator(embedding_linker=linker)
+        assert gen.embedding_linker is linker
+
+    def test_default_similarity_threshold_is_low(self, linker: EmbeddingLinker) -> None:
+        """Default similarity threshold is 0.7 per ontology spec."""
+        gen = UnnamedDigestGenerator(embedding_linker=linker)
+        assert gen.similarity_threshold == pytest.approx(0.7)
+
+    def test_custom_similarity_threshold(self, linker: EmbeddingLinker) -> None:
+        """Custom threshold overrides the default."""
+        gen = UnnamedDigestGenerator(embedding_linker=linker, similarity_threshold=0.85)
+        assert gen.similarity_threshold == pytest.approx(0.85)
+
+
+# ---- load_unnamed_fragments ----
+
+
+class TestLoadUnnamedFragments:
+    """Tests for UnnamedDigestGenerator.load_unnamed_fragments."""
+
+    def test_empty_dir_returns_empty(
+        self, generator: UnnamedDigestGenerator, vault: Path
+    ) -> None:
+        """An empty Unnamed/ directory yields no fragments."""
+        assert generator.load_unnamed_fragments(vault) == []
+
+    def test_reads_fragments_from_unnamed(
+        self, generator: UnnamedDigestGenerator, vault: Path
+    ) -> None:
+        """Unnamed/*.md markdown files are parsed into Fragment models."""
+        when = datetime(2026, 2, 10, 12, 0, tzinfo=UTC)
+        _write_unnamed_fragment(vault, "alpha", created=when)
+        _write_unnamed_fragment(vault, "beta", created=when)
+        loaded = generator.load_unnamed_fragments(vault)
+        titles = sorted(f.title for f in loaded)
+        assert titles == ["alpha", "beta"]
+
+    def test_skips_digests_subdirectory(
+        self, generator: UnnamedDigestGenerator, vault: Path
+    ) -> None:
+        """The Digests/ subdirectory is excluded from the fragment list."""
+        when = datetime(2026, 2, 10, tzinfo=UTC)
+        _write_unnamed_fragment(vault, "alpha", created=when)
+        digests = vault / "10-Liminal" / "Unnamed" / "Digests"
+        digests.mkdir(parents=True, exist_ok=True)
+        (digests / "2026-W06.md").write_text("---\ntype: digest\n---\n", "utf-8")
+        loaded = generator.load_unnamed_fragments(vault)
+        assert len(loaded) == 1
+        assert loaded[0].title == "alpha"
+
+    def test_skips_non_fragment_markdown(
+        self, generator: UnnamedDigestGenerator, vault: Path
+    ) -> None:
+        """Markdown files that don't parse as Fragment are silently skipped."""
+        when = datetime(2026, 2, 10, tzinfo=UTC)
+        _write_unnamed_fragment(vault, "alpha", created=when)
+        bad = vault / "10-Liminal" / "Unnamed" / "stray.md"
+        bad.write_text("---\ntype: not-a-fragment\n---\n", "utf-8")
+        loaded = generator.load_unnamed_fragments(vault)
+        assert [f.title for f in loaded] == ["alpha"]
+
+    def test_missing_unnamed_dir_returns_empty(
+        self, generator: UnnamedDigestGenerator, tmp_path: Path
+    ) -> None:
+        """A missing 10-Liminal/Unnamed/ directory returns an empty list."""
+        assert generator.load_unnamed_fragments(tmp_path) == []
+
+
+# ---- filter_fragments_in_week ----
+
+
+class TestFilterFragmentsInWeek:
+    """Tests for UnnamedDigestGenerator.filter_fragments_in_week."""
+
+    def test_includes_week_start_inclusive(
+        self, generator: UnnamedDigestGenerator
+    ) -> None:
+        """Fragments created exactly at ``week_start`` are included."""
+        week_start = _week_start()
+        frag = Fragment(
+            title="boundary-low",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+        )
+        result = generator.filter_fragments_in_week([frag], week_start)
+        assert result == [frag]
+
+    def test_excludes_week_end_exclusive(
+        self, generator: UnnamedDigestGenerator
+    ) -> None:
+        """Fragments created on ``week_start + 7`` are excluded."""
+        week_start = _week_start()
+        frag = Fragment(
+            title="boundary-high",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+            created=datetime.combine(
+                week_start + timedelta(days=7), datetime.min.time(), tzinfo=UTC
+            ),
+        )
+        assert generator.filter_fragments_in_week([frag], week_start) == []
+
+    def test_excludes_previous_week(self, generator: UnnamedDigestGenerator) -> None:
+        """Fragments from before the window are excluded."""
+        week_start = _week_start()
+        frag = Fragment(
+            title="old",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+            created=datetime.combine(
+                week_start - timedelta(days=1), datetime.min.time(), tzinfo=UTC
+            ),
+        )
+        assert generator.filter_fragments_in_week([frag], week_start) == []
+
+
+# ---- detect_unnamed_clusters ----
+
+
+class TestDetectUnnamedClusters:
+    """Tests for UnnamedDigestGenerator.detect_unnamed_clusters."""
+
+    def test_empty_input_returns_empty(self, generator: UnnamedDigestGenerator) -> None:
+        """Empty input yields no clusters."""
+        assert generator.detect_unnamed_clusters([]) == []
+
+    def test_single_fragment_no_clusters(
+        self, generator: UnnamedDigestGenerator
+    ) -> None:
+        """A single fragment cannot form a cluster."""
+        frag = Fragment(
+            title="solo",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        assert generator.detect_unnamed_clusters([frag]) == []
+
+    def test_identical_titles_cluster_together(self, linker: EmbeddingLinker) -> None:
+        """Identical titles yield identical embeddings and form one cluster."""
+        gen = UnnamedDigestGenerator(embedding_linker=linker, similarity_threshold=0.7)
+        frag_a = Fragment(
+            title="recurring-dream",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        frag_b = Fragment(
+            title="recurring-dream",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        clusters = gen.detect_unnamed_clusters([frag_a, frag_b])
+        assert len(clusters) == 1
+        assert {f.id for f in clusters[0]} == {frag_a.id, frag_b.id}
+
+    def test_threshold_gates_cluster_membership(self, linker: EmbeddingLinker) -> None:
+        """An impossibly high threshold collapses all clusters to singletons."""
+        gen = UnnamedDigestGenerator(embedding_linker=linker, similarity_threshold=1.01)
+        frag_a = Fragment(
+            title="same-string",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        frag_b = Fragment(
+            title="same-string",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        assert gen.detect_unnamed_clusters([frag_a, frag_b]) == []
+
+    def test_distinct_fragments_do_not_cluster(
+        self, mock_sentence_transformer: MagicMock, linker: EmbeddingLinker
+    ) -> None:
+        """Fragments with unrelated titles produce no cluster above 0.7."""
+        del mock_sentence_transformer
+        gen = UnnamedDigestGenerator(embedding_linker=linker, similarity_threshold=0.99)
+        frag_a = Fragment(
+            title="alpha",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        frag_b = Fragment(
+            title="bravo",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        frag_c = Fragment(
+            title="charlie",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        assert gen.detect_unnamed_clusters([frag_a, frag_b, frag_c]) == []
+
+
+# ---- generate_weekly_digest ----
+
+
+class TestGenerateWeeklyDigest:
+    """Tests for UnnamedDigestGenerator.generate_weekly_digest."""
+
+    def test_creates_digest_in_expected_directory(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """The digest is written to 10-Liminal/Unnamed/Digests/."""
+        week_start = _week_start()
+        _write_unnamed_fragment(
+            vault,
+            "alpha",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        assert path.exists()
+        assert path.parent == vault / "10-Liminal" / "Unnamed" / "Digests"
+
+    def test_digest_filename_uses_iso_week(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """Digest filename encodes ISO year-week (e.g. 2026-W07)."""
+        week_start = _week_start()
+        _write_unnamed_fragment(
+            vault,
+            "alpha",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        iso_year, iso_week, _ = week_start.isocalendar()
+        assert path.name == f"{iso_year}-W{iso_week:02d}.md"
+
+    def test_digest_frontmatter(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """Digest frontmatter includes type, week_start, and week_end."""
+        week_start = _week_start()
+        _write_unnamed_fragment(
+            vault,
+            "alpha",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+        assert content.startswith("---\n")
+        assert "type: unnamed-digest" in content
+        assert f"week_start: {week_start.isoformat()}" in content
+        assert f"week_end: {(week_start + timedelta(days=6)).isoformat()}" in content
+
+    def test_digest_lists_fragments_with_excerpts(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """Digest includes each fragment's title, wiki-link, and excerpt."""
+        week_start = _week_start()
+        _write_unnamed_fragment(
+            vault,
+            "alpha",
+            title="A curious recurring feeling",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+            frag_id="frag-alpha-1",
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+        assert "## Fragments This Week" in content
+        assert "A curious recurring feeling" in content
+        assert "[[frag-alpha-1]]" in content
+        assert "Body content for alpha" in content
+
+    def test_digest_includes_prompt_section(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """Digest includes the open-ended reflection prompt."""
+        week_start = _week_start()
+        _write_unnamed_fragment(
+            vault,
+            "alpha",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+        assert "## Reflection Prompt" in content
+        assert (
+            "What do these have in common that the current ontology can't express?"
+            in content
+        )
+
+    def test_digest_includes_growth_section(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """Digest reports week-over-week growth of the Unnamed folder."""
+        week_start = _week_start()
+        _write_unnamed_fragment(
+            vault,
+            "alpha",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+        assert "## Week-over-Week Growth" in content
+        assert "This week" in content
+
+    def test_digest_reports_cluster_when_titles_repeat(
+        self,
+        linker: EmbeddingLinker,
+        vault: Path,
+    ) -> None:
+        """Duplicate titles produce a similarity cluster in the digest output."""
+        gen = UnnamedDigestGenerator(embedding_linker=linker, similarity_threshold=0.7)
+        week_start = _week_start()
+        when = datetime.combine(week_start, datetime.min.time(), tzinfo=UTC)
+        _write_unnamed_fragment(
+            vault, "a", title="same phrase", frag_id="frag-a", created=when
+        )
+        _write_unnamed_fragment(
+            vault, "b", title="same phrase", frag_id="frag-b", created=when
+        )
+        path = gen.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+        assert "## Similarity Clusters" in content
+        assert "Cluster 1" in content
+        assert "[[frag-a]]" in content
+        assert "[[frag-b]]" in content
+
+    def test_digest_reports_no_clusters_when_none_found(
+        self,
+        linker: EmbeddingLinker,
+        vault: Path,
+    ) -> None:
+        """When no clusters meet the threshold, the digest says so."""
+        gen = UnnamedDigestGenerator(embedding_linker=linker, similarity_threshold=1.01)
+        week_start = _week_start()
+        when = datetime.combine(week_start, datetime.min.time(), tzinfo=UTC)
+        _write_unnamed_fragment(vault, "a", title="unique-a", created=when)
+        _write_unnamed_fragment(vault, "b", title="unique-b", created=when)
+        path = gen.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+        assert "## Similarity Clusters" in content
+        assert "No similarity clusters emerged this week." in content
+
+    def test_digest_ignores_fragments_outside_window(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """Fragments outside the week window aren't listed in this week's digest."""
+        week_start = _week_start()
+        in_week = datetime.combine(week_start, datetime.min.time(), tzinfo=UTC)
+        out_of_week = datetime.combine(
+            week_start - timedelta(days=3), datetime.min.time(), tzinfo=UTC
+        )
+        _write_unnamed_fragment(
+            vault,
+            "in",
+            title="in-window",
+            frag_id="frag-in",
+            created=in_week,
+        )
+        _write_unnamed_fragment(
+            vault,
+            "out",
+            title="out-of-window",
+            frag_id="frag-out",
+            created=out_of_week,
+        )
+        path = generator.generate_weekly_digest(vault, week_start)
+        content = path.read_text(encoding="utf-8")
+        assert "[[frag-in]]" in content
+        assert "[[frag-out]]" not in content
+
+    def test_digest_handles_empty_week(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """An empty week still produces a digest file with an empty-week message."""
+        path = generator.generate_weekly_digest(vault, _week_start())
+        content = path.read_text(encoding="utf-8")
+        assert "No unnamed fragments recorded this week." in content
+
+    def test_persists_history_entry(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """Each run appends to 00-Creek-Meta/Processing-Log/unnamed-history.json."""
+        week_start = _week_start()
+        _write_unnamed_fragment(
+            vault,
+            "alpha",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+        )
+        generator.generate_weekly_digest(vault, week_start)
+        history_path = (
+            vault / "00-Creek-Meta" / "Processing-Log" / "unnamed-history.json"
+        )
+        assert history_path.exists()
+        history = json.loads(history_path.read_text(encoding="utf-8"))
+        assert len(history) == 1
+        assert history[0]["week_start"] == week_start.isoformat()
+        assert history[0]["fragment_count"] == 1
+        assert history[0]["total_unnamed"] == 1
+
+    def test_reports_growth_against_previous_week(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """Subsequent runs report delta vs. the previous recorded week."""
+        week_one = _week_start()
+        week_two = week_one + timedelta(days=7)
+        _write_unnamed_fragment(
+            vault,
+            "alpha",
+            created=datetime.combine(week_one, datetime.min.time(), tzinfo=UTC),
+            frag_id="frag-alpha",
+        )
+        generator.generate_weekly_digest(vault, week_one)
+
+        _write_unnamed_fragment(
+            vault,
+            "beta",
+            created=datetime.combine(week_two, datetime.min.time(), tzinfo=UTC),
+            frag_id="frag-beta",
+        )
+        _write_unnamed_fragment(
+            vault,
+            "gamma",
+            created=datetime.combine(week_two, datetime.min.time(), tzinfo=UTC),
+            frag_id="frag-gamma",
+        )
+        path_two = generator.generate_weekly_digest(vault, week_two)
+        content = path_two.read_text(encoding="utf-8")
+        assert "Previous week" in content
+        # Previous week: 1 fragment, this week: 2 fragments, delta: +1
+        assert "Change: +1" in content
+
+    def test_rerun_on_same_week_replaces_digest(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """Running twice for the same week overwrites the digest file."""
+        week_start = _week_start()
+        _write_unnamed_fragment(
+            vault,
+            "alpha",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+        )
+        first = generator.generate_weekly_digest(vault, week_start)
+        first_mtime = first.stat().st_mtime
+        _write_unnamed_fragment(
+            vault,
+            "beta",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+        )
+        second = generator.generate_weekly_digest(vault, week_start)
+        assert second == first
+        assert second.stat().st_mtime >= first_mtime
+        assert "[[frag-beta]]" in second.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Closes #37.

Implements `UnnamedDigestGenerator` to surface fragments collecting in `10-Liminal/Unnamed/` — the ontology's "most important research site" per Section 10.1. Each weekly run:

- **Collects** fragments from `10-Liminal/Unnamed/` whose `created` date falls in `[week_start, week_start + 7)` (ISO-week convention, skipping the `Digests/` subfolder).
- **Clusters** them via cosine similarity over sentence-transformer embeddings, using a deliberately loose threshold (default **0.7**) so even faint patterns surface. Uses a union-find over resonant pairs to produce connected components, filtering out singletons.
- **Writes** a markdown digest at `10-Liminal/Unnamed/Digests/<iso-year>-W<week>.md` containing:
  - A fragment list with excerpts and wiki-links
  - Similarity clusters (when any emerge)
  - A non-prescriptive reflection prompt: *"What do these have in common that the current ontology can't express?"*
  - Week-over-week growth stats against the previous recorded week
- **Persists** history to `00-Creek-Meta/Processing-Log/unnamed-history.json` so subsequent runs can report deltas.

Wired into the CLI as `creek report --type unnamed`, which uses the current ISO week's Monday as `week_start`.

## Acceptance criteria

- [x] Weekly digest note generated with correct date range
- [x] Fragments listed with excerpts and wiki-links
- [x] Similarity clusters detected among unnamed fragments
- [x] Generated reflection prompt included
- [x] Week-over-week growth tracking included
- [x] Tests verify digest generation with fixture data

## Test plan

- [x] `./scripts/lint.sh --check` — passes
- [x] `./scripts/format.sh --check` — passes
- [x] `./scripts/test.sh` — 2014 passed, 1 skipped (pre-existing Ollama skip)
- [x] `./scripts/coverage.sh` — 94.49% total (exceeds 90% threshold)
- [x] `mypy creek/generate/unnamed.py creek/cli.py` — zero errors in new code
- [x] `./scripts/complexity.sh` — grade A (avg cyclomatic 2.89)
- [x] 29 new unit tests in `tests/test_unnamed_digest.py` covering init, fragment loading, week filtering, clustering, rendering, history, and re-runs
- [x] CLI integration test in `tests/test_cli.py::test_report_unnamed_command`

https://claude.ai/code/session_01K9yvSuaJGtHxQXYJi22si9
