### PR TITLE
fix(types): resolve mypy strict mode type errors on main

### DIFF
--- a/creek-tools/creek/generate/decisions.py
+++ b/creek-tools/creek/generate/decisions.py
@@ -87,21 +87,22 @@ def _sanitize_title(title: str) -> str:
     return cleaned[:80]
 
 
-def _build_frequency_context(fragment: Fragment) -> list[str]:
+def _build_frequency_context(fragment: Fragment) -> list[Frequency]:
     """Extract all frequency values from a fragment.
 
     Args:
         fragment: The source fragment.
 
     Returns:
-        List of frequency code strings (e.g. ``["F1", "F5"]``).
+        List of ``Frequency`` enum values (e.g. ``[Frequency.F1, Frequency.F5]``),
+        excluding the ``UNCLASSIFIED`` primary.
     """
-    freqs: list[str] = []
-    primary = str(fragment.frequency.primary)
-    if primary != "unclassified":
+    freqs: list[Frequency] = []
+    primary = Frequency(fragment.frequency.primary)
+    if primary != Frequency.UNCLASSIFIED:
         freqs.append(primary)
     for sec in fragment.frequency.secondary:
-        freqs.append(str(sec))
+        freqs.append(Frequency(sec))
     return freqs
 
 

--- a/creek-tools/creek/link/embeddings.py
+++ b/creek-tools/creek/link/embeddings.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import itertools
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 
@@ -42,7 +42,10 @@ def _load_sentence_transformer(
     """
     from sentence_transformers import SentenceTransformer
 
-    return SentenceTransformer(model_name, cache_folder=cache_folder)
+    return cast(
+        "SentenceTransformerType",
+        SentenceTransformer(model_name, cache_folder=cache_folder),
+    )
 
 
 class EmbeddingLinker:
@@ -155,10 +158,9 @@ class EmbeddingLinker:
             path: Destination file path (typically ``*.npz``).
         """
         arrays = {k: np.array(v, dtype=np.float32) for k, v in embeddings.items()}
-        np.savez_compressed(
-            path,
-            **arrays,
-        )
+        # ``allow_pickle`` is passed explicitly so mypy can narrow the kwargs
+        # type for ``**arrays`` to ``ArrayLike`` instead of matching ``bool``.
+        np.savez_compressed(path, allow_pickle=True, **arrays)
         logger.info("Saved %d embedding(s) to %s", len(embeddings), path)
 
     def load_embeddings(self, path: Path) -> dict[str, list[float]]:


### PR DESCRIPTION
Three errors were causing `./scripts/typecheck.sh` to fail on main:

- `creek/generate/decisions.py:169`: `_build_frequency_context` was typed
  to return `list[str]` but `DecisionCandidate.frequency_context` expects
  `list[Frequency]`. Updated the helper to build and return `Frequency`
  enum values directly (Frequency is a StrEnum, so runtime behaviour is
  unchanged; values already round-trip through the field validator).
- `creek/link/embeddings.py:45`: `SentenceTransformer(...)` is untyped
  upstream, so mypy inferred `Any`. Added `typing.cast` to the declared
  `SentenceTransformerType`.
- `creek/link/embeddings.py:160`: `np.savez_compressed(path, **arrays)`
  tripped mypy's overload matcher because `**dict[str, ndarray]` could
  theoretically collide with the `allow_pickle: bool` kwarg. Passing
  `allow_pickle=True` explicitly narrows the kwargs so the `ArrayLike`
  overload is selected.

All project quality gates now pass: ruff lint, ruff format, mypy strict,
bandit, complexity, 2099 unit tests, and coverage (94.53%). The pip-audit
warnings surfaced during `check-all` are in ambient system packages
(cryptography, pip, pyjwt, setuptools, wheel) and are not listed in the
project's requirements — pre-existing environment noise, not introduced
by this change.

https://claude.ai/code/session_01Wxak4366q73KPxu4GGiAqj