### PR TITLE
feat(atomize): structural splitter for zoom-in re-atomization (FEAT-021)

### DIFF
--- a/creek-tools/creek/atomize/__init__.py
+++ b/creek-tools/creek/atomize/__init__.py
@@ -1,0 +1,16 @@
+"""Confidence-driven re-atomization operators (FEAT-021 / FEAT-022).
+
+This package houses the structural splitter (zoom in, FEAT-021) and —
+once landed — the conversational aggregator (zoom out, FEAT-022). Both
+operators are pure, deterministic transforms on fragments: callers
+(notably FEAT-023) decide when to invoke them and how to persist the
+results.
+"""
+
+from creek.atomize.split import (
+    SentenceTokenizer,
+    default_sentence_tokenizer,
+    split,
+)
+
+__all__ = ["SentenceTokenizer", "default_sentence_tokenizer", "split"]

--- a/creek-tools/creek/atomize/split.py
+++ b/creek-tools/creek/atomize/split.py
@@ -1,0 +1,269 @@
+"""Structural splitter — decompose a fragment into finer-grain children.
+
+This module implements FEAT-021: the *zoom-in* half of confidence-driven
+re-atomization (FEAT-023). Given any fragment that resists classification
+because it is too large or polyphonic, :func:`split` returns its structural
+children at one level finer granularity.
+
+Level transitions (zoom-in):
+
+    ``document``    -> ``section``    (split at H1/H2 headings)
+    ``section``     -> ``subsection`` (split at H3+ headings)
+    ``subsection``  -> ``paragraph``  (split at blank-line boundaries)
+    ``paragraph``   -> ``sentence``   (configurable sentence tokenizer)
+    ``sentence``    -> terminal: returns ``[]``
+
+A document with no headings collapses ``document -> paragraph`` (skipping
+the empty section and subsection levels). More generally the operator
+never produces zero-content levels: when a transition would yield a
+single chunk identical to the parent's body, it cascades through the
+finer levels until a real split happens or it bottoms out at sentence.
+
+Idempotence: re-splitting the same fragment produces children with
+identical IDs and contents, because child IDs are derived deterministically
+from ``(parent_id, level, sibling_index)`` via
+:func:`creek.ingest.base.generate_child_fragment_id`.
+
+The twin zoom-out operator is FEAT-022 (aggregator); persistence of
+returned children is FEAT-023 (re-atomization driver). This module
+performs neither.
+
+Note on the input type: the spec phrases the signature as
+``split(fragment: Fragment) -> list[Fragment]``. In the current model,
+:class:`~creek.models.Fragment` carries only frontmatter metadata — the
+body text lives on :class:`~creek.ingest.base.IngestedFragment`, which
+pairs a ``Fragment`` with its converted Markdown body. Because the spec
+requires children to carry "the verbatim text slice from the parent",
+the splitter operates on the pair, so the runtime signature is
+``split(IngestedFragment) -> list[IngestedFragment]``.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Final
+
+from creek.ingest.base import IngestedFragment, generate_child_fragment_id
+
+if TYPE_CHECKING:
+    from creek.models import Fragment, FragmentLevel
+
+SentenceTokenizer = Callable[[str], list[str]]
+"""A function that splits text into sentence strings.
+
+The default :func:`default_sentence_tokenizer` is a regex heuristic
+sufficient for English prose. Callers needing higher fidelity (clinical
+text, multi-language) pass their own tokenizer to :func:`split` via the
+``sentence_tokenizer`` keyword.
+"""
+
+_H1_H2_HEADING: Final = re.compile(r"^(?:#{1,2})[ \t]+(.+?)\s*$", re.MULTILINE)
+_H3_PLUS_HEADING: Final = re.compile(r"^(?:#{3,6})[ \t]+(.+?)\s*$", re.MULTILINE)
+_BLANK_LINE: Final = re.compile(r"\n[ \t]*\n+")
+_SENTENCE_BOUNDARY: Final = re.compile(
+    r"(?:(?<=[.!?])|(?<=[.!?][\"'\]\)]))\s+(?=[A-Z\"'\(\[])",
+)
+_TITLE_FALLBACK_MAX_LEN: Final = 60
+
+_Piece = tuple[str | None, str]
+"""A (heading, body_slice) pair produced by an internal carving step."""
+
+
+def default_sentence_tokenizer(text: str) -> list[str]:
+    """Tokenize prose into sentences using a regex heuristic.
+
+    Splits on sentence-terminating punctuation (``.``, ``!``, ``?``)
+    optionally followed by closing brackets or quotes, then whitespace
+    and a capital letter or opening bracket/quote. Empty input yields
+    an empty list.
+
+    Args:
+        text: Raw text to tokenize.
+
+    Returns:
+        A list of trimmed sentence strings (no empty entries).
+    """
+    stripped = text.strip()
+    if not stripped:
+        return []
+    parts = _SENTENCE_BOUNDARY.split(stripped)
+    return [piece.strip() for piece in parts if piece.strip()]
+
+
+def split(
+    fragment: IngestedFragment,
+    *,
+    sentence_tokenizer: SentenceTokenizer = default_sentence_tokenizer,
+) -> list[IngestedFragment]:
+    """Decompose a fragment into its structural children one level finer.
+
+    Args:
+        fragment: Parent fragment paired with its body text. The
+            parent's ``fragment.level`` selects the transition.
+        sentence_tokenizer: Pluggable tokenizer used for
+            ``paragraph -> sentence`` transitions (and any cascades that
+            reach the sentence level). Must accept a string and return
+            a list of sentence strings.
+
+    Returns:
+        Children at the finest non-empty level reachable from the
+        parent's level. Empty list when the parent is at ``sentence``
+        (terminal), at a zoom-out level (``exchange``, ``burst``,
+        ``session``), or when no decomposition is possible.
+    """
+    parent = fragment.fragment
+    body = fragment.body
+    dispatch: dict[
+        FragmentLevel,
+        Callable[[Fragment, str, SentenceTokenizer], list[IngestedFragment]],
+    ] = {
+        "document": _split_document,
+        "section": _split_section,
+        "subsection": _paragraphs_or_sentences,
+        "paragraph": _split_paragraph,
+    }
+    handler = dispatch.get(parent.level)
+    if handler is None:
+        return []
+    return handler(parent, body, sentence_tokenizer)
+
+
+# ---- Per-level handlers -----------------------------------------------------
+
+
+def _split_document(
+    parent: Fragment,
+    body: str,
+    tokenizer: SentenceTokenizer,
+) -> list[IngestedFragment]:
+    """Split a document into sections, cascading when no H1/H2 are present."""
+    sections = _carve_by_headings(body, _H1_H2_HEADING)
+    if sections:
+        return _build_children(parent, sections, "section")
+    subsections = _carve_by_headings(body, _H3_PLUS_HEADING)
+    if subsections:
+        return _build_children(parent, subsections, "subsection")
+    return _paragraphs_or_sentences(parent, body, tokenizer)
+
+
+def _split_section(
+    parent: Fragment,
+    body: str,
+    tokenizer: SentenceTokenizer,
+) -> list[IngestedFragment]:
+    """Split a section into subsections, cascading when no H3+ are present."""
+    subsections = _carve_by_headings(body, _H3_PLUS_HEADING)
+    if subsections:
+        return _build_children(parent, subsections, "subsection")
+    return _paragraphs_or_sentences(parent, body, tokenizer)
+
+
+def _paragraphs_or_sentences(
+    parent: Fragment,
+    body: str,
+    tokenizer: SentenceTokenizer,
+) -> list[IngestedFragment]:
+    """Split into paragraphs; cascade to sentences when there's only one."""
+    paragraphs = [chunk.strip() for chunk in _BLANK_LINE.split(body) if chunk.strip()]
+    if len(paragraphs) > 1:
+        pieces: list[_Piece] = [(None, para) for para in paragraphs]
+        return _build_children(parent, pieces, "paragraph")
+    return _split_paragraph(parent, body, tokenizer)
+
+
+def _split_paragraph(
+    parent: Fragment,
+    body: str,
+    tokenizer: SentenceTokenizer,
+) -> list[IngestedFragment]:
+    """Split a paragraph into sentences via the configured tokenizer."""
+    sentences = tokenizer(body)
+    if len(sentences) <= 1:
+        return []
+    pieces: list[_Piece] = [(None, sentence) for sentence in sentences]
+    return _build_children(parent, pieces, "sentence")
+
+
+# ---- Carving primitives -----------------------------------------------------
+
+
+def _carve_by_headings(
+    body: str,
+    pattern: re.Pattern[str],
+) -> list[_Piece]:
+    """Slice ``body`` at heading boundaries.
+
+    Each match becomes a ``(heading_text, slice)`` pair where ``slice``
+    starts at the heading line itself and runs to (but does not include)
+    the next heading. Content before the first heading — the preamble —
+    is returned as a leading ``(None, slice)`` pair only when non-empty.
+
+    Returns an empty list if no headings match, so callers can detect
+    "no structure at this level" and cascade.
+    """
+    matches = list(pattern.finditer(body))
+    if not matches:
+        return []
+
+    pieces: list[_Piece] = []
+    preamble = body[: matches[0].start()].strip()
+    if preamble:
+        pieces.append((None, preamble))
+
+    for idx, match in enumerate(matches):
+        heading_text = match.group(1).strip()
+        slice_start = match.start()
+        slice_end = matches[idx + 1].start() if idx + 1 < len(matches) else len(body)
+        pieces.append((heading_text, body[slice_start:slice_end].strip()))
+
+    return pieces
+
+
+def _build_children(
+    parent: Fragment,
+    pieces: list[_Piece],
+    child_level: FragmentLevel,
+) -> list[IngestedFragment]:
+    """Construct child ``IngestedFragment`` objects from ``pieces``.
+
+    Children inherit every parent field unchanged except the hierarchy
+    fields: ``id`` is derived from ``(parent.id, child_level, index)``,
+    ``parent_id`` points to the parent, ``child_ids`` is cleared,
+    ``level`` is set, and ``structural_path`` is extended by the child's
+    heading (when present).
+    """
+    children: list[IngestedFragment] = []
+    for index, (heading, content) in enumerate(pieces):
+        child_id = generate_child_fragment_id(parent.id, child_level, index)
+        title = heading or _derive_title_from_content(content)
+        structural_path = parent.structural_path.copy()
+        if heading:
+            structural_path.append(heading)
+        child_fragment = parent.model_copy(
+            update={
+                "id": child_id,
+                "title": title,
+                "parent_id": parent.id,
+                "child_ids": [],
+                "level": child_level,
+                "structural_path": structural_path,
+            },
+        )
+        children.append(IngestedFragment(fragment=child_fragment, body=content))
+    return children
+
+
+def _derive_title_from_content(content: str) -> str:
+    """Return a short title from the first line of ``content``.
+
+    Used when a child has no heading of its own (preamble slices,
+    paragraphs, sentences). The carving primitives only ever pass
+    non-empty content here, so the first non-empty line always exists.
+    Long first lines are truncated with an ellipsis so the title stays
+    scannable in a vault index.
+    """
+    first_line = content.strip().splitlines()[0]
+    if len(first_line) <= _TITLE_FALLBACK_MAX_LEN:
+        return first_line
+    return first_line[: _TITLE_FALLBACK_MAX_LEN - 1].rstrip() + "…"

--- a/creek-tools/creek/atomize/split.py
+++ b/creek-tools/creek/atomize/split.py
@@ -78,6 +78,11 @@ def default_sentence_tokenizer(text: str) -> list[str]:
     and a capital letter or opening bracket/quote. Empty input yields
     an empty list.
 
+    Known failure modes: abbreviations (``Dr. Smith``) and ellipses
+    (``... and then``) produce extra splits. Callers needing higher
+    fidelity (clinical text, formal prose, multi-language) should pass
+    their own tokenizer via :func:`split`'s ``sentence_tokenizer`` kwarg.
+
     Args:
         text: Raw text to tokenize.
 
@@ -89,6 +94,9 @@ def default_sentence_tokenizer(text: str) -> list[str]:
         return []
     parts = _SENTENCE_BOUNDARY.split(stripped)
     return [piece.strip() for piece in parts if piece.strip()]
+
+
+_LevelHandler = Callable[["Fragment", str, SentenceTokenizer], list[IngestedFragment]]
 
 
 def split(
@@ -113,20 +121,10 @@ def split(
         ``session``), or when no decomposition is possible.
     """
     parent = fragment.fragment
-    body = fragment.body
-    dispatch: dict[
-        FragmentLevel,
-        Callable[[Fragment, str, SentenceTokenizer], list[IngestedFragment]],
-    ] = {
-        "document": _split_document,
-        "section": _split_section,
-        "subsection": _paragraphs_or_sentences,
-        "paragraph": _split_paragraph,
-    }
-    handler = dispatch.get(parent.level)
+    handler = _DISPATCH.get(parent.level)
     if handler is None:
         return []
-    return handler(parent, body, sentence_tokenizer)
+    return handler(parent, fragment.body, sentence_tokenizer)
 
 
 # ---- Per-level handlers -----------------------------------------------------
@@ -169,7 +167,10 @@ def _paragraphs_or_sentences(
     if len(paragraphs) > 1:
         pieces: list[_Piece] = [(None, para) for para in paragraphs]
         return _build_children(parent, pieces, "paragraph")
-    return _split_paragraph(parent, body, tokenizer)
+    # Forward the stripped paragraph (not raw body) so a custom tokenizer that
+    # skips its own .strip() doesn't receive leading/trailing whitespace.
+    cascade_body = paragraphs[0] if paragraphs else body
+    return _split_paragraph(parent, cascade_body, tokenizer)
 
 
 def _split_paragraph(
@@ -183,6 +184,16 @@ def _split_paragraph(
         return []
     pieces: list[_Piece] = [(None, sentence) for sentence in sentences]
     return _build_children(parent, pieces, "sentence")
+
+
+_DISPATCH: dict[FragmentLevel, _LevelHandler] = {
+    "document": _split_document,
+    "section": _split_section,
+    "subsection": _paragraphs_or_sentences,
+    "paragraph": _split_paragraph,
+}
+"""Level → handler routing table for :func:`split`; hoisted so callers in a
+hot loop don't re-allocate it on every invocation."""
 
 
 # ---- Carving primitives -----------------------------------------------------

--- a/creek-tools/tests/test_atomize_split.py
+++ b/creek-tools/tests/test_atomize_split.py
@@ -129,6 +129,21 @@ class TestSubsectionToParagraph:
     def test_subsection_with_single_sentence_returns_empty(self) -> None:
         assert split(_make(body="Indivisible content.", level="subsection")) == []
 
+    def test_single_paragraph_cascade_forwards_stripped_body(self) -> None:
+        """Custom tokenizers receive the stripped paragraph, not raw body."""
+        seen: list[str] = []
+
+        def recording_tokenizer(text: str) -> list[str]:
+            seen.append(text)
+            return text.split("|")
+
+        body = "  \n\nalpha|bravo|charlie  \n\n  "
+        split(
+            _make(body=body, level="subsection"),
+            sentence_tokenizer=recording_tokenizer,
+        )
+        assert seen == ["alpha|bravo|charlie"]
+
 
 # ---- Section → subsection ----
 
@@ -225,6 +240,11 @@ class TestDocumentToSection:
         ingested = _make(body=body, level="document")
         children = split(ingested)
         assert _levels(children) == ["sentence", "sentence"]
+
+    def test_document_with_empty_body_returns_empty(self) -> None:
+        """Cascade bottoms out cleanly when there's nothing to decompose."""
+        assert split(_make(body="", level="document")) == []
+        assert split(_make(body="   \n\t\n  ", level="document")) == []
 
     def test_document_preamble_before_first_heading_is_preserved(self) -> None:
         body = "Intro paragraph with no heading.\n\n# A heading\n\nBody under heading."

--- a/creek-tools/tests/test_atomize_split.py
+++ b/creek-tools/tests/test_atomize_split.py
@@ -1,0 +1,414 @@
+"""Tests for the FEAT-021 structural splitter (zoom-in re-atomization)."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from creek.atomize.split import (
+    SentenceTokenizer,
+    default_sentence_tokenizer,
+    split,
+)
+from creek.ingest.base import IngestedFragment, generate_child_fragment_id
+from creek.models import Fragment, FragmentLevel, FragmentSource, SourcePlatform
+
+# ---- Helpers ----
+
+
+def _make(
+    *,
+    body: str,
+    level: FragmentLevel = "document",
+    frag_id: str = "frag-rootroot0000",
+    structural_path: list[str] | None = None,
+    title: str = "Root Doc",
+) -> IngestedFragment:
+    """Build an ``IngestedFragment`` at the requested structural level."""
+    fragment = Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=SourcePlatform.ESSAY),
+        level=level,
+        structural_path=structural_path or [],
+        tags=["root-tag"],
+    )
+    return IngestedFragment(fragment=fragment, body=body)
+
+
+def _bodies(children: list[IngestedFragment]) -> list[str]:
+    return [c.body for c in children]
+
+
+def _levels(children: list[IngestedFragment]) -> list[str]:
+    return [c.fragment.level for c in children]
+
+
+def _normalize_ws(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+# ---- Sentence-level: terminal ----
+
+
+class TestSentenceTerminal:
+    """A sentence is the smallest atom; splitting one returns []."""
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "The sentence stands alone.",
+            "Even with multiple? Punctuation marks! Inside.",
+        ],
+    )
+    def test_sentence_level_returns_empty(self, body: str) -> None:
+        assert split(_make(body=body, level="sentence")) == []
+
+
+# ---- Paragraph → sentence ----
+
+
+class TestParagraphToSentence:
+    """Paragraph splits into sentences via the configured tokenizer."""
+
+    def test_paragraph_to_multiple_sentences(self) -> None:
+        body = "First sentence. Second sentence! Third one?"
+        ingested = _make(body=body, level="paragraph")
+        children = split(ingested)
+        assert _levels(children) == ["sentence", "sentence", "sentence"]
+        assert _bodies(children) == [
+            "First sentence.",
+            "Second sentence!",
+            "Third one?",
+        ]
+
+    def test_single_sentence_paragraph_returns_empty(self) -> None:
+        ingested = _make(body="No further atom is possible.", level="paragraph")
+        assert split(ingested) == []
+
+    def test_empty_paragraph_returns_empty(self) -> None:
+        ingested = _make(body="   \n  ", level="paragraph")
+        assert split(ingested) == []
+
+    def test_custom_tokenizer_is_used(self) -> None:
+        body = "one|two|three"
+
+        def pipe_tokenizer(text: str) -> list[str]:
+            return [p.strip() for p in text.split("|") if p.strip()]
+
+        ingested = _make(body=body, level="paragraph")
+        children = split(ingested, sentence_tokenizer=pipe_tokenizer)
+        assert _bodies(children) == ["one", "two", "three"]
+        assert _levels(children) == ["sentence"] * 3
+
+
+# ---- Subsection → paragraph ----
+
+
+class TestSubsectionToParagraph:
+    """Subsection splits at blank-line paragraph boundaries."""
+
+    def test_multiple_paragraphs(self) -> None:
+        body = "Para one.\n\nPara two.\n\nPara three."
+        children = split(_make(body=body, level="subsection"))
+        assert _levels(children) == ["paragraph"] * 3
+        assert _bodies(children) == ["Para one.", "Para two.", "Para three."]
+
+    def test_paragraphs_with_blank_whitespace_lines(self) -> None:
+        body = "Alpha.\n   \nBravo.\n\t\nCharlie."
+        children = split(_make(body=body, level="subsection"))
+        assert _bodies(children) == ["Alpha.", "Bravo.", "Charlie."]
+
+    def test_subsection_with_single_paragraph_cascades_to_sentences(self) -> None:
+        body = "Only one para. But two sentences here."
+        children = split(_make(body=body, level="subsection"))
+        assert _levels(children) == ["sentence", "sentence"]
+        assert _bodies(children) == ["Only one para.", "But two sentences here."]
+
+    def test_subsection_with_single_sentence_returns_empty(self) -> None:
+        assert split(_make(body="Indivisible content.", level="subsection")) == []
+
+
+# ---- Section → subsection ----
+
+
+class TestSectionToSubsection:
+    """Section splits at H3+ headings, cascades when none present."""
+
+    def test_section_splits_at_h3_headings(self) -> None:
+        body = (
+            "Preamble paragraph here.\n\n"
+            "### First subsection\n\n"
+            "Body of first subsection.\n\n"
+            "### Second subsection\n\n"
+            "Body of second subsection."
+        )
+        ingested = _make(body=body, level="section")
+        children = split(ingested)
+        assert _levels(children) == ["subsection", "subsection", "subsection"]
+        # The preamble (no heading) appears first, then the two H3 chunks.
+        assert children[0].body == "Preamble paragraph here."
+        assert children[1].body.startswith("### First subsection")
+        assert children[2].body.startswith("### Second subsection")
+
+    def test_section_with_h4_h5_h6_headings(self) -> None:
+        body = "#### Four\n\nA\n\n##### Five\n\nB\n\n###### Six\n\nC"
+        children = split(_make(body=body, level="section"))
+        assert len(children) == 3
+        assert all(c.fragment.level == "subsection" for c in children)
+
+    def test_section_with_no_h3_cascades_to_paragraphs(self) -> None:
+        children = split(
+            _make(body="First paragraph.\n\nSecond paragraph.", level="section"),
+        )
+        assert _levels(children) == ["paragraph", "paragraph"]
+        assert _bodies(children) == ["First paragraph.", "Second paragraph."]
+
+    def test_section_with_no_h3_and_one_paragraph_cascades_to_sentences(
+        self,
+    ) -> None:
+        children = split(
+            _make(body="Hello there. World remains.", level="section"),
+        )
+        assert _levels(children) == ["sentence", "sentence"]
+
+
+# ---- Document → section ----
+
+
+class TestDocumentToSection:
+    """Document splits at H1/H2 headings or cascades through finer levels."""
+
+    def test_document_splits_at_h1_h2(self) -> None:
+        body = (
+            "# First section\n\n"
+            "Body of first section.\n\n"
+            "## Second section\n\n"
+            "Body of second section."
+        )
+        ingested = _make(body=body, level="document")
+        children = split(ingested)
+        assert _levels(children) == ["section", "section"]
+        assert children[0].fragment.structural_path == ["First section"]
+        assert children[1].fragment.structural_path == ["Second section"]
+
+    def test_document_h3_only_cascades_to_subsection(self) -> None:
+        body = (
+            "### Only subsection heading\n\n"
+            "Some body text.\n\n"
+            "### Another subsection\n\n"
+            "More body text."
+        )
+        ingested = _make(body=body, level="document")
+        children = split(ingested)
+        assert _levels(children) == ["subsection", "subsection"]
+
+    def test_document_with_no_headings_collapses_to_paragraph(self) -> None:
+        """Acceptance: ``document → paragraph`` when no headings present."""
+        body = (
+            "First paragraph of an unstructured note.\n\n"
+            "Second paragraph continues.\n\n"
+            "Third paragraph closes it."
+        )
+        ingested = _make(body=body, level="document")
+        children = split(ingested)
+        assert _levels(children) == ["paragraph", "paragraph", "paragraph"]
+        assert _bodies(children) == [
+            "First paragraph of an unstructured note.",
+            "Second paragraph continues.",
+            "Third paragraph closes it.",
+        ]
+
+    def test_document_with_no_headings_one_para_collapses_to_sentence(self) -> None:
+        body = "Single para. Two sentences worth."
+        ingested = _make(body=body, level="document")
+        children = split(ingested)
+        assert _levels(children) == ["sentence", "sentence"]
+
+    def test_document_preamble_before_first_heading_is_preserved(self) -> None:
+        body = "Intro paragraph with no heading.\n\n# A heading\n\nBody under heading."
+        ingested = _make(body=body, level="document")
+        children = split(ingested)
+        assert len(children) == 2
+        assert children[0].body == "Intro paragraph with no heading."
+        # First child has no heading so structural_path is inherited unchanged.
+        assert children[0].fragment.structural_path == []
+        assert children[1].fragment.structural_path == ["A heading"]
+
+
+# ---- Inheritance & ID semantics ----
+
+
+class TestChildMetadata:
+    """Children inherit parent metadata and carry deterministic identity."""
+
+    def test_child_ids_are_deterministic_helper_outputs(self) -> None:
+        body = "# Alpha\n\nA body.\n\n# Bravo\n\nB body."
+        ingested = _make(body=body, level="document", frag_id="frag-parent01abcd")
+        children = split(ingested)
+        assert [c.fragment.id for c in children] == [
+            generate_child_fragment_id("frag-parent01abcd", "section", 0),
+            generate_child_fragment_id("frag-parent01abcd", "section", 1),
+        ]
+
+    def test_children_carry_parent_id_level_and_inherit_metadata(self) -> None:
+        body = "# A\n\nbody one\n\n# B\n\nbody two"
+        ingested = _make(body=body, level="document", frag_id="frag-pp1122334455")
+        children = split(ingested)
+        for child in children:
+            assert child.fragment.parent_id == "frag-pp1122334455"
+            assert child.fragment.level == "section"
+            assert child.fragment.child_ids == []
+            assert child.fragment.source.platform == "essay"
+            assert child.fragment.tags == ["root-tag"]
+
+    def test_structural_path_extends_with_heading(self) -> None:
+        body = "# Outer\n\nbody one\n\n# Other\n\nbody two"
+        ingested = _make(body=body, level="document", structural_path=["Top"])
+        children = split(ingested)
+        assert children[0].fragment.structural_path == ["Top", "Outer"]
+        assert children[1].fragment.structural_path == ["Top", "Other"]
+
+    def test_structural_path_unchanged_for_headless_children(self) -> None:
+        ingested = _make(
+            body="First para.\n\nSecond para.",
+            level="document",
+            structural_path=["Top"],
+        )
+        for child in split(ingested):
+            assert child.fragment.structural_path == ["Top"]
+
+    def test_child_title_is_heading_when_present(self) -> None:
+        body = "# Alpha Heading\n\nbody one\n\n## Bravo Heading\n\nbody two"
+        ingested = _make(body=body, level="document")
+        children = split(ingested)
+        assert children[0].fragment.title == "Alpha Heading"
+        assert children[1].fragment.title == "Bravo Heading"
+
+    def test_child_title_falls_back_to_content_excerpt(self) -> None:
+        body = "Sentence alpha here. Sentence bravo here."
+        ingested = _make(body=body, level="paragraph")
+        children = split(ingested)
+        assert children[0].fragment.title == "Sentence alpha here."
+        assert children[1].fragment.title == "Sentence bravo here."
+
+    def test_long_first_line_title_is_truncated_with_ellipsis(self) -> None:
+        long_first = "x" * 200
+        body = f"{long_first}.\n\nSecond paragraph here."
+        ingested = _make(body=body, level="subsection")
+        children = split(ingested)
+        title = children[0].fragment.title
+        assert title.endswith("…")
+        assert len(title) <= 60
+
+    def test_whitespace_only_section_preamble_skipped(self) -> None:
+        body = "   \n  \n# Heading\n\nBody under heading."
+        ingested = _make(body=body, level="document")
+        children = split(ingested)
+        assert len(children) == 1
+        assert children[0].fragment.title == "Heading"
+
+
+# ---- Idempotency ----
+
+
+class TestIdempotency:
+    """Splitting twice yields identical children."""
+
+    @pytest.mark.parametrize(
+        ("level", "body"),
+        [
+            ("document", "# A\n\none\n\n# B\n\ntwo"),
+            ("paragraph", "Alpha sentence. Bravo sentence."),
+        ],
+    )
+    def test_repeat_split_yields_same_ids_and_bodies(
+        self,
+        level: FragmentLevel,
+        body: str,
+    ) -> None:
+        ingested = _make(body=body, level=level)
+        first = split(ingested)
+        second = split(ingested)
+        assert [c.fragment.id for c in first] == [c.fragment.id for c in second]
+        assert _bodies(first) == _bodies(second)
+
+
+# ---- Property: concatenation preserves text ----
+
+
+class TestConcatenationProperty:
+    """Concatenated child text equals parent text up to whitespace."""
+
+    @pytest.mark.parametrize(
+        ("level", "body"),
+        [
+            (
+                "document",
+                "# Alpha\n\nA body.\n\n## Bravo\n\nB body.",
+            ),
+            (
+                "document",
+                "Para one.\n\nPara two.\n\nPara three.",
+            ),
+            (
+                "section",
+                "### Sub one\n\none body.\n\n### Sub two\n\ntwo body.",
+            ),
+            (
+                "subsection",
+                "Para one.\n\nPara two.",
+            ),
+            (
+                "paragraph",
+                "Sentence one. Sentence two. Sentence three.",
+            ),
+        ],
+    )
+    def test_concatenation_equals_parent_up_to_whitespace(
+        self,
+        level: FragmentLevel,
+        body: str,
+    ) -> None:
+        ingested = _make(body=body, level=level)
+        children = split(ingested)
+        assert children, "expected non-empty decomposition for this fixture"
+        concatenated = " ".join(c.body for c in children)
+        assert _normalize_ws(concatenated) == _normalize_ws(body)
+
+
+# ---- Zoom-out levels are terminal for zoom-in ----
+
+
+class TestZoomOutLevelsTerminalForZoomIn:
+    """Aggregation levels (exchange/burst/session) return [] from zoom-in."""
+
+    @pytest.mark.parametrize("level", ["exchange", "burst", "session"])
+    def test_returns_empty(self, level: FragmentLevel) -> None:
+        ingested = _make(body="any content here", level=level)
+        assert split(ingested) == []
+
+
+# ---- Default sentence tokenizer ----
+
+
+class TestDefaultSentenceTokenizer:
+    """The default regex tokenizer handles common prose patterns."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("One. Two. Three.", ["One.", "Two.", "Three."]),
+            ("Is it? Yes! Continue.", ["Is it?", "Yes!", "Continue."]),
+            ('"Stop." She paused.', ['"Stop."', "She paused."]),
+            ("", []),
+            ("   \n  ", []),
+        ],
+    )
+    def test_tokenizer_cases(self, text: str, expected: list[str]) -> None:
+        assert default_sentence_tokenizer(text) == expected
+
+    def test_sentence_tokenizer_protocol_matches_signature(self) -> None:
+        tok: SentenceTokenizer = default_sentence_tokenizer
+        assert tok("Hello. World.") == ["Hello.", "World."]


### PR DESCRIPTION
## Summary

Closes #252. Adds `creek.atomize.split` — the *zoom-in* half of confidence-driven re-atomization (FEAT-023). Given a fragment that resists classification, `split()` returns its structural children one level finer along the spec'd transition chain:

```
document    -> section     (split at H1/H2 headings)
section     -> subsection  (split at H3+ headings)
subsection  -> paragraph   (blank-line boundaries)
paragraph   -> sentence    (configurable tokenizer)
sentence    -> terminal: returns []
```

A document with no headings collapses to paragraph (skipping the empty section/subsection levels). More generally the operator never produces zero-content levels — when a transition would yield a single chunk equal to the parent, it cascades to the next finer level.

Children inherit parent source, tags, and classification metadata; only the hierarchy fields (`id`, `parent_id`, `child_ids`, `level`, `structural_path`) are rewritten. IDs come from `generate_child_fragment_id(parent_id, level, index)` so re-splitting is bit-identical — required for FEAT-023's idempotent re-atomization driver.

The default sentence tokenizer is a pure-Python regex heuristic (no NLTK dependency); callers pass a custom `SentenceTokenizer` via keyword for higher-fidelity needs.

### Note on the signature

The spec phrases the operator as `split(fragment: Fragment) -> list[Fragment]`. `Fragment` in the current model carries only frontmatter metadata; the body text lives on `IngestedFragment`, the pipeline's metadata+body pairing. Since the spec requires children to carry "the verbatim text slice from the parent", the runtime signature is `split(IngestedFragment) -> list[IngestedFragment]`. The module docstring documents the interpretation.

## Acceptance criteria

- [x] `split()` produces correct children at each documented transition — `TestDocumentToSection`, `TestSectionToSubsection`, `TestSubsectionToParagraph`, `TestParagraphToSentence`.
- [x] A document with no headings splits `document → paragraph` — `test_document_with_no_headings_collapses_to_paragraph`.
- [x] Sentence-level fragments return `[]` and are flagged as terminal — `TestSentenceTerminal`.
- [x] Child IDs are deterministic; running `split` twice yields equal lists — `TestIdempotency`, `test_child_ids_are_deterministic_helper_outputs`.
- [x] Property test: concatenating children's text equals the parent's text up to whitespace — `TestConcatenationProperty` (parametrised across all transitions).
- [x] Tests with ≥90% branch coverage — 98% on `split.py`, 100% on `__init__.py`.
- [x] MyPy strict, Ruff zero violations — all 12 quality gates pass via `./scripts/check-all.sh`.

## Test plan

- [x] `./scripts/check-all.sh` exits 0 locally (Linting, Formatting, MyPy, Pylint ≥9.0, Bandit, pip-audit, Radon/Xenon, Refurb, Tryceratops, unit tests, coverage ≥90%, per-file gate)
- [ ] CI green on the PR
- [ ] Reviewer LGTM


---
_Generated by [Claude Code](https://claude.ai/code/session_01TpFwUfpRncwjwvsa3rDqqQ)_