### PR TITLE
feat: execute Batch B — CLI surface and consent gate

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING
 
 import frontmatter
 import yaml
-from pydantic import ValidationError
 
 from creek.classify.constants import (
     CLASSIFICATION_METHOD_KEY,
@@ -29,6 +28,7 @@ from creek.classify.llm import LLMClassifier
 from creek.classify.rules import RuleClassifier
 from creek.ingest.base import LA_TZ
 from creek.models import Fragment, Frequency
+from creek.vault.reader import try_load_fragment
 
 if TYPE_CHECKING:
     from creek.config import CreekConfig
@@ -239,7 +239,15 @@ def _classify_one(
 
 
 def _read_fragment(md_file: Path) -> tuple[Fragment, str, dict[str, object]] | None:
-    """Load a fragment file's metadata, body, and raw frontmatter dict.
+    """Thin alias for :func:`creek.vault.reader.try_load_fragment`.
+
+    Kept as a private name so existing patches in
+    ``tests/test_classify_engine.py`` continue to target the engine
+    module rather than the shared reader. The semantics are
+    identical: ``None`` means "not a Creek fragment, silently skip",
+    while real I/O failures propagate so the engine's outer
+    ``except`` block can record them on
+    :attr:`ClassifySummary.errors`.
 
     Args:
         md_file: Markdown file to load.
@@ -247,25 +255,14 @@ def _read_fragment(md_file: Path) -> tuple[Fragment, str, dict[str, object]] | N
     Returns:
         ``(fragment, body, raw_metadata)`` for valid fragments, or
         ``None`` when the file is well-formed YAML but is **not** a
-        Creek fragment (no ``type: fragment`` key, or a schema
-        mismatch). Real I/O failures are propagated to the caller so
-        they can be recorded on :attr:`ClassifySummary.errors`.
+        Creek fragment.
 
     Raises:
         OSError: When the file cannot be opened.
         ValueError: When the YAML cannot be parsed.
         yaml.YAMLError: When the YAML parser rejects the document.
     """
-    post = frontmatter.load(str(md_file))
-    metadata = dict(post.metadata)
-    if metadata.get("type") != "fragment":
-        return None
-    try:
-        fragment = Fragment.model_validate(metadata)
-    except ValidationError:
-        logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
-        return None
-    return fragment, str(post.content), metadata
+    return try_load_fragment(md_file)
 
 
 def _write_fragment(

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path  # noqa: TC003 — runtime use in dataclass field
+from pathlib import Path  # noqa: TC003  # no issue: runtime dataclass field
 from typing import TYPE_CHECKING
 
 import frontmatter
@@ -176,7 +176,7 @@ def _classify_one(
         if confidence >= confidence_threshold:
             return rule_result, True
 
-    if llm is None:  # pragma: no cover — guarded by ``method == "llm"``
+    if llm is None:  # pragma: no cover  # no issue: defensive guard, unreachable
         msg = "LLM classifier required when method='llm'"
         raise RuntimeError(msg)
     return llm.classify(rule_result, content=body), False

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -13,12 +13,17 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path  # noqa: TC003 — runtime use in dataclass field
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING
 
 import frontmatter
 import yaml
 from pydantic import ValidationError
 
+from creek.classify.constants import (
+    CLASSIFICATION_METHOD_KEY,
+    CLASSIFIED_AT_KEY,
+    MANUAL_METHOD,
+)
 from creek.classify.llm import LLMClassifier
 from creek.classify.rules import RuleClassifier
 from creek.ingest.base import LA_TZ
@@ -28,14 +33,6 @@ if TYPE_CHECKING:
     from creek.config import CreekConfig
 
 logger = logging.getLogger(__name__)
-
-_CLASSIFICATION_METHOD_KEY: Final[str] = "classification_method"
-"""Frontmatter key carrying ``rules | llm | manual``."""
-
-_CLASSIFIED_AT_KEY: Final[str] = "classified_at"
-"""Frontmatter key carrying the ISO-8601 classification timestamp."""
-
-_MANUAL_METHOD: Final[str] = "manual"
 
 
 @dataclass(frozen=True)
@@ -66,7 +63,6 @@ def run_classify(
     vault_path: Path,
     config: CreekConfig,
     method: str,
-    batch_size: int,
     force: bool,
 ) -> ClassifySummary:
     """Classify every fragment in *vault_path* using the chosen method.
@@ -75,9 +71,6 @@ def run_classify(
         vault_path: Vault root.
         config: Loaded Creek configuration.
         method: ``"rules"`` or ``"llm"``.
-        batch_size: Reserved; the current LLM classifier processes
-            fragments individually because the per-vault scan is
-            already streaming.
         force: When ``True``, overwrite ``classification_method:
             manual`` decisions.
 
@@ -99,13 +92,19 @@ def run_classify(
 
     for md_file in sorted(fragments_root.rglob("*.md")):
         total += 1
-        record = _read_fragment(md_file)
+        try:
+            record = _read_fragment(md_file)
+        except (OSError, ValueError, yaml.YAMLError) as exc:
+            errors.append(f"unreadable fragment {md_file}: {exc}")
+            continue
         if record is None:
-            errors.append(f"unreadable fragment: {md_file}")
+            # File parsed cleanly but is not a Creek fragment (no
+            # ``type: fragment`` field, or schema mismatch). Silently
+            # skip — markdown notes coexist with fragments in the vault.
             continue
         fragment, body, raw = record
 
-        if not force and raw.get(_CLASSIFICATION_METHOD_KEY) == _MANUAL_METHOD:
+        if not force and raw.get(CLASSIFICATION_METHOD_KEY) == MANUAL_METHOD:
             preserved += 1
             continue
 
@@ -190,14 +189,18 @@ def _read_fragment(md_file: Path) -> tuple[Fragment, str, dict[str, object]] | N
         md_file: Markdown file to load.
 
     Returns:
-        ``(fragment, body, raw_metadata)`` or ``None`` when the file is
-        not a valid fragment record.
+        ``(fragment, body, raw_metadata)`` for valid fragments, or
+        ``None`` when the file is well-formed YAML but is **not** a
+        Creek fragment (no ``type: fragment`` key, or a schema
+        mismatch). Real I/O failures are propagated to the caller so
+        they can be recorded on :attr:`ClassifySummary.errors`.
+
+    Raises:
+        OSError: When the file cannot be opened.
+        ValueError: When the YAML cannot be parsed.
+        yaml.YAMLError: When the YAML parser rejects the document.
     """
-    try:
-        post = frontmatter.load(str(md_file))
-    except (OSError, ValueError, yaml.YAMLError):
-        logger.debug("Skipping unreadable markdown file: %s", md_file)
-        return None
+    post = frontmatter.load(str(md_file))
     metadata = dict(post.metadata)
     if metadata.get("type") != "fragment":
         return None
@@ -233,8 +236,8 @@ def _write_fragment(
     """
     new_metadata = dict(raw)
     new_metadata.update(fragment.model_dump(mode="json"))
-    new_metadata[_CLASSIFICATION_METHOD_KEY] = method
-    new_metadata[_CLASSIFIED_AT_KEY] = datetime.now(tz=LA_TZ).isoformat()
+    new_metadata[CLASSIFICATION_METHOD_KEY] = method
+    new_metadata[CLASSIFIED_AT_KEY] = datetime.now(tz=LA_TZ).isoformat()
 
     post = frontmatter.Post(content=body, **new_metadata)
     md_file.write_text(frontmatter.dumps(post), encoding="utf-8")

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -10,7 +10,7 @@ and ``classified_at`` timestamp on each fragment so that subsequent
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path  # noqa: TC003  # no issue: runtime dataclass field
 from typing import TYPE_CHECKING
@@ -23,6 +23,7 @@ from creek.classify.constants import (
     CLASSIFICATION_METHOD_KEY,
     CLASSIFIED_AT_KEY,
     MANUAL_METHOD,
+    RULES_METHOD,
 )
 from creek.classify.llm import LLMClassifier
 from creek.classify.rules import RuleClassifier
@@ -40,14 +41,20 @@ class ClassifySummary:
     """Counts produced by a single ``creek classify`` run.
 
     Attributes:
-        total: Total fragment files visited.
-        classified: Fragments whose frontmatter was updated.
+        total: Number of Creek fragments visited (non-fragment markdown
+            files in ``01-Fragments`` are silently skipped and not
+            counted here).
+        classified: Fragments whose frontmatter was updated. A
+            ``--method llm`` run that short-circuits to the rule
+            result still counts as classified — the work is real and
+            the file is rewritten.
         preserved_manual: Fragments left unchanged because the operator
             previously stamped them ``method: manual`` and ``--force``
             was not passed.
-        skipped_high_confidence: Fragments the LLM was not asked about
-            because the rules classifier already produced a confident
-            answer.
+        skipped_high_confidence: Subset of ``classified`` for which
+            the LLM was not invoked because the rule classifier
+            produced a high-confidence answer. The fragment is still
+            stamped ``classification_method: rules`` on disk.
         errors: Human-readable error messages (one per failure).
     """
 
@@ -56,6 +63,21 @@ class ClassifySummary:
     preserved_manual: int
     skipped_high_confidence: int
     errors: list[str]
+
+
+@dataclass
+class _RunCounts:
+    """Mutable counters threaded through the per-file dispatch.
+
+    Pulled out of :func:`run_classify` so the loop body can update
+    counts without inflating that function's cyclomatic complexity.
+    """
+
+    total: int = 0
+    classified: int = 0
+    preserved: int = 0
+    skipped: int = 0
+    errors: list[str] = field(default_factory=list)
 
 
 def run_classify(
@@ -83,63 +105,97 @@ def run_classify(
 
     rules = RuleClassifier()
     llm = LLMClassifier(config=config.llm) if method == "llm" else None
-
-    total = 0
-    classified = 0
-    preserved = 0
-    skipped = 0
-    errors: list[str] = []
+    counts = _RunCounts()
 
     for md_file in sorted(fragments_root.rglob("*.md")):
-        total += 1
-        try:
-            record = _read_fragment(md_file)
-        except (OSError, ValueError, yaml.YAMLError) as exc:
-            errors.append(f"unreadable fragment {md_file}: {exc}")
-            continue
-        if record is None:
-            # File parsed cleanly but is not a Creek fragment (no
-            # ``type: fragment`` field, or schema mismatch). Silently
-            # skip — markdown notes coexist with fragments in the vault.
-            continue
-        fragment, body, raw = record
-
-        if not force and raw.get(CLASSIFICATION_METHOD_KEY) == MANUAL_METHOD:
-            preserved += 1
-            continue
-
-        new_fragment, was_skipped = _classify_one(
-            fragment=fragment,
-            body=body,
+        _process_file(
+            md_file=md_file,
             method=method,
+            force=force,
             rules=rules,
             llm=llm,
             confidence_threshold=config.classification.confidence_threshold,
+            counts=counts,
         )
-        if was_skipped:
-            skipped += 1
-            continue
-
-        try:
-            _write_fragment(
-                md_file=md_file,
-                fragment=new_fragment,
-                body=body,
-                method=method,
-                raw=raw,
-            )
-        except OSError as exc:
-            errors.append(f"failed to update {md_file}: {exc}")
-            continue
-        classified += 1
 
     return ClassifySummary(
-        total=total,
-        classified=classified,
-        preserved_manual=preserved,
-        skipped_high_confidence=skipped,
-        errors=errors,
+        total=counts.total,
+        classified=counts.classified,
+        preserved_manual=counts.preserved,
+        skipped_high_confidence=counts.skipped,
+        errors=counts.errors,
     )
+
+
+def _process_file(
+    *,
+    md_file: Path,
+    method: str,
+    force: bool,
+    rules: RuleClassifier,
+    llm: LLMClassifier | None,
+    confidence_threshold: float,
+    counts: _RunCounts,
+) -> None:
+    """Classify a single fragment file and update ``counts`` in place.
+
+    Args:
+        md_file: The file to consider.
+        method: ``"rules"`` or ``"llm"``.
+        force: Whether to overwrite manual classifications.
+        rules: Shared :class:`RuleClassifier` instance.
+        llm: Shared :class:`LLMClassifier` (when ``method == "llm"``).
+        confidence_threshold: Threshold below which the LLM is invoked.
+        counts: Mutable per-run counters; mutated in place.
+    """
+    try:
+        record = _read_fragment(md_file)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        counts.errors.append(f"unreadable fragment {md_file}: {exc}")
+        return
+    if record is None:
+        # File parsed cleanly but is not a Creek fragment (no
+        # ``type: fragment`` field, or schema mismatch). Silently skip —
+        # markdown notes coexist with fragments in the vault, and it
+        # would be misleading to count them in ``total``.
+        return
+    # Only count files we actually identify as Creek fragments.
+    counts.total += 1
+    fragment, body, raw = record
+
+    if not force and raw.get(CLASSIFICATION_METHOD_KEY) == MANUAL_METHOD:
+        counts.preserved += 1
+        return
+
+    new_fragment, was_skipped = _classify_one(
+        fragment=fragment,
+        body=body,
+        method=method,
+        rules=rules,
+        llm=llm,
+        confidence_threshold=confidence_threshold,
+    )
+    # When ``--method llm`` short-circuits because the rule classifier
+    # already produced a confident answer, the provenance stamp must
+    # reflect what actually classified the fragment ("rules"), not
+    # the user's CLI choice ("llm"). Either way the fragment IS
+    # persisted — we never skip the write, only the LLM call.
+    write_method = RULES_METHOD if was_skipped else method
+
+    try:
+        _write_fragment(
+            md_file=md_file,
+            fragment=new_fragment,
+            body=body,
+            method=write_method,
+            raw=raw,
+        )
+    except OSError as exc:
+        counts.errors.append(f"failed to update {md_file}: {exc}")
+        return
+    counts.classified += 1
+    if was_skipped:
+        counts.skipped += 1
 
 
 def _classify_one(

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -1,0 +1,240 @@
+"""Vault-driven classification engine for the ``creek classify`` command.
+
+Loads every fragment from ``<vault>/01-Fragments/``, dispatches to the
+configured classifier (rules or LLM), and rewrites each fragment file
+in place with the updated frontmatter. Records the chosen ``method``
+and ``classified_at`` timestamp on each fragment so that subsequent
+``creek classify`` runs can preserve manual decisions.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path  # noqa: TC003 — runtime use in dataclass field
+from typing import TYPE_CHECKING, Final
+
+import frontmatter
+import yaml
+from pydantic import ValidationError
+
+from creek.classify.llm import LLMClassifier
+from creek.classify.rules import RuleClassifier
+from creek.ingest.base import LA_TZ
+from creek.models import Fragment, Frequency
+
+if TYPE_CHECKING:
+    from creek.config import CreekConfig
+
+logger = logging.getLogger(__name__)
+
+_CLASSIFICATION_METHOD_KEY: Final[str] = "classification_method"
+"""Frontmatter key carrying ``rules | llm | manual``."""
+
+_CLASSIFIED_AT_KEY: Final[str] = "classified_at"
+"""Frontmatter key carrying the ISO-8601 classification timestamp."""
+
+_MANUAL_METHOD: Final[str] = "manual"
+
+
+@dataclass(frozen=True)
+class ClassifySummary:
+    """Counts produced by a single ``creek classify`` run.
+
+    Attributes:
+        total: Total fragment files visited.
+        classified: Fragments whose frontmatter was updated.
+        preserved_manual: Fragments left unchanged because the operator
+            previously stamped them ``method: manual`` and ``--force``
+            was not passed.
+        skipped_high_confidence: Fragments the LLM was not asked about
+            because the rules classifier already produced a confident
+            answer.
+        errors: Human-readable error messages (one per failure).
+    """
+
+    total: int
+    classified: int
+    preserved_manual: int
+    skipped_high_confidence: int
+    errors: list[str]
+
+
+def run_classify(
+    *,
+    vault_path: Path,
+    config: CreekConfig,
+    method: str,
+    batch_size: int,
+    force: bool,
+) -> ClassifySummary:
+    """Classify every fragment in *vault_path* using the chosen method.
+
+    Args:
+        vault_path: Vault root.
+        config: Loaded Creek configuration.
+        method: ``"rules"`` or ``"llm"``.
+        batch_size: Reserved; the current LLM classifier processes
+            fragments individually because the per-vault scan is
+            already streaming.
+        force: When ``True``, overwrite ``classification_method:
+            manual`` decisions.
+
+    Returns:
+        A :class:`ClassifySummary` reporting per-method counts.
+    """
+    fragments_root = vault_path / "01-Fragments"
+    if not fragments_root.exists():
+        return ClassifySummary(0, 0, 0, 0, [])
+
+    rules = RuleClassifier()
+    llm = LLMClassifier(config=config.llm) if method == "llm" else None
+
+    total = 0
+    classified = 0
+    preserved = 0
+    skipped = 0
+    errors: list[str] = []
+
+    for md_file in sorted(fragments_root.rglob("*.md")):
+        total += 1
+        record = _read_fragment(md_file)
+        if record is None:
+            errors.append(f"unreadable fragment: {md_file}")
+            continue
+        fragment, body, raw = record
+
+        if not force and raw.get(_CLASSIFICATION_METHOD_KEY) == _MANUAL_METHOD:
+            preserved += 1
+            continue
+
+        new_fragment, was_skipped = _classify_one(
+            fragment=fragment,
+            body=body,
+            method=method,
+            rules=rules,
+            llm=llm,
+            confidence_threshold=config.classification.confidence_threshold,
+        )
+        if was_skipped:
+            skipped += 1
+            continue
+
+        try:
+            _write_fragment(
+                md_file=md_file,
+                fragment=new_fragment,
+                body=body,
+                method=method,
+                raw=raw,
+            )
+        except OSError as exc:
+            errors.append(f"failed to update {md_file}: {exc}")
+            continue
+        classified += 1
+
+    return ClassifySummary(
+        total=total,
+        classified=classified,
+        preserved_manual=preserved,
+        skipped_high_confidence=skipped,
+        errors=errors,
+    )
+
+
+def _classify_one(
+    *,
+    fragment: Fragment,
+    body: str,
+    method: str,
+    rules: RuleClassifier,
+    llm: LLMClassifier | None,
+    confidence_threshold: float,
+) -> tuple[Fragment, bool]:
+    """Run the chosen classifier on a single fragment.
+
+    Args:
+        fragment: Fragment to classify.
+        body: Markdown body for keyword scoring.
+        method: ``"rules"`` or ``"llm"``.
+        rules: Shared :class:`RuleClassifier` instance.
+        llm: :class:`LLMClassifier` instance when ``method == "llm"``.
+        confidence_threshold: Threshold below which the LLM is invoked
+            during ``--method llm`` runs.
+
+    Returns:
+        Tuple of ``(updated_fragment, skipped)``. ``skipped`` is
+        ``True`` when the LLM was not invoked because the rule
+        classifier already produced a confident answer.
+    """
+    if method == "rules":
+        return rules.classify(fragment, content=body), False
+
+    rule_result = rules.classify(fragment, content=body)
+    if rule_result.frequency.primary != Frequency.UNCLASSIFIED:
+        confidence = rules.confidence_score(rule_result, content=body)
+        if confidence >= confidence_threshold:
+            return rule_result, True
+
+    if llm is None:  # pragma: no cover — guarded by ``method == "llm"``
+        msg = "LLM classifier required when method='llm'"
+        raise RuntimeError(msg)
+    return llm.classify(rule_result, content=body), False
+
+
+def _read_fragment(md_file: Path) -> tuple[Fragment, str, dict[str, object]] | None:
+    """Load a fragment file's metadata, body, and raw frontmatter dict.
+
+    Args:
+        md_file: Markdown file to load.
+
+    Returns:
+        ``(fragment, body, raw_metadata)`` or ``None`` when the file is
+        not a valid fragment record.
+    """
+    try:
+        post = frontmatter.load(str(md_file))
+    except (OSError, ValueError, yaml.YAMLError):
+        logger.debug("Skipping unreadable markdown file: %s", md_file)
+        return None
+    metadata = dict(post.metadata)
+    if metadata.get("type") != "fragment":
+        return None
+    try:
+        fragment = Fragment.model_validate(metadata)
+    except ValidationError:
+        logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
+        return None
+    return fragment, str(post.content), metadata
+
+
+def _write_fragment(
+    *,
+    md_file: Path,
+    fragment: Fragment,
+    body: str,
+    method: str,
+    raw: dict[str, object],
+) -> None:
+    """Persist updated fragment metadata back to its file.
+
+    Preserves the existing classification provenance keys so that
+    ``classified_at`` reflects the most recent update and the prior
+    ``method`` is replaced.
+
+    Args:
+        md_file: Destination file (rewritten in place).
+        fragment: Updated fragment metadata.
+        body: Markdown body to retain below the frontmatter.
+        method: ``"rules"``, ``"llm"``, or ``"manual"``.
+        raw: Original frontmatter dict — used to preserve any
+            non-Fragment keys (e.g. operator-applied tags).
+    """
+    new_metadata = dict(raw)
+    new_metadata.update(fragment.model_dump(mode="json"))
+    new_metadata[_CLASSIFICATION_METHOD_KEY] = method
+    new_metadata[_CLASSIFIED_AT_KEY] = datetime.now(tz=LA_TZ).isoformat()
+
+    post = frontmatter.Post(content=body, **new_metadata)
+    md_file.write_text(frontmatter.dumps(post), encoding="utf-8")

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -40,6 +40,11 @@ logger = logging.getLogger(__name__)
 class ClassifySummary:
     """Counts produced by a single ``creek classify`` run.
 
+    The dataclass is genuinely immutable: ``errors`` is a tuple, not a
+    list, so ``frozen=True`` actually prevents mutation. Callers that
+    want to mutate the per-run state should work with the private
+    :class:`_RunCounts` accumulator instead.
+
     Attributes:
         total: Number of Creek fragments visited (non-fragment markdown
             files in ``01-Fragments`` are silently skipped and not
@@ -62,7 +67,7 @@ class ClassifySummary:
     classified: int
     preserved_manual: int
     skipped_high_confidence: int
-    errors: list[str]
+    errors: tuple[str, ...]
 
 
 @dataclass
@@ -101,7 +106,7 @@ def run_classify(
     """
     fragments_root = vault_path / "01-Fragments"
     if not fragments_root.exists():
-        return ClassifySummary(0, 0, 0, 0, [])
+        return ClassifySummary(0, 0, 0, 0, ())
 
     rules = RuleClassifier()
     llm = LLMClassifier(config=config.llm) if method == "llm" else None
@@ -123,7 +128,10 @@ def run_classify(
         classified=counts.classified,
         preserved_manual=counts.preserved,
         skipped_high_confidence=counts.skipped,
-        errors=counts.errors,
+        # Snapshot-by-tuple so the frozen dataclass is genuinely
+        # immutable: the caller can't accidentally append to the
+        # underlying list and reach into completed-run state.
+        errors=tuple(counts.errors),
     )
 
 

--- a/creek-tools/creek/classify/constants.py
+++ b/creek-tools/creek/classify/constants.py
@@ -1,0 +1,29 @@
+"""Shared frontmatter keys for fragment classification provenance.
+
+These string literals live on every fragment's YAML frontmatter and are
+read or written by the classification engine, the review-queue runner,
+and any future consumer that needs to know how a fragment's
+classification was last produced. Keeping them in a single module
+prevents the keys from drifting apart silently — a rename in one
+writer that the other writer (or any reader) doesn't pick up would
+make manual decisions silently re-enter the review queue.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+CLASSIFICATION_METHOD_KEY: Final[str] = "classification_method"
+"""Frontmatter key carrying ``rules | llm | manual``."""
+
+CLASSIFIED_AT_KEY: Final[str] = "classified_at"
+"""Frontmatter key carrying the ISO-8601 classification timestamp."""
+
+MANUAL_METHOD: Final[str] = "manual"
+"""Sentinel ``classification_method`` value reserved for human review."""
+
+RULES_METHOD: Final[str] = "rules"
+"""``classification_method`` value emitted by the rule classifier."""
+
+LLM_METHOD: Final[str] = "llm"
+"""``classification_method`` value emitted by the LLM classifier."""

--- a/creek-tools/creek/classify/review_runner.py
+++ b/creek-tools/creek/classify/review_runner.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import datetime
-from pathlib import Path  # noqa: TC003 — runtime use in dataclass field
+from pathlib import Path  # noqa: TC003  # no issue: runtime dataclass field
 from typing import TYPE_CHECKING
 
 import frontmatter

--- a/creek-tools/creek/classify/review_runner.py
+++ b/creek-tools/creek/classify/review_runner.py
@@ -1,0 +1,251 @@
+"""Interactive review queue runner for the ``creek review`` command.
+
+Walks the vault for fragments that need human review (per
+:class:`ReviewQueueGenerator.needs_review`), prompts for an
+``accept / override / defer / quit`` decision, and writes the
+operator's choice back to the fragment file as
+``classification_method: manual`` plus an ``classified_at`` timestamp.
+
+A subsequent ``creek classify`` pass preserves manual decisions unless
+``--force`` is supplied.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path  # noqa: TC003 — runtime use in dataclass field
+from typing import TYPE_CHECKING, Final
+
+import frontmatter
+import typer
+import yaml
+from pydantic import ValidationError
+
+from creek.classify.review import ReviewQueueGenerator
+from creek.ingest.base import LA_TZ
+from creek.models import Fragment, Frequency, FrequencyClassification
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+logger = logging.getLogger(__name__)
+
+_CLASSIFICATION_METHOD_KEY: Final[str] = "classification_method"
+_CLASSIFIED_AT_KEY: Final[str] = "classified_at"
+
+
+@dataclass(frozen=True)
+class ReviewEntry:
+    """A single fragment surfaced for human review.
+
+    Attributes:
+        path: Path of the fragment file.
+        fragment: Parsed :class:`Fragment` metadata.
+        body: Markdown body retained when rewriting the file.
+        raw_metadata: Original frontmatter dict (any non-Fragment keys
+            are preserved on rewrite).
+    """
+
+    path: Path
+    fragment: Fragment
+    body: str
+    raw_metadata: dict[str, object]
+
+
+@dataclass
+class ReviewSummary:
+    """Counts produced by an interactive review session.
+
+    Attributes:
+        accepted: Fragments accepted as-is and stamped manual.
+        overridden: Fragments whose primary frequency was overridden.
+        deferred: Fragments left unchanged for a later session.
+    """
+
+    accepted: int = 0
+    overridden: int = 0
+    deferred: int = 0
+
+
+def format_review_summary(entry: ReviewEntry) -> str:
+    """Render a one-line summary for a queue entry.
+
+    Args:
+        entry: Queue entry to render.
+
+    Returns:
+        Human-readable summary line.
+    """
+    fragment = entry.fragment
+    return (
+        f"- {fragment.title} ({fragment.id}) "
+        f"freq={fragment.frequency.primary} phase={fragment.wavelength.phase}"
+    )
+
+
+class ReviewQueueRunner:
+    """Walk pending fragments and persist operator decisions.
+
+    Args:
+        vault_path: Vault root.
+        console: Rich console used for prompts and status output.
+    """
+
+    def __init__(self, vault_path: Path, console: Console) -> None:
+        """Initialise the runner.
+
+        Args:
+            vault_path: Vault root.
+            console: Rich console sink.
+        """
+        self.vault_path = vault_path
+        self.console = console
+        self._generator = ReviewQueueGenerator()
+
+    def list_pending(self) -> list[ReviewEntry]:
+        """Return every fragment that currently needs review.
+
+        Already-resolved fragments (``classification_method: manual``)
+        are excluded so the queue empties as the operator works.
+
+        Returns:
+            List of pending :class:`ReviewEntry` records.
+        """
+        fragments_root = self.vault_path / "01-Fragments"
+        if not fragments_root.exists():
+            return []
+
+        entries: list[ReviewEntry] = []
+        for md_file in sorted(fragments_root.rglob("*.md")):
+            entry = _read_entry(md_file)
+            if entry is None:
+                continue
+            if entry.raw_metadata.get(_CLASSIFICATION_METHOD_KEY) == "manual":
+                continue
+            if not self._generator.needs_review(entry.fragment):
+                continue
+            entries.append(entry)
+        return entries
+
+    def run_interactive(self, entries: list[ReviewEntry]) -> ReviewSummary:
+        """Prompt the operator for a decision on each entry.
+
+        Args:
+            entries: Pending entries from :meth:`list_pending`.
+
+        Returns:
+            A :class:`ReviewSummary` with per-decision counts.
+        """
+        summary = ReviewSummary()
+        for index, entry in enumerate(entries, start=1):
+            self.console.print(
+                f"\n[bold]({index}/{len(entries)})[/bold] "
+                f"{format_review_summary(entry)}",
+            )
+            choice = (
+                typer.prompt(
+                    "[a]ccept / [o]verride / [d]efer / [q]uit",
+                    default="d",
+                )
+                .strip()
+                .lower()
+            )
+
+            if choice == "q":
+                self.console.print("[yellow]Exiting review.[/yellow]")
+                break
+            if choice == "a":
+                _persist_manual(entry, entry.fragment)
+                summary.accepted += 1
+            elif choice == "o":
+                new_fragment = _override_frequency(entry, self.console)
+                if new_fragment is None:
+                    summary.deferred += 1
+                    continue
+                _persist_manual(entry, new_fragment)
+                summary.overridden += 1
+            else:
+                summary.deferred += 1
+        return summary
+
+
+def _override_frequency(
+    entry: ReviewEntry,
+    console: Console,
+) -> Fragment | None:
+    """Prompt for a new primary frequency and return an updated fragment.
+
+    Args:
+        entry: Entry being overridden.
+        console: Rich console sink.
+
+    Returns:
+        The updated fragment, or ``None`` when the operator's input
+        does not match a known frequency.
+    """
+    response = typer.prompt(
+        "New primary frequency (F1..F10 / unclassified)",
+        default=str(entry.fragment.frequency.primary),
+    ).strip()
+    try:
+        primary = Frequency(response.upper() if response.startswith("f") else response)
+    except ValueError:
+        console.print(f"[red]Unknown frequency {response!r}; skipping.[/red]")
+        return None
+
+    return entry.fragment.model_copy(
+        update={
+            "frequency": FrequencyClassification(
+                primary=primary,
+                secondary=list(entry.fragment.frequency.secondary),
+            ),
+        },
+    )
+
+
+def _persist_manual(entry: ReviewEntry, fragment: Fragment) -> None:
+    """Write the operator's decision back to disk.
+
+    Args:
+        entry: Original entry (used for path and body).
+        fragment: Updated fragment metadata to persist.
+    """
+    metadata = dict(entry.raw_metadata)
+    metadata.update(fragment.model_dump(mode="json"))
+    metadata[_CLASSIFICATION_METHOD_KEY] = "manual"
+    metadata[_CLASSIFIED_AT_KEY] = datetime.now(tz=LA_TZ).isoformat()
+
+    post = frontmatter.Post(content=entry.body, **metadata)
+    entry.path.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+def _read_entry(md_file: Path) -> ReviewEntry | None:
+    """Load *md_file* into a :class:`ReviewEntry`, returning ``None`` on error.
+
+    Args:
+        md_file: Path to a fragment file.
+
+    Returns:
+        Parsed entry or ``None`` if the file is not a fragment.
+    """
+    try:
+        post = frontmatter.load(str(md_file))
+    except (OSError, ValueError, yaml.YAMLError):
+        logger.debug("Skipping unreadable markdown file: %s", md_file)
+        return None
+    metadata = dict(post.metadata)
+    if metadata.get("type") != "fragment":
+        return None
+    try:
+        fragment = Fragment.model_validate(metadata)
+    except ValidationError:
+        logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
+        return None
+    return ReviewEntry(
+        path=md_file,
+        fragment=fragment,
+        body=str(post.content),
+        raw_metadata=metadata,
+    )

--- a/creek-tools/creek/classify/review_runner.py
+++ b/creek-tools/creek/classify/review_runner.py
@@ -173,6 +173,27 @@ class ReviewQueueRunner:
         return summary
 
 
+def _parse_frequency_input(value: str) -> Frequency | None:
+    """Parse operator-typed frequency input case-insensitively.
+
+    Accepts ``F1``..``F10`` (any casing) plus ``unclassified`` (any
+    casing). Returns ``None`` for anything else so the caller can
+    print a helpful error and defer the entry instead of silently
+    falling through.
+
+    Args:
+        value: Raw response from the prompt.
+
+    Returns:
+        The matching :class:`Frequency` enum, or ``None`` on no match.
+    """
+    cleaned = value.strip().lower()
+    for member in Frequency:
+        if cleaned == member.value.lower():
+            return member
+    return None
+
+
 def _override_frequency(
     entry: ReviewEntry,
     console: Console,
@@ -191,9 +212,8 @@ def _override_frequency(
         "New primary frequency (F1..F10 / unclassified)",
         default=str(entry.fragment.frequency.primary),
     ).strip()
-    try:
-        primary = Frequency(response.upper() if response.startswith("f") else response)
-    except ValueError:
+    primary = _parse_frequency_input(response)
+    if primary is None:
         console.print(f"[red]Unknown frequency {response!r}; skipping.[/red]")
         return None
 

--- a/creek-tools/creek/classify/review_runner.py
+++ b/creek-tools/creek/classify/review_runner.py
@@ -13,7 +13,7 @@ A subsequent ``creek classify`` pass preserves manual decisions unless
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path  # noqa: TC003  # no issue: runtime dataclass field
 from typing import TYPE_CHECKING
@@ -64,11 +64,16 @@ class ReviewSummary:
         accepted: Fragments accepted as-is and stamped manual.
         overridden: Fragments whose primary frequency was overridden.
         deferred: Fragments left unchanged for a later session.
+        errors: Human-readable error messages collected when persisting
+            an operator's decision failed (e.g. disk full, permission
+            denied). The classify engine uses the same shape on
+            ``ClassifySummary.errors`` for symmetry.
     """
 
     accepted: int = 0
     overridden: int = 0
     deferred: int = 0
+    errors: list[str] = field(default_factory=list)
 
 
 def format_review_summary(entry: ReviewEntry) -> str:
@@ -159,18 +164,50 @@ class ReviewQueueRunner:
                 self.console.print("[yellow]Exiting review.[/yellow]")
                 break
             if choice == "a":
-                _persist_manual(entry, entry.fragment)
-                summary.accepted += 1
+                if self._save(entry, entry.fragment, summary):
+                    summary.accepted += 1
             elif choice == "o":
                 new_fragment = _override_frequency(entry, self.console)
                 if new_fragment is None:
                     summary.deferred += 1
                     continue
-                _persist_manual(entry, new_fragment)
-                summary.overridden += 1
+                if self._save(entry, new_fragment, summary):
+                    summary.overridden += 1
             else:
                 summary.deferred += 1
         return summary
+
+    def _save(
+        self,
+        entry: ReviewEntry,
+        fragment: Fragment,
+        summary: ReviewSummary,
+    ) -> bool:
+        """Persist an operator's decision, capturing any I/O failure.
+
+        Without this guard a disk-full or permission-denied error mid
+        ``creek review`` session would propagate as a raw traceback;
+        we instead record the failure on ``summary.errors`` and
+        surface it through the console so the operator can fix the
+        underlying problem and resume.
+
+        Args:
+            entry: The queue entry being persisted.
+            fragment: The updated fragment metadata to write.
+            summary: Mutable summary to record any error onto.
+
+        Returns:
+            ``True`` when the write succeeded; ``False`` when an
+            ``OSError`` was caught.
+        """
+        try:
+            _persist_manual(entry, fragment)
+        except OSError as exc:
+            message = f"failed to persist {entry.path}: {exc}"
+            summary.errors.append(message)
+            self.console.print(f"[red]{message}[/red]")
+            return False
+        return True
 
 
 def _parse_frequency_input(value: str) -> Frequency | None:

--- a/creek-tools/creek/classify/review_runner.py
+++ b/creek-tools/creek/classify/review_runner.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING
 import frontmatter
 import typer
 import yaml
-from pydantic import ValidationError
 
 from creek.classify.constants import (
     CLASSIFICATION_METHOD_KEY,
@@ -31,6 +30,7 @@ from creek.classify.constants import (
 from creek.classify.review import ReviewQueueGenerator
 from creek.ingest.base import LA_TZ
 from creek.models import Fragment, Frequency, FrequencyClassification
+from creek.vault.reader import try_load_fragment
 
 if TYPE_CHECKING:
     from rich.console import Console
@@ -283,6 +283,13 @@ def _persist_manual(entry: ReviewEntry, fragment: Fragment) -> None:
 def _read_entry(md_file: Path) -> ReviewEntry | None:
     """Load *md_file* into a :class:`ReviewEntry`, returning ``None`` on error.
 
+    Delegates the validation chain to
+    :func:`creek.vault.reader.try_load_fragment` so the engine,
+    review runner, and link engine share one definition of "is this
+    a Creek fragment?" — a future schema change to :class:`Fragment`
+    or rename of the ``type`` sentinel only needs to update the
+    shared helper.
+
     Args:
         md_file: Path to a fragment file.
 
@@ -290,21 +297,16 @@ def _read_entry(md_file: Path) -> ReviewEntry | None:
         Parsed entry or ``None`` if the file is not a fragment.
     """
     try:
-        post = frontmatter.load(str(md_file))
+        record = try_load_fragment(md_file)
     except (OSError, ValueError, yaml.YAMLError):
         logger.debug("Skipping unreadable markdown file: %s", md_file)
         return None
-    metadata = dict(post.metadata)
-    if metadata.get("type") != "fragment":
+    if record is None:
         return None
-    try:
-        fragment = Fragment.model_validate(metadata)
-    except ValidationError:
-        logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
-        return None
+    fragment, body, metadata = record
     return ReviewEntry(
         path=md_file,
         fragment=fragment,
-        body=str(post.content),
+        body=body,
         raw_metadata=metadata,
     )

--- a/creek-tools/creek/classify/review_runner.py
+++ b/creek-tools/creek/classify/review_runner.py
@@ -16,13 +16,18 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path  # noqa: TC003 — runtime use in dataclass field
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING
 
 import frontmatter
 import typer
 import yaml
 from pydantic import ValidationError
 
+from creek.classify.constants import (
+    CLASSIFICATION_METHOD_KEY,
+    CLASSIFIED_AT_KEY,
+    MANUAL_METHOD,
+)
 from creek.classify.review import ReviewQueueGenerator
 from creek.ingest.base import LA_TZ
 from creek.models import Fragment, Frequency, FrequencyClassification
@@ -31,9 +36,6 @@ if TYPE_CHECKING:
     from rich.console import Console
 
 logger = logging.getLogger(__name__)
-
-_CLASSIFICATION_METHOD_KEY: Final[str] = "classification_method"
-_CLASSIFIED_AT_KEY: Final[str] = "classified_at"
 
 
 @dataclass(frozen=True)
@@ -122,7 +124,7 @@ class ReviewQueueRunner:
             entry = _read_entry(md_file)
             if entry is None:
                 continue
-            if entry.raw_metadata.get(_CLASSIFICATION_METHOD_KEY) == "manual":
+            if entry.raw_metadata.get(CLASSIFICATION_METHOD_KEY) == MANUAL_METHOD:
                 continue
             if not self._generator.needs_review(entry.fragment):
                 continue
@@ -214,8 +216,8 @@ def _persist_manual(entry: ReviewEntry, fragment: Fragment) -> None:
     """
     metadata = dict(entry.raw_metadata)
     metadata.update(fragment.model_dump(mode="json"))
-    metadata[_CLASSIFICATION_METHOD_KEY] = "manual"
-    metadata[_CLASSIFIED_AT_KEY] = datetime.now(tz=LA_TZ).isoformat()
+    metadata[CLASSIFICATION_METHOD_KEY] = MANUAL_METHOD
+    metadata[CLASSIFIED_AT_KEY] = datetime.now(tz=LA_TZ).isoformat()
 
     post = frontmatter.Post(content=entry.body, **metadata)
     entry.path.write_text(frontmatter.dumps(post), encoding="utf-8")

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -720,6 +720,10 @@ def review(
         f"[bold green]Review complete: {summary.accepted} accepted, "
         f"{summary.overridden} overridden, {summary.deferred} deferred.[/bold green]",
     )
+    if summary.errors:
+        console.print(f"[yellow]Errors: {len(summary.errors)}[/yellow]")
+        for err in summary.errors:
+            console.print(f"  [dim]{err}[/dim]")
 
 
 @app.command()

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -538,6 +538,10 @@ def classify(
         f"({summary.preserved_manual} manual preserved, "
         f"{summary.skipped_high_confidence} skipped).[/bold green]",
     )
+    if summary.errors:
+        console.print(f"[yellow]Errors: {len(summary.errors)}[/yellow]")
+        for err in summary.errors:
+            console.print(f"  [dim]{err}[/dim]")
 
 
 @app.command()

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import os
+import re
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -15,7 +17,6 @@ from creek.consent import ConsentManager
 from creek.pipeline import Pipeline, RedactionRequiredError
 
 if TYPE_CHECKING:
-    from creek.config import CreekConfig
     from creek.generate.drafts import DraftLLM
     from creek.ingest.base import Ingestor
     from creek.models import Phase
@@ -44,15 +45,37 @@ def _consent_log_dir(vault_path: Path) -> Path:
     return vault_path / "00-Creek-Meta" / "Processing-Log"
 
 
-def _operator_identity() -> str:
-    """Return a best-effort identity string for the current operator.
+_OPERATOR_IDENTITY_MAX_LEN = 64
+"""Cap on the operator identity recorded in the consent log.
 
-    Falls back to ``"cli"`` when the environment provides nothing.
+Adversaries with control of ``USER``/``USERNAME`` (e.g. a misconfigured
+CI runner) could otherwise inject arbitrary text into the audit
+record. Truncating to a reasonable length and filtering to a safe
+character set bounds the blast radius without preventing legitimate
+unicode usernames.
+"""
+
+_OPERATOR_IDENTITY_ALLOWED_CHARS = re.compile(r"[^\w.@+\- ]")
+"""Characters stripped from the raw env-var value before logging."""
+
+
+def _operator_identity() -> str:
+    """Return a best-effort, sanitised identity string for the operator.
+
+    Reads ``USER`` then ``USERNAME`` from the environment, strips
+    control characters and metacharacters that have no place in an
+    audit log entry, truncates to
+    :data:`_OPERATOR_IDENTITY_MAX_LEN` characters, and falls back to
+    ``"cli"`` when the result is empty.
 
     Returns:
         Identity string suitable for stamping on a consent record.
     """
-    return os.environ.get("USER") or os.environ.get("USERNAME") or "cli"
+    raw = os.environ.get("USER") or os.environ.get("USERNAME") or ""
+    cleaned = _OPERATOR_IDENTITY_ALLOWED_CHARS.sub("", raw).strip()
+    if not cleaned:
+        return "cli"
+    return cleaned[:_OPERATOR_IDENTITY_MAX_LEN]
 
 
 def _format_summary(file_count: int, size_bytes: int) -> str:
@@ -71,7 +94,6 @@ def _format_summary(file_count: int, size_bytes: int) -> str:
 
 def _gate_consent(
     *,
-    config: CreekConfig,
     source_path: Path,
     vault_path: Path,
     source_type: str,
@@ -86,8 +108,6 @@ def _gate_consent(
     operator marker so it can be audited later.
 
     Args:
-        config: Loaded Creek config (currently unused, reserved for
-            future per-source consent policy hooks).
         source_path: Source directory the operator wants to ingest.
         vault_path: Vault path used to locate the consent log.
         source_type: Source identifier for the consent record (e.g.
@@ -167,8 +187,6 @@ def _is_interactive() -> bool:
     Returns:
         ``True`` when stdin is a terminal.
     """
-    import sys
-
     try:
         return bool(sys.stdin.isatty())
     except (AttributeError, ValueError):
@@ -285,7 +303,6 @@ def process(
     )
 
     consent_manager = _gate_consent(
-        config=config,
         source_path=source_path,
         vault_path=vault_path,
         source_type="pipeline",
@@ -345,7 +362,6 @@ def ingest(
         raise typer.Exit(code=2)
 
     _gate_consent(
-        config=config,
         source_path=input,
         vault_path=vault_path,
         source_type=type,
@@ -480,7 +496,6 @@ _LINK_METHODS = ("embeddings", "temporal", "eddies")
 def classify(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
     method: str = typer.Option("rules", help="Classification method (rules|llm)"),
-    batch_size: int = typer.Option(50, help="Batch size for LLM classification"),
     force: bool = typer.Option(
         False,
         "--force",
@@ -495,6 +510,9 @@ def classify(
     ``classification.confidence_threshold``. Fragments with
     ``classification.method: manual`` are preserved unless ``--force``
     is supplied.
+
+    LLM concurrency is governed by ``llm.max_concurrent`` in the
+    config, not a CLI flag.
     """
     if method not in _CLASSIFY_METHODS:
         console.print(
@@ -512,7 +530,6 @@ def classify(
         vault_path=vault_path,
         config=config,
         method=method,
-        batch_size=batch_size,
         force=force,
     )
     console.print(

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1,5 +1,8 @@
 """Creek CLI -- command-line interface for the Creek knowledge organization pipeline."""
 
+from __future__ import annotations
+
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -8,10 +11,13 @@ from rich.console import Console
 from rich.table import Table
 
 from creek.config import load_config
-from creek.pipeline import Pipeline
+from creek.consent import ConsentManager
+from creek.pipeline import Pipeline, RedactionRequiredError
 
 if TYPE_CHECKING:
+    from creek.config import CreekConfig
     from creek.generate.drafts import DraftLLM
+    from creek.ingest.base import Ingestor
     from creek.models import Phase
     from creek.purge import PurgeEngine, PurgeResult
 
@@ -26,12 +32,249 @@ app.add_typer(purge_app, name="purge")
 console = Console()
 
 
+def _consent_log_dir(vault_path: Path) -> Path:
+    """Resolve the canonical consent log directory beneath a vault.
+
+    Args:
+        vault_path: Vault root.
+
+    Returns:
+        Path to ``<vault>/00-Creek-Meta/Processing-Log``.
+    """
+    return vault_path / "00-Creek-Meta" / "Processing-Log"
+
+
+def _operator_identity() -> str:
+    """Return a best-effort identity string for the current operator.
+
+    Falls back to ``"cli"`` when the environment provides nothing.
+
+    Returns:
+        Identity string suitable for stamping on a consent record.
+    """
+    return os.environ.get("USER") or os.environ.get("USERNAME") or "cli"
+
+
+def _format_summary(file_count: int, size_bytes: int) -> str:
+    """Render a human-readable size summary for the consent prompt.
+
+    Args:
+        file_count: Number of files in the source.
+        size_bytes: Aggregate size of those files in bytes.
+
+    Returns:
+        A short ``"<N> files, <X> MB"`` style description.
+    """
+    mb = size_bytes / (1024 * 1024)
+    return f"{file_count} file(s), {mb:.1f} MB"
+
+
+def _gate_consent(
+    *,
+    config: CreekConfig,
+    source_path: Path,
+    vault_path: Path,
+    source_type: str,
+    assume_yes: bool,
+) -> ConsentManager:
+    """Prompt for, or auto-grant, consent for processing *source_path*.
+
+    Returns a :class:`ConsentManager` that the pipeline can consult.
+    First-time sources display a short summary and require explicit
+    confirmation. Non-interactive callers must pass ``--yes``; the
+    bypass is recorded as a consent grant with an ``assume_yes``
+    operator marker so it can be audited later.
+
+    Args:
+        config: Loaded Creek config (currently unused, reserved for
+            future per-source consent policy hooks).
+        source_path: Source directory the operator wants to ingest.
+        vault_path: Vault path used to locate the consent log.
+        source_type: Source identifier for the consent record (e.g.
+            ``"pipeline"``, ``"markdown"``).
+        assume_yes: When ``True``, skip the interactive prompt.
+
+    Returns:
+        A :class:`ConsentManager` rooted at the vault's processing log.
+
+    Raises:
+        typer.Exit: With code ``1`` when the operator declines, or
+            when consent has not been recorded and the caller is
+            non-interactive without ``--yes``.
+    """
+    log_dir = _consent_log_dir(vault_path)
+    manager = ConsentManager(log_dir=log_dir)
+
+    if manager.check_consent(source_type, str(source_path)):
+        return manager
+
+    if not source_path.exists():
+        console.print(f"[red]Source path not found: {source_path}[/red]")
+        raise typer.Exit(code=2)
+
+    summary = manager.get_source_summary(source_path, exclusions=[])
+    console.print(f"[bold]First time processing {source_path}.[/bold]")
+    console.print(
+        f"Found: {_format_summary(summary.file_count, summary.total_size_bytes)}."
+    )
+    if summary.sample_filenames:
+        sample = ", ".join(summary.sample_filenames[:5])
+        console.print(f"Sample: {sample}")
+
+    if assume_yes:
+        manager.record_consent(
+            source_type=source_type,
+            source_path=str(source_path),
+            file_count=summary.file_count,
+            exclusions=[],
+            operator=f"{_operator_identity()} (assume_yes)",
+        )
+        console.print(
+            "[yellow]Consent auto-granted via --yes; recorded in consent log.[/yellow]",
+        )
+        return manager
+
+    if not _is_interactive():
+        console.print(
+            "[red]Non-interactive shell and consent not on file. "
+            "Re-run with --yes or run interactively to record consent.[/red]",
+        )
+        raise typer.Exit(code=1)
+
+    if not typer.confirm("Proceed?", default=False):
+        console.print("[yellow]Consent declined; aborting.[/yellow]")
+        raise typer.Exit(code=1)
+
+    manager.record_consent(
+        source_type=source_type,
+        source_path=str(source_path),
+        file_count=summary.file_count,
+        exclusions=[],
+        operator=_operator_identity(),
+    )
+    console.print("[green]Consent recorded.[/green]")
+    return manager
+
+
+def _is_interactive() -> bool:
+    """Return ``True`` when stdin appears to be attached to a TTY.
+
+    The CliRunner used in tests reports stdin as a non-TTY; tests
+    therefore use ``--yes`` or ``input=`` to drive prompts. Returning
+    ``False`` here prevents ``typer.confirm`` from looping forever in
+    pipeline-driven invocations.
+
+    Returns:
+        ``True`` when stdin is a terminal.
+    """
+    import sys
+
+    try:
+        return bool(sys.stdin.isatty())
+    except (AttributeError, ValueError):
+        return False
+
+
+def _resolve_ingestor(type_name: str) -> type[Ingestor]:
+    """Look up an ingestor class by registry key, exiting on miss.
+
+    Args:
+        type_name: Registry key (e.g. ``"markdown"``, ``"claude"``).
+
+    Returns:
+        The matching :class:`~creek.ingest.base.Ingestor` subclass.
+
+    Raises:
+        typer.Exit: With code ``2`` when *type_name* is unknown.
+    """
+    from creek.ingest import INGESTOR_REGISTRY
+
+    cls = INGESTOR_REGISTRY.get(type_name)
+    if cls is None:
+        known = ", ".join(sorted(INGESTOR_REGISTRY.keys()))
+        console.print(
+            f"[red]Unknown ingestor type {type_name!r}. Known types: {known}[/red]",
+        )
+        raise typer.Exit(code=2)
+    return cls
+
+
+def _run_ingest(
+    *,
+    ingestor_cls: type[Ingestor],
+    source_type: str,
+    input_path: Path,
+    vault_path: Path,
+) -> tuple[int, list[str]]:
+    """Run a single ingestor and persist its output to the vault.
+
+    Args:
+        ingestor_cls: Concrete :class:`Ingestor` subclass to run.
+        source_type: Registry key, used to prefix error messages.
+        input_path: Source directory or file to ingest.
+        vault_path: Vault root for :class:`VaultWriter`.
+
+    Returns:
+        Tuple of ``(written_count, errors)`` where ``errors`` is a list
+        of human-readable strings prefixed with ``[<source_type>]``.
+
+    Raises:
+        typer.Exit: With code ``1`` when the vault cannot be opened.
+    """
+    from creek.ingest.base import assemble_ingested_fragment
+    from creek.vault.writer import VaultWriter
+
+    try:
+        writer = VaultWriter(vault_path=vault_path)
+    except FileNotFoundError as exc:
+        console.print(f"[red]Vault unavailable: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+
+    ingestor = ingestor_cls()
+    ingest_result = ingestor.ingest(input_path)
+
+    errors: list[str] = [f"[{source_type}] {err}" for err in ingest_result.errors]
+    written = 0
+    for parsed in ingest_result.fragments:
+        try:
+            assembled = assemble_ingested_fragment(parsed)
+        except (KeyError, ValueError) as exc:
+            errors.append(
+                f"[{source_type}] failed to assemble fragment from "
+                f"{parsed.source_path}: {exc}",
+            )
+            continue
+        try:
+            writer.write_fragment(assembled.fragment, body=assembled.body)
+        except (OSError, KeyError) as exc:
+            errors.append(
+                f"[{source_type}] failed to write {assembled.fragment.id}: {exc}",
+            )
+            continue
+        written += 1
+
+    return written, errors
+
+
 @app.command()
 def process(
     source: Path | None = typer.Option(None, help="Source directory to process"),
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the consent prompt for first-time sources (logged).",
+    ),
 ) -> None:
-    """Full pipeline: ingest, redact, classify, link, index."""
+    """Run the full pipeline: redact, ingest, classify, link, index.
+
+    Aborts with a remediation hint if the redaction scanner finds
+    unresolved sensitive matches; run ``creek redact --apply`` first to
+    clear them. Per-source consent is enforced — first-time sources
+    prompt for confirmation before ingestion. Use ``--yes`` to skip the
+    prompt in non-interactive contexts (the bypass is logged).
+    """
     config = load_config()
     source_path = source or config.source_drive
     vault_path = vault or config.vault_path
@@ -41,8 +284,20 @@ def process(
         f"source={source_path}, vault={vault_path}[/bold green]"
     )
 
-    pipeline = Pipeline(config=config)
-    result = pipeline.run(source_path=source_path, vault_path=vault_path)
+    consent_manager = _gate_consent(
+        config=config,
+        source_path=source_path,
+        vault_path=vault_path,
+        source_type="pipeline",
+        assume_yes=yes,
+    )
+
+    pipeline = Pipeline(config=config, consent_manager=consent_manager)
+    try:
+        result = pipeline.run(source_path=source_path, vault_path=vault_path)
+    except RedactionRequiredError as exc:
+        console.print(f"[red]Redaction gate: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
 
     console.print(f"[bold]Files scanned:[/bold] {result.files_scanned}")
     console.print(f"[bold]Fragments created:[/bold] {result.fragments_created}")
@@ -58,15 +313,57 @@ def process(
 
 @app.command()
 def ingest(
-    type: str | None = typer.Option(None, help="Source type to ingest"),
-    input: Path | None = typer.Option(None, help="Input path"),
-    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    type: str | None = typer.Option(None, "--type", help="Source type to ingest"),
+    input: Path | None = typer.Option(None, "--input", help="Input path"),
+    vault: Path | None = typer.Option(None, "--vault", help="Obsidian vault path"),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the consent prompt for first-time sources (logged).",
+    ),
 ) -> None:
-    """Ingest a specific source type."""
-    console.print(
-        f"[bold green]Would ingest: "
-        f"type={type}, input={input}, vault={vault}[/bold green]"
+    """Ingest a specific source type into the vault.
+
+    Resolves ``--type`` against
+    :data:`creek.ingest.INGESTOR_REGISTRY`, runs the matching ingestor
+    against ``--input``, and writes each produced fragment via
+    :class:`~creek.vault.writer.VaultWriter`. Re-running against the same
+    input is idempotent: deterministic fragment IDs ensure existing
+    files are recognised and skipped.
+    """
+    if type is None or input is None:
+        console.print("[red]--type and --input are required.[/red]")
+        raise typer.Exit(code=2)
+
+    config = load_config()
+    vault_path = vault or config.vault_path
+    ingestor_cls = _resolve_ingestor(type)
+
+    if not input.exists():
+        console.print(f"[red]Input path not found: {input}[/red]")
+        raise typer.Exit(code=2)
+
+    _gate_consent(
+        config=config,
+        source_path=input,
+        vault_path=vault_path,
+        source_type=type,
+        assume_yes=yes,
     )
+
+    written, errors = _run_ingest(
+        ingestor_cls=ingestor_cls,
+        source_type=type,
+        input_path=input,
+        vault_path=vault_path,
+    )
+
+    console.print(f"[bold green]Ingested {written} fragment(s).[/bold green]")
+    if errors:
+        console.print(f"[yellow]Errors: {len(errors)}[/yellow]")
+        for err in errors:
+            console.print(f"  [dim]{err}[/dim]")
 
 
 def _dispatch_redact(
@@ -175,27 +472,100 @@ def redact(
     )
 
 
+_CLASSIFY_METHODS = ("rules", "llm")
+_LINK_METHODS = ("embeddings", "temporal", "eddies")
+
+
 @app.command()
 def classify(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
-    method: str = typer.Option("rules", help="Classification method"),
-    batch_size: int = typer.Option(50, help="Batch size for classification"),
+    method: str = typer.Option("rules", help="Classification method (rules|llm)"),
+    batch_size: int = typer.Option(50, help="Batch size for LLM classification"),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Overwrite fragments classified as method: manual.",
+    ),
 ) -> None:
-    """Run classification on vault fragments."""
+    """Run classification on existing vault fragments.
+
+    ``--method rules`` runs the keyword-based classifier locally.
+    ``--method llm`` calls the configured LLM provider for any
+    fragment the rules left unclassified or below
+    ``classification.confidence_threshold``. Fragments with
+    ``classification.method: manual`` are preserved unless ``--force``
+    is supplied.
+    """
+    if method not in _CLASSIFY_METHODS:
+        console.print(
+            f"[red]Unknown method {method!r}. "
+            f"Supported: {', '.join(_CLASSIFY_METHODS)}.[/red]",
+        )
+        raise typer.Exit(code=2)
+
+    config = load_config()
+    vault_path = _resolve_vault(vault)
+
+    from creek.classify.classify_engine import run_classify
+
+    summary = run_classify(
+        vault_path=vault_path,
+        config=config,
+        method=method,
+        batch_size=batch_size,
+        force=force,
+    )
     console.print(
-        f"[bold green]Would classify: vault={vault}, "
-        f"method={method}, batch_size={batch_size}[/bold green]"
+        f"[bold green]Classified {summary.classified} of "
+        f"{summary.total} fragment(s) "
+        f"({summary.preserved_manual} manual preserved, "
+        f"{summary.skipped_high_confidence} skipped).[/bold green]",
     )
 
 
 @app.command()
 def link(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
-    method: str = typer.Option("embeddings", help="Linking method"),
+    method: str = typer.Option(
+        "embeddings",
+        help="Linking method (embeddings|temporal|eddies)",
+    ),
+    rebuild: bool = typer.Option(
+        False,
+        "--rebuild",
+        help="Invalidate the embeddings cache and recompute from scratch.",
+    ),
 ) -> None:
-    """Run linking pass to connect fragments."""
+    """Run a single linker stage against the vault.
+
+    Loads every fragment from ``<vault>/01-Fragments/``, runs the chosen
+    linker, and writes the resulting links back to fragment frontmatter
+    (and any thread/eddy notes). ``--rebuild`` invalidates the cached
+    embeddings file before running ``--method embeddings`` so the
+    similarity matrix is recomputed from scratch.
+    """
+    if method not in _LINK_METHODS:
+        console.print(
+            f"[red]Unknown method {method!r}. "
+            f"Supported: {', '.join(_LINK_METHODS)}.[/red]",
+        )
+        raise typer.Exit(code=2)
+
+    config = load_config()
+    vault_path = _resolve_vault(vault)
+
+    from creek.link.link_engine import run_link
+
+    summary = run_link(
+        vault_path=vault_path,
+        config=config,
+        method=method,
+        rebuild=rebuild,
+    )
     console.print(
-        f"[bold green]Would link: vault={vault}, method={method}[/bold green]"
+        f"[bold green]{method.capitalize()} linker: "
+        f"{summary.fragment_count} fragment(s), "
+        f"{summary.link_count} link(s).[/bold green]",
     )
 
 
@@ -286,9 +656,49 @@ def report(
 @app.command()
 def review(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    list_only: bool = typer.Option(
+        False,
+        "--list",
+        help="Print pending review queue items and exit (non-interactive).",
+    ),
 ) -> None:
-    """Interactive review queue for fragments."""
-    console.print(f"[bold green]Would review: vault={vault}[/bold green]")
+    """Walk the review queue and persist accept/override/defer decisions.
+
+    Prints each fragment that needs review, then prompts for one of:
+
+    * ``a`` — accept the current classification (writes
+      ``classification.method: manual``).
+    * ``o`` — override; the operator types a new primary frequency.
+    * ``d`` — defer (skip without changes).
+    * ``q`` — quit.
+
+    Pass ``--list`` to dump the queue without prompting; useful in CI
+    or when scripting around the queue.
+    """
+    vault_path = _resolve_vault(vault)
+
+    from creek.classify.review_runner import (
+        ReviewQueueRunner,
+        format_review_summary,
+    )
+
+    runner = ReviewQueueRunner(vault_path=vault_path, console=console)
+    pending = runner.list_pending()
+
+    if not pending:
+        console.print("[green]Review queue is empty.[/green]")
+        return
+
+    if list_only:
+        for entry in pending:
+            console.print(format_review_summary(entry))
+        return
+
+    summary = runner.run_interactive(pending)
+    console.print(
+        f"[bold green]Review complete: {summary.accepted} accepted, "
+        f"{summary.overridden} overridden, {summary.deferred} deferred.[/bold green]",
+    )
 
 
 @app.command()
@@ -378,7 +788,7 @@ def skills(
     )
 
 
-def _parse_phase(phase: str) -> "Phase":
+def _parse_phase(phase: str) -> Phase:
     """Parse a phase CLI argument, exiting with code 2 on unknown values.
 
     Args:
@@ -458,7 +868,7 @@ def _read_voice_core(path: Path | None) -> str:
         raise typer.Exit(code=2) from exc
 
 
-def _build_draft_llm() -> "DraftLLM":
+def _build_draft_llm() -> DraftLLM:
     """Construct a :data:`DraftLLM` callable from the configured LLM provider.
 
     Uses the Ollama/Anthropic adapter already wired up for classification.
@@ -716,7 +1126,7 @@ def clean_report(
 # ---------------------------------------------------------------------------
 
 
-def _render_purge_result(result: "PurgeResult") -> None:
+def _render_purge_result(result: PurgeResult) -> None:
     """Render a purge result as a rich table.
 
     Args:
@@ -761,7 +1171,7 @@ def _build_engine(
     vault: Path | None,
     *,
     dry_run: bool,
-) -> "PurgeEngine":
+) -> PurgeEngine:
     """Construct a :class:`PurgeEngine` rooted at the resolved vault.
 
     Args:

--- a/creek-tools/creek/link/link_engine.py
+++ b/creek-tools/creek/link/link_engine.py
@@ -14,17 +14,14 @@ from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003  # no issue: runtime dataclass field
 from typing import TYPE_CHECKING, Final
 
-import frontmatter
-import yaml
-from pydantic import ValidationError
-
 from creek.link.eddies import EddyDetector
 from creek.link.embeddings import EmbeddingLinker
 from creek.link.temporal import TemporalLinker
-from creek.models import Fragment
+from creek.vault.reader import iter_vault_fragments
 
 if TYPE_CHECKING:
     from creek.config import CreekConfig
+    from creek.models import Fragment
 
 logger = logging.getLogger(__name__)
 
@@ -200,8 +197,12 @@ def _load_or_compute_embeddings(
 def _load_fragments(vault_path: Path) -> list[Fragment]:
     """Load every fragment file under ``<vault>/01-Fragments/``.
 
-    Files that fail to parse are logged and skipped; they should never
-    block a linking pass.
+    Delegates the per-file validation chain to
+    :func:`creek.vault.reader.iter_vault_fragments` so the link
+    engine, classify engine, and review runner share one definition
+    of "is this a Creek fragment?" Linking doesn't surface I/O
+    failures to the operator (yet) — they're skipped at DEBUG
+    level inside the helper, the same way they were before.
 
     Args:
         vault_path: Vault root.
@@ -209,23 +210,5 @@ def _load_fragments(vault_path: Path) -> list[Fragment]:
     Returns:
         Sorted list of :class:`Fragment` instances.
     """
-    fragments_root = vault_path / "01-Fragments"
-    if not fragments_root.exists():
-        return []
-
-    out: list[Fragment] = []
-    for md_file in sorted(fragments_root.rglob("*.md")):
-        try:
-            post = frontmatter.load(str(md_file))
-        except (OSError, ValueError, yaml.YAMLError):
-            logger.debug("Skipping unreadable markdown file: %s", md_file)
-            continue
-        metadata = dict(post.metadata)
-        if metadata.get("type") != "fragment":
-            continue
-        try:
-            out.append(Fragment.model_validate(metadata))
-        except ValidationError:
-            logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
-            continue
-    return out
+    records = iter_vault_fragments(vault_path / "01-Fragments")
+    return [fragment for _path, fragment, _body, _raw in records]

--- a/creek-tools/creek/link/link_engine.py
+++ b/creek-tools/creek/link/link_engine.py
@@ -1,0 +1,216 @@
+"""Vault-driven linking engine for the ``creek link`` command.
+
+Loads every fragment from ``<vault>/01-Fragments/``, dispatches to the
+chosen linker stage (embeddings, temporal, or eddies), and reports the
+resulting link count back to the CLI. Honours ``--rebuild`` by deleting
+the cached embeddings archive so the embedding linker recomputes from
+scratch.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path  # noqa: TC003 — runtime use in dataclass field
+from typing import TYPE_CHECKING, Final
+
+import frontmatter
+import yaml
+from pydantic import ValidationError
+
+from creek.link.eddies import EddyDetector
+from creek.link.embeddings import EmbeddingLinker
+from creek.link.temporal import TemporalLinker
+from creek.models import Fragment
+
+if TYPE_CHECKING:
+    from creek.config import CreekConfig
+
+logger = logging.getLogger(__name__)
+
+_EMBEDDINGS_CACHE_NAME: Final[str] = "embeddings.npz"
+"""Filename of the persisted embeddings archive within the vault."""
+
+_EMBEDDINGS_CACHE_DIR: Final[str] = "00-Creek-Meta"
+
+
+@dataclass(frozen=True)
+class LinkSummary:
+    """Counts produced by a single ``creek link`` run.
+
+    Attributes:
+        method: Linker that was run (``embeddings`` / ``temporal`` /
+            ``eddies``).
+        fragment_count: Number of fragments loaded from the vault.
+        link_count: Edges or clusters produced (resonances, temporal
+            links, or eddy clusters depending on ``method``).
+    """
+
+    method: str
+    fragment_count: int
+    link_count: int
+
+
+def run_link(
+    *,
+    vault_path: Path,
+    config: CreekConfig,
+    method: str,
+    rebuild: bool,
+) -> LinkSummary:
+    """Run a single linker stage against the vault.
+
+    Args:
+        vault_path: Vault root.
+        config: Loaded Creek configuration.
+        method: ``"embeddings"``, ``"temporal"``, or ``"eddies"``.
+        rebuild: When ``True`` and ``method == "embeddings"``, delete
+            the cached embeddings archive before recomputing.
+
+    Returns:
+        A :class:`LinkSummary` capturing per-method counts.
+    """
+    cache_path = vault_path / _EMBEDDINGS_CACHE_DIR / _EMBEDDINGS_CACHE_NAME
+    if rebuild and cache_path.exists():
+        cache_path.unlink()
+        logger.info("Removed cached embeddings archive at %s", cache_path)
+
+    fragments = _load_fragments(vault_path)
+
+    if not fragments:
+        return LinkSummary(method=method, fragment_count=0, link_count=0)
+
+    if method == "embeddings":
+        link_count = _run_embeddings(
+            fragments=fragments,
+            config=config,
+            cache_path=cache_path,
+            rebuild=rebuild,
+        )
+    elif method == "temporal":
+        temporal = TemporalLinker()
+        links = temporal.find_temporal_links(
+            fragments,
+            window_hours=config.linking.temporal_window_hours,
+        )
+        link_count = len(links)
+    else:
+        embeddings = _load_or_compute_embeddings(
+            fragments=fragments,
+            config=config,
+            cache_path=cache_path,
+            rebuild=False,
+        )
+        detector = EddyDetector(embeddings=embeddings)
+        eddies = detector.detect_eddies(
+            fragments,
+            min_fragments=config.linking.eddy_min_fragments,
+        )
+        link_count = len(eddies)
+
+    return LinkSummary(
+        method=method,
+        fragment_count=len(fragments),
+        link_count=link_count,
+    )
+
+
+def _run_embeddings(
+    *,
+    fragments: list[Fragment],
+    config: CreekConfig,
+    cache_path: Path,
+    rebuild: bool,
+) -> int:
+    """Compute embeddings, optionally re-using the on-disk cache.
+
+    Args:
+        fragments: Fragments to embed.
+        config: Loaded Creek configuration.
+        cache_path: Where to read/write the cached embeddings archive.
+        rebuild: When ``True``, ignore any cached archive.
+
+    Returns:
+        Number of resonance edges discovered.
+    """
+    embeddings = _load_or_compute_embeddings(
+        fragments=fragments,
+        config=config,
+        cache_path=cache_path,
+        rebuild=rebuild,
+    )
+
+    linker = EmbeddingLinker(config=config.embeddings)
+    resonances = linker.find_resonances(embeddings)
+    return len(resonances)
+
+
+def _load_or_compute_embeddings(
+    *,
+    fragments: list[Fragment],
+    config: CreekConfig,
+    cache_path: Path,
+    rebuild: bool,
+) -> dict[str, list[float]]:
+    """Return embeddings for *fragments*, hitting the cache when fresh.
+
+    Args:
+        fragments: Fragments to embed.
+        config: Loaded Creek configuration.
+        cache_path: Embedding archive path.
+        rebuild: When ``True``, ignore the cache and recompute.
+
+    Returns:
+        Mapping of fragment ID to embedding vector.
+    """
+    linker = EmbeddingLinker(config=config.embeddings)
+
+    if not rebuild and cache_path.exists():
+        try:
+            cached = linker.load_embeddings(cache_path)
+        except (OSError, ValueError):
+            logger.warning("Cached embeddings unreadable; recomputing")
+            cached = {}
+        existing_ids = {fragment.id for fragment in fragments} & cached.keys()
+        new = linker.generate_embeddings(fragments, existing_ids=existing_ids)
+        merged = {**cached, **new}
+    else:
+        merged = linker.generate_embeddings(fragments)
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    linker.save_embeddings(merged, cache_path)
+    return merged
+
+
+def _load_fragments(vault_path: Path) -> list[Fragment]:
+    """Load every fragment file under ``<vault>/01-Fragments/``.
+
+    Files that fail to parse are logged and skipped; they should never
+    block a linking pass.
+
+    Args:
+        vault_path: Vault root.
+
+    Returns:
+        Sorted list of :class:`Fragment` instances.
+    """
+    fragments_root = vault_path / "01-Fragments"
+    if not fragments_root.exists():
+        return []
+
+    out: list[Fragment] = []
+    for md_file in sorted(fragments_root.rglob("*.md")):
+        try:
+            post = frontmatter.load(str(md_file))
+        except (OSError, ValueError, yaml.YAMLError):
+            logger.debug("Skipping unreadable markdown file: %s", md_file)
+            continue
+        metadata = dict(post.metadata)
+        if metadata.get("type") != "fragment":
+            continue
+        try:
+            out.append(Fragment.model_validate(metadata))
+        except ValidationError:
+            logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
+            continue
+    return out

--- a/creek-tools/creek/link/link_engine.py
+++ b/creek-tools/creek/link/link_engine.py
@@ -178,7 +178,17 @@ def _load_or_compute_embeddings(
         merged = linker.generate_embeddings(fragments)
 
     cache_path.parent.mkdir(parents=True, exist_ok=True)
-    linker.save_embeddings(merged, cache_path)
+    try:
+        linker.save_embeddings(merged, cache_path)
+    except OSError as exc:
+        # Disk full / permission denied / read-only volume. Linking
+        # itself succeeded — losing the cache only costs a recompute on
+        # the next run, so we degrade gracefully instead of crashing.
+        logger.warning(
+            "Failed to persist embeddings cache to %s: %s",
+            cache_path,
+            exc,
+        )
     return merged
 
 

--- a/creek-tools/creek/link/link_engine.py
+++ b/creek-tools/creek/link/link_engine.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from pathlib import Path  # noqa: TC003 — runtime use in dataclass field
+from pathlib import Path  # noqa: TC003  # no issue: runtime dataclass field
 from typing import TYPE_CHECKING, Final
 
 import frontmatter

--- a/creek-tools/creek/link/link_engine.py
+++ b/creek-tools/creek/link/link_engine.py
@@ -71,7 +71,12 @@ def run_link(
         A :class:`LinkSummary` capturing per-method counts.
     """
     cache_path = vault_path / _EMBEDDINGS_CACHE_DIR / _EMBEDDINGS_CACHE_NAME
-    if rebuild and cache_path.exists():
+    # ``--rebuild`` is documented as "invalidate the embeddings cache",
+    # so only act on it for the embeddings linker. Temporal and eddy
+    # methods don't own the cache and shouldn't side-effect it — eddy
+    # *consumes* the cache, so blowing it away under that method would
+    # silently force a recompute the operator didn't ask for.
+    if rebuild and method == "embeddings" and cache_path.exists():
         cache_path.unlink()
         logger.info("Removed cached embeddings archive at %s", cache_path)
 

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -6,6 +6,13 @@ source directory, producing a :class:`PipelineResult` with aggregate counts.
 
 Processing is gated on user consent via :class:`~creek.consent.ConsentManager`:
 if consent has not been recorded for a source, the pipeline skips ingestion.
+
+The redaction stage is **fail-loud**: when ``redaction.enabled`` is true and
+the scanner finds unresolved sensitive content, the pipeline raises
+:class:`RedactionRequiredError` and refuses to ingest. The user must run
+``creek redact --apply`` first. This trades a small ergonomic cost for the
+guarantee that ``creek process`` can never silently leak secrets into the
+vault.
 """
 
 import logging
@@ -22,11 +29,41 @@ from creek.generate.indexes import IndexGenerator
 from creek.ingest import INGESTOR_REGISTRY
 from creek.ingest.base import IngestedFragment, assemble_ingested_fragment
 from creek.link.linker import LinkingPipeline
-from creek.models import Fragment
+from creek.models import Fragment, Frequency
 from creek.redact.scanner import RedactionScanner
 from creek.vault.writer import VaultWriter
 
 logger = logging.getLogger(__name__)
+
+
+class RedactionRequiredError(RuntimeError):
+    """Raised when ``creek process`` finds unresolved redaction matches.
+
+    The pipeline refuses to ingest until the user runs
+    ``creek redact --apply --source <path>`` (or accepts the matches by
+    setting ``redaction.dry_run: true``). Carrying the match count lets
+    the CLI render an exact remediation message.
+
+    Attributes:
+        match_count: Number of unresolved redaction matches found.
+        source_path: The source directory that was scanned.
+    """
+
+    def __init__(self, match_count: int, source_path: Path) -> None:
+        """Build a fail-loud redaction error with a remediation hint.
+
+        Args:
+            match_count: Number of unresolved sensitive matches.
+            source_path: Source directory the scanner walked.
+        """
+        self.match_count = match_count
+        self.source_path = source_path
+        super().__init__(
+            f"Redaction scan found {match_count} unresolved match(es) in "
+            f"{source_path}. Run `creek redact --apply --source "
+            f"{source_path}` (or set redaction.dry_run: true to skip "
+            "this gate) before re-running `creek process`."
+        )
 
 
 class PipelineResult(BaseModel):
@@ -181,7 +218,15 @@ class Pipeline:
         )
 
     def _run_redaction(self, source_path: Path, result: PipelineResult) -> int:
-        """Scan source files for sensitive data.
+        """Scan source files for sensitive data and abort if any are found.
+
+        When ``redaction.enabled`` is true and the scanner reports any
+        unresolved matches, this method raises
+        :class:`RedactionRequiredError` rather than ingest sensitive
+        content into the vault. Set ``redaction.dry_run: true`` to keep
+        the scan informational (matches are logged but the pipeline
+        proceeds); the documented remediation is to run
+        ``creek redact --apply`` first.
 
         Args:
             source_path: Directory to scan.
@@ -189,6 +234,10 @@ class Pipeline:
 
         Returns:
             Number of files scanned.
+
+        Raises:
+            RedactionRequiredError: When matches are found and
+                ``redaction.dry_run`` is false.
         """
         if not source_path.exists():
             logger.warning("Source path does not exist: %s", source_path)
@@ -197,15 +246,28 @@ class Pipeline:
         files = list(source_path.rglob("*"))
         file_count = sum(1 for f in files if f.is_file())
 
-        if self.config.redaction.enabled:
-            matches = self.scanner.scan_directory(source_path)
-            if matches:
-                logger.info(
-                    "Redaction scan found %d potential PII match(es)",
-                    len(matches),
-                )
+        if not self.config.redaction.enabled:
+            return file_count
 
-        return file_count
+        matches = self.scanner.scan_directory(source_path)
+        if not matches:
+            return file_count
+
+        if self.config.redaction.dry_run:
+            logger.warning(
+                "Redaction scan found %d potential PII match(es) "
+                "(dry_run=true; pipeline will continue without applying)",
+                len(matches),
+            )
+            return file_count
+
+        logger.error(
+            "Redaction scan found %d unresolved match(es) in %s; "
+            "refusing to ingest until they are applied.",
+            len(matches),
+            source_path,
+        )
+        raise RedactionRequiredError(len(matches), source_path)
 
     def _run_ingestion(
         self, source_path: Path, result: PipelineResult
@@ -268,7 +330,14 @@ class Pipeline:
         vault_path: Path,
         result: PipelineResult,
     ) -> list[IngestedFragment]:
-        """Classify fragments through rules, LLM, and review queue.
+        """Classify fragments through rules, optional LLM, and review queue.
+
+        Runs the rule-based classifier first, then escalates to the LLM
+        only for fragments that the rules left below
+        ``ClassificationConfig.confidence_threshold`` or with an
+        unclassified primary frequency. Fragments whose source platform
+        is in ``human_review_sources`` are never sent to the LLM — they
+        always go to the review queue for a human decision.
 
         Classification operates on the inner :class:`Fragment`; the body
         is preserved unchanged on the returned :class:`IngestedFragment`.
@@ -287,8 +356,9 @@ class Pipeline:
 
         classified: list[IngestedFragment] = []
         for item in ingested:
-            frag = self.rule_classifier.classify(item.fragment)
-            frag = self.llm_classifier.classify(frag)
+            frag = self.rule_classifier.classify(item.fragment, content=item.body)
+            if self._needs_llm(frag, item.body):
+                frag = self.llm_classifier.classify(frag, content=item.body)
             classified.append(IngestedFragment(fragment=frag, body=item.body))
 
         self.review_generator.generate_queue(
@@ -296,6 +366,44 @@ class Pipeline:
             vault_path,
         )
         return classified
+
+    def _needs_llm(self, fragment: Fragment, content: str) -> bool:
+        """Return ``True`` when the rule classifier left this fragment uncertain.
+
+        A fragment is sent to the LLM when:
+
+        * its source platform is not in
+          :attr:`ClassificationConfig.human_review_sources` (those go
+          straight to the review queue without LLM assistance), and
+        * the rule classifier left its primary frequency unclassified
+          *or* its rule-derived confidence sits below
+          :attr:`ClassificationConfig.confidence_threshold`.
+
+        Fragments whose source platform is in ``auto_classify_sources``
+        and whose rules already produced a confident answer are skipped,
+        which is the cost-saving fast path for cleanly-classified bulk
+        imports.
+
+        Args:
+            fragment: Fragment after the rule-classifier pass.
+            content: Markdown body the rule classifier scored.
+
+        Returns:
+            ``True`` if :class:`LLMClassifier` should be invoked.
+        """
+        classification = self.config.classification
+
+        if fragment.source.platform in classification.human_review_sources:
+            return False
+
+        if fragment.frequency.primary == Frequency.UNCLASSIFIED:
+            return True
+
+        confidence = self.rule_classifier.confidence_score(
+            fragment,
+            content=content,
+        )
+        return confidence < classification.confidence_threshold
 
     def _write_to_vault(
         self,

--- a/creek-tools/creek/vault/__init__.py
+++ b/creek-tools/creek/vault/__init__.py
@@ -1,5 +1,10 @@
-"""Creek vault subpackage — write ontological primitives to an Obsidian vault."""
+"""Creek vault subpackage — read/write ontological primitives in an Obsidian vault."""
 
+from creek.vault.reader import iter_vault_fragments, try_load_fragment
 from creek.vault.writer import VaultWriter
 
-__all__ = ["VaultWriter"]
+__all__ = [
+    "VaultWriter",
+    "iter_vault_fragments",
+    "try_load_fragment",
+]

--- a/creek-tools/creek/vault/reader.py
+++ b/creek-tools/creek/vault/reader.py
@@ -1,0 +1,110 @@
+"""Vault-side fragment reader — single source of truth for loading fragments.
+
+The classify engine, review runner, and link engine all walk
+``<vault>/01-Fragments/`` looking for files that parse as Creek
+fragments. They differ only in what they want back:
+
+- the classify engine needs ``(fragment, body, raw_metadata)`` so it
+  can rewrite the file with updated frontmatter while preserving any
+  non-Fragment keys;
+- the review runner builds a :class:`ReviewEntry` around the same
+  triple plus the source path;
+- the link engine just needs the :class:`Fragment` itself.
+
+Before this module existed the three sites carried independent copies
+of the same three-step validation chain (``frontmatter.load`` → check
+``type == "fragment"`` → :meth:`Fragment.model_validate`). A schema
+change to :class:`Fragment` or a rename of the ``type`` sentinel
+would have required keeping three implementations in lock-step. The
+helpers here remove that drift risk by exposing one validated load
+path; callers project the result into whatever shape they need.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path  # noqa: TC003  # no issue: runtime use in type hints
+
+import frontmatter
+import yaml
+from pydantic import ValidationError
+
+from creek.models import Fragment
+
+logger = logging.getLogger(__name__)
+
+
+def try_load_fragment(
+    md_file: Path,
+) -> tuple[Fragment, str, dict[str, object]] | None:
+    """Load a single fragment file, returning ``None`` for non-fragments.
+
+    The function distinguishes two failure modes:
+
+    * **Real I/O / parse failures** propagate as ``OSError``,
+      ``ValueError``, or :class:`yaml.YAMLError` so the caller can
+      record them on its summary's ``errors`` list.
+    * **Non-fragment markdown** (no ``type: fragment`` field, or a
+      schema mismatch) returns ``None`` so the caller silently skips
+      it. Markdown notes coexist with fragments in a vault and aren't
+      errors.
+
+    Args:
+        md_file: Path to a markdown file inside ``<vault>/01-Fragments``.
+
+    Returns:
+        ``(fragment, body, raw_metadata)`` for a valid Creek fragment,
+        or ``None`` when the file is well-formed YAML but not a
+        fragment.
+
+    Raises:
+        OSError: When the file cannot be read.
+        ValueError: When the YAML cannot be parsed.
+        yaml.YAMLError: When the YAML parser rejects the document.
+    """
+    post = frontmatter.load(str(md_file))
+    metadata = dict(post.metadata)
+    if metadata.get("type") != "fragment":
+        return None
+    try:
+        fragment = Fragment.model_validate(metadata)
+    except ValidationError:
+        logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
+        return None
+    return fragment, str(post.content), metadata
+
+
+def iter_vault_fragments(
+    fragments_root: Path,
+) -> list[tuple[Path, Fragment, str, dict[str, object]]]:
+    """Walk ``fragments_root`` and yield every valid Creek fragment.
+
+    Convenience wrapper for callers that want every loadable fragment
+    without manually distinguishing real I/O failures from
+    non-fragment skips. I/O failures are logged at DEBUG level and
+    skipped — callers that need to surface them to the operator
+    should iterate manually with :func:`try_load_fragment`.
+
+    Args:
+        fragments_root: Path to ``<vault>/01-Fragments`` (or any
+            directory tree containing fragment files).
+
+    Returns:
+        Sorted list of ``(path, fragment, body, raw_metadata)``
+        tuples — one per valid fragment.
+    """
+    if not fragments_root.exists():
+        return []
+
+    out: list[tuple[Path, Fragment, str, dict[str, object]]] = []
+    for md_file in sorted(fragments_root.rglob("*.md")):
+        try:
+            record = try_load_fragment(md_file)
+        except (OSError, ValueError, yaml.YAMLError):
+            logger.debug("Skipping unreadable markdown file: %s", md_file)
+            continue
+        if record is None:
+            continue
+        fragment, body, raw = record
+        out.append((md_file, fragment, body, raw))
+    return out

--- a/creek-tools/docs/redaction.md
+++ b/creek-tools/docs/redaction.md
@@ -87,3 +87,28 @@ Redaction sanitises *content*; it doesn't delete the fragment. If you need a fra
 - **Always** scan before `creek ingest` on any new export.
 - **Re-scan** the vault after every classification pass, especially if you've turned on the LLM path — it can occasionally surface PII the rules missed.
 - **Audit** the report monthly. The audit log under `<vault>/00-Creek-Meta/audit/` records every apply.
+
+## How `creek process` interacts with redaction
+
+`creek process` is **fail-loud**: when the redaction scan finds any unresolved
+matches it raises `RedactionRequiredError` and exits non-zero before
+ingestion. The CLI prints an exact remediation hint:
+
+```
+Redaction gate: Redaction scan found 17 unresolved match(es) in /tmp/exports.
+Run `creek redact --apply --source /tmp/exports` (or set redaction.dry_run:
+true to skip this gate) before re-running `creek process`.
+```
+
+Two ways to override the gate:
+
+1. **Recommended.** Run `creek redact --apply --source <path>` so the
+   replacements happen with operator review, then re-run
+   `creek process`.
+2. Set `redaction.dry_run: true` in your `creek_config.yaml`. The
+   pipeline still scans and logs the matches, but does not abort. This
+   is the right setting only when the source is known to be safe — e.g.
+   regenerating a vault from already-cleaned exports.
+
+This trades a small ergonomic cost (an extra command) for the guarantee
+that `creek process` cannot silently leak secrets into the vault.

--- a/creek-tools/tests/e2e/test_full_pipeline_redaction.py
+++ b/creek-tools/tests/e2e/test_full_pipeline_redaction.py
@@ -2,8 +2,9 @@
 
 Drops a source file containing a deliberately well-known test secret,
 runs the full pipeline, and asserts the secret does not appear in any
-file written under the vault. Catches the BUG-004 regression where the
-pipeline scans for redactions but never applies them.
+file written under the vault. Pinned to the fail-loud behaviour
+documented in ``docs/redaction.md``: the pipeline must refuse to ingest
+when unresolved redaction matches exist.
 """
 
 from __future__ import annotations
@@ -16,20 +17,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from creek.config import CreekConfig
-from creek.pipeline import Pipeline
+from creek.pipeline import Pipeline, RedactionRequiredError
 
-pytestmark = [
-    pytest.mark.e2e,
-    pytest.mark.xfail(
-        reason=(
-            "BUG-004: pipeline scans for redactions but does not apply "
-            "them. strict=True so when the redactor is wired into the "
-            "ingestion path the test XPASSES, fails CI, and forces "
-            "removal of this xfail marker."
-        ),
-        strict=True,
-    ),
-]
+pytestmark = [pytest.mark.e2e]
 
 
 _SECRET = "AKIAIOSFODNN7EXAMPLE"  # pragma: allowlist secret  AWS test example
@@ -39,12 +29,11 @@ _SECRET = "AKIAIOSFODNN7EXAMPLE"  # pragma: allowlist secret  AWS test example
 def test_pipeline_does_not_leak_secret_into_vault(
     synthetic_vault: Path, synthetic_source: Path
 ) -> None:
-    """A well-known fake AWS key must not survive to any vault file.
+    """A well-known fake AWS key must never reach any vault file.
 
-    Reads every file in the resulting vault and asserts the secret token
-    is absent. This is a hard "no leaks" invariant: even if redaction
-    only rewrites *some* files, none of them should contain the literal
-    AKIA* token.
+    With the fail-loud redaction gate, the pipeline aborts before
+    ingestion when it sees the secret. Either way the invariant holds:
+    no file under the vault contains the literal AKIA* token.
     """
     note = synthetic_source / "leaky.md"
     note.write_text(
@@ -54,7 +43,8 @@ def test_pipeline_does_not_leak_secret_into_vault(
 
     config = CreekConfig()
     pipeline = Pipeline(config=config)
-    pipeline.run(source_path=synthetic_source, vault_path=synthetic_vault)
+    with pytest.raises(RedactionRequiredError):
+        pipeline.run(source_path=synthetic_source, vault_path=synthetic_vault)
 
     for path in synthetic_vault.rglob("*"):
         if not path.is_file():

--- a/creek-tools/tests/helpers.py
+++ b/creek-tools/tests/helpers.py
@@ -1,0 +1,62 @@
+"""Shared helpers for fragment-driven test files.
+
+Each engine test (classify, link, review) needs to seed a vault with a
+real fragment file before the system under test runs. The helper used
+to be copy-pasted across three test modules; centralising it here
+keeps the on-disk shape of a fragment fixture in one place so
+``Fragment.model_dump`` evolutions can't silently diverge between
+suites.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003 — runtime use in type hints
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+if TYPE_CHECKING:
+    from creek.models import Fragment
+
+
+def write_fragment_file(
+    *,
+    vault: Path,
+    fragment: Fragment,
+    body: str,
+    method: str | None = None,
+    extras: dict[str, object] | None = None,
+    subfolder: str = "Notes",
+) -> Path:
+    """Persist *fragment* under ``<vault>/01-Fragments/<subfolder>``.
+
+    Args:
+        vault: Vault root.
+        fragment: Fragment metadata to persist.
+        body: Markdown body the file should carry below the frontmatter.
+        method: Optional ``classification_method`` to stamp (typically
+            one of ``"rules" | "llm" | "manual"``).
+        extras: Extra frontmatter keys to merge in alongside the
+            Fragment fields.
+        subfolder: Vault subfolder under ``01-Fragments``; defaults to
+            ``"Notes"`` so tests don't need to know the canonical
+            ``SourcePlatform`` mapping.
+
+    Returns:
+        Path to the freshly-written file.
+    """
+    fragments_dir = vault / "01-Fragments" / subfolder
+    fragments_dir.mkdir(parents=True, exist_ok=True)
+
+    metadata = fragment.model_dump(mode="json")
+    if method is not None:
+        metadata["classification_method"] = method
+    if extras:
+        metadata.update(extras)
+
+    path = fragments_dir / f"{fragment.id}.md"
+    path.write_text(
+        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
+        encoding="utf-8",
+    )
+    return path

--- a/creek-tools/tests/helpers.py
+++ b/creek-tools/tests/helpers.py
@@ -10,7 +10,7 @@ suites.
 
 from __future__ import annotations
 
-from pathlib import Path  # noqa: TC003 — runtime use in type hints
+from pathlib import Path  # noqa: TC003  # no issue: runtime helper signature
 from typing import TYPE_CHECKING
 
 import frontmatter

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -121,7 +121,9 @@ def test_run_classify_skips_non_fragment_files(tmp_path: Path) -> None:
 
     The classify engine treats a missing/wrong ``type`` field as "not a
     Creek fragment, leave it alone" — these are not errors, they're
-    arbitrary markdown that happens to share the directory.
+    arbitrary markdown that happens to share the directory. Such
+    files must not appear in ``summary.total`` either, otherwise the
+    "Classified N of M" CLI message becomes misleading.
     """
     vault = tmp_path / "vault"
     fragments_dir = vault / "01-Fragments" / "Notes"
@@ -135,7 +137,7 @@ def test_run_classify_skips_non_fragment_files(tmp_path: Path) -> None:
         method="rules",
         force=False,
     )
-    assert summary.total == 1
+    assert summary.total == 0
     assert summary.classified == 0
     assert summary.errors == []
 
@@ -177,14 +179,23 @@ def test_run_classify_unreadable_file_records_error(tmp_path: Path) -> None:
 
 
 def test_run_classify_llm_skips_high_confidence(tmp_path: Path) -> None:
-    """When rules give a confident answer, the LLM is not invoked."""
+    """High-confidence rule result is persisted with method='rules'.
+
+    When ``--method llm`` and the rule classifier produces a
+    confident answer, the LLM is short-circuited but the rule's
+    classification IS written back to disk — otherwise the operator's
+    work would be silently discarded and the fragment would re-enter
+    the review queue on every run.
+    """
+    import frontmatter
+
     vault = tmp_path / "vault"
     fragment = Fragment(
         id="frag-skip00000000",
         title="Confident already",
         source=FragmentSource(platform=SourcePlatform.MARKDOWN),
     )
-    _write_fragment(
+    file = _write_fragment(
         vault=vault,
         fragment=fragment,
         body="Power dominance control conquest force aggression bold rage warrior",
@@ -203,6 +214,49 @@ def test_run_classify_llm_skips_high_confidence(tmp_path: Path) -> None:
 
     mock_llm.assert_not_called()
     assert summary.skipped_high_confidence >= 1
+    assert summary.classified == summary.skipped_high_confidence
+
+    # The rule-classified fragment must be persisted with the truthful
+    # provenance stamp, not the user's CLI choice.
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "rules"
+    assert "classified_at" in reloaded.metadata
+
+
+def test_run_classify_total_only_counts_creek_fragments(tmp_path: Path) -> None:
+    """``total`` excludes arbitrary markdown notes that share the directory.
+
+    A vault with 2 Creek fragments and 3 unrelated Obsidian notes
+    must report ``total == 2`` — not 5. Counting non-fragments would
+    surface as a misleading "Classified 2 of 5" CLI message.
+    """
+    vault = tmp_path / "vault"
+    for i in range(2):
+        _write_fragment(
+            vault=vault,
+            fragment=Fragment(
+                id=f"frag-realfrag00{i:03d}",
+                title=f"Real fragment {i}",
+                source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+            ),
+            body="Power dominance bold rage warrior conquest",
+        )
+
+    notes_dir = vault / "01-Fragments" / "Notes"
+    for i in range(3):
+        note = notes_dir / f"unrelated-{i}.md"
+        # Plain Obsidian note — no ``type: fragment`` frontmatter.
+        note.write_text(f"# Unrelated {i}\n\nJust a note.\n", encoding="utf-8")
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    assert summary.total == 2
+    assert summary.classified == 2
 
 
 def test_run_classify_llm_invoked_for_low_confidence(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -1,0 +1,236 @@
+"""Tests for the vault-driven classification engine.
+
+Covers the dispatch logic in :mod:`creek.classify.classify_engine`,
+including manual-decision preservation, ``--force`` behaviour, the
+high-confidence skip path, and error handling around bad fragment
+files.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import frontmatter
+
+from creek.classify.classify_engine import run_classify
+from creek.config import CreekConfig
+from creek.models import Fragment, FragmentSource, SourcePlatform
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_fragment(
+    *,
+    vault: Path,
+    fragment: Fragment,
+    body: str,
+    method: str | None = None,
+    extras: dict[str, object] | None = None,
+) -> Path:
+    """Persist a fragment file under ``<vault>/01-Fragments/Notes``.
+
+    Args:
+        vault: Vault root.
+        fragment: Fragment metadata to persist.
+        body: Markdown body for the file.
+        method: Optional ``classification_method`` to stamp.
+        extras: Extra frontmatter keys to merge in.
+
+    Returns:
+        Path to the freshly-written file.
+    """
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True, exist_ok=True)
+    metadata = fragment.model_dump(mode="json")
+    if method is not None:
+        metadata["classification_method"] = method
+    if extras:
+        metadata.update(extras)
+    path = fragments_dir / f"{fragment.id}.md"
+    path.write_text(
+        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_run_classify_returns_zeroes_when_no_fragments_dir(tmp_path: Path) -> None:
+    """Missing ``01-Fragments`` returns a zeroed summary, not an error."""
+    summary = run_classify(
+        vault_path=tmp_path / "vault",
+        config=CreekConfig(),
+        method="rules",
+        batch_size=10,
+        force=False,
+    )
+    assert summary.total == 0
+    assert summary.classified == 0
+
+
+def test_run_classify_rules_updates_fragments(tmp_path: Path) -> None:
+    """Rule classification stamps ``classification_method: rules``."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-aaaaaaaaaaaa",
+        title="Power and dominance",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="Power dominance control conquest force aggression bold rage warrior",
+    )
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        batch_size=10,
+        force=False,
+    )
+
+    assert summary.classified == 1
+    assert summary.total == 1
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "rules"
+
+
+def test_run_classify_preserves_manual_without_force(tmp_path: Path) -> None:
+    """Manual decisions survive a ``--method rules`` pass."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-manual000000",
+        title="Hand-tagged",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="body",
+        method="manual",
+    )
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        batch_size=10,
+        force=False,
+    )
+
+    assert summary.preserved_manual == 1
+    assert summary.classified == 0
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "manual"
+
+
+def test_run_classify_force_overwrites_manual(tmp_path: Path) -> None:
+    """``--force`` rewrites manual fragments."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-manual000001",
+        title="Force me",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="body",
+        method="manual",
+    )
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        batch_size=10,
+        force=True,
+    )
+
+    assert summary.classified == 1
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "rules"
+
+
+def test_run_classify_unreadable_file_records_error(tmp_path: Path) -> None:
+    """Bad fragment files surface as errors, not crashes."""
+    vault = tmp_path / "vault"
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True)
+    bad = fragments_dir / "bad.md"
+    bad.write_text("---\nnot: valid\n---\nplain", encoding="utf-8")
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        batch_size=10,
+        force=False,
+    )
+    assert summary.total == 1
+    # The file is "valid YAML" but missing type=fragment, so it's silently
+    # skipped (fragment readers swallow non-fragment docs by design).
+    assert summary.classified == 0
+
+
+def test_run_classify_llm_skips_high_confidence(tmp_path: Path) -> None:
+    """When rules give a confident answer, the LLM is not invoked."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-skip00000000",
+        title="Confident already",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="Power dominance control conquest force aggression bold rage warrior",
+    )
+
+    config = CreekConfig()
+    config.classification.confidence_threshold = 0.0
+
+    with patch("creek.classify.classify_engine.LLMClassifier.classify") as mock_llm:
+        summary = run_classify(
+            vault_path=vault,
+            config=config,
+            method="llm",
+            batch_size=10,
+            force=False,
+        )
+
+    mock_llm.assert_not_called()
+    assert summary.skipped_high_confidence >= 1
+
+
+def test_run_classify_llm_invoked_for_low_confidence(tmp_path: Path) -> None:
+    """The LLM classifier runs when rules leave the fragment unclassified."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-llmcall00000",
+        title="not enough signal",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="ordinary content with no signal keywords at all",
+    )
+
+    config = CreekConfig()
+
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify",
+        side_effect=lambda f, content="": f,
+    ) as mock_llm:
+        run_classify(
+            vault_path=vault,
+            config=config,
+            method="llm",
+            batch_size=10,
+            force=False,
+        )
+
+    mock_llm.assert_called_once()

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -16,44 +16,10 @@ import frontmatter
 from creek.classify.classify_engine import run_classify
 from creek.config import CreekConfig
 from creek.models import Fragment, FragmentSource, SourcePlatform
+from tests.helpers import write_fragment_file as _write_fragment
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-def _write_fragment(
-    *,
-    vault: Path,
-    fragment: Fragment,
-    body: str,
-    method: str | None = None,
-    extras: dict[str, object] | None = None,
-) -> Path:
-    """Persist a fragment file under ``<vault>/01-Fragments/Notes``.
-
-    Args:
-        vault: Vault root.
-        fragment: Fragment metadata to persist.
-        body: Markdown body for the file.
-        method: Optional ``classification_method`` to stamp.
-        extras: Extra frontmatter keys to merge in.
-
-    Returns:
-        Path to the freshly-written file.
-    """
-    fragments_dir = vault / "01-Fragments" / "Notes"
-    fragments_dir.mkdir(parents=True, exist_ok=True)
-    metadata = fragment.model_dump(mode="json")
-    if method is not None:
-        metadata["classification_method"] = method
-    if extras:
-        metadata.update(extras)
-    path = fragments_dir / f"{fragment.id}.md"
-    path.write_text(
-        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
-        encoding="utf-8",
-    )
-    return path
 
 
 def test_run_classify_returns_zeroes_when_no_fragments_dir(tmp_path: Path) -> None:
@@ -62,7 +28,6 @@ def test_run_classify_returns_zeroes_when_no_fragments_dir(tmp_path: Path) -> No
         vault_path=tmp_path / "vault",
         config=CreekConfig(),
         method="rules",
-        batch_size=10,
         force=False,
     )
     assert summary.total == 0
@@ -87,7 +52,6 @@ def test_run_classify_rules_updates_fragments(tmp_path: Path) -> None:
         vault_path=vault,
         config=CreekConfig(),
         method="rules",
-        batch_size=10,
         force=False,
     )
 
@@ -116,7 +80,6 @@ def test_run_classify_preserves_manual_without_force(tmp_path: Path) -> None:
         vault_path=vault,
         config=CreekConfig(),
         method="rules",
-        batch_size=10,
         force=False,
     )
 
@@ -145,7 +108,6 @@ def test_run_classify_force_overwrites_manual(tmp_path: Path) -> None:
         vault_path=vault,
         config=CreekConfig(),
         method="rules",
-        batch_size=10,
         force=True,
     )
 
@@ -154,8 +116,13 @@ def test_run_classify_force_overwrites_manual(tmp_path: Path) -> None:
     assert reloaded["classification_method"] == "rules"
 
 
-def test_run_classify_unreadable_file_records_error(tmp_path: Path) -> None:
-    """Bad fragment files surface as errors, not crashes."""
+def test_run_classify_skips_non_fragment_files(tmp_path: Path) -> None:
+    """Files that parse as YAML but aren't fragments are silently skipped.
+
+    The classify engine treats a missing/wrong ``type`` field as "not a
+    Creek fragment, leave it alone" — these are not errors, they're
+    arbitrary markdown that happens to share the directory.
+    """
     vault = tmp_path / "vault"
     fragments_dir = vault / "01-Fragments" / "Notes"
     fragments_dir.mkdir(parents=True)
@@ -166,13 +133,49 @@ def test_run_classify_unreadable_file_records_error(tmp_path: Path) -> None:
         vault_path=vault,
         config=CreekConfig(),
         method="rules",
-        batch_size=10,
         force=False,
     )
     assert summary.total == 1
-    # The file is "valid YAML" but missing type=fragment, so it's silently
-    # skipped (fragment readers swallow non-fragment docs by design).
     assert summary.classified == 0
+    assert summary.errors == []
+
+
+def test_run_classify_unreadable_file_records_error(tmp_path: Path) -> None:
+    """Files that fail to load surface on ``summary.errors``.
+
+    Simulates an OSError at write time by patching ``_write_fragment``
+    so that the file gets through validation and into the rewrite path,
+    where the engine's ``except OSError`` branch records the failure.
+    """
+    from unittest.mock import patch
+
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-iofail000000",
+        title="Power dominance bold rage warrior conquest",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="Power dominance control conquest force aggression bold rage warrior",
+    )
+
+    with patch(
+        "creek.classify.classify_engine._write_fragment",
+        side_effect=OSError("disk full"),
+    ):
+        summary = run_classify(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="rules",
+            force=False,
+        )
+
+    assert summary.total == 1
+    assert summary.classified == 0
+    assert len(summary.errors) == 1
+    assert "disk full" in summary.errors[0]
 
 
 def test_run_classify_llm_skips_high_confidence(tmp_path: Path) -> None:
@@ -197,7 +200,6 @@ def test_run_classify_llm_skips_high_confidence(tmp_path: Path) -> None:
             vault_path=vault,
             config=config,
             method="llm",
-            batch_size=10,
             force=False,
         )
 
@@ -229,7 +231,6 @@ def test_run_classify_llm_invoked_for_low_confidence(tmp_path: Path) -> None:
             vault_path=vault,
             config=config,
             method="llm",
-            batch_size=10,
             force=False,
         )
 

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -116,6 +116,37 @@ def test_run_classify_force_overwrites_manual(tmp_path: Path) -> None:
     assert reloaded["classification_method"] == "rules"
 
 
+def test_classify_summary_errors_is_an_immutable_tuple(tmp_path: Path) -> None:
+    """``ClassifySummary`` is genuinely immutable, not just frozen.
+
+    A ``frozen=True`` dataclass with a ``list`` field would let
+    callers mutate the list in place — defeating the purpose of the
+    annotation. Pin the contract: ``summary.errors`` is a tuple, and
+    appending to it raises.
+    """
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-immutable001",
+        title="Immutable",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    assert isinstance(summary.errors, tuple)
+    import pytest as _pytest
+
+    with _pytest.raises(AttributeError):
+        # Tuples have no ``append``; the call is the regression pin.
+        summary.errors.append("oops")  # type: ignore[attr-defined]
+
+
 def test_run_classify_skips_non_fragment_files(tmp_path: Path) -> None:
     """Files that parse as YAML but aren't fragments are silently skipped.
 
@@ -139,7 +170,7 @@ def test_run_classify_skips_non_fragment_files(tmp_path: Path) -> None:
     )
     assert summary.total == 0
     assert summary.classified == 0
-    assert summary.errors == []
+    assert summary.errors == ()
 
 
 def test_run_classify_unreadable_file_records_error(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -147,8 +147,6 @@ def test_run_classify_unreadable_file_records_error(tmp_path: Path) -> None:
     so that the file gets through validation and into the rewrite path,
     where the engine's ``except OSError`` branch records the failure.
     """
-    from unittest.mock import patch
-
     vault = tmp_path / "vault"
     fragment = Fragment(
         id="frag-iofail000000",

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -619,6 +619,41 @@ def test_review_list_only(tmp_path: Path) -> None:
     assert "Need a human eye" in result.output
 
 
+def test_operator_identity_strips_metacharacters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adversarial USER/USERNAME values are stripped before logging."""
+    from creek.cli import _operator_identity
+
+    monkeypatch.setenv("USER", "alice;rm -rf /\nboom")
+    assert _operator_identity() == "alicerm -rf boom"
+
+
+def test_operator_identity_truncates_long_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pathological-length env values are truncated to the configured cap."""
+    from creek.cli import _OPERATOR_IDENTITY_MAX_LEN, _operator_identity
+
+    monkeypatch.setenv("USER", "a" * 200)
+    result = _operator_identity()
+    assert len(result) == _OPERATOR_IDENTITY_MAX_LEN
+
+
+def test_operator_identity_falls_back_to_cli(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty (or all-stripped) identity falls back to ``"cli"``."""
+    from creek.cli import _operator_identity
+
+    monkeypatch.delenv("USER", raising=False)
+    monkeypatch.delenv("USERNAME", raising=False)
+    assert _operator_identity() == "cli"
+
+    monkeypatch.setenv("USER", ";;;\n\n")
+    assert _operator_identity() == "cli"
+
+
 def test_process_aborts_when_consent_declined(tmp_path: Path) -> None:
     """Declining the consent prompt aborts the pipeline non-zero."""
     src = tmp_path / "src"

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -696,6 +696,73 @@ def test_process_records_consent_with_yes_flag(tmp_path: Path) -> None:
     assert any(r["source_path"] == str(src) for r in records)
 
 
+def test_process_skips_prompt_when_consent_already_recorded(tmp_path: Path) -> None:
+    """Second invocation against a consented source needs no ``--yes``.
+
+    The core INC-010 invariant: once consent is on file, subsequent
+    runs against that source path proceed silently. A re-prompt would
+    be friction; a silent abort would be worse.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "note.md").write_text("Body\n")
+    vault = tmp_path / "vault"
+    for d in ("00-Creek-Meta", "01-Fragments", "02-Threads", "03-Eddies"):
+        (vault / d).mkdir(parents=True)
+
+    # First run records consent via ``--yes``.
+    first = runner.invoke(
+        app,
+        ["process", "--source", str(src), "--vault", str(vault), "--yes"],
+    )
+    assert first.exit_code == 0, first.output
+
+    # Second run, no ``--yes`` — must succeed because consent is cached.
+    second = runner.invoke(
+        app,
+        ["process", "--source", str(src), "--vault", str(vault)],
+    )
+    assert second.exit_code == 0, second.output
+    # And it must not have re-prompted (no "First time processing").
+    assert "First time processing" not in second.output
+
+
+def test_process_consent_is_per_source(tmp_path: Path) -> None:
+    """A different source path still triggers the gate.
+
+    Consent is recorded per (source_type, source_path) tuple. Granting
+    consent for ``/srcA`` must not waive the gate for ``/srcB`` —
+    otherwise an operator's first-source approval would silently
+    extend to every future source they ingest.
+    """
+    src_a = tmp_path / "src_a"
+    src_a.mkdir()
+    (src_a / "a.md").write_text("A\n")
+
+    src_b = tmp_path / "src_b"
+    src_b.mkdir()
+    (src_b / "b.md").write_text("B\n")
+
+    vault = tmp_path / "vault"
+    for d in ("00-Creek-Meta", "01-Fragments", "02-Threads", "03-Eddies"):
+        (vault / d).mkdir(parents=True)
+
+    # Consent for src_a only.
+    granted = runner.invoke(
+        app,
+        ["process", "--source", str(src_a), "--vault", str(vault), "--yes"],
+    )
+    assert granted.exit_code == 0, granted.output
+
+    # src_b without ``--yes`` and no recorded consent → exit 1.
+    blocked = runner.invoke(
+        app,
+        ["process", "--source", str(src_b), "--vault", str(vault)],
+    )
+    assert blocked.exit_code == 1
+    assert "consent" in blocked.output.lower() or "Non-interactive" in blocked.output
+
+
 def test_process_aborts_on_unresolved_redactions(tmp_path: Path) -> None:
     """``creek process`` exits 1 with a remediation hint when secrets exist."""
     src = tmp_path / "src"

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -45,9 +45,9 @@ def test_process_command(tmp_path: Path) -> None:
 
     result = runner.invoke(
         app,
-        ["process", "--source", str(source), "--vault", str(vault)],
+        ["process", "--source", str(source), "--vault", str(vault), "--yes"],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
 
 
 def test_ingest_help() -> None:
@@ -57,8 +57,51 @@ def test_ingest_help() -> None:
     assert "ingest" in result.output.lower()
 
 
-def test_ingest_command() -> None:
-    """Test that ingest command runs with required args."""
+def test_ingest_command_requires_input(tmp_path: Path) -> None:
+    """The ingest command refuses to run when --input is missing."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    result = runner.invoke(
+        app,
+        ["ingest", "--type", "markdown", "--vault", str(vault)],
+    )
+    assert result.exit_code == 2
+
+
+def test_ingest_command_rejects_unknown_type(tmp_path: Path) -> None:
+    """An unknown --type exits 2 with a hint listing known types."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+    (vault / "01-Fragments").mkdir(parents=True)
+    src = tmp_path / "in"
+    src.mkdir()
+    result = runner.invoke(
+        app,
+        [
+            "ingest",
+            "--type",
+            "nope",
+            "--input",
+            str(src),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "Unknown ingestor type" in result.output
+
+
+def test_ingest_command_writes_fragments(tmp_path: Path) -> None:
+    """The ingest command resolves the registry and writes fragments."""
+    vault = tmp_path / "vault"
+    for d in ["00-Creek-Meta", "01-Fragments/Notes"]:
+        (vault / d).mkdir(parents=True)
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "note.md").write_text("# Hello\n\nFirst note about systems.\n")
+
     result = runner.invoke(
         app,
         [
@@ -66,12 +109,56 @@ def test_ingest_command() -> None:
             "--type",
             "markdown",
             "--input",
-            "/fake/in",
+            str(src),
             "--vault",
-            "/fake/vault",
+            str(vault),
+            "--yes",
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.output
+    written = list((vault / "01-Fragments").rglob("*.md"))
+    assert len(written) >= 1
+
+
+def test_ingest_command_idempotent(tmp_path: Path) -> None:
+    """Running ingest twice against the same source writes no new files."""
+    vault = tmp_path / "vault"
+    for d in ["00-Creek-Meta", "01-Fragments/Notes"]:
+        (vault / d).mkdir(parents=True)
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "note.md").write_text("# Hello\n\nIdempotent run.\n")
+
+    runner.invoke(
+        app,
+        [
+            "ingest",
+            "--type",
+            "markdown",
+            "--input",
+            str(src),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+    first = sorted((vault / "01-Fragments").rglob("*.md"))
+    runner.invoke(
+        app,
+        [
+            "ingest",
+            "--type",
+            "markdown",
+            "--input",
+            str(src),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+    second = sorted((vault / "01-Fragments").rglob("*.md"))
+    assert [p.name for p in first] == [p.name for p in second]
 
 
 def test_redact_help() -> None:
@@ -139,27 +226,133 @@ def test_classify_help() -> None:
     assert "classify" in result.output.lower()
 
 
-def test_classify_command() -> None:
-    """Test that classify command runs with required args."""
-    result = runner.invoke(app, ["classify", "--vault", "/fake/vault"])
+def test_classify_command_runs_against_empty_vault(tmp_path: Path) -> None:
+    """``creek classify`` exits 0 against a vault with no fragments."""
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    result = runner.invoke(app, ["classify", "--vault", str(vault)])
+    assert result.exit_code == 0, result.output
+
+
+def test_classify_rejects_unknown_method(tmp_path: Path) -> None:
+    """An unknown ``--method`` exits with code 2."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    result = runner.invoke(
+        app,
+        ["classify", "--vault", str(vault), "--method", "magic"],
+    )
+    assert result.exit_code == 2
+    assert "Unknown method" in result.output
+
+
+def test_classify_rules_writes_method_to_frontmatter(tmp_path: Path) -> None:
+    """``creek classify --method rules`` stamps the method on each fragment."""
+    import frontmatter
+
+    from creek.models import Fragment, FragmentSource, SourcePlatform
+
+    vault = tmp_path / "vault"
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True)
+
+    fragment = Fragment(
+        id="frag-test12345678",
+        title="Power and dominance",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    body = (
+        "Power dominance control conquest force aggression bold fearless "
+        "warrior rage impulsive rebellion."
+    )
+    file = fragments_dir / "fragment.md"
+    file.write_text(
+        frontmatter.dumps(
+            frontmatter.Post(content=body, **fragment.model_dump(mode="json")),
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["classify", "--vault", str(vault), "--method", "rules"],
+    )
+    assert result.exit_code == 0, result.output
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "rules"
+    assert "classified_at" in reloaded.metadata
+
+
+def test_classify_preserves_manual_without_force(tmp_path: Path) -> None:
+    """A ``manual`` decision is not overwritten when ``--force`` is absent."""
+    import frontmatter
+
+    from creek.models import Fragment, FragmentSource, SourcePlatform
+
+    vault = tmp_path / "vault"
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True)
+
+    fragment = Fragment(
+        id="frag-manual000000",
+        title="Hand-tagged note",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    metadata = fragment.model_dump(mode="json")
+    metadata["classification_method"] = "manual"
+    metadata["classified_at"] = "2026-01-01T00:00:00-08:00"
+    file = fragments_dir / "manual.md"
+    file.write_text(
+        frontmatter.dumps(frontmatter.Post(content="body", **metadata)),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["classify", "--vault", str(vault), "--method", "rules"],
+    )
     assert result.exit_code == 0
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "manual"
 
 
-def test_classify_with_options() -> None:
-    """Test that classify command runs with all options."""
+def test_classify_force_overrides_manual(tmp_path: Path) -> None:
+    """``--force`` overwrites ``classification_method: manual`` decisions."""
+    import frontmatter
+
+    from creek.models import Fragment, FragmentSource, SourcePlatform
+
+    vault = tmp_path / "vault"
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True)
+
+    fragment = Fragment(
+        id="frag-manual000001",
+        title="Tag it again",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    metadata = fragment.model_dump(mode="json")
+    metadata["classification_method"] = "manual"
+    file = fragments_dir / "manual.md"
+    file.write_text(
+        frontmatter.dumps(frontmatter.Post(content="body", **metadata)),
+        encoding="utf-8",
+    )
+
     result = runner.invoke(
         app,
         [
             "classify",
             "--vault",
-            "/fake/vault",
+            str(vault),
             "--method",
-            "llm",
-            "--batch-size",
-            "25",
+            "rules",
+            "--force",
         ],
     )
     assert result.exit_code == 0
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "rules"
 
 
 def test_link_help() -> None:
@@ -169,19 +362,48 @@ def test_link_help() -> None:
     assert "link" in result.output.lower()
 
 
-def test_link_command() -> None:
-    """Test that link command runs with required args."""
-    result = runner.invoke(app, ["link", "--vault", "/fake/vault"])
-    assert result.exit_code == 0
+def test_link_command_runs_against_empty_vault(tmp_path: Path) -> None:
+    """``creek link`` exits 0 against a vault with no fragments."""
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    result = runner.invoke(app, ["link", "--vault", str(vault)])
+    assert result.exit_code == 0, result.output
 
 
-def test_link_with_method() -> None:
-    """Test that link command runs with --method option."""
+def test_link_rejects_unknown_method(tmp_path: Path) -> None:
+    """An unknown ``--method`` exits with code 2."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
     result = runner.invoke(
         app,
-        ["link", "--vault", "/fake/vault", "--method", "graph"],
+        ["link", "--vault", str(vault), "--method", "graph"],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 2
+    assert "Unknown method" in result.output
+
+
+def test_link_rebuild_clears_embeddings_cache(tmp_path: Path) -> None:
+    """``--rebuild`` deletes the cached embeddings archive before linking."""
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    cache_dir = vault / "00-Creek-Meta"
+    cache_dir.mkdir(parents=True)
+    cache_path = cache_dir / "embeddings.npz"
+    cache_path.write_bytes(b"stale-cache")
+
+    result = runner.invoke(
+        app,
+        [
+            "link",
+            "--vault",
+            str(vault),
+            "--method",
+            "embeddings",
+            "--rebuild",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert not cache_path.exists()
 
 
 def test_report_help() -> None:
@@ -361,10 +583,135 @@ def test_review_help() -> None:
     assert "review" in result.output.lower()
 
 
-def test_review_command() -> None:
-    """Test that review command runs with required args."""
-    result = runner.invoke(app, ["review", "--vault", "/fake/vault"])
-    assert result.exit_code == 0
+def test_review_empty_queue(tmp_path: Path) -> None:
+    """Empty queue: ``creek review`` exits 0 with a friendly message."""
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    result = runner.invoke(app, ["review", "--vault", str(vault)])
+    assert result.exit_code == 0, result.output
+    assert "Review queue is empty" in result.output
+
+
+def test_review_list_only(tmp_path: Path) -> None:
+    """``creek review --list`` prints pending entries without prompting."""
+    import frontmatter
+
+    from creek.models import Fragment, FragmentSource, SourcePlatform
+
+    vault = tmp_path / "vault"
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True)
+    fragment = Fragment(
+        id="frag-pending00000",
+        title="Need a human eye",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = fragments_dir / "pending.md"
+    file.write_text(
+        frontmatter.dumps(
+            frontmatter.Post(content="body", **fragment.model_dump(mode="json")),
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["review", "--vault", str(vault), "--list"])
+    assert result.exit_code == 0, result.output
+    assert "Need a human eye" in result.output
+
+
+def test_process_aborts_when_consent_declined(tmp_path: Path) -> None:
+    """Declining the consent prompt aborts the pipeline non-zero."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "note.md").write_text("Just a note.\n")
+    vault = tmp_path / "vault"
+    for d in ("00-Creek-Meta", "01-Fragments", "02-Threads", "03-Eddies"):
+        (vault / d).mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        ["process", "--source", str(src), "--vault", str(vault)],
+    )
+    # Non-interactive shell with no consent on file: exit 1.
+    assert result.exit_code == 1
+    assert "consent" in result.output.lower() or "Non-interactive" in result.output
+
+
+def test_process_records_consent_with_yes_flag(tmp_path: Path) -> None:
+    """``--yes`` records consent so a second run no longer prompts."""
+    import json
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "note.md").write_text("Body\n")
+    vault = tmp_path / "vault"
+    for d in ("00-Creek-Meta", "01-Fragments", "02-Threads", "03-Eddies"):
+        (vault / d).mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        ["process", "--source", str(src), "--vault", str(vault), "--yes"],
+    )
+    assert result.exit_code == 0, result.output
+
+    log_file = vault / "00-Creek-Meta" / "Processing-Log" / "consent-log.json"
+    assert log_file.exists()
+    data = json.loads(log_file.read_text(encoding="utf-8"))
+    records = data["records"]
+    assert any(r["source_path"] == str(src) for r in records)
+
+
+def test_process_aborts_on_unresolved_redactions(tmp_path: Path) -> None:
+    """``creek process`` exits 1 with a remediation hint when secrets exist."""
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "leaky.md").write_text("Email me at user@example.com\n")
+    vault = tmp_path / "vault"
+    for d in ("00-Creek-Meta", "01-Fragments", "02-Threads", "03-Eddies"):
+        (vault / d).mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        ["process", "--source", str(src), "--vault", str(vault), "--yes"],
+    )
+    assert result.exit_code == 1
+    # rich's console may soft-wrap the remediation hint, so match the parts
+    # individually rather than the literal full command.
+    output = result.output.lower()
+    assert "redact" in output
+    assert "apply" in output
+
+
+def test_review_accept_writes_manual(tmp_path: Path) -> None:
+    """Accepting an entry stamps ``classification_method: manual``."""
+    import frontmatter
+
+    from creek.models import Fragment, FragmentSource, SourcePlatform
+
+    vault = tmp_path / "vault"
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True)
+    fragment = Fragment(
+        id="frag-accept000000",
+        title="Accept me",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = fragments_dir / "accept.md"
+    file.write_text(
+        frontmatter.dumps(
+            frontmatter.Post(content="body", **fragment.model_dump(mode="json")),
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["review", "--vault", str(vault)],
+        input="a\n",
+    )
+    assert result.exit_code == 0, result.output
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "manual"
 
 
 def test_purge_help() -> None:

--- a/creek-tools/tests/test_link_engine.py
+++ b/creek-tools/tests/test_link_engine.py
@@ -64,6 +64,36 @@ def test_run_link_embeddings_writes_cache(tmp_path: Path) -> None:
     assert cache_path.exists()
 
 
+def test_run_link_embeddings_save_oserror_does_not_crash(
+    tmp_path: Path,
+) -> None:
+    """An OSError while persisting the cache must not propagate."""
+    from unittest.mock import patch
+
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-saveerr00000",
+        title="Save error",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    with patch(
+        "creek.link.embeddings.EmbeddingLinker.save_embeddings",
+        side_effect=OSError("disk full"),
+    ):
+        summary = run_link(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="embeddings",
+            rebuild=False,
+        )
+
+    # Linking still completes; the lost cache only costs a recompute
+    # on the next run.
+    assert summary.fragment_count == 1
+
+
 def test_run_link_temporal_returns_link_count(tmp_path: Path) -> None:
     """Temporal linker returns a numeric count for the CLI."""
     vault = tmp_path / "vault"

--- a/creek-tools/tests/test_link_engine.py
+++ b/creek-tools/tests/test_link_engine.py
@@ -43,6 +43,32 @@ def test_run_link_rebuild_clears_cache(tmp_path: Path) -> None:
     assert not cache_path.exists()
 
 
+def test_run_link_rebuild_is_noop_for_temporal(tmp_path: Path) -> None:
+    """``--rebuild`` must not delete the cache when method != embeddings.
+
+    ``--rebuild`` is documented as "invalidate the embeddings cache".
+    Running it under ``--method temporal`` previously also blew away
+    the cache as a side effect; that's the regression being pinned
+    here.
+    """
+    vault = tmp_path / "vault"
+    cache_dir = vault / "00-Creek-Meta"
+    cache_dir.mkdir(parents=True)
+    cache_path = cache_dir / "embeddings.npz"
+    sentinel = b"keep-me"
+    cache_path.write_bytes(sentinel)
+    (vault / "01-Fragments").mkdir(parents=True)
+
+    run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="temporal",
+        rebuild=True,
+    )
+    assert cache_path.exists()
+    assert cache_path.read_bytes() == sentinel
+
+
 def test_run_link_embeddings_writes_cache(tmp_path: Path) -> None:
     """Embeddings are persisted to the on-disk cache after a run."""
     vault = tmp_path / "vault"

--- a/creek-tools/tests/test_link_engine.py
+++ b/creek-tools/tests/test_link_engine.py
@@ -1,0 +1,171 @@
+"""Tests for the vault-driven linking engine."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.config import CreekConfig
+from creek.link.link_engine import run_link
+from creek.models import Fragment, FragmentSource, SourcePlatform
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_fragment(
+    *,
+    vault: Path,
+    fragment: Fragment,
+    body: str,
+) -> Path:
+    """Persist *fragment* under ``<vault>/01-Fragments/Notes`` for linking.
+
+    Args:
+        vault: Vault root.
+        fragment: Fragment metadata to persist.
+        body: Markdown body for the file.
+
+    Returns:
+        Path to the written fragment.
+    """
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True, exist_ok=True)
+    metadata = fragment.model_dump(mode="json")
+    path = fragments_dir / f"{fragment.id}.md"
+    path.write_text(
+        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_run_link_zero_for_empty_vault(tmp_path: Path) -> None:
+    """An empty vault returns zero counts without raising."""
+    summary = run_link(
+        vault_path=tmp_path / "vault",
+        config=CreekConfig(),
+        method="embeddings",
+        rebuild=False,
+    )
+    assert summary.fragment_count == 0
+    assert summary.link_count == 0
+
+
+def test_run_link_rebuild_clears_cache(tmp_path: Path) -> None:
+    """``rebuild=True`` removes any pre-existing embeddings archive."""
+    vault = tmp_path / "vault"
+    cache_dir = vault / "00-Creek-Meta"
+    cache_dir.mkdir(parents=True)
+    cache_path = cache_dir / "embeddings.npz"
+    cache_path.write_bytes(b"stale-cache")
+    (vault / "01-Fragments").mkdir(parents=True)
+
+    run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="embeddings",
+        rebuild=True,
+    )
+    assert not cache_path.exists()
+
+
+def test_run_link_embeddings_writes_cache(tmp_path: Path) -> None:
+    """Embeddings are persisted to the on-disk cache after a run."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-cache0000000",
+        title="Test fragment",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    summary = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="embeddings",
+        rebuild=False,
+    )
+    assert summary.fragment_count == 1
+    cache_path = vault / "00-Creek-Meta" / "embeddings.npz"
+    assert cache_path.exists()
+
+
+def test_run_link_temporal_returns_link_count(tmp_path: Path) -> None:
+    """Temporal linker returns a numeric count for the CLI."""
+    vault = tmp_path / "vault"
+    for i in range(2):
+        _write_fragment(
+            vault=vault,
+            fragment=Fragment(
+                id=f"frag-temporal0{i:03d}",
+                title=f"Note {i}",
+                source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+            ),
+            body="body",
+        )
+
+    summary = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="temporal",
+        rebuild=False,
+    )
+    assert summary.fragment_count == 2
+    assert summary.link_count >= 0
+
+
+def test_run_link_eddies_returns_cluster_count(tmp_path: Path) -> None:
+    """Eddy linker reports cluster count, regardless of size."""
+    vault = tmp_path / "vault"
+    for i in range(3):
+        _write_fragment(
+            vault=vault,
+            fragment=Fragment(
+                id=f"frag-eddy00000{i:03d}",
+                title=f"Eddy member {i}",
+                source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+            ),
+            body="body",
+        )
+
+    summary = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="eddies",
+        rebuild=False,
+    )
+    assert summary.fragment_count == 3
+    assert summary.link_count >= 0
+
+
+def test_run_link_uses_existing_cache(tmp_path: Path) -> None:
+    """A second run reuses the cached embeddings archive."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-cachehit0000",
+        title="Reused fragment",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="embeddings",
+        rebuild=False,
+    )
+    cache_path = vault / "00-Creek-Meta" / "embeddings.npz"
+    first_mtime = cache_path.stat().st_mtime
+
+    run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="embeddings",
+        rebuild=False,
+    )
+    # Cache may be re-saved (timestamp can differ) but content should
+    # at least still exist.
+    assert cache_path.exists()
+    assert cache_path.stat().st_mtime >= first_mtime

--- a/creek-tools/tests/test_link_engine.py
+++ b/creek-tools/tests/test_link_engine.py
@@ -4,41 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import frontmatter
-
 from creek.config import CreekConfig
 from creek.link.link_engine import run_link
 from creek.models import Fragment, FragmentSource, SourcePlatform
+from tests.helpers import write_fragment_file as _write_fragment
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-def _write_fragment(
-    *,
-    vault: Path,
-    fragment: Fragment,
-    body: str,
-) -> Path:
-    """Persist *fragment* under ``<vault>/01-Fragments/Notes`` for linking.
-
-    Args:
-        vault: Vault root.
-        fragment: Fragment metadata to persist.
-        body: Markdown body for the file.
-
-    Returns:
-        Path to the written fragment.
-    """
-    fragments_dir = vault / "01-Fragments" / "Notes"
-    fragments_dir.mkdir(parents=True, exist_ok=True)
-    metadata = fragment.model_dump(mode="json")
-    path = fragments_dir / f"{fragment.id}.md"
-    path.write_text(
-        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
-        encoding="utf-8",
-    )
-    return path
 
 
 def test_run_link_zero_for_empty_vault(tmp_path: Path) -> None:
@@ -141,7 +113,15 @@ def test_run_link_eddies_returns_cluster_count(tmp_path: Path) -> None:
 
 
 def test_run_link_uses_existing_cache(tmp_path: Path) -> None:
-    """A second run reuses the cached embeddings archive."""
+    """A second run reuses the cached embeddings archive without re-encoding.
+
+    The mtime check on its own is a tautology (mtime can only grow). The
+    real invariant is that the embedding model is *not* re-invoked when
+    the cache covers every fragment ID — patching ``encode`` and
+    asserting it is never called proves the cache hit.
+    """
+    from unittest.mock import patch
+
     vault = tmp_path / "vault"
     fragment = Fragment(
         id="frag-cachehit0000",
@@ -157,15 +137,25 @@ def test_run_link_uses_existing_cache(tmp_path: Path) -> None:
         rebuild=False,
     )
     cache_path = vault / "00-Creek-Meta" / "embeddings.npz"
-    first_mtime = cache_path.stat().st_mtime
-
-    run_link(
-        vault_path=vault,
-        config=CreekConfig(),
-        method="embeddings",
-        rebuild=False,
-    )
-    # Cache may be re-saved (timestamp can differ) but content should
-    # at least still exist.
     assert cache_path.exists()
-    assert cache_path.stat().st_mtime >= first_mtime
+    cached_bytes = cache_path.read_bytes()
+
+    with patch(
+        "creek.link.embeddings.EmbeddingLinker.generate_embeddings",
+        wraps=lambda *_args, **_kw: {},
+    ) as mock_generate:
+        run_link(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="embeddings",
+            rebuild=False,
+        )
+
+    # The second run still calls ``generate_embeddings`` (so unseen
+    # fragments would be picked up), but it must short-circuit because
+    # ``existing_ids`` covers every fragment we just embedded.
+    mock_generate.assert_called_once()
+    _, called_kwargs = mock_generate.call_args
+    assert fragment.id in called_kwargs["existing_ids"]
+    # And the cache content must be preserved across the round-trip.
+    assert cache_path.read_bytes() == cached_bytes

--- a/creek-tools/tests/test_pipeline.py
+++ b/creek-tools/tests/test_pipeline.py
@@ -250,12 +250,48 @@ class TestPipelineStages:
             pipeline.run(source_path=source_path, vault_path=vault_path)
             mock_scan.assert_called_once_with(source_path)
 
-    def test_redaction_logs_when_matches_found(self, vault_path, tmp_path):
-        """Test that redaction scan logs findings when PII is detected."""
+    def test_redaction_dry_run_continues_when_matches_found(
+        self,
+        vault_path,
+        tmp_path,
+    ):
+        """Dry-run scan logs findings but lets the pipeline continue."""
+        config = CreekConfig()
+        config.redaction.dry_run = True
+        src = tmp_path / "pii_source"
+        src.mkdir()
+        (src / "contact.md").write_text("Email me at user@example.com")
+
+        pipeline = Pipeline(config=config)
+        result = pipeline.run(source_path=src, vault_path=vault_path)
+        assert result.files_scanned == 1
+
+    def test_redaction_fails_loud_when_matches_found(
+        self,
+        vault_path,
+        tmp_path,
+    ):
+        """When matches exist and dry_run is false, the pipeline aborts."""
+        from creek.pipeline import RedactionRequiredError
+
         config = CreekConfig()
         src = tmp_path / "pii_source"
         src.mkdir()
         (src / "contact.md").write_text("Email me at user@example.com")
+
+        pipeline = Pipeline(config=config)
+        with pytest.raises(RedactionRequiredError) as excinfo:
+            pipeline.run(source_path=src, vault_path=vault_path)
+
+        assert excinfo.value.match_count >= 1
+        assert "creek redact --apply" in str(excinfo.value)
+
+    def test_redaction_clean_source_continues(self, vault_path, tmp_path):
+        """A source with no matches should run end-to-end."""
+        config = CreekConfig()
+        src = tmp_path / "clean_source"
+        src.mkdir()
+        (src / "ok.md").write_text("Just notes — no secrets here.")
 
         pipeline = Pipeline(config=config)
         result = pipeline.run(source_path=src, vault_path=vault_path)
@@ -448,6 +484,7 @@ class TestPipelineErrorSurfacing:
                     str(source_path),
                     "--vault",
                     str(vault_path),
+                    "--yes",
                 ],
             )
         assert result.exit_code == 0
@@ -610,6 +647,7 @@ class TestCLIProcess:
                 str(source_path),
                 "--vault",
                 str(vault_path),
+                "--yes",
             ],
         )
         assert result.exit_code == 0
@@ -630,6 +668,7 @@ class TestCLIProcess:
                 str(source_path),
                 "--vault",
                 str(vault_path),
+                "--yes",
             ],
         )
         assert result.exit_code == 0
@@ -858,3 +897,128 @@ class TestPipelineConsent:
         cm = ConsentManager(log_dir=log_dir)
         pipeline = Pipeline(config=config, consent_manager=cm)
         assert pipeline.consent_manager is cm
+
+
+# ---------------------------------------------------------------------------
+# BUG-003: classification gating on confidence threshold
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineClassificationGating:
+    """Tests that LLM classification only runs when rules are uncertain."""
+
+    def _make_ingested(
+        self,
+        platform: str = "markdown",
+        title: str = "Mock note",
+    ):
+        """Return a single ``IngestedFragment`` with the given source platform."""
+        from creek.ingest.base import IngestedFragment
+        from creek.models import Fragment, FragmentSource, SourcePlatform
+
+        fragment = Fragment(
+            id="frag-test12345678",
+            title=title,
+            source=FragmentSource(platform=SourcePlatform(platform)),
+        )
+        return IngestedFragment(fragment=fragment, body="body text")
+
+    def test_high_confidence_skips_llm(self, config, vault_path):
+        """If rules give high confidence, LLM is not invoked."""
+        pipeline = Pipeline(config=config)
+        item = self._make_ingested()
+
+        with (
+            patch.object(
+                pipeline.rule_classifier,
+                "classify",
+                side_effect=lambda f, content="": f.model_copy(
+                    update={
+                        "frequency": f.frequency.model_copy(
+                            update={"primary": "F5"},
+                        ),
+                    },
+                ),
+            ),
+            patch.object(
+                pipeline.rule_classifier,
+                "confidence_score",
+                return_value=0.95,
+            ),
+            patch.object(pipeline.llm_classifier, "classify") as mock_llm,
+        ):
+            pipeline._run_classification([item], vault_path, PipelineResult())
+
+        mock_llm.assert_not_called()
+
+    def test_low_confidence_invokes_llm(self, config, vault_path):
+        """If rules give low confidence, LLM is invoked."""
+        pipeline = Pipeline(config=config)
+        item = self._make_ingested()
+
+        with (
+            patch.object(
+                pipeline.rule_classifier,
+                "classify",
+                side_effect=lambda f, content="": f.model_copy(
+                    update={
+                        "frequency": f.frequency.model_copy(
+                            update={"primary": "F5"},
+                        ),
+                    },
+                ),
+            ),
+            patch.object(
+                pipeline.rule_classifier,
+                "confidence_score",
+                return_value=0.1,
+            ),
+            patch.object(
+                pipeline.llm_classifier,
+                "classify",
+                side_effect=lambda f, content="": f,
+            ) as mock_llm,
+        ):
+            pipeline._run_classification([item], vault_path, PipelineResult())
+
+        mock_llm.assert_called_once()
+
+    def test_unclassified_invokes_llm(self, config, vault_path):
+        """If rules leave fragment unclassified, LLM is invoked."""
+        pipeline = Pipeline(config=config)
+        item = self._make_ingested()
+
+        with (
+            patch.object(
+                pipeline.rule_classifier,
+                "classify",
+                side_effect=lambda f, content="": f,
+            ),
+            patch.object(
+                pipeline.llm_classifier,
+                "classify",
+                side_effect=lambda f, content="": f,
+            ) as mock_llm,
+        ):
+            pipeline._run_classification([item], vault_path, PipelineResult())
+
+        mock_llm.assert_called_once()
+
+    def test_human_review_source_skips_llm(self, vault_path):
+        """Sources in human_review_sources never reach the LLM."""
+        config = CreekConfig()
+        config.classification.human_review_sources = ["journal"]
+        pipeline = Pipeline(config=config)
+        item = self._make_ingested(platform="journal")
+
+        with (
+            patch.object(
+                pipeline.rule_classifier,
+                "classify",
+                side_effect=lambda f, content="": f,
+            ),
+            patch.object(pipeline.llm_classifier, "classify") as mock_llm,
+        ):
+            pipeline._run_classification([item], vault_path, PipelineResult())
+
+        mock_llm.assert_not_called()

--- a/creek-tools/tests/test_review_runner.py
+++ b/creek-tools/tests/test_review_runner.py
@@ -226,6 +226,41 @@ def test_run_interactive_override_accepts_uppercase_unclassified(
     assert reloaded["frequency"]["primary"] == "unclassified"
 
 
+def test_run_interactive_persist_oserror_records_error(tmp_path: Path) -> None:
+    """A disk error during ``_persist_manual`` is captured, not propagated.
+
+    Without this guard a disk-full or permission-denied write mid
+    review session would surface as a raw traceback at the CLI;
+    instead it must be recorded on ``ReviewSummary.errors`` so the
+    operator can fix the underlying problem and resume.
+    """
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-saveerr00001",
+        title="Save error",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    runner = ReviewQueueRunner(vault_path=vault, console=Console())
+    pending = runner.list_pending()
+
+    with (
+        patch(
+            "creek.classify.review_runner._persist_manual",
+            side_effect=OSError("disk full"),
+        ),
+        patch("typer.prompt", return_value="a"),
+    ):
+        summary = runner.run_interactive(pending)
+
+    # The accept counter does NOT increment when persistence fails —
+    # only successful writes count toward ``accepted``.
+    assert summary.accepted == 0
+    assert len(summary.errors) == 1
+    assert "disk full" in summary.errors[0]
+
+
 def test_format_review_summary_contains_id(tmp_path: Path) -> None:
     """The single-line summary surfaces the fragment ID for the operator."""
     vault = tmp_path / "vault"

--- a/creek-tools/tests/test_review_runner.py
+++ b/creek-tools/tests/test_review_runner.py
@@ -180,6 +180,52 @@ def test_run_interactive_override_with_unknown_frequency_defers(
     assert reloaded.get("classification_method") != "manual"
 
 
+def test_parse_frequency_input_accepts_case_variants() -> None:
+    """``_parse_frequency_input`` is case-insensitive across the enum."""
+    from creek.classify.review_runner import _parse_frequency_input
+
+    assert _parse_frequency_input("F1") == Frequency.F1
+    assert _parse_frequency_input("f1") == Frequency.F1
+    assert _parse_frequency_input("  F10  ") == Frequency.F10
+    assert _parse_frequency_input("unclassified") == Frequency.UNCLASSIFIED
+    assert _parse_frequency_input("UNCLASSIFIED") == Frequency.UNCLASSIFIED
+    assert _parse_frequency_input("Unclassified") == Frequency.UNCLASSIFIED
+
+
+def test_parse_frequency_input_rejects_unknown() -> None:
+    """Unknown values return ``None`` rather than raising."""
+    from creek.classify.review_runner import _parse_frequency_input
+
+    assert _parse_frequency_input("magenta") is None
+    assert _parse_frequency_input("F11") is None
+    assert _parse_frequency_input("") is None
+
+
+def test_run_interactive_override_accepts_uppercase_unclassified(
+    tmp_path: Path,
+) -> None:
+    """Operators typing ``UNCLASSIFIED`` should not silently get deferred."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-uncl00000001",
+        title="Uppercase unclassified",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        frequency=FrequencyClassification(primary=Frequency.F5),
+    )
+    file = _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    runner = ReviewQueueRunner(vault_path=vault, console=Console())
+    pending = runner.list_pending()
+
+    with patch("typer.prompt", side_effect=["o", "UNCLASSIFIED"]):
+        summary = runner.run_interactive(pending)
+
+    assert summary.overridden == 1
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "manual"
+    assert reloaded["frequency"]["primary"] == "unclassified"
+
+
 def test_format_review_summary_contains_id(tmp_path: Path) -> None:
     """The single-line summary surfaces the fragment ID for the operator."""
     vault = tmp_path / "vault"

--- a/creek-tools/tests/test_review_runner.py
+++ b/creek-tools/tests/test_review_runner.py
@@ -1,0 +1,227 @@
+"""Tests for the interactive review queue runner."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import frontmatter
+from rich.console import Console
+
+from creek.classify.review_runner import (
+    ReviewQueueRunner,
+    format_review_summary,
+)
+from creek.models import (
+    Confidence,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    SourcePlatform,
+    VoiceClassification,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_fragment(
+    *,
+    vault: Path,
+    fragment: Fragment,
+    body: str,
+    method: str | None = None,
+) -> Path:
+    """Persist *fragment* in the vault for review.
+
+    Args:
+        vault: Vault root.
+        fragment: Fragment metadata to persist.
+        body: Markdown body to retain on disk.
+        method: Optional ``classification_method`` to stamp.
+
+    Returns:
+        Path to the written fragment.
+    """
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True, exist_ok=True)
+    metadata = fragment.model_dump(mode="json")
+    if method is not None:
+        metadata["classification_method"] = method
+    path = fragments_dir / f"{fragment.id}.md"
+    path.write_text(
+        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_list_pending_returns_only_review_candidates(tmp_path: Path) -> None:
+    """Confident, manual-stamped fragments are not in the queue."""
+    vault = tmp_path / "vault"
+
+    confident = Fragment(
+        id="frag-confident0001",
+        title="Confident",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        frequency=FrequencyClassification(primary=Frequency.F5),
+        voice=VoiceClassification(confidence=Confidence.SETTLED),
+    )
+    _write_fragment(vault=vault, fragment=confident, body="body")
+
+    pending = Fragment(
+        id="frag-pending00001",
+        title="Pending",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(vault=vault, fragment=pending, body="body")
+
+    runner = ReviewQueueRunner(vault_path=vault, console=Console())
+    queue = runner.list_pending()
+    titles = {entry.fragment.title for entry in queue}
+    assert "Pending" in titles
+    assert "Confident" not in titles
+
+
+def test_list_pending_skips_manual(tmp_path: Path) -> None:
+    """Already-resolved (``manual``) fragments are excluded from the queue."""
+    vault = tmp_path / "vault"
+
+    fragment = Fragment(
+        id="frag-resolved0001",
+        title="Resolved",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(vault=vault, fragment=fragment, body="body", method="manual")
+
+    runner = ReviewQueueRunner(vault_path=vault, console=Console())
+    assert runner.list_pending() == []
+
+
+def test_run_interactive_accept_persists_manual(tmp_path: Path) -> None:
+    """Choosing ``accept`` rewrites the file with manual provenance."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-acceptme0001",
+        title="Accept me",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    runner = ReviewQueueRunner(vault_path=vault, console=Console())
+    pending = runner.list_pending()
+
+    with patch("typer.prompt", return_value="a"):
+        summary = runner.run_interactive(pending)
+
+    assert summary.accepted == 1
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "manual"
+
+
+def test_run_interactive_defer_leaves_file(tmp_path: Path) -> None:
+    """``defer`` is a no-op for the file."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-deferme00001",
+        title="Defer me",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    runner = ReviewQueueRunner(vault_path=vault, console=Console())
+    pending = runner.list_pending()
+    before = file.read_text(encoding="utf-8")
+
+    with patch("typer.prompt", return_value="d"):
+        summary = runner.run_interactive(pending)
+
+    assert summary.deferred == 1
+    assert file.read_text(encoding="utf-8") == before
+
+
+def test_run_interactive_quit_breaks_loop(tmp_path: Path) -> None:
+    """``quit`` aborts the loop without touching remaining files."""
+    vault = tmp_path / "vault"
+    for i in range(2):
+        _write_fragment(
+            vault=vault,
+            fragment=Fragment(
+                id=f"frag-quitme0000{i:02d}",
+                title=f"Quit {i}",
+                source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+            ),
+            body="body",
+        )
+
+    runner = ReviewQueueRunner(vault_path=vault, console=Console())
+    pending = runner.list_pending()
+
+    with patch("typer.prompt", return_value="q"):
+        summary = runner.run_interactive(pending)
+
+    assert summary.accepted == 0
+    assert summary.overridden == 0
+
+
+def test_run_interactive_override_writes_new_frequency(tmp_path: Path) -> None:
+    """``override`` collects a frequency and persists the change."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-override0001",
+        title="Override me",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    runner = ReviewQueueRunner(vault_path=vault, console=Console())
+    pending = runner.list_pending()
+
+    with patch("typer.prompt", side_effect=["o", "F5"]):
+        summary = runner.run_interactive(pending)
+
+    assert summary.overridden == 1
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "manual"
+    assert reloaded["frequency"]["primary"] == "F5"
+
+
+def test_run_interactive_override_with_unknown_frequency_defers(
+    tmp_path: Path,
+) -> None:
+    """A bad ``override`` value defers the fragment and prints a warning."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-overridebad01",
+        title="Bad override",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    runner = ReviewQueueRunner(vault_path=vault, console=Console())
+    pending = runner.list_pending()
+
+    with patch("typer.prompt", side_effect=["o", "magenta"]):
+        summary = runner.run_interactive(pending)
+
+    assert summary.deferred == 1
+    reloaded = frontmatter.load(str(file))
+    assert reloaded.get("classification_method") != "manual"
+
+
+def test_format_review_summary_contains_id(tmp_path: Path) -> None:
+    """The single-line summary surfaces the fragment ID for the operator."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-fmtsummary001",
+        title="Format me",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    runner = ReviewQueueRunner(vault_path=vault, console=Console())
+    pending = runner.list_pending()
+    text = format_review_summary(pending[0])
+    assert "frag-fmtsummary001" in text
+    assert "Format me" in text

--- a/creek-tools/tests/test_review_runner.py
+++ b/creek-tools/tests/test_review_runner.py
@@ -21,40 +21,10 @@ from creek.models import (
     SourcePlatform,
     VoiceClassification,
 )
+from tests.helpers import write_fragment_file as _write_fragment
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-
-def _write_fragment(
-    *,
-    vault: Path,
-    fragment: Fragment,
-    body: str,
-    method: str | None = None,
-) -> Path:
-    """Persist *fragment* in the vault for review.
-
-    Args:
-        vault: Vault root.
-        fragment: Fragment metadata to persist.
-        body: Markdown body to retain on disk.
-        method: Optional ``classification_method`` to stamp.
-
-    Returns:
-        Path to the written fragment.
-    """
-    fragments_dir = vault / "01-Fragments" / "Notes"
-    fragments_dir.mkdir(parents=True, exist_ok=True)
-    metadata = fragment.model_dump(mode="json")
-    if method is not None:
-        metadata["classification_method"] = method
-    path = fragments_dir / f"{fragment.id}.md"
-    path.write_text(
-        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
-        encoding="utf-8",
-    )
-    return path
 
 
 def test_list_pending_returns_only_review_candidates(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_vault_reader.py
+++ b/creek-tools/tests/test_vault_reader.py
@@ -1,0 +1,88 @@
+"""Tests for the shared vault fragment reader."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.models import Fragment, FragmentSource, SourcePlatform
+from creek.vault.reader import iter_vault_fragments, try_load_fragment
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_try_load_fragment_returns_triple(tmp_path: Path) -> None:
+    """Valid fragments come back as ``(fragment, body, raw_metadata)``."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-readok000001",
+        title="Readable",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = write_fragment_file(vault=vault, fragment=fragment, body="hello")
+
+    record = try_load_fragment(file)
+    assert record is not None
+    loaded_fragment, body, raw = record
+    assert loaded_fragment.id == fragment.id
+    assert body.strip() == "hello"
+    assert raw["type"] == "fragment"
+
+
+def test_try_load_fragment_returns_none_for_non_fragment(tmp_path: Path) -> None:
+    """A markdown file without ``type: fragment`` is skipped silently."""
+    file = tmp_path / "note.md"
+    file.write_text("---\nnot: a fragment\n---\nplain body\n", encoding="utf-8")
+
+    assert try_load_fragment(file) is None
+
+
+def test_try_load_fragment_returns_none_for_invalid_schema(tmp_path: Path) -> None:
+    """Files claiming ``type: fragment`` but missing required keys skip silently."""
+    file = tmp_path / "broken.md"
+    file.write_text(
+        "---\ntype: fragment\nid: frag-broken000001\n---\nbody\n",
+        encoding="utf-8",
+    )
+
+    # The Fragment schema requires ``title`` and ``source``; this entry
+    # has neither, so model validation fails and we get ``None`` rather
+    # than a raised exception.
+    assert try_load_fragment(file) is None
+
+
+def test_try_load_fragment_propagates_oserror(tmp_path: Path) -> None:
+    """Real I/O failures propagate so the caller can surface them."""
+    missing = tmp_path / "does-not-exist.md"
+    with pytest.raises(OSError):
+        try_load_fragment(missing)
+
+
+def test_iter_vault_fragments_skips_non_fragments(tmp_path: Path) -> None:
+    """``iter_vault_fragments`` returns only valid Creek fragments."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-mixed000001",
+        title="Real one",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    write_fragment_file(vault=vault, fragment=fragment, body="body")
+
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    (fragments_dir / "plain.md").write_text("# Just a note\n", encoding="utf-8")
+    (fragments_dir / "broken-yaml.md").write_text(
+        "---\nbroken: [\n",
+        encoding="utf-8",
+    )
+
+    records = iter_vault_fragments(vault / "01-Fragments")
+    titles = [record[1].title for record in records]
+    assert titles == ["Real one"]
+
+
+def test_iter_vault_fragments_returns_empty_for_missing_root(tmp_path: Path) -> None:
+    """Missing ``01-Fragments`` returns an empty list, not an error."""
+    assert iter_vault_fragments(tmp_path / "no-such-dir") == []


### PR DESCRIPTION
Replaces the four CLI stubs (ingest/classify/link/review) with real
engine wiring, gates `process` and `ingest` on per-source consent, and
fixes two pipeline correctness bugs the launch was leaking through.

* BUG-003 — `Pipeline._run_classification` now invokes the LLM only
  when the rule classifier left the fragment unclassified or below
  `ClassificationConfig.confidence_threshold`. Sources in
  `human_review_sources` skip the LLM entirely and route to the review
  queue.

* BUG-004 — `Pipeline._run_redaction` is fail-loud: when matches exist
  and `redaction.dry_run` is false the pipeline raises
  `RedactionRequiredError` and refuses to ingest. Documented in
  `docs/redaction.md`. Pinned by an e2e test that previously xfailed.

* INC-001 — `creek ingest --type --input --vault` resolves the
  registry, runs the matching ingestor, and writes idempotently via
  `VaultWriter`. `creek classify` and `creek link` load fragments from
  `<vault>/01-Fragments/`, dispatch on `--method`, and persist back to
  frontmatter (new engines: `creek/classify/classify_engine.py`,
  `creek/link/link_engine.py`).

* INC-002 — `creek review` walks the queue with an
  accept/override/defer/quit prompt, persisting decisions as
  `classification_method: manual` plus a `classified_at` timestamp
  (new runner: `creek/classify/review_runner.py`).

* INC-010 — `creek process` and `creek ingest` instantiate a
  `ConsentManager` rooted at `<vault>/00-Creek-Meta/Processing-Log/`
  and prompt for first-time consent. `--yes` skips the prompt and is
  recorded in the consent log. Non-interactive callers without
  `--yes` and prior consent abort exit 1 with a clear message.

* INC-011 — `creek classify --force` overrides
  `classification_method: manual`; `creek link --rebuild` deletes the
  cached embeddings archive at `<vault>/00-Creek-Meta/embeddings.npz`
  before recomputing.

Tests: 21 new engine tests + new CLI integration tests for ingest,
classify, link, review, consent gating, and redaction abort. The
previously-xfailing redaction e2e test is now strict and passing.

https://claude.ai/code/session_01Fxqhm2226mKAUJsFZDXYoE