### PR TITLE
feat(batch-h): operational polish — time helper, BUG-002/009/010, OPS-001, INC-012/013/017/018

### DIFF
--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -157,11 +157,15 @@ See [`docs/configuration.md`](docs/configuration.md) for the full schema with ex
 
 ## Source platforms
 
-The ingestion pipeline currently supports **12** source platforms, each backed by a registered `Ingestor`:
+The ingestion pipeline currently ships **10** registered `Ingestor`s plus a read-only Google Drive downloader that routes mirrored files back through the matching ingestor:
 
-`claude`, `chatgpt`, `discord`, `gdrive`, `code`, `documents` (.docx / .pdf), `markdown`, `spreadsheet` (.xlsx / .csv), `presentation` (.pptx), `images` (with OCR), `generic` (fallback for unknown text), and `other`.
+`claude`, `chatgpt`, `discord`, `code`, `document` (.docx / .pdf), `markdown`, `spreadsheet` (.xlsx / .csv), `presentation` (.pptx), `image` (with OCR), and `generic` (fallback for unknown text).
+
+`gdrive` is a downloader, not an ingestor — it stages files locally and dispatches each one to the appropriate ingestor by extension. The `other` enum value on `SourcePlatform` is reserved for downstream consumers (e.g. fragments synthesised from praxes) and has no parser.
 
 Each ingestor follows the same four-stage contract — `discover` → `parse` → `convert_to_markdown` → `generate_frontmatter` — and writes one fragment per logical unit (per chat thread, per sheet, per slide deck, per file). See [`docs/ingestion.md`](docs/ingestion.md) for which is right for which export.
+
+The pinned count is exercised by `tests/test_ingest_registry.py` so any change to `INGESTOR_REGISTRY` lights up red until this paragraph is updated alongside it.
 
 ---
 

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -48,8 +48,13 @@ from creek.ingest.base import LA_TZ
 from creek.models import Fragment, Frequency
 from creek.vault.reader import try_load_fragment
 
-LLM_PROGRESS_FILENAME = "llm-progress.json"
-"""Per-vault progress log filename written under ``00-Creek-Meta/Processing-Log/``."""
+LLM_PROGRESS_FILENAME = "llm-progress.jsonl"
+"""Per-vault progress log filename written under ``00-Creek-Meta/Processing-Log/``.
+
+Newline-delimited JSON (one ``{"id": ...}`` object per line); the
+``.jsonl`` suffix signals the format honestly to an operator opening
+the file.
+"""
 
 _RESUMABLE_METHODS: frozenset[str] = frozenset({MANUAL_METHOD, LLM_METHOD})
 
@@ -76,9 +81,15 @@ class ClassifySummary:
             ``--method llm`` run that short-circuits to the rule
             result still counts as classified — the work is real and
             the file is rewritten.
-        preserved_manual: Fragments left unchanged because the operator
-            previously stamped them ``method: manual`` and ``--force``
-            was not passed.
+        preserved_manual: Fragments left unchanged because a prior run
+            already settled the classification and ``--force`` was not
+            passed. Covers both ``classification_method: manual`` (the
+            original operator-curated case) and ``classification_method:
+            llm`` (OPS-001 resume — re-running ``--method llm`` after a
+            crash skips fragments already classified by the LLM so the
+            operator does not re-pay for tokens). The field name is
+            kept for backwards compatibility; rename to ``preserved`` is
+            tracked alongside the next CLI message refresh.
         skipped_high_confidence: Subset of ``classified`` for which
             the LLM was not invoked because the rule classifier
             produced a high-confidence answer. The fragment is still
@@ -134,11 +145,14 @@ def run_classify(
     rules = RuleClassifier()
     llm = LLMClassifier(config=config.llm) if method == "llm" else None
     counts = _RunCounts()
-    progress_path = (
-        vault_path / "00-Creek-Meta" / "Processing-Log" / LLM_PROGRESS_FILENAME
-        if method == LLM_METHOD
-        else None
-    )
+    progress_path: Path | None = None
+    if method == LLM_METHOD:
+        progress_dir = vault_path / "00-Creek-Meta" / "Processing-Log"
+        # Create the directory once, not per fragment — a 10k-fragment
+        # vault would otherwise issue 10k redundant ``mkdir`` syscalls
+        # in ``_record_llm_progress``.
+        progress_dir.mkdir(parents=True, exist_ok=True)
+        progress_path = progress_dir / LLM_PROGRESS_FILENAME
 
     for md_file in sorted(fragments_root.rglob("*.md")):
         _process_file(
@@ -354,13 +368,15 @@ def _record_llm_progress(progress_path: Path, fragment_id: str) -> None:
     classification proceeds — losing the line costs at most extra log
     output on the next run, never a re-classification.
 
+    The parent directory is created up-front by :func:`run_classify`,
+    so this writer never issues ``mkdir`` per fragment.
+
     Args:
-        progress_path: Destination path. Parent directory is created
-            if missing.
+        progress_path: Destination path under
+            ``<vault>/00-Creek-Meta/Processing-Log/``.
         fragment_id: ID of the fragment just classified by the LLM.
     """
     try:
-        progress_path.parent.mkdir(parents=True, exist_ok=True)
         with progress_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps({"id": fragment_id}) + "\n")
     except OSError as exc:

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -380,9 +380,12 @@ def _record_llm_progress(progress_path: Path, fragment_id: str) -> None:
         with progress_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps({"id": fragment_id}) + "\n")
     except OSError as exc:
+        # OPS-003: keep the fragment-id prefix so this WARNING is
+        # grep-able alongside other per-fragment failures.
         logger.warning(
-            "Could not append %s to llm-progress checkpoint %s: %s",
+            "[fragment=%s path=%s] Could not append to llm-progress checkpoint %s: %s",
             fragment_id,
+            progress_path,
             progress_path,
             exc,
         )

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -4,11 +4,28 @@ Loads every fragment from ``<vault>/01-Fragments/``, dispatches to the
 configured classifier (rules or LLM), and rewrites each fragment file
 in place with the updated frontmatter. Records the chosen ``method``
 and ``classified_at`` timestamp on each fragment so that subsequent
-``creek classify`` runs can preserve manual decisions.
+``creek classify`` runs can preserve manual decisions and resume
+mid-run after a crash.
+
+Resume contract (OPS-001)
+-------------------------
+
+``creek classify --method llm`` is **resumable by default**:
+
+1. Each fragment's frontmatter is rewritten the moment the LLM call
+   returns, so progress is durable on per-fragment granularity.
+2. Re-running the command short-circuits any fragment whose
+   ``classification_method`` is already ``llm`` (or ``manual``). Pass
+   ``--force`` to re-classify everything from scratch.
+3. The set of fragment IDs touched during the current run is appended
+   to ``<vault>/00-Creek-Meta/Processing-Log/llm-progress.json`` for
+   observability; this file is informational and **not** the source
+   of truth — the per-fragment frontmatter is.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -21,6 +38,7 @@ import yaml
 from creek.classify.constants import (
     CLASSIFICATION_METHOD_KEY,
     CLASSIFIED_AT_KEY,
+    LLM_METHOD,
     MANUAL_METHOD,
     RULES_METHOD,
 )
@@ -29,6 +47,11 @@ from creek.classify.rules import RuleClassifier
 from creek.ingest.base import LA_TZ
 from creek.models import Fragment, Frequency
 from creek.vault.reader import try_load_fragment
+
+LLM_PROGRESS_FILENAME = "llm-progress.json"
+"""Per-vault progress log filename written under ``00-Creek-Meta/Processing-Log/``."""
+
+_RESUMABLE_METHODS: frozenset[str] = frozenset({MANUAL_METHOD, LLM_METHOD})
 
 if TYPE_CHECKING:
     from creek.config import CreekConfig
@@ -111,6 +134,11 @@ def run_classify(
     rules = RuleClassifier()
     llm = LLMClassifier(config=config.llm) if method == "llm" else None
     counts = _RunCounts()
+    progress_path = (
+        vault_path / "00-Creek-Meta" / "Processing-Log" / LLM_PROGRESS_FILENAME
+        if method == LLM_METHOD
+        else None
+    )
 
     for md_file in sorted(fragments_root.rglob("*.md")):
         _process_file(
@@ -121,6 +149,7 @@ def run_classify(
             llm=llm,
             confidence_threshold=config.classification.confidence_threshold,
             counts=counts,
+            progress_path=progress_path,
         )
 
     return ClassifySummary(
@@ -144,17 +173,23 @@ def _process_file(
     llm: LLMClassifier | None,
     confidence_threshold: float,
     counts: _RunCounts,
+    progress_path: Path | None,
 ) -> None:
     """Classify a single fragment file and update ``counts`` in place.
 
     Args:
         md_file: The file to consider.
         method: ``"rules"`` or ``"llm"``.
-        force: Whether to overwrite manual classifications.
+        force: Whether to overwrite previously-classified fragments.
         rules: Shared :class:`RuleClassifier` instance.
         llm: Shared :class:`LLMClassifier` (when ``method == "llm"``).
         confidence_threshold: Threshold below which the LLM is invoked.
         counts: Mutable per-run counters; mutated in place.
+        progress_path: Optional path to the LLM-progress checkpoint file
+            (OPS-001). When set, the fragment ID is appended after a
+            successful LLM classification. Manual / rules-shortcircuit
+            paths are not appended — only paid LLM calls need to be
+            recovered on resume.
     """
     try:
         record = _read_fragment(md_file)
@@ -171,7 +206,11 @@ def _process_file(
     counts.total += 1
     fragment, body, raw = record
 
-    if not force and raw.get(CLASSIFICATION_METHOD_KEY) == MANUAL_METHOD:
+    # Skip fragments whose previous run already settled the classification:
+    # ``manual`` is operator-curated; ``llm`` is a paid LLM call we don't
+    # want to repeat after a crash (OPS-001 resume contract). Pass
+    # ``--force`` to re-classify everything.
+    if not force and raw.get(CLASSIFICATION_METHOD_KEY) in _RESUMABLE_METHODS:
         counts.preserved += 1
         return
 
@@ -204,6 +243,8 @@ def _process_file(
     counts.classified += 1
     if was_skipped:
         counts.skipped += 1
+    elif progress_path is not None and write_method == LLM_METHOD:
+        _record_llm_progress(progress_path, new_fragment.id)
 
 
 def _classify_one(
@@ -302,3 +343,30 @@ def _write_fragment(
 
     post = frontmatter.Post(content=body, **new_metadata)
     md_file.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+def _record_llm_progress(progress_path: Path, fragment_id: str) -> None:
+    """Append *fragment_id* to the per-vault LLM-progress checkpoint (OPS-001).
+
+    The progress file is informational: the per-fragment frontmatter is
+    the source of truth for "this was classified by the LLM". Failing
+    to write the checkpoint is logged at ``WARNING`` and the
+    classification proceeds — losing the line costs at most extra log
+    output on the next run, never a re-classification.
+
+    Args:
+        progress_path: Destination path. Parent directory is created
+            if missing.
+        fragment_id: ID of the fragment just classified by the LLM.
+    """
+    try:
+        progress_path.parent.mkdir(parents=True, exist_ok=True)
+        with progress_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps({"id": fragment_id}) + "\n")
+    except OSError as exc:
+        logger.warning(
+            "Could not append %s to llm-progress checkpoint %s: %s",
+            fragment_id,
+            progress_path,
+            exc,
+        )

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -18,9 +18,10 @@ Resume contract (OPS-001)
    ``classification_method`` is already ``llm`` (or ``manual``). Pass
    ``--force`` to re-classify everything from scratch.
 3. The set of fragment IDs touched during the current run is appended
-   to ``<vault>/00-Creek-Meta/Processing-Log/llm-progress.json`` for
-   observability; this file is informational and **not** the source
-   of truth — the per-fragment frontmatter is.
+   to ``<vault>/00-Creek-Meta/Processing-Log/llm-progress.jsonl`` for
+   observability (newline-delimited JSON, one ``{"id": ...}`` object
+   per line); this file is informational and **not** the source of
+   truth — the per-fragment frontmatter is.
 """
 
 from __future__ import annotations
@@ -381,11 +382,14 @@ def _record_llm_progress(progress_path: Path, fragment_id: str) -> None:
             handle.write(json.dumps({"id": fragment_id}) + "\n")
     except OSError as exc:
         # OPS-003: keep the fragment-id prefix so this WARNING is
-        # grep-able alongside other per-fragment failures.
+        # grep-able alongside other per-fragment failures. ``checkpoint=``
+        # rather than ``path=`` because the file path here is the
+        # progress checkpoint, not the fragment's source — the OPS-003
+        # convention reserves ``path=`` for ``source.original_file``.
         logger.warning(
-            "[fragment=%s path=%s] Could not append to llm-progress checkpoint %s: %s",
+            "[fragment=%s checkpoint=%s] "
+            "Could not append to llm-progress checkpoint: %s",
             fragment_id,
-            progress_path,
             progress_path,
             exc,
         )

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -29,7 +29,6 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime
 from pathlib import Path  # noqa: TC003  # no issue: runtime dataclass field
 from typing import TYPE_CHECKING
 
@@ -45,8 +44,8 @@ from creek.classify.constants import (
 )
 from creek.classify.llm import LLMClassifier
 from creek.classify.rules import RuleClassifier
-from creek.ingest.base import LA_TZ
 from creek.models import Fragment, Frequency
+from creek.time import now_la
 from creek.vault.reader import try_load_fragment
 
 LLM_PROGRESS_FILENAME = "llm-progress.jsonl"
@@ -354,7 +353,11 @@ def _write_fragment(
     new_metadata = dict(raw)
     new_metadata.update(fragment.model_dump(mode="json"))
     new_metadata[CLASSIFICATION_METHOD_KEY] = method
-    new_metadata[CLASSIFIED_AT_KEY] = datetime.now(tz=LA_TZ).isoformat()
+    # BUG-002: route through the shared LA helper rather than calling
+    # ``datetime.now(tz=LA_TZ)`` directly, so every classified_at
+    # timestamp written to disk uses the same code path as every
+    # other LA-anchored timestamp in the pipeline.
+    new_metadata[CLASSIFIED_AT_KEY] = now_la().isoformat()
 
     post = frontmatter.Post(content=body, **new_metadata)
     md_file.write_text(frontmatter.dumps(post), encoding="utf-8")

--- a/creek-tools/creek/classify/llm.py
+++ b/creek-tools/creek/classify/llm.py
@@ -693,8 +693,15 @@ class LLMClassifier:
                 ValueError,
                 yaml.YAMLError,
             ) as exc:
+                # OPS-003: include fragment ID + source path so the
+                # operator can find the failing fragment quickly when
+                # scanning logs. Prefix tag matches OPS-003 convention.
                 logger.warning(
-                    "Attempt %d/%d failed for '%s': %s",
+                    "[fragment=%s path=%s provider=%s] "
+                    "Classify attempt %d/%d failed for '%s': %s",
+                    fragment.id,
+                    fragment.source.original_file or "<inline>",
+                    self.config.provider,
                     attempt + 1,
                     self.MAX_RETRIES,
                     fragment.title,
@@ -704,7 +711,11 @@ class LLMClassifier:
                     time.sleep(self.RETRY_DELAY)
 
         logger.error(
+            "[fragment=%s path=%s provider=%s] "
             "All %d retries exhausted for '%s' — returning unchanged",
+            fragment.id,
+            fragment.source.original_file or "<inline>",
+            self.config.provider,
             self.MAX_RETRIES,
             fragment.title,
         )
@@ -765,17 +776,7 @@ class LLMClassifier:
 
             for future in future_iter:
                 idx = futures[future]
-                try:
-                    result = future.result()
-                    ordered[idx] = result
-                    if result.frequency.primary != Frequency.UNCLASSIFIED:
-                        stats.classified += 1
-                except Exception:
-                    logger.exception(
-                        "Unexpected error classifying fragment %d",
-                        idx,
-                    )
-                    stats.failed += 1
+                self._collect_one_result(future, idx, ordered, stats)
 
         logger.info(
             "Batch complete: %d total, %d classified, %d failed",
@@ -784,6 +785,36 @@ class LLMClassifier:
             stats.failed,
         )
         return ordered
+
+    def _collect_one_result(
+        self,
+        future: Future[Fragment],
+        idx: int,
+        ordered: list[Fragment],
+        stats: BatchStats,
+    ) -> None:
+        """Pull a future's result into ``ordered`` and update ``stats`` (OPS-003).
+
+        Extracted from :meth:`classify_batch` so the per-result error
+        path can include the failing fragment's ID and source path
+        without inflating the parent function's complexity.
+        """
+        try:
+            result = future.result()
+            ordered[idx] = result
+            if result.frequency.primary != Frequency.UNCLASSIFIED:
+                stats.classified += 1
+        except Exception:
+            failing = ordered[idx]
+            logger.exception(
+                "[fragment=%s path=%s provider=%s] "
+                "Unexpected error classifying fragment %d",
+                failing.id,
+                failing.source.original_file or "<inline>",
+                self.config.provider,
+                idx,
+            )
+            stats.failed += 1
 
 
 # ---- Private helpers for _apply_classification ----

--- a/creek-tools/creek/classify/privacy.py
+++ b/creek-tools/creek/classify/privacy.py
@@ -155,29 +155,21 @@ class PrivacyClassifier:
     ) -> Fragment:
         """Apply *tier*-specific handling rules and return a new fragment.
 
-        The resulting fragment carries:
-
-        * ``privacy_tier`` set to *tier*.
-        * ``voice_proxy_eligible`` set to ``False`` for ``INTIMATE`` and
-          ``True`` for ``PUBLIC`` and ``PERSONAL``. The reset on
-          downgrade matters: a fragment previously enforced as
-          ``INTIMATE`` and later re-classified to ``PERSONAL`` would
-          otherwise stay opted out of voice proxy generation.
+        The resulting fragment carries ``privacy_tier`` set to *tier*.
+        ``voice_proxy_eligible`` is a derived property
+        (:class:`Fragment.voice_proxy_eligible`, BUG-009) computed from
+        ``privacy_tier`` and ``source.author``, so re-classification
+        between tiers automatically flips eligibility without requiring
+        a paired write.
 
         Args:
             fragment: The fragment to update. Not mutated.
             tier: The privacy tier to apply.
 
         Returns:
-            A new :class:`Fragment` with ``privacy_tier`` and
-            ``voice_proxy_eligible`` set to match *tier*.
+            A new :class:`Fragment` with ``privacy_tier`` set to *tier*.
         """
-        return fragment.model_copy(
-            update={
-                "privacy_tier": tier,
-                "voice_proxy_eligible": tier != PrivacyTier.INTIMATE,
-            },
-        )
+        return fragment.model_copy(update={"privacy_tier": tier})
 
     def classify_and_enforce(
         self,

--- a/creek-tools/creek/classify/privacy.py
+++ b/creek-tools/creek/classify/privacy.py
@@ -15,7 +15,7 @@ Section 13.2 of the Creek Ontology defines three privacy tiers:
   by content signals.
 
 When in doubt the classifier returns :class:`PrivacyTier.PERSONAL`
-rather than :class:`PrivacyTier.PUBLIC` — leaking content the user
+rather than :class:`PrivacyTier.OPEN` — leaking content the user
 considered private is far worse than the inverse.
 """
 
@@ -113,7 +113,7 @@ class PrivacyClassifier:
         1. Self-authored + recovery keyword in title or body → ``INTIMATE``.
         2. Self-authored journal source → ``INTIMATE``.
         3. Self-authored confessional register with conviction → ``INTIMATE``.
-        4. Essay source → :class:`PrivacyTier.PUBLIC`.
+        4. Essay source → :class:`PrivacyTier.OPEN`.
         5. Discord with a non-DM channel name → ``PUBLIC``.
         6. Anything else (chatbots, DMs, unmapped sources, AI-authored
            content with sensitive keywords) → ``PERSONAL``.
@@ -141,7 +141,7 @@ class PrivacyClassifier:
             if self._is_high_confidence_confessional(fragment):
                 return PrivacyTier.INTIMATE
         if platform == SourcePlatform.ESSAY:
-            return PrivacyTier.PUBLIC
+            return PrivacyTier.OPEN
         if platform == SourcePlatform.DISCORD:
             return self._classify_discord(fragment)
         # Chatbots, DMs, unmapped sources, AI-authored sensitive content
@@ -229,4 +229,4 @@ class PrivacyClassifier:
         tokens = {token for token in _CHANNEL_TOKEN_SPLIT.split(channel) if token}
         if tokens & _PRIVATE_DISCORD_TOKENS:
             return PrivacyTier.PERSONAL
-        return PrivacyTier.PUBLIC
+        return PrivacyTier.OPEN

--- a/creek-tools/creek/classify/review.py
+++ b/creek-tools/creek/classify/review.py
@@ -7,11 +7,11 @@ mandatory human review.
 """
 
 import logging
-from datetime import datetime
 from pathlib import Path
 
 from creek.config import ClassificationConfig
 from creek.models import Confidence, Fragment, Frequency, PrivacyTier
+from creek.time import now_la
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +98,7 @@ class ReviewQueueGenerator:
             len(fragments),
         )
 
-        timestamp = datetime.now().strftime("%Y-%m-%d_%H%M%S")
+        timestamp = now_la().strftime("%Y-%m-%d_%H%M%S")
         filename = f"review-queue-{timestamp}.md"
         output_path = vault_path / filename
 
@@ -120,7 +120,7 @@ class ReviewQueueGenerator:
         lines: list[str] = [
             "# Classification Review Queue",
             "",
-            f"Generated: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            f"Generated: {now_la().strftime('%Y-%m-%d %H:%M:%S %Z')}",
             f"Fragments to review: {len(fragments)}",
             "",
         ]

--- a/creek-tools/creek/clean/context.py
+++ b/creek-tools/creek/clean/context.py
@@ -215,8 +215,10 @@ class ContextExtractor:
 def _enforce_constraints(fragment: Fragment) -> Fragment:
     """Apply universal constraints to a non-self fragment.
 
-    - Sets ``voice_proxy_eligible`` to ``False``.
     - Downgrades ``intimate`` privacy tier to ``personal``.
+    - ``voice_proxy_eligible`` is a derived property (BUG-009): non-self
+      fragments are excluded automatically because the property requires
+      ``source.author == Authorship.SELF``. No explicit write needed.
 
     Args:
         fragment: The fragment to constrain.
@@ -225,7 +227,6 @@ def _enforce_constraints(fragment: Fragment) -> Fragment:
         A deep copy of the fragment with constraints applied.
     """
     updated = fragment.model_copy(deep=True)
-    updated.voice_proxy_eligible = False
 
     if updated.privacy_tier == PrivacyTier.INTIMATE:
         updated.privacy_tier = PrivacyTier.PERSONAL

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1549,9 +1549,6 @@ def purge_source(
         raise typer.Exit(code=2)
 
     engine = _build_engine(vault, dry_run=dry_run)
-    # source_type guaranteed non-None by the XOR check above when
-    # source_path is None.
-    platform = source_type or ""
     if source_path is not None:
         try:
             count = engine.count_fragments_from_source_path(
@@ -1563,8 +1560,15 @@ def purge_source(
             raise typer.Exit(code=2) from exc
         target_repr = f"source path {source_path!r} (match={match})"
     else:
-        count = engine.count_fragments_from_source(platform)
-        target_repr = f"source platform {platform!r}"
+        # The XOR guard above guarantees source_type is non-None
+        # whenever source_path is None — assert that invariant
+        # explicitly so a future refactor that breaks it surfaces
+        # immediately rather than silently passing an empty platform.
+        assert source_type is not None, (  # nosec B101
+            "XOR guard failed: source_type required when source_path is None"
+        )
+        count = engine.count_fragments_from_source(source_type)
+        target_repr = f"source platform {source_type!r}"
     console.print(
         f"[bold]This will delete {count} fragments from {target_repr}.[/bold]",
     )
@@ -1574,7 +1578,10 @@ def purge_source(
     if source_path is not None:
         result = engine.purge_source_path(source_path, match=match)
     else:
-        result = engine.purge_source(platform)
+        assert source_type is not None, (  # nosec B101
+            "XOR guard failed: source_type required when source_path is None"
+        )
+        result = engine.purge_source(source_type)
     _render_purge_result(result)
 
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1478,7 +1478,17 @@ def purge_fragment(
     _render_purge_result(result)
 
 
-_PURGE_SOURCE_MATCH_MODES = ("exact", "substring", "regex")
+def _purge_source_match_modes() -> tuple[str, ...]:
+    """Return the canonical ``--match`` modes for ``purge source --source-path``.
+
+    Reuses :data:`creek.purge.engine.SOURCE_PATH_MATCH_MODES` (INC-008
+    review nit) so the CLI usage error can never drift from the engine
+    validator. Returned as a sorted tuple for deterministic CLI help
+    output.
+    """
+    from creek.purge.engine import SOURCE_PATH_MATCH_MODES
+
+    return tuple(sorted(SOURCE_PATH_MATCH_MODES))
 
 
 @purge_app.command(name="source")
@@ -1530,10 +1540,11 @@ def purge_source(
             "[red]Pass exactly one of SOURCE_TYPE or --source-path.[/red]",
         )
         raise typer.Exit(code=2)
-    if match not in _PURGE_SOURCE_MATCH_MODES:
+    valid_modes = _purge_source_match_modes()
+    if match not in valid_modes:
         console.print(
             f"[red]Unknown --match {match!r}; expected one of "
-            f"{', '.join(_PURGE_SOURCE_MATCH_MODES)}.[/red]",
+            f"{', '.join(valid_modes)}.[/red]",
         )
         raise typer.Exit(code=2)
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -259,9 +259,21 @@ def _resolve_ingestor(type_name: str) -> type[Ingestor]:
     cls = INGESTOR_REGISTRY.get(type_name)
     if cls is None:
         known = ", ".join(sorted(INGESTOR_REGISTRY.keys()))
-        console.print(
-            f"[red]Unknown ingestor type {type_name!r}. Known types: {known}[/red]",
-        )
+        if type_name == "gdrive":
+            # ARCH-001: gdrive is a downloader, not an ingestor. Direct
+            # the operator to the two-stage flow rather than failing
+            # with a generic "unknown type" message.
+            console.print(
+                "[red]gdrive is a downloader, not an ingestor. Run "
+                "[bold]creek gdrive --download --staging <dir>[/bold] to mirror "
+                "Drive files locally, then point the appropriate ingestor at "
+                "the staging directory (e.g. [bold]creek ingest --type document "
+                "--input <dir>[/bold] for .docx / .pdf files).[/red]",
+            )
+        else:
+            console.print(
+                f"[red]Unknown ingestor type {type_name!r}. Known types: {known}[/red]",
+            )
         raise typer.Exit(code=2)
     return cls
 
@@ -321,6 +333,47 @@ def _run_ingest(
         written += 1
 
     return written, errors
+
+
+@app.command()
+def init(
+    vault: Path = typer.Option(..., help="Vault root to initialise"),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Overwrite an existing creek_config.yaml.",
+    ),
+) -> None:
+    """Write a starter ``creek_config.yaml`` under the vault (ARCH-002).
+
+    A vault without a config silently picks up the built-in defaults,
+    which rarely match what a careful operator wants. ``creek init``
+    materialises a starter config at
+    ``<vault>/00-Creek-Meta/creek_config.yaml`` so the operator can
+    edit a real file with their own privacy / redaction / cleaning
+    decisions before any ingestion runs.
+
+    Existing files are preserved unless ``--force`` is passed.
+    """
+    from creek.config import generate_default_config
+
+    config_dir = vault / "00-Creek-Meta"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "creek_config.yaml"
+    if config_path.exists() and not force:
+        console.print(
+            f"[yellow]{config_path} already exists; "
+            "pass --force to overwrite.[/yellow]",
+        )
+        raise typer.Exit(code=1)
+    generate_default_config(config_path)
+    console.print(
+        f"[bold green]Wrote starter config to {config_path}.[/bold green]",
+    )
+    console.print(
+        "[dim]Edit it before running [bold]creek process[/bold] — the "
+        "defaults are intentionally cautious.[/dim]",
+    )
 
 
 @app.command()
@@ -1425,11 +1478,31 @@ def purge_fragment(
     _render_purge_result(result)
 
 
+_PURGE_SOURCE_MATCH_MODES = ("exact", "substring", "regex")
+
+
 @purge_app.command(name="source")
 def purge_source(
-    source_type: str = typer.Argument(
-        ...,
-        help="Source platform (e.g. claude, discord)",
+    source_type: str | None = typer.Argument(
+        None,
+        help=(
+            "Source platform (e.g. claude, discord). Mutually exclusive "
+            "with --source-path."
+        ),
+    ),
+    source_path: str | None = typer.Option(
+        None,
+        "--source-path",
+        help=(
+            "Match against source.original_file in each fragment's "
+            "frontmatter (INC-008). Use with --match to choose the "
+            "comparison mode."
+        ),
+    ),
+    match: str = typer.Option(
+        "exact",
+        "--match",
+        help="How --source-path is compared: exact | substring | regex.",
     ),
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
     dry_run: bool = typer.Option(False, help="Preview changes without deleting"),
@@ -1440,16 +1513,57 @@ def purge_source(
         help="Skip interactive confirmation",
     ),
 ) -> None:
-    """Delete every fragment ingested from a given source."""
+    """Delete every fragment ingested from a given source.
+
+    Two modes:
+
+    * Positional ``SOURCE_TYPE`` matches against ``source.platform``
+      (e.g. ``claude``, ``discord``) — the original behaviour.
+    * ``--source-path`` matches against ``source.original_file`` with
+      a configurable ``--match`` mode (INC-008): ``exact`` (default),
+      ``substring``, or ``regex``.
+
+    The two are mutually exclusive; pass exactly one.
+    """
+    if (source_type is None) == (source_path is None):
+        console.print(
+            "[red]Pass exactly one of SOURCE_TYPE or --source-path.[/red]",
+        )
+        raise typer.Exit(code=2)
+    if match not in _PURGE_SOURCE_MATCH_MODES:
+        console.print(
+            f"[red]Unknown --match {match!r}; expected one of "
+            f"{', '.join(_PURGE_SOURCE_MATCH_MODES)}.[/red]",
+        )
+        raise typer.Exit(code=2)
+
     engine = _build_engine(vault, dry_run=dry_run)
-    count = engine.count_fragments_from_source(source_type)
+    # source_type guaranteed non-None by the XOR check above when
+    # source_path is None.
+    platform = source_type or ""
+    if source_path is not None:
+        try:
+            count = engine.count_fragments_from_source_path(
+                source_path,
+                match=match,
+            )
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(code=2) from exc
+        target_repr = f"source path {source_path!r} (match={match})"
+    else:
+        count = engine.count_fragments_from_source(platform)
+        target_repr = f"source platform {platform!r}"
     console.print(
-        f"[bold]This will delete {count} fragments from {source_type!r}.[/bold]",
+        f"[bold]This will delete {count} fragments from {target_repr}.[/bold]",
     )
     if not dry_run and not _confirm("Continue?", assume_yes=yes):
         console.print("[yellow]Aborted.[/yellow]")
         return
-    result = engine.purge_source(source_type)
+    if source_path is not None:
+        result = engine.purge_source_path(source_path, match=match)
+    else:
+        result = engine.purge_source(platform)
     _render_purge_result(result)
 
 

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -9,12 +9,15 @@ API keys (e.g. ``ANTHROPIC_API_KEY``) are **never** stored in the YAML
 file — they must come from environment variables.
 """
 
+import logging
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
 import yaml
 from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
 
 
 class LLMConfig(BaseModel):
@@ -541,15 +544,27 @@ class CreekConfig(BaseSettings):
         return v
 
 
-def load_config(config_path: Path | None = None) -> CreekConfig:
+def load_config(
+    config_path: Path | None = None,
+    *,
+    warn_on_missing: bool = True,
+) -> CreekConfig:
     """Load configuration from a YAML file with environment variable overrides.
 
     If *config_path* does not exist, returns a ``CreekConfig`` populated
-    entirely from defaults and environment variables.
+    entirely from defaults and environment variables and (per ARCH-002)
+    emits a ``WARNING`` so the operator knows their data-handling
+    decisions are being made by the defaults rather than their own
+    config. Pass ``warn_on_missing=False`` to silence the warning when
+    the caller has already established that the missing file is
+    expected (e.g. ``creek init`` runs before any config exists).
 
     Args:
         config_path: Path to a ``creek_config.yaml`` file.  Defaults to
             ``creek_config.yaml`` in the current directory.
+        warn_on_missing: When ``True`` (default), log a WARNING if the
+            file does not exist. Suppress for CLI commands that
+            legitimately operate in the no-config state.
 
     Returns:
         A fully-validated ``CreekConfig`` instance.
@@ -562,6 +577,15 @@ def load_config(config_path: Path | None = None) -> CreekConfig:
             data: dict[str, object] = yaml.safe_load(f) or {}
         return CreekConfig.model_validate(data)
 
+    if warn_on_missing:
+        logger.warning(
+            "Config file %s not found; running with built-in defaults. "
+            "Run `creek init --vault <vault>` to write a starter config, "
+            "or pass --config <path> to point at one explicitly. "
+            "Pipeline behaviour (privacy, redaction, cleaning) depends on "
+            "this file — silent defaults are usually not what you want.",
+            config_path,
+        )
     return CreekConfig()
 
 

--- a/creek-tools/creek/generate/skills.py
+++ b/creek-tools/creek/generate/skills.py
@@ -32,6 +32,7 @@ from creek.generate.indexes import (
     FREQUENCY_THEMES,
 )
 from creek.models import (
+    Authorship,
     Eddy,
     Fragment,
     Frequency,
@@ -493,8 +494,17 @@ def _load_typed_model(
 
 
 def _is_snapshot_fragment(fragment: Fragment, *, allow_intimate: bool) -> bool:
-    """Return ``True`` when *fragment* is eligible for the snapshot."""
-    if not fragment.voice_proxy_eligible:
+    """Return ``True`` when *fragment* is eligible for the snapshot.
+
+    Eligibility derivation post-BUG-009:
+
+    * Non-self authorship is never eligible (mirrors the universal
+      constraint enforced by :class:`creek.clean.context.ContextExtractor`).
+    * INTIMATE content is excluded unless the operator passes
+      ``allow_intimate=True``; this opt-in matches the user-facing
+      ``--include-tier intimate`` switch on the generation CLI.
+    """
+    if str(fragment.source.author) != Authorship.SELF.value:
         return False
     is_intimate = str(fragment.privacy_tier) == PrivacyTier.INTIMATE.value
     return allow_intimate or not is_intimate

--- a/creek-tools/creek/generate/skills.py
+++ b/creek-tools/creek/generate/skills.py
@@ -503,11 +503,17 @@ def _is_snapshot_fragment(fragment: Fragment, *, allow_intimate: bool) -> bool:
     * INTIMATE content is excluded unless the operator passes
       ``allow_intimate=True``; this opt-in matches the user-facing
       ``--include-tier intimate`` switch on the generation CLI.
+
+    The non-INTIMATE branch is exactly :attr:`Fragment.voice_proxy_eligible`;
+    the function does not delegate to the property because
+    ``allow_intimate=True`` deliberately overrides the INTIMATE
+    exclusion that the property bakes in.
     """
-    if str(fragment.source.author) != Authorship.SELF.value:
+    if fragment.source.author != Authorship.SELF:
         return False
-    is_intimate = str(fragment.privacy_tier) == PrivacyTier.INTIMATE.value
-    return allow_intimate or not is_intimate
+    if fragment.privacy_tier == PrivacyTier.INTIMATE:
+        return allow_intimate
+    return True
 
 
 def _collect_fragments(

--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -29,6 +29,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
+import chardet
+
 from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
@@ -192,30 +194,72 @@ Excel emits for "CSV UTF-8" exports. ``cp1252`` is the Windows
 default for legacy Excel "CSV (Comma delimited)" exports — a near
 superset of Latin-1 that decodes any byte sequence without raising,
 so it serves as a guaranteed-success fallback.
+
+A ``chardet`` probe between the two catches non-Western encodings
+(Shift-JIS, GBK, ISO-8859-5, …) that ``cp1252`` would otherwise
+decode silently into mojibake (BUG-010).
+"""
+
+CSV_CHARDET_CONFIDENCE_THRESHOLD: float = 0.7
+"""Minimum ``chardet`` confidence required to trust an auto-detected encoding.
+
+Below this we fall through to ``cp1252`` and emit a warning so the
+user knows the result may be mojibake.
 """
 
 
 def _read_csv(path: Path) -> WorkbookData:
     """Read a CSV file as a single-sheet workbook.
 
-    Tries each encoding in :data:`CSV_ENCODING_FALLBACKS` in order —
-    decoding with the first that succeeds. ``cp1252`` is positioned
-    last because it accepts arbitrary bytes and so always succeeds,
-    guaranteeing the read never raises ``UnicodeDecodeError``.
+    Probe order:
+
+    1. ``utf-8-sig`` — handles BOM + plain UTF-8, the dominant case.
+    2. ``chardet`` — detects non-Western encodings (Shift-JIS, GBK,
+       ISO-8859-5, …) when its confidence exceeds
+       :data:`CSV_CHARDET_CONFIDENCE_THRESHOLD`.
+    3. ``cp1252`` — last-resort fallback that accepts any byte
+       sequence. Emits a ``WARNING`` log including the file path so
+       the user has a chance to spot mojibake before it lands in the
+       vault (BUG-010).
     """
     raw = path.read_bytes()
-    for encoding in CSV_ENCODING_FALLBACKS:
+    try:
+        text = raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        pass
+    else:
+        return _csv_text_to_workbook(path, text)
+
+    detection = chardet.detect(raw)
+    detected = detection.get("encoding")
+    confidence = detection.get("confidence") or 0.0
+    if (
+        detected
+        and confidence >= CSV_CHARDET_CONFIDENCE_THRESHOLD
+        and detected.lower() not in {"ascii", "utf-8-sig", "cp1252"}
+    ):
         try:
-            text = raw.decode(encoding)
-        except UnicodeDecodeError:
-            continue
-        rows = [tuple(row) for row in csv.reader(text.splitlines())]
-        return WorkbookData(sheets=(_split_header(path.stem, rows),))
-    # Unreachable: ``cp1252`` accepts any byte sequence so the loop
-    # always returns. We keep this guard so a future change to the
-    # fallback list cannot silently produce an undefined return.
-    msg = f"Unable to decode CSV {path} with any known encoding."
-    raise AssertionError(msg)  # pragma: no cover
+            text = raw.decode(detected)
+        except (UnicodeDecodeError, LookupError):
+            pass
+        else:
+            return _csv_text_to_workbook(path, text)
+
+    text = raw.decode("cp1252")
+    logger.warning(
+        "CSV %s decoded as cp1252 (chardet best guess: %s @ %.2f); "
+        "non-Western content may render as mojibake.",
+        path,
+        detected or "unknown",
+        confidence,
+    )
+    return _csv_text_to_workbook(path, text)
+
+
+def _csv_text_to_workbook(path: Path, text: str) -> WorkbookData:
+    """Parse decoded CSV ``text`` into a single-sheet :class:`WorkbookData`."""
+    rows = [tuple(row) for row in csv.reader(text.splitlines())]
+    return WorkbookData(sheets=(_split_header(path.stem, rows),))
 
 
 def _split_header(

--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -186,20 +186,6 @@ def _cell_to_str(value: Any) -> str:
     return str(value)
 
 
-CSV_ENCODING_FALLBACKS: tuple[str, ...] = ("utf-8-sig", "cp1252")
-"""Encoding probe order for CSV reads.
-
-``utf-8-sig`` decodes plain UTF-8 *and* strips the UTF-8 BOM that
-Excel emits for "CSV UTF-8" exports. ``cp1252`` is the Windows
-default for legacy Excel "CSV (Comma delimited)" exports — a near
-superset of Latin-1 that decodes any byte sequence without raising,
-so it serves as a guaranteed-success fallback.
-
-A ``chardet`` probe between the two catches non-Western encodings
-(Shift-JIS, GBK, ISO-8859-5, …) that ``cp1252`` would otherwise
-decode silently into mojibake (BUG-010).
-"""
-
 CSV_CHARDET_CONFIDENCE_THRESHOLD: float = 0.7
 """Minimum ``chardet`` confidence required to trust an auto-detected encoding.
 

--- a/creek-tools/creek/link/eddies.py
+++ b/creek-tools/creek/link/eddies.py
@@ -32,8 +32,11 @@ from __future__ import annotations
 
 import logging
 import re
+import sys
 from collections import Counter
 from typing import TYPE_CHECKING
+
+from tqdm import tqdm
 
 from creek.models import Eddy
 
@@ -437,7 +440,16 @@ class EddyDetector:
         """
         n = len(ids)
         labels = [_UNVISITED] * n
-        neighbour_cache = [self._neighbours(ids, i) for i in range(n)]
+        # OPS-004: neighbour-cache build is O(N²); progress bar in TTYs.
+        neighbour_cache = [
+            self._neighbours(ids, i)
+            for i in tqdm(
+                range(n),
+                desc="Eddy neighbours",
+                unit="frag",
+                disable=not sys.stderr.isatty(),
+            )
+        ]
         cluster_id = 0
         for i in range(n):
             if labels[i] != _UNVISITED:

--- a/creek-tools/creek/link/embeddings.py
+++ b/creek-tools/creek/link/embeddings.py
@@ -10,7 +10,10 @@ from __future__ import annotations
 
 import itertools
 import logging
+import sys
 from typing import TYPE_CHECKING, cast
+
+from tqdm import tqdm
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -225,7 +228,18 @@ class EmbeddingLinker:
         similarity_matrix = normalized @ normalized.T
 
         resonances: list[tuple[str, str, float]] = []
-        for i, j in itertools.combinations(range(len(ids)), 2):
+        # OPS-004: pairwise loop is O(N²); on a 10k-fragment vault this
+        # is ~50M iterations and runs for minutes. Show tqdm in TTYs and
+        # stay silent in non-interactive runs (CI logs, pipes).
+        n_pairs = len(ids) * (len(ids) - 1) // 2
+        pair_iter = tqdm(
+            itertools.combinations(range(len(ids)), 2),
+            total=n_pairs,
+            desc="Resonances",
+            unit="pair",
+            disable=not sys.stderr.isatty(),
+        )
+        for i, j in pair_iter:
             sim = float(similarity_matrix[i, j])
             if sim >= self.config.similarity_threshold:
                 resonances.append((ids[i], ids[j], sim))

--- a/creek-tools/creek/link/threads.py
+++ b/creek-tools/creek/link/threads.py
@@ -21,6 +21,7 @@ from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
 
 from creek.models import Frequency, Thread, ThreadStatus
+from creek.time import now_la
 
 if TYPE_CHECKING:
     from creek.models import Fragment
@@ -326,13 +327,14 @@ class ThreadDetector:
             merge_jaccard: Title-token Jaccard threshold used by
                 :meth:`suggest_merges`. Defaults to 0.3.
             now: Reference "now" for status calculation; defaults to
-                :func:`datetime.now`. Useful for deterministic tests.
+                :func:`creek.time.now_la` (America/Los_Angeles tz-aware).
+                Useful for deterministic tests.
         """
         self.embeddings: dict[str, list[float]] = embeddings or {}
         self.window_days = window_days
         self.similarity_threshold = similarity_threshold
         self.merge_jaccard = merge_jaccard
-        self._now = now or datetime.now()
+        self._now = now or now_la()
         self._thread_members: dict[str, list[str]] = {}
 
     @property

--- a/creek-tools/creek/link/threads.py
+++ b/creek-tools/creek/link/threads.py
@@ -16,9 +16,12 @@ from __future__ import annotations
 
 import logging
 import re
+import sys
 from collections import Counter
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
+
+from tqdm import tqdm
 
 from creek.models import Frequency, Thread, ThreadStatus
 from creek.time import now_la
@@ -402,7 +405,16 @@ class ThreadDetector:
             uf.add(frag.id)
 
         window = timedelta(days=self.window_days)
-        for i, frag_a in enumerate(sorted_frags):
+        # OPS-004: outer loop drives the wall-time on a 10k-vault link
+        # rebuild. tqdm in TTYs, silent elsewhere.
+        outer = tqdm(
+            enumerate(sorted_frags),
+            total=len(sorted_frags),
+            desc="Threads",
+            unit="frag",
+            disable=not sys.stderr.isatty(),
+        )
+        for i, frag_a in outer:
             for frag_b in sorted_frags[i + 1 :]:
                 if frag_b.created - frag_a.created > window:
                     break

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -349,6 +349,11 @@ class Fragment(BaseModel):
     context: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
 
+    # BUG-009: the ``[prop-decorator]`` suppression below is a known
+    # mypy / Pydantic-v2 limitation when stacking ``@computed_field``
+    # over ``@property`` — see
+    # https://github.com/pydantic/pydantic/issues/6710. The bytes-on-disk
+    # behaviour is correct; mypy just can't model the descriptor stack.
     @computed_field  # type: ignore[prop-decorator]
     @property
     def voice_proxy_eligible(self) -> bool:

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -204,12 +204,44 @@ class PrivacyTier(StrEnum):
 
     Controls visibility and handling restrictions. ``intimate`` content
     is reserved exclusively for self-authored fragments.
+
+    Naming history (INC-003): the canonical name is ``OPEN``
+    (``"open"``) per ontology §13.2 — "openly publishable", not
+    "internet-public". The legacy value ``"public"`` is accepted on
+    input via :meth:`_missing_` and silently mapped to ``OPEN``, with
+    a :class:`DeprecationWarning` so an operator running against an
+    older vault knows to migrate. Plan removal in the next minor
+    version.
     """
 
-    PUBLIC = "public"
+    OPEN = "open"
     PERSONAL = "personal"
     INTIMATE = "intimate"
     UNCLASSIFIED = "unclassified"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "PrivacyTier | None":
+        """Map the deprecated ``"public"`` string to :attr:`OPEN`.
+
+        Old vaults serialised the tier as ``public``. INC-003 renamed
+        the canonical value to ``open``; this hook keeps those vaults
+        loadable for one release while emitting a
+        :class:`DeprecationWarning` that names the migration path.
+        Any other unknown value still raises ``ValueError`` from the
+        StrEnum constructor.
+        """
+        if isinstance(value, str) and value == "public":
+            import warnings
+
+            warnings.warn(
+                "PrivacyTier value 'public' is deprecated; use 'open'. "
+                "INC-003: support for 'public' will be removed in the "
+                "next minor release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return cls.OPEN
+        return None
 
 
 # ---- ID Generation Helpers ----

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -10,7 +10,9 @@ import uuid
 from datetime import date, datetime
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, computed_field
+
+from creek.time import now_la, today_la
 
 # ---- Enums ----
 
@@ -330,8 +332,8 @@ class Fragment(BaseModel):
     id: str
     title: str
     source: FragmentSource
-    created: datetime = Field(default_factory=datetime.now)
-    ingested: datetime = Field(default_factory=datetime.now)
+    created: datetime = Field(default_factory=now_la)
+    ingested: datetime = Field(default_factory=now_la)
     frequency: FrequencyClassification = Field(
         default_factory=FrequencyClassification,
     )
@@ -345,8 +347,23 @@ class Fragment(BaseModel):
     praxis_potential: PraxisPotential = PraxisPotential.NONE
     privacy_tier: PrivacyTier = PrivacyTier.UNCLASSIFIED
     context: list[str] = Field(default_factory=list)
-    voice_proxy_eligible: bool = True
     tags: list[str] = Field(default_factory=list)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def voice_proxy_eligible(self) -> bool:
+        """Whether this fragment may feed voice-proxy generation.
+
+        Derived (BUG-009) so the flag cannot drift from ``privacy_tier``
+        and ``source.author``: only self-authored, non-INTIMATE fragments
+        are eligible. INTIMATE content is excluded per ontology §13.2,
+        and AI / collaborator / other-authored content is excluded per
+        the universal-constraints rule in :mod:`creek.clean.context`.
+        """
+        return (
+            self.privacy_tier != PrivacyTier.INTIMATE
+            and self.source.author == Authorship.SELF
+        )
 
 
 class DecisionCandidate(BaseModel):
@@ -381,8 +398,8 @@ class Thread(BaseModel):
     id: str = Field(default_factory=_generate_thread_id)
     title: str
     status: ThreadStatus = ThreadStatus.ACTIVE
-    first_seen: date = Field(default_factory=date.today)
-    last_seen: date = Field(default_factory=date.today)
+    first_seen: date = Field(default_factory=today_la)
+    last_seen: date = Field(default_factory=today_la)
     frequency_affinity: list[Frequency] = Field(default_factory=list)
     fragment_count: int = 0
     description: str = ""
@@ -400,7 +417,7 @@ class Eddy(BaseModel):
     type: str = "eddy"
     id: str = Field(default_factory=_generate_eddy_id)
     title: str
-    formed: date = Field(default_factory=date.today)
+    formed: date = Field(default_factory=today_la)
     fragment_count: int = 0
     threads: list[str] = Field(default_factory=list)
     description: str = ""
@@ -440,7 +457,7 @@ class Decision(BaseModel):
     id: str = Field(default_factory=_generate_decision_id)
     title: str
     status: DecisionStatus = DecisionStatus.SENSING
-    opened: date = Field(default_factory=date.today)
+    opened: date = Field(default_factory=today_la)
     decided: date | None = None
     frequency_context: list[Frequency] = Field(default_factory=list)
     wavelength_phase_at_opening: str = ""

--- a/creek-tools/creek/purge/audit.py
+++ b/creek-tools/creek/purge/audit.py
@@ -6,6 +6,17 @@ entry captures the timestamp, operation, criteria dict, affected
 fragment IDs, deletion counts, references scrubbed, embeddings removed,
 operator, and dry-run flag.
 
+Timezone (BUG-002): purge-audit entries deliberately stamp ``UTC``
+rather than ``America/Los_Angeles`` (the rest of the pipeline). The
+audit chain is forensic infrastructure — its consumers are operators
+investigating an incident, log-aggregation tooling, and downstream
+pipelines that may run on hosts in any timezone. UTC is the portable
+default for that audience and is what every other tamper-evident log
+in the repo (vault-writer provenance, redaction audit, privacy
+elevation audit) also uses. Fragment / thread / eddy timestamps stay
+on LA per ontology §8.3 because they describe the user's lived
+experience; audit timestamps describe a machine event.
+
 Backward compatibility: an existing legacy
 ``<vault>/00-Creek-Meta/Processing-Log/purge-log.json`` file is migrated
 into the new JSONL log on first read or write, then removed. The

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -27,6 +27,7 @@ from pydantic import BaseModel, Field
 from creek.purge.audit import PurgeAuditEntry, PurgeAuditLog
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ _CLASSIFICATION_RESET_FIELDS: tuple[str, ...] = (
 """Frontmatter fields wiped by ``purge_classifications``."""
 
 _FILE_DELETING_OPERATIONS: frozenset[str] = frozenset(
-    {"fragment", "source", "daterange", "vault"},
+    {"fragment", "source", "source-path", "daterange", "vault"},
 )
 """Explicit allowlist of operations that remove files from disk.
 
@@ -208,6 +209,60 @@ class PurgeEngine:
             Number of matching fragment files.
         """
         return len(self._fragments_from_source(source_type))
+
+    def purge_source_path(
+        self,
+        source_path: str,
+        *,
+        match: str = "exact",
+    ) -> PurgeResult:
+        """Delete every fragment whose ``source.original_file`` matches (INC-008).
+
+        Args:
+            source_path: The path (or substring / regex) to match against
+                each fragment's ``source.original_file``.
+            match: ``"exact"`` (full-string equality, default),
+                ``"substring"`` (Python ``in``), or ``"regex"``
+                (re.search). An invalid regex raises ``ValueError``
+                fast rather than silently mismatching.
+
+        Returns:
+            A :class:`PurgeResult` summarising the deletions and
+            recording the match mode in its criteria.
+
+        Raises:
+            ValueError: When ``match`` is unrecognised, or when
+                ``match="regex"`` and ``source_path`` is not a valid
+                regex.
+        """
+        result = PurgeResult(
+            operation="source-path",
+            target=source_path,
+            criteria={"source_path": source_path, "match": match},
+            dry_run=self.dry_run,
+        )
+        matches = self._fragments_from_source_path(source_path, match=match)
+        for frag_file, post in matches:
+            self._purge_single(frag_file, post, result)
+        self._write_audit(result)
+        return result
+
+    def count_fragments_from_source_path(
+        self,
+        source_path: str,
+        *,
+        match: str = "exact",
+    ) -> int:
+        """Count fragments whose ``source.original_file`` matches (INC-008).
+
+        Args:
+            source_path: The path / substring / regex to match.
+            match: One of ``"exact"`` / ``"substring"`` / ``"regex"``.
+
+        Returns:
+            Number of matching fragment files.
+        """
+        return len(self._fragments_from_source_path(source_path, match=match))
 
     # -- Classifications purge -------------------------------------------
 
@@ -402,6 +457,36 @@ class PurgeEngine:
             if post is None:
                 continue
             if _extract_source_platform(post) == source_type:
+                matches.append((frag_file, post))
+        return matches
+
+    def _fragments_from_source_path(
+        self,
+        source_path: str,
+        *,
+        match: str,
+    ) -> list[tuple[Path, frontmatter.Post]]:
+        """List fragments whose ``source.original_file`` matches *source_path*.
+
+        Args:
+            source_path: Path string / substring / regex.
+            match: ``"exact"`` / ``"substring"`` / ``"regex"``.
+
+        Returns:
+            List of ``(path, post)`` pairs.
+
+        Raises:
+            ValueError: When *match* is unrecognised, or when
+                ``match="regex"`` and *source_path* is not a valid regex.
+        """
+        predicate = _build_source_path_matcher(source_path, match=match)
+        matches: list[tuple[Path, frontmatter.Post]] = []
+        for frag_file in self._list_fragment_files():
+            post = self._load_frontmatter(frag_file)
+            if post is None:
+                continue
+            original_file = _extract_source_original_file(post)
+            if original_file is not None and predicate(original_file):
                 matches.append((frag_file, post))
         return matches
 
@@ -625,6 +710,65 @@ def _extract_source_platform(post: frontmatter.Post) -> str | None:
         platform = source.get("platform")
         return str(platform) if platform is not None else None
     return None
+
+
+def _extract_source_original_file(post: frontmatter.Post) -> str | None:
+    """Extract the ``source.original_file`` string from frontmatter (INC-008).
+
+    Args:
+        post: Parsed frontmatter post.
+
+    Returns:
+        The original file path, or ``None`` when missing.
+    """
+    source = post.get("source")
+    if isinstance(source, dict):
+        original = source.get("original_file")
+        return str(original) if original is not None else None
+    return None
+
+
+_VALID_SOURCE_PATH_MATCH_MODES: frozenset[str] = frozenset(
+    {"exact", "substring", "regex"},
+)
+
+
+def _build_source_path_matcher(
+    source_path: str,
+    *,
+    match: str,
+) -> Callable[[str], bool]:
+    """Build a per-fragment predicate from *source_path* and *match* mode.
+
+    Args:
+        source_path: Path string the operator passed.
+        match: One of ``"exact"`` / ``"substring"`` / ``"regex"``.
+
+    Returns:
+        A callable that takes a fragment's ``source.original_file`` and
+        returns ``True`` when the fragment should be purged.
+
+    Raises:
+        ValueError: When *match* is unrecognised, or when
+            ``match="regex"`` and *source_path* is not a valid regex.
+    """
+    if match not in _VALID_SOURCE_PATH_MATCH_MODES:
+        msg = (
+            f"Unknown match mode {match!r}; expected one of "
+            f"{sorted(_VALID_SOURCE_PATH_MATCH_MODES)}."
+        )
+        raise ValueError(msg)
+    if match == "exact":
+        return lambda candidate: candidate == source_path
+    if match == "substring":
+        return lambda candidate: source_path in candidate
+    # match == "regex"
+    try:
+        pattern = re.compile(source_path)
+    except re.error as exc:
+        msg = f"Invalid regex {source_path!r}: {exc}"
+        raise ValueError(msg) from exc
+    return lambda candidate: pattern.search(candidate) is not None
 
 
 def _build_wikilink_pattern(title: str) -> re.Pattern[str]:

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -728,9 +728,16 @@ def _extract_source_original_file(post: frontmatter.Post) -> str | None:
     return None
 
 
-_VALID_SOURCE_PATH_MATCH_MODES: frozenset[str] = frozenset(
+SOURCE_PATH_MATCH_MODES: frozenset[str] = frozenset(
     {"exact", "substring", "regex"},
 )
+"""Canonical set of valid ``--match`` modes for ``purge source --source-path``.
+
+Exported (no leading underscore) so the CLI layer can re-use the same
+constant rather than duplicating it. The CLI iterates this set when
+rendering its own usage error and the engine validates against it
+inside :meth:`PurgeEngine.purge_source_path`. INC-008.
+"""
 
 
 def _build_source_path_matcher(
@@ -752,10 +759,10 @@ def _build_source_path_matcher(
         ValueError: When *match* is unrecognised, or when
             ``match="regex"`` and *source_path* is not a valid regex.
     """
-    if match not in _VALID_SOURCE_PATH_MATCH_MODES:
+    if match not in SOURCE_PATH_MATCH_MODES:
         msg = (
             f"Unknown match mode {match!r}; expected one of "
-            f"{sorted(_VALID_SOURCE_PATH_MATCH_MODES)}."
+            f"{sorted(SOURCE_PATH_MATCH_MODES)}."
         )
         raise ValueError(msg)
     if match == "exact":

--- a/creek-tools/creek/time.py
+++ b/creek-tools/creek/time.py
@@ -1,0 +1,31 @@
+"""Centralised timezone helpers for the Creek pipeline.
+
+The Creek ontology (§8.3) and ``docs/ingestion.md`` mandate that every
+timestamp the pipeline produces is normalised to America/Los_Angeles.
+Bare :func:`datetime.now` calls leak the host timezone (or, worse,
+produce naive datetimes that fail to compare against tz-aware ones with
+``TypeError``), so production code routes through :func:`now_la` /
+:func:`today_la` instead.
+
+The constant :data:`LA_TZ` is re-exported from
+:mod:`creek.ingest.base` to preserve the historical import path while
+giving callers a dependency-free home for the helper.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from zoneinfo import ZoneInfo
+
+LA_TZ = ZoneInfo("America/Los_Angeles")
+"""Target timezone for all normalized timestamps (America/Los_Angeles)."""
+
+
+def now_la() -> datetime:
+    """Return the current time as a tz-aware datetime in America/Los_Angeles."""
+    return datetime.now(tz=LA_TZ)
+
+
+def today_la() -> date:
+    """Return today's date as observed in America/Los_Angeles."""
+    return now_la().date()

--- a/creek-tools/docs/classification.md
+++ b/creek-tools/docs/classification.md
@@ -80,7 +80,7 @@ Re-running `creek classify --method llm` after a crash is therefore the resume c
 
 Pass `--force` if you genuinely want to re-classify everything (for example, after a model upgrade).
 
-The engine also appends each classified fragment ID to `<vault>/00-Creek-Meta/Processing-Log/llm-progress.json` for observability. The file is informational — the per-fragment frontmatter is the source of truth.
+The engine also appends each classified fragment ID to `<vault>/00-Creek-Meta/Processing-Log/llm-progress.jsonl` for observability (newline-delimited JSON, one `{"id": ...}` object per line). The file is informational — the per-fragment frontmatter is the source of truth.
 
 ## LLM provider details
 

--- a/creek-tools/docs/classification.md
+++ b/creek-tools/docs/classification.md
@@ -72,6 +72,16 @@ creek review --vault ~/Obsidian/Creek-Vault
 
 `creek review` prints a TUI of pending fragments, lets you accept / override / defer each one, and writes the human decisions back to frontmatter as `method: manual`. Manual decisions are stable across re-classification — `creek classify` will not overwrite a `method: manual` field unless you pass `--force`.
 
+## Crash recovery and resume (OPS-001)
+
+LLM classification of a 10k-fragment vault takes hours. To make a partial run survivable, `creek classify` writes each fragment back to disk **the moment the LLM call returns** — not at end-of-batch. If the process is killed (laptop closed, network blip, OOM), every fragment classified up to that point keeps its result on disk.
+
+Re-running `creek classify --method llm` after a crash is therefore the resume command — there is no separate `--resume` flag. The engine skips any fragment whose `classification_method` is already `llm` (or `manual`); only fragments still at `rules` or unclassified are sent to the provider. This means you do not pay the Anthropic provider twice for the same fragment.
+
+Pass `--force` if you genuinely want to re-classify everything (for example, after a model upgrade).
+
+The engine also appends each classified fragment ID to `<vault>/00-Creek-Meta/Processing-Log/llm-progress.json` for observability. The file is informational — the per-fragment frontmatter is the source of truth.
+
 ## LLM provider details
 
 ### Ollama (default, local)

--- a/creek-tools/docs/cleaning-and-purge.md
+++ b/creek-tools/docs/cleaning-and-purge.md
@@ -85,13 +85,29 @@ Use this when you've already identified the unwanted fragment (e.g. via `creek c
 
 ### `creek purge source`
 
-Delete every fragment ingested from a given source path. Useful when you imported a directory by accident, or when a person has asked for their messages to be removed.
+Delete every fragment ingested from a given source. Two complementary modes (INC-008):
 
-```bash
-creek purge source --source-path ~/exports/unwanted.zip --vault ~/Obsidian/Creek-Vault
-```
+- **By platform** (positional argument). Matches against `source.platform`. Useful when you want to wipe everything from a specific exporter:
 
-The source path is matched against `source.original_file` in each fragment's frontmatter — exact match by default, or substring with `--match substring`.
+  ```bash
+  creek purge source claude --vault ~/Obsidian/Creek-Vault
+  creek purge source discord --vault ~/Obsidian/Creek-Vault
+  ```
+
+- **By source path** (`--source-path`). Matches against `source.original_file` in each fragment's frontmatter. The `--match` mode controls how the path is compared:
+
+  ```bash
+  # Exact path equality (the default).
+  creek purge source --source-path ~/exports/unwanted.zip --vault ~/Obsidian/Creek-Vault
+
+  # Substring containment — handy when staged files share a directory.
+  creek purge source --source-path /exports/2026-04 --match substring --vault ~/Obsidian/Creek-Vault
+
+  # Regex — fail fast on a malformed pattern; no silent mismatches.
+  creek purge source --source-path "diary-2026-04-2[0-9]\.md$" --match regex --vault ~/Obsidian/Creek-Vault
+  ```
+
+Pass exactly one of the two modes; mixing them is a usage error. Both modes record the chosen criteria — including `--match` — to the audit log so an operator can reconstruct what each purge actually targeted.
 
 ### `creek purge classifications`
 

--- a/creek-tools/docs/cleaning-pipeline.md
+++ b/creek-tools/docs/cleaning-pipeline.md
@@ -1,0 +1,139 @@
+# Cleaning pipeline
+
+The `creek/clean/` package contains the modules that decide *which* content survives ingestion and *what shape* it takes once it does. They run inline during `creek ingest` (and again, against the saved vault, during `creek clean *`). Every module is wired to a `cleaning.*` section in [`configuration.md`](configuration.md) so the same knobs that this doc names also appear in `~/.config/creek/config.yaml`.
+
+This page is the missing manual: what each module does, when it runs, what failure looks like, and which knob to turn when something is off.
+
+For the **CLI hygiene commands** (`creek clean orphans`, `clean stale-reviews`, etc.), see [`cleaning-and-purge.md`](cleaning-and-purge.md). This page is about the *inline* pipeline, not the post-hoc CLI.
+
+---
+
+## Order of operations
+
+```
+raw bytes → pre-ingestion filter (per source)
+          → ingestor (parse + frontmatter)
+          → AuthorshipTagger
+          → ContextExtractor
+          → FragmentValidator
+          → QualityScorer
+          → Deduplicator + SemanticDeduplicator
+          → privacy classifier  (then: vault writer)
+```
+
+A fragment that fails validation lands in the **review queue** rather than getting silently dropped. A fragment that fails quality gets `action=skip` and is recorded but not written. A fragment flagged as a duplicate gets a `dedup` tag and points at the canonical fragment.
+
+---
+
+## Pre-ingestion filters (`creek/clean/filters/`)
+
+Each filter receives raw source data **before** the ingestor turns it into a Fragment. They are the cheapest place to drop noise — every byte filtered here saves work downstream.
+
+| Module | What it does | Config section | Failure mode |
+|---|---|---|---|
+| [`filters/chatbot.py`](../creek/clean/filters/chatbot.py) (`ChatbotFilter`) | Strips system prompts, tool-call outputs, regeneration loops, abandoned conversations, short human turns from Claude / ChatGPT exports. | `cleaning.chatbot` | If too aggressive, real human turns disappear. Lower `min_human_turn_chars` or disable specific `skip_*` flags. |
+| [`filters/discord.py`](../creek/clean/filters/discord.py) (`DiscordFilter`) | Skips bot messages, emoji-only / sticker-only posts, command invocations, link dumps, below-min-length text. Reply chains preserved even when short. | `cleaning.discord` | If your guild's `?cmd` prefix is non-standard, set `command_prefixes` so commands are still recognised. |
+| [`filters/google_drive.py`](../creek/clean/filters/google_drive.py) (`GoogleDriveFilter`) | Skips "Copy of …" duplicates, empty docs, multi-author files, oversized exports. | `cleaning.google_drive` | A "Copy of" file you actually want kept needs `prefer_newest=False` or a manual rename. |
+| [`filters/markdown.py`](../creek/clean/filters/markdown.py) (`MarkdownFilter`) | Skips empty / frontmatter-only / template-residue markdown files. | `cleaning.markdown` | Lower `min_body_chars` if short notes are being dropped. |
+
+A filter never raises on bad input — it returns a `FilterResult` with `keep=False` and a reason, so the ingest pipeline can record "filtered N files" without crashing.
+
+---
+
+## Inline cleaners (run on every Fragment)
+
+These run after the ingestor produces a Fragment but before it reaches the vault writer. Each is a pure function over `Fragment` so they compose without ordering surprises.
+
+### [`authorship.py`](../creek/clean/authorship.py) — `AuthorshipTagger`
+
+Sets `Fragment.source.author` to one of `self | ai | other | collaborative`. Source-aware:
+
+- **Claude / ChatGPT** — human turns → `self`, assistant turns → `ai`.
+- **Discord** — match author against `self_usernames`; mixed authorship → `collaborative`.
+- **Markdown / journal** — defaults to `self`.
+
+**No config section** — driven by `interlocutor` and platform metadata. Failure: missing `interlocutor` falls back to `self`; check `creek/clean/authorship.py` rules if attribution looks wrong.
+
+### [`context.py`](../creek/clean/context.py) — `ContextExtractor`
+
+Decides what to do with non-self content. Three configurable modes (set `cleaning.context.mode` or pass programmatically):
+
+| Mode | Behaviour |
+|---|---|
+| `context_metadata` (default) | Store others' content as `context` entries on the nearest user fragment. Drop the standalone fragment. |
+| `low_priority` | Keep as separate fragments tagged `low-priority`; exclude from voice-proxy generation. |
+| `skip` | Drop entirely. Only user content survives. |
+
+Universal constraints applied across all modes:
+
+- Non-self fragments are **never** voice-proxy eligible (the field is now a derived property — see [BUG-009](../../plans/git-issues/BUG-009-voice-proxy-eligible-flag-stale.md)).
+- Non-self fragments are **never** classified `intimate`; an `intimate` tier on a non-self fragment is downgraded to `personal`.
+
+### [`validator.py`](../creek/clean/validator.py) — `FragmentValidator`
+
+Checks required fields, UTF-8 encoding, ISO-8601 timestamps, and a configurable minimum content length. Invalid fragments are routed to the review queue rather than discarded — see `cleaning.validation`.
+
+Failure mode: a fragment with mojibake (e.g. CSV decoded as cp1252 by mistake — see [BUG-010](../../plans/git-issues/BUG-010-csv-cp1252-fallback-silent-mojibake.md)) lands in review, where you can re-ingest with the right encoding.
+
+### [`quality.py`](../creek/clean/quality.py) — `QualityScorer`
+
+Computes a 0.0 – 1.0 score from Shannon entropy, stop-word ratio, length, URL-only / emoji-only detection, and alphanumeric presence. Recommends `accept`, `review`, or `skip` (`cleaning.quality.skip_threshold` / `review_threshold`).
+
+Failure mode: legitimate short notes scored `skip`. Lower `min_chars` or `min_words`.
+
+### [`dedup.py`](../creek/clean/dedup.py) — `Deduplicator`
+
+Two-tier dedup:
+
+- **Exact** — same SHA-256 over `(source, timestamp, content)`. The deterministic ID (see `creek/ingest/base.py:generate_fragment_id`) means re-running ingestion is idempotent.
+- **Normalised** — match after lowercasing, whitespace strip, punctuation removal.
+
+Cross-run state lives at `<vault>/00-Creek-Meta/dedup-manifest.json`. Drop the file to force a fresh dedup pass.
+
+### [`semantic_dedup.py`](../creek/clean/semantic_dedup.py) — `SemanticDeduplicator`
+
+Cosine similarity over pre-computed embeddings. Two thresholds:
+
+- ≥ `duplicate_threshold` (default 0.95) → flagged as duplicate.
+- between `resonance_threshold` (default 0.75) and the duplicate threshold → flagged as a *resonance* (related but distinct).
+
+Runs only after embeddings exist (`creek link --method embeddings` populates them). Failure mode: false positives on boilerplate; raise `duplicate_threshold` and / or extend the per-source filter list.
+
+### [`hygiene.py`](../creek/clean/hygiene.py) — vault scanners
+
+Drives the `creek clean *` CLI commands:
+
+- `OrphanScanner` — fragments with zero links after `cleaning.hygiene.orphan_age_days`.
+- `StaleReviewScanner` — review-queue items older than `cleaning.hygiene.stale_review_days`.
+- `BrokenLinkScanner` — wiki-links pointing at nonexistent files.
+- `DuplicateScanner` — runs normalised + semantic dedup against the saved vault.
+- `HygieneReporter` — aggregate report of vault health.
+
+These run only via the CLI (`creek clean orphans`, …); they are **not** part of the inline ingestion pipeline.
+
+---
+
+## Disabling a step
+
+Most config sections have a `enabled: bool` (or per-rule `skip_*` toggles). To disable a step entirely, set the matching `enabled` flag to `false` and re-run ingestion. Where no `enabled` flag exists, the rules can be neutralised individually (`min_chars: 0`, empty `command_prefixes: []`, etc.). See `creek/config.py` for the authoritative shape.
+
+---
+
+## Common symptoms
+
+| Symptom | Likely culprit | Knob to turn |
+|---|---|---|
+| 30 % of fragments dropped silently | `QualityScorer` skip threshold too high | `cleaning.quality.skip_threshold` |
+| Real human turns missing from chatbot exports | `ChatbotFilter` over-aggressive | `cleaning.chatbot.min_human_turn_chars`, `skip_short_human` |
+| Discord short replies missing | `DiscordFilter` short-text rule | `cleaning.discord.min_chars`, `preserve_replies` |
+| Mojibake in CSV-derived fragments | `cp1252` fallback fired ([BUG-010](../../plans/git-issues/BUG-010-csv-cp1252-fallback-silent-mojibake.md)) | Re-ingest with explicit encoding; check the WARNING log line for the offending file |
+| Voice-proxy eligibility wrong | Stale `voice_proxy_eligible` field | Pull from a build that includes [BUG-009](../../plans/git-issues/BUG-009-voice-proxy-eligible-flag-stale.md) — the field is now a derived property |
+| Duplicate fragments accepted | Stale `dedup-manifest.json` from earlier run | Delete `<vault>/00-Creek-Meta/dedup-manifest.json` and re-ingest |
+
+---
+
+## See also
+
+- [`configuration.md`](configuration.md) — config schema for every `cleaning.*` knob.
+- [`cleaning-and-purge.md`](cleaning-and-purge.md) — CLI hygiene commands (post-hoc, not inline).
+- [`ingestion.md`](ingestion.md) — how ingestors plug into the cleaning pipeline.

--- a/creek-tools/docs/decisions.md
+++ b/creek-tools/docs/decisions.md
@@ -1,0 +1,125 @@
+# Decision support
+
+The decision-support layer (Ontology §12) detects decision-relevant fragments, drafts a Decision note in the vault, gathers cross-vault context, and enforces the **anti-manipulation guardrails** in §12.4 — the rules that keep this from becoming a recommender system.
+
+This page is the user-facing manual for what the implementation actually does. It complements [`generation.md`](generation.md), which lists the CLI route, and [Ontology §12](../../00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md), which is the spec.
+
+---
+
+## Lifecycle
+
+A Decision moves through the five statuses defined on `DecisionStatus`:
+
+```
+sensing → deliberating → committing → enacted → reflecting
+```
+
+| Status | Folder | Meaning |
+|---|---|---|
+| `sensing` | `08-Decisions/Active/` | Something feels like a decision is forming. Detector creates the draft here. |
+| `deliberating` | `08-Decisions/Active/` | Options listed; criteria being weighed. |
+| `committing` | `08-Decisions/Active/` | A direction has emerged; preparing to enact. |
+| `enacted` | `08-Decisions/Archive/` | Decision lived out. Note moved to Archive. |
+| `reflecting` | `08-Decisions/Archive/` | Looking back from a distance. Note stays in Archive. |
+
+Statuses are advanced by `DecisionDetector.update_decision_phase(decision_id, new_phase, vault_path)`. The function rewrites the frontmatter `status` field and moves the file between `Active/` and `Archive/` automatically. Invalid statuses raise `ValueError` — there is no silent fallback.
+
+The frontmatter follows `creek.models.Decision`: `id`, `title`, `status`, `opened`, `decided`, `frequency_context`, `wavelength_phase_at_opening`, `relevant_threads`, `relevant_praxis`, `options`, `criteria`, `outcome`, `tags`. The opening wavelength phase is captured at draft time and is **never** rewritten by later phase advances — the historical record matters more than tidying the frontmatter.
+
+---
+
+## Detection (DecisionDetector)
+
+`creek/generate/decisions.py:DecisionDetector` scans classified fragments using two strategies:
+
+1. **Keyword** — case-insensitive title match against `DECISION_KEYWORDS`:
+   `should i`, `trying to decide`, `weighing options`, `not sure whether`,
+   `torn between`, `considering`, `the question is`. Score base **0.7**.
+2. **Pattern** — `praxis_potential = explicit` AND `confidence = exploring`
+   AND the primary+secondary frequencies overlap a known pair
+   (`F1+F4` agency × structure, or `F1+F5` agency × achievement).
+   Score base **0.6**.
+
+A fragment matching both strategies produces a single candidate scored **0.9**.
+
+Each candidate captures `wavelength_phase_at_detection` and the active `frequency_context` so the eventual Decision note can preserve the felt-sense of when the question first surfaced.
+
+---
+
+## Drafting (`create_decision_note`)
+
+`DecisionDetector.create_decision_note(candidate, vault_path)` writes a draft to `08-Decisions/Active/<date>-<sanitised-title>.md` with:
+
+- `status: sensing`
+- `opened: <today, LA-tz>`
+- `wavelength_phase_at_opening` carried over from detection
+- a body skeleton with `## Source Fragments`, `## Options`, `## Criteria`
+- two `_Option 1_` / `_Option 2_` placeholders the user fills in
+
+The file is human-edited from there. Status advances are operator-driven, not automatic.
+
+---
+
+## Context gathering (`DecisionContextGatherer`)
+
+For an active Decision, `DecisionContextGatherer` aggregates **read-only** cross-vault context:
+
+- **Related threads** — Jaccard-similar threads, by title and tag tokens.
+- **Past decisions** — same-frequency or same-theme decisions in `Archive/`. Used as precedent, not advice.
+- **Current wavelength** — the most recent wavelength observation, if any.
+- **Relevant praxis** — praxis whose frequencies overlap the decision.
+- **Frequency affinity** — top frequencies active across the related set.
+- **Interventions** — `(frequency_color, phase_value)` lookups against the §12.5 Phase × Frequency map (e.g. `(orange, rising) → Pranayama`, `(green, diminishing) → Journaling`).
+
+The aggregator returns a `DecisionContext` dataclass; rendering happens through `render_context_text(...)`, which is then passed through `apply_guardrails(...)` before being written to disk. This is where §12.4 lives.
+
+---
+
+## §12.4 anti-manipulation guardrails
+
+`DecisionContextGatherer.apply_guardrails(text)` strips directive, urgency, and scarcity framings from any rendered context block. The patterns and replacements are defined in `_DIRECTIVE_REPLACEMENTS`:
+
+| Pattern (case-insensitive) | Replacement |
+|---|---|
+| `you should` | `one option is to` |
+| `you need to` | `one possibility is to` |
+| `you must` | `one possibility is to` |
+| `the best option` | `one option` |
+| `the right choice` | `one possibility` |
+| `it's clear that` | `one reading is that` |
+| `obviously` | `from one perspective` |
+| `act now` | `act when it feels right` |
+| `before it's too late` | `when the moment feels right` |
+| `last chance` | `a moment that is present` |
+| `this is permanent` | `some considerations include` |
+| `this is irreversible` | `some considerations include` |
+
+The contract is one-way: guardrails only **soften** language. A future PR that adds new directive patterns must extend `_DIRECTIVE_REPLACEMENTS` (and a regression test) so the guardrail keeps working as the model the system reads from changes.
+
+These guardrails are tested in `tests/test_decisions.py`; any change to `_DIRECTIVE_REPLACEMENTS` shows up there.
+
+---
+
+## Re-opening behaviour
+
+The lifecycle is conventionally one-directional: a decision in `enacted` or `reflecting` lives in `Archive/`. To re-open, advance the same `decision_id` back to `committing` (or earlier) — `update_decision_phase` will move the file from `Archive/` back into `Active/` and update the `status` frontmatter field. There is no re-open prevention guard; the file move is the audit trail.
+
+`opened` is preserved across phase changes; `decided` is set when the operator transitions to `enacted` (the model permits `None`, so a re-opened decision can leave `decided` empty until it commits again).
+
+---
+
+## CLI route
+
+```bash
+creek report --type decision --vault ~/Obsidian/Creek-Vault
+```
+
+Drives the detector across `01-Fragments/`, drafts notes for newly-detected candidates under `08-Decisions/Active/`, and refreshes the context block (with guardrails applied) on every Active decision. See [`generation.md`](generation.md#reports) for the shared `--type` table.
+
+---
+
+## See also
+
+- [`generation.md`](generation.md) — broader generation surface, including `report --type decision`.
+- [Ontology §12](../../00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md) — full spec.
+- `creek/models.py:Decision`, `DecisionStatus`, `DecisionCandidate` — frontmatter schema.

--- a/creek-tools/docs/emergence.md
+++ b/creek-tools/docs/emergence.md
@@ -1,0 +1,116 @@
+# Emergence infrastructure
+
+The Creek Ontology §10 carves out five emergence sub-systems — places where the vault is allowed to grow patterns the ontology itself does not predict. Each is implemented under `creek/generate/`, surfaced via `creek report --type <kind>`, and pinned by tests in `tests/`. This page documents the *exact* criteria that decide whether content is surfaced, so a missing pattern is recognisable as a bug rather than mistaken for intended behaviour.
+
+The audit below maps each §10 criterion to its code path and test, so a future change that drifts from the spec lights up red.
+
+| Spec | Module | Status |
+|---|---|---|
+| §10.1 Unnamed Digest | [`creek/generate/unnamed.py`](../creek/generate/unnamed.py) | ✅ implemented |
+| §10.2 Paradox Preservation | [`creek/generate/paradox.py`](../creek/generate/paradox.py) | ✅ implemented |
+| §10.3 Synchronicity Detection | [`creek/generate/synchronicity.py`](../creek/generate/synchronicity.py) | ✅ all four criteria pinned |
+| §10.4 Compost Tracking | [`creek/generate/compost.py`](../creek/generate/compost.py) | ✅ implemented |
+| §10.5 Emergent Tag Garden | [`creek/generate/tags.py`](../creek/generate/tags.py) | ✅ implemented |
+
+---
+
+## §10.1 — Unnamed Digest
+
+`UnnamedDigestGenerator` collects fragments under `10-Liminal/Unnamed/` (skipping the `Digests/` subfolder) within a seven-day window and writes a digest at `10-Liminal/Unnamed/Digests/<iso-year>-W<week>.md`.
+
+| Criterion | Implementation |
+|---|---|
+| **Weekly cadence** | Digest filename is `<iso-year>-W<week>`; runs are de-duplicated by week. |
+| **Embedding similarity within Unnamed** | Cosine similarity over sentence-transformer embeddings. Threshold defaults to **0.7** (deliberately loose so faint clusters surface). |
+| **Surface clusters** | Fragments are grouped by similarity; the digest renders one section per cluster with excerpts. |
+| **Reflection prompt** | A non-prescriptive prompt asks what the clustered fragments share that the current ontology cannot express. |
+
+CLI: `creek report --type unnamed --period weekly --vault <vault>`.
+
+History persists to `00-Creek-Meta/Processing-Log/unnamed-history.json` so each run reports growth deltas.
+
+---
+
+## §10.2 — Paradox Preservation
+
+`ParadoxDetector` finds contradictory stances *across* fragments from the same person without resolving them. A paradox is **always** kept and **never** flattened — it is a data point about polygnostic experience, not an error.
+
+Four detection rules; a fragment pair matching any one becomes a paradox:
+
+1. **Phase contradiction** — high semantic similarity between fragments sitting on opposite phases of the Archetypal Wavelength cycle.
+2. **Confidence contradiction** — fragments on a shared thread carrying opposite confidence levels (e.g. `musing` vs `settled`).
+3. **Dosage contradiction** — same primary frequency where one fragment marks it `medicine` and the other `toxic`.
+4. **Keyword contradiction** — explicit contradiction phrases (`but actually`, `I used to think`, `contrary to what I said`) paired with a topically-linked fragment.
+
+Output: a note in `10-Liminal/Paradoxes/` linking both fragments, a neutral description of the tension, and the `#paradox` tag plus relevant frequency tags. CLI: `creek report --type paradox`.
+
+---
+
+## §10.3 — Synchronicity Detection
+
+`SynchronicityDetector` filters resonance pairs already discovered by the linking pass and surfaces only those that meet **all four** §10.3 criteria. The strictness is deliberate — synchronicities are reflective prompts, not knowledge links.
+
+| Criterion (§10.3) | Pinned threshold |
+|---|---|
+| Semantic similarity strictly **>** 0.9 | `DEFAULT_SIMILARITY_THRESHOLD = 0.9` |
+| Source types are **different** | `fragment_a.source.platform != fragment_b.source.platform` |
+| Created **>** 30 days apart | `DEFAULT_MIN_TIME_GAP_DAYS = 30` |
+| Not obviously about the same project / task — filter out "still working on X" noise | `_STATUS_UPDATE_PHRASES = ("still working on", "progress on", "update on")`, plus shared proper-noun project-name detection |
+
+The pinned values live in [`creek/generate/synchronicity.py`](../creek/generate/synchronicity.py); the regression tests in [`tests/test_synchronicity.py`](../tests/test_synchronicity.py) cover each criterion. A regression PR that loosens any threshold without updating both tests and this doc fails the build.
+
+Output: `10-Liminal/Synchronicities/<id>.md` linking the pair, the cosine score, the time gap in days, and a reflection prompt. CLI: `creek report --type synchronicity`.
+
+---
+
+## §10.4 — Compost Tracking
+
+`CompostTracker` surfaces threads and projects that have died or been abandoned and writes a compost note that **preserves** rather than deletes. Triggers:
+
+- A `Thread.status` transitions to `resolved`.
+- Fragments reference abandoned projects (heuristic: fragments tagged `abandoned`, `let-go`, or referencing dormant threads).
+
+The compost note records:
+
+- **What the idea was** — title plus one-paragraph summary.
+- **Why it was abandoned** — extracted from referencing fragments when explicit; left as a prompt otherwise.
+- **What energy / insight it contained that may still be alive** — unresolved questions, active frequencies.
+- **Links to referencing fragments** — wiki-links so the compost stays reachable.
+
+Output: `10-Liminal/Compost/<id>.md`. CLI: `creek report --type compost`.
+
+---
+
+## §10.5 — Emergent Tag Garden
+
+`TagGardenGenerator` maintains `00-Creek-Meta/Tag-Garden.md` and a per-run history at `00-Creek-Meta/Processing-Log/tag-history.json`.
+
+| Criterion | Implementation |
+|---|---|
+| List all tags in use with counts | Vault scan computes `{tag: count}`. |
+| Highlight tags that are growing rapidly | History delta against last run; `new_tags` and `growing_tags` reported separately. |
+| Flag tag clusters that may indicate a new Thread or Eddy | Co-occurrence analysis surfaces clusters above a configurable threshold. |
+| Quarterly suggestion of consolidation / splits | The CLI accepts `--period quarterly`; tag-similarity (SequenceMatcher) suggests consolidations when two tags overlap > 0.85. |
+
+Output: `00-Creek-Meta/Tag-Garden.md`. CLI: `creek report --type tags --period quarterly`.
+
+---
+
+## Pinning the thresholds
+
+Every numeric threshold above is pinned by a regression test in `tests/`. Changes to:
+
+- `DEFAULT_SIMILARITY_THRESHOLD` (synchronicity)
+- `DEFAULT_MIN_TIME_GAP_DAYS` (synchronicity)
+- The Unnamed-Digest similarity floor (0.7)
+- The Tag-Garden growth detection deltas
+
+require the corresponding test and this doc to move together. If you find a §10 criterion you cannot locate in code, file a `BUG-*` under `plans/git-issues/` rather than letting the gap go un-tracked.
+
+---
+
+## See also
+
+- [`generation.md`](generation.md) — `creek report --type` table.
+- [Ontology §10](../../00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md) — full spec.
+- [`linking.md`](linking.md) — embedding linker that feeds the synchronicity and unnamed-digest detectors.

--- a/creek-tools/docs/generation.md
+++ b/creek-tools/docs/generation.md
@@ -15,7 +15,7 @@ The `generate` family of commands turns a classified, linked vault into the arte
 |------------------|--------------------------------------------|---------------|
 | `wavelength`     | `05-Wavelength/<period>-<date>.md`         | `creek.generate.wavelength` |
 | `synchronicity`  | `05-Wavelength/Synchronicities/`           | `creek.generate.synchronicity` |
-| `decision`       | `08-Decisions/<fragment>.md`               | `creek.generate.decisions` |
+| `decision`       | `08-Decisions/<fragment>.md`               | `creek.generate.decisions` — see [`decisions.md`](decisions.md) |
 | `paradox`        | `04-Praxis/Paradoxes/`                     | `creek.generate.paradox` |
 | `compost`        | `04-Praxis/Compost/`                       | `creek.generate.compost` |
 | `unnamed`        | `10-Liminal/Unnamed-Digest-<period>.md`    | `creek.generate.unnamed` |
@@ -34,6 +34,8 @@ creek report --type unnamed --period monthly --vault ~/Obsidian/Creek-Vault
 # Surprising cross-source resonances.
 creek report --type synchronicity --vault ~/Obsidian/Creek-Vault
 ```
+
+The `synchronicity`, `paradox`, `compost`, `unnamed`, and `tags` report types collectively make up the **emergence infrastructure** described in Ontology §10. The exact criteria that decide whether content is surfaced (similarity thresholds, time-gap floors, project-name filters) live in [`emergence.md`](emergence.md).
 
 ## Voice Skill Tree
 

--- a/creek-tools/docs/ingestion.md
+++ b/creek-tools/docs/ingestion.md
@@ -44,7 +44,7 @@ creek ingest --type code         --input ~/projects/diary     --vault ~/Obsidian
 - `.xlsx` files emit **one fragment per sheet**; `.csv` files are a single-sheet workbook named after the file stem.
 - Sheets larger than 100 rows render as a `head 10 + tail 5 + total count` summary so giant exports stay legible.
 - Cells with `|` or embedded newlines are escaped to `\|` and `<br>` so the rendered GFM table never breaks.
-- CSV decoding probes `utf-8-sig` first (handles BOM + plain UTF-8), then falls back to `cp1252` (handles legacy Excel exports). You will not get a `UnicodeDecodeError`.
+- CSV decoding probes `utf-8-sig` first (handles BOM + plain UTF-8), then runs a `chardet` confidence-gated detection step (≥ 0.70 confidence) so non-Western encodings (Shift-JIS, GBK, ISO-8859-5, …) are decoded with the right codec. If neither succeeds, it falls back to `cp1252` (handles legacy Excel exports) and emits a `WARNING` log naming the file so the user can spot mojibake before it lands in the vault. You will not get a `UnicodeDecodeError`.
 - Header detection is currently a heuristic: the first row is treated as headers when every cell is a non-empty string. A `has_header` override is tracked in [#165](https://github.com/Geoffe-Ga/Creek-Vault/issues/165).
 
 ## Presentation (`presentation`)

--- a/creek-tools/docs/ingestion.md
+++ b/creek-tools/docs/ingestion.md
@@ -11,16 +11,17 @@ Every ingestor is registered in `creek.ingest.INGESTOR_REGISTRY`. The table maps
 | `claude`        | Claude conversation export ZIP / JSON.                                | none                          |
 | `chatgpt`       | ChatGPT conversation export ZIP.                                      | none                          |
 | `discord`       | Discord channel exports (DiscordChatExporter HTML or JSON).           | none                          |
-| `gdrive`        | Files mirrored by `creek gdrive --download` into the staging dir.     | (see [Google Drive](#google-drive)) |
 | `code`          | A directory tree of source files (`.py`, `.ts`, `.go`, `.md`, …).     | none                          |
-| `documents`     | `.docx` and `.pdf` documents.                                         | `python-docx`, `pdfminer.six` |
+| `document`      | `.docx` and `.pdf` documents.                                         | `python-docx`, `pdfminer.six` |
 | `markdown`      | Loose `.md` files.                                                    | none                          |
 | `spreadsheet`   | `.xlsx` (one fragment per sheet) and `.csv` (one fragment per file).  | `openpyxl` (XLSX only)        |
 | `presentation`  | `.pptx` (one fragment per deck; slides become sections).              | `python-pptx`                 |
-| `images`        | `.png` / `.jpg` / `.tiff` / `.pdf-page-as-image` via OCR.             | `pytesseract`, `pdf2image`, system `tesseract`, `poppler` |
+| `image`         | `.png` / `.jpg` / `.tiff` / `.pdf-page-as-image` via OCR.             | `pytesseract`, `pdf2image`, system `tesseract`, `poppler` |
 | `generic`       | Plain-text fallback for unknown extensions.                           | none                          |
 
 If `--type` is omitted, `creek process` picks ingestors by file extension.
+
+`gdrive` is **not** a `--type` (ARCH-001) — it is a downloader. Run `creek gdrive --download --staging <dir>` to mirror Drive files locally, then run `creek ingest --type document --input <dir>` (or `--type spreadsheet`, etc.) against the staged directory. See [Google Drive](#google-drive) below.
 
 ## Common patterns
 
@@ -66,9 +67,12 @@ creek ingest --type code         --input ~/projects/diary     --vault ~/Obsidian
 # First run opens a browser for OAuth; subsequent runs are non-interactive.
 creek gdrive --download --staging ~/staging/gdrive
 
-# The staging tree mirrors the Drive folder hierarchy.
-# Pipe it through ingest like any other directory.
-creek ingest --type gdrive --input ~/staging/gdrive --vault ~/Obsidian/Creek-Vault
+# The staging tree mirrors the Drive folder hierarchy. Run the
+# matching ingestor for each file family (ARCH-001 — there is no
+# ``--type gdrive``; passing it now prints a redirect message).
+creek ingest --type document    --input ~/staging/gdrive --vault ~/Obsidian/Creek-Vault
+creek ingest --type spreadsheet --input ~/staging/gdrive --vault ~/Obsidian/Creek-Vault
+creek ingest --type markdown    --input ~/staging/gdrive --vault ~/Obsidian/Creek-Vault
 ```
 
 Subsequent `--download` runs are **incremental** — unchanged files are skipped, deletions are mirrored as soft deletes (the staging file is removed; the vault fragment isn't, so you can choose whether to `creek purge source` it).

--- a/creek-tools/docs/linking.md
+++ b/creek-tools/docs/linking.md
@@ -68,6 +68,8 @@ linking:
 
 `creek.generate.synchronicity.SynchronicityDetector` (run via `creek report --type synchronicity`) flags resonance edges that are **surprising** — fragments from very different sources or registers that the embeddings consider similar. These are the most interesting findings in practice; they often surface unconscious connections between, say, a therapy reflection and a software design note. Output lands in `05-Wavelength/Synchronicities/`.
 
+The exact criteria for "surprising" — cosine similarity > 0.9, different source types, > 30 days apart, and "still working on X"-style status updates filtered out — live in [`emergence.md`](emergence.md) alongside the other §10 emergence sub-systems.
+
 ## Reading the graph
 
 Every linker writes both directions of every edge. The fragment frontmatter shows local neighbours; the thread / eddy notes show connected components; and `creek report --type linking` prints aggregate statistics:

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -61,6 +61,44 @@ def test_run_classify_rules_updates_fragments(tmp_path: Path) -> None:
     assert reloaded["classification_method"] == "rules"
 
 
+def test_classified_at_is_la_tz_aware(tmp_path: Path) -> None:
+    """The ``classified_at`` frontmatter timestamp is LA-tz-aware (BUG-002).
+
+    A naive implementation would call ``datetime.now()`` and silently
+    record host-tz timestamps that fail to compare against the LA-tz
+    timestamps elsewhere in the pipeline. Pin the contract.
+    """
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-classifiedat",
+        title="Power and dominance",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="Power dominance control conquest force aggression bold rage warrior",
+    )
+
+    run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    reloaded = frontmatter.load(str(file))
+    classified_at = reloaded["classified_at"]
+    assert isinstance(classified_at, str)
+    parsed = datetime.fromisoformat(classified_at)
+    assert parsed.tzinfo is not None
+    la_offset = ZoneInfo("America/Los_Angeles").utcoffset(parsed)
+    assert parsed.utcoffset() == la_offset
+
+
 def test_run_classify_preserves_manual_without_force(tmp_path: Path) -> None:
     """Manual decisions survive a ``--method rules`` pass."""
     vault = tmp_path / "vault"

--- a/creek-tools/tests/test_classify_engine_resume.py
+++ b/creek-tools/tests/test_classify_engine_resume.py
@@ -1,0 +1,172 @@
+"""Regression tests for the OPS-001 LLM checkpoint/resume contract.
+
+After a partial ``creek classify --method llm`` run, re-running the
+command must not re-classify fragments that already carry
+``classification_method: llm``. The progress checkpoint at
+``<vault>/00-Creek-Meta/Processing-Log/llm-progress.json`` must capture
+each newly-classified fragment ID so an operator can audit the run.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import frontmatter
+
+from creek.classify.classify_engine import LLM_PROGRESS_FILENAME, run_classify
+from creek.config import CreekConfig
+from creek.models import Fragment, FragmentSource, SourcePlatform
+from tests.helpers import write_fragment_file as _write_fragment
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _llm_low_confidence_config() -> CreekConfig:
+    """Force the engine to invoke the LLM rather than short-circuiting on rules."""
+    config = CreekConfig()
+    # Threshold above any plausible rule confidence so the LLM is always
+    # invoked — keeps the test deterministic.
+    config.classification.confidence_threshold = 1.0
+    return config
+
+
+def _seed_unclassified_fragment(
+    *,
+    vault: Path,
+    frag_id: str,
+    title: str,
+) -> Path:
+    """Write a fragment with no rule signal, so the LLM path is exercised."""
+    fragment = Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    return _write_fragment(vault=vault, fragment=fragment, body="ambiguous body")
+
+
+def test_already_llm_classified_fragment_is_skipped(tmp_path: Path) -> None:
+    """A fragment with ``classification_method: llm`` is left alone (OPS-001).
+
+    This is what makes a re-run after a crash a resume rather than a
+    full restart — and what saves the operator from re-paying for
+    Anthropic tokens already spent.
+    """
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-already1234",
+        title="already done",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="ambiguous body",
+        method="llm",
+    )
+
+    with patch("creek.classify.classify_engine.LLMClassifier.classify") as mock_llm:
+        summary = run_classify(
+            vault_path=vault,
+            config=_llm_low_confidence_config(),
+            method="llm",
+            force=False,
+        )
+
+    mock_llm.assert_not_called()
+    assert summary.preserved_manual == 1
+    assert summary.classified == 0
+    reloaded = frontmatter.load(str(file))
+    assert reloaded["classification_method"] == "llm"
+
+
+def test_force_overrides_resume_skip(tmp_path: Path) -> None:
+    """``--force`` re-classifies even fragments already marked ``llm``."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-force00000a",
+        title="force me",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="ambiguous body",
+        method="llm",
+    )
+
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify",
+        side_effect=lambda frag, content="": frag,
+    ) as mock_llm:
+        run_classify(
+            vault_path=vault,
+            config=_llm_low_confidence_config(),
+            method="llm",
+            force=True,
+        )
+
+    mock_llm.assert_called_once()
+
+
+def test_progress_file_records_classified_fragment_ids(tmp_path: Path) -> None:
+    """Each LLM-classified fragment ID is appended to the progress file."""
+    vault = tmp_path / "vault"
+    _seed_unclassified_fragment(
+        vault=vault,
+        frag_id="frag-progress001",
+        title="first",
+    )
+    _seed_unclassified_fragment(
+        vault=vault,
+        frag_id="frag-progress002",
+        title="second",
+    )
+
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify",
+        side_effect=lambda frag, content="": frag,
+    ):
+        run_classify(
+            vault_path=vault,
+            config=_llm_low_confidence_config(),
+            method="llm",
+            force=False,
+        )
+
+    progress_file = vault / "00-Creek-Meta" / "Processing-Log" / LLM_PROGRESS_FILENAME
+    assert progress_file.exists()
+    recorded_ids = [
+        json.loads(line)["id"]
+        for line in progress_file.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    assert set(recorded_ids) == {"frag-progress001", "frag-progress002"}
+
+
+def test_progress_file_not_created_for_rules_method(tmp_path: Path) -> None:
+    """``--method rules`` does not touch the LLM-progress checkpoint."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-rulesonly00",
+        title="Power and dominance",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="Power dominance control conquest force aggression bold rage warrior",
+    )
+
+    run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    progress_file = vault / "00-Creek-Meta" / "Processing-Log" / LLM_PROGRESS_FILENAME
+    assert not progress_file.exists()

--- a/creek-tools/tests/test_classify_engine_resume.py
+++ b/creek-tools/tests/test_classify_engine_resume.py
@@ -3,8 +3,9 @@
 After a partial ``creek classify --method llm`` run, re-running the
 command must not re-classify fragments that already carry
 ``classification_method: llm``. The progress checkpoint at
-``<vault>/00-Creek-Meta/Processing-Log/llm-progress.json`` must capture
-each newly-classified fragment ID so an operator can audit the run.
+``<vault>/00-Creek-Meta/Processing-Log/llm-progress.jsonl`` must
+capture each newly-classified fragment ID so an operator can audit the
+run.
 """
 
 from __future__ import annotations

--- a/creek-tools/tests/test_classify_engine_resume.py
+++ b/creek-tools/tests/test_classify_engine_resume.py
@@ -147,6 +147,71 @@ def test_progress_file_records_classified_fragment_ids(tmp_path: Path) -> None:
     assert set(recorded_ids) == {"frag-progress001", "frag-progress002"}
 
 
+def test_progress_file_appends_across_runs(tmp_path: Path) -> None:
+    """A second resume run appends to the existing progress file (OPS-001).
+
+    The recovery guarantee depends on the progress file growing —
+    truncating on every invocation would erase the audit trail of
+    fragments classified before a crash. This test seeds two
+    fragments, lets the first run classify only one of them, then
+    seeds a third, runs again, and confirms all three IDs are present
+    in the appended file.
+    """
+    vault = tmp_path / "vault"
+    _seed_unclassified_fragment(
+        vault=vault,
+        frag_id="frag-append0001",
+        title="first",
+    )
+
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify",
+        side_effect=lambda frag, content="": frag,
+    ):
+        run_classify(
+            vault_path=vault,
+            config=_llm_low_confidence_config(),
+            method="llm",
+            force=False,
+        )
+
+    # Add two more unclassified fragments and resume.
+    _seed_unclassified_fragment(
+        vault=vault,
+        frag_id="frag-append0002",
+        title="second",
+    )
+    _seed_unclassified_fragment(
+        vault=vault,
+        frag_id="frag-append0003",
+        title="third",
+    )
+
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify",
+        side_effect=lambda frag, content="": frag,
+    ):
+        run_classify(
+            vault_path=vault,
+            config=_llm_low_confidence_config(),
+            method="llm",
+            force=False,
+        )
+
+    progress_file = vault / "00-Creek-Meta" / "Processing-Log" / LLM_PROGRESS_FILENAME
+    recorded_ids = [
+        json.loads(line)["id"]
+        for line in progress_file.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    # The first ID survives the second run (file appended, not truncated).
+    assert set(recorded_ids) == {
+        "frag-append0001",
+        "frag-append0002",
+        "frag-append0003",
+    }
+
+
 def test_progress_file_not_created_for_rules_method(tmp_path: Path) -> None:
     """``--method rules`` does not touch the LLM-progress checkpoint."""
     vault = tmp_path / "vault"

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -92,6 +92,39 @@ def test_ingest_command_rejects_unknown_type(tmp_path: Path) -> None:
     assert "Unknown ingestor type" in result.output
 
 
+def test_ingest_command_gdrive_type_redirects_to_two_stage_flow(
+    tmp_path: Path,
+) -> None:
+    """``--type gdrive`` prints the two-stage flow rather than the generic error.
+
+    ARCH-001: ``gdrive`` is a downloader, not an ingestor. The CLI
+    must direct the operator to ``creek gdrive --download`` followed
+    by the appropriate ``--type document`` / ``--type spreadsheet``
+    rather than failing with the bland "Unknown ingestor type" message.
+    """
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+    (vault / "01-Fragments").mkdir(parents=True)
+    src = tmp_path / "in"
+    src.mkdir()
+    result = runner.invoke(
+        app,
+        [
+            "ingest",
+            "--type",
+            "gdrive",
+            "--input",
+            str(src),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "gdrive is a downloader" in result.output
+    assert "creek gdrive --download" in result.output
+
+
 def test_ingest_command_writes_fragments(tmp_path: Path) -> None:
     """The ingest command resolves the registry and writes fragments."""
     vault = tmp_path / "vault"

--- a/creek-tools/tests/test_config_init_warning.py
+++ b/creek-tools/tests/test_config_init_warning.py
@@ -1,0 +1,104 @@
+"""Regression tests for ARCH-002: missing-config warning + ``creek init``.
+
+A vault with no ``creek_config.yaml`` previously silently picked up the
+built-in defaults. ARCH-002 requires:
+
+* :func:`creek.config.load_config` emits a ``WARNING`` when the file
+  is missing (suppressable via ``warn_on_missing=False``).
+* ``creek init --vault <vault>`` writes a starter config, refusing to
+  overwrite an existing file unless ``--force`` is passed.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import yaml
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.config import load_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+runner = CliRunner()
+
+
+def test_load_config_warns_on_missing_file(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A missing config logs a WARNING with the resolved path (ARCH-002)."""
+    missing = tmp_path / "creek_config.yaml"
+
+    with caplog.at_level(logging.WARNING, logger="creek.config"):
+        config = load_config(missing)
+
+    assert config is not None  # falls back to defaults
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("not found" in r.message for r in warnings)
+    assert any(str(missing) in r.message for r in warnings)
+
+
+def test_load_config_silenced_when_warn_on_missing_false(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """``warn_on_missing=False`` suppresses the WARNING (used by ``creek init``)."""
+    missing = tmp_path / "creek_config.yaml"
+
+    with caplog.at_level(logging.WARNING, logger="creek.config"):
+        load_config(missing, warn_on_missing=False)
+
+    assert not any(
+        r.levelno == logging.WARNING and "not found" in r.message
+        for r in caplog.records
+    )
+
+
+def test_creek_init_writes_starter_config(tmp_path: Path) -> None:
+    """``creek init --vault <vault>`` materialises a starter config."""
+    vault = tmp_path / "vault"
+    result = runner.invoke(app, ["init", "--vault", str(vault)])
+
+    assert result.exit_code == 0
+    config_path = vault / "00-Creek-Meta" / "creek_config.yaml"
+    assert config_path.exists()
+    # The starter is valid YAML with the expected top-level keys.
+    data = yaml.safe_load(config_path.read_text())
+    assert "classification" in data
+    assert "redaction" in data
+
+
+def test_creek_init_refuses_to_overwrite_without_force(tmp_path: Path) -> None:
+    """A pre-existing config is preserved unless ``--force`` is passed."""
+    vault = tmp_path / "vault"
+    config_dir = vault / "00-Creek-Meta"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "creek_config.yaml"
+    config_path.write_text("# operator-edited\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["init", "--vault", str(vault)])
+
+    assert result.exit_code == 1
+    assert config_path.read_text() == "# operator-edited\n"
+
+
+def test_creek_init_force_overwrites_existing(tmp_path: Path) -> None:
+    """``--force`` rewrites the config from scratch."""
+    vault = tmp_path / "vault"
+    config_dir = vault / "00-Creek-Meta"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "creek_config.yaml"
+    config_path.write_text("# old\n", encoding="utf-8")
+
+    result = runner.invoke(app, ["init", "--vault", str(vault), "--force"])
+
+    assert result.exit_code == 0
+    rewritten = config_path.read_text()
+    assert rewritten != "# old\n"
+    assert "classification" in yaml.safe_load(rewritten)

--- a/creek-tools/tests/test_generate_privacy_filter.py
+++ b/creek-tools/tests/test_generate_privacy_filter.py
@@ -66,7 +66,7 @@ def test_mining_load_excludes_intimate_by_default(tmp_path: Path) -> None:
         fragments_dir, "frag-i", title="Diary", privacy_tier="intimate", body="x"
     )
     _write_fragment(
-        fragments_dir, "frag-o", title="Essay", privacy_tier="public", body="y"
+        fragments_dir, "frag-o", title="Essay", privacy_tier="open", body="y"
     )
 
     pairs = _load_fragments(fragments_dir)
@@ -122,7 +122,7 @@ def test_drafts_load_excludes_intimate_by_default(tmp_path: Path) -> None:
         fragments_dir, "frag-i", title="Diary", privacy_tier="intimate", body="x"
     )
     _write_fragment(
-        fragments_dir, "frag-o", title="Essay", privacy_tier="public", body="y"
+        fragments_dir, "frag-o", title="Essay", privacy_tier="open", body="y"
     )
 
     loaded = _load_fragments_by_id(fragments_dir)

--- a/creek-tools/tests/test_ingest_registry.py
+++ b/creek-tools/tests/test_ingest_registry.py
@@ -1,0 +1,42 @@
+"""Pin tests for the ``INGESTOR_REGISTRY`` size and identity (INC-012).
+
+The README claims a specific count of registered ingestors. This file
+pins both the count and the names so that adding or removing an
+ingestor lights up red until the README paragraph is updated alongside
+the registry.
+"""
+
+from __future__ import annotations
+
+from creek.ingest import INGESTOR_REGISTRY
+
+_EXPECTED_INGESTOR_NAMES: frozenset[str] = frozenset(
+    {
+        "chatgpt",
+        "claude",
+        "code",
+        "discord",
+        "document",
+        "generic",
+        "image",
+        "markdown",
+        "presentation",
+        "spreadsheet",
+    },
+)
+
+
+def test_ingestor_registry_size_matches_readme() -> None:
+    """Pin the registry size to the README's "10 source ingestors" claim."""
+    # Update both this assertion and the README paragraph in
+    # ``creek-tools/README.md`` ("Source platforms") together.
+    assert len(INGESTOR_REGISTRY) == 10
+
+
+def test_ingestor_registry_names_match_readme() -> None:
+    """Pin the exact set of registered ingestor names.
+
+    `gdrive` is intentionally absent (it is a downloader, not an
+    ``Ingestor``) and `other` has no parser.
+    """
+    assert set(INGESTOR_REGISTRY.keys()) == _EXPECTED_INGESTOR_NAMES

--- a/creek-tools/tests/test_privacy.py
+++ b/creek-tools/tests/test_privacy.py
@@ -57,7 +57,7 @@ class TestClassifyTier:
         """Essays are published outputs and get the PUBLIC tier."""
         classifier = PrivacyClassifier()
         frag = _make_fragment(platform=SourcePlatform.ESSAY)
-        assert classifier.classify_tier(frag) == PrivacyTier.PUBLIC
+        assert classifier.classify_tier(frag) == PrivacyTier.OPEN
 
     def test_journal_source_is_intimate(self) -> None:
         """Journal entries are always treated as INTIMATE."""
@@ -91,13 +91,13 @@ class TestClassifyTier:
         """Discord channels in named guild rooms are treated as PUBLIC."""
         classifier = PrivacyClassifier()
         frag = _make_fragment(platform=SourcePlatform.DISCORD, channel="general")
-        assert classifier.classify_tier(frag) == PrivacyTier.PUBLIC
+        assert classifier.classify_tier(frag) == PrivacyTier.OPEN
 
     def test_discord_admin_channel_is_not_falsely_personal(self) -> None:
         """``admin`` contains the ``dm`` substring but is not a DM token."""
         classifier = PrivacyClassifier()
         frag = _make_fragment(platform=SourcePlatform.DISCORD, channel="admin")
-        assert classifier.classify_tier(frag) == PrivacyTier.PUBLIC
+        assert classifier.classify_tier(frag) == PrivacyTier.OPEN
 
     def test_discord_without_channel_is_personal(self) -> None:
         """Discord without channel metadata defaults to PERSONAL (safer)."""
@@ -277,9 +277,9 @@ class TestEnforceTier:
         """PUBLIC content remains voice-proxy eligible."""
         classifier = PrivacyClassifier()
         frag = _make_fragment()
-        result = classifier.enforce_tier(frag, PrivacyTier.PUBLIC)
+        result = classifier.enforce_tier(frag, PrivacyTier.OPEN)
         assert result.voice_proxy_eligible is True
-        assert result.privacy_tier == PrivacyTier.PUBLIC
+        assert result.privacy_tier == PrivacyTier.OPEN
 
     def test_personal_keeps_voice_proxy_enabled(self) -> None:
         """PERSONAL content remains voice-proxy eligible."""
@@ -320,8 +320,8 @@ class TestEnforceTier:
         classifier = PrivacyClassifier()
         frag = _make_fragment()
         intimate = classifier.enforce_tier(frag, PrivacyTier.INTIMATE)
-        promoted = classifier.enforce_tier(intimate, PrivacyTier.PUBLIC)
-        assert promoted.privacy_tier == PrivacyTier.PUBLIC
+        promoted = classifier.enforce_tier(intimate, PrivacyTier.OPEN)
+        assert promoted.privacy_tier == PrivacyTier.OPEN
         assert promoted.voice_proxy_eligible is True
 
 
@@ -344,7 +344,7 @@ class TestClassifyAndEnforce:
         classifier = PrivacyClassifier()
         frag = _make_fragment(platform=SourcePlatform.ESSAY)
         result = classifier.classify_and_enforce(frag)
-        assert result.privacy_tier == PrivacyTier.PUBLIC
+        assert result.privacy_tier == PrivacyTier.OPEN
         assert result.voice_proxy_eligible is True
 
     def test_recovery_content_via_one_shot_method(self) -> None:
@@ -398,7 +398,7 @@ class TestReviewQueueIntegration:
             source=FragmentSource(platform=SourcePlatform.ESSAY),
             frequency=FrequencyClassification(primary=Frequency.F3),
             voice=VoiceClassification(confidence=Confidence.SETTLED),
-            privacy_tier=PrivacyTier.PUBLIC,
+            privacy_tier=PrivacyTier.OPEN,
         )
         assert generator.needs_review(frag) is False
 

--- a/creek-tools/tests/test_privacy_filter.py
+++ b/creek-tools/tests/test_privacy_filter.py
@@ -59,7 +59,7 @@ def test_default_excludes_intimate_summarises_personal() -> None:
     inputs = [
         _frag(id_="frag-i", tier=PrivacyTier.INTIMATE, body="secret stuff"),
         _frag(id_="frag-p", tier=PrivacyTier.PERSONAL, body="personal stuff"),
-        _frag(id_="frag-o", tier=PrivacyTier.PUBLIC, body="open stuff"),
+        _frag(id_="frag-o", tier=PrivacyTier.OPEN, body="open stuff"),
     ]
 
     out = list(filter_fragments_by_tier(inputs))
@@ -99,7 +99,7 @@ def test_intimate_or_all_lets_everything_through(
     inputs = [
         _frag(id_="frag-i", tier=PrivacyTier.INTIMATE, body="secret"),
         _frag(id_="frag-p", tier=PrivacyTier.PERSONAL, body="personal"),
-        _frag(id_="frag-o", tier=PrivacyTier.PUBLIC, body="open"),
+        _frag(id_="frag-o", tier=PrivacyTier.OPEN, body="open"),
     ]
 
     out = list(filter_fragments_by_tier(inputs, override=override))
@@ -178,7 +178,7 @@ def test_open_override_matches_default_behaviour() -> None:
     inputs = [
         _frag(id_="frag-i", tier=PrivacyTier.INTIMATE, body="x"),
         _frag(id_="frag-p", tier=PrivacyTier.PERSONAL, body="full"),
-        _frag(id_="frag-o", tier=PrivacyTier.PUBLIC, body="open"),
+        _frag(id_="frag-o", tier=PrivacyTier.OPEN, body="open"),
     ]
 
     default_out = list(filter_fragments_by_tier(inputs))

--- a/creek-tools/tests/test_privacy_tier_alias.py
+++ b/creek-tools/tests/test_privacy_tier_alias.py
@@ -1,0 +1,59 @@
+"""Regression tests for the INC-003 ``PrivacyTier`` rename.
+
+``PrivacyTier.PUBLIC`` was renamed to ``PrivacyTier.OPEN`` (value
+``"public"`` → ``"open"``) per ontology §13.2. Old vaults serialised
+the tier as ``"public"``; the rename ships a ``_missing_`` hook that
+maps the legacy string to :attr:`PrivacyTier.OPEN` while emitting a
+:class:`DeprecationWarning` so operators know to migrate.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from creek.models import PrivacyTier
+
+
+def test_open_is_canonical() -> None:
+    """``PrivacyTier.OPEN`` is the canonical name + value (openly publishable)."""
+    assert PrivacyTier.OPEN.value == "open"
+    assert PrivacyTier("open") is PrivacyTier.OPEN
+
+
+def test_public_alias_returns_open_with_deprecation_warning() -> None:
+    """``PrivacyTier("public")`` resolves to OPEN and emits a deprecation warning."""
+    with pytest.warns(DeprecationWarning, match="'public' is deprecated"):
+        result = PrivacyTier("public")
+    assert result is PrivacyTier.OPEN
+
+
+def test_public_alias_does_not_create_new_enum_value() -> None:
+    """The legacy string maps to the existing :attr:`OPEN` member, not a new one."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        result = PrivacyTier("public")
+    assert result is PrivacyTier.OPEN
+    # PrivacyTier members are exactly: OPEN, PERSONAL, INTIMATE, UNCLASSIFIED.
+    assert {m.name for m in PrivacyTier} == {
+        "OPEN",
+        "PERSONAL",
+        "INTIMATE",
+        "UNCLASSIFIED",
+    }
+
+
+def test_unknown_tier_still_raises() -> None:
+    """Unknown tier values still raise ``ValueError`` — only ``"public"`` is aliased."""
+    with pytest.raises(ValueError, match="not a valid PrivacyTier"):
+        PrivacyTier("definitely-not-a-tier")
+
+
+def test_other_existing_values_unchanged() -> None:
+    """``PERSONAL``, ``INTIMATE``, and ``UNCLASSIFIED`` round-trip without warnings."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert PrivacyTier("personal") is PrivacyTier.PERSONAL
+        assert PrivacyTier("intimate") is PrivacyTier.INTIMATE
+        assert PrivacyTier("unclassified") is PrivacyTier.UNCLASSIFIED

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -331,6 +331,139 @@ def test_source_count_matches(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Engine tests — purge_source_path with match modes (INC-008)
+# ---------------------------------------------------------------------------
+
+
+def _write_fragment_with_original(
+    vault: Path,
+    frag_id: str,
+    title: str,
+    *,
+    original_file: str,
+) -> Path:
+    """Write a fragment with an explicit ``source.original_file`` path."""
+    target = vault / "01-Fragments" / "Conversations" / f"{title}.md"
+    metadata: dict[str, object] = {
+        "id": frag_id,
+        "title": title,
+        "type": "fragment",
+        "source": {"platform": "claude", "original_file": original_file},
+        "threads": [],
+        "eddies": [],
+        "frequency": {"primary": "F3", "secondary": []},
+        "wavelength": {
+            "phase": "rising",
+            "mode": "inhabit",
+            "orientation": "do",
+            "dosage": "medicine",
+            "color": "orange",
+            "descriptor": "bright",
+        },
+        "voice": {"voice_register": "analytical", "confidence": "settled"},
+    }
+    target.write_text(frontmatter.dumps(frontmatter.Post(content="x", **metadata)))
+    return target
+
+
+def test_purge_source_path_exact_match(tmp_path: Path) -> None:
+    """``--match exact`` deletes only the fragment with the exact path (INC-008)."""
+    vault = _make_vault(tmp_path)
+    _write_fragment_with_original(
+        vault, "frag-A", "Alpha", original_file="/exports/claude/2026-04-28.json"
+    )
+    _write_fragment_with_original(
+        vault, "frag-B", "Bravo", original_file="/exports/claude/2026-04-29.json"
+    )
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source_path("/exports/claude/2026-04-28.json", match="exact")
+
+    assert result.fragments_affected == 1
+    remaining = list((vault / "01-Fragments").rglob("*.md"))
+    assert len(remaining) == 1
+    assert remaining[0].name == "Bravo.md"
+
+
+def test_purge_source_path_substring_match(tmp_path: Path) -> None:
+    """``--match substring`` deletes every fragment whose path contains the term."""
+    vault = _make_vault(tmp_path)
+    _write_fragment_with_original(
+        vault, "frag-A", "Alpha", original_file="/exports/2026-04-28.json"
+    )
+    _write_fragment_with_original(
+        vault, "frag-B", "Bravo", original_file="/exports/2026-04-29.json"
+    )
+    _write_fragment_with_original(
+        vault, "frag-C", "Charlie", original_file="/notes/diary.md"
+    )
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source_path("/exports/", match="substring")
+
+    assert result.fragments_affected == 2
+    remaining = list((vault / "01-Fragments").rglob("*.md"))
+    assert len(remaining) == 1
+    assert remaining[0].name == "Charlie.md"
+
+
+def test_purge_source_path_regex_match(tmp_path: Path) -> None:
+    """``--match regex`` accepts a regex pattern and deletes matching fragments."""
+    vault = _make_vault(tmp_path)
+    _write_fragment_with_original(
+        vault, "frag-A", "Alpha", original_file="/exports/2026-04-28.json"
+    )
+    _write_fragment_with_original(
+        vault, "frag-B", "Bravo", original_file="/exports/2026-04-29.json"
+    )
+    _write_fragment_with_original(
+        vault, "frag-C", "Charlie", original_file="/notes/diary.md"
+    )
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source_path(r"2026-04-2[89]\.json$", match="regex")
+
+    assert result.fragments_affected == 2
+    remaining = list((vault / "01-Fragments").rglob("*.md"))
+    assert len(remaining) == 1
+    assert remaining[0].name == "Charlie.md"
+
+
+def test_purge_source_path_invalid_regex_raises(tmp_path: Path) -> None:
+    """A bad regex fails fast with ``ValueError`` rather than silently mismatching."""
+    vault = _make_vault(tmp_path)
+    engine = PurgeEngine(vault)
+
+    with pytest.raises(ValueError, match="Invalid regex"):
+        engine.purge_source_path("[unclosed", match="regex")
+
+
+def test_purge_source_path_unknown_match_mode_raises(tmp_path: Path) -> None:
+    """Unknown match modes are rejected up-front."""
+    vault = _make_vault(tmp_path)
+    engine = PurgeEngine(vault)
+
+    with pytest.raises(ValueError, match="Unknown match mode"):
+        engine.purge_source_path("/anywhere", match="fuzzy")
+
+
+def test_purge_source_path_audit_records_match_mode(tmp_path: Path) -> None:
+    """The audit entry captures both ``source_path`` and ``match`` (INC-008)."""
+    vault = _make_vault(tmp_path)
+    _write_fragment_with_original(
+        vault, "frag-A", "Alpha", original_file="/exports/2026-04-28.json"
+    )
+    engine = PurgeEngine(vault)
+
+    engine.purge_source_path("/exports/", match="substring")
+
+    audit_entries = PurgeAuditLog(vault).read()
+    assert audit_entries[-1].operation == "source-path"
+    assert audit_entries[-1].criteria["source_path"] == "/exports/"
+    assert audit_entries[-1].criteria["match"] == "substring"
+
+
+# ---------------------------------------------------------------------------
 # Engine tests — purge_classifications
 # ---------------------------------------------------------------------------
 

--- a/creek-tools/tests/test_skills.py
+++ b/creek-tools/tests/test_skills.py
@@ -100,7 +100,15 @@ def _build_fragment(
     privacy: PrivacyTier = PrivacyTier.PERSONAL,
     proxy_eligible: bool = True,
 ) -> Fragment:
-    """Create a Fragment with the specified classification."""
+    """Create a Fragment with the specified classification.
+
+    ``proxy_eligible=False`` is honoured by routing through the
+    privacy-tier signal: voice-proxy ineligibility is now a derived
+    property (BUG-009) of ``privacy_tier`` and ``source.author``, so
+    forcing ineligibility is equivalent to escalating to ``INTIMATE``.
+    """
+    if not proxy_eligible:
+        privacy = PrivacyTier.INTIMATE
     return Fragment(
         id=frag_id,
         title=title,
@@ -115,7 +123,6 @@ def _build_fragment(
         ),
         voice=VoiceClassification(voice_register=register, confidence=confidence),
         privacy_tier=privacy,
-        voice_proxy_eligible=proxy_eligible,
     )
 
 

--- a/creek-tools/tests/test_skills.py
+++ b/creek-tools/tests/test_skills.py
@@ -106,8 +106,21 @@ def _build_fragment(
     privacy-tier signal: voice-proxy ineligibility is now a derived
     property (BUG-009) of ``privacy_tier`` and ``source.author``, so
     forcing ineligibility is equivalent to escalating to ``INTIMATE``.
+
+    Mixing ``proxy_eligible=False`` with an explicit non-INTIMATE
+    ``privacy`` is rejected up-front rather than silently overriding
+    the caller's choice — the helper would otherwise hide a real
+    misconfiguration in a future test.
     """
     if not proxy_eligible:
+        if privacy not in (PrivacyTier.PERSONAL, PrivacyTier.INTIMATE):
+            msg = (
+                "_build_fragment(proxy_eligible=False, privacy=...) only accepts "
+                "PERSONAL (default) or INTIMATE; ineligibility is now derived "
+                "from privacy_tier so non-INTIMATE tiers cannot be forced "
+                "ineligible without changing source.author."
+            )
+            raise ValueError(msg)
         privacy = PrivacyTier.INTIMATE
     return Fragment(
         id=frag_id,

--- a/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
+++ b/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
@@ -478,6 +478,62 @@ class TestCsvFiles:
         assert "| name | note |" in markdown
         assert "café" in markdown
 
+    def test_csv_shift_jis_decodes_with_chardet(self, tmp_path: Path) -> None:
+        """A Shift-JIS CSV is decoded via the chardet probe (BUG-010).
+
+        Without the probe, ``cp1252`` would silently turn the multi-byte
+        Japanese sequences into mojibake. ``chardet`` needs a generous
+        sample to reach the confidence threshold, so this test uses
+        a long, varied corpus rather than a couple of rows.
+        """
+        csv_path = tmp_path / "shift_jis.csv"
+        # A varied phrase repeated until chardet has hundreds of bytes
+        # of distinguishing signal — small samples produce low
+        # confidence and would (correctly) fall through to cp1252.
+        phrase = (
+            "名前,都市,メモ\n"
+            "田中,東京,ありがとうございます\n"
+            "鈴木,大阪,初めまして、よろしくお願いします\n"
+            "佐藤,京都,日本語のテキストはマルチバイトです\n"
+        )
+        rows = phrase * 60
+        csv_path.write_bytes(rows.encode("shift_jis"))
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        markdown = ingestor.convert_to_markdown(fragments[0])
+        # If we had decoded as cp1252 the kanji would be replaced by
+        # Latin-1 characters. The exact byte-for-byte output depends on
+        # chardet's choice (Shift-JIS / cp932 are equivalent for these
+        # characters), so the test asserts that at least one of the
+        # input kanji round-trips intact.
+        assert any(ch in markdown for ch in "東京名前田中大阪京都")
+
+    def test_csv_cp1252_fallback_logs_warning(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The cp1252 fallback logs a WARNING with the file path (BUG-010).
+
+        Pure-ASCII content fits every codec, so chardet declines to
+        commit (its top guess is ``ascii``, which we reject in favour
+        of cp1252 to keep behaviour stable). The warning lets the user
+        spot mojibake before it lands in the vault.
+        """
+        import logging
+
+        csv_path = tmp_path / "ascii.csv"
+        # Bytes invalid as utf-8 force the fallback path even on
+        # shorter samples where chardet is uncertain.
+        csv_path.write_bytes(b"name,note\r\nAlice,caf\xe9\r\n")
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        with caplog.at_level(logging.WARNING, logger="creek.ingest.spreadsheets"):
+            ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert any(
+            "decoded as cp1252" in record.message and "ascii.csv" in record.message
+            for record in caplog.records
+        )
+
 
 # ---- OpenpyxlBackend lazy-import ---------------------------------------
 

--- a/creek-tools/tests/test_time.py
+++ b/creek-tools/tests/test_time.py
@@ -37,9 +37,32 @@ def test_now_la_is_tz_aware_in_la() -> None:
     assert moment.utcoffset() == ZoneInfo("America/Los_Angeles").utcoffset(moment)
 
 
-def test_today_la_returns_la_calendar_date() -> None:
-    """``today_la()`` agrees with ``now_la().date()`` regardless of host TZ."""
-    assert today_la() == now_la().date()
+def test_today_la_uses_la_calendar_not_utc(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``today_la()`` reads the LA wall calendar, not the UTC one.
+
+    Replaces an earlier circular assertion. We freeze ``datetime.now``
+    inside ``creek.time`` to a moment that is **already the next day
+    in UTC but still the previous day in LA**: 03:30 UTC on May 4
+    = 20:30 PDT on May 3. ``today_la()`` must return ``2026-05-03``;
+    a naive implementation that called ``date.today()`` (host-tz
+    dependent) or ``datetime.now(tz=UTC).date()`` would return
+    ``2026-05-04`` and fail.
+    """
+    import creek.time as creek_time
+
+    utc_moment = datetime(2026, 5, 4, 3, 30, tzinfo=ZoneInfo("UTC"))
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz: object = None) -> datetime:
+            del tz  # signature must match stdlib; tz argument is unused
+            return utc_moment.astimezone(ZoneInfo("America/Los_Angeles"))
+
+    monkeypatch.setattr(creek_time, "datetime", _FrozenDatetime)
+
+    assert today_la().isoformat() == "2026-05-03"
 
 
 def test_la_tz_constant_matches_zoneinfo() -> None:

--- a/creek-tools/tests/test_time.py
+++ b/creek-tools/tests/test_time.py
@@ -57,7 +57,12 @@ def test_today_la_uses_la_calendar_not_utc(
     class _FrozenDatetime(datetime):
         @classmethod
         def now(cls, tz: object = None) -> datetime:
-            del tz  # signature must match stdlib; tz argument is unused
+            # ``now_la`` must always pass the LA tz; if a future refactor
+            # drops the argument or passes UTC, the assertion makes the
+            # regression loud rather than silent.
+            assert tz == ZoneInfo("America/Los_Angeles"), (
+                f"now_la() must call now(tz=LA_TZ); got tz={tz!r}"
+            )
             return utc_moment.astimezone(ZoneInfo("America/Los_Angeles"))
 
     monkeypatch.setattr(creek_time, "datetime", _FrozenDatetime)

--- a/creek-tools/tests/test_time.py
+++ b/creek-tools/tests/test_time.py
@@ -1,0 +1,131 @@
+"""Regression tests for ``creek.time`` and the BUG-002 timezone sweep.
+
+These tests pin two facts that earlier code regressed on:
+
+1. The :func:`creek.time.now_la` helper returns a tz-aware datetime
+   anchored to America/Los_Angeles.
+2. Default fragment / thread / eddy / decision timestamps are tz-aware
+   in LA, so naive↔aware comparisons downstream do not raise.
+3. Host timezone does not change behaviour: setting ``TZ`` to UTC,
+   Asia/Tokyo, and America/New_York produces the same answers.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from creek.link.threads import ThreadDetector
+from creek.models import (
+    Decision,
+    Eddy,
+    Fragment,
+    FragmentSource,
+    SourcePlatform,
+    Thread,
+)
+from creek.time import LA_TZ, now_la, today_la
+
+
+def test_now_la_is_tz_aware_in_la() -> None:
+    """``now_la()`` is tz-aware and anchored to America/Los_Angeles."""
+    moment = now_la()
+    assert moment.tzinfo is not None
+    assert moment.utcoffset() == ZoneInfo("America/Los_Angeles").utcoffset(moment)
+
+
+def test_today_la_returns_la_calendar_date() -> None:
+    """``today_la()`` agrees with ``now_la().date()`` regardless of host TZ."""
+    assert today_la() == now_la().date()
+
+
+def test_la_tz_constant_matches_zoneinfo() -> None:
+    """The exported ``LA_TZ`` constant is the LA zoneinfo, not a tzname str."""
+    sample = datetime(2026, 4, 1, tzinfo=LA_TZ)
+    assert sample.utcoffset() == ZoneInfo("America/Los_Angeles").utcoffset(sample)
+
+
+class TestFragmentDefaultTimestamps:
+    """Default ``Fragment.created`` / ``Fragment.ingested`` are tz-aware (BUG-002)."""
+
+    def test_fragment_created_is_tz_aware(self) -> None:
+        """A default-constructed Fragment carries a tz-aware ``created``."""
+        frag = Fragment(
+            id="frag-test1234",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+        )
+        assert frag.created.tzinfo is not None
+
+    def test_fragment_ingested_is_tz_aware(self) -> None:
+        """A default-constructed Fragment carries a tz-aware ``ingested``."""
+        frag = Fragment(
+            id="frag-test1234",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+        )
+        assert frag.ingested.tzinfo is not None
+
+    def test_fragment_default_timestamps_are_la(self) -> None:
+        """Fragment defaults agree with the LA timezone."""
+        frag = Fragment(
+            id="frag-test1234",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+        )
+        la_offset = ZoneInfo("America/Los_Angeles").utcoffset(frag.created)
+        assert frag.created.utcoffset() == la_offset
+
+
+class TestThreadEddyDecisionDefaults:
+    """Date defaults route through ``today_la`` (BUG-002)."""
+
+    def test_thread_first_seen_is_la_date(self) -> None:
+        """A default-constructed Thread carries a date computed in LA."""
+        thread = Thread(title="t")
+        assert thread.first_seen == today_la()
+
+    def test_eddy_formed_is_la_date(self) -> None:
+        """A default-constructed Eddy carries a date computed in LA."""
+        eddy = Eddy(title="e")
+        assert eddy.formed == today_la()
+
+    def test_decision_opened_is_la_date(self) -> None:
+        """A default-constructed Decision carries a date computed in LA."""
+        decision = Decision(title="d")
+        assert decision.opened == today_la()
+
+
+class TestThreadDetectorDefaultNow:
+    """ThreadDetector ``_now`` default is tz-aware (BUG-002)."""
+
+    def test_default_now_is_tz_aware(self) -> None:
+        """Constructing without an explicit ``now`` yields a tz-aware moment."""
+        detector = ThreadDetector()
+        assert detector._now.tzinfo is not None  # pin internal state
+
+
+@pytest.mark.parametrize("tz_env", ["UTC", "Asia/Tokyo", "America/New_York"])
+def test_fragment_defaults_independent_of_host_tz(
+    tz_env: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting host ``TZ`` does not change Fragment default behaviour.
+
+    The acceptance criterion from BUG-002: re-running with different
+    host timezones produces identical assertions.
+    """
+    monkeypatch.setenv("TZ", tz_env)
+    if hasattr(time, "tzset"):
+        time.tzset()
+    frag = Fragment(
+        id="frag-test1234",
+        title="t",
+        source=FragmentSource(platform=SourcePlatform.OTHER),
+    )
+    # Regardless of host TZ, the offset matches LA.
+    la_offset = ZoneInfo("America/Los_Angeles").utcoffset(frag.created)
+    assert frag.created.utcoffset() == la_offset

--- a/creek-tools/tests/test_voice_proxy_eligible_computed.py
+++ b/creek-tools/tests/test_voice_proxy_eligible_computed.py
@@ -48,7 +48,7 @@ def test_personal_tier_self_author_is_eligible() -> None:
 
 def test_public_tier_self_author_is_eligible() -> None:
     """A PUBLIC self-authored fragment is voice-proxy eligible."""
-    frag = _make_fragment(privacy_tier=PrivacyTier.PUBLIC)
+    frag = _make_fragment(privacy_tier=PrivacyTier.OPEN)
     assert frag.voice_proxy_eligible is True
 
 
@@ -58,7 +58,7 @@ def test_public_tier_self_author_is_eligible() -> None:
 )
 def test_non_self_author_is_never_eligible(author: Authorship) -> None:
     """Non-self authorship excludes the fragment regardless of tier."""
-    frag = _make_fragment(privacy_tier=PrivacyTier.PUBLIC, author=author)
+    frag = _make_fragment(privacy_tier=PrivacyTier.OPEN, author=author)
     assert frag.voice_proxy_eligible is False
 
 
@@ -69,7 +69,7 @@ def test_voice_proxy_eligible_has_no_setter() -> None:
     routed at a computed field; callers must update the underlying
     ``privacy_tier`` / ``source.author`` instead.
     """
-    frag = _make_fragment(privacy_tier=PrivacyTier.PUBLIC)
+    frag = _make_fragment(privacy_tier=PrivacyTier.OPEN)
     with pytest.raises((AttributeError, ValueError)):
         frag.voice_proxy_eligible = False  # type: ignore[misc]
 

--- a/creek-tools/tests/test_voice_proxy_eligible_computed.py
+++ b/creek-tools/tests/test_voice_proxy_eligible_computed.py
@@ -46,8 +46,8 @@ def test_personal_tier_self_author_is_eligible() -> None:
     assert frag.voice_proxy_eligible is True
 
 
-def test_public_tier_self_author_is_eligible() -> None:
-    """A PUBLIC self-authored fragment is voice-proxy eligible."""
+def test_open_tier_self_author_is_eligible() -> None:
+    """An OPEN self-authored fragment is voice-proxy eligible (post-INC-003 rename)."""
     frag = _make_fragment(privacy_tier=PrivacyTier.OPEN)
     assert frag.voice_proxy_eligible is True
 

--- a/creek-tools/tests/test_voice_proxy_eligible_computed.py
+++ b/creek-tools/tests/test_voice_proxy_eligible_computed.py
@@ -1,0 +1,82 @@
+"""Regression tests for the BUG-009 fix.
+
+``Fragment.voice_proxy_eligible`` is now a derived property: it cannot
+drift from ``privacy_tier`` and ``source.author``. Constructing a
+fragment with INTIMATE tier — even *without* going through
+``PrivacyClassifier.enforce_tier`` — must produce
+``voice_proxy_eligible == False``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from creek.models import (
+    Authorship,
+    Fragment,
+    FragmentSource,
+    PrivacyTier,
+    SourcePlatform,
+)
+
+
+def _make_fragment(
+    *,
+    privacy_tier: PrivacyTier = PrivacyTier.UNCLASSIFIED,
+    author: Authorship = Authorship.SELF,
+) -> Fragment:
+    """Construct a Fragment without routing through any classifier."""
+    return Fragment(
+        id="frag-bug009test",
+        title="t",
+        source=FragmentSource(platform=SourcePlatform.JOURNAL, author=author),
+        privacy_tier=privacy_tier,
+    )
+
+
+def test_intimate_tier_disables_voice_proxy_without_enforce() -> None:
+    """Hand-constructing an INTIMATE fragment is enough to opt out (BUG-009)."""
+    frag = _make_fragment(privacy_tier=PrivacyTier.INTIMATE)
+    assert frag.voice_proxy_eligible is False
+
+
+def test_personal_tier_self_author_is_eligible() -> None:
+    """A PERSONAL self-authored fragment is voice-proxy eligible."""
+    frag = _make_fragment(privacy_tier=PrivacyTier.PERSONAL)
+    assert frag.voice_proxy_eligible is True
+
+
+def test_public_tier_self_author_is_eligible() -> None:
+    """A PUBLIC self-authored fragment is voice-proxy eligible."""
+    frag = _make_fragment(privacy_tier=PrivacyTier.PUBLIC)
+    assert frag.voice_proxy_eligible is True
+
+
+@pytest.mark.parametrize(
+    "author",
+    [Authorship.AI, Authorship.OTHER, Authorship.COLLABORATIVE],
+)
+def test_non_self_author_is_never_eligible(author: Authorship) -> None:
+    """Non-self authorship excludes the fragment regardless of tier."""
+    frag = _make_fragment(privacy_tier=PrivacyTier.PUBLIC, author=author)
+    assert frag.voice_proxy_eligible is False
+
+
+def test_voice_proxy_eligible_has_no_setter() -> None:
+    """The derived property cannot be reassigned (BUG-009 invariant).
+
+    Pydantic emits a ``ValidationError`` when an attribute setter is
+    routed at a computed field; callers must update the underlying
+    ``privacy_tier`` / ``source.author`` instead.
+    """
+    frag = _make_fragment(privacy_tier=PrivacyTier.PUBLIC)
+    with pytest.raises((AttributeError, ValueError)):
+        frag.voice_proxy_eligible = False  # type: ignore[misc]
+
+
+def test_tier_mutation_flips_eligibility() -> None:
+    """Mutating ``privacy_tier`` to INTIMATE updates eligibility immediately."""
+    frag = _make_fragment(privacy_tier=PrivacyTier.PERSONAL)
+    assert frag.voice_proxy_eligible is True
+    frag.privacy_tier = PrivacyTier.INTIMATE
+    assert frag.voice_proxy_eligible is False


### PR DESCRIPTION
Closes the safe-to-parallelise half of Batch H plus the previously-deferred items now that Batch C has merged. Branch is rebased onto current `main` (no conflicts).

Code changes
------------

- `creek/time.py` (new): `now_la()` and `today_la()` helpers anchored to America/Los_Angeles, plus a re-exported `LA_TZ` constant. Sweeps `models.py` defaults, `classify/review.py` timestamps, and `link/threads.py` default `_now` to use the helpers (BUG-002). `creek/purge/audit.py` deliberately keeps UTC for forensic portability — documented in the module docstring.

- `creek/models.py`:
  - `voice_proxy_eligible` is now a Pydantic computed field derived from `privacy_tier` and `source.author`. Hand-constructing a fragment with INTIMATE tier is enough to opt out of voice-proxy generation; the field cannot drift from the tier (BUG-009). Updates `classify/privacy.py` and `clean/context.py` to drop the redundant writes; updates `generate/skills.py` to derive eligibility from authorship + tier directly with enum equality (no string coercion).
  - `PrivacyTier.PUBLIC = "public"` renamed to `PrivacyTier.OPEN = "open"` per ontology §13.2 (INC-003). The legacy `"public"` string still loads via `_missing_` with a `DeprecationWarning` so older vaults migrate cleanly.

- `creek/ingest/spreadsheets.py`: CSV decoding probes `utf-8-sig` → `chardet` (≥ 0.7 confidence) → `cp1252` with a WARNING that names the offending file (BUG-010). Documented in `docs/ingestion.md`.

- `creek/classify/classify_engine.py`: `--method llm` is now resumable by default. Fragments already stamped `classification_method=llm` (or `manual`) are skipped without re-invoking the LLM; `--force` overrides. Each classified ID is appended to `<vault>/00-Creek-Meta/Processing-Log/llm-progress.jsonl` for observability (OPS-001). Documented in `docs/classification.md`.

- `creek/classify/llm.py`, `creek/classify/classify_engine.py`: per-fragment error/warning logs carry a `[fragment=… path=… provider=…]` prefix so the failing fragment is grep-able in logs (OPS-003). The progress-checkpoint append failure uses `[fragment=… checkpoint=…]` since the file path is the checkpoint, not the fragment.

- `creek/cli.py`:
  - New `creek init --vault <vault>` writes a starter `creek_config.yaml` under `00-Creek-Meta/`. `load_config` warns on missing config (ARCH-002).
  - `creek ingest --type gdrive` returns a tailored two-stage-flow error rather than the generic "unknown type" message (ARCH-001).
  - `creek purge source` gains `--source-path` and `--match {exact,substring,regex}`; the audit entry records the match mode (INC-008). The CLI re-uses the engine's `SOURCE_PATH_MATCH_MODES` so the validator and usage error cannot drift.

- `creek/link/{embeddings,threads,eddies}.py`: `tqdm` progress bars on the resonance, threads, and eddies hot loops; `disable=not sys.stderr.isatty()` so CI logs and pipes stay clean (OPS-004).

Documentation
-------------

- `docs/cleaning-pipeline.md` (new): end-user manual for `creek/clean/*` — module-by-module walkthrough, config knobs, common symptoms (INC-013).
- `docs/decisions.md` (new): decision-support lifecycle, §12.4 anti-manipulation guardrails, re-opening behaviour, CLI route (INC-017).
- `docs/emergence.md` (new): audit + spec for §10.1–10.5 emergence features (Unnamed, Paradox, Synchronicity, Compost, Tag Garden). All four §10.3 synchronicity criteria pinned (INC-018).
- `README.md`: ingestor count corrected to 10 + gdrive downloader, matches `INGESTOR_REGISTRY` (INC-012). Cross-references added from `generation.md` and `linking.md`.
- `docs/ingestion.md`: removed `--type gdrive` row; documented the chardet probe (BUG-010).
- `docs/cleaning-and-purge.md`: `purge source` two-mode documentation with `--match` examples (INC-008).
- `docs/classification.md`: OPS-001 crash-recovery section.

Tests
-----

- `tests/test_time.py`: BUG-002 regressions, including the parametrised host-TZ check from the issue.
- `tests/test_voice_proxy_eligible_computed.py`: BUG-009 regressions — derived property cannot be set, INTIMATE tier alone disables eligibility.
- `tests/test_privacy_tier_alias.py`: INC-003 — pin `OPEN` is canonical, `"public"` alias emits DeprecationWarning.
- `tests/test_ingest_registry.py`: pin `INGESTOR_REGISTRY` size + names to the README claim (INC-012).
- `tests/test_classify_engine_resume.py`: OPS-001 — skip on already-llm-classified, `--force` overrides, progress file append-across-runs, rules-method does not create file.
- `tests/test_spreadsheet_presentation_ingestors.py`: Shift-JIS CSV round-trip + ASCII-but-not-UTF-8 cp1252-warning case.
- `tests/test_config_init_warning.py`: ARCH-002 — warning on missing config, `creek init` writes/refuses-overwrite/forces.
- `tests/test_purge.py` additions: INC-008 — exact / substring / regex match modes, invalid regex fails fast, audit captures the mode.
- `tests/test_cli.py` addition: ARCH-001 `--type gdrive` redirect message.

`./scripts/check-all.sh` exits 0; coverage 93.53 %; 3009 tests pass.

Closes BUG-002, BUG-009, BUG-010, OPS-001, OPS-003, OPS-004, ARCH-001, ARCH-002, INC-003, INC-008, INC-012, INC-013, INC-017, INC-018.

https://claude.ai/code/session_014yQdgKkuXx8R8vucMYrwhe