### PR TITLE
fix(models): require deterministic Fragment.id; add MARKDOWN platform (BUG-007, BUG-011)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -49,6 +49,11 @@ def process(
     console.print(f"[bold]Classifications made:[/bold] {result.classifications_made}")
     console.print(f"[bold]Links found:[/bold] {result.links_found}")
     console.print(f"[bold]Indexes generated:[/bold] {result.indexes_generated}")
+    error_count = len(result.errors)
+    error_style = "red" if error_count else "dim"
+    console.print(f"[bold {error_style}]Errors:[/bold {error_style}] {error_count}")
+    for err in result.errors:
+        console.print(f"  [dim]{err}[/dim]")
 
 
 @app.command()

--- a/creek-tools/creek/ingest/__init__.py
+++ b/creek-tools/creek/ingest/__init__.py
@@ -22,7 +22,14 @@ Exports:
     MarkdownIngestor: Concrete ingestor for plain Markdown files.
 """
 
-from creek.ingest.base import Ingestor, IngestResult, ParsedFragment, RawDocument
+from creek.ingest.base import (
+    IngestedFragment,
+    Ingestor,
+    IngestResult,
+    ParsedFragment,
+    RawDocument,
+    assemble_ingested_fragment,
+)
 from creek.ingest.chatgpt import ChatGPTIngestor
 from creek.ingest.claude import ClaudeIngestor
 from creek.ingest.code import CodeIngestor
@@ -72,11 +79,13 @@ __all__ = [
     "GoogleDriveDownloader",
     "ImageIngestor",
     "IngestResult",
+    "IngestedFragment",
     "Ingestor",
     "MarkdownIngestor",
     "ParsedFragment",
     "PresentationIngestor",
     "RawDocument",
     "SpreadsheetIngestor",
+    "assemble_ingested_fragment",
     "route_to_ingestor",
 ]

--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -292,6 +292,16 @@ def assemble_ingested_fragment(parsed: ParsedFragment) -> IngestedFragment:
             or ``markdown`` keys; this signals an ingestor contract
             violation rather than a recoverable parse error.
     """
+    for required_key in ("frontmatter", "markdown"):
+        if required_key not in parsed.metadata:
+            msg = (
+                f"Ingestor for {parsed.source_path!r} did not set "
+                f"'{required_key}' in ParsedFragment.metadata; "
+                "every Ingestor.ingest() must populate both 'markdown' "
+                "and 'frontmatter' before yielding a fragment."
+            )
+            raise KeyError(msg)
+
     frontmatter_dict: dict[str, Any] = dict(parsed.metadata["frontmatter"])
     body: str = str(parsed.metadata["markdown"])
 

--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -18,12 +18,14 @@ import abc
 import hashlib
 import logging
 from datetime import UTC, datetime
-from pathlib import Path  # noqa: TC003 — needed at runtime by Pydantic
+from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
 
 import chardet
 from pydantic import BaseModel, ConfigDict, Field
+
+from creek.models import Fragment
 
 logger = logging.getLogger(__name__)
 
@@ -98,6 +100,26 @@ class ProvenanceEntry(BaseModel):
 
     status: str
     """Status of the ingest operation (e.g., 'success', 'error', 'skipped')."""
+
+
+class IngestedFragment(BaseModel):
+    """A pipeline-ready fragment paired with its converted markdown body.
+
+    The four-stage ingestor protocol still produces ``ParsedFragment``
+    objects internally; this sibling model is the *clean* hand-off shape
+    consumed by the pipeline orchestrator and ``VaultWriter`` so the
+    body and the structured ``Fragment`` metadata travel together
+    instead of being smuggled through ``ParsedFragment.metadata``.
+
+    Attributes:
+        fragment: The validated ``Fragment`` carrying frontmatter
+            metadata, classifications, and a deterministic ID.
+        body: The converted Markdown body that will be written below
+            the YAML frontmatter in the vault file.
+    """
+
+    fragment: Fragment
+    body: str
 
 
 class IngestResult(BaseModel):
@@ -240,6 +262,49 @@ def generate_fragment_id(source: str, timestamp: datetime, content: str) -> str:
     hash_input = f"{source}:{timestamp.isoformat()}:{content}"
     digest = hashlib.sha256(hash_input.encode()).hexdigest()[:12]
     return f"frag-{digest}"
+
+
+def assemble_ingested_fragment(parsed: ParsedFragment) -> IngestedFragment:
+    """Combine a ``ParsedFragment`` with its frontmatter into an ``IngestedFragment``.
+
+    The four-stage ``ingest()`` orchestrator stashes both the converted
+    Markdown body (``parsed.metadata["markdown"]``) and the generated
+    Creek frontmatter dict (``parsed.metadata["frontmatter"]``) on the
+    parsed fragment. This helper:
+
+    1. Pulls the frontmatter dict out and deep-merges in the deterministic
+       ``frag-<sha>`` ID so re-running the pipeline against the same
+       source remains idempotent.
+    2. Falls back to the source file stem for the title when an ingestor
+       didn't supply one (e.g. ``DiscordIngestor``'s frontmatter omits it).
+    3. Validates the dict into a ``Fragment`` and pairs it with the body.
+
+    Args:
+        parsed: A parsed fragment produced by an ingestor's four-stage
+            pipeline. Must have ``markdown`` and ``frontmatter`` keys
+            populated in ``metadata``.
+
+    Returns:
+        An :class:`IngestedFragment` with structured metadata and body.
+
+    Raises:
+        KeyError: If ``parsed.metadata`` is missing the ``frontmatter``
+            or ``markdown`` keys; this signals an ingestor contract
+            violation rather than a recoverable parse error.
+    """
+    frontmatter_dict: dict[str, Any] = dict(parsed.metadata["frontmatter"])
+    body: str = str(parsed.metadata["markdown"])
+
+    frontmatter_dict["id"] = generate_fragment_id(
+        parsed.source_path,
+        parsed.timestamp,
+        parsed.content,
+    )
+    frontmatter_dict.setdefault("type", "fragment")
+    frontmatter_dict.setdefault("title", Path(parsed.source_path).stem or "Untitled")
+
+    fragment = Fragment.model_validate(frontmatter_dict)
+    return IngestedFragment(fragment=fragment, body=body)
 
 
 def file_modified_time(path: Path) -> datetime:

--- a/creek-tools/creek/ingest/markdown.py
+++ b/creek-tools/creek/ingest/markdown.py
@@ -129,6 +129,8 @@ def _infer_platform(document_type: str, file_path: Path) -> SourcePlatform:
     First checks the document type for a direct mapping. If the type
     is ``'notes'``, falls back to path-based heuristics (e.g., files
     in a ``daily/`` or ``journal/`` directory are classified as journal).
+    Generic markdown notes default to :attr:`SourcePlatform.MARKDOWN`
+    so the writer routes them to the dedicated ``Notes`` subfolder.
 
     Args:
         document_type: The detected document type (journal, essay, etc.).
@@ -166,7 +168,7 @@ def _infer_platform_from_path(file_path: Path) -> SourcePlatform:
     if any(p.search(path_str) for p in _ESSAY_PATH_PATTERNS):
         return SourcePlatform.ESSAY
 
-    return SourcePlatform.OTHER
+    return SourcePlatform.MARKDOWN
 
 
 def _merge_frontmatter(

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -174,6 +174,7 @@ class SourcePlatform(StrEnum):
     JOURNAL = "journal"
     ESSAY = "essay"
     CODE = "code"
+    MARKDOWN = "markdown"
     EMAIL = "email"
     DOCUMENT = "document"
     IMAGE_OCR = "image_ocr"
@@ -212,9 +213,22 @@ class PrivacyTier(StrEnum):
 # ---- ID Generation Helpers ----
 
 
-def _generate_frag_id() -> str:
-    """Generate a unique fragment ID with prefix 'frag-'."""
-    return f"frag-{uuid.uuid4().hex[:8]}"
+def synthetic_fragment_id() -> str:
+    """Generate a synthetic (random) fragment ID with prefix 'frag-'.
+
+    Reserved for fragments without a deterministic ``(source, timestamp,
+    content)`` triple — for example, synthesised praxis-derived fragments
+    or test fixtures. Production ingestors must use the deterministic
+    :func:`creek.ingest.base.generate_fragment_id` instead so re-running
+    the pipeline against the same source is idempotent.
+
+    The width matches ``generate_fragment_id`` (12 hex chars) so the two
+    namespaces are visually indistinguishable downstream.
+
+    Returns:
+        A random ID string in the format ``frag-XXXXXXXXXXXX``.
+    """
+    return f"frag-{uuid.uuid4().hex[:12]}"
 
 
 def _generate_thread_id() -> str:
@@ -313,7 +327,7 @@ class Fragment(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
 
     type: str = "fragment"
-    id: str = Field(default_factory=_generate_frag_id)
+    id: str
     title: str
     source: FragmentSource
     created: datetime = Field(default_factory=datetime.now)

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -108,8 +108,9 @@ class Pipeline:
             1. Redaction scan on source files
             2. Ingestion (discover ingestors for source type)
             3. Classification (rule -> LLM -> review queue)
-            4. Linking (embeddings, temporal, threads, eddies)
-            5. Index generation
+            4. Vault write (persist classified fragments + bodies)
+            5. Linking (embeddings, temporal, threads, eddies)
+            6. Index generation
 
         Args:
             source_path: Directory containing source files to process.
@@ -145,15 +146,15 @@ class Pipeline:
         classified = self._run_classification(ingested, vault_path, result)
         result.classifications_made = len(classified)
 
-        # Stage 3.5: Persist classified fragments into the vault.
+        # Stage 4: Vault write -- persist classified fragments+bodies.
         self._write_to_vault(classified, vault_path, result)
 
-        # Stage 4: Linking
+        # Stage 5: Linking
         fragments_only = [item.fragment for item in classified]
         link_total = self._run_linking(fragments_only, vault_path, result)
         result.links_found = link_total
 
-        # Stage 5: Indexing
+        # Stage 6: Indexing
         index_count = self._run_indexing(vault_path, result)
         result.indexes_generated = index_count
 
@@ -331,7 +332,14 @@ class Pipeline:
         for item in classified:
             try:
                 writer.write_fragment(item.fragment, body=item.body)
-            except OSError as exc:
+            except (OSError, KeyError) as exc:
+                # OSError covers filesystem-level failures (permissions,
+                # disk full). KeyError covers a missing platform mapping —
+                # ``_PLATFORM_SUBFOLDER`` is enforced as total by a unit
+                # test, but if a future enum value slips through review
+                # the writer's bare ``dict[]`` access would otherwise
+                # crash the whole run. Record either as a per-fragment
+                # error and keep processing the rest.
                 result.errors.append(
                     f"[vault-writer] failed to write {item.fragment.id}: {exc}",
                 )

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -11,7 +11,7 @@ if consent has not been recorded for a source, the pipeline skips ingestion.
 import logging
 from pathlib import Path
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from creek.classify.llm import LLMClassifier
 from creek.classify.review import ReviewQueueGenerator
@@ -20,9 +20,11 @@ from creek.config import CreekConfig
 from creek.consent import ConsentManager
 from creek.generate.indexes import IndexGenerator
 from creek.ingest import INGESTOR_REGISTRY
+from creek.ingest.base import IngestedFragment, assemble_ingested_fragment
 from creek.link.linker import LinkingPipeline
-from creek.models import Fragment, FragmentSource, SourcePlatform
+from creek.models import Fragment
 from creek.redact.scanner import RedactionScanner
+from creek.vault.writer import VaultWriter
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +38,9 @@ class PipelineResult(BaseModel):
         classifications_made: Number of fragments classified.
         links_found: Total link count across all linking stages.
         indexes_generated: Number of index notes generated.
+        errors: Human-readable error messages collected from each stage.
+            Each entry is prefixed with its source ingestor name so the
+            user can trace the failure back to the offending file.
     """
 
     files_scanned: int = 0
@@ -43,6 +48,7 @@ class PipelineResult(BaseModel):
     classifications_made: int = 0
     links_found: int = 0
     indexes_generated: int = 0
+    errors: list[str] = Field(default_factory=list)
 
 
 class Pipeline:
@@ -132,15 +138,19 @@ class Pipeline:
             return result
 
         # Stage 2: Ingestion
-        fragments = self._run_ingestion(source_path, result)
-        result.fragments_created = len(fragments)
+        ingested = self._run_ingestion(source_path, result)
+        result.fragments_created = len(ingested)
 
         # Stage 3: Classification
-        classified = self._run_classification(fragments, vault_path, result)
+        classified = self._run_classification(ingested, vault_path, result)
         result.classifications_made = len(classified)
 
+        # Stage 3.5: Persist classified fragments into the vault.
+        self._write_to_vault(classified, vault_path, result)
+
         # Stage 4: Linking
-        link_total = self._run_linking(classified, vault_path, result)
+        fragments_only = [item.fragment for item in classified]
+        link_total = self._run_linking(fragments_only, vault_path, result)
         result.links_found = link_total
 
         # Stage 5: Indexing
@@ -198,18 +208,27 @@ class Pipeline:
 
     def _run_ingestion(
         self, source_path: Path, result: PipelineResult
-    ) -> list[Fragment]:
-        """Discover and run ingestors for available source types.
+    ) -> list[IngestedFragment]:
+        """Discover and run ingestors, returning structured fragment+body bundles.
 
-        If the INGESTOR_REGISTRY is empty (skeleton phase), logs a
-        warning and returns an empty list.
+        For each ingestor in :data:`INGESTOR_REGISTRY`, this method:
+
+        1. Calls ``ingest()`` to produce parsed fragments and any errors.
+        2. Forwards each error onto :attr:`PipelineResult.errors`,
+           prefixed with the ingestor's registry key for traceability.
+        3. Assembles each parsed fragment into an :class:`IngestedFragment`
+           carrying a deterministic ``frag-`` ID and the converted body.
+        4. Treats per-fragment assembly failures as recoverable: the
+           failure is recorded on ``result.errors`` and skipped, rather
+           than aborting the whole pipeline.
 
         Args:
             source_path: Directory containing source files.
-            result: Pipeline result (unused directly but kept for symmetry).
+            result: Pipeline result; mutated to collect error messages.
 
         Returns:
-            List of Fragment models created by ingestion.
+            List of :class:`IngestedFragment` ready for classification
+            and vault writing.
         """
         if not INGESTOR_REGISTRY:
             logger.warning(
@@ -218,48 +237,108 @@ class Pipeline:
             )
             return []
 
-        fragments: list[Fragment] = []
+        ingested: list[IngestedFragment] = []
         for name, ingestor_cls in INGESTOR_REGISTRY.items():
             logger.info("Running ingestor: %s", name)
             ingestor = ingestor_cls()
             ingest_result = ingestor.ingest(source_path)
+            for err in ingest_result.errors:
+                result.errors.append(f"[{name}] {err}")
             for parsed in ingest_result.fragments:
-                fragment = Fragment(
-                    title=parsed.source_path,
-                    source=FragmentSource(platform=SourcePlatform.OTHER),
-                )
-                fragments.append(fragment)
+                try:
+                    ingested.append(assemble_ingested_fragment(parsed))
+                except (KeyError, ValueError) as exc:
+                    # Surface contract / validation failures as user-visible
+                    # errors instead of silently dropping the fragment.
+                    result.errors.append(
+                        f"[{name}] failed to assemble fragment from "
+                        f"{parsed.source_path}: {exc}",
+                    )
+                    logger.exception(
+                        "Failed to assemble fragment from %s",
+                        parsed.source_path,
+                    )
 
-        return fragments
+        return ingested
 
     def _run_classification(
         self,
-        fragments: list[Fragment],
+        ingested: list[IngestedFragment],
         vault_path: Path,
         result: PipelineResult,
-    ) -> list[Fragment]:
+    ) -> list[IngestedFragment]:
         """Classify fragments through rules, LLM, and review queue.
 
+        Classification operates on the inner :class:`Fragment`; the body
+        is preserved unchanged on the returned :class:`IngestedFragment`.
+
         Args:
-            fragments: Fragments to classify.
-            vault_path: Vault path for writing review queue.
-            result: Pipeline result (unused directly but kept for symmetry).
+            ingested: Ingested fragment+body bundles to classify.
+            vault_path: Vault path for writing the review queue.
+            result: Pipeline result (unused; kept for symmetry).
 
         Returns:
-            List of classified Fragment models.
+            List of classified :class:`IngestedFragment` items.
         """
-        if not fragments:
+        if not ingested:
             logger.info("No fragments to classify.")
             return []
 
-        classified: list[Fragment] = []
-        for fragment in fragments:
-            frag = self.rule_classifier.classify(fragment)
+        classified: list[IngestedFragment] = []
+        for item in ingested:
+            frag = self.rule_classifier.classify(item.fragment)
             frag = self.llm_classifier.classify(frag)
-            classified.append(frag)
+            classified.append(IngestedFragment(fragment=frag, body=item.body))
 
-        self.review_generator.generate_queue(classified, vault_path)
+        self.review_generator.generate_queue(
+            [item.fragment for item in classified],
+            vault_path,
+        )
         return classified
+
+    def _write_to_vault(
+        self,
+        classified: list[IngestedFragment],
+        vault_path: Path,
+        result: PipelineResult,
+    ) -> None:
+        """Persist classified fragments to the vault, body and all.
+
+        Each fragment is written via :class:`VaultWriter`, which routes
+        to the correct ``01-Fragments/<subfolder>/`` directory based on
+        the fragment's source platform. Idempotency is enforced by the
+        writer's existing ID-based duplicate detection: re-running the
+        pipeline against the same source produces zero new files.
+
+        Failures are appended to :attr:`PipelineResult.errors` so the
+        user can see which fragments were not persisted.
+
+        Args:
+            classified: Classified fragment+body bundles.
+            vault_path: Root of the Obsidian vault to write into.
+            result: Pipeline result; mutated to collect error messages.
+        """
+        if not classified:
+            return
+
+        try:
+            writer = VaultWriter(vault_path=vault_path)
+        except FileNotFoundError as exc:
+            result.errors.append(f"[vault-writer] {exc}")
+            logger.exception("Vault writer initialisation failed")
+            return
+
+        for item in classified:
+            try:
+                writer.write_fragment(item.fragment, body=item.body)
+            except OSError as exc:
+                result.errors.append(
+                    f"[vault-writer] failed to write {item.fragment.id}: {exc}",
+                )
+                logger.exception(
+                    "Failed to write fragment %s to vault",
+                    item.fragment.id,
+                )
 
     def _run_linking(
         self,

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -39,14 +39,25 @@ if TYPE_CHECKING:
         Thread,
     )
 
-# Map source platform -> 01-Fragments subfolder
+# Map source platform -> 01-Fragments subfolder.
+# This mapping must remain *total* across SourcePlatform — every enum
+# value has an entry. The totality is enforced by a unit test in
+# tests/test_vault_writer.py so missing entries fail loudly rather than
+# silently routing fragments to ``Unsorted/``.
 _PLATFORM_SUBFOLDER: dict[str, str] = {
     SourcePlatform.CLAUDE: "Conversations",
     SourcePlatform.CHATGPT: "Conversations",
     SourcePlatform.DISCORD: "Messages",
+    SourcePlatform.EMAIL: "Messages",
     SourcePlatform.ESSAY: "Writing",
     SourcePlatform.JOURNAL: "Journal",
     SourcePlatform.CODE: "Technical",
+    SourcePlatform.MARKDOWN: "Notes",
+    SourcePlatform.DOCUMENT: "Documents",
+    SourcePlatform.SPREADSHEET: "Data",
+    SourcePlatform.PRESENTATION: "Decks",
+    SourcePlatform.IMAGE_OCR: "Images",
+    SourcePlatform.OTHER: "Unsorted",
 }
 
 # Map praxis type -> 04-Praxis subfolder
@@ -85,6 +96,46 @@ def _sanitize_title(title: str) -> str:
     cleaned = re.sub(r"[^\w\s-]", "", title)
     cleaned = cleaned.strip().replace(" ", "-")
     return cleaned[:_MAX_FILENAME_LENGTH]
+
+
+def _render_thread_body(thread: Thread) -> str:
+    """Render a one-paragraph summary body for a Thread."""
+    desc = thread.description.strip() or (
+        f"Thread `{thread.title}` carries {thread.fragment_count} fragments "
+        f"and is currently {thread.status}."
+    )
+    return f"{desc}\n"
+
+
+def _render_eddy_body(eddy: Eddy) -> str:
+    """Render a one-paragraph summary body for an Eddy."""
+    desc = eddy.description.strip() or (
+        f"Eddy `{eddy.title}` clusters {eddy.fragment_count} fragments "
+        f"across {len(eddy.threads)} thread(s)."
+    )
+    return f"{desc}\n"
+
+
+def _render_praxis_body(praxis: Praxis) -> str:
+    """Render a one-paragraph summary body for a Praxis."""
+    return (
+        f"Praxis `{praxis.title}` is a {praxis.praxis_type} "
+        f"({praxis.status}); review {praxis.review_interval}.\n"
+    )
+
+
+def _render_decision_body(decision: Decision) -> str:
+    """Render a one-paragraph summary body for a Decision."""
+    body_parts = [
+        f"Decision `{decision.title}` is currently {decision.status}.",
+    ]
+    if decision.options:
+        body_parts.append(
+            "Options under consideration: " + ", ".join(decision.options) + ".",
+        )
+    if decision.outcome:
+        body_parts.append(f"Outcome: {decision.outcome}.")
+    return " ".join(body_parts) + "\n"
 
 
 def _extract_date_str(model: BaseModel) -> str:
@@ -148,29 +199,36 @@ class VaultWriter:
 
         self.vault_path = vault_path
 
-    def write_fragment(self, fragment: Fragment) -> Path:
+    def write_fragment(self, fragment: Fragment, body: str = "") -> Path:
         """Write a Fragment to the appropriate 01-Fragments/ subfolder.
 
-        Maps the fragment's source platform to a subfolder (e.g. claude
-        and chatgpt -> Conversations, discord -> Messages). Platforms
-        without an explicit mapping go to Unsorted.
+        Maps the fragment's source platform to a subfolder via the total
+        ``_PLATFORM_SUBFOLDER`` mapping. The ``body`` parameter holds the
+        converted markdown content, which is written below the YAML
+        frontmatter — without it the fragment file would contain only
+        metadata (the historical bug).
 
         Args:
             fragment: The Fragment model to write.
+            body: The markdown body to render below the frontmatter.
+                Empty strings are accepted (e.g. for placeholder writes
+                in tests) but should be considered a code smell in
+                production callers.
 
         Returns:
             Path to the written (or existing duplicate) markdown file.
         """
         platform = fragment.source.platform
-        subfolder = _PLATFORM_SUBFOLDER.get(str(platform), "Unsorted")
+        subfolder = _PLATFORM_SUBFOLDER[str(platform)]
         target_dir = self.vault_path / "01-Fragments" / subfolder
-        return self._write_model(fragment, target_dir)
+        return self._write_model(fragment, target_dir, body=body)
 
     def write_thread(self, thread: Thread) -> Path:
         """Write a Thread to 02-Threads/{status}/.
 
         The subfolder is determined by the thread's status field,
-        capitalised (e.g. Active, Dormant, Resolved).
+        capitalised (e.g. Active, Dormant, Resolved). A short summary
+        body is rendered automatically.
 
         Args:
             thread: The Thread model to write.
@@ -180,10 +238,13 @@ class VaultWriter:
         """
         status_folder = str(thread.status).capitalize()
         target_dir = self.vault_path / "02-Threads" / status_folder
-        return self._write_model(thread, target_dir)
+        return self._write_model(thread, target_dir, body=_render_thread_body(thread))
 
     def write_eddy(self, eddy: Eddy) -> Path:
         """Write an Eddy to 03-Eddies/.
+
+        A short summary body describing the eddy's fragment count and
+        bridged threads is rendered automatically.
 
         Args:
             eddy: The Eddy model to write.
@@ -192,13 +253,14 @@ class VaultWriter:
             Path to the written (or existing duplicate) markdown file.
         """
         target_dir = self.vault_path / "03-Eddies"
-        return self._write_model(eddy, target_dir)
+        return self._write_model(eddy, target_dir, body=_render_eddy_body(eddy))
 
     def write_praxis(self, praxis: Praxis) -> Path:
         """Write a Praxis to 04-Praxis/{type}/.
 
         Maps praxis_type to subfolder: habit/practice -> Daily,
         framework/commitment -> Seasonal, insight -> Situational.
+        A short summary body is rendered automatically.
 
         Args:
             praxis: The Praxis model to write.
@@ -208,13 +270,14 @@ class VaultWriter:
         """
         subfolder = _PRAXIS_SUBFOLDER.get(str(praxis.praxis_type), "Situational")
         target_dir = self.vault_path / "04-Praxis" / subfolder
-        return self._write_model(praxis, target_dir)
+        return self._write_model(praxis, target_dir, body=_render_praxis_body(praxis))
 
     def write_decision(self, decision: Decision) -> Path:
         """Write a Decision to 08-Decisions/{status}/.
 
         Active statuses (sensing, deliberating, committing) go to
         Active/. Completed statuses (enacted, reflecting) go to Archive/.
+        A short summary body is rendered automatically.
 
         Args:
             decision: The Decision model to write.
@@ -226,7 +289,11 @@ class VaultWriter:
             "Active" if str(decision.status) in _ACTIVE_DECISION_STATUSES else "Archive"
         )
         target_dir = self.vault_path / "08-Decisions" / subfolder
-        return self._write_model(decision, target_dir)
+        return self._write_model(
+            decision,
+            target_dir,
+            body=_render_decision_body(decision),
+        )
 
     def write_any(self, model: BaseModel) -> Path:
         """Dispatch to the appropriate write method based on the model's type field.
@@ -257,15 +324,22 @@ class VaultWriter:
             raise ValueError(msg)
         return writer(model)
 
-    def _write_model(self, model: BaseModel, target_dir: Path) -> Path:
+    def _write_model(
+        self,
+        model: BaseModel,
+        target_dir: Path,
+        *,
+        body: str = "",
+    ) -> Path:
         """Serialise a model to markdown with YAML frontmatter and write to disk.
 
         Handles duplicate detection (by ID), filename generation,
-        frontmatter serialisation, and provenance logging.
+        frontmatter serialisation, body rendering, and provenance logging.
 
         Args:
             model: The Pydantic model to serialise.
             target_dir: The vault directory to write the file to.
+            body: Markdown body to render below the frontmatter block.
 
         Returns:
             Path to the written (or existing duplicate) file.
@@ -281,7 +355,7 @@ class VaultWriter:
         file_path = target_dir / filename
 
         data = model.model_dump(mode="json")
-        post = frontmatter.Post(content="", **data)
+        post = frontmatter.Post(content=body, **data)
         content = frontmatter.dumps(post)
         file_path.write_text(content, encoding="utf-8")
 

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -301,6 +301,17 @@ class VaultWriter:
         Inspects the ``type`` attribute of the model and calls the
         corresponding ``write_*`` method.
 
+        .. note::
+
+            For ``Fragment`` models this dispatch path produces a
+            **header-only** vault file because there is no body to
+            forward through the generic ``BaseModel`` signature. The
+            primary ingestion path bypasses ``write_any`` and calls
+            :meth:`write_fragment` directly with the converted Markdown
+            body. Reach for ``write_any`` only when you genuinely have
+            no body — e.g. compaction tooling that re-writes existing
+            metadata blobs.
+
         Args:
             model: A Pydantic model with a ``type`` field.
 

--- a/creek-tools/tests/e2e/__init__.py
+++ b/creek-tools/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end tests for the Creek pipeline."""

--- a/creek-tools/tests/e2e/test_pipeline_markdown_e2e.py
+++ b/creek-tools/tests/e2e/test_pipeline_markdown_e2e.py
@@ -1,0 +1,89 @@
+"""End-to-end test: markdown source becomes a populated vault fragment.
+
+This test exercises the full ``Pipeline`` against a markdown source
+directory and verifies the canonical batch-A acceptance criteria:
+
+- A real fragment file is produced under ``01-Fragments/``
+- The fragment carries the platform reported by the ingestor (``markdown``)
+- The fragment ID is the deterministic 12-hex SHA-256 prefix
+- The converted markdown body is preserved below the frontmatter
+- ``PipelineResult.errors`` is empty for a clean run
+- A second run is idempotent (no duplicate fragment files)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.config import CreekConfig
+from creek.pipeline import Pipeline
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+VAULT_DIRS: list[str] = [
+    "00-Creek-Meta/Processing-Log",
+    "01-Fragments/Conversations",
+    "01-Fragments/Messages",
+    "01-Fragments/Writing",
+    "01-Fragments/Journal",
+    "01-Fragments/Technical",
+    "01-Fragments/Notes",
+    "01-Fragments/Documents",
+    "01-Fragments/Data",
+    "01-Fragments/Decks",
+    "01-Fragments/Images",
+    "01-Fragments/Unsorted",
+    "02-Threads/Active",
+    "02-Threads/Dormant",
+    "02-Threads/Resolved",
+    "03-Eddies",
+    "04-Praxis/Daily",
+    "04-Praxis/Seasonal",
+    "04-Praxis/Situational",
+    "06-Frequencies",
+    "08-Decisions/Active",
+    "08-Decisions/Archive",
+]
+
+
+def _make_empty_vault(vault_path: Path) -> Path:
+    """Materialise the minimal vault directory layout."""
+    for d in VAULT_DIRS:
+        (vault_path / d).mkdir(parents=True, exist_ok=True)
+    return vault_path
+
+
+@pytest.mark.e2e
+def test_pipeline_writes_real_fragment(tmp_path: Path) -> None:
+    """A markdown source file becomes a real, well-formed vault fragment."""
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "note.md").write_text(
+        "# A note\n\nBody text.\n",
+        encoding="utf-8",
+    )
+    vault = _make_empty_vault(tmp_path / "vault")
+
+    config = CreekConfig()
+    result = Pipeline(config=config).run(source_path=source, vault_path=vault)
+
+    assert result.fragments_created == 1
+    assert result.errors == []
+
+    written = list((vault / "01-Fragments").rglob("*.md"))
+    assert len(written) == 1
+    post = frontmatter.load(str(written[0]))
+    assert post["source"]["platform"] == "markdown"
+    assert post["id"].startswith("frag-")
+    # SHA-256[:12], not uuid8
+    assert len(post["id"].removeprefix("frag-")) == 12
+    assert "Body text." in post.content
+
+    # Idempotency: re-running writes nothing new.
+    Pipeline(config=config).run(source_path=source, vault_path=vault)
+    assert len(list((vault / "01-Fragments").rglob("*.md"))) == 1

--- a/creek-tools/tests/test_authorship.py
+++ b/creek-tools/tests/test_authorship.py
@@ -513,6 +513,7 @@ class TestAuthorshipIntegration:
         from creek.models import Fragment, FragmentSource
 
         fragment = Fragment(
+            id="frag-000000000002",
             title="Claude conversation turn 1",
             source=FragmentSource(
                 platform="claude",
@@ -532,6 +533,7 @@ class TestAuthorshipIntegration:
         from creek.models import Fragment, FragmentSource
 
         fragment = Fragment(
+            id="frag-000000000001",
             title="Discord message group",
             source=FragmentSource(
                 platform="discord",

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -66,6 +66,7 @@ def _make_fragment(
         A Fragment instance with the given title and platform.
     """
     return Fragment(
+        id="frag-000000000003",
         title=title,
         source=FragmentSource(platform=platform),
     )

--- a/creek-tools/tests/test_context.py
+++ b/creek-tools/tests/test_context.py
@@ -41,7 +41,10 @@ def _make_fragment(
     privacy_tier: PrivacyTier = PrivacyTier.UNCLASSIFIED,
 ) -> Fragment:
     """Create a test fragment with the given authorship."""
+    from creek.models import synthetic_fragment_id
+
     return Fragment(
+        id=synthetic_fragment_id(),
         title=title,
         source=FragmentSource(
             platform=platform,

--- a/creek-tools/tests/test_dedup.py
+++ b/creek-tools/tests/test_dedup.py
@@ -478,6 +478,7 @@ class TestDeduplicatorIntegration:
         content = "Today I reflected on the nature of creativity."
 
         fragment = Fragment(
+            id="frag-000000000007",
             title="Journal Entry",
             source=FragmentSource(
                 platform="journal",
@@ -515,6 +516,7 @@ class TestDeduplicatorIntegration:
         content_original = "The key insight is that patterns repeat."
 
         frag_discord = Fragment(
+            id="frag-000000000006",
             title="Discord message",
             source=FragmentSource(
                 platform="discord",
@@ -523,6 +525,7 @@ class TestDeduplicatorIntegration:
             created=ts,
         )
         frag_journal = Fragment(
+            id="frag-000000000005",
             title="Journal note",
             source=FragmentSource(
                 platform="journal",

--- a/creek-tools/tests/test_dedup_vault_seeding.py
+++ b/creek-tools/tests/test_dedup_vault_seeding.py
@@ -439,6 +439,7 @@ class TestVaultSeedingIntegration:
         content = "The key insight is that patterns repeat."
 
         fragment = Fragment(
+            id="frag-000000000008",
             title="Insight note",
             source=FragmentSource(
                 platform="journal",

--- a/creek-tools/tests/test_embeddings.py
+++ b/creek-tools/tests/test_embeddings.py
@@ -27,7 +27,10 @@ _DIMS = 384  # all-MiniLM-L6-v2 output dimensions
 
 def _make_fragment(title: str = "Test Fragment") -> Fragment:
     """Create a minimal Fragment for testing."""
+    from creek.models import synthetic_fragment_id
+
     return Fragment(
+        id=synthetic_fragment_id(),
         title=title,
         source=FragmentSource(platform=SourcePlatform.CLAUDE),
     )

--- a/creek-tools/tests/test_ingest.py
+++ b/creek-tools/tests/test_ingest.py
@@ -16,11 +16,13 @@ from zoneinfo import ZoneInfo
 import pytest
 
 from creek.ingest.base import (
+    IngestedFragment,
     Ingestor,
     IngestResult,
     ParsedFragment,
     ProvenanceEntry,
     RawDocument,
+    assemble_ingested_fragment,
     create_provenance_entry,
     generate_fragment_id,
     normalize_encoding,
@@ -765,3 +767,95 @@ class TestIngestPackage:
         assert ParsedFragment is not None
         assert IngestResult is not None
         assert Ingestor is not None
+
+
+# ---- assemble_ingested_fragment Tests ----
+
+
+class TestAssembleIngestedFragment:
+    """Tests for the ``assemble_ingested_fragment`` helper.
+
+    Covers the happy path and the documented contract-violation paths
+    where an ingestor forgot to populate ``frontmatter`` or ``markdown``
+    on ``ParsedFragment.metadata``.
+    """
+
+    def _parsed(self, **metadata_overrides: object) -> ParsedFragment:
+        """Build a ParsedFragment with a minimal frontmatter+markdown payload."""
+        ts = datetime(2026, 1, 15, 12, 0, tzinfo=LA_TZ)
+        metadata: dict[str, object] = {
+            "markdown": "# A note\n\nBody text.\n",
+            "frontmatter": {
+                "type": "fragment",
+                "title": "A note",
+                "source": {"platform": "markdown"},
+            },
+        }
+        metadata.update(metadata_overrides)
+        return ParsedFragment(
+            content="# A note\n\nBody text.\n",
+            metadata=metadata,
+            source_path="/tmp/note.md",
+            timestamp=ts,
+        )
+
+    def test_assembles_fragment_with_deterministic_id(self) -> None:
+        """Happy path: returns IngestedFragment with deterministic ``frag-<sha>``."""
+        ingested = assemble_ingested_fragment(self._parsed())
+        assert isinstance(ingested, IngestedFragment)
+        assert ingested.fragment.id.startswith("frag-")
+        # SHA-256[:12] — 12 hex chars after the prefix
+        assert len(ingested.fragment.id.removeprefix("frag-")) == 12
+        assert ingested.body == "# A note\n\nBody text.\n"
+
+    def test_id_matches_generate_fragment_id(self) -> None:
+        """The injected ID is exactly what generate_fragment_id produces."""
+        parsed = self._parsed()
+        expected = generate_fragment_id(
+            parsed.source_path,
+            parsed.timestamp,
+            parsed.content,
+        )
+        ingested = assemble_ingested_fragment(parsed)
+        assert ingested.fragment.id == expected
+
+    def test_falls_back_to_source_stem_for_title(self) -> None:
+        """When the ingestor's frontmatter omits title, use the file stem."""
+        parsed = self._parsed(
+            frontmatter={"type": "fragment", "source": {"platform": "markdown"}},
+        )
+        ingested = assemble_ingested_fragment(parsed)
+        assert ingested.fragment.title == "note"  # /tmp/note.md → "note"
+
+    def test_missing_frontmatter_raises_descriptive_keyerror(self) -> None:
+        """Missing 'frontmatter' key surfaces as a descriptive KeyError."""
+        parsed = ParsedFragment(
+            content="x",
+            metadata={"markdown": "x"},
+            source_path="/tmp/broken.md",
+            timestamp=datetime.now(tz=LA_TZ),
+        )
+        with pytest.raises(KeyError, match="frontmatter"):
+            assemble_ingested_fragment(parsed)
+
+    def test_missing_markdown_raises_descriptive_keyerror(self) -> None:
+        """Missing 'markdown' key surfaces as a descriptive KeyError."""
+        parsed = ParsedFragment(
+            content="x",
+            metadata={"frontmatter": {"type": "fragment"}},
+            source_path="/tmp/broken.md",
+            timestamp=datetime.now(tz=LA_TZ),
+        )
+        with pytest.raises(KeyError, match="markdown"):
+            assemble_ingested_fragment(parsed)
+
+    def test_keyerror_includes_source_path(self) -> None:
+        """The error message names the offending source path for traceability."""
+        parsed = ParsedFragment(
+            content="x",
+            metadata={"markdown": "x"},
+            source_path="/tmp/specific-file.md",
+            timestamp=datetime.now(tz=LA_TZ),
+        )
+        with pytest.raises(KeyError, match="specific-file"):
+            assemble_ingested_fragment(parsed)

--- a/creek-tools/tests/test_ingest.py
+++ b/creek-tools/tests/test_ingest.py
@@ -780,7 +780,11 @@ class TestAssembleIngestedFragment:
     on ``ParsedFragment.metadata``.
     """
 
-    def _parsed(self, **metadata_overrides: object) -> ParsedFragment:
+    def _parsed(
+        self,
+        source_path: str = "fixtures/note.md",
+        **metadata_overrides: object,
+    ) -> ParsedFragment:
         """Build a ParsedFragment with a minimal frontmatter+markdown payload."""
         ts = datetime(2026, 1, 15, 12, 0, tzinfo=LA_TZ)
         metadata: dict[str, object] = {
@@ -795,7 +799,7 @@ class TestAssembleIngestedFragment:
         return ParsedFragment(
             content="# A note\n\nBody text.\n",
             metadata=metadata,
-            source_path="/tmp/note.md",
+            source_path=source_path,
             timestamp=ts,
         )
 
@@ -825,14 +829,15 @@ class TestAssembleIngestedFragment:
             frontmatter={"type": "fragment", "source": {"platform": "markdown"}},
         )
         ingested = assemble_ingested_fragment(parsed)
-        assert ingested.fragment.title == "note"  # /tmp/note.md → "note"
+        # fixtures/note.md → "note"
+        assert ingested.fragment.title == "note"
 
     def test_missing_frontmatter_raises_descriptive_keyerror(self) -> None:
         """Missing 'frontmatter' key surfaces as a descriptive KeyError."""
         parsed = ParsedFragment(
             content="x",
             metadata={"markdown": "x"},
-            source_path="/tmp/broken.md",
+            source_path="fixtures/broken.md",
             timestamp=datetime.now(tz=LA_TZ),
         )
         with pytest.raises(KeyError, match="frontmatter"):
@@ -843,7 +848,7 @@ class TestAssembleIngestedFragment:
         parsed = ParsedFragment(
             content="x",
             metadata={"frontmatter": {"type": "fragment"}},
-            source_path="/tmp/broken.md",
+            source_path="fixtures/broken.md",
             timestamp=datetime.now(tz=LA_TZ),
         )
         with pytest.raises(KeyError, match="markdown"):
@@ -854,7 +859,7 @@ class TestAssembleIngestedFragment:
         parsed = ParsedFragment(
             content="x",
             metadata={"markdown": "x"},
-            source_path="/tmp/specific-file.md",
+            source_path="fixtures/specific-file.md",
             timestamp=datetime.now(tz=LA_TZ),
         )
         with pytest.raises(KeyError, match="specific-file"):

--- a/creek-tools/tests/test_ingest_markdown.py
+++ b/creek-tools/tests/test_ingest_markdown.py
@@ -387,10 +387,10 @@ class TestPlatformInference:
             SourcePlatform.CODE
         )
 
-    def test_infers_other_platform_for_notes(self) -> None:
-        """Should infer OTHER platform for notes-type documents."""
+    def test_infers_markdown_platform_for_notes(self) -> None:
+        """Should infer MARKDOWN platform for unclassified note-type documents."""
         assert _infer_platform("notes", Path("/notes/misc.md")) == (
-            SourcePlatform.OTHER
+            SourcePlatform.MARKDOWN
         )
 
     def test_infers_journal_from_path(self) -> None:

--- a/creek-tools/tests/test_link.py
+++ b/creek-tools/tests/test_link.py
@@ -48,9 +48,13 @@ def _make_fragment(
     phase: Phase = Phase.UNCLASSIFIED,
     mode: Mode = Mode.UNCLASSIFIED,
     emotional_texture: list[str] | None = None,
+    fid: str | None = None,
 ) -> Fragment:
     """Create a Fragment for testing with configurable classification fields."""
+    from creek.models import synthetic_fragment_id
+
     return Fragment(
+        id=fid if fid is not None else synthetic_fragment_id(),
         title=title,
         source=FragmentSource(platform=platform),
         created=created or datetime.now(),
@@ -1855,6 +1859,7 @@ class TestLinkingPipeline:
             linking_config=LinkingConfig(),
         )
         fragment = Fragment(
+            id="frag-00000000000b",
             title="Test",
             source=FragmentSource(platform=SourcePlatform.CLAUDE),
             threads=["existing-thread"],
@@ -1883,6 +1888,7 @@ class TestLinkingPipeline:
             linking_config=LinkingConfig(),
         )
         fragment = Fragment(
+            id="frag-00000000000a",
             title="Test",
             source=FragmentSource(platform=SourcePlatform.CLAUDE),
             threads=["[[Existing]]"],

--- a/creek-tools/tests/test_models.py
+++ b/creek-tools/tests/test_models.py
@@ -239,7 +239,7 @@ class TestSourcePlatformEnum:
     """Tests for the SourcePlatform enum."""
 
     def test_all_platforms_exist(self) -> None:
-        """Verify all 12 source platform values exist."""
+        """Verify the full set of source platform values, including markdown."""
         expected = [
             "claude",
             "chatgpt",
@@ -247,6 +247,7 @@ class TestSourcePlatformEnum:
             "journal",
             "essay",
             "code",
+            "markdown",
             "email",
             "document",
             "image_ocr",
@@ -382,13 +383,14 @@ class TestFragment:
     def test_minimal_creation(self) -> None:
         """Fragment with only title should use defaults for everything else."""
         frag = Fragment(
+            id="frag-000000000015",
             title="Test Fragment",
             source=FragmentSource(platform=SourcePlatform.CLAUDE),
         )
         assert frag.type == "fragment"
         assert frag.title == "Test Fragment"
         assert frag.id.startswith("frag-")
-        assert len(frag.id) == 13  # "frag-" + 8 hex chars
+        assert len(frag.id) == 17  # "frag-" + 12 hex chars
         assert frag.frequency.primary == "unclassified"
         assert frag.wavelength.phase == "unclassified"
         assert frag.voice.voice_register is None
@@ -402,6 +404,7 @@ class TestFragment:
         """Fragment with all fields specified should work."""
         now = datetime(2024, 1, 15, 10, 30, 0)
         frag = Fragment(
+            id="frag-000000000014",
             title="Deep Insight",
             source=FragmentSource(
                 platform=SourcePlatform.JOURNAL,
@@ -437,13 +440,17 @@ class TestFragment:
         assert frag.voice.voice_register == "analytical"
         assert frag.praxis_potential == "explicit"
 
-    def test_id_auto_generation(self) -> None:
-        """Each Fragment should get a unique auto-generated ID."""
+    def test_synthetic_id_is_unique(self) -> None:
+        """synthetic_fragment_id() returns distinct, frag-prefixed values."""
+        from creek.models import synthetic_fragment_id
+
         frag1 = Fragment(
+            id=synthetic_fragment_id(),
             title="A",
             source=FragmentSource(platform=SourcePlatform.CLAUDE),
         )
         frag2 = Fragment(
+            id=synthetic_fragment_id(),
             title="B",
             source=FragmentSource(platform=SourcePlatform.CLAUDE),
         )
@@ -454,6 +461,7 @@ class TestFragment:
     def test_model_dump_serializable(self) -> None:
         """Fragment model_dump should produce a JSON-serializable dict."""
         frag = Fragment(
+            id="frag-000000000011",
             title="Test",
             source=FragmentSource(platform=SourcePlatform.CLAUDE),
         )
@@ -468,6 +476,7 @@ class TestFragment:
     def test_round_trip(self) -> None:
         """Create a Fragment, dump it, and recreate from the dict."""
         original = Fragment(
+            id="frag-000000000010",
             title="Round Trip Test",
             source=FragmentSource(
                 platform=SourcePlatform.ESSAY,
@@ -738,15 +747,32 @@ class TestIdGeneration:
     """Tests for ID generation across all models."""
 
     def test_fragment_id_format(self) -> None:
-        """Fragment ID should match frag-XXXXXXXX format."""
+        """Fragment IDs (synthetic or deterministic) are 12-hex with frag- prefix."""
+        from creek.models import synthetic_fragment_id
+
         frag = Fragment(
+            id=synthetic_fragment_id(),
             title="Test",
             source=FragmentSource(platform=SourcePlatform.CLAUDE),
         )
         assert frag.id.startswith("frag-")
         hex_part = frag.id[5:]
-        assert len(hex_part) == 8
+        assert len(hex_part) == 12
         int(hex_part, 16)  # Should not raise — valid hex
+
+    def test_fragment_id_required(self) -> None:
+        """Fragment without an explicit id raises a validation error."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Fragment.model_validate(
+                {
+                    "title": "Test",
+                    "source": FragmentSource(
+                        platform=SourcePlatform.CLAUDE,
+                    ).model_dump(),
+                },
+            )
 
     def test_thread_id_format(self) -> None:
         """Thread ID should match thread-XXXXXXXX format."""
@@ -803,6 +829,7 @@ class TestEnumSerialization:
     def test_fragment_enums_as_strings(self) -> None:
         """Fragment model_dump should serialize all enums as strings."""
         frag = Fragment(
+            id="frag-00000000000d",
             title="Test",
             source=FragmentSource(platform=SourcePlatform.CLAUDE),
             frequency=FrequencyClassification(primary=Frequency.F1),

--- a/creek-tools/tests/test_paradox.py
+++ b/creek-tools/tests/test_paradox.py
@@ -52,7 +52,10 @@ def make_fragment(
     threads: list[str] | None = None,
 ) -> Fragment:
     """Build a synthetic Fragment with explicit classification axes."""
+    from creek.models import synthetic_fragment_id
+
     kwargs: dict[str, object] = {
+        "id": fid if fid is not None else synthetic_fragment_id(),
         "title": title,
         "source": FragmentSource(platform=SourcePlatform.JOURNAL),
         "frequency": FrequencyClassification(
@@ -63,8 +66,6 @@ def make_fragment(
         "voice": VoiceClassification(confidence=confidence),
         "threads": threads or [],
     }
-    if fid is not None:
-        kwargs["id"] = fid
     return Fragment(**kwargs)
 
 

--- a/creek-tools/tests/test_pipeline.py
+++ b/creek-tools/tests/test_pipeline.py
@@ -309,6 +309,11 @@ class TestPipelineWithFragments:
     def _make_mock_ingestor_registry(self, source_path):
         """Build a mock INGESTOR_REGISTRY that returns one ParsedFragment.
 
+        Mirrors the post-fix four-stage ingestor contract: each parsed
+        fragment carries its converted ``markdown`` body and the
+        ``frontmatter`` dict on ``metadata`` so the pipeline can
+        assemble it into a real :class:`Fragment` with a deterministic ID.
+
         Args:
             source_path: The source path, used for provenance.
 
@@ -321,7 +326,14 @@ class TestPipelineWithFragments:
 
         fragment = ParsedFragment(
             content="Test content about systems and patterns",
-            metadata={},
+            metadata={
+                "markdown": "Test content about systems and patterns",
+                "frontmatter": {
+                    "type": "fragment",
+                    "title": "Mock note",
+                    "source": {"platform": "markdown"},
+                },
+            },
             source_path=str(source_path / "note1.md"),
             timestamp=datetime.now(),
         )
@@ -366,6 +378,81 @@ class TestPipelineWithFragments:
         # Review queue file should exist in vault_path
         review_files = list(vault_path.glob("review-queue-*.md"))
         assert len(review_files) == 1
+
+
+class TestPipelineErrorSurfacing:
+    """Tests that ingestor errors and assembly failures reach PipelineResult."""
+
+    def _make_failing_registry(self, source_path):
+        """Build a registry whose ingestor reports one error and one good fragment."""
+        from datetime import datetime
+
+        from creek.ingest.base import IngestResult, ParsedFragment
+
+        bad_path = str(source_path / "broken.bin")
+        good = ParsedFragment(
+            content="Good content",
+            metadata={
+                "markdown": "Good content",
+                "frontmatter": {
+                    "type": "fragment",
+                    "title": "Good note",
+                    "source": {"platform": "markdown"},
+                },
+            },
+            source_path=str(source_path / "good.md"),
+            timestamp=datetime.now(),
+        )
+        ingest_result = IngestResult(
+            fragments=[good],
+            errors=[f"parse error for {bad_path}: corrupt header"],
+        )
+        mock_ingestor = MagicMock()
+        mock_ingestor.return_value.ingest.return_value = ingest_result
+        return {"mock": mock_ingestor}, bad_path
+
+    def test_errors_surface_on_pipeline_result(
+        self,
+        config,
+        vault_path,
+        source_path,
+    ) -> None:
+        """Ingestor-reported errors land on PipelineResult.errors."""
+        registry, bad_path = self._make_failing_registry(source_path)
+        pipeline = Pipeline(config=config)
+        with patch("creek.pipeline.INGESTOR_REGISTRY", registry):
+            result = pipeline.run(source_path=source_path, vault_path=vault_path)
+        assert result.fragments_created == 1
+        assert len(result.errors) == 1
+        assert bad_path in result.errors[0]
+        assert result.errors[0].startswith("[mock]")
+
+    def test_cli_process_prints_errors(
+        self,
+        vault_path,
+        source_path,
+    ) -> None:
+        """CLI process command surfaces both fragment count and error count."""
+        from typer.testing import CliRunner
+
+        from creek.cli import app
+
+        registry, _bad_path = self._make_failing_registry(source_path)
+        runner = CliRunner()
+        with patch("creek.pipeline.INGESTOR_REGISTRY", registry):
+            result = runner.invoke(
+                app,
+                [
+                    "process",
+                    "--source",
+                    str(source_path),
+                    "--vault",
+                    str(vault_path),
+                ],
+            )
+        assert result.exit_code == 0
+        assert "Errors:" in result.output
+        assert "1" in result.output
 
 
 # ---------------------------------------------------------------------------
@@ -496,7 +583,9 @@ class TestPipelineIntegration:
         # Markdown ingestor finds .md files
         assert result.fragments_created >= 3
         assert result.classifications_made >= 3
-        assert result.links_found == 0
+        # Linking now runs on real fragments (was a no-op when bodies were
+        # discarded); we just assert it completed and produced a count.
+        assert result.links_found >= 0
         # Indexes should be generated
         assert result.indexes_generated >= 4
 

--- a/creek-tools/tests/test_pipeline.py
+++ b/creek-tools/tests/test_pipeline.py
@@ -451,8 +451,95 @@ class TestPipelineErrorSurfacing:
                 ],
             )
         assert result.exit_code == 0
-        assert "Errors:" in result.output
-        assert "1" in result.output
+        # Match the rendered error count line precisely so an unrelated
+        # "1" elsewhere in the output (line numbers, fragment counts,
+        # etc.) does not fool this assertion.
+        assert "Errors: 1" in result.output
+        # The error message itself should be visible to the user.
+        assert "broken.bin" in result.output
+
+    def test_assembly_failure_surfaces_as_error(
+        self,
+        config,
+        vault_path,
+        source_path,
+    ) -> None:
+        """Per-fragment assembly failures land on PipelineResult.errors."""
+        from datetime import datetime
+
+        from creek.ingest.base import IngestResult, ParsedFragment
+
+        # ParsedFragment with missing 'frontmatter' / 'markdown' keys —
+        # violates the ingestor contract and triggers the recoverable
+        # ``KeyError`` branch in _run_ingestion.
+        broken = ParsedFragment(
+            content="x",
+            metadata={},  # contract violation
+            source_path=str(source_path / "broken.md"),
+            timestamp=datetime.now(),
+        )
+        ingest_result = IngestResult(fragments=[broken])
+        mock_ingestor = MagicMock()
+        mock_ingestor.return_value.ingest.return_value = ingest_result
+        registry = {"mock": mock_ingestor}
+
+        pipeline = Pipeline(config=config)
+        with patch("creek.pipeline.INGESTOR_REGISTRY", registry):
+            result = pipeline.run(source_path=source_path, vault_path=vault_path)
+
+        assert result.fragments_created == 0
+        assert len(result.errors) == 1
+        assert "[mock]" in result.errors[0]
+        assert "broken.md" in result.errors[0]
+
+    def test_vault_write_keyerror_surfaces_as_error(
+        self,
+        config,
+        vault_path,
+        source_path,
+    ) -> None:
+        """A missing platform mapping at write time becomes a graceful error."""
+        from datetime import datetime
+
+        from creek.ingest.base import IngestResult, ParsedFragment
+
+        good = ParsedFragment(
+            content="content",
+            metadata={
+                "markdown": "content",
+                "frontmatter": {
+                    "type": "fragment",
+                    "title": "Note",
+                    "source": {"platform": "markdown"},
+                },
+            },
+            source_path=str(source_path / "good.md"),
+            timestamp=datetime.now(),
+        )
+        ingest_result = IngestResult(fragments=[good])
+        mock_ingestor = MagicMock()
+        mock_ingestor.return_value.ingest.return_value = ingest_result
+        registry = {"mock": mock_ingestor}
+
+        # Simulate the regression scenario the writer guard is defending
+        # against: an enum value with no entry in _PLATFORM_SUBFOLDER.
+        # We patch the mapping to remove the markdown entry; the writer
+        # would otherwise raise an uncaught KeyError that bypasses the
+        # error infrastructure.
+        from creek.vault import writer as writer_mod
+
+        broken_map = dict(writer_mod._PLATFORM_SUBFOLDER)
+        broken_map.pop("markdown")
+        pipeline = Pipeline(config=config)
+        with (
+            patch("creek.pipeline.INGESTOR_REGISTRY", registry),
+            patch.object(writer_mod, "_PLATFORM_SUBFOLDER", broken_map),
+        ):
+            result = pipeline.run(source_path=source_path, vault_path=vault_path)
+
+        # Pipeline keeps running; the missing-mapping fragment surfaces as
+        # an error but doesn't crash the run.
+        assert any("vault-writer" in err for err in result.errors)
 
 
 # ---------------------------------------------------------------------------
@@ -583,9 +670,16 @@ class TestPipelineIntegration:
         # Markdown ingestor finds .md files
         assert result.fragments_created >= 3
         assert result.classifications_made >= 3
-        # Linking now runs on real fragments (was a no-op when bodies were
-        # discarded); we just assert it completed and produced a count.
-        assert result.links_found >= 0
+        # Linking now runs against real fragment metadata. The mock
+        # SentenceTransformer in conftest.py is deterministic within a
+        # single pytest process (seeded by hash() of each fragment's
+        # content), so the count is stable across re-runs but its
+        # absolute value depends on PYTHONHASHSEED. We bound it to a
+        # sane envelope rather than pin an exact number: the lower
+        # bound catches "linker silently skipped"; the upper bound
+        # catches "linker exploded into N^2 spam links".
+        assert isinstance(result.links_found, int)
+        assert 0 <= result.links_found <= result.fragments_created**2
         # Indexes should be generated
         assert result.indexes_generated >= 4
 

--- a/creek-tools/tests/test_privacy.py
+++ b/creek-tools/tests/test_privacy.py
@@ -32,7 +32,10 @@ def _make_fragment(
     author: Authorship = Authorship.SELF,
 ) -> Fragment:
     """Build a deterministic Fragment for tests."""
+    from creek.models import synthetic_fragment_id
+
     return Fragment(
+        id=synthetic_fragment_id(),
         title=title,
         source=FragmentSource(platform=platform, channel=channel, author=author),
         created=datetime(2026, 4, 1, tzinfo=UTC),
@@ -377,6 +380,7 @@ class TestReviewQueueIntegration:
         """INTIMATE always needs human review even with full classification."""
         generator = ReviewQueueGenerator()
         frag = Fragment(
+            id="frag-000000000018",
             title="Personal note",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
             frequency=FrequencyClassification(primary=Frequency.F5),
@@ -389,6 +393,7 @@ class TestReviewQueueIntegration:
         """A fully-classified PUBLIC fragment is not flagged."""
         generator = ReviewQueueGenerator()
         frag = Fragment(
+            id="frag-000000000017",
             title="Published essay",
             source=FragmentSource(platform=SourcePlatform.ESSAY),
             frequency=FrequencyClassification(primary=Frequency.F3),

--- a/creek-tools/tests/test_unnamed_digest.py
+++ b/creek-tools/tests/test_unnamed_digest.py
@@ -182,6 +182,7 @@ class TestFilterFragmentsInWeek:
         """Fragments created exactly at ``week_start`` are included."""
         week_start = _week_start()
         frag = Fragment(
+            id="frag-000000000024",
             title="boundary-low",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
             created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
@@ -195,6 +196,7 @@ class TestFilterFragmentsInWeek:
         """Fragments created on ``week_start + 7`` are excluded."""
         week_start = _week_start()
         frag = Fragment(
+            id="frag-000000000023",
             title="boundary-high",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
             created=datetime.combine(
@@ -207,6 +209,7 @@ class TestFilterFragmentsInWeek:
         """Fragments from before the window are excluded."""
         week_start = _week_start()
         frag = Fragment(
+            id="frag-000000000022",
             title="old",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
             created=datetime.combine(
@@ -231,6 +234,7 @@ class TestDetectUnnamedClusters:
     ) -> None:
         """A single fragment cannot form a cluster."""
         frag = Fragment(
+            id="frag-000000000021",
             title="solo",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
         )
@@ -240,10 +244,12 @@ class TestDetectUnnamedClusters:
         """Identical titles yield identical embeddings and form one cluster."""
         gen = UnnamedDigestGenerator(embedding_linker=linker, similarity_threshold=0.7)
         frag_a = Fragment(
+            id="frag-000000000020",
             title="recurring-dream",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
         )
         frag_b = Fragment(
+            id="frag-00000000001f",
             title="recurring-dream",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
         )
@@ -255,10 +261,12 @@ class TestDetectUnnamedClusters:
         """An impossibly high threshold collapses all clusters to singletons."""
         gen = UnnamedDigestGenerator(embedding_linker=linker, similarity_threshold=1.01)
         frag_a = Fragment(
+            id="frag-00000000001e",
             title="same-string",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
         )
         frag_b = Fragment(
+            id="frag-00000000001d",
             title="same-string",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
         )
@@ -276,14 +284,17 @@ class TestDetectUnnamedClusters:
         """
         gen = UnnamedDigestGenerator(embedding_linker=linker, similarity_threshold=0.99)
         frag_a = Fragment(
+            id="frag-00000000001c",
             title="alpha",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
         )
         frag_b = Fragment(
+            id="frag-00000000001b",
             title="bravo",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
         )
         frag_c = Fragment(
+            id="frag-00000000001a",
             title="charlie",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
         )

--- a/creek-tools/tests/test_validator.py
+++ b/creek-tools/tests/test_validator.py
@@ -27,7 +27,10 @@ from creek.models import Fragment, FragmentSource, SourcePlatform
 
 def _make_fragment(**overrides: object) -> Fragment:
     """Build a valid Fragment with sensible defaults, applying overrides."""
+    from creek.models import synthetic_fragment_id
+
     defaults: dict[str, object] = {
+        "id": synthetic_fragment_id(),
         "title": ("A sufficiently long content body for validation testing purposes"),
         "source": FragmentSource(
             platform=SourcePlatform.CLAUDE,

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -48,6 +48,11 @@ def vault_path(tmp_path: Path) -> Path:
         "01-Fragments/Writing",
         "01-Fragments/Journal",
         "01-Fragments/Technical",
+        "01-Fragments/Notes",
+        "01-Fragments/Documents",
+        "01-Fragments/Data",
+        "01-Fragments/Decks",
+        "01-Fragments/Images",
         "01-Fragments/Unsorted",
         "02-Threads/Active",
         "02-Threads/Dormant",
@@ -189,6 +194,37 @@ class TestWriteFragment:
         assert "title: Test Conversation Fragment" in content
         assert "type: fragment" in content
 
+    def test_write_fragment_persists_body(
+        self,
+        writer: VaultWriter,
+        sample_fragment: Fragment,
+    ) -> None:
+        """Provided body text is written below the frontmatter block."""
+        import frontmatter as fm_mod
+
+        body = "# A Note\n\nReal body content goes here.\n"
+        result = writer.write_fragment(sample_fragment, body=body)
+        post = fm_mod.load(str(result))
+        assert "Real body content goes here." in post.content
+        assert post["id"] == "frag-test0001"
+
+    def test_write_fragment_body_round_trips_through_pydantic(
+        self,
+        writer: VaultWriter,
+        sample_fragment: Fragment,
+    ) -> None:
+        """Frontmatter survives round-trip back into a Fragment model."""
+        import frontmatter as fm_mod
+
+        body = "Body that must survive serialisation."
+        result = writer.write_fragment(sample_fragment, body=body)
+        post = fm_mod.load(str(result))
+        round_tripped = Fragment.model_validate(dict(post.metadata))
+        assert round_tripped.id == sample_fragment.id
+        assert round_tripped.title == sample_fragment.title
+        assert body.strip() in post.content.strip()
+        assert round_tripped.type == "fragment"
+
     def test_write_fragment_chatgpt_goes_to_conversations(
         self,
         writer: VaultWriter,
@@ -267,31 +303,96 @@ class TestWriteFragment:
         result = writer.write_fragment(frag)
         assert "01-Fragments/Unsorted" in str(result)
 
-    def test_write_fragment_email_goes_to_unsorted(
+    def test_write_fragment_email_goes_to_messages(
         self,
         writer: VaultWriter,
     ) -> None:
-        """Email platform (not explicitly mapped) goes to Unsorted."""
+        """Email fragments share the Messages subfolder with chat platforms."""
         frag = Fragment(
             id="frag-email001",
             title="Email Fragment",
             source=FragmentSource(platform=SourcePlatform.EMAIL),
         )
         result = writer.write_fragment(frag)
-        assert "01-Fragments/Unsorted" in str(result)
+        assert "01-Fragments/Messages" in str(result)
 
-    def test_write_fragment_image_ocr_goes_to_unsorted(
+    def test_write_fragment_image_ocr_goes_to_images(
         self,
         writer: VaultWriter,
     ) -> None:
-        """Image OCR platform (not explicitly mapped) goes to Unsorted."""
+        """OCR'd image fragments land in the Images subfolder."""
         frag = Fragment(
             id="frag-ocr00001",
             title="OCR Fragment",
             source=FragmentSource(platform=SourcePlatform.IMAGE_OCR),
         )
         result = writer.write_fragment(frag)
-        assert "01-Fragments/Unsorted" in str(result)
+        assert "01-Fragments/Images" in str(result)
+
+    def test_write_fragment_document_goes_to_documents(
+        self,
+        writer: VaultWriter,
+    ) -> None:
+        """Document fragments land in the Documents subfolder."""
+        frag = Fragment(
+            id="frag-doc00001",
+            title="Doc Fragment",
+            source=FragmentSource(platform=SourcePlatform.DOCUMENT),
+        )
+        result = writer.write_fragment(frag)
+        assert "01-Fragments/Documents" in str(result)
+
+    def test_write_fragment_spreadsheet_goes_to_data(
+        self,
+        writer: VaultWriter,
+    ) -> None:
+        """Spreadsheet fragments land in the Data subfolder."""
+        frag = Fragment(
+            id="frag-xls00001",
+            title="Sheet Fragment",
+            source=FragmentSource(platform=SourcePlatform.SPREADSHEET),
+        )
+        result = writer.write_fragment(frag)
+        assert "01-Fragments/Data" in str(result)
+
+    def test_write_fragment_presentation_goes_to_decks(
+        self,
+        writer: VaultWriter,
+    ) -> None:
+        """Presentation fragments land in the Decks subfolder."""
+        frag = Fragment(
+            id="frag-ppt00001",
+            title="Deck Fragment",
+            source=FragmentSource(platform=SourcePlatform.PRESENTATION),
+        )
+        result = writer.write_fragment(frag)
+        assert "01-Fragments/Decks" in str(result)
+
+    def test_write_fragment_markdown_goes_to_notes(
+        self,
+        writer: VaultWriter,
+    ) -> None:
+        """Generic markdown fragments land in the Notes subfolder."""
+        frag = Fragment(
+            id="frag-md0000001",
+            title="Markdown Note",
+            source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        )
+        result = writer.write_fragment(frag)
+        assert "01-Fragments/Notes" in str(result)
+
+    def test_platform_subfolder_mapping_is_total(self) -> None:
+        """Every SourcePlatform must have an explicit subfolder mapping.
+
+        Guards against regressions where a new platform silently routes
+        to ``Unsorted/`` because a developer forgot to extend the map.
+        """
+        from creek.vault.writer import _PLATFORM_SUBFOLDER
+
+        unmapped = {p for p in SourcePlatform if p not in _PLATFORM_SUBFOLDER}
+        assert unmapped == set(), (
+            f"Missing _PLATFORM_SUBFOLDER entries for: {sorted(unmapped)}"
+        )
 
 
 # ---- write_thread ----


### PR DESCRIPTION
BUG-007: Replace ``_generate_frag_id`` (uuid4, 8-hex) with a clearly-named
``synthetic_fragment_id`` helper (uuid4, 12-hex) and remove the default
factory from ``Fragment.id`` so callers must supply an ID — either the
deterministic ``generate_fragment_id`` from the ingest path, or the new
synthetic helper for one-off cases (test fixtures, synthesised praxis
notes). Idempotency now flows from the contract, not from luck.

BUG-011: Add ``SourcePlatform.MARKDOWN`` and update the markdown
ingestor to fall back to it instead of OTHER when no clearer signal
is present. This pairs with the writer's full ``_PLATFORM_SUBFOLDER``
totality fix (next commit) so generic markdown notes land in
``01-Fragments/Notes/`` rather than ``Unsorted/``.

All test fixtures and helpers now pass an explicit ``id`` (either a
literal placeholder or ``synthetic_fragment_id()``). The existing
``test_fragment_id_format`` test was widened to assert 12-hex output;
``test_id_auto_generation`` was repurposed as ``test_synthetic_id_is_unique``;
``test_fragment_id_required`` was added to lock in the validation
behaviour.

https://claude.ai/code/session_01VYx3f1u1FBT9C8e4TAYHnX