### PR TITLE
Add OpenClaw skill pack for Creek CLI maximum utility

### DIFF
--- a/.openclaw/README.md
+++ b/.openclaw/README.md
@@ -1,0 +1,21 @@
+# OpenClaw Skills for Creek Vault
+
+This directory provides OpenClaw-discoverable skills for operating the
+Creek Vault repository and Creek CLI at maximum utility.
+
+## Start here
+
+- `.openclaw/skills/creek-max-utility/SKILL.md` (orchestrator)
+
+## Focused playbooks
+
+- `.openclaw/skills/creek-cli-playbooks/compile-query-lint-save.SKILL.md`
+- `.openclaw/skills/creek-cli-playbooks/init-sync-generate.SKILL.md`
+- `.openclaw/skills/creek-cli-playbooks/safety-and-quality-gates.SKILL.md`
+
+## Design goals
+
+- Fast intent-to-command mapping
+- Canonical usage of `creek` CLI verbs
+- Reproducible command evidence and quality gates
+- Strict provenance, contradiction, and privacy-tier discipline

--- a/.openclaw/skills/creek-cli-playbooks/compile-query-lint-save.SKILL.md
+++ b/.openclaw/skills/creek-cli-playbooks/compile-query-lint-save.SKILL.md
@@ -1,0 +1,53 @@
+---
+name: compile-query-lint-save
+description: >-
+  Execute Creek's core four-verb lifecycle with reproducible CLI operations.
+  Use when an OpenClaw agent must transform fragments, answer questions,
+  inspect hygiene, and persist results in-vault. Includes command order,
+  fallback logic, and evidence capture. Do NOT use for repository bootstrapping;
+  use init-sync-generate.
+metadata:
+  owner: Creek Vault
+  version: 1.0.0
+---
+
+# Compile / Query / Lint / Save Playbook
+
+## Recommended order
+
+1. `creek compile --vault <path>`
+2. `creek query --vault <path> --question "..."`
+3. `creek lint --vault <path>`
+4. `creek save --vault <path> ...` (if user requests persistence)
+
+## Compile protocol
+
+- Use compile before high-confidence answers when fragments may be newer than compiled pages.
+- Capture what was compiled and whether any pages were skipped/refused.
+
+## Query protocol
+
+- Default to compiled-first behavior.
+- Use bypass mode only when user explicitly needs raw fragment-level investigation.
+- Return confidence notes when answers depend on stale or sparse compiled data.
+
+## Lint protocol
+
+- Run lint after substantial updates or before save/reporting.
+- Treat lint contradictions as signals for paradox handling, not auto-fixes.
+
+## Save protocol
+
+- Pick kind deliberately (`thread`, `eddy`, `praxis`, `paradox`, etc.).
+- Include concise title/body that preserves meaning and provenance context.
+- Respect privacy-tier defaults and explicit consent requirements.
+
+## Minimal artifact log template
+
+```text
+Intent:
+Command:
+Exit:
+Artifacts:
+Decision:
+```

--- a/.openclaw/skills/creek-cli-playbooks/init-sync-generate.SKILL.md
+++ b/.openclaw/skills/creek-cli-playbooks/init-sync-generate.SKILL.md
@@ -1,0 +1,39 @@
+---
+name: init-sync-generate
+description: >-
+  Bootstrap and maintain canonical vault scaffolding and skill trees through the
+  Creek CLI. Use when an OpenClaw agent needs to initialize a vault, refresh
+  schema skills, or regenerate the voice-skill tree. Do NOT use for day-to-day
+  compile/query/lint/save execution; use compile-query-lint-save.
+metadata:
+  owner: Creek Vault
+  version: 1.0.0
+---
+
+# Init / Sync / Generate Playbook
+
+## Use cases
+
+- New vault setup
+- Post-upgrade schema skill refresh
+- Regeneration of `creek-skills/` voice tree
+
+## Commands
+
+```bash
+creek init --vault <path>
+creek skills sync --vault <path>
+creek skills generate --vault <path> [--output <path>]
+```
+
+## Rules
+
+1. `init` is for first-time structure creation and safe refresh of canonical assets.
+2. `skills sync` updates schema-skill files from upstream templates.
+3. `skills generate` builds style/voice-oriented skill trees; keep distinct from schema-skill contract.
+
+## Validation steps
+
+- Verify generated/updated paths exist.
+- Summarize counts or changed files where output provides them.
+- If run in repo development mode, commit only intended artifacts.

--- a/.openclaw/skills/creek-cli-playbooks/safety-and-quality-gates.SKILL.md
+++ b/.openclaw/skills/creek-cli-playbooks/safety-and-quality-gates.SKILL.md
@@ -1,0 +1,38 @@
+---
+name: safety-and-quality-gates
+description: >-
+  Apply operational safety checks for provenance, contradiction handling, and
+  privacy-tier protection during Creek CLI workflows. Use when an OpenClaw
+  agent is about to finalize outputs or save content. Do NOT use as a substitute
+  for the command execution playbooks.
+metadata:
+  owner: Creek Vault
+  version: 1.0.0
+---
+
+# Safety and Quality Gates
+
+## Gate 1: Provenance integrity
+
+- Do not present synthesized claims as facts without source alignment.
+- Preserve IDs/traceability where the workflow provides it.
+
+## Gate 2: Contradictions are data
+
+- If claims conflict, route to paradox/liminal handling.
+- Never silently choose a winner unless explicitly asked for a hypothesis.
+
+## Gate 3: Privacy-tier discipline
+
+- Treat intimate content as opt-in for reuse.
+- Avoid accidental persistence or exposure in generated artifacts.
+
+## Gate 4: CLI correctness
+
+- Validate command/flags against `creek-tools/creek/cli.py`.
+- Avoid shell one-offs that bypass documented behavior unless debugging is required.
+
+## Gate 5: Final response quality
+
+- Include what was done, what changed, and what remains uncertain.
+- Provide reproducible commands for follow-up.

--- a/.openclaw/skills/creek-max-utility/SKILL.md
+++ b/.openclaw/skills/creek-max-utility/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: creek-max-utility
+description: >-
+  Operate the Creek Vault repository with maximum effectiveness through the
+  canonical CLI lifecycle. Use when an OpenClaw agent needs to answer,
+  compile, lint, save, scaffold, or maintain a Creek vault with reliable
+  provenance and privacy controls. Provides end-to-end runbooks, command
+  selection logic, and quality gates. Do NOT use for general Python coding
+  style advice unrelated to Creek operations.
+metadata:
+  owner: Creek Vault
+  version: 1.0.0
+---
+
+# Creek Max Utility
+
+Primary orchestration skill for OpenClaw agents working in this repository.
+Follow this skill first, then load the referenced playbooks for the specific
+verb being executed.
+
+## What "maximum utility" means
+
+1. Prefer canonical Creek commands over ad-hoc scripts whenever a command
+   exists.
+2. Preserve provenance and privacy-tier guarantees.
+3. Use compile/query/lint/save as the default operating loop.
+4. Keep repository + vault state reproducible (document flags, paths, outputs).
+
+## Repository orientation (first 90 seconds)
+
+Run these checks immediately:
+
+```bash
+pwd
+python --version
+rg --files README.md creek-tools/creek/cli.py creek-tools/creek/templates/skills
+```
+
+Then review:
+- `README.md` for repo and vault topology.
+- `creek-tools/creek/cli.py` for all supported commands and options.
+- `creek-tools/creek/templates/skills/*.SKILL.md` for canonical operational contracts.
+
+## Default execution contract
+
+### Step 1 — Identify intent
+Map user request to one or more verbs:
+- **Compile**: reconcile fragments into compiled pages.
+- **Query**: answer from compiled layer first, then fragments when needed.
+- **Lint**: detect hygiene issues and contradictions.
+- **Save**: write validated outputs back into the vault.
+- **Scaffold/Sync**: initialize or refresh canonical structure and schema skills.
+- **Generate Skills**: emit voice-skill tree (`creek skills generate`).
+
+### Step 2 — Select playbook
+Load exactly one focused playbook in `.openclaw/skills/creek-cli-playbooks/`:
+- `compile-query-lint-save.SKILL.md`
+- `init-sync-generate.SKILL.md`
+- `safety-and-quality-gates.SKILL.md`
+
+### Step 3 — Execute with evidence
+For every command run, capture:
+- exact command line
+- key output summary
+- artifacts/paths touched
+- follow-up decision (next command or stop)
+
+### Step 4 — Close the loop
+Before finishing:
+1. Run relevant checks (lint/tests/CLI dry-runs when possible).
+2. Confirm privacy-tier handling when content is user-derived.
+3. Summarize outcomes + unresolved risks.
+
+## Non-negotiable guardrails
+
+- Never bypass compiled-first query behavior unless explicitly requested.
+- Never resolve paradox contradictions by force; route to liminal/paradox flows.
+- Never silently down-tier intimate content.
+- Never invent CLI flags; verify in `creek-tools/creek/cli.py`.
+
+## Quick command map
+
+```bash
+# Install CLI in editable mode
+pip install -e ./creek-tools
+
+# Initialize or update vault scaffolding
+creek init --vault <path>
+creek skills sync --vault <path>
+
+# Core lifecycle
+creek compile --vault <path>
+creek query --vault <path> --question "..."
+creek lint --vault <path>
+creek save --vault <path> --kind thread --title "..." --body-file <file>
+
+# Voice-skill generation
+creek skills generate --vault <path>
+```
+
+## References to load on demand
+
+- `references/operational-checklist.md`
+- `references/troubleshooting.md`

--- a/.openclaw/skills/creek-max-utility/references/operational-checklist.md
+++ b/.openclaw/skills/creek-max-utility/references/operational-checklist.md
@@ -1,0 +1,37 @@
+# Operational Checklist for OpenClaw Agents
+
+## Session start checklist
+
+1. Confirm working directory and branch.
+2. Confirm Creek CLI is available:
+   - `creek --help`
+   - if missing: `pip install -e ./creek-tools`
+3. Confirm target vault path exists and has expected structure.
+4. Identify whether task is read-only, write-to-vault, or write-to-repo.
+
+## Decision matrix
+
+- Need structured synthesis from raw fragments → `creek compile`
+- Need direct answer with provenance awareness → `creek query`
+- Need hygiene / gap / contradiction detection → `creek lint`
+- Need to persist outcome into vault → `creek save`
+- Need canonical tree in new vault → `creek init`
+- Need upstream schema-skill refresh → `creek skills sync`
+- Need voice-conditioning tree regeneration → `creek skills generate`
+
+## Evidence discipline
+
+For each execution block, record:
+- Intent
+- Command
+- Exit status
+- Material outputs
+- Interpretation
+
+## Quality gate checklist (before finalizing)
+
+- Commands used are canonical and reproducible.
+- Output summary references real files/paths.
+- Privacy-tier assumptions are explicit.
+- Contradictions are not flattened into fake consensus.
+- Any bypass flags (`--bypass-compiled`, etc.) are justified.

--- a/.openclaw/skills/creek-max-utility/references/troubleshooting.md
+++ b/.openclaw/skills/creek-max-utility/references/troubleshooting.md
@@ -1,0 +1,39 @@
+# Troubleshooting: Creek CLI in this Repository
+
+## CLI command not found
+
+Symptoms:
+- `creek: command not found`
+
+Actions:
+1. Run `pip install -e ./creek-tools`
+2. Verify with `creek --help`
+3. If virtualenv mismatch, run `python -m pip install -e ./creek-tools`
+
+## Command succeeds but produced no useful output
+
+Actions:
+1. Check vault path argument and permissions.
+2. Confirm expected source files exist in the vault.
+3. Re-run with narrower scope flags (where supported) for diagnostics.
+
+## Query quality appears weak
+
+Actions:
+1. Ensure compiled pages exist (`creek compile`).
+2. Re-run query without bypassing compiled layer.
+3. Run `creek lint` and inspect data gaps/contradictions.
+
+## Unexpected contradictions
+
+Actions:
+1. Do not reconcile manually in place.
+2. Route contradiction to paradox/liminal flow per schema skills.
+3. Re-run compile/lint after adding contradiction artifact.
+
+## Save behavior and privacy concerns
+
+Actions:
+1. Verify intended destination type (thread/eddy/praxis/paradox/etc.).
+2. Confirm tier handling for personal/intimate content.
+3. Never down-tier implicitly; require explicit user intent.


### PR DESCRIPTION
### Motivation

- Provide a discoverable, opinionated set of OpenClaw skills so an agent can operate the Creek CLI and vault workflows with consistent intent-to-command mapping, provenance preservation, and privacy-tier discipline.
- Capture canonical runbooks and safety gates so agents avoid ad-hoc or privacy-breaking operations and follow the compile/query/lint/save lifecycle by default.

### Description

- Add a top-level OpenClaw skills root at `.openclaw/` with an index (`.openclaw/README.md`) that points agents to the orchestration skill and focused playbooks.
- Add the orchestrator skill `creek-max-utility` at `.openclaw/skills/creek-max-utility/SKILL.md` with frontmatter, an execution contract, guardrails, and a quick CLI command map.
- Add reference docs under `.openclaw/skills/creek-max-utility/references/` for an operational checklist and troubleshooting guidance.
- Add three focused playbooks under `.openclaw/skills/creek-cli-playbooks/` for `compile-query-lint-save`, `init-sync-generate`, and `safety-and-quality-gates` to let agents load minimal, role-specific instructions.

### Testing

- Ran repository scans (`rg`) to locate `AGENTS.md`, the existing skills templates, and to confirm discovery keywords and paths were present and resolvable, and those searches returned expected results.
- Printed and inspected the new files (`nl` / `sed`) to verify each new `SKILL.md` has YAML frontmatter and the expected sections (orientation, playbook selection, guardrails, references).
- Verified the created files are readable at the intended discoverable paths under `.openclaw/` and that the playbooks reference canonical `creek` CLI verbs; no unit tests were changed and no Python test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e5e54e2508322a0d86b013fc8c48b)