### PR TITLE
feat(mcp): purge tools + elevated authorization + audit hardening (FEAT-012)

### DIFF
--- a/creek-tools/creek_mcp/audit.py
+++ b/creek-tools/creek_mcp/audit.py
@@ -39,7 +39,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from creek.audit import AuditChainBrokenError, AuditLog
+from creek.audit import AuditLog
+from creek.audit.log import GENESIS_PREV_HASH
 
 if TYPE_CHECKING:
     from creek_mcp.tier_ceiling import TierCeiling
@@ -180,14 +181,23 @@ class MCPAuditLog:
 def verify_mcp_audit_chain(vault_path: Path) -> None:
     """Walk ``mcp.jsonl`` under *vault_path* and validate both invariants.
 
-    Two checks run in tandem:
+    The function reads the log exactly once and validates both checks
+    against the same byte snapshot:
 
-    * ``prev_hash`` chain — delegated to :class:`creek.audit.AuditLog`,
-      which detects removal / reordering by comparing each entry's
-      ``prev_hash`` against ``sha256`` of the previous full line.
+    * ``prev_hash`` chain — each entry's stored ``prev_hash`` is
+      compared against ``sha256`` of the previous full line. Removing
+      or reordering an entry breaks the link at the next line.
     * ``entry_hash`` per entry — recomputed from the stored payload
-      (sans the field itself) and compared to the persisted digest, so
-      a mutation of any other field is flagged on its own.
+      (excluding ``entry_hash``/``prev_hash`` to avoid circularity)
+      and compared to the persisted digest. Mutating any other field
+      invalidates the hash on its own.
+
+    Reading once is intentional: an earlier two-pass version (verify
+    chain via :class:`AuditLog.verify`, then iterate via
+    :class:`AuditLog.read`) had a TOCTOU window. A concurrent appender
+    could grow the file between the two opens, leaving the trailing
+    new entries unchecked by ``entry_hash``. The single snapshot here
+    closes that gap — both invariants see the same set of lines.
 
     A missing log is trivially valid (no entries to disagree about).
 
@@ -197,21 +207,54 @@ def verify_mcp_audit_chain(vault_path: Path) -> None:
     log_path = vault_path / MCP_AUDIT_RELPATH
     if not log_path.exists():
         return
-    audit_log = AuditLog(log_path)
-    try:
-        audit_log.verify()
-    except AuditChainBrokenError as exc:
-        msg = f"MCP audit chain broken: {exc}"
-        raise MCPAuditChainBrokenError(msg) from exc
-    for index, entry in enumerate(audit_log.read()):
-        stored = entry.get(ENTRY_HASH_FIELD)
-        if stored is None:
-            msg = f"MCP audit line {index} is missing 'entry_hash'"
-            raise MCPAuditChainBrokenError(msg)
-        expected = _content_hash(entry)
-        if stored != expected:
-            msg = (
-                f"MCP audit entry_hash mismatch at line {index}: "
-                f"expected {expected!r}, found {stored!r}"
-            )
-            raise MCPAuditChainBrokenError(msg)
+    with log_path.open("r", encoding="utf-8") as handle:
+        lines = [
+            stripped for stripped in (raw.rstrip("\n") for raw in handle) if stripped
+        ]
+    previous_line: str | None = None
+    for index, raw_line in enumerate(lines):
+        try:
+            entry = json.loads(raw_line)
+        except json.JSONDecodeError as exc:
+            msg = f"MCP audit line {index} is not valid JSON"
+            raise MCPAuditChainBrokenError(msg) from exc
+        _verify_prev_hash(entry, previous_line, index)
+        _verify_entry_hash(entry, index)
+        previous_line = raw_line
+
+
+def _verify_prev_hash(
+    entry: dict[str, Any],
+    previous_line: str | None,
+    index: int,
+) -> None:
+    """Confirm *entry*'s ``prev_hash`` matches ``sha256`` of *previous_line*."""
+    if "prev_hash" not in entry:
+        msg = f"MCP audit line {index} is missing 'prev_hash'"
+        raise MCPAuditChainBrokenError(msg)
+    expected = (
+        GENESIS_PREV_HASH
+        if previous_line is None
+        else hashlib.sha256(previous_line.encode("utf-8")).hexdigest()
+    )
+    if entry["prev_hash"] != expected:
+        msg = (
+            f"MCP audit chain broken at line {index}: "
+            f"expected prev_hash {expected!r}, found {entry['prev_hash']!r}"
+        )
+        raise MCPAuditChainBrokenError(msg)
+
+
+def _verify_entry_hash(entry: dict[str, Any], index: int) -> None:
+    """Confirm *entry*'s stored ``entry_hash`` matches recomputed content."""
+    stored = entry.get(ENTRY_HASH_FIELD)
+    if stored is None:
+        msg = f"MCP audit line {index} is missing 'entry_hash'"
+        raise MCPAuditChainBrokenError(msg)
+    expected = _content_hash(entry)
+    if stored != expected:
+        msg = (
+            f"MCP audit entry_hash mismatch at line {index}: "
+            f"expected {expected!r}, found {stored!r}"
+        )
+        raise MCPAuditChainBrokenError(msg)

--- a/creek-tools/creek_mcp/audit.py
+++ b/creek-tools/creek_mcp/audit.py
@@ -1,11 +1,14 @@
-"""MCP-side audit log (FEAT-010).
+"""MCP-side audit log (FEAT-010 + FEAT-012 hardening).
 
 Every MCP tool invocation appends one entry to
 ``<vault>/00-Creek-Meta/audit/mcp.jsonl``. The module exists as its own
-boundary from day 1 — FEAT-011 adds write-side fields; FEAT-012 hardens
-further if needed. The storage layer already delegates to
-:class:`creek.audit.AuditLog`, so the hash-chain + flock guarantees that
-guard ``redact.jsonl`` also guard ``mcp.jsonl``.
+boundary from day 1 — FEAT-011 adds write-side fields, and FEAT-012
+adds the per-entry ``entry_hash`` plus a chain verifier so that
+tampering with any single field is detectable without comparing to a
+known-good snapshot. The storage layer delegates to
+:class:`creek.audit.AuditLog`, so the ``prev_hash`` chain and the
+exclusive ``flock`` during writes that guard ``redact.jsonl`` also
+guard ``mcp.jsonl``.
 
 The module records ``args_summary``, not raw arguments: long strings
 become ``{"len": N}``, lists become counts, dicts become key sets, so
@@ -14,21 +17,74 @@ Callers are expected to pass *only* the MCP-supplied parameters into
 ``append(args=...)`` — never internal state such as ``vault_path``,
 which is resolved by the server bootstrap and so does not enter the
 audit trail.
+
+FEAT-012 hardening details:
+
+* ``entry_hash`` = SHA-256 of the entry's content excluding the
+  ``entry_hash`` field itself (sorted JSON, UTF-8). Mutating any field
+  invalidates the hash, so a verifier can flag the tampered entry on
+  its own — without needing the next entry's ``prev_hash``.
+* ``prev_hash`` continues to chain through ``creek.audit.AuditLog``,
+  so removing or reordering entries breaks the chain even if every
+  individual ``entry_hash`` survives.
+* :func:`verify_mcp_audit_chain` walks both invariants and raises
+  :class:`MCPAuditChainBrokenError` on any mismatch.
 """
 
 from __future__ import annotations
 
+import hashlib
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from creek.audit import AuditLog
+from creek.audit import AuditChainBrokenError, AuditLog
 
 if TYPE_CHECKING:
     from creek_mcp.tier_ceiling import TierCeiling
 
 MCP_AUDIT_RELPATH = Path("00-Creek-Meta/audit/mcp.jsonl")
 """Canonical MCP audit log location under the vault root."""
+
+ENTRY_HASH_FIELD = "entry_hash"
+"""Reserved field carrying ``sha256`` of the entry's content."""
+
+
+class MCPAuditChainBrokenError(Exception):
+    """Raised when :func:`verify_mcp_audit_chain` detects tampering.
+
+    The error message names the offending line index (zero-based) and
+    which invariant failed — ``entry_hash`` mismatch (mutation) or
+    ``prev_hash`` mismatch (reordering / removal) — so operators can
+    bisect which entry the editor touched.
+    """
+
+
+_HASH_EXCLUDED_FIELDS = frozenset({"entry_hash", "prev_hash"})
+"""Fields stripped before computing ``entry_hash``.
+
+``entry_hash`` is removed to avoid the obvious circularity, and
+``prev_hash`` is removed because the chain link is owned by
+:class:`creek.audit.AuditLog` and stamped *after* the MCP layer fixes
+its content hash. Excluding both means ``entry_hash`` covers the
+caller-supplied payload — the part the MCP layer is responsible for —
+while ``prev_hash`` covers placement in the chain. The two invariants
+are independent: mutating any non-hash field invalidates
+``entry_hash``; reordering or removing lines invalidates the chain.
+"""
+
+
+def _content_hash(entry: dict[str, Any]) -> str:
+    """Return ``sha256`` of *entry* with chain / hash fields removed.
+
+    Sorted JSON keys pin the byte layout so two callers serialising
+    the same logical entry agree on the digest.
+    """
+    payload = {k: v for k, v in entry.items() if k not in _HASH_EXCLUDED_FIELDS}
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True).encode("utf-8"),
+    ).hexdigest()
 
 
 def summarise_args(args: dict[str, Any]) -> dict[str, Any]:
@@ -113,4 +169,49 @@ class MCPAuditLog:
             entry["created_tier"] = created_tier
         if affected_fragment_ids is not None:
             entry["affected_fragment_ids"] = list(affected_fragment_ids)
+        # entry_hash before prev_hash: prev_hash is added inside
+        # AuditLog.append and folds entry_hash into the chained bytes,
+        # so a verifier that recomputes entry_hash on read sees an
+        # entry whose content matches the chain link of its successor.
+        entry[ENTRY_HASH_FIELD] = _content_hash(entry)
         self._audit.append(entry)
+
+
+def verify_mcp_audit_chain(vault_path: Path) -> None:
+    """Walk ``mcp.jsonl`` under *vault_path* and validate both invariants.
+
+    Two checks run in tandem:
+
+    * ``prev_hash`` chain — delegated to :class:`creek.audit.AuditLog`,
+      which detects removal / reordering by comparing each entry's
+      ``prev_hash`` against ``sha256`` of the previous full line.
+    * ``entry_hash`` per entry — recomputed from the stored payload
+      (sans the field itself) and compared to the persisted digest, so
+      a mutation of any other field is flagged on its own.
+
+    A missing log is trivially valid (no entries to disagree about).
+
+    Raises:
+        MCPAuditChainBrokenError: When either invariant fails.
+    """
+    log_path = vault_path / MCP_AUDIT_RELPATH
+    if not log_path.exists():
+        return
+    audit_log = AuditLog(log_path)
+    try:
+        audit_log.verify()
+    except AuditChainBrokenError as exc:
+        msg = f"MCP audit chain broken: {exc}"
+        raise MCPAuditChainBrokenError(msg) from exc
+    for index, entry in enumerate(audit_log.read()):
+        stored = entry.get(ENTRY_HASH_FIELD)
+        if stored is None:
+            msg = f"MCP audit line {index} is missing 'entry_hash'"
+            raise MCPAuditChainBrokenError(msg)
+        expected = _content_hash(entry)
+        if stored != expected:
+            msg = (
+                f"MCP audit entry_hash mismatch at line {index}: "
+                f"expected {expected!r}, found {stored!r}"
+            )
+            raise MCPAuditChainBrokenError(msg)

--- a/creek-tools/creek_mcp/auth.py
+++ b/creek-tools/creek_mcp/auth.py
@@ -1,0 +1,40 @@
+"""Elevated-authorization gate for destructive MCP tools (FEAT-012).
+
+``creek.purge.*`` tools mutate the vault irreversibly. The MCP boundary
+gates them behind an environment-variable token (``CREEK_MCP_ELEVATED_TOKEN``)
+provided to the developer's Claude Code but withheld from CrawDad.
+
+The comparison MUST use :func:`hmac.compare_digest` rather than ``==``:
+a timing-side-channel comparison would leak the token byte-by-byte to a
+hostile MCP client. ``hmac.compare_digest`` runs in constant time
+relative to the input length, so an attacker cannot probe the secret
+through repeated calls. The :mod:`creek_mcp.auth` test module asserts
+via an AST walk that ``is_elevated`` contains no ``==``/``!=`` on the
+hot path; the rule is mechanical, not stylistic.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+
+ELEVATED_TOKEN_ENV = "CREEK_MCP_ELEVATED_TOKEN"
+"""Env var the server reads at startup to learn the expected token."""
+
+
+def is_elevated(provided_token: str | None) -> bool:
+    """Return ``True`` when *provided_token* matches the configured secret.
+
+    The gate fails closed when either side is missing: an absent or
+    empty ``CREEK_MCP_ELEVATED_TOKEN`` denies every call, and a missing
+    client token cannot accidentally match an empty server token. Only
+    a non-empty server token combined with a constant-time match
+    against the client value returns ``True``.
+    """
+    expected = os.environ.get(ELEVATED_TOKEN_ENV, "")
+    if not expected or not provided_token:
+        return False
+    return hmac.compare_digest(
+        expected.encode("utf-8"),
+        provided_token.encode("utf-8"),
+    )

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -27,6 +27,11 @@ from creek_mcp.tools import (
     link_tool,
     lint_tool,
     mine_tool,
+    purge_classifications_tool,
+    purge_daterange_tool,
+    purge_fragment_tool,
+    purge_source_tool,
+    purge_vault_tool,
     report_tool,
     save_tool,
     skills_refresh_tool,
@@ -296,6 +301,81 @@ def build_server(
             target_title=target_title,
             llm_factory=compile_factory,
             privacy_tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.purge.fragment")
+    def _purge_fragment(
+        fragment_id: str,
+        auth_token: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        """Delete one fragment by ID (elevated authorization required)."""
+        return purge_fragment_tool(
+            vault_path=vault,
+            fragment_id=fragment_id,
+            auth_token=auth_token,
+            dry_run=dry_run,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.purge.source")
+    def _purge_source(
+        source_type: str,
+        auth_token: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        """Delete every fragment from *source_type* (elevated auth required)."""
+        return purge_source_tool(
+            vault_path=vault,
+            source_type=source_type,
+            auth_token=auth_token,
+            dry_run=dry_run,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.purge.classifications")
+    def _purge_classifications(
+        auth_token: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        """Reset classification metadata vault-wide (elevated auth required)."""
+        return purge_classifications_tool(
+            vault_path=vault,
+            auth_token=auth_token,
+            dry_run=dry_run,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.purge.daterange")
+    def _purge_daterange(
+        start: str,
+        end: str,
+        auth_token: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        """Delete fragments created in ``[start, end]`` (elevated auth required)."""
+        return purge_daterange_tool(
+            vault_path=vault,
+            start=start,
+            end=end,
+            auth_token=auth_token,
+            dry_run=dry_run,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.purge.vault")
+    def _purge_vault(
+        confirm_vault_path: str | None = None,
+        auth_token: str | None = None,
+        dry_run: bool = False,
+    ) -> dict[str, Any]:
+        """Destroy all vault content (elevated auth + path confirmation)."""
+        return purge_vault_tool(
+            vault_path=vault,
+            confirm_vault_path=confirm_vault_path,
+            auth_token=auth_token,
+            dry_run=dry_run,
             consumer=consumer,
         )
 

--- a/creek-tools/creek_mcp/tools/__init__.py
+++ b/creek-tools/creek_mcp/tools/__init__.py
@@ -1,4 +1,4 @@
-"""MCP tool implementations exposed by ``creek_mcp.server`` (FEAT-010/011)."""
+"""MCP tool implementations exposed by ``creek_mcp.server`` (FEAT-010/011/012)."""
 
 from creek_mcp.tools.classify import classify_tool
 from creek_mcp.tools.compile import compile_tool
@@ -7,6 +7,13 @@ from creek_mcp.tools.ingest import ingest_tool
 from creek_mcp.tools.link import link_tool
 from creek_mcp.tools.lint import lint_tool
 from creek_mcp.tools.mine import mine_tool
+from creek_mcp.tools.purge import (
+    purge_classifications_tool,
+    purge_daterange_tool,
+    purge_fragment_tool,
+    purge_source_tool,
+    purge_vault_tool,
+)
 from creek_mcp.tools.report import report_tool
 from creek_mcp.tools.save import save_tool
 from creek_mcp.tools.skills import skills_refresh_tool
@@ -21,6 +28,11 @@ __all__ = [
     "link_tool",
     "lint_tool",
     "mine_tool",
+    "purge_classifications_tool",
+    "purge_daterange_tool",
+    "purge_fragment_tool",
+    "purge_source_tool",
+    "purge_vault_tool",
     "report_tool",
     "save_tool",
     "skills_refresh_tool",

--- a/creek-tools/creek_mcp/tools/purge.py
+++ b/creek-tools/creek_mcp/tools/purge.py
@@ -5,8 +5,9 @@ Code (configured with ``CREEK_MCP_ELEVATED_TOKEN``) can drive
 destructive operations through MCP while CrawDad's Discord bot — which
 deliberately is not given the token — fails closed. Every call
 appends an audit entry to ``mcp.jsonl`` regardless of whether the
-purge proceeded; a silent denial would defeat the whole point of an
-elevated gate.
+purge proceeded — including engine exceptions, which are caught and
+audited via :func:`_audit_engine_error`. A silent denial (or silent
+failure) would defeat the whole point of an elevated gate.
 
 The five tools mirror the CLI:
 
@@ -129,6 +130,29 @@ def _result_payload(
     }
 
 
+def _audit_engine_error(
+    vault_path: Path,
+    *,
+    tool: str,
+    args: dict[str, Any],
+    consumer: str,
+    exc: BaseException,
+) -> dict[str, Any]:
+    """Audit an engine-side exception and return a structured refusal.
+
+    The module docstring promises every call writes an audit entry; an
+    uncaught raise from :class:`PurgeEngine` would break that promise.
+    Catching ``Exception`` is deliberate — engine failures can be any
+    subclass (``OSError``, ``ValueError``, ``RuntimeError``) and a
+    silent leak would skip the audit.
+
+    ``BaseException`` is left uncaught so ``KeyboardInterrupt`` and
+    ``SystemExit`` still propagate as the operator expects.
+    """
+    _audit_refusal(vault_path, tool=tool, args=args, consumer=consumer)
+    return _refusal(tool=tool, reason=f"purge engine failed: {exc}")
+
+
 def _gate(
     *,
     tool: str,
@@ -169,7 +193,16 @@ def purge_fragment_tool(
     if refusal is not None:
         return refusal
     engine = PurgeEngine(vault_path, dry_run=dry_run)
-    result = engine.purge_fragment(fragment_id)
+    try:
+        result = engine.purge_fragment(fragment_id)
+    except Exception as exc:
+        return _audit_engine_error(
+            vault_path,
+            tool=_FRAGMENT_TOOL,
+            args=args,
+            consumer=consumer,
+            exc=exc,
+        )
     _audit_success(
         vault_path,
         tool=_FRAGMENT_TOOL,
@@ -200,7 +233,16 @@ def purge_source_tool(
     if refusal is not None:
         return refusal
     engine = PurgeEngine(vault_path, dry_run=dry_run)
-    result = engine.purge_source(source_type)
+    try:
+        result = engine.purge_source(source_type)
+    except Exception as exc:
+        return _audit_engine_error(
+            vault_path,
+            tool=_SOURCE_TOOL,
+            args=args,
+            consumer=consumer,
+            exc=exc,
+        )
     _audit_success(
         vault_path,
         tool=_SOURCE_TOOL,
@@ -230,7 +272,16 @@ def purge_classifications_tool(
     if refusal is not None:
         return refusal
     engine = PurgeEngine(vault_path, dry_run=dry_run)
-    result = engine.purge_classifications()
+    try:
+        result = engine.purge_classifications()
+    except Exception as exc:
+        return _audit_engine_error(
+            vault_path,
+            tool=_CLASSIFICATIONS_TOOL,
+            args=args,
+            consumer=consumer,
+            exc=exc,
+        )
     _audit_success(
         vault_path,
         tool=_CLASSIFICATIONS_TOOL,
@@ -279,9 +330,14 @@ def purge_daterange_tool(
     engine = PurgeEngine(vault_path, dry_run=dry_run)
     try:
         result = engine.purge_daterange(start_date, end_date)
-    except ValueError as exc:
-        _audit_refusal(vault_path, tool=_DATERANGE_TOOL, args=args, consumer=consumer)
-        return _refusal(tool=_DATERANGE_TOOL, reason=str(exc))
+    except Exception as exc:
+        return _audit_engine_error(
+            vault_path,
+            tool=_DATERANGE_TOOL,
+            args=args,
+            consumer=consumer,
+            exc=exc,
+        )
     _audit_success(
         vault_path,
         tool=_DATERANGE_TOOL,
@@ -339,7 +395,16 @@ def purge_vault_tool(
             ),
         )
     engine = PurgeEngine(vault_path, dry_run=dry_run)
-    result = engine.purge_vault(VAULT_PURGE_CONFIRMATION)
+    try:
+        result = engine.purge_vault(VAULT_PURGE_CONFIRMATION)
+    except Exception as exc:
+        return _audit_engine_error(
+            vault_path,
+            tool=_VAULT_TOOL,
+            args=args,
+            consumer=consumer,
+            exc=exc,
+        )
     _audit_success(
         vault_path,
         tool=_VAULT_TOOL,

--- a/creek-tools/creek_mcp/tools/purge.py
+++ b/creek-tools/creek_mcp/tools/purge.py
@@ -1,0 +1,359 @@
+"""MCP purge tools gated by elevated authorization (FEAT-012).
+
+Wraps :class:`creek.purge.engine.PurgeEngine` so the developer's Claude
+Code (configured with ``CREEK_MCP_ELEVATED_TOKEN``) can drive
+destructive operations through MCP while CrawDad's Discord bot — which
+deliberately is not given the token — fails closed. Every call
+appends an audit entry to ``mcp.jsonl`` regardless of whether the
+purge proceeded; a silent denial would defeat the whole point of an
+elevated gate.
+
+The five tools mirror the CLI:
+
+* ``creek.purge.fragment`` — delete one fragment by ID.
+* ``creek.purge.source`` — delete every fragment from a source platform.
+* ``creek.purge.classifications`` — wipe classification metadata.
+* ``creek.purge.daterange`` — delete fragments inside a date window.
+* ``creek.purge.vault`` — destroy all vault content (preserves folders).
+
+``creek.purge.vault`` additionally requires the caller to echo the
+absolute path of the target vault back via ``confirm_vault_path``,
+mirroring the CLI's interactive prompt. Both the token and the
+confirmation are required — neither alone is sufficient.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any
+
+from creek.purge import PurgeEngine
+from creek.purge.engine import VAULT_PURGE_CONFIRMATION, PurgeResult
+from creek_mcp.audit import MCPAuditLog
+from creek_mcp.auth import is_elevated
+from creek_mcp.tier_ceiling import TierCeiling
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_FRAGMENT_TOOL = "creek.purge.fragment"
+_SOURCE_TOOL = "creek.purge.source"
+_CLASSIFICATIONS_TOOL = "creek.purge.classifications"
+_DATERANGE_TOOL = "creek.purge.daterange"
+_VAULT_TOOL = "creek.purge.vault"
+
+_REFUSAL_NO_TOKEN = (
+    "elevated authorization required: set CREEK_MCP_ELEVATED_TOKEN on the "
+    "server and pass a matching auth_token"
+)
+
+
+def _refusal(
+    *,
+    tool: str,
+    reason: str,
+) -> dict[str, Any]:
+    """Build the canonical refusal payload for purge tools.
+
+    Mirrors :func:`creek_mcp.tier_ceiling.refusal_response` but does
+    not carry a tier ceiling — purge tools have no body to filter, so
+    ``tier_ceiling`` would be misleading on the refusal payload.
+    """
+    return {
+        "status": "refused",
+        "tool": tool,
+        "reason": reason,
+    }
+
+
+def _audit_refusal(
+    vault_path: Path,
+    *,
+    tool: str,
+    args: dict[str, Any],
+    consumer: str,
+) -> None:
+    """Record a refused purge attempt in the MCP audit log.
+
+    Refusals are audited so the timeline shows every attempt — silent
+    denials would let a hostile or buggy client probe the gate without
+    leaving a trail. The token never enters ``args``: callers strip it
+    before calling this helper.
+    """
+    MCPAuditLog(vault_path).append(
+        tool=tool,
+        args=args,
+        tier_ceiling=TierCeiling.OPEN,
+        consumer=consumer,
+    )
+
+
+def _audit_success(
+    vault_path: Path,
+    *,
+    tool: str,
+    args: dict[str, Any],
+    consumer: str,
+    result: PurgeResult,
+) -> None:
+    """Record a successful purge in the MCP audit log."""
+    MCPAuditLog(vault_path).append(
+        tool=tool,
+        args=args,
+        tier_ceiling=TierCeiling.OPEN,
+        consumer=consumer,
+        affected_fragment_ids=list(result.affected_fragment_ids),
+    )
+
+
+def _result_payload(
+    *,
+    tool: str,
+    result: PurgeResult,
+) -> dict[str, Any]:
+    """Render a :class:`PurgeResult` as the structured tool response."""
+    return {
+        "status": "ok",
+        "tool": tool,
+        "operation": result.operation,
+        "target": result.target,
+        "criteria": dict(result.criteria),
+        "affected_fragment_ids": list(result.affected_fragment_ids),
+        "fragments_affected": result.fragments_affected,
+        "deleted_files": list(result.deleted_files),
+        "wikilinks_removed": result.wikilinks_removed,
+        "threads_updated": result.threads_updated,
+        "eddies_updated": result.eddies_updated,
+        "classifications_reset": result.classifications_reset,
+        "dry_run": result.dry_run,
+    }
+
+
+def _gate(
+    *,
+    tool: str,
+    auth_token: str | None,
+    vault_path: Path,
+    args: dict[str, Any],
+    consumer: str,
+) -> dict[str, Any] | None:
+    """Return a refusal payload when the gate fails, otherwise ``None``.
+
+    Routes through :func:`creek_mcp.auth.is_elevated` and emits a
+    refusal audit entry on denial. Callers proceed with the purge
+    only when this helper returns ``None``.
+    """
+    if is_elevated(auth_token):
+        return None
+    _audit_refusal(vault_path, tool=tool, args=args, consumer=consumer)
+    return _refusal(tool=tool, reason=_REFUSAL_NO_TOKEN)
+
+
+def purge_fragment_tool(
+    *,
+    vault_path: Path,
+    fragment_id: str,
+    auth_token: str | None,
+    dry_run: bool = False,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Delete a single fragment by ID after passing the elevated gate."""
+    args = {"fragment_id": fragment_id, "dry_run": dry_run}
+    refusal = _gate(
+        tool=_FRAGMENT_TOOL,
+        auth_token=auth_token,
+        vault_path=vault_path,
+        args=args,
+        consumer=consumer,
+    )
+    if refusal is not None:
+        return refusal
+    engine = PurgeEngine(vault_path, dry_run=dry_run)
+    result = engine.purge_fragment(fragment_id)
+    _audit_success(
+        vault_path,
+        tool=_FRAGMENT_TOOL,
+        args=args,
+        consumer=consumer,
+        result=result,
+    )
+    return _result_payload(tool=_FRAGMENT_TOOL, result=result)
+
+
+def purge_source_tool(
+    *,
+    vault_path: Path,
+    source_type: str,
+    auth_token: str | None,
+    dry_run: bool = False,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Delete every fragment ingested from *source_type*."""
+    args = {"source_type": source_type, "dry_run": dry_run}
+    refusal = _gate(
+        tool=_SOURCE_TOOL,
+        auth_token=auth_token,
+        vault_path=vault_path,
+        args=args,
+        consumer=consumer,
+    )
+    if refusal is not None:
+        return refusal
+    engine = PurgeEngine(vault_path, dry_run=dry_run)
+    result = engine.purge_source(source_type)
+    _audit_success(
+        vault_path,
+        tool=_SOURCE_TOOL,
+        args=args,
+        consumer=consumer,
+        result=result,
+    )
+    return _result_payload(tool=_SOURCE_TOOL, result=result)
+
+
+def purge_classifications_tool(
+    *,
+    vault_path: Path,
+    auth_token: str | None,
+    dry_run: bool = False,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Reset classification fields on every fragment to unclassified."""
+    args = {"dry_run": dry_run}
+    refusal = _gate(
+        tool=_CLASSIFICATIONS_TOOL,
+        auth_token=auth_token,
+        vault_path=vault_path,
+        args=args,
+        consumer=consumer,
+    )
+    if refusal is not None:
+        return refusal
+    engine = PurgeEngine(vault_path, dry_run=dry_run)
+    result = engine.purge_classifications()
+    _audit_success(
+        vault_path,
+        tool=_CLASSIFICATIONS_TOOL,
+        args=args,
+        consumer=consumer,
+        result=result,
+    )
+    return _result_payload(tool=_CLASSIFICATIONS_TOOL, result=result)
+
+
+def _parse_iso_date(value: str, *, field: str) -> date:
+    """Parse *value* as an ISO date or raise ``ValueError`` naming *field*."""
+    try:
+        return datetime.fromisoformat(value).date()
+    except ValueError as exc:
+        msg = f"{field} is not a valid ISO date: {value!r}"
+        raise ValueError(msg) from exc
+
+
+def purge_daterange_tool(
+    *,
+    vault_path: Path,
+    start: str,
+    end: str,
+    auth_token: str | None,
+    dry_run: bool = False,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Delete fragments whose ``created`` date falls within ``[start, end]``."""
+    args = {"start": start, "end": end, "dry_run": dry_run}
+    refusal = _gate(
+        tool=_DATERANGE_TOOL,
+        auth_token=auth_token,
+        vault_path=vault_path,
+        args=args,
+        consumer=consumer,
+    )
+    if refusal is not None:
+        return refusal
+    try:
+        start_date = _parse_iso_date(start, field="start")
+        end_date = _parse_iso_date(end, field="end")
+    except ValueError as exc:
+        _audit_refusal(vault_path, tool=_DATERANGE_TOOL, args=args, consumer=consumer)
+        return _refusal(tool=_DATERANGE_TOOL, reason=str(exc))
+    engine = PurgeEngine(vault_path, dry_run=dry_run)
+    try:
+        result = engine.purge_daterange(start_date, end_date)
+    except ValueError as exc:
+        _audit_refusal(vault_path, tool=_DATERANGE_TOOL, args=args, consumer=consumer)
+        return _refusal(tool=_DATERANGE_TOOL, reason=str(exc))
+    _audit_success(
+        vault_path,
+        tool=_DATERANGE_TOOL,
+        args=args,
+        consumer=consumer,
+        result=result,
+    )
+    return _result_payload(tool=_DATERANGE_TOOL, result=result)
+
+
+def purge_vault_tool(
+    *,
+    vault_path: Path,
+    confirm_vault_path: str | None,
+    auth_token: str | None,
+    dry_run: bool = False,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Destroy every fragment, thread, eddy, and related file.
+
+    Requires both the elevated token *and* ``confirm_vault_path``
+    matching the resolved target vault path. The audit entry records
+    that the operator confirmed the path (boolean, not the path string,
+    so the audit log does not echo absolute filesystem paths back into
+    a tier-aware artefact).
+    """
+    args = {
+        "confirm_vault_path": confirm_vault_path is not None,
+        "dry_run": dry_run,
+    }
+    refusal = _gate(
+        tool=_VAULT_TOOL,
+        auth_token=auth_token,
+        vault_path=vault_path,
+        args=args,
+        consumer=consumer,
+    )
+    if refusal is not None:
+        return refusal
+    if confirm_vault_path is None:
+        _audit_refusal(vault_path, tool=_VAULT_TOOL, args=args, consumer=consumer)
+        return _refusal(
+            tool=_VAULT_TOOL,
+            reason=(
+                "creek.purge.vault requires confirm_vault_path matching the "
+                "target vault's absolute path"
+            ),
+        )
+    if not _paths_equivalent(vault_path, confirm_vault_path):
+        _audit_refusal(vault_path, tool=_VAULT_TOOL, args=args, consumer=consumer)
+        return _refusal(
+            tool=_VAULT_TOOL,
+            reason=(
+                "confirm_vault_path does not match the target vault's resolved path"
+            ),
+        )
+    engine = PurgeEngine(vault_path, dry_run=dry_run)
+    result = engine.purge_vault(VAULT_PURGE_CONFIRMATION)
+    _audit_success(
+        vault_path,
+        tool=_VAULT_TOOL,
+        args=args,
+        consumer=consumer,
+        result=result,
+    )
+    return _result_payload(tool=_VAULT_TOOL, result=result)
+
+
+def _paths_equivalent(vault_path: Path, candidate: str) -> bool:
+    """Return ``True`` when *candidate* resolves to *vault_path*."""
+    try:
+        resolved_candidate = type(vault_path)(candidate).resolve(strict=False)
+    except (OSError, ValueError):
+        return False
+    return resolved_candidate == vault_path.resolve(strict=False)

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -39,7 +39,21 @@ interactively will appear to hang, which is correct.
 | `creek.skills.refresh`  | none beyond `ceiling`                                       | Voice-skill tree regen; intimate exemplars already excluded.      |
 | `creek.compile`         | `fragment_ids`, `target_kind`, `target_id`, `target_title`  | Idempotent per FEAT-003; no-op re-runs do not log a duplicate.    |
 
-FEAT-012 adds `purge.*` and consent-elevated paths.
+### Purge tools (FEAT-012, elevated authorization required)
+
+| Tool                            | Inputs                                              | Authorization                                              |
+|---------------------------------|-----------------------------------------------------|------------------------------------------------------------|
+| `creek.purge.fragment`          | `fragment_id`, `auth_token`, `dry_run?`             | `auth_token` must match `CREEK_MCP_ELEVATED_TOKEN`         |
+| `creek.purge.source`            | `source_type`, `auth_token`, `dry_run?`             | `auth_token` must match `CREEK_MCP_ELEVATED_TOKEN`         |
+| `creek.purge.classifications`   | `auth_token`, `dry_run?`                            | `auth_token` must match `CREEK_MCP_ELEVATED_TOKEN`         |
+| `creek.purge.daterange`         | `start`, `end` (ISO dates), `auth_token`, `dry_run?`| `auth_token` must match `CREEK_MCP_ELEVATED_TOKEN`         |
+| `creek.purge.vault`             | `confirm_vault_path`, `auth_token`, `dry_run?`      | BOTH the token AND `confirm_vault_path` matching the vault |
+
+Purge tools deliberately do not accept a `privacy_tier_ceiling`
+parameter: they do not return vault content, so the ceiling
+invariant from FEAT-010 does not apply. Authorization is the only
+gate, and refusals are themselves audited so a hostile client
+cannot probe the gate silently.
 
 Every tool requires a `privacy_tier_ceiling` parameter
 (`open` | `personal` | `intimate` | `all`); default is `open`. Note
@@ -60,6 +74,59 @@ rather than silently downgraded — the body never lands in the vault
 and the audit entry records the refusal without the body. The same
 gate applies to `creek.ingest` because the default ingestor tier is
 `personal`.
+
+### Elevated-authorization model (FEAT-012)
+
+The `creek.purge.*` family is gated by a separate token from the
+tier-ceiling system. The server reads `CREEK_MCP_ELEVATED_TOKEN`
+from its environment at startup; callers present a matching string
+via the `auth_token` parameter on each purge tool. Comparison runs
+through `hmac.compare_digest` (constant-time), not `==`, so a hostile
+client cannot probe the token byte-by-byte through timing.
+
+Operational rules:
+
+- **CrawDad does not get the token.** The Discord bot's MCP client
+  (FEAT-013+) is launched without `CREEK_MCP_ELEVATED_TOKEN`, and its
+  MCP requests omit `auth_token`. Every purge call from CrawDad
+  therefore returns `status="refused"` — there is no Discord command
+  surface that could accidentally destroy vault content.
+- **The developer's Claude Code can be configured with the token.**
+  Add `"CREEK_MCP_ELEVATED_TOKEN": "<your-token>"` to the `env` block
+  of `.mcp.json` (alongside `CREEK_MCP_CONSUMER`). Treat the token
+  like any other vault secret — keep it out of public dotfiles and
+  shared shells.
+- **`creek.purge.vault` requires both the token AND
+  `confirm_vault_path`.** The confirmation must match the resolved
+  absolute path of the target vault, mirroring the CLI's interactive
+  "type the vault path to proceed" prompt. Either guard alone
+  refuses the call.
+- **Refusals are audited.** A refused purge attempt still appends an
+  entry to `mcp.jsonl`, so a token-less probe leaves a trail. The
+  `auth_token` value never enters the audit log — only the
+  refusal-or-success outcome and the structured args summary.
+
+Example `.mcp.json` for a Claude Code instance configured for
+destructive ops:
+
+```json
+{
+  "mcpServers": {
+    "creek-tools": {
+      "command": "creek-tools-mcp",
+      "env": {
+        "CREEK_MCP_CONSUMER": "claude-code",
+        "CREEK_MCP_ELEVATED_TOKEN": "rotate-this-monthly"
+      }
+    }
+  }
+}
+```
+
+> Do **not** copy this `env` block into the CrawDad host config. The
+> token is deliberately withheld from CrawDad so a Discord-side
+> intent can never escalate into a vault deletion. If you need to
+> rotate the token, rotate it on the developer's Claude Code only.
 
 ## Claude Code
 
@@ -115,8 +182,28 @@ The vault path is *not* recorded — it's resolved internally from
 rules: long strings become `{"len": N}`, lists become `{"count": N}`,
 dicts become `{"keys": [...]}`. A draft request for an
 `intimate`-tier fragment never leaks the body into the audit
-trail. Hash chaining is provided by `creek.audit.AuditLog`; FEAT-012's
-hardening pass extends the entry shape, not the storage layer.
+trail. Hash chaining is provided by `creek.audit.AuditLog`; FEAT-012
+adds the per-entry `entry_hash` and a verifier on top — see below.
+
+#### Tamper-evidence (FEAT-012)
+
+Every entry carries two integrity fields:
+
+- `prev_hash` — SHA-256 of the previous line's bytes (chain link).
+  Removing or reordering an entry invalidates the chain at the next
+  line.
+- `entry_hash` — SHA-256 of the entry's payload (excluding
+  `entry_hash` and `prev_hash`). Mutating any other field — `tool`,
+  `consumer`, `tier_ceiling`, the args summary — invalidates this
+  hash on its own, even if the line position survives.
+
+`creek_mcp.audit.verify_mcp_audit_chain(vault_path)` walks both
+invariants and raises `MCPAuditChainBrokenError` on the first
+mismatch. The walk is cheap (one read pass, one hash per line) and
+is safe to call from any operator script. Writes hold an exclusive
+`flock` on the log so two processes appending in parallel cannot
+interleave half-written lines; concurrent-write safety is exercised
+by `tests/test_mcp_audit.py::test_concurrent_process_appends_do_not_corrupt_log`.
 
 #### Write-tool audit fields (FEAT-011)
 

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -92,10 +92,14 @@ Operational rules:
   therefore returns `status="refused"` — there is no Discord command
   surface that could accidentally destroy vault content.
 - **The developer's Claude Code can be configured with the token.**
-  Add `"CREEK_MCP_ELEVATED_TOKEN": "<your-token>"` to the `env` block
-  of `.mcp.json` (alongside `CREEK_MCP_CONSUMER`). Treat the token
-  like any other vault secret — keep it out of public dotfiles and
-  shared shells.
+  Generate one with high entropy:
+  ```bash
+  python -c "import secrets; print(secrets.token_hex(32))"
+  ```
+  Add `"CREEK_MCP_ELEVATED_TOKEN": "<generated-token>"` to the `env`
+  block of `.mcp.json` (alongside `CREEK_MCP_CONSUMER`). Treat the
+  token like any other vault secret — keep it out of public dotfiles
+  and shared shells.
 - **`creek.purge.vault` requires both the token AND
   `confirm_vault_path`.** The confirmation must match the resolved
   absolute path of the target vault, mirroring the CLI's interactive
@@ -107,7 +111,9 @@ Operational rules:
   refusal-or-success outcome and the structured args summary.
 
 Example `.mcp.json` for a Claude Code instance configured for
-destructive ops:
+destructive ops (replace the token with a freshly generated one — the
+sample shown here is high-entropy hex from `secrets.token_hex(32)` and
+must not be reused):
 
 ```json
 {
@@ -116,7 +122,7 @@ destructive ops:
       "command": "creek-tools-mcp",
       "env": {
         "CREEK_MCP_CONSUMER": "claude-code",
-        "CREEK_MCP_ELEVATED_TOKEN": "rotate-this-monthly"
+        "CREEK_MCP_ELEVATED_TOKEN": "REPLACE_WITH_secrets.token_hex(32)"
       }
     }
   }

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
     "httpx>=0.27.0",
     "tqdm>=4.66.0",
     "mcp>=1.0.0,<2.0.0",
+    # Security: pin urllib3 above CVE-2026-44431 / CVE-2026-44432
+    # (transitive via requests/conan). Both are fixed in 2.7.0.
+    "urllib3>=2.7.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",

--- a/creek-tools/tests/test_mcp_audit.py
+++ b/creek-tools/tests/test_mcp_audit.py
@@ -204,14 +204,16 @@ def test_verifier_reads_log_file_only_once(
             consumer="claude-code",
         )
 
+    from typing import Any
+
     log_path = tmp_path / MCP_AUDIT_RELPATH
     opens: list[None] = []
-    real_open = Path.open
+    real_open: Any = Path.open
 
-    def counting_open(self: Path, *args: object, **kwargs: object) -> object:
+    def counting_open(self: Path, *args: Any, **kwargs: Any) -> Any:
         if self.resolve() == log_path.resolve():
             opens.append(None)
-        return real_open(self, *args, **kwargs)  # type: ignore[arg-type]
+        return real_open(self, *args, **kwargs)
 
     monkeypatch.setattr(Path, "open", counting_open)
     verify_mcp_audit_chain(tmp_path)

--- a/creek-tools/tests/test_mcp_audit.py
+++ b/creek-tools/tests/test_mcp_audit.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import multiprocessing as mp
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
 
@@ -17,9 +17,6 @@ from creek_mcp.audit import (
     verify_mcp_audit_chain,
 )
 from creek_mcp.tier_ceiling import TierCeiling
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def test_summarise_args_keeps_short_scalars() -> None:
@@ -182,6 +179,45 @@ def test_verifier_detects_removed_entry(tmp_path: Path) -> None:
 
     with pytest.raises(MCPAuditChainBrokenError):
         verify_mcp_audit_chain(tmp_path)
+
+
+def test_verifier_reads_log_file_only_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The verifier snapshots the file so chain + entry_hash share one view.
+
+    Regression for the TOCTOU window flagged on PR #233: the old
+    implementation called ``AuditLog.verify()`` and then
+    ``AuditLog.read()`` separately, so a concurrent append between
+    the two opens would let the chain check pass on N+1 lines while
+    the ``entry_hash`` loop iterated only N. The fix is to read the
+    log once and run both checks on that snapshot — observable here
+    by counting opens of the log path.
+    """
+    log = MCPAuditLog(tmp_path)
+    for i in range(3):
+        log.append(
+            tool="creek.lint",
+            args={"i": i},
+            tier_ceiling=TierCeiling.OPEN,
+            consumer="claude-code",
+        )
+
+    log_path = tmp_path / MCP_AUDIT_RELPATH
+    opens: list[None] = []
+    real_open = Path.open
+
+    def counting_open(self: Path, *args: object, **kwargs: object) -> object:
+        if self.resolve() == log_path.resolve():
+            opens.append(None)
+        return real_open(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", counting_open)
+    verify_mcp_audit_chain(tmp_path)
+    assert len(opens) == 1, (
+        f"verify_mcp_audit_chain must read the log once; saw {len(opens)} opens"
+    )
 
 
 def test_verifier_handles_missing_log(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_mcp_audit.py
+++ b/creek-tools/tests/test_mcp_audit.py
@@ -1,11 +1,21 @@
-"""Tests for the MCP audit log (FEAT-010)."""
+"""Tests for the MCP audit log (FEAT-010 + FEAT-012 hardening)."""
 
 from __future__ import annotations
 
+import hashlib
 import json
+import multiprocessing as mp
 from typing import TYPE_CHECKING
 
-from creek_mcp.audit import MCP_AUDIT_RELPATH, MCPAuditLog, summarise_args
+import pytest
+
+from creek_mcp.audit import (
+    MCP_AUDIT_RELPATH,
+    MCPAuditChainBrokenError,
+    MCPAuditLog,
+    summarise_args,
+    verify_mcp_audit_chain,
+)
 from creek_mcp.tier_ceiling import TierCeiling
 
 if TYPE_CHECKING:
@@ -80,3 +90,132 @@ def test_append_does_not_leak_full_body(tmp_path: Path) -> None:
     entry = json.loads(contents.splitlines()[0])
     assert entry["args_summary"]["prompt_body"] == {"len": len(body)}
     assert entry["args_summary"]["phase"] == "rising"
+
+
+# ---------------------------------------------------------------------------
+# FEAT-012 audit hardening: entry_hash + verifier + locking
+# ---------------------------------------------------------------------------
+
+
+def test_append_stamps_entry_hash_alongside_prev_hash(tmp_path: Path) -> None:
+    """Every entry carries both ``prev_hash`` and a content ``entry_hash``."""
+    log = MCPAuditLog(tmp_path)
+    log.append(
+        tool="creek.lint",
+        args={"checks": ["double-link"]},
+        tier_ceiling=TierCeiling.OPEN,
+        consumer="claude-code",
+    )
+    entry = json.loads(
+        (tmp_path / MCP_AUDIT_RELPATH).read_text(encoding="utf-8").splitlines()[0],
+    )
+    assert "prev_hash" in entry
+    assert "entry_hash" in entry
+    body = {k: v for k, v in entry.items() if k not in {"entry_hash", "prev_hash"}}
+    expected = hashlib.sha256(
+        json.dumps(body, sort_keys=True).encode("utf-8"),
+    ).hexdigest()
+    assert entry["entry_hash"] == expected
+
+
+def test_verifier_accepts_untampered_chain(tmp_path: Path) -> None:
+    """A clean chain passes :func:`verify_mcp_audit_chain` silently."""
+    log = MCPAuditLog(tmp_path)
+    for tool_name in ("creek.lint", "creek.mine", "creek.state.read"):
+        log.append(
+            tool=tool_name,
+            args={"x": 1},
+            tier_ceiling=TierCeiling.OPEN,
+            consumer="claude-code",
+        )
+    verify_mcp_audit_chain(tmp_path)
+
+
+def test_verifier_detects_mutated_payload(tmp_path: Path) -> None:
+    """Mutating any field of a stored entry breaks ``entry_hash``."""
+    log = MCPAuditLog(tmp_path)
+    log.append(
+        tool="creek.lint",
+        args={"x": 1},
+        tier_ceiling=TierCeiling.OPEN,
+        consumer="claude-code",
+    )
+    log.append(
+        tool="creek.mine",
+        args={"x": 2},
+        tier_ceiling=TierCeiling.OPEN,
+        consumer="claude-code",
+    )
+    log_path = tmp_path / MCP_AUDIT_RELPATH
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    tampered_first = lines[0].replace('"creek.lint"', '"creek.LINT"')
+    log_path.write_text(tampered_first + "\n" + lines[1] + "\n", encoding="utf-8")
+
+    with pytest.raises(MCPAuditChainBrokenError):
+        verify_mcp_audit_chain(tmp_path)
+
+
+def test_verifier_detects_removed_entry(tmp_path: Path) -> None:
+    """Dropping a line breaks the ``prev_hash`` of the next entry."""
+    log = MCPAuditLog(tmp_path)
+    log.append(
+        tool="creek.lint",
+        args={"x": 1},
+        tier_ceiling=TierCeiling.OPEN,
+        consumer="claude-code",
+    )
+    log.append(
+        tool="creek.mine",
+        args={"x": 2},
+        tier_ceiling=TierCeiling.OPEN,
+        consumer="claude-code",
+    )
+    log.append(
+        tool="creek.state.read",
+        args={},
+        tier_ceiling=TierCeiling.OPEN,
+        consumer="claude-code",
+    )
+    log_path = tmp_path / MCP_AUDIT_RELPATH
+    lines = log_path.read_text(encoding="utf-8").splitlines()
+    log_path.write_text(lines[0] + "\n" + lines[2] + "\n", encoding="utf-8")
+
+    with pytest.raises(MCPAuditChainBrokenError):
+        verify_mcp_audit_chain(tmp_path)
+
+
+def test_verifier_handles_missing_log(tmp_path: Path) -> None:
+    """A missing log is trivially valid — there are no entries to disagree about."""
+    verify_mcp_audit_chain(tmp_path)
+
+
+def _append_one(path: Path, worker: int) -> None:
+    """Top-level helper so ``multiprocessing`` can import it."""
+    log = MCPAuditLog(path)
+    log.append(
+        tool="creek.lint",
+        args={"worker": worker},
+        tier_ceiling=TierCeiling.OPEN,
+        consumer="claude-code",
+    )
+
+
+def test_concurrent_process_appends_do_not_corrupt_log(tmp_path: Path) -> None:
+    """Two processes appending in parallel produce a still-verifiable chain.
+
+    FEAT-012 test plan: concurrent writes from separate processes must
+    not corrupt the log. The underlying :class:`creek.audit.AuditLog`
+    holds an exclusive flock during write; we exercise that path here
+    and assert the chain still passes verification afterwards.
+    """
+    ctx = mp.get_context("spawn")
+    procs = [ctx.Process(target=_append_one, args=(tmp_path, i)) for i in range(4)]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(timeout=30)
+        assert proc.exitcode == 0
+
+    lines = (tmp_path / MCP_AUDIT_RELPATH).read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 4
+    verify_mcp_audit_chain(tmp_path)

--- a/creek-tools/tests/test_mcp_auth.py
+++ b/creek-tools/tests/test_mcp_auth.py
@@ -1,0 +1,111 @@
+"""Tests for the MCP elevated-authorization gate (FEAT-012).
+
+The gate decides whether a destructive tool call (``creek.purge.*``)
+may proceed. The expected token lives in the ``CREEK_MCP_ELEVATED_TOKEN``
+environment variable at server startup; callers present a matching
+token via the ``auth_token`` tool argument. The comparison MUST use
+:func:`hmac.compare_digest` so a hostile client cannot infer the token
+byte-by-byte via timing.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from creek_mcp import auth
+
+if TYPE_CHECKING:
+    import pytest
+
+
+def test_is_elevated_returns_false_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without an elevated token configured the gate fails closed."""
+    monkeypatch.delenv("CREEK_MCP_ELEVATED_TOKEN", raising=False)
+    assert auth.is_elevated("anything") is False
+
+
+def test_is_elevated_returns_false_when_env_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty env token is treated as unset; the gate must not match ``""``."""
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", "")
+    assert auth.is_elevated("") is False
+    assert auth.is_elevated("anything") is False
+
+
+def test_is_elevated_returns_false_when_provided_token_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing client token fails closed even when env token is configured."""
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", "super-secret")
+    assert auth.is_elevated(None) is False
+    assert auth.is_elevated("") is False
+
+
+def test_is_elevated_returns_false_for_mismatched_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-matching client token is rejected."""
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", "super-secret")
+    assert auth.is_elevated("not-the-secret") is False
+
+
+def test_is_elevated_returns_true_for_matching_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A correct client token unlocks elevated tools."""
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", "super-secret")
+    assert auth.is_elevated("super-secret") is True
+
+
+def test_is_elevated_uses_hmac_compare_digest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The gate routes the comparison through :func:`hmac.compare_digest`.
+
+    Plain ``==`` on string tokens is timing-vulnerable. The test
+    monkey-patches ``hmac.compare_digest`` and asserts ``is_elevated``
+    calls it with the expected and actual tokens as bytes.
+    """
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", "super-secret")
+    calls: list[tuple[object, object]] = []
+
+    def _spy(a: object, b: object) -> bool:
+        calls.append((a, b))
+        return a == b  # only inside the test spy, never inside auth.py
+
+    monkeypatch.setattr(auth.hmac, "compare_digest", _spy)
+    assert auth.is_elevated("super-secret") is True
+    assert calls, "is_elevated must route through hmac.compare_digest"
+    expected, actual = calls[0]
+    assert expected == b"super-secret"
+    assert actual == b"super-secret"
+
+
+def test_auth_module_source_uses_compare_digest_not_equality() -> None:
+    """Static check: ``auth.py`` must not compare token strings with ``==``.
+
+    ADAPT-004 / FEAT-012: elevated-auth comparisons MUST be constant
+    time. Walking the AST is more robust than a textual search — it
+    won't false-positive on string literals like ``"=="`` in docstrings.
+    """
+    source = Path(auth.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef):
+            continue
+        if node.name != "is_elevated":
+            continue
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Compare):
+                for op in sub.ops:
+                    if isinstance(op, ast.Eq | ast.NotEq):
+                        msg = (
+                            "is_elevated must not use ==/!= on tokens; "
+                            "use hmac.compare_digest"
+                        )
+                        raise AssertionError(msg)

--- a/creek-tools/tests/test_mcp_purge.py
+++ b/creek-tools/tests/test_mcp_purge.py
@@ -325,6 +325,129 @@ def test_purge_audit_entry_records_operation_and_consumer(vault: Path) -> None:
     assert "auth_token" not in entry["args_summary"]
 
 
+# ---------------------------------------------------------------------------
+# Engine-exception path: the audit-completeness invariant
+# ---------------------------------------------------------------------------
+
+
+_EXPLOSIVE_FAILURE = "engine boom"
+
+
+def _explode(*_args: object, **_kwargs: object) -> None:
+    """Stand-in for a :class:`PurgeEngine` method that raises mid-call."""
+    raise RuntimeError(_EXPLOSIVE_FAILURE)
+
+
+def test_purge_fragment_audits_engine_exception(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raise from ``PurgeEngine.purge_fragment`` still writes one audit entry.
+
+    Regression for the audit-completeness invariant flagged on PR #233.
+    The module docstring promises "every call appends an audit entry to
+    ``mcp.jsonl`` regardless of whether the purge proceeded" — an
+    unhandled exception in the engine would silently break that.
+    """
+    from creek.purge import PurgeEngine as _PurgeEngine
+
+    monkeypatch.setattr(_PurgeEngine, "purge_fragment", _explode)
+    result = purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "refused"
+    assert _EXPLOSIVE_FAILURE in result["reason"]
+    entries = _audit_entries(vault)
+    assert len(entries) == 1
+    assert entries[0]["tool"] == "creek.purge.fragment"
+
+
+def test_purge_source_audits_engine_exception(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raise from ``PurgeEngine.purge_source`` still writes one audit entry."""
+    from creek.purge import PurgeEngine as _PurgeEngine
+
+    monkeypatch.setattr(_PurgeEngine, "purge_source", _explode)
+    result = purge_source_tool(
+        vault_path=vault,
+        source_type="journal",
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "refused"
+    assert _EXPLOSIVE_FAILURE in result["reason"]
+    entries = _audit_entries(vault)
+    assert len(entries) == 1
+    assert entries[0]["tool"] == "creek.purge.source"
+
+
+def test_purge_classifications_audits_engine_exception(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raise from ``PurgeEngine.purge_classifications`` still writes audit."""
+    from creek.purge import PurgeEngine as _PurgeEngine
+
+    monkeypatch.setattr(_PurgeEngine, "purge_classifications", _explode)
+    result = purge_classifications_tool(
+        vault_path=vault,
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "refused"
+    assert _EXPLOSIVE_FAILURE in result["reason"]
+    entries = _audit_entries(vault)
+    assert len(entries) == 1
+    assert entries[0]["tool"] == "creek.purge.classifications"
+
+
+def test_purge_vault_audits_engine_exception(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raise from ``PurgeEngine.purge_vault`` still writes one audit entry.
+
+    The path-confirmation guards both passed at this point; the failure
+    happens inside the engine. The audit must still capture it.
+    """
+    from creek.purge import PurgeEngine as _PurgeEngine
+
+    monkeypatch.setattr(_PurgeEngine, "purge_vault", _explode)
+    result = purge_vault_tool(
+        vault_path=vault,
+        confirm_vault_path=str(vault),
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "refused"
+    assert _EXPLOSIVE_FAILURE in result["reason"]
+    entries = _audit_entries(vault)
+    assert len(entries) == 1
+    assert entries[0]["tool"] == "creek.purge.vault"
+
+
+def test_purge_daterange_audits_engine_exception(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``daterange`` already handled ValueError; this pins the general case."""
+    from creek.purge import PurgeEngine as _PurgeEngine
+
+    monkeypatch.setattr(_PurgeEngine, "purge_daterange", _explode)
+    result = purge_daterange_tool(
+        vault_path=vault,
+        start="2026-05-01",
+        end="2026-05-02",
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "refused"
+    assert _EXPLOSIVE_FAILURE in result["reason"]
+    entries = _audit_entries(vault)
+    assert len(entries) == 1
+    assert entries[0]["tool"] == "creek.purge.daterange"
+
+
 def test_crawdad_consumer_cannot_purge(
     vault: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/creek-tools/tests/test_mcp_purge.py
+++ b/creek-tools/tests/test_mcp_purge.py
@@ -1,0 +1,347 @@
+"""Tests for the FEAT-012 MCP purge tools.
+
+The purge tools wrap :class:`creek.purge.engine.PurgeEngine` behind the
+elevated-authorization gate (:mod:`creek_mcp.auth`). A call without the
+``CREEK_MCP_ELEVATED_TOKEN`` token returns a structured refusal — never
+a partial purge — and the ``creek.purge.vault`` tool additionally
+requires a ``confirm_vault_path`` matching the absolute path of the
+target vault, mirroring the CLI's interactive guard.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+from creek_mcp.tools.purge import (
+    purge_classifications_tool,
+    purge_daterange_tool,
+    purge_fragment_tool,
+    purge_source_tool,
+    purge_vault_tool,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+ELEVATED_TOKEN = "test-elevated-secret"
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Iterator[Path]:
+    """Seed a vault tree with a single fragment for the purge tools."""
+    for relparts in (
+        ("00-Creek-Meta", "audit"),
+        ("00-Creek-Meta", "Processing-Log"),
+        ("01-Fragments", "Notes"),
+        ("02-Threads", "Active"),
+        ("03-Eddies",),
+    ):
+        (tmp_path.joinpath(*relparts)).mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "type": "fragment",
+        "id": "frag-001",
+        "title": "Test fragment",
+        "created": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "ingested": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "F1", "secondary": []},
+        "privacy_tier": "open",
+        "eddies": [],
+    }
+    fragment_path = tmp_path / "01-Fragments" / "Notes" / "frag-001.md"
+    fragment_path.write_text(
+        frontmatter.dumps(frontmatter.Post(content="Body.", **metadata)),
+        encoding="utf-8",
+    )
+    yield tmp_path
+
+
+@pytest.fixture(autouse=True)
+def configured_elevated_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a known elevated token to every purge test by default."""
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", ELEVATED_TOKEN)
+
+
+def _audit_entries(vault_path: Path) -> list[dict[str, object]]:
+    """Return parsed MCP audit entries for the test vault."""
+    log = vault_path / MCP_AUDIT_RELPATH
+    if not log.exists():
+        return []
+    return [json.loads(line) for line in log.read_text().splitlines() if line]
+
+
+# ---------------------------------------------------------------------------
+# Refusal path: no token, wrong token
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "invoke",
+    [
+        lambda vault: purge_fragment_tool(
+            vault_path=vault,
+            fragment_id="frag-001",
+            auth_token=None,
+        ),
+        lambda vault: purge_source_tool(
+            vault_path=vault,
+            source_type="journal",
+            auth_token=None,
+        ),
+        lambda vault: purge_classifications_tool(
+            vault_path=vault,
+            auth_token=None,
+        ),
+        lambda vault: purge_daterange_tool(
+            vault_path=vault,
+            start="2026-05-01",
+            end="2026-05-02",
+            auth_token=None,
+        ),
+        lambda vault: purge_vault_tool(
+            vault_path=vault,
+            confirm_vault_path=str(vault),
+            auth_token=None,
+        ),
+    ],
+)
+def test_purge_tool_refuses_without_token(
+    vault: Path,
+    invoke: object,
+) -> None:
+    """Each purge tool refuses when no elevated token is supplied.
+
+    The fragment must remain on disk after the refusal — a partial
+    purge with no audit cover would be the worst-case outcome.
+    """
+    result = invoke(vault)  # type: ignore[operator]
+    assert result["status"] == "refused"
+    assert result["reason"].startswith("elevated authorization required")
+    fragment = vault / "01-Fragments" / "Notes" / "frag-001.md"
+    assert fragment.exists(), "no purge tool may delete files without auth"
+
+
+def test_purge_tool_refuses_with_wrong_token(vault: Path) -> None:
+    """A non-matching token is rejected by the gate."""
+    result = purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token="not-the-secret",
+    )
+    assert result["status"] == "refused"
+    assert (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def test_refused_purge_still_writes_audit_entry(vault: Path) -> None:
+    """Refusals are themselves audited — silent denials are not allowed."""
+    purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=None,
+    )
+    entries = _audit_entries(vault)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["tool"] == "creek.purge.fragment"
+    assert entry["consumer"] in {"unknown", "claude-code", "crawdad"}
+    # No leak of the (absent) auth token into args_summary
+    assert "auth_token" not in entry["args_summary"]
+
+
+# ---------------------------------------------------------------------------
+# Happy path with elevated token
+# ---------------------------------------------------------------------------
+
+
+def test_purge_fragment_with_token_deletes_file(vault: Path) -> None:
+    """With the elevated token, ``creek.purge.fragment`` deletes the file."""
+    result = purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "ok"
+    assert result["tool"] == "creek.purge.fragment"
+    assert result["fragments_affected"] == 1
+    assert not (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def test_purge_fragment_dry_run_preserves_file(vault: Path) -> None:
+    """``dry_run=True`` previews without deleting."""
+    result = purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=ELEVATED_TOKEN,
+        dry_run=True,
+    )
+    assert result["status"] == "ok"
+    assert result["dry_run"] is True
+    assert (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def test_purge_source_with_token_deletes_matching_fragments(vault: Path) -> None:
+    """``creek.purge.source`` removes every fragment from the platform."""
+    result = purge_source_tool(
+        vault_path=vault,
+        source_type="journal",
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "ok"
+    assert result["fragments_affected"] == 1
+    assert not (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def test_purge_classifications_with_token_resets_fields(vault: Path) -> None:
+    """``creek.purge.classifications`` wipes classification fields."""
+    result = purge_classifications_tool(
+        vault_path=vault,
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "ok"
+    assert result["classifications_reset"] == 1
+    post = frontmatter.load(
+        str(vault / "01-Fragments" / "Notes" / "frag-001.md"),
+    )
+    assert post["frequency"]["primary"] == "unclassified"  # type: ignore[index]
+
+
+def test_purge_daterange_with_token_deletes_in_window(vault: Path) -> None:
+    """``creek.purge.daterange`` deletes fragments created in the window."""
+    result = purge_daterange_tool(
+        vault_path=vault,
+        start="2026-05-01",
+        end="2026-05-02",
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "ok"
+    assert result["fragments_affected"] == 1
+
+
+def test_purge_daterange_rejects_invalid_date(vault: Path) -> None:
+    """Malformed ISO dates surface a structured error, not a stack trace."""
+    result = purge_daterange_tool(
+        vault_path=vault,
+        start="not-a-date",
+        end="2026-05-02",
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "refused"
+    assert "start" in result["reason"] or "date" in result["reason"]
+
+
+def test_purge_daterange_rejects_inverted_window(vault: Path) -> None:
+    """The engine raises when ``end`` is before ``start`` — surface it cleanly."""
+    result = purge_daterange_tool(
+        vault_path=vault,
+        start="2026-05-10",
+        end="2026-05-01",
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "refused"
+
+
+# ---------------------------------------------------------------------------
+# Vault purge: requires BOTH token and confirm_vault_path
+# ---------------------------------------------------------------------------
+
+
+def test_purge_vault_refuses_without_confirm_path(vault: Path) -> None:
+    """Even with the elevated token, ``confirm_vault_path`` is required."""
+    result = purge_vault_tool(
+        vault_path=vault,
+        confirm_vault_path=None,
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "refused"
+    assert (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def test_purge_vault_refuses_when_confirm_path_does_not_match(
+    vault: Path,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """The confirmation path must equal the resolved vault root exactly."""
+    other = tmp_path_factory.mktemp("other-vault")
+    result = purge_vault_tool(
+        vault_path=vault,
+        confirm_vault_path=str(other),
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "refused"
+    assert (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def test_purge_vault_proceeds_with_token_and_matching_path(vault: Path) -> None:
+    """Token + matching path = the only combination that destroys content."""
+    result = purge_vault_tool(
+        vault_path=vault,
+        confirm_vault_path=str(vault),
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "ok"
+    assert not (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def test_purge_vault_resolves_relative_confirmation_paths(vault: Path) -> None:
+    """Symlink-free, relative-form paths still resolve to the same vault."""
+    # `.../vault/.` resolves to vault; resolution must accept it.
+    result = purge_vault_tool(
+        vault_path=vault,
+        confirm_vault_path=str(vault / "."),
+        auth_token=ELEVATED_TOKEN,
+    )
+    assert result["status"] == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Audit hardening: the purge entries chain into the MCP audit log
+# ---------------------------------------------------------------------------
+
+
+def test_purge_audit_entry_records_operation_and_consumer(vault: Path) -> None:
+    """A successful purge appends to ``mcp.jsonl`` with ``entry_hash``."""
+    purge_fragment_tool(
+        vault_path=vault,
+        fragment_id="frag-001",
+        auth_token=ELEVATED_TOKEN,
+        consumer="claude-code",
+    )
+    entries = _audit_entries(vault)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["tool"] == "creek.purge.fragment"
+    assert entry["consumer"] == "claude-code"
+    assert "entry_hash" in entry
+    assert "prev_hash" in entry
+    # Token must not leak into the args summary
+    assert "auth_token" not in entry["args_summary"]
+
+
+def test_crawdad_consumer_cannot_purge(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end regression: a CrawDad-style call (no token) is refused.
+
+    CrawDad's MCP client is deliberately configured without the
+    elevated token. The vault must remain intact after such a call —
+    this test stands in for the FEAT's "CrawDad cannot purge anything"
+    fixture-vault regression.
+    """
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", "kept-secret")
+    result = purge_vault_tool(
+        vault_path=vault,
+        confirm_vault_path=str(vault),
+        auth_token=None,  # CrawDad has no token
+        consumer="crawdad",
+    )
+    assert result["status"] == "refused"
+    assert (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -27,6 +27,11 @@ EXPECTED_TOOLS = {
     "creek.report",
     "creek.skills.refresh",
     "creek.compile",
+    "creek.purge.fragment",
+    "creek.purge.source",
+    "creek.purge.classifications",
+    "creek.purge.daterange",
+    "creek.purge.vault",
 }
 
 
@@ -100,16 +105,39 @@ def test_call_tool_save_through_mcp(vault: Path) -> None:
 
 
 def test_every_tool_requires_privacy_tier_ceiling_parameter(vault: Path) -> None:
-    """The FEAT-010 acceptance criterion: ceiling is in every tool's schema."""
+    """The FEAT-010 acceptance criterion: ceiling is in every tool's schema.
+
+    FEAT-012 carve-out: ``creek.purge.*`` tools don't read vault
+    content — they take an elevated ``auth_token`` instead — so the
+    tier-ceiling invariant doesn't apply to them.
+    """
     server = build_server(
         vault_path=vault,
         draft_llm_factory=lambda: lambda prompt: "ignored",
     )
     tools = asyncio.run(server.list_tools())
     for tool in tools:
+        if tool.name.startswith("creek.purge."):
+            continue
         schema = tool.inputSchema
         assert "privacy_tier_ceiling" in schema["properties"], (
             f"{tool.name} missing privacy_tier_ceiling in its input schema"
+        )
+
+
+def test_purge_tools_require_auth_token_parameter(vault: Path) -> None:
+    """FEAT-012: every ``creek.purge.*`` tool exposes an ``auth_token`` slot."""
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    tools = asyncio.run(server.list_tools())
+    purge_tools = [t for t in tools if t.name.startswith("creek.purge.")]
+    assert len(purge_tools) == 5
+    for tool in purge_tools:
+        schema = tool.inputSchema
+        assert "auth_token" in schema["properties"], (
+            f"{tool.name} missing auth_token in its input schema"
         )
 
 


### PR DESCRIPTION
## Summary

Implements [FEAT-012](../blob/main/plans/git-issues/FEAT-012-mcp-purge-tools-elevated-auth.md): exposes the `creek purge.*` family via MCP behind an elevated-authorization gate so the developer's Claude Code can drive destructive ops through the same surface CrawDad uses, while CrawDad itself (no token) fails closed.

- **Auth gate** (`creek_mcp/auth.py`): `is_elevated()` matches the request's `auth_token` against `CREEK_MCP_ELEVATED_TOKEN` via `hmac.compare_digest` — verified by both a runtime spy and a static AST check that no `==` slips into the hot path.
- **Audit hardening** (`creek_mcp/audit.py`): every entry now carries `entry_hash` (SHA-256 of payload excluding chain fields) on top of the existing `prev_hash`; `verify_mcp_audit_chain()` walks both invariants. Cross-process concurrent writes are exercised by a multiprocessing-spawn test.
- **Five purge tools** (`creek_mcp/tools/purge.py`): `fragment`, `source`, `classifications`, `daterange`, `vault`. Refusals are themselves audited. `creek.purge.vault` requires *both* the token *and* a `confirm_vault_path` matching the resolved vault path.
- **Docs** (`docs/mcp.md`): new "Elevated-authorization model" and "Tamper-evidence" sections plus the purge-tool table, with an explicit "do not give this token to CrawDad" note.
- **Security**: pin `urllib3>=2.7.0` in `pyproject.toml` to clear CVE-2026-44431 / CVE-2026-44432 surfaced by `pip-audit` (transitive via `requests`/`conan`). Pre-existing on `main`; would otherwise block this PR's `check-all.sh`.

## Acceptance criteria verified

- [x] All five `creek.purge.*` tools exposed and gated by the elevated-auth check (`tests/test_mcp_server.py::test_purge_tools_require_auth_token_parameter`, `tests/test_mcp_purge.py::test_purge_*_with_token_*`).
- [x] Without the token, every purge call returns a structured refusal — never a silent partial purge (`test_purge_tool_refuses_without_token`, `test_purge_tool_refuses_with_wrong_token`, `test_crawdad_consumer_cannot_purge`).
- [x] `creek.purge.vault` requires both token and `confirm_vault_path` (`test_purge_vault_refuses_without_confirm_path`, `test_purge_vault_refuses_when_confirm_path_does_not_match`, `test_purge_vault_proceeds_with_token_and_matching_path`).
- [x] Audit entries carry `prev_hash` / `entry_hash`; `verify_mcp_audit_chain()` exists and is exercised by tests (`test_append_stamps_entry_hash_alongside_prev_hash`, `test_verifier_*` family).
- [x] Concurrent-write safety tested (`test_concurrent_process_appends_do_not_corrupt_log` — 4 processes via `multiprocessing.spawn`).
- [x] `docs/mcp.md` documents the elevated-auth model with explicit "do not give this token to CrawDad" guidance.
- [x] ≥90% branch coverage on `creek_mcp/{auth,audit,tools/purge}.py` (local: auth 100%, audit 91.3%, purge 96.7%).
- [x] `creek_mcp/auth.py` uses `hmac.compare_digest(expected, actual)` — not `==`. Verified by a unit test that monkey-patches `hmac.compare_digest` and a static AST walk asserting `is_elevated` contains no `Eq`/`NotEq` comparisons (`test_is_elevated_uses_hmac_compare_digest`, `test_auth_module_source_uses_compare_digest_not_equality`).

## Test plan

- [x] `tests/test_mcp_auth.py` — 7 tests covering empty-env, missing-token, mismatch, match, runtime spy on `hmac.compare_digest`, and the AST static check.
- [x] `tests/test_mcp_audit.py` — 6 new FEAT-012 tests (entry_hash stamping, verifier accept/reject mutation/removal, missing-log, multiprocessing concurrent writes) on top of the existing FEAT-010 coverage.
- [x] `tests/test_mcp_purge.py` — 20 tests covering refusal paths (no token / wrong token, parametrised over all five tools), dry-run preservation, daterange validation, vault confirmation, audit recording, and CrawDad-style end-to-end refusal.
- [x] `tests/test_mcp_server.py` — server registration of all 17 tools (read + write + purge) plus the `auth_token`-schema invariant on the purge subset.
- [x] Local `./scripts/check-all.sh` exits 0 (10/10 quality checks pass; 3424 tests pass; total coverage 93.51%).

Source candidate: [ADAPT-004](../blob/main/plans/2026-05-05_comparative-analysis/candidates/ADAPT-004-mcp-server-as-interface.md) (part 3 of 3). Dependencies FEAT-010 (#224) and FEAT-011 (#228) are merged to `main`.

https://claude.ai/code/session_01M8i6urGkBP54TcbmiwSVBR

---
_Generated by [Claude Code](https://claude.ai/code/session_01M8i6urGkBP54TcbmiwSVBR)_