### PR TITLE
fix(taxonomy): reconcile phase/mode/frequency drift to spec (INC-019)

### DIFF
--- a/creek-tools/creek/generate/compost.py
+++ b/creek-tools/creek/generate/compost.py
@@ -489,7 +489,7 @@ class CompostTracker:
             "",
             "# Compost Report",
             "",
-            "This report surveys every composting idea in the vault and ",
+            "This report surveys every composted note in the vault and ",
             "cross-references them against the threads currently alive.",
             "",
             "## All Compost Notes",
@@ -501,7 +501,7 @@ class CompostTracker:
             "SORT composted_date DESC",
             "```",
             "",
-            "## Composting Ideas (snapshot)",
+            "## Composted Notes (snapshot)",
             "",
         ]
         if compost_notes:

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -9,6 +9,7 @@ for the APTITUDE frequency framework and Archetypal Wavelength mapping.
 import uuid
 from datetime import date, datetime
 from enum import StrEnum
+from typing import TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 
@@ -17,8 +18,76 @@ from creek.time import now_la, today_la
 # ---- Enums ----
 
 
+# INC-019 migration aliases — drifted phase/mode/frequency strings
+# that pre-INC-019 vaults / hand-edited frontmatter may still carry.
+# Each enum below routes these legacy values through ``_missing_`` to
+# the matching canonical member with a one-release
+# :class:`DeprecationWarning`. The mappings come from
+# ``plans/git-issues/INC-019-spec-impl-drift-phase-mode-frequency-taxonomy.md``
+# and the regression tests in ``tests/test_taxonomy_aliases.py`` /
+# ``tests/fixtures/canonical_taxonomy.yaml``.
+_PHASE_LEGACY_ALIASES = {
+    "origins": "rising",
+    "cresting": "withdrawal",
+    "receding": "diminishing",
+    "composting": "restoration",
+}
+
+_MODE_LEGACY_ALIASES = {
+    "solo": "inhabit",
+    "dialogue": "express",
+    "reflective": "integrate",
+    "analytic": "collaborate",
+}
+
+_FREQUENCY_LEGACY_ALIASES = {
+    "amplitude": "F1",
+    "pitch": "F2",
+}
+
+
+_E = TypeVar("_E", bound=StrEnum)
+
+
+def _legacy_alias_lookup(
+    cls: type[_E],
+    value: object,
+    aliases: dict[str, str],
+) -> _E | None:
+    """Resolve ``value`` through the INC-019 legacy alias table.
+
+    Returns the canonical enum member (warning the caller via
+    :class:`DeprecationWarning`) when ``value`` is one of the
+    drifted strings, or ``None`` otherwise so the StrEnum machinery
+    raises ``ValueError`` as it normally would.
+    """
+    if not isinstance(value, str):
+        return None
+    canonical = aliases.get(value)
+    if canonical is None:
+        return None
+    import warnings
+
+    warnings.warn(
+        f"{cls.__name__} value {value!r} is deprecated; use "
+        f"{canonical!r}. INC-019: support for legacy phase/mode/"
+        "frequency names will be removed in the next minor release.",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    return cls(canonical)
+
+
 class Frequency(StrEnum):
-    """APTITUDE frequency classification (F1-F10 plus unclassified)."""
+    """APTITUDE frequency classification (F1-F10 plus unclassified).
+
+    Naming history (INC-019): the canonical names are the F-codes
+    ``F1``..``F10`` matching ontology §6.1. Legacy wave-physics strings
+    (``"amplitude"``, ``"pitch"``) are accepted on input via
+    :meth:`_missing_` and silently mapped to the canonical F-code with
+    a :class:`DeprecationWarning`. Plan removal in the next minor
+    release.
+    """
 
     F1 = "F1"
     F2 = "F2"
@@ -32,9 +101,28 @@ class Frequency(StrEnum):
     F10 = "F10"
     UNCLASSIFIED = "unclassified"
 
+    @classmethod
+    def _missing_(cls, value: object) -> "Frequency | None":
+        """Map legacy wave-physics strings to canonical F-codes.
+
+        See INC-019 for the full mapping. Any other unknown value
+        still raises ``ValueError`` from the StrEnum constructor.
+        """
+        return _legacy_alias_lookup(cls, value, _FREQUENCY_LEGACY_ALIASES)
+
 
 class Phase(StrEnum):
-    """Archetypal Wavelength phase within the six-phase cycle."""
+    """Archetypal Wavelength phase within the six-phase cycle.
+
+    Naming history (INC-019): the canonical names are
+    ``rising``/``peaking``/``withdrawal``/``diminishing``/
+    ``bottoming_out``/``restoration`` per ontology §7.1. Legacy
+    drift strings (``"origins"``, ``"cresting"``, ``"receding"``,
+    ``"composting"``) are accepted on input via :meth:`_missing_`
+    and silently mapped to the canonical phase with a
+    :class:`DeprecationWarning`. Plan removal in the next minor
+    release.
+    """
 
     RISING = "rising"
     PEAKING = "peaking"
@@ -44,9 +132,27 @@ class Phase(StrEnum):
     RESTORATION = "restoration"
     UNCLASSIFIED = "unclassified"
 
+    @classmethod
+    def _missing_(cls, value: object) -> "Phase | None":
+        """Map legacy drift phase strings to canonical phases.
+
+        See INC-019 for the full mapping. Any other unknown value
+        still raises ``ValueError`` from the StrEnum constructor.
+        """
+        return _legacy_alias_lookup(cls, value, _PHASE_LEGACY_ALIASES)
+
 
 class Mode(StrEnum):
-    """Engagement mode describing how a frequency is being experienced."""
+    """Engagement mode describing how a frequency is being experienced.
+
+    Naming history (INC-019): the canonical names are
+    ``inhabit``/``express``/``collaborate``/``integrate``/``absorb``
+    per ontology §7.2. Legacy drift strings (``"solo"``,
+    ``"dialogue"``, ``"reflective"``, ``"analytic"``) are accepted on
+    input via :meth:`_missing_` and silently mapped to the canonical
+    mode with a :class:`DeprecationWarning`. Plan removal in the next
+    minor release.
+    """
 
     INHABIT = "inhabit"
     EXPRESS = "express"
@@ -54,6 +160,15 @@ class Mode(StrEnum):
     INTEGRATE = "integrate"
     ABSORB = "absorb"
     UNCLASSIFIED = "unclassified"
+
+    @classmethod
+    def _missing_(cls, value: object) -> "Mode | None":
+        """Map legacy drift mode strings to canonical modes.
+
+        See INC-019 for the full mapping. Any other unknown value
+        still raises ``ValueError`` from the StrEnum constructor.
+        """
+        return _legacy_alias_lookup(cls, value, _MODE_LEGACY_ALIASES)
 
 
 class Orientation(StrEnum):

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -7,6 +7,7 @@ for the APTITUDE frequency framework and Archetypal Wavelength mapping.
 """
 
 import uuid
+import warnings
 from datetime import date, datetime
 from enum import StrEnum
 from typing import TypeVar
@@ -18,14 +19,7 @@ from creek.time import now_la, today_la
 # ---- Enums ----
 
 
-# INC-019 migration aliases — drifted phase/mode/frequency strings
-# that pre-INC-019 vaults / hand-edited frontmatter may still carry.
-# Each enum below routes these legacy values through ``_missing_`` to
-# the matching canonical member with a one-release
-# :class:`DeprecationWarning`. The mappings come from
-# ``plans/git-issues/INC-019-spec-impl-drift-phase-mode-frequency-taxonomy.md``
-# and the regression tests in ``tests/test_taxonomy_aliases.py`` /
-# ``tests/fixtures/canonical_taxonomy.yaml``.
+# INC-019 one-release migration aliases — see the INC doc for context.
 _PHASE_LEGACY_ALIASES = {
     "origins": "rising",
     "cresting": "withdrawal",
@@ -54,24 +48,16 @@ def _legacy_alias_lookup(
     value: object,
     aliases: dict[str, str],
 ) -> _E | None:
-    """Resolve ``value`` through the INC-019 legacy alias table.
-
-    Returns the canonical enum member (warning the caller via
-    :class:`DeprecationWarning`) when ``value`` is one of the
-    drifted strings, or ``None`` otherwise so the StrEnum machinery
-    raises ``ValueError`` as it normally would.
-    """
+    """Resolve a legacy INC-019 string to its canonical enum member, or None."""
     if not isinstance(value, str):
         return None
     canonical = aliases.get(value)
     if canonical is None:
         return None
-    import warnings
-
     warnings.warn(
-        f"{cls.__name__} value {value!r} is deprecated; use "
-        f"{canonical!r}. INC-019: support for legacy phase/mode/"
-        "frequency names will be removed in the next minor release.",
+        f"{cls.__name__} value {value!r} is deprecated; use {canonical!r}. "
+        "INC-019: support for legacy phase/mode/frequency names will be "
+        "removed in the next minor release.",
         DeprecationWarning,
         stacklevel=3,
     )
@@ -79,15 +65,7 @@ def _legacy_alias_lookup(
 
 
 class Frequency(StrEnum):
-    """APTITUDE frequency classification (F1-F10 plus unclassified).
-
-    Naming history (INC-019): the canonical names are the F-codes
-    ``F1``..``F10`` matching ontology §6.1. Legacy wave-physics strings
-    (``"amplitude"``, ``"pitch"``) are accepted on input via
-    :meth:`_missing_` and silently mapped to the canonical F-code with
-    a :class:`DeprecationWarning`. Plan removal in the next minor
-    release.
-    """
+    """APTITUDE frequency F1..F10 (plus unclassified); see INC-019 for aliases."""
 
     F1 = "F1"
     F2 = "F2"
@@ -103,26 +81,12 @@ class Frequency(StrEnum):
 
     @classmethod
     def _missing_(cls, value: object) -> "Frequency | None":
-        """Map legacy wave-physics strings to canonical F-codes.
-
-        See INC-019 for the full mapping. Any other unknown value
-        still raises ``ValueError`` from the StrEnum constructor.
-        """
+        """Map legacy INC-019 wave-physics strings to canonical F-codes."""
         return _legacy_alias_lookup(cls, value, _FREQUENCY_LEGACY_ALIASES)
 
 
 class Phase(StrEnum):
-    """Archetypal Wavelength phase within the six-phase cycle.
-
-    Naming history (INC-019): the canonical names are
-    ``rising``/``peaking``/``withdrawal``/``diminishing``/
-    ``bottoming_out``/``restoration`` per ontology §7.1. Legacy
-    drift strings (``"origins"``, ``"cresting"``, ``"receding"``,
-    ``"composting"``) are accepted on input via :meth:`_missing_`
-    and silently mapped to the canonical phase with a
-    :class:`DeprecationWarning`. Plan removal in the next minor
-    release.
-    """
+    """Archetypal Wavelength six-phase cycle; see INC-019 for aliases."""
 
     RISING = "rising"
     PEAKING = "peaking"
@@ -134,25 +98,12 @@ class Phase(StrEnum):
 
     @classmethod
     def _missing_(cls, value: object) -> "Phase | None":
-        """Map legacy drift phase strings to canonical phases.
-
-        See INC-019 for the full mapping. Any other unknown value
-        still raises ``ValueError`` from the StrEnum constructor.
-        """
+        """Map legacy INC-019 drift phase strings to canonical phases."""
         return _legacy_alias_lookup(cls, value, _PHASE_LEGACY_ALIASES)
 
 
 class Mode(StrEnum):
-    """Engagement mode describing how a frequency is being experienced.
-
-    Naming history (INC-019): the canonical names are
-    ``inhabit``/``express``/``collaborate``/``integrate``/``absorb``
-    per ontology §7.2. Legacy drift strings (``"solo"``,
-    ``"dialogue"``, ``"reflective"``, ``"analytic"``) are accepted on
-    input via :meth:`_missing_` and silently mapped to the canonical
-    mode with a :class:`DeprecationWarning`. Plan removal in the next
-    minor release.
-    """
+    """Engagement mode for a fragment; see INC-019 for legacy aliases."""
 
     INHABIT = "inhabit"
     EXPRESS = "express"
@@ -163,11 +114,7 @@ class Mode(StrEnum):
 
     @classmethod
     def _missing_(cls, value: object) -> "Mode | None":
-        """Map legacy drift mode strings to canonical modes.
-
-        See INC-019 for the full mapping. Any other unknown value
-        still raises ``ValueError`` from the StrEnum constructor.
-        """
+        """Map legacy INC-019 drift mode strings to canonical modes."""
         return _legacy_alias_lookup(cls, value, _MODE_LEGACY_ALIASES)
 
 

--- a/creek-tools/docs/classification.md
+++ b/creek-tools/docs/classification.md
@@ -1,6 +1,6 @@
 # Classification
 
-Classification tags every fragment along five dimensions: **frequency** (the APTITUDE 10-frequency system), **archetypal phase** (Origins, Rising, Peaking, Cresting, Receding, Composting), **mode**, **register**, and **privacy tier**. The classifier writes its decisions into the fragment's frontmatter; downstream stages (linking, generation) consume those tags.
+Classification tags every fragment along five dimensions: **frequency** (the APTITUDE F1–F10 system), **archetypal phase** (Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration), **mode** (Inhabit, Express, Collaborate, Integrate, Absorb), **register**, and **privacy tier**. The classifier writes its decisions into the fragment's frontmatter; downstream stages (linking, generation) consume those tags.
 
 > Routing fragments through the Anthropic provider sends content to a third party. The privacy-tier system gates this — `intimate` fragments stay local — but the broader trade-offs and the hardening done against prompt-injection (SEC-004) are documented in the [threat model](security/threat-model.md).
 
@@ -29,10 +29,12 @@ For each fragment the classifier appends frontmatter like:
 
 ```yaml
 classification:
-  frequency: amplitude       # one of the 10 APTITUDE frequencies
-  phase: rising              # one of 6 archetypal phases
-  mode: solo                 # solo | dialogue | reflective | analytic
-  register: intimate         # intimate | personal | public | professional
+  frequency: F1              # one of F1..F10 (APTITUDE)
+  phase: rising              # rising | peaking | withdrawal | diminishing | bottoming_out | restoration
+  mode: inhabit              # inhabit | express | collaborate | integrate | absorb
+  orientation: do            # do | feel | do_feel
+  dosage: medicine           # medicine | toxic | ambiguous
+  register: confessional     # confessional | analytical | playful | prophetic | instructional | raw | conversational
   confidence: 0.82
   method: rules              # rules | llm | manual
   classified_at: 2026-04-28T17:30:00Z

--- a/creek-tools/docs/generation.md
+++ b/creek-tools/docs/generation.md
@@ -44,12 +44,12 @@ The `synchronicity`, `paradox`, `compost`, `unnamed`, and `tags` report types co
 ```
 creek-skills/
 ├── frequencies/
-│   ├── amplitude/SKILL.md
-│   ├── pitch/SKILL.md
-│   └── …
-├── phases/{origins,rising,peaking,cresting,receding,composting}/SKILL.md
-├── modes/{solo,dialogue,reflective,analytic}/SKILL.md
-├── registers/{intimate,personal,public,professional}/SKILL.md
+│   ├── F1/SKILL.md
+│   ├── F2/SKILL.md
+│   └── …                                           # F1..F10 (APTITUDE)
+├── phases/{rising,peaking,withdrawal,diminishing,bottoming_out,restoration}/SKILL.md
+├── modes/{inhabit,express,collaborate,integrate,absorb}/SKILL.md
+├── registers/{confessional,analytical,playful,prophetic,instructional,raw,conversational}/SKILL.md
 ├── threads/<thread-id>/SKILL.md
 ├── eddies/<eddy-id>/SKILL.md
 └── meta/
@@ -83,8 +83,8 @@ Re-run any time after ingesting / classifying. The generator is idempotent — o
 # Print the top 10 ideas across all strategies.
 creek mine --vault ~/Obsidian/Creek-Vault --limit 10
 
-# Filter to ideas that fit a current Cresting phase.
-creek mine --vault ~/Obsidian/Creek-Vault --phase cresting --limit 5
+# Filter to ideas that fit a current Withdrawal phase.
+creek mine --vault ~/Obsidian/Creek-Vault --phase withdrawal --limit 5
 ```
 
 Each `IdeaSeed` has a strategy, a score, the contributing fragments, and a hint about the angle. You'll typically pick one (`--index N`) to feed into `creek draft`.
@@ -99,6 +99,7 @@ creek draft --vault ~/Obsidian/Creek-Vault
 
 # Pick the third-ranked idea and override the phase.
 creek draft --vault ~/Obsidian/Creek-Vault --index 2 --phase peaking
+
 
 # Prepend a voice-core text file to the prompt.
 creek draft --vault ~/Obsidian/Creek-Vault --voice-core ./voice-core.md
@@ -115,10 +116,10 @@ draft:
     - frag-5d4e9c1a7f31
     - frag-2a6b8e3c9d44
   skill_stack:
-    - skills/frequencies/amplitude
-    - skills/phases/cresting
-    - skills/modes/reflective
-    - skills/registers/intimate
+    - skills/frequencies/F1
+    - skills/phases/withdrawal
+    - skills/modes/integrate
+    - skills/registers/confessional
     - skills/meta/voice-core
   llm:
     provider: ollama

--- a/creek-tools/tests/fixtures/canonical_taxonomy.yaml
+++ b/creek-tools/tests/fixtures/canonical_taxonomy.yaml
@@ -1,0 +1,77 @@
+# Canonical Wavelength Taxonomy (INC-019)
+#
+# This file is the regression anchor for the spec/implementation
+# alignment of phase, mode, and frequency names. It mirrors, verbatim,
+# the canonical taxonomy in
+# ``00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md``:
+#
+#   - Frequencies: §6.1 (lines 396-407)
+#   - Phases:      §7.1 (lines 421-435)
+#   - Modes:       §7.2 (lines 451-463)
+#
+# The regression test in ``tests/test_taxonomy_alignment.py`` asserts
+# that the enums in ``creek/models.py`` use these exact lowercase
+# values. If the spec or the model drifts, this fixture must be
+# updated in lockstep — that is the point of the test.
+#
+# Drift values listed under ``deprecated_aliases`` come from the
+# pre-INC-019 documentation drift documented in
+# ``plans/git-issues/INC-019-spec-impl-drift-phase-mode-frequency-taxonomy.md``.
+# They are mapped to the canonical names so vaults written by older
+# tool versions remain loadable for one release with a deprecation
+# warning, after which the alias hooks will be removed.
+phases:
+  canonical:
+    - rising
+    - peaking
+    - withdrawal
+    - diminishing
+    - bottoming_out
+    - restoration
+  deprecated_aliases:
+    origins: rising
+    cresting: withdrawal
+    receding: diminishing
+    composting: restoration
+modes:
+  canonical:
+    - inhabit
+    - express
+    - collaborate
+    - integrate
+    - absorb
+  deprecated_aliases:
+    solo: inhabit
+    dialogue: express
+    reflective: integrate
+    analytic: collaborate
+frequencies:
+  # The frequencies are stored in the model as the F1..F10 codes; the
+  # human-readable names below come from §6.1 of the spec and are
+  # listed here so the regression test can assert the F-codes are
+  # complete and ordered.
+  canonical_codes:
+    - F1
+    - F2
+    - F3
+    - F4
+    - F5
+    - F6
+    - F7
+    - F8
+    - F9
+    - F10
+  canonical_names:
+    F1: Agency
+    F2: Receptivity
+    F3: Self-Love / Power
+    F4: Community Love / Conformity
+    F5: Achievism
+    F6: Pluralism
+    F7: Integration
+    F8: True Self / Transcendence
+    F9: Unity
+    F10: Emptiness
+  deprecated_aliases:
+    amplitude: F1
+    pitch: F2

--- a/creek-tools/tests/test_taxonomy_aliases.py
+++ b/creek-tools/tests/test_taxonomy_aliases.py
@@ -1,0 +1,136 @@
+"""Regression tests for INC-019 one-release migration aliases.
+
+INC-019 reconciles spec/implementation drift on three axes — phase,
+mode, and frequency — by bringing ``creek-tools`` to the canonical
+ontology vocabulary. Old vaults / hand-edited frontmatter may still
+serialise the drifted strings (``origins``, ``cresting``, ``solo``,
+``amplitude``, etc.). For one release we accept those values on input,
+silently map them to the canonical names, and emit a
+:class:`DeprecationWarning` so the operator knows to migrate.
+
+The pattern mirrors INC-003's ``PrivacyTier("public")`` alias — see
+``tests/test_privacy_tier_alias.py``.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+
+from creek.models import Frequency, Mode, Phase
+
+PHASE_ALIASES = {
+    "origins": Phase.RISING,
+    "cresting": Phase.WITHDRAWAL,
+    "receding": Phase.DIMINISHING,
+    "composting": Phase.RESTORATION,
+}
+
+MODE_ALIASES = {
+    "solo": Mode.INHABIT,
+    "dialogue": Mode.EXPRESS,
+    "reflective": Mode.INTEGRATE,
+    "analytic": Mode.COLLABORATE,
+}
+
+FREQUENCY_ALIASES = {
+    "amplitude": Frequency.F1,
+    "pitch": Frequency.F2,
+}
+
+
+@pytest.mark.parametrize(
+    ("legacy", "canonical"),
+    list(PHASE_ALIASES.items()),
+)
+def test_phase_legacy_value_maps_to_canonical_with_warning(
+    legacy: str,
+    canonical: Phase,
+) -> None:
+    """Drifted phase strings resolve to their canonical enum member."""
+    with pytest.warns(DeprecationWarning, match="INC-019"):
+        result = Phase(legacy)
+    assert result is canonical
+
+
+@pytest.mark.parametrize(
+    ("legacy", "canonical"),
+    list(MODE_ALIASES.items()),
+)
+def test_mode_legacy_value_maps_to_canonical_with_warning(
+    legacy: str,
+    canonical: Mode,
+) -> None:
+    """Drifted mode strings resolve to their canonical enum member."""
+    with pytest.warns(DeprecationWarning, match="INC-019"):
+        result = Mode(legacy)
+    assert result is canonical
+
+
+@pytest.mark.parametrize(
+    ("legacy", "canonical"),
+    list(FREQUENCY_ALIASES.items()),
+)
+def test_frequency_legacy_value_maps_to_canonical_with_warning(
+    legacy: str,
+    canonical: Frequency,
+) -> None:
+    """Drifted frequency strings resolve to the matching F-code."""
+    with pytest.warns(DeprecationWarning, match="INC-019"):
+        result = Frequency(legacy)
+    assert result is canonical
+
+
+def test_unknown_phase_still_raises() -> None:
+    """Unknown phase strings continue to raise ``ValueError``."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with pytest.raises(ValueError, match="not a valid Phase"):
+            Phase("definitely-not-a-phase")
+
+
+def test_unknown_mode_still_raises() -> None:
+    """Unknown mode strings continue to raise ``ValueError``."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with pytest.raises(ValueError, match="not a valid Mode"):
+            Mode("definitely-not-a-mode")
+
+
+def test_unknown_frequency_still_raises() -> None:
+    """Unknown frequency strings continue to raise ``ValueError``."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        with pytest.raises(ValueError, match="not a valid Frequency"):
+            Frequency("definitely-not-a-frequency")
+
+
+def test_aliases_do_not_create_new_enum_members() -> None:
+    """Aliases route to existing members, never minting new ones."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        for legacy in PHASE_ALIASES:
+            Phase(legacy)
+        for legacy in MODE_ALIASES:
+            Mode(legacy)
+        for legacy in FREQUENCY_ALIASES:
+            Frequency(legacy)
+    # Only the canonical six phases plus ``unclassified`` exist.
+    assert len(list(Phase)) == 7
+    # Only the canonical five modes plus ``unclassified`` exist.
+    assert len(list(Mode)) == 6
+    # Only F1..F10 plus ``unclassified`` exist.
+    assert len(list(Frequency)) == 11
+
+
+def test_canonical_values_round_trip_without_warnings() -> None:
+    """Canonical values round-trip silently — no deprecation noise."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert Phase("rising") is Phase.RISING
+        assert Phase("bottoming_out") is Phase.BOTTOMING_OUT
+        assert Mode("inhabit") is Mode.INHABIT
+        assert Mode("absorb") is Mode.ABSORB
+        assert Frequency("F1") is Frequency.F1
+        assert Frequency("F10") is Frequency.F10

--- a/creek-tools/tests/test_taxonomy_alignment.py
+++ b/creek-tools/tests/test_taxonomy_alignment.py
@@ -1,0 +1,92 @@
+"""Regression tests for INC-019 wavelength taxonomy alignment.
+
+These tests pin the canonical phase, mode, and frequency vocabulary
+defined in ``00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md``
+and assert that ``creek.models`` agrees with that spec verbatim.
+
+The canonical lists live in ``tests/fixtures/canonical_taxonomy.yaml``
+so the test fails when *either* the spec or the model drifts. If the
+ontology spec ever revises a name, both the fixture and the model
+must be updated together — the test makes that requirement explicit.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+from creek.models import Frequency, Mode, Phase
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "canonical_taxonomy.yaml"
+
+
+@pytest.fixture(scope="module")
+def canonical() -> dict[str, Any]:
+    """Load the canonical taxonomy fixture once per test module."""
+    with FIXTURE_PATH.open(encoding="utf-8") as fh:
+        loaded = yaml.safe_load(fh)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_phase_enum_matches_canonical_list_in_order(
+    canonical: dict[str, Any],
+) -> None:
+    """``Phase`` exposes the spec's six phases in canonical narrative order."""
+    expected = canonical["phases"]["canonical"]
+    actual = [p.value for p in Phase if p is not Phase.UNCLASSIFIED]
+    assert actual == expected
+
+
+def test_mode_enum_matches_canonical_list_in_order(
+    canonical: dict[str, Any],
+) -> None:
+    """``Mode`` exposes the spec's five modes in canonical order."""
+    expected = canonical["modes"]["canonical"]
+    actual = [m.value for m in Mode if m is not Mode.UNCLASSIFIED]
+    assert actual == expected
+
+
+def test_frequency_enum_matches_canonical_codes(
+    canonical: dict[str, Any],
+) -> None:
+    """``Frequency`` exposes F1..F10 in spec order (plus ``unclassified``)."""
+    expected = canonical["frequencies"]["canonical_codes"]
+    actual = [f.value for f in Frequency if f is not Frequency.UNCLASSIFIED]
+    assert actual == expected
+
+
+def test_phase_enum_has_no_drift_values() -> None:
+    """No drift phase names (``origins``, ``cresting``, ``receding``,
+    ``composting``) are first-class enum members."""
+    drift = {"origins", "cresting", "receding", "composting"}
+    enum_values = {p.value for p in Phase}
+    assert drift.isdisjoint(enum_values)
+
+
+def test_mode_enum_has_no_drift_values() -> None:
+    """No drift mode names (``solo``, ``dialogue``, ``reflective``,
+    ``analytic``) are first-class enum members."""
+    drift = {"solo", "dialogue", "reflective", "analytic"}
+    enum_values = {m.value for m in Mode}
+    assert drift.isdisjoint(enum_values)
+
+
+def test_frequency_enum_has_no_wave_physics_drift() -> None:
+    """No drift frequency names (``amplitude``, ``pitch``) are
+    first-class enum members."""
+    drift = {"amplitude", "pitch"}
+    enum_values = {f.value for f in Frequency}
+    assert drift.isdisjoint(enum_values)
+
+
+def test_canonical_fixture_lists_have_expected_lengths(
+    canonical: dict[str, Any],
+) -> None:
+    """The fixture itself exposes 6 phases, 5 modes, and 10 frequencies."""
+    assert len(canonical["phases"]["canonical"]) == 6
+    assert len(canonical["modes"]["canonical"]) == 5
+    assert len(canonical["frequencies"]["canonical_codes"]) == 10

--- a/creek-tools/tests/test_taxonomy_docs_drift.py
+++ b/creek-tools/tests/test_taxonomy_docs_drift.py
@@ -1,0 +1,70 @@
+"""Regression tests for INC-019 documentation drift.
+
+The user-facing docs in ``creek-tools/docs/`` and any user-facing
+strings in ``creek-tools/creek/`` must use the canonical taxonomy
+verbatim. These tests grep the relevant files and assert the drifted
+phase / mode / frequency strings do not reappear.
+
+Drift values are taken from
+``plans/git-issues/INC-019-spec-impl-drift-phase-mode-frequency-taxonomy.md``.
+The canonical names are pinned in
+``tests/fixtures/canonical_taxonomy.yaml``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+DOCS_DIR = Path(__file__).resolve().parents[1] / "docs"
+COMPOST_PY = Path(__file__).resolve().parents[1] / "creek" / "generate" / "compost.py"
+
+# Drift words that must not appear in user-facing copy. Word boundaries
+# protect substrings like ``analytical`` (a VoiceRegister, unrelated to
+# the drifted ``analytic`` mode) and ``compost.py`` filenames.
+DRIFT_PATTERNS = [
+    r"\bOrigins\b",
+    r"\bCresting\b",
+    r"\bcresting\b",
+    r"\bReceding\b",
+    r"\bComposting\b",
+    r"\bamplitude\b",
+    r"\bpitch\b",
+    # Phrase-level drift that matches the INC's own grep recipes.
+    r"solo\s*\|\s*dialogue\s*\|\s*reflective\s*\|\s*analytic",
+    r"\{\s*solo\s*,\s*dialogue\s*,\s*reflective\s*,\s*analytic\s*\}",
+]
+
+
+@pytest.mark.parametrize("pattern", DRIFT_PATTERNS)
+def test_classification_doc_has_no_drift(pattern: str) -> None:
+    """``docs/classification.md`` uses the canonical taxonomy verbatim."""
+    text = (DOCS_DIR / "classification.md").read_text(encoding="utf-8")
+    assert not re.search(pattern, text), (
+        f"INC-019 drift pattern {pattern!r} reappeared in classification.md"
+    )
+
+
+@pytest.mark.parametrize("pattern", DRIFT_PATTERNS)
+def test_generation_doc_has_no_drift(pattern: str) -> None:
+    """``docs/generation.md`` uses the canonical taxonomy verbatim."""
+    text = (DOCS_DIR / "generation.md").read_text(encoding="utf-8")
+    assert not re.search(pattern, text), (
+        f"INC-019 drift pattern {pattern!r} reappeared in generation.md"
+    )
+
+
+def test_compost_module_has_no_drifted_phase_header() -> None:
+    """``creek/generate/compost.py`` does not emit a ``Composting`` header."""
+    text = COMPOST_PY.read_text(encoding="utf-8")
+    # User-facing strings — match the INC author's grep recipe but
+    # restricted to inside ``"..."`` literals so the module name and
+    # docstrings are not falsely flagged.
+    string_literals = re.findall(r'"([^"]*)"', text)
+    offenders = [literal for literal in string_literals if "Composting" in literal]
+    assert offenders == [], (
+        "compost.py emits a 'Composting' header that mirrors the drift phase "
+        f"name; offenders: {offenders!r}"
+    )

--- a/creek-tools/tests/test_taxonomy_docs_drift.py
+++ b/creek-tools/tests/test_taxonomy_docs_drift.py
@@ -23,15 +23,25 @@ COMPOST_PY = Path(__file__).resolve().parents[1] / "creek" / "generate" / "compo
 
 # Drift words that must not appear in user-facing copy. Word boundaries
 # protect substrings like ``analytical`` (a VoiceRegister, unrelated to
-# the drifted ``analytic`` mode) and ``compost.py`` filenames.
+# the drifted ``analytic`` mode) and ``compost.py`` filenames. Both
+# title-case (prose) and lowercase (YAML frontmatter / skill-tree
+# directory) forms are listed for the phase-name drift, since either
+# could leak back into the docs.
 DRIFT_PATTERNS = [
     r"\bOrigins\b",
+    r"\borigins\b",
     r"\bCresting\b",
     r"\bcresting\b",
     r"\bReceding\b",
+    r"\breceding\b",
     r"\bComposting\b",
-    r"\bamplitude\b",
-    r"\bpitch\b",
+    r"\bcomposting\b",
+    # ``amplitude`` and ``pitch`` are common English words; anchor to
+    # the contexts where they appeared as drift (frontmatter values
+    # and skill-tree directory paths) so prose like "the pitch of the
+    # voice" doesn't trip the gate as the docs grow.
+    r"frequency:\s*(?:amplitude|pitch)\b",
+    r"frequencies/(?:amplitude|pitch)\b",
     # Phrase-level drift that matches the INC's own grep recipes.
     r"solo\s*\|\s*dialogue\s*\|\s*reflective\s*\|\s*analytic",
     r"\{\s*solo\s*,\s*dialogue\s*,\s*reflective\s*,\s*analytic\s*\}",


### PR DESCRIPTION
## Summary

Resolves [INC-019](../blob/main/plans/git-issues/INC-019-spec-impl-drift-phase-mode-frequency-taxonomy.md) — the spec/implementation drift on phase, mode, and frequency naming. The canonical taxonomy lives in `00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md` (§6.1, §7.1, §7.2). The `Phase` / `Mode` / `Frequency` enums in `creek/models.py` already matched the spec; this PR pins that alignment with regression tests, removes the documentation drift, and ships one-release migration aliases (mirroring the INC-003 `PrivacyTier` pattern) so pre-INC-019 vaults remain loadable.

This is the prerequisite [ADOPT-001](../blob/main/plans/2026-05-05_comparative-analysis/candidates/ADOPT-001-three-layer-compiled-architecture.md) flagged in the comparative analysis: compile-then-query needs one source of truth for the load-bearing taxonomy.

## Changes

- `tests/fixtures/canonical_taxonomy.yaml` — single source of truth for the regression suite (6 phases, 5 modes, F1..F10).
- `tests/test_taxonomy_alignment.py` — asserts each enum's value list equals the canonical fixture verbatim and contains no drift members.
- `tests/test_taxonomy_aliases.py` — exercises the new `_missing_` hooks: `origins`/`cresting`/`receding`/`composting` → canonical phases, `solo`/`dialogue`/`reflective`/`analytic` → canonical modes, `amplitude`/`pitch` → `F1`/`F2`. Each emits a `DeprecationWarning` referencing INC-019.
- `tests/test_taxonomy_docs_drift.py` — greppability gate that fails if drift terms reappear in `docs/classification.md`, `docs/generation.md`, or `creek/generate/compost.py` user-facing strings.
- `creek/models.py` — adds `_legacy_alias_lookup` helper and `_missing_` hooks on `Phase`, `Mode`, `Frequency` (one-release migration aliases).
- `docs/classification.md`, `docs/generation.md` — replace drift names (`Origins`/`Cresting`/`Receding`/`Composting`, `solo|dialogue|reflective|analytic`, `amplitude`/`pitch`) with canonical vocabulary.
- `creek/generate/compost.py` — rename the `## Composting Ideas (snapshot)` header to `## Composted Notes (snapshot)` so the compost report does not collide with the drifted phase name.

## Acceptance criteria — verified

- ✅ `grep -rn 'Origins\|Cresting\|Receding\|Composting' creek-tools/` returns zero hits in user-facing strings.
- ✅ `grep -rn 'solo.*dialogue\|reflective.*analytic' creek-tools/` returns zero hits in user-facing strings.
- ✅ `grep -rn 'amplitude\|pitch' creek-tools/` returns zero hits in user-facing strings.
- ✅ `creek/models.py` enum definitions match the spec verbatim (already true; now pinned by `test_taxonomy_alignment.py`).
- ✅ Regression test asserts each enum's value list equals the canonical fixture (`test_taxonomy_alignment.py`, fixture in `tests/fixtures/canonical_taxonomy.yaml`).
- ✅ One-release migration aliases via `_missing_` hooks emit a `DeprecationWarning` and route legacy values to canonical members (`test_taxonomy_aliases.py`).
- ✅ `docs/classification.md` and `docs/generation.md` use the spec's vocabulary verbatim.
- ✅ Voice-skill tree directory naming in `docs/generation.md` uses canonical names; runtime emitter (`creek/generate/skills.py`) was already canonical.

## Out of scope (next PR)

- Actually populating the `Orientation` and `Dosage` fields end-to-end through the rules + LLM classifiers — they are wired into the model and shown in `docs/classification.md`'s frontmatter example, but the LLM prompt and rule heuristics still focus on phase/mode/frequency. INC-019 is the taxonomy reconciliation; teaching the classifier to fill the new fields is a separate piece of work.

## Test plan

- [x] `./scripts/check-all.sh` exits 0 (all 9 gates green: linting, formatting, mypy strict, pylint, bandit + pip-audit, complexity, unit tests, coverage 93.53%, per-file coverage)
- [x] New regression suite (41 tests) passes red→green: alignment tests passed immediately (enums already canonical); alias tests + doc-drift tests went red until `_missing_` hooks landed and docs were rewritten.
- [x] No regressions in the broader suite (3051 unit tests pass, 19 integration deselected as default).

https://claude.ai/code/session_014N1Tw4dEhSvuVGHLxfeyZY

---
_Generated by [Claude Code](https://claude.ai/code/session_014N1Tw4dEhSvuVGHLxfeyZY)_