### PR TITLE
feat(compost): embedding-similarity gate + LLM verifier (FEAT-018)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -83,9 +83,14 @@ skills_app = typer.Typer(
     name="skills",
     help="Voice Skill Tree generation and schema-skill template sync.",
 )
+compost_app = typer.Typer(
+    name="compost",
+    help="Compost detection utilities (FEAT-018: embedding gate + verifier).",
+)
 app.add_typer(clean_app, name="clean")
 app.add_typer(purge_app, name="purge")
 app.add_typer(skills_app, name="skills")
+app.add_typer(compost_app, name="compost")
 console = Console()
 
 
@@ -2442,3 +2447,64 @@ def _resolve_purge_phrase(
     if typed.strip() != expected:
         return None
     return VAULT_PURGE_CONFIRMATION
+
+
+@compost_app.command("calibrate")
+def compost_calibrate(
+    fixture: Path | None = typer.Option(
+        None,
+        "--fixture",
+        help=(
+            "Path to a YAML calibration set of `{text, expected: bool}` "
+            "entries. When omitted, the command reports the packaged "
+            "exemplar set and explains how to author a fixture."
+        ),
+    ),
+    exemplars: Path | None = typer.Option(
+        None,
+        "--exemplars",
+        help=(
+            "Path to a custom exemplars YAML. Defaults to the packaged "
+            "`creek/generate/exemplars/compost.yaml`."
+        ),
+    ),
+) -> None:
+    """Report exemplar coverage and (when supplied) fixture recall (FEAT-018).
+
+    With ``--fixture`` omitted, prints the loaded exemplar count by
+    texture so operators can audit the curated set. With a fixture
+    supplied, scores recall + precision against the labelled set so
+    the operator can tune ``compost.embedding_threshold`` against
+    their corpus. The full calibration loop lands once a real fixture
+    is collected from the user's vault; today this command exists so
+    the workflow is discoverable.
+    """
+    from creek.generate.compost_embedding import load_exemplars
+
+    try:
+        loaded = load_exemplars(exemplars)
+    except (FileNotFoundError, ValueError) as exc:
+        console.print(f"[red]Failed to load exemplars: {exc}[/red]")
+        raise typer.Exit(code=2) from exc
+
+    by_texture: dict[str, int] = {}
+    for exemplar in loaded:
+        by_texture[exemplar.texture] = by_texture.get(exemplar.texture, 0) + 1
+    console.print(f"[bold green]Loaded {len(loaded)} compost exemplars.[/bold green]")
+    for texture, count in sorted(by_texture.items()):
+        console.print(f"  {texture:<20} {count}")
+
+    if fixture is None:
+        console.print(
+            "\nNo --fixture supplied. To score recall/precision, author a "
+            "YAML list of `{text, expected: bool}` entries from real vault "
+            "fragments and re-run with `--fixture path/to/fixture.yaml`.",
+        )
+        return
+
+    console.print(
+        f"\n[yellow]Fixture-driven scoring against {fixture} is not yet "
+        "implemented (FEAT-018 stub). The fixture format and recall/"
+        "precision report land in a follow-up once a real labelled set "
+        "is collected.[/yellow]",
+    )

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -450,6 +450,49 @@ class CleaningConfig(BaseModel):
     """Data hygiene settings."""
 
 
+class CompostConfig(BaseModel):
+    """Compost detection configuration (FEAT-018).
+
+    Replaces the legacy five-phrase abandonment keyword regex with a
+    two-stage pipeline: an embedding-similarity gate against curated
+    exemplars (``creek/generate/exemplars/compost.yaml``), followed by
+    an optional LLM verifier that returns ``yes`` / ``no`` /
+    ``ambiguous``. Ambiguous verdicts route to a review queue rather
+    than the canonical compost folder.
+    """
+
+    embedding_threshold: float = Field(default=0.6, ge=0.0, le=1.0)
+    """Cosine-similarity floor above which a fragment is sent to the
+    verifier. Deliberately wide-net (0.6) — the verifier owns precision.
+    Tighten once a calibration set exists for your real corpus.
+    """
+
+    llm_verification: bool = True
+    """When ``True``, candidates that pass the embedding gate are sent
+    to the LLM verifier. When ``False``, the embedding gate alone
+    decides acceptance (faster + offline, but more false positives).
+    """
+
+    review_queue_relpath: str = "10-Liminal/Compost/Review"
+    """Vault-relative path under which ``ambiguous`` verdicts are filed.
+    Operators triage this queue manually and either promote to canonical
+    compost or delete.
+    """
+
+    skip_paradox: bool = True
+    """When ``True``, fragments tagged ``paradox`` or living under
+    ``10-Liminal/Paradoxes/`` are skipped — paradoxes are contradiction-
+    holding notes by design, not compost candidates.
+    """
+
+    exemplars_relpath: str | None = None
+    """Vault-relative path to a custom exemplars YAML. When ``None``,
+    the packaged default (``creek/generate/exemplars/compost.yaml``)
+    is used. Override only after running ``creek compost calibrate``
+    against your corpus has shown the defaults under-recall.
+    """
+
+
 class SourcePaths(BaseModel):
     """Source data paths (relative to ``source_drive``)."""
 
@@ -529,6 +572,9 @@ class CreekConfig(BaseSettings):
 
     cleaning: CleaningConfig = Field(default_factory=CleaningConfig)
     """Data cleaning pipeline settings."""
+
+    compost: CompostConfig = Field(default_factory=CompostConfig)
+    """Compost detection settings (FEAT-018: embedding gate + verifier)."""
 
     sources: SourcePaths = Field(default_factory=SourcePaths)
     """Source data path mappings."""

--- a/creek-tools/creek/generate/__init__.py
+++ b/creek-tools/creek/generate/__init__.py
@@ -1,9 +1,20 @@
 """Creek generate package — index and note generation for the Creek vault."""
 
 from creek.generate.compost import (
-    ABANDONMENT_KEYWORDS,
     CompostCandidate,
     CompostTracker,
+)
+from creek.generate.compost_embedding import (
+    PACKAGED_EXEMPLARS_PATH,
+    CompostExemplar,
+    load_exemplars,
+    make_similarity_fn,
+)
+from creek.generate.compost_verifier import (
+    CompostVerdict,
+    CompostVerifierResult,
+    LLMCompostVerifier,
+    SupportsVerifyCompost,
 )
 from creek.generate.decisions import (
     DECISION_KEYWORDS,
@@ -102,7 +113,6 @@ from creek.generate.wavelength import (
 )
 
 __all__ = [
-    "ABANDONMENT_KEYWORDS",
     "CONTRADICTION_KEYWORDS",
     "DECISION_KEYWORDS",
     "DEFAULT_MAX_EXEMPLARS",
@@ -130,6 +140,7 @@ __all__ = [
     "METAPHOR_DOMAINS",
     "MODE_ORIENTATION_KEYS",
     "MODE_ORIENTATION_STANCES",
+    "PACKAGED_EXEMPLARS_PATH",
     "PHASE_KEYS",
     "PHASE_VOICE_RHYTHMS",
     "PRACTICE_MAP",
@@ -143,7 +154,10 @@ __all__ = [
     "BorrowedTermEntry",
     "CoinedTermEntry",
     "CompostCandidate",
+    "CompostExemplar",
     "CompostTracker",
+    "CompostVerdict",
+    "CompostVerifierResult",
     "DecisionContext",
     "DecisionContextGatherer",
     "DecisionDetector",
@@ -155,6 +169,7 @@ __all__ = [
     "IdeaMiner",
     "IdeaSeed",
     "IndexGenerator",
+    "LLMCompostVerifier",
     "Lexicon",
     "LexiconContext",
     "LexiconGenerator",
@@ -172,6 +187,7 @@ __all__ = [
     "SkillExemplar",
     "SkillTreeGenerator",
     "StateReportGenerator",
+    "SupportsVerifyCompost",
     "SynchronicityDetector",
     "TagGardenGenerator",
     "TagScanResult",
@@ -183,4 +199,6 @@ __all__ = [
     "WavelengthSnapshot",
     "WavelengthTracker",
     "decision_from_note",
+    "load_exemplars",
+    "make_similarity_fn",
 ]

--- a/creek-tools/creek/generate/compost.py
+++ b/creek-tools/creek/generate/compost.py
@@ -5,10 +5,17 @@ surfaces threads, fragments, and projects that have fallen dormant or been
 explicitly abandoned, writes ``10-Liminal/Compost/`` notes preserving what
 each idea was, why it faded, and what energy may still be alive, and
 generates an overview report cross-referencing active threads.
+
+FEAT-018 replaced the five-phrase ``ABANDONMENT_KEYWORDS`` regex with a
+two-stage detection: an embedding-similarity gate against curated
+exemplars (:mod:`creek.generate.compost_embedding`) followed by an
+optional LLM verifier (:mod:`creek.generate.compost_verifier`) whose
+``ambiguous`` verdicts route to a vault-relative review queue.
 """
 
 from __future__ import annotations
 
+import logging
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -17,25 +24,23 @@ from typing import TYPE_CHECKING
 
 import frontmatter
 
+from creek.generate.compost_verifier import CompostVerdict
 from creek.models import (
     Confidence,
     Fragment,
     PraxisPotential,
+    PrivacyTier,
     Thread,
     ThreadStatus,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
     from pathlib import Path
 
-ABANDONMENT_KEYWORDS: tuple[str, ...] = (
-    "gave up on",
-    "abandoned",
-    "never finished",
-    "put aside",
-    "shelved",
-)
-"""Case-insensitive phrases flagging a fragment as describing abandonment."""
+    from creek.generate.compost_verifier import SupportsVerifyCompost
+
+logger = logging.getLogger(__name__)
 
 _DORMANCY_DAYS: int = 180
 """Threads without new fragments for this many days become compost."""
@@ -71,10 +76,19 @@ class CompostCandidate:
         energy_fragment_ids: IDs of fragments whose confidence or
             ``praxis_potential`` marks them as crystallised thinking worth
             preserving ("what energy remains").
-        matched_keywords: Abandonment keywords matched against the source.
-            Empty for thread and project candidates.
         energy_excerpts: Optional short excerpts describing the surviving
             energy; rendered as bullet points under "What energy remains".
+        similarity: Embedding-gate cosine similarity to the closest
+            exemplar. ``None`` for thread and project candidates and
+            for fragment candidates produced before FEAT-018.
+        verifier_reasoning: One-sentence reason returned by the LLM
+            verifier (:mod:`creek.generate.compost_verifier`).
+            ``None`` when the verifier was skipped or the candidate
+            originated from a thread/project source.
+        for_review: When ``True`` the candidate routes to the operator
+            review queue (``CompostConfig.review_queue_relpath``)
+            rather than the canonical compost folder. Set for
+            ``ambiguous`` verifier verdicts.
     """
 
     source_type: str
@@ -83,8 +97,10 @@ class CompostCandidate:
     reason: str
     fragment_ids: list[str] = field(default_factory=list)
     energy_fragment_ids: list[str] = field(default_factory=list)
-    matched_keywords: list[str] = field(default_factory=list)
     energy_excerpts: list[str] = field(default_factory=list)
+    similarity: float | None = None
+    verifier_reasoning: str | None = None
+    for_review: bool = False
 
 
 # ---- Helpers ----
@@ -111,10 +127,14 @@ def _fragment_thread_titles(fragment: Fragment) -> list[str]:
     return titles
 
 
-def _matched_abandonment_keywords(title: str) -> list[str]:
-    """Return abandonment keywords present in *title* (case-insensitive)."""
-    lowered = title.lower()
-    return [kw for kw in ABANDONMENT_KEYWORDS if kw in lowered]
+def _is_paradox(fragment: Fragment) -> bool:
+    """Return whether *fragment* is a paradox note (skipped by compost detection)."""
+    return "paradox" in fragment.tags
+
+
+def _is_intimate(fragment: Fragment) -> bool:
+    """Return whether *fragment* carries the intimate privacy tier."""
+    return fragment.privacy_tier == PrivacyTier.INTIMATE
 
 
 def _sanitize_filename(title: str) -> str:
@@ -140,6 +160,11 @@ class CompostTracker:
         project_gap_days: int = _PROJECT_GAP_DAYS,
         project_min_fragments: int = _PROJECT_MIN_FRAGMENTS,
         now: datetime | None = None,
+        similarity_fn: Callable[[str], float] | None = None,
+        verifier: SupportsVerifyCompost | None = None,
+        embedding_threshold: float = 0.6,
+        skip_paradox: bool = True,
+        skip_intimate: bool = True,
     ) -> None:
         """Initialise the tracker.
 
@@ -154,11 +179,39 @@ class CompostTracker:
             now: Reference "now" for age calculations. Defaults to
                 :func:`datetime.now` (timezone-naive). Useful for
                 deterministic tests.
+            similarity_fn: Closure mapping a text string to its maximum
+                cosine similarity against the compost exemplar set
+                (see :mod:`creek.generate.compost_embedding`). When
+                ``None``, fragment-level compost detection is skipped
+                — thread-level dormancy and project-silence detection
+                still run.
+            verifier: Optional LLM verifier. When supplied, every
+                fragment that clears *embedding_threshold* is sent
+                through ``verifier.verify(...)``; ``yes`` → canonical
+                compost, ``ambiguous`` → review queue
+                (``for_review=True``), ``no`` → skipped. When ``None``,
+                clearing the embedding threshold alone accepts the
+                fragment as canonical compost.
+            embedding_threshold: Minimum cosine similarity (against the
+                exemplars) required for a fragment to advance to the
+                verifier. Defaults to 0.6 — deliberately wide-net.
+            skip_paradox: When ``True``, fragments tagged ``paradox``
+                are excluded from compost detection. Defaults to
+                ``True``.
+            skip_intimate: When ``True``, fragments with
+                ``privacy_tier == intimate`` are excluded from compost
+                detection. Defaults to ``True`` (matching the default
+                policy in :mod:`creek.classify.privacy_filter`).
         """
         self.dormancy_days = dormancy_days
         self.project_gap_days = project_gap_days
         self.project_min_fragments = project_min_fragments
         self._now = now or datetime.now(tz=UTC).replace(tzinfo=None)
+        self._similarity_fn = similarity_fn
+        self._verifier = verifier
+        self._embedding_threshold = embedding_threshold
+        self._skip_paradox = skip_paradox
+        self._skip_intimate = skip_intimate
 
     # ---- Detection ----
 
@@ -166,6 +219,8 @@ class CompostTracker:
         self,
         threads: list[Thread],
         fragments: list[Fragment],
+        *,
+        fragment_bodies: Mapping[str, str] | None = None,
     ) -> list[CompostCandidate]:
         """Scan *threads* and *fragments* for compost candidates.
 
@@ -173,21 +228,32 @@ class CompostTracker:
 
         1. Threads with ``status == resolved`` or whose ``last_seen`` is
            older than :attr:`dormancy_days`.
-        2. Fragments whose title contains an abandonment keyword.
+        2. Fragments whose embedding similarity to the curated compost
+           exemplar set exceeds :attr:`_embedding_threshold` (FEAT-018).
+           Optionally verified by an LLM before acceptance.
         3. Tagged projects that appear in early fragments but have not
            been mentioned for more than :attr:`project_gap_days`.
 
+        Paradox-tagged and intimate-tier fragments are skipped per
+        ``skip_paradox`` / ``skip_intimate`` on the constructor.
+
         Args:
             threads: Threads to scan.
-            fragments: Fragments to scan (used for keyword detection,
+            fragments: Fragments to scan (used for embedding detection,
                 project tracking, and energy extraction).
+            fragment_bodies: Optional mapping of fragment ID to body
+                text. When supplied, the embedding gate uses
+                ``title + body``; when omitted, title-only.
 
         Returns:
             A list of :class:`CompostCandidate` models, ordered
             thread-candidates → fragment-candidates → project-candidates.
         """
         thread_candidates = self._detect_threads(threads, fragments)
-        fragment_candidates = self._detect_keyword_fragments(fragments)
+        fragment_candidates = self._detect_abandonment_fragments(
+            fragments,
+            fragment_bodies or {},
+        )
         project_candidates = self._detect_disappeared_projects(fragments)
         return [*thread_candidates, *fragment_candidates, *project_candidates]
 
@@ -234,33 +300,81 @@ class CompostTracker:
             return f"Dormant for {days_since} days"
         return None
 
-    def _detect_keyword_fragments(
+    def _detect_abandonment_fragments(
         self,
         fragments: list[Fragment],
+        bodies: Mapping[str, str],
     ) -> list[CompostCandidate]:
-        """Detect fragments whose title signals abandonment."""
+        """Detect fragments that semantically describe abandonment (FEAT-018).
+
+        Two-stage pipeline: embedding-similarity gate → optional LLM
+        verifier. Paradox-tagged and intimate-tier fragments are
+        skipped here so neither the embedding nor the verifier sees
+        them — important because the verifier may call out to a cloud
+        LLM and intimate content must never leave the device.
+        """
+        if self._similarity_fn is None:
+            return []
         candidates: list[CompostCandidate] = []
         for fragment in fragments:
-            matched = _matched_abandonment_keywords(fragment.title)
-            if not matched:
+            if self._skip_paradox and _is_paradox(fragment):
                 continue
-            candidates.append(
-                CompostCandidate(
-                    source_type="fragment",
-                    source_id=fragment.id,
-                    title=fragment.title,
-                    reason=f"Abandonment keyword: {matched[0]}",
-                    fragment_ids=[fragment.id],
-                    energy_fragment_ids=(
-                        [fragment.id] if _fragment_is_energetic(fragment) else []
-                    ),
-                    matched_keywords=matched,
-                    energy_excerpts=(
-                        [fragment.title] if _fragment_is_energetic(fragment) else []
-                    ),
-                ),
-            )
+            if self._skip_intimate and _is_intimate(fragment):
+                continue
+            body = bodies.get(fragment.id, "")
+            text = f"{fragment.title}\n{body}".strip() if body else fragment.title
+            similarity = self._similarity_fn(text)
+            if similarity < self._embedding_threshold:
+                continue
+            candidate = self._verify_fragment_candidate(fragment, body, similarity)
+            if candidate is not None:
+                candidates.append(candidate)
         return candidates
+
+    def _verify_fragment_candidate(
+        self,
+        fragment: Fragment,
+        body: str,
+        similarity: float,
+    ) -> CompostCandidate | None:
+        """Stage 2: route an above-threshold fragment through the verifier.
+
+        When ``self._verifier`` is ``None`` the embedding gate alone
+        accepts the candidate. Otherwise:
+
+        * ``yes`` → canonical compost candidate;
+        * ``ambiguous`` → review-queue candidate (``for_review=True``);
+        * ``no`` → returns ``None`` (skip).
+        """
+        verdict: CompostVerdict
+        reasoning: str | None
+        if self._verifier is None:
+            verdict = CompostVerdict.YES
+            reasoning = None
+        else:
+            result = self._verifier.verify(title=fragment.title, body=body)
+            verdict = result.verdict
+            reasoning = result.reasoning
+            if verdict == CompostVerdict.NO:
+                return None
+        is_energetic = _fragment_is_energetic(fragment)
+        reason = (
+            f"Embedding-similarity {similarity:.2f}"
+            if reasoning is None
+            else f"{reasoning} (similarity {similarity:.2f})"
+        )
+        return CompostCandidate(
+            source_type="fragment",
+            source_id=fragment.id,
+            title=fragment.title,
+            reason=reason,
+            fragment_ids=[fragment.id],
+            energy_fragment_ids=[fragment.id] if is_energetic else [],
+            energy_excerpts=[fragment.title] if is_energetic else [],
+            similarity=similarity,
+            verifier_reasoning=reasoning,
+            for_review=verdict == CompostVerdict.AMBIGUOUS,
+        )
 
     def _detect_disappeared_projects(
         self,
@@ -317,24 +431,38 @@ class CompostTracker:
         self,
         candidate: CompostCandidate,
         vault_path: Path,
+        *,
+        review_queue_relpath: str = "10-Liminal/Compost/Review",
     ) -> Path:
         """Write a compost note for *candidate* into the vault.
 
-        The note lives at ``10-Liminal/Compost/<date>-<sanitised-title>.md``.
-        Frontmatter captures the source reference, composted date, reason,
-        tags, and fragment links. The body carries the three required
-        sections ("What it was", "Why it composted", "What energy
-        remains") plus a trailing list of all related fragments.
+        Canonical compost notes live at
+        ``10-Liminal/Compost/<date>-<sanitised-title>.md``. Candidates
+        whose verifier returned ``ambiguous`` (``candidate.for_review``
+        is ``True``) instead route to *review_queue_relpath* so the
+        operator can triage them before they are filed canonically.
+
+        Frontmatter captures the source reference, composted date,
+        reason, tags, and fragment links. The body carries the three
+        required sections ("What it was", "Why it composted", "What
+        energy remains") plus a trailing list of all related fragments.
 
         Args:
             candidate: The compost candidate to record.
             vault_path: Path to the root of the Obsidian vault.
+            review_queue_relpath: Vault-relative path for ambiguous
+                verifier verdicts. Defaults to
+                ``"10-Liminal/Compost/Review"``; callers wiring config
+                pass ``config.compost.review_queue_relpath``.
 
         Returns:
             Path to the written note.
         """
-        compost_dir = vault_path / "10-Liminal" / "Compost"
-        compost_dir.mkdir(parents=True, exist_ok=True)
+        if candidate.for_review:
+            target_dir = vault_path / review_queue_relpath
+        else:
+            target_dir = vault_path / "10-Liminal" / "Compost"
+        target_dir.mkdir(parents=True, exist_ok=True)
 
         today = self._now.date()
         metadata = self._build_metadata(candidate, today)
@@ -342,7 +470,7 @@ class CompostTracker:
         post = frontmatter.Post(content=body, **metadata)
 
         filename = f"{today.isoformat()}-{_sanitize_filename(candidate.title)}.md"
-        note_path = compost_dir / filename
+        note_path = target_dir / filename
         note_path.write_text(frontmatter.dumps(post), encoding="utf-8")
         return note_path
 
@@ -352,13 +480,16 @@ class CompostTracker:
         today: date,
     ) -> dict[str, object]:
         """Build the frontmatter metadata dict for *candidate*."""
+        tags = ["compost"]
+        if candidate.for_review:
+            tags.append("compost-review")
         metadata: dict[str, object] = {
             "type": "compost",
             "title": candidate.title,
             "composted_date": today.isoformat(),
             "reason": candidate.reason,
             "fragments": [f"[[{fid}]]" for fid in candidate.fragment_ids],
-            "tags": ["compost"],
+            "tags": tags,
         }
         if candidate.source_type == "thread":
             metadata["original_thread"] = f"[[{candidate.source_id}]]"
@@ -366,8 +497,10 @@ class CompostTracker:
             metadata["original_fragment"] = f"[[{candidate.source_id}]]"
         else:
             metadata["original_project"] = candidate.source_id
-        if candidate.matched_keywords:
-            metadata["matched_keywords"] = list(candidate.matched_keywords)
+        if candidate.similarity is not None:
+            metadata["embedding_similarity"] = round(candidate.similarity, 4)
+        if candidate.verifier_reasoning is not None:
+            metadata["verifier_reasoning"] = candidate.verifier_reasoning
         return metadata
 
     @staticmethod

--- a/creek-tools/creek/generate/compost_embedding.py
+++ b/creek-tools/creek/generate/compost_embedding.py
@@ -1,0 +1,165 @@
+"""Exemplar-based embedding similarity gate for compost detection (FEAT-018).
+
+Replaces the literal-phrase ``ABANDONMENT_KEYWORDS`` regex with a
+semantic gate. A curated list of *exemplars* — short prose passages
+that capture the texture of idea-abandonment across registers — is
+loaded from a packaged YAML file. At detection time the embedding
+linker encodes each fragment's text and the exemplar bodies, then the
+gate returns the maximum cosine similarity. Fragments above the
+configured threshold (default 0.6, deliberately wide) advance to the
+LLM verifier in :mod:`creek.generate.compost_verifier`.
+
+The design intentionally couples loosely: the loader returns simple
+:class:`CompostExemplar` dataclasses, and :func:`make_similarity_fn`
+returns a closure that callers can swap out for a deterministic stub
+in tests.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+
+    from creek.link.embeddings import EmbeddingLinker
+
+logger = logging.getLogger(__name__)
+
+PACKAGED_EXEMPLARS_PATH: Path = Path(__file__).parent / "exemplars" / "compost.yaml"
+"""Location of the packaged default exemplar set."""
+
+_REQUIRED_KEYS: frozenset[str] = frozenset({"title", "body", "texture", "rationale"})
+"""Keys every exemplar entry must carry."""
+
+
+@dataclass(frozen=True)
+class CompostExemplar:
+    """One curated abandonment-texture exemplar.
+
+    Attributes:
+        title: Human-readable label (not used for matching).
+        body: The text the embedding gate matches fragment text against.
+        texture: One-word descriptor (e.g. ``circling``, ``releasing``).
+        rationale: One-sentence explanation of why this exemplar
+            represents compost; surfaced in the calibration report.
+    """
+
+    title: str
+    body: str
+    texture: str
+    rationale: str
+
+
+def load_exemplars(path: Path | None = None) -> tuple[CompostExemplar, ...]:
+    """Load and validate compost exemplars from *path* (or the packaged default).
+
+    Args:
+        path: Path to a YAML file holding a list of exemplar entries.
+            When ``None``, loads :data:`PACKAGED_EXEMPLARS_PATH`.
+
+    Returns:
+        Tuple of :class:`CompostExemplar`, one per YAML record.
+
+    Raises:
+        FileNotFoundError: If *path* does not exist.
+        ValueError: If the YAML is empty, the wrong shape, or any
+            entry is missing a required key.
+    """
+    target = path or PACKAGED_EXEMPLARS_PATH
+    if not target.exists():
+        msg = f"Compost exemplars file not found: {target}"
+        raise FileNotFoundError(msg)
+
+    with target.open() as f:
+        raw = yaml.safe_load(f)
+
+    if not isinstance(raw, list) or not raw:
+        msg = f"Compost exemplars file {target} must contain a non-empty list."
+        raise ValueError(msg)
+
+    exemplars: list[CompostExemplar] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            msg = f"Exemplar {index} in {target} is not a mapping."
+            raise ValueError(msg)
+        missing = _REQUIRED_KEYS - entry.keys()
+        if missing:
+            msg = (
+                f"Exemplar {index} in {target} is missing required keys: "
+                f"{sorted(missing)}"
+            )
+            raise ValueError(msg)
+        exemplars.append(
+            CompostExemplar(
+                title=str(entry["title"]),
+                body=str(entry["body"]),
+                texture=str(entry["texture"]),
+                rationale=str(entry["rationale"]),
+            ),
+        )
+    return tuple(exemplars)
+
+
+def _cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Return the cosine similarity between two equal-length vectors.
+
+    Returns ``0.0`` for either-zero vectors so callers can use the
+    result directly as a sort key without a degenerate-magnitude
+    guard.
+    """
+    dot: float = math.fsum(x * y for x, y in zip(a, b, strict=True))
+    norm_a: float = math.sqrt(math.fsum(x * x for x in a))
+    norm_b: float = math.sqrt(math.fsum(y * y for y in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def make_similarity_fn(
+    exemplars: Sequence[CompostExemplar],
+    linker: EmbeddingLinker,
+) -> Callable[[str], float]:
+    """Return a closure mapping text → max cosine similarity to exemplars.
+
+    Exemplar embeddings are computed once on the first call and cached
+    in the closure, so repeated invocations over a fragment list pay
+    the encode cost only for the fragment text itself.
+
+    Args:
+        exemplars: Curated abandonment-texture exemplars.
+        linker: An :class:`EmbeddingLinker` configured with the same
+            model that will encode fragment text. Production callers
+            wire in the project-wide linker; tests pass a fake.
+
+    Returns:
+        A callable that, given any string, returns the maximum cosine
+        similarity to any exemplar body, in ``[0.0, 1.0]``.
+    """
+    exemplar_vectors: list[list[float]] = []
+
+    def _ensure_exemplar_vectors() -> None:
+        if exemplar_vectors:
+            return
+        for exemplar in exemplars:
+            exemplar_vectors.append(linker.generate_embedding(exemplar.body))
+
+    def similarity(text: str) -> float:
+        if not text.strip():
+            return 0.0
+        _ensure_exemplar_vectors()
+        if not exemplar_vectors:
+            return 0.0
+        fragment_vector = linker.generate_embedding(text)
+        return max(
+            _cosine_similarity(fragment_vector, exemplar_vector)
+            for exemplar_vector in exemplar_vectors
+        )
+
+    return similarity

--- a/creek-tools/creek/generate/compost_verifier.py
+++ b/creek-tools/creek/generate/compost_verifier.py
@@ -1,0 +1,162 @@
+"""LLM verifier for compost candidates (FEAT-018 stage 2).
+
+The embedding gate in :mod:`creek.generate.compost_embedding` casts a
+wide net. Fragments that cross the similarity threshold are sent here
+for precision: the LLM is asked whether this text really describes a
+user *abandoning an idea or project*, returning ``yes`` / ``no`` /
+``ambiguous`` plus a one-sentence reason.
+
+Ambiguous verdicts route to the operator's compost review queue
+(``10-Liminal/Compost/Review``) rather than being filed canonically.
+
+The :class:`SupportsVerifyCompost` protocol lets the
+:class:`creek.generate.compost.CompostTracker` accept either the real
+:class:`LLMCompostVerifier` or a deterministic stub in tests, mirroring
+the calibration seam in :mod:`creek.classify.calibration`.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from creek.classify.llm import AnthropicProvider
+
+logger = logging.getLogger(__name__)
+
+
+class CompostVerdict(StrEnum):
+    """Three-state verifier outcome.
+
+    ``YES`` and ``NO`` are decisive; ``AMBIGUOUS`` routes the fragment
+    to a review queue for human triage rather than the canonical
+    compost folder.
+    """
+
+    YES = "yes"
+    NO = "no"
+    AMBIGUOUS = "ambiguous"
+
+
+@dataclass(frozen=True)
+class CompostVerifierResult:
+    """One verifier verdict for one fragment.
+
+    Attributes:
+        verdict: Decisive yes/no or ambiguous.
+        reasoning: One-sentence explanation surfaced in the compost
+            note's frontmatter (``verifier_reasoning`` key) so the
+            operator can audit decisions later.
+    """
+
+    verdict: CompostVerdict
+    reasoning: str
+
+
+class SupportsVerifyCompost(Protocol):
+    """Subset of verifier surface the compost tracker needs.
+
+    Any object exposing :meth:`verify` with this signature is accepted
+    by :class:`creek.generate.compost.CompostTracker`. Real verifier
+    wraps :class:`creek.classify.llm.AnthropicProvider`; tests pass a
+    deterministic stub.
+    """
+
+    def verify(self, *, title: str, body: str) -> CompostVerifierResult:
+        """Classify *title*/*body* as compost / not / ambiguous."""
+
+
+_PROMPT_TEMPLATE: str = (
+    "You are auditing a personal-journal fragment to decide whether it describes "
+    "the *abandonment of an idea, project, or thread of thought*. Abandonment "
+    "includes: explicit release, drift away by loss of interest, displacement "
+    "by something else, exhaustion of attention, and self-honest naming of "
+    "indefinite postponement. Abandonment does NOT include: temporary "
+    "frustration mid-flow, deciding to take a break, completing the work, or "
+    "expressing a paradox.\n"
+    "\n"
+    "Title: {title}\n"
+    "\n"
+    "Body:\n"
+    "{body}\n"
+    "\n"
+    "Respond with EXACTLY this format on three lines:\n"
+    "VERDICT: <yes|no|ambiguous>\n"
+    "REASONING: <one sentence, no more than 25 words>\n"
+    "\n"
+    "Use ``ambiguous`` when the fragment plausibly reads either way and a "
+    "human should triage it."
+)
+
+_VERDICT_RE = re.compile(r"^VERDICT:\s*(yes|no|ambiguous)\s*$", re.IGNORECASE)
+_REASONING_RE = re.compile(r"^REASONING:\s*(.+?)\s*$", re.IGNORECASE)
+
+
+def _parse_verifier_response(text: str) -> CompostVerifierResult:
+    """Parse the LLM's three-line response into a :class:`CompostVerifierResult`.
+
+    Falls back to ``AMBIGUOUS`` with the raw response as the reason
+    when the format is violated, so a malformed response routes to the
+    review queue rather than silently dropping the fragment.
+    """
+    verdict: CompostVerdict | None = None
+    reasoning = ""
+    for line in text.splitlines():
+        verdict_match = _VERDICT_RE.match(line.strip())
+        if verdict_match:
+            verdict = CompostVerdict(verdict_match.group(1).lower())
+            continue
+        reasoning_match = _REASONING_RE.match(line.strip())
+        if reasoning_match:
+            reasoning = reasoning_match.group(1)
+    if verdict is None:
+        logger.warning(
+            "Compost verifier returned unparseable response; routing to review.",
+        )
+        return CompostVerifierResult(
+            verdict=CompostVerdict.AMBIGUOUS,
+            reasoning=f"Unparseable verifier response: {text[:120]}",
+        )
+    return CompostVerifierResult(verdict=verdict, reasoning=reasoning or "(no reason)")
+
+
+class LLMCompostVerifier:
+    """Default :class:`SupportsVerifyCompost` impl backed by Anthropic.
+
+    Wraps an :class:`creek.classify.llm.AnthropicProvider` and parses
+    the three-line response format defined by ``_PROMPT_TEMPLATE``.
+    Reuses the existing classify infrastructure rather than building
+    a parallel transport layer.
+    """
+
+    def __init__(self, provider: AnthropicProvider) -> None:
+        """Initialise the verifier.
+
+        Args:
+            provider: A constructed :class:`AnthropicProvider`. Caller
+                is responsible for handling the ``ANTHROPIC_API_KEY``
+                and ``CREEK_ANTHROPIC_CONSENT`` env-var preconditions.
+        """
+        self._provider = provider
+
+    def verify(self, *, title: str, body: str) -> CompostVerifierResult:
+        """Send *title* + *body* to the LLM and parse the response.
+
+        Args:
+            title: Fragment title shown verbatim in the prompt.
+            body: Fragment body (truncated by the prompt template
+                itself if the caller chooses; this method passes it
+                through unchanged).
+
+        Returns:
+            A :class:`CompostVerifierResult`. Malformed LLM responses
+            yield :attr:`CompostVerdict.AMBIGUOUS` so the fragment
+            routes to review rather than being dropped.
+        """
+        prompt = _PROMPT_TEMPLATE.format(title=title.strip() or "(untitled)", body=body)
+        response = self._provider.call(prompt)
+        return _parse_verifier_response(response)

--- a/creek-tools/creek/generate/exemplars/__init__.py
+++ b/creek-tools/creek/generate/exemplars/__init__.py
@@ -1,0 +1,14 @@
+"""Compost exemplar fixtures shipped as package data (FEAT-018).
+
+This package exists so that ``creek.generate.exemplars`` is a real
+Python subpackage rather than an unmanaged data directory. Setuptools
+needs the ``__init__.py`` to discover the directory and ship the YAML
+fixtures via ``[tool.setuptools.package-data]``; without it,
+non-editable installs would silently omit the file and
+:func:`creek.generate.compost_embedding.load_exemplars` would raise
+``FileNotFoundError`` at runtime.
+
+The exemplar YAMLs themselves (``compost.yaml``) are not imported as
+Python modules — they are loaded by
+:func:`creek.generate.compost_embedding.load_exemplars`.
+"""

--- a/creek-tools/creek/generate/exemplars/compost.yaml
+++ b/creek-tools/creek/generate/exemplars/compost.yaml
@@ -133,7 +133,7 @@
 - title: I'm done pretending this is alive
   body: I've been treating this like a live project for months when it
     clearly isn't. Every time I update the status I'm performing for
-    no one. Calling it: this is compost. There's something in here worth
+    no one. Calling it — this is compost. There's something in here worth
     keeping but it isn't a project anymore.
   texture: releasing
   rationale: Explicit reframing from "active" to "compost"; names the

--- a/creek-tools/creek/generate/exemplars/compost.yaml
+++ b/creek-tools/creek/generate/exemplars/compost.yaml
@@ -1,0 +1,141 @@
+# Compost exemplars for FEAT-018 embedding-similarity detection.
+#
+# These exemplars seed the embedding gate in
+# creek/generate/compost.py. A fragment whose *body* exceeds
+# CompostConfig.embedding_threshold against the max-similarity of any
+# entry below is routed to the LLM verifier (stage 2). Entries should
+# capture the texture of idea-abandonment, not the literal phrasing
+# of the old `_ABANDONMENT_KEYWORDS` regex.
+#
+# Each entry:
+#   title:     human-readable label (not used for matching)
+#   body:      the matched text. 2-6 sentences. Match against fragment body.
+#   texture:   one of: circling, releasing, drifting, exhaustion,
+#              identity-drift, displacement, deflation, postponement,
+#              quiet-walk-away
+#   rationale: one-sentence explanation of why this is compost
+#
+# Curate this list as the user's actual abandonment voice. The regex
+# era used five literal phrases; this list should be diverse enough
+# that an embedding model can recognize abandonment phrased in the
+# user's own register (F6-F9, reflective, embodied, recursive).
+---
+- title: Circling without landing
+  body: I keep coming back to this question and never finishing the thought.
+    Every time I sit down with it the same circle opens, the same circle closes,
+    and I walk away with nothing new. The thread itself is the work,
+    apparently, and the work refuses to crystallize.
+  texture: circling
+  rationale: Repeated approach with no settling — the canonical "this isn't
+    going anywhere" pattern that has no literal abandonment keyword.
+
+- title: Quiet release
+  body: I'm letting this one go. Not with any drama, not as a failure,
+    just — it's not mine anymore. It belonged to a version of me that's
+    no longer the one holding the pen.
+  texture: releasing
+  rationale: Conscious release without struggle; the abandonment is
+    framed as completion, not defeat.
+
+- title: Drifted out of the room
+  body: Looking at the notes I made three months ago I barely recognize
+    the person who was urgent about this. Whatever pulled me toward it
+    pulled past it. I'm not interested anymore and I can't honestly say why.
+  texture: drifting
+  rationale: Loss of interest by drift rather than decision; "I'm not
+    interested anymore" without literal "abandoned".
+
+- title: I no longer recognize this thread
+  body: The thread went somewhere I no longer recognize. The premise I
+    started with isn't a premise I'd write today. I could keep pulling
+    on it out of momentum but I'd be performing continuity, not actually
+    continuing anything.
+  texture: identity-drift
+  rationale: The work has drifted from the author rather than the author
+    from the work; either way it's compost.
+
+- title: Too tired to keep this alive
+  body: I don't have the energy to keep tending this. It needed weekly
+    attention to stay warm and I gave it three weeks of cold and now
+    when I open the file the room feels empty. Maybe later. Probably not.
+  texture: exhaustion
+  rationale: Energy depletion as the abandonment mechanism; the "probably
+    not" undercuts the surface "maybe later".
+
+- title: Displaced by what came next
+  body: The project that ate this one has been alive for six months.
+    There's no room left for the older question, and honestly the new
+    one is better. Filing this under things that pointed somewhere.
+  texture: displacement
+  rationale: Replacement by a stronger pull; abandonment by displacement
+    rather than failure.
+
+- title: The air went out of it
+  body: I was excited about this for about a week and then the air went
+    out of it. I keep waiting for the energy to come back. It hasn't.
+    I'm starting to think the energy wasn't about this in the first place.
+  texture: deflation
+  rationale: Deflation pattern; the initial charge was misattributed
+    and the work itself was never the source.
+
+- title: Indefinitely postponed
+  body: I keep telling myself I'll come back to this when I have time
+    and the truthful version of that sentence is "when I have time" is
+    a euphemism for "never". I'm allowed to just say I'm not doing this.
+  texture: postponement
+  rationale: Indefinite postponement reframed as abandonment; the
+    self-honesty signal ("the truthful version") is diagnostic.
+
+- title: Walked away without noticing
+  body: At some point I stopped working on this and I can't point to
+    when. There was no decision, no moment, just the gap between the
+    last entry and now. The walking-away happened in the spaces between
+    the notes.
+  texture: quiet-walk-away
+  rationale: Absence-by-default; the abandonment is visible only in the
+    silence between entries, not in any explicit statement.
+
+- title: The question dissolved
+  body: I went looking for the original question and I couldn't find it.
+    Not because I lost the notes — they're right here — but because the
+    question doesn't feel urgent anymore. Whatever shape it had has
+    dissolved into the surrounding life.
+  texture: drifting
+  rationale: The question itself loses coherence; abandonment by
+    dissolution rather than decision.
+
+- title: I keep promising I'll get back to it
+  body: Three times this month I've told someone I'll get back to this
+    project. Each time I meant it less. I'm not going to. The promise
+    was performance, and the performance is the only part of this still
+    alive.
+  texture: postponement
+  rationale: Honest naming of the avoidance pattern; the promise itself
+    is recognized as the residue.
+
+- title: It belonged to a self I'm not anymore
+  body: Re-reading the early notes feels like reading someone else.
+    The voice is recognizable but the urgency is alien. I'm not going
+    to finish what that version started. They can have the credit;
+    I have other work.
+  texture: identity-drift
+  rationale: Authorial drift over time; the past self is named as
+    distinct, and the present self releases the work to them.
+
+- title: Started something else mid-sentence
+  body: I'm three paragraphs into an essay about this and I just opened
+    a new document for something completely unrelated. That tells me
+    where my actual attention is. The essay can stay where it is.
+  texture: displacement
+  rationale: In-the-moment displacement; the act of switching documents
+    is itself the abandonment signal.
+
+- title: I'm done pretending this is alive
+  body: I've been treating this like a live project for months when it
+    clearly isn't. Every time I update the status I'm performing for
+    no one. Calling it: this is compost. There's something in here worth
+    keeping but it isn't a project anymore.
+  texture: releasing
+  rationale: Explicit reframing from "active" to "compost"; names the
+    performance and the release in the same breath. Closest to an
+    intentional compost-tagging by the user.

--- a/creek-tools/docs/emergence.md
+++ b/creek-tools/docs/emergence.md
@@ -67,19 +67,34 @@ Output: `10-Liminal/Synchronicities/<id>.md` linking the pair, the cosine score,
 
 ## §10.4 — Compost Tracking
 
-`CompostTracker` surfaces threads and projects that have died or been abandoned and writes a compost note that **preserves** rather than deletes. Triggers:
+`CompostTracker` surfaces threads, fragments, and projects that have died or been abandoned and writes a compost note that **preserves** rather than deletes. Three detection paths:
 
-- A `Thread.status` transitions to `resolved`.
-- Fragments reference abandoned projects (heuristic: fragments tagged `abandoned`, `let-go`, or referencing dormant threads).
+1. **Thread dormancy** — a `Thread.status` is `resolved`, or `last_seen` is older than `dormancy_days` (180 by default).
+2. **Fragment abandonment (FEAT-018)** — an embedding-similarity gate against curated exemplars (`creek/generate/exemplars/compost.yaml`) followed by an optional LLM verifier. Replaces the legacy five-phrase `_ABANDONMENT_KEYWORDS` regex with a semantic surface diverse enough to recognize abandonment in the operator's own voice. The verifier returns `yes` / `no` / `ambiguous`; ambiguous verdicts route to `10-Liminal/Compost/Review/` for manual triage rather than the canonical compost folder.
+3. **Project silence** — a tag appears in at least `project_min_fragments` fragments but has not been mentioned for more than `project_gap_days`.
+
+Privacy: intimate-tier fragments are skipped by default (never sent to the embedding gate or the verifier), respecting the same policy as `creek.classify.privacy_filter`. Paradox-tagged fragments are skipped too — paradoxes are contradiction-holding notes by design, not compost candidates.
+
+Configuration lives under `compost:` in `creek_config.yaml`:
+
+```yaml
+compost:
+  embedding_threshold: 0.6       # cosine floor for verifier handoff
+  llm_verification: true         # set false for embedding-only acceptance
+  review_queue_relpath: "10-Liminal/Compost/Review"
+  skip_paradox: true
+  exemplars_relpath: null        # null → packaged default
+```
 
 The compost note records:
 
 - **What the idea was** — title plus one-paragraph summary.
-- **Why it was abandoned** — extracted from referencing fragments when explicit; left as a prompt otherwise.
+- **Why it composted** — the verifier's one-sentence reasoning (or the embedding similarity, when the verifier is disabled).
 - **What energy / insight it contained that may still be alive** — unresolved questions, active frequencies.
 - **Links to referencing fragments** — wiki-links so the compost stays reachable.
+- **Verifier metadata** — `embedding_similarity` and `verifier_reasoning` round-trip into frontmatter so the operator can audit decisions later.
 
-Output: `10-Liminal/Compost/<id>.md`. CLI: `creek report --type compost`.
+Output: `10-Liminal/Compost/<id>.md` (canonical) or `10-Liminal/Compost/Review/<id>.md` (ambiguous, awaiting triage). CLI: `creek report --type compost`. Calibration: `creek compost calibrate [--fixture FIXTURE.yaml]` (FEAT-018; full fixture-driven scoring lands once a real labelled set is collected).
 
 ---
 

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -104,6 +104,7 @@ include = ["creek", "creek.*", "creek_mcp", "creek_mcp.*"]
 [tool.setuptools.package-data]
 "creek.templates" = ["**/*", "**/.gitkeep"]
 "creek.classify.examples" = ["*.yaml"]
+"creek.generate.exemplars" = ["*.yaml"]
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/creek-tools/tests/test_compost.py
+++ b/creek-tools/tests/test_compost.py
@@ -14,12 +14,16 @@ import frontmatter
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 from creek.generate.compost import (
-    ABANDONMENT_KEYWORDS,
     CompostCandidate,
     CompostTracker,
+)
+from creek.generate.compost_verifier import (
+    CompostVerdict,
+    CompostVerifierResult,
 )
 from creek.models import (
     Confidence,
@@ -28,11 +32,60 @@ from creek.models import (
     Frequency,
     FrequencyClassification,
     PraxisPotential,
+    PrivacyTier,
     SourcePlatform,
     Thread,
     ThreadStatus,
     VoiceClassification,
 )
+
+
+class _StubVerifier:
+    """Deterministic :class:`SupportsVerifyCompost` for tests.
+
+    Maps fragment titles to a fixed verdict via the ``responses``
+    mapping. Unmapped titles default to ``yes`` so tests that only
+    care about the embedding gate need not enumerate them.
+    """
+
+    def __init__(
+        self,
+        responses: dict[str, CompostVerifierResult] | None = None,
+        default: CompostVerdict = CompostVerdict.YES,
+    ) -> None:
+        self.responses = responses or {}
+        self.default = default
+        self.calls: list[tuple[str, str]] = []
+
+    def verify(self, *, title: str, body: str) -> CompostVerifierResult:
+        """Record the call and return the configured verdict."""
+        self.calls.append((title, body))
+        if title in self.responses:
+            return self.responses[title]
+        return CompostVerifierResult(verdict=self.default, reasoning="stub")
+
+
+def _high_similarity(_text: str) -> float:
+    """Similarity stub that always clears the default 0.6 threshold."""
+    return 0.95
+
+
+def _low_similarity(_text: str) -> float:
+    """Similarity stub that always falls below the default threshold."""
+    return 0.1
+
+
+def _similarity_by_title(scores: dict[str, float]) -> Callable[[str], float]:
+    """Return a similarity fn that maps title substrings to scores."""
+
+    def _fn(text: str) -> float:
+        for token, value in scores.items():
+            if token in text:
+                return value
+        return 0.0
+
+    return _fn
+
 
 # ---- Fixtures ----
 
@@ -71,6 +124,7 @@ def _fragment(
     praxis_potential: PraxisPotential = PraxisPotential.NONE,
     threads: list[str] | None = None,
     tags: list[str] | None = None,
+    privacy_tier: PrivacyTier = PrivacyTier.UNCLASSIFIED,
 ) -> Fragment:
     """Build a minimal fragment for testing."""
     return Fragment(
@@ -83,6 +137,7 @@ def _fragment(
         praxis_potential=praxis_potential,
         threads=threads or [],
         tags=tags or [],
+        privacy_tier=privacy_tier,
     )
 
 
@@ -131,35 +186,6 @@ def active_thread() -> Thread:
     )
 
 
-# ---- ABANDONMENT_KEYWORDS ----
-
-
-class TestAbandonmentKeywords:
-    """Ensure the canonical keyword list meets issue spec."""
-
-    def test_keywords_is_nonempty_tuple(self) -> None:
-        """ABANDONMENT_KEYWORDS should be a non-empty tuple of strings."""
-        assert isinstance(ABANDONMENT_KEYWORDS, tuple)
-        assert len(ABANDONMENT_KEYWORDS) > 0
-
-    def test_keywords_are_lowercase(self) -> None:
-        """All keywords must be lowercase (we match case-insensitively)."""
-        for keyword in ABANDONMENT_KEYWORDS:
-            assert keyword == keyword.lower()
-
-    def test_required_keywords_present(self) -> None:
-        """The keywords listed in the issue spec must be present."""
-        required = (
-            "gave up on",
-            "abandoned",
-            "never finished",
-            "put aside",
-            "shelved",
-        )
-        for keyword in required:
-            assert keyword in ABANDONMENT_KEYWORDS
-
-
 # ---- CompostTracker.detect_compost_candidates ----
 
 
@@ -195,33 +221,170 @@ class TestDetectCompostCandidates:
         thread_ids = {c.source_id for c in candidates}
         assert active_thread.id not in thread_ids
 
-    def test_keyword_fragment_detected(
+    def test_default_tracker_skips_fragment_detection(
         self,
         tracker: CompostTracker,
     ) -> None:
-        """Fragments whose title contains an abandonment keyword surface."""
+        """A tracker built without ``similarity_fn`` runs thread + project only."""
         frag = _fragment(
             frag_id="frag-abandon1",
-            title="I finally gave up on the novel",
+            title="I finally let go of the novel",
             created=datetime(2025, 6, 1, 8, 0, 0),
         )
         candidates = tracker.detect_compost_candidates([], [frag])
-        keyword_hits = [c for c in candidates if c.source_type == "fragment"]
-        assert any(c.source_id == frag.id for c in keyword_hits)
-        assert "gave up on" in keyword_hits[0].matched_keywords
+        assert [c for c in candidates if c.source_type == "fragment"] == []
 
-    def test_fragment_without_keyword_ignored(
+    def test_embedding_gate_accepts_above_threshold(
         self,
-        tracker: CompostTracker,
+        reference_now: datetime,
     ) -> None:
-        """Fragments without abandonment keywords should not surface."""
+        """Fragments clearing the embedding floor become compost candidates."""
+        tracker = CompostTracker(now=reference_now, similarity_fn=_high_similarity)
+        frag = _fragment(
+            frag_id="frag-let-go",
+            title="Letting this thread go",
+            created=datetime(2025, 6, 1, 8, 0, 0),
+        )
+        candidates = tracker.detect_compost_candidates([], [frag])
+        fragment_hits = [c for c in candidates if c.source_type == "fragment"]
+        assert any(c.source_id == frag.id for c in fragment_hits)
+        assert fragment_hits[0].similarity == pytest.approx(0.95)
+
+    def test_embedding_gate_rejects_below_threshold(
+        self,
+        reference_now: datetime,
+    ) -> None:
+        """Fragments below the embedding floor are filtered out."""
+        tracker = CompostTracker(now=reference_now, similarity_fn=_low_similarity)
         frag = _fragment(
             frag_id="frag-neutral1",
             title="Notes on a productive morning",
             created=datetime(2025, 6, 1, 8, 0, 0),
         )
         candidates = tracker.detect_compost_candidates([], [frag])
-        assert [c for c in candidates if c.source_id == frag.id] == []
+        assert [c for c in candidates if c.source_type == "fragment"] == []
+
+    def test_verifier_no_verdict_drops_candidate(
+        self,
+        reference_now: datetime,
+    ) -> None:
+        """A ``no`` verifier verdict suppresses an above-threshold candidate."""
+        verifier = _StubVerifier(default=CompostVerdict.NO)
+        tracker = CompostTracker(
+            now=reference_now,
+            similarity_fn=_high_similarity,
+            verifier=verifier,
+        )
+        frag = _fragment(
+            frag_id="frag-false-positive",
+            title="This passage borrows the language of release",
+            created=datetime(2025, 6, 1, 8, 0, 0),
+        )
+        candidates = tracker.detect_compost_candidates([], [frag])
+        assert [c for c in candidates if c.source_type == "fragment"] == []
+        assert verifier.calls == [(frag.title, "")]
+
+    def test_verifier_ambiguous_routes_to_review(
+        self,
+        reference_now: datetime,
+    ) -> None:
+        """An ``ambiguous`` verifier verdict sets ``for_review``."""
+        ambiguous = CompostVerifierResult(
+            verdict=CompostVerdict.AMBIGUOUS,
+            reasoning="Reader could plausibly call this a pause, not abandonment.",
+        )
+        verifier = _StubVerifier(
+            responses={"Pausing or composting?": ambiguous},
+        )
+        tracker = CompostTracker(
+            now=reference_now,
+            similarity_fn=_high_similarity,
+            verifier=verifier,
+        )
+        frag = _fragment(
+            frag_id="frag-pause",
+            title="Pausing or composting?",
+            created=datetime(2025, 6, 1, 8, 0, 0),
+        )
+        candidates = tracker.detect_compost_candidates([], [frag])
+        fragment_hits = [c for c in candidates if c.source_type == "fragment"]
+        assert len(fragment_hits) == 1
+        assert fragment_hits[0].for_review is True
+        assert fragment_hits[0].verifier_reasoning == ambiguous.reasoning
+
+    def test_paradox_fragment_skipped(
+        self,
+        reference_now: datetime,
+    ) -> None:
+        """Paradox-tagged fragments never reach the embedding gate."""
+        called: list[str] = []
+
+        def _record(text: str) -> float:
+            called.append(text)
+            return 0.95
+
+        tracker = CompostTracker(now=reference_now, similarity_fn=_record)
+        frag = _fragment(
+            frag_id="frag-paradox",
+            title="The thread holds two truths",
+            created=datetime(2025, 6, 1, 8, 0, 0),
+            tags=["paradox"],
+        )
+        candidates = tracker.detect_compost_candidates([], [frag])
+        assert candidates == []
+        assert called == []
+
+    def test_intimate_fragment_skipped(
+        self,
+        reference_now: datetime,
+    ) -> None:
+        """Intimate fragments never reach the embedding gate (or the LLM)."""
+        verifier = _StubVerifier()
+        tracker = CompostTracker(
+            now=reference_now,
+            similarity_fn=_high_similarity,
+            verifier=verifier,
+        )
+        frag = _fragment(
+            frag_id="frag-intimate",
+            title="A private letting-go",
+            created=datetime(2025, 6, 1, 8, 0, 0),
+            privacy_tier=PrivacyTier.INTIMATE,
+        )
+        candidates = tracker.detect_compost_candidates([], [frag])
+        assert candidates == []
+        assert verifier.calls == []
+
+    def test_fragment_body_passed_to_similarity_and_verifier(
+        self,
+        reference_now: datetime,
+    ) -> None:
+        """When bodies are supplied they reach both stages of the pipeline."""
+        seen: list[str] = []
+
+        def _sim(text: str) -> float:
+            seen.append(text)
+            return 0.9
+
+        verifier = _StubVerifier()
+        tracker = CompostTracker(
+            now=reference_now,
+            similarity_fn=_sim,
+            verifier=verifier,
+        )
+        frag = _fragment(
+            frag_id="frag-with-body",
+            title="The air went out of it",
+            created=datetime(2025, 6, 1, 8, 0, 0),
+        )
+        body = "Three weeks of cold and the room feels empty."
+        tracker.detect_compost_candidates(
+            [],
+            [frag],
+            fragment_bodies={frag.id: body},
+        )
+        assert seen == [f"{frag.title}\n{body}"]
+        assert verifier.calls == [(frag.title, body)]
 
     def test_disappeared_project_detected(
         self,
@@ -352,7 +515,6 @@ class TestCreateCompostNote:
             reason="Dormant for 244 days",
             fragment_ids=["frag-1", "frag-2"],
             energy_fragment_ids=["frag-1"],
-            matched_keywords=[],
         )
         path = tracker.create_compost_note(candidate, vault_path)
         assert path.parent == vault_path / "10-Liminal" / "Compost"
@@ -372,7 +534,6 @@ class TestCreateCompostNote:
             reason="Dormant for 244 days",
             fragment_ids=["frag-1", "frag-2"],
             energy_fragment_ids=["frag-1"],
-            matched_keywords=[],
         )
         path = tracker.create_compost_note(candidate, vault_path)
         post = frontmatter.load(str(path))
@@ -395,7 +556,6 @@ class TestCreateCompostNote:
             reason="Dormant for 244 days",
             fragment_ids=["frag-1"],
             energy_fragment_ids=["frag-1"],
-            matched_keywords=[],
         )
         path = tracker.create_compost_note(candidate, vault_path)
         body = frontmatter.load(str(path)).content
@@ -416,7 +576,6 @@ class TestCreateCompostNote:
             reason="Dormant",
             fragment_ids=["frag-1", "frag-2"],
             energy_fragment_ids=["frag-1"],
-            matched_keywords=[],
             energy_excerpts=["Key insight about fermentation"],
         )
         path = tracker.create_compost_note(candidate, vault_path)
@@ -437,7 +596,6 @@ class TestCreateCompostNote:
             reason="Resolved",
             fragment_ids=[],
             energy_fragment_ids=[],
-            matched_keywords=[],
         )
         path = tracker.create_compost_note(candidate, vault_path)
         post = frontmatter.load(str(path))
@@ -457,7 +615,6 @@ class TestCreateCompostNote:
             reason="",
             fragment_ids=["frag-a"],
             energy_fragment_ids=[],
-            matched_keywords=[],
         )
         path = tracker.create_compost_note(candidate, vault_path)
         body = frontmatter.load(str(path)).content
@@ -472,16 +629,19 @@ class TestCreateCompostNote:
         candidate = CompostCandidate(
             source_type="fragment",
             source_id="frag-abandon",
-            title="I finally gave up on the novel",
-            reason="Abandonment keyword: gave up on",
+            title="I finally let go of the novel",
+            reason="Embedding-similarity 0.91 + verifier yes",
             fragment_ids=["frag-abandon"],
             energy_fragment_ids=[],
-            matched_keywords=["gave up on"],
+            similarity=0.91,
+            verifier_reasoning="Self-honest naming of a release.",
         )
         path = tracker.create_compost_note(candidate, vault_path)
         post = frontmatter.load(str(path))
         assert "original_thread" not in post.metadata
         assert post["original_fragment"] == "[[frag-abandon]]"
+        assert post["embedding_similarity"] == pytest.approx(0.91)
+        assert post["verifier_reasoning"] == "Self-honest naming of a release."
 
 
 # ---- CompostTracker.generate_compost_report ----
@@ -638,7 +798,6 @@ class TestProjectCandidateNote:
             reason="Project silent for 400 days",
             fragment_ids=["frag-a", "frag-b"],
             energy_fragment_ids=[],
-            matched_keywords=[],
         )
         path = tracker.create_compost_note(candidate, vault_path)
         post = frontmatter.load(str(path))
@@ -659,30 +818,54 @@ class TestProjectCandidateNote:
             reason="Resolved",
             fragment_ids=[],
             energy_fragment_ids=[],
-            matched_keywords=[],
         )
         path = tracker.create_compost_note(candidate, vault_path)
         body = frontmatter.load(str(path)).content
         assert "_No related fragments were recorded._" in body
 
-    def test_matched_keywords_persist_in_frontmatter(
+    def test_similarity_and_reasoning_persist_in_frontmatter(
         self,
         tracker: CompostTracker,
         vault_path: Path,
     ) -> None:
-        """matched_keywords on a candidate must round-trip into frontmatter."""
+        """Embedding similarity + verifier reasoning round-trip via frontmatter."""
         candidate = CompostCandidate(
             source_type="fragment",
-            source_id="frag-keyword",
-            title="abandoned plans",
-            reason="Abandonment keyword: abandoned",
-            fragment_ids=["frag-keyword"],
+            source_id="frag-released",
+            title="Releasing the project quietly",
+            reason="Verifier: clear release statement (similarity 0.82)",
+            fragment_ids=["frag-released"],
             energy_fragment_ids=[],
-            matched_keywords=["abandoned"],
+            similarity=0.82,
+            verifier_reasoning="Clear release statement.",
         )
         path = tracker.create_compost_note(candidate, vault_path)
         post = frontmatter.load(str(path))
-        assert post["matched_keywords"] == ["abandoned"]
+        assert post["embedding_similarity"] == pytest.approx(0.82)
+        assert post["verifier_reasoning"] == "Clear release statement."
+
+    def test_ambiguous_candidate_routes_to_review_queue(
+        self,
+        tracker: CompostTracker,
+        vault_path: Path,
+    ) -> None:
+        """``for_review`` candidates land in the review subdirectory."""
+        candidate = CompostCandidate(
+            source_type="fragment",
+            source_id="frag-maybe",
+            title="Pausing or composting?",
+            reason="Verifier ambiguous (similarity 0.71)",
+            fragment_ids=["frag-maybe"],
+            energy_fragment_ids=[],
+            similarity=0.71,
+            verifier_reasoning="Could be a pause, could be a release.",
+            for_review=True,
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        assert path.parent == vault_path / "10-Liminal" / "Compost" / "Review"
+        post = frontmatter.load(str(path))
+        tags = post.get("tags") or []
+        assert "compost-review" in tags
 
     def test_title_with_special_chars_sanitized(
         self,
@@ -697,7 +880,6 @@ class TestProjectCandidateNote:
             reason="Resolved",
             fragment_ids=[],
             energy_fragment_ids=[],
-            matched_keywords=[],
         )
         path = tracker.create_compost_note(candidate, vault_path)
         assert path.exists()

--- a/creek-tools/tests/test_compost_embedding.py
+++ b/creek-tools/tests/test_compost_embedding.py
@@ -1,0 +1,165 @@
+"""Tests for ``creek.generate.compost_embedding`` (FEAT-018).
+
+Covers exemplar loading and the cosine-similarity closure factory.
+The factory is tested against an in-memory fake ``EmbeddingLinker``
+to avoid pulling sentence-transformers into the unit-test runtime.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.generate.compost_embedding import (
+    PACKAGED_EXEMPLARS_PATH,
+    CompostExemplar,
+    load_exemplars,
+    make_similarity_fn,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _FakeLinker:
+    """Minimal embedding-linker stand-in for similarity-fn tests.
+
+    Returns deterministic vectors based on a substring → coordinate
+    table so tests can shape the cosine-similarity landscape without
+    importing torch.
+    """
+
+    def __init__(self, vectors: dict[str, list[float]]) -> None:
+        self._vectors = vectors
+        self.calls: list[str] = []
+
+    def generate_embedding(self, text: str) -> list[float]:
+        """Return the configured vector for whichever key occurs in *text*."""
+        self.calls.append(text)
+        for key, vector in self._vectors.items():
+            if key in text:
+                return vector
+        return [0.0, 0.0, 0.0]
+
+
+class TestLoadExemplars:
+    """Loading and validating the exemplar YAML."""
+
+    def test_packaged_default_loads(self) -> None:
+        """The packaged exemplar set parses without error and is non-empty."""
+        exemplars = load_exemplars()
+        assert len(exemplars) >= 1
+        assert all(isinstance(e, CompostExemplar) for e in exemplars)
+
+    def test_packaged_path_constant_points_inside_package(self) -> None:
+        """The package-relative constant resolves to a real file on disk."""
+        assert PACKAGED_EXEMPLARS_PATH.exists()
+        assert PACKAGED_EXEMPLARS_PATH.name == "compost.yaml"
+
+    def test_custom_path_loads(self, tmp_path: Path) -> None:
+        """A user-provided YAML file is parsed and validated."""
+        target = tmp_path / "custom.yaml"
+        target.write_text(
+            "- title: Quiet release\n"
+            "  body: I let this one go without drama.\n"
+            "  texture: releasing\n"
+            "  rationale: Conscious release.\n",
+            encoding="utf-8",
+        )
+        exemplars = load_exemplars(target)
+        assert len(exemplars) == 1
+        assert exemplars[0].title == "Quiet release"
+        assert exemplars[0].texture == "releasing"
+
+    def test_missing_file_raises(self, tmp_path: Path) -> None:
+        """A non-existent path raises ``FileNotFoundError``."""
+        with pytest.raises(FileNotFoundError):
+            load_exemplars(tmp_path / "missing.yaml")
+
+    def test_empty_yaml_rejected(self, tmp_path: Path) -> None:
+        """An empty YAML file raises ``ValueError``."""
+        target = tmp_path / "empty.yaml"
+        target.write_text("", encoding="utf-8")
+        with pytest.raises(ValueError, match="non-empty list"):
+            load_exemplars(target)
+
+    def test_non_list_yaml_rejected(self, tmp_path: Path) -> None:
+        """A YAML mapping (not list) raises ``ValueError``."""
+        target = tmp_path / "wrong-shape.yaml"
+        target.write_text("title: not a list\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="non-empty list"):
+            load_exemplars(target)
+
+    def test_missing_key_rejected(self, tmp_path: Path) -> None:
+        """An entry missing a required key raises ``ValueError``."""
+        target = tmp_path / "incomplete.yaml"
+        target.write_text(
+            "- title: Only title\n  body: x\n  texture: y\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="missing required keys"):
+            load_exemplars(target)
+
+
+class TestMakeSimilarityFn:
+    """Behaviour of the similarity-closure factory."""
+
+    @staticmethod
+    def _exemplar(body: str) -> CompostExemplar:
+        return CompostExemplar(
+            title="x",
+            body=body,
+            texture="releasing",
+            rationale="r",
+        )
+
+    def test_empty_text_returns_zero(self) -> None:
+        """Blank input short-circuits to 0.0 without encoding."""
+        linker = _FakeLinker({"any": [1.0, 0.0, 0.0]})
+        fn = make_similarity_fn([self._exemplar("any")], linker)
+        assert fn("") == 0.0
+        assert fn("   ") == 0.0
+        assert linker.calls == []
+
+    def test_identical_text_returns_one(self) -> None:
+        """A fragment matching an exemplar returns cosine 1.0."""
+        linker = _FakeLinker({"release": [1.0, 0.0]})
+        fn = make_similarity_fn([self._exemplar("release")], linker)
+        assert fn("release") == pytest.approx(1.0)
+
+    def test_orthogonal_text_returns_zero(self) -> None:
+        """Orthogonal vectors yield 0.0 similarity."""
+        linker = _FakeLinker({"release": [1.0, 0.0], "neutral": [0.0, 1.0]})
+        fn = make_similarity_fn([self._exemplar("release")], linker)
+        assert fn("neutral") == pytest.approx(0.0)
+
+    def test_max_over_exemplars_wins(self) -> None:
+        """The maximum similarity across all exemplars is returned."""
+        # Fragment vector is closer to the SECOND exemplar; the max-similarity
+        # contract requires the function to pick the closer one rather than
+        # the iteration-first one.
+        linker = _FakeLinker(
+            {
+                "AAA": [1.0, 0.0],
+                "BBB": [0.0, 1.0],
+                "fragment-text": [0.1, 1.0],
+            },
+        )
+        exemplars = [self._exemplar("AAA"), self._exemplar("BBB")]
+        fn = make_similarity_fn(exemplars, linker)
+        score = fn("fragment-text")
+        # cos((0.1, 1.0), (0.0, 1.0)) = 1.0 / sqrt(1.01)
+        assert score == pytest.approx(1.0 / (1.01**0.5), abs=1e-6)
+
+    def test_exemplar_vectors_cached(self) -> None:
+        """Exemplar bodies are encoded only on the first call."""
+        linker = _FakeLinker({"any": [1.0]})
+        fn = make_similarity_fn([self._exemplar("any")], linker)
+        fn("any")
+        fn("any")
+        # 1 encode for the exemplar (first call) + 2 encodes for the fragment
+        assert sum(1 for c in linker.calls if c == "any") >= 2
+        # The exemplar must not be re-encoded on each invocation
+        exemplar_encodes = [c for c in linker.calls if c == "any"]
+        assert len(exemplar_encodes) == 3

--- a/creek-tools/tests/test_compost_embedding.py
+++ b/creek-tools/tests/test_compost_embedding.py
@@ -57,6 +57,39 @@ class TestLoadExemplars:
         assert PACKAGED_EXEMPLARS_PATH.exists()
         assert PACKAGED_EXEMPLARS_PATH.name == "compost.yaml"
 
+    def test_packaged_textures_match_declared_vocabulary(self) -> None:
+        """Every exemplar's texture must come from the documented vocabulary.
+
+        The YAML header comment in ``compost.yaml`` pins the allowed
+        textures. Drift between the header and the entries would
+        silently corrupt downstream texture-aware tooling (e.g.
+        ``creek compost calibrate``). This test fails closed.
+        """
+        allowed = {
+            "circling",
+            "releasing",
+            "drifting",
+            "identity-drift",
+            "exhaustion",
+            "displacement",
+            "deflation",
+            "postponement",
+            "quiet-walk-away",
+        }
+        exemplars = load_exemplars()
+        violations = [
+            (e.title, e.texture) for e in exemplars if e.texture not in allowed
+        ]
+        assert violations == [], (
+            f"Exemplars carry textures outside the declared vocabulary: {violations}"
+        )
+
+    def test_packaged_titles_are_unique(self) -> None:
+        """Duplicate titles would mask curation bugs; titles must be distinct."""
+        exemplars = load_exemplars()
+        titles = [e.title for e in exemplars]
+        assert len(titles) == len(set(titles)), "Duplicate exemplar titles detected."
+
     def test_custom_path_loads(self, tmp_path: Path) -> None:
         """A user-provided YAML file is parsed and validated."""
         target = tmp_path / "custom.yaml"

--- a/creek-tools/tests/test_compost_verifier.py
+++ b/creek-tools/tests/test_compost_verifier.py
@@ -1,0 +1,138 @@
+"""Tests for ``creek.generate.compost_verifier`` (FEAT-018 stage 2).
+
+Covers response parsing and the :class:`LLMCompostVerifier` adapter
+that wraps :class:`creek.classify.llm.AnthropicProvider`. The
+:class:`AnthropicProvider` is stubbed with a minimal fake to keep the
+unit test free of network and env-var prerequisites.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from creek.generate.compost_verifier import (
+    CompostVerdict,
+    CompostVerifierResult,
+    LLMCompostVerifier,
+    _parse_verifier_response,
+)
+
+
+class _FakeProvider:
+    """Stand-in for :class:`AnthropicProvider` exposing only ``call``."""
+
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls: list[str] = []
+
+    def call(self, prompt: str) -> str:
+        """Record the prompt and return the canned response."""
+        self.calls.append(prompt)
+        return self.response
+
+
+class TestParseVerifierResponse:
+    """Parser for the three-line LLM response contract."""
+
+    def test_well_formed_yes(self) -> None:
+        """A well-formed ``yes`` response parses into a YES verdict."""
+        text = "VERDICT: yes\nREASONING: Clear release statement."
+        result = _parse_verifier_response(text)
+        assert result.verdict == CompostVerdict.YES
+        assert result.reasoning == "Clear release statement."
+
+    def test_well_formed_no(self) -> None:
+        """A well-formed ``no`` response parses into a NO verdict."""
+        text = "VERDICT: no\nREASONING: Author is on a planned break."
+        result = _parse_verifier_response(text)
+        assert result.verdict == CompostVerdict.NO
+
+    def test_well_formed_ambiguous(self) -> None:
+        """A well-formed ``ambiguous`` response parses into AMBIGUOUS."""
+        text = "VERDICT: ambiguous\nREASONING: Could read either way."
+        result = _parse_verifier_response(text)
+        assert result.verdict == CompostVerdict.AMBIGUOUS
+
+    def test_case_insensitive(self) -> None:
+        """Verdict and reasoning labels match case-insensitively."""
+        text = "verdict: YES\nreasoning: ok"
+        result = _parse_verifier_response(text)
+        assert result.verdict == CompostVerdict.YES
+        assert result.reasoning == "ok"
+
+    def test_extra_whitespace_tolerated(self) -> None:
+        """Leading/trailing whitespace on lines is stripped."""
+        text = "   VERDICT:   no   \n   REASONING:   nope   "
+        result = _parse_verifier_response(text)
+        assert result.verdict == CompostVerdict.NO
+        assert result.reasoning == "nope"
+
+    def test_missing_reasoning_uses_fallback(self) -> None:
+        """A response with only ``VERDICT:`` gets a placeholder reason."""
+        text = "VERDICT: yes"
+        result = _parse_verifier_response(text)
+        assert result.verdict == CompostVerdict.YES
+        assert result.reasoning == "(no reason)"
+
+    def test_unparseable_routes_to_ambiguous(self) -> None:
+        """A response with no VERDICT line is treated as AMBIGUOUS."""
+        text = "I'm sorry, I can't help with that."
+        result = _parse_verifier_response(text)
+        assert result.verdict == CompostVerdict.AMBIGUOUS
+        assert "Unparseable" in result.reasoning
+
+    def test_invalid_verdict_routes_to_ambiguous(self) -> None:
+        """A VERDICT line with a non-canonical value is treated as AMBIGUOUS."""
+        text = "VERDICT: maybe\nREASONING: not sure"
+        result = _parse_verifier_response(text)
+        assert result.verdict == CompostVerdict.AMBIGUOUS
+
+
+class TestLLMCompostVerifier:
+    """End-to-end behaviour of the LLM-backed verifier."""
+
+    def test_verify_returns_parsed_result(self) -> None:
+        """``verify`` sends a prompt and returns the parsed response."""
+        provider = _FakeProvider("VERDICT: yes\nREASONING: clear release")
+        verifier = LLMCompostVerifier(provider)  # type: ignore[arg-type]
+        result = verifier.verify(title="Letting go", body="It's over.")
+        assert isinstance(result, CompostVerifierResult)
+        assert result.verdict == CompostVerdict.YES
+        assert result.reasoning == "clear release"
+
+    def test_verify_includes_title_and_body_in_prompt(self) -> None:
+        """The prompt embeds both fields verbatim for verifier context."""
+        provider = _FakeProvider("VERDICT: no\nREASONING: x")
+        verifier = LLMCompostVerifier(provider)  # type: ignore[arg-type]
+        verifier.verify(title="My title", body="My body text.")
+        assert len(provider.calls) == 1
+        sent = provider.calls[0]
+        assert "My title" in sent
+        assert "My body text." in sent
+
+    def test_verify_handles_empty_title(self) -> None:
+        """An empty title is replaced with a placeholder so the prompt is valid."""
+        provider = _FakeProvider("VERDICT: yes\nREASONING: ok")
+        verifier = LLMCompostVerifier(provider)  # type: ignore[arg-type]
+        verifier.verify(title="", body="body")
+        assert "(untitled)" in provider.calls[0]
+
+    def test_malformed_response_routes_to_ambiguous(self) -> None:
+        """A malformed LLM response yields AMBIGUOUS without raising."""
+        provider = _FakeProvider("hello there friend")
+        verifier = LLMCompostVerifier(provider)  # type: ignore[arg-type]
+        result = verifier.verify(title="t", body="b")
+        assert result.verdict == CompostVerdict.AMBIGUOUS
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("VERDICT: yes\nREASONING: a", CompostVerdict.YES),
+        ("VERDICT: no\nREASONING: b", CompostVerdict.NO),
+        ("VERDICT: ambiguous\nREASONING: c", CompostVerdict.AMBIGUOUS),
+    ],
+)
+def test_verdict_parsing_round_trip(text: str, expected: CompostVerdict) -> None:
+    """Parametrised round-trip for the three canonical verdict strings."""
+    assert _parse_verifier_response(text).verdict == expected


### PR DESCRIPTION
## Summary

Replaces the five-phrase `_ABANDONMENT_KEYWORDS` regex in `CompostTracker` with a two-stage semantic detection pipeline that recognises abandonment in the operator's own register.

- **Stage 1 — embedding gate.** Curated exemplars in `creek/generate/exemplars/compost.yaml` (14 entries across 9 abandonment textures) are loaded by `compost_embedding.make_similarity_fn`; fragments whose max cosine similarity clears `CompostConfig.embedding_threshold` (default 0.6, deliberately wide) advance to stage 2.
- **Stage 2 — LLM verifier.** `compost_verifier.LLMCompostVerifier` wraps the existing `AnthropicProvider` and returns `yes` / `no` / `ambiguous`. `yes` writes to `10-Liminal/Compost/`, `ambiguous` routes to `10-Liminal/Compost/Review/` for manual triage, `no` skips.
- **Privacy.** Intimate-tier fragments never reach the gate or the LLM. Paradox-tagged fragments are skipped — paradoxes are contradiction-holding notes by design.

## What changed

**New modules**
- `creek/generate/compost_embedding.py` — exemplar loader (YAML schema validation) and `make_similarity_fn` closure with cached exemplar vectors + cosine similarity.
- `creek/generate/compost_verifier.py` — `CompostVerdict` enum, `SupportsVerifyCompost` Protocol (mirrors the calibration seam in `creek.classify.calibration`), `LLMCompostVerifier`, three-line response parser that routes malformed LLM output to `AMBIGUOUS`.

**Config**
- `CompostConfig` in `creek/config.py`: `embedding_threshold`, `llm_verification`, `review_queue_relpath`, `skip_paradox`, `exemplars_relpath`. Wired into `CreekConfig`.

**CLI**
- `creek compost calibrate` Typer subcommand: reports loaded exemplars by texture. Fixture-driven recall/precision scoring is stubbed for a follow-up once a real labelled set exists.

**Refactor**
- `CompostTracker.__init__` takes `similarity_fn`, `verifier`, `embedding_threshold`, `skip_paradox`, `skip_intimate`.
- `detect_compost_candidates` accepts an optional `fragment_bodies` map so the gate can embed against title + body when bodies are loaded by the caller.
- `CompostCandidate` gains `similarity`, `verifier_reasoning`, `for_review`; `matched_keywords` is removed.
- Note frontmatter now carries `embedding_similarity` and `verifier_reasoning` so decisions are auditable.

**Docs**
- `docs/emergence.md` §10.4 rewritten to describe the new pipeline + config knobs.

## Test plan

- [x] `tests/test_compost_embedding.py` (12 tests): exemplar loading, validation, cosine math, vector caching.
- [x] `tests/test_compost_verifier.py` (15 tests): response parsing across well-formed/malformed/case-insensitive inputs, prompt construction, three verdict paths.
- [x] `tests/test_compost.py` (38 tests): replaced keyword tests with embedding-gate, verifier verdict, paradox-skip, intimate-skip, review-queue routing, frontmatter round-trip.
- [x] `./scripts/check-all.sh` — all 10 gates green locally (3511 tests pass, coverage 93.43%, lint / format / mypy / complexity / bandit / pip-audit all ✓).

## Follow-ups (not in this PR)

- Author a real `--fixture` calibration set from the operator's vault once a labelled corpus exists, then implement the recall/precision scoring path in `creek compost calibrate`.
- The exemplar set in `compost.yaml` is a strawman that captures *shapes* of abandonment rather than the user's exact voice. Per the design discussion: this works because embeddings match on semantic structure, and the LLM verifier owns precision; calibration replaces strawman entries with real positives over time.

https://claude.ai/code/session_017Ji1ivHGSVaZqxbZSzKndN