### PR TITLE
feat(ingest): add Image/OCR ingestor with injectable backend (#54)

### DIFF
--- a/creek-tools/creek/ingest/__init__.py
+++ b/creek-tools/creek/ingest/__init__.py
@@ -17,6 +17,7 @@ Exports:
     DiscordIngestor: Concrete ingestor for Discord message exports.
     DocumentIngestor: Concrete ingestor for document files (DOCX, PDF, HTML, TXT).
     GenericIngestor: Fallback ingestor for unrecognized file formats.
+    ImageIngestor: Concrete ingestor for image files via OCR.
     MarkdownIngestor: Concrete ingestor for plain Markdown files.
 """
 
@@ -27,6 +28,7 @@ from creek.ingest.code import CodeIngestor
 from creek.ingest.discord import DiscordIngestor
 from creek.ingest.documents import DocumentIngestor
 from creek.ingest.generic import GenericIngestor
+from creek.ingest.images import ImageIngestor
 from creek.ingest.markdown import MarkdownIngestor
 
 # Registry mapping ingestor names to their concrete classes.
@@ -38,6 +40,7 @@ INGESTOR_REGISTRY: dict[str, type[Ingestor]] = {
     "discord": DiscordIngestor,
     "document": DocumentIngestor,
     "generic": GenericIngestor,
+    "image": ImageIngestor,
     "markdown": MarkdownIngestor,
 }
 
@@ -49,6 +52,7 @@ __all__ = [
     "DiscordIngestor",
     "DocumentIngestor",
     "GenericIngestor",
+    "ImageIngestor",
     "IngestResult",
     "Ingestor",
     "MarkdownIngestor",

--- a/creek-tools/creek/ingest/images.py
+++ b/creek-tools/creek/ingest/images.py
@@ -69,13 +69,16 @@ class OcrResult:
         confidence: OCR confidence in ``[0.0, 1.0]``.
         page: 1-based page index (PDFs); ``0`` for standalone images.
         image_type: One of ``screenshot``, ``photo_of_text``, ``diagram``,
-            ``scanned_pdf_page``, ``image``, ``other``.
+            ``scanned_pdf_page``, or ``other``. Defaults to ``"other"``
+            so a callers that build an ``OcrResult`` without classifying
+            the image still produces a value :func:`detect_image_type`
+            could return.
     """
 
     text: str
     confidence: float
     page: int = 0
-    image_type: str = "image"
+    image_type: str = "other"
 
 
 @runtime_checkable
@@ -224,14 +227,18 @@ def _average_confidence(conf_values: list[Any]) -> float:
     Tesseract reports confidences in ``0-100`` (or ``-1`` for missing).
     Empty or all-negative input returns ``0.0``.
     """
-    numeric = [float(v) for v in conf_values if _is_positive_number(v)]
+    numeric = [float(v) for v in conf_values if _is_non_negative_number(v)]
     if not numeric:
         return 0.0
     return sum(numeric) / len(numeric) / 100.0
 
 
-def _is_positive_number(value: Any) -> bool:
-    """Return ``True`` when *value* parses to a non-negative float."""
+def _is_non_negative_number(value: Any) -> bool:
+    """Return ``True`` when *value* parses to a non-negative float.
+
+    Used to filter tesseract's ``-1`` sentinel for "missing confidence"
+    while preserving the legitimate ``0`` value for "low confidence".
+    """
     try:
         return float(value) >= 0
     except (TypeError, ValueError):
@@ -288,13 +295,19 @@ class ImageIngestor(Ingestor):
         """Recursively find every supported image under *source_path*.
 
         Args:
-            source_path: Directory (or single file) to scan.
+            source_path: Directory (or single file) to scan. When given
+                a single file, only image extensions in
+                :data:`IMAGE_EXTENSIONS` are accepted; anything else
+                returns an empty list (the document ingestor pipeline
+                routes non-images elsewhere).
 
         Returns:
             A list of :class:`RawDocument` per discovered image.
         """
         if source_path.is_file():
-            paths = [source_path]
+            paths = (
+                [source_path] if source_path.suffix.lower() in IMAGE_EXTENSIONS else []
+            )
         else:
             paths = [
                 p
@@ -383,7 +396,7 @@ class ImageIngestor(Ingestor):
                     metadata={
                         "original_file": str(pdf_path),
                         "ocr_confidence": result.confidence,
-                        "image_type": result.image_type or "scanned_pdf_page",
+                        "image_type": result.image_type,
                         "language": self.language,
                         "page": result.page,
                     },

--- a/creek-tools/creek/ingest/images.py
+++ b/creek-tools/creek/ingest/images.py
@@ -1,0 +1,412 @@
+"""Image and OCR ingestor for the Creek ingest pipeline.
+
+Implements §54: ingest screenshots, photos of handwritten notes, and
+diagrams by running OCR. The ingestor is decoupled from the OCR backend
+through the :class:`OcrEngine` protocol so callers can plug in any OCR
+implementation; tests inject a deterministic stub. The default
+:class:`PytesseractOcrEngine` lazily imports ``pytesseract``,
+``Pillow``, and ``pdf2image`` so unit tests run cleanly even when those
+optional dependencies (and the ``tesseract``/``poppler`` system
+binaries) are not installed.
+
+The ingestor also exposes :meth:`ImageIngestor.ingest_pdf`, which the
+:class:`~creek.ingest.documents.DocumentIngestor` can call when it
+detects a scanned (image-only) PDF, routing the OCR work here instead
+of trying to extract text that does not exist.
+
+Optional dependencies (install separately to enable real OCR):
+
+* ``pytesseract`` — Python wrapper around the ``tesseract`` binary.
+* ``Pillow`` — image preprocessing (contrast / rotation).
+* ``pdf2image`` — converts PDF pages to images (requires ``poppler``).
+
+Without these the ingestor still discovers files and the test suite
+runs end-to-end via the stub engine; only :class:`PytesseractOcrEngine`
+itself raises :class:`PytesseractUnavailableError` at OCR time.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from creek.ingest.base import Ingestor, ParsedFragment, RawDocument
+from creek.models import SourcePlatform
+
+logger = logging.getLogger(__name__)
+
+
+IMAGE_EXTENSIONS: frozenset[str] = frozenset(
+    {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"},
+)
+"""File extensions handled by :class:`ImageIngestor`."""
+
+
+_DEFAULT_LANGUAGE: str = "eng"
+"""Default tesseract language code; override per-engine for multi-lang OCR."""
+
+
+_IMAGE_TYPE_HINTS: dict[str, tuple[str, ...]] = {
+    "screenshot": ("screenshot", "screen-shot", "screen_shot", "screencap"),
+    "photo_of_text": ("scan", "scanned", "handwritten", "notebook", "page"),
+    "diagram": ("diagram", "chart", "schematic", "flowchart", "wireframe"),
+}
+"""Filename token hints used by :func:`detect_image_type`."""
+
+
+# ---- Public dataclasses + protocol --------------------------------------
+
+
+@dataclass(frozen=True)
+class OcrResult:
+    """Result of running OCR on a single image or PDF page.
+
+    Attributes:
+        text: Extracted text. Empty when OCR returned nothing usable.
+        confidence: OCR confidence in ``[0.0, 1.0]``.
+        page: 1-based page index (PDFs); ``0`` for standalone images.
+        image_type: One of ``screenshot``, ``photo_of_text``, ``diagram``,
+            ``scanned_pdf_page``, ``image``, ``other``.
+    """
+
+    text: str
+    confidence: float
+    page: int = 0
+    image_type: str = "image"
+
+
+@runtime_checkable
+class OcrEngine(Protocol):
+    """Pluggable OCR backend.
+
+    Implementations must be deterministic given the same input file —
+    callers (including tests) rely on stable output for the same path.
+    """
+
+    def is_available(self) -> bool:
+        """Return ``True`` when the backend can perform OCR right now."""
+
+    def extract_text(self, image_path: Path) -> OcrResult:
+        """Run OCR on a single image file."""
+
+    def extract_pdf_pages(self, pdf_path: Path) -> list[OcrResult]:
+        """Run OCR on every page of a (scanned) PDF."""
+
+
+class PytesseractUnavailableError(RuntimeError):
+    """Raised when an OCR call is made but pytesseract is not installed."""
+
+
+# ---- Default OCR engine --------------------------------------------------
+
+
+class PytesseractOcrEngine:
+    """OCR engine backed by ``pytesseract`` + ``pdf2image``.
+
+    Imports of the optional dependencies are deferred until the moment
+    of use so the rest of the package — and the unit tests — can run
+    on systems without ``tesseract`` or ``poppler`` installed.
+
+    Attributes:
+        language: Tesseract language code(s) (e.g. ``eng`` or ``eng+fra``).
+    """
+
+    def __init__(self, language: str = _DEFAULT_LANGUAGE) -> None:
+        """Initialise the engine.
+
+        Args:
+            language: Tesseract language code(s). See the tesseract
+                documentation for available codes.
+        """
+        self.language = language
+
+    def is_available(self) -> bool:
+        """Return ``True`` when both pytesseract and Pillow import cleanly."""
+        try:
+            import pytesseract  # noqa: F401
+            from PIL import Image  # noqa: F401
+        except ImportError:
+            return False
+        return True
+
+    def extract_text(self, image_path: Path) -> OcrResult:
+        """Run OCR on *image_path* and return the resulting text.
+
+        Args:
+            image_path: Filesystem path to the image file.
+
+        Returns:
+            An :class:`OcrResult` carrying the extracted text and the
+            average per-word confidence reported by tesseract.
+
+        Raises:
+            PytesseractUnavailableError: When ``pytesseract`` or
+                ``Pillow`` cannot be imported.
+        """
+        try:
+            import pytesseract
+            from PIL import Image, ImageEnhance
+        except ImportError as exc:
+            msg = (
+                "pytesseract and Pillow are required for OCR. "
+                "Install them with `pip install pytesseract pillow` "
+                "and ensure the `tesseract` system binary is on PATH."
+            )
+            raise PytesseractUnavailableError(msg) from exc
+
+        with Image.open(image_path) as raw:
+            image = ImageEnhance.Contrast(raw.convert("RGB")).enhance(2.0)
+            text = pytesseract.image_to_string(image, lang=self.language)
+            data = pytesseract.image_to_data(
+                image,
+                lang=self.language,
+                output_type=pytesseract.Output.DICT,
+            )
+        confidence = _average_confidence(data.get("conf", []))
+        image_type = detect_image_type(image_path)
+        return OcrResult(
+            text=text.strip(),
+            confidence=confidence,
+            image_type=image_type,
+        )
+
+    def extract_pdf_pages(self, pdf_path: Path) -> list[OcrResult]:
+        """Convert *pdf_path* to images page by page and OCR each one.
+
+        Args:
+            pdf_path: Filesystem path to the PDF.
+
+        Returns:
+            One :class:`OcrResult` per page (1-based ``page`` index).
+
+        Raises:
+            PytesseractUnavailableError: When ``pdf2image``,
+                ``pytesseract``, or ``Pillow`` cannot be imported.
+        """
+        try:
+            import pytesseract
+            from pdf2image import convert_from_path
+        except ImportError as exc:
+            msg = (
+                "pytesseract and pdf2image are required for scanned-PDF OCR. "
+                "Install them with `pip install pytesseract pdf2image pillow` "
+                "and ensure both `tesseract` and `poppler` are on PATH."
+            )
+            raise PytesseractUnavailableError(msg) from exc
+
+        pages = convert_from_path(str(pdf_path))
+        results: list[OcrResult] = []
+        for index, page_image in enumerate(pages, start=1):
+            text = pytesseract.image_to_string(page_image, lang=self.language)
+            data = pytesseract.image_to_data(
+                page_image,
+                lang=self.language,
+                output_type=pytesseract.Output.DICT,
+            )
+            confidence = _average_confidence(data.get("conf", []))
+            results.append(
+                OcrResult(
+                    text=text.strip(),
+                    confidence=confidence,
+                    page=index,
+                    image_type="scanned_pdf_page",
+                ),
+            )
+        return results
+
+
+def _average_confidence(conf_values: list[Any]) -> float:
+    """Compute mean confidence in ``[0, 1]`` from tesseract's per-word values.
+
+    Tesseract reports confidences in ``0-100`` (or ``-1`` for missing).
+    Empty or all-negative input returns ``0.0``.
+    """
+    numeric = [float(v) for v in conf_values if _is_positive_number(v)]
+    if not numeric:
+        return 0.0
+    return sum(numeric) / len(numeric) / 100.0
+
+
+def _is_positive_number(value: Any) -> bool:
+    """Return ``True`` when *value* parses to a non-negative float."""
+    try:
+        return float(value) >= 0
+    except (TypeError, ValueError):
+        return False
+
+
+# ---- Image-type heuristics ----------------------------------------------
+
+
+def detect_image_type(path: Path) -> str:
+    """Classify an image file by filename hints.
+
+    Returns one of ``screenshot``, ``photo_of_text``, ``diagram``, or
+    ``other``. The classification is intentionally cheap — real
+    content-aware detection is out of scope for this ingestor.
+    """
+    name = path.stem.lower()
+    for category, hints in _IMAGE_TYPE_HINTS.items():
+        if any(hint in name for hint in hints):
+            return category
+    return "other"
+
+
+# ---- ImageIngestor -------------------------------------------------------
+
+
+class ImageIngestor(Ingestor):
+    """Ingest images by running OCR and emitting markdown fragments.
+
+    The OCR backend is injected through :class:`OcrEngine` so callers
+    can substitute a deterministic stub in tests. The default backend
+    is :class:`PytesseractOcrEngine`, which lazily imports its
+    dependencies; production users must install ``pytesseract`` and
+    ``Pillow`` themselves and have the ``tesseract`` binary on PATH.
+    """
+
+    def __init__(
+        self,
+        engine: OcrEngine | None = None,
+        language: str = _DEFAULT_LANGUAGE,
+    ) -> None:
+        """Initialise the ingestor.
+
+        Args:
+            engine: Optional OCR backend. Defaults to a fresh
+                :class:`PytesseractOcrEngine` when ``None``.
+            language: Forwarded to the default engine when *engine*
+                is ``None``. Ignored otherwise.
+        """
+        self.engine = engine if engine is not None else PytesseractOcrEngine(language)
+        self.language = language
+
+    def discover(self, source_path: Path) -> list[RawDocument]:
+        """Recursively find every supported image under *source_path*.
+
+        Args:
+            source_path: Directory (or single file) to scan.
+
+        Returns:
+            A list of :class:`RawDocument` per discovered image.
+        """
+        if source_path.is_file():
+            paths = [source_path]
+        else:
+            paths = [
+                p
+                for p in sorted(source_path.rglob("*"))
+                if p.is_file() and p.suffix.lower() in IMAGE_EXTENSIONS
+            ]
+        return [
+            RawDocument(
+                path=path,
+                content=path.read_bytes(),
+                metadata={"original_file": str(path)},
+                detected_encoding="binary",
+            )
+            for path in paths
+        ]
+
+    def parse(self, raw: RawDocument) -> list[ParsedFragment]:
+        """Run OCR on the raw image and return at most one fragment.
+
+        An image with no recoverable text yields an empty list rather
+        than a fragment with an empty body — empty fragments would
+        clutter the vault without carrying signal.
+        """
+        result = self.engine.extract_text(raw.path)
+        if not result.text.strip():
+            logger.info("OCR produced no text for %s; skipping fragment.", raw.path)
+            return []
+        return [
+            ParsedFragment(
+                content=result.text.strip(),
+                metadata={
+                    "original_file": str(raw.path),
+                    "ocr_confidence": result.confidence,
+                    "image_type": result.image_type,
+                    "language": self.language,
+                },
+                source_path=str(raw.path),
+                timestamp=_modified_time(raw.path),
+            ),
+        ]
+
+    def convert_to_markdown(self, fragment: ParsedFragment) -> str:
+        """Embed the original image, then the OCR'd body."""
+        original = fragment.metadata.get("original_file", fragment.source_path)
+        image_name = Path(original).name
+        return f"![[{image_name}]]\n\n{fragment.content.strip()}\n"
+
+    def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
+        """Produce the YAML frontmatter for an OCR'd image fragment."""
+        return {
+            "type": "fragment",
+            "source": {
+                "platform": SourcePlatform.IMAGE_OCR.value,
+                "original_file": fragment.metadata.get(
+                    "original_file",
+                    fragment.source_path,
+                ),
+            },
+            "ocr_confidence": fragment.metadata.get("ocr_confidence", 0.0),
+            "image_type": fragment.metadata.get("image_type", "other"),
+            "language": fragment.metadata.get("language", self.language),
+            "ingested": fragment.timestamp.isoformat(),
+        }
+
+    def ingest_pdf(self, pdf_path: Path) -> list[ParsedFragment]:
+        """Run OCR on every page of *pdf_path* and return per-page fragments.
+
+        Used by :class:`~creek.ingest.documents.DocumentIngestor` (or a
+        future pipeline orchestrator) when a PDF is detected as
+        scanned. Pages with no recoverable text are skipped.
+
+        Args:
+            pdf_path: Path to the (scanned) PDF.
+
+        Returns:
+            One :class:`ParsedFragment` per non-empty page.
+        """
+        results = self.engine.extract_pdf_pages(pdf_path)
+        fragments: list[ParsedFragment] = []
+        for result in results:
+            if not result.text.strip():
+                continue
+            fragments.append(
+                ParsedFragment(
+                    content=result.text.strip(),
+                    metadata={
+                        "original_file": str(pdf_path),
+                        "ocr_confidence": result.confidence,
+                        "image_type": result.image_type or "scanned_pdf_page",
+                        "language": self.language,
+                        "page": result.page,
+                    },
+                    source_path=str(pdf_path),
+                    timestamp=_modified_time(pdf_path),
+                ),
+            )
+        return fragments
+
+
+def _modified_time(path: Path) -> datetime:
+    """Return the file's mtime as a timezone-aware UTC datetime."""
+    from datetime import UTC
+
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+
+
+__all__ = [
+    "IMAGE_EXTENSIONS",
+    "ImageIngestor",
+    "OcrEngine",
+    "OcrResult",
+    "PytesseractOcrEngine",
+    "PytesseractUnavailableError",
+    "detect_image_type",
+]

--- a/creek-tools/creek/ingest/images.py
+++ b/creek-tools/creek/ingest/images.py
@@ -51,10 +51,17 @@ _DEFAULT_LANGUAGE: str = "eng"
 
 _IMAGE_TYPE_HINTS: dict[str, tuple[str, ...]] = {
     "screenshot": ("screenshot", "screen-shot", "screen_shot", "screencap"),
-    "photo_of_text": ("scan", "scanned", "handwritten", "notebook", "page"),
+    "photo_of_text": ("scan", "scanned", "handwritten", "notebook"),
     "diagram": ("diagram", "chart", "schematic", "flowchart", "wireframe"),
 }
-"""Filename token hints used by :func:`detect_image_type`."""
+"""Filename token hints used by :func:`detect_image_type`.
+
+The dict is iterated in insertion order and the **first matching
+category wins** (priority: screenshot > photo_of_text > diagram).
+The bare token ``page`` is intentionally absent because substrings
+like ``webpage`` would falsely classify "webpage screenshot" as
+``photo_of_text``; ``scanned-page-3.jpg`` still matches via ``scan``.
+"""
 
 
 # ---- Public dataclasses + protocol --------------------------------------
@@ -254,6 +261,11 @@ def detect_image_type(path: Path) -> str:
     Returns one of ``screenshot``, ``photo_of_text``, ``diagram``, or
     ``other``. The classification is intentionally cheap — real
     content-aware detection is out of scope for this ingestor.
+
+    Matching is **first-wins** on the insertion order of
+    :data:`_IMAGE_TYPE_HINTS`: a filename matching both ``screenshot``
+    and ``photo_of_text`` hints (e.g. ``screenshot-of-scanned-page.png``)
+    is classified as ``screenshot``.
     """
     name = path.stem.lower()
     for category, hints in _IMAGE_TYPE_HINTS.items():
@@ -285,8 +297,14 @@ class ImageIngestor(Ingestor):
         Args:
             engine: Optional OCR backend. Defaults to a fresh
                 :class:`PytesseractOcrEngine` when ``None``.
-            language: Forwarded to the default engine when *engine*
-                is ``None``. Ignored otherwise.
+            language: Tesseract language code. When *engine* is
+                ``None`` the value is forwarded to the default
+                :class:`PytesseractOcrEngine`. When a custom engine is
+                supplied the engine owns its own language settings;
+                this attribute is then used **only** to tag parsed
+                fragments via the ``language`` metadata key, so callers
+                can reconcile per-fragment language with the engine
+                that produced them.
         """
         self.engine = engine if engine is not None else PytesseractOcrEngine(language)
         self.language = language
@@ -303,6 +321,14 @@ class ImageIngestor(Ingestor):
 
         Returns:
             A list of :class:`RawDocument` per discovered image.
+
+        Note:
+            Image bytes are *not* loaded into the returned
+            :class:`RawDocument` because :meth:`parse` (and the OCR
+            engine it delegates to) reads from disk via the file path.
+            For an image-heavy vault, eagerly reading every image into
+            memory at discovery time would be wasteful and could cause
+            OOM on large TIFFs or scanned PDFs.
         """
         if source_path.is_file():
             paths = (
@@ -317,7 +343,7 @@ class ImageIngestor(Ingestor):
         return [
             RawDocument(
                 path=path,
-                content=path.read_bytes(),
+                content=b"",
                 metadata={"original_file": str(path)},
                 detected_encoding="binary",
             )
@@ -375,9 +401,15 @@ class ImageIngestor(Ingestor):
     def ingest_pdf(self, pdf_path: Path) -> list[ParsedFragment]:
         """Run OCR on every page of *pdf_path* and return per-page fragments.
 
-        Used by :class:`~creek.ingest.documents.DocumentIngestor` (or a
-        future pipeline orchestrator) when a PDF is detected as
-        scanned. Pages with no recoverable text are skipped.
+        This is a deliberately separate entry point — the standard
+        :meth:`Ingestor.ingest` pipeline only handles file extensions
+        in :data:`IMAGE_EXTENSIONS`. Scanned PDFs are routed here from
+        :class:`~creek.ingest.documents.DocumentIngestor` (or a
+        higher-level orchestrator) once it detects via
+        ``_detect_scanned_pdf`` that text extraction won't work. Until
+        that integration lands, callers can invoke this method directly
+        on a known-scanned PDF. Pages with no recoverable text are
+        skipped.
 
         Args:
             pdf_path: Path to the (scanned) PDF.

--- a/creek-tools/creek/ingest/images.py
+++ b/creek-tools/creek/ingest/images.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
@@ -158,7 +158,7 @@ class PytesseractOcrEngine:
         """
         try:
             import pytesseract
-            from PIL import Image, ImageEnhance
+            from PIL import Image
         except ImportError as exc:
             msg = (
                 "pytesseract and Pillow are required for OCR. "
@@ -168,19 +168,12 @@ class PytesseractOcrEngine:
             raise PytesseractUnavailableError(msg) from exc
 
         with Image.open(image_path) as raw:
-            image = ImageEnhance.Contrast(raw.convert("RGB")).enhance(2.0)
-            text = pytesseract.image_to_string(image, lang=self.language)
-            data = pytesseract.image_to_data(
-                image,
-                lang=self.language,
-                output_type=pytesseract.Output.DICT,
-            )
-        confidence = _average_confidence(data.get("conf", []))
-        image_type = detect_image_type(image_path)
+            image = self._preprocess(raw)
+            text, confidence = self._ocr_image(pytesseract, image)
         return OcrResult(
-            text=text.strip(),
+            text=text,
             confidence=confidence,
-            image_type=image_type,
+            image_type=detect_image_type(image_path),
         )
 
     def extract_pdf_pages(self, pdf_path: Path) -> list[OcrResult]:
@@ -210,22 +203,41 @@ class PytesseractOcrEngine:
         pages = convert_from_path(str(pdf_path))
         results: list[OcrResult] = []
         for index, page_image in enumerate(pages, start=1):
-            text = pytesseract.image_to_string(page_image, lang=self.language)
-            data = pytesseract.image_to_data(
-                page_image,
-                lang=self.language,
-                output_type=pytesseract.Output.DICT,
-            )
-            confidence = _average_confidence(data.get("conf", []))
+            preprocessed = self._preprocess(page_image)
+            text, confidence = self._ocr_image(pytesseract, preprocessed)
             results.append(
                 OcrResult(
-                    text=text.strip(),
+                    text=text,
                     confidence=confidence,
                     page=index,
                     image_type="scanned_pdf_page",
                 ),
             )
         return results
+
+    @staticmethod
+    def _preprocess(image: Any) -> Any:
+        """Boost contrast on *image* prior to OCR.
+
+        Centralised so :meth:`extract_text` and :meth:`extract_pdf_pages`
+        produce comparable OCR quality — previously the PDF path skipped
+        contrast enhancement which yielded systematically worse results
+        on faint scans.
+        """
+        from PIL import ImageEnhance
+
+        return ImageEnhance.Contrast(image.convert("RGB")).enhance(2.0)
+
+    def _ocr_image(self, pytesseract: Any, image: Any) -> tuple[str, float]:
+        """Run tesseract on a preprocessed image, returning ``(text, confidence)``."""
+        text = pytesseract.image_to_string(image, lang=self.language)
+        data = pytesseract.image_to_data(
+            image,
+            lang=self.language,
+            output_type=pytesseract.Output.DICT,
+        )
+        confidence = _average_confidence(data.get("conf", []))
+        return text.strip(), confidence
 
 
 def _average_confidence(conf_values: list[Any]) -> float:
@@ -356,6 +368,18 @@ class ImageIngestor(Ingestor):
         An image with no recoverable text yields an empty list rather
         than a fragment with an empty body — empty fragments would
         clutter the vault without carrying signal.
+
+        Raises:
+            PytesseractUnavailableError: When the default
+                :class:`PytesseractOcrEngine` is in use and
+                ``pytesseract`` / ``Pillow`` are not installed.
+                Custom :class:`OcrEngine` implementations may raise
+                their own errors. The base
+                :meth:`Ingestor.ingest` orchestrator catches
+                :class:`Exception` and records it on
+                :class:`IngestResult.errors`, so callers using the
+                full pipeline see a structured error rather than a
+                crash.
         """
         result = self.engine.extract_text(raw.path)
         if not result.text.strip():
@@ -376,10 +400,18 @@ class ImageIngestor(Ingestor):
         ]
 
     def convert_to_markdown(self, fragment: ParsedFragment) -> str:
-        """Embed the original image, then the OCR'd body."""
+        """Embed the original image, then the OCR'd body.
+
+        For multi-page scanned-PDF fragments produced by
+        :meth:`ingest_pdf`, the embed carries the Obsidian
+        ``#page=N`` anchor so each page renders independently.
+        Standalone-image fragments use the bare ``![[name]]`` embed.
+        """
         original = fragment.metadata.get("original_file", fragment.source_path)
         image_name = Path(original).name
-        return f"![[{image_name}]]\n\n{fragment.content.strip()}\n"
+        page = fragment.metadata.get("page", 0)
+        embed = f"![[{image_name}#page={page}]]" if page else f"![[{image_name}]]"
+        return f"{embed}\n\n{fragment.content.strip()}\n"
 
     def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
         """Produce the YAML frontmatter for an OCR'd image fragment."""
@@ -441,8 +473,6 @@ class ImageIngestor(Ingestor):
 
 def _modified_time(path: Path) -> datetime:
     """Return the file's mtime as a timezone-aware UTC datetime."""
-    from datetime import UTC
-
     return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
 
 

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -131,6 +131,10 @@ module = ["markdownify", "pdfminer", "pdfminer.*", "docx", "docx.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = ["pytesseract", "PIL", "PIL.*", "pdf2image", "pdf2image.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
 

--- a/creek-tools/tests/test_images_ingestor.py
+++ b/creek-tools/tests/test_images_ingestor.py
@@ -1,0 +1,425 @@
+"""Tests for the Image/OCR ingestor (issue #54)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.ingest.images import (
+    IMAGE_EXTENSIONS,
+    ImageIngestor,
+    OcrEngine,
+    OcrResult,
+    PytesseractOcrEngine,
+    detect_image_type,
+)
+from creek.ingest.images import (
+    PytesseractUnavailableError as PytesseractMissingError,
+)
+from creek.models import SourcePlatform
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---- Stub OCR engine -----------------------------------------------------
+
+
+class StubOcrEngine:
+    """Deterministic in-memory OCR engine for tests."""
+
+    def __init__(
+        self,
+        image_results: dict[str, OcrResult] | None = None,
+        pdf_results: dict[str, list[OcrResult]] | None = None,
+    ) -> None:
+        self._image_results = image_results or {}
+        self._pdf_results = pdf_results or {}
+        self.calls: list[str] = []
+
+    def is_available(self) -> bool:
+        return True
+
+    def extract_text(self, image_path: Path) -> OcrResult:
+        self.calls.append(str(image_path))
+        if image_path.name in self._image_results:
+            return self._image_results[image_path.name]
+        return OcrResult(
+            text=f"OCR text from {image_path.name}",
+            confidence=0.9,
+            image_type="image",
+        )
+
+    def extract_pdf_pages(self, pdf_path: Path) -> list[OcrResult]:
+        self.calls.append(str(pdf_path))
+        if pdf_path.name in self._pdf_results:
+            return self._pdf_results[pdf_path.name]
+        return [
+            OcrResult(
+                text=f"Page 1 from {pdf_path.name}",
+                confidence=0.85,
+                page=1,
+                image_type="scanned_pdf_page",
+            ),
+        ]
+
+
+# ---- Module exports -----------------------------------------------------
+
+
+class TestModuleExports:
+    """``creek.ingest.images`` exposes the expected public surface."""
+
+    def test_image_extensions_covers_required_set(self) -> None:
+        """All seven image extensions from §54 are recognised."""
+        expected = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff", ".webp"}
+        assert expected.issubset(IMAGE_EXTENSIONS)
+
+    def test_ocr_engine_protocol_has_required_methods(self) -> None:
+        """Stub OCR engines satisfy the protocol."""
+        assert isinstance(StubOcrEngine(), OcrEngine)
+
+    def test_image_ingestor_re_exported_from_package(self) -> None:
+        """``from creek.ingest import ImageIngestor`` works."""
+        from creek.ingest import ImageIngestor as Reexported
+
+        assert Reexported is ImageIngestor
+
+
+# ---- detect_image_type --------------------------------------------------
+
+
+class TestDetectImageType:
+    """File-name heuristics for image type detection."""
+
+    def test_screenshot_filename_is_screenshot(self) -> None:
+        """``Screenshot 2026-04-20.png`` → screenshot."""
+        from pathlib import Path
+
+        result = detect_image_type(Path("Screenshot 2026-04-20 at 09.32.png"))
+        assert result == "screenshot"
+
+    def test_screen_dash_shot_filename(self) -> None:
+        """``screen-shot-1.png`` → screenshot."""
+        from pathlib import Path
+
+        assert detect_image_type(Path("screen-shot-1.png")) == "screenshot"
+
+    def test_scanned_filename_is_photo_of_text(self) -> None:
+        """``scanned-page-3.jpg`` → photo_of_text."""
+        from pathlib import Path
+
+        assert detect_image_type(Path("scanned-page-3.jpg")) == "photo_of_text"
+
+    def test_diagram_filename_is_diagram(self) -> None:
+        """``diagram-architecture.png`` → diagram."""
+        from pathlib import Path
+
+        assert detect_image_type(Path("diagram-architecture.png")) == "diagram"
+
+    def test_unknown_filename_is_other(self) -> None:
+        """Unrecognised filenames fall back to ``other``."""
+        from pathlib import Path
+
+        assert detect_image_type(Path("random-photo.jpg")) == "other"
+
+
+# ---- ImageIngestor.discover --------------------------------------------
+
+
+class TestDiscover:
+    """``discover`` finds image files recursively and ignores non-images."""
+
+    def test_finds_all_image_extensions(self, tmp_path: Path) -> None:
+        """All seven image extensions are discovered."""
+        for name in (
+            "a.png",
+            "b.jpg",
+            "c.jpeg",
+            "d.gif",
+            "e.bmp",
+            "f.tiff",
+            "g.webp",
+        ):
+            (tmp_path / name).write_bytes(b"\x89PNG\r\n\x1a\n")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        raws = ingestor.discover(tmp_path)
+        assert {raw.path.name for raw in raws} == {
+            "a.png",
+            "b.jpg",
+            "c.jpeg",
+            "d.gif",
+            "e.bmp",
+            "f.tiff",
+            "g.webp",
+        }
+
+    def test_ignores_non_image_extensions(self, tmp_path: Path) -> None:
+        """Non-image files (``.md``, ``.txt``) are skipped."""
+        (tmp_path / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        (tmp_path / "note.md").write_text("# note")
+        (tmp_path / "data.csv").write_text("a,b,c")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        raws = ingestor.discover(tmp_path)
+        assert [raw.path.name for raw in raws] == ["image.png"]
+
+    def test_recursive_discovery(self, tmp_path: Path) -> None:
+        """Images in subdirectories are discovered."""
+        nested = tmp_path / "deep" / "nested"
+        nested.mkdir(parents=True, exist_ok=True)
+        (nested / "deep.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        raws = ingestor.discover(tmp_path)
+        assert any("deep.png" in str(raw.path) for raw in raws)
+
+    def test_extension_matching_is_case_insensitive(self, tmp_path: Path) -> None:
+        """``.PNG`` and ``.JPG`` are still images."""
+        (tmp_path / "shout.PNG").write_bytes(b"\x89PNG\r\n\x1a\n")
+        (tmp_path / "shout.JPG").write_bytes(b"\xff\xd8\xff\xe0")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        raws = ingestor.discover(tmp_path)
+        assert {raw.path.name for raw in raws} == {"shout.PNG", "shout.JPG"}
+
+
+# ---- ImageIngestor.parse + ingest --------------------------------------
+
+
+def _write_image(path: Path) -> None:
+    """Write a placeholder PNG file (signature only, not a real image)."""
+    path.write_bytes(b"\x89PNG\r\n\x1a\n")
+
+
+class TestParseAndIngest:
+    """Parse runs OCR and produces a ParsedFragment with body + metadata."""
+
+    def test_parse_returns_one_fragment_per_image(self, tmp_path: Path) -> None:
+        """Each image produces exactly one ParsedFragment."""
+        image_path = tmp_path / "screenshot.png"
+        _write_image(image_path)
+        engine = StubOcrEngine(
+            image_results={
+                "screenshot.png": OcrResult(
+                    text="Hello creek",
+                    confidence=0.92,
+                    image_type="screenshot",
+                ),
+            },
+        )
+        ingestor = ImageIngestor(engine=engine)
+        raws = ingestor.discover(tmp_path)
+        fragments = ingestor.parse(raws[0])
+        assert len(fragments) == 1
+        assert fragments[0].content == "Hello creek"
+
+    def test_parse_records_ocr_confidence_in_metadata(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The fragment's metadata carries the OCR confidence score."""
+        image_path = tmp_path / "screenshot.png"
+        _write_image(image_path)
+        engine = StubOcrEngine(
+            image_results={
+                "screenshot.png": OcrResult(
+                    text="Hello",
+                    confidence=0.74,
+                    image_type="screenshot",
+                ),
+            },
+        )
+        ingestor = ImageIngestor(engine=engine)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert fragments[0].metadata["ocr_confidence"] == pytest.approx(0.74)
+        assert fragments[0].metadata["image_type"] == "screenshot"
+
+    def test_parse_records_original_image_path(self, tmp_path: Path) -> None:
+        """The original image path is preserved on the fragment."""
+        image_path = tmp_path / "ocr.png"
+        _write_image(image_path)
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert fragments[0].source_path == str(image_path)
+
+    def test_parse_skips_empty_ocr_text(self, tmp_path: Path) -> None:
+        """An image with no recoverable text yields no fragment."""
+        image_path = tmp_path / "blank.png"
+        _write_image(image_path)
+        engine = StubOcrEngine(
+            image_results={
+                "blank.png": OcrResult(text="", confidence=0.0),
+            },
+        )
+        ingestor = ImageIngestor(engine=engine)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert fragments == []
+
+    def test_full_ingest_pipeline_succeeds(self, tmp_path: Path) -> None:
+        """The full ingest() pipeline returns a populated IngestResult."""
+        image_path = tmp_path / "screenshot.png"
+        _write_image(image_path)
+        engine = StubOcrEngine(
+            image_results={
+                "screenshot.png": OcrResult(
+                    text="A screenshot",
+                    confidence=0.88,
+                    image_type="screenshot",
+                ),
+            },
+        )
+        ingestor = ImageIngestor(engine=engine)
+        result = ingestor.ingest(tmp_path)
+        assert len(result.fragments) == 1
+        assert result.fragments[0].content == "A screenshot"
+        assert result.errors == []
+
+
+# ---- ImageIngestor.convert_to_markdown ---------------------------------
+
+
+class TestConvertToMarkdown:
+    """Markdown rendering embeds the original image link."""
+
+    def test_markdown_starts_with_image_link(self, tmp_path: Path) -> None:
+        """The rendered markdown begins with an Obsidian image embed."""
+        from creek.ingest.base import ParsedFragment
+
+        fragment = ParsedFragment(
+            content="OCR'd text body",
+            metadata={
+                "original_file": str(tmp_path / "shot.png"),
+                "ocr_confidence": 0.9,
+                "image_type": "screenshot",
+            },
+            source_path=str(tmp_path / "shot.png"),
+            timestamp=datetime(2026, 4, 27, tzinfo=UTC),
+        )
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        markdown = ingestor.convert_to_markdown(fragment)
+        assert markdown.startswith("![[")
+        assert "shot.png" in markdown
+        assert "OCR'd text body" in markdown
+
+
+# ---- ImageIngestor.generate_frontmatter --------------------------------
+
+
+class TestGenerateFrontmatter:
+    """Frontmatter carries source.platform=image_ocr + OCR metadata."""
+
+    def test_frontmatter_has_image_ocr_platform(self, tmp_path: Path) -> None:
+        """``source.platform`` is the ``image_ocr`` enum value."""
+        from creek.ingest.base import ParsedFragment
+
+        fragment = ParsedFragment(
+            content="text",
+            metadata={
+                "original_file": str(tmp_path / "x.png"),
+                "ocr_confidence": 0.8,
+                "image_type": "screenshot",
+            },
+            source_path=str(tmp_path / "x.png"),
+            timestamp=datetime(2026, 4, 27, tzinfo=UTC),
+        )
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        fm = ingestor.generate_frontmatter(fragment)
+        assert fm["source"]["platform"] == SourcePlatform.IMAGE_OCR.value
+        assert fm["source"]["original_file"] == str(tmp_path / "x.png")
+        assert fm["ocr_confidence"] == pytest.approx(0.8)
+        assert fm["image_type"] == "screenshot"
+
+
+# ---- ImageIngestor.ingest_pdf -----------------------------------------
+
+
+class TestIngestPdf:
+    """Scanned PDFs route through the OCR engine page by page."""
+
+    def test_ingest_pdf_returns_one_fragment_per_page(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Each PDF page yields a ParsedFragment with page-numbered metadata."""
+        pdf_path = tmp_path / "scan.pdf"
+        pdf_path.write_bytes(b"%PDF-1.4")
+        engine = StubOcrEngine(
+            pdf_results={
+                "scan.pdf": [
+                    OcrResult(
+                        text="Page 1 body",
+                        confidence=0.7,
+                        page=1,
+                        image_type="scanned_pdf_page",
+                    ),
+                    OcrResult(
+                        text="Page 2 body",
+                        confidence=0.65,
+                        page=2,
+                        image_type="scanned_pdf_page",
+                    ),
+                ],
+            },
+        )
+        ingestor = ImageIngestor(engine=engine)
+        fragments = ingestor.ingest_pdf(pdf_path)
+        assert len(fragments) == 2
+        assert fragments[0].content == "Page 1 body"
+        assert fragments[1].metadata["page"] == 2
+        assert fragments[0].metadata["image_type"] == "scanned_pdf_page"
+
+    def test_ingest_pdf_skips_pages_without_text(self, tmp_path: Path) -> None:
+        """Pages with empty OCR are skipped."""
+        pdf_path = tmp_path / "scan.pdf"
+        pdf_path.write_bytes(b"%PDF-1.4")
+        engine = StubOcrEngine(
+            pdf_results={
+                "scan.pdf": [
+                    OcrResult(text="Real content", confidence=0.8, page=1),
+                    OcrResult(text="", confidence=0.0, page=2),
+                ],
+            },
+        )
+        ingestor = ImageIngestor(engine=engine)
+        fragments = ingestor.ingest_pdf(pdf_path)
+        assert len(fragments) == 1
+        assert fragments[0].content == "Real content"
+
+
+# ---- PytesseractOcrEngine ---------------------------------------------
+
+
+class TestPytesseractOcrEngine:
+    """Default OCR backend respects the optional-dep contract."""
+
+    def test_is_available_returns_false_when_pytesseract_missing(self) -> None:
+        """Without pytesseract, the engine reports unavailable."""
+        # pytesseract is not installed in the test environment.
+        engine = PytesseractOcrEngine()
+        assert engine.is_available() is False
+
+    def test_extract_text_raises_when_pytesseract_missing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Calling extract_text without pytesseract raises a clear error."""
+        image_path = tmp_path / "x.png"
+        _write_image(image_path)
+        engine = PytesseractOcrEngine()
+        with pytest.raises(PytesseractMissingError, match="pytesseract"):
+            engine.extract_text(image_path)
+
+    def test_extract_pdf_pages_raises_when_pdf2image_missing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Calling extract_pdf_pages without deps raises a clear error."""
+        pdf_path = tmp_path / "x.pdf"
+        pdf_path.write_bytes(b"%PDF-1.4")
+        engine = PytesseractOcrEngine()
+        with pytest.raises(PytesseractMissingError):
+            engine.extract_pdf_pages(pdf_path)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/creek-tools/tests/test_images_ingestor.py
+++ b/creek-tools/tests/test_images_ingestor.py
@@ -14,6 +14,8 @@ from creek.ingest.images import (
     OcrResult,
     PytesseractOcrEngine,
     PytesseractUnavailableError,
+    _average_confidence,
+    _is_non_negative_number,
     detect_image_type,
 )
 from creek.models import SourcePlatform
@@ -33,14 +35,17 @@ class StubOcrEngine:
         image_results: dict[str, OcrResult] | None = None,
         pdf_results: dict[str, list[OcrResult]] | None = None,
     ) -> None:
+        """Seed canned results keyed by file name."""
         self._image_results = image_results or {}
         self._pdf_results = pdf_results or {}
         self.calls: list[str] = []
 
     def is_available(self) -> bool:
+        """Stub engines are always available — no system deps."""
         return True
 
     def extract_text(self, image_path: Path) -> OcrResult:
+        """Return the canned image result, or a deterministic fallback."""
         self.calls.append(str(image_path))
         if image_path.name in self._image_results:
             return self._image_results[image_path.name]
@@ -50,6 +55,7 @@ class StubOcrEngine:
         )
 
     def extract_pdf_pages(self, pdf_path: Path) -> list[OcrResult]:
+        """Return the canned PDF page results, or a single-page fallback."""
         self.calls.append(str(pdf_path))
         if pdf_path.name in self._pdf_results:
             return self._pdf_results[pdf_path.name]
@@ -205,7 +211,7 @@ class TestDiscover:
         text_path.write_text("hello", encoding="utf-8")
         ingestor = ImageIngestor(engine=StubOcrEngine())
         raws = ingestor.discover(text_path)
-        assert raws == []
+        assert not raws
 
 
 # ---- ImageIngestor.parse + ingest --------------------------------------
@@ -267,6 +273,14 @@ class TestParseAndIngest:
         fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
         assert fragments[0].source_path == str(image_path)
 
+    def test_parse_propagates_language_to_metadata(self, tmp_path: Path) -> None:
+        """The ingestor's configured language reaches fragment metadata."""
+        image_path = tmp_path / "ocr.png"
+        _write_image(image_path)
+        ingestor = ImageIngestor(engine=StubOcrEngine(), language="eng+fra")
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert fragments[0].metadata["language"] == "eng+fra"
+
     def test_parse_skips_empty_ocr_text(self, tmp_path: Path) -> None:
         """An image with no recoverable text yields no fragment."""
         image_path = tmp_path / "blank.png"
@@ -278,7 +292,7 @@ class TestParseAndIngest:
         )
         ingestor = ImageIngestor(engine=engine)
         fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
-        assert fragments == []
+        assert not fragments
 
     def test_full_ingest_pipeline_succeeds(self, tmp_path: Path) -> None:
         """The full ingest() pipeline returns a populated IngestResult."""
@@ -414,20 +428,71 @@ class TestIngestPdf:
 # ---- PytesseractOcrEngine ---------------------------------------------
 
 
-class TestPytesseractOcrEngine:
-    """Default OCR backend respects the optional-dep contract."""
+def _make_import_blocker(blocked_modules: set[str]) -> object:
+    """Build an ``__import__`` replacement that raises for *blocked_modules*.
 
-    def test_is_available_returns_false_when_pytesseract_missing(self) -> None:
+    Used to make :class:`PytesseractOcrEngine` tests deterministic
+    regardless of whether ``pytesseract`` / ``Pillow`` / ``pdf2image``
+    are installed in the surrounding environment.
+    """
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked_import(
+        name: str,
+        module_globals: dict[str, object] | None = None,
+        module_locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        """Raise ImportError for blocked modules; defer everything else."""
+        root = name.split(".", 1)[0]
+        if root in blocked_modules or name in blocked_modules:
+            msg = f"mocked-missing: {name}"
+            raise ImportError(msg)
+        return real_import(name, module_globals, module_locals, fromlist, level)
+
+    return _blocked_import
+
+
+class TestPytesseractOcrEngine:
+    """Default OCR backend respects the optional-dep contract.
+
+    These tests deterministically simulate the missing-dep state by
+    monkeypatching ``builtins.__import__`` so they pass regardless of
+    whether pytesseract / Pillow / pdf2image happen to be installed in
+    the surrounding environment.
+    """
+
+    def test_is_available_returns_false_when_pytesseract_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Without pytesseract, the engine reports unavailable."""
-        # pytesseract is not installed in the test environment.
+        import builtins
+
+        monkeypatch.setattr(
+            builtins,
+            "__import__",
+            _make_import_blocker({"pytesseract", "PIL"}),
+        )
         engine = PytesseractOcrEngine()
-        assert engine.is_available() is False
+        assert not engine.is_available()
 
     def test_extract_text_raises_when_pytesseract_missing(
         self,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Calling extract_text without pytesseract raises a clear error."""
+        import builtins
+
+        monkeypatch.setattr(
+            builtins,
+            "__import__",
+            _make_import_blocker({"pytesseract", "PIL"}),
+        )
         image_path = tmp_path / "x.png"
         _write_image(image_path)
         engine = PytesseractOcrEngine()
@@ -437,13 +502,97 @@ class TestPytesseractOcrEngine:
     def test_extract_pdf_pages_raises_when_pdf2image_missing(
         self,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Calling extract_pdf_pages without deps raises a clear error."""
+        import builtins
+
+        monkeypatch.setattr(
+            builtins,
+            "__import__",
+            _make_import_blocker({"pytesseract", "pdf2image"}),
+        )
         pdf_path = tmp_path / "x.pdf"
         pdf_path.write_bytes(b"%PDF-1.4")
         engine = PytesseractOcrEngine()
         with pytest.raises(PytesseractUnavailableError):
             engine.extract_pdf_pages(pdf_path)
+
+
+# ---- Helper function unit tests ---------------------------------------
+
+
+class TestAverageConfidence:
+    """`_average_confidence` normalises tesseract's per-word values to [0, 1]."""
+
+    def test_empty_input_is_zero(self) -> None:
+        """An empty list returns 0.0 — there is no signal to average."""
+        assert _average_confidence([]) == 0.0
+
+    def test_all_negative_sentinels_is_zero(self) -> None:
+        """Tesseract uses -1 for "missing"; an all-negative list filters down to 0.0."""
+        assert _average_confidence([-1, -1, -1]) == 0.0
+
+    def test_negative_sentinels_are_filtered_out(self) -> None:
+        """Mixed input ignores negatives and averages only the non-negative values."""
+        # 100 + 50 average to 75, normalised to 0.75.
+        result = _average_confidence([100, 50, -1])
+        assert result == pytest.approx(0.75)
+
+    def test_zero_confidence_is_kept(self) -> None:
+        """A legitimate 0% confidence is *not* the same as the -1 sentinel."""
+        result = _average_confidence([0, 100])
+        assert result == pytest.approx(0.5)
+
+    def test_string_inputs_are_coerced(self) -> None:
+        """Tesseract's JSON output sometimes hands back strings; coerce gracefully."""
+        result = _average_confidence(["80", "60", "40"])
+        assert result == pytest.approx(0.6)
+
+    def test_unparseable_inputs_are_skipped(self) -> None:
+        """Junk values (None, non-numeric strings) are dropped, not exploded."""
+        result = _average_confidence([None, "junk", 80, 40])
+        assert result == pytest.approx(0.6)
+
+
+class TestIsNonNegativeNumber:
+    """`_is_non_negative_number` filters tesseract's -1 sentinel."""
+
+    @pytest.mark.parametrize("value", [0, 0.0, 1, 100, "0", "75"])
+    def test_non_negative_values_are_accepted(self, value: object) -> None:
+        """Zero, positive ints/floats, and numeric strings are kept."""
+        assert _is_non_negative_number(value)
+
+    @pytest.mark.parametrize("value", [-1, -0.5, "-1", "-100"])
+    def test_negative_values_are_rejected(self, value: object) -> None:
+        """Negative numbers (incl. tesseract's -1 sentinel) are filtered."""
+        assert not _is_non_negative_number(value)
+
+    @pytest.mark.parametrize("value", [None, "junk", object()])
+    def test_unparseable_values_are_rejected(self, value: object) -> None:
+        """Non-numeric input returns False rather than raising."""
+        assert not _is_non_negative_number(value)
+
+
+# ---- detect_image_type priority ---------------------------------------
+
+
+class TestDetectImageTypePriority:
+    """`detect_image_type` resolves overlapping hints by first-wins order."""
+
+    def test_screenshot_outranks_photo_of_text(self) -> None:
+        """A name matching both 'screenshot' and 'scan' resolves to screenshot."""
+        from pathlib import Path
+
+        result = detect_image_type(Path("screenshot-of-scanned-page.png"))
+        assert result == "screenshot"
+
+    def test_webpage_does_not_match_photo_of_text(self) -> None:
+        """The bare 'page' token was removed; webpage thumbnails stay 'other'."""
+        from pathlib import Path
+
+        result = detect_image_type(Path("webpage-thumbnail.png"))
+        assert result == "other"
 
 
 if __name__ == "__main__":

--- a/creek-tools/tests/test_images_ingestor.py
+++ b/creek-tools/tests/test_images_ingestor.py
@@ -1,4 +1,4 @@
-"""Tests for the Image/OCR ingestor (issue #54)."""
+"""Tests for the Image/OCR ingestor."""
 
 from __future__ import annotations
 
@@ -13,10 +13,8 @@ from creek.ingest.images import (
     OcrEngine,
     OcrResult,
     PytesseractOcrEngine,
+    PytesseractUnavailableError,
     detect_image_type,
-)
-from creek.ingest.images import (
-    PytesseractUnavailableError as PytesseractMissingError,
 )
 from creek.models import SourcePlatform
 
@@ -49,7 +47,6 @@ class StubOcrEngine:
         return OcrResult(
             text=f"OCR text from {image_path.name}",
             confidence=0.9,
-            image_type="image",
         )
 
     def extract_pdf_pages(self, pdf_path: Path) -> list[OcrResult]:
@@ -181,6 +178,34 @@ class TestDiscover:
         ingestor = ImageIngestor(engine=StubOcrEngine())
         raws = ingestor.discover(tmp_path)
         assert {raw.path.name for raw in raws} == {"shout.PNG", "shout.JPG"}
+
+    def test_discover_single_image_file_returns_one_raw(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Calling discover with a single image file returns one RawDocument."""
+        image_path = tmp_path / "shot.png"
+        image_path.write_bytes(b"\x89PNG\r\n\x1a\n")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        raws = ingestor.discover(image_path)
+        assert len(raws) == 1
+        assert raws[0].path == image_path
+
+    def test_discover_single_non_image_file_returns_empty(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A non-image file passed directly is rejected, not OCR'd.
+
+        Without the extension guard, a stray ``.txt`` or ``.py`` could
+        flow into the OCR engine and produce noise — the document
+        ingestor pipeline routes non-images through other handlers.
+        """
+        text_path = tmp_path / "notes.txt"
+        text_path.write_text("hello", encoding="utf-8")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        raws = ingestor.discover(text_path)
+        assert raws == []
 
 
 # ---- ImageIngestor.parse + ingest --------------------------------------
@@ -406,7 +431,7 @@ class TestPytesseractOcrEngine:
         image_path = tmp_path / "x.png"
         _write_image(image_path)
         engine = PytesseractOcrEngine()
-        with pytest.raises(PytesseractMissingError, match="pytesseract"):
+        with pytest.raises(PytesseractUnavailableError, match="pytesseract"):
             engine.extract_text(image_path)
 
     def test_extract_pdf_pages_raises_when_pdf2image_missing(
@@ -417,7 +442,7 @@ class TestPytesseractOcrEngine:
         pdf_path = tmp_path / "x.pdf"
         pdf_path.write_bytes(b"%PDF-1.4")
         engine = PytesseractOcrEngine()
-        with pytest.raises(PytesseractMissingError):
+        with pytest.raises(PytesseractUnavailableError):
             engine.extract_pdf_pages(pdf_path)
 
 

--- a/creek-tools/tests/test_images_ingestor.py
+++ b/creek-tools/tests/test_images_ingestor.py
@@ -340,6 +340,58 @@ class TestConvertToMarkdown:
         assert "shot.png" in markdown
         assert "OCR'd text body" in markdown
 
+    def test_pdf_page_fragment_renders_with_page_anchor(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """PDF-page fragments render with Obsidian's ``#page=N`` anchor.
+
+        Without the anchor, every page from the same PDF would embed
+        the whole document, losing the per-page context that
+        :meth:`ImageIngestor.ingest_pdf` carefully preserved in
+        metadata.
+        """
+        from creek.ingest.base import ParsedFragment
+
+        fragment = ParsedFragment(
+            content="OCR'd page 3 body",
+            metadata={
+                "original_file": str(tmp_path / "scan.pdf"),
+                "ocr_confidence": 0.7,
+                "image_type": "scanned_pdf_page",
+                "page": 3,
+            },
+            source_path=str(tmp_path / "scan.pdf"),
+            timestamp=datetime(2026, 4, 27, tzinfo=UTC),
+        )
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        markdown = ingestor.convert_to_markdown(fragment)
+        assert markdown.startswith("![[scan.pdf#page=3]]")
+        assert "OCR'd page 3 body" in markdown
+
+    def test_image_fragment_without_page_omits_anchor(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Standalone image fragments use the bare ``![[name]]`` embed."""
+        from creek.ingest.base import ParsedFragment
+
+        fragment = ParsedFragment(
+            content="hello",
+            metadata={
+                "original_file": str(tmp_path / "shot.png"),
+                "ocr_confidence": 0.9,
+                "image_type": "screenshot",
+                # ``page`` deliberately absent.
+            },
+            source_path=str(tmp_path / "shot.png"),
+            timestamp=datetime(2026, 4, 27, tzinfo=UTC),
+        )
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        markdown = ingestor.convert_to_markdown(fragment)
+        assert markdown.startswith("![[shot.png]]")
+        assert "#page=" not in markdown
+
 
 # ---- ImageIngestor.generate_frontmatter --------------------------------
 


### PR DESCRIPTION
## Summary

Implements §54 of the polish epic — an ingestor for screenshots, photos of handwritten notes, diagrams, and scanned PDFs.

The OCR backend is decoupled from the ingestor through the **`OcrEngine`** protocol. Tests inject a deterministic `StubOcrEngine`; production users get **`PytesseractOcrEngine`**, which **lazily** imports `pytesseract` / `Pillow` / `pdf2image` so the rest of the package — and the test suite — runs cleanly without the optional dependencies installed.

### Public surface
- **`IMAGE_EXTENSIONS`** — frozenset of the seven supported file extensions (`.png .jpg .jpeg .gif .bmp .tiff .webp`).
- **`OcrResult`** — frozen dataclass: `text`, `confidence` (0-1), optional `page` index, `image_type`.
- **`OcrEngine`** — runtime-checkable `Protocol`; any object exposing the three methods plugs in.
- **`PytesseractOcrEngine`** — production engine. Reports `is_available()` False when deps are missing; raises `PytesseractUnavailableError` with install instructions when `extract_*` is called without them.
- **`detect_image_type`** — filename-token heuristic returning `screenshot`, `photo_of_text`, `diagram`, or `other`.
- **`ImageIngestor`** — concrete `Ingestor` with `discover` / `parse` / `convert_to_markdown` / `generate_frontmatter`, plus `ingest_pdf` for routing scanned PDFs through OCR page by page. Empty-OCR fragments are dropped.

### Wiring
- `creek.ingest` re-exports `ImageIngestor` and registers it in `INGESTOR_REGISTRY` under `"image"`.
- `pyproject.toml` adds an mypy override for `pytesseract` / `PIL` / `pdf2image` so strict type-checking passes without the optional deps installed.

## Test plan

- [x] `./scripts/check-all.sh` — 6/7 gates green (only the dev-container env's pre-existing pip-audit findings remain; CI ignores them via the existing config).
- [x] **24 new tests** in `tests/test_images_ingestor.py` covering:
  - All 7 image extensions discovered (recursive + case-insensitive)
  - Non-image files ignored
  - `parse` produces fragments with `ocr_confidence`, `image_type`, `language`, `original_file`
  - Empty-OCR images yield no fragment
  - `convert_to_markdown` renders the Obsidian image embed first, then OCR text
  - `generate_frontmatter` carries `source.platform=image_ocr` and OCR metadata
  - `ingest_pdf` returns one fragment per non-empty page with `page` index
  - Image-type heuristics: screenshot / photo_of_text / diagram / other
  - `PytesseractOcrEngine.is_available()` returns False without deps
  - `PytesseractUnavailableError` raised with install instructions
- [x] Coverage 94.27% (above 90% threshold)
- [ ] CI: Code Quality & Testing (3.11/3.12/3.13) green
- [ ] Claude review LGTM

Closes #54

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vu1KnoJQDQh4kCLdR6VJTM)_