### PR TITLE
feat(classify): confidence-driven re-atomization orchestrator (FEAT-023)

### DIFF
--- a/creek-tools/creek/classify/reatomize.py
+++ b/creek-tools/creek/classify/reatomize.py
@@ -1,0 +1,528 @@
+"""Confidence-driven re-atomization orchestrator (FEAT-023).
+
+Ties together the FEAT-021 zoom-in splitter and the FEAT-022 zoom-out
+aggregator: when a classifier returns ``unclassified`` or scores below
+the configured confidence floor, this orchestrator chooses a direction
+based on the fragment's source and structural level, re-atomizes
+accordingly, classifies the new units, and recurses. Recursion stops
+when a unit clears the threshold, hits a terminal level (sentence on
+the small end, session on the large end), or reaches the per-config
+max-depth ceiling.
+
+A leaf that still won't classify is honestly recorded as
+``unclassified`` — exactly the philosophy the rest of the pipeline
+already honours, expressed structurally instead of as a single failed
+verdict on a too-large or too-small unit.
+
+Pure transform: the orchestrator returns a :class:`ClassificationTree`
+and never touches disk. Callers (the CLI, batch scripts) walk the tree
+to persist its nodes; that separation keeps the unit tests fast and
+the persistence concern reusable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from creek.atomize.aggregate import AggregateLevel, AggregationConfig, aggregate
+from creek.atomize.split import SentenceTokenizer, default_sentence_tokenizer, split
+from creek.ingest.base import IngestedFragment
+from creek.models import (
+    Fragment,
+    FragmentLevel,
+    Frequency,
+    Phase,
+    SourcePlatform,
+)
+
+if TYPE_CHECKING:
+    from creek.config import ClassificationConfig
+
+__all__ = [
+    "ClassificationTree",
+    "Classifier",
+    "Direction",
+    "ReatomizeConfig",
+    "StopReason",
+    "choose_direction",
+    "classify_reatomize",
+    "classify_reatomize_stream",
+]
+
+Direction = Literal["split", "aggregate"]
+DirectionOverride = Literal["auto", "split", "aggregate"]
+
+StopReason = Literal[
+    "accepted",
+    "terminal",
+    "max_depth",
+    "disabled",
+    "no_decomposition",
+    "aggregate_no_siblings",
+    "split",
+    "aggregated",
+]
+"""Why the orchestrator stopped recursing on a given subtree.
+
+Leaf reasons (``children`` is empty):
+
+``accepted``: classifier cleared :attr:`ReatomizeConfig.threshold`.
+``terminal``: at a level the operators refuse to decompose
+(sentence / session).
+``max_depth``: hit :attr:`ReatomizeConfig.max_depth`.
+``disabled``: the run was opt-out; no recursion attempted.
+``no_decomposition``: the chosen operator returned no children.
+``aggregate_no_siblings``: zoom-out chosen on a lone fragment with no
+siblings; see :func:`classify_reatomize_stream`.
+
+Internal reasons (``children`` is non-empty):
+
+``split``: parent was decomposed by the FEAT-021 zoom-in splitter.
+``aggregated``: parent was assembled by the FEAT-022 zoom-out
+aggregator (only produced by :func:`classify_reatomize_stream`).
+"""
+
+Classifier = Callable[[IngestedFragment], tuple[IngestedFragment, float]]
+"""Callable contract for FEAT-023 classification.
+
+Takes an :class:`IngestedFragment` (fragment metadata + body) and
+returns the classified fragment paired with a 0..1 confidence score.
+The function shape stays simple so tests can mock it with a closure
+and production code can adapt :class:`~creek.classify.rules.RuleClassifier`
+or :class:`~creek.classify.llm.LLMClassifier` via a thin wrapper.
+"""
+
+_CHAT_PLATFORMS: frozenset[SourcePlatform] = frozenset(
+    {
+        SourcePlatform.DISCORD,
+        SourcePlatform.CLAUDE,
+        SourcePlatform.CHATGPT,
+    },
+)
+"""Source platforms whose ``document``-level units are chat messages.
+
+Slack is named in the FEAT-023 spec but is not yet enumerated in
+:class:`SourcePlatform`; it will join this set once added.
+"""
+
+_DOCUMENT_PLATFORMS: frozenset[SourcePlatform] = frozenset(
+    {
+        SourcePlatform.DOCUMENT,
+        SourcePlatform.MARKDOWN,
+        SourcePlatform.CODE,
+        SourcePlatform.ESSAY,
+        SourcePlatform.JOURNAL,
+        SourcePlatform.EMAIL,
+        SourcePlatform.SPREADSHEET,
+        SourcePlatform.PRESENTATION,
+        SourcePlatform.IMAGE_OCR,
+    },
+)
+"""Source platforms whose top-level units are long-form documents."""
+
+_TERMINAL_LEVELS: frozenset[FragmentLevel] = frozenset({"sentence", "session"})
+"""Levels that resist further re-atomization in either direction."""
+
+_AGGREGATE_NEXT_LEVEL: dict[FragmentLevel, AggregateLevel] = {
+    "document": "exchange",
+    "exchange": "burst",
+    "burst": "session",
+}
+"""For each source level, the FEAT-022 target one step coarser."""
+
+
+@dataclass(frozen=True)
+class ClassificationTree:
+    """Recursive output of :func:`classify_reatomize`.
+
+    Each node carries the classified fragment, the per-node confidence
+    score, the reason recursion stopped (or ``"split"`` / ``"aggregated"``
+    when the node has children), and the sub-trees produced.
+    ``frozen=True`` so callers can hash or set-membership-test nodes
+    without surprise.
+
+    Attributes:
+        fragment: Classified fragment (frontmatter + body).
+        confidence: Score the classifier returned for this fragment.
+        stop_reason: Why recursion ended at this node, or how it
+            continued (``split`` / ``aggregated``) when ``children``
+            is non-empty.
+        children: Sub-trees produced by re-atomization.
+        depth: Distance from the root the caller invoked the
+            orchestrator at (root is 0). Recorded so a downstream
+            renderer or test can assert depth-bounded recursion
+            without re-walking the tree.
+    """
+
+    fragment: IngestedFragment
+    confidence: float
+    stop_reason: StopReason
+    children: tuple[ClassificationTree, ...] = ()
+    depth: int = 0
+
+
+@dataclass
+class ReatomizeConfig:
+    """Runtime knobs for :func:`classify_reatomize`.
+
+    Mirrors the four ``classification.reatomize_*`` YAML fields but
+    keeps runtime-only fields (operator hooks, tokenizer) out of the
+    user-facing config schema.
+
+    Attributes:
+        enabled: Master switch. ``False`` short-circuits to a single
+            classify pass per fragment (mirrors the legacy engine).
+            Default ``False`` per FEAT-023's "opt-in for v1" framing.
+        threshold: Confidence floor that triggers re-atomization.
+            Default ``0.7`` matches
+            :class:`creek.config.ClassificationConfig.confidence_threshold`.
+        max_depth: Recursion ceiling counted from the root (depth 0).
+        direction: ``"auto"`` (heuristic), ``"split"``, or
+            ``"aggregate"`` — overrides :func:`choose_direction`.
+        sentence_tokenizer: Forwarded into the FEAT-021 splitter for
+            paragraph→sentence transitions.
+        aggregation_config: Forwarded into FEAT-022; defaults to stock
+            thresholds. Callers wire an embedder when burst runs are
+            in play.
+    """
+
+    enabled: bool = False
+    threshold: float = 0.7
+    max_depth: int = 4
+    direction: DirectionOverride = "auto"
+    sentence_tokenizer: SentenceTokenizer = field(
+        default=default_sentence_tokenizer,
+    )
+    aggregation_config: AggregationConfig = field(default_factory=AggregationConfig)
+
+    @classmethod
+    def from_classification_config(
+        cls,
+        config: ClassificationConfig,
+        *,
+        aggregation_config: AggregationConfig | None = None,
+    ) -> ReatomizeConfig:
+        """Project the FEAT-023 knobs out of a :class:`ClassificationConfig`.
+
+        Centralises the ``reatomize_threshold is None`` fallback so
+        the CLI and tests don't each re-derive it.
+
+        Args:
+            config: Loaded vault classification config.
+            aggregation_config: Optional pre-built FEAT-022 config —
+                callers that want a calibrated embedder wire it here.
+
+        Returns:
+            A ready-to-use :class:`ReatomizeConfig`.
+        """
+        threshold = (
+            config.reatomize_threshold
+            if config.reatomize_threshold is not None
+            else config.confidence_threshold
+        )
+        return cls(
+            enabled=config.reatomize,
+            threshold=threshold,
+            max_depth=config.reatomize_max_depth,
+            direction=config.reatomize_direction,
+            aggregation_config=aggregation_config or AggregationConfig(),
+        )
+
+
+def classify_reatomize(
+    fragment: IngestedFragment,
+    classifier: Classifier,
+    *,
+    config: ReatomizeConfig,
+    _depth: int = 0,
+) -> ClassificationTree:
+    """Classify ``fragment`` and recursively re-atomize when uncertain.
+
+    Implements the FEAT-023 algorithm:
+
+    1. Classify the fragment.
+    2. If accepted (confidence ≥ threshold AND no required dimension
+       is ``unclassified``), return a leaf.
+    3. Otherwise pick a direction (split / aggregate) via
+       :func:`choose_direction`, decompose, recurse on the children.
+    4. Stop on terminal levels, ``max_depth``, empty decomposition,
+       or lone-fragment aggregate requests.
+
+    Idempotency: re-running on byte-identical input yields a tree of
+    identical shape because both operators are deterministic and the
+    classifier-driven branches collapse to the same shape when the
+    fragments are unchanged.
+
+    Args:
+        fragment: Root fragment to classify.
+        classifier: Callable returning ``(classified, confidence)``.
+        config: Per-run knobs.
+        _depth: Internal recursion counter; callers should not pass.
+
+    Returns:
+        A :class:`ClassificationTree` rooted at ``fragment``.
+    """
+    classified, confidence = classifier(fragment)
+
+    if not config.enabled:
+        return _leaf(classified, confidence, "disabled", _depth)
+    if _is_accepted(classified.fragment, confidence, config.threshold):
+        return _leaf(classified, confidence, "accepted", _depth)
+    if classified.fragment.level in _TERMINAL_LEVELS:
+        return _leaf(classified, confidence, "terminal", _depth)
+    if _depth >= config.max_depth:
+        return _leaf(classified, confidence, "max_depth", _depth)
+
+    direction = choose_direction(classified.fragment, config.direction)
+    if direction == "aggregate":
+        return _leaf(classified, confidence, "aggregate_no_siblings", _depth)
+    return _zoom_in(classified, confidence, classifier, config, _depth)
+
+
+def classify_reatomize_stream(
+    fragments: list[IngestedFragment],
+    classifier: Classifier,
+    *,
+    config: ReatomizeConfig,
+) -> list[ClassificationTree]:
+    """Batch entry point that supports zoom-out via FEAT-022 aggregation.
+
+    For chat-style inputs (short, low-content fragments) the single-
+    fragment API cannot aggregate — there are no siblings to combine
+    with. This helper accepts the full stream, classifies each member,
+    and when zoom-out is the chosen direction for the weak members,
+    rolls them up via FEAT-022, classifies the parents, and returns
+    trees whose ``children`` are the original (now-classified) leaves.
+
+    When no fragment is weak, every input becomes an ``accepted``
+    single-node tree. When the direction comes back as ``split``, the
+    stream falls through to the single-fragment orchestrator on each
+    input, preserving FEAT-023's zoom-in algorithm verbatim.
+
+    Args:
+        fragments: Stream to classify. The aggregator groups by
+            :class:`creek.models.FragmentSource` key per FEAT-022.
+        classifier: Same callable as :func:`classify_reatomize`.
+        config: Per-run knobs.
+
+    Returns:
+        A list of :class:`ClassificationTree` — one per parent
+        produced (or per pass-through fragment when zoom-out wasn't
+        triggered).
+    """
+    if not fragments:
+        return []
+
+    classified_leaves = [classifier(frag) for frag in fragments]
+    return _route_stream(fragments, classified_leaves, classifier, config)
+
+
+def choose_direction(
+    fragment: Fragment,
+    override: DirectionOverride = "auto",
+) -> Direction:
+    """Pick a re-atomization direction for ``fragment``.
+
+    Honours an explicit ``override`` first, then routes by
+    ``source.platform`` and structural ``level`` per the FEAT-023
+    heuristic:
+
+    - Chat sources (``discord`` / ``claude`` / ``chatgpt``) at a chat-
+      level (``document`` = message, ``exchange``) zoom **out** to
+      stitch sparse context into the level where meaning lives.
+    - Document sources at top levels (``document`` / ``section``) zoom
+      **in**, slicing polyphonic content into focused children.
+    - Finer carved levels (``paragraph`` / ``subsection``) always zoom
+      in — they're already past any aggregation target.
+    - Anything else defaults to ``split``: aggregate without a clear
+      chat-stream signal risks combining unrelated material; ``split``
+      can at worst return no children and become an honest leaf.
+
+    Args:
+        fragment: Fragment whose source + level drive the heuristic.
+        override: ``"auto"`` (use heuristic) or one of
+            ``"split"`` / ``"aggregate"`` to bypass it.
+
+    Returns:
+        ``"split"`` or ``"aggregate"``.
+    """
+    if override != "auto":
+        return override
+
+    # FragmentSource uses ``use_enum_values=True``, so ``platform`` is the
+    # enum's string value at this point — feed it back through the enum
+    # to compare set-membership without leaning on string literals.
+    platform = SourcePlatform(fragment.source.platform)
+    level = fragment.level
+
+    if platform in _CHAT_PLATFORMS and level in {"document", "exchange"}:
+        return "aggregate"
+    if platform in _DOCUMENT_PLATFORMS and level in {"document", "section"}:
+        return "split"
+    if level in {"paragraph", "subsection"}:
+        return "split"
+    return "split"
+
+
+# ---- Internals --------------------------------------------------------------
+
+
+def _leaf(
+    fragment: IngestedFragment,
+    confidence: float,
+    stop_reason: StopReason,
+    depth: int,
+) -> ClassificationTree:
+    """Build a leaf node — exists to keep the ``classify_reatomize`` body terse."""
+    return ClassificationTree(
+        fragment=fragment,
+        confidence=confidence,
+        stop_reason=stop_reason,
+        depth=depth,
+    )
+
+
+def _route_stream(
+    fragments: list[IngestedFragment],
+    classified_leaves: list[tuple[IngestedFragment, float]],
+    classifier: Classifier,
+    config: ReatomizeConfig,
+) -> list[ClassificationTree]:
+    """Pick a stream-handling strategy after the initial pass.
+
+    Factored out of :func:`classify_reatomize_stream` so neither
+    function exceeds the per-function complexity ceiling (Xenon B).
+    """
+    if not config.enabled:
+        return [_leaf(cl, conf, "disabled", 0) for cl, conf in classified_leaves]
+
+    weak = [
+        (cl, conf)
+        for cl, conf in classified_leaves
+        if not _is_accepted(cl.fragment, conf, config.threshold)
+    ]
+    if not weak:
+        return [_leaf(cl, conf, "accepted", 0) for cl, conf in classified_leaves]
+
+    direction = choose_direction(weak[0][0].fragment, config.direction)
+    if direction != "aggregate":
+        return [
+            classify_reatomize(frag, classifier, config=config) for frag in fragments
+        ]
+    return _zoom_out_stream(classified_leaves, classifier, config)
+
+
+def _is_accepted(fragment: Fragment, confidence: float, threshold: float) -> bool:
+    """Return ``True`` when ``fragment`` clears the FEAT-023 accept bar.
+
+    A fragment is accepted iff every required dimension is classified
+    (frequency primary + wavelength phase — the two dimensions the
+    pipeline downstream depends on most) AND the per-fragment score
+    meets ``threshold``. Other dimensions (mode, orientation, dosage)
+    may remain ``unclassified``; they are governed by the LLM's own
+    per-dimension floor (see
+    :attr:`creek.config.LLMConfig.unclassified_threshold`), and forcing
+    them through re-atomization would over-fire.
+    """
+    if confidence < threshold:
+        return False
+    if fragment.frequency.primary == Frequency.UNCLASSIFIED.value:
+        return False
+    return fragment.wavelength.phase != Phase.UNCLASSIFIED.value
+
+
+def _zoom_in(
+    classified: IngestedFragment,
+    confidence: float,
+    classifier: Classifier,
+    config: ReatomizeConfig,
+    depth: int,
+) -> ClassificationTree:
+    """Run the FEAT-021 splitter and recurse on every child."""
+    children = split(classified, sentence_tokenizer=config.sentence_tokenizer)
+    if not children:
+        return _leaf(classified, confidence, "no_decomposition", depth)
+    sub_trees = tuple(
+        classify_reatomize(child, classifier, config=config, _depth=depth + 1)
+        for child in children
+    )
+    return ClassificationTree(
+        fragment=classified,
+        confidence=confidence,
+        stop_reason="split",
+        children=sub_trees,
+        depth=depth,
+    )
+
+
+def _zoom_out_stream(
+    classified_leaves: list[tuple[IngestedFragment, float]],
+    classifier: Classifier,
+    config: ReatomizeConfig,
+) -> list[ClassificationTree]:
+    """Aggregate the stream up one level and classify each parent.
+
+    The aggregator (FEAT-022) is fragment-centric. We strip the bodies,
+    ask it to roll the stream to the next coarser level, and rebuild
+    :class:`IngestedFragment` envelopes whose bodies are the joiner-
+    concatenated child bodies. That keeps the parent classifier-readable
+    without re-implementing FEAT-022's joining rules.
+    """
+    base_level = classified_leaves[0][0].fragment.level
+    target = _AGGREGATE_NEXT_LEVEL.get(base_level)
+    if target is None:
+        return [_leaf(cl, conf, "terminal", 0) for cl, conf in classified_leaves]
+
+    leaf_lookup: dict[str, tuple[IngestedFragment, float]] = {
+        cl.fragment.id: (cl, conf) for cl, conf in classified_leaves
+    }
+    parents = aggregate(
+        [cl.fragment for cl, _ in classified_leaves],
+        level=target,
+        config=config.aggregation_config,
+    )
+    return [
+        _tree_for_parent(parent, target, leaf_lookup, classifier, config)
+        for parent in parents
+    ]
+
+
+def _tree_for_parent(
+    parent: Fragment,
+    target: AggregateLevel,
+    leaf_lookup: dict[str, tuple[IngestedFragment, float]],
+    classifier: Classifier,
+    config: ReatomizeConfig,
+) -> ClassificationTree:
+    """Classify ``parent`` and wrap its leaves as a sub-tree."""
+    if parent.level != target:
+        cl, conf = leaf_lookup[parent.id]
+        return _leaf(cl, conf, "accepted", 0)
+
+    body = config.aggregation_config.joiner.join(
+        leaf_lookup[c_id][0].body for c_id in parent.child_ids
+    )
+    parent_ingested = IngestedFragment(fragment=parent, body=body)
+    classified_parent, parent_conf = classifier(parent_ingested)
+    child_trees = tuple(
+        ClassificationTree(
+            fragment=leaf_lookup[c_id][0],
+            confidence=leaf_lookup[c_id][1],
+            stop_reason="terminal",
+            depth=1,
+        )
+        for c_id in parent.child_ids
+    )
+    stop: StopReason = (
+        "aggregated"
+        if _is_accepted(classified_parent.fragment, parent_conf, config.threshold)
+        else "no_decomposition"
+    )
+    return ClassificationTree(
+        fragment=classified_parent,
+        confidence=parent_conf,
+        stop_reason=stop,
+        children=child_trees,
+    )

--- a/creek-tools/creek/classify/reatomize.py
+++ b/creek-tools/creek/classify/reatomize.py
@@ -61,8 +61,10 @@ StopReason = Literal[
     "disabled",
     "no_decomposition",
     "aggregate_no_siblings",
+    "passthrough",
     "split",
     "aggregated",
+    "aggregated_weak",
 ]
 """Why the orchestrator stopped recursing on a given subtree.
 
@@ -76,12 +78,22 @@ Leaf reasons (``children`` is empty):
 ``no_decomposition``: the chosen operator returned no children.
 ``aggregate_no_siblings``: zoom-out chosen on a lone fragment with no
 siblings; see :func:`classify_reatomize_stream`.
+``passthrough``: a stream member the FEAT-022 aggregator declined to
+combine (wrong level for the target transition) AND that didn't
+clear the threshold on its own — distinct from ``accepted`` so
+downstream gates don't conflate "the orchestrator did nothing" with
+"the classifier was confident".
 
 Internal reasons (``children`` is non-empty):
 
 ``split``: parent was decomposed by the FEAT-021 zoom-in splitter.
 ``aggregated``: parent was assembled by the FEAT-022 zoom-out
-aggregator (only produced by :func:`classify_reatomize_stream`).
+aggregator AND cleared the threshold (only produced by
+:func:`classify_reatomize_stream`).
+``aggregated_weak``: parent was assembled by the aggregator but the
+re-classified parent still failed the threshold. Symmetric with
+``aggregated`` for downstream consumers that want to find the
+"aggregation happened but didn't resolve uncertainty" subset.
 """
 
 Classifier = Callable[[IngestedFragment], tuple[IngestedFragment, float]]
@@ -106,21 +118,6 @@ _CHAT_PLATFORMS: frozenset[SourcePlatform] = frozenset(
 Slack is named in the FEAT-023 spec but is not yet enumerated in
 :class:`SourcePlatform`; it will join this set once added.
 """
-
-_DOCUMENT_PLATFORMS: frozenset[SourcePlatform] = frozenset(
-    {
-        SourcePlatform.DOCUMENT,
-        SourcePlatform.MARKDOWN,
-        SourcePlatform.CODE,
-        SourcePlatform.ESSAY,
-        SourcePlatform.JOURNAL,
-        SourcePlatform.EMAIL,
-        SourcePlatform.SPREADSHEET,
-        SourcePlatform.PRESENTATION,
-        SourcePlatform.IMAGE_OCR,
-    },
-)
-"""Source platforms whose top-level units are long-form documents."""
 
 _TERMINAL_LEVELS: frozenset[FragmentLevel] = frozenset({"sentence", "session"})
 """Levels that resist further re-atomization in either direction."""
@@ -190,6 +187,11 @@ class ReatomizeConfig:
 
     enabled: bool = False
     threshold: float = 0.7
+    # Deliberately not validated with ge=1 (unlike
+    # ``ClassificationConfig.reatomize_max_depth``): the runtime knob
+    # accepts 0 so tests can short-circuit recursion at the root, and
+    # the CLI path projects from ``ClassificationConfig`` which already
+    # enforces the user-facing floor.
     max_depth: int = 4
     direction: DirectionOverride = "auto"
     sentence_tokenizer: SentenceTokenizer = field(
@@ -327,18 +329,14 @@ def choose_direction(
 
     Honours an explicit ``override`` first, then routes by
     ``source.platform`` and structural ``level`` per the FEAT-023
-    heuristic:
-
-    - Chat sources (``discord`` / ``claude`` / ``chatgpt``) at a chat-
-      level (``document`` = message, ``exchange``) zoom **out** to
-      stitch sparse context into the level where meaning lives.
-    - Document sources at top levels (``document`` / ``section``) zoom
-      **in**, slicing polyphonic content into focused children.
-    - Finer carved levels (``paragraph`` / ``subsection``) always zoom
-      in — they're already past any aggregation target.
-    - Anything else defaults to ``split``: aggregate without a clear
-      chat-stream signal risks combining unrelated material; ``split``
-      can at worst return no children and become an honest leaf.
+    heuristic: chat sources (``discord`` / ``claude`` / ``chatgpt``)
+    at a chat-level (``document`` = message, ``exchange``) zoom
+    **out** to stitch sparse context into the level where meaning
+    lives; every other combination — document sources at top levels,
+    finer carved levels at any source, the unknown-platform fallback —
+    zooms **in**. Aggregate without a clear chat-stream signal risks
+    combining unrelated material; ``split`` can at worst return no
+    children and become an honest leaf.
 
     Args:
         fragment: Fragment whose source + level drive the heuristic.
@@ -359,10 +357,11 @@ def choose_direction(
 
     if platform in _CHAT_PLATFORMS and level in {"document", "exchange"}:
         return "aggregate"
-    if platform in _DOCUMENT_PLATFORMS and level in {"document", "section"}:
-        return "split"
-    if level in {"paragraph", "subsection"}:
-        return "split"
+    # Document-source top levels, paragraph/subsection at any source, and
+    # the unknown-platform fallback all default to ``split``. Aggregate
+    # without a clear chat-stream signal risks combining unrelated
+    # material; ``split`` can at worst return no children and become an
+    # honest leaf.
     return "split"
 
 
@@ -406,6 +405,13 @@ def _route_stream(
     if not weak:
         return [_leaf(cl, conf, "accepted", 0) for cl, conf in classified_leaves]
 
+    # Pin the direction off the first weak fragment. The stream API
+    # assumes a homogeneous source (one Discord conversation, one
+    # document corpus) — the FEAT-022 aggregator itself groups by
+    # FragmentSource key, so mixed streams already split cleanly at
+    # that layer. A caller mixing chat + document sources in the same
+    # batch should either segment up-front or invoke
+    # :func:`classify_reatomize` per fragment.
     direction = choose_direction(weak[0][0].fragment, config.direction)
     if direction != "aggregate":
         return [
@@ -498,8 +504,18 @@ def _tree_for_parent(
 ) -> ClassificationTree:
     """Classify ``parent`` and wrap its leaves as a sub-tree."""
     if parent.level != target:
+        # Pass-through: FEAT-022 declined to aggregate this fragment
+        # (wrong source level for the target transition). Distinguish
+        # the "classifier was confident" case from "we did nothing
+        # further" so a downstream gate on ``stop_reason == "accepted"``
+        # doesn't pick up weak fragments by accident.
         cl, conf = leaf_lookup[parent.id]
-        return _leaf(cl, conf, "accepted", 0)
+        reason: StopReason = (
+            "accepted"
+            if _is_accepted(cl.fragment, conf, config.threshold)
+            else "passthrough"
+        )
+        return _leaf(cl, conf, reason, 0)
 
     body = config.aggregation_config.joiner.join(
         leaf_lookup[c_id][0].body for c_id in parent.child_ids
@@ -515,10 +531,13 @@ def _tree_for_parent(
         )
         for c_id in parent.child_ids
     )
+    # Children are non-empty here, so ``no_decomposition`` (defined as
+    # "operator returned no children") would be a lie. Use the dedicated
+    # ``aggregated_weak`` for the unconfident-parent case instead.
     stop: StopReason = (
         "aggregated"
         if _is_accepted(classified_parent.fragment, parent_conf, config.threshold)
-        else "no_decomposition"
+        else "aggregated_weak"
     )
     return ClassificationTree(
         fragment=classified_parent,

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -7,7 +7,7 @@ import os
 import re
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 import typer
 from rich.console import Console
@@ -690,6 +690,7 @@ def redact(
 
 _CLASSIFY_METHODS = ("rules", "llm")
 _LINK_METHODS = ("embeddings", "temporal", "eddies")
+_REATOMIZE_DIRECTIONS = ("auto", "split", "aggregate")
 
 
 @app.command()
@@ -728,6 +729,24 @@ def classify(
             "loud on a regressed prompt or example set."
         ),
     ),
+    reatomize: bool = typer.Option(
+        False,
+        "--reatomize",
+        help=(
+            "Enable FEAT-023 confidence-driven re-atomization for this run "
+            "regardless of the YAML default. Below-threshold or unclassified "
+            "fragments are re-atomized (split or aggregated) and re-classified "
+            "until a leaf clears the threshold or a terminal level is reached."
+        ),
+    ),
+    reatomize_direction: str = typer.Option(
+        "auto",
+        "--reatomize-direction",
+        help=(
+            "Override the FEAT-023 direction heuristic. 'auto' routes by "
+            "source/level; 'split' forces zoom-in; 'aggregate' forces zoom-out."
+        ),
+    ),
 ) -> None:
     """Run classification on existing vault fragments.
 
@@ -760,8 +779,29 @@ def classify(
             f"Supported: {', '.join(_CLASSIFY_METHODS)}.[/red]",
         )
         raise typer.Exit(code=2)
+    if reatomize_direction not in _REATOMIZE_DIRECTIONS:
+        console.print(
+            f"[red]Unknown --reatomize-direction {reatomize_direction!r}. "
+            f"Supported: {', '.join(_REATOMIZE_DIRECTIONS)}.[/red]",
+        )
+        raise typer.Exit(code=2)
 
     config = load_config()
+    if reatomize:
+        # Late-bind the FEAT-023 CLI overrides into the loaded config so
+        # downstream call-sites only ever look at the config object, not
+        # at sticky locals. The `reatomize_direction` here is already
+        # validated against `_REATOMIZE_DIRECTIONS`, so the cast to the
+        # config's `Literal` is sound.
+        config.classification = config.classification.model_copy(
+            update={
+                "reatomize": True,
+                "reatomize_direction": cast(
+                    "Literal['auto', 'split', 'aggregate']",
+                    reatomize_direction,
+                ),
+            },
+        )
     vault_path = _resolve_vault(vault)
 
     from creek.classify.classify_engine import run_classify

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -11,6 +11,7 @@ file — they must come from environment variables.
 
 import logging
 from pathlib import Path
+from typing import Literal
 from zoneinfo import ZoneInfo
 
 import yaml
@@ -132,6 +133,44 @@ class ClassificationConfig(BaseModel):
         default_factory=lambda: ["journal"],
     )
     """Sources that require human review after classification."""
+
+    reatomize: bool = False
+    """Opt-in switch for FEAT-023 confidence-driven re-atomization.
+
+    When ``False`` (default) the classify pipeline behaves exactly as
+    it did before FEAT-023: a single pass over each fragment, no
+    structural decomposition. When ``True``, low-confidence /
+    ``unclassified`` results trigger the zoom-in splitter (FEAT-021) or
+    zoom-out aggregator (FEAT-022), recursing until a leaf reaches the
+    confidence threshold, a terminal level (sentence / session), or
+    :attr:`reatomize_max_depth`.
+    """
+
+    reatomize_threshold: float | None = Field(default=None, ge=0.0, le=1.0)
+    """Confidence floor that triggers re-atomization (FEAT-023).
+
+    ``None`` (default) means "use :attr:`confidence_threshold`" — the
+    same floor that already gates a paid LLM call. Set this lower than
+    the main threshold to keep the rules-vs-LLM gate at one place but
+    only fire re-atomization on truly hopeless fragments.
+    """
+
+    reatomize_max_depth: int = Field(default=4, ge=1)
+    """Hard ceiling on FEAT-023 recursion depth.
+
+    Caps unbounded zoom-in on a fractal document. Counted from the
+    root fragment (depth 0). Once reached, the orchestrator accepts
+    whatever classification it has, even if still ``unclassified``.
+    """
+
+    reatomize_direction: Literal["auto", "split", "aggregate"] = "auto"
+    """FEAT-023 direction-choice override.
+
+    ``"auto"`` (default) routes by ``source.platform`` and ``level``
+    per the heuristic in :mod:`creek.classify.reatomize`. ``"split"``
+    or ``"aggregate"`` force a single direction regardless of source
+    — useful for triage runs over a known-uniform corpus.
+    """
 
 
 class ContextConfig(BaseModel):

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -316,8 +316,14 @@ def test_classify_reatomize_help_lists_flag() -> None:
     """The classify help text advertises the FEAT-023 flags."""
     result = runner.invoke(app, ["classify", "--help"])
     assert result.exit_code == 0
-    assert "--reatomize" in result.output
-    assert "--reatomize-direction" in result.output
+    # Typer's Rich-formatted help inserts ANSI colour escapes between
+    # consecutive characters in option names (so the literal substring
+    # ``--reatomize`` does not appear contiguously when the runner
+    # captures the styled stream — observed on Python 3.12/3.13 CI).
+    # Strip ANSI before asserting.
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    assert "--reatomize" in plain
+    assert "--reatomize-direction" in plain
 
 
 def test_classify_rules_writes_method_to_frontmatter(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -293,6 +293,33 @@ def test_classify_rejects_unknown_method(tmp_path: Path) -> None:
     assert "Unknown method" in result.output
 
 
+def test_classify_rejects_unknown_reatomize_direction(tmp_path: Path) -> None:
+    """An unknown ``--reatomize-direction`` exits with code 2."""
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    result = runner.invoke(
+        app,
+        [
+            "classify",
+            "--vault",
+            str(vault),
+            "--reatomize",
+            "--reatomize-direction",
+            "sideways",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "reatomize-direction" in result.output
+
+
+def test_classify_reatomize_help_lists_flag() -> None:
+    """The classify help text advertises the FEAT-023 flags."""
+    result = runner.invoke(app, ["classify", "--help"])
+    assert result.exit_code == 0
+    assert "--reatomize" in result.output
+    assert "--reatomize-direction" in result.output
+
+
 def test_classify_rules_writes_method_to_frontmatter(tmp_path: Path) -> None:
     """``creek classify --method rules`` stamps the method on each fragment."""
     import frontmatter

--- a/creek-tools/tests/test_config.py
+++ b/creek-tools/tests/test_config.py
@@ -106,6 +106,34 @@ class TestClassificationConfig:
         assert cfg.auto_classify_sources == ["claude", "chatgpt", "discord"]
         assert cfg.human_review_sources == ["journal"]
 
+    def test_reatomize_defaults_match_feat_023_spec(self) -> None:
+        """FEAT-023 knobs default to disabled / inherit / 4 / auto."""
+        cfg = ClassificationConfig()
+        assert cfg.reatomize is False
+        assert cfg.reatomize_threshold is None
+        assert cfg.reatomize_max_depth == 4
+        assert cfg.reatomize_direction == "auto"
+
+    def test_reatomize_threshold_accepts_explicit_float(self) -> None:
+        """An explicit reatomize_threshold survives validation."""
+        cfg = ClassificationConfig(reatomize_threshold=0.5)
+        assert cfg.reatomize_threshold == 0.5
+
+    def test_reatomize_threshold_rejects_out_of_range(self) -> None:
+        """The reatomize_threshold guard rails are [0.0, 1.0]."""
+        with pytest.raises(ValueError, match="reatomize_threshold"):
+            ClassificationConfig(reatomize_threshold=1.5)
+
+    def test_reatomize_max_depth_must_be_positive(self) -> None:
+        """``reatomize_max_depth`` rejects zero/negative values."""
+        with pytest.raises(ValueError, match="reatomize_max_depth"):
+            ClassificationConfig(reatomize_max_depth=0)
+
+    def test_reatomize_direction_rejects_unknown_value(self) -> None:
+        """Only ``auto`` / ``split`` / ``aggregate`` are accepted."""
+        with pytest.raises(ValueError, match="reatomize_direction"):
+            ClassificationConfig(reatomize_direction="sideways")
+
 
 class TestRedactionConfig:
     """Tests for RedactionConfig model."""

--- a/creek-tools/tests/test_reatomize.py
+++ b/creek-tools/tests/test_reatomize.py
@@ -1,0 +1,659 @@
+"""Tests for the FEAT-023 confidence-driven re-atomization orchestrator."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from creek.atomize.aggregate import AggregationConfig
+from creek.classify.reatomize import (
+    ClassificationTree,
+    Classifier,
+    ReatomizeConfig,
+    choose_direction,
+    classify_reatomize,
+    classify_reatomize_stream,
+)
+from creek.config import ClassificationConfig
+from creek.ingest.base import IngestedFragment
+from creek.models import (
+    Authorship,
+    Fragment,
+    FragmentLevel,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Phase,
+    SourcePlatform,
+    WavelengthClassification,
+)
+
+# ---- Helpers ---------------------------------------------------------------
+
+
+def _make_ingested(
+    *,
+    body: str = "",
+    level: FragmentLevel = "document",
+    platform: SourcePlatform = SourcePlatform.MARKDOWN,
+    title: str = "Root doc",
+    frag_id: str = "frag-rootroot0000",
+    minute: int = 0,
+    interlocutor: str | None = None,
+    author: Authorship = Authorship.SELF,
+) -> IngestedFragment:
+    """Construct an :class:`IngestedFragment` for orchestrator tests."""
+    when = datetime(2025, 5, 1, 12, 0, tzinfo=UTC) + timedelta(minutes=minute)
+    fragment = Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(
+            platform=platform,
+            interlocutor=interlocutor,
+            channel="general",
+            conversation_id="conv-1",
+            author=author,
+        ),
+        created=when,
+        level=level,
+    )
+    return IngestedFragment(fragment=fragment, body=body)
+
+
+def _classified(
+    fragment: Fragment,
+    *,
+    frequency: Frequency = Frequency.F5,
+    phase: Phase = Phase.RISING,
+) -> Fragment:
+    """Return a copy of ``fragment`` with the given primary axes set."""
+    return fragment.model_copy(
+        update={
+            "frequency": FrequencyClassification(primary=frequency),
+            "wavelength": WavelengthClassification(phase=phase),
+        },
+    )
+
+
+def _accepting_classifier(confidence: float = 0.95) -> Classifier:
+    """A classifier that always confidently classifies its input."""
+
+    def _classify(ingested: IngestedFragment) -> tuple[IngestedFragment, float]:
+        return (
+            IngestedFragment(
+                fragment=_classified(ingested.fragment),
+                body=ingested.body,
+            ),
+            confidence,
+        )
+
+    return _classify
+
+
+def _rejecting_classifier(confidence: float = 0.2) -> Classifier:
+    """A classifier that returns ``unclassified`` results below threshold."""
+
+    def _classify(ingested: IngestedFragment) -> tuple[IngestedFragment, float]:
+        return ingested, confidence
+
+    return _classify
+
+
+# ---- ReatomizeConfig defaults & projection ---------------------------------
+
+
+class TestReatomizeConfig:
+    """Defaults, factory, and projection from :class:`ClassificationConfig`."""
+
+    def test_defaults_mirror_spec(self) -> None:
+        """Defaults match the FEAT-023 spec (disabled / 0.7 / 4 / auto)."""
+        cfg = ReatomizeConfig()
+        assert cfg.enabled is False
+        assert cfg.threshold == pytest.approx(0.7)
+        assert cfg.max_depth == 4
+        assert cfg.direction == "auto"
+
+    def test_from_classification_config_inherits_confidence_threshold(self) -> None:
+        """A missing reatomize_threshold falls back to confidence_threshold."""
+        cls_cfg = ClassificationConfig(confidence_threshold=0.8, reatomize=True)
+        cfg = ReatomizeConfig.from_classification_config(cls_cfg)
+        assert cfg.threshold == pytest.approx(0.8)
+        assert cfg.enabled is True
+
+    def test_from_classification_config_uses_explicit_reatomize_threshold(
+        self,
+    ) -> None:
+        """An explicit reatomize_threshold overrides confidence_threshold."""
+        cls_cfg = ClassificationConfig(
+            confidence_threshold=0.8,
+            reatomize_threshold=0.4,
+        )
+        cfg = ReatomizeConfig.from_classification_config(cls_cfg)
+        assert cfg.threshold == pytest.approx(0.4)
+
+    def test_from_classification_config_accepts_aggregation_override(self) -> None:
+        """Callers can wire a tuned AggregationConfig for burst runs."""
+        agg = AggregationConfig(burst_similarity_threshold=0.9)
+        cls_cfg = ClassificationConfig()
+        cfg = ReatomizeConfig.from_classification_config(
+            cls_cfg,
+            aggregation_config=agg,
+        )
+        assert cfg.aggregation_config is agg
+
+
+# ---- Direction heuristic ---------------------------------------------------
+
+
+class TestChooseDirection:
+    """The FEAT-023 direction-choice heuristic on (platform, level)."""
+
+    @pytest.mark.parametrize(
+        ("platform", "level", "expected"),
+        [
+            # Chat sources at chat-level: zoom out.
+            (SourcePlatform.DISCORD, "document", "aggregate"),
+            (SourcePlatform.CLAUDE, "document", "aggregate"),
+            (SourcePlatform.CHATGPT, "exchange", "aggregate"),
+            # Document sources at top-level: zoom in.
+            (SourcePlatform.MARKDOWN, "document", "split"),
+            (SourcePlatform.ESSAY, "section", "split"),
+            (SourcePlatform.CODE, "document", "split"),
+            # Finer carved levels → always zoom in.
+            (SourcePlatform.DISCORD, "paragraph", "split"),
+            (SourcePlatform.MARKDOWN, "subsection", "split"),
+            # Unknown platform → conservative zoom in.
+            (SourcePlatform.OTHER, "document", "split"),
+        ],
+    )
+    def test_heuristic_routes_by_platform_and_level(
+        self,
+        platform: SourcePlatform,
+        level: FragmentLevel,
+        expected: str,
+    ) -> None:
+        ingested = _make_ingested(platform=platform, level=level)
+        assert choose_direction(ingested.fragment) == expected
+
+    @pytest.mark.parametrize(
+        ("override", "platform"),
+        [("split", SourcePlatform.DISCORD), ("aggregate", SourcePlatform.MARKDOWN)],
+    )
+    def test_explicit_override_wins(
+        self,
+        override: str,
+        platform: SourcePlatform,
+    ) -> None:
+        """Non-``auto`` overrides bypass the heuristic entirely."""
+        ingested = _make_ingested(platform=platform, level="document")
+        assert choose_direction(ingested.fragment, override) == override  # type: ignore[arg-type]
+
+
+# ---- Disabled path ---------------------------------------------------------
+
+
+class TestDisabled:
+    """When ``enabled=False`` the orchestrator runs a single pass."""
+
+    def test_returns_disabled_leaf(self) -> None:
+        ingested = _make_ingested(body="some body", level="document")
+        tree = classify_reatomize(
+            ingested,
+            _accepting_classifier(),
+            config=ReatomizeConfig(enabled=False),
+        )
+        assert tree.stop_reason == "disabled"
+        assert tree.children == ()
+        assert tree.depth == 0
+
+    def test_disabled_does_not_split_even_when_below_threshold(self) -> None:
+        body = "# H1\n\nfirst para.\n\nsecond para."
+        ingested = _make_ingested(body=body, level="document")
+        tree = classify_reatomize(
+            ingested,
+            _rejecting_classifier(),
+            config=ReatomizeConfig(enabled=False, threshold=0.9),
+        )
+        assert tree.stop_reason == "disabled"
+        assert tree.children == ()
+
+    def test_stream_disabled_returns_per_input_leaves(self) -> None:
+        ingested = [
+            _make_ingested(
+                frag_id="frag-a",
+                body="hi",
+                platform=SourcePlatform.DISCORD,
+            ),
+            _make_ingested(
+                frag_id="frag-b",
+                body="ok",
+                platform=SourcePlatform.DISCORD,
+            ),
+        ]
+        trees = classify_reatomize_stream(
+            ingested,
+            _accepting_classifier(),
+            config=ReatomizeConfig(enabled=False),
+        )
+        assert [t.stop_reason for t in trees] == ["disabled", "disabled"]
+
+
+# ---- Acceptance path -------------------------------------------------------
+
+
+class TestAccepted:
+    """Confidence ≥ threshold and required dimensions set → leaf accepted."""
+
+    def test_accepts_when_classifier_returns_confident(self) -> None:
+        ingested = _make_ingested(body="anything", level="document")
+        tree = classify_reatomize(
+            ingested,
+            _accepting_classifier(0.95),
+            config=ReatomizeConfig(enabled=True, threshold=0.7),
+        )
+        assert tree.stop_reason == "accepted"
+        assert tree.confidence == pytest.approx(0.95)
+        assert tree.children == ()
+
+    def test_rejects_when_required_dimension_unclassified(self) -> None:
+        """Even a high score doesn't accept if frequency.primary is unset."""
+
+        def _classifier(ig: IngestedFragment) -> tuple[IngestedFragment, float]:
+            # High confidence but frequency stays UNCLASSIFIED.
+            return ig, 0.99
+
+        body = "Paragraph one.\n\nParagraph two."
+        ingested = _make_ingested(body=body, level="document")
+        tree = classify_reatomize(
+            ingested,
+            _classifier,
+            config=ReatomizeConfig(enabled=True, threshold=0.7),
+        )
+        assert tree.stop_reason == "split"
+        assert len(tree.children) >= 1
+
+
+# ---- Stopping conditions ---------------------------------------------------
+
+
+class TestTerminalLevels:
+    """Sentence and session are terminal — orchestrator never decomposes them."""
+
+    @pytest.mark.parametrize("level", ["sentence", "session"])
+    def test_terminal_levels_stop(self, level: FragmentLevel) -> None:
+        ingested = _make_ingested(body="x", level=level)
+        tree = classify_reatomize(
+            ingested,
+            _rejecting_classifier(),
+            config=ReatomizeConfig(enabled=True, threshold=0.9),
+        )
+        assert tree.stop_reason == "terminal"
+        assert tree.children == ()
+
+
+class TestMaxDepth:
+    """Recursion stops at the configured ``max_depth``."""
+
+    def test_max_depth_zero_short_circuits_immediately(self) -> None:
+        body = "# H1\n\nfirst.\n\nsecond."
+        ingested = _make_ingested(body=body, level="document")
+        tree = classify_reatomize(
+            ingested,
+            _rejecting_classifier(),
+            config=ReatomizeConfig(enabled=True, threshold=0.9, max_depth=0),
+        )
+        assert tree.stop_reason == "max_depth"
+        assert tree.children == ()
+
+    def test_max_depth_bounds_recursion(self) -> None:
+        """At max_depth=1, root may split but its children must not."""
+        body = "# A\n\npara one.\n\npara two.\n\n# B\n\npara three.\n\npara four."
+        ingested = _make_ingested(body=body, level="document")
+        tree = classify_reatomize(
+            ingested,
+            _rejecting_classifier(),
+            config=ReatomizeConfig(enabled=True, threshold=0.9, max_depth=1),
+        )
+        assert tree.stop_reason == "split"
+        assert tree.children
+        for child in tree.children:
+            assert child.stop_reason in {"max_depth", "no_decomposition", "terminal"}
+            assert child.children == ()
+
+
+class TestNoDecomposition:
+    """A splitter that returns no children produces an honest leaf."""
+
+    def test_paragraph_with_one_sentence_yields_no_decomposition(self) -> None:
+        ingested = _make_ingested(body="Just one sentence.", level="paragraph")
+        tree = classify_reatomize(
+            ingested,
+            _rejecting_classifier(),
+            config=ReatomizeConfig(enabled=True, threshold=0.9),
+        )
+        assert tree.stop_reason == "no_decomposition"
+        assert tree.children == ()
+
+
+class TestAggregateNoSiblings:
+    """Single-fragment API can't aggregate; records that fact and stops."""
+
+    def test_lone_chat_message_records_aggregate_no_siblings(self) -> None:
+        ingested = _make_ingested(
+            body="hi",
+            level="document",
+            platform=SourcePlatform.DISCORD,
+        )
+        tree = classify_reatomize(
+            ingested,
+            _rejecting_classifier(),
+            config=ReatomizeConfig(enabled=True, threshold=0.9),
+        )
+        assert tree.stop_reason == "aggregate_no_siblings"
+        assert tree.children == ()
+
+
+# ---- Zoom-in integration ---------------------------------------------------
+
+
+class TestZoomInIntegration:
+    """Polyphonic document → confidently-classified leaves."""
+
+    @staticmethod
+    def _polyphonic_doc() -> IngestedFragment:
+        body = (
+            "# Section on Power\n\n"
+            "power dominance control conquest force aggression "
+            "bold fearless warrior rage impulsive rebellion\n\n"
+            "# Section on Order\n\n"
+            "order discipline rules duty authority morality "
+            "structure hierarchy obedience law\n"
+        )
+        return _make_ingested(
+            body=body,
+            level="document",
+            platform=SourcePlatform.ESSAY,
+            title="Polyphonic essay",
+        )
+
+    @staticmethod
+    def _mock_section_classifier() -> Classifier:
+        """LLM mock: roots stay unclassified, sections classify by heading."""
+
+        def _classify(ig: IngestedFragment) -> tuple[IngestedFragment, float]:
+            level = ig.fragment.level
+            title = ig.fragment.title.lower()
+            if level == "document":
+                return ig, 0.2
+            if "power" in title:
+                return (
+                    IngestedFragment(
+                        fragment=_classified(
+                            ig.fragment,
+                            frequency=Frequency.F3,
+                            phase=Phase.PEAKING,
+                        ),
+                        body=ig.body,
+                    ),
+                    0.92,
+                )
+            if "order" in title:
+                return (
+                    IngestedFragment(
+                        fragment=_classified(
+                            ig.fragment,
+                            frequency=Frequency.F4,
+                            phase=Phase.WITHDRAWAL,
+                        ),
+                        body=ig.body,
+                    ),
+                    0.88,
+                )
+            return ig, 0.1
+
+        return _classify
+
+    def test_polyphonic_document_yields_classified_leaves(self) -> None:
+        tree = classify_reatomize(
+            self._polyphonic_doc(),
+            self._mock_section_classifier(),
+            config=ReatomizeConfig(enabled=True, threshold=0.7),
+        )
+        assert tree.stop_reason == "split"
+        leaves = _collect_leaves(tree)
+        assert len(leaves) == 2
+        accepted = [leaf for leaf in leaves if leaf.stop_reason == "accepted"]
+        assert len(accepted) == 2
+        primaries = {leaf.fragment.fragment.frequency.primary for leaf in accepted}
+        assert primaries == {Frequency.F3.value, Frequency.F4.value}
+
+    def test_idempotent_reruns_yield_identical_tree(self) -> None:
+        """Acceptance criterion: re-running produces no duplicate children."""
+        classifier = self._mock_section_classifier()
+        cfg = ReatomizeConfig(enabled=True, threshold=0.7)
+        first = classify_reatomize(self._polyphonic_doc(), classifier, config=cfg)
+        second = classify_reatomize(self._polyphonic_doc(), classifier, config=cfg)
+        assert _shape_signature(first) == _shape_signature(second)
+        assert _ids(first) == _ids(second)
+
+
+# ---- Zoom-out integration --------------------------------------------------
+
+
+class TestZoomOutIntegration:
+    """Stream of short chat messages → confidently-classified exchange parents."""
+
+    @staticmethod
+    def _short_chat_messages() -> list[IngestedFragment]:
+        return [
+            _make_ingested(
+                frag_id=f"frag-msg{idx:08}",
+                body=body,
+                title=body,
+                level="document",
+                platform=SourcePlatform.DISCORD,
+                minute=idx,
+                interlocutor="alice",
+                author=Authorship.SELF if idx % 2 == 0 else Authorship.OTHER,
+            )
+            for idx, body in enumerate(["hi", "hey", "ok", "thanks"])
+        ]
+
+    @staticmethod
+    def _aggregating_classifier() -> Classifier:
+        """LLM mock: messages stay unclassified, exchange parents classify."""
+
+        def _classify(ig: IngestedFragment) -> tuple[IngestedFragment, float]:
+            if ig.fragment.level == "exchange":
+                return (
+                    IngestedFragment(
+                        fragment=_classified(
+                            ig.fragment,
+                            frequency=Frequency.F2,
+                            phase=Phase.RESTORATION,
+                        ),
+                        body=ig.body,
+                    ),
+                    0.9,
+                )
+            return ig, 0.2
+
+        return _classify
+
+    def test_stream_zooms_out_into_exchange_parents(self) -> None:
+        trees = classify_reatomize_stream(
+            self._short_chat_messages(),
+            self._aggregating_classifier(),
+            config=ReatomizeConfig(enabled=True, threshold=0.7),
+        )
+        assert len(trees) == 1
+        parent_tree = trees[0]
+        assert parent_tree.stop_reason == "aggregated"
+        assert parent_tree.fragment.fragment.level == "exchange"
+        assert parent_tree.fragment.fragment.frequency.primary == Frequency.F2.value
+        # All four messages live under the single exchange parent.
+        assert len(parent_tree.children) == 4
+
+    def test_stream_idempotent_under_rerun(self) -> None:
+        classifier = self._aggregating_classifier()
+        cfg = ReatomizeConfig(enabled=True, threshold=0.7)
+        first = classify_reatomize_stream(
+            self._short_chat_messages(),
+            classifier,
+            config=cfg,
+        )
+        second = classify_reatomize_stream(
+            self._short_chat_messages(),
+            classifier,
+            config=cfg,
+        )
+        assert [_shape_signature(t) for t in first] == [
+            _shape_signature(t) for t in second
+        ]
+        assert [_ids(t) for t in first] == [_ids(t) for t in second]
+
+    def test_stream_returns_empty_for_empty_input(self) -> None:
+        trees = classify_reatomize_stream(
+            [],
+            _accepting_classifier(),
+            config=ReatomizeConfig(enabled=True),
+        )
+        assert trees == []
+
+    def test_stream_skips_aggregation_when_all_accepted(self) -> None:
+        messages = self._short_chat_messages()
+        trees = classify_reatomize_stream(
+            messages,
+            _accepting_classifier(0.95),
+            config=ReatomizeConfig(enabled=True, threshold=0.7),
+        )
+        assert len(trees) == len(messages)
+        assert all(t.stop_reason == "accepted" for t in trees)
+
+    def test_stream_falls_through_to_split_for_document_sources(self) -> None:
+        """Document-source weak fragments use the single-fragment splitter."""
+        body = "# H1\n\npara one.\n\npara two."
+        docs = [
+            _make_ingested(
+                frag_id="frag-doc-a",
+                body=body,
+                level="document",
+                platform=SourcePlatform.MARKDOWN,
+            ),
+        ]
+        trees = classify_reatomize_stream(
+            docs,
+            _rejecting_classifier(),
+            config=ReatomizeConfig(enabled=True, threshold=0.9),
+        )
+        assert len(trees) == 1
+        assert trees[0].stop_reason == "split"
+
+    def test_stream_aggregator_passthrough_keeps_classified_leaf(self) -> None:
+        """A pass-through fragment from FEAT-022 stays as a single-node leaf.
+
+        Mixing a ``document``-level message with a ``burst``-level fragment
+        forces the aggregator's eligibility partition to emit the burst as
+        pass-through. The orchestrator must recognise that and return its
+        original classification rather than re-classify it as a new parent.
+        """
+
+        def _mixed_classifier(
+            ig: IngestedFragment,
+        ) -> tuple[IngestedFragment, float]:
+            if ig.fragment.level == "exchange":
+                return (
+                    IngestedFragment(
+                        fragment=_classified(
+                            ig.fragment,
+                            frequency=Frequency.F2,
+                            phase=Phase.RISING,
+                        ),
+                        body=ig.body,
+                    ),
+                    0.9,
+                )
+            return ig, 0.2
+
+        mixed = [
+            _make_ingested(
+                frag_id="frag-msg00000001",
+                body="hi",
+                level="document",
+                platform=SourcePlatform.DISCORD,
+                minute=0,
+            ),
+            _make_ingested(
+                frag_id="frag-burst00001",
+                body="burst body",
+                level="burst",
+                platform=SourcePlatform.DISCORD,
+                minute=5,
+            ),
+        ]
+        trees = classify_reatomize_stream(
+            mixed,
+            _mixed_classifier,
+            config=ReatomizeConfig(
+                enabled=True,
+                threshold=0.7,
+                direction="aggregate",
+            ),
+        )
+        # The aggregator emits one exchange parent and one burst pass-through.
+        stops = {t.stop_reason for t in trees}
+        assert "aggregated" in stops
+        assert "accepted" in stops  # the pass-through leaf
+
+    def test_stream_returns_terminal_when_base_level_is_session(self) -> None:
+        """A stream already at the terminal level can't aggregate further."""
+        sessions = [
+            _make_ingested(
+                frag_id=f"frag-sess{idx:08}",
+                body="x",
+                level="session",
+                platform=SourcePlatform.DISCORD,
+                minute=idx,
+            )
+            for idx in range(2)
+        ]
+        # Force aggregate direction so the stream takes the zoom-out branch.
+        trees = classify_reatomize_stream(
+            sessions,
+            _rejecting_classifier(),
+            config=ReatomizeConfig(
+                enabled=True,
+                threshold=0.9,
+                direction="aggregate",
+            ),
+        )
+        # Sessions hit the terminal guard in the zoom-out branch.
+        assert all(t.stop_reason == "terminal" for t in trees)
+
+
+# ---- Walk helpers ----------------------------------------------------------
+
+
+def _collect_leaves(tree: ClassificationTree) -> list[ClassificationTree]:
+    if not tree.children:
+        return [tree]
+    leaves: list[ClassificationTree] = []
+    for child in tree.children:
+        leaves.extend(_collect_leaves(child))
+    return leaves
+
+
+def _shape_signature(tree: ClassificationTree) -> tuple[object, ...]:
+    return (
+        tree.fragment.fragment.id,
+        tree.stop_reason,
+        tuple(_shape_signature(c) for c in tree.children),
+    )
+
+
+def _ids(tree: ClassificationTree) -> list[str]:
+    out = [tree.fragment.fragment.id]
+    for child in tree.children:
+        out.extend(_ids(child))
+    return out

--- a/creek-tools/tests/test_reatomize.py
+++ b/creek-tools/tests/test_reatomize.py
@@ -550,13 +550,14 @@ class TestZoomOutIntegration:
         assert len(trees) == 1
         assert trees[0].stop_reason == "split"
 
-    def test_stream_aggregator_passthrough_keeps_classified_leaf(self) -> None:
-        """A pass-through fragment from FEAT-022 stays as a single-node leaf.
+    def test_stream_passthrough_weak_fragment_marked_passthrough(self) -> None:
+        """A weak pass-through fragment is labeled ``passthrough``, not ``accepted``.
 
         Mixing a ``document``-level message with a ``burst``-level fragment
         forces the aggregator's eligibility partition to emit the burst as
-        pass-through. The orchestrator must recognise that and return its
-        original classification rather than re-classify it as a new parent.
+        pass-through. When that pass-through fragment failed the threshold
+        on its own, ``stop_reason`` must NOT be ``accepted`` — downstream
+        consumers gate dashboards and export queues on that field.
         """
 
         def _mixed_classifier(
@@ -604,7 +605,109 @@ class TestZoomOutIntegration:
         # The aggregator emits one exchange parent and one burst pass-through.
         stops = {t.stop_reason for t in trees}
         assert "aggregated" in stops
-        assert "accepted" in stops  # the pass-through leaf
+        # The weak burst pass-through must be flagged honestly, NOT "accepted":
+        # confidence was 0.2 against a threshold of 0.7.
+        assert "passthrough" in stops
+        assert "accepted" not in stops
+
+    def test_stream_passthrough_strong_fragment_marked_accepted(self) -> None:
+        """A pass-through fragment that *does* pass the threshold stays ``accepted``."""
+
+        def _strong_passthrough_classifier(
+            ig: IngestedFragment,
+        ) -> tuple[IngestedFragment, float]:
+            if ig.fragment.level == "exchange":
+                return (
+                    IngestedFragment(
+                        fragment=_classified(
+                            ig.fragment,
+                            frequency=Frequency.F2,
+                            phase=Phase.RISING,
+                        ),
+                        body=ig.body,
+                    ),
+                    0.9,
+                )
+            if ig.fragment.level == "burst":
+                # Confident pass-through — must keep its "accepted" label.
+                return (
+                    IngestedFragment(
+                        fragment=_classified(
+                            ig.fragment,
+                            frequency=Frequency.F5,
+                            phase=Phase.PEAKING,
+                        ),
+                        body=ig.body,
+                    ),
+                    0.95,
+                )
+            # The document-level message stays weak so aggregation fires.
+            return ig, 0.2
+
+        mixed = [
+            _make_ingested(
+                frag_id="frag-msg00000002",
+                body="hi",
+                level="document",
+                platform=SourcePlatform.DISCORD,
+                minute=0,
+            ),
+            _make_ingested(
+                frag_id="frag-burst00002",
+                body="burst body",
+                level="burst",
+                platform=SourcePlatform.DISCORD,
+                minute=5,
+            ),
+        ]
+        trees = classify_reatomize_stream(
+            mixed,
+            _strong_passthrough_classifier,
+            config=ReatomizeConfig(
+                enabled=True,
+                threshold=0.7,
+                direction="aggregate",
+            ),
+        )
+        stops = {t.stop_reason for t in trees}
+        assert "aggregated" in stops
+        assert "accepted" in stops  # confident pass-through keeps "accepted"
+        assert "passthrough" not in stops  # confident burst is NOT a weak passthrough
+
+    def test_stream_aggregated_weak_parent_marked_aggregated_weak(self) -> None:
+        """An aggregated parent that still fails the threshold gets ``aggregated_weak``.
+
+        ``no_decomposition`` is reserved for "operator returned no children";
+        a parent with non-empty children must not borrow that label.
+        """
+
+        def _weak_parent_classifier(
+            _ig: IngestedFragment,
+        ) -> tuple[IngestedFragment, float]:
+            # Every fragment — leaf or aggregated parent — scores below threshold.
+            return _ig, 0.2
+
+        messages = [
+            _make_ingested(
+                frag_id=f"frag-weak{idx:08}",
+                body=body,
+                title=body,
+                level="document",
+                platform=SourcePlatform.DISCORD,
+                minute=idx,
+            )
+            for idx, body in enumerate(["a", "b", "c"])
+        ]
+        trees = classify_reatomize_stream(
+            messages,
+            _weak_parent_classifier,
+            config=ReatomizeConfig(enabled=True, threshold=0.7),
+        )
+        assert len(trees) == 1
+        parent = trees[0]
+        # Children were produced, so "no_decomposition" would be a lie.
+        assert parent.children
+        assert parent.stop_reason == "aggregated_weak"
 
     def test_stream_returns_terminal_when_base_level_is_session(self) -> None:
         """A stream already at the terminal level can't aggregate further."""


### PR DESCRIPTION
Closes #254.

## Summary

Adds `creek/classify/reatomize.py`, the orchestrator that closes the loop opened by FEAT-020 / FEAT-021 / FEAT-022: when a classifier returns `unclassified` or scores below the configured confidence floor, the orchestrator chooses a direction by source + level, re-atomizes (split or aggregate), classifies the new units, and recurses until a leaf clears the threshold or hits a terminal level (sentence / session) or the `reatomize_max_depth` ceiling.

- `classify_reatomize(fragment, classifier, *, config) -> ClassificationTree` — the spec single-fragment API; handles zoom-in fully and records `aggregate_no_siblings` when zoom-out is chosen on a lone fragment.
- `classify_reatomize_stream(fragments, classifier, *, config) -> list[ClassificationTree]` — batch entry point that rolls a stream of weak chat messages up via FEAT-022 and re-classifies the aggregated parents (needed for the zoom-out integration test).
- `choose_direction(fragment, override)` — the heuristic, exposed so the CLI's `--reatomize-direction` composes with it.
- `ClassificationConfig` grows four FEAT-023 knobs (`reatomize`, `reatomize_threshold`, `reatomize_max_depth`, `reatomize_direction`); defaults preserve flat behaviour.
- `creek classify --reatomize` / `--reatomize-direction {auto,split,aggregate}` overrides at the CLI.

Pure transform: the orchestrator returns a `ClassificationTree` and never touches disk; callers walk the tree to persist nodes. That separation keeps the unit tests fast and the persistence concern reusable.

## Acceptance criteria — verified

- [x] **Flat behaviour preserved when `reatomize: false` (default)** — `ClassificationConfig.reatomize` defaults to `False`; `TestDisabled` exercises the short-circuit on both the single-fragment and stream APIs.
- [x] **Re-atomization occurs on `unclassified` / below-threshold results when enabled** — `TestAccepted.test_rejects_when_required_dimension_unclassified` plus both integration tests.
- [x] **Recursion stops at sentence and session levels** — `TestTerminalLevels.test_terminal_levels_stop` (parametrized on both terminal levels).
- [x] **Recursion stops at `reatomize_max_depth`** — `TestMaxDepth.test_max_depth_zero_short_circuits_immediately` and `test_max_depth_bounds_recursion`.
- [x] **Idempotent re-runs** — `TestZoomInIntegration.test_idempotent_reruns_yield_identical_tree` and `TestZoomOutIntegration.test_stream_idempotent_under_rerun` compare shape signatures and ID sequences across two runs on byte-identical inputs.
- [x] **Integration test (zoom-in)** — `TestZoomInIntegration.test_polyphonic_document_yields_classified_leaves` synthesises a two-section essay; the mocked LLM rejects the document but classifies each section, producing two confidently-classified leaves at F3 / F4.
- [x] **Integration test (zoom-out)** — `TestZoomOutIntegration.test_stream_zooms_out_into_exchange_parents` synthesises a stream of four short chat messages; the mocked LLM rejects each message but classifies the aggregated exchange parent at F2 / RESTORATION.
- [x] **Direction heuristic exercised with chat AND document sources** — `TestChooseDirection.test_heuristic_routes_by_platform_and_level` covers Discord / Claude / ChatGPT alongside Markdown / Essay / Code, plus the `OTHER` fallback and explicit overrides.
- [x] **≥90 % branch coverage** — `creek/classify/reatomize.py` lands at 98.69 % per-file; project aggregate stays at 93.54 %.
- [x] **MyPy strict, Ruff zero violations** — `./scripts/check-all.sh` exits 0 (all 12 gates green: lint, format, types, pylint, security, complexity, refurb, tryceratops, tests, coverage, per-file coverage, state-budget).

## Stay Green

`./scripts/check-all.sh` exits 0 locally — 3695 tests passed, 93.54 % branch coverage.

## Test plan

- [ ] CI: all gates green on push.
- [ ] Verify acceptance-criteria checkboxes above against the merged tests.

https://claude.ai/code/session_01WyqehJoUzUXNyg4Uk5V1tK

---
_Generated by [Claude Code](https://claude.ai/code/session_01WyqehJoUzUXNyg4Uk5V1tK)_