### PR TITLE
feat(generate): add wavelength tracking for temporal phase detection (#42)

### DIFF
--- a/creek-tools/creek/generate/__init__.py
+++ b/creek-tools/creek/generate/__init__.py
@@ -26,13 +26,27 @@ from creek.generate.synchronicity import (
     SynchronicityDetector,
 )
 from creek.generate.tags import TagGardenGenerator, TagScanResult
+from creek.generate.wavelength import (
+    DEFAULT_ROLLING_WEEKS,
+    DEFAULT_TOXIC_CONSECUTIVE_WEEKS,
+    DEFAULT_TOXIC_THRESHOLD,
+    DEFAULT_WINDOW_DAYS,
+    DosageTrend,
+    PhaseTransition,
+    WavelengthSnapshot,
+    WavelengthTracker,
+)
 
 __all__ = [
     "ABANDONMENT_KEYWORDS",
     "CONTRADICTION_KEYWORDS",
     "DECISION_KEYWORDS",
     "DEFAULT_MIN_TIME_GAP_DAYS",
+    "DEFAULT_ROLLING_WEEKS",
     "DEFAULT_SIMILARITY_THRESHOLD",
+    "DEFAULT_TOXIC_CONSECUTIVE_WEEKS",
+    "DEFAULT_TOXIC_THRESHOLD",
+    "DEFAULT_WINDOW_DAYS",
     "FREQUENCY_COLORS",
     "FREQUENCY_NAMES",
     "PRACTICE_MAP",
@@ -42,11 +56,15 @@ __all__ = [
     "DecisionContext",
     "DecisionContextGatherer",
     "DecisionDetector",
+    "DosageTrend",
     "IndexGenerator",
     "Paradox",
     "ParadoxDetector",
+    "PhaseTransition",
     "SynchronicityDetector",
     "TagGardenGenerator",
     "TagScanResult",
+    "WavelengthSnapshot",
+    "WavelengthTracker",
     "decision_from_note",
 ]

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -176,14 +176,17 @@ class WavelengthTracker:
             rolling_weeks: Weeks in the dosage rolling average. Defaults to 4.
                 Must be a positive integer.
             toxic_threshold: Ratio above which a frequency is "trending
-                toward overdose". Defaults to 0.6.
+                toward overdose". Defaults to 0.6. Must be in ``(0.0, 1.0]``;
+                values outside that range would either flag every frequency
+                vacuously or flag none at all.
             consecutive_weeks: Consecutive weeks above ``toxic_threshold``
                 required to flag a frequency. Defaults to 3. Must be a
                 positive integer.
 
         Raises:
             ValueError: If ``window_days``, ``rolling_weeks``, or
-                ``consecutive_weeks`` is less than 1.
+                ``consecutive_weeks`` is less than 1, or if
+                ``toxic_threshold`` is outside ``(0.0, 1.0]``.
         """
         if window_days < 1:
             msg = f"window_days must be >= 1, got {window_days}"
@@ -193,6 +196,9 @@ class WavelengthTracker:
             raise ValueError(msg)
         if consecutive_weeks < 1:
             msg = f"consecutive_weeks must be >= 1, got {consecutive_weeks}"
+            raise ValueError(msg)
+        if not 0.0 < toxic_threshold <= 1.0:
+            msg = f"toxic_threshold must be in (0.0, 1.0], got {toxic_threshold}"
             raise ValueError(msg)
         self.window_days = window_days
         self.rolling_weeks = rolling_weeks
@@ -351,7 +357,7 @@ class WavelengthTracker:
             if not freq or freq == Frequency.UNCLASSIFIED.value:
                 continue
             grouped[freq].append(fragment)
-        return grouped
+        return dict(grouped)
 
     @staticmethod
     def _weekly_toxic_ratios(
@@ -380,8 +386,7 @@ class WavelengthTracker:
         if not weekly:
             return []
         result: list[tuple[date, float]] = []
-        for idx in range(len(weekly)):
-            week = weekly[idx][0]
+        for idx, (week, _ratio) in enumerate(weekly):
             start = max(0, idx - self.rolling_weeks + 1)
             sample = [r for _, r in weekly[start : idx + 1]]
             result.append((week, sum(sample) / len(sample)))
@@ -422,10 +427,23 @@ class WavelengthTracker:
         The report file is named ``<report_date>-<period>.md``; if a file
         with that name already exists it is overwritten.
 
+        ``period`` controls the filename suffix, the ``period`` frontmatter
+        value, and the tag, but it does **not** change the analysis
+        granularity — both ``"weekly"`` and ``"monthly"`` runs aggregate
+        over :attr:`window_days`-sized windows. Callers who want coarser
+        monthly aggregation should construct the tracker with a larger
+        ``window_days`` (e.g. 28 or 30) when writing a monthly report.
+
+        Performance note: this method does
+        ``O(fragment_date_span / window_days)`` snapshot passes over the
+        fragment list. With ``window_days=1`` over a multi-year vault this
+        can produce thousands of snapshots; callers generating reports on
+        large corpora should prefer the default weekly windowing.
+
         Args:
             vault_path: Root of the Obsidian vault.
             period: Either ``"weekly"`` or ``"monthly"``. Controls the
-                report title and filename suffix.
+                report filename suffix and frontmatter.
             fragments: Fragments to aggregate. Empty lists still produce a
                 valid report.
             report_date: Date stamp used in the filename and ``generated_on``

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -1,0 +1,594 @@
+"""Wavelength tracking — descriptive phase detection from fragment metadata.
+
+Implements Section 7.5 of the Creek Ontology. The :class:`WavelengthTracker`
+aggregates wavelength classifications across a time window into snapshots,
+detects phase transitions between adjacent snapshots, tracks rolling medicine-
+vs-toxic dosage ratios per APTITUDE frequency, and writes periodic reports to
+``05-Wavelength/Phase-Maps/``.
+
+The module is deliberately **descriptive only**. It never prescribes action,
+never suggests the human "should" do anything, and never names a phase as
+"better" or "worse". The point is to mirror pattern back to the observer.
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.models import Dosage, Frequency, Mode, Phase
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from creek.models import Fragment
+
+
+DEFAULT_WINDOW_DAYS: int = 7
+"""Default analysis window for :meth:`WavelengthTracker.analyze_period` helpers."""
+
+DEFAULT_ROLLING_WEEKS: int = 4
+"""Rolling-average window, in weeks, for dosage trend smoothing."""
+
+DEFAULT_TOXIC_THRESHOLD: float = 0.6
+"""Toxic ratio above which a frequency enters the "trending" zone."""
+
+DEFAULT_TOXIC_CONSECUTIVE_WEEKS: int = 3
+"""Number of consecutive high-toxic weeks needed to flag a frequency."""
+
+_VALID_PERIODS: frozenset[str] = frozenset({"weekly", "monthly"})
+"""Accepted period strings for :meth:`WavelengthTracker.generate_report`."""
+
+
+@dataclass
+class WavelengthSnapshot:
+    """Descriptive summary of wavelength classifications in one time window.
+
+    Attributes:
+        start_date: Inclusive lower bound of the analysed window.
+        end_date: Inclusive upper bound of the analysed window.
+        dominant_phase: Most frequent Archetypal Wavelength phase, or
+            ``unclassified`` when no classified fragments were found.
+        dominant_mode: Most frequent engagement mode, or ``unclassified``.
+        medicine_percent: Share of classified fragments marked ``medicine``.
+        toxic_percent: Share of classified fragments marked ``toxic``.
+        emotional_texture_cloud: ``(tag, count)`` pairs ordered by
+            descending frequency.
+        confidence: How consistent the dominant phase is across the
+            window, in ``[0.0, 1.0]``. Zero when no classifications exist.
+        fragment_count: Number of fragments that fell inside the window.
+        supporting_fragment_ids: IDs of every fragment in the window.
+    """
+
+    start_date: date
+    end_date: date
+    dominant_phase: str
+    dominant_mode: str
+    medicine_percent: float
+    toxic_percent: float
+    emotional_texture_cloud: list[tuple[str, int]]
+    confidence: float
+    fragment_count: int
+    supporting_fragment_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+class PhaseTransition:
+    """A detected shift in dominant phase between two adjacent snapshots.
+
+    Attributes:
+        from_phase: Dominant phase of the earlier snapshot.
+        to_phase: Dominant phase of the later snapshot.
+        from_date: End date of the earlier snapshot.
+        to_date: Start date of the later snapshot.
+        supporting_fragment_ids: Fragment IDs from both snapshots that
+            witnessed the transition.
+    """
+
+    from_phase: str
+    to_phase: str
+    from_date: date
+    to_date: date
+    supporting_fragment_ids: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DosageTrend:
+    """Rolling medicine-vs-toxic dosage ratios per APTITUDE frequency.
+
+    Attributes:
+        frequency_trends: For each classified frequency, a list of
+            ``(week_start_date, toxic_ratio)`` pairs forming a rolling
+            average over :attr:`WavelengthTracker.rolling_weeks` weeks.
+        flagged_frequencies: Frequencies whose rolling toxic ratio stays
+            above :attr:`WavelengthTracker.toxic_threshold` for at least
+            :attr:`WavelengthTracker.consecutive_weeks` consecutive weeks.
+    """
+
+    frequency_trends: dict[str, list[tuple[date, float]]] = field(
+        default_factory=dict,
+    )
+    flagged_frequencies: list[str] = field(default_factory=list)
+
+
+def _week_start(day: date) -> date:
+    """Return the Monday of the ISO week containing *day*."""
+    return day - timedelta(days=day.weekday())
+
+
+def _fragment_in_window(fragment: Fragment, start: date, end: date) -> bool:
+    """Return whether *fragment* was created within ``[start, end]`` inclusive."""
+    frag_date = fragment.created.date()
+    return start <= frag_date <= end
+
+
+def _most_common_classified(values: list[str], unclassified: str) -> str:
+    """Return the most common *values* entry, ignoring *unclassified* markers."""
+    classified = [v for v in values if v and v != unclassified]
+    if not classified:
+        return unclassified
+    counter = Counter(classified)
+    return counter.most_common(1)[0][0]
+
+
+def _ratio(numerator: int, denominator: int) -> float:
+    """Return ``numerator / denominator`` or ``0.0`` when denominator is zero."""
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+class WavelengthTracker:
+    """Aggregate, observe, and describe wavelength patterns across time.
+
+    The tracker never prescribes. Every method produces a descriptive
+    artifact: a snapshot, a transition, a trend, or a markdown report.
+
+    Attributes:
+        window_days: Length of the analysis window used by snapshot and
+            weekly aggregation helpers.
+        rolling_weeks: Rolling-average window, in weeks, for dosage trend
+            smoothing.
+        toxic_threshold: Toxic ratio above which a frequency enters the
+            trending zone.
+        consecutive_weeks: Number of consecutive high-toxic weeks needed
+            to flag a frequency.
+    """
+
+    def __init__(
+        self,
+        *,
+        window_days: int = DEFAULT_WINDOW_DAYS,
+        rolling_weeks: int = DEFAULT_ROLLING_WEEKS,
+        toxic_threshold: float = DEFAULT_TOXIC_THRESHOLD,
+        consecutive_weeks: int = DEFAULT_TOXIC_CONSECUTIVE_WEEKS,
+    ) -> None:
+        """Initialise the tracker.
+
+        Args:
+            window_days: Length of the snapshot window. Defaults to 7.
+            rolling_weeks: Weeks in the dosage rolling average. Defaults to 4.
+            toxic_threshold: Ratio above which a frequency is "trending
+                toward overdose". Defaults to 0.6.
+            consecutive_weeks: Consecutive weeks above ``toxic_threshold``
+                required to flag a frequency. Defaults to 3.
+        """
+        self.window_days = window_days
+        self.rolling_weeks = rolling_weeks
+        self.toxic_threshold = toxic_threshold
+        self.consecutive_weeks = consecutive_weeks
+
+    # ---- analyze_period ----
+
+    def analyze_period(
+        self,
+        fragments: list[Fragment],
+        start: date,
+        end: date,
+    ) -> WavelengthSnapshot:
+        """Aggregate *fragments* in ``[start, end]`` into a descriptive snapshot.
+
+        Args:
+            fragments: Fragments to analyse. Those outside the window are
+                silently skipped.
+            start: Inclusive lower bound (date).
+            end: Inclusive upper bound (date).
+
+        Returns:
+            A :class:`WavelengthSnapshot` describing the period.
+        """
+        in_window = [f for f in fragments if _fragment_in_window(f, start, end)]
+        phases = [str(f.wavelength.phase) for f in in_window]
+        modes = [str(f.wavelength.mode) for f in in_window]
+        dosages = [str(f.wavelength.dosage) for f in in_window]
+
+        dominant_phase = _most_common_classified(phases, Phase.UNCLASSIFIED.value)
+        dominant_mode = _most_common_classified(modes, Mode.UNCLASSIFIED.value)
+        medicine, toxic = self._dosage_shares(dosages)
+        texture = self._texture_cloud(in_window)
+        confidence = self._phase_confidence(phases, dominant_phase)
+
+        return WavelengthSnapshot(
+            start_date=start,
+            end_date=end,
+            dominant_phase=dominant_phase,
+            dominant_mode=dominant_mode,
+            medicine_percent=medicine,
+            toxic_percent=toxic,
+            emotional_texture_cloud=texture,
+            confidence=confidence,
+            fragment_count=len(in_window),
+            supporting_fragment_ids=[f.id for f in in_window],
+        )
+
+    @staticmethod
+    def _dosage_shares(dosages: list[str]) -> tuple[float, float]:
+        """Return ``(medicine_share, toxic_share)`` over classified dosages."""
+        classified = [d for d in dosages if d and d != Dosage.UNCLASSIFIED.value]
+        total = len(classified)
+        medicine = sum(1 for d in classified if d == Dosage.MEDICINE.value)
+        toxic = sum(1 for d in classified if d == Dosage.TOXIC.value)
+        return _ratio(medicine, total), _ratio(toxic, total)
+
+    @staticmethod
+    def _texture_cloud(fragments: list[Fragment]) -> list[tuple[str, int]]:
+        """Return emotional texture tags counted and sorted by descending count."""
+        counter: Counter[str] = Counter()
+        for fragment in fragments:
+            counter.update(fragment.emotional_texture)
+        return counter.most_common()
+
+    @staticmethod
+    def _phase_confidence(phases: list[str], dominant_phase: str) -> float:
+        """Return the share of classified phases that match *dominant_phase*."""
+        classified = [p for p in phases if p and p != Phase.UNCLASSIFIED.value]
+        if not classified or dominant_phase == Phase.UNCLASSIFIED.value:
+            return 0.0
+        matching = sum(1 for p in classified if p == dominant_phase)
+        return matching / len(classified)
+
+    # ---- detect_transitions ----
+
+    def detect_transitions(
+        self,
+        snapshots: list[WavelengthSnapshot],
+    ) -> list[PhaseTransition]:
+        """Compare adjacent snapshots and emit a transition when the phase shifts.
+
+        Unclassified dominant phases are skipped on either side of the pair:
+        a transition requires both snapshots to have a classified phase.
+
+        Args:
+            snapshots: Snapshots in chronological order.
+
+        Returns:
+            List of :class:`PhaseTransition` objects.
+        """
+        transitions: list[PhaseTransition] = []
+        unclassified = Phase.UNCLASSIFIED.value
+        for earlier, later in itertools.pairwise(snapshots):
+            if unclassified in (earlier.dominant_phase, later.dominant_phase):
+                continue
+            if earlier.dominant_phase == later.dominant_phase:
+                continue
+            transitions.append(
+                PhaseTransition(
+                    from_phase=earlier.dominant_phase,
+                    to_phase=later.dominant_phase,
+                    from_date=earlier.end_date,
+                    to_date=later.start_date,
+                    supporting_fragment_ids=[
+                        *earlier.supporting_fragment_ids,
+                        *later.supporting_fragment_ids,
+                    ],
+                ),
+            )
+        return transitions
+
+    # ---- track_dosage_trends ----
+
+    def track_dosage_trends(self, fragments: list[Fragment]) -> DosageTrend:
+        """Compute rolling toxic ratios per frequency and flag overdose trends.
+
+        For each classified frequency the tracker builds weekly buckets,
+        computes the toxic share within each bucket, then smooths the
+        series with a trailing rolling average of :attr:`rolling_weeks`
+        weeks. A frequency is flagged when its rolling average sits above
+        :attr:`toxic_threshold` for at least :attr:`consecutive_weeks`
+        consecutive weeks.
+
+        Args:
+            fragments: Fragments to analyse.
+
+        Returns:
+            A :class:`DosageTrend` with per-frequency series and a flag list.
+        """
+        grouped = self._group_by_frequency(fragments)
+        trends: dict[str, list[tuple[date, float]]] = {}
+        flagged: list[str] = []
+        for frequency, frags in grouped.items():
+            weekly = self._weekly_toxic_ratios(frags)
+            rolling = self._rolling_average(weekly)
+            trends[frequency] = rolling
+            if self._is_trending_toxic(rolling):
+                flagged.append(frequency)
+        return DosageTrend(frequency_trends=trends, flagged_frequencies=flagged)
+
+    @staticmethod
+    def _group_by_frequency(
+        fragments: list[Fragment],
+    ) -> dict[str, list[Fragment]]:
+        """Group *fragments* by their classified primary frequency."""
+        grouped: dict[str, list[Fragment]] = defaultdict(list)
+        for fragment in fragments:
+            freq = str(fragment.frequency.primary)
+            if not freq or freq == Frequency.UNCLASSIFIED.value:
+                continue
+            grouped[freq].append(fragment)
+        return grouped
+
+    @staticmethod
+    def _weekly_toxic_ratios(
+        fragments: list[Fragment],
+    ) -> list[tuple[date, float]]:
+        """Return ``(week_start, toxic_ratio)`` for each week spanned by fragments."""
+        buckets: dict[date, list[str]] = defaultdict(list)
+        for fragment in fragments:
+            dosage = str(fragment.wavelength.dosage)
+            if not dosage or dosage == Dosage.UNCLASSIFIED.value:
+                continue
+            week = _week_start(fragment.created.date())
+            buckets[week].append(dosage)
+        weekly: list[tuple[date, float]] = []
+        for week in sorted(buckets):
+            dosages = buckets[week]
+            toxic = sum(1 for d in dosages if d == Dosage.TOXIC.value)
+            weekly.append((week, _ratio(toxic, len(dosages))))
+        return weekly
+
+    def _rolling_average(
+        self,
+        weekly: list[tuple[date, float]],
+    ) -> list[tuple[date, float]]:
+        """Apply a trailing *rolling_weeks* mean to *weekly* toxic ratios."""
+        if not weekly:
+            return []
+        window = max(1, self.rolling_weeks)
+        result: list[tuple[date, float]] = []
+        for idx in range(len(weekly)):
+            week = weekly[idx][0]
+            start = max(0, idx - window + 1)
+            sample = [r for _, r in weekly[start : idx + 1]]
+            result.append((week, sum(sample) / len(sample)))
+        return result
+
+    def _is_trending_toxic(self, rolling: list[tuple[date, float]]) -> bool:
+        """Return whether *rolling* has *consecutive_weeks* above the threshold."""
+        streak = 0
+        for _, ratio in rolling:
+            if ratio > self.toxic_threshold:
+                streak += 1
+                if streak >= self.consecutive_weeks:
+                    return True
+            else:
+                streak = 0
+        return False
+
+    # ---- generate_report ----
+
+    def generate_report(
+        self,
+        vault_path: Path,
+        period: str,
+        fragments: list[Fragment],
+    ) -> Path:
+        """Write a descriptive wavelength report to ``05-Wavelength/Phase-Maps/``.
+
+        The report aggregates *fragments* into weekly snapshots, detects
+        transitions, tracks dosage trends, and renders the five required
+        sections: Current Phase, Phase History, Dosage Trends, Transition
+        Log, and Emotional Texture Cloud. Language is descriptive only.
+
+        Args:
+            vault_path: Root of the Obsidian vault.
+            period: Either ``"weekly"`` or ``"monthly"``. Controls the
+                report title and filename prefix.
+            fragments: Fragments to aggregate. Empty lists still produce a
+                valid report.
+
+        Returns:
+            Path to the written markdown report.
+
+        Raises:
+            ValueError: If *period* is not ``"weekly"`` or ``"monthly"``.
+        """
+        if period not in _VALID_PERIODS:
+            msg = f"Unknown period {period!r}; expected one of {sorted(_VALID_PERIODS)}"
+            raise ValueError(msg)
+
+        target_dir = vault_path / "05-Wavelength" / "Phase-Maps"
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        snapshots = self._weekly_snapshots(fragments)
+        transitions = self.detect_transitions(snapshots)
+        trend = self.track_dosage_trends(fragments)
+
+        today = date.today()
+        body = self._render_report_body(snapshots, transitions, trend)
+        post = frontmatter.Post(
+            content=body,
+            type="wavelength-report",
+            period=period,
+            generated_on=today.isoformat(),
+            window_days=self.window_days,
+            flagged_frequencies=list(trend.flagged_frequencies),
+            tags=["wavelength", f"wavelength-{period}"],
+        )
+
+        note_path = target_dir / f"{today.isoformat()}-{period}.md"
+        note_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return note_path
+
+    def _weekly_snapshots(
+        self,
+        fragments: list[Fragment],
+    ) -> list[WavelengthSnapshot]:
+        """Build contiguous weekly snapshots spanning the fragment date range."""
+        if not fragments:
+            return []
+        first = min(f.created.date() for f in fragments)
+        last = max(f.created.date() for f in fragments)
+        start = _week_start(first)
+        snapshots: list[WavelengthSnapshot] = []
+        while start <= last:
+            end = start + timedelta(days=self.window_days - 1)
+            snapshots.append(self.analyze_period(fragments, start, end))
+            start = end + timedelta(days=1)
+        return snapshots
+
+    @staticmethod
+    def _render_report_body(
+        snapshots: list[WavelengthSnapshot],
+        transitions: list[PhaseTransition],
+        trend: DosageTrend,
+    ) -> str:
+        """Render the full markdown body for the report."""
+        lines: list[str] = []
+        lines.extend(_render_current_phase(snapshots))
+        lines.extend(_render_phase_history(snapshots))
+        lines.extend(_render_dosage_trends(trend))
+        lines.extend(_render_transition_log(transitions))
+        lines.extend(_render_texture_cloud(snapshots))
+        lines.extend(_render_dataview_section())
+        return "\n".join(lines)
+
+
+# ---- Report rendering helpers ----
+
+
+def _render_current_phase(snapshots: list[WavelengthSnapshot]) -> list[str]:
+    """Render the ``Current Phase`` section describing the latest snapshot."""
+    lines = ["## Current Phase", ""]
+    if not snapshots:
+        lines.append("_No fragments available for this period._")
+        lines.append("")
+        return lines
+    current = snapshots[-1]
+    lines.append(
+        f"- Dominant phase: **{current.dominant_phase}** "
+        f"(confidence {current.confidence:.2f})",
+    )
+    lines.append(f"- Dominant mode: **{current.dominant_mode}**")
+    lines.append(f"- Fragment count: {current.fragment_count}")
+    lines.append(
+        f"- Medicine share: {current.medicine_percent:.2f} | "
+        f"Toxic share: {current.toxic_percent:.2f}",
+    )
+    lines.append("")
+    return lines
+
+
+def _render_phase_history(snapshots: list[WavelengthSnapshot]) -> list[str]:
+    """Render one bullet per snapshot as a chronological history."""
+    lines = ["## Phase History", ""]
+    if not snapshots:
+        lines.append("_No snapshots recorded._")
+        lines.append("")
+        return lines
+    for snap in snapshots:
+        lines.append(
+            f"- {snap.start_date.isoformat()} → {snap.end_date.isoformat()}: "
+            f"{snap.dominant_phase} ({snap.fragment_count} fragments)",
+        )
+    lines.append("")
+    return lines
+
+
+def _render_dosage_trends(trend: DosageTrend) -> list[str]:
+    """Render the Dosage Trends section, listing flagged frequencies neutrally."""
+    lines = ["## Dosage Trends", ""]
+    if not trend.frequency_trends:
+        lines.append("_No classified frequencies recorded._")
+        lines.append("")
+        return lines
+    for freq in sorted(trend.frequency_trends):
+        series = trend.frequency_trends[freq]
+        if not series:
+            continue
+        latest_week, latest_ratio = series[-1]
+        lines.append(
+            f"- **{freq}**: latest rolling toxic share "
+            f"{latest_ratio:.2f} (week of {latest_week.isoformat()})",
+        )
+    if trend.flagged_frequencies:
+        lines.append("")
+        lines.append("Frequencies trending toward overdose (descriptive signal):")
+        for freq in sorted(trend.flagged_frequencies):
+            lines.append(f"- {freq}")
+    lines.append("")
+    return lines
+
+
+def _render_transition_log(transitions: list[PhaseTransition]) -> list[str]:
+    """Render one bullet per detected phase transition."""
+    lines = ["## Transition Log", ""]
+    if not transitions:
+        lines.append("_No phase transitions detected in this period._")
+        lines.append("")
+        return lines
+    for trans in transitions:
+        lines.append(
+            f"- {trans.from_date.isoformat()} → {trans.to_date.isoformat()}: "
+            f"{trans.from_phase} → {trans.to_phase}",
+        )
+    lines.append("")
+    return lines
+
+
+def _render_texture_cloud(snapshots: list[WavelengthSnapshot]) -> list[str]:
+    """Render an emotional texture cloud aggregated across all snapshots."""
+    lines = ["## Emotional Texture Cloud", ""]
+    merged: Counter[str] = Counter()
+    for snap in snapshots:
+        for tag, count in snap.emotional_texture_cloud:
+            merged[tag] += count
+    if not merged:
+        lines.append("_No emotional texture tags recorded._")
+        lines.append("")
+        return lines
+    for tag, count in merged.most_common():
+        lines.append(f"- `{tag}` x{count}")
+    lines.append("")
+    return lines
+
+
+def _render_dataview_section() -> list[str]:
+    """Render a Dataview query block for fragments grouped by phase."""
+    return [
+        "## Fragments by Phase",
+        "",
+        "```dataview",
+        "TABLE wavelength.phase AS Phase, created AS Created",
+        'FROM "01-Fragments"',
+        'WHERE type = "fragment"',
+        "SORT created DESC",
+        "```",
+        "",
+    ]
+
+
+__all__ = [
+    "DEFAULT_ROLLING_WEEKS",
+    "DEFAULT_TOXIC_CONSECUTIVE_WEEKS",
+    "DEFAULT_TOXIC_THRESHOLD",
+    "DEFAULT_WINDOW_DAYS",
+    "DosageTrend",
+    "PhaseTransition",
+    "WavelengthSnapshot",
+    "WavelengthTracker",
+]

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -172,12 +172,28 @@ class WavelengthTracker:
 
         Args:
             window_days: Length of the snapshot window. Defaults to 7.
+                Must be a positive integer.
             rolling_weeks: Weeks in the dosage rolling average. Defaults to 4.
+                Must be a positive integer.
             toxic_threshold: Ratio above which a frequency is "trending
                 toward overdose". Defaults to 0.6.
             consecutive_weeks: Consecutive weeks above ``toxic_threshold``
-                required to flag a frequency. Defaults to 3.
+                required to flag a frequency. Defaults to 3. Must be a
+                positive integer.
+
+        Raises:
+            ValueError: If ``window_days``, ``rolling_weeks``, or
+                ``consecutive_weeks`` is less than 1.
         """
+        if window_days < 1:
+            msg = f"window_days must be >= 1, got {window_days}"
+            raise ValueError(msg)
+        if rolling_weeks < 1:
+            msg = f"rolling_weeks must be >= 1, got {rolling_weeks}"
+            raise ValueError(msg)
+        if consecutive_weeks < 1:
+            msg = f"consecutive_weeks must be >= 1, got {consecutive_weeks}"
+            raise ValueError(msg)
         self.window_days = window_days
         self.rolling_weeks = rolling_weeks
         self.toxic_threshold = toxic_threshold
@@ -302,6 +318,11 @@ class WavelengthTracker:
         :attr:`toxic_threshold` for at least :attr:`consecutive_weeks`
         consecutive weeks.
 
+        Dosage buckets always use ISO calendar weeks (Monday boundaries),
+        independent of :attr:`window_days`. This is deliberate: the
+        ontology specifies weekly dosage accounting, and snapshot windows
+        are allowed to span multiple or fractional weeks.
+
         Args:
             fragments: Fragments to analyse.
 
@@ -358,11 +379,10 @@ class WavelengthTracker:
         """Apply a trailing *rolling_weeks* mean to *weekly* toxic ratios."""
         if not weekly:
             return []
-        window = max(1, self.rolling_weeks)
         result: list[tuple[date, float]] = []
         for idx in range(len(weekly)):
             week = weekly[idx][0]
-            start = max(0, idx - window + 1)
+            start = max(0, idx - self.rolling_weeks + 1)
             sample = [r for _, r in weekly[start : idx + 1]]
             result.append((week, sum(sample) / len(sample)))
         return result
@@ -386,20 +406,31 @@ class WavelengthTracker:
         vault_path: Path,
         period: str,
         fragments: list[Fragment],
+        *,
+        report_date: date | None = None,
     ) -> Path:
         """Write a descriptive wavelength report to ``05-Wavelength/Phase-Maps/``.
 
-        The report aggregates *fragments* into weekly snapshots, detects
-        transitions, tracks dosage trends, and renders the five required
-        sections: Current Phase, Phase History, Dosage Trends, Transition
-        Log, and Emotional Texture Cloud. Language is descriptive only.
+        The report aggregates *fragments* into window-sized snapshots (each
+        snapshot spans :attr:`window_days` days), detects transitions, tracks
+        dosage trends (bucketed by ISO calendar week; see
+        :meth:`track_dosage_trends`), and renders six sections: Current
+        Phase, Phase History, Dosage Trends, Transition Log, Emotional
+        Texture Cloud, and a Dataview query over all fragments. Language
+        is descriptive only.
+
+        The report file is named ``<report_date>-<period>.md``; if a file
+        with that name already exists it is overwritten.
 
         Args:
             vault_path: Root of the Obsidian vault.
             period: Either ``"weekly"`` or ``"monthly"``. Controls the
-                report title and filename prefix.
+                report title and filename suffix.
             fragments: Fragments to aggregate. Empty lists still produce a
                 valid report.
+            report_date: Date stamp used in the filename and ``generated_on``
+                frontmatter field. Defaults to :meth:`date.today`, so tests
+                can pin it for determinism.
 
         Returns:
             Path to the written markdown report.
@@ -414,31 +445,40 @@ class WavelengthTracker:
         target_dir = vault_path / "05-Wavelength" / "Phase-Maps"
         target_dir.mkdir(parents=True, exist_ok=True)
 
-        snapshots = self._weekly_snapshots(fragments)
+        snapshots = self._window_snapshots(fragments)
         transitions = self.detect_transitions(snapshots)
         trend = self.track_dosage_trends(fragments)
 
-        today = date.today()
+        stamp = report_date if report_date is not None else date.today()
         body = self._render_report_body(snapshots, transitions, trend)
         post = frontmatter.Post(
             content=body,
             type="wavelength-report",
             period=period,
-            generated_on=today.isoformat(),
+            generated_on=stamp.isoformat(),
             window_days=self.window_days,
             flagged_frequencies=list(trend.flagged_frequencies),
             tags=["wavelength", f"wavelength-{period}"],
         )
 
-        note_path = target_dir / f"{today.isoformat()}-{period}.md"
+        note_path = target_dir / f"{stamp.isoformat()}-{period}.md"
         note_path.write_text(frontmatter.dumps(post), encoding="utf-8")
         return note_path
 
-    def _weekly_snapshots(
+    def _window_snapshots(
         self,
         fragments: list[Fragment],
     ) -> list[WavelengthSnapshot]:
-        """Build contiguous weekly snapshots spanning the fragment date range."""
+        """Build contiguous ``window_days``-sized snapshots spanning the range.
+
+        Windows are anchored to ISO week starts (Monday) for readability;
+        if ``window_days`` is not a multiple of 7 the final window may
+        extend past the last fragment, which is harmless because
+        :meth:`analyze_period` filters by date.
+
+        Dosage trends computed elsewhere always bucket by 7-day ISO weeks
+        regardless of ``window_days`` — see :meth:`track_dosage_trends`.
+        """
         if not fragments:
             return []
         first = min(f.created.date() for f in fragments)

--- a/creek-tools/tests/test_wavelength_tracker.py
+++ b/creek-tools/tests/test_wavelength_tracker.py
@@ -158,6 +158,26 @@ class TestTrackerInit:
         with pytest.raises(ValueError, match="consecutive_weeks"):
             WavelengthTracker(consecutive_weeks=0)
 
+    def test_rejects_toxic_threshold_above_one(self) -> None:
+        """A threshold above 1.0 can never be exceeded and would never flag."""
+        with pytest.raises(ValueError, match="toxic_threshold"):
+            WavelengthTracker(toxic_threshold=1.5)
+
+    def test_rejects_toxic_threshold_at_zero(self) -> None:
+        """A threshold of 0.0 flags every non-zero toxic ratio and is vacuous."""
+        with pytest.raises(ValueError, match="toxic_threshold"):
+            WavelengthTracker(toxic_threshold=0.0)
+
+    def test_rejects_negative_toxic_threshold(self) -> None:
+        """Negative thresholds are rejected."""
+        with pytest.raises(ValueError, match="toxic_threshold"):
+            WavelengthTracker(toxic_threshold=-0.1)
+
+    def test_accepts_toxic_threshold_of_one(self) -> None:
+        """The upper bound 1.0 is inclusive — flagging requires 100% toxic."""
+        trk = WavelengthTracker(toxic_threshold=1.0)
+        assert trk.toxic_threshold == pytest.approx(1.0)
+
 
 # ---- analyze_period ----
 
@@ -725,6 +745,38 @@ class TestTrackDosageTrends:
         trend = tracker.track_dosage_trends(fragments)
         assert trend.frequency_trends == {}
 
+    def test_ratio_exactly_at_threshold_does_not_flag(self) -> None:
+        """``_is_trending_toxic`` uses strict ``>``; exact threshold is safe."""
+        trk = WavelengthTracker(
+            toxic_threshold=0.6,
+            consecutive_weeks=2,
+            rolling_weeks=1,
+        )
+        fragments: list[Fragment] = []
+        # Two consecutive weeks where exactly 60% of fragments are toxic.
+        # Strict > 0.6 means the flag should NOT fire.
+        for week in range(2):
+            base_day = 1 + week * 7
+            for offset, dosage in enumerate(
+                [
+                    Dosage.TOXIC,
+                    Dosage.TOXIC,
+                    Dosage.TOXIC,
+                    Dosage.MEDICINE,
+                    Dosage.MEDICINE,
+                ],
+            ):
+                fragments.append(
+                    _make_fragment(
+                        frag_id=f"w{week}-{offset}",
+                        created=datetime(2025, 1, base_day, 10, offset, 0),
+                        frequency=Frequency.F1,
+                        dosage=dosage,
+                    ),
+                )
+        trend = trk.track_dosage_trends(fragments)
+        assert Frequency.F1.value not in trend.flagged_frequencies
+
     def test_rolling_window_larger_than_series(self) -> None:
         """Rolling average handles the case where the window exceeds data points."""
         trk = WavelengthTracker(rolling_weeks=10)
@@ -936,6 +988,31 @@ class TestGenerateReport:
         assert path.name == "2025-06-01-weekly.md"
         post = frontmatter.load(str(path))
         assert post["generated_on"] == "2025-06-01"
+
+    def test_report_overwrites_same_day_file(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+        sample_fragments: list[Fragment],
+    ) -> None:
+        """Regenerating on the same date overwrites the prior file."""
+        stamp = date(2025, 6, 1)
+        first = tracker.generate_report(
+            vault_path,
+            "weekly",
+            sample_fragments,
+            report_date=stamp,
+        )
+        second = tracker.generate_report(
+            vault_path,
+            "weekly",
+            [],  # empty fragments -> different content
+            report_date=stamp,
+        )
+        assert first == second
+        # Second run's content differs from first because input changed.
+        content = second.read_text(encoding="utf-8")
+        assert "No fragments available for this period" in content
 
 
 # ---- PhaseTransition / DosageTrend dataclasses ----

--- a/creek-tools/tests/test_wavelength_tracker.py
+++ b/creek-tools/tests/test_wavelength_tracker.py
@@ -133,6 +133,31 @@ class TestTrackerInit:
         assert trk.toxic_threshold == pytest.approx(0.75)
         assert trk.consecutive_weeks == 2
 
+    def test_rejects_zero_window_days(self) -> None:
+        """Zero-length windows would infinite-loop; the constructor rejects them."""
+        with pytest.raises(ValueError, match="window_days"):
+            WavelengthTracker(window_days=0)
+
+    def test_rejects_negative_window_days(self) -> None:
+        """Negative window_days is also rejected."""
+        with pytest.raises(ValueError, match="window_days"):
+            WavelengthTracker(window_days=-3)
+
+    def test_rejects_zero_rolling_weeks(self) -> None:
+        """Zero rolling weeks would produce an empty rolling average."""
+        with pytest.raises(ValueError, match="rolling_weeks"):
+            WavelengthTracker(rolling_weeks=0)
+
+    def test_rejects_negative_rolling_weeks(self) -> None:
+        """Negative rolling_weeks is rejected."""
+        with pytest.raises(ValueError, match="rolling_weeks"):
+            WavelengthTracker(rolling_weeks=-2)
+
+    def test_rejects_zero_consecutive_weeks(self) -> None:
+        """consecutive_weeks below 1 would flag every frequency vacuously."""
+        with pytest.raises(ValueError, match="consecutive_weeks"):
+            WavelengthTracker(consecutive_weeks=0)
+
 
 # ---- analyze_period ----
 
@@ -700,6 +725,29 @@ class TestTrackDosageTrends:
         trend = tracker.track_dosage_trends(fragments)
         assert trend.frequency_trends == {}
 
+    def test_rolling_window_larger_than_series(self) -> None:
+        """Rolling average handles the case where the window exceeds data points."""
+        trk = WavelengthTracker(rolling_weeks=10)
+        fragments = [
+            _make_fragment(
+                frag_id="a",
+                created=datetime(2025, 1, 6),
+                frequency=Frequency.F1,
+                dosage=Dosage.TOXIC,
+            ),
+            _make_fragment(
+                frag_id="b",
+                created=datetime(2025, 1, 13),
+                frequency=Frequency.F1,
+                dosage=Dosage.MEDICINE,
+            ),
+        ]
+        trend = trk.track_dosage_trends(fragments)
+        series = trend.frequency_trends[Frequency.F1.value]
+        # Week 1 (all toxic) -> 1.0. Week 2 average over both -> 0.5.
+        assert series[0][1] == pytest.approx(1.0)
+        assert series[1][1] == pytest.approx(0.5)
+
 
 # ---- generate_report ----
 
@@ -799,7 +847,7 @@ class TestGenerateReport:
         vault_path: Path,
         sample_fragments: list[Fragment],
     ) -> None:
-        """Report body has the five required sections."""
+        """Report body has all six rendered sections."""
         path = tracker.generate_report(vault_path, "weekly", sample_fragments)
         content = path.read_text(encoding="utf-8")
         assert "Current Phase" in content
@@ -807,6 +855,7 @@ class TestGenerateReport:
         assert "Dosage Trends" in content
         assert "Transition Log" in content
         assert "Emotional Texture Cloud" in content
+        assert "Fragments by Phase" in content
 
     def test_report_is_descriptive_not_prescriptive(
         self,
@@ -860,6 +909,33 @@ class TestGenerateReport:
         path = tracker.generate_report(vault_path, "weekly", fragments)
         content = path.read_text(encoding="utf-8")
         assert "F3" in content
+
+    def test_report_monthly_filename_suffix(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+        sample_fragments: list[Fragment],
+    ) -> None:
+        """Monthly reports end with ``-monthly.md``."""
+        path = tracker.generate_report(vault_path, "monthly", sample_fragments)
+        assert path.name.endswith("-monthly.md")
+
+    def test_report_date_is_deterministic(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+        sample_fragments: list[Fragment],
+    ) -> None:
+        """``report_date`` pins the filename and the ``generated_on`` field."""
+        path = tracker.generate_report(
+            vault_path,
+            "weekly",
+            sample_fragments,
+            report_date=date(2025, 6, 1),
+        )
+        assert path.name == "2025-06-01-weekly.md"
+        post = frontmatter.load(str(path))
+        assert post["generated_on"] == "2025-06-01"
 
 
 # ---- PhaseTransition / DosageTrend dataclasses ----

--- a/creek-tools/tests/test_wavelength_tracker.py
+++ b/creek-tools/tests/test_wavelength_tracker.py
@@ -1,0 +1,887 @@
+"""Tests for creek.generate.wavelength — wavelength tracking.
+
+Covers WavelengthTracker's four public methods: analyze_period (snapshot
+aggregation), detect_transitions (phase-change detection), track_dosage_trends
+(rolling medicine/toxic ratios per frequency), and generate_report (writing a
+wavelength report into the vault at ``05-Wavelength/Phase-Maps/``).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.generate.wavelength import (
+    DEFAULT_ROLLING_WEEKS,
+    DEFAULT_TOXIC_CONSECUTIVE_WEEKS,
+    DEFAULT_TOXIC_THRESHOLD,
+    DEFAULT_WINDOW_DAYS,
+    DosageTrend,
+    PhaseTransition,
+    WavelengthSnapshot,
+    WavelengthTracker,
+)
+from creek.models import (
+    Dosage,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Mode,
+    Phase,
+    SourcePlatform,
+    WavelengthClassification,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---- Fixtures ----
+
+
+def _make_fragment(
+    *,
+    frag_id: str,
+    title: str = "test fragment",
+    created: datetime,
+    phase: Phase = Phase.UNCLASSIFIED,
+    mode: Mode = Mode.UNCLASSIFIED,
+    dosage: Dosage = Dosage.UNCLASSIFIED,
+    emotional_texture: list[str] | None = None,
+    frequency: Frequency = Frequency.UNCLASSIFIED,
+) -> Fragment:
+    """Construct a test Fragment with the given wavelength/frequency fields."""
+    return Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        created=created,
+        frequency=FrequencyClassification(primary=frequency),
+        wavelength=WavelengthClassification(
+            phase=phase,
+            mode=mode,
+            dosage=dosage,
+        ),
+        emotional_texture=emotional_texture or [],
+    )
+
+
+@pytest.fixture()
+def tracker() -> WavelengthTracker:
+    """Return a default WavelengthTracker."""
+    return WavelengthTracker()
+
+
+@pytest.fixture()
+def vault_path(tmp_path: Path) -> Path:
+    """Return a vault root with the expected Phase-Maps folder."""
+    (tmp_path / "05-Wavelength" / "Phase-Maps").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+# ---- Module Constants ----
+
+
+class TestConstants:
+    """Tests for module-level default constants."""
+
+    def test_window_days_is_seven(self) -> None:
+        """Default window is 7 days per Section 7.5 technical notes."""
+        assert DEFAULT_WINDOW_DAYS == 7
+
+    def test_rolling_weeks_is_four(self) -> None:
+        """Default rolling average for dosage is 4 weeks."""
+        assert DEFAULT_ROLLING_WEEKS == 4
+
+    def test_toxic_threshold_is_point_six(self) -> None:
+        """Frequencies above 60% toxic flag for potential overdose."""
+        assert pytest.approx(0.6) == DEFAULT_TOXIC_THRESHOLD
+
+    def test_consecutive_weeks_is_three(self) -> None:
+        """Flag triggers after 3+ consecutive weeks over threshold."""
+        assert DEFAULT_TOXIC_CONSECUTIVE_WEEKS == 3
+
+
+# ---- Init ----
+
+
+class TestTrackerInit:
+    """Tests for WavelengthTracker.__init__."""
+
+    def test_defaults(self) -> None:
+        """Default constructor uses module-level thresholds."""
+        trk = WavelengthTracker()
+        assert trk.window_days == DEFAULT_WINDOW_DAYS
+        assert trk.rolling_weeks == DEFAULT_ROLLING_WEEKS
+        assert trk.toxic_threshold == pytest.approx(DEFAULT_TOXIC_THRESHOLD)
+        assert trk.consecutive_weeks == DEFAULT_TOXIC_CONSECUTIVE_WEEKS
+
+    def test_accepts_overrides(self) -> None:
+        """Constructor accepts override parameters."""
+        trk = WavelengthTracker(
+            window_days=14,
+            rolling_weeks=6,
+            toxic_threshold=0.75,
+            consecutive_weeks=2,
+        )
+        assert trk.window_days == 14
+        assert trk.rolling_weeks == 6
+        assert trk.toxic_threshold == pytest.approx(0.75)
+        assert trk.consecutive_weeks == 2
+
+
+# ---- analyze_period ----
+
+
+class TestAnalyzePeriod:
+    """Tests for WavelengthTracker.analyze_period."""
+
+    def test_empty_fragments_returns_unclassified_snapshot(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """With no fragments, the snapshot reports unclassified dominants."""
+        snap = tracker.analyze_period([], date(2025, 1, 1), date(2025, 1, 7))
+        assert snap.dominant_phase == Phase.UNCLASSIFIED.value
+        assert snap.dominant_mode == Mode.UNCLASSIFIED.value
+        assert snap.fragment_count == 0
+
+    def test_snapshot_records_period_bounds(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Start and end dates flow through to the snapshot."""
+        snap = tracker.analyze_period([], date(2025, 2, 1), date(2025, 2, 7))
+        assert snap.start_date == date(2025, 2, 1)
+        assert snap.end_date == date(2025, 2, 7)
+
+    def test_filters_fragments_outside_window(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Fragments created outside the [start, end] window are ignored."""
+        fragments = [
+            _make_fragment(
+                frag_id="frag-1",
+                created=datetime(2025, 1, 15, 10, 0, 0),
+                phase=Phase.PEAKING,
+            ),
+            _make_fragment(
+                frag_id="frag-2",
+                created=datetime(2025, 1, 20, 10, 0, 0),
+                phase=Phase.WITHDRAWAL,
+            ),
+        ]
+        snap = tracker.analyze_period(
+            fragments,
+            date(2025, 1, 1),
+            date(2025, 1, 7),
+        )
+        assert snap.fragment_count == 0
+
+    def test_dominant_phase_is_most_common(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Dominant phase equals the most frequent phase in the window."""
+        fragments = [
+            _make_fragment(
+                frag_id=f"frag-{i}",
+                created=datetime(2025, 1, 3, 10, i, 0),
+                phase=Phase.PEAKING,
+            )
+            for i in range(3)
+        ]
+        fragments.append(
+            _make_fragment(
+                frag_id="frag-other",
+                created=datetime(2025, 1, 4, 10, 0, 0),
+                phase=Phase.WITHDRAWAL,
+            ),
+        )
+        snap = tracker.analyze_period(
+            fragments,
+            date(2025, 1, 1),
+            date(2025, 1, 7),
+        )
+        assert snap.dominant_phase == Phase.PEAKING.value
+        assert snap.fragment_count == 4
+
+    def test_dominant_mode_is_most_common(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Dominant mode equals the most frequent mode in the window."""
+        fragments = [
+            _make_fragment(
+                frag_id="a",
+                created=datetime(2025, 1, 2),
+                mode=Mode.INHABIT,
+            ),
+            _make_fragment(
+                frag_id="b",
+                created=datetime(2025, 1, 3),
+                mode=Mode.INHABIT,
+            ),
+            _make_fragment(
+                frag_id="c",
+                created=datetime(2025, 1, 4),
+                mode=Mode.EXPRESS,
+            ),
+        ]
+        snap = tracker.analyze_period(
+            fragments,
+            date(2025, 1, 1),
+            date(2025, 1, 7),
+        )
+        assert snap.dominant_mode == Mode.INHABIT.value
+
+    def test_unclassified_values_are_ignored_for_dominant(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Unclassified phases don't count toward the dominant phase."""
+        fragments = [
+            _make_fragment(
+                frag_id="a",
+                created=datetime(2025, 1, 2),
+                phase=Phase.UNCLASSIFIED,
+            ),
+            _make_fragment(
+                frag_id="b",
+                created=datetime(2025, 1, 3),
+                phase=Phase.UNCLASSIFIED,
+            ),
+            _make_fragment(
+                frag_id="c",
+                created=datetime(2025, 1, 4),
+                phase=Phase.RISING,
+            ),
+        ]
+        snap = tracker.analyze_period(
+            fragments,
+            date(2025, 1, 1),
+            date(2025, 1, 7),
+        )
+        assert snap.dominant_phase == Phase.RISING.value
+
+    def test_dosage_percentages_sum_correctly(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Medicine and toxic percentages reflect fragment counts."""
+        fragments = [
+            _make_fragment(
+                frag_id="a",
+                created=datetime(2025, 1, 2),
+                dosage=Dosage.MEDICINE,
+            ),
+            _make_fragment(
+                frag_id="b",
+                created=datetime(2025, 1, 3),
+                dosage=Dosage.MEDICINE,
+            ),
+            _make_fragment(
+                frag_id="c",
+                created=datetime(2025, 1, 4),
+                dosage=Dosage.MEDICINE,
+            ),
+            _make_fragment(
+                frag_id="d",
+                created=datetime(2025, 1, 5),
+                dosage=Dosage.TOXIC,
+            ),
+        ]
+        snap = tracker.analyze_period(
+            fragments,
+            date(2025, 1, 1),
+            date(2025, 1, 7),
+        )
+        assert snap.medicine_percent == pytest.approx(0.75)
+        assert snap.toxic_percent == pytest.approx(0.25)
+
+    def test_emotional_texture_cloud_counts_tags(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Emotional texture cloud aggregates and counts tag occurrences."""
+        fragments = [
+            _make_fragment(
+                frag_id="a",
+                created=datetime(2025, 1, 2),
+                emotional_texture=["grief", "tender"],
+            ),
+            _make_fragment(
+                frag_id="b",
+                created=datetime(2025, 1, 3),
+                emotional_texture=["grief"],
+            ),
+            _make_fragment(
+                frag_id="c",
+                created=datetime(2025, 1, 4),
+                emotional_texture=["joy"],
+            ),
+        ]
+        snap = tracker.analyze_period(
+            fragments,
+            date(2025, 1, 1),
+            date(2025, 1, 7),
+        )
+        cloud = dict(snap.emotional_texture_cloud)
+        assert cloud["grief"] == 2
+        assert cloud["tender"] == 1
+        assert cloud["joy"] == 1
+
+    def test_emotional_texture_cloud_ordered_by_count(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Cloud entries are ordered most-common first."""
+        fragments = [
+            _make_fragment(
+                frag_id=f"frag-{i}",
+                created=datetime(2025, 1, 3, 10, i, 0),
+                emotional_texture=["grief"],
+            )
+            for i in range(3)
+        ]
+        fragments.append(
+            _make_fragment(
+                frag_id="frag-joy",
+                created=datetime(2025, 1, 4),
+                emotional_texture=["joy"],
+            ),
+        )
+        snap = tracker.analyze_period(
+            fragments,
+            date(2025, 1, 1),
+            date(2025, 1, 7),
+        )
+        assert snap.emotional_texture_cloud[0] == ("grief", 3)
+
+    def test_confidence_is_one_when_fully_consistent(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Confidence is 1.0 when all fragments share the same phase."""
+        fragments = [
+            _make_fragment(
+                frag_id=f"frag-{i}",
+                created=datetime(2025, 1, 3, 10, i, 0),
+                phase=Phase.RISING,
+            )
+            for i in range(5)
+        ]
+        snap = tracker.analyze_period(
+            fragments,
+            date(2025, 1, 1),
+            date(2025, 1, 7),
+        )
+        assert snap.confidence == pytest.approx(1.0)
+
+    def test_confidence_reflects_diversity(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Confidence is lower when phases are split."""
+        fragments = [
+            _make_fragment(
+                frag_id="a",
+                created=datetime(2025, 1, 2),
+                phase=Phase.RISING,
+            ),
+            _make_fragment(
+                frag_id="b",
+                created=datetime(2025, 1, 3),
+                phase=Phase.WITHDRAWAL,
+            ),
+        ]
+        snap = tracker.analyze_period(
+            fragments,
+            date(2025, 1, 1),
+            date(2025, 1, 7),
+        )
+        assert snap.confidence == pytest.approx(0.5)
+
+
+# ---- detect_transitions ----
+
+
+def _snapshot(
+    *,
+    start: date,
+    end: date,
+    phase: str,
+    supporting_ids: list[str] | None = None,
+) -> WavelengthSnapshot:
+    """Construct a WavelengthSnapshot with minimal fields for transition tests."""
+    return WavelengthSnapshot(
+        start_date=start,
+        end_date=end,
+        dominant_phase=phase,
+        dominant_mode=Mode.UNCLASSIFIED.value,
+        medicine_percent=0.0,
+        toxic_percent=0.0,
+        emotional_texture_cloud=[],
+        confidence=1.0,
+        fragment_count=len(supporting_ids or []),
+        supporting_fragment_ids=supporting_ids or [],
+    )
+
+
+class TestDetectTransitions:
+    """Tests for WavelengthTracker.detect_transitions."""
+
+    def test_empty_snapshots_returns_empty(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """No snapshots means no transitions."""
+        assert tracker.detect_transitions([]) == []
+
+    def test_single_snapshot_returns_empty(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """A single snapshot cannot produce a transition."""
+        snapshots = [
+            _snapshot(
+                start=date(2025, 1, 1),
+                end=date(2025, 1, 7),
+                phase=Phase.PEAKING.value,
+            ),
+        ]
+        assert tracker.detect_transitions(snapshots) == []
+
+    def test_no_change_yields_no_transition(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Adjacent snapshots with the same phase don't transition."""
+        snapshots = [
+            _snapshot(
+                start=date(2025, 1, 1),
+                end=date(2025, 1, 7),
+                phase=Phase.PEAKING.value,
+            ),
+            _snapshot(
+                start=date(2025, 1, 8),
+                end=date(2025, 1, 14),
+                phase=Phase.PEAKING.value,
+            ),
+        ]
+        assert tracker.detect_transitions(snapshots) == []
+
+    def test_phase_change_detected(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """A phase change between adjacent snapshots yields one transition."""
+        snapshots = [
+            _snapshot(
+                start=date(2025, 1, 1),
+                end=date(2025, 1, 7),
+                phase=Phase.PEAKING.value,
+                supporting_ids=["frag-a"],
+            ),
+            _snapshot(
+                start=date(2025, 1, 8),
+                end=date(2025, 1, 14),
+                phase=Phase.WITHDRAWAL.value,
+                supporting_ids=["frag-b"],
+            ),
+        ]
+        transitions = tracker.detect_transitions(snapshots)
+        assert len(transitions) == 1
+        assert transitions[0].from_phase == Phase.PEAKING.value
+        assert transitions[0].to_phase == Phase.WITHDRAWAL.value
+
+    def test_transition_records_dates_from_both_snapshots(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Transition captures the from-window end and to-window start."""
+        snapshots = [
+            _snapshot(
+                start=date(2025, 1, 1),
+                end=date(2025, 1, 7),
+                phase=Phase.PEAKING.value,
+            ),
+            _snapshot(
+                start=date(2025, 1, 8),
+                end=date(2025, 1, 14),
+                phase=Phase.WITHDRAWAL.value,
+            ),
+        ]
+        trans = tracker.detect_transitions(snapshots)[0]
+        assert trans.from_date == date(2025, 1, 7)
+        assert trans.to_date == date(2025, 1, 8)
+
+    def test_transition_collects_supporting_fragments(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Transition aggregates supporting fragment IDs from both windows."""
+        snapshots = [
+            _snapshot(
+                start=date(2025, 1, 1),
+                end=date(2025, 1, 7),
+                phase=Phase.PEAKING.value,
+                supporting_ids=["frag-a"],
+            ),
+            _snapshot(
+                start=date(2025, 1, 8),
+                end=date(2025, 1, 14),
+                phase=Phase.WITHDRAWAL.value,
+                supporting_ids=["frag-b", "frag-c"],
+            ),
+        ]
+        trans = tracker.detect_transitions(snapshots)[0]
+        assert "frag-a" in trans.supporting_fragment_ids
+        assert "frag-b" in trans.supporting_fragment_ids
+        assert "frag-c" in trans.supporting_fragment_ids
+
+    def test_multiple_transitions_detected(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Each adjacent-pair phase change yields its own transition."""
+        snapshots = [
+            _snapshot(
+                start=date(2025, 1, 1),
+                end=date(2025, 1, 7),
+                phase=Phase.RISING.value,
+            ),
+            _snapshot(
+                start=date(2025, 1, 8),
+                end=date(2025, 1, 14),
+                phase=Phase.PEAKING.value,
+            ),
+            _snapshot(
+                start=date(2025, 1, 15),
+                end=date(2025, 1, 21),
+                phase=Phase.WITHDRAWAL.value,
+            ),
+        ]
+        transitions = tracker.detect_transitions(snapshots)
+        assert len(transitions) == 2
+        assert transitions[0].to_phase == Phase.PEAKING.value
+        assert transitions[1].from_phase == Phase.PEAKING.value
+
+    def test_unclassified_snapshots_do_not_transition(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Transitions to or from UNCLASSIFIED are skipped."""
+        snapshots = [
+            _snapshot(
+                start=date(2025, 1, 1),
+                end=date(2025, 1, 7),
+                phase=Phase.UNCLASSIFIED.value,
+            ),
+            _snapshot(
+                start=date(2025, 1, 8),
+                end=date(2025, 1, 14),
+                phase=Phase.PEAKING.value,
+            ),
+        ]
+        assert tracker.detect_transitions(snapshots) == []
+
+
+# ---- track_dosage_trends ----
+
+
+class TestTrackDosageTrends:
+    """Tests for WavelengthTracker.track_dosage_trends."""
+
+    def test_empty_fragments_returns_empty_trend(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """No fragments means no frequency trends and no flags."""
+        trend = tracker.track_dosage_trends([])
+        assert isinstance(trend, DosageTrend)
+        assert trend.frequency_trends == {}
+        assert trend.flagged_frequencies == []
+
+    def test_tracks_per_frequency_series(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Each frequency with classified fragments gets its own rolling series."""
+        fragments = [
+            _make_fragment(
+                frag_id="a",
+                created=datetime(2025, 1, 1),
+                frequency=Frequency.F1,
+                dosage=Dosage.MEDICINE,
+            ),
+            _make_fragment(
+                frag_id="b",
+                created=datetime(2025, 1, 2),
+                frequency=Frequency.F2,
+                dosage=Dosage.TOXIC,
+            ),
+        ]
+        trend = tracker.track_dosage_trends(fragments)
+        assert Frequency.F1.value in trend.frequency_trends
+        assert Frequency.F2.value in trend.frequency_trends
+
+    def test_flags_sustained_high_toxic(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """A frequency over 60% toxic for 3+ weeks is flagged."""
+        fragments: list[Fragment] = []
+        # 5 weeks where F1 is 100% toxic.
+        for week in range(5):
+            fragments.append(
+                _make_fragment(
+                    frag_id=f"frag-{week}",
+                    created=datetime(2025, 1, 1 + week * 7),
+                    frequency=Frequency.F1,
+                    dosage=Dosage.TOXIC,
+                ),
+            )
+        trend = tracker.track_dosage_trends(fragments)
+        assert Frequency.F1.value in trend.flagged_frequencies
+
+    def test_does_not_flag_brief_toxic_burst(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """A single toxic week does not trigger the flag."""
+        fragments = [
+            _make_fragment(
+                frag_id="toxic",
+                created=datetime(2025, 1, 1),
+                frequency=Frequency.F1,
+                dosage=Dosage.TOXIC,
+            ),
+            _make_fragment(
+                frag_id="med-1",
+                created=datetime(2025, 1, 8),
+                frequency=Frequency.F1,
+                dosage=Dosage.MEDICINE,
+            ),
+            _make_fragment(
+                frag_id="med-2",
+                created=datetime(2025, 1, 15),
+                frequency=Frequency.F1,
+                dosage=Dosage.MEDICINE,
+            ),
+            _make_fragment(
+                frag_id="med-3",
+                created=datetime(2025, 1, 22),
+                frequency=Frequency.F1,
+                dosage=Dosage.MEDICINE,
+            ),
+        ]
+        trend = tracker.track_dosage_trends(fragments)
+        assert Frequency.F1.value not in trend.flagged_frequencies
+
+    def test_ignores_unclassified_frequency(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """Fragments without a classified frequency do not create a series."""
+        fragments = [
+            _make_fragment(
+                frag_id="a",
+                created=datetime(2025, 1, 1),
+                frequency=Frequency.UNCLASSIFIED,
+                dosage=Dosage.TOXIC,
+            ),
+        ]
+        trend = tracker.track_dosage_trends(fragments)
+        assert trend.frequency_trends == {}
+
+
+# ---- generate_report ----
+
+
+@pytest.fixture()
+def sample_fragments() -> list[Fragment]:
+    """Fragments spanning five weeks with a visible RISING -> PEAKING shift."""
+    fragments: list[Fragment] = []
+    for day in range(7):
+        fragments.append(
+            _make_fragment(
+                frag_id=f"rise-{day}",
+                created=datetime(2025, 1, 1 + day, 12, 0, 0),
+                phase=Phase.RISING,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+                frequency=Frequency.F1,
+                emotional_texture=["eager"],
+            ),
+        )
+    for day in range(7):
+        fragments.append(
+            _make_fragment(
+                frag_id=f"peak-{day}",
+                created=datetime(2025, 1, 8 + day, 12, 0, 0),
+                phase=Phase.PEAKING,
+                mode=Mode.EXPRESS,
+                dosage=Dosage.MEDICINE,
+                frequency=Frequency.F2,
+                emotional_texture=["radiant"],
+            ),
+        )
+    return fragments
+
+
+class TestGenerateReport:
+    """Tests for WavelengthTracker.generate_report."""
+
+    def test_writes_file_to_phase_maps(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+        sample_fragments: list[Fragment],
+    ) -> None:
+        """Report lives under ``05-Wavelength/Phase-Maps/``."""
+        path = tracker.generate_report(vault_path, "weekly", sample_fragments)
+        assert path.exists()
+        rel = path.relative_to(vault_path)
+        assert rel.parts[0] == "05-Wavelength"
+        assert rel.parts[1] == "Phase-Maps"
+
+    def test_creates_target_dir_if_missing(
+        self,
+        tracker: WavelengthTracker,
+        tmp_path: Path,
+        sample_fragments: list[Fragment],
+    ) -> None:
+        """Target directory is created when it does not exist."""
+        path = tracker.generate_report(tmp_path, "weekly", sample_fragments)
+        assert path.exists()
+
+    def test_report_has_wavelength_type(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+        sample_fragments: list[Fragment],
+    ) -> None:
+        """Frontmatter includes ``type: wavelength-report``."""
+        path = tracker.generate_report(vault_path, "weekly", sample_fragments)
+        post = frontmatter.load(str(path))
+        assert post["type"] == "wavelength-report"
+
+    def test_report_has_period(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+        sample_fragments: list[Fragment],
+    ) -> None:
+        """Frontmatter records the report period (weekly or monthly)."""
+        path = tracker.generate_report(vault_path, "weekly", sample_fragments)
+        post = frontmatter.load(str(path))
+        assert post["period"] == "weekly"
+
+    def test_report_rejects_unknown_period(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+        sample_fragments: list[Fragment],
+    ) -> None:
+        """Only ``weekly`` and ``monthly`` are accepted report periods."""
+        with pytest.raises(ValueError, match="period"):
+            tracker.generate_report(vault_path, "daily", sample_fragments)
+
+    def test_report_body_has_required_sections(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+        sample_fragments: list[Fragment],
+    ) -> None:
+        """Report body has the five required sections."""
+        path = tracker.generate_report(vault_path, "weekly", sample_fragments)
+        content = path.read_text(encoding="utf-8")
+        assert "Current Phase" in content
+        assert "Phase History" in content
+        assert "Dosage Trends" in content
+        assert "Transition Log" in content
+        assert "Emotional Texture Cloud" in content
+
+    def test_report_is_descriptive_not_prescriptive(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+        sample_fragments: list[Fragment],
+    ) -> None:
+        """Report must not contain prescriptive words like 'should'/'must'."""
+        path = tracker.generate_report(vault_path, "weekly", sample_fragments)
+        content = path.read_text(encoding="utf-8").lower()
+        assert "you should" not in content
+        assert "you must" not in content
+        assert "you need to" not in content
+
+    def test_report_includes_dataview_query(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+        sample_fragments: list[Fragment],
+    ) -> None:
+        """Report includes at least one Dataview query block."""
+        path = tracker.generate_report(vault_path, "weekly", sample_fragments)
+        content = path.read_text(encoding="utf-8")
+        assert "```dataview" in content
+
+    def test_empty_fragments_still_generates_report(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Report generation is robust to an empty fragment list."""
+        path = tracker.generate_report(vault_path, "monthly", [])
+        assert path.exists()
+
+    def test_report_flagged_frequencies_are_listed(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Flagged frequencies appear in the Dosage Trends section."""
+        fragments = [
+            _make_fragment(
+                frag_id=f"frag-{week}",
+                created=datetime(2025, 1, 1 + week * 7),
+                frequency=Frequency.F3,
+                dosage=Dosage.TOXIC,
+                phase=Phase.DIMINISHING,
+            )
+            for week in range(5)
+        ]
+        path = tracker.generate_report(vault_path, "weekly", fragments)
+        content = path.read_text(encoding="utf-8")
+        assert "F3" in content
+
+
+# ---- PhaseTransition / DosageTrend dataclasses ----
+
+
+class TestDataclasses:
+    """Surface tests for PhaseTransition / DosageTrend defaults."""
+
+    def test_phase_transition_records_core_fields(self) -> None:
+        """PhaseTransition stores from/to phases, dates, and fragment IDs."""
+        trans = PhaseTransition(
+            from_phase=Phase.PEAKING.value,
+            to_phase=Phase.WITHDRAWAL.value,
+            from_date=date(2025, 1, 7),
+            to_date=date(2025, 1, 8),
+            supporting_fragment_ids=["frag-a"],
+        )
+        assert trans.from_phase == Phase.PEAKING.value
+        assert trans.supporting_fragment_ids == ["frag-a"]
+
+    def test_dosage_trend_default_empty_lists(self) -> None:
+        """DosageTrend initialises with empty structures."""
+        trend = DosageTrend()
+        assert trend.frequency_trends == {}
+        assert trend.flagged_frequencies == []


### PR DESCRIPTION
Implements Section 7.5 of the Creek Ontology. WavelengthTracker aggregates
wavelength classifications into weekly snapshots, detects phase transitions
between adjacent windows, tracks rolling medicine-vs-toxic dosage ratios
per APTITUDE frequency, and writes descriptive reports to
05-Wavelength/Phase-Maps/.

The module is strictly descriptive -- it never prescribes, judges a phase,
or recommends action. It mirrors pattern back to the observer.

https://claude.ai/code/session_012ePYRioK2cArauUf1wgApL