### PR TITLE
feat(generate): add voice exemplar collection by register (#47)

### DIFF
--- a/creek-tools/creek/generate/__init__.py
+++ b/creek-tools/creek/generate/__init__.py
@@ -26,6 +26,12 @@ from creek.generate.synchronicity import (
     SynchronicityDetector,
 )
 from creek.generate.tags import TagGardenGenerator, TagScanResult
+from creek.generate.voice import (
+    DEFAULT_MAX_PER_REGISTER,
+    DEFAULT_MIN_PER_REGISTER,
+    VOICE_REGISTERS,
+    VoiceExemplarCollector,
+)
 from creek.generate.wavelength import (
     DEFAULT_ROLLING_WEEKS,
     DEFAULT_TOXIC_CONSECUTIVE_WEEKS,
@@ -41,6 +47,8 @@ __all__ = [
     "ABANDONMENT_KEYWORDS",
     "CONTRADICTION_KEYWORDS",
     "DECISION_KEYWORDS",
+    "DEFAULT_MAX_PER_REGISTER",
+    "DEFAULT_MIN_PER_REGISTER",
     "DEFAULT_MIN_TIME_GAP_DAYS",
     "DEFAULT_ROLLING_WEEKS",
     "DEFAULT_SIMILARITY_THRESHOLD",
@@ -51,6 +59,7 @@ __all__ = [
     "FREQUENCY_NAMES",
     "PRACTICE_MAP",
     "REFLECTION_PROMPT",
+    "VOICE_REGISTERS",
     "CompostCandidate",
     "CompostTracker",
     "DecisionContext",
@@ -64,6 +73,7 @@ __all__ = [
     "SynchronicityDetector",
     "TagGardenGenerator",
     "TagScanResult",
+    "VoiceExemplarCollector",
     "WavelengthSnapshot",
     "WavelengthTracker",
     "decision_from_note",

--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -22,6 +22,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import frontmatter
+import yaml
 from pydantic import ValidationError
 
 from creek.models import (
@@ -139,7 +140,7 @@ def _load_fragment_with_body(
     """
     try:
         post = frontmatter.load(str(md_file))
-    except (OSError, ValueError):
+    except (OSError, ValueError, yaml.YAMLError):
         logger.debug("Skipping unreadable markdown file: %s", md_file)
         return None
     metadata = dict(post.metadata)
@@ -191,13 +192,20 @@ class VoiceExemplarCollector:
 
         Raises:
             ValueError: If ``max_per_register`` or ``min_per_register``
-                is less than 1.
+                is less than 1, or if ``min_per_register`` exceeds
+                ``max_per_register``.
         """
         if max_per_register < 1:
             msg = f"max_per_register must be >= 1, got {max_per_register}"
             raise ValueError(msg)
         if min_per_register < 1:
             msg = f"min_per_register must be >= 1, got {min_per_register}"
+            raise ValueError(msg)
+        if min_per_register > max_per_register:
+            msg = (
+                f"min_per_register ({min_per_register}) "
+                f"> max_per_register ({max_per_register})"
+            )
             raise ValueError(msg)
         self.max_per_register = max_per_register
         self.min_per_register = min_per_register
@@ -261,9 +269,13 @@ class VoiceExemplarCollector:
         return register
 
     def _warn_below_minimum(self, buckets: dict[str, list[Fragment]]) -> None:
-        """Emit a warning for any register short of :attr:`min_per_register`."""
+        """Emit a warning for registers with some but too few exemplars.
+
+        Registers with zero exemplars are silently skipped — a warning
+        is only useful when a register *has* data but not enough.
+        """
         for register, frags in buckets.items():
-            if len(frags) < self.min_per_register:
+            if 0 < len(frags) < self.min_per_register:
                 logger.warning(
                     "Voice register %r has only %d exemplars (minimum %d).",
                     register,
@@ -285,7 +297,7 @@ class VoiceExemplarCollector:
         - All classification axes populated (frequency, wavelength
           phase / mode, voice register, voice confidence): +1 point.
 
-        Ties are broken by descending ID for deterministic ordering.
+        Ties are broken by ascending ID for deterministic ordering.
 
         Args:
             fragments: Fragments to rank. May be empty.
@@ -327,6 +339,10 @@ class VoiceExemplarCollector:
         folder, copies (or rewrites) up to :attr:`max_per_register` of
         the top-ranked fragments, and writes a ``_Summary.md`` note
         recording statistics about the cohort.
+
+        Fragments in each register bucket are ranked internally via
+        :meth:`rank_exemplars` before being persisted — callers do not
+        need to pre-rank.
 
         Args:
             exemplars: Mapping of register → fragments, typically the

--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -1,0 +1,431 @@
+"""Voice exemplar collection — gather high-confidence fragments by register.
+
+Implements Section 11.1 of the Creek Ontology. The
+:class:`VoiceExemplarCollector` scans the vault for fragments whose
+``voice.confidence`` has crystallised (``settled`` or ``conviction``),
+groups them by ``voice.register``, ranks them by quality, and writes
+the top exemplars under ``07-Voice/Register-Samples/<register>/`` so a
+voice proxy can later train against curated samples.
+
+The collector is deliberately conservative about privacy: ``intimate``
+tier fragments are excluded by default and only included when the caller
+explicitly opts in. Saved exemplars include a per-register summary note
+recording the breakdown of confidence levels.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+from pydantic import ValidationError
+
+from creek.models import (
+    Confidence,
+    Fragment,
+    Frequency,
+    Mode,
+    Phase,
+    PrivacyTier,
+    VoiceRegister,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+VOICE_REGISTERS: tuple[str, ...] = tuple(register.value for register in VoiceRegister)
+"""All seven canonical voice registers from the Creek ontology."""
+
+DEFAULT_MAX_PER_REGISTER: int = 20
+"""Default cap on exemplars retained per register."""
+
+DEFAULT_MIN_PER_REGISTER: int = 5
+"""Registers with fewer than this many exemplars trigger a warning."""
+
+_FRAGMENTS_SUBDIR: str = "01-Fragments"
+"""Vault subdirectory scanned for fragment markdown files."""
+
+_SAMPLES_SUBPATH: tuple[str, str] = ("07-Voice", "Register-Samples")
+"""Vault path where ranked exemplars are persisted."""
+
+_QUALIFYING_CONFIDENCE: frozenset[str] = frozenset(
+    {Confidence.SETTLED.value, Confidence.CONVICTION.value},
+)
+"""Confidence levels that make a fragment eligible as an exemplar."""
+
+_CONFIDENCE_SCORE: dict[str, int] = {
+    Confidence.CONVICTION.value: 3,
+    Confidence.SETTLED.value: 2,
+}
+"""Per-confidence base score contribution to the ranking."""
+
+_MEDIUM_LENGTH_MIN_WORDS: int = 200
+"""Lower bound (inclusive) of the medium-length word band."""
+
+_MEDIUM_LENGTH_MAX_WORDS: int = 800
+"""Upper bound (inclusive) of the medium-length word band."""
+
+_LENGTH_BONUS: int = 1
+"""Score bonus applied to medium-length bodies."""
+
+_CLASSIFICATION_BONUS: int = 1
+"""Score bonus applied when every classification axis is populated."""
+
+_SUMMARY_FILENAME: str = "_Summary.md"
+"""Filename used for the per-register summary note."""
+
+
+@dataclass(frozen=True)
+class _ExemplarRecord:
+    """Cached scoring data captured during ``collect_exemplars``.
+
+    Attributes:
+        word_count: Number of whitespace-delimited tokens in the body.
+        source_path: Original markdown path of the fragment, used by
+            :meth:`VoiceExemplarCollector.save_exemplars` to copy the
+            file into the register samples folder.
+    """
+
+    word_count: int
+    source_path: Path
+
+
+def _confidence_value(fragment: Fragment) -> str:
+    """Return the fragment's voice confidence as a string (or empty)."""
+    return str(fragment.voice.confidence) if fragment.voice.confidence else ""
+
+
+def _register_value(fragment: Fragment) -> str:
+    """Return the fragment's voice register as a string (or empty)."""
+    return str(fragment.voice.voice_register) if fragment.voice.voice_register else ""
+
+
+def _is_fully_classified(fragment: Fragment) -> bool:
+    """Return whether every primary classification axis is populated."""
+    if str(fragment.frequency.primary) == Frequency.UNCLASSIFIED.value:
+        return False
+    if str(fragment.wavelength.phase) == Phase.UNCLASSIFIED.value:
+        return False
+    if str(fragment.wavelength.mode) == Mode.UNCLASSIFIED.value:
+        return False
+    if not fragment.voice.voice_register:
+        return False
+    return bool(fragment.voice.confidence)
+
+
+def _word_count(body: str) -> int:
+    """Return the whitespace-delimited token count of *body*."""
+    return len(body.split())
+
+
+def _load_fragment_with_body(
+    md_file: Path,
+) -> tuple[Fragment, str] | None:
+    """Parse *md_file* into a Fragment and return it with its body text.
+
+    Args:
+        md_file: Markdown file to read.
+
+    Returns:
+        A ``(fragment, body)`` pair, or ``None`` when the file is not a
+        valid fragment record (unreadable, wrong type, or invalid
+        frontmatter).
+    """
+    try:
+        post = frontmatter.load(str(md_file))
+    except (OSError, ValueError):
+        logger.debug("Skipping unreadable markdown file: %s", md_file)
+        return None
+    metadata = dict(post.metadata)
+    if metadata.get("type") != "fragment":
+        return None
+    try:
+        fragment = Fragment.model_validate(metadata)
+    except ValidationError:
+        logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
+        return None
+    return fragment, post.content
+
+
+class VoiceExemplarCollector:
+    """Collect, rank, and persist voice exemplars from the vault.
+
+    The collector caches per-fragment word counts and source paths during
+    :meth:`collect_exemplars` so that :meth:`rank_exemplars` and
+    :meth:`save_exemplars` can reuse the data without re-reading disk.
+    Calling ``rank_exemplars`` or ``save_exemplars`` before
+    ``collect_exemplars`` still works — fragments without cached data
+    fall back to in-memory serialisation.
+
+    Attributes:
+        max_per_register: Maximum exemplars retained per register after
+            ranking.
+        min_per_register: Minimum exemplars expected per register; below
+            this threshold the collector emits a warning.
+        allow_intimate: When ``True``, fragments tagged ``intimate``
+            participate in collection. Defaults to ``False``.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_per_register: int = DEFAULT_MAX_PER_REGISTER,
+        min_per_register: int = DEFAULT_MIN_PER_REGISTER,
+        allow_intimate: bool = False,
+    ) -> None:
+        """Initialise the collector.
+
+        Args:
+            max_per_register: Cap on exemplars retained per register.
+                Must be at least 1.
+            min_per_register: Minimum exemplars per register before a
+                warning is emitted. Must be at least 1.
+            allow_intimate: Whether to include ``intimate`` privacy tier
+                fragments. Defaults to ``False``.
+
+        Raises:
+            ValueError: If ``max_per_register`` or ``min_per_register``
+                is less than 1.
+        """
+        if max_per_register < 1:
+            msg = f"max_per_register must be >= 1, got {max_per_register}"
+            raise ValueError(msg)
+        if min_per_register < 1:
+            msg = f"min_per_register must be >= 1, got {min_per_register}"
+            raise ValueError(msg)
+        self.max_per_register = max_per_register
+        self.min_per_register = min_per_register
+        self.allow_intimate = allow_intimate
+        self._records: dict[str, _ExemplarRecord] = {}
+
+    # ---- Collection ----
+
+    def collect_exemplars(self, vault_path: Path) -> dict[str, list[Fragment]]:
+        """Scan ``01-Fragments/`` and group qualifying exemplars by register.
+
+        Fragments are kept when their ``voice.confidence`` is ``settled``
+        or ``conviction`` and their ``voice.register`` is set. Intimate
+        privacy tier fragments are filtered out unless
+        :attr:`allow_intimate` is ``True``. Each register key in the
+        returned dict is always present; empty registers map to ``[]``.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            Dict mapping every voice register to its qualifying
+            fragments, in the order they were discovered on disk.
+        """
+        self._records = {}
+        buckets: dict[str, list[Fragment]] = {reg: [] for reg in VOICE_REGISTERS}
+        fragments_dir = vault_path / _FRAGMENTS_SUBDIR
+        if not fragments_dir.is_dir():
+            self._warn_below_minimum(buckets)
+            return buckets
+
+        for md_file in sorted(fragments_dir.rglob("*.md")):
+            loaded = _load_fragment_with_body(md_file)
+            if loaded is None:
+                continue
+            fragment, body = loaded
+            register = self._eligible_register(fragment)
+            if register is None:
+                continue
+            buckets[register].append(fragment)
+            self._records[fragment.id] = _ExemplarRecord(
+                word_count=_word_count(body),
+                source_path=md_file,
+            )
+
+        self._warn_below_minimum(buckets)
+        return buckets
+
+    def _eligible_register(self, fragment: Fragment) -> str | None:
+        """Return the fragment's register if it qualifies, else ``None``."""
+        if _confidence_value(fragment) not in _QUALIFYING_CONFIDENCE:
+            return None
+        if (
+            not self.allow_intimate
+            and str(fragment.privacy_tier) == PrivacyTier.INTIMATE.value
+        ):
+            return None
+        register = _register_value(fragment)
+        if register not in VOICE_REGISTERS:
+            return None
+        return register
+
+    def _warn_below_minimum(self, buckets: dict[str, list[Fragment]]) -> None:
+        """Emit a warning for any register short of :attr:`min_per_register`."""
+        for register, frags in buckets.items():
+            if len(frags) < self.min_per_register:
+                logger.warning(
+                    "Voice register %r has only %d exemplars (minimum %d).",
+                    register,
+                    len(frags),
+                    self.min_per_register,
+                )
+
+    # ---- Ranking ----
+
+    def rank_exemplars(self, fragments: list[Fragment]) -> list[Fragment]:
+        """Rank *fragments* by quality and return the top ``max_per_register``.
+
+        Scoring (max 5 per fragment):
+
+        - ``conviction`` confidence: 3 points; ``settled``: 2 points.
+        - Body length in ``[200, 800]`` words: +1 point (uses the cached
+          word count from :meth:`collect_exemplars`; falls back to 0
+          when the fragment was not previously collected).
+        - All classification axes populated (frequency, wavelength
+          phase / mode, voice register, voice confidence): +1 point.
+
+        Ties are broken by descending ID for deterministic ordering.
+
+        Args:
+            fragments: Fragments to rank. May be empty.
+
+        Returns:
+            Up to :attr:`max_per_register` fragments, sorted by
+            descending score.
+        """
+        if not fragments:
+            return []
+        scored = sorted(
+            fragments,
+            key=lambda f: (-self._score(f), f.id),
+        )
+        return scored[: self.max_per_register]
+
+    def _score(self, fragment: Fragment) -> int:
+        """Return the integer ranking score for *fragment*."""
+        score = _CONFIDENCE_SCORE.get(_confidence_value(fragment), 0)
+        record = self._records.get(fragment.id)
+        if record is not None and (
+            _MEDIUM_LENGTH_MIN_WORDS <= record.word_count <= _MEDIUM_LENGTH_MAX_WORDS
+        ):
+            score += _LENGTH_BONUS
+        if _is_fully_classified(fragment):
+            score += _CLASSIFICATION_BONUS
+        return score
+
+    # ---- Persistence ----
+
+    def save_exemplars(
+        self,
+        exemplars: dict[str, list[Fragment]],
+        vault_path: Path,
+    ) -> dict[str, Path]:
+        """Copy ranked exemplars into ``07-Voice/Register-Samples/<register>/``.
+
+        For each non-empty register the collector creates the destination
+        folder, copies (or rewrites) up to :attr:`max_per_register` of
+        the top-ranked fragments, and writes a ``_Summary.md`` note
+        recording statistics about the cohort.
+
+        Args:
+            exemplars: Mapping of register → fragments, typically the
+                output of :meth:`collect_exemplars`. Non-canonical
+                register keys are skipped with a debug log entry.
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            Mapping of register → path of the written summary note for
+            every non-empty register.
+        """
+        samples_root = vault_path.joinpath(*_SAMPLES_SUBPATH)
+        summaries: dict[str, Path] = {}
+        for register, fragments in exemplars.items():
+            if register not in VOICE_REGISTERS:
+                logger.debug("Skipping unknown voice register %r", register)
+                continue
+            if not fragments:
+                continue
+            ranked = self.rank_exemplars(fragments)
+            register_dir = samples_root / register
+            register_dir.mkdir(parents=True, exist_ok=True)
+            for fragment in ranked:
+                self._persist_fragment(fragment, register_dir)
+            summaries[register] = self._write_summary(register, ranked, register_dir)
+        return summaries
+
+    def _persist_fragment(self, fragment: Fragment, register_dir: Path) -> Path:
+        """Copy the source file for *fragment* (or serialise from memory)."""
+        target = register_dir / f"{fragment.id}.md"
+        record = self._records.get(fragment.id)
+        if record is not None and record.source_path.exists():
+            shutil.copy2(record.source_path, target)
+            return target
+        data = fragment.model_dump(mode="json")
+        post = frontmatter.Post(content="", **data)
+        target.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return target
+
+    def _write_summary(
+        self,
+        register: str,
+        ranked: list[Fragment],
+        register_dir: Path,
+    ) -> Path:
+        """Write the per-register summary note and return its path."""
+        conviction = sum(
+            1 for f in ranked if _confidence_value(f) == Confidence.CONVICTION.value
+        )
+        settled = sum(
+            1 for f in ranked if _confidence_value(f) == Confidence.SETTLED.value
+        )
+        body = self._render_summary_body(register, ranked, conviction, settled)
+        post = frontmatter.Post(
+            content=body,
+            type="voice-register-summary",
+            voice_register=register,
+            exemplar_count=len(ranked),
+            conviction_count=conviction,
+            settled_count=settled,
+            generated_at=datetime.now(tz=UTC).isoformat(),
+            tags=["voice", "voice-register", register],
+        )
+        summary_path = register_dir / _SUMMARY_FILENAME
+        summary_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return summary_path
+
+    @staticmethod
+    def _render_summary_body(
+        register: str,
+        ranked: list[Fragment],
+        conviction: int,
+        settled: int,
+    ) -> str:
+        """Render the markdown body of a register summary note."""
+        lines: list[str] = [
+            f"# Voice Register: {register}",
+            "",
+            "## Statistics",
+            "",
+            f"- Exemplar count: {len(ranked)}",
+            f"- Conviction confidence: {conviction}",
+            f"- Settled confidence: {settled}",
+            "",
+            "## Exemplars",
+            "",
+        ]
+        if ranked:
+            for fragment in ranked:
+                lines.append(f"- [[{fragment.id}|{fragment.title}]]")
+        else:
+            lines.append("_No exemplars collected._")
+        lines.append("")
+        return "\n".join(lines)
+
+
+__all__ = [
+    "DEFAULT_MAX_PER_REGISTER",
+    "DEFAULT_MIN_PER_REGISTER",
+    "VOICE_REGISTERS",
+    "VoiceExemplarCollector",
+]

--- a/creek-tools/tests/test_voice_exemplars.py
+++ b/creek-tools/tests/test_voice_exemplars.py
@@ -399,7 +399,7 @@ class TestRankExemplars:
             )
             _write_fragment(vault, frag, body_words=400)
             fragments.append(frag)
-        small = VoiceExemplarCollector(max_per_register=3)
+        small = VoiceExemplarCollector(max_per_register=3, min_per_register=1)
         small.collect_exemplars(vault)
         ranked = small.rank_exemplars(fragments)
         assert len(ranked) == 3
@@ -509,7 +509,7 @@ class TestSaveExemplars:
                 confidence=Confidence.SETTLED,
             )
             _write_fragment(vault, frag, body_words=400)
-        small = VoiceExemplarCollector(max_per_register=2)
+        small = VoiceExemplarCollector(max_per_register=2, min_per_register=1)
         exemplars = small.collect_exemplars(vault)
         small.save_exemplars(exemplars, vault)
         register_dir = vault / "07-Voice" / "Register-Samples" / "raw"
@@ -591,6 +591,11 @@ class TestInitValidation:
         """Passing a non-positive ``min_per_register`` raises ``ValueError``."""
         with pytest.raises(ValueError, match="min_per_register"):
             VoiceExemplarCollector(min_per_register=0)
+
+    def test_min_greater_than_max_raises(self) -> None:
+        """``min_per_register > max_per_register`` raises ``ValueError``."""
+        with pytest.raises(ValueError, match=r"min_per_register.*> max_per_register"):
+            VoiceExemplarCollector(min_per_register=20, max_per_register=5)
 
 
 # ---- Classification completeness branches ----
@@ -727,3 +732,119 @@ class TestSaveFallback:
         target = vault / "07-Voice" / "Register-Samples" / "analytical" / "frag-gone.md"
         assert target.exists()
         assert "analytical" in result
+
+    def test_fallback_serialisation_produces_valid_frontmatter(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """In-memory fallback must produce a parseable frontmatter document."""
+        frag = _build_fragment(
+            frag_id="frag-mem2",
+            title="In-memory fragment",
+            register=VoiceRegister.PLAYFUL,
+            confidence=Confidence.SETTLED,
+        )
+        collector.save_exemplars({"playful": [frag]}, vault)
+        target = vault / "07-Voice" / "Register-Samples" / "playful" / "frag-mem2.md"
+        post = frontmatter.load(str(target))
+        assert post["type"] == "fragment"
+        assert post["id"] == "frag-mem2"
+        assert post["title"] == "In-memory fragment"
+
+
+# ---- Tie-breaking ----
+
+
+class TestTieBreaking:
+    """Deterministic ordering when fragments have equal scores."""
+
+    def test_equal_score_ordered_by_ascending_id(
+        self,
+        vault: Path,
+    ) -> None:
+        """Fragments with identical scores are ordered by ascending ID."""
+        collector = VoiceExemplarCollector(max_per_register=10)
+        frag_z = _build_fragment(
+            frag_id="frag-zzz",
+            title="Z fragment",
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.SETTLED,
+        )
+        frag_a = _build_fragment(
+            frag_id="frag-aaa",
+            title="A fragment",
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.SETTLED,
+        )
+        _write_fragment(vault, frag_z, body_words=400)
+        _write_fragment(vault, frag_a, body_words=400)
+        collector.collect_exemplars(vault)
+        ranked = collector.rank_exemplars([frag_z, frag_a])
+        assert [f.id for f in ranked] == ["frag-aaa", "frag-zzz"]
+
+
+# ---- YAML error resilience ----
+
+
+class TestYamlErrorResilience:
+    """Malformed YAML must not abort the vault scan."""
+
+    def test_skips_broken_yaml_frontmatter(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Files with syntactically invalid YAML are silently skipped."""
+        broken = vault / "01-Fragments" / "Journal" / "bad-yaml.md"
+        broken.write_text(
+            "---\nkey: [\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+        good = _build_fragment(
+            frag_id="frag-yaml-ok",
+            title="Good YAML",
+            register=VoiceRegister.RAW,
+            confidence=Confidence.SETTLED,
+        )
+        _write_fragment(vault, good, body_words=400)
+        exemplars = collector.collect_exemplars(vault)
+        assert [f.id for f in exemplars["raw"]] == ["frag-yaml-ok"]
+
+
+# ---- Warning suppression for empty registers ----
+
+
+class TestWarningBehavior:
+    """Warning logic for registers below minimum threshold."""
+
+    def test_no_warnings_for_empty_registers(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Registers with zero exemplars must not emit warnings."""
+        with caplog.at_level(logging.WARNING, logger="creek.generate.voice"):
+            collector.collect_exemplars(vault)
+        assert caplog.records == []
+
+    def test_warns_when_register_has_some_but_below_minimum(
+        self,
+        vault: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Registers with 1..min-1 exemplars emit a warning."""
+        collector = VoiceExemplarCollector(min_per_register=3)
+        for idx in range(2):
+            frag = _build_fragment(
+                frag_id=f"frag-warn-{idx}",
+                title=f"Warn frag {idx}",
+                register=VoiceRegister.PLAYFUL,
+                confidence=Confidence.SETTLED,
+            )
+            _write_fragment(vault, frag, body_words=400)
+        with caplog.at_level(logging.WARNING, logger="creek.generate.voice"):
+            collector.collect_exemplars(vault)
+        playful_warnings = [r for r in caplog.records if "playful" in r.message]
+        assert len(playful_warnings) == 1

--- a/creek-tools/tests/test_voice_exemplars.py
+++ b/creek-tools/tests/test_voice_exemplars.py
@@ -1,0 +1,729 @@
+"""Tests for creek.generate.voice — voice exemplar collection.
+
+Covers the ``VoiceExemplarCollector`` class implementing Section 11.1 of
+the Creek Ontology: scan vault fragments for high-confidence voice
+samples grouped by register, rank by quality, and persist the top
+exemplars under ``07-Voice/Register-Samples/``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.generate.voice import (
+    DEFAULT_MAX_PER_REGISTER,
+    DEFAULT_MIN_PER_REGISTER,
+    VOICE_REGISTERS,
+    VoiceExemplarCollector,
+)
+from creek.models import (
+    Confidence,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Mode,
+    Phase,
+    PrivacyTier,
+    SourcePlatform,
+    VoiceClassification,
+    VoiceRegister,
+    WavelengthClassification,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    """Create a minimal vault tree with the folders the collector touches."""
+    for folder in (
+        "01-Fragments/Journal",
+        "01-Fragments/Conversations",
+        "01-Fragments/Writing",
+        "07-Voice/Register-Samples",
+    ):
+        (tmp_path / folder).mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+@pytest.fixture()
+def collector() -> VoiceExemplarCollector:
+    """Create a default VoiceExemplarCollector."""
+    return VoiceExemplarCollector()
+
+
+def _build_fragment(
+    *,
+    frag_id: str,
+    title: str,
+    register: VoiceRegister | None,
+    confidence: Confidence | None,
+    privacy: PrivacyTier = PrivacyTier.PERSONAL,
+    fully_classified: bool = True,
+) -> Fragment:
+    """Build a Fragment with the desired voice / privacy / classification state."""
+    if fully_classified:
+        frequency = FrequencyClassification(primary=Frequency.F5)
+        wavelength = WavelengthClassification(
+            phase=Phase.RISING,
+            mode=Mode.EXPRESS,
+        )
+    else:
+        frequency = FrequencyClassification()
+        wavelength = WavelengthClassification()
+    return Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        created=datetime(2026, 1, 15, 12, 0, 0),
+        ingested=datetime(2026, 1, 15, 12, 0, 0),
+        frequency=frequency,
+        wavelength=wavelength,
+        voice=VoiceClassification(voice_register=register, confidence=confidence),
+        privacy_tier=privacy,
+    )
+
+
+def _write_fragment(
+    vault_path: Path,
+    fragment: Fragment,
+    *,
+    body_words: int,
+    subfolder: str = "Journal",
+) -> Path:
+    """Persist *fragment* under ``01-Fragments/{subfolder}/`` with a body."""
+    body = " ".join(["word"] * body_words)
+    data = fragment.model_dump(mode="json")
+    post = frontmatter.Post(content=body, **data)
+    target = vault_path / "01-Fragments" / subfolder / f"{fragment.id}.md"
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+# ---- Module surface ----
+
+
+class TestModuleSurface:
+    """Exported constants must match the issue specification."""
+
+    def test_voice_registers_covers_seven_canonical_registers(self) -> None:
+        """All seven ontology voice registers must be enumerated."""
+        expected = {
+            "confessional",
+            "analytical",
+            "playful",
+            "prophetic",
+            "instructional",
+            "raw",
+            "conversational",
+        }
+        assert set(VOICE_REGISTERS) == expected
+
+    def test_default_min_is_five(self) -> None:
+        """Default minimum exemplars per register should follow the spec."""
+        assert DEFAULT_MIN_PER_REGISTER == 5
+
+    def test_default_max_is_twenty(self) -> None:
+        """Default maximum exemplars per register should follow the spec."""
+        assert DEFAULT_MAX_PER_REGISTER == 20
+
+
+# ---- collect_exemplars ----
+
+
+class TestCollectExemplars:
+    """Scan the vault, filter by confidence/privacy, group by register."""
+
+    def test_collects_settled_and_conviction_only(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Only ``settled`` and ``conviction`` confidence levels qualify."""
+        keep = _build_fragment(
+            frag_id="frag-keep1",
+            title="Keep me",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.SETTLED,
+        )
+        keep2 = _build_fragment(
+            frag_id="frag-keep2",
+            title="Keep me too",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.CONVICTION,
+        )
+        drop = _build_fragment(
+            frag_id="frag-drop1",
+            title="Drop me",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.MUSING,
+        )
+        for frag in (keep, keep2, drop):
+            _write_fragment(vault, frag, body_words=400)
+
+        exemplars = collector.collect_exemplars(vault)
+        ids = {f.id for f in exemplars["confessional"]}
+        assert ids == {"frag-keep1", "frag-keep2"}
+
+    def test_groups_by_register(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Fragments end up in the bucket matching their voice register."""
+        confess = _build_fragment(
+            frag_id="frag-c1",
+            title="A confession",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.SETTLED,
+        )
+        analytic = _build_fragment(
+            frag_id="frag-a1",
+            title="An analysis",
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.SETTLED,
+        )
+        _write_fragment(vault, confess, body_words=400)
+        _write_fragment(vault, analytic, body_words=400, subfolder="Writing")
+
+        exemplars = collector.collect_exemplars(vault)
+        assert [f.id for f in exemplars["confessional"]] == ["frag-c1"]
+        assert [f.id for f in exemplars["analytical"]] == ["frag-a1"]
+
+    def test_returns_all_seven_register_keys(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Every register key is present, even when empty."""
+        exemplars = collector.collect_exemplars(vault)
+        assert set(exemplars) == set(VOICE_REGISTERS)
+        assert all(value == [] for value in exemplars.values())
+
+    def test_excludes_intimate_by_default(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Intimate-tier fragments are dropped unless explicitly opted in."""
+        intimate = _build_fragment(
+            frag_id="frag-int1",
+            title="Intimate piece",
+            register=VoiceRegister.RAW,
+            confidence=Confidence.SETTLED,
+            privacy=PrivacyTier.INTIMATE,
+        )
+        _write_fragment(vault, intimate, body_words=400)
+        exemplars = collector.collect_exemplars(vault)
+        assert exemplars["raw"] == []
+
+    def test_includes_intimate_when_opted_in(
+        self,
+        vault: Path,
+    ) -> None:
+        """Setting ``allow_intimate=True`` includes intimate-tier fragments."""
+        intimate = _build_fragment(
+            frag_id="frag-int1",
+            title="Intimate piece",
+            register=VoiceRegister.RAW,
+            confidence=Confidence.SETTLED,
+            privacy=PrivacyTier.INTIMATE,
+        )
+        _write_fragment(vault, intimate, body_words=400)
+        opted_in = VoiceExemplarCollector(allow_intimate=True)
+        exemplars = opted_in.collect_exemplars(vault)
+        assert [f.id for f in exemplars["raw"]] == ["frag-int1"]
+
+    def test_skips_fragments_without_register(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Fragments missing a voice_register are not collected."""
+        no_register = _build_fragment(
+            frag_id="frag-none",
+            title="No register",
+            register=None,
+            confidence=Confidence.SETTLED,
+        )
+        _write_fragment(vault, no_register, body_words=400)
+        exemplars = collector.collect_exemplars(vault)
+        for frags in exemplars.values():
+            assert "frag-none" not in {f.id for f in frags}
+
+    def test_warns_when_register_below_minimum(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Registers with fewer than the minimum exemplars emit a warning."""
+        single = _build_fragment(
+            frag_id="frag-only1",
+            title="Lone exemplar",
+            register=VoiceRegister.PROPHETIC,
+            confidence=Confidence.CONVICTION,
+        )
+        _write_fragment(vault, single, body_words=400)
+        with caplog.at_level(logging.WARNING, logger="creek.generate.voice"):
+            collector.collect_exemplars(vault)
+        assert any("prophetic" in record.message for record in caplog.records)
+
+    def test_handles_missing_fragments_directory(
+        self,
+        tmp_path: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """A vault without ``01-Fragments`` returns the empty-bucket dict."""
+        exemplars = collector.collect_exemplars(tmp_path)
+        assert set(exemplars) == set(VOICE_REGISTERS)
+        assert all(value == [] for value in exemplars.values())
+
+    def test_skips_unparseable_files(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Markdown files that fail to parse are silently skipped."""
+        (vault / "01-Fragments" / "Journal" / "broken.md").write_bytes(b"\x00\x01\x02")
+        good = _build_fragment(
+            frag_id="frag-good",
+            title="Good fragment",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.SETTLED,
+        )
+        _write_fragment(vault, good, body_words=400)
+        exemplars = collector.collect_exemplars(vault)
+        assert [f.id for f in exemplars["confessional"]] == ["frag-good"]
+
+
+# ---- rank_exemplars ----
+
+
+class TestRankExemplars:
+    """Ranking by confidence, content length, and classification completeness."""
+
+    def test_conviction_outranks_settled(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Conviction-confidence fragments rank above settled ones."""
+        settled = _build_fragment(
+            frag_id="frag-settled",
+            title="Settled",
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.SETTLED,
+        )
+        conviction = _build_fragment(
+            frag_id="frag-conviction",
+            title="Conviction",
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.CONVICTION,
+        )
+        _write_fragment(vault, settled, body_words=400)
+        _write_fragment(vault, conviction, body_words=400)
+        collector.collect_exemplars(vault)
+        ranked = collector.rank_exemplars([settled, conviction])
+        assert [f.id for f in ranked] == ["frag-conviction", "frag-settled"]
+
+    def test_medium_length_outranks_short(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Medium-length (200-800 words) bodies score higher than short ones."""
+        short = _build_fragment(
+            frag_id="frag-short",
+            title="Short",
+            register=VoiceRegister.PLAYFUL,
+            confidence=Confidence.SETTLED,
+        )
+        medium = _build_fragment(
+            frag_id="frag-medium",
+            title="Medium",
+            register=VoiceRegister.PLAYFUL,
+            confidence=Confidence.SETTLED,
+        )
+        _write_fragment(vault, short, body_words=50)
+        _write_fragment(vault, medium, body_words=400)
+        collector.collect_exemplars(vault)
+        ranked = collector.rank_exemplars([short, medium])
+        assert ranked[0].id == "frag-medium"
+
+    def test_full_classification_outranks_partial(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Fragments with full classification rank above partial ones."""
+        partial = _build_fragment(
+            frag_id="frag-partial",
+            title="Partial",
+            register=VoiceRegister.INSTRUCTIONAL,
+            confidence=Confidence.SETTLED,
+            fully_classified=False,
+        )
+        complete = _build_fragment(
+            frag_id="frag-complete",
+            title="Complete",
+            register=VoiceRegister.INSTRUCTIONAL,
+            confidence=Confidence.SETTLED,
+            fully_classified=True,
+        )
+        _write_fragment(vault, partial, body_words=400)
+        _write_fragment(vault, complete, body_words=400)
+        collector.collect_exemplars(vault)
+        ranked = collector.rank_exemplars([partial, complete])
+        assert ranked[0].id == "frag-complete"
+
+    def test_top_n_truncation(self, vault: Path) -> None:
+        """rank_exemplars returns at most ``max_per_register`` entries."""
+        fragments: list[Fragment] = []
+        for idx in range(6):
+            frag = _build_fragment(
+                frag_id=f"frag-rank-{idx}",
+                title=f"Frag {idx}",
+                register=VoiceRegister.CONVERSATIONAL,
+                confidence=Confidence.SETTLED,
+            )
+            _write_fragment(vault, frag, body_words=400)
+            fragments.append(frag)
+        small = VoiceExemplarCollector(max_per_register=3)
+        small.collect_exemplars(vault)
+        ranked = small.rank_exemplars(fragments)
+        assert len(ranked) == 3
+
+    def test_empty_input_returns_empty(
+        self,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Empty input yields an empty ranked list."""
+        assert collector.rank_exemplars([]) == []
+
+
+# ---- save_exemplars ----
+
+
+class TestSaveExemplars:
+    """Persist top exemplars and per-register summary notes to the vault."""
+
+    def test_copies_fragment_files_to_register_folder(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Fragment markdown files land under the matching register folder."""
+        frag = _build_fragment(
+            frag_id="frag-save1",
+            title="Saved",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.SETTLED,
+        )
+        _write_fragment(vault, frag, body_words=400)
+        exemplars = collector.collect_exemplars(vault)
+        collector.save_exemplars(exemplars, vault)
+        target = (
+            vault / "07-Voice" / "Register-Samples" / "confessional" / "frag-save1.md"
+        )
+        assert target.exists()
+
+    def test_summary_note_written_per_register(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Each non-empty register gets a summary note with stats."""
+        frag = _build_fragment(
+            frag_id="frag-sum1",
+            title="Summary fodder",
+            register=VoiceRegister.PLAYFUL,
+            confidence=Confidence.CONVICTION,
+        )
+        _write_fragment(vault, frag, body_words=400)
+        exemplars = collector.collect_exemplars(vault)
+        collector.save_exemplars(exemplars, vault)
+        summary = vault / "07-Voice" / "Register-Samples" / "playful" / "_Summary.md"
+        assert summary.exists()
+        post = frontmatter.load(str(summary))
+        assert post["voice_register"] == "playful"
+        assert post["exemplar_count"] == 1
+        assert post["type"] == "voice-register-summary"
+
+    def test_summary_includes_per_confidence_breakdown(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Summary frontmatter records the conviction/settled split."""
+        a = _build_fragment(
+            frag_id="frag-conv1",
+            title="Conviction sample",
+            register=VoiceRegister.PROPHETIC,
+            confidence=Confidence.CONVICTION,
+        )
+        b = _build_fragment(
+            frag_id="frag-settle1",
+            title="Settled sample",
+            register=VoiceRegister.PROPHETIC,
+            confidence=Confidence.SETTLED,
+        )
+        _write_fragment(vault, a, body_words=400)
+        _write_fragment(vault, b, body_words=400)
+        exemplars = collector.collect_exemplars(vault)
+        collector.save_exemplars(exemplars, vault)
+        summary = vault / "07-Voice" / "Register-Samples" / "prophetic" / "_Summary.md"
+        post = frontmatter.load(str(summary))
+        assert post["conviction_count"] == 1
+        assert post["settled_count"] == 1
+
+    def test_skips_empty_registers(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Empty register buckets do not create a folder or summary."""
+        exemplars = collector.collect_exemplars(vault)
+        collector.save_exemplars(exemplars, vault)
+        for register in VOICE_REGISTERS:
+            folder = vault / "07-Voice" / "Register-Samples" / register
+            assert not folder.exists()
+
+    def test_truncates_to_max_per_register(self, vault: Path) -> None:
+        """save_exemplars writes only the top ``max_per_register`` files."""
+        for idx in range(4):
+            frag = _build_fragment(
+                frag_id=f"frag-trunc-{idx}",
+                title=f"Trunc {idx}",
+                register=VoiceRegister.RAW,
+                confidence=Confidence.SETTLED,
+            )
+            _write_fragment(vault, frag, body_words=400)
+        small = VoiceExemplarCollector(max_per_register=2)
+        exemplars = small.collect_exemplars(vault)
+        small.save_exemplars(exemplars, vault)
+        register_dir = vault / "07-Voice" / "Register-Samples" / "raw"
+        copied = sorted(
+            p.name for p in register_dir.glob("*.md") if p.name != "_Summary.md"
+        )
+        assert len(copied) == 2
+
+    def test_returns_summary_paths(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """save_exemplars returns the per-register summary paths."""
+        frag = _build_fragment(
+            frag_id="frag-return1",
+            title="Return path",
+            register=VoiceRegister.INSTRUCTIONAL,
+            confidence=Confidence.SETTLED,
+        )
+        _write_fragment(vault, frag, body_words=400)
+        exemplars = collector.collect_exemplars(vault)
+        result = collector.save_exemplars(exemplars, vault)
+        assert "instructional" in result
+        assert result["instructional"].name == "_Summary.md"
+
+    def test_save_without_collect_falls_back_to_dump(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Saving without a prior collect serialises fragments from memory."""
+        frag = _build_fragment(
+            frag_id="frag-mem1",
+            title="In-memory only",
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.CONVICTION,
+        )
+        result = collector.save_exemplars({"analytical": [frag]}, vault)
+        target = vault / "07-Voice" / "Register-Samples" / "analytical" / "frag-mem1.md"
+        assert target.exists()
+        assert "analytical" in result
+
+    def test_save_skips_unknown_register_keys(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Non-canonical register keys are silently skipped."""
+        frag = _build_fragment(
+            frag_id="frag-bogus",
+            title="Bogus register",
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.SETTLED,
+        )
+        result = collector.save_exemplars({"made-up-register": [frag]}, vault)
+        assert result == {}
+
+    def test_summary_body_lists_zero_exemplars_when_empty(
+        self,
+    ) -> None:
+        """The internal summary renderer handles the no-ranked-exemplars case."""
+        body = VoiceExemplarCollector._render_summary_body("playful", [], 0, 0)
+        assert "_No exemplars collected._" in body
+
+
+# ---- Init validation ----
+
+
+class TestInitValidation:
+    """Constructor argument validation."""
+
+    def test_max_per_register_must_be_positive(self) -> None:
+        """Passing a non-positive ``max_per_register`` raises ``ValueError``."""
+        with pytest.raises(ValueError, match="max_per_register"):
+            VoiceExemplarCollector(max_per_register=0)
+
+    def test_min_per_register_must_be_positive(self) -> None:
+        """Passing a non-positive ``min_per_register`` raises ``ValueError``."""
+        with pytest.raises(ValueError, match="min_per_register"):
+            VoiceExemplarCollector(min_per_register=0)
+
+
+# ---- Classification completeness branches ----
+
+
+def _partial_fragment(
+    *,
+    frag_id: str,
+    frequency: FrequencyClassification,
+    wavelength: WavelengthClassification,
+    voice: VoiceClassification,
+) -> Fragment:
+    """Build a Fragment with caller-controlled classification axes."""
+    return Fragment(
+        id=frag_id,
+        title=frag_id,
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        frequency=frequency,
+        wavelength=wavelength,
+        voice=voice,
+    )
+
+
+class TestClassificationCompleteness:
+    """Each classification axis must be set for the bonus to apply."""
+
+    def test_each_missing_axis_drops_classification_bonus(
+        self,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """The complete fragment outranks every single-axis-missing partial."""
+        complete = _build_fragment(
+            frag_id="frag-zcomplete",
+            title="Complete",
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.SETTLED,
+        )
+        analytical_settled = VoiceClassification(
+            voice_register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.SETTLED,
+        )
+        full_wavelength = WavelengthClassification(
+            phase=Phase.RISING,
+            mode=Mode.EXPRESS,
+        )
+        full_frequency = FrequencyClassification(primary=Frequency.F5)
+        partials = [
+            _partial_fragment(
+                frag_id="frag-nofreq",
+                frequency=FrequencyClassification(),
+                wavelength=full_wavelength,
+                voice=analytical_settled,
+            ),
+            _partial_fragment(
+                frag_id="frag-nophase",
+                frequency=full_frequency,
+                wavelength=WavelengthClassification(mode=Mode.EXPRESS),
+                voice=analytical_settled,
+            ),
+            _partial_fragment(
+                frag_id="frag-nomode",
+                frequency=full_frequency,
+                wavelength=WavelengthClassification(phase=Phase.RISING),
+                voice=analytical_settled,
+            ),
+            _partial_fragment(
+                frag_id="frag-novoice",
+                frequency=full_frequency,
+                wavelength=full_wavelength,
+                voice=VoiceClassification(confidence=Confidence.SETTLED),
+            ),
+        ]
+        ranked = collector.rank_exemplars([*partials, complete])
+        assert ranked[0].id == "frag-zcomplete"
+
+
+# ---- Loader resilience ----
+
+
+class TestLoaderResilience:
+    """The loader must skip malformed frontmatter without raising."""
+
+    def test_skips_non_fragment_type(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Markdown files whose ``type`` is not ``fragment`` are ignored."""
+        path = vault / "01-Fragments" / "Journal" / "thread-like.md"
+        path.write_text(
+            "---\ntype: thread\nid: thread-x\ntitle: Not a fragment\n---\n",
+            encoding="utf-8",
+        )
+        exemplars = collector.collect_exemplars(vault)
+        assert all(value == [] for value in exemplars.values())
+
+    def test_skips_invalid_fragment_metadata(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Fragments whose frontmatter fails validation are skipped."""
+        path = vault / "01-Fragments" / "Journal" / "bad.md"
+        path.write_text(
+            "---\ntype: fragment\nid: frag-bad\n---\n\nbody\n",
+            encoding="utf-8",
+        )
+        exemplars = collector.collect_exemplars(vault)
+        assert all(value == [] for value in exemplars.values())
+
+
+# ---- Save fallback ----
+
+
+class TestSaveFallback:
+    """save_exemplars must handle a missing or moved source file."""
+
+    def test_falls_back_when_cached_source_missing(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """If the cached source path is gone, save serialises in-memory."""
+        frag = _build_fragment(
+            frag_id="frag-gone",
+            title="Will be removed",
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.SETTLED,
+        )
+        source = _write_fragment(vault, frag, body_words=400)
+        collector.collect_exemplars(vault)
+        source.unlink()
+        result = collector.save_exemplars({"analytical": [frag]}, vault)
+        target = vault / "07-Voice" / "Register-Samples" / "analytical" / "frag-gone.md"
+        assert target.exists()
+        assert "analytical" in result


### PR DESCRIPTION
## Summary

- Implement `VoiceExemplarCollector` class in `creek/generate/voice.py` (Section 11.1 of the Creek Ontology)
- Scan vault fragments for `voice.confidence` in {settled, conviction}, group by all 7 voice registers
- Rank exemplars by quality metrics: confidence level (conviction=3, settled=2), medium-length body (+1), classification completeness (+1)
- Privacy tier filtering: exclude intimate-tier fragments by default, opt-in via `allow_intimate=True`
- Save top exemplars (configurable, default 20/register) to `07-Voice/Register-Samples/{register}/` with per-register summary notes
- Warn when any register has fewer than 5 exemplars
- Register module in `creek/generate/__init__.py` with full `__all__` exports

## Test plan

- [x] 32 tests in `tests/test_voice_exemplars.py` covering all acceptance criteria
- [x] Module surface: 7 canonical registers, default min=5 / max=20
- [x] `collect_exemplars`: settled/conviction filtering, register grouping, intimate exclusion/opt-in, missing register skipping, unparseable file resilience, missing directory handling, below-minimum warnings
- [x] `rank_exemplars`: conviction > settled ordering, medium-length body bonus, classification completeness bonus, top-N truncation, empty input
- [x] `save_exemplars`: file copy to register folders, summary note with confidence breakdown, empty register skipping, max truncation, fallback serialisation, unknown register keys
- [x] Init validation: ValueError on invalid max/min
- [x] Classification completeness: each missing axis tested independently
- [x] Loader resilience: non-fragment type, invalid metadata
- [x] Save fallback: cached source path deleted before save
- [x] voice.py coverage: 97.79% | project total: 94.72%
- [x] `check-all.sh`: lint, format, complexity, tests, coverage all pass (type/security failures are pre-existing on main)

Closes #47