### PR TITLE
docs(plans): file FEAT-017/018/019 — classification hardening, compost upgrade, vault sovereignty

### DIFF
--- a/plans/git-issues/FEAT-001-schema-skills-compile-lint-save.md
+++ b/plans/git-issues/FEAT-001-schema-skills-compile-lint-save.md
@@ -5,7 +5,7 @@
 **Estimated LOC:** ~400
 **Estimated complexity:** S
 **Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md`](../2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md) (part 1 of 2)
-**Dependencies:** INC-019 (must land first — schema skills reference canonical taxonomy)
+**Dependencies:** INC-019 (done), **FEAT-019** (vault-sovereignty topology must be settled — "vault root" means the user's local vault, not the repo root; schema-skill source lives in the repo template, gets deployed to the user vault)
 **Parallelizable with peers:** yes (with FEAT-002, FEAT-005)
 **Wave:** 1 (schema foundation)
 
@@ -15,10 +15,17 @@ Author a small root `AGENTS.md` plus the first three schema-skill files under `0
 
 ## Files to touch
 
-- `AGENTS.md` (new, vault root) — points at `00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md` as canonical and defines the compile/query/lint/save contract in ≤3000 tokens.
-- `00-Creek-Meta/Skills/compile.SKILL.md` (new) — how to compile fragments → wiki pages, per-source, manual trigger, with provenance preservation.
-- `00-Creek-Meta/Skills/lint.SKILL.md` (new) — what `creek lint` does, with the explicit "do not resolve paradoxes" guard rail.
-- `00-Creek-Meta/Skills/save.SKILL.md` (new) — when and where to file good answers back, with privacy-tier rules.
+**Canonical (in repo, version-controlled — source of truth):**
+- `creek-tools/creek/templates/AGENTS.md` (new) — canonical template; FEAT-019's `creek init` deploys this to the user vault.
+- `creek-tools/creek/templates/skills/compile.SKILL.md` (new) — canonical template.
+- `creek-tools/creek/templates/skills/lint.SKILL.md` (new) — canonical template.
+- `creek-tools/creek/templates/skills/save.SKILL.md` (new) — canonical template.
+
+**Per-vault (deployed by `creek init` — not version-controlled in the repo, only in the user's local vault):**
+- `<vault>/AGENTS.md` — points at `<vault>/00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md` as canonical and defines the compile/query/lint/save contract in ≤3000 tokens.
+- `<vault>/00-Creek-Meta/Skills/compile.SKILL.md` — how to compile fragments → wiki pages.
+- `<vault>/00-Creek-Meta/Skills/lint.SKILL.md` — what `creek lint` does, with the explicit "do not resolve paradoxes" guard rail.
+- `<vault>/00-Creek-Meta/Skills/save.SKILL.md` — when and where to file good answers back, with privacy-tier rules.
 
 ## Pre-decided choices
 

--- a/plans/git-issues/FEAT-002-schema-skills-paradox-liminal-privacy-wavelength.md
+++ b/plans/git-issues/FEAT-002-schema-skills-paradox-liminal-privacy-wavelength.md
@@ -5,7 +5,7 @@
 **Estimated LOC:** ~400
 **Estimated complexity:** S
 **Source candidate:** [`plans/2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md`](../2026-05-05_comparative-analysis/candidates/ADAPT-005-modular-skill-files-as-schema.md) (part 2 of 2)
-**Dependencies:** FEAT-001 (the root `AGENTS.md` it composes with)
+**Dependencies:** FEAT-019 (vault-sovereignty topology — canonical schema-skill source lives in the repo template, gets deployed to the user vault), FEAT-001 (the root `AGENTS.md` it composes with)
 **Parallelizable with peers:** yes (with FEAT-005 only; FEAT-003 and FEAT-004 hard-depend on this FEAT)
 **Wave:** 1 (schema foundation)
 
@@ -15,10 +15,17 @@ Author the four remaining schema-skill files under `00-Creek-Meta/Skills/` cover
 
 ## Files to touch
 
-- `00-Creek-Meta/Skills/paradox.SKILL.md` (new) — how to handle contradictions: route to `10-Liminal/Paradoxes/`, never resolve.
-- `00-Creek-Meta/Skills/liminal.SKILL.md` (new) — when to leave content uncategorized; the four-layer architecture's fourth layer.
-- `00-Creek-Meta/Skills/privacy-tier.SKILL.md` (new) — the `open` / `personal` / `intimate` ladder and the fail-closed defaults.
-- `00-Creek-Meta/Skills/wavelength-aware.SKILL.md` (new) — phase as the lens through which every other tag is interpreted.
+**Canonical (in repo, version-controlled — deployed by FEAT-019's `creek init`):**
+- `creek-tools/creek/templates/skills/paradox.SKILL.md` (new)
+- `creek-tools/creek/templates/skills/liminal.SKILL.md` (new)
+- `creek-tools/creek/templates/skills/privacy-tier.SKILL.md` (new)
+- `creek-tools/creek/templates/skills/wavelength-aware.SKILL.md` (new)
+
+**Per-vault (materialized at `creek init`-time; user can edit; `creek skills sync` re-deploys canonical updates):**
+- `<vault>/00-Creek-Meta/Skills/paradox.SKILL.md` — how to handle contradictions: route to `10-Liminal/Paradoxes/`, never resolve.
+- `<vault>/00-Creek-Meta/Skills/liminal.SKILL.md` — when to leave content uncategorized; the four-layer architecture's fourth layer.
+- `<vault>/00-Creek-Meta/Skills/privacy-tier.SKILL.md` — the `open` / `personal` / `intimate` ladder and the fail-closed defaults.
+- `<vault>/00-Creek-Meta/Skills/wavelength-aware.SKILL.md` — phase as the lens through which every other tag is interpreted.
 
 ## Pre-decided choices
 

--- a/plans/git-issues/FEAT-017-classification-prompt-hardening.md
+++ b/plans/git-issues/FEAT-017-classification-prompt-hardening.md
@@ -1,0 +1,67 @@
+# FEAT-017: Classification prompt hardening — few-shot, CoT, calibration, default-unclassified bias
+
+**Severity:** High (v1.0 — voice fidelity)
+**Category:** FEAT
+**Estimated LOC:** ~600 (code ~400 + fixtures ~200; may split into 017a/017b if code crosses 500)
+**Estimated complexity:** L (right at the budget; flagged splittable)
+**Source candidate:** This FEAT addresses a "slop signal" critique surfaced after the comparative analysis merged. There is no candidate file — the critique is the source. See PR #199 context + the slop critique in the project history.
+**Dependencies:** INC-019 (done), FEAT-001/002 (paradox + wavelength-aware skill files define the contract the prompt should honour)
+**Parallelizable with peers:** yes (with FEAT-018 and FEAT-019; FEAT-004 should land *after* this to consume hardened classifications)
+**Wave:** late Wave 1 / early Wave 2 (before any consumer of LLM classification — at minimum FEAT-004, FEAT-014, FEAT-015)
+
+## Goal
+
+The current `creek/classify/llm.py:54` prompt asks a (default) local Ollama model to pick a 7-dimensional tuple from 94,500 combinations in one shot with no examples, no chain-of-thought, no calibration, and no human-in-the-loop sample check. Downstream consumers — voice-skill activation, `creek draft`, compile-time synthesis, the audit report's wavelength snapshot — treat the YAML response as truth. Voice fidelity is downstream of classification quality; this FEAT closes that gap.
+
+## Files to touch
+
+- `creek-tools/creek/classify/llm.py` — replace the single-shot prompt with a two-step (reason → emit) pipeline; load few-shot examples from fixture; add per-dimension confidence threshold gates.
+- `creek-tools/creek/classify/examples/` (new directory) — markdown/YAML fixtures: 5–10 hand-curated example fragments per dimension covering Medicine/Toxic, ambiguous phase, multi-frequency content, paradox indicators.
+- `creek-tools/creek/classify/calibration.py` (new) — runs the LLM against a held-out labeled fixture set and reports per-dimension agreement rates.
+- `creek-tools/tests/fixtures/classification/calibration_set.yaml` (new) — ~50 hand-labeled fragments (Geoff labels them; this FEAT establishes the format and ships a starter set; full set lands incrementally).
+- `creek-tools/tests/test_calibration.py` (new) — CI test that runs calibration and asserts per-dimension agreement ≥ a documented floor (start lenient: ≥40% for Mode/Orientation/Dosage, ≥60% for Frequency/Phase, ≥75% for Voice Register).
+- `creek-tools/creek/classify/classify_engine.py` — wire the two-step pipeline through `--method llm`; default-unclassified bias for low-confidence dimensions.
+- `creek-tools/creek/cli.py` — add `creek classify --calibrate` subcommand that runs the calibration fixture and prints per-dimension agreement.
+- `creek-tools/docs/classification.md` — document few-shot examples, CoT pipeline, calibration model floor, and per-dimension default-unclassified thresholds.
+
+## Pre-decided choices
+
+- **Two-step pipeline (CoT):** the prompt now asks the model first for a brief reasoning trace ("Walk through which frequency this most resonates with and why, then which phase, then which mode..."), then for the YAML tuple. Reasoning trace is captured in `classification.reasoning` frontmatter for auditability (truncated to 400 chars to stay tier-safe — intimate-tier fragments don't leak reasoning into vault).
+- **Few-shot format:** 5–10 examples per dimension, drawn from already-classified fragments where the user has reviewed and accepted the classification. Stored as YAML lists under `creek/classify/examples/{frequency,phase,mode,dosage,register,confidence}.yaml`. Loaded into the prompt as a rotating sample (3–5 per call to keep token cost bounded) using a stable hash of the fragment ID as the seed (deterministic per fragment, varied across the corpus).
+- **Default-unclassified bias:** for **Mode**, **Orientation**, and **Dosage** specifically, if the model's self-reported confidence < `LLMConfig.unclassified_threshold` (default 0.55), the dimension defaults to `unclassified` rather than the model's pick. Frequency, Phase, and Voice Register keep the model's pick — these are more stable signals.
+- **Calibration model floor:** Haiku (`claude-haiku-4-5-20251001`) and mistral (default Ollama) are too small for reliable 7-dimensional one-shot picks. The calibration test documents the expected accuracy floor at each tier. The prompt itself is model-agnostic; recommended model is Sonnet (`claude-sonnet-4-6`) for production classification. Document this clearly so users don't run mistral and trust the output.
+- **Calibration cadence:** the CI test runs the calibration set on every PR that touches `creek/classify/`. Locally, `creek classify --calibrate` is a separate subcommand the user invokes when tweaking the prompt or the example set.
+- **Reasoning trace tier-safety:** reasoning is logged to vault frontmatter for `open` and `personal` tiers (truncated to 400 chars); for `intimate` tier, reasoning is logged *only* to `00-Creek-Meta/Processing-Log/classify-llm-trace.jsonl` (gitignored per FEAT-019), never into the fragment frontmatter.
+- **Per-fragment classification is acknowledged as noisy.** Documentation explicitly says the wavelength signal is reliable as a *weekly aggregation across many fragments*, not as a single-fragment certainty. The audit report's wavelength snapshot (FEAT-006/007, merged) already aggregates; this FEAT just makes the inherent uncertainty per-fragment explicit in docs.
+- **Default privacy tier of `classification.reasoning` field:** inherits from the fragment's `privacy_tier`. Never escalated.
+- **Splittability:** if the implementing PR exceeds 500 LOC of non-fixture code, split into FEAT-017a (prompt + CoT pipeline in `llm.py`) and FEAT-017b (calibration fixture + CI gate). FEAT-018 / FEAT-019 do not depend on which side lands first.
+
+## Test plan
+
+- Unit: `_build_few_shot_prompt(fragment, examples)` produces a stable prompt for a stable input (deterministic example sampling).
+- Unit: the two-step pipeline call captures reasoning trace + parsed YAML; reasoning trace is truncated to 400 chars in fragment frontmatter and stored in full in the trace log.
+- Unit: the default-unclassified bias activates when model confidence < threshold for Mode/Orientation/Dosage; does NOT activate for Frequency/Phase/Voice Register.
+- Unit: intimate-tier fragments have empty `classification.reasoning` in their frontmatter; the trace log captures the full reasoning.
+- Integration: `creek classify --calibrate` runs the fixture set, reports per-dimension agreement, exits 0 if all floors met.
+- CI: a `tests/test_calibration.py` job runs the calibration set every PR that touches `creek/classify/`; floor breach fails the build.
+- Regression: existing `creek classify --method llm` callers continue to work; the new pipeline is the only path for new classifications, but accepts the old YAML format for backwards compatibility.
+- Documentation: `docs/classification.md` documents the new pipeline, the model floor, and the per-fragment-is-noisy / weekly-aggregation-is-signal framing.
+
+## Acceptance criteria
+
+- `CLASSIFICATION_PROMPT` in `creek/classify/llm.py` includes 3–5 rotating few-shot examples per dimension drawn from `creek/classify/examples/`.
+- The prompt is a two-step (reasoning → YAML) pipeline; reasoning trace is captured and tier-routed correctly.
+- Default-unclassified bias is implemented for Mode/Orientation/Dosage with a configurable threshold (default 0.55).
+- A calibration fixture exists at `tests/fixtures/classification/calibration_set.yaml` with ≥30 hand-labeled fragments (full ~50 lands incrementally via additional fragments added by the human reviewer).
+- A `creek classify --calibrate` CLI subcommand exists and reports per-dimension agreement.
+- The CI test fails when calibration agreement drops below the documented per-dimension floor.
+- `docs/classification.md` documents the new pipeline, the model floor recommendation (Sonnet), the per-fragment-noisy / aggregate-meaningful framing, and the default-unclassified thresholds.
+- ≥90% branch coverage on the changed `creek/classify/` paths.
+
+## References
+
+- The slop critique (no public artifact; documented in PR conversation history).
+- `creek/classify/llm.py:54-96` (the prompt as it stands today).
+- INTEGRATION-PLAN.md "Voice fidelity through the stack" — this FEAT is the gate at the input layer.
+- ADOPT-006 / FEAT-006 (confidence tiers on edges — analogous discipline at a different layer).
+- Spec sections relevant to dimensional ambiguity: §6.2 ("Don't force it. If a fragment doesn't clearly map to any Frequency, leave it `unclassified`"), §7.4 (Medicine vs Toxic ambiguity), §10.2 (paradox preservation).

--- a/plans/git-issues/FEAT-018-compost-embeddings-llm-upgrade.md
+++ b/plans/git-issues/FEAT-018-compost-embeddings-llm-upgrade.md
@@ -1,0 +1,71 @@
+# FEAT-018: Replace compost phrase-matcher with embedding-similarity + LLM verification
+
+**Severity:** High (v1.0 quality)
+**Category:** FEAT
+**Estimated LOC:** ~350 (net — replacing existing 523-line module; estimated +200 / -150)
+**Estimated complexity:** M
+**Source candidate:** Slop critique surfaced after the comparative analysis (PR #199). The user explicitly chose to keep compost as an LLM-driven feature rather than retire it to manual-only.
+**Dependencies:** FEAT-017 (embedding-confidence and tier-safety conventions land first), FEAT-001 (paradox.SKILL.md to ensure compost detection doesn't accidentally flatten paradoxes)
+**Parallelizable with peers:** yes (with FEAT-019 and most of Wave 2+)
+**Wave:** Wave 2 (post-FEAT-017)
+
+## Goal
+
+`creek/generate/compost.py` is 523 lines of code that triggers a "compost" classification when a fragment title contains one of five hardcoded phrases (`"gave up on"`, `"abandoned"`, `"shelved"`, and two more around lines 32–37). This is metaphor-driven coding: the spec calls compost "decomposing ideas that may fertilize future growth" and the implementation is a regex over five strings against the title only. Replace with an embedding-similarity gate plus an LLM verification step so compost detection has actual signal.
+
+## Files to touch
+
+- `creek-tools/creek/generate/compost.py` — replace `_ABANDONMENT_KEYWORDS` (lines 32–37) and `_matched_abandonment_keywords` with the embedding + LLM verification pipeline.
+- `creek-tools/creek/generate/exemplars/compost.yaml` (new) — 10–20 hand-curated example fragments that genuinely express idea-abandonment, written by the user and reviewed before merging. Different in tone from the regex phrases: should cover "I keep circling this and never landing", "this thread went somewhere I no longer recognize", "I let this one go", etc., not just literal "gave up".
+- `creek-tools/creek/classify/embeddings_helper.py` (or reuse existing `creek/link/embeddings.py`) — provide `compute_similarity(fragment_body, exemplars)` returning a max-similarity score.
+- `creek-tools/tests/fixtures/compost/` (new) — fixture set: 10 positive examples (real abandonment), 10 negatives (false-positive risks like "I was about to give up but then…").
+- `creek-tools/tests/test_compost.py` — regression tests covering embedding gate + LLM verification + provenance.
+- `creek-tools/docs/emergence.md` — update §10.4 documentation to describe the new pipeline.
+
+## Pre-decided choices
+
+- **Two-stage pipeline:**
+  1. **Embedding gate (cheap):** compute cosine similarity between the fragment body (not just title) and each exemplar in `compost.yaml`. If max similarity ≥ `CompostConfig.embedding_threshold` (default 0.72 — looser than the synchronicity 0.9 because compost is more diffuse), proceed to stage 2. Otherwise skip — this fragment is not a compost candidate.
+  2. **LLM verification (selective):** invoke a single-fragment, two-state prompt: "Is this fragment expressing abandonment of an idea, a project, or a line of inquiry? Reply `yes`, `no`, or `ambiguous` plus a one-sentence reasoning trace." Only the embedding-gated fragments hit the LLM, so cost stays bounded. `yes` → compost. `ambiguous` → routed to `10-Liminal/Compost/Review/` (manual review queue, similar to existing review queue patterns). `no` → not compost.
+- **Title-only matching is removed.** The body is the signal; titles in this corpus are LLM-generated summaries and frequently miss the abandonment signal.
+- **Privacy-tier respect:** `intimate`-tier fragments are still subject to compost detection (the user's most intimate journals are often where abandonment lives), but the compost note's body is title-only summary by default (matches the existing privacy_filter behaviour for intimate content).
+- **Paradox-aware:** if a fragment is in `10-Liminal/Paradoxes/` or carries `tags: [paradox]`, compost detection is skipped. A paradox-tagged fragment that *also* names abandonment is a paradox first; compost can be added manually by the user if they decide.
+- **LOC budget:** replacing 523 lines with ~300 means net deletion. The new module is smaller because removing the hardcoded phrase machinery + the special-case logic around it is the bulk of the deletion. Embedding + LLM call is short.
+- **Backwards-compat:** existing compost notes (created by the regex pipeline before this FEAT lands) are kept untouched. The new pipeline runs only on fragments that haven't been compost-classified previously.
+- **CompostConfig knobs:**
+  ```yaml
+  compost:
+    embedding_threshold: 0.72
+    llm_verification: true       # set false to skip stage 2 (then ambiguous → not compost)
+    review_queue_dir: "10-Liminal/Compost/Review/"
+  ```
+
+## Test plan
+
+- Unit: embedding gate against fixture positives returns similarity ≥ threshold; against negatives returns < threshold.
+- Unit: LLM verification correctly routes `yes`/`no`/`ambiguous` to the right destination (compost / skip / review queue), using a recorded LLM-response fixture (no live calls in unit tests).
+- Unit: paradox-tagged fragments skip compost detection.
+- Unit: intimate-tier fragments produce title-only compost notes.
+- Regression (against the existing keyword cases): fragments with title "I gave up on the X project" should still be detected as compost (assuming the body also expresses abandonment) — verifies we didn't regress on cases the regex caught for the right reason.
+- Regression (false-positive removal): fragments with title "I was about to give up but I kept going" should NOT be compost — verifies we removed cases the regex caught wrongly.
+- Integration: `creek lint --check compost` (or `creek report --type compost`) against a fixture vault writes the expected compost notes and review-queue entries.
+- Coverage: ≥90% branch coverage on the new `creek/generate/compost.py`.
+
+## Acceptance criteria
+
+- Hardcoded `_ABANDONMENT_KEYWORDS` is deleted; replaced with an embedding-similarity gate against `creek/generate/exemplars/compost.yaml`.
+- LLM verification step exists and is invoked only on embedding-gated candidates.
+- Exemplar set `compost.yaml` has ≥10 entries reviewed by the user.
+- A fixture-based test suite covers positive, negative, and false-positive-risk cases.
+- Paradox-tagged fragments are skipped by compost detection (verified by regression test).
+- The `CompostConfig` schema is exposed in `00-Creek-Meta/creek_config.yaml` with documented defaults.
+- `docs/emergence.md` §10.4 documents the new pipeline; the spec at `00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md:996-1003` is unchanged (the spec doesn't prescribe regex; the implementation chose regex).
+- ≥90% branch coverage on `creek/generate/compost.py`.
+
+## References
+
+- `creek/generate/compost.py:32-37` (the five hardcoded phrases).
+- `creek/generate/compost.py:114-126` (`_matched_abandonment_keywords`).
+- Spec §10.4 (compost framing: "decomposing ideas that may fertilize future growth").
+- FEAT-017 (sets the few-shot + tier-safety conventions this FEAT mirrors).
+- INC-018 (existing tracker for "paradox / tag garden / compost emergence" — this FEAT specifically addresses the compost slice).

--- a/plans/git-issues/FEAT-019-vault-sovereignty-separate-user-vault-from-repo.md
+++ b/plans/git-issues/FEAT-019-vault-sovereignty-separate-user-vault-from-repo.md
@@ -1,0 +1,103 @@
+# FEAT-019: Vault sovereignty — separate user vault from repository
+
+**Severity:** High (v1.0 — privacy + sovereignty non-negotiable)
+**Category:** FEAT
+**Estimated LOC:** ~500 (mostly deletions + a templates directory + an extended `creek init`)
+**Estimated complexity:** M
+**Source candidate:** User-stated requirement after PR #199 / #202 merged. "I don't want to check my personal journal fragments into github. And the folders look super weird sitting there empty." The fourth non-negotiable in the comparative analysis (privacy/sovereignty) is currently weaker than it should be: vault folder structure is committed to the repo as empty placeholders, which means (a) the repo encodes a vault topology that the user might not want, (b) personal data leaks risk if anyone ever pushes a fragment file (the `.gitignore` whitelist is fail-open by default of the structural rule), (c) it looks weird.
+**Dependencies:** none (independent of every other FEAT). Should land *before* FEAT-001 / FEAT-002 if those haven't merged yet, so their "vault root" / "00-Creek-Meta/Skills/" targets are unambiguous.
+**Parallelizable with peers:** yes (with FEAT-017, FEAT-018)
+**Wave:** Wave 1 prerequisite (sequence before FEAT-001)
+
+## Goal
+
+Separate the repository (toolchain + canonical reference material) from the user's vault (personal content, operational state). The repo carries `creek-tools/`, the ontology spec, canonical templates, schema-skill source files, and planning docs. The user's vault lives wherever they want it (`~/Obsidian/Creek-Vault/` by default) and is scaffolded by `creek init --vault <path>`. The repo has no empty placeholder directories; the user's vault never enters version control.
+
+## Files to touch
+
+### Removals from the repo
+- Delete `01-Fragments/` (with all empty subdirs).
+- Delete `02-Threads/` (with all empty subdirs).
+- Delete `03-Eddies/`.
+- Delete `04-Praxis/` (with all empty subdirs).
+- Delete `05-Wavelength/` (with all empty subdirs).
+- Delete `06-Frequencies/` (with all empty subdirs).
+- Delete `07-Voice/` (with all empty subdirs).
+- Delete `08-Decisions/` (with all empty subdirs).
+- Delete `09-Reference/` (with all empty subdirs).
+- Delete `10-Liminal/` (with all empty subdirs).
+
+### Repository additions
+- `creek-tools/creek/templates/vault/` (new directory) — canonical, version-controlled template of the vault folder structure. Empty `.gitkeep`-style markers describe the intended topology; the user's actual content never lives here.
+- `creek-tools/creek/templates/AGENTS.md` (new) — canonical template of the operational AGENTS.md that FEAT-001 creates; deployed to the user's vault by `creek init`.
+- `creek-tools/creek/templates/skills/` (new) — canonical source of truth for the schema-skill tree (FEAT-001/002 wrote into `00-Creek-Meta/Skills/`; that location is now per-vault and gets seeded from this canonical directory).
+
+### Repository preservation
+- `00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md` — canonical spec, **stays in the repo**. The user's vault gets a symlink or copy as part of `creek init`.
+- `plans/`, `creek-tools/`, `CLAUDE.md`, `README.md` — unchanged.
+
+### Removals from .gitignore
+- Strip the whitelist entries for `01-Fragments/` through `10-Liminal/` since the directories no longer exist in the repo at all.
+- Strip the `creek-skills/` whitelist (also per-vault, generated content).
+- Keep the `**/git-issues/` rule as-is.
+
+### CLI extensions
+- `creek-tools/creek/cli.py:340-379` (`def init`) — extend the existing `creek init` to:
+  - Take `--vault <path>` (required; no default to current directory because that's how personal data lands in repos by accident).
+  - Refuse if `<path>` is inside a git repository unless `--allow-in-repo` is passed (with a warning). This protects against the failure mode that motivated this FEAT.
+  - Scaffold the vault folder structure from `creek-tools/creek/templates/vault/`.
+  - Copy the canonical ontology spec into `<vault>/00-Creek-Meta/Ontology/` (or symlink — see Pre-decided choices).
+  - Copy the canonical AGENTS.md into `<vault>/AGENTS.md` (the FEAT-001 target).
+  - Copy the canonical schema-skill tree into `<vault>/00-Creek-Meta/Skills/`.
+  - Create a minimal `<vault>/00-Creek-Meta/creek_config.yaml` (similar to today's behaviour, possibly already implemented).
+- `creek-tools/creek/cli.py` — add `creek skills sync` command that re-deploys the canonical schema-skill tree from `creek-tools/creek/templates/skills/` into `<vault>/00-Creek-Meta/Skills/` (so the user can pull upstream skill updates after they upgrade `creek-tools`).
+
+### Documentation
+- `README.md` (repo root) — clarify: "this repo is the *tool* and the canonical material. Your vault lives elsewhere (default: `~/Obsidian/Creek-Vault/`). Run `creek init --vault <path>` to scaffold a vault."
+- `creek-tools/README.md` — update the Quickstart to start with `creek init --vault ~/Obsidian/Creek-Vault` before any other command.
+- `creek-tools/CLAUDE.md` — add a short "repo topology" section near the top: repo = toolchain + canonical; vault = user data.
+- `creek-tools/docs/getting-started.md` — explicit step: "1. Pick a vault location (NOT inside this repo). 2. `creek init --vault <that path>`. 3. ..."
+
+## Pre-decided choices
+
+- **Repo never contains user vault content.** The deletion of `01-Fragments/` … `10-Liminal/` is permanent. The repo carries the template under `creek-tools/creek/templates/vault/`; that template is what `creek init` materializes into the user's chosen path.
+- **`creek init --vault <path>` is required (no default).** Defaulting to current directory is how personal data ends up in repos. The required flag forces the user to make an explicit choice.
+- **Refuse to init inside a git repository by default.** If `<path>` resolves under a `.git/` parent, `creek init` errors with: `<path> is inside a git repository. Personal vault data should not be version-controlled. Pass --allow-in-repo to override.` This is a sovereignty guard, not a hard block — power users can override.
+- **Canonical ontology spec is copied, not symlinked.** Symlinks don't survive cross-platform; copies are robust. `creek init` documents the copy and explains how to re-sync (`creek init --refresh` re-copies canonical material without touching user content).
+- **Schema-skill tree (FEAT-001/002) is canonical-source in the repo, deployed to vault.** The canonical files live at `creek-tools/creek/templates/skills/*.SKILL.md`. `creek init` copies them to `<vault>/00-Creek-Meta/Skills/`. `creek skills sync` re-deploys to pick up upstream changes. Users can edit their per-vault copies; a sync overwrites, with a confirm prompt if local changes are detected.
+- **AGENTS.md handling:** the canonical template lives at `creek-tools/creek/templates/AGENTS.md`. `creek init` copies to `<vault>/AGENTS.md`. The user can edit the deployed copy.
+- **Existing local vaults are not broken.** If someone has already started using the in-repo folders (which the gitignore made effectively impossible, but in principle), document the migration: `creek init --vault <new-path> --migrate-from <old-repo-root>` (deferred — not in this FEAT).
+- **The user's intended vault path is documented as a personal choice.** Suggested default: `~/Obsidian/Creek-Vault/` (the existing repo name). The user can pick anything.
+- **`00-Creek-Meta/` no longer exists at the repo root.** The Ontology spec moves to `docs/Ontology/creek_ontology_agent_prompt.md` (repo-level) and gets copied into `<vault>/00-Creek-Meta/Ontology/` during init.
+
+## Test plan
+
+- Unit: `creek init --vault /tmp/test-vault` creates the documented folder structure.
+- Unit: `creek init --vault <path-inside-this-repo>` refuses with the documented error message.
+- Unit: `creek init --vault <path-inside-this-repo> --allow-in-repo` proceeds (with a warning) for power users.
+- Unit: the canonical schema-skill tree at `creek-tools/creek/templates/skills/` is non-empty and lints clean (every `*.SKILL.md` parses as valid frontmatter + body).
+- Unit: `creek skills sync --vault <path>` re-copies the canonical tree; with `--check-modified` it refuses if local changes exist, otherwise prompts.
+- Regression: existing creek-tools commands (`process`, `classify`, `link`, etc.) work against a vault scaffolded by the new `creek init`.
+- Regression: the repo's CI suite passes without the now-deleted top-level vault folders (no test depends on `01-Fragments/` etc. being on disk in the repo).
+- Documentation: every existing doc that referenced `01-Fragments/` (etc.) as paths in the repo is updated to clarify those paths exist in the user's vault.
+
+## Acceptance criteria
+
+- The repo no longer contains `01-Fragments/`, `02-Threads/`, `03-Eddies/`, `04-Praxis/`, `05-Wavelength/`, `06-Frequencies/`, `07-Voice/`, `08-Decisions/`, `09-Reference/`, `10-Liminal/` (verified by directory listing after merge).
+- `00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md` either stays at the repo level (preferred) or moves to `docs/Ontology/`; a `creek init` deployment to a fresh vault produces a `<vault>/00-Creek-Meta/Ontology/creek_ontology_agent_prompt.md` matching the canonical content byte-for-byte.
+- `creek-tools/creek/templates/vault/` exists and is the canonical scaffolding source.
+- `creek init --vault <path>` is required (errors helpfully without it); refuses inside-a-repo paths by default; succeeds with `--allow-in-repo`.
+- `creek skills sync` exists and re-deploys canonical skills to a target vault.
+- `README.md` (repo root) makes the topology explicit before the user runs any command.
+- The CI suite passes without the deleted folders.
+- ≥90% branch coverage on the changed CLI paths.
+- `.gitignore` is cleaned up — no orphan whitelist entries for paths the repo no longer contains.
+
+## References
+
+- INTEGRATION-PLAN.md distinctiveness watchlist: "Privacy / sovereignty by construction" (priority 4 of the four non-negotiables).
+- FEAT-001 (the AGENTS.md target — this FEAT clarifies where "vault root" resolves to).
+- FEAT-002 (the schema-skill tree — this FEAT establishes the canonical-vs-deployed split).
+- FEAT-013 (CrawDad's `crawdad.yaml` config will name the vault path; once FEAT-019 lands, that path defaults to `~/Obsidian/Creek-Vault/` rather than the repo root).
+- Existing `creek init` at `creek-tools/creek/cli.py:340-379` (the extension target).
+- `.gitignore` whitelist entries for `01-Fragments/` etc. (the cleanup target).

--- a/plans/git-issues/INDEX.md
+++ b/plans/git-issues/INDEX.md
@@ -206,22 +206,25 @@ Critical-path-aware note: Batches A, B, C, D each contain at least one Critical 
 
 ## 4a. v1.0 implementation roadmap (FEAT-001…FEAT-016)
 
-The 16 `FEAT-*` files in this directory translate the [comparative-analysis ADOPT/ADAPT candidates](../2026-05-05_comparative-analysis/) into pull-ready work units. Each FEAT is sized for a single PR ≤~700 LOC, names the file paths it touches in `creek-tools/` (or in the new `crawdad/` project), pre-decides the open questions from its source candidate, and ships its own test plan + acceptance criteria. The `/work-issue FEAT-NNN` flow can pick any FEAT whose dependencies have landed.
+The 19 `FEAT-*` files in this directory translate the [comparative-analysis ADOPT/ADAPT candidates](../2026-05-05_comparative-analysis/) plus three post-merge additions (FEAT-017 / 018 / 019) into pull-ready work units. Each FEAT is sized for a single PR ≤~700 LOC, names the file paths it touches in `creek-tools/` (or in the new `crawdad/` project), pre-decides the open questions from its source candidate, and ships its own test plan + acceptance criteria. The `/work-issue FEAT-NNN` flow can pick any FEAT whose dependencies have landed.
 
-**Wave 0 — prerequisite (Batch 0, the existing INC-019)**
-- INC-019 — taxonomy reconciliation. Blocks the entire v1.0 roadmap.
+**Wave 0 — prerequisites**
+- **INC-019** — taxonomy reconciliation (done).
+- **FEAT-019** — vault sovereignty: separate user vault from repo, scaffold via `creek init --vault <path>`. Sequence *before* FEAT-001 so "vault root" semantics are unambiguous.
 
-**Wave 1 — schema foundation (sequential after INC-019; FEAT-002 depends on FEAT-001)**
+**Wave 1 — schema foundation (sequential after FEAT-019; FEAT-002 depends on FEAT-001)**
 | ID | Title | LOC | Depends |
 |---|---|---:|---|
-| [FEAT-001](FEAT-001-schema-skills-compile-lint-save.md) | Schema skills (compile / lint / save) + root `AGENTS.md` | ~400 | INC-019 |
-| [FEAT-002](FEAT-002-schema-skills-paradox-liminal-privacy-wavelength.md) | Schema skills (paradox / liminal / privacy-tier / wavelength-aware) | ~400 | FEAT-001 |
+| [FEAT-001](FEAT-001-schema-skills-compile-lint-save.md) | Schema skills (compile / lint / save) + root `AGENTS.md` (deployed) | ~400 | INC-019, FEAT-019 |
+| [FEAT-002](FEAT-002-schema-skills-paradox-liminal-privacy-wavelength.md) | Schema skills (paradox / liminal / privacy-tier / wavelength-aware) (deployed) | ~400 | FEAT-019, FEAT-001 |
 
-**Wave 2 — compiled-layer primitives**
+**Wave 2 — compiled-layer primitives + classification quality**
 | ID | Title | LOC | Depends |
 |---|---|---:|---|
 | [FEAT-003](FEAT-003-compile-primitive.md) | Compile primitive — `creek compile <fragment-id>` | ~450 | INC-019, FEAT-001/002 |
-| [FEAT-004](FEAT-004-compiled-layer-query-routing.md) | Compiled-layer query routing in `creek mine` / `creek draft` | ~450 | FEAT-003 |
+| [FEAT-017](FEAT-017-classification-prompt-hardening.md) | Classification prompt hardening (few-shot + CoT + calibration + default-unclassified) | ~600 (splittable) | INC-019, FEAT-001/002 |
+| [FEAT-018](FEAT-018-compost-embeddings-llm-upgrade.md) | Compost: embeddings + LLM verification (replaces 5-phrase regex) | ~350 | FEAT-017, FEAT-001 |
+| [FEAT-004](FEAT-004-compiled-layer-query-routing.md) | Compiled-layer query routing in `creek mine` / `creek draft` | ~450 | FEAT-003, FEAT-017 |
 | [FEAT-005](FEAT-005-deterministic-first-pipeline.md) | Deterministic-first pipeline + `--no-llm` end-to-end | ~260 | none (parallelizable) |
 
 **Wave 3 — observability + hygiene**
@@ -247,9 +250,11 @@ The 16 `FEAT-*` files in this directory translate the [comparative-analysis ADOP
 | [FEAT-015](FEAT-015-crawdad-sonnet-composer-loop.md) | CrawDad — Sonnet composer + 5-round loop + voice-skill activation | ~450 | FEAT-014 |
 | [FEAT-016](FEAT-016-slash-command-grammar.md) | `/creek` and `/crawdad` slash-command grammars | ~400 | FEAT-010/011/012, FEAT-015 |
 
-**Critical path:** INC-019 → FEAT-001 → FEAT-002 → FEAT-003 → FEAT-004 → FEAT-006 → FEAT-008 → FEAT-009 → FEAT-010 → FEAT-011 → FEAT-012 → FEAT-013 → FEAT-014 → FEAT-015. Fourteen sequential PRs (one prerequisite + thirteen FEATs); the remaining three FEATs (005, 007, 016) parallelize off the path. Total: 17 PRs for full v1.0 (Creek Vault data layer + CrawDad agent layer).
+**Critical path:** INC-019 → **FEAT-019** → FEAT-001 → FEAT-002 → FEAT-003 → **FEAT-017** → FEAT-004 → FEAT-006 → FEAT-008 → FEAT-009 → FEAT-010 → FEAT-011 → FEAT-012 → FEAT-013 → FEAT-014 → FEAT-015. Sixteen sequential PRs (one taxonomy prerequisite + fifteen FEATs); the remaining four FEATs (005, 007, 016, 018) parallelize off the path. Total: 20 PRs for full v1.0 (Creek Vault data layer + CrawDad agent layer).
 
-**LOC envelope:** every FEAT is sized to ≤700 LOC. The largest is FEAT-009 (`creek save`, ~580 LOC).
+FEAT-017 may split into 017a/017b if the implementing PR exceeds 500 LOC of non-fixture code (see the FEAT for the split criterion).
+
+**LOC envelope:** every FEAT is sized to ≤700 LOC. The largest is FEAT-017 (~600 LOC, splittable) and FEAT-009 (`creek save`, ~580 LOC).
 
 **Execution model:** `/work-issue FEAT-NNN` reads the FEAT file, branches, runs TDD against the named acceptance criteria, opens a PR. Open questions in each FEAT are pre-decided so the implementer doesn't pause mid-PR. If a candidate's `Pre-decided choices` block needs to change in light of implementation reality, that's a separate PR that updates the FEAT first.
 


### PR DESCRIPTION
## Summary

Three new FEAT-* issue files filed after the comparative-analysis roadmap (PR #202) merged. Two address a slop critique surfaced after merge; one addresses user-stated privacy/sovereignty concerns about the empty vault folders sitting in the repo.

| FEAT | What | LOC | Wave |
|---|---|---:|---|
| [FEAT-017](plans/git-issues/FEAT-017-classification-prompt-hardening.md) | Classification prompt: few-shot + CoT + calibration + default-unclassified bias | ~600 (splittable) | 2 (on path, before FEAT-004) |
| [FEAT-018](plans/git-issues/FEAT-018-compost-embeddings-llm-upgrade.md) | Compost detector: embeddings + LLM verification (replaces 5-phrase regex) | ~350 | 2 (off path) |
| [FEAT-019](plans/git-issues/FEAT-019-vault-sovereignty-separate-user-vault-from-repo.md) | Vault sovereignty: separate user vault from repo, extend `creek init` | ~500 | 0 (prerequisite, before FEAT-001) |

## What the slop critique was

The reviewing model flagged two real issues post-merge:

1. **`creek/classify/llm.py:54`** — the LLM classifier asks a (default) local Ollama model to pick a 7-dimensional tuple (94,500 combinations) in one shot with **no few-shot examples, no chain-of-thought, no calibration, no human-in-the-loop sample**. Downstream consumers (voice-skill activation, drafts, audit report) treat the YAML response as truth. FEAT-017 closes that gap.

2. **`creek/generate/compost.py:32-37`** — compost detection is matching `"gave up on"`, `"abandoned"`, `"shelved"` as regex against fragment titles. 523 lines of code for hardcoded phrase matching. FEAT-018 replaces with embedding-similarity + LLM verification while keeping compost as an automated feature (per explicit user preference, not retire-to-manual).

## What FEAT-019 fixes

The repo currently contains empty placeholder folders (`01-Fragments/`, `02-Threads/`, etc.) as a structural template. The user's complaint: *"I don't want to check my personal journal fragments into github. And the folders look super weird sitting there empty."*

FEAT-019 deletes the placeholder structure from the repo and extends `creek init --vault <path>` to scaffold the vault topology from canonical templates bundled with `creek-tools/`. `creek init` refuses to init inside a git repo by default (sovereignty guard) — the user has to consciously pick a path outside the repo. Establishes the canonical-vs-deployed split: schema-skill source-of-truth lives in `creek-tools/creek/templates/skills/`, gets deployed by `creek init` and re-deployable via `creek skills sync`.

## Edits to merged-and-in-flight FEATs

FEAT-001 and FEAT-002 reference `00-Creek-Meta/Skills/` and "vault root" as their schema-skill targets. Those locations are now per-vault (deployed) rather than committed-in-repo. Updated both FEATs to make the canonical (in-repo template) vs deployed (per-vault) distinction explicit.

## INDEX.md changes

- Wave 0 (prerequisites) now contains both INC-019 (done) and FEAT-019.
- Wave 2 expanded to include FEAT-017 (on critical path, before FEAT-004) and FEAT-018 (off path).
- Critical path lengthens: **16 sequential PRs** (was 14). Total v1.0: **20 PRs** (was 17).

## Discovery during recon

7 FEATs are already merged (003, 005, 006, 007, 008, 009, 010). The team is well into Waves 2 and 3. FEAT-017 ideally would have landed before FEAT-006 — too late for that. It now sits as a retrofit before FEAT-004 (compiled-layer query routing, in flight) and FEAT-014/015 (CrawDad, future).

## What's not in this PR

- No source code modified.
- Implementation of FEAT-017/018/019 happens in separate PRs (one per FEAT, ≤700 LOC).
- No FEAT for v1.1+ candidates.

## Test plan

- [ ] `ls plans/git-issues/FEAT-01[789]-*.md | wc -l` returns 3.
- [ ] Each FEAT renders cleanly in GitHub markdown.
- [ ] INDEX.md wave tables include FEAT-017/018/019 in the right waves.
- [ ] Updated FEAT-001/002 still parse / render.
- [ ] No source code changed.

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01La83RPcY88EDBk4bqNnhBy)_