### PR TITLE
test(calibration): rebalance fixture coverage across all dimensions

### DIFF
--- a/creek-tools/tests/fixtures/classification/calibration_set.yaml
+++ b/creek-tools/tests/fixtures/classification/calibration_set.yaml
@@ -21,10 +21,12 @@
 # Coverage targets: every frequency ≥3 entries; every phase ≥4 entries;
 # every mode ≥6 entries; every register and orientation ≥4 entries;
 # every dosage ≥6 entries (medicine naturally dominates introspective
-# fragments, so its ratio is looser than other dimensions). When adding
-# new entries, prefer the rarest cell in each dimension so the rarest
-# value stays within ~3× the most common — that keeps the agreement
-# metric well-conditioned across every value.
+# fragments, so its ratio is looser than other dimensions: currently
+# ~4.67× the rarest dosage value, tolerate up to ~5× before adding
+# more toxic/ambiguous entries). When adding new entries, prefer the
+# rarest cell in each dimension so the rarest value stays within ~3×
+# the most common on every non-dosage dimension — that keeps the
+# agreement metric well-conditioned across every value.
 - id: cal-001
   title: Lockout
   body: My keys are gone and I cannot get into the apartment tonight. Stomach is in

--- a/creek-tools/tests/fixtures/classification/calibration_set.yaml
+++ b/creek-tools/tests/fixtures/classification/calibration_set.yaml
@@ -18,9 +18,13 @@
 #     dosage:           medicine | toxic | ambiguous
 #     voice_register:   confessional | analytical | playful | prophetic | instructional | raw | conversational
 #
-# Coverage targets: every frequency at least once; every phase at least once;
-# every mode, dosage, register, and orientation appears in ≥3 entries so the
-# agreement metric has signal on every value.
+# Coverage targets: every frequency ≥3 entries; every phase ≥4 entries;
+# every mode ≥6 entries; every register and orientation ≥4 entries;
+# every dosage ≥6 entries (medicine naturally dominates introspective
+# fragments, so its ratio is looser than other dimensions). When adding
+# new entries, prefer the rarest cell in each dimension so the rarest
+# value stays within ~3× the most common — that keeps the agreement
+# metric well-conditioned across every value.
 - id: cal-001
   title: Lockout
   body: My keys are gone and I cannot get into the apartment tonight. Stomach is in
@@ -373,3 +377,127 @@
     orientation: do_feel
     dosage: medicine
     voice_register: confessional
+# Coverage-fill entries (cal-033..cal-042) added to lift the rarest values
+# in each dimension to the floors named in the header. Each entry targets
+# a previously underrepresented cell across frequency, phase, mode, dosage,
+# register, and orientation.
+- id: cal-033
+  title: Nothing has weight
+  body: Nothing has weight tonight. Not the book, not the food, not the worry I
+    came in with. I do not know if this is peace or numbness and I cannot tell
+    which would be worse.
+  expected:
+    frequency: F10
+    phase: bottoming_out
+    mode: inhabit
+    orientation: feel
+    dosage: ambiguous
+    voice_register: raw
+- id: cal-034
+  title: Stepping back from the chair
+  body: I have been the one calling the shots for two years and the cost is
+    showing. Stepping back from the chair is the only honest move, and I can
+    see the next person taking it better than I would now.
+  expected:
+    frequency: F3
+    phase: diminishing
+    mode: integrate
+    orientation: do_feel
+    dosage: medicine
+    voice_register: analytical
+- id: cal-035
+  title: Three folders and a clearing time
+  body: Three folders, one clearing time, no email after seven. Run it for six
+    months and re-evaluate. The system either still fits or it does not, and
+    either answer is allowed.
+  expected:
+    frequency: F4
+    phase: diminishing
+    mode: absorb
+    orientation: do_feel
+    dosage: ambiguous
+    voice_register: instructional
+- id: cal-036
+  title: Walking the watershed again
+  body: We walked the watershed trail again. The frogs are back this spring
+    after two years quiet. We will keep walking it once a month and write down
+    what we see, because nobody else is.
+  expected:
+    frequency: F8
+    phase: restoration
+    mode: integrate
+    orientation: do_feel
+    dosage: medicine
+    voice_register: prophetic
+- id: cal-037
+  title: The kettle whistled
+  body: The kettle whistled and I noticed I had been gone. Not gone-gone. Just
+    absent of myself, in the good way. The tea is excellent and I am right
+    here.
+  expected:
+    frequency: F10
+    phase: restoration
+    mode: absorb
+    orientation: feel
+    dosage: medicine
+    voice_register: playful
+- id: cal-038
+  title: Three sentences for stepping down
+  body: Three sentences for stepping down well. I am leaving the role. I am not
+    leaving the team. I am happy to help you find a replacement. Say them out
+    loud before the meeting.
+  expected:
+    frequency: F3
+    phase: restoration
+    mode: express
+    orientation: do
+    dosage: medicine
+    voice_register: instructional
+- id: cal-039
+  title: The rules we are not living
+  body: We agreed on the household rules two years ago and we are not living
+    them. Nobody wants to be the one to bring it up. We keep sleeping past the
+    agreed wake time and resenting each other quietly.
+  expected:
+    frequency: F4
+    phase: bottoming_out
+    mode: collaborate
+    orientation: do_feel
+    dosage: toxic
+    voice_register: conversational
+- id: cal-040
+  title: Reading the brief at midnight
+  body: The maples on this block lost their colour two weeks early again. I have
+    been reading the climate brief at midnight every night this week. Tomorrow
+    I will know more things and feel exactly the same way.
+  expected:
+    frequency: F8
+    phase: diminishing
+    mode: absorb
+    orientation: do_feel
+    dosage: toxic
+    voice_register: raw
+- id: cal-041
+  title: The question I used to lose sleep over
+  body: Used to be that this question would keep me up all night. Now it is just
+    a question. I am not sure if I have outgrown it or buried it. Either way
+    the kettle is on.
+  expected:
+    frequency: F10
+    phase: diminishing
+    mode: inhabit
+    orientation: feel
+    dosage: ambiguous
+    voice_register: playful
+- id: cal-042
+  title: Group text gone quiet
+  body: Group text has been quiet for a week and I am the only one who feels it.
+    Probably they are fine. Probably I have made it into a thing it is not. The
+    not knowing is the worst part.
+  expected:
+    frequency: F2
+    phase: bottoming_out
+    mode: inhabit
+    orientation: feel
+    dosage: toxic
+    voice_register: raw


### PR DESCRIPTION
## Summary

The FEAT-017 `calibration_set.yaml` met its stated minimums (every frequency/phase ≥1, every mode/dosage/register/orientation ≥3) but several dimensions skewed heavily, leaving the per-dimension agreement metric weakly conditioned on rare values. This PR appends 10 new entries (`cal-033`..`cal-042`) targeting the rarest cell in each dimension, and tightens the header coverage targets to reflect the new floors. **No existing labels were modified** — ground truth is preserved.

## Before → After (max / min counts and worst-case ratio)

| Dimension      | Before                                        | After                                       |
|----------------|-----------------------------------------------|---------------------------------------------|
| frequency      | F10=1, F3/F4/F8=2 … F9=8  (**ratio 8.00×**)   | min=3, max=8  (**ratio 2.67×**)             |
| phase          | bot/dim=2 … peaking=9  (**ratio 4.50×**)      | min=5, max=9  (**ratio 1.80×**)             |
| mode           | 5 … express=11  (**ratio 2.20×**)             | min=6, max=12  (**ratio 2.00×**)            |
| orientation    | do_feel=4 … feel=16  (**ratio 4.00×**)        | min=9, max=20  (**ratio 2.22×**)            |
| dosage         | toxic=3 … medicine=24  (**ratio 8.00×**)      | min=6, max=28  (**ratio 4.67×**) †          |
| voice_register | inst/playful=2 … confessional=11  (**5.50×**) | min=4, max=11  (**ratio 2.75×**)            |

† `medicine` naturally dominates introspective journal-style fragments; the header now explicitly notes the dosage ratio is allowed to be looser than other dimensions.

## What the new entries cover

Each entry hits one of the previously-underrepresented cells in multiple dimensions simultaneously:

| ID | freq | phase | mode | orient | dosage | register |
|----|------|-------|------|--------|--------|----------|
| cal-033 | F10 | bottoming_out | inhabit | feel | ambiguous | raw |
| cal-034 | F3  | diminishing | integrate | do_feel | medicine | analytical |
| cal-035 | F4  | diminishing | absorb | do_feel | ambiguous | instructional |
| cal-036 | F8  | restoration | integrate | do_feel | medicine | prophetic |
| cal-037 | F10 | restoration | absorb | feel | medicine | playful |
| cal-038 | F3  | restoration | express | do | medicine | instructional |
| cal-039 | F4  | bottoming_out | collaborate | do_feel | toxic | conversational |
| cal-040 | F8  | diminishing | absorb | do_feel | toxic | raw |
| cal-041 | F10 | diminishing | inhabit | feel | ambiguous | playful |
| cal-042 | F2  | bottoming_out | inhabit | feel | toxic | raw |

## Test plan

- [x] YAML parses (`yaml.safe_load` round-trip)
- [x] All 42 entries carry the full 6-dimension `expected:` block
- [x] IDs unique and sequential
- [x] `pytest tests/test_calibration.py` — 26 passed
- [x] `pytest tests/test_cli.py -k calibrate` — 4 passed
- [x] `pytest tests/test_taxonomy_alignment.py` — 7 passed (no enum drift)
- [ ] Reviewer: spot-check that the new ground-truth labels read as defensible (esp. cal-033 ambiguous vs toxic, cal-035 instructional voice with diminishing phase, cal-040 do_feel vs feel)

## Out of scope (flagged from the same audit, deferred)

- **Frequency naming drift** between `canonical_taxonomy.yaml` (F1=Agency, F2=Receptivity, F8=True Self/Transcendence) and `frequency.yaml` few-shot rationales (F1=survival, F2=tribal-belonging, F8=ecological holism). The calibration set follows the few-shot framing; reconciling with the spec is a separate ontology-alignment task.
- **`dosage.yaml` few-shot skew** (2 medicine / 2 toxic / 1 ambiguous) — minor; not a calibration-coverage issue.
- **Possible label re-review** on `cal-001` (lockout → peaking/ambiguous) and `cal-023` ("What I have not told anyone" → F9 unity), both of which read closer to other labels but were left untouched per the no-relabel rule of this PR.

https://claude.ai/code/session_011yeqi7n5ipiSTa1wCjWbNn

---
_Generated by [Claude Code](https://claude.ai/code/session_011yeqi7n5ipiSTa1wCjWbNn)_