### PR TITLE
feat(mcp): creek-tools-mcp server + five read tools (FEAT-010)

### DIFF
--- a/creek-tools/creek_mcp/__init__.py
+++ b/creek-tools/creek_mcp/__init__.py
@@ -1,0 +1,13 @@
+"""creek-tools MCP server package (FEAT-010).
+
+Exposes the read-only ``creek`` CLI surface as MCP tools so CrawDad and
+the developer's Claude Code consume the same vault interface with
+privacy-tier ceiling enforcement at the protocol boundary. This PR
+(part 1 of 2) ships the ``state.read`` / ``state.render`` tools and
+the audit + tier-ceiling substrate; the ``lint`` / ``mine`` / ``draft``
+tools land in the follow-up.
+"""
+
+from creek_mcp.tier_ceiling import TierCeiling, TierCeilingViolationError
+
+__all__ = ["TierCeiling", "TierCeilingViolationError"]

--- a/creek-tools/creek_mcp/__init__.py
+++ b/creek-tools/creek_mcp/__init__.py
@@ -2,10 +2,10 @@
 
 Exposes the read-only ``creek`` CLI surface as MCP tools so CrawDad and
 the developer's Claude Code consume the same vault interface with
-privacy-tier ceiling enforcement at the protocol boundary. This PR
-(part 1 of 2) ships the ``state.read`` / ``state.render`` tools and
-the audit + tier-ceiling substrate; the ``lint`` / ``mine`` / ``draft``
-tools land in the follow-up.
+privacy-tier ceiling enforcement at the protocol boundary. Ships the
+five read tools — ``state.read``, ``state.render``, ``lint``, ``mine``,
+``draft`` — and the audit + tier-ceiling substrate that FEAT-011's
+write tools and FEAT-012's purge tools will share.
 """
 
 from creek_mcp.tier_ceiling import TierCeiling, TierCeilingViolationError

--- a/creek-tools/creek_mcp/audit.py
+++ b/creek-tools/creek_mcp/audit.py
@@ -10,6 +10,10 @@ guard ``redact.jsonl`` also guard ``mcp.jsonl``.
 The module records ``args_summary``, not raw arguments: long strings
 become ``{"len": N}``, lists become counts, dicts become key sets, so
 an ``intimate``-tier draft request never leaks the body to the log.
+Callers are expected to pass *only* the MCP-supplied parameters into
+``append(args=...)`` — never internal state such as ``vault_path``,
+which is resolved by the server bootstrap and so does not enter the
+audit trail.
 """
 
 from __future__ import annotations

--- a/creek-tools/creek_mcp/audit.py
+++ b/creek-tools/creek_mcp/audit.py
@@ -1,0 +1,96 @@
+"""MCP-side audit log (FEAT-010).
+
+Every MCP tool invocation appends one entry to
+``<vault>/00-Creek-Meta/audit/mcp.jsonl``. The module exists as its own
+boundary from day 1 — FEAT-011 adds write-side fields; FEAT-012 hardens
+further if needed. The storage layer already delegates to
+:class:`creek.audit.AuditLog`, so the hash-chain + flock guarantees that
+guard ``redact.jsonl`` also guard ``mcp.jsonl``.
+
+The module records ``args_summary``, not raw arguments: long strings
+become ``{"len": N}``, lists become counts, dicts become key sets, so
+an ``intimate``-tier draft request never leaks the body to the log.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from creek.audit import AuditLog
+
+if TYPE_CHECKING:
+    from creek_mcp.tier_ceiling import TierCeiling
+
+MCP_AUDIT_RELPATH = Path("00-Creek-Meta/audit/mcp.jsonl")
+"""Canonical MCP audit log location under the vault root."""
+
+
+def summarise_args(args: dict[str, Any]) -> dict[str, Any]:
+    """Return a privacy-safe summary of *args* for the audit log.
+
+    Strings are kept up to a short prefix length so the audit log never
+    captures a fragment body or draft prompt; long fields are reported
+    as ``{"len": N}`` instead. Pure scalars and short strings pass
+    through unchanged so the audit entry still names *which* skill /
+    phase / index a tool was invoked with.
+    """
+    summary: dict[str, Any] = {}
+    for key, value in args.items():
+        if isinstance(value, str):
+            if len(value) <= 64:
+                summary[key] = value
+            else:
+                summary[key] = {"len": len(value)}
+        elif isinstance(value, list | tuple):
+            summary[key] = {"count": len(value)}
+        elif isinstance(value, dict):
+            summary[key] = {"keys": sorted(value.keys())}
+        else:
+            summary[key] = value
+    return summary
+
+
+class MCPAuditLog:
+    """Append-only audit log for MCP tool invocations.
+
+    Args:
+        vault_path: Vault root under which ``00-Creek-Meta/audit/mcp.jsonl``
+            lives. The parent directory is created on the first append.
+    """
+
+    def __init__(self, vault_path: Path) -> None:
+        """Resolve the canonical audit path under *vault_path*."""
+        self.vault_path = vault_path
+        self.log_path = vault_path / MCP_AUDIT_RELPATH
+        self._audit = AuditLog(self.log_path)
+
+    def append(
+        self,
+        *,
+        tool: str,
+        args: dict[str, Any],
+        tier_ceiling: TierCeiling,
+        consumer: str,
+    ) -> None:
+        """Append one structured entry for an MCP tool call.
+
+        Args:
+            tool: Dot-namespaced tool name (e.g. ``creek.state.read``).
+            args: Raw kwargs the tool was invoked with; summarised
+                before persistence so bodies cannot leak.
+            tier_ceiling: The ceiling the caller supplied.
+            consumer: A free-form identifier (``"crawdad"``,
+                ``"claude-code"``, ``"unknown"``) recording who invoked
+                the tool. CrawDad and Claude Code register distinct
+                values; unknown consumers fall back to ``"unknown"``.
+        """
+        entry = {
+            "tool": tool,
+            "args_summary": summarise_args(args),
+            "tier_ceiling": tier_ceiling.value,
+            "consumer": consumer,
+            "timestamp": datetime.now(tz=UTC).isoformat(),
+        }
+        self._audit.append(entry)

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -1,0 +1,86 @@
+"""creek-tools MCP server bootstrap (FEAT-010 part 1 of 2).
+
+Stdio transport per the FEAT-010 pre-decided choice. This PR ships the
+``creek.state.read`` and ``creek.state.render`` tools plus the
+audit-log + tier-ceiling substrate that every read tool will share.
+``creek.lint``, ``creek.mine``, and ``creek.draft`` arrive in the
+follow-up PR (FEAT-010 part 2) once this skeleton has merged.
+
+The bootstrap is a single function so it can be exercised by a unit
+test (``build_server``) and also serve as the ``creek-tools-mcp``
+entry point (``main``).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+from mcp.server.fastmcp import FastMCP
+
+from creek.config import load_config
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools import state_read_tool, state_render_tool
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SERVER_NAME = "creek-tools-mcp"
+
+
+def _resolve_vault(vault_path: Path | None) -> Path:
+    """Return the supplied path or fall back to ``load_config().vault_path``."""
+    if vault_path is not None:
+        return vault_path
+    return load_config().vault_path
+
+
+def _consumer_from_env() -> str:
+    """Return the consumer identifier from ``CREEK_MCP_CONSUMER`` or unknown."""
+    return os.environ.get("CREEK_MCP_CONSUMER", "unknown")
+
+
+def build_server(*, vault_path: Path | None = None) -> FastMCP:
+    """Construct a :class:`FastMCP` instance with the FEAT-010 part-1 tools.
+
+    Args:
+        vault_path: Override vault root. Defaults to
+            ``load_config().vault_path`` so the MCP surface honours the
+            same configuration that drives the CLI.
+    """
+    server: FastMCP = FastMCP(SERVER_NAME)
+    vault = _resolve_vault(vault_path)
+    consumer = _consumer_from_env()
+
+    @server.tool(name="creek.state.read")
+    def _state_read(
+        privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    ) -> dict[str, Any]:
+        """Return the latest 00-Creek-Meta/State/latest.md content."""
+        return state_read_tool(
+            vault_path=vault,
+            privacy_tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.state.render")
+    def _state_render(
+        privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    ) -> dict[str, Any]:
+        """Re-render the audit report (the expensive path)."""
+        return state_render_tool(
+            vault_path=vault,
+            privacy_tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+        )
+
+    return server
+
+
+def main() -> None:
+    """Run the MCP server over stdio (entry point for ``creek-tools-mcp``)."""
+    build_server().run(transport="stdio")
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via the entry point
+    main()

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -1,14 +1,13 @@
-"""creek-tools MCP server bootstrap (FEAT-010 part 1 of 2).
+"""creek-tools MCP server bootstrap (FEAT-010).
 
-Stdio transport per the FEAT-010 pre-decided choice. This PR ships the
-``creek.state.read`` and ``creek.state.render`` tools plus the
-audit-log + tier-ceiling substrate that every read tool will share.
-``creek.lint``, ``creek.mine``, and ``creek.draft`` arrive in the
-follow-up PR (FEAT-010 part 2) once this skeleton has merged.
+Stdio transport per the FEAT-010 pre-decided choice. Five read tools
+land in this PR — ``creek.state.read``, ``creek.state.render``,
+``creek.lint``, ``creek.mine``, and ``creek.draft`` — plus the
+audit-log + tier-ceiling substrate they share.
 
-The bootstrap is a single function so it can be exercised by a unit
-test (``build_server``) and also serve as the ``creek-tools-mcp``
-entry point (``main``).
+The bootstrap is a single function so it can be exercised by unit
+tests (``build_server``) and serve as the ``creek-tools-mcp`` entry
+point (``main``).
 """
 
 from __future__ import annotations
@@ -20,9 +19,16 @@ from mcp.server.fastmcp import FastMCP
 
 from creek.config import load_config
 from creek_mcp.tier_ceiling import TierCeiling
-from creek_mcp.tools import state_read_tool, state_render_tool
+from creek_mcp.tools import (
+    lint_tool,
+    mine_tool,
+    state_read_tool,
+    state_render_tool,
+)
+from creek_mcp.tools.draft import draft_tool
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 SERVER_NAME = "creek-tools-mcp"
@@ -40,17 +46,46 @@ def _consumer_from_env() -> str:
     return os.environ.get("CREEK_MCP_CONSUMER", "unknown")
 
 
-def build_server(*, vault_path: Path | None = None) -> FastMCP:
-    """Construct a :class:`FastMCP` instance with the FEAT-010 part-1 tools.
+def _build_draft_llm() -> Callable[[str], str]:
+    """Return the production LLM callable, mirroring ``creek draft``.
+
+    Imported lazily so an absent LLM provider only fails the ``draft``
+    invocation, not the whole server startup. ``state``/``lint``/``mine``
+    must remain callable on hosts without an Anthropic key or running
+    Ollama.
+    """
+    from creek.classify.llm import LLMClassifier
+
+    config = load_config()
+    classifier = LLMClassifier(config.llm)
+    if not classifier.available:
+        msg = (
+            "LLM provider unavailable; cannot generate draft. "
+            "Check Ollama or ANTHROPIC_API_KEY configuration."
+        )
+        raise RuntimeError(msg)
+    return classifier.invoke_prompt
+
+
+def build_server(
+    *,
+    vault_path: Path | None = None,
+    draft_llm_factory: Callable[[], Callable[[str], str]] | None = None,
+) -> FastMCP:
+    """Construct a :class:`FastMCP` instance with all five FEAT-010 tools.
 
     Args:
         vault_path: Override vault root. Defaults to
             ``load_config().vault_path`` so the MCP surface honours the
-            same configuration that drives the CLI.
+            same configuration as the CLI.
+        draft_llm_factory: Optional factory for the draft LLM. The
+            factory is invoked lazily so only ``creek.draft`` needs an
+            LLM provider.
     """
     server: FastMCP = FastMCP(SERVER_NAME)
     vault = _resolve_vault(vault_path)
     consumer = _consumer_from_env()
+    factory = draft_llm_factory or _build_draft_llm
 
     @server.tool(name="creek.state.read")
     def _state_read(
@@ -71,6 +106,52 @@ def build_server(*, vault_path: Path | None = None) -> FastMCP:
         return state_render_tool(
             vault_path=vault,
             privacy_tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.lint")
+    def _lint(
+        privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+        checks: list[str] | None = None,
+        since: str | None = None,
+    ) -> dict[str, Any]:
+        """Run the unified hygiene lint pass."""
+        return lint_tool(
+            vault_path=vault,
+            privacy_tier_ceiling=privacy_tier_ceiling,
+            checks=checks,
+            since=since,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.mine")
+    def _mine(
+        privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+        phase: str = "unclassified",
+        limit: int = 10,
+    ) -> dict[str, Any]:
+        """Mine essay seeds from the vault."""
+        return mine_tool(
+            vault_path=vault,
+            privacy_tier_ceiling=privacy_tier_ceiling,
+            phase=phase,
+            limit=limit,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.draft")
+    def _draft(
+        privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+        phase: str = "unclassified",
+        index: int = 0,
+    ) -> dict[str, Any]:
+        """Generate an essay draft from a mined idea."""
+        return draft_tool(
+            vault_path=vault,
+            llm=factory(),
+            privacy_tier_ceiling=privacy_tier_ceiling,
+            phase=phase,
+            index=index,
             consumer=consumer,
         )
 

--- a/creek-tools/creek_mcp/tier_ceiling.py
+++ b/creek-tools/creek_mcp/tier_ceiling.py
@@ -1,0 +1,105 @@
+"""Privacy-tier ceiling enforcement at the MCP boundary (FEAT-010).
+
+Every read tool accepts a required ``privacy_tier_ceiling`` parameter;
+content above the ceiling is omitted or returned as a title-only stub.
+The four ceiling values mirror
+:class:`creek.classify.privacy_filter.PrivacyTierOverride` so the MCP
+surface and ``--include-tier`` stay in lock-step.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from creek.classify.privacy_filter import PrivacyTierOverride
+from creek.models import PrivacyTier
+
+
+class TierCeiling(StrEnum):
+    """MCP-side ceiling parameter values.
+
+    Ordering: ``OPEN`` is the most restrictive (only ``open`` content is
+    visible) and ``ALL`` is the broadest (every tier, including
+    ``unclassified``, is visible).
+    """
+
+    OPEN = "open"
+    PERSONAL = "personal"
+    INTIMATE = "intimate"
+    ALL = "all"
+
+
+class TierCeilingViolationError(Exception):
+    """Raised when a tool would return content above the ceiling.
+
+    Tool wrappers convert this into a structured ``"refused"`` response
+    rather than a transport-level error; the exception keeps the refusal
+    path in one place so no individual tool can silently leak content
+    above the ceiling.
+    """
+
+
+_CEILING_TO_OVERRIDE = {
+    TierCeiling.OPEN: PrivacyTierOverride.OPEN,
+    TierCeiling.PERSONAL: PrivacyTierOverride.PERSONAL,
+    TierCeiling.INTIMATE: PrivacyTierOverride.INTIMATE,
+    TierCeiling.ALL: PrivacyTierOverride.ALL,
+}
+
+
+_TIER_RANK = {
+    PrivacyTier.OPEN: 0,
+    PrivacyTier.UNCLASSIFIED: 0,
+    PrivacyTier.PERSONAL: 1,
+    PrivacyTier.INTIMATE: 2,
+}
+
+
+_CEILING_RANK = {
+    TierCeiling.OPEN: 0,
+    TierCeiling.PERSONAL: 1,
+    TierCeiling.INTIMATE: 2,
+    TierCeiling.ALL: 3,
+}
+
+
+def to_privacy_override(ceiling: TierCeiling) -> PrivacyTierOverride:
+    """Map a :class:`TierCeiling` to the matching CLI override value.
+
+    Lets tool wrappers feed the ceiling straight into the existing
+    privacy-filter machinery so a single source of truth governs which
+    fragments are admitted into generation flows.
+    """
+    return _CEILING_TO_OVERRIDE[ceiling]
+
+
+def tier_allowed(tier: PrivacyTier, ceiling: TierCeiling) -> bool:
+    """Return ``True`` when *tier* is admissible under *ceiling*.
+
+    ``ALL`` admits every tier (including ``unclassified``); other
+    ceilings compare by rank so ``PERSONAL`` admits ``open`` +
+    ``personal`` but rejects ``intimate``.
+    """
+    if ceiling is TierCeiling.ALL:
+        return True
+    return _TIER_RANK[tier] <= _CEILING_RANK[ceiling]
+
+
+def refusal_response(
+    *,
+    tool: str,
+    ceiling: TierCeiling,
+    reason: str,
+) -> dict[str, object]:
+    """Build the canonical ``"refused"`` payload for tier violations.
+
+    Tool wrappers return this dict verbatim so MCP clients can rely on a
+    stable shape: ``status: "refused"``, an echo of the offending tool
+    + ceiling, and a human-readable ``reason``.
+    """
+    return {
+        "status": "refused",
+        "tool": tool,
+        "tier_ceiling": ceiling.value,
+        "reason": reason,
+    }

--- a/creek-tools/creek_mcp/tools/__init__.py
+++ b/creek-tools/creek_mcp/tools/__init__.py
@@ -1,0 +1,10 @@
+"""MCP tool implementations exposed by ``creek_mcp.server`` (FEAT-010).
+
+PR-A ships the ``state`` family; ``lint``, ``mine``, and ``draft`` arrive
+in the follow-up FEAT-010 PR.
+"""
+
+from creek_mcp.tools.state import state_render_tool
+from creek_mcp.tools.state_read import state_read_tool
+
+__all__ = ["state_read_tool", "state_render_tool"]

--- a/creek-tools/creek_mcp/tools/__init__.py
+++ b/creek-tools/creek_mcp/tools/__init__.py
@@ -1,10 +1,15 @@
-"""MCP tool implementations exposed by ``creek_mcp.server`` (FEAT-010).
+"""MCP tool implementations exposed by ``creek_mcp.server`` (FEAT-010)."""
 
-PR-A ships the ``state`` family; ``lint``, ``mine``, and ``draft`` arrive
-in the follow-up FEAT-010 PR.
-"""
-
+from creek_mcp.tools.draft import draft_tool
+from creek_mcp.tools.lint import lint_tool
+from creek_mcp.tools.mine import mine_tool
 from creek_mcp.tools.state import state_render_tool
 from creek_mcp.tools.state_read import state_read_tool
 
-__all__ = ["state_read_tool", "state_render_tool"]
+__all__ = [
+    "draft_tool",
+    "lint_tool",
+    "mine_tool",
+    "state_read_tool",
+    "state_render_tool",
+]

--- a/creek-tools/creek_mcp/tools/draft.py
+++ b/creek-tools/creek_mcp/tools/draft.py
@@ -1,0 +1,98 @@
+"""``creek.draft`` MCP tool — generate an essay draft from a mined idea.
+
+The wrapper accepts an injectable ``llm`` callable so tests can
+exercise it without hitting a real model. In production the server
+bootstrap injects the same Ollama/Anthropic adapter the CLI uses.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+from creek.generate.drafts import DraftGenerator
+from creek.generate.mining import IdeaMiner
+from creek.models import Phase
+from creek_mcp.audit import MCPAuditLog
+from creek_mcp.tier_ceiling import (
+    TierCeiling,
+    TierCeilingViolationError,
+    refusal_response,
+    to_privacy_override,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+TOOL_NAME = "creek.draft"
+
+
+class _DraftLLM(Protocol):
+    def __call__(self, prompt: str) -> str: ...
+
+
+def draft_tool(
+    *,
+    vault_path: Path,
+    llm: _DraftLLM,
+    skills_root: Path | None = None,
+    privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    phase: str = "unclassified",
+    index: int = 0,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Mine ideas, draft the *index*-th, and persist with full provenance.
+
+    The full draft body never enters the response so tier violations
+    cannot leak via MCP — callers follow up with ``creek.state.read``
+    or open the saved file directly to inspect the body.
+    """
+    MCPAuditLog(vault_path).append(
+        tool=TOOL_NAME,
+        args={
+            "vault_path": str(vault_path),
+            "phase": phase,
+            "index": index,
+        },
+        tier_ceiling=privacy_tier_ceiling,
+        consumer=consumer,
+    )
+    override = to_privacy_override(privacy_tier_ceiling)
+    skills_dir = skills_root if skills_root is not None else vault_path / "creek-skills"
+    seeds = IdeaMiner(privacy_override=override).mine_all(
+        vault_path,
+        current_phase=Phase(phase),
+    )
+    if not seeds:
+        return {
+            "status": "empty",
+            "tool": TOOL_NAME,
+            "tier_ceiling": privacy_tier_ceiling.value,
+            "reason": "no idea seeds surfaced",
+        }
+    if index < 0 or index >= len(seeds):
+        msg = f"--index {index} out of range (0..{len(seeds) - 1})"
+        raise TierCeilingViolationError(msg)
+    idea = seeds[index]
+    generator = DraftGenerator(
+        llm=llm,
+        skills_root=skills_dir,
+        privacy_override=override,
+    )
+    try:
+        draft = generator.generate_draft(idea, vault_path=vault_path)
+    except RuntimeError as exc:
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason=str(exc),
+        )
+    saved = generator.save_draft(draft, vault_path)
+    return {
+        "status": "ok",
+        "tool": TOOL_NAME,
+        "tier_ceiling": privacy_tier_ceiling.value,
+        "draft_path": str(saved.relative_to(vault_path)),
+        "title": draft.title,
+        "idea_strategy": draft.idea_strategy,
+        "source_fragments": list(draft.source_fragments),
+    }

--- a/creek-tools/creek_mcp/tools/draft.py
+++ b/creek-tools/creek_mcp/tools/draft.py
@@ -15,7 +15,6 @@ from creek.models import Phase
 from creek_mcp.audit import MCPAuditLog
 from creek_mcp.tier_ceiling import (
     TierCeiling,
-    TierCeilingViolationError,
     refusal_response,
     to_privacy_override,
 )
@@ -48,11 +47,7 @@ def draft_tool(
     """
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
-        args={
-            "vault_path": str(vault_path),
-            "phase": phase,
-            "index": index,
-        },
+        args={"phase": phase, "index": index},
         tier_ceiling=privacy_tier_ceiling,
         consumer=consumer,
     )
@@ -70,8 +65,11 @@ def draft_tool(
             "reason": "no idea seeds surfaced",
         }
     if index < 0 or index >= len(seeds):
-        msg = f"--index {index} out of range (0..{len(seeds) - 1})"
-        raise TierCeilingViolationError(msg)
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason=f"index {index} out of range (0..{len(seeds) - 1})",
+        )
     idea = seeds[index]
     generator = DraftGenerator(
         llm=llm,

--- a/creek-tools/creek_mcp/tools/lint.py
+++ b/creek-tools/creek_mcp/tools/lint.py
@@ -29,11 +29,11 @@ def lint_tool(
     bodies — but the parameter is still required per FEAT-010 to keep
     tool signatures uniform.
     """
+    resolved_checks = list(checks) if checks is not None else None
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
         args={
-            "vault_path": str(vault_path),
-            "checks": list(checks) if checks else None,
+            "checks": resolved_checks,
             "since": since,
         },
         tier_ceiling=privacy_tier_ceiling,
@@ -41,7 +41,7 @@ def lint_tool(
     )
     since_dt = parse_since(since) if since else None
     runner = LintRunner(vault_path=vault_path, since=since_dt, since_text=since)
-    report = runner.run(checks=list(checks) if checks else None)
+    report = runner.run(checks=resolved_checks)
     written = runner.write(report)
     return {
         "status": "ok",

--- a/creek-tools/creek_mcp/tools/lint.py
+++ b/creek-tools/creek_mcp/tools/lint.py
@@ -1,0 +1,59 @@
+"""``creek.lint`` MCP tool — unified vault hygiene checks (FEAT-008)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from creek.lint import LintRunner, parse_since
+from creek_mcp.audit import MCPAuditLog
+from creek_mcp.tier_ceiling import TierCeiling
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+TOOL_NAME = "creek.lint"
+
+
+def lint_tool(
+    *,
+    vault_path: Path,
+    privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    checks: list[str] | None = None,
+    since: str | None = None,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Run the unified lint pass and persist a markdown report.
+
+    Lint reads only compiled-layer metadata (eddies, threads, tag
+    indexes, paradoxes) so the tier ceiling does not gate any fragment
+    bodies — but the parameter is still required per FEAT-010 to keep
+    tool signatures uniform.
+    """
+    MCPAuditLog(vault_path).append(
+        tool=TOOL_NAME,
+        args={
+            "vault_path": str(vault_path),
+            "checks": list(checks) if checks else None,
+            "since": since,
+        },
+        tier_ceiling=privacy_tier_ceiling,
+        consumer=consumer,
+    )
+    since_dt = parse_since(since) if since else None
+    runner = LintRunner(vault_path=vault_path, since=since_dt, since_text=since)
+    report = runner.run(checks=list(checks) if checks else None)
+    written = runner.write(report)
+    return {
+        "status": "ok",
+        "tool": TOOL_NAME,
+        "tier_ceiling": privacy_tier_ceiling.value,
+        "report_path": str(written.relative_to(vault_path)),
+        "checks": [
+            {
+                "name": result.name,
+                "summary": result.summary,
+                "finding_count": len(result.findings),
+            }
+            for result in report.results
+        ],
+    }

--- a/creek-tools/creek_mcp/tools/mine.py
+++ b/creek-tools/creek_mcp/tools/mine.py
@@ -34,11 +34,7 @@ def mine_tool(
     """
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
-        args={
-            "vault_path": str(vault_path),
-            "phase": phase,
-            "limit": limit,
-        },
+        args={"phase": phase, "limit": limit},
         tier_ceiling=privacy_tier_ceiling,
         consumer=consumer,
     )

--- a/creek-tools/creek_mcp/tools/mine.py
+++ b/creek-tools/creek_mcp/tools/mine.py
@@ -1,0 +1,65 @@
+"""``creek.mine`` MCP tool — surface essay seeds from the vault."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from creek.generate.mining import IdeaMiner
+from creek.models import Phase
+from creek_mcp.audit import MCPAuditLog
+from creek_mcp.tier_ceiling import TierCeiling, to_privacy_override
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+TOOL_NAME = "creek.mine"
+_DEFAULT_LIMIT = 10
+
+
+def mine_tool(
+    *,
+    vault_path: Path,
+    privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    phase: str = "unclassified",
+    limit: int = _DEFAULT_LIMIT,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Mine essay seeds and return a structured, score-ranked list.
+
+    The ceiling maps onto the existing
+    :class:`creek.classify.privacy_filter.PrivacyTierOverride` so
+    intimate fragments are excluded at the source — the MCP wrapper
+    cannot widen access beyond what the CLI flag would permit. A
+    ``limit`` of zero or negative returns every seed.
+    """
+    MCPAuditLog(vault_path).append(
+        tool=TOOL_NAME,
+        args={
+            "vault_path": str(vault_path),
+            "phase": phase,
+            "limit": limit,
+        },
+        tier_ceiling=privacy_tier_ceiling,
+        consumer=consumer,
+    )
+    override = to_privacy_override(privacy_tier_ceiling)
+    seeds = IdeaMiner(privacy_override=override).mine_all(
+        vault_path,
+        current_phase=Phase(phase),
+    )
+    display = seeds if limit <= 0 else seeds[:limit]
+    return {
+        "status": "ok",
+        "tool": TOOL_NAME,
+        "tier_ceiling": privacy_tier_ceiling.value,
+        "total": len(seeds),
+        "seeds": [
+            {
+                "strategy": seed.strategy.value,
+                "title": seed.title,
+                "score": round(seed.score, 4),
+                "source_fragments": list(seed.source_fragments),
+            }
+            for seed in display
+        ],
+    }

--- a/creek-tools/creek_mcp/tools/state.py
+++ b/creek-tools/creek_mcp/tools/state.py
@@ -32,7 +32,7 @@ def state_render_tool(
     """
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
-        args={"vault_path": str(vault_path)},
+        args={},
         tier_ceiling=privacy_tier_ceiling,
         consumer=consumer,
     )

--- a/creek-tools/creek_mcp/tools/state.py
+++ b/creek-tools/creek_mcp/tools/state.py
@@ -1,0 +1,46 @@
+"""``creek.state.render`` MCP tool — re-render the audit report.
+
+Mirrors ``creek state`` from the CLI. Re-rendering walks the vault, so
+callers should prefer :func:`creek_mcp.tools.state_read.state_read_tool`
+when they only need the most recent rendered output.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from creek.generate.state import StateReportGenerator
+from creek_mcp.audit import MCPAuditLog
+from creek_mcp.tier_ceiling import TierCeiling
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+TOOL_NAME = "creek.state.render"
+
+
+def state_render_tool(
+    *,
+    vault_path: Path,
+    privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Re-render the audit report and return the written file path.
+
+    The rendered file lives under ``00-Creek-Meta/State/<iso-week>.md``;
+    ``latest.md`` is refreshed atomically by the underlying generator.
+    """
+    MCPAuditLog(vault_path).append(
+        tool=TOOL_NAME,
+        args={"vault_path": str(vault_path)},
+        tier_ceiling=privacy_tier_ceiling,
+        consumer=consumer,
+    )
+    written = StateReportGenerator(vault_path=vault_path).write()
+    return {
+        "status": "ok",
+        "tool": TOOL_NAME,
+        "tier_ceiling": privacy_tier_ceiling.value,
+        "report_path": str(written.relative_to(vault_path)),
+        "content": written.read_text(encoding="utf-8"),
+    }

--- a/creek-tools/creek_mcp/tools/state_read.py
+++ b/creek-tools/creek_mcp/tools/state_read.py
@@ -1,0 +1,57 @@
+"""``creek.state.read`` MCP tool — cheap read of ``State/latest.md``.
+
+This is the FEAT-010 cheap path: no re-render, no walking the vault,
+just hand back the most recent audit-report bytes. ``creek.state.render``
+in :mod:`creek_mcp.tools.state` regenerates the report; ``read`` exists
+so CrawDad's Discord turn-around stays fast.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from creek_mcp.audit import MCPAuditLog
+from creek_mcp.tier_ceiling import TierCeiling
+
+_STATE_LATEST_RELPATH = Path("00-Creek-Meta/State/latest.md")
+TOOL_NAME = "creek.state.read"
+
+
+def state_read_tool(
+    *,
+    vault_path: Path,
+    privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Return the latest audit-report bytes plus tool metadata.
+
+    The audit report aggregates eddy/thread/synchronicity *titles* —
+    it never embeds fragment bodies — so the tier-ceiling enforcement
+    here is the gate on whether the report itself can be returned at
+    all, not a body-level filter. A missing report yields a structured
+    "no report yet" status rather than a crash so a fresh vault stays
+    usable.
+    """
+    MCPAuditLog(vault_path).append(
+        tool=TOOL_NAME,
+        args={"vault_path": str(vault_path)},
+        tier_ceiling=privacy_tier_ceiling,
+        consumer=consumer,
+    )
+    report_path = vault_path / _STATE_LATEST_RELPATH
+    if not report_path.exists():
+        return {
+            "status": "empty",
+            "tool": TOOL_NAME,
+            "tier_ceiling": privacy_tier_ceiling.value,
+            "report_path": str(_STATE_LATEST_RELPATH),
+            "content": "",
+        }
+    return {
+        "status": "ok",
+        "tool": TOOL_NAME,
+        "tier_ceiling": privacy_tier_ceiling.value,
+        "report_path": str(_STATE_LATEST_RELPATH),
+        "content": report_path.read_text(encoding="utf-8"),
+    }

--- a/creek-tools/creek_mcp/tools/state_read.py
+++ b/creek-tools/creek_mcp/tools/state_read.py
@@ -35,7 +35,7 @@ def state_read_tool(
     """
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
-        args={"vault_path": str(vault_path)},
+        args={},
         tier_ceiling=privacy_tier_ceiling,
         consumer=consumer,
     )

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -1,0 +1,84 @@
+# `creek-tools-mcp` registration guide (FEAT-010)
+
+The `creek-tools-mcp` server exposes the read-only `creek` CLI surface
+as MCP tools. Both the developer's Claude Code and the CrawDad Discord
+bot (FEAT-013+) consume the same surface, so privacy-tier enforcement
+and audit-log writes happen at one boundary.
+
+## Installation
+
+```bash
+pip install -e .   # from creek-tools/
+```
+
+The entry point is registered by `pyproject.toml` as
+`creek-tools-mcp`. The server speaks JSON-RPC over stdio; running it
+interactively will appear to hang, which is correct.
+
+## Tools (FEAT-010 part 1)
+
+| Tool                  | Purpose                                                    |
+|-----------------------|------------------------------------------------------------|
+| `creek.state.read`    | Return the latest `00-Creek-Meta/State/latest.md` content. |
+| `creek.state.render`  | Re-render the audit report (expensive).                    |
+
+The follow-up PR adds `creek.lint`, `creek.mine`, and `creek.draft`.
+FEAT-011 adds write tools; FEAT-012 adds `purge.*`.
+
+Every tool requires a `privacy_tier_ceiling` parameter
+(`open` | `personal` | `intimate` | `all`); default is `open`. Content
+above the ceiling is omitted or returned as a title-only stub — the
+ceiling cannot be bypassed by the caller.
+
+## Claude Code
+
+Add an entry to your project's `.mcp.json` (or to user-level
+`~/.claude/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "creek-tools": {
+      "command": "creek-tools-mcp",
+      "env": {"CREEK_MCP_CONSUMER": "claude-code"}
+    }
+  }
+}
+```
+
+`CREEK_MCP_CONSUMER` is recorded on every audit-log entry so we can
+tell apart calls from Claude Code, CrawDad, or operator-driven runs.
+
+## Claude Desktop / Cursor / Zed
+
+All three read the same `mcp.json` schema; the registration entry
+above works verbatim. Drop it in the host's MCP config location.
+
+## CrawDad
+
+CrawDad (FEAT-013+) treats this server's tool registry as its
+`intents` schema (FEAT-014). The Discord bot spawns the server as a
+stdio child process. Set `CREEK_MCP_CONSUMER=crawdad` in the bot's
+environment so the audit trail distinguishes Discord-driven calls.
+
+## Audit log
+
+Every tool invocation appends one entry to
+`<vault>/00-Creek-Meta/audit/mcp.jsonl`:
+
+```json
+{
+  "tool": "creek.state.read",
+  "args_summary": {"vault_path": "/path/to/vault"},
+  "tier_ceiling": "open",
+  "consumer": "claude-code",
+  "timestamp": "2026-05-11T12:34:56+00:00",
+  "prev_hash": "..."
+}
+```
+
+`args_summary` is compact: long strings become `{"len": N}`, lists
+become `{"count": N}`, dicts become `{"keys": [...]}`. A draft request
+for an `intimate`-tier fragment never leaks the body into the audit
+trail. Hash chaining is provided by `creek.audit.AuditLog`; FEAT-012's
+hardening pass extends the entry shape, not the storage layer.

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -15,15 +15,18 @@ The entry point is registered by `pyproject.toml` as
 `creek-tools-mcp`. The server speaks JSON-RPC over stdio; running it
 interactively will appear to hang, which is correct.
 
-## Tools (FEAT-010 part 1)
+## Tools
 
 | Tool                  | Purpose                                                    |
 |-----------------------|------------------------------------------------------------|
 | `creek.state.read`    | Return the latest `00-Creek-Meta/State/latest.md` content. |
 | `creek.state.render`  | Re-render the audit report (expensive).                    |
+| `creek.lint`          | Run the unified hygiene lint pass (FEAT-008).              |
+| `creek.mine`          | Surface essay seeds from the compiled vault layer.         |
+| `creek.draft`         | Draft an essay from a mined idea (requires an LLM).        |
 
-The follow-up PR adds `creek.lint`, `creek.mine`, and `creek.draft`.
-FEAT-011 adds write tools; FEAT-012 adds `purge.*`.
+FEAT-011 adds write tools (`save`, `ingest`, `classify`, `link`,
+`report`, `skills.generate`); FEAT-012 adds `purge.*`.
 
 Every tool requires a `privacy_tier_ceiling` parameter
 (`open` | `personal` | `intimate` | `all`); default is `open`. Content
@@ -82,3 +85,16 @@ become `{"count": N}`, dicts become `{"keys": [...]}`. A draft request
 for an `intimate`-tier fragment never leaks the body into the audit
 trail. Hash chaining is provided by `creek.audit.AuditLog`; FEAT-012's
 hardening pass extends the entry shape, not the storage layer.
+
+## Troubleshooting
+
+- **Server appears to hang:** correct. It speaks JSON-RPC over stdio.
+  Use `python -m creek_mcp.server` for the same effect.
+- **`No module named "mcp"`:** install with `pip install -e .` — FEAT-010
+  added the `mcp` SDK to `pyproject.toml`.
+- **`creek.draft` returns "LLM provider unavailable":** the server
+  loads the LLM lazily so only `draft` requires it. Configure
+  `ANTHROPIC_API_KEY` or a running Ollama instance.
+- **Fewer mine seeds than expected:** the ceiling is filtering intimate
+  fragments by design. Raise the ceiling to `intimate` or `all` only
+  when the caller is authorised.

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -29,9 +29,14 @@ FEAT-011 adds write tools (`save`, `ingest`, `classify`, `link`,
 `report`, `skills.generate`); FEAT-012 adds `purge.*`.
 
 Every tool requires a `privacy_tier_ceiling` parameter
-(`open` | `personal` | `intimate` | `all`); default is `open`. Content
-above the ceiling is omitted or returned as a title-only stub — the
-ceiling cannot be bypassed by the caller.
+(`open` | `personal` | `intimate` | `all`); default is `open`. Note
+that `open` is the *most restrictive* setting — it restricts the
+caller to open-tier (publishable) content only, not "open access".
+The ladder goes `open` (publishable) → `personal` (summarised
+personal allowed) → `intimate` (everything self-authored) → `all`
+(every tier including unclassified). Content above the ceiling is
+omitted or returned as a title-only stub — the ceiling cannot be
+bypassed by the caller.
 
 ## Claude Code
 
@@ -71,8 +76,8 @@ Every tool invocation appends one entry to
 
 ```json
 {
-  "tool": "creek.state.read",
-  "args_summary": {"vault_path": "/path/to/vault"},
+  "tool": "creek.mine",
+  "args_summary": {"phase": "rising", "limit": 10},
   "tier_ceiling": "open",
   "consumer": "claude-code",
   "timestamp": "2026-05-11T12:34:56+00:00",
@@ -80,9 +85,13 @@ Every tool invocation appends one entry to
 }
 ```
 
-`args_summary` is compact: long strings become `{"len": N}`, lists
-become `{"count": N}`, dicts become `{"keys": [...]}`. A draft request
-for an `intimate`-tier fragment never leaks the body into the audit
+`args_summary` captures the MCP-supplied arguments to the tool (the
+ceiling is already a top-level field, so it's not duplicated here).
+The vault path is *not* recorded — it's resolved internally from
+`load_config()` and never enters the audit trail. Compact summary
+rules: long strings become `{"len": N}`, lists become `{"count": N}`,
+dicts become `{"keys": [...]}`. A draft request for an
+`intimate`-tier fragment never leaks the body into the audit
 trail. Hash chaining is provided by `creek.audit.AuditLog`; FEAT-012's
 hardening pass extends the entry shape, not the storage layer.
 

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "chardet>=7.4.3",
     "httpx>=0.27.0",
     "tqdm>=4.66.0",
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2.0.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "chardet>=7.4.3",
     "httpx>=0.27.0",
     "tqdm>=4.66.0",
+    "mcp>=1.0.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -33,6 +34,7 @@ classifiers = [
 
 [project.scripts]
 creek = "creek.cli:app"
+creek-tools-mcp = "creek_mcp.server:main"
 
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.40.0"]
@@ -94,7 +96,7 @@ requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
-include = ["creek", "creek.*"]
+include = ["creek", "creek.*", "creek_mcp", "creek_mcp.*"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"
@@ -103,6 +105,7 @@ addopts = [
     "--strict-markers",
     "--strict-config",
     "--cov=creek",
+    "--cov=creek_mcp",
     "--cov-branch",
     "--cov-report=term-missing:skip-covered",
     "--cov-report=html",
@@ -120,7 +123,7 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 
 [tool.coverage.run]
-source = ["creek"]
+source = ["creek", "creek_mcp"]
 branch = true
 omit = [
     "*/tests/*",

--- a/creek-tools/tests/test_mcp_audit.py
+++ b/creek-tools/tests/test_mcp_audit.py
@@ -42,8 +42,8 @@ def test_append_writes_jsonl_entry_under_vault(tmp_path: Path) -> None:
     """A tool invocation writes one chained JSONL line to mcp.jsonl."""
     log = MCPAuditLog(tmp_path)
     log.append(
-        tool="creek.state.read",
-        args={"vault_path": str(tmp_path)},
+        tool="creek.mine",
+        args={"phase": "rising", "limit": 10},
         tier_ceiling=TierCeiling.OPEN,
         consumer="claude-code",
     )
@@ -52,10 +52,10 @@ def test_append_writes_jsonl_entry_under_vault(tmp_path: Path) -> None:
     lines = log_file.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     entry = json.loads(lines[0])
-    assert entry["tool"] == "creek.state.read"
+    assert entry["tool"] == "creek.mine"
     assert entry["tier_ceiling"] == "open"
     assert entry["consumer"] == "claude-code"
-    assert entry["args_summary"] == {"vault_path": str(tmp_path)}
+    assert entry["args_summary"] == {"phase": "rising", "limit": 10}
     assert "prev_hash" in entry  # chained via creek.audit.AuditLog
     assert "timestamp" in entry
 

--- a/creek-tools/tests/test_mcp_audit.py
+++ b/creek-tools/tests/test_mcp_audit.py
@@ -1,0 +1,82 @@
+"""Tests for the MCP audit log (FEAT-010)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from creek_mcp.audit import MCP_AUDIT_RELPATH, MCPAuditLog, summarise_args
+from creek_mcp.tier_ceiling import TierCeiling
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_summarise_args_keeps_short_scalars() -> None:
+    """Scalars and short strings pass through unchanged."""
+    summary = summarise_args({"phase": "rising", "index": 3, "limit": 10})
+    assert summary == {"phase": "rising", "index": 3, "limit": 10}
+
+
+def test_summarise_args_compacts_long_strings() -> None:
+    """Long strings are reported by length, not body."""
+    body = "x" * 4096
+    summary = summarise_args({"body": body, "title": "ok"})
+    assert summary["body"] == {"len": 4096}
+    assert summary["title"] == "ok"
+
+
+def test_summarise_args_compacts_lists_and_dicts() -> None:
+    """Lists report counts; dicts report keys (not values)."""
+    summary = summarise_args(
+        {
+            "fragments": ["a", "b", "c"],
+            "meta": {"author": "Geoff", "tier": "intimate"},
+        },
+    )
+    assert summary["fragments"] == {"count": 3}
+    assert summary["meta"] == {"keys": ["author", "tier"]}
+
+
+def test_append_writes_jsonl_entry_under_vault(tmp_path: Path) -> None:
+    """A tool invocation writes one chained JSONL line to mcp.jsonl."""
+    log = MCPAuditLog(tmp_path)
+    log.append(
+        tool="creek.state.read",
+        args={"vault_path": str(tmp_path)},
+        tier_ceiling=TierCeiling.OPEN,
+        consumer="claude-code",
+    )
+    log_file = tmp_path / MCP_AUDIT_RELPATH
+    assert log_file.exists()
+    lines = log_file.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["tool"] == "creek.state.read"
+    assert entry["tier_ceiling"] == "open"
+    assert entry["consumer"] == "claude-code"
+    assert entry["args_summary"] == {"vault_path": str(tmp_path)}
+    assert "prev_hash" in entry  # chained via creek.audit.AuditLog
+    assert "timestamp" in entry
+
+
+def test_append_does_not_leak_full_body(tmp_path: Path) -> None:
+    """Regression: full fragment bodies must not enter the audit log.
+
+    The FEAT-010 acceptance criterion: ``args_summary`` not full args.
+    An intimate-tier draft request with a 10kB body should record only
+    the length.
+    """
+    log = MCPAuditLog(tmp_path)
+    body = "intimate prose " * 1000
+    log.append(
+        tool="creek.draft",
+        args={"prompt_body": body, "phase": "rising"},
+        tier_ceiling=TierCeiling.INTIMATE,
+        consumer="crawdad",
+    )
+    contents = (tmp_path / MCP_AUDIT_RELPATH).read_text(encoding="utf-8")
+    assert body not in contents
+    entry = json.loads(contents.splitlines()[0])
+    assert entry["args_summary"]["prompt_body"] == {"len": len(body)}
+    assert entry["args_summary"]["phase"] == "rising"

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -14,7 +14,13 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-EXPECTED_TOOLS = {"creek.state.read", "creek.state.render"}
+EXPECTED_TOOLS = {
+    "creek.state.read",
+    "creek.state.render",
+    "creek.lint",
+    "creek.mine",
+    "creek.draft",
+}
 
 
 @pytest.fixture
@@ -27,6 +33,7 @@ def vault(tmp_path: Path) -> Iterator[Path]:
         "01-Fragments/Notes",
         "02-Threads/Active",
         "03-Eddies",
+        "creek-skills",
     ):
         (tmp_path / sub).mkdir(parents=True, exist_ok=True)
     yield tmp_path
@@ -39,18 +46,19 @@ def _structured(result: object) -> dict[str, object]:
 
 def test_build_server_returns_fastmcp_instance(vault: Path) -> None:
     """The bootstrap returns a configured :class:`FastMCP` instance."""
-    server = build_server(vault_path=vault)
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
     assert server.name == SERVER_NAME
 
 
-def test_build_server_registers_part_one_tools(vault: Path) -> None:
-    """The state read/render tools surface via ``list_tools``.
-
-    FEAT-010 part 2 adds ``creek.lint``, ``creek.mine``, and
-    ``creek.draft`` — those land in the follow-up PR. This test pins
-    the part-1 surface so the registration regression is caught early.
-    """
-    server = build_server(vault_path=vault)
+def test_build_server_registers_five_read_tools(vault: Path) -> None:
+    """All five FEAT-010 read tools surface via ``list_tools``."""
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
     tools = asyncio.run(server.list_tools())
     names = {tool.name for tool in tools}
     assert names == EXPECTED_TOOLS
@@ -58,7 +66,10 @@ def test_build_server_registers_part_one_tools(vault: Path) -> None:
 
 def test_every_tool_requires_privacy_tier_ceiling_parameter(vault: Path) -> None:
     """The FEAT-010 acceptance criterion: ceiling is in every tool's schema."""
-    server = build_server(vault_path=vault)
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
     tools = asyncio.run(server.list_tools())
     for tool in tools:
         schema = tool.inputSchema
@@ -73,7 +84,10 @@ def test_call_tool_state_read_through_mcp(vault: Path) -> None:
         "# Audit\n\nhello\n",
         encoding="utf-8",
     )
-    server = build_server(vault_path=vault)
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
     result = asyncio.run(
         server.call_tool("creek.state.read", {"privacy_tier_ceiling": "open"}),
     )
@@ -85,7 +99,10 @@ def test_call_tool_state_read_through_mcp(vault: Path) -> None:
 
 def test_call_tool_state_render_through_mcp(vault: Path) -> None:
     """The render path is reachable via ``call_tool``."""
-    server = build_server(vault_path=vault)
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
     result = asyncio.run(
         server.call_tool(
             "creek.state.render",
@@ -94,6 +111,53 @@ def test_call_tool_state_render_through_mcp(vault: Path) -> None:
     )
     structured = _structured(result)
     assert structured["status"] == "ok"
+
+
+def test_call_tool_lint_through_mcp(vault: Path) -> None:
+    """The lint path is reachable via ``call_tool`` and returns ``checks``."""
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    result = asyncio.run(
+        server.call_tool("creek.lint", {"privacy_tier_ceiling": "open"}),
+    )
+    structured = _structured(result)
+    assert structured["status"] == "ok"
+    assert "checks" in structured
+
+
+def test_call_tool_mine_through_mcp(vault: Path) -> None:
+    """The mine path is reachable via ``call_tool``."""
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    result = asyncio.run(
+        server.call_tool(
+            "creek.mine",
+            {"privacy_tier_ceiling": "open", "phase": "rising", "limit": 3},
+        ),
+    )
+    structured = _structured(result)
+    assert structured["status"] == "ok"
+
+
+def test_call_tool_draft_through_mcp(vault: Path) -> None:
+    """The draft path is reachable via ``call_tool``."""
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    result = asyncio.run(
+        server.call_tool(
+            "creek.draft",
+            {"privacy_tier_ceiling": "open", "phase": "rising"},
+        ),
+    )
+    structured = _structured(result)
+    # Empty vault → no seeds; tool returns structured ``empty``.
+    assert structured["status"] == "empty"
 
 
 def test_build_server_falls_back_to_load_config(
@@ -106,8 +170,55 @@ def test_build_server_falls_back_to_load_config(
         vault_path = vault
 
     monkeypatch.setattr("creek_mcp.server.load_config", lambda: _StubConfig())
-    server = build_server()
+    server = build_server(draft_llm_factory=lambda: lambda prompt: "x")
     assert server.name == SERVER_NAME
+
+
+def test_build_draft_llm_raises_when_classifier_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The production factory bubbles a clear error when no LLM is reachable."""
+    from creek_mcp import server as server_module
+
+    class _UnavailableClassifier:
+        available = False
+
+        def __init__(self, _config: object) -> None:
+            pass
+
+        def invoke_prompt(self, prompt: str) -> str:  # pragma: no cover
+            return ""
+
+    monkeypatch.setattr(
+        "creek.classify.llm.LLMClassifier",
+        _UnavailableClassifier,
+    )
+    with pytest.raises(RuntimeError, match="LLM provider unavailable"):
+        server_module._build_draft_llm()
+
+
+def test_build_draft_llm_returns_invoke_prompt_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the classifier reports ``available``, the factory returns the callable."""
+    from creek_mcp import server as server_module
+
+    class _AvailableClassifier:
+        available = True
+
+        def __init__(self, _config: object) -> None:
+            pass
+
+        def invoke_prompt(self, prompt: str) -> str:
+            return "drafted body"
+
+    monkeypatch.setattr(
+        "creek.classify.llm.LLMClassifier",
+        _AvailableClassifier,
+    )
+    llm = server_module._build_draft_llm()
+    assert callable(llm)
+    assert llm("hi") == "drafted body"
 
 
 def test_main_invokes_server_run(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -1,0 +1,125 @@
+"""Bootstrap + registration tests for the creek-tools MCP server (FEAT-010)."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek_mcp.server import SERVER_NAME, build_server
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+EXPECTED_TOOLS = {"creek.state.read", "creek.state.render"}
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Iterator[Path]:
+    """Yield a freshly seeded vault for the server tests."""
+    for sub in (
+        "00-Creek-Meta/State",
+        "00-Creek-Meta/Processing-Log",
+        "00-Creek-Meta/audit",
+        "01-Fragments/Notes",
+        "02-Threads/Active",
+        "03-Eddies",
+    ):
+        (tmp_path / sub).mkdir(parents=True, exist_ok=True)
+    yield tmp_path
+
+
+def _structured(result: object) -> dict[str, object]:
+    """Pull the structured-content dict out of a FastMCP ``call_tool`` result."""
+    return result[1] if isinstance(result, tuple) else result  # type: ignore[return-value, index]
+
+
+def test_build_server_returns_fastmcp_instance(vault: Path) -> None:
+    """The bootstrap returns a configured :class:`FastMCP` instance."""
+    server = build_server(vault_path=vault)
+    assert server.name == SERVER_NAME
+
+
+def test_build_server_registers_part_one_tools(vault: Path) -> None:
+    """The state read/render tools surface via ``list_tools``.
+
+    FEAT-010 part 2 adds ``creek.lint``, ``creek.mine``, and
+    ``creek.draft`` — those land in the follow-up PR. This test pins
+    the part-1 surface so the registration regression is caught early.
+    """
+    server = build_server(vault_path=vault)
+    tools = asyncio.run(server.list_tools())
+    names = {tool.name for tool in tools}
+    assert names == EXPECTED_TOOLS
+
+
+def test_every_tool_requires_privacy_tier_ceiling_parameter(vault: Path) -> None:
+    """The FEAT-010 acceptance criterion: ceiling is in every tool's schema."""
+    server = build_server(vault_path=vault)
+    tools = asyncio.run(server.list_tools())
+    for tool in tools:
+        schema = tool.inputSchema
+        assert "privacy_tier_ceiling" in schema["properties"], (
+            f"{tool.name} missing privacy_tier_ceiling in its input schema"
+        )
+
+
+def test_call_tool_state_read_through_mcp(vault: Path) -> None:
+    """End-to-end: ``call_tool("creek.state.read")`` returns the report bytes."""
+    (vault / "00-Creek-Meta" / "State" / "latest.md").write_text(
+        "# Audit\n\nhello\n",
+        encoding="utf-8",
+    )
+    server = build_server(vault_path=vault)
+    result = asyncio.run(
+        server.call_tool("creek.state.read", {"privacy_tier_ceiling": "open"}),
+    )
+    structured = _structured(result)
+    assert structured["status"] == "ok"
+    assert structured["tool"] == "creek.state.read"
+    assert "Audit" in structured["content"]  # type: ignore[operator]
+
+
+def test_call_tool_state_render_through_mcp(vault: Path) -> None:
+    """The render path is reachable via ``call_tool``."""
+    server = build_server(vault_path=vault)
+    result = asyncio.run(
+        server.call_tool(
+            "creek.state.render",
+            {"privacy_tier_ceiling": "open"},
+        ),
+    )
+    structured = _structured(result)
+    assert structured["status"] == "ok"
+
+
+def test_build_server_falls_back_to_load_config(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without an explicit ``vault_path``, the bootstrap reads ``load_config``."""
+
+    class _StubConfig:
+        vault_path = vault
+
+    monkeypatch.setattr("creek_mcp.server.load_config", lambda: _StubConfig())
+    server = build_server()
+    assert server.name == SERVER_NAME
+
+
+def test_main_invokes_server_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``main()`` calls ``FastMCP.run(transport='stdio')``."""
+    from creek_mcp import server as server_module
+
+    runs: list[tuple[object, ...]] = []
+
+    class _StubServer:
+        def run(self, transport: str) -> None:
+            runs.append((transport,))
+
+    monkeypatch.setattr(server_module, "build_server", lambda: _StubServer())
+    server_module.main()
+    assert runs == [("stdio",)]

--- a/creek-tools/tests/test_mcp_tier_ceiling.py
+++ b/creek-tools/tests/test_mcp_tier_ceiling.py
@@ -1,0 +1,86 @@
+"""Tests for the MCP privacy-tier ceiling helpers (FEAT-010)."""
+
+from __future__ import annotations
+
+import pytest
+
+from creek.classify.privacy_filter import PrivacyTierOverride
+from creek.models import PrivacyTier
+from creek_mcp.tier_ceiling import (
+    TierCeiling,
+    TierCeilingViolationError,
+    refusal_response,
+    tier_allowed,
+    to_privacy_override,
+)
+
+
+def test_tier_ceiling_values_match_cli_override() -> None:
+    """Ceiling values mirror the existing CLI ``--include-tier`` enum."""
+    assert {t.value for t in TierCeiling} == {t.value for t in PrivacyTierOverride}
+
+
+@pytest.mark.parametrize(
+    ("ceiling", "expected"),
+    [
+        (TierCeiling.OPEN, PrivacyTierOverride.OPEN),
+        (TierCeiling.PERSONAL, PrivacyTierOverride.PERSONAL),
+        (TierCeiling.INTIMATE, PrivacyTierOverride.INTIMATE),
+        (TierCeiling.ALL, PrivacyTierOverride.ALL),
+    ],
+)
+def test_to_privacy_override_maps_one_to_one(
+    ceiling: TierCeiling,
+    expected: PrivacyTierOverride,
+) -> None:
+    """Every ceiling resolves to the matching CLI override."""
+    assert to_privacy_override(ceiling) is expected
+
+
+@pytest.mark.parametrize(
+    ("tier", "ceiling", "expected"),
+    [
+        (PrivacyTier.OPEN, TierCeiling.OPEN, True),
+        (PrivacyTier.PERSONAL, TierCeiling.OPEN, False),
+        (PrivacyTier.INTIMATE, TierCeiling.OPEN, False),
+        (PrivacyTier.OPEN, TierCeiling.PERSONAL, True),
+        (PrivacyTier.PERSONAL, TierCeiling.PERSONAL, True),
+        (PrivacyTier.INTIMATE, TierCeiling.PERSONAL, False),
+        (PrivacyTier.INTIMATE, TierCeiling.INTIMATE, True),
+        (PrivacyTier.INTIMATE, TierCeiling.ALL, True),
+        (PrivacyTier.UNCLASSIFIED, TierCeiling.OPEN, True),
+        (PrivacyTier.UNCLASSIFIED, TierCeiling.ALL, True),
+    ],
+)
+def test_tier_allowed_matrix(
+    tier: PrivacyTier,
+    ceiling: TierCeiling,
+    expected: bool,
+) -> None:
+    """``tier_allowed`` rejects content above the ceiling.
+
+    ``all`` admits every tier including ``unclassified``; ``open`` admits
+    only ``open`` and ``unclassified``.
+    """
+    assert tier_allowed(tier, ceiling) is expected
+
+
+def test_refusal_response_shape() -> None:
+    """Refusals have a stable, MCP-friendly dict shape."""
+    response = refusal_response(
+        tool="creek.draft",
+        ceiling=TierCeiling.OPEN,
+        reason="intimate content requested",
+    )
+    assert response == {
+        "status": "refused",
+        "tool": "creek.draft",
+        "tier_ceiling": "open",
+        "reason": "intimate content requested",
+    }
+
+
+def test_tier_ceiling_violation_is_exception() -> None:
+    """The violation error is raisable and catchable in tool wrappers."""
+    with pytest.raises(TierCeilingViolationError):
+        raise TierCeilingViolationError("test")

--- a/creek-tools/tests/test_mcp_tools.py
+++ b/creek-tools/tests/test_mcp_tools.py
@@ -187,6 +187,20 @@ def test_lint_since_window(vault: Path) -> None:
     assert result["status"] == "ok"
 
 
+def test_lint_empty_checks_list_runs_nothing(vault: Path) -> None:
+    """``checks=[]`` must be distinct from ``checks=None``.
+
+    Regression for PR #224 review: a falsy-check (``if checks``) on the
+    parameter previously collapsed ``[]`` into ``None`` and ran the
+    full default check set, the opposite of what an explicit empty
+    list signals.
+    """
+    result_empty = lint_tool(vault_path=vault, checks=[])
+    result_default = lint_tool(vault_path=vault)
+    assert len(result_empty["checks"]) == 0
+    assert len(result_default["checks"]) > 0
+
+
 # ---------------------------------------------------------------------------
 # mine
 # ---------------------------------------------------------------------------
@@ -351,13 +365,18 @@ def test_draft_refuses_when_llm_returns_empty(
     assert "LLM" in result["reason"]
 
 
-def test_draft_raises_for_out_of_range_index(
+def test_draft_refuses_for_out_of_range_index(
     vault: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """An out-of-range index raises :class:`TierCeilingViolationError`."""
-    from creek_mcp.tier_ceiling import TierCeilingViolationError
+    """An out-of-range index returns a structured refusal, not a raise.
 
+    Regression for PR #224 review: the previous implementation raised
+    ``TierCeilingViolationError`` for caller input errors, conflating
+    privacy refusals with programmer mistakes and bypassing the
+    refusal-response JSON path. The graceful pattern mirrors the
+    ``"no idea seeds"`` empty path already in ``draft_tool``.
+    """
     monkeypatch.setattr(
         "creek_mcp.tools.draft.IdeaMiner",
         lambda **kw: type(
@@ -366,10 +385,12 @@ def test_draft_raises_for_out_of_range_index(
             {"mine_all": lambda self, vault_path, *, current_phase: [_stub_seed()]},
         )(),
     )
-    with pytest.raises(TierCeilingViolationError):
-        draft_tool(
-            vault_path=vault,
-            llm=lambda prompt: "x",
-            phase="rising",
-            index=99,
-        )
+    result = draft_tool(
+        vault_path=vault,
+        llm=lambda prompt: "x",
+        phase="rising",
+        index=99,
+    )
+    assert result["status"] == "refused"
+    assert result["tool"] == "creek.draft"
+    assert "out of range" in result["reason"]

--- a/creek-tools/tests/test_mcp_tools.py
+++ b/creek-tools/tests/test_mcp_tools.py
@@ -1,0 +1,156 @@
+"""Per-tool integration tests for the MCP wrappers (FEAT-010).
+
+This PR covers ``creek.state.read`` and ``creek.state.render``. The
+``lint``/``mine``/``draft`` wrappers land in FEAT-010 part 2 with their
+own per-tool tests.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.state import state_render_tool
+from creek_mcp.tools.state_read import state_read_tool
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+def _seed_vault(vault: Path) -> None:
+    """Create the minimum folder layout the read tools expect."""
+    for sub in (
+        "00-Creek-Meta/State",
+        "00-Creek-Meta/Processing-Log",
+        "00-Creek-Meta/audit",
+        "01-Fragments/Notes",
+        "02-Threads/Active",
+        "03-Eddies",
+        "04-Praxis/Daily",
+        "10-Liminal/Synchronicities",
+    ):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+
+
+def _write_fragment(
+    vault: Path,
+    *,
+    frag_id: str,
+    title: str = "Note",
+    privacy_tier: str = "open",
+    body: str = "body text",
+) -> None:
+    """Write a minimal fragment file (frontmatter + body)."""
+    metadata = {
+        "type": "fragment",
+        "id": frag_id,
+        "title": title,
+        "created": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "ingested": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "F1", "secondary": []},
+        "privacy_tier": privacy_tier,
+        "eddies": [],
+    }
+    target = vault / "01-Fragments" / "Notes" / f"{frag_id}.md"
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Iterator[Path]:
+    """Yield a freshly seeded vault rooted under ``tmp_path``."""
+    _seed_vault(tmp_path)
+    yield tmp_path
+
+
+# ---------------------------------------------------------------------------
+# state.read
+# ---------------------------------------------------------------------------
+
+
+def test_state_read_returns_latest_md_content(vault: Path) -> None:
+    """``state.read`` reads ``00-Creek-Meta/State/latest.md`` verbatim."""
+    (vault / "00-Creek-Meta" / "State" / "latest.md").write_text(
+        "# Audit report\n\nVault summary lives here.\n",
+        encoding="utf-8",
+    )
+    result = state_read_tool(vault_path=vault)
+    assert result["status"] == "ok"
+    assert result["tool"] == "creek.state.read"
+    assert result["tier_ceiling"] == "open"
+    assert "Audit report" in result["content"]
+
+
+def test_state_read_returns_empty_on_missing_report(vault: Path) -> None:
+    """A fresh vault with no rendered report yields a structured "empty"."""
+    result = state_read_tool(vault_path=vault)
+    assert result["status"] == "empty"
+    assert result["content"] == ""
+
+
+def test_state_read_writes_audit_entry(vault: Path) -> None:
+    """Every invocation appends one chained line to ``mcp.jsonl``."""
+    state_read_tool(
+        vault_path=vault,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+        consumer="claude-code",
+    )
+    raw = (vault / MCP_AUDIT_RELPATH).read_text(encoding="utf-8")
+    entry = json.loads(raw.splitlines()[0])
+    assert entry["tool"] == "creek.state.read"
+    assert entry["consumer"] == "claude-code"
+    assert entry["tier_ceiling"] == "personal"
+
+
+def test_state_read_does_not_embed_fragment_bodies(vault: Path) -> None:
+    """Intimate fragment bodies must not appear in the audit report.
+
+    The audit report aggregates titles + counts. A vault with an
+    ``intimate``-tier fragment must not see its body surface through
+    ``state.read`` even when the caller specifies ``ceiling=open``.
+    """
+    _write_fragment(
+        vault,
+        frag_id="frag-intimate-1",
+        title="Private moment",
+        privacy_tier="intimate",
+        body="this is a secret journal body",
+    )
+    (vault / "00-Creek-Meta" / "State" / "latest.md").write_text(
+        "# Audit report\n\n- Fragments: 1\n",
+        encoding="utf-8",
+    )
+    result = state_read_tool(vault_path=vault)
+    assert "secret journal body" not in result["content"]
+
+
+# ---------------------------------------------------------------------------
+# state.render
+# ---------------------------------------------------------------------------
+
+
+def test_state_render_writes_report_file(vault: Path) -> None:
+    """``state.render`` regenerates ``State/<iso-week>.md`` and returns it."""
+    result = state_render_tool(vault_path=vault)
+    assert result["status"] == "ok"
+    assert result["report_path"].startswith("00-Creek-Meta/State/")
+    assert "# Creek state" in result["content"]
+
+
+def test_state_render_writes_audit_entry(vault: Path) -> None:
+    """Render path also writes the audit entry."""
+    state_render_tool(vault_path=vault, consumer="crawdad")
+    raw = (vault / MCP_AUDIT_RELPATH).read_text(encoding="utf-8")
+    entry = json.loads(raw.splitlines()[0])
+    assert entry["tool"] == "creek.state.render"
+    assert entry["consumer"] == "crawdad"

--- a/creek-tools/tests/test_mcp_tools.py
+++ b/creek-tools/tests/test_mcp_tools.py
@@ -1,9 +1,4 @@
-"""Per-tool integration tests for the MCP wrappers (FEAT-010).
-
-This PR covers ``creek.state.read`` and ``creek.state.render``. The
-``lint``/``mine``/``draft`` wrappers land in FEAT-010 part 2 with their
-own per-tool tests.
-"""
+"""Per-tool integration tests for the MCP wrappers (FEAT-010)."""
 
 from __future__ import annotations
 
@@ -16,6 +11,9 @@ import pytest
 
 from creek_mcp.audit import MCP_AUDIT_RELPATH
 from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.draft import draft_tool
+from creek_mcp.tools.lint import lint_tool
+from creek_mcp.tools.mine import mine_tool
 from creek_mcp.tools.state import state_render_tool
 from creek_mcp.tools.state_read import state_read_tool
 
@@ -34,7 +32,9 @@ def _seed_vault(vault: Path) -> None:
         "02-Threads/Active",
         "03-Eddies",
         "04-Praxis/Daily",
+        "07-Voice/Drafts",
         "10-Liminal/Synchronicities",
+        "creek-skills",
     ):
         (vault / sub).mkdir(parents=True, exist_ok=True)
 
@@ -154,3 +154,222 @@ def test_state_render_writes_audit_entry(vault: Path) -> None:
     entry = json.loads(raw.splitlines()[0])
     assert entry["tool"] == "creek.state.render"
     assert entry["consumer"] == "crawdad"
+
+
+# ---------------------------------------------------------------------------
+# lint
+# ---------------------------------------------------------------------------
+
+
+def test_lint_runs_default_checks(vault: Path) -> None:
+    """The default invocation returns one ``checks`` entry per ran check."""
+    result = lint_tool(vault_path=vault)
+    assert result["status"] == "ok"
+    assert result["tool"] == "creek.lint"
+    assert len(result["checks"]) >= 1
+    assert all("name" in check for check in result["checks"])
+
+
+def test_lint_writes_audit_entry_with_checks_summary(vault: Path) -> None:
+    """The audit entry captures the check list as a count summary."""
+    lint_tool(vault_path=vault, checks=["broken-links"], consumer="crawdad")
+    raw = (vault / MCP_AUDIT_RELPATH).read_text(encoding="utf-8")
+    entry = json.loads(raw.splitlines()[0])
+    assert entry["tool"] == "creek.lint"
+    # ``checks=["broken-links"]`` collapses to ``{"count": 1}`` via
+    # summarise_args, so the audit log never grows with check names.
+    assert entry["args_summary"]["checks"] == {"count": 1}
+
+
+def test_lint_since_window(vault: Path) -> None:
+    """``since`` triggers semantic checks via ``parse_since``."""
+    result = lint_tool(vault_path=vault, since="7d")
+    assert result["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# mine
+# ---------------------------------------------------------------------------
+
+
+def test_mine_returns_empty_list_for_fresh_vault(vault: Path) -> None:
+    """An empty vault yields zero seeds without raising."""
+    result = mine_tool(vault_path=vault, phase="rising")
+    assert result["status"] == "ok"
+    assert result["total"] == 0
+    assert result["seeds"] == []
+
+
+def test_mine_honours_tier_ceiling(vault: Path) -> None:
+    """``ceiling=open`` maps to ``PrivacyTierOverride.OPEN`` for the miner."""
+    result = mine_tool(
+        vault_path=vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        phase="unclassified",
+    )
+    assert result["tier_ceiling"] == "open"
+
+
+def test_mine_writes_audit_entry(vault: Path) -> None:
+    """The audit entry pins phase + limit but not vault contents."""
+    mine_tool(vault_path=vault, phase="rising", limit=5, consumer="crawdad")
+    raw = (vault / MCP_AUDIT_RELPATH).read_text(encoding="utf-8")
+    entry = json.loads(raw.splitlines()[0])
+    assert entry["tool"] == "creek.mine"
+    assert entry["args_summary"]["phase"] == "rising"
+    assert entry["args_summary"]["limit"] == 5
+
+
+# ---------------------------------------------------------------------------
+# draft
+# ---------------------------------------------------------------------------
+
+
+def _stub_seed() -> object:
+    """Build a minimal :class:`IdeaSeed`-shaped object for draft tests."""
+    from creek.generate.mining import IdeaSeed, MiningStrategy
+
+    return IdeaSeed(
+        strategy=MiningStrategy.THREAD_TERMINUS,
+        title="Stub idea",
+        source_fragments=("frag-1",),
+        threads=("thread-1",),
+        eddies=("eddy-1",),
+        frequency_affinity=(),
+        brief_description="brief",
+        score=0.75,
+    )
+
+
+def test_draft_returns_empty_when_no_seeds(vault: Path) -> None:
+    """No seeds → structured empty (not a crash, not a refusal)."""
+    result = draft_tool(
+        vault_path=vault,
+        llm=lambda prompt: "ignored",
+        phase="rising",
+    )
+    assert result["status"] == "empty"
+    assert result["reason"] == "no idea seeds surfaced"
+
+
+def test_draft_writes_audit_entry_for_empty_seed_path(vault: Path) -> None:
+    """Audit happens even when the draft cannot proceed (empty seeds)."""
+    draft_tool(
+        vault_path=vault,
+        llm=lambda prompt: "ignored",
+        phase="rising",
+        consumer="crawdad",
+    )
+    raw = (vault / MCP_AUDIT_RELPATH).read_text(encoding="utf-8")
+    entry = json.loads(raw.splitlines()[0])
+    assert entry["tool"] == "creek.draft"
+    assert entry["consumer"] == "crawdad"
+    # Body never embedded in args_summary — LLM responses live outside
+    # the audit log.
+    assert "body" not in entry["args_summary"]
+
+
+def test_draft_success_path_saves_file(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When seeds exist, ``draft_tool`` saves a draft and returns its path."""
+    from creek.generate.drafts import Draft
+
+    monkeypatch.setattr(
+        "creek_mcp.tools.draft.IdeaMiner",
+        lambda **kw: type(
+            "_M",
+            (),
+            {"mine_all": lambda self, vault_path, *, current_phase: [_stub_seed()]},
+        )(),
+    )
+
+    class _StubGenerator:
+        def __init__(self, **kw: object) -> None:
+            pass
+
+        def generate_draft(self, idea: object, *, vault_path: Path) -> Draft:
+            return Draft(
+                title="Stub idea",
+                body="drafted",
+                idea_strategy="thread_terminus",
+                source_fragments=("frag-1",),
+                threads=("thread-1",),
+                eddies=("eddy-1",),
+                skill_stack=(),
+                prompt="prompt",
+                generated_date=datetime(2026, 5, 11, tzinfo=UTC),
+            )
+
+        def save_draft(self, draft: Draft, vault_path: Path) -> Path:
+            target = vault_path / "07-Voice" / "Drafts" / "2026-05-11-stub.md"
+            target.write_text("body", encoding="utf-8")
+            return target
+
+    monkeypatch.setattr("creek_mcp.tools.draft.DraftGenerator", _StubGenerator)
+    result = draft_tool(
+        vault_path=vault,
+        llm=lambda prompt: "drafted",
+        phase="rising",
+    )
+    assert result["status"] == "ok"
+    assert result["draft_path"] == "07-Voice/Drafts/2026-05-11-stub.md"
+    assert result["title"] == "Stub idea"
+    assert result["source_fragments"] == ["frag-1"]
+
+
+def test_draft_refuses_when_llm_returns_empty(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``RuntimeError`` from the generator is converted into a refusal."""
+    monkeypatch.setattr(
+        "creek_mcp.tools.draft.IdeaMiner",
+        lambda **kw: type(
+            "_M",
+            (),
+            {"mine_all": lambda self, vault_path, *, current_phase: [_stub_seed()]},
+        )(),
+    )
+
+    class _BrokenGenerator:
+        def __init__(self, **kw: object) -> None:
+            pass
+
+        def generate_draft(self, idea: object, *, vault_path: Path) -> object:
+            msg = "LLM returned an empty draft body"
+            raise RuntimeError(msg)
+
+    monkeypatch.setattr("creek_mcp.tools.draft.DraftGenerator", _BrokenGenerator)
+    result = draft_tool(
+        vault_path=vault,
+        llm=lambda prompt: "",
+        phase="rising",
+    )
+    assert result["status"] == "refused"
+    assert "LLM" in result["reason"]
+
+
+def test_draft_raises_for_out_of_range_index(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An out-of-range index raises :class:`TierCeilingViolationError`."""
+    from creek_mcp.tier_ceiling import TierCeilingViolationError
+
+    monkeypatch.setattr(
+        "creek_mcp.tools.draft.IdeaMiner",
+        lambda **kw: type(
+            "_M",
+            (),
+            {"mine_all": lambda self, vault_path, *, current_phase: [_stub_seed()]},
+        )(),
+    )
+    with pytest.raises(TierCeilingViolationError):
+        draft_tool(
+            vault_path=vault,
+            llm=lambda prompt: "x",
+            phase="rising",
+            index=99,
+        )


### PR DESCRIPTION
## Summary

Stands up `creek-tools-mcp` and exposes the five FEAT-010 read tools — `creek.state.read`, `creek.state.render`, `creek.lint`, `creek.mine`, `creek.draft` — with privacy-tier ceiling enforcement + audit-log writes at the MCP boundary. Stdio transport, official Anthropic `mcp` SDK, registration recipe in `docs/mcp.md`.

Rebased on top of FEAT-007 (#225) now that wavelength snapshot + suggested questions are on main. Two commits on this branch:

1. `feat(mcp): scaffold creek-tools-mcp server with state read tools (FEAT-010 part 1/2)` — package skeleton, audit/tier-ceiling substrate, `state.read` + `state.render`.
2. `feat(mcp): add creek.lint, creek.mine, creek.draft tools (FEAT-010 part 2/2)` — the remaining three tools on top of the part-1 skeleton.

## Acceptance criteria from FEAT-010

| Criterion | Status |
|---|---|
| `creek-tools-mcp` server starts via `python -m creek_mcp.server` / entry point | ✅ `test_main_invokes_server_run`, `test_build_server_returns_fastmcp_instance` |
| Five read tools exposed and callable via MCP | ✅ `test_build_server_registers_five_read_tools` + per-tool `call_tool` end-to-end tests |
| `privacy_tier_ceiling` required on every read tool; tier-violations refuse rather than leak | ✅ `test_every_tool_requires_privacy_tier_ceiling_parameter` walks every registered tool's JSON Schema; `TierCeilingViolationError` + `refusal_response` cover the refusal path. |
| Audit-log writes on every tool call, with `args_summary` not full args | ✅ `MCPAuditLog` delegates to `creek.audit.AuditLog` (hash chain + flock); `test_append_does_not_leak_full_body` regression-tests that a 15 kB body never enters the log. |
| Registration recipe in `docs/mcp.md` for Claude Code (Desktop/Cursor share `mcp.json`) | ✅ |
| ≥90% branch coverage on `creek_mcp/` | ✅ Aggregate 93.56%; per-file all ≥85% (state.py 85% — only the `TYPE_CHECKING` import). |

## Pre-decided choices honoured

- Official Anthropic `mcp` Python SDK (pinned `>=1.0.0` in `pyproject.toml`); stdio transport, not HTTP.
- Tool naming: `creek.state.read`, `creek.state.render`, `creek.lint`, `creek.mine`, `creek.draft` (lowercase, dot-namespaced, 1-to-1 with CLI).
- `privacy_tier_ceiling` enum with values `open` / `personal` / `intimate` / `all`, default `open`.
- Audit log lives in its own module (`creek_mcp/audit.py`) from day 1; storage delegates to `creek.audit.AuditLog` so FEAT-012's hardening is additive (new fields), not a storage swap.
- `args_summary` not full args (the summariser owns the rule centrally).
- Lazy LLM factory so `creek.draft` is the only tool that requires an Anthropic key / running Ollama.

## Test plan

- [x] `./scripts/check-all.sh` exits 0 locally (10/10 checks green, 3,320 tests pass, 93.56% aggregate branch coverage).
- [x] `python -m pytest tests/test_mcp_*` — 51 tests, all pass.
- [ ] CI passes on all jobs.

## Dependency note

All FEAT-010 dependencies are now on main: FEAT-004 (#211), FEAT-006 (#216/#218), FEAT-007 (#225), FEAT-008 (#219). Branch was rebased on `origin/main` after #225 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)