### PR TITLE
chore(crawdad): address FEAT-015 review nits (#234 follow-up)

### DIFF
--- a/crawdad/crawdad/composer.py
+++ b/crawdad/crawdad/composer.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger("crawdad.composer")
 
-_PARADOX_KEYWORDS = ("paradox", "paradoxes")
+PARADOX_KEYWORDS = ("paradox", "paradoxes")
 _PARADOX_RULE = (
     "Paradox rule: if any tool result names a paradox, NAME the paradox "
     "in your reply but do NOT propose resolution. Paradoxes are evidence "
@@ -136,12 +136,22 @@ def _results_block(tool_results: list[ToolResult]) -> str:
 
 
 def _mentions_paradox(results: list[ToolResult]) -> bool:
-    """Return True when any tool result body or intent mentions a paradox."""
+    """Return True when any tool result body or intent mentions a paradox.
+
+    Exported (without leading underscore via the module-level
+    :data:`PARADOX_KEYWORDS`) so :mod:`crawdad.loop` can reuse the same
+    detection rule for paradox routing. Keeping the implementation
+    here — the composer is the conceptual owner of paradox-tolerance.
+    """
     for result in results:
         haystack = f"{result.intent_type} {result.body}".lower()
-        if any(kw in haystack for kw in _PARADOX_KEYWORDS):
+        if any(kw in haystack for kw in PARADOX_KEYWORDS):
             return True
     return False
+
+
+# Public re-export for sibling modules that need the same detection rule.
+mentions_paradox = _mentions_paradox
 
 
 class SonnetComposer:

--- a/crawdad/crawdad/dispatcher.py
+++ b/crawdad/crawdad/dispatcher.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
+from crawdad.intents import PrivacyTierCeiling
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -36,12 +38,19 @@ class UnknownIntentError(RuntimeError):
 
 
 class ToolResult(BaseModel):
-    """One tool's response, threaded back through the loop."""
+    """One tool's response, threaded back through the loop.
+
+    ``privacy_tier_ceiling`` mirrors the source intent's ceiling so
+    downstream consumers (e.g. the loop's paradox-routing helper) can
+    re-authorise follow-up tool calls at the same or higher tier
+    without rediscovering the source authorization.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     intent_type: str
     body: str
+    privacy_tier_ceiling: PrivacyTierCeiling = PrivacyTierCeiling.OPEN
 
 
 class IntentDispatcher:
@@ -90,7 +99,13 @@ class IntentDispatcher:
                 raise UnknownIntentError(msg)
             body = await self._session.call_tool(intent.type, _build_arguments(intent))
             _LOGGER.debug("dispatched %s: %d chars returned", intent.type, len(body))
-            results.append(ToolResult(intent_type=intent.type, body=body))
+            results.append(
+                ToolResult(
+                    intent_type=intent.type,
+                    body=body,
+                    privacy_tier_ceiling=intent.privacy_tier_ceiling,
+                )
+            )
         return results
 
 

--- a/crawdad/crawdad/loop.py
+++ b/crawdad/crawdad/loop.py
@@ -47,7 +47,7 @@ from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, ConfigDict
 
-from crawdad.composer import ComposerFailureError
+from crawdad.composer import ComposerFailureError, mentions_paradox
 from crawdad.config import MAX_LOOP_ROUNDS
 from crawdad.dispatcher import (
     IntentDispatcher,
@@ -81,7 +81,6 @@ _COMPOSER_FAILURE_REPLY = (
     "I'm having trouble composing right now — try again in a moment."
 )
 
-_PARADOX_KEYWORDS = ("paradox", "paradoxes")
 _SAVE_TOOL_NAME = "creek.save"
 
 
@@ -204,11 +203,17 @@ class AgentLoop:
     async def _maybe_route_paradox(self, results: list[ToolResult]) -> list[ToolResult]:
         """If results mention a paradox, ensure a save call to liminal land.
 
+        The auto-injected ``creek.save`` inherits the highest
+        ``privacy_tier_ceiling`` seen across the surfacing results so
+        the save call is authorised for whatever tier the source content
+        sat at. Using a fixed OPEN ceiling would silently fail when a
+        paradox surfaced inside personal- or intimate-tier content.
+
         Returns the (possibly augmented) results list. Idempotent — if
         a ``creek.save`` was already dispatched in this turn, no extra
         call is made.
         """
-        if not _mentions_paradox(results):
+        if not mentions_paradox(results):
             return results
         if _SAVE_TOOL_NAME not in self._known_tools:
             _LOGGER.debug(
@@ -222,7 +227,7 @@ class AgentLoop:
 
         save_intent = Intent(
             type=_SAVE_TOOL_NAME,
-            privacy_tier_ceiling=PrivacyTierCeiling.OPEN,
+            privacy_tier_ceiling=_max_ceiling_from(results),
             args={"target": "paradox"},
         )
         save_response = RouterResponse(intents=[save_intent], compose=False)
@@ -235,13 +240,25 @@ class AgentLoop:
         return [*results, *saved]
 
 
-def _mentions_paradox(results: list[ToolResult]) -> bool:
-    """Return True when any result body or intent name mentions a paradox."""
+def _max_ceiling_from(results: list[ToolResult]) -> PrivacyTierCeiling:
+    """Return the most permissive ceiling observed across *results*.
+
+    Ordered low→high by the underlying enum value strings: ``all`` is
+    treated as the most permissive (it's literally the "no ceiling"
+    sentinel), then ``intimate`` → ``personal`` → ``open``. Defaults
+    to OPEN when no results carry a ceiling.
+    """
+    rank = {
+        PrivacyTierCeiling.OPEN: 0,
+        PrivacyTierCeiling.PERSONAL: 1,
+        PrivacyTierCeiling.INTIMATE: 2,
+        PrivacyTierCeiling.ALL: 3,
+    }
+    best = PrivacyTierCeiling.OPEN
     for result in results:
-        haystack = f"{result.intent_type} {result.body}".lower()
-        if any(kw in haystack for kw in _PARADOX_KEYWORDS):
-            return True
-    return False
+        if rank[result.privacy_tier_ceiling] > rank[best]:
+            best = result.privacy_tier_ceiling
+    return best
 
 
 async def run_one_turn(

--- a/crawdad/crawdad/skill_loader.py
+++ b/crawdad/crawdad/skill_loader.py
@@ -43,6 +43,9 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger("crawdad.skill_loader")
 
 _PHASE_RE = re.compile(r"phase[:\s]*\*{0,2}([a-z\-]+)", re.IGNORECASE)
+# Same shape as the captured phase slug. Used to validate caller-supplied
+# register names so path construction can't be tricked into traversal.
+_SAFE_NAME_RE = re.compile(r"^[a-z][a-z\-]*$")
 _PROMPT_SEPARATOR = "\n\n---\n\n"
 
 
@@ -125,6 +128,14 @@ def load_skills_for_session(
         if register in seen:
             continue
         seen.add(register)
+        if not _SAFE_NAME_RE.match(register):
+            # FEAT-016 will let slash commands set extra registers from
+            # user input; refuse any name that would escape the registers/
+            # subdirectory (path traversal, absolute paths, dotfiles).
+            _LOGGER.warning(
+                "ignoring register name %r — must match [a-z][a-z-]*", register
+            )
+            continue
         register_path = root / "registers" / f"{register}.SKILL.md"
         _append_if_present(collected, register_path, name=f"register:{register}")
 

--- a/crawdad/tests/test_loop.py
+++ b/crawdad/tests/test_loop.py
@@ -421,6 +421,90 @@ async def test_run_one_turn_returns_loop_outcome(
     assert outcome.kind == "composed"
 
 
+async def test_loop_paradox_save_mcp_failure_short_circuits(
+    state: SessionState, skills: VoiceSkillStack
+) -> None:
+    """An MCPUnavailableError during the paradox save returns the soft reply.
+
+    The auto-injected ``creek.save`` runs *after* the regular dispatch
+    loop terminates. If the MCP subprocess dies between the surfacing
+    call and the save, the loop must downgrade to the documented
+    unreachable-reply outcome rather than crashing.
+    """
+    router = _ScriptedRouter(
+        [
+            RouterResponse(intents=[Intent(type="creek.lint")]),
+            RouterResponse(intents=[], compose=True),
+        ]
+    )
+    session = _ScriptedSession(
+        replies={"creek.lint": "paradox detected"},
+        errors={"creek.save": MCPUnavailableError("subprocess died between calls")},
+    )
+    composer = _ScriptedComposer("(unused — should not be reached)")
+    loop = AgentLoop(
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(session),  # type: ignore[arg-type]
+        known_tools=("creek.lint", "creek.save"),
+        history=ConversationHistory(),
+        session_state=state,
+        skills=skills,
+    )
+
+    outcome = await loop.run("hi")
+
+    assert outcome.kind == "mcp_unavailable"
+    assert composer.calls == []
+
+
+async def test_loop_paradox_save_inherits_max_ceiling(
+    state: SessionState, skills: VoiceSkillStack
+) -> None:
+    """The auto-injected paradox save uses the highest ceiling from results.
+
+    Regression for review feedback: a fixed OPEN ceiling would refuse
+    saves on personal- or intimate-tier source content. The save must
+    inherit at least the highest ceiling the surfacing call used.
+    """
+    from crawdad.intents import PrivacyTierCeiling
+
+    router = _ScriptedRouter(
+        [
+            RouterResponse(
+                intents=[
+                    Intent(
+                        type="creek.lint",
+                        privacy_tier_ceiling=PrivacyTierCeiling.INTIMATE,
+                    )
+                ]
+            ),
+            RouterResponse(intents=[], compose=True),
+        ]
+    )
+    session = _ScriptedSession(
+        replies={
+            "creek.lint": "paradox detected in 03-Eddies/eddy-x",
+            "creek.save": "saved",
+        }
+    )
+    composer = _ScriptedComposer("done")
+    loop = AgentLoop(
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(session),  # type: ignore[arg-type]
+        known_tools=("creek.lint", "creek.save"),
+        history=ConversationHistory(),
+        session_state=state,
+        skills=skills,
+    )
+
+    await loop.run("anything surfacing?")
+
+    save_call = next((args for name, args in session.calls if name == "creek.save"))
+    assert save_call["privacy_tier_ceiling"] == "intimate"
+
+
 async def test_loop_records_user_and_assistant_turns(
     state: SessionState, skills: VoiceSkillStack
 ) -> None:

--- a/crawdad/tests/test_skill_loader.py
+++ b/crawdad/tests/test_skill_loader.py
@@ -126,6 +126,34 @@ def test_load_skills_handles_state_without_wavelength(
     assert any("Confessional" in body for body in bodies)
 
 
+def test_load_skills_refuses_unsafe_register_name(
+    vault_with_voice_tree: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Register names with path-separator / traversal chars are refused.
+
+    FEAT-016 will let slash commands set extra registers from user
+    input; without this guard a name like ``../../etc/passwd`` would
+    escape ``creek-skills/registers/``.
+    """
+    import logging
+
+    caplog.set_level(logging.WARNING, logger="crawdad.skill_loader")
+
+    stack = load_skills_for_session(
+        vault_path=vault_with_voice_tree,
+        state=_make_state("rising"),
+        extra_registers=("../../etc/passwd", "Praxis"),  # uppercase too
+    )
+
+    names = stack.names()
+    # voice-core + phase:rising + register:confessional only.
+    # Both invalid register names ("../..." and "Praxis") are refused.
+    assert "register:../../etc/passwd" not in names
+    assert "register:Praxis" not in names
+    assert any("must match" in record.message for record in caplog.records)
+
+
 def test_voice_skill_stack_as_prompt_context(vault_with_voice_tree: Path) -> None:
     """``as_prompt_context`` concatenates with separators for the composer prompt."""
     state = _make_state("rising")


### PR DESCRIPTION
## Summary

Follow-up to PR #234 (FEAT-015). The verdict on that PR was **COMMENTS** — no blockers — but the reviewer flagged four items worth folding into a small cleanup. This PR addresses all four.

Net diff: **+180 / -15** across 6 files. **114 tests pass** (3 new), **92.39% branch coverage**, all 7 local gates green.

## Items addressed

| # | Item | Where | Test |
|---|---|---|---|
| 1 | 🟡 **Deduplicate `_mentions_paradox` / `_PARADOX_KEYWORDS`** — identical in `composer.py` and `loop.py` was a future drift risk | `composer.py` is now the canonical owner (renamed const to public `PARADOX_KEYWORDS`); `loop.py` imports `mentions_paradox` | Existing paradox tests cover both call sites |
| 2 | 🟡 **`PrivacyTierCeiling.OPEN` for auto paradox save was wrong** — would have silently failed against personal/intimate source content per FEAT-011's write-side tier rule | `ToolResult` now carries the source intent's ceiling; `_max_ceiling_from` picks the highest observed across the surfacing results | New: `test_loop_paradox_save_inherits_max_ceiling` |
| 3 | 🟢 **`extra_registers` not validated** — FEAT-016 will let slash commands set this from user input | `skill_loader._SAFE_NAME_RE = ^[a-z][a-z\-]*$` refuses traversal / dotfile / uppercase names with a WARNING log | New: `test_load_skills_refuses_unsafe_register_name` |
| 4 | 🟢 **Test gap**: `_maybe_route_paradox` raising `MCPUnavailableError` was uncovered | Added in `loop.py` | New: `test_loop_paradox_save_mcp_failure_short_circuits` |

## Why the ceiling fix is a real correctness improvement

The MCP server's write-side rule (FEAT-011): a write tool that would create a fragment / compiled page at tier `T` requires the caller's `privacy_tier_ceiling >= T`.

A paradox surfaced via `creek.lint --privacy_tier_ceiling=intimate` exposes intimate-tier source content. Auto-saving it to `10-Liminal/Paradoxes/` with a fixed `ceiling=open` would have been **refused at the MCP boundary** — silently breaking paradox routing on exactly the cases the user most cares about (intense personal/shadow material, per the ontology).

The new behaviour: the auto-save inherits the highest ceiling observed across the surfacing results. If the round only used OPEN, the save is OPEN (back-compatible with the existing tests).

## Reference

- Parent PR: #234 — closes CrawDad v1.0 (FEAT-015).
- All four items framed as non-blocking in the parent review's verdict (`COMMENTS`).

## Test plan

- [x] `./scripts/check-all.sh` exits 0 locally — 7/7 gates green.
- [x] **114 tests pass** (3 new), **92.39% branch coverage**.
- [x] No literal model IDs outside `config.py` — the existing regression test still passes after the imports moved.
- [ ] CI green on all jobs.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VqPZsk7QWgNbeVSymTmgKG)_