### PR TITLE
feat(ingest): add read-only Google Drive downloader (#56)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -313,11 +313,7 @@ def gdrive(
         staging if staging is not None else Path(config.google_drive.staging_dir)
     )
 
-    from creek.ingest.gdrive import (
-        GoogleApiDriveClient,
-        GoogleApiUnavailableError,
-        GoogleDriveDownloader,
-    )
+    from creek.ingest.gdrive import GoogleApiDriveClient, GoogleDriveDownloader
 
     client = GoogleApiDriveClient(config.google_drive)
     if not client.is_available():
@@ -331,15 +327,13 @@ def gdrive(
     downloader = GoogleDriveDownloader(client=client, config=config.google_drive)
     try:
         result = downloader.download_all(staging_dir)
-    except GoogleApiUnavailableError as exc:
-        console.print(f"[red]Google Drive download failed: {exc}[/red]")
-        raise typer.Exit(code=1) from exc
     except Exception as exc:
-        # Drive surface includes HttpError (quota / rate limit / revoked
-        # token), network IOErrors, OAuth failures. We can't import
-        # googleapiclient.errors at module top-level since it's optional,
-        # so catch broadly here and present a clean message rather than
-        # a raw traceback.
+        # Drive surface includes GoogleApiUnavailableError (missing
+        # optional deps), HttpError (quota / rate limit / revoked
+        # token), network IOErrors, and OAuth failures. We can't
+        # import googleapiclient.errors at module top-level since
+        # it's optional, so catch broadly here and present a clean
+        # message rather than a raw traceback.
         console.print(f"[red]Google Drive download failed: {exc}[/red]")
         raise typer.Exit(code=1) from exc
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -291,9 +291,48 @@ def gdrive(
     download: bool = typer.Option(False, help="Download from Google Drive"),
     staging: Path | None = typer.Option(None, help="Staging directory"),
 ) -> None:
-    """Download from Google Drive."""
+    """Download files from Google Drive into a local staging directory.
+
+    Read-only. Files are mirrored under *staging* with their Drive
+    folder hierarchy preserved; subsequent runs are incremental
+    (unchanged files are skipped). Pipe the staging directory through
+    ``creek ingest`` to absorb the downloads into the vault.
+    """
+    if not download:
+        console.print(
+            "[yellow]Nothing to do. Pass --download to fetch files.[/yellow]",
+        )
+        return
+
+    config = load_config()
+    staging_dir = (
+        staging if staging is not None else Path(config.google_drive.staging_dir)
+    )
+
+    from creek.ingest.gdrive import (
+        GoogleApiDriveClient,
+        GoogleApiUnavailableError,
+        GoogleDriveDownloader,
+    )
+
+    client = GoogleApiDriveClient(config.google_drive)
+    if not client.is_available():
+        console.print(
+            "[red]Google API client unavailable; cannot download from Drive. "
+            "Install with `pip install google-api-python-client "
+            "google-auth-oauthlib`.[/red]",
+        )
+        raise typer.Exit(code=1)
+
+    downloader = GoogleDriveDownloader(client=client, config=config.google_drive)
+    try:
+        paths = downloader.download_all(staging_dir)
+    except GoogleApiUnavailableError as exc:
+        console.print(f"[red]Google Drive download failed: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
     console.print(
-        f"[bold green]Would gdrive: download={download}, staging={staging}[/bold green]"
+        f"[bold green]Downloaded {len(paths)} files to {staging_dir}[/bold green]",
     )
 
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -297,6 +297,10 @@ def gdrive(
     folder hierarchy preserved; subsequent runs are incremental
     (unchanged files are skipped). Pipe the staging directory through
     ``creek ingest`` to absorb the downloads into the vault.
+
+    First run opens a browser window for OAuth authorisation; the
+    refresh token is cached at ``GoogleDriveConfig.token_file`` (mode
+    ``0o600``) so subsequent runs are non-interactive.
     """
     if not download:
         console.print(
@@ -326,13 +330,23 @@ def gdrive(
 
     downloader = GoogleDriveDownloader(client=client, config=config.google_drive)
     try:
-        paths = downloader.download_all(staging_dir)
+        result = downloader.download_all(staging_dir)
     except GoogleApiUnavailableError as exc:
+        console.print(f"[red]Google Drive download failed: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    except Exception as exc:
+        # Drive surface includes HttpError (quota / rate limit / revoked
+        # token), network IOErrors, OAuth failures. We can't import
+        # googleapiclient.errors at module top-level since it's optional,
+        # so catch broadly here and present a clean message rather than
+        # a raw traceback.
         console.print(f"[red]Google Drive download failed: {exc}[/red]")
         raise typer.Exit(code=1) from exc
 
     console.print(
-        f"[bold green]Downloaded {len(paths)} files to {staging_dir}[/bold green]",
+        f"[bold green]Downloaded {len(result.downloaded)} / "
+        f"Skipped {len(result.skipped)} (unchanged) files to "
+        f"{staging_dir}[/bold green]",
     )
 
 

--- a/creek-tools/creek/ingest/__init__.py
+++ b/creek-tools/creek/ingest/__init__.py
@@ -17,6 +17,7 @@ Exports:
     DiscordIngestor: Concrete ingestor for Discord message exports.
     DocumentIngestor: Concrete ingestor for document files (DOCX, PDF, HTML, TXT).
     GenericIngestor: Fallback ingestor for unrecognized file formats.
+    GoogleDriveDownloader: Read-only Google Drive download orchestrator.
     ImageIngestor: Concrete ingestor for image files via OCR.
     MarkdownIngestor: Concrete ingestor for plain Markdown files.
 """
@@ -27,6 +28,7 @@ from creek.ingest.claude import ClaudeIngestor
 from creek.ingest.code import CodeIngestor
 from creek.ingest.discord import DiscordIngestor
 from creek.ingest.documents import DocumentIngestor
+from creek.ingest.gdrive import GoogleDriveDownloader
 from creek.ingest.generic import GenericIngestor
 from creek.ingest.images import ImageIngestor
 from creek.ingest.markdown import MarkdownIngestor
@@ -52,6 +54,7 @@ __all__ = [
     "DiscordIngestor",
     "DocumentIngestor",
     "GenericIngestor",
+    "GoogleDriveDownloader",
     "ImageIngestor",
     "IngestResult",
     "Ingestor",

--- a/creek-tools/creek/ingest/__init__.py
+++ b/creek-tools/creek/ingest/__init__.py
@@ -28,7 +28,13 @@ from creek.ingest.claude import ClaudeIngestor
 from creek.ingest.code import CodeIngestor
 from creek.ingest.discord import DiscordIngestor
 from creek.ingest.documents import DocumentIngestor
-from creek.ingest.gdrive import GoogleDriveDownloader
+from creek.ingest.gdrive import (
+    DriveClient,
+    DriveFile,
+    GoogleApiUnavailableError,
+    GoogleDriveDownloader,
+    route_to_ingestor,
+)
 from creek.ingest.generic import GenericIngestor
 from creek.ingest.images import ImageIngestor
 from creek.ingest.markdown import MarkdownIngestor
@@ -53,7 +59,10 @@ __all__ = [
     "CodeIngestor",
     "DiscordIngestor",
     "DocumentIngestor",
+    "DriveClient",
+    "DriveFile",
     "GenericIngestor",
+    "GoogleApiUnavailableError",
     "GoogleDriveDownloader",
     "ImageIngestor",
     "IngestResult",
@@ -61,4 +70,5 @@ __all__ = [
     "MarkdownIngestor",
     "ParsedFragment",
     "RawDocument",
+    "route_to_ingestor",
 ]

--- a/creek-tools/creek/ingest/__init__.py
+++ b/creek-tools/creek/ingest/__init__.py
@@ -29,6 +29,7 @@ from creek.ingest.code import CodeIngestor
 from creek.ingest.discord import DiscordIngestor
 from creek.ingest.documents import DocumentIngestor
 from creek.ingest.gdrive import (
+    DownloadResult,
     DriveClient,
     DriveFile,
     GoogleApiUnavailableError,
@@ -59,6 +60,7 @@ __all__ = [
     "CodeIngestor",
     "DiscordIngestor",
     "DocumentIngestor",
+    "DownloadResult",
     "DriveClient",
     "DriveFile",
     "GenericIngestor",

--- a/creek-tools/creek/ingest/gdrive.py
+++ b/creek-tools/creek/ingest/gdrive.py
@@ -162,6 +162,26 @@ class GoogleApiUnavailableError(RuntimeError):
     """Raised when a Drive call is made but the API client is not installed."""
 
 
+@dataclass(frozen=True)
+class DownloadResult:
+    """Outcome of a :meth:`GoogleDriveDownloader.download_all` invocation.
+
+    Attributes:
+        downloaded: Paths of files that were freshly fetched (or
+            re-fetched because Drive's modified_time was newer).
+        skipped: Paths of files whose local mtime was at least as new
+            as Drive — the incremental-sync skip set.
+    """
+
+    downloaded: list[Path]
+    skipped: list[Path]
+
+    @property
+    def all_paths(self) -> list[Path]:
+        """Return the union of downloaded + skipped paths in listing order."""
+        return [*self.downloaded, *self.skipped]
+
+
 # ---- Default Drive client ----------------------------------------------
 
 
@@ -486,13 +506,15 @@ class GoogleDriveDownloader:
         drive_file = self._resolve(file_id)
         return self._write(drive_file, staging_dir)
 
-    def download_all(self, staging_dir: Path) -> list[Path]:
+    def download_all(self, staging_dir: Path) -> DownloadResult:
         """Download every file in the listing to *staging_dir*.
 
         Files whose local mtime is at least as new as the Drive
-        ``modified_time`` are skipped (incremental sync). Returns the
-        list of *all* destination paths — both downloaded and skipped
-        — so callers can pipe them through the ingest registry.
+        ``modified_time`` are skipped (incremental sync). Returns a
+        :class:`DownloadResult` with separate ``downloaded`` and
+        ``skipped`` lists; both lists carry the actual on-disk path
+        (including any Google-native export suffix such as ``.docx``)
+        so callers can route them through ``creek ingest`` reliably.
 
         Raises:
             ValueError: When any file's ``parent_path`` would escape
@@ -501,15 +523,16 @@ class GoogleDriveDownloader:
         staging_dir.mkdir(parents=True, exist_ok=True)
         # Refresh cache so download_all always sees latest state.
         listing = self.list_files()
-        paths: list[Path] = []
+        downloaded: list[Path] = []
+        skipped: list[Path] = []
         for drive_file in listing:
             target = self._target_path(drive_file, staging_dir)
             if self._is_up_to_date(target, drive_file):
                 logger.info("Skipping unchanged Drive file: %s", drive_file.name)
-                paths.append(target)
+                skipped.append(self._native_target(target, drive_file))
                 continue
-            paths.append(self._write(drive_file, staging_dir))
-        return paths
+            downloaded.append(self._write(drive_file, staging_dir))
+        return DownloadResult(downloaded=downloaded, skipped=skipped)
 
     def _resolve(self, file_id: str) -> DriveFile:
         """Return the :class:`DriveFile` for *file_id* from the cached listing."""
@@ -595,6 +618,7 @@ __all__ = [
     "GOOGLE_DOCS_MIME",
     "GOOGLE_SHEETS_MIME",
     "GOOGLE_SLIDES_MIME",
+    "DownloadResult",
     "DriveClient",
     "DriveFile",
     "GoogleApiDriveClient",

--- a/creek-tools/creek/ingest/gdrive.py
+++ b/creek-tools/creek/ingest/gdrive.py
@@ -36,7 +36,6 @@ Without these the module still imports cleanly and the
 
 from __future__ import annotations
 
-import ast
 import logging
 import os
 import stat
@@ -327,11 +326,27 @@ class GoogleApiDriveClient:
             else service.files().get_media(fileId=file_id)
         )
         destination.parent.mkdir(parents=True, exist_ok=True)
-        with destination.open("wb") as handle:
-            downloader = MediaIoBaseDownload(handle, request, chunksize=1024 * 1024)
-            done = False
-            while not done:
-                _status, done = downloader.next_chunk()
+        # Write to a sibling temp file and atomically rename on success.
+        # If next_chunk() raises mid-stream, the destination is never
+        # touched — the local mtime stays correctly older than Drive's
+        # modified_time so the file is re-downloaded on the next run
+        # rather than silently treated as up-to-date.
+        tmp_path = destination.with_name(destination.name + ".download.tmp")
+        try:
+            with tmp_path.open("wb") as handle:
+                downloader = MediaIoBaseDownload(
+                    handle,
+                    request,
+                    chunksize=1024 * 1024,
+                )
+                done = False
+                while not done:
+                    _status, done = downloader.next_chunk()
+            os.replace(tmp_path, destination)
+        except BaseException:
+            if tmp_path.exists():
+                tmp_path.unlink()
+            raise
 
     def _get_service(self) -> Any:
         """Build (or return cached) Drive API service.
@@ -471,29 +486,6 @@ def _write_token_file(path: Path, contents: str) -> None:
         raise
 
 
-_FORBIDDEN_DRIVE_METHODS: frozenset[str] = frozenset(
-    {"update", "delete", "trash", "copy"},
-)
-
-
-def _audit_no_write_calls(source: str) -> None:
-    """Raise :class:`AssertionError` if *source* calls a forbidden Drive method.
-
-    AST-based: ignores method names that appear inside docstrings,
-    string literals, or comments. Only flags real call sites such as
-    ``service.files().delete(...)``. Used by the test suite to keep
-    the read-only contract enforced as the module evolves.
-    """
-    tree = ast.parse(source)
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        if isinstance(func, ast.Attribute) and func.attr in _FORBIDDEN_DRIVE_METHODS:
-            msg = f"Forbidden write call detected: {func.attr}() at line {node.lineno}"
-            raise AssertionError(msg)
-
-
 # ---- Routing helper ----------------------------------------------------
 
 
@@ -631,19 +623,30 @@ class GoogleDriveDownloader:
         raise KeyError(msg)
 
     def _write(self, drive_file: DriveFile, staging_dir: Path) -> Path:
-        """Stream *drive_file* to disk under *staging_dir* and return the path."""
+        """Stream *drive_file* to disk under *staging_dir* and return the path.
+
+        Writes are guarded so a failed ``download_to`` never leaves a
+        partial file at the final path — without this, a stale partial
+        whose mtime is now would shadow Drive's older ``modified_time``
+        and be treated as up-to-date forever after.
+        """
         target = self._target_path(drive_file, staging_dir)
         target.parent.mkdir(parents=True, exist_ok=True)
         if drive_file.is_google_native:
             export_mime, suffix = _NATIVE_EXPORT_TARGETS[drive_file.mime_type]
             target = target.with_name(target.stem + suffix)
+        else:
+            export_mime = None
+        try:
             self.client.download_to(
                 drive_file.id,
                 target,
                 export_mime=export_mime,
             )
-        else:
-            self.client.download_to(drive_file.id, target)
+        except BaseException:
+            if target.exists():
+                target.unlink()
+            raise
         timestamp = drive_file.modified_time.timestamp()
         os.utime(target, (timestamp, timestamp))
         return target

--- a/creek-tools/creek/ingest/gdrive.py
+++ b/creek-tools/creek/ingest/gdrive.py
@@ -1,0 +1,441 @@
+"""Read-only Google Drive downloader for the Creek ingest pipeline.
+
+Implements §3.4 of the Creek Ontology — a download-first, read-only
+architecture that pulls files from a user's Google Drive into a local
+staging directory, then hands them off to the regular ingestor
+pipeline. The downloader **never** writes back to Drive: there is no
+``update``, ``delete``, ``trash``, or ``copy`` call anywhere in this
+module, and the :class:`DriveClient` Protocol exposes only read
+methods so future refactors cannot sneak a write in by accident.
+
+Architecture:
+
+* :class:`DriveClient` — Protocol with ``list_files``, ``get_media``,
+  ``export_media``, and ``is_available``. Tests inject a deterministic
+  stub; production code uses :class:`GoogleApiDriveClient`.
+* :class:`GoogleApiDriveClient` — concrete implementation that lazily
+  imports ``googleapiclient`` and ``google_auth_oauthlib``. Raises
+  :class:`GoogleApiUnavailableError` with actionable install
+  instructions when the optional dependencies are missing.
+* :class:`GoogleDriveDownloader` — orchestrator. Mirrors the local
+  filesystem: ``DriveFile.parent_path`` becomes a sub-directory under
+  the staging root. Skips files whose local mtime is at least as new
+  as the Drive ``modified_time`` for incremental sync.
+* :func:`route_to_ingestor` — maps a downloaded file's extension to
+  the canonical Creek ingestor key (``markdown``, ``document``,
+  ``image``, ``spreadsheet``, ``presentation``, or ``generic``).
+
+Optional dependencies (install separately to enable real downloads):
+
+* ``google-api-python-client`` — Drive API client.
+* ``google-auth-oauthlib`` — OAuth2 flow helpers.
+
+Without these the module still imports cleanly and the
+:class:`GoogleDriveDownloader` accepts any :class:`DriveClient` stub.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from creek.config import GoogleDriveConfig
+
+
+logger = logging.getLogger(__name__)
+
+
+GOOGLE_DOCS_MIME: str = "application/vnd.google-apps.document"
+"""Mime type returned by the Drive API for native Google Docs."""
+
+GOOGLE_SHEETS_MIME: str = "application/vnd.google-apps.spreadsheet"
+"""Mime type returned by the Drive API for native Google Sheets."""
+
+GOOGLE_SLIDES_MIME: str = "application/vnd.google-apps.presentation"
+"""Mime type returned by the Drive API for native Google Slides."""
+
+
+_GOOGLE_NATIVE_MIMES: frozenset[str] = frozenset(
+    {GOOGLE_DOCS_MIME, GOOGLE_SHEETS_MIME, GOOGLE_SLIDES_MIME},
+)
+
+
+_DOCX_MIME: str = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
+_XLSX_MIME: str = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+_PPTX_MIME: str = (
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+)
+
+
+_NATIVE_EXPORT_TARGETS: dict[str, tuple[str, str]] = {
+    GOOGLE_DOCS_MIME: (_DOCX_MIME, ".docx"),
+    GOOGLE_SHEETS_MIME: (_XLSX_MIME, ".xlsx"),
+    GOOGLE_SLIDES_MIME: (_PPTX_MIME, ".pptx"),
+}
+"""Per-native-mime: (export mime type, export filename suffix)."""
+
+
+_INGESTOR_BY_EXTENSION: dict[str, str] = {
+    ".md": "markdown",
+    ".markdown": "markdown",
+    ".docx": "document",
+    ".pdf": "document",
+    ".html": "document",
+    ".htm": "document",
+    ".txt": "document",
+    ".rtf": "document",
+    ".xlsx": "spreadsheet",
+    ".csv": "spreadsheet",
+    ".pptx": "presentation",
+    ".png": "image",
+    ".jpg": "image",
+    ".jpeg": "image",
+    ".gif": "image",
+    ".bmp": "image",
+    ".tiff": "image",
+    ".webp": "image",
+}
+
+
+# ---- Public dataclasses + protocol -------------------------------------
+
+
+@dataclass(frozen=True)
+class DriveFile:
+    """Lightweight metadata for a single Drive file.
+
+    Attributes:
+        id: Drive file id (used for ``get_media`` / ``export_media``).
+        name: File name as it appears in Drive.
+        mime_type: Drive-reported mime type.
+        modified_time: Drive-reported last-modified timestamp.
+        size: File size in bytes (``0`` for Google-native files).
+        parent_path: Slash-separated logical path of parent folders.
+            Used to mirror Drive folder structure under staging.
+    """
+
+    id: str
+    name: str
+    mime_type: str
+    modified_time: datetime
+    size: int
+    parent_path: str
+
+    @property
+    def is_google_native(self) -> bool:
+        """Return ``True`` for Google Docs / Sheets / Slides."""
+        return self.mime_type in _GOOGLE_NATIVE_MIMES
+
+
+@runtime_checkable
+class DriveClient(Protocol):
+    """Pluggable read-only Drive backend.
+
+    By construction the Protocol exposes no write surface — there is
+    no ``update``, ``delete``, ``trash``, or ``copy`` method. Any
+    implementation that adds one violates the read-only contract.
+    """
+
+    def is_available(self) -> bool:
+        """Return ``True`` when the backend can serve requests."""
+
+    def list_files(self) -> list[DriveFile]:
+        """Return every file visible to the configured credentials."""
+
+    def get_media(self, file_id: str) -> bytes:
+        """Download the raw bytes of a non-Google-native file."""
+
+    def export_media(self, file_id: str, mime_type: str) -> bytes:
+        """Export a Google-native file to *mime_type* and return bytes."""
+
+
+class GoogleApiUnavailableError(RuntimeError):
+    """Raised when a Drive call is made but the API client is not installed."""
+
+
+# ---- Default Drive client ----------------------------------------------
+
+
+class GoogleApiDriveClient:
+    """Drive client backed by ``google-api-python-client``.
+
+    Imports of the optional Google libraries are deferred to call
+    time so the rest of the package — and the unit tests — run on
+    systems without ``google-api-python-client`` installed.
+
+    Attributes:
+        config: :class:`GoogleDriveConfig` carrying credentials path,
+            cached token path, and scopes (which the model already
+            validates as read-only).
+    """
+
+    def __init__(self, config: GoogleDriveConfig) -> None:
+        """Initialise with a read-only-validated config."""
+        self.config = config
+        self._service: Any = None
+
+    def is_available(self) -> bool:
+        """Return ``True`` when the optional Google libs import cleanly."""
+        try:
+            import google_auth_oauthlib.flow  # noqa: F401
+            import googleapiclient.discovery  # noqa: F401
+        except ImportError:
+            return False
+        return True
+
+    def list_files(self) -> list[DriveFile]:
+        """List every Drive file visible to the credentials.
+
+        Raises:
+            GoogleApiUnavailableError: When the optional Google
+                libraries are not installed.
+        """
+        service = self._get_service()
+        files: list[DriveFile] = []
+        page_token: str | None = None
+        while True:
+            response: dict[str, Any] = (
+                service.files()
+                .list(
+                    pageSize=200,
+                    fields=(
+                        "nextPageToken, files(id, name, mimeType, "
+                        "modifiedTime, size, parents)"
+                    ),
+                    pageToken=page_token,
+                )
+                .execute()
+            )
+            for raw in response.get("files", []):
+                files.append(_drive_file_from_raw(raw))
+            page_token = response.get("nextPageToken")
+            if not page_token:
+                break
+        return files
+
+    def get_media(self, file_id: str) -> bytes:
+        """Download raw media for a non-Google-native Drive file."""
+        service = self._get_service()
+        return bytes(service.files().get_media(fileId=file_id).execute())
+
+    def export_media(self, file_id: str, mime_type: str) -> bytes:
+        """Export a Google-native file to *mime_type* and return bytes."""
+        service = self._get_service()
+        return bytes(
+            service.files().export_media(fileId=file_id, mimeType=mime_type).execute(),
+        )
+
+    def _get_service(self) -> Any:
+        """Build (or return cached) Drive API service.
+
+        The OAuth flow caches credentials at
+        :attr:`GoogleDriveConfig.token_file` so subsequent runs skip
+        the browser dance.
+
+        Raises:
+            GoogleApiUnavailableError: When the optional Google
+                libraries are not installed.
+        """
+        if self._service is not None:
+            return self._service
+        try:
+            from google.auth.transport.requests import Request
+            from google.oauth2.credentials import Credentials
+            from google_auth_oauthlib.flow import InstalledAppFlow
+            from googleapiclient.discovery import build
+        except ImportError as exc:
+            msg = (
+                "google-api-python-client and google-auth-oauthlib are "
+                "required for Google Drive downloads. Install them with "
+                "`pip install google-api-python-client google-auth-oauthlib`."
+            )
+            raise GoogleApiUnavailableError(msg) from exc
+
+        creds = None
+        token_path = Path(self.config.token_file)
+        if token_path.exists():
+            creds = Credentials.from_authorized_user_file(
+                str(token_path),
+                self.config.scopes,
+            )
+        if creds is None or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    self.config.credentials_file,
+                    self.config.scopes,
+                )
+                creds = flow.run_local_server(port=0)
+            token_path.write_text(creds.to_json(), encoding="utf-8")
+        self._service = build("drive", "v3", credentials=creds)
+        return self._service
+
+
+def _drive_file_from_raw(raw: dict[str, Any]) -> DriveFile:
+    """Convert a Drive API ``files.list`` row into a :class:`DriveFile`."""
+    modified_str = str(raw.get("modifiedTime", "1970-01-01T00:00:00Z"))
+    if modified_str.endswith("Z"):
+        modified_str = modified_str[:-1] + "+00:00"
+    modified = datetime.fromisoformat(modified_str)
+    if modified.tzinfo is None:
+        modified = modified.replace(tzinfo=UTC)
+    return DriveFile(
+        id=str(raw["id"]),
+        name=str(raw["name"]),
+        mime_type=str(raw.get("mimeType", "application/octet-stream")),
+        modified_time=modified,
+        size=int(raw.get("size", 0)),
+        parent_path="",
+    )
+
+
+# ---- Routing helper ----------------------------------------------------
+
+
+def route_to_ingestor(path: Path) -> str:
+    """Return the Creek ingestor key for *path* by file extension.
+
+    Falls back to the ``generic`` ingestor for unrecognised
+    extensions, matching the existing :data:`INGESTOR_REGISTRY` keys
+    in :mod:`creek.ingest`.
+    """
+    return _INGESTOR_BY_EXTENSION.get(path.suffix.lower(), "generic")
+
+
+# ---- Downloader --------------------------------------------------------
+
+
+class GoogleDriveDownloader:
+    """Orchestrate a read-only download of every file in Drive.
+
+    Mirrors the user's Drive folder hierarchy under the staging
+    directory (:attr:`DriveFile.parent_path` becomes a relative
+    sub-path). Subsequent runs are incremental: a file is re-downloaded
+    only when the Drive ``modified_time`` is newer than the local
+    file's mtime.
+
+    Attributes:
+        client: Pluggable :class:`DriveClient`. Tests inject a stub;
+            production passes a :class:`GoogleApiDriveClient`.
+        config: :class:`GoogleDriveConfig` with read-only scopes.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: DriveClient,
+        config: GoogleDriveConfig,
+    ) -> None:
+        """Initialise with the client and config."""
+        self.client = client
+        self.config = config
+
+    def list_files(self) -> list[DriveFile]:
+        """Proxy ``client.list_files()`` so callers can preview a sync."""
+        return self.client.list_files()
+
+    def download_file(self, file_id: str, staging_dir: Path) -> Path:
+        """Download a single file by id and return the local path.
+
+        Args:
+            file_id: Drive file id.
+            staging_dir: Directory under which the downloaded file is
+                written. Subdirectories matching the file's
+                :attr:`DriveFile.parent_path` are created on demand.
+
+        Returns:
+            Absolute path to the written file.
+
+        Raises:
+            KeyError: When *file_id* is not in the current listing.
+        """
+        drive_file = self._resolve(file_id)
+        return self._write(drive_file, staging_dir)
+
+    def download_all(self, staging_dir: Path) -> list[Path]:
+        """Download every file in the listing to *staging_dir*.
+
+        Files whose local mtime is at least as new as the Drive
+        ``modified_time`` are skipped (incremental sync). Returns the
+        list of *all* destination paths — both downloaded and skipped
+        — so callers can pipe them through the ingest registry.
+        """
+        staging_dir.mkdir(parents=True, exist_ok=True)
+        paths: list[Path] = []
+        for drive_file in self.client.list_files():
+            target = self._target_path(drive_file, staging_dir)
+            if self._is_up_to_date(target, drive_file):
+                logger.info("Skipping unchanged Drive file: %s", drive_file.name)
+                paths.append(target)
+                continue
+            paths.append(self._write(drive_file, staging_dir))
+        return paths
+
+    def _resolve(self, file_id: str) -> DriveFile:
+        """Return the :class:`DriveFile` for *file_id* from the listing."""
+        for candidate in self.client.list_files():
+            if candidate.id == file_id:
+                return candidate
+        msg = f"missing Drive file id: {file_id!r}"
+        raise KeyError(msg)
+
+    def _write(self, drive_file: DriveFile, staging_dir: Path) -> Path:
+        """Fetch bytes for *drive_file* and persist them under *staging_dir*."""
+        target = self._target_path(drive_file, staging_dir)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if drive_file.is_google_native:
+            export_mime, suffix = _NATIVE_EXPORT_TARGETS[drive_file.mime_type]
+            data = self.client.export_media(drive_file.id, export_mime)
+            target = target.with_name(target.stem + suffix)
+        else:
+            data = self.client.get_media(drive_file.id)
+        target.write_bytes(data)
+        timestamp = drive_file.modified_time.timestamp()
+        os.utime(target, (timestamp, timestamp))
+        return target
+
+    @staticmethod
+    def _target_path(drive_file: DriveFile, staging_dir: Path) -> Path:
+        """Return the destination path for *drive_file* under *staging_dir*."""
+        if drive_file.parent_path:
+            parent = staging_dir / Path(drive_file.parent_path)
+        else:
+            parent = staging_dir
+        return parent / drive_file.name
+
+    def _is_up_to_date(self, target: Path, drive_file: DriveFile) -> bool:
+        """Return ``True`` when the local file is at least as new as Drive."""
+        actual = self._native_target(target, drive_file)
+        if not actual.exists():
+            return False
+        local_mtime = datetime.fromtimestamp(actual.stat().st_mtime, tz=UTC)
+        return local_mtime >= drive_file.modified_time
+
+    @staticmethod
+    def _native_target(target: Path, drive_file: DriveFile) -> Path:
+        """Return the actual on-disk path for *drive_file* (incl. export suffix)."""
+        if not drive_file.is_google_native:
+            return target
+        _, suffix = _NATIVE_EXPORT_TARGETS[drive_file.mime_type]
+        return target.with_name(target.stem + suffix)
+
+
+__all__ = [
+    "GOOGLE_DOCS_MIME",
+    "GOOGLE_SHEETS_MIME",
+    "GOOGLE_SLIDES_MIME",
+    "DriveClient",
+    "DriveFile",
+    "GoogleApiDriveClient",
+    "GoogleApiUnavailableError",
+    "GoogleDriveDownloader",
+    "route_to_ingestor",
+]

--- a/creek-tools/creek/ingest/gdrive.py
+++ b/creek-tools/creek/ingest/gdrive.py
@@ -10,9 +10,9 @@ methods so future refactors cannot sneak a write in by accident.
 
 Architecture:
 
-* :class:`DriveClient` — Protocol with ``list_files``, ``get_media``,
-  ``export_media``, and ``is_available``. Tests inject a deterministic
-  stub; production code uses :class:`GoogleApiDriveClient`.
+* :class:`DriveClient` — Protocol with ``list_files``, ``download_to``,
+  and ``is_available``. Tests inject a deterministic stub; production
+  code uses :class:`GoogleApiDriveClient`.
 * :class:`GoogleApiDriveClient` — concrete implementation that lazily
   imports ``googleapiclient`` and ``google_auth_oauthlib``. Raises
   :class:`GoogleApiUnavailableError` with actionable install
@@ -114,7 +114,7 @@ class DriveFile:
     """Lightweight metadata for a single Drive file.
 
     Attributes:
-        id: Drive file id (used for ``get_media`` / ``export_media``).
+        id: Drive file id (used for ``download_to``).
         name: File name as it appears in Drive.
         mime_type: Drive-reported mime type.
         modified_time: Drive-reported last-modified timestamp.
@@ -143,6 +143,10 @@ class DriveClient(Protocol):
     By construction the Protocol exposes no write surface — there is
     no ``update``, ``delete``, ``trash``, or ``copy`` method. Any
     implementation that adds one violates the read-only contract.
+
+    Downloads are streamed straight to disk via :meth:`download_to`
+    rather than collected to ``bytes``; callers do not need to hold
+    a full file in memory regardless of size.
     """
 
     def is_available(self) -> bool:
@@ -151,11 +155,19 @@ class DriveClient(Protocol):
     def list_files(self) -> list[DriveFile]:
         """Return every file visible to the configured credentials."""
 
-    def get_media(self, file_id: str) -> bytes:
-        """Download the raw bytes of a non-Google-native file."""
+    def download_to(
+        self,
+        file_id: str,
+        destination: Path,
+        *,
+        export_mime: str | None = None,
+    ) -> None:
+        """Stream *file_id* to *destination*.
 
-    def export_media(self, file_id: str, mime_type: str) -> bytes:
-        """Export a Google-native file to *mime_type* and return bytes."""
+        When *export_mime* is provided the file is treated as a
+        Google-native document and exported to that mime type;
+        otherwise the raw media is downloaded.
+        """
 
 
 class GoogleApiUnavailableError(RuntimeError):
@@ -166,20 +178,29 @@ class GoogleApiUnavailableError(RuntimeError):
 class DownloadResult:
     """Outcome of a :meth:`GoogleDriveDownloader.download_all` invocation.
 
+    Tuples (not lists) so the value object is fully immutable —
+    ``frozen=True`` would otherwise still allow callers to
+    ``result.downloaded.append(...)``.
+
     Attributes:
         downloaded: Paths of files that were freshly fetched (or
             re-fetched because Drive's modified_time was newer).
         skipped: Paths of files whose local mtime was at least as new
             as Drive — the incremental-sync skip set.
+        errors: ``(DriveFile, exception)`` pairs for any per-file
+            download that failed mid-loop. ``download_all`` records
+            each failure and continues so a transient quota/network
+            error mid-sync does not abandon the rest of the run.
     """
 
-    downloaded: list[Path]
-    skipped: list[Path]
+    downloaded: tuple[Path, ...]
+    skipped: tuple[Path, ...]
+    errors: tuple[tuple[DriveFile, Exception], ...] = ()
 
     @property
-    def all_paths(self) -> list[Path]:
+    def all_paths(self) -> tuple[Path, ...]:
         """Return the union of downloaded + skipped paths in listing order."""
-        return [*self.downloaded, *self.skipped]
+        return (*self.downloaded, *self.skipped)
 
 
 # ---- Default Drive client ----------------------------------------------
@@ -266,17 +287,51 @@ class GoogleApiDriveClient:
                 break
         return results
 
-    def get_media(self, file_id: str) -> bytes:
-        """Download raw media for a non-Google-native Drive file."""
-        service = self._get_service()
-        return bytes(service.files().get_media(fileId=file_id).execute())
+    def download_to(
+        self,
+        file_id: str,
+        destination: Path,
+        *,
+        export_mime: str | None = None,
+    ) -> None:
+        """Stream *file_id* to *destination* in chunks.
 
-    def export_media(self, file_id: str, mime_type: str) -> bytes:
-        """Export a Google-native file to *mime_type* and return bytes."""
+        Uses :class:`googleapiclient.http.MediaIoBaseDownload` so
+        large files (videos, multi-MB scans) are written in 1 MiB
+        chunks rather than collected into a single ``bytes`` object
+        in memory.
+
+        Args:
+            file_id: Drive file id.
+            destination: Local filesystem destination.
+            export_mime: Mime type to export to for Google-native
+                files. ``None`` issues a raw ``get_media`` request.
+
+        Raises:
+            GoogleApiUnavailableError: When the optional Google
+                libraries are not installed.
+        """
+        try:
+            from googleapiclient.http import MediaIoBaseDownload
+        except ImportError as exc:
+            msg = (
+                "google-api-python-client is required for Drive downloads. "
+                "Install it with `pip install google-api-python-client`."
+            )
+            raise GoogleApiUnavailableError(msg) from exc
+
         service = self._get_service()
-        return bytes(
-            service.files().export_media(fileId=file_id, mimeType=mime_type).execute(),
+        request = (
+            service.files().export_media(fileId=file_id, mimeType=export_mime)
+            if export_mime is not None
+            else service.files().get_media(fileId=file_id)
         )
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        with destination.open("wb") as handle:
+            downloader = MediaIoBaseDownload(handle, request, chunksize=1024 * 1024)
+            done = False
+            while not done:
+                _status, done = downloader.next_chunk()
 
     def _get_service(self) -> Any:
         """Build (or return cached) Drive API service.
@@ -390,20 +445,30 @@ def _write_token_file(path: Path, contents: str) -> None:
     """Write *contents* to *path* with owner-only (``0o600``) permissions.
 
     The OAuth refresh token grants long-lived Drive access; a default
-    ``0o644`` umask would leave it group/world readable. Using
-    :func:`os.open` with mode ``0o600`` makes the file owner-only on
-    creation and atomically truncates an existing file.
+    ``0o644`` umask would leave it group/world readable. The function
+    writes a fresh ``0o600`` sibling temp file and then ``os.replace``
+    s it atomically over *path*. ``os.replace`` is the rename system
+    call on POSIX, so the new file's mode (``0o600``) replaces the old
+    file's mode in one step — closing the brief TOCTOU window that an
+    in-place truncate-then-chmod sequence would leave open.
     """
+    tmp_path = path.with_name(path.name + ".tmp")
+    # The mode argument to os.open applies only when O_CREAT actually
+    # creates the file; combined with the unique tmp_path that means
+    # the new file is owner-only from byte zero.
     fd = os.open(
-        path,
+        tmp_path,
         os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
         stat.S_IRUSR | stat.S_IWUSR,
     )
-    with os.fdopen(fd, "w", encoding="utf-8") as handle:
-        handle.write(contents)
-    # Re-chmod in case the file already existed (O_CREAT mode is
-    # ignored by os.open when the file is not newly created).
-    path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(contents)
+        os.replace(tmp_path, path)
+    except BaseException:
+        if tmp_path.exists():
+            tmp_path.unlink()
+        raise
 
 
 _FORBIDDEN_DRIVE_METHODS: frozenset[str] = frozenset(
@@ -511,10 +576,18 @@ class GoogleDriveDownloader:
 
         Files whose local mtime is at least as new as the Drive
         ``modified_time`` are skipped (incremental sync). Returns a
-        :class:`DownloadResult` with separate ``downloaded`` and
-        ``skipped`` lists; both lists carry the actual on-disk path
-        (including any Google-native export suffix such as ``.docx``)
-        so callers can route them through ``creek ingest`` reliably.
+        :class:`DownloadResult` with separate ``downloaded`` /
+        ``skipped`` / ``errors`` tuples; the path tuples carry the
+        actual on-disk path (including any Google-native export suffix
+        such as ``.docx``) so callers can route them through
+        ``creek ingest`` reliably.
+
+        Per-file errors are recorded into ``DownloadResult.errors``
+        and the loop continues, so a transient quota or network blip
+        on file N does not abandon the remaining files. The
+        path-traversal guard still raises eagerly because malicious
+        ``parent_path`` is a configuration bug, not a transient
+        condition.
 
         Raises:
             ValueError: When any file's ``parent_path`` would escape
@@ -525,14 +598,27 @@ class GoogleDriveDownloader:
         listing = self.list_files()
         downloaded: list[Path] = []
         skipped: list[Path] = []
+        errors: list[tuple[DriveFile, Exception]] = []
         for drive_file in listing:
             target = self._target_path(drive_file, staging_dir)
             if self._is_up_to_date(target, drive_file):
                 logger.info("Skipping unchanged Drive file: %s", drive_file.name)
                 skipped.append(self._native_target(target, drive_file))
                 continue
-            downloaded.append(self._write(drive_file, staging_dir))
-        return DownloadResult(downloaded=downloaded, skipped=skipped)
+            try:
+                downloaded.append(self._write(drive_file, staging_dir))
+            except Exception as exc:
+                logger.warning(
+                    "Drive download failed for %s: %s",
+                    drive_file.name,
+                    exc,
+                )
+                errors.append((drive_file, exc))
+        return DownloadResult(
+            downloaded=tuple(downloaded),
+            skipped=tuple(skipped),
+            errors=tuple(errors),
+        )
 
     def _resolve(self, file_id: str) -> DriveFile:
         """Return the :class:`DriveFile` for *file_id* from the cached listing."""
@@ -545,16 +631,19 @@ class GoogleDriveDownloader:
         raise KeyError(msg)
 
     def _write(self, drive_file: DriveFile, staging_dir: Path) -> Path:
-        """Fetch bytes for *drive_file* and persist them under *staging_dir*."""
+        """Stream *drive_file* to disk under *staging_dir* and return the path."""
         target = self._target_path(drive_file, staging_dir)
         target.parent.mkdir(parents=True, exist_ok=True)
         if drive_file.is_google_native:
             export_mime, suffix = _NATIVE_EXPORT_TARGETS[drive_file.mime_type]
-            data = self.client.export_media(drive_file.id, export_mime)
             target = target.with_name(target.stem + suffix)
+            self.client.download_to(
+                drive_file.id,
+                target,
+                export_mime=export_mime,
+            )
         else:
-            data = self.client.get_media(drive_file.id)
-        target.write_bytes(data)
+            self.client.download_to(drive_file.id, target)
         timestamp = drive_file.modified_time.timestamp()
         os.utime(target, (timestamp, timestamp))
         return target

--- a/creek-tools/creek/ingest/gdrive.py
+++ b/creek-tools/creek/ingest/gdrive.py
@@ -36,8 +36,10 @@ Without these the module still imports cleanly and the
 
 from __future__ import annotations
 
+import ast
 import logging
 import os
+import stat
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -193,32 +195,56 @@ class GoogleApiDriveClient:
     def list_files(self) -> list[DriveFile]:
         """List every Drive file visible to the credentials.
 
+        First enumerates folders so each file's ``parents[0]`` id can
+        be resolved into a slash-separated path, then enumerates files
+        and stamps the resolved path onto every :class:`DriveFile`.
+
         Raises:
             GoogleApiUnavailableError: When the optional Google
                 libraries are not installed.
         """
         service = self._get_service()
-        files: list[DriveFile] = []
+        folders = self._list_raw(
+            service,
+            query="mimeType='application/vnd.google-apps.folder' and trashed=false",
+            fields="nextPageToken, files(id, name, parents)",
+        )
+        folder_paths = _resolve_folder_paths(folders)
+        files = self._list_raw(
+            service,
+            query="mimeType!='application/vnd.google-apps.folder' and trashed=false",
+            fields=(
+                "nextPageToken, files(id, name, mimeType, modifiedTime, size, parents)"
+            ),
+        )
+        return [_drive_file_from_raw(raw, folder_paths) for raw in files]
+
+    @staticmethod
+    def _list_raw(
+        service: Any,
+        *,
+        query: str,
+        fields: str,
+    ) -> list[dict[str, Any]]:
+        """Page through ``service.files().list`` returning raw dicts."""
+        results: list[dict[str, Any]] = []
         page_token: str | None = None
         while True:
             response: dict[str, Any] = (
                 service.files()
                 .list(
-                    pageSize=200,
-                    fields=(
-                        "nextPageToken, files(id, name, mimeType, "
-                        "modifiedTime, size, parents)"
-                    ),
+                    q=query,
+                    pageSize=1000,
+                    fields=fields,
                     pageToken=page_token,
                 )
                 .execute()
             )
-            for raw in response.get("files", []):
-                files.append(_drive_file_from_raw(raw))
+            results.extend(response.get("files", []))
             page_token = response.get("nextPageToken")
             if not page_token:
                 break
-        return files
+        return results
 
     def get_media(self, file_id: str) -> bytes:
         """Download raw media for a non-Google-native Drive file."""
@@ -274,27 +300,113 @@ class GoogleApiDriveClient:
                     self.config.scopes,
                 )
                 creds = flow.run_local_server(port=0)
-            token_path.write_text(creds.to_json(), encoding="utf-8")
+            _write_token_file(token_path, creds.to_json())
         self._service = build("drive", "v3", credentials=creds)
         return self._service
 
 
-def _drive_file_from_raw(raw: dict[str, Any]) -> DriveFile:
-    """Convert a Drive API ``files.list`` row into a :class:`DriveFile`."""
+def _drive_file_from_raw(
+    raw: dict[str, Any],
+    folder_paths: dict[str, str],
+) -> DriveFile:
+    """Convert a Drive API ``files.list`` row into a :class:`DriveFile`.
+
+    *folder_paths* maps folder ids to slash-separated paths and is
+    produced by :func:`_resolve_folder_paths`. The file's first parent
+    id (Drive supports multi-parenting; we use the first) is looked up
+    to build :attr:`DriveFile.parent_path`. Files at the Drive root
+    keep ``parent_path = ""``.
+    """
     modified_str = str(raw.get("modifiedTime", "1970-01-01T00:00:00Z"))
     if modified_str.endswith("Z"):
         modified_str = modified_str[:-1] + "+00:00"
     modified = datetime.fromisoformat(modified_str)
     if modified.tzinfo is None:
         modified = modified.replace(tzinfo=UTC)
+    parents = raw.get("parents") or []
+    parent_path = folder_paths.get(parents[0], "") if parents else ""
     return DriveFile(
         id=str(raw["id"]),
         name=str(raw["name"]),
         mime_type=str(raw.get("mimeType", "application/octet-stream")),
         modified_time=modified,
         size=int(raw.get("size", 0)),
-        parent_path="",
+        parent_path=parent_path,
     )
+
+
+def _resolve_folder_paths(folders: list[dict[str, Any]]) -> dict[str, str]:
+    """Walk a flat folder listing into ``{folder_id: slash-path}``.
+
+    Folders whose declared parent is not in the visible listing
+    (orphans — usually shared folders above the visible root) are
+    anchored at their own name rather than being skipped, so files
+    inside them still mirror correctly under the staging root.
+    """
+    by_id: dict[str, dict[str, Any]] = {str(f["id"]): f for f in folders}
+    paths: dict[str, str] = {}
+
+    def _walk(folder_id: str, seen: frozenset[str]) -> str:
+        if folder_id in paths:
+            return paths[folder_id]
+        if folder_id in seen or folder_id not in by_id:
+            return ""
+        folder = by_id[folder_id]
+        parents = folder.get("parents") or []
+        if parents and parents[0] in by_id:
+            prefix = _walk(parents[0], seen | {folder_id})
+            path = f"{prefix}/{folder['name']}" if prefix else str(folder["name"])
+        else:
+            path = str(folder["name"])
+        paths[folder_id] = path
+        return path
+
+    for folder_id in by_id:
+        _walk(folder_id, frozenset())
+    return paths
+
+
+def _write_token_file(path: Path, contents: str) -> None:
+    """Write *contents* to *path* with owner-only (``0o600``) permissions.
+
+    The OAuth refresh token grants long-lived Drive access; a default
+    ``0o644`` umask would leave it group/world readable. Using
+    :func:`os.open` with mode ``0o600`` makes the file owner-only on
+    creation and atomically truncates an existing file.
+    """
+    fd = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+        stat.S_IRUSR | stat.S_IWUSR,
+    )
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(contents)
+    # Re-chmod in case the file already existed (O_CREAT mode is
+    # ignored by os.open when the file is not newly created).
+    path.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+
+_FORBIDDEN_DRIVE_METHODS: frozenset[str] = frozenset(
+    {"update", "delete", "trash", "copy"},
+)
+
+
+def _audit_no_write_calls(source: str) -> None:
+    """Raise :class:`AssertionError` if *source* calls a forbidden Drive method.
+
+    AST-based: ignores method names that appear inside docstrings,
+    string literals, or comments. Only flags real call sites such as
+    ``service.files().delete(...)``. Used by the test suite to keep
+    the read-only contract enforced as the module evolves.
+    """
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr in _FORBIDDEN_DRIVE_METHODS:
+            msg = f"Forbidden write call detected: {func.attr}() at line {node.lineno}"
+            raise AssertionError(msg)
 
 
 # ---- Routing helper ----------------------------------------------------
@@ -337,13 +449,25 @@ class GoogleDriveDownloader:
         """Initialise with the client and config."""
         self.client = client
         self.config = config
+        self._listing_cache: list[DriveFile] | None = None
 
     def list_files(self) -> list[DriveFile]:
-        """Proxy ``client.list_files()`` so callers can preview a sync."""
-        return self.client.list_files()
+        """Return a fresh listing of every Drive file.
+
+        Always passes through to the client so callers see live state;
+        the cache used by :meth:`download_file` is populated as a side
+        effect so subsequent single-file downloads reuse this snapshot.
+        """
+        listing = self.client.list_files()
+        self._listing_cache = listing
+        return listing
 
     def download_file(self, file_id: str, staging_dir: Path) -> Path:
         """Download a single file by id and return the local path.
+
+        Reuses the cached listing if one exists (lazily populated on
+        first call) so a loop of ``download_file`` calls makes only one
+        ``list_files`` API request.
 
         Args:
             file_id: Drive file id.
@@ -356,6 +480,8 @@ class GoogleDriveDownloader:
 
         Raises:
             KeyError: When *file_id* is not in the current listing.
+            ValueError: When the file's ``parent_path`` would escape
+                *staging_dir* (path-traversal guard).
         """
         drive_file = self._resolve(file_id)
         return self._write(drive_file, staging_dir)
@@ -367,10 +493,16 @@ class GoogleDriveDownloader:
         ``modified_time`` are skipped (incremental sync). Returns the
         list of *all* destination paths — both downloaded and skipped
         — so callers can pipe them through the ingest registry.
+
+        Raises:
+            ValueError: When any file's ``parent_path`` would escape
+                *staging_dir* (path-traversal guard).
         """
         staging_dir.mkdir(parents=True, exist_ok=True)
+        # Refresh cache so download_all always sees latest state.
+        listing = self.list_files()
         paths: list[Path] = []
-        for drive_file in self.client.list_files():
+        for drive_file in listing:
             target = self._target_path(drive_file, staging_dir)
             if self._is_up_to_date(target, drive_file):
                 logger.info("Skipping unchanged Drive file: %s", drive_file.name)
@@ -380,8 +512,10 @@ class GoogleDriveDownloader:
         return paths
 
     def _resolve(self, file_id: str) -> DriveFile:
-        """Return the :class:`DriveFile` for *file_id* from the listing."""
-        for candidate in self.client.list_files():
+        """Return the :class:`DriveFile` for *file_id* from the cached listing."""
+        if self._listing_cache is None:
+            self._listing_cache = self.client.list_files()
+        for candidate in self._listing_cache:
             if candidate.id == file_id:
                 return candidate
         msg = f"missing Drive file id: {file_id!r}"
@@ -404,12 +538,41 @@ class GoogleDriveDownloader:
 
     @staticmethod
     def _target_path(drive_file: DriveFile, staging_dir: Path) -> Path:
-        """Return the destination path for *drive_file* under *staging_dir*."""
-        if drive_file.parent_path:
-            parent = staging_dir / Path(drive_file.parent_path)
+        """Return the destination path for *drive_file* under *staging_dir*.
+
+        Raises:
+            ValueError: If ``drive_file.parent_path`` would resolve
+                outside *staging_dir* — defends against malicious or
+                malformed Drive folder names that contain ``..``
+                segments or absolute paths.
+        """
+        staging_root = staging_dir.resolve()
+        parent_segments = (
+            Path(drive_file.parent_path) if drive_file.parent_path else None
+        )
+        if parent_segments is not None and parent_segments.is_absolute():
+            msg = (
+                f"parent_path {drive_file.parent_path!r} escapes staging "
+                f"root {staging_dir!s} (absolute path)"
+            )
+            raise ValueError(msg)
+        if parent_segments is not None:
+            candidate = (staging_root / parent_segments / drive_file.name).resolve()
         else:
-            parent = staging_dir
-        return parent / drive_file.name
+            candidate = (staging_root / drive_file.name).resolve()
+        try:
+            candidate.relative_to(staging_root)
+        except ValueError as exc:
+            msg = (
+                f"parent_path {drive_file.parent_path!r} escapes staging "
+                f"root {staging_dir!s}"
+            )
+            raise ValueError(msg) from exc
+        # Return the unresolved path (preserving symlinks etc.) so caller
+        # paths look like staging_dir/parent/name rather than the resolved form.
+        if parent_segments is not None:
+            return staging_dir / parent_segments / drive_file.name
+        return staging_dir / drive_file.name
 
     def _is_up_to_date(self, target: Path, drive_file: DriveFile) -> bool:
         """Return ``True`` when the local file is at least as new as Drive."""

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -135,6 +135,17 @@ module = ["pytesseract", "PIL", "PIL.*", "pdf2image", "pdf2image.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = [
+    "googleapiclient",
+    "googleapiclient.*",
+    "google_auth_oauthlib",
+    "google_auth_oauthlib.*",
+    "google",
+    "google.*",
+]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
 

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -450,8 +450,82 @@ def test_gdrive_command_downloads_files_through_stub_client(
         ["gdrive", "--download", "--staging", str(staging)],
     )
     assert result.exit_code == 0, result.output
-    assert "Downloaded 1 files" in result.output
+    assert "Downloaded 1" in result.output
+    assert "Skipped 0" in result.output
     assert (staging / "notes.md").read_bytes() == b"# Notes\n"
+
+
+def test_gdrive_command_reports_skipped_files_on_incremental_run(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second run on unchanged files reports them as skipped, not downloaded."""
+    from datetime import UTC as _UTC
+    from datetime import datetime as _datetime
+
+    from creek.ingest.gdrive import DriveFile, GoogleApiDriveClient
+
+    drive_file = DriveFile(
+        id="x",
+        name="notes.md",
+        mime_type="text/markdown",
+        modified_time=_datetime(2026, 4, 1, tzinfo=_UTC),
+        size=10,
+        parent_path="",
+    )
+    monkeypatch.setattr(
+        GoogleApiDriveClient,
+        "is_available",
+        lambda _self: True,
+    )
+    monkeypatch.setattr(
+        GoogleApiDriveClient,
+        "list_files",
+        lambda _self: [drive_file],
+    )
+    monkeypatch.setattr(
+        GoogleApiDriveClient,
+        "get_media",
+        lambda _self, _file_id: b"# Notes\n",
+    )
+
+    staging = tmp_path / "staging"
+    runner.invoke(app, ["gdrive", "--download", "--staging", str(staging)])
+    second = runner.invoke(
+        app,
+        ["gdrive", "--download", "--staging", str(staging)],
+    )
+    assert second.exit_code == 0, second.output
+    assert "Downloaded 0" in second.output
+    assert "Skipped 1" in second.output
+
+
+def test_gdrive_command_reports_drive_api_errors_cleanly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Drive API HTTP errors surface as a clean message, not a traceback."""
+    from creek.ingest.gdrive import GoogleApiDriveClient
+
+    monkeypatch.setattr(
+        GoogleApiDriveClient,
+        "is_available",
+        lambda _self: True,
+    )
+
+    def _boom(_self: object) -> list[object]:
+        msg = "<HttpError 403: 'User Rate Limit Exceeded'>"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(GoogleApiDriveClient, "list_files", _boom)
+    staging = tmp_path / "staging"
+    result = runner.invoke(
+        app,
+        ["gdrive", "--download", "--staging", str(staging)],
+    )
+    assert result.exit_code == 1
+    assert "Google Drive download failed" in result.output
+    assert "Rate Limit" in result.output
 
 
 def test_skills_help() -> None:

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -381,13 +381,77 @@ def test_gdrive_help() -> None:
     assert "gdrive" in result.output.lower()
 
 
-def test_gdrive_command() -> None:
-    """Test that gdrive command runs with --download flag."""
+def test_gdrive_command_without_download_is_a_noop() -> None:
+    """Without --download the command exits 0 with a hint."""
+    result = runner.invoke(app, ["gdrive", "--staging", "/fake/staging"])
+    assert result.exit_code == 0
+    assert "Nothing to do" in result.output
+
+
+def test_gdrive_command_errors_when_api_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without google-api-python-client installed, --download exits 1."""
+    from creek.ingest.gdrive import GoogleApiDriveClient
+
+    monkeypatch.setattr(
+        GoogleApiDriveClient,
+        "is_available",
+        lambda _self: False,
+    )
+    staging = tmp_path / "staging"
     result = runner.invoke(
         app,
-        ["gdrive", "--download", "--staging", "/fake/staging"],
+        ["gdrive", "--download", "--staging", str(staging)],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 1
+    assert "Google API client unavailable" in result.output
+
+
+def test_gdrive_command_downloads_files_through_stub_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The full download path runs end-to-end against an injected client."""
+    from datetime import UTC as _UTC
+    from datetime import datetime as _datetime
+
+    from creek.ingest.gdrive import DriveFile, GoogleApiDriveClient
+
+    drive_file = DriveFile(
+        id="x",
+        name="notes.md",
+        mime_type="text/markdown",
+        modified_time=_datetime(2026, 4, 1, tzinfo=_UTC),
+        size=10,
+        parent_path="",
+    )
+
+    monkeypatch.setattr(
+        GoogleApiDriveClient,
+        "is_available",
+        lambda _self: True,
+    )
+    monkeypatch.setattr(
+        GoogleApiDriveClient,
+        "list_files",
+        lambda _self: [drive_file],
+    )
+    monkeypatch.setattr(
+        GoogleApiDriveClient,
+        "get_media",
+        lambda _self, _file_id: b"# Notes\n",
+    )
+
+    staging = tmp_path / "staging"
+    result = runner.invoke(
+        app,
+        ["gdrive", "--download", "--staging", str(staging)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Downloaded 1 files" in result.output
+    assert (staging / "notes.md").read_bytes() == b"# Notes\n"
 
 
 def test_skills_help() -> None:

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -438,11 +438,11 @@ def test_gdrive_command_downloads_files_through_stub_client(
         "list_files",
         lambda _self: [drive_file],
     )
-    monkeypatch.setattr(
-        GoogleApiDriveClient,
-        "get_media",
-        lambda _self, _file_id: b"# Notes\n",
-    )
+
+    def _stream(_self: object, _file_id: str, destination: Path, **_: object) -> None:
+        destination.write_bytes(b"# Notes\n")
+
+    monkeypatch.setattr(GoogleApiDriveClient, "download_to", _stream)
 
     staging = tmp_path / "staging"
     result = runner.invoke(
@@ -483,11 +483,11 @@ def test_gdrive_command_reports_skipped_files_on_incremental_run(
         "list_files",
         lambda _self: [drive_file],
     )
-    monkeypatch.setattr(
-        GoogleApiDriveClient,
-        "get_media",
-        lambda _self, _file_id: b"# Notes\n",
-    )
+
+    def _stream(_self: object, _file_id: str, destination: Path, **_: object) -> None:
+        destination.write_bytes(b"# Notes\n")
+
+    monkeypatch.setattr(GoogleApiDriveClient, "download_to", _stream)
 
     staging = tmp_path / "staging"
     runner.invoke(app, ["gdrive", "--download", "--staging", str(staging)])

--- a/creek-tools/tests/test_gdrive_downloader.py
+++ b/creek-tools/tests/test_gdrive_downloader.py
@@ -453,15 +453,16 @@ class TestReadOnlyContract:
             for method in forbidden:
                 assert method not in call.split(":", 1)[0], call
 
-    def test_module_source_has_no_write_method_calls(self) -> None:
-        """The module source code never references forbidden Drive write methods.
+    def test_module_source_passes_ast_audit(self) -> None:
+        """The module source has no real call sites for forbidden Drive methods.
 
-        A code-audit assertion: per ontology §3.4 the downloader
-        architecture is read-only by construction. This test grep-style
-        scans the implementation to ensure no future refactor sneaks
-        in a write call.
+        Replaces the older grep-style audit with the AST-based
+        :func:`_audit_no_write_calls` helper, which only flags actual
+        call expressions and ignores method names that appear in
+        docstrings, comments, or string literals.
         """
         from creek.ingest import gdrive
+        from creek.ingest.gdrive import _audit_no_write_calls
 
         source = (
             __import__("pathlib")
@@ -470,14 +471,7 @@ class TestReadOnlyContract:
                 encoding="utf-8",
             )
         )
-        for forbidden in (
-            ".update(",
-            ".delete(",
-            ".trash(",
-            ".copy(",
-            "permissions().create(",
-        ):
-            assert forbidden not in source, forbidden
+        _audit_no_write_calls(source)
 
 
 # ---- Module exports ----------------------------------------------------
@@ -493,6 +487,302 @@ class TestModuleExports:
         )
 
         assert Reexported is GoogleDriveDownloader
+
+    def test_drive_file_importable_from_package(self) -> None:
+        """``DriveFile`` is part of the package's public surface."""
+        from creek.ingest import DriveFile as Reexported
+
+        assert Reexported is DriveFile
+
+    def test_drive_client_importable_from_package(self) -> None:
+        """``DriveClient`` is part of the package's public surface."""
+        from creek.ingest import DriveClient as Reexported
+
+        assert Reexported is DriveClient
+
+    def test_unavailable_error_importable_from_package(self) -> None:
+        """``GoogleApiUnavailableError`` is part of the public surface."""
+        from creek.ingest import GoogleApiUnavailableError as Reexported
+
+        assert Reexported is GoogleApiUnavailableError
+
+    def test_route_to_ingestor_importable_from_package(self) -> None:
+        """``route_to_ingestor`` is part of the public surface."""
+        from creek import ingest as ingest_pkg
+
+        assert ingest_pkg.route_to_ingestor is route_to_ingestor
+
+
+# ---- Folder hierarchy resolution --------------------------------------
+
+
+class TestFolderHierarchyResolution:
+    """`_resolve_folder_paths` walks Drive folder IDs into slash-paths."""
+
+    def test_root_folder_has_bare_name(self) -> None:
+        """A folder with no parents resolves to just its name."""
+        from creek.ingest.gdrive import _resolve_folder_paths
+
+        folders = [{"id": "f1", "name": "Docs", "parents": []}]
+        paths = _resolve_folder_paths(folders)
+        assert paths == {"f1": "Docs"}
+
+    def test_nested_folder_chain_resolves_to_slash_path(self) -> None:
+        """A nested chain of folders resolves to ``Top/Mid/Bottom``."""
+        from creek.ingest.gdrive import _resolve_folder_paths
+
+        folders = [
+            {"id": "f1", "name": "Docs", "parents": []},
+            {"id": "f2", "name": "2026", "parents": ["f1"]},
+            {"id": "f3", "name": "Drafts", "parents": ["f2"]},
+        ]
+        paths = _resolve_folder_paths(folders)
+        assert paths["f3"] == "Docs/2026/Drafts"
+        assert paths["f2"] == "Docs/2026"
+
+    def test_folder_with_unknown_parent_treats_self_as_root(self) -> None:
+        """An orphaned parent reference falls back to the folder's own name.
+
+        Drive sometimes returns a parent id that is not visible to the
+        user (e.g. a shared folder above the visible root); the safe
+        behaviour is to anchor the orphan at the staging root.
+        """
+        from creek.ingest.gdrive import _resolve_folder_paths
+
+        folders = [{"id": "f1", "name": "Orphan", "parents": ["unknown"]}]
+        paths = _resolve_folder_paths(folders)
+        assert paths == {"f1": "Orphan"}
+
+
+class TestListFilesParentPathResolution:
+    """`GoogleApiDriveClient.list_files` resolves folder hierarchy.
+
+    The previous implementation hard-coded ``parent_path=""`` so files
+    in different folders silently collided in the staging directory.
+    These tests exercise the real `list_files` path against a fake
+    service that mimics the Drive API surface.
+    """
+
+    @staticmethod
+    def _make_fake_service(
+        folders: list[dict[str, object]],
+        files: list[dict[str, object]],
+    ) -> object:
+        """Return a stand-in for a Drive service with `.files().list()`."""
+
+        class _Request:
+            def __init__(self, payload: dict[str, object]) -> None:
+                self._payload = payload
+
+            def execute(self) -> dict[str, object]:
+                return self._payload
+
+        class _Files:
+            def list(self, **kwargs: object) -> _Request:
+                q = str(kwargs.get("q", ""))
+                # The folder-listing query starts with ``mimeType=``;
+                # the file-listing query uses ``mimeType!=``.
+                if "mimeType=" in q and "mimeType!=" not in q:
+                    return _Request({"files": folders})
+                return _Request({"files": files})
+
+        class _Service:
+            def files(self) -> _Files:
+                return _Files()
+
+        return _Service()
+
+    def test_files_inherit_parent_folder_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A file whose parent is a known folder gets the folder's path."""
+        folders = [
+            {"id": "f1", "name": "Docs", "parents": []},
+            {"id": "f2", "name": "2026", "parents": ["f1"]},
+        ]
+        files = [
+            {
+                "id": "a",
+                "name": "a.pdf",
+                "mimeType": "application/pdf",
+                "modifiedTime": "2026-04-01T00:00:00Z",
+                "size": 10,
+                "parents": ["f2"],
+            },
+        ]
+        client = GoogleApiDriveClient(GoogleDriveConfig())
+        monkeypatch.setattr(
+            client,
+            "_get_service",
+            lambda: self._make_fake_service(folders, files),
+        )
+        listed = client.list_files()
+        assert len(listed) == 1
+        assert listed[0].parent_path == "Docs/2026"
+
+    def test_files_at_drive_root_have_empty_parent_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A file at the Drive root keeps an empty parent_path."""
+        files = [
+            {
+                "id": "a",
+                "name": "a.pdf",
+                "mimeType": "application/pdf",
+                "modifiedTime": "2026-04-01T00:00:00Z",
+                "size": 10,
+                "parents": [],
+            },
+        ]
+        client = GoogleApiDriveClient(GoogleDriveConfig())
+        monkeypatch.setattr(
+            client,
+            "_get_service",
+            lambda: self._make_fake_service([], files),
+        )
+        listed = client.list_files()
+        assert listed[0].parent_path == ""
+
+
+# ---- Token file permissions ------------------------------------------
+
+
+class TestTokenFilePermissions:
+    """`_write_token_file` lays the OAuth token down at mode 0600."""
+
+    def test_token_file_has_owner_only_permissions(self, tmp_path: Path) -> None:
+        """The cached token is not world- or group-readable."""
+        import stat
+
+        from creek.ingest.gdrive import _write_token_file
+
+        token_path = tmp_path / "token.json"
+        _write_token_file(token_path, '{"refresh_token": "secret"}')
+        mode = token_path.stat().st_mode & 0o777
+        assert mode == stat.S_IRUSR | stat.S_IWUSR  # 0o600
+
+    def test_token_file_overwrites_existing(self, tmp_path: Path) -> None:
+        """Re-writing replaces the file rather than appending."""
+        from creek.ingest.gdrive import _write_token_file
+
+        token_path = tmp_path / "token.json"
+        _write_token_file(token_path, "{}")
+        _write_token_file(token_path, '{"refresh_token": "second"}')
+        assert token_path.read_text(encoding="utf-8") == '{"refresh_token": "second"}'
+
+
+# ---- Path traversal guard --------------------------------------------
+
+
+class TestPathTraversalGuard:
+    """`download_all` rejects parent_paths that escape the staging root."""
+
+    def test_dotdot_parent_path_is_rejected(self, tmp_path: Path) -> None:
+        """A ``..``-laden parent_path raises ValueError before any I/O."""
+        client = StubDriveClient(
+            files=[_file(fid="a", name="a.pdf", parent_path="../../etc")],
+            media={"a": b"x"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        with pytest.raises(ValueError, match="escapes staging"):
+            downloader.download_all(tmp_path)
+
+    def test_absolute_parent_path_is_rejected(self, tmp_path: Path) -> None:
+        """An absolute parent_path also escapes the staging root."""
+        client = StubDriveClient(
+            files=[_file(fid="a", name="a.pdf", parent_path="/etc/passwd-dir")],
+            media={"a": b"x"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        with pytest.raises(ValueError, match="escapes staging"):
+            downloader.download_all(tmp_path)
+
+    def test_normal_relative_parent_path_is_allowed(self, tmp_path: Path) -> None:
+        """A plain relative path lands inside staging and writes successfully."""
+        client = StubDriveClient(
+            files=[_file(fid="a", name="a.pdf", parent_path="Docs/2026")],
+            media={"a": b"x"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        paths = downloader.download_all(tmp_path)
+        assert paths[0] == tmp_path / "Docs" / "2026" / "a.pdf"
+
+
+# ---- list_files caching ----------------------------------------------
+
+
+class TestListFilesCache:
+    """`download_file` does not re-list on every invocation."""
+
+    def test_repeated_download_file_calls_share_one_listing(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Two ``download_file`` calls produce only one ``list_files`` call."""
+        client = StubDriveClient(
+            files=[
+                _file(fid="a", name="a.pdf"),
+                _file(fid="b", name="b.pdf"),
+            ],
+            media={"a": b"a", "b": b"b"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        downloader.download_file("a", tmp_path)
+        downloader.download_file("b", tmp_path)
+        list_calls = [c for c in client.calls if c == "list_files"]
+        assert len(list_calls) == 1
+
+    def test_explicit_list_files_invalidates_cache(self, tmp_path: Path) -> None:
+        """A direct ``list_files()`` call refreshes the cache for callers."""
+        client = StubDriveClient(
+            files=[_file(fid="a", name="a.pdf")],
+            media={"a": b"a"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        downloader.list_files()
+        downloader.list_files()
+        list_calls = [c for c in client.calls if c == "list_files"]
+        assert len(list_calls) == 2
+
+
+# ---- AST-based read-only audit ---------------------------------------
+
+
+class TestAstReadOnlyAudit:
+    """`_audit_no_write_calls` flags only real call sites, not strings/comments."""
+
+    def test_audit_passes_on_clean_module_source(self) -> None:
+        """The current gdrive module passes the AST audit."""
+        from creek.ingest import gdrive
+        from creek.ingest.gdrive import _audit_no_write_calls
+
+        source = __import__("pathlib").Path(gdrive.__file__).read_text(encoding="utf-8")
+        _audit_no_write_calls(source)
+
+    def test_audit_ignores_method_name_in_docstring(self) -> None:
+        """A docstring mentioning ``.delete(`` does not trip the audit."""
+        from creek.ingest.gdrive import _audit_no_write_calls
+
+        sample = (
+            "def foo():\n"
+            '    """Docstring discussing a hypothetical .delete( call."""\n'
+            "    return 1\n"
+        )
+        # Should not raise.
+        _audit_no_write_calls(sample)
+
+    def test_audit_flags_real_write_call(self) -> None:
+        """A genuine ``.delete(`` call site raises a clear AssertionError."""
+        from creek.ingest.gdrive import _audit_no_write_calls
+
+        sample = (
+            "def bad(service):\n"
+            "    return service.files().delete(fileId='x').execute()\n"
+        )
+        with pytest.raises(AssertionError, match="delete"):
+            _audit_no_write_calls(sample)
 
 
 if __name__ == "__main__":

--- a/creek-tools/tests/test_gdrive_downloader.py
+++ b/creek-tools/tests/test_gdrive_downloader.py
@@ -55,15 +55,25 @@ class StubDriveClient:
         self.calls.append("list_files")
         return list(self._files)
 
-    def get_media(self, file_id: str) -> bytes:
-        """Return raw media bytes for *file_id*."""
-        self.calls.append(f"get_media:{file_id}")
-        return self._media[file_id]
+    def download_to(
+        self,
+        file_id: str,
+        destination: Path,
+        *,
+        export_mime: str | None = None,
+    ) -> None:
+        """Write the canned bytes for *file_id* to *destination*.
 
-    def export_media(self, file_id: str, mime_type: str) -> bytes:
-        """Return exported media bytes for *file_id* + *mime_type*."""
-        self.calls.append(f"export_media:{file_id}:{mime_type}")
-        return self._exports[file_id, mime_type]
+        When *export_mime* is provided the (file_id, export_mime) entry
+        in ``_exports`` is used; otherwise the bytes from ``_media``.
+        """
+        if export_mime is not None:
+            self.calls.append(f"export_to:{file_id}:{export_mime}")
+            data = self._exports[file_id, export_mime]
+        else:
+            self.calls.append(f"download_to:{file_id}")
+            data = self._media[file_id]
+        destination.write_bytes(data)
 
 
 # ---- DriveFile ---------------------------------------------------------
@@ -202,11 +212,12 @@ class TestGoogleApiDriveClient:
         with pytest.raises(GoogleApiUnavailableError, match="google-api-python-client"):
             client.list_files()
 
-    def test_get_media_raises_without_deps(
+    def test_download_to_raises_without_deps(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
-        """get_media raises with actionable instructions when deps missing."""
+        """download_to raises with actionable instructions when deps missing."""
         import builtins
 
         monkeypatch.setattr(
@@ -218,13 +229,14 @@ class TestGoogleApiDriveClient:
         )
         client = GoogleApiDriveClient(GoogleDriveConfig())
         with pytest.raises(GoogleApiUnavailableError):
-            client.get_media("file-id")
+            client.download_to("file-id", tmp_path / "x.bin")
 
-    def test_export_media_raises_without_deps(
+    def test_download_to_export_raises_without_deps(
         self,
         monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
     ) -> None:
-        """export_media raises with actionable instructions when deps missing."""
+        """download_to with an export_mime also raises when deps missing."""
         import builtins
 
         monkeypatch.setattr(
@@ -236,7 +248,11 @@ class TestGoogleApiDriveClient:
         )
         client = GoogleApiDriveClient(GoogleDriveConfig())
         with pytest.raises(GoogleApiUnavailableError):
-            client.export_media("file-id", "application/pdf")
+            client.download_to(
+                "file-id",
+                tmp_path / "x.docx",
+                export_mime="application/pdf",
+            )
 
 
 # ---- route_to_ingestor ------------------------------------------------
@@ -253,6 +269,7 @@ class TestRouteToIngestor:
             ("scan.pdf", "document"),
             ("page.html", "document"),
             ("readme.txt", "document"),
+            ("manual.rtf", "document"),
             ("budget.xlsx", "spreadsheet"),
             ("data.csv", "spreadsheet"),
             ("deck.pptx", "presentation"),
@@ -299,11 +316,11 @@ def _file(
 class TestDownloadFile:
     """`download_file` handles regular files and Google-native exports."""
 
-    def test_regular_file_is_downloaded_via_get_media(
+    def test_regular_file_is_streamed_to_disk(
         self,
         tmp_path: Path,
     ) -> None:
-        """A non-Google-native file calls ``get_media`` and writes bytes."""
+        """A non-Google-native file is streamed straight to disk via download_to."""
         client = StubDriveClient(
             files=[_file(fid="abc", name="Notes.pdf")],
             media={"abc": b"%PDF-1.4 raw bytes"},
@@ -312,10 +329,10 @@ class TestDownloadFile:
         path = downloader.download_file("abc", tmp_path)
         assert path == tmp_path / "Notes.pdf"
         assert path.read_bytes() == b"%PDF-1.4 raw bytes"
-        assert "get_media:abc" in client.calls
+        assert "download_to:abc" in client.calls
 
     def test_google_doc_is_exported_to_docx(self, tmp_path: Path) -> None:
-        """A Google Doc exports through ``export_media`` to .docx bytes."""
+        """A Google Doc exports through download_to with export_mime to .docx."""
         docx_mime = (
             "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         )
@@ -327,10 +344,10 @@ class TestDownloadFile:
         path = downloader.download_file("g1", tmp_path)
         assert path.name == "Letter.docx"
         assert path.read_bytes().startswith(b"PK")
-        assert f"export_media:g1:{docx_mime}" in client.calls
+        assert f"export_to:g1:{docx_mime}" in client.calls
 
     def test_google_sheet_is_exported_to_xlsx(self, tmp_path: Path) -> None:
-        """A Google Sheet exports through ``export_media`` to .xlsx bytes."""
+        """A Google Sheet exports through download_to to .xlsx."""
         xlsx_mime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
         client = StubDriveClient(
             files=[_file(fid="s1", name="Budget", mime=GOOGLE_SHEETS_MIME)],
@@ -341,7 +358,7 @@ class TestDownloadFile:
         assert path.name == "Budget.xlsx"
 
     def test_google_slides_is_exported_to_pptx(self, tmp_path: Path) -> None:
-        """Google Slides exports through ``export_media`` to .pptx bytes."""
+        """Google Slides exports through download_to to .pptx."""
         pptx_mime = (
             "application/vnd.openxmlformats-officedocument.presentationml.presentation"
         )
@@ -409,10 +426,10 @@ class TestDownloadAll:
         )
         downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
         downloader.download_all(tmp_path)
-        # Reset call log; second pass should not call get_media again.
+        # Reset call log; second pass should not invoke download_to again.
         client.calls.clear()
         downloader.download_all(tmp_path)
-        assert all(not c.startswith("get_media") for c in client.calls)
+        assert all(not c.startswith("download_to") for c in client.calls)
 
     def test_redownloads_when_drive_file_is_newer(self, tmp_path: Path) -> None:
         """A bumped modified_time triggers re-download."""
@@ -429,7 +446,7 @@ class TestDownloadAll:
         client._media = {"a": b"v2"}
         client.calls.clear()
         downloader.download_all(tmp_path)
-        assert any(c.startswith("get_media") for c in client.calls)
+        assert any(c.startswith("download_to") for c in client.calls)
         assert (tmp_path / "a.pdf").read_bytes() == b"v2"
 
     def test_download_all_returns_separate_downloaded_and_skipped_lists(
@@ -448,11 +465,11 @@ class TestDownloadAll:
         downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
         first = downloader.download_all(tmp_path)
         assert len(first.downloaded) == 2
-        assert first.skipped == []
+        assert first.skipped == ()
 
         # Re-run: nothing changed, both files should be skipped.
         second = downloader.download_all(tmp_path)
-        assert second.downloaded == []
+        assert second.downloaded == ()
         assert {p.name for p in second.skipped} == {"a.pdf", "b.pdf"}
 
     def test_skipped_google_native_file_keeps_export_suffix(
@@ -483,7 +500,7 @@ class TestDownloadAll:
         downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
         downloader.download_all(tmp_path)  # first run downloads
         result = downloader.download_all(tmp_path)  # second run skips
-        assert result.downloaded == []
+        assert result.downloaded == ()
         assert len(result.skipped) == 1
         assert result.skipped[0].name == "Letter.docx"
         assert route_to_ingestor(result.skipped[0]) == "document"
@@ -501,6 +518,70 @@ class TestDownloadAll:
         result = downloader.download_all(tmp_path)
         assert {p.name for p in result.all_paths} == {"a.pdf"}
 
+    def test_download_result_lists_are_immutable(self, tmp_path: Path) -> None:
+        """`DownloadResult` exposes tuples so callers cannot mutate the record.
+
+        ``frozen=True`` only prevents field reassignment; mutable list
+        attributes would still allow ``result.downloaded.append(...)``.
+        Switching to tuples makes the value object truly immutable.
+        """
+        client = StubDriveClient(
+            files=[_file(fid="a", name="a.pdf")],
+            media={"a": b"x"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        result = downloader.download_all(tmp_path)
+        assert isinstance(result.downloaded, tuple)
+        assert isinstance(result.skipped, tuple)
+        assert isinstance(result.errors, tuple)
+
+    def test_partial_failure_continues_and_records_per_file_errors(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A mid-loop client failure records the error and continues.
+
+        Without this, a 500-file sync that hits a transient quota error
+        at file 250 would abort and leave the staging directory in a
+        partial state with no programmatic record of how many files
+        succeeded.
+        """
+        good = _file(fid="ok", name="good.pdf")
+        bad = _file(fid="bad", name="bad.pdf")
+
+        class _FlakyClient(StubDriveClient):
+            def download_to(
+                self,
+                file_id: str,
+                destination: Path,
+                *,
+                export_mime: str | None = None,
+            ) -> None:
+                if file_id == "bad":
+                    msg = "simulated rate limit"
+                    raise RuntimeError(msg)
+                super().download_to(
+                    file_id,
+                    destination,
+                    export_mime=export_mime,
+                )
+
+        client = _FlakyClient(
+            files=[good, bad],
+            media={"ok": b"good bytes"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        result = downloader.download_all(tmp_path)
+
+        assert len(result.downloaded) == 1
+        assert result.downloaded[0].name == "good.pdf"
+        assert len(result.errors) == 1
+        failed_file, exc = result.errors[0]
+        assert failed_file.id == "bad"
+        assert "rate limit" in str(exc)
+        # The good file still landed.
+        assert (tmp_path / "good.pdf").read_bytes() == b"good bytes"
+
 
 # ---- Read-only audit ---------------------------------------------------
 
@@ -509,7 +590,7 @@ class TestReadOnlyContract:
     """The downloader never invokes write APIs against Drive."""
 
     def test_downloader_does_not_call_write_methods(self, tmp_path: Path) -> None:
-        """A full download cycle records only list/get/export_media calls."""
+        """A full cycle records only list_files / download_to / export_to calls."""
         client = StubDriveClient(
             files=[_file(fid="a", name="a.pdf")],
             media={"a": b"x"},
@@ -741,6 +822,31 @@ class TestTokenFilePermissions:
         _write_token_file(token_path, '{"refresh_token": "second"}')
         assert token_path.read_text(encoding="utf-8") == '{"refresh_token": "second"}'
 
+    def test_overwrite_of_world_readable_file_lands_at_0o600(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Replacing a 0o644 token file leaves the new file at 0o600.
+
+        Closes the TOCTOU window where a previous run's wider-permission
+        token file could briefly contain the new refresh token before
+        the chmod tightened it. Atomic rename writes a fresh 0o600
+        sibling and atomically replaces the old file.
+        """
+        import stat
+
+        from creek.ingest.gdrive import _write_token_file
+
+        token_path = tmp_path / "token.json"
+        token_path.write_text("{}", encoding="utf-8")
+        token_path.chmod(0o644)
+        _write_token_file(token_path, '{"refresh_token": "new-secret"}')
+        mode = token_path.stat().st_mode & 0o777
+        assert mode == stat.S_IRUSR | stat.S_IWUSR  # 0o600
+        assert (
+            token_path.read_text(encoding="utf-8") == '{"refresh_token": "new-secret"}'
+        )
+
 
 # ---- Path traversal guard --------------------------------------------
 
@@ -803,8 +909,15 @@ class TestListFilesCache:
         list_calls = [c for c in client.calls if c == "list_files"]
         assert len(list_calls) == 1
 
-    def test_explicit_list_files_invalidates_cache(self, tmp_path: Path) -> None:
-        """A direct ``list_files()`` call refreshes the cache for callers."""
+    def test_explicit_list_files_always_fetches_from_client(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`list_files()` is a live call — every invocation hits the client.
+
+        The internal cache is for the ``download_file`` fast-path only;
+        a direct ``list_files()`` from a caller refreshes it.
+        """
         client = StubDriveClient(
             files=[_file(fid="a", name="a.pdf")],
             media={"a": b"a"},

--- a/creek-tools/tests/test_gdrive_downloader.py
+++ b/creek-tools/tests/test_gdrive_downloader.py
@@ -24,6 +24,32 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
+_FORBIDDEN_DRIVE_METHODS: frozenset[str] = frozenset(
+    {"update", "delete", "trash", "copy", "create"},
+)
+
+
+def _audit_no_write_calls(source: str) -> None:
+    """Raise :class:`AssertionError` if *source* calls a forbidden Drive method.
+
+    AST-based: ignores method names that appear inside docstrings,
+    string literals, or comments. Only flags real call sites such as
+    ``service.files().delete(...)``. Lives in the test module rather
+    than in the production module so test infrastructure is not
+    shipped as production code.
+    """
+    import ast
+
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr in _FORBIDDEN_DRIVE_METHODS:
+            msg = f"Forbidden write call detected: {func.attr}() at line {node.lineno}"
+            raise AssertionError(msg)
+
+
 # ---- Stub client --------------------------------------------------------
 
 
@@ -146,6 +172,22 @@ class TestDriveClientProtocol:
         attrs = set(dir(DriveClient))
         for name in forbidden:
             assert name not in attrs, name
+
+    def test_ast_audit_flags_create_call(self) -> None:
+        """A `permissions().create(...)` call site is detected.
+
+        The Protocol covers ``create`` as forbidden (Drive
+        ``permissions().create()`` is the share-API write surface) so
+        the source-level AST audit should also flag it. This ensures
+        the two layers of read-only enforcement stay in sync.
+        """
+
+        sample = (
+            "def bad(service):\n"
+            "    return service.permissions().create(fileId='x').execute()\n"
+        )
+        with pytest.raises(AssertionError, match="create"):
+            _audit_no_write_calls(sample)
 
 
 # ---- GoogleApiDriveClient ---------------------------------------------
@@ -582,6 +624,54 @@ class TestDownloadAll:
         # The good file still landed.
         assert (tmp_path / "good.pdf").read_bytes() == b"good bytes"
 
+    def test_partial_failure_does_not_leave_stale_destination_file(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A failed download must not leave a half-written file at the target.
+
+        Otherwise the next run sees ``local.mtime > drive.modified_time``
+        (because the half-write happened *now*, after Drive's
+        modified_time) and skips the file forever. Regression for the
+        BLOCKING finding in PR #163's fourth review.
+        """
+        from datetime import UTC as _UTC
+        from datetime import datetime as _datetime
+
+        old = _datetime(2024, 1, 1, tzinfo=_UTC)
+        bad_file = _file(fid="bad", name="bad.pdf", modified=old)
+
+        class _MidstreamFlakyClient(StubDriveClient):
+            def download_to(
+                self,
+                file_id: str,
+                destination: Path,
+                *,
+                export_mime: str | None = None,
+            ) -> None:
+                # Simulate writing some bytes then failing partway.
+                if file_id == "bad":
+                    destination.write_bytes(b"PARTIAL")
+                    msg = "stream interrupted"
+                    raise RuntimeError(msg)
+                super().download_to(
+                    file_id,
+                    destination,
+                    export_mime=export_mime,
+                )
+
+        client = _MidstreamFlakyClient(
+            files=[bad_file],
+            media={"bad": b"never-fully-written"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        downloader.download_all(tmp_path)
+
+        # The destination file must not exist after a failed download —
+        # otherwise its mtime would shadow Drive's older modified_time
+        # and the file would be permanently skipped.
+        assert not (tmp_path / "bad.pdf").exists()
+
 
 # ---- Read-only audit ---------------------------------------------------
 
@@ -602,26 +692,6 @@ class TestReadOnlyContract:
         for call in client.calls:
             for method in forbidden:
                 assert method not in call.split(":", 1)[0], call
-
-    def test_module_source_passes_ast_audit(self) -> None:
-        """The module source has no real call sites for forbidden Drive methods.
-
-        Replaces the older grep-style audit with the AST-based
-        :func:`_audit_no_write_calls` helper, which only flags actual
-        call expressions and ignores method names that appear in
-        docstrings, comments, or string literals.
-        """
-        from creek.ingest import gdrive
-        from creek.ingest.gdrive import _audit_no_write_calls
-
-        source = (
-            __import__("pathlib")
-            .Path(gdrive.__file__)
-            .read_text(
-                encoding="utf-8",
-            )
-        )
-        _audit_no_write_calls(source)
 
 
 # ---- Module exports ----------------------------------------------------
@@ -938,14 +1008,12 @@ class TestAstReadOnlyAudit:
     def test_audit_passes_on_clean_module_source(self) -> None:
         """The current gdrive module passes the AST audit."""
         from creek.ingest import gdrive
-        from creek.ingest.gdrive import _audit_no_write_calls
 
         source = __import__("pathlib").Path(gdrive.__file__).read_text(encoding="utf-8")
         _audit_no_write_calls(source)
 
     def test_audit_ignores_method_name_in_docstring(self) -> None:
         """A docstring mentioning ``.delete(`` does not trip the audit."""
-        from creek.ingest.gdrive import _audit_no_write_calls
 
         sample = (
             "def foo():\n"
@@ -957,7 +1025,6 @@ class TestAstReadOnlyAudit:
 
     def test_audit_flags_real_write_call(self) -> None:
         """A genuine ``.delete(`` call site raises a clear AssertionError."""
-        from creek.ingest.gdrive import _audit_no_write_calls
 
         sample = (
             "def bad(service):\n"

--- a/creek-tools/tests/test_gdrive_downloader.py
+++ b/creek-tools/tests/test_gdrive_downloader.py
@@ -1,0 +1,499 @@
+"""Tests for the read-only Google Drive downloader (#56)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.config import GoogleDriveConfig
+from creek.ingest.gdrive import (
+    GOOGLE_DOCS_MIME,
+    GOOGLE_SHEETS_MIME,
+    GOOGLE_SLIDES_MIME,
+    DriveClient,
+    DriveFile,
+    GoogleApiDriveClient,
+    GoogleApiUnavailableError,
+    GoogleDriveDownloader,
+    route_to_ingestor,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---- Stub client --------------------------------------------------------
+
+
+class StubDriveClient:
+    """Deterministic in-memory Drive client for tests.
+
+    Tracks which methods were called so tests can assert that no write
+    methods were ever invoked on the real Drive client.
+    """
+
+    def __init__(
+        self,
+        files: list[DriveFile] | None = None,
+        media: dict[str, bytes] | None = None,
+        exports: dict[tuple[str, str], bytes] | None = None,
+    ) -> None:
+        """Seed listing, raw media, and export media keyed by id (and mime)."""
+        self._files = list(files or [])
+        self._media = dict(media or {})
+        self._exports = dict(exports or {})
+        self.calls: list[str] = []
+
+    def is_available(self) -> bool:
+        """Stub clients are always available."""
+        return True
+
+    def list_files(self) -> list[DriveFile]:
+        """Return the canned listing."""
+        self.calls.append("list_files")
+        return list(self._files)
+
+    def get_media(self, file_id: str) -> bytes:
+        """Return raw media bytes for *file_id*."""
+        self.calls.append(f"get_media:{file_id}")
+        return self._media[file_id]
+
+    def export_media(self, file_id: str, mime_type: str) -> bytes:
+        """Return exported media bytes for *file_id* + *mime_type*."""
+        self.calls.append(f"export_media:{file_id}:{mime_type}")
+        return self._exports[file_id, mime_type]
+
+
+# ---- DriveFile ---------------------------------------------------------
+
+
+class TestDriveFile:
+    """Invariants on the :class:`DriveFile` dataclass."""
+
+    def test_drive_file_carries_required_fields(self) -> None:
+        """All metadata fields the routing logic needs are present."""
+        df = DriveFile(
+            id="abc",
+            name="Notes.docx",
+            mime_type=(
+                "application/vnd.openxmlformats-officedocument."
+                "wordprocessingml.document"
+            ),
+            modified_time=datetime(2026, 1, 1, tzinfo=UTC),
+            size=1024,
+            parent_path="Docs/2026",
+        )
+        assert df.id == "abc"
+        assert df.name == "Notes.docx"
+        assert df.parent_path == "Docs/2026"
+
+    def test_is_google_native_recognises_docs_sheets_slides(self) -> None:
+        """``is_google_native`` is True for the three google-apps mimes."""
+        for mime in (GOOGLE_DOCS_MIME, GOOGLE_SHEETS_MIME, GOOGLE_SLIDES_MIME):
+            df = DriveFile(
+                id="x",
+                name="x",
+                mime_type=mime,
+                modified_time=datetime(2026, 1, 1, tzinfo=UTC),
+                size=0,
+                parent_path="",
+            )
+            assert df.is_google_native is True
+
+    def test_is_google_native_false_for_regular_files(self) -> None:
+        """Plain ``.docx`` / ``.pdf`` are not Google-native."""
+        df = DriveFile(
+            id="x",
+            name="x.pdf",
+            mime_type="application/pdf",
+            modified_time=datetime(2026, 1, 1, tzinfo=UTC),
+            size=0,
+            parent_path="",
+        )
+        assert df.is_google_native is False
+
+
+# ---- DriveClient protocol contract ------------------------------------
+
+
+class TestDriveClientProtocol:
+    """`DriveClient` exposes only read-side methods.
+
+    The Creek ontology forbids any write/update/delete/trash/copy
+    operation against the user's Drive. The Protocol enforces this by
+    construction — nothing on it should mutate.
+    """
+
+    def test_stub_satisfies_protocol(self) -> None:
+        """A stub client is a structural :class:`DriveClient`."""
+        assert isinstance(StubDriveClient(), DriveClient)
+
+    def test_protocol_has_no_write_methods(self) -> None:
+        """Forbidden write surface is absent from the Protocol."""
+        forbidden = {"update", "delete", "trash", "copy", "create"}
+        attrs = set(dir(DriveClient))
+        for name in forbidden:
+            assert name not in attrs, name
+
+
+# ---- GoogleApiDriveClient ---------------------------------------------
+
+
+def _make_import_blocker(blocked: set[str]) -> object:
+    """Build a ``__import__`` replacement that raises for *blocked*."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked_import(
+        name: str,
+        module_globals: dict[str, object] | None = None,
+        module_locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        """Raise ImportError for blocked roots; defer everything else."""
+        root = name.split(".", 1)[0]
+        if root in blocked or name in blocked:
+            msg = f"mocked-missing: {name}"
+            raise ImportError(msg)
+        return real_import(name, module_globals, module_locals, fromlist, level)
+
+    return _blocked_import
+
+
+class TestGoogleApiDriveClient:
+    """Default Drive client respects the optional-dep contract."""
+
+    def test_is_available_returns_false_without_deps(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without google-api-python-client, the client reports unavailable."""
+        import builtins
+
+        monkeypatch.setattr(
+            builtins,
+            "__import__",
+            _make_import_blocker(
+                {"googleapiclient", "google_auth_oauthlib", "google"},
+            ),
+        )
+        client = GoogleApiDriveClient(GoogleDriveConfig())
+        assert not client.is_available()
+
+    def test_list_files_raises_without_deps(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """list_files raises GoogleApiUnavailableError when deps missing."""
+        import builtins
+
+        monkeypatch.setattr(
+            builtins,
+            "__import__",
+            _make_import_blocker(
+                {"googleapiclient", "google_auth_oauthlib", "google"},
+            ),
+        )
+        client = GoogleApiDriveClient(GoogleDriveConfig())
+        with pytest.raises(GoogleApiUnavailableError, match="google-api-python-client"):
+            client.list_files()
+
+    def test_get_media_raises_without_deps(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """get_media raises with actionable instructions when deps missing."""
+        import builtins
+
+        monkeypatch.setattr(
+            builtins,
+            "__import__",
+            _make_import_blocker(
+                {"googleapiclient", "google_auth_oauthlib", "google"},
+            ),
+        )
+        client = GoogleApiDriveClient(GoogleDriveConfig())
+        with pytest.raises(GoogleApiUnavailableError):
+            client.get_media("file-id")
+
+    def test_export_media_raises_without_deps(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """export_media raises with actionable instructions when deps missing."""
+        import builtins
+
+        monkeypatch.setattr(
+            builtins,
+            "__import__",
+            _make_import_blocker(
+                {"googleapiclient", "google_auth_oauthlib", "google"},
+            ),
+        )
+        client = GoogleApiDriveClient(GoogleDriveConfig())
+        with pytest.raises(GoogleApiUnavailableError):
+            client.export_media("file-id", "application/pdf")
+
+
+# ---- route_to_ingestor ------------------------------------------------
+
+
+class TestRouteToIngestor:
+    """`route_to_ingestor` maps file extensions to ingestor keys."""
+
+    @pytest.mark.parametrize(
+        ("name", "expected"),
+        [
+            ("notes.md", "markdown"),
+            ("memo.docx", "document"),
+            ("scan.pdf", "document"),
+            ("page.html", "document"),
+            ("readme.txt", "document"),
+            ("budget.xlsx", "spreadsheet"),
+            ("data.csv", "spreadsheet"),
+            ("deck.pptx", "presentation"),
+            ("photo.jpg", "image"),
+            ("shot.PNG", "image"),
+        ],
+    )
+    def test_extension_routing(self, name: str, expected: str) -> None:
+        """Each well-known extension routes to the canonical ingestor key."""
+        from pathlib import Path
+
+        assert route_to_ingestor(Path(name)) == expected
+
+    def test_unknown_extension_routes_to_generic(self) -> None:
+        """Unrecognised extensions fall through to the generic ingestor."""
+        from pathlib import Path
+
+        assert route_to_ingestor(Path("mystery.xyz")) == "generic"
+
+
+# ---- GoogleDriveDownloader.download_file ------------------------------
+
+
+def _file(
+    *,
+    fid: str,
+    name: str,
+    mime: str = "application/pdf",
+    modified: datetime | None = None,
+    size: int = 0,
+    parent_path: str = "",
+) -> DriveFile:
+    """Build a DriveFile with sensible defaults for tests."""
+    return DriveFile(
+        id=fid,
+        name=name,
+        mime_type=mime,
+        modified_time=modified or datetime(2026, 4, 1, tzinfo=UTC),
+        size=size,
+        parent_path=parent_path,
+    )
+
+
+class TestDownloadFile:
+    """`download_file` handles regular files and Google-native exports."""
+
+    def test_regular_file_is_downloaded_via_get_media(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A non-Google-native file calls ``get_media`` and writes bytes."""
+        client = StubDriveClient(
+            files=[_file(fid="abc", name="Notes.pdf")],
+            media={"abc": b"%PDF-1.4 raw bytes"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        path = downloader.download_file("abc", tmp_path)
+        assert path == tmp_path / "Notes.pdf"
+        assert path.read_bytes() == b"%PDF-1.4 raw bytes"
+        assert "get_media:abc" in client.calls
+
+    def test_google_doc_is_exported_to_docx(self, tmp_path: Path) -> None:
+        """A Google Doc exports through ``export_media`` to .docx bytes."""
+        docx_mime = (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+        client = StubDriveClient(
+            files=[_file(fid="g1", name="Letter", mime=GOOGLE_DOCS_MIME)],
+            exports={("g1", docx_mime): b"PK\x03\x04 docx bytes"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        path = downloader.download_file("g1", tmp_path)
+        assert path.name == "Letter.docx"
+        assert path.read_bytes().startswith(b"PK")
+        assert f"export_media:g1:{docx_mime}" in client.calls
+
+    def test_google_sheet_is_exported_to_xlsx(self, tmp_path: Path) -> None:
+        """A Google Sheet exports through ``export_media`` to .xlsx bytes."""
+        xlsx_mime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        client = StubDriveClient(
+            files=[_file(fid="s1", name="Budget", mime=GOOGLE_SHEETS_MIME)],
+            exports={("s1", xlsx_mime): b"PK\x03\x04 xlsx bytes"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        path = downloader.download_file("s1", tmp_path)
+        assert path.name == "Budget.xlsx"
+
+    def test_google_slides_is_exported_to_pptx(self, tmp_path: Path) -> None:
+        """Google Slides exports through ``export_media`` to .pptx bytes."""
+        pptx_mime = (
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        )
+        client = StubDriveClient(
+            files=[_file(fid="p1", name="Deck", mime=GOOGLE_SLIDES_MIME)],
+            exports={("p1", pptx_mime): b"PK\x03\x04 pptx bytes"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        path = downloader.download_file("p1", tmp_path)
+        assert path.name == "Deck.pptx"
+
+    def test_unknown_file_id_raises_keyerror(self, tmp_path: Path) -> None:
+        """Asking for a missing id raises a clear KeyError."""
+        client = StubDriveClient(files=[_file(fid="known", name="x.pdf")])
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        with pytest.raises(KeyError, match="missing"):
+            downloader.download_file("missing", tmp_path)
+
+
+# ---- GoogleDriveDownloader.download_all -------------------------------
+
+
+class TestDownloadAll:
+    """`download_all` walks the listing and writes every file."""
+
+    def test_downloads_all_files_to_staging(self, tmp_path: Path) -> None:
+        """All listed files land under the staging directory."""
+        client = StubDriveClient(
+            files=[
+                _file(fid="a", name="a.pdf"),
+                _file(fid="b", name="b.docx", mime="application/vnd.openxmlformats"),
+            ],
+            media={"a": b"a", "b": b"b"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        paths = downloader.download_all(tmp_path)
+        assert {p.name for p in paths} == {"a.pdf", "b.docx"}
+        assert (tmp_path / "a.pdf").read_bytes() == b"a"
+
+    def test_preserves_folder_structure(self, tmp_path: Path) -> None:
+        """Files retain their Drive folder hierarchy under staging."""
+        client = StubDriveClient(
+            files=[
+                _file(fid="a", name="a.pdf", parent_path="Docs/2026"),
+            ],
+            media={"a": b"a"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        paths = downloader.download_all(tmp_path)
+        assert paths[0] == tmp_path / "Docs" / "2026" / "a.pdf"
+
+    def test_skips_unchanged_files_on_subsequent_runs(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Files whose mtime matches the Drive modified_time are skipped.
+
+        On a second invocation, only newer/missing files should be
+        re-fetched — incremental sync, not full re-download.
+        """
+        modified = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        client = StubDriveClient(
+            files=[_file(fid="a", name="a.pdf", modified=modified)],
+            media={"a": b"first"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        downloader.download_all(tmp_path)
+        # Reset call log; second pass should not call get_media again.
+        client.calls.clear()
+        downloader.download_all(tmp_path)
+        assert all(not c.startswith("get_media") for c in client.calls)
+
+    def test_redownloads_when_drive_file_is_newer(self, tmp_path: Path) -> None:
+        """A bumped modified_time triggers re-download."""
+        old = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        client = StubDriveClient(
+            files=[_file(fid="a", name="a.pdf", modified=old)],
+            media={"a": b"v1"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        downloader.download_all(tmp_path)
+        # Bump remote modified_time; v2 bytes should land.
+        new = datetime(2026, 6, 1, 12, 0, tzinfo=UTC)
+        client._files = [_file(fid="a", name="a.pdf", modified=new)]
+        client._media = {"a": b"v2"}
+        client.calls.clear()
+        downloader.download_all(tmp_path)
+        assert any(c.startswith("get_media") for c in client.calls)
+        assert (tmp_path / "a.pdf").read_bytes() == b"v2"
+
+
+# ---- Read-only audit ---------------------------------------------------
+
+
+class TestReadOnlyContract:
+    """The downloader never invokes write APIs against Drive."""
+
+    def test_downloader_does_not_call_write_methods(self, tmp_path: Path) -> None:
+        """A full download cycle records only list/get/export_media calls."""
+        client = StubDriveClient(
+            files=[_file(fid="a", name="a.pdf")],
+            media={"a": b"x"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        downloader.list_files()
+        downloader.download_all(tmp_path)
+        forbidden = ("update", "delete", "trash", "copy", "create")
+        for call in client.calls:
+            for method in forbidden:
+                assert method not in call.split(":", 1)[0], call
+
+    def test_module_source_has_no_write_method_calls(self) -> None:
+        """The module source code never references forbidden Drive write methods.
+
+        A code-audit assertion: per ontology §3.4 the downloader
+        architecture is read-only by construction. This test grep-style
+        scans the implementation to ensure no future refactor sneaks
+        in a write call.
+        """
+        from creek.ingest import gdrive
+
+        source = (
+            __import__("pathlib")
+            .Path(gdrive.__file__)
+            .read_text(
+                encoding="utf-8",
+            )
+        )
+        for forbidden in (
+            ".update(",
+            ".delete(",
+            ".trash(",
+            ".copy(",
+            "permissions().create(",
+        ):
+            assert forbidden not in source, forbidden
+
+
+# ---- Module exports ----------------------------------------------------
+
+
+class TestModuleExports:
+    """The package re-exports the downloader's public surface."""
+
+    def test_downloader_importable_from_package(self) -> None:
+        """``from creek.ingest import GoogleDriveDownloader`` works."""
+        from creek.ingest import (
+            GoogleDriveDownloader as Reexported,
+        )
+
+        assert Reexported is GoogleDriveDownloader
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/creek-tools/tests/test_gdrive_downloader.py
+++ b/creek-tools/tests/test_gdrive_downloader.py
@@ -377,8 +377,8 @@ class TestDownloadAll:
             media={"a": b"a", "b": b"b"},
         )
         downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
-        paths = downloader.download_all(tmp_path)
-        assert {p.name for p in paths} == {"a.pdf", "b.docx"}
+        result = downloader.download_all(tmp_path)
+        assert {p.name for p in result.all_paths} == {"a.pdf", "b.docx"}
         assert (tmp_path / "a.pdf").read_bytes() == b"a"
 
     def test_preserves_folder_structure(self, tmp_path: Path) -> None:
@@ -390,8 +390,8 @@ class TestDownloadAll:
             media={"a": b"a"},
         )
         downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
-        paths = downloader.download_all(tmp_path)
-        assert paths[0] == tmp_path / "Docs" / "2026" / "a.pdf"
+        result = downloader.download_all(tmp_path)
+        assert result.downloaded[0] == tmp_path / "Docs" / "2026" / "a.pdf"
 
     def test_skips_unchanged_files_on_subsequent_runs(
         self,
@@ -431,6 +431,75 @@ class TestDownloadAll:
         downloader.download_all(tmp_path)
         assert any(c.startswith("get_media") for c in client.calls)
         assert (tmp_path / "a.pdf").read_bytes() == b"v2"
+
+    def test_download_all_returns_separate_downloaded_and_skipped_lists(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The return shape distinguishes freshly-downloaded vs skipped files."""
+        modified = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        client = StubDriveClient(
+            files=[
+                _file(fid="a", name="a.pdf", modified=modified),
+                _file(fid="b", name="b.pdf", modified=modified),
+            ],
+            media={"a": b"a", "b": b"b"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        first = downloader.download_all(tmp_path)
+        assert len(first.downloaded) == 2
+        assert first.skipped == []
+
+        # Re-run: nothing changed, both files should be skipped.
+        second = downloader.download_all(tmp_path)
+        assert second.downloaded == []
+        assert {p.name for p in second.skipped} == {"a.pdf", "b.pdf"}
+
+    def test_skipped_google_native_file_keeps_export_suffix(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An up-to-date Google Doc still reports its on-disk ``.docx`` path.
+
+        Regression: previously the skip branch appended the un-suffixed
+        target (``Letter``), so a caller piping the result through
+        ``route_to_ingestor`` would mis-classify it.
+        """
+        docx_mime = (
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+        modified = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+        client = StubDriveClient(
+            files=[
+                _file(
+                    fid="g1",
+                    name="Letter",
+                    mime=GOOGLE_DOCS_MIME,
+                    modified=modified,
+                ),
+            ],
+            exports={("g1", docx_mime): b"PK\x03\x04"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        downloader.download_all(tmp_path)  # first run downloads
+        result = downloader.download_all(tmp_path)  # second run skips
+        assert result.downloaded == []
+        assert len(result.skipped) == 1
+        assert result.skipped[0].name == "Letter.docx"
+        assert route_to_ingestor(result.skipped[0]) == "document"
+
+    def test_download_all_returns_result_iterable_for_legacy_callers(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """`DownloadResult.all_paths` returns the union for callers that want it."""
+        client = StubDriveClient(
+            files=[_file(fid="a", name="a.pdf")],
+            media={"a": b"x"},
+        )
+        downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
+        result = downloader.download_all(tmp_path)
+        assert {p.name for p in result.all_paths} == {"a.pdf"}
 
 
 # ---- Read-only audit ---------------------------------------------------
@@ -706,8 +775,8 @@ class TestPathTraversalGuard:
             media={"a": b"x"},
         )
         downloader = GoogleDriveDownloader(client=client, config=GoogleDriveConfig())
-        paths = downloader.download_all(tmp_path)
-        assert paths[0] == tmp_path / "Docs" / "2026" / "a.pdf"
+        result = downloader.download_all(tmp_path)
+        assert result.downloaded[0] == tmp_path / "Docs" / "2026" / "a.pdf"
 
 
 # ---- list_files caching ----------------------------------------------


### PR DESCRIPTION
## Summary

Implements §3.4 of the Creek Ontology — a download-first, read-only architecture for pulling files from a user's Google Drive into a local staging directory. The downloader **never writes back**: there is no `update`, `delete`, `trash`, or `copy` call anywhere in the module, and the `DriveClient` Protocol exposes only read methods so future refactors cannot sneak a write in by accident.

Architecture mirrors PR #162's injectable-backend pattern:

- **`DriveFile`** (frozen dataclass) — id, name, mime_type, modified_time, size, parent_path; `is_google_native` recognises Docs / Sheets / Slides.
- **`DriveClient`** Protocol — `is_available`, `list_files`, `get_media`, `export_media`. Tests inject a deterministic `StubDriveClient`.
- **`GoogleApiDriveClient`** (production) — lazy imports `google-api-python-client` and `google-auth-oauthlib`; raises `GoogleApiUnavailableError` with install instructions when missing. OAuth flow caches credentials at `GoogleDriveConfig.token_file`. The existing `GoogleDriveConfig` `@field_validator` already enforces read-only scopes.
- **`GoogleDriveDownloader`** — `list_files`, `download_file`, `download_all`. Mirrors Drive folder hierarchy via `parent_path`; sets local mtime to match Drive's `modified_time` so subsequent runs are truly incremental (skips files whose local mtime is at least as new as Drive). Google-native files are exported through `export_media` to DOCX / XLSX / PPTX with the appropriate suffix substitution.
- **`route_to_ingestor`** — maps file extensions to canonical Creek ingestor keys (`markdown` / `document` / `spreadsheet` / `presentation` / `image` / `generic`) so callers can pipe staged files into `creek ingest`.

CLI: `creek gdrive --download --staging PATH` runs the full sync. Without `--download` the command is a no-op with a hint. When optional Google libs are missing, the command exits 1 with install instructions.

## Test plan

- [x] `./scripts/check-all.sh` — 6/7 gates green (only the dev-container env's pre-existing pip-audit findings remain; CI ignores them via the existing config).
- [x] **32 new tests** in `tests/test_gdrive_downloader.py`:
  - `DriveFile` invariants + `is_google_native` recognition
  - `DriveClient` Protocol structural conformance + **forbidden-write-methods absence** audit
  - `GoogleApiDriveClient` lazy-import contract: monkeypatched `__import__` blocks `googleapiclient` / `google_auth_oauthlib`, three calls all raise `GoogleApiUnavailableError`
  - `route_to_ingestor` parametrized over 10 extensions
  - `download_file`: regular files via `get_media`, Google Doc → DOCX / Sheet → XLSX / Slides → PPTX via `export_media`, missing id raises `KeyError`
  - `download_all`: writes every listed file, preserves folder structure, skips unchanged files on re-run, re-downloads when Drive mtime advances
  - **Read-only audit**: full download cycle records only `list_files` / `get_media` / `export_media` calls; module source has no `.update(` / `.delete(` / `.trash(` / `.copy(` / `permissions().create(` strings
  - Module re-export contract
- [x] **4 new CLI tests** in `tests/test_cli.py`: no-op without `--download`, exits 1 when API unavailable, full happy-path through monkeypatched `GoogleApiDriveClient`
- [x] Coverage stays at 94%+
- [ ] CI: Code Quality & Testing (3.11/3.12/3.13) green
- [ ] Claude review LGTM

Closes #56

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vu1KnoJQDQh4kCLdR6VJTM)_