### PR TITLE
fix(compile): tolerate fenced JSON and preambles from Anthropic (INC-007)

### DIFF
--- a/creek-tools/creek/compile/engine.py
+++ b/creek-tools/creek/compile/engine.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
@@ -262,6 +263,7 @@ def _build_prompt(
         "Return JSON with two arrays: 'claims' (each having 'id', 'text', "
         "'fragment_ids') and 'paradoxes' (each having 'description', "
         "'fragment_ids'). Never flatten contradictions into a claim.",
+        "Respond with raw JSON only. No prose, no preamble, no Markdown code fences.",
         "",
         "Source fragments:",
     ]
@@ -277,13 +279,83 @@ def _build_prompt(
     return "\n".join(sections)
 
 
+_JSON_FENCE_RE = re.compile(
+    r"```(?:json|JSON)?[ \t]*\r?\n?(.*?)\r?\n?[ \t]*```",
+    re.DOTALL,
+)
+"""First fenced code block in a Markdown-ish response (group 1 = inner text).
+
+Tolerates an optional ``json`` language tag and surrounding whitespace.
+Non-greedy so it stops at the first closing fence even when the LLM
+emits multiple blocks.
+"""
+
+
+def _strip_fenced_block(raw: str) -> str | None:
+    """Return the first fenced code block's inner text, or ``None`` if absent."""
+    match = _JSON_FENCE_RE.search(raw)
+    if match is None:
+        return None
+    return match.group(1).strip()
+
+
+def _extract_first_json_object(raw: str) -> str | None:
+    """Return the substring of the first balanced JSON object in *raw*.
+
+    Uses :class:`json.JSONDecoder.raw_decode` from the first ``{``, so
+    nested braces and braces inside JSON strings don't confuse the
+    scan. Returns ``None`` if no opener is present or if the decoder
+    cannot consume a complete object from that point.
+    """
+    start = raw.find("{")
+    if start == -1:
+        return None
+    try:
+        _, end = json.JSONDecoder().raw_decode(raw, start)
+    except json.JSONDecodeError:
+        return None
+    return raw[start:end]
+
+
+def _json_candidates(raw: str) -> list[str]:
+    """Build an ordered list of JSON decoding candidates from *raw*.
+
+    The raw response comes first (the happy path: a well-behaved LLM
+    returned bare JSON), then a fenced-code-block strip, then a
+    first-balanced-object extraction. Duplicates are skipped so callers
+    don't pay for parsing the same string twice.
+    """
+    candidates = [raw]
+    fenced = _strip_fenced_block(raw)
+    if fenced is not None and fenced not in candidates:
+        candidates.append(fenced)
+    extracted = _extract_first_json_object(raw)
+    if extracted is not None and extracted not in candidates:
+        candidates.append(extracted)
+    return candidates
+
+
+def _decode_json_tolerant(raw: str) -> object:
+    """Decode JSON from an LLM response, tolerating fences and preambles.
+
+    Claude 4.x routinely wraps structured responses in ``` ```json … ```
+    `` ` fences or prefaces them with a short preamble (INC-007). The
+    strict :func:`json.loads` path rejects both; this helper retries
+    against successively more aggressive cleanups before giving up.
+    """
+    last_error: json.JSONDecodeError | None = None
+    for candidate in _json_candidates(raw):
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError as exc:
+            last_error = exc
+    msg = "Compile LLM returned non-JSON output."
+    raise ValueError(msg) from last_error
+
+
 def _parse_llm_payload(raw: str) -> dict[str, list[dict[str, object]]]:
     """Parse the LLM response into the canonical ``{claims, paradoxes}`` dict."""
-    try:
-        decoded = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        msg = "Compile LLM returned non-JSON output."
-        raise ValueError(msg) from exc
+    decoded = _decode_json_tolerant(raw)
     if not isinstance(decoded, dict):
         msg = "Compile LLM payload must be a JSON object."
         raise ValueError(msg)  # noqa: TRY004  # ValueError unifies all LLM-payload schema errors with the JSONDecodeError branch above.

--- a/creek-tools/tests/test_compile.py
+++ b/creek-tools/tests/test_compile.py
@@ -543,6 +543,160 @@ def test_compile_fragments_rejects_non_json_response() -> None:
         )
 
 
+def test_compile_fragments_tolerates_json_fenced_block() -> None:
+    """LLM responses wrapped in ``` ```json ... ``` `` ` parse successfully.
+
+    Claude 4.x routinely wraps structured responses in fenced code
+    blocks regardless of prompt wording (INC-007). The parser must
+    survive both ``` ```json `` ` and bare ``` ``` `` ` fences.
+    """
+    frag = _make_fragment(frag_id="frag-aaa")
+    payload = json.dumps(
+        {
+            "claims": [{"id": "c1", "text": "X.", "fragment_ids": ["frag-aaa"]}],
+            "paradoxes": [],
+        },
+    )
+    wrapped = f"```json\n{payload}\n```"
+    llm, _ = _make_llm([wrapped])
+    result = compile_fragments(
+        [(frag, "body")],
+        llm=llm,
+        target_kind="thread",
+        target_id="t",
+        target_title="T",
+    )
+    assert [p.claim_id for p in result.page.provenance] == ["c1"]
+
+
+def test_compile_fragments_tolerates_plain_fenced_block() -> None:
+    """LLM responses wrapped in a plain ``` ``` `` ` fence (no language tag) parse."""
+    frag = _make_fragment(frag_id="frag-aaa")
+    payload = json.dumps(
+        {
+            "claims": [{"id": "c1", "text": "X.", "fragment_ids": ["frag-aaa"]}],
+            "paradoxes": [],
+        },
+    )
+    wrapped = f"```\n{payload}\n```"
+    llm, _ = _make_llm([wrapped])
+    result = compile_fragments(
+        [(frag, "body")],
+        llm=llm,
+        target_kind="thread",
+        target_id="t",
+        target_title="T",
+    )
+    assert [p.claim_id for p in result.page.provenance] == ["c1"]
+
+
+def test_compile_fragments_tolerates_leading_preamble() -> None:
+    """A short preamble before the JSON object is stripped before parsing."""
+    frag = _make_fragment(frag_id="frag-aaa")
+    payload = json.dumps(
+        {
+            "claims": [{"id": "c1", "text": "X.", "fragment_ids": ["frag-aaa"]}],
+            "paradoxes": [],
+        },
+    )
+    wrapped = f"Here is the requested JSON:\n{payload}"
+    llm, _ = _make_llm([wrapped])
+    result = compile_fragments(
+        [(frag, "body")],
+        llm=llm,
+        target_kind="thread",
+        target_id="t",
+        target_title="T",
+    )
+    assert [p.claim_id for p in result.page.provenance] == ["c1"]
+
+
+def test_compile_fragments_tolerates_trailing_text() -> None:
+    """A trailing sign-off after the JSON object is ignored."""
+    frag = _make_fragment(frag_id="frag-aaa")
+    payload = json.dumps(
+        {
+            "claims": [{"id": "c1", "text": "X.", "fragment_ids": ["frag-aaa"]}],
+            "paradoxes": [],
+        },
+    )
+    wrapped = f"{payload}\n\nLet me know if you need anything else."
+    llm, _ = _make_llm([wrapped])
+    result = compile_fragments(
+        [(frag, "body")],
+        llm=llm,
+        target_kind="thread",
+        target_id="t",
+        target_title="T",
+    )
+    assert [p.claim_id for p in result.page.provenance] == ["c1"]
+
+
+def test_compile_fragments_handles_nested_braces_in_payload() -> None:
+    """A wrapped payload with braces inside string values still parses."""
+    frag = _make_fragment(frag_id="frag-aaa")
+    payload = json.dumps(
+        {
+            "claims": [
+                {
+                    "id": "c1",
+                    "text": "A claim with {curly} braces in the text {value}.",
+                    "fragment_ids": ["frag-aaa"],
+                },
+            ],
+            "paradoxes": [],
+        },
+    )
+    wrapped = f"```json\n{payload}\n```"
+    llm, _ = _make_llm([wrapped])
+    result = compile_fragments(
+        [(frag, "body")],
+        llm=llm,
+        target_kind="thread",
+        target_id="t",
+        target_title="T",
+    )
+    assert [p.claim_id for p in result.page.provenance] == ["c1"]
+
+
+def test_compile_fragments_rejects_unterminated_object_in_fence() -> None:
+    """An unterminated JSON object — even inside a fence — still raises."""
+    frag = _make_fragment(frag_id="frag-aaa")
+    llm, _ = _make_llm(['```json\n{"claims": [{"id": "c1"\n```'])
+    with pytest.raises(ValueError, match="non-JSON"):
+        compile_fragments(
+            [(frag, "body")],
+            llm=llm,
+            target_kind="thread",
+            target_id="t",
+            target_title="T",
+        )
+
+
+def test_build_prompt_requests_raw_json() -> None:
+    """The compile prompt explicitly instructs the LLM to emit raw JSON only.
+
+    Tightening the prompt is one half of the INC-007 fix; the tolerant
+    parser is the other. Together they keep the system forgiving on
+    input and explicit on output.
+    """
+    frag = _make_fragment(frag_id="frag-aaa")
+    response = _llm_response(
+        claims=[{"id": "c1", "text": "x", "fragment_ids": ["frag-aaa"]}],
+    )
+    llm, prompts = _make_llm([response])
+    compile_fragments(
+        [(frag, "body")],
+        llm=llm,
+        target_kind="thread",
+        target_id="t",
+        target_title="T",
+    )
+    lowered = prompts[0].lower()
+    assert "raw json" in lowered
+    assert "code fence" in lowered or "fenced" in lowered or "fences" in lowered
+
+
 def test_compile_fragments_rejects_non_object_payload() -> None:
     """A JSON array (rather than an object) at the top level is rejected."""
     frag = _make_fragment(frag_id="frag-aaa")


### PR DESCRIPTION
## Summary
Hardens the compile engine's LLM response parser to tolerate common Claude 4.x output patterns: Markdown code fences (with or without `json` language tags), leading preambles, and trailing sign-offs. Implements a two-part fix: tightens the prompt to explicitly request raw JSON, and adds a tolerant parser that tries multiple extraction strategies before failing.

## Changes

### Source Code (`creek/compile/engine.py`)
- **Added `_strip_fenced_block()`**: Extracts content from the first Markdown code fence (``` ```json … ``` `` ` or ``` ``` `` `), handling optional language tags and whitespace.
- **Added `_extract_first_json_object()`**: Uses `json.JSONDecoder.raw_decode()` to find and extract the first balanced JSON object, correctly handling nested braces and braces within string values.
- **Added `_json_candidates()`**: Builds an ordered list of parsing candidates (raw response, fenced block, extracted object) to avoid redundant decoding attempts.
- **Added `_decode_json_tolerant()`**: Replaces strict `json.loads()` with a multi-strategy fallback chain that tries candidates in order before raising a unified error.
- **Updated `_build_prompt()`**: Added explicit instruction: "Respond with raw JSON only. No prose, no preamble, no Markdown code fences."
- **Updated `_parse_llm_payload()`**: Now calls `_decode_json_tolerant()` instead of `json.loads()`.

### Tests (`tests/test_compile.py`)
- **`test_compile_fragments_tolerates_json_fenced_block()`**: Verifies parsing of ``` ```json … ``` `` ` wrapped responses.
- **`test_compile_fragments_tolerates_plain_fenced_block()`**: Verifies parsing of ``` ``` … ``` `` ` (no language tag) wrapped responses.
- **`test_compile_fragments_tolerates_leading_preamble()`**: Verifies that short preambles before JSON are stripped.
- **`test_compile_fragments_tolerates_trailing_text()`**: Verifies that trailing sign-offs after JSON are ignored.
- **`test_compile_fragments_handles_nested_braces_in_payload()`**: Ensures nested braces in claim text don't break parsing.
- **`test_compile_fragments_rejects_unterminated_object_in_fence()`**: Confirms that malformed JSON still raises an error, even inside fences.
- **`test_build_prompt_requests_raw_json()`**: Validates that the updated prompt includes the new raw JSON and code fence guidance.

## Implementation Details
- The regex `_JSON_FENCE_RE` uses non-greedy matching (`.*?`) to stop at the first closing fence, preventing issues when the LLM emits multiple blocks.
- `_extract_first_json_object()` leverages `raw_decode()` to correctly handle complex payloads with braces in string values, avoiding naive brace-counting approaches.
- The candidate list deduplicates to avoid parsing the same string twice (e.g., if raw input is already a fenced block).
- All error paths converge on a single `ValueError` with message "Compile LLM returned non-JSON output." to maintain backward compatibility with existing error handling.

## Addresses
- **INC-007**: Claude 4.x routinely wraps structured responses in code fences regardless of prompt wording. This fix makes the system forgiving on input (tolerant parser) while being explicit on output (tightened prompt).

https://claude.ai/code/session_017peMSdypj3tgUnypJLUA9K