### PR TITLE
feat(crawdad): Haiku router + intent dispatcher (FEAT-014)

### DIFF
--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -18,13 +18,13 @@ from typing import TYPE_CHECKING, Protocol, cast
 import discord
 
 from crawdad.dispatcher import IntentDispatcher, UnknownIntentError
+from crawdad.history import ConversationHistory
 from crawdad.mcp_client import MCPUnavailableError
 from crawdad.router import RouterParseError
 
 if TYPE_CHECKING:
     from crawdad.config import CrawDadConfig
     from crawdad.dispatcher import ToolResult
-    from crawdad.history import ConversationHistory
     from crawdad.mcp_client import MCPClient
     from crawdad.router import IntentRouter
     from crawdad.state import SessionState, StateUnavailableError
@@ -143,7 +143,7 @@ async def _route_and_dispatch(
     try:
         response = await router.extract_intents(
             message=message.content,
-            history=history or _empty_history(),
+            history=history or ConversationHistory(),
             state=session_state,
         )
     except RouterParseError as exc:
@@ -207,13 +207,6 @@ def _stub_reply() -> str:
         "crawdad here — wiring scaffold is up. "
         "(FEAT-015 will swap this for the composer-driven reply.)"
     )
-
-
-def _empty_history() -> ConversationHistory:
-    """Return a throwaway empty history for callers that opt out of tracking."""
-    from crawdad.history import ConversationHistory
-
-    return ConversationHistory()
 
 
 class CrawDadClient(discord.Client):

--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -1,14 +1,13 @@
-"""Pure-logic Discord message handling.
+"""Pure-logic Discord message handling (FEAT-013 + FEAT-014).
 
-``handle_message`` is intentionally a free function (not a ``Client``
-method) so the test suite can drive it with fakes for ``Message``,
-``Author``, and ``Channel``. The thin ``CrawDadClient`` subclass below
-just forwards Discord events to the handler — every interesting
+``handle_message`` is a free function so the test suite can drive it
+with fakes for ``Message``, ``Author``, and ``Channel``. The thin
+``CrawDadClient`` subclass forwards Discord events; every interesting
 decision lives here.
 
-FEAT-014 will swap the stub reply for the Haiku-router pipeline; the
-allowlist gate and the missing-state / unreachable-MCP graceful
-responses are stable.
+FEAT-014 wires the Haiku router + MCP dispatcher into the handler. The
+reply is still a "boring structured summary" — FEAT-015 swaps that for
+the Sonnet composer.
 """
 
 from __future__ import annotations
@@ -18,21 +17,34 @@ from typing import TYPE_CHECKING, Protocol, cast
 
 import discord
 
+from crawdad.dispatcher import IntentDispatcher, UnknownIntentError
+from crawdad.mcp_client import MCPUnavailableError
+from crawdad.router import RouterParseError
+
 if TYPE_CHECKING:
     from crawdad.config import CrawDadConfig
-    from crawdad.mcp_client import MCPUnavailableError
+    from crawdad.dispatcher import ToolResult
+    from crawdad.history import ConversationHistory
+    from crawdad.mcp_client import MCPClient
+    from crawdad.router import IntentRouter
     from crawdad.state import SessionState, StateUnavailableError
 
 _LOGGER = logging.getLogger("crawdad.bot")
 
-_STUB_REPLY = (
-    "crawdad here — wiring scaffold is up. "
-    "(FEAT-014 will swap this stub for a real Haiku-routed response.)"
-)
 _STATE_UNAVAILABLE_REPLY = (
     "no audit report yet — run `creek state` in the vault and try again."
 )
 _MCP_UNAVAILABLE_REPLY = "creek-tools is unreachable; try again in a moment."
+_ROUTER_PARSE_REPLY = "I lost the thread on that one — can you rephrase your question?"
+_UNKNOWN_INTENT_REPLY = (
+    "I tried to use a tool I don't have. Try a different question, or "
+    "check `creek-tools` for the available tool surface."
+)
+_NO_TOOL_CALL_REPLY = (
+    "noted — no tool call seemed necessary for that. (FEAT-015 will compose "
+    "a richer reply.)"
+)
+_DISCORD_REPLY_LIMIT = 1900
 
 
 class _MessageLike(Protocol):
@@ -64,7 +76,7 @@ class _ChannelLike(Protocol):
     @property
     def id(self) -> int: ...  # pragma: no cover - protocol stub
 
-    async def send(self, content: str) -> None: ...  # pragma: no cover - protocol stub
+    async def send(self, content: str) -> None: ...  # pragma: no cover
 
 
 async def handle_message(
@@ -73,6 +85,10 @@ async def handle_message(
     config: CrawDadConfig,
     session_state: SessionState | None,
     bot_user_id: int,
+    router: IntentRouter | None = None,
+    mcp_client: MCPClient | None = None,
+    known_tools: tuple[str, ...] = (),
+    history: ConversationHistory | None = None,
 ) -> None:
     """Process one Discord message.
 
@@ -80,10 +96,17 @@ async def handle_message(
         message: The inbound Discord (or fake) message.
         config: Runtime config — supplies the allowlist.
         session_state: Result of :func:`crawdad.state.load_session_state`,
-            or ``None`` if the load raised :class:`StateUnavailableError`.
-        bot_user_id: The bot's own Discord user id. Used to suppress
-            self-replies (which would otherwise feed back into
-            ``on_message`` and loop).
+            or ``None`` if missing.
+        bot_user_id: The bot's own Discord user id (self-suppression).
+        router: FEAT-014 Haiku router. ``None`` falls back to the
+            FEAT-013 stub reply (used by tests that don't exercise the
+            agent loop).
+        mcp_client: Factory for opening an MCP session per message.
+            Must be provided when ``router`` is.
+        known_tools: MCP tool names snapshotted at session start;
+            forwarded to :class:`IntentDispatcher` as the allowlist.
+        history: Conversation transcript appended in place. ``None``
+            means "don't record this turn" — handy for tests.
     """
     if message.author.id == bot_user_id or message.author.bot:
         return
@@ -92,7 +115,78 @@ async def handle_message(
     if session_state is None:
         await message.channel.send(_STATE_UNAVAILABLE_REPLY)
         return
-    await message.channel.send(_STUB_REPLY)
+    if router is None or mcp_client is None:
+        await message.channel.send(_stub_reply())
+        return
+    await _route_and_dispatch(
+        message=message,
+        session_state=session_state,
+        router=router,
+        mcp_client=mcp_client,
+        known_tools=known_tools,
+        history=history,
+    )
+
+
+async def _route_and_dispatch(
+    *,
+    message: _MessageLike,
+    session_state: SessionState,
+    router: IntentRouter,
+    mcp_client: MCPClient,
+    known_tools: tuple[str, ...],
+    history: ConversationHistory | None,
+) -> None:
+    """Run the Haiku → dispatcher pipeline; format the reply."""
+    if history is not None:
+        history.append("user", message.content)
+    try:
+        response = await router.extract_intents(
+            message=message.content,
+            history=history or _empty_history(),
+            state=session_state,
+        )
+    except RouterParseError as exc:
+        _LOGGER.warning("router parse error: %s", exc)
+        await message.channel.send(_ROUTER_PARSE_REPLY)
+        return
+    try:
+        async with mcp_client.connect() as session:
+            dispatcher = IntentDispatcher(session=session, known_tools=known_tools)
+            results = await dispatcher.dispatch(response)
+    except UnknownIntentError as exc:
+        _LOGGER.warning("unknown intent: %s", exc)
+        await message.channel.send(_UNKNOWN_INTENT_REPLY)
+        return
+    except MCPUnavailableError as exc:
+        _LOGGER.warning("MCP unavailable mid-dispatch: %s", exc)
+        await message.channel.send(_MCP_UNAVAILABLE_REPLY)
+        return
+    reply = format_structured_reply(results)
+    if history is not None:
+        history.append("assistant", reply)
+    await message.channel.send(reply)
+
+
+def format_structured_reply(results: list[ToolResult]) -> str:
+    """Render dispatcher results as the FEAT-014 boring-summary text.
+
+    FEAT-015 replaces this with the Sonnet composer; the structure here
+    is deliberately bland and parseable so behaviour gaps stay visible
+    until the composer lands.
+    """
+    if not results:
+        return _NO_TOOL_CALL_REPLY
+    lines = ["I called these tools:"]
+    for result in results:
+        snippet = result.body.strip().replace("\n", " ")
+        if len(snippet) > 300:
+            snippet = snippet[:297] + "..."
+        lines.append(f"- `{result.intent_type}` → {snippet}")
+    rendered = "\n".join(lines)
+    if len(rendered) > _DISCORD_REPLY_LIMIT:
+        rendered = rendered[: _DISCORD_REPLY_LIMIT - 3] + "..."
+    return rendered
 
 
 def render_state_unavailable_reply(error: StateUnavailableError) -> str:
@@ -107,24 +201,43 @@ def render_mcp_unavailable_reply(error: MCPUnavailableError) -> str:
     return _MCP_UNAVAILABLE_REPLY
 
 
-class CrawDadClient(discord.Client):
-    """Tiny ``discord.Client`` subclass that delegates to :func:`handle_message`.
+def _stub_reply() -> str:
+    """FEAT-013 fallback used when the router/dispatcher aren't wired."""
+    return (
+        "crawdad here — wiring scaffold is up. "
+        "(FEAT-015 will swap this for the composer-driven reply.)"
+    )
 
-    The runtime wiring lives in :mod:`crawdad.cli`; this class is just
-    the Discord glue.
-    """
+
+def _empty_history() -> ConversationHistory:
+    """Return a throwaway empty history for callers that opt out of tracking."""
+    from crawdad.history import ConversationHistory
+
+    return ConversationHistory()
+
+
+class CrawDadClient(discord.Client):
+    """``discord.Client`` subclass that delegates to :func:`handle_message`."""
 
     def __init__(
         self,
         *,
         config: CrawDadConfig,
         session_state: SessionState | None,
+        router: IntentRouter | None = None,
+        mcp_client: MCPClient | None = None,
+        known_tools: tuple[str, ...] = (),
+        history: ConversationHistory | None = None,
         intents: discord.Intents | None = None,
     ) -> None:
-        """Store config and session state; init the parent ``Client``."""
+        """Store config + agent-loop components; init the parent ``Client``."""
         super().__init__(intents=intents or self._default_intents())
         self._config = config
         self._session_state = session_state
+        self._router = router
+        self._mcp_client = mcp_client
+        self._known_tools = known_tools
+        self._history = history
 
     @staticmethod
     def _default_intents() -> discord.Intents:
@@ -147,4 +260,8 @@ class CrawDadClient(discord.Client):
             config=self._config,
             session_state=self._session_state,
             bot_user_id=self.user.id,
+            router=self._router,
+            mcp_client=self._mcp_client,
+            known_tools=self._known_tools,
+            history=self._history,
         )

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -2,7 +2,8 @@
 
 The CLI is intentionally small: parse argv, resolve config, hand off to
 :func:`run_bot`. The runtime wires together :func:`load_session_state`,
-:class:`MCPClient`, and :class:`CrawDadClient`.
+:class:`MCPClient`, an :class:`IntentRouter`, and
+:class:`CrawDadClient`.
 """
 
 from __future__ import annotations
@@ -13,15 +14,21 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import anthropic
+
 from crawdad.bot import CrawDadClient
-from crawdad.config import load_config
+from crawdad.config import DEFAULT_ROUTER_MODEL, load_config
+from crawdad.history import ConversationHistory
+from crawdad.intents import ToolInfo
 from crawdad.mcp_client import MCPClient, MCPUnavailableError
+from crawdad.router import IntentRouter
 from crawdad.state import StateUnavailableError, load_session_state
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from crawdad.config import CrawDadConfig
+    from crawdad.mcp_client import ToolDetails
     from crawdad.state import SessionState
 
 _LOGGER = logging.getLogger("crawdad.cli")
@@ -54,18 +61,62 @@ def run_bot(config: CrawDadConfig) -> None:
     """Boot the Discord client; load session state once at start.
 
     Startup runs two short-lived event loops in sequence: ``asyncio.run``
-    drives :func:`_probe_mcp` (which spawns and tears down the MCP
-    subprocess to verify connectivity), then ``discord.Client.run``
-    spins up the permanent loop. The probe's subprocess is therefore
-    *not* the same subprocess FEAT-014's dispatcher will use at message
-    time — each MCP call spawns a fresh subprocess until FEAT-014
-    introduces a long-lived connection.
+    drives :func:`_startup_probe` (which spawns and tears down the MCP
+    subprocess to verify connectivity and snapshot the advertised
+    tools), then ``discord.Client.run`` spins up the permanent loop.
+    Each user-message turn spawns its own MCP subprocess via
+    :class:`crawdad.mcp_client.MCPClient` until FEAT-014's loop is
+    upgraded to share a long-lived connection.
     """
     logging.basicConfig(level=logging.INFO)
     session_state = _safe_load_state(config.vault_path)
-    asyncio.run(_probe_mcp(config))
-    client = CrawDadClient(config=config, session_state=session_state)
+    tool_details = asyncio.run(_startup_probe(config))
+    router, mcp_client, known_tools, history = _build_agent_components(
+        config=config, tool_details=tool_details
+    )
+    client = CrawDadClient(
+        config=config,
+        session_state=session_state,
+        router=router,
+        mcp_client=mcp_client,
+        known_tools=known_tools,
+        history=history,
+    )
     client.run(config.discord_bot_token)
+
+
+def _build_agent_components(
+    *,
+    config: CrawDadConfig,
+    tool_details: tuple[ToolDetails, ...],
+) -> tuple[IntentRouter | None, MCPClient, tuple[str, ...], ConversationHistory]:
+    """Construct the long-lived router + MCP client + history for the session.
+
+    Returns ``router=None`` when no tools were advertised (the probe
+    failed); the bot falls back to the FEAT-013 stub reply rather than
+    asking Haiku to route into an empty tool set.
+    """
+    mcp_client = MCPClient(config.mcp_server_command)
+    known_tools = tuple(tool.name for tool in tool_details)
+    history = ConversationHistory()
+    if not tool_details:
+        _LOGGER.warning("no MCP tools advertised; router is disabled this session")
+        return None, mcp_client, known_tools, history
+    anthropic_client = anthropic.AsyncAnthropic(api_key=config.anthropic_api_key)
+    router_tools = [
+        ToolInfo(
+            name=tool.name,
+            description=tool.description,
+            input_schema=tool.input_schema,
+        )
+        for tool in tool_details
+    ]
+    router = IntentRouter(
+        anthropic_client=anthropic_client,
+        model=DEFAULT_ROUTER_MODEL,
+        tools=router_tools,
+    )
+    return router, mcp_client, known_tools, history
 
 
 def _safe_load_state(vault_path: Path) -> SessionState | None:
@@ -77,14 +128,15 @@ def _safe_load_state(vault_path: Path) -> SessionState | None:
         return None
 
 
-async def _probe_mcp(config: CrawDadConfig) -> None:
-    """Connectivity check only — does NOT validate the tool schema.
+async def _startup_probe(config: CrawDadConfig) -> tuple[ToolDetails, ...]:
+    """Connectivity check + tool-surface snapshot.
 
-    Spawns the MCP subprocess, calls ``list_tools``, logs the advertised
-    names, then disconnects. A misconfigured ``mcp_server_command`` that
-    starts successfully but exposes zero tools will still pass this
-    probe — FEAT-014's dispatcher is responsible for verifying the
-    specific tools it needs (``creek.state.read`` et al.) are present.
+    Calls :meth:`MCPSession.list_tool_details` so FEAT-014's router can
+    build its intents schema and the dispatcher can refuse intents
+    referencing unadvertised tool names. A misconfigured
+    ``mcp_server_command`` that starts but advertises no tools yields
+    an empty tuple — the caller sees that and disables the router for
+    the session (still starts the bot, still posts the FEAT-013 stub).
 
     Probe failure is logged at WARNING and swallowed so the bot still
     starts; mid-session outages are handled by ``MCPUnavailableError``
@@ -92,13 +144,18 @@ async def _probe_mcp(config: CrawDadConfig) -> None:
     """
     try:
         async with MCPClient(config.mcp_server_command).connect() as session:
-            tools = await session.list_tools()
-            _LOGGER.info("MCP tools advertised: %s", ", ".join(tools))
+            details = await session.list_tool_details()
+            _LOGGER.info(
+                "MCP tools advertised: %s",
+                ", ".join(tool.name for tool in details),
+            )
+            return details
     except MCPUnavailableError as exc:
         _LOGGER.warning(
             "MCP probe failed at startup; the bot will start anyway: %s",
             exc,
         )
+        return ()
 
 
 if __name__ == "__main__":  # pragma: no cover - executed via entry point

--- a/crawdad/crawdad/config.py
+++ b/crawdad/crawdad/config.py
@@ -4,6 +4,13 @@ Secrets — the Discord bot token and the Anthropic API key — come from
 environment variables (``DISCORD_BOT_TOKEN``, ``ANTHROPIC_API_KEY``).
 Everything else (vault path, MCP server command, allowlists) comes from
 ``crawdad.yaml``. The two sources are merged in :func:`load_config`.
+
+FEAT-014 adds the agent-loop knobs. The Haiku router model identifier
+lives here so no other module under ``crawdad/crawdad/`` references a
+model ID literal — model IDs move (today: ``claude-haiku-4-5-20251001``;
+the constant is the contract, not the literal). The
+``CRAWDAD_ROUTER_MODEL`` env var overrides the fallback for
+local-only experiments.
 """
 
 from __future__ import annotations
@@ -16,7 +23,20 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 _ENV_DISCORD_TOKEN = "DISCORD_BOT_TOKEN"
 _ENV_ANTHROPIC_KEY = "ANTHROPIC_API_KEY"
+_ENV_ROUTER_MODEL = "CRAWDAD_ROUTER_MODEL"
 _DEFAULT_MCP_COMMAND: tuple[str, ...] = ("creek-tools-mcp",)
+
+# The single place a Haiku model literal lives in this package. Other
+# modules must read ``DEFAULT_ROUTER_MODEL`` (or accept a model argument
+# resolved from it) — see the regression test that enforces this.
+_DEFAULT_ROUTER_MODEL_FALLBACK = "claude-haiku-4-5-20251001"
+DEFAULT_ROUTER_MODEL: str = os.environ.get(
+    _ENV_ROUTER_MODEL, _DEFAULT_ROUTER_MODEL_FALLBACK
+)
+
+# History truncation knobs (ADOPT-008 hard cliff; FEAT-016 may refine).
+HISTORY_MAX_ENTRIES: int = 20
+HISTORY_MAX_CHARS_PER_ENTRY: int = 2000
 
 
 class CrawDadConfig(BaseModel):

--- a/crawdad/crawdad/dispatcher.py
+++ b/crawdad/crawdad/dispatcher.py
@@ -1,0 +1,107 @@
+"""Intent → MCP tool dispatcher (FEAT-014).
+
+Takes a :class:`crawdad.intents.RouterResponse`, validates each intent
+against the snapshot of MCP tool names taken at session start, and
+invokes the matching tool with the intent's args. Tool results come
+back as a list of :class:`ToolResult` envelopes that the bot handler
+formats into a Discord reply (FEAT-014's "boring summary" path).
+
+FEAT-015 will wrap this dispatcher in the 5-round loop; the
+``privacy_tier_ceiling`` field is forwarded verbatim because the MCP
+server enforces the policy at the protocol boundary (FEAT-010/011).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from crawdad.intents import Intent, RouterResponse
+    from crawdad.mcp_client import MCPSession
+
+_LOGGER = logging.getLogger("crawdad.dispatcher")
+
+
+class UnknownIntentError(RuntimeError):
+    """Router emitted an intent whose ``type`` is not an advertised tool.
+
+    The bot handler maps this to a user-facing "I tried to do X but I
+    don't have a tool for it" reply.
+    """
+
+
+class ToolResult(BaseModel):
+    """One tool's response, threaded back through the loop."""
+
+    model_config = ConfigDict(frozen=True)
+
+    intent_type: str
+    body: str
+
+
+class IntentDispatcher:
+    """Forward each router intent to the corresponding MCP tool call."""
+
+    def __init__(
+        self,
+        *,
+        session: MCPSession,
+        known_tools: Iterable[str],
+    ) -> None:
+        """Cache the advertised tools so unknown intents fail fast.
+
+        Args:
+            session: An already-connected
+                :class:`crawdad.mcp_client.MCPSession`.
+            known_tools: The MCP tool names snapshotted at session
+                start. Intent types outside this set raise
+                :class:`UnknownIntentError`.
+        """
+        self._session = session
+        self._known_tools = frozenset(known_tools)
+
+    async def dispatch(self, response: RouterResponse) -> list[ToolResult]:
+        """Invoke each intent in order; collect the textual tool results.
+
+        Args:
+            response: Router output to act on.
+
+        Returns:
+            One :class:`ToolResult` per intent, in document order.
+
+        Raises:
+            UnknownIntentError: an intent's ``type`` is not advertised.
+            crawdad.mcp_client.MCPUnavailableError: forwarded from the
+                MCP session; the bot handler maps it to the documented
+                soft-error reply.
+        """
+        results: list[ToolResult] = []
+        for intent in response.intents:
+            if intent.type not in self._known_tools:
+                msg = (
+                    f"router emitted intent type {intent.type!r} which is not "
+                    "in the advertised MCP tool set"
+                )
+                raise UnknownIntentError(msg)
+            body = await self._session.call_tool(intent.type, _build_arguments(intent))
+            _LOGGER.debug("dispatched %s: %d chars returned", intent.type, len(body))
+            results.append(ToolResult(intent_type=intent.type, body=body))
+        return results
+
+
+def _build_arguments(intent: Intent) -> dict[str, object]:
+    """Merge the intent's args with the privacy_tier_ceiling field.
+
+    The MCP server reads ``privacy_tier_ceiling`` from the call args as
+    a sibling of any tool-specific arguments — see FEAT-010's tool
+    signatures. The router carries it on the :class:`Intent` model;
+    we flatten it into the MCP call here.
+    """
+    payload: dict[str, object] = dict(intent.args)
+    payload.setdefault("privacy_tier_ceiling", intent.privacy_tier_ceiling.value)
+    return payload

--- a/crawdad/crawdad/dispatcher.py
+++ b/crawdad/crawdad/dispatcher.py
@@ -100,8 +100,10 @@ def _build_arguments(intent: Intent) -> dict[str, object]:
     The MCP server reads ``privacy_tier_ceiling`` from the call args as
     a sibling of any tool-specific arguments — see FEAT-010's tool
     signatures. The router carries it on the :class:`Intent` model;
-    we flatten it into the MCP call here.
+    the intent model is authoritative, so we *overwrite* any
+    conflicting key inside ``intent.args`` rather than letting Haiku
+    smuggle a looser tier through the args dict.
     """
     payload: dict[str, object] = dict(intent.args)
-    payload.setdefault("privacy_tier_ceiling", intent.privacy_tier_ceiling.value)
+    payload["privacy_tier_ceiling"] = intent.privacy_tier_ceiling.value
     return payload

--- a/crawdad/crawdad/history.py
+++ b/crawdad/crawdad/history.py
@@ -1,0 +1,68 @@
+"""Episodic-memory-lite for the CrawDad agent loop.
+
+ADOPT-008 §truncation discipline: the last 20 conversation entries,
+each truncated to 2000 characters. A hard cliff — no smarter
+compression in v1.0 (FEAT-016 may refine).
+
+``ConversationHistory`` is intentionally a tiny class around
+:class:`collections.deque`. It owns the eviction + truncation rules so
+callers (router prompt builder, loop) never have to reason about the
+budget.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+from pydantic import BaseModel, ConfigDict
+
+from crawdad.config import HISTORY_MAX_CHARS_PER_ENTRY, HISTORY_MAX_ENTRIES
+
+
+class HistoryEntry(BaseModel):
+    """A single turn in the conversation transcript."""
+
+    model_config = ConfigDict(frozen=True)
+
+    role: str
+    content: str
+
+
+class ConversationHistory:
+    """Bounded FIFO transcript for the current Discord session.
+
+    The bound is enforced on every :meth:`append`; the
+    :meth:`as_list` view never reflects more than
+    :data:`crawdad.config.HISTORY_MAX_ENTRIES` items.
+    """
+
+    def __init__(self) -> None:
+        """Start an empty transcript."""
+        self._entries: deque[HistoryEntry] = deque(maxlen=HISTORY_MAX_ENTRIES)
+
+    def append(self, role: str, content: str) -> None:
+        """Record one turn; truncate ``content`` to the per-entry budget.
+
+        Args:
+            role: ``"user"`` or ``"assistant"`` (free-form so future
+                tool-use turns can label themselves; not enforced).
+            content: The text of the turn. Truncated to
+                :data:`crawdad.config.HISTORY_MAX_CHARS_PER_ENTRY` chars.
+
+        Raises:
+            ValueError: when ``role`` is the empty string — almost
+                certainly a programming error.
+        """
+        if not role:
+            msg = "role must be a non-empty string"
+            raise ValueError(msg)
+        truncated = content[:HISTORY_MAX_CHARS_PER_ENTRY]
+        self._entries.append(HistoryEntry(role=role, content=truncated))
+
+    def as_list(self) -> list[HistoryEntry]:
+        """Return a list snapshot suitable for prompt assembly."""
+        return list(self._entries)
+
+    def clear(self) -> None:
+        """Drop every entry; used by 5-round cap reset (FEAT-015)."""
+        self._entries.clear()

--- a/crawdad/crawdad/intents.py
+++ b/crawdad/crawdad/intents.py
@@ -1,0 +1,110 @@
+"""Intent schema for the Haiku router (FEAT-014).
+
+ADOPT-008 §pre-decided choices: the ``intents`` JSON schema lives next
+to the MCP tool registry — every intent ``type`` is an MCP tool name,
+1-to-1. Generating the schema from the live ``tools/list`` response
+keeps the router prompt and the dispatcher honest as the tool surface
+grows (FEAT-011 / FEAT-012 / future).
+
+This module owns three things:
+
+* :class:`Intent` — a single router-emitted call (``type`` + ``args``).
+* :class:`RouterResponse` — the strict JSON shape Haiku must produce.
+* :func:`build_intents_schema` — turn a list of MCP tool descriptors
+  into a JSON Schema the router prompt can paste verbatim.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class PrivacyTierCeiling(StrEnum):
+    """Per-intent privacy tier ceiling.
+
+    Mirrors :class:`creek_mcp.tier_ceiling.TierCeiling` enum values so
+    the router emits the exact string the MCP server validates.
+    """
+
+    OPEN = "open"
+    PERSONAL = "personal"
+    INTIMATE = "intimate"
+    ALL = "all"
+
+
+class Intent(BaseModel):
+    """One tool call the router asked the dispatcher to make."""
+
+    model_config = ConfigDict(frozen=True)
+
+    type: str = Field(min_length=1)
+    privacy_tier_ceiling: PrivacyTierCeiling = PrivacyTierCeiling.OPEN
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class RouterResponse(BaseModel):
+    """The exact JSON shape Haiku must emit — no prose, no extras."""
+
+    model_config = ConfigDict(frozen=True)
+
+    intents: list[Intent]
+
+
+class ToolInfo(BaseModel):
+    """A normalised view of one entry in the MCP ``tools/list`` response."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+
+
+def build_intents_schema(tools: list[ToolInfo]) -> dict[str, Any]:
+    """Return a JSON Schema for the router's ``{intents: [...]}`` output.
+
+    Args:
+        tools: The MCP server's currently advertised tools, fetched once
+            at session start and cached. The schema's ``type`` enum is
+            the list of ``tool.name`` values.
+
+    Returns:
+        A JSON-Schema-compatible dict that the router prompt can paste
+        verbatim and that a downstream JSON parser can validate against.
+    """
+    tool_names = [tool.name for tool in tools]
+    return {
+        "type": "object",
+        "properties": {
+            "intents": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string",
+                            "enum": tool_names,
+                            "description": (
+                                "MCP tool name to invoke; must match one "
+                                "of the advertised tools."
+                            ),
+                        },
+                        "privacy_tier_ceiling": {
+                            "type": "string",
+                            "enum": [t.value for t in PrivacyTierCeiling],
+                            "default": PrivacyTierCeiling.OPEN.value,
+                        },
+                        "args": {
+                            "type": "object",
+                            "description": "Tool-specific arguments.",
+                        },
+                    },
+                    "required": ["type"],
+                },
+            },
+        },
+        "required": ["intents"],
+    }

--- a/crawdad/crawdad/mcp_client.py
+++ b/crawdad/crawdad/mcp_client.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any
 
 from mcp import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
+from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -36,6 +37,21 @@ class MCPUnavailableError(RuntimeError):
     subprocess exits or stops responding, the bot does NOT exit. It
     catches this error and replies gracefully to Discord.
     """
+
+
+class ToolDetails(BaseModel):
+    """Normalised view of one tool from MCP ``tools/list``.
+
+    FEAT-014's router uses these to build the intents JSON Schema.
+    Kept here (not in :mod:`crawdad.intents`) so the wrapper module
+    owns the SDK ↔ Pydantic translation in one place.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    description: str
+    input_schema: dict[str, Any]
 
 
 class MCPSession:
@@ -54,6 +70,29 @@ class MCPSession:
             msg = "list_tools failed; the MCP subprocess may have exited"
             raise MCPUnavailableError(msg) from exc
         return tuple(tool.name for tool in result.tools)
+
+    async def list_tool_details(self) -> tuple[ToolDetails, ...]:
+        """Return tool name + description + input schema for every tool.
+
+        FEAT-014's router needs the descriptions and JSON Schemas to
+        build an :func:`intents.build_intents_schema` payload. The names
+        accessor (:meth:`list_tools`) stays for callers that only need
+        the connectivity probe.
+        """
+        try:
+            result = await self._session.list_tools()
+        except Exception as exc:
+            _LOGGER.debug("list_tool_details raised %s: %r", type(exc).__name__, exc)
+            msg = "list_tool_details failed; the MCP subprocess may have exited"
+            raise MCPUnavailableError(msg) from exc
+        return tuple(
+            ToolDetails(
+                name=tool.name,
+                description=tool.description or "",
+                input_schema=dict(tool.inputSchema or {}),
+            )
+            for tool in result.tools
+        )
 
     async def call_tool(
         self,

--- a/crawdad/crawdad/router.py
+++ b/crawdad/crawdad/router.py
@@ -31,6 +31,7 @@ import logging
 import re
 from typing import TYPE_CHECKING, Any
 
+import anthropic
 from pydantic import ValidationError
 
 from crawdad.intents import RouterResponse, ToolInfo, build_intents_schema
@@ -161,18 +162,31 @@ class IntentRouter:
         history: ConversationHistory,
         state: SessionState | None,
     ) -> RouterResponse:
-        """Return the parsed :class:`RouterResponse` for ``message``."""
+        """Return the parsed :class:`RouterResponse` for ``message``.
+
+        Raises:
+            RouterParseError: when the SDK call fails (rate-limit,
+                auth, connection, etc.) or when the response body is
+                not parseable JSON. The bot handler maps both to the
+                "I lost the thread; can you rephrase?" user-facing
+                reply rather than crashing.
+        """
         prompt = build_router_prompt(
             message=message,
             history=history,
             state=state,
             tools=self._tools,
         )
-        response = await self._client.messages.create(
-            model=self._model,
-            max_tokens=self._max_tokens,
-            messages=[{"role": "user", "content": prompt}],
-        )
+        try:
+            response = await self._client.messages.create(
+                model=self._model,
+                max_tokens=self._max_tokens,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except anthropic.AnthropicError as exc:
+            _LOGGER.warning("Haiku API call failed: %s: %r", type(exc).__name__, exc)
+            msg = f"Haiku API call failed: {type(exc).__name__}"
+            raise RouterParseError(msg) from exc
         raw_text = _extract_text(response)
         return _parse_router_payload(raw_text)
 

--- a/crawdad/crawdad/router.py
+++ b/crawdad/crawdad/router.py
@@ -1,0 +1,214 @@
+"""Haiku-driven intent extraction (FEAT-014).
+
+Given the user's message, recent conversation history, and the loaded
+session state, the router asks Haiku for a strict JSON
+``{intents: [...]}`` array. The dispatcher (:mod:`crawdad.dispatcher`)
+takes it from there.
+
+ADOPT-008 §pre-decided choices:
+
+* The router's job is *intent extraction only*, never prose. Haiku
+  emits JSON; Sonnet (FEAT-015) does composition.
+* Wavelength-aware: the prompt names the current phase so Haiku biases
+  toward phase-appropriate intents (no ``mine`` / ``draft`` during
+  Bottoming Out; prefer ``surface_paradox`` / ``compost``).
+* History truncation cliff: last 20 entries x 2000 chars each (enforced
+  by :class:`crawdad.history.ConversationHistory`, not here).
+* Per-intent ``privacy_tier_ceiling`` defaults to ``open`` for the
+  developer; configurable in v1.1.
+
+The router accepts an injected Anthropic client so tests can drive it
+with a fake. The model identifier is passed in (resolved from
+:data:`crawdad.config.DEFAULT_ROUTER_MODEL` by callers) so no literal
+model ID lives in this module — see the
+``test_no_model_id_literals_outside_config`` regression.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import TYPE_CHECKING, Any
+
+from pydantic import ValidationError
+
+from crawdad.intents import RouterResponse, ToolInfo, build_intents_schema
+
+if TYPE_CHECKING:
+    from crawdad.history import ConversationHistory
+    from crawdad.state import SessionState
+
+_LOGGER = logging.getLogger("crawdad.router")
+
+_FENCED_JSON_RE = re.compile(r"```(?:json)?\s*(.*?)```", re.DOTALL)
+
+_BOTTOMING_OUT_HINT = (
+    "If the current phase is Bottoming Out or Diminishing, PREFER intents "
+    "that surface compost, paradoxes, or synchronicities. AVOID `creek.mine` "
+    "and `creek.draft` until the wavelength shifts upward."
+)
+_RISING_HINT = (
+    "If the current phase is Rising or Peaking, mining and drafting "
+    "intents are appropriate."
+)
+_DEFAULT_PHASE_HINT = (
+    "Tune intent choice to the current wavelength phase if one is present."
+)
+
+
+class RouterParseError(RuntimeError):
+    """The Haiku response could not be parsed into a :class:`RouterResponse`.
+
+    The bot maps this to a user-facing "I lost the thread; can you
+    rephrase?" reply rather than crashing.
+    """
+
+
+def build_router_prompt(
+    *,
+    message: str,
+    history: ConversationHistory,
+    state: SessionState | None,
+    tools: list[ToolInfo],
+) -> str:
+    """Assemble the system + user prompt the router sends to Haiku.
+
+    Returns a single string the caller passes as the ``messages`` body.
+    Kept as a free function so prompt assembly is fully testable without
+    an LLM client.
+    """
+    schema = build_intents_schema(tools)
+    wavelength = (
+        state.wavelength_snapshot if state and state.wavelength_snapshot else None
+    )
+    phase_hint = _phase_hint_for(wavelength)
+    history_lines = [
+        f"  - {entry.role}: {entry.content}" for entry in history.as_list()
+    ]
+    history_block = (
+        "Recent history:\n" + "\n".join(history_lines) if history_lines else ""
+    )
+    wavelength_block = (
+        f"Current wavelength:\n  {wavelength}"
+        if wavelength
+        else "Current wavelength: (no wavelength snapshot available)"
+    )
+    tools_block = "Available MCP tools:\n" + "\n".join(
+        f"  - {tool.name}: {tool.description}" for tool in tools
+    )
+    schema_block = "Intents JSON schema (your output MUST validate):\n" + json.dumps(
+        schema, indent=2
+    )
+    return (
+        "You are the intent-extraction router for the CrawDad spiritual "
+        "companion. Your job is to read the user's latest message and emit "
+        'ONLY a JSON object of the form {"intents": [...]}.\n\n'
+        f"{phase_hint}\n\n"
+        f"{wavelength_block}\n\n"
+        f"{history_block}\n\n"
+        f"{tools_block}\n\n"
+        f"{schema_block}\n\n"
+        f"User message: {message}\n\n"
+        "Reply with the JSON object only. No prose, no markdown fences."
+    )
+
+
+def _phase_hint_for(wavelength: str | None) -> str:
+    """Return the phase-aware instruction string for the prompt."""
+    if not wavelength:
+        return _DEFAULT_PHASE_HINT
+    lowered = wavelength.lower()
+    if "bottoming" in lowered or "diminishing" in lowered or "withdrawal" in lowered:
+        return _BOTTOMING_OUT_HINT
+    if "rising" in lowered or "peaking" in lowered:
+        return _RISING_HINT
+    return _DEFAULT_PHASE_HINT
+
+
+class IntentRouter:
+    """Wraps the Anthropic SDK call + JSON parse for one user message."""
+
+    def __init__(
+        self,
+        *,
+        anthropic_client: Any,
+        model: str,
+        tools: list[ToolInfo],
+        max_tokens: int = 1024,
+    ) -> None:
+        """Store the injected client and the cached tools schema.
+
+        Args:
+            anthropic_client: An :class:`anthropic.AsyncAnthropic`
+                instance (or a test double with the same shape).
+            model: The Haiku model identifier — resolved from
+                :data:`crawdad.config.DEFAULT_ROUTER_MODEL` by the
+                caller, NEVER a literal in this module.
+            tools: The advertised MCP tool surface, snapshotted at
+                session start by :meth:`MCPSession.list_tool_details`.
+            max_tokens: Hard cap on the router's reply length.
+        """
+        self._client = anthropic_client
+        self._model = model
+        self._tools = tools
+        self._max_tokens = max_tokens
+
+    async def extract_intents(
+        self,
+        *,
+        message: str,
+        history: ConversationHistory,
+        state: SessionState | None,
+    ) -> RouterResponse:
+        """Return the parsed :class:`RouterResponse` for ``message``."""
+        prompt = build_router_prompt(
+            message=message,
+            history=history,
+            state=state,
+            tools=self._tools,
+        )
+        response = await self._client.messages.create(
+            model=self._model,
+            max_tokens=self._max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw_text = _extract_text(response)
+        return _parse_router_payload(raw_text)
+
+
+def _extract_text(response: Any) -> str:
+    """Pull the concatenated text from a (possibly multi-block) reply."""
+    parts: list[str] = []
+    for block in getattr(response, "content", []) or []:
+        text = getattr(block, "text", None)
+        if text is not None:
+            parts.append(str(text))
+    return "\n".join(parts)
+
+
+def _parse_router_payload(raw: str) -> RouterResponse:
+    """Decode the JSON body out of *raw* and validate it."""
+    candidate = _strip_fences(raw).strip()
+    if not candidate:
+        msg = "router returned an empty body — expected JSON intents object"
+        raise RouterParseError(msg)
+    try:
+        decoded = json.loads(candidate)
+    except json.JSONDecodeError as exc:
+        _LOGGER.debug("router raw body: %r", raw)
+        msg = "router did not return valid JSON"
+        raise RouterParseError(msg) from exc
+    try:
+        return RouterResponse.model_validate(decoded)
+    except ValidationError as exc:
+        msg = "router JSON did not match the intents schema"
+        raise RouterParseError(msg) from exc
+
+
+def _strip_fences(raw: str) -> str:
+    """Return the JSON body of a possibly fenced markdown response."""
+    match = _FENCED_JSON_RE.search(raw)
+    if match:
+        return match.group(1)
+    return raw

--- a/crawdad/tests/fixtures/fake_mcp_server.py
+++ b/crawdad/tests/fixtures/fake_mcp_server.py
@@ -13,13 +13,18 @@ from mcp.server.fastmcp import FastMCP
 
 
 def build() -> FastMCP:
-    """Return a fresh :class:`FastMCP` with a single ``echo`` tool."""
+    """Return a fresh :class:`FastMCP` with ``echo`` and ``ping`` tools."""
     server: FastMCP = FastMCP("crawdad-test-mcp")
 
     @server.tool(name="echo")
     def _echo(message: str = "hi") -> dict[str, str]:
         """Return *message* unchanged so callers can verify round-tripping."""
         return {"reply": message}
+
+    @server.tool(name="ping")
+    def _ping() -> dict[str, str]:
+        """Return a fixed pong; used by tests that need a second tool name."""
+        return {"reply": "pong"}
 
     return server
 

--- a/crawdad/tests/test_bot.py
+++ b/crawdad/tests/test_bot.py
@@ -324,3 +324,245 @@ async def test_crawdad_client_on_ready_logs(
     await client.on_ready()
 
     assert any("connected" in record.message for record in caplog.records)
+
+
+def test_format_structured_reply_renders_each_tool_result() -> None:
+    """Each tool result becomes one bullet line in the reply."""
+    from crawdad.bot import format_structured_reply
+    from crawdad.dispatcher import ToolResult
+
+    reply = format_structured_reply(
+        [
+            ToolResult(intent_type="creek.state.read", body="state body"),
+            ToolResult(intent_type="creek.mine", body="seed one\nseed two"),
+        ]
+    )
+
+    assert "creek.state.read" in reply
+    assert "state body" in reply
+    assert "creek.mine" in reply
+
+
+def test_format_structured_reply_handles_empty_results() -> None:
+    """No intents produced means the router skipped tools — surface that."""
+    from crawdad.bot import format_structured_reply
+
+    reply = format_structured_reply([])
+
+    assert "no tool call" in reply.lower()
+
+
+def test_format_structured_reply_truncates_long_body() -> None:
+    """Long tool bodies get capped per-line."""
+    from crawdad.bot import format_structured_reply
+    from crawdad.dispatcher import ToolResult
+
+    long_body = "x" * 1000
+    reply = format_structured_reply(
+        [ToolResult(intent_type="creek.state.read", body=long_body)]
+    )
+
+    assert "..." in reply
+
+
+class _StubRouter:
+    """Async-compatible router stand-in for handler tests."""
+
+    def __init__(self, response: Any) -> None:
+        self._response = response
+        self.calls: list[dict[str, Any]] = []
+
+    async def extract_intents(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        if isinstance(self._response, Exception):
+            raise self._response
+        return self._response
+
+
+class _StubSession:
+    """Stand-in for :class:`crawdad.mcp_client.MCPSession`."""
+
+    def __init__(
+        self,
+        *,
+        replies: dict[str, str] | None = None,
+        errors: dict[str, Exception] | None = None,
+    ) -> None:
+        self.replies = replies or {}
+        self.errors = errors or {}
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any] | None = None
+    ) -> str:
+        if name in self.errors:
+            raise self.errors[name]
+        return self.replies.get(name, "")
+
+
+class _StubMCPClient:
+    """Stand-in for :class:`crawdad.mcp_client.MCPClient`."""
+
+    def __init__(self, session: _StubSession) -> None:
+        self._session = session
+
+    def connect(self) -> Any:
+        session = self._session
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _ctx() -> Any:
+            yield session
+
+        return _ctx()
+
+
+async def test_handle_message_runs_router_and_dispatcher(
+    config: CrawDadConfig, session_state: SessionState
+) -> None:
+    """An allowlisted message flows through router → dispatcher → reply."""
+    from crawdad.history import ConversationHistory
+    from crawdad.intents import Intent, RouterResponse
+
+    router = _StubRouter(RouterResponse(intents=[Intent(type="creek.state.read")]))
+    session = _StubSession(replies={"creek.state.read": "state body"})
+    mcp_client = _StubMCPClient(session)
+    history = ConversationHistory()
+    channel = _FakeChannel(id=999, sent=[])
+    message: Any = _FakeMessage(
+        author=_FakeAuthor(id=111),
+        channel=channel,
+        content="what's surfacing?",
+    )
+
+    await handle_message(
+        message,
+        config=config,
+        session_state=session_state,
+        bot_user_id=42,
+        router=router,  # type: ignore[arg-type]
+        mcp_client=mcp_client,  # type: ignore[arg-type]
+        known_tools=("creek.state.read",),
+        history=history,
+    )
+
+    assert len(channel.sent) == 1
+    assert "creek.state.read" in channel.sent[0]
+    # History gets both the user message and the assistant reply.
+    entries = history.as_list()
+    assert entries[0].role == "user"
+    assert entries[-1].role == "assistant"
+
+
+async def test_handle_message_translates_router_parse_error(
+    config: CrawDadConfig, session_state: SessionState
+) -> None:
+    """RouterParseError → "I lost the thread" reply, not a crash."""
+    from crawdad.router import RouterParseError
+
+    router = _StubRouter(RouterParseError("not JSON"))
+    mcp_client = _StubMCPClient(_StubSession())
+    channel = _FakeChannel(id=999, sent=[])
+    message: Any = _FakeMessage(
+        author=_FakeAuthor(id=111),
+        channel=channel,
+        content="hi",
+    )
+
+    await handle_message(
+        message,
+        config=config,
+        session_state=session_state,
+        bot_user_id=42,
+        router=router,  # type: ignore[arg-type]
+        mcp_client=mcp_client,  # type: ignore[arg-type]
+        known_tools=("creek.state.read",),
+    )
+
+    assert len(channel.sent) == 1
+    assert "rephrase" in channel.sent[0].lower()
+
+
+async def test_handle_message_translates_unknown_intent(
+    config: CrawDadConfig, session_state: SessionState
+) -> None:
+    """UnknownIntentError → "I tried to use a tool I don't have" reply."""
+    from crawdad.intents import Intent, RouterResponse
+
+    router = _StubRouter(RouterResponse(intents=[Intent(type="creek.bogus")]))
+    mcp_client = _StubMCPClient(_StubSession())
+    channel = _FakeChannel(id=999, sent=[])
+    message: Any = _FakeMessage(
+        author=_FakeAuthor(id=111),
+        channel=channel,
+        content="hi",
+    )
+
+    await handle_message(
+        message,
+        config=config,
+        session_state=session_state,
+        bot_user_id=42,
+        router=router,  # type: ignore[arg-type]
+        mcp_client=mcp_client,  # type: ignore[arg-type]
+        known_tools=("creek.state.read",),
+    )
+
+    assert len(channel.sent) == 1
+    assert "tool" in channel.sent[0].lower()
+
+
+async def test_handle_message_translates_mcp_unavailable_in_dispatch(
+    config: CrawDadConfig, session_state: SessionState
+) -> None:
+    """MCPUnavailableError during dispatch → graceful soft-error reply."""
+    from crawdad.intents import Intent, RouterResponse
+    from crawdad.mcp_client import MCPUnavailableError
+
+    router = _StubRouter(RouterResponse(intents=[Intent(type="creek.state.read")]))
+    session = _StubSession(
+        errors={"creek.state.read": MCPUnavailableError("subprocess died")}
+    )
+    mcp_client = _StubMCPClient(session)
+    channel = _FakeChannel(id=999, sent=[])
+    message: Any = _FakeMessage(
+        author=_FakeAuthor(id=111),
+        channel=channel,
+        content="hi",
+    )
+
+    await handle_message(
+        message,
+        config=config,
+        session_state=session_state,
+        bot_user_id=42,
+        router=router,  # type: ignore[arg-type]
+        mcp_client=mcp_client,  # type: ignore[arg-type]
+        known_tools=("creek.state.read",),
+    )
+
+    assert len(channel.sent) == 1
+    assert "unreachable" in channel.sent[0].lower()
+
+
+async def test_handle_message_without_router_uses_stub_reply(
+    config: CrawDadConfig, session_state: SessionState
+) -> None:
+    """When router=None (test mode), the FEAT-013 stub reply is still posted."""
+    channel = _FakeChannel(id=999, sent=[])
+    message: Any = _FakeMessage(
+        author=_FakeAuthor(id=111),
+        channel=channel,
+        content="hi",
+    )
+
+    await handle_message(
+        message,
+        config=config,
+        session_state=session_state,
+        bot_user_id=42,
+        router=None,
+        mcp_client=None,
+    )
+
+    assert len(channel.sent) == 1
+    assert "scaffold" in channel.sent[0].lower()

--- a/crawdad/tests/test_cli.py
+++ b/crawdad/tests/test_cli.py
@@ -85,6 +85,8 @@ def test_run_bot_wires_state_and_starts_client(
     vault_with_state: Path,
 ) -> None:
     """``run_bot`` loads state, probes MCP, and hands the token to discord."""
+    from crawdad.mcp_client import ToolDetails
+
     config = patched_config.model_copy(update={"vault_path": vault_with_state})
     captured: dict[str, Any] = {}
 
@@ -95,17 +97,26 @@ def test_run_bot_wires_state_and_starts_client(
         def run(self, token: str) -> None:
             captured["token"] = token
 
-    async def _ok_probe(_c: CrawDadConfig) -> None:
+    async def _ok_probe(_c: CrawDadConfig) -> tuple[ToolDetails, ...]:
         captured["probed"] = True
+        return (
+            ToolDetails(
+                name="creek.state.read",
+                description="Read latest.md",
+                input_schema={"type": "object"},
+            ),
+        )
 
     monkeypatch.setattr(cli, "CrawDadClient", _FakeClient)
-    monkeypatch.setattr(cli, "_probe_mcp", _ok_probe)
+    monkeypatch.setattr(cli, "_startup_probe", _ok_probe)
 
     cli.run_bot(config)
 
     assert captured["token"] == config.discord_bot_token
     assert captured["probed"] is True
     assert captured["init_kwargs"]["session_state"] is not None
+    assert captured["init_kwargs"]["router"] is not None
+    assert captured["init_kwargs"]["known_tools"] == ("creek.state.read",)
 
 
 def test_run_bot_swallows_missing_state(
@@ -124,29 +135,39 @@ def test_run_bot_swallows_missing_state(
         def run(self, _token: str) -> None:
             captured["ran"] = True
 
-    async def _ok_probe(_c: CrawDadConfig) -> None:
-        return None
+    async def _ok_probe(_c: CrawDadConfig) -> tuple[Any, ...]:
+        return ()
 
     monkeypatch.setattr(cli, "CrawDadClient", _FakeClient)
-    monkeypatch.setattr(cli, "_probe_mcp", _ok_probe)
+    monkeypatch.setattr(cli, "_startup_probe", _ok_probe)
 
     cli.run_bot(config)
 
     assert captured["init_kwargs"]["session_state"] is None
+    # Empty tool surface disables the router.
+    assert captured["init_kwargs"]["router"] is None
     assert captured["ran"] is True
 
 
-async def test_probe_mcp_logs_tools_on_success(
+async def test_startup_probe_returns_tool_details_on_success(
     patched_config: CrawDadConfig,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A working MCP subprocess produces an INFO log listing tool names."""
+    """``_startup_probe`` returns the advertised tool surface for the router."""
     from contextlib import asynccontextmanager
 
+    from crawdad.mcp_client import ToolDetails
+
     class _Session:
-        async def list_tools(self) -> tuple[str, ...]:
-            return ("echo",)
+        async def list_tool_details(self) -> tuple[ToolDetails, ...]:
+            return (
+                ToolDetails(
+                    name="echo",
+                    description="echo back",
+                    input_schema={"type": "object"},
+                ),
+            )
 
     class _Client:
         def __init__(self, _command: tuple[str, ...]) -> None:
@@ -159,17 +180,19 @@ async def test_probe_mcp_logs_tools_on_success(
     monkeypatch.setattr(cli, "MCPClient", _Client)
     caplog.set_level("INFO", logger="crawdad.cli")
 
-    await cli._probe_mcp(patched_config)
+    details = await cli._startup_probe(patched_config)
 
+    assert len(details) == 1
+    assert details[0].name == "echo"
     assert any("echo" in record.message for record in caplog.records)
 
 
-async def test_probe_mcp_logs_warning_on_failure(
+async def test_startup_probe_returns_empty_on_failure(
     patched_config: CrawDadConfig,
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """A broken MCP probe logs a warning but does NOT raise — bot keeps running."""
+    """A broken probe returns an empty tuple — bot still starts."""
     from contextlib import asynccontextmanager
 
     class _Client:
@@ -187,6 +210,43 @@ async def test_probe_mcp_logs_warning_on_failure(
     monkeypatch.setattr(cli, "MCPClient", _Client)
     caplog.set_level("WARNING", logger="crawdad.cli")
 
-    await cli._probe_mcp(patched_config)
+    details = await cli._startup_probe(patched_config)
 
+    assert details == ()
     assert any("MCP probe failed" in record.message for record in caplog.records)
+
+
+def test_build_agent_components_disables_router_when_no_tools(
+    patched_config: CrawDadConfig,
+) -> None:
+    """Empty tool list → router=None, history still constructed."""
+    router, mcp_client, known_tools, history = cli._build_agent_components(
+        config=patched_config, tool_details=()
+    )
+
+    assert router is None
+    assert mcp_client is not None
+    assert known_tools == ()
+    assert history is not None
+
+
+def test_build_agent_components_constructs_router_when_tools_present(
+    patched_config: CrawDadConfig,
+) -> None:
+    """A non-empty tool surface produces a wired ``IntentRouter``."""
+    from crawdad.mcp_client import ToolDetails
+
+    details = (
+        ToolDetails(
+            name="creek.state.read",
+            description="Read latest.md",
+            input_schema={"type": "object"},
+        ),
+    )
+
+    router, _client, known_tools, _history = cli._build_agent_components(
+        config=patched_config, tool_details=details
+    )
+
+    assert router is not None
+    assert known_tools == ("creek.state.read",)

--- a/crawdad/tests/test_dispatcher.py
+++ b/crawdad/tests/test_dispatcher.py
@@ -1,0 +1,120 @@
+"""Tests for ``crawdad.dispatcher``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from crawdad.dispatcher import (
+    IntentDispatcher,
+    ToolResult,
+    UnknownIntentError,
+)
+from crawdad.intents import Intent, RouterResponse
+from crawdad.mcp_client import MCPUnavailableError
+
+
+class _FakeSession:
+    """Stand-in for :class:`crawdad.mcp_client.MCPSession`."""
+
+    def __init__(
+        self,
+        *,
+        replies: dict[str, str] | None = None,
+        errors: dict[str, Exception] | None = None,
+    ) -> None:
+        self.replies = replies or {}
+        self.errors = errors or {}
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any] | None = None
+    ) -> str:
+        self.calls.append((name, arguments or {}))
+        if name in self.errors:
+            raise self.errors[name]
+        return self.replies.get(name, "")
+
+
+async def test_dispatcher_invokes_each_intent_in_order() -> None:
+    """Intents are dispatched 1-to-1 against the MCP session, in order."""
+    session: Any = _FakeSession(
+        replies={"creek.state.read": "state-body", "creek.mine": "mine-seeds"}
+    )
+    dispatcher = IntentDispatcher(
+        session=session,
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+
+    response = RouterResponse(
+        intents=[
+            Intent(type="creek.state.read"),
+            Intent(type="creek.mine", args={"phase": "rising"}),
+        ]
+    )
+
+    results = await dispatcher.dispatch(response)
+
+    assert results == [
+        ToolResult(intent_type="creek.state.read", body="state-body"),
+        ToolResult(intent_type="creek.mine", body="mine-seeds"),
+    ]
+    assert session.calls == [
+        ("creek.state.read", {"privacy_tier_ceiling": "open"}),
+        (
+            "creek.mine",
+            {"phase": "rising", "privacy_tier_ceiling": "open"},
+        ),
+    ]
+
+
+async def test_dispatcher_rejects_unknown_intent_type() -> None:
+    """An intent whose ``type`` is not in the advertised tools is refused."""
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(session=session, known_tools=("creek.state.read",))
+
+    response = RouterResponse(intents=[Intent(type="creek.unicorn")])
+
+    with pytest.raises(UnknownIntentError, match=r"creek\.unicorn"):
+        await dispatcher.dispatch(response)
+
+    assert session.calls == []
+
+
+async def test_dispatcher_returns_empty_list_for_no_intents() -> None:
+    """An empty intents array means the router decided no tools were needed."""
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(session=session, known_tools=("creek.state.read",))
+
+    results = await dispatcher.dispatch(RouterResponse(intents=[]))
+
+    assert results == []
+    assert session.calls == []
+
+
+async def test_dispatcher_propagates_mcp_unavailable() -> None:
+    """A subprocess death during dispatch surfaces as MCPUnavailableError."""
+    session: Any = _FakeSession(
+        errors={"creek.state.read": MCPUnavailableError("subprocess died")}
+    )
+    dispatcher = IntentDispatcher(session=session, known_tools=("creek.state.read",))
+
+    with pytest.raises(MCPUnavailableError):
+        await dispatcher.dispatch(
+            RouterResponse(intents=[Intent(type="creek.state.read")])
+        )
+
+
+async def test_dispatcher_preserves_privacy_tier_ceiling() -> None:
+    """The router's tier ceiling reaches the MCP call site verbatim."""
+    session: Any = _FakeSession(replies={"creek.state.read": "ok"})
+    dispatcher = IntentDispatcher(session=session, known_tools=("creek.state.read",))
+
+    await dispatcher.dispatch(
+        RouterResponse(
+            intents=[Intent(type="creek.state.read", privacy_tier_ceiling="personal")]
+        )
+    )
+
+    assert session.calls[0][1]["privacy_tier_ceiling"] == "personal"

--- a/crawdad/tests/test_dispatcher.py
+++ b/crawdad/tests/test_dispatcher.py
@@ -118,3 +118,29 @@ async def test_dispatcher_preserves_privacy_tier_ceiling() -> None:
     )
 
     assert session.calls[0][1]["privacy_tier_ceiling"] == "personal"
+
+
+async def test_dispatcher_intent_ceiling_overrides_conflicting_args() -> None:
+    """The Intent's declared ceiling wins over a conflicting key in args.
+
+    Regression for review feedback: Haiku could otherwise smuggle a
+    looser tier through ``args["privacy_tier_ceiling"]``. The Intent
+    model is authoritative — the MCP server must see the ceiling the
+    router declared, not the one Haiku tucked into the args dict.
+    """
+    session: Any = _FakeSession(replies={"creek.state.read": "ok"})
+    dispatcher = IntentDispatcher(session=session, known_tools=("creek.state.read",))
+
+    await dispatcher.dispatch(
+        RouterResponse(
+            intents=[
+                Intent(
+                    type="creek.state.read",
+                    privacy_tier_ceiling="personal",
+                    args={"privacy_tier_ceiling": "all"},  # Haiku tried to smuggle
+                )
+            ]
+        )
+    )
+
+    assert session.calls[0][1]["privacy_tier_ceiling"] == "personal"

--- a/crawdad/tests/test_history.py
+++ b/crawdad/tests/test_history.py
@@ -1,0 +1,80 @@
+"""Tests for ``crawdad.history``."""
+
+from __future__ import annotations
+
+import pytest
+
+from crawdad.config import HISTORY_MAX_CHARS_PER_ENTRY, HISTORY_MAX_ENTRIES
+from crawdad.history import ConversationHistory, HistoryEntry
+
+
+def test_history_starts_empty() -> None:
+    """A fresh history has no entries."""
+    history = ConversationHistory()
+
+    assert history.as_list() == []
+
+
+def test_history_append_records_role_and_content() -> None:
+    """Entries land on the deque in document order."""
+    history = ConversationHistory()
+
+    history.append("user", "hello")
+    history.append("assistant", "world")
+
+    assert history.as_list() == [
+        HistoryEntry(role="user", content="hello"),
+        HistoryEntry(role="assistant", content="world"),
+    ]
+
+
+def test_history_truncates_long_content() -> None:
+    """Per-entry content is capped at HISTORY_MAX_CHARS_PER_ENTRY chars."""
+    history = ConversationHistory()
+    long_message = "x" * (HISTORY_MAX_CHARS_PER_ENTRY + 500)
+
+    history.append("user", long_message)
+
+    stored = history.as_list()[0].content
+    assert len(stored) == HISTORY_MAX_CHARS_PER_ENTRY
+    assert stored == "x" * HISTORY_MAX_CHARS_PER_ENTRY
+
+
+def test_history_evicts_oldest_beyond_max_entries() -> None:
+    """The 21st append drops the first entry — strict FIFO at the cap."""
+    history = ConversationHistory()
+    for index in range(HISTORY_MAX_ENTRIES + 1):
+        history.append("user", f"msg-{index}")
+
+    entries = history.as_list()
+    assert len(entries) == HISTORY_MAX_ENTRIES
+    # First message (msg-0) was evicted; second (msg-1) is now oldest.
+    assert entries[0].content == "msg-1"
+    assert entries[-1].content == f"msg-{HISTORY_MAX_ENTRIES}"
+
+
+def test_history_clear_resets() -> None:
+    """``clear()`` empties the deque for session resets."""
+    history = ConversationHistory()
+    history.append("user", "hello")
+    history.append("assistant", "world")
+
+    history.clear()
+
+    assert history.as_list() == []
+
+
+def test_history_rejects_empty_role() -> None:
+    """An empty role is a programming error, caught at append time."""
+    history = ConversationHistory()
+
+    with pytest.raises(ValueError, match="role"):
+        history.append("", "anything")
+
+
+def test_history_entry_is_frozen() -> None:
+    """HistoryEntry instances are immutable so prompt assembly can't mutate."""
+    entry = HistoryEntry(role="user", content="hello")
+
+    with pytest.raises((TypeError, AttributeError, ValueError)):
+        entry.role = "assistant"  # type: ignore[misc]

--- a/crawdad/tests/test_intents.py
+++ b/crawdad/tests/test_intents.py
@@ -1,0 +1,108 @@
+"""Tests for ``crawdad.intents``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from crawdad.intents import (
+    Intent,
+    PrivacyTierCeiling,
+    RouterResponse,
+    ToolInfo,
+    build_intents_schema,
+)
+
+
+def test_intent_default_privacy_tier_is_open() -> None:
+    """Per FEAT-014 §pre-decided choices, ``open`` is the default."""
+    intent = Intent(type="creek.state.read")
+
+    assert intent.privacy_tier_ceiling == PrivacyTierCeiling.OPEN
+    assert intent.args == {}
+
+
+def test_intent_rejects_empty_type() -> None:
+    """An empty intent type is a programming error from a bad router output."""
+    with pytest.raises(ValidationError):
+        Intent(type="")
+
+
+def test_intent_accepts_args() -> None:
+    """Tool-specific args ride in ``args`` (validated by the MCP server)."""
+    intent = Intent(
+        type="creek.mine",
+        args={"phase": "rising", "limit": 5},
+        privacy_tier_ceiling=PrivacyTierCeiling.PERSONAL,
+    )
+
+    assert intent.args == {"phase": "rising", "limit": 5}
+    assert intent.privacy_tier_ceiling == PrivacyTierCeiling.PERSONAL
+
+
+def test_router_response_parses_json_payload() -> None:
+    """``RouterResponse`` is the strict JSON shape Haiku must emit."""
+    payload: dict[str, Any] = {
+        "intents": [
+            {"type": "creek.state.read"},
+            {"type": "creek.mine", "args": {"phase": "rising"}},
+        ]
+    }
+
+    response = RouterResponse.model_validate(payload)
+
+    assert len(response.intents) == 2
+    assert response.intents[0].type == "creek.state.read"
+    assert response.intents[1].args == {"phase": "rising"}
+
+
+def test_router_response_accepts_empty_intents() -> None:
+    """No intents = the router decided no tool calls are needed."""
+    response = RouterResponse.model_validate({"intents": []})
+
+    assert response.intents == []
+
+
+def test_router_response_rejects_missing_intents_key() -> None:
+    """Missing ``intents`` key is malformed router output."""
+    with pytest.raises(ValidationError):
+        RouterResponse.model_validate({"reply": "hello"})
+
+
+def test_build_intents_schema_lists_each_tool() -> None:
+    """The schema's ``type`` enum reflects every advertised MCP tool."""
+    tools = [
+        ToolInfo(
+            name="creek.state.read",
+            description="Read latest.md",
+            input_schema={"type": "object", "properties": {}},
+        ),
+        ToolInfo(
+            name="creek.mine",
+            description="Mine essay seeds.",
+            input_schema={
+                "type": "object",
+                "properties": {"phase": {"type": "string"}},
+            },
+        ),
+    ]
+
+    schema = build_intents_schema(tools)
+
+    assert schema["type"] == "object"
+    assert "intents" in schema["properties"]
+    intent_item = schema["properties"]["intents"]["items"]
+    assert sorted(intent_item["properties"]["type"]["enum"]) == [
+        "creek.mine",
+        "creek.state.read",
+    ]
+
+
+def test_build_intents_schema_empty_tool_list() -> None:
+    """An empty registry produces a schema that allows no intent types."""
+    schema = build_intents_schema([])
+
+    intent_item = schema["properties"]["intents"]["items"]
+    assert intent_item["properties"]["type"]["enum"] == []

--- a/crawdad/tests/test_mcp_client.py
+++ b/crawdad/tests/test_mcp_client.py
@@ -99,3 +99,27 @@ async def test_session_call_tool_translates_underlying_failure() -> None:
 
     with pytest.raises(MCPUnavailableError, match="call_tool"):
         await session.call_tool("anything", {})
+
+
+async def test_list_tool_details_returns_name_description_and_schema() -> None:
+    """``list_tool_details`` powers FEAT-014's intents-schema generation."""
+    async with MCPClient(_fixture_command()).connect() as session:
+        details = await session.list_tool_details()
+
+    names = {tool.name for tool in details}
+    assert {"echo", "ping"}.issubset(names)
+    echo = next(tool for tool in details if tool.name == "echo")
+    assert echo.input_schema["type"] == "object"
+    # FastMCP wraps the function signature; ``message`` is the kwarg.
+    assert "message" in echo.input_schema.get("properties", {})
+
+
+async def test_list_tool_details_translates_underlying_failure() -> None:
+    """Failures during the detailed listing map to MCPUnavailableError."""
+    from crawdad.mcp_client import MCPSession
+
+    broken: Any = _BrokenSession()
+    session = MCPSession(broken)
+
+    with pytest.raises(MCPUnavailableError, match="list_tool_details"):
+        await session.list_tool_details()

--- a/crawdad/tests/test_no_model_literals.py
+++ b/crawdad/tests/test_no_model_literals.py
@@ -1,0 +1,36 @@
+"""Static check: no Claude model-ID literals live outside ``config.py``.
+
+FEAT-014 §pre-decided choices §27 mandates this: model IDs move, so the
+constant ``DEFAULT_ROUTER_MODEL`` in ``config.py`` is the contract.
+Other modules must read it (or accept a model argument resolved from
+it), never reference the literal string.
+
+The check is a simple grep so it remains fast and trivially debuggable
+when it fires.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent.parent / "crawdad"
+_ALLOWED_FILE = "config.py"
+_MODEL_PATTERN = re.compile(r"claude-(haiku|sonnet|opus)-\d", re.IGNORECASE)
+
+
+def test_no_model_id_literals_outside_config() -> None:
+    """No ``crawdad/*.py`` (except ``config.py``) contains a model ID string."""
+    offenders: list[str] = []
+    for path in _PACKAGE_ROOT.rglob("*.py"):
+        if path.name == _ALLOWED_FILE:
+            continue
+        text = path.read_text(encoding="utf-8")
+        match = _MODEL_PATTERN.search(text)
+        if match:
+            offenders.append(f"{path.relative_to(_PACKAGE_ROOT)}: {match.group(0)!r}")
+    assert not offenders, (
+        "model-ID literals found outside config.py: "
+        + ", ".join(offenders)
+        + " — read DEFAULT_ROUTER_MODEL from config.py instead."
+    )

--- a/crawdad/tests/test_router.py
+++ b/crawdad/tests/test_router.py
@@ -1,0 +1,243 @@
+"""Tests for ``crawdad.router``."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from crawdad.history import ConversationHistory
+from crawdad.intents import PrivacyTierCeiling, ToolInfo
+from crawdad.router import (
+    IntentRouter,
+    RouterParseError,
+    build_router_prompt,
+)
+from crawdad.state import SessionState
+
+
+@pytest.fixture
+def tools() -> list[ToolInfo]:
+    return [
+        ToolInfo(
+            name="creek.state.read",
+            description="Read latest.md",
+            input_schema={"type": "object"},
+        ),
+        ToolInfo(
+            name="creek.mine",
+            description="Mine essay seeds.",
+            input_schema={
+                "type": "object",
+                "properties": {"phase": {"type": "string"}},
+            },
+        ),
+    ]
+
+
+@pytest.fixture
+def session_state() -> SessionState:
+    return SessionState(
+        raw_markdown="snapshot",
+        wavelength_snapshot="Phase: **rising** (confidence 0.84)",
+        eddies=("eddy-clarity",),
+        threads=("thread-voice",),
+        suggested_questions=("What is surfacing?",),
+    )
+
+
+class _FakeAnthropic:
+    """Minimal stand-in for ``anthropic.AsyncAnthropic`` used in tests."""
+
+    def __init__(self, response_text: str) -> None:
+        self._response_text = response_text
+        self.calls: list[dict[str, Any]] = []
+        self.messages = self  # so router can call client.messages.create
+
+    async def create(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return _FakeResponse(self._response_text)
+
+
+class _FakeResponse:
+    def __init__(self, text: str) -> None:
+        self.content = [_FakeBlock(text)]
+
+
+class _FakeBlock:
+    def __init__(self, text: str) -> None:
+        self.type = "text"
+        self.text = text
+
+
+def test_build_router_prompt_includes_wavelength_and_history(
+    tools: list[ToolInfo], session_state: SessionState
+) -> None:
+    """The prompt names the wavelength snapshot, history, and tools."""
+    history = ConversationHistory()
+    history.append("user", "what's surfacing?")
+
+    prompt = build_router_prompt(
+        message="what about now?",
+        history=history,
+        state=session_state,
+        tools=tools,
+    )
+
+    assert "rising" in prompt
+    assert "what's surfacing?" in prompt
+    assert "creek.state.read" in prompt
+    assert "creek.mine" in prompt
+    assert "what about now?" in prompt
+
+
+def test_build_router_prompt_handles_missing_state(tools: list[ToolInfo]) -> None:
+    """A ``None`` session_state degrades gracefully — no wavelength line."""
+    prompt = build_router_prompt(
+        message="hi",
+        history=ConversationHistory(),
+        state=None,
+        tools=tools,
+    )
+
+    assert "hi" in prompt
+    # No wavelength prefix when state is unavailable.
+    assert "wavelength" not in prompt.lower() or "no wavelength" in prompt.lower()
+
+
+def test_build_router_prompt_phase_aware_instruction(
+    tools: list[ToolInfo],
+) -> None:
+    """Bottoming-Out phases steer Haiku away from mine/draft (ADOPT-008)."""
+    state = SessionState(
+        raw_markdown="snapshot",
+        wavelength_snapshot="Phase: **bottoming-out** (confidence 0.71)",
+        eddies=(),
+        threads=(),
+        suggested_questions=(),
+    )
+
+    prompt = build_router_prompt(
+        message="anything",
+        history=ConversationHistory(),
+        state=state,
+        tools=tools,
+    )
+
+    assert "bottoming-out" in prompt
+    assert "compost" in prompt.lower() or "paradox" in prompt.lower()
+
+
+async def test_router_extract_intents_parses_valid_json(
+    tools: list[ToolInfo], session_state: SessionState
+) -> None:
+    """A well-formed Haiku reply lands on a :class:`RouterResponse`."""
+    fake_haiku = _FakeAnthropic(
+        json.dumps(
+            {
+                "intents": [
+                    {
+                        "type": "creek.state.read",
+                        "privacy_tier_ceiling": "open",
+                    }
+                ]
+            }
+        )
+    )
+    router = IntentRouter(
+        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        model="claude-haiku-test",
+        tools=tools,
+    )
+
+    response = await router.extract_intents(
+        message="what's surfacing?",
+        history=ConversationHistory(),
+        state=session_state,
+    )
+
+    assert len(response.intents) == 1
+    assert response.intents[0].type == "creek.state.read"
+    assert response.intents[0].privacy_tier_ceiling == PrivacyTierCeiling.OPEN
+
+
+async def test_router_uses_configured_model(
+    tools: list[ToolInfo], session_state: SessionState
+) -> None:
+    """The injected model name is the one passed to the Anthropic SDK."""
+    fake_haiku = _FakeAnthropic(json.dumps({"intents": []}))
+    router = IntentRouter(
+        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        model="custom-haiku-id",
+        tools=tools,
+    )
+
+    await router.extract_intents(
+        message="hi",
+        history=ConversationHistory(),
+        state=session_state,
+    )
+
+    assert fake_haiku.calls[0]["model"] == "custom-haiku-id"
+
+
+async def test_router_rejects_non_json_response(
+    tools: list[ToolInfo], session_state: SessionState
+) -> None:
+    """A non-JSON Haiku reply raises ``RouterParseError``."""
+    fake_haiku = _FakeAnthropic("here is some prose, not JSON")
+    router = IntentRouter(
+        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        model="claude-haiku-test",
+        tools=tools,
+    )
+
+    with pytest.raises(RouterParseError, match="JSON"):
+        await router.extract_intents(
+            message="hi",
+            history=ConversationHistory(),
+            state=session_state,
+        )
+
+
+async def test_router_rejects_missing_intents_key(
+    tools: list[ToolInfo], session_state: SessionState
+) -> None:
+    """JSON without the ``intents`` array is malformed router output."""
+    fake_haiku = _FakeAnthropic(json.dumps({"reply": "hi"}))
+    router = IntentRouter(
+        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        model="claude-haiku-test",
+        tools=tools,
+    )
+
+    with pytest.raises(RouterParseError):
+        await router.extract_intents(
+            message="hi",
+            history=ConversationHistory(),
+            state=session_state,
+        )
+
+
+async def test_router_extracts_fenced_json_blocks(
+    tools: list[ToolInfo], session_state: SessionState
+) -> None:
+    """Markdown fences around the JSON are tolerated."""
+    payload = json.dumps({"intents": [{"type": "creek.state.read"}]})
+    fake_haiku = _FakeAnthropic(
+        f"Sure, here is the result:\n\n```json\n{payload}\n```\n"
+    )
+    router = IntentRouter(
+        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        model="claude-haiku-test",
+        tools=tools,
+    )
+
+    response = await router.extract_intents(
+        message="hi",
+        history=ConversationHistory(),
+        state=session_state,
+    )
+
+    assert response.intents[0].type == "creek.state.read"

--- a/crawdad/tests/test_router.py
+++ b/crawdad/tests/test_router.py
@@ -220,6 +220,49 @@ async def test_router_rejects_missing_intents_key(
         )
 
 
+class _RaisingAnthropic:
+    """``messages.create`` raises an injected exception, modeling SDK errors."""
+
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.messages = self
+
+    async def create(self, **_kwargs: Any) -> Any:
+        raise self._exc
+
+
+async def test_router_translates_anthropic_api_error_to_parse_error(
+    tools: list[ToolInfo], session_state: SessionState
+) -> None:
+    """Rate-limit / connection / auth errors surface as ``RouterParseError``.
+
+    The bot maps ``RouterParseError`` to a user-visible reply; without
+    this translation the SDK error would propagate through
+    ``handle_message`` into discord.py and the user would receive no
+    reply at all.
+    """
+    import anthropic
+
+    # ``APIError`` requires a request kwarg in modern SDK versions; we
+    # construct a minimal subclass exception that still belongs to the
+    # base ``AnthropicError`` hierarchy.
+    fake_haiku = _RaisingAnthropic(
+        anthropic.AnthropicError("simulated rate-limit / API failure")
+    )
+    router = IntentRouter(
+        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        model="claude-haiku-test",
+        tools=tools,
+    )
+
+    with pytest.raises(RouterParseError, match="Haiku API call failed"):
+        await router.extract_intents(
+            message="hi",
+            history=ConversationHistory(),
+            state=session_state,
+        )
+
+
 async def test_router_extracts_fenced_json_blocks(
     tools: list[ToolInfo], session_state: SessionState
 ) -> None:


### PR DESCRIPTION
## Summary

Adds the first half of the CrawDad agent loop: a **Haiku-driven intent extraction step** + a **1-to-1 MCP tool dispatcher**. The "boring structured reply" path is now wired through `handle_message`; FEAT-015 will swap the structured summary for the Sonnet composer + 5-round loop.

Implements [`plans/git-issues/FEAT-014-crawdad-haiku-router-dispatcher.md`](https://github.com/Geoffe-Ga/Creek-Vault/blob/claude/crawdad-haiku-router-dispatcher/plans/git-issues/FEAT-014-crawdad-haiku-router-dispatcher.md).

## Acceptance criteria coverage

| FEAT-014 acceptance criterion | Status | Verified by |
|---|---|---|
| `crawdad run` handles a Discord message via Haiku → dispatcher → tool call → boring structured reply | ✅ | `tests/test_bot.py::test_handle_message_runs_router_and_dispatcher` (end-to-end through the public handler with stub router + stub MCP session) |
| `intents` schema is generated from the MCP tool registry at startup | ✅ | `cli._startup_probe` calls `MCPSession.list_tool_details()`; `_build_agent_components` feeds the result into `IntentRouter` + `build_intents_schema`. Tests: `test_cli.py::test_startup_probe_returns_tool_details_on_success`, `test_intents.py::test_build_intents_schema_lists_each_tool`. |
| History truncation enforced (20 entries × 2000 chars each) | ✅ | `tests/test_history.py::test_history_truncates_long_content` + `test_history_evicts_oldest_beyond_max_entries` |
| Wavelength-aware bias documented in router prompt + verified by fixture-based regression | ✅ | `tests/test_router.py::test_build_router_prompt_phase_aware_instruction` — a Bottoming Out snapshot produces a prompt containing the compost/paradox hint, not mine/draft. |
| ≥90% branch coverage | ✅ | **93.66% aggregate**; per-file all ≥89%. |

Pre-decided choice §27 (no literal model ID outside `config.py`) verified by **`tests/test_no_model_literals.py`** — a recursive grep over `crawdad/crawdad/*.py` for `claude-(haiku|sonnet|opus)-\d` excluding `config.py`.

## Architecture

```
Discord message
  ▼
handle_message  (bot.py — allowlist gate, state check)
  ▼
IntentRouter.extract_intents  (router.py)
  ─ prompt = role + wavelength + history + tools schema + user message
  ─ Haiku call (model = DEFAULT_ROUTER_MODEL)
  ─ parse strict JSON {intents: [...]}
  ▼
async with mcp_client.connect() as session:
    IntentDispatcher(session, known_tools)  (dispatcher.py)
      ─ for each intent: validate type in known_tools, call MCP tool, collect ToolResult
  ▼
format_structured_reply(results)  (bot.py — FEAT-015 swaps this for Sonnet)
  ▼
Discord
```

The MCP session is per-message; the router is long-lived. FEAT-015 will wrap router → dispatch → compose in a 5-round loop.

## What FEAT-014 ships

| Module | Purpose |
|---|---|
| `crawdad/config.py` | New `DEFAULT_ROUTER_MODEL` (env `CRAWDAD_ROUTER_MODEL`, fallback `claude-haiku-4-5-20251001`). `HISTORY_MAX_ENTRIES = 20`, `HISTORY_MAX_CHARS_PER_ENTRY = 2000`. |
| `crawdad/history.py` | `ConversationHistory` deque with truncation + eviction. |
| `crawdad/intents.py` | `Intent`, `RouterResponse`, `PrivacyTierCeiling`, `ToolInfo`, `build_intents_schema()`. |
| `crawdad/mcp_client.py` | New `list_tool_details()` returning `ToolDetails(name, description, input_schema)` — the schema source for the router. |
| `crawdad/router.py` | `IntentRouter` (Haiku call + JSON parse, tolerant of ```json fences) + `build_router_prompt` free function for testability. Wavelength-aware bias: Bottoming Out / Diminishing → compost+paradox hint; Rising / Peaking → mine/draft welcome. |
| `crawdad/dispatcher.py` | `IntentDispatcher.dispatch()` — 1-to-1 intent → MCP tool. `UnknownIntentError` for unadvertised types; `MCPUnavailableError` forwarded. |
| `crawdad/bot.py` | `handle_message` adds `router` + `mcp_client` + `known_tools` + `history` params. Five user-facing replies (state-unavailable, MCP-unreachable, router-parse-error, unknown-intent, no-tool-call-needed). |
| `crawdad/cli.py` | `_startup_probe` returns `ToolDetails` tuple; `_build_agent_components` constructs router + history + MCPClient. Empty tool surface disables the router gracefully. |

## Pre-decided choices honoured

- **Router model from `config.py:DEFAULT_ROUTER_MODEL`**, never a literal in other modules. Verified by `test_no_model_literals.py` (recursive grep).
- **History truncation**: hard cliff at 20 × 2000 chars.
- **Intents schema regenerated from `tools/list`** at startup; cached for the session.
- **Router prompt structure**: role + context (wavelength + history + tools schema) + strict JSON output instruction.
- **Wavelength-aware bias**: explicit per-phase hint baked into the prompt.
- **Per-intent `privacy_tier_ceiling`**: defaults to `open`, flattened into the MCP call args by the dispatcher.
- **No Sonnet call in this PR.** Bot posts a "boring structured summary" (one bullet per tool result, body truncated to 300 chars per line).

## Dependency note

Required dependency **FEAT-013 is merged** (`a320948`, PR #227). The merged FEAT-011 (`d92dd41`, PR #228) is *not* strictly required by FEAT-014 — the intents schema is generated dynamically from `tools/list`, so FEAT-011's write tools (and FEAT-012's purge tools when they land) are automatically picked up by the next session start.

## Test plan

- [x] `./scripts/check-all.sh` exits 0 locally — 7/7 gates green.
- [x] **80 tests pass**, 93.66% branch coverage (up from 94.24% — slight dip because of the new error-path branches in `bot.py`, all green).
- [x] No literal model IDs outside `config.py` (regression test).
- [ ] CI green on all jobs.

## LOC breakdown

| Category | LOC |
|---|---|
| Source (`crawdad/crawdad/*.py` new + edits) | ~820 |
| Tests (`tests/*.py` new + edits) | ~900 |
| **Total diff** | **1708 insertions, 58 deletions** |

In line with FEAT-013's shape (1940 LOC total). Source-only delta is above FEAT-014's ~450 LOC estimate because the `bot.py` refactor for the new dispatcher signature carries a lot of docstring + signature churn; the actual new logic is ~600 lines.

## FEAT-015 parallelism note

**FEAT-015 is not parallelizable with FEAT-014.** Its plan file is explicit: `Dependencies: FEAT-014`, `Parallelizable with peers: no`. FEAT-015 replaces the `format_structured_reply` path with the Sonnet composer and wraps the whole thing in the 5-round loop — both need this PR's router + dispatcher to land first.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VqPZsk7QWgNbeVSymTmgKG)_