### PR TITLE
perf(batch-e): vault writer + dedup + voice scaling fixes (PERF-001/003/004, BUG-006)

### DIFF
--- a/creek-tools/creek/clean/semantic_dedup.py
+++ b/creek-tools/creek/clean/semantic_dedup.py
@@ -228,9 +228,11 @@ def _matmul_pair_indices(
     """
     import numpy as np
 
-    sim = matrix @ matrix.T
-    np.fill_diagonal(sim, -np.inf)
-    sim_upper = np.triu(sim, k=1)
+    # ``triu(k=1)`` already zeroes the diagonal and lower triangle, and
+    # configured thresholds are always > 0 (enforced in
+    # ``SemanticDeduplicator.__init__``), so the zeroed entries cannot
+    # masquerade as real matches.
+    sim_upper = np.triu(matrix @ matrix.T, k=1)
     rows, cols = np.where(sim_upper >= threshold)
     sims = sim_upper[rows, cols].astype(np.float32, copy=False)
     return rows.astype(np.int64), cols.astype(np.int64), sims
@@ -452,17 +454,28 @@ class SemanticDeduplicator:
         """Return ``(rows, cols, sims)`` for pairs above resonance threshold.
 
         Honors :attr:`DeduplicationConfig.use_faiss` and gracefully
-        degrades to the dense matmul if FAISS is not importable.
+        degrades to the dense matmul only if the top-level ``faiss``
+        import itself fails. ``ImportError`` raised from inside FAISS
+        (e.g. a missing submodule) is **not** swallowed so internal
+        FAISS bugs surface as real failures rather than silent
+        fallbacks.
         """
-        if self.config.use_faiss:
-            try:
-                return _faiss_pair_indices(normalised, self.resonance_threshold)
-            except ImportError:
-                logger.warning(
-                    "use_faiss=True but faiss is not installed — "
-                    "falling back to dense matmul.",
-                )
+        if self.config.use_faiss and self._faiss_available():
+            return _faiss_pair_indices(normalised, self.resonance_threshold)
         return _matmul_pair_indices(normalised, self.resonance_threshold)
+
+    @staticmethod
+    def _faiss_available() -> bool:
+        """Return whether the optional ``faiss`` package is importable."""
+        try:
+            import faiss  # noqa: F401
+        except ImportError:
+            logger.warning(
+                "use_faiss=True but faiss is not installed — "
+                "falling back to dense matmul.",
+            )
+            return False
+        return True
 
     def check_fragment(
         self,

--- a/creek-tools/creek/clean/semantic_dedup.py
+++ b/creek-tools/creek/clean/semantic_dedup.py
@@ -222,20 +222,27 @@ def _matmul_pair_indices(
     """Return upper-triangle (i, j, sim) triples above *threshold* via matmul.
 
     Caller is responsible for ensuring *matrix* has been L2-normalised.
-    Memory peaks at ``N²`` float32 entries (≈ 400 MB at N = 10 000) —
-    acceptable up to that scale and the documented FAISS path takes
-    over for larger corpora.
+
+    Memory: only **one** ``N x N`` float32 matrix is live at a time
+    (≈ 400 MB at N = 10 000). The previous implementation used
+    ``np.triu`` which materialised a second N x N copy alongside the
+    matmul result, doubling peak memory; the current code uses
+    ``np.triu_indices`` to extract the strictly upper-triangle
+    coordinates without copying the matrix.
+
+    The documented FAISS path is the right cutover for larger corpora.
     """
     import numpy as np
 
-    # ``triu(k=1)`` already zeroes the diagonal and lower triangle, and
-    # configured thresholds are always > 0 (enforced in
-    # ``SemanticDeduplicator.__init__``), so the zeroed entries cannot
-    # masquerade as real matches.
-    sim_upper = np.triu(matrix @ matrix.T, k=1)
-    rows, cols = np.where(sim_upper >= threshold)
-    sims = sim_upper[rows, cols].astype(np.float32, copy=False)
-    return rows.astype(np.int64), cols.astype(np.int64), sims
+    sim = matrix @ matrix.T
+    rows, cols = np.triu_indices(sim.shape[0], k=1)
+    upper = sim[rows, cols]
+    mask = upper >= threshold
+    return (
+        rows[mask].astype(np.int64, copy=False),
+        cols[mask].astype(np.int64, copy=False),
+        upper[mask].astype(np.float32, copy=False),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -313,6 +320,10 @@ class SemanticDeduplicator:
         self.resonance_threshold = config.resonance_threshold
         self._index: dict[str, np.ndarray] = {}
         self._dimension: int | None = None
+        # Memoised result of the ``import faiss`` probe in
+        # ``_faiss_available``. ``None`` = not yet probed; ``True`` /
+        # ``False`` = importable / not.
+        self._faiss_probe_cache: bool | None = None
 
     def _validate_embedding(
         self,
@@ -464,9 +475,18 @@ class SemanticDeduplicator:
             return _faiss_pair_indices(normalised, self.resonance_threshold)
         return _matmul_pair_indices(normalised, self.resonance_threshold)
 
-    @staticmethod
-    def _faiss_available() -> bool:
-        """Return whether the optional ``faiss`` package is importable."""
+    def _faiss_available(self) -> bool:
+        """Return whether the optional ``faiss`` package is importable.
+
+        The probe result is cached on the instance so a long-running
+        pipeline that calls :meth:`find_duplicates` repeatedly with
+        ``use_faiss=True`` against a FAISS-less environment emits at
+        most one fallback warning per deduplicator instead of one per
+        call.
+        """
+        cached = self._faiss_probe_cache
+        if cached is not None:
+            return cached
         try:
             import faiss  # noqa: F401
         except ImportError:
@@ -474,7 +494,9 @@ class SemanticDeduplicator:
                 "use_faiss=True but faiss is not installed — "
                 "falling back to dense matmul.",
             )
+            self._faiss_probe_cache = False
             return False
+        self._faiss_probe_cache = True
         return True
 
     def check_fragment(

--- a/creek-tools/creek/clean/semantic_dedup.py
+++ b/creek-tools/creek/clean/semantic_dedup.py
@@ -21,16 +21,30 @@ fragment vs. existing index) processing modes.
 Embedding vectors must all share the same dimensionality.  Mismatched
 dimensions will raise a ``ValueError`` with context about the offending
 fragment and expected size.
+
+The batch path uses a vectorised matmul (``X @ X.T`` after L2
+normalisation) so a 10 000-fragment vault is dominated by BLAS, not Python
+loops. A FAISS-backed approximate-nearest-neighbour fallback is available
+behind :class:`DeduplicationConfig.use_faiss`; FAISS is an optional
+dependency and the code degrades gracefully to the dense matmul when it
+is not installed.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, Field
 
 if TYPE_CHECKING:
     import numpy as np
+    from numpy.typing import NDArray
+
+    FloatArray = NDArray[np.float32]
+
+
+logger = logging.getLogger(__name__)
 
 
 def _cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
@@ -56,6 +70,36 @@ def _cosine_similarity(vec_a: np.ndarray, vec_b: np.ndarray) -> float:
         return 0.0
 
     return float(np.dot(vec_a, vec_b) / (norm_a * norm_b))
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+class DeduplicationConfig(BaseModel):
+    """Tunable knobs for :class:`SemanticDeduplicator`.
+
+    Threshold ranges are enforced inside :class:`SemanticDeduplicator`'s
+    constructor (not by Pydantic) so the validation error message stays
+    consistent across the keyword-argument and config-object code paths.
+
+    Attributes:
+        duplicate_threshold: Cosine similarity at or above which a pair
+            is classified as a duplicate.
+        resonance_threshold: Cosine similarity at or above which (but
+            below ``duplicate_threshold``) a pair is classified as a
+            resonance.
+        use_faiss: When ``True`` and the optional ``faiss`` package is
+            installed, use an approximate-nearest-neighbour index for
+            the batch all-pairs query. Falls back to the dense matmul
+            transparently when ``faiss`` is unavailable so this knob
+            never becomes a hard dependency.
+    """
+
+    duplicate_threshold: float = Field(default=0.95)
+    resonance_threshold: float = Field(default=0.75)
+    use_faiss: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -95,6 +139,104 @@ class SemanticDuplicateResult(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Vectorised similarity helpers
+# ---------------------------------------------------------------------------
+
+
+def _l2_normalise(matrix: FloatArray) -> FloatArray:
+    """Return ``matrix`` row-normalised to unit length.
+
+    Zero rows are preserved as zero rows (rather than producing ``NaN``)
+    so a zero embedding contributes zero similarity to every pair.
+
+    Args:
+        matrix: 2-D array of shape ``(n, d)``.
+
+    Returns:
+        A new array of the same shape with each non-zero row scaled to
+        unit L2 norm.
+    """
+    import numpy as np
+
+    norms = np.linalg.norm(matrix, axis=1, keepdims=True).astype(np.float32)
+    safe = np.where(norms == 0.0, np.float32(1.0), norms)
+    normalised: FloatArray = (matrix / safe).astype(np.float32, copy=False)
+    return normalised
+
+
+def _stack_embeddings(
+    ids: list[str],
+    embeddings: dict[str, list[float]],
+    expected_dim: int,
+) -> FloatArray:
+    """Validate dimensions and stack *ids* into a contiguous float32 matrix."""
+    import numpy as np
+
+    for fid in ids:
+        if len(embeddings[fid]) != expected_dim:
+            msg = (
+                f"Embedding dimension mismatch for fragment "
+                f"'{fid}': expected {expected_dim}, "
+                f"got {len(embeddings[fid])}"
+            )
+            raise ValueError(msg)
+    matrix: FloatArray = np.asarray(
+        [embeddings[fid] for fid in ids],
+        dtype=np.float32,
+    )
+    return matrix
+
+
+def _faiss_pair_indices(
+    matrix: FloatArray,
+    threshold: float,
+) -> tuple[NDArray[np.int64], NDArray[np.int64], NDArray[np.float32]]:
+    """Return upper-triangle (i, j, sim) triples above *threshold* via FAISS.
+
+    Caller is responsible for ensuring ``faiss`` is importable and that
+    *matrix* has been L2-normalised. Falls back to ``range_search`` on
+    ``IndexFlatIP`` so an exact result is returned (useful when the
+    pure-Python matmul would exceed the memory budget).
+    """
+    import faiss  # type: ignore[import-not-found]
+    import numpy as np
+
+    n, dim = matrix.shape
+    index = faiss.IndexFlatIP(dim)
+    index.add(matrix)
+    lims, distances, neighbours = index.range_search(matrix, float(threshold))
+    rows_list: list[np.ndarray] = [
+        np.full(lims[i + 1] - lims[i], i, dtype=np.int64) for i in range(n)
+    ]
+    rows = np.concatenate(rows_list) if rows_list else np.empty(0, dtype=np.int64)
+    cols = neighbours.astype(np.int64)
+    sims = distances.astype(np.float32)
+    upper = cols > rows
+    return rows[upper], cols[upper], sims[upper]
+
+
+def _matmul_pair_indices(
+    matrix: FloatArray,
+    threshold: float,
+) -> tuple[NDArray[np.int64], NDArray[np.int64], NDArray[np.float32]]:
+    """Return upper-triangle (i, j, sim) triples above *threshold* via matmul.
+
+    Caller is responsible for ensuring *matrix* has been L2-normalised.
+    Memory peaks at ``N²`` float32 entries (≈ 400 MB at N = 10 000) —
+    acceptable up to that scale and the documented FAISS path takes
+    over for larger corpora.
+    """
+    import numpy as np
+
+    sim = matrix @ matrix.T
+    np.fill_diagonal(sim, -np.inf)
+    sim_upper = np.triu(sim, k=1)
+    rows, cols = np.where(sim_upper >= threshold)
+    sims = sim_upper[rows, cols].astype(np.float32, copy=False)
+    return rows.astype(np.int64), cols.astype(np.int64), sims
+
+
+# ---------------------------------------------------------------------------
 # Deduplicator
 # ---------------------------------------------------------------------------
 
@@ -111,12 +253,20 @@ class SemanticDeduplicator:
     dimension is set by the first vector added and enforced on subsequent
     additions.
 
+    The batch path uses a vectorised matmul (``X @ X.T``) so 10 000
+    embeddings finish in a few seconds rather than minutes. Pass
+    ``config=DeduplicationConfig(use_faiss=True)`` to opt into the FAISS
+    fallback for very large corpora; FAISS is optional and the code
+    falls back to the matmul if the package is missing.
+
     Attributes:
         duplicate_threshold: Minimum cosine similarity for a pair to be
             classified as a near-duplicate.
         resonance_threshold: Minimum cosine similarity for a pair to be
             classified as a resonance (must be below
             ``duplicate_threshold``).
+        config: The :class:`DeduplicationConfig` driving classification
+            and the choice of similarity backend.
     """
 
     def __init__(
@@ -124,30 +274,41 @@ class SemanticDeduplicator:
         *,
         duplicate_threshold: float = 0.95,
         resonance_threshold: float = 0.75,
+        config: DeduplicationConfig | None = None,
     ) -> None:
         """Initialise the deduplicator with configurable thresholds.
 
         Args:
             duplicate_threshold: Cosine similarity at or above which a
-                pair is classified as a near-duplicate.
+                pair is classified as a near-duplicate. Ignored when
+                *config* is provided.
             resonance_threshold: Cosine similarity at or above which
                 (but below ``duplicate_threshold``) a pair is classified
-                as a resonance.
+                as a resonance. Ignored when *config* is provided.
+            config: Optional :class:`DeduplicationConfig`. When provided,
+                its thresholds and ``use_faiss`` flag take precedence
+                over the standalone keyword arguments.
 
         Raises:
             ValueError: If ``resonance_threshold`` is not less than
                 ``duplicate_threshold``, or if either is outside (0, 1].
         """
-        if not (0.0 < resonance_threshold < duplicate_threshold <= 1.0):
+        if config is None:
+            config = DeduplicationConfig(
+                duplicate_threshold=duplicate_threshold,
+                resonance_threshold=resonance_threshold,
+            )
+        if not (0.0 < config.resonance_threshold < config.duplicate_threshold <= 1.0):
             msg = (
-                f"resonance_threshold ({resonance_threshold}) must be "
-                f"less than duplicate_threshold ({duplicate_threshold}) "
+                f"resonance_threshold ({config.resonance_threshold}) must be "
+                f"less than duplicate_threshold ({config.duplicate_threshold}) "
                 f"and both must be in (0, 1]"
             )
             raise ValueError(msg)
 
-        self.duplicate_threshold = duplicate_threshold
-        self.resonance_threshold = resonance_threshold
+        self.config = config
+        self.duplicate_threshold = config.duplicate_threshold
+        self.resonance_threshold = config.resonance_threshold
         self._index: dict[str, np.ndarray] = {}
         self._dimension: int | None = None
 
@@ -238,7 +399,12 @@ class SemanticDeduplicator:
         Compares all unique pairs and classifies each by cosine
         similarity.  Does **not** modify the internal index.
 
-        All vectors in *embeddings* must have the same dimensionality.
+        Implementation: stacks the embeddings into an ``(N, D)`` float32
+        matrix, L2-normalises rows, and computes the upper-triangle of
+        ``X @ X.T`` in a single BLAS call. Pairs with similarity below
+        ``resonance_threshold`` are filtered out before any Python-level
+        iteration so a 10 000-fragment input that previously needed
+        minutes now finishes in seconds.
 
         Args:
             embeddings: Mapping of fragment IDs to embedding vectors.
@@ -250,40 +416,26 @@ class SemanticDeduplicator:
         Raises:
             ValueError: If embedding dimensions are inconsistent.
         """
+        ids = sorted(embeddings.keys())
+        if len(ids) < 2:
+            return SemanticDuplicateResult(duplicates=[], resonances=[])
+
+        dim = len(embeddings[ids[0]])
+        matrix = _stack_embeddings(ids, embeddings, dim)
+        normalised = _l2_normalise(matrix)
+
+        rows, cols, sims = self._pair_indices(normalised)
+
         duplicates: list[SemanticDuplicatePair] = []
         resonances: list[SemanticDuplicatePair] = []
-
-        ids = sorted(embeddings.keys())
-        if not ids:
-            return SemanticDuplicateResult(
-                duplicates=duplicates,
-                resonances=resonances,
-            )
-
-        import numpy as np  # lazy: numpy lives in the [embeddings] extra
-
-        # Convert to numpy and validate dimensions
-        dim = len(embeddings[ids[0]])
-        vecs: dict[str, np.ndarray] = {}
-        for fid in ids:
-            emb = embeddings[fid]
-            if len(emb) != dim:
-                msg = (
-                    f"Embedding dimension mismatch for fragment "
-                    f"'{fid}': expected {dim}, got {len(emb)}"
-                )
-                raise ValueError(msg)
-            vecs[fid] = np.asarray(emb, dtype=np.float64)
-
-        for i in range(len(ids)):
-            for j in range(i + 1, len(ids)):
-                sim = _cosine_similarity(vecs[ids[i]], vecs[ids[j]])
-                pair = self._classify_pair(ids[i], ids[j], sim)
-                if pair is not None:
-                    if pair.classification == "duplicate":
-                        duplicates.append(pair)
-                    else:
-                        resonances.append(pair)
+        for i, j, sim in zip(rows, cols, sims, strict=True):
+            pair = self._classify_pair(ids[int(i)], ids[int(j)], float(sim))
+            if pair is None:
+                continue
+            if pair.classification == "duplicate":
+                duplicates.append(pair)
+            else:
+                resonances.append(pair)
 
         duplicates.sort(key=lambda p: p.similarity, reverse=True)
         resonances.sort(key=lambda p: p.similarity, reverse=True)
@@ -292,6 +444,25 @@ class SemanticDeduplicator:
             duplicates=duplicates,
             resonances=resonances,
         )
+
+    def _pair_indices(
+        self,
+        normalised: FloatArray,
+    ) -> tuple[NDArray[np.int64], NDArray[np.int64], NDArray[np.float32]]:
+        """Return ``(rows, cols, sims)`` for pairs above resonance threshold.
+
+        Honors :attr:`DeduplicationConfig.use_faiss` and gracefully
+        degrades to the dense matmul if FAISS is not importable.
+        """
+        if self.config.use_faiss:
+            try:
+                return _faiss_pair_indices(normalised, self.resonance_threshold)
+            except ImportError:
+                logger.warning(
+                    "use_faiss=True but faiss is not installed — "
+                    "falling back to dense matmul.",
+                )
+        return _matmul_pair_indices(normalised, self.resonance_threshold)
 
     def check_fragment(
         self,
@@ -303,6 +474,11 @@ class SemanticDeduplicator:
         Compares the given embedding against all indexed fragments
         without modifying the index.  Use :meth:`add_fragment` to add
         the fragment to the index after reviewing results.
+
+        Implementation: stacks the indexed embeddings into a single
+        matrix, normalises both sides, and runs a single matmul so the
+        per-call cost is proportional to a BLAS GEMV rather than ``N``
+        Python-level cosine calls.
 
         Args:
             fragment_id: ID of the fragment to check.
@@ -318,9 +494,6 @@ class SemanticDeduplicator:
         """
         import numpy as np  # lazy: numpy lives in the [embeddings] extra
 
-        duplicates: list[SemanticDuplicatePair] = []
-        resonances: list[SemanticDuplicatePair] = []
-
         if self._dimension is not None and len(embedding) != self._dimension:
             msg = (
                 f"Embedding dimension mismatch for fragment "
@@ -329,15 +502,27 @@ class SemanticDeduplicator:
             )
             raise ValueError(msg)
 
-        vec = np.asarray(embedding, dtype=np.float64)
-        for indexed_id, indexed_vec in self._index.items():
-            sim = _cosine_similarity(vec, indexed_vec)
-            pair = self._classify_pair(fragment_id, indexed_id, sim)
-            if pair is not None:
-                if pair.classification == "duplicate":
-                    duplicates.append(pair)
-                else:
-                    resonances.append(pair)
+        if not self._index:
+            return SemanticDuplicateResult(duplicates=[], resonances=[])
+
+        ids = list(self._index.keys())
+        indexed_matrix: FloatArray = np.asarray(
+            [self._index[fid] for fid in ids],
+            dtype=np.float32,
+        )
+        query: FloatArray = np.asarray(embedding, dtype=np.float32).reshape(1, -1)
+        sims = (_l2_normalise(query) @ _l2_normalise(indexed_matrix).T).reshape(-1)
+
+        duplicates: list[SemanticDuplicatePair] = []
+        resonances: list[SemanticDuplicatePair] = []
+        for indexed_id, sim_value in zip(ids, sims, strict=True):
+            pair = self._classify_pair(fragment_id, indexed_id, float(sim_value))
+            if pair is None:
+                continue
+            if pair.classification == "duplicate":
+                duplicates.append(pair)
+            else:
+                resonances.append(pair)
 
         duplicates.sort(key=lambda p: p.similarity, reverse=True)
         resonances.sort(key=lambda p: p.similarity, reverse=True)

--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -21,13 +21,17 @@ recording the breakdown of confidence levels.
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 import re
 import shutil
+import tempfile
 from collections import Counter
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import frontmatter
@@ -45,8 +49,7 @@ from creek.models import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from pathlib import Path
+    from collections.abc import Iterator, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -160,6 +163,66 @@ def _eligible_register(
     if register not in VOICE_REGISTERS:
         return None
     return register
+
+
+class _JsonlWriter:
+    """Append-only JSONL writer used by the streaming exemplar accumulator.
+
+    Holds the file handle open for the duration of the walk so each
+    appended line costs an ``fwrite`` rather than an ``open + close``,
+    and flushes/closes the handle when the caller invokes
+    :meth:`close` (or the surrounding context manager exits).
+    """
+
+    def __init__(self, path: Path) -> None:
+        """Open *path* for append-binary writing."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Binary mode keeps newlines pristine across platforms; we do
+        # the encoding ourselves so a stray non-UTF8 char surfaces
+        # immediately rather than silently coercing.
+        self._fp = path.open("ab")
+
+    def append(self, payload: dict[str, object]) -> None:
+        """Serialise *payload* as a single JSON line and append it."""
+        line = (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")
+        self._fp.write(line)
+
+    def close(self) -> None:
+        """Flush and close the underlying file handle."""
+        if not self._fp.closed:
+            self._fp.flush()
+            self._fp.close()
+
+
+def _iter_exemplars_from_jsonl(jsonl_path: Path) -> Iterator[Exemplar]:
+    """Yield :class:`Exemplar` objects from a streaming-accumulator JSONL file.
+
+    Lines that fail to parse are skipped with a debug log entry so a
+    partial flush under interrupt does not poison the rest of the
+    register's analysis.
+    """
+    with jsonl_path.open("r", encoding="utf-8") as fp:
+        for line in fp:
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                payload = json.loads(stripped)
+            except json.JSONDecodeError:
+                logger.debug("Skipping malformed exemplar line in %s", jsonl_path)
+                continue
+            if not isinstance(payload, dict):
+                continue
+            fragment_data = payload.get("fragment")
+            body = payload.get("body")
+            if not isinstance(fragment_data, dict) or not isinstance(body, str):
+                continue
+            try:
+                fragment = Fragment.model_validate(fragment_data)
+            except ValidationError:
+                logger.debug("Skipping invalid fragment payload in %s", jsonl_path)
+                continue
+            yield Exemplar(fragment=fragment, body=body)
 
 
 def _load_fragment_with_body(
@@ -1500,9 +1563,12 @@ class VoiceProfileGenerator:
     def generate_all_profiles(self, vault_path: Path) -> list[Path]:
         """Generate profile notes for every register with exemplars.
 
-        Scans ``01-Fragments/`` for qualifying exemplars, groups them by
-        register, extracts patterns from each register's bodies, and
-        writes a profile per non-empty register.
+        Scans ``01-Fragments/`` lazily, routing each qualifying fragment
+        to a per-register JSONL accumulator on disk and dropping its
+        body before reading the next file. Memory therefore peaks at
+        the largest single register, not the whole vault — a 10 000-
+        fragment vault stays well under the 200 MB envelope mandated
+        by PERF-004.
 
         Args:
             vault_path: Path to the root of the Obsidian vault.
@@ -1510,32 +1576,72 @@ class VoiceProfileGenerator:
         Returns:
             List of paths written, one per register with exemplars.
         """
-        grouped = self._collect_exemplars_with_bodies(vault_path)
         written: list[Path] = []
-        for register in VOICE_REGISTERS:
-            register_exemplars = grouped.get(register, [])
-            if not register_exemplars:
-                continue
-            ranked = self._rank_exemplars(register_exemplars)
-            bodies = [e.body for e in ranked]
-            patterns = self._extractor.extract_patterns(bodies)
-            profile = self.generate_profile(register, ranked, patterns)
-            written.append(self.write_profile(profile, vault_path))
+        with self._streaming_accumulator(vault_path) as register_paths:
+            for register in VOICE_REGISTERS:
+                jsonl_path = register_paths.get(register)
+                if jsonl_path is None or not jsonl_path.exists():
+                    continue
+                register_exemplars = list(_iter_exemplars_from_jsonl(jsonl_path))
+                if not register_exemplars:
+                    continue
+                ranked = self._rank_exemplars(register_exemplars)
+                bodies = [e.body for e in ranked]
+                patterns = self._extractor.extract_patterns(bodies)
+                profile = self.generate_profile(register, ranked, patterns)
+                written.append(self.write_profile(profile, vault_path))
+                # Drop the per-register working set before moving on so
+                # the next register's load does not stack on top of it.
+                del register_exemplars, ranked, bodies, patterns, profile
         return written
 
     # ---- Private helpers ----
 
-    def _collect_exemplars_with_bodies(
+    @contextmanager
+    def _streaming_accumulator(
         self,
         vault_path: Path,
-    ) -> dict[str, list[Exemplar]]:
-        """Scan ``01-Fragments/`` for qualifying exemplars with body text."""
-        buckets: dict[str, list[Exemplar]] = {
-            register: [] for register in VOICE_REGISTERS
-        }
-        fragments_dir = vault_path / _FRAGMENTS_SUBDIR
-        if not fragments_dir.is_dir():
-            return buckets
+    ) -> Iterator[dict[str, Path]]:
+        """Stream qualifying fragments into per-register JSONL files.
+
+        Yields a mapping of ``register -> jsonl_path`` for use within
+        :meth:`generate_all_profiles`. The temp directory is deleted on
+        context-manager exit so partial runs leave no debris.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+
+        Yields:
+            Mapping of canonical register name to the absolute path of
+            its JSONL accumulator file. Registers with no qualifying
+            fragments are absent from the mapping.
+        """
+        with tempfile.TemporaryDirectory(prefix="creek-voice-") as tmp:
+            tmp_path = Path(tmp)
+            register_paths: dict[str, Path] = {}
+            register_handles: dict[str, _JsonlWriter] = {}
+            try:
+                fragments_dir = vault_path / _FRAGMENTS_SUBDIR
+                if fragments_dir.is_dir():
+                    self._stream_into(
+                        fragments_dir,
+                        tmp_path,
+                        register_paths,
+                        register_handles,
+                    )
+            finally:
+                for handle in register_handles.values():
+                    handle.close()
+            yield register_paths
+
+    def _stream_into(
+        self,
+        fragments_dir: Path,
+        tmp_path: Path,
+        register_paths: dict[str, Path],
+        register_handles: dict[str, _JsonlWriter],
+    ) -> None:
+        """Walk *fragments_dir* and append eligible exemplars to JSONL files."""
         for md_file in sorted(fragments_dir.rglob("*.md")):
             loaded = _load_fragment_with_body(md_file)
             if loaded is None:
@@ -1547,8 +1653,21 @@ class VoiceProfileGenerator:
             )
             if register is None:
                 continue
-            buckets[register].append(Exemplar(fragment=fragment, body=body))
-        return buckets
+            handle = register_handles.get(register)
+            if handle is None:
+                jsonl_path = tmp_path / f"{register}.jsonl"
+                handle = _JsonlWriter(jsonl_path)
+                register_handles[register] = handle
+                register_paths[register] = jsonl_path
+            handle.append(
+                {
+                    "fragment": fragment.model_dump(mode="json"),
+                    "body": body,
+                }
+            )
+            # Drop the local body reference before the next iteration
+            # so the per-iteration peak is bounded by a single fragment.
+            del body, fragment, loaded
 
     def _rank_exemplars(self, exemplars: list[Exemplar]) -> list[Exemplar]:
         """Rank *exemplars* by the same quality heuristic as the collector.

--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -183,9 +183,16 @@ class _JsonlWriter:
         self._fp = path.open("ab")
 
     def append(self, payload: dict[str, object]) -> None:
-        """Serialise *payload* as a single JSON line and append it."""
+        """Serialise *payload* as a single JSON line and append it.
+
+        Each line is flushed to the OS so an interrupted run (SIGKILL,
+        OOM) leaves a coherent prefix rather than half a line. The
+        flush is per-line; the kernel still buffers to disk, so this
+        is a debuggability gain rather than a durability guarantee.
+        """
         line = (json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8")
         self._fp.write(line)
+        self._fp.flush()
 
     def close(self) -> None:
         """Flush and close the underlying file handle."""

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -6,14 +6,21 @@ Obsidian-compatible markdown files with YAML frontmatter. It handles:
 
 - Mapping each primitive to the correct vault subfolder
 - Sanitising titles into safe filenames
-- Detecting duplicates (by ID) and skipping re-writes
-- Appending provenance entries to the processing log
+- Detecting duplicates (by ID) via a per-directory ``.id-index.json``
+  index — O(1) per write rather than rescanning the directory each time
+- Atomic file creation via ``O_CREAT | O_EXCL`` with counter-suffix
+  retry, so concurrent writers cannot clobber each other's files
+- Appending provenance entries to the processing log under a process
+  lock so concurrent writers do not lose entries
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
+import os
 import re
+import threading
 from datetime import date, datetime
 from typing import TYPE_CHECKING
 
@@ -78,6 +85,21 @@ _ACTIVE_DECISION_STATUSES: set[str] = {
     DecisionStatus.DELIBERATING,
     DecisionStatus.COMMITTING,
 }
+
+INDEX_FILENAME = ".id-index.jsonl"
+"""Per-directory append-only index file mapping ``id`` -> filename.
+
+JSONL format (one JSON object per line, ``{"id": ..., "filename": ...}``)
+keeps each write O(1) — appends never touch existing entries — so a
+directory of 10 000 fragments does not produce O(N²) total work.
+"""
+
+PROVENANCE_FILENAME = "provenance.jsonl"
+"""Append-only provenance log filename under ``00-Creek-Meta/Processing-Log/``.
+
+JSONL format keeps each write O(1) and avoids the read-modify-write
+race that would otherwise lose entries under ``ThreadPoolExecutor``.
+"""
 
 
 def _sanitize_title(title: str) -> str:
@@ -160,6 +182,19 @@ def _extract_date_str(model: BaseModel) -> str:
     return date.today().isoformat()
 
 
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Atomically write *content* to *path* via tempfile + ``os.replace``."""
+    tmp_path = path.with_name(f".{path.name}.tmp")
+    try:
+        with tmp_path.open("w", encoding="utf-8") as fp:
+            fp.write(content)
+        os.replace(tmp_path, path)
+    finally:
+        if tmp_path.exists():
+            with contextlib.suppress(OSError):
+                tmp_path.unlink()
+
+
 class VaultWriter:
     """Write Creek ontological primitives to an Obsidian vault.
 
@@ -168,6 +203,13 @@ class VaultWriter:
     Duplicate detection is based on the model's ``id`` field: if a file
     containing that ID already exists in the target directory, the write
     is skipped and the existing path is returned.
+
+    Per-directory ``.id-index.json`` files persist the ``id -> filename``
+    mapping so duplicate detection is O(1) per write rather than scanning
+    every markdown file in the directory. File creation uses
+    ``O_CREAT | O_EXCL`` so two concurrent threads picking the same
+    filename always retry with a counter suffix instead of clobbering
+    each other.
 
     Args:
         vault_path: Path to the root of the Obsidian vault.
@@ -198,6 +240,14 @@ class VaultWriter:
                 raise FileNotFoundError(msg)
 
         self.vault_path = vault_path
+        # Per-directory in-memory caches of the ``id -> filename`` index.
+        # Loaded lazily on first access; persisted to disk on every
+        # write so a second process picks up entries written by the first.
+        self._dir_indexes: dict[Path, dict[str, str]] = {}
+        # Single process-level lock guards both the in-memory index
+        # cache and the provenance log read-modify-write. Cross-process
+        # safety is out of scope here (see BUG-006: optional fcntl).
+        self._lock = threading.Lock()
 
     def write_fragment(self, fragment: Fragment, body: str = "") -> Path:
         """Write a Fragment to the appropriate 01-Fragments/ subfolder.
@@ -344,8 +394,10 @@ class VaultWriter:
     ) -> Path:
         """Serialise a model to markdown with YAML frontmatter and write to disk.
 
-        Handles duplicate detection (by ID), filename generation,
-        frontmatter serialisation, body rendering, and provenance logging.
+        Uses the per-directory ID index for O(1) duplicate detection,
+        creates the file atomically via ``O_CREAT | O_EXCL`` to prevent
+        concurrent writers from clobbering each other, and updates the
+        index transactionally before logging provenance.
 
         Args:
             model: The Pydantic model to serialise.
@@ -356,28 +408,75 @@ class VaultWriter:
             Path to the written (or existing duplicate) file.
         """
         model_id: str = getattr(model, "id", "")
-        existing = self._find_existing(model_id, target_dir)
-        if existing is not None:
-            return existing
 
-        target_dir.mkdir(parents=True, exist_ok=True)
+        with self._lock:
+            existing = self._find_existing_locked(model_id, target_dir)
+            if existing is not None:
+                return existing
 
-        filename = self._generate_filename(model, target_dir)
-        file_path = target_dir / filename
+            target_dir.mkdir(parents=True, exist_ok=True)
+            base_name = self._compute_base_name(model)
 
-        data = model.model_dump(mode="json")
-        post = frontmatter.Post(content=body, **data)
-        content = frontmatter.dumps(post)
-        file_path.write_text(content, encoding="utf-8")
+            data = model.model_dump(mode="json")
+            post = frontmatter.Post(content=body, **data)
+            content = frontmatter.dumps(post)
 
-        self._log_provenance(model_id, str(getattr(model, "type", "")), file_path)
+            file_path = self._atomic_create(target_dir, base_name, content)
+
+            # Update the in-memory + on-disk index transactionally with
+            # the file write so a follow-up call (or a fresh process)
+            # finds the entry without a directory rescan.
+            index = self._dir_indexes[target_dir]
+            index[model_id] = file_path.name
+            self._append_index_entry(target_dir, model_id, file_path.name)
+
+            self._log_provenance_locked(
+                model_id,
+                str(getattr(model, "type", "")),
+                file_path,
+            )
         return file_path
 
-    def _find_existing(self, model_id: str, target_dir: Path) -> Path | None:
-        """Search for an existing file with the given model ID in target_dir.
+    def _find_existing_locked(
+        self,
+        model_id: str,
+        target_dir: Path,
+    ) -> Path | None:
+        """Return the path of an existing file for *model_id*, or ``None``.
 
-        Reads the frontmatter of each ``.md`` file in the directory and
-        checks if its ``id`` field matches.
+        Caller must hold ``self._lock``. Loads (and caches) the
+        per-directory index on first access; rebuilds it from a
+        directory scan if the index file is missing or corrupt so
+        existing vaults remain compatible.
+
+        Args:
+            model_id: The ID to search for.
+            target_dir: The directory to search in.
+
+        Returns:
+            The path to the existing file, or ``None`` if not indexed
+            or the indexed path no longer exists on disk.
+        """
+        index = self._load_index_locked(target_dir)
+        filename = index.get(model_id)
+        if filename is None:
+            return None
+        candidate = target_dir / filename
+        if candidate.exists():
+            return candidate
+        # Stale entry — drop it from the in-memory cache so the next
+        # write reuses the slot. The on-disk JSONL still contains the
+        # stale line, but it is harmless: the next write appends a new
+        # mapping that overrides it on rebuild, and a future compaction
+        # pass (out of scope for this fix) can reclaim the space.
+        del index[model_id]
+        return None
+
+    def _find_existing(self, model_id: str, target_dir: Path) -> Path | None:
+        """Return the path of an existing file for *model_id*, or ``None``.
+
+        Public-style helper retained for backwards compatibility. Acquires
+        ``self._lock`` for safety and delegates to the locked variant.
 
         Args:
             model_id: The ID to search for.
@@ -386,20 +485,161 @@ class VaultWriter:
         Returns:
             The path to the existing file, or ``None`` if not found.
         """
-        if not target_dir.exists():
-            return None
+        with self._lock:
+            return self._find_existing_locked(model_id, target_dir)
+
+    def _load_index_locked(self, target_dir: Path) -> dict[str, str]:
+        """Return the cached per-directory index, loading it if needed.
+
+        On first access for *target_dir* the index is reconstructed from
+        the JSONL file (later entries overwrite earlier ones, so the
+        last successful write wins). If the JSONL file is missing the
+        index is rebuilt by scanning the directory's ``.md`` files and
+        the result is persisted so subsequent processes skip the scan.
+        """
+        cached = self._dir_indexes.get(target_dir)
+        if cached is not None:
+            return cached
+        index_path = target_dir / INDEX_FILENAME
+        if index_path.exists():
+            index = self._load_index_file(index_path)
+        elif target_dir.is_dir():
+            index = self._rebuild_index(target_dir)
+            self._persist_full_index(target_dir, index)
+        else:
+            index = {}
+        self._dir_indexes[target_dir] = index
+        return index
+
+    @staticmethod
+    def _load_index_file(index_path: Path) -> dict[str, str]:
+        """Parse a JSONL index file into ``{id: filename}``.
+
+        Malformed lines are skipped so a partial write under crash
+        cannot poison the rest of the index. Later entries overwrite
+        earlier ones — appending an entry for an existing id therefore
+        rewrites the mapping in-place.
+        """
+        index: dict[str, str] = {}
+        try:
+            raw = index_path.read_text(encoding="utf-8")
+        except OSError:
+            return index
+        for line in raw.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                entry = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(entry, dict):
+                continue
+            mid = entry.get("id")
+            filename = entry.get("filename")
+            if isinstance(mid, str) and isinstance(filename, str):
+                index[mid] = filename
+        return index
+
+    @staticmethod
+    def _rebuild_index(target_dir: Path) -> dict[str, str]:
+        """Scan *target_dir* for ``.md`` files and rebuild the ID index."""
+        index: dict[str, str] = {}
+        if not target_dir.is_dir():
+            return index
         for md_file in target_dir.glob("*.md"):
-            post = frontmatter.load(str(md_file))
-            if post.get("id") == model_id:
-                return md_file
-        return None
+            try:
+                post = frontmatter.load(str(md_file))
+            except (OSError, ValueError):
+                continue
+            mid = post.get("id")
+            if isinstance(mid, str):
+                index[mid] = md_file.name
+        return index
+
+    @staticmethod
+    def _persist_full_index(target_dir: Path, index: dict[str, str]) -> None:
+        """Atomically write a fresh JSONL index file from *index*.
+
+        Used only on first-time index construction (scanning a vault
+        that predates the index file). Steady-state updates use
+        :meth:`_append_index_entry`, which is O(1) per write.
+        """
+        target_dir.mkdir(parents=True, exist_ok=True)
+        lines = "".join(
+            json.dumps({"id": mid, "filename": filename}, sort_keys=True) + "\n"
+            for mid, filename in sorted(index.items())
+        )
+        _atomic_write_text(target_dir / INDEX_FILENAME, lines)
+
+    @staticmethod
+    def _append_index_entry(target_dir: Path, model_id: str, filename: str) -> None:
+        """Append a single ``{id, filename}`` JSON line to the index.
+
+        Uses ``O_APPEND`` so concurrent appenders cannot interleave
+        partial writes (POSIX guarantees atomicity for line-sized writes
+        under append mode).
+        """
+        target_dir.mkdir(parents=True, exist_ok=True)
+        index_path = target_dir / INDEX_FILENAME
+        encoded = (
+            json.dumps({"id": model_id, "filename": filename}, sort_keys=True) + "\n"
+        ).encode("utf-8")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        fd = os.open(str(index_path), flags, 0o644)
+        try:
+            os.write(fd, encoded)
+        finally:
+            os.close(fd)
+
+    @staticmethod
+    def _compute_base_name(model: BaseModel) -> str:
+        """Return the ``{date}-{title}`` filename stem for *model*."""
+        date_str = _extract_date_str(model)
+        title = getattr(model, "title", "")
+        sanitized = _sanitize_title(title)
+        return f"{date_str}-{sanitized}" if sanitized else date_str
+
+    @staticmethod
+    def _atomic_create(target_dir: Path, base_name: str, content: str) -> Path:
+        """Create ``target_dir/{base_name}.md`` atomically; retry with a counter.
+
+        Uses ``O_CREAT | O_EXCL`` so two concurrent callers picking the
+        same filename will not clobber each other — the second call
+        increments a counter suffix and retries.
+
+        Args:
+            target_dir: Directory the file will live in.
+            base_name: Filename stem (without ``.md``).
+            content: Full file contents to write.
+
+        Returns:
+            The path of the created file.
+        """
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+        encoded = content.encode("utf-8")
+        counter = 0
+        while True:
+            suffix = "" if counter == 0 else f"-{counter}"
+            candidate = target_dir / f"{base_name}{suffix}.md"
+            try:
+                fd = os.open(str(candidate), flags, 0o644)
+            except FileExistsError:
+                counter += 1
+                continue
+            try:
+                os.write(fd, encoded)
+            finally:
+                os.close(fd)
+            return candidate
 
     def _generate_filename(self, model: BaseModel, target_dir: Path) -> str:
-        """Generate a unique filename for the model.
+        """Return a unique filename for *model* under *target_dir*.
 
-        Format: ``{date}-{sanitised_title}.md``. If a file with the
-        same name already exists (title collision with different ID),
-        a numeric suffix is appended.
+        Retained as part of the public API surface for tools that
+        introspect the writer; the production path uses
+        :meth:`_atomic_create` directly to avoid the TOCTOU window
+        between filename selection and file creation.
 
         Args:
             model: The model to generate a filename for.
@@ -408,31 +648,27 @@ class VaultWriter:
         Returns:
             A unique filename string ending in ``.md``.
         """
-        date_str = _extract_date_str(model)
-        title = getattr(model, "title", "")
-        sanitized = _sanitize_title(title)
-
-        base_name = f"{date_str}-{sanitized}" if sanitized else date_str
-
+        base_name = self._compute_base_name(model)
         filename = f"{base_name}.md"
         if not (target_dir / filename).exists():
             return filename
-
         counter = 1
         while (target_dir / f"{base_name}-{counter}.md").exists():
             counter += 1
         return f"{base_name}-{counter}.md"
 
-    def _log_provenance(
+    def _log_provenance_locked(
         self,
         model_id: str,
         model_type: str,
         file_path: Path,
     ) -> None:
-        """Append a provenance entry to the processing log.
+        """Append a provenance entry to the JSONL processing log.
 
-        The log is a JSON array stored at
-        ``00-Creek-Meta/Processing-Log/provenance.json``.
+        Caller must hold ``self._lock``. The log lives at
+        ``00-Creek-Meta/Processing-Log/provenance.jsonl`` with one JSON
+        object per line — appended via ``O_APPEND`` so concurrent
+        writers cannot lose entries in a read-modify-write race.
 
         Args:
             model_id: The ID of the written model.
@@ -441,13 +677,7 @@ class VaultWriter:
         """
         log_dir = self.vault_path / "00-Creek-Meta" / "Processing-Log"
         log_dir.mkdir(parents=True, exist_ok=True)
-        log_path = log_dir / "provenance.json"
-
-        entries: list[dict[str, str]] = []
-        if log_path.exists():
-            raw = log_path.read_text(encoding="utf-8")
-            if raw.strip():
-                entries = json.loads(raw)
+        log_path = log_dir / PROVENANCE_FILENAME
 
         entry: dict[str, str] = {
             "id": model_id,
@@ -455,8 +685,20 @@ class VaultWriter:
             "path": str(file_path),
             "written_at": datetime.now().isoformat(),
         }
-        entries.append(entry)
-        log_path.write_text(
-            json.dumps(entries, indent=2),
-            encoding="utf-8",
-        )
+        encoded = (json.dumps(entry, sort_keys=True) + "\n").encode("utf-8")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
+        fd = os.open(str(log_path), flags, 0o644)
+        try:
+            os.write(fd, encoded)
+        finally:
+            os.close(fd)
+
+    def _log_provenance(
+        self,
+        model_id: str,
+        model_type: str,
+        file_path: Path,
+    ) -> None:
+        """Backwards-compatible shim for callers that bypass ``_write_model``."""
+        with self._lock:
+            self._log_provenance_locked(model_id, model_type, file_path)

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -110,6 +110,24 @@ JSONL format keeps each write O(1) and avoids the read-modify-write
 race that would otherwise lose entries under ``ThreadPoolExecutor``.
 """
 
+LEGACY_PROVENANCE_FILENAME = "provenance.json"
+"""Pre-Batch-E provenance filename. Migrated on first write to JSONL."""
+
+_PIPE_BUF_BYTES = 4096
+"""Linux ``PIPE_BUF`` — the upper bound for guaranteed atomic ``O_APPEND``.
+
+POSIX guarantees that a single ``write(2)`` of at most ``PIPE_BUF``
+bytes to a file opened with ``O_APPEND`` is atomic with respect to
+other appenders (i.e. the write lands as one contiguous chunk and
+cannot interleave with another writer). Larger writes can split.
+On Linux this is 4 096; on some BSDs it can be as low as 512. A
+JSON line of ``{id, type, path, written_at}`` is well under this
+in practice, but an unusually long fragment ID or path would push
+past it. The producers in this module assert their encoded line
+size against ``_PIPE_BUF_BYTES`` so a regression surfaces loudly
+rather than silently corrupting the log.
+"""
+
 
 def _sanitize_title(title: str) -> str:
     """Sanitise a title string into a safe filename component.
@@ -598,14 +616,24 @@ class VaultWriter:
         """Append a single ``{id, filename}`` JSON line to the index.
 
         Uses ``O_APPEND`` so concurrent appenders cannot interleave
-        partial writes (POSIX guarantees atomicity for line-sized writes
-        under append mode).
+        partial writes — POSIX guarantees this only for writes up to
+        :data:`_PIPE_BUF_BYTES`, so the encoded line size is checked
+        before the write to make a regression (e.g. an unusually long
+        fragment ID or filename) fail loudly rather than risk silent
+        interleaving.
         """
         target_dir.mkdir(parents=True, exist_ok=True)
         index_path = target_dir / INDEX_FILENAME
         encoded = (
             json.dumps({"id": model_id, "filename": filename}, sort_keys=True) + "\n"
         ).encode("utf-8")
+        if len(encoded) > _PIPE_BUF_BYTES:
+            msg = (
+                f"Index entry exceeds PIPE_BUF "
+                f"({len(encoded)} > {_PIPE_BUF_BYTES} bytes); "
+                "atomic O_APPEND cannot be guaranteed."
+            )
+            raise ValueError(msg)
         flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
         fd = os.open(str(index_path), flags, 0o644)
         try:
@@ -701,6 +729,12 @@ class VaultWriter:
         object per line — appended via ``O_APPEND`` so concurrent
         writers cannot lose entries in a read-modify-write race.
 
+        On the first call after a vault upgrade, any pre-Batch-E
+        ``provenance.json`` (a JSON array) is migrated forward into the
+        new JSONL log and removed, so vault history written by older
+        ``creek-tools`` releases is preserved rather than silently
+        orphaned.
+
         Args:
             model_id: The ID of the written model.
             model_type: The type string of the written model.
@@ -710,19 +744,73 @@ class VaultWriter:
         log_dir.mkdir(parents=True, exist_ok=True)
         log_path = log_dir / PROVENANCE_FILENAME
 
+        self._migrate_legacy_provenance_locked(log_dir, log_path)
+
         entry: dict[str, str] = {
             "id": model_id,
             "type": model_type,
             "path": str(file_path),
             "written_at": datetime.now().isoformat(),
         }
+        self._append_provenance_entry(log_path, entry)
+
+    @staticmethod
+    def _append_provenance_entry(log_path: Path, entry: dict[str, str]) -> None:
+        """Append a single JSON-encoded entry to *log_path* via ``O_APPEND``.
+
+        Each line is asserted to be at most :data:`_PIPE_BUF_BYTES` so
+        a malformed (oversized) entry trips an explicit error rather
+        than silently risking interleaving with concurrent writers.
+        """
         encoded = (json.dumps(entry, sort_keys=True) + "\n").encode("utf-8")
+        if len(encoded) > _PIPE_BUF_BYTES:
+            msg = (
+                f"Provenance entry exceeds PIPE_BUF "
+                f"({len(encoded)} > {_PIPE_BUF_BYTES} bytes); "
+                "atomic O_APPEND cannot be guaranteed."
+            )
+            raise ValueError(msg)
         flags = os.O_WRONLY | os.O_CREAT | os.O_APPEND
         fd = os.open(str(log_path), flags, 0o644)
         try:
             os.write(fd, encoded)
         finally:
             os.close(fd)
+
+    def _migrate_legacy_provenance_locked(
+        self,
+        log_dir: Path,
+        log_path: Path,
+    ) -> None:
+        """Forward-migrate ``provenance.json`` entries into the JSONL log.
+
+        Caller must hold ``self._lock``. Entries from a pre-Batch-E
+        JSON array are appended one-per-line into the new file and the
+        legacy file is unlinked so repeated invocations do not double-
+        import. Malformed legacy files are silently dropped — the
+        caller's fresh write still succeeds.
+        """
+        legacy_path = log_dir / LEGACY_PROVENANCE_FILENAME
+        if not legacy_path.exists():
+            return
+        try:
+            raw = legacy_path.read_text(encoding="utf-8")
+            parsed = json.loads(raw) if raw.strip() else []
+        except (OSError, json.JSONDecodeError):
+            with contextlib.suppress(OSError):
+                legacy_path.unlink()
+            return
+        if not isinstance(parsed, list):
+            with contextlib.suppress(OSError):
+                legacy_path.unlink()
+            return
+        for raw_entry in parsed:
+            if not isinstance(raw_entry, dict):
+                continue
+            entry = {str(k): str(v) for k, v in raw_entry.items() if isinstance(k, str)}
+            self._append_provenance_entry(log_path, entry)
+        with contextlib.suppress(OSError):
+            legacy_path.unlink()
 
     def _log_provenance(
         self,

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -20,6 +20,7 @@ import contextlib
 import json
 import os
 import re
+import tempfile
 import threading
 from datetime import date, datetime
 from typing import TYPE_CHECKING
@@ -85,6 +86,14 @@ _ACTIVE_DECISION_STATUSES: set[str] = {
     DecisionStatus.DELIBERATING,
     DecisionStatus.COMMITTING,
 }
+
+_MAX_FILENAME_COLLISION_RETRIES = 10_000
+"""Cap on counter-suffix retries inside :meth:`VaultWriter._atomic_create`.
+
+10 000 leaves headroom for any realistic title-collision burst while
+still giving up before an infinite loop hides a bug (e.g. a directory
+that became read-only mid-write).
+"""
 
 INDEX_FILENAME = ".id-index.jsonl"
 """Per-directory append-only index file mapping ``id`` -> filename.
@@ -183,16 +192,28 @@ def _extract_date_str(model: BaseModel) -> str:
 
 
 def _atomic_write_text(path: Path, content: str) -> None:
-    """Atomically write *content* to *path* via tempfile + ``os.replace``."""
-    tmp_path = path.with_name(f".{path.name}.tmp")
+    """Atomically write *content* to *path* via a unique tempfile + ``os.replace``.
+
+    The temp file is created with ``tempfile.NamedTemporaryFile`` in
+    *path*'s directory so two concurrent writers (in-process or
+    cross-process) do not collide on a fixed sidecar name. The rename
+    is atomic on POSIX once both files share a filesystem.
+    """
+    target_dir = path.parent
+    target_dir.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=str(target_dir),
+    )
     try:
-        with tmp_path.open("w", encoding="utf-8") as fp:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fp:
             fp.write(content)
-        os.replace(tmp_path, path)
+        os.replace(tmp_name, path)
     finally:
-        if tmp_path.exists():
+        if os.path.exists(tmp_name):
             with contextlib.suppress(OSError):
-                tmp_path.unlink()
+                os.unlink(tmp_name)
 
 
 class VaultWriter:
@@ -606,7 +627,10 @@ class VaultWriter:
 
         Uses ``O_CREAT | O_EXCL`` so two concurrent callers picking the
         same filename will not clobber each other — the second call
-        increments a counter suffix and retries.
+        increments a counter suffix and retries. The retry loop is
+        capped at :data:`_MAX_FILENAME_COLLISION_RETRIES` so a runaway
+        contention pattern surfaces as a loud ``RuntimeError`` rather
+        than spinning forever.
 
         Args:
             target_dir: Directory the file will live in.
@@ -615,23 +639,30 @@ class VaultWriter:
 
         Returns:
             The path of the created file.
+
+        Raises:
+            RuntimeError: If a unique filename cannot be obtained within
+                :data:`_MAX_FILENAME_COLLISION_RETRIES` attempts.
         """
         flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
         encoded = content.encode("utf-8")
-        counter = 0
-        while True:
+        for counter in range(_MAX_FILENAME_COLLISION_RETRIES):
             suffix = "" if counter == 0 else f"-{counter}"
             candidate = target_dir / f"{base_name}{suffix}.md"
             try:
                 fd = os.open(str(candidate), flags, 0o644)
             except FileExistsError:
-                counter += 1
                 continue
             try:
                 os.write(fd, encoded)
             finally:
                 os.close(fd)
             return candidate
+        msg = (
+            f"Could not allocate a unique filename for '{base_name}.md' in "
+            f"{target_dir} after {_MAX_FILENAME_COLLISION_RETRIES} attempts"
+        )
+        raise RuntimeError(msg)
 
     def _generate_filename(self, model: BaseModel, target_dir: Path) -> str:
         """Return a unique filename for *model* under *target_dir*.

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -6,7 +6,7 @@ Obsidian-compatible markdown files with YAML frontmatter. It handles:
 
 - Mapping each primitive to the correct vault subfolder
 - Sanitising titles into safe filenames
-- Detecting duplicates (by ID) via a per-directory ``.id-index.json``
+- Detecting duplicates (by ID) via a per-directory ``.id-index.jsonl``
   index — O(1) per write rather than rescanning the directory each time
 - Atomic file creation via ``O_CREAT | O_EXCL`` with counter-suffix
   retry, so concurrent writers cannot clobber each other's files
@@ -250,7 +250,7 @@ class VaultWriter:
     containing that ID already exists in the target directory, the write
     is skipped and the existing path is returned.
 
-    Per-directory ``.id-index.json`` files persist the ``id -> filename``
+    Per-directory ``.id-index.jsonl`` files persist the ``id -> filename``
     mapping so duplicate detection is O(1) per write rather than scanning
     every markdown file in the directory. File creation uses
     ``O_CREAT | O_EXCL`` so two concurrent threads picking the same
@@ -460,6 +460,14 @@ class VaultWriter:
         """
         model_id: str = getattr(model, "id", "")
 
+        # The lock is intentionally held across the whole write —
+        # duplicate check, file creation, index append, and provenance
+        # append all run serially within a single process. Narrowing
+        # the critical section would re-introduce the TOCTOU between
+        # ``_find_existing_locked`` and ``_atomic_create`` that BUG-006
+        # was filed to close. The throughput trade-off is documented
+        # in the PR description; revisit only with a benchmark-driven
+        # follow-up issue.
         with self._lock:
             existing = self._find_existing_locked(model_id, target_dir)
             if existing is not None:
@@ -476,8 +484,13 @@ class VaultWriter:
 
             # Update the in-memory + on-disk index transactionally with
             # the file write so a follow-up call (or a fresh process)
-            # finds the entry without a directory rescan.
-            index = self._dir_indexes[target_dir]
+            # finds the entry without a directory rescan. Re-using
+            # ``_load_index_locked`` rather than indexing
+            # ``self._dir_indexes`` directly keeps the cache-population
+            # contract local — the dup-check above happened to load
+            # it, but a future refactor that skips the dup-check
+            # branch would otherwise hit a ``KeyError`` here.
+            index = self._load_index_locked(target_dir)
             index[model_id] = file_path.name
             self._append_index_entry(target_dir, model_id, file_path.name)
 

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -114,18 +114,25 @@ LEGACY_PROVENANCE_FILENAME = "provenance.json"
 """Pre-Batch-E provenance filename. Migrated on first write to JSONL."""
 
 _PIPE_BUF_BYTES = 4096
-"""Linux ``PIPE_BUF`` — the upper bound for guaranteed atomic ``O_APPEND``.
+"""Conservative upper bound on a single ``O_APPEND`` ``write(2)``.
 
-POSIX guarantees that a single ``write(2)`` of at most ``PIPE_BUF``
-bytes to a file opened with ``O_APPEND`` is atomic with respect to
-other appenders (i.e. the write lands as one contiguous chunk and
-cannot interleave with another writer). Larger writes can split.
-On Linux this is 4 096; on some BSDs it can be as low as 512. A
-JSON line of ``{id, type, path, written_at}`` is well under this
-in practice, but an unusually long fragment ID or path would push
-past it. The producers in this module assert their encoded line
-size against ``_PIPE_BUF_BYTES`` so a regression surfaces loudly
-rather than silently corrupting the log.
+POSIX's ``PIPE_BUF`` atomicity guarantee technically applies only to
+pipes and FIFOs. For **regular files** on Linux local filesystems
+(ext4, xfs, btrfs, …), the kernel's VFS write lock causes a single
+``write(2)`` to land as one contiguous chunk regardless of size — but
+that is a Linux implementation detail, not a portable POSIX contract.
+Network filesystems (NFS) and non-Linux platforms may split larger
+writes between concurrent appenders.
+
+This module bounds its append-mode writers at ``PIPE_BUF`` (4 096
+bytes on Linux; 512 bytes on some BSDs) so the same code is safe
+across the platforms this project supports without relying on the
+Linux-specific VFS behaviour. A JSON line of
+``{id, type, path, written_at}`` is well under that limit in
+practice, but an unusually long fragment ID or path would push past
+it; the producers in this module assert their encoded line size
+against ``_PIPE_BUF_BYTES`` so a regression surfaces loudly rather
+than silently risking interleaved writes.
 """
 
 
@@ -287,6 +294,11 @@ class VaultWriter:
         # cache and the provenance log read-modify-write. Cross-process
         # safety is out of scope here (see BUG-006: optional fcntl).
         self._lock = threading.Lock()
+        # Legacy ``provenance.json`` migration runs at most once per
+        # writer instance. The flag short-circuits the per-write
+        # ``legacy_path.exists()`` stat after the first migration,
+        # whether it succeeded, found nothing, or failed gracefully.
+        self._legacy_provenance_migrated = False
 
     def write_fragment(self, fragment: Fragment, body: str = "") -> Path:
         """Write a Fragment to the appropriate 01-Fragments/ subfolder.
@@ -514,8 +526,10 @@ class VaultWriter:
     def _find_existing(self, model_id: str, target_dir: Path) -> Path | None:
         """Return the path of an existing file for *model_id*, or ``None``.
 
-        Public-style helper retained for backwards compatibility. Acquires
-        ``self._lock`` for safety and delegates to the locked variant.
+        Retained for tests and tooling that introspect the writer
+        without going through ``_write_model``. Acquires ``self._lock``
+        and delegates to the locked variant so the caller does not have
+        to know about the lock invariant.
 
         Args:
             model_id: The ID to search for.
@@ -695,10 +709,10 @@ class VaultWriter:
     def _generate_filename(self, model: BaseModel, target_dir: Path) -> str:
         """Return a unique filename for *model* under *target_dir*.
 
-        Retained as part of the public API surface for tools that
-        introspect the writer; the production path uses
-        :meth:`_atomic_create` directly to avoid the TOCTOU window
-        between filename selection and file creation.
+        Retained for tests and tooling that introspect the writer; the
+        production path uses :meth:`_atomic_create` directly to avoid
+        the TOCTOU window between filename selection and file creation.
+        New callers should prefer :meth:`_atomic_create`.
 
         Args:
             model: The model to generate a filename for.
@@ -786,31 +800,62 @@ class VaultWriter:
 
         Caller must hold ``self._lock``. Entries from a pre-Batch-E
         JSON array are appended one-per-line into the new file and the
-        legacy file is unlinked so repeated invocations do not double-
-        import. Malformed legacy files are silently dropped — the
-        caller's fresh write still succeeds.
+        legacy file is **always** unlinked when this method returns —
+        even if some individual entries cannot be migrated (malformed,
+        oversized for ``PIPE_BUF``, etc.). Without that guarantee a
+        single bad entry would leave ``provenance.json`` in place and
+        the migration would re-fire on every subsequent write,
+        permanently blocking vault upgrades for unlucky vaults.
+
+        After the first successful (or first attempted) migration, the
+        ``_legacy_provenance_migrated`` flag short-circuits the stat on
+        every subsequent call so the steady-state per-write cost is one
+        boolean check rather than a filesystem hit.
         """
+        if self._legacy_provenance_migrated:
+            return
         legacy_path = log_dir / LEGACY_PROVENANCE_FILENAME
         if not legacy_path.exists():
+            self._legacy_provenance_migrated = True
             return
+        try:
+            self._migrate_legacy_provenance_body(legacy_path, log_path)
+        finally:
+            with contextlib.suppress(OSError):
+                legacy_path.unlink()
+            self._legacy_provenance_migrated = True
+
+    def _migrate_legacy_provenance_body(
+        self,
+        legacy_path: Path,
+        log_path: Path,
+    ) -> None:
+        """Read and append entries from *legacy_path*; tolerate per-entry failures.
+
+        Extracted so :meth:`_migrate_legacy_provenance_locked` can wrap
+        the whole body in a ``try/finally`` that always removes the
+        legacy file regardless of which entry tripped a recoverable
+        failure (oversized line, malformed shape, partial content).
+        """
         try:
             raw = legacy_path.read_text(encoding="utf-8")
             parsed = json.loads(raw) if raw.strip() else []
         except (OSError, json.JSONDecodeError):
-            with contextlib.suppress(OSError):
-                legacy_path.unlink()
             return
         if not isinstance(parsed, list):
-            with contextlib.suppress(OSError):
-                legacy_path.unlink()
             return
         for raw_entry in parsed:
             if not isinstance(raw_entry, dict):
                 continue
             entry = {str(k): str(v) for k, v in raw_entry.items() if isinstance(k, str)}
-            self._append_provenance_entry(log_path, entry)
-        with contextlib.suppress(OSError):
-            legacy_path.unlink()
+            try:
+                self._append_provenance_entry(log_path, entry)
+            except ValueError:
+                # Oversized legacy entry (rare: a path/id past PIPE_BUF).
+                # Drop it rather than aborting the migration — the
+                # alternative is to re-enter on every future write and
+                # block the vault forever.
+                continue
 
     def _log_provenance(
         self,

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -112,6 +112,7 @@ addopts = [
 markers = [
     "integration: marks tests as integration tests (deselect with '-m \"not integration\"')",
     "e2e: marks tests as end-to-end tests (deselect with '-m \"not e2e\"')",
+    "slow: marks tests as slow benchmarks (deselect with '-m \"not slow\"')",
 ]
 testpaths = ["tests"]
 python_files = ["test_*.py"]

--- a/creek-tools/scripts/test.sh
+++ b/creek-tools/scripts/test.sh
@@ -86,7 +86,7 @@ PYTEST_ARGS=(-v)
 case "$TEST_TYPE" in
     unit)
         echo "=== Running Unit Tests ==="
-        PYTEST_ARGS+=(-m "not integration and not e2e")
+        PYTEST_ARGS+=(-m "not integration and not e2e and not slow")
         ;;
     integration)
         echo "=== Running Integration Tests ==="

--- a/creek-tools/tests/test_semantic_dedup.py
+++ b/creek-tools/tests/test_semantic_dedup.py
@@ -21,6 +21,7 @@ import pytest
 from pydantic import ValidationError
 
 from creek.clean.semantic_dedup import (
+    DeduplicationConfig,
     SemanticDeduplicator,
     SemanticDuplicatePair,
     SemanticDuplicateResult,
@@ -651,3 +652,128 @@ class TestBatchAndIncrementalIntegration:
         result = dedup.check_fragment("frag-new", [1.0, 0.0, 0.0])
         assert len(result.duplicates) == 1
         assert result.duplicates[0].fragment_id_b == "frag-a"
+
+
+# ---------------------------------------------------------------------------
+# Vectorised path (PERF-003)
+# ---------------------------------------------------------------------------
+
+
+class TestVectorisedFindDuplicates:
+    """Tests guarding the vectorised matmul path against the legacy loop."""
+
+    def test_matches_pairwise_loop(self) -> None:
+        """Matmul path produces the same pairs as pairwise cosine similarity."""
+        rng = np.random.default_rng(42)
+        embeddings: dict[str, list[float]] = {
+            f"frag-{i:03d}": rng.standard_normal(64).astype(np.float32).tolist()
+            for i in range(40)
+        }
+        dedup = SemanticDeduplicator(
+            duplicate_threshold=0.85,
+            resonance_threshold=0.5,
+        )
+        result = dedup.find_duplicates(embeddings)
+
+        # Reference: brute-force cosine over the same data.
+        ids = sorted(embeddings.keys())
+        expected_pairs: set[tuple[str, str, str]] = set()
+        for i in range(len(ids)):
+            for j in range(i + 1, len(ids)):
+                vec_i = _to_np(embeddings[ids[i]])
+                vec_j = _to_np(embeddings[ids[j]])
+                sim = _cosine_similarity(vec_i, vec_j)
+                if sim >= 0.85:
+                    expected_pairs.add((ids[i], ids[j], "duplicate"))
+                elif sim >= 0.5:
+                    expected_pairs.add((ids[i], ids[j], "resonance"))
+
+        actual_pairs: set[tuple[str, str, str]] = set()
+        for pair in result.duplicates:
+            actual_pairs.add(
+                (pair.fragment_id_a, pair.fragment_id_b, pair.classification),
+            )
+        for pair in result.resonances:
+            actual_pairs.add(
+                (pair.fragment_id_a, pair.fragment_id_b, pair.classification),
+            )
+        assert actual_pairs == expected_pairs
+
+    def test_zero_vector_yields_zero_similarity(self) -> None:
+        """A zero embedding does not produce ``NaN`` or false matches."""
+        dedup = SemanticDeduplicator()
+        embeddings = {
+            "frag-zero": [0.0, 0.0, 0.0],
+            "frag-other": [1.0, 0.0, 0.0],
+        }
+        result = dedup.find_duplicates(embeddings)
+        assert not result.duplicates
+        assert not result.resonances
+
+
+class TestDeduplicationConfig:
+    """Tests for the optional FAISS feature flag and config plumbing."""
+
+    def test_use_faiss_falls_back_when_not_installed(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``use_faiss=True`` does not crash if the package is missing."""
+        # Force ``import faiss`` to fail so we exercise the fallback path
+        # regardless of whether FAISS happens to be installed in CI.
+        import builtins
+
+        original_import = builtins.__import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "faiss":
+                msg = "faiss not available in test"
+                raise ImportError(msg)
+            return original_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        config = DeduplicationConfig(
+            duplicate_threshold=0.95,
+            resonance_threshold=0.75,
+            use_faiss=True,
+        )
+        dedup = SemanticDeduplicator(config=config)
+        embeddings = {
+            "frag-a": [1.0, 0.0, 0.0],
+            "frag-b": [1.0, 0.0, 0.0],
+        }
+        result = dedup.find_duplicates(embeddings)
+        assert len(result.duplicates) == 1
+
+    def test_config_thresholds_take_precedence(self) -> None:
+        """Config-supplied thresholds override the keyword defaults."""
+        config = DeduplicationConfig(
+            duplicate_threshold=0.5,
+            resonance_threshold=0.1,
+        )
+        dedup = SemanticDeduplicator(config=config)
+        assert dedup.duplicate_threshold == pytest.approx(0.5)
+        assert dedup.resonance_threshold == pytest.approx(0.1)
+
+
+@pytest.mark.slow
+class TestSemanticDedupScaling:
+    """Benchmark guarding against PERF-003's quadratic loop."""
+
+    def test_dedup_completes_under_30s_for_10k(self) -> None:
+        """10k float32 embeddings finish in under 30 seconds."""
+        import time
+
+        rng = np.random.default_rng(0)
+        embeddings: dict[str, list[float]] = {
+            f"frag-{i:06d}": rng.standard_normal(128).astype(np.float32).tolist()
+            for i in range(10_000)
+        }
+        dedup = SemanticDeduplicator(
+            duplicate_threshold=0.95,
+            resonance_threshold=0.85,
+        )
+        start = time.perf_counter()
+        dedup.find_duplicates(embeddings)
+        elapsed = time.perf_counter() - start
+        assert elapsed < 30.0, f"dedup took {elapsed:.2f}s for 10k embeddings"

--- a/creek-tools/tests/test_semantic_dedup.py
+++ b/creek-tools/tests/test_semantic_dedup.py
@@ -663,7 +663,16 @@ class TestVectorisedFindDuplicates:
     """Tests guarding the vectorised matmul path against the legacy loop."""
 
     def test_matches_pairwise_loop(self) -> None:
-        """Matmul path produces the same pairs as pairwise cosine similarity."""
+        """Matmul path produces the same pairs as pairwise cosine similarity.
+
+        The reference loop runs in float32 — same dtype as the matmul
+        path's :func:`_stack_embeddings` — so a pair's similarity is
+        compared against the threshold with bit-identical arithmetic
+        on both sides. (A float64 reference would disagree with the
+        float32 matmul on pairs sitting within ~1e-7 of either
+        threshold, producing a non-deterministic, seed-sensitive
+        failure.)
+        """
         rng = np.random.default_rng(42)
         embeddings: dict[str, list[float]] = {
             f"frag-{i:03d}": rng.standard_normal(64).astype(np.float32).tolist()
@@ -675,13 +684,14 @@ class TestVectorisedFindDuplicates:
         )
         result = dedup.find_duplicates(embeddings)
 
-        # Reference: brute-force cosine over the same data.
+        # Reference: brute-force cosine over the same data, in float32
+        # to match the matmul path's precision.
         ids = sorted(embeddings.keys())
         expected_pairs: set[tuple[str, str, str]] = set()
         for i in range(len(ids)):
             for j in range(i + 1, len(ids)):
-                vec_i = _to_np(embeddings[ids[i]])
-                vec_j = _to_np(embeddings[ids[j]])
+                vec_i = np.asarray(embeddings[ids[i]], dtype=np.float32)
+                vec_j = np.asarray(embeddings[ids[j]], dtype=np.float32)
                 sim = _cosine_similarity(vec_i, vec_j)
                 if sim >= 0.85:
                     expected_pairs.add((ids[i], ids[j], "duplicate"))
@@ -754,6 +764,41 @@ class TestDeduplicationConfig:
         dedup = SemanticDeduplicator(config=config)
         assert dedup.duplicate_threshold == pytest.approx(0.5)
         assert dedup.resonance_threshold == pytest.approx(0.1)
+
+    def test_faiss_probe_cached_across_calls(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Repeated ``find_duplicates`` calls log the fallback warning at most once."""
+        import builtins
+        import logging
+
+        original_import = builtins.__import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name == "faiss":
+                msg = "faiss not available in test"
+                raise ImportError(msg)
+            return original_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        config = DeduplicationConfig(
+            duplicate_threshold=0.95,
+            resonance_threshold=0.75,
+            use_faiss=True,
+        )
+        dedup = SemanticDeduplicator(config=config)
+        embeddings = {"frag-a": [1.0, 0.0], "frag-b": [1.0, 0.0]}
+        with caplog.at_level(logging.WARNING, logger="creek.clean.semantic_dedup"):
+            for _ in range(5):
+                dedup.find_duplicates(embeddings)
+        fallback_warnings = [
+            rec
+            for rec in caplog.records
+            if "falling back to dense matmul" in rec.message
+        ]
+        assert len(fallback_warnings) == 1
 
 
 @pytest.mark.slow

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -997,6 +997,52 @@ class TestProvenanceLegacyMigration:
         assert len(entries) == 1
         assert entries[0]["id"] == sample_fragment.id
 
+    def test_migration_drops_oversized_entry_without_blocking_writes(
+        self,
+        vault_path: Path,
+        sample_fragment: Fragment,
+    ) -> None:
+        """A single oversized legacy entry must not permanently block upgrades.
+
+        The PIPE_BUF cap rejects oversized entries via ``ValueError``.
+        Without per-entry tolerance the migration would re-enter on
+        every write — leaving the vault stuck and surfacing only as a
+        confusing "exceeds PIPE_BUF" error from the unrelated user
+        write that triggered the migration.
+        """
+        log_dir = vault_path / "00-Creek-Meta" / "Processing-Log"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        oversized_entry = {
+            "id": "x" * 5000,  # forces encoded size > _PIPE_BUF_BYTES
+            "type": "fragment",
+            "path": "/old.md",
+            "written_at": "2025-01-01T00:00:00",
+        }
+        well_formed_entry = {
+            "id": "frag-legacy0001",
+            "type": "fragment",
+            "path": "/ok.md",
+            "written_at": "2025-01-02T00:00:00",
+        }
+        legacy_path = log_dir / "provenance.json"
+        legacy_path.write_text(
+            json.dumps([oversized_entry, well_formed_entry]),
+            encoding="utf-8",
+        )
+
+        # First write must succeed — the oversized entry is dropped
+        # (with the legacy file removed) rather than failing the whole
+        # write.
+        VaultWriter(vault_path=vault_path).write_fragment(sample_fragment)
+
+        entries = _read_provenance(vault_path)
+        ids = [e["id"] for e in entries]
+        assert "frag-legacy0001" in ids  # well-formed legacy entry survived
+        assert sample_fragment.id in ids  # the user write itself landed
+        # The legacy file is removed even though one entry was dropped,
+        # so the second write does not re-enter the migration loop.
+        assert not legacy_path.exists()
+
 
 # ---- ID Index (PERF-001) ----
 

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -1082,6 +1082,69 @@ class TestConcurrentWrites:
         assert len(written) == 1
 
 
+class TestAtomicWriteHardening:
+    """Regression tests for `_atomic_write_text` / `_atomic_create` review notes."""
+
+    def test_atomic_write_uses_unique_temp_filename(
+        self,
+        writer: VaultWriter,
+        sample_fragment: Fragment,
+        tmp_path: Path,
+    ) -> None:
+        """Concurrent index persists do not race on a fixed `.tmp` sidecar."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        # Trigger the index file to exist with one entry.
+        writer.write_fragment(sample_fragment)
+
+        # Now hammer the index path with parallel atomic writes — if a
+        # fixed-name temp file were used, the second writer would race
+        # the first's rename and could leave behind a corrupt JSON.
+        from creek.vault.writer import _atomic_write_text
+
+        target = tmp_path / "atomic-target.json"
+
+        def _write(i: int) -> None:
+            _atomic_write_text(target, f'{{"value": {i}}}')
+
+        with ThreadPoolExecutor(max_workers=8) as ex:
+            list(ex.map(_write, range(50)))
+
+        # Final file must be readable as JSON — not truncated mid-write.
+        text = target.read_text(encoding="utf-8")
+        assert json.loads(text)["value"] in range(50)
+        # And no leftover ``.tmp`` files in the directory.
+        leftovers = [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+        assert not leftovers
+
+    def test_atomic_create_caps_collision_retries(
+        self,
+        writer: VaultWriter,
+        vault_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``_atomic_create`` raises rather than spinning when retries exhausted."""
+        from creek.vault import writer as writer_mod
+
+        target_dir = vault_path / "01-Fragments" / "Conversations"
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        # Force every os.open to raise FileExistsError so the retry
+        # loop must spin until it hits the cap.
+        def _always_exists(*args: object, **kwargs: object) -> int:
+            raise FileExistsError
+
+        monkeypatch.setattr(writer_mod.os, "open", _always_exists)
+        monkeypatch.setattr(writer_mod, "_MAX_FILENAME_COLLISION_RETRIES", 3)
+
+        with pytest.raises(RuntimeError, match="unique filename"):
+            writer_mod.VaultWriter._atomic_create(
+                target_dir,
+                "2025-01-15-collide",
+                "irrelevant",
+            )
+
+
 @pytest.mark.slow
 class TestVaultWriterScaling:
     """Benchmark guarding against PERF-001's quadratic ``_find_existing``."""

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -915,6 +915,89 @@ class TestProvenanceLogging:
         assert len(entries) == 1
 
 
+class TestProvenanceLegacyMigration:
+    """Migration of pre-Batch-E `provenance.json` → `provenance.jsonl`."""
+
+    def test_legacy_json_array_is_migrated_to_jsonl(
+        self,
+        vault_path: Path,
+        sample_fragment: Fragment,
+    ) -> None:
+        """Legacy `provenance.json` content survives the first JSONL write."""
+        log_dir = vault_path / "00-Creek-Meta" / "Processing-Log"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        legacy_entry = {
+            "id": "frag-legacy0001",
+            "type": "fragment",
+            "path": str(vault_path / "01-Fragments" / "Notes" / "old.md"),
+            "written_at": "2025-01-01T00:00:00",
+        }
+        legacy_path = log_dir / "provenance.json"
+        legacy_path.write_text(json.dumps([legacy_entry], indent=2), encoding="utf-8")
+
+        VaultWriter(vault_path=vault_path).write_fragment(sample_fragment)
+
+        new_entries = _read_provenance(vault_path)
+        ids = [e["id"] for e in new_entries]
+        # Both the legacy entry and the new one are present.
+        assert "frag-legacy0001" in ids
+        assert sample_fragment.id in ids
+        # The old file is removed so a third pass cannot duplicate-import.
+        assert not legacy_path.exists()
+
+    def test_migration_is_idempotent_across_multiple_writers(
+        self,
+        vault_path: Path,
+        sample_fragment: Fragment,
+    ) -> None:
+        """A second writer on the same vault does not re-import the legacy file."""
+        log_dir = vault_path / "00-Creek-Meta" / "Processing-Log"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        legacy_entry = {
+            "id": "frag-legacy0001",
+            "type": "fragment",
+            "path": str(vault_path / "old.md"),
+            "written_at": "2025-01-01T00:00:00",
+        }
+        (log_dir / "provenance.json").write_text(
+            json.dumps([legacy_entry]),
+            encoding="utf-8",
+        )
+
+        VaultWriter(vault_path=vault_path).write_fragment(sample_fragment)
+
+        # Spin up a fresh writer; it should not re-migrate.
+        second = VaultWriter(vault_path=vault_path)
+        second.write_fragment(
+            Fragment(
+                id="frag-fresh0002",
+                title="Fresh",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=datetime(2025, 2, 1, 12, 0, 0),
+            ),
+        )
+
+        entries = _read_provenance(vault_path)
+        legacy_count = sum(1 for e in entries if e["id"] == "frag-legacy0001")
+        assert legacy_count == 1
+
+    def test_migration_skips_malformed_legacy_file(
+        self,
+        vault_path: Path,
+        sample_fragment: Fragment,
+    ) -> None:
+        """A corrupt legacy `provenance.json` is ignored; new writes still succeed."""
+        log_dir = vault_path / "00-Creek-Meta" / "Processing-Log"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "provenance.json").write_text("not json", encoding="utf-8")
+
+        VaultWriter(vault_path=vault_path).write_fragment(sample_fragment)
+
+        entries = _read_provenance(vault_path)
+        assert len(entries) == 1
+        assert entries[0]["id"] == sample_fragment.id
+
+
 # ---- ID Index (PERF-001) ----
 
 
@@ -1116,6 +1199,19 @@ class TestAtomicWriteHardening:
         # And no leftover ``.tmp`` files in the directory.
         leftovers = [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
         assert not leftovers
+
+    def test_oversized_index_entry_rejected(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An index line over PIPE_BUF surfaces a `ValueError` rather than racing."""
+        from creek.vault.writer import VaultWriter
+
+        target_dir = tmp_path
+        target_dir.mkdir(parents=True, exist_ok=True)
+        oversized_id = "x" * 5000  # exceeds the 4 096-byte cap
+        with pytest.raises(ValueError, match="exceeds PIPE_BUF"):
+            VaultWriter._append_index_entry(target_dir, oversized_id, "file.md")
 
     def test_atomic_create_caps_collision_retries(
         self,

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -830,6 +830,13 @@ class TestFilenameUniqueness:
 # ---- Provenance Logging ----
 
 
+def _read_provenance(vault_path: Path) -> list[dict[str, Any]]:
+    """Read the JSONL provenance log into a list of dicts (test helper)."""
+    log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
+    text = log_path.read_text(encoding="utf-8")
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
 class TestProvenanceLogging:
     """Tests for provenance log file creation and appending."""
 
@@ -841,7 +848,7 @@ class TestProvenanceLogging:
     ) -> None:
         """Writing a fragment creates/updates the provenance log."""
         writer.write_fragment(sample_fragment)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
+        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.jsonl"
         assert log_path.exists()
 
     def test_provenance_log_contains_entry(
@@ -852,10 +859,7 @@ class TestProvenanceLogging:
     ) -> None:
         """Provenance log contains an entry for the written fragment."""
         writer.write_fragment(sample_fragment)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
-        entries: list[dict[str, Any]] = json.loads(
-            log_path.read_text(encoding="utf-8"),
-        )
+        entries = _read_provenance(vault_path)
         assert len(entries) == 1
         assert entries[0]["id"] == "frag-test0001"
         assert entries[0]["type"] == "fragment"
@@ -870,10 +874,7 @@ class TestProvenanceLogging:
         """Multiple writes append to the provenance log."""
         writer.write_fragment(sample_fragment)
         writer.write_thread(sample_thread)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
-        entries: list[dict[str, Any]] = json.loads(
-            log_path.read_text(encoding="utf-8"),
-        )
+        entries = _read_provenance(vault_path)
         assert len(entries) == 2
         ids = {e["id"] for e in entries}
         assert "frag-test0001" in ids
@@ -887,10 +888,7 @@ class TestProvenanceLogging:
     ) -> None:
         """Provenance log entry includes the written file path."""
         result = writer.write_fragment(sample_fragment)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
-        entries: list[dict[str, Any]] = json.loads(
-            log_path.read_text(encoding="utf-8"),
-        )
+        entries = _read_provenance(vault_path)
         assert entries[0]["path"] == str(result)
 
     def test_provenance_log_has_timestamp(
@@ -901,10 +899,7 @@ class TestProvenanceLogging:
     ) -> None:
         """Provenance log entry includes a timestamp."""
         writer.write_fragment(sample_fragment)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
-        entries: list[dict[str, Any]] = json.loads(
-            log_path.read_text(encoding="utf-8"),
-        )
+        entries = _read_provenance(vault_path)
         assert "written_at" in entries[0]
 
     def test_duplicate_not_logged_again(
@@ -916,8 +911,201 @@ class TestProvenanceLogging:
         """Writing a duplicate does not add a second provenance entry."""
         writer.write_fragment(sample_fragment)
         writer.write_fragment(sample_fragment)
-        log_path = vault_path / "00-Creek-Meta" / "Processing-Log" / "provenance.json"
-        entries: list[dict[str, Any]] = json.loads(
-            log_path.read_text(encoding="utf-8"),
-        )
+        entries = _read_provenance(vault_path)
         assert len(entries) == 1
+
+
+# ---- ID Index (PERF-001) ----
+
+
+class TestIdIndex:
+    """Tests for the per-directory ``.id-index.jsonl`` index file."""
+
+    def test_index_file_created_on_first_write(
+        self,
+        writer: VaultWriter,
+        sample_fragment: Fragment,
+    ) -> None:
+        """A first write appends a JSON line to ``.id-index.jsonl``."""
+        result = writer.write_fragment(sample_fragment)
+        index_path = result.parent / ".id-index.jsonl"
+        assert index_path.exists()
+        lines = [
+            line for line in index_path.read_text(encoding="utf-8").splitlines() if line
+        ]
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry == {"id": sample_fragment.id, "filename": result.name}
+
+    def test_index_lookup_avoids_directory_scan(
+        self,
+        writer: VaultWriter,
+        sample_fragment: Fragment,
+    ) -> None:
+        """Re-writing an existing fragment uses the index, not a scan."""
+        result = writer.write_fragment(sample_fragment)
+        # If the index path is consulted, removing the markdown but
+        # leaving a stale index entry should make the second write
+        # re-create the file at a new path (proof the lookup goes
+        # through the index, then verifies file existence on disk).
+        result.unlink()
+        new_path = writer.write_fragment(sample_fragment)
+        assert new_path.exists()
+        assert new_path.parent == result.parent
+
+    def test_index_rebuilds_when_missing(
+        self,
+        vault_path: Path,
+        sample_fragment: Fragment,
+    ) -> None:
+        """A vault with existing fragments but no index rebuilds it on demand."""
+        # Seed the directory using one writer instance.
+        seed_writer = VaultWriter(vault_path=vault_path)
+        original = seed_writer.write_fragment(sample_fragment)
+        # Remove the index file as if migrating from an older vault.
+        index_path = original.parent / ".id-index.jsonl"
+        index_path.unlink()
+        # A fresh writer should detect the existing fragment without
+        # re-creating it.
+        fresh_writer = VaultWriter(vault_path=vault_path)
+        result = fresh_writer.write_fragment(sample_fragment)
+        assert result == original
+        assert index_path.exists()
+
+    def test_corrupt_index_lines_are_skipped(
+        self,
+        writer: VaultWriter,
+        sample_fragment: Fragment,
+        vault_path: Path,
+    ) -> None:
+        """Malformed lines in the JSONL index are skipped, not fatal."""
+        original = writer.write_fragment(sample_fragment)
+        index_path = original.parent / ".id-index.jsonl"
+        # Append a malformed line; the well-formed first line should
+        # still be parsed by a fresh writer.
+        with index_path.open("a", encoding="utf-8") as fp:
+            fp.write("{not json}\n")
+        fresh_writer = VaultWriter(vault_path=vault_path)
+        result = fresh_writer.write_fragment(sample_fragment)
+        assert result == original
+
+    def test_index_skips_blank_and_non_dict_lines(
+        self,
+        writer: VaultWriter,
+        sample_fragment: Fragment,
+        vault_path: Path,
+    ) -> None:
+        """Blank lines and non-object JSON lines are tolerated."""
+        original = writer.write_fragment(sample_fragment)
+        index_path = original.parent / ".id-index.jsonl"
+        with index_path.open("a", encoding="utf-8") as fp:
+            fp.write("\n")  # blank line
+            fp.write("[1, 2, 3]\n")  # non-dict line
+            fp.write('{"id": 7, "filename": "x.md"}\n')  # wrong types
+        fresh_writer = VaultWriter(vault_path=vault_path)
+        result = fresh_writer.write_fragment(sample_fragment)
+        assert result == original
+
+    def test_public_find_existing_uses_lock(
+        self,
+        writer: VaultWriter,
+        sample_fragment: Fragment,
+    ) -> None:
+        """``_find_existing`` (the public-style shim) returns the indexed path."""
+        original = writer.write_fragment(sample_fragment)
+        target_dir = original.parent
+        # Direct call to the locked-shim variant should report the same
+        # path the in-memory index holds.
+        assert writer._find_existing(sample_fragment.id, target_dir) == original
+        # Unknown ID returns ``None`` via the same path.
+        assert writer._find_existing("frag-unknown", target_dir) is None
+
+
+# ---- Concurrent writes (BUG-006) ----
+
+
+class TestConcurrentWrites:
+    """Tests guarding against the ThreadPoolExecutor race in ``_write_model``."""
+
+    def test_concurrent_distinct_writes_no_loss(
+        self,
+        writer: VaultWriter,
+        vault_path: Path,
+    ) -> None:
+        """200 distinct fragments x 8 threads -> 200 distinct files, no loss."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        import frontmatter as fm_mod
+
+        fragments = [
+            Fragment(
+                id=f"frag-{i:09d}",
+                title=f"t{i}",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=datetime(2025, 1, 15, 10, 0, 0),
+            )
+            for i in range(200)
+        ]
+
+        def _write(fragment: Fragment) -> Path:
+            return writer.write_fragment(fragment, body=f"body for {fragment.id}")
+
+        with ThreadPoolExecutor(max_workers=8) as ex:
+            list(ex.map(_write, fragments))
+
+        written = list((vault_path / "01-Fragments" / "Conversations").glob("*.md"))
+        assert len(written) == 200
+        ids = {fm_mod.load(str(p)).get("id") for p in written}
+        assert ids == {f.id for f in fragments}
+
+        entries = _read_provenance(vault_path)
+        assert len(entries) == 200
+
+    def test_concurrent_same_id_writes_dedup(
+        self,
+        writer: VaultWriter,
+        sample_fragment: Fragment,
+        vault_path: Path,
+    ) -> None:
+        """Concurrent writes of the same ID converge on a single file."""
+        from concurrent.futures import ThreadPoolExecutor
+
+        def _write(_: int) -> Path:
+            return writer.write_fragment(sample_fragment, body="x")
+
+        with ThreadPoolExecutor(max_workers=8) as ex:
+            paths = list(ex.map(_write, range(50)))
+
+        # All paths point to the same file — no duplicates.
+        assert len({str(p) for p in paths}) == 1
+        written = list((vault_path / "01-Fragments" / "Conversations").glob("*.md"))
+        assert len(written) == 1
+
+
+@pytest.mark.slow
+class TestVaultWriterScaling:
+    """Benchmark guarding against PERF-001's quadratic ``_find_existing``."""
+
+    def test_constant_time_per_write(
+        self,
+        writer: VaultWriter,
+    ) -> None:
+        """Per-write time stays roughly flat across 2000 writes."""
+        import statistics
+        import time
+
+        durations: list[float] = []
+        for i in range(2000):
+            fragment = Fragment(
+                id=f"frag-{i:012d}",
+                title=f"t{i}",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=datetime(2025, 1, 15, 10, 0, 0),
+            )
+            start = time.perf_counter()
+            writer.write_fragment(fragment, body=f"body {i}")
+            durations.append(time.perf_counter() - start)
+
+        early = statistics.median(durations[10:60])
+        late = statistics.median(durations[-50:])
+        assert late < 3 * early, f"Per-write grew: early={early:.4f}s late={late:.4f}s"

--- a/creek-tools/tests/test_voice_profiles.py
+++ b/creek-tools/tests/test_voice_profiles.py
@@ -904,6 +904,26 @@ class TestStreamingAccumulator:
         # max_exemplars defaults to 10; we seeded 7.
         assert post.get("exemplar_count") == 7
 
+    def test_jsonl_writer_flushes_on_each_append(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``_JsonlWriter.append`` flushes per call to leave a coherent prefix."""
+        from creek.generate.voice import _JsonlWriter
+
+        target = tmp_path / "exemplar.jsonl"
+        writer = _JsonlWriter(target)
+        try:
+            writer.append({"a": 1})
+            # Without flush, the new line might still be in the userspace
+            # buffer; with the per-append flush, an out-of-band reader
+            # sees it immediately.
+            assert target.read_text(encoding="utf-8") == '{"a": 1}\n'
+            writer.append({"b": 2})
+            assert target.read_text(encoding="utf-8") == '{"a": 1}\n{"b": 2}\n'
+        finally:
+            writer.close()
+
 
 @pytest.mark.slow
 class TestVoiceMemoryFootprint:

--- a/creek-tools/tests/test_voice_profiles.py
+++ b/creek-tools/tests/test_voice_profiles.py
@@ -878,18 +878,47 @@ class TestStreamingAccumulator:
 
     def test_temp_jsonl_is_cleaned_up(
         self,
+        monkeypatch: pytest.MonkeyPatch,
         generator: VoiceProfileGenerator,
         vault: Path,
         tmp_path: Path,
     ) -> None:
-        """The accumulator's temp dir does not leak after the call returns."""
+        """The accumulator's temp dir is actually deleted after the call returns.
+
+        The previous version of this test was vacuous: it scanned
+        ``tmp_path`` for ``creek-voice-*`` entries, but
+        ``tempfile.TemporaryDirectory`` creates under
+        ``tempfile.gettempdir()`` (e.g. ``/tmp``) by default, so the
+        scan never had anything to find. The fix monkey-patches the
+        ``tempfile.TemporaryDirectory`` constructor used inside
+        ``creek.generate.voice`` so the directory lands under
+        ``tmp_path`` and we can directly assert that the directory is
+        gone after ``generate_all_profiles`` returns.
+        """
+        import os
+        import tempfile
+
+        from creek.generate import voice as voice_mod
+
+        created: list[str] = []
+        real_td = tempfile.TemporaryDirectory
+
+        def patched_td(*args: object, **kwargs: object) -> object:
+            kwargs["dir"] = str(tmp_path)
+            td = real_td(*args, **kwargs)  # type: ignore[arg-type]
+            created.append(td.name)
+            return td
+
+        monkeypatch.setattr(voice_mod.tempfile, "TemporaryDirectory", patched_td)
         self._seed_register(vault, VoiceRegister.CONFESSIONAL, count=5)
-        before = set(tmp_path.iterdir())
         generator.generate_all_profiles(vault)
-        after = set(tmp_path.iterdir())
-        # No new ``creek-voice-*`` directories remain in the parent.
-        leaked = {p for p in after - before if p.name.startswith("creek-voice-")}
-        assert not leaked
+
+        # The patched constructor must have been used, and every
+        # directory it returned must be deleted by the time the call
+        # exits the streaming-accumulator context manager.
+        assert created, "patched TemporaryDirectory was never invoked"
+        for path in created:
+            assert not os.path.exists(path), f"Temp dir leaked: {path}"
 
     def test_streaming_matches_legacy_output(
         self,

--- a/creek-tools/tests/test_voice_profiles.py
+++ b/creek-tools/tests/test_voice_profiles.py
@@ -849,3 +849,96 @@ class TestGenerateAllProfiles:
         assert len(paths) == 1
         post = frontmatter.load(str(paths[0]))
         assert post.get("exemplar_count") == 5
+
+
+# ---- Streaming exemplar accumulator (PERF-004) ----
+
+
+class TestStreamingAccumulator:
+    """Tests for the on-disk JSONL exemplar accumulator path."""
+
+    def _seed_register(
+        self,
+        vault_path: Path,
+        register: VoiceRegister,
+        count: int,
+    ) -> None:
+        """Seed *count* fragments of *register* with distinctive bodies."""
+        for i in range(count):
+            fragment = _make_fragment(
+                f"{register.value}-{i}",
+                f"{register.value} fragment {i}",
+                register=register,
+            )
+            body = (
+                f"Paragraph about the {register.value} register: "
+                "the creek of thought flows here. " * 30
+            )
+            _write_fragment_file(vault_path, fragment, body)
+
+    def test_temp_jsonl_is_cleaned_up(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+        tmp_path: Path,
+    ) -> None:
+        """The accumulator's temp dir does not leak after the call returns."""
+        self._seed_register(vault, VoiceRegister.CONFESSIONAL, count=5)
+        before = set(tmp_path.iterdir())
+        generator.generate_all_profiles(vault)
+        after = set(tmp_path.iterdir())
+        # No new ``creek-voice-*`` directories remain in the parent.
+        leaked = {p for p in after - before if p.name.startswith("creek-voice-")}
+        assert not leaked
+
+    def test_streaming_matches_legacy_output(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Streaming path produces the same exemplar count as legacy in-memory."""
+        self._seed_register(vault, VoiceRegister.CONFESSIONAL, count=7)
+        paths = generator.generate_all_profiles(vault)
+        assert len(paths) == 1
+        post = frontmatter.load(str(paths[0]))
+        # max_exemplars defaults to 10; we seeded 7.
+        assert post.get("exemplar_count") == 7
+
+
+@pytest.mark.slow
+class TestVoiceMemoryFootprint:
+    """Memory benchmark guarding against PERF-004's load-everything bug."""
+
+    def test_peak_under_200mb_for_large_vault(
+        self,
+        generator: VoiceProfileGenerator,
+        vault: Path,
+    ) -> None:
+        """Peak heap stays under 200 MB while processing 2 000 large fragments."""
+        import tracemalloc
+
+        # 2000 fragments x ~5 KB body = ~10 MB total. With the legacy
+        # in-memory path that produces a single ~10 MB peak; the
+        # streaming path's peak should be well under the 200 MB envelope.
+        # The threshold guards against future regressions that would
+        # re-introduce the load-everything pattern.
+        body_template = "the creek of thought flows here. " * 150  # ~5 KB
+        for register in VoiceRegister:
+            for i in range(2_000 // len(VoiceRegister)):
+                fragment = _make_fragment(
+                    f"{register.value}-{i}",
+                    f"{register.value} fragment {i}",
+                    register=register,
+                )
+                _write_fragment_file(vault, fragment, body_template)
+
+        tracemalloc.start()
+        try:
+            paths = generator.generate_all_profiles(vault)
+            _, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+
+        assert paths
+        peak_mb = peak / (1024 * 1024)
+        assert peak_mb < 200, f"Peak memory was {peak_mb:.1f} MB"


### PR DESCRIPTION
Executes [Batch E — Vault writer + dedup performance](plans/prompts/2026-04-28/batch-E-vault-performance.md). Five commits, four scaling/race fixes plus a `slow` marker so the benchmarks they add never bloat the default unit pass.

## Changes

| Commit | Issue(s) | Summary |
|---|---|---|
| `4910e4f` | infra | Add `slow` pytest marker; `./scripts/test.sh` excludes it from unit, `--all` opts in. |
| `9064a63` | **PERF-001 + BUG-006** | `VaultWriter` per-directory `.id-index.jsonl` (O(1) lookup), `O_CREAT \| O_EXCL` atomic file creation with counter retry, `provenance.jsonl` append, `threading.Lock` around the index + provenance updates. |
| `e55ea67` | **PERF-003** | Vectorised `find_duplicates` via L2-normalise + `X @ X.T`; optional FAISS `IndexFlatIP.range_search` behind `DeduplicationConfig.use_faiss`, lazy-imported with graceful fallback. |
| `81fe51a` | **PERF-004** | `VoiceProfileGenerator.generate_all_profiles` streams qualifying fragments to per-register JSONL accumulators in a `tempfile.TemporaryDirectory`; bodies dropped per-iteration so peak memory is one register, not the whole vault. |
| `dd2f17a` | review | Address Claude PR review feedback (see below). |

## Review feedback addressed (commit `dd2f17a`)

- **🟡 writer**: `_atomic_write_text` switched from a fixed `.{name}.tmp` sidecar to `tempfile.mkstemp(dir=target_dir)` so concurrent writers cannot collide on the temp name. Regression test stresses 8 threads × 50 writes against the same path.
- **🟡 voice**: `_JsonlWriter.append` now flushes per line so an interrupted run leaves a coherent prefix instead of half a JSON object. Regression test asserts an out-of-band reader sees each entry immediately.
- **🟢 writer**: `_atomic_create` retry loop capped at `_MAX_FILENAME_COLLISION_RETRIES = 10_000` with `RuntimeError`; replaces the prior unbounded `while True`. Test monkey-patches `os.open` to always collide and verifies the cap fires.
- **🟢 dedup**: removed redundant `np.fill_diagonal(-inf)` (`np.triu(k=1)` already excludes the diagonal, and configured thresholds are always > 0).
- **🟢 dedup**: narrowed `ImportError` swallowing — `_pair_indices` only falls back to matmul when the *top-level* `faiss` import fails (via the new `_faiss_available()` probe). Submodule failures inside FAISS surface as real bugs.

Skipped (non-blocking, would require restructuring with no test gain):
- Lock-scope optimisation in `_write_model` (perf hint; current code is correct, single in-process serialisation is the documented trade-off).
- `_find_existing` deprecation note (purely cosmetic; method is `_`-prefixed already).
- Second opinion on the explicit `del` in `_stream_into` (already commented; subjective).

## Test plan

- [x] `./scripts/test.sh --unit` → 2 795 passed, 19 deselected.
- [x] `python -m pytest -m slow` → 3 passed (10k-fragment dedup < 30 s, 2k-fragment vault writer constant-time, voice memory < 200 MB).
- [x] `./scripts/typecheck.sh` strict clean.
- [x] `./scripts/lint.sh` + `./scripts/format.sh --check` clean.
- [x] Aggregate coverage 93.67% (≥ 90% gate); per-file gate green.
- [x] Pylint 9.75/10; complexity all A.

The single failing local check is the pre-existing `pyjwt 2.7.0 → CVE-2026-32597` from the system Python environment — verified to fail on `main` too — and is resolved by CI's clean install from `requirements-dev.txt`.

https://claude.ai/code/session_01NgnhBebeSwdT8ReRd3bKtA