### PR TITLE
feat(generate): add compost tracking for abandoned threads (#40)

### DIFF
--- a/creek-tools/creek/generate/__init__.py
+++ b/creek-tools/creek/generate/__init__.py
@@ -1,5 +1,10 @@
 """Creek generate package — index and note generation for the Creek vault."""
 
+from creek.generate.compost import (
+    ABANDONMENT_KEYWORDS,
+    CompostCandidate,
+    CompostTracker,
+)
 from creek.generate.decisions import (
     DECISION_KEYWORDS,
     PRACTICE_MAP,
@@ -12,10 +17,13 @@ from creek.generate.indexes import FREQUENCY_COLORS, FREQUENCY_NAMES, IndexGener
 from creek.generate.tags import TagGardenGenerator, TagScanResult
 
 __all__ = [
+    "ABANDONMENT_KEYWORDS",
     "DECISION_KEYWORDS",
     "FREQUENCY_COLORS",
     "FREQUENCY_NAMES",
     "PRACTICE_MAP",
+    "CompostCandidate",
+    "CompostTracker",
     "DecisionContext",
     "DecisionContextGatherer",
     "DecisionDetector",

--- a/creek-tools/creek/generate/compost.py
+++ b/creek-tools/creek/generate/compost.py
@@ -1,0 +1,523 @@
+"""Compost tracking — abandoned threads and projects as composted notes.
+
+Implements Section 10.4 of the Creek Ontology. The :class:`CompostTracker`
+surfaces threads, fragments, and projects that have fallen dormant or been
+explicitly abandoned, writes ``10-Liminal/Compost/`` notes preserving what
+each idea was, why it faded, and what energy may still be alive, and
+generates an overview report cross-referencing active threads.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.models import (
+    Confidence,
+    Fragment,
+    PraxisPotential,
+    Thread,
+    ThreadStatus,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+ABANDONMENT_KEYWORDS: tuple[str, ...] = (
+    "gave up on",
+    "abandoned",
+    "never finished",
+    "put aside",
+    "shelved",
+)
+"""Case-insensitive phrases flagging a fragment as describing abandonment."""
+
+_DORMANCY_DAYS: int = 180
+"""Threads without new fragments for this many days become compost."""
+
+_PROJECT_GAP_DAYS: int = 180
+"""Projects whose latest fragment is older than this are treated as gone."""
+
+_PROJECT_MIN_FRAGMENTS: int = 2
+"""A project must appear in at least this many fragments to be tracked."""
+
+_HIGH_CONFIDENCE: frozenset[str] = frozenset(
+    {Confidence.SETTLED.value, Confidence.CONVICTION.value},
+)
+"""Confidence levels whose fragments count as surviving energy."""
+
+_UNKNOWN_REASON: str = "unknown"
+"""Rendered when a candidate has no recorded reason."""
+
+
+@dataclass
+class CompostCandidate:
+    """A single compost candidate flagged by :class:`CompostTracker`.
+
+    Attributes:
+        source_type: One of ``"thread"``, ``"fragment"``, or ``"project"``.
+        source_id: Thread ID, fragment ID, or project tag — the key that
+            uniquely identifies the source in the vault.
+        title: Human-readable title of the thread, fragment, or project.
+        reason: Explanation of why the source was composted (empty string
+            when unknown; the note body renders ``unknown`` in that case).
+        fragment_ids: Every fragment ID linked to the source. For project
+            candidates, this is the set of fragments that carried the tag.
+        energy_fragment_ids: IDs of fragments whose confidence or
+            ``praxis_potential`` marks them as crystallised thinking worth
+            preserving ("what energy remains").
+        matched_keywords: Abandonment keywords matched against the source.
+            Empty for thread and project candidates.
+        energy_excerpts: Optional short excerpts describing the surviving
+            energy; rendered as bullet points under "What energy remains".
+    """
+
+    source_type: str
+    source_id: str
+    title: str
+    reason: str
+    fragment_ids: list[str] = field(default_factory=list)
+    energy_fragment_ids: list[str] = field(default_factory=list)
+    matched_keywords: list[str] = field(default_factory=list)
+    energy_excerpts: list[str] = field(default_factory=list)
+
+
+# ---- Helpers ----
+
+
+def _confidence_value(fragment: Fragment) -> str:
+    """Return the fragment's voice confidence as a string (or empty)."""
+    return str(fragment.voice.confidence) if fragment.voice.confidence else ""
+
+
+def _fragment_is_energetic(fragment: Fragment) -> bool:
+    """Return whether a fragment carries crystallised, surviving energy."""
+    if _confidence_value(fragment) in _HIGH_CONFIDENCE:
+        return True
+    return str(fragment.praxis_potential) == PraxisPotential.EXPLICIT.value
+
+
+def _fragment_thread_titles(fragment: Fragment) -> list[str]:
+    """Extract wiki-linked thread titles from a fragment's ``threads`` list."""
+    titles: list[str] = []
+    for raw in fragment.threads:
+        match = re.fullmatch(r"\[\[(.+)\]\]", raw.strip())
+        titles.append(match.group(1) if match else raw.strip())
+    return titles
+
+
+def _matched_abandonment_keywords(title: str) -> list[str]:
+    """Return abandonment keywords present in *title* (case-insensitive)."""
+    lowered = title.lower()
+    return [kw for kw in ABANDONMENT_KEYWORDS if kw in lowered]
+
+
+def _sanitize_filename(title: str) -> str:
+    """Sanitise a title for use as part of a filename."""
+    cleaned = re.sub(r"[^\w\s-]", "", title).strip()
+    cleaned = re.sub(r"\s+", "-", cleaned)
+    return cleaned[:80] or "compost"
+
+
+class CompostTracker:
+    """Track, record, and report on composted threads and projects.
+
+    Attributes:
+        dormancy_days: Idle window after which threads become compost.
+        project_gap_days: Gap after which a tagged project is compost.
+        project_min_fragments: Minimum fragment count to track a project.
+    """
+
+    def __init__(
+        self,
+        *,
+        dormancy_days: int = _DORMANCY_DAYS,
+        project_gap_days: int = _PROJECT_GAP_DAYS,
+        project_min_fragments: int = _PROJECT_MIN_FRAGMENTS,
+        now: datetime | None = None,
+    ) -> None:
+        """Initialise the tracker.
+
+        Args:
+            dormancy_days: Threads without new fragments for this many
+                days become compost candidates. Defaults to 180.
+            project_gap_days: Projects whose most recent fragment is
+                older than this (in days) count as compost. Defaults to
+                180.
+            project_min_fragments: Minimum fragment count for a project
+                (tag) to be tracked. Defaults to 2.
+            now: Reference "now" for age calculations. Defaults to
+                :func:`datetime.now` (timezone-naive). Useful for
+                deterministic tests.
+        """
+        self.dormancy_days = dormancy_days
+        self.project_gap_days = project_gap_days
+        self.project_min_fragments = project_min_fragments
+        self._now = now or datetime.now(tz=UTC).replace(tzinfo=None)
+
+    # ---- Detection ----
+
+    def detect_compost_candidates(
+        self,
+        threads: list[Thread],
+        fragments: list[Fragment],
+    ) -> list[CompostCandidate]:
+        """Scan *threads* and *fragments* for compost candidates.
+
+        The detection covers three sources:
+
+        1. Threads with ``status == resolved`` or whose ``last_seen`` is
+           older than :attr:`dormancy_days`.
+        2. Fragments whose title contains an abandonment keyword.
+        3. Tagged projects that appear in early fragments but have not
+           been mentioned for more than :attr:`project_gap_days`.
+
+        Args:
+            threads: Threads to scan.
+            fragments: Fragments to scan (used for keyword detection,
+                project tracking, and energy extraction).
+
+        Returns:
+            A list of :class:`CompostCandidate` models, ordered
+            thread-candidates → fragment-candidates → project-candidates.
+        """
+        thread_candidates = self._detect_threads(threads, fragments)
+        fragment_candidates = self._detect_keyword_fragments(fragments)
+        project_candidates = self._detect_disappeared_projects(fragments)
+        return [*thread_candidates, *fragment_candidates, *project_candidates]
+
+    def _detect_threads(
+        self,
+        threads: list[Thread],
+        fragments: list[Fragment],
+    ) -> list[CompostCandidate]:
+        """Detect compost candidates whose source is a thread."""
+        today = self._now.date()
+        candidates: list[CompostCandidate] = []
+        for thread in threads:
+            reason = self._thread_reason(thread, today)
+            if reason is None:
+                continue
+            related = [
+                frag
+                for frag in fragments
+                if thread.title in _fragment_thread_titles(frag)
+            ]
+            candidates.append(
+                CompostCandidate(
+                    source_type="thread",
+                    source_id=thread.id,
+                    title=thread.title,
+                    reason=reason,
+                    fragment_ids=[frag.id for frag in related],
+                    energy_fragment_ids=[
+                        frag.id for frag in related if _fragment_is_energetic(frag)
+                    ],
+                    energy_excerpts=[
+                        frag.title for frag in related if _fragment_is_energetic(frag)
+                    ],
+                ),
+            )
+        return candidates
+
+    def _thread_reason(self, thread: Thread, today: date) -> str | None:
+        """Return a compost reason for *thread*, or ``None`` if not a candidate."""
+        if str(thread.status) == ThreadStatus.RESOLVED.value:
+            return "Thread marked resolved"
+        days_since = (today - thread.last_seen).days
+        if days_since > self.dormancy_days:
+            return f"Dormant for {days_since} days"
+        return None
+
+    def _detect_keyword_fragments(
+        self,
+        fragments: list[Fragment],
+    ) -> list[CompostCandidate]:
+        """Detect fragments whose title signals abandonment."""
+        candidates: list[CompostCandidate] = []
+        for fragment in fragments:
+            matched = _matched_abandonment_keywords(fragment.title)
+            if not matched:
+                continue
+            candidates.append(
+                CompostCandidate(
+                    source_type="fragment",
+                    source_id=fragment.id,
+                    title=fragment.title,
+                    reason=f"Abandonment keyword: {matched[0]}",
+                    fragment_ids=[fragment.id],
+                    energy_fragment_ids=(
+                        [fragment.id] if _fragment_is_energetic(fragment) else []
+                    ),
+                    matched_keywords=matched,
+                    energy_excerpts=(
+                        [fragment.title] if _fragment_is_energetic(fragment) else []
+                    ),
+                ),
+            )
+        return candidates
+
+    def _detect_disappeared_projects(
+        self,
+        fragments: list[Fragment],
+    ) -> list[CompostCandidate]:
+        """Detect tagged projects that have fallen silent."""
+        cutoff = self._now - timedelta(days=self.project_gap_days)
+        tag_fragments = self._group_fragments_by_tag(fragments)
+        candidates: list[CompostCandidate] = []
+        for tag, frags in tag_fragments.items():
+            candidate = self._project_candidate(tag, frags, cutoff)
+            if candidate is not None:
+                candidates.append(candidate)
+        return candidates
+
+    @staticmethod
+    def _group_fragments_by_tag(
+        fragments: list[Fragment],
+    ) -> dict[str, list[Fragment]]:
+        """Group fragments by each tag they carry."""
+        grouped: dict[str, list[Fragment]] = defaultdict(list)
+        for fragment in fragments:
+            for tag in fragment.tags:
+                grouped[tag].append(fragment)
+        return grouped
+
+    def _project_candidate(
+        self,
+        tag: str,
+        frags: list[Fragment],
+        cutoff: datetime,
+    ) -> CompostCandidate | None:
+        """Return a project candidate for *tag*, or ``None`` if still active."""
+        if len(frags) < self.project_min_fragments:
+            return None
+        last_seen = max(frag.created for frag in frags)
+        if last_seen >= cutoff:
+            return None
+        days = (self._now - last_seen).days
+        energetic = [frag for frag in frags if _fragment_is_energetic(frag)]
+        return CompostCandidate(
+            source_type="project",
+            source_id=tag,
+            title=tag,
+            reason=f"Project silent for {days} days",
+            fragment_ids=[frag.id for frag in frags],
+            energy_fragment_ids=[frag.id for frag in energetic],
+            energy_excerpts=[frag.title for frag in energetic],
+        )
+
+    # ---- Note generation ----
+
+    def create_compost_note(
+        self,
+        candidate: CompostCandidate,
+        vault_path: Path,
+    ) -> Path:
+        """Write a compost note for *candidate* into the vault.
+
+        The note lives at ``10-Liminal/Compost/<date>-<sanitised-title>.md``.
+        Frontmatter captures the source reference, composted date, reason,
+        tags, and fragment links. The body carries the three required
+        sections ("What it was", "Why it composted", "What energy
+        remains") plus a trailing list of all related fragments.
+
+        Args:
+            candidate: The compost candidate to record.
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            Path to the written note.
+        """
+        compost_dir = vault_path / "10-Liminal" / "Compost"
+        compost_dir.mkdir(parents=True, exist_ok=True)
+
+        today = self._now.date()
+        metadata = self._build_metadata(candidate, today)
+        body = self._render_body(candidate)
+        post = frontmatter.Post(content=body, **metadata)
+
+        filename = f"{today.isoformat()}-{_sanitize_filename(candidate.title)}.md"
+        note_path = compost_dir / filename
+        note_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return note_path
+
+    @staticmethod
+    def _build_metadata(
+        candidate: CompostCandidate,
+        today: date,
+    ) -> dict[str, object]:
+        """Build the frontmatter metadata dict for *candidate*."""
+        metadata: dict[str, object] = {
+            "type": "compost",
+            "title": candidate.title,
+            "composted_date": today.isoformat(),
+            "reason": candidate.reason,
+            "fragments": [f"[[{fid}]]" for fid in candidate.fragment_ids],
+            "tags": ["compost"],
+        }
+        if candidate.source_type == "thread":
+            metadata["original_thread"] = f"[[{candidate.source_id}]]"
+        elif candidate.source_type == "fragment":
+            metadata["original_fragment"] = f"[[{candidate.source_id}]]"
+        else:
+            metadata["original_project"] = candidate.source_id
+        if candidate.matched_keywords:
+            metadata["matched_keywords"] = list(candidate.matched_keywords)
+        return metadata
+
+    @staticmethod
+    def _render_body(candidate: CompostCandidate) -> str:
+        """Render the markdown body for *candidate*."""
+        lines: list[str] = []
+        lines.append("## What it was")
+        lines.append("")
+        lines.append(
+            f"A {candidate.source_type} titled **{candidate.title}** that "
+            "has since composted back into the vault.",
+        )
+        lines.append("")
+        lines.append("## Why it composted")
+        lines.append("")
+        lines.append(candidate.reason or _UNKNOWN_REASON)
+        lines.append("")
+        lines.append("## What energy remains")
+        lines.append("")
+        if candidate.energy_fragment_ids:
+            for fid in candidate.energy_fragment_ids:
+                lines.append(f"- [[{fid}]]")
+            if candidate.energy_excerpts:
+                lines.append("")
+                for excerpt in candidate.energy_excerpts:
+                    lines.append(f"> {excerpt}")
+        else:
+            lines.append("_No crystallised insights were flagged for preservation._")
+        lines.append("")
+        lines.append("## Related Fragments")
+        lines.append("")
+        if candidate.fragment_ids:
+            for fid in candidate.fragment_ids:
+                lines.append(f"- [[{fid}]]")
+        else:
+            lines.append("_No related fragments were recorded._")
+        lines.append("")
+        return "\n".join(lines)
+
+    # ---- Reporting ----
+
+    def generate_compost_report(self, vault_path: Path) -> Path:
+        """Generate the vault-level compost overview report.
+
+        The report lives at ``10-Liminal/Compost/_Compost-Report.md`` and
+        contains a Dataview query that lists every compost note plus a
+        section cross-referencing currently active threads (so you can
+        notice when a composted idea resurfaces in new growth).
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            Path to the generated report file.
+        """
+        compost_dir = vault_path / "10-Liminal" / "Compost"
+        compost_dir.mkdir(parents=True, exist_ok=True)
+        report_path = compost_dir / "_Compost-Report.md"
+
+        existing_notes = self._load_existing_compost_notes(compost_dir, report_path)
+        active_threads = self._load_active_threads(vault_path / "02-Threads")
+
+        text = self._render_report(existing_notes, active_threads, self._now.date())
+        report_path.write_text(text, encoding="utf-8")
+        return report_path
+
+    @staticmethod
+    def _load_existing_compost_notes(
+        compost_dir: Path,
+        report_path: Path,
+    ) -> list[tuple[str, str]]:
+        """Return ``(title, filename)`` tuples for compost notes in *compost_dir*."""
+        notes: list[tuple[str, str]] = []
+        for md_file in sorted(compost_dir.glob("*.md")):
+            if md_file == report_path:
+                continue
+            try:
+                post = frontmatter.load(str(md_file))
+            except (OSError, ValueError):
+                continue
+            if post.get("type") != "compost":
+                continue
+            title = str(post.get("title") or md_file.stem)
+            notes.append((title, md_file.stem))
+        return notes
+
+    @staticmethod
+    def _load_active_threads(threads_dir: Path) -> list[tuple[str, str]]:
+        """Return ``(title, id)`` tuples for active thread notes."""
+        if not threads_dir.exists():
+            return []
+        active: list[tuple[str, str]] = []
+        for md_file in sorted(threads_dir.glob("*.md")):
+            try:
+                post = frontmatter.load(str(md_file))
+            except (OSError, ValueError):
+                continue
+            status = str(post.get("status") or "")
+            if status != ThreadStatus.ACTIVE.value:
+                continue
+            title = str(post.get("title") or md_file.stem)
+            thread_id = str(post.get("id") or md_file.stem)
+            active.append((title, thread_id))
+        return active
+
+    @staticmethod
+    def _render_report(
+        compost_notes: list[tuple[str, str]],
+        active_threads: list[tuple[str, str]],
+        generated_on: date,
+    ) -> str:
+        """Render the full markdown report text."""
+        lines = [
+            "---",
+            "title: Compost Report",
+            "type: compost-report",
+            f"generated: {generated_on.isoformat()}",
+            "---",
+            "",
+            "# Compost Report",
+            "",
+            "This report surveys every composting idea in the vault and ",
+            "cross-references them against the threads currently alive.",
+            "",
+            "## All Compost Notes",
+            "",
+            "```dataview",
+            "TABLE composted_date, reason",
+            'FROM "10-Liminal/Compost"',
+            'WHERE type = "compost"',
+            "SORT composted_date DESC",
+            "```",
+            "",
+            "## Composting Ideas (snapshot)",
+            "",
+        ]
+        if compost_notes:
+            for title, stem in compost_notes:
+                lines.append(f"- [[{stem}|{title}]]")
+        else:
+            lines.append("_No compost notes recorded yet._")
+        lines.extend(["", "## Active Threads", ""])
+        lines.append(
+            "Use this list to notice when composted ideas feed new growth:",
+        )
+        lines.append("")
+        if active_threads:
+            for title, thread_id in active_threads:
+                lines.append(f"- [[{thread_id}|{title}]]")
+        else:
+            lines.append("_No active threads recorded yet._")
+        lines.append("")
+        return "\n".join(lines)

--- a/creek-tools/tests/test_compost.py
+++ b/creek-tools/tests/test_compost.py
@@ -1,0 +1,711 @@
+"""Tests for creek.generate.compost — compost tracking for abandoned threads.
+
+Covers the ``CompostTracker`` class (detection, note creation, report
+generation) plus the ``CompostCandidate`` dataclass and helper
+utilities. All behaviour maps to the acceptance criteria on Issue #40.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from creek.generate.compost import (
+    ABANDONMENT_KEYWORDS,
+    CompostCandidate,
+    CompostTracker,
+)
+from creek.models import (
+    Confidence,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    PraxisPotential,
+    SourcePlatform,
+    Thread,
+    ThreadStatus,
+    VoiceClassification,
+)
+
+# ---- Fixtures ----
+
+
+@pytest.fixture()
+def vault_path(tmp_path: Path) -> Path:
+    """Create a minimal vault structure with the Compost subtree."""
+    dirs = [
+        "00-Creek-Meta",
+        "02-Threads",
+        "10-Liminal/Compost",
+    ]
+    for rel in dirs:
+        (tmp_path / rel).mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+@pytest.fixture()
+def reference_now() -> datetime:
+    """Reference "now" that all age calculations use in tests."""
+    return datetime(2026, 4, 1, 12, 0, 0)
+
+
+@pytest.fixture()
+def tracker(reference_now: datetime) -> CompostTracker:
+    """Create a CompostTracker with a deterministic clock."""
+    return CompostTracker(now=reference_now)
+
+
+def _fragment(
+    *,
+    frag_id: str,
+    title: str,
+    created: datetime,
+    confidence: Confidence | None = None,
+    praxis_potential: PraxisPotential = PraxisPotential.NONE,
+    threads: list[str] | None = None,
+    tags: list[str] | None = None,
+) -> Fragment:
+    """Build a minimal fragment for testing."""
+    return Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        created=created,
+        frequency=FrequencyClassification(primary=Frequency.F5),
+        voice=VoiceClassification(confidence=confidence),
+        praxis_potential=praxis_potential,
+        threads=threads or [],
+        tags=tags or [],
+    )
+
+
+@pytest.fixture()
+def dormant_thread() -> Thread:
+    """Thread whose last_seen is beyond the dormancy threshold."""
+    return Thread(
+        id="thread-dormant1",
+        title="Abandoned Sourdough Experiments",
+        status=ThreadStatus.DORMANT,
+        first_seen=date(2024, 1, 1),
+        last_seen=date(2025, 8, 1),
+        fragment_count=4,
+        frequency_affinity=[Frequency.F5],
+        description="Tried sourdough every weekend for months then drifted.",
+    )
+
+
+@pytest.fixture()
+def resolved_thread() -> Thread:
+    """Thread explicitly marked resolved."""
+    return Thread(
+        id="thread-resolved1",
+        title="Deciding on a thesis topic",
+        status=ThreadStatus.RESOLVED,
+        first_seen=date(2025, 1, 1),
+        last_seen=date(2025, 3, 15),
+        fragment_count=6,
+        frequency_affinity=[Frequency.F6],
+        description="Settled on a direction in March.",
+    )
+
+
+@pytest.fixture()
+def active_thread() -> Thread:
+    """Thread that is still active (not a compost candidate)."""
+    return Thread(
+        id="thread-active01",
+        title="Daily Meditation Practice",
+        status=ThreadStatus.ACTIVE,
+        first_seen=date(2025, 6, 1),
+        last_seen=date(2026, 3, 20),
+        fragment_count=40,
+        frequency_affinity=[Frequency.F7],
+        description="Ongoing sit practice.",
+    )
+
+
+# ---- ABANDONMENT_KEYWORDS ----
+
+
+class TestAbandonmentKeywords:
+    """Ensure the canonical keyword list meets issue spec."""
+
+    def test_keywords_is_nonempty_tuple(self) -> None:
+        """ABANDONMENT_KEYWORDS should be a non-empty tuple of strings."""
+        assert isinstance(ABANDONMENT_KEYWORDS, tuple)
+        assert len(ABANDONMENT_KEYWORDS) > 0
+
+    def test_keywords_are_lowercase(self) -> None:
+        """All keywords must be lowercase (we match case-insensitively)."""
+        for keyword in ABANDONMENT_KEYWORDS:
+            assert keyword == keyword.lower()
+
+    def test_required_keywords_present(self) -> None:
+        """The keywords listed in the issue spec must be present."""
+        required = (
+            "gave up on",
+            "abandoned",
+            "never finished",
+            "put aside",
+            "shelved",
+        )
+        for keyword in required:
+            assert keyword in ABANDONMENT_KEYWORDS
+
+
+# ---- CompostTracker.detect_compost_candidates ----
+
+
+class TestDetectCompostCandidates:
+    """Detection of compost candidates across threads and fragments."""
+
+    def test_dormant_thread_detected(
+        self,
+        tracker: CompostTracker,
+        dormant_thread: Thread,
+    ) -> None:
+        """Threads inactive >180 days should surface."""
+        candidates = tracker.detect_compost_candidates([dormant_thread], [])
+        thread_candidates = [c for c in candidates if c.source_type == "thread"]
+        assert any(c.source_id == dormant_thread.id for c in thread_candidates)
+
+    def test_resolved_thread_detected(
+        self,
+        tracker: CompostTracker,
+        resolved_thread: Thread,
+    ) -> None:
+        """Resolved threads should always be compost candidates."""
+        candidates = tracker.detect_compost_candidates([resolved_thread], [])
+        assert any(c.source_id == resolved_thread.id for c in candidates)
+
+    def test_active_thread_excluded(
+        self,
+        tracker: CompostTracker,
+        active_thread: Thread,
+    ) -> None:
+        """Active threads must not surface as compost candidates."""
+        candidates = tracker.detect_compost_candidates([active_thread], [])
+        thread_ids = {c.source_id for c in candidates}
+        assert active_thread.id not in thread_ids
+
+    def test_keyword_fragment_detected(
+        self,
+        tracker: CompostTracker,
+    ) -> None:
+        """Fragments whose title contains an abandonment keyword surface."""
+        frag = _fragment(
+            frag_id="frag-abandon1",
+            title="I finally gave up on the novel",
+            created=datetime(2025, 6, 1, 8, 0, 0),
+        )
+        candidates = tracker.detect_compost_candidates([], [frag])
+        keyword_hits = [c for c in candidates if c.source_type == "fragment"]
+        assert any(c.source_id == frag.id for c in keyword_hits)
+        assert "gave up on" in keyword_hits[0].matched_keywords
+
+    def test_fragment_without_keyword_ignored(
+        self,
+        tracker: CompostTracker,
+    ) -> None:
+        """Fragments without abandonment keywords should not surface."""
+        frag = _fragment(
+            frag_id="frag-neutral1",
+            title="Notes on a productive morning",
+            created=datetime(2025, 6, 1, 8, 0, 0),
+        )
+        candidates = tracker.detect_compost_candidates([], [frag])
+        assert [c for c in candidates if c.source_id == frag.id] == []
+
+    def test_disappeared_project_detected(
+        self,
+        tracker: CompostTracker,
+        reference_now: datetime,
+    ) -> None:
+        """Projects (tags) that appear early but vanish become candidates."""
+        early = datetime(2024, 1, 15, 12, 0, 0)
+        later_cutoff = reference_now - timedelta(days=300)
+        fragments = [
+            _fragment(
+                frag_id=f"frag-proj-{idx}",
+                title=f"Greenhouse notes {idx}",
+                created=early + timedelta(days=idx),
+                tags=["greenhouse"],
+            )
+            for idx in range(3)
+        ]
+        # A totally unrelated recent fragment so the fragment list is not empty
+        fragments.append(
+            _fragment(
+                frag_id="frag-current",
+                title="Current unrelated fragment",
+                created=later_cutoff + timedelta(days=250),
+                tags=["other"],
+            ),
+        )
+        candidates = tracker.detect_compost_candidates([], fragments)
+        project_candidates = [c for c in candidates if c.source_type == "project"]
+        assert any(c.source_id == "greenhouse" for c in project_candidates)
+
+    def test_active_project_not_flagged(
+        self,
+        tracker: CompostTracker,
+        reference_now: datetime,
+    ) -> None:
+        """Projects with a recent fragment must not be flagged."""
+        fragments = [
+            _fragment(
+                frag_id="frag-p-a",
+                title="Piano early",
+                created=reference_now - timedelta(days=400),
+                tags=["piano"],
+            ),
+            _fragment(
+                frag_id="frag-p-b",
+                title="Piano middle",
+                created=reference_now - timedelta(days=200),
+                tags=["piano"],
+            ),
+            _fragment(
+                frag_id="frag-p-c",
+                title="Piano recent",
+                created=reference_now - timedelta(days=10),
+                tags=["piano"],
+            ),
+        ]
+        candidates = tracker.detect_compost_candidates([], fragments)
+        project_ids = {c.source_id for c in candidates if c.source_type == "project"}
+        assert "piano" not in project_ids
+
+    def test_empty_inputs_return_empty(self, tracker: CompostTracker) -> None:
+        """No threads or fragments → no candidates."""
+        assert tracker.detect_compost_candidates([], []) == []
+
+    def test_candidate_captures_energy_fragments(
+        self,
+        tracker: CompostTracker,
+        dormant_thread: Thread,
+    ) -> None:
+        """Candidates must link to high-confidence fragments as ``energy``."""
+        settled_frag = _fragment(
+            frag_id="frag-energy1",
+            title="Key sourdough insight",
+            created=datetime(2025, 7, 15, 9, 0, 0),
+            confidence=Confidence.SETTLED,
+            threads=[f"[[{dormant_thread.title}]]"],
+        )
+        low_frag = _fragment(
+            frag_id="frag-musing1",
+            title="Stray sourdough notes",
+            created=datetime(2025, 7, 16, 9, 0, 0),
+            confidence=Confidence.MUSING,
+            threads=[f"[[{dormant_thread.title}]]"],
+        )
+        candidates = tracker.detect_compost_candidates(
+            [dormant_thread],
+            [settled_frag, low_frag],
+        )
+        thread_cand = next(c for c in candidates if c.source_type == "thread")
+        assert settled_frag.id in thread_cand.energy_fragment_ids
+        assert low_frag.id not in thread_cand.energy_fragment_ids
+
+    def test_praxis_potential_counts_as_energy(
+        self,
+        tracker: CompostTracker,
+        resolved_thread: Thread,
+    ) -> None:
+        """Fragments with explicit praxis_potential count as energy."""
+        frag = _fragment(
+            frag_id="frag-praxis1",
+            title="Praxis fragment for thesis",
+            created=datetime(2025, 2, 1, 9, 0, 0),
+            praxis_potential=PraxisPotential.EXPLICIT,
+            threads=[f"[[{resolved_thread.title}]]"],
+        )
+        candidates = tracker.detect_compost_candidates([resolved_thread], [frag])
+        thread_cand = next(c for c in candidates if c.source_type == "thread")
+        assert frag.id in thread_cand.energy_fragment_ids
+
+
+# ---- CompostTracker.create_compost_note ----
+
+
+class TestCreateCompostNote:
+    """Vault note creation for a compost candidate."""
+
+    def test_note_written_to_compost_folder(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Notes must land in ``10-Liminal/Compost/``."""
+        candidate = CompostCandidate(
+            source_type="thread",
+            source_id="thread-dormant1",
+            title="Abandoned Sourdough Experiments",
+            reason="Dormant for 244 days",
+            fragment_ids=["frag-1", "frag-2"],
+            energy_fragment_ids=["frag-1"],
+            matched_keywords=[],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        assert path.parent == vault_path / "10-Liminal" / "Compost"
+        assert path.exists()
+
+    def test_note_has_required_frontmatter(
+        self,
+        tracker: CompostTracker,
+        reference_now: datetime,
+        vault_path: Path,
+    ) -> None:
+        """Frontmatter must record type, reason, fragments, and date."""
+        candidate = CompostCandidate(
+            source_type="thread",
+            source_id="thread-dormant1",
+            title="Abandoned Sourdough Experiments",
+            reason="Dormant for 244 days",
+            fragment_ids=["frag-1", "frag-2"],
+            energy_fragment_ids=["frag-1"],
+            matched_keywords=[],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        post = frontmatter.load(str(path))
+        assert post["type"] == "compost"
+        assert post["original_thread"] == "[[thread-dormant1]]"
+        assert post["composted_date"] == reference_now.date().isoformat()
+        assert post["reason"] == "Dormant for 244 days"
+        assert post["fragments"] == ["[[frag-1]]", "[[frag-2]]"]
+
+    def test_note_body_has_required_sections(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """The body must contain the three required narrative sections."""
+        candidate = CompostCandidate(
+            source_type="thread",
+            source_id="thread-dormant1",
+            title="Abandoned Sourdough Experiments",
+            reason="Dormant for 244 days",
+            fragment_ids=["frag-1"],
+            energy_fragment_ids=["frag-1"],
+            matched_keywords=[],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        body = frontmatter.load(str(path)).content
+        assert "## What it was" in body
+        assert "## Why it composted" in body
+        assert "## What energy remains" in body
+
+    def test_note_lists_energy_fragment_links(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """The energy section must list wiki-links to energy fragments."""
+        candidate = CompostCandidate(
+            source_type="thread",
+            source_id="thread-dormant1",
+            title="Abandoned Sourdough Experiments",
+            reason="Dormant",
+            fragment_ids=["frag-1", "frag-2"],
+            energy_fragment_ids=["frag-1"],
+            matched_keywords=[],
+            energy_excerpts=["Key insight about fermentation"],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        body = frontmatter.load(str(path)).content
+        assert "[[frag-1]]" in body
+        assert "Key insight about fermentation" in body
+
+    def test_note_tagged_compost(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Compost notes must carry the ``#compost`` tag."""
+        candidate = CompostCandidate(
+            source_type="thread",
+            source_id="thread-x",
+            title="Some thread",
+            reason="Resolved",
+            fragment_ids=[],
+            energy_fragment_ids=[],
+            matched_keywords=[],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        post = frontmatter.load(str(path))
+        tags = post.get("tags") or []
+        assert "compost" in tags
+
+    def test_unknown_reason_recorded(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Missing reason renders as 'unknown' in the body."""
+        candidate = CompostCandidate(
+            source_type="fragment",
+            source_id="frag-a",
+            title="Fragment without reason",
+            reason="",
+            fragment_ids=["frag-a"],
+            energy_fragment_ids=[],
+            matched_keywords=[],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        body = frontmatter.load(str(path)).content
+        assert "unknown" in body.lower()
+
+    def test_fragment_source_uses_original_fragment_link(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Fragment-sourced candidates link to their fragment, not a thread."""
+        candidate = CompostCandidate(
+            source_type="fragment",
+            source_id="frag-abandon",
+            title="I finally gave up on the novel",
+            reason="Abandonment keyword: gave up on",
+            fragment_ids=["frag-abandon"],
+            energy_fragment_ids=[],
+            matched_keywords=["gave up on"],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        post = frontmatter.load(str(path))
+        assert "original_thread" not in post.metadata
+        assert post["original_fragment"] == "[[frag-abandon]]"
+
+
+# ---- CompostTracker.generate_compost_report ----
+
+
+class TestGenerateCompostReport:
+    """Vault-level compost report generation."""
+
+    def test_report_written_to_compost_root(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """The report is written inside the Compost directory."""
+        path = tracker.generate_compost_report(vault_path)
+        assert path.parent == vault_path / "10-Liminal" / "Compost"
+        assert path.exists()
+
+    def test_report_contains_dataview_query(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Report should use a Dataview query to list compost notes."""
+        path = tracker.generate_compost_report(vault_path)
+        text = path.read_text(encoding="utf-8")
+        assert "```dataview" in text
+        assert 'type = "compost"' in text
+
+    def test_report_cross_references_active_threads(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Report should include an active-thread cross-reference section."""
+        path = tracker.generate_compost_report(vault_path)
+        text = path.read_text(encoding="utf-8")
+        assert "Active Threads" in text
+
+    def test_report_lists_existing_compost_notes(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Existing compost notes must appear in the report body."""
+        compost_dir = vault_path / "10-Liminal" / "Compost"
+        existing = compost_dir / "2025-08-01-abandoned-sourdough.md"
+        existing.write_text(
+            "---\n"
+            "type: compost\n"
+            "title: Abandoned Sourdough\n"
+            "composted_date: 2025-08-01\n"
+            "---\n\n"
+            "## What it was\n\nSourdough explorations.\n",
+            encoding="utf-8",
+        )
+        path = tracker.generate_compost_report(vault_path)
+        text = path.read_text(encoding="utf-8")
+        assert "Abandoned Sourdough" in text
+
+    def test_report_skips_non_compost_notes(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Files that aren't compost notes should be ignored."""
+        compost_dir = vault_path / "10-Liminal" / "Compost"
+        stranger = compost_dir / "stranger.md"
+        stranger.write_text(
+            "---\ntype: note\ntitle: Something Else\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+        path = tracker.generate_compost_report(vault_path)
+        text = path.read_text(encoding="utf-8")
+        assert "Something Else" not in text
+
+    def test_report_ignores_unparseable_compost_file(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Compost files that cannot be parsed should not crash the report."""
+        compost_dir = vault_path / "10-Liminal" / "Compost"
+        # Binary bytes will make frontmatter.load raise.
+        (compost_dir / "broken.md").write_bytes(b"\x00\x01\x02")
+        path = tracker.generate_compost_report(vault_path)
+        assert path.exists()
+
+    def test_report_regenerates_over_existing_report(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Running the report twice must not re-list the report itself."""
+        first = tracker.generate_compost_report(vault_path)
+        second = tracker.generate_compost_report(vault_path)
+        assert first == second
+        text = second.read_text(encoding="utf-8")
+        assert "[[_Compost-Report|" not in text
+
+    def test_report_lists_active_threads(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Active threads in ``02-Threads`` should appear in the report."""
+        threads_dir = vault_path / "02-Threads"
+        (threads_dir / "daily-meditation.md").write_text(
+            "---\n"
+            "id: thread-active01\n"
+            "title: Daily Meditation Practice\n"
+            "status: active\n"
+            "---\n",
+            encoding="utf-8",
+        )
+        (threads_dir / "resolved-thesis.md").write_text(
+            "---\nid: thread-res1\ntitle: Old Thesis\nstatus: resolved\n---\n",
+            encoding="utf-8",
+        )
+        (threads_dir / "broken-thread.md").write_bytes(b"\x00\x01")
+        path = tracker.generate_compost_report(vault_path)
+        text = path.read_text(encoding="utf-8")
+        assert "Daily Meditation Practice" in text
+        assert "Old Thesis" not in text
+
+    def test_report_handles_missing_threads_dir(
+        self,
+        tracker: CompostTracker,
+        tmp_path: Path,
+    ) -> None:
+        """A vault without a threads dir should still produce a report."""
+        (tmp_path / "10-Liminal" / "Compost").mkdir(parents=True)
+        path = tracker.generate_compost_report(tmp_path)
+        text = path.read_text(encoding="utf-8")
+        assert "No active threads" in text
+
+
+# ---- Project candidate note generation ----
+
+
+class TestProjectCandidateNote:
+    """Ensure project-sourced candidates produce valid notes."""
+
+    def test_project_note_has_original_project_field(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Project candidates should record ``original_project`` in metadata."""
+        candidate = CompostCandidate(
+            source_type="project",
+            source_id="greenhouse",
+            title="greenhouse",
+            reason="Project silent for 400 days",
+            fragment_ids=["frag-a", "frag-b"],
+            energy_fragment_ids=[],
+            matched_keywords=[],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        post = frontmatter.load(str(path))
+        assert post["original_project"] == "greenhouse"
+        assert "original_thread" not in post.metadata
+        assert "original_fragment" not in post.metadata
+
+    def test_note_without_related_fragments_has_fallback(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """A candidate with no fragment IDs uses the fallback sentence."""
+        candidate = CompostCandidate(
+            source_type="thread",
+            source_id="thread-empty",
+            title="Empty thread",
+            reason="Resolved",
+            fragment_ids=[],
+            energy_fragment_ids=[],
+            matched_keywords=[],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        body = frontmatter.load(str(path)).content
+        assert "_No related fragments were recorded._" in body
+
+    def test_matched_keywords_persist_in_frontmatter(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """matched_keywords on a candidate must round-trip into frontmatter."""
+        candidate = CompostCandidate(
+            source_type="fragment",
+            source_id="frag-keyword",
+            title="abandoned plans",
+            reason="Abandonment keyword: abandoned",
+            fragment_ids=["frag-keyword"],
+            energy_fragment_ids=[],
+            matched_keywords=["abandoned"],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        post = frontmatter.load(str(path))
+        assert post["matched_keywords"] == ["abandoned"]
+
+    def test_title_with_special_chars_sanitized(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """Non-word characters in titles must not break filename creation."""
+        candidate = CompostCandidate(
+            source_type="thread",
+            source_id="thread-weird",
+            title="What?! / a wild ride * indeed",
+            reason="Resolved",
+            fragment_ids=[],
+            energy_fragment_ids=[],
+            matched_keywords=[],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        assert path.exists()
+        assert "?" not in path.name
+        assert "/" not in path.name
+
+    def test_tracker_defaults_to_wall_clock(self) -> None:
+        """When ``now`` is omitted, tracker uses a real timestamp."""
+        tracker = CompostTracker()
+        # Detection on empty inputs should not error and must return empty.
+        assert tracker.detect_compost_candidates([], []) == []


### PR DESCRIPTION
## Summary

Implements Section 10.4 of the Creek Ontology (Issue #40) via a new `CompostTracker` that surfaces dormant threads, abandonment-keyword fragments, and tagged projects that have fallen silent — then writes them as compost notes and a cross-referenced report.

- `creek/generate/compost.py` — `CompostTracker` with three methods:
  - `detect_compost_candidates(threads, fragments)` — flags threads with `status == resolved` or idle for >180 days, fragments whose title contains an abandonment keyword (`"gave up on"`, `"abandoned"`, `"never finished"`, `"put aside"`, `"shelved"`), and tagged projects whose most recent fragment is older than 180 days
  - `create_compost_note(candidate, vault_path)` — writes `10-Liminal/Compost/<date>-<title>.md` with the required `type: compost` frontmatter (including `original_thread`/`original_fragment`/`original_project`, `fragments`, `composted_date`, `reason`, `tags: [compost]`) and the required body sections: **What it was**, **Why it composted**, **What energy remains**, plus a Related Fragments list
  - `generate_compost_report(vault_path)` — writes `10-Liminal/Compost/_Compost-Report.md` with a Dataview query listing every compost note and a cross-reference section surfacing currently active threads
- "What energy remains" extracts fragments whose voice confidence is `settled`/`conviction` or whose `praxis_potential` is `explicit`, preserving the most crystallised thinking from abandoned threads
- Deterministic `now` parameter on `CompostTracker` keeps dates reproducible in tests

## Test plan

- [x] `pytest tests/test_compost.py` — 34 new tests, all green
- [x] `./scripts/test.sh --coverage` — 2,008 tests pass, 94.7% coverage
- [x] `./scripts/lint.sh` — clean
- [x] `./scripts/format.sh --check` — clean
- [x] `./scripts/complexity.sh` — all blocks rank ≤ B
- [x] Tests cover dormant threads, resolved threads, keyword fragments, disappeared projects, energy extraction (confidence + praxis_potential), note rendering, report generation, malformed-file tolerance, and missing-directory tolerance

Closes #40