### PR TITLE
chore(deps-dev): consolidate cryptography/pip/pyjwt/wheel pin bumps

### DIFF
--- a/creek-tools/requirements-dev.txt
+++ b/creek-tools/requirements-dev.txt
@@ -10,8 +10,8 @@
 # Pinned transitive bumps to address pip-audit findings (DEP-003).
 # These are dev/build-time tools whose vulnerable older versions can leak
 # in via pip's resolver. See ./scripts/security.sh for documented ignores.
-cryptography>=46.0.6
-pip>=26.1
-pyjwt>=2.12.0
+cryptography>=48.0.0
+pip>=26.1.1
+pyjwt>=2.12.1
 setuptools>=78.1.1
-wheel>=0.46.2
+wheel>=0.47.0


### PR DESCRIPTION
## Summary

Consolidates the four open Dependabot PRs against `creek-tools/requirements-dev.txt` (the DEP-003 dev-tool pin set) into a single update:

| PR | Package | From | To |
|----|---------|------|----|
| #221 | `cryptography` | `>=46.0.6` | `>=48.0.0` |
| #222 | `pip` | `>=26.1` | `>=26.1.1` |
| #196 | `pyjwt` | `>=2.12.0` | `>=2.12.1` |
| #198 | `wheel` | `>=0.46.2` | `>=0.47.0` |

All four are dev/build-time pins maintained to satisfy `pip-audit` findings — keeping them in lockstep avoids resolver churn from four separate PRs.

### Compatibility notes

- `cryptography 48.0.0` drops Python 3.8 support. `creek-tools` already requires `python >=3.11`, so this is a no-op for us.
- `pip 26.1.1` is a bugfix release over `26.1` (the `__pycache__` removal revert).
- `pyjwt 2.12.1` adds a missing `typing_extensions` dep for Python <3.11 — irrelevant for our floor but harmless.
- `wheel 0.47.0` is a feature release with no API removals.

### Closes

Closes #196
Closes #198
Closes #221
Closes #222

## Test plan

- [ ] CI green on `creek-tools` jobs (3.11 / 3.12 / 3.13)
- [ ] `./scripts/security.sh` (pip-audit) still passes locally
- [ ] Dependabot PRs auto-close on merge

https://claude.ai/code/session_017Kfx9NSjuw8RPdL5wJB4nA

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKtBqLcfbS8SeyPgxVQV7Y)_