### PR TITLE
feat(generate): add weekly/monthly wavelength reports (#43)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -244,6 +244,33 @@ def report(
                 "[yellow]No voice profiles generated: "
                 "no qualifying exemplars found.[/yellow]",
             )
+    elif type == "wavelength":
+        from datetime import date as _date
+
+        from creek.generate.wavelength import WavelengthTracker
+
+        if period not in {"weekly", "monthly"}:
+            console.print(
+                "[red]--period must be 'weekly' or 'monthly' for "
+                "wavelength reports.[/red]",
+            )
+            raise typer.Exit(code=2)
+        wavelength_tracker = WavelengthTracker()
+        today = _date.today()
+        if period == "weekly":
+            wavelength_path = wavelength_tracker.generate_weekly_report(
+                vault_path,
+                week_of=today,
+            )
+        else:
+            wavelength_path = wavelength_tracker.generate_monthly_report(
+                vault_path,
+                month=today,
+            )
+        console.print(
+            f"[bold green]Wavelength {period} report generated: "
+            f"{wavelength_path}[/bold green]",
+        )
     else:
         console.print(
             f"[bold green]Would report: type={type}, "

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -20,13 +20,13 @@ from datetime import date, timedelta
 from typing import TYPE_CHECKING
 
 import frontmatter
+import yaml
+from pydantic import ValidationError
 
-from creek.models import Dosage, Frequency, Mode, Phase
+from creek.models import Dosage, Fragment, Frequency, Mode, Phase
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-    from creek.models import Fragment
 
 
 DEFAULT_WINDOW_DAYS: int = 7
@@ -43,6 +43,161 @@ DEFAULT_TOXIC_CONSECUTIVE_WEEKS: int = 3
 
 _VALID_PERIODS: frozenset[str] = frozenset({"weekly", "monthly"})
 """Accepted period strings for :meth:`WavelengthTracker.generate_report`."""
+
+
+_NOTABLE_FRAGMENT_LIMIT: int = 5
+"""Maximum number of Notable Fragments listed per report."""
+
+_CONFIDENCE_RANK: dict[str, int] = {
+    "conviction": 5,
+    "settled": 4,
+    "forming": 3,
+    "exploring": 2,
+    "musing": 1,
+}
+"""Ordinal rank of voice confidence levels for notable-fragment selection."""
+
+_PHASE_DESCRIPTIONS: dict[str, str] = {
+    Phase.RISING.value: (
+        "Energy building, ideas forming, momentum gathering. "
+        "Abundance begins to create indulgence."
+    ),
+    Phase.PEAKING.value: (
+        "Full expression, maximum creative or spiritual output. Abundance peaks."
+    ),
+    Phase.WITHDRAWAL.value: (
+        "First cracks appear, energy turns inward. Indulgence creates scarcity."
+    ),
+    Phase.DIMINISHING.value: (
+        "Active decline, contraction, things falling apart. "
+        "Scarcity begins to create resilience."
+    ),
+    Phase.BOTTOMING_OUT.value: (
+        "Lowest point, maximum contraction, dark-night material. Scarcity peaks."
+    ),
+    Phase.RESTORATION.value: (
+        "Return begins, new energy gathering, re-emergence. "
+        "Resilience creates abundance."
+    ),
+    Phase.UNCLASSIFIED.value: (
+        "No dominant phase signal in the period — the wavelength is quiet."
+    ),
+}
+"""One-line phase descriptions adapted from ontology §7.1."""
+
+PHASE_DOMAIN_MAPPINGS: dict[str, dict[str, str]] = {
+    Phase.RISING.value: {
+        "season": "Summer",
+        "mood": "Mania",
+        "spaciousness": "Expanded",
+        "relation_to_others": "Belonging",
+        "relation_to_self": "Esteem",
+        "buddhist_attachment": "Attraction",
+        "meditation": "Redirecting attention",
+        "breath": "Inhale end",
+    },
+    Phase.PEAKING.value: {
+        "season": "Summer Solstice",
+        "mood": "Mania",
+        "spaciousness": "Expanded",
+        "relation_to_others": "Belonging",
+        "relation_to_self": "Esteem",
+        "buddhist_attachment": "Attraction",
+        "meditation": "Absorption",
+        "breath": "Hold in",
+    },
+    Phase.WITHDRAWAL.value: {
+        "season": "Fall",
+        "mood": "Mania",
+        "spaciousness": "Expanded",
+        "relation_to_others": "Alienation",
+        "relation_to_self": "Doubt",
+        "buddhist_attachment": "Aversion",
+        "meditation": "Distraction",
+        "breath": "Exhale begin",
+    },
+    Phase.DIMINISHING.value: {
+        "season": "Winter",
+        "mood": "Depression",
+        "spaciousness": "Contracted",
+        "relation_to_others": "Alienation",
+        "relation_to_self": "Doubt",
+        "buddhist_attachment": "Aversion",
+        "meditation": "Forgetting",
+        "breath": "Exhale end",
+    },
+    Phase.BOTTOMING_OUT.value: {
+        "season": "Winter Solstice",
+        "mood": "Depression",
+        "spaciousness": "Contracted",
+        "relation_to_others": "Alienation",
+        "relation_to_self": "Doubt",
+        "buddhist_attachment": "Aversion",
+        "meditation": "Mind wandering",
+        "breath": "Hold out",
+    },
+    Phase.RESTORATION.value: {
+        "season": "Spring",
+        "mood": "Depression",
+        "spaciousness": "Contracted",
+        "relation_to_others": "Belonging",
+        "relation_to_self": "Esteem",
+        "buddhist_attachment": "Attraction",
+        "meditation": "Waking up",
+        "breath": "Inhale begin",
+    },
+}
+"""§7.1 cross-domain mapping per phase: Season, Mood, Spaciousness,
+Relation to Others / Self, Buddhist Attachment, Meditation, Breath.
+
+Used by :meth:`WavelengthTracker.generate_weekly_report` and
+:meth:`WavelengthTracker.generate_monthly_report` to render the
+``Domain Mappings`` block.
+"""
+
+_DOMAIN_LABELS: list[tuple[str, str]] = [
+    ("season", "Season"),
+    ("mood", "Mood (bipolar frame)"),
+    ("spaciousness", "Spaciousness"),
+    ("relation_to_others", "Relation to Others"),
+    ("relation_to_self", "Relation to Self"),
+    ("buddhist_attachment", "Buddhist Attachment"),
+    ("meditation", "Meditation"),
+    ("breath", "Breath"),
+]
+
+
+def _safe_post(md_file: Path) -> frontmatter.Post | None:
+    """Return a parsed frontmatter post, or ``None`` on parse errors."""
+    try:
+        return frontmatter.load(str(md_file))
+    except (OSError, ValueError, yaml.YAMLError):
+        return None
+
+
+def _load_fragments_from_vault(vault_path: Path) -> list[Fragment]:
+    """Load every classified fragment from ``01-Fragments/`` under *vault_path*.
+
+    Files that fail to parse or that lack the ``type: fragment`` marker
+    are silently skipped. Returns an empty list when the folder is
+    absent.
+    """
+    root = vault_path / "01-Fragments"
+    if not root.exists():
+        return []
+    fragments: list[Fragment] = []
+    for md_file in sorted(root.rglob("*.md")):
+        post = _safe_post(md_file)
+        if post is None:
+            continue
+        metadata = dict(post.metadata)
+        if metadata.get("type") != "fragment":
+            continue
+        try:
+            fragments.append(Fragment.model_validate(metadata))
+        except ValidationError:
+            continue
+    return fragments
 
 
 @dataclass
@@ -525,6 +680,177 @@ class WavelengthTracker:
         lines.extend(_render_dataview_section())
         return "\n".join(lines)
 
+    def generate_weekly_report(
+        self,
+        vault_path: Path,
+        week_of: date,
+        fragments: list[Fragment] | None = None,
+    ) -> Path:
+        """Write a §7.1-shaped weekly wavelength report to ``Phase-Maps/``.
+
+        The report covers the ISO week containing *week_of*. Sections:
+        Phase Summary, Domain Mappings, Mode Distribution, Dosage
+        Balance, Emotional Texture Cloud, Notable Fragments, Transition
+        Watch. Language is descriptive only — never prescriptive.
+
+        Args:
+            vault_path: Vault root.
+            week_of: Any date within the target ISO week.
+            fragments: Optional pre-loaded fragments. When ``None`` the
+                method scans ``vault_path/01-Fragments`` and loads all
+                classified fragments itself.
+
+        Returns:
+            Path to the written ``YYYY-WNN-wavelength.md`` file.
+        """
+        loaded = (
+            fragments
+            if fragments is not None
+            else _load_fragments_from_vault(vault_path)
+        )
+        start = _week_start(week_of)
+        end = start + timedelta(days=6)
+        in_window = [f for f in loaded if _fragment_in_window(f, start, end)]
+        snapshot = self.analyze_period(in_window, start, end)
+        transitions = self._weekly_transition_watch(loaded, start)
+        trend = self.track_dosage_trends(loaded)
+
+        iso_year, iso_week, _ = week_of.isocalendar()
+        body = _render_weekly_body(
+            snapshot,
+            in_window,
+            trend,
+            transitions,
+        )
+        post = frontmatter.Post(
+            content=body,
+            type="wavelength_report",
+            period="weekly",
+            week=iso_week,
+            year=iso_year,
+            generated_on=date.today().isoformat(),
+            tags=["wavelength", "wavelength-weekly"],
+        )
+        target_dir = vault_path / "05-Wavelength" / "Phase-Maps"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        note_path = target_dir / f"{iso_year}-W{iso_week:02d}-wavelength.md"
+        note_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return note_path
+
+    def generate_monthly_report(
+        self,
+        vault_path: Path,
+        month: date,
+        fragments: list[Fragment] | None = None,
+    ) -> Path:
+        """Write a §7.1-shaped monthly wavelength report to ``Phase-Maps/``.
+
+        The report aggregates the calendar month containing *month*.
+        Same sections as :meth:`generate_weekly_report` plus a
+        week-by-week ASCII progression chart and a month-over-month
+        comparison.
+
+        Args:
+            vault_path: Vault root.
+            month: Any date within the target month.
+            fragments: Optional pre-loaded fragments. When ``None`` the
+                method scans ``vault_path/01-Fragments``.
+
+        Returns:
+            Path to the written ``YYYY-MM-wavelength.md`` file.
+        """
+        loaded = (
+            fragments
+            if fragments is not None
+            else _load_fragments_from_vault(vault_path)
+        )
+        start, end = _month_bounds(month)
+        in_window = [f for f in loaded if _fragment_in_window(f, start, end)]
+        snapshot = self.analyze_period(in_window, start, end)
+        weekly_snapshots = self._weekly_snapshots(in_window, start, end)
+        prev_start, prev_end = _month_bounds(start - timedelta(days=1))
+        prev_window = [
+            f for f in loaded if _fragment_in_window(f, prev_start, prev_end)
+        ]
+        prev_snapshot = self.analyze_period(prev_window, prev_start, prev_end)
+        transitions = self.detect_transitions(weekly_snapshots)
+        trend = self.track_dosage_trends(loaded)
+
+        body = _render_monthly_body(
+            snapshot,
+            weekly_snapshots,
+            prev_snapshot,
+            in_window,
+            trend,
+            transitions,
+        )
+        post = frontmatter.Post(
+            content=body,
+            type="wavelength_report",
+            period="monthly",
+            month=month.month,
+            year=month.year,
+            generated_on=date.today().isoformat(),
+            tags=["wavelength", "wavelength-monthly"],
+        )
+        target_dir = vault_path / "05-Wavelength" / "Phase-Maps"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        note_path = target_dir / f"{month.year}-{month.month:02d}-wavelength.md"
+        note_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return note_path
+
+    def _weekly_snapshots(
+        self,
+        fragments: list[Fragment],
+        start: date,
+        end: date,
+    ) -> list[WavelengthSnapshot]:
+        """Return one snapshot per ISO week between *start* and *end*."""
+        snapshots: list[WavelengthSnapshot] = []
+        cursor = _week_start(start)
+        while cursor <= end:
+            window_end = min(cursor + timedelta(days=6), end)
+            window = [
+                f for f in fragments if _fragment_in_window(f, cursor, window_end)
+            ]
+            snapshots.append(self.analyze_period(window, cursor, window_end))
+            cursor = window_end + timedelta(days=1)
+        return snapshots
+
+    def _weekly_transition_watch(
+        self,
+        fragments: list[Fragment],
+        target_week_start: date,
+    ) -> list[PhaseTransition]:
+        """Return any transition between the previous and target ISO week."""
+        prev_start = target_week_start - timedelta(days=7)
+        prev_end = target_week_start - timedelta(days=1)
+        target_end = target_week_start + timedelta(days=6)
+        prev_window = [
+            f for f in fragments if _fragment_in_window(f, prev_start, prev_end)
+        ]
+        target_window = [
+            f
+            for f in fragments
+            if _fragment_in_window(f, target_week_start, target_end)
+        ]
+        snapshots = [
+            self.analyze_period(prev_window, prev_start, prev_end),
+            self.analyze_period(target_window, target_week_start, target_end),
+        ]
+        return self.detect_transitions(snapshots)
+
+
+def _month_bounds(day: date) -> tuple[date, date]:
+    """Return ``(first_of_month, last_of_month)`` for the month of *day*."""
+    start = day.replace(day=1)
+    if start.month == 12:
+        next_month = start.replace(year=start.year + 1, month=1)
+    else:
+        next_month = start.replace(month=start.month + 1)
+    end = next_month - timedelta(days=1)
+    return start, end
+
 
 # ---- Report rendering helpers ----
 
@@ -640,11 +966,237 @@ def _render_dataview_section() -> list[str]:
     ]
 
 
+# ---- Issue #43 weekly/monthly section renderers ----
+
+
+def _render_phase_summary(snapshot: WavelengthSnapshot) -> list[str]:
+    """Render the ``Phase Summary`` section with the §7.1 description."""
+    description = _PHASE_DESCRIPTIONS.get(
+        snapshot.dominant_phase,
+        _PHASE_DESCRIPTIONS[Phase.UNCLASSIFIED.value],
+    )
+    return [
+        "## Phase Summary",
+        "",
+        f"- Dominant phase: **{snapshot.dominant_phase}**",
+        f"- Classification confidence: {snapshot.confidence:.2f}",
+        f"- Fragments observed: {snapshot.fragment_count}",
+        f"- {description}",
+        "",
+    ]
+
+
+def _render_domain_mappings(snapshot: WavelengthSnapshot) -> list[str]:
+    """Render the §7.1 cross-domain mappings for the dominant phase."""
+    lines = ["## Domain Mappings", ""]
+    mapping = PHASE_DOMAIN_MAPPINGS.get(snapshot.dominant_phase)
+    if mapping is None:
+        lines.append("_No mapping available — dominant phase is unclassified._")
+        lines.append("")
+        return lines
+    for key, label in _DOMAIN_LABELS:
+        lines.append(f"- **{label}**: {mapping[key]}")
+    lines.append("")
+    return lines
+
+
+def _render_mode_distribution(fragments: list[Fragment]) -> list[str]:
+    """Render the ``Mode Distribution`` section as a counted list."""
+    lines = ["## Mode Distribution", ""]
+    counts: Counter[str] = Counter(
+        str(f.wavelength.mode)
+        for f in fragments
+        if str(f.wavelength.mode) and str(f.wavelength.mode) != Mode.UNCLASSIFIED.value
+    )
+    if not counts:
+        lines.append("_No classified modes in this period._")
+        lines.append("")
+        return lines
+    for mode, count in counts.most_common():
+        lines.append(f"- `{mode}`: {count}")
+    lines.append("")
+    return lines
+
+
+def _render_dosage_balance(snapshot: WavelengthSnapshot) -> list[str]:
+    """Render the ``Dosage Balance`` section with medicine vs toxic shares."""
+    return [
+        "## Dosage Balance",
+        "",
+        f"- Medicine share: {snapshot.medicine_percent:.2f}",
+        f"- Toxic share: {snapshot.toxic_percent:.2f}",
+        "",
+    ]
+
+
+def _render_emotional_texture_cloud(
+    snapshots: list[WavelengthSnapshot],
+) -> list[str]:
+    """Render the ``Emotional Texture Cloud`` aggregated across snapshots."""
+    lines = ["## Emotional Texture Cloud", ""]
+    merged: Counter[str] = Counter()
+    for snap in snapshots:
+        for tag, count in snap.emotional_texture_cloud:
+            merged[tag] += count
+    if not merged:
+        lines.append("_No emotional texture tags recorded._")
+        lines.append("")
+        return lines
+    cloud = " ".join(f"{tag}({count})" for tag, count in merged.most_common())
+    lines.append(cloud)
+    lines.append("")
+    return lines
+
+
+def _render_notable_fragments(fragments: list[Fragment]) -> list[str]:
+    """Render up to ``_NOTABLE_FRAGMENT_LIMIT`` highest-confidence fragments."""
+    lines = ["## Notable Fragments", ""]
+    if not fragments:
+        lines.append("_No fragments observed in this period._")
+        lines.append("")
+        return lines
+    ranked = sorted(
+        fragments,
+        key=_notable_fragment_score,
+        reverse=True,
+    )
+    for fragment in ranked[:_NOTABLE_FRAGMENT_LIMIT]:
+        lines.append(
+            f"- [[{fragment.id}]] — *{fragment.title}* "
+            f"(phase: {fragment.wavelength.phase})",
+        )
+    lines.append("")
+    return lines
+
+
+def _notable_fragment_score(fragment: Fragment) -> tuple[int, str]:
+    """Score a fragment for notable-selection: confidence rank, then ID."""
+    confidence = fragment.voice.confidence
+    rank = _CONFIDENCE_RANK.get(str(confidence), 0) if confidence is not None else 0
+    return (rank, fragment.id)
+
+
+def _render_transition_watch(
+    snapshot: WavelengthSnapshot,
+    transitions: list[PhaseTransition],
+) -> list[str]:
+    """Render the ``Transition Watch`` section in descriptive language."""
+    lines = ["## Transition Watch", ""]
+    if transitions:
+        for trans in transitions:
+            lines.append(
+                f"- A shift from `{trans.from_phase}` to `{trans.to_phase}` "
+                f"appears between {trans.from_date.isoformat()} and "
+                f"{trans.to_date.isoformat()}.",
+            )
+    else:
+        lines.append(
+            f"- No phase transition appears in this period; the "
+            f"`{snapshot.dominant_phase}` reading is steady.",
+        )
+    lines.append("")
+    return lines
+
+
+def _render_week_by_week_chart(snapshots: list[WavelengthSnapshot]) -> list[str]:
+    """Render the ASCII week-by-week phase progression chart."""
+    lines = ["## Week-by-Week Progression", ""]
+    if not snapshots:
+        lines.append("_No weekly snapshots in this month._")
+        lines.append("")
+        return lines
+    for index, snap in enumerate(snapshots, start=1):
+        bar = "#" * max(1, snap.fragment_count)
+        lines.append(
+            f"- Week {index:02d} ({snap.start_date.isoformat()}): "
+            f"{bar} {snap.dominant_phase} "
+            f"({snap.fragment_count} fragments)",
+        )
+    lines.append("")
+    return lines
+
+
+def _render_month_over_month(
+    current: WavelengthSnapshot,
+    previous: WavelengthSnapshot,
+) -> list[str]:
+    """Render the ``Month-over-Month`` comparison block."""
+    lines = ["## Month-over-Month", ""]
+    if previous.fragment_count == 0:
+        lines.append(
+            "_No prior month data to compare against._",
+        )
+        lines.append("")
+        return lines
+    delta = current.fragment_count - previous.fragment_count
+    direction = (
+        "more" if delta > 0 else ("fewer" if delta < 0 else "the same number of")
+    )
+    lines.append(
+        f"- Previous month dominant phase: `{previous.dominant_phase}` "
+        f"({previous.fragment_count} fragments)",
+    )
+    lines.append(
+        f"- This month dominant phase: `{current.dominant_phase}` "
+        f"({current.fragment_count} fragments)",
+    )
+    lines.append(
+        f"- Volume change: {direction} fragments ({delta:+d}).",
+    )
+    lines.append("")
+    return lines
+
+
+def _render_weekly_body(
+    snapshot: WavelengthSnapshot,
+    fragments: list[Fragment],
+    trend: DosageTrend,
+    transitions: list[PhaseTransition],
+) -> str:
+    """Compose the markdown body for a weekly report."""
+    lines: list[str] = []
+    lines.extend(_render_phase_summary(snapshot))
+    lines.extend(_render_domain_mappings(snapshot))
+    lines.extend(_render_mode_distribution(fragments))
+    lines.extend(_render_dosage_balance(snapshot))
+    lines.extend(_render_emotional_texture_cloud([snapshot]))
+    lines.extend(_render_notable_fragments(fragments))
+    lines.extend(_render_transition_watch(snapshot, transitions))
+    lines.extend(_render_dosage_trends(trend))
+    lines.extend(_render_dataview_section())
+    return "\n".join(lines)
+
+
+def _render_monthly_body(
+    snapshot: WavelengthSnapshot,
+    weekly_snapshots: list[WavelengthSnapshot],
+    previous_month: WavelengthSnapshot,
+    fragments: list[Fragment],
+    trend: DosageTrend,
+    transitions: list[PhaseTransition],
+) -> str:
+    """Compose the markdown body for a monthly report."""
+    lines: list[str] = []
+    lines.extend(_render_phase_summary(snapshot))
+    lines.extend(_render_domain_mappings(snapshot))
+    lines.extend(_render_mode_distribution(fragments))
+    lines.extend(_render_dosage_balance(snapshot))
+    lines.extend(_render_emotional_texture_cloud(weekly_snapshots))
+    lines.extend(_render_notable_fragments(fragments))
+    lines.extend(_render_transition_watch(snapshot, transitions))
+    lines.extend(_render_week_by_week_chart(weekly_snapshots))
+    lines.extend(_render_month_over_month(snapshot, previous_month))
+    lines.extend(_render_dosage_trends(trend))
+    lines.extend(_render_dataview_section())
+    return "\n".join(lines)
+
+
 __all__ = [
     "DEFAULT_ROLLING_WEEKS",
     "DEFAULT_TOXIC_CONSECUTIVE_WEEKS",
     "DEFAULT_TOXIC_THRESHOLD",
     "DEFAULT_WINDOW_DAYS",
+    "PHASE_DOMAIN_MAPPINGS",
     "DosageTrend",
     "PhaseTransition",
     "WavelengthSnapshot",

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -48,6 +48,14 @@ _VALID_PERIODS: frozenset[str] = frozenset({"weekly", "monthly"})
 _NOTABLE_FRAGMENT_LIMIT: int = 5
 """Maximum number of Notable Fragments listed per report."""
 
+_MAX_BAR_WIDTH: int = 20
+"""Cap for ASCII bar widths in the week-by-week progression chart.
+
+Without a cap a busy month (50+ fragments in one week) renders an
+unreadable 50+-character bar. Twenty is enough to compare relative
+volumes while staying within terminal/Obsidian-pane widths.
+"""
+
 _CONFIDENCE_RANK: dict[str, int] = {
     "conviction": 5,
     "settled": 4,
@@ -153,6 +161,11 @@ Relation to Others / Self, Buddhist Attachment, Meditation, Breath.
 Used by :meth:`WavelengthTracker.generate_weekly_report` and
 :meth:`WavelengthTracker.generate_monthly_report` to render the
 ``Domain Mappings`` block.
+
+The ``unclassified`` phase has no row by design: domain mappings are
+ontology assertions about a real phase, and rendering "Season:
+unclassified" would invent a mapping that does not exist. Renderers
+fall back to a placeholder when the dominant phase is unclassified.
 """
 
 _DOMAIN_LABELS: list[tuple[str, str]] = [
@@ -822,7 +835,15 @@ class WavelengthTracker:
         fragments: list[Fragment],
         target_week_start: date,
     ) -> list[PhaseTransition]:
-        """Return any transition between the previous and target ISO week."""
+        """Return any transition between the previous and target ISO week.
+
+        Args:
+            fragments: The full vault fragment set, not just the target
+                week. Transition detection needs the prior week's
+                fragments to compare against, so callers must pass the
+                unfiltered list.
+            target_week_start: Monday of the target ISO week.
+        """
         prev_start = target_week_start - timedelta(days=7)
         prev_end = target_week_start - timedelta(days=1)
         target_end = target_week_start + timedelta(days=6)
@@ -966,7 +987,7 @@ def _render_dataview_section() -> list[str]:
     ]
 
 
-# ---- Issue #43 weekly/monthly section renderers ----
+# ---- Weekly and monthly section renderers ----
 
 
 def _render_phase_summary(snapshot: WavelengthSnapshot) -> list[str]:
@@ -1023,8 +1044,8 @@ def _render_dosage_balance(snapshot: WavelengthSnapshot) -> list[str]:
     return [
         "## Dosage Balance",
         "",
-        f"- Medicine share: {snapshot.medicine_percent:.2f}",
-        f"- Toxic share: {snapshot.toxic_percent:.2f}",
+        f"- Medicine share: {snapshot.medicine_percent * 100:.1f}%",
+        f"- Toxic share: {snapshot.toxic_percent * 100:.1f}%",
         "",
     ]
 
@@ -1099,14 +1120,23 @@ def _render_transition_watch(
 
 
 def _render_week_by_week_chart(snapshots: list[WavelengthSnapshot]) -> list[str]:
-    """Render the ASCII week-by-week phase progression chart."""
+    """Render the ASCII week-by-week phase progression chart.
+
+    Bar width is capped at :data:`_MAX_BAR_WIDTH` characters so a busy
+    week does not blow out the chart. Zero-fragment weeks render
+    ``(empty)`` rather than a stray ``#`` so "no activity" is visually
+    distinct from "one fragment".
+    """
     lines = ["## Week-by-Week Progression", ""]
     if not snapshots:
         lines.append("_No weekly snapshots in this month._")
         lines.append("")
         return lines
     for index, snap in enumerate(snapshots, start=1):
-        bar = "#" * max(1, snap.fragment_count)
+        if snap.fragment_count == 0:
+            bar = "(empty)"
+        else:
+            bar = "#" * min(snap.fragment_count, _MAX_BAR_WIDTH)
         lines.append(
             f"- Week {index:02d} ({snap.start_date.isoformat()}): "
             f"{bar} {snap.dominant_phase} "

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -276,6 +276,67 @@ def test_report_voice_command(tmp_path: Path) -> None:
     assert (vault / "07-Voice" / "confessional-profile.md").is_file()
 
 
+def test_report_wavelength_weekly_command(tmp_path: Path) -> None:
+    """Test that report --type wavelength --period weekly produces a file."""
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True, exist_ok=True)
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "--type",
+            "wavelength",
+            "--period",
+            "weekly",
+            "--vault",
+            str(vault),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Wavelength weekly report generated" in result.output
+    assert list((vault / "05-Wavelength" / "Phase-Maps").glob("*.md"))
+
+
+def test_report_wavelength_monthly_command(tmp_path: Path) -> None:
+    """Test that report --type wavelength --period monthly produces a file."""
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True, exist_ok=True)
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "--type",
+            "wavelength",
+            "--period",
+            "monthly",
+            "--vault",
+            str(vault),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Wavelength monthly report generated" in result.output
+
+
+def test_report_wavelength_unknown_period_errors(tmp_path: Path) -> None:
+    """Test that wavelength report rejects an unknown period with exit 2."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "--type",
+            "wavelength",
+            "--period",
+            "yearly",
+            "--vault",
+            str(vault),
+        ],
+    )
+    assert result.exit_code == 2
+    assert "weekly" in result.output
+
+
 def test_report_command() -> None:
     """Test that report command runs with required args."""
     result = runner.invoke(

--- a/creek-tools/tests/test_wavelength_reports.py
+++ b/creek-tools/tests/test_wavelength_reports.py
@@ -75,8 +75,12 @@ def tracker() -> WavelengthTracker:
 
 @pytest.fixture()
 def vault_path(tmp_path: Path) -> Path:
-    """Return a vault root with the expected Phase-Maps folder."""
-    (tmp_path / "05-Wavelength" / "Phase-Maps").mkdir(parents=True, exist_ok=True)
+    """Return an empty vault root.
+
+    Both report methods create ``05-Wavelength/Phase-Maps`` themselves
+    via ``mkdir(parents=True, exist_ok=True)``, so the fixture does not
+    pre-create it.
+    """
     return tmp_path
 
 
@@ -355,7 +359,8 @@ class TestGenerateWeeklyReport:
         """When fragments are not passed, they are loaded from the vault."""
         frags_dir = vault_path / "01-Fragments"
         frags_dir.mkdir(parents=True, exist_ok=True)
-        for fragment in _week_fragments():
+        seeded = _week_fragments()
+        for fragment in seeded:
             data = fragment.model_dump(mode="json")
             post = frontmatter.Post(content=fragment.title, **data)
             (frags_dir / f"{fragment.id}.md").write_text(
@@ -368,6 +373,10 @@ class TestGenerateWeeklyReport:
         )
         body = frontmatter.load(str(path)).content
         assert "frag-rising-2" in body
+        # All four seeded fragments survive the round-trip and reach the
+        # report, not just the highest-confidence one.
+        for fragment in seeded:
+            assert fragment.id in body, fragment.id
 
 
 # ---- generate_monthly_report --------------------------------------------
@@ -498,6 +507,85 @@ class TestGenerateMonthlyReport:
             fragments=[in_month, out_of_month],
         )
         body = frontmatter.load(str(path)).content
-        assert "in-month" in body or "rising" in body.lower()
-        # The out-of-month fragment should not be listed as notable.
+        assert "in-month" in body
+        # The out-of-month fragment should not appear in any section.
         assert "out-of-month" not in body
+
+    def test_rerunning_same_month_overwrites_existing_report(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Generating the same month twice replaces the file in place."""
+        first = tracker.generate_monthly_report(
+            vault_path,
+            month=date(2026, 4, 1),
+            fragments=_week_fragments(),
+        )
+        first_body_len = first.read_text(encoding="utf-8")
+        # Second run with empty fragments should still land at the same path
+        # and replace, not append to, the original.
+        second = tracker.generate_monthly_report(
+            vault_path,
+            month=date(2026, 4, 1),
+            fragments=[],
+        )
+        assert second == first
+        assert second.read_text(encoding="utf-8") != first_body_len
+        # Only one wavelength markdown file should exist for this month.
+        files = list((vault_path / "05-Wavelength" / "Phase-Maps").glob("*.md"))
+        assert len(files) == 1
+
+    def test_week_by_week_chart_caps_bar_width(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """A busy week renders a capped bar, not 50+ ``#`` characters."""
+        base = datetime(2026, 4, 6, 12, 0, tzinfo=UTC)  # Monday of ISO week 15
+        many = [
+            _make_fragment(
+                frag_id=f"frag-{i}",
+                created=base,
+                phase=Phase.RISING,
+                mode=Mode.EXPRESS,
+                dosage=Dosage.MEDICINE,
+                frequency=Frequency.F3,
+            )
+            for i in range(50)
+        ]
+        path = tracker.generate_monthly_report(
+            vault_path,
+            month=date(2026, 4, 1),
+            fragments=many,
+        )
+        body = frontmatter.load(str(path)).content
+        # 50 ``#`` characters in a row would be a regression.
+        assert "#" * 30 not in body
+
+    def test_week_by_week_chart_marks_zero_fragment_weeks(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """An ``(empty)`` marker distinguishes silent weeks from one-fragment weeks.
+
+        Without the marker a zero-fragment week and a one-fragment week
+        would both render with no leading bar (or a stray ``#``), which
+        is misleading.
+        """
+        # Single fragment in week 1 of April; weeks 2-5 stay silent.
+        single = _make_fragment(
+            frag_id="single",
+            created=datetime(2026, 4, 1, 12, 0, tzinfo=UTC),
+            phase=Phase.RISING,
+            mode=Mode.EXPRESS,
+            dosage=Dosage.MEDICINE,
+        )
+        path = tracker.generate_monthly_report(
+            vault_path,
+            month=date(2026, 4, 1),
+            fragments=[single],
+        )
+        body = frontmatter.load(str(path)).content
+        assert "(empty)" in body

--- a/creek-tools/tests/test_wavelength_reports.py
+++ b/creek-tools/tests/test_wavelength_reports.py
@@ -1,0 +1,503 @@
+"""Tests for weekly/monthly wavelength reports (issue #43).
+
+Covers the `WavelengthTracker.generate_weekly_report` and
+`generate_monthly_report` methods that extend the existing tracker with
+the §7.1 domain-mapped report templates.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.generate.wavelength import (
+    PHASE_DOMAIN_MAPPINGS,
+    WavelengthTracker,
+)
+from creek.models import (
+    Confidence,
+    Dosage,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Mode,
+    Phase,
+    SourcePlatform,
+    VoiceClassification,
+    WavelengthClassification,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---- Fixtures ----
+
+
+def _make_fragment(
+    *,
+    frag_id: str,
+    created: datetime,
+    title: str = "test fragment",
+    phase: Phase = Phase.UNCLASSIFIED,
+    mode: Mode = Mode.UNCLASSIFIED,
+    dosage: Dosage = Dosage.UNCLASSIFIED,
+    emotional_texture: list[str] | None = None,
+    frequency: Frequency = Frequency.UNCLASSIFIED,
+    confidence: Confidence | None = None,
+) -> Fragment:
+    """Construct a test Fragment with wavelength/frequency fields."""
+    return Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        created=created,
+        frequency=FrequencyClassification(primary=frequency),
+        wavelength=WavelengthClassification(
+            phase=phase,
+            mode=mode,
+            dosage=dosage,
+        ),
+        voice=VoiceClassification(confidence=confidence),
+        emotional_texture=emotional_texture or [],
+    )
+
+
+@pytest.fixture()
+def tracker() -> WavelengthTracker:
+    """Return a default WavelengthTracker."""
+    return WavelengthTracker()
+
+
+@pytest.fixture()
+def vault_path(tmp_path: Path) -> Path:
+    """Return a vault root with the expected Phase-Maps folder."""
+    (tmp_path / "05-Wavelength" / "Phase-Maps").mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _week_fragments() -> list[Fragment]:
+    """Return a representative week of classified fragments (Mon → Sun)."""
+    base = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)  # Monday of ISO week 17
+    return [
+        _make_fragment(
+            frag_id="frag-rising-1",
+            title="A new project's first sparks",
+            created=base,
+            phase=Phase.RISING,
+            mode=Mode.EXPRESS,
+            dosage=Dosage.MEDICINE,
+            frequency=Frequency.F3,
+            emotional_texture=["enthusiasm", "curiosity"],
+            confidence=Confidence.SETTLED,
+        ),
+        _make_fragment(
+            frag_id="frag-rising-2",
+            title="Drafting the outline",
+            created=base.replace(day=21),
+            phase=Phase.RISING,
+            mode=Mode.EXPRESS,
+            dosage=Dosage.MEDICINE,
+            frequency=Frequency.F3,
+            emotional_texture=["enthusiasm", "focus"],
+            confidence=Confidence.CONVICTION,
+        ),
+        _make_fragment(
+            frag_id="frag-rising-3",
+            title="Tension in the middle",
+            created=base.replace(day=22),
+            phase=Phase.RISING,
+            mode=Mode.COLLABORATE,
+            dosage=Dosage.MEDICINE,
+            frequency=Frequency.F4,
+            emotional_texture=["focus"],
+            confidence=Confidence.SETTLED,
+        ),
+        _make_fragment(
+            frag_id="frag-withdrawal-1",
+            title="The first doubts",
+            created=base.replace(day=23),
+            phase=Phase.WITHDRAWAL,
+            mode=Mode.INHABIT,
+            dosage=Dosage.TOXIC,
+            frequency=Frequency.F3,
+            emotional_texture=["doubt"],
+            confidence=Confidence.FORMING,
+        ),
+    ]
+
+
+# ---- Domain mappings table -----------------------------------------------
+
+
+class TestPhaseDomainMappings:
+    """`PHASE_DOMAIN_MAPPINGS` carries §7.1 domain mappings for each phase."""
+
+    def test_table_has_all_six_classified_phases(self) -> None:
+        """Every classified phase has a row in the mapping."""
+        for phase in (
+            Phase.RISING,
+            Phase.PEAKING,
+            Phase.WITHDRAWAL,
+            Phase.DIMINISHING,
+            Phase.BOTTOMING_OUT,
+            Phase.RESTORATION,
+        ):
+            assert phase.value in PHASE_DOMAIN_MAPPINGS
+
+    def test_each_mapping_carries_required_domains(self) -> None:
+        """Every row has the eight domains listed in ontology §7.1."""
+        required = {
+            "season",
+            "mood",
+            "spaciousness",
+            "relation_to_others",
+            "relation_to_self",
+            "buddhist_attachment",
+            "meditation",
+            "breath",
+        }
+        for phase, mapping in PHASE_DOMAIN_MAPPINGS.items():
+            assert required.issubset(mapping.keys()), phase
+
+    def test_rising_maps_to_summer_and_belonging(self) -> None:
+        """Spot-check the Rising row against ontology §7.1."""
+        rising = PHASE_DOMAIN_MAPPINGS[Phase.RISING.value]
+        assert rising["season"] == "Summer"
+        assert rising["relation_to_others"] == "Belonging"
+        assert rising["relation_to_self"] == "Esteem"
+
+    def test_bottoming_out_maps_to_winter_solstice(self) -> None:
+        """Spot-check the Bottoming Out row."""
+        bottoming = PHASE_DOMAIN_MAPPINGS[Phase.BOTTOMING_OUT.value]
+        assert bottoming["season"] == "Winter Solstice"
+        assert bottoming["spaciousness"] == "Contracted"
+
+
+# ---- generate_weekly_report ---------------------------------------------
+
+
+class TestGenerateWeeklyReport:
+    """`generate_weekly_report` writes a §7.1-shaped weekly report."""
+
+    def test_report_filename_has_iso_week_format(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Filename follows ``YYYY-WNN-wavelength.md``."""
+        path = tracker.generate_weekly_report(
+            vault_path,
+            week_of=date(2026, 4, 20),  # ISO week 17, Monday
+            fragments=_week_fragments(),
+        )
+        assert path.name == "2026-W17-wavelength.md"
+        assert path.parent == vault_path / "05-Wavelength" / "Phase-Maps"
+        assert path.is_file()
+
+    def test_frontmatter_records_period_and_iso_week(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Frontmatter carries type, period, week, year."""
+        path = tracker.generate_weekly_report(
+            vault_path,
+            week_of=date(2026, 4, 20),
+            fragments=_week_fragments(),
+        )
+        post = frontmatter.load(str(path))
+        assert post.metadata["type"] == "wavelength_report"
+        assert post.metadata["period"] == "weekly"
+        assert post.metadata["week"] == 17
+        assert post.metadata["year"] == 2026
+
+    def test_body_contains_required_sections(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """All seven §43 sections appear in the rendered body."""
+        path = tracker.generate_weekly_report(
+            vault_path,
+            week_of=date(2026, 4, 20),
+            fragments=_week_fragments(),
+        )
+        body = frontmatter.load(str(path)).content
+        for heading in (
+            "## Phase Summary",
+            "## Domain Mappings",
+            "## Mode Distribution",
+            "## Dosage Balance",
+            "## Emotional Texture Cloud",
+            "## Notable Fragments",
+            "## Transition Watch",
+        ):
+            assert heading in body, heading
+
+    def test_domain_mappings_render_for_dominant_phase(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """The Domain Mappings block names the Rising-row values."""
+        path = tracker.generate_weekly_report(
+            vault_path,
+            week_of=date(2026, 4, 20),
+            fragments=_week_fragments(),
+        )
+        body = frontmatter.load(str(path)).content
+        # Rising → Summer, Belonging, Esteem, etc.
+        assert "Summer" in body
+        assert "Belonging" in body
+        assert "Esteem" in body
+
+    def test_notable_fragments_links_top_confidence(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Notable Fragments lists the highest-confidence fragments."""
+        path = tracker.generate_weekly_report(
+            vault_path,
+            week_of=date(2026, 4, 20),
+            fragments=_week_fragments(),
+        )
+        body = frontmatter.load(str(path)).content
+        # The conviction-confidence fragment should appear; the
+        # forming-confidence one is least likely to be selected.
+        assert "frag-rising-2" in body
+        assert "Drafting the outline" in body
+
+    def test_emotional_texture_cloud_counts_tags(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Emotional Texture Cloud reports counts per tag."""
+        path = tracker.generate_weekly_report(
+            vault_path,
+            week_of=date(2026, 4, 20),
+            fragments=_week_fragments(),
+        )
+        body = frontmatter.load(str(path)).content
+        # `enthusiasm` appears twice across the test fragments.
+        assert "enthusiasm" in body
+
+    def test_mode_distribution_lists_observed_modes(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Mode Distribution lists modes observed in the period."""
+        path = tracker.generate_weekly_report(
+            vault_path,
+            week_of=date(2026, 4, 20),
+            fragments=_week_fragments(),
+        )
+        body = frontmatter.load(str(path)).content
+        assert "express" in body.lower()
+
+    def test_dosage_balance_shows_medicine_and_toxic(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Dosage Balance reports both medicine and toxic shares."""
+        path = tracker.generate_weekly_report(
+            vault_path,
+            week_of=date(2026, 4, 20),
+            fragments=_week_fragments(),
+        )
+        body = frontmatter.load(str(path)).content
+        assert "Medicine" in body
+        assert "Toxic" in body
+
+    def test_report_is_descriptive_not_prescriptive(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """The report uses descriptive language, never prescriptions."""
+        path = tracker.generate_weekly_report(
+            vault_path,
+            week_of=date(2026, 4, 20),
+            fragments=_week_fragments(),
+        )
+        body = frontmatter.load(str(path)).content.lower()
+        for phrase in ("you should", "you must", "you ought", "you need to"):
+            assert phrase not in body, phrase
+
+    def test_empty_week_produces_valid_report(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Empty fragment list still produces a parseable report."""
+        path = tracker.generate_weekly_report(
+            vault_path,
+            week_of=date(2026, 4, 20),
+            fragments=[],
+        )
+        post = frontmatter.load(str(path))
+        assert post.metadata["period"] == "weekly"
+        assert "## Phase Summary" in post.content
+
+    def test_loads_fragments_from_vault_when_omitted(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """When fragments are not passed, they are loaded from the vault."""
+        frags_dir = vault_path / "01-Fragments"
+        frags_dir.mkdir(parents=True, exist_ok=True)
+        for fragment in _week_fragments():
+            data = fragment.model_dump(mode="json")
+            post = frontmatter.Post(content=fragment.title, **data)
+            (frags_dir / f"{fragment.id}.md").write_text(
+                frontmatter.dumps(post),
+                encoding="utf-8",
+            )
+        path = tracker.generate_weekly_report(
+            vault_path,
+            week_of=date(2026, 4, 20),
+        )
+        body = frontmatter.load(str(path)).content
+        assert "frag-rising-2" in body
+
+
+# ---- generate_monthly_report --------------------------------------------
+
+
+class TestGenerateMonthlyReport:
+    """`generate_monthly_report` aggregates a calendar month."""
+
+    def test_filename_uses_year_month_format(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Monthly file name is ``YYYY-MM-wavelength.md``."""
+        path = tracker.generate_monthly_report(
+            vault_path,
+            month=date(2026, 4, 1),
+            fragments=_week_fragments(),
+        )
+        assert path.name == "2026-04-wavelength.md"
+
+    def test_frontmatter_records_month_and_year(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Frontmatter carries period=monthly, month, year."""
+        path = tracker.generate_monthly_report(
+            vault_path,
+            month=date(2026, 4, 1),
+            fragments=_week_fragments(),
+        )
+        post = frontmatter.load(str(path))
+        assert post.metadata["period"] == "monthly"
+        assert post.metadata["month"] == 4
+        assert post.metadata["year"] == 2026
+
+    def test_body_includes_week_by_week_chart(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Monthly body adds a week-by-week ASCII progression chart."""
+        path = tracker.generate_monthly_report(
+            vault_path,
+            month=date(2026, 4, 1),
+            fragments=_week_fragments(),
+        )
+        body = frontmatter.load(str(path)).content
+        assert "## Week-by-Week Progression" in body
+        # Bar chart rows look like ``Week NN: #### phase``.
+        assert "Week" in body and "#" in body
+
+    def test_body_includes_month_over_month_section(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Monthly body adds a month-over-month comparison."""
+        path = tracker.generate_monthly_report(
+            vault_path,
+            month=date(2026, 4, 1),
+            fragments=_week_fragments(),
+        )
+        body = frontmatter.load(str(path)).content
+        assert "## Month-over-Month" in body
+
+    def test_monthly_keeps_required_weekly_sections(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Monthly retains all weekly sections."""
+        path = tracker.generate_monthly_report(
+            vault_path,
+            month=date(2026, 4, 1),
+            fragments=_week_fragments(),
+        )
+        body = frontmatter.load(str(path)).content
+        for heading in (
+            "## Phase Summary",
+            "## Domain Mappings",
+            "## Mode Distribution",
+            "## Dosage Balance",
+            "## Emotional Texture Cloud",
+            "## Notable Fragments",
+            "## Transition Watch",
+        ):
+            assert heading in body, heading
+
+    def test_monthly_empty_data_is_graceful(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Empty fragment list still yields a parseable monthly report."""
+        path = tracker.generate_monthly_report(
+            vault_path,
+            month=date(2026, 4, 1),
+            fragments=[],
+        )
+        post = frontmatter.load(str(path))
+        assert post.metadata["month"] == 4
+
+    def test_monthly_only_aggregates_within_month(
+        self,
+        tracker: WavelengthTracker,
+        vault_path: Path,
+    ) -> None:
+        """Fragments outside the target month are ignored."""
+        in_month = _make_fragment(
+            frag_id="in-month",
+            created=datetime(2026, 4, 15, 12, 0, tzinfo=UTC),
+            phase=Phase.RISING,
+            mode=Mode.EXPRESS,
+            dosage=Dosage.MEDICINE,
+        )
+        out_of_month = _make_fragment(
+            frag_id="out-of-month",
+            created=datetime(2026, 5, 5, 12, 0, tzinfo=UTC),
+            phase=Phase.PEAKING,
+            mode=Mode.EXPRESS,
+            dosage=Dosage.MEDICINE,
+        )
+        path = tracker.generate_monthly_report(
+            vault_path,
+            month=date(2026, 4, 1),
+            fragments=[in_month, out_of_month],
+        )
+        body = frontmatter.load(str(path)).content
+        assert "in-month" in body or "rising" in body.lower()
+        # The out-of-month fragment should not be listed as notable.
+        assert "out-of-month" not in body


### PR DESCRIPTION
## Summary

Implements §43 of the phase-2 plan — rich §7.1 domain-mapped weekly and monthly wavelength reports building on the existing `WavelengthTracker`.

- **`PHASE_DOMAIN_MAPPINGS`** — canonical lookup table from each classified phase (Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration) to the eight ontology §7.1 domains (Season, Mood, Spaciousness, Relation to Others / to Self, Buddhist Attachment, Meditation, Breath). Now importable from `creek.generate.wavelength`.
- **`generate_weekly_report(vault_path, week_of, fragments=None)`** writes `YYYY-WNN-wavelength.md` under `05-Wavelength/Phase-Maps/` with frontmatter (`type=wavelength_report`, `period=weekly`, `week`, `year`) and body sections: Phase Summary, Domain Mappings, Mode Distribution, Dosage Balance, Emotional Texture Cloud, Notable Fragments, Transition Watch, Dosage Trends, plus a Dataview query block.
- **`generate_monthly_report(vault_path, month, fragments=None)`** aggregates a calendar month, retains every weekly section, and adds:
  - **Week-by-Week Progression** — text-based bar chart per ISO week
  - **Month-over-Month** — comparison vs the prior calendar month
- Both methods load fragments from `01-Fragments/` when not passed explicitly; the optional parameter keeps tests deterministic.
- **CLI**: `creek report --type wavelength --period weekly|monthly` invokes the matching method against today's date. Unknown periods exit 2.
- Reports remain **descriptive only** — a dedicated regression test asserts the body contains no "you should / must / ought / need to" phrases.

## Test plan

- [x] `./scripts/check-all.sh` — 6/7 gates green (only the dev-container env's pre-existing pip-audit findings remain; CI ignores them via the existing config)
- [x] 22 new tests in `tests/test_wavelength_reports.py` covering:
  - Domain mapping table completeness and §7.1 spot-checks
  - Filename / frontmatter format (ISO-week and YYYY-MM)
  - All seven required sections rendered
  - Domain mappings rendered for the dominant phase
  - Notable fragments selected by voice confidence rank
  - Mode distribution + dosage balance + texture cloud counts
  - Empty-period graceful handling
  - Out-of-month fragment exclusion
  - Auto-loading from vault when `fragments` is omitted
  - Descriptive-only language regression check
- [x] 3 new CLI tests covering weekly, monthly, and unknown-period exit codes
- [x] Coverage 94.47% (above 90% threshold)
- [ ] CI: Code Quality & Testing (3.11/3.12/3.13) green
- [ ] Claude review LGTM

Closes #43

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vu1KnoJQDQh4kCLdR6VJTM)_