### PR TITLE
Add cve-remediation, git-workflow, user-facing-error-messages from well-worn-tools

### DIFF
--- a/.claude/skills/cve-remediation/SKILL.md
+++ b/.claude/skills/cve-remediation/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: cve-remediation
+description: >-
+  Remediate dependency vulnerability scanner failures by verifying live
+  package registry data and upgrading instead of suppressing. Use when an
+  SCA / CVE tool fails or files an alert: npm audit, pnpm audit, yarn audit,
+  pip-audit, safety, Snyk, Dependabot, Trivy, Grype, OSV-Scanner, audit-ci,
+  cargo audit, govulncheck, bundler-audit, Renovate, or any CI step
+  reporting a CVE / GHSA / OSV advisory. The first action is ALWAYS to look
+  up the latest published version on the live registry — training data is
+  months stale and almost never knows the current version. Suppression,
+  ignore, or allowlist entries are the absolute last resort, only after
+  upgrade and override paths are proven unavailable; surrounding GitHub
+  issues and justification docs do not by themselves count as remediation.
+  Do NOT use for vulnerabilities in your own application code (use security
+  skill), general linter or type checker bypasses (use max-quality-no-shortcuts
+  skill), or unrelated CI failures (use ci-debugging skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# CVE Remediation
+
+A dependency vulnerability scanner just failed. The fix is almost always a version bump — but you must look up the current version on the live registry, because your training data is months out of date and the version you remember is probably not the latest.
+
+## The Anti-Pattern to Resist
+
+When a CVE alert fires, the path of least resistance feels like:
+
+1. Add a suppression / ignore / allowlist entry.
+2. File a GitHub issue.
+3. Write a justification doc.
+4. Move on.
+
+**Do not start here.** This sequence is correct only as a final fallback after upgrade paths are demonstrably exhausted. Treating it as the default leaves real, fixable vulnerabilities in production behind a paper trail of issues that nobody revisits. Polished documentation around a suppression is not a fix.
+
+## Instructions
+
+### Step 1: Parse the Alert
+
+Extract from the scanner output:
+
+- Package name and ecosystem (npm, PyPI, crates.io, Go module, Maven, RubyGems, NuGet, Composer)
+- Currently installed version
+- Advisory ID (`CVE-YYYY-NNNNN`, `GHSA-xxxx-xxxx-xxxx`, `OSV-YYYY-NNNN`)
+- Severity (critical, high, moderate, low)
+- "Patched versions" range (e.g., `>= 1.4.2`)
+- Whether it is a direct or transitive dependency
+
+If any field is missing, look it up before acting. Do not remediate from a half-read alert.
+
+### Step 2: Look Up the LATEST Published Version (Critical)
+
+**You do not know the current version.** Your training data trails reality by months and most ecosystems publish daily. Whatever version you "know" is the latest is probably wrong. Always query the live registry first.
+
+| Ecosystem | Quick command |
+|-----------|---------------|
+| npm / pnpm / yarn | `npm view <pkg> version` |
+| PyPI              | `pip index versions <pkg>` |
+| crates.io         | `cargo search <pkg> --limit 1` |
+| Go modules        | `go list -m -versions <module>` |
+| Maven Central     | see `references/registry-lookups.md` |
+| RubyGems          | `gem search -re <pkg>` |
+| NuGet             | see `references/registry-lookups.md` |
+| Packagist         | `composer show <pkg> --available --no-interaction` |
+
+See `references/registry-lookups.md` for HTTP fallbacks when the package manager CLI is not available, and for listing the full version history.
+
+### Step 3: Verify the Latest Version Actually Fixes the CVE
+
+A newer version is not automatically a patched version. Confirm the fix:
+
+1. Compare the latest registry version against the advisory's "patched versions" range. If `latest >= fixed-in`, upgrading fixes it.
+2. Read the changelog / release notes for the version that introduced the fix.
+3. For GHSA: `gh api /advisories/<GHSA-id> --jq '.vulnerabilities[].patched_versions'`
+4. For OSV: `curl -s https://api.osv.dev/v1/vulns/<id> | jq '.affected[].ranges'`
+
+If the latest version is still vulnerable, the CVE is genuinely unpatched. Skip to Step 6.
+
+### Step 4: Apply the Upgrade
+
+**Direct dependency** — bump the version constraint, regenerate the lockfile, test:
+
+```bash
+npm install <pkg>@<fixed-version>
+uv add "<pkg>>=<fixed-version>"
+poetry add "<pkg>@^<fixed-version>"
+cargo update -p <pkg> --precise <fixed-version>
+go get <module>@<fixed-version> && go mod tidy
+bundle update <pkg> --conservative
+```
+
+**Transitive dependency** — find the direct dependency that pulls it in, and either bump that direct dependency to a version whose tree includes the patched transitive, or override the transitive directly:
+
+| Ecosystem | Override mechanism |
+|-----------|--------------------|
+| npm       | `"overrides"` in `package.json` |
+| Yarn      | `"resolutions"` in `package.json` |
+| pnpm      | `"pnpm.overrides"` in `package.json` |
+| pip       | constraints file via `pip install -c constraints.txt` |
+| Poetry / uv | direct entry in `[tool.poetry.dependencies]` / `[project.dependencies]` |
+| Cargo     | `[patch.crates-io]` in `Cargo.toml` |
+| Go        | `replace` directive in `go.mod` |
+| Bundler   | explicit entry in `Gemfile` |
+
+Confirm the override took effect:
+
+```bash
+npm ls <pkg>
+pip show <pkg>
+cargo tree -i <pkg>
+go mod why <module>
+```
+
+### Step 5: Verify the Fix
+
+1. Re-run the scanner that failed. It must pass.
+2. Run the project's test suite, type checker, and linter. Upgrades can introduce breakage.
+3. For major version bumps, read the upstream changelog and adapt callers as needed.
+
+If tests break, fix the breakage. Do not roll back the upgrade unless the breakage is genuinely insurmountable — and if it is, treat the upgrade as blocked and escalate, do not silently suppress.
+
+### Step 6: Last Resort — Suppression (Only If Truly Unfixable)
+
+You may add a suppression / ignore / allowlist entry only if ALL of these hold:
+
+- [ ] Step 2 confirmed: no patched version exists on the live registry yet.
+- [ ] Step 3 confirmed: the latest published version is still vulnerable.
+- [ ] Upstream maintainers have a tracking issue or PR you can link to (or, if not, you have opened one).
+- [ ] You have considered and rejected: forking, applying a `patch-package` / `cargo patch` / equivalent local patch, swapping libraries.
+- [ ] You have explicitly assessed exposure: severity × reachability × runtime context.
+
+If all five hold, suppress using `references/suppression-template.md`. The suppression must include:
+
+1. Advisory ID and link
+2. Why no upgrade exists, with link to upstream tracking
+3. Reachability and exposure assessment
+4. Concrete review date, no more than 30 days out
+5. Linked GitHub issue tracking re-evaluation
+
+A bare `# noqa`, `audit-ci.json` allowlist, or `.snyk` entry without these is incomplete. Reject your own work if any of the five is missing.
+
+### Step 7: Commit and Document
+
+- Upgrade commit: `fix(deps): bump <pkg> to <version> for <CVE-id>`
+- Suppression commit: include the GitHub issue number, and the issue must encode the review date as a label or due date so it is rediscoverable.
+
+## Examples
+
+### Example 1: Direct npm Dependency, Patched Version Available
+
+**Alert**: `lodash 4.17.20` has CVE-2021-23337 (high). Fixed in `>= 4.17.21`.
+
+```bash
+$ npm view lodash version
+4.17.21
+$ npm install lodash@4.17.21
+$ npm audit                # passes
+$ npm test                 # passes
+```
+
+Commit: `fix(deps): bump lodash to 4.17.21 for CVE-2021-23337`.
+
+### Example 2: Transitive Python Dependency
+
+**Alert**: `urllib3 1.26.5` (transitive via `requests`) has GHSA-v845-jxx5-vc9f. Fixed in `>= 1.26.18`.
+
+```bash
+$ pip index versions urllib3
+Available versions: 2.2.3, 2.2.2, ..., 1.26.20, 1.26.18
+$ pip show requests | grep Requires      # confirms requests pins urllib3<2
+$ uv add "urllib3>=1.26.18,<2"
+$ uv lock && uv sync
+$ pip-audit                              # passes
+```
+
+### Example 3: No Patch Available — Genuine Last Resort
+
+**Alert**: `obscure-lib 0.3.1` has CVE-2025-XXXXX. No fixed version listed.
+
+```bash
+$ npm view obscure-lib version
+0.3.1                                    # latest is still vulnerable
+$ gh api /advisories/GHSA-xxxx-yyyy-zzzz --jq '.vulnerabilities[].patched_versions'
+""                                       # no patch exists
+$ gh search issues --repo upstream/obscure-lib "CVE-2025-XXXXX"
+# Found: upstream/obscure-lib#42 — fix in progress
+```
+
+Open project issue, link to upstream issue #42, set review date 30 days out, suppress using the template in `references/suppression-template.md`.
+
+## Troubleshooting
+
+### Error: "I'm sure version X.Y.Z is the latest"
+
+You are not. Run the registry lookup command from Step 2. Training data lag is the single most common reason this skill exists.
+
+### Error: "The override didn't change the resolved version"
+
+Override syntax wrong, or lockfile not regenerated. After editing the override:
+
+- npm: delete `node_modules` and `package-lock.json`, then `npm install`
+- pnpm: `pnpm install --force`
+- Cargo: `cargo update`
+- Verify with `<package-manager> ls <pkg>` or `cargo tree -i <pkg>`.
+
+### Error: "Tests break after the upgrade"
+
+Not a reason to suppress. Read the changelog, fix the breakage. If a major version jump is too disruptive right now, pin to the highest minor / patch within your current major that contains the fix.
+
+### Error: "The vulnerable code path is unreachable from our app"
+
+Reachability is supporting evidence for prioritization, never a substitute for upgrading when a fix exists. Reachability arguments belong only in Step 6, when no fix exists at all.
+
+### Error: "Just adding the suppression and an issue is faster"
+
+Yes, and the suppression has no expiry the tooling enforces. Every "temporary" suppression added without an enforced review date is a permanent unfixed CVE wearing a costume.

--- a/.claude/skills/cve-remediation/references/registry-lookups.md
+++ b/.claude/skills/cve-remediation/references/registry-lookups.md
@@ -1,0 +1,147 @@
+# Live Registry Lookups
+
+Your training data is stale. Always query the registry. CLI commands are preferred when available; HTTP fallbacks let you confirm versions when the package manager is not installed in the current environment.
+
+## npm / pnpm / yarn (npm registry)
+
+```bash
+# Latest version
+npm view <pkg> version
+
+# All versions, newest last
+npm view <pkg> versions --json
+
+# Latest version of a specific dist-tag
+npm view <pkg> dist-tags
+
+# HTTP fallback (no Node toolchain required)
+curl -s "https://registry.npmjs.org/<pkg>/latest" | jq -r '.version'
+curl -s "https://registry.npmjs.org/<pkg>" | jq -r '.["dist-tags"].latest'
+```
+
+## PyPI (Python)
+
+```bash
+# Latest version (modern pip)
+pip index versions <pkg>
+
+# Show installed and latest in one go
+pip install <pkg>==                      # error message lists all versions
+
+# HTTP fallback
+curl -s "https://pypi.org/pypi/<pkg>/json" | jq -r '.info.version'
+curl -s "https://pypi.org/pypi/<pkg>/json" | jq -r '.releases | keys[]' | sort -V | tail
+```
+
+## crates.io (Rust)
+
+```bash
+cargo search <pkg> --limit 1
+
+# HTTP fallback
+curl -s "https://crates.io/api/v1/crates/<pkg>" | jq -r '.crate.max_stable_version'
+```
+
+## Go modules
+
+```bash
+go list -m -versions <module>            # space-separated, oldest first
+
+# HTTP fallback (proxy)
+curl -s "https://proxy.golang.org/<module>/@latest" | jq -r '.Version'
+curl -s "https://proxy.golang.org/<module>/@v/list"   # all versions
+```
+
+Lowercase module path components that contain capitals: `proxy.golang.org` requires `!` escaping (e.g. `gitHub.com` -> `git!hub.com`). Easier path: use `go list`.
+
+## Maven Central (Java / Kotlin / Scala)
+
+```bash
+# Latest version of group:artifact
+curl -s "https://search.maven.org/solrsearch/select?q=g:<group>+AND+a:<artifact>&rows=1&wt=json" \
+  | jq -r '.response.docs[0].latestVersion'
+
+# All versions
+curl -s "https://search.maven.org/solrsearch/select?q=g:<group>+AND+a:<artifact>&core=gav&rows=50&wt=json" \
+  | jq -r '.response.docs[].v'
+```
+
+## RubyGems
+
+```bash
+gem search -re <pkg>                     # remote, exact match
+
+# HTTP fallback
+curl -s "https://rubygems.org/api/v1/gems/<pkg>.json" | jq -r '.version'
+curl -s "https://rubygems.org/api/v1/versions/<pkg>.json" | jq -r '.[].number'
+```
+
+## NuGet (.NET)
+
+```bash
+# HTTP — flat container index, last entry is the latest
+curl -s "https://api.nuget.org/v3-flatcontainer/<pkg-lowercase>/index.json" \
+  | jq -r '.versions[-1]'
+```
+
+## Packagist (PHP / Composer)
+
+```bash
+composer show <pkg> --available --no-interaction
+
+# HTTP fallback
+curl -s "https://repo.packagist.org/p2/<vendor>/<pkg>.json" \
+  | jq -r '.packages."<vendor>/<pkg>"[0].version'
+```
+
+## Hex (Elixir / Erlang)
+
+```bash
+mix hex.info <pkg>
+
+# HTTP fallback
+curl -s "https://hex.pm/api/packages/<pkg>" | jq -r '.releases[0].version'
+```
+
+## Pub (Dart / Flutter)
+
+```bash
+curl -s "https://pub.dev/api/packages/<pkg>" | jq -r '.latest.version'
+```
+
+## Container images (Trivy / Grype findings)
+
+When the alert is on a base image rather than a language package:
+
+```bash
+# Docker Hub tags
+curl -s "https://hub.docker.com/v2/repositories/<org>/<image>/tags/?page_size=50&ordering=last_updated" \
+  | jq -r '.results[].name'
+
+# GitHub Container Registry
+gh api "/orgs/<org>/packages/container/<image>/versions" --jq '.[].metadata.container.tags[]'
+```
+
+## Advisory Databases
+
+Confirm the *patched-in* version, not just the latest:
+
+```bash
+# GitHub Security Advisories
+gh api /advisories/<GHSA-id> --jq '{summary, severity, vulnerabilities: .vulnerabilities[] | {package, vulnerable_version_range, patched_versions, ecosystem: .package.ecosystem}}'
+
+# OSV.dev (cross-ecosystem)
+curl -s https://api.osv.dev/v1/vulns/<id> | jq '{summary, affected: .affected[] | {package: .package, ranges: .ranges, fixed: [.ranges[].events[] | select(.fixed) | .fixed]}}'
+
+# NVD (CVE-only)
+curl -s "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=<CVE-id>" | jq '.vulnerabilities[0].cve.descriptions[0].value'
+```
+
+## Verifying You Got the Live Answer
+
+Two sanity checks before acting:
+
+1. The version returned is greater than the version installed locally. If they match, you may be looking at a cached metadata file — retry without cache (`npm view --no-cache`, `pip cache purge`).
+2. The publish date on the latest version is recent. `npm view <pkg> time.modified` and `pip show <pkg>` (after install) confirm freshness.
+
+If a registry call fails or returns stale-looking data, prefer to escalate over guessing. A wrong version number causes either an unnecessary suppression or a broken upgrade.

--- a/.claude/skills/cve-remediation/references/suppression-template.md
+++ b/.claude/skills/cve-remediation/references/suppression-template.md
@@ -1,0 +1,133 @@
+# Suppression Template (Last Resort)
+
+Use ONLY after Steps 2-5 of `SKILL.md` have been exhausted. A suppression that omits any of the five required fields is incomplete and must not be merged.
+
+## Required Fields
+
+Every suppression — wherever it lives (`audit-ci.json`, `.snyk`, `pip-audit --ignore-vuln`, `cargo-deny.toml`, `go.work` exclusions, GitHub Dependabot dismissals, inline tool comments) — must carry these five fields, either inline or in a linked tracking issue:
+
+1. **Advisory ID** — `CVE-YYYY-NNNNN`, `GHSA-xxxx-xxxx-xxxx`, or `OSV-YYYY-NNNN` plus a link to the canonical advisory page.
+2. **Why no upgrade exists** — one sentence stating that the latest registry version is still vulnerable, plus a link to the upstream tracking issue or PR.
+3. **Reachability and exposure assessment** — whether the vulnerable code path is reachable from this app, what data it touches, and what the realistic blast radius is.
+4. **Review date** — concrete ISO 8601 date, no more than 30 days from today. Encoded as a label or due date on the tracking issue so it is rediscoverable.
+5. **Tracking issue** — link to the project issue created to re-evaluate. The issue references the upstream tracking link and carries the review date.
+
+## Justification Block (paste into the suppression file)
+
+```text
+Advisory:        <CVE / GHSA / OSV id>            (<link>)
+Latest version:  <version>  confirmed via <registry command>  on <YYYY-MM-DD>
+Patched in:      none yet
+Upstream:        <link to upstream issue or PR>
+Reachability:    <reachable | not reachable | unknown>  - <one-line evidence>
+Exposure:        <data touched, runtime context, public/internal>
+Reviewed by:     <name>                                       on <YYYY-MM-DD>
+Review by:       <YYYY-MM-DD>   (issue: <link>)
+```
+
+## Per-Tool Examples
+
+### `audit-ci.json` (npm / pnpm / yarn)
+
+```json
+{
+  "high": true,
+  "allowlist": [
+    {
+      "advisory": "GHSA-xxxx-yyyy-zzzz",
+      "comment": "Latest obscure-lib (0.3.1) still vulnerable. Upstream fix in obscure-lib#42. Not reachable from runtime (build-only). Review by 2026-05-30, tracking issue #138."
+    }
+  ]
+}
+```
+
+### `.snyk`
+
+```yaml
+ignore:
+  SNYK-JS-OBSCURELIB-12345:
+    - "*":
+        reason: |
+          Latest obscure-lib 0.3.1 still vulnerable (verified 2026-05-02 via npm view).
+          Upstream fix in obscure-lib#42. Build-only path, not reachable at runtime.
+          Tracking: github.com/our-org/our-repo/issues/138.
+        expires: 2026-05-30T00:00:00.000Z
+```
+
+### `pip-audit`
+
+```bash
+pip-audit --ignore-vuln GHSA-xxxx-yyyy-zzzz \
+  --desc "obscure-lib 0.3.1 latest, no patch; upstream PR #42; review 2026-05-30; issue #138"
+```
+
+Prefer encoding the same justification in a checked-in `pyproject.toml` block so it survives across runs:
+
+```toml
+[tool.pip-audit]
+# obscure-lib 0.3.1 latest, no patch yet.
+# Upstream: https://github.com/upstream/obscure-lib/pull/42
+# Reachability: build-time only.
+# Tracking issue: #138, review by 2026-05-30.
+ignore-vulns = ["GHSA-xxxx-yyyy-zzzz"]
+```
+
+### `cargo-deny.toml`
+
+```toml
+[advisories]
+ignore = [
+  # GHSA-xxxx-yyyy-zzzz: obscure-crate 0.3.1 latest, no patch yet.
+  # Upstream: https://github.com/upstream/obscure-crate/issues/42
+  # Reachability: not exercised in our binary (feature-gated).
+  # Tracking: #138, review by 2026-05-30.
+  "RUSTSEC-2025-XXXX",
+]
+```
+
+### Dependabot (`.github/dependabot.yml`)
+
+Dependabot does not natively support time-boxed ignores; encode the review date in the tracking issue title and re-enable the alert when revisiting.
+
+```yaml
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule: { interval: "weekly" }
+    ignore:
+      - dependency-name: "obscure-lib"
+        # Tracking: #138 (review 2026-05-30) - latest 0.3.1 still vulnerable
+```
+
+## Tracking Issue Template
+
+Title: `[CVE] <advisory-id> in <package> — review by <YYYY-MM-DD>`
+
+Body:
+
+```markdown
+**Advisory:** <link>
+**Package:** <ecosystem>/<package> @ <currently-installed-version>
+**Latest registry version:** <version> (confirmed <YYYY-MM-DD>)
+**Patched in:** none yet
+**Upstream tracking:** <link to upstream issue/PR>
+
+**Reachability:** <reachable | not reachable | unknown>
+<one paragraph evidence>
+
+**Exposure:** <data touched, runtime context, public/internal>
+
+**Suppression location:** `<path/to/file>` line <N>
+
+**Review by:** <YYYY-MM-DD>
+On the review date, re-run the scanner and check the upstream tracking link.
+If a patched version exists, remove the suppression and upgrade.
+If still no patch, re-justify and bump the review date by no more than 30 days,
+or escalate to the security team.
+```
+
+Apply labels: `security`, `cve-suppression`, and a date label (e.g. `review:2026-05-30`) so the backlog can be queried.
+
+## What This Template is NOT
+
+This is not a substitute for upgrading. If you find yourself filling it out without having completed Steps 2-5 of the main workflow, stop and go back. The completeness of this paperwork has zero correlation with the soundness of the suppression — only the upstream registry state and your reachability analysis do.

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: git-workflow
+description: >-
+  Issue-first development workflow with template-file-based gh commands and
+  label hygiene. Use when creating issues, starting new work, making branches,
+  committing changes, or opening PRs. Covers the full issue-to-PR lifecycle
+  using file-based templates instead of inline strings. Do NOT use for
+  bug-specific debugging or RCA (use bug-squashing-methodology), PR code review
+  (use comprehensive-pr-review), or backlog cleanup and issue triage (use
+  backlog-grooming).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Git Workflow
+
+Issue-first development: every change starts with an issue, flows through a branch, and lands via a PR. Use template files for all gh commands instead of inline strings.
+
+## Instructions
+
+### Step 1: Check for Existing Issue
+
+Before any work, search for an existing issue:
+
+```bash
+gh issue list --search "keyword" --state open
+gh issue list --search "keyword" --state all
+```
+
+- If an issue exists, reference it and skip to Step 4.
+- If no issue exists, confirm with the user before creating one.
+
+### Step 2: Label Hygiene
+
+Before creating an issue, check existing labels:
+
+```bash
+gh label list
+```
+
+- Use an existing label if one fits.
+- Create a new label only if no similar one exists:
+  ```bash
+  gh label create "label-name" --description "What it covers" --color "hex"
+  ```
+
+### Step 3: Create Issue via Template File
+
+Write the issue body to a file, then pass it to `gh`:
+
+```bash
+mkdir -p plans/github-issues
+# Write body to plans/github-issues/ISSUE_NNN_slug.md
+gh issue create \
+  --title "type(scope): Brief description" \
+  --body-file plans/github-issues/ISSUE_NNN_slug.md \
+  --label "label1,label2"
+```
+
+Never inline long strings into `--body`. See `references/templates.md` for the issue body structure.
+
+After creation, note the issue number for branch naming and commit references.
+
+### Step 4: Branch from Issue
+
+Create a branch referencing the issue number:
+
+```bash
+git checkout -b type/short-description-NNN
+```
+
+Branch type prefixes:
+- `feat/` — new feature
+- `fix/` — bug fix
+- `chore/` — maintenance, deps, config
+- `docs/` — documentation only
+
+Example: `feat/add-user-search-42`, `fix/pagination-offset-87`
+
+### Step 5: Commit via Message File
+
+Write the commit message to a temp file, then commit with `-F`:
+
+```bash
+# Write message to plans/github-issues/COMMIT_NNN_slug.md
+git commit -F plans/github-issues/COMMIT_NNN_slug.md
+```
+
+Use conventional commit format in the message. See `references/templates.md` for the commit message structure.
+
+### Step 6: PR via Template File
+
+Write the PR body to a file, then create the PR:
+
+```bash
+# Write body to plans/github-issues/PR_NNN_slug.md
+gh pr create \
+  --title "type(scope): Brief description" \
+  --body-file plans/github-issues/PR_NNN_slug.md
+```
+
+The PR body must include `Closes #NNN` to auto-close the issue on merge. See `references/templates.md` for the PR body structure.
+
+### Step 7: Post-Merge Cleanup
+
+After the PR merges:
+
+```bash
+# Switch back to main and pull
+git checkout main && git pull
+
+# Delete the local branch
+git branch -d type/short-description-NNN
+
+# Verify the issue auto-closed
+gh issue view NNN --json state
+```
+
+## Examples
+
+### Example 1: Feature Development from Scratch
+
+User asks: "Add a /health endpoint to the API."
+
+**Search for existing issue:**
+```bash
+gh issue list --search "health endpoint" --state all
+# No results
+```
+
+**Confirm with user**, then check labels and create issue:
+```bash
+gh label list
+# "enhancement" exists, no need to create
+```
+
+Write `plans/github-issues/ISSUE_52_health-endpoint.md`:
+```markdown
+## Problem
+
+The API has no health check endpoint. Load balancers and monitoring tools
+need a lightweight endpoint to verify the service is running.
+
+## Proposed Solution
+
+Add a `GET /health` endpoint that returns `200 OK` with a JSON body
+containing service status and version.
+
+## Acceptance Criteria
+
+- [ ] `GET /health` returns 200 with `{"status": "ok", "version": "x.y.z"}`
+- [ ] Response time under 50ms (no DB calls)
+- [ ] Endpoint is unauthenticated
+```
+
+```bash
+gh issue create \
+  --title "feat(api): Add /health endpoint" \
+  --body-file plans/github-issues/ISSUE_52_health-endpoint.md \
+  --label "enhancement"
+# Created issue #52
+```
+
+**Branch and work:**
+```bash
+git checkout -b feat/add-health-endpoint-52
+# ... implement the feature ...
+```
+
+**Commit via file** — write `plans/github-issues/COMMIT_52_health-endpoint.md`:
+```
+feat(api): add /health endpoint
+
+Add lightweight health check endpoint for load balancer and monitoring
+integration. Returns service status and version without hitting the
+database.
+
+Refs #52
+```
+
+```bash
+git commit -F plans/github-issues/COMMIT_52_health-endpoint.md
+```
+
+**PR via file** — write `plans/github-issues/PR_52_health-endpoint.md`:
+```markdown
+## Summary
+
+Add a `GET /health` endpoint that returns service status and version
+for load balancer health checks.
+
+## Changes
+
+- Added `GET /health` route in `src/routes/health.ts`
+- Returns `{"status": "ok", "version": "1.2.0"}`
+- No authentication required, no database calls
+
+## Test Plan
+
+- [ ] `curl localhost:3000/health` returns 200
+- [ ] Response body matches expected schema
+- [ ] Response time under 50ms
+
+Closes #52
+```
+
+```bash
+gh pr create \
+  --title "feat(api): Add /health endpoint" \
+  --body-file plans/github-issues/PR_52_health-endpoint.md
+```
+
+### Example 2: Work Where Issue Already Exists
+
+User asks: "Fix the broken pagination on the users list."
+
+**Search for existing issue:**
+```bash
+gh issue list --search "pagination users" --state open
+# Found: #87 "bug: Users list pagination returns duplicates"
+```
+
+Issue #87 already exists — skip issue creation, go straight to branching:
+
+```bash
+git checkout -b fix/pagination-offset-87
+# ... fix the bug ...
+```
+
+**Commit via file** — write `plans/github-issues/COMMIT_87_pagination-fix.md`:
+```
+fix(users): correct pagination offset calculation
+
+Off-by-one error in offset: page * limit should be (page - 1) * limit
+since pages are 1-indexed.
+
+Fixes #87
+```
+
+```bash
+git commit -F plans/github-issues/COMMIT_87_pagination-fix.md
+```
+
+**PR via file** — write `plans/github-issues/PR_87_pagination-fix.md`:
+```markdown
+## Summary
+
+Fix off-by-one pagination bug causing duplicate items across pages.
+
+## Changes
+
+- Fixed offset calculation in `src/services/users.ts:45`
+- `offset = (page - 1) * limit` instead of `page * limit`
+
+## Test Plan
+
+- [ ] Page 1 and page 2 return no overlapping items
+- [ ] Last page returns correct number of items
+- [ ] Single-page result sets unaffected
+
+Closes #87
+```
+
+```bash
+gh pr create \
+  --title "fix(users): Correct pagination offset" \
+  --body-file plans/github-issues/PR_87_pagination-fix.md
+```
+
+## Troubleshooting
+
+### Error: No matching labels found
+
+If `gh label list` returns no relevant labels:
+1. Check if the repo uses a different labeling convention (e.g., `type:bug` vs `bug`).
+2. Create a new label only after confirming no similar one exists.
+3. Use descriptive names and colors consistent with existing labels.
+
+### Error: Issue already exists for this work
+
+If `gh issue list --search` finds a matching issue:
+1. Read the existing issue to confirm it covers the same scope.
+2. If it does, reference it directly — do not create a duplicate.
+3. If it's related but different, create a new issue and cross-reference.
+
+### Error: PR description file path issues
+
+If `gh pr create --body-file` fails:
+1. Verify the file exists: `ls plans/github-issues/PR_NNN_slug.md`
+2. Check for typos in the path — the directory may be `plan/` or `plans/`.
+3. Ensure the file is not empty (gh rejects empty body files).

--- a/.claude/skills/git-workflow/references/templates.md
+++ b/.claude/skills/git-workflow/references/templates.md
@@ -1,0 +1,92 @@
+# Git Workflow Templates
+
+## Issue Body Template
+
+Write to `plans/github-issues/ISSUE_NNN_slug.md`:
+
+```markdown
+## Problem
+
+[What is broken, missing, or needed. 2-3 sentences.]
+
+## Context
+
+[Why this matters. User impact, system impact, or business reason.]
+
+## Proposed Solution
+
+[How to fix or implement. Brief technical approach.]
+
+## Acceptance Criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Labels
+
+[Suggested labels — verify against `gh label list` before applying.]
+```
+
+## PR Body Template
+
+Write to `plans/github-issues/PR_NNN_slug.md`:
+
+```markdown
+## Summary
+
+[1-3 sentences describing what this PR does and why.]
+
+## Changes
+
+- [Change 1 with file reference]
+- [Change 2 with file reference]
+- [Change 3 with file reference]
+
+## Test Plan
+
+- [ ] Test scenario 1
+- [ ] Test scenario 2
+- [ ] Test scenario 3
+
+Closes #NNN
+```
+
+## Commit Message Template
+
+Write to `plans/github-issues/COMMIT_NNN_slug.md`:
+
+```
+type(scope): brief description
+
+[Body: 1-3 sentences explaining WHY, not just WHAT. Include context
+that isn't obvious from the diff.]
+
+[Footer: issue reference]
+Refs #NNN
+```
+
+### Conventional Commit Types
+
+| Type       | When to Use                        |
+|------------|------------------------------------|
+| `feat`     | New feature                        |
+| `fix`      | Bug fix                            |
+| `chore`    | Maintenance, deps, config          |
+| `docs`     | Documentation only                 |
+| `refactor` | Code change that doesn't add/fix   |
+| `test`     | Adding or updating tests           |
+| `ci`       | CI/CD pipeline changes             |
+
+### Issue Reference Keywords
+
+Use in commit messages and PR bodies:
+
+| Keyword               | Effect on Merge              |
+|-----------------------|------------------------------|
+| `Closes #NNN`        | Auto-closes the issue        |
+| `Fixes #NNN`         | Auto-closes the issue        |
+| `Resolves #NNN`      | Auto-closes the issue        |
+| `Refs #NNN`          | Links without closing        |
+
+Use `Closes` in the PR body (auto-close on merge). Use `Refs` in commit messages (link without closing, since the PR handles closure).

--- a/.claude/skills/user-facing-error-messages/SKILL.md
+++ b/.claude/skills/user-facing-error-messages/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: user-facing-error-messages
+description: >-
+  Audit and rewrite user-facing error messages so users can self-serve instead
+  of emailing support. Use when auditing error messages across an app,
+  improving or rewriting error wording, reviewing toasts, alerts, flash
+  messages, form validation copy, or empty/failure states, or when a message
+  feels opaque, blame-y, or ends in "contact support". Covers the four-part
+  rubric (what / why / next / escape), an inventory-and-triage audit workflow,
+  rewrite templates, and security-safe disclosure rules.
+  Do NOT use for exception architecture, typed errors, or developer-facing
+  logging (use error-handling skill); for the security rules around what
+  errors may safely disclose in auth/crypto paths (use security skill); or
+  for the visual styling of alerts, toasts, and banners (use
+  frontend-aesthetics skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# User-Facing Error Messages
+
+Write every error message as if you are the user reading it at 2am trying to get unstuck. The goal is self-service, not a support ticket.
+
+## Core Principle
+
+If a user hits this error, they have exactly one question: **"What do I do now?"** An error message that cannot answer that question has failed, no matter how technically accurate it is.
+
+"Contact support" is never a primary call-to-action. It is the last-resort escape hatch after you have done everything you can to let the user self-serve.
+
+## Instructions
+
+### Step 1: Adopt the User Empathy Lens
+
+Before writing or reviewing any message, answer these out loud:
+
+1. **Who hits this?** (End user? Admin? Developer integrating the API?)
+2. **What were they trying to do?** (The task, not the code path.)
+3. **What can they actually change?** (Their input? A setting? Wait and retry? Nothing?)
+4. **What is the emotional state?** (Lost work = high stakes. Typo in a form = low stakes. Tone must match.)
+
+If the answer to #3 is "nothing", the message must say so explicitly and offer an escape (status page, support link with a pre-filled trace ID, retry button).
+
+### Step 2: Apply the Four-Part Rubric
+
+Every user-facing error message is scored on four components. A passing message hits all four in plain language.
+
+| Component | Question it answers | Example |
+|-----------|--------------------|---------|
+| **What** | What went wrong, in human terms? | "We couldn't save your draft." |
+| **Why** | Why it happened — only if the user can act on it | "Your network dropped mid-save." |
+| **Next** | The single most useful next action | "Check your connection and tap Retry." |
+| **Escape** | Where to go if Next fails | "Still stuck? [Open a ticket] (ref: 7F3A2)" |
+
+Skip **Why** when it leaks internals, blames the user, or gives them no lever. Skip it; don't lie or filler.
+
+### Step 3: Run the Audit Workflow
+
+For a full-app audit, follow `references/audit-workflow.md`. The short version:
+
+1. **Inventory** every user-facing error source: `raise`/`throw`, toast/flash/snackbar calls, HTTP error responses rendered to users, form validation strings, empty-state copy, 4xx/5xx pages, email/SMS failures.
+2. **Classify** each string: user-facing vs. developer-facing (logs, stack traces). Only user-facing strings are in scope.
+3. **Score** each against the four-part rubric. Flag any message that scores below 3/4 or contains an anti-pattern from Step 4.
+4. **Triage** by blast radius: high-traffic paths first (login, checkout, save), then happy-path adjacent, then rare edge cases.
+5. **Rewrite** using the templates in `references/rewrite-templates.md`.
+6. **Preserve debuggability**: surface a short trace ID/error code so support can find the log line, but never make the code the whole message.
+
+### Step 4: Eliminate the Anti-Patterns
+
+Reject and rewrite any message matching these:
+
+- **The shrug**: "An error occurred." / "Something went wrong." / "Oops!"
+- **The opaque code**: "Error 0x80042108" with no human sentence.
+- **The blame**: "You entered an invalid email." (Use "That email is missing an @ — did you mean `name@example.com`?")
+- **The dev leak**: "NullPointerException in UserService.load()" / "ECONNREFUSED 127.0.0.1:5432".
+- **The dead-end**: ends in "contact support" with no trace ID, no link, and no attempt at self-serve.
+- **The jargon**: "Malformed payload", "Constraint violation", "Upstream 502" — translate.
+- **The panic**: ALL CAPS, stacked exclamation points, red-on-red screaming banners for recoverable cases.
+- **The liar**: "Please try again" when the request will deterministically fail again (e.g., invalid credentials, validation errors).
+- **The thief**: silently loses the user's work. Always confirm what was saved/preserved.
+
+### Step 5: Respect Security Boundaries
+
+Some errors intentionally stay vague. Coordinate with the `security` skill for these categories:
+
+- **Auth failures**: "Email or password is incorrect" (do not confirm which). Still actionable: "Reset password" link.
+- **Authorization**: "You don't have access to this project. Ask the project owner to invite you." Do not reveal existence of protected resources to unauthenticated users.
+- **Rate limits on sensitive endpoints**: give a cooldown window, not the exact counter state.
+
+Security vagueness is not an excuse for useless messages — the **Next** and **Escape** components still apply.
+
+### Step 6: Apply the Self-Service Sanity Check
+
+Before shipping, read the rewritten message aloud and ask:
+
+- [ ] Can a non-technical user name what broke?
+- [ ] Does it tell them exactly what to try next?
+- [ ] Does it preserve their work, or tell them it's lost?
+- [ ] Is there a trace ID or error code they can quote to support?
+- [ ] Does the tone match the severity (calm for recoverable, serious for data loss)?
+- [ ] Would I, half-asleep at 2am, know what to do?
+
+If any checkbox fails, rewrite.
+
+## Examples
+
+### Example 1: Form Validation — Specific, Actionable, Kind
+
+**Before:** `Invalid input.`
+
+**After:** `Phone number must be 10 digits — you entered 9. Example: (555) 123-4567.`
+
+- **What**: phone number wrong length
+- **Why**: 9 vs 10 digits (specific)
+- **Next**: implicit — add the missing digit, format example shown
+- **Escape**: not needed at this severity
+
+### Example 2: Server Error — Preserve Work, Offer Trace
+
+**Before:** `An unexpected error occurred. Please try again or contact support.`
+
+**After:**
+> We couldn't publish your post, but your draft is saved.
+>
+> Our servers hiccuped on the way to the database. Try again in a minute — if it happens twice, [open a ticket] and mention **ref: 7F3A2-B9**.
+
+- **What**: publish failed, draft safe
+- **Why**: brief, non-blaming, non-technical
+- **Next**: wait and retry
+- **Escape**: ticket link with pre-filled trace ID
+
+### Example 3: Auth Failure — Security-Safe Without Being Useless
+
+**Before:** `Login failed.`
+
+**After:** `That email and password don't match. [Reset password] or [create an account] if you're new here.`
+
+Note: does not confirm which field is wrong (security), but still points to the two real next actions.
+
+### Example 4: Full-App Audit Kickoff
+
+User says: *"We keep getting support emails that are just screenshots of error toasts. Do an audit."*
+
+1. Run Step 3 inventory (`references/audit-workflow.md` for grep patterns by stack).
+2. Produce a spreadsheet: message text, file:line, trigger frequency (from logs if available), rubric score, proposed rewrite.
+3. Sort by frequency × severity; fix the top decile first.
+4. For each rewrite, add a trace ID surface if one doesn't exist.
+5. Open a PR per subsystem, not one giant PR, so each is reviewable.
+
+## Troubleshooting
+
+### Error: The "why" would leak implementation details
+
+Drop the **Why** line. Keep **What** / **Next** / **Escape**. "Why" is optional; it is never worth a security or confusion cost to force one in.
+
+### Error: There's genuinely nothing the user can do
+
+Say so, and redirect energy usefully: "Our payments provider is down. You don't need to do anything — we'll retry automatically and email you when the charge goes through. [Status page]." The user's next action is "close this and stop worrying", which is a real, valid **Next**.
+
+### Error: Product/legal pushes back on specifics
+
+Push back with data: support-ticket volume traceable to opaque messages. If specifics are truly blocked (compliance, trade secret), the compromise is a trace ID the user can quote — never just "contact support".
+
+### Error: The message has to be short (toast, inline)
+
+Layer the disclosure: short message + "Details" link or expandable. The 4 components don't have to be in one sentence, they have to be in one experience.
+
+### Error: Message is internationalized and rewrite must pass translation
+
+Avoid idioms, contractions, and puns. Keep trace IDs and example values out of the translated string (interpolate them). See `references/rewrite-templates.md` for i18n-safe patterns.

--- a/.claude/skills/user-facing-error-messages/references/audit-workflow.md
+++ b/.claude/skills/user-facing-error-messages/references/audit-workflow.md
@@ -1,0 +1,111 @@
+# Audit Workflow
+
+A repeatable process for auditing every user-facing error message in an application. Use this when the task is "go wide" rather than "fix this one message".
+
+## 1. Inventory
+
+Cast a wide net. The goal is to collect every string that could ever reach a user in a failure state.
+
+### Where user-facing errors live
+
+- **Form validation**: inline field errors, form-level summary errors
+- **Toast / snackbar / flash messages**: ephemeral notifications
+- **Alert / banner / modal dialogs**: blocking or prominent errors
+- **4xx / 5xx pages**: 400, 401, 403, 404, 409, 422, 429, 500, 502, 503, 504
+- **Empty states with failure context**: "We couldn't load your projects"
+- **Email / SMS / push failures**: both the user's copy and the admin's copy
+- **API error bodies**: if the API is consumed by a third-party UI or CLI
+- **CLI stderr**: for developer-facing tools, the CLI *is* the UI
+- **Webhook failure notifications**: delivery retries, dead-letter queues
+- **Payment / billing failures**: card declines, subscription lapses
+
+### Grep patterns by stack
+
+Adjust to your codebase. Start broad, then narrow.
+
+```bash
+# Python (Flask/Django/FastAPI)
+rg -n 'flash\(|messages\.error|raise.*Error\(|HTTPException\(|abort\(' --glob '*.py'
+
+# JavaScript / TypeScript
+rg -n 'toast\.|showError|throw new \w*Error|res\.status\(\d+\)\.(json|send)' --glob '*.{ts,tsx,js,jsx}'
+
+# Templates (Jinja2 / ERB / Blade)
+rg -n 'error|alert' --glob '*.{html,jinja,erb,blade.php}'
+
+# Generic: quoted strings near error handling
+rg -B1 -A1 'error|failed|invalid|unable' --glob '!*.{lock,min.js}'
+```
+
+### Output shape
+
+Put the inventory in a spreadsheet or markdown table — one row per message:
+
+| # | File:Line | Trigger path | Current text | User-facing? | Frequency (30d) |
+|---|-----------|--------------|--------------|--------------|-----------------|
+| 1 | `auth/login.py:42` | POST /login bad creds | "Login failed." | Yes | 18,400 |
+| 2 | `api/users.py:88` | 500 fallback | "Internal server error" | Yes | 230 |
+
+## 2. Classify
+
+Mark each message:
+
+- **User-facing** — rendered to a human through the product UI. In scope.
+- **Developer-facing** — logs, stack traces, telemetry. Out of scope for this audit (see `error-handling` skill).
+- **Mixed** — e.g., an API error body that both logs emit *and* consumers render. Treat as user-facing; developers can read user-friendly text too.
+
+If classification is unclear, ask: *"If my parent hit this, would they see this exact string?"*
+
+## 3. Score
+
+For each user-facing message, score 0 or 1 on each rubric component:
+
+- [ ] **What**: names what failed in human terms
+- [ ] **Why**: gives a cause the user can act on (skip safely if N/A)
+- [ ] **Next**: specifies a concrete next action
+- [ ] **Escape**: offers a path when Next fails (trace ID, status page, support link)
+
+Also flag any message containing an anti-pattern (shrug, opaque code, blame, dev leak, dead-end, jargon, panic, liar, thief — see SKILL.md Step 4).
+
+A message passing fewer than 3/4 components or containing any anti-pattern is a rewrite candidate.
+
+## 4. Triage
+
+Sort rewrite candidates by **blast radius**:
+
+```
+priority_score = frequency × severity × stuck_factor
+```
+
+- **Frequency**: how often this message is seen (from logs, analytics, or support tickets).
+- **Severity**: 3 for data loss / payment / auth, 2 for core workflow, 1 for edge cases.
+- **Stuck factor**: 3 if no self-serve path exists, 2 if partial, 1 if easy workaround.
+
+Fix the top decile first. A full audit that ships nothing is worse than a focused audit that ships the top 20 messages.
+
+## 5. Rewrite
+
+Use templates from `rewrite-templates.md`. Each rewrite includes:
+
+- New message text
+- Trace ID surface (add one if missing — even a short hash of request ID helps support)
+- Severity / tone check (calm vs. serious)
+- Preservation statement if applicable ("your draft is saved")
+
+Keep the old error code or create a new one; map it in a lookup table so support can still match tickets to log lines.
+
+## 6. Ship in Reviewable Chunks
+
+- One PR per subsystem (auth, billing, forms, API, etc.), not one mega-PR.
+- Include before/after in the PR description so reviewers can feel the improvement.
+- Add a regression test or snapshot where feasible, so future commits can't quietly downgrade a message back to "An error occurred".
+
+## 7. Measure
+
+After shipping, watch:
+
+- Support-ticket volume tagged with the subsystem.
+- "Same user retried same action" rate (are they getting unstuck?).
+- Error-toast dismiss time (too fast = they didn't read; too slow = confusion).
+
+A good audit reduces support-ticket volume in the audited subsystem within the first month.

--- a/.claude/skills/user-facing-error-messages/references/rewrite-templates.md
+++ b/.claude/skills/user-facing-error-messages/references/rewrite-templates.md
@@ -1,0 +1,190 @@
+# Rewrite Templates
+
+Copy-pasteable before/after pairs organized by error category. Each template applies the four-part rubric (What / Why / Next / Escape) from `SKILL.md`.
+
+## Form & Input Validation
+
+### Required field missing
+
+- **Bad:** `This field is required.`
+- **Good:** `Email address is required — we'll send your receipt here.`
+
+Include the *purpose* of the field so the user sees why we're asking.
+
+### Format mismatch
+
+- **Bad:** `Invalid date.`
+- **Good:** `Use the format MM/DD/YYYY — for example, 04/13/2026.`
+
+Always show one concrete example in the right format.
+
+### Length / range
+
+- **Bad:** `Password does not meet requirements.`
+- **Good:** `Passwords need at least 12 characters. Yours has 7 — try a memorable passphrase like "tree-river-sunset".`
+
+Name the requirement, name the actual value, and suggest an approach.
+
+### Uniqueness / taken
+
+- **Bad:** `Username unavailable.`
+- **Good:** `"geoff" is taken. Try **geoff2026**, **geoff-g**, or [sign in] if it's you.`
+
+Offer suggestions derived from the user's input.
+
+## Authentication & Authorization
+
+### Bad credentials
+
+- **Bad:** `Authentication failed.`
+- **Good:** `That email and password don't match. [Reset password] or [create an account].`
+
+Do not disclose which field was wrong. Both next actions still work.
+
+### Session expired
+
+- **Bad:** `Unauthorized.`
+- **Good:** `You were signed out after 30 minutes of inactivity. [Sign in again] — your draft is saved.`
+
+Name the cause in user terms. Confirm preserved work.
+
+### Permission denied
+
+- **Bad:** `403 Forbidden.`
+- **Good:** `You don't have access to the "Marketing" workspace. Ask its owner, **Sam Rivera**, to invite you — or [switch workspaces].`
+
+Name the missing grant and the person who can give it.
+
+### MFA / 2FA failure
+
+- **Bad:** `Invalid code.`
+- **Good:** `That 6-digit code didn't match. Codes expire every 30 seconds — open your authenticator app and try the newest one. [Lost access?]`
+
+Explain the time-boxing and give the lost-device escape hatch.
+
+## Network / Service Failures
+
+### Transient server error
+
+- **Bad:** `Something went wrong. Please try again.`
+- **Good:**
+  > We couldn't save your changes — our server hiccuped.
+  >
+  > Your work is still in the form. [Try again] — if it fails twice, check [status.example.com] or [open a ticket] (ref: 7F3A2).
+
+Confirm preserved state; give retry, status page, and ticket path.
+
+### Offline / network down
+
+- **Bad:** `Network error.`
+- **Good:** `You're offline. We'll save your changes as soon as you're back on the internet — don't close this tab.`
+
+Own the user's fear (data loss). Tell them the action they *shouldn't* take.
+
+### Upstream/3rd-party down
+
+- **Bad:** `Gateway timeout.`
+- **Good:** `Our payment processor (Stripe) is slow right now. Your card wasn't charged. [Try again] in a minute, or [choose a different payment method].`
+
+Name the upstream plainly. Confirm no side effects.
+
+### Rate limited
+
+- **Bad:** `429 Too Many Requests.`
+- **Good:** `You've hit the limit of 60 messages per minute. You can send again in **42 seconds**.`
+
+Quantify the limit and the countdown. Avoid giving attackers exact state on sensitive endpoints — coordinate with `security` skill.
+
+## Payment & Billing
+
+### Card declined
+
+- **Bad:** `Payment failed.`
+- **Good:** `Your card ending in **1234** was declined by the issuing bank. Try a different card or contact your bank — we never see why they declined.`
+
+Say what you know and what you *don't* know. Prevent users from blaming you.
+
+### Subscription lapsed
+
+- **Bad:** `Access denied.`
+- **Good:** `Your Pro subscription ended on April 1. [Renew now] to restore team members, integrations, and analytics — nothing has been deleted.`
+
+Reassure about data. List what they're missing to create a clear value case.
+
+## Data / Storage
+
+### Not found
+
+- **Bad:** `404 Not Found.`
+- **Good:** `We couldn't find a project at that link. It may have been deleted or renamed. [See all your projects] or [search].`
+
+Offer two ways to rediscover.
+
+### Conflict / stale edit
+
+- **Bad:** `409 Conflict.`
+- **Good:** `Alex edited this page after you opened it. [See their changes], [overwrite with yours], or [merge both].`
+
+Name the other actor. Give a real choice.
+
+### Upload too large
+
+- **Bad:** `File too large.`
+- **Good:** `That file is **18 MB** — the limit is **10 MB**. [Compress it here] or email it as a link instead.`
+
+Actual size, actual limit, actual alternative.
+
+## CLI / Developer Tools
+
+CLIs *are* a UI. The same rubric applies, adjusted for a technical audience.
+
+- **Bad:** `ENOENT`
+- **Good:**
+  ```
+  ✗ Couldn't find config file at ./well-worn.toml
+
+    We checked: .  ../  ~/
+    Run `well-worn init` to create one, or pass --config <path>.
+  ```
+
+Show the search path. Name the fix command.
+
+## Empty / Zero-State Failures
+
+Failure isn't always red. Sometimes it's an empty page.
+
+- **Bad:** `No results.`
+- **Good:** `No projects match "archive 2019". Try removing a filter, or [clear all filters] to start over.`
+
+Name the query, name the levers.
+
+## i18n-Safe Patterns
+
+Messages that must translate cleanly:
+
+- Interpolate variables — don't concatenate strings.
+- Avoid contractions, idioms, puns.
+- Keep trace IDs, example values, and numbers out of the translatable string.
+
+```python
+# Bad
+msg = "Couldn't find " + name + " — did you mean " + suggestion + "?"
+
+# Good
+msg = _("We couldn't find {name}. Did you mean {suggestion}?").format(
+    name=name, suggestion=suggestion
+)
+```
+
+## Tone Ladder
+
+Pick severity, match tone:
+
+| Severity | Example scenario | Tone | Example opening |
+|----------|-----------------|------|-----------------|
+| Low | Typo in form | Helpful, light | "Almost! …" |
+| Medium | Request failed, recoverable | Calm, factual | "We couldn't save …" |
+| High | Data loss possible | Serious, direct | "Your changes weren't saved …" |
+| Critical | Security / account takeover | Urgent, action-first | "Sign out of all devices now …" |
+
+Never use exclamation points on Medium+. Never use "Oops" or "Uh oh" on High+.

--- a/.github/workflows/iteration-trigger.yml
+++ b/.github/workflows/iteration-trigger.yml
@@ -1,0 +1,95 @@
+name: Iteration Trigger
+
+# Posts a brief executive summary on a PR (commenting as Geoffe-Ga via PAT)
+# whenever CI completes fully green AND a Claude review has been posted.
+# The comment is intended to fire a webhook that wakes the Claude Code mobile
+# app via MCP so it can continue iterating on feedback. Capped at 10 self-posts
+# per PR to avoid runaway loops.
+#
+# Required secrets:
+#   GEOFFE_GA_PAT  - personal access token for Geoffe-Ga with `pull-requests: write`.
+#                    Without this the comment would post as github-actions[bot]
+#                    and the mobile webhook would not recognize the author.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  nudge:
+    name: Post executive summary
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR number from head branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          PR=$(gh pr list -R "$REPO" --head "$BRANCH" --state open \
+                 --json number --jq '.[0].number // empty')
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: Compose and post summary
+        if: steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GEOFFE_GA_PAT }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.pr.outputs.number }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          MARKER: '<!-- iteration-trigger -->'
+        run: |
+          set -euo pipefail
+
+          # Pull PR comments once (first 100 is plenty for an active PR).
+          gh api "repos/$REPO/issues/$PR/comments?per_page=100" > comments.json
+
+          # Cap: stop after 10 prior self-posts on this PR.
+          PRIOR=$(grep -c "$MARKER" comments.json || true)
+          if [ "$PRIOR" -ge 10 ]; then
+            echo "Cap reached ($PRIOR/10) - skipping"
+            exit 0
+          fi
+
+          # Find latest Claude review comment (its body contains 'Verdict').
+          CLAUDE=$(jq -c '[.[] | select(.body | test("Verdict"))] | last // empty' comments.json)
+          if [ -z "$CLAUDE" ]; then
+            echo "No Claude review yet - skipping"
+            exit 0
+          fi
+          ID=$(jq -r '.id'   <<<"$CLAUDE")
+          BODY=$(jq -r '.body' <<<"$CLAUDE")
+
+          # Summarize verdict via grep on the Claude comment body.
+          if   grep -qE 'CHANGES[_ ]REQUESTED' <<<"$BODY"; then VERDICT='CHANGES REQUESTED'
+          elif grep -q   'LGTM'                <<<"$BODY"; then VERDICT='LGTM'
+          else                                                  VERDICT='COMMENTS'
+          fi
+
+          # CI status from check-runs on the head SHA.
+          gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" > runs.json
+          TOTAL=$(jq '.check_runs | length'                                       runs.json)
+          GREEN=$(jq '[.check_runs[] | select(.conclusion=="success")] | length' runs.json)
+
+          if [ "$GREEN" = "$TOTAL" ] && [ "$VERDICT" = "LGTM" ]; then
+            ACTION="You are cleared to squash merge, delete the branch, clean any worktrees, and unsubscribe from webhooks. Please proceed."
+          else
+            ACTION="pull comment ${ID} to see in-depth feedback and continue iterating"
+          fi
+
+          BODY=$(printf '%s\n%s\n%s\n%s\n' \
+            "$MARKER" \
+            "**CI**: ${GREEN}/${TOTAL} Green" \
+            "**VERDICT**: ${VERDICT}" \
+            "**Action**: ${ACTION}")
+          gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$BODY"


### PR DESCRIPTION
## Summary

Adds 3 skill(s) from [`Geoffe-Ga/well-worn-tools`](https://github.com/Geoffe-Ga/well-worn-tools/tree/22ee048) to this repo.

## Skills

- **cve-remediation** — - Remediate dependency vulnerability scanner failures by verifying live package registry data and upgrading instead of suppressing.
- **git-workflow** — - Issue-first development workflow with template-file-based gh commands and label hygiene.
- **user-facing-error-messages** — - Audit and rewrite user-facing error messages so users can self-serve instead of emailing support.

## Provenance

Source SHA: `22ee0481d6609a647feef742417b02692434cd08`
Distributed via the `distribute-skills` skill (`metadata.distribute: false`, stays in well-worn-tools).

## Test plan

- [ ] Confirm `.claude/skills/` directory structure looks right
- [ ] Spot-check one SKILL.md frontmatter for syntax
- [ ] Decide whether each skill's triggers fit this repo's workflows