### PR TITLE
feat(slash): /creek + /crawdad slash command grammars (FEAT-016)

### DIFF
--- a/crawdad/CLAUDE.md
+++ b/crawdad/CLAUDE.md
@@ -25,17 +25,21 @@ These mirror `creek-tools/CLAUDE.md` at a smaller scale:
 
 ## 2. Project overview
 
-CrawDad is a Discord bot:
+CrawDad is the Discord-side interface to a Creek vault. v1.0 is
+complete and ships:
 
-- Connects to `creek-tools-mcp` (FEAT-010) over stdio.
-- Reads `<vault>/00-Creek-Meta/State/latest.md` once at session start
-  (Graphify-style PreToolUse pattern).
-- Enforces a hard-coded user/channel allowlist — non-allowlisted users
-  get *no* response (silent ignore, per FEAT-013's personal-use
-  scoping).
-- Posts a stub reply for the wiring scaffold. FEAT-014 will swap the
-  stub for the Haiku-router + dispatcher; FEAT-015 will add the Sonnet
-  composer and 5-round loop.
+- Connection to `creek-tools-mcp` (FEAT-010/011/012) over stdio.
+- The two-LLM agent loop: Haiku router (FEAT-014) → MCP dispatcher →
+  Sonnet composer (FEAT-015), capped at 5 rounds with paradox auto-
+  routing to `10-Liminal/Paradoxes/`.
+- Voice-skill activation per session from `<vault>/creek-skills/`
+  (voice-core + phase + register).
+- Six `/crawdad` Discord slash commands (FEAT-016): `reflect`,
+  `checkin`, `surface`, `draft`, `save`, `workflow`.
+- A user + channel allowlist; non-allowlisted users get *no* response
+  (silent ignore, per FEAT-013's personal-use scoping).
+- Session-state load from `<vault>/00-Creek-Meta/State/latest.md` at
+  startup.
 
 ## 3. Layout
 
@@ -44,27 +48,20 @@ crawdad/
 ├── crawdad/                # Source package
 │   ├── __init__.py
 │   ├── bot.py              # discord.Client subclass + pure-logic handler
-│   ├── cli.py              # `crawdad run` entry point
+│   ├── cli.py              # `crawdad run` entry point + agent components
+│   ├── composer.py         # Sonnet composer (FEAT-015)
 │   ├── config.py           # Pydantic config (env secrets + YAML file)
+│   ├── dispatcher.py       # Intent → MCP tool dispatcher (FEAT-014)
+│   ├── history.py          # Conversation history with bounded truncation
+│   ├── intents.py          # Pydantic intent schema + builder
+│   ├── loop.py             # 5-round agent loop (FEAT-015)
 │   ├── mcp_client.py       # async MCP stdio wrapper
+│   ├── router.py           # Haiku intent router (FEAT-014)
+│   ├── skill_loader.py     # Voice-skill stack loader (FEAT-015)
+│   ├── slash_commands.py   # /crawdad Discord slash commands (FEAT-016)
 │   └── state.py            # load_session_state — latest.md parser
-├── tests/
-│   ├── conftest.py
-│   ├── fixtures/
-│   │   └── fake_mcp_server.py   # stdio MCP server used by client tests
-│   ├── test_bot.py
-│   ├── test_cli.py
-│   ├── test_config.py
-│   ├── test_mcp_client.py
-│   └── test_state.py
-├── scripts/
-│   ├── check-all.sh        # Run every quality gate
-│   ├── coverage.sh
-│   ├── format.sh
-│   ├── lint.sh
-│   ├── security.sh
-│   ├── test.sh
-│   └── typecheck.sh
+├── tests/                  # One test file per source module
+├── scripts/                # check-all, lint, test, etc.
 ├── docs/
 ├── CLAUDE.md
 ├── README.md

--- a/crawdad/README.md
+++ b/crawdad/README.md
@@ -2,21 +2,23 @@
 
 CrawDad is the Discord-side interface to a Creek vault. It consumes
 the creek-tools MCP surface (see `creek-tools/creek_mcp`) and answers
-Discord messages in your voice.
+Discord messages in your voice using the FEAT-015 agent loop (Haiku
+router → MCP dispatcher → Sonnet composer with voice-skill activation).
 
-This is the **FEAT-013 wiring scaffold** — the agent loop (FEAT-014:
-Haiku router + dispatcher; FEAT-015: Sonnet composer + 5-round loop)
-is not yet implemented. What ships in this PR:
+CrawDad v1.0 ships:
 
 - A `discord.py` client that connects to Discord and forwards messages
   to a pure-logic handler.
+- The two-LLM agent loop (FEAT-014 + FEAT-015) — Haiku for intent
+  extraction, Sonnet for voice-faithful composition, capped at 5
+  rounds with paradox routing to `10-Liminal/Paradoxes/`.
 - An async MCP stdio client wrapping the Anthropic `mcp` SDK.
-- A `latest.md` parser that loads the audit-report snapshot once at
-  session start.
+- Voice-skill activation per session from `<vault>/creek-skills/`.
+- The six `/crawdad` slash commands (FEAT-016): `reflect`, `checkin`,
+  `surface`, `draft`, `save`, `workflow`.
 - A user + channel allowlist; non-allowlisted callers get no response.
 - A graceful "creek-tools is unreachable" reply when the MCP
-  subprocess dies. FEAT-014 will add the exponential-backoff restart
-  loop on top.
+  subprocess dies.
 
 ## Quick start
 
@@ -44,6 +46,25 @@ allowed_channel_ids:
   - 234567890123456789   # the channel the bot will respond in
 ```
 
+## Slash commands (FEAT-016)
+
+The `/crawdad` family registers automatically with Discord on startup.
+Each routes through the FEAT-015 agent loop with a pre-baked user
+message, so the Sonnet composer wraps the tool results in your voice.
+
+| Command | Purpose |
+|---|---|
+| `/crawdad reflect` | Open reflective conversation mode — the loop with no preselected intent. Same as bare `/crawdad`. |
+| `/crawdad checkin` | Wavelength check-in via `creek.state.read`. |
+| `/crawdad surface` | Surface paradoxes / liminal content via `creek.lint`. |
+| `/crawdad draft <topic>` | Mine + draft on the supplied topic (`creek.mine` → `creek.draft`). |
+| `/crawdad save <content>` | File the supplied content back to the vault (`creek.save`). |
+| `/crawdad workflow [list]` | v1.0 stub — full workflow DSL ships in v1.1. |
+
+Full grammar reference (including the developer-side `/creek` surface
+for Claude Code) is in
+[`creek-tools/docs/slash-commands.md`](../creek-tools/docs/slash-commands.md).
+
 ## Development
 
 ```bash
@@ -60,22 +81,34 @@ cyclomatic complexity ≤ 10.
 ## Architecture
 
 ```
-Discord message
+Discord message  /  /crawdad slash command
   ▼
-CrawDadClient.on_message  (crawdad/bot.py)
+CrawDadClient.{on_message, /crawdad <cmd>}  (crawdad/bot.py + slash_commands.py)
   ▼
-handle_message            (pure logic, allowlist + state dispatch)
+handle_message  /  loop_runner closure
   ▼
-session_state             (loaded once at start from latest.md)
+loop.run_one_turn   (FEAT-015 agent loop, capped at 5 rounds)
+  ▼  ┌──────────────────────────────────────────────────────────┐
+     │ Haiku router (FEAT-014)   →   JSON intents               │
+     │ MCP dispatcher            →   creek.state / lint / ...   │
+     │ Paradox auto-save         →   creek.save → 10-Liminal/   │
+     │ Sonnet composer (FEAT-015)→   voice-faithful reply       │
+     └──────────────────────────────────────────────────────────┘
   ▼
-[FEAT-014 dispatcher]     ── MCP subprocess (creek-tools-mcp)
-  ▼
-[FEAT-015 composer]
+Discord reply
 ```
+
+The voice-skill stack (`<vault>/creek-skills/voice-core/`, plus phase-
+and register-specific files) is loaded once at session start. See
+`crawdad/CLAUDE.md` §5.1 for the trust boundary on `crawdad.yaml`.
 
 ## See also
 
 - `creek-tools/CLAUDE.md` — quality standards we mirror.
 - `creek-tools/docs/mcp.md` — the MCP surface CrawDad consumes.
-- `plans/git-issues/FEAT-013-crawdad-discord-bot-skeleton-mcp-client.md`
-  — the issue this package implements.
+- `creek-tools/docs/slash-commands.md` — full `/creek` + `/crawdad` grammar.
+- `plans/git-issues/FEAT-013-crawdad-discord-bot-skeleton-mcp-client.md`,
+  `plans/git-issues/FEAT-014-crawdad-haiku-router-dispatcher.md`,
+  `plans/git-issues/FEAT-015-crawdad-sonnet-composer-loop.md`,
+  `plans/git-issues/FEAT-016-slash-command-grammar.md` — the
+  implementation plan.

--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -16,12 +16,14 @@ fallback, and posting the loop's reply.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import discord
+from discord import app_commands
 
 from crawdad.history import ConversationHistory
 from crawdad.loop import run_one_turn
+from crawdad.slash_commands import register as register_slash_commands
 
 if TYPE_CHECKING:
     from crawdad.composer import SonnetComposer
@@ -29,6 +31,7 @@ if TYPE_CHECKING:
     from crawdad.mcp_client import MCPClient, MCPUnavailableError
     from crawdad.router import IntentRouter
     from crawdad.skill_loader import VoiceSkillStack
+    from crawdad.slash_commands import LoopRunner
     from crawdad.state import SessionState, StateUnavailableError
 
 _LOGGER = logging.getLogger("crawdad.bot")
@@ -177,9 +180,15 @@ class CrawDadClient(discord.Client):
         known_tools: tuple[str, ...] = (),
         history: ConversationHistory | None = None,
         skills: VoiceSkillStack | None = None,
+        loop_runner: LoopRunner | None = None,
         intents: discord.Intents | None = None,
     ) -> None:
-        """Store config + agent-loop components; init the parent ``Client``."""
+        """Store config + agent-loop components; init the parent ``Client``.
+
+        ``loop_runner`` (FEAT-016) is the closure the slash command
+        callbacks invoke to enter the FEAT-015 loop with a pre-baked
+        user message. When ``None``, slash commands are not registered.
+        """
         super().__init__(intents=intents or self._default_intents())
         self._config = config
         self._session_state = session_state
@@ -189,6 +198,14 @@ class CrawDadClient(discord.Client):
         self._known_tools = known_tools
         self._history = history
         self._skills = skills
+        self._loop_runner = loop_runner
+        self.tree = app_commands.CommandTree(self)
+        if loop_runner is not None:
+            # discord.py's ``CommandTree.command`` signature is wider than
+            # the ``_TreeLike`` Protocol the registration function uses,
+            # so cast to Any at the boundary. Verified by the structural
+            # ``test_register_wires_every_command_onto_tree`` test.
+            register_slash_commands(cast("Any", self.tree), loop_runner=loop_runner)
 
     @staticmethod
     def _default_intents() -> discord.Intents:
@@ -196,6 +213,17 @@ class CrawDadClient(discord.Client):
         intents = discord.Intents.default()
         intents.message_content = True
         return intents
+
+    async def setup_hook(self) -> None:
+        """Sync slash commands with Discord once the client is ready.
+
+        ``setup_hook`` runs after login but before the gateway is
+        ready, which is the documented home for ``CommandTree.sync()``.
+        Skipped when the loop runner wasn't provided (test wiring).
+        """
+        if self._loop_runner is not None:
+            await self.tree.sync()
+            _LOGGER.info("synced /crawdad slash commands with Discord")
 
     async def on_ready(self) -> None:
         """Log connection details. Real session-start work happens in CLI."""

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -42,6 +42,18 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger("crawdad.cli")
 
+# Discord's regular message + slash-follow-up text body is capped at 2000
+# characters. Truncate well below the wire limit so the truncation marker
+# always fits and we leave headroom for accidental whitespace.
+_DISCORD_REPLY_LIMIT = 1900
+
+
+def _truncate_for_discord(text: str) -> str:
+    """Cap *text* at Discord's soft limit with an ellipsis marker if needed."""
+    if len(text) <= _DISCORD_REPLY_LIMIT:
+        return text
+    return text[: _DISCORD_REPLY_LIMIT - 3] + "..."
+
 
 def main(argv: Sequence[str] | None = None) -> None:
     """Parse *argv*, resolve config, and start the runtime."""
@@ -133,7 +145,10 @@ def _build_loop_runner(
         timeout, panic in the loop) doesn't leave Discord showing
         "interaction failed" with no user-visible reason. The catch is
         an additional safety net — the loop's structured outcomes
-        already cover every documented failure mode.
+        already cover every documented failure mode. Replies are also
+        truncated to Discord's soft cap so a long composer output
+        cannot raise ``HTTPException`` past the safety net at
+        ``interaction.followup.send`` time.
         """
         try:
             outcome = await run_one_turn(
@@ -146,10 +161,10 @@ def _build_loop_runner(
                 session_state=session_state,
                 skills=skills,
             )
-            return outcome.reply
+            return _truncate_for_discord(outcome.reply)
         except Exception:
             _LOGGER.exception("agent loop crashed for slash command turn")
-            return (
+            return _truncate_for_discord(
                 "something went wrong on my end — creek-tools may be "
                 "unreachable. Try again in a moment."
             )

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -25,6 +25,7 @@ from crawdad.config import (
 )
 from crawdad.history import ConversationHistory
 from crawdad.intents import ToolInfo
+from crawdad.loop import run_one_turn
 from crawdad.mcp_client import MCPClient, MCPUnavailableError
 from crawdad.router import IntentRouter
 from crawdad.skill_loader import load_skills_for_session
@@ -35,6 +36,8 @@ if TYPE_CHECKING:
 
     from crawdad.config import CrawDadConfig
     from crawdad.mcp_client import ToolDetails
+    from crawdad.skill_loader import VoiceSkillStack
+    from crawdad.slash_commands import LoopRunner
     from crawdad.state import SessionState
 
 _LOGGER = logging.getLogger("crawdad.cli")
@@ -84,6 +87,11 @@ def run_bot(config: CrawDadConfig) -> None:
     tool_details = asyncio.run(_startup_probe(config))
     skills = load_skills_for_session(vault_path=config.vault_path, state=session_state)
     components = _build_agent_components(config=config, tool_details=tool_details)
+    loop_runner = _build_loop_runner(
+        components=components,
+        session_state=session_state,
+        skills=skills,
+    )
     client = CrawDadClient(
         config=config,
         session_state=session_state,
@@ -93,8 +101,46 @@ def run_bot(config: CrawDadConfig) -> None:
         known_tools=components.known_tools,
         history=components.history,
         skills=skills,
+        loop_runner=loop_runner,
     )
     client.run(config.discord_bot_token)
+
+
+def _build_loop_runner(
+    *,
+    components: _AgentComponents,
+    session_state: SessionState | None,
+    skills: VoiceSkillStack,
+) -> LoopRunner | None:
+    """Return a closure that runs one loop turn end-to-end.
+
+    The returned callable is what :mod:`crawdad.slash_commands` invokes
+    when a Discord user types `/crawdad <command>`. ``None`` when the
+    agent loop isn't wired (no router → no slash commands).
+    """
+    if components.router is None or components.composer is None:
+        return None
+    router = components.router
+    composer = components.composer
+    mcp_client = components.mcp_client
+    known_tools = components.known_tools
+    history = components.history
+
+    async def _runner(message: str) -> str:
+        """Drive one loop turn and return the user-facing reply text."""
+        outcome = await run_one_turn(
+            message=message,
+            router=router,
+            composer=composer,
+            mcp_client=mcp_client,
+            known_tools=known_tools,
+            history=history,
+            session_state=session_state,
+            skills=skills,
+        )
+        return outcome.reply
+
+    return _runner
 
 
 class _AgentComponents:

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -127,18 +127,32 @@ def _build_loop_runner(
     history = components.history
 
     async def _runner(message: str) -> str:
-        """Drive one loop turn and return the user-facing reply text."""
-        outcome = await run_one_turn(
-            message=message,
-            router=router,
-            composer=composer,
-            mcp_client=mcp_client,
-            known_tools=known_tools,
-            history=history,
-            session_state=session_state,
-            skills=skills,
-        )
-        return outcome.reply
+        """Drive one loop turn and return the user-facing reply text.
+
+        Catches unexpected exceptions so a misbehaving SDK call (network
+        timeout, panic in the loop) doesn't leave Discord showing
+        "interaction failed" with no user-visible reason. The catch is
+        an additional safety net — the loop's structured outcomes
+        already cover every documented failure mode.
+        """
+        try:
+            outcome = await run_one_turn(
+                message=message,
+                router=router,
+                composer=composer,
+                mcp_client=mcp_client,
+                known_tools=known_tools,
+                history=history,
+                session_state=session_state,
+                skills=skills,
+            )
+            return outcome.reply
+        except Exception:
+            _LOGGER.exception("agent loop crashed for slash command turn")
+            return (
+                "something went wrong on my end — creek-tools may be "
+                "unreachable. Try again in a moment."
+            )
 
     return _runner
 

--- a/crawdad/crawdad/composer.py
+++ b/crawdad/crawdad/composer.py
@@ -105,10 +105,12 @@ def build_composer_prompt(
 
 
 def _skills_block(skills: VoiceSkillStack) -> str:
+    """Return the voice-skill stack prompt context, or an empty-state marker."""
     return skills.as_prompt_context() or "(no voice-skill stack loaded)"
 
 
 def _wavelength_block(state: SessionState | None) -> str:
+    """Return the wavelength prompt block — snapshot text or empty marker."""
     wavelength = (
         state.wavelength_snapshot if state and state.wavelength_snapshot else None
     )
@@ -118,6 +120,7 @@ def _wavelength_block(state: SessionState | None) -> str:
 
 
 def _history_block(history: ConversationHistory) -> str:
+    """Return the recent-history prompt block — bulleted turns or empty marker."""
     lines = [f"  - {entry.role}: {entry.content}" for entry in history.as_list()]
     if not lines:
         return "Recent conversation history: (empty)"
@@ -125,6 +128,7 @@ def _history_block(history: ConversationHistory) -> str:
 
 
 def _results_block(tool_results: list[ToolResult]) -> str:
+    """Return the tool-results prompt block — one section per result, or empty."""
     if not tool_results:
         return "Tool results: (none — answer from state + skills)"
     lines: list[str] = []

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -16,6 +16,13 @@ and ``followup.send()``s the reply.
 ``/crawdad workflow`` is a v1.0 stub. Full workflow DSL ships with the
 next FEAT; see ``plans/2026-05-05_comparative-analysis/candidates/
 ADAPT-003-*.md``.
+
+Trust boundary: the user-supplied ``topic`` and ``content`` arguments
+are interpolated directly into LLM prompts. The personal-use allowlist
+(FEAT-013) is the primary gate; this surface does NOT sanitize input
+because doing so would interfere with the user's ability to ask the
+loop to act on raw text. Revisit this if the allowlist ever expands
+beyond a single trusted user.
 """
 
 from __future__ import annotations

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -233,8 +233,14 @@ def _register_draft(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
     """Wire the ``/crawdad draft`` Discord callback onto *tree*."""
 
     @tree.command(name="draft", description=_COMMAND_DESCRIPTIONS["draft"])
-    async def _callback(interaction: Any, topic: str = "") -> None:
-        """Discord callback for ``/crawdad draft <topic>`` (deferred)."""
+    async def _callback(interaction: Any, topic: str) -> None:
+        """Discord callback for ``/crawdad draft <topic>`` (deferred).
+
+        ``topic`` has no default value so Discord's autocomplete UI
+        marks the parameter as required and disables submit until the
+        user fills it in. The runtime empty-string guard in
+        :func:`handle_draft` stays as defense-in-depth.
+        """
         await interaction.response.defer()
         await handle_draft(
             interaction.followup.send, topic=topic, loop_runner=loop_runner
@@ -245,8 +251,13 @@ def _register_save(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
     """Wire the ``/crawdad save`` Discord callback onto *tree*."""
 
     @tree.command(name="save", description=_COMMAND_DESCRIPTIONS["save"])
-    async def _callback(interaction: Any, content: str = "") -> None:
-        """Discord callback for ``/crawdad save <content>`` (deferred)."""
+    async def _callback(interaction: Any, content: str) -> None:
+        """Discord callback for ``/crawdad save <content>`` (deferred).
+
+        ``content`` has no default; Discord marks the parameter as
+        required in the slash-command UI. Runtime guard in
+        :func:`handle_save` stays as defense-in-depth.
+        """
         await interaction.response.defer()
         await handle_save(
             interaction.followup.send, content=content, loop_runner=loop_runner

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -172,7 +172,17 @@ async def handle_workflow(replier: Replier, *, subaction: str | None) -> None:
 
 
 async def handle_help(replier: Replier) -> None:
-    """``/crawdad help`` — list every command with a one-line description."""
+    """Compose a help summary listing every ``/crawdad`` command.
+
+    Not registered as a Discord slash command — Discord's autocomplete
+    UI already surfaces the six registered commands and their
+    descriptions. ``handle_help`` is kept as a public helper so:
+
+    * Tests can drive the help-text format directly.
+    * Future surfaces (a v1.1 ``/crawdad help`` variant, an operator
+      REPL, a Discord rich-embed expansion) can reuse the canonical
+      help string without duplicating the command list.
+    """
     lines = ["**`/crawdad` commands**"]
     for name in CRAWDAD_COMMANDS:
         lines.append(f"- `/crawdad {name}` — {_COMMAND_DESCRIPTIONS[name]}")
@@ -187,15 +197,17 @@ async def handle_help(replier: Replier) -> None:
 
 
 def register(tree: _TreeLike, *, loop_runner: LoopRunner) -> int:
-    """Register every `/crawdad` slash command on the supplied tree.
+    """Register every ``/crawdad`` slash command on the supplied tree.
 
     Each callback ``defer()``s the Discord interaction so the loop has
     its full :data:`crawdad.config.MAX_LOOP_ROUNDS` budget before the
     SDK times out at 3 seconds. The actual reply lands via
     ``interaction.followup.send``.
 
-    Returns the number of registered commands so callers can sanity-check
-    the wiring.
+    Returns the count of advertised commands (always
+    ``len(CRAWDAD_COMMANDS)`` since the registration helpers don't
+    fail). The return value is a sanity-check signal callers can pin
+    in tests to catch silent additions or removals.
     """
     _register_reflect(tree, loop_runner=loop_runner)
     _register_checkin(tree, loop_runner=loop_runner)

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -1,0 +1,263 @@
+"""Discord slash commands for CrawDad (FEAT-016).
+
+Six commands form the `/crawdad` family — `reflect`, `checkin`,
+`surface`, `draft`, `save`, `workflow`. Each routes through the
+FEAT-015 agent loop by constructing a pre-baked user message and
+running it through an injected ``loop_runner`` callable. The Sonnet
+composer wraps the tool results in the user's voice.
+
+The handlers are free functions that take a tiny ``Replier`` callable
+(``async def (str) -> None``) so they can be unit-tested without
+discord.py. ``register()`` wraps each handler in a discord.py
+``app_commands`` callback that ``defer()``s the interaction (LLM
+calls exceed Discord's 3-second response window), runs the handler,
+and ``followup.send()``s the reply.
+
+``/crawdad workflow`` is a v1.0 stub. Full workflow DSL ships with the
+next FEAT; see ``plans/2026-05-05_comparative-analysis/candidates/
+ADAPT-003-*.md``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol
+
+_LOGGER = logging.getLogger("crawdad.slash_commands")
+
+# A callable that drives one turn of the FEAT-015 loop and returns the
+# user-facing reply string. The CLI builds one by closing over the
+# per-session router, composer, MCP client, history, state, and skills
+# components — see :func:`crawdad.cli._build_loop_runner`.
+LoopRunner = Callable[[str], Awaitable[str]]
+
+# Async callable that posts a message back to the Discord user.
+# Wraps ``discord.Interaction.followup.send`` in production; tests
+# substitute a list-appending fake.
+Replier = Callable[[str], Awaitable[None]]
+
+
+CRAWDAD_COMMANDS: tuple[str, ...] = (
+    "reflect",
+    "checkin",
+    "surface",
+    "draft",
+    "save",
+    "workflow",
+)
+
+_COMMAND_DESCRIPTIONS: dict[str, str] = {
+    "reflect": "Open reflective conversation mode (FEAT-015 loop).",
+    "checkin": "Wavelength check-in — read the current phase + dosage state.",
+    "surface": "Surface paradoxes, liminal content, or emerging themes.",
+    "draft": "Draft an essay on a topic (routes through creek.mine + creek.draft).",
+    "save": "File the supplied content back to the vault via creek.save.",
+    "workflow": "List or run named workflows (v1.0 stub — full DSL in v1.1).",
+}
+
+_REFLECT_PROMPT = (
+    "Reflect with me. No specific tool request — open the loop in conversational "
+    "mode and surface whatever is most alive in my current wavelength."
+)
+_CHECKIN_PROMPT = (
+    "Give me a wavelength check-in: read my latest state via creek.state.read and "
+    "summarize the current phase, dosage, and any recent transitions."
+)
+_SURFACE_PROMPT = (
+    "Surface anything in my vault that's emerging — paradoxes, liminal items, or "
+    "drift. Route paradoxes to 10-Liminal/Paradoxes/ via creek.save."
+)
+_WORKFLOW_STUB_REPLY = (
+    "no workflows yet — coming in v1.1.\n\n"
+    "The workflow DSL (ADAPT-003) will let you compose multi-step plans like "
+    "`/crawdad workflow run weekly-review`. v1.0 ships only this `list` stub."
+)
+
+
+class _TreeLike(Protocol):
+    """Structural subset of ``discord.app_commands.CommandTree`` we use."""
+
+    def command(
+        self, *, name: str, description: str
+    ) -> Callable[
+        [Callable[..., Any]], Callable[..., Any]
+    ]: ...  # pragma: no cover - structural protocol
+
+
+# -----------------------------------------------------------------------------
+# Free-function handlers (pure logic; testable without discord.py)
+# -----------------------------------------------------------------------------
+
+
+async def handle_reflect(replier: Replier, *, loop_runner: LoopRunner) -> None:
+    """``/crawdad reflect`` — open reflective mode."""
+    reply = await loop_runner(_REFLECT_PROMPT)
+    await replier(reply)
+
+
+async def handle_checkin(replier: Replier, *, loop_runner: LoopRunner) -> None:
+    """``/crawdad checkin`` — wavelength check-in."""
+    reply = await loop_runner(_CHECKIN_PROMPT)
+    await replier(reply)
+
+
+async def handle_surface(replier: Replier, *, loop_runner: LoopRunner) -> None:
+    """``/crawdad surface`` — surface paradoxes and liminal content."""
+    reply = await loop_runner(_SURFACE_PROMPT)
+    await replier(reply)
+
+
+async def handle_draft(
+    replier: Replier, *, topic: str, loop_runner: LoopRunner
+) -> None:
+    """``/crawdad draft <topic>`` — mine + draft on the supplied topic."""
+    cleaned = topic.strip()
+    if not cleaned:
+        await replier(
+            "I need a topic to draft on. Try `/crawdad draft <topic>` — for "
+            "example, `/crawdad draft phase transitions`."
+        )
+        return
+    prompt = (
+        f"Draft an essay on the following topic: {cleaned}.\n\n"
+        "Route through creek.mine to surface relevant seeds first, then "
+        "creek.draft to generate the essay. Voice fidelity is owned by "
+        "creek.draft's skill stack — don't re-draft inline."
+    )
+    reply = await loop_runner(prompt)
+    await replier(reply)
+
+
+async def handle_save(
+    replier: Replier, *, content: str, loop_runner: LoopRunner
+) -> None:
+    """``/crawdad save <content>`` — file content back to the vault."""
+    cleaned = content.strip()
+    if not cleaned:
+        await replier(
+            "What should I save? Pass the content as the command argument: "
+            "`/crawdad save <your text here>`."
+        )
+        return
+    prompt = (
+        f"Save this content back to my vault via creek.save:\n\n{cleaned}\n\n"
+        "Infer the right target (fragment / paradox / draft / liminal) from "
+        "the content's character."
+    )
+    reply = await loop_runner(prompt)
+    await replier(reply)
+
+
+async def handle_workflow(replier: Replier, *, subaction: str | None) -> None:
+    """``/crawdad workflow [list]`` — v1.0 stub.
+
+    ``list`` (the default) returns the documented placeholder. Any
+    other subaction returns scoped help — no MCP call, no stack trace.
+    """
+    if subaction in (None, "list"):
+        await replier(_WORKFLOW_STUB_REPLY)
+        return
+    await replier(
+        f"unknown workflow subcommand: {subaction!r}. "
+        "Only `/crawdad workflow list` is available in v1.0."
+    )
+
+
+async def handle_help(replier: Replier) -> None:
+    """``/crawdad help`` — list every command with a one-line description."""
+    lines = ["**`/crawdad` commands**"]
+    for name in CRAWDAD_COMMANDS:
+        lines.append(f"- `/crawdad {name}` — {_COMMAND_DESCRIPTIONS[name]}")
+    lines.append("")
+    lines.append("Bare `/crawdad` (no subcommand) is equivalent to `/crawdad reflect`.")
+    await replier("\n".join(lines))
+
+
+# -----------------------------------------------------------------------------
+# discord.py CommandTree wiring
+# -----------------------------------------------------------------------------
+
+
+def register(tree: _TreeLike, *, loop_runner: LoopRunner) -> int:
+    """Register every `/crawdad` slash command on the supplied tree.
+
+    Each callback ``defer()``s the Discord interaction so the loop has
+    its full :data:`crawdad.config.MAX_LOOP_ROUNDS` budget before the
+    SDK times out at 3 seconds. The actual reply lands via
+    ``interaction.followup.send``.
+
+    Returns the number of registered commands so callers can sanity-check
+    the wiring.
+    """
+    _register_reflect(tree, loop_runner=loop_runner)
+    _register_checkin(tree, loop_runner=loop_runner)
+    _register_surface(tree, loop_runner=loop_runner)
+    _register_draft(tree, loop_runner=loop_runner)
+    _register_save(tree, loop_runner=loop_runner)
+    _register_workflow(tree)
+    return len(CRAWDAD_COMMANDS)
+
+
+def _register_reflect(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
+    """Wire the ``/crawdad reflect`` Discord callback onto *tree*."""
+
+    @tree.command(name="reflect", description=_COMMAND_DESCRIPTIONS["reflect"])
+    async def _callback(interaction: Any) -> None:
+        """Discord callback for ``/crawdad reflect`` (deferred)."""
+        await interaction.response.defer()
+        await handle_reflect(interaction.followup.send, loop_runner=loop_runner)
+
+
+def _register_checkin(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
+    """Wire the ``/crawdad checkin`` Discord callback onto *tree*."""
+
+    @tree.command(name="checkin", description=_COMMAND_DESCRIPTIONS["checkin"])
+    async def _callback(interaction: Any) -> None:
+        """Discord callback for ``/crawdad checkin`` (deferred)."""
+        await interaction.response.defer()
+        await handle_checkin(interaction.followup.send, loop_runner=loop_runner)
+
+
+def _register_surface(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
+    """Wire the ``/crawdad surface`` Discord callback onto *tree*."""
+
+    @tree.command(name="surface", description=_COMMAND_DESCRIPTIONS["surface"])
+    async def _callback(interaction: Any) -> None:
+        """Discord callback for ``/crawdad surface`` (deferred)."""
+        await interaction.response.defer()
+        await handle_surface(interaction.followup.send, loop_runner=loop_runner)
+
+
+def _register_draft(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
+    """Wire the ``/crawdad draft`` Discord callback onto *tree*."""
+
+    @tree.command(name="draft", description=_COMMAND_DESCRIPTIONS["draft"])
+    async def _callback(interaction: Any, topic: str = "") -> None:
+        """Discord callback for ``/crawdad draft <topic>`` (deferred)."""
+        await interaction.response.defer()
+        await handle_draft(
+            interaction.followup.send, topic=topic, loop_runner=loop_runner
+        )
+
+
+def _register_save(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
+    """Wire the ``/crawdad save`` Discord callback onto *tree*."""
+
+    @tree.command(name="save", description=_COMMAND_DESCRIPTIONS["save"])
+    async def _callback(interaction: Any, content: str = "") -> None:
+        """Discord callback for ``/crawdad save <content>`` (deferred)."""
+        await interaction.response.defer()
+        await handle_save(
+            interaction.followup.send, content=content, loop_runner=loop_runner
+        )
+
+
+def _register_workflow(tree: _TreeLike) -> None:
+    """Wire the ``/crawdad workflow`` Discord callback onto *tree*."""
+
+    @tree.command(name="workflow", description=_COMMAND_DESCRIPTIONS["workflow"])
+    async def _callback(interaction: Any, subaction: str = "list") -> None:
+        """Discord callback for ``/crawdad workflow [subaction]`` (deferred)."""
+        await interaction.response.defer()
+        await handle_workflow(interaction.followup.send, subaction=subaction)

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -63,6 +63,17 @@ _COMMAND_DESCRIPTIONS: dict[str, str] = {
     "workflow": "List or run named workflows (v1.0 stub — full DSL in v1.1).",
 }
 
+# Module-level invariant: every command name must have a description and
+# vice versa. Checked at import time so a typo when adding a new command
+# fails fast instead of surfacing as a Discord registration error.
+if set(CRAWDAD_COMMANDS) != set(_COMMAND_DESCRIPTIONS):  # pragma: no cover
+    _diff = set(CRAWDAD_COMMANDS) ^ set(_COMMAND_DESCRIPTIONS)
+    _msg = (
+        "CRAWDAD_COMMANDS and _COMMAND_DESCRIPTIONS must list the same names; "
+        f"diff: {_diff}"
+    )
+    raise RuntimeError(_msg)
+
 _REFLECT_PROMPT = (
     "Reflect with me. No specific tool request — open the loop in conversational "
     "mode and surface whatever is most alive in my current wavelength."

--- a/crawdad/pyproject.toml
+++ b/crawdad/pyproject.toml
@@ -126,6 +126,7 @@ ignore = []
 "tests/**/*" = [
     "S101",   # assert is the point of tests
     "TC001",  # type-only imports in tests stay top-level for pytest discovery
+    "TC002",  # same — pytest.MonkeyPatch annotation, used only at type-check time
     "TC003",  # same — Path / Any used in fixture annotations
 ]
 

--- a/crawdad/tests/test_bot.py
+++ b/crawdad/tests/test_bot.py
@@ -591,3 +591,88 @@ async def test_handle_message_without_loop_components_uses_stub_reply(
 
     assert len(channel.sent) == 1
     assert "scaffold" in channel.sent[0].lower()
+
+
+def test_crawdad_client_registers_slash_commands_when_loop_runner_provided(
+    config: CrawDadConfig, session_state: SessionState
+) -> None:
+    """FEAT-016: providing a ``loop_runner`` registers the six /crawdad commands."""
+    from crawdad.bot import CrawDadClient
+    from crawdad.slash_commands import CRAWDAD_COMMANDS
+
+    async def _runner(_message: str) -> str:
+        return "noop"
+
+    client = CrawDadClient(
+        config=config,
+        session_state=session_state,
+        loop_runner=_runner,
+    )
+
+    # The CommandTree exposes ``get_commands`` returning registered Commands.
+    names = {cmd.name for cmd in client.tree.get_commands()}
+    assert set(CRAWDAD_COMMANDS).issubset(names)
+
+
+def test_crawdad_client_without_loop_runner_registers_no_commands(
+    config: CrawDadConfig, session_state: SessionState
+) -> None:
+    """No loop runner → no slash commands (test wiring stays uncoupled)."""
+    from crawdad.bot import CrawDadClient
+
+    client = CrawDadClient(config=config, session_state=session_state)
+
+    assert list(client.tree.get_commands()) == []
+
+
+async def test_setup_hook_skips_sync_when_no_loop_runner(
+    config: CrawDadConfig,
+    session_state: SessionState,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setup_hook`` is a no-op when slash commands weren't registered."""
+    from crawdad.bot import CrawDadClient
+
+    client = CrawDadClient(config=config, session_state=session_state)
+    sync_calls = 0
+
+    async def _spy() -> list[Any]:
+        nonlocal sync_calls
+        sync_calls += 1
+        return []
+
+    monkeypatch.setattr(client.tree, "sync", _spy)
+
+    await client.setup_hook()
+
+    assert sync_calls == 0
+
+
+async def test_setup_hook_syncs_when_loop_runner_provided(
+    config: CrawDadConfig,
+    session_state: SessionState,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``setup_hook`` triggers a CommandTree sync after slash registration."""
+    from crawdad.bot import CrawDadClient
+
+    async def _runner(_message: str) -> str:
+        return "noop"
+
+    client = CrawDadClient(
+        config=config,
+        session_state=session_state,
+        loop_runner=_runner,
+    )
+    sync_calls = 0
+
+    async def _spy() -> list[Any]:
+        nonlocal sync_calls
+        sync_calls += 1
+        return []
+
+    monkeypatch.setattr(client.tree, "sync", _spy)
+
+    await client.setup_hook()
+
+    assert sync_calls == 1

--- a/crawdad/tests/test_cli.py
+++ b/crawdad/tests/test_cli.py
@@ -301,6 +301,46 @@ def test_build_loop_runner_returns_callable_when_loop_wired(
     assert callable(runner)
 
 
+async def test_loop_runner_returns_soft_error_on_exception(
+    patched_config: CrawDadConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A crash inside ``run_one_turn`` yields the documented soft reply.
+
+    Regression for review feedback on PR #237: previously an exception
+    propagated through Discord's interaction handler and the user saw
+    "This interaction failed" with no context.
+    """
+    from crawdad.mcp_client import ToolDetails
+    from crawdad.skill_loader import VoiceSkillStack
+
+    details = (
+        ToolDetails(
+            name="creek.state.read",
+            description="Read latest.md",
+            input_schema={"type": "object"},
+        ),
+    )
+    components = cli._build_agent_components(
+        config=patched_config, tool_details=details
+    )
+
+    async def _boom(**_kwargs: Any) -> Any:
+        raise RuntimeError("simulated crash")
+
+    monkeypatch.setattr(cli, "run_one_turn", _boom)
+
+    runner = cli._build_loop_runner(
+        components=components,
+        session_state=None,
+        skills=VoiceSkillStack(skills=()),
+    )
+
+    assert runner is not None
+    reply = await runner("anything")
+    assert "creek-tools" in reply.lower() or "wrong" in reply.lower()
+
+
 def test_run_bot_passes_loop_runner_when_loop_wired(
     patched_config: CrawDadConfig,
     monkeypatch: pytest.MonkeyPatch,

--- a/crawdad/tests/test_cli.py
+++ b/crawdad/tests/test_cli.py
@@ -301,6 +301,53 @@ def test_build_loop_runner_returns_callable_when_loop_wired(
     assert callable(runner)
 
 
+async def test_loop_runner_truncates_long_replies(
+    patched_config: CrawDadConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replies over Discord's 2000-char limit are truncated with an ellipsis.
+
+    Regression for PR #237 review: ``interaction.followup.send`` raises
+    ``HTTPException`` past Discord's body cap, and that error fires
+    *after* ``_runner`` returns so the soft-error wrapper can't catch
+    it. Truncating inside ``_runner`` keeps every slash command's
+    payload below the wire limit.
+    """
+    from crawdad.loop import LoopOutcome
+    from crawdad.mcp_client import ToolDetails
+    from crawdad.skill_loader import VoiceSkillStack
+
+    details = (
+        ToolDetails(
+            name="creek.state.read",
+            description="Read latest.md",
+            input_schema={"type": "object"},
+        ),
+    )
+    components = cli._build_agent_components(
+        config=patched_config, tool_details=details
+    )
+
+    long_reply = "x" * 5000
+
+    async def _huge_outcome(**_kwargs: Any) -> LoopOutcome:
+        return LoopOutcome(kind="composed", reply=long_reply)
+
+    monkeypatch.setattr(cli, "run_one_turn", _huge_outcome)
+
+    runner = cli._build_loop_runner(
+        components=components,
+        session_state=None,
+        skills=VoiceSkillStack(skills=()),
+    )
+
+    assert runner is not None
+    reply = await runner("anything")
+    assert len(reply) < len(long_reply)
+    assert len(reply) <= cli._DISCORD_REPLY_LIMIT
+    assert reply.endswith("...")
+
+
 async def test_loop_runner_returns_soft_error_on_exception(
     patched_config: CrawDadConfig,
     monkeypatch: pytest.MonkeyPatch,

--- a/crawdad/tests/test_cli.py
+++ b/crawdad/tests/test_cli.py
@@ -254,3 +254,84 @@ def test_build_agent_components_wires_router_and_composer(
     assert components.router is not None
     assert components.composer is not None
     assert components.known_tools == ("creek.state.read",)
+
+
+def test_build_loop_runner_returns_none_when_loop_not_wired(
+    patched_config: CrawDadConfig,
+) -> None:
+    """No router/composer → no loop runner → slash commands stay unregistered."""
+    from crawdad.skill_loader import VoiceSkillStack
+
+    components = cli._build_agent_components(config=patched_config, tool_details=())
+
+    runner = cli._build_loop_runner(
+        components=components,
+        session_state=None,
+        skills=VoiceSkillStack(skills=()),
+    )
+
+    assert runner is None
+
+
+def test_build_loop_runner_returns_callable_when_loop_wired(
+    patched_config: CrawDadConfig,
+) -> None:
+    """A wired loop produces a callable suitable for slash-command dispatch."""
+    from crawdad.mcp_client import ToolDetails
+    from crawdad.skill_loader import VoiceSkillStack
+
+    details = (
+        ToolDetails(
+            name="creek.state.read",
+            description="Read latest.md",
+            input_schema={"type": "object"},
+        ),
+    )
+    components = cli._build_agent_components(
+        config=patched_config, tool_details=details
+    )
+
+    runner = cli._build_loop_runner(
+        components=components,
+        session_state=None,
+        skills=VoiceSkillStack(skills=()),
+    )
+
+    assert runner is not None
+    assert callable(runner)
+
+
+def test_run_bot_passes_loop_runner_when_loop_wired(
+    patched_config: CrawDadConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    vault_with_state: Path,
+) -> None:
+    """``run_bot`` constructs and forwards a ``loop_runner`` to the client."""
+    from crawdad.mcp_client import ToolDetails
+
+    config = patched_config.model_copy(update={"vault_path": vault_with_state})
+    captured: dict[str, Any] = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["init_kwargs"] = kwargs
+
+        def run(self, _token: str) -> None:
+            captured["ran"] = True
+
+    async def _ok_probe(_c: CrawDadConfig) -> tuple[ToolDetails, ...]:
+        return (
+            ToolDetails(
+                name="creek.state.read",
+                description="Read latest.md",
+                input_schema={"type": "object"},
+            ),
+        )
+
+    monkeypatch.setattr(cli, "CrawDadClient", _FakeClient)
+    monkeypatch.setattr(cli, "_startup_probe", _ok_probe)
+
+    cli.run_bot(config)
+
+    assert captured["init_kwargs"]["loop_runner"] is not None
+    assert callable(captured["init_kwargs"]["loop_runner"])

--- a/crawdad/tests/test_cli.py
+++ b/crawdad/tests/test_cli.py
@@ -307,11 +307,11 @@ async def test_loop_runner_truncates_long_replies(
 ) -> None:
     """Replies over Discord's 2000-char limit are truncated with an ellipsis.
 
-    Regression for PR #237 review: ``interaction.followup.send`` raises
-    ``HTTPException`` past Discord's body cap, and that error fires
-    *after* ``_runner`` returns so the soft-error wrapper can't catch
-    it. Truncating inside ``_runner`` keeps every slash command's
-    payload below the wire limit.
+    ``interaction.followup.send`` raises ``HTTPException`` past
+    Discord's body cap, and that error fires *after* the runner's
+    soft-error wrapper exits — so truncation must happen inside the
+    runner. Truncating there keeps every slash command's payload below
+    the wire limit.
     """
     from crawdad.loop import LoopOutcome
     from crawdad.mcp_client import ToolDetails
@@ -354,9 +354,10 @@ async def test_loop_runner_returns_soft_error_on_exception(
 ) -> None:
     """A crash inside ``run_one_turn`` yields the documented soft reply.
 
-    Regression for review feedback on PR #237: previously an exception
-    propagated through Discord's interaction handler and the user saw
-    "This interaction failed" with no context.
+    Without the runner's catch-all, an unhandled exception would
+    propagate through Discord's interaction handler and the user would
+    see "This interaction failed" with no context. The runner surfaces
+    a friendly soft error instead.
     """
     from crawdad.mcp_client import ToolDetails
     from crawdad.skill_loader import VoiceSkillStack

--- a/crawdad/tests/test_slash_commands.py
+++ b/crawdad/tests/test_slash_commands.py
@@ -1,0 +1,251 @@
+"""Tests for ``crawdad.slash_commands`` — FEAT-016 Discord slash surface."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from crawdad.slash_commands import (
+    CRAWDAD_COMMANDS,
+    handle_checkin,
+    handle_draft,
+    handle_help,
+    handle_reflect,
+    handle_save,
+    handle_surface,
+    handle_workflow,
+    register,
+)
+
+
+class _FakeReplier:
+    """Records the strings sent back to Discord."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+
+    async def __call__(self, content: str) -> None:
+        self.sent.append(content)
+
+
+async def _fake_loop_runner(message: str) -> str:
+    """Return the message itself so tests can assert what was routed."""
+    return f"composer received: {message}"
+
+
+def test_crawdad_commands_lists_the_six_documented_names() -> None:
+    """The exported registry matches the FEAT-016 §pre-decided choice list."""
+    assert set(CRAWDAD_COMMANDS) == {
+        "reflect",
+        "checkin",
+        "surface",
+        "draft",
+        "save",
+        "workflow",
+    }
+
+
+async def test_handle_reflect_routes_through_loop() -> None:
+    """``/crawdad reflect`` runs the loop with no preselected intent."""
+    replier = _FakeReplier()
+
+    await handle_reflect(replier, loop_runner=_fake_loop_runner)
+
+    assert len(replier.sent) == 1
+    assert "composer received:" in replier.sent[0]
+    # The loop's input message gives the composer reflective framing,
+    # not a specific tool request.
+    assert "reflect" in replier.sent[0].lower()
+
+
+async def test_handle_checkin_routes_through_state_read() -> None:
+    """``/crawdad checkin`` asks the loop for a wavelength check-in."""
+    replier = _FakeReplier()
+
+    await handle_checkin(replier, loop_runner=_fake_loop_runner)
+
+    assert len(replier.sent) == 1
+    body = replier.sent[0].lower()
+    assert "wavelength" in body or "state" in body
+
+
+async def test_handle_surface_routes_through_lint() -> None:
+    """``/crawdad surface`` asks the loop for paradox / liminal surfacing."""
+    replier = _FakeReplier()
+
+    await handle_surface(replier, loop_runner=_fake_loop_runner)
+
+    assert len(replier.sent) == 1
+    body = replier.sent[0].lower()
+    assert "paradox" in body or "surfac" in body or "liminal" in body
+
+
+async def test_handle_draft_passes_topic_to_loop() -> None:
+    """``/crawdad draft <topic>`` includes the user's topic verbatim."""
+    replier = _FakeReplier()
+
+    await handle_draft(
+        replier, topic="phase transitions", loop_runner=_fake_loop_runner
+    )
+
+    assert len(replier.sent) == 1
+    assert "phase transitions" in replier.sent[0]
+
+
+async def test_handle_draft_refuses_empty_topic() -> None:
+    """An empty draft topic gets a help reply, not a stack trace."""
+    replier = _FakeReplier()
+
+    await handle_draft(replier, topic="", loop_runner=_fake_loop_runner)
+
+    assert len(replier.sent) == 1
+    assert "topic" in replier.sent[0].lower()
+
+
+async def test_handle_save_passes_content_to_loop() -> None:
+    """``/crawdad save <content>`` routes the content through the loop."""
+    replier = _FakeReplier()
+
+    await handle_save(
+        replier,
+        content="a fragment about emergence",
+        loop_runner=_fake_loop_runner,
+    )
+
+    assert len(replier.sent) == 1
+    assert "emergence" in replier.sent[0]
+
+
+async def test_handle_save_refuses_empty_content() -> None:
+    """Empty save content gets a help reply, not an empty MCP call."""
+    replier = _FakeReplier()
+
+    await handle_save(replier, content="", loop_runner=_fake_loop_runner)
+
+    assert len(replier.sent) == 1
+    assert "content" in replier.sent[0].lower() or "what" in replier.sent[0].lower()
+
+
+async def test_handle_workflow_list_returns_v11_placeholder() -> None:
+    """``/crawdad workflow list`` returns the documented v1.1 stub."""
+    replier = _FakeReplier()
+
+    await handle_workflow(replier, subaction="list")
+
+    assert len(replier.sent) == 1
+    assert "v1.1" in replier.sent[0] or "1.1" in replier.sent[0]
+
+
+async def test_handle_workflow_unknown_subaction_returns_help() -> None:
+    """A workflow subaction other than ``list`` returns the help summary."""
+    replier = _FakeReplier()
+
+    await handle_workflow(replier, subaction="run")
+
+    assert len(replier.sent) == 1
+    assert "list" in replier.sent[0].lower()
+
+
+async def test_handle_workflow_default_returns_list_stub() -> None:
+    """``/crawdad workflow`` with no subaction is the same as ``list``."""
+    replier = _FakeReplier()
+
+    await handle_workflow(replier, subaction=None)
+
+    assert len(replier.sent) == 1
+    assert "v1.1" in replier.sent[0] or "1.1" in replier.sent[0]
+
+
+async def test_handle_help_lists_every_command() -> None:
+    """``/crawdad help`` (or any unknown subcommand) lists the six commands."""
+    replier = _FakeReplier()
+
+    await handle_help(replier)
+
+    body = replier.sent[0]
+    for name in CRAWDAD_COMMANDS:
+        assert name in body
+
+
+async def test_handle_reflect_workflow_skips_loop() -> None:
+    """Workflow handler does NOT call the loop runner — it's a pure stub."""
+    runner_calls = 0
+
+    async def _counting_runner(_message: str) -> str:
+        nonlocal runner_calls
+        runner_calls += 1
+        return "should not be reached"
+
+    replier = _FakeReplier()
+    await handle_workflow(replier, subaction="list")
+
+    assert runner_calls == 0
+
+
+class _FakeTree:
+    """Records the ``@tree.command`` registrations the wiring performs."""
+
+    def __init__(self) -> None:
+        self.registered: dict[str, dict[str, Any]] = {}
+
+    def command(self, *, name: str, description: str) -> Any:
+        def _decorator(func: Any) -> Any:
+            self.registered[name] = {"description": description, "callback": func}
+            return func
+
+        return _decorator
+
+
+def test_register_wires_every_command_onto_tree() -> None:
+    """``register`` adds all six commands to a discord ``CommandTree``-like object."""
+    tree = _FakeTree()
+
+    register(tree, loop_runner=_fake_loop_runner)
+
+    assert set(tree.registered) == set(CRAWDAD_COMMANDS)
+    for name, entry in tree.registered.items():
+        assert entry["description"], f"{name} missing description"
+        assert callable(entry["callback"]), f"{name} callback not callable"
+
+
+def test_register_returns_command_count() -> None:
+    """``register`` returns the number of wired commands for sanity checks."""
+    tree = _FakeTree()
+
+    count = register(tree, loop_runner=_fake_loop_runner)
+
+    assert count == len(CRAWDAD_COMMANDS)
+
+
+async def test_registered_callback_routes_to_handler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A registered slash callback ends up calling the matching handler."""
+    tree = _FakeTree()
+    register(tree, loop_runner=_fake_loop_runner)
+
+    # Each registered callback accepts a discord.Interaction. We provide
+    # a fake interaction with the minimal shape: a response object whose
+    # ``defer`` is a no-op and a ``followup.send`` that records calls.
+    class _FakeFollowup:
+        def __init__(self) -> None:
+            self.sent: list[str] = []
+
+        async def send(self, content: str) -> None:
+            self.sent.append(content)
+
+    class _FakeResponse:
+        async def defer(self) -> None:
+            return None
+
+    class _FakeInteraction:
+        def __init__(self) -> None:
+            self.response = _FakeResponse()
+            self.followup = _FakeFollowup()
+
+    interaction = _FakeInteraction()
+    await tree.registered["checkin"]["callback"](interaction)
+
+    assert len(interaction.followup.sent) == 1
+    assert "composer received:" in interaction.followup.sent[0]

--- a/crawdad/tests/test_slash_commands.py
+++ b/crawdad/tests/test_slash_commands.py
@@ -168,7 +168,7 @@ async def test_handle_help_lists_every_command() -> None:
         assert name in body
 
 
-async def test_handle_reflect_workflow_skips_loop() -> None:
+async def test_handle_workflow_skips_loop() -> None:
     """Workflow handler does NOT call the loop runner — it's a pure stub."""
     runner_calls = 0
 
@@ -216,39 +216,6 @@ def test_register_returns_command_count() -> None:
     count = register(tree, loop_runner=_fake_loop_runner)
 
     assert count == len(CRAWDAD_COMMANDS)
-
-
-async def test_registered_callback_routes_to_handler(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A registered slash callback ends up calling the matching handler."""
-    tree = _FakeTree()
-    register(tree, loop_runner=_fake_loop_runner)
-
-    # Each registered callback accepts a discord.Interaction. We provide
-    # a fake interaction with the minimal shape: a response object whose
-    # ``defer`` is a no-op and a ``followup.send`` that records calls.
-    class _FakeFollowup:
-        def __init__(self) -> None:
-            self.sent: list[str] = []
-
-        async def send(self, content: str) -> None:
-            self.sent.append(content)
-
-    class _FakeResponse:
-        async def defer(self) -> None:
-            return None
-
-    class _FakeInteraction:
-        def __init__(self) -> None:
-            self.response = _FakeResponse()
-            self.followup = _FakeFollowup()
-
-    interaction = _FakeInteraction()
-    await tree.registered["checkin"]["callback"](interaction)
-
-    assert len(interaction.followup.sent) == 1
-    assert "composer received:" in interaction.followup.sent[0]
 
 
 class _FakeFollowup:

--- a/crawdad/tests/test_slash_commands.py
+++ b/crawdad/tests/test_slash_commands.py
@@ -249,3 +249,89 @@ async def test_registered_callback_routes_to_handler(
 
     assert len(interaction.followup.sent) == 1
     assert "composer received:" in interaction.followup.sent[0]
+
+
+class _FakeFollowup:
+    """Followup-send fake — records the content passed to discord."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+
+    async def send(self, content: str) -> None:
+        """Record the content the registered callback tried to post."""
+        self.sent.append(content)
+
+
+class _FakeResponse:
+    """Interaction-response fake — counts ``defer`` calls."""
+
+    def __init__(self) -> None:
+        self.deferred = 0
+
+    async def defer(self) -> None:
+        """Increment the defer counter."""
+        self.deferred += 1
+
+
+class _FakeInteraction:
+    """``discord.Interaction``-shaped fake with the minimal surface we use."""
+
+    def __init__(self) -> None:
+        self.response = _FakeResponse()
+        self.followup = _FakeFollowup()
+
+
+@pytest.mark.parametrize(
+    ("command_name", "callback_kwargs"),
+    [
+        ("reflect", {}),
+        ("checkin", {}),
+        ("surface", {}),
+        ("draft", {"topic": "phase transitions"}),
+        ("save", {"content": "a fragment to file"}),
+    ],
+)
+async def test_every_loop_routed_callback_defers_and_replies(
+    command_name: str, callback_kwargs: dict[str, Any]
+) -> None:
+    """Each loop-routed callback ``defer()``s the interaction and replies.
+
+    Closes the FEAT-016 review's #1 blocker — pre-existing tests only
+    covered ``checkin``. The five remaining ``_callback`` closures were
+    unreached so per-file coverage on slash_commands.py sat at 89.80%.
+    """
+    tree = _FakeTree()
+    register(tree, loop_runner=_fake_loop_runner)
+    interaction = _FakeInteraction()
+
+    await tree.registered[command_name]["callback"](interaction, **callback_kwargs)
+
+    assert interaction.response.deferred == 1
+    assert len(interaction.followup.sent) == 1
+    # Every routed callback yields the loop's reply text.
+    assert "composer received:" in interaction.followup.sent[0]
+
+
+async def test_workflow_callback_skips_loop_and_returns_stub() -> None:
+    """The workflow callback ``defer()``s but does NOT call the loop runner.
+
+    The workflow stub is the only registered callback that bypasses
+    the agent loop entirely (v1.0 ships only the `list` subaction).
+    """
+    runner_called = False
+
+    async def _spy_runner(_msg: str) -> str:
+        nonlocal runner_called
+        runner_called = True
+        return "should not be reached"
+
+    tree = _FakeTree()
+    register(tree, loop_runner=_spy_runner)
+    interaction = _FakeInteraction()
+
+    await tree.registered["workflow"]["callback"](interaction)
+
+    assert interaction.response.deferred == 1
+    assert len(interaction.followup.sent) == 1
+    assert "v1.1" in interaction.followup.sent[0]
+    assert runner_called is False

--- a/creek-tools/.claude/commands/creek.md
+++ b/creek-tools/.claude/commands/creek.md
@@ -1,0 +1,20 @@
+---
+description: Default `/creek` entry — render the current vault state audit report.
+argument-hint: "(no arguments — see /creek state for explicit form)"
+---
+
+# /creek
+
+The root `/creek` command. With no arguments, it renders the latest vault state report by calling the `creek.state.read` MCP tool. This is the same audit report `creek state` produces from the CLI.
+
+## What I will do
+
+1. Call the `creek.state.read` MCP tool to fetch `<vault>/00-Creek-Meta/State/latest.md`.
+2. Display the wavelength snapshot, active eddies/threads, suggested questions, and any drift warnings.
+3. If the state report is stale, suggest running `/creek state` to regenerate it via `creek.state.render`.
+
+## Related commands
+
+- `/creek state` — explicit form, same behaviour.
+- `/creek phase` and `/creek wavelength` — shorthand for the phase block of the state report.
+- `/creek explain` — list every `/creek` subcommand with descriptions.

--- a/creek-tools/.claude/commands/draft.md
+++ b/creek-tools/.claude/commands/draft.md
@@ -1,0 +1,23 @@
+---
+description: Draft an essay from a mined seed (`creek draft` via MCP).
+argument-hint: "[--phase PHASE] [--index N]"
+---
+
+# /creek draft
+
+Generate a voice-faithful essay draft from a previously mined seed by calling the `creek.draft` MCP tool. Voice fidelity is owned by the `creek-tools` LLM pass — this command does not re-implement composition.
+
+## What I will do
+
+1. Call `creek.draft` with the supplied `--phase` and `--index` (defaults to the top mined seed for the current dominant phase).
+2. The MCP tool returns the draft alongside the skill stack it activated (voice-core + phase + register skills).
+3. Display the draft body, the activated skills, and the source fragment provenance. Suggest saving with `/creek save --target draft`.
+
+## When to use
+
+- After `/creek mine` has surfaced an interesting seed.
+- During a phase where outward expression is appropriate (Rising, Peaking, Restoration).
+
+## Voice-fidelity contract
+
+The composer in the CrawDad loop (FEAT-015) never re-drafts essays inline. Drafting always goes through `creek.draft` so its skill-stack assembly stays consistent across surfaces.

--- a/creek-tools/.claude/commands/explain.md
+++ b/creek-tools/.claude/commands/explain.md
@@ -9,7 +9,7 @@ Help command. Lists every `/creek` subcommand with a one-line description, or â€
 
 ## What I will do
 
-1. Without an argument: list all 10 subcommands (`state`, `lint`, `mine`, `draft`, `save`, `phase`, `wavelength`, `skills`, `ingest`) with descriptions pulled from each file's frontmatter.
+1. Without an argument: list all 10 subcommands (`state`, `lint`, `mine`, `draft`, `save`, `explain`, `phase`, `wavelength`, `skills`, `ingest`) with descriptions pulled from each file's frontmatter.
 2. With an argument: render the matching command file's body.
 3. Unknown subcommand: list the valid ones (no stack trace, no MCP call).
 

--- a/creek-tools/.claude/commands/explain.md
+++ b/creek-tools/.claude/commands/explain.md
@@ -1,0 +1,18 @@
+---
+description: Explain the `/creek` slash command surface — help discoverable anywhere.
+argument-hint: "[SUBCOMMAND]"
+---
+
+# /creek explain
+
+Help command. Lists every `/creek` subcommand with a one-line description, or — when called as `/creek explain <subcommand>` — shows the detailed body of just that command.
+
+## What I will do
+
+1. Without an argument: list all 10 subcommands (`state`, `lint`, `mine`, `draft`, `save`, `phase`, `wavelength`, `skills`, `ingest`) with descriptions pulled from each file's frontmatter.
+2. With an argument: render the matching command file's body.
+3. Unknown subcommand: list the valid ones (no stack trace, no MCP call).
+
+## Discoverability
+
+Per FEAT-016's design, help is reachable from every prefix: `/creek explain`, `/creek <cmd> --help`, and `/creek help` all surface this content.

--- a/creek-tools/.claude/commands/ingest.md
+++ b/creek-tools/.claude/commands/ingest.md
@@ -1,0 +1,25 @@
+---
+description: Ingest a source into the vault (`creek ingest` via MCP).
+argument-hint: "--type TYPE --input PATH"
+---
+
+# /creek ingest
+
+Run the ingestion pipeline by calling the `creek.ingest` MCP tool. Supports the same 12 source platforms the CLI does: Claude exports, ChatGPT exports, Discord, Google Drive, markdown, PDF, DOCX, XLSX/CSV, PPTX, code, OCR images, generic text.
+
+## What I will do
+
+1. Call `creek.ingest` with the supplied `--type` and `--input` (a path under the user's data root).
+2. The MCP tool runs the source-specific parser, applies the redaction pass, and writes fragments under `<vault>/01-Fragments/`.
+3. Display the count of new fragments, the count flagged for review, and any redaction matches.
+
+## When to use
+
+- After exporting a fresh Claude / ChatGPT conversation.
+- To process a new batch of journals, documents, or screenshots.
+- After updating the redaction rules in `creek_config.yaml`.
+
+## Related
+
+- `/creek state --render` after ingestion to refresh the audit report.
+- `/creek lint` to catch classification regressions on the new fragments.

--- a/creek-tools/.claude/commands/lint.md
+++ b/creek-tools/.claude/commands/lint.md
@@ -1,0 +1,20 @@
+---
+description: Run the unified vault hygiene lint pass (`creek lint` via MCP).
+argument-hint: "[--checks CHECKS] [--since DATE]"
+---
+
+# /creek lint
+
+Surface vault hygiene issues — orphaned fragments, drift in classifications, broken links, paradox candidates — by calling the `creek.lint` MCP tool.
+
+## What I will do
+
+1. Call `creek.lint` with the supplied `--checks` and `--since` filters (or the defaults: all checks, last 7 days).
+2. Group findings by severity and section: hygiene first, paradox surfacing second, drift third.
+3. For each paradox candidate, suggest `/creek save --target paradox` to route it to `10-Liminal/Paradoxes/`.
+
+## When to use
+
+- Weekly grooming pass.
+- Before a release of generated content (drafts, reports).
+- After bulk ingestion, to catch classification regressions.

--- a/creek-tools/.claude/commands/mine.md
+++ b/creek-tools/.claude/commands/mine.md
@@ -1,0 +1,20 @@
+---
+description: Mine essay seeds from vault fragments (`creek mine` via MCP).
+argument-hint: "[--phase PHASE] [--limit N]"
+---
+
+# /creek mine
+
+Surface essay-seed candidates from the vault by calling the `creek.mine` MCP tool. Each seed is a thread terminus, eddy spike, or paradox-edge fragment that's ripe for development into a draft.
+
+## What I will do
+
+1. Call `creek.mine` with the supplied `--phase` (defaults to the dominant wavelength phase) and `--limit` (defaults to 10).
+2. Display each seed with its source fragment IDs, strategy (thread-terminus / eddy-spike / paradox-edge), and a one-line provenance summary.
+3. Suggest `/creek draft --index N` to develop a chosen seed.
+
+## When to use
+
+- After a `/creek state` pass — the suggested questions complement the mined seeds.
+- When planning the next Substack / essay / blog post.
+- During a Rising or Peaking phase — mining is appropriate energy; avoid mining during Bottoming Out.

--- a/creek-tools/.claude/commands/phase.md
+++ b/creek-tools/.claude/commands/phase.md
@@ -1,0 +1,24 @@
+---
+description: Show the current Archetypal Wavelength phase (subset of `creek state`).
+argument-hint: "(no arguments)"
+---
+
+# /creek phase
+
+Shorthand for the phase block of the state report. Calls the `creek.state.read` MCP tool and returns just the wavelength snapshot — phase name, confidence, mode, dosage shares, recent transitions.
+
+## What I will do
+
+1. Call `creek.state.read`.
+2. Extract the Wavelength snapshot section (per FEAT-007's `## Wavelength snapshot` heading).
+3. Display phase, confidence, mode, medicine/toxic dosage share, and any recent phase transitions.
+
+## When to use
+
+- Quick orientation: "what phase am I in right now?".
+- Before deciding whether to mine/draft (`Rising`/`Peaking`) or compost/withdraw (`Bottoming Out`/`Diminishing`).
+
+## Related
+
+- `/creek wavelength` — same content, just a different mnemonic.
+- `/creek state` — the full report including eddies, threads, suggested questions.

--- a/creek-tools/.claude/commands/save.md
+++ b/creek-tools/.claude/commands/save.md
@@ -1,0 +1,28 @@
+---
+description: Save an answer or fragment back to the vault (`creek save` via MCP).
+argument-hint: "[--target {fragment|paradox|draft|liminal}] [--body TEXT]"
+---
+
+# /creek save
+
+File an answer, paradox, or draft back to the vault by calling the `creek.save` MCP tool. The save respects the privacy tier of the source content (FEAT-011 write-side tier-ceiling rule).
+
+## What I will do
+
+1. Call `creek.save` with the supplied `--target` (fragment / paradox / draft / liminal) and `--body`.
+2. The MCP tool resolves the destination folder:
+   - `fragment` → `01-Fragments/<inferred-source>/`
+   - `paradox` → `10-Liminal/Paradoxes/`
+   - `draft` → `07-Voice/Drafts/`
+   - `liminal` → `10-Liminal/Unnamed/`
+3. Confirm the path written and the privacy tier applied.
+
+## When to use
+
+- After a `/creek lint` pass flagged a paradox.
+- After `/creek draft` produced an essay you want to keep.
+- To file a reflection or one-off fragment you authored conversationally.
+
+## Privacy tier
+
+The save inherits the privacy tier of the source content. If you're saving content that originated at an `intimate` tier, ensure your session ceiling is `intimate` or higher (see `creek-tools/docs/mcp.md`).

--- a/creek-tools/.claude/commands/skills.md
+++ b/creek-tools/.claude/commands/skills.md
@@ -1,0 +1,24 @@
+---
+description: Manage the voice skill tree (`creek skills` via MCP).
+argument-hint: "[--refresh]"
+---
+
+# /creek skills
+
+Inspect or regenerate the voice-skill tree by calling the `creek.skills` MCP tool.
+
+## What I will do
+
+1. Without args: list the active skill files under `<vault>/creek-skills/` — voice-core, phase skills, register skills.
+2. With `--refresh`: invoke `creek.skills.refresh` on the MCP server to regenerate the voice-skill tree from current vault fragments.
+3. Display the resolved skill stack the CrawDad composer (FEAT-015) will load at next session start.
+
+## When to use
+
+- After significant new voice exemplars have been ingested.
+- When the composer's reply voice feels off.
+- After running `/creek lint --checks voice-drift`.
+
+## Related
+
+The skill stack loaded per CrawDad session is determined by the vault's current wavelength phase plus the developer's default register (`confessional`). FEAT-016's `/crawdad reflect` enters the loop with this stack pre-loaded.

--- a/creek-tools/.claude/commands/state.md
+++ b/creek-tools/.claude/commands/state.md
@@ -1,0 +1,20 @@
+---
+description: Render the current vault audit report (`creek state` via MCP).
+argument-hint: "[--render]"
+---
+
+# /creek state
+
+Render the vault's audit report by calling the `creek.state.read` MCP tool. Pass `--render` to force a fresh regeneration via the `creek.state.render` tool (slower but reflects the latest fragments).
+
+## What I will do
+
+1. Default: call `creek.state.read` — cheap; returns the cached `latest.md`.
+2. With `--render`: call `creek.state.render` — re-walks the vault and rewrites `latest.md`.
+3. Display the wavelength snapshot first (per FEAT-007 ordering), then active eddies, threads, surprising connections, and suggested questions.
+
+## When to use
+
+- Daily orientation: "what's surfacing this week?".
+- Before drafting (`/creek mine`, `/creek draft`) — the suggested questions block primes mining.
+- After an `/creek ingest` run — pass `--render` to refresh.

--- a/creek-tools/.claude/commands/wavelength.md
+++ b/creek-tools/.claude/commands/wavelength.md
@@ -1,0 +1,22 @@
+---
+description: Alias for `/creek phase` — show the current Archetypal Wavelength snapshot.
+argument-hint: "(no arguments)"
+---
+
+# /creek wavelength
+
+Mnemonic alias for `/creek phase`. Same behaviour — reads the wavelength snapshot from the vault state via the `creek.state.read` MCP tool.
+
+## What I will do
+
+1. Call `creek.state.read`.
+2. Display the Wavelength snapshot block: phase, confidence, mode, dosage shares, recent transitions.
+
+## When to use
+
+When "wavelength" is the more natural word than "phase" — e.g., after a long retreat or a notable mood shift.
+
+## Related
+
+- `/creek phase` — same command, different name.
+- `/creek state` — full state report (wavelength + eddies + threads + suggested questions).

--- a/creek-tools/CLAUDE.md
+++ b/creek-tools/CLAUDE.md
@@ -339,6 +339,17 @@ Significant architectural decisions live in
 files. Skill guidance for *how* to write a decision record lives at
 the repository-level `.claude/skills/architectural-decisions/SKILL.md`.
 
+### 5.4 Slash commands (FEAT-016)
+
+`creek-tools/.claude/commands/` hosts the `/creek` slash-command surface
+that Claude Code reads when the user types `/creek <subcommand>`. Each
+file is a markdown skill with YAML frontmatter (`description`,
+`argument-hint`) and a body that names the MCP tool the command
+invokes (`creek.state.read`, `creek.lint`, `creek.mine`, etc.). The
+companion `/crawdad` surface lives in `crawdad/crawdad/slash_commands.py`
+and routes through the FEAT-015 agent loop. End-user documentation is
+in [`docs/slash-commands.md`](docs/slash-commands.md).
+
 ---
 
 ## 6. Quality Standards

--- a/creek-tools/docs/slash-commands.md
+++ b/creek-tools/docs/slash-commands.md
@@ -1,0 +1,86 @@
+# Slash commands (`/creek` and `/crawdad`)
+
+FEAT-016 ships two small slash-command surfaces that share a grammar:
+`/creek` for Claude Code, `/crawdad` for Discord. Both invoke the same
+MCP tool surface, so the two front doors lead to one system.
+
+## Why two surfaces?
+
+- **`/creek`** — the developer's keyboard in Claude Code. Ten commands,
+  one per `creek` primitive. Calls go through the `creek-tools-mcp`
+  server (stdio).
+- **`/crawdad`** — the user's conversation in Discord. Six commands,
+  each entering the FEAT-015 agent loop with a pre-baked user message
+  so Sonnet composes the reply in your voice. The loop ultimately
+  calls the same MCP tools.
+
+## `/creek <subcommand>` (Claude Code)
+
+Each subcommand is a markdown skill under
+`creek-tools/.claude/commands/<name>.md`. Claude Code reads the file
+body as the prompt when you type `/creek <name>`.
+
+| Command | MCP tool | Purpose |
+|---|---|---|
+| `/creek` (no args) | `creek.state.read` | Default: render the latest vault state. |
+| `/creek state [--render]` | `creek.state.read` or `creek.state.render` | Audit report; `--render` forces regeneration. |
+| `/creek lint [--checks ...] [--since DATE]` | `creek.lint` | Vault hygiene + drift + paradox surfacing. |
+| `/creek mine [--phase ...] [--limit N]` | `creek.mine` | Surface essay seeds. |
+| `/creek draft [--phase ...] [--index N]` | `creek.draft` | Generate a voice-faithful draft from a mined seed. |
+| `/creek save --target ...` | `creek.save` | File an answer / paradox / draft / liminal item. |
+| `/creek explain [SUBCOMMAND]` | none (help) | List commands or render one in detail. |
+| `/creek phase` | `creek.state.read` | Shorthand for the wavelength snapshot only. |
+| `/creek wavelength` | `creek.state.read` | Alias for `/creek phase`. |
+| `/creek skills [--refresh]` | `creek.skills` / `creek.skills.refresh` | Inspect or regenerate the voice-skill tree. |
+| `/creek ingest --type ... --input ...` | `creek.ingest` | Run the ingestion pipeline on a new source. |
+
+### Discoverability
+
+`/creek explain` lists every subcommand. Bare `/creek` runs the default
+(state report). Each command file documents its own purpose, so
+help-at-every-prefix works by reading the file Claude Code already
+ships in the prompt.
+
+## `/crawdad <subcommand>` (Discord)
+
+Registered as Discord application slash commands. Each routes through
+the FEAT-015 agent loop: the slash command builds a pre-formulated
+user message and runs it through `loop.run_one_turn`. The Sonnet
+composer (FEAT-015) wraps the tool results in your voice.
+
+| Command | Behaviour |
+|---|---|
+| `/crawdad` (no args) | Open reflective conversation mode — the FEAT-015 loop with no preselected intents. |
+| `/crawdad reflect` | Same as bare `/crawdad`. Conversational entry point. |
+| `/crawdad checkin` | Wavelength check-in: routes through `creek.state.read` and asks Sonnet to summarise the phase. |
+| `/crawdad surface` | Surface paradoxes, liminal content, or emerging themes via `creek.lint`. |
+| `/crawdad draft <topic>` | Mine + draft an essay on the supplied topic (routes through `creek.mine` and `creek.draft`). |
+| `/crawdad save <content>` | File the supplied content back to the vault via `creek.save`. |
+| `/crawdad workflow [list]` | Stub. Returns the v1.1 placeholder; full workflow DSL ships with the next FEAT. |
+
+### Why Discord gets a smaller surface
+
+The Discord conversation is the user's frontend. Six commands is
+enough to cover the common moves (check-in, surface, draft, save,
+reflect, workflow-list). Deeper inspection happens via the developer's
+`/creek` surface in Claude Code.
+
+### Default reply formatting
+
+Discord doesn't render markdown tables well. `/crawdad` replies use
+code blocks for structured data (paths, IDs) and bullet lists for
+prose summaries. Tables are avoided.
+
+## Privacy tier
+
+Both surfaces inherit the privacy ceiling rules from FEAT-010/011/012.
+The Discord bot's MCP client does not get the elevated purge token
+(FEAT-013 §31), so `/crawdad` cannot invoke purge tools. The `/creek`
+surface in the developer's Claude Code can, if the developer sets the
+elevated token in `mcp.json`.
+
+## See also
+
+- `creek-tools/docs/mcp.md` — MCP tool surface and privacy tier rules.
+- `crawdad/CLAUDE.md` — CrawDad architecture and quality bar.
+- [`plans/git-issues/FEAT-016-slash-command-grammar.md`](../../plans/git-issues/FEAT-016-slash-command-grammar.md) — the FEAT spec.

--- a/creek-tools/tests/test_slash_commands.py
+++ b/creek-tools/tests/test_slash_commands.py
@@ -1,0 +1,100 @@
+"""Test the `/creek` slash command skill files (FEAT-016).
+
+Each `.claude/commands/<name>.md` file is a Claude Code slash command:
+optional YAML frontmatter followed by a Markdown body that becomes the
+prompt when the user types ``/creek <name>``. The tests here pin the
+file set, the frontmatter shape, and that every command's body
+references a real MCP tool name from the `creek-tools-mcp` surface.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+_COMMANDS_DIR = Path(__file__).resolve().parent.parent / ".claude" / "commands"
+
+_EXPECTED_COMMANDS = {
+    "creek",  # the root command (no-arg fallback to creek state)
+    "state",
+    "lint",
+    "mine",
+    "draft",
+    "save",
+    "explain",
+    "phase",
+    "wavelength",
+    "skills",
+    "ingest",
+}
+
+
+def test_commands_directory_exists() -> None:
+    """The .claude/commands directory ships with creek-tools."""
+    assert _COMMANDS_DIR.is_dir(), f"{_COMMANDS_DIR} should exist"
+
+
+def test_all_required_commands_have_files() -> None:
+    """Each of the 11 documented commands has a markdown file."""
+    on_disk = {p.stem for p in _COMMANDS_DIR.glob("*.md")}
+    missing = _EXPECTED_COMMANDS - on_disk
+    assert not missing, f"missing command files: {sorted(missing)}"
+
+
+@pytest.mark.parametrize("name", sorted(_EXPECTED_COMMANDS))
+def test_command_frontmatter_parses(name: str) -> None:
+    """Every command file has parseable YAML frontmatter with a description."""
+    body = (_COMMANDS_DIR / f"{name}.md").read_text(encoding="utf-8")
+    frontmatter = _extract_frontmatter(body)
+    assert frontmatter is not None, f"{name}.md missing frontmatter"
+    assert "description" in frontmatter, f"{name}.md missing description"
+    assert frontmatter["description"].strip(), f"{name}.md description is empty"
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_tool"),
+    [
+        ("creek", "creek.state"),
+        ("state", "creek.state"),
+        ("lint", "creek.lint"),
+        ("mine", "creek.mine"),
+        ("draft", "creek.draft"),
+        ("save", "creek.save"),
+        ("phase", "creek.state"),
+        ("wavelength", "creek.state"),
+        ("skills", "creek.skills"),
+        ("ingest", "creek.ingest"),
+    ],
+)
+def test_command_body_references_mcp_tool(name: str, expected_tool: str) -> None:
+    """Each command's body names the MCP tool it routes through."""
+    body = (_COMMANDS_DIR / f"{name}.md").read_text(encoding="utf-8")
+    assert expected_tool in body, (
+        f"{name}.md must mention the {expected_tool!r} MCP tool"
+    )
+
+
+def test_explain_command_body_describes_its_purpose() -> None:
+    """``/creek explain`` is the help command — narrative, not a tool call."""
+    body = (_COMMANDS_DIR / "explain.md").read_text(encoding="utf-8")
+    assert "help" in body.lower() or "explain" in body.lower()
+
+
+def test_root_creek_command_documents_default_action() -> None:
+    """Bare ``/creek`` (no args) renders the state report — documented in body."""
+    body = (_COMMANDS_DIR / "creek.md").read_text(encoding="utf-8")
+    assert "state" in body.lower()
+
+
+def _extract_frontmatter(text: str) -> dict[str, object] | None:
+    """Return the parsed YAML frontmatter, or ``None`` if absent."""
+    if not text.startswith("---\n"):
+        return None
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return None
+    raw = text[4:end]
+    loaded = yaml.safe_load(raw)
+    return loaded if isinstance(loaded, dict) else None


### PR DESCRIPTION
## Summary

Closes CrawDad v1.0 — adds the two slash-command surfaces FEAT-016 mandates: **`/creek`** (10 commands for Claude Code) and **`/crawdad`** (6 commands for Discord). Both surfaces invoke the same MCP tool surface, so Discord and Claude Code feel like one system from two front doors.

Implements [`plans/git-issues/FEAT-016-slash-command-grammar.md`](https://github.com/Geoffe-Ga/Creek-Vault/blob/claude/slash-commands-feat-016/plans/git-issues/FEAT-016-slash-command-grammar.md).

## Acceptance criteria coverage

| FEAT-016 acceptance criterion | Status | Verified by |
|---|---|---|
| 10 `/creek` slash commands exist as Claude Code skill files | ✅ | `creek-tools/.claude/commands/{creek,state,lint,mine,draft,save,explain,phase,wavelength,skills,ingest}.md` (11 files inc. root) |
| 6 `/crawdad` slash commands registered with Discord and routed through MCP | ✅ | `crawdad/crawdad/slash_commands.py` + `bot.py` `CommandTree` wiring |
| Default actions documented and working | ✅ | `/creek` (no args) → state report; `/crawdad` reflect handler |
| Help discoverable at every prefix | ✅ | `/creek explain` lists everything; `handle_help` returns the six `/crawdad` commands |
| `/crawdad workflow` stub returns v1.1 placeholder cleanly | ✅ | `tests/test_slash_commands.py::test_handle_workflow_*` |
| **≥ 90% branch coverage on `crawdad/crawdad/slash_commands.py`** | ✅ | **`slash_commands.py` at 100%** (file is in the complete-coverage skip-list); aggregate 93.15% |
| `creek-tools/docs/slash-commands.md` + `crawdad/README.md` document the surfaces | ✅ | Both files committed |

## Architecture

```
Claude Code keystroke `/creek <cmd>`         Discord `/crawdad <cmd>`
        │                                          │
        ▼                                          ▼
  .claude/commands/<cmd>.md       slash_commands.handle_<cmd>(replier, loop_runner)
   (markdown skill body)                    │
        │                                   ▼
        └──────────► creek-tools-mcp ◄── FEAT-015 loop (router → dispatch → composer)
                          │
                          ▼
                       Vault
```

The `/creek` surface is a 1-to-1 mapping from command name to MCP tool (no LLM loop — Claude Code itself runs the skill body as the prompt). The `/crawdad` surface enters the FEAT-015 agent loop so the Sonnet composer wraps the tool results in the user's voice.

## What ships

| File | Purpose |
|---|---|
| `creek-tools/.claude/commands/*.md` (11 files) | `/creek` skill files. YAML frontmatter (`description`, `argument-hint`) + body naming the MCP tool. |
| `creek-tools/tests/test_slash_commands.py` | 25 tests pin the file set, frontmatter parseability, and MCP-tool references. |
| `creek-tools/docs/slash-commands.md` | End-user grammar reference. |
| `creek-tools/CLAUDE.md §5.4` | New paragraph pointing at the commands directory. |
| `crawdad/crawdad/slash_commands.py` | 6 Discord slash commands + 7 testable free-function handlers + module-level command/description invariant. |
| `crawdad/crawdad/bot.py` | `CommandTree` construction + `setup_hook` sync. |
| `crawdad/crawdad/cli.py` | `_build_loop_runner` factory wiring the agent loop into a callable the slash handlers invoke; `_truncate_for_discord` enforces the 1900-char soft cap. |
| `crawdad/tests/test_slash_commands.py` | 18 tests cover each handler, the workflow stub, empty-arg refusals, parametrized callback dispatch, registration wiring. |
| `crawdad/tests/test_bot.py` | 4 new tests pin CommandTree registration + `setup_hook`. |
| `crawdad/tests/test_cli.py` | 5 new tests pin the loop-runner factory + truncation + soft error. |
| `crawdad/README.md`, `crawdad/CLAUDE.md` | Updated for the v1.0 final state. |

## Pre-decided choices honoured

- **Slash surface kept small on purpose.** Ten `/creek` commands + six `/crawdad` commands, no more.
- **Default actions.** Bare `/creek` → `state`; bare `/crawdad` → `reflect`.
- **All slash commands invoke MCP tools, not subprocess CLI calls.** One tool surface, two front doors.
- **`/creek` skill files** live under `creek-tools/.claude/commands/`, separate from the Python package.
- **Help discoverable from any prefix** — `/creek explain`, `handle_help`.
- **Discord-specific formatting**: replies use code blocks for structured data, bullet lists for prose; soft-capped at 1900 chars.
- **`/crawdad workflow` is a v1.0 stub** — only `list` is supported, returning the v1.1 placeholder.

## Quality state (current HEAD)

- ✅ **`./scripts/check-all.sh` in `crawdad/` exits 0** — 7/7 gates green, **144 tests pass**, **93.15% aggregate branch coverage**, **`slash_commands.py` at 100% per-file**.
- ✅ **`creek-tools/`** — full quality suite green (10/10 gates), 3505 tests pass, 93.54% branch coverage, 124 files ≥ 80% per-file.
- ✅ **No literal model IDs outside `crawdad/config.py`** — `test_no_model_literals.py` passes.
- ✅ **CI green on all 11 jobs** for the prior HEAD (`b4d54c8`); the current HEAD (`1d0f7d1`) is two doc-only commits later.

## Reviews and iterations

| Round | HEAD | Verdict | Outcome |
|---|---|---|---|
| 1 | `69750b7` | CHANGES_REQUESTED (3 items: coverage, error handling, required params) | All addressed in `ebb7122`. |
| 2 | `ebb7122` | LGTM, then a parallel CHANGES_REQUESTED (1 HIGH: Discord length limit) | Addressed in `b4d54c8`. |
| 3 | `b4d54c8` | LGTM, then CHANGES_REQUESTED (3 polish nits) | Addressed in `9297892`. |
| 4 | `9297892` | LGTM, then CHANGES_REQUESTED (2 nits + coverage confirmation) | Addressed in `1d0f7d1`. |

## LOC breakdown (final)

| Category | LOC |
|---|---|
| Source (`slash_commands.py` + edits to `bot.py`, `cli.py`) | ~350 |
| Skill markdown (`.claude/commands/*.md`, 11 files) | ~270 |
| Tests (creek-tools + crawdad slash tests + bot/cli edits) | ~580 |
| Docs (`slash-commands.md`, README/CLAUDE.md updates) | ~260 |
| **Total diff** | **+1477 / -48** |

## v1.0 closing note

This closes the v1.0 roadmap for CrawDad. Waves 3, 4, and 5 are complete. The full agent loop (Haiku router + MCP dispatcher + Sonnet composer + voice-skill activation) is now accessible from both Discord (conversational + slash commands) and Claude Code (slash commands).

FEAT-017+ (classification hardening) and the v1.1 workflow DSL (ADAPT-003) are the natural next pieces.