### PR TITLE
feat: execute Batch C — audit and privacy substrate

### DIFF
--- a/creek-tools/creek/audit/__init__.py
+++ b/creek-tools/creek/audit/__init__.py
@@ -1,0 +1,15 @@
+"""Tamper-evident JSONL audit log substrate.
+
+The :class:`AuditLog` primitive backs every compliance log in the
+project — purge, redaction, privacy-tier overrides — by writing each
+entry as a single JSONL line with a sha256 hash chain so any post-hoc
+tampering can be detected via :meth:`AuditLog.verify`.
+
+Use the primitive via the per-domain wrappers (e.g.
+:class:`creek.purge.audit.PurgeAuditLog`); reach for :class:`AuditLog`
+directly only when introducing a new compliance log surface.
+"""
+
+from creek.audit.log import AuditChainBroken, AuditChainBrokenError, AuditLog
+
+__all__ = ["AuditChainBroken", "AuditChainBrokenError", "AuditLog"]

--- a/creek-tools/creek/audit/log.py
+++ b/creek-tools/creek/audit/log.py
@@ -212,6 +212,11 @@ class AuditLog:
         ):
             if _HAS_FCNTL:
                 fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            # Invariant: the flock above is acquired iff control reaches
+            # the ``try`` below. A failure of the ``flock`` call would
+            # raise out of the ``with`` block before ``finally`` runs,
+            # so the unlock there is the release for *this* lock — not
+            # for whatever happens to be locked at the OS level.
             try:
                 prev_hash = self._compute_prev_hash()
                 chained = {**payload, _PREV_HASH_FIELD: prev_hash}

--- a/creek-tools/creek/audit/log.py
+++ b/creek-tools/creek/audit/log.py
@@ -100,6 +100,13 @@ def _last_line(path: Path) -> str | None:
 class AuditLog:
     """Append-only JSONL log with a sha256 hash chain.
 
+    The instance caches the most recently written line's hash and the
+    file's post-write size so that repeated single-writer appends are
+    O(1) rather than O(N) — a regression flagged on PR #193 for the
+    vault writer's 10k-fragment ingest path. The cache is invalidated
+    transparently when a different process or instance grows the file
+    in between writes (size mismatch ⇒ rescan).
+
     Args:
         path: Filesystem path to the log file. Parent directories are
             created on first write.
@@ -108,6 +115,8 @@ class AuditLog:
     def __init__(self, path: Path) -> None:
         """Store the resolved log path; defer all I/O until first use."""
         self.path = path
+        self._cached_last_hash: str | None = None
+        self._cached_size: int | None = None
 
     def append(self, payload: dict[str, Any]) -> None:
         """Append *payload* as a JSON line, stamping in the chain hash.
@@ -134,14 +143,35 @@ class AuditLog:
             if _HAS_FCNTL:
                 fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
             try:
-                last = _last_line(self.path)
-                prev_hash = GENESIS_PREV_HASH if last is None else _hash_line(last)
+                prev_hash = self._compute_prev_hash()
                 chained = {**payload, _PREV_HASH_FIELD: prev_hash}
-                fh.write(json.dumps(chained, sort_keys=True) + "\n")
+                line = json.dumps(chained, sort_keys=True)
+                fh.write(line + "\n")
                 fh.flush()
+                self._cached_last_hash = _hash_line(line)
+                self._cached_size = self.path.stat().st_size
             finally:
                 if _HAS_FCNTL:
                     fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+    def _compute_prev_hash(self) -> str:
+        """Return the chain hash for the next append.
+
+        Uses the per-instance cache when the on-disk file size still
+        matches the size we last wrote; otherwise falls back to a full
+        ``_last_line`` rescan. The size check correctly invalidates the
+        cache when a different process or another :class:`AuditLog`
+        instance has appended in between.
+        """
+        on_disk_size = self.path.stat().st_size if self.path.exists() else 0
+        if (
+            self._cached_last_hash is not None
+            and self._cached_size == on_disk_size
+            and on_disk_size > 0
+        ):
+            return self._cached_last_hash
+        last = _last_line(self.path)
+        return GENESIS_PREV_HASH if last is None else _hash_line(last)
 
     def read(self) -> Iterator[dict[str, Any]]:
         """Yield every entry in the log as a dict, oldest first.

--- a/creek-tools/creek/audit/log.py
+++ b/creek-tools/creek/audit/log.py
@@ -13,11 +13,19 @@ Concurrency:
   freshly opened file descriptor for every append, so callers do not
   share state between processes.
 * Cross-thread safety is provided by a module-level ``threading.Lock``
-  keyed on the resolved log path, so multiple :class:`AuditLog`
-  instances that point at the same file still serialise correctly.
+  keyed on the **resolved** log path, so ``Path("audit.jsonl")`` and
+  ``Path("./audit.jsonl")`` correctly share a lock even though the raw
+  ``Path`` objects compare unequal.
 * On platforms without ``fcntl`` (notably Windows) only the in-process
   lock applies; cross-process concurrency falls back to "best effort"
   and callers must not run multiple processes against the same log.
+
+Durability: every successful ``append`` calls ``os.fsync`` on the file
+descriptor before releasing the flock, so a crash (power loss, OOM
+kill) immediately after ``append`` returns does not silently lose the
+last entry. For a tamper-evidence log a silent loss-without-detection
+is the worst failure mode; ``fsync`` makes the durability boundary
+explicit.
 
 The threat model is "careless or hostile editor", not "well-funded
 adversary"; the chain is integrity, not authentication. An attacker who
@@ -31,6 +39,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import threading
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
@@ -67,9 +76,18 @@ AuditChainBroken = AuditChainBrokenError
 
 
 def _thread_lock_for(path: Path) -> threading.Lock:
-    """Return the per-path lock used to serialise threaded appends."""
+    """Return the per-path lock used to serialise threaded appends.
+
+    The key is ``path.resolve()`` so that two :class:`AuditLog`
+    instances constructed with different representations of the same
+    file (``"audit.jsonl"`` vs ``"./audit.jsonl"`` vs an absolute path)
+    share the same lock. Without resolution the raw ``Path`` objects
+    compare unequal and would each get their own lock, silently
+    breaking cross-thread serialisation.
+    """
+    resolved = path.resolve(strict=False)
     with _THREAD_LOCKS_GUARD:
-        return _THREAD_LOCKS[path]
+        return _THREAD_LOCKS[resolved]
 
 
 def _hash_line(line: str) -> str:
@@ -148,6 +166,13 @@ class AuditLog:
                 line = json.dumps(chained, sort_keys=True)
                 fh.write(line + "\n")
                 fh.flush()
+                # fsync inside the flock window: the lock guarantees no
+                # other writer races us, and fsync guarantees the bytes
+                # are durable before we release the lock or return to
+                # the caller. Without fsync, a crash between flush and
+                # the OS's lazy writeback would silently drop the entry
+                # — the worst failure mode for a tamper-evidence log.
+                os.fsync(fh.fileno())
                 self._cached_last_hash = _hash_line(line)
                 self._cached_size = self.path.stat().st_size
             finally:

--- a/creek-tools/creek/audit/log.py
+++ b/creek-tools/creek/audit/log.py
@@ -1,0 +1,220 @@
+"""Append-only JSONL audit log with a sha256 hash chain and locking.
+
+Each appended entry is one JSON object on its own line; the object
+carries a ``prev_hash`` field equal to ``sha256`` of the previous line's
+bytes. The first line uses an all-zero genesis hash. Any post-hoc
+tampering — line removal, payload mutation, reordering — invalidates
+the chain and is surfaced by :meth:`AuditLog.verify` as an
+:class:`AuditChainBroken` exception.
+
+Concurrency:
+
+* Cross-process safety on POSIX is provided by ``fcntl.flock`` on a
+  freshly opened file descriptor for every append, so callers do not
+  share state between processes.
+* Cross-thread safety is provided by a module-level ``threading.Lock``
+  keyed on the resolved log path, so multiple :class:`AuditLog`
+  instances that point at the same file still serialise correctly.
+* On platforms without ``fcntl`` (notably Windows) only the in-process
+  lock applies; cross-process concurrency falls back to "best effort"
+  and callers must not run multiple processes against the same log.
+
+The threat model is "careless or hostile editor", not "well-funded
+adversary"; the chain is integrity, not authentication. An attacker who
+can rewrite the entire log can also recompute every hash. Real
+authentication would need an off-host signature, which this module
+intentionally does not provide.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import threading
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+try:
+    import fcntl
+
+    _HAS_FCNTL = True
+except ImportError:  # pragma: no cover - exercised only on Windows
+    fcntl = None  # type: ignore[assignment]
+    _HAS_FCNTL = False
+
+logger = logging.getLogger(__name__)
+
+GENESIS_PREV_HASH = "0" * 64
+"""Genesis hash for the first entry in a fresh chain."""
+
+_PREV_HASH_FIELD = "prev_hash"
+_THREAD_LOCKS: dict[Path, threading.Lock] = defaultdict(threading.Lock)
+_THREAD_LOCKS_GUARD = threading.Lock()
+
+
+class AuditChainBrokenError(Exception):
+    """Raised when :meth:`AuditLog.verify` detects tampering."""
+
+
+# Backward-compatible alias mirroring the spec example in
+# plans/prompts/2026-04-28/batch-C-audit-and-privacy-substrate.md.
+AuditChainBroken = AuditChainBrokenError
+
+
+def _thread_lock_for(path: Path) -> threading.Lock:
+    """Return the per-path lock used to serialise threaded appends."""
+    with _THREAD_LOCKS_GUARD:
+        return _THREAD_LOCKS[path]
+
+
+def _hash_line(line: str) -> str:
+    """Return the sha256 hex digest of *line* (no trailing newline)."""
+    return hashlib.sha256(line.encode("utf-8")).hexdigest()
+
+
+def _last_line(path: Path) -> str | None:
+    """Return the last non-empty line of *path*, or ``None`` when empty.
+
+    The implementation reads the whole file because audit logs are
+    append-only and the wall-clock cost is dominated by the lock and
+    fsync rather than the I/O. A future optimisation could ``seek`` to
+    the tail and walk backwards, but that adds branches without a
+    measured win for the entry sizes this module sees.
+    """
+    if not path.exists():
+        return None
+    raw = path.read_text(encoding="utf-8")
+    if not raw:
+        return None
+    lines = [line for line in raw.splitlines() if line]
+    if not lines:
+        return None
+    return lines[-1]
+
+
+class AuditLog:
+    """Append-only JSONL log with a sha256 hash chain.
+
+    Args:
+        path: Filesystem path to the log file. Parent directories are
+            created on first write.
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Store the resolved log path; defer all I/O until first use."""
+        self.path = path
+
+    def append(self, payload: dict[str, Any]) -> None:
+        """Append *payload* as a JSON line, stamping in the chain hash.
+
+        The caller MUST NOT supply a ``prev_hash`` field; the log owns
+        the chain so callers cannot accidentally break it. The append
+        is atomic per line on POSIX thanks to ``O_APPEND`` + flock.
+
+        Args:
+            payload: Caller-provided JSON-serialisable dict.
+
+        Raises:
+            ValueError: If *payload* contains a ``prev_hash`` key.
+        """
+        if _PREV_HASH_FIELD in payload:
+            msg = "payload must not include the reserved 'prev_hash' field"
+            raise ValueError(msg)
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        with (
+            _thread_lock_for(self.path),
+            self.path.open("a", encoding="utf-8") as fh,
+        ):
+            if _HAS_FCNTL:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            try:
+                last = _last_line(self.path)
+                prev_hash = GENESIS_PREV_HASH if last is None else _hash_line(last)
+                chained = {**payload, _PREV_HASH_FIELD: prev_hash}
+                fh.write(json.dumps(chained, sort_keys=True) + "\n")
+                fh.flush()
+            finally:
+                if _HAS_FCNTL:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+    def read(self) -> Iterator[dict[str, Any]]:
+        """Yield every entry in the log as a dict, oldest first.
+
+        Malformed lines are skipped (they would have been caught by
+        :meth:`verify` already); pure read-side iteration must remain
+        forgiving so consumers like dashboards can render whatever the
+        chain still contains.
+        """
+        if not self.path.exists():
+            return
+        with self.path.open("r", encoding="utf-8") as fh:
+            for raw_line in fh:
+                stripped = raw_line.rstrip("\n")
+                if not stripped:
+                    continue
+                try:
+                    yield json.loads(stripped)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Skipping malformed audit line in %s",
+                        self.path,
+                    )
+
+    def verify(self) -> None:
+        """Walk the chain and raise :class:`AuditChainBroken` on tampering.
+
+        A missing or empty log is considered trivially valid — there are
+        no entries to disagree about. A line that fails to parse as
+        JSON, a missing ``prev_hash`` field, or a mismatch against the
+        recomputed sha256 of the prior line all raise.
+        """
+        if not self.path.exists():
+            return
+        with self.path.open("r", encoding="utf-8") as fh:
+            previous_line: str | None = None
+            for index, raw_line in enumerate(fh):
+                stripped = raw_line.rstrip("\n")
+                if not stripped:
+                    continue
+                self._verify_line(stripped, previous_line, index)
+                previous_line = stripped
+
+    def _verify_line(
+        self,
+        line: str,
+        previous_line: str | None,
+        index: int,
+    ) -> None:
+        """Validate one chained line against its expected prev_hash.
+
+        Args:
+            line: The raw JSON line being validated.
+            previous_line: The full bytes of the prior chain line, or
+                ``None`` for the first entry.
+            index: Zero-based index of *line* in the file, used for
+                diagnostics in the raised exception.
+        """
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError as exc:
+            msg = f"Audit line {index} is not valid JSON"
+            raise AuditChainBrokenError(msg) from exc
+        if _PREV_HASH_FIELD not in entry:
+            msg = f"Audit line {index} is missing 'prev_hash'"
+            raise AuditChainBrokenError(msg)
+        expected = (
+            GENESIS_PREV_HASH if previous_line is None else _hash_line(previous_line)
+        )
+        if entry[_PREV_HASH_FIELD] != expected:
+            msg = (
+                f"Audit chain broken at line {index}: "
+                f"expected prev_hash {expected!r}, "
+                f"found {entry[_PREV_HASH_FIELD]!r}"
+            )
+            raise AuditChainBrokenError(msg)

--- a/creek-tools/creek/audit/log.py
+++ b/creek-tools/creek/audit/log.py
@@ -41,7 +41,7 @@ import json
 import logging
 import os
 import threading
-from collections import defaultdict
+import weakref
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -62,8 +62,43 @@ GENESIS_PREV_HASH = "0" * 64
 """Genesis hash for the first entry in a fresh chain."""
 
 _PREV_HASH_FIELD = "prev_hash"
-_THREAD_LOCKS: dict[Path, threading.Lock] = defaultdict(threading.Lock)
-_THREAD_LOCKS_GUARD = threading.Lock()
+
+
+class _LockHolder:
+    """Weakref-able container for a per-path :class:`threading.Lock`.
+
+    ``threading.Lock`` is a C-level object without a ``__weakref__``
+    slot, so it cannot be the value of a :class:`weakref.WeakValueDictionary`
+    directly. Wrapping it in a tiny Python object gives us the slot and
+    keeps the lock alive for as long as any :class:`AuditLog` instance
+    references the holder.
+    """
+
+    __slots__ = ("__weakref__", "lock")
+
+    def __init__(self) -> None:
+        """Initialise the holder with a fresh :class:`threading.Lock`."""
+        self.lock = threading.Lock()
+
+
+_THREAD_LOCK_HOLDERS: weakref.WeakValueDictionary[Path, _LockHolder] = (
+    weakref.WeakValueDictionary()
+)
+"""Per-resolved-path lock holders.
+
+A :class:`weakref.WeakValueDictionary` so holders (and the locks they
+own) can be reclaimed once no live :class:`AuditLog` references the
+holder for a given path. Long-running daemons writing to many distinct
+log paths therefore do not accumulate dead lock entries; the test
+suite, where each ``tmp_path`` is unique, also stays bounded across
+runs.
+
+Each :class:`AuditLog` keeps a strong reference to its holder via
+``AuditLog._lock_holder`` so the dict entry is pinned for the
+instance's lifetime even when no append is currently in flight.
+"""
+
+_THREAD_LOCK_HOLDERS_GUARD = threading.Lock()
 
 
 class AuditChainBrokenError(Exception):
@@ -75,19 +110,28 @@ class AuditChainBrokenError(Exception):
 AuditChainBroken = AuditChainBrokenError
 
 
-def _thread_lock_for(path: Path) -> threading.Lock:
-    """Return the per-path lock used to serialise threaded appends.
+def _thread_lock_holder_for(path: Path) -> _LockHolder:
+    """Return the per-path lock holder used to serialise threaded appends.
 
     The key is ``path.resolve()`` so that two :class:`AuditLog`
     instances constructed with different representations of the same
     file (``"audit.jsonl"`` vs ``"./audit.jsonl"`` vs an absolute path)
-    share the same lock. Without resolution the raw ``Path`` objects
-    compare unequal and would each get their own lock, silently
+    share the same holder. Without resolution the raw ``Path`` objects
+    compare unequal and would each get their own holder, silently
     breaking cross-thread serialisation.
+
+    Returning the holder (rather than the bare lock) lets the caller
+    pin the entry in the :class:`weakref.WeakValueDictionary` for as
+    long as it needs the lock — the dict's value would otherwise be
+    eligible for GC the instant this function returns.
     """
     resolved = path.resolve(strict=False)
-    with _THREAD_LOCKS_GUARD:
-        return _THREAD_LOCKS[resolved]
+    with _THREAD_LOCK_HOLDERS_GUARD:
+        holder = _THREAD_LOCK_HOLDERS.get(resolved)
+        if holder is None:
+            holder = _LockHolder()
+            _THREAD_LOCK_HOLDERS[resolved] = holder
+        return holder
 
 
 def _hash_line(line: str) -> str:
@@ -135,6 +179,14 @@ class AuditLog:
         self.path = path
         self._cached_last_hash: str | None = None
         self._cached_size: int | None = None
+        # Pin the per-path lock holder for the lifetime of this
+        # AuditLog. Holding a strong reference keeps the
+        # WeakValueDictionary entry alive so concurrent AuditLogs on
+        # the same path share the same lock. When the last AuditLog
+        # for a path is GC'd the holder (and lock) become eligible for
+        # collection — long-running daemons writing to many distinct
+        # paths therefore do not leak locks.
+        self._lock_holder = _thread_lock_holder_for(path)
 
     def append(self, payload: dict[str, Any]) -> None:
         """Append *payload* as a JSON line, stamping in the chain hash.
@@ -155,7 +207,7 @@ class AuditLog:
 
         self.path.parent.mkdir(parents=True, exist_ok=True)
         with (
-            _thread_lock_for(self.path),
+            self._lock_holder.lock,
             self.path.open("a", encoding="utf-8") as fh,
         ):
             if _HAS_FCNTL:

--- a/creek-tools/creek/classify/privacy_filter.py
+++ b/creek-tools/creek/classify/privacy_filter.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeGuard
 
 from creek.audit import AuditLog
 from creek.models import PrivacyTier
@@ -48,12 +48,20 @@ class PrivacyTierOverride(StrEnum):
     ALL = "all"
 
 
-def override_elevates(override: PrivacyTierOverride | None) -> bool:
+def override_elevates(
+    override: PrivacyTierOverride | None,
+) -> TypeGuard[PrivacyTierOverride]:
     """Return whether *override* expands access beyond the default.
 
     The default policy is "include open + personal-as-summary, exclude
     intimate". Anything other than ``None`` or ``OPEN`` raises the bar
     and therefore obliges the caller to write an audit entry.
+
+    Returns a :class:`~typing.TypeGuard` so callers that branch on this
+    predicate get the narrowed non-``None`` type for free — encoding the
+    fact that ``None`` and ``OPEN`` are operationally equivalent at the
+    type level prevents the redundant ``override is None`` guard the
+    PR #193 review flagged from ever reappearing.
     """
     if override is None:
         return False

--- a/creek-tools/creek/classify/privacy_filter.py
+++ b/creek-tools/creek/classify/privacy_filter.py
@@ -16,6 +16,7 @@ writing an entry to the privacy audit log via
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
@@ -28,6 +29,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
     from creek.models import Fragment
+
+logger = logging.getLogger(__name__)
 
 
 PRIVACY_AUDIT_RELPATH = Path("00-Creek-Meta/audit/privacy.jsonl")
@@ -136,8 +139,28 @@ def filter_fragments_by_tier(
 
 
 def _tier_of(fragment: Fragment) -> PrivacyTier:
-    """Return the fragment's privacy tier as a :class:`PrivacyTier`."""
-    return PrivacyTier(fragment.privacy_tier)
+    """Return the fragment's privacy tier as a :class:`PrivacyTier`.
+
+    Pydantic's :class:`~creek.models.Fragment` validator constrains
+    ``privacy_tier`` to the enum values, so unrecognised strings should
+    not normally reach this helper. The defensive ``except`` exists for
+    fragments that bypassed Pydantic validation (e.g. legacy data hand-
+    edited in the vault, or a future schema migration that adds a tier
+    we don't yet know about). Failing closed to ``INTIMATE`` ensures an
+    unknown classification is treated as the most-restrictive tier
+    rather than silently defaulting to ``open`` and exposing the body.
+    """
+    try:
+        return PrivacyTier(fragment.privacy_tier)
+    except ValueError:
+        logger.warning(
+            "Fragment %s carries unrecognised privacy_tier %r; "
+            "treating as INTIMATE for fail-closed filtering. "
+            "Re-run `creek classify` to assign a recognised tier.",
+            fragment.id,
+            fragment.privacy_tier,
+        )
+        return PrivacyTier.INTIMATE
 
 
 def record_privacy_override(

--- a/creek-tools/creek/classify/privacy_filter.py
+++ b/creek-tools/creek/classify/privacy_filter.py
@@ -1,0 +1,175 @@
+"""Single source of truth for tier filtering in generation flows.
+
+Section 13.2 of the Creek Ontology promises that intimate fragments are
+excluded from generation prompts by default and that personal fragments
+contribute summaries (not full bodies). This module owns the *one*
+implementation of that promise so ``mine``, ``draft``, ``report``, and
+``skills`` cannot drift out of agreement with each other.
+
+The filter accepts an optional :class:`PrivacyTierOverride` representing
+the operator-supplied ``--include-tier`` flag. When the override raises
+the included tier above the default, the caller is responsible for
+writing an entry to the privacy audit log via
+:func:`record_privacy_override`; the helper exposes
+:func:`override_elevates` so callers can detect when an audit is owed.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from creek.audit import AuditLog
+from creek.models import PrivacyTier
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from creek.models import Fragment
+
+
+PRIVACY_AUDIT_RELPATH = Path("00-Creek-Meta/audit/privacy.jsonl")
+"""Canonical privacy-override audit log location under the vault root."""
+
+
+class PrivacyTierOverride(StrEnum):
+    """``--include-tier`` flag values.
+
+    The values are ordered so that ``OPEN`` is the most restrictive
+    (default) and ``ALL`` is the broadest override; the comparison is
+    done by name, not lexically.
+    """
+
+    OPEN = "open"
+    PERSONAL = "personal"
+    INTIMATE = "intimate"
+    ALL = "all"
+
+
+def override_elevates(override: PrivacyTierOverride | None) -> bool:
+    """Return whether *override* expands access beyond the default.
+
+    The default policy is "include open + personal-as-summary, exclude
+    intimate". Anything other than ``None`` or ``OPEN`` raises the bar
+    and therefore obliges the caller to write an audit entry.
+    """
+    if override is None:
+        return False
+    return override is not PrivacyTierOverride.OPEN
+
+
+def _summarize_personal(fragment: Fragment) -> str:
+    """Replace a personal fragment's body with a title-only summary.
+
+    Title-only is the v1 contract documented in SEC-006; richer summaries
+    can land later without changing the call sites.
+    """
+    title = fragment.title.strip() or fragment.id
+    return f"[Personal-tier summary: {title}]"
+
+
+def _allows_intimate(override: PrivacyTierOverride | None) -> bool:
+    """Return ``True`` when intimate fragments may pass through."""
+    return override in (PrivacyTierOverride.INTIMATE, PrivacyTierOverride.ALL)
+
+
+def _allows_full_personal_body(override: PrivacyTierOverride | None) -> bool:
+    """Return ``True`` when personal fragments contribute their full body."""
+    return override in (
+        PrivacyTierOverride.PERSONAL,
+        PrivacyTierOverride.INTIMATE,
+        PrivacyTierOverride.ALL,
+    )
+
+
+def filter_fragments_by_tier(
+    fragments: Iterable[tuple[Fragment, str]],
+    *,
+    override: PrivacyTierOverride | None = None,
+) -> Iterator[tuple[Fragment, str]]:
+    """Yield ``(fragment, body)`` pairs honouring tier policy.
+
+    Default behaviour:
+
+    * ``intimate`` → excluded.
+    * ``personal`` → included with body replaced by a title-only summary.
+    * ``open`` / ``public`` → included with full body.
+
+    Override semantics:
+
+    * ``OPEN`` (or ``None``): default behaviour.
+    * ``PERSONAL``: personal bodies pass through unredacted; intimate
+      remains excluded.
+    * ``INTIMATE`` / ``ALL``: every tier passes through with its full
+      body.
+
+    Args:
+        fragments: Iterable of ``(fragment, body)`` pairs from the
+            caller's vault scan.
+        override: Optional :class:`PrivacyTierOverride` from
+            ``--include-tier``.
+    """
+    for fragment, body in fragments:
+        tier = _tier_of(fragment)
+        if tier == PrivacyTier.INTIMATE and not _allows_intimate(override):
+            continue
+        if tier == PrivacyTier.PERSONAL and not _allows_full_personal_body(override):
+            yield fragment, _summarize_personal(fragment)
+            continue
+        yield fragment, body
+
+
+def _tier_of(fragment: Fragment) -> PrivacyTier:
+    """Return the fragment's privacy tier as a :class:`PrivacyTier`."""
+    return PrivacyTier(fragment.privacy_tier)
+
+
+def record_privacy_override(
+    *,
+    vault_path: Path,
+    command: str,
+    fragment_ids: Iterable[str],
+    operator: str,
+    override: PrivacyTierOverride,
+) -> None:
+    """Append a privacy-override audit entry to ``audit/privacy.jsonl``.
+
+    Args:
+        vault_path: Vault root under which the audit log lives.
+        command: CLI subcommand name (e.g. ``"mine"``, ``"draft"``).
+        fragment_ids: Fragment IDs included by the override.
+        operator: Identity of the operator that issued the override.
+        override: The :class:`PrivacyTierOverride` value that was
+            applied.
+    """
+    log = AuditLog(vault_path / PRIVACY_AUDIT_RELPATH)
+    payload: dict[str, Any] = {
+        "timestamp": datetime.now(tz=UTC).isoformat(),
+        "command": command,
+        "operator": operator,
+        "include_tier": override.value,
+        "fragment_ids": list(fragment_ids),
+    }
+    log.append(payload)
+
+
+def parse_include_tier(value: str | None) -> PrivacyTierOverride | None:
+    """Parse a CLI ``--include-tier`` value into the typed enum.
+
+    Returns ``None`` for an unset flag so the call site can short-circuit
+    without a noisy comparison; raises :class:`ValueError` with the
+    canonical option list when the value is malformed so the CLI can
+    re-raise with ``typer.Exit(2)``.
+    """
+    if value is None:
+        return None
+    try:
+        return PrivacyTierOverride(value.lower())
+    except ValueError as exc:
+        msg = (
+            f"Unknown --include-tier {value!r}. "
+            f"Use one of: {', '.join(member.value for member in PrivacyTierOverride)}."
+        )
+        raise ValueError(msg) from exc

--- a/creek-tools/creek/classify/privacy_filter.py
+++ b/creek-tools/creek/classify/privacy_filter.py
@@ -96,6 +96,12 @@ def filter_fragments_by_tier(
     * ``intimate`` → excluded.
     * ``personal`` → included with body replaced by a title-only summary.
     * ``open`` / ``public`` → included with full body.
+    * ``unclassified`` → treated as ``open`` (pass through with full
+      body). Fragments without an explicit privacy tier are presumed
+      non-sensitive; the classifier should backfill an explicit tier
+      before they enter sensitive flows. Operators uncomfortable with
+      this default should run ``creek classify`` first so every
+      fragment carries a deliberate tier.
 
     Override semantics:
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -12,15 +12,60 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from creek.classify.privacy_filter import (
+    PrivacyTierOverride,
+    override_elevates,
+    parse_include_tier,
+    record_privacy_override,
+)
 from creek.config import load_config
 from creek.consent import ConsentManager
 from creek.pipeline import Pipeline, RedactionRequiredError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from creek.generate.drafts import DraftLLM
     from creek.ingest.base import Ingestor
     from creek.models import Phase
     from creek.purge import PurgeEngine, PurgeResult
+
+
+_INCLUDE_TIER_HELP = (
+    "Privacy-tier override: open, personal, intimate, or all. "
+    "Default policy excludes intimate fragments and replaces personal "
+    "bodies with title-only summaries. Elevated values are recorded in "
+    "<vault>/00-Creek-Meta/audit/privacy.jsonl."
+)
+
+
+def _parse_include_tier(value: str | None) -> PrivacyTierOverride | None:
+    """Parse --include-tier and exit 2 with a clear error on bad values."""
+    try:
+        return parse_include_tier(value)
+    except ValueError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=2) from exc
+
+
+def _audit_privacy_override_if_needed(
+    *,
+    vault_path: Path,
+    command: str,
+    override: PrivacyTierOverride | None,
+    fragment_ids: list[str],
+) -> None:
+    """Append a privacy-override audit entry when *override* elevates."""
+    if not override_elevates(override) or override is None:
+        return
+    record_privacy_override(
+        vault_path=vault_path,
+        command=command,
+        fragment_ids=fragment_ids,
+        operator=_operator_identity(),
+        override=override,
+    )
+
 
 app = typer.Typer(name="creek", help="Creek knowledge organization pipeline")
 clean_app = typer.Typer(name="clean", help="Vault hygiene commands")
@@ -431,6 +476,7 @@ def _dispatch_redact(
             verbose=verbose,
             assume_yes=assume_yes,
             console=console,
+            vault=vault,
         )
         return
     # Invariant: redact() rejects any flag combination where review is
@@ -590,88 +636,114 @@ def link(
     )
 
 
+def _report_tags(vault_path: Path) -> None:
+    """Generate the tag-garden report."""
+    from creek.generate.tags import TagGardenGenerator
+
+    path = TagGardenGenerator(vault_path=vault_path).generate_garden()
+    console.print(f"[bold green]Tag Garden generated: {path}[/bold green]")
+
+
+def _report_unnamed(vault_path: Path) -> None:
+    """Generate the weekly unnamed-fragment digest."""
+    from datetime import date as _date
+    from datetime import timedelta as _timedelta
+
+    from creek.generate.unnamed import UnnamedDigestGenerator
+    from creek.link.embeddings import EmbeddingLinker
+
+    config = load_config()
+    linker = EmbeddingLinker(config=config.embeddings)
+    digest_generator = UnnamedDigestGenerator(embedding_linker=linker)
+    today = _date.today()
+    week_start = today - _timedelta(days=today.weekday())
+    digest_path = digest_generator.generate_weekly_digest(vault_path, week_start)
+    console.print(
+        f"[bold green]Unnamed digest generated: {digest_path}[/bold green]",
+    )
+
+
+def _report_voice(vault_path: Path) -> None:
+    """Generate per-register voice profiles, if exemplars exist."""
+    from creek.generate.voice import VoiceProfileGenerator
+
+    profile_paths = VoiceProfileGenerator().generate_all_profiles(vault_path)
+    if not profile_paths:
+        console.print(
+            "[yellow]No voice profiles generated: "
+            "no qualifying exemplars found.[/yellow]",
+        )
+        return
+    names = ", ".join(path.stem for path in profile_paths)
+    console.print(
+        f"[bold green]Voice profiles generated ({len(profile_paths)}): "
+        f"{names}[/bold green]",
+    )
+
+
+def _report_wavelength(vault_path: Path, period: str | None) -> None:
+    """Generate weekly or monthly wavelength reports."""
+    from datetime import date as _date
+
+    from creek.generate.wavelength import WavelengthTracker
+
+    if period not in {"weekly", "monthly"}:
+        console.print(
+            "[red]--period must be 'weekly' or 'monthly' for wavelength reports.[/red]",
+        )
+        raise typer.Exit(code=2)
+    tracker = WavelengthTracker()
+    today = _date.today()
+    if period == "weekly":
+        wavelength_path = tracker.generate_weekly_report(vault_path, week_of=today)
+    else:
+        wavelength_path = tracker.generate_monthly_report(vault_path, month=today)
+    console.print(
+        f"[bold green]Wavelength {period} report generated: "
+        f"{wavelength_path}[/bold green]",
+    )
+
+
+_REPORT_DISPATCH: dict[str, Callable[[Path], None]] = {
+    "tags": _report_tags,
+    "unnamed": _report_unnamed,
+    "voice": _report_voice,
+}
+
+
 @app.command()
 def report(
     type: str | None = typer.Option(None, help="Report type"),
     period: str | None = typer.Option(None, help="Report period"),
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    include_tier: str | None = typer.Option(
+        None,
+        "--include-tier",
+        help=_INCLUDE_TIER_HELP,
+    ),
 ) -> None:
     """Generate reports on vault state."""
     config = load_config()
     vault_path = vault or config.vault_path
+    override = _parse_include_tier(include_tier)
+    _audit_privacy_override_if_needed(
+        vault_path=vault_path,
+        command=f"report.{type}" if type else "report",
+        override=override,
+        fragment_ids=[],
+    )
 
-    if type == "tags":
-        from creek.generate.tags import TagGardenGenerator
-
-        generator = TagGardenGenerator(vault_path=vault_path)
-        path = generator.generate_garden()
-        console.print(f"[bold green]Tag Garden generated: {path}[/bold green]")
-    elif type == "unnamed":
-        from datetime import date as _date
-        from datetime import timedelta as _timedelta
-
-        from creek.generate.unnamed import UnnamedDigestGenerator
-        from creek.link.embeddings import EmbeddingLinker
-
-        linker = EmbeddingLinker(config=config.embeddings)
-        digest_generator = UnnamedDigestGenerator(embedding_linker=linker)
-        today = _date.today()
-        week_start = today - _timedelta(days=today.weekday())
-        digest_path = digest_generator.generate_weekly_digest(
-            vault_path,
-            week_start,
-        )
-        console.print(
-            f"[bold green]Unnamed digest generated: {digest_path}[/bold green]",
-        )
-    elif type == "voice":
-        from creek.generate.voice import VoiceProfileGenerator
-
-        profile_generator = VoiceProfileGenerator()
-        profile_paths = profile_generator.generate_all_profiles(vault_path)
-        if profile_paths:
-            names = ", ".join(path.stem for path in profile_paths)
-            console.print(
-                f"[bold green]Voice profiles generated ({len(profile_paths)}): "
-                f"{names}[/bold green]",
-            )
-        else:
-            console.print(
-                "[yellow]No voice profiles generated: "
-                "no qualifying exemplars found.[/yellow]",
-            )
-    elif type == "wavelength":
-        from datetime import date as _date
-
-        from creek.generate.wavelength import WavelengthTracker
-
-        if period not in {"weekly", "monthly"}:
-            console.print(
-                "[red]--period must be 'weekly' or 'monthly' for "
-                "wavelength reports.[/red]",
-            )
-            raise typer.Exit(code=2)
-        wavelength_tracker = WavelengthTracker()
-        today = _date.today()
-        if period == "weekly":
-            wavelength_path = wavelength_tracker.generate_weekly_report(
-                vault_path,
-                week_of=today,
-            )
-        else:
-            wavelength_path = wavelength_tracker.generate_monthly_report(
-                vault_path,
-                month=today,
-            )
-        console.print(
-            f"[bold green]Wavelength {period} report generated: "
-            f"{wavelength_path}[/bold green]",
-        )
-    else:
-        console.print(
-            f"[bold green]Would report: type={type}, "
-            f"period={period}, vault={vault_path}[/bold green]"
-        )
+    handler = _REPORT_DISPATCH.get(type or "")
+    if handler is not None:
+        handler(vault_path)
+        return
+    if type == "wavelength":
+        _report_wavelength(vault_path, period)
+        return
+    console.print(
+        f"[bold green]Would report: type={type}, "
+        f"period={period}, vault={vault_path}[/bold green]",
+    )
 
 
 @app.command()
@@ -789,6 +861,11 @@ def skills(
     generate: bool = typer.Option(False, help="Generate voice skill files"),
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
     output: Path | None = typer.Option(None, help="Output path"),
+    include_tier: str | None = typer.Option(
+        None,
+        "--include-tier",
+        help=_INCLUDE_TIER_HELP,
+    ),
 ) -> None:
     """Generate the Voice Skill Tree (Section 11.4).
 
@@ -796,6 +873,19 @@ def skills(
     ``<vault>/creek-skills``) covering frequencies, phases, modes,
     registers, threads, eddies, and two meta skills.
     """
+    override = _parse_include_tier(include_tier)
+    if override is not None and override is not PrivacyTierOverride.OPEN:
+        # Skill tree generation already excludes intimate exemplars; the
+        # override is recorded as an explicit operator decision rather
+        # than mutating downstream behaviour.
+        vault_path_for_audit = _resolve_vault(vault)
+        _audit_privacy_override_if_needed(
+            vault_path=vault_path_for_audit,
+            command="skills",
+            override=override,
+            fragment_ids=[],
+        )
+
     if not generate:
         console.print(
             "[yellow]Pass --generate to create the Voice Skill Tree.[/yellow]",
@@ -846,6 +936,11 @@ def mine(
         10,
         help="Maximum number of seeds to display (0 for all).",
     ),
+    include_tier: str | None = typer.Option(
+        None,
+        "--include-tier",
+        help=_INCLUDE_TIER_HELP,
+    ),
 ) -> None:
     """Mine blog and essay ideas from the vault (Section 11.5).
 
@@ -857,7 +952,18 @@ def mine(
 
     vault_path = _resolve_vault(vault)
     current_phase = _parse_phase(phase)
-    seeds = IdeaMiner().mine_all(vault_path, current_phase=current_phase)
+    override = _parse_include_tier(include_tier)
+    seeds = IdeaMiner(privacy_override=override).mine_all(
+        vault_path,
+        current_phase=current_phase,
+    )
+    fragment_ids = sorted({fid for seed in seeds for fid in seed.source_fragments})
+    _audit_privacy_override_if_needed(
+        vault_path=vault_path,
+        command="mine",
+        override=override,
+        fragment_ids=fragment_ids,
+    )
     if not seeds:
         console.print("[yellow]No idea seeds surfaced.[/yellow]")
         return
@@ -940,6 +1046,11 @@ def draft(
         "--voice-core",
         help="Path to a voice-core text file prepended to the prompt.",
     ),
+    include_tier: str | None = typer.Option(
+        None,
+        "--include-tier",
+        help=_INCLUDE_TIER_HELP,
+    ),
 ) -> None:
     """Draft an essay from a mined idea with the activated skill stack.
 
@@ -955,9 +1066,13 @@ def draft(
     skills_dir = skills_root if skills_root is not None else vault_path / "creek-skills"
     current_phase = _parse_phase(phase)
     voice_text = _read_voice_core(voice_core)
+    override = _parse_include_tier(include_tier)
     llm = _build_draft_llm()
 
-    seeds = IdeaMiner().mine_all(vault_path, current_phase=current_phase)
+    seeds = IdeaMiner(privacy_override=override).mine_all(
+        vault_path,
+        current_phase=current_phase,
+    )
     if not seeds:
         console.print("[yellow]No idea seeds surfaced; nothing to draft.[/yellow]")
         return
@@ -968,10 +1083,17 @@ def draft(
         raise typer.Exit(code=2)
 
     idea = seeds[index]
+    _audit_privacy_override_if_needed(
+        vault_path=vault_path,
+        command="draft",
+        override=override,
+        fragment_ids=list(idea.source_fragments),
+    )
     generator = DraftGenerator(
         llm=llm,
         skills_root=skills_dir,
         voice_core=voice_text,
+        privacy_override=override,
     )
 
     console.print(generator.present_idea(idea))

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -887,17 +887,17 @@ def skills(
     registers, threads, eddies, and two meta skills.
     """
     override = _parse_include_tier(include_tier)
-    if override is not None and override is not PrivacyTierOverride.OPEN:
-        # Skill tree generation already excludes intimate exemplars; the
-        # override is recorded as an explicit operator decision rather
-        # than mutating downstream behaviour.
-        vault_path_for_audit = _resolve_vault(vault)
-        _audit_privacy_override_if_needed(
-            vault_path=vault_path_for_audit,
-            command="skills",
-            override=override,
-            fragment_ids=[],
-        )
+    # Skill tree generation already excludes intimate exemplars; the
+    # override is recorded as an explicit operator decision rather
+    # than mutating downstream behaviour. _audit_privacy_override_if_
+    # needed already short-circuits for None / OPEN via override_elev-
+    # ates, so there is no extra guard to write at this call site.
+    _audit_privacy_override_if_needed(
+        vault_path=_resolve_vault(vault),
+        command="skills",
+        override=override,
+        fragment_ids=[],
+    )
 
     if not generate:
         console.print(

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -724,7 +724,18 @@ def report(
         help=_INCLUDE_TIER_HELP,
     ),
 ) -> None:
-    """Generate reports on vault state."""
+    """Generate reports on vault state.
+
+    Privacy override audit: ``report`` flows iterate vault content
+    internally (per-week digests, per-register profiles, …) rather
+    than operating on a caller-supplied fragment list, so the audit
+    entry is **invocation-level** and intentionally carries an empty
+    ``fragment_ids`` list. The ``command`` field encodes the report
+    type (e.g. ``"report.unnamed"``) so operators can still trace
+    *which* report was elevated, even though per-fragment scope is
+    not available. ``mine`` and ``draft`` audit *after* the handler
+    runs because the IDs are derived from mining seeds.
+    """
     config = load_config()
     vault_path = vault or config.vault_path
     override = _parse_include_tier(include_tier)

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -56,7 +56,9 @@ def _audit_privacy_override_if_needed(
     fragment_ids: list[str],
 ) -> None:
     """Append a privacy-override audit entry when *override* elevates."""
-    if not override_elevates(override) or override is None:
+    if override is None:
+        return
+    if not override_elevates(override):
         return
     record_privacy_override(
         vault_path=vault_path,

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -60,8 +60,6 @@ def _audit_privacy_override_if_needed(
     fragment_ids: list[str],
 ) -> None:
     """Append a privacy-override audit entry when *override* elevates."""
-    if override is None:
-        return
     if not override_elevates(override):
         return
     record_privacy_override(

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -32,6 +32,10 @@ import frontmatter
 import yaml
 from pydantic import ValidationError
 
+from creek.classify.privacy_filter import (
+    PrivacyTierOverride,
+    filter_fragments_by_tier,
+)
 from creek.models import (
     Eddy,
     Fragment,
@@ -113,11 +117,21 @@ def _safe_post(md_file: Path) -> frontmatter.Post | None:
         return None
 
 
-def _load_fragments_by_id(root: Path) -> dict[str, tuple[Fragment, str]]:
-    """Return ``{fragment.id: (fragment, body)}`` for every fragment under *root*."""
+def _load_fragments_by_id(
+    root: Path,
+    *,
+    privacy_override: PrivacyTierOverride | None = None,
+) -> dict[str, tuple[Fragment, str]]:
+    """Return ``{fragment.id: (fragment, body)}`` for every fragment under *root*.
+
+    The privacy override is forwarded to
+    :func:`~creek.classify.privacy_filter.filter_fragments_by_tier` so
+    intimate content never leaks into the draft prompt under default
+    policy and personal bodies are replaced by title-only summaries.
+    """
     if not root.exists():
         return {}
-    collected: dict[str, tuple[Fragment, str]] = {}
+    pairs: list[tuple[Fragment, str]] = []
     for md_file in sorted(root.rglob("*.md")):
         post = _safe_post(md_file)
         if post is None:
@@ -130,8 +144,9 @@ def _load_fragments_by_id(root: Path) -> dict[str, tuple[Fragment, str]]:
         except ValidationError:
             logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
             continue
-        collected[fragment.id] = (fragment, post.content)
-    return collected
+        pairs.append((fragment, post.content))
+    filtered = filter_fragments_by_tier(pairs, override=privacy_override)
+    return {f.id: (f, body) for f, body in filtered}
 
 
 def _load_threads_by_id(root: Path) -> dict[str, Thread]:
@@ -240,6 +255,7 @@ class DraftGenerator:
         llm: DraftLLM,
         skills_root: Path,
         voice_core: str = "",
+        privacy_override: PrivacyTierOverride | None = None,
     ) -> None:
         """Initialise with an LLM client and skill tree root.
 
@@ -250,10 +266,14 @@ class DraftGenerator:
             voice_core: Optional voice-core description the prompt will
                 open with (e.g. a paragraph describing the human's
                 baseline voice).
+            privacy_override: Optional ``--include-tier`` value applied
+                when scanning vault fragments for skill inference and
+                source material gathering.
         """
         self._llm = llm
         self.skills_root = skills_root
         self.voice_core = voice_core
+        self.privacy_override = privacy_override
 
     def present_idea(self, idea: IdeaSeed) -> str:
         """Format *idea* as an invitation rather than an imperative.
@@ -309,7 +329,10 @@ class DraftGenerator:
         loaded = (
             fragments
             if fragments is not None
-            else _load_fragments_by_id(vault_path / _FRAGMENTS_SUBDIR)
+            else _load_fragments_by_id(
+                vault_path / _FRAGMENTS_SUBDIR,
+                privacy_override=self.privacy_override,
+            )
         )
         source_frags = [
             loaded[fid][0] for fid in idea.source_fragments if fid in loaded
@@ -385,7 +408,10 @@ class DraftGenerator:
         loaded = (
             fragments
             if fragments is not None
-            else _load_fragments_by_id(vault_path / _FRAGMENTS_SUBDIR)
+            else _load_fragments_by_id(
+                vault_path / _FRAGMENTS_SUBDIR,
+                privacy_override=self.privacy_override,
+            )
         )
         frag_block = _render_fragment_section(idea.source_fragments, loaded)
         if frag_block:
@@ -443,7 +469,10 @@ class DraftGenerator:
             A populated :class:`Draft` — the body comes from the LLM
             callable; everything else is provenance.
         """
-        fragments = _load_fragments_by_id(vault_path / _FRAGMENTS_SUBDIR)
+        fragments = _load_fragments_by_id(
+            vault_path / _FRAGMENTS_SUBDIR,
+            privacy_override=self.privacy_override,
+        )
         skill_stack = self.select_skill_stack(
             idea,
             vault_path=vault_path,

--- a/creek-tools/creek/generate/mining.py
+++ b/creek-tools/creek/generate/mining.py
@@ -36,6 +36,10 @@ import frontmatter
 import yaml
 from pydantic import ValidationError
 
+from creek.classify.privacy_filter import (
+    PrivacyTierOverride,
+    filter_fragments_by_tier,
+)
 from creek.models import (
     Eddy,
     Fragment,
@@ -227,8 +231,18 @@ def _validate_fragment(post: frontmatter.Post, path: Path) -> Fragment | None:
         return None
 
 
-def _load_fragments(root: Path) -> list[tuple[Fragment, str]]:
-    """Load every fragment under *root* as ``(fragment, body)`` tuples."""
+def _load_fragments(
+    root: Path,
+    *,
+    privacy_override: PrivacyTierOverride | None = None,
+) -> list[tuple[Fragment, str]]:
+    """Load every fragment under *root* as ``(fragment, body)`` tuples.
+
+    ``privacy_override`` is forwarded to
+    :func:`~creek.classify.privacy_filter.filter_fragments_by_tier`; the
+    default policy excludes intimate fragments and replaces personal
+    bodies with title-only summaries.
+    """
     if not root.exists():
         return []
     collected: list[tuple[Fragment, str]] = []
@@ -239,26 +253,45 @@ def _load_fragments(root: Path) -> list[tuple[Fragment, str]]:
         fragment = _validate_fragment(post, md_file)
         if fragment is not None:
             collected.append((fragment, post.content))
-    return collected
+    return list(filter_fragments_by_tier(collected, override=privacy_override))
 
 
-def _load_liminal_fragments(liminal_root: Path) -> list[tuple[Fragment, str, str]]:
+def _liminal_kind(md_file: Path, liminal_root: Path) -> str | None:
+    """Return the immediate subfolder name (``Unnamed`` etc.), or ``None``.
+
+    Returns ``None`` to signal "skip this file" — used for the
+    ``synchronicities`` subfolder, whose records are reflection notes
+    rather than fragments.
+    """
+    try:
+        relative = md_file.relative_to(liminal_root)
+    except ValueError:  # pragma: no cover - defensive
+        return None
+    kind = relative.parts[0] if relative.parts else ""
+    if kind.lower() == "synchronicities":
+        return None
+    return kind
+
+
+def _load_liminal_fragments(
+    liminal_root: Path,
+    *,
+    privacy_override: PrivacyTierOverride | None = None,
+) -> list[tuple[Fragment, str, str]]:
     """Return ``(fragment, body, kind)`` tuples for liminal fragments.
 
     *kind* is the immediate subfolder name under ``10-Liminal`` — typically
     ``"Unnamed"`` or ``"Compost"``. The Synchronicities subfolder is
     excluded because its records are reflection notes, not fragments.
+
+    ``privacy_override`` is forwarded to the shared tier filter.
     """
     if not liminal_root.exists():
         return []
     collected: list[tuple[Fragment, str, str]] = []
     for md_file in sorted(liminal_root.rglob("*.md")):
-        try:
-            relative = md_file.relative_to(liminal_root)
-        except ValueError:  # pragma: no cover - defensive
-            continue
-        kind = relative.parts[0] if relative.parts else ""
-        if kind.lower() == "synchronicities":
+        kind = _liminal_kind(md_file, liminal_root)
+        if kind is None:
             continue
         post = _safe_post(md_file)
         if post is None:
@@ -266,7 +299,10 @@ def _load_liminal_fragments(liminal_root: Path) -> list[tuple[Fragment, str, str
         fragment = _validate_fragment(post, md_file)
         if fragment is not None:
             collected.append((fragment, post.content, kind))
-    return collected
+    kind_by_id: dict[str, str] = {f.id: kind for f, _body, kind in collected}
+    pairs = [(f, body) for f, body, _kind in collected]
+    filtered = list(filter_fragments_by_tier(pairs, override=privacy_override))
+    return [(f, body, kind_by_id[f.id]) for f, body in filtered]
 
 
 _ModelT = TypeVar("_ModelT", Thread, Eddy)
@@ -333,10 +369,25 @@ def _load_synchronicities(root: Path) -> list[tuple[str, str, float]]:
     return pairs
 
 
-def _load_mining_snapshot(vault_path: Path) -> MiningSnapshot:
-    """Scan *vault_path* for every record the miner needs."""
-    fragments = _load_fragments(vault_path / _FRAGMENTS_SUBDIR)
-    liminal = _load_liminal_fragments(vault_path / _LIMINAL_SUBDIR)
+def _load_mining_snapshot(
+    vault_path: Path,
+    *,
+    privacy_override: PrivacyTierOverride | None = None,
+) -> MiningSnapshot:
+    """Scan *vault_path* for every record the miner needs.
+
+    The privacy override flows through to fragment loaders so callers
+    cannot accidentally bypass tier filtering by reading the snapshot
+    directly.
+    """
+    fragments = _load_fragments(
+        vault_path / _FRAGMENTS_SUBDIR,
+        privacy_override=privacy_override,
+    )
+    liminal = _load_liminal_fragments(
+        vault_path / _LIMINAL_SUBDIR,
+        privacy_override=privacy_override,
+    )
     threads = _load_typed(
         vault_path / _THREADS_SUBDIR,
         type_tag="thread",
@@ -373,6 +424,7 @@ class IdeaMiner:
         min_chain_length: int = DEFAULT_MIN_CHAIN_LENGTH,
         similarity_liminal: float = DEFAULT_SIMILARITY_LIMINAL,
         similarity_resonance: float = DEFAULT_SIMILARITY_RESONANCE,
+        privacy_override: PrivacyTierOverride | None = None,
     ) -> None:
         """Initialise with optional threshold and similarity overrides.
 
@@ -387,12 +439,16 @@ class IdeaMiner:
                 to anchor to an eddy.
             similarity_resonance: Minimum similarity for a resonance-chain
                 edge.
+            privacy_override: Optional ``--include-tier`` value. The
+                default policy excludes intimate fragments and replaces
+                personal bodies with title-only summaries.
         """
         self._similarity_fn: SimilarityFn = similarity_fn or _jaccard_similarity
         self.min_thread_fragments = min_thread_fragments
         self.min_chain_length = min_chain_length
         self.similarity_liminal = similarity_liminal
         self.similarity_resonance = similarity_resonance
+        self.privacy_override = privacy_override
 
     def _resolve_snapshot(
         self,
@@ -402,7 +458,10 @@ class IdeaMiner:
         """Return *snapshot* if provided, otherwise load from *vault_path*."""
         if snapshot is not None:
             return snapshot
-        return _load_mining_snapshot(vault_path)
+        return _load_mining_snapshot(
+            vault_path,
+            privacy_override=self.privacy_override,
+        )
 
     # ---- Strategy: Thread terminus ----
 

--- a/creek-tools/creek/purge/audit.py
+++ b/creek-tools/creek/purge/audit.py
@@ -176,21 +176,52 @@ class PurgeAuditLog:
             self._migration_settled = True
             return
         if self.log_path.exists() and self.log_path.stat().st_size > 0:
+            # JSONL already populated AND legacy still on disk: a
+            # previous attempt wrote some entries then crashed before
+            # unlinking, or an operator restored the legacy file. The
+            # state is half-migrated; silently doing nothing would let
+            # the inconsistency drift indefinitely, so surface it
+            # explicitly the first time we see it.
+            logger.warning(
+                "Purge audit migration: %s exists and %s also exists with "
+                "content; skipping migration. Inspect both files and remove "
+                "%s by hand once you have confirmed every legacy entry is in "
+                "the new log.",
+                self._legacy_path,
+                self.log_path,
+                self._legacy_path,
+            )
             self._migration_settled = True
             return
         legacy_entries = self._load_legacy_entries()
         if legacy_entries is None:
             self._migration_settled = True
             return
-        for entry in legacy_entries:
-            # Strip prev_hash defensively: AuditLog.append rejects
-            # payloads carrying the reserved chain key, and a legacy
-            # log written by an earlier audit substrate (or hand-edited
-            # by an operator) could include one. Without this guard the
-            # whole migration aborts with ValueError.
-            sanitised = {k: v for k, v in entry.items() if k != "prev_hash"}
-            self._audit.append(_coerce_legacy_entry(sanitised))
-        self._audit.append(self._migration_marker(len(legacy_entries)))
+        try:
+            for entry in legacy_entries:
+                # Strip prev_hash defensively: AuditLog.append rejects
+                # payloads carrying the reserved chain key, and a legacy
+                # log written by an earlier audit substrate (or hand-edited
+                # by an operator) could include one. Without this guard the
+                # whole migration aborts with ValueError.
+                sanitised = {k: v for k, v in entry.items() if k != "prev_hash"}
+                self._audit.append(_coerce_legacy_entry(sanitised))
+            self._audit.append(self._migration_marker(len(legacy_entries)))
+        except OSError:
+            # Mid-migration failure (disk full, permission flip). The
+            # new log now has partial content so the size guard above
+            # will short-circuit subsequent attempts; the legacy file
+            # is left in place deliberately so no entries are lost.
+            # Warn loudly so the operator can reconcile before the
+            # next run silently treats the partial state as "already
+            # migrated".
+            logger.exception(
+                "Purge audit migration of %s into %s failed mid-write; legacy "
+                "file left intact for manual reconciliation.",
+                self._legacy_path,
+                self.log_path,
+            )
+            raise
         self._legacy_path.unlink(missing_ok=True)
         self._migration_settled = True
 

--- a/creek-tools/creek/purge/audit.py
+++ b/creek-tools/creek/purge/audit.py
@@ -118,6 +118,13 @@ class PurgeAuditLog:
         self.log_path = vault_path / PURGE_AUDIT_RELPATH
         self._legacy_path = vault_path / LEGACY_PURGE_LOG_RELPATH
         self._audit = AuditLog(self.log_path)
+        # Flip to True after a successful migration (or when there is
+        # nothing to migrate) so subsequent append/read calls skip the
+        # filesystem stat that the legacy-detection path would
+        # otherwise perform on every operation. Stays False until the
+        # first append/read so callers that construct the wrapper
+        # without ever touching it pay no migration cost.
+        self._migration_settled = False
 
     def append(self, entry: PurgeAuditEntry) -> None:
         """Append a new entry to the audit log.
@@ -158,20 +165,28 @@ class PurgeAuditLog:
         If the legacy file exists and the new JSONL log is empty, every
         legacy entry is replayed into the new chain in order, a
         ``purge.audit.migration`` marker is appended, and the legacy file
-        is unlinked. Subsequent calls become a cheap path-existence
-        check thanks to the unlink.
+        is unlinked. After the first call the instance flips
+        :attr:`_migration_settled` so subsequent calls skip the legacy
+        stat altogether — important for the vault-writer ingest path
+        where ``append`` is hot.
         """
+        if self._migration_settled:
+            return
         if not self._legacy_path.exists():
+            self._migration_settled = True
             return
         if self.log_path.exists() and self.log_path.stat().st_size > 0:
+            self._migration_settled = True
             return
         legacy_entries = self._load_legacy_entries()
         if legacy_entries is None:
+            self._migration_settled = True
             return
         for entry in legacy_entries:
             self._audit.append(_coerce_legacy_entry(entry))
         self._audit.append(self._migration_marker(len(legacy_entries)))
         self._legacy_path.unlink(missing_ok=True)
+        self._migration_settled = True
 
     def _load_legacy_entries(self) -> list[dict[str, Any]] | None:
         """Return parsed legacy entries, or ``None`` when unreadable."""

--- a/creek-tools/creek/purge/audit.py
+++ b/creek-tools/creek/purge/audit.py
@@ -183,7 +183,13 @@ class PurgeAuditLog:
             self._migration_settled = True
             return
         for entry in legacy_entries:
-            self._audit.append(_coerce_legacy_entry(entry))
+            # Strip prev_hash defensively: AuditLog.append rejects
+            # payloads carrying the reserved chain key, and a legacy
+            # log written by an earlier audit substrate (or hand-edited
+            # by an operator) could include one. Without this guard the
+            # whole migration aborts with ValueError.
+            sanitised = {k: v for k, v in entry.items() if k != "prev_hash"}
+            self._audit.append(_coerce_legacy_entry(sanitised))
         self._audit.append(self._migration_marker(len(legacy_entries)))
         self._legacy_path.unlink(missing_ok=True)
         self._migration_settled = True

--- a/creek-tools/creek/purge/audit.py
+++ b/creek-tools/creek/purge/audit.py
@@ -1,12 +1,16 @@
 """Audit log for purge operations.
 
-Records every purge operation — including dry runs — to a JSON log at
-``00-Creek-Meta/Processing-Log/purge-log.json``. Each entry captures the
-timestamp, operation, target, affected count, operator, and dry-run flag.
+Records every purge operation — including dry runs — to a tamper-
+evident JSONL log at ``<vault>/00-Creek-Meta/audit/purge.jsonl``. Each
+entry captures the timestamp, operation, criteria dict, affected
+fragment IDs, deletion counts, references scrubbed, embeddings removed,
+operator, and dry-run flag.
 
-The log is a JSON array; new entries are appended. If the file does not
-exist it is created. Malformed existing logs are rebuilt from scratch
-rather than losing new entries.
+Backward compatibility: an existing legacy
+``<vault>/00-Creek-Meta/Processing-Log/purge-log.json`` file is migrated
+into the new JSONL log on first read or write, then removed. The
+migration writes one entry per legacy record plus a final
+``purge.audit.migration`` marker, so the chain captures the move.
 """
 
 from __future__ import annotations
@@ -14,16 +18,22 @@ from __future__ import annotations
 import json
 import logging
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import Any
 
 from pydantic import BaseModel, Field
 
-if TYPE_CHECKING:
-    from pathlib import Path
+from creek.audit import AuditLog
 
 logger = logging.getLogger(__name__)
 
 _DEFAULT_OPERATOR = "human via CLI"
+
+LEGACY_PURGE_LOG_RELPATH = Path("00-Creek-Meta/Processing-Log/purge-log.json")
+"""Pre-Batch-C purge log location used for one-time migration."""
+
+PURGE_AUDIT_RELPATH = Path("00-Creek-Meta/audit/purge.jsonl")
+"""Canonical Batch-C purge audit log location."""
 
 
 class PurgeAuditEntry(BaseModel):
@@ -33,28 +43,69 @@ class PurgeAuditEntry(BaseModel):
         timestamp: UTC ISO-format datetime of the purge.
         operation: Operation name (``fragment``, ``source``,
             ``classifications``, ``daterange``, ``vault``).
-        target: The purge target (fragment ID, source type, etc.).
-        count: Number of affected files or fragments.
-        operator: Who performed the purge (default ``"human via CLI"``).
+        criteria: Structured input that drove the purge (e.g. fragment
+            ID, source platform, date range).
+        affected_fragments: Fragment IDs touched by the operation.
+        fragments_deleted: Number of fragment files removed from disk.
+        references_scrubbed: Number of wiki-link references removed.
+        embeddings_removed: Number of fragments whose embeddings should
+            be considered invalidated by the purge.
+        operator: Who performed the purge.
         dry_run: Whether the purge was a dry-run preview.
+        target: Legacy field preserved for backward compatibility on
+            read; populated only when reading pre-Batch-C entries.
+        count: Legacy fragment count preserved for backward compatibility
+            on read.
     """
 
     timestamp: str = Field(
         default_factory=lambda: datetime.now(tz=UTC).isoformat(),
     )
     operation: str
-    target: str
-    count: int
+    criteria: dict[str, Any] = Field(default_factory=dict)
+    affected_fragments: list[str] = Field(default_factory=list)
+    fragments_deleted: int = 0
+    references_scrubbed: int = 0
+    embeddings_removed: int = 0
     operator: str = _DEFAULT_OPERATOR
     dry_run: bool = False
 
+    target: str | None = None
+    count: int | None = None
+
+
+def _coerce_legacy_entry(raw: dict[str, Any]) -> dict[str, Any]:
+    """Upgrade a pre-Batch-C entry shape into the current schema.
+
+    Pre-Batch-C entries carried ``target`` (str) and ``count`` (int).
+    The new schema uses ``criteria`` (dict) and ``fragments_deleted``.
+    Both old fields are preserved on the resulting entry so a downstream
+    consumer that still expects them does not break.
+    """
+    if "criteria" in raw and "affected_fragments" in raw:
+        return raw
+    upgraded = dict(raw)
+    target = raw.get("target")
+    if target is not None and "criteria" not in raw:
+        upgraded["criteria"] = {"target": target}
+    if "count" in raw and "fragments_deleted" not in raw:
+        upgraded["fragments_deleted"] = int(raw.get("count", 0) or 0)
+    upgraded.setdefault("affected_fragments", [])
+    upgraded.setdefault("references_scrubbed", 0)
+    upgraded.setdefault("embeddings_removed", 0)
+    return upgraded
+
 
 class PurgeAuditLog:
-    """Append-only JSON audit log for purge operations.
+    """Tamper-evident JSONL audit log for purge operations.
+
+    The log lives at :data:`PURGE_AUDIT_RELPATH` under the vault root
+    and is backed by :class:`creek.audit.AuditLog`, so every append
+    extends a sha256 hash chain that :meth:`creek.audit.AuditLog.verify`
+    can validate.
 
     Args:
-        vault_path: Root of the Obsidian vault. The log file lives at
-            ``{vault_path}/00-Creek-Meta/Processing-Log/purge-log.json``.
+        vault_path: Root of the Obsidian vault.
     """
 
     def __init__(self, vault_path: Path) -> None:
@@ -64,58 +115,96 @@ class PurgeAuditLog:
             vault_path: Root of the Obsidian vault.
         """
         self.vault_path = vault_path
-        self.log_path = (
-            vault_path / "00-Creek-Meta" / "Processing-Log" / "purge-log.json"
-        )
+        self.log_path = vault_path / PURGE_AUDIT_RELPATH
+        self._legacy_path = vault_path / LEGACY_PURGE_LOG_RELPATH
+        self._audit = AuditLog(self.log_path)
 
     def append(self, entry: PurgeAuditEntry) -> None:
         """Append a new entry to the audit log.
 
-        Creates the log directory and file if missing. If the existing
-        log is malformed, it is replaced with a fresh log containing
-        only the new entry.
-
         Args:
             entry: The audit entry to append.
         """
-        self.log_path.parent.mkdir(parents=True, exist_ok=True)
-        entries = self._read_entries()
-        entries.append(entry.model_dump(mode="json"))
-        self.log_path.write_text(
-            json.dumps(entries, indent=2),
-            encoding="utf-8",
-        )
+        self._migrate_legacy_if_needed()
+        payload = entry.model_dump(mode="json", exclude_none=True)
+        self._audit.append(payload)
 
     def read(self) -> list[PurgeAuditEntry]:
         """Read all entries from the audit log.
 
         Returns:
-            List of parsed :class:`PurgeAuditEntry` objects. Empty list
-            if the log does not exist or is malformed.
+            List of parsed :class:`PurgeAuditEntry` objects in append
+            order.
         """
-        entries = self._read_entries()
-        return [PurgeAuditEntry.model_validate(e) for e in entries]
+        self._migrate_legacy_if_needed()
+        entries: list[PurgeAuditEntry] = []
+        for raw in self._audit.read():
+            entry_data = {k: v for k, v in raw.items() if k != "prev_hash"}
+            upgraded = _coerce_legacy_entry(entry_data)
+            entries.append(PurgeAuditEntry.model_validate(upgraded))
+        return entries
 
-    def _read_entries(self) -> list[dict[str, object]]:
-        """Read raw entry dicts from the log file.
+    def verify(self) -> None:
+        """Verify the audit log's hash chain.
 
-        Returns:
-            List of raw entry dicts. Empty list if the log is missing
-            or unreadable.
+        Raises:
+            creek.audit.AuditChainBroken: If the chain is broken.
         """
-        if not self.log_path.exists():
+        self._audit.verify()
+
+    def _migrate_legacy_if_needed(self) -> None:
+        """One-shot migration of the pre-Batch-C JSON-array log.
+
+        If the legacy file exists and the new JSONL log is empty, every
+        legacy entry is replayed into the new chain in order, a
+        ``purge.audit.migration`` marker is appended, and the legacy file
+        is unlinked. Subsequent calls become a cheap path-existence
+        check thanks to the unlink.
+        """
+        if not self._legacy_path.exists():
+            return
+        if self.log_path.exists() and self.log_path.stat().st_size > 0:
+            return
+        legacy_entries = self._load_legacy_entries()
+        if legacy_entries is None:
+            return
+        for entry in legacy_entries:
+            self._audit.append(_coerce_legacy_entry(entry))
+        self._audit.append(self._migration_marker(len(legacy_entries)))
+        self._legacy_path.unlink(missing_ok=True)
+
+    def _load_legacy_entries(self) -> list[dict[str, Any]] | None:
+        """Return parsed legacy entries, or ``None`` when unreadable."""
+        try:
+            raw = self._legacy_path.read_text(encoding="utf-8")
+        except OSError:
+            logger.warning("Could not read legacy purge log %s", self._legacy_path)
+            return None
+        if not raw.strip():
             return []
         try:
-            raw = self.log_path.read_text(encoding="utf-8")
-            if not raw.strip():
-                return []
             data = json.loads(raw)
-        except (OSError, json.JSONDecodeError):
+        except json.JSONDecodeError:
             logger.warning(
-                "Purge log at %s is unreadable — starting fresh.",
-                self.log_path,
+                "Legacy purge log %s is not valid JSON; skipping migration",
+                self._legacy_path,
             )
             return []
         if not isinstance(data, list):
             return []
         return [item for item in data if isinstance(item, dict)]
+
+    def _migration_marker(self, migrated_count: int) -> dict[str, Any]:
+        """Build the ``purge.audit.migration`` chain marker payload."""
+        return {
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+            "operation": "purge.audit.migration",
+            "criteria": {"legacy_path": str(self._legacy_path)},
+            "affected_fragments": [],
+            "fragments_deleted": 0,
+            "references_scrubbed": 0,
+            "embeddings_removed": 0,
+            "operator": "system",
+            "dry_run": False,
+            "migrated_entries": migrated_count,
+        }

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -62,6 +62,9 @@ class PurgeResult(BaseModel):
     Attributes:
         operation: Name of the operation (``fragment``, ``source``, ...).
         target: The purge target (fragment id, source type, date range, ...).
+        criteria: Structured representation of *target* used for the
+            audit log (e.g. ``{"fragment_id": "frag-abc"}``).
+        affected_fragment_ids: IDs of fragments touched by the operation.
         dry_run: Whether deletions were only previewed.
         deleted_files: Paths of files deleted (or that would be deleted).
         fragments_affected: Number of fragments directly affected.
@@ -73,6 +76,8 @@ class PurgeResult(BaseModel):
 
     operation: str
     target: str
+    criteria: dict[str, object] = Field(default_factory=dict)
+    affected_fragment_ids: list[str] = Field(default_factory=list)
     dry_run: bool = False
     deleted_files: list[str] = Field(default_factory=list)
     fragments_affected: int = 0
@@ -126,6 +131,7 @@ class PurgeEngine:
         result = PurgeResult(
             operation="fragment",
             target=fragment_id,
+            criteria={"fragment_id": fragment_id},
             dry_run=self.dry_run,
         )
         frag_file, post = self._find_fragment_by_id(fragment_id)
@@ -138,6 +144,7 @@ class PurgeEngine:
         eddy_ids = [str(e) for e in post.get("eddies", []) or []]
 
         result.deleted_files.append(str(frag_file))
+        result.affected_fragment_ids.append(fragment_id)
         result.fragments_affected = 1
         result.wikilinks_removed = self._scrub_wikilinks(title, exclude=frag_file)
         result.threads_updated = self._decrement_counts(
@@ -170,6 +177,7 @@ class PurgeEngine:
         result = PurgeResult(
             operation="source",
             target=source_type,
+            criteria={"source_type": source_type},
             dry_run=self.dry_run,
         )
         matches = self._fragments_from_source(source_type)
@@ -204,6 +212,7 @@ class PurgeEngine:
         result = PurgeResult(
             operation="classifications",
             target="all",
+            criteria={"scope": "all"},
             dry_run=self.dry_run,
         )
         for frag_file in self._list_fragment_files():
@@ -212,6 +221,9 @@ class PurgeEngine:
                 continue
             if self._reset_classifications(post):
                 result.classifications_reset += 1
+                frag_id = post.get("id")
+                if isinstance(frag_id, str):
+                    result.affected_fragment_ids.append(frag_id)
                 if not self.dry_run:
                     frag_file.write_text(
                         frontmatter.dumps(post),
@@ -248,6 +260,7 @@ class PurgeEngine:
         result = PurgeResult(
             operation="daterange",
             target=target,
+            criteria={"start": start.isoformat(), "end": end.isoformat()},
             dry_run=self.dry_run,
         )
         for frag_file in self._list_fragment_files():
@@ -290,6 +303,7 @@ class PurgeEngine:
         result = PurgeResult(
             operation="vault",
             target="entire vault",
+            criteria={"scope": "entire vault"},
             dry_run=self.dry_run,
         )
         for folder in _VAULT_CONTENT_FOLDERS:
@@ -321,6 +335,9 @@ class PurgeEngine:
         eddy_ids = [str(e) for e in post.get("eddies", []) or []]
 
         result.deleted_files.append(str(frag_file))
+        frag_id = post.get("id")
+        if isinstance(frag_id, str):
+            result.affected_fragment_ids.append(frag_id)
         result.fragments_affected += 1
         result.wikilinks_removed += self._scrub_wikilinks(
             title,
@@ -526,13 +543,25 @@ class PurgeEngine:
     def _write_audit(self, result: PurgeResult) -> None:
         """Append a :class:`PurgeAuditEntry` for a completed purge.
 
+        ``fragments_deleted`` counts only operations that remove files
+        from disk; ``classifications`` resets metadata in place and
+        therefore reports zero deletions. ``embeddings_removed`` mirrors
+        ``fragments_deleted`` because every deleted fragment's cached
+        embedding is invalidated at the next ``creek link`` run; the
+        engine does not maintain the embedding cache directly.
+
         Args:
             result: The result whose metadata should be logged.
         """
+        deletes_files = result.operation != "classifications"
+        fragments_deleted = result.fragments_affected if deletes_files else 0
         entry = PurgeAuditEntry(
             operation=result.operation,
-            target=result.target,
-            count=result.fragments_affected,
+            criteria=dict(result.criteria),
+            affected_fragments=list(result.affected_fragment_ids),
+            fragments_deleted=fragments_deleted,
+            references_scrubbed=result.wikilinks_removed,
+            embeddings_removed=fragments_deleted,
             dry_run=result.dry_run,
         )
         self.audit_log.append(entry)

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -55,6 +55,18 @@ _CLASSIFICATION_RESET_FIELDS: tuple[str, ...] = (
 )
 """Frontmatter fields wiped by ``purge_classifications``."""
 
+_FILE_DELETING_OPERATIONS: frozenset[str] = frozenset(
+    {"fragment", "source", "daterange", "vault"},
+)
+"""Explicit allowlist of operations that remove files from disk.
+
+Operations not listed here (currently only ``classifications``, which
+resets metadata in place) record ``fragments_deleted=0`` regardless of
+``fragments_affected``. Any new operation type added to this engine
+must be classified explicitly here — defaulting unknown operations to
+"deletes files" would risk over-counting deletions in audit entries.
+"""
+
 
 class PurgeResult(BaseModel):
     """Outcome of a single purge operation.
@@ -544,16 +556,33 @@ class PurgeEngine:
         """Append a :class:`PurgeAuditEntry` for a completed purge.
 
         ``fragments_deleted`` counts only operations that remove files
-        from disk; ``classifications`` resets metadata in place and
-        therefore reports zero deletions. ``embeddings_removed`` mirrors
+        from disk (see :data:`_FILE_DELETING_OPERATIONS`);
+        ``classifications`` resets metadata in place and therefore
+        reports zero deletions. ``embeddings_removed`` mirrors
         ``fragments_deleted`` because every deleted fragment's cached
         embedding is invalidated at the next ``creek link`` run; the
         engine does not maintain the embedding cache directly.
 
         Args:
             result: The result whose metadata should be logged.
+
+        Raises:
+            ValueError: If ``result.operation`` is not a known purge
+                operation. Unknown operations are rejected explicitly
+                so a new operation type cannot silently default to
+                ``deletes_files=True``.
         """
-        deletes_files = result.operation != "classifications"
+        if result.operation in _FILE_DELETING_OPERATIONS:
+            deletes_files = True
+        elif result.operation == "classifications":
+            deletes_files = False
+        else:
+            msg = (
+                f"Unknown purge operation {result.operation!r}; classify it "
+                f"explicitly in _FILE_DELETING_OPERATIONS or add a metadata-only "
+                f"branch before logging."
+            )
+            raise ValueError(msg)
         fragments_deleted = result.fragments_affected if deletes_files else 0
         entry = PurgeAuditEntry(
             operation=result.operation,

--- a/creek-tools/creek/redact/__init__.py
+++ b/creek-tools/creek/redact/__init__.py
@@ -8,12 +8,15 @@ Sensitive matched text is **never** stored — only salted SHA-256 hashes are
 retained so that duplicate detections can be correlated without leaking data.
 """
 
+from creek.redact.audit import RedactionAuditEntry, RedactionAuditLog
 from creek.redact.patterns import REDACTION_PATTERNS
 from creek.redact.redactor import Redactor
 from creek.redact.scanner import RedactionMatch, RedactionScanner, ScanSummary
 
 __all__ = [
     "REDACTION_PATTERNS",
+    "RedactionAuditEntry",
+    "RedactionAuditLog",
     "RedactionMatch",
     "RedactionScanner",
     "Redactor",

--- a/creek-tools/creek/redact/audit.py
+++ b/creek-tools/creek/redact/audit.py
@@ -1,0 +1,82 @@
+"""Audit log for ``creek redact --apply`` operations.
+
+Every committed (or dry-run-previewed) redaction writes one entry per
+touched file to the tamper-evident JSONL log at
+``<vault>/00-Creek-Meta/audit/redact.jsonl``. The log is backed by
+:class:`creek.audit.AuditLog`, so the same hash-chain integrity that
+guards purge and privacy-override events also guards redactions.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from creek.audit import AuditLog
+
+REDACT_AUDIT_RELPATH = Path("00-Creek-Meta/audit/redact.jsonl")
+"""Canonical redaction audit log location under the vault root."""
+
+
+class RedactionAuditEntry(BaseModel):
+    """One audit record for a single redacted file.
+
+    Attributes:
+        timestamp: UTC ISO-format datetime of the apply event.
+        source_path: The file path whose contents were rewritten,
+            stored as a string for portability.
+        pattern_names: Pattern names that matched in the file.
+        match_counts: Per-pattern hit count.
+        replacement_template: Marker template used to replace each hit
+            (``[REDACTED:{name}]``).
+        operator: Who initiated the apply.
+        dry_run: ``True`` when the file would have been rewritten but
+            was preserved by ``--dry-run``.
+    """
+
+    timestamp: str = Field(
+        default_factory=lambda: datetime.now(tz=UTC).isoformat(),
+    )
+    source_path: str
+    pattern_names: list[str] = Field(default_factory=list)
+    match_counts: dict[str, int] = Field(default_factory=dict)
+    replacement_template: str = "[REDACTED:{name}]"
+    operator: str = "human via CLI"
+    dry_run: bool = False
+
+
+class RedactionAuditLog:
+    """Append-only redaction audit log rooted at a vault path.
+
+    Args:
+        vault_path: Vault root under which the audit JSONL lives.
+    """
+
+    def __init__(self, vault_path: Path) -> None:
+        """Resolve the canonical audit path under *vault_path*."""
+        self.vault_path = vault_path
+        self.log_path = vault_path / REDACT_AUDIT_RELPATH
+        self._audit = AuditLog(self.log_path)
+
+    def append(self, entry: RedactionAuditEntry) -> None:
+        """Append a :class:`RedactionAuditEntry` to the chained log."""
+        self._audit.append(entry.model_dump(mode="json"))
+
+    def read(self) -> list[RedactionAuditEntry]:
+        """Return every audit entry parsed back into the model."""
+        entries: list[RedactionAuditEntry] = []
+        for raw in self._audit.read():
+            payload: dict[str, Any] = {k: v for k, v in raw.items() if k != "prev_hash"}
+            entries.append(RedactionAuditEntry.model_validate(payload))
+        return entries
+
+    def verify(self) -> None:
+        """Verify the audit log's hash chain.
+
+        Raises:
+            creek.audit.AuditChainBroken: When the chain is broken.
+        """
+        self._audit.verify()

--- a/creek-tools/creek/redact/cli_commands.py
+++ b/creek-tools/creek/redact/cli_commands.py
@@ -23,6 +23,7 @@ from rich.table import Table
 from rich.text import Text
 
 from creek.config import load_config
+from creek.redact.audit import RedactionAuditEntry, RedactionAuditLog
 from creek.redact.patterns import PATTERN_METADATA
 from creek.redact.redactor import Redactor
 from creek.redact.scanner import RedactionScanner, ScanSummary
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
     from rich.console import Console
 
     from creek.config import CreekConfig
+    from creek.redact.scanner import RedactionMatch
 
 
 # ---------------------------------------------------------------------------
@@ -351,6 +353,53 @@ def _atomic_write(file_path: Path, content: str) -> None:
         raise
 
 
+def _matches_by_file(
+    summary: ScanSummary,
+) -> dict[Path, list[RedactionMatch]]:
+    """Group *summary*'s matches into ``{file_path: [matches]}``."""
+    grouped: dict[Path, list[RedactionMatch]] = {}
+    for match in summary.matches:
+        grouped.setdefault(match.file_path, []).append(match)
+    return grouped
+
+
+def _audit_entry_for_file(
+    file_path: Path,
+    file_matches: list[RedactionMatch],
+    *,
+    dry_run: bool,
+) -> RedactionAuditEntry:
+    """Build a :class:`RedactionAuditEntry` for one touched file."""
+    counts: dict[str, int] = {}
+    for match in file_matches:
+        counts[match.match_type] = counts.get(match.match_type, 0) + 1
+    return RedactionAuditEntry(
+        source_path=str(file_path),
+        pattern_names=sorted(counts.keys()),
+        match_counts=counts,
+        dry_run=dry_run,
+    )
+
+
+def _write_redaction_audit(
+    summary: ScanSummary,
+    files: list[Path],
+    *,
+    vault_path: Path,
+    dry_run: bool,
+) -> None:
+    """Append one audit entry per touched file under *vault_path*."""
+    audit_log = RedactionAuditLog(vault_path)
+    grouped = _matches_by_file(summary)
+    for file_path in files:
+        file_matches = grouped.get(file_path, [])
+        if not file_matches:
+            continue
+        audit_log.append(
+            _audit_entry_for_file(file_path, file_matches, dry_run=dry_run),
+        )
+
+
 def _apply_redactions(
     redactor: Redactor,
     files: list[Path],
@@ -421,8 +470,14 @@ def run_apply(
     verbose: bool,
     assume_yes: bool,
     console: Console,
+    vault: Path | None = None,
 ) -> None:
     """Scan *source*, obtain consent, and redact files in place.
+
+    Both dry-run and apply runs append per-file entries to
+    ``<vault>/00-Creek-Meta/audit/redact.jsonl`` so the audit trail
+    captures every preview operators reviewed in addition to the
+    committed rewrites.
 
     Args:
         source: File or directory to scan and redact.
@@ -430,9 +485,12 @@ def run_apply(
         verbose: When ``True``, render the per-match table.
         assume_yes: Skip the interactive confirmation prompt.
         console: Rich console sink.
+        vault: Vault root for the audit log. Defaults to
+            ``load_config().vault_path``.
     """
     _require_existing(console, source, "Source path")
     config = load_config()
+    vault_path = vault if vault is not None else config.vault_path
     scanner, summary = _scan_source(source, config)
     render_summary(summary, console)
     if verbose:
@@ -442,16 +500,29 @@ def run_apply(
         console.print("[green]No findings — nothing to redact.[/green]")
         return
 
+    files = _files_from_summary(summary)
+
     if dry_run:
+        _write_redaction_audit(
+            summary,
+            files,
+            vault_path=vault_path,
+            dry_run=True,
+        )
         console.print("[yellow]Dry run: no files modified.[/yellow]")
         return
 
-    files = _files_from_summary(summary)
     if not _confirm_apply(files, assume_yes=assume_yes, console=console):
         return
 
     redactor = Redactor(config=config.redaction, salt=scanner.salt)
     _apply_redactions(redactor, files, console)
+    _write_redaction_audit(
+        summary,
+        files,
+        vault_path=vault_path,
+        dry_run=False,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -12,6 +12,8 @@ Obsidian-compatible markdown files with YAML frontmatter. It handles:
 
 from __future__ import annotations
 
+import json
+import logging
 import re
 from datetime import date, datetime
 from typing import TYPE_CHECKING
@@ -78,6 +80,70 @@ _ACTIVE_DECISION_STATUSES: set[str] = {
     DecisionStatus.DELIBERATING,
     DecisionStatus.COMMITTING,
 }
+
+logger = logging.getLogger(__name__)
+
+
+def _read_legacy_provenance_entries(legacy_path: Path) -> list[dict[str, object]]:
+    """Return parsed legacy provenance entries, or empty on any failure."""
+    try:
+        raw = legacy_path.read_text(encoding="utf-8")
+    except OSError:
+        logger.warning("Could not read legacy provenance log %s", legacy_path)
+        return []
+    if not raw.strip():
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning(
+            "Legacy provenance log %s is not valid JSON; skipping migration",
+            legacy_path,
+        )
+        return []
+    if not isinstance(data, list):
+        return []
+    return [item for item in data if isinstance(item, dict)]
+
+
+def _provenance_migration_marker(
+    legacy_path: Path,
+    migrated_count: int,
+) -> dict[str, object]:
+    """Build the migration marker entry recorded in the new chain."""
+    return {
+        "id": "_migration_",
+        "type": "provenance.migration",
+        "path": str(legacy_path),
+        "written_at": datetime.now().isoformat(),
+        "migrated_entries": migrated_count,
+    }
+
+
+def _migrate_legacy_provenance(
+    legacy_path: Path,
+    new_log: AuditLog,
+) -> None:
+    """One-shot migration of pre-Batch-C ``provenance.json`` array.
+
+    Older vaults shipped a JSON-array log at ``provenance.json``;
+    Batch C switched to JSONL via :class:`AuditLog` so the log is
+    chained, append-only, and crash-safe. We replay every legacy
+    entry into the new chain in original order, append a marker
+    line so the migration is auditable, and unlink the legacy
+    file. If the new log is already populated we leave the legacy
+    file alone so a partially-migrated state can be resolved by
+    inspection.
+    """
+    if not legacy_path.exists():
+        return
+    if new_log.path.exists() and new_log.path.stat().st_size > 0:
+        return
+    legacy_entries = _read_legacy_provenance_entries(legacy_path)
+    for entry in legacy_entries:
+        new_log.append(entry)
+    new_log.append(_provenance_migration_marker(legacy_path, len(legacy_entries)))
+    legacy_path.unlink(missing_ok=True)
 
 
 def _sanitize_title(title: str) -> str:
@@ -203,8 +269,11 @@ class VaultWriter:
         # vault-writer ingest loop. A fresh AuditLog per call would
         # collapse the cache and re-introduce the O(N²) read flagged
         # on PR #193 (BLOCKING review item, comment 4365147477).
-        self._provenance_log = AuditLog(
-            vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl",
+        processing_log_dir = vault_path / "00-Creek-Meta" / "Processing-Log"
+        self._provenance_log = AuditLog(processing_log_dir / "provenance.jsonl")
+        _migrate_legacy_provenance(
+            processing_log_dir / "provenance.json",
+            self._provenance_log,
         )
 
     def write_fragment(self, fragment: Fragment, body: str = "") -> Path:

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -224,14 +224,43 @@ def _migrate_legacy_provenance(
     if not legacy_path.exists():
         return
     if new_log.path.exists() and new_log.path.stat().st_size > 0:
+        # JSONL already populated AND legacy still on disk: a previous
+        # attempt wrote some entries then crashed before unlinking, or
+        # an operator copied the legacy file back in. Either way the
+        # state is half-migrated and silently doing nothing would let
+        # the inconsistency drift indefinitely. Surface it explicitly
+        # so an operator inspecting logs notices.
+        logger.warning(
+            "Provenance migration: %s exists and %s also exists with content; "
+            "skipping migration. Inspect both files and remove %s by hand once "
+            "you have confirmed every legacy entry is in the new log.",
+            legacy_path,
+            new_log.path,
+            legacy_path,
+        )
         return
     legacy_entries, status = _read_legacy_provenance_entries(legacy_path)
-    for entry in legacy_entries:
-        sanitised = {k: v for k, v in entry.items() if k != "prev_hash"}
-        new_log.append(sanitised)
-    new_log.append(
-        _provenance_migration_marker(legacy_path, len(legacy_entries), status),
-    )
+    try:
+        for entry in legacy_entries:
+            sanitised = {k: v for k, v in entry.items() if k != "prev_hash"}
+            new_log.append(sanitised)
+        new_log.append(
+            _provenance_migration_marker(legacy_path, len(legacy_entries), status),
+        )
+    except OSError:
+        # Mid-migration failure (disk full, permission flip). The new
+        # log now has partial content so the size guard above will
+        # short-circuit subsequent attempts; the legacy file is left
+        # in place deliberately so no entries are lost. Warn loudly so
+        # the operator can resolve it before the next run silently
+        # treats the partial state as "already migrated".
+        logger.exception(
+            "Provenance migration of %s into %s failed mid-write; legacy file "
+            "left intact for manual reconciliation.",
+            legacy_path,
+            new_log.path,
+        )
+        raise
     legacy_path.unlink(missing_ok=True)
 
 

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -84,15 +84,30 @@ _ACTIVE_DECISION_STATUSES: set[str] = {
 logger = logging.getLogger(__name__)
 
 
-def _read_legacy_provenance_entries(legacy_path: Path) -> list[dict[str, object]]:
-    """Return parsed legacy provenance entries, or empty on any failure."""
+def _read_legacy_provenance_entries(
+    legacy_path: Path,
+) -> tuple[list[dict[str, object]], str]:
+    """Return (entries, status) for the legacy provenance log.
+
+    ``status`` is one of:
+
+    * ``"ok"`` — file parsed cleanly (entries may still be empty if the
+      file held an empty array).
+    * ``"read_failed"`` — :class:`OSError` while reading the file.
+    * ``"parse_failed"`` — file existed but did not parse as JSON or
+      did not contain a list.
+
+    The status is stamped on the migration marker so an operator
+    inspecting the audit log can distinguish a clean migration of an
+    empty legacy file from a transient I/O error that lost data.
+    """
     try:
         raw = legacy_path.read_text(encoding="utf-8")
     except OSError:
         logger.warning("Could not read legacy provenance log %s", legacy_path)
-        return []
+        return [], "read_failed"
     if not raw.strip():
-        return []
+        return [], "ok"
     try:
         data = json.loads(raw)
     except json.JSONDecodeError:
@@ -100,15 +115,16 @@ def _read_legacy_provenance_entries(legacy_path: Path) -> list[dict[str, object]
             "Legacy provenance log %s is not valid JSON; skipping migration",
             legacy_path,
         )
-        return []
+        return [], "parse_failed"
     if not isinstance(data, list):
-        return []
-    return [item for item in data if isinstance(item, dict)]
+        return [], "parse_failed"
+    return [item for item in data if isinstance(item, dict)], "ok"
 
 
 def _provenance_migration_marker(
     legacy_path: Path,
     migrated_count: int,
+    status: str,
 ) -> dict[str, object]:
     """Build the migration marker entry recorded in the new chain."""
     return {
@@ -117,6 +133,7 @@ def _provenance_migration_marker(
         "path": str(legacy_path),
         "written_at": datetime.now().isoformat(),
         "migrated_entries": migrated_count,
+        "migration_status": status,
     }
 
 
@@ -134,15 +151,23 @@ def _migrate_legacy_provenance(
     file. If the new log is already populated we leave the legacy
     file alone so a partially-migrated state can be resolved by
     inspection.
+
+    Defensively strips any caller-supplied ``prev_hash`` field from
+    legacy entries before append — :meth:`AuditLog.append` rejects
+    payloads that try to forge the chain key, and we want migration
+    of older logs to be tolerant rather than blow up at startup.
     """
     if not legacy_path.exists():
         return
     if new_log.path.exists() and new_log.path.stat().st_size > 0:
         return
-    legacy_entries = _read_legacy_provenance_entries(legacy_path)
+    legacy_entries, status = _read_legacy_provenance_entries(legacy_path)
     for entry in legacy_entries:
-        new_log.append(entry)
-    new_log.append(_provenance_migration_marker(legacy_path, len(legacy_entries)))
+        sanitised = {k: v for k, v in entry.items() if k != "prev_hash"}
+        new_log.append(sanitised)
+    new_log.append(
+        _provenance_migration_marker(legacy_path, len(legacy_entries), status),
+    )
     legacy_path.unlink(missing_ok=True)
 
 

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -12,13 +12,13 @@ Obsidian-compatible markdown files with YAML frontmatter. It handles:
 
 from __future__ import annotations
 
-import json
 import re
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
 import frontmatter
 
+from creek.audit import AuditLog
 from creek.models import (
     DecisionStatus,
     PraxisType,
@@ -431,32 +431,26 @@ class VaultWriter:
     ) -> None:
         """Append a provenance entry to the processing log.
 
-        The log is a JSON array stored at
-        ``00-Creek-Meta/Processing-Log/provenance.json``.
+        The log is a JSONL stream (one entry per line, hash-chained for
+        free via :class:`creek.audit.AuditLog`) stored at
+        ``00-Creek-Meta/Processing-Log/provenance.jsonl``. Switching from
+        the previous JSON-array shape eliminates the read-modify-write
+        cycle that made appends ``O(n)`` in log size and dropped
+        concurrent writes (see PERF-002 / BUG-006).
 
         Args:
             model_id: The ID of the written model.
             model_type: The type string of the written model.
             file_path: The path where the model was written.
         """
-        log_dir = self.vault_path / "00-Creek-Meta" / "Processing-Log"
-        log_dir.mkdir(parents=True, exist_ok=True)
-        log_path = log_dir / "provenance.json"
-
-        entries: list[dict[str, str]] = []
-        if log_path.exists():
-            raw = log_path.read_text(encoding="utf-8")
-            if raw.strip():
-                entries = json.loads(raw)
-
-        entry: dict[str, str] = {
-            "id": model_id,
-            "type": model_type,
-            "path": str(file_path),
-            "written_at": datetime.now().isoformat(),
-        }
-        entries.append(entry)
-        log_path.write_text(
-            json.dumps(entries, indent=2),
-            encoding="utf-8",
+        log_path = (
+            self.vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
+        )
+        AuditLog(log_path).append(
+            {
+                "id": model_id,
+                "type": model_type,
+                "path": str(file_path),
+                "written_at": datetime.now().isoformat(),
+            },
         )

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -885,7 +885,7 @@ class VaultWriter:
                 "id": model_id,
                 "type": model_type,
                 "path": str(file_path),
-                "written_at": datetime.now().isoformat(),
+                "written_at": datetime.now(tz=UTC).isoformat(),
             },
         )
 

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import logging
 import re
-from datetime import date, datetime
+from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING
 
 import frontmatter
@@ -126,12 +126,18 @@ def _provenance_migration_marker(
     migrated_count: int,
     status: str,
 ) -> dict[str, object]:
-    """Build the migration marker entry recorded in the new chain."""
+    """Build the migration marker entry recorded in the new chain.
+
+    Timestamp is UTC-stamped to match every other audit log entry in
+    the system; a naive ``datetime.now()`` would produce a local-time
+    string that would not be comparable to the ``timestamp`` fields in
+    the surrounding compliance entries.
+    """
     return {
         "id": "_migration_",
         "type": "provenance.migration",
         "path": str(legacy_path),
-        "written_at": datetime.now().isoformat(),
+        "written_at": datetime.now(tz=UTC).isoformat(),
         "migrated_entries": migrated_count,
         "migration_status": status,
     }

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -198,6 +198,14 @@ class VaultWriter:
                 raise FileNotFoundError(msg)
 
         self.vault_path = vault_path
+        # Reuse a single AuditLog instance across every provenance
+        # append so the per-instance hash cache stays warm across the
+        # vault-writer ingest loop. A fresh AuditLog per call would
+        # collapse the cache and re-introduce the O(N²) read flagged
+        # on PR #193 (BLOCKING review item, comment 4365147477).
+        self._provenance_log = AuditLog(
+            vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl",
+        )
 
     def write_fragment(self, fragment: Fragment, body: str = "") -> Path:
         """Write a Fragment to the appropriate 01-Fragments/ subfolder.
@@ -438,15 +446,17 @@ class VaultWriter:
         cycle that made appends ``O(n)`` in log size and dropped
         concurrent writes (see PERF-002 / BUG-006).
 
+        Reuses :attr:`_provenance_log` so the per-instance hash cache
+        stays warm across calls — vital for 10k-fragment ingest paths
+        where a transient :class:`AuditLog` per call would re-read the
+        whole log every append.
+
         Args:
             model_id: The ID of the written model.
             model_type: The type string of the written model.
             file_path: The path where the model was written.
         """
-        log_path = (
-            self.vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
-        )
-        AuditLog(log_path).append(
+        self._provenance_log.append(
             {
                 "id": model_id,
                 "type": model_type,

--- a/creek-tools/docs/classification.md
+++ b/creek-tools/docs/classification.md
@@ -97,7 +97,7 @@ The Anthropic path is **not** the default — opt in deliberately. Cost on a 10k
 | `personal` | All                 | + named entities, locations, financial detail | Daily notes, journals, decisions. |
 | `intimate` | Title + tags only   | + body                  | Therapy / health / relationship reflections. |
 
-Generation flows (`mine`, `draft`, `report`) honour the tier: `intimate` fragments are excluded by default; `personal` fragments are included but have body text replaced with summaries; `open` fragments pass through unredacted. Override with `--include-tier intimate` if you genuinely want intimate fragments fed to the LLM (this is logged in the audit trail).
+Generation flows (`mine`, `draft`, `report`, `skills`) honour the tier via the shared filter in `creek/classify/privacy_filter.py`: `intimate` fragments are excluded by default; `personal` fragments are included with their body replaced by a title-only summary; `open` (or `public`) fragments pass through unredacted. Override with `--include-tier {open,personal,intimate,all}` if you genuinely want a richer scope; any value above the default writes an audit entry to `<vault>/00-Creek-Meta/audit/privacy.jsonl`.
 
 ## Re-classifying after taxonomy changes
 

--- a/creek-tools/docs/cleaning-and-purge.md
+++ b/creek-tools/docs/cleaning-and-purge.md
@@ -67,9 +67,9 @@ creek clean report --vault ~/Obsidian/Creek-Vault
 `creek purge` is destructive. Every command:
 
 1. **Refuses without confirmation** unless you pass `--yes`.
-2. **Records an audit entry** under `<vault>/00-Creek-Meta/audit/purge-<timestamp>.json` with the criteria, the affected fragment IDs, and the operator.
+2. **Records an audit entry** by appending one JSONL line to `<vault>/00-Creek-Meta/audit/purge.jsonl` with the criteria, the affected fragment IDs, and the operator. The file is hash-chained — see [Audit trail](#audit-trail) for the integrity guarantees.
 3. **Scrubs every reference** — wiki-links pointing at the deleted fragment(s) are removed from every other fragment's frontmatter and body.
-4. **Removes embeddings** from the cache so the deleted content is not surfaceable through resonances.
+4. **Removes embeddings** from the cache at the next `creek link` run so the deleted content is no longer surfaceable through resonances.
 
 ### `creek purge fragment`
 
@@ -120,20 +120,26 @@ creek purge vault --vault ~/Obsidian/Creek-Vault --yes
 
 ## Audit trail
 
-Every purge writes an entry under `<vault>/00-Creek-Meta/audit/`:
+Every purge appends one JSONL line to `<vault>/00-Creek-Meta/audit/purge.jsonl`. Each entry carries an inline `prev_hash` (sha256 of the previous line) so a tampered or truncated log can be detected via the verification API:
 
 ```json
 {
-  "operation": "purge.source",
-  "criteria": {"source_path": "/home/me/exports/unwanted.zip"},
+  "operation": "source",
+  "criteria": {"source_type": "claude"},
   "affected_fragments": ["frag-...", "frag-..."],
   "operator": "sgsg",
   "timestamp": "2026-04-28T18:01:23Z",
   "fragments_deleted": 47,
   "references_scrubbed": 312,
-  "embeddings_removed": 47
+  "embeddings_removed": 47,
+  "dry_run": false,
+  "prev_hash": "0000…"
 }
 ```
+
+`creek redact --apply` writes alongside it at `<vault>/00-Creek-Meta/audit/redact.jsonl`. Privacy-tier overrides (e.g. `creek mine --include-tier intimate`) write to `<vault>/00-Creek-Meta/audit/privacy.jsonl`. Operational provenance from ingestion stays at `<vault>/00-Creek-Meta/Processing-Log/provenance.jsonl` (separate location: not compliance-grade, allowed to be lossy).
+
+A pre-Batch-C `Processing-Log/purge-log.json` from older installs is migrated automatically on first read or write — every legacy entry is replayed into the new chain, a `purge.audit.migration` marker is recorded, and the old file is removed.
 
 The audit trail itself is **not purgeable** by `creek` — it's the system's compliance record. You can `git rm` it manually, but that's outside the tool.
 

--- a/creek-tools/docs/configuration.md
+++ b/creek-tools/docs/configuration.md
@@ -237,6 +237,9 @@ Env-vars take precedence over the YAML file. This is how CI runs `creek-tools` a
 | YAML config                    | `<vault>/00-Creek-Meta/creek_config.yaml` |
 | OAuth refresh token            | `<google_drive.token_file>` (default `token.json`, mode `0o600`) |
 | Embedding cache                | `<vault>/00-Creek-Meta/embeddings.parquet` |
-| Audit log (purges, redactions) | `<vault>/00-Creek-Meta/audit/` |
+| Audit log (purges)             | `<vault>/00-Creek-Meta/audit/purge.jsonl` (hash-chained JSONL) |
+| Audit log (redactions)         | `<vault>/00-Creek-Meta/audit/redact.jsonl` (hash-chained JSONL) |
+| Audit log (privacy overrides)  | `<vault>/00-Creek-Meta/audit/privacy.jsonl` (hash-chained JSONL) |
+| Provenance log (ingest)        | `<vault>/00-Creek-Meta/Processing-Log/provenance.jsonl` (operational; not compliance-grade) |
 | Review queue                   | Frontmatter on each fragment (`review: pending`) |
 | Skill tree                     | `<vault>/creek-skills/` (override with `creek skills --output`) |

--- a/creek-tools/docs/generation.md
+++ b/creek-tools/docs/generation.md
@@ -133,6 +133,7 @@ All generation flows (`mine`, `draft`, `report`, `skills`) respect the privacy t
 - `intimate` fragments are **excluded** from prompts entirely.
 - `personal` fragments contribute a title-only summary, not the full body.
 - `open` (or `public`) fragments contribute full content.
+- `unclassified` fragments are treated as `open` (full body) on the assumption that anything still missing a tier was never deemed sensitive. **Run `creek classify` before generation flows** so each fragment carries an explicit tier; otherwise an unreviewed body could enter an LLM prompt that the privacy filter would have otherwise summarised or excluded. Fragments carrying a tier value the classifier doesn't recognise (e.g. hand-edited frontmatter, a forward-incompatible schema migration) fail **closed** to `intimate` and emit a warning that names the fragment ID.
 
 You can override with `--include-tier {open,personal,intimate,all}` on any of those commands. The default (`open` or omitting the flag) keeps the policy above. `personal` lets personal bodies through unredacted; `intimate` and `all` let intimate bodies through as well. Any value that elevates inclusion above the default appends an entry to `<vault>/00-Creek-Meta/audit/privacy.jsonl` capturing the operator, command, fragment IDs, and timestamp.
 

--- a/creek-tools/docs/generation.md
+++ b/creek-tools/docs/generation.md
@@ -128,13 +128,13 @@ This means every draft can be **re-run** later from the same seed and skill stac
 
 ## Local-first ergonomics
 
-All generation flows respect the privacy tier configuration. By default:
+All generation flows (`mine`, `draft`, `report`, `skills`) respect the privacy tier configuration via the shared filter in `creek/classify/privacy_filter.py`. By default:
 
 - `intimate` fragments are **excluded** from prompts entirely.
-- `personal` fragments contribute summaries, not full bodies.
-- `open` fragments contribute full content.
+- `personal` fragments contribute a title-only summary, not the full body.
+- `open` (or `public`) fragments contribute full content.
 
-You can override with `--include-tier intimate` if you genuinely want intimate content in the prompt — the override is logged in the audit trail.
+You can override with `--include-tier {open,personal,intimate,all}` on any of those commands. The default (`open` or omitting the flag) keeps the policy above. `personal` lets personal bodies through unredacted; `intimate` and `all` let intimate bodies through as well. Any value that elevates inclusion above the default appends an entry to `<vault>/00-Creek-Meta/audit/privacy.jsonl` capturing the operator, command, fragment IDs, and timestamp.
 
 ## Common patterns
 

--- a/creek-tools/docs/redaction.md
+++ b/creek-tools/docs/redaction.md
@@ -86,7 +86,7 @@ Redaction sanitises *content*; it doesn't delete the fragment. If you need a fra
 
 - **Always** scan before `creek ingest` on any new export.
 - **Re-scan** the vault after every classification pass, especially if you've turned on the LLM path — it can occasionally surface PII the rules missed.
-- **Audit** the report monthly. The audit log under `<vault>/00-Creek-Meta/audit/` records every apply.
+- **Audit** the report monthly. Every `creek redact --apply` invocation appends one JSONL entry per touched file to `<vault>/00-Creek-Meta/audit/redact.jsonl` — including dry-runs, marked with `dry_run: true`. The log shares the same hash-chain integrity as the purge audit log; see [cleaning-and-purge.md → Audit trail](cleaning-and-purge.md#audit-trail) for the full schema.
 
 ## How `creek process` interacts with redaction
 

--- a/creek-tools/tests/e2e/test_full_pipeline_purge.py
+++ b/creek-tools/tests/e2e/test_full_pipeline_purge.py
@@ -20,18 +20,7 @@ if TYPE_CHECKING:
 from creek.config import CreekConfig
 from creek.pipeline import Pipeline
 
-pytestmark = [
-    pytest.mark.e2e,
-    pytest.mark.xfail(
-        reason=(
-            "INC-005: purge_source does not yet write to "
-            "00-Creek-Meta/Audit. strict=True so when the audit log "
-            "is wired up the test XPASSES, fails CI, and forces "
-            "removal of this xfail marker."
-        ),
-        strict=True,
-    ),
-]
+pytestmark = [pytest.mark.e2e]
 
 
 def test_purge_round_trip_clears_fragments_and_writes_audit(
@@ -66,6 +55,6 @@ def test_purge_round_trip_clears_fragments_and_writes_audit(
         "Purge engine returned None — purge command may be a stub (INC-002)"
     )
 
-    audit_dir = synthetic_vault / "00-Creek-Meta" / "Audit"
+    audit_dir = synthetic_vault / "00-Creek-Meta" / "audit"
     audit_files = list(audit_dir.glob("*"))
-    assert audit_files, "Purge produced no audit log entry — INC-004 / INC-005 sentinel"
+    assert audit_files, "Purge produced no audit log entry"

--- a/creek-tools/tests/test_audit_log.py
+++ b/creek-tools/tests/test_audit_log.py
@@ -164,3 +164,59 @@ def test_creates_parent_directory(tmp_path: Path) -> None:
     log = AuditLog(tmp_path / "deep" / "nested" / "audit.jsonl")
     log.append({"op": "first"})
     assert log.path.exists()
+
+
+def test_repeated_appends_do_not_rescan_log_when_single_writer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A long single-writer run reuses the cached prev_hash.
+
+    Regression for the O(N²) ``_last_line`` rescan flagged on PR #193:
+    the optimisation is to remember the last hash + post-write file
+    size on the instance, and re-read the file only when a foreign
+    process resizes it. We assert that after the first append the
+    fallback reader is not invoked again.
+    """
+    from creek.audit import log as log_module
+
+    log = AuditLog(tmp_path / "audit.jsonl")
+    log.append({"op": "first"})
+
+    rescans = {"count": 0}
+    real_last_line = log_module._last_line
+
+    def counting_last_line(path: object) -> object:
+        rescans["count"] += 1
+        return real_last_line(path)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(log_module, "_last_line", counting_last_line)
+
+    for i in range(50):
+        log.append({"op": "x", "i": i})
+
+    assert rescans["count"] == 0
+    log.verify()
+
+
+def test_cache_invalidated_when_foreign_writer_resizes_file(
+    tmp_path: Path,
+) -> None:
+    """A foreign-process append (different instance) is detected on next write.
+
+    Two ``AuditLog`` instances on the same path simulate two processes:
+    instance A writes, instance B writes, then A writes again. A's cache
+    is now stale (B grew the file in between); A must rescan to find
+    the true last line, otherwise the chain breaks.
+    """
+    path = tmp_path / "audit.jsonl"
+    log_a = AuditLog(path)
+    log_b = AuditLog(path)
+
+    log_a.append({"op": "a1"})
+    log_b.append({"op": "b1"})
+    log_a.append({"op": "a2"})
+
+    AuditLog(path).verify()
+    entries = [e["op"] for e in AuditLog(path).read()]
+    assert entries == ["a1", "b1", "a2"]

--- a/creek-tools/tests/test_audit_log.py
+++ b/creek-tools/tests/test_audit_log.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
@@ -197,6 +198,55 @@ def test_repeated_appends_do_not_rescan_log_when_single_writer(
 
     assert rescans["count"] == 0
     log.verify()
+
+
+def test_thread_lock_keyed_on_resolved_path(tmp_path: Path) -> None:
+    """Two instances on equivalent paths share the same thread lock.
+
+    Regression for PR #193 review: ``Path("audit.jsonl")`` and
+    ``Path("./audit.jsonl")`` compare unequal but resolve to the same
+    file. If the lock dictionary keyed on the raw ``Path`` they would
+    each get their own ``Lock``, silently breaking cross-thread
+    serialisation. We assert that the resolved-path keying makes the
+    instances share a lock.
+    """
+    from creek.audit.log import _thread_lock_for
+
+    same_file = tmp_path / "audit.jsonl"
+    relative_form = (tmp_path / "." / "audit.jsonl").resolve()
+    lock_a = _thread_lock_for(same_file)
+    lock_b = _thread_lock_for(relative_form)
+    assert lock_a is lock_b
+
+
+def test_append_calls_fsync_for_durability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each append fsyncs the file descriptor before releasing the lock.
+
+    Regression for PR #193 review: ``flush`` only pushes data into the
+    OS page cache; a crash before kernel writeback can silently lose
+    the last entry. We monkeypatch ``os.fsync`` and assert it is called
+    exactly once per append, on a real fd.
+    """
+    from creek.audit import log as log_module
+
+    calls: list[int] = []
+    real_fsync = os.fsync
+
+    def recording_fsync(fd: int) -> None:
+        calls.append(fd)
+        real_fsync(fd)
+
+    monkeypatch.setattr(log_module.os, "fsync", recording_fsync)
+
+    log = AuditLog(tmp_path / "audit.jsonl")
+    log.append({"op": "first"})
+    log.append({"op": "second"})
+
+    assert len(calls) == 2
+    assert all(isinstance(fd, int) and fd >= 0 for fd in calls)
 
 
 def test_cache_invalidated_when_foreign_writer_resizes_file(

--- a/creek-tools/tests/test_audit_log.py
+++ b/creek-tools/tests/test_audit_log.py
@@ -210,13 +210,14 @@ def test_thread_lock_keyed_on_resolved_path(tmp_path: Path) -> None:
     serialisation. We assert that the resolved-path keying makes the
     instances share a lock.
     """
-    from creek.audit.log import _thread_lock_for
+    from creek.audit.log import _thread_lock_holder_for
 
     same_file = tmp_path / "audit.jsonl"
     relative_form = (tmp_path / "." / "audit.jsonl").resolve()
-    lock_a = _thread_lock_for(same_file)
-    lock_b = _thread_lock_for(relative_form)
-    assert lock_a is lock_b
+    holder_a = _thread_lock_holder_for(same_file)
+    holder_b = _thread_lock_holder_for(relative_form)
+    assert holder_a is holder_b
+    assert holder_a.lock is holder_b.lock
 
 
 def test_append_calls_fsync_for_durability(
@@ -270,3 +271,48 @@ def test_cache_invalidated_when_foreign_writer_resizes_file(
     AuditLog(path).verify()
     entries = [e["op"] for e in AuditLog(path).read()]
     assert entries == ["a1", "b1", "a2"]
+
+
+def test_thread_lock_holder_collected_when_no_audit_log_references_it(
+    tmp_path: Path,
+) -> None:
+    """The per-path lock holder is GC-eligible once no AuditLog pins it.
+
+    Regression for PR #193 review (comment 4367360694 HIGH): the prior
+    ``defaultdict[Path, Lock]`` accumulated one lock per distinct path
+    forever, leaking memory in long-running daemons (and in test
+    suites where every ``tmp_path`` is unique). Switching to a
+    ``WeakValueDictionary`` keyed on a holder lets dead entries fall
+    out as soon as the last :class:`AuditLog` for that path is
+    collected.
+
+    We assert the holder is *strongly* referenced while an AuditLog
+    exists (so concurrent AuditLogs on the same path share the lock)
+    and *weakly* referenced afterwards (so the entry is reclaimable).
+    """
+    import gc
+    import weakref
+
+    from creek.audit.log import _THREAD_LOCK_HOLDERS
+
+    path = tmp_path / "gc-audit.jsonl"
+    log = AuditLog(path)
+    log.append({"op": "x"})
+
+    resolved = path.resolve(strict=False)
+    holder = _THREAD_LOCK_HOLDERS.get(resolved)
+    assert holder is not None
+    holder_ref = weakref.ref(holder)
+
+    # While the AuditLog is alive the holder must stay reachable.
+    del holder
+    gc.collect()
+    assert holder_ref() is not None
+    assert _THREAD_LOCK_HOLDERS.get(resolved) is not None
+
+    # Drop the AuditLog (the only strong reference) and the holder
+    # becomes eligible for collection.
+    del log
+    gc.collect()
+    assert holder_ref() is None
+    assert _THREAD_LOCK_HOLDERS.get(resolved) is None

--- a/creek-tools/tests/test_audit_log.py
+++ b/creek-tools/tests/test_audit_log.py
@@ -1,0 +1,166 @@
+"""Tests for the tamper-evident JSONL audit log primitive.
+
+The :class:`creek.audit.AuditLog` is the integrity backbone for every
+compliance log in the project (purge, redaction, privacy overrides). The
+tests in this module exercise three guarantees:
+
+* Append is atomic across threads and processes (no losses, no
+  half-written lines).
+* The hash chain detects any post-hoc tampering with a clear exception.
+* The schema is JSONL — the file remains byte-iterable even mid-run, so
+  ``O_APPEND`` writes never trigger a read-modify-write cycle.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from concurrent.futures import ThreadPoolExecutor
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.audit import AuditChainBroken, AuditLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_append_round_trips_payload(tmp_path: Path) -> None:
+    """A single append is observable via read()."""
+    log = AuditLog(tmp_path / "audit.jsonl")
+    log.append({"operation": "x", "i": 1})
+
+    entries = list(log.read())
+    assert len(entries) == 1
+    assert entries[0]["operation"] == "x"
+    assert entries[0]["i"] == 1
+
+
+def test_append_writes_jsonl_one_entry_per_line(tmp_path: Path) -> None:
+    """Each appended payload becomes one newline-terminated JSON object."""
+    log = AuditLog(tmp_path / "audit.jsonl")
+    log.append({"op": "first"})
+    log.append({"op": "second"})
+
+    raw = log.path.read_text(encoding="utf-8")
+    lines = raw.splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["op"] == "first"
+    assert json.loads(lines[1])["op"] == "second"
+
+
+def test_genesis_prev_hash_is_zero(tmp_path: Path) -> None:
+    """The first entry has a genesis (all-zero) prev_hash."""
+    log = AuditLog(tmp_path / "audit.jsonl")
+    log.append({"op": "first"})
+
+    entry = next(iter(log.read()))
+    assert entry["prev_hash"] == "0" * 64
+
+
+def test_subsequent_prev_hash_matches_previous_line(tmp_path: Path) -> None:
+    """The prev_hash of entry N equals sha256 of entry N-1's bytes."""
+    log = AuditLog(tmp_path / "audit.jsonl")
+    log.append({"op": "first"})
+    log.append({"op": "second"})
+
+    raw = log.path.read_text(encoding="utf-8").splitlines()
+    expected = hashlib.sha256(raw[0].encode("utf-8")).hexdigest()
+    second_entry = json.loads(raw[1])
+    assert second_entry["prev_hash"] == expected
+
+
+def test_verify_passes_for_untampered_log(tmp_path: Path) -> None:
+    """verify() returns silently when every prev_hash is intact."""
+    log = AuditLog(tmp_path / "audit.jsonl")
+    for i in range(5):
+        log.append({"op": "x", "i": i})
+
+    log.verify()
+
+
+def test_verify_rejects_removed_first_entry(tmp_path: Path) -> None:
+    """Removing the first line breaks the chain and verify() raises."""
+    log = AuditLog(tmp_path / "audit.jsonl")
+    log.append({"op": "first"})
+    log.append({"op": "second"})
+
+    lines = log.path.read_text(encoding="utf-8").splitlines()
+    log.path.write_text(lines[1] + "\n", encoding="utf-8")
+
+    with pytest.raises(AuditChainBroken):
+        log.verify()
+
+
+def test_verify_rejects_modified_payload(tmp_path: Path) -> None:
+    """Mutating a stored field breaks the chain at the next entry."""
+    log = AuditLog(tmp_path / "audit.jsonl")
+    log.append({"op": "first", "value": 1})
+    log.append({"op": "second"})
+
+    lines = log.path.read_text(encoding="utf-8").splitlines()
+    tampered_first = lines[0].replace('"value": 1', '"value": 999')
+    log.path.write_text(tampered_first + "\n" + lines[1] + "\n", encoding="utf-8")
+
+    with pytest.raises(AuditChainBroken):
+        log.verify()
+
+
+def test_verify_handles_empty_log(tmp_path: Path) -> None:
+    """An empty log is trivially valid."""
+    log = AuditLog(tmp_path / "audit.jsonl")
+    log.verify()
+
+
+def test_verify_handles_missing_log(tmp_path: Path) -> None:
+    """A missing log is trivially valid (no entries to verify)."""
+    log = AuditLog(tmp_path / "missing.jsonl")
+    log.verify()
+
+
+def test_read_missing_returns_empty(tmp_path: Path) -> None:
+    """read() on a missing log yields no entries."""
+    log = AuditLog(tmp_path / "missing.jsonl")
+    assert list(log.read()) == []
+
+
+def test_concurrent_appends_lose_nothing(tmp_path: Path) -> None:
+    """Eight threads each appending 100 entries lose no entries."""
+    path = tmp_path / "audit.jsonl"
+
+    def append_n(worker: int) -> None:
+        log = AuditLog(path)
+        for j in range(100):
+            log.append({"op": "x", "worker": worker, "j": j})
+
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        list(ex.map(append_n, range(8)))
+
+    log = AuditLog(path)
+    assert sum(1 for _ in log.read()) == 800
+    log.verify()
+
+
+def test_corrupt_line_raises_on_read(tmp_path: Path) -> None:
+    """A malformed JSON line raises AuditChainBroken from verify()."""
+    log = AuditLog(tmp_path / "audit.jsonl")
+    log.append({"op": "first"})
+    log.path.write_text("not json\n", encoding="utf-8")
+
+    with pytest.raises(AuditChainBroken):
+        log.verify()
+
+
+def test_payload_with_prev_hash_is_rejected(tmp_path: Path) -> None:
+    """Caller-supplied prev_hash is forbidden — the log owns the chain."""
+    log = AuditLog(tmp_path / "audit.jsonl")
+    with pytest.raises(ValueError, match="prev_hash"):
+        log.append({"op": "x", "prev_hash": "deadbeef"})
+
+
+def test_creates_parent_directory(tmp_path: Path) -> None:
+    """Append creates the parent directory tree if missing."""
+    log = AuditLog(tmp_path / "deep" / "nested" / "audit.jsonl")
+    log.append({"op": "first"})
+    assert log.path.exists()

--- a/creek-tools/tests/test_cli_privacy.py
+++ b/creek-tools/tests/test_cli_privacy.py
@@ -1,0 +1,170 @@
+"""Tests for the ``--include-tier`` CLI flag and audit-trail wiring.
+
+The flag must be available on every generation surface (``mine``,
+``draft``, ``report``, ``skills``) and must produce an audit-log entry
+whenever the operator elevates inclusion above the default tier.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+from typer.testing import CliRunner
+
+from creek.audit import AuditLog
+from creek.classify.privacy_filter import PRIVACY_AUDIT_RELPATH
+from creek.cli import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Vault fixture
+# ---------------------------------------------------------------------------
+
+
+def _make_mining_vault(tmp_path: Path) -> Path:
+    """Build a vault with an intimate journal fragment and a thread terminus.
+
+    The thread terminus seed surfaces under all strategies regardless of
+    the privacy override, so we can verify the seed list contents based
+    on whether the intimate fragment is included.
+    """
+    vault = tmp_path / "vault"
+    for sub in (
+        "00-Creek-Meta/audit",
+        "01-Fragments/Journal",
+        "02-Threads/Active",
+        "03-Eddies",
+        "10-Liminal/Unnamed",
+    ):
+        (vault / sub).mkdir(parents=True)
+
+    intimate_id = "frag-intimate"
+    intimate_path = vault / "01-Fragments" / "Journal" / "intimate.md"
+    intimate_meta: dict[str, object] = {
+        "id": intimate_id,
+        "title": "Recovery reflections",
+        "type": "fragment",
+        "source": {"platform": "journal", "author": "self", "original_file": "j.md"},
+        "created": datetime(2025, 1, 1, tzinfo=UTC).isoformat(),
+        "frequency": {"primary": "F3", "secondary": []},
+        "wavelength": {
+            "phase": "rising",
+            "mode": "inhabit",
+            "orientation": "do",
+            "dosage": "medicine",
+            "color": "orange",
+            "descriptor": "bright",
+        },
+        "voice": {"voice_register": "confessional", "confidence": "conviction"},
+        "privacy_tier": "intimate",
+    }
+    intimate_path.write_text(
+        frontmatter.dumps(
+            frontmatter.Post(content="intimate body", **intimate_meta),
+        ),
+        encoding="utf-8",
+    )
+
+    thread_path = vault / "02-Threads" / "Active" / "Waves.md"
+    thread_meta: dict[str, object] = {
+        "id": "thread-waves",
+        "title": "Waves",
+        "type": "thread",
+        "status": "active",
+        "fragment_count": 50,
+        "frequency_affinity": ["F3"],
+    }
+    thread_path.write_text(
+        frontmatter.dumps(frontmatter.Post(content="", **thread_meta)),
+        encoding="utf-8",
+    )
+
+    return vault
+
+
+# ---------------------------------------------------------------------------
+# CLI tests
+# ---------------------------------------------------------------------------
+
+
+def test_mine_default_excludes_intimate_no_audit(tmp_path: Path) -> None:
+    """Default ``creek mine`` excludes intimate and writes no audit entry."""
+    vault = _make_mining_vault(tmp_path)
+
+    result = runner.invoke(app, ["mine", "--vault", str(vault)])
+    assert result.exit_code == 0, result.output
+    assert "Recovery reflections" not in result.output
+
+    audit_path = vault / PRIVACY_AUDIT_RELPATH
+    assert not audit_path.exists()
+
+
+def test_mine_with_include_tier_writes_audit(tmp_path: Path) -> None:
+    """``--include-tier intimate`` writes a privacy audit entry."""
+    vault = _make_mining_vault(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "mine",
+            "--vault",
+            str(vault),
+            "--include-tier",
+            "intimate",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    audit_path = vault / PRIVACY_AUDIT_RELPATH
+    assert audit_path.exists()
+    entries = list(AuditLog(audit_path).read())
+    assert len(entries) == 1
+    assert entries[0]["command"] == "mine"
+    assert entries[0]["include_tier"] == "intimate"
+
+
+def test_mine_rejects_unknown_include_tier(tmp_path: Path) -> None:
+    """A bogus ``--include-tier`` value exits with code 2."""
+    vault = _make_mining_vault(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["mine", "--vault", str(vault), "--include-tier", "leaky"],
+    )
+    assert result.exit_code == 2
+    assert "include-tier" in result.output
+
+
+def test_mine_help_mentions_include_tier() -> None:
+    """``creek mine --help`` advertises the new flag."""
+    result = runner.invoke(app, ["mine", "--help"])
+    assert result.exit_code == 0
+    assert "--include-tier" in result.output
+
+
+def test_draft_help_mentions_include_tier() -> None:
+    """``creek draft --help`` advertises the new flag."""
+    result = runner.invoke(app, ["draft", "--help"])
+    assert result.exit_code == 0
+    assert "--include-tier" in result.output
+
+
+def test_report_help_mentions_include_tier() -> None:
+    """``creek report --help`` advertises the new flag."""
+    result = runner.invoke(app, ["report", "--help"])
+    assert result.exit_code == 0
+    assert "--include-tier" in result.output
+
+
+def test_skills_help_mentions_include_tier() -> None:
+    """``creek skills --help`` advertises the new flag."""
+    result = runner.invoke(app, ["skills", "--help"])
+    assert result.exit_code == 0
+    assert "--include-tier" in result.output

--- a/creek-tools/tests/test_cli_privacy.py
+++ b/creek-tools/tests/test_cli_privacy.py
@@ -7,6 +7,7 @@ whenever the operator elevates inclusion above the default tier.
 
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -21,6 +22,18 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 runner = CliRunner()
+
+# Click 8 + Rich emit ANSI styling around dashes when stdout is detected
+# as a terminal (CI runners differ from local CliRunner here), which
+# breaks naive substring searches like ``"--include-tier" in output``
+# because the dashes are split across reset codes. Strip ANSI before
+# asserting on help text.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mGKHF]")
+
+
+def _plain(text: str) -> str:
+    """Return *text* with ANSI escape sequences stripped."""
+    return _ANSI_RE.sub("", text)
 
 
 # ---------------------------------------------------------------------------
@@ -146,25 +159,25 @@ def test_mine_help_mentions_include_tier() -> None:
     """``creek mine --help`` advertises the new flag."""
     result = runner.invoke(app, ["mine", "--help"])
     assert result.exit_code == 0
-    assert "--include-tier" in result.output
+    assert "--include-tier" in _plain(result.output)
 
 
 def test_draft_help_mentions_include_tier() -> None:
     """``creek draft --help`` advertises the new flag."""
     result = runner.invoke(app, ["draft", "--help"])
     assert result.exit_code == 0
-    assert "--include-tier" in result.output
+    assert "--include-tier" in _plain(result.output)
 
 
 def test_report_help_mentions_include_tier() -> None:
     """``creek report --help`` advertises the new flag."""
     result = runner.invoke(app, ["report", "--help"])
     assert result.exit_code == 0
-    assert "--include-tier" in result.output
+    assert "--include-tier" in _plain(result.output)
 
 
 def test_skills_help_mentions_include_tier() -> None:
     """``creek skills --help`` advertises the new flag."""
     result = runner.invoke(app, ["skills", "--help"])
     assert result.exit_code == 0
-    assert "--include-tier" in result.output
+    assert "--include-tier" in _plain(result.output)

--- a/creek-tools/tests/test_cli_redact.py
+++ b/creek-tools/tests/test_cli_redact.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os as real_os
 from typing import TYPE_CHECKING
 
+import pytest
 from typer.testing import CliRunner
 
 from creek.cli import app
@@ -17,9 +18,19 @@ from creek.cli import app
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import pytest
-
 runner = CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _isolate_audit_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Run each test inside its own tmp_path so audit logs do not leak.
+
+    ``creek redact --apply`` writes to ``<vault>/00-Creek-Meta/audit/``
+    where ``<vault>`` defaults to ``Path(".")`` when no ``--vault`` is
+    supplied. Without this fixture the per-test audit JSONL would land
+    in the project's working directory and pollute the source tree.
+    """
+    monkeypatch.chdir(tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/creek-tools/tests/test_generate_privacy_filter.py
+++ b/creek-tools/tests/test_generate_privacy_filter.py
@@ -1,0 +1,151 @@
+"""SEC-006: mining and drafting must filter out intimate fragments by default.
+
+Pinning the behaviour at the engine level (independent of the CLI)
+guards against regressions where a future contributor adds a new
+generation flow that bypasses the shared filter.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.classify.privacy_filter import PrivacyTierOverride
+from creek.generate.drafts import _load_fragments_by_id
+from creek.generate.mining import _load_fragments
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_fragment(
+    fragments_dir: Path,
+    fragment_id: str,
+    *,
+    title: str,
+    privacy_tier: str,
+    body: str,
+) -> None:
+    """Persist a fragment markdown file with the given privacy tier."""
+    metadata: dict[str, object] = {
+        "id": fragment_id,
+        "title": title,
+        "type": "fragment",
+        "source": {
+            "platform": "journal",
+            "author": "self",
+            "original_file": "x.md",
+        },
+        "created": datetime(2025, 1, 1, tzinfo=UTC).isoformat(),
+        "frequency": {"primary": "F3", "secondary": []},
+        "wavelength": {
+            "phase": "rising",
+            "mode": "inhabit",
+            "orientation": "do",
+            "dosage": "medicine",
+            "color": "orange",
+            "descriptor": "bright",
+        },
+        "voice": {"voice_register": "analytical", "confidence": "settled"},
+        "privacy_tier": privacy_tier,
+    }
+    target = fragments_dir / f"{fragment_id}.md"
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
+        encoding="utf-8",
+    )
+
+
+def test_mining_load_excludes_intimate_by_default(tmp_path: Path) -> None:
+    """``_load_fragments`` returns no intimate fragments under default policy."""
+    fragments_dir = tmp_path / "01-Fragments"
+    fragments_dir.mkdir()
+    _write_fragment(
+        fragments_dir, "frag-i", title="Diary", privacy_tier="intimate", body="x"
+    )
+    _write_fragment(
+        fragments_dir, "frag-o", title="Essay", privacy_tier="public", body="y"
+    )
+
+    pairs = _load_fragments(fragments_dir)
+    ids = [f.id for f, _ in pairs]
+    assert ids == ["frag-o"]
+
+
+def test_mining_load_summarises_personal_by_default(tmp_path: Path) -> None:
+    """Personal fragments survive but their bodies are replaced."""
+    fragments_dir = tmp_path / "01-Fragments"
+    fragments_dir.mkdir()
+    _write_fragment(
+        fragments_dir,
+        "frag-p",
+        title="Personal note",
+        privacy_tier="personal",
+        body="confidential body",
+    )
+
+    pairs = _load_fragments(fragments_dir)
+    assert len(pairs) == 1
+    _, body = pairs[0]
+    assert "confidential body" not in body
+    assert "Personal note" in body
+
+
+def test_mining_load_with_intimate_override_includes_full_body(tmp_path: Path) -> None:
+    """``--include-tier intimate`` lets intimate bodies pass through."""
+    fragments_dir = tmp_path / "01-Fragments"
+    fragments_dir.mkdir()
+    _write_fragment(
+        fragments_dir,
+        "frag-i",
+        title="Diary",
+        privacy_tier="intimate",
+        body="diary body",
+    )
+
+    pairs = _load_fragments(
+        fragments_dir,
+        privacy_override=PrivacyTierOverride.INTIMATE,
+    )
+    assert len(pairs) == 1
+    _, body = pairs[0]
+    assert body == "diary body"
+
+
+def test_drafts_load_excludes_intimate_by_default(tmp_path: Path) -> None:
+    """``_load_fragments_by_id`` mirrors the mining default behaviour."""
+    fragments_dir = tmp_path / "01-Fragments"
+    fragments_dir.mkdir()
+    _write_fragment(
+        fragments_dir, "frag-i", title="Diary", privacy_tier="intimate", body="x"
+    )
+    _write_fragment(
+        fragments_dir, "frag-o", title="Essay", privacy_tier="public", body="y"
+    )
+
+    loaded = _load_fragments_by_id(fragments_dir)
+    assert "frag-i" not in loaded
+    assert "frag-o" in loaded
+
+
+def test_drafts_load_with_intimate_override_returns_full_body(tmp_path: Path) -> None:
+    """``--include-tier intimate`` overrides the default for drafts too."""
+    fragments_dir = tmp_path / "01-Fragments"
+    fragments_dir.mkdir()
+    _write_fragment(
+        fragments_dir,
+        "frag-i",
+        title="Diary",
+        privacy_tier="intimate",
+        body="diary body",
+    )
+
+    loaded = _load_fragments_by_id(
+        fragments_dir,
+        privacy_override=PrivacyTierOverride.INTIMATE,
+    )
+    assert "frag-i" in loaded
+    _, body = loaded["frag-i"]
+    assert body == "diary body"

--- a/creek-tools/tests/test_privacy_filter.py
+++ b/creek-tools/tests/test_privacy_filter.py
@@ -128,6 +128,46 @@ def test_unclassified_tier_passes_through_with_full_body() -> None:
     assert body == "raw body"
 
 
+def test_tier_of_unknown_string_fails_closed_to_intimate(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Fragments carrying an unrecognised tier string fail closed.
+
+    Regression for PR #193 review (comment 4367360694 LOW): the prior
+    ``_tier_of`` did ``PrivacyTier(fragment.privacy_tier)`` with no
+    safety net, so a hand-edited or schema-migrated vault with an
+    unknown tier string would crash generation flows. The new helper
+    catches the :class:`ValueError`, logs a warning that names the
+    fragment ID, and returns :data:`PrivacyTier.INTIMATE` so the
+    fragment is excluded from the default-policy output.
+    """
+    from creek.classify.privacy_filter import _tier_of
+
+    # ``model_construct`` skips Pydantic validation, allowing us to
+    # plant a bogus tier value the same way a hand-edited markdown file
+    # or a forward-incompatible schema migration would.
+    bogus = Fragment.model_construct(
+        id="frag-bogus",
+        title="t",
+        source=FragmentSource(
+            platform=SourcePlatform.JOURNAL,
+            author=Authorship.SELF,
+            original_file="x.md",
+        ),
+        created=datetime(2025, 1, 1, tzinfo=UTC),
+        privacy_tier="brand-new-tier-v2",  # type: ignore[arg-type]
+        frequency=FrequencyClassification(primary=Frequency.UNCLASSIFIED, secondary=[]),
+    )
+
+    with caplog.at_level("WARNING", logger="creek.classify.privacy_filter"):
+        tier = _tier_of(bogus)
+
+    assert tier is PrivacyTier.INTIMATE
+    assert any(
+        "frag-bogus" in r.message and "INTIMATE" in r.message for r in caplog.records
+    )
+
+
 def test_open_override_matches_default_behaviour() -> None:
     """``--include-tier open`` explicitly == default (no flag).
 

--- a/creek-tools/tests/test_privacy_filter.py
+++ b/creek-tools/tests/test_privacy_filter.py
@@ -108,6 +108,48 @@ def test_intimate_or_all_lets_everything_through(
     assert bodies == {"frag-i": "secret", "frag-p": "personal", "frag-o": "open"}
 
 
+def test_unclassified_tier_passes_through_with_full_body() -> None:
+    """``unclassified`` is treated as ``open`` — full body, no exclusion.
+
+    Documents and pins the existing fall-through behaviour. Fragments
+    that have not yet been classified are presumed non-sensitive; the
+    classifier should backfill an explicit tier before they enter
+    sensitive flows.
+    """
+    inputs = [
+        _frag(id_="frag-u", tier=PrivacyTier.UNCLASSIFIED, body="raw body"),
+    ]
+
+    out = list(filter_fragments_by_tier(inputs))
+
+    assert len(out) == 1
+    fragment, body = out[0]
+    assert fragment.id == "frag-u"
+    assert body == "raw body"
+
+
+def test_open_override_matches_default_behaviour() -> None:
+    """``--include-tier open`` explicitly == default (no flag).
+
+    The flag value exists for symmetry with ``personal``/``intimate``/
+    ``all``; users who pass it should observe identical filtering to
+    callers who pass nothing.
+    """
+    inputs = [
+        _frag(id_="frag-i", tier=PrivacyTier.INTIMATE, body="x"),
+        _frag(id_="frag-p", tier=PrivacyTier.PERSONAL, body="full"),
+        _frag(id_="frag-o", tier=PrivacyTier.PUBLIC, body="open"),
+    ]
+
+    default_out = list(filter_fragments_by_tier(inputs))
+    open_out = list(
+        filter_fragments_by_tier(inputs, override=PrivacyTierOverride.OPEN),
+    )
+
+    assert [f.id for f, _ in default_out] == [f.id for f, _ in open_out]
+    assert [body for _, body in default_out] == [body for _, body in open_out]
+
+
 def test_override_elevates_matrix() -> None:
     """The elevation predicate is true for everything except None/open."""
     assert not override_elevates(None)

--- a/creek-tools/tests/test_privacy_filter.py
+++ b/creek-tools/tests/test_privacy_filter.py
@@ -1,0 +1,150 @@
+"""Tests for :mod:`creek.classify.privacy_filter`.
+
+The module owns tier filtering for every generation flow, so the tests
+pin down each branch of the override matrix and confirm the privacy
+audit log records exactly the elevated-inclusion calls.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.audit import AuditLog
+from creek.classify.privacy_filter import (
+    PRIVACY_AUDIT_RELPATH,
+    PrivacyTierOverride,
+    filter_fragments_by_tier,
+    override_elevates,
+    parse_include_tier,
+    record_privacy_override,
+)
+from creek.models import (
+    Authorship,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    PrivacyTier,
+    SourcePlatform,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _frag(
+    *, id_: str, tier: PrivacyTier, title: str = "T", body: str = "B"
+) -> tuple[Fragment, str]:
+    """Return a (fragment, body) pair pinned to a specific privacy tier."""
+    fragment = Fragment(
+        id=id_,
+        title=title,
+        source=FragmentSource(
+            platform=SourcePlatform.JOURNAL,
+            author=Authorship.SELF,
+            original_file="x.md",
+        ),
+        created=datetime(2025, 1, 1, tzinfo=UTC),
+        privacy_tier=tier,
+        frequency=FrequencyClassification(primary=Frequency.UNCLASSIFIED, secondary=[]),
+    )
+    return fragment, body
+
+
+def test_default_excludes_intimate_summarises_personal() -> None:
+    """Default policy drops intimate and replaces personal bodies."""
+    inputs = [
+        _frag(id_="frag-i", tier=PrivacyTier.INTIMATE, body="secret stuff"),
+        _frag(id_="frag-p", tier=PrivacyTier.PERSONAL, body="personal stuff"),
+        _frag(id_="frag-o", tier=PrivacyTier.PUBLIC, body="open stuff"),
+    ]
+
+    out = list(filter_fragments_by_tier(inputs))
+
+    ids = [f.id for f, _ in out]
+    assert "frag-i" not in ids
+    bodies = {f.id: body for f, body in out}
+    assert bodies["frag-o"] == "open stuff"
+    assert "personal stuff" not in bodies["frag-p"]
+    assert "summary" in bodies["frag-p"].lower()
+
+
+def test_personal_override_passes_full_body_excludes_intimate() -> None:
+    """``--include-tier personal`` keeps personal bodies, drops intimate."""
+    inputs = [
+        _frag(id_="frag-i", tier=PrivacyTier.INTIMATE, body="x"),
+        _frag(id_="frag-p", tier=PrivacyTier.PERSONAL, body="full body"),
+    ]
+
+    out = list(
+        filter_fragments_by_tier(inputs, override=PrivacyTierOverride.PERSONAL),
+    )
+
+    ids = [f.id for f, _ in out]
+    assert ids == ["frag-p"]
+    assert out[0][1] == "full body"
+
+
+@pytest.mark.parametrize(
+    "override",
+    [PrivacyTierOverride.INTIMATE, PrivacyTierOverride.ALL],
+)
+def test_intimate_or_all_lets_everything_through(
+    override: PrivacyTierOverride,
+) -> None:
+    """``intimate``/``all`` includes every tier with full bodies."""
+    inputs = [
+        _frag(id_="frag-i", tier=PrivacyTier.INTIMATE, body="secret"),
+        _frag(id_="frag-p", tier=PrivacyTier.PERSONAL, body="personal"),
+        _frag(id_="frag-o", tier=PrivacyTier.PUBLIC, body="open"),
+    ]
+
+    out = list(filter_fragments_by_tier(inputs, override=override))
+
+    bodies = {f.id: body for f, body in out}
+    assert bodies == {"frag-i": "secret", "frag-p": "personal", "frag-o": "open"}
+
+
+def test_override_elevates_matrix() -> None:
+    """The elevation predicate is true for everything except None/open."""
+    assert not override_elevates(None)
+    assert not override_elevates(PrivacyTierOverride.OPEN)
+    assert override_elevates(PrivacyTierOverride.PERSONAL)
+    assert override_elevates(PrivacyTierOverride.INTIMATE)
+    assert override_elevates(PrivacyTierOverride.ALL)
+
+
+def test_record_privacy_override_writes_audit_entry(tmp_path: Path) -> None:
+    """Recording an override appends a chained entry to privacy.jsonl."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    record_privacy_override(
+        vault_path=vault,
+        command="mine",
+        fragment_ids=["frag-A", "frag-B"],
+        operator="alice",
+        override=PrivacyTierOverride.INTIMATE,
+    )
+
+    log_path = vault / PRIVACY_AUDIT_RELPATH
+    assert log_path.exists()
+    entries = list(AuditLog(log_path).read())
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["command"] == "mine"
+    assert entry["operator"] == "alice"
+    assert entry["include_tier"] == "intimate"
+    assert entry["fragment_ids"] == ["frag-A", "frag-B"]
+
+
+def test_parse_include_tier_handles_known_and_unknown() -> None:
+    """The parser accepts canonical values and rejects others."""
+    assert parse_include_tier(None) is None
+    assert parse_include_tier("intimate") is PrivacyTierOverride.INTIMATE
+    assert parse_include_tier("ALL") is PrivacyTierOverride.ALL
+    with pytest.raises(ValueError, match="--include-tier"):
+        parse_include_tier("nope")

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -1138,3 +1138,121 @@ def test_audit_log_legacy_corrupt_json_is_skipped(tmp_path: Path) -> None:
     entries = log.read()
 
     assert any(e.operation == "purge.audit.migration" for e in entries)
+
+
+def test_audit_log_migration_with_empty_preexisting_log_does_not_double(
+    tmp_path: Path,
+) -> None:
+    """Empty pre-created log_path + legacy file migrates exactly once.
+
+    Reproduces the edge case flagged in review: an earlier operation
+    may have opened the new JSONL log path in append mode without
+    writing, leaving it on disk at zero bytes. The size guard in
+    :meth:`PurgeAuditLog._migrate_legacy_if_needed` permits the
+    migration to proceed in that case (size > 0 is the only short-
+    circuit). A second construction afterwards must be a no-op,
+    otherwise legacy entries would double on every fresh instance.
+    """
+    vault = _make_vault(tmp_path)
+    legacy_path = vault / "00-Creek-Meta" / "Processing-Log" / "purge-log.json"
+    legacy_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy_path.write_text(
+        json.dumps(
+            [
+                {
+                    "timestamp": "2025-01-01T00:00:00+00:00",
+                    "operation": "fragment",
+                    "target": "frag-empty-precreate",
+                    "count": 1,
+                    "operator": "legacy",
+                    "dry_run": False,
+                },
+            ],
+        ),
+        encoding="utf-8",
+    )
+    new_log_path = vault / "00-Creek-Meta" / "audit" / "purge.jsonl"
+    new_log_path.parent.mkdir(parents=True, exist_ok=True)
+    new_log_path.touch()
+    assert new_log_path.stat().st_size == 0
+
+    first = PurgeAuditLog(vault)
+    first_entries = first.read()
+    first.verify()
+
+    # Migration ran exactly once: legacy fragment + migration marker.
+    assert not legacy_path.exists()
+    assert len(first_entries) == 2
+    assert first_entries[0].operation == "fragment"
+    assert first_entries[1].operation == "purge.audit.migration"
+
+    # A fresh instance must not re-migrate (legacy is gone, log has size).
+    second_entries = PurgeAuditLog(vault).read()
+    assert len(second_entries) == 2
+    assert [e.operation for e in second_entries] == [
+        "fragment",
+        "purge.audit.migration",
+    ]
+
+
+def test_write_audit_known_operations_use_explicit_allowlist(tmp_path: Path) -> None:
+    """Each known operation routes through the explicit allowlist.
+
+    Pins the contract that ``classifications`` records zero deletions
+    while file-deleting operations report ``fragments_affected`` as
+    ``fragments_deleted``. Replaces the previous string-equality
+    inference (``operation != "classifications"``), which would have
+    silently classified any new operation as file-deleting.
+    """
+    vault = _make_vault(tmp_path)
+    engine = PurgeEngine(vault, dry_run=True)
+
+    for operation in ("fragment", "source", "daterange", "vault"):
+        engine._write_audit(
+            PurgeResult(
+                operation=operation,
+                target=f"target-{operation}",
+                fragments_affected=2,
+                affected_fragment_ids=["frag-A", "frag-B"],
+                dry_run=True,
+            ),
+        )
+    engine._write_audit(
+        PurgeResult(
+            operation="classifications",
+            target="target-classifications",
+            fragments_affected=2,
+            affected_fragment_ids=["frag-A", "frag-B"],
+            dry_run=True,
+        ),
+    )
+
+    entries = engine.audit_log.read()
+    by_op = {e.operation: e for e in entries if e.operation != "purge.audit.migration"}
+    assert by_op["fragment"].fragments_deleted == 2
+    assert by_op["source"].fragments_deleted == 2
+    assert by_op["daterange"].fragments_deleted == 2
+    assert by_op["vault"].fragments_deleted == 2
+    assert by_op["classifications"].fragments_deleted == 0
+
+
+def test_write_audit_rejects_unknown_operation(tmp_path: Path) -> None:
+    """An unknown operation name must raise rather than default-include.
+
+    Defaulting unknown operations to ``deletes_files=True`` would silently
+    over-count deletions whenever a new purge type is introduced. This
+    test pins the explicit-rejection contract so any future operation
+    name is forced through the allowlist.
+    """
+    vault = _make_vault(tmp_path)
+    engine = PurgeEngine(vault)
+
+    with pytest.raises(ValueError, match="Unknown purge operation"):
+        engine._write_audit(
+            PurgeResult(
+                operation="brand-new-op",
+                target="t",
+                fragments_affected=99,
+                dry_run=False,
+            ),
+        )

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -1128,7 +1128,13 @@ def test_audit_log_empty_file_is_treated_as_empty(tmp_path: Path) -> None:
 
 
 def test_audit_log_legacy_corrupt_json_is_skipped(tmp_path: Path) -> None:
-    """A malformed legacy log is left alone but does not crash readers."""
+    """A malformed legacy log is left alone but does not crash readers.
+
+    The migration runs (the marker is written so an operator can see
+    that the corrupt file was observed), and the legacy file is then
+    unlinked so subsequent runs do not re-discover it. Asserting the
+    cleanup explicitly closes the gap noted in the PR #193 review.
+    """
     vault = _make_vault(tmp_path)
     legacy_path = vault / "00-Creek-Meta" / "Processing-Log" / "purge-log.json"
     legacy_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1138,6 +1144,7 @@ def test_audit_log_legacy_corrupt_json_is_skipped(tmp_path: Path) -> None:
     entries = log.read()
 
     assert any(e.operation == "purge.audit.migration" for e in entries)
+    assert not legacy_path.exists()
 
 
 def test_audit_log_migration_with_empty_preexisting_log_does_not_double(

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -586,6 +586,49 @@ def test_audit_log_migrates_legacy_purge_log(tmp_path: Path) -> None:
     assert any(e.operation == "purge.audit.migration" for e in entries)
 
 
+def test_audit_log_legacy_migration_strips_prev_hash(tmp_path: Path) -> None:
+    """Legacy purge entries carrying ``prev_hash`` migrate cleanly.
+
+    Mirrors the provenance migration regression test. Without the
+    sanitiser in :meth:`PurgeAuditLog._migrate_legacy_if_needed`,
+    :meth:`creek.audit.AuditLog.append` would raise ``ValueError`` and
+    abort the entire migration with the legacy file still on disk.
+    """
+    vault = _make_vault(tmp_path)
+    legacy_path = vault / "00-Creek-Meta" / "Processing-Log" / "purge-log.json"
+    legacy_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy_path.write_text(
+        json.dumps(
+            [
+                {
+                    "timestamp": "2025-01-01T00:00:00+00:00",
+                    "operation": "fragment",
+                    "target": "frag-with-prev",
+                    "count": 1,
+                    "operator": "legacy",
+                    "dry_run": False,
+                    "prev_hash": "deadbeef" * 8,
+                },
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    log = PurgeAuditLog(vault)
+    entries = log.read()
+
+    # Migration completed: legacy file removed, marker recorded.
+    assert not legacy_path.exists()
+    assert any(e.operation == "purge.audit.migration" for e in entries)
+    # Verify the chain — confirms append() did not blow up midway.
+    log.verify()
+    # The migrated entry's prev_hash on disk is the chain hash, not the
+    # legacy value the test seeded.
+    raw = log.log_path.read_text(encoding="utf-8").splitlines()
+    first = json.loads(raw[0])
+    assert first["prev_hash"] == "0" * 64
+
+
 def test_audit_log_concurrent_appends_lose_nothing(tmp_path: Path) -> None:
     """Threaded appends produce N entries with no losses."""
     from concurrent.futures import ThreadPoolExecutor

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -276,8 +276,10 @@ def test_fragment_purge_writes_audit(tmp_path: Path) -> None:
     assert len(entries) == 1
     entry = entries[0]
     assert entry.operation == "fragment"
-    assert entry.target == "frag-A"
-    assert entry.count == 1
+    assert entry.criteria == {"fragment_id": "frag-A"}
+    assert entry.affected_fragments == ["frag-A"]
+    assert entry.fragments_deleted == 1
+    assert entry.embeddings_removed == 1
     assert entry.operator == "human via CLI"
     assert entry.dry_run is False
 
@@ -492,44 +494,55 @@ def test_audit_log_appends_entries(tmp_path: Path) -> None:
     log = PurgeAuditLog(vault)
 
     log.append(
-        PurgeAuditEntry(operation="fragment", target="frag-A", count=1),
+        PurgeAuditEntry(
+            operation="fragment",
+            criteria={"fragment_id": "frag-A"},
+            affected_fragments=["frag-A"],
+            fragments_deleted=1,
+        ),
     )
     log.append(
-        PurgeAuditEntry(operation="source", target="claude", count=3),
+        PurgeAuditEntry(
+            operation="source",
+            criteria={"source_type": "claude"},
+            fragments_deleted=3,
+        ),
     )
 
     entries = log.read()
     assert len(entries) == 2
-    assert entries[0].target == "frag-A"
-    assert entries[1].target == "claude"
+    assert entries[0].criteria["fragment_id"] == "frag-A"
+    assert entries[1].criteria["source_type"] == "claude"
 
 
 def test_audit_log_path_location(tmp_path: Path) -> None:
-    """Audit log lives at 00-Creek-Meta/Processing-Log/purge-log.json."""
+    """Audit log lives at 00-Creek-Meta/audit/purge.jsonl."""
     vault = _make_vault(tmp_path)
     log = PurgeAuditLog(vault)
-    log.append(PurgeAuditEntry(operation="vault", target="x", count=0))
+    log.append(PurgeAuditEntry(operation="vault"))
 
-    expected = vault / "00-Creek-Meta" / "Processing-Log" / "purge-log.json"
+    expected = vault / "00-Creek-Meta" / "audit" / "purge.jsonl"
     assert expected.exists()
-    data = json.loads(expected.read_text(encoding="utf-8"))
-    assert isinstance(data, list)
-    assert data[0]["operation"] == "vault"
+    lines = expected.read_text(encoding="utf-8").splitlines()
+    payload = json.loads(lines[0])
+    assert payload["operation"] == "vault"
+    assert payload["prev_hash"] == "0" * 64
 
 
-def test_audit_log_recovers_from_corruption(tmp_path: Path) -> None:
-    """Malformed log is rebuilt when appending a new entry."""
+def test_audit_log_chain_detects_tampering(tmp_path: Path) -> None:
+    """Removing the first entry breaks the chain on verify()."""
+    from creek.audit import AuditChainBroken
+
     vault = _make_vault(tmp_path)
     log = PurgeAuditLog(vault)
-    log.log_path.parent.mkdir(parents=True, exist_ok=True)
-    log.log_path.write_text("{not valid json", encoding="utf-8")
+    log.append(PurgeAuditEntry(operation="fragment", criteria={"id": "A"}))
+    log.append(PurgeAuditEntry(operation="fragment", criteria={"id": "B"}))
 
-    log.append(
-        PurgeAuditEntry(operation="fragment", target="frag-A", count=1),
-    )
+    lines = log.log_path.read_text(encoding="utf-8").splitlines()
+    log.log_path.write_text(lines[1] + "\n", encoding="utf-8")
 
-    entries = log.read()
-    assert len(entries) == 1
+    with pytest.raises(AuditChainBroken):
+        log.verify()
 
 
 def test_audit_log_read_missing_returns_empty(tmp_path: Path) -> None:
@@ -537,6 +550,65 @@ def test_audit_log_read_missing_returns_empty(tmp_path: Path) -> None:
     vault = _make_vault(tmp_path)
     log = PurgeAuditLog(vault)
     assert log.read() == []
+
+
+def test_audit_log_migrates_legacy_purge_log(tmp_path: Path) -> None:
+    """Pre-Batch-C purge-log.json is migrated to the new JSONL log."""
+    vault = _make_vault(tmp_path)
+    legacy_path = vault / "00-Creek-Meta" / "Processing-Log" / "purge-log.json"
+    legacy_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy_path.write_text(
+        json.dumps(
+            [
+                {
+                    "timestamp": "2025-01-01T00:00:00+00:00",
+                    "operation": "fragment",
+                    "target": "frag-X",
+                    "count": 1,
+                    "operator": "legacy",
+                    "dry_run": False,
+                },
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    log = PurgeAuditLog(vault)
+    entries = log.read()
+
+    assert not legacy_path.exists()
+    assert log.log_path.exists()
+    assert any(
+        (e.operation == "fragment" and "frag-X" in (e.target or ""))
+        or e.criteria.get("target") == "frag-X"
+        for e in entries
+    )
+    assert any(e.operation == "purge.audit.migration" for e in entries)
+
+
+def test_audit_log_concurrent_appends_lose_nothing(tmp_path: Path) -> None:
+    """Threaded appends produce N entries with no losses."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    vault = _make_vault(tmp_path)
+
+    def append_n(worker: int) -> None:
+        log = PurgeAuditLog(vault)
+        for j in range(20):
+            log.append(
+                PurgeAuditEntry(
+                    operation="fragment",
+                    criteria={"worker": worker, "j": j},
+                ),
+            )
+
+    with ThreadPoolExecutor(max_workers=4) as ex:
+        list(ex.map(append_n, range(4)))
+
+    log = PurgeAuditLog(vault)
+    entries = log.read()
+    assert len(entries) == 80
+    log.verify()
 
 
 # ---------------------------------------------------------------------------
@@ -885,11 +957,14 @@ def test_audit_log_empty_file_is_treated_as_empty(tmp_path: Path) -> None:
     assert log.read() == []
 
 
-def test_audit_log_non_list_json_is_discarded(tmp_path: Path) -> None:
-    """A top-level non-list JSON value is discarded on read."""
+def test_audit_log_legacy_corrupt_json_is_skipped(tmp_path: Path) -> None:
+    """A malformed legacy log is left alone but does not crash readers."""
     vault = _make_vault(tmp_path)
-    log = PurgeAuditLog(vault)
-    log.log_path.parent.mkdir(parents=True, exist_ok=True)
-    log.log_path.write_text('{"not": "a list"}', encoding="utf-8")
+    legacy_path = vault / "00-Creek-Meta" / "Processing-Log" / "purge-log.json"
+    legacy_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy_path.write_text("{not json", encoding="utf-8")
 
-    assert log.read() == []
+    log = PurgeAuditLog(vault)
+    entries = log.read()
+
+    assert any(e.operation == "purge.audit.migration" for e in entries)

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -1195,6 +1195,115 @@ def test_audit_log_migration_with_empty_preexisting_log_does_not_double(
     ]
 
 
+def test_audit_log_migration_oserror_preserves_legacy_and_logs(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mid-migration OSError keeps the legacy file and logs the failure.
+
+    Regression for PR #193 review (comment 4367360694 HIGH): without
+    the explicit try/except, a failed ``AuditLog.append`` (disk full,
+    permission flip) would leave the new JSONL with partial content
+    while silently losing the rest of the legacy entries — and the
+    next instance's size guard would treat the partial state as a
+    clean prior migration. The new code re-raises so the caller sees
+    the failure, leaves the legacy file intact, and emits an
+    EXCEPTION-level log entry the operator can act on.
+    """
+    from creek.audit.log import AuditLog
+
+    vault = _make_vault(tmp_path)
+    legacy_path = vault / "00-Creek-Meta" / "Processing-Log" / "purge-log.json"
+    legacy_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy_path.write_text(
+        json.dumps(
+            [
+                {
+                    "timestamp": "2025-01-01T00:00:00+00:00",
+                    "operation": "fragment",
+                    "target": "frag-doomed",
+                    "count": 1,
+                    "operator": "legacy",
+                    "dry_run": False,
+                },
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    real_append = AuditLog.append
+
+    def failing_append(self: AuditLog, payload: dict[str, object]) -> None:
+        if payload.get("operation") == "fragment":
+            raise OSError("simulated disk full")
+        real_append(self, payload)
+
+    monkeypatch.setattr(AuditLog, "append", failing_append)
+
+    with caplog.at_level("ERROR", logger="creek.purge.audit"), pytest.raises(OSError):
+        PurgeAuditLog(vault).read()
+
+    # Legacy file preserved so no entries are lost.
+    assert legacy_path.exists()
+    # Operator has a high-signal log line to act on.
+    assert any(
+        "failed mid-write" in record.message and "purge-log.json" in record.message
+        for record in caplog.records
+    )
+
+
+def test_audit_log_orphaned_legacy_file_logs_warning(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Half-migrated state (both files present, JSONL non-empty) is logged.
+
+    Regression for PR #193 review (comment 4367360694 HIGH): the size
+    guard would silently skip migration when both the legacy and new
+    log carried content, leaving an operator unaware that the legacy
+    file was orphaned. The warning makes the inconsistency visible
+    the first time it is encountered.
+    """
+    from creek.audit import AuditLog
+
+    vault = _make_vault(tmp_path)
+    legacy_path = vault / "00-Creek-Meta" / "Processing-Log" / "purge-log.json"
+    new_path = vault / "00-Creek-Meta" / "audit" / "purge.jsonl"
+    legacy_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy_path.write_text(
+        json.dumps(
+            [
+                {
+                    "timestamp": "2025-01-01T00:00:00+00:00",
+                    "operation": "fragment",
+                    "target": "frag-orphan",
+                    "count": 1,
+                    "operator": "legacy",
+                    "dry_run": False,
+                },
+            ],
+        ),
+        encoding="utf-8",
+    )
+    AuditLog(new_path).append(
+        {
+            "timestamp": "2025-02-01T00:00:00+00:00",
+            "operation": "fragment",
+            "criteria": {"fragment_id": "frag-already"},
+        },
+    )
+
+    with caplog.at_level("WARNING", logger="creek.purge.audit"):
+        PurgeAuditLog(vault).read()
+
+    assert legacy_path.exists()
+    assert any(
+        "skipping migration" in record.message and "purge-log.json" in record.message
+        for record in caplog.records
+    )
+
+
 def test_write_audit_known_operations_use_explicit_allowlist(tmp_path: Path) -> None:
     """Each known operation routes through the explicit allowlist.
 

--- a/creek-tools/tests/test_redact_audit.py
+++ b/creek-tools/tests/test_redact_audit.py
@@ -1,0 +1,163 @@
+"""Tests for the redaction audit log and ``creek redact --apply`` wiring.
+
+Two surfaces are exercised:
+
+* :class:`creek.redact.audit.RedactionAuditLog` — append/read round trip
+  and chain integrity inherited from :class:`creek.audit.AuditLog`.
+* The ``creek redact --apply`` CLI flow — both ``--dry-run`` and the
+  committed apply must write one entry per touched file.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.redact.audit import RedactionAuditEntry, RedactionAuditLog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+def _write_secret_file(path: Path) -> None:
+    """Write a file containing a synthetic SSN match."""
+    path.write_text("contact: 123-45-6789\n", encoding="utf-8")
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Create a vault with the directories the audit log needs."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta" / "audit").mkdir(parents=True)
+    return vault
+
+
+def test_redaction_audit_round_trips(tmp_path: Path) -> None:
+    """An appended entry is readable through :meth:`RedactionAuditLog.read`."""
+    vault = _make_vault(tmp_path)
+    log = RedactionAuditLog(vault)
+    log.append(
+        RedactionAuditEntry(
+            source_path="/tmp/file.md",
+            pattern_names=["ssn"],
+            match_counts={"ssn": 2},
+        ),
+    )
+
+    entries = log.read()
+    assert len(entries) == 1
+    assert entries[0].source_path == "/tmp/file.md"
+    assert entries[0].match_counts == {"ssn": 2}
+
+
+def test_redaction_audit_path_is_jsonl(tmp_path: Path) -> None:
+    """The redaction audit lives at ``00-Creek-Meta/audit/redact.jsonl``."""
+    vault = _make_vault(tmp_path)
+    log = RedactionAuditLog(vault)
+    log.append(
+        RedactionAuditEntry(source_path="/tmp/x.md", pattern_names=["ssn"]),
+    )
+
+    expected = vault / "00-Creek-Meta" / "audit" / "redact.jsonl"
+    assert log.log_path == expected
+    assert expected.exists()
+    raw = expected.read_text(encoding="utf-8")
+    assert raw.count("\n") == 1
+
+
+def test_cli_redact_apply_writes_audit_entry(tmp_path: Path) -> None:
+    """A committed redact-apply call writes one audit entry per file."""
+    vault = _make_vault(tmp_path)
+    target = tmp_path / "secret.md"
+    _write_secret_file(target)
+
+    result = runner.invoke(
+        app,
+        [
+            "redact",
+            "--apply",
+            "--source",
+            str(target),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    audit_log = RedactionAuditLog(vault)
+    entries = audit_log.read()
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.source_path == str(target)
+    assert entry.dry_run is False
+    assert entry.match_counts.get("ssn", 0) >= 1
+
+
+def test_cli_redact_dry_run_writes_audit_entry(tmp_path: Path) -> None:
+    """A dry-run apply still writes an audit entry, marked dry_run=True."""
+    vault = _make_vault(tmp_path)
+    target = tmp_path / "secret.md"
+    _write_secret_file(target)
+    original = target.read_text(encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "redact",
+            "--apply",
+            "--source",
+            str(target),
+            "--vault",
+            str(vault),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert target.read_text(encoding="utf-8") == original
+    entries = RedactionAuditLog(vault).read()
+    assert len(entries) == 1
+    assert entries[0].dry_run is True
+
+
+def test_cli_redact_no_findings_writes_no_audit_entry(tmp_path: Path) -> None:
+    """A clean source produces no audit entries."""
+    vault = _make_vault(tmp_path)
+    target = tmp_path / "clean.md"
+    target.write_text("nothing to see here\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "redact",
+            "--apply",
+            "--source",
+            str(target),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert RedactionAuditLog(vault).read() == []
+
+
+def test_redaction_audit_chain_integrity(tmp_path: Path) -> None:
+    """Tampering with the redaction log fails verify()."""
+    from creek.audit import AuditChainBroken
+
+    vault = _make_vault(tmp_path)
+    log = RedactionAuditLog(vault)
+    log.append(RedactionAuditEntry(source_path="a.md"))
+    log.append(RedactionAuditEntry(source_path="b.md"))
+
+    lines = log.log_path.read_text(encoding="utf-8").splitlines()
+    log.log_path.write_text(lines[1] + "\n", encoding="utf-8")
+    with pytest.raises(AuditChainBroken):
+        log.verify()

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -919,3 +919,38 @@ class TestProvenanceLogging:
         writer.write_fragment(sample_fragment)
         entries = self._read_entries(self._provenance_path(vault_path))
         assert len(entries) == 1
+
+    def test_provenance_chain_intact_after_many_writes(
+        self,
+        writer: VaultWriter,
+        vault_path: Path,
+    ) -> None:
+        """Many writes share a single AuditLog and produce a valid chain.
+
+        Regression for PR #193 review (comment 4365147477): a transient
+        ``AuditLog`` per provenance write would defeat the per-instance
+        hash cache, re-reading the entire log every append. This test
+        writes ten fragments through ``write_fragment`` and asserts the
+        resulting chain still verifies — caching cannot have broken the
+        chain semantics.
+        """
+        from creek.audit import AuditLog
+
+        for i in range(10):
+            frag = Fragment(
+                id=f"frag-prov-{i:04d}",
+                title=f"Provenance Chain {i}",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=datetime(2025, 1, 15, 10, 30, 0),
+            )
+            writer.write_fragment(frag)
+
+        log_path = self._provenance_path(vault_path)
+        entries = self._read_entries(log_path)
+        assert len(entries) == 10
+        AuditLog(log_path).verify()
+        # Same VaultWriter writes share one AuditLog instance per the
+        # __init__ change. We assert the cache was reused at least once
+        # by checking the cache fields are populated post-run.
+        assert writer._provenance_log._cached_last_hash is not None
+        assert writer._provenance_log._cached_size is not None

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -920,6 +920,82 @@ class TestProvenanceLogging:
         entries = self._read_entries(self._provenance_path(vault_path))
         assert len(entries) == 1
 
+    def test_legacy_provenance_json_migrated_on_first_writer(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """Pre-Batch-C provenance.json is replayed into provenance.jsonl.
+
+        Regression for PR #193 review (comment 4365568699 BLOCKING #2):
+        operators upgrading from a vault that already has the legacy
+        JSON-array log must not lose those entries when the new
+        :class:`creek.audit.AuditLog`-backed JSONL log is constructed.
+        """
+        from creek.audit import AuditLog
+
+        legacy_path = (
+            vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
+        )
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "frag-old-001",
+                        "type": "fragment",
+                        "path": "/tmp/old-frag.md",
+                        "written_at": "2025-12-31T23:59:59",
+                    },
+                    {
+                        "id": "frag-old-002",
+                        "type": "fragment",
+                        "path": "/tmp/old-frag-2.md",
+                        "written_at": "2026-01-01T00:00:00",
+                    },
+                ],
+            ),
+            encoding="utf-8",
+        )
+
+        VaultWriter(vault_path=vault_path)
+
+        new_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
+        assert new_path.exists()
+        assert not legacy_path.exists()
+        entries = self._read_entries(new_path)
+        ids = [e.get("id") for e in entries]
+        assert "frag-old-001" in ids
+        assert "frag-old-002" in ids
+        assert any(e.get("type") == "provenance.migration" for e in entries)
+        AuditLog(new_path).verify()
+
+    def test_legacy_provenance_migration_skipped_when_jsonl_already_populated(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """If the JSONL log already has entries, the legacy JSON is left alone.
+
+        Prevents a half-migrated state from being silently re-migrated;
+        the operator must resolve the inconsistency by inspection.
+        """
+        legacy_path = (
+            vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
+        )
+        new_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text(json.dumps([{"id": "old", "type": "fragment"}]))
+        # Pre-populate the new log via a fresh AuditLog to simulate a
+        # prior partial migration.
+        from creek.audit import AuditLog
+
+        AuditLog(new_path).append({"id": "already-here", "type": "fragment"})
+
+        VaultWriter(vault_path=vault_path)
+
+        assert legacy_path.exists()  # Untouched.
+        ids = [e.get("id") for e in self._read_entries(new_path)]
+        assert ids == ["already-here"]
+
     def test_provenance_chain_intact_after_many_writes(
         self,
         writer: VaultWriter,

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -1112,6 +1112,42 @@ class TestProvenanceLogging:
         ids_after = [e.get("id") for e in self._read_entries(new_path)]
         assert ids_after == ["frag-empty-pre", "_migration_"]
 
+    def test_legacy_provenance_orphaned_file_logs_warning(
+        self,
+        vault_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Half-migrated state (both files present, JSONL non-empty) is logged.
+
+        Regression for PR #193 review (comment 4367360694 HIGH): the
+        size guard would silently skip migration when both the legacy
+        and the new log carried content, leaving an operator unaware
+        that the legacy file was orphaned. The warning makes the
+        inconsistency visible the first time it is encountered.
+        """
+        from creek.audit import AuditLog
+
+        legacy_path = (
+            vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
+        )
+        new_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text(
+            json.dumps([{"id": "orphan-frag", "type": "fragment"}]),
+            encoding="utf-8",
+        )
+        AuditLog(new_path).append({"id": "already-here", "type": "fragment"})
+
+        with caplog.at_level("WARNING", logger="creek.vault.writer"):
+            VaultWriter(vault_path=vault_path)
+
+        assert legacy_path.exists()
+        assert any(
+            "skipping migration" in record.message
+            and "provenance.json" in record.message
+            for record in caplog.records
+        )
+
     def test_provenance_chain_intact_after_many_writes(
         self,
         writer: VaultWriter,

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -1066,6 +1066,52 @@ class TestProvenanceLogging:
         ids = [e.get("id") for e in self._read_entries(new_path)]
         assert ids == ["already-here"]
 
+    def test_legacy_provenance_migration_with_empty_preexisting_jsonl(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """Empty pre-created provenance.jsonl + legacy JSON migrates once.
+
+        Regression for PR #193 review (comment 4367110538 BLOCKING #3):
+        the size guard short-circuits only when the new log has size > 0.
+        An earlier code path may have opened ``provenance.jsonl`` for
+        append (creating it as a 0-byte file) without writing. This test
+        pins that the migration still runs, replays the legacy entries,
+        and a second writer constructed afterwards is a no-op so legacy
+        entries cannot double across instances.
+        """
+        legacy_path = (
+            vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
+        )
+        new_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text(
+            json.dumps(
+                [
+                    {"id": "frag-empty-pre", "type": "fragment"},
+                ],
+            ),
+            encoding="utf-8",
+        )
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        new_path.touch()
+        assert new_path.stat().st_size == 0
+
+        VaultWriter(vault_path=vault_path)
+
+        # First instance migrated cleanly.
+        assert not legacy_path.exists()
+        entries = self._read_entries(new_path)
+        ids = [e.get("id") for e in entries]
+        types = [e.get("type") for e in entries]
+        assert ids == ["frag-empty-pre", "_migration_"]
+        assert types == ["fragment", "provenance.migration"]
+
+        # A second writer must not re-migrate anything.
+        VaultWriter(vault_path=vault_path)
+        ids_after = [e.get("id") for e in self._read_entries(new_path)]
+        assert ids_after == ["frag-empty-pre", "_migration_"]
+
     def test_provenance_chain_intact_after_many_writes(
         self,
         writer: VaultWriter,

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -833,6 +833,20 @@ class TestFilenameUniqueness:
 class TestProvenanceLogging:
     """Tests for provenance log file creation and appending."""
 
+    @staticmethod
+    def _provenance_path(vault_path: Path) -> Path:
+        """Return the canonical JSONL provenance log path."""
+        return vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
+
+    @staticmethod
+    def _read_entries(log_path: Path) -> list[dict[str, Any]]:
+        """Parse a JSONL provenance log into a list of dict entries."""
+        entries: list[dict[str, Any]] = []
+        for line in log_path.read_text(encoding="utf-8").splitlines():
+            if line:
+                entries.append(json.loads(line))
+        return entries
+
     def test_provenance_log_created(
         self,
         writer: VaultWriter,
@@ -841,8 +855,7 @@ class TestProvenanceLogging:
     ) -> None:
         """Writing a fragment creates/updates the provenance log."""
         writer.write_fragment(sample_fragment)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
-        assert log_path.exists()
+        assert self._provenance_path(vault_path).exists()
 
     def test_provenance_log_contains_entry(
         self,
@@ -852,10 +865,7 @@ class TestProvenanceLogging:
     ) -> None:
         """Provenance log contains an entry for the written fragment."""
         writer.write_fragment(sample_fragment)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
-        entries: list[dict[str, Any]] = json.loads(
-            log_path.read_text(encoding="utf-8"),
-        )
+        entries = self._read_entries(self._provenance_path(vault_path))
         assert len(entries) == 1
         assert entries[0]["id"] == "frag-test0001"
         assert entries[0]["type"] == "fragment"
@@ -870,10 +880,7 @@ class TestProvenanceLogging:
         """Multiple writes append to the provenance log."""
         writer.write_fragment(sample_fragment)
         writer.write_thread(sample_thread)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
-        entries: list[dict[str, Any]] = json.loads(
-            log_path.read_text(encoding="utf-8"),
-        )
+        entries = self._read_entries(self._provenance_path(vault_path))
         assert len(entries) == 2
         ids = {e["id"] for e in entries}
         assert "frag-test0001" in ids
@@ -887,10 +894,7 @@ class TestProvenanceLogging:
     ) -> None:
         """Provenance log entry includes the written file path."""
         result = writer.write_fragment(sample_fragment)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
-        entries: list[dict[str, Any]] = json.loads(
-            log_path.read_text(encoding="utf-8"),
-        )
+        entries = self._read_entries(self._provenance_path(vault_path))
         assert entries[0]["path"] == str(result)
 
     def test_provenance_log_has_timestamp(
@@ -901,10 +905,7 @@ class TestProvenanceLogging:
     ) -> None:
         """Provenance log entry includes a timestamp."""
         writer.write_fragment(sample_fragment)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
-        entries: list[dict[str, Any]] = json.loads(
-            log_path.read_text(encoding="utf-8"),
-        )
+        entries = self._read_entries(self._provenance_path(vault_path))
         assert "written_at" in entries[0]
 
     def test_duplicate_not_logged_again(
@@ -916,8 +917,5 @@ class TestProvenanceLogging:
         """Writing a duplicate does not add a second provenance entry."""
         writer.write_fragment(sample_fragment)
         writer.write_fragment(sample_fragment)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
-        entries: list[dict[str, Any]] = json.loads(
-            log_path.read_text(encoding="utf-8"),
-        )
+        entries = self._read_entries(self._provenance_path(vault_path))
         assert len(entries) == 1

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -966,8 +966,71 @@ class TestProvenanceLogging:
         ids = [e.get("id") for e in entries]
         assert "frag-old-001" in ids
         assert "frag-old-002" in ids
-        assert any(e.get("type") == "provenance.migration" for e in entries)
+        marker = next(e for e in entries if e.get("type") == "provenance.migration")
+        assert marker["migrated_entries"] == 2
+        assert marker["migration_status"] == "ok"
         AuditLog(new_path).verify()
+
+    def test_legacy_provenance_migration_marks_corrupt_input(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """Malformed legacy JSON is recorded as ``parse_failed``.
+
+        Distinguishes a clean migration of an empty legacy file from a
+        transient parse failure that lost data — the operator can audit
+        which case occurred.
+        """
+        legacy_path = (
+            vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
+        )
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text("{not valid json", encoding="utf-8")
+
+        VaultWriter(vault_path=vault_path)
+
+        new_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
+        entries = self._read_entries(new_path)
+        marker = next(e for e in entries if e.get("type") == "provenance.migration")
+        assert marker["migration_status"] == "parse_failed"
+        assert marker["migrated_entries"] == 0
+
+    def test_legacy_provenance_migration_strips_prev_hash(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """Legacy entries carrying ``prev_hash`` are sanitised before append.
+
+        :meth:`AuditLog.append` rejects payloads that try to forge the
+        chain key. Migration must be tolerant of older logs that may
+        have stamped ``prev_hash`` themselves rather than blow up at
+        startup.
+        """
+        legacy_path = (
+            vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
+        )
+        legacy_path.parent.mkdir(parents=True, exist_ok=True)
+        legacy_path.write_text(
+            json.dumps(
+                [
+                    {
+                        "id": "frag-with-prev",
+                        "type": "fragment",
+                        "prev_hash": "deadbeef" * 8,
+                    },
+                ],
+            ),
+            encoding="utf-8",
+        )
+
+        VaultWriter(vault_path=vault_path)
+
+        new_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
+        entries = self._read_entries(new_path)
+        migrated = next(e for e in entries if e.get("id") == "frag-with-prev")
+        # The line's prev_hash field is the chain hash, not the legacy
+        # value. Genesis hash of an empty chain is 64 zeros.
+        assert migrated["prev_hash"] == "0" * 64
 
     def test_legacy_provenance_migration_skipped_when_jsonl_already_populated(
         self,


### PR DESCRIPTION
Rebuild the compliance substrate as tamper-evident JSONL with hash-chain
integrity and wire generation flows to the privacy-tier filter.

- Add creek.audit.AuditLog: O_APPEND + fcntl.flock + sha256 chain with
  AuditChainBrokenError on tampering.
- Migrate PurgeAuditLog to <vault>/00-Creek-Meta/audit/purge.jsonl with
  the documented schema (criteria, affected_fragments, fragments_deleted,
  references_scrubbed, embeddings_removed); auto-migrate any legacy
  Processing-Log/purge-log.json on first read or write.
- Switch VaultWriter._log_provenance to JSONL via AuditLog (PERF-002).
- Add RedactionAuditLog and write per-file audit entries from
  creek redact --apply (including --dry-run, marked dry_run=true).
- Add creek.classify.privacy_filter as the single tier-filter helper for
  every generation flow; mining and drafts skip intimate fragments and
  replace personal bodies with title-only summaries by default.
- Add --include-tier {open,personal,intimate,all} to mine, draft, report,
  and skills; elevated values record an audit entry under
  <vault>/00-Creek-Meta/audit/privacy.jsonl.
- Update docs (cleaning-and-purge, redaction, generation, classification,
  configuration) to match the new paths, schemas, and flag behaviour.

Closes SEC-005, SEC-006, INC-004, INC-005, INC-007, INC-015, PERF-002.

https://claude.ai/code/session_015Tt64Vse6keRPvtTQGcdpu