### PR TITLE
feat(ingest): substack-aware ingestor with publication-date preservation (FEAT-024)

### DIFF
--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -161,9 +161,9 @@ See [`docs/configuration.md`](docs/configuration.md) for the full schema with ex
 
 ## Source platforms
 
-The ingestion pipeline currently ships **10** registered `Ingestor`s plus a read-only Google Drive downloader that routes mirrored files back through the matching ingestor:
+The ingestion pipeline currently ships **11** registered `Ingestor`s plus a read-only Google Drive downloader that routes mirrored files back through the matching ingestor:
 
-`claude`, `chatgpt`, `discord`, `code`, `document` (.docx / .pdf), `markdown`, `spreadsheet` (.xlsx / .csv), `presentation` (.pptx), `image` (with OCR), and `generic` (fallback for unknown text).
+`claude`, `chatgpt`, `discord`, `code`, `document` (.docx / .pdf), `markdown`, `spreadsheet` (.xlsx / .csv), `presentation` (.pptx), `image` (with OCR), `substack` (newsletter exports), and `generic` (fallback for unknown text).
 
 `gdrive` is a downloader, not an ingestor — it stages files locally and dispatches each one to the appropriate ingestor by extension. The `other` enum value on `SourcePlatform` is reserved for downstream consumers (e.g. fragments synthesised from praxes) and has no parser.
 

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -289,9 +289,28 @@ def _week_start(day: date) -> date:
     return day - timedelta(days=day.weekday())
 
 
+def _fragment_effective_date(fragment: Fragment) -> date:
+    """Return the date this fragment should be bucketed under.
+
+    Prefers :attr:`Fragment.authored_at` (FEAT-024 / FEAT-025) — when an
+    ingestor extracts the source's own timestamp (a Substack post's
+    publish date, a Discord message's ``timestamp``), that date is what
+    every time-bucket surface should see so a 2024 essay does not get
+    counted as part of *this week's* wavelength. Falls back to
+    :attr:`Fragment.created` when no authored date was extracted.
+    """
+    if fragment.authored_at is not None:
+        return fragment.authored_at.date()
+    return fragment.created.date()
+
+
 def _fragment_in_window(fragment: Fragment, start: date, end: date) -> bool:
-    """Return whether *fragment* was created within ``[start, end]`` inclusive."""
-    frag_date = fragment.created.date()
+    """Return whether *fragment* falls within ``[start, end]`` inclusive.
+
+    Bucketing uses :func:`_fragment_effective_date` so a historical
+    Substack export does not register as current-week activity (FEAT-024).
+    """
+    frag_date = _fragment_effective_date(fragment)
     return start <= frag_date <= end
 
 
@@ -537,7 +556,7 @@ class WavelengthTracker:
             dosage = str(fragment.wavelength.dosage)
             if not dosage or dosage == Dosage.UNCLASSIFIED.value:
                 continue
-            week = _week_start(fragment.created.date())
+            week = _week_start(_fragment_effective_date(fragment))
             buckets[week].append(dosage)
         weekly: list[tuple[date, float]] = []
         for week in sorted(buckets):

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -292,10 +292,10 @@ def _week_start(day: date) -> date:
 def _fragment_effective_date(fragment: Fragment) -> date:
     """Return the date this fragment should be bucketed under.
 
-    Prefers :attr:`Fragment.authored_at` (FEAT-024 / FEAT-025) — when an
-    ingestor extracts the source's own timestamp (a Substack post's
-    publish date, a Discord message's ``timestamp``), that date is what
-    every time-bucket surface should see so a 2024 essay does not get
+    Prefers :attr:`Fragment.authored_at` — when an ingestor extracts
+    the source's own timestamp (a Substack post's publish date, a
+    Discord message's ``timestamp``), that date is what every
+    time-bucket surface should see so a 2024 essay does not get
     counted as part of *this week's* wavelength. Falls back to
     :attr:`Fragment.created` when no authored date was extracted.
     """
@@ -308,7 +308,7 @@ def _fragment_in_window(fragment: Fragment, start: date, end: date) -> bool:
     """Return whether *fragment* falls within ``[start, end]`` inclusive.
 
     Bucketing uses :func:`_fragment_effective_date` so a historical
-    Substack export does not register as current-week activity (FEAT-024).
+    export does not register as current-week activity.
     """
     frag_date = _fragment_effective_date(fragment)
     return start <= frag_date <= end

--- a/creek-tools/creek/ingest/__init__.py
+++ b/creek-tools/creek/ingest/__init__.py
@@ -48,6 +48,7 @@ from creek.ingest.images import ImageIngestor
 from creek.ingest.markdown import MarkdownIngestor
 from creek.ingest.presentations import PresentationIngestor
 from creek.ingest.spreadsheets import SpreadsheetIngestor
+from creek.ingest.substack import SubstackIngestor
 
 # Registry mapping ingestor names to their concrete classes.
 # To add a new ingestor, import its class above and add an entry here.
@@ -62,6 +63,7 @@ INGESTOR_REGISTRY: dict[str, type[Ingestor]] = {
     "markdown": MarkdownIngestor,
     "presentation": PresentationIngestor,
     "spreadsheet": SpreadsheetIngestor,
+    "substack": SubstackIngestor,
 }
 
 __all__ = [
@@ -86,6 +88,7 @@ __all__ = [
     "PresentationIngestor",
     "RawDocument",
     "SpreadsheetIngestor",
+    "SubstackIngestor",
     "assemble_ingested_fragment",
     "route_to_ingestor",
 ]

--- a/creek-tools/creek/ingest/_detection.py
+++ b/creek-tools/creek/ingest/_detection.py
@@ -1,0 +1,54 @@
+"""Format-detection helpers shared by the ingestors.
+
+Lives in its own module so neither :mod:`creek.ingest.documents` nor
+:mod:`creek.ingest.substack` needs to import from the other to ask
+"does this directory look like a Substack export?". Keeping detection
+helpers cycle-free here means new format detectors can be added without
+having to think about import order.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+POSTS_CSV_FILENAME = "posts.csv"
+"""The canonical Substack-export metadata sidecar."""
+
+_LEADING_DIGITS = re.compile(r"^(\d+)")
+"""Capture the leading numeric component of a Substack HTML filename."""
+
+
+def extract_post_id(filename: str) -> str | None:
+    """Return the leading numeric component of a Substack HTML filename.
+
+    Substack names post files ``<post_id>.<slug>.html``. We split on the
+    leading digit run rather than ``"."`` because some slugs themselves
+    contain ``.``, and a regex anchored at the start is the simplest
+    way to read past those without misclassifying.
+    """
+    match = _LEADING_DIGITS.match(filename)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def is_substack_export(path: Path) -> bool:
+    """Return whether *path* looks like a Substack export directory.
+
+    A Substack export root holds a ``posts.csv`` sidecar plus at least
+    one ``<post_id>.<slug>.html`` post file (Substack drops the HTML
+    files either next to ``posts.csv`` or one level down inside a
+    ``posts/`` subdirectory). Files and missing paths short-circuit to
+    ``False`` so the check is safe to call against arbitrary CLI input.
+    """
+    if not path.exists() or not path.is_dir():
+        return False
+    if not (path / POSTS_CSV_FILENAME).is_file():
+        return False
+    return any(
+        extract_post_id(p.name) is not None for p in path.rglob("*.html") if p.is_file()
+    )

--- a/creek-tools/creek/ingest/documents.py
+++ b/creek-tools/creek/ingest/documents.py
@@ -28,6 +28,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from creek.ingest._detection import is_substack_export
 from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
@@ -35,6 +36,7 @@ from creek.ingest.base import (
     normalize_encoding,
     normalize_timestamp,
 )
+from creek.ingest.html import parse_html_to_markdown
 from creek.models import SourcePlatform
 
 logger = logging.getLogger(__name__)
@@ -57,30 +59,16 @@ _DOCUMENT_PLATFORM_EXTENSIONS: frozenset[str] = frozenset({".docx", ".pdf", ".rt
 
 
 def _parse_html_to_markdown(html: str) -> str:
-    """Convert an HTML string to clean ATX-style markdown.
+    """Re-export of :func:`creek.ingest.html.parse_html_to_markdown`.
 
-    Uses ``markdownify`` with ATX heading style for consistent output.
-
-    Args:
-        html: The HTML content to convert.
-
-    Returns:
-        A markdown-formatted string.
-
-    Raises:
-        ImportError: If ``markdownify`` is not installed. Install with
-            ``pip install creek-tools[documents]``.
+    The implementation moved to :mod:`creek.ingest.html` so
+    :mod:`creek.ingest.substack` can use it without reaching into a
+    private symbol of this module. This thin shim keeps existing
+    tests and downstream callers that import the underscore-prefixed
+    name working; new code should import the public
+    :func:`creek.ingest.html.parse_html_to_markdown` directly.
     """
-    try:
-        import markdownify
-    except ImportError as exc:
-        msg = (
-            "markdownify is required for HTML ingestion. "
-            "Install with: pip install creek-tools[documents]"
-        )
-        raise ImportError(msg) from exc
-    result: str = markdownify.markdownify(html, heading_style="ATX")
-    return result
+    return parse_html_to_markdown(html)
 
 
 def _wrap_txt_with_structure(text: str) -> str:
@@ -383,13 +371,12 @@ class DocumentIngestor(Ingestor):
         for files with supported extensions. Returns empty list for
         nonexistent paths.
 
-        FEAT-024: Substack export directories (``posts.csv`` + per-post
-        ``<id>.<slug>.html``) are claimed by :class:`SubstackIngestor`;
-        ``DocumentIngestor`` defers to that ingestor rather than
-        double-emitting every post as an opaque HTML document. This keeps
-        the auto-detect path of ``creek process`` (which fans every
-        registered ingestor at the source) from producing two fragments
-        per Substack essay.
+        Substack export directories (``posts.csv`` + per-post
+        ``<id>.<slug>.html``) are claimed by ``SubstackIngestor``;
+        ``DocumentIngestor`` defers to it rather than double-emitting
+        every post as an opaque HTML document, so the auto-detect path
+        of ``creek process`` (which fans every registered ingestor at
+        the source) produces one fragment per essay, not two.
 
         Args:
             source_path: A file or directory path to search.
@@ -402,9 +389,6 @@ class DocumentIngestor(Ingestor):
 
         if source_path.is_file():
             return self._discover_single_file(source_path)
-
-        # Defer Substack exports to SubstackIngestor (FEAT-024).
-        from creek.ingest.substack import is_substack_export
 
         if is_substack_export(source_path):
             return []
@@ -506,7 +490,7 @@ class DocumentIngestor(Ingestor):
         if file_type == ".pdf":
             return self._extract_pdf_content(raw_bytes)
         if file_type in {".html", ".htm"}:
-            return _parse_html_to_markdown(text)
+            return parse_html_to_markdown(text)
         if file_type == ".txt":
             return _wrap_txt_with_structure(text)
         # RTF and other formats: return raw text

--- a/creek-tools/creek/ingest/documents.py
+++ b/creek-tools/creek/ingest/documents.py
@@ -383,6 +383,14 @@ class DocumentIngestor(Ingestor):
         for files with supported extensions. Returns empty list for
         nonexistent paths.
 
+        FEAT-024: Substack export directories (``posts.csv`` + per-post
+        ``<id>.<slug>.html``) are claimed by :class:`SubstackIngestor`;
+        ``DocumentIngestor`` defers to that ingestor rather than
+        double-emitting every post as an opaque HTML document. This keeps
+        the auto-detect path of ``creek process`` (which fans every
+        registered ingestor at the source) from producing two fragments
+        per Substack essay.
+
         Args:
             source_path: A file or directory path to search.
 
@@ -394,6 +402,12 @@ class DocumentIngestor(Ingestor):
 
         if source_path.is_file():
             return self._discover_single_file(source_path)
+
+        # Defer Substack exports to SubstackIngestor (FEAT-024).
+        from creek.ingest.substack import is_substack_export
+
+        if is_substack_export(source_path):
+            return []
 
         return self._discover_directory(source_path)
 

--- a/creek-tools/creek/ingest/html.py
+++ b/creek-tools/creek/ingest/html.py
@@ -1,0 +1,38 @@
+"""HTML → markdown conversion helper shared across ingestors.
+
+Promoting this out of :mod:`creek.ingest.documents` (where it lived as the
+private ``_parse_html_to_markdown``) breaks the import cycle that would
+otherwise form between :mod:`creek.ingest.documents` and
+:mod:`creek.ingest.substack`: both ingest HTML, and both should import
+the converter from a neutral module rather than reaching into each
+other's private API.
+"""
+
+from __future__ import annotations
+
+
+def parse_html_to_markdown(html: str) -> str:
+    """Convert an HTML string to clean ATX-style markdown.
+
+    Uses ``markdownify`` with ATX heading style for consistent output.
+
+    Args:
+        html: The HTML content to convert.
+
+    Returns:
+        A markdown-formatted string.
+
+    Raises:
+        ImportError: If ``markdownify`` is not installed. Install with
+            ``pip install creek-tools[documents]``.
+    """
+    try:
+        import markdownify
+    except ImportError as exc:
+        msg = (
+            "markdownify is required for HTML ingestion. "
+            "Install with: pip install creek-tools[documents]"
+        )
+        raise ImportError(msg) from exc
+    result: str = markdownify.markdownify(html, heading_style="ATX")
+    return result

--- a/creek-tools/creek/ingest/substack.py
+++ b/creek-tools/creek/ingest/substack.py
@@ -1,4 +1,4 @@
-"""Substack-aware ingestor for the Creek ingest pipeline (FEAT-024).
+"""Substack-aware ingestor for the Creek ingest pipeline.
 
 A Substack export bundles a ``posts.csv`` metadata sidecar alongside per-post
 ``<post_id>.<slug>.html`` files. The generic :class:`DocumentIngestor` treats
@@ -31,10 +31,14 @@ from __future__ import annotations
 
 import csv
 import logging
-import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from creek.ingest._detection import (
+    POSTS_CSV_FILENAME,
+    extract_post_id,
+    is_substack_export,
+)
 from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
@@ -43,7 +47,7 @@ from creek.ingest.base import (
     normalize_encoding,
     normalize_timestamp,
 )
-from creek.ingest.documents import _parse_html_to_markdown
+from creek.ingest.html import parse_html_to_markdown
 from creek.models import SourceKind, SourcePlatform
 
 if TYPE_CHECKING:
@@ -52,10 +56,23 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# ---- Constants ----
+# ---- Public re-exports ----
 
-POSTS_CSV_FILENAME = "posts.csv"
-"""The canonical Substack-export metadata sidecar."""
+# Detection helpers live in ``creek.ingest._detection`` so
+# ``creek.ingest.documents`` can import them without forming a cycle
+# with this module. They are re-exported here for the existing
+# substack-facing test surface and for downstream callers that want a
+# single "all things Substack" import location.
+__all__ = [
+    "POSTS_CSV_FILENAME",
+    "SUBSCRIBER_CSV_SUFFIXES",
+    "SUBSCRIBER_LIST_PREFIX",
+    "SubstackIngestor",
+    "is_substack_export",
+]
+
+
+# ---- Constants ----
 
 SUBSCRIBER_CSV_SUFFIXES: frozenset[str] = frozenset(
     {".delivers.csv", ".opens.csv"},
@@ -70,9 +87,6 @@ because Substack names them ``<post_id>.<slug>.delivers.csv`` /
 
 SUBSCRIBER_LIST_PREFIX = "email_list"
 """Filename prefix for the top-level subscriber list CSV (also PII)."""
-
-_LEADING_DIGITS = re.compile(r"^(\d+)")
-"""Capture the leading numeric component of a Substack HTML filename."""
 
 # Columns ``_parse_posts_csv`` will surface verbatim. Anything else in
 # the CSV is ignored — Substack's export schema has drifted over the
@@ -95,38 +109,41 @@ _KNOWN_POSTS_COLUMNS: frozenset[str] = frozenset(
 # ---- Helper functions ----
 
 
-def is_substack_export(path: Path) -> bool:
-    """Return whether *path* looks like a Substack export directory.
+# Backwards-compatible alias for the test surface that imports
+# ``_extract_post_id`` from this module by name.
+_extract_post_id = extract_post_id
 
-    A Substack export root holds a ``posts.csv`` sidecar plus at least
-    one ``<post_id>.<slug>.html`` post file (Substack drops the HTML
-    files either next to ``posts.csv`` or one level down inside a
-    ``posts/`` subdirectory). Files and missing paths short-circuit to
-    ``False`` so the check is safe to call against arbitrary CLI input.
+
+# Optional ``posts.csv`` columns whose values are surfaced verbatim
+# into the fragment frontmatter when present. Driving the assignment
+# from a table keeps :meth:`SubstackIngestor.generate_frontmatter`
+# below the project's cyclomatic-complexity ceiling and makes adding
+# a new column a one-line change.
+_OPTIONAL_FRONTMATTER_FIELDS: tuple[str, ...] = (
+    "subtitle",
+    "audience",
+    "podcast_url",
+)
+
+
+def _merge_optional_fields(
+    frontmatter_dict: dict[str, Any],
+    row: dict[str, str],
+    post_id: object,
+) -> None:
+    """Copy non-empty optional Substack columns into *frontmatter_dict*.
+
+    Empty / whitespace-only values are skipped so the frontmatter does
+    not carry blank keys that downstream consumers would have to
+    null-check. ``post_id`` is treated separately because its source
+    is the parsed-fragment metadata, not the CSV row.
     """
-    if not path.exists() or not path.is_dir():
-        return False
-    if not (path / POSTS_CSV_FILENAME).is_file():
-        return False
-    return any(
-        _extract_post_id(p.name) is not None
-        for p in path.rglob("*.html")
-        if p.is_file()
-    )
-
-
-def _extract_post_id(filename: str) -> str | None:
-    """Return the leading numeric component of a Substack HTML filename.
-
-    Substack names post files ``<post_id>.<slug>.html``. We split on the
-    leading digit run rather than ``"."`` because some slugs themselves
-    contain ``.``, and a regex anchored at the start is the simplest
-    way to read past those without misclassifying.
-    """
-    match = _LEADING_DIGITS.match(filename)
-    if match is None:
-        return None
-    return match.group(1)
+    for key in _OPTIONAL_FRONTMATTER_FIELDS:
+        value = (row.get(key) or "").strip()
+        if value:
+            frontmatter_dict[key] = value
+    if post_id:
+        frontmatter_dict["substack_post_id"] = post_id
 
 
 def _parse_posts_csv(csv_path: Path) -> dict[str, dict[str, str]]:
@@ -203,7 +220,7 @@ def _resolve_authored_at(
 
 
 class SubstackIngestor(Ingestor):
-    """Ingestor for Substack newsletter exports (FEAT-024).
+    """Ingestor for Substack newsletter exports.
 
     Discovers ``posts.csv`` once at the export root, recursively walks
     the directory for per-post ``<post_id>.<slug>.html`` files, and
@@ -231,7 +248,14 @@ class SubstackIngestor(Ingestor):
         ingestor refuses to emit anything (auto-detection failed and
         the caller likely meant ``--type document``). Subscriber-PII
         CSVs are filtered here so the parse stage cannot see them.
+
+        ``_posts_metadata`` is reset unconditionally on every call so a
+        reused ingestor instance cannot leak the previous export's
+        rows into a later parse — defensive against the (rare) caller
+        that runs the same ingestor against several sources in sequence.
         """
+        self._posts_metadata = {}
+
         if not source_path.exists() or not source_path.is_dir():
             return []
 
@@ -250,7 +274,7 @@ class SubstackIngestor(Ingestor):
             # PII guard at the discover boundary regardless.
             if _is_subscriber_csv(html_file):
                 continue
-            post_id = _extract_post_id(html_file.name)
+            post_id = extract_post_id(html_file.name)
             if post_id is None:
                 logger.debug(
                     "Substack HTML %s has no leading post_id; skipping",
@@ -279,14 +303,14 @@ class SubstackIngestor(Ingestor):
 
         The fragment's ``timestamp`` is the publication date when
         available so the base class's deterministic fragment-ID hash is
-        stable across re-ingests (FEAT-024 idempotency requirement).
+        stable across re-ingests — the idempotency contract.
         """
         post_id = str(raw.metadata.get("post_id", ""))
         row = self._posts_metadata.get(post_id)
         authored_at, timestamp = _resolve_authored_at(row, raw.path)
 
         text, encoding = normalize_encoding(raw.content)
-        markdown_body = _parse_html_to_markdown(text)
+        markdown_body = parse_html_to_markdown(text)
 
         return [
             ParsedFragment(
@@ -318,17 +342,15 @@ class SubstackIngestor(Ingestor):
         row = fragment.metadata.get("post_row") or {}
         title = (row.get("title") or "").strip() or Path(fragment.source_path).stem
 
-        source: dict[str, Any] = {
-            "platform": SourcePlatform.SUBSTACK,
-            "kind": SourceKind.WRITING,
-            "original_file": fragment.source_path,
-            "original_encoding": fragment.metadata.get("source_encoding", "utf-8"),
-        }
-
         frontmatter_dict: dict[str, Any] = {
             "type": "fragment",
             "title": title,
-            "source": source,
+            "source": {
+                "platform": SourcePlatform.SUBSTACK,
+                "kind": SourceKind.WRITING,
+                "original_file": fragment.source_path,
+                "original_encoding": fragment.metadata.get("source_encoding", "utf-8"),
+            },
             "created": fragment.timestamp.isoformat(),
         }
 
@@ -336,14 +358,5 @@ class SubstackIngestor(Ingestor):
         if authored_at is not None:
             frontmatter_dict["authored_at"] = authored_at.isoformat()
 
-        subtitle = (row.get("subtitle") or "").strip()
-        if subtitle:
-            frontmatter_dict["subtitle"] = subtitle
-        audience = (row.get("audience") or "").strip()
-        if audience:
-            frontmatter_dict["audience"] = audience
-        post_id = fragment.metadata.get("post_id")
-        if post_id:
-            frontmatter_dict["substack_post_id"] = post_id
-
+        _merge_optional_fields(frontmatter_dict, row, fragment.metadata.get("post_id"))
         return frontmatter_dict

--- a/creek-tools/creek/ingest/substack.py
+++ b/creek-tools/creek/ingest/substack.py
@@ -1,0 +1,349 @@
+"""Substack-aware ingestor for the Creek ingest pipeline (FEAT-024).
+
+A Substack export bundles a ``posts.csv`` metadata sidecar alongside per-post
+``<post_id>.<slug>.html`` files. The generic :class:`DocumentIngestor` treats
+each HTML file as opaque, throws away the real publication date, and routes
+the result to ``01-Fragments/Unsorted/`` — actively misleading the State
+report (which then claims a 2024 essay is part of *this week's* wavelength)
+and burying published essays alongside private chat fragments.
+
+This ingestor:
+
+* auto-detects a Substack export by the presence of ``posts.csv`` + at least
+  one matching per-post HTML file,
+* parses ``posts.csv`` once and maps each post ID (the leading numeric
+  component of the HTML filename) to its publication date, title, subtitle,
+  audience, and any other useful columns,
+* emits a fragment per HTML post with
+  ``source.platform = SUBSTACK`` / ``source.kind = WRITING`` and
+  ``authored_at`` populated from ``posts.csv`` (never the filesystem
+  date),
+* explicitly skips ``email_list*.csv``, ``*.delivers.csv``, and
+  ``*.opens.csv`` — subscriber PII that has no place in the vault.
+
+Re-running the ingestor against an already-ingested export is idempotent:
+fragment IDs derive from ``(source_path, authored_at, content)`` so
+identical inputs produce identical IDs and the vault writer's per-directory
+ID index recognises and skips duplicates.
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from creek.ingest.base import (
+    Ingestor,
+    ParsedFragment,
+    RawDocument,
+    file_modified_time,
+    normalize_encoding,
+    normalize_timestamp,
+)
+from creek.ingest.documents import _parse_html_to_markdown
+from creek.models import SourceKind, SourcePlatform
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+# ---- Constants ----
+
+POSTS_CSV_FILENAME = "posts.csv"
+"""The canonical Substack-export metadata sidecar."""
+
+SUBSCRIBER_CSV_SUFFIXES: frozenset[str] = frozenset(
+    {".delivers.csv", ".opens.csv"},
+)
+"""Filename suffixes for per-post subscriber-engagement CSVs.
+
+These files record which subscribers received or opened each post and
+are pure PII. They MUST NOT produce fragments. The check is suffix-based
+because Substack names them ``<post_id>.<slug>.delivers.csv`` /
+``<post_id>.<slug>.opens.csv``.
+"""
+
+SUBSCRIBER_LIST_PREFIX = "email_list"
+"""Filename prefix for the top-level subscriber list CSV (also PII)."""
+
+_LEADING_DIGITS = re.compile(r"^(\d+)")
+"""Capture the leading numeric component of a Substack HTML filename."""
+
+# Columns ``_parse_posts_csv`` will surface verbatim. Anything else in
+# the CSV is ignored — Substack's export schema has drifted over the
+# years and a future column we don't recognise should not break ingest.
+_KNOWN_POSTS_COLUMNS: frozenset[str] = frozenset(
+    {
+        "post_id",
+        "post_date",
+        "title",
+        "subtitle",
+        "type",
+        "audience",
+        "is_published",
+        "is_public",
+        "podcast_url",
+    },
+)
+
+
+# ---- Helper functions ----
+
+
+def is_substack_export(path: Path) -> bool:
+    """Return whether *path* looks like a Substack export directory.
+
+    A Substack export root holds a ``posts.csv`` sidecar plus at least
+    one ``<post_id>.<slug>.html`` post file (Substack drops the HTML
+    files either next to ``posts.csv`` or one level down inside a
+    ``posts/`` subdirectory). Files and missing paths short-circuit to
+    ``False`` so the check is safe to call against arbitrary CLI input.
+    """
+    if not path.exists() or not path.is_dir():
+        return False
+    if not (path / POSTS_CSV_FILENAME).is_file():
+        return False
+    return any(
+        _extract_post_id(p.name) is not None
+        for p in path.rglob("*.html")
+        if p.is_file()
+    )
+
+
+def _extract_post_id(filename: str) -> str | None:
+    """Return the leading numeric component of a Substack HTML filename.
+
+    Substack names post files ``<post_id>.<slug>.html``. We split on the
+    leading digit run rather than ``"."`` because some slugs themselves
+    contain ``.``, and a regex anchored at the start is the simplest
+    way to read past those without misclassifying.
+    """
+    match = _LEADING_DIGITS.match(filename)
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _parse_posts_csv(csv_path: Path) -> dict[str, dict[str, str]]:
+    """Parse ``posts.csv`` into ``{post_id: {column: value}}``.
+
+    Unknown columns are dropped (Substack's export schema drifts over
+    the years). Rows without a ``post_id`` are skipped — the value is
+    the join key, and a row that cannot be joined is useless to the
+    ingestor. A missing file yields an empty dict so the caller can
+    treat "no metadata" as a recoverable state.
+    """
+    if not csv_path.is_file():
+        return {}
+    metadata: dict[str, dict[str, str]] = {}
+    with csv_path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            post_id = (row.get("post_id") or "").strip()
+            if not post_id:
+                continue
+            metadata[post_id] = {
+                key: value
+                for key, value in row.items()
+                if key in _KNOWN_POSTS_COLUMNS and value is not None
+            }
+    return metadata
+
+
+def _is_subscriber_csv(path: Path) -> bool:
+    """Return whether *path* is a subscriber-engagement CSV (PII).
+
+    Covers both layouts: per-post ``<post_id>.<slug>.delivers.csv`` /
+    ``.opens.csv`` and the top-level ``email_list*.csv`` roster.
+    """
+    name = path.name.lower()
+    if name.startswith(SUBSCRIBER_LIST_PREFIX) and name.endswith(".csv"):
+        return True
+    return any(name.endswith(suffix) for suffix in SUBSCRIBER_CSV_SUFFIXES)
+
+
+def _resolve_authored_at(
+    row: dict[str, str] | None,
+    file_path: Path,
+) -> tuple[datetime | None, datetime]:
+    """Return ``(authored_at, timestamp)`` for a Substack post.
+
+    ``authored_at`` is the post's true publication date from
+    ``posts.csv``, or ``None`` when no CSV row matches the HTML file
+    (the honest answer — never guess).
+
+    ``timestamp`` is what the base-class pipeline feeds into the
+    deterministic fragment-ID hash. We use ``authored_at`` when we have
+    one so re-running the ingestor against the same export produces
+    identical IDs (the writer's ID index then skips the duplicate),
+    and the filesystem mtime otherwise — the same fallback every other
+    Creek ingestor uses for an undated source.
+    """
+    raw_date = (row or {}).get("post_date", "").strip()
+    if raw_date:
+        try:
+            authored = normalize_timestamp(raw_date, None)
+        except ValueError:
+            logger.warning(
+                "Substack posts.csv row for %s has unparseable post_date %r",
+                file_path,
+                raw_date,
+            )
+        else:
+            return authored, authored
+    return None, file_modified_time(file_path)
+
+
+# ---- SubstackIngestor ----
+
+
+class SubstackIngestor(Ingestor):
+    """Ingestor for Substack newsletter exports (FEAT-024).
+
+    Discovers ``posts.csv`` once at the export root, recursively walks
+    the directory for per-post ``<post_id>.<slug>.html`` files, and
+    produces one fragment per post with publication-date-aware metadata.
+
+    Subscriber-engagement CSVs are filtered explicitly (see
+    :data:`SUBSCRIBER_CSV_SUFFIXES`) and never reach the parse stage,
+    so subscriber PII cannot escape into the vault even by accident.
+    """
+
+    def __init__(self) -> None:
+        """Initialise the ingestor with empty per-run state.
+
+        ``_posts_metadata`` is the parsed ``posts.csv`` mapping; it is
+        populated during :meth:`discover` so :meth:`parse` can join
+        each HTML file back to its publication date in O(1) without
+        re-reading the CSV per post.
+        """
+        self._posts_metadata: dict[str, dict[str, str]] = {}
+
+    def discover(self, source_path: Path) -> list[RawDocument]:
+        """Find post HTML files inside a Substack export directory.
+
+        The export root must contain ``posts.csv``; otherwise the
+        ingestor refuses to emit anything (auto-detection failed and
+        the caller likely meant ``--type document``). Subscriber-PII
+        CSVs are filtered here so the parse stage cannot see them.
+        """
+        if not source_path.exists() or not source_path.is_dir():
+            return []
+
+        csv_path = source_path / POSTS_CSV_FILENAME
+        if not csv_path.is_file():
+            return []
+
+        self._posts_metadata = _parse_posts_csv(csv_path)
+
+        docs: list[RawDocument] = []
+        for html_file in sorted(source_path.rglob("*.html")):
+            if not html_file.is_file():
+                continue
+            # Paranoia — an HTML extension shouldn't match the subscriber
+            # filter, but a future export-layout change could; keep the
+            # PII guard at the discover boundary regardless.
+            if _is_subscriber_csv(html_file):
+                continue
+            post_id = _extract_post_id(html_file.name)
+            if post_id is None:
+                logger.debug(
+                    "Substack HTML %s has no leading post_id; skipping",
+                    html_file,
+                )
+                continue
+            docs.append(self._read_html(html_file, post_id))
+        return docs
+
+    def _read_html(self, file_path: Path, post_id: str) -> RawDocument:
+        """Read one post HTML into a :class:`RawDocument`."""
+        raw_bytes = file_path.read_bytes()
+        _text, encoding = normalize_encoding(raw_bytes)
+        return RawDocument(
+            path=file_path,
+            content=raw_bytes,
+            metadata={
+                "source_type": "substack",
+                "post_id": post_id,
+            },
+            detected_encoding=encoding,
+        )
+
+    def parse(self, raw: RawDocument) -> list[ParsedFragment]:
+        """Parse one post HTML, joining it against the cached ``posts.csv`` row.
+
+        The fragment's ``timestamp`` is the publication date when
+        available so the base class's deterministic fragment-ID hash is
+        stable across re-ingests (FEAT-024 idempotency requirement).
+        """
+        post_id = str(raw.metadata.get("post_id", ""))
+        row = self._posts_metadata.get(post_id)
+        authored_at, timestamp = _resolve_authored_at(row, raw.path)
+
+        text, encoding = normalize_encoding(raw.content)
+        markdown_body = _parse_html_to_markdown(text)
+
+        return [
+            ParsedFragment(
+                content=markdown_body,
+                metadata={
+                    "post_id": post_id,
+                    "post_row": dict(row) if row else {},
+                    "authored_at": authored_at,
+                    "source_encoding": encoding,
+                },
+                source_path=str(raw.path),
+                timestamp=timestamp,
+            ),
+        ]
+
+    def convert_to_markdown(self, fragment: ParsedFragment) -> str:
+        """Return the already-converted markdown body."""
+        return fragment.content
+
+    def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
+        """Build Creek frontmatter with Substack-aware fields.
+
+        Sets ``source.platform = SUBSTACK`` / ``source.kind = WRITING``
+        and ``authored_at`` from ``posts.csv``. Pulls the title and any
+        optional metadata (subtitle, audience, podcast URL) from the
+        cached row when available; falls back to the HTML filename
+        stem when the row is missing.
+        """
+        row = fragment.metadata.get("post_row") or {}
+        title = (row.get("title") or "").strip() or Path(fragment.source_path).stem
+
+        source: dict[str, Any] = {
+            "platform": SourcePlatform.SUBSTACK,
+            "kind": SourceKind.WRITING,
+            "original_file": fragment.source_path,
+            "original_encoding": fragment.metadata.get("source_encoding", "utf-8"),
+        }
+
+        frontmatter_dict: dict[str, Any] = {
+            "type": "fragment",
+            "title": title,
+            "source": source,
+            "created": fragment.timestamp.isoformat(),
+        }
+
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            frontmatter_dict["authored_at"] = authored_at.isoformat()
+
+        subtitle = (row.get("subtitle") or "").strip()
+        if subtitle:
+            frontmatter_dict["subtitle"] = subtitle
+        audience = (row.get("audience") or "").strip()
+        if audience:
+            frontmatter_dict["audience"] = audience
+        post_id = fragment.metadata.get("post_id")
+        if post_id:
+            frontmatter_dict["substack_post_id"] = post_id
+
+        return frontmatter_dict

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -280,7 +280,27 @@ class SourcePlatform(StrEnum):
     IMAGE_OCR = "image_ocr"
     SPREADSHEET = "spreadsheet"
     PRESENTATION = "presentation"
+    SUBSTACK = "substack"
     OTHER = "other"
+
+
+class SourceKind(StrEnum):
+    """Coarse semantic category for a fragment's source (FEAT-024).
+
+    Where :class:`SourcePlatform` answers *where the bytes came from*
+    (Substack, ChatGPT, Discord, …), ``SourceKind`` answers *what kind
+    of material it is* — a published essay versus a private journal
+    entry, a chat message versus a code file. Downstream surfaces use
+    the kind to make policy decisions (public-by-design vs.
+    private-by-default redaction, voice-proxy register selection,
+    folder routing) independently of which platform produced it.
+
+    Only the values FEAT-024 actually consumes are defined; the enum
+    is expected to grow as other ingestors adopt the contract.
+    """
+
+    WRITING = "writing"
+    UNCLASSIFIED = "unclassified"
 
 
 class Authorship(StrEnum):
@@ -407,6 +427,7 @@ class FragmentSource(BaseModel):
     model_config = ConfigDict(use_enum_values=True)
 
     platform: SourcePlatform
+    kind: SourceKind = SourceKind.UNCLASSIFIED
     original_file: str | None = None
     original_encoding: str | None = None
     conversation_id: str | None = None
@@ -464,6 +485,12 @@ class Fragment(BaseModel):
     source: FragmentSource
     created: datetime = Field(default_factory=now_la)
     ingested: datetime = Field(default_factory=now_la)
+    # FEAT-024: timestamp the source *itself* records (a Substack post's
+    # publish date, a Discord message's ``timestamp``, …) as opposed to
+    # when the file was scanned (``created``) or ingested into the vault
+    # (``ingested``). ``None`` is the honest answer when no source date
+    # is extractable; FEAT-025 will roll this out across every ingestor.
+    authored_at: datetime | None = None
     frequency: FrequencyClassification = Field(
         default_factory=FrequencyClassification,
     )

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -285,7 +285,7 @@ class SourcePlatform(StrEnum):
 
 
 class SourceKind(StrEnum):
-    """Coarse semantic category for a fragment's source (FEAT-024).
+    """Coarse semantic category for a fragment's source.
 
     Where :class:`SourcePlatform` answers *where the bytes came from*
     (Substack, ChatGPT, Discord, …), ``SourceKind`` answers *what kind
@@ -294,9 +294,6 @@ class SourceKind(StrEnum):
     the kind to make policy decisions (public-by-design vs.
     private-by-default redaction, voice-proxy register selection,
     folder routing) independently of which platform produced it.
-
-    Only the values FEAT-024 actually consumes are defined; the enum
-    is expected to grow as other ingestors adopt the contract.
     """
 
     WRITING = "writing"
@@ -485,11 +482,9 @@ class Fragment(BaseModel):
     source: FragmentSource
     created: datetime = Field(default_factory=now_la)
     ingested: datetime = Field(default_factory=now_la)
-    # FEAT-024: timestamp the source *itself* records (a Substack post's
-    # publish date, a Discord message's ``timestamp``, …) as opposed to
-    # when the file was scanned (``created``) or ingested into the vault
-    # (``ingested``). ``None`` is the honest answer when no source date
-    # is extractable; FEAT-025 will roll this out across every ingestor.
+    # Timestamp the source itself records (a Substack post's publish
+    # date, a Discord message's ``timestamp``, …); ``None`` is the
+    # honest answer when no source date is extractable — never guess.
     authored_at: datetime | None = None
     frequency: FrequencyClassification = Field(
         default_factory=FrequencyClassification,

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -60,6 +60,7 @@ _PLATFORM_SUBFOLDER: dict[str, str] = {
     SourcePlatform.DISCORD: "Messages",
     SourcePlatform.EMAIL: "Messages",
     SourcePlatform.ESSAY: "Writing",
+    SourcePlatform.SUBSTACK: "Writing/Substack",
     SourcePlatform.JOURNAL: "Journal",
     SourcePlatform.CODE: "Technical",
     SourcePlatform.MARKDOWN: "Notes",

--- a/creek-tools/tests/e2e/conftest.py
+++ b/creek-tools/tests/e2e/conftest.py
@@ -24,6 +24,7 @@ _VAULT_DIRS = (
     "01-Fragments/Conversations",
     "01-Fragments/Messages",
     "01-Fragments/Writing",
+    "01-Fragments/Writing/Substack",
     "01-Fragments/Journal",
     "01-Fragments/Technical",
     "01-Fragments/Notes",

--- a/creek-tools/tests/e2e/test_pipeline_markdown_e2e.py
+++ b/creek-tools/tests/e2e/test_pipeline_markdown_e2e.py
@@ -30,6 +30,7 @@ VAULT_DIRS: list[str] = [
     "01-Fragments/Conversations",
     "01-Fragments/Messages",
     "01-Fragments/Writing",
+    "01-Fragments/Writing/Substack",
     "01-Fragments/Journal",
     "01-Fragments/Technical",
     "01-Fragments/Notes",

--- a/creek-tools/tests/test_ingest_documents.py
+++ b/creek-tools/tests/test_ingest_documents.py
@@ -271,6 +271,23 @@ class TestParseHtmlToMarkdown:
         result = _parse_html_to_markdown(html)
         assert "Click here" in result
 
+    def test_missing_markdownify_raises_helpful_error(self) -> None:
+        """When the optional ``markdownify`` extra is absent, raise a clear ImportError.
+
+        Users who installed ``creek-tools`` without the ``[documents]``
+        extra should see a one-liner pointing at the install command,
+        not an opaque ``ModuleNotFoundError``.
+        """
+        import sys
+
+        from creek.ingest.html import parse_html_to_markdown
+
+        with (
+            patch.dict(sys.modules, {"markdownify": None}),
+            pytest.raises(ImportError, match=r"creek-tools\[documents\]"),
+        ):
+            parse_html_to_markdown("<p>x</p>")
+
 
 # ---- TXT Parsing Tests ----
 

--- a/creek-tools/tests/test_ingest_registry.py
+++ b/creek-tools/tests/test_ingest_registry.py
@@ -22,15 +22,16 @@ _EXPECTED_INGESTOR_NAMES: frozenset[str] = frozenset(
         "markdown",
         "presentation",
         "spreadsheet",
+        "substack",
     },
 )
 
 
 def test_ingestor_registry_size_matches_readme() -> None:
-    """Pin the registry size to the README's "10 source ingestors" claim."""
+    """Pin the registry size to the README's "11 source ingestors" claim."""
     # Update both this assertion and the README paragraph in
     # ``creek-tools/README.md`` ("Source platforms") together.
-    assert len(INGESTOR_REGISTRY) == 10
+    assert len(INGESTOR_REGISTRY) == 11
 
 
 def test_ingestor_registry_names_match_readme() -> None:

--- a/creek-tools/tests/test_ingest_substack.py
+++ b/creek-tools/tests/test_ingest_substack.py
@@ -1,4 +1,4 @@
-"""Tests for creek.ingest.substack — Substack-aware ingestor (FEAT-024).
+"""Tests for creek.ingest.substack — Substack-aware ingestor.
 
 Covers Substack-export detection, ``posts.csv`` metadata extraction,
 publication-date preservation via ``authored_at``, source taxonomy
@@ -225,6 +225,35 @@ class TestSubstackIngestion:
             assemble_ingested_fragment(p).fragment.title for p in result.fragments
         )
         assert titles == ["Hello World", "Latest", "Second Essay"]
+
+    def test_optional_metadata_columns_surface_in_frontmatter(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``subtitle``, ``audience``, and ``podcast_url`` round-trip into frontmatter.
+
+        These are the optional ``posts.csv`` columns the ingestor
+        promises in its docstring; if any silently disappeared,
+        downstream surfaces (privacy gates, voice-proxy training) would
+        lose useful context.
+        """
+        (tmp_path / "posts.csv").write_text(
+            "post_id,post_date,title,subtitle,audience,podcast_url\n"
+            "111,2024-03-15T08:30:00.000Z,Hello,A subtitle,only_paid,"
+            "https://example.com/p/111.mp3\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "111.hello.html").write_text(
+            "<html><body><p>hi</p></body></html>",
+            encoding="utf-8",
+        )
+        result = SubstackIngestor().ingest(tmp_path)
+        assert len(result.fragments) == 1
+        frontmatter = result.fragments[0].metadata["frontmatter"]
+        assert frontmatter["subtitle"] == "A subtitle"
+        assert frontmatter["audience"] == "only_paid"
+        assert frontmatter["podcast_url"] == "https://example.com/p/111.mp3"
+        assert frontmatter["substack_post_id"] == "111"
 
     def test_html_body_converted_to_markdown(self, tmp_path: Path) -> None:
         _write_substack_export(tmp_path)

--- a/creek-tools/tests/test_ingest_substack.py
+++ b/creek-tools/tests/test_ingest_substack.py
@@ -1,0 +1,440 @@
+"""Tests for creek.ingest.substack — Substack-aware ingestor (FEAT-024).
+
+Covers Substack-export detection, ``posts.csv`` metadata extraction,
+publication-date preservation via ``authored_at``, source taxonomy
+(``platform = SUBSTACK`` / ``kind = WRITING``), folder routing under
+``01-Fragments/Writing/Substack/``, idempotent re-ingestion, and the
+deliberate skip of subscriber-engagement CSVs (PII).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.ingest.base import assemble_ingested_fragment
+from creek.ingest.substack import (
+    SUBSCRIBER_CSV_SUFFIXES,
+    SubstackIngestor,
+    _extract_post_id,
+    _parse_posts_csv,
+    is_substack_export,
+)
+from creek.models import SourceKind, SourcePlatform
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---- Sample data ----
+
+_POSTS_CSV = (
+    "post_id,post_date,title,subtitle,type,audience,is_published\n"
+    "111,2024-03-15T08:30:00.000Z,Hello World,A first post,newsletter,everyone,true\n"
+    "222,2025-01-02T12:00:00.000Z,Second Essay,On craft,newsletter,only_paid,true\n"
+    "333,2026-04-01T09:00:00.000Z,Latest,About spring,newsletter,everyone,true\n"
+)
+
+_HTML_TEMPLATE = (
+    "<html><body><h1>{title}</h1>"
+    "<p>This is the body of the {title} essay.</p></body></html>"
+)
+
+
+def _write_substack_export(tmp_path: Path) -> Path:
+    """Create a faithful (minimal) Substack export at *tmp_path*.
+
+    Returns the export root.
+    """
+    (tmp_path / "posts.csv").write_text(_POSTS_CSV, encoding="utf-8")
+    posts_dir = tmp_path / "posts"
+    posts_dir.mkdir()
+    for post_id, slug, title in [
+        ("111", "hello-world", "Hello World"),
+        ("222", "second-essay", "Second Essay"),
+        ("333", "latest", "Latest"),
+    ]:
+        (posts_dir / f"{post_id}.{slug}.html").write_text(
+            _HTML_TEMPLATE.format(title=title),
+            encoding="utf-8",
+        )
+    # Subscriber-engagement files that MUST be ignored (PII).
+    (tmp_path / "email_list.csv").write_text(
+        "email\nuser@example.com\n",
+        encoding="utf-8",
+    )
+    (posts_dir / "111.hello-world.delivers.csv").write_text(
+        "email,delivered\nuser@example.com,true\n",
+        encoding="utf-8",
+    )
+    (posts_dir / "111.hello-world.opens.csv").write_text(
+        "email,opened\nuser@example.com,true\n",
+        encoding="utf-8",
+    )
+    return tmp_path
+
+
+# ---- Detection ----
+
+
+class TestIsSubstackExport:
+    """Auto-detection of Substack export directories."""
+
+    def test_detects_directory_with_posts_csv_and_html(self, tmp_path: Path) -> None:
+        _write_substack_export(tmp_path)
+        assert is_substack_export(tmp_path) is True
+
+    def test_rejects_directory_without_posts_csv(self, tmp_path: Path) -> None:
+        (tmp_path / "foo.html").write_text("<p>x</p>", encoding="utf-8")
+        assert is_substack_export(tmp_path) is False
+
+    def test_rejects_directory_without_html_files(self, tmp_path: Path) -> None:
+        (tmp_path / "posts.csv").write_text(_POSTS_CSV, encoding="utf-8")
+        assert is_substack_export(tmp_path) is False
+
+    def test_rejects_nonexistent_path(self, tmp_path: Path) -> None:
+        assert is_substack_export(tmp_path / "nope") is False
+
+    def test_rejects_file_path(self, tmp_path: Path) -> None:
+        target = tmp_path / "posts.csv"
+        target.write_text(_POSTS_CSV, encoding="utf-8")
+        assert is_substack_export(target) is False
+
+
+# ---- posts.csv parsing ----
+
+
+class TestParsePostsCsv:
+    """Parsing of the Substack ``posts.csv`` metadata sidecar."""
+
+    def test_parses_rows_into_post_id_map(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "posts.csv"
+        csv_path.write_text(_POSTS_CSV, encoding="utf-8")
+        result = _parse_posts_csv(csv_path)
+        assert set(result) == {"111", "222", "333"}
+        assert result["111"]["title"] == "Hello World"
+        assert result["222"]["audience"] == "only_paid"
+        assert result["333"]["post_date"].startswith("2026-04-01")
+
+    def test_missing_file_returns_empty_dict(self, tmp_path: Path) -> None:
+        assert _parse_posts_csv(tmp_path / "missing.csv") == {}
+
+    def test_rows_without_post_id_are_skipped(self, tmp_path: Path) -> None:
+        csv_path = tmp_path / "posts.csv"
+        csv_path.write_text(
+            "post_id,title\n,Has no id\n42,Has id\n",
+            encoding="utf-8",
+        )
+        result = _parse_posts_csv(csv_path)
+        assert set(result) == {"42"}
+
+
+# ---- File-name parsing ----
+
+
+class TestExtractPostId:
+    """Mapping ``<id>.<slug>.html`` filenames back to their post ID."""
+
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("111.hello-world.html", "111"),
+            ("222.second-essay.html", "222"),
+            ("9999999.long-post-slug.html", "9999999"),
+            ("42.foo.bar.html", "42"),
+        ],
+    )
+    def test_extracts_leading_numeric_component(
+        self,
+        filename: str,
+        expected: str,
+    ) -> None:
+        assert _extract_post_id(filename) == expected
+
+    @pytest.mark.parametrize(
+        "filename",
+        ["welcome.html", "no-id.html", ".html", ""],
+    )
+    def test_returns_none_for_unparseable_filenames(self, filename: str) -> None:
+        assert _extract_post_id(filename) is None
+
+
+# ---- Subscriber-CSV safety ----
+
+
+class TestSubscriberCsvSkip:
+    """PII-bearing engagement CSVs must never produce a fragment."""
+
+    def test_constants_cover_all_substack_subscriber_files(self) -> None:
+        assert ".delivers.csv" in SUBSCRIBER_CSV_SUFFIXES
+        assert ".opens.csv" in SUBSCRIBER_CSV_SUFFIXES
+
+    def test_ingestor_does_not_emit_fragments_for_engagement_csvs(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        _write_substack_export(tmp_path)
+        result = SubstackIngestor().ingest(tmp_path)
+        emitted_paths = [frag.source_path for frag in result.fragments]
+        assert not any("delivers.csv" in p for p in emitted_paths)
+        assert not any("opens.csv" in p for p in emitted_paths)
+        assert not any("email_list.csv" in p for p in emitted_paths)
+
+
+# ---- End-to-end ingestion ----
+
+
+class TestSubstackIngestion:
+    """Whole-export ingestion: metadata, dates, folder routing, taxonomy."""
+
+    def test_emits_one_fragment_per_html_post(self, tmp_path: Path) -> None:
+        _write_substack_export(tmp_path)
+        result = SubstackIngestor().ingest(tmp_path)
+        assert len(result.fragments) == 3
+        assert not result.errors
+
+    def test_authored_at_matches_posts_csv_publish_date(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        _write_substack_export(tmp_path)
+        result = SubstackIngestor().ingest(tmp_path)
+        by_id: dict[str, str] = {}
+        for parsed in result.fragments:
+            assembled = assemble_ingested_fragment(parsed)
+            authored = assembled.fragment.authored_at
+            assert authored is not None, "Substack fragments must carry authored_at"
+            by_id[assembled.fragment.title] = authored.date().isoformat()
+        assert by_id["Hello World"] == "2024-03-15"
+        assert by_id["Second Essay"] == "2025-01-02"
+        assert by_id["Latest"] == "2026-04-01"
+
+    def test_source_platform_and_kind(self, tmp_path: Path) -> None:
+        _write_substack_export(tmp_path)
+        result = SubstackIngestor().ingest(tmp_path)
+        for parsed in result.fragments:
+            assembled = assemble_ingested_fragment(parsed)
+            assert assembled.fragment.source.platform == SourcePlatform.SUBSTACK
+            assert assembled.fragment.source.kind == SourceKind.WRITING
+
+    def test_title_pulled_from_posts_csv(self, tmp_path: Path) -> None:
+        _write_substack_export(tmp_path)
+        result = SubstackIngestor().ingest(tmp_path)
+        titles = sorted(
+            assemble_ingested_fragment(p).fragment.title for p in result.fragments
+        )
+        assert titles == ["Hello World", "Latest", "Second Essay"]
+
+    def test_html_body_converted_to_markdown(self, tmp_path: Path) -> None:
+        _write_substack_export(tmp_path)
+        result = SubstackIngestor().ingest(tmp_path)
+        for parsed in result.fragments:
+            assembled = assemble_ingested_fragment(parsed)
+            # Markdownify renders the H1 as an ATX heading.
+            assert assembled.body.lstrip().startswith("#")
+
+    def test_html_without_csv_row_falls_back_to_mtime(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # Export with a stranded HTML — no matching posts.csv row.
+        (tmp_path / "posts.csv").write_text(
+            "post_id,post_date,title\n111,2024-03-15T00:00:00.000Z,Hello\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "111.hello.html").write_text(
+            "<html><body><p>hi</p></body></html>",
+            encoding="utf-8",
+        )
+        stranded = tmp_path / "999.stranded.html"
+        stranded.write_text(
+            "<html><body><p>orphan</p></body></html>",
+            encoding="utf-8",
+        )
+        result = SubstackIngestor().ingest(tmp_path)
+        assert len(result.fragments) == 2
+        stranded_frags = [f for f in result.fragments if f.source_path == str(stranded)]
+        assert len(stranded_frags) == 1
+        assembled = assemble_ingested_fragment(stranded_frags[0])
+        # No authored date available → field is None, honest answer.
+        assert assembled.fragment.authored_at is None
+
+
+# ---- Idempotency ----
+
+
+class TestIdempotentReIngest:
+    """Re-running SubstackIngestor against the same export is a no-op."""
+
+    def test_fragment_ids_stable_across_runs(self, tmp_path: Path) -> None:
+        _write_substack_export(tmp_path)
+        first = SubstackIngestor().ingest(tmp_path)
+        second = SubstackIngestor().ingest(tmp_path)
+        first_ids = sorted(
+            assemble_ingested_fragment(p).fragment.id for p in first.fragments
+        )
+        second_ids = sorted(
+            assemble_ingested_fragment(p).fragment.id for p in second.fragments
+        )
+        assert first_ids == second_ids
+
+
+# ---- Folder routing (writer-side) ----
+
+
+class TestFolderRouting:
+    """Substack fragments must land under ``01-Fragments/Writing/Substack/``."""
+
+    def test_writer_routes_substack_to_writing_substack(self, tmp_path: Path) -> None:
+        from creek.vault.writer import _PLATFORM_SUBFOLDER
+
+        assert _PLATFORM_SUBFOLDER[SourcePlatform.SUBSTACK] == "Writing/Substack"
+
+    def test_end_to_end_write_lands_in_writing_substack(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from creek.vault.writer import VaultWriter
+
+        # Minimal vault scaffold.
+        vault = tmp_path / "vault"
+        (vault / "00-Creek-Meta" / "Processing-Log").mkdir(parents=True)
+        (vault / "01-Fragments").mkdir(parents=True)
+
+        export = tmp_path / "export"
+        export.mkdir()
+        _write_substack_export(export)
+
+        result = SubstackIngestor().ingest(export)
+        writer = VaultWriter(vault_path=vault)
+        for parsed in result.fragments:
+            assembled = assemble_ingested_fragment(parsed)
+            written = writer.write_fragment(assembled.fragment, body=assembled.body)
+            assert "01-Fragments/Writing/Substack" in str(written)
+
+    def test_registry_exposes_substack(self) -> None:
+        from creek.ingest import INGESTOR_REGISTRY
+
+        assert "substack" in INGESTOR_REGISTRY
+        assert INGESTOR_REGISTRY["substack"] is SubstackIngestor
+
+    def test_document_ingestor_defers_to_substack(self, tmp_path: Path) -> None:
+        """``DocumentIngestor`` must yield no HTML fragments from a Substack export.
+
+        Without this guard, ``creek process`` (which runs every registered
+        ingestor against the source) would double-emit each essay: once
+        as an opaque HTML document and again as a publication-dated
+        Substack post.
+        """
+        from creek.ingest.documents import DocumentIngestor
+
+        _write_substack_export(tmp_path)
+        docs = DocumentIngestor().discover(tmp_path)
+        assert docs == []
+
+
+# ---- Discover handling ----
+
+
+class TestDiscoverEdgeCases:
+    """Discover behaviour outside the happy path."""
+
+    def test_nonexistent_path_returns_empty(self, tmp_path: Path) -> None:
+        result = SubstackIngestor().ingest(tmp_path / "missing")
+        assert result.fragments == []
+
+    def test_file_input_is_rejected_gracefully(self, tmp_path: Path) -> None:
+        # A SubstackIngestor only makes sense against a directory; a
+        # single HTML file lacks the posts.csv sidecar, so nothing is
+        # emitted and no exception escapes.
+        sole = tmp_path / "sole.html"
+        sole.write_text("<html><body><p>solo</p></body></html>", encoding="utf-8")
+        result = SubstackIngestor().ingest(sole)
+        assert result.fragments == []
+
+    def test_export_without_posts_csv_emits_no_fragments(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        (tmp_path / "111.foo.html").write_text(
+            "<html><body><p>hi</p></body></html>",
+            encoding="utf-8",
+        )
+        result = SubstackIngestor().ingest(tmp_path)
+        assert result.fragments == []
+
+    def test_html_files_without_post_id_prefix_are_skipped(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """``index.html`` and other unprefixed HTML files are dropped silently.
+
+        Substack exports sometimes ship a top-level ``index.html`` table
+        of contents; without a leading post-ID component there is no
+        join key into ``posts.csv``, so emitting a fragment would just
+        create a stub with no metadata. Honest answer: skip it.
+        """
+        (tmp_path / "posts.csv").write_text(
+            "post_id,post_date,title\n111,2024-03-15T00:00:00.000Z,Hi\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "111.real-post.html").write_text(
+            "<html><body><p>hi</p></body></html>",
+            encoding="utf-8",
+        )
+        (tmp_path / "index.html").write_text(
+            "<html><body><p>toc</p></body></html>",
+            encoding="utf-8",
+        )
+        result = SubstackIngestor().ingest(tmp_path)
+        assert len(result.fragments) == 1
+        assert "111.real-post.html" in result.fragments[0].source_path
+
+    def test_unparseable_post_date_falls_back_to_mtime(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A malformed ``post_date`` in ``posts.csv`` is not allowed to crash ingest.
+
+        Substack's export schema has drifted in the past; the ingestor
+        should warn and fall back to filesystem mtime rather than dump
+        a stack trace and lose every other post in the batch.
+        """
+        (tmp_path / "posts.csv").write_text(
+            "post_id,post_date,title\n111,not-a-real-date,Broken Date\n",
+            encoding="utf-8",
+        )
+        (tmp_path / "111.broken.html").write_text(
+            "<html><body><p>hi</p></body></html>",
+            encoding="utf-8",
+        )
+        result = SubstackIngestor().ingest(tmp_path)
+        assert len(result.fragments) == 1
+        assembled = assemble_ingested_fragment(result.fragments[0])
+        assert assembled.fragment.authored_at is None
+
+
+class TestSubscriberCsvHelpers:
+    """Direct unit tests for the PII-filter helper."""
+
+    def test_email_list_csv_is_recognised(self, tmp_path: Path) -> None:
+        from creek.ingest.substack import _is_subscriber_csv
+
+        path = tmp_path / "email_list.csv"
+        path.write_text("email\n", encoding="utf-8")
+        assert _is_subscriber_csv(path) is True
+
+    def test_delivers_csv_is_recognised(self, tmp_path: Path) -> None:
+        from creek.ingest.substack import _is_subscriber_csv
+
+        path = tmp_path / "111.foo.delivers.csv"
+        path.write_text("email\n", encoding="utf-8")
+        assert _is_subscriber_csv(path) is True
+
+    def test_posts_csv_is_not_a_subscriber_csv(self, tmp_path: Path) -> None:
+        from creek.ingest.substack import _is_subscriber_csv
+
+        path = tmp_path / "posts.csv"
+        path.write_text("post_id\n", encoding="utf-8")
+        assert _is_subscriber_csv(path) is False

--- a/creek-tools/tests/test_models.py
+++ b/creek-tools/tests/test_models.py
@@ -302,12 +302,12 @@ class TestFragmentSource:
         assert dump["platform"] == "journal"
 
     def test_kind_defaults_to_unclassified(self) -> None:
-        """FragmentSource.kind defaults to UNCLASSIFIED (FEAT-024)."""
+        """FragmentSource.kind defaults to UNCLASSIFIED."""
         source = FragmentSource(platform=SourcePlatform.JOURNAL)
         assert source.kind == SourceKind.UNCLASSIFIED.value
 
     def test_kind_writing_roundtrips(self) -> None:
-        """``kind = WRITING`` is preserved through model_dump (FEAT-024)."""
+        """``kind = WRITING`` is preserved through model_dump."""
         source = FragmentSource(
             platform=SourcePlatform.SUBSTACK,
             kind=SourceKind.WRITING,
@@ -460,7 +460,7 @@ class TestFragment:
         assert frag.praxis_potential == "explicit"
 
     def test_authored_at_defaults_to_none(self) -> None:
-        """Fragment.authored_at is ``None`` by default (FEAT-024).
+        """Fragment.authored_at is ``None`` by default.
 
         ``None`` is the honest answer when no source date was extracted
         — fragments should never guess an authored date.
@@ -473,7 +473,7 @@ class TestFragment:
         assert frag.authored_at is None
 
     def test_authored_at_round_trips_through_dump(self) -> None:
-        """``authored_at`` survives model_dump → model_validate (FEAT-024)."""
+        """``authored_at`` survives model_dump → model_validate."""
         from datetime import UTC, datetime
 
         when = datetime(2024, 3, 15, 8, 30, tzinfo=UTC)

--- a/creek-tools/tests/test_models.py
+++ b/creek-tools/tests/test_models.py
@@ -27,6 +27,7 @@ from creek.models import (
     PraxisStatus,
     PraxisType,
     ReviewInterval,
+    SourceKind,
     SourcePlatform,
     Thread,
     ThreadStatus,
@@ -255,6 +256,7 @@ class TestSourcePlatformEnum:
             "image_ocr",
             "spreadsheet",
             "presentation",
+            "substack",
             "other",
         ]
         actual = [s.value for s in SourcePlatform]
@@ -298,6 +300,21 @@ class TestFragmentSource:
         dump = source.model_dump()
         assert isinstance(dump["platform"], str)
         assert dump["platform"] == "journal"
+
+    def test_kind_defaults_to_unclassified(self) -> None:
+        """FragmentSource.kind defaults to UNCLASSIFIED (FEAT-024)."""
+        source = FragmentSource(platform=SourcePlatform.JOURNAL)
+        assert source.kind == SourceKind.UNCLASSIFIED.value
+
+    def test_kind_writing_roundtrips(self) -> None:
+        """``kind = WRITING`` is preserved through model_dump (FEAT-024)."""
+        source = FragmentSource(
+            platform=SourcePlatform.SUBSTACK,
+            kind=SourceKind.WRITING,
+        )
+        dump = source.model_dump()
+        assert dump["kind"] == "writing"
+        assert dump["platform"] == "substack"
 
 
 class TestFrequencyClassification:
@@ -441,6 +458,38 @@ class TestFragment:
         assert frag.wavelength.phase == "peaking"
         assert frag.voice.voice_register == "analytical"
         assert frag.praxis_potential == "explicit"
+
+    def test_authored_at_defaults_to_none(self) -> None:
+        """Fragment.authored_at is ``None`` by default (FEAT-024).
+
+        ``None`` is the honest answer when no source date was extracted
+        — fragments should never guess an authored date.
+        """
+        frag = Fragment(
+            id="frag-000000000016",
+            title="No date",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+        )
+        assert frag.authored_at is None
+
+    def test_authored_at_round_trips_through_dump(self) -> None:
+        """``authored_at`` survives model_dump → model_validate (FEAT-024)."""
+        from datetime import UTC, datetime
+
+        when = datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+        frag = Fragment(
+            id="frag-000000000017",
+            title="Old essay",
+            source=FragmentSource(
+                platform=SourcePlatform.SUBSTACK,
+                kind=SourceKind.WRITING,
+            ),
+            authored_at=when,
+        )
+        dump = frag.model_dump(mode="json")
+        assert dump["authored_at"].startswith("2024-03-15")
+        roundtrip = Fragment.model_validate(dump)
+        assert roundtrip.authored_at == when
 
     def test_synthetic_id_is_unique(self) -> None:
         """synthetic_fragment_id() returns distinct, frag-prefixed values."""

--- a/creek-tools/tests/test_wavelength_tracker.py
+++ b/creek-tools/tests/test_wavelength_tracker.py
@@ -1040,7 +1040,7 @@ class TestDataclasses:
         assert trend.flagged_frequencies == []
 
 
-# ---- FEAT-024 authored_at fallback ----
+# ---- authored_at fallback ----
 
 
 class TestAuthoredAtBucketing:

--- a/creek-tools/tests/test_wavelength_tracker.py
+++ b/creek-tools/tests/test_wavelength_tracker.py
@@ -1038,3 +1038,58 @@ class TestDataclasses:
         trend = DosageTrend()
         assert trend.frequency_trends == {}
         assert trend.flagged_frequencies == []
+
+
+# ---- FEAT-024 authored_at fallback ----
+
+
+class TestAuthoredAtBucketing:
+    """``authored_at`` takes precedence over ``created`` for time bucketing.
+
+    Without this, a Substack export ingested today would show up in
+    *this week's* wavelength snapshot even when every essay was
+    published years ago.
+    """
+
+    def test_fragment_with_authored_at_is_bucketed_by_authored_date(
+        self,
+        tracker: WavelengthTracker,
+    ) -> None:
+        """A 2024-authored fragment ingested today must miss the current window."""
+        from datetime import UTC, timedelta
+
+        from creek.generate.wavelength import _fragment_effective_date
+
+        ingested_today = datetime.now(tz=UTC)
+        old_authored = datetime(2024, 3, 15, tzinfo=UTC)
+        frag = _make_fragment(
+            frag_id="frag-old",
+            created=ingested_today,
+            phase=Phase.RISING,
+            dosage=Dosage.MEDICINE,
+            frequency=Frequency.F1,
+        )
+        frag = frag.model_copy(update={"authored_at": old_authored})
+        assert _fragment_effective_date(frag) == old_authored.date()
+
+        # A current-week window should NOT contain the 2024-authored fragment.
+        snapshot = tracker.analyze_period(
+            [frag],
+            ingested_today.date() - timedelta(days=6),
+            ingested_today.date(),
+        )
+        assert snapshot.fragment_count == 0
+
+    def test_fragment_without_authored_at_falls_back_to_created(self) -> None:
+        """When ``authored_at`` is ``None`` the bucket date is ``created``."""
+        from datetime import UTC
+
+        from creek.generate.wavelength import _fragment_effective_date
+
+        frag = _make_fragment(
+            frag_id="frag-fresh",
+            created=datetime(2026, 5, 23, tzinfo=UTC),
+        )
+        # No authored_at set → falls back to created.
+        assert frag.authored_at is None
+        assert _fragment_effective_date(frag) == frag.created.date()


### PR DESCRIPTION
## Summary

Substack newsletter exports now ingest as a first-class source instead of getting flattened into opaque HTML. The ingestor:

- **Parses `posts.csv`** and joins each per-post HTML back to its real publication date, title, subtitle, and audience.
- **Preserves the source's own date** in a new `Fragment.authored_at` field (separate from `ingested`). The State report / wavelength tracker now bucket fragments by `authored_at` when present, so a 2024 essay no longer claims to be part of *this week's* wavelength.
- **Routes to `01-Fragments/Writing/Substack/`** via `platform=SUBSTACK` + `kind=WRITING` (new `SourceKind` taxonomy). Published essays no longer live in `Unsorted/` next to chat exports.
- **Skips subscriber CSVs** explicitly (`email_list*.csv`, `*.delivers.csv`, `*.opens.csv`) — subscriber PII is excluded by suffix and the rule is tested.
- **Re-ingest is idempotent**: fragment IDs derive from `(source_path, authored_at, content)`, so identical input produces identical IDs and the writer's per-directory index skips duplicates.
- **DocumentIngestor defers** when it sees a Substack export, so `creek process` (which runs every registered ingestor) doesn't double-emit each essay.

`SourceKind` ships with `WRITING` / `UNCLASSIFIED` — only what FEAT-024 needs. The enum is expected to grow as other ingestors adopt the `authored_at` contract under FEAT-025.

## Test plan

- [x] `pytest tests/test_ingest_substack.py` — 37 tests covering detection, `posts.csv` parsing, post-ID extraction, PII-CSV skip, end-to-end ingestion (authored_at, platform/kind, title, body conversion, stranded HTML fallback), idempotency, folder routing, registry, document-ingestor defer, and edge cases.
- [x] `tests/test_models.py` — `Fragment.authored_at` defaults to `None`, round-trips through `model_dump` / `model_validate`; `FragmentSource.kind` defaults to `UNCLASSIFIED`, `WRITING` round-trips.
- [x] `tests/test_wavelength_tracker.py::TestAuthoredAtBucketing` — a 2024-authored fragment ingested today is NOT counted in the current-week wavelength snapshot; fragments without `authored_at` fall back to `created`.
- [x] `./scripts/check-all.sh`: all 12 gates green (lint, format, mypy strict, pylint, bandit, complexity, refurb, tryceratops, 3695 unit tests, coverage 93.52% aggregate / 96.58% on `creek/ingest/substack.py`, per-file coverage gate, state-budget).

## Out of scope

- Cross-ingestor backfill of `authored_at` (covered by FEAT-025's `creek ingest --refresh-dates`).
- Other blog platforms (Medium, Ghost, WordPress) — follow-ups once Substack's path is established.
- Heuristic re-routing of fragments previously ingested by `DocumentIngestor` from a Substack export — would require either a manual purge or the FEAT-025 refresh helper.

Closes #262

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdCspY4tFeqaxJWQgwysdD)_