### PR TITLE
feat(generate): implement paradox preservation detector (#38)

### DIFF
--- a/creek-tools/creek/generate/__init__.py
+++ b/creek-tools/creek/generate/__init__.py
@@ -9,17 +9,27 @@ from creek.generate.decisions import (
     decision_from_note,
 )
 from creek.generate.indexes import FREQUENCY_COLORS, FREQUENCY_NAMES, IndexGenerator
+from creek.generate.paradox import (
+    CONTRADICTION_KEYWORDS,
+    REFLECTION_PROMPT,
+    Paradox,
+    ParadoxDetector,
+)
 from creek.generate.tags import TagGardenGenerator, TagScanResult
 
 __all__ = [
+    "CONTRADICTION_KEYWORDS",
     "DECISION_KEYWORDS",
     "FREQUENCY_COLORS",
     "FREQUENCY_NAMES",
     "PRACTICE_MAP",
+    "REFLECTION_PROMPT",
     "DecisionContext",
     "DecisionContextGatherer",
     "DecisionDetector",
     "IndexGenerator",
+    "Paradox",
+    "ParadoxDetector",
     "TagGardenGenerator",
     "TagScanResult",
     "decision_from_note",

--- a/creek-tools/creek/generate/paradox.py
+++ b/creek-tools/creek/generate/paradox.py
@@ -1,0 +1,515 @@
+"""Paradox Preservation — detect contradictions without resolving them.
+
+Implements Section 10.2 of the Creek Ontology: when the system finds
+contradictory stances across fragments from the same person, it does
+*not* resolve the contradiction. Instead, a note is written to
+``10-Liminal/Paradoxes/`` that links both fragments, describes the
+detected tension in neutral language, and offers a reflection prompt.
+
+Detection operates on four independent rules:
+
+1. **Phase contradiction** — fragments with high semantic similarity that
+   sit on opposite phases of the Archetypal Wavelength cycle.
+2. **Confidence contradiction** — fragments on a shared thread carrying
+   opposite confidence levels (e.g. ``musing`` vs ``settled``).
+3. **Dosage contradiction** — fragments with the same primary frequency
+   where one marks it ``medicine`` and the other ``toxic``.
+4. **Keyword contradiction** — a fragment whose title contains an
+   explicit contradiction phrase (``but actually``, ``I used to think``,
+   ``contrary to what I said``) paired with a topically-linked fragment.
+
+Each paradox links exactly two fragments. The generated note is
+deliberately neutral: no resolution, prescription, or judgment.
+"""
+
+from __future__ import annotations
+
+import itertools
+import math
+import re
+from dataclasses import dataclass, field
+from datetime import date
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.models import Confidence, Dosage, Phase
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from creek.models import Fragment
+
+
+CONTRADICTION_KEYWORDS: tuple[str, ...] = (
+    "but actually",
+    "i used to think",
+    "contrary to what i said",
+)
+"""Case-insensitive phrases that mark a fragment as self-aware of contradiction."""
+
+
+REFLECTION_PROMPT: str = (
+    "These fragments hold tension with each other. "
+    "What truth lives in the space between them?"
+)
+"""The reflection prompt appended to every paradox note.
+
+Invites integration by sitting with the tension rather than resolving it.
+"""
+
+
+_DEFAULT_SIMILARITY_THRESHOLD: float = 0.7
+"""Minimum cosine similarity for two fragments to count as the same topic."""
+
+
+_EXCERPT_MAX_CHARS: int = 280
+"""Maximum excerpt length written into a paradox note."""
+
+
+_OPPOSITE_PHASE_PAIRS: frozenset[frozenset[str]] = frozenset(
+    {
+        frozenset({Phase.RISING.value, Phase.DIMINISHING.value}),
+        frozenset({Phase.RISING.value, Phase.BOTTOMING_OUT.value}),
+        frozenset({Phase.PEAKING.value, Phase.BOTTOMING_OUT.value}),
+        frozenset({Phase.PEAKING.value, Phase.DIMINISHING.value}),
+        frozenset({Phase.WITHDRAWAL.value, Phase.RESTORATION.value}),
+    },
+)
+"""Archetypal Wavelength phase pairs treated as opposites for Rule 1."""
+
+
+_OPPOSITE_CONFIDENCE_PAIRS: frozenset[frozenset[str]] = frozenset(
+    {
+        frozenset({Confidence.MUSING.value, Confidence.SETTLED.value}),
+        frozenset({Confidence.MUSING.value, Confidence.CONVICTION.value}),
+        frozenset({Confidence.EXPLORING.value, Confidence.SETTLED.value}),
+        frozenset({Confidence.EXPLORING.value, Confidence.CONVICTION.value}),
+    },
+)
+"""Confidence pairs treated as opposites for Rule 2."""
+
+
+_OPPOSITE_DOSAGE_PAIR: frozenset[str] = frozenset(
+    {Dosage.MEDICINE.value, Dosage.TOXIC.value},
+)
+"""Dosage pair treated as opposite for Rule 3."""
+
+
+_CONTRADICTION_DESCRIPTIONS: dict[str, str] = {
+    "phase": (
+        "These fragments sit on opposite phases of the Archetypal "
+        "Wavelength while sharing topic."
+    ),
+    "confidence": (
+        "These fragments travel the same thread at very different "
+        "levels of settled-ness."
+    ),
+    "dosage": (
+        "The same frequency is experienced as medicine in one fragment "
+        "and as toxic in the other."
+    ),
+    "keyword": (
+        "One fragment explicitly marks a shift from a stance held in the other."
+    ),
+}
+"""Neutral, descriptive summaries of each contradiction type."""
+
+
+_FILENAME_SANITIZER = re.compile(r"[^\w\-]+")
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Compute cosine similarity between two equal-length vectors.
+
+    Args:
+        a: First embedding vector.
+        b: Second embedding vector.
+
+    Returns:
+        Cosine similarity in ``[-1.0, 1.0]``; ``0.0`` if either vector
+        is empty or has zero norm.
+    """
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b, strict=False))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if 0.0 in (norm_a, norm_b):
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def _fragment_frequencies(fragment: Fragment) -> set[str]:
+    """Collect all classified frequency codes from a fragment.
+
+    Args:
+        fragment: The fragment whose frequency set to extract.
+
+    Returns:
+        Set of frequency code strings (``"F1"``, ``"F2"``, ...), excluding
+        ``unclassified``.
+    """
+    freqs: set[str] = set()
+    primary = str(fragment.frequency.primary)
+    if primary and primary != "unclassified":
+        freqs.add(primary)
+    for sec in fragment.frequency.secondary:
+        sec_str = str(sec)
+        if sec_str and sec_str != "unclassified":
+            freqs.add(sec_str)
+    return freqs
+
+
+def _excerpt(fragment: Fragment) -> str:
+    """Return a short, clean excerpt for a fragment.
+
+    Fragments carry only a title in the current model; the title is used
+    as the excerpt, truncated at :data:`_EXCERPT_MAX_CHARS`.
+
+    Args:
+        fragment: The fragment to excerpt.
+
+    Returns:
+        A single-line excerpt string.
+    """
+    raw = fragment.title.strip()
+    if len(raw) <= _EXCERPT_MAX_CHARS:
+        return raw
+    return raw[: _EXCERPT_MAX_CHARS - 1].rstrip() + "\u2026"
+
+
+def _has_contradiction_keyword(fragment: Fragment) -> bool:
+    """Check whether a fragment title contains any contradiction keyword.
+
+    Args:
+        fragment: The fragment to inspect.
+
+    Returns:
+        ``True`` if any configured keyword appears (case-insensitive).
+    """
+    lowered = fragment.title.lower()
+    return any(kw in lowered for kw in CONTRADICTION_KEYWORDS)
+
+
+@dataclass
+class Paradox:
+    """A detected contradiction linking two (or more) fragments.
+
+    Attributes:
+        fragment_ids: IDs of the fragments the paradox links, in stable
+            order (typically two).
+        contradiction_type: Which detection rule matched. One of
+            ``"phase"``, ``"confidence"``, ``"dosage"``, ``"keyword"``.
+        frequencies: Frequency codes shared by the fragments, used as
+            additional tags on the paradox note.
+        excerpts: Short excerpts (one per fragment, matching
+            :attr:`fragment_ids` order).
+        detected_date: The date the paradox was recorded. Defaults to
+            today.
+        similarity: Optional cosine similarity score between the
+            fragments when embeddings are available. Stored for
+            diagnostics; never surfaced to the human.
+    """
+
+    fragment_ids: list[str]
+    contradiction_type: str
+    frequencies: list[str] = field(default_factory=list)
+    excerpts: list[str] = field(default_factory=list)
+    detected_date: date = field(default_factory=date.today)
+    similarity: float = 0.0
+
+
+class ParadoxDetector:
+    """Detect and record paradoxes across a collection of fragments.
+
+    Attributes:
+        similarity_threshold: Minimum cosine similarity required to treat
+            two fragments as sharing a topic (Rule 1 and Rule 4).
+    """
+
+    def __init__(
+        self,
+        similarity_threshold: float = _DEFAULT_SIMILARITY_THRESHOLD,
+    ) -> None:
+        """Initialise the detector.
+
+        Args:
+            similarity_threshold: Minimum cosine similarity above which
+                two fragments are considered the same topic.
+        """
+        self.similarity_threshold = similarity_threshold
+
+    # ---- Public API ----
+
+    def detect_paradoxes(
+        self,
+        fragments: list[Fragment],
+        *,
+        embeddings: dict[str, list[float]] | None = None,
+    ) -> list[Paradox]:
+        """Scan fragments for contradictory pairs.
+
+        Applies the four detection rules described in the module
+        docstring. Each fragment pair is emitted at most once; the
+        first matching rule wins in the priority order: phase, keyword,
+        confidence, dosage.
+
+        Args:
+            fragments: Fragments to inspect. Fewer than two yields no
+                paradoxes.
+            embeddings: Optional mapping of fragment ID to embedding
+                vector. When provided, it is used to compute cosine
+                similarity for the topic-sharing rules. When absent,
+                only the thread- and frequency-based rules can match.
+
+        Returns:
+            List of :class:`Paradox` instances, one per contradictory
+            pair discovered.
+        """
+        if len(fragments) < 2:
+            return []
+
+        embeddings = embeddings or {}
+        paradoxes: list[Paradox] = []
+        for a, b in itertools.combinations(fragments, 2):
+            similarity = self._pair_similarity(a, b, embeddings)
+            paradox = self._detect_pair(a, b, similarity)
+            if paradox is not None:
+                paradoxes.append(paradox)
+        return paradoxes
+
+    def create_paradox_note(self, paradox: Paradox, vault_path: Path) -> Path:
+        """Write a paradox to ``<vault>/10-Liminal/Paradoxes/`` as Markdown.
+
+        Writes a YAML-frontmatter note that:
+
+        * carries ``type: paradox``, the linked fragment IDs, the
+          overlapping frequencies, and the detected date in frontmatter;
+        * tags the note with ``paradox`` plus a lowercase tag per shared
+          frequency;
+        * renders each fragment as a wikilink with its excerpt;
+        * states the detected tension in neutral, descriptive language;
+        * includes the :data:`REFLECTION_PROMPT`.
+
+        The note is idempotent with respect to the paradox: writing the
+        same :class:`Paradox` twice produces the same file path and
+        overwrites the content without creating duplicates.
+
+        Args:
+            paradox: The paradox to record.
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            The path to the written markdown note.
+        """
+        target_dir = vault_path / "10-Liminal" / "Paradoxes"
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        tags = ["paradox"]
+        tags.extend(freq.lower() for freq in paradox.frequencies)
+
+        body = self._render_body(paradox)
+        post = frontmatter.Post(
+            content=body,
+            type="paradox",
+            fragments=paradox.fragment_ids.copy(),
+            frequencies=paradox.frequencies.copy(),
+            detected_date=paradox.detected_date.isoformat(),
+            tags=tags,
+        )
+
+        note_path = target_dir / self._filename(paradox)
+        note_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return note_path
+
+    # ---- Pair detection ----
+
+    def _detect_pair(
+        self,
+        a: Fragment,
+        b: Fragment,
+        similarity: float,
+    ) -> Paradox | None:
+        """Apply the four rules to a single fragment pair.
+
+        Rules are evaluated in priority order: phase, keyword,
+        confidence, dosage. The first match wins and short-circuits.
+
+        Args:
+            a: First fragment.
+            b: Second fragment.
+            similarity: Cosine similarity between their embeddings, or
+                ``0.0`` when embeddings are unavailable.
+
+        Returns:
+            A Paradox for the first matching rule, or ``None``.
+        """
+        kind = self._match_rule(a, b, similarity)
+        if kind is None:
+            return None
+        return self._build_paradox(a, b, kind, similarity)
+
+    def _match_rule(
+        self,
+        a: Fragment,
+        b: Fragment,
+        similarity: float,
+    ) -> str | None:
+        """Return the label of the first matching detection rule."""
+        high_similarity = similarity >= self.similarity_threshold
+        if high_similarity and self._opposite_phases(a, b):
+            return "phase"
+        if self._matches_keyword_rule(a, b, high_similarity=high_similarity):
+            return "keyword"
+        if self._share_thread(a, b) and self._opposite_confidences(a, b):
+            return "confidence"
+        if self._share_primary_frequency(a, b) and self._opposite_dosages(a, b):
+            return "dosage"
+        return None
+
+    def _matches_keyword_rule(
+        self,
+        a: Fragment,
+        b: Fragment,
+        *,
+        high_similarity: bool,
+    ) -> bool:
+        """Check whether the explicit-keyword rule fires for the pair."""
+        if not (_has_contradiction_keyword(a) or _has_contradiction_keyword(b)):
+            return False
+        return (
+            high_similarity
+            or self._share_thread(a, b)
+            or self._share_primary_frequency(a, b)
+        )
+
+    def _pair_similarity(
+        self,
+        a: Fragment,
+        b: Fragment,
+        embeddings: dict[str, list[float]],
+    ) -> float:
+        """Return cosine similarity for a pair, or ``0.0`` if missing."""
+        vec_a = embeddings.get(a.id)
+        vec_b = embeddings.get(b.id)
+        if vec_a is None or vec_b is None:
+            return 0.0
+        return _cosine_similarity(vec_a, vec_b)
+
+    @staticmethod
+    def _opposite_phases(a: Fragment, b: Fragment) -> bool:
+        """Check whether two fragments occupy opposite wavelength phases."""
+        phase_a = str(a.wavelength.phase)
+        phase_b = str(b.wavelength.phase)
+        if not phase_a or not phase_b:
+            return False
+        return frozenset({phase_a, phase_b}) in _OPPOSITE_PHASE_PAIRS
+
+    @staticmethod
+    def _opposite_confidences(a: Fragment, b: Fragment) -> bool:
+        """Check whether two fragments carry opposite confidence levels."""
+        conf_a = a.voice.confidence
+        conf_b = b.voice.confidence
+        if conf_a is None or conf_b is None:
+            return False
+        pair = frozenset({str(conf_a), str(conf_b)})
+        return pair in _OPPOSITE_CONFIDENCE_PAIRS
+
+    @staticmethod
+    def _opposite_dosages(a: Fragment, b: Fragment) -> bool:
+        """Check whether two fragments mark the same frequency medicine vs toxic."""
+        dos_a = str(a.wavelength.dosage)
+        dos_b = str(b.wavelength.dosage)
+        return frozenset({dos_a, dos_b}) == _OPPOSITE_DOSAGE_PAIR
+
+    @staticmethod
+    def _share_thread(a: Fragment, b: Fragment) -> bool:
+        """Check whether two fragments belong to at least one common thread."""
+        return bool(set(a.threads) & set(b.threads))
+
+    @staticmethod
+    def _share_primary_frequency(a: Fragment, b: Fragment) -> bool:
+        """Check whether two fragments share a classified primary frequency."""
+        primary_a = str(a.frequency.primary)
+        primary_b = str(b.frequency.primary)
+        if primary_a == "unclassified" or primary_b == "unclassified":
+            return False
+        return primary_a == primary_b
+
+    # ---- Paradox construction ----
+
+    @staticmethod
+    def _build_paradox(
+        a: Fragment,
+        b: Fragment,
+        kind: str,
+        similarity: float,
+    ) -> Paradox:
+        """Assemble a :class:`Paradox` for a matched pair.
+
+        Args:
+            a: First fragment.
+            b: Second fragment.
+            kind: The contradiction type label.
+            similarity: Similarity score (0 when embeddings absent).
+
+        Returns:
+            A populated Paradox.
+        """
+        shared_freqs = sorted(
+            _fragment_frequencies(a) & _fragment_frequencies(b),
+        )
+        return Paradox(
+            fragment_ids=[a.id, b.id],
+            contradiction_type=kind,
+            frequencies=shared_freqs,
+            excerpts=[_excerpt(a), _excerpt(b)],
+            similarity=similarity,
+        )
+
+    # ---- Note rendering ----
+
+    def _render_body(self, paradox: Paradox) -> str:
+        """Render the Markdown body for a paradox note."""
+        lines: list[str] = []
+        for idx, (fid, excerpt) in enumerate(
+            zip(paradox.fragment_ids, paradox.excerpts, strict=False),
+            start=1,
+        ):
+            lines.append(f"## Fragment {idx}: [[{fid}]]")
+            lines.append("")
+            lines.append(f"> {excerpt}")
+            lines.append("")
+
+        lines.append("## Observed Tension")
+        lines.append("")
+        lines.append(self._describe_contradiction(paradox))
+        lines.append("")
+        lines.append("## Reflection Prompt")
+        lines.append("")
+        lines.append(REFLECTION_PROMPT)
+        return "\n".join(lines)
+
+    @staticmethod
+    def _describe_contradiction(paradox: Paradox) -> str:
+        """Describe the detected tension in neutral language.
+
+        Args:
+            paradox: The paradox to describe.
+
+        Returns:
+            A one-sentence neutral description.
+        """
+        return _CONTRADICTION_DESCRIPTIONS.get(
+            paradox.contradiction_type,
+            "A tension has been detected between these fragments.",
+        )
+
+    @staticmethod
+    def _filename(paradox: Paradox) -> str:
+        """Build a stable filename for a paradox note."""
+        iso = paradox.detected_date.isoformat()
+        stem = "-".join(paradox.fragment_ids[:2]) or "paradox"
+        sanitized = _FILENAME_SANITIZER.sub("-", stem).strip("-")
+        return f"{iso}-{sanitized}.md"

--- a/creek-tools/tests/test_paradox.py
+++ b/creek-tools/tests/test_paradox.py
@@ -1,0 +1,483 @@
+"""Tests for creek.generate.paradox — Paradox Preservation (Section 10.2).
+
+Tests cover the ``ParadoxDetector`` class which detects contradictory
+fragment pairs (opposite phases, opposite confidence on shared threads,
+opposite dosage on shared frequencies, and explicit contradiction
+keywords) and writes paradox notes to ``10-Liminal/Paradoxes/`` without
+ever resolving or judging the contradiction.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from creek.generate.paradox import (
+    CONTRADICTION_KEYWORDS,
+    REFLECTION_PROMPT,
+    Paradox,
+    ParadoxDetector,
+)
+from creek.models import (
+    Confidence,
+    Dosage,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Phase,
+    SourcePlatform,
+    VoiceClassification,
+    WavelengthClassification,
+)
+
+# ---- Helpers ----
+
+
+def make_fragment(
+    title: str,
+    *,
+    fid: str | None = None,
+    primary: Frequency = Frequency.UNCLASSIFIED,
+    secondary: list[Frequency] | None = None,
+    phase: Phase = Phase.UNCLASSIFIED,
+    dosage: Dosage = Dosage.UNCLASSIFIED,
+    confidence: Confidence | None = None,
+    threads: list[str] | None = None,
+) -> Fragment:
+    """Build a synthetic Fragment with explicit classification axes."""
+    kwargs: dict[str, object] = {
+        "title": title,
+        "source": FragmentSource(platform=SourcePlatform.JOURNAL),
+        "frequency": FrequencyClassification(
+            primary=primary,
+            secondary=secondary or [],
+        ),
+        "wavelength": WavelengthClassification(phase=phase, dosage=dosage),
+        "voice": VoiceClassification(confidence=confidence),
+        "threads": threads or [],
+    }
+    if fid is not None:
+        kwargs["id"] = fid
+    return Fragment(**kwargs)
+
+
+def unit_embedding(seed: int, dims: int = 8) -> list[float]:
+    """Make a tiny deterministic unit vector for similarity math."""
+    vec = [0.0] * dims
+    vec[seed % dims] = 1.0
+    return vec
+
+
+# ---- Paradox dataclass ----
+
+
+class TestParadox:
+    """Tests for the Paradox dataclass."""
+
+    def test_paradox_holds_two_fragment_ids(self) -> None:
+        """A paradox links exactly two fragments by default."""
+        p = Paradox(
+            fragment_ids=["frag-a", "frag-b"],
+            contradiction_type="phase",
+        )
+        assert p.fragment_ids == ["frag-a", "frag-b"]
+        assert p.contradiction_type == "phase"
+        assert p.frequencies == []
+        assert p.excerpts == []
+        assert p.detected_date == date.today()
+
+
+# ---- Detection: phase contradiction ----
+
+
+class TestDetectPhaseContradiction:
+    """Rule 1: high semantic similarity + opposite wavelength phases."""
+
+    def test_detects_rising_vs_diminishing(self) -> None:
+        """Opposite phases with high similarity trigger a phase paradox."""
+        a = make_fragment("Career ambitions", fid="frag-a", phase=Phase.RISING)
+        b = make_fragment("Career ambitions", fid="frag-b", phase=Phase.DIMINISHING)
+        embeddings = {"frag-a": unit_embedding(0), "frag-b": unit_embedding(0)}
+
+        detector = ParadoxDetector(similarity_threshold=0.7)
+        paradoxes = detector.detect_paradoxes([a, b], embeddings=embeddings)
+
+        assert len(paradoxes) == 1
+        assert paradoxes[0].contradiction_type == "phase"
+        assert set(paradoxes[0].fragment_ids) == {"frag-a", "frag-b"}
+
+    def test_low_similarity_is_not_paradox(self) -> None:
+        """Opposite phases without shared topic produce no paradox."""
+        a = make_fragment("Career ambitions", fid="frag-a", phase=Phase.RISING)
+        b = make_fragment("Career ambitions", fid="frag-b", phase=Phase.DIMINISHING)
+        embeddings = {"frag-a": unit_embedding(0), "frag-b": unit_embedding(3)}
+
+        detector = ParadoxDetector(similarity_threshold=0.7)
+        paradoxes = detector.detect_paradoxes([a, b], embeddings=embeddings)
+
+        assert not paradoxes
+
+    def test_same_phase_no_paradox(self) -> None:
+        """Same phase even with high similarity is not a paradox."""
+        a = make_fragment("x", fid="frag-a", phase=Phase.RISING)
+        b = make_fragment("x", fid="frag-b", phase=Phase.RISING)
+        embeddings = {"frag-a": unit_embedding(0), "frag-b": unit_embedding(0)}
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes([a, b], embeddings=embeddings)
+
+        assert not paradoxes
+
+
+# ---- Detection: confidence contradiction ----
+
+
+class TestDetectConfidenceContradiction:
+    """Rule 2: shared thread + opposite confidence levels."""
+
+    def test_detects_musing_vs_settled_on_shared_thread(self) -> None:
+        """Shared thread with musing vs settled confidence is a paradox."""
+        a = make_fragment(
+            "Trust",
+            fid="frag-a",
+            confidence=Confidence.MUSING,
+            threads=["thread-trust"],
+        )
+        b = make_fragment(
+            "Trust",
+            fid="frag-b",
+            confidence=Confidence.SETTLED,
+            threads=["thread-trust"],
+        )
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes([a, b])
+
+        assert len(paradoxes) == 1
+        assert paradoxes[0].contradiction_type == "confidence"
+
+    def test_no_shared_thread_no_paradox(self) -> None:
+        """Opposite confidence without a shared thread is not a paradox."""
+        a = make_fragment(
+            "Trust",
+            fid="frag-a",
+            confidence=Confidence.MUSING,
+            threads=["thread-a"],
+        )
+        b = make_fragment(
+            "Trust",
+            fid="frag-b",
+            confidence=Confidence.SETTLED,
+            threads=["thread-b"],
+        )
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes([a, b])
+
+        assert not paradoxes
+
+
+# ---- Detection: dosage contradiction ----
+
+
+class TestDetectDosageContradiction:
+    """Rule 3: same primary frequency + opposite dosage."""
+
+    def test_medicine_vs_toxic_on_same_frequency(self) -> None:
+        """Same primary frequency with medicine vs toxic is a paradox."""
+        a = make_fragment(
+            "Solitude as refuge",
+            fid="frag-a",
+            primary=Frequency.F2,
+            dosage=Dosage.MEDICINE,
+        )
+        b = make_fragment(
+            "Solitude as exile",
+            fid="frag-b",
+            primary=Frequency.F2,
+            dosage=Dosage.TOXIC,
+        )
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes([a, b])
+
+        assert len(paradoxes) == 1
+        assert paradoxes[0].contradiction_type == "dosage"
+        assert "F2" in paradoxes[0].frequencies
+
+    def test_different_frequency_no_paradox(self) -> None:
+        """Medicine vs toxic on different primaries is not a paradox."""
+        a = make_fragment(
+            "x",
+            fid="frag-a",
+            primary=Frequency.F1,
+            dosage=Dosage.MEDICINE,
+        )
+        b = make_fragment(
+            "x",
+            fid="frag-b",
+            primary=Frequency.F2,
+            dosage=Dosage.TOXIC,
+        )
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes([a, b])
+
+        assert not paradoxes
+
+
+# ---- Detection: explicit contradiction keywords ----
+
+
+class TestDetectKeywordContradiction:
+    """Rule 4: fragment titles with explicit contradiction keywords."""
+
+    @pytest.mark.parametrize("keyword", CONTRADICTION_KEYWORDS)
+    def test_detects_each_keyword(self, keyword: str) -> None:
+        """Each configured keyword triggers a keyword paradox."""
+        earlier = make_fragment(
+            "My views on commitment",
+            fid="frag-earlier",
+            threads=["thread-commit"],
+        )
+        later = make_fragment(
+            f"{keyword}, commitment matters",
+            fid="frag-later",
+            threads=["thread-commit"],
+        )
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes([earlier, later])
+
+        assert len(paradoxes) == 1
+        assert paradoxes[0].contradiction_type == "keyword"
+
+    def test_keyword_alone_without_link_no_paradox(self) -> None:
+        """Keyword without shared topic/thread/frequency produces no paradox."""
+        a = make_fragment("Totally unrelated", fid="frag-a")
+        b = make_fragment("I used to think sushi was great", fid="frag-b")
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes([a, b])
+
+        assert not paradoxes
+
+
+# ---- Detection: general behavior ----
+
+
+class TestDetectParadoxesGeneral:
+    """General behaviours across all detection rules."""
+
+    def test_no_paradox_for_unrelated_fragments(self) -> None:
+        """Fragments with no overlap produce no paradoxes."""
+        a = make_fragment("a", fid="frag-a")
+        b = make_fragment("b", fid="frag-b")
+
+        detector = ParadoxDetector()
+        assert not detector.detect_paradoxes([a, b])
+
+    def test_no_paradox_for_single_fragment(self) -> None:
+        """A single fragment cannot be a paradox."""
+        a = make_fragment("a", fid="frag-a")
+        detector = ParadoxDetector()
+        assert not detector.detect_paradoxes([a])
+
+    def test_detects_multiple_paradoxes(self) -> None:
+        """Multiple contradiction types across fragments each surface."""
+        a = make_fragment(
+            "Alpha",
+            fid="frag-a",
+            primary=Frequency.F3,
+            dosage=Dosage.MEDICINE,
+        )
+        b = make_fragment(
+            "Alpha inverted",
+            fid="frag-b",
+            primary=Frequency.F3,
+            dosage=Dosage.TOXIC,
+        )
+        c = make_fragment(
+            "Beta",
+            fid="frag-c",
+            confidence=Confidence.MUSING,
+            threads=["thread-x"],
+        )
+        d = make_fragment(
+            "Beta",
+            fid="frag-d",
+            confidence=Confidence.SETTLED,
+            threads=["thread-x"],
+        )
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes([a, b, c, d])
+
+        kinds = sorted(p.contradiction_type for p in paradoxes)
+        assert kinds == ["confidence", "dosage"]
+
+    def test_pairs_are_deduplicated(self) -> None:
+        """A fragment pair produces at most one paradox."""
+        a = make_fragment(
+            "Same thread, same freq",
+            fid="frag-a",
+            primary=Frequency.F5,
+            dosage=Dosage.MEDICINE,
+            confidence=Confidence.MUSING,
+            threads=["thread-x"],
+        )
+        b = make_fragment(
+            "Same thread, same freq",
+            fid="frag-b",
+            primary=Frequency.F5,
+            dosage=Dosage.TOXIC,
+            confidence=Confidence.SETTLED,
+            threads=["thread-x"],
+        )
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes([a, b])
+
+        assert len(paradoxes) == 1
+
+
+# ---- Note creation ----
+
+
+class TestCreateParadoxNote:
+    """Tests for ``ParadoxDetector.create_paradox_note``."""
+
+    @pytest.fixture()
+    def paradox(self) -> Paradox:
+        """Build a sample Paradox referencing two fragments on F2."""
+        return Paradox(
+            fragment_ids=["frag-a", "frag-b"],
+            contradiction_type="dosage",
+            frequencies=["F2"],
+            excerpts=["Solitude as refuge", "Solitude as exile"],
+            detected_date=date(2026, 4, 12),
+        )
+
+    def test_note_written_to_liminal_paradoxes(
+        self,
+        paradox: Paradox,
+        tmp_path: Path,
+    ) -> None:
+        """The note is written under 10-Liminal/Paradoxes/."""
+        detector = ParadoxDetector()
+        note_path = detector.create_paradox_note(paradox, tmp_path)
+
+        assert note_path.exists()
+        assert note_path.parent == tmp_path / "10-Liminal" / "Paradoxes"
+
+    def test_frontmatter_contains_required_fields(
+        self,
+        paradox: Paradox,
+        tmp_path: Path,
+    ) -> None:
+        """Frontmatter carries type, fragment links, frequencies, date."""
+        detector = ParadoxDetector()
+        note_path = detector.create_paradox_note(paradox, tmp_path)
+        post = frontmatter.load(str(note_path))
+
+        assert post["type"] == "paradox"
+        assert post["fragments"] == ["frag-a", "frag-b"]
+        assert post["frequencies"] == ["F2"]
+        assert post["detected_date"] == "2026-04-12"
+
+    def test_paradox_tag_is_applied(
+        self,
+        paradox: Paradox,
+        tmp_path: Path,
+    ) -> None:
+        """The ``paradox`` tag plus relevant frequency tags are set."""
+        detector = ParadoxDetector()
+        note_path = detector.create_paradox_note(paradox, tmp_path)
+        post = frontmatter.load(str(note_path))
+
+        tags = post["tags"]
+        assert "paradox" in tags
+        assert "f2" in tags
+
+    def test_body_links_to_both_fragments(
+        self,
+        paradox: Paradox,
+        tmp_path: Path,
+    ) -> None:
+        """Both fragment IDs appear as wikilinks in the body."""
+        detector = ParadoxDetector()
+        note_path = detector.create_paradox_note(paradox, tmp_path)
+        body = frontmatter.load(str(note_path)).content
+
+        assert "[[frag-a]]" in body
+        assert "[[frag-b]]" in body
+
+    def test_body_contains_both_excerpts(
+        self,
+        paradox: Paradox,
+        tmp_path: Path,
+    ) -> None:
+        """Both fragment excerpts appear in the body."""
+        detector = ParadoxDetector()
+        note_path = detector.create_paradox_note(paradox, tmp_path)
+        body = frontmatter.load(str(note_path)).content
+
+        assert "Solitude as refuge" in body
+        assert "Solitude as exile" in body
+
+    def test_body_includes_reflection_prompt(
+        self,
+        paradox: Paradox,
+        tmp_path: Path,
+    ) -> None:
+        """The reflection prompt is present, inviting integration not resolution."""
+        detector = ParadoxDetector()
+        note_path = detector.create_paradox_note(paradox, tmp_path)
+        body = frontmatter.load(str(note_path)).content
+
+        assert REFLECTION_PROMPT in body
+
+    def test_body_contains_no_resolution_language(
+        self,
+        paradox: Paradox,
+        tmp_path: Path,
+    ) -> None:
+        """The body never prescribes a resolution or renders judgment."""
+        detector = ParadoxDetector()
+        note_path = detector.create_paradox_note(paradox, tmp_path)
+        text = note_path.read_text(encoding="utf-8").lower()
+
+        forbidden = [
+            "resolve",
+            "resolution",
+            "should",
+            "must",
+            "correct",
+            "incorrect",
+            "right answer",
+            "wrong answer",
+            "fix this",
+        ]
+        for term in forbidden:
+            assert term not in text, f"paradox note leaked judgment: {term!r}"
+
+    def test_idempotent_for_same_paradox(
+        self,
+        paradox: Paradox,
+        tmp_path: Path,
+    ) -> None:
+        """Writing the same paradox twice produces a single stable file."""
+        detector = ParadoxDetector()
+        first = detector.create_paradox_note(paradox, tmp_path)
+        second = detector.create_paradox_note(paradox, tmp_path)
+
+        assert first == second
+        files = list((tmp_path / "10-Liminal" / "Paradoxes").glob("*.md"))
+        assert len(files) == 1


### PR DESCRIPTION
## Summary

Implements Section 10.2 of the Creek ontology — **Paradox Preservation**. When the system detects contradictory stances across fragments from the same person, it preserves the tension in `10-Liminal/Paradoxes/` instead of resolving it. Paradoxes are data points about the human's polygnostic nature, not errors to fix.

### What's new

- **`creek-tools/creek/generate/paradox.py`** — new module exposing:
  - `Paradox` — dataclass linking two fragments with their detected contradiction.
  - `ParadoxDetector` — detects contradictions and writes paradox notes.
  - `CONTRADICTION_KEYWORDS`, `REFLECTION_PROMPT` — public constants.

### Detection rules (`ParadoxDetector.detect_paradoxes`)

Each fragment pair is evaluated against four independent rules (first match wins, priority order: phase → keyword → confidence → dosage):

1. **Phase contradiction** — high semantic similarity (cosine ≥ 0.7) + opposite Archetypal Wavelength phases.
2. **Keyword contradiction** — explicit phrases (`but actually`, `I used to think`, `contrary to what I said`) on a topically-linked pair.
3. **Confidence contradiction** — shared thread + opposite confidence (`musing` vs `settled`).
4. **Dosage contradiction** — same primary frequency + opposite dosage (`medicine` vs `toxic`).

Embeddings are optional: rules 3 and 4 work without them; rules 1 and 2 fall back to thread/frequency overlap when embeddings are absent.

### Note creation (`ParadoxDetector.create_paradox_note`)

- Writes to `10-Liminal/Paradoxes/<date>-<frag-a>-<frag-b>.md`
- Frontmatter: `type: paradox`, `fragments`, `frequencies`, `detected_date`, `tags`
- Tagged with `paradox` plus lowercase frequency tags
- Body renders each fragment as a wikilink `[[frag-id]]` with excerpt
- "Observed Tension" section uses neutral, descriptive language only
- Reflection prompt invites integration: _"These fragments hold tension with each other. What truth lives in the space between them?"_
- A dedicated test asserts the note contains no resolution/judgment vocabulary (`resolve`, `should`, `must`, `correct`, `right answer`, etc.)

### Acceptance criteria

- [x] Contradictory fragment pairs detected (all 4 rules covered)
- [x] Paradox notes created in `10-Liminal/Paradoxes/`
- [x] Notes link to both fragments via `[[fragment_id]]` wikilinks
- [x] No resolution or judgment in paradox notes (enforced by test)
- [x] `#paradox` tag applied
- [x] 24 tests with synthetic contradictory fragment pairs

## Test plan

- [x] `./scripts/test.sh` — 2008 passed, 1 skipped (unrelated Ollama)
- [x] `./scripts/coverage.sh` — 94.55% total; 91.12% on `paradox.py`
- [x] `./scripts/lint.sh` — all checks passed
- [x] `./scripts/format.sh --check` — all checks passed
- [x] `./scripts/complexity.sh` — all ranks ≤ A
- [ ] `./scripts/typecheck.sh` — pre-existing failures only (stubs for `tqdm`, `decisions.py:169`, `embeddings.py:45/160`); no new errors in paradox module
- [ ] `./scripts/security.sh` — pre-existing pip-audit findings only (setuptools, wheel); no new issues

Closes #38