### PR TITLE
feat(classify): two-step LLM pipeline + few-shot + unclassified bias (FEAT-017a)

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -37,14 +37,17 @@ import yaml
 
 from creek.classify.constants import (
     CLASSIFICATION_METHOD_KEY,
+    CLASSIFICATION_REASONING_KEY,
+    CLASSIFICATION_REASONING_MAX_CHARS,
     CLASSIFIED_AT_KEY,
+    CLASSIFY_TRACE_LOG_FILENAME,
     LLM_METHOD,
     MANUAL_METHOD,
     RULES_METHOD,
 )
 from creek.classify.llm import LLMClassifier
 from creek.classify.rules import RuleClassifier
-from creek.models import Fragment, Frequency
+from creek.models import Fragment, Frequency, PrivacyTier
 from creek.time import now_la
 from creek.vault.reader import try_load_fragment
 
@@ -55,6 +58,9 @@ Newline-delimited JSON (one ``{"id": ...}`` object per line); the
 ``.jsonl`` suffix signals the format honestly to an operator opening
 the file.
 """
+
+_PROCESSING_LOG_SUBDIR = ("00-Creek-Meta", "Processing-Log")
+"""Per-vault subdirectory carrying the LLM progress + trace logs."""
 
 _RESUMABLE_METHODS: frozenset[str] = frozenset({MANUAL_METHOD, LLM_METHOD})
 
@@ -146,13 +152,15 @@ def run_classify(
     llm = LLMClassifier(config=config.llm) if method == "llm" else None
     counts = _RunCounts()
     progress_path: Path | None = None
+    trace_log_path: Path | None = None
     if method == LLM_METHOD:
-        progress_dir = vault_path / "00-Creek-Meta" / "Processing-Log"
+        progress_dir = vault_path.joinpath(*_PROCESSING_LOG_SUBDIR)
         # Create the directory once, not per fragment — a 10k-fragment
         # vault would otherwise issue 10k redundant ``mkdir`` syscalls
         # in ``_record_llm_progress``.
         progress_dir.mkdir(parents=True, exist_ok=True)
         progress_path = progress_dir / LLM_PROGRESS_FILENAME
+        trace_log_path = progress_dir / CLASSIFY_TRACE_LOG_FILENAME
 
     for md_file in sorted(fragments_root.rglob("*.md")):
         _process_file(
@@ -164,6 +172,7 @@ def run_classify(
             confidence_threshold=config.classification.confidence_threshold,
             counts=counts,
             progress_path=progress_path,
+            trace_log_path=trace_log_path,
         )
 
     return ClassifySummary(
@@ -188,6 +197,7 @@ def _process_file(
     confidence_threshold: float,
     counts: _RunCounts,
     progress_path: Path | None,
+    trace_log_path: Path | None,
 ) -> None:
     """Classify a single fragment file and update ``counts`` in place.
 
@@ -204,6 +214,10 @@ def _process_file(
             successful LLM classification. Manual / rules-shortcircuit
             paths are not appended — only paid LLM calls need to be
             recovered on resume.
+        trace_log_path: Optional path to the FEAT-017 reasoning trace
+            log. When set, ``intimate``-tier fragments route their full
+            reasoning trace here instead of into frontmatter; other
+            tiers store a truncated trace in frontmatter regardless.
     """
     try:
         record = _read_fragment(md_file)
@@ -228,7 +242,7 @@ def _process_file(
         counts.preserved += 1
         return
 
-    new_fragment, was_skipped = _classify_one(
+    new_fragment, was_skipped, reasoning = _classify_one(
         fragment=fragment,
         body=body,
         method=method,
@@ -243,6 +257,12 @@ def _process_file(
     # persisted — we never skip the write, only the LLM call.
     write_method = RULES_METHOD if was_skipped else method
 
+    reasoning_for_frontmatter = _route_reasoning(
+        fragment=new_fragment,
+        reasoning=reasoning,
+        method=write_method,
+        trace_log_path=trace_log_path,
+    )
     try:
         _write_fragment(
             md_file=md_file,
@@ -250,6 +270,7 @@ def _process_file(
             body=body,
             method=write_method,
             raw=raw,
+            reasoning=reasoning_for_frontmatter,
         )
     except OSError as exc:
         counts.errors.append(f"failed to update {md_file}: {exc}")
@@ -269,7 +290,7 @@ def _classify_one(
     rules: RuleClassifier,
     llm: LLMClassifier | None,
     confidence_threshold: float,
-) -> tuple[Fragment, bool]:
+) -> tuple[Fragment, bool, str]:
     """Run the chosen classifier on a single fragment.
 
     Args:
@@ -282,23 +303,108 @@ def _classify_one(
             during ``--method llm`` runs.
 
     Returns:
-        Tuple of ``(updated_fragment, skipped)``. ``skipped`` is
+        ``(updated_fragment, skipped, reasoning)``. ``skipped`` is
         ``True`` when the LLM was not invoked because the rule
-        classifier already produced a confident answer.
+        classifier already produced a confident answer. ``reasoning``
+        is the LLM's reasoning trace (FEAT-017); empty string for the
+        rules path or when the LLM produced no preamble.
     """
     if method == "rules":
-        return rules.classify(fragment, content=body), False
+        return rules.classify(fragment, content=body), False, ""
 
     rule_result = rules.classify(fragment, content=body)
     if rule_result.frequency.primary != Frequency.UNCLASSIFIED:
         confidence = rules.confidence_score(rule_result, content=body)
         if confidence >= confidence_threshold:
-            return rule_result, True
+            return rule_result, True, ""
 
     if llm is None:  # pragma: no cover  # no issue: defensive guard, unreachable
         msg = "LLM classifier required when method='llm'"
         raise RuntimeError(msg)
-    return llm.classify(rule_result, content=body), False
+    llm_result = llm.classify_with_reasoning(rule_result, content=body)
+    return llm_result.fragment, False, llm_result.reasoning
+
+
+def _route_reasoning(
+    *,
+    fragment: Fragment,
+    reasoning: str,
+    method: str,
+    trace_log_path: Path | None,
+) -> str:
+    """Persist the LLM reasoning trace per FEAT-017 tier-routing rules.
+
+    For ``intimate``-tier fragments the full reasoning is appended to
+    ``trace_log_path`` (gitignored per FEAT-019) and the frontmatter
+    receives an empty string — keeping intimate model traces out of
+    files that may be synced or shared. For all other tiers the trace
+    is truncated to :data:`CLASSIFICATION_REASONING_MAX_CHARS` and
+    returned for direct embedding in frontmatter.
+
+    Args:
+        fragment: The fragment whose tier dictates routing.
+        reasoning: The raw reasoning preamble; may be empty.
+        method: ``"rules"`` (no-op routing), ``"llm"``, or
+            ``"manual"``.
+        trace_log_path: Destination for intimate-tier full traces.
+
+    Returns:
+        The string the engine should store in
+        ``classification_reasoning`` frontmatter. Empty when there is
+        no reasoning to persist (rules path) or the fragment is
+        intimate (the full trace goes to the log file instead).
+    """
+    if method != LLM_METHOD or not reasoning:
+        return ""
+    if fragment.privacy_tier == PrivacyTier.INTIMATE.value:
+        if trace_log_path is not None:
+            _append_trace_log(trace_log_path, fragment, reasoning)
+        return ""
+    return _truncate_reasoning(reasoning)
+
+
+def _truncate_reasoning(text: str) -> str:
+    """Truncate *text* to :data:`CLASSIFICATION_REASONING_MAX_CHARS`.
+
+    The truncation marker is a single ``…`` so a downstream reader can
+    tell the trace was cropped without parsing the byte length.
+    """
+    if len(text) <= CLASSIFICATION_REASONING_MAX_CHARS:
+        return text
+    return text[: CLASSIFICATION_REASONING_MAX_CHARS - 1] + "…"
+
+
+def _append_trace_log(
+    trace_log_path: Path,
+    fragment: Fragment,
+    reasoning: str,
+) -> None:
+    """Append a full reasoning trace to the intimate-tier log file.
+
+    Failing to write the trace is logged at ``WARNING`` and the
+    classification proceeds — losing the log entry costs observability,
+    never a re-classification.
+
+    Args:
+        trace_log_path: Destination JSONL file.
+        fragment: Source fragment for the ID + tier in the record.
+        reasoning: Full reasoning text (un-truncated).
+    """
+    record = {
+        "id": fragment.id,
+        "tier": fragment.privacy_tier,
+        "reasoning": reasoning,
+    }
+    try:
+        with trace_log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record) + "\n")
+    except OSError as exc:
+        logger.warning(
+            "[fragment=%s trace=%s] Could not append to classify-trace log: %s",
+            fragment.id,
+            trace_log_path,
+            exc,
+        )
 
 
 def _read_fragment(md_file: Path) -> tuple[Fragment, str, dict[str, object]] | None:
@@ -335,12 +441,17 @@ def _write_fragment(
     body: str,
     method: str,
     raw: dict[str, object],
+    reasoning: str,
 ) -> None:
     """Persist updated fragment metadata back to its file.
 
     Preserves the existing classification provenance keys so that
     ``classified_at`` reflects the most recent update and the prior
-    ``method`` is replaced.
+    ``method`` is replaced. The reasoning trace (FEAT-017) is stored
+    in :data:`creek.classify.constants.CLASSIFICATION_REASONING_KEY`
+    when non-empty, and removed from the frontmatter otherwise so an
+    intimate-tier fragment never inherits a stale trace from a
+    previous run at a different tier.
 
     Args:
         md_file: Destination file (rewritten in place).
@@ -349,6 +460,9 @@ def _write_fragment(
         method: ``"rules"``, ``"llm"``, or ``"manual"``.
         raw: Original frontmatter dict — used to preserve any
             non-Fragment keys (e.g. operator-applied tags).
+        reasoning: Per-FEAT-017 ``classification_reasoning`` value
+            already truncated / tier-routed by :func:`_route_reasoning`.
+            Empty string clears the field on disk.
     """
     new_metadata = dict(raw)
     new_metadata.update(fragment.model_dump(mode="json"))
@@ -358,6 +472,10 @@ def _write_fragment(
     # timestamp written to disk uses the same code path as every
     # other LA-anchored timestamp in the pipeline.
     new_metadata[CLASSIFIED_AT_KEY] = now_la().isoformat()
+    if reasoning:
+        new_metadata[CLASSIFICATION_REASONING_KEY] = reasoning
+    else:
+        new_metadata.pop(CLASSIFICATION_REASONING_KEY, None)
 
     post = frontmatter.Post(content=body, **new_metadata)
     md_file.write_text(frontmatter.dumps(post), encoding="utf-8")

--- a/creek-tools/creek/classify/constants.py
+++ b/creek-tools/creek/classify/constants.py
@@ -27,3 +27,30 @@ RULES_METHOD: Final[str] = "rules"
 
 LLM_METHOD: Final[str] = "llm"
 """``classification_method`` value emitted by the LLM classifier."""
+
+CLASSIFICATION_REASONING_KEY: Final[str] = "classification_reasoning"
+"""Frontmatter key carrying the truncated LLM reasoning trace (FEAT-017).
+
+Populated only by ``--method llm`` runs. ``open`` and ``personal``
+fragments store a 400-char truncation here for auditability; ``intimate``
+fragments persist an empty string and route the full trace to the
+gitignored trace log instead (see :data:`CLASSIFY_TRACE_LOG_FILENAME`).
+"""
+
+CLASSIFICATION_REASONING_MAX_CHARS: Final[int] = 400
+"""Maximum characters of LLM reasoning persisted to fragment frontmatter.
+
+Longer traces are routed to the trace log instead so neither the
+fragment file nor downstream renderers (Obsidian preview, MCP
+endpoints) have to handle multi-kilobyte provenance strings inline.
+"""
+
+CLASSIFY_TRACE_LOG_FILENAME: Final[str] = "classify-llm-trace.jsonl"
+"""Per-vault trace log filename (under ``00-Creek-Meta/Processing-Log/``).
+
+Newline-delimited JSON, one record per LLM classification, carrying
+``{id, tier, reasoning}``. For ``intimate`` fragments this is the
+**only** place the reasoning trace lives — it never enters the
+fragment's frontmatter. The log is gitignored (FEAT-019) so vault
+sharing does not leak intimate-tier model traces.
+"""

--- a/creek-tools/creek/classify/examples/__init__.py
+++ b/creek-tools/creek/classify/examples/__init__.py
@@ -1,0 +1,10 @@
+"""Few-shot example fixtures for LLM classification (FEAT-017).
+
+Each ``<dimension>.yaml`` file in this package holds a list of
+``{title, body, label, rationale}`` entries used by
+:mod:`creek.classify.few_shot` to build rotating few-shot prompts.
+
+The files are shipped with the wheel via ``[tool.setuptools.package-data]``
+so installed copies of ``creek-tools`` can build the same prompt as a
+source checkout.
+"""

--- a/creek-tools/creek/classify/examples/dosage.yaml
+++ b/creek-tools/creek/classify/examples/dosage.yaml
@@ -1,0 +1,27 @@
+# Few-shot examples for Dosage (Medicine vs Toxic vs Ambiguous).
+# Dosages: medicine | toxic | ambiguous
+- title: Long walk after the hard call
+  body: I needed to move my body and not talk to anyone. By the second mile I had
+    stopped replaying the conversation in my head.
+  label: medicine
+  rationale: The frequency-expression genuinely metabolised the difficulty.
+- title: Doom-scrolling at midnight
+  body: I told myself I was staying informed. Three hours in I was just
+    accelerating the dread.
+  label: toxic
+  rationale: The frequency-expression amplified harm rather than processed it.
+- title: Drink with old colleagues
+  body: It was warm and familiar and I felt seen. I also said things I would
+    not have said sober and woke up uneasy.
+  label: ambiguous
+  rationale: Medicine and toxicity present simultaneously; do not collapse to one.
+- title: Quiet morning with the journal
+  body: I wrote three pages of nonsense and then the actual thing I have been
+    avoiding finally came out.
+  label: medicine
+  rationale: Practice produced honest contact; the expression did its work.
+- title: Picking the fight again
+  body: I knew where it would go before I said the first sentence. I said it
+    anyway, and we both lost the evening.
+  label: toxic
+  rationale: Repeating a known-harmful pattern; the dosage was wrong.

--- a/creek-tools/creek/classify/examples/frequency.yaml
+++ b/creek-tools/creek/classify/examples/frequency.yaml
@@ -1,0 +1,52 @@
+# Few-shot examples for APTITUDE frequency classification (F1..F10).
+# Each entry: title (short), body (representative excerpt), label (one of F1..F10), rationale (why).
+- title: Locked out again
+  body: My keys are gone and I cannot get into the apartment tonight. Stomach is in
+    a knot. I keep checking my pockets like that will change something.
+  label: F1
+  rationale: Bodily safety and shelter rupture; survival texture, not strategy.
+- title: Team retro
+  body: We circled the same complaint three times and never landed. People want to
+    belong to a competent group more than they want to be right.
+  label: F2
+  rationale: Tribal-belonging concern; whose group, whose loyalty.
+- title: Saying no to the contract
+  body: I am the one with the authority to walk away. If I do not exercise it now,
+    I never will.
+  label: F3
+  rationale: Power and agency over a decision; F3 is about owning the choice.
+- title: Inbox triage rules
+  body: I need three folders, a daily clearing time, and a hard rule about not
+    checking after 7pm. Order will save me here.
+  label: F4
+  rationale: Order and structure as the medicine for the problem.
+- title: Roadmap stake
+  body: If the launch slips past Q3 the whole funding round shifts. I have to plan
+    backwards from the demo date.
+  label: F5
+  rationale: Achievement and strategy under a deadline; explicit goal framing.
+- title: Sitting with grief
+  body: She just needed someone to be in the room while she cried. I did not try
+    to fix anything.
+  label: F6
+  rationale: Community and empathy without a fix; presence as the gift.
+- title: Wiring two services
+  body: The auth proxy and the billing API have to agree on the customer ID space.
+    The whole system breaks otherwise.
+  label: F7
+  rationale: Integration of multiple systems; thinking in interfaces.
+- title: Watershed walk
+  body: The creek I grew up beside is gone. The aquifer it fed is the same one
+    under the new development.
+  label: F8
+  rationale: Ecological holism; the personal and the planetary as one body.
+- title: Just watching
+  body: I sat on the back step and the cat came over. I did not need anything
+    to happen.
+  label: F9
+  rationale: Witness mode, being rather than doing.
+- title: One thing
+  body: There is no separation between the dishwasher humming and the question
+    I am sitting with.
+  label: F10
+  rationale: Non-dual, unity texture; F10 collapses subject and object.

--- a/creek-tools/creek/classify/examples/mode.yaml
+++ b/creek-tools/creek/classify/examples/mode.yaml
@@ -1,0 +1,27 @@
+# Few-shot examples for engagement Mode.
+# Modes: inhabit | express | collaborate | integrate | absorb
+- title: Just being with the grief
+  body: I did not journal it or talk it out. I let it be there with me and went
+    about the day with it close.
+  label: inhabit
+  rationale: Inside the felt experience without externalising; living-in.
+- title: Speaking the speech
+  body: I wrote the keynote in one sitting, said it out loud twice, then walked
+    onstage and delivered it as written.
+  label: express
+  rationale: Outward articulation of an internal state; voice-forward.
+- title: Working out a design with R
+  body: We sketched the schema on a napkin, took turns poking holes, and now we
+    both know what we are building.
+  label: collaborate
+  rationale: Joint construction with a peer; neither person alone produced it.
+- title: After the workshop
+  body: I am chewing on what L said about boundaries. It connects to the therapy
+    homework and to the disagreement I had at work last week.
+  label: integrate
+  rationale: Cross-context synthesis; pulling threads together internally.
+- title: Reading without taking notes
+  body: I read the chapter, set the book down, and let it sit. I do not want to
+    summarise it. I want it to soak.
+  label: absorb
+  rationale: Receptive uptake; no output, no analysis, just intake.

--- a/creek-tools/creek/classify/examples/phase.yaml
+++ b/creek-tools/creek/classify/examples/phase.yaml
@@ -1,0 +1,32 @@
+# Few-shot examples for Archetypal Wavelength phase.
+# Phases: rising | peaking | withdrawal | diminishing | bottoming_out | restoration
+- title: New project gathering momentum
+  body: I cannot wait to start. The ideas are stacking faster than I can write
+    them down and every conversation feeds the next.
+  label: rising
+  rationale: Energy accelerating into commitment; novelty-fuelled lift.
+- title: Launch week
+  body: We are in it. The product is live, calls are nonstop, every decision
+    matters and nothing waits.
+  label: peaking
+  rationale: Top of the curve; full output, no slack.
+- title: I need to step back
+  body: I have been sprinting for a month and I can feel the diminishing returns.
+    I am going to cancel two meetings tomorrow and just think.
+  label: withdrawal
+  rationale: Conscious pulling-back at the top of the curve, not collapse.
+- title: Losing interest in the side project
+  body: The same code that lit me up in January feels like homework now. I am not
+    sure I have anything more to say about it.
+  label: diminishing
+  rationale: Voluntary or involuntary decline of energy and meaning.
+- title: I cannot move
+  body: I have been on the couch for three days. The work is undone, my partner
+    is patient, and I am still flat.
+  label: bottoming_out
+  rationale: Trough; flatness without obvious cause or path back.
+- title: Slow walk after the fever
+  body: I made tea and read one chapter and went to bed early. Small things felt
+    like enough, which is new.
+  label: restoration
+  rationale: Coming back online gently; capacity returning before activity does.

--- a/creek-tools/creek/classify/examples/register.yaml
+++ b/creek-tools/creek/classify/examples/register.yaml
@@ -1,0 +1,38 @@
+# Few-shot examples for Voice Register.
+# Registers: confessional | analytical | playful | prophetic | instructional | raw | conversational
+- title: What I have not told anyone
+  body: I have been afraid of this for months and I have not said it out loud.
+    I am saying it now because the silence is heavier than the truth.
+  label: confessional
+  rationale: First-person disclosure of a withheld interior; vulnerability is the
+    point.
+- title: Why the rollout failed
+  body: Three factors compounded. The dependency graph had a cycle, the
+    rollback path was untested, and the on-call rota had a gap.
+  label: analytical
+  rationale: Dispassionate breakdown of causes; structure over feeling.
+- title: The cat negotiations
+  body: She wants the chair, I want the chair, the chair has opinions about who
+    deserves the chair. Diplomacy is ongoing.
+  label: playful
+  rationale: Lightness and wordplay; the form is the texture.
+- title: What the next decade demands
+  body: The systems we built will not survive the conditions we built them for.
+    We will either rebuild them or be rebuilt by what comes.
+  label: prophetic
+  rationale: Future-tense, declarative, weight-bearing; not a forecast, a call.
+- title: How to set up the dev env
+  body: Clone the repo. Run ./scripts/setup.sh. Source the venv. If pre-commit
+    fails, run pre-commit install once and try again.
+  label: instructional
+  rationale: Imperative, sequential, transferable; pedagogy is the point.
+- title: It is two in the morning
+  body: Everything I write tonight is going to be wrong. I am writing anyway
+    because I cannot sleep and the inside of my head will not be quiet.
+  label: raw
+  rationale: Unfiltered, unedited, present-tense affect.
+- title: Coffee with M
+  body: We caught up. She is well. I told her about the move and she laughed
+    in the good way.
+  label: conversational
+  rationale: Companionable, low-stakes, register of catching up.

--- a/creek-tools/creek/classify/few_shot.py
+++ b/creek-tools/creek/classify/few_shot.py
@@ -1,0 +1,244 @@
+"""Few-shot example loading and prompt assembly for LLM classification (FEAT-017).
+
+The bundled ``creek/classify/examples/<dimension>.yaml`` fixtures hold
+hand-curated example fragments for each classification dimension
+(frequency, phase, mode, dosage, register). This module loads them
+once, samples a deterministic-per-fragment subset, and renders them
+into the prompt block injected before the request itself.
+
+A stable hash of the fragment ID seeds the sample so the same fragment
+always sees the same few-shot block (reproducible classifications)
+while different fragments rotate through the corpus (broader coverage
+across a vault).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import random
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
+from typing import Final
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+DIMENSIONS: Final[tuple[str, ...]] = (
+    "frequency",
+    "phase",
+    "mode",
+    "dosage",
+    "register",
+)
+"""Classification dimensions backed by example fixtures."""
+
+EXAMPLES_PER_DIMENSION: Final[int] = 3
+"""Examples included per dimension in a rendered few-shot block.
+
+Three keeps the prompt under the ~12 KiB ceiling even with body
+truncation while still showing the model multiple cases per axis.
+"""
+
+_RESOURCES_PACKAGE: Final[str] = "creek.classify.examples"
+_BODY_CAP_CHARS: Final[int] = 240
+"""Characters retained from each example body before injection.
+
+Caps the prompt growth from few-shot examples so a long body in a
+fixture cannot push the full prompt past
+:data:`creek.classify.llm._MAX_PROMPT_CONTENT_CHARS` and crowd out the
+actual fragment being classified.
+"""
+
+
+@dataclass(frozen=True)
+class FewShotExample:
+    """A single labelled example for the few-shot prompt block.
+
+    Attributes:
+        title: Short headline of the example fragment.
+        body: Representative excerpt (capped at
+            :data:`_BODY_CAP_CHARS` when rendered).
+        label: Canonical enum value for the dimension this example
+            illustrates (e.g. ``"F3"`` for frequency, ``"rising"`` for
+            phase).
+        rationale: One-sentence explanation of why this label fits;
+            shown to the model so the reasoning pattern is part of the
+            example, not just the answer.
+    """
+
+    title: str
+    body: str
+    label: str
+    rationale: str
+
+
+@lru_cache(maxsize=1)
+def _load_all_examples() -> dict[str, tuple[FewShotExample, ...]]:
+    """Load every dimension's fixture file into immutable tuples.
+
+    Cached so the YAML round-trip happens at most once per process.
+
+    Returns:
+        Mapping ``{dimension: (example, ...)}`` for every dimension in
+        :data:`DIMENSIONS`. Missing or empty files are reported as a
+        warning and yield an empty tuple — the prompt builder will
+        silently skip dimensions with no examples rather than fail
+        classification.
+    """
+    loaded: dict[str, tuple[FewShotExample, ...]] = {}
+    for dim in DIMENSIONS:
+        try:
+            raw = (
+                resources.files(_RESOURCES_PACKAGE)
+                .joinpath(f"{dim}.yaml")
+                .read_text(
+                    encoding="utf-8",
+                )
+            )
+        except (FileNotFoundError, ModuleNotFoundError) as exc:
+            logger.warning("Few-shot fixture for %s not found: %s", dim, exc)
+            loaded[dim] = ()
+            continue
+        parsed = yaml.safe_load(raw) or []
+        if not isinstance(parsed, list):
+            logger.warning("Few-shot fixture %s.yaml is not a list; ignoring", dim)
+            loaded[dim] = ()
+            continue
+        loaded[dim] = tuple(_coerce(entry) for entry in parsed if _is_valid(entry))
+    return loaded
+
+
+def _is_valid(entry: object) -> bool:
+    """Return ``True`` when *entry* is a dict carrying all required keys."""
+    if not isinstance(entry, dict):
+        return False
+    return all(
+        isinstance(entry.get(k), str) for k in ("title", "body", "label", "rationale")
+    )
+
+
+def _coerce(entry: object) -> FewShotExample:
+    """Convert a validated dict to :class:`FewShotExample`.
+
+    Args:
+        entry: Already validated by :func:`_is_valid` immediately
+            before this call. Re-checked here so the type narrowing
+            survives without an ``assert``.
+
+    Returns:
+        Immutable example record.
+
+    Raises:
+        TypeError: If *entry* is not a mapping. Should be unreachable
+            because :func:`_is_valid` is the only gate.
+    """
+    if not isinstance(entry, dict):
+        msg = "_coerce called with non-dict entry"
+        raise TypeError(msg)
+    return FewShotExample(
+        title=str(entry["title"]),
+        body=str(entry["body"]),
+        label=str(entry["label"]),
+        rationale=str(entry["rationale"]),
+    )
+
+
+def examples_for(dimension: str) -> tuple[FewShotExample, ...]:
+    """Return every example fixture for *dimension*.
+
+    Args:
+        dimension: One of :data:`DIMENSIONS`.
+
+    Returns:
+        The dimension's full example tuple, or an empty tuple if the
+        dimension is unknown.
+    """
+    return _load_all_examples().get(dimension, ())
+
+
+def _seed_for(fragment_id: str) -> int:
+    """Compute a stable integer seed from a fragment ID.
+
+    Args:
+        fragment_id: Stable per-fragment identifier (e.g. ``frag-abc123``).
+
+    Returns:
+        Non-negative integer suitable for seeding :mod:`random`.
+    """
+    digest = hashlib.sha256(fragment_id.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], byteorder="big", signed=False)
+
+
+def sample_examples(
+    fragment_id: str,
+    *,
+    per_dimension: int = EXAMPLES_PER_DIMENSION,
+) -> dict[str, tuple[FewShotExample, ...]]:
+    """Pick a deterministic-per-fragment sample of examples for each dimension.
+
+    The sample is identical across repeated calls for the same
+    ``fragment_id`` (so re-classifying a fragment uses the same
+    examples) but varies across fragment IDs so a vault as a whole
+    rotates through the available fixture corpus.
+
+    Args:
+        fragment_id: Stable per-fragment identifier; seeds the
+            random sample so the choice is deterministic per fragment.
+        per_dimension: Maximum examples per dimension. Capped at the
+            number of fixtures available for the dimension.
+
+    Returns:
+        Mapping ``{dimension: (example, ...)}`` with at most
+        ``per_dimension`` entries per dimension, in randomised order.
+    """
+    # The seed is a deterministic hash of the fragment ID. The PRNG is
+    # used only to rotate example fixtures across a vault — never for
+    # security-sensitive choices — so the standard ``random.Random``
+    # is appropriate here.
+    rng = random.Random(_seed_for(fragment_id))  # nosec B311
+    chosen: dict[str, tuple[FewShotExample, ...]] = {}
+    for dim, pool in _load_all_examples().items():
+        if not pool:
+            chosen[dim] = ()
+            continue
+        size = min(per_dimension, len(pool))
+        chosen[dim] = tuple(rng.sample(pool, size))
+    return chosen
+
+
+def render_block(samples: dict[str, tuple[FewShotExample, ...]]) -> str:
+    """Render a sampled few-shot block as plain prompt text.
+
+    The block uses dimension headings and one ``- title / label /
+    rationale / body`` quad per example. Bodies are truncated to
+    :data:`_BODY_CAP_CHARS` so a long fixture cannot starve the prompt
+    of room for the actual fragment.
+
+    Args:
+        samples: Output of :func:`sample_examples`.
+
+    Returns:
+        Multi-line prompt block. Empty string if no samples have any
+        examples (e.g. fixtures absent at runtime).
+    """
+    lines: list[str] = []
+    for dim in DIMENSIONS:
+        chosen = samples.get(dim, ())
+        if not chosen:
+            continue
+        lines.append(f"## {dim.title()} examples")
+        for ex in chosen:
+            body = (
+                ex.body
+                if len(ex.body) <= _BODY_CAP_CHARS
+                else ex.body[:_BODY_CAP_CHARS] + "…"
+            )
+            lines.append(f"- title: {ex.title}")
+            lines.append(f"  label: {ex.label}")
+            lines.append(f"  rationale: {ex.rationale}")
+            lines.append(f"  body: {body}")
+        lines.append("")
+    return "\n".join(lines).rstrip()

--- a/creek-tools/creek/classify/llm.py
+++ b/creek-tools/creek/classify/llm.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import time
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -27,6 +28,8 @@ from typing import TYPE_CHECKING, TypeVar
 import httpx
 import yaml
 from tqdm import tqdm
+
+from creek.classify import few_shot
 
 if TYPE_CHECKING:
     import anthropic
@@ -76,8 +79,22 @@ instructional, raw, conversational
 
 7. **Confidence**: musing, exploring, forming, settled, conviction
 
-Respond ONLY with valid YAML in this exact format (no extra text):
+A few labelled examples (do not include these in your YAML output):
 
+{examples}
+
+Two-step protocol (FEAT-017):
+
+Step 1 — Reason briefly. Walk through which frequency this most resonates
+with and why, then which phase, then which mode, orientation, and dosage,
+and finally the voice register. Two to four short sentences total.
+
+Step 2 — Emit your classification as valid YAML inside a fenced
+```yaml ... ``` block. The YAML must follow this exact schema (do not
+include any other keys; ``confidence_scores`` reports how certain you
+are about each gated dimension, on a 0.0-1.0 scale):
+
+```yaml
 frequency:
   primary: F3
   secondary: [F5]
@@ -89,12 +106,32 @@ wavelength:
 voice:
   voice_register: analytical
   confidence: forming
+confidence_scores:
+  mode: 0.7
+  orientation: 0.7
+  dosage: 0.7
+```
+
+If a dimension is genuinely unclear, set ``unclassified`` rather than
+guessing. For Mode / Orientation / Dosage we will treat any
+``confidence_scores`` entry below {threshold:.2f} as ``unclassified``,
+so calibrate honestly.
 
 Fragment title: {title}
 Fragment content:
 {content}
 """
-"""Prompt template for LLM-based fragment classification."""
+"""Prompt template for two-step LLM-based fragment classification (FEAT-017).
+
+Placeholders:
+
+- ``{examples}``: rendered few-shot block from :mod:`creek.classify.few_shot`.
+- ``{threshold}``: ``LLMConfig.unclassified_threshold`` (decimal, two
+  decimals) shown to the model so honesty about uncertainty is
+  rewarded rather than penalised.
+- ``{title}``, ``{content}``: the fragment being classified, after
+  :func:`_sanitise_for_prompt` neutralises injection vectors.
+"""
 
 _DOSAGE_AMBIGUOUS_MARKERS: frozenset[str] = frozenset(
     {
@@ -109,13 +146,15 @@ _DOSAGE_AMBIGUOUS_MARKERS: frozenset[str] = frozenset(
 
 
 _ALLOWED_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
-    {"frequency", "wavelength", "voice"},
+    {"frequency", "wavelength", "voice", "confidence_scores"},
 )
 """Top-level keys recognised in a documented LLM classification response.
 
-Mirrors the three sections in :data:`CLASSIFICATION_PROMPT`. Update
-both when adding a new classification dimension — ``validate_response``
-will otherwise reject the LLM's output as unexpected.
+Mirrors the sections in :data:`CLASSIFICATION_PROMPT`. ``confidence_scores``
+was added by FEAT-017 to carry per-dimension self-reported confidence
+for the default-unclassified bias on Mode / Orientation / Dosage.
+Update both when adding a new section — ``validate_response`` will
+otherwise reject the LLM's output as unexpected.
 """
 
 
@@ -159,6 +198,72 @@ def _sanitise_for_prompt(text: str) -> str:
     if len(cleaned) > _MAX_PROMPT_CONTENT_CHARS:
         cleaned = cleaned[:_MAX_PROMPT_CONTENT_CHARS]
     return cleaned
+
+
+_BIASED_DIMENSIONS: frozenset[str] = frozenset({"mode", "orientation", "dosage"})
+"""Dimensions gated by ``LLMConfig.unclassified_threshold`` (FEAT-017).
+
+Frequency, Phase, and Voice Register are not biased because they are
+more stable signals empirically; using them is the point of having an
+LLM pass at all.
+"""
+
+_YAML_FENCE_RE: re.Pattern[str] = re.compile(
+    r"```(?:yaml)?\s*\n(.*?)```",
+    flags=re.DOTALL,
+)
+"""Match a fenced YAML block; group 1 is the inner YAML text."""
+
+_YAML_HEAD_RE: re.Pattern[str] = re.compile(
+    r"^(frequency|wavelength|voice):", re.MULTILINE
+)
+"""Match the start of an unfenced YAML payload (a documented top-level key)."""
+
+
+def _split_reasoning_and_yaml(response: str) -> tuple[str, str]:
+    r"""Split a two-step LLM response into reasoning preamble and YAML payload.
+
+    Tolerates three response shapes the model produces in practice:
+
+    1. A fenced ``\`\`\`yaml ... \`\`\`\`` block preceded by reasoning prose.
+    2. Reasoning prose followed by bare YAML starting at column 0.
+    3. Pure YAML with no reasoning (backwards-compat with the
+       pre-FEAT-017 prompt).
+
+    Args:
+        response: Raw LLM response text.
+
+    Returns:
+        ``(reasoning, yaml_text)``. ``reasoning`` is the stripped
+        preamble, possibly empty. ``yaml_text`` is the YAML block,
+        with code fences stripped if present.
+    """
+    fenced = _YAML_FENCE_RE.search(response)
+    if fenced is not None:
+        return response[: fenced.start()].strip(), fenced.group(1).strip()
+    head = _YAML_HEAD_RE.search(response)
+    if head is not None:
+        return response[: head.start()].strip(), response[head.start() :].strip()
+    return "", response.strip()
+
+
+@dataclass(frozen=True)
+class LLMClassificationResult:
+    """Outcome of a single FEAT-017 two-step classification call.
+
+    Attributes:
+        fragment: The fragment with updated classification fields.
+            When the call short-circuits (provider unavailable, retries
+            exhausted), this is the input fragment unchanged.
+        reasoning: Reasoning preamble emitted by the model before the
+            YAML payload. Empty when the model produced pure YAML (the
+            pre-FEAT-017 response shape) or the call short-circuited.
+            Truncation / tier-routing is the engine's responsibility,
+            not this dataclass's — the raw trace lives here.
+    """
+
+    fragment: Fragment
+    reasoning: str
 
 
 @dataclass
@@ -545,13 +650,20 @@ class LLMClassifier:
         fragment: Fragment,
         content: str = "",
     ) -> str:
-        """Build the classification prompt for a fragment.
+        """Build the FEAT-017 two-step classification prompt for a fragment.
 
         The fragment title and content are attacker-controlled (they
         originate from third-party messages, scraped material, etc.).
         Each is passed through :func:`_sanitise_for_prompt` to neutralise
         YAML-fence and HTML-comment injection and to cap the body length
         before substitution — see SEC-004.
+
+        A deterministic-per-fragment few-shot block is rendered from
+        :mod:`creek.classify.few_shot` and substituted into the
+        ``{examples}`` placeholder so the model sees worked examples
+        before classifying the new fragment. The threshold value is
+        shown to the model so it has an incentive to report honest
+        per-dimension confidence rather than pad numbers up.
 
         Args:
             fragment: The fragment to classify.
@@ -563,7 +675,11 @@ class LLMClassifier:
         safe_title = _sanitise_for_prompt(fragment.title)
         body = content if content else "(no content provided)"
         safe_content = _sanitise_for_prompt(body)
+        samples = few_shot.sample_examples(fragment.id)
+        examples_block = few_shot.render_block(samples) or "(no examples bundled)"
         return CLASSIFICATION_PROMPT.format(
+            examples=examples_block,
+            threshold=self.config.unclassified_threshold,
             title=safe_title,
             content=safe_content,
         )
@@ -647,7 +763,11 @@ class LLMClassifier:
         """
         updates: dict[str, object] = {}
         _apply_frequency(data, updates)
-        _apply_wavelength(data, updates)
+        _apply_wavelength(
+            data,
+            updates,
+            unclassified_threshold=self.config.unclassified_threshold,
+        )
         _apply_voice(data, updates)
         if not updates:
             return fragment
@@ -660,11 +780,12 @@ class LLMClassifier:
     ) -> Fragment:
         """Classify a fragment using the configured LLM provider.
 
-        Builds a prompt, dispatches it to the configured provider (Ollama
-        or Anthropic), parses the YAML response, and updates the
-        fragment.  Retries on failure up to ``MAX_RETRIES`` times.
-        Returns the fragment unchanged if the provider is unavailable
-        or all retries are exhausted.
+        Back-compat wrapper around :meth:`classify_with_reasoning` that
+        drops the reasoning trace. Existing callers that only need the
+        Fragment continue to work unchanged. New callers (e.g. the
+        classification engine in :mod:`creek.classify.classify_engine`)
+        should call :meth:`classify_with_reasoning` so the reasoning
+        can be persisted alongside the classification.
 
         Args:
             fragment: The fragment to classify.
@@ -673,20 +794,50 @@ class LLMClassifier:
         Returns:
             The fragment with updated classification fields.
         """
+        return self.classify_with_reasoning(fragment, content).fragment
+
+    def classify_with_reasoning(
+        self,
+        fragment: Fragment,
+        content: str = "",
+    ) -> LLMClassificationResult:
+        """Run the FEAT-017 two-step pipeline and return Fragment + reasoning.
+
+        Builds the two-step prompt, dispatches it to the configured
+        provider (Ollama or Anthropic), splits the response into a
+        reasoning preamble and YAML payload, parses the YAML, and
+        applies the classification. Retries on failure up to
+        ``MAX_RETRIES`` times. Returns the fragment unchanged with an
+        empty reasoning trace if the provider is unavailable or all
+        retries are exhausted.
+
+        Args:
+            fragment: The fragment to classify.
+            content: Optional content text for the fragment.
+
+        Returns:
+            :class:`LLMClassificationResult` carrying the updated
+            fragment and the raw reasoning trace (empty when the call
+            short-circuited or the model returned pure YAML).
+        """
         if not self.available:
             logger.warning(
                 "LLM provider unavailable — returning fragment '%s' unchanged",
                 fragment.title,
             )
-            return fragment
+            return LLMClassificationResult(fragment=fragment, reasoning="")
 
         prompt = self._build_prompt(fragment, content)
 
         for attempt in range(self.MAX_RETRIES):
             try:
                 raw = self._invoke_llm(prompt)
-                data = self.validate_response(raw)
-                return self._apply_classification(fragment, data)
+                reasoning, yaml_text = _split_reasoning_and_yaml(raw)
+                data = self.validate_response(yaml_text)
+                return LLMClassificationResult(
+                    fragment=self._apply_classification(fragment, data),
+                    reasoning=reasoning,
+                )
             except (
                 httpx.HTTPError,
                 RuntimeError,
@@ -719,7 +870,7 @@ class LLMClassifier:
             self.MAX_RETRIES,
             fragment.title,
         )
-        return fragment
+        return LLMClassificationResult(fragment=fragment, reasoning="")
 
     def classify_batch(
         self,
@@ -851,37 +1002,122 @@ def _apply_frequency(
     )
 
 
+def _confidence_score(scores: object, dimension: str) -> float | None:
+    """Return the per-dimension confidence value from a ``confidence_scores`` map.
+
+    Args:
+        scores: The ``confidence_scores`` value from the parsed YAML
+            (any type — the LLM may emit garbage).
+        dimension: ``"mode"``, ``"orientation"``, or ``"dosage"``.
+
+    Returns:
+        The float in ``[0.0, 1.0]`` when reported and parseable, else
+        ``None`` (treated by the bias as "no score reported — keep
+        the model's pick").
+    """
+    if not isinstance(scores, dict):
+        return None
+    value = scores.get(dimension)
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
 def _apply_wavelength(
     data: dict[str, object],
     updates: dict[str, object],
+    *,
+    unclassified_threshold: float,
 ) -> None:
-    """Extract wavelength classification from parsed data.
+    """Extract wavelength classification from parsed data with FEAT-017 bias.
+
+    Mode, Orientation, and Dosage are downgraded to ``unclassified``
+    when the model's self-reported per-dimension confidence (read from
+    ``data['confidence_scores'][dimension]``) is below
+    ``unclassified_threshold``. A missing or unparseable score leaves
+    the model's pick intact — the bias only fires when the model
+    explicitly reports low confidence.
+
+    Phase is **not** gated by the bias (FEAT-017 calls phase a stable
+    signal; gating it would be more cost than benefit).
 
     Args:
         data: Parsed LLM response.
         updates: Dict to populate with wavelength updates.
+        unclassified_threshold: Minimum confidence to keep the model's
+            pick for Mode / Orientation / Dosage; below this the
+            dimension defaults to ``unclassified``.
     """
     wave_data = data.get("wavelength")
     if not isinstance(wave_data, dict):
         return
+    scores = data.get("confidence_scores")
     updates["wavelength"] = WavelengthClassification(
-        phase=_parse_enum(
-            wave_data.get("phase"),
-            Phase,
-            Phase.UNCLASSIFIED,
-        ),
-        mode=_parse_enum(
+        phase=_parse_enum(wave_data.get("phase"), Phase, Phase.UNCLASSIFIED),
+        mode=_biased_enum(
             wave_data.get("mode"),
             Mode,
             Mode.UNCLASSIFIED,
+            score=_confidence_score(scores, "mode"),
+            threshold=unclassified_threshold,
         ),
-        orientation=_parse_enum(
+        orientation=_biased_enum(
             wave_data.get("orientation"),
             Orientation,
             Orientation.UNCLASSIFIED,
+            score=_confidence_score(scores, "orientation"),
+            threshold=unclassified_threshold,
         ),
-        dosage=_parse_dosage(wave_data.get("dosage")),
+        dosage=_biased_dosage(
+            wave_data.get("dosage"),
+            score=_confidence_score(scores, "dosage"),
+            threshold=unclassified_threshold,
+        ),
     )
+
+
+def _biased_enum(
+    value: object,
+    enum_type: type[_EnumT],
+    default: _EnumT,
+    *,
+    score: float | None,
+    threshold: float,
+) -> _EnumT:
+    """Apply :data:`_BIASED_DIMENSIONS` gating to a regular enum parse.
+
+    A reported confidence strictly below the threshold overrides the
+    model's pick with ``default`` (always the ``unclassified`` member
+    of the enum). When ``score`` is ``None`` (no value reported), the
+    bias does not fire — the model's pick stands.
+    """
+    if score is not None and score < threshold:
+        return default
+    return _parse_enum(value, enum_type, default)
+
+
+def _biased_dosage(
+    value: object,
+    *,
+    score: float | None,
+    threshold: float,
+) -> Dosage:
+    """Apply :data:`_BIASED_DIMENSIONS` gating to dosage parsing.
+
+    A separate helper because dosage uses :func:`_parse_dosage` (which
+    treats ambiguity markers specially) rather than the plain
+    :func:`_parse_enum` used by mode/orientation.
+    """
+    if score is not None and score < threshold:
+        return Dosage.UNCLASSIFIED
+    return _parse_dosage(value)
 
 
 def _apply_voice(

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -38,6 +38,17 @@ class LLMConfig(BaseModel):
     max_concurrent: int = 5
     """Maximum number of concurrent LLM requests."""
 
+    unclassified_threshold: float = Field(default=0.55, ge=0.0, le=1.0)
+    """Per-dimension confidence floor below which Mode / Orientation /
+    Dosage default to ``unclassified`` rather than the model's pick (FEAT-017).
+
+    Frequency, Phase, and Voice Register are not gated by this knob —
+    they are more stable signals empirically and using them is the
+    point of having an LLM pass at all. The 0.55 default is deliberately
+    lenient; tighten it once a calibration set exists (FEAT-017b) and
+    the per-dimension agreement rate on your corpus is known.
+    """
+
 
 class EmbeddingsConfig(BaseModel):
     """Embedding model configuration."""

--- a/creek-tools/docs/classification.md
+++ b/creek-tools/docs/classification.md
@@ -43,9 +43,43 @@ classification:
 privacy:
   tier: personal             # open | personal | intimate
   reasoning: "Mentions financial detail; default-personal."
+classification_reasoning: |  # FEAT-017: present only for --method llm at open/personal tiers
+  This is F3 because the operator owns the decision; rising phase because the
+  energy is accelerating into commitment; express mode because the speech is
+  outward; analytical register and forming confidence.
 ```
 
 Privacy tiers are enforced by `creek.classify.privacy.PrivacyClassifier`. The default policy is **fail-closed**: ambiguous fragments are tagged `personal` (not `open`), and `intimate` requires explicit signals.
+
+## The two-step LLM pipeline (FEAT-017)
+
+`--method llm` runs use a chain-of-thought prompt that asks the model first for a short reasoning trace, then for the YAML tuple. The classifier splits the response into:
+
+- a **reasoning preamble** persisted as `classification_reasoning` in fragment frontmatter (truncated to 400 characters) for `open` and `personal` tiers, and
+- a **YAML payload** whose fields drive the standard `classification:` block.
+
+For `intimate`-tier fragments the reasoning preamble is **never** stored in the fragment file. The full trace lands in `<vault>/00-Creek-Meta/Processing-Log/classify-llm-trace.jsonl` — gitignorable per FEAT-019, so vault sharing cannot leak intimate-tier model traces.
+
+The prompt also embeds a **few-shot example block** sampled deterministically per fragment ID from `creek/classify/examples/<dimension>.yaml`. Same fragment → same examples on every re-run (reproducible classifications); different fragments rotate through the corpus.
+
+### Default-unclassified bias
+
+The new prompt asks the model to emit a `confidence_scores` map alongside its picks:
+
+```yaml
+confidence_scores:
+  mode: 0.7
+  orientation: 0.4
+  dosage: 0.9
+```
+
+For **Mode**, **Orientation**, and **Dosage** specifically, any reported confidence below `LLMConfig.unclassified_threshold` (default `0.55`) downgrades the model's pick to `unclassified` rather than guessing. **Frequency**, **Phase**, and **Voice Register** are not gated by this bias — they are more stable signals empirically and using them is the point of running an LLM pass.
+
+Per-fragment LLM classification is inherently noisy. The reliable wavelength signal is the **weekly aggregation** of many fragments (consumed by the `creek state` audit report in FEAT-006/007), not any single-fragment certainty.
+
+### Recommended model floor
+
+Mistral via Ollama and Haiku via Anthropic are too small for reliable 7-dimensional picks on subtle content. Reach for **Sonnet** (`claude-sonnet-4-6`) when classification quality matters. The prompt itself is model-agnostic; only the achievable agreement rate changes.
 
 ## Configuration
 
@@ -62,6 +96,7 @@ llm:
   model: mistral
   batch_size: 50
   max_concurrent: 5
+  unclassified_threshold: 0.55           # FEAT-017: bias for Mode / Orientation / Dosage
 ```
 
 The CLI selects rules vs LLM via `--method`. Rule-based classification reads frequency / phase keyword atlases bundled with the package; you can override or extend them at runtime by editing the relevant module data.

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -98,6 +98,10 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 include = ["creek", "creek.*", "creek_mcp", "creek_mcp.*"]
 
+[tool.setuptools.package-data]
+"creek.classify.examples" = ["*.yaml"]
+
+
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = [

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -577,9 +577,10 @@ class TestBuildPromptSanitisation:
         huge = "x" * (32 * 1024)
         frag = _make_fragment(title="ok")
         prompt = classifier._build_prompt(frag, content=huge)
-        # Cap is 8 KiB plus a few hundred chars of prompt header.
+        # FEAT-017: 8 KiB content cap + ~3 KiB CoT header + ~5 KiB
+        # rotated few-shot examples block (capped per fixture body too).
         assert len(prompt) < len(huge)
-        assert len(prompt) <= 8192 + 4096
+        assert len(prompt) <= 8192 + 8192
 
 
 # ---- Apply Classification ----
@@ -2068,3 +2069,241 @@ class TestMatchConfidenceNoDeadCode:
             "",
         )
         assert isinstance(result, Confidence)
+
+
+# ---- FEAT-017a: two-step pipeline, reasoning, unclassified bias ----
+
+
+_REASONING_PROSE: str = (
+    "I read this as F3 because the operator names walking away from "
+    "the contract. Rising phase, express mode, do orientation, medicine "
+    "dosage, analytical register, forming confidence."
+)
+
+_RESPONSE_WITH_REASONING: str = (
+    _REASONING_PROSE
+    + "\n\n```yaml\n"
+    + _VALID_YAML_RESPONSE
+    + "confidence_scores:\n"
+    + "  mode: 0.9\n"
+    + "  orientation: 0.9\n"
+    + "  dosage: 0.9\n"
+    + "```\n"
+)
+
+
+class TestPromptHasFewShotAndThreshold:
+    """The FEAT-017 prompt embeds the few-shot block and the threshold."""
+
+    def test_prompt_contains_few_shot_dimension_headings(self) -> None:
+        """Each dimension that has examples is named in the rendered prompt."""
+        classifier = LLMClassifier(config=LLMConfig())
+        prompt = classifier._build_prompt(_make_fragment())
+        assert "Frequency examples" in prompt
+        assert "Phase examples" in prompt
+        assert "Mode examples" in prompt
+        assert "Dosage examples" in prompt
+        assert "Register examples" in prompt
+
+    def test_prompt_renders_threshold(self) -> None:
+        """The threshold the model is asked to honour is shown verbatim."""
+        classifier = LLMClassifier(
+            config=LLMConfig(unclassified_threshold=0.6),
+        )
+        prompt = classifier._build_prompt(_make_fragment())
+        assert "0.60" in prompt
+
+    def test_prompt_is_deterministic_per_fragment_id(self) -> None:
+        """A given fragment ID always picks the same few-shot examples."""
+        classifier = LLMClassifier(config=LLMConfig())
+        frag = _make_fragment()
+        first = classifier._build_prompt(frag)
+        second = classifier._build_prompt(frag)
+        assert first == second
+
+
+class TestSplitReasoningAndYaml:
+    """`_split_reasoning_and_yaml` handles the three response shapes."""
+
+    def test_fenced_block_separates_reasoning(self) -> None:
+        """A fenced YAML block extracts reasoning preamble from prose."""
+        from creek.classify.llm import _split_reasoning_and_yaml
+
+        reasoning, yaml_text = _split_reasoning_and_yaml(_RESPONSE_WITH_REASONING)
+        assert "F3 because" in reasoning
+        assert "frequency:" in yaml_text
+        assert "```" not in yaml_text
+
+    def test_bare_yaml_after_prose_is_split(self) -> None:
+        """Reasoning followed by bare YAML (no fences) still splits."""
+        from creek.classify.llm import _split_reasoning_and_yaml
+
+        raw = "Some musing then the answer.\n\n" + _VALID_YAML_RESPONSE
+        reasoning, yaml_text = _split_reasoning_and_yaml(raw)
+        assert reasoning == "Some musing then the answer."
+        assert yaml_text.startswith("frequency:")
+
+    def test_pure_yaml_returns_empty_reasoning(self) -> None:
+        """Backwards-compat: a pre-FEAT-017 pure-YAML response yields no trace."""
+        from creek.classify.llm import _split_reasoning_and_yaml
+
+        reasoning, yaml_text = _split_reasoning_and_yaml(_VALID_YAML_RESPONSE)
+        assert reasoning == ""
+        assert yaml_text.startswith("frequency:")
+
+
+class TestClassifyWithReasoning:
+    """`classify_with_reasoning` returns Fragment plus a reasoning trace."""
+
+    @patch.object(LLMClassifier, "_call_ollama")
+    def test_returns_reasoning_when_model_provides_one(
+        self,
+        mock_call: MagicMock,
+    ) -> None:
+        """A fenced response yields the prose preamble in ``reasoning``."""
+        mock_call.return_value = _RESPONSE_WITH_REASONING
+        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
+        result = classifier.classify_with_reasoning(_make_fragment())
+        assert result.fragment.frequency.primary == Frequency.F3
+        assert "F3 because" in result.reasoning
+
+    @patch.object(LLMClassifier, "_call_ollama")
+    def test_returns_empty_reasoning_for_pure_yaml(
+        self,
+        mock_call: MagicMock,
+    ) -> None:
+        """The pre-FEAT-017 pure-YAML response shape still works (empty trace)."""
+        mock_call.return_value = _VALID_YAML_RESPONSE
+        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
+        result = classifier.classify_with_reasoning(_make_fragment())
+        assert result.fragment.frequency.primary == Frequency.F3
+        assert result.reasoning == ""
+
+    def test_returns_unchanged_when_unavailable(self) -> None:
+        """An unavailable provider yields the fragment unchanged + empty trace."""
+        classifier = _make_classifier_unavailable(LLMClassifier(config=LLMConfig()))
+        frag = _make_fragment()
+        result = classifier.classify_with_reasoning(frag)
+        assert result.fragment is frag
+        assert result.reasoning == ""
+
+    @patch.object(LLMClassifier, "_call_ollama")
+    @patch("creek.classify.llm.time.sleep")
+    def test_returns_empty_reasoning_after_retries_exhausted(
+        self,
+        _mock_sleep: MagicMock,
+        mock_call: MagicMock,
+    ) -> None:
+        """All-retries-failed yields the original fragment + empty trace."""
+        mock_call.side_effect = httpx.ConnectError("fail")
+        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
+        classifier.MAX_RETRIES = 2
+        result = classifier.classify_with_reasoning(_make_fragment())
+        assert result.reasoning == ""
+
+
+class TestUnclassifiedBias:
+    """FEAT-017 default-unclassified bias for Mode / Orientation / Dosage."""
+
+    def _yaml_with_scores(self, **scores: float) -> str:
+        """Return a YAML payload that picks all dimensions then declares scores."""
+        score_block = "\n".join(f"  {k}: {v}" for k, v in scores.items())
+        return _VALID_YAML_RESPONSE + "confidence_scores:\n" + score_block + "\n"
+
+    @patch.object(LLMClassifier, "_call_ollama")
+    def test_low_mode_confidence_forces_unclassified(
+        self,
+        mock_call: MagicMock,
+    ) -> None:
+        """A mode confidence below the threshold downgrades to unclassified."""
+        mock_call.return_value = self._yaml_with_scores(
+            mode=0.3,
+            orientation=0.9,
+            dosage=0.9,
+        )
+        classifier = _make_classifier_available(
+            LLMClassifier(config=LLMConfig(unclassified_threshold=0.55)),
+        )
+        result = classifier.classify(_make_fragment())
+        assert result.wavelength.mode == Mode.UNCLASSIFIED
+        # Phase / Frequency / Register are not gated.
+        assert result.wavelength.phase == Phase.RISING
+        assert result.frequency.primary == Frequency.F3
+
+    @patch.object(LLMClassifier, "_call_ollama")
+    def test_high_confidence_preserves_pick(
+        self,
+        mock_call: MagicMock,
+    ) -> None:
+        """A model-reported confidence at-or-above threshold keeps the model's pick."""
+        mock_call.return_value = self._yaml_with_scores(
+            mode=0.9,
+            orientation=0.9,
+            dosage=0.9,
+        )
+        classifier = _make_classifier_available(
+            LLMClassifier(config=LLMConfig(unclassified_threshold=0.55)),
+        )
+        result = classifier.classify(_make_fragment())
+        assert result.wavelength.mode == Mode.EXPRESS
+        assert result.wavelength.orientation == Orientation.DO
+        assert result.wavelength.dosage == Dosage.MEDICINE
+
+    @patch.object(LLMClassifier, "_call_ollama")
+    def test_bias_applies_to_orientation_and_dosage(
+        self,
+        mock_call: MagicMock,
+    ) -> None:
+        """Low orientation + dosage confidences both downgrade independently."""
+        mock_call.return_value = self._yaml_with_scores(
+            mode=0.9,
+            orientation=0.2,
+            dosage=0.4,
+        )
+        classifier = _make_classifier_available(
+            LLMClassifier(config=LLMConfig(unclassified_threshold=0.55)),
+        )
+        result = classifier.classify(_make_fragment())
+        assert result.wavelength.mode == Mode.EXPRESS
+        assert result.wavelength.orientation == Orientation.UNCLASSIFIED
+        assert result.wavelength.dosage == Dosage.UNCLASSIFIED
+
+    @patch.object(LLMClassifier, "_call_ollama")
+    def test_missing_confidence_score_keeps_model_pick(
+        self,
+        mock_call: MagicMock,
+    ) -> None:
+        """Without a confidence_scores block, the model's pick is unchanged."""
+        mock_call.return_value = _VALID_YAML_RESPONSE
+        classifier = _make_classifier_available(
+            LLMClassifier(config=LLMConfig(unclassified_threshold=0.55)),
+        )
+        result = classifier.classify(_make_fragment())
+        assert result.wavelength.mode == Mode.EXPRESS
+        assert result.wavelength.orientation == Orientation.DO
+
+    @patch.object(LLMClassifier, "_call_ollama")
+    def test_unparseable_confidence_keeps_model_pick(
+        self,
+        mock_call: MagicMock,
+    ) -> None:
+        """A non-numeric confidence value is treated as 'no score reported'."""
+        mock_call.return_value = (
+            _VALID_YAML_RESPONSE + "confidence_scores:\n  mode: not-a-number\n"
+        )
+        classifier = _make_classifier_available(
+            LLMClassifier(config=LLMConfig(unclassified_threshold=0.55)),
+        )
+        result = classifier.classify(_make_fragment())
+        assert result.wavelength.mode == Mode.EXPRESS
+
+    def test_phase_is_not_gated_even_at_zero_confidence(self) -> None:
+        """Phase has no entry in :data:`_BIASED_DIMENSIONS`; the bias must skip it."""
+        from creek.classify.llm import _BIASED_DIMENSIONS
+
+        assert "phase" not in _BIASED_DIMENSIONS
+        assert "frequency" not in _BIASED_DIMENSIONS
+        assert "voice_register" not in _BIASED_DIMENSIONS
+        assert "mode" in _BIASED_DIMENSIONS
+        assert "orientation" in _BIASED_DIMENSIONS
+        assert "dosage" in _BIASED_DIMENSIONS

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 import frontmatter
 
 from creek.classify.classify_engine import run_classify
+from creek.classify.llm import LLMClassificationResult
 from creek.config import CreekConfig
 from creek.models import Fragment, FragmentSource, SourcePlatform
 from tests.helpers import write_fragment_file as _write_fragment
@@ -273,7 +274,9 @@ def test_run_classify_llm_skips_high_confidence(tmp_path: Path) -> None:
     config = CreekConfig()
     config.classification.confidence_threshold = 0.0
 
-    with patch("creek.classify.classify_engine.LLMClassifier.classify") as mock_llm:
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning",
+    ) as mock_llm:
         summary = run_classify(
             vault_path=vault,
             config=config,
@@ -345,8 +348,11 @@ def test_run_classify_llm_invoked_for_low_confidence(tmp_path: Path) -> None:
     config = CreekConfig()
 
     with patch(
-        "creek.classify.classify_engine.LLMClassifier.classify",
-        side_effect=lambda f, content="": f,
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning",
+        side_effect=lambda f, content="": LLMClassificationResult(
+            fragment=f,
+            reasoning="",
+        ),
     ) as mock_llm:
         run_classify(
             vault_path=vault,
@@ -356,3 +362,178 @@ def test_run_classify_llm_invoked_for_low_confidence(tmp_path: Path) -> None:
         )
 
     mock_llm.assert_called_once()
+
+
+# ---- FEAT-017a: classification_reasoning tier-routing ----
+
+
+_LONG_REASONING: str = (
+    "I worked through this in detail. "
+    "The frequency is clearly F3 because the operator is exercising "
+    "authority over a decision. "
+    + ("the same point repeated until we hit the cap. " * 20)
+)
+
+
+def _run_with_reasoning(
+    vault: Path,
+    fragment: Fragment,
+    body: str,
+    reasoning: str,
+) -> None:
+    """Seed *fragment* into *vault* and run the engine with a canned reasoning trace."""
+    _write_fragment(vault=vault, fragment=fragment, body=body)
+    config = CreekConfig()
+    config.classification.confidence_threshold = 1.0  # force LLM path
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning",
+        side_effect=lambda f, content="": LLMClassificationResult(
+            fragment=f,
+            reasoning=reasoning,
+        ),
+    ):
+        run_classify(
+            vault_path=vault,
+            config=config,
+            method="llm",
+            force=False,
+        )
+
+
+def test_open_tier_truncates_reasoning_into_frontmatter(tmp_path: Path) -> None:
+    """An ``open``-tier fragment carries a truncated trace in its frontmatter."""
+    import importlib
+
+    from creek.models import PrivacyTier
+
+    vault = tmp_path / "vault"
+    frag = Fragment(
+        id="frag-opentier001",
+        title="open",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        privacy_tier=PrivacyTier.OPEN,
+    )
+    _run_with_reasoning(vault, frag, body="open content", reasoning=_LONG_REASONING)
+
+    constants = importlib.import_module("creek.classify.constants")
+    reloaded = frontmatter.load(
+        str(vault / "01-Fragments" / "Notes" / "frag-opentier001.md"),
+    )
+    stored = reloaded[constants.CLASSIFICATION_REASONING_KEY]
+    assert isinstance(stored, str)
+    assert stored.endswith("…")
+    assert len(stored) == constants.CLASSIFICATION_REASONING_MAX_CHARS
+
+
+def test_personal_tier_truncates_reasoning_into_frontmatter(tmp_path: Path) -> None:
+    """A ``personal``-tier fragment also gets the truncated trace in frontmatter."""
+    import importlib
+
+    from creek.models import PrivacyTier
+
+    vault = tmp_path / "vault"
+    frag = Fragment(
+        id="frag-personal001",
+        title="personal",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        privacy_tier=PrivacyTier.PERSONAL,
+    )
+    _run_with_reasoning(vault, frag, body="personal content", reasoning=_LONG_REASONING)
+
+    constants = importlib.import_module("creek.classify.constants")
+    reloaded = frontmatter.load(
+        str(vault / "01-Fragments" / "Notes" / "frag-personal001.md"),
+    )
+    stored = reloaded[constants.CLASSIFICATION_REASONING_KEY]
+    assert isinstance(stored, str)
+    assert stored
+    assert len(stored) <= constants.CLASSIFICATION_REASONING_MAX_CHARS
+
+
+def test_intimate_tier_writes_full_trace_to_log_not_frontmatter(
+    tmp_path: Path,
+) -> None:
+    """An ``intimate``-tier fragment's full trace lives in the log file only."""
+    import json as _json
+
+    from creek.classify.constants import (
+        CLASSIFICATION_REASONING_KEY,
+        CLASSIFY_TRACE_LOG_FILENAME,
+    )
+    from creek.models import PrivacyTier
+
+    vault = tmp_path / "vault"
+    frag = Fragment(
+        id="frag-intimate001",
+        title="intimate",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        privacy_tier=PrivacyTier.INTIMATE,
+    )
+    _run_with_reasoning(vault, frag, body="intimate content", reasoning=_LONG_REASONING)
+
+    reloaded = frontmatter.load(
+        str(vault / "01-Fragments" / "Notes" / "frag-intimate001.md"),
+    )
+    # Frontmatter MUST NOT carry the reasoning for intimate-tier fragments.
+    assert CLASSIFICATION_REASONING_KEY not in reloaded.metadata
+
+    # Full trace lives in the gitignorable trace log.
+    log_path = vault / "00-Creek-Meta" / "Processing-Log" / CLASSIFY_TRACE_LOG_FILENAME
+    assert log_path.exists()
+    records = [
+        _json.loads(line)
+        for line in log_path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    assert len(records) == 1
+    assert records[0]["id"] == frag.id
+    assert records[0]["tier"] == "intimate"
+    assert records[0]["reasoning"] == _LONG_REASONING
+
+
+def test_short_reasoning_is_persisted_verbatim(tmp_path: Path) -> None:
+    """A trace shorter than the cap is stored without truncation marker."""
+    from creek.classify.constants import CLASSIFICATION_REASONING_KEY
+    from creek.models import PrivacyTier
+
+    vault = tmp_path / "vault"
+    frag = Fragment(
+        id="frag-shortreas01",
+        title="short",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        privacy_tier=PrivacyTier.OPEN,
+    )
+    short = "Brief reasoning."
+    _run_with_reasoning(vault, frag, body="content", reasoning=short)
+
+    reloaded = frontmatter.load(
+        str(vault / "01-Fragments" / "Notes" / "frag-shortreas01.md"),
+    )
+    assert reloaded[CLASSIFICATION_REASONING_KEY] == short
+
+
+def test_rules_method_does_not_persist_reasoning(tmp_path: Path) -> None:
+    """``--method rules`` runs never emit a classification_reasoning field."""
+    from creek.classify.constants import CLASSIFICATION_REASONING_KEY
+
+    vault = tmp_path / "vault"
+    frag = Fragment(
+        id="frag-rulesreas01",
+        title="rules-only",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=frag,
+        body="power dominance bold rage warrior",
+    )
+    run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+    reloaded = frontmatter.load(
+        str(vault / "01-Fragments" / "Notes" / "frag-rulesreas01.md"),
+    )
+    assert CLASSIFICATION_REASONING_KEY not in reloaded.metadata

--- a/creek-tools/tests/test_classify_engine_resume.py
+++ b/creek-tools/tests/test_classify_engine_resume.py
@@ -17,9 +17,17 @@ from unittest.mock import patch
 import frontmatter
 
 from creek.classify.classify_engine import LLM_PROGRESS_FILENAME, run_classify
+from creek.classify.llm import LLMClassificationResult
 from creek.config import CreekConfig
 from creek.models import Fragment, FragmentSource, SourcePlatform
 from tests.helpers import write_fragment_file as _write_fragment
+
+
+def _stub_llm_result(frag: Fragment, content: str = "") -> LLMClassificationResult:
+    """Stub for ``classify_with_reasoning`` used across resume tests."""
+    del content
+    return LLMClassificationResult(fragment=frag, reasoning="")
+
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -69,7 +77,9 @@ def test_already_llm_classified_fragment_is_skipped(tmp_path: Path) -> None:
         method="llm",
     )
 
-    with patch("creek.classify.classify_engine.LLMClassifier.classify") as mock_llm:
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning"
+    ) as mock_llm:
         summary = run_classify(
             vault_path=vault,
             config=_llm_low_confidence_config(),
@@ -100,8 +110,8 @@ def test_force_overrides_resume_skip(tmp_path: Path) -> None:
     )
 
     with patch(
-        "creek.classify.classify_engine.LLMClassifier.classify",
-        side_effect=lambda frag, content="": frag,
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning",
+        side_effect=_stub_llm_result,
     ) as mock_llm:
         run_classify(
             vault_path=vault,
@@ -128,8 +138,8 @@ def test_progress_file_records_classified_fragment_ids(tmp_path: Path) -> None:
     )
 
     with patch(
-        "creek.classify.classify_engine.LLMClassifier.classify",
-        side_effect=lambda frag, content="": frag,
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning",
+        side_effect=_stub_llm_result,
     ):
         run_classify(
             vault_path=vault,
@@ -166,8 +176,8 @@ def test_progress_file_appends_across_runs(tmp_path: Path) -> None:
     )
 
     with patch(
-        "creek.classify.classify_engine.LLMClassifier.classify",
-        side_effect=lambda frag, content="": frag,
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning",
+        side_effect=_stub_llm_result,
     ):
         run_classify(
             vault_path=vault,
@@ -189,8 +199,8 @@ def test_progress_file_appends_across_runs(tmp_path: Path) -> None:
     )
 
     with patch(
-        "creek.classify.classify_engine.LLMClassifier.classify",
-        side_effect=lambda frag, content="": frag,
+        "creek.classify.classify_engine.LLMClassifier.classify_with_reasoning",
+        side_effect=_stub_llm_result,
     ):
         run_classify(
             vault_path=vault,

--- a/creek-tools/tests/test_classify_few_shot.py
+++ b/creek-tools/tests/test_classify_few_shot.py
@@ -1,0 +1,233 @@
+"""Tests for creek.classify.few_shot (FEAT-017a)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.classify import few_shot
+from creek.classify.few_shot import (
+    DIMENSIONS,
+    EXAMPLES_PER_DIMENSION,
+    FewShotExample,
+    examples_for,
+    render_block,
+    sample_examples,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class TestExamplesLoad:
+    """The bundled YAML fixtures load into FewShotExample tuples."""
+
+    def test_every_dimension_has_at_least_five_examples(self) -> None:
+        """FEAT-017 acceptance: 5-10 examples per dimension shipped."""
+        for dim in DIMENSIONS:
+            pool = examples_for(dim)
+            assert len(pool) >= 5, f"{dim} has only {len(pool)} examples"
+
+    def test_each_example_is_immutable_record(self) -> None:
+        """Examples expose title, body, label, rationale strings."""
+        for dim in DIMENSIONS:
+            for ex in examples_for(dim):
+                assert isinstance(ex, FewShotExample)
+                assert ex.title and ex.body and ex.label and ex.rationale
+
+    def test_unknown_dimension_returns_empty(self) -> None:
+        """An unrecognised dimension yields ``()`` rather than raising."""
+        assert examples_for("nonsense") == ()
+
+
+class TestSampleExamples:
+    """sample_examples returns a deterministic per-fragment sample."""
+
+    def test_deterministic_for_same_fragment_id(self) -> None:
+        """The same fragment ID always picks the same examples."""
+        first = sample_examples("frag-abc123")
+        second = sample_examples("frag-abc123")
+        assert first == second
+
+    def test_differs_across_fragment_ids(self) -> None:
+        """Different IDs rotate the example pool (at least one dim changes)."""
+        a = sample_examples("frag-aaaaaaa1")
+        b = sample_examples("frag-bbbbbbb2")
+        # With ≥5 fixtures per dim and 3 picked, collisions are possible per
+        # dim but exceedingly unlikely across all five. Require at least one
+        # dimension to differ.
+        differing = [dim for dim in DIMENSIONS if a[dim] != b[dim]]
+        assert differing, "every dimension picked identical examples"
+
+    def test_respects_per_dimension_cap(self) -> None:
+        """Each dimension yields at most ``per_dimension`` examples."""
+        sample = sample_examples("frag-cap0", per_dimension=2)
+        for dim in DIMENSIONS:
+            assert len(sample[dim]) <= 2
+
+    def test_default_count_matches_module_constant(self) -> None:
+        """The default sample size is EXAMPLES_PER_DIMENSION."""
+        sample = sample_examples("frag-default")
+        for dim in DIMENSIONS:
+            pool_size = len(examples_for(dim))
+            assert len(sample[dim]) == min(EXAMPLES_PER_DIMENSION, pool_size)
+
+
+class TestRenderBlock:
+    """render_block produces a prompt-ready string."""
+
+    def test_block_mentions_every_dimension_with_examples(self) -> None:
+        """Each dimension that has examples is named in the rendered block."""
+        block = render_block(sample_examples("frag-render"))
+        for dim in DIMENSIONS:
+            if examples_for(dim):
+                assert dim.title() in block
+
+    def test_block_includes_labels(self) -> None:
+        """Each rendered example shows its canonical label."""
+        sample = sample_examples("frag-render")
+        block = render_block(sample)
+        for chosen in sample.values():
+            for ex in chosen:
+                assert ex.label in block
+
+    def test_truncates_long_body(self) -> None:
+        """A body longer than the cap is truncated with an ellipsis."""
+        long_body = "x" * 1000
+        sample = {
+            "frequency": (
+                FewShotExample(
+                    title="t",
+                    body=long_body,
+                    label="F1",
+                    rationale="r",
+                ),
+            ),
+        }
+        block = render_block(sample)
+        assert long_body not in block
+        assert "…" in block
+
+    def test_empty_samples_produce_empty_block(self) -> None:
+        """All-empty input renders to the empty string, not whitespace."""
+        empty = dict.fromkeys(DIMENSIONS, ())
+        assert render_block(empty) == ""
+
+
+class TestLoaderResilience:
+    """The loader degrades gracefully when fixtures are malformed."""
+
+    def test_invalid_yaml_entry_is_skipped(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Entries missing required keys are dropped silently with a warning."""
+        # Clear the lru_cache so our monkeypatched fixture takes effect.
+        few_shot._load_all_examples.cache_clear()
+        try:
+            sentinel = [
+                {"title": "ok", "body": "b", "label": "F1", "rationale": "r"},
+                {"title": "missing body"},  # invalid
+                "not a dict at all",  # invalid
+            ]
+
+            class _StubResource:
+                def joinpath(self, name: str) -> _StubResource:
+                    self.name = name
+                    return self
+
+                def read_text(self, encoding: str) -> str:
+                    import yaml as _yaml
+
+                    return _yaml.safe_dump(sentinel)
+
+            monkeypatch.setattr(
+                few_shot.resources,
+                "files",
+                lambda _pkg: _StubResource(),
+            )
+            loaded = few_shot._load_all_examples()
+            for dim in DIMENSIONS:
+                assert all(isinstance(e, FewShotExample) for e in loaded[dim])
+                assert len(loaded[dim]) == 1  # only the well-formed entry
+        finally:
+            few_shot._load_all_examples.cache_clear()
+
+    def test_missing_fixture_returns_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A FileNotFoundError on a fixture yields an empty tuple, not a crash."""
+        few_shot._load_all_examples.cache_clear()
+        try:
+
+            class _MissingResource:
+                def joinpath(self, name: str) -> _MissingResource:
+                    self.name = name
+                    return self
+
+                def read_text(self, encoding: str) -> str:
+                    raise FileNotFoundError(self.name)
+
+            monkeypatch.setattr(
+                few_shot.resources,
+                "files",
+                lambda _pkg: _MissingResource(),
+            )
+            loaded = few_shot._load_all_examples()
+            for dim in DIMENSIONS:
+                assert loaded[dim] == ()
+        finally:
+            few_shot._load_all_examples.cache_clear()
+
+    def test_non_list_yaml_returns_empty(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A YAML scalar at the top of a fixture is rejected with a warning."""
+        few_shot._load_all_examples.cache_clear()
+        try:
+
+            class _ScalarResource:
+                def joinpath(self, name: str) -> _ScalarResource:
+                    self.name = name
+                    return self
+
+                def read_text(self, encoding: str) -> str:
+                    return "not_a_list: scalar\n"
+
+            monkeypatch.setattr(
+                few_shot.resources,
+                "files",
+                lambda _pkg: _ScalarResource(),
+            )
+            loaded = few_shot._load_all_examples()
+            for dim in DIMENSIONS:
+                assert loaded[dim] == ()
+        finally:
+            few_shot._load_all_examples.cache_clear()
+
+
+class TestCoerceGuard:
+    """`_coerce` raises rather than silently producing a half-built example."""
+
+    def test_coerce_rejects_non_dict(self) -> None:
+        """The TypeError branch fires when the gate is bypassed."""
+        import pytest as _pytest
+
+        with _pytest.raises(TypeError, match="non-dict"):
+            few_shot._coerce("not a dict")  # type: ignore[arg-type]
+
+
+class TestSampleExamplesEmptyPool:
+    """`sample_examples` handles an empty fixture pool without crashing."""
+
+    def test_dimension_with_no_examples_yields_empty_tuple(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A dimension whose pool is empty is mapped to ``()`` in the sample."""
+        stub_pool = dict.fromkeys(DIMENSIONS, ())
+        monkeypatch.setattr(few_shot, "_load_all_examples", lambda: stub_pool)
+        sample = few_shot.sample_examples("frag-empty00001")
+        for dim in DIMENSIONS:
+            assert sample[dim] == ()


### PR DESCRIPTION
## Summary

Implements **FEAT-017a** — the prompt-pipeline portion of the classification-prompt-hardening work — against [`plans/git-issues/FEAT-017-classification-prompt-hardening.md`](https://github.com/Geoffe-Ga/Creek-Vault/blob/main/plans/git-issues/FEAT-017-classification-prompt-hardening.md). Unblocks FEAT-018 (compost embeddings + LLM verification), which declares FEAT-017 as a dependency.

### What changes

- **Two-step CoT prompt** in `creek/classify/llm.py`: the model first reasons, then emits its picks inside a fenced YAML block. The classifier splits the response into a reasoning preamble and a YAML payload.
- **Few-shot examples** loaded from bundled per-dimension YAML fixtures under `creek/classify/examples/` (`frequency.yaml`, `phase.yaml`, `mode.yaml`, `dosage.yaml`, `register.yaml` — 5–10 examples each). `creek.classify.few_shot.sample_examples` picks a deterministic-per-fragment-id subset so re-classifying the same fragment is reproducible while a vault rotates through the corpus.
- **Default-unclassified bias** for Mode / Orientation / Dosage: when the model's self-reported `confidence_scores` for those dimensions is below `LLMConfig.unclassified_threshold` (default `0.55`), the engine overrides the pick with `unclassified` rather than guessing. Frequency, Phase, and Voice Register are not gated.
- **Tier-routed reasoning persistence** in `creek/classify/classify_engine.py`:
  - `open` / `personal` → 400-char truncation in `classification_reasoning` frontmatter
  - `intimate` → full trace appended to `<vault>/00-Creek-Meta/Processing-Log/classify-llm-trace.jsonl` (gitignored per FEAT-019), frontmatter left empty so vault sync cannot leak intimate-tier traces
  - `rules` method → no reasoning persisted; the key is actively removed if present
- New `LLMClassificationResult` and `LLMClassifier.classify_with_reasoning(...)`; existing `classify(...)` is a back-compat wrapper that drops the trace.
- New `LLMConfig.unclassified_threshold` config knob; new constants `CLASSIFICATION_REASONING_KEY`, `CLASSIFICATION_REASONING_MAX_CHARS`, `CLASSIFY_TRACE_LOG_FILENAME`.
- `pyproject.toml` ships `creek/classify/examples/*.yaml` with the wheel.
- `docs/classification.md` documents the new pipeline, the few-shot block, the unclassified bias, and the model-floor recommendation.

### Acceptance criteria verified

| FEAT-017 acceptance criterion | Status |
|---|---|
| `CLASSIFICATION_PROMPT` includes 3–5 rotating few-shot examples per dimension from `creek/classify/examples/` | ✅ |
| Two-step (reasoning → YAML) pipeline; reasoning trace captured and tier-routed | ✅ |
| Default-unclassified bias for Mode / Orientation / Dosage; configurable threshold default `0.55` | ✅ |
| `docs/classification.md` documents the new pipeline, model floor recommendation, per-fragment-noisy framing | ✅ |
| ≥90% branch coverage on changed `creek/classify/` paths | ✅ (`few_shot.py` 100%, full-suite total 93.61%) |
| Calibration fixture (`tests/fixtures/classification/calibration_set.yaml`) with ≥30 fragments | ⏳ **FEAT-017b** |
| `creek classify --calibrate` subcommand | ⏳ **FEAT-017b** |
| CI test fails when calibration agreement drops below documented per-dimension floor | ⏳ **FEAT-017b** |

### Size note

This PR is large for the project's usual cadence (~1500 LOC). The FEAT explicitly anticipated this and called for an 017a/017b split — this branch is the 017a half (prompt + CoT + few-shot + bias + engine wiring + tests). FEAT-017b will land the calibration fixture + `--calibrate` CLI + CI gate as a separate, smaller PR.

### Quality gates (local `./scripts/check-all.sh`)

| Gate | Result |
|---|---|
| Ruff lint | ✅ |
| Ruff format | ✅ |
| MyPy strict | ✅ |
| Pylint (9.0 floor) | ✅ 9.75/10 |
| Bandit (medium+) | ✅ 0 issues |
| Complexity (Xenon B) | ✅ |
| Unit tests | ✅ 3358 passed, 20 deselected |
| Coverage 90% aggregate | ✅ 93.61% |
| Per-file coverage 80% | ✅ |
| `creek state` size budget | ✅ |
| pip-audit | ❌ pre-existing on `main`: env-installed `pip 24.0` + newly-published `urllib3` CVEs (CVE-2026-44431/44432) not yet listed in `scripts/security.sh` ignore set. Unrelated to this PR. |

## Test plan

- [x] Unit tests added: `tests/test_classify_few_shot.py` (16 tests), `tests/test_classify.py` `TestPromptHasFewShotAndThreshold` / `TestSplitReasoningAndYaml` / `TestClassifyWithReasoning` / `TestUnclassifiedBias`, `tests/test_classify_engine.py` 5 tier-routing tests.
- [x] Existing tests updated to patch `classify_with_reasoning` instead of `classify` (engine and resume suites).
- [x] `./scripts/check-all.sh` green except for the pre-existing pip-audit env issue noted above.

## Follow-ups (out of scope for this PR)

- **FEAT-017b**: calibration fixture + `creek classify --calibrate` + CI agreement gate.
- **FEAT-018**: compost embedding + LLM verification — unblocked by this PR landing.
- `creek/classify/llm.py` now has 1145 LOC (pylint `too-many-lines` at 1000). Worth splitting in a follow-up; not in scope here.

https://claude.ai/code/session_017Ji1ivHGSVaZqxbZSzKndN

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ji1ivHGSVaZqxbZSzKndN)_