### PR TITLE
feat(atomize): conversational aggregator stitches fragments upward (FEAT-022)

### DIFF
--- a/creek-tools/creek/atomize/__init__.py
+++ b/creek-tools/creek/atomize/__init__.py
@@ -1,16 +1,27 @@
 """Confidence-driven re-atomization operators (FEAT-021 / FEAT-022).
 
-This package houses the structural splitter (zoom in, FEAT-021) and —
-once landed — the conversational aggregator (zoom out, FEAT-022). Both
-operators are pure, deterministic transforms on fragments: callers
-(notably FEAT-023) decide when to invoke them and how to persist the
-results.
+This package houses the structural splitter (zoom in, FEAT-021) and the
+conversational aggregator (zoom out, FEAT-022). Both operators are
+pure, deterministic transforms on fragments: callers (notably FEAT-023)
+decide when to invoke them and how to persist the results.
 """
 
+from creek.atomize.aggregate import (
+    AggregateLevel,
+    AggregationConfig,
+    aggregate,
+)
 from creek.atomize.split import (
     SentenceTokenizer,
     default_sentence_tokenizer,
     split,
 )
 
-__all__ = ["SentenceTokenizer", "default_sentence_tokenizer", "split"]
+__all__ = [
+    "AggregateLevel",
+    "AggregationConfig",
+    "SentenceTokenizer",
+    "aggregate",
+    "default_sentence_tokenizer",
+    "split",
+]

--- a/creek-tools/creek/atomize/aggregate.py
+++ b/creek-tools/creek/atomize/aggregate.py
@@ -1,0 +1,341 @@
+"""Conversational aggregator — stitch fragments into coarser parents (FEAT-022).
+
+Zoom-out twin of the FEAT-021 splitter: stitches a stream of too-small
+fragments (chat one-liners) into the parent units where meaning lives.
+Vocabulary is chat-first (``exchange`` → ``burst`` → ``session``), but
+the mechanics are general: any sequence of fragments at ``level=document``
+(or below) sharing a ``FragmentSource`` rolls upward through the same
+transitions. ``session`` is terminal — session-level input is a no-op.
+
+The operator never mutates inputs on disk; it returns new parents and
+leaves persistence to the caller (FEAT-023).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from creek.models import Authorship, Fragment, FragmentSource
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from datetime import datetime
+
+    from creek.models import FragmentLevel
+
+AggregateLevel = Literal["exchange", "burst", "session"]
+"""Target levels supported by :func:`aggregate`.
+
+``exchange`` groups consecutive ``document``-level messages (≤2 speakers,
+within ``exchange_max_gap_minutes``). ``burst`` groups consecutive
+``exchange``-level fragments by topic continuity (cosine similarity ≥
+``burst_similarity_threshold``). ``session`` groups consecutive
+``burst``-level fragments (within ``session_max_gap_minutes``); session
+is terminal.
+"""
+
+_SOURCE_LEVELS: dict[AggregateLevel, FragmentLevel] = {
+    "exchange": "document",
+    "burst": "exchange",
+    "session": "burst",
+}
+
+
+@dataclass
+class AggregationConfig:
+    """Knobs for the conversational aggregator (FEAT-022).
+
+    The three numeric knobs mirror the YAML ``linking:`` section so the
+    aggregator tunes from a per-vault config; ``joiner`` and ``embedder``
+    are runtime-only. All threshold checks are inclusive.
+
+    Attributes:
+        exchange_max_gap_minutes: Max minute-gap between messages in the
+            same exchange.
+        burst_similarity_threshold: Cosine-similarity floor that keeps
+            two consecutive exchanges in the same burst.
+        session_max_gap_minutes: Max minute-gap between bursts in the
+            same session.
+        joiner: Separator used to concatenate child titles.
+        embedder: Callable returning dense embeddings for a list of
+            strings; required for multi-exchange ``burst`` runs. Injected
+            so tests and calibration scripts can stub the
+            sentence-transformers dependency.
+    """
+
+    exchange_max_gap_minutes: int = 30
+    burst_similarity_threshold: float = 0.7
+    session_max_gap_minutes: int = 360
+    joiner: str = "\n\n"
+    embedder: Callable[[list[str]], list[list[float]]] | None = None
+
+
+def aggregate(
+    fragments: list[Fragment],
+    *,
+    level: AggregateLevel,
+    config: AggregationConfig,
+) -> list[Fragment]:
+    """Aggregate fragments upward to the requested ``level``.
+
+    The aggregator partitions the input into fragments whose ``level``
+    matches the expected source level for ``level`` (eligible) and the
+    rest (pass-through). Eligible fragments are grouped by source key
+    and aggregated; pass-through fragments are returned unchanged.
+
+    Idempotency: re-running on the same input produces parents with
+    identical IDs and identical concatenated text. Cross-source
+    grouping is out of scope in v1 — only fragments sharing a
+    ``(platform, channel, conversation_id)`` key combine.
+
+    Args:
+        fragments: Fragments to aggregate. Mixed levels are allowed;
+            only fragments at the expected source level participate.
+        level: Target aggregation level (``exchange``, ``burst``, or
+            ``session``).
+        config: Aggregator knobs.
+
+    Returns:
+        A new list containing aggregated parents followed by any
+        pass-through fragments (in their original relative order).
+    """
+    if not fragments:
+        return []
+
+    source_level = _SOURCE_LEVELS[level]
+    eligible: list[Fragment] = []
+    passthrough: list[Fragment] = []
+    for frag in fragments:
+        if frag.level == source_level:
+            eligible.append(frag)
+        else:
+            passthrough.append(frag)
+
+    if not eligible:
+        return fragments.copy()
+
+    parents = _aggregate_eligible(eligible, level, config)
+    return parents + passthrough
+
+
+def _aggregate_eligible(
+    eligible: list[Fragment],
+    level: AggregateLevel,
+    config: AggregationConfig,
+) -> list[Fragment]:
+    """Group eligible fragments by source key and dispatch the transition."""
+    by_source: dict[str, list[Fragment]] = {}
+    for frag in eligible:
+        key = _source_key(frag.source)
+        by_source.setdefault(key, []).append(frag)
+
+    parents: list[Fragment] = []
+    for source_frags in by_source.values():
+        sorted_frags = sorted(source_frags, key=lambda f: f.created)
+        parents.extend(_group_by_level(sorted_frags, level, config))
+    return parents
+
+
+def _group_by_level(
+    fragments: list[Fragment],
+    level: AggregateLevel,
+    config: AggregationConfig,
+) -> list[Fragment]:
+    """Dispatch grouping to the per-level transition and build parents."""
+    if level == "exchange":
+        groups = _group_to_exchanges(fragments, config)
+    elif level == "burst":
+        groups = _group_to_bursts(fragments, config)
+    else:
+        groups = _group_to_sessions(fragments, config)
+    return [_build_parent(g, level, config) for g in groups]
+
+
+def _group_to_exchanges(
+    fragments: list[Fragment],
+    config: AggregationConfig,
+) -> list[list[Fragment]]:
+    """Group consecutive messages into exchanges (≤2 speakers, gap-bounded)."""
+    groups: list[list[Fragment]] = [[fragments[0]]]
+    for current in fragments[1:]:
+        prev = groups[-1][-1]
+        gap_minutes = _minutes_between(prev.created, current.created)
+        candidate = [*groups[-1], current]
+        within_gap = gap_minutes <= config.exchange_max_gap_minutes
+        within_speakers = len(_speakers(candidate)) <= 2
+        if within_gap and within_speakers:
+            groups[-1].append(current)
+        else:
+            groups.append([current])
+    return groups
+
+
+def _group_to_bursts(
+    fragments: list[Fragment],
+    config: AggregationConfig,
+) -> list[list[Fragment]]:
+    """Group consecutive exchanges into topic-continuous bursts.
+
+    Topic continuity = cosine similarity ≥ ``burst_similarity_threshold``
+    between consecutive exchange title embeddings.
+
+    Raises:
+        ValueError: If more than one exchange is supplied and
+            ``config.embedder`` is ``None``.
+    """
+    if len(fragments) == 1:
+        return [fragments.copy()]
+
+    if config.embedder is None:
+        msg = (
+            "aggregate(level='burst', ...) requires AggregationConfig.embedder "
+            "to compute topic-continuity similarity between exchanges."
+        )
+        raise ValueError(msg)
+
+    embeddings = config.embedder([f.title for f in fragments])
+    groups: list[list[Fragment]] = [[fragments[0]]]
+    for i in range(1, len(fragments)):
+        sim = _cosine(embeddings[i - 1], embeddings[i])
+        if sim >= config.burst_similarity_threshold:
+            groups[-1].append(fragments[i])
+        else:
+            groups.append([fragments[i]])
+    return groups
+
+
+def _group_to_sessions(
+    fragments: list[Fragment],
+    config: AggregationConfig,
+) -> list[list[Fragment]]:
+    """Group consecutive bursts into sessions (gap-bounded)."""
+    groups: list[list[Fragment]] = [[fragments[0]]]
+    for current in fragments[1:]:
+        prev = groups[-1][-1]
+        gap_minutes = _minutes_between(prev.created, current.created)
+        if gap_minutes <= config.session_max_gap_minutes:
+            groups[-1].append(current)
+        else:
+            groups.append([current])
+    return groups
+
+
+def _build_parent(
+    children: list[Fragment],
+    level: FragmentLevel,
+    config: AggregationConfig,
+) -> Fragment:
+    """Assemble an aggregated parent Fragment from an ordered child list.
+
+    Carries a deterministic ID from ``(source_key, level, child_ids)``,
+    ``child_ids`` in input order, joiner-concatenated titles, inherited
+    source (with ``author`` promoted to ``COLLABORATIVE`` on multi-speaker
+    groups), and tags for the date-range and participants.
+    """
+    child_ids = [c.id for c in children]
+    source = _inherit_source(children)
+    parent_id = _aggregate_id(_source_key(source), level, child_ids)
+    title = config.joiner.join(c.title for c in children)
+    earliest = min(c.created for c in children)
+    latest = max(c.created for c in children)
+    return Fragment(
+        id=parent_id,
+        title=title,
+        source=source,
+        created=earliest,
+        child_ids=child_ids,
+        level=level,
+        tags=_parent_tags(level, earliest, latest, _speakers(children)),
+    )
+
+
+def _inherit_source(children: list[Fragment]) -> FragmentSource:
+    """Build the parent's :class:`FragmentSource` from its children.
+
+    Channel, platform, conversation_id, and original_file are inherited
+    from the first child (callers guarantee a shared source key).
+    ``author`` is promoted to ``COLLABORATIVE`` when ≥2 distinct authors
+    appear; ``interlocutor`` is the comma-joined sorted set of child
+    interlocutors.
+    """
+    first = children[0].source
+    authors = {c.source.author for c in children}
+    interlocutors = sorted(
+        {c.source.interlocutor for c in children if c.source.interlocutor},
+    )
+    author = Authorship.COLLABORATIVE if len(authors) > 1 else next(iter(authors))
+    return FragmentSource(
+        platform=first.platform,
+        original_file=first.original_file,
+        original_encoding=first.original_encoding,
+        conversation_id=first.conversation_id,
+        channel=first.channel,
+        interlocutor=", ".join(interlocutors) if interlocutors else None,
+        author=author,
+    )
+
+
+def _parent_tags(
+    level: FragmentLevel,
+    earliest: datetime,
+    latest: datetime,
+    speakers: set[str],
+) -> list[str]:
+    """Build deterministic parent tags (level marker, date-range, speakers)."""
+    tags = [
+        f"aggregated/{level}",
+        f"daterange/{earliest.date().isoformat()}_{latest.date().isoformat()}",
+    ]
+    tags.extend(f"speaker/{s}" for s in sorted(speakers))
+    return tags
+
+
+def _speakers(fragments: list[Fragment]) -> set[str]:
+    """Return distinct speaker identities (``"{author}|{interlocutor}"``)."""
+    return {f"{f.source.author}|{f.source.interlocutor or ''}" for f in fragments}
+
+
+def _source_key(source: FragmentSource) -> str:
+    """Build the cross-fragment grouping key (platform|channel|conversation_id)."""
+    return f"{source.platform}|{source.channel or ''}|{source.conversation_id or ''}"
+
+
+def _aggregate_id(
+    source_key: str,
+    level: FragmentLevel,
+    child_ids: list[str],
+) -> str:
+    """Compute the deterministic parent ID that anchors FEAT-022 idempotency.
+
+    Order of ``child_ids`` matters — a reorder yields a different ID. The
+    shape mirrors :func:`creek.ingest.base.generate_fragment_id` so
+    downstream code cannot distinguish a deterministic root from an
+    aggregated parent.
+    """
+    child_hash = hashlib.sha256("|".join(child_ids).encode()).hexdigest()
+    hash_input = f"{source_key}:{level}:{child_hash}"
+    digest = hashlib.sha256(hash_input.encode()).hexdigest()[:12]
+    return f"frag-{digest}"
+
+
+def _minutes_between(earlier: datetime, later: datetime) -> float:
+    """Return the absolute gap between two timestamps, in minutes."""
+    return abs((later - earlier).total_seconds()) / 60.0
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    """Cosine similarity between two equal-length float vectors.
+
+    Pure-Python so the aggregator does not pull numpy into the import
+    graph for callers who only need exchange/session transitions.
+    Returns ``0.0`` when either vector has zero norm.
+    """
+    dot = sum((x * y for x, y in zip(a, b, strict=True)), 0.0)
+    norm_a = math.sqrt(sum((x * x for x in a), 0.0))
+    norm_b = math.sqrt(sum((x * x for x in b), 0.0))
+    if 0.0 in (norm_a, norm_b):
+        return 0.0
+    return dot / (norm_a * norm_b)

--- a/creek-tools/creek/atomize/aggregate.py
+++ b/creek-tools/creek/atomize/aggregate.py
@@ -227,7 +227,7 @@ def _group_to_sessions(
 
 def _build_parent(
     children: list[Fragment],
-    level: FragmentLevel,
+    level: AggregateLevel,
     config: AggregationConfig,
 ) -> Fragment:
     """Assemble an aggregated parent Fragment from an ordered child list.

--- a/creek-tools/creek/atomize/aggregate.py
+++ b/creek-tools/creek/atomize/aggregate.py
@@ -26,6 +26,8 @@ if TYPE_CHECKING:
 
     from creek.models import FragmentLevel
 
+__all__ = ["AggregateLevel", "AggregationConfig", "aggregate"]
+
 AggregateLevel = Literal["exchange", "burst", "session"]
 """Target levels supported by :func:`aggregate`.
 

--- a/creek-tools/creek/atomize/aggregate.py
+++ b/creek-tools/creek/atomize/aggregate.py
@@ -103,6 +103,9 @@ def aggregate(
     Returns:
         A new list containing aggregated parents followed by any
         pass-through fragments (in their original relative order).
+        Parents within the same source key are time-ordered, but two
+        source keys are emitted in dict-insertion order — not
+        interleaved chronologically.
     """
     if not fragments:
         return []
@@ -281,7 +284,7 @@ def _inherit_source(children: list[Fragment]) -> FragmentSource:
 
 
 def _parent_tags(
-    level: FragmentLevel,
+    level: AggregateLevel,
     earliest: datetime,
     latest: datetime,
     speakers: set[str],
@@ -307,7 +310,7 @@ def _source_key(source: FragmentSource) -> str:
 
 def _aggregate_id(
     source_key: str,
-    level: FragmentLevel,
+    level: AggregateLevel,
     child_ids: list[str],
 ) -> str:
     """Compute the deterministic parent ID that anchors FEAT-022 idempotency.

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -100,7 +100,7 @@ class LinkingConfig(BaseModel):
     eddy_min_fragments: int = 5
     """Minimum fragments required to form an Eddy."""
 
-    exchange_max_gap_minutes: int = 30
+    exchange_max_gap_minutes: int = Field(default=30, ge=1)
     """Maximum minute-gap between consecutive messages still grouped into
     the same ``exchange`` by the FEAT-022 aggregator. Inclusive boundary.
     """
@@ -111,7 +111,7 @@ class LinkingConfig(BaseModel):
     Inclusive boundary.
     """
 
-    session_max_gap_minutes: int = 360
+    session_max_gap_minutes: int = Field(default=360, ge=1)
     """Maximum minute-gap between consecutive bursts still grouped into the
     same ``session`` by the FEAT-022 aggregator. Inclusive boundary.
     """

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -100,6 +100,22 @@ class LinkingConfig(BaseModel):
     eddy_min_fragments: int = 5
     """Minimum fragments required to form an Eddy."""
 
+    exchange_max_gap_minutes: int = 30
+    """Maximum minute-gap between consecutive messages still grouped into
+    the same ``exchange`` by the FEAT-022 aggregator. Inclusive boundary.
+    """
+
+    burst_similarity_threshold: float = Field(default=0.7, ge=0.0, le=1.0)
+    """Cosine-similarity floor below which two consecutive exchanges start
+    separate ``burst``-level parents in the FEAT-022 aggregator.
+    Inclusive boundary.
+    """
+
+    session_max_gap_minutes: int = 360
+    """Maximum minute-gap between consecutive bursts still grouped into the
+    same ``session`` by the FEAT-022 aggregator. Inclusive boundary.
+    """
+
 
 class ClassificationConfig(BaseModel):
     """Classification pipeline configuration."""

--- a/creek-tools/tests/test_atomize_aggregate.py
+++ b/creek-tools/tests/test_atomize_aggregate.py
@@ -315,10 +315,6 @@ class TestBurstTransition:
 
     def test_similarity_equal_to_threshold_stays_in_burst(self) -> None:
         """Boundary: similarity exactly at threshold keeps the burst joined."""
-        cfg = AggregationConfig(
-            burst_similarity_threshold=0.5,
-            embedder=_fake_embedder({"a": [1.0, 0.0], "b": [0.5, 0.5**0.5 * 1.0]}),
-        )
         # cosine([1,0], [0.5, 0.866]) ≈ 0.5 — equality boundary.
         exchanges = [
             _frag(id_="e1", title="a", minute=0, level="exchange"),

--- a/creek-tools/tests/test_atomize_aggregate.py
+++ b/creek-tools/tests/test_atomize_aggregate.py
@@ -1,0 +1,524 @@
+"""Tests for the FEAT-022 conversational aggregator.
+
+Exercises ``creek.atomize.aggregate.aggregate`` end-to-end:
+
+- Each level transition (``document`` → ``exchange`` → ``burst`` →
+  ``session``).
+- Single-message roll-up through all three levels.
+- Idempotency contract.
+- Session-as-terminal behaviour.
+- Gap and similarity boundary tests.
+- Source-key grouping and cross-source isolation.
+- Helper functions (cosine, ID, source-key).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from creek.atomize.aggregate import (
+    AggregationConfig,
+    _aggregate_id,
+    _cosine,
+    _source_key,
+    aggregate,
+)
+from creek.models import (
+    Authorship,
+    Fragment,
+    FragmentLevel,
+    FragmentSource,
+    SourcePlatform,
+)
+
+# ---- Helpers ----
+
+
+def _src(
+    *,
+    platform: SourcePlatform = SourcePlatform.DISCORD,
+    channel: str | None = "general",
+    conversation_id: str | None = "conv-1",
+    interlocutor: str | None = "alice",
+    author: Authorship = Authorship.SELF,
+) -> FragmentSource:
+    """Build a FragmentSource with chat-friendly defaults."""
+    return FragmentSource(
+        platform=platform,
+        channel=channel,
+        conversation_id=conversation_id,
+        interlocutor=interlocutor,
+        author=author,
+    )
+
+
+def _frag(
+    *,
+    id_: str,
+    title: str,
+    minute: int,
+    level: FragmentLevel = "document",
+    source: FragmentSource | None = None,
+    base: datetime | None = None,
+) -> Fragment:
+    """Build a Fragment at a specific minute offset from ``base``."""
+    when = (base or datetime(2025, 5, 1, 12, 0, tzinfo=UTC)) + timedelta(minutes=minute)
+    return Fragment(
+        id=id_,
+        title=title,
+        source=source or _src(),
+        created=when,
+        level=level,
+    )
+
+
+def _fake_embedder(vectors: dict[str, list[float]]):
+    """Build a deterministic embedder from a title → vector mapping."""
+
+    def _embed(texts: list[str]) -> list[list[float]]:
+        return [vectors[t] for t in texts]
+
+    return _embed
+
+
+# ---- AggregationConfig defaults ----
+
+
+class TestAggregationConfigDefaults:
+    """Defaults must match the values published in the FEAT-022 spec."""
+
+    def test_exchange_gap_default(self) -> None:
+        """Default exchange_max_gap_minutes is 30."""
+        assert AggregationConfig().exchange_max_gap_minutes == 30
+
+    def test_burst_similarity_default(self) -> None:
+        """Default burst_similarity_threshold is 0.7."""
+        assert AggregationConfig().burst_similarity_threshold == pytest.approx(0.7)
+
+    def test_session_gap_default(self) -> None:
+        """Default session_max_gap_minutes is 360 (6 hours)."""
+        assert AggregationConfig().session_max_gap_minutes == 360
+
+    def test_joiner_default(self) -> None:
+        """Default joiner is a blank-line separator."""
+        assert AggregationConfig().joiner == "\n\n"
+
+    def test_embedder_default(self) -> None:
+        """Embedder is unset by default — burst transitions must inject."""
+        assert AggregationConfig().embedder is None
+
+
+# ---- Empty / passthrough ----
+
+
+class TestEmptyAndPassthrough:
+    """Edge cases for the eligibility partition."""
+
+    def test_empty_input_returns_empty(self) -> None:
+        """Empty input returns an empty list at every level."""
+        cfg = AggregationConfig()
+        assert aggregate([], level="exchange", config=cfg) == []
+        assert aggregate([], level="burst", config=cfg) == []
+        assert aggregate([], level="session", config=cfg) == []
+
+    def test_session_level_input_returns_unchanged(self) -> None:
+        """Session-level fragments are terminal — passed through verbatim."""
+        cfg = AggregationConfig()
+        sessions = [
+            _frag(id_="s1", title="session 1", minute=0, level="session"),
+            _frag(id_="s2", title="session 2", minute=10, level="session"),
+        ]
+        result = aggregate(sessions, level="session", config=cfg)
+        assert result == sessions
+
+    def test_input_at_unrelated_level_passes_through(self) -> None:
+        """Mismatched level on every fragment returns inputs unchanged."""
+        cfg = AggregationConfig()
+        frags = [_frag(id_="d1", title="doc", minute=0, level="document")]
+        # Asking for burst but only have documents → passthrough.
+        result = aggregate(frags, level="burst", config=cfg)
+        assert result == frags
+
+    def test_mixed_eligible_and_passthrough(self) -> None:
+        """Pass-through fragments accompany aggregated parents in the output."""
+        cfg = AggregationConfig()
+        docs = [
+            _frag(id_="d1", title="hi", minute=0, level="document"),
+            _frag(id_="d2", title="there", minute=5, level="document"),
+        ]
+        burst_input = _frag(id_="b1", title="burst", minute=0, level="burst")
+        result = aggregate([*docs, burst_input], level="exchange", config=cfg)
+        # One exchange parent + the burst pass-through.
+        assert len(result) == 2
+        assert result[-1] is burst_input
+
+
+# ---- Exchange transition ----
+
+
+class TestExchangeTransition:
+    """document → exchange grouping (gap + ≤2 speakers)."""
+
+    def test_two_speakers_within_gap_form_one_exchange(self) -> None:
+        """A short back-and-forth between two speakers becomes one exchange."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=30)
+        src_self = _src(author=Authorship.SELF, interlocutor="alice")
+        src_other = _src(author=Authorship.OTHER, interlocutor="alice")
+        docs = [
+            _frag(id_="d1", title="hello", minute=0, source=src_self),
+            _frag(id_="d2", title="hi", minute=5, source=src_other),
+            _frag(id_="d3", title="how are you?", minute=10, source=src_self),
+        ]
+        [parent] = aggregate(docs, level="exchange", config=cfg)
+        assert parent.level == "exchange"
+        assert parent.child_ids == ["d1", "d2", "d3"]
+        assert parent.title == "hello\n\nhi\n\nhow are you?"
+
+    def test_gap_exceeded_starts_new_exchange(self) -> None:
+        """A gap above the threshold breaks the exchange."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=10)
+        src_self = _src(author=Authorship.SELF, interlocutor="alice")
+        src_other = _src(author=Authorship.OTHER, interlocutor="alice")
+        docs = [
+            _frag(id_="d1", title="hi", minute=0, source=src_self),
+            _frag(id_="d2", title="hey", minute=5, source=src_other),
+            _frag(id_="d3", title="back later", minute=100, source=src_self),
+        ]
+        parents = aggregate(docs, level="exchange", config=cfg)
+        assert [p.child_ids for p in parents] == [["d1", "d2"], ["d3"]]
+
+    def test_gap_equal_to_threshold_keeps_group(self) -> None:
+        """The gap ceiling is inclusive: exactly-threshold gaps stay grouped."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=10)
+        docs = [
+            _frag(id_="d1", title="a", minute=0),
+            _frag(id_="d2", title="b", minute=10),
+        ]
+        [parent] = aggregate(docs, level="exchange", config=cfg)
+        assert parent.child_ids == ["d1", "d2"]
+
+    def test_third_speaker_starts_new_exchange(self) -> None:
+        """Introducing a third speaker forces a new exchange group."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=120)
+        a = _src(author=Authorship.SELF, interlocutor="alice")
+        b = _src(author=Authorship.OTHER, interlocutor="alice")
+        c = _src(author=Authorship.OTHER, interlocutor="bob")
+        docs = [
+            _frag(id_="d1", title="me", minute=0, source=a),
+            _frag(id_="d2", title="alice", minute=5, source=b),
+            _frag(id_="d3", title="bob", minute=10, source=c),
+        ]
+        parents = aggregate(docs, level="exchange", config=cfg)
+        assert [p.child_ids for p in parents] == [["d1", "d2"], ["d3"]]
+
+    def test_single_document_rolls_up_into_one_exchange(self) -> None:
+        """A solo message still produces an exchange parent (1-child)."""
+        cfg = AggregationConfig()
+        docs = [_frag(id_="d1", title="lonely", minute=0)]
+        [parent] = aggregate(docs, level="exchange", config=cfg)
+        assert parent.child_ids == ["d1"]
+        assert parent.level == "exchange"
+
+    def test_exchange_parent_inherits_source_channel(self) -> None:
+        """The parent's source carries the children's channel/platform."""
+        cfg = AggregationConfig()
+        src = _src(channel="creek-dev", platform=SourcePlatform.DISCORD)
+        docs = [_frag(id_="d1", title="hi", minute=0, source=src)]
+        [parent] = aggregate(docs, level="exchange", config=cfg)
+        assert parent.source.channel == "creek-dev"
+        assert parent.source.platform == SourcePlatform.DISCORD.value
+
+    def test_exchange_parent_promotes_author_to_collaborative(self) -> None:
+        """Mixed-author exchanges set parent.source.author = COLLABORATIVE."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=30)
+        a = _src(author=Authorship.SELF, interlocutor="alice")
+        b = _src(author=Authorship.OTHER, interlocutor="alice")
+        docs = [
+            _frag(id_="d1", title="hi", minute=0, source=a),
+            _frag(id_="d2", title="hey", minute=5, source=b),
+        ]
+        [parent] = aggregate(docs, level="exchange", config=cfg)
+        assert parent.source.author == Authorship.COLLABORATIVE.value
+
+    def test_exchange_parent_keeps_single_author_when_homogeneous(self) -> None:
+        """A solo-self exchange keeps author=SELF (no spurious promotion)."""
+        cfg = AggregationConfig()
+        docs = [_frag(id_="d1", title="thinking", minute=0)]
+        [parent] = aggregate(docs, level="exchange", config=cfg)
+        assert parent.source.author == Authorship.SELF.value
+
+    def test_exchange_parent_tags_include_daterange(self) -> None:
+        """Parent tags carry the inclusive date-range of its children."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=30 * 24 * 60)
+        base = datetime(2025, 5, 1, 12, 0, tzinfo=UTC)
+        docs = [
+            _frag(id_="d1", title="a", minute=0, base=base),
+            _frag(id_="d2", title="b", minute=60, base=base),
+        ]
+        [parent] = aggregate(docs, level="exchange", config=cfg)
+        assert "daterange/2025-05-01_2025-05-01" in parent.tags
+        assert "aggregated/exchange" in parent.tags
+
+    def test_exchange_parent_interlocutor_joins_speakers(self) -> None:
+        """The parent's interlocutor field surfaces every child's interlocutor."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=30)
+        a = _src(author=Authorship.SELF, interlocutor="alice")
+        b = _src(author=Authorship.SELF, interlocutor="bob")
+        docs = [
+            _frag(id_="d1", title="to alice", minute=0, source=a),
+            _frag(id_="d2", title="to bob", minute=5, source=b),
+        ]
+        [parent] = aggregate(docs, level="exchange", config=cfg)
+        assert parent.source.interlocutor == "alice, bob"
+
+
+# ---- Burst transition ----
+
+
+class TestBurstTransition:
+    """exchange → burst grouping via embedding similarity."""
+
+    def test_high_similarity_collapses_to_one_burst(self) -> None:
+        """Adjacent same-topic exchanges merge into one burst."""
+        cfg = AggregationConfig(
+            burst_similarity_threshold=0.7,
+            embedder=_fake_embedder(
+                {"a": [1.0, 0.0], "b": [0.99, 0.1], "c": [0.98, 0.2]},
+            ),
+        )
+        exchanges = [
+            _frag(id_="e1", title="a", minute=0, level="exchange"),
+            _frag(id_="e2", title="b", minute=30, level="exchange"),
+            _frag(id_="e3", title="c", minute=60, level="exchange"),
+        ]
+        [burst] = aggregate(exchanges, level="burst", config=cfg)
+        assert burst.child_ids == ["e1", "e2", "e3"]
+        assert burst.level == "burst"
+
+    def test_low_similarity_splits_into_multiple_bursts(self) -> None:
+        """Topic shift below threshold starts a new burst."""
+        cfg = AggregationConfig(
+            burst_similarity_threshold=0.7,
+            embedder=_fake_embedder(
+                {"a": [1.0, 0.0], "b": [0.0, 1.0], "c": [0.0, 1.0]},
+            ),
+        )
+        exchanges = [
+            _frag(id_="e1", title="a", minute=0, level="exchange"),
+            _frag(id_="e2", title="b", minute=10, level="exchange"),
+            _frag(id_="e3", title="c", minute=20, level="exchange"),
+        ]
+        parents = aggregate(exchanges, level="burst", config=cfg)
+        assert [p.child_ids for p in parents] == [["e1"], ["e2", "e3"]]
+
+    def test_similarity_equal_to_threshold_stays_in_burst(self) -> None:
+        """Boundary: similarity exactly at threshold keeps the burst joined."""
+        cfg = AggregationConfig(
+            burst_similarity_threshold=0.5,
+            embedder=_fake_embedder({"a": [1.0, 0.0], "b": [0.5, 0.5**0.5 * 1.0]}),
+        )
+        # cosine([1,0], [0.5, 0.866]) ≈ 0.5 — equality boundary.
+        exchanges = [
+            _frag(id_="e1", title="a", minute=0, level="exchange"),
+            _frag(id_="e2", title="b", minute=10, level="exchange"),
+        ]
+        cfg = AggregationConfig(
+            burst_similarity_threshold=_cosine([1.0, 0.0], [0.5, 0.8660254]),
+            embedder=_fake_embedder({"a": [1.0, 0.0], "b": [0.5, 0.8660254]}),
+        )
+        [burst] = aggregate(exchanges, level="burst", config=cfg)
+        assert burst.child_ids == ["e1", "e2"]
+
+    def test_single_exchange_rolls_up_without_embedder(self) -> None:
+        """A single-exchange burst skips the similarity check."""
+        cfg = AggregationConfig(embedder=None)
+        exchanges = [_frag(id_="e1", title="solo", minute=0, level="exchange")]
+        [burst] = aggregate(exchanges, level="burst", config=cfg)
+        assert burst.child_ids == ["e1"]
+        assert burst.level == "burst"
+
+    def test_missing_embedder_raises_on_multi_exchange_burst(self) -> None:
+        """Calling burst with no embedder + >1 exchange is a contract error."""
+        cfg = AggregationConfig(embedder=None)
+        exchanges = [
+            _frag(id_="e1", title="a", minute=0, level="exchange"),
+            _frag(id_="e2", title="b", minute=10, level="exchange"),
+        ]
+        with pytest.raises(ValueError, match="embedder"):
+            aggregate(exchanges, level="burst", config=cfg)
+
+
+# ---- Session transition ----
+
+
+class TestSessionTransition:
+    """burst → session grouping by temporal gap."""
+
+    def test_close_bursts_merge_into_one_session(self) -> None:
+        """Bursts within the session window collapse into one session."""
+        cfg = AggregationConfig(session_max_gap_minutes=120)
+        bursts = [
+            _frag(id_="b1", title="a", minute=0, level="burst"),
+            _frag(id_="b2", title="b", minute=60, level="burst"),
+            _frag(id_="b3", title="c", minute=180, level="burst"),
+        ]
+        [session] = aggregate(bursts, level="session", config=cfg)
+        assert session.child_ids == ["b1", "b2", "b3"]
+        assert session.level == "session"
+
+    def test_large_gap_splits_into_two_sessions(self) -> None:
+        """A gap above session_max_gap_minutes starts a new session."""
+        cfg = AggregationConfig(session_max_gap_minutes=60)
+        bursts = [
+            _frag(id_="b1", title="a", minute=0, level="burst"),
+            _frag(id_="b2", title="b", minute=30, level="burst"),
+            _frag(id_="b3", title="c", minute=500, level="burst"),
+        ]
+        parents = aggregate(bursts, level="session", config=cfg)
+        assert [p.child_ids for p in parents] == [["b1", "b2"], ["b3"]]
+
+    def test_session_gap_equal_to_threshold_keeps_group(self) -> None:
+        """Inclusive boundary: equal-to-threshold gaps stay in the session."""
+        cfg = AggregationConfig(session_max_gap_minutes=60)
+        bursts = [
+            _frag(id_="b1", title="a", minute=0, level="burst"),
+            _frag(id_="b2", title="b", minute=60, level="burst"),
+        ]
+        [session] = aggregate(bursts, level="session", config=cfg)
+        assert session.child_ids == ["b1", "b2"]
+
+
+# ---- Cross-source isolation ----
+
+
+class TestCrossSourceIsolation:
+    """Only fragments sharing a source key combine (v1 scope)."""
+
+    def test_different_channels_do_not_merge(self) -> None:
+        """Two channels in the same platform stay separate."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        src_a = _src(channel="alpha")
+        src_b = _src(channel="beta")
+        docs = [
+            _frag(id_="d1", title="x", minute=0, source=src_a),
+            _frag(id_="d2", title="y", minute=10, source=src_b),
+        ]
+        parents = aggregate(docs, level="exchange", config=cfg)
+        assert len(parents) == 2
+        assert {p.source.channel for p in parents} == {"alpha", "beta"}
+
+    def test_different_platforms_do_not_merge(self) -> None:
+        """Different platforms with the same channel stay separate."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        src_d = _src(platform=SourcePlatform.DISCORD, channel="dev")
+        src_c = _src(platform=SourcePlatform.CLAUDE, channel="dev")
+        docs = [
+            _frag(id_="d1", title="x", minute=0, source=src_d),
+            _frag(id_="d2", title="y", minute=10, source=src_c),
+        ]
+        parents = aggregate(docs, level="exchange", config=cfg)
+        assert len(parents) == 2
+
+
+# ---- Idempotency ----
+
+
+class TestIdempotency:
+    """Re-running aggregation against identical input is deterministic."""
+
+    def test_exchange_ids_stable_across_runs(self) -> None:
+        """Running exchange aggregation twice yields identical IDs/content."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=30)
+        docs = [
+            _frag(id_="d1", title="a", minute=0),
+            _frag(id_="d2", title="b", minute=10),
+        ]
+        first = aggregate(docs, level="exchange", config=cfg)
+        second = aggregate(docs, level="exchange", config=cfg)
+        assert [p.id for p in first] == [p.id for p in second]
+        assert [p.title for p in first] == [p.title for p in second]
+        assert [p.child_ids for p in first] == [p.child_ids for p in second]
+
+    def test_full_roll_up_is_idempotent(self) -> None:
+        """document→exchange→burst→session chain is reproducible end-to-end."""
+        embedder = _fake_embedder({"hello": [1.0, 0.0]})
+        cfg = AggregationConfig(embedder=embedder)
+        docs = [_frag(id_="d1", title="hello", minute=0)]
+        chain_1 = _roll_up(docs, cfg)
+        chain_2 = _roll_up(docs, cfg)
+        assert chain_1.id == chain_2.id
+        assert chain_1.title == chain_2.title
+        assert chain_1.child_ids == chain_2.child_ids
+
+
+# ---- Single-message roll-up (acceptance criterion) ----
+
+
+class TestSingleMessageRollUp:
+    """A solo document rolls upward through exchange → burst → session."""
+
+    def test_single_message_rolls_to_session(self) -> None:
+        """Document → exchange → burst → session preserves the lineage."""
+        embedder = _fake_embedder({"only": [1.0, 0.0]})
+        cfg = AggregationConfig(embedder=embedder)
+        docs = [_frag(id_="d1", title="only", minute=0)]
+        [exchange] = aggregate(docs, level="exchange", config=cfg)
+        [burst] = aggregate([exchange], level="burst", config=cfg)
+        [session] = aggregate([burst], level="session", config=cfg)
+        assert exchange.level == "exchange"
+        assert burst.level == "burst"
+        assert session.level == "session"
+        assert exchange.child_ids == ["d1"]
+        assert burst.child_ids == [exchange.id]
+        assert session.child_ids == [burst.id]
+
+
+# ---- Helpers (cosine, IDs, source keys) ----
+
+
+class TestHelpers:
+    """Internal helpers — independently tested for boundary coverage."""
+
+    def test_cosine_orthogonal_is_zero(self) -> None:
+        """Orthogonal vectors → cosine 0."""
+        assert _cosine([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+
+    def test_cosine_parallel_is_one(self) -> None:
+        """Parallel vectors → cosine 1."""
+        assert _cosine([1.0, 2.0], [2.0, 4.0]) == pytest.approx(1.0)
+
+    def test_cosine_zero_vector_returns_zero(self) -> None:
+        """A zero vector cannot be normalised — return 0.0."""
+        assert _cosine([0.0, 0.0], [1.0, 1.0]) == 0.0
+        assert _cosine([1.0, 1.0], [0.0, 0.0]) == 0.0
+
+    def test_aggregate_id_changes_with_child_order(self) -> None:
+        """ID derivation factors child order — a reorder yields a new ID."""
+        a = _aggregate_id("key", "exchange", ["c1", "c2"])
+        b = _aggregate_id("key", "exchange", ["c2", "c1"])
+        assert a != b
+
+    def test_aggregate_id_changes_with_level(self) -> None:
+        """Same children at different levels produce different parent IDs."""
+        a = _aggregate_id("key", "exchange", ["c1"])
+        b = _aggregate_id("key", "burst", ["c1"])
+        assert a != b
+
+    def test_source_key_none_fields_collapse_to_empty(self) -> None:
+        """Missing channel/conversation_id collapse to empty placeholders."""
+        source = FragmentSource(platform=SourcePlatform.JOURNAL)
+        key = _source_key(source)
+        assert key == "journal||"
+
+
+# ---- Module-private helpers used in tests ----
+
+
+def _roll_up(docs: list[Fragment], cfg: AggregationConfig) -> Fragment:
+    """Roll a document chain to session, returning the final parent."""
+    [exchange] = aggregate(docs, level="exchange", config=cfg)
+    [burst] = aggregate([exchange], level="burst", config=cfg)
+    [session] = aggregate([burst], level="session", config=cfg)
+    return session

--- a/creek-tools/tests/test_atomize_aggregate.py
+++ b/creek-tools/tests/test_atomize_aggregate.py
@@ -124,7 +124,14 @@ class TestEmptyAndPassthrough:
         assert aggregate([], level="session", config=cfg) == []
 
     def test_session_level_input_returns_unchanged(self) -> None:
-        """Session-level fragments are terminal — passed through verbatim."""
+        """Session-level fragments are terminal.
+
+        Mechanism: ``_SOURCE_LEVELS["session"] == "burst"``, so a fragment
+        already at ``session`` fails the eligibility check and falls into
+        the passthrough partition. The "session is terminal" guarantee is
+        a consequence of that source-level mismatch, not a special-cased
+        branch in :func:`aggregate`.
+        """
         cfg = AggregationConfig()
         sessions = [
             _frag(id_="s1", title="session 1", minute=0, level="session"),


### PR DESCRIPTION
Closes #253.

## Summary

Adds `creek/atomize/aggregate.py` — the zoom-out twin of the FEAT-021
splitter. The `aggregate()` function stitches a stream of too-small
fragments (typically chat one-liners) into the parent units where meaning
lives, walking the `document → exchange → burst → session` hierarchy one
transition per call.

- **Exchange** grouping bounds ≤2 speakers and `exchange_max_gap_minutes`.
- **Burst** grouping uses cosine similarity ≥ `burst_similarity_threshold`
  between consecutive exchange title embeddings; the embedder is injectable
  so unit tests can stub sentence-transformers.
- **Session** grouping bounds `session_max_gap_minutes` between bursts;
  session is terminal — session-level input is returned unchanged.
- Parent IDs are deterministic from `(source_key, level, child_ids)` so
  re-runs are idempotent.
- Cross-source aggregation is out of scope per the v1 spec; only fragments
  sharing `(platform, channel, conversation_id)` combine.

The three numeric knobs (`exchange_max_gap_minutes=30`,
`burst_similarity_threshold=0.7`, `session_max_gap_minutes=360`) land
under `LinkingConfig` in `creek_config.yaml`, re-using the existing
temporal-window precedent.

## Acceptance criteria — all verified

- [x] `aggregate()` produces correct parents at each documented transition
  for synthesised chat fixtures (`TestExchangeTransition`,
  `TestBurstTransition`, `TestSessionTransition`).
- [x] Single-message input at `level=document` rolls upward correctly
  through `exchange → burst → session`
  (`TestSingleMessageRollUp.test_single_message_rolls_to_session`).
- [x] Idempotent: re-running yields parents with identical IDs and
  contents (`TestIdempotency`).
- [x] Session-level input returns unchanged
  (`TestEmptyAndPassthrough.test_session_level_input_returns_unchanged`).
- [x] Gap and similarity thresholds are honoured (boundary tests in
  `test_gap_equal_to_threshold_keeps_group`,
  `test_similarity_equal_to_threshold_stays_in_burst`,
  `test_session_gap_equal_to_threshold_keeps_group`).
- [x] Tests with ≥90 % branch coverage (`creek/atomize/aggregate.py` ≈
  98.8 % branch coverage; 38 new tests).
- [x] MyPy strict, Ruff zero violations — `./scripts/check-all.sh` is
  fully green (12/12 gates passing locally).

## Out of scope (per issue body)

- Persistence of aggregated parents to the vault (FEAT-023).
- The zoom-in direction (FEAT-021).
- Cross-source aggregation.

## Test plan

- [x] `./scripts/check-all.sh` exits 0 locally
- [ ] CI green on this PR

https://claude.ai/code/session_011Mdh6NP9aipjguGLPcCSwb

---
_Generated by [Claude Code](https://claude.ai/code/session_011Mdh6NP9aipjguGLPcCSwb)_