### PR TITLE
feat(classify): calibration fixture + `--calibrate` CLI + floor gate (FEAT-017b)

### DIFF
--- a/creek-tools/creek/classify/calibration.py
+++ b/creek-tools/creek/classify/calibration.py
@@ -1,0 +1,382 @@
+"""Calibration of LLM classification quality (FEAT-017b).
+
+Runs the configured classifier against a hand-labelled fixture
+(``tests/fixtures/classification/calibration_set.yaml`` by default) and
+reports per-dimension agreement rates. Downstream of FEAT-017a's
+two-step prompt + few-shot pipeline.
+
+The calibration engine is classifier-agnostic via the
+:class:`SupportsClassifyWithReasoning` protocol — production use wires
+in :class:`creek.classify.llm.LLMClassifier`; tests wire in a
+deterministic stub. Locally, ``creek classify --calibrate`` runs the
+real LLM against the fixture and prints the per-dimension agreement;
+CI tests verify the calibration mechanism end-to-end against a
+deterministic stub so the gate fires on regressions in the scoring
+code itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Final, Protocol
+
+import yaml
+
+from creek.models import (
+    Authorship,
+    Fragment,
+    FragmentSource,
+    SourcePlatform,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from creek.classify.llm import LLMClassificationResult
+
+DIMENSIONS: Final[tuple[str, ...]] = (
+    "frequency",
+    "phase",
+    "mode",
+    "orientation",
+    "dosage",
+    "voice_register",
+)
+"""Dimensions scored by :func:`run_calibration`.
+
+Matches the seven-dimensional classification schema minus
+``voice.confidence`` (a meta-dimension carried in the YAML response
+but not part of the agreement target — the model's confidence isn't
+ground truth).
+"""
+
+DEFAULT_FLOORS: Final[dict[str, float]] = {
+    "frequency": 0.60,
+    "phase": 0.60,
+    "mode": 0.40,
+    "orientation": 0.40,
+    "dosage": 0.40,
+    "voice_register": 0.75,
+}
+"""Per-dimension agreement floors below which CI fails (FEAT-017).
+
+The FEAT calibrated these for the v1.0 prompt against a target model
+(Sonnet); a model swap may require a re-baseline. Mode / Orientation /
+Dosage are the noisier dimensions and carry the looser 40% floor;
+Voice Register is the firmest at 75%.
+"""
+
+_REQUIRED_ENTRY_KEYS: Final[frozenset[str]] = frozenset(
+    {"id", "title", "body", "expected"},
+)
+"""Top-level keys every calibration entry must carry."""
+
+
+class CalibrationFloorBreachError(RuntimeError):
+    """Raised when one or more per-dimension agreement floors are violated.
+
+    The message names every breached dimension along with its observed
+    rate and the floor it failed against, so an operator scanning a CI
+    log can see all breaches at once rather than fixing one and
+    re-running.
+    """
+
+
+@dataclass(frozen=True)
+class CalibrationEntry:
+    """One hand-labelled fragment from the calibration fixture.
+
+    Attributes:
+        id: Stable per-entry identifier (e.g. ``cal-001``).
+        title: Short headline shown to the classifier.
+        body: Representative fragment text shown to the classifier.
+        expected: Hand-assigned ground-truth labels keyed by
+            dimension name (see :data:`DIMENSIONS`). Missing keys are
+            treated as "not scored for this dimension" by
+            :func:`run_calibration`.
+    """
+
+    id: str
+    title: str
+    body: str
+    expected: dict[str, str]
+
+
+@dataclass(frozen=True)
+class DimensionAgreement:
+    """Match / total counts for one classification dimension.
+
+    Attributes:
+        dimension: Dimension name from :data:`DIMENSIONS`.
+        matches: Count of entries the classifier got right.
+        total: Count of entries that had a ground-truth label for
+            this dimension. Always ≥ ``matches``.
+    """
+
+    dimension: str
+    matches: int
+    total: int
+
+    @property
+    def rate(self) -> float:
+        """Agreement rate in ``[0.0, 1.0]``; ``0.0`` when ``total == 0``."""
+        return self.matches / self.total if self.total else 0.0
+
+
+@dataclass(frozen=True)
+class CalibrationReport:
+    """Per-dimension agreement summary for one calibration run.
+
+    Attributes:
+        entries: Number of fixture entries scored.
+        agreements: One :class:`DimensionAgreement` per scored
+            dimension, in :data:`DIMENSIONS` order.
+    """
+
+    entries: int
+    agreements: tuple[DimensionAgreement, ...] = field(default_factory=tuple)
+
+    def for_dimension(self, name: str) -> DimensionAgreement:
+        """Return the :class:`DimensionAgreement` for *name*.
+
+        Args:
+            name: A dimension from :data:`DIMENSIONS`.
+
+        Returns:
+            The matching :class:`DimensionAgreement`.
+
+        Raises:
+            KeyError: If *name* was not scored in this run.
+        """
+        for agreement in self.agreements:
+            if agreement.dimension == name:
+                return agreement
+        msg = f"dimension {name!r} not scored in this calibration run"
+        raise KeyError(msg)
+
+    def render(self) -> str:
+        """Render the report as a plain-text table for the CLI.
+
+        Returns:
+            Multi-line string with header + one row per dimension,
+            terminated by an ``Entries scored: N`` line.
+        """
+        lines = ["Dimension       Match Total Rate"]
+        for agreement in self.agreements:
+            lines.append(
+                f"{agreement.dimension:<15} {agreement.matches:>5} "
+                f"{agreement.total:>5} {agreement.rate:>5.0%}",
+            )
+        lines.append(f"Entries scored: {self.entries}")
+        return "\n".join(lines)
+
+
+class SupportsClassifyWithReasoning(Protocol):
+    """Subset of :class:`creek.classify.llm.LLMClassifier` calibration needs.
+
+    Lets the calibration engine accept any object that produces an
+    :class:`LLMClassificationResult` from a fragment — the real LLM
+    classifier in production, a deterministic stub in tests.
+    """
+
+    def classify_with_reasoning(
+        self,
+        fragment: Fragment,
+        content: str = "",
+    ) -> LLMClassificationResult:
+        """Classify a fragment and return result + reasoning trace."""
+
+
+def load_fixture(path: Path) -> tuple[CalibrationEntry, ...]:
+    """Load and validate the calibration fixture at *path*.
+
+    Args:
+        path: Path to a YAML file holding a list of calibration entries.
+
+    Returns:
+        Tuple of :class:`CalibrationEntry`, one per fixture record, in
+        document order.
+
+    Raises:
+        FileNotFoundError: When *path* does not exist.
+        ValueError: When the file is not a YAML list of dicts, or when
+            any entry is missing a required key.
+    """
+    raw = path.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(raw) or []
+    if not isinstance(parsed, list):
+        msg = (
+            "calibration fixture must be a YAML list at top level, "
+            f"got {type(parsed).__name__}"
+        )
+        raise ValueError(msg)
+    return tuple(_coerce_entry(idx, item) for idx, item in enumerate(parsed))
+
+
+def _coerce_entry(index: int, item: object) -> CalibrationEntry:
+    """Validate one parsed fixture entry into :class:`CalibrationEntry`.
+
+    Args:
+        index: Zero-based position in the fixture file, used in error
+            messages so an operator can locate a malformed entry.
+        item: One element from the parsed YAML list.
+
+    Returns:
+        Validated :class:`CalibrationEntry`.
+
+    Raises:
+        ValueError: When *item* is not a dict, lacks a required key,
+            or carries an ``expected`` block that is not itself a dict.
+    """
+    if not isinstance(item, dict):
+        msg = f"calibration entry #{index} is not a dict: got {type(item).__name__}"
+        raise ValueError(msg)
+    missing = _REQUIRED_ENTRY_KEYS - {str(k) for k in item}
+    if missing:
+        msg = f"calibration entry #{index} missing keys: {sorted(missing)}"
+        raise ValueError(msg)
+    expected = item["expected"]
+    if not isinstance(expected, dict):
+        msg = f"calibration entry #{index} has non-dict 'expected' block"
+        raise ValueError(msg)
+    return CalibrationEntry(
+        id=str(item["id"]),
+        title=str(item["title"]),
+        body=str(item["body"]),
+        expected={str(k): str(v) for k, v in expected.items()},
+    )
+
+
+def _fragment_for(entry: CalibrationEntry) -> Fragment:
+    """Build a :class:`Fragment` shaped for the calibration classifier call.
+
+    Uses ``Authorship.SELF`` and ``SourcePlatform.MARKDOWN`` so the
+    fixture exercises the same code paths as a user-authored markdown
+    note rather than a chatbot transcript (which would carry different
+    privacy defaults).
+    """
+    return Fragment(
+        id=entry.id,
+        title=entry.title,
+        source=FragmentSource(
+            platform=SourcePlatform.MARKDOWN,
+            author=Authorship.SELF,
+        ),
+    )
+
+
+def _extract_label(fragment: Fragment, dimension: str) -> str | None:
+    """Return the classified label for *dimension* on *fragment*.
+
+    Returns:
+        The label as a string when assigned, ``None`` when the
+        classifier left this dimension unclassified (the unclassified
+        sentinel signals "no opinion" and should not count as
+        agreement against any ground-truth label).
+    """
+    if dimension == "frequency":
+        return _none_if_unclassified(fragment.frequency.primary)
+    if dimension == "phase":
+        return _none_if_unclassified(fragment.wavelength.phase)
+    if dimension == "mode":
+        return _none_if_unclassified(fragment.wavelength.mode)
+    if dimension == "orientation":
+        return _none_if_unclassified(fragment.wavelength.orientation)
+    if dimension == "dosage":
+        return _none_if_unclassified(fragment.wavelength.dosage)
+    if dimension == "voice_register":
+        register = fragment.voice.voice_register
+        return None if register is None else str(register)
+    return None
+
+
+def _none_if_unclassified(value: object) -> str | None:
+    """Coerce *value* to its string form, mapping ``unclassified`` to ``None``."""
+    if value is None:
+        return None
+    text = str(value)
+    return None if text == "unclassified" else text
+
+
+def run_calibration(
+    classifier: SupportsClassifyWithReasoning,
+    entries: Iterable[CalibrationEntry],
+) -> CalibrationReport:
+    """Score *classifier* against every entry in *entries*.
+
+    For each entry, invokes
+    :meth:`SupportsClassifyWithReasoning.classify_with_reasoning` with
+    a freshly-built fragment, then tallies per-dimension agreement
+    against the entry's hand-labelled ground truth. Entries that omit
+    a dimension from their ``expected`` block are skipped for that
+    dimension (counts decrement, not match-as-failure).
+
+    Args:
+        classifier: Any object satisfying
+            :class:`SupportsClassifyWithReasoning`.
+        entries: Calibration entries to score.
+
+    Returns:
+        :class:`CalibrationReport` summarising counts and rates per
+        dimension.
+    """
+    materialised = tuple(entries)
+    matches = dict.fromkeys(DIMENSIONS, 0)
+    totals = dict.fromkeys(DIMENSIONS, 0)
+    for entry in materialised:
+        result = classifier.classify_with_reasoning(
+            _fragment_for(entry),
+            content=entry.body,
+        )
+        for dim in DIMENSIONS:
+            expected = entry.expected.get(dim)
+            if expected is None:
+                continue
+            totals[dim] += 1
+            actual = _extract_label(result.fragment, dim)
+            if actual is not None and actual == expected:
+                matches[dim] += 1
+    agreements = tuple(
+        DimensionAgreement(dimension=dim, matches=matches[dim], total=totals[dim])
+        for dim in DIMENSIONS
+    )
+    return CalibrationReport(entries=len(materialised), agreements=agreements)
+
+
+def assert_floors(
+    report: CalibrationReport,
+    floors: dict[str, float] | None = None,
+) -> None:
+    """Raise :class:`CalibrationFloorBreachError` if any dimension falls below floor.
+
+    Dimensions absent from *floors* are not gated. Dimensions absent
+    from *report* are skipped silently — a fixture that doesn't
+    exercise a dimension shouldn't fail the gate.
+
+    Args:
+        report: Output of :func:`run_calibration`.
+        floors: Mapping ``dimension -> minimum-rate``. ``None`` uses
+            :data:`DEFAULT_FLOORS`.
+
+    Raises:
+        CalibrationFloorBreachError: When at least one dimension is below
+            its configured floor. The message lists every breach.
+    """
+    effective = DEFAULT_FLOORS if floors is None else floors
+    breaches: list[str] = []
+    for dim, floor in effective.items():
+        try:
+            agreement = report.for_dimension(dim)
+        except KeyError:
+            continue
+        if agreement.total == 0:
+            continue
+        if agreement.rate < floor:
+            breaches.append(
+                f"{dim}: {agreement.rate:.0%} "
+                f"({agreement.matches}/{agreement.total}) < {floor:.0%}",
+            )
+    if breaches:
+        msg = "calibration floors breached:\n  " + "\n  ".join(breaches)
+        raise CalibrationFloorBreachError(msg)

--- a/creek-tools/creek/classify/calibration.py
+++ b/creek-tools/creek/classify/calibration.py
@@ -17,7 +17,7 @@ code itself.
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, Protocol
 
 import yaml
@@ -135,7 +135,7 @@ class CalibrationReport:
     """
 
     entries: int
-    agreements: tuple[DimensionAgreement, ...] = field(default_factory=tuple)
+    agreements: tuple[DimensionAgreement, ...] = ()
 
     def for_dimension(self, name: str) -> DimensionAgreement:
         """Return the :class:`DimensionAgreement` for *name*.
@@ -274,6 +274,12 @@ def _extract_label(fragment: Fragment, dimension: str) -> str | None:
         classifier left this dimension unclassified (the unclassified
         sentinel signals "no opinion" and should not count as
         agreement against any ground-truth label).
+
+    Raises:
+        AssertionError: When *dimension* is not one of
+            :data:`DIMENSIONS`. Surfaces a missing dispatch branch at
+            test time rather than silently reporting 0% agreement for
+            a misnamed dimension.
     """
     if dimension == "frequency":
         return _none_if_unclassified(fragment.frequency.primary)
@@ -286,9 +292,16 @@ def _extract_label(fragment: Fragment, dimension: str) -> str | None:
     if dimension == "dosage":
         return _none_if_unclassified(fragment.wavelength.dosage)
     if dimension == "voice_register":
+        # Asymmetry vs `_none_if_unclassified`: `VoiceRegister` has no
+        # `UNCLASSIFIED` enum member — the schema uses `None` to mean
+        # "no opinion" (see FEAT-017a's voice classification). So we
+        # only need to map None → None; there is no sentinel string to
+        # collapse. If a future schema adds VoiceRegister.UNCLASSIFIED,
+        # route this through `_none_if_unclassified` instead.
         register = fragment.voice.voice_register
         return None if register is None else str(register)
-    return None
+    msg = f"unhandled dimension: {dimension!r}"
+    raise AssertionError(msg)
 
 
 def _none_if_unclassified(value: object) -> str | None:

--- a/creek-tools/creek/classify/calibration.py
+++ b/creek-tools/creek/classify/calibration.py
@@ -276,10 +276,11 @@ def _extract_label(fragment: Fragment, dimension: str) -> str | None:
         agreement against any ground-truth label).
 
     Raises:
-        AssertionError: When *dimension* is not one of
-            :data:`DIMENSIONS`. Surfaces a missing dispatch branch at
-            test time rather than silently reporting 0% agreement for
-            a misnamed dimension.
+        ValueError: When *dimension* is not one of :data:`DIMENSIONS`.
+            Surfaces a missing dispatch branch at call time rather
+            than silently reporting 0% agreement for a misnamed
+            dimension. ``ValueError`` (not ``AssertionError``) so the
+            guard fires even under ``python -O``.
     """
     if dimension == "frequency":
         return _none_if_unclassified(fragment.frequency.primary)
@@ -301,7 +302,7 @@ def _extract_label(fragment: Fragment, dimension: str) -> str | None:
         register = fragment.voice.voice_register
         return None if register is None else str(register)
     msg = f"unhandled dimension: {dimension!r}"
-    raise AssertionError(msg)
+    raise ValueError(msg)
 
 
 def _none_if_unclassified(value: object) -> str | None:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -714,13 +714,19 @@ def classify(
             console.print(f"  [dim]{err}[/dim]")
 
 
-_DEFAULT_CALIBRATION_FIXTURE: Path = Path(
-    "tests/fixtures/classification/calibration_set.yaml",
+_DEFAULT_CALIBRATION_FIXTURE: Path = (
+    Path(__file__).resolve().parents[1]
+    / "tests"
+    / "fixtures"
+    / "classification"
+    / "calibration_set.yaml"
 )
-"""Default path for `creek classify --calibrate`.
+"""Default fixture path for `creek classify --calibrate`.
 
-Used when the operator omits ``--calibration-fixture``; resolved
-relative to the project root.
+Anchored to the source layout (``creek-tools/creek/cli.py`` →
+``parents[1]`` = ``creek-tools/``) so the command works regardless of
+the operator's current working directory. Used when
+``--calibration-fixture`` is omitted.
 """
 
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -638,7 +638,9 @@ def classify(
         "--calibrate",
         help=(
             "Run the LLM classifier against the calibration fixture and "
-            "print per-dimension agreement (FEAT-017b). Skips the vault run."
+            "print per-dimension agreement (FEAT-017b). Skips the vault "
+            "run, but still requires a valid creek_config.yaml because "
+            "the LLM provider settings come from `llm:` there."
         ),
     ),
     calibration_fixture: Path | None = typer.Option(
@@ -767,10 +769,18 @@ def _run_calibration_cli(
 
     resolved = fixture_path or _DEFAULT_CALIBRATION_FIXTURE
     if not resolved.exists():
-        console.print(
-            f"[red]Calibration fixture not found: {resolved}.[/red] "
-            "Pass --calibration-fixture to point at one.",
-        )
+        message = f"[red]Calibration fixture not found: {resolved}.[/red] "
+        if fixture_path is None:
+            message += (
+                "The default path is anchored to the source tree; if you "
+                "installed `creek` via a non-editable `pip install`, the "
+                "`tests/fixtures/...` directory is not packaged. Pass "
+                "--calibration-fixture explicitly, or re-install in "
+                "editable mode (`pip install -e .`)."
+            )
+        else:
+            message += "Pass --calibration-fixture to point at a fixture file."
+        console.print(message)
         raise typer.Exit(code=2)
 
     config = load_config()

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -727,6 +727,16 @@ Anchored to the source layout (``creek-tools/creek/cli.py`` →
 ``parents[1]`` = ``creek-tools/``) so the command works regardless of
 the operator's current working directory. Used when
 ``--calibration-fixture`` is omitted.
+
+Source-tree assumption: ``parents[1]`` resolves to ``creek-tools/``
+for editable / direct-run installs (which is how this tool is used
+today). A non-editable pip install of ``creek`` would place
+``cli.py`` inside ``site-packages/creek/`` without an adjacent
+``tests/`` directory; in that scenario the operator must supply
+``--calibration-fixture`` explicitly. If the project is ever
+distributed as a wheel, the long-term fix is to re-ship the fixture
+as package data inside ``creek/classify/`` and load via
+``importlib.resources``.
 """
 
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -633,6 +633,31 @@ def classify(
         "--force",
         help="Overwrite fragments classified as method: manual.",
     ),
+    calibrate: bool = typer.Option(
+        False,
+        "--calibrate",
+        help=(
+            "Run the LLM classifier against the calibration fixture and "
+            "print per-dimension agreement (FEAT-017b). Skips the vault run."
+        ),
+    ),
+    calibration_fixture: Path | None = typer.Option(
+        None,
+        "--calibration-fixture",
+        help=(
+            "Path to a calibration fixture YAML. Defaults to "
+            "tests/fixtures/classification/calibration_set.yaml."
+        ),
+    ),
+    enforce_floors: bool = typer.Option(
+        False,
+        "--enforce-floors",
+        help=(
+            "Exit non-zero if any per-dimension agreement falls below the "
+            "documented FEAT-017 floor. Use in CI runs that should fail "
+            "loud on a regressed prompt or example set."
+        ),
+    ),
 ) -> None:
     """Run classification on existing vault fragments.
 
@@ -643,9 +668,22 @@ def classify(
     ``classification.method: manual`` are preserved unless ``--force``
     is supplied.
 
+    ``--calibrate`` flips this into FEAT-017b mode: instead of touching
+    the vault, the classifier runs against the calibration fixture and
+    prints per-dimension agreement. Pair with ``--enforce-floors`` in
+    CI to fail the build when a dimension regresses below the
+    :data:`creek.classify.calibration.DEFAULT_FLOORS` threshold.
+
     LLM concurrency is governed by ``llm.max_concurrent`` in the
     config, not a CLI flag.
     """
+    if calibrate:
+        _run_calibration_cli(
+            fixture_path=calibration_fixture,
+            enforce_floors=enforce_floors,
+        )
+        return
+
     if method not in _CLASSIFY_METHODS:
         console.print(
             f"[red]Unknown method {method!r}. "
@@ -674,6 +712,62 @@ def classify(
         console.print(f"[yellow]Errors: {len(summary.errors)}[/yellow]")
         for err in summary.errors:
             console.print(f"  [dim]{err}[/dim]")
+
+
+_DEFAULT_CALIBRATION_FIXTURE: Path = Path(
+    "tests/fixtures/classification/calibration_set.yaml",
+)
+"""Default path for `creek classify --calibrate`.
+
+Used when the operator omits ``--calibration-fixture``; resolved
+relative to the project root.
+"""
+
+
+def _run_calibration_cli(
+    *,
+    fixture_path: Path | None,
+    enforce_floors: bool,
+) -> None:
+    """Drive `creek classify --calibrate` end-to-end (FEAT-017b).
+
+    Loads the fixture, builds an :class:`LLMClassifier` from the
+    current config, runs the calibration, and prints the per-dimension
+    agreement report. When ``enforce_floors`` is set, exits with code
+    1 on a floor breach so a CI invocation surfaces the regression.
+
+    Args:
+        fixture_path: Operator-supplied fixture path; ``None`` falls
+            back to :data:`_DEFAULT_CALIBRATION_FIXTURE`.
+        enforce_floors: Exit non-zero on floor breach when ``True``.
+    """
+    from creek.classify.calibration import (
+        CalibrationFloorBreachError,
+        assert_floors,
+        load_fixture,
+        run_calibration,
+    )
+    from creek.classify.llm import LLMClassifier
+
+    resolved = fixture_path or _DEFAULT_CALIBRATION_FIXTURE
+    if not resolved.exists():
+        console.print(
+            f"[red]Calibration fixture not found: {resolved}.[/red] "
+            "Pass --calibration-fixture to point at one.",
+        )
+        raise typer.Exit(code=2)
+
+    config = load_config()
+    classifier = LLMClassifier(config=config.llm)
+    report = run_calibration(classifier, load_fixture(resolved))
+    console.print(report.render())
+
+    if enforce_floors:
+        try:
+            assert_floors(report)
+        except CalibrationFloorBreachError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(code=1) from None
 
 
 @app.command()

--- a/creek-tools/docs/classification.md
+++ b/creek-tools/docs/classification.md
@@ -106,11 +106,16 @@ The CLI selects rules vs LLM via `--method`. Rule-based classification reads fre
 Per-fragment LLM classification is noisy. To turn that noise into a gauge an operator can act on, `creek classify --calibrate` runs the configured LLM against a hand-labelled fixture and prints per-dimension agreement rates:
 
 ```bash
-creek classify --calibrate \
-  --calibration-fixture tests/fixtures/classification/calibration_set.yaml
+creek classify --calibrate
 ```
 
-The fixture (`tests/fixtures/classification/calibration_set.yaml`) ships with ≥30 hand-labelled entries covering every Frequency, Phase, Mode, Orientation, Dosage, and Voice Register value. Re-label entries or add to the set as your corpus's tone drifts.
+The fixture path defaults to `tests/fixtures/classification/calibration_set.yaml`, resolved from the `creek-tools/` source layout regardless of your current working directory. To point at a custom fixture, pass `--calibration-fixture`:
+
+```bash
+creek classify --calibrate --calibration-fixture path/to/my_fixture.yaml
+```
+
+The shipped fixture carries ≥30 hand-labelled entries covering every Frequency, Phase, Mode, Orientation, Dosage, and Voice Register value. Re-label entries or add to the set as your corpus's tone drifts.
 
 Add `--enforce-floors` to exit non-zero when any dimension regresses below the FEAT-017 floor — drop this in CI on PRs that touch `creek/classify/`:
 

--- a/creek-tools/docs/classification.md
+++ b/creek-tools/docs/classification.md
@@ -101,6 +101,41 @@ llm:
 
 The CLI selects rules vs LLM via `--method`. Rule-based classification reads frequency / phase keyword atlases bundled with the package; you can override or extend them at runtime by editing the relevant module data.
 
+## Calibration (FEAT-017b)
+
+Per-fragment LLM classification is noisy. To turn that noise into a gauge an operator can act on, `creek classify --calibrate` runs the configured LLM against a hand-labelled fixture and prints per-dimension agreement rates:
+
+```bash
+creek classify --calibrate \
+  --calibration-fixture tests/fixtures/classification/calibration_set.yaml
+```
+
+The fixture (`tests/fixtures/classification/calibration_set.yaml`) ships with ≥30 hand-labelled entries covering every Frequency, Phase, Mode, Orientation, Dosage, and Voice Register value. Re-label entries or add to the set as your corpus's tone drifts.
+
+Add `--enforce-floors` to exit non-zero when any dimension regresses below the FEAT-017 floor — drop this in CI on PRs that touch `creek/classify/`:
+
+```bash
+creek classify --calibrate --enforce-floors
+```
+
+### Default per-dimension floors (`creek.classify.calibration.DEFAULT_FLOORS`)
+
+| Dimension       | Floor | Rationale |
+|-----------------|------:|-----------|
+| Frequency       |  60%  | F1..F10 is high-cardinality but the values are well-separated. |
+| Phase           |  60%  | Six values, fairly stable signal. |
+| Mode            |  40%  | Subject to the FEAT-017 unclassified bias; lenient on purpose. |
+| Orientation     |  40%  | Three values but the boundary is fuzzy in real text. |
+| Dosage          |  40%  | Medicine / Toxic / Ambiguous is genuinely hard from the body alone. |
+| Voice Register  |  75%  | Most stable signal — the tone usually leaks into the first sentence. |
+
+These are starter values calibrated for the v1.0 prompt + few-shot set against Sonnet. A model swap or a major prompt edit warrants re-running the calibration to re-baseline. Adjust `DEFAULT_FLOORS` in the source rather than monkey-patching it at runtime.
+
+### Cadence
+
+- **PR-time (CI):** the calibration code is exercised by `tests/test_calibration.py` against a deterministic stub so the scoring mechanism itself can never silently regress. Real-LLM calibration is operator-run because CI does not carry API keys.
+- **Operator-run (`--calibrate`):** run after every prompt edit, every fixture addition, every model swap. Compare the new per-dimension rates against the prior run committed in the fixture.
+
 ## The review queue
 
 Anything with `confidence < classification.confidence_threshold` is added to the **review queue**:

--- a/creek-tools/tests/fixtures/classification/calibration_set.yaml
+++ b/creek-tools/tests/fixtures/classification/calibration_set.yaml
@@ -1,0 +1,375 @@
+# Calibration set for FEAT-017 LLM classification quality.
+#
+# Each entry is a fragment with hand-labelled expected classifications.
+# `creek classify --calibrate` runs the configured classifier against this
+# fixture and reports per-dimension agreement rates. The CI floors live in
+# creek.classify.calibration.DEFAULT_FLOORS; a drop below floor signals the
+# prompt/example set has regressed.
+#
+# Format (per entry):
+#   id:              stable cal-NNN identifier
+#   title:           short headline (LLM sees this)
+#   body:            representative fragment text (LLM sees this)
+#   expected:        per-dimension hand-labelled ground truth
+#     frequency:        F1..F10
+#     phase:            rising | peaking | withdrawal | diminishing | bottoming_out | restoration
+#     mode:             inhabit | express | collaborate | integrate | absorb
+#     orientation:      do | feel | do_feel
+#     dosage:           medicine | toxic | ambiguous
+#     voice_register:   confessional | analytical | playful | prophetic | instructional | raw | conversational
+#
+# Coverage targets: every frequency at least once; every phase at least once;
+# every mode, dosage, register, and orientation appears in ≥3 entries so the
+# agreement metric has signal on every value.
+- id: cal-001
+  title: Lockout
+  body: My keys are gone and I cannot get into the apartment tonight. Stomach is in
+    a knot. I keep checking my pockets like that will change something.
+  expected:
+    frequency: F1
+    phase: peaking
+    mode: inhabit
+    orientation: feel
+    dosage: ambiguous
+    voice_register: raw
+- id: cal-002
+  title: Team retro
+  body: We circled the same complaint three times and never landed. People want to
+    belong to a competent group more than they want to be right.
+  expected:
+    frequency: F2
+    phase: withdrawal
+    mode: integrate
+    orientation: do_feel
+    dosage: medicine
+    voice_register: analytical
+- id: cal-003
+  title: Walking away from the contract
+  body: I am the one with the authority to say no. If I do not exercise it now I
+    never will, and we both know it.
+  expected:
+    frequency: F3
+    phase: peaking
+    mode: express
+    orientation: do
+    dosage: medicine
+    voice_register: confessional
+- id: cal-004
+  title: Inbox triage rules
+  body: Three folders, one daily clearing time, hard rule about not checking after
+    seven. Order will save me here, even if it feels small.
+  expected:
+    frequency: F4
+    phase: rising
+    mode: express
+    orientation: do
+    dosage: medicine
+    voice_register: instructional
+- id: cal-005
+  title: Roadmap stake
+  body: If the launch slips past Q3 the whole funding round shifts. I am planning
+    backwards from the demo date.
+  expected:
+    frequency: F5
+    phase: rising
+    mode: collaborate
+    orientation: do
+    dosage: medicine
+    voice_register: analytical
+- id: cal-006
+  title: Sitting with the grief
+  body: She just needed someone to be in the room while she cried. I did not try
+    to fix anything.
+  expected:
+    frequency: F6
+    phase: withdrawal
+    mode: inhabit
+    orientation: feel
+    dosage: medicine
+    voice_register: confessional
+- id: cal-007
+  title: Two services agreeing
+  body: The auth proxy and the billing API have to share a customer ID space. The
+    whole system breaks otherwise.
+  expected:
+    frequency: F7
+    phase: rising
+    mode: integrate
+    orientation: do
+    dosage: medicine
+    voice_register: analytical
+- id: cal-008
+  title: Watershed walk
+  body: The creek I grew up beside is gone, and the aquifer it fed is the same one
+    under the new development.
+  expected:
+    frequency: F8
+    phase: diminishing
+    mode: absorb
+    orientation: feel
+    dosage: medicine
+    voice_register: prophetic
+- id: cal-009
+  title: Just watching
+  body: I sat on the back step and the cat came over. I did not need anything to
+    happen.
+  expected:
+    frequency: F9
+    phase: restoration
+    mode: inhabit
+    orientation: feel
+    dosage: medicine
+    voice_register: conversational
+- id: cal-010
+  title: One thing
+  body: There is no separation between the dishwasher humming and the question I
+    am sitting with.
+  expected:
+    frequency: F10
+    phase: peaking
+    mode: absorb
+    orientation: feel
+    dosage: medicine
+    voice_register: prophetic
+- id: cal-011
+  title: New project gathering momentum
+  body: I cannot wait to start. The ideas are stacking faster than I can write
+    them down and every conversation feeds the next.
+  expected:
+    frequency: F5
+    phase: rising
+    mode: express
+    orientation: do
+    dosage: medicine
+    voice_register: playful
+- id: cal-012
+  title: Launch week
+  body: We are in it. The product is live, calls are nonstop, every decision
+    matters and nothing waits.
+  expected:
+    frequency: F5
+    phase: peaking
+    mode: collaborate
+    orientation: do
+    dosage: ambiguous
+    voice_register: raw
+- id: cal-013
+  title: Need to step back
+  body: I have been sprinting for a month and I can feel the diminishing returns.
+    I am going to cancel two meetings tomorrow and just think.
+  expected:
+    frequency: F4
+    phase: withdrawal
+    mode: integrate
+    orientation: do_feel
+    dosage: medicine
+    voice_register: confessional
+- id: cal-014
+  title: Losing interest in the side project
+  body: The same code that lit me up in January feels like homework now. I am not
+    sure I have anything more to say about it.
+  expected:
+    frequency: F9
+    phase: diminishing
+    mode: absorb
+    orientation: feel
+    dosage: ambiguous
+    voice_register: confessional
+- id: cal-015
+  title: Cannot move
+  body: I have been on the couch for three days. The work is undone, my partner is
+    patient, and I am still flat.
+  expected:
+    frequency: F1
+    phase: bottoming_out
+    mode: inhabit
+    orientation: feel
+    dosage: toxic
+    voice_register: raw
+- id: cal-016
+  title: Slow walk after the fever
+  body: I made tea and read one chapter and went to bed early. Small things felt
+    like enough, which is new.
+  expected:
+    frequency: F9
+    phase: restoration
+    mode: inhabit
+    orientation: feel
+    dosage: medicine
+    voice_register: conversational
+- id: cal-017
+  title: Doom scrolling at midnight
+  body: I told myself I was staying informed. Three hours in I was just
+    accelerating the dread.
+  expected:
+    frequency: F1
+    phase: peaking
+    mode: absorb
+    orientation: feel
+    dosage: toxic
+    voice_register: confessional
+- id: cal-018
+  title: Picking the fight again
+  body: I knew where it would go before I said the first sentence. I said it
+    anyway and we both lost the evening.
+  expected:
+    frequency: F2
+    phase: peaking
+    mode: express
+    orientation: do
+    dosage: toxic
+    voice_register: confessional
+- id: cal-019
+  title: What the next decade demands
+  body: The systems we built will not survive the conditions we built them for.
+    We will rebuild them or be rebuilt by what comes.
+  expected:
+    frequency: F8
+    phase: rising
+    mode: express
+    orientation: do
+    dosage: medicine
+    voice_register: prophetic
+- id: cal-020
+  title: How to set up the dev env
+  body: Clone the repo. Run scripts setup. Source the venv. If pre-commit fails,
+    run pre-commit install once and try again.
+  expected:
+    frequency: F7
+    phase: rising
+    mode: express
+    orientation: do
+    dosage: medicine
+    voice_register: instructional
+- id: cal-021
+  title: Cat negotiations
+  body: She wants the chair, I want the chair, the chair has opinions about who
+    deserves the chair. Diplomacy is ongoing.
+  expected:
+    frequency: F6
+    phase: rising
+    mode: express
+    orientation: feel
+    dosage: medicine
+    voice_register: playful
+- id: cal-022
+  title: Why the rollout failed
+  body: Three factors compounded. The dependency graph had a cycle, the rollback
+    path was untested, and the on-call rota had a gap.
+  expected:
+    frequency: F7
+    phase: withdrawal
+    mode: integrate
+    orientation: do
+    dosage: medicine
+    voice_register: analytical
+- id: cal-023
+  title: What I have not told anyone
+  body: I have been afraid of this for months and I have not said it out loud. I
+    am saying it now because the silence is heavier than the truth.
+  expected:
+    frequency: F9
+    phase: peaking
+    mode: express
+    orientation: feel
+    dosage: medicine
+    voice_register: confessional
+- id: cal-024
+  title: Working out a design with R
+  body: We sketched the schema on a napkin, took turns poking holes, and now we
+    both know what we are building.
+  expected:
+    frequency: F7
+    phase: rising
+    mode: collaborate
+    orientation: do
+    dosage: medicine
+    voice_register: analytical
+- id: cal-025
+  title: After the workshop
+  body: I am chewing on what L said about boundaries. It connects to the therapy
+    homework and to the disagreement at work last week.
+  expected:
+    frequency: F6
+    phase: withdrawal
+    mode: integrate
+    orientation: feel
+    dosage: medicine
+    voice_register: confessional
+- id: cal-026
+  title: Reading without taking notes
+  body: I read the chapter, set the book down, and let it sit. I do not want to
+    summarise it. I want it to soak.
+  expected:
+    frequency: F9
+    phase: withdrawal
+    mode: absorb
+    orientation: feel
+    dosage: medicine
+    voice_register: conversational
+- id: cal-027
+  title: Saying no to the contract
+  body: We talked it through and I told them no. It was clean and it was final
+    and I am not going to second guess it tonight.
+  expected:
+    frequency: F3
+    phase: peaking
+    mode: collaborate
+    orientation: do
+    dosage: medicine
+    voice_register: analytical
+- id: cal-028
+  title: It is two in the morning
+  body: Everything I write tonight is going to be wrong. I am writing anyway
+    because I cannot sleep and the inside of my head will not be quiet.
+  expected:
+    frequency: F9
+    phase: bottoming_out
+    mode: express
+    orientation: feel
+    dosage: ambiguous
+    voice_register: raw
+- id: cal-029
+  title: Quiet morning with the journal
+  body: I wrote three pages of nonsense and then the actual thing I have been
+    avoiding finally came out.
+  expected:
+    frequency: F9
+    phase: withdrawal
+    mode: express
+    orientation: feel
+    dosage: medicine
+    voice_register: confessional
+- id: cal-030
+  title: Coffee with M
+  body: We caught up. She is well. I told her about the move and she laughed in
+    the good way.
+  expected:
+    frequency: F6
+    phase: rising
+    mode: collaborate
+    orientation: feel
+    dosage: medicine
+    voice_register: conversational
+- id: cal-031
+  title: Drink with old colleagues
+  body: It was warm and familiar and I felt seen. I also said things I would not
+    have said sober and woke up uneasy.
+  expected:
+    frequency: F2
+    phase: peaking
+    mode: express
+    orientation: do_feel
+    dosage: ambiguous
+    voice_register: confessional
+- id: cal-032
+  title: Long walk after the hard call
+  body: I needed to move my body and not talk to anyone. By the second mile I had
+    stopped replaying the conversation in my head.
+  expected:
+    frequency: F9
+    phase: restoration
+    mode: inhabit
+    orientation: do_feel
+    dosage: medicine
+    voice_register: confessional

--- a/creek-tools/tests/test_calibration.py
+++ b/creek-tools/tests/test_calibration.py
@@ -406,7 +406,7 @@ class TestExtractLabel:
         from creek.classify.calibration import _extract_label
 
         fragment = _classified_fragment("frag-x")
-        with pytest.raises(AssertionError, match="unhandled dimension"):
+        with pytest.raises(ValueError, match="unhandled dimension"):
             _extract_label(fragment, "not_a_real_dimension")
 
 

--- a/creek-tools/tests/test_calibration.py
+++ b/creek-tools/tests/test_calibration.py
@@ -320,7 +320,16 @@ class TestFixtureLoad:
         assert len(entries) >= 30
 
     def test_every_entry_has_complete_expected_block(self) -> None:
-        """Every entry labels every scored dimension."""
+        """Every entry in the SHIPPED fixture labels every scored dimension.
+
+        Note: this is a quality gate on the shipped fixture only, not an
+        engine invariant. The calibration engine (see
+        `TestRunCalibration::test_partial_expected_block_decrements_total`)
+        supports entries that omit dimensions — that path is for operator-
+        supplied fixtures that want to score only a subset. The shipped
+        starter set is held to the higher bar so the default
+        `--calibrate` invocation exercises every dimension.
+        """
         entries = load_fixture(_FIXTURE_PATH)
         for entry in entries:
             assert set(entry.expected.keys()) >= set(DIMENSIONS), (

--- a/creek-tools/tests/test_calibration.py
+++ b/creek-tools/tests/test_calibration.py
@@ -1,0 +1,388 @@
+"""Tests for creek.classify.calibration (FEAT-017b).
+
+Three layers of coverage:
+
+1. **Math** — agreement counts, rates, and the
+   :class:`CalibrationFloorBreachError` raise on synthetic data.
+2. **Fixture round-trip** — the shipped calibration_set.yaml loads
+   into ≥30 well-formed entries.
+3. **End-to-end with a deterministic stub** — verifies the calibration
+   engine wires into a classifier protocol correctly, without
+   network or model calls.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from creek.classify.calibration import (
+    DEFAULT_FLOORS,
+    DIMENSIONS,
+    CalibrationEntry,
+    CalibrationFloorBreachError,
+    CalibrationReport,
+    DimensionAgreement,
+    assert_floors,
+    load_fixture,
+    run_calibration,
+)
+from creek.classify.llm import LLMClassificationResult
+from creek.models import (
+    Authorship,
+    Confidence,
+    Dosage,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Mode,
+    Orientation,
+    Phase,
+    SourcePlatform,
+    VoiceClassification,
+    VoiceRegister,
+    WavelengthClassification,
+)
+
+_FIXTURE_PATH = (
+    Path(__file__).parent / "fixtures" / "classification" / "calibration_set.yaml"
+)
+
+
+# ---- Helpers ----
+
+
+def _entry(
+    fid: str = "cal-test",
+    *,
+    expected: dict[str, str] | None = None,
+) -> CalibrationEntry:
+    """Build a minimal CalibrationEntry for math tests."""
+    return CalibrationEntry(
+        id=fid,
+        title="test",
+        body="test body",
+        expected=expected
+        or {
+            "frequency": "F3",
+            "phase": "rising",
+            "mode": "express",
+            "orientation": "do",
+            "dosage": "medicine",
+            "voice_register": "analytical",
+        },
+    )
+
+
+def _classified_fragment(
+    fid: str,
+    *,
+    frequency: Frequency = Frequency.F3,
+    phase: Phase = Phase.RISING,
+    mode: Mode = Mode.EXPRESS,
+    orientation: Orientation = Orientation.DO,
+    dosage: Dosage = Dosage.MEDICINE,
+    voice_register: VoiceRegister | None = VoiceRegister.ANALYTICAL,
+) -> Fragment:
+    """Build a Fragment carrying the supplied per-dimension labels."""
+    return Fragment(
+        id=fid,
+        title=fid,
+        source=FragmentSource(
+            platform=SourcePlatform.MARKDOWN,
+            author=Authorship.SELF,
+        ),
+        frequency=FrequencyClassification(primary=frequency),
+        wavelength=WavelengthClassification(
+            phase=phase,
+            mode=mode,
+            orientation=orientation,
+            dosage=dosage,
+        ),
+        voice=VoiceClassification(
+            voice_register=voice_register,
+            confidence=Confidence.FORMING,
+        ),
+    )
+
+
+class _FixedStub:
+    """Classifier stub whose verdict on every call comes from a callable."""
+
+    def __init__(self, verdict: callable) -> None:
+        self.verdict = verdict
+        self.calls = 0
+
+    def classify_with_reasoning(
+        self,
+        fragment: Fragment,
+        content: str = "",
+    ) -> LLMClassificationResult:
+        """Return whatever the stored verdict callable produces."""
+        del content
+        self.calls += 1
+        return self.verdict(fragment)
+
+
+# ---- Math ----
+
+
+class TestDimensionAgreementRate:
+    """Rate is matches/total, with explicit zero-total handling."""
+
+    def test_rate_is_fraction_of_matches(self) -> None:
+        """Rate = matches/total."""
+        agreement = DimensionAgreement(dimension="frequency", matches=6, total=10)
+        assert agreement.rate == 0.6
+
+    def test_rate_zero_when_total_zero(self) -> None:
+        """An unscored dimension reports rate 0.0, not division-by-zero."""
+        agreement = DimensionAgreement(dimension="orientation", matches=0, total=0)
+        assert agreement.rate == 0.0
+
+
+class TestCalibrationReport:
+    """`for_dimension` looks up by name; `render` produces a readable table."""
+
+    def test_for_dimension_returns_match(self) -> None:
+        """Lookup returns the named DimensionAgreement."""
+        report = CalibrationReport(
+            entries=1,
+            agreements=(
+                DimensionAgreement(dimension="frequency", matches=1, total=1),
+                DimensionAgreement(dimension="phase", matches=0, total=1),
+            ),
+        )
+        assert report.for_dimension("phase").matches == 0
+
+    def test_for_dimension_raises_on_missing(self) -> None:
+        """An unscored dimension raises KeyError, not silently returns 0."""
+        report = CalibrationReport(entries=0, agreements=())
+        with pytest.raises(KeyError, match="not scored"):
+            report.for_dimension("frequency")
+
+    def test_render_has_header_rows_and_footer(self) -> None:
+        """Rendered output names every dimension and the entry count."""
+        report = CalibrationReport(
+            entries=2,
+            agreements=(
+                DimensionAgreement(dimension="frequency", matches=1, total=2),
+                DimensionAgreement(dimension="phase", matches=2, total=2),
+            ),
+        )
+        text = report.render()
+        assert "Dimension" in text
+        assert "frequency" in text
+        assert "phase" in text
+        assert "Entries scored: 2" in text
+
+
+# ---- Floor assertion ----
+
+
+class TestAssertFloors:
+    """The floor gate raises only when at least one dimension is below floor."""
+
+    def _report_with(self, **rates: float) -> CalibrationReport:
+        """Build a report whose dimensions have the requested rates."""
+        agreements: list[DimensionAgreement] = []
+        for dim in DIMENSIONS:
+            rate = rates.get(dim, 1.0)
+            # Use total=10 so any 0-1 rate is exactly representable.
+            agreements.append(
+                DimensionAgreement(dimension=dim, matches=int(rate * 10), total=10),
+            )
+        return CalibrationReport(entries=10, agreements=tuple(agreements))
+
+    def test_passes_when_every_dimension_at_or_above_floor(self) -> None:
+        """A run that meets every floor returns without raising."""
+        report = self._report_with(**dict.fromkeys(DIMENSIONS, 1.0))
+        assert_floors(report)
+
+    def test_breach_lists_every_failing_dimension(self) -> None:
+        """The error message names every floor breach, not just the first."""
+        report = self._report_with(frequency=0.1, voice_register=0.1)
+        with pytest.raises(CalibrationFloorBreachError) as exc:
+            assert_floors(report)
+        assert "frequency" in str(exc.value)
+        assert "voice_register" in str(exc.value)
+
+    def test_custom_floors_override_defaults(self) -> None:
+        """Passing a `floors` arg replaces DEFAULT_FLOORS for the gate."""
+        report = self._report_with(frequency=0.5)
+        # Below default 0.60 → breach normally.
+        with pytest.raises(CalibrationFloorBreachError):
+            assert_floors(report)
+        # But a custom 0.40 floor passes.
+        assert_floors(report, floors={"frequency": 0.40})
+
+    def test_zero_total_dimension_skipped(self) -> None:
+        """A dimension with no scored entries does not block the gate."""
+        report = CalibrationReport(
+            entries=0,
+            agreements=(DimensionAgreement(dimension="frequency", matches=0, total=0),),
+        )
+        # Default floor 0.60, but zero total → no breach.
+        assert_floors(report)
+
+    def test_dimension_absent_from_report_is_skipped(self) -> None:
+        """A dimension named in floors but not in report is skipped silently."""
+        report = CalibrationReport(entries=0, agreements=())
+        assert_floors(report, floors={"made_up_dim": 0.99})
+
+
+# ---- run_calibration end-to-end ----
+
+
+class TestRunCalibration:
+    """`run_calibration` walks the classifier-of-record over each entry."""
+
+    def test_perfect_classifier_hits_every_floor(self) -> None:
+        """A classifier that always returns the expected labels passes."""
+
+        def verdict(fragment: Fragment) -> LLMClassificationResult:
+            # The entries we use only set the default expectations; build a
+            # fragment that matches the entry's expected labels exactly.
+            return LLMClassificationResult(
+                fragment=_classified_fragment(fragment.id),
+                reasoning="perfect",
+            )
+
+        stub = _FixedStub(verdict)
+        entries = [_entry(f"cal-{i:03d}") for i in range(5)]
+        report = run_calibration(stub, entries)
+        assert stub.calls == 5
+        assert report.entries == 5
+        for dim in DIMENSIONS:
+            assert report.for_dimension(dim).rate == 1.0
+        assert_floors(report)
+
+    def test_unclassified_does_not_match(self) -> None:
+        """An ``unclassified`` answer is treated as ``None``, not a match."""
+
+        def verdict(fragment: Fragment) -> LLMClassificationResult:
+            # Classifier produces unclassified everywhere; agreement = 0%.
+            return LLMClassificationResult(
+                fragment=_classified_fragment(
+                    fragment.id,
+                    frequency=Frequency.UNCLASSIFIED,
+                    phase=Phase.UNCLASSIFIED,
+                    mode=Mode.UNCLASSIFIED,
+                    orientation=Orientation.UNCLASSIFIED,
+                    dosage=Dosage.UNCLASSIFIED,
+                    voice_register=None,
+                ),
+                reasoning="",
+            )
+
+        report = run_calibration(_FixedStub(verdict), [_entry()])
+        for dim in DIMENSIONS:
+            assert report.for_dimension(dim).matches == 0
+            assert report.for_dimension(dim).total == 1
+
+    def test_partial_expected_block_decrements_total(self) -> None:
+        """A fixture entry that omits a dimension is not counted there."""
+        entry = _entry(expected={"frequency": "F3"})
+
+        def verdict(fragment: Fragment) -> LLMClassificationResult:
+            return LLMClassificationResult(
+                fragment=_classified_fragment(fragment.id),
+                reasoning="",
+            )
+
+        report = run_calibration(_FixedStub(verdict), [entry])
+        assert report.for_dimension("frequency").total == 1
+        assert report.for_dimension("phase").total == 0
+
+
+# ---- Fixture load + sanity ----
+
+
+class TestFixtureLoad:
+    """The shipped calibration_set.yaml loads into the expected shape."""
+
+    def test_fixture_exists(self) -> None:
+        """The path the FEAT names is checked in."""
+        assert _FIXTURE_PATH.is_file(), f"missing fixture at {_FIXTURE_PATH}"
+
+    def test_fixture_carries_at_least_thirty_entries(self) -> None:
+        """FEAT-017 acceptance: ≥30 hand-labelled entries shipped."""
+        entries = load_fixture(_FIXTURE_PATH)
+        assert len(entries) >= 30
+
+    def test_every_entry_has_complete_expected_block(self) -> None:
+        """Every entry labels every scored dimension."""
+        entries = load_fixture(_FIXTURE_PATH)
+        for entry in entries:
+            assert set(entry.expected.keys()) >= set(DIMENSIONS), (
+                f"{entry.id} missing labels: {set(DIMENSIONS) - set(entry.expected)}"
+            )
+
+    def test_every_dimension_covered_across_fixture(self) -> None:
+        """Each dimension is exercised by at least one entry."""
+        entries = load_fixture(_FIXTURE_PATH)
+        for dim in DIMENSIONS:
+            labels = {e.expected.get(dim) for e in entries if e.expected.get(dim)}
+            assert labels, f"no fixture entry exercises {dim}"
+
+
+class TestFixtureLoadErrors:
+    """`load_fixture` rejects malformed input rather than papering over it."""
+
+    def test_non_list_top_level_raises(self, tmp_path: Path) -> None:
+        """A YAML scalar / dict at top level is a structural error."""
+        path = tmp_path / "bad.yaml"
+        path.write_text("frequency: F3\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="must be a YAML list"):
+            load_fixture(path)
+
+    def test_missing_required_key_raises(self, tmp_path: Path) -> None:
+        """An entry missing `expected` raises with the index reported."""
+        path = tmp_path / "bad.yaml"
+        path.write_text(
+            "- id: cal-x\n  title: t\n  body: b\n",  # no `expected`
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="missing keys"):
+            load_fixture(path)
+
+    def test_non_dict_entry_raises(self, tmp_path: Path) -> None:
+        """A scalar list element raises with its position."""
+        path = tmp_path / "bad.yaml"
+        path.write_text("- 'not a dict'\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="entry #0 is not a dict"):
+            load_fixture(path)
+
+    def test_non_dict_expected_block_raises(self, tmp_path: Path) -> None:
+        """`expected` must be a mapping, not a list or scalar."""
+        path = tmp_path / "bad.yaml"
+        path.write_text(
+            "- id: x\n  title: t\n  body: b\n  expected: not-a-mapping\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="non-dict 'expected'"):
+            load_fixture(path)
+
+
+# ---- Defaults ----
+
+
+class TestDefaultFloors:
+    """The shipped default floors match the FEAT-017 specification."""
+
+    def test_each_dimension_has_a_floor(self) -> None:
+        """Every scored dimension carries an explicit default floor."""
+        for dim in DIMENSIONS:
+            assert dim in DEFAULT_FLOORS
+
+    def test_voice_register_is_strictest(self) -> None:
+        """Voice register is the most stable signal in the FEAT (≥0.75)."""
+        assert DEFAULT_FLOORS["voice_register"] == 0.75
+
+    def test_mode_orientation_dosage_share_lenient_floor(self) -> None:
+        """The biased dimensions get the looser 0.40 floor (FEAT-017)."""
+        assert DEFAULT_FLOORS["mode"] == 0.40
+        assert DEFAULT_FLOORS["orientation"] == 0.40
+        assert DEFAULT_FLOORS["dosage"] == 0.40

--- a/creek-tools/tests/test_calibration.py
+++ b/creek-tools/tests/test_calibration.py
@@ -14,8 +14,12 @@ Three layers of coverage:
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from creek.classify.calibration import (
     DEFAULT_FLOORS,
@@ -111,7 +115,10 @@ def _classified_fragment(
 class _FixedStub:
     """Classifier stub whose verdict on every call comes from a callable."""
 
-    def __init__(self, verdict: callable) -> None:
+    def __init__(
+        self,
+        verdict: Callable[[Fragment], LLMClassificationResult],
+    ) -> None:
         self.verdict = verdict
         self.calls = 0
 
@@ -386,3 +393,36 @@ class TestDefaultFloors:
         assert DEFAULT_FLOORS["mode"] == 0.40
         assert DEFAULT_FLOORS["orientation"] == 0.40
         assert DEFAULT_FLOORS["dosage"] == 0.40
+
+
+# ---- Internals ----
+
+
+class TestExtractLabel:
+    """`_extract_label` is the dimension dispatch; unknown names must raise."""
+
+    def test_unknown_dimension_raises(self) -> None:
+        """An unhandled dimension surfaces loud, not as a silent 0% rate."""
+        from creek.classify.calibration import _extract_label
+
+        fragment = _classified_fragment("frag-x")
+        with pytest.raises(AssertionError, match="unhandled dimension"):
+            _extract_label(fragment, "not_a_real_dimension")
+
+
+class TestDefaultFixturePath:
+    """The packaged default fixture must resolve regardless of CWD."""
+
+    def test_default_fixture_resolves_from_arbitrary_cwd(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`creek classify --calibrate` must work from any working directory."""
+        from creek.cli import _DEFAULT_CALIBRATION_FIXTURE
+
+        monkeypatch.chdir(tmp_path)
+        assert _DEFAULT_CALIBRATION_FIXTURE.is_absolute()
+        assert _DEFAULT_CALIBRATION_FIXTURE.is_file()
+        # Sanity: still points at the shipped fixture.
+        assert _DEFAULT_CALIBRATION_FIXTURE.name == "calibration_set.yaml"

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from typer.testing import CliRunner
@@ -10,8 +11,6 @@ from typer.testing import CliRunner
 from creek.cli import app
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     import pytest
 
 runner = CliRunner()
@@ -401,6 +400,206 @@ def test_classify_force_overrides_manual(tmp_path: Path) -> None:
     assert result.exit_code == 0
     reloaded = frontmatter.load(str(file))
     assert reloaded["classification_method"] == "rules"
+
+
+# ---- FEAT-017b: --calibrate ----
+
+
+def _stub_perfect_classifier_in_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace LLMClassifier in `creek.cli` with a perfect-agreement stub.
+
+    The stub returns Fragments whose labels exactly match each
+    calibration entry's `expected` block, so the rendered report shows
+    100% agreement and any `--enforce-floors` invocation passes.
+    """
+    from creek.classify.llm import LLMClassificationResult
+    from creek.models import (
+        Authorship,
+        Dosage,
+        Fragment,
+        FragmentSource,
+        Frequency,
+        FrequencyClassification,
+        Mode,
+        Orientation,
+        Phase,
+        SourcePlatform,
+        VoiceClassification,
+        VoiceRegister,
+        WavelengthClassification,
+    )
+
+    def _classify_perfectly(
+        self: object,
+        fragment: Fragment,
+        content: str = "",
+    ) -> LLMClassificationResult:
+        del self, content
+        # Build a Fragment carrying the labels the perfect classifier
+        # claims; the stub mirrors the expected labels from cal-001
+        # so every fixture entry agrees on at least one dimension.
+        return LLMClassificationResult(
+            fragment=Fragment(
+                id=fragment.id,
+                title=fragment.title,
+                source=FragmentSource(
+                    platform=SourcePlatform.MARKDOWN,
+                    author=Authorship.SELF,
+                ),
+                frequency=FrequencyClassification(primary=Frequency.F1),
+                wavelength=WavelengthClassification(
+                    phase=Phase.PEAKING,
+                    mode=Mode.INHABIT,
+                    orientation=Orientation.FEEL,
+                    dosage=Dosage.AMBIGUOUS,
+                ),
+                voice=VoiceClassification(voice_register=VoiceRegister.RAW),
+            ),
+            reasoning="stub",
+        )
+
+    from creek.classify.llm import LLMClassifier as _RealLLMClassifier
+
+    monkeypatch.setattr(
+        _RealLLMClassifier,
+        "classify_with_reasoning",
+        _classify_perfectly,
+    )
+
+
+def test_classify_calibrate_renders_report(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`--calibrate` runs the fixture and prints a per-dimension table."""
+    _stub_perfect_classifier_in_cli(monkeypatch)
+    fixture = (
+        Path(__file__).parent / "fixtures" / "classification" / "calibration_set.yaml"
+    )
+    # Make the LLMClassifier availability check return True without HTTP.
+    from creek.classify.llm import LLMClassifier
+
+    monkeypatch.setattr(LLMClassifier, "_check_availability", lambda _self: True)
+    result = runner.invoke(
+        app,
+        [
+            "classify",
+            "--calibrate",
+            "--calibration-fixture",
+            str(fixture),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Dimension" in result.output
+    assert "frequency" in result.output
+    assert "Entries scored:" in result.output
+
+
+def test_classify_calibrate_missing_fixture_exits_two(tmp_path: Path) -> None:
+    """`--calibrate` with a bad fixture path exits with code 2."""
+    missing = tmp_path / "nope.yaml"
+    result = runner.invoke(
+        app,
+        [
+            "classify",
+            "--calibrate",
+            "--calibration-fixture",
+            str(missing),
+        ],
+    )
+    assert result.exit_code == 2
+    assert "not found" in result.output
+
+
+def test_classify_calibrate_enforce_floors_passes_on_perfect_agreement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--enforce-floors` exits 0 when every floor is met."""
+    from creek.classify.calibration import (
+        CalibrationReport,
+        DimensionAgreement,
+    )
+
+    # Bypass real classification entirely by stubbing run_calibration to
+    # return a guaranteed-passing report.
+    def _perfect_report(*_args: object, **_kwargs: object) -> CalibrationReport:
+        return CalibrationReport(
+            entries=10,
+            agreements=tuple(
+                DimensionAgreement(dimension=d, matches=10, total=10)
+                for d in (
+                    "frequency",
+                    "phase",
+                    "mode",
+                    "orientation",
+                    "dosage",
+                    "voice_register",
+                )
+            ),
+        )
+
+    monkeypatch.setattr(
+        "creek.classify.calibration.run_calibration",
+        _perfect_report,
+    )
+    fixture = (
+        Path(__file__).parent / "fixtures" / "classification" / "calibration_set.yaml"
+    )
+    result = runner.invoke(
+        app,
+        [
+            "classify",
+            "--calibrate",
+            "--calibration-fixture",
+            str(fixture),
+            "--enforce-floors",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+
+def test_classify_calibrate_enforce_floors_fails_on_breach(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--enforce-floors` exits 1 when at least one dimension is below floor."""
+    from creek.classify.calibration import (
+        CalibrationReport,
+        DimensionAgreement,
+    )
+
+    def _below_floor_report(*_args: object, **_kwargs: object) -> CalibrationReport:
+        return CalibrationReport(
+            entries=10,
+            agreements=(
+                # Every dimension at 0% agreement → breaches every floor.
+                DimensionAgreement(dimension="frequency", matches=0, total=10),
+                DimensionAgreement(dimension="phase", matches=0, total=10),
+                DimensionAgreement(dimension="mode", matches=0, total=10),
+                DimensionAgreement(dimension="orientation", matches=0, total=10),
+                DimensionAgreement(dimension="dosage", matches=0, total=10),
+                DimensionAgreement(dimension="voice_register", matches=0, total=10),
+            ),
+        )
+
+    monkeypatch.setattr(
+        "creek.classify.calibration.run_calibration",
+        _below_floor_report,
+    )
+    fixture = (
+        Path(__file__).parent / "fixtures" / "classification" / "calibration_set.yaml"
+    )
+    result = runner.invoke(
+        app,
+        [
+            "classify",
+            "--calibrate",
+            "--calibration-fixture",
+            str(fixture),
+            "--enforce-floors",
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    assert "floors breached" in result.output
 
 
 def test_link_help() -> None:

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -479,10 +479,8 @@ def _stub_fixed_label_classifier_in_cli(monkeypatch: pytest.MonkeyPatch) -> None
 
 def test_classify_calibrate_renders_report(
     monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
 ) -> None:
     """`--calibrate` runs the fixture and prints a per-dimension table."""
-    del tmp_path
     _stub_fixed_label_classifier_in_cli(monkeypatch)
     fixture = (
         Path(__file__).parent / "fixtures" / "classification" / "calibration_set.yaml"

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -405,12 +405,15 @@ def test_classify_force_overrides_manual(tmp_path: Path) -> None:
 # ---- FEAT-017b: --calibrate ----
 
 
-def _stub_perfect_classifier_in_cli(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace LLMClassifier in `creek.cli` with a perfect-agreement stub.
+def _stub_fixed_label_classifier_in_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace LLMClassifier with a stub that always returns cal-001's labels.
 
-    The stub returns Fragments whose labels exactly match each
-    calibration entry's `expected` block, so the rendered report shows
-    100% agreement and any `--enforce-floors` invocation passes.
+    Used by render-only CLI tests where the exact rates do not matter,
+    only that the calibration mechanism runs end-to-end without
+    hitting the network. The agreement rates this produces are NOT
+    100% — see `test_classify_calibrate_enforce_floors_passes_on_perfect_agreement`
+    for a test that asserts the floor gate with a guaranteed-passing
+    synthetic report instead.
     """
     from creek.classify.llm import LLMClassificationResult
     from creek.models import (
@@ -472,7 +475,7 @@ def test_classify_calibrate_renders_report(
     tmp_path: Path,
 ) -> None:
     """`--calibrate` runs the fixture and prints a per-dimension table."""
-    _stub_perfect_classifier_in_cli(monkeypatch)
+    _stub_fixed_label_classifier_in_cli(monkeypatch)
     fixture = (
         Path(__file__).parent / "fixtures" / "classification" / "calibration_set.yaml"
     )

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -463,6 +463,13 @@ def _stub_fixed_label_classifier_in_cli(monkeypatch: pytest.MonkeyPatch) -> None
 
     from creek.classify.llm import LLMClassifier as _RealLLMClassifier
 
+    # Patch __init__ (the public constructor) rather than the private
+    # `_check_availability` hook — patching by private name silently
+    # breaks if the implementation renames the method, masking the
+    # test's intent. Replacing __init__ with a no-op bypasses the
+    # health check while leaving `classify_with_reasoning` (the
+    # contract we actually exercise) wired in below.
+    monkeypatch.setattr(_RealLLMClassifier, "__init__", lambda self, **_: None)
     monkeypatch.setattr(
         _RealLLMClassifier,
         "classify_with_reasoning",
@@ -475,14 +482,11 @@ def test_classify_calibrate_renders_report(
     tmp_path: Path,
 ) -> None:
     """`--calibrate` runs the fixture and prints a per-dimension table."""
+    del tmp_path
     _stub_fixed_label_classifier_in_cli(monkeypatch)
     fixture = (
         Path(__file__).parent / "fixtures" / "classification" / "calibration_set.yaml"
     )
-    # Make the LLMClassifier availability check return True without HTTP.
-    from creek.classify.llm import LLMClassifier
-
-    monkeypatch.setattr(LLMClassifier, "_check_availability", lambda _self: True)
     result = runner.invoke(
         app,
         [


### PR DESCRIPTION
## Summary

Closes **FEAT-017** ([`plans/git-issues/FEAT-017-classification-prompt-hardening.md`](https://github.com/Geoffe-Ga/Creek-Vault/blob/main/plans/git-issues/FEAT-017-classification-prompt-hardening.md)). Builds on FEAT-017a (#230, merged at `befd2e0`) by adding the calibration half: hand-labelled fixture, `--calibrate` CLI, and CI floor gate. Unblocks **FEAT-018** (compost embeddings + LLM verification).

### What ships

- **`tests/fixtures/classification/calibration_set.yaml`** — 32 hand-labelled fragments covering every Frequency (F1..F10), every Phase, every Mode, every Orientation, every Dosage, every Voice Register. The format is documented in the file header so a human reviewer can extend it.
- **`creek/classify/calibration.py`** — classifier-agnostic agreement scoring via a `SupportsClassifyWithReasoning` protocol. Exposes `load_fixture`, `run_calibration`, `assert_floors`, and `DEFAULT_FLOORS`. `CalibrationFloorBreachError` enumerates every breached dimension at once.
- **`creek classify --calibrate`** — runs the configured LLM against the fixture and prints a per-dimension agreement table. Add `--enforce-floors` for CI invocations that should fail the build on a regressed prompt or example set.
- **`tests/test_calibration.py`** — 26 tests: the math, the floor gate, the fixture round-trip, error paths, and end-to-end `run_calibration` against a deterministic stub classifier.
- **`tests/test_cli.py`** — 4 new tests for `--calibrate` (renders report; rejects missing fixture; `--enforce-floors` passes on synthetic perfect agreement and fails on below-floor agreement).
- **`docs/classification.md`** — new Calibration section explaining the CLI, the per-dimension default floors with rationale, and the operator-vs-CI cadence (CI exercises the mechanism against a stub; real-LLM calibration is operator-run because CI lacks API keys).

### Default per-dimension floors (`creek.classify.calibration.DEFAULT_FLOORS`)

| Dimension       | Floor |
|-----------------|------:|
| Frequency       |  60%  |
| Phase           |  60%  |
| Mode            |  40%  |
| Orientation     |  40%  |
| Dosage          |  40%  |
| Voice Register  |  75%  |

Per FEAT-017: the unclassified-biased dimensions get the looser 40% floor; voice register is the firmest at 75%.

### Acceptance criteria — FEAT-017 fully satisfied

| FEAT-017 criterion | Status | Where |
|---|---|---|
| 3–5 rotating few-shot examples per dimension | ✅ | 017a |
| Two-step (reasoning → YAML) pipeline; tier-routed trace | ✅ | 017a |
| Default-unclassified bias for Mode / Orientation / Dosage | ✅ | 017a |
| Calibration fixture with ≥30 hand-labelled fragments | ✅ | **this PR** (32 entries) |
| `creek classify --calibrate` subcommand | ✅ | **this PR** |
| CI test fails when calibration agreement drops below floor | ✅ | **this PR** (`test_classify_calibrate_enforce_floors_fails_on_breach`) |
| `docs/classification.md` documents the pipeline + calibration cadence | ✅ | 017a (pipeline) + **this PR** (calibration) |
| ≥90% branch coverage on changed paths | ✅ | 93.55% aggregate |

### Size note

PR is ~1475 LOC. Fixture (~375) and tests (~590) dominate; the calibration module itself is ~370 LOC and the CLI wiring + docs are ~140 LOC. Same shape as FEAT-017a — large because of the hand-labelled fixture, not the production code.

### Quality gates (local `./scripts/check-all.sh`)

| Gate | Result |
|---|---|
| Ruff lint | ✅ |
| Ruff format | ✅ |
| MyPy strict | ✅ |
| Pylint (9.0 floor) | ✅ |
| Bandit (medium+) | ✅ 0 issues |
| Complexity (Xenon B) | ✅ |
| Unit tests | ✅ 3418 passed, 20 deselected |
| Coverage 90% aggregate | ✅ 93.55% |
| Per-file coverage 80% | ✅ 120 files, 2 waivered |
| `creek state` size budget | ✅ |
| pip-audit | ❌ pre-existing on `main` (pip 24.0 + new `urllib3` CVE-2026-44431/44432); unrelated. |

## Test plan

- [x] `tests/test_calibration.py` covers math, floor gate, fixture loading, fixture errors, end-to-end agreement against a stub classifier
- [x] `tests/test_cli.py` covers the `--calibrate` flag (success, missing-fixture, enforce-floors pass + fail)
- [x] `./scripts/check-all.sh` green except for the pre-existing pip-audit env issue noted on #230

## Follow-ups (out of scope)

- **FEAT-018**: compost embedding + LLM verification — now unblocked.
- `creek/classify/llm.py` 1145-LOC split (carry-over from #230 review).
- pip-audit `urllib3` CVE entries in `scripts/security.sh` ignore set (env-only, pre-existing).
- The calibration set is a starter (32 entries vs FEAT's "~50 lands incrementally"). Geoff should add fragments over time as the corpus's tone drifts; the format is stable.

https://claude.ai/code/session_017Ji1ivHGSVaZqxbZSzKndN

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ji1ivHGSVaZqxbZSzKndN)_