### PR TITLE
docs(skills): FEAT-001 follow-up for save schema

### DIFF
--- a/creek-tools/creek/templates/skills/save.SKILL.md
+++ b/creek-tools/creek/templates/skills/save.SKILL.md
@@ -63,6 +63,7 @@ privacy_tier: open | personal | intimate
 consent: explicit | inherited      # required when tier is intimate
 wavelength:
   phase: rising | peaking | withdrawal | diminishing | bottoming_out | restoration
+  observed_phase: rising | peaking | withdrawal | diminishing | bottoming_out | restoration  # optional; written when source conversation contradicts inherited phase
   mode: inhabit | express | collaborate | integrate | absorb
   orientation: do | feel | do_feel
   dosage: medicine | toxic


### PR DESCRIPTION
Fixes #207.

This PR now contains only the canonical template update in `creek-tools/creek/templates/skills/save.SKILL.md`:
- add `wavelength.observed_phase` next to `phase` in the schema block

The earlier `.gitignore` hunk became obsolete after rebasing onto current `main`, so it is no longer part of this diff.
