### PR TITLE
feat(generate): add voice register profile generation (#49)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -226,6 +226,22 @@ def report(
         console.print(
             f"[bold green]Unnamed digest generated: {digest_path}[/bold green]",
         )
+    elif type == "voice":
+        from creek.generate.voice import VoiceProfileGenerator
+
+        profile_generator = VoiceProfileGenerator()
+        profile_paths = profile_generator.generate_all_profiles(vault_path)
+        if profile_paths:
+            names = ", ".join(path.stem for path in profile_paths)
+            console.print(
+                f"[bold green]Voice profiles generated ({len(profile_paths)}): "
+                f"{names}[/bold green]",
+            )
+        else:
+            console.print(
+                "[yellow]No voice profiles generated: "
+                "no qualifying exemplars found.[/yellow]",
+            )
     else:
         console.print(
             f"[bold green]Would report: type={type}, "

--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -45,6 +45,7 @@ from creek.models import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -132,6 +133,33 @@ def _is_fully_classified(fragment: Fragment) -> bool:
 def _word_count(body: str) -> int:
     """Return the whitespace-delimited token count of *body*."""
     return len(body.split())
+
+
+def _eligible_register(
+    fragment: Fragment,
+    *,
+    allow_intimate: bool,
+) -> str | None:
+    """Return the fragment's register if it qualifies as an exemplar.
+
+    Args:
+        fragment: Candidate fragment.
+        allow_intimate: When ``False``, ``intimate`` privacy tier
+            fragments are rejected.
+
+    Returns:
+        The canonical register string when the fragment has qualifying
+        confidence, allowed privacy tier, and a canonical register;
+        otherwise ``None``.
+    """
+    if _confidence_value(fragment) not in _QUALIFYING_CONFIDENCE:
+        return None
+    if not allow_intimate and str(fragment.privacy_tier) == PrivacyTier.INTIMATE.value:
+        return None
+    register = _register_value(fragment)
+    if register not in VOICE_REGISTERS:
+        return None
+    return register
 
 
 def _load_fragment_with_body(
@@ -265,17 +293,7 @@ class VoiceExemplarCollector:
 
     def _eligible_register(self, fragment: Fragment) -> str | None:
         """Return the fragment's register if it qualifies, else ``None``."""
-        if _confidence_value(fragment) not in _QUALIFYING_CONFIDENCE:
-            return None
-        if (
-            not self.allow_intimate
-            and str(fragment.privacy_tier) == PrivacyTier.INTIMATE.value
-        ):
-            return None
-        register = _register_value(fragment)
-        if register not in VOICE_REGISTERS:
-            return None
-        return register
+        return _eligible_register(fragment, allow_intimate=self.allow_intimate)
 
     def _warn_below_minimum(self, buckets: dict[str, list[Fragment]]) -> None:
         """Emit a warning for registers with some but too few exemplars.
@@ -1090,11 +1108,505 @@ class VoicePatternExtractor:
         return tuple(coined)
 
 
+# ---------------------------------------------------------------------------
+# Voice register profile generation — Section 11.2
+# ---------------------------------------------------------------------------
+
+
+_PROFILE_SUBDIR: str = "07-Voice"
+"""Vault subdirectory where register profile notes are persisted."""
+
+_PROFILE_FILENAME_SUFFIX: str = "-profile.md"
+"""Filename suffix for register profile markdown files."""
+
+_DEFAULT_MAX_EXEMPLARS_PER_PROFILE: int = 10
+"""Default maximum number of exemplar passages included in a profile."""
+
+_DEFAULT_MIN_EXEMPLARS_PER_PROFILE: int = 5
+"""Registers below this threshold trigger a warning during profile generation."""
+
+_REGISTER_VOICE_DESCRIPTIONS: dict[str, str] = {
+    "confessional": (
+        "Write in a confessional register. Use first person. "
+        "Start from vulnerability and sensory detail, then arrive at insight. "
+        "Let paragraphs build from concrete experience to abstract reflection. "
+        "Favour em-dashes for asides."
+    ),
+    "analytical": (
+        "Write in an analytical register. Use precise, qualified claims "
+        "grounded in evidence. Move from observation to inference to "
+        "implication. Metaphors illustrate; they do not carry the argument."
+    ),
+    "playful": (
+        "Write in a playful register. Let wit carry the argument. "
+        "Puns, reversals, and small jokes are welcome. Irony underlines "
+        "sincerity rather than distancing from it."
+    ),
+    "prophetic": (
+        "Write in a prophetic register. Speak with declarative clarity. "
+        "Let each claim stand without apology. Cadence matters — "
+        "short lines have weight."
+    ),
+    "instructional": (
+        "Write in an instructional register. Lead the reader one step at a "
+        "time. Define every term on first use. Resolve each paragraph to "
+        "an actionable understanding."
+    ),
+    "raw": (
+        "Write in a raw register. Preserve the rough edges of the thought. "
+        "Let ideas arrive half-formed. Use fragments. Trust the reader to "
+        "fill the gaps."
+    ),
+    "conversational": (
+        "Write in a conversational register. Address the reader directly. "
+        "Use the second person when natural. Keep paragraphs short so the "
+        "exchange stays alive."
+    ),
+}
+"""Register-specific opening lines for the generated LLM voice prompts."""
+
+_REGISTER_ANTI_PATTERNS: dict[str, tuple[str, ...]] = {
+    "confessional": (
+        "Do not use corporate or management language.",
+        "Do not hedge with qualifiers like 'perhaps' or 'possibly'.",
+        "Do not structure thoughts as bullet points.",
+    ),
+    "analytical": (
+        "Do not assert emotion without evidence.",
+        "Do not adopt confessional first-person intimacy.",
+        "Do not issue prophetic pronouncements.",
+    ),
+    "playful": (
+        "Do not adopt formal academic solemnity.",
+        "Do not use jargon without winking at it.",
+        "Do not chain flat declarative sentences without variation.",
+    ),
+    "prophetic": (
+        "Do not hedge or qualify the vision.",
+        "Do not soften the claim with bureaucratic disclaimers.",
+        "Do not diminish the statement with self-deprecation.",
+    ),
+    "instructional": (
+        "Do not insert confessional asides that detour the reader.",
+        "Do not leave jargon undefined on first use.",
+        "Do not stop at metaphor without making the mechanism explicit.",
+    ),
+    "raw": (
+        "Do not polish the rough edges into smoothness.",
+        "Do not pre-empt the reader with explanatory framing.",
+        "Do not translate the moment into academic language.",
+    ),
+    "conversational": (
+        "Do not monologue without addressing the reader.",
+        "Do not use academic distance or formal register.",
+        "Do not bury the exchange under dense paragraphs.",
+    ),
+}
+"""Register-specific list of constraints the voice should never violate."""
+
+
+@dataclass(frozen=True)
+class Exemplar:
+    """A voice exemplar: a fragment's metadata paired with its body text.
+
+    :class:`VoiceProfileGenerator` consumes these to compose register
+    profiles. Bodies are kept separate from the :class:`Fragment` model
+    because Fragment only stores frontmatter; the body lives in the
+    markdown file alongside it.
+
+    Attributes:
+        fragment: The exemplar fragment's metadata.
+        body: The exemplar's prose body as stored on disk.
+    """
+
+    fragment: Fragment
+    body: str
+
+
+def _exemplar_score(exemplar: Exemplar) -> int:
+    """Return the ranking score for *exemplar*.
+
+    Mirrors :meth:`VoiceExemplarCollector._score` but reads word count
+    from the exemplar's body rather than a cached record: confidence
+    base (3 for conviction, 2 for settled), +1 bonus for a body in the
+    medium-length band [200, 800] words, and +1 bonus when every
+    classification axis is populated.
+    """
+    fragment = exemplar.fragment
+    score = _CONFIDENCE_SCORE.get(_confidence_value(fragment), 0)
+    word_count = _word_count(exemplar.body)
+    if _MEDIUM_LENGTH_MIN_WORDS <= word_count <= _MEDIUM_LENGTH_MAX_WORDS:
+        score += _LENGTH_BONUS
+    if _is_fully_classified(fragment):
+        score += _CLASSIFICATION_BONUS
+    return score
+
+
+@dataclass(frozen=True)
+class VoiceProfile:
+    """A per-register voice profile ready to be persisted as markdown.
+
+    Attributes:
+        register: The canonical voice register this profile describes.
+        exemplars: Tuple of 5-10 sample passages that exemplify the
+            register.
+        patterns: The :class:`VoicePatterns` extracted from the passages.
+        voice_prompt: A reusable LLM instruction block describing how to
+            write in this register.
+        anti_patterns: The register's "DO NOT" constraints.
+        generated_at: Timezone-aware timestamp of profile generation.
+    """
+
+    register: str
+    exemplars: tuple[str, ...]
+    patterns: VoicePatterns
+    voice_prompt: str
+    anti_patterns: tuple[str, ...]
+    generated_at: datetime
+
+    @property
+    def exemplar_count(self) -> int:
+        """Return the number of sample passages included in the profile."""
+        return len(self.exemplars)
+
+
+def _format_structural_patterns(patterns: VoicePatterns) -> list[str]:
+    """Render the structural pattern section as markdown bullet lines."""
+    sm = patterns.sentence_metrics
+    pm = patterns.paragraph_metrics
+    lines = [
+        f"- Average sentence length: {sm.average_length:.1f} words "
+        f"(short {sm.short_count} / medium {sm.medium_count} / "
+        f"long {sm.long_count}).",
+        f"- Sentence fragments used as rhetorical beats: {sm.fragment_count}.",
+        f"- Question frequency: {sm.question_frequency:.2f}.",
+        f"- Average sentences per paragraph: {pm.average_sentences_per_paragraph:.1f}.",
+    ]
+    if patterns.transitions:
+        top = ", ".join(word for word, _ in patterns.transitions[:5])
+        lines.append(f"- Preferred transitions: {top}.")
+    return lines
+
+
+def _format_metaphor_families(patterns: VoicePatterns) -> list[str]:
+    """Render the metaphor family section as markdown bullet lines."""
+    if not patterns.metaphor_families:
+        return ["- No recurring metaphor families detected."]
+    lines: list[str] = []
+    for family in patterns.metaphor_families:
+        matches = ", ".join(family.matches)
+        lines.append(f"- **{family.domain}**: {matches}.")
+    return lines
+
+
+def _format_rhetorical_moves(patterns: VoicePatterns) -> list[str]:
+    """Render the rhetorical moves section as markdown bullet lines."""
+    moves = patterns.rhetorical_moves
+    return [
+        f"- Self-deprecation before insight: {moves.self_deprecation_count}.",
+        f"- Paradox constructions: {moves.paradox_count}.",
+        f"- Callbacks to earlier points: {moves.callback_count}.",
+    ]
+
+
+def _build_voice_prompt(
+    register: str,
+    patterns: VoicePatterns,
+    anti_patterns: tuple[str, ...],
+) -> str:
+    """Construct the LLM-ready voice prompt for a register.
+
+    Args:
+        register: Canonical register name.
+        patterns: Extracted :class:`VoicePatterns` for this register.
+        anti_patterns: The register's DO NOT constraints.
+
+    Returns:
+        A multi-paragraph instruction block an LLM can follow to write
+        in this register.
+    """
+    lines: list[str] = [_REGISTER_VOICE_DESCRIPTIONS[register], ""]
+    if patterns.metaphor_families:
+        domains = ", ".join(f.domain for f in patterns.metaphor_families)
+        lines.append(f"Metaphors surface from: {domains}.")
+    moves = patterns.rhetorical_moves
+    if moves.paradox_count > 0:
+        lines.append("Use paradox constructions to hold tension without resolving it.")
+    if moves.callback_count > 0:
+        lines.append("Call back to earlier points to build narrative continuity.")
+    if moves.self_deprecation_count > 0:
+        lines.append(
+            "Allow brief self-deprecation before arriving at an insight.",
+        )
+    if patterns.vocabulary.recurring_phrases:
+        phrases = ", ".join(patterns.vocabulary.recurring_phrases[:3])
+        lines.append(f"Lean on recurring phrases such as: {phrases}.")
+    lines.extend(("", f"NEVER: {' '.join(anti_patterns)}"))
+    return "\n".join(lines)
+
+
+class VoiceProfileGenerator:
+    """Compose per-register voice profiles from exemplars and patterns.
+
+    The generator realises Section 11.2 of the Creek Ontology: for each
+    voice register, produce a profile note combining 5-10 exemplar
+    passages, the extracted :class:`VoicePatterns`, a reusable LLM voice
+    prompt, and register-specific anti-patterns.
+
+    Attributes:
+        max_exemplars: Upper bound on exemplars retained per profile.
+        min_exemplars: Threshold below which a warning is logged.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_exemplars: int = _DEFAULT_MAX_EXEMPLARS_PER_PROFILE,
+        min_exemplars: int = _DEFAULT_MIN_EXEMPLARS_PER_PROFILE,
+        collector: VoiceExemplarCollector | None = None,
+        extractor: VoicePatternExtractor | None = None,
+    ) -> None:
+        """Initialise the generator.
+
+        Args:
+            max_exemplars: Upper bound on exemplars per profile. Must be
+                at least 1.
+            min_exemplars: Lower bound below which a warning is logged.
+                Must be at least 1 and no greater than ``max_exemplars``.
+            collector: Optional :class:`VoiceExemplarCollector` used by
+                :meth:`generate_all_profiles`. Defaults to a collector
+                configured with the same exemplar bounds.
+            extractor: Optional :class:`VoicePatternExtractor` used by
+                :meth:`generate_all_profiles`. Defaults to a plain
+                extractor.
+
+        Raises:
+            ValueError: If either bound is less than 1, or if
+                ``min_exemplars`` exceeds ``max_exemplars``.
+        """
+        if max_exemplars < 1:
+            msg = f"max_exemplars must be >= 1, got {max_exemplars}"
+            raise ValueError(msg)
+        if min_exemplars < 1:
+            msg = f"min_exemplars must be >= 1, got {min_exemplars}"
+            raise ValueError(msg)
+        if min_exemplars > max_exemplars:
+            msg = f"min_exemplars ({min_exemplars}) > max_exemplars ({max_exemplars})"
+            raise ValueError(msg)
+        self.max_exemplars = max_exemplars
+        self.min_exemplars = min_exemplars
+        self._collector = collector or VoiceExemplarCollector(
+            max_per_register=max_exemplars,
+            min_per_register=min_exemplars,
+        )
+        self._extractor = extractor or VoicePatternExtractor()
+
+    def generate_profile(
+        self,
+        register: str,
+        exemplars: Sequence[Exemplar],
+        patterns: VoicePatterns,
+    ) -> VoiceProfile:
+        """Compose a :class:`VoiceProfile` from exemplars and patterns.
+
+        Passages are taken from the first :attr:`max_exemplars` entries
+        of *exemplars* so callers can pre-rank before invoking. The
+        generated voice prompt is register-specific and incorporates
+        detected metaphor families and rhetorical moves. Registers with
+        fewer than :attr:`min_exemplars` samples log a warning but still
+        produce a profile.
+
+        Args:
+            register: One of the seven canonical voice registers.
+            exemplars: Ordered sequence of exemplars; the top
+                :attr:`max_exemplars` are retained.
+            patterns: :class:`VoicePatterns` extracted from the
+                exemplars' bodies.
+
+        Returns:
+            A fully populated :class:`VoiceProfile`.
+
+        Raises:
+            ValueError: If *register* is not one of the seven canonical
+                voice registers, or if *exemplars* is empty.
+        """
+        if register not in VOICE_REGISTERS:
+            msg = f"Unknown voice register: {register!r}"
+            raise ValueError(msg)
+        if not exemplars:
+            msg = f"Cannot generate profile for {register!r}: exemplars is empty"
+            raise ValueError(msg)
+        selected = list(exemplars)[: self.max_exemplars]
+        if len(selected) < self.min_exemplars:
+            logger.warning(
+                "Voice register %r has only %d exemplar(s) for profile (minimum %d).",
+                register,
+                len(selected),
+                self.min_exemplars,
+            )
+        anti_patterns = _REGISTER_ANTI_PATTERNS[register]
+        voice_prompt = _build_voice_prompt(register, patterns, anti_patterns)
+        return VoiceProfile(
+            register=register,
+            exemplars=tuple(e.body for e in selected),
+            patterns=patterns,
+            voice_prompt=voice_prompt,
+            anti_patterns=anti_patterns,
+            generated_at=datetime.now(tz=UTC),
+        )
+
+    def write_profile(
+        self,
+        profile: VoiceProfile,
+        vault_path: Path,
+    ) -> Path:
+        """Persist *profile* to ``07-Voice/<register>-profile.md``.
+
+        The output follows the Section 11.2 template with the required
+        markdown headings and a YAML frontmatter block capturing the
+        profile metadata.
+
+        Args:
+            profile: The profile to write.
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            Absolute path of the written markdown file.
+
+        Raises:
+            ValueError: If ``profile.register`` is not one of the seven
+                canonical voice registers. :class:`VoiceProfile` is a
+                public dataclass, so this guard prevents path traversal
+                when a caller constructs a profile directly.
+        """
+        if profile.register not in VOICE_REGISTERS:
+            msg = f"Unknown voice register on profile: {profile.register!r}"
+            raise ValueError(msg)
+        profile_dir = vault_path / _PROFILE_SUBDIR
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        target = profile_dir / f"{profile.register}{_PROFILE_FILENAME_SUFFIX}"
+        body = self._render_profile_body(profile)
+        post = frontmatter.Post(
+            content=body,
+            type="voice_profile",
+            register=profile.register,
+            exemplar_count=profile.exemplar_count,
+            generated_date=profile.generated_at.isoformat(),
+            tags=["voice", "voice-profile", profile.register],
+        )
+        target.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return target
+
+    def generate_all_profiles(self, vault_path: Path) -> list[Path]:
+        """Generate profile notes for every register with exemplars.
+
+        Scans ``01-Fragments/`` for qualifying exemplars, groups them by
+        register, extracts patterns from each register's bodies, and
+        writes a profile per non-empty register.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            List of paths written, one per register with exemplars.
+        """
+        grouped = self._collect_exemplars_with_bodies(vault_path)
+        written: list[Path] = []
+        for register in VOICE_REGISTERS:
+            register_exemplars = grouped.get(register, [])
+            if not register_exemplars:
+                continue
+            ranked = self._rank_exemplars(register_exemplars)
+            bodies = [e.body for e in ranked]
+            patterns = self._extractor.extract_patterns(bodies)
+            profile = self.generate_profile(register, ranked, patterns)
+            written.append(self.write_profile(profile, vault_path))
+        return written
+
+    # ---- Private helpers ----
+
+    def _collect_exemplars_with_bodies(
+        self,
+        vault_path: Path,
+    ) -> dict[str, list[Exemplar]]:
+        """Scan ``01-Fragments/`` for qualifying exemplars with body text."""
+        buckets: dict[str, list[Exemplar]] = {
+            register: [] for register in VOICE_REGISTERS
+        }
+        fragments_dir = vault_path / _FRAGMENTS_SUBDIR
+        if not fragments_dir.is_dir():
+            return buckets
+        for md_file in sorted(fragments_dir.rglob("*.md")):
+            loaded = _load_fragment_with_body(md_file)
+            if loaded is None:
+                continue
+            fragment, body = loaded
+            register = _eligible_register(
+                fragment,
+                allow_intimate=self._collector.allow_intimate,
+            )
+            if register is None:
+                continue
+            buckets[register].append(Exemplar(fragment=fragment, body=body))
+        return buckets
+
+    def _rank_exemplars(self, exemplars: list[Exemplar]) -> list[Exemplar]:
+        """Rank *exemplars* by the same quality heuristic as the collector.
+
+        Scoring mirrors :meth:`VoiceExemplarCollector.rank_exemplars` but
+        operates on :class:`Exemplar` values, avoiding coupling to the
+        collector's internal cache. Ties are broken by ascending
+        fragment id for deterministic ordering.
+
+        Returns:
+            Up to :attr:`max_exemplars` exemplars, sorted by descending
+            score.
+        """
+        scored = sorted(
+            exemplars,
+            key=lambda e: (-_exemplar_score(e), e.fragment.id),
+        )
+        return scored[: self.max_exemplars]
+
+    @staticmethod
+    def _render_profile_body(profile: VoiceProfile) -> str:
+        """Render the markdown body of a voice profile note."""
+        lines: list[str] = [
+            f"# Voice Proxy: {profile.register.title()}",
+            "",
+            "## Prompt for LLM",
+            "",
+            profile.voice_prompt,
+            "",
+            "### Structural Patterns",
+            "",
+            *_format_structural_patterns(profile.patterns),
+            "",
+            "### Metaphor Families",
+            "",
+            *_format_metaphor_families(profile.patterns),
+            "",
+            "### Rhetorical Moves",
+            "",
+            *_format_rhetorical_moves(profile.patterns),
+            "",
+            "### Sample Passages",
+            "",
+        ]
+        for index, passage in enumerate(profile.exemplars, start=1):
+            lines.extend((f"{index}. {passage}", ""))
+        lines.extend(("### Anti-Patterns (DO NOT)", ""))
+        lines.extend(f"- {pattern}" for pattern in profile.anti_patterns)
+        lines.append("")
+        return "\n".join(lines)
+
+
 __all__ = [
     "DEFAULT_MAX_PER_REGISTER",
     "DEFAULT_MIN_PER_REGISTER",
     "METAPHOR_DOMAINS",
     "VOICE_REGISTERS",
+    "Exemplar",
     "Lexicon",
     "MetaphorFamily",
     "ParagraphMetrics",
@@ -1104,4 +1616,6 @@ __all__ = [
     "VoiceExemplarCollector",
     "VoicePatternExtractor",
     "VoicePatterns",
+    "VoiceProfile",
+    "VoiceProfileGenerator",
 ]

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -216,6 +216,64 @@ def test_report_unnamed_command(tmp_path: Path) -> None:
     assert (vault / "10-Liminal" / "Unnamed" / "Digests").is_dir()
 
 
+def test_report_voice_command(tmp_path: Path) -> None:
+    """Test that report --type voice generates register profiles."""
+    from datetime import UTC, datetime
+
+    import frontmatter
+
+    from creek.models import (
+        Confidence,
+        Fragment,
+        FragmentSource,
+        Frequency,
+        FrequencyClassification,
+        Mode,
+        Phase,
+        PrivacyTier,
+        SourcePlatform,
+        VoiceClassification,
+        VoiceRegister,
+        WavelengthClassification,
+    )
+
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments" / "Journal").mkdir(parents=True, exist_ok=True)
+    (vault / "07-Voice").mkdir(parents=True, exist_ok=True)
+
+    for i in range(5):
+        fragment = Fragment(
+            id=f"frag-{i}",
+            title=f"Fragment {i}",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+            created=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
+            ingested=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
+            frequency=FrequencyClassification(primary=Frequency.F5),
+            wavelength=WavelengthClassification(
+                phase=Phase.RISING,
+                mode=Mode.EXPRESS,
+            ),
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.CONFESSIONAL,
+                confidence=Confidence.CONVICTION,
+            ),
+            privacy_tier=PrivacyTier.PERSONAL,
+        )
+        body = "The creek of thought flows gently downstream. " * 20
+        data = fragment.model_dump(mode="json")
+        post = frontmatter.Post(content=body, **data)
+        target = vault / "01-Fragments" / "Journal" / f"{fragment.id}.md"
+        target.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["report", "--type", "voice", "--vault", str(vault)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Voice profile" in result.output or "voice profile" in result.output
+    assert (vault / "07-Voice" / "confessional-profile.md").is_file()
+
+
 def test_report_command() -> None:
     """Test that report command runs with required args."""
     result = runner.invoke(

--- a/creek-tools/tests/test_voice_profiles.py
+++ b/creek-tools/tests/test_voice_profiles.py
@@ -1,0 +1,851 @@
+"""Tests for creek.generate.voice — voice register profile generation.
+
+Covers :class:`VoiceProfileGenerator` implementing Section 11.2 of the
+Creek Ontology: per-register profile notes combining top exemplar
+passages, extracted patterns, a reusable LLM voice prompt, and
+register-specific anti-patterns.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.generate.voice import (
+    VOICE_REGISTERS,
+    Exemplar,
+    Lexicon,
+    MetaphorFamily,
+    ParagraphMetrics,
+    PunctuationHabits,
+    RhetoricalMoves,
+    SentenceMetrics,
+    VoicePatterns,
+    VoiceProfile,
+    VoiceProfileGenerator,
+)
+from creek.models import (
+    Confidence,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Mode,
+    Phase,
+    PrivacyTier,
+    SourcePlatform,
+    VoiceClassification,
+    VoiceRegister,
+    WavelengthClassification,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---- Helpers ----
+
+
+def _make_fragment(
+    frag_id: str,
+    title: str,
+    register: VoiceRegister = VoiceRegister.CONFESSIONAL,
+    confidence: Confidence = Confidence.CONVICTION,
+) -> Fragment:
+    """Build a fully classified fragment for exemplar use."""
+    return Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        created=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
+        ingested=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
+        frequency=FrequencyClassification(primary=Frequency.F5),
+        wavelength=WavelengthClassification(
+            phase=Phase.RISING,
+            mode=Mode.EXPRESS,
+        ),
+        voice=VoiceClassification(
+            voice_register=register,
+            confidence=confidence,
+        ),
+        privacy_tier=PrivacyTier.PERSONAL,
+    )
+
+
+def _exemplar(frag_id: str, body: str) -> Exemplar:
+    """Build an Exemplar with a default fragment and the given body."""
+    return Exemplar(
+        fragment=_make_fragment(frag_id, f"Title {frag_id}"),
+        body=body,
+    )
+
+
+def _flat_patterns() -> VoicePatterns:
+    """Build a VoicePatterns with all-zero structural metrics."""
+    return VoicePatterns(
+        sentence_metrics=SentenceMetrics(
+            average_length=0.0,
+            short_count=0,
+            medium_count=0,
+            long_count=0,
+            fragment_count=0,
+            question_frequency=0.0,
+            total_sentences=0,
+        ),
+        paragraph_metrics=ParagraphMetrics(
+            average_sentences_per_paragraph=0.0,
+        ),
+        transitions=(),
+        metaphor_families=(),
+        rhetorical_moves=RhetoricalMoves(
+            self_deprecation_count=0,
+            paradox_count=0,
+            callback_count=0,
+        ),
+        vocabulary=Lexicon(
+            distinctive_words=(),
+            coined_terms=(),
+            recurring_phrases=(),
+        ),
+        punctuation=PunctuationHabits(
+            em_dash_frequency=0.0,
+            ellipsis_frequency=0.0,
+            parenthetical_frequency=0.0,
+            exclamation_frequency=0.0,
+        ),
+    )
+
+
+def _rich_patterns() -> VoicePatterns:
+    """Build a VoicePatterns with enough content to exercise prompt rendering."""
+    return VoicePatterns(
+        sentence_metrics=SentenceMetrics(
+            average_length=14.2,
+            short_count=5,
+            medium_count=12,
+            long_count=3,
+            fragment_count=2,
+            question_frequency=0.15,
+            total_sentences=20,
+        ),
+        paragraph_metrics=ParagraphMetrics(
+            average_sentences_per_paragraph=3.4,
+        ),
+        transitions=(("however", 4), ("therefore", 2)),
+        metaphor_families=(
+            MetaphorFamily(
+                domain="water",
+                matches=("creek", "flow", "eddy"),
+                example_sentences=("The creek of thought flows into a deep eddy.",),
+            ),
+            MetaphorFamily(
+                domain="body",
+                matches=("heart", "breath"),
+                example_sentences=("I felt it in my bones.",),
+            ),
+        ),
+        rhetorical_moves=RhetoricalMoves(
+            self_deprecation_count=3,
+            paradox_count=2,
+            callback_count=1,
+        ),
+        vocabulary=Lexicon(
+            distinctive_words=("creek", "eddy", "fragment"),
+            coined_terms=("polygnosticism",),
+            recurring_phrases=("creek of thought",),
+        ),
+        punctuation=PunctuationHabits(
+            em_dash_frequency=5.0,
+            ellipsis_frequency=1.5,
+            parenthetical_frequency=2.0,
+            exclamation_frequency=0.5,
+        ),
+    )
+
+
+def _write_fragment_file(
+    vault_path: Path,
+    fragment: Fragment,
+    body: str,
+    *,
+    subfolder: str = "Journal",
+) -> Path:
+    """Persist *fragment* with *body* under ``01-Fragments/{subfolder}/``."""
+    fragments_dir = vault_path / "01-Fragments" / subfolder
+    fragments_dir.mkdir(parents=True, exist_ok=True)
+    data = fragment.model_dump(mode="json")
+    post = frontmatter.Post(content=body, **data)
+    target = fragments_dir / f"{fragment.id}.md"
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture()
+def generator() -> VoiceProfileGenerator:
+    """Create a default VoiceProfileGenerator."""
+    return VoiceProfileGenerator()
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    """Create a minimal vault tree with folders the generator uses."""
+    for folder in ("01-Fragments/Journal", "07-Voice"):
+        (tmp_path / folder).mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+# ---- Module surface ----
+
+
+class TestModuleSurface:
+    """Exported names for the voice profile feature."""
+
+    def test_voice_profile_generator_exported(self) -> None:
+        """VoiceProfileGenerator is exported from the module."""
+        from creek.generate import voice
+
+        assert hasattr(voice, "VoiceProfileGenerator")
+        assert "VoiceProfileGenerator" in voice.__all__
+
+    def test_voice_profile_exported(self) -> None:
+        """VoiceProfile is exported from the module."""
+        from creek.generate import voice
+
+        assert hasattr(voice, "VoiceProfile")
+        assert "VoiceProfile" in voice.__all__
+
+    def test_exemplar_exported(self) -> None:
+        """Exemplar is exported from the module."""
+        from creek.generate import voice
+
+        assert hasattr(voice, "Exemplar")
+        assert "Exemplar" in voice.__all__
+
+
+# ---- VoiceProfileGenerator __init__ ----
+
+
+class TestVoiceProfileGeneratorInit:
+    """Constructor validation."""
+
+    def test_default_max_exemplars_is_ten(self) -> None:
+        """Default upper bound is 10 exemplars per profile (ontology spec)."""
+        assert VoiceProfileGenerator().max_exemplars == 10
+
+    def test_default_min_exemplars_is_five(self) -> None:
+        """Default lower bound is 5 exemplars per profile (ontology spec)."""
+        assert VoiceProfileGenerator().min_exemplars == 5
+
+    def test_max_exemplars_below_one_rejected(self) -> None:
+        """max_exemplars < 1 is invalid."""
+        with pytest.raises(ValueError, match="max_exemplars"):
+            VoiceProfileGenerator(max_exemplars=0)
+
+    def test_min_exemplars_below_one_rejected(self) -> None:
+        """min_exemplars < 1 is invalid."""
+        with pytest.raises(ValueError, match="min_exemplars"):
+            VoiceProfileGenerator(min_exemplars=0)
+
+    def test_min_exceeding_max_rejected(self) -> None:
+        """min_exemplars must not exceed max_exemplars."""
+        with pytest.raises(ValueError, match="min_exemplars"):
+            VoiceProfileGenerator(min_exemplars=8, max_exemplars=6)
+
+
+# ---- generate_profile ----
+
+
+class TestGenerateProfile:
+    """VoiceProfileGenerator.generate_profile behaviour."""
+
+    def test_returns_voice_profile(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """generate_profile returns a VoiceProfile instance."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        assert isinstance(profile, VoiceProfile)
+
+    def test_register_is_stored(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """The profile records the target register."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "analytical",
+            exemplars,
+            _flat_patterns(),
+        )
+        assert profile.register == "analytical"
+
+    def test_exemplar_count_respects_max(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """At most max_exemplars passages are retained per profile."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(25)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        assert profile.exemplar_count == generator.max_exemplars
+        assert len(profile.exemplars) == generator.max_exemplars
+
+    def test_preserves_passages(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """Passages are the exemplar body texts, in order."""
+        exemplars = [
+            _exemplar("f1", "First body."),
+            _exemplar("f2", "Second body."),
+        ]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        assert profile.exemplars == ("First body.", "Second body.")
+
+    def test_unknown_register_rejected(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """A register outside the canonical seven is rejected."""
+        with pytest.raises(ValueError, match="register"):
+            generator.generate_profile(
+                "mystic",
+                [_exemplar("f1", "Body.")],
+                _flat_patterns(),
+            )
+
+    def test_voice_prompt_mentions_register(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """The voice prompt names the register so the LLM knows its tone."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        assert "confessional" in profile.voice_prompt.lower()
+
+    def test_voice_prompt_has_never_clause(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """The voice prompt contains an explicit NEVER section."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        assert "NEVER" in profile.voice_prompt
+
+    def test_voice_prompt_reflects_metaphor_families(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """Detected metaphor domains are surfaced in the voice prompt."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _rich_patterns(),
+        )
+        assert "water" in profile.voice_prompt
+
+    def test_anti_patterns_register_specific(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """Each register has its own tuple of anti-patterns."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        confessional = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        analytical = generator.generate_profile(
+            "analytical",
+            exemplars,
+            _flat_patterns(),
+        )
+        assert confessional.anti_patterns != analytical.anti_patterns
+        assert confessional.anti_patterns
+        assert analytical.anti_patterns
+
+    def test_confessional_anti_patterns_match_ontology_example(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """Confessional anti-patterns follow the issue's worked example."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        joined = " ".join(profile.anti_patterns).lower()
+        assert "corporate" in joined
+        assert "bullet" in joined
+
+    def test_generated_at_populated(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """generated_at is timezone-aware and close to now."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        assert profile.generated_at.tzinfo is not None
+
+    def test_below_minimum_logs_warning(
+        self,
+        generator: VoiceProfileGenerator,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Registers with fewer than ``min_exemplars`` samples warn."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(2)]
+        with caplog.at_level("WARNING", logger="creek.generate.voice"):
+            generator.generate_profile(
+                "confessional",
+                exemplars,
+                _flat_patterns(),
+            )
+        assert any("confessional" in rec.message for rec in caplog.records)
+
+    def test_empty_exemplars_rejected(
+        self,
+        generator: VoiceProfileGenerator,
+    ) -> None:
+        """A register with no exemplars cannot produce a profile."""
+        with pytest.raises(ValueError, match="exemplars"):
+            generator.generate_profile(
+                "confessional",
+                [],
+                _flat_patterns(),
+            )
+
+
+# ---- Ranking heuristics via generate_all_profiles ----
+
+
+class TestRankingHeuristics:
+    """Exercise the scoring branches of ``_exemplar_score``."""
+
+    def test_short_body_does_not_earn_length_bonus(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Bodies outside 200-800 words skip the length bonus."""
+        short = _make_fragment(
+            "short-1",
+            "Short body",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.CONVICTION,
+        )
+        _write_fragment_file(vault, short, "Just a few words.")
+        for i in range(4):
+            fragment = _make_fragment(
+                f"medium-{i}",
+                f"Medium {i}",
+                register=VoiceRegister.CONFESSIONAL,
+                confidence=Confidence.CONVICTION,
+            )
+            _write_fragment_file(vault, fragment, "word " * 400)
+        paths = generator.generate_all_profiles(vault)
+        assert len(paths) == 1
+
+    def test_unclassified_fragment_does_not_earn_classification_bonus(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Fragments with missing classification axes skip the bonus."""
+        unclassified = Fragment(
+            id="unclassified-1",
+            title="Unclassified",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+            created=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
+            ingested=datetime(2026, 1, 15, 12, 0, 0, tzinfo=UTC),
+            # Defaults leave frequency/phase unclassified.
+            frequency=FrequencyClassification(),
+            wavelength=WavelengthClassification(),
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.CONFESSIONAL,
+                confidence=Confidence.CONVICTION,
+            ),
+            privacy_tier=PrivacyTier.PERSONAL,
+        )
+        _write_fragment_file(vault, unclassified, "word " * 400)
+        for i in range(4):
+            fragment = _make_fragment(
+                f"classified-{i}",
+                f"Classified {i}",
+                register=VoiceRegister.CONFESSIONAL,
+                confidence=Confidence.CONVICTION,
+            )
+            _write_fragment_file(vault, fragment, "word " * 400)
+        paths = generator.generate_all_profiles(vault)
+        assert len(paths) == 1
+        # Fully classified fragments should rank above the unclassified one.
+        post = frontmatter.load(str(paths[0]))
+        assert post.get("exemplar_count") == 5
+
+
+# ---- write_profile ----
+
+
+class TestWriteProfile:
+    """VoiceProfileGenerator.write_profile produces a correct markdown note."""
+
+    def test_writes_to_voice_folder(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """The profile lives at ``07-Voice/<register>-profile.md``."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        path = generator.write_profile(profile, vault)
+        assert path == vault / "07-Voice" / "confessional-profile.md"
+        assert path.is_file()
+
+    def test_creates_voice_directory_if_missing(
+        self,
+        generator: VoiceProfileGenerator,
+        tmp_path: Path,
+    ) -> None:
+        """The 07-Voice directory is created if it does not yet exist."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        path = generator.write_profile(profile, tmp_path)
+        assert path.parent == tmp_path / "07-Voice"
+
+    def test_frontmatter_type_is_voice_profile(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Frontmatter ``type`` is ``voice_profile``."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        path = generator.write_profile(profile, vault)
+        post = frontmatter.load(str(path))
+        assert post.get("type") == "voice_profile"
+
+    def test_frontmatter_has_register(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Frontmatter includes the register name."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "analytical",
+            exemplars,
+            _flat_patterns(),
+        )
+        path = generator.write_profile(profile, vault)
+        post = frontmatter.load(str(path))
+        assert post.get("register") == "analytical"
+
+    def test_frontmatter_has_exemplar_count(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Frontmatter records how many exemplar passages are present."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        path = generator.write_profile(profile, vault)
+        post = frontmatter.load(str(path))
+        assert post.get("exemplar_count") == 5
+
+    def test_frontmatter_has_generated_date(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Frontmatter records the generation date as ISO 8601 string."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        generated = frontmatter.load(
+            str(generator.write_profile(profile, vault)),
+        ).get("generated_date")
+        assert isinstance(generated, str)
+        # Must be parseable ISO 8601
+        datetime.fromisoformat(generated)
+
+    @pytest.mark.parametrize(
+        "heading",
+        [
+            "## Prompt for LLM",
+            "### Structural Patterns",
+            "### Metaphor Families",
+            "### Rhetorical Moves",
+            "### Sample Passages",
+            "### Anti-Patterns (DO NOT)",
+        ],
+    )
+    def test_body_contains_required_headings(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+        heading: str,
+    ) -> None:
+        """The profile body follows the Section 11.2 template headings."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _rich_patterns(),
+        )
+        content = generator.write_profile(profile, vault).read_text(encoding="utf-8")
+        assert heading in content
+
+    def test_body_includes_sample_passages(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Each exemplar body appears in the Sample Passages section."""
+        exemplars = [
+            _exemplar("f1", "First unique marker one."),
+            _exemplar("f2", "Second unique marker two."),
+            _exemplar("f3", "Third unique marker three."),
+            _exemplar("f4", "Fourth unique marker four."),
+            _exemplar("f5", "Fifth unique marker five."),
+        ]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        content = generator.write_profile(profile, vault).read_text(encoding="utf-8")
+        for body in (
+            "First unique marker one.",
+            "Fifth unique marker five.",
+        ):
+            assert body in content
+
+    def test_body_includes_anti_patterns(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Anti-patterns appear in the DO NOT section."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        profile = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        content = generator.write_profile(profile, vault).read_text(encoding="utf-8")
+        for pattern in profile.anti_patterns:
+            assert pattern in content
+
+    def test_rejects_profile_with_non_canonical_register(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """A profile whose register is not canonical is refused (path safety)."""
+        legitimate = generator.generate_profile(
+            "confessional",
+            [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)],
+            _flat_patterns(),
+        )
+        # Construct a malicious profile with a traversal-style register.
+        tampered = VoiceProfile(
+            register="../etc/passwd",
+            exemplars=legitimate.exemplars,
+            patterns=legitimate.patterns,
+            voice_prompt=legitimate.voice_prompt,
+            anti_patterns=legitimate.anti_patterns,
+            generated_at=legitimate.generated_at,
+        )
+        with pytest.raises(ValueError, match="register"):
+            generator.write_profile(tampered, vault)
+
+    def test_overwrites_existing_profile(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Calling write_profile twice overwrites the previous file."""
+        exemplars = [_exemplar(f"f{i}", f"Body {i}.") for i in range(5)]
+        first = generator.generate_profile(
+            "confessional",
+            exemplars,
+            _flat_patterns(),
+        )
+        path = generator.write_profile(first, vault)
+        second = generator.generate_profile(
+            "confessional",
+            [_exemplar(f"g{i}", f"Updated body {i}.") for i in range(5)],
+            _flat_patterns(),
+        )
+        path2 = generator.write_profile(second, vault)
+        assert path == path2
+        content = path2.read_text(encoding="utf-8")
+        assert "Updated body 0." in content
+
+
+# ---- generate_all_profiles ----
+
+
+class TestGenerateAllProfiles:
+    """End-to-end: scan vault, generate a profile for every non-empty register."""
+
+    def _seed_register(
+        self,
+        vault_path: Path,
+        register: VoiceRegister,
+        count: int,
+    ) -> None:
+        """Seed *count* fragments of *register* with distinctive bodies."""
+        for i in range(count):
+            fragment = _make_fragment(
+                f"{register.value}-{i}",
+                f"{register.value} fragment {i}",
+                register=register,
+            )
+            body = (
+                f"Paragraph about the {register.value} register: "
+                "the creek of thought flows here. " * 30
+            )
+            _write_fragment_file(vault_path, fragment, body)
+
+    def test_returns_list_of_paths(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """generate_all_profiles returns the list of paths it wrote."""
+        self._seed_register(vault, VoiceRegister.CONFESSIONAL, count=5)
+        paths = generator.generate_all_profiles(vault)
+        assert isinstance(paths, list)
+        assert len(paths) == 1
+        assert paths[0].is_file()
+
+    def test_creates_profile_per_populated_register(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Every register with exemplars gets a profile."""
+        self._seed_register(vault, VoiceRegister.CONFESSIONAL, count=5)
+        self._seed_register(vault, VoiceRegister.ANALYTICAL, count=5)
+        paths = generator.generate_all_profiles(vault)
+        registers = {p.stem.replace("-profile", "") for p in paths}
+        assert registers == {"confessional", "analytical"}
+
+    def test_skips_registers_without_exemplars(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Registers without any fragments are not written."""
+        self._seed_register(vault, VoiceRegister.CONFESSIONAL, count=5)
+        paths = generator.generate_all_profiles(vault)
+        names = {p.name for p in paths}
+        assert "confessional-profile.md" in names
+        assert "prophetic-profile.md" not in names
+
+    def test_all_seven_registers_when_seeded(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Seeding every register produces seven profile files."""
+        for register in VoiceRegister:
+            self._seed_register(vault, register, count=5)
+        paths = generator.generate_all_profiles(vault)
+        assert len(paths) == len(VOICE_REGISTERS)
+
+    def test_profiles_have_valid_frontmatter(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Generated files have valid YAML frontmatter with required keys."""
+        self._seed_register(vault, VoiceRegister.CONFESSIONAL, count=5)
+        paths = generator.generate_all_profiles(vault)
+        post = frontmatter.load(str(paths[0]))
+        assert post.get("type") == "voice_profile"
+        assert post.get("register") == "confessional"
+        assert post.get("exemplar_count") == 5
+
+    def test_missing_vault_returns_empty_list(
+        self,
+        generator: VoiceProfileGenerator,
+        tmp_path: Path,
+    ) -> None:
+        """A vault without a 01-Fragments dir yields no profiles."""
+        paths = generator.generate_all_profiles(tmp_path)
+        assert not paths
+
+    def test_skips_unreadable_and_ineligible_files(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Non-fragment, invalid, and ineligible markdown files are skipped."""
+        self._seed_register(vault, VoiceRegister.CONFESSIONAL, count=5)
+        # A file that is not a fragment (missing ``type: fragment``).
+        stray = vault / "01-Fragments" / "Journal" / "stray.md"
+        stray.write_text("---\ntype: note\n---\njust prose", encoding="utf-8")
+        # An ineligible fragment (musing confidence — too early to qualify).
+        musing = _make_fragment(
+            "musing-1",
+            "Too early",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.MUSING,
+        )
+        _write_fragment_file(vault, musing, "Body text here.")
+        paths = generator.generate_all_profiles(vault)
+        assert len(paths) == 1
+        post = frontmatter.load(str(paths[0]))
+        assert post.get("exemplar_count") == 5


### PR DESCRIPTION
Implement Section 11.2 of the Creek Ontology: for each of the seven
voice registers, generate a profile note with 5-10 exemplar passages,
extracted patterns, a reusable LLM voice prompt, and register-specific
anti-patterns. The profiles let a downstream model approximate each
register when asked to write in the user's voice.

Adds to creek/generate/voice.py:

- ``Exemplar`` — pairs a Fragment's metadata with its body text.
- ``VoiceProfile`` — dataclass holding the full profile payload.
- ``VoiceProfileGenerator`` — orchestrates generation:
  - ``generate_profile(register, exemplars, patterns)`` composes a
    profile, validating the register and warning when fewer than five
    exemplars are available.
  - ``write_profile(profile, vault_path)`` persists the profile to
    ``07-Voice/<register>-profile.md`` with the required Section 11.2
    template (## Prompt for LLM, ### Structural Patterns, ### Metaphor
    Families, ### Rhetorical Moves, ### Sample Passages, ### Anti-
    Patterns (DO NOT)). Validates ``profile.register`` against the
    canonical set to prevent path traversal from directly constructed
    profiles.
  - ``generate_all_profiles(vault_path)`` scans ``01-Fragments/``,
    groups qualifying exemplars by register, extracts patterns, and
    writes a profile per populated register.

Refactors ``_eligible_register`` into a module-level helper shared by
the collector and the profile generator's own vault scan. Adds
``_exemplar_score`` as a pure ranking function operating on
``Exemplar`` values so the generator does not depend on the
collector's internal cache.

CLI: ``creek report --type voice`` runs ``generate_all_profiles`` and
reports the generated profile names.

Testing: 46 new tests in ``tests/test_voice_profiles.py`` cover
constructor validation, per-register profile composition, LLM prompt
shape, anti-pattern content, write-profile frontmatter and template,
path-traversal rejection, ranking edge cases, and end-to-end vault
scans. Adds a CLI test for ``report --type voice``. Voice module
coverage: 98.71%; project total: 94.90%.