### PR TITLE
feat(ingest): add XLSX/CSV and PPTX ingestors (#57)

### DIFF
--- a/creek-tools/creek/ingest/__init__.py
+++ b/creek-tools/creek/ingest/__init__.py
@@ -39,6 +39,8 @@ from creek.ingest.gdrive import (
 from creek.ingest.generic import GenericIngestor
 from creek.ingest.images import ImageIngestor
 from creek.ingest.markdown import MarkdownIngestor
+from creek.ingest.presentations import PresentationIngestor
+from creek.ingest.spreadsheets import SpreadsheetIngestor
 
 # Registry mapping ingestor names to their concrete classes.
 # To add a new ingestor, import its class above and add an entry here.
@@ -51,6 +53,8 @@ INGESTOR_REGISTRY: dict[str, type[Ingestor]] = {
     "generic": GenericIngestor,
     "image": ImageIngestor,
     "markdown": MarkdownIngestor,
+    "presentation": PresentationIngestor,
+    "spreadsheet": SpreadsheetIngestor,
 }
 
 __all__ = [
@@ -71,6 +75,8 @@ __all__ = [
     "Ingestor",
     "MarkdownIngestor",
     "ParsedFragment",
+    "PresentationIngestor",
     "RawDocument",
+    "SpreadsheetIngestor",
     "route_to_ingestor",
 ]

--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -242,6 +242,15 @@ def generate_fragment_id(source: str, timestamp: datetime, content: str) -> str:
     return f"frag-{digest}"
 
 
+def file_modified_time(path: Path) -> datetime:
+    """Return *path*'s modification time as a timezone-aware UTC datetime.
+
+    Centralised so file-based ingestors share a single conversion
+    rule and do not drift apart over time.
+    """
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+
+
 def create_provenance_entry(
     source_path: str,
     ingestor_name: str,

--- a/creek-tools/creek/ingest/presentations.py
+++ b/creek-tools/creek/ingest/presentations.py
@@ -1,0 +1,307 @@
+"""Presentation ingestor for the Creek pipeline.
+
+Implements the PPTX half of §57 of the Creek Ontology — ingest
+PowerPoint presentations as one fragment per file, with each slide
+rendered as a labelled markdown section. Speaker notes are inlined
+under their slide so reviewers can see what was said alongside the
+visual content.
+
+The presentation backend is decoupled through the
+:class:`PresentationBackend` Protocol so callers can plug in any
+implementation; tests inject a deterministic stub. The default
+:class:`PythonPptxBackend` lazily imports ``python-pptx`` so the
+rest of the package — and the unit tests — run cleanly even when
+that optional dependency is not installed.
+
+Optional dependency (install separately to enable PPTX support):
+
+* ``python-pptx`` — pure-Python PPTX reader.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from creek.ingest.base import Ingestor, ParsedFragment, RawDocument
+from creek.models import SourcePlatform
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+PRESENTATION_EXTENSIONS: frozenset[str] = frozenset({".pptx"})
+"""File extensions handled by :class:`PresentationIngestor`."""
+
+
+# ---- Public dataclasses + protocol --------------------------------------
+
+
+@dataclass(frozen=True)
+class SlideData:
+    """A single slide's content extracted from a presentation.
+
+    Attributes:
+        index: 1-based slide number.
+        title: Slide title text. ``None`` if no title placeholder.
+        body: Concatenated body / placeholder text, newline-separated.
+        notes: Speaker notes. Empty string when the slide has none.
+    """
+
+    index: int
+    title: str | None
+    body: str
+    notes: str = ""
+
+
+@dataclass(frozen=True)
+class PresentationData:
+    """A presentation decomposed into ordered slides.
+
+    Attributes:
+        title: Optional presentation title (from core properties).
+        slides: Slides in presentation order.
+    """
+
+    title: str | None
+    slides: tuple[SlideData, ...]
+
+
+@runtime_checkable
+class PresentationBackend(Protocol):
+    """Pluggable presentation backend.
+
+    Implementations must be deterministic and side-effect-free; the
+    same input file should always produce the same
+    :class:`PresentationData`.
+    """
+
+    def is_available(self) -> bool:
+        """Return ``True`` when the backend can perform reads right now."""
+
+    def read_presentation(self, path: Path) -> PresentationData:
+        """Read *path* and return its decomposed :class:`PresentationData`."""
+
+
+class PythonPptxUnavailableError(RuntimeError):
+    """Raised when a PPTX read is attempted without ``python-pptx`` installed."""
+
+
+# ---- Default backend ---------------------------------------------------
+
+
+class PythonPptxBackend:
+    """Presentation backend backed by ``python-pptx``.
+
+    Imports of the optional dependency are deferred to call time so
+    the rest of the package runs cleanly without it.
+    """
+
+    def is_available(self) -> bool:
+        """Return ``True`` when ``python-pptx`` imports cleanly."""
+        try:
+            import pptx  # noqa: F401
+        except ImportError:
+            return False
+        return True
+
+    def read_presentation(self, path: Path) -> PresentationData:
+        """Read *path* and return a :class:`PresentationData`.
+
+        Args:
+            path: Filesystem path to a ``.pptx`` file.
+
+        Returns:
+            The decomposed :class:`PresentationData`.
+
+        Raises:
+            PythonPptxUnavailableError: When ``python-pptx`` is not
+                installed.
+        """
+        try:
+            from pptx import Presentation
+        except ImportError as exc:
+            msg = (
+                "python-pptx is required for PPTX ingestion. Install it with "
+                "`pip install python-pptx`."
+            )
+            raise PythonPptxUnavailableError(msg) from exc
+
+        prs = Presentation(str(path))
+        slides: list[SlideData] = []
+        for index, slide in enumerate(prs.slides, start=1):
+            slides.append(_slide_to_data(slide, index))
+        title = self._extract_title(prs)
+        return PresentationData(title=title, slides=tuple(slides))
+
+    @staticmethod
+    def _extract_title(prs: Any) -> str | None:
+        """Return the presentation's core-properties title, if set."""
+        try:
+            return str(prs.core_properties.title) or None
+        except (AttributeError, ValueError):
+            return None
+
+
+def _slide_to_data(slide: Any, index: int) -> SlideData:
+    """Convert a python-pptx slide object into a :class:`SlideData`."""
+    title: str | None = None
+    body_chunks: list[str] = []
+    for shape in slide.shapes:
+        if not getattr(shape, "has_text_frame", False):
+            continue
+        text = shape.text_frame.text.strip()
+        if not text:
+            continue
+        if shape == slide.shapes.title and title is None:
+            title = text
+        else:
+            body_chunks.append(text)
+    notes = ""
+    if getattr(slide, "has_notes_slide", False):
+        try:
+            notes = slide.notes_slide.notes_text_frame.text.strip()
+        except AttributeError:
+            notes = ""
+    return SlideData(
+        index=index,
+        title=title,
+        body="\n".join(body_chunks),
+        notes=notes,
+    )
+
+
+# ---- PresentationIngestor ----------------------------------------------
+
+
+class PresentationIngestor(Ingestor):
+    """Ingest PPTX files as one fragment per presentation."""
+
+    def __init__(self, backend: PresentationBackend | None = None) -> None:
+        """Initialise with a backend; defaults to :class:`PythonPptxBackend`."""
+        self.backend = backend if backend is not None else PythonPptxBackend()
+
+    def discover(self, source_path: Path) -> list[RawDocument]:
+        """Recursively find ``.pptx`` files under *source_path*.
+
+        Single-file paths whose suffix is unsupported return an empty
+        list. File bytes are not slurped at discovery time — the
+        backend reads from disk via the :class:`Path`.
+        """
+        if source_path.is_file():
+            paths = (
+                [source_path]
+                if source_path.suffix.lower() in PRESENTATION_EXTENSIONS
+                else []
+            )
+        else:
+            paths = [
+                p
+                for p in sorted(source_path.rglob("*"))
+                if p.is_file() and p.suffix.lower() in PRESENTATION_EXTENSIONS
+            ]
+        return [
+            RawDocument(
+                path=path,
+                content=b"",
+                metadata={"original_file": str(path)},
+                detected_encoding="binary",
+            )
+            for path in paths
+        ]
+
+    def parse(self, raw: RawDocument) -> list[ParsedFragment]:
+        """Emit a single fragment carrying the entire presentation."""
+        data = self.backend.read_presentation(raw.path)
+        if not data.slides:
+            logger.info(
+                "Presentation %s has no slides; skipping fragment.",
+                raw.path,
+            )
+            return []
+        timestamp = _modified_time(raw.path)
+        return [
+            ParsedFragment(
+                content="",  # Markdown rendered in convert_to_markdown.
+                metadata={
+                    "original_file": str(raw.path),
+                    "title": data.title or raw.path.stem,
+                    "slide_count": len(data.slides),
+                    "slides": [
+                        {
+                            "index": slide.index,
+                            "title": slide.title or "",
+                            "body": slide.body,
+                            "notes": slide.notes,
+                        }
+                        for slide in data.slides
+                    ],
+                },
+                source_path=str(raw.path),
+                timestamp=timestamp,
+            ),
+        ]
+
+    def convert_to_markdown(self, fragment: ParsedFragment) -> str:
+        """Render the presentation as a markdown document.
+
+        One ``## Slide N: Title`` block per slide with the body inlined
+        and speaker notes (when present) under a ``**Speaker notes:**``
+        sub-section.
+        """
+        title = str(fragment.metadata.get("title", "Presentation"))
+        slides: list[dict[str, Any]] = list(fragment.metadata.get("slides", []))
+        lines: list[str] = [f"# {title}", ""]
+        for slide in slides:
+            heading = f"## Slide {slide['index']}"
+            if slide.get("title"):
+                heading = f"{heading}: {slide['title']}"
+            lines.append(heading)
+            lines.append("")
+            body = str(slide.get("body", ""))
+            if body:
+                lines.append(body)
+                lines.append("")
+            notes = str(slide.get("notes", ""))
+            if notes:
+                lines.append("**Speaker notes:**")
+                lines.append("")
+                lines.append(notes)
+                lines.append("")
+        return "\n".join(lines).rstrip() + "\n"
+
+    def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
+        """Produce YAML frontmatter for a presentation fragment."""
+        return {
+            "type": "fragment",
+            "source": {
+                "platform": SourcePlatform.PRESENTATION.value,
+                "original_file": fragment.metadata.get(
+                    "original_file",
+                    fragment.source_path,
+                ),
+            },
+            "title": fragment.metadata.get("title", ""),
+            "slide_count": fragment.metadata.get("slide_count", 0),
+            "ingested": fragment.timestamp.isoformat(),
+        }
+
+
+def _modified_time(path: Path) -> datetime:
+    """Return the file's mtime as a timezone-aware UTC datetime."""
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+
+
+__all__ = [
+    "PRESENTATION_EXTENSIONS",
+    "PresentationBackend",
+    "PresentationData",
+    "PresentationIngestor",
+    "PythonPptxBackend",
+    "PythonPptxUnavailableError",
+    "SlideData",
+]

--- a/creek-tools/creek/ingest/presentations.py
+++ b/creek-tools/creek/ingest/presentations.py
@@ -22,10 +22,14 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
-from creek.ingest.base import Ingestor, ParsedFragment, RawDocument
+from creek.ingest.base import (
+    Ingestor,
+    ParsedFragment,
+    RawDocument,
+    file_modified_time,
+)
 from creek.models import SourcePlatform
 
 if TYPE_CHECKING:
@@ -140,16 +144,29 @@ class PythonPptxBackend:
 
     @staticmethod
     def _extract_title(prs: Any) -> str | None:
-        """Return the presentation's core-properties title, if set."""
+        """Return the presentation's core-properties title, if set.
+
+        ``python-pptx`` exposes ``core_properties.title`` as either a
+        non-empty string, an empty string, or ``None``. We coerce all
+        absent-or-blank cases to ``None`` so callers can safely fall
+        back to the file stem with ``data.title or path.stem`` —
+        without the literal string ``"None"`` ever surfacing in
+        rendered markdown or YAML frontmatter.
+        """
         try:
-            return str(prs.core_properties.title) or None
+            title = prs.core_properties.title
         except (AttributeError, ValueError):
             return None
+        if title is None:
+            return None
+        stripped = str(title).strip()
+        return stripped or None
 
 
 def _slide_to_data(slide: Any, index: int) -> SlideData:
     """Convert a python-pptx slide object into a :class:`SlideData`."""
     title: str | None = None
+    title_shape = slide.shapes.title
     body_chunks: list[str] = []
     for shape in slide.shapes:
         if not getattr(shape, "has_text_frame", False):
@@ -157,7 +174,7 @@ def _slide_to_data(slide: Any, index: int) -> SlideData:
         text = shape.text_frame.text.strip()
         if not text:
             continue
-        if shape == slide.shapes.title and title is None:
+        if title_shape is not None and shape is title_shape and title is None:
             title = text
         else:
             body_chunks.append(text)
@@ -223,7 +240,7 @@ class PresentationIngestor(Ingestor):
                 raw.path,
             )
             return []
-        timestamp = _modified_time(raw.path)
+        timestamp = file_modified_time(raw.path)
         return [
             ParsedFragment(
                 content="",  # Markdown rendered in convert_to_markdown.
@@ -289,11 +306,6 @@ class PresentationIngestor(Ingestor):
             "slide_count": fragment.metadata.get("slide_count", 0),
             "ingested": fragment.timestamp.isoformat(),
         }
-
-
-def _modified_time(path: Path) -> datetime:
-    """Return the file's mtime as a timezone-aware UTC datetime."""
-    return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
 
 
 __all__ = [

--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -179,11 +179,36 @@ def _cell_to_str(value: Any) -> str:
     return str(value)
 
 
+CSV_ENCODING_FALLBACKS: tuple[str, ...] = ("utf-8-sig", "cp1252")
+"""Encoding probe order for CSV reads.
+
+``utf-8-sig`` decodes plain UTF-8 *and* strips the UTF-8 BOM that
+Excel emits for "CSV UTF-8" exports. ``cp1252`` is the Windows
+default for legacy Excel "CSV (Comma delimited)" exports — a near
+superset of Latin-1 that decodes any byte sequence without raising,
+so it serves as a guaranteed-success fallback.
+"""
+
+
 def _read_csv(path: Path) -> WorkbookData:
-    """Read a CSV file as a single-sheet workbook."""
-    with path.open("r", encoding="utf-8", newline="") as handle:
-        rows = [tuple(row) for row in csv.reader(handle)]
-    return WorkbookData(sheets=(_split_header(path.stem, rows),))
+    """Read a CSV file as a single-sheet workbook.
+
+    Tries each encoding in :data:`CSV_ENCODING_FALLBACKS` in order —
+    decoding with the first that succeeds. ``cp1252`` is positioned
+    last because it accepts arbitrary bytes and so always succeeds,
+    guaranteeing the read never raises ``UnicodeDecodeError``.
+    """
+    raw = path.read_bytes()
+    for encoding in CSV_ENCODING_FALLBACKS:
+        try:
+            text = raw.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+        rows = [tuple(row) for row in csv.reader(text.splitlines())]
+        return WorkbookData(sheets=(_split_header(path.stem, rows),))
+    # Should be unreachable: cp1252 decodes any byte sequence.
+    msg = f"Unable to decode CSV {path} with any known encoding."
+    raise UnicodeDecodeError("csv", raw, 0, 1, msg)  # pragma: no cover
 
 
 def _split_header(
@@ -328,24 +353,54 @@ def _extract_headers_and_rows(
     return headers, rows
 
 
+def _escape_cell(value: object) -> str:
+    """Escape a cell value for safe inclusion in a GFM table.
+
+    GFM uses ``|`` as the column separator and a literal newline as
+    the row terminator, so cells carrying either character would
+    corrupt the table layout. We escape ``|`` to ``\\|`` (the GFM
+    canonical form) and replace any newline with ``<br>`` so the
+    cell renders on a single visual line.
+    """
+    return (
+        str(value)
+        .replace("|", r"\|")
+        .replace("\r\n", "<br>")
+        .replace("\n", "<br>")
+        .replace("\r", "<br>")
+    )
+
+
+def _render_row(cells: list[str] | tuple[str, ...]) -> str:
+    """Render one GFM table row from a sequence of pre-escaped cells."""
+    return "| " + " | ".join(cells) + " |"
+
+
 def _render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
-    """Return markdown lines for a GFM table, summarising oversize sheets."""
+    """Return markdown lines for a GFM table, summarising oversize sheets.
+
+    Cells are escaped via :func:`_escape_cell` so values containing
+    ``|`` or newlines do not corrupt the table. Sheets larger than
+    :data:`SUMMARY_THRESHOLD` are emitted as a single table whose
+    body is the head + tail rows; the summary note appears *before*
+    the table so the reader sees the truncation context first.
+    """
+    safe_headers = [_escape_cell(header) for header in headers]
+    separator = _render_row(["---"] * len(safe_headers))
     lines: list[str] = []
-    lines.append("| " + " | ".join(headers) + " |")
-    lines.append("| " + " | ".join("---" for _ in headers) + " |")
     if len(rows) > SUMMARY_THRESHOLD:
-        lines.append(
-            f"_Showing first {SUMMARY_HEAD_ROWS} and last "
-            f"{SUMMARY_TAIL_ROWS} of {len(rows)} rows._",
+        lines.extend(
+            (
+                f"_Showing first {SUMMARY_HEAD_ROWS} and last "
+                f"{SUMMARY_TAIL_ROWS} of {len(rows)} rows._",
+                "",
+            ),
         )
-        lines.append("")
-        lines.append("| " + " | ".join(headers) + " |")
-        lines.append("| " + " | ".join("---" for _ in headers) + " |")
         displayed = rows[:SUMMARY_HEAD_ROWS] + rows[-SUMMARY_TAIL_ROWS:]
     else:
         displayed = rows
-    for row in displayed:
-        lines.append("| " + " | ".join(str(cell) for cell in row) + " |")
+    lines.extend((_render_row(safe_headers), separator))
+    lines.extend(_render_row([_escape_cell(cell) for cell in row]) for row in displayed)
     return lines
 
 

--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -1,0 +1,363 @@
+"""Spreadsheet ingestor for the Creek pipeline.
+
+Implements §57 of the Creek Ontology — ingest XLSX workbooks (one
+fragment per sheet) and CSV files (one fragment per file). The
+spreadsheet backend is decoupled through the
+:class:`SpreadsheetBackend` Protocol so callers can plug in any
+implementation; tests inject a deterministic stub. The default
+:class:`OpenpyxlBackend` lazily imports ``openpyxl`` so the rest of
+the package — and the unit tests — run cleanly even when that
+optional dependency is not installed. CSV parsing uses Python's
+stdlib ``csv`` module and works without any optional dependency.
+
+Sheets larger than :data:`SUMMARY_THRESHOLD` rows render as a
+truncated table with the first :data:`SUMMARY_HEAD_ROWS` and last
+:data:`SUMMARY_TAIL_ROWS` rows plus the total row count, so giant
+exports stay legible without re-paginating the entire vault entry.
+
+Optional dependency (install separately to enable XLSX support):
+
+* ``openpyxl`` — pure-Python XLSX reader.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from creek.ingest.base import Ingestor, ParsedFragment, RawDocument
+from creek.models import SourcePlatform
+
+logger = logging.getLogger(__name__)
+
+
+SPREADSHEET_EXTENSIONS: frozenset[str] = frozenset({".xlsx", ".csv"})
+"""File extensions handled by :class:`SpreadsheetIngestor`."""
+
+
+SUMMARY_THRESHOLD: int = 100
+"""Row count above which a sheet renders as a head/tail summary."""
+
+SUMMARY_HEAD_ROWS: int = 10
+"""Number of leading rows kept in a summarised table."""
+
+SUMMARY_TAIL_ROWS: int = 5
+"""Number of trailing rows kept in a summarised table."""
+
+
+# ---- Public dataclasses + protocol --------------------------------------
+
+
+@dataclass(frozen=True)
+class SheetData:
+    """A single worksheet within a workbook.
+
+    Attributes:
+        name: Sheet name as it appears in the workbook.
+        headers: Optional header row (auto-detected by the backend);
+            ``None`` when the first row is data.
+        rows: All data rows as tuples of strings (formulas resolved to
+            calculated values, dates ISO-formatted).
+    """
+
+    name: str
+    headers: tuple[str, ...] | None
+    rows: tuple[tuple[str, ...], ...]
+
+    @property
+    def is_empty(self) -> bool:
+        """``True`` when neither headers nor rows carry any signal."""
+        return not self.rows and not self.headers
+
+
+@dataclass(frozen=True)
+class WorkbookData:
+    """A workbook (XLSX or CSV) decomposed into sheets.
+
+    A CSV file always presents as a one-sheet workbook whose sheet is
+    named after the file stem.
+    """
+
+    sheets: tuple[SheetData, ...]
+
+
+@runtime_checkable
+class SpreadsheetBackend(Protocol):
+    """Pluggable spreadsheet backend.
+
+    Implementations must be deterministic and side-effect-free; the
+    same input file should always produce the same
+    :class:`WorkbookData`.
+    """
+
+    def is_available(self) -> bool:
+        """Return ``True`` when the backend can perform reads right now."""
+
+    def read_workbook(self, path: Path) -> WorkbookData:
+        """Read *path* and return its decomposed :class:`WorkbookData`."""
+
+
+class OpenpyxlUnavailableError(RuntimeError):
+    """Raised when an XLSX read is attempted without ``openpyxl`` installed."""
+
+
+# ---- Default backend ---------------------------------------------------
+
+
+class OpenpyxlBackend:
+    """Spreadsheet backend backed by ``openpyxl`` (XLSX) and stdlib ``csv``.
+
+    Imports of the optional ``openpyxl`` dependency are deferred to
+    call time so the rest of the package runs cleanly without it.
+    CSV files are read via Python's stdlib :mod:`csv` module and
+    therefore always work — ``is_available()`` reflects only the
+    XLSX path.
+    """
+
+    def is_available(self) -> bool:
+        """Return ``True`` when ``openpyxl`` imports cleanly."""
+        try:
+            import openpyxl  # noqa: F401
+        except ImportError:
+            return False
+        return True
+
+    def read_workbook(self, path: Path) -> WorkbookData:
+        """Read *path* and return a :class:`WorkbookData`.
+
+        Args:
+            path: Filesystem path to a ``.xlsx`` or ``.csv`` file.
+
+        Returns:
+            A :class:`WorkbookData` with one or more
+            :class:`SheetData` entries.
+
+        Raises:
+            OpenpyxlUnavailableError: When *path* is an XLSX file and
+                ``openpyxl`` is not installed.
+        """
+        suffix = path.suffix.lower()
+        if suffix == ".csv":
+            return _read_csv(path)
+        return self._read_xlsx(path)
+
+    @staticmethod
+    def _read_xlsx(path: Path) -> WorkbookData:
+        """Read an XLSX file via ``openpyxl``."""
+        try:
+            import openpyxl
+        except ImportError as exc:
+            msg = (
+                "openpyxl is required for XLSX ingestion. Install it with "
+                "`pip install openpyxl`."
+            )
+            raise OpenpyxlUnavailableError(msg) from exc
+
+        workbook = openpyxl.load_workbook(path, data_only=True, read_only=True)
+        sheets: list[SheetData] = []
+        for name in workbook.sheetnames:
+            worksheet = workbook[name]
+            raw_rows = [
+                tuple(_cell_to_str(cell) for cell in row)
+                for row in worksheet.iter_rows(values_only=True)
+            ]
+            sheets.append(_split_header(name, raw_rows))
+        workbook.close()
+        return WorkbookData(sheets=tuple(sheets))
+
+
+def _cell_to_str(value: Any) -> str:
+    """Coerce a workbook cell value to its display string form."""
+    if value is None:
+        return ""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value)
+
+
+def _read_csv(path: Path) -> WorkbookData:
+    """Read a CSV file as a single-sheet workbook."""
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        rows = [tuple(row) for row in csv.reader(handle)]
+    return WorkbookData(sheets=(_split_header(path.stem, rows),))
+
+
+def _split_header(
+    name: str,
+    rows: list[tuple[str, ...]],
+) -> SheetData:
+    """Split *rows* into ``(headers, data_rows)``.
+
+    Auto-detects a header row: the first row qualifies when every
+    cell is a non-empty string. Otherwise the first row is treated
+    as data and ``headers`` is ``None``.
+    """
+    if not rows:
+        return SheetData(name=name, headers=None, rows=())
+    first = rows[0]
+    if first and all(cell.strip() for cell in first):
+        return SheetData(
+            name=name,
+            headers=tuple(first),
+            rows=tuple(rows[1:]),
+        )
+    return SheetData(name=name, headers=None, rows=tuple(rows))
+
+
+# ---- SpreadsheetIngestor -----------------------------------------------
+
+
+class SpreadsheetIngestor(Ingestor):
+    """Ingest XLSX and CSV files as one fragment per sheet."""
+
+    def __init__(self, backend: SpreadsheetBackend | None = None) -> None:
+        """Initialise with a backend; defaults to :class:`OpenpyxlBackend`."""
+        self.backend = backend if backend is not None else OpenpyxlBackend()
+
+    def discover(self, source_path: Path) -> list[RawDocument]:
+        """Recursively find ``.xlsx`` and ``.csv`` files under *source_path*.
+
+        Single-file paths whose suffix is unsupported return an empty
+        list so the ingest pipeline can route them elsewhere. File
+        bytes are not slurped at discovery time — each backend reads
+        from disk via the :class:`Path`.
+        """
+        if source_path.is_file():
+            paths = (
+                [source_path]
+                if source_path.suffix.lower() in SPREADSHEET_EXTENSIONS
+                else []
+            )
+        else:
+            paths = [
+                p
+                for p in sorted(source_path.rglob("*"))
+                if p.is_file() and p.suffix.lower() in SPREADSHEET_EXTENSIONS
+            ]
+        return [
+            RawDocument(
+                path=path,
+                content=b"",
+                metadata={"original_file": str(path)},
+                detected_encoding="binary"
+                if path.suffix.lower() == ".xlsx"
+                else "utf-8",
+            )
+            for path in paths
+        ]
+
+    def parse(self, raw: RawDocument) -> list[ParsedFragment]:
+        """Read the workbook and emit one fragment per non-empty sheet."""
+        workbook = self.backend.read_workbook(raw.path)
+        timestamp = _modified_time(raw.path)
+        fragments: list[ParsedFragment] = []
+        for sheet in workbook.sheets:
+            if sheet.is_empty:
+                continue
+            column_count = (
+                len(sheet.headers)
+                if sheet.headers
+                else (len(sheet.rows[0]) if sheet.rows else 0)
+            )
+            fragments.append(
+                ParsedFragment(
+                    content="",  # Markdown rendered in convert_to_markdown.
+                    metadata={
+                        "original_file": str(raw.path),
+                        "sheet": sheet.name,
+                        "rows": len(sheet.rows),
+                        "columns": column_count,
+                        "headers": list(sheet.headers) if sheet.headers else [],
+                        "row_data": [list(row) for row in sheet.rows],
+                    },
+                    source_path=str(raw.path),
+                    timestamp=timestamp,
+                ),
+            )
+        return fragments
+
+    def convert_to_markdown(self, fragment: ParsedFragment) -> str:
+        """Render the sheet as a GFM table with optional summary truncation."""
+        headers, rows = _extract_headers_and_rows(fragment)
+        sheet_name = str(fragment.metadata.get("sheet", "Sheet"))
+        original = Path(
+            str(fragment.metadata.get("original_file", fragment.source_path))
+        )
+        lines = [f"# {original.name} — {sheet_name}", ""]
+        if not headers and not rows:
+            lines.append("_(empty sheet)_")
+            return "\n".join(lines) + "\n"
+        lines.extend(_render_table(headers, rows))
+        return "\n".join(lines) + "\n"
+
+    def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
+        """Produce YAML frontmatter for a spreadsheet fragment."""
+        return {
+            "type": "fragment",
+            "source": {
+                "platform": SourcePlatform.SPREADSHEET.value,
+                "original_file": fragment.metadata.get(
+                    "original_file",
+                    fragment.source_path,
+                ),
+            },
+            "sheet": fragment.metadata.get("sheet", ""),
+            "rows": fragment.metadata.get("rows", 0),
+            "columns": fragment.metadata.get("columns", 0),
+            "ingested": fragment.timestamp.isoformat(),
+        }
+
+
+def _modified_time(path: Path) -> datetime:
+    """Return the file's mtime as a timezone-aware UTC datetime."""
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+
+
+def _extract_headers_and_rows(
+    fragment: ParsedFragment,
+) -> tuple[list[str], list[list[str]]]:
+    """Return ``(headers, rows)`` from a parsed fragment's metadata."""
+    headers: list[str] = list(fragment.metadata.get("headers", []))
+    rows: list[list[str]] = [list(row) for row in fragment.metadata.get("row_data", [])]
+    if not headers and rows:
+        headers = [f"col{i + 1}" for i in range(len(rows[0]))]
+    return headers, rows
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> list[str]:
+    """Return markdown lines for a GFM table, summarising oversize sheets."""
+    lines: list[str] = []
+    lines.append("| " + " | ".join(headers) + " |")
+    lines.append("| " + " | ".join("---" for _ in headers) + " |")
+    if len(rows) > SUMMARY_THRESHOLD:
+        lines.append(
+            f"_Showing first {SUMMARY_HEAD_ROWS} and last "
+            f"{SUMMARY_TAIL_ROWS} of {len(rows)} rows._",
+        )
+        lines.append("")
+        lines.append("| " + " | ".join(headers) + " |")
+        lines.append("| " + " | ".join("---" for _ in headers) + " |")
+        displayed = rows[:SUMMARY_HEAD_ROWS] + rows[-SUMMARY_TAIL_ROWS:]
+    else:
+        displayed = rows
+    for row in displayed:
+        lines.append("| " + " | ".join(str(cell) for cell in row) + " |")
+    return lines
+
+
+__all__ = [
+    "SPREADSHEET_EXTENSIONS",
+    "SUMMARY_HEAD_ROWS",
+    "SUMMARY_TAIL_ROWS",
+    "SUMMARY_THRESHOLD",
+    "OpenpyxlBackend",
+    "OpenpyxlUnavailableError",
+    "SheetData",
+    "SpreadsheetBackend",
+    "SpreadsheetIngestor",
+    "WorkbookData",
+]

--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -25,11 +25,16 @@ from __future__ import annotations
 import csv
 import logging
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
-from creek.ingest.base import Ingestor, ParsedFragment, RawDocument
+from creek.ingest.base import (
+    Ingestor,
+    ParsedFragment,
+    RawDocument,
+    file_modified_time,
+)
 from creek.models import SourcePlatform
 
 logger = logging.getLogger(__name__)
@@ -206,9 +211,11 @@ def _read_csv(path: Path) -> WorkbookData:
             continue
         rows = [tuple(row) for row in csv.reader(text.splitlines())]
         return WorkbookData(sheets=(_split_header(path.stem, rows),))
-    # Should be unreachable: cp1252 decodes any byte sequence.
+    # Unreachable: ``cp1252`` accepts any byte sequence so the loop
+    # always returns. We keep this guard so a future change to the
+    # fallback list cannot silently produce an undefined return.
     msg = f"Unable to decode CSV {path} with any known encoding."
-    raise UnicodeDecodeError("csv", raw, 0, 1, msg)  # pragma: no cover
+    raise AssertionError(msg)  # pragma: no cover
 
 
 def _split_header(
@@ -278,7 +285,7 @@ class SpreadsheetIngestor(Ingestor):
     def parse(self, raw: RawDocument) -> list[ParsedFragment]:
         """Read the workbook and emit one fragment per non-empty sheet."""
         workbook = self.backend.read_workbook(raw.path)
-        timestamp = _modified_time(raw.path)
+        timestamp = file_modified_time(raw.path)
         fragments: list[ParsedFragment] = []
         for sheet in workbook.sheets:
             if sheet.is_empty:
@@ -335,11 +342,6 @@ class SpreadsheetIngestor(Ingestor):
             "columns": fragment.metadata.get("columns", 0),
             "ingested": fragment.timestamp.isoformat(),
         }
-
-
-def _modified_time(path: Path) -> datetime:
-    """Return the file's mtime as a timezone-aware UTC datetime."""
-    return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
 
 
 def _extract_headers_and_rows(

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -177,6 +177,8 @@ class SourcePlatform(StrEnum):
     EMAIL = "email"
     DOCUMENT = "document"
     IMAGE_OCR = "image_ocr"
+    SPREADSHEET = "spreadsheet"
+    PRESENTATION = "presentation"
     OTHER = "other"
 
 

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -135,6 +135,10 @@ module = ["pytesseract", "PIL", "PIL.*", "pdf2image", "pdf2image.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
+module = ["openpyxl", "openpyxl.*", "pptx", "pptx.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = [
     "googleapiclient",
     "googleapiclient.*",

--- a/creek-tools/tests/test_models.py
+++ b/creek-tools/tests/test_models.py
@@ -239,7 +239,7 @@ class TestSourcePlatformEnum:
     """Tests for the SourcePlatform enum."""
 
     def test_all_platforms_exist(self) -> None:
-        """Verify all 10 source platform values exist."""
+        """Verify all 12 source platform values exist."""
         expected = [
             "claude",
             "chatgpt",
@@ -250,6 +250,8 @@ class TestSourcePlatformEnum:
             "email",
             "document",
             "image_ocr",
+            "spreadsheet",
+            "presentation",
             "other",
         ]
         actual = [s.value for s in SourcePlatform]

--- a/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
+++ b/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
@@ -1,0 +1,663 @@
+"""Tests for the spreadsheet and presentation ingestors (#57)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.ingest.presentations import (
+    PRESENTATION_EXTENSIONS,
+    PresentationBackend,
+    PresentationData,
+    PresentationIngestor,
+    PythonPptxBackend,
+    PythonPptxUnavailableError,
+    SlideData,
+)
+from creek.ingest.spreadsheets import (
+    SPREADSHEET_EXTENSIONS,
+    OpenpyxlBackend,
+    OpenpyxlUnavailableError,
+    SheetData,
+    SpreadsheetBackend,
+    SpreadsheetIngestor,
+    WorkbookData,
+)
+from creek.models import SourcePlatform
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---- Stub backends -----------------------------------------------------
+
+
+class StubSpreadsheetBackend:
+    """Deterministic spreadsheet backend for tests."""
+
+    def __init__(self, workbooks: dict[str, WorkbookData] | None = None) -> None:
+        """Seed the backend with canned workbook data keyed by filename."""
+        self._workbooks = dict(workbooks or {})
+        self.calls: list[str] = []
+
+    def is_available(self) -> bool:
+        """Stubs are always available."""
+        return True
+
+    def read_workbook(self, path: Path) -> WorkbookData:
+        """Return the canned workbook for *path*."""
+        self.calls.append(f"read_workbook:{path.name}")
+        return self._workbooks[path.name]
+
+
+class StubPresentationBackend:
+    """Deterministic presentation backend for tests."""
+
+    def __init__(
+        self,
+        presentations: dict[str, PresentationData] | None = None,
+    ) -> None:
+        """Seed the backend with canned presentation data keyed by filename."""
+        self._presentations = dict(presentations or {})
+        self.calls: list[str] = []
+
+    def is_available(self) -> bool:
+        """Stubs are always available."""
+        return True
+
+    def read_presentation(self, path: Path) -> PresentationData:
+        """Return the canned presentation for *path*."""
+        self.calls.append(f"read_presentation:{path.name}")
+        return self._presentations[path.name]
+
+
+def _make_import_blocker(blocked: set[str]) -> object:
+    """Build a ``__import__`` replacement that raises for *blocked*."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _blocked_import(
+        name: str,
+        module_globals: dict[str, object] | None = None,
+        module_locals: dict[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
+        """Raise ImportError for blocked roots; defer everything else."""
+        root = name.split(".", 1)[0]
+        if root in blocked or name in blocked:
+            msg = f"mocked-missing: {name}"
+            raise ImportError(msg)
+        return real_import(name, module_globals, module_locals, fromlist, level)
+
+    return _blocked_import
+
+
+# ---- Helpers -----------------------------------------------------------
+
+
+def _write_xlsx_placeholder(path: Path) -> None:
+    """Write a minimal XLSX magic-byte placeholder (parsed via stub backend)."""
+    path.write_bytes(b"PK\x03\x04 placeholder")
+
+
+def _write_csv(path: Path, rows: list[list[str]]) -> None:
+    """Write a comma-separated value file at *path*."""
+    import csv
+
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        csv.writer(handle).writerows(rows)
+
+
+def _write_pptx_placeholder(path: Path) -> None:
+    """Write a minimal PPTX magic-byte placeholder (parsed via stub backend)."""
+    path.write_bytes(b"PK\x03\x04 placeholder pptx")
+
+
+# =======================================================================
+# SpreadsheetIngestor
+# =======================================================================
+
+
+class TestModuleConstants:
+    """Public constants exposed by the spreadsheet module."""
+
+    def test_extensions_cover_xlsx_and_csv(self) -> None:
+        """Both .xlsx and .csv are recognised."""
+        assert ".xlsx" in SPREADSHEET_EXTENSIONS
+        assert ".csv" in SPREADSHEET_EXTENSIONS
+
+
+class TestSheetData:
+    """Invariants on the :class:`SheetData` value object."""
+
+    def test_immutable_rows_are_tuples(self) -> None:
+        """Rows are stored as tuples of tuples — immutable end-to-end."""
+        sheet = SheetData(
+            name="Q1",
+            headers=("month", "amount"),
+            rows=(("Jan", "100"), ("Feb", "200")),
+        )
+        assert isinstance(sheet.rows, tuple)
+        assert isinstance(sheet.rows[0], tuple)
+
+
+# ---- discover ---------------------------------------------------------
+
+
+class TestSpreadsheetDiscover:
+    """`SpreadsheetIngestor.discover` finds the right files."""
+
+    def test_finds_xlsx_and_csv(self, tmp_path: Path) -> None:
+        """Both .xlsx and .csv files are discovered."""
+        _write_xlsx_placeholder(tmp_path / "a.xlsx")
+        _write_csv(tmp_path / "b.csv", [["h"], ["v"]])
+        ingestor = SpreadsheetIngestor(backend=StubSpreadsheetBackend())
+        raws = ingestor.discover(tmp_path)
+        assert {raw.path.name for raw in raws} == {"a.xlsx", "b.csv"}
+
+    def test_ignores_non_spreadsheet_files(self, tmp_path: Path) -> None:
+        """Files with unsupported extensions are skipped."""
+        _write_xlsx_placeholder(tmp_path / "ok.xlsx")
+        (tmp_path / "note.md").write_text("# md")
+        (tmp_path / "shot.png").write_bytes(b"\x89PNG")
+        ingestor = SpreadsheetIngestor(backend=StubSpreadsheetBackend())
+        raws = ingestor.discover(tmp_path)
+        assert [raw.path.name for raw in raws] == ["ok.xlsx"]
+
+    def test_recursive_discovery(self, tmp_path: Path) -> None:
+        """Files in subdirectories are found."""
+        nested = tmp_path / "deep"
+        nested.mkdir()
+        _write_xlsx_placeholder(nested / "deep.xlsx")
+        ingestor = SpreadsheetIngestor(backend=StubSpreadsheetBackend())
+        raws = ingestor.discover(tmp_path)
+        assert any("deep.xlsx" in str(raw.path) for raw in raws)
+
+    def test_extension_match_is_case_insensitive(self, tmp_path: Path) -> None:
+        """``.XLSX`` and ``.CSV`` count too."""
+        _write_xlsx_placeholder(tmp_path / "shout.XLSX")
+        ingestor = SpreadsheetIngestor(backend=StubSpreadsheetBackend())
+        raws = ingestor.discover(tmp_path)
+        assert {raw.path.name for raw in raws} == {"shout.XLSX"}
+
+    def test_single_image_file_returns_empty(self, tmp_path: Path) -> None:
+        """A single non-spreadsheet file returns an empty discovery."""
+        png = tmp_path / "x.png"
+        png.write_bytes(b"\x89PNG")
+        ingestor = SpreadsheetIngestor(backend=StubSpreadsheetBackend())
+        assert ingestor.discover(png) == []
+
+    def test_does_not_load_file_bytes(self, tmp_path: Path) -> None:
+        """Discovery records the path but does not slurp the bytes."""
+        path = tmp_path / "huge.xlsx"
+        _write_xlsx_placeholder(path)
+        ingestor = SpreadsheetIngestor(backend=StubSpreadsheetBackend())
+        raws = ingestor.discover(tmp_path)
+        assert raws[0].content == b""
+
+
+# ---- parse / ingest ---------------------------------------------------
+
+
+class TestSpreadsheetParse:
+    """Each sheet becomes a :class:`ParsedFragment`."""
+
+    def test_one_fragment_per_sheet(self, tmp_path: Path) -> None:
+        """A workbook with two sheets yields two fragments."""
+        path = tmp_path / "report.xlsx"
+        _write_xlsx_placeholder(path)
+        backend = StubSpreadsheetBackend(
+            workbooks={
+                "report.xlsx": WorkbookData(
+                    sheets=(
+                        SheetData(
+                            name="Q1",
+                            headers=("month", "amount"),
+                            rows=(("Jan", "100"),),
+                        ),
+                        SheetData(
+                            name="Q2",
+                            headers=("month", "amount"),
+                            rows=(("Apr", "300"),),
+                        ),
+                    ),
+                ),
+            },
+        )
+        ingestor = SpreadsheetIngestor(backend=backend)
+        raws = ingestor.discover(tmp_path)
+        fragments = ingestor.parse(raws[0])
+        assert len(fragments) == 2
+        assert {f.metadata["sheet"] for f in fragments} == {"Q1", "Q2"}
+
+    def test_fragment_metadata_records_dimensions(self, tmp_path: Path) -> None:
+        """``rows`` / ``columns`` are recorded on each fragment's metadata."""
+        path = tmp_path / "data.xlsx"
+        _write_xlsx_placeholder(path)
+        backend = StubSpreadsheetBackend(
+            workbooks={
+                "data.xlsx": WorkbookData(
+                    sheets=(
+                        SheetData(
+                            name="Sheet1",
+                            headers=("a", "b", "c"),
+                            rows=(("1", "2", "3"), ("4", "5", "6")),
+                        ),
+                    ),
+                ),
+            },
+        )
+        ingestor = SpreadsheetIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert fragments[0].metadata["rows"] == 2
+        assert fragments[0].metadata["columns"] == 3
+
+    def test_empty_sheet_yields_no_fragment(self, tmp_path: Path) -> None:
+        """A sheet with no headers and no rows is dropped."""
+        path = tmp_path / "blank.xlsx"
+        _write_xlsx_placeholder(path)
+        backend = StubSpreadsheetBackend(
+            workbooks={
+                "blank.xlsx": WorkbookData(
+                    sheets=(SheetData(name="Empty", headers=None, rows=()),),
+                ),
+            },
+        )
+        ingestor = SpreadsheetIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert fragments == []
+
+
+# ---- convert_to_markdown ----------------------------------------------
+
+
+class TestSpreadsheetMarkdown:
+    """Markdown rendering uses GFM tables."""
+
+    def test_small_sheet_renders_full_table(self, tmp_path: Path) -> None:
+        """A small sheet (≤ summary threshold) renders every row."""
+        path = tmp_path / "small.xlsx"
+        _write_xlsx_placeholder(path)
+        backend = StubSpreadsheetBackend(
+            workbooks={
+                "small.xlsx": WorkbookData(
+                    sheets=(
+                        SheetData(
+                            name="Sheet1",
+                            headers=("month", "amount"),
+                            rows=(("Jan", "100"), ("Feb", "200")),
+                        ),
+                    ),
+                ),
+            },
+        )
+        ingestor = SpreadsheetIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        markdown = ingestor.convert_to_markdown(fragments[0])
+        assert "| month | amount |" in markdown
+        assert "| --- | --- |" in markdown
+        assert "| Jan | 100 |" in markdown
+        assert "| Feb | 200 |" in markdown
+
+    def test_large_sheet_is_summarised(self, tmp_path: Path) -> None:
+        """A sheet > summary threshold shows first/last N rows + total count."""
+        path = tmp_path / "huge.xlsx"
+        _write_xlsx_placeholder(path)
+        big_rows = tuple((str(i), f"v{i}") for i in range(150))
+        backend = StubSpreadsheetBackend(
+            workbooks={
+                "huge.xlsx": WorkbookData(
+                    sheets=(
+                        SheetData(
+                            name="Big",
+                            headers=("idx", "value"),
+                            rows=big_rows,
+                        ),
+                    ),
+                ),
+            },
+        )
+        ingestor = SpreadsheetIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        markdown = ingestor.convert_to_markdown(fragments[0])
+        assert "150 rows" in markdown  # Total count surfaced.
+        assert "v0" in markdown  # First few rows kept.
+        assert "v149" in markdown  # Last few rows kept.
+        # Middle rows trimmed:
+        assert "v75" not in markdown
+
+
+# ---- generate_frontmatter ---------------------------------------------
+
+
+class TestSpreadsheetFrontmatter:
+    """Frontmatter shape for spreadsheet fragments."""
+
+    def test_frontmatter_records_platform_and_dimensions(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Frontmatter has source.platform=spreadsheet plus sheet/row/col counts."""
+        from datetime import UTC, datetime
+
+        from creek.ingest.base import ParsedFragment
+
+        fragment = ParsedFragment(
+            content="",
+            metadata={
+                "original_file": str(tmp_path / "x.xlsx"),
+                "sheet": "Q1",
+                "rows": 5,
+                "columns": 3,
+            },
+            source_path=str(tmp_path / "x.xlsx"),
+            timestamp=datetime(2026, 4, 27, tzinfo=UTC),
+        )
+        ingestor = SpreadsheetIngestor(backend=StubSpreadsheetBackend())
+        fm = ingestor.generate_frontmatter(fragment)
+        assert fm["source"]["platform"] == SourcePlatform.SPREADSHEET.value
+        assert fm["sheet"] == "Q1"
+        assert fm["rows"] == 5
+        assert fm["columns"] == 3
+
+
+# ---- CSV path --------------------------------------------------------
+
+
+class TestCsvFiles:
+    """CSV files are read directly through Python's stdlib."""
+
+    def test_csv_renders_as_single_sheet(self, tmp_path: Path) -> None:
+        """A CSV file is parsed as one sheet named after the file."""
+        csv_path = tmp_path / "rows.csv"
+        _write_csv(csv_path, [["a", "b"], ["1", "2"], ["3", "4"]])
+        # Use the production OpenpyxlBackend; CSV parsing does not
+        # require the optional openpyxl dep.
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert len(fragments) == 1
+        markdown = ingestor.convert_to_markdown(fragments[0])
+        assert "| a | b |" in markdown
+        assert "| 1 | 2 |" in markdown
+
+
+# ---- OpenpyxlBackend lazy-import ---------------------------------------
+
+
+class TestOpenpyxlBackend:
+    """Default backend respects the optional-dep contract."""
+
+    def test_is_available_returns_false_without_openpyxl(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without openpyxl, the backend reports unavailable."""
+        import builtins
+
+        monkeypatch.setattr(
+            builtins,
+            "__import__",
+            _make_import_blocker({"openpyxl"}),
+        )
+        backend = OpenpyxlBackend()
+        assert not backend.is_available()
+
+    def test_xlsx_read_raises_without_openpyxl(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Reading an .xlsx without openpyxl raises a clear error."""
+        import builtins
+
+        monkeypatch.setattr(
+            builtins,
+            "__import__",
+            _make_import_blocker({"openpyxl"}),
+        )
+        path = tmp_path / "x.xlsx"
+        _write_xlsx_placeholder(path)
+        backend = OpenpyxlBackend()
+        with pytest.raises(OpenpyxlUnavailableError, match="openpyxl"):
+            backend.read_workbook(path)
+
+
+# =======================================================================
+# PresentationIngestor
+# =======================================================================
+
+
+class TestPresentationConstants:
+    """Public constants exposed by the presentation module."""
+
+    def test_extensions_cover_pptx(self) -> None:
+        """``.pptx`` is the only supported extension."""
+        assert ".pptx" in PRESENTATION_EXTENSIONS
+
+
+class TestSlideData:
+    """Invariants on the :class:`SlideData` value object."""
+
+    def test_default_notes_is_empty(self) -> None:
+        """Slides without speaker notes carry an empty notes string."""
+        slide = SlideData(index=1, title="Title", body="Body")
+        assert slide.notes == ""
+
+
+# ---- discover ---------------------------------------------------------
+
+
+class TestPresentationDiscover:
+    """`PresentationIngestor.discover` finds .pptx files."""
+
+    def test_finds_pptx(self, tmp_path: Path) -> None:
+        """``.pptx`` files are discovered."""
+        _write_pptx_placeholder(tmp_path / "deck.pptx")
+        ingestor = PresentationIngestor(backend=StubPresentationBackend())
+        raws = ingestor.discover(tmp_path)
+        assert [raw.path.name for raw in raws] == ["deck.pptx"]
+
+    def test_ignores_non_pptx_files(self, tmp_path: Path) -> None:
+        """Other extensions are skipped."""
+        _write_pptx_placeholder(tmp_path / "ok.pptx")
+        (tmp_path / "ignored.docx").write_bytes(b"PK")
+        ingestor = PresentationIngestor(backend=StubPresentationBackend())
+        raws = ingestor.discover(tmp_path)
+        assert [raw.path.name for raw in raws] == ["ok.pptx"]
+
+
+# ---- parse / convert_to_markdown ---------------------------------------
+
+
+class TestPresentationParse:
+    """One :class:`ParsedFragment` per presentation, with all slides inlined."""
+
+    def test_parse_returns_one_fragment(self, tmp_path: Path) -> None:
+        """A single presentation file yields a single fragment."""
+        path = tmp_path / "deck.pptx"
+        _write_pptx_placeholder(path)
+        backend = StubPresentationBackend(
+            presentations={
+                "deck.pptx": PresentationData(
+                    title="My Talk",
+                    slides=(
+                        SlideData(
+                            index=1,
+                            title="Hello",
+                            body="World",
+                            notes="speaker note",
+                        ),
+                        SlideData(
+                            index=2,
+                            title="Two",
+                            body="Bullet 1\nBullet 2",
+                        ),
+                    ),
+                ),
+            },
+        )
+        ingestor = PresentationIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert len(fragments) == 1
+        assert fragments[0].metadata["slide_count"] == 2
+        assert fragments[0].metadata["title"] == "My Talk"
+
+    def test_markdown_renders_one_section_per_slide(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The markdown body has ``## Slide 1: Hello`` style sections."""
+        path = tmp_path / "deck.pptx"
+        _write_pptx_placeholder(path)
+        backend = StubPresentationBackend(
+            presentations={
+                "deck.pptx": PresentationData(
+                    title="My Talk",
+                    slides=(
+                        SlideData(
+                            index=1,
+                            title="Hello",
+                            body="World",
+                            notes="speaker note",
+                        ),
+                        SlideData(index=2, title="Two", body="Bullet"),
+                    ),
+                ),
+            },
+        )
+        ingestor = PresentationIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        markdown = ingestor.convert_to_markdown(fragments[0])
+        assert "## Slide 1: Hello" in markdown
+        assert "## Slide 2: Two" in markdown
+        assert "World" in markdown
+        assert "Bullet" in markdown
+        # Speaker notes get a labelled subsection.
+        assert "speaker note" in markdown
+
+    def test_empty_presentation_yields_no_fragment(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A presentation with no slides is dropped."""
+        path = tmp_path / "empty.pptx"
+        _write_pptx_placeholder(path)
+        backend = StubPresentationBackend(
+            presentations={
+                "empty.pptx": PresentationData(title=None, slides=()),
+            },
+        )
+        ingestor = PresentationIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert fragments == []
+
+
+# ---- generate_frontmatter ---------------------------------------------
+
+
+class TestPresentationFrontmatter:
+    """Frontmatter shape for presentation fragments."""
+
+    def test_frontmatter_records_platform_and_slide_count(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """source.platform=presentation plus slide_count and title."""
+        from datetime import UTC, datetime
+
+        from creek.ingest.base import ParsedFragment
+
+        fragment = ParsedFragment(
+            content="",
+            metadata={
+                "original_file": str(tmp_path / "deck.pptx"),
+                "title": "My Talk",
+                "slide_count": 4,
+            },
+            source_path=str(tmp_path / "deck.pptx"),
+            timestamp=datetime(2026, 4, 27, tzinfo=UTC),
+        )
+        ingestor = PresentationIngestor(backend=StubPresentationBackend())
+        fm = ingestor.generate_frontmatter(fragment)
+        assert fm["source"]["platform"] == SourcePlatform.PRESENTATION.value
+        assert fm["title"] == "My Talk"
+        assert fm["slide_count"] == 4
+
+
+# ---- PythonPptxBackend lazy-import -----------------------------------
+
+
+class TestPythonPptxBackend:
+    """Default backend respects the optional-dep contract."""
+
+    def test_is_available_returns_false_without_pptx(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without python-pptx, the backend reports unavailable."""
+        import builtins
+
+        monkeypatch.setattr(
+            builtins,
+            "__import__",
+            _make_import_blocker({"pptx"}),
+        )
+        backend = PythonPptxBackend()
+        assert not backend.is_available()
+
+    def test_read_raises_without_pptx(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Reading a .pptx without python-pptx raises a clear error."""
+        import builtins
+
+        monkeypatch.setattr(
+            builtins,
+            "__import__",
+            _make_import_blocker({"pptx"}),
+        )
+        path = tmp_path / "x.pptx"
+        _write_pptx_placeholder(path)
+        backend = PythonPptxBackend()
+        with pytest.raises(PythonPptxUnavailableError, match="python-pptx"):
+            backend.read_presentation(path)
+
+
+# ---- Module re-exports -----------------------------------------------
+
+
+class TestModuleExports:
+    """Both ingestors are part of the ``creek.ingest`` public surface."""
+
+    def test_spreadsheet_importable_from_package(self) -> None:
+        """``from creek.ingest import SpreadsheetIngestor`` works."""
+        from creek.ingest import SpreadsheetIngestor as Reexported
+
+        assert Reexported is SpreadsheetIngestor
+
+    def test_presentation_importable_from_package(self) -> None:
+        """``from creek.ingest import PresentationIngestor`` works."""
+        from creek.ingest import PresentationIngestor as Reexported
+
+        assert Reexported is PresentationIngestor
+
+    def test_protocols_satisfy_structural_typing(self) -> None:
+        """Stub backends are structural matches for their Protocols."""
+        assert isinstance(StubSpreadsheetBackend(), SpreadsheetBackend)
+        assert isinstance(StubPresentationBackend(), PresentationBackend)
+
+    def test_registry_keys_route_correctly(self) -> None:
+        """The INGESTOR_REGISTRY keys ``spreadsheet`` and ``presentation`` resolve."""
+        from creek.ingest import INGESTOR_REGISTRY
+
+        assert INGESTOR_REGISTRY["spreadsheet"] is SpreadsheetIngestor
+        assert INGESTOR_REGISTRY["presentation"] is PresentationIngestor
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
+++ b/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
@@ -722,6 +722,67 @@ class TestPythonPptxBackend:
         with pytest.raises(PythonPptxUnavailableError, match="python-pptx"):
             backend.read_presentation(path)
 
+    def test_extract_title_returns_none_when_core_property_is_none(
+        self,
+    ) -> None:
+        """python-pptx sets core_properties.title to None — not the string."""
+
+        class _CoreProps:
+            title = None
+
+        class _Prs:
+            core_properties = _CoreProps()
+
+        assert PythonPptxBackend._extract_title(_Prs()) is None
+
+    def test_extract_title_strips_whitespace_and_treats_blank_as_none(
+        self,
+    ) -> None:
+        """A title made entirely of whitespace is treated as absent."""
+
+        class _CoreProps:
+            title = "   "
+
+        class _Prs:
+            core_properties = _CoreProps()
+
+        assert PythonPptxBackend._extract_title(_Prs()) is None
+
+    def test_extract_title_returns_real_title_unchanged(self) -> None:
+        """A populated title is returned verbatim (after .strip())."""
+
+        class _CoreProps:
+            title = "  My Talk  "
+
+        class _Prs:
+            core_properties = _CoreProps()
+
+        assert PythonPptxBackend._extract_title(_Prs()) == "My Talk"
+
+
+class TestPresentationParseHandlesMissingTitle:
+    """Untitled presentations must not surface the literal string ``None``."""
+
+    def test_untitled_pptx_falls_back_to_file_stem(self, tmp_path: Path) -> None:
+        """When ``data.title`` is ``None`` the fragment uses the file stem."""
+        path = tmp_path / "anonymous.pptx"
+        _write_pptx_placeholder(path)
+        backend = StubPresentationBackend(
+            presentations={
+                "anonymous.pptx": PresentationData(
+                    title=None,
+                    slides=(SlideData(index=1, title="Hi", body="There"),),
+                ),
+            },
+        )
+        ingestor = PresentationIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert fragments[0].metadata["title"] == "anonymous"
+        markdown = ingestor.convert_to_markdown(fragments[0])
+        assert "# anonymous" in markdown
+        # The literal string "None" should never surface as the document title.
+        assert "# None" not in markdown
+
 
 # ---- Module re-exports -----------------------------------------------
 

--- a/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
+++ b/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
@@ -329,6 +329,75 @@ class TestSpreadsheetMarkdown:
         # Middle rows trimmed:
         assert "v75" not in markdown
 
+    def test_large_sheet_renders_single_header_after_summary(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Summary note precedes a single GFM table — no duplicate header."""
+        path = tmp_path / "huge.xlsx"
+        _write_xlsx_placeholder(path)
+        big_rows = tuple((str(i), f"v{i}") for i in range(150))
+        backend = StubSpreadsheetBackend(
+            workbooks={
+                "huge.xlsx": WorkbookData(
+                    sheets=(
+                        SheetData(
+                            name="Big",
+                            headers=("idx", "value"),
+                            rows=big_rows,
+                        ),
+                    ),
+                ),
+            },
+        )
+        ingestor = SpreadsheetIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        markdown = ingestor.convert_to_markdown(fragments[0])
+        header_line = "| idx | value |"
+        # The header row should appear exactly once.
+        assert markdown.count(header_line) == 1
+        # The separator row should appear exactly once too.
+        assert markdown.count("| --- | --- |") == 1
+        # The summary note should appear before the header in the document.
+        summary_idx = markdown.index("Showing first")
+        header_idx = markdown.index(header_line)
+        assert summary_idx < header_idx, (
+            "Summary note should precede the (single) header row."
+        )
+
+    def test_pipe_and_newline_in_cell_are_escaped(self, tmp_path: Path) -> None:
+        """Cells containing ``|`` or newlines do not corrupt GFM tables."""
+        path = tmp_path / "escapes.xlsx"
+        _write_xlsx_placeholder(path)
+        backend = StubSpreadsheetBackend(
+            workbooks={
+                "escapes.xlsx": WorkbookData(
+                    sheets=(
+                        SheetData(
+                            name="Sheet1",
+                            headers=("a|b", "c"),
+                            rows=(("x | y", "line1\nline2"),),
+                        ),
+                    ),
+                ),
+            },
+        )
+        ingestor = SpreadsheetIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        markdown = ingestor.convert_to_markdown(fragments[0])
+        # The literal cell text must be present in escaped form.
+        assert r"a\|b" in markdown
+        assert r"x \| y" in markdown
+        # Newlines inside a cell must not split the table row.
+        assert "line1<br>line2" in markdown
+        # Every non-empty markdown line that begins with `|` should have
+        # the same column count (3 pipes for 2 columns).
+        table_rows = [line for line in markdown.splitlines() if line.startswith("|")]
+        column_counts = {line.count("|") - line.count(r"\|") for line in table_rows}
+        assert column_counts == {3}, (
+            f"Mismatched pipe counts indicate broken escaping: {column_counts}"
+        )
+
 
 # ---- generate_frontmatter ---------------------------------------------
 
@@ -382,6 +451,32 @@ class TestCsvFiles:
         markdown = ingestor.convert_to_markdown(fragments[0])
         assert "| a | b |" in markdown
         assert "| 1 | 2 |" in markdown
+
+    def test_csv_with_utf8_bom_is_decoded(self, tmp_path: Path) -> None:
+        """CSV files saved with a UTF-8 BOM (common from Excel) decode cleanly."""
+        csv_path = tmp_path / "bom.csv"
+        # Real-world Excel "CSV UTF-8" exports prepend the BOM.
+        csv_path.write_bytes(
+            "﻿name,city\nAlice,Münster\nBob,São Paulo\n".encode(),
+        )
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        markdown = ingestor.convert_to_markdown(fragments[0])
+        # Header row must not carry the BOM character.
+        assert "﻿" not in markdown
+        assert "| name | city |" in markdown
+        assert "Münster" in markdown
+        assert "São Paulo" in markdown
+
+    def test_csv_with_cp1252_falls_back(self, tmp_path: Path) -> None:
+        """CSV files saved as CP1252 (legacy Excel default) decode without crashing."""
+        csv_path = tmp_path / "legacy.csv"
+        csv_path.write_bytes("name,note\nAlice,café\n".encode("cp1252"))
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        markdown = ingestor.convert_to_markdown(fragments[0])
+        assert "| name | note |" in markdown
+        assert "café" in markdown
 
 
 # ---- OpenpyxlBackend lazy-import ---------------------------------------


### PR DESCRIPTION
## Summary

Implements §57 of the Creek Ontology — sub-parsers for **XLSX** / **CSV** workbooks and **PPTX** presentations. Architecture mirrors the injectable-backend pattern established in PRs #162 (Image/OCR) and #163 (Google Drive):

### `SpreadsheetIngestor` (`creek/ingest/spreadsheets.py`)
- **`SpreadsheetBackend`** Protocol with `read_workbook()` → frozen `WorkbookData(sheets=tuple[SheetData, ...])`.
- **`OpenpyxlBackend`** (production): lazy imports `openpyxl` for `.xlsx`; CSVs use stdlib `csv` so they always parse. `OpenpyxlUnavailableError` carries install instructions.
- **One `ParsedFragment` per sheet**; auto-detects a header row when the first row's cells are all non-empty strings.
- **Markdown**: GFM tables. Sheets > 100 rows render as **first 10 + last 5 + total count**, so giant exports stay legible.
- Frontmatter: `source.platform=spreadsheet` plus sheet/row/column counts.

### `PresentationIngestor` (`creek/ingest/presentations.py`)
- **`PresentationBackend`** Protocol with `read_presentation()` → `PresentationData(title, slides=tuple[SlideData, ...])`.
- **`PythonPptxBackend`** (production): lazy imports `python-pptx`. `PythonPptxUnavailableError` carries install instructions.
- **One `ParsedFragment` per file**. Each slide renders as `## Slide N: Title` with body inlined and a `**Speaker notes:**` sub-section when the slide carries notes.
- Frontmatter: `source.platform=presentation` plus `title` and `slide_count`.

### Wiring
- `creek.models` adds `SourcePlatform.SPREADSHEET` + `SourcePlatform.PRESENTATION`.
- `creek.ingest` re-exports both classes and registers them in `INGESTOR_REGISTRY` under `"spreadsheet"` and `"presentation"` (which is exactly what `route_to_ingestor` in #56 already routes to).
- `pyproject.toml` adds an mypy override for `openpyxl` + `pptx` so strict type-checking passes without the optional deps.

## Test plan

- [x] `./scripts/check-all.sh` — 6/7 gates green (only the dev-container env's pre-existing pip-audit findings remain).
- [x] **31 new tests** in `tests/test_spreadsheet_presentation_ingestors.py`:
  - Discover: all 3 supported extensions, recursive, case-insensitive, single-file rejection, no eager byte-load
  - Parse: one fragment per sheet, dimensions recorded, empty sheets dropped, single fragment per presentation
  - Markdown: small sheet → full GFM table; large sheet → head/tail summary; CSV path; per-slide section with speaker-notes subsection
  - Frontmatter: `source.platform` is `spreadsheet` / `presentation`; counts surfaced
  - Optional-dep contract: monkeypatched `__import__` blocks `openpyxl`/`pptx`; both backends report `is_available()` False and raise the dedicated `*UnavailableError`
  - Module exports + `INGESTOR_REGISTRY` keys
- [x] `tests/test_models.py` updated for the two new `SourcePlatform` values.
- [x] Coverage: 94%+ (above 90% threshold)
- [ ] CI: Code Quality & Testing (3.11/3.12/3.13) green
- [ ] Claude review LGTM

Closes #57

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vu1KnoJQDQh4kCLdR6VJTM)_