### PR TITLE
feat(fragment): hierarchical fragment data model (FEAT-020)

### DIFF
--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -26,7 +26,7 @@ from zoneinfo import ZoneInfo
 import chardet
 from pydantic import BaseModel, ConfigDict, Field
 
-from creek.models import Fragment
+from creek.models import Fragment, FragmentLevel
 
 logger = logging.getLogger(__name__)
 
@@ -262,7 +262,11 @@ def generate_fragment_id(source: str, timestamp: datetime, content: str) -> str:
     return f"frag-{digest}"
 
 
-def generate_child_fragment_id(parent_id: str, level: str, index: int) -> str:
+def generate_child_fragment_id(
+    parent_id: str,
+    level: FragmentLevel,
+    index: int,
+) -> str:
     """Generate a deterministic child fragment ID (FEAT-020).
 
     The output matches :func:`generate_fragment_id`'s shape — a
@@ -280,8 +284,10 @@ def generate_child_fragment_id(parent_id: str, level: str, index: int) -> str:
 
     Args:
         parent_id: ID of the parent fragment (root or otherwise).
-        level: Structural level of the child — one of
-            :data:`creek.models.FragmentLevel`'s values.
+        level: Structural level of the child. Typed as
+            :data:`creek.models.FragmentLevel` so MyPy strict catches
+            invalid level strings (e.g. ``"chapter"``) at call sites
+            instead of letting them silently flow through to the hash.
         index: Zero-based position of this child among its siblings.
 
     Returns:

--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -262,6 +262,36 @@ def generate_fragment_id(source: str, timestamp: datetime, content: str) -> str:
     return f"frag-{digest}"
 
 
+def generate_child_fragment_id(parent_id: str, level: str, index: int) -> str:
+    """Generate a deterministic child fragment ID (FEAT-020).
+
+    The output matches :func:`generate_fragment_id`'s shape — a
+    ``frag-XXXXXXXXXXXX`` SHA-256 prefix — so child IDs are
+    indistinguishable from root IDs downstream and the same dedup,
+    indexing, and resonance code paths work for both.
+
+    Re-running the splitter (FEAT-021) or aggregator (FEAT-022) against
+    an unchanged parent must produce the same child IDs in the same
+    order so the second run is a no-op — that idempotency is why the
+    tuple is ``(parent_id, level, index)`` and not, say,
+    ``(parent_id, child_content)`` (content-keyed IDs would change
+    every time a trivial whitespace edit landed upstream and explode
+    the resonance graph).
+
+    Args:
+        parent_id: ID of the parent fragment (root or otherwise).
+        level: Structural level of the child — one of
+            :data:`creek.models.FragmentLevel`'s values.
+        index: Zero-based position of this child among its siblings.
+
+    Returns:
+        A deterministic ID string in the format ``frag-XXXXXXXXXXXX``.
+    """
+    hash_input = f"{parent_id}:{level}:{index}"
+    digest = hashlib.sha256(hash_input.encode()).hexdigest()[:12]
+    return f"frag-{digest}"
+
+
 def assemble_ingested_fragment(parsed: ParsedFragment) -> IngestedFragment:
     """Combine a ``ParsedFragment`` with its frontmatter into an ``IngestedFragment``.
 

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -478,13 +478,7 @@ class Fragment(BaseModel):
     privacy_tier: PrivacyTier = PrivacyTier.UNCLASSIFIED
     context: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
-    # FEAT-020 hierarchical fragment data model. Flat (pre-FEAT-020)
-    # fragments load as root documents: ``parent_id=None``,
-    # ``child_ids=[]``, ``level="document"``, ``structural_path=[]``.
-    # These four fields are direction-agnostic — a parent may be the
-    # level *above* its children whether the children were carved out
-    # by the FEAT-021 zoom-in splitter or stitched together by the
-    # FEAT-022 zoom-out aggregator.
+    # FEAT-020 hierarchy; defaults (None, [], "document", []) = root document.
     parent_id: str | None = None
     child_ids: list[str] = Field(default_factory=list)
     level: FragmentLevel = "document"

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -20,6 +20,27 @@ from creek.time import now_la, today_la
 CompileTargetKind = Literal["thread", "eddy", "frequency_index"]
 """The compiled-page surfaces ``creek compile`` may target (FEAT-003)."""
 
+FragmentLevel = Literal[
+    "sentence",
+    "paragraph",
+    "subsection",
+    "section",
+    "document",
+    "exchange",
+    "burst",
+    "session",
+]
+"""Structural level a :class:`Fragment` sits at within its source hierarchy.
+
+The first four values (``sentence`` … ``section``) describe levels carved
+*down* from a longer document by the FEAT-021 zoom-in splitter. The last
+three (``exchange``, ``burst``, ``session``) describe levels stitched
+*up* from short messages by the FEAT-022 zoom-out aggregator. ``document``
+is the default for any flat ingestion — a chat conversation, an essay, a
+note — and is therefore what every pre-FEAT-020 fragment is treated as
+when it loads without an explicit ``level`` field.
+"""
+
 
 def _utc_now() -> datetime:
     """Return the current time in UTC (used as a Pydantic default factory).
@@ -457,6 +478,17 @@ class Fragment(BaseModel):
     privacy_tier: PrivacyTier = PrivacyTier.UNCLASSIFIED
     context: list[str] = Field(default_factory=list)
     tags: list[str] = Field(default_factory=list)
+    # FEAT-020 hierarchical fragment data model. Flat (pre-FEAT-020)
+    # fragments load as root documents: ``parent_id=None``,
+    # ``child_ids=[]``, ``level="document"``, ``structural_path=[]``.
+    # These four fields are direction-agnostic — a parent may be the
+    # level *above* its children whether the children were carved out
+    # by the FEAT-021 zoom-in splitter or stitched together by the
+    # FEAT-022 zoom-out aggregator.
+    parent_id: str | None = None
+    child_ids: list[str] = Field(default_factory=list)
+    level: FragmentLevel = "document"
+    structural_path: list[str] = Field(default_factory=list)
 
     # BUG-009: the ``[prop-decorator]`` suppression below is a known
     # mypy / Pydantic-v2 limitation when stacking ``@computed_field``

--- a/creek-tools/tests/test_ingest.py
+++ b/creek-tools/tests/test_ingest.py
@@ -503,10 +503,10 @@ class TestGenerateChildFragmentId:
 
     def test_shape_matches_root_fragment_id(self) -> None:
         """Child IDs use the same ``frag-`` + 12-hex shape as root IDs."""
+        import re
+
         child_id = generate_child_fragment_id("frag-aaaabbbbcccc", "paragraph", 0)
-        assert child_id.startswith("frag-")
-        assert len(child_id) == 17
-        int(child_id[5:], 16)
+        assert re.fullmatch(r"frag-[0-9a-f]{12}", child_id), child_id
 
     def test_deterministic(self) -> None:
         """Same ``(parent_id, level, index)`` triple always returns the same ID."""

--- a/creek-tools/tests/test_ingest.py
+++ b/creek-tools/tests/test_ingest.py
@@ -24,6 +24,7 @@ from creek.ingest.base import (
     RawDocument,
     assemble_ingested_fragment,
     create_provenance_entry,
+    generate_child_fragment_id,
     generate_fragment_id,
     normalize_encoding,
     normalize_timestamp,
@@ -492,6 +493,56 @@ class TestGenerateFragmentId:
         expected_id = f"frag-{expected_hash}"
         actual_id = generate_fragment_id(source, ts, content)
         assert actual_id == expected_id
+
+
+# ---- generate_child_fragment_id Tests (FEAT-020) ----
+
+
+class TestGenerateChildFragmentId:
+    """Tests for the FEAT-020 stable child-fragment ID helper."""
+
+    def test_shape_matches_root_fragment_id(self) -> None:
+        """Child IDs use the same ``frag-`` + 12-hex shape as root IDs."""
+        child_id = generate_child_fragment_id("frag-aaaabbbbcccc", "paragraph", 0)
+        assert child_id.startswith("frag-")
+        assert len(child_id) == 17
+        int(child_id[5:], 16)
+
+    def test_deterministic(self) -> None:
+        """Same ``(parent_id, level, index)`` triple always returns the same ID."""
+        id1 = generate_child_fragment_id("frag-aaaabbbbcccc", "paragraph", 3)
+        id2 = generate_child_fragment_id("frag-aaaabbbbcccc", "paragraph", 3)
+        assert id1 == id2
+
+    def test_different_parent_produces_different_id(self) -> None:
+        """Distinct parents must produce distinct child IDs at the same slot."""
+        id1 = generate_child_fragment_id("frag-aaaabbbbcccc", "paragraph", 0)
+        id2 = generate_child_fragment_id("frag-aaaabbbbddddd", "paragraph", 0)
+        assert id1 != id2
+
+    def test_different_level_produces_different_id(self) -> None:
+        """Same parent and index at different structural levels differ."""
+        id1 = generate_child_fragment_id("frag-aaaabbbbcccc", "paragraph", 0)
+        id2 = generate_child_fragment_id("frag-aaaabbbbcccc", "section", 0)
+        assert id1 != id2
+
+    def test_different_index_produces_different_id(self) -> None:
+        """Sibling positions produce distinct IDs so the tree is unambiguous."""
+        id1 = generate_child_fragment_id("frag-aaaabbbbcccc", "paragraph", 0)
+        id2 = generate_child_fragment_id("frag-aaaabbbbcccc", "paragraph", 1)
+        assert id1 != id2
+
+    def test_uses_sha256(self) -> None:
+        """ID body is SHA-256 of ``{parent_id}:{level}:{index}`` (first 12 hex)."""
+        parent_id = "frag-aaaabbbbcccc"
+        level = "section"
+        index = 7
+        expected_hash = hashlib.sha256(
+            f"{parent_id}:{level}:{index}".encode(),
+        ).hexdigest()[:12]
+        assert generate_child_fragment_id(parent_id, level, index) == (
+            f"frag-{expected_hash}"
+        )
 
 
 # ---- create_provenance_entry Tests ----

--- a/creek-tools/tests/test_models.py
+++ b/creek-tools/tests/test_models.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import date, datetime
+from typing import get_args
 
 import pytest
 from pydantic import ValidationError
@@ -14,6 +15,7 @@ from creek.models import (
     Dosage,
     Eddy,
     Fragment,
+    FragmentLevel,
     FragmentSource,
     Frequency,
     FrequencyClassification,
@@ -540,8 +542,15 @@ class TestFragmentHierarchy:
         ]
 
     def test_all_documented_levels_accepted(self) -> None:
-        """Every value in the FEAT-020 ``FragmentLevel`` enumeration is valid."""
-        for level in (
+        """Every value in the FEAT-020 ``FragmentLevel`` Literal is valid.
+
+        Iterates the Literal's own ``get_args`` tuple so MyPy strict sees
+        each iteration variable as a genuine ``FragmentLevel`` — no
+        ``# type: ignore`` suppression. This proves the type contract,
+        not just runtime acceptance of string lookalikes.
+        """
+        levels = get_args(FragmentLevel)
+        assert set(levels) == {
             "sentence",
             "paragraph",
             "subsection",
@@ -550,12 +559,13 @@ class TestFragmentHierarchy:
             "exchange",
             "burst",
             "session",
-        ):
+        }
+        for level in levels:
             frag = Fragment(
                 id=f"frag-lvl-{level}",
                 title=f"Level {level}",
                 source=FragmentSource(platform=SourcePlatform.JOURNAL),
-                level=level,  # type: ignore[arg-type]
+                level=level,
             )
             assert frag.level == level
 

--- a/creek-tools/tests/test_models.py
+++ b/creek-tools/tests/test_models.py
@@ -495,6 +495,126 @@ class TestFragment:
         assert restored.tags == original.tags
 
 
+class TestFragmentHierarchy:
+    """Tests for the FEAT-020 hierarchical fragment data model.
+
+    Covers the four new fields (``parent_id``, ``child_ids``, ``level``,
+    ``structural_path``), their documented defaults, and round-tripping
+    through ``model_dump`` / ``model_validate`` so the writer/reader
+    contracts inherit a known-good base.
+    """
+
+    def test_hierarchy_defaults_match_documented_root_document(self) -> None:
+        """A flat fragment defaults to ``(None, [], "document", [])``."""
+        frag = Fragment(
+            id="frag-hier00000001",
+            title="Flat",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+        )
+        assert frag.parent_id is None
+        assert frag.child_ids == []
+        assert frag.level == "document"
+        assert frag.structural_path == []
+
+    def test_full_hierarchy_specified(self) -> None:
+        """Every hierarchy field accepts the values described in FEAT-020."""
+        frag = Fragment(
+            id="frag-hier00000002",
+            title="Para 3",
+            source=FragmentSource(platform=SourcePlatform.ESSAY),
+            parent_id="frag-hier00000001",
+            child_ids=["frag-hier00000003", "frag-hier00000004"],
+            level="paragraph",
+            structural_path=["The Capricorn Moon", "On grief", "para-3"],
+        )
+        assert frag.parent_id == "frag-hier00000001"
+        assert frag.child_ids == [
+            "frag-hier00000003",
+            "frag-hier00000004",
+        ]
+        assert frag.level == "paragraph"
+        assert frag.structural_path == [
+            "The Capricorn Moon",
+            "On grief",
+            "para-3",
+        ]
+
+    def test_all_documented_levels_accepted(self) -> None:
+        """Every value in the FEAT-020 ``FragmentLevel`` enumeration is valid."""
+        for level in (
+            "sentence",
+            "paragraph",
+            "subsection",
+            "section",
+            "document",
+            "exchange",
+            "burst",
+            "session",
+        ):
+            frag = Fragment(
+                id=f"frag-lvl-{level}",
+                title=f"Level {level}",
+                source=FragmentSource(platform=SourcePlatform.JOURNAL),
+                level=level,  # type: ignore[arg-type]
+            )
+            assert frag.level == level
+
+    def test_unknown_level_rejected(self) -> None:
+        """An invalid ``level`` value fails Pydantic validation up front."""
+        with pytest.raises(ValidationError):
+            Fragment.model_validate(
+                {
+                    "id": "frag-hier00000005",
+                    "title": "Bad",
+                    "source": {"platform": "claude"},
+                    "level": "chapter",
+                },
+            )
+
+    def test_hierarchy_round_trips_through_model_dump(self) -> None:
+        """Hierarchy fields survive ``model_dump(mode="json")`` → re-validate."""
+        original = Fragment(
+            id="frag-hier00000006",
+            title="Round trip",
+            source=FragmentSource(platform=SourcePlatform.CHATGPT),
+            parent_id="frag-parent00000",
+            child_ids=["frag-childa00000", "frag-childb00000"],
+            level="exchange",
+            structural_path=["#general", "2026-04-22 evening", "exchange-12"],
+        )
+        dump = original.model_dump(mode="json")
+        restored = Fragment.model_validate(dump)
+        assert restored.parent_id == original.parent_id
+        assert restored.child_ids == original.child_ids
+        assert restored.level == original.level
+        assert restored.structural_path == original.structural_path
+
+    def test_legacy_fragment_without_hierarchy_keys_loads_with_defaults(
+        self,
+    ) -> None:
+        """Pre-FEAT-020 frontmatter (no hierarchy keys) loads as a root document.
+
+        Acceptance criterion: "Pre-existing fragments (no hierarchy
+        fields in frontmatter) load with the documented defaults — no
+        crash, no warning spam."
+        """
+        import warnings
+
+        legacy_metadata = {
+            "type": "fragment",
+            "id": "frag-legacy000001",
+            "title": "Old-school fragment",
+            "source": {"platform": "claude"},
+        }
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            frag = Fragment.model_validate(legacy_metadata)
+        assert frag.parent_id is None
+        assert frag.child_ids == []
+        assert frag.level == "document"
+        assert frag.structural_path == []
+
+
 class TestThread:
     """Tests for the Thread model."""
 

--- a/creek-tools/tests/test_properties_frontmatter.py
+++ b/creek-tools/tests/test_properties_frontmatter.py
@@ -81,13 +81,40 @@ _TIMESTAMPS = st.datetimes(
 _PLATFORMS = st.sampled_from(list(SourcePlatform))
 
 
+_LEVELS = st.sampled_from(
+    [
+        "sentence",
+        "paragraph",
+        "subsection",
+        "section",
+        "document",
+        "exchange",
+        "burst",
+        "session",
+    ],
+)
+
+_FRAG_IDS = st.from_regex(r"frag-[0-9a-f]{12}", fullmatch=True)
+
+_STRUCTURAL_PATH = st.lists(
+    st.text(
+        alphabet=st.characters(
+            blacklist_categories=("Cs", "Cc"),
+            blacklist_characters="\x00",
+        ),
+        min_size=1,
+        max_size=40,
+    ).filter(lambda s: s.strip() != ""),
+    max_size=5,
+)
+
+
 @st.composite
 def fragments(draw: st.DrawFn) -> Fragment:
     """Build a Fragment instance from primitive strategies."""
+    parent_id = draw(st.one_of(st.none(), _FRAG_IDS))
     return Fragment(
-        id=draw(
-            st.from_regex(r"frag-[0-9a-f]{12}", fullmatch=True),
-        ),
+        id=draw(_FRAG_IDS),
         title=draw(_TITLES),
         source=FragmentSource(
             platform=draw(_PLATFORMS),
@@ -96,6 +123,10 @@ def fragments(draw: st.DrawFn) -> Fragment:
         created=draw(_TIMESTAMPS),
         ingested=draw(_TIMESTAMPS),
         tags=draw(_TAGS),
+        parent_id=parent_id,
+        child_ids=draw(st.lists(_FRAG_IDS, max_size=6, unique=True)),
+        level=draw(_LEVELS),
+        structural_path=draw(_STRUCTURAL_PATH),
     )
 
 
@@ -147,6 +178,36 @@ def test_fragment_id_survives_roundtrip(
     written_path = writer.write_fragment(fragment)
     post = frontmatter.load(str(written_path))
     assert post.metadata["id"] == fragment.id
+
+
+@_PROFILE
+@given(fragment=fragments())
+def test_fragment_hierarchy_write_read_write_bytes_identical(
+    fragment: Fragment, tmp_path_factory: TempPathFactory
+) -> None:
+    """FEAT-020 acceptance: write → read → write yields identical bytes.
+
+    The first write produces the canonical on-disk form. We load the
+    file back through the shared vault reader, re-write the loaded
+    fragment into a second vault, and assert the two files are
+    byte-for-byte equal. Any non-determinism in the YAML serialisation
+    (list ordering, scalar quoting, key drift) would break this
+    contract.
+    """
+    from creek.vault.reader import try_load_fragment
+
+    vault_a = _make_vault(tmp_path_factory.mktemp("vault_a"))
+    vault_b = _make_vault(tmp_path_factory.mktemp("vault_b"))
+    writer_a = VaultWriter(vault_path=vault_a)
+    writer_b = VaultWriter(vault_path=vault_b)
+
+    path_a = writer_a.write_fragment(fragment, body="round-trip body")
+    record = try_load_fragment(path_a)
+    assert record is not None
+    loaded_fragment, body, _raw = record
+    path_b = writer_b.write_fragment(loaded_fragment, body=body)
+
+    assert path_a.read_bytes() == path_b.read_bytes()
 
 
 def test_frontmatter_roundtrip_smoke(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_properties_frontmatter.py
+++ b/creek-tools/tests/test_properties_frontmatter.py
@@ -11,7 +11,7 @@ fixtures miss.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, get_args
 
 import frontmatter
 from hypothesis import HealthCheck, given, settings
@@ -20,6 +20,7 @@ from hypothesis import strategies as st
 from creek.models import (
     Authorship,
     Fragment,
+    FragmentLevel,
     FragmentSource,
     SourcePlatform,
 )
@@ -81,18 +82,10 @@ _TIMESTAMPS = st.datetimes(
 _PLATFORMS = st.sampled_from(list(SourcePlatform))
 
 
-_LEVELS = st.sampled_from(
-    [
-        "sentence",
-        "paragraph",
-        "subsection",
-        "section",
-        "document",
-        "exchange",
-        "burst",
-        "session",
-    ],
-)
+# Derived from ``FragmentLevel`` so a new level added in models.py is
+# automatically exercised by these property tests — no parallel list to
+# keep in sync (matches the ``_PLATFORMS`` pattern above).
+_LEVELS = st.sampled_from(list(get_args(FragmentLevel)))
 
 _FRAG_IDS = st.from_regex(r"frag-[0-9a-f]{12}", fullmatch=True)
 

--- a/creek-tools/tests/test_vault_reader.py
+++ b/creek-tools/tests/test_vault_reader.py
@@ -155,8 +155,10 @@ def test_try_load_fragment_round_trips_hierarchy_fields(tmp_path: Path) -> None:
     assert loaded_fragment.child_ids == ["frag-hier-kidaa", "frag-hier-kidbb"]
     assert loaded_fragment.level == "section"
     assert loaded_fragment.structural_path == ["Essay", "Part 2"]
-    # raw_metadata must surface the hierarchy keys too — classify/link
+    # raw_metadata must surface every hierarchy key — classify/link
     # engines pass raw forward when rewriting frontmatter, so dropping
-    # them here would silently nuke the hierarchy on the next write.
+    # any one would silently nuke that field on the next write.
     assert raw["parent_id"] == "frag-hier-parent"
+    assert raw["child_ids"] == ["frag-hier-kidaa", "frag-hier-kidbb"]
     assert raw["level"] == "section"
+    assert raw["structural_path"] == ["Essay", "Part 2"]

--- a/creek-tools/tests/test_vault_reader.py
+++ b/creek-tools/tests/test_vault_reader.py
@@ -86,3 +86,77 @@ def test_iter_vault_fragments_skips_non_fragments(tmp_path: Path) -> None:
 def test_iter_vault_fragments_returns_empty_for_missing_root(tmp_path: Path) -> None:
     """Missing ``01-Fragments`` returns an empty list, not an error."""
     assert iter_vault_fragments(tmp_path / "no-such-dir") == []
+
+
+def test_try_load_fragment_without_hierarchy_keys_defaults_to_root(
+    tmp_path: Path,
+) -> None:
+    """Pre-FEAT-020 fragments load as root documents without crash or warning.
+
+    Acceptance criterion: "Pre-existing fragments (no hierarchy fields
+    in frontmatter) load with the documented defaults — no crash, no
+    warning spam." Loads a hand-crafted legacy frontmatter blob (no
+    ``parent_id`` / ``child_ids`` / ``level`` / ``structural_path``
+    keys) with ``warnings`` promoted to errors so any incidental
+    deprecation noise from the schema would fail the test.
+    """
+    import warnings
+
+    legacy = tmp_path / "legacy.md"
+    legacy.write_text(
+        "---\n"
+        "type: fragment\n"
+        "id: frag-legacy000007\n"
+        "title: Pre-FEAT-020 fragment\n"
+        "source:\n"
+        "  platform: claude\n"
+        "---\n"
+        "Body of the legacy fragment.\n",
+        encoding="utf-8",
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        record = try_load_fragment(legacy)
+
+    assert record is not None
+    fragment, body, raw = record
+    assert fragment.parent_id is None
+    assert fragment.child_ids == []
+    assert fragment.level == "document"
+    assert fragment.structural_path == []
+    assert body.strip() == "Body of the legacy fragment."
+    # Legacy frontmatter must remain untouched — raw should not have
+    # been mutated to inject the new keys (callers that round-trip via
+    # ``raw`` would otherwise stamp defaults into untouched vault
+    # files and explode the audit diff on the next pass).
+    assert "parent_id" not in raw
+    assert "level" not in raw
+
+
+def test_try_load_fragment_round_trips_hierarchy_fields(tmp_path: Path) -> None:
+    """A fragment carrying every hierarchy field round-trips through reader."""
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-hier-readok",
+        title="Hierarchical",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        parent_id="frag-hier-parent",
+        child_ids=["frag-hier-kidaa", "frag-hier-kidbb"],
+        level="section",
+        structural_path=["Essay", "Part 2"],
+    )
+    file = write_fragment_file(vault=vault, fragment=fragment, body="body")
+
+    record = try_load_fragment(file)
+    assert record is not None
+    loaded_fragment, _body, raw = record
+    assert loaded_fragment.parent_id == "frag-hier-parent"
+    assert loaded_fragment.child_ids == ["frag-hier-kidaa", "frag-hier-kidbb"]
+    assert loaded_fragment.level == "section"
+    assert loaded_fragment.structural_path == ["Essay", "Part 2"]
+    # raw_metadata must surface the hierarchy keys too — classify/link
+    # engines pass raw forward when rewriting frontmatter, so dropping
+    # them here would silently nuke the hierarchy on the next write.
+    assert raw["parent_id"] == "frag-hier-parent"
+    assert raw["level"] == "section"

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -381,6 +381,60 @@ class TestWriteFragment:
         result = writer.write_fragment(frag)
         assert "01-Fragments/Notes" in str(result)
 
+    def test_write_fragment_persists_hierarchy_fields(
+        self,
+        writer: VaultWriter,
+    ) -> None:
+        """FEAT-020 hierarchy fields appear in frontmatter and re-validate.
+
+        Acceptance criterion: "``VaultWriter`` serialises hierarchy
+        fields to frontmatter; ``VaultReader`` parses them back."
+        """
+        import frontmatter as fm_mod
+
+        frag = Fragment(
+            id="frag-hier-write1",
+            title="Hierarchy Write",
+            source=FragmentSource(platform=SourcePlatform.ESSAY),
+            created=datetime(2025, 1, 15, 10, 30, 0),
+            parent_id="frag-hier-root00",
+            child_ids=["frag-hier-childa", "frag-hier-childb"],
+            level="subsection",
+            structural_path=["The Capricorn Moon", "On grief"],
+        )
+        result = writer.write_fragment(frag)
+        text = result.read_text(encoding="utf-8")
+        assert "parent_id: frag-hier-root00" in text
+        assert "level: subsection" in text
+
+        post = fm_mod.load(str(result))
+        reloaded = Fragment.model_validate(dict(post.metadata))
+        assert reloaded.parent_id == "frag-hier-root00"
+        assert reloaded.child_ids == ["frag-hier-childa", "frag-hier-childb"]
+        assert reloaded.level == "subsection"
+        assert reloaded.structural_path == ["The Capricorn Moon", "On grief"]
+
+    def test_write_fragment_defaults_serialise_as_root_document(
+        self,
+        writer: VaultWriter,
+        sample_fragment: Fragment,
+    ) -> None:
+        """A flat fragment's frontmatter records the documented defaults.
+
+        Pre-FEAT-020 callers that never set the hierarchy fields must
+        produce vault files whose ``parent_id``/``child_ids``/``level``/
+        ``structural_path`` round-trip back to the documented defaults
+        — so downstream loads of those files re-create root documents.
+        """
+        import frontmatter as fm_mod
+
+        result = writer.write_fragment(sample_fragment)
+        post = fm_mod.load(str(result))
+        assert post["parent_id"] is None
+        assert post["child_ids"] == []
+        assert post["level"] == "document"
+        assert post["structural_path"] == []
+
     def test_platform_subfolder_mapping_is_total(self) -> None:
         """Every SourcePlatform must have an explicit subfolder mapping.
 

--- a/creek-tools/uv.lock
+++ b/creek-tools/uv.lock
@@ -3312,15 +3312,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #251.

## Summary

Data-model groundwork for confidence-driven re-atomization. Adds the
four hierarchy fields described in FEAT-020 to `Fragment` so the
future FEAT-021 zoom-in splitter, FEAT-022 zoom-out aggregator, and
FEAT-023 orchestrator can carve or stitch fragments without
reshaping the schema:

- `parent_id: str | None` — parent fragment, `None` for root.
- `child_ids: list[str]` — direct children in order.
- `level: FragmentLevel` — structural level, default `"document"`.
- `structural_path: list[str]` — breadcrumb from the root.

`FragmentLevel` is a new `Literal` covering the eight permitted
levels (`sentence` / `paragraph` / `subsection` / `section` /
`document` / `exchange` / `burst` / `session`). `VaultWriter` and
`VaultReader` round-trip the new fields for free because they
already go through `model_dump(mode="json")` / `model_validate`;
pre-FEAT-020 vault files load as root documents with the documented
defaults and no warning spam.

Adds `creek.ingest.base.generate_child_fragment_id(parent_id,
level, index)` so future splitters and aggregators produce stable
`frag-<sha>` IDs deterministic from the `(parent, level, index)`
triple — re-runs against unchanged sources stay idempotent and child
IDs are shape-identical to root IDs so downstream code (dedup,
indexing, resonance) treats them uniformly.

No behavioural change for existing ingestion — every flat fragment
on disk today loads as a root document. Out-of-scope work (splitter,
aggregator, orchestrator, linker awareness) is tracked in
FEAT-021..023 per the issue.

This PR also incidentally bumps `starlette 1.0.0 → 1.0.1` to fix
the pre-existing `PYSEC-2026-161` CVE flagged on `main`, applied
during the local `check-all.sh` security gate via the
`cve-remediation` skill. The full quality gate is now 12/12 green.

## Acceptance criteria

- [x] `Fragment` model carries the four new fields with the
      documented defaults (`tests/test_models.py::TestFragmentHierarchy`).
- [x] `VaultWriter` serialises hierarchy fields to frontmatter;
      `VaultReader` parses them back
      (`tests/test_vault_writer.py::TestWriteFragment::test_write_fragment_persists_hierarchy_fields`,
      `tests/test_vault_reader.py::test_try_load_fragment_round_trips_hierarchy_fields`).
- [x] Round-trip property test: write → read → write produces
      identical bytes for arbitrary hierarchies
      (`tests/test_properties_frontmatter.py::test_fragment_hierarchy_write_read_write_bytes_identical`,
      Hypothesis, 200 examples).
- [x] Pre-existing fragments without hierarchy keys load with the
      documented defaults — no crash, no warning spam (asserted with
      `warnings.simplefilter("error")` in
      `tests/test_vault_reader.py::test_try_load_fragment_without_hierarchy_keys_defaults_to_root`
      and the matching model-level test).
- [x] Stable child-fragment ID helper deterministic from
      `(parent_id, level, index)`, typed against `FragmentLevel`,
      matching the existing `frag-<sha>` convention
      (`tests/test_ingest.py::TestGenerateChildFragmentId`).
- [x] Hypothesis `_LEVELS` strategy derived from
      `get_args(FragmentLevel)` so future Literal additions flow
      through automatically.
- [x] MyPy strict, Ruff zero violations, 3570 passed test suite,
      93.43% aggregate branch coverage, full `check-all.sh` 12/12.

## Test plan

- [x] `./scripts/check-all.sh` — 12/12 gates green (security gate
      now passes after the starlette bump).
- [x] `pytest tests/test_models.py tests/test_ingest.py
      tests/test_vault_writer.py tests/test_vault_reader.py
      tests/test_fragment.py tests/test_properties_frontmatter.py`
      — passes.
- [x] `pytest` (full suite) — 3570 passed, 20 deselected (slow),
      93.43% branch coverage.
