### PR TITLE
feat(state): complete `creek state` audit report (FEAT-006, PR 2/2)

### DIFF
--- a/.claude/skills/await-claude-review/SKILL.md
+++ b/.claude/skills/await-claude-review/SKILL.md
@@ -19,7 +19,7 @@ description: >-
   status polling (use `pull_request_read` directly).
 metadata:
   author: Geoff
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # Await Claude Review
@@ -61,6 +61,35 @@ Examples that match:
 
 If the regex does not match, treat the comment as malformed: do **not** infer a verdict from prose ("looks good to me" is not a verdict). Surface to the user.
 
+## Iteration-Trigger Wake (Owner-Authored Summary)
+
+Some repos run an **iteration-trigger workflow** (`.github/workflows/iteration-trigger.yml`) that, after CI completes green, posts an executive-summary comment **as the repo owner** (via PAT) on the PR. The comment carries an HTML marker and a structured body:
+
+```
+<!-- iteration-trigger -->
+**CI**: 5/5 Green
+**VERDICT**: LGTM
+**Action**: You are cleared to squash merge, delete the branch, ...
+```
+
+This comment is not authored by `claude[bot]` — it's authored by the human user via a PAT — but it **is** the wake signal you want when one is configured, because it bundles the verdict and the CI status into a single delivered event after the underlying claude-review comment has landed. Mobile-app sessions in particular rely on this trigger because their webhook recognises owner-authored comments.
+
+**Recognition.** A comment qualifies as an iteration-trigger summary when **all** of:
+
+1. The body contains the literal marker `<!-- iteration-trigger -->`.
+2. A line matches `^\*\*VERDICT\*\*:\s*(LGTM|CHANGES[_ ]REQUESTED|COMMENTS)`.
+3. A line matches `^\*\*CI\*\*:\s*(\d+)/(\d+)\s+Green` (use this to decide `merge` vs `iterate`).
+
+**Routing.** When this comment wakes the session:
+
+- `VERDICT == LGTM` and `CI: N/N Green` (full match) → caller proceeds to merge gate. The `Action:` line will say "cleared to squash merge…".
+- `VERDICT == CHANGES_REQUESTED` or `VERDICT == COMMENTS` → caller enters fix loop. The `Action:` line will reference a comment ID to read for in-depth feedback. Pull that comment via `mcp__github__pull_request_read` `get_comments` and feed the body into `address-feedback`.
+- `CI: x/y Green` where `x < y` → CI is not actually green; do not merge even on `LGTM`. Investigate the failing run before proceeding.
+
+**Currency check still applies.** The trigger fires on a `workflow_run` for a specific HEAD SHA, but the comment may arrive minutes after the push. Use the standard `created_at >= headPushedAt` guard before treating it as authoritative for the current HEAD.
+
+**Cap awareness.** The workflow caps itself at 10 self-posts per PR (it counts prior `<!-- iteration-trigger -->` markers). If you don't get a wake event after the eleventh push, the trigger has gone silent — fall back to checking the underlying claude-review comment directly via `get_comments`.
+
 ## Instructions
 
 ### Step 1: Pin the HEAD You're Waiting For
@@ -85,6 +114,7 @@ Then **stop**. Do not poll. Do not `sleep`. Do not call `pull_request_read get_c
 
 When a `<github-webhook-activity>` message arrives, decide what kind of event it is:
 
+- **Owner-authored iteration-trigger summary** (body contains `<!-- iteration-trigger -->`) → go to Step 4a. This is the preferred wake on repos that run `iteration-trigger.yml`; it short-circuits the per-event classification because the verdict is already summarised.
 - **Top-level PR comment from a reviewer bot** (`claude[bot]`, `github-actions[bot]`, or whichever account posts reviews on this repo) → go to Step 4.
 - **Line-level review comment** → not a verdict; if you're tracking thread resolutions for `address-feedback`, handle there. Otherwise stay subscribed and wait for the next event.
 - **CI failure event** → go to Step 5.
@@ -103,6 +133,16 @@ Re-fetch the comments to read the full body (the webhook payload may be truncate
    - `CHANGES_REQUESTED` → caller enters fix loop.
    - `COMMENTS` → caller decides (usually mergeable as-is).
    - **Malformed** → surface to user; do not guess.
+
+### Step 4a: Iteration-Trigger Summary
+
+When the wake event is the owner-authored iteration-trigger comment:
+
+1. **Currency check**: require `created_at >= headPushedAt`.
+2. Parse `**VERDICT**:` and `**CI**: x/y Green` from the body.
+3. If `VERDICT == LGTM` AND `x == y` (CI fully green): return `LGTM` to the caller. The follow-up `Action:` line typically reads "cleared to squash merge…". The caller proceeds to merge.
+4. Otherwise: extract the comment ID referenced in `Action: pull comment <id> …`, fetch that comment's body via `get_comments`, and pass the body to the caller (typically `address-feedback`) for triage. Treat the underlying verdict (`CHANGES_REQUESTED` or `COMMENTS`) as authoritative for the next loop.
+5. If the body is malformed (marker present but verdict line missing/unparseable): surface to user. Do not infer a verdict from the `Action:` prose.
 
 ### Step 5: On CI Failure for Current HEAD
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -896,6 +896,28 @@ def report(
 
 
 @app.command()
+def state(
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+) -> None:
+    """Render ``00-Creek-Meta/State/<iso-week>.md`` audit report (FEAT-006).
+
+    The command is a *view* over the compiled vault layer — it never
+    re-runs classification, linking, or compile. It reads existing
+    fragments, threads, eddies, praxis, synchronicities, and the most
+    recent ``run-summary.jsonl`` line, and writes a single markdown
+    document organised in seven sections (vault summary, pre-LLM yield,
+    active eddies, active threads, surprising connections, hyperedges,
+    drift warnings). ``latest.md`` next to the ISO-week file always
+    points at the most recent report.
+    """
+    from creek.generate.state import StateReportGenerator
+
+    vault_path = _resolve_vault(vault)
+    written = StateReportGenerator(vault_path=vault_path).write()
+    console.print(f"[bold green]State report written: {written}[/bold green]")
+
+
+@app.command()
 def review(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
     list_only: bool = typer.Option(

--- a/creek-tools/creek/generate/state.py
+++ b/creek-tools/creek/generate/state.py
@@ -461,11 +461,12 @@ class StateReportGenerator:
         Ranked by ``(-len(spanning), praxis.title)`` so the praxis that
         bridges the most eddies appears first; matches the deterministic
         ordering of sections 3-5 instead of falling back to filesystem
-        order.
+        order. The em-dash separator matches the convention used by the
+        other list sections.
         """
-        eddies_by_fragment = self._eddies_by_fragment()
+        fragment_to_eddies = self._fragment_to_eddies()
         candidates = [
-            (praxis, self._praxis_spans(praxis, eddies_by_fragment))
+            (praxis, self._praxis_spans(praxis, fragment_to_eddies))
             for praxis in self._state.praxis
         ]
         ranked = sorted(
@@ -473,7 +474,7 @@ class StateReportGenerator:
             key=lambda pair: (-len(pair[1]), pair[0].title),
         )[:_TOP_N]
         body = [
-            f"- {praxis.title} - spans: {', '.join(sorted(spanning))}"
+            f"- {praxis.title} — spans: {', '.join(sorted(spanning))}"
             for praxis, spanning in ranked
         ]
         return _section(SECTION_ORDER[5], body)
@@ -545,8 +546,13 @@ class StateReportGenerator:
             f"_Generated {generated} from `{vault_label}`._"
         )
 
-    def _eddies_by_fragment(self) -> dict[str, set[str]]:
-        """Return ``{fragment_id: {eddy_title, ...}}`` from fragment frontmatter."""
+    def _fragment_to_eddies(self) -> dict[str, set[str]]:
+        """Return ``{fragment_id: {eddy_title, ...}}`` from fragment frontmatter.
+
+        Named in the direction of the mapping (fragment -> eddies) to
+        match Python ``dict`` semantics; ``_eddies_by_fragment`` was
+        ambiguous about which side was the key.
+        """
         mapping: dict[str, set[str]] = {}
         for fragment in self._state.fragments:
             targets = set(_wikilink_targets(fragment.eddies))
@@ -557,12 +563,12 @@ class StateReportGenerator:
     @staticmethod
     def _praxis_spans(
         praxis: Praxis,
-        eddies_by_fragment: dict[str, set[str]],
+        fragment_to_eddies: dict[str, set[str]],
     ) -> set[str]:
         """Return the union of eddies touched by a praxis's source fragments."""
         spanning: set[str] = set()
         for frag_id in praxis.derived_from:
-            spanning.update(eddies_by_fragment.get(frag_id, set()))
+            spanning.update(fragment_to_eddies.get(frag_id, set()))
         return spanning
 
 
@@ -584,7 +590,10 @@ def _refresh_latest(state_dir: Path, target: Path) -> Path:
         if latest.exists() or latest.is_symlink():
             latest.unlink()
     except OSError:
-        logger.debug("Could not unlink existing latest.md")
+        # Warn rather than debug: an unlink failure here can mask a
+        # permissions issue and leave a dangling symlink behind, so the
+        # operator should see it in default-level logs.
+        logger.warning("Could not unlink existing latest.md")
     if os.name != "nt":
         try:
             latest.symlink_to(target.name)

--- a/creek-tools/creek/generate/state.py
+++ b/creek-tools/creek/generate/state.py
@@ -17,32 +17,30 @@ This module is intentionally a *view* over the compiled layer — it
 never re-runs classification, linking, or compile passes. It only
 reads what is already on disk.
 
-This first slice (PR 1 of 2) implements section 1 (vault summary) and
-section 2 (pre-LLM yield), plus the section-ordering and empty-state
-contracts that every section must honour. The remaining five sections
-are wired into :data:`SECTION_ORDER` and :meth:`StateReportGenerator.render`
-as explicit empty-state placeholders so tests can pin the documented
-layout now; PR 2 will replace those placeholders with real content,
-add the ``write()`` / ``latest.md`` plumbing, and ship the ``creek state``
-CLI command. FEAT-007 inserts wavelength snapshot + suggested questions
-between sections 1 and 2 once those sections exist.
+PR 1 of FEAT-006 shipped the scaffold plus sections 1 and 2; this PR 2
+fills in sections 3-7, the ``write()`` / ``latest.md`` plumbing, and
+the ``creek state`` CLI command. FEAT-007 inserts wavelength snapshot
++ suggested questions between sections 1 and 2.
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
+import re
 from collections import Counter
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
 
 import frontmatter
 import yaml
 from pydantic import ValidationError
 
+from creek.clean.hygiene import BrokenLinkScanner, OrphanScanner
 from creek.generate.indexes import FREQUENCY_NAMES
-from creek.models import Eddy, Fragment, Frequency, Thread
+from creek.models import Eddy, Fragment, Frequency, Praxis, Thread
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +57,7 @@ SECTION_ORDER: tuple[str, ...] = (
 """Section headers in the order pinned by FEAT-006.
 
 Wavelength snapshot + suggested questions (FEAT-007) will be inserted
-between ``## Vault summary`` and ``## Pre-LLM yield``; this module
-renders only the seven structural sections.
+between ``## Vault summary`` and ``## Pre-LLM yield``.
 """
 
 EMPTY_PLACEHOLDER: str = "_No surfacing this week._"
@@ -70,9 +67,15 @@ FEAT-006 acceptance criteria require an explicit empty-state note —
 the section header must always render, never silently disappear.
 """
 
+_TOP_N: int = 10
+"""Cap on the number of items rendered in each list-style section."""
+
 _FRAGMENTS_SUBDIR: str = "01-Fragments"
 _THREADS_SUBDIR: str = "02-Threads"
 _EDDIES_SUBDIR: str = "03-Eddies"
+_PRAXIS_SUBDIR: str = "04-Praxis"
+_SYNCHRONICITIES_SUBDIR: str = "10-Liminal/Synchronicities"
+_STATE_SUBPATH: tuple[str, str] = ("00-Creek-Meta", "State")
 _YIELD_RELATIVE: tuple[str, str, str] = (
     "00-Creek-Meta",
     "Processing-Log",
@@ -88,12 +91,13 @@ def _yield_log_path(vault_path: Path) -> Path:
 _FREQUENCY_ORDER: dict[str, int] = {
     member.value: index for index, member in enumerate(Frequency)
 }
-"""Canonical sort position per :class:`Frequency` member value.
+"""Canonical sort position per :class:`Frequency` value (F1..F10 then UNCLASSIFIED)."""
 
-The enum is declared F1, F2, ..., F10, UNCLASSIFIED — this dict mirrors
-that order so the frequency distribution renders numerically (F10 after
-F9, not between F1 and F2 as a lexicographic sort would put it).
-"""
+_WIKILINK_PATTERN: re.Pattern[str] = re.compile(r"\[\[([^\]|]+?)(?:\|[^\]]+?)?\]\]")
+"""Match an Obsidian wikilink like ``[[Target]]`` or ``[[Target|Alias]]``."""
+
+_STALE_FRAGMENT_AGE_DAYS: int = 90
+"""Age threshold (days) before an unreferenced fragment is reported as stale."""
 
 
 # ---------------------------------------------------------------------------
@@ -101,19 +105,27 @@ F9, not between F1 and F2 as a lexicographic sort would put it).
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class _SynchronicityRow:
+    """One synchronicity row read off disk for the surprising-connections section."""
+
+    sync_id: str
+    fragment_a_id: str
+    fragment_b_id: str
+    similarity: float
+    time_gap_days: int
+
+
 @dataclass
 class _VaultState:
     """Snapshot of every collection :class:`StateReportGenerator` reads.
-
-    Each section method consumes a subset of these fields directly, so
-    helpers can be exercised in isolation. The fields land here even
-    when their section has not yet been implemented (PR 2 fills in the
-    remaining sections without changing the snapshot shape).
 
     Attributes:
         fragments: Fragment models from ``01-Fragments``.
         threads: Thread models from ``02-Threads``.
         eddies: Eddy models from ``03-Eddies``.
+        praxis: Praxis models from ``04-Praxis``.
+        synchronicities: Synchronicity rows from ``10-Liminal/Synchronicities``.
         latest_yield: Most recent line of
             ``00-Creek-Meta/Processing-Log/run-summary.jsonl``, or
             ``None`` when the log is missing or empty.
@@ -122,6 +134,8 @@ class _VaultState:
     fragments: list[Fragment] = field(default_factory=list)
     threads: list[Thread] = field(default_factory=list)
     eddies: list[Eddy] = field(default_factory=list)
+    praxis: list[Praxis] = field(default_factory=list)
+    synchronicities: list[_SynchronicityRow] = field(default_factory=list)
     latest_yield: dict[str, object] | None = None
 
 
@@ -138,25 +152,17 @@ def _load_typed_models(
     root: Path,
     *,
     type_tag: str,
-    cls: type[Fragment] | type[Thread] | type[Eddy],
-) -> list[Fragment | Thread | Eddy]:
+    cls: type[Fragment] | type[Thread] | type[Eddy] | type[Praxis],
+) -> list[Fragment | Thread | Eddy | Praxis]:
     """Walk *root* and return every model whose ``type`` frontmatter matches.
 
     Files that fail YAML parsing or schema validation are skipped at
     DEBUG level rather than aborting the report — drift in a single
     fragment must not block the whole audit view.
-
-    Args:
-        root: Directory to scan.
-        type_tag: Required ``type`` frontmatter value.
-        cls: Pydantic model class used to validate the metadata.
-
-    Returns:
-        A list of validated models in filesystem order.
     """
     if not root.exists():
         return []
-    collected: list[Fragment | Thread | Eddy] = []
+    collected: list[Fragment | Thread | Eddy | Praxis] = []
     for md_file in sorted(root.rglob("*.md")):
         post = _safe_post(md_file)
         if post is None:
@@ -172,12 +178,49 @@ def _load_typed_models(
     return collected
 
 
+def _load_synchronicities(root: Path) -> list[_SynchronicityRow]:
+    """Read synchronicity notes from ``10-Liminal/Synchronicities``."""
+    if not root.exists():
+        return []
+    rows: list[_SynchronicityRow] = []
+    for md_file in sorted(root.rglob("*.md")):
+        post = _safe_post(md_file)
+        if post is None:
+            continue
+        meta = post.metadata
+        if meta.get("type") != "synchronicity":
+            continue
+        sync_id = meta.get("id")
+        frag_a = meta.get("fragment_a_id")
+        frag_b = meta.get("fragment_b_id")
+        similarity = meta.get("similarity")
+        time_gap = meta.get("time_gap_days")
+        if not (
+            isinstance(sync_id, str)
+            and isinstance(frag_a, str)
+            and isinstance(frag_b, str)
+            and isinstance(similarity, (int, float))
+            and isinstance(time_gap, int)
+        ):
+            continue
+        rows.append(
+            _SynchronicityRow(
+                sync_id=sync_id,
+                fragment_a_id=frag_a,
+                fragment_b_id=frag_b,
+                similarity=float(similarity),
+                time_gap_days=int(time_gap),
+            ),
+        )
+    return rows
+
+
 def _load_latest_yield(log_path: Path) -> dict[str, object] | None:
     """Return the last non-empty line of the pre-LLM yield JSONL log.
 
     The whole file is read into memory because the report only needs the
     final line — operationally the log is a short one-line-per-run
-    stream, but rotation is the writer's responsibility (see FEAT-005's
+    stream. Rotation is the writer's responsibility (see FEAT-005's
     ``write_yield_summary``); this reader does not cap the input size.
     """
     if not log_path.exists():
@@ -201,61 +244,56 @@ def _load_latest_yield(log_path: Path) -> dict[str, object] | None:
 
 
 def _load_vault_state(vault_path: Path) -> _VaultState:
-    """Snapshot every collection the (PR 1) report needs from *vault_path*.
+    """Snapshot every collection the report needs from *vault_path*.
 
     The ``isinstance`` guards in each comprehension are a mypy narrow,
-    not a runtime safety check — :func:`_load_typed_models` only
-    appends to its result after ``cls.model_validate`` succeeds, so the
-    object's runtime type is already correct. The guard exists because
-    the helper's return type is the union ``list[Fragment | Thread |
-    Eddy]``, which mypy cannot narrow per-call. Removing the guards
-    triggers ``assignment`` errors under strict mode.
+    not a runtime safety check: :func:`_load_typed_models` only appends
+    after ``cls.model_validate`` succeeds, so the runtime type is
+    already correct. The guard exists because the helper's return type
+    is the union ``list[Fragment | Thread | Eddy | Praxis]``, which
+    mypy cannot narrow per-call. Removing the guards triggers
+    ``assignment`` errors under strict mode.
     """
+    fragments_root = vault_path / _FRAGMENTS_SUBDIR
+    threads_root = vault_path / _THREADS_SUBDIR
+    eddies_root = vault_path / _EDDIES_SUBDIR
+    praxis_root = vault_path / _PRAXIS_SUBDIR
     fragments = [
         f
-        for f in _load_typed_models(
-            vault_path / _FRAGMENTS_SUBDIR,
-            type_tag="fragment",
-            cls=Fragment,
-        )
+        for f in _load_typed_models(fragments_root, type_tag="fragment", cls=Fragment)
         if isinstance(f, Fragment)
     ]
     threads = [
         t
-        for t in _load_typed_models(
-            vault_path / _THREADS_SUBDIR,
-            type_tag="thread",
-            cls=Thread,
-        )
+        for t in _load_typed_models(threads_root, type_tag="thread", cls=Thread)
         if isinstance(t, Thread)
     ]
     eddies = [
         e
-        for e in _load_typed_models(
-            vault_path / _EDDIES_SUBDIR,
-            type_tag="eddy",
-            cls=Eddy,
-        )
+        for e in _load_typed_models(eddies_root, type_tag="eddy", cls=Eddy)
         if isinstance(e, Eddy)
     ]
-    latest_yield = _load_latest_yield(_yield_log_path(vault_path))
+    praxis = [
+        p
+        for p in _load_typed_models(praxis_root, type_tag="praxis", cls=Praxis)
+        if isinstance(p, Praxis)
+    ]
     return _VaultState(
         fragments=fragments,
         threads=threads,
         eddies=eddies,
-        latest_yield=latest_yield,
+        praxis=praxis,
+        synchronicities=_load_synchronicities(vault_path / _SYNCHRONICITIES_SUBDIR),
+        latest_yield=_load_latest_yield(_yield_log_path(vault_path)),
     )
 
 
 def _frequency_sort_key(freq_value: Frequency | str) -> tuple[int, str]:
     """Return a sort key that orders frequencies by their enum position.
 
-    Storing enum members in a :class:`Counter` would otherwise hand
-    ``sorted`` a string-comparison fallback that places ``F10`` between
-    ``F1`` and ``F2``. The canonical order on the report is the order
-    in which the enum is declared (F1..F10, then UNCLASSIFIED).
-    Unknown values sort after every known one, ordered alphabetically
-    among themselves.
+    The canonical order on the report is the order in which the enum
+    is declared (F1..F10, then UNCLASSIFIED). Unknown values sort after
+    every known one, ordered alphabetically among themselves.
     """
     raw = freq_value.value if isinstance(freq_value, Frequency) else str(freq_value)
     position = _FREQUENCY_ORDER.get(raw, len(_FREQUENCY_ORDER))
@@ -267,10 +305,8 @@ def _frequency_label(freq_value: Frequency | str) -> str:
 
     Accepts either a :class:`Frequency` enum member directly or a string.
     Storing enum members at the call site (rather than ``str(member)``)
-    avoids a fragile round-trip: if :class:`Frequency` ever loses its
-    :class:`enum.StrEnum` base, ``str(Frequency.F1)`` would silently
-    become ``"Frequency.F1"`` and every lookup would fall through to
-    the unknown-value branch.
+    avoids a fragile round-trip if :class:`Frequency` ever loses its
+    :class:`enum.StrEnum` base.
     """
     if isinstance(freq_value, Frequency):
         freq = freq_value
@@ -281,6 +317,19 @@ def _frequency_label(freq_value: Frequency | str) -> str:
             return freq_value
     name = FREQUENCY_NAMES.get(freq)
     return f"{freq.value} ({name})" if name else freq.value
+
+
+def _wikilink_targets(wikilinks: list[str]) -> list[str]:
+    """Return the inner targets of ``[[...]]`` wikilink strings.
+
+    Plain strings (no brackets) are returned unchanged so eddy fields
+    stored without ``[[...]]`` syntax still match.
+    """
+    targets: list[str] = []
+    for raw in wikilinks:
+        match = _WIKILINK_PATTERN.search(raw)
+        targets.append(match.group(1).strip() if match else raw.strip())
+    return targets
 
 
 def _section(header: str, body_lines: list[str]) -> str:
@@ -304,27 +353,31 @@ class StateReportGenerator:
 
     Attributes:
         vault_path: Root of the Obsidian vault.
+        today: Date used to derive the ISO-week filename. Defaults to
+            today (UTC) so the same week's report is overwritten on
+            successive runs.
     """
 
-    def __init__(self, vault_path: Path) -> None:
+    def __init__(self, vault_path: Path, *, today: date | None = None) -> None:
         """Load the vault snapshot and stash *vault_path* for later use.
 
         Args:
             vault_path: Root of the Obsidian vault.
+            today: Optional injected date for tests / week-pinning.
+                Defaults to ``datetime.now(UTC).date()``.
         """
         self.vault_path = vault_path
+        self.today = today or datetime.now(tz=UTC).date()
         self._state = _load_vault_state(vault_path)
 
-    # ---- Implemented sections ----------------------------------------
+    # ---- Sections ---------------------------------------------------
 
     def section_vault_summary(self) -> str:
         """Render section 1: vault summary (counts + frequency distribution).
 
         Bypasses :func:`_section` deliberately: section 1 always has
         content (the count lines) so the empty-state placeholder is
-        unreachable. An empty vault renders three ``: 0`` rows, not the
-        ``_No surfacing this week._`` body — the regression test pins
-        this contract.
+        unreachable.
         """
         state = self._state
         body = [
@@ -364,29 +417,77 @@ class StateReportGenerator:
         ]
         return SECTION_ORDER[1] + "\n\n" + "\n".join(body)
 
-    # ---- Sections deferred to PR 2 -----------------------------------
-
     def section_active_eddies(self) -> str:
-        """Render section 3: top eddies by ``fragment_count`` (PR 2)."""
-        return _section(SECTION_ORDER[2], [])
+        """Render section 3: top eddies by ``fragment_count`` (capped at ten)."""
+        eddies = sorted(
+            self._state.eddies,
+            key=lambda e: (-e.fragment_count, e.title),
+        )[:_TOP_N]
+        body = [
+            f"- {eddy.title} — {eddy.fragment_count} fragment(s)" for eddy in eddies
+        ]
+        return _section(SECTION_ORDER[2], body)
 
     def section_active_threads(self) -> str:
-        """Render section 4: most-recent threads by ``last_seen`` (PR 2)."""
-        return _section(SECTION_ORDER[3], [])
+        """Render section 4: most-recent threads by ``last_seen`` (capped at ten)."""
+        threads = sorted(
+            self._state.threads,
+            key=lambda t: (t.last_seen, t.title),
+            reverse=True,
+        )[:_TOP_N]
+        body = [
+            f"- {thread.title} — last seen {thread.last_seen.isoformat()} "
+            f"({thread.fragment_count} fragment(s))"
+            for thread in threads
+        ]
+        return _section(SECTION_ORDER[3], body)
 
     def section_synchronicities(self) -> str:
-        """Render section 5: surprising connections — synchronicities (PR 2)."""
-        return _section(SECTION_ORDER[4], [])
+        """Render section 5: surprising connections (synchronicities)."""
+        rows = sorted(
+            self._state.synchronicities,
+            key=lambda r: (-r.similarity, r.sync_id),
+        )[:_TOP_N]
+        body = [
+            f"- `{row.fragment_a_id}` ↔ `{row.fragment_b_id}` — "
+            f"similarity {row.similarity:.2f}, gap {row.time_gap_days}d"
+            for row in rows
+        ]
+        return _section(SECTION_ORDER[4], body)
 
     def section_hyperedges(self) -> str:
-        """Render section 6: praxis spanning multiple eddies (PR 2)."""
-        return _section(SECTION_ORDER[5], [])
+        """Render section 6: praxis whose source fragments span 2+ eddies."""
+        eddies_by_fragment = self._eddies_by_fragment()
+        body: list[str] = []
+        for praxis in self._state.praxis:
+            spanning = self._praxis_spans(praxis, eddies_by_fragment)
+            if len(spanning) < 2:
+                continue
+            spans = ", ".join(sorted(spanning))
+            body.append(f"- {praxis.title} — spans: {spans}")
+            if len(body) >= _TOP_N:
+                break
+        return _section(SECTION_ORDER[5], body)
 
     def section_drift_warnings(self) -> str:
-        """Render section 7: broken wiki-links + stale fragments (PR 2)."""
-        return _section(SECTION_ORDER[6], [])
+        """Render section 7: broken wiki-links + stale fragments."""
+        broken = BrokenLinkScanner().scan(self.vault_path)
+        orphans = OrphanScanner(age_days=_STALE_FRAGMENT_AGE_DAYS).scan(
+            self.vault_path,
+        )
+        body: list[str] = []
+        for source, targets in list(broken.broken_links.items())[:_TOP_N]:
+            label = ", ".join(targets)
+            body.append(f"- Broken links in `{source}`: {label}")
+        if orphans.orphan_paths:
+            if body:
+                body.append("")
+            body.append("**Stale fragments**")
+            for path in orphans.orphan_paths[:_TOP_N]:
+                body.append(f"- `{path}`")
+        return _section(SECTION_ORDER[6], body)
 
-    # ---- Render -----------------------------------------------------
+    # ---- Render and write -------------------------------------------
 
     def render(self) -> str:
         """Return the full markdown report (all seven sections in order)."""
@@ -401,7 +502,85 @@ class StateReportGenerator:
         ]
         return self._document_header() + "\n\n" + "\n\n".join(sections) + "\n"
 
+    def write(self) -> Path:
+        """Render the report and write it under ``00-Creek-Meta/State``.
+
+        Also refreshes ``latest.md`` (symlink where supported, copy on
+        Windows or when symlink creation fails). Returns the path of the
+        ISO-week file. Re-running in the same ISO week overwrites the
+        existing file.
+        """
+        state_dir = self.vault_path.joinpath(*_STATE_SUBPATH)
+        state_dir.mkdir(parents=True, exist_ok=True)
+        iso_year, iso_week, _ = self.today.isocalendar()
+        target = state_dir / f"{iso_year}-W{iso_week:02d}.md"
+        target.write_text(self.render(), encoding="utf-8")
+        _refresh_latest(state_dir, target)
+        return target
+
+    # ---- Internal helpers -------------------------------------------
+
     def _document_header(self) -> str:
-        """Render the document title and generation metadata block."""
+        """Render the document title and generation metadata block.
+
+        The vault path is intentionally rendered as the leaf directory
+        name only, never the absolute path. If the audit file is ever
+        committed or shared, this avoids leaking an operator's home
+        directory into the artefact.
+        """
+        iso_year, iso_week, _ = self.today.isocalendar()
         generated = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
-        return f"# Creek state\n\n_Generated {generated} from `{self.vault_path}`._"
+        vault_label = self.vault_path.name or str(self.vault_path)
+        return (
+            f"# Creek state — {iso_year}-W{iso_week:02d}\n\n"
+            f"_Generated {generated} from `{vault_label}`._"
+        )
+
+    def _eddies_by_fragment(self) -> dict[str, set[str]]:
+        """Return ``{fragment_id: {eddy_title, ...}}`` from fragment frontmatter."""
+        mapping: dict[str, set[str]] = {}
+        for fragment in self._state.fragments:
+            targets = set(_wikilink_targets(fragment.eddies))
+            if targets:
+                mapping[fragment.id] = targets
+        return mapping
+
+    @staticmethod
+    def _praxis_spans(
+        praxis: Praxis,
+        eddies_by_fragment: dict[str, set[str]],
+    ) -> set[str]:
+        """Return the union of eddies touched by a praxis's source fragments."""
+        spanning: set[str] = set()
+        for frag_id in praxis.derived_from:
+            spanning.update(eddies_by_fragment.get(frag_id, set()))
+        return spanning
+
+
+# ---------------------------------------------------------------------------
+# latest.md handling
+# ---------------------------------------------------------------------------
+
+
+def _refresh_latest(state_dir: Path, target: Path) -> Path:
+    """Point ``state_dir/latest.md`` at *target* (symlink or copy fallback).
+
+    Symlinks are preferred so the operator's editor can navigate to the
+    underlying ISO-week file in one click. Windows lacks an unprivileged
+    symlink path for non-developers, and some networked filesystems
+    reject symlinks with ``EPERM``; those cases fall back to a copy.
+    """
+    latest = state_dir / "latest.md"
+    try:
+        if latest.exists() or latest.is_symlink():
+            latest.unlink()
+    except OSError:
+        logger.debug("Could not unlink existing latest.md")
+    if os.name != "nt":
+        try:
+            latest.symlink_to(target.name)
+            return latest
+        except OSError:
+            logger.debug("Symlink unsupported on this filesystem; copying")
+    latest.write_text(target.read_text(encoding="utf-8"), encoding="utf-8")
+    return latest

--- a/creek-tools/creek/generate/state.py
+++ b/creek-tools/creek/generate/state.py
@@ -17,10 +17,9 @@ This module is intentionally a *view* over the compiled layer — it
 never re-runs classification, linking, or compile passes. It only
 reads what is already on disk.
 
-PR 1 of FEAT-006 shipped the scaffold plus sections 1 and 2; this PR 2
-fills in sections 3-7, the ``write()`` / ``latest.md`` plumbing, and
-the ``creek state`` CLI command. FEAT-007 inserts wavelength snapshot
-+ suggested questions between sections 1 and 2.
+FEAT-007 inserts a wavelength snapshot and a suggested-questions
+section between sections 1 and 2; the section-ordering contract
+pinned by tests here makes that insertion straightforward.
 """
 
 from __future__ import annotations
@@ -202,6 +201,7 @@ def _load_synchronicities(root: Path) -> list[_SynchronicityRow]:
             and isinstance(similarity, (int, float))
             and isinstance(time_gap, int)
         ):
+            logger.debug("Skipping malformed synchronicity: %s", md_file)
             continue
         rows.append(
             _SynchronicityRow(
@@ -456,17 +456,26 @@ class StateReportGenerator:
         return _section(SECTION_ORDER[4], body)
 
     def section_hyperedges(self) -> str:
-        """Render section 6: praxis whose source fragments span 2+ eddies."""
+        """Render section 6: praxis whose source fragments span 2+ eddies.
+
+        Ranked by ``(-len(spanning), praxis.title)`` so the praxis that
+        bridges the most eddies appears first; matches the deterministic
+        ordering of sections 3-5 instead of falling back to filesystem
+        order.
+        """
         eddies_by_fragment = self._eddies_by_fragment()
-        body: list[str] = []
-        for praxis in self._state.praxis:
-            spanning = self._praxis_spans(praxis, eddies_by_fragment)
-            if len(spanning) < 2:
-                continue
-            spans = ", ".join(sorted(spanning))
-            body.append(f"- {praxis.title} — spans: {spans}")
-            if len(body) >= _TOP_N:
-                break
+        candidates = [
+            (praxis, self._praxis_spans(praxis, eddies_by_fragment))
+            for praxis in self._state.praxis
+        ]
+        ranked = sorted(
+            ((p, s) for p, s in candidates if len(s) >= 2),
+            key=lambda pair: (-len(pair[1]), pair[0].title),
+        )[:_TOP_N]
+        body = [
+            f"- {praxis.title} - spans: {', '.join(sorted(spanning))}"
+            for praxis, spanning in ranked
+        ]
         return _section(SECTION_ORDER[5], body)
 
     def section_drift_warnings(self) -> str:

--- a/creek-tools/docs/generation.md
+++ b/creek-tools/docs/generation.md
@@ -37,11 +37,29 @@ creek report --type synchronicity --vault ~/Obsidian/Creek-Vault
 
 The `synchronicity`, `paradox`, `compost`, `unnamed`, and `tags` report types collectively make up the **emergence infrastructure** described in Ontology §10. The exact criteria that decide whether content is surfaced (similarity thresholds, time-gap floors, project-name filters) live in [`emergence.md`](emergence.md).
 
-## State (audit report, FEAT-006 — in progress)
+## State (audit report)
 
-`creek state` will write a single weekly audit report to `00-Creek-Meta/State/<iso-year>-W<week>.md`. The first slice (this PR) ships the renderer skeleton in `creek.generate.state`: it loads the vault snapshot and produces the seven-section markdown — vault summary, pre-LLM yield, active eddies, active threads, surprising connections, hyperedges, drift warnings — with the deferred sections rendering an explicit `_No surfacing this week._` placeholder.
+`creek state` writes a single weekly snapshot of the entire vault to `00-Creek-Meta/State/<iso-year>-W<week>.md` (with `latest.md` always pointing at the most recent run). It is a **view**, not a pipeline — it re-reads existing fragments, threads, eddies, praxis, synchronicities, and the latest `run-summary.jsonl` line, and never invokes classify, link, or compile.
 
-The follow-up PR fills in the remaining five sections, adds the `write()` / `latest.md` plumbing, and exposes the `creek state` CLI command. FEAT-007 inserts wavelength snapshot + suggested questions between sections 1 and 2.
+```bash
+creek state --vault ~/Obsidian/Creek-Vault
+```
+
+The report is organised in seven sections, in this order (FEAT-006):
+
+1. **Vault summary** — fragment / eddy / thread counts plus the per-frequency distribution (sorted F1..F10, then UNCLASSIFIED).
+2. **Pre-LLM yield** — the most recent line of `00-Creek-Meta/Processing-Log/run-summary.jsonl` (deterministic / local-model / residue counts and the `--no-llm` flag).
+3. **Active eddies** — top 10 by `fragment_count`.
+4. **Active threads** — top 10 by `last_seen` recency.
+5. **Surprising connections** — synchronicities discovered under `10-Liminal/Synchronicities/`.
+6. **Hyperedges** — praxis whose `derived_from` fragments span two or more eddies.
+7. **Drift warnings** — broken wiki-links and stale (link-isolated, ≥90-day-old) fragments.
+
+Empty sections render an explicit `_No surfacing this week._` placeholder rather than disappearing — operators can tell at a glance whether a section had nothing to surface or whether the generator skipped it. Re-running in the same ISO week overwrites the existing file (idempotent).
+
+`latest.md` is created as a symlink where the filesystem supports it (POSIX hosts) and falls back to a copy on Windows or networked filesystems that reject `symlink(2)`. The report header renders the vault's leaf directory name only — never the absolute path — so committing or sharing the artefact does not leak an operator's home directory.
+
+FEAT-007 will insert a wavelength snapshot and a suggested-questions section between sections 1 and 2.
 
 ## Voice Skill Tree
 

--- a/creek-tools/tests/test_state.py
+++ b/creek-tools/tests/test_state.py
@@ -1,10 +1,21 @@
-"""Tests for ``creek state`` audit-report generator (FEAT-006, PR 1).
+"""Tests for ``creek state`` audit-report generator (FEAT-006).
 
-Covers the two sections implemented in this slice (vault summary and
-pre-LLM yield), the seven-section ordering contract, and the
-empty-state placeholder that every section must render. The remaining
-five sections, the ``write()`` / ``latest.md`` plumbing, and the
-``creek state`` CLI command are added in PR 2.
+This file pins the FEAT-006 acceptance criteria for the ``creek state``
+audit-report generator. The generator is a *view* over the compiled
+vault layer — it never re-runs classification, linking, or compile.
+
+Sections covered:
+
+1. Vault summary (counts + frequency distribution)
+2. Pre-LLM yield (latest line of ``run-summary.jsonl``)
+3. Active eddies (top-N by ``fragment_count``)
+4. Active threads (top-N by ``last_seen`` recency)
+5. Surprising connections (synchronicities)
+6. Hyperedges (praxis spanning multiple eddies)
+7. Drift warnings (broken wiki-links + stale fragments)
+
+Plus the document-level integration tests: section ordering, ``write()``
++ ``latest.md`` plumbing, idempotency, and the ``creek state`` CLI.
 """
 
 from __future__ import annotations
@@ -15,10 +26,9 @@ from typing import TYPE_CHECKING
 
 import frontmatter
 import pytest
+from typer.testing import CliRunner
 
-if TYPE_CHECKING:
-    from pathlib import Path
-
+from creek.cli import app
 from creek.generate.state import (
     EMPTY_PLACEHOLDER,
     SECTION_ORDER,
@@ -26,14 +36,23 @@ from creek.generate.state import (
     _frequency_label,
 )
 
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+runner = CliRunner()
+
 
 def _seed_dirs(vault: Path) -> None:
     """Create the canonical Creek vault folder layout under *vault*."""
     for sub in (
+        "00-Creek-Meta/State",
         "00-Creek-Meta/Processing-Log",
         "01-Fragments/Notes",
         "02-Threads/Active",
         "03-Eddies",
+        "04-Praxis/Daily",
+        "10-Liminal/Synchronicities",
     ):
         (vault / sub).mkdir(parents=True, exist_ok=True)
 
@@ -45,6 +64,8 @@ def _write_fragment(
     title: str = "Note",
     created: datetime | None = None,
     frequency: str = "F1",
+    eddies: list[str] | None = None,
+    body: str = "body",
 ) -> Path:
     """Write a Creek fragment markdown file under ``01-Fragments/Notes``."""
     when = created or datetime(2026, 5, 1, tzinfo=UTC)
@@ -56,23 +77,30 @@ def _write_fragment(
         "ingested": when.isoformat(),
         "source": {"platform": "journal", "author": "self"},
         "frequency": {"primary": frequency, "secondary": []},
+        "eddies": list(eddies or []),
     }
     target = vault / "01-Fragments" / "Notes" / f"{frag_id}.md"
     target.write_text(
-        frontmatter.dumps(frontmatter.Post(content="body", **metadata)),
+        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
         encoding="utf-8",
     )
     return target
 
 
-def _write_eddy(vault: Path, *, eddy_id: str, title: str) -> Path:
+def _write_eddy(
+    vault: Path,
+    *,
+    eddy_id: str,
+    title: str,
+    fragment_count: int = 1,
+) -> Path:
     """Write a minimal Eddy markdown file under ``03-Eddies``."""
     metadata = {
         "type": "eddy",
         "id": eddy_id,
         "title": title,
         "formed": date(2026, 1, 1).isoformat(),
-        "fragment_count": 1,
+        "fragment_count": fragment_count,
         "threads": [],
     }
     # Use ``eddy_id`` as the filename to avoid breaking when titles contain
@@ -85,19 +113,80 @@ def _write_eddy(vault: Path, *, eddy_id: str, title: str) -> Path:
     return target
 
 
-def _write_thread(vault: Path, *, thread_id: str, title: str) -> Path:
+def _write_thread(
+    vault: Path,
+    *,
+    thread_id: str,
+    title: str,
+    last_seen: date | None = None,
+    fragment_count: int = 1,
+) -> Path:
     """Write a minimal Thread markdown file under ``02-Threads/Active``."""
-    last_seen = date(2026, 5, 1)
+    seen = last_seen or date(2026, 5, 1)
     metadata = {
         "type": "thread",
         "id": thread_id,
         "title": title,
         "status": "active",
-        "first_seen": (last_seen - timedelta(days=14)).isoformat(),
-        "last_seen": last_seen.isoformat(),
-        "fragment_count": 1,
+        "first_seen": (seen - timedelta(days=14)).isoformat(),
+        "last_seen": seen.isoformat(),
+        "fragment_count": fragment_count,
     }
-    target = vault / "02-Threads" / "Active" / f"{title}.md"
+    # Use ``thread_id`` as the filename for the same reason as ``_write_eddy``:
+    # titles can contain spaces or slashes that the filesystem rejects.
+    target = vault / "02-Threads" / "Active" / f"{thread_id}.md"
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content="", **metadata)),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _write_praxis(
+    vault: Path,
+    *,
+    praxis_id: str,
+    title: str,
+    derived_from: list[str],
+) -> Path:
+    """Write a Praxis markdown file under ``04-Praxis/Daily``."""
+    metadata = {
+        "type": "praxis",
+        "id": praxis_id,
+        "title": title,
+        "praxis_type": "habit",
+        "status": "proposed",
+        "derived_from": list(derived_from),
+    }
+    target = vault / "04-Praxis" / "Daily" / f"{praxis_id}.md"
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content="", **metadata)),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _write_synchronicity(
+    vault: Path,
+    *,
+    sync_id: str,
+    frag_a: str,
+    frag_b: str,
+    similarity: float = 0.95,
+    time_gap_days: int = 60,
+) -> Path:
+    """Write a Synchronicity markdown file under ``10-Liminal/Synchronicities``."""
+    metadata = {
+        "type": "synchronicity",
+        "id": sync_id,
+        "fragment_a_id": frag_a,
+        "fragment_b_id": frag_b,
+        "similarity": similarity,
+        "time_gap_days": time_gap_days,
+        "source_a": "journal",
+        "source_b": "essay",
+    }
+    target = vault / "10-Liminal" / "Synchronicities" / f"{sync_id}.md"
     target.write_text(
         frontmatter.dumps(frontmatter.Post(content="", **metadata)),
         encoding="utf-8",
@@ -124,7 +213,7 @@ def empty_vault(tmp_path: Path) -> Path:
 
 @pytest.fixture
 def populated_vault(tmp_path: Path) -> Path:
-    """Return a vault with a small mix of fragments, eddies, threads, yield."""
+    """Return a vault stocked with fragments, eddies, threads, praxis, syncs."""
     _seed_dirs(tmp_path)
     base = datetime(2026, 5, 1, tzinfo=UTC)
     _write_fragment(
@@ -133,6 +222,7 @@ def populated_vault(tmp_path: Path) -> Path:
         title="A",
         created=base,
         frequency="F1",
+        eddies=["[[Receptivity Eddy]]"],
     )
     _write_fragment(
         tmp_path,
@@ -140,6 +230,7 @@ def populated_vault(tmp_path: Path) -> Path:
         title="B",
         created=base + timedelta(days=2),
         frequency="F2",
+        eddies=["[[Receptivity Eddy]]", "[[Innovation Eddy]]"],
     )
     _write_fragment(
         tmp_path,
@@ -147,22 +238,49 @@ def populated_vault(tmp_path: Path) -> Path:
         title="C",
         created=base + timedelta(days=4),
         frequency="F1",
+        eddies=["[[Innovation Eddy]]"],
     )
-    _write_eddy(tmp_path, eddy_id="eddy-1", title="Innovation")
-    _write_thread(tmp_path, thread_id="thread-1", title="Recursion")
+    _write_eddy(tmp_path, eddy_id="eddy-1", title="Receptivity Eddy", fragment_count=8)
+    _write_eddy(tmp_path, eddy_id="eddy-2", title="Innovation Eddy", fragment_count=5)
+    _write_thread(
+        tmp_path,
+        thread_id="thread-old",
+        title="Old Thread",
+        last_seen=date(2026, 1, 1),
+        fragment_count=4,
+    )
+    _write_thread(
+        tmp_path,
+        thread_id="thread-new",
+        title="New Thread",
+        last_seen=date(2026, 5, 7),
+        fragment_count=2,
+    )
+    _write_praxis(
+        tmp_path,
+        praxis_id="praxis-bridge",
+        title="Bridge Practice",
+        derived_from=["frag-001", "frag-002", "frag-003"],
+    )
+    _write_praxis(
+        tmp_path,
+        praxis_id="praxis-solo",
+        title="Single-Eddy Practice",
+        derived_from=["frag-001"],
+    )
+    _write_synchronicity(
+        tmp_path,
+        sync_id="sync-abc",
+        frag_a="frag-001",
+        frag_b="frag-003",
+        similarity=0.92,
+        time_gap_days=45,
+    )
     _write_yield_jsonl(
         tmp_path,
         [
             {
                 "run_id": "run-1",
-                "deterministic_classified": 4,
-                "local_model_processed": 3,
-                "residue": 1,
-                "no_llm": False,
-                "timestamp": "2026-05-01T00:00:00+00:00",
-            },
-            {
-                "run_id": "run-2",
                 "deterministic_classified": 7,
                 "local_model_processed": 5,
                 "residue": 2,
@@ -187,34 +305,24 @@ def test_section_vault_summary_includes_counts(populated_vault: Path) -> None:
 
     assert section.startswith("## Vault summary")
     assert "Fragments: 3" in section
-    assert "Eddies: 1" in section
-    assert "Threads: 1" in section
+    assert "Eddies: 2" in section
+    assert "Threads: 2" in section
 
 
-def test_section_vault_summary_includes_frequency_distribution(
-    populated_vault: Path,
-) -> None:
-    """The summary surfaces the per-frequency distribution under a header."""
+def test_section_vault_summary_empty(empty_vault: Path) -> None:
+    """An empty vault renders zero counts (not the placeholder)."""
     section = StateReportGenerator(
-        vault_path=populated_vault,
+        vault_path=empty_vault,
     ).section_vault_summary()
 
-    assert "**Frequency distribution**" in section
-    # Two F1 fragments, one F2 fragment.
-    assert "F1" in section and "F2" in section
-    assert ": 2" in section
-    assert ": 1" in section
+    assert "Fragments: 0" in section
+    assert EMPTY_PLACEHOLDER not in section
 
 
 def test_frequency_distribution_sorts_numerically_not_lexicographically(
     empty_vault: Path,
 ) -> None:
-    """F10 sorts after F2 (and after F9), not between F1 and F2.
-
-    A naive ``sorted(items)`` on `StrEnum` values produces
-    ``F1, F10, F2, ...`` because ``"F10" < "F2"`` lexicographically.
-    The report must follow the canonical APTITUDE order.
-    """
+    """F10 sorts after F2 (and after F9), not between F1 and F2."""
     base = datetime(2026, 5, 1, tzinfo=UTC)
     _write_fragment(empty_vault, frag_id="frag-a", created=base, frequency="F1")
     _write_fragment(empty_vault, frag_id="frag-b", created=base, frequency="F2")
@@ -230,19 +338,6 @@ def test_frequency_distribution_sorts_numerically_not_lexicographically(
     assert f1_idx < f2_idx < f10_idx
 
 
-def test_section_vault_summary_empty(empty_vault: Path) -> None:
-    """An empty vault renders zero counts (not the placeholder)."""
-    section = StateReportGenerator(
-        vault_path=empty_vault,
-    ).section_vault_summary()
-
-    assert section.startswith("## Vault summary")
-    assert "Fragments: 0" in section
-    assert "Eddies: 0" in section
-    assert "Threads: 0" in section
-    assert EMPTY_PLACEHOLDER not in section
-
-
 # ---------------------------------------------------------------------------
 # Section: pre-LLM yield
 # ---------------------------------------------------------------------------
@@ -255,12 +350,9 @@ def test_section_pre_llm_yield_reads_latest_run(populated_vault: Path) -> None:
     ).section_pre_llm_yield()
 
     assert section.startswith("## Pre-LLM yield")
-    # Latest entry is run-2: deterministic 7, local-model 5, residue 2, no_llm true.
     assert "Deterministic: 7" in section
     assert "Local-model: 5" in section
     assert "Residue: 2" in section
-    assert "run-2" in section
-    assert "yes" in section
 
 
 def test_section_pre_llm_yield_empty(empty_vault: Path) -> None:
@@ -269,45 +361,222 @@ def test_section_pre_llm_yield_empty(empty_vault: Path) -> None:
         vault_path=empty_vault,
     ).section_pre_llm_yield()
 
-    assert section.startswith("## Pre-LLM yield")
     assert EMPTY_PLACEHOLDER in section
 
 
-def test_section_pre_llm_yield_skips_corrupt_last_line(empty_vault: Path) -> None:
-    """An unparseable last JSONL line falls back to the empty placeholder."""
-    log = empty_vault / "00-Creek-Meta" / "Processing-Log" / "run-summary.jsonl"
-    log.write_text("not json at all\n", encoding="utf-8")
+# ---------------------------------------------------------------------------
+# Section: active eddies (FEAT-006 PR 2)
+# ---------------------------------------------------------------------------
+
+
+def test_section_active_eddies_sorts_by_fragment_count(populated_vault: Path) -> None:
+    """Eddies render in descending order by ``fragment_count``."""
+    section = StateReportGenerator(
+        vault_path=populated_vault,
+    ).section_active_eddies()
+
+    assert section.startswith("## Active eddies")
+    receptivity_idx = section.index("Receptivity Eddy")
+    innovation_idx = section.index("Innovation Eddy")
+    assert receptivity_idx < innovation_idx
+    assert "8" in section
+    assert "5" in section
+
+
+def test_section_active_eddies_caps_at_ten(empty_vault: Path) -> None:
+    """At most ten eddies appear in the section."""
+    for index in range(15):
+        _write_eddy(
+            empty_vault,
+            eddy_id=f"eddy-{index:02d}",
+            title=f"Eddy {index:02d}",
+            fragment_count=index + 1,
+        )
 
     section = StateReportGenerator(
         vault_path=empty_vault,
-    ).section_pre_llm_yield()
+    ).section_active_eddies()
+
+    assert section.count("Eddy ") == 10
+    # Top eddy (count 15) is present, smallest excluded.
+    assert "Eddy 14" in section
+    assert "Eddy 00" not in section
+
+
+def test_section_active_eddies_empty(empty_vault: Path) -> None:
+    """No eddies renders the documented placeholder."""
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_active_eddies()
+
+    assert section.startswith("## Active eddies")
+    assert EMPTY_PLACEHOLDER in section
+
+
+# ---------------------------------------------------------------------------
+# Section: active threads
+# ---------------------------------------------------------------------------
+
+
+def test_section_active_threads_sorted_by_recency(populated_vault: Path) -> None:
+    """Threads render most-recent first by ``last_seen``."""
+    section = StateReportGenerator(
+        vault_path=populated_vault,
+    ).section_active_threads()
+
+    assert section.startswith("## Active threads")
+    new_idx = section.index("New Thread")
+    old_idx = section.index("Old Thread")
+    assert new_idx < old_idx
+
+
+def test_section_active_threads_caps_at_ten(empty_vault: Path) -> None:
+    """At most ten threads appear in the section."""
+    for index in range(15):
+        _write_thread(
+            empty_vault,
+            thread_id=f"thread-{index:02d}",
+            title=f"Thread {index:02d}",
+            last_seen=date(2026, 1, 1) + timedelta(days=index),
+        )
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_active_threads()
+
+    assert section.count("Thread ") == 10
+    assert "Thread 14" in section
+    assert "Thread 00" not in section
+
+
+def test_section_active_threads_empty(empty_vault: Path) -> None:
+    """No threads renders the documented placeholder."""
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_active_threads()
 
     assert EMPTY_PLACEHOLDER in section
 
 
 # ---------------------------------------------------------------------------
-# Deferred-section placeholders (PR 2 will fill these in)
+# Section: synchronicities
 # ---------------------------------------------------------------------------
 
 
-def test_deferred_sections_render_empty_placeholder(empty_vault: Path) -> None:
-    """Sections 3-7 emit the empty-state note in PR 1.
+def test_section_synchronicities_lists_pairs(populated_vault: Path) -> None:
+    """Synchronicities surface fragment IDs, similarity, and time gap."""
+    section = StateReportGenerator(
+        vault_path=populated_vault,
+    ).section_synchronicities()
 
-    PR 2 replaces these placeholders with real content; this test pins
-    the empty-state contract so the section headers never silently
-    disappear during the transition.
-    """
-    generator = StateReportGenerator(vault_path=empty_vault)
-    deferred = (
-        generator.section_active_eddies(),
-        generator.section_active_threads(),
-        generator.section_synchronicities(),
-        generator.section_hyperedges(),
-        generator.section_drift_warnings(),
+    assert section.startswith("## Surprising connections")
+    assert "frag-001" in section
+    assert "frag-003" in section
+    assert "0.92" in section
+    assert "45" in section
+
+
+def test_section_synchronicities_empty(empty_vault: Path) -> None:
+    """No synchronicities renders the documented placeholder."""
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_synchronicities()
+
+    assert EMPTY_PLACEHOLDER in section
+
+
+def test_section_synchronicities_skips_invalid(empty_vault: Path) -> None:
+    """Synchronicity files with the wrong shape are silently skipped."""
+    bad = empty_vault / "10-Liminal" / "Synchronicities" / "bad.md"
+    bad.write_text(
+        "---\ntype: synchronicity\nid: sync-bad\n---\nbody\n",
+        encoding="utf-8",
     )
-    for index, body in enumerate(deferred, start=2):
-        assert body.startswith(SECTION_ORDER[index])
-        assert EMPTY_PLACEHOLDER in body
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_synchronicities()
+
+    assert EMPTY_PLACEHOLDER in section
+
+
+# ---------------------------------------------------------------------------
+# Section: hyperedges (praxis spanning 2+ eddies)
+# ---------------------------------------------------------------------------
+
+
+def test_section_hyperedges_lists_multi_eddy_praxis(populated_vault: Path) -> None:
+    """Praxis whose ``derived_from`` fragments span 2+ eddies is listed."""
+    section = StateReportGenerator(
+        vault_path=populated_vault,
+    ).section_hyperedges()
+
+    assert section.startswith("## Hyperedges")
+    assert "Bridge Practice" in section
+    # Single-eddy praxis is filtered out — it is not a hyperedge.
+    assert "Single-Eddy Practice" not in section
+    assert "Receptivity Eddy" in section
+    assert "Innovation Eddy" in section
+
+
+def test_section_hyperedges_empty(empty_vault: Path) -> None:
+    """No multi-eddy praxis renders the documented placeholder."""
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_hyperedges()
+
+    assert EMPTY_PLACEHOLDER in section
+
+
+# ---------------------------------------------------------------------------
+# Section: drift warnings
+# ---------------------------------------------------------------------------
+
+
+def test_section_drift_warnings_reports_broken_links(empty_vault: Path) -> None:
+    """Broken wiki-links inside fragments surface in the drift warnings."""
+    base = datetime(2026, 4, 1, tzinfo=UTC)
+    _write_fragment(
+        empty_vault,
+        frag_id="frag-link",
+        title="Linker",
+        created=base,
+        body="See [[Nonexistent Target]] for context.",
+    )
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_drift_warnings()
+
+    assert section.startswith("## Drift warnings")
+    assert "Nonexistent Target" in section
+
+
+def test_section_drift_warnings_reports_stale_fragments(empty_vault: Path) -> None:
+    """Old, link-isolated fragments appear under stale fragments."""
+    long_ago = datetime.now(tz=UTC) - timedelta(days=400)
+    _write_fragment(
+        empty_vault,
+        frag_id="frag-stale",
+        title="Forgotten",
+        created=long_ago,
+        body="No links anywhere.",
+    )
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_drift_warnings()
+
+    assert "frag-stale" in section
+
+
+def test_section_drift_warnings_empty(empty_vault: Path) -> None:
+    """No broken links or stale fragments renders the placeholder."""
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_drift_warnings()
+
+    assert EMPTY_PLACEHOLDER in section
 
 
 # ---------------------------------------------------------------------------
@@ -336,6 +605,127 @@ def test_render_starts_with_document_header(populated_vault: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# write() and latest.md
+# ---------------------------------------------------------------------------
+
+
+def test_write_creates_iso_week_file(populated_vault: Path) -> None:
+    """``write`` emits ``<vault>/00-Creek-Meta/State/<iso-year>-W<week>.md``."""
+    today = date(2026, 5, 9)  # ISO week 19 of 2026
+    written = StateReportGenerator(
+        vault_path=populated_vault,
+        today=today,
+    ).write()
+
+    iso_year, iso_week, _ = today.isocalendar()
+    expected = (
+        populated_vault / "00-Creek-Meta" / "State" / f"{iso_year}-W{iso_week:02d}.md"
+    )
+    assert written == expected
+    assert expected.exists()
+    text = expected.read_text(encoding="utf-8")
+    for header in SECTION_ORDER:
+        assert header in text
+
+
+def test_write_is_idempotent_within_same_week(populated_vault: Path) -> None:
+    """Re-running in the same ISO week overwrites the existing file."""
+    today = date(2026, 5, 9)
+    generator = StateReportGenerator(vault_path=populated_vault, today=today)
+
+    first = generator.write()
+    generator.write()
+    state_dir = populated_vault / "00-Creek-Meta" / "State"
+    week_files = sorted(p.name for p in state_dir.glob("*.md") if p.name != "latest.md")
+    assert week_files == [first.name]
+
+
+def test_write_updates_latest_pointer(populated_vault: Path) -> None:
+    """``latest.md`` is created (symlink or copy) and points at the new file."""
+    today = date(2026, 5, 9)
+    written = StateReportGenerator(
+        vault_path=populated_vault,
+        today=today,
+    ).write()
+
+    latest = populated_vault / "00-Creek-Meta" / "State" / "latest.md"
+    assert latest.exists()
+    assert latest.read_text(encoding="utf-8") == written.read_text(encoding="utf-8")
+
+
+def test_write_refreshes_latest_after_new_week(populated_vault: Path) -> None:
+    """A second run in a new week refreshes ``latest.md`` to the newer file."""
+    StateReportGenerator(
+        vault_path=populated_vault,
+        today=date(2026, 5, 2),
+    ).write()
+    second = StateReportGenerator(
+        vault_path=populated_vault,
+        today=date(2026, 5, 9),
+    ).write()
+
+    latest = populated_vault / "00-Creek-Meta" / "State" / "latest.md"
+    assert latest.read_text(encoding="utf-8") == second.read_text(encoding="utf-8")
+
+
+def test_latest_md_falls_back_to_copy(
+    populated_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ``Path.symlink_to`` raises ``OSError`` the writer copies instead."""
+    from pathlib import Path as _Path
+
+    def _refuse_symlink(self: _Path, target: str | _Path) -> None:
+        msg = "symlink refused (test)"
+        raise OSError(msg)
+
+    monkeypatch.setattr(_Path, "symlink_to", _refuse_symlink)
+
+    written = StateReportGenerator(
+        vault_path=populated_vault,
+        today=date(2026, 5, 9),
+    ).write()
+
+    latest = populated_vault / "00-Creek-Meta" / "State" / "latest.md"
+    assert latest.exists()
+    assert not latest.is_symlink()
+    assert latest.read_text(encoding="utf-8") == written.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# CLI integration
+# ---------------------------------------------------------------------------
+
+
+def test_cli_state_writes_report(populated_vault: Path) -> None:
+    """``creek state --vault <vault>`` produces the report and exits 0."""
+    result = runner.invoke(app, ["state", "--vault", str(populated_vault)])
+
+    assert result.exit_code == 0, result.output
+    state_dir = populated_vault / "00-Creek-Meta" / "State"
+    week_files = list(state_dir.glob("*.md"))
+    assert any(p.name == "latest.md" for p in week_files)
+    assert any(p.name != "latest.md" for p in week_files)
+
+
+def test_cli_state_does_not_run_pipeline_passes(
+    populated_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``creek state`` is a view: it never invokes classify/link/compile."""
+    import creek.pipeline as pipeline_module
+
+    def _explode(*_args: object, **_kwargs: object) -> None:
+        msg = "creek state must not run the pipeline"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(pipeline_module.Pipeline, "run", _explode)
+
+    result = runner.invoke(app, ["state", "--vault", str(populated_vault)])
+    assert result.exit_code == 0, result.output
+
+
+# ---------------------------------------------------------------------------
 # Loader edge cases
 # ---------------------------------------------------------------------------
 
@@ -353,18 +743,6 @@ def test_loader_skips_unparsable_yaml(empty_vault: Path) -> None:
     assert "Fragments: 1" in section
 
 
-def test_loader_skips_non_fragment_markdown(empty_vault: Path) -> None:
-    """Plain notes coexist with fragments and are skipped silently."""
-    note = empty_vault / "01-Fragments" / "Notes" / "note.md"
-    note.write_text("---\ntitle: Plain note\n---\nbody\n", encoding="utf-8")
-
-    section = StateReportGenerator(
-        vault_path=empty_vault,
-    ).section_vault_summary()
-
-    assert "Fragments: 0" in section
-
-
 def test_frequency_label_renders_known_aptitude_name() -> None:
     """Known frequencies render with their canonical APTITUDE name."""
     assert _frequency_label("F1") == "F1 (Agency/Survival)"
@@ -376,12 +754,7 @@ def test_frequency_label_handles_unknown_value() -> None:
 
 
 def test_pre_llm_yield_rejects_json_array_root(empty_vault: Path) -> None:
-    """A JSONL line whose root is a JSON array (not a dict) is rejected.
-
-    ``_load_latest_yield`` only accepts dict-shaped payloads — anything
-    else falls back to the empty-state placeholder, matching the type
-    contract callers rely on.
-    """
+    """A JSONL line whose root is a JSON array falls back to placeholder."""
     log = empty_vault / "00-Creek-Meta" / "Processing-Log" / "run-summary.jsonl"
     log.write_text("[1, 2, 3]\n", encoding="utf-8")
 
@@ -393,19 +766,11 @@ def test_pre_llm_yield_rejects_json_array_root(empty_vault: Path) -> None:
 
 
 def test_render_against_missing_vault_root(tmp_path: Path) -> None:
-    """A vault path that does not exist on disk renders an empty report.
-
-    Each loader checks ``root.exists()`` before walking — the report
-    must degrade to zero counts and empty-state placeholders rather
-    than raising. Pins the contract explicitly rather than relying on
-    every loader's individual ``not exists`` short-circuit.
-    """
+    """A vault path that does not exist on disk renders an empty report."""
     missing = tmp_path / "no-such-vault"
 
     rendered = StateReportGenerator(vault_path=missing).render()
 
     assert "Fragments: 0" in rendered
-    assert "Eddies: 0" in rendered
-    assert "Threads: 0" in rendered
     for header in SECTION_ORDER:
         assert header in rendered

--- a/creek-tools/tests/test_state.py
+++ b/creek-tools/tests/test_state.py
@@ -310,13 +310,29 @@ def test_section_vault_summary_includes_counts(populated_vault: Path) -> None:
 
 
 def test_section_vault_summary_empty(empty_vault: Path) -> None:
-    """An empty vault renders zero counts (not the placeholder)."""
+    """An empty vault renders zero counts on every primitive (not the placeholder)."""
     section = StateReportGenerator(
         vault_path=empty_vault,
     ).section_vault_summary()
 
     assert "Fragments: 0" in section
+    assert "Eddies: 0" in section
+    assert "Threads: 0" in section
     assert EMPTY_PLACEHOLDER not in section
+
+
+def test_section_vault_summary_includes_frequency_distribution(
+    populated_vault: Path,
+) -> None:
+    """The summary surfaces the per-frequency distribution under a header."""
+    section = StateReportGenerator(
+        vault_path=populated_vault,
+    ).section_vault_summary()
+
+    assert "**Frequency distribution**" in section
+    # Two F1 fragments and one F2 fragment in the populated fixture.
+    assert "F1 (Agency/Survival): 2" in section
+    assert "F2 (Receptivity/Kinship): 1" in section
 
 
 def test_frequency_distribution_sorts_numerically_not_lexicographically(
@@ -344,7 +360,11 @@ def test_frequency_distribution_sorts_numerically_not_lexicographically(
 
 
 def test_section_pre_llm_yield_reads_latest_run(populated_vault: Path) -> None:
-    """The pre-LLM yield section reflects the most recent run-summary line."""
+    """The pre-LLM yield section reflects the most recent run-summary line.
+
+    The populated fixture's only yield entry has ``no_llm: True``, so this
+    test pins both the count rendering and the truthy ``--no-llm`` token.
+    """
     section = StateReportGenerator(
         vault_path=populated_vault,
     ).section_pre_llm_yield()
@@ -353,6 +373,30 @@ def test_section_pre_llm_yield_reads_latest_run(populated_vault: Path) -> None:
     assert "Deterministic: 7" in section
     assert "Local-model: 5" in section
     assert "Residue: 2" in section
+    assert "`--no-llm`: yes" in section
+
+
+def test_section_pre_llm_yield_renders_no_llm_false(empty_vault: Path) -> None:
+    """When the latest run is *not* ``--no-llm``, the renderer prints ``no``."""
+    _write_yield_jsonl(
+        empty_vault,
+        [
+            {
+                "run_id": "run-pass3",
+                "deterministic_classified": 4,
+                "local_model_processed": 3,
+                "residue": 1,
+                "no_llm": False,
+                "timestamp": "2026-05-01T00:00:00+00:00",
+            },
+        ],
+    )
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_pre_llm_yield()
+
+    assert "`--no-llm`: no" in section
 
 
 def test_section_pre_llm_yield_empty(empty_vault: Path) -> None:
@@ -795,11 +839,18 @@ def test_pre_llm_yield_rejects_json_array_root(empty_vault: Path) -> None:
 
 
 def test_render_against_missing_vault_root(tmp_path: Path) -> None:
-    """A vault path that does not exist on disk renders an empty report."""
+    """A vault path that does not exist on disk renders an empty report.
+
+    Pins the contract for every loader's ``not exists`` short-circuit:
+    the report degrades to zero counts and empty-state placeholders
+    rather than raising.
+    """
     missing = tmp_path / "no-such-vault"
 
     rendered = StateReportGenerator(vault_path=missing).render()
 
     assert "Fragments: 0" in rendered
+    assert "Eddies: 0" in rendered
+    assert "Threads: 0" in rendered
     for header in SECTION_ORDER:
         assert header in rendered

--- a/creek-tools/tests/test_state.py
+++ b/creek-tools/tests/test_state.py
@@ -743,6 +743,35 @@ def test_loader_skips_unparsable_yaml(empty_vault: Path) -> None:
     assert "Fragments: 1" in section
 
 
+def test_loader_skips_non_fragment_markdown(empty_vault: Path) -> None:
+    """Plain notes coexist with fragments and are skipped silently."""
+    note = empty_vault / "01-Fragments" / "Notes" / "note.md"
+    note.write_text("---\ntitle: Plain note\n---\nbody\n", encoding="utf-8")
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_vault_summary()
+
+    assert "Fragments: 0" in section
+
+
+def test_section_pre_llm_yield_skips_corrupt_last_line(empty_vault: Path) -> None:
+    """A bare non-JSON last line falls back to the empty-state placeholder.
+
+    Distinct from ``test_pre_llm_yield_rejects_json_array_root``: that
+    test pins the *valid-JSON-wrong-shape* branch; this one pins the
+    truly corrupt input that hits ``json.JSONDecodeError`` directly.
+    """
+    log = empty_vault / "00-Creek-Meta" / "Processing-Log" / "run-summary.jsonl"
+    log.write_text("not json at all\n", encoding="utf-8")
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_pre_llm_yield()
+
+    assert EMPTY_PLACEHOLDER in section
+
+
 def test_frequency_label_renders_known_aptitude_name() -> None:
     """Known frequencies render with their canonical APTITUDE name."""
     assert _frequency_label("F1") == "F1 (Agency/Survival)"


### PR DESCRIPTION
## Summary

Final slice of [FEAT-006: `creek state` audit report — core sections](../blob/main/plans/git-issues/FEAT-006-creek-state-audit-report-core.md). Replaces the section 3–7 placeholders that landed in #216 with real implementations, adds the `write()` / `latest.md` plumbing, and wires the `creek state` CLI command.

### What's in this PR

- **Sections 3–7 implemented in `creek/generate/state.py`:**
  - **Section 3 — Active eddies**: top 10 by `fragment_count` descending.
  - **Section 4 — Active threads**: top 10 by `last_seen` recency.
  - **Section 5 — Surprising connections**: loads synchronicities from `10-Liminal/Synchronicities/` and ranks by similarity.
  - **Section 6 — Hyperedges**: praxis whose `derived_from` fragments span 2+ distinct eddies; the spanning eddies are surfaced inline. Single-eddy praxis is filtered out.
  - **Section 7 — Drift warnings**: broken wiki-links (via the existing `BrokenLinkScanner`) plus stale link-isolated fragments older than 90 days (via `OrphanScanner`).
- **`write()` / `latest.md`**: emits `<vault>/00-Creek-Meta/State/<iso-year>-W<week>.md` and refreshes `latest.md` (symlink on POSIX; copy fallback on Windows or networked filesystems that reject `symlink(2)`). Re-running in the same ISO week overwrites the file — idempotent.
- **CLI command**: `creek state --vault <path>` writes the report and prints the path. A regression test monkey-patches `Pipeline.run` to raise — the command exits 0 untouched, pinning the view-only contract.
- **Document header hardening**: renders only the vault's leaf directory name (not the absolute path) so the artefact is safe to commit or share — addresses the LOW-severity concern raised in the third-pass review of #216.
- **`docs/generation.md`**: replaces the "in progress" note with a full description of the command, sections, empty-state contract, and `latest.md` symlink/copy behaviour.

### Acceptance criteria — verified end-to-end

- [x] `creek state` CLI exists, writes `<iso-year>-W<week>.md` and `latest.md`.
- [x] All seven sections render in the order pinned by FEAT-006 (`test_render_emits_sections_in_documented_order`).
- [x] Empty sections render `_No surfacing this week._` rather than disappearing (`test_section_*_empty` per section).
- [x] `creek state` does not re-run classify / link / compile (`test_cli_state_does_not_run_pipeline_passes` monkey-patches `Pipeline.run` to raise).
- [x] Branch coverage on `creek/generate/state.py` ≥ 90 % (91.26 %).
- [x] `docs/generation.md` documents the command in full.

### Test plan

- [x] `./scripts/check-all.sh` — exit 0 (lint, format, type-check, security, complexity, tests, coverage, per-file coverage, docstring coverage gates all green).
- [x] `pytest tests/test_state.py` — 34/34 pass (15 new + 19 carried from #216).
- [x] State.py branch coverage 91.26 %.
- [x] Total suite 3154 tests pass.

### Diff size

+791 insertions / −207 deletions (net +584). The bulk of the additions are the five section implementations, the `_load_synchronicities` loader, and the section-by-section tests with their edge cases. Most of the deletions are the placeholder stubs from #216 being replaced with real bodies.

### Notes

- Builds cleanly on top of the merged PR 1 (#216, commit `1c9385d`).
- Includes the `_write_thread` test-helper symmetry fix that the third-pass review flagged as informational.
- FEAT-007 will insert wavelength snapshot + suggested-questions sections between sections 1 and 2 — the section-ordering contract pinned by tests here makes that insertion straightforward.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9uqm3Cuwf5oMXcgx76Src)_