### PR TITLE
docs(skills): paradox / liminal / privacy-tier / wavelength-aware (FEAT-002)

### DIFF
--- a/00-Creek-Meta/Skills/liminal.SKILL.md
+++ b/00-Creek-Meta/Skills/liminal.SKILL.md
@@ -1,0 +1,101 @@
+# liminal.SKILL.md
+
+**Concern:** when to leave content uncategorized
+**Layer:** schema → defines the rules of the fourth (liminal) layer
+**Budget:** ≤1500 tokens
+**Loaded by:** Claude Code, CrawDad, any agent that classifies, compiles, lints, or saves
+
+## The four-layer architecture
+
+Creek's data model has **four** layers, not three. The fourth is the load-bearing one — it is what makes Creek different from a wiki.
+
+| Layer | Folder(s) | Owner | Mutability |
+|---|---|---|---|
+| **Raw** | `01-Fragments/` | Human + ingestor | Append-only after ingest |
+| **Compiled** | `02-Threads/`, `03-Eddies/`, `04-Praxis/`, `06-Frequencies/` | LLM-curated, human-reviewed | Rewritable by `creek compile` |
+| **Schema** | `00-Creek-Meta/Ontology/`, `00-Creek-Meta/Skills/`, `AGENTS.md` | Human + agent co-evolved | Versioned; deliberate |
+| **Liminal** | `10-Liminal/Paradoxes/`, `10-Liminal/Unnamed/`, `10-Liminal/Synchronicities/`, `10-Liminal/Compost/` | LLM-surfaced, human-curated | Append-on-emergence; promotion is human-only |
+
+## The liminal layer is *not* a wiki sub-folder
+
+Say it once, plainly: **the liminal layer is not a wiki sub-folder.**
+
+A wiki sub-folder is overflow — a place to put content that doesn't fit anywhere else, with the implicit goal of eventually re-filing it where it "belongs." Liminal is the opposite. It is a first-class destination with its own ontology and its own preservation rules. Content that lands here is not waiting to be re-filed; it is exactly where it should be until the system has earned the right to file it differently.
+
+This is the **fourth-layer distinction**, and it is non-negotiable per the INTEGRATION-PLAN.md distinctiveness watchlist.
+
+## The four liminal sub-folders
+
+Each sub-folder is a different *kind* of refusal-to-flatten. They are not interchangeable.
+
+### `10-Liminal/Paradoxes/`
+
+Two or more fragments hold *directly opposing stances on a settled claim*. The system never picks a winner. See `paradox.SKILL.md` for the full rule (verbatim: "Contradictions are data, not defects. Route to `10-Liminal/Paradoxes/`. Do not propose resolution.").
+
+### `10-Liminal/Unnamed/`
+
+A pattern is clearly real — recurring, weighty, present in multiple fragments — but does not fit any existing Thread, Eddy, Praxis, or Frequency. Lint routes it here; compile defers to it; CrawDad surfaces it in the weekly Unnamed Digest. It is not a backlog. It is a research site (spec §10.1).
+
+### `10-Liminal/Synchronicities/`
+
+Fragments from very different sources/times that read as semantically near-identical (similarity > 0.9, ≥30 days apart, different platforms, not just "still working on X"). The system flags the resonance; the human decides whether the synchronicity is meaningful (spec §10.3).
+
+### `10-Liminal/Compost/`
+
+Threads that have gone dormant or resolved with abandoned energy; ideas, projects, and stances that the human stopped feeding. They are not deleted — they decompose into future growth. A Compost note records what the energy was, why it ended (when known), and what insight may still be alive in it (spec §10.4).
+
+## When the agent routes to Liminal
+
+Three triggers:
+
+1. **The classifier is uncertain.** Ambiguous frequency, no fitting phase, mode unreadable — the fragment goes to `01-Fragments/Unsorted/` (raw) or, if the *pattern* is the unfittable thing, to `10-Liminal/Unnamed/` (liminal).
+2. **`creek compile` would lose information.** A compile run that would silently flatten a contradiction routes that contradiction to `10-Liminal/Paradoxes/` instead. A compile that would produce a Thread synthesizing fragments that do not actually share a narrative current routes the cluster to `10-Liminal/Unnamed/`.
+3. **`creek lint` finds an emergent pattern.** Missing pages, surprise resonances, dormant threads — lint routes them to the appropriate Liminal sub-folder. Lint never auto-creates compiled pages and never resolves paradoxes.
+
+The shared rule: **synthesis-that-would-falsify routes to Liminal. Synthesis-that-would-clarify produces a compiled-layer page.**
+
+## Promotion out of Liminal
+
+Promotion is human-only. The four mechanics:
+
+- **Unnamed → Thread / Eddy / Praxis.** When an Unnamed cluster has matured (fragments accumulate; the human names it; the Unnamed Digest signal stays loud across multiple weeks), the human invokes `creek save` or `creek compile` to seed the new compiled-layer page. The Unnamed note stays as historical context.
+- **Paradox → held forever.** Paradoxes do not get promoted. A new fragment may name a present-tense resolution; the Paradox note remains as evidence that both stances were once held.
+- **Synchronicity → Thread or Praxis (rare).** Most Synchronicities stay where they are. When a synchronicity recurs enough to suggest a directional pattern, the human can promote.
+- **Compost → no promotion.** Compost is terminal in one direction (the idea stopped being fed) but generative in another (it informs future fragments). A Compost note may be *referenced* by new compiled pages; it is never re-activated in place.
+
+## Frontmatter discipline
+
+Every Liminal note carries:
+
+```yaml
+type: paradox | unnamed | synchronicity | compost
+id: {liminal-type}-{uuid-short}
+title: "{the pattern in the human's voice}"
+created: "YYYY-MM-DDTHH:MM:SS-08:00"
+contributing_fragments:
+  - frag-{id}
+frequency:
+  primary: F1 | F2 | F3 | F4 | F5 | F6 | F7 | F8 | F9 | F10 | unclassified
+  secondary: []
+wavelength:
+  phase: rising | peaking | withdrawal | diminishing | bottoming_out | restoration
+  mode: inhabit | express | collaborate | integrate | absorb
+  orientation: do | feel | do_feel
+  dosage: medicine | toxic
+status: held | dormant | resolved-with-abandoned-energy
+```
+
+Liminal notes use the canonical taxonomy verbatim (INC-019). Phases: Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration. Modes: Inhabit, Express, Collaborate, Integrate, Absorb. Frequencies: F1–F10 by their canonical names.
+
+## What Liminal is not
+
+- **Not a backlog.** Items here are not waiting to be processed.
+- **Not a junk drawer.** Routing decisions are deliberate, per the rules above.
+- **Not exempt from privacy tiers.** A Liminal note inherits the most-restrictive tier of its contributing fragments. See `privacy-tier.SKILL.md`.
+- **Not a place to bypass `creek purge`.** Deletion still requires elevated auth.
+
+## Reference
+
+- Spec §10 (Emergence Infrastructure) — sub-sections §10.1 Unnamed, §10.2 Paradox, §10.3 Synchronicity, §10.4 Compost.
+- INTEGRATION-PLAN.md distinctiveness watchlist: liminal-as-fourth-layer is the highest-priority non-negotiable.
+- `paradox.SKILL.md`, `compile.SKILL.md` ("When compile refuses"), `lint.SKILL.md`, `save.SKILL.md`.

--- a/00-Creek-Meta/Skills/paradox.SKILL.md
+++ b/00-Creek-Meta/Skills/paradox.SKILL.md
@@ -1,0 +1,85 @@
+# paradox.SKILL.md
+
+**Concern:** contradictions across fragments
+**Layer:** schema → routes contradictions to the liminal layer
+**Budget:** ≤1500 tokens
+**Loaded by:** Claude Code, CrawDad, any agent that classifies, compiles, lints, or saves
+
+## The load-bearing rule
+
+> **Contradictions are data, not defects. Route to `10-Liminal/Paradoxes/`. Do not propose resolution.**
+
+This sentence is the difference between a generic-wiki agent and a Creek agent. Karpathy's wiki treats a contradiction as a defect to fix — pick a winner, edit the loser, move on. Creek treats a contradiction as a data point about a polygnostic human whose stance on the same claim has shifted across phases, modes, or seasons. The contradiction is the evidence; flattening it destroys the evidence.
+
+Repeat verbatim, do not paraphrase. `lint.SKILL.md` carries the corresponding "lint never resolves paradoxes" form of this rule; `save.SKILL.md` exposes it as the `paradox` save destination.
+
+## What counts as a paradox
+
+A paradox is two or more fragments from the same human that hold *directly opposing stances on a settled claim*. The diagnostics are:
+
+- **Same claim.** Both fragments are about the same proposition (about the human, about a project, about a relationship, about a practice).
+- **Settled stance.** Each fragment commits to its position — not "I'm wondering whether X" but "X is true" or "X is false."
+- **Direct opposition.** Not nuance, not refinement, not "I changed my mind in March." A paradox holds *both* stances as live; a chronological revision is just an updated claim.
+
+If the fragments are about different claims, or are not settled, or are temporally ordered along a single trajectory, this is not a paradox — and routing it to `10-Liminal/Paradoxes/` would dilute the folder's signal. Surface it as a stale-claim flag in `creek lint` instead.
+
+## What to do with a paradox
+
+When detected (by `creek lint`'s contradiction check, by a CrawDad reflection, or by the human noticing it during review):
+
+1. **Create a note in `10-Liminal/Paradoxes/`** that names the paradox in the human's own words wherever possible.
+2. **Link both (or all) contributing fragments** by ID — do not embed bodies; the fragments stay sovereign in `01-Fragments/`.
+3. **Tag with `#paradox`** plus the relevant Frequencies (whichever F1–F10 the contradiction lives at) and the Phase under which each side was held, when known.
+4. **Do not pick a winner. Do not annotate one side as "wrong."** The paradox note describes the tension; it does not resolve it.
+5. **Surface the paradox upward** — `creek compile` will read the Paradox note's frontmatter and refuse to flatten the underlying contradiction into a Thread or Eddy synthesis.
+
+The Paradox note's frontmatter:
+
+```yaml
+type: paradox
+id: paradox-{uuid-short}
+title: "{the paradox in the human's voice}"
+created: "YYYY-MM-DDTHH:MM:SS-08:00"
+contributing_fragments:
+  - frag-{id}
+  - frag-{id}
+frequency:
+  primary: F1 | F2 | F3 | F4 | F5 | F6 | F7 | F8 | F9 | F10 | unclassified
+  secondary: []
+wavelength:
+  phase_a: rising | peaking | withdrawal | diminishing | bottoming_out | restoration
+  phase_b: rising | peaking | withdrawal | diminishing | bottoming_out | restoration
+status: held         # never `resolved`; deletion only via `creek purge`
+```
+
+## Canonical taxonomy
+
+Paradoxes use these names verbatim (INC-019 reconciliation):
+
+- **Phases (six):** Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration.
+- **Modes (five):** Inhabit, Express, Collaborate, Integrate, Absorb.
+- **Orientations:** Do, Feel, Do/Feel.
+- **Dosage:** Medicine, Toxic.
+- **Frequencies (ten):** F1 Agency, F2 Receptivity, F3 Self-Love / Power, F4 Community Love / Conformity, F5 Achievism, F6 Pluralism, F7 Integration, F8 True Self / Transcendence, F9 Unity, F10 Emptiness.
+
+Every Paradox note inherits these tags from its contributing fragments — never collapse divergent tags to a majority. If side A is Bottoming Out / Toxic and side B is Restoration / Medicine, both belong on the note; that is precisely the data the paradox preserves.
+
+## What the agent must never do
+
+These are non-negotiable:
+
+1. **Never propose a synthesis.** "Both are true in their own way" is a synthesis. So is "the truth is in the middle." Name the tension; stop there.
+2. **Never edit the contributing fragments to align them.** Fragments are append-only after ingest; the Paradox note is the only place the contradiction is named.
+3. **Never auto-promote a Paradox to a Thread or Eddy.** A Thread tells a directional story; an Eddy is a topic cluster. A Paradox is neither — it is the system honoring §10.2 of the spec.
+4. **Never delete a Paradox note silently.** Deletion goes through `creek purge` with elevated auth; a paradox that "no longer feels true" is itself data about the human's wavelength position.
+5. **Never let a Paradox short-circuit privacy tiers.** If either contributing fragment is `intimate`, the Paradox note inherits `intimate` and the inclusion rules in `privacy-tier.SKILL.md` apply.
+
+## When a paradox does get re-examined
+
+Sometimes the human revisits a Paradox and decides one side has, in fact, been outgrown. The right move is *not* to delete the Paradox or to edit it into a synthesis. It is to **save a new fragment** that names the resolution in the present tense, then let `creek compile` produce a Thread or Praxis page that links the Paradox note as historical context. The Paradox stays held; the new fragment carries the new stance. The vault remembers both.
+
+## Reference
+
+- Spec §10.2 (Paradox Preservation) and §10 (Emergence Infrastructure).
+- INTEGRATION-PLAN.md distinctiveness watchlist: paradox preservation is one of the four non-negotiables.
+- `lint.SKILL.md` for the contradiction-detection check; `save.SKILL.md` for the `paradox` destination.

--- a/00-Creek-Meta/Skills/privacy-tier.SKILL.md
+++ b/00-Creek-Meta/Skills/privacy-tier.SKILL.md
@@ -1,0 +1,79 @@
+# privacy-tier.SKILL.md
+
+**Concern:** the open / personal / intimate ladder
+**Layer:** schema → gates every read, write, and generation flow
+**Budget:** ≤1500 tokens
+**Loaded by:** Claude Code, CrawDad, the MCP server, every CLI verb that reads or generates from fragments
+
+## The three tiers
+
+Privacy tiers come from spec §13.2. They are the first thing any agent checks before reading a fragment body, generating a derivative, or surfacing a summary.
+
+| Tier | Sources (examples) | Default handling |
+|---|---|---|
+| **`open`** | Published essays, public Discord messages, openly publishable writing | Full body available to every flow. |
+| **`personal`** | Chatbot conversations, private Discord messages, ordinary journaling | Title + summary only by default. Body included only when the operator passes `--include-tier personal` (or higher) for that call, with an audit entry. |
+| **`intimate`** | Journal entries on recovery, trauma, sexuality, or anything the human flagged as intimate at ingest | Excluded entirely by default. Included only when the operator passes `--include-tier intimate` (or `all`) *and* explicit consent is on file. Never enters voice-proxy generation without explicit consent. |
+
+Tier names use these spellings, no synonyms: **`open`**, **`personal`**, **`intimate`**. The legacy value `public` was renamed to `open` per INC-003; only `open` is canonical going forward.
+
+## Fail-closed defaults
+
+The system fails closed: when in doubt, restrict.
+
+| Situation | Default tier |
+|---|---|
+| Source classifier returns ambiguous or low-confidence privacy signal | `personal` |
+| Source classifier raises, the file is unreadable, or the tier field is missing | `intimate` |
+| Fragment touches an intimate-tier source even briefly during a conversation | `intimate` (the conversation inherits the most-restrictive contributing tier) |
+| Liminal note (Paradox / Unnamed / Synchronicity / Compost) | inherits the most-restrictive tier of its contributing fragments |
+| Reflection or save generated during a session that touched intimate content | `intimate` until the human explicitly down-tiers, per `save.SKILL.md` |
+
+The rule, in one line: **ambiguous → `personal`; unknown → `intimate`.** Never `open`.
+
+## Per-tier inclusion behaviour for the four generation verbs
+
+The four generation verbs — `creek mine`, `creek draft`, `creek report`, `creek skills` — share a single privacy filter (the `creek.classify.privacy_filter` module). They do not get to drift out of agreement with each other.
+
+| Verb | `open` | `personal` (default) | `personal` (with `--include-tier personal`) | `intimate` (default) | `intimate` (with `--include-tier intimate` + consent) |
+|---|---|---|---|---|---|
+| `creek mine` (blog-idea seeds) | full body | title + summary | full body | excluded | full body, audit logged |
+| `creek draft` (essay generation) | full body | title + summary | full body | excluded | full body, audit logged |
+| `creek report` (wavelength / voice / threads reports) | full body in report | title + summary in report | full body in report | counted in metrics only; never quoted | full body, audit logged |
+| `creek skills` (voice-skill tree exemplars) | exemplar passages allowed | exemplar passages allowed (title + extracted passage) | full body for exemplar selection | **never used as exemplars**; do not contribute even with `--include-tier intimate` *unless* `allow_intimate=True` plus consent | exemplar passages allowed, audit logged |
+
+Two flow-level rules that override the table:
+
+1. **Voice proxy: always opt-in.** Even with `--include-tier intimate`, intimate fragments contribute to the voice-skill tree only when the human has explicitly opted in (`SkillTreeGenerator(allow_intimate=True)` and consent on file). The tier flag alone is not enough.
+2. **Audit on elevation.** Any call that uses `--include-tier personal`, `--include-tier intimate`, or `--include-tier all` writes an entry to `00-Creek-Meta/audit/privacy.jsonl` recording the verb, vault, override, fragment count, and timestamp. Calls without elevation do not write audit entries.
+
+## What the agent must never do
+
+1. **Never write `tier: open` by default.** When the source classifier is silent, write `personal` (or `intimate`, per the fail-closed table).
+2. **Never include a personal-tier body in a generation prompt without `--include-tier personal` (or higher).** Title + summary is the default contract.
+3. **Never include an intimate-tier fragment in any generation flow without explicit consent on file.** A `--include-tier intimate` flag without consent fails closed.
+4. **Never let a Liminal note bypass tier inheritance.** A Paradox between a `personal` and an `intimate` fragment is `intimate`.
+5. **Never silently down-tier.** A `creek save` that touched intimate content saves as `intimate` unless the human explicitly down-tiers per `save.SKILL.md`'s consent flag.
+
+## Frontmatter
+
+Every fragment, compiled page, and Liminal note carries:
+
+```yaml
+privacy_tier: open | personal | intimate
+consent: explicit | inherited      # required when tier is intimate
+```
+
+`consent: explicit` requires a human-confirmed flag at the operation that produced the note (via `--consent` or interactive prompt). `consent: inherited` is acceptable only when the originating fragment already carries `consent: explicit`.
+
+## Canonical taxonomy
+
+Tier names verbatim: **`open`**, **`personal`**, **`intimate`**. Wavelength and frequency tags follow the canonical taxonomy (INC-019); see `compile.SKILL.md` and `wavelength-aware.SKILL.md`.
+
+## Reference
+
+- Spec §13.2 (Privacy Tiers); §13.5 (Consent Architecture).
+- INC-003 (the `public` → `open` rename).
+- SEC-006 (intimate fragments must not leak into mine / draft).
+- `creek.classify.privacy_filter` (the canonical implementation).
+- `save.SKILL.md` for save-time tier defaults; `wavelength-aware.SKILL.md` for the snapshot's read scope.

--- a/00-Creek-Meta/Skills/wavelength-aware.SKILL.md
+++ b/00-Creek-Meta/Skills/wavelength-aware.SKILL.md
@@ -1,0 +1,114 @@
+# wavelength-aware.SKILL.md
+
+**Concern:** phase as the lens through which every other tag is interpreted
+**Layer:** schema → re-reads frequency / mode / orientation / dosage in the human's *current* phase
+**Budget:** ≤1500 tokens
+**Loaded by:** Claude Code, CrawDad, every classifier, every generation flow
+
+## Why phase is the lens
+
+Frequency, mode, orientation, and dosage are descriptive. **Phase tells the agent which reading is live right now.** A fragment about "Power-With" (Red Express/Do Medicine) reads differently when the human is in Peaking versus Diminishing — same tag, different operative meaning. An agent that ignores phase will produce technically-classified-yet-tone-deaf output: matching the labels, missing the human.
+
+This is the wavelength-aware discipline. Every other schema-skill (`compile`, `lint`, `save`, `paradox`, `liminal`, `privacy-tier`) consumes its rules; this skill names them.
+
+## The four wavelength axes
+
+All four axes use the canonical taxonomy verbatim (INC-019). No synonyms, no abbreviations.
+
+### Six phases
+
+The Archetypal Wavelength has **six** phases — not four, not five — mapping a narrative of Abundance and Scarcity:
+
+| Phase | Narrative | Operative reading |
+|---|---|---|
+| **Rising** | Abundance begins to create Indulgence | Energy building; commitment, inspiration, fresh momentum. |
+| **Peaking** | Abundance peaks | Full expression, flow, glory, attunement. |
+| **Withdrawal** | Indulgence creates Scarcity | First cracks; doubt, distraction, the come-down. |
+| **Diminishing** | Scarcity begins to create Resilience | Active decline; loss of focus, contraction, radical acceptance. |
+| **Bottoming Out** | Scarcity peaks | Maximum contraction; despair, fallow, dark-night material. |
+| **Restoration** | Resilience creates Abundance | Re-emergence; vulnerability, new flow, healthy craving. |
+
+(Spec §7.1.)
+
+### Five modes × Do/Feel orientation
+
+Modes are functional stances, not emotions. Each pairs with a **Do** or **Feel** orientation, except Absorb which collapses to Do/Feel (Ultraviolet, where Do and Feel merge):
+
+| Mode | Orientations | Spiral Dynamics colours |
+|---|---|---|
+| **Inhabit** | Do (Beige) / Feel (Purple) | Body and kinship presence. |
+| **Express** | Do (Red) / Feel (Blue) | Outward projection of power or devotion. |
+| **Collaborate** | Do (Orange) / Feel (Green) | Working with reality; experiment or empathy. |
+| **Integrate** | Do (Yellow) / Feel (Teal) | Weaving parts into wholes. |
+| **Absorb** | Do/Feel (Ultraviolet) | Dissolving into unified awareness. |
+
+(Spec §7.2.)
+
+### Medicine vs. Toxic dosage
+
+Every Mode × Phase cell has a **Medicine** (right-sized, healthy) and a **Toxic** (overdose, shadow) expression. Same Mode + Phase, two cells; the agent must surface both whenever a fragment hovers near the boundary rather than collapsing to the majority.
+
+Examples (full table in spec §7.3):
+
+- **Purple, Withdrawal** → Medicine: Introspectivity. Toxic: Anxiety.
+- **Red, Peaking** → Medicine: Power-With. Toxic: Power-Over.
+- **Green, Diminishing** → Medicine: Unwinding. Toxic: Alienation.
+- **Ultraviolet, Bottoming Out** → Medicine: Pleasure. Toxic: Aversion.
+
+When a fragment could plausibly read either way, save both readings; let the human resolve at review.
+
+## The wavelength snapshot
+
+The agent does not guess the human's current phase from in-session signals. It reads the **wavelength snapshot**:
+
+> **Snapshot location: `00-Creek-Meta/State/latest.md`** (created by FEAT-007 — `creek state`).
+
+The snapshot is a small Markdown file with frontmatter naming the human's *currently observed* phase, mode, orientation, and dosage tendency, plus a confidence score and an `as_of` timestamp. Every wavelength-aware flow reads this file at session start and treats its contents as the operative lens until a fresher snapshot is written.
+
+Indicative shape (FEAT-007 finalises the schema):
+
+```yaml
+---
+type: state-snapshot
+as_of: "YYYY-MM-DDTHH:MM:SS-08:00"
+window_days: 14
+phase: rising | peaking | withdrawal | diminishing | bottoming_out | restoration
+mode: inhabit | express | collaborate | integrate | absorb
+orientation: do | feel | do_feel
+dosage_trend: medicine | toxic | mixed
+confidence: 0.0-1.0
+---
+```
+
+If the snapshot is missing, stale (`as_of` > 30 days), or fails to load, the agent falls back to **phase: unclassified, confidence: 0.0** and notes the degraded read in its output. It does not invent a phase.
+
+## What "wavelength-aware" looks like in each verb
+
+- **`creek classify`** uses phase to disambiguate Medicine/Toxic readings of an otherwise-clear Mode + Frequency.
+- **`creek compile`** preserves phase in compiled-page frontmatter; when source fragments disagree on phase, surfaces both (`wavelength.phase` + `wavelength.observed_phase`) rather than collapsing.
+- **`creek lint`** reports may use phase to weight stale-claim and contradiction signals (a Restoration-phase claim contradicting a Diminishing-phase claim is *typical* across cycles, not a bug).
+- **`creek save`** inherits the snapshot's phase by default, with the dual-phase escape per `save.SKILL.md`.
+- **`creek mine` / `creek draft`** filter and rank by phase fit so the surfaced ideas match where the human actually is, not an average across the corpus.
+- **CrawDad** loads the snapshot at session start and lets the Haiku router weight phase-matched skills more heavily.
+
+## What the agent must never do
+
+1. **Never paraphrase the canonical names.** `Bottoming Out` not `bottoming-out` in prose; `bottoming_out` only as the YAML enum value. INC-019 reconciled drift; do not re-introduce it.
+2. **Never collapse Medicine and Toxic to "neutral."** Boundary readings stay tagged on both sides.
+3. **Never silently overwrite the snapshot.** Updates flow through `creek state` (FEAT-007); ad-hoc edits violate the audit trail.
+4. **Never read the snapshot through privacy-tier escalation.** The snapshot itself is `personal`-tier metadata; reading it does not unlock intimate fragments. See `privacy-tier.SKILL.md`.
+5. **Never assume Absorb has a Do-only or Feel-only reading.** Absorb is Do/Feel; the orientation collapses.
+
+## Canonical taxonomy
+
+- **Phases (six):** Rising, Peaking, Withdrawal, Diminishing, Bottoming Out, Restoration.
+- **Modes (five):** Inhabit, Express, Collaborate, Integrate, Absorb.
+- **Orientations:** Do, Feel, Do/Feel.
+- **Dosage:** Medicine, Toxic.
+- **Frequencies (ten):** F1 Agency, F2 Receptivity, F3 Self-Love / Power, F4 Community Love / Conformity, F5 Achievism, F6 Pluralism, F7 Integration, F8 True Self / Transcendence, F9 Unity, F10 Emptiness.
+
+## Reference
+
+- Spec §7.1 (six phases), §7.2 (five modes × Do/Feel), §7.3 (Medicine vs. Toxic full map), §7.4 (how to use modes for classification), §7.5 (temporal wavelength tracking).
+- FEAT-007 — `creek state` writes `00-Creek-Meta/State/latest.md`.
+- `compile.SKILL.md` (frontmatter shape), `save.SKILL.md` (dual-phase convention).


### PR DESCRIPTION
Implements [FEAT-002](../blob/main/plans/git-issues/FEAT-002-schema-skills-paradox-liminal-privacy-wavelength.md) — the four remaining schema-skill files under `00-Creek-Meta/Skills/` covering Creek's non-negotiables (paradox preservation, liminal-as-fourth-layer, fail-closed privacy tiers) and the wavelength lens. These guard rails are what every downstream FEAT (003+) must respect.

## Summary

- **`paradox.SKILL.md`** — the verbatim guard rail "Contradictions are data, not defects. Route to `10-Liminal/Paradoxes/`. Do not propose resolution." plus paradox detection criteria, frontmatter shape, and the held-forever discipline.
- **`liminal.SKILL.md`** — names the four-layer architecture (raw / compiled / schema / liminal) and states plainly that the liminal layer is *not* a wiki sub-folder. Documents the four sub-folders, routing triggers, and human-only promotion paths.
- **`privacy-tier.SKILL.md`** — the `open` / `personal` / `intimate` ladder, fail-closed defaults (ambiguous → `personal`, unknown → `intimate`), and per-tier inclusion behaviour for `mine` / `draft` / `report` / `skills`.
- **`wavelength-aware.SKILL.md`** — six phases × five modes × Do/Feel × Medicine/Toxic, plus the snapshot location at `00-Creek-Meta/State/latest.md` (created in FEAT-007).

Total diff: **379 LOC added**, comfortably under the 700-LOC ceiling.

## Acceptance criteria — all verified

| Criterion | Verification |
|---|---|
| `paradox.SKILL.md` exists, ≤1500 tokens, contains the verbatim rule | ✅ ~892 words / ~1160 tokens; rule present verbatim on line 9 |
| `liminal.SKILL.md` exists, ≤1500 tokens, names the four-layer architecture and explicitly says the liminal layer is *not* a wiki sub-folder | ✅ ~936 words / ~1217 tokens; four-layer table at lines 14–18; "the liminal layer is not a wiki sub-folder" verbatim at line 21 |
| `privacy-tier.SKILL.md` exists, ≤1500 tokens, documents the three tiers, the fail-closed default, and per-tier behaviour for `mine` / `draft` / `report` / `skills` | ✅ ~845 words / ~1100 tokens; tier table, fail-closed table, and four-verb behaviour table all present |
| `wavelength-aware.SKILL.md` exists, ≤1500 tokens, documents six phases × five modes × Do/Feel × Medicine/Toxic and points at `00-Creek-Meta/State/latest.md` | ✅ ~980 words / ~1270 tokens; all four axes covered; snapshot location named at line 64 |
| All four files use canonical taxonomy and respect INC-019's resolution | ✅ Phase / mode / orientation / dosage / frequency names used verbatim; `open` (not `public`) per INC-003 |

Manual size-budget verification was used (the enforcing token-budget lint check arrives with FEAT-008, per FEAT-001's note).

## Stay Green

`creek-tools/scripts/check-all.sh` exits 0 — 9/9 checks pass:

- Linting (Ruff) ✓
- Formatting (Ruff) ✓
- Type checking (MyPy strict) ✓
- Pylint ✓
- Security (Bandit + pip-audit) ✓
- Complexity (Radon + Xenon) ✓
- Unit tests (3071 passed, 20 deselected) ✓
- Aggregate coverage 93.52% ✓
- Per-file coverage gate (79 strict ≥80%, 2 waivered ≥65%) ✓

This PR is doc-only — no Python source touched — so the existing test suite is unaffected.

## Dependencies verified

- **FEAT-001** (root `AGENTS.md` and the first three schema skills): merged on main as `edbe66b` (#204).
- **INC-019** (canonical taxonomy reconciliation): merged on main as `66fa6f4` (#203).
- **INC-003** (`public` → `open` privacy-tier rename): done; `PrivacyTier.OPEN = "open"` in `creek/models.py:279`.

Parallelizable peer FEAT-005 has also already merged (`09766ea`, #205); no conflict.

## Test plan

- [x] Each new file ≤1500 tokens (manual verification — see acceptance table above).
- [x] Verbatim guard rails grep-confirmed in `paradox.SKILL.md` and `liminal.SKILL.md`.
- [x] Canonical taxonomy (INC-019) used verbatim in all four files.
- [x] `creek-tools/scripts/check-all.sh` exits 0.
- [ ] FEAT-003+ conformance review: subsequent FEATs' "Pre-decided choices" blocks must respect the rules these four skills name. (Tracked downstream.)

https://claude.ai/code/session_0158ZLoAxozesS5qzv5LLM1T

---
_Generated by [Claude Code](https://claude.ai/code/session_0158ZLoAxozesS5qzv5LLM1T)_