### PR TITLE
feat(query): compile-layer-first routing for mine/draft (FEAT-004)

### DIFF
--- a/00-Creek-Meta/Skills/query.SKILL.md
+++ b/00-Creek-Meta/Skills/query.SKILL.md
@@ -1,0 +1,128 @@
+# query.SKILL.md
+
+**Verb:** `creek query` (plus every read-side consumer: `creek mine`,
+`creek draft`, CrawDad reflection, ad hoc agent reads)
+**Layer:** schema → governs how the compiled / raw / liminal layers
+are *read*
+**Budget:** ≤1500 tokens
+**Loaded by:** Claude Code, CrawDad, any agent answering "what does
+the vault know about X?"
+
+## What `creek query` does
+
+Query is the read-side counterpart to `creek compile`. It answers
+questions about the vault's accumulated knowledge by routing through
+the compiled layer first. Compile is what makes the vault compounding;
+query is what spends that compounding instead of paying the
+synthesis cost on every read.
+
+There is no single CLI verb named `creek query` today — the contract
+is enforced by every command and agent that reads the vault, with
+`creek mine` and `creek draft` as the primary surfaces (FEAT-004).
+
+## The compiled-layer-first rule
+
+Three rules, in strict order of precedence:
+
+### 1. Read the compiled layer first
+
+When asked "what does the vault know about X?":
+
+1. Check `02-Threads/`, `03-Eddies/`, and `06-Frequencies/` for a
+   compiled page covering the topic.
+2. If a compiled page exists, **use it** as the primary source. Its
+   per-claim provenance footnotes (see `compile.SKILL.md`) tell you
+   which fragment IDs back each claim.
+3. Cite the compiled page directly. Don't paraphrase it from
+   fragments — that re-introduces the lossy compression compile
+   already paid for.
+
+### 2. Fragments are the fallback, not the default
+
+Drop down to `01-Fragments/` only when:
+
+- The compiled page does not exist for the relevant target.
+- The compiled page exists but is `inferred`-tier or contradicts what
+  fresh fragments say (stale).
+- An exact-quote use case demands the original fragment text — in
+  which case the compiled page's provenance gives you the fragment
+  IDs to load.
+
+When you fall back, the system records the gap. `creek mine` and
+`creek draft` log a `compile-needed` entry to
+`00-Creek-Meta/Processing-Log/compile-gaps.jsonl`; agents and humans
+should do the same when reading manually. `creek lint` later surfaces
+these gaps so the human can recompile or accept.
+
+### 3. `10-Liminal/` is a destination, not an overflow bin
+
+Read from `10-Liminal/` only when paradoxes, unnamed patterns, or
+synchronicities are themselves what's being queried. Liminal content
+exists because compile **refused** to flatten it; treating it as a
+fallback synthesis layer falsifies the refusal.
+
+## Escape hatch: `--bypass-compiled`
+
+`creek mine --bypass-compiled` and `creek draft --bypass-compiled`
+skip the compiled layer entirely and read fragments directly. The
+flag is documented, prints a stderr warning, and is for diagnostic
+use only — for example, verifying that a compiled page faithfully
+represents its source fragments. Routine reads must not pass it.
+
+## Provenance traversal
+
+Every claim on a compiled page carries a per-claim `[^claim-NN]`
+footnote whose entry in frontmatter `provenance:` lists the fragment
+IDs that produced it (see `compile.SKILL.md`). Use this when:
+
+- A draft needs an exact quote from a source fragment.
+- A reader needs to verify a claim against its sources.
+- A lint pass detects drift between a compiled page and current
+  fragments.
+
+The provenance traversal is the bridge from the compiled summary back
+to the raw record. Agents that collapse to "just read the fragments"
+are doing query backwards — the design's whole point is that compile
+already paid the cost of the rollup.
+
+## Privacy tiers during query
+
+Privacy tiers (Open / Personal / Intimate) flow with the data, not
+with the verb:
+
+- A compiled page that aggregates Personal-tier fragments must carry
+  the highest contributing tier in its frontmatter.
+- Default reads filter Intimate fragments out and replace Personal
+  bodies with title-only summaries.
+- The `--include-tier` override appends an audit entry to
+  `<vault>/00-Creek-Meta/audit/privacy.jsonl` (spec §13.2).
+
+A compile-first read is *not* a way around the tier filter. The
+filter operates on whichever surface (compiled or raw) the query
+ultimately reads.
+
+## Canonical taxonomy
+
+Query results carry the same tag vocabulary as everything else:
+
+- **Phases (six):** Rising, Peaking, Withdrawal, Diminishing,
+  Bottoming Out, Restoration.
+- **Modes (five):** Inhabit, Express, Collaborate, Integrate, Absorb.
+- **Orientations:** Do, Feel, Do/Feel.
+- **Dosage:** Medicine, Toxic.
+- **Frequencies (ten):** F1 Agency, F2 Receptivity, F3 Self-Love /
+  Power, F4 Community Love / Conformity, F5 Achievism, F6 Pluralism,
+  F7 Integration, F8 True Self / Transcendence, F9 Unity, F10
+  Emptiness.
+
+INC-019 reconciled drift here; do not paraphrase.
+
+## What query does *not* do
+
+- It does not write. Read-side only. If a query produces a useful
+  artifact (a draft, a praxis note, a paradox) the result is filed
+  via `creek save`, not by the query path.
+- It does not auto-recompile. A missing compiled page logs a gap;
+  recompile is a separate, human-triggered `creek compile` invocation.
+- It does not collapse paradoxes. A query that lands in
+  `10-Liminal/Paradoxes/` returns the paradox intact.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,17 +32,13 @@ Every agent operating on the vault uses these four verbs. Each has a dedicated s
 | Verb | Skill file | What it does |
 |---|---|---|
 | `creek compile` | [`00-Creek-Meta/Skills/compile.SKILL.md`](00-Creek-Meta/Skills/compile.SKILL.md) | Per-source, interactive, provenance-preserving rollup of fragments → compiled-layer pages (Threads, Eddies, Praxis, Frequency indexes) |
-| `creek query` | (covered inline in this file; dedicated skill arrives with FEAT-004) | Read the compiled layer first; fall back to fragments only when the compiled page is missing or insufficient |
+| `creek query` | [`00-Creek-Meta/Skills/query.SKILL.md`](00-Creek-Meta/Skills/query.SKILL.md) | Read the compiled layer first; fall back to fragments only when the compiled page is missing or insufficient. `creek mine` and `creek draft` route through this contract; `--bypass-compiled` is a documented escape hatch. |
 | `creek lint` | [`00-Creek-Meta/Skills/lint.SKILL.md`](00-Creek-Meta/Skills/lint.SKILL.md) | Unified hygiene check across orphans, contradictions, stale claims, missing pages, data gaps. **Lint never resolves paradoxes; contradictions route to `10-Liminal/Paradoxes/`.** |
 | `creek save` | [`00-Creek-Meta/Skills/save.SKILL.md`](00-Creek-Meta/Skills/save.SKILL.md) | File a good answer back into the vault as thread / eddy / praxis / paradox / unnamed / draft, honoring privacy tiers |
 
 ### Query — the compiled-layer-first rule
 
-Until FEAT-004 ships a dedicated `query.SKILL.md`, the contract is:
-
-1. **Compiled-layer first.** When asked "what does the vault know about X?", read the relevant Thread, Eddy, or Frequency-index page first.
-2. **Fragments are the fallback.** Drop down to `01-Fragments/` only when the compiled page is missing, stale, or contradicts what fresh fragments say. When you do, surface the discrepancy as a `creek lint` candidate.
-3. **`10-Liminal/` is not a fallback.** It's a deliberate destination, not an overflow bin. Don't read from it as if it were a synthesis layer; read from it to honor what the system has refused to flatten.
+The full contract lives in [`00-Creek-Meta/Skills/query.SKILL.md`](00-Creek-Meta/Skills/query.SKILL.md). The rule, in one paragraph: read the relevant `02-Threads/` / `03-Eddies/` / `06-Frequencies/` page first; drop down to `01-Fragments/` only when the compiled page is missing, stale, or contradicts fresh fragments (and let `creek mine` / `creek draft` log a `compile-needed` entry to `00-Creek-Meta/Processing-Log/compile-gaps.jsonl` so `creek lint` can surface it); never treat `10-Liminal/` as an overflow bin — read it only when paradoxes or unnamed patterns are themselves the subject. `--bypass-compiled` is the documented escape hatch.
 
 ## Canonical taxonomy
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1104,6 +1104,20 @@ def skills(
     )
 
 
+def _warn_bypass_compiled(verb: str) -> None:
+    """Emit a stderr warning when ``--bypass-compiled`` is set.
+
+    The escape hatch lets an operator side-step the compiled-layer
+    routing introduced in FEAT-004. Warning loudly is the contract:
+    bypass should be a deliberate, visible choice, not silent.
+    """
+    print(  # operator-facing CLI warning
+        f"[creek {verb}] WARNING: --bypass-compiled is set; "
+        "the compiled-layer-first contract is being side-stepped.",
+        file=sys.stderr,
+    )
+
+
 def _parse_phase(phase: str) -> Phase:
     """Parse a phase CLI argument, exiting with code 2 on unknown values.
 
@@ -1142,19 +1156,38 @@ def mine(
         "--include-tier",
         help=_INCLUDE_TIER_HELP,
     ),
+    bypass_compiled: bool = typer.Option(
+        False,
+        "--bypass-compiled",
+        help=(
+            "Skip the compiled layer and read fragments directly. "
+            "Documented escape hatch — emits a stderr warning."
+        ),
+    ),
 ) -> None:
     """Mine blog and essay ideas from the vault (Section 11.5).
 
     Runs every strategy - liminal cross-eddy, thread terminus, resonance
     chain, and wavelength-phase window - then prints a deduped,
     score-ranked table of :class:`IdeaSeed` records.
+
+    By default the miner routes through the compiled layer first
+    (Threads, Eddies, Frequency indexes) and falls back to fragments
+    only when a compiled page is missing — appending a
+    ``compile-needed`` entry to ``compile-gaps.jsonl`` for ``creek
+    lint`` to surface later (FEAT-004).
     """
     from creek.generate.mining import IdeaMiner
 
     vault_path = _resolve_vault(vault)
     current_phase = _parse_phase(phase)
     override = _parse_include_tier(include_tier)
-    seeds = IdeaMiner(privacy_override=override).mine_all(
+    if bypass_compiled:
+        _warn_bypass_compiled("mine")
+    seeds = IdeaMiner(
+        privacy_override=override,
+        bypass_compiled=bypass_compiled,
+    ).mine_all(
         vault_path,
         current_phase=current_phase,
     )
@@ -1252,6 +1285,14 @@ def draft(
         "--include-tier",
         help=_INCLUDE_TIER_HELP,
     ),
+    bypass_compiled: bool = typer.Option(
+        False,
+        "--bypass-compiled",
+        help=(
+            "Skip the compiled layer when gathering source material. "
+            "Documented escape hatch — emits a stderr warning."
+        ),
+    ),
 ) -> None:
     """Draft an essay from a mined idea with the activated skill stack.
 
@@ -1269,8 +1310,13 @@ def draft(
     voice_text = _read_voice_core(voice_core)
     override = _parse_include_tier(include_tier)
     llm = _build_draft_llm()
+    if bypass_compiled:
+        _warn_bypass_compiled("draft")
 
-    seeds = IdeaMiner(privacy_override=override).mine_all(
+    seeds = IdeaMiner(
+        privacy_override=override,
+        bypass_compiled=bypass_compiled,
+    ).mine_all(
         vault_path,
         current_phase=current_phase,
     )
@@ -1295,6 +1341,7 @@ def draft(
         skills_root=skills_dir,
         voice_core=voice_text,
         privacy_override=override,
+        bypass_compiled=bypass_compiled,
     )
 
     console.print(generator.present_idea(idea))

--- a/creek-tools/creek/generate/compile_routing.py
+++ b/creek-tools/creek/generate/compile_routing.py
@@ -1,0 +1,180 @@
+"""Compiled-layer routing helpers (FEAT-004).
+
+``creek mine`` and ``creek draft`` route through the compiled layer
+first — Threads, Eddies, and per-frequency index notes — falling back
+to fragments only when the compiled page is missing or insufficient.
+The fallback is an operational signal, not silent: every miss appends
+a ``compile-needed`` entry to ``00-Creek-Meta/Processing-Log/
+compile-gaps.jsonl`` so ``creek lint`` can surface the gap later.
+
+This module is the single read-side surface for the compiled layer.
+Mining and drafting both consume it; the CLI's ``--bypass-compiled``
+escape hatch short-circuits the index load entirely.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path  # runtime use in dataclass / type hints
+
+import frontmatter
+import yaml
+from pydantic import ValidationError
+
+from creek.models import CompiledPage
+
+logger = logging.getLogger(__name__)
+
+
+COMPILE_GAPS_RELPATH: Path = Path("00-Creek-Meta/Processing-Log/compile-gaps.jsonl")
+"""Vault-relative path of the compile-gaps log."""
+
+_THREAD_DIR: Path = Path("02-Threads")
+_EDDY_DIR: Path = Path("03-Eddies")
+_FREQ_DIR: Path = Path("06-Frequencies")
+
+
+@dataclass(frozen=True)
+class CompiledPageIndex:
+    """Compiled-layer pages keyed by ``(target_kind, target_id)``.
+
+    Attributes:
+        threads: ``{thread_id: CompiledPage}`` for every page under
+            ``02-Threads/``.
+        eddies: ``{eddy_id: CompiledPage}`` for every page under
+            ``03-Eddies/``.
+        frequency_indexes: ``{frequency_id: CompiledPage}`` for every
+            page under ``06-Frequencies/``.
+        bypassed: ``True`` when the index was constructed in bypass
+            mode — every lookup returns a miss and miss-logging is
+            suppressed (the ``--bypass-compiled`` escape hatch).
+    """
+
+    threads: dict[str, CompiledPage] = field(default_factory=dict)
+    eddies: dict[str, CompiledPage] = field(default_factory=dict)
+    frequency_indexes: dict[str, CompiledPage] = field(default_factory=dict)
+    bypassed: bool = False
+
+    def thread(self, target_id: str) -> CompiledPage | None:
+        """Return the compiled thread page for *target_id*, or ``None``."""
+        if self.bypassed:
+            return None
+        return self.threads.get(target_id)
+
+    def eddy(self, target_id: str) -> CompiledPage | None:
+        """Return the compiled eddy page for *target_id*, or ``None``."""
+        if self.bypassed:
+            return None
+        return self.eddies.get(target_id)
+
+    def frequency_index(self, target_id: str) -> CompiledPage | None:
+        """Return the compiled frequency-index page, or ``None``."""
+        if self.bypassed:
+            return None
+        return self.frequency_indexes.get(target_id)
+
+    def fragment_ids_for(self, page: CompiledPage) -> tuple[str, ...]:
+        """Return the unique fragment IDs traced by *page*'s provenance."""
+        seen: list[str] = []
+        for entry in page.provenance:
+            for fid in entry.fragment_ids:
+                if fid and fid not in seen:
+                    seen.append(fid)
+        return tuple(seen)
+
+
+def empty_index(*, bypassed: bool = False) -> CompiledPageIndex:
+    """Return an empty :class:`CompiledPageIndex`.
+
+    Args:
+        bypassed: When ``True``, the returned index reports every
+            lookup as a miss without recording a gap. Used by the
+            ``--bypass-compiled`` escape hatch.
+    """
+    return CompiledPageIndex(bypassed=bypassed)
+
+
+def load_compiled_pages(vault_path: Path) -> CompiledPageIndex:
+    """Scan *vault_path* and return every compiled-layer page.
+
+    Pages are loaded from ``02-Threads/``, ``03-Eddies/``, and
+    ``06-Frequencies/``. Files missing a ``type: compiled_page``
+    sentinel or failing schema validation are skipped silently.
+
+    Args:
+        vault_path: Vault root.
+
+    Returns:
+        A populated :class:`CompiledPageIndex`. When the relevant
+        directories do not exist the index is empty (``bypassed=False``
+        so misses are still logged downstream).
+    """
+    return CompiledPageIndex(
+        threads=_load_pages(vault_path / _THREAD_DIR, "thread"),
+        eddies=_load_pages(vault_path / _EDDY_DIR, "eddy"),
+        frequency_indexes=_load_pages(vault_path / _FREQ_DIR, "frequency_index"),
+    )
+
+
+def _load_pages(root: Path, target_kind: str) -> dict[str, CompiledPage]:
+    """Load every compiled page of *target_kind* under *root*."""
+    if not root.exists():
+        return {}
+    out: dict[str, CompiledPage] = {}
+    for md_file in sorted(root.rglob("*.md")):
+        try:
+            post = frontmatter.load(str(md_file))
+        except (OSError, ValueError, yaml.YAMLError):
+            logger.debug("Skipping unreadable compiled page: %s", md_file)
+            continue
+        metadata = dict(post.metadata)
+        if metadata.get("type") != "compiled_page":
+            continue
+        if metadata.get("target_kind") != target_kind:
+            continue
+        metadata.setdefault("body", post.content)
+        try:
+            page = CompiledPage.model_validate(metadata)
+        except ValidationError:
+            logger.debug("Skipping invalid compiled page: %s", md_file)
+            continue
+        out[page.target_id] = page
+    return out
+
+
+def log_compile_gap(
+    vault_path: Path,
+    *,
+    target_kind: str,
+    target_id: str,
+    surfaced_by: str,
+    reason: str,
+) -> None:
+    """Append a ``compile-needed`` entry to ``compile-gaps.jsonl``.
+
+    The log is plain JSONL (no chain hash) — it's an operational
+    backlog ``creek lint`` reads later, not a tamper-evidence record.
+
+    Args:
+        vault_path: Vault root.
+        target_kind: ``"thread"``, ``"eddy"``, or ``"frequency_index"``.
+        target_id: Stable ID of the missing compiled-layer surface.
+        surfaced_by: Verb that hit the gap (``"mine"`` or ``"draft"``)
+            plus an optional strategy/context tag.
+        reason: Short human-readable reason — typically
+            ``"missing"`` or ``"insufficient"``.
+    """
+    record = {
+        "timestamp": datetime.now(tz=UTC).isoformat(),
+        "target_kind": target_kind,
+        "target_id": target_id,
+        "surfaced_by": surfaced_by,
+        "reason": reason,
+    }
+    log_path = vault_path / COMPILE_GAPS_RELPATH
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=True) + "\n")

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -36,7 +36,14 @@ from creek.classify.privacy_filter import (
     PrivacyTierOverride,
     filter_fragments_by_tier,
 )
+from creek.generate.compile_routing import (
+    CompiledPageIndex,
+    empty_index,
+    load_compiled_pages,
+    log_compile_gap,
+)
 from creek.models import (
+    CompiledPage,
     Eddy,
     Fragment,
     Phase,
@@ -256,6 +263,7 @@ class DraftGenerator:
         skills_root: Path,
         voice_core: str = "",
         privacy_override: PrivacyTierOverride | None = None,
+        bypass_compiled: bool = False,
     ) -> None:
         """Initialise with an LLM client and skill tree root.
 
@@ -269,11 +277,16 @@ class DraftGenerator:
             privacy_override: Optional ``--include-tier`` value applied
                 when scanning vault fragments for skill inference and
                 source material gathering.
+            bypass_compiled: When ``True`` the source-material gathering
+                step skips the compiled layer and pulls fragments
+                directly. Default ``False`` honours the FEAT-004
+                compile-then-query discipline.
         """
         self._llm = llm
         self.skills_root = skills_root
         self.voice_core = voice_core
         self.privacy_override = privacy_override
+        self.bypass_compiled = bypass_compiled
 
     def present_idea(self, idea: IdeaSeed) -> str:
         """Format *idea* as an invitation rather than an imperative.
@@ -385,21 +398,26 @@ class DraftGenerator:
         *,
         vault_path: Path,
         fragments: dict[str, tuple[Fragment, str]] | None = None,
+        compiled_pages: CompiledPageIndex | None = None,
     ) -> str:
-        """Collect fragment bodies and thread/eddy descriptions for *idea*.
+        """Collect compiled-layer summaries (compile-first) for *idea*.
 
-        Returns a markdown-shaped block the LLM can cite from. Missing
-        IDs are skipped quietly. The sections are:
-
-        * ``## Source fragments`` — ``### {id}: {title}`` followed by body.
-        * ``## Threads`` — ``### {id}: {title}`` followed by description.
-        * ``## Eddies`` — ``### {id}: {title}`` followed by description.
+        FEAT-004 routing: thread and eddy sections render the compiled
+        page body when one exists; missing pages fall back to the
+        frontmatter description and append a ``compile-needed`` entry
+        to ``00-Creek-Meta/Processing-Log/compile-gaps.jsonl``. Source
+        fragments are still pulled inline so drafts can quote them
+        verbatim — provenance traversal stays available even when the
+        compiled summary is the primary source.
 
         Args:
             idea: Idea seed whose IDs drive the lookup.
             vault_path: Vault root used to load fragments/threads/eddies.
             fragments: Optional pre-loaded ``{id: (Fragment, body)}`` map;
                 when provided the vault is not re-scanned for fragments.
+            compiled_pages: Optional pre-loaded compiled-page index. When
+                ``None`` the index is loaded (or bypassed) per
+                :attr:`bypass_compiled`.
 
         Returns:
             A newline-joined markdown string.
@@ -413,18 +431,93 @@ class DraftGenerator:
                 privacy_override=self.privacy_override,
             )
         )
+        compiled = self._resolve_compiled_pages(vault_path, compiled_pages)
         frag_block = _render_fragment_section(idea.source_fragments, loaded)
         if frag_block:
             sections.append(frag_block)
-        threads = _load_threads_by_id(vault_path / _THREADS_SUBDIR)
-        thread_block = _render_thread_section(idea.threads, threads)
+        thread_block = self._compose_thread_section(idea, vault_path, compiled)
         if thread_block:
             sections.append(thread_block)
-        eddies = _load_eddies_by_id(vault_path / _EDDIES_SUBDIR)
-        eddy_block = _render_eddy_section(idea.eddies, eddies)
+        eddy_block = self._compose_eddy_section(idea, vault_path, compiled)
         if eddy_block:
             sections.append(eddy_block)
         return "\n\n".join(sections)
+
+    def _resolve_compiled_pages(
+        self,
+        vault_path: Path,
+        compiled_pages: CompiledPageIndex | None,
+    ) -> CompiledPageIndex:
+        """Return *compiled_pages* if provided, otherwise load it."""
+        if compiled_pages is not None:
+            return compiled_pages
+        if self.bypass_compiled:
+            return empty_index(bypassed=True)
+        return load_compiled_pages(vault_path)
+
+    def _compose_thread_section(
+        self,
+        idea: IdeaSeed,
+        vault_path: Path,
+        compiled: CompiledPageIndex,
+    ) -> str:
+        """Render the ``## Threads`` block, compile-first."""
+        if not idea.threads:
+            return ""
+        threads = _load_threads_by_id(vault_path / _THREADS_SUBDIR)
+        entries: list[str] = []
+        for tid in idea.threads:
+            page = compiled.thread(tid)
+            if page is not None:
+                entries.append(_render_compiled_entry(tid, page))
+                continue
+            if not compiled.bypassed:
+                log_compile_gap(
+                    vault_path,
+                    target_kind="thread",
+                    target_id=tid,
+                    surfaced_by="draft",
+                    reason="missing",
+                )
+            thread = threads.get(tid)
+            if thread is not None:
+                desc = thread.description.strip() or "(no description)"
+                entries.append(f"### {tid}: {thread.title}\n{desc}")
+        if not entries:
+            return ""
+        return "## Threads\n\n" + "\n\n".join(entries)
+
+    def _compose_eddy_section(
+        self,
+        idea: IdeaSeed,
+        vault_path: Path,
+        compiled: CompiledPageIndex,
+    ) -> str:
+        """Render the ``## Eddies`` block, compile-first."""
+        if not idea.eddies:
+            return ""
+        eddies = _load_eddies_by_id(vault_path / _EDDIES_SUBDIR)
+        entries: list[str] = []
+        for eid in idea.eddies:
+            page = compiled.eddy(eid)
+            if page is not None:
+                entries.append(_render_compiled_entry(eid, page))
+                continue
+            if not compiled.bypassed:
+                log_compile_gap(
+                    vault_path,
+                    target_kind="eddy",
+                    target_id=eid,
+                    surfaced_by="draft",
+                    reason="missing",
+                )
+            eddy = eddies.get(eid)
+            if eddy is not None:
+                desc = eddy.description.strip() or "(no description)"
+                entries.append(f"### {eid}: {eddy.title}\n{desc}")
+        if not entries:
+            return ""
+        return "## Eddies\n\n" + "\n\n".join(entries)
 
     def _compose_prompt(
         self,
@@ -473,6 +566,7 @@ class DraftGenerator:
             vault_path / _FRAGMENTS_SUBDIR,
             privacy_override=self.privacy_override,
         )
+        compiled_pages = self._resolve_compiled_pages(vault_path, None)
         skill_stack = self.select_skill_stack(
             idea,
             vault_path=vault_path,
@@ -483,6 +577,7 @@ class DraftGenerator:
             idea,
             vault_path=vault_path,
             fragments=fragments,
+            compiled_pages=compiled_pages,
         )
         prompt = self._compose_prompt(idea, skill_stack, source_material)
         body = self._llm(prompt).strip()
@@ -536,6 +631,21 @@ class DraftGenerator:
         )
         target.write_text(frontmatter.dumps(post), encoding="utf-8")
         return target
+
+
+def _render_compiled_entry(target_id: str, page: CompiledPage) -> str:
+    """Return a ``### {id}: {title}`` block sourced from the compiled page.
+
+    The body strips any leading ``# {title}`` heading (compile renders
+    the title as the first line) so the ``###`` header isn't shadowed.
+    """
+    body = page.body.strip()
+    lines = body.splitlines()
+    if lines and lines[0].lstrip("# ").strip() == page.title.strip():
+        body = "\n".join(lines[1:]).strip()
+    if not body:
+        body = "(compiled page has no body)"
+    return f"### {target_id}: {page.title}\n{body}"
 
 
 def _render_skill_section(path: Path) -> str:

--- a/creek-tools/creek/generate/mining.py
+++ b/creek-tools/creek/generate/mining.py
@@ -40,6 +40,12 @@ from creek.classify.privacy_filter import (
     PrivacyTierOverride,
     filter_fragments_by_tier,
 )
+from creek.generate.compile_routing import (
+    CompiledPageIndex,
+    empty_index,
+    load_compiled_pages,
+    log_compile_gap,
+)
 from creek.models import (
     Eddy,
     Fragment,
@@ -208,6 +214,7 @@ class MiningSnapshot:
     eddies: tuple[Eddy, ...] = ()
     published_essay_titles: tuple[str, ...] = ()
     synchronicities: tuple[tuple[str, str, float], ...] = field(default_factory=tuple)
+    compiled_pages: CompiledPageIndex = field(default_factory=empty_index)
 
 
 def _safe_post(md_file: Path) -> frontmatter.Post | None:
@@ -373,12 +380,15 @@ def _load_mining_snapshot(
     vault_path: Path,
     *,
     privacy_override: PrivacyTierOverride | None = None,
+    bypass_compiled: bool = False,
 ) -> MiningSnapshot:
     """Scan *vault_path* for every record the miner needs.
 
     The privacy override flows through to fragment loaders so callers
     cannot accidentally bypass tier filtering by reading the snapshot
-    directly.
+    directly. When ``bypass_compiled`` is ``True`` the compiled-page
+    index is constructed in bypass mode — every lookup misses without
+    reading the compiled-layer subdirectories.
     """
     fragments = _load_fragments(
         vault_path / _FRAGMENTS_SUBDIR,
@@ -400,6 +410,13 @@ def _load_mining_snapshot(
     )
     essay_titles = _load_essay_titles(vault_path / _ESSAYS_SUBDIR)
     syncs = _load_synchronicities(vault_path / _SYNCHRONICITIES_SUBDIR)
+    compiled = (
+        empty_index(bypassed=True)
+        if bypass_compiled
+        else load_compiled_pages(
+            vault_path,
+        )
+    )
     return MiningSnapshot(
         fragments=tuple(fragments),
         liminal_fragments=tuple(liminal),
@@ -407,6 +424,7 @@ def _load_mining_snapshot(
         eddies=tuple(eddies),
         published_essay_titles=tuple(essay_titles),
         synchronicities=tuple(syncs),
+        compiled_pages=compiled,
     )
 
 
@@ -425,6 +443,7 @@ class IdeaMiner:
         similarity_liminal: float = DEFAULT_SIMILARITY_LIMINAL,
         similarity_resonance: float = DEFAULT_SIMILARITY_RESONANCE,
         privacy_override: PrivacyTierOverride | None = None,
+        bypass_compiled: bool = False,
     ) -> None:
         """Initialise with optional threshold and similarity overrides.
 
@@ -442,6 +461,10 @@ class IdeaMiner:
             privacy_override: Optional ``--include-tier`` value. The
                 default policy excludes intimate fragments and replaces
                 personal bodies with title-only summaries.
+            bypass_compiled: When ``True`` the miner skips the
+                compiled-layer index entirely and reads fragments
+                directly. Default ``False`` honours the FEAT-004
+                compile-then-query discipline.
         """
         self._similarity_fn: SimilarityFn = similarity_fn or _jaccard_similarity
         self.min_thread_fragments = min_thread_fragments
@@ -449,6 +472,7 @@ class IdeaMiner:
         self.similarity_liminal = similarity_liminal
         self.similarity_resonance = similarity_resonance
         self.privacy_override = privacy_override
+        self.bypass_compiled = bypass_compiled
 
     def _resolve_snapshot(
         self,
@@ -461,6 +485,7 @@ class IdeaMiner:
         return _load_mining_snapshot(
             vault_path,
             privacy_override=self.privacy_override,
+            bypass_compiled=self.bypass_compiled,
         )
 
     # ---- Strategy: Thread terminus ----
@@ -480,6 +505,11 @@ class IdeaMiner:
           :attr:`min_thread_fragments`.
         * No published essay title substantially overlaps with the
           thread title.
+
+        When a compiled thread page exists, ``source_fragments`` is
+        derived from its provenance rather than rescanned from raw
+        fragments. Missing pages append a ``compile-needed`` entry to
+        ``compile-gaps.jsonl``.
         """
         snap = self._resolve_snapshot(vault_path, snapshot)
         seeds: list[IdeaSeed] = []
@@ -490,7 +520,14 @@ class IdeaMiner:
                 continue
             if self._has_matching_essay(thread.title, snap.published_essay_titles):
                 continue
-            seeds.append(self._seed_from_thread(thread, snap.fragments))
+            seeds.append(
+                self._seed_from_thread(
+                    thread,
+                    snap.fragments,
+                    snap.compiled_pages,
+                    vault_path,
+                ),
+            )
         return seeds
 
     def _has_matching_essay(
@@ -508,11 +545,31 @@ class IdeaMiner:
         self,
         thread: Thread,
         fragments: tuple[tuple[Fragment, str], ...],
+        compiled: CompiledPageIndex,
+        vault_path: Path,
     ) -> IdeaSeed:
-        """Build an :class:`IdeaSeed` for a thread-terminus candidate."""
-        linked = tuple(
-            frag.id for frag, _body in fragments if thread.id in frag.threads
-        )
+        """Build an :class:`IdeaSeed` for a thread-terminus candidate.
+
+        Source fragments are read from the compiled thread page's
+        provenance when one exists; otherwise the miner falls back to
+        scanning raw-fragment ``threads`` membership and records the
+        gap so ``creek lint`` can surface it later.
+        """
+        compiled_thread = compiled.thread(thread.id)
+        if compiled_thread is not None:
+            linked = compiled.fragment_ids_for(compiled_thread)
+        else:
+            linked = tuple(
+                frag.id for frag, _body in fragments if thread.id in frag.threads
+            )
+            if not compiled.bypassed:
+                log_compile_gap(
+                    vault_path,
+                    target_kind="thread",
+                    target_id=thread.id,
+                    surfaced_by="mine.thread_terminus",
+                    reason="missing",
+                )
         description = (
             f"Thread '{thread.id}' has accumulated {thread.fragment_count} "
             "fragments without becoming a published essay. Its sustained "
@@ -651,18 +708,64 @@ class IdeaMiner:
         matches *current_phase* and its :attr:`praxis_potential` is
         :attr:`PraxisPotential.EXPLICIT`. Unclassified phases yield no
         seeds.
+
+        Compile-first routing: when a compiled ``06-Frequencies/{F}``
+        page exists for the fragment's primary frequency, only its
+        provenance fragments surface; fragments outside that
+        provenance are deferred until the index is recompiled. Missing
+        frequency indexes log a ``compile-needed`` entry.
         """
         if str(current_phase) == Phase.UNCLASSIFIED.value:
             return []
         snap = self._resolve_snapshot(vault_path, snapshot)
+        gaps_logged: set[str] = set()
         seeds: list[IdeaSeed] = []
         for fragment, _body in snap.fragments:
             if not _matches_phase(fragment, current_phase):
                 continue
             if str(fragment.praxis_potential) != PraxisPotential.EXPLICIT.value:
                 continue
+            if not self._frequency_admits_fragment(
+                fragment,
+                snap.compiled_pages,
+                vault_path,
+                gaps_logged,
+            ):
+                continue
             seeds.append(self._seed_from_phase_match(fragment, current_phase))
         return seeds
+
+    def _frequency_admits_fragment(
+        self,
+        fragment: Fragment,
+        compiled: CompiledPageIndex,
+        vault_path: Path,
+        gaps_logged: set[str],
+    ) -> bool:
+        """Return ``True`` when *fragment* survives compile-first routing.
+
+        - Compiled frequency-index page exists → fragment must appear in
+          its provenance.
+        - Compiled frequency-index page missing → log a gap once per
+          frequency and admit the fragment (fragments-as-fallback).
+        - Bypass mode → admit unconditionally without logging.
+        """
+        primary = str(fragment.frequency.primary)
+        compiled_freq = compiled.frequency_index(primary)
+        if compiled_freq is not None:
+            return fragment.id in compiled.fragment_ids_for(compiled_freq)
+        if compiled.bypassed:
+            return True
+        if primary not in gaps_logged:
+            gaps_logged.add(primary)
+            log_compile_gap(
+                vault_path,
+                target_kind="frequency_index",
+                target_id=primary,
+                surfaced_by="mine.wavelength_window",
+                reason="missing",
+            )
+        return True
 
     def _seed_from_phase_match(
         self,
@@ -698,12 +801,20 @@ class IdeaMiner:
         For every fragment under ``10-Liminal/{Unnamed,Compost}``, the
         best-scoring eddy above :attr:`similarity_liminal` becomes the
         anchor. The similarity score compares the liminal fragment's
-        title + body text with the eddy's title + description.
+        title + body text against the *compiled* eddy page's body when
+        one exists, falling back to the eddy's frontmatter description
+        and recording a ``compile-needed`` entry per missing eddy.
         """
         snap = self._resolve_snapshot(vault_path, snapshot)
         seeds: list[IdeaSeed] = []
         for fragment, body, _kind in snap.liminal_fragments:
-            best = self._best_eddy_match(fragment, body, snap.eddies)
+            best = self._best_eddy_match(
+                fragment,
+                body,
+                snap.eddies,
+                snap.compiled_pages,
+                vault_path,
+            )
             if best is None:
                 continue
             eddy, score = best
@@ -715,12 +826,14 @@ class IdeaMiner:
         fragment: Fragment,
         body: str,
         eddies: tuple[Eddy, ...],
+        compiled: CompiledPageIndex,
+        vault_path: Path,
     ) -> tuple[Eddy, float] | None:
         """Return the eddy with the highest similarity above threshold."""
         frag_text = f"{fragment.title}\n{body}"
         scored: list[tuple[Eddy, float]] = []
         for eddy in eddies:
-            eddy_text = f"{eddy.title}\n{eddy.description}"
+            eddy_text = self._eddy_compare_text(eddy, compiled, vault_path)
             score = self._similarity_fn(frag_text, eddy_text)
             if score >= self.similarity_liminal:
                 scored.append((eddy, score))
@@ -728,6 +841,31 @@ class IdeaMiner:
             return None
         scored.sort(key=operator.itemgetter(1), reverse=True)
         return scored[0]
+
+    def _eddy_compare_text(
+        self,
+        eddy: Eddy,
+        compiled: CompiledPageIndex,
+        vault_path: Path,
+    ) -> str:
+        """Return the comparison text for *eddy*, compile-first.
+
+        Uses the compiled eddy page's body when available; otherwise
+        falls back to the eddy's frontmatter description and logs a
+        compile-gap entry.
+        """
+        compiled_eddy = compiled.eddy(eddy.id)
+        if compiled_eddy is not None:
+            return f"{compiled_eddy.title}\n{compiled_eddy.body}"
+        if not compiled.bypassed:
+            log_compile_gap(
+                vault_path,
+                target_kind="eddy",
+                target_id=eddy.id,
+                surfaced_by="mine.liminal_cross_eddy",
+                reason="missing",
+            )
+        return f"{eddy.title}\n{eddy.description}"
 
     def _seed_from_liminal(
         self,

--- a/creek-tools/creek/generate/mining.py
+++ b/creek-tools/creek/generate/mining.py
@@ -806,6 +806,7 @@ class IdeaMiner:
         and recording a ``compile-needed`` entry per missing eddy.
         """
         snap = self._resolve_snapshot(vault_path, snapshot)
+        gaps_logged: set[str] = set()
         seeds: list[IdeaSeed] = []
         for fragment, body, _kind in snap.liminal_fragments:
             best = self._best_eddy_match(
@@ -814,6 +815,7 @@ class IdeaMiner:
                 snap.eddies,
                 snap.compiled_pages,
                 vault_path,
+                gaps_logged,
             )
             if best is None:
                 continue
@@ -828,12 +830,18 @@ class IdeaMiner:
         eddies: tuple[Eddy, ...],
         compiled: CompiledPageIndex,
         vault_path: Path,
+        gaps_logged: set[str],
     ) -> tuple[Eddy, float] | None:
         """Return the eddy with the highest similarity above threshold."""
         frag_text = f"{fragment.title}\n{body}"
         scored: list[tuple[Eddy, float]] = []
         for eddy in eddies:
-            eddy_text = self._eddy_compare_text(eddy, compiled, vault_path)
+            eddy_text = self._eddy_compare_text(
+                eddy,
+                compiled,
+                vault_path,
+                gaps_logged,
+            )
             score = self._similarity_fn(frag_text, eddy_text)
             if score >= self.similarity_liminal:
                 scored.append((eddy, score))
@@ -847,17 +855,24 @@ class IdeaMiner:
         eddy: Eddy,
         compiled: CompiledPageIndex,
         vault_path: Path,
+        gaps_logged: set[str],
     ) -> str:
         """Return the comparison text for *eddy*, compile-first.
 
         Uses the compiled eddy page's body when available; otherwise
         falls back to the eddy's frontmatter description and logs a
         compile-gap entry.
+
+        ``gaps_logged`` is a per-run accumulator of eddy IDs whose gap
+        has already been recorded; it ensures one entry per missing
+        eddy regardless of how many liminal fragments visit it,
+        mirroring the wavelength-window dedup contract.
         """
         compiled_eddy = compiled.eddy(eddy.id)
         if compiled_eddy is not None:
             return f"{compiled_eddy.title}\n{compiled_eddy.body}"
-        if not compiled.bypassed:
+        if not compiled.bypassed and eddy.id not in gaps_logged:
+            gaps_logged.add(eddy.id)
             log_compile_gap(
                 vault_path,
                 target_kind="eddy",

--- a/creek-tools/docs/generation.md
+++ b/creek-tools/docs/generation.md
@@ -89,9 +89,38 @@ creek mine --vault ~/Obsidian/Creek-Vault --phase withdrawal --limit 5
 
 Each `IdeaSeed` has a strategy, a score, the contributing fragments, and a hint about the angle. You'll typically pick one (`--index N`) to feed into `creek draft`.
 
+### Compiled-layer routing (FEAT-004)
+
+`creek mine` and `creek draft` route through the compiled layer first.
+For every thread, eddy, or frequency the strategy needs, the miner
+reads the relevant `02-Threads/` / `03-Eddies/` / `06-Frequencies/`
+page (produced by `creek compile`, FEAT-003) and uses its body and
+provenance instead of rescanning raw fragments. When a compiled page
+is missing the miner falls back to fragments and appends a
+`compile-needed` entry to `<vault>/00-Creek-Meta/Processing-Log/
+compile-gaps.jsonl`; `creek lint` surfaces these gaps later so the
+operator can recompile.
+
+The contract is the four-verb rule documented in
+`00-Creek-Meta/Skills/query.SKILL.md` (compile-then-query): compile
+once, read many. Routine reads should not bypass it.
+
+The escape hatch is `--bypass-compiled` on both commands:
+
+```bash
+# Diagnostic: read fragments directly, skipping the compiled layer.
+creek mine  --vault ~/Obsidian/Creek-Vault --bypass-compiled
+creek draft --vault ~/Obsidian/Creek-Vault --bypass-compiled --index 0
+```
+
+When set, the flag emits a stderr warning ("the compiled-layer-first
+contract is being side-stepped"). Use it for verification — for
+example, comparing a compiled page against its source fragments — not
+as a default mode of operation.
+
 ## Drafting
 
-`creek draft` takes a mined idea, assembles the skill stack (frequency + phase + mode + register skills, plus the voice-core meta skill), gathers the source material (the seed's contributing fragments), prompts the LLM, and saves the draft to `07-Voice/Drafts/<date>-<slug>.md`.
+`creek draft` takes a mined idea, assembles the skill stack (frequency + phase + mode + register skills, plus the voice-core meta skill), gathers the source material (compile-first: the relevant compiled-layer page bodies, with fragments retained for exact-quote provenance traversal), prompts the LLM, and saves the draft to `07-Voice/Drafts/<date>-<slug>.md`.
 
 ```bash
 # Draft the top idea using the currently configured LLM.

--- a/creek-tools/requirements-dev.txt
+++ b/creek-tools/requirements-dev.txt
@@ -11,6 +11,7 @@
 # These are dev/build-time tools whose vulnerable older versions can leak
 # in via pip's resolver. See ./scripts/security.sh for documented ignores.
 cryptography>=46.0.6
+pip>=26.1
 pyjwt>=2.12.0
 setuptools>=78.1.1
 wheel>=0.46.2

--- a/creek-tools/scripts/security.sh
+++ b/creek-tools/scripts/security.sh
@@ -90,6 +90,10 @@ fi
 #   - CVE-2026-24049: wheel — RECORD parsing edge case; wheel is build-
 #     tooling only and never reaches the production runtime.
 #     https://nvd.nist.gov/vuln/detail/CVE-2026-24049
+#
+# CVE-2026-6357 (pip < 26.1) is fixed upstream; ``requirements-dev.txt``
+# pins ``pip>=26.1`` so pip-audit no longer reports it. No --ignore-vuln
+# entry needed here.
 pip-audit \
     --ignore-vuln PYSEC-2022-42969 \
     --ignore-vuln CVE-2025-8869 \

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from typer.testing import CliRunner
@@ -14,6 +15,20 @@ if TYPE_CHECKING:
     import pytest
 
 runner = CliRunner()
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _strip_ansi(text: str) -> str:
+    """Return *text* with ANSI escape sequences removed.
+
+    Typer/Click's Rich formatter splits long option names like
+    ``--bypass-compiled`` across colour-styled segments when CI's
+    terminal supports ANSI; the literal substring then disappears
+    from ``result.output``. Stripping ANSI before substring assertions
+    keeps the tests environment-independent.
+    """
+    return _ANSI_ESCAPE_RE.sub("", text)
 
 
 def test_help() -> None:
@@ -1216,14 +1231,14 @@ def test_mine_bypass_compiled_flag_advertised_in_help() -> None:
     """``creek mine --help`` documents the FEAT-004 escape hatch."""
     result = runner.invoke(app, ["mine", "--help"])
     assert result.exit_code == 0
-    assert "--bypass-compiled" in result.output
+    assert "--bypass-compiled" in _strip_ansi(result.output)
 
 
 def test_draft_bypass_compiled_flag_advertised_in_help() -> None:
     """``creek draft --help`` documents the FEAT-004 escape hatch."""
     result = runner.invoke(app, ["draft", "--help"])
     assert result.exit_code == 0
-    assert "--bypass-compiled" in result.output
+    assert "--bypass-compiled" in _strip_ansi(result.output)
 
 
 def test_mine_bypass_compiled_warns_and_skips_routing(

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1210,3 +1210,46 @@ def test_draft_unknown_phase_errors() -> None:
         ["draft", "--vault", "/fake/vault", "--phase", "nonsense"],
     )
     assert result.exit_code == 2
+
+
+def test_mine_bypass_compiled_flag_advertised_in_help() -> None:
+    """``creek mine --help`` documents the FEAT-004 escape hatch."""
+    result = runner.invoke(app, ["mine", "--help"])
+    assert result.exit_code == 0
+    assert "--bypass-compiled" in result.output
+
+
+def test_draft_bypass_compiled_flag_advertised_in_help() -> None:
+    """``creek draft --help`` documents the FEAT-004 escape hatch."""
+    result = runner.invoke(app, ["draft", "--help"])
+    assert result.exit_code == 0
+    assert "--bypass-compiled" in result.output
+
+
+def test_mine_bypass_compiled_warns_and_skips_routing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--bypass-compiled`` constructs the miner in bypass mode and warns."""
+    from creek.generate.mining import IdeaMiner
+
+    captured: dict[str, bool] = {}
+    real_init = IdeaMiner.__init__
+
+    def _spy_init(self: IdeaMiner, **kwargs: object) -> None:
+        captured["bypass"] = bool(kwargs.get("bypass_compiled"))
+        real_init(self, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(IdeaMiner, "__init__", _spy_init)
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    result = runner.invoke(
+        app,
+        ["mine", "--vault", str(vault), "--bypass-compiled"],
+    )
+
+    assert result.exit_code == 0
+    assert captured["bypass"] is True
+    assert "--bypass-compiled" in result.output
+    assert "side-step" in result.output.lower()

--- a/creek-tools/tests/test_compile_routing.py
+++ b/creek-tools/tests/test_compile_routing.py
@@ -1,0 +1,205 @@
+"""Tests for ``creek.generate.compile_routing`` (FEAT-004)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.compile.provenance import ProvenanceEntry
+from creek.generate.compile_routing import (
+    COMPILE_GAPS_RELPATH,
+    CompiledPageIndex,
+    empty_index,
+    load_compiled_pages,
+    log_compile_gap,
+)
+from creek.models import CompiledPage
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_compiled_page(
+    target: Path,
+    *,
+    target_kind: str,
+    target_id: str,
+    title: str,
+    fragment_ids: tuple[str, ...] = (),
+    body: str = "# Body\n",
+) -> None:
+    """Persist a compiled-layer page at *target*."""
+    provenance = [
+        ProvenanceEntry(
+            claim_id=f"claim-{i}",
+            claim_excerpt=f"excerpt-{i}",
+            fragment_ids=[fid],
+            compiled_at=datetime(2026, 4, 1, tzinfo=UTC),
+            compile_method="llm",
+        )
+        for i, fid in enumerate(fragment_ids, start=1)
+    ]
+    page = CompiledPage(
+        target_kind=target_kind,
+        target_id=target_id,
+        title=title,
+        body=body,
+        provenance=provenance,
+    )
+    metadata = page.model_dump(mode="json", exclude={"body"})
+    target.parent.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(content=body, **metadata)
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+class TestLoadCompiledPages:
+    """``load_compiled_pages`` indexes by target_kind + target_id."""
+
+    def test_loads_threads_eddies_and_frequencies(self, tmp_path: Path) -> None:
+        """One page per kind round-trips via the index."""
+        _write_compiled_page(
+            tmp_path / "02-Threads" / "Active" / "thread-grief.md",
+            target_kind="thread",
+            target_id="thread-grief",
+            title="Grief",
+            fragment_ids=("frag-a",),
+        )
+        _write_compiled_page(
+            tmp_path / "03-Eddies" / "eddy-rituals.md",
+            target_kind="eddy",
+            target_id="eddy-rituals",
+            title="Rituals",
+            fragment_ids=("frag-b",),
+        )
+        _write_compiled_page(
+            tmp_path / "06-Frequencies" / "F3.md",
+            target_kind="frequency_index",
+            target_id="F3",
+            title="F3 Self-Love / Power",
+            fragment_ids=("frag-c",),
+        )
+
+        index = load_compiled_pages(tmp_path)
+
+        assert index.thread("thread-grief") is not None
+        assert index.eddy("eddy-rituals") is not None
+        assert index.frequency_index("F3") is not None
+
+    def test_missing_directories_yield_empty_index(self, tmp_path: Path) -> None:
+        """Vaults without compiled subdirs return empty maps, not errors."""
+        index = load_compiled_pages(tmp_path)
+        assert index.threads == {}
+        assert index.eddies == {}
+        assert index.frequency_indexes == {}
+
+    def test_skips_non_compiled_pages_in_compiled_dirs(self, tmp_path: Path) -> None:
+        """Files without ``type: compiled_page`` are ignored."""
+        target = tmp_path / "02-Threads" / "stray.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        post = frontmatter.Post(content="not a compiled page", title="Stray")
+        target.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+        index = load_compiled_pages(tmp_path)
+
+        assert index.threads == {}
+
+    def test_fragment_ids_for_dedupes_provenance(self, tmp_path: Path) -> None:
+        """Repeated fragment IDs across claims surface once, in order."""
+        page = CompiledPage(
+            target_kind="thread",
+            target_id="t",
+            title="t",
+            body="x",
+            provenance=[
+                ProvenanceEntry(
+                    claim_id="c1",
+                    claim_excerpt="e1",
+                    fragment_ids=["frag-a", "frag-b"],
+                    compiled_at=datetime(2026, 4, 1, tzinfo=UTC),
+                    compile_method="llm",
+                ),
+                ProvenanceEntry(
+                    claim_id="c2",
+                    claim_excerpt="e2",
+                    fragment_ids=["frag-b", "frag-c"],
+                    compiled_at=datetime(2026, 4, 1, tzinfo=UTC),
+                    compile_method="llm",
+                ),
+            ],
+        )
+        index = empty_index()
+        assert index.fragment_ids_for(page) == ("frag-a", "frag-b", "frag-c")
+
+
+class TestBypassedIndex:
+    """``empty_index(bypassed=True)`` reports every lookup as a miss."""
+
+    def test_bypassed_index_returns_none_for_known_id(self) -> None:
+        """Even when the dict has a page, bypass mode reports a miss."""
+        page = CompiledPage(
+            target_kind="thread",
+            target_id="thread-grief",
+            title="Grief",
+            body="x",
+        )
+        index = CompiledPageIndex(threads={"thread-grief": page}, bypassed=True)
+        assert index.thread("thread-grief") is None
+        assert index.eddy("anything") is None
+        assert index.frequency_index("F1") is None
+
+    def test_non_bypassed_returns_page(self) -> None:
+        """The same map without bypass returns the page."""
+        page = CompiledPage(
+            target_kind="thread",
+            target_id="thread-grief",
+            title="Grief",
+            body="x",
+        )
+        index = CompiledPageIndex(threads={"thread-grief": page})
+        assert index.thread("thread-grief") is page
+
+
+class TestLogCompileGap:
+    """``log_compile_gap`` appends to ``compile-gaps.jsonl``."""
+
+    def test_appends_jsonl_entry(self, tmp_path: Path) -> None:
+        """The log records target/reason/surfaced-by fields per call."""
+        log_compile_gap(
+            tmp_path,
+            target_kind="thread",
+            target_id="thread-x",
+            surfaced_by="mine.thread_terminus",
+            reason="missing",
+        )
+        log_compile_gap(
+            tmp_path,
+            target_kind="eddy",
+            target_id="eddy-y",
+            surfaced_by="draft",
+            reason="missing",
+        )
+
+        log_file = tmp_path / COMPILE_GAPS_RELPATH
+        lines = log_file.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+        first = json.loads(lines[0])
+        assert first["target_kind"] == "thread"
+        assert first["target_id"] == "thread-x"
+        assert first["surfaced_by"] == "mine.thread_terminus"
+        assert first["reason"] == "missing"
+        assert "timestamp" in first
+
+    def test_creates_processing_log_dir(self, tmp_path: Path) -> None:
+        """Parent dirs are created on demand."""
+        assert not (tmp_path / "00-Creek-Meta").exists()
+        log_compile_gap(
+            tmp_path,
+            target_kind="frequency_index",
+            target_id="F5",
+            surfaced_by="mine",
+            reason="insufficient",
+        )
+        assert (tmp_path / COMPILE_GAPS_RELPATH).exists()

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -638,3 +638,189 @@ class TestSaveDraft:
         assert frontmatter.load(str(first)).content.strip() == "First."
         assert frontmatter.load(str(second)).content.strip() == "Second."
         assert frontmatter.load(str(third)).content.strip() == "Third."
+
+
+# ---- FEAT-004 compiled-layer routing ---------------------------------
+
+
+def _write_compiled_thread_page(
+    vault: Path,
+    *,
+    target_id: str,
+    title: str,
+    body: str,
+    fragment_ids: tuple[str, ...] = (),
+) -> Path:
+    """Persist a compiled-layer thread page in a non-colliding subfolder."""
+    from creek.compile.provenance import ProvenanceEntry
+    from creek.models import CompiledPage
+
+    page = CompiledPage(
+        target_kind="thread",
+        target_id=target_id,
+        title=title,
+        body=body,
+        provenance=[
+            ProvenanceEntry(
+                claim_id=f"claim-{i}",
+                claim_excerpt=f"excerpt {i}",
+                fragment_ids=[fid],
+                compiled_at=datetime(2026, 4, 1, tzinfo=UTC),
+                compile_method="llm",
+            )
+            for i, fid in enumerate(fragment_ids, start=1)
+        ],
+    )
+    metadata = page.model_dump(mode="json", exclude={"body"})
+    target = vault / "02-Threads" / "Compiled" / f"{target_id}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(content=body, **metadata)
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+def _write_compiled_eddy_page(
+    vault: Path,
+    *,
+    target_id: str,
+    title: str,
+    body: str,
+) -> Path:
+    """Persist a compiled-layer eddy page in a non-colliding subfolder."""
+    from creek.models import CompiledPage
+
+    page = CompiledPage(target_kind="eddy", target_id=target_id, title=title, body=body)
+    metadata = page.model_dump(mode="json", exclude={"body"})
+    target = vault / "03-Eddies" / "Compiled" / f"{target_id}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(content=body, **metadata)
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+class TestGatherSourceMaterialCompileFirst:
+    """``gather_source_material`` reads the compiled layer before fragments."""
+
+    def test_compiled_thread_body_is_used_when_present(
+        self,
+        vault: Path,
+        skills_root: Path,
+        llm_echo: Callable[[str], str],
+    ) -> None:
+        """The compiled thread synthesis text replaces the description."""
+        thread = Thread(
+            id="thread-A",
+            title="Listening practice",
+            status=ThreadStatus.ACTIVE,
+            first_seen=date(2026, 1, 1),
+            last_seen=date(2026, 4, 1),
+            description="Bare frontmatter description.",
+        )
+        _write_thread(vault, thread)
+        _write_compiled_thread_page(
+            vault,
+            target_id="thread-A",
+            title="Listening practice",
+            body="# Listening practice\nThe synthesised body says listening matters.\n",
+        )
+        gen = DraftGenerator(llm=llm_echo, skills_root=skills_root)
+        seed = _build_seed(threads=("thread-A",))
+
+        block = gen.gather_source_material(seed, vault_path=vault)
+
+        assert "synthesised body says listening matters" in block
+        assert "Bare frontmatter description" not in block
+        gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
+        assert not gaps_log.exists()
+
+    def test_missing_compiled_thread_falls_back_and_logs_gap(
+        self,
+        vault: Path,
+        skills_root: Path,
+        llm_echo: Callable[[str], str],
+    ) -> None:
+        """Without a compiled page, frontmatter description appears + gap entry."""
+        thread = Thread(
+            id="thread-A",
+            title="Listening practice",
+            status=ThreadStatus.ACTIVE,
+            first_seen=date(2026, 1, 1),
+            last_seen=date(2026, 4, 1),
+            description="Frontmatter fallback text.",
+        )
+        _write_thread(vault, thread)
+        gen = DraftGenerator(llm=llm_echo, skills_root=skills_root)
+        seed = _build_seed(threads=("thread-A",))
+
+        block = gen.gather_source_material(seed, vault_path=vault)
+
+        assert "Frontmatter fallback text" in block
+        gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
+        assert gaps_log.exists()
+        contents = gaps_log.read_text(encoding="utf-8")
+        assert "thread-A" in contents
+        assert '"surfaced_by": "draft"' in contents
+
+    def test_compiled_eddy_body_replaces_description(
+        self,
+        vault: Path,
+        skills_root: Path,
+        llm_echo: Callable[[str], str],
+    ) -> None:
+        """Same compile-first behaviour for eddies."""
+        eddy = Eddy(
+            id="eddy-A",
+            title="Water as teacher",
+            formed=date(2026, 1, 1),
+            description="Stale frontmatter description.",
+        )
+        _write_eddy(vault, eddy)
+        _write_compiled_eddy_page(
+            vault,
+            target_id="eddy-A",
+            title="Water as teacher",
+            body="# Water as teacher\nWater is the teacher we keep returning to.\n",
+        )
+        gen = DraftGenerator(llm=llm_echo, skills_root=skills_root)
+        seed = _build_seed(eddies=("eddy-A",))
+
+        block = gen.gather_source_material(seed, vault_path=vault)
+
+        assert "Water is the teacher" in block
+        assert "Stale frontmatter description" not in block
+
+    def test_bypass_compiled_pulls_descriptions_and_skips_log(
+        self,
+        vault: Path,
+        skills_root: Path,
+        llm_echo: Callable[[str], str],
+    ) -> None:
+        """``bypass_compiled=True`` reads frontmatter only and never logs gaps."""
+        thread = Thread(
+            id="thread-A",
+            title="Listening practice",
+            status=ThreadStatus.ACTIVE,
+            first_seen=date(2026, 1, 1),
+            last_seen=date(2026, 4, 1),
+            description="Frontmatter description.",
+        )
+        _write_thread(vault, thread)
+        _write_compiled_thread_page(
+            vault,
+            target_id="thread-A",
+            title="Listening practice",
+            body="# Listening practice\nCompiled body that bypass should NOT see.\n",
+        )
+        gen = DraftGenerator(
+            llm=llm_echo,
+            skills_root=skills_root,
+            bypass_compiled=True,
+        )
+        seed = _build_seed(threads=("thread-A",))
+
+        block = gen.gather_source_material(seed, vault_path=vault)
+
+        assert "Frontmatter description" in block
+        assert "bypass should NOT see" not in block
+        gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
+        assert not gaps_log.exists()

--- a/creek-tools/tests/test_mining.py
+++ b/creek-tools/tests/test_mining.py
@@ -903,3 +903,386 @@ class TestMineAll:
         )
 
         assert any(s.strategy is MiningStrategy.THREAD_TERMINUS for s in seeds)
+
+
+# ---- FEAT-004 compiled-layer routing -------------------------------------
+
+
+def _write_compiled_thread_page(
+    vault: Path,
+    *,
+    target_id: str,
+    title: str,
+    fragment_ids: tuple[str, ...],
+) -> Path:
+    """Persist a compiled-layer thread page under ``02-Threads/Active``."""
+    from creek.compile.provenance import ProvenanceEntry
+    from creek.models import CompiledPage
+
+    page = CompiledPage(
+        target_kind="thread",
+        target_id=target_id,
+        title=title,
+        body=f"# {title}\n",
+        provenance=[
+            ProvenanceEntry(
+                claim_id=f"claim-{i}",
+                claim_excerpt=f"excerpt {i}",
+                fragment_ids=[fid],
+                compiled_at=datetime(2026, 4, 1, tzinfo=UTC),
+                compile_method="llm",
+            )
+            for i, fid in enumerate(fragment_ids, start=1)
+        ],
+    )
+    metadata = page.model_dump(mode="json", exclude={"body"})
+    # Use a distinct subfolder so the test fixture can coexist with the
+    # Thread-frontmatter note ``_write_thread`` places under Active/.
+    target = vault / "02-Threads" / "Compiled" / f"{target_id}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(content=page.body, **metadata)
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+def _write_compiled_eddy_page(
+    vault: Path,
+    *,
+    target_id: str,
+    title: str,
+    body: str,
+) -> Path:
+    """Persist a compiled-layer eddy page under ``03-Eddies``."""
+    from creek.models import CompiledPage
+
+    page = CompiledPage(target_kind="eddy", target_id=target_id, title=title, body=body)
+    metadata = page.model_dump(mode="json", exclude={"body"})
+    # Distinct subfolder so the eddy frontmatter file at the canonical
+    # path coexists with the compiled page.
+    target = vault / "03-Eddies" / "Compiled" / f"{target_id}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(content=body, **metadata)
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+def _write_compiled_frequency_page(
+    vault: Path,
+    *,
+    target_id: str,
+    fragment_ids: tuple[str, ...],
+) -> Path:
+    """Persist a compiled frequency-index page under ``06-Frequencies``."""
+    from creek.compile.provenance import ProvenanceEntry
+    from creek.models import CompiledPage
+
+    page = CompiledPage(
+        target_kind="frequency_index",
+        target_id=target_id,
+        title=f"{target_id} index",
+        body=f"# {target_id}\n",
+        provenance=[
+            ProvenanceEntry(
+                claim_id=f"claim-{i}",
+                claim_excerpt=f"excerpt {i}",
+                fragment_ids=[fid],
+                compiled_at=datetime(2026, 4, 1, tzinfo=UTC),
+                compile_method="llm",
+            )
+            for i, fid in enumerate(fragment_ids, start=1)
+        ],
+    )
+    metadata = page.model_dump(mode="json", exclude={"body"})
+    target = vault / "06-Frequencies" / f"{target_id}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(content=page.body, **metadata)
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+class TestCompileFirstThreadTerminus:
+    """``mine_thread_terminus`` reads compiled pages before fragments."""
+
+    def test_provenance_drives_source_fragments_when_compiled_page_exists(
+        self,
+        vault: Path,
+        miner: IdeaMiner,
+    ) -> None:
+        """Compiled-page provenance — not raw fragment scan — provides IDs."""
+        thread = _build_thread(
+            thread_id="thread-grief",
+            title="Grief rhythm",
+            fragment_count=12,
+        )
+        _write_thread(vault, thread)
+        _write_compiled_thread_page(
+            vault,
+            target_id="thread-grief",
+            title="Grief rhythm",
+            fragment_ids=("frag-compiled-1", "frag-compiled-2"),
+        )
+        for day in range(1, 13):
+            _write_fragment(
+                vault,
+                _build_fragment(
+                    frag_id=f"frag-raw-{day}",
+                    title=f"raw {day}",
+                    threads=("thread-grief",),
+                    created_day=day,
+                ),
+                "Body.",
+            )
+
+        seeds = miner.mine_thread_terminus(vault)
+
+        assert len(seeds) == 1
+        assert set(seeds[0].source_fragments) == {
+            "frag-compiled-1",
+            "frag-compiled-2",
+        }
+        gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
+        assert not gaps_log.exists()
+
+    def test_missing_compiled_page_falls_back_and_logs_gap(
+        self,
+        vault: Path,
+        miner: IdeaMiner,
+    ) -> None:
+        """Without a compiled page, fragments-as-fallback + gap entry."""
+        thread = _build_thread(
+            thread_id="thread-fallback",
+            title="Fallback thread",
+            fragment_count=12,
+        )
+        _write_thread(vault, thread)
+        for day in range(1, 13):
+            _write_fragment(
+                vault,
+                _build_fragment(
+                    frag_id=f"frag-{day:02d}",
+                    title=f"raw {day}",
+                    threads=("thread-fallback",),
+                    created_day=day,
+                ),
+                "Body.",
+            )
+
+        seeds = miner.mine_thread_terminus(vault)
+
+        assert len(seeds) == 1
+        assert "frag-01" in seeds[0].source_fragments
+        gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
+        assert gaps_log.exists()
+        contents = gaps_log.read_text(encoding="utf-8")
+        assert "thread-fallback" in contents
+        assert "mine.thread_terminus" in contents
+
+    def test_bypass_compiled_skips_log_and_uses_fragment_scan(
+        self,
+        vault: Path,
+    ) -> None:
+        """``bypass_compiled=True`` reads raw fragments and never logs."""
+        thread = _build_thread(
+            thread_id="thread-bypass",
+            title="Bypass thread",
+            fragment_count=12,
+        )
+        _write_thread(vault, thread)
+        _write_compiled_thread_page(
+            vault,
+            target_id="thread-bypass",
+            title="Bypass thread",
+            fragment_ids=("frag-compiled-1",),
+        )
+        for day in range(1, 13):
+            _write_fragment(
+                vault,
+                _build_fragment(
+                    frag_id=f"frag-{day:02d}",
+                    title=f"raw {day}",
+                    threads=("thread-bypass",),
+                    created_day=day,
+                ),
+                "Body.",
+            )
+
+        bypass_miner = IdeaMiner(bypass_compiled=True)
+        seeds = bypass_miner.mine_thread_terminus(vault)
+
+        assert len(seeds) == 1
+        assert "frag-compiled-1" not in seeds[0].source_fragments
+        assert "frag-01" in seeds[0].source_fragments
+        gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
+        assert not gaps_log.exists()
+
+
+class TestCompileFirstLiminalCrossEddy:
+    """``mine_liminal_cross_eddy`` compares against compiled eddy bodies."""
+
+    def test_compiled_eddy_body_drives_similarity(
+        self,
+        vault: Path,
+        miner: IdeaMiner,
+    ) -> None:
+        """Compile-first routing reads the eddy's compiled body, not its description."""
+        eddy = _build_eddy(
+            eddy_id="eddy-grief",
+            title="Bare frontmatter title",
+            description="bland",
+        )
+        _write_eddy(vault, eddy)
+        _write_compiled_eddy_page(
+            vault,
+            target_id="eddy-grief",
+            title="Grief rituals metabolise",
+            body="# Grief rituals\nGrief rituals metabolise the body slowly.\n",
+        )
+
+        frag = _build_fragment(frag_id="frag-w", title="Wandering")
+        _write_liminal_fragment(
+            vault,
+            frag,
+            "Grief rituals metabolise the body slowly.",
+            kind="Unnamed",
+        )
+
+        seeds = miner.mine_liminal_cross_eddy(vault)
+
+        assert len(seeds) == 1
+        assert seeds[0].eddies == ("eddy-grief",)
+        gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
+        assert not gaps_log.exists()
+
+    def test_missing_compiled_eddy_logs_gap(
+        self,
+        vault: Path,
+        miner: IdeaMiner,
+    ) -> None:
+        """A frontmatter-only eddy still seeds (fallback) but logs a gap."""
+        eddy = _build_eddy(
+            eddy_id="eddy-grief",
+            title="Grief practices",
+            description="Rituals for metabolising grief.",
+        )
+        _write_eddy(vault, eddy)
+
+        frag = _build_fragment(frag_id="frag-w", title="Wandering")
+        _write_liminal_fragment(
+            vault,
+            frag,
+            "Notes on grief rituals and metabolising grief slowly.",
+            kind="Unnamed",
+        )
+
+        miner.mine_liminal_cross_eddy(vault)
+
+        gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
+        assert gaps_log.exists()
+        assert "eddy-grief" in gaps_log.read_text(encoding="utf-8")
+
+
+class TestCompileFirstWavelengthWindow:
+    """``mine_wavelength_windows`` admits via compiled frequency provenance."""
+
+    def test_compiled_frequency_filters_to_provenance(
+        self,
+        vault: Path,
+        miner: IdeaMiner,
+    ) -> None:
+        """Only fragments listed in the compiled F<x> page surface."""
+        in_provenance = _build_fragment(
+            frag_id="frag-listed",
+            title="Listed fragment",
+            phase=Phase.RISING,
+            praxis=PraxisPotential.EXPLICIT,
+            frequency=Frequency.F5,
+        )
+        outside_provenance = _build_fragment(
+            frag_id="frag-orphan",
+            title="Orphan fragment",
+            phase=Phase.RISING,
+            praxis=PraxisPotential.EXPLICIT,
+            frequency=Frequency.F5,
+        )
+        _write_fragment(vault, in_provenance, "body")
+        _write_fragment(vault, outside_provenance, "body")
+        _write_compiled_frequency_page(
+            vault,
+            target_id="F5",
+            fragment_ids=("frag-listed",),
+        )
+
+        seeds = miner.mine_wavelength_windows(vault, current_phase=Phase.RISING)
+
+        ids = {fid for seed in seeds for fid in seed.source_fragments}
+        assert ids == {"frag-listed"}
+
+    def test_missing_frequency_index_logs_one_gap_per_frequency(
+        self,
+        vault: Path,
+        miner: IdeaMiner,
+    ) -> None:
+        """All fragments fall through and the gap log records one entry per F<x>."""
+        for fid in ("frag-1", "frag-2"):
+            _write_fragment(
+                vault,
+                _build_fragment(
+                    frag_id=fid,
+                    title=fid,
+                    phase=Phase.RISING,
+                    praxis=PraxisPotential.EXPLICIT,
+                    frequency=Frequency.F5,
+                ),
+                "body",
+            )
+
+        seeds = miner.mine_wavelength_windows(vault, current_phase=Phase.RISING)
+
+        assert len(seeds) == 2
+        gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
+        lines = gaps_log.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        assert "F5" in lines[0]
+
+
+class TestCompileFirstUnchangedExternalBehaviour:
+    """User-facing seeds are unchanged when the vault has compiled coverage."""
+
+    def test_present_vault_yields_same_seeds_with_or_without_routing(
+        self,
+        vault: Path,
+    ) -> None:
+        """Seeds from a fully-compiled vault match the bypass output (regression AC)."""
+        thread = _build_thread(
+            thread_id="thread-grief",
+            title="Grief rhythm",
+            fragment_count=12,
+        )
+        _write_thread(vault, thread)
+        for day in range(1, 13):
+            _write_fragment(
+                vault,
+                _build_fragment(
+                    frag_id=f"frag-{day:02d}",
+                    title=f"raw {day}",
+                    threads=("thread-grief",),
+                    created_day=day,
+                ),
+                "Body.",
+            )
+        _write_compiled_thread_page(
+            vault,
+            target_id="thread-grief",
+            title="Grief rhythm",
+            fragment_ids=tuple(f"frag-{day:02d}" for day in range(1, 13)),
+        )
+
+        compiled_seeds = IdeaMiner().mine_all(vault, current_phase=Phase.UNCLASSIFIED)
+        bypass_seeds = IdeaMiner(bypass_compiled=True).mine_all(
+            vault,
+            current_phase=Phase.UNCLASSIFIED,
+        )
+
+        compiled_titles = {s.title for s in compiled_seeds}
+        bypass_titles = {s.title for s in bypass_seeds}
+        assert compiled_titles == bypass_titles

--- a/creek-tools/tests/test_mining.py
+++ b/creek-tools/tests/test_mining.py
@@ -8,6 +8,7 @@ wavelength-phase windows.
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -1179,6 +1180,41 @@ class TestCompileFirstLiminalCrossEddy:
         gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
         assert gaps_log.exists()
         assert "eddy-grief" in gaps_log.read_text(encoding="utf-8")
+
+    def test_missing_compiled_eddy_logs_one_gap_per_eddy(
+        self,
+        vault: Path,
+        miner: IdeaMiner,
+    ) -> None:
+        """Per-run dedup: each eddy logs once regardless of liminal-fragment count.
+
+        Mirrors the wavelength-window dedup contract. With L liminal
+        fragments and E uncompiled eddies, the log should grow by E
+        entries per run, not L * E.
+        """
+        for eid in ("eddy-grief", "eddy-rituals"):
+            _write_eddy(
+                vault,
+                _build_eddy(
+                    eddy_id=eid,
+                    title=f"{eid} title",
+                    description="Notes on grief rituals and metabolising grief slowly.",
+                ),
+            )
+        for n in range(3):
+            _write_liminal_fragment(
+                vault,
+                _build_fragment(frag_id=f"frag-{n}", title=f"Wandering {n}"),
+                "Notes on grief rituals and metabolising grief slowly.",
+                kind="Unnamed",
+            )
+
+        miner.mine_liminal_cross_eddy(vault)
+
+        gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
+        lines = gaps_log.read_text(encoding="utf-8").strip().splitlines()
+        eddy_ids_logged = [json.loads(line)["target_id"] for line in lines]
+        assert sorted(eddy_ids_logged) == sorted(["eddy-grief", "eddy-rituals"])
 
 
 class TestCompileFirstWavelengthWindow:


### PR DESCRIPTION
## Summary

Implements [FEAT-004](../blob/main/plans/git-issues/FEAT-004-compiled-layer-query-routing.md): `creek mine` and `creek draft` now route through the compiled layer (`02-Threads/`, `03-Eddies/`, `06-Frequencies/`) before falling back to fragments — operationalising the compile-then-query discipline that ADOPT-001 made structural in FEAT-003.

- New `creek/generate/compile_routing.py` module loads the compiled-page index keyed by `(target_kind, target_id)` and exposes `log_compile_gap()` which appends to `00-Creek-Meta/Processing-Log/compile-gaps.jsonl`.
- `mine_thread_terminus` derives `source_fragments` from the compiled thread's provenance; `mine_liminal_cross_eddy` compares against the compiled eddy body; `mine_wavelength_windows` gates fragments through compiled frequency-index provenance.
- `draft.gather_source_material` reads compiled thread/eddy bodies for the prompt; falls back to frontmatter descriptions only when the compiled page is missing.
- `--bypass-compiled` flag added to `creek mine` and `creek draft`. It short-circuits the index, emits a stderr warning, and is documented as a diagnostic escape hatch.
- New `00-Creek-Meta/Skills/query.SKILL.md` (~128 lines, ≤1500 tokens). `AGENTS.md`'s inline 3-rule query contract is replaced with a pointer to it — closing the FEAT-001 asymmetry where compile/lint/save had dedicated skills but query was inline.
- `creek-tools/docs/generation.md` documents the routing change and the `--bypass-compiled` flag.

## Acceptance criteria verified

- ✅ `creek mine` and `creek draft` both check compiled pages before fragments (see `mine_thread_terminus`, `mine_liminal_cross_eddy`, `mine_wavelength_windows`, `gather_source_material`).
- ✅ `--bypass-compiled` flag exists on both commands and is documented (`creek/cli.py`, `docs/generation.md`).
- ✅ Missing compiled pages log to `00-Creek-Meta/Processing-Log/compile-gaps.jsonl` (`compile_routing.log_compile_gap`).
- ✅ Regression test verifies `creek draft` routes through the compiled layer in the absence of `--bypass-compiled` (`TestGatherSourceMaterialCompileFirst::test_compiled_thread_body_is_used_when_present` and `…test_bypass_compiled_pulls_descriptions_and_skips_log`).
- ✅ ≥90% branch coverage maintained — total coverage 93.42%, per-file gates green.
- ✅ Documentation in `docs/generation.md` updated.
- ✅ `query.SKILL.md` exists, ≤1500 tokens, and `AGENTS.md`'s inline 3-rule coverage is replaced with a pointer.

## LOC note

Net diff is ~1445 LOC (961 tracked + 513 untracked − 29 deletions), above the FEAT's ~450 LOC estimate. The overrun is mostly tests covering each routing strategy + the gap log + the bypass flag, plus the new `query.SKILL.md` mandated by an AC. Production code is ~519 LOC; tests ~817 LOC; docs ~167 LOC.

## Test plan

- [x] `./scripts/check-all.sh` green (3119 passed, 9 quality gates pass)
- [x] New unit tests cover compile-first routing, the gap log, and `--bypass-compiled` for both `mine` and `draft`
- [x] Regression test verifies same-vault seeds match between compile-first and bypass paths (`TestCompileFirstUnchangedExternalBehaviour`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YMSBdQHFu8bACqebqVPjNB)_