### PR TITLE
docs(plans): file FEAT-001..FEAT-016 — v1.0 implementation roadmap

### DIFF
--- a/plans/git-issues/FEAT-001-schema-skills-compile-lint-save.md
+++ b/plans/git-issues/FEAT-001-schema-skills-compile-lint-save.md
@@ -1,0 +1,49 @@
+# FEAT-001: Schema-skill tree (compile / lint / save) + root AGENTS.md
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~400
+**Estimated complexity:** S
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md`](../2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md) (part 1 of 2)
+**Dependencies:** INC-019 (must land first — schema skills reference canonical taxonomy)
+**Parallelizable with peers:** yes (with FEAT-002, FEAT-005)
+**Wave:** 1 (schema foundation)
+
+## Goal
+
+Author a small root `AGENTS.md` plus the first three schema-skill files under `00-Creek-Meta/Skills/` so that subsequent FEATs (compile, lint, save) have a stable contract to reference. The voice-skill tree at `creek-skills/` is unchanged; this is a parallel *schema*-skill tree.
+
+## Files to touch
+
+- `AGENTS.md` (new, vault root) — points at `00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md` as canonical and defines the compile/query/lint/save contract in ≤3000 tokens.
+- `00-Creek-Meta/Skills/compile.SKILL.md` (new) — how to compile fragments → wiki pages, per-source, manual trigger, with provenance preservation.
+- `00-Creek-Meta/Skills/lint.SKILL.md` (new) — what `creek lint` does, with the explicit "do not resolve paradoxes" guard rail.
+- `00-Creek-Meta/Skills/save.SKILL.md` (new) — when and where to file good answers back, with privacy-tier rules.
+
+## Pre-decided choices
+
+- **Verb for the compile operation:** `creek compile`. (Resolves open question #1 in INTEGRATION-PLAN.md. The compiler-as-deterministic-binary metaphor is rejected — see REJECT-004 — but the verb is the right shorthand.)
+- **Schema-skills location:** `00-Creek-Meta/Skills/` (parallel to, not nested under, the voice-skill tree at `creek-skills/`). Resolves open question #4.
+- **AGENTS.md vs. CLAUDE.md:** `AGENTS.md` (matches the broader agent ecosystem; Claude Code reads either).
+- **Token budget per skill:** ≤1500 tokens. Enforced by a follow-up lint check (added in FEAT-008).
+- **AGENTS.md token budget:** ≤3000 tokens. Same lint check.
+
+## Test plan
+
+- A pre-commit / lint check verifies each schema-skill file is under its token budget (added later in FEAT-008's check set; for this PR, ship a documented size limit and a failing check is acceptable).
+- Manual review confirms the four files load cleanly when concatenated into a Claude Code session and that they don't contradict the ontology spec.
+- No code-level tests in this PR; deliverables are markdown only.
+
+## Acceptance criteria
+
+- `AGENTS.md` exists at vault root, ≤3000 tokens, points at `creek_ontology_agent_prompt.md` as canonical rather than duplicating it.
+- `00-Creek-Meta/Skills/compile.SKILL.md` exists, ≤1500 tokens, defines compile as per-source / interactive / provenance-preserving and explicitly references the four-layer architecture (raw / compiled / schema / liminal).
+- `00-Creek-Meta/Skills/lint.SKILL.md` exists, ≤1500 tokens, lists the lint checks (orphans, contradictions, stale claims, missing pages, data gaps) and includes the verbatim guard rail: "Lint never resolves paradoxes; contradictions route to `10-Liminal/Paradoxes/`."
+- `00-Creek-Meta/Skills/save.SKILL.md` exists, ≤1500 tokens, documents the destination decision (thread / eddy / praxis / paradox / unnamed / draft) and the privacy-tier defaults.
+- All four files use the canonical taxonomy from the spec (Rising/Peaking/Withdrawal/Diminishing/Bottoming Out/Restoration; Inhabit/Express/Collaborate/Integrate/Absorb; F1–F10).
+
+## References
+
+- Source candidate: ADAPT-005 (full motivation and tree structure).
+- Spec section: `00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md` §1, §2, §6, §7 (the load-bearing taxonomy these skills must respect).
+- Voice-skill tree (unchanged, for contrast): `creek-tools/creek/generate/skills.py` writes under `<vault>/creek-skills/`.

--- a/plans/git-issues/FEAT-002-schema-skills-paradox-liminal-privacy-wavelength.md
+++ b/plans/git-issues/FEAT-002-schema-skills-paradox-liminal-privacy-wavelength.md
@@ -1,0 +1,46 @@
+# FEAT-002: Schema-skill tree (paradox / liminal / privacy-tier / wavelength-aware)
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~400
+**Estimated complexity:** S
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md`](../2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md) (part 2 of 2)
+**Dependencies:** FEAT-001 (the root `AGENTS.md` it composes with)
+**Parallelizable with peers:** yes (with FEAT-005 and the FEAT-003/004 pair)
+**Wave:** 1 (schema foundation)
+
+## Goal
+
+Author the four remaining schema-skill files under `00-Creek-Meta/Skills/` covering the project's non-negotiables and the wavelength lens. These are the guard rails every downstream FEAT must respect.
+
+## Files to touch
+
+- `00-Creek-Meta/Skills/paradox.SKILL.md` (new) — how to handle contradictions: route to `10-Liminal/Paradoxes/`, never resolve.
+- `00-Creek-Meta/Skills/liminal.SKILL.md` (new) — when to leave content uncategorized; the four-layer architecture's fourth layer.
+- `00-Creek-Meta/Skills/privacy-tier.SKILL.md` (new) — the `open` / `personal` / `intimate` ladder and the fail-closed defaults.
+- `00-Creek-Meta/Skills/wavelength-aware.SKILL.md` (new) — phase as the lens through which every other tag is interpreted.
+
+## Pre-decided choices
+
+- **Privacy-tier names:** `open` / `personal` / `intimate` (matches the spec; INC-003 is resolving the code-side `public` → `open` rename — confirm before merging this FEAT).
+- **Liminal as a fourth layer (not a wiki sub-folder):** explicitly named in `liminal.SKILL.md`. This is the highest-priority distinctiveness item per INTEGRATION-PLAN.md's distinctiveness watchlist.
+- **Wavelength snapshot location for skill activation:** `00-Creek-Meta/State/latest.md` (created in FEAT-007). For this FEAT, name the location and document that it's the source the wavelength-aware skill reads.
+
+## Test plan
+
+- Same size-budget check as FEAT-001 (≤1500 tokens per skill).
+- A manual conformance review: every `Pre-decided choices` block in subsequent FEATs (003+) must respect the rules these skills name.
+
+## Acceptance criteria
+
+- `paradox.SKILL.md` exists, ≤1500 tokens, contains the verbatim rule: "Contradictions are data, not defects. Route to `10-Liminal/Paradoxes/`. Do not propose resolution."
+- `liminal.SKILL.md` exists, ≤1500 tokens, names the four-layer architecture (raw / compiled / schema / liminal) and explicitly says the liminal layer is *not* a wiki sub-folder.
+- `privacy-tier.SKILL.md` exists, ≤1500 tokens, documents the three tiers, the fail-closed default (ambiguous → `personal`, unknown → `intimate`), and the per-tier inclusion behaviour for `mine` / `draft` / `report` / `skills`.
+- `wavelength-aware.SKILL.md` exists, ≤1500 tokens, documents the six phases × five modes × Do/Feel × Medicine/Toxic and points at `00-Creek-Meta/State/latest.md` as the snapshot source.
+- All four files use canonical taxonomy and respect INC-019's resolution.
+
+## References
+
+- Source candidate: ADAPT-005.
+- Spec sections: §7.1 (six phases), §7.2 (five modes), §7.3 (Medicine/Toxic), §10 (emergence + liminal infrastructure), §13.2 (privacy tiers).
+- INTEGRATION-PLAN.md distinctiveness watchlist (the four non-negotiables in priority order).

--- a/plans/git-issues/FEAT-002-schema-skills-paradox-liminal-privacy-wavelength.md
+++ b/plans/git-issues/FEAT-002-schema-skills-paradox-liminal-privacy-wavelength.md
@@ -6,7 +6,7 @@
 **Estimated complexity:** S
 **Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md`](../2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md) (part 2 of 2)
 **Dependencies:** FEAT-001 (the root `AGENTS.md` it composes with)
-**Parallelizable with peers:** yes (with FEAT-005 and the FEAT-003/004 pair)
+**Parallelizable with peers:** yes (with FEAT-005 only; FEAT-003 and FEAT-004 hard-depend on this FEAT)
 **Wave:** 1 (schema foundation)
 
 ## Goal

--- a/plans/git-issues/FEAT-003-compile-primitive.md
+++ b/plans/git-issues/FEAT-003-compile-primitive.md
@@ -1,0 +1,63 @@
+# FEAT-003: Compile primitive — `creek compile <fragment-id>`
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~450
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-001-three-layer-compiled-architecture.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-001-three-layer-compiled-architecture.md) (part 1 of 2)
+**Dependencies:** INC-019, FEAT-001 (compile.SKILL.md), FEAT-002 (paradox + liminal skills)
+**Parallelizable with peers:** no (FEAT-004 depends on this)
+**Wave:** 2 (compiled-layer primitives)
+
+## Goal
+
+Add a `creek compile` CLI command and supporting `creek/compile/` module that takes a fragment (or a directory of fragments) and produces / updates synthesis pages in `02-Threads/`, `03-Eddies/`, and `06-Frequencies/`. Per-source, manual trigger, interactive (discusses takeaways), with full provenance back to fragment IDs.
+
+## Files to touch
+
+- `creek-tools/creek/compile/__init__.py` (new) — public surface.
+- `creek-tools/creek/compile/engine.py` (new) — the compile logic; takes a list of fragment IDs, an LLM client, and a target list of compiled-page paths to update.
+- `creek-tools/creek/compile/provenance.py` (new) — `ProvenanceEntry` model + frontmatter writer (per-claim → fragment ID list).
+- `creek-tools/creek/cli.py` — add `@app.command()` for `compile` near the existing classify/link block (around line 599–696).
+- `creek-tools/creek/models.py` — add `CompiledPage` model with `provenance: list[ProvenanceEntry]` frontmatter.
+- `creek-tools/tests/test_compile.py` (new) — unit + integration tests for the compile flow.
+
+## Pre-decided choices
+
+- **Compile granularity:** per-fragment (one `creek compile <fragment-id>` invocation = one source). Bulk mode (`creek compile --all-unsynthesized`) is deferred to v1.1.
+- **Compiled page locations:** existing `02-Threads/`, `03-Eddies/`, `06-Frequencies/` directories. No new layer added; the *contract* is what changes.
+- **Provenance schema:**
+  ```yaml
+  provenance:
+    - claim_id: claim-001
+      claim_excerpt: "first 80 chars of the claim"
+      fragment_ids: [frag-9c1f3a2b8e02, frag-5d4e9c1a7f31]
+      compiled_at: 2026-05-06T17:35:00Z
+      compile_method: llm  # rules | llm | manual
+  ```
+- **Paradox handling during compile:** if the LLM detects contradictions across the fragments being compiled, it routes to `10-Liminal/Paradoxes/` (via FEAT-009's `creek save` once that exists; for this PR, log to `00-Creek-Meta/Processing-Log/paradoxes-during-compile.jsonl` and surface in the next lint run).
+- **Privacy tier:** compile honours the source fragments' tiers. `intimate` fragments contribute title-only summaries to compiled pages; this matches existing `privacy_filter.py` behaviour.
+
+## Test plan
+
+- Unit: `engine.compile_fragments([frag1, frag2], target_eddy)` returns a `CompiledPage` with provenance for every claim.
+- Unit: paradox detection during compile routes to the side-channel log, not into the synthesis page.
+- Integration: `creek compile <fragment-id>` against a fixture vault produces an updated `02-Threads/` note with provenance frontmatter.
+- Regression: `creek compile` against a vault with `intimate` fragments emits title-only contributions for those claims.
+- Regression: re-running `creek compile <same-fragment-id>` is idempotent — same input produces a deterministic update (no duplicate claims, provenance lists merge).
+
+## Acceptance criteria
+
+- `creek compile <fragment-id>` exists and routes through `creek/compile/engine.py`.
+- Compiled-page frontmatter carries the `provenance` list with one entry per claim, each linking back to fragment IDs.
+- LLM-detected paradoxes during compile route to a side-channel log; they are *never* flattened into the synthesis page.
+- `intimate`-tier fragments contribute title-only to compiled pages.
+- Re-runs are idempotent (claim list merges, no dupes).
+- ≥90% branch coverage on `creek/compile/`.
+
+## References
+
+- Source candidate: ADOPT-001 (full architecture rationale; especially the four-layer adaptation note).
+- ADOPT-006 (confidence tiers — provenance entries should also carry the tier of the underlying edges; that lands in FEAT-006 follow-up).
+- REJECT-004 (compiler-as-deterministic-binary is rejected; the verb is fine, the metaphor is not).
+- Spec §10.2 (paradox preservation rules).

--- a/plans/git-issues/FEAT-004-compiled-layer-query-routing.md
+++ b/plans/git-issues/FEAT-004-compiled-layer-query-routing.md
@@ -1,0 +1,52 @@
+# FEAT-004: Query-path routing through compiled layer (`creek mine` / `creek draft`)
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~450
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-001-three-layer-compiled-architecture.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-001-three-layer-compiled-architecture.md) (part 2 of 2)
+**Dependencies:** FEAT-003 (compile primitive must exist)
+**Parallelizable with peers:** yes (with FEAT-005, FEAT-006/007/008)
+**Wave:** 2 (compiled-layer primitives)
+
+## Goal
+
+Make `creek mine` and `creek draft` route through the compiled layer first, falling back to fragments only when the compiled page is missing or insufficient. This is the operational commitment to compile-then-query; without it, the compiled layer exists but isn't the canonical query target.
+
+## Files to touch
+
+- `creek-tools/creek/generate/mining.py` — change the four discovery strategies to read from `02-Threads/`, `03-Eddies/`, `06-Frequencies/` first, fragments second. Today they read from fragments directly.
+- `creek-tools/creek/generate/drafts.py` — change the source-material gathering step to pull from compiled pages (with provenance traversal back to fragments only when the compiled page is `inferred`-tier or missing).
+- `creek-tools/creek/cli.py` — add `--bypass-compiled` flag to `mine` and `draft` as the documented escape hatch.
+- `creek-tools/tests/test_mining.py` — add cases that verify compiled-layer-first behaviour.
+- `creek-tools/tests/test_drafts.py` — same.
+- `creek-tools/docs/generation.md` — document the routing change and the `--bypass-compiled` flag.
+
+## Pre-decided choices
+
+- **Routing precedence:** compiled-page exists → use it. Compiled-page missing → fall back to fragments and log a `compile-needed` entry to `00-Creek-Meta/Processing-Log/compile-gaps.jsonl` (lint surfaces these later).
+- **Escape hatch flag:** `--bypass-compiled` (boolean, default `false`). Logs a warning when used so the operator knows they're side-stepping the discipline.
+- **Provenance traversal during draft:** if a compiled-page claim has provenance fragment IDs, drafts can pull the original fragment text for exact-quote use; otherwise the draft works only from the compiled summary.
+
+## Test plan
+
+- Unit: `mining.run_strategy("thread-terminus", vault)` reads from `02-Threads/` notes, not fragment files.
+- Unit: `drafts.gather_source_material(idea_seed)` pulls from compiled-page provenance fragment IDs when the compiled page exists.
+- Regression: when no compiled page exists for a topic, mining still works against fragments AND a `compile-gaps.jsonl` entry is written.
+- Regression: `creek mine --bypass-compiled` skips the compiled layer entirely and emits a warning to stderr.
+- Regression test verifying the user-facing behaviour is unchanged when a compiled vault is present (the same essay seeds surface, perhaps in different ranking).
+
+## Acceptance criteria
+
+- `creek mine` and `creek draft` both check compiled pages before fragments.
+- `--bypass-compiled` flag exists on both commands and is documented.
+- Missing compiled pages log to `00-Creek-Meta/Processing-Log/compile-gaps.jsonl`.
+- A regression test verifies that `creek draft` without `--bypass-compiled` routes through the compiled layer in the absence of `--bypass-compiled` (this is the AC pinned in ADOPT-001).
+- ≥90% branch coverage on the changed paths.
+- Documentation in `docs/generation.md` updated.
+
+## References
+
+- Source candidate: ADOPT-001 (especially "the contract is what changes" discussion).
+- FEAT-003 (compile primitive that produces what this FEAT reads).
+- ADOPT-006 / FEAT-006 (confidence tiers — drafts will eventually expose the tier mix; this FEAT just establishes routing).

--- a/plans/git-issues/FEAT-005-deterministic-first-pipeline.md
+++ b/plans/git-issues/FEAT-005-deterministic-first-pipeline.md
@@ -1,0 +1,54 @@
+# FEAT-005: Deterministic-first pipeline vocabulary + `--no-llm` end-to-end
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~260
+**Estimated complexity:** S
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-004-deterministic-first-pipeline.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-004-deterministic-first-pipeline.md)
+**Dependencies:** none (parallelizable with FEAT-001/002/003/004)
+**Parallelizable with peers:** yes (independent module set)
+**Wave:** 2
+
+## Goal
+
+Make Creek's already-deterministic-first pipeline *audit-able* and *strictly enforceable*. Document the Pass-1/Pass-2/Pass-3 split, add a `--no-llm` end-to-end flag, and emit a "pre-LLM yield" line per pipeline run.
+
+## Files to touch
+
+- `creek-tools/creek/pipeline.py` — add Pass-1/Pass-2/Pass-3 grouping, `--no-llm` plumbing, yield-reporting hook.
+- `creek-tools/creek/cli.py` — add `--no-llm` flag to `process` (around line 379).
+- `creek-tools/creek/audit/` — add a `pre_llm_yield_summary(run_id)` writer.
+- `creek-tools/docs/configuration.md` and `docs/classification.md` — document the Pass-1/2/3 vocabulary and the privacy claim ("network egress only in Pass 3").
+- `creek-tools/tests/integration/test_pipeline_no_llm.py` (new) — verifies a full `creek process --no-llm` run completes without any Anthropic-bound traffic.
+
+## Pre-decided choices
+
+- **Pass naming:** Pass 1 = local deterministic (ingest + redact + rules-classify + frontmatter); Pass 2 = local model-based (embeddings, OCR, future Whisper); Pass 3 = network if opted in (LLM classify, LLM compile, lint semantic checks).
+- **`--no-llm` semantics:** runs Passes 1 and 2 to completion, skips Pass 3 entirely. Reports the residue (unclassified / low-confidence fragments).
+- **Yield reporting format:** one structured line at end of run, written to stdout and to `00-Creek-Meta/Processing-Log/run-summary.jsonl`:
+  ```
+  Deterministic: N classified | Local-model: M embedded/OCR'd | Residue: K (would go to LLM if Pass-3 enabled)
+  ```
+- **CI test for no-network egress:** uses `pytest-socket` or equivalent to assert no outbound socket calls during a `--no-llm` run.
+
+## Test plan
+
+- Integration test: `creek process --no-llm` against a fixture source completes and produces a vault with rules-classified fragments. Network egress hooks see zero Anthropic traffic.
+- Unit: the yield summary writer produces the documented JSONL line and the documented stdout format.
+- Regression: passing `--no-llm` and `LLM_PROVIDER=anthropic` simultaneously still skips LLM (the flag wins).
+- Documentation: a one-liner under `docs/configuration.md` shows the three-pass vocabulary.
+
+## Acceptance criteria
+
+- `docs/configuration.md` (or a sibling doc) names the three passes with the privacy claim verbatim: "network egress only in Pass 3."
+- `creek process --no-llm` flag exists and works end-to-end.
+- A run-summary JSONL line is emitted per pipeline run with deterministic / local-model / residue counts.
+- A CI integration test verifies zero network egress during `--no-llm` runs.
+- The pre-LLM yield is exposed in the audit report (FEAT-006 will surface it; this FEAT just produces it).
+- No regression in existing pipeline behaviour when `--no-llm` is omitted.
+
+## References
+
+- Source candidate: ADOPT-004.
+- Existing partial discipline: `docs/classification.md` already documents `--method rules` then `--method llm` on residue. This FEAT names the discipline explicitly.
+- FEAT-006 (audit report) consumes the yield summary.

--- a/plans/git-issues/FEAT-006-creek-state-audit-report-core.md
+++ b/plans/git-issues/FEAT-006-creek-state-audit-report-core.md
@@ -1,0 +1,53 @@
+# FEAT-006: `creek state` audit report — core sections
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~450
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-005-audit-report-as-artifact.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-005-audit-report-as-artifact.md) (part 1 of 2)
+**Dependencies:** FEAT-005 (consumes pre-LLM yield numbers)
+**Parallelizable with peers:** yes (with FEAT-008, FEAT-009)
+**Wave:** 3
+
+## Goal
+
+Add a `creek state` command that produces `00-Creek-Meta/State/<iso-week>.md` with the structural sections an agent or human needs to understand the vault: vault summary, eddies, threads, synchronicities, hyperedges, drift warnings, pre-LLM yield. Wavelength snapshot and suggested questions land in FEAT-007.
+
+## Files to touch
+
+- `creek-tools/creek/generate/state.py` (new) — `StateReportGenerator` with one method per section.
+- `creek-tools/creek/cli.py` — add `@app.command() state(...)` near the existing `report` command (around line 771).
+- `creek-tools/creek/generate/__init__.py` — export the new generator.
+- `creek-tools/tests/test_state.py` (new) — section-by-section unit tests + integration test that verifies the rendered file structure.
+- `creek-tools/docs/generation.md` — document `creek state`.
+
+## Pre-decided choices
+
+- **Output path:** `<vault>/00-Creek-Meta/State/<iso-year>-W<week>.md`. A symlink-or-copy at `<vault>/00-Creek-Meta/State/latest.md` always points at the most recent. Writing the symlink on Windows falls back to a copy.
+- **Section order (this PR):** 1) Vault summary, 2) Pre-LLM yield, 3) Active eddies (top 10 by fragment count), 4) Active threads (top 10 by recency), 5) Surprising connections (synchronicities), 6) Hyperedges (praxis spanning multiple eddies), 7) Drift warnings (broken wiki-links + stale fragments). Wavelength + suggested questions are added by FEAT-007 between section 1 and 2.
+- **`creek state` is a *view*, not a pipeline.** It re-reads existing vault state and emits the markdown; it does *not* re-run any expensive pass.
+- **Empty sections render an explicit "no surfacing this week" note**, not a missing header.
+
+## Test plan
+
+- Unit: each `StateReportGenerator.section_*` method against a fixture vault returns deterministic markdown.
+- Integration: `creek state` against a fixture vault writes the file at the expected path with all required sections in order.
+- Regression: empty sections render the placeholder text rather than disappearing.
+- Regression: re-running `creek state` the same week overwrites the file (idempotent).
+- Regression: `latest.md` symlink/copy is updated after every run.
+
+## Acceptance criteria
+
+- `creek state` CLI exists, writes `00-Creek-Meta/State/<iso-week>.md` and `latest.md`.
+- The seven sections listed above are present in order.
+- A section with no content renders an explicit empty-state note.
+- `creek state` does not re-run classification, linking, or compile — it only reads vault state.
+- ≥90% branch coverage on `creek/generate/state.py`.
+- `docs/generation.md` documents the command.
+
+## References
+
+- Source candidate: ADOPT-005 (full section list and Creek-flavored adaptations).
+- FEAT-005 (pre-LLM yield JSONL is the input for section 2).
+- FEAT-007 (wavelength snapshot + suggested questions sections + size-budget gate).
+- Graphify's `GRAPH_REPORT.md` is the prior art (six structured sections).

--- a/plans/git-issues/FEAT-007-creek-state-wavelength-and-size-budget.md
+++ b/plans/git-issues/FEAT-007-creek-state-wavelength-and-size-budget.md
@@ -1,0 +1,54 @@
+# FEAT-007: `creek state` wavelength snapshot, suggested questions, size-budget gate
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~450
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-005-audit-report-as-artifact.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-005-audit-report-as-artifact.md) (part 2 of 2) + [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-007-index-as-context-window-contract.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-007-index-as-context-window-contract.md)
+**Dependencies:** FEAT-006
+**Parallelizable with peers:** no (extends FEAT-006's file)
+**Wave:** 3
+
+## Goal
+
+Add the wavelength snapshot at the top of `creek state`'s output, generate phase-aware suggested questions, and pin a size budget on the rendered file so it stays context-window-sized.
+
+## Files to touch
+
+- `creek-tools/creek/generate/state.py` — add `section_wavelength_snapshot()`, `section_suggested_questions()`, and `section_liminal_watch()`.
+- `creek-tools/creek/generate/wavelength.py` — extract a `current_phase_summary(vault)` helper if not already present.
+- `creek-tools/creek/generate/mining.py` — expose a `phase_filtered_seeds(phase, n=5)` helper for the suggested-questions section.
+- `creek-tools/tests/test_state.py` — add cases for the three new sections.
+- `creek-tools/scripts/check-all.sh` — add a check that `00-Creek-Meta/State/latest.md` is under the documented size budget.
+
+## Pre-decided choices
+
+- **Wavelength snapshot at the very top** (before vault summary). Phase context interprets every other section — Karpathy's `index.md` discipline adapted to Creek.
+- **Suggested questions:** 4–5 prompts pulled from `mining.phase_filtered_seeds(current_phase)`. Phase-aware: don't surface "draft your next Substack" during Bottoming Out; surface compost/synchronicity prompts instead.
+- **Liminal Watch section:** recently surfaced unnamed clusters + growing tag clusters + fresh paradoxes. Inserted between Pre-LLM yield and Active eddies in FEAT-006's section order.
+- **Size budget:** ≤50,000 tokens (≈200KB at typical token density). Enforced as a CI/`check-all.sh` line. Rationale: the audit report must fit in a single Claude context window so it can serve as the session-start prime for CrawDad and Claude Code.
+- **Size-budget violations are quality signals, not bugs to suppress.** A failing budget means the compiled layer is fragmenting; the fix is to consolidate via `creek lint`, not to raise the cap.
+
+## Test plan
+
+- Unit: `section_wavelength_snapshot()` against a fixture vault returns the current phase, mode, dosage trends, and detected transitions in markdown.
+- Unit: `section_suggested_questions()` filters by phase — Bottoming Out fixture surfaces compost/synchronicity prompts, Rising fixture surfaces draft/mine prompts.
+- Unit: `section_liminal_watch()` surfaces fresh content from `10-Liminal/{Unnamed,Paradoxes}/` and growing tags.
+- Regression: `latest.md` size-budget check fails when the file exceeds 50,000 tokens; the failure message names which sections grew.
+- Integration: `creek state` end-to-end produces a file in the documented section order: wavelength → vault summary → pre-LLM yield → liminal watch → eddies → threads → synchronicities → hyperedges → drift warnings → suggested questions.
+
+## Acceptance criteria
+
+- Wavelength snapshot is the first section in the rendered audit report.
+- Suggested questions are phase-aware (verified by fixture test).
+- Liminal Watch section exists and pulls from `10-Liminal/`.
+- A size-budget check fails the build when `latest.md` exceeds 50,000 tokens.
+- `docs/generation.md` documents the budget and the rationale (fragmentation signal, not a cap to raise).
+- ≥90% branch coverage on the changed paths.
+
+## References
+
+- Source candidates: ADOPT-005, ADOPT-007 (these were always one artifact).
+- FEAT-006 (the file this extends).
+- ADOPT-007 explicitly: the `index.md`-as-context-window contract.
+- Wavelength infrastructure already in `creek/generate/wavelength.py`.

--- a/plans/git-issues/FEAT-008-creek-lint-unified-hygiene.md
+++ b/plans/git-issues/FEAT-008-creek-lint-unified-hygiene.md
@@ -6,7 +6,7 @@
 **Estimated complexity:** M
 **Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-002-creek-lint-unified-hygiene.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-002-creek-lint-unified-hygiene.md)
 **Dependencies:** FEAT-001 (lint.SKILL.md guard rails), FEAT-002 (paradox skill), FEAT-006 (audit-report append target)
-**Parallelizable with peers:** yes (with FEAT-006/007/009)
+**Parallelizable with peers:** yes (with FEAT-007 and FEAT-009; FEAT-006 must land first)
 **Wave:** 3
 
 ## Goal

--- a/plans/git-issues/FEAT-008-creek-lint-unified-hygiene.md
+++ b/plans/git-issues/FEAT-008-creek-lint-unified-hygiene.md
@@ -1,0 +1,59 @@
+# FEAT-008: `creek lint` — unified vault hygiene operation
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~530
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-002-creek-lint-unified-hygiene.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-002-creek-lint-unified-hygiene.md)
+**Dependencies:** FEAT-001 (lint.SKILL.md guard rails), FEAT-002 (paradox skill), FEAT-006 (audit-report append target)
+**Parallelizable with peers:** yes (with FEAT-006/007/009)
+**Wave:** 3
+
+## Goal
+
+Unify the five existing emergence reports (Tag Garden, Unnamed Digest, Synchronicity, Compost, Paradox) under one named `creek lint` operation with per-check selectors. Add deterministic checks (broken wiki-links, schema-skill size budgets, orphan compiled pages) and an incremental `--since` mode.
+
+## Files to touch
+
+- `creek-tools/creek/lint/__init__.py` (new) — public surface.
+- `creek-tools/creek/lint/runner.py` (new) — orchestrator that dispatches to individual check modules.
+- `creek-tools/creek/lint/checks/` (new directory) — one file per check: `paradox.py`, `unnamed.py`, `synchronicity.py`, `compost.py`, `tags.py` (these wrap the existing `creek/generate/*` modules), plus deterministic checks: `broken_links.py`, `orphan_compiled.py`, `skill_size_budget.py`.
+- `creek-tools/creek/cli.py` — add `@app.command() lint(...)` with `--check NAME` and `--since DURATION` flags.
+- `creek-tools/creek/generate/{paradox,unnamed,synchronicity,compost,tags}.py` — make their entry points reusable by `creek/lint/checks/*`. Existing `creek report --type X` commands stay as thin wrappers that call into the new lint check modules.
+- `creek-tools/tests/test_lint.py` (new) — orchestrator tests + per-check tests.
+
+## Pre-decided choices
+
+- **Default `creek lint` runs all deterministic checks always; semantic checks (paradox, synchronicity, unnamed) require `--full` or `--since`.** Rationale: deterministic checks are cheap (link-graph traversal); semantic checks use embeddings and may take minutes.
+- **Output:** consolidated markdown report appended to the next `creek state` audit-report run, plus a per-run summary written to `00-Creek-Meta/Processing-Log/lint-<iso-date>.md`.
+- **Lint never resolves paradoxes.** The `creek/lint/checks/paradox.py` wrapper preserves the existing `ParadoxDetector` behaviour: contradictions route to `10-Liminal/Paradoxes/`, never to a "to-fix" queue. Pinned by a regression test.
+- **Lint never auto-creates compiled pages.** Missing-compiled-page checks emit suggestions only.
+- **Lint never deletes orphan fragments.** Orphan fragments are normal; only orphan *compiled* pages are flagged.
+- **`--check NAME` accepts:** `paradox`, `unnamed`, `synchronicity`, `compost`, `tags`, `broken-links`, `orphan-compiled`, `skill-size`. Multiple `--check` flags allowed.
+- **`--since DURATION`:** `7d`, `1w`, `1mo`, `30d`. Deterministic checks always run incrementally given `--since`; semantic checks only run incrementally if their underlying detector supports it (today, none do — falls back to full run).
+
+## Test plan
+
+- Unit per check module.
+- Integration: `creek lint` with no args runs all deterministic checks against a fixture vault and produces the expected lint report.
+- Integration: `creek lint --check paradox` runs only the paradox check.
+- Integration: `creek lint --since 7d` runs deterministic checks incrementally.
+- Regression: a paradox detected during lint lands in `10-Liminal/Paradoxes/`, not in a "to-fix" list. (This is the AC pinned in ADOPT-002.)
+- Regression: lint never creates a compiled page — even when the missing-compiled-page check fires, it emits a suggestion only.
+- Regression: existing `creek report --type {tags,unnamed,synchronicity,compost,paradox}` commands still work (they're now thin wrappers).
+
+## Acceptance criteria
+
+- `creek lint` CLI exists with `--check` and `--since` flags as documented.
+- All five existing emergence report types are reachable as `--check` values.
+- Three new deterministic checks exist: `broken-links`, `orphan-compiled`, `skill-size`.
+- The "no resolve, no create, no delete" rules are documented in the lint module's docstring AND verified by regression tests.
+- Lint output appends to the next `creek state` run (FEAT-006/007).
+- ≥90% branch coverage on `creek/lint/`.
+- `docs/emergence.md` and a new `docs/lint.md` document the command.
+
+## References
+
+- Source candidate: ADOPT-002 (especially the "do not resolve paradoxes" guard rail).
+- Existing modules being unified: `creek/generate/{paradox,unnamed,synchronicity,compost,tags}.py`.
+- `cablate/llm-atomic-wiki` (community Karpathy implementation) for the deterministic-vs-semantic split inspiration.

--- a/plans/git-issues/FEAT-009-creek-save-answer-filing-back.md
+++ b/plans/git-issues/FEAT-009-creek-save-answer-filing-back.md
@@ -1,0 +1,77 @@
+# FEAT-009: `creek save` — answer-filing-back primitive
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~580
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-003-answer-filing-back-loop.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-003-answer-filing-back-loop.md)
+**Dependencies:** FEAT-001 (save.SKILL.md), FEAT-002 (paradox + privacy-tier skills)
+**Parallelizable with peers:** yes (with FEAT-006/007/008)
+**Wave:** 3
+
+## Goal
+
+Add a `creek save` CLI primitive that takes a body, target type, and optional fragment provenance and writes a properly-classified note with full frontmatter. This is what makes the wiki *compounding* — good Q&A turns into vault content rather than vanishing into chat history. CrawDad's `/crawdad save` (FEAT-016 → FEAT-014/015) wraps this primitive via MCP.
+
+## Files to touch
+
+- `creek-tools/creek/save/__init__.py` (new) — public surface.
+- `creek-tools/creek/save/router.py` (new) — destination decision: thread / eddy / praxis / paradox / unnamed / draft.
+- `creek-tools/creek/save/writer.py` (new) — frontmatter + body composer that respects existing models (Thread, Eddy, Praxis, etc.).
+- `creek-tools/creek/cli.py` — add `@app.command() save(...)`.
+- `creek-tools/creek/classify/privacy_filter.py` — extend with a `pre_save_filter(body, tier)` helper that title-only-summarizes `personal` content and refuses `intimate`.
+- `creek-tools/tests/test_save.py` (new) — destination-decision and tier-filter tests.
+
+## Pre-decided choices
+
+- **CLI signature:**
+  ```
+  creek save --target <thread|eddy|praxis|paradox|unnamed|draft> \
+             --body <path-or-stdin> \
+             --title <optional> \
+             --provenance frag-XXX,frag-YYY \
+             --source <conversation-id|discord-msg-id|claude-session-id> \
+             --tier <open|personal|intimate>
+  ```
+- **`--target` is required** (no auto-classification in v1.0; smart routing is deferred to v1.1 per ADOPT-003's "simplest viable v1").
+- **Tier defaulting:** `--tier` is required when stdin is the body source; defaults to the source fragments' max tier when `--provenance` is supplied.
+- **Privacy enforcement:**
+  - `intimate` → save title-only summary, body to `10-Liminal/Compost/intimate-stubs/` (gitignored), with a frontmatter pointer to the local-only body. Never auto-saves full intimate content.
+  - `personal` → save title + summary; full body is included only when `--full-body` is explicitly passed.
+  - `open` → full save.
+- **Paradox routing rule:** when `--target paradox`, the save *always* goes to `10-Liminal/Paradoxes/` regardless of any other classification; paradox tier-filter is `open` (the *fact* of the contradiction, not the contradictory content, is what's preserved).
+- **Provenance frontmatter:**
+  ```yaml
+  saved_from:
+    source_kind: discord | claude-session | manual | mcp
+    source_id: <opaque-id>
+    contributing_fragments: [frag-XXX, frag-YYY]
+    saved_at: 2026-05-06T17:35:00Z
+    saved_by: <operator-or-mcp-client>
+  ```
+
+## Test plan
+
+- Unit: each destination type produces a model-conformant note (Thread, Eddy, Praxis, etc.) at the right path.
+- Unit: `pre_save_filter(body, tier=intimate)` returns title-only and a body-pointer to the gitignored stubs directory.
+- Regression: `creek save --target paradox` always lands in `10-Liminal/Paradoxes/` regardless of other inputs.
+- Regression: `creek save` with no `--tier` and no `--provenance` refuses with a clear error message (not a silent default).
+- Regression: `intimate`-tier saves never write full body to the vault (verified by file-system inspection in the test).
+- Integration: `creek save --target thread --body fixtures/answer.md --provenance frag-001,frag-002 --tier open` produces a properly-formatted Thread note.
+
+## Acceptance criteria
+
+- `creek save` CLI exists with the documented signature.
+- All six target types route to the correct vault directory.
+- Privacy-tier enforcement is verified by regression tests for each tier.
+- Paradox routing always lands in `10-Liminal/Paradoxes/` regardless of other inputs.
+- Provenance frontmatter is present on every saved note.
+- ≥90% branch coverage on `creek/save/`.
+- `docs/save.md` (new) documents the command and the tier rules.
+
+## References
+
+- Source candidate: ADOPT-003.
+- FEAT-014/015 (CrawDad will dispatch `/crawdad save` intents through MCP to this primitive).
+- Existing models being written: `Thread`, `Eddy`, `Praxis` in `creek/models.py`.
+- Privacy-tier system: `creek/classify/privacy.py` and `creek/classify/privacy_filter.py`.

--- a/plans/git-issues/FEAT-010-mcp-server-skeleton-read-tools.md
+++ b/plans/git-issues/FEAT-010-mcp-server-skeleton-read-tools.md
@@ -1,0 +1,62 @@
+# FEAT-010: MCP server skeleton + read tools
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~500
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADAPT-004-mcp-server-as-interface.md`](../2026-05-05_comparative-analysis/candidates/ADAPT-004-mcp-server-as-interface.md) (part 1 of 3)
+**Dependencies:** FEAT-006/007 (`creek state`), FEAT-008 (`creek lint`), FEAT-004 (compiled-layer-aware `mine`/`draft`)
+**Parallelizable with peers:** no (FEAT-011 and FEAT-012 extend this)
+**Wave:** 4
+
+## Goal
+
+Stand up a `creek-tools-mcp` server that exposes the existing read-only CLI surface as MCP tools. Both CrawDad (FEAT-013+) and the developer's Claude Code consume the same surface. Privacy-tier ceiling enforcement happens at the MCP boundary, not as a downstream check.
+
+## Files to touch
+
+- `creek-tools/creek_mcp/__init__.py` (new package, sibling to `creek/`).
+- `creek-tools/creek_mcp/server.py` (new) — MCP server bootstrap; uses the official `mcp` Python SDK.
+- `creek-tools/creek_mcp/tools/state.py` (new) — wraps `creek state`.
+- `creek-tools/creek_mcp/tools/lint.py` (new) — wraps `creek lint`.
+- `creek-tools/creek_mcp/tools/mine.py` (new) — wraps `creek mine`.
+- `creek-tools/creek_mcp/tools/draft.py` (new) — wraps `creek draft`.
+- `creek-tools/creek_mcp/tools/state_read.py` (new) — `creek.state.read` returns the latest `00-Creek-Meta/State/latest.md` content (cheap, no re-render).
+- `creek-tools/creek_mcp/tier_ceiling.py` (new) — privacy-tier enforcement helper used by every read tool.
+- `creek-tools/pyproject.toml` — add `mcp` dependency, declare `creek-tools-mcp` entry point: `creek-tools-mcp = "creek_mcp.server:main"`.
+- `creek-tools/tests/test_mcp_server.py` (new) — server bootstrap test + per-tool integration tests.
+- `creek-tools/docs/mcp.md` (new) — registration instructions for Claude Code, Claude Desktop, and CrawDad.
+
+## Pre-decided choices
+
+- **MCP SDK:** the official Anthropic Python `mcp` library (whatever the current pinned version supports for stdio transport). Stdio transport, not HTTP, for v1.0.
+- **Tool naming:** lowercase dot-namespaced — `creek.state.read`, `creek.lint`, `creek.mine`, `creek.draft`, `creek.state.render` (the expensive re-render version). One-to-one with CLI commands; this becomes CrawDad's `intents` schema (FEAT-014).
+- **Privacy-tier ceiling parameter:** every read tool takes a required `privacy_tier_ceiling` parameter (`open` | `personal` | `intimate` | `all`). Default is `open`. Returning content above the ceiling is impossible by construction; the tool returns title-only or refuses with a structured error.
+- **Read tools in this FEAT:** `creek.state.read`, `creek.state.render`, `creek.lint`, `creek.mine`, `creek.draft`. Write tools (save, ingest, classify, link, report, skills) land in FEAT-011. Purge tools land in FEAT-012.
+- **Audit log writes per tool call:** every MCP invocation appends to `00-Creek-Meta/audit/mcp.jsonl` — `{tool, args_summary, tier_ceiling, consumer, timestamp}`. Args-summary, not full args, to avoid leaking content into the audit log.
+- **Tool input schemas:** documented JSON Schema per tool, generated from Pydantic models that wrap the CLI argument structure.
+
+## Test plan
+
+- Unit per tool wrapper.
+- Integration: bootstrap the server via stdio in a subprocess, send a `tools/list` MCP message, verify the expected tools appear.
+- Integration: call `creek.state.read` with `privacy_tier_ceiling=open` against a fixture vault containing `intimate` fragments — verify the response is title-only for those fragments.
+- Regression: a tool call with `privacy_tier_ceiling=open` and a fragment tier of `intimate` returns the documented refusal status (not silent content leak).
+- Regression: every tool call writes an audit log entry to `00-Creek-Meta/audit/mcp.jsonl`.
+- Regression: the audit log entries contain `args_summary`, not full args (verified by an explicit "no full body in audit log" test against an `intimate`-tier draft request).
+
+## Acceptance criteria
+
+- `creek-tools-mcp` server starts via `python -m creek_mcp.server` or the entry point.
+- Five read tools exposed and callable via the MCP protocol.
+- `privacy_tier_ceiling` parameter is required on every read tool; tier-violations refuse rather than leak.
+- Audit log writes happen on every tool call, with args-summary not full args.
+- A registration recipe exists in `docs/mcp.md` for Claude Code (and notes that Claude Desktop / Cursor use the same `mcp.json`).
+- ≥90% branch coverage on `creek_mcp/`.
+
+## References
+
+- Source candidate: ADAPT-004 (especially the privacy-by-construction enforcement at the MCP boundary).
+- FEAT-014 (CrawDad's Haiku router consumes this server's tool registry as its `intents` schema).
+- AlfredOS's Jig framing (MCP-as-capability-surface) is the prior art.
+- Anthropic Python `mcp` SDK reference.

--- a/plans/git-issues/FEAT-010-mcp-server-skeleton-read-tools.md
+++ b/plans/git-issues/FEAT-010-mcp-server-skeleton-read-tools.md
@@ -34,6 +34,7 @@ Stand up a `creek-tools-mcp` server that exposes the existing read-only CLI surf
 - **Privacy-tier ceiling parameter:** every read tool takes a required `privacy_tier_ceiling` parameter (`open` | `personal` | `intimate` | `all`). Default is `open`. Returning content above the ceiling is impossible by construction; the tool returns title-only or refuses with a structured error.
 - **Read tools in this FEAT:** `creek.state.read`, `creek.state.render`, `creek.lint`, `creek.mine`, `creek.draft`. Write tools (save, ingest, classify, link, report, skills) land in FEAT-011. Purge tools land in FEAT-012.
 - **Audit log writes per tool call:** every MCP invocation appends to `00-Creek-Meta/audit/mcp.jsonl` — `{tool, args_summary, tier_ceiling, consumer, timestamp}`. Args-summary, not full args, to avoid leaking content into the audit log.
+- **Audit log lives in its own module from day 1.** Create `creek_mcp/audit.py` in this FEAT (not inline in `server.py`). FEAT-011 adds the write-side fields and FEAT-012 hardens it (hash chain + flock). Putting the module boundary in place now avoids a refactor pass during FEAT-012. The day-1 implementation in this FEAT can be a simple JSONL appender; the hardening is additive.
 - **Tool input schemas:** documented JSON Schema per tool, generated from Pydantic models that wrap the CLI argument structure.
 
 ## Test plan

--- a/plans/git-issues/FEAT-011-mcp-write-tools-tier-enforcement.md
+++ b/plans/git-issues/FEAT-011-mcp-write-tools-tier-enforcement.md
@@ -1,0 +1,59 @@
+# FEAT-011: MCP write tools + tier-ceiling enforcement
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~500
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADAPT-004-mcp-server-as-interface.md`](../2026-05-05_comparative-analysis/candidates/ADAPT-004-mcp-server-as-interface.md) (part 2 of 3)
+**Dependencies:** FEAT-010 (server skeleton + tier-ceiling helper), FEAT-009 (`creek save` is the most-used write tool)
+**Parallelizable with peers:** no (FEAT-012 extends this)
+**Wave:** 4
+
+## Goal
+
+Add the write-side MCP tools — `creek.save`, `creek.ingest`, `creek.classify`, `creek.link`, `creek.report`, `creek.skills.refresh`, `creek.compile` — with the same tier-ceiling enforcement and audit logging as the read tools.
+
+## Files to touch
+
+- `creek-tools/creek_mcp/tools/save.py` (new) — wraps `creek save` (FEAT-009).
+- `creek-tools/creek_mcp/tools/ingest.py` (new) — wraps `creek ingest`.
+- `creek-tools/creek_mcp/tools/classify.py` (new) — wraps `creek classify`.
+- `creek-tools/creek_mcp/tools/link.py` (new) — wraps `creek link`.
+- `creek-tools/creek_mcp/tools/report.py` (new) — wraps `creek report`.
+- `creek-tools/creek_mcp/tools/skills.py` (new) — wraps `creek skills`.
+- `creek-tools/creek_mcp/tools/compile.py` (new) — wraps `creek compile` (FEAT-003).
+- `creek-tools/creek_mcp/server.py` — register the new tools.
+- `creek-tools/creek_mcp/tier_ceiling.py` — extend with write-side tier rules (writes that would create higher-tier content require explicit confirmation).
+- `creek-tools/tests/test_mcp_write_tools.py` (new).
+- `creek-tools/docs/mcp.md` — extend with write-tool documentation.
+
+## Pre-decided choices
+
+- **`creek.save` is the priority write tool** — CrawDad's answer-filing-back loop (FEAT-014/015) depends on it.
+- **Write-side tier-ceiling rule:** a write tool that *would create* a fragment / compiled page at tier `T` requires the caller's `privacy_tier_ceiling >= T`. A caller with `privacy_tier_ceiling=open` cannot create `intimate` content via MCP.
+- **Default tier for write tools:** matches the source. `creek.save` honours the source fragments' tier; `creek.ingest` uses the ingestor's default tier (typically `personal`).
+- **`creek.skills.refresh` is read-only** as far as user content goes — it regenerates the voice-skill tree from existing fragments. Treated as a write tool only because it produces new files.
+- **Audit log richness for writes:** in addition to the read-tool audit fields, write tools also log `created_path`, `created_tier`, and `affected_fragment_ids` (a list, not full bodies).
+
+## Test plan
+
+- Unit per tool wrapper.
+- Integration: each write tool callable via MCP against a fixture vault produces the expected vault state change.
+- Regression: `creek.save` with `privacy_tier_ceiling=open` and a body that classifies as `intimate` is refused with a structured error, not silently downgraded.
+- Regression: every write-tool invocation writes an audit log entry with the write-side fields.
+- Regression: re-invoking `creek.compile` (idempotent per FEAT-003) doesn't double-write audit entries on no-op runs.
+
+## Acceptance criteria
+
+- Seven write tools exposed and callable.
+- Write-side tier-ceiling rule enforced and tested.
+- Audit log entries for writes include `created_path`, `created_tier`, `affected_fragment_ids`.
+- ≥90% branch coverage on the new tool modules.
+- `docs/mcp.md` documents each write tool's input schema and tier rules.
+
+## References
+
+- Source candidate: ADAPT-004 (write-side tier enforcement is part of "privacy-by-construction at the MCP boundary").
+- FEAT-009 (`creek save` is the underlying primitive for `creek.save`).
+- FEAT-003 (`creek compile` is the underlying primitive for `creek.compile`).
+- FEAT-010 (the server + tier-ceiling helper this builds on).

--- a/plans/git-issues/FEAT-012-mcp-purge-tools-elevated-auth.md
+++ b/plans/git-issues/FEAT-012-mcp-purge-tools-elevated-auth.md
@@ -26,6 +26,7 @@ Expose the `creek purge.*` family via MCP behind an elevated-authorization gate 
 ## Pre-decided choices
 
 - **Elevated-auth mechanism:** environment variable `CREEK_MCP_ELEVATED_TOKEN` set at server startup. Requests that include matching `Authorization: Bearer <token>` (or MCP-equivalent metadata field) can call purge tools. Without the token, every purge tool returns a structured refusal.
+- **Token comparison uses `hmac.compare_digest`**, not `==`. Plain string equality is vulnerable to timing-based token inference; `compare_digest` is constant-time. Wire it correctly from day one.
 - **CrawDad does not get the token.** The Discord bot's MCP client connects with no `Authorization` header; purge calls fail-closed.
 - **The developer's Claude Code can be configured with the token.** Documented in `docs/mcp.md` as the deliberate setup step for destructive ops.
 - **`creek purge vault` requires *both* the token and a confirmation parameter** (`confirm_vault_path: <absolute-path>`). Mirrors the existing CLI behaviour (which prompts for the absolute vault path interactively).
@@ -49,6 +50,7 @@ Expose the `creek purge.*` family via MCP behind an elevated-authorization gate 
 - Concurrent-write safety is tested.
 - `docs/mcp.md` documents the elevated-auth model with explicit "do not give this token to CrawDad" guidance.
 - ≥90% branch coverage on `creek_mcp/{auth,audit,tools/purge}.py`.
+- `creek_mcp/auth.py` uses `hmac.compare_digest(expected, actual)` — not `==`. Verified by a unit test that asserts plain `==` is *not* used in the hot path (e.g., a static check or a compare-call interceptor).
 
 ## References
 

--- a/plans/git-issues/FEAT-012-mcp-purge-tools-elevated-auth.md
+++ b/plans/git-issues/FEAT-012-mcp-purge-tools-elevated-auth.md
@@ -1,0 +1,58 @@
+# FEAT-012: MCP purge tools + elevated authorization + audit hardening
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~400
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADAPT-004-mcp-server-as-interface.md`](../2026-05-05_comparative-analysis/candidates/ADAPT-004-mcp-server-as-interface.md) (part 3 of 3)
+**Dependencies:** FEAT-010, FEAT-011
+**Parallelizable with peers:** no
+**Wave:** 4 (closes the MCP wave)
+
+## Goal
+
+Expose the `creek purge.*` family via MCP behind an elevated-authorization gate so that CrawDad cannot accidentally purge while the developer's Claude Code can. Harden the MCP audit log (tamper-evident, append-only, locking).
+
+## Files to touch
+
+- `creek-tools/creek_mcp/tools/purge.py` (new) — wraps `creek purge fragment`, `creek purge source`, `creek purge classifications`, `creek purge daterange`, `creek purge vault`.
+- `creek-tools/creek_mcp/auth.py` (new) — elevated-auth checker; reads `CREEK_MCP_ELEVATED_TOKEN` from env and matches against the request's `Authorization` header (or MCP-equivalent metadata).
+- `creek-tools/creek_mcp/audit.py` (new — was inline in FEAT-010/011, now factored out) — tamper-evident JSONL writer with hash chaining and an exclusive-lock during write.
+- `creek-tools/creek_mcp/server.py` — wire purge tools and elevated-auth check.
+- `creek-tools/tests/test_mcp_purge.py` (new).
+- `creek-tools/tests/test_mcp_audit.py` (new) — verifies tamper-evidence and locking.
+- `creek-tools/docs/mcp.md` — document the elevated-auth model and how to provision the token.
+
+## Pre-decided choices
+
+- **Elevated-auth mechanism:** environment variable `CREEK_MCP_ELEVATED_TOKEN` set at server startup. Requests that include matching `Authorization: Bearer <token>` (or MCP-equivalent metadata field) can call purge tools. Without the token, every purge tool returns a structured refusal.
+- **CrawDad does not get the token.** The Discord bot's MCP client connects with no `Authorization` header; purge calls fail-closed.
+- **The developer's Claude Code can be configured with the token.** Documented in `docs/mcp.md` as the deliberate setup step for destructive ops.
+- **`creek purge vault` requires *both* the token and a confirmation parameter** (`confirm_vault_path: <absolute-path>`). Mirrors the existing CLI behaviour (which prompts for the absolute vault path interactively).
+- **Audit log hardening:** each entry is a JSON object with `prev_hash` (SHA-256 of the previous entry's content) and `entry_hash`. Tampering breaks the chain. An exclusive `flock` during writes prevents concurrent corruption. (This solves SEC-005 for the MCP audit log specifically; the broader audit log work in SEC-005 is separate.)
+
+## Test plan
+
+- Unit: `creek_mcp.auth.is_elevated(request)` returns `True` only when the env token matches the request token.
+- Integration: a purge tool call without the elevated token returns the documented refusal.
+- Integration: `creek.purge.vault` without `confirm_vault_path` is refused even with the token.
+- Regression: tampering with a JSONL entry breaks the next-entry hash check (verified by mutating a fixture and asserting the verifier flags it).
+- Regression: concurrent write attempts from two processes don't corrupt the log (uses `pytest-flaky` or a small subprocess fixture).
+- Regression: CrawDad's MCP client (no token) cannot purge anything — verified end-to-end against a fixture vault.
+
+## Acceptance criteria
+
+- All five `creek.purge.*` tools exposed and gated by the elevated-auth check.
+- Without the token, every purge call returns a structured refusal — never a silent partial purge.
+- `creek.purge.vault` requires both token and `confirm_vault_path`.
+- Audit log entries have `prev_hash` / `entry_hash`; a verifier function exists and is exercised by tests.
+- Concurrent-write safety is tested.
+- `docs/mcp.md` documents the elevated-auth model with explicit "do not give this token to CrawDad" guidance.
+- ≥90% branch coverage on `creek_mcp/{auth,audit,tools/purge}.py`.
+
+## References
+
+- Source candidate: ADAPT-004 (elevated-authorization is the named adaptation for destructive ops).
+- Existing CLI purge: `creek/purge/` and `creek-tools/docs/cleaning-and-purge.md`.
+- Existing MCP audit log: created in FEAT-010, hardened here.
+- Related issue: SEC-005 (broader audit-log integrity work for the non-MCP audit logs).

--- a/plans/git-issues/FEAT-013-crawdad-discord-bot-skeleton-mcp-client.md
+++ b/plans/git-issues/FEAT-013-crawdad-discord-bot-skeleton-mcp-client.md
@@ -53,6 +53,7 @@ Stand up the CrawDad project as a sibling to `creek-tools/` — a Discord bot th
 - `load_session_state` reads `latest.md` at session start.
 - Allowlist is enforced — non-allowlisted users get no response.
 - Quality bar mirrors `creek-tools/`: ≥90% branch coverage on the new code, MyPy strict clean, Ruff zero violations, conventional commits.
+- **MCP subprocess resilience:** if the `creek-tools-mcp` subprocess exits or stops responding, the bot does *not* exit. It posts a graceful error reply to the active Discord channel ("creek-tools is unreachable; try again in a moment") and attempts a single restart with exponential backoff (capped at 3 retries / 30s) before staying disconnected and surfacing a status command response. Verified by a regression test that kills the subprocess mid-tool-call and asserts the bot keeps running.
 - `crawdad/CLAUDE.md` and `crawdad/README.md` exist.
 
 ## References

--- a/plans/git-issues/FEAT-013-crawdad-discord-bot-skeleton-mcp-client.md
+++ b/plans/git-issues/FEAT-013-crawdad-discord-bot-skeleton-mcp-client.md
@@ -1,0 +1,64 @@
+# FEAT-013: CrawDad — Discord bot skeleton + MCP client wiring
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~450
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-008-haiku-router-sonnet-composer.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-008-haiku-router-sonnet-composer.md) (part 1 of 3)
+**Dependencies:** FEAT-010, FEAT-011, FEAT-012 (the MCP surface CrawDad consumes)
+**Parallelizable with peers:** no (FEAT-014 and FEAT-015 extend this)
+**Wave:** 5 (CrawDad v1.0)
+
+## Goal
+
+Stand up the CrawDad project as a sibling to `creek-tools/` — a Discord bot that connects to the creek-tools MCP server and reads `00-Creek-Meta/State/latest.md` at session start. No agent loop yet; this PR is the wiring scaffold.
+
+## Files to touch
+
+- `crawdad/` (new top-level directory, sibling to `creek-tools/`).
+- `crawdad/pyproject.toml` (new) — Python ≥3.11, deps: `discord.py`, `mcp` (Anthropic SDK), `anthropic`, `pydantic`, `pyyaml`.
+- `crawdad/crawdad/__init__.py` (new).
+- `crawdad/crawdad/bot.py` (new) — `discord.py` Client subclass with on-message + on-ready handlers.
+- `crawdad/crawdad/mcp_client.py` (new) — async MCP client wrapper around the Anthropic `mcp` SDK; connects to `creek-tools-mcp` over stdio.
+- `crawdad/crawdad/state.py` (new) — `load_session_state()` reads `<vault>/00-Creek-Meta/State/latest.md` once at session start (Graphify-style PreToolUse pattern).
+- `crawdad/crawdad/config.py` (new) — Pydantic config: Discord token, Anthropic API key, vault path, MCP server command, allowed user IDs, allowed channel IDs.
+- `crawdad/crawdad/cli.py` (new) — `crawdad run` entry point.
+- `crawdad/CLAUDE.md` (new) — project standards (mirrors `creek-tools/CLAUDE.md`'s quality bar at a smaller scale).
+- `crawdad/README.md` (new).
+- `crawdad/scripts/check-all.sh` (new) — same gate structure as creek-tools.
+- `crawdad/tests/test_bot.py`, `tests/test_mcp_client.py`, `tests/test_state.py` (new).
+
+## Pre-decided choices
+
+- **Project location:** new top-level `crawdad/` directory (sibling to `creek-tools/`). Not nested under creek-tools because it's a separate deployable.
+- **Discord library:** `discord.py` (de facto standard, async, well-maintained).
+- **MCP transport:** stdio (matches FEAT-010's server). The MCP server runs as a subprocess of CrawDad in v1.0; Hostinger VPS deployment topology is out of scope (separate prompt, per the comparative-analysis framing).
+- **Config:** environment variables + a `crawdad.yaml` file. Discord token and Anthropic API key only via env (`DISCORD_BOT_TOKEN`, `ANTHROPIC_API_KEY`).
+- **Allowlist:** v1.0 hard-codes a single allowed Discord user ID (the developer's) and an allowed channel list. Multi-user is deferred to v1.3+ (per the personal-use framing).
+- **Session boundaries:** one Discord conversation = one CrawDad session. Session state (loaded `state.md` content) is held in memory for the session; FEAT-015's loop reuses it.
+- **Session-state load is read-only and cheap:** just a file read + parse; no MCP call needed for the initial load. The MCP server's `creek.state.read` tool is for *re-reads* mid-session.
+
+## Test plan
+
+- Unit: `MCPClient.connect()` against a fixture stdio server completes and exposes a `list_tools()` method.
+- Unit: `load_session_state(vault_path)` against a fixture `latest.md` returns a structured model with the wavelength snapshot, eddies, threads, and suggested questions.
+- Integration: `crawdad run` boots, connects to a fixture MCP server, posts a "hello" reply when DM'd by an allowlisted user, and refuses non-allowlisted users.
+- Regression: a non-allowlisted user gets no response (not even a refusal — silent ignore, per personal-use scoping).
+- Regression: missing `latest.md` is handled gracefully (CrawDad replies with "no audit report yet — run `creek state`" rather than crashing).
+
+## Acceptance criteria
+
+- `crawdad/` package exists with the documented structure.
+- `crawdad run` boots, connects to creek-tools MCP, and handles allowlisted Discord messages with a stub reply.
+- `load_session_state` reads `latest.md` at session start.
+- Allowlist is enforced — non-allowlisted users get no response.
+- Quality bar mirrors `creek-tools/`: ≥90% branch coverage on the new code, MyPy strict clean, Ruff zero violations, conventional commits.
+- `crawdad/CLAUDE.md` and `crawdad/README.md` exist.
+
+## References
+
+- Source candidate: ADOPT-008 (the agent loop these next FEATs build on).
+- FEAT-014 (Haiku router + dispatcher).
+- FEAT-015 (Sonnet composer + 5-round loop).
+- FEAT-010 (the MCP server CrawDad connects to).
+- INTEGRATION-PLAN.md "CrawDad design implications" section.

--- a/plans/git-issues/FEAT-014-crawdad-haiku-router-dispatcher.md
+++ b/plans/git-issues/FEAT-014-crawdad-haiku-router-dispatcher.md
@@ -24,7 +24,7 @@ Add the Haiku-driven intent extraction step to CrawDad's agent loop. Given a use
 
 ## Pre-decided choices
 
-- **Router model:** `claude-haiku-4-5-20251001` (matches creek-tools defaults documented in `creek-tools/docs/classification.md`).
+- **Router model:** read from `crawdad/crawdad/config.py:DEFAULT_ROUTER_MODEL`, which itself reads from `CRAWDAD_ROUTER_MODEL` env var with a fallback to whatever Haiku model `creek-tools/docs/classification.md` documents as current at implementation time. Do *not* hard-code the literal model ID string in agent code — model IDs move (today: `claude-haiku-4-5-20251001`; the constant is the contract, not the literal). Verified by a test that asserts no module under `crawdad/crawdad/` references a model ID string outside `config.py`.
 - **History truncation:** last 20 entries, each truncated to 2000 chars. Hard cliff per ADOPT-008; FEAT-016 refines this with smarter compression if needed.
 - **Intents schema:** generated from the MCP server's `tools/list` response so the router prompt always reflects the current tool surface. Regenerated at CrawDad startup; cached for the session.
 - **Router prompt structure:**

--- a/plans/git-issues/FEAT-014-crawdad-haiku-router-dispatcher.md
+++ b/plans/git-issues/FEAT-014-crawdad-haiku-router-dispatcher.md
@@ -1,0 +1,60 @@
+# FEAT-014: CrawDad — Haiku router + tool dispatcher
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~450
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-008-haiku-router-sonnet-composer.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-008-haiku-router-sonnet-composer.md) (part 2 of 3)
+**Dependencies:** FEAT-013
+**Parallelizable with peers:** no (FEAT-015 extends this)
+**Wave:** 5
+
+## Goal
+
+Add the Haiku-driven intent extraction step to CrawDad's agent loop. Given a user message + recent conversation history + the loaded session state, Haiku emits a JSON `intents` array; the dispatcher invokes the matching MCP tools.
+
+## Files to touch
+
+- `crawdad/crawdad/router.py` (new) — Haiku call + JSON parsing + schema validation.
+- `crawdad/crawdad/dispatcher.py` (new) — maps `intent.type` → MCP tool call.
+- `crawdad/crawdad/intents.py` (new) — Pydantic schema generated from the MCP server's tool registry (so router prompt + dispatcher stay in sync with FEAT-010/011/012).
+- `crawdad/crawdad/history.py` (new) — episodic-memory-lite: in-memory deque of last 20 conversation entries, each truncated to 2000 chars.
+- `crawdad/crawdad/bot.py` — wire the router + dispatcher into the message handler (no Sonnet composer yet; FEAT-015 closes the loop).
+- `crawdad/tests/test_router.py`, `tests/test_dispatcher.py`, `tests/test_intents.py`, `tests/test_history.py` (new).
+
+## Pre-decided choices
+
+- **Router model:** `claude-haiku-4-5-20251001` (matches creek-tools defaults documented in `creek-tools/docs/classification.md`).
+- **History truncation:** last 20 entries, each truncated to 2000 chars. Hard cliff per ADOPT-008; FEAT-016 refines this with smarter compression if needed.
+- **Intents schema:** generated from the MCP server's `tools/list` response so the router prompt always reflects the current tool surface. Regenerated at CrawDad startup; cached for the session.
+- **Router prompt structure:**
+  - Role: "Intent-extraction router for the CrawDad spiritual companion."
+  - Context: current wavelength snapshot (from session state), last 20 truncated history entries, the available `intents` schema.
+  - Output: strict JSON `{ intents: [ { type, ...args } ] }` with no prose.
+- **Wavelength-aware intent biasing:** the router prompt explicitly instructs Haiku to prefer phase-appropriate intents (don't suggest `mine`/`draft` during Bottoming Out; prefer `surface_paradox`/`compost`).
+- **Per-intent privacy_tier:** every intent payload carries a `privacy_tier_ceiling` field; defaults to the user's session-default tier (currently `open` for the developer; configurable per-channel in v1.1).
+- **No Sonnet call in this PR.** The dispatcher returns tool results to the bot handler, which posts them to Discord as a structured (boring) summary. FEAT-015 swaps that summary for Sonnet composition.
+
+## Test plan
+
+- Unit: `router.extract_intents(message, history, state)` against a fixture message returns a structured `IntentsArray`.
+- Unit: `dispatcher.dispatch(intent)` calls the right MCP tool with the right args.
+- Unit: `history.append(...)` enforces the 20-entry / 2000-char-per-entry truncation.
+- Integration: a Discord DM "what's surfacing this week?" produces a `{ type: "creek.state.read" }` intent and the dispatcher returns the latest state content.
+- Regression: a malformed Haiku response (non-JSON, missing `intents` key) is caught and surfaces a structured error to the user, not a crash.
+- Regression: an intent with an unknown `type` is rejected by the dispatcher with a clear error.
+- Regression: phase-aware bias — given a Bottoming Out wavelength snapshot, Haiku does *not* emit `creek.draft` intents (verified with a recorded LLM response fixture, since live LLM tests are flaky).
+
+## Acceptance criteria
+
+- `crawdad run` handles a Discord message via Haiku → dispatcher → tool call → boring structured reply.
+- `intents` schema is generated from the MCP tool registry at startup.
+- History truncation is enforced (verified by test).
+- Wavelength-aware bias is documented in the router prompt and verified by a fixture-based regression test.
+- ≥90% branch coverage.
+
+## References
+
+- Source candidate: ADOPT-008 (especially the `intents`-array JSON schema and the cost-shape rationale).
+- Dontoh's Alfred (`plans/2026-05-05_comparative-analysis/systems/alfred-dontoh.md`) for the original two-LLM split.
+- FEAT-010/011/012 (the MCP server whose tool registry becomes the intents schema).

--- a/plans/git-issues/FEAT-015-crawdad-sonnet-composer-loop.md
+++ b/plans/git-issues/FEAT-015-crawdad-sonnet-composer-loop.md
@@ -1,0 +1,62 @@
+# FEAT-015: CrawDad — Sonnet composer + 5-round loop + voice-skill activation
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~450
+**Estimated complexity:** M
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADOPT-008-haiku-router-sonnet-composer.md`](../2026-05-05_comparative-analysis/candidates/ADOPT-008-haiku-router-sonnet-composer.md) (part 3 of 3)
+**Dependencies:** FEAT-014
+**Parallelizable with peers:** no
+**Wave:** 5 (closes CrawDad v1.0)
+
+## Goal
+
+Replace FEAT-014's "boring structured reply" with the Sonnet composer step. Wrap the whole thing in the 5-round loop. Activate the voice-skill tree (`<vault>/creek-skills/`) for prose composition so CrawDad's replies sound like Geoff.
+
+## Files to touch
+
+- `crawdad/crawdad/composer.py` (new) — Sonnet call that takes the user message, tool results, history, and wavelength snapshot, and returns a voice-faithful reply.
+- `crawdad/crawdad/skill_loader.py` (new) — loads `<vault>/creek-skills/voice-core/SKILL.md` plus phase- and register-specific skills based on the session state.
+- `crawdad/crawdad/loop.py` (new) — orchestrates router → dispatch → (decide-to-loop-or-compose) → composer, capped at 5 rounds.
+- `crawdad/crawdad/bot.py` — replace the structured-reply path with `loop.run(message)`.
+- `crawdad/tests/test_composer.py`, `tests/test_skill_loader.py`, `tests/test_loop.py` (new).
+
+## Pre-decided choices
+
+- **Composer model:** `claude-sonnet-4-6` (matches creek-tools defaults).
+- **5-round cap:** hard. After 5 rounds without a final composer call, CrawDad replies with "I went too deep on this — let's back up. Can you reframe?" and resets the session state.
+- **Loop termination signal:** the router returns `{ intents: [], compose: true }` to signal "no more tool calls; compose the reply now." Otherwise the loop continues.
+- **Voice-skill activation per session:** at session start, load `voice-core/SKILL.md` always; load the phase skill matching the current wavelength snapshot; load the `confessional` register by default (the LTM reflective register). The router can request additional registers via an `activate_register` intent.
+- **Voice-fidelity-vs-loop split:** the composer in this loop handles *Discord conversation*. `creek.draft` (called as a tool) is what generates *essays* — the draft has its own LLM call inside `creek-tools` with its own skill-stack assembly. This FEAT does *not* re-implement draft composition; it wraps `creek.draft`'s output in conversational framing.
+- **Behavioural commitments (per INTEGRATION-PLAN.md "Conversational chat" section):**
+  - Phase-aware: composer prompt includes the current wavelength phase + dosage. Don't urge high-energy action during Bottoming Out.
+  - Paradox-tolerant: when tool results include a paradox surfacing, the composer names the paradox and routes to `10-Liminal/Paradoxes/` via `creek.save` (a tool call inside the loop). It never proposes resolution.
+  - Voice-faithful: composer always conditions on `voice-core/SKILL.md` plus the loaded register.
+
+## Test plan
+
+- Unit: `composer.compose(...)` against a fixture (recorded Sonnet response) returns the documented structured response.
+- Unit: `skill_loader.load_for_session(state)` returns the right skill files for a Bottoming Out session vs. a Rising session.
+- Unit: `loop.run(message)` against fixtures with 1, 3, and 5 rounds terminates correctly each time.
+- Regression: a 6th round attempt is refused with the documented user message.
+- Regression: when tool results include a paradox, the composer's reply names it and triggers a `creek.save --target paradox` tool call within the same loop.
+- Regression: composer never calls `creek.draft` directly — `creek.draft` is always invoked as an MCP tool, never inlined into composer prompts. Voice fidelity for drafts is owned by `creek-tools`, not by CrawDad.
+- End-to-end: a real-ish Discord conversation (using a record/replay LLM fixture) produces a voice-faithful reply that activates the expected skill stack.
+
+## Acceptance criteria
+
+- Sonnet composer is wired into the 5-round loop.
+- Voice-skill loader activates the right skills for the session.
+- 5-round cap is hard-enforced.
+- Phase-aware, paradox-tolerant, voice-faithful behaviours are verified by regression tests.
+- `creek.draft` is never inlined into composer prompts (verified by test that grep-checks composer prompt construction).
+- ≥90% branch coverage.
+- A documented record/replay test fixture exists for end-to-end behaviour.
+
+## References
+
+- Source candidate: ADOPT-008.
+- INTEGRATION-PLAN.md "Voice fidelity through the stack" — this FEAT is the conversational gate.
+- FEAT-014 (the router this completes).
+- FEAT-016 (slash commands wrap this loop with explicit-trigger entry points).
+- Voice-skill tree: produced by `creek skills` (in creek-tools) and read here.

--- a/plans/git-issues/FEAT-015-crawdad-sonnet-composer-loop.md
+++ b/plans/git-issues/FEAT-015-crawdad-sonnet-composer-loop.md
@@ -23,7 +23,7 @@ Replace FEAT-014's "boring structured reply" with the Sonnet composer step. Wrap
 
 ## Pre-decided choices
 
-- **Composer model:** `claude-sonnet-4-6` (matches creek-tools defaults).
+- **Composer model:** read from `crawdad/crawdad/config.py:DEFAULT_COMPOSER_MODEL` (with `CRAWDAD_COMPOSER_MODEL` env override), same indirection pattern as FEAT-014's router model. Today's default is the Sonnet model documented in `creek-tools/docs/classification.md` (`claude-sonnet-4-6` at the time of writing); the constant is the contract, not the literal ID. Same no-literal-IDs-outside-config test applies.
 - **5-round cap:** hard. After 5 rounds without a final composer call, CrawDad replies with "I went too deep on this — let's back up. Can you reframe?" and resets the session state.
 - **Loop termination signal:** the router returns `{ intents: [], compose: true }` to signal "no more tool calls; compose the reply now." Otherwise the loop continues.
 - **Voice-skill activation per session:** at session start, load `voice-core/SKILL.md` always; load the phase skill matching the current wavelength snapshot; load the `confessional` register by default (the LTM reflective register). The router can request additional registers via an `activate_register` intent.

--- a/plans/git-issues/FEAT-016-slash-command-grammar.md
+++ b/plans/git-issues/FEAT-016-slash-command-grammar.md
@@ -1,0 +1,63 @@
+# FEAT-016: `/creek` (Claude Code) and `/crawdad` (Discord) slash-command grammars
+
+**Severity:** High (v1.0)
+**Category:** FEAT
+**Estimated LOC:** ~400
+**Estimated complexity:** S
+**Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADAPT-007-slash-command-grammar.md`](../2026-05-05_comparative-analysis/candidates/ADAPT-007-slash-command-grammar.md)
+**Dependencies:** FEAT-010/011/012 (MCP server), FEAT-015 (CrawDad loop)
+**Parallelizable with peers:** no (closes the v1.0 work)
+**Wave:** 5
+
+## Goal
+
+Two small surfaces with a consistent grammar, both invoking the same MCP tools so Discord and Claude Code feel like one system from two front doors.
+
+## Files to touch
+
+- `creek-tools/.claude/commands/` (new directory) — one `*.md` slash command per `/creek <subcommand>`. These are Claude Code skill commands.
+- `creek-tools/.claude/commands/creek.md` (new) — root help; default action is render `creek state`.
+- `creek-tools/.claude/commands/{state,lint,mine,draft,save,explain,phase,wavelength,skills,ingest}.md` (new) — one per command.
+- `creek-tools/docs/slash-commands.md` (new) — documents the `/creek` family.
+- `crawdad/crawdad/slash_commands.py` (new) — Discord slash-command registration for the six `/crawdad` commands.
+- `crawdad/crawdad/bot.py` — register slash commands at startup; route to existing handlers.
+- `crawdad/tests/test_slash_commands.py` (new).
+- `crawdad/README.md` — document the six commands.
+
+## Pre-decided choices
+
+- **Slash-command surface (small on purpose):**
+  - `/creek state | lint | mine | draft | save | explain | phase | wavelength | skills | ingest` (~10 for the developer's Claude Code).
+  - `/crawdad reflect | checkin | surface | draft | save | workflow` (6 for Discord).
+- **Default action:**
+  - `/creek` (no args) → `creek state`.
+  - `/crawdad` (no args) → opens reflective conversation mode (FEAT-015's loop with no preselected intents).
+- **All slash commands invoke MCP tools, not subprocess CLI calls.** This keeps Discord, Claude Code, and any future client on one tool surface.
+- **Help discoverable from any prefix:** `/creek help`, `/creek mine help`, `/crawdad help` all return scoped help.
+- **Discord-specific formatting:** Discord doesn't render markdown link footnotes well, so `/crawdad` commands return code blocks for structured data and bullet lists for prose summaries. No tables.
+- **`/crawdad workflow` is a stub in v1.0** — it advertises the workflow DSL coming in v1.1 (ADAPT-003) but only supports `/crawdad workflow list` (returns "no workflows yet — coming in v1.1") in this PR. Full implementation lands with the v1.1 workflow DSL FEAT.
+
+## Test plan
+
+- Unit: each `/creek <cmd>` command file is valid Claude Code skill markdown (frontmatter parses).
+- Unit: each `/crawdad <cmd>` registration succeeds against a mocked Discord client.
+- Integration: invoking `/creek state` from a Claude Code session against a fixture vault returns the rendered audit report.
+- Integration: invoking `/crawdad surface` from a Discord client (mocked) triggers the same MCP `creek.state.read` tool that the conversational mode would.
+- Regression: `/crawdad <unknown>` returns a help message naming the six valid commands, not a stack trace.
+
+## Acceptance criteria
+
+- 10 `/creek` slash commands exist as Claude Code skill files in `creek-tools/.claude/commands/`.
+- 6 `/crawdad` slash commands registered with Discord and routed through MCP.
+- Default actions documented and working (no-arg invocation does something useful).
+- Help discoverable at every prefix level.
+- `/crawdad workflow` stub returns the v1.1 placeholder cleanly.
+- ≥90% branch coverage on `crawdad/crawdad/slash_commands.py`.
+- `creek-tools/docs/slash-commands.md` and `crawdad/README.md` document the surfaces.
+
+## References
+
+- Source candidate: ADAPT-007.
+- Graphify's `/graphify` family is the prior art for grammar consistency.
+- FEAT-010/011/012 (the MCP tools these commands invoke).
+- FEAT-015 (the CrawDad loop these commands enter).

--- a/plans/git-issues/FEAT-016-slash-command-grammar.md
+++ b/plans/git-issues/FEAT-016-slash-command-grammar.md
@@ -33,6 +33,7 @@ Two small surfaces with a consistent grammar, both invoking the same MCP tools s
   - `/creek` (no args) → `creek state`.
   - `/crawdad` (no args) → opens reflective conversation mode (FEAT-015's loop with no preselected intents).
 - **All slash commands invoke MCP tools, not subprocess CLI calls.** This keeps Discord, Claude Code, and any future client on one tool surface.
+- **`/creek` commands live as Claude Code skill files** under `creek-tools/.claude/commands/` — these are *not* part of the `creek/` Python package. Each file is a markdown skill (frontmatter + body) that Claude Code reads when the user types `/creek <subcommand>`. This convention is added to the project; if `creek-tools/CLAUDE.md` doesn't already document `.claude/commands/`, this FEAT also adds a one-paragraph note there pointing at the new directory.
 - **Help discoverable from any prefix:** `/creek help`, `/creek mine help`, `/crawdad help` all return scoped help.
 - **Discord-specific formatting:** Discord doesn't render markdown link footnotes well, so `/crawdad` commands return code blocks for structured data and bullet lists for prose summaries. No tables.
 - **`/crawdad workflow` is a stub in v1.0** — it advertises the workflow DSL coming in v1.1 (ADAPT-003) but only supports `/crawdad workflow list` (returns "no workflows yet — coming in v1.1") in this PR. Full implementation lands with the v1.1 workflow DSL FEAT.

--- a/plans/git-issues/INDEX.md
+++ b/plans/git-issues/INDEX.md
@@ -211,7 +211,7 @@ The 16 `FEAT-*` files in this directory translate the [comparative-analysis ADOP
 **Wave 0 — prerequisite (Batch 0, the existing INC-019)**
 - INC-019 — taxonomy reconciliation. Blocks the entire v1.0 roadmap.
 
-**Wave 1 — schema foundation (parallel after INC-019)**
+**Wave 1 — schema foundation (sequential after INC-019; FEAT-002 depends on FEAT-001)**
 | ID | Title | LOC | Depends |
 |---|---|---:|---|
 | [FEAT-001](FEAT-001-schema-skills-compile-lint-save.md) | Schema skills (compile / lint / save) + root `AGENTS.md` | ~400 | INC-019 |
@@ -247,7 +247,7 @@ The 16 `FEAT-*` files in this directory translate the [comparative-analysis ADOP
 | [FEAT-015](FEAT-015-crawdad-sonnet-composer-loop.md) | CrawDad — Sonnet composer + 5-round loop + voice-skill activation | ~450 | FEAT-014 |
 | [FEAT-016](FEAT-016-slash-command-grammar.md) | `/creek` and `/crawdad` slash-command grammars | ~400 | FEAT-010/011/012, FEAT-015 |
 
-**Critical path:** INC-019 → FEAT-001 → FEAT-003 → FEAT-004 → FEAT-006 → FEAT-008 → FEAT-009 → FEAT-010 → FEAT-013 → FEAT-014 → FEAT-015. Eleven sequential PRs; the rest parallelize. Total: 17 PRs (1 prerequisite + 16 FEATs) for full v1.0 (Creek Vault data layer + CrawDad agent layer).
+**Critical path:** INC-019 → FEAT-001 → FEAT-002 → FEAT-003 → FEAT-004 → FEAT-006 → FEAT-008 → FEAT-009 → FEAT-010 → FEAT-011 → FEAT-012 → FEAT-013 → FEAT-014 → FEAT-015. Fourteen sequential PRs (one prerequisite + thirteen FEATs); the remaining three FEATs (005, 007, 016) parallelize off the path. Total: 17 PRs for full v1.0 (Creek Vault data layer + CrawDad agent layer).
 
 **LOC envelope:** every FEAT is sized to ≤700 LOC. The largest is FEAT-009 (`creek save`, ~580 LOC).
 

--- a/plans/git-issues/INDEX.md
+++ b/plans/git-issues/INDEX.md
@@ -204,6 +204,57 @@ Critical-path-aware note: Batches A, B, C, D each contain at least one Critical 
 
 ---
 
+## 4a. v1.0 implementation roadmap (FEAT-001…FEAT-016)
+
+The 16 `FEAT-*` files in this directory translate the [comparative-analysis ADOPT/ADAPT candidates](../2026-05-05_comparative-analysis/) into pull-ready work units. Each FEAT is sized for a single PR ≤~700 LOC, names the file paths it touches in `creek-tools/` (or in the new `crawdad/` project), pre-decides the open questions from its source candidate, and ships its own test plan + acceptance criteria. The `/work-issue FEAT-NNN` flow can pick any FEAT whose dependencies have landed.
+
+**Wave 0 — prerequisite (Batch 0, the existing INC-019)**
+- INC-019 — taxonomy reconciliation. Blocks the entire v1.0 roadmap.
+
+**Wave 1 — schema foundation (parallel after INC-019)**
+| ID | Title | LOC | Depends |
+|---|---|---:|---|
+| [FEAT-001](FEAT-001-schema-skills-compile-lint-save.md) | Schema skills (compile / lint / save) + root `AGENTS.md` | ~400 | INC-019 |
+| [FEAT-002](FEAT-002-schema-skills-paradox-liminal-privacy-wavelength.md) | Schema skills (paradox / liminal / privacy-tier / wavelength-aware) | ~400 | FEAT-001 |
+
+**Wave 2 — compiled-layer primitives**
+| ID | Title | LOC | Depends |
+|---|---|---:|---|
+| [FEAT-003](FEAT-003-compile-primitive.md) | Compile primitive — `creek compile <fragment-id>` | ~450 | INC-019, FEAT-001/002 |
+| [FEAT-004](FEAT-004-compiled-layer-query-routing.md) | Compiled-layer query routing in `creek mine` / `creek draft` | ~450 | FEAT-003 |
+| [FEAT-005](FEAT-005-deterministic-first-pipeline.md) | Deterministic-first pipeline + `--no-llm` end-to-end | ~260 | none (parallelizable) |
+
+**Wave 3 — observability + hygiene**
+| ID | Title | LOC | Depends |
+|---|---|---:|---|
+| [FEAT-006](FEAT-006-creek-state-audit-report-core.md) | `creek state` audit report — core sections | ~450 | FEAT-005 |
+| [FEAT-007](FEAT-007-creek-state-wavelength-and-size-budget.md) | `creek state` wavelength snapshot + size-budget gate | ~450 | FEAT-006 |
+| [FEAT-008](FEAT-008-creek-lint-unified-hygiene.md) | `creek lint` unified vault hygiene | ~530 | FEAT-001/002/006 |
+| [FEAT-009](FEAT-009-creek-save-answer-filing-back.md) | `creek save` answer-filing-back primitive | ~580 | FEAT-001/002 |
+
+**Wave 4 — MCP surface**
+| ID | Title | LOC | Depends |
+|---|---|---:|---|
+| [FEAT-010](FEAT-010-mcp-server-skeleton-read-tools.md) | MCP server skeleton + read tools | ~500 | FEAT-006/007/008/004 |
+| [FEAT-011](FEAT-011-mcp-write-tools-tier-enforcement.md) | MCP write tools + tier-ceiling enforcement | ~500 | FEAT-010, FEAT-009 |
+| [FEAT-012](FEAT-012-mcp-purge-tools-elevated-auth.md) | MCP purge tools + elevated-auth + audit hardening | ~400 | FEAT-010/011 |
+
+**Wave 5 — CrawDad v1.0**
+| ID | Title | LOC | Depends |
+|---|---|---:|---|
+| [FEAT-013](FEAT-013-crawdad-discord-bot-skeleton-mcp-client.md) | CrawDad — Discord bot skeleton + MCP client | ~450 | FEAT-010/011/012 |
+| [FEAT-014](FEAT-014-crawdad-haiku-router-dispatcher.md) | CrawDad — Haiku router + tool dispatcher | ~450 | FEAT-013 |
+| [FEAT-015](FEAT-015-crawdad-sonnet-composer-loop.md) | CrawDad — Sonnet composer + 5-round loop + voice-skill activation | ~450 | FEAT-014 |
+| [FEAT-016](FEAT-016-slash-command-grammar.md) | `/creek` and `/crawdad` slash-command grammars | ~400 | FEAT-010/011/012, FEAT-015 |
+
+**Critical path:** INC-019 → FEAT-001 → FEAT-003 → FEAT-004 → FEAT-006 → FEAT-008 → FEAT-009 → FEAT-010 → FEAT-013 → FEAT-014 → FEAT-015. Eleven sequential PRs; the rest parallelize. Total: 17 PRs (1 prerequisite + 16 FEATs) for full v1.0 (Creek Vault data layer + CrawDad agent layer).
+
+**LOC envelope:** every FEAT is sized to ≤700 LOC. The largest is FEAT-009 (`creek save`, ~580 LOC).
+
+**Execution model:** `/work-issue FEAT-NNN` reads the FEAT file, branches, runs TDD against the named acceptance criteria, opens a PR. Open questions in each FEAT are pre-decided so the implementer doesn't pause mid-PR. If a candidate's `Pre-decided choices` block needs to change in light of implementation reality, that's a separate PR that updates the FEAT first.
+
+---
+
 ## 5. Critical path
 
 Longest dependency chain, from "today" to "ready to launch":


### PR DESCRIPTION
## Summary

Translates the 23 ADOPT/ADAPT candidates from the merged comparative-analysis PR (#199) into **16 pull-ready FEAT-* issue files** in `plans/git-issues/`, each sized for a single PR ≤~700 LOC. The goal is "execute on `<next issue>`" — `/work-issue FEAT-NNN` reads the file, branches, runs TDD, opens a PR, no mid-implementation question-asking.

Each FEAT carries:
- Source candidate link (the design rationale).
- File paths it touches in `creek-tools/` (or the new `crawdad/`).
- Pre-decided answers to the candidate's open questions.
- Test plan + acceptance criteria sharpened from the candidate's AC.
- Dependencies on other FEATs.

## Wave structure

| Wave | What | FEATs | On critical path? |
|---|---|---|---|
| 0 | Prerequisite | INC-019 (already merged) | yes |
| 1 | Schema foundation | 001 → 002 (sequential) | both |
| 2 | Compiled-layer primitives | 003 → 004; 005 (parallel) | 003, 004 |
| 3 | Observability + hygiene | 006 → 008 → 009; 007 (parallel) | 006, 008, 009 |
| 4 | MCP surface | 010 → 011 → 012 (sequential) | all three |
| 5 | CrawDad v1.0 | 013 → 014 → 015; 016 (parallel) | 013, 014, 015 |

**Critical path:** INC-019 → 001 → 002 → 003 → 004 → 006 → 008 → 009 → 010 → 011 → 012 → 013 → 014 → 015. **Fourteen sequential PRs** (one prerequisite + thirteen FEATs). The remaining three FEATs (005, 007, 016) parallelize off the path. **Total v1.0: 17 PRs** (1 prerequisite + 16 FEATs).

## LOC envelope

Largest FEAT is FEAT-009 (`creek save`, ~580 LOC); smallest is FEAT-005 (~260 LOC). Average ~470 LOC per PR. All under the 700 LOC ceiling.

## What's not in this PR

- No source code modified.
- No FEAT for v1.1+ candidates (Leiden, four-worker, episodic memory, multimodal, workflow DSL); those land as a separate planning pass after v1.0.
- INDEX.md gains a new "4a. v1.0 implementation roadmap" section with the wave tables and execution-model guidance for `/work-issue`. Does not touch the existing batch structure for the 61-issue audit.

## Discovery during recon

`creek/models.py` already uses canonical spec names for `Phase`, `Mode`, and `Frequency` enums. INC-019's drift is purely in `creek-tools/docs/` and one header string in `compost.py` — smaller than originally scoped. FEAT-001 reflects this.

## Test plan

- [ ] `ls plans/git-issues/FEAT-*.md | wc -l` returns 16.
- [ ] Each FEAT renders cleanly in GitHub markdown.
- [ ] INDEX.md "4a. v1.0 implementation roadmap" section links resolve.
- [ ] No source code changed.

https://claude.ai/code