### PR TITLE
refactor(ingest): caller-controllable spreadsheet header detection (#165)

### DIFF
--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -104,8 +104,24 @@ class SpreadsheetBackend(Protocol):
     def is_available(self) -> bool:
         """Return ``True`` when the backend can perform reads right now."""
 
-    def read_workbook(self, path: Path) -> WorkbookData:
-        """Read *path* and return its decomposed :class:`WorkbookData`."""
+    def read_workbook(
+        self,
+        path: Path,
+        *,
+        has_header: bool | None = None,
+    ) -> WorkbookData:
+        """Read *path* and return its decomposed :class:`WorkbookData`.
+
+        ``has_header`` lets callers override the per-sheet header
+        auto-detection heuristic (#165):
+
+        * ``None`` (default) — auto-detect: a row qualifies as headers
+          only when every cell is a non-empty string.
+        * ``True`` — always treat the first row of every sheet as a
+          header row, regardless of content.
+        * ``False`` — never treat the first row as a header; render
+          ``col1..colN`` placeholders instead.
+        """
 
 
 class OpenpyxlUnavailableError(RuntimeError):
@@ -133,11 +149,20 @@ class OpenpyxlBackend:
             return False
         return True
 
-    def read_workbook(self, path: Path) -> WorkbookData:
+    def read_workbook(
+        self,
+        path: Path,
+        *,
+        has_header: bool | None = None,
+    ) -> WorkbookData:
         """Read *path* and return a :class:`WorkbookData`.
 
         Args:
             path: Filesystem path to a ``.xlsx`` or ``.csv`` file.
+            has_header: Per-call override for header auto-detection
+                (#165). ``None`` keeps the heuristic, ``True`` forces
+                the first row to be a header, ``False`` forces it to
+                be data.
 
         Returns:
             A :class:`WorkbookData` with one or more
@@ -149,11 +174,11 @@ class OpenpyxlBackend:
         """
         suffix = path.suffix.lower()
         if suffix == ".csv":
-            return _read_csv(path)
-        return self._read_xlsx(path)
+            return _read_csv(path, has_header=has_header)
+        return self._read_xlsx(path, has_header=has_header)
 
     @staticmethod
-    def _read_xlsx(path: Path) -> WorkbookData:
+    def _read_xlsx(path: Path, *, has_header: bool | None = None) -> WorkbookData:
         """Read an XLSX file via ``openpyxl``."""
         try:
             import openpyxl
@@ -172,7 +197,7 @@ class OpenpyxlBackend:
                 tuple(_cell_to_str(cell) for cell in row)
                 for row in worksheet.iter_rows(values_only=True)
             ]
-            sheets.append(_split_header(name, raw_rows))
+            sheets.append(_split_header(name, raw_rows, has_header=has_header))
         workbook.close()
         return WorkbookData(sheets=tuple(sheets))
 
@@ -194,7 +219,7 @@ user knows the result may be mojibake.
 """
 
 
-def _read_csv(path: Path) -> WorkbookData:
+def _read_csv(path: Path, *, has_header: bool | None = None) -> WorkbookData:
     """Read a CSV file as a single-sheet workbook.
 
     Probe order:
@@ -207,6 +232,9 @@ def _read_csv(path: Path) -> WorkbookData:
        sequence. Emits a ``WARNING`` log including the file path so
        the user has a chance to spot mojibake before it lands in the
        vault (BUG-010).
+
+    ``has_header`` is threaded into :func:`_split_header` so callers
+    can override per-call header auto-detection (#165).
     """
     raw = path.read_bytes()
     try:
@@ -214,7 +242,7 @@ def _read_csv(path: Path) -> WorkbookData:
     except UnicodeDecodeError:
         pass
     else:
-        return _csv_text_to_workbook(path, text)
+        return _csv_text_to_workbook(path, text, has_header=has_header)
 
     detection = chardet.detect(raw)
     detected = detection.get("encoding")
@@ -229,7 +257,7 @@ def _read_csv(path: Path) -> WorkbookData:
         except (UnicodeDecodeError, LookupError):
             pass
         else:
-            return _csv_text_to_workbook(path, text)
+            return _csv_text_to_workbook(path, text, has_header=has_header)
 
     text = raw.decode("cp1252")
     logger.warning(
@@ -239,28 +267,47 @@ def _read_csv(path: Path) -> WorkbookData:
         detected or "unknown",
         confidence,
     )
-    return _csv_text_to_workbook(path, text)
+    return _csv_text_to_workbook(path, text, has_header=has_header)
 
 
-def _csv_text_to_workbook(path: Path, text: str) -> WorkbookData:
+def _csv_text_to_workbook(
+    path: Path,
+    text: str,
+    *,
+    has_header: bool | None = None,
+) -> WorkbookData:
     """Parse decoded CSV ``text`` into a single-sheet :class:`WorkbookData`."""
     rows = [tuple(row) for row in csv.reader(text.splitlines())]
-    return WorkbookData(sheets=(_split_header(path.stem, rows),))
+    return WorkbookData(
+        sheets=(_split_header(path.stem, rows, has_header=has_header),),
+    )
 
 
 def _split_header(
     name: str,
     rows: list[tuple[str, ...]],
+    *,
+    has_header: bool | None = None,
 ) -> SheetData:
     """Split *rows* into ``(headers, data_rows)``.
 
-    Auto-detects a header row: the first row qualifies when every
-    cell is a non-empty string. Otherwise the first row is treated
-    as data and ``headers`` is ``None``.
+    Header-row selection follows ``has_header`` (#165):
+
+    * ``None`` (default) auto-detects via the heuristic — the first
+      row qualifies when every cell is a non-empty string.
+    * ``True`` always treats the first row as headers, regardless of
+      content. An empty sheet (``rows == []``) still yields no
+      headers since there is no first row to promote.
+    * ``False`` never treats the first row as headers; the rendered
+      table will use auto-generated ``colN`` placeholders.
     """
     if not rows:
         return SheetData(name=name, headers=None, rows=())
     first = rows[0]
+    if has_header is False:
+        return SheetData(name=name, headers=None, rows=tuple(rows))
+    if has_header is True:
+        return SheetData(name=name, headers=first, rows=tuple(rows[1:]))
     if first and all(cell.strip() for cell in first):
         return SheetData(
             name=name,
@@ -312,9 +359,21 @@ class SpreadsheetIngestor(Ingestor):
             for path in paths
         ]
 
-    def parse(self, raw: RawDocument) -> list[ParsedFragment]:
-        """Read the workbook and emit one fragment per non-empty sheet."""
-        workbook = self.backend.read_workbook(raw.path)
+    def parse(
+        self,
+        raw: RawDocument,
+        *,
+        has_header: bool | None = None,
+    ) -> list[ParsedFragment]:
+        """Read the workbook and emit one fragment per non-empty sheet.
+
+        ``has_header`` lets callers override per-document header
+        auto-detection (#165). The default ``None`` preserves the
+        heuristic; ``True`` / ``False`` force the first row to be
+        treated as headers / data respectively, in every sheet of the
+        workbook.
+        """
+        workbook = self.backend.read_workbook(raw.path, has_header=has_header)
         timestamp = file_modified_time(raw.path)
         fragments: list[ParsedFragment] = []
         for sheet in workbook.sheets:

--- a/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
+++ b/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
@@ -45,8 +45,19 @@ class StubSpreadsheetBackend:
         """Stubs are always available."""
         return True
 
-    def read_workbook(self, path: Path) -> WorkbookData:
-        """Return the canned workbook for *path*."""
+    def read_workbook(
+        self,
+        path: Path,
+        *,
+        has_header: bool | None = None,
+    ) -> WorkbookData:
+        """Return the canned workbook for *path*.
+
+        ``has_header`` is accepted for Protocol compatibility (#165)
+        but ignored — canned ``WorkbookData`` already has its
+        ``SheetData.headers`` baked in by each test.
+        """
+        del has_header
         self.calls.append(f"read_workbook:{path.name}")
         return self._workbooks[path.name]
 
@@ -533,6 +544,184 @@ class TestCsvFiles:
             "decoded as cp1252" in record.message and "ascii.csv" in record.message
             for record in caplog.records
         )
+
+
+# ---- has_header override (#165) ---------------------------------------
+
+
+class TestHasHeaderOverride:
+    """Caller-controllable header detection (#165).
+
+    The legacy heuristic — "first row qualifies as headers when every
+    cell is a non-empty string" — produces false positives on data
+    sheets whose first row happens to be all-strings (country names,
+    labels, etc.). Three modes:
+
+    * ``has_header=None`` (default) preserves the heuristic.
+    * ``has_header=True``  forces the first row to be headers.
+    * ``has_header=False`` forces the first row to be data and the
+      sheet's headers to be auto-generated ``colN`` placeholders at
+      render time.
+    """
+
+    def test_csv_heuristic_promotes_all_string_first_row(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Default ``has_header=None`` still auto-detects (heuristic intact).
+
+        This pins today's behaviour: a CSV whose first row is all
+        non-empty strings is treated as a header row. The next test
+        shows why this is sometimes wrong; together they describe the
+        bug the override fixes.
+        """
+        csv_path = tmp_path / "countries.csv"
+        _write_csv(
+            csv_path, [["France", "Germany", "Spain"], ["Italy", "Greece", "Portugal"]]
+        )
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        # The heuristic promotes the first row, so "France" lands in headers.
+        assert fragments[0].metadata["headers"] == ["France", "Germany", "Spain"]
+        assert fragments[0].metadata["row_data"] == [
+            ["Italy", "Greece", "Portugal"],
+        ]
+
+    def test_csv_has_header_false_keeps_first_row_as_data(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``has_header=False`` overrides the heuristic for the false-positive case.
+
+        Same all-string-first-row sheet as above, but now the caller
+        knows it's data — the first row stays in ``row_data`` and the
+        rendered table uses generated ``col1..colN`` headers.
+        """
+        csv_path = tmp_path / "countries.csv"
+        _write_csv(
+            csv_path, [["France", "Germany", "Spain"], ["Italy", "Greece", "Portugal"]]
+        )
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        raws = ingestor.discover(tmp_path)
+        fragments = ingestor.parse(raws[0], has_header=False)
+        assert fragments[0].metadata["headers"] == []
+        assert fragments[0].metadata["row_data"] == [
+            ["France", "Germany", "Spain"],
+            ["Italy", "Greece", "Portugal"],
+        ]
+        markdown = ingestor.convert_to_markdown(fragments[0])
+        assert "| col1 | col2 | col3 |" in markdown
+        assert "| France | Germany | Spain |" in markdown
+
+    def test_csv_has_header_true_forces_first_row_as_header(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``has_header=True`` forces a header even when the heuristic would reject it.
+
+        Empty cells in the first row normally disqualify it; with the
+        override, it is still promoted to headers.
+        """
+        csv_path = tmp_path / "blank_cells.csv"
+        # First row has an empty cell — the heuristic would treat all
+        # rows as data. The override forces a header anyway.
+        _write_csv(csv_path, [["name", "", "city"], ["Alice", "30", "NYC"]])
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        raws = ingestor.discover(tmp_path)
+        fragments = ingestor.parse(raws[0], has_header=True)
+        assert fragments[0].metadata["headers"] == ["name", "", "city"]
+        assert fragments[0].metadata["row_data"] == [["Alice", "30", "NYC"]]
+
+    def test_csv_has_header_none_matches_default_call(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``has_header=None`` explicit is identical to omitting the kwarg."""
+        csv_path = tmp_path / "rows.csv"
+        _write_csv(csv_path, [["a", "b"], ["1", "2"]])
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        raws = ingestor.discover(tmp_path)
+        default = ingestor.parse(raws[0])
+        explicit_none = ingestor.parse(raws[0], has_header=None)
+        assert default[0].metadata["headers"] == explicit_none[0].metadata["headers"]
+        assert default[0].metadata["row_data"] == explicit_none[0].metadata["row_data"]
+
+    def test_stub_backend_receives_has_header(self, tmp_path: Path) -> None:
+        """``has_header`` propagates from ingestor.parse to backend.read_workbook.
+
+        The stub records every call's ``has_header`` value so we can
+        prove the override travels through the ingestor instead of
+        being silently dropped on the floor.
+        """
+
+        class RecordingBackend:
+            """Stub backend that records the has_header it was called with."""
+
+            def __init__(self) -> None:
+                """Initialise an empty call-log."""
+                self.received: list[bool | None] = []
+
+            def is_available(self) -> bool:
+                """Test backend is always available."""
+                return True
+
+            def read_workbook(
+                self,
+                path: Path,
+                *,
+                has_header: bool | None = None,
+            ) -> WorkbookData:
+                """Record ``has_header`` and return a canned workbook."""
+                self.received.append(has_header)
+                return WorkbookData(
+                    sheets=(
+                        SheetData(
+                            name=path.stem,
+                            headers=("h1", "h2") if has_header else None,
+                            rows=(("v1", "v2"),),
+                        ),
+                    ),
+                )
+
+        path = tmp_path / "data.xlsx"
+        _write_xlsx_placeholder(path)
+        backend = RecordingBackend()
+        ingestor = SpreadsheetIngestor(backend=backend)
+        raws = ingestor.discover(tmp_path)
+        ingestor.parse(raws[0], has_header=True)
+        ingestor.parse(raws[0], has_header=False)
+        ingestor.parse(raws[0])
+        assert backend.received == [True, False, None]
+
+    def test_xlsx_has_header_false_keeps_first_row_as_data(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``has_header=False`` flows through the XLSX path as well as CSV.
+
+        Real workbook (via openpyxl) so the override is exercised end
+        to end on both spreadsheet formats. Without the override, the
+        all-string first row would be promoted to headers by the
+        heuristic.
+        """
+        import openpyxl
+
+        path = tmp_path / "labels.xlsx"
+        workbook = openpyxl.Workbook()
+        worksheet = workbook.active
+        assert worksheet is not None
+        worksheet.append(["France", "Germany", "Spain"])
+        worksheet.append(["Italy", "Greece", "Portugal"])
+        workbook.save(path)
+
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        raws = ingestor.discover(tmp_path)
+        fragments = ingestor.parse(raws[0], has_header=False)
+        assert fragments[0].metadata["headers"] == []
+        assert fragments[0].metadata["row_data"] == [
+            ["France", "Germany", "Spain"],
+            ["Italy", "Greece", "Portugal"],
+        ]
 
 
 # ---- OpenpyxlBackend lazy-import ---------------------------------------


### PR DESCRIPTION
## Summary

`creek/ingest/spreadsheets.py::_split_header` auto-detects a header row by checking that every cell in the first row is a non-empty string. This false-positives on data sheets whose first row is all-strings (country names, labels, etc.) — flagged in both claude-reviews on PR #164.

This PR adds an opt-in `has_header: bool | None = None` keyword argument threaded from `SpreadsheetIngestor.parse()` through the `SpreadsheetBackend.read_workbook()` Protocol into `_split_header`:

- `None` (default) — heuristic intact, no behaviour change.
- `True` — first row is always treated as headers, regardless of content.
- `False` — first row is always data; rendering uses generated `col1..colN` placeholders.

The `SpreadsheetBackend` Protocol gains the new kwarg, and `OpenpyxlBackend` plus the test `StubSpreadsheetBackend` are updated to match. The override flows through both the CSV and XLSX paths.

## Test plan

- [x] `./scripts/check-all.sh` passes (lint, format, mypy strict, pylint, bandit, complexity, refurb, tryceratops, 3,656 tests, 93.59% coverage, per-file coverage gate).
- [x] New `TestHasHeaderOverride` covers six paths:
  - default heuristic still promotes an all-string first row (pins legacy behaviour)
  - `has_header=False` keeps an all-string first row as data, renders `colN` placeholders
  - `has_header=True` forces a header even when the heuristic would reject (empty cell)
  - `has_header=None` matches the no-kwarg default exactly
  - `has_header` propagates from `parse()` → `backend.read_workbook()` via a recording stub
  - XLSX end-to-end via a real openpyxl workbook

Closes #165.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuPZp5dHyJdjPrvtVbQw7K)_