### PR TITLE
docs(skills): add observed_phase to save.SKILL.md YAML schema (#207)

### DIFF
--- a/creek-tools/creek/templates/skills/save.SKILL.md
+++ b/creek-tools/creek/templates/skills/save.SKILL.md
@@ -66,6 +66,7 @@ wavelength:
   mode: inhabit | express | collaborate | integrate | absorb
   orientation: do | feel | do_feel
   dosage: medicine | toxic
+  observed_phase: rising | peaking | withdrawal | diminishing | bottoming_out | restoration  # optional; written when source conversation contradicts inherited phase
 frequency:
   primary: F1 | F2 | F3 | F4 | F5 | F6 | F7 | F8 | F9 | F10 | unclassified
   secondary: []


### PR DESCRIPTION
## Summary

Implements item 1 of #207 — adds the `wavelength.observed_phase` field to the YAML schema example inside `save.SKILL.md`, mirroring the field already present in `compile.SKILL.md`. Without this, a future implementer reading only the schema block (not the prose two paragraphs below it) would miss the dual-phase convention.

```diff
 wavelength:
   phase: rising | peaking | withdrawal | diminishing | bottoming_out | restoration
   mode: inhabit | express | collaborate | integrate | absorb
   orientation: do | feel | do_feel
   dosage: medicine | toxic
+  observed_phase: rising | peaking | withdrawal | diminishing | bottoming_out | restoration  # optional; written when source conversation contradicts inherited phase
 frequency:
```

## Items 2 & 3 are obsolete

Items 2 (stale `.gitignore` line-52 comment) and 3 (explicit `!00-Creek-Meta/Scripts/` whitelist) were obsoleted by FEAT-019 (PR #229), which restructured the repository two days after this issue was filed:

- `00-Creek-Meta/` at the repo root no longer exists.
- The schema-skill tree is now a template under `creek-tools/creek/templates/skills/` that `creek init --vault <path>` deploys into a user-chosen vault.
- `.gitignore` was completely rewritten; the line-52 comment and the `!00-Creek-Meta/Skills/` whitelist patterns the issue references no longer exist. The current file simply ignores `/00-Creek-Meta/` (and the other vault topology folders) at the repo root in case a user accidentally creates them — there's no symmetric `Scripts/` whitelist to add because nothing in `00-Creek-Meta/` is tracked at the repo root anymore.

So items 2 and 3 should be closed as obsolete; item 1 is the only still-actionable nit.

## Test plan

- [x] Diff is a single-line addition inside the YAML schema block, matching the format and inline-comment convention used in `compile.SKILL.md`.
- [x] `uv run pre-commit run --files creek/templates/skills/save.SKILL.md` → all hooks pass (trailing-whitespace, EOF, line-ending, mixed-line-ending, detect-secrets).
- [x] `tests/test_vault_sovereignty.py::test_canonical_skill_files_are_present` continues to pass — it asserts file presence by name only, not content.
- [x] No code paths reference `observed_phase` in YAML parsing today (it's an optional documentation contract for future `creek compile`/`creek save` implementations).

Closes #207

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fd2TP1ppTUgFV8GZQB9ZtW)_