### PR TITLE
feat(pipeline): deterministic-first three-pass vocabulary + --no-llm (FEAT-005)

### DIFF
--- a/creek-tools/creek/audit/__init__.py
+++ b/creek-tools/creek/audit/__init__.py
@@ -11,5 +11,19 @@ directly only when introducing a new compliance log surface.
 """
 
 from creek.audit.log import AuditChainBroken, AuditChainBrokenError, AuditLog
+from creek.audit.yield_summary import (
+    PreLLMYieldSummary,
+    format_yield_line,
+    write_yield_summary,
+    yield_summary_path,
+)
 
-__all__ = ["AuditChainBroken", "AuditChainBrokenError", "AuditLog"]
+__all__ = [
+    "AuditChainBroken",
+    "AuditChainBrokenError",
+    "AuditLog",
+    "PreLLMYieldSummary",
+    "format_yield_line",
+    "write_yield_summary",
+    "yield_summary_path",
+]

--- a/creek-tools/creek/audit/yield_summary.py
+++ b/creek-tools/creek/audit/yield_summary.py
@@ -1,0 +1,112 @@
+"""Pre-LLM yield summary writer (FEAT-005).
+
+After every ``creek process`` run the pipeline reports how much work the
+deterministic and local-model passes (Pass 1 + Pass 2) accomplished
+without ever invoking the network LLM (Pass 3). This module owns the
+on-disk format: one JSONL line per run, appended to
+``<vault>/00-Creek-Meta/Processing-Log/run-summary.jsonl``.
+
+The format is deliberately not chained (unlike :class:`creek.audit.AuditLog`)
+because run summaries are operational telemetry, not compliance evidence —
+losing or skipping a line is recoverable (just re-run), and a hash chain
+would force a global write lock on what is otherwise an append-only
+stream that downstream tools want to ``tail``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+_LOG_SUBPATH = ("00-Creek-Meta", "Processing-Log", "run-summary.jsonl")
+
+
+class PreLLMYieldSummary(BaseModel):
+    """One pipeline run's deterministic / local-model / residue counts.
+
+    Attributes:
+        run_id: Stable identifier for the pipeline run; used to correlate
+            the summary line with provenance and audit entries.
+        deterministic_classified: Fragments confidently classified by
+            Pass 1 (rules) — including ``human_review_sources`` whose
+            policy is to skip the LLM entirely.
+        local_model_processed: Fragments that went through Pass 2
+            (embeddings / OCR). On a normal run this equals the count of
+            fragments handed to the linker; ``--no-llm`` does not change
+            this number.
+        residue: Fragments that the rule classifier left uncertain —
+            i.e. would have been routed to the LLM if Pass 3 were
+            enabled. Reported even when Pass 3 ran, so audit consumers
+            can see the deterministic-pass yield for any run.
+        no_llm: Whether the run was launched with ``--no-llm``. False
+            for normal runs that did dispatch residue to the LLM.
+        timestamp: UTC timestamp of summary emission, populated
+            automatically when omitted.
+    """
+
+    run_id: str
+    deterministic_classified: int
+    local_model_processed: int
+    residue: int
+    no_llm: bool
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+def format_yield_line(summary: PreLLMYieldSummary) -> str:
+    """Return the human-readable stdout line documented in FEAT-005.
+
+    The exact wording is pinned by the FEAT and consumed verbatim by the
+    audit report (FEAT-006), so the format string is intentionally
+    rigid — do not localise or reorder the segments.
+
+    Args:
+        summary: The yield counts to render.
+
+    Returns:
+        A single-line string suitable for ``console.print`` or stdout.
+    """
+    return (
+        f"Deterministic: {summary.deterministic_classified} classified | "
+        f"Local-model: {summary.local_model_processed} embedded/OCR'd | "
+        f"Residue: {summary.residue} (would go to LLM if Pass-3 enabled)"
+    )
+
+
+def yield_summary_path(vault_path: Path) -> Path:
+    """Resolve the canonical path for ``run-summary.jsonl`` under *vault_path*.
+
+    Args:
+        vault_path: Vault root.
+
+    Returns:
+        ``<vault>/00-Creek-Meta/Processing-Log/run-summary.jsonl``.
+    """
+    return vault_path.joinpath(*_LOG_SUBPATH)
+
+
+def write_yield_summary(*, vault_path: Path, summary: PreLLMYieldSummary) -> Path:
+    """Append *summary* to ``run-summary.jsonl`` under *vault_path*.
+
+    Creates the parent directory tree on demand. Each call appends one
+    JSONL line — the file is read by FEAT-006's audit report by streaming
+    line-by-line, so callers MUST NOT rewrite or reorder existing lines.
+
+    Args:
+        vault_path: Vault root the run was processed into.
+        summary: The yield counts to persist.
+
+    Returns:
+        The absolute path of the written log file.
+    """
+    log_path = yield_summary_path(vault_path)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    line = summary.model_dump_json()
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(line + "\n")
+    return log_path

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -386,6 +386,17 @@ def process(
         "-y",
         help="Skip the consent prompt for first-time sources (logged).",
     ),
+    no_llm: bool = typer.Option(
+        False,
+        "--no-llm",
+        help=(
+            "Skip Pass 3 (LLM classification). Pass 1 (deterministic) "
+            "and Pass 2 (local model: embeddings, OCR) still run; "
+            "residue is reported but never sent to Anthropic / Ollama. "
+            "Wins over LLMConfig.provider — safe to combine with "
+            "provider: anthropic for an audited zero-egress run."
+        ),
+    ),
 ) -> None:
     """Run the full pipeline: redact, ingest, classify, link, index.
 
@@ -394,6 +405,11 @@ def process(
     clear them. Per-source consent is enforced — first-time sources
     prompt for confirmation before ingestion. Use ``--yes`` to skip the
     prompt in non-interactive contexts (the bypass is logged).
+
+    Pass ``--no-llm`` to run the deterministic and local-model passes
+    end-to-end without ever invoking Pass 3 (LLM classification). The
+    pre-LLM yield line emitted at the end of the run reports the
+    deterministic / local-model / residue counts.
     """
     config = load_config()
     source_path = source or config.source_drive
@@ -401,7 +417,8 @@ def process(
 
     console.print(
         f"[bold green]Running full pipeline: "
-        f"source={source_path}, vault={vault_path}[/bold green]"
+        f"source={source_path}, vault={vault_path}"
+        f"{' (no-LLM)' if no_llm else ''}[/bold green]"
     )
 
     consent_manager = _gate_consent(
@@ -411,7 +428,11 @@ def process(
         assume_yes=yes,
     )
 
-    pipeline = Pipeline(config=config, consent_manager=consent_manager)
+    pipeline = Pipeline(
+        config=config,
+        consent_manager=consent_manager,
+        no_llm=no_llm,
+    )
     try:
         result = pipeline.run(source_path=source_path, vault_path=vault_path)
     except RedactionRequiredError as exc:
@@ -423,6 +444,12 @@ def process(
     console.print(f"[bold]Classifications made:[/bold] {result.classifications_made}")
     console.print(f"[bold]Links found:[/bold] {result.links_found}")
     console.print(f"[bold]Indexes generated:[/bold] {result.indexes_generated}")
+    console.print(
+        f"[bold]Deterministic:[/bold] {result.deterministic_classified} classified | "
+        f"[bold]Local-model:[/bold] {result.local_model_processed} embedded/OCR'd | "
+        f"[bold]Residue:[/bold] {result.residue} "
+        "(would go to LLM if Pass-3 enabled)"
+    )
     error_count = len(result.errors)
     error_style = "red" if error_count else "dim"
     console.print(f"[bold {error_style}]Errors:[/bold {error_style}] {error_count}")

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -13,13 +13,29 @@ the scanner finds unresolved sensitive content, the pipeline raises
 ``creek redact --apply`` first. This trades a small ergonomic cost for the
 guarantee that ``creek process`` can never silently leak secrets into the
 vault.
+
+The pipeline runs in three named passes (FEAT-005):
+
+* **Pass 1 (deterministic, local):** redaction scan, ingestion, rules-based
+  classification, frontmatter generation. No network egress.
+* **Pass 2 (local model-based):** embeddings, OCR, future Whisper. Local
+  model inference; still no network egress.
+* **Pass 3 (network if opted in):** LLM classification of residue. Skipped
+  entirely when ``no_llm`` is set, in which case the privacy claim
+  "network egress only in Pass 3" is enforced by construction.
 """
 
 import logging
+import uuid
 from pathlib import Path
 
 from pydantic import BaseModel, Field
 
+from creek.audit.yield_summary import (
+    PreLLMYieldSummary,
+    format_yield_line,
+    write_yield_summary,
+)
 from creek.classify.llm import LLMClassifier
 from creek.classify.review import ReviewQueueGenerator
 from creek.classify.rules import RuleClassifier
@@ -75,6 +91,17 @@ class PipelineResult(BaseModel):
         classifications_made: Number of fragments classified.
         links_found: Total link count across all linking stages.
         indexes_generated: Number of index notes generated.
+        deterministic_classified: Fragments confidently resolved by Pass 1
+            (rules + ``human_review_sources`` short-circuit). Reported on
+            every run so the audit report (FEAT-006) can graph the
+            deterministic-pass yield over time.
+        local_model_processed: Fragments that traversed Pass 2 (embeddings
+            / OCR). Equals the count handed to the linking pipeline; the
+            ``--no-llm`` flag does not change this number.
+        residue: Fragments the rule classifier left uncertain — i.e.
+            would have been routed to the LLM if Pass 3 were enabled.
+            Always reported, even on normal runs that did dispatch the
+            residue.
         errors: Human-readable error messages collected from each stage.
             Each entry is prefixed with its source ingestor name so the
             user can trace the failure back to the offending file.
@@ -85,6 +112,9 @@ class PipelineResult(BaseModel):
     classifications_made: int = 0
     links_found: int = 0
     indexes_generated: int = 0
+    deterministic_classified: int = 0
+    local_model_processed: int = 0
+    residue: int = 0
     errors: list[str] = Field(default_factory=list)
 
 
@@ -114,6 +144,8 @@ class Pipeline:
         self,
         config: CreekConfig,
         consent_manager: ConsentManager | None = None,
+        *,
+        no_llm: bool = False,
     ) -> None:
         """Initialise the pipeline and all subsystem components.
 
@@ -121,9 +153,17 @@ class Pipeline:
             config: Top-level Creek configuration.
             consent_manager: Optional consent manager. When provided,
                 ``run()`` checks for prior consent before ingesting.
+            no_llm: When ``True``, skip Pass 3 (LLM classification)
+                entirely. The deterministic and local-model passes still
+                run; the run summary records ``no_llm: true`` and the
+                pipeline never invokes ``llm_classifier.classify`` —
+                guaranteeing zero network egress along the LLM path.
+                The flag wins over ``LLMConfig.provider`` so passing
+                ``no_llm=True`` with ``provider: anthropic`` is safe.
         """
         self.config = config
         self.consent_manager = consent_manager
+        self.no_llm = no_llm
         self.scanner = RedactionScanner(config=config.redaction)
         self.rule_classifier = RuleClassifier()
         self.llm_classifier = LLMClassifier(config=config.llm)
@@ -195,8 +235,45 @@ class Pipeline:
         index_count = self._run_indexing(vault_path, result)
         result.indexes_generated = index_count
 
+        # Stage 7: Pre-LLM yield summary (FEAT-005). Always emit — even on
+        # consent-skipped runs the audit report wants a row, so callers
+        # writing dashboards do not silently lose the bookkeeping.
+        self._emit_yield_summary(vault_path, result)
+
         logger.info("Pipeline complete: %s", result)
         return result
+
+    def _emit_yield_summary(
+        self,
+        vault_path: Path,
+        result: PipelineResult,
+    ) -> None:
+        """Persist a one-line yield summary to ``run-summary.jsonl``.
+
+        Failure to write the summary must NOT abort the pipeline — the
+        audit substrate is observability, not a precondition for the
+        run. We log the exception and move on. The line itself is also
+        logged at INFO so operators reading stdout still see the yield.
+
+        Args:
+            vault_path: Vault root the run wrote into.
+            result: Populated pipeline result with yield counts.
+        """
+        summary = PreLLMYieldSummary(
+            run_id=uuid.uuid4().hex,
+            deterministic_classified=result.deterministic_classified,
+            local_model_processed=result.local_model_processed,
+            residue=result.residue,
+            no_llm=self.no_llm,
+        )
+        try:
+            write_yield_summary(vault_path=vault_path, summary=summary)
+        except OSError:
+            logger.exception(
+                "Failed to write pre-LLM yield summary under %s",
+                vault_path,
+            )
+        logger.info(format_yield_line(summary))
 
     def _check_consent(self, source_path: Path) -> bool:
         """Check if consent has been granted for the given source.
@@ -339,13 +416,19 @@ class Pipeline:
         is in ``human_review_sources`` are never sent to the LLM — they
         always go to the review queue for a human decision.
 
+        When ``self.no_llm`` is true, the LLM dispatch is skipped
+        regardless of confidence. The fragment keeps whatever the rule
+        classifier gave it, and the residue counter still increments so
+        the run summary records what *would* have been routed to Pass 3.
+
         Classification operates on the inner :class:`Fragment`; the body
         is preserved unchanged on the returned :class:`IngestedFragment`.
 
         Args:
             ingested: Ingested fragment+body bundles to classify.
             vault_path: Vault path for writing the review queue.
-            result: Pipeline result (unused; kept for symmetry).
+            result: Pipeline result; mutated to track per-pass yield
+                counts (``deterministic_classified`` / ``residue``).
 
         Returns:
             List of classified :class:`IngestedFragment` items.
@@ -358,7 +441,11 @@ class Pipeline:
         for item in ingested:
             frag = self.rule_classifier.classify(item.fragment, content=item.body)
             if self._needs_llm(frag, item.body):
-                frag = self.llm_classifier.classify(frag, content=item.body)
+                result.residue += 1
+                if not self.no_llm:
+                    frag = self.llm_classifier.classify(frag, content=item.body)
+            else:
+                result.deterministic_classified += 1
             classified.append(IngestedFragment(fragment=frag, body=item.body))
 
         self.review_generator.generate_queue(
@@ -464,10 +551,18 @@ class Pipeline:
     ) -> int:
         """Run the linking pipeline on classified fragments.
 
+        Treated as Pass 2 work for yield-summary purposes: every fragment
+        handed to the linker exercises local-model inference (sentence
+        transformers for embeddings, plus the deterministic temporal /
+        thread / eddy detectors that operate on those embeddings).
+        :attr:`PipelineResult.local_model_processed` is bumped here so
+        the audit report can attribute Pass-2 work back to the run.
+
         Args:
             fragments: Classified fragments to link.
             vault_path: Vault path for linking output.
-            result: Pipeline result (unused directly but kept for symmetry).
+            result: Pipeline result; mutated to record
+                ``local_model_processed``.
 
         Returns:
             Total link count across all linking stages.
@@ -476,6 +571,7 @@ class Pipeline:
             logger.info("No fragments to link.")
             return 0
 
+        result.local_model_processed += len(fragments)
         link_result = self.linking_pipeline.run(fragments, vault_path)
         return (
             link_result.resonance_count

--- a/creek-tools/docs/classification.md
+++ b/creek-tools/docs/classification.md
@@ -10,10 +10,12 @@ Classification tags every fragment along five dimensions: **frequency** (the APT
 
 | Method   | Backend                        | When to use |
 |----------|--------------------------------|-------------|
-| `rules`  | Heuristic pattern matchers     | Default. Cheap, deterministic, runs offline. Captures roughly 70% of fragments confidently. |
-| `llm`    | Ollama (default) or Anthropic  | For the long tail of ambiguous fragments. Slower, requires either a local model or `ANTHROPIC_API_KEY`. |
+| `rules`  | Heuristic pattern matchers     | Default. Cheap, deterministic, runs offline. Captures roughly 70% of fragments confidently. **This is Pass 1 work — no network egress.** |
+| `llm`    | Ollama (default) or Anthropic  | For the long tail of ambiguous fragments. Slower, requires either a local model or `ANTHROPIC_API_KEY`. **This is Pass 3 work — the only pass that leaves the machine when the Anthropic provider is selected.** |
 
 A common workflow: run `--method rules` over the whole vault first, then run `--method llm` only on fragments whose classification is `unclassified` or whose confidence is below `ClassificationConfig.confidence_threshold`.
+
+Run `creek process --no-llm` for an end-to-end run that completes Passes 1 and 2 but never invokes the LLM — every fragment the rules left uncertain shows up as **residue** in the run summary instead. See [the three-pass pipeline](configuration.md#the-three-pass-pipeline) in the configuration reference for the full vocabulary.
 
 ```bash
 # Rules pass.

--- a/creek-tools/docs/configuration.md
+++ b/creek-tools/docs/configuration.md
@@ -4,6 +4,26 @@
 
 This page is the field-by-field reference. Every section maps to a `BaseModel` you can read in `config.py`.
 
+## The three-pass pipeline
+
+`creek process` runs in three named passes (FEAT-005); **network egress only in Pass 3.**
+
+| Pass | Scope | What it does |
+|------|-------|--------------|
+| **Pass 1 — deterministic, local** | No network | Ingestion, redaction, rules-based classification, frontmatter generation. |
+| **Pass 2 — local model-based** | No network | Embeddings (sentence-transformers), OCR (pytesseract), future Whisper transcription. Local model inference only. |
+| **Pass 3 — network if opted in** | Network | LLM classification of residue (`creek classify --method llm`), LLM-driven compile, lint semantic checks. |
+
+Pass 3 is opt-in per run. Use `creek process --no-llm` to run Passes 1 and 2 to completion and skip Pass 3 entirely; the residue (unclassified or low-confidence fragments) is reported in the run summary. The flag wins over `LLMConfig.provider`, so passing `--no-llm` while `provider: anthropic` is configured is safe — no Anthropic call is ever made.
+
+After every run a one-line summary is appended to `<vault>/00-Creek-Meta/Processing-Log/run-summary.jsonl` and printed to stdout, e.g.
+
+```
+Deterministic: 7431 classified | Local-model: 9323 embedded/OCR'd | Residue: 1892 (would go to LLM if Pass-3 enabled)
+```
+
+The summary is consumed by the audit report (FEAT-006).
+
 ## Top-level
 
 ```yaml

--- a/creek-tools/tests/test_pipeline_no_llm.py
+++ b/creek-tools/tests/test_pipeline_no_llm.py
@@ -1,0 +1,376 @@
+"""Tests for the deterministic-first pipeline (FEAT-005).
+
+Covers:
+
+* The ``no_llm`` flag short-circuits the LLM classifier — Pass 3 is
+  skipped entirely.
+* ``PipelineResult`` records the per-pass yield counts (deterministic /
+  local-model / residue) on every run.
+* Even when ``--no-llm`` collides with ``LLMConfig.provider: anthropic``,
+  the flag wins (regression guard from the FEAT test plan).
+* Each ``Pipeline.run`` writes one JSONL line to
+  ``00-Creek-Meta/Processing-Log/run-summary.jsonl``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from creek.config import CreekConfig
+from creek.ingest.base import IngestedFragment, IngestResult, ParsedFragment
+from creek.models import Fragment, FragmentSource, SourcePlatform
+from creek.pipeline import Pipeline, PipelineResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+VAULT_DIRS: list[str] = [
+    "00-Creek-Meta/Processing-Log",
+    "01-Fragments/Conversations",
+    "01-Fragments/Messages",
+    "01-Fragments/Unsorted",
+    "02-Threads/Active",
+    "02-Threads/Dormant",
+    "02-Threads/Resolved",
+    "03-Eddies",
+    "04-Praxis/Daily",
+    "04-Praxis/Seasonal",
+    "04-Praxis/Situational",
+    "06-Frequencies",
+    "08-Decisions/Active",
+    "08-Decisions/Archive",
+]
+
+
+@pytest.fixture()
+def vault_path(tmp_path: Path) -> Path:
+    """Create a minimal Obsidian vault structure under ``tmp_path``."""
+    vault = tmp_path / "vault"
+    for d in VAULT_DIRS:
+        (vault / d).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+@pytest.fixture()
+def source_path(tmp_path: Path) -> Path:
+    """Create a source directory with sample markdown files."""
+    src = tmp_path / "source"
+    src.mkdir()
+    (src / "note1.md").write_text("# A note\n\nSome content.")
+    return src
+
+
+def _make_ingested(title: str = "x", platform: str = "markdown") -> IngestedFragment:
+    """Return a single ``IngestedFragment`` for direct stage testing."""
+    fragment = Fragment(
+        id=f"frag-{title:>014}"[-19:],
+        title=title,
+        source=FragmentSource(platform=SourcePlatform(platform)),
+    )
+    return IngestedFragment(fragment=fragment, body="body text")
+
+
+class TestNoLLMFlagSkipsLLMClassifier:
+    """``no_llm=True`` must prevent any call to ``llm_classifier.classify``."""
+
+    def test_no_llm_skips_llm_even_when_residue_present(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """A fragment the rules left unclassified is not sent to the LLM."""
+        config = CreekConfig()
+        pipeline = Pipeline(config=config, no_llm=True)
+        item = _make_ingested()
+
+        with (
+            patch.object(
+                pipeline.rule_classifier,
+                "classify",
+                side_effect=lambda f, content="": f,
+            ),
+            patch.object(pipeline.llm_classifier, "classify") as mock_llm,
+        ):
+            pipeline._run_classification([item], vault_path, PipelineResult())
+
+        mock_llm.assert_not_called()
+
+    def test_default_pipeline_still_invokes_llm_for_residue(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """Without ``no_llm``, residue still flows to the LLM (no regression)."""
+        config = CreekConfig()
+        pipeline = Pipeline(config=config)  # no_llm defaults to False
+        item = _make_ingested()
+
+        with (
+            patch.object(
+                pipeline.rule_classifier,
+                "classify",
+                side_effect=lambda f, content="": f,
+            ),
+            patch.object(
+                pipeline.llm_classifier,
+                "classify",
+                side_effect=lambda f, content="": f,
+            ) as mock_llm,
+        ):
+            pipeline._run_classification([item], vault_path, PipelineResult())
+
+        mock_llm.assert_called_once()
+
+
+class TestNoLLMOverridesAnthropicProvider:
+    """Regression: ``--no-llm`` wins even with ``LLM_PROVIDER=anthropic``."""
+
+    def test_no_llm_wins_over_anthropic_provider(self, vault_path: Path) -> None:
+        """An Anthropic-configured pipeline still skips Pass 3 with no_llm."""
+        config = CreekConfig()
+        config.llm.provider = "anthropic"
+        pipeline = Pipeline(config=config, no_llm=True)
+        item = _make_ingested()
+
+        with (
+            patch.object(
+                pipeline.rule_classifier,
+                "classify",
+                side_effect=lambda f, content="": f,
+            ),
+            patch.object(pipeline.llm_classifier, "classify") as mock_llm,
+        ):
+            pipeline._run_classification([item], vault_path, PipelineResult())
+
+        mock_llm.assert_not_called()
+
+
+class TestPipelineResultYieldCounts:
+    """``PipelineResult`` must expose per-pass counts."""
+
+    def test_yield_counts_default_to_zero(self) -> None:
+        """A fresh result records zero on every yield field."""
+        result = PipelineResult()
+        assert result.deterministic_classified == 0
+        assert result.local_model_processed == 0
+        assert result.residue == 0
+
+    def test_high_confidence_counts_as_deterministic(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """A confidently rule-classified fragment lands in deterministic."""
+        config = CreekConfig()
+        pipeline = Pipeline(config=config, no_llm=True)
+        item = _make_ingested()
+        result = PipelineResult()
+
+        with (
+            patch.object(
+                pipeline.rule_classifier,
+                "classify",
+                side_effect=lambda f, content="": f.model_copy(
+                    update={
+                        "frequency": f.frequency.model_copy(
+                            update={"primary": "F5"},
+                        ),
+                    },
+                ),
+            ),
+            patch.object(
+                pipeline.rule_classifier,
+                "confidence_score",
+                return_value=0.95,
+            ),
+        ):
+            pipeline._run_classification([item], vault_path, result)
+
+        assert result.deterministic_classified == 1
+        assert result.residue == 0
+
+    def test_low_confidence_counts_as_residue(self, vault_path: Path) -> None:
+        """A low-confidence rule-classified fragment is residue."""
+        config = CreekConfig()
+        pipeline = Pipeline(config=config, no_llm=True)
+        item = _make_ingested()
+        result = PipelineResult()
+
+        with (
+            patch.object(
+                pipeline.rule_classifier,
+                "classify",
+                side_effect=lambda f, content="": f.model_copy(
+                    update={
+                        "frequency": f.frequency.model_copy(
+                            update={"primary": "F5"},
+                        ),
+                    },
+                ),
+            ),
+            patch.object(
+                pipeline.rule_classifier,
+                "confidence_score",
+                return_value=0.1,
+            ),
+        ):
+            pipeline._run_classification([item], vault_path, result)
+
+        assert result.deterministic_classified == 0
+        assert result.residue == 1
+
+
+class TestRunSummaryEmitted:
+    """``Pipeline.run`` must persist a yield-summary JSONL line."""
+
+    def _make_mock_ingestor_registry(self, source_path: Path) -> dict[str, MagicMock]:
+        """Build a registry that returns one ``ParsedFragment`` for tests."""
+        fragment = ParsedFragment(
+            content="Test content about systems and patterns",
+            metadata={
+                "markdown": "Test content about systems and patterns",
+                "frontmatter": {
+                    "type": "fragment",
+                    "title": "Mock note",
+                    "source": {"platform": "markdown"},
+                },
+            },
+            source_path=str(source_path / "note1.md"),
+            timestamp=datetime.now(),
+        )
+        ingest_result = IngestResult(fragments=[fragment])
+        mock_ingestor = MagicMock()
+        mock_ingestor.return_value.ingest.return_value = ingest_result
+        return {"mock": mock_ingestor}
+
+    def test_run_writes_run_summary_jsonl(
+        self,
+        vault_path: Path,
+        source_path: Path,
+    ) -> None:
+        """``run()`` appends a single JSONL line to ``run-summary.jsonl``."""
+        config = CreekConfig()
+        pipeline = Pipeline(config=config, no_llm=True)
+        registry = self._make_mock_ingestor_registry(source_path)
+
+        with patch("creek.pipeline.INGESTOR_REGISTRY", registry):
+            pipeline.run(source_path=source_path, vault_path=vault_path)
+
+        log = vault_path / "00-Creek-Meta" / "Processing-Log" / "run-summary.jsonl"
+        assert log.exists()
+        lines = log.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 1
+        entry = json.loads(lines[0])
+        assert entry["no_llm"] is True
+        assert "deterministic_classified" in entry
+        assert "local_model_processed" in entry
+        assert "residue" in entry
+
+
+class TestCLINoLLMFlag:
+    """``creek process --no-llm`` wires the flag through to the pipeline."""
+
+    def test_cli_no_llm_renders_yield_line(
+        self,
+        vault_path: Path,
+        source_path: Path,
+    ) -> None:
+        """The CLI prints the documented Deterministic/Local-model/Residue line."""
+        from typer.testing import CliRunner
+
+        from creek.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "process",
+                "--source",
+                str(source_path),
+                "--vault",
+                str(vault_path),
+                "--yes",
+                "--no-llm",
+            ],
+        )
+        assert result.exit_code == 0
+        # Rich may soft-wrap long lines, so collapse whitespace before
+        # asserting on the documented yield-line wording.
+        normalized = " ".join(result.output.split())
+        assert "Deterministic:" in normalized
+        assert "Local-model:" in normalized
+        assert "Residue:" in normalized
+        assert "would go to LLM if Pass-3 enabled" in normalized
+
+    def test_cli_no_llm_writes_run_summary(
+        self,
+        vault_path: Path,
+        source_path: Path,
+    ) -> None:
+        """The CLI records the ``no_llm: true`` flag in the persisted summary."""
+        from typer.testing import CliRunner
+
+        from creek.cli import app
+
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            [
+                "process",
+                "--source",
+                str(source_path),
+                "--vault",
+                str(vault_path),
+                "--yes",
+                "--no-llm",
+            ],
+        )
+        assert result.exit_code == 0
+        log = vault_path / "00-Creek-Meta" / "Processing-Log" / "run-summary.jsonl"
+        entry = json.loads(log.read_text(encoding="utf-8").splitlines()[-1])
+        assert entry["no_llm"] is True
+
+
+class TestNoLLMNoNetworkEgress:
+    """A ``--no-llm`` pipeline run must not open any outbound socket."""
+
+    @pytest.mark.integration
+    def test_no_llm_run_makes_no_outbound_connections(
+        self,
+        vault_path: Path,
+        source_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Patch ``socket.socket.connect`` to fail; ``--no-llm`` must not trip it.
+
+        This is the load-bearing privacy assertion of FEAT-005: with the
+        flag set, the pipeline must complete a normal run without ever
+        opening a network socket (no Ollama health check, no Anthropic
+        call, no Whisper download). Any attempted ``connect`` raises and
+        fails the test.
+        """
+        import socket
+
+        class NetworkBlockedError(RuntimeError):
+            """Raised when --no-llm code attempts a network connection."""
+
+        def _blocked(*args: object, **kwargs: object) -> None:
+            msg = "network egress blocked under --no-llm"
+            raise NetworkBlockedError(msg)
+
+        monkeypatch.setattr(socket.socket, "connect", _blocked)
+        monkeypatch.setattr(socket.socket, "connect_ex", _blocked)
+
+        # Even the Anthropic provider should be a no-op under --no-llm:
+        # set the provider so a regression that ignores the flag would
+        # surface as a NetworkBlockedError on first availability check.
+        config = CreekConfig()
+        config.llm.provider = "anthropic"
+        pipeline = Pipeline(config=config, no_llm=True)
+        result = pipeline.run(source_path=source_path, vault_path=vault_path)
+
+        # No raise => no socket touched. Sanity-check the run completed.
+        assert isinstance(result, PipelineResult)

--- a/creek-tools/tests/test_pre_llm_yield_summary.py
+++ b/creek-tools/tests/test_pre_llm_yield_summary.py
@@ -1,0 +1,97 @@
+"""Tests for the pre-LLM yield summary writer (FEAT-005).
+
+The summary writer is the audit substrate that records, per pipeline run,
+how much work the deterministic and local-model passes (Pass 1 + Pass 2)
+accomplished without ever invoking the network LLM (Pass 3). Each entry
+is one JSONL line under ``00-Creek-Meta/Processing-Log/run-summary.jsonl``
+so downstream tooling (FEAT-006 audit report) can stream the file.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from creek.audit.yield_summary import (
+    PreLLMYieldSummary,
+    format_yield_line,
+    write_yield_summary,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _summary(**overrides: object) -> PreLLMYieldSummary:
+    """Return a default ``PreLLMYieldSummary`` with overrides applied."""
+    base: dict[str, object] = {
+        "run_id": "run-1",
+        "deterministic_classified": 7,
+        "local_model_processed": 5,
+        "residue": 2,
+        "no_llm": True,
+    }
+    base.update(overrides)
+    return PreLLMYieldSummary(**base)  # type: ignore[arg-type]
+
+
+def test_format_yield_line_matches_documented_template() -> None:
+    """The stdout line follows the format pinned in FEAT-005."""
+    line = format_yield_line(
+        _summary(deterministic_classified=7, local_model_processed=5, residue=2),
+    )
+    assert line == (
+        "Deterministic: 7 classified | "
+        "Local-model: 5 embedded/OCR'd | "
+        "Residue: 2 (would go to LLM if Pass-3 enabled)"
+    )
+
+
+def test_write_yield_summary_creates_jsonl(tmp_path: Path) -> None:
+    """A single write produces one JSONL line at the documented path."""
+    written = write_yield_summary(vault_path=tmp_path, summary=_summary())
+
+    expected = tmp_path / "00-Creek-Meta" / "Processing-Log" / "run-summary.jsonl"
+    assert written == expected
+    assert expected.exists()
+
+    lines = expected.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    payload = json.loads(lines[0])
+    assert payload["run_id"] == "run-1"
+    assert payload["deterministic_classified"] == 7
+    assert payload["local_model_processed"] == 5
+    assert payload["residue"] == 2
+    assert payload["no_llm"] is True
+    assert "timestamp" in payload
+
+
+def test_write_yield_summary_appends_across_runs(tmp_path: Path) -> None:
+    """Subsequent runs append rather than overwrite — JSONL is per-run."""
+    write_yield_summary(vault_path=tmp_path, summary=_summary(run_id="run-1"))
+    write_yield_summary(vault_path=tmp_path, summary=_summary(run_id="run-2"))
+
+    log = tmp_path / "00-Creek-Meta" / "Processing-Log" / "run-summary.jsonl"
+    lines = log.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0])["run_id"] == "run-1"
+    assert json.loads(lines[1])["run_id"] == "run-2"
+
+
+def test_write_yield_summary_creates_log_dir(tmp_path: Path) -> None:
+    """The Processing-Log directory is created lazily on first write."""
+    log_dir = tmp_path / "00-Creek-Meta" / "Processing-Log"
+    assert not log_dir.exists()
+    write_yield_summary(vault_path=tmp_path, summary=_summary())
+    assert log_dir.is_dir()
+
+
+def test_yield_summary_records_no_llm_flag(tmp_path: Path) -> None:
+    """The persisted entry distinguishes --no-llm runs from normal ones."""
+    write_yield_summary(
+        vault_path=tmp_path,
+        summary=_summary(no_llm=False),
+    )
+    log = tmp_path / "00-Creek-Meta" / "Processing-Log" / "run-summary.jsonl"
+    payload = json.loads(log.read_text(encoding="utf-8").splitlines()[0])
+    assert payload["no_llm"] is False


### PR DESCRIPTION
Implements [FEAT-005: Deterministic-first pipeline vocabulary + `--no-llm` end-to-end](../blob/main/plans/git-issues/FEAT-005-deterministic-first-pipeline.md).

Names the three-pass discipline (Pass 1 deterministic / Pass 2 local-model / Pass 3 network) that Creek's pipeline already follows in spirit, and makes the privacy claim **"network egress only in Pass 3"** enforceable per-run via a new `--no-llm` flag.

## What changed

- `creek/pipeline.py` — `Pipeline.__init__` accepts `no_llm`; `_run_classification` short-circuits the LLM when set, while still tracking residue (so the audit number is honest); `_run_linking` records local-model work; `run()` emits a yield summary at the end.
- `creek/cli.py` — `creek process --no-llm` plumbed through and rendered in stdout.
- `creek/audit/yield_summary.py` — new `PreLLMYieldSummary` model + `write_yield_summary` writer that appends one JSONL line per run to `<vault>/00-Creek-Meta/Processing-Log/run-summary.jsonl`; consumed by FEAT-006.
- `docs/configuration.md`, `docs/classification.md` — documents the three passes with the privacy claim verbatim.
- `tests/test_pre_llm_yield_summary.py`, `tests/test_pipeline_no_llm.py` — TDD coverage for every acceptance criterion below, including a `socket.socket.connect`-patching integration test that fails the suite if `--no-llm` opens any outbound socket.

## Acceptance criteria

- [x] `docs/configuration.md` names the three passes with the privacy claim verbatim: *"network egress only in Pass 3."* — see the "The three-pass pipeline" section.
- [x] `creek process --no-llm` flag exists and works end-to-end. — `TestCLINoLLMFlag` covers the CLI surface; `TestNoLLMFlagSkipsLLMClassifier` covers the dispatch gate.
- [x] A run-summary JSONL line is emitted per pipeline run with deterministic / local-model / residue counts. — `TestRunSummaryEmitted` + `tests/test_pre_llm_yield_summary.py`.
- [x] A CI integration test verifies zero network egress during `--no-llm` runs. — `TestNoLLMNoNetworkEgress::test_no_llm_run_makes_no_outbound_connections` patches `socket.socket.connect` to raise; pipeline runs with `provider: anthropic` + `--no-llm` and completes with no socket touched.
- [x] The pre-LLM yield is exposed in the audit report (FEAT-006 will surface it; this FEAT just produces it). — `creek.audit.yield_summary` is now importable from `creek.audit`.
- [x] No regression in existing pipeline behaviour when `--no-llm` is omitted. — `TestNoLLMFlagSkipsLLMClassifier::test_default_pipeline_still_invokes_llm_for_residue` plus all 60 existing `tests/test_pipeline.py` tests still pass.

Regression also tested: `--no-llm` with `LLM_PROVIDER=anthropic` set still skips Pass 3 (`TestNoLLMOverridesAnthropicProvider`).

## Local verification

`./scripts/check-all.sh` from `creek-tools/` exits clean on every gate except the pre-existing `pip-audit` finding for pip 24.0 itself (CVE-2026-6357), which also fails on `main`. Coverage 93.52%, 3071 tests pass.

## Notes

- PR is 752 LOC; user explicitly approved pushing as-is given the FEAT's acceptance criteria require integration + regression + CLI + writer test coverage.

https://claude.ai/code/session_016amVwUnQPuMWLp5Kshtt4s

---
_Generated by [Claude Code](https://claude.ai/code/session_016amVwUnQPuMWLp5Kshtt4s)_