### PR TITLE
docs(skills): schema-skill tree + root AGENTS.md (FEAT-001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,7 +93,7 @@
 !10-Liminal/**/
 !10-Liminal/**/.gitkeep
 
-# 00-Creek-Meta — track Scripts/ fully, .gitkeep in others, Ontology prompt
+# 00-Creek-Meta — track Scripts/ and Skills/ fully, .gitkeep in others, Ontology prompt
 00-Creek-Meta/Templates/**
 !00-Creek-Meta/Templates/**/
 !00-Creek-Meta/Templates/**/.gitkeep
@@ -106,6 +106,10 @@
 !00-Creek-Meta/Ontology/**/
 !00-Creek-Meta/Ontology/**/.gitkeep
 !00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md
+
+# Schema-skill tree (FEAT-001) — fully tracked, parallel to creek-skills/
+!00-Creek-Meta/Skills/
+!00-Creek-Meta/Skills/**
 
 # ============================================================
 # DEVELOPMENT ARTIFACTS

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 
 # --- Explicitly tracked root files ---
 !.gitignore
+!AGENTS.md
 !CLAUDE.md
 !README.md
 

--- a/00-Creek-Meta/Skills/compile.SKILL.md
+++ b/00-Creek-Meta/Skills/compile.SKILL.md
@@ -1,0 +1,102 @@
+# compile.SKILL.md
+
+**Verb:** `creek compile`
+**Layer:** schema → produces compiled-layer pages
+**Budget:** ≤1500 tokens
+**Loaded by:** Claude Code, CrawDad, any agent running rollups
+
+## What `creek compile` does
+
+Compile rolls up fragments from the **raw** layer (`01-Fragments/`) into curated pages on the **compiled** layer (`02-Threads/`, `03-Eddies/`, `04-Praxis/`, `06-Frequencies/`). It is the operation that makes the vault compounding rather than session-bound.
+
+Compile does **not** classify fragments (`creek classify` does). It does **not** resolve contradictions (`creek lint` routes them; `compile` refuses to flatten them). It does **not** ingest new sources (`creek ingest` does).
+
+## The four-layer architecture
+
+`creek compile` is the boundary operation between two of the four layers:
+
+| Layer | Folder(s) | Compile's relationship |
+|---|---|---|
+| **Raw** | `01-Fragments/` | Read-only inputs. Never modified by compile. |
+| **Compiled** | `02-Threads/`, `03-Eddies/`, `04-Praxis/`, `06-Frequencies/` | Compile's only write target. Rewritten in full per run; previous version archived. |
+| **Schema** | `00-Creek-Meta/Ontology/`, `00-Creek-Meta/Skills/`, `AGENTS.md` | Read-only contract. Compile honors it; never edits it. |
+| **Liminal** | `10-Liminal/` (Paradoxes, Unnamed, Synchronicities, Compost) | Compile defers here when synthesis would falsify. See "When compile refuses." |
+
+## Operating discipline
+
+Three rules, in order of precedence:
+
+### 1. Per-source
+
+Each compile run targets one source page at a time — a single Thread, a single Eddy, a single Praxis note, a single Frequency index. Bulk recompile is allowed but is a sequence of per-source runs, not a monolithic pass. This bounds blast radius and makes provenance auditable.
+
+### 2. Interactive (manual trigger)
+
+Compile is human-triggered, not on-write or on-schedule. The human invokes `creek compile <target>` (or accepts a CrawDad proposal); the agent reads the relevant fragments, drafts the compiled page, and presents the diff for human review before writing. No silent recompiles. No auto-recompile on fragment append.
+
+### 3. Provenance-preserving
+
+Every claim on a compiled page must trace back to the fragment(s) that produced it. The compiled page's frontmatter carries:
+
+```yaml
+type: thread | eddy | praxis | frequency_index
+sources:
+  - frag-{id}      # every fragment that contributed
+  - frag-{id}
+compiled_at: "YYYY-MM-DDTHH:MM:SS-08:00"
+compiled_by: claude-code | crawdad | human
+compiled_from: ["01-Fragments/Conversations/...", ...]
+wavelength:
+  phase: rising | peaking | withdrawal | diminishing | bottoming_out | restoration
+  mode: inhabit | express | collaborate | integrate | absorb
+  orientation: do | feel | do_feel
+  dosage: medicine | toxic
+frequency:
+  primary: F1 | F2 | F3 | F4 | F5 | F6 | F7 | F8 | F9 | F10 | unclassified
+  secondary: []
+```
+
+Inline claims that paraphrase a fragment carry a per-claim provenance pointer (e.g., `[^frag-abc12]`) so a downstream consumer (`creek draft`, CrawDad reflection) can verify against source. Lossy compression here is the load-bearing risk for voice fidelity; treat provenance loss as a compile bug.
+
+## Canonical taxonomy
+
+Compile uses these names verbatim. INC-019 reconciled drift; do not paraphrase.
+
+- **Phases (six):** Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration.
+- **Modes (five):** Inhabit, Express, Collaborate, Integrate, Absorb.
+- **Orientations:** Do, Feel, Do/Feel.
+- **Dosage:** Medicine, Toxic.
+- **Frequencies (ten):** F1 Agency, F2 Receptivity, F3 Self-Love / Power, F4 Community Love / Conformity, F5 Achievism, F6 Pluralism, F7 Integration, F8 True Self / Transcendence, F9 Unity, F10 Emptiness.
+
+Compiled pages must inherit these tags from their source fragments. When source fragments disagree on phase/mode/dosage, surface both — never collapse to the majority.
+
+## When compile refuses
+
+Compile actively defers to `10-Liminal/` rather than synthesize across:
+
+| Situation | Destination |
+|---|---|
+| Fragments contradict on a settled claim | `10-Liminal/Paradoxes/` (link both fragments; do not pick a winner) |
+| Pattern present in fragments but no Thread or Eddy fits | `10-Liminal/Unnamed/` (let it cluster; recompile after the next Unnamed Digest) |
+| Cross-source semantic identity > 0.9 across >30 days, different sources | `10-Liminal/Synchronicities/` |
+| Thread has gone dormant or resolved with abandoned energy | `10-Liminal/Compost/` |
+
+These are not error states. They are the system honoring the spec's §10 emergence infrastructure. A compile run that produces compiled-page output **and** Liminal-folder output for the same target is correct, not broken.
+
+## What good output looks like
+
+A compiled page is correct when:
+
+- Every paragraph of synthesis carries a provenance pointer to ≥1 fragment.
+- Phase, mode, orientation, dosage, frequency in the frontmatter match the canonical taxonomy verbatim.
+- No contradictions are silently resolved — divergent stances are either preserved on the page or routed to `10-Liminal/Paradoxes/`.
+- The page reads as the human's voice, not a generic summary. Use the voice-skill tree at `creek-skills/` to condition tone.
+- The previous version is archived (not overwritten in place) so the audit trail through `00-Creek-Meta/Processing-Log/` stays append-only.
+
+## What compile does not do
+
+- Does not classify. `creek classify` writes per-fragment frontmatter; compile reads it.
+- Does not lint. `creek lint` checks hygiene; compile produces the artifacts that lint inspects.
+- Does not save. `creek save` files good answers back into the vault as new fragments or compiled pages; compile only consumes existing fragments.
+- Does not delete. Compile is additive (with archive); deletion is `creek purge` and requires elevated auth.
+- Does not bypass privacy tiers. Intimate-tier fragments may appear in compiled pages only when the human has explicitly opted in for that target.

--- a/00-Creek-Meta/Skills/compile.SKILL.md
+++ b/00-Creek-Meta/Skills/compile.SKILL.md
@@ -51,12 +51,15 @@ wavelength:
   mode: inhabit | express | collaborate | integrate | absorb
   orientation: do | feel | do_feel
   dosage: medicine | toxic
+  observed_phase: rising | peaking | withdrawal | diminishing | bottoming_out | restoration  # optional; see save.SKILL.md
 frequency:
   primary: F1 | F2 | F3 | F4 | F5 | F6 | F7 | F8 | F9 | F10 | unclassified
   secondary: []
 ```
 
 Inline claims that paraphrase a fragment carry a per-claim provenance pointer (e.g., `[^frag-abc12]`) so a downstream consumer (`creek draft`, CrawDad reflection) can verify against source. Lossy compression here is the load-bearing risk for voice fidelity; treat provenance loss as a compile bug.
+
+`wavelength.observed_phase` may appear when a saved note (`creek save`) inherited a phase from its source conversation but the conversation itself contradicted that phase — see `save.SKILL.md` for the dual-phase convention. Compile reads both when reconciling; downstream consumers should expect either field.
 
 ## Canonical taxonomy
 

--- a/00-Creek-Meta/Skills/lint.SKILL.md
+++ b/00-Creek-Meta/Skills/lint.SKILL.md
@@ -1,0 +1,104 @@
+# lint.SKILL.md
+
+**Verb:** `creek lint`
+**Layer:** schema → reads compiled + raw + liminal layers, writes a report
+**Budget:** ≤1500 tokens
+**Loaded by:** Claude Code, CrawDad, any agent surfacing "what's growing / stale / contradicting / orphaned"
+
+## What `creek lint` does
+
+`creek lint` is the unified hygiene operation across the vault. It runs five checks, produces one consolidated markdown report, and proposes fixes that the human approves. It replaces the five separate `creek report --type {tags|unnamed|synchronicity|compost|paradox}` entry points with one verb.
+
+## The load-bearing guard rail
+
+> **Lint never resolves paradoxes; contradictions route to `10-Liminal/Paradoxes/`.**
+
+This sentence is the difference between a generic-wiki lint and a Creek lint. Karpathy's lint treats contradictions as defects to fix. Creek treats them as data about a polygnostic human. The guard rail is non-negotiable and is repeated verbatim in the lint module's docstring (per FEAT-008 enforcement).
+
+## The five checks
+
+| Check | What it surfaces | Action |
+|---|---|---|
+| **Orphans** | Compiled pages with zero inbound links; orphan tags from the Tag Garden | Flag for review. Orphan *fragments* are normal — only orphan compiled pages get flagged. |
+| **Contradictions** | Two or more fragments with directly opposing stances on a settled claim | Route both fragments to `10-Liminal/Paradoxes/` with `#paradox` and the relevant Frequencies. Never pick a winner. |
+| **Stale claims** | Compiled-page claims a newer fragment supersedes | Flag for human review. Claims are versioned, not deleted. |
+| **Missing pages** | Important concepts mentioned ≥N times across fragments but lacking their own Thread/Eddy/Praxis | Route to `10-Liminal/Unnamed/` for the next Unnamed Digest. **Never auto-create compiled pages.** |
+| **Data gaps** | Topics where the vault has questions but no fragment answers them | Surface as questions in the report. Do not auto-fetch from web; CrawDad's conversational mode picks these up later. |
+
+## Deterministic vs. semantic checks
+
+Two cost classes; lint runs them on different cadences:
+
+- **Deterministic** (always run, fast): broken wiki-links, frontmatter validation, tag co-occurrence, orphan detection, schema-skill token-budget enforcement (this file ≤1500 tokens; `AGENTS.md` ≤3000 tokens).
+- **Semantic** (slower, behind a flag or longer cadence): contradiction detection, synchronicity surfacing, unnamed clustering — these consume embeddings and/or LLM calls.
+
+Default behavior:
+
+```bash
+creek lint --vault <path>                  # all deterministic checks; semantic on default cadence
+creek lint --vault <path> --check tags     # single check
+creek lint --vault <path> --report-only    # don't propose fixes
+creek lint --vault <path> --since 7d       # incremental (deterministic checks default to incremental)
+```
+
+## What lint must never do
+
+These are non-negotiable behaviors documented in the lint module's docstring (FEAT-008 enforces):
+
+1. **Never auto-create compiled pages.** Force-classification violates liminal preservation. Missing-page candidates go to `10-Liminal/Unnamed/`, where they cluster naturally. The human (or `creek compile`) decides when an Unnamed pattern earns a Thread or Eddy.
+2. **Never resolve contradictions.** Lint never resolves paradoxes; contradictions route to `10-Liminal/Paradoxes/`.
+3. **Never delete orphan fragments.** Isolated insights belong somewhere even when not yet linked. Only orphan *compiled* pages are candidates for deletion, and only after human review.
+4. **Never auto-fetch external data.** "Data gaps" are presented as questions in the report, not as web-search prompts.
+5. **Never bypass privacy tiers.** Lint reads frontmatter freely, but body content from intimate-tier fragments stays out of the report. Personal-tier bodies appear only as title + summary unless the human has opted in.
+
+## Report shape
+
+One consolidated markdown document, one section per check, with a header summary:
+
+```markdown
+# Creek Lint Report — YYYY-MM-DD
+
+## Summary
+- Checks run: orphans, contradictions, stale claims, missing pages, data gaps
+- Mode: deterministic + semantic
+- Window: --since 7d
+
+## Orphans
+...
+
+## Contradictions
+- Routed to 10-Liminal/Paradoxes/: 3
+...
+
+## Stale claims
+...
+
+## Missing pages
+- Routed to 10-Liminal/Unnamed/: 7
+...
+
+## Data gaps
+- Open questions (no auto-fetch): 4
+...
+```
+
+Output lives at `00-Creek-Meta/Processing-Log/lint/YYYY-MM-DD.md`. The processing log is append-only; previous reports are not overwritten.
+
+## Canonical taxonomy
+
+Lint reports use these names verbatim (INC-019 reconciliation):
+
+- **Phases (six):** Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration.
+- **Modes (five):** Inhabit, Express, Collaborate, Integrate, Absorb.
+- **Orientations:** Do, Feel, Do/Feel.
+- **Dosage:** Medicine, Toxic.
+- **Frequencies (ten):** F1 Agency, F2 Receptivity, F3 Self-Love / Power, F4 Community Love / Conformity, F5 Achievism, F6 Pluralism, F7 Integration, F8 True Self / Transcendence, F9 Unity, F10 Emptiness.
+
+When lint surfaces a paradox or a missing page, frontmatter on the routed Liminal note carries the relevant Frequency tags so future compiles can pick them up.
+
+## What lint does not do
+
+- Does not compile. `creek compile` produces compiled pages; lint inspects them.
+- Does not save. `creek save` files good answers back; lint inspects what's been saved.
+- Does not classify. `creek classify` assigns frequency/phase/mode; lint validates the assignments.
+- Does not purge. `creek purge` deletes; lint flags candidates and stops.

--- a/00-Creek-Meta/Skills/save.SKILL.md
+++ b/00-Creek-Meta/Skills/save.SKILL.md
@@ -1,0 +1,99 @@
+# save.SKILL.md
+
+**Verb:** `creek save`
+**Layer:** schema → writes to raw, compiled, or liminal layer depending on destination
+**Budget:** ≤1500 tokens
+**Loaded by:** Claude Code, CrawDad, any agent that wants to file a good answer back into the vault
+
+## What `creek save` does
+
+`creek save` files a good answer — a reflection, a comparison, a connection, a draft, a named contradiction — back into the vault. It is the mechanic that differentiates "wiki" from "stored chat history." Without it, every conversation re-derives the same insights from scratch.
+
+The command takes a body, a target type, optional fragment provenance, and writes a properly-classified note with full frontmatter to the right destination.
+
+## The destination decision
+
+Six destinations. The agent (or human) picks one explicitly per save call; ambiguity routes to `unnamed`.
+
+| Destination | Folder | When to pick it |
+|---|---|---|
+| **thread** | `02-Threads/Active/` (or `Dormant/`, `Resolved/`) | A reflection that names a known *narrative current* in a fresh way — temporal, has a direction. |
+| **eddy** | `03-Eddies/` | A reflection that names a *topic cluster* — a recurring concern, project, or area of attention. |
+| **praxis** | `04-Praxis/Daily/` (or `Seasonal/`, `Situational/`) | A reflection that produces an *actionable insight* or practice the human can deepen. |
+| **paradox** | `10-Liminal/Paradoxes/` | A reflection that names a contradiction. **Save preserves it; never resolves it.** |
+| **unnamed** | `10-Liminal/Unnamed/` | A pattern that's clearly real but doesn't fit anywhere yet. The default for ambiguous routing. |
+| **draft** | `07-Voice/Drafts/` | A draft fragment of writing — essay seed, blog idea, Substack outline — that the human may polish. |
+
+The simplest viable v1 is to ask the human: `creek save --target {thread|eddy|praxis|paradox|unnamed|draft}`. The smarter v1.1 is for CrawDad to propose a target and let the human confirm, using the same rules-then-LLM pipeline as `creek classify`.
+
+## Privacy-tier defaults
+
+Privacy tiers come from spec §13.2 and gate what `creek save` will write. The defaults:
+
+| Tier | Sources (examples) | Auto-save default |
+|---|---|---|
+| **Open** | Published essays, public Discord messages | Full save (title + body + frontmatter). |
+| **Personal** | Chatbot conversations, private Discord messages | Title + summary only by default. Body saves only when the human passes `--include-body` per call. |
+| **Intimate** | Journal entries, recovery-related content | **Never auto-saves.** Human must invoke save explicitly with `--tier intimate --consent` per call; otherwise the operation refuses. Never enters voice-proxy generation. |
+
+Privacy tier is inherited from the source conversation/fragment. A reflection generated during a conversation that touched intimate content is intimate by default; the agent must explicitly down-tier with human consent.
+
+## Required frontmatter
+
+Every saved note carries:
+
+```yaml
+type: thread | eddy | praxis | paradox | unnamed | draft
+id: {primitive}-{uuid-short}
+title: "{auto-generated, human-overridable}"
+created: "YYYY-MM-DDTHH:MM:SS-08:00"
+saved_by: claude-code | crawdad | human
+saved_from:
+  source: claude-code-conversation | discord | journal | other
+  conversation_id: "{if applicable}"
+  message_id: "{Discord message ID, if applicable}"
+provenance:
+  contributing_fragments:
+    - frag-{id}        # fragments that informed this answer
+    - frag-{id}
+  activated_skills:
+    - voice-core
+    - {phase-skill, mode-skill, frequency-skill, register-skill}
+privacy_tier: open | personal | intimate
+consent: explicit | inherited      # required when tier is intimate
+wavelength:
+  phase: rising | peaking | withdrawal | diminishing | bottoming_out | restoration
+  mode: inhabit | express | collaborate | integrate | absorb
+  orientation: do | feel | do_feel
+  dosage: medicine | toxic
+frequency:
+  primary: F1 | F2 | F3 | F4 | F5 | F6 | F7 | F8 | F9 | F10 | unclassified
+  secondary: []
+```
+
+CrawDad knows the human's recent wavelength position; saved notes inherit it unless the conversation explicitly contradicts. When the conversation suggests a different phase/mode, save both as `wavelength.phase` and `wavelength.observed_phase` so the next compile can reconcile.
+
+## Canonical taxonomy
+
+Save uses these names verbatim (INC-019 reconciliation):
+
+- **Phases (six):** Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration.
+- **Modes (five):** Inhabit, Express, Collaborate, Integrate, Absorb.
+- **Orientations:** Do, Feel, Do/Feel.
+- **Dosage:** Medicine, Toxic.
+- **Frequencies (ten):** F1 Agency, F2 Receptivity, F3 Self-Love / Power, F4 Community Love / Conformity, F5 Achievism, F6 Pluralism, F7 Integration, F8 True Self / Transcendence, F9 Unity, F10 Emptiness.
+
+## Operating discipline
+
+1. **Auto-filing is opt-in per command.** A `/crawdad reflect` that auto-files everything is the wrong default. Save is explicit, both for privacy and because the human owns what enters the vault.
+2. **Paradoxes route to `paradox`, never to `thread` or `eddy`.** A regression test (FEAT-009) verifies this. Saving a contradiction as a synthesis page is a bug, not a feature.
+3. **Provenance is required, not optional.** A save without `contributing_fragments` provenance is rejected. If the answer didn't draw on fragments, it's not a save target — it's a new fragment, route through `creek ingest` instead.
+4. **The human can always overwrite.** The auto-generated title, the proposed destination, the inherited tier — all are defaults. The human's explicit choice wins.
+5. **Liminal destinations are first-class.** `paradox` and `unnamed` are not consolation prizes; they are the right destinations when they're the right destinations. Honor them.
+
+## What save does not do
+
+- Does not compile. Saved Threads/Eddies/Praxis appear in the compiled layer but are seeds, not rollups; `creek compile` later integrates them.
+- Does not lint. Saved notes get inspected by `creek lint` like any other compiled-layer artifact.
+- Does not bypass `creek purge`. Saved notes are deletable like any other; saving never grants permanence.
+- Does not file intimate content silently. Refuses without explicit consent.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,81 @@
+# AGENTS.md — Creek Vault Agent Contract
+
+**Status:** Schema entry point. ≤3000 tokens. Points at canonical material; does not duplicate it.
+
+This file is the first thing an agent (Claude Code, CrawDad, or any other LLM session) loads when starting work in the Creek Vault. It defines the four-verb contract — **compile / query / lint / save** — and points at the canonical specification and the per-verb schema skills.
+
+## Canonical specification
+
+The single source of truth for the Creek Ontology is:
+
+- [`00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md`](00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md)
+
+When this file and the spec disagree, **the spec wins.** This file is a pointer; do not paraphrase the spec here.
+
+## The four-layer architecture
+
+Creek's data model has four layers with explicit ownership:
+
+| Layer | Folder(s) | Owner | Mutability |
+|---|---|---|---|
+| **Raw** | `01-Fragments/` | Human-writable, ingestor-writable | Append-only after ingest; provenance frozen |
+| **Compiled** | `02-Threads/`, `03-Eddies/`, `04-Praxis/`, `06-Frequencies/` | LLM-curated, human-reviewed | Rewritable by `creek compile`; every claim links back to fragment IDs |
+| **Schema** | `00-Creek-Meta/Ontology/`, `00-Creek-Meta/Skills/`, this file | Human + agent co-evolved | Versioned; changes are deliberate |
+| **Liminal** | `10-Liminal/` (Paradoxes, Unnamed, Synchronicities, Compost) | LLM-surfaced, human-curated | Compilation explicitly fails or refuses here — that's the point |
+
+The voice-skill tree at `creek-skills/` (LLM-conditioning material) is parallel to and distinct from the schema-skill tree at `00-Creek-Meta/Skills/` (operational instructions). Do not conflate them.
+
+## The four-verb contract
+
+Every agent operating on the vault uses these four verbs. Each has a dedicated schema-skill file under `00-Creek-Meta/Skills/`; load the relevant one when the verb is invoked.
+
+| Verb | Skill file | What it does |
+|---|---|---|
+| `creek compile` | [`00-Creek-Meta/Skills/compile.SKILL.md`](00-Creek-Meta/Skills/compile.SKILL.md) | Per-source, interactive, provenance-preserving rollup of fragments → compiled-layer pages (Threads, Eddies, Praxis, Frequency indexes) |
+| `creek query` | (covered inline in this file; dedicated skill arrives with FEAT-004) | Read the compiled layer first; fall back to fragments only when the compiled page is missing or insufficient |
+| `creek lint` | [`00-Creek-Meta/Skills/lint.SKILL.md`](00-Creek-Meta/Skills/lint.SKILL.md) | Unified hygiene check across orphans, contradictions, stale claims, missing pages, data gaps. **Lint never resolves paradoxes; contradictions route to `10-Liminal/Paradoxes/`.** |
+| `creek save` | [`00-Creek-Meta/Skills/save.SKILL.md`](00-Creek-Meta/Skills/save.SKILL.md) | File a good answer back into the vault as thread / eddy / praxis / paradox / unnamed / draft, honoring privacy tiers |
+
+### Query — the compiled-layer-first rule
+
+Until FEAT-004 ships a dedicated `query.SKILL.md`, the contract is:
+
+1. **Compiled-layer first.** When asked "what does the vault know about X?", read the relevant Thread, Eddy, or Frequency-index page first.
+2. **Fragments are the fallback.** Drop down to `01-Fragments/` only when the compiled page is missing, stale, or contradicts what fresh fragments say. When you do, surface the discrepancy as a `creek lint` candidate.
+3. **`10-Liminal/` is not a fallback.** It's a deliberate destination, not an overflow bin. Don't read from it as if it were a synthesis layer; read from it to honor what the system has refused to flatten.
+
+## Canonical taxonomy
+
+All schema skills, compile prompts, lint reports, and save destinations use these names verbatim. No synonyms, no abbreviations. INC-019 reconciled drift here; do not re-introduce it.
+
+- **Wavelength phases (six):** Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration.
+- **Wavelength modes (five):** Inhabit, Express, Collaborate, Integrate, Absorb.
+- **Wavelength orientations:** Do, Feel, Do/Feel.
+- **Wavelength dosage:** Medicine, Toxic.
+- **APTITUDE frequencies (ten):** F1 Agency, F2 Receptivity, F3 Self-Love / Power, F4 Community Love / Conformity, F5 Achievism, F6 Pluralism, F7 Integration, F8 True Self / Transcendence, F9 Unity, F10 Emptiness.
+
+For the full definitions of each, see spec §6 (Frequencies) and §7 (Wavelength). For the Medicine/Toxic-by-phase map, see §7.3.
+
+## Non-negotiables
+
+These hard constraints come from the spec; they are repeated here because every verb depends on them:
+
+1. **Liminal preservation.** Paradoxes are data, not defects. Unnamed patterns are research sites, not failures. The four verbs honor this — `compile` refuses to flatten contradictions, `lint` routes them to `10-Liminal/`, `save` has a `paradox` destination, and `query` reads `10-Liminal/` only when it is the right destination.
+2. **Provenance preservation.** Every claim on a compiled page traces back to fragment IDs in frontmatter. No orphan synthesis. See `compile.SKILL.md` for the required frontmatter shape.
+3. **Privacy tiers (Open / Personal / Intimate).** Intimate content never auto-saves and never enters voice-proxy generation without explicit consent. Personal content saves title + summary only by default. See `save.SKILL.md` for defaults and spec §13.2 for sources.
+4. **No external API calls during ingestion.** The LLM classification pass is the only stage that may hit a cloud API, and only when the human has explicitly opted in. Compile, lint, save, and query are local-default.
+5. **The human owns what enters the vault.** Auto-filing is opt-in per command. The human is the curator; the agent is the bookkeeper.
+
+## Token budgets
+
+- This file: **≤3000 tokens.**
+- Each schema skill under `00-Creek-Meta/Skills/`: **≤1500 tokens.**
+
+A `creek lint` size check enforces these budgets (FEAT-008). Files over budget fail the build.
+
+## What this file is not
+
+- Not the spec. The spec is `00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md`.
+- Not the voice-skill tree. That lives at `creek-skills/` and is generated by `creek-tools/creek/generate/skills.py`.
+- Not the engineering CLAUDE.md. `creek-tools/CLAUDE.md` covers Python quality standards for the tooling subproject and is unrelated to vault semantics.
+- Not exhaustive. When in doubt, follow the spec, then the relevant schema skill, then ask.

--- a/plans/git-issues/FEAT-004-compiled-layer-query-routing.md
+++ b/plans/git-issues/FEAT-004-compiled-layer-query-routing.md
@@ -21,6 +21,7 @@ Make `creek mine` and `creek draft` route through the compiled layer first, fall
 - `creek-tools/tests/test_mining.py` — add cases that verify compiled-layer-first behaviour.
 - `creek-tools/tests/test_drafts.py` — same.
 - `creek-tools/docs/generation.md` — document the routing change and the `--bypass-compiled` flag.
+- `00-Creek-Meta/Skills/query.SKILL.md` (new) — extract the query contract from `AGENTS.md` (currently inline as 3 rules) into a dedicated schema-skill file, replacing the inline rules with a pointer. FEAT-001 deliberately shipped query inline and noted the asymmetry; this FEAT closes that gap so an agent loading only `AGENTS.md` gets full coverage of all four verbs.
 
 ## Pre-decided choices
 
@@ -44,6 +45,7 @@ Make `creek mine` and `creek draft` route through the compiled layer first, fall
 - A regression test verifies that `creek draft` without `--bypass-compiled` routes through the compiled layer in the absence of `--bypass-compiled` (this is the AC pinned in ADOPT-001).
 - ≥90% branch coverage on the changed paths.
 - Documentation in `docs/generation.md` updated.
+- `00-Creek-Meta/Skills/query.SKILL.md` exists, ≤1500 tokens, and `AGENTS.md`'s inline 3-rule query coverage is replaced with a pointer to it (closes the FEAT-001 asymmetry where compile/lint/save have dedicated skills but query is inline).
 
 ## References
 


### PR DESCRIPTION
Implements [FEAT-001](../blob/main/plans/git-issues/FEAT-001-schema-skills-compile-lint-save.md) — the schema-skill foundation that subsequent compile / lint / save FEATs reference.

## Summary

- New `AGENTS.md` at vault root: thin entry point that points at `00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md` as canonical and defines the four-verb contract (compile / query / lint / save).
- New `00-Creek-Meta/Skills/` (parallel to, not nested under, the voice-skill tree at `creek-skills/`):
  - `compile.SKILL.md` — per-source / interactive / provenance-preserving rollups, with the four-layer architecture (raw / compiled / schema / liminal).
  - `lint.SKILL.md` — five checks (orphans, contradictions, stale claims, missing pages, data gaps) with the verbatim guard rail.
  - `save.SKILL.md` — destination decision (thread / eddy / praxis / paradox / unnamed / draft) and privacy-tier defaults.
- `.gitignore`: whitelist `AGENTS.md` alongside the other tracked root files.

Total diff: **387 LOC**, well under the 700-LOC ceiling.

## Acceptance criteria — verified

- [x] **AGENTS.md exists at vault root**, ≤3000 tokens, points at `creek_ontology_agent_prompt.md` as canonical rather than duplicating it. (Approx 1175–1590 tokens by word/char rule-of-thumb.)
- [x] **`compile.SKILL.md` exists**, ≤1500 tokens, defines compile as **per-source / interactive / provenance-preserving** and explicitly references the **four-layer architecture (raw / compiled / schema / liminal)**.
- [x] **`lint.SKILL.md` exists**, ≤1500 tokens, lists the lint checks (orphans, contradictions, stale claims, missing pages, data gaps) and includes the verbatim guard rail: *"Lint never resolves paradoxes; contradictions route to `10-Liminal/Paradoxes/`."*
- [x] **`save.SKILL.md` exists**, ≤1500 tokens, documents the destination decision (thread / eddy / praxis / paradox / unnamed / draft) and the privacy-tier defaults (Open / Personal / Intimate).
- [x] **All four files use the canonical INC-019 taxonomy verbatim**: Rising/Peaking/Withdrawal/Diminishing/Bottoming Out/Restoration; Inhabit/Express/Collaborate/Integrate/Absorb; F1–F10.

## Pre-decided choices honored

- Verb is `creek compile` (REJECT-004 metaphor noted; verb retained).
- Schema-skills location is `00-Creek-Meta/Skills/`, parallel to (not nested under) `creek-skills/`.
- `AGENTS.md` (not `CLAUDE.md`) at vault root.
- Token budgets: AGENTS.md ≤3000; each SKILL.md ≤1500.

## Dependencies

- INC-019 (taxonomy reconciliation) is merged on `main` (commit `66fa6f4`, PR #203). ✓

## Test plan

- [x] Files load cleanly when concatenated; no contradictions with the ontology spec.
- [x] All four files use canonical taxonomy verbatim.
- [x] Verbatim guard rail present in `lint.SKILL.md`.
- [x] Token budgets documented in each file's header; FEAT-008 will add the lint check that enforces them (per the FEAT test plan: *"for this PR, ship a documented size limit and a failing check is acceptable"*).
- [x] No code-level tests in this PR; deliverables are markdown only (per FEAT test plan).

## Stay-Green note

`./scripts/check-all.sh` in `creek-tools/` shows 5 failing checks (Type checking, Security, Unit tests, Coverage, Per-file coverage gate) — verified pre-existing on `origin/main` with the same environment, unrelated to this docs-only diff. They reflect environmental drift (mypy/anthropic SDK/document-parser modules) tracked elsewhere; no regressions introduced here.

---

Source candidate: [`plans/2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md`](../blob/main/plans/2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md) (part 1 of 2).

https://claude.ai/code/session_014DPE864uGDFrwHHn2XEqbU

---
_Generated by [Claude Code](https://claude.ai/code/session_014DPE864uGDFrwHHn2XEqbU)_