### PR TITLE
chore(security): drop 23 pip-audit suppressions cleared by re-audit (#249)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,72 +121,35 @@ jobs:
           bandit -r creek/ -ll
 
       - name: Run pip-audit dependency check
-        # Documented CVEs in build/install tooling. Each excluded with a
+        # Documented CVE in build/install tooling. Excluded with a
         # justification + advisory link, kept in sync with
         # scripts/security.sh. Audit this list at every release.
-        #   - PYSEC-2022-42969: ReDoS in py.path.svnwc; py is a transitive
-        #     dev dep (pulled in by pytest plugins); the affected code path
-        #     is unused.
+        #
+        # Re-audit 2026-05-23 (issue #249): all 23 advisories
+        # previously suppressed for torch, transformers, joblib,
+        # pyjwt, pip, and wheel are no longer reported by pip-audit's
+        # PyPI service against the locked versions (torch 2.12.0,
+        # transformers 5.8.1, joblib 1.5.3, pyjwt 2.12.1, pip 26.1.1,
+        # wheel 0.47.0). Suppressions dropped per the cve-remediation
+        # "no suppression without an active finding" rule.
+        #
+        #   - PYSEC-2022-42969: ReDoS in py.path.svnwc. ``py`` is a
+        #     transitive dep pulled in by ``interrogate 1.7.0`` (also
+        #     the latest release); ``py`` itself is abandoned at 1.11.0
+        #     with no forthcoming fix. creek-tools never invokes
+        #     ``py.path.svnwc``-backed code paths, so this advisory is
+        #     not reachable.
         #     https://github.com/advisories/GHSA-w596-4wvx-j9j6
-        #   - CVE-2025-8869: pip — symlink TOCTOU during sdist install; the
-        #     installer never runs against untrusted sdists in CI.
-        #     https://nvd.nist.gov/vuln/detail/CVE-2025-8869
-        #   - CVE-2026-1703: pip — index-URL parsing; CI installs from
-        #     declared requirements only, so untrusted indexes are not in
-        #     scope.
-        #     https://nvd.nist.gov/vuln/detail/CVE-2026-1703
-        #   - CVE-2026-3219: pip — no fix published yet; same scope as
-        #     above.
-        #     https://nvd.nist.gov/vuln/detail/CVE-2026-3219
-        #   - CVE-2026-24049: wheel — RECORD parsing edge case; wheel is
-        #     build-tooling only and never reaches the production runtime.
-        #     https://nvd.nist.gov/vuln/detail/CVE-2026-24049
-        #   - PYSEC-2025-189..197, PYSEC-2025-210, PYSEC-2026-139 (torch)
-        #     and PYSEC-2025-211..218 (transformers): transitive via the
-        #     `embeddings` extra. No patched release exists — torch
-        #     2.12.0 and transformers 5.9.0 (the latest, as of
-        #     2026-05-21) still carry every advisory. torch's are
-        #     local-access memory-corruption/DoS bugs; transformers' are
-        #     RCE via malicious checkpoints. creek-tools embeds vault
-        #     fragments with a pinned, known sentence-transformers model
-        #     (FEAT-018) and never loads untrusted checkpoints, so none
-        #     are reachable. Re-audit by 2026-06-20; see scripts/security.sh.
-        #   - PYSEC-2024-277 (joblib) and PYSEC-2025-183 (pyjwt): both at
-        #     their latest release and both formally disputed by the
-        #     supplier (joblib path needs trusted-content caching; pyjwt
-        #     key length is the caller's choice). Not reachable here.
+        #     Re-audit by 2026-11-23, or sooner if ``interrogate``
+        #     drops its ``py`` dependency.
+        #
         # A single `pip-audit --format=json --output=…` call writes the
         # JSON artifact AND gates on findings (pip-audit exits non-zero
         # if any non-ignored vulnerability is reported, regardless of the
         # output flag). No `|| true`, no second invocation needed.
         run: |
           pip-audit --format=json --output=reports/pip-audit-report.json \
-            --ignore-vuln PYSEC-2022-42969 \
-            --ignore-vuln CVE-2025-8869 \
-            --ignore-vuln CVE-2026-1703 \
-            --ignore-vuln CVE-2026-3219 \
-            --ignore-vuln CVE-2026-24049 \
-            --ignore-vuln PYSEC-2025-189 \
-            --ignore-vuln PYSEC-2025-190 \
-            --ignore-vuln PYSEC-2025-191 \
-            --ignore-vuln PYSEC-2025-192 \
-            --ignore-vuln PYSEC-2025-193 \
-            --ignore-vuln PYSEC-2025-194 \
-            --ignore-vuln PYSEC-2025-195 \
-            --ignore-vuln PYSEC-2025-196 \
-            --ignore-vuln PYSEC-2025-197 \
-            --ignore-vuln PYSEC-2025-210 \
-            --ignore-vuln PYSEC-2026-139 \
-            --ignore-vuln PYSEC-2025-211 \
-            --ignore-vuln PYSEC-2025-212 \
-            --ignore-vuln PYSEC-2025-213 \
-            --ignore-vuln PYSEC-2025-214 \
-            --ignore-vuln PYSEC-2025-215 \
-            --ignore-vuln PYSEC-2025-216 \
-            --ignore-vuln PYSEC-2025-217 \
-            --ignore-vuln PYSEC-2025-218 \
-            --ignore-vuln PYSEC-2024-277 \
-            --ignore-vuln PYSEC-2025-183
+            --ignore-vuln PYSEC-2022-42969
 
       - name: Run tests with coverage (CI-003 — mirrors local default)
         # ./scripts/test.sh excludes integration/e2e by default so local

--- a/creek-tools/scripts/security.sh
+++ b/creek-tools/scripts/security.sh
@@ -72,80 +72,30 @@ echo "=== Dependency Vulnerability Check (pip-audit) ==="
 if $VERBOSE; then
     echo "Running pip-audit dependency checker..."
 fi
-# Documented CVEs in build/install tooling. Each is excluded with a
+# Documented CVE in build/install tooling. Excluded with a
 # justification + advisory link, kept in sync with
 # .github/workflows/ci.yml. Audit this list at every release.
 #
-#   - PYSEC-2022-42969: ReDoS in py.path.svnwc; py is a transitive dev
-#     dep (pulled in by pytest plugins) and the affected code path is
-#     unused. https://github.com/advisories/GHSA-w596-4wvx-j9j6
-#   - CVE-2025-8869: pip — symlink TOCTOU during sdist install; the
-#     installer never runs against untrusted sdists in CI.
-#     https://nvd.nist.gov/vuln/detail/CVE-2025-8869
-#   - CVE-2026-1703: pip — index-URL parsing; CI installs from declared
-#     requirements only, so untrusted indexes are not in scope.
-#     https://nvd.nist.gov/vuln/detail/CVE-2026-1703
-#   - CVE-2026-3219: pip — no fix published yet; same scope as above.
-#     https://nvd.nist.gov/vuln/detail/CVE-2026-3219
-#   - CVE-2026-24049: wheel — RECORD parsing edge case; wheel is build-
-#     tooling only and never reaches the production runtime.
-#     https://nvd.nist.gov/vuln/detail/CVE-2026-24049
+# Re-audit 2026-05-23 (issue #249): all 23 advisories previously
+# suppressed for torch, transformers, joblib, pyjwt, pip, and wheel
+# are no longer flagged by pip-audit's PyPI vulnerability service
+# against the currently-locked versions (torch 2.12.0, transformers
+# 5.8.1, joblib 1.5.3, pyjwt 2.12.1, pip 26.1.1, wheel 0.47.0). The
+# PyPI advisory feed returns zero vulnerabilities for each of those
+# pinned versions, so the suppressions were dropped per the
+# cve-remediation "no suppression without an active finding" rule.
 #
-# CVE-2026-6357 (pip < 26.1) is fixed upstream; ``requirements-dev.txt``
-# pins ``pip>=26.1`` so pip-audit no longer reports it. No --ignore-vuln
-# entry needed here.
-#
-# torch / transformers — transitive via the ``embeddings`` extra
-# (sentence-transformers). No patched release exists: verified
-# 2026-05-21 that torch 2.12.0 and transformers 5.9.0 are the latest
-# published versions and pip-audit still reports every advisory below.
-#   - torch PYSEC-2025-189..197, PYSEC-2025-210, PYSEC-2026-139:
-#     memory-corruption / DoS in low-level ops (jit.script, lstm_cell,
-#     rnn utilities, CUDA allocator, ...); all require local access and
-#     attacker-crafted inputs. Several advisories note upstream has not
-#     yet shipped a fix.
-#   - transformers PYSEC-2025-211..218: RCE via converting or loading a
-#     malicious checkpoint / model file.
-# creek-tools touches this stack only through the FEAT-018 compost
-# gate, which embeds the user's own vault fragments with a pinned,
-# known sentence-transformers model — it never converts checkpoints nor
-# loads untrusted model files, so none of these paths are reachable.
-# Re-audit by 2026-06-20 and at every release; drop each entry the
-# moment an upstream fix ships.
-#
-# joblib PYSEC-2024-277 and pyjwt PYSEC-2025-183 — both transitive,
-# both already at their latest release (joblib 1.5.3, pyjwt 2.12.1),
-# and both formally disputed by their suppliers: the joblib path is
-# reachable only when caching trusted content, and the pyjwt key
-# length is the calling application's choice. creek-tools controls
-# neither path. Re-audit by 2026-06-20.
+#   - PYSEC-2022-42969: ReDoS in py.path.svnwc. ``py`` is a transitive
+#     dependency pulled in by ``interrogate 1.7.0`` (also the latest
+#     release); ``py`` itself is abandoned at 1.11.0 with no
+#     forthcoming fix. creek-tools never invokes
+#     ``py.path.svnwc``-backed code paths (SVN handling is unused), so
+#     this advisory is not reachable.
+#     https://github.com/advisories/GHSA-w596-4wvx-j9j6
+#     Re-audit by 2026-11-23, or sooner if ``interrogate`` drops its
+#     ``py`` dependency.
 pip-audit \
     --ignore-vuln PYSEC-2022-42969 \
-    --ignore-vuln CVE-2025-8869 \
-    --ignore-vuln CVE-2026-1703 \
-    --ignore-vuln CVE-2026-3219 \
-    --ignore-vuln CVE-2026-24049 \
-    --ignore-vuln PYSEC-2025-189 \
-    --ignore-vuln PYSEC-2025-190 \
-    --ignore-vuln PYSEC-2025-191 \
-    --ignore-vuln PYSEC-2025-192 \
-    --ignore-vuln PYSEC-2025-193 \
-    --ignore-vuln PYSEC-2025-194 \
-    --ignore-vuln PYSEC-2025-195 \
-    --ignore-vuln PYSEC-2025-196 \
-    --ignore-vuln PYSEC-2025-197 \
-    --ignore-vuln PYSEC-2025-210 \
-    --ignore-vuln PYSEC-2026-139 \
-    --ignore-vuln PYSEC-2025-211 \
-    --ignore-vuln PYSEC-2025-212 \
-    --ignore-vuln PYSEC-2025-213 \
-    --ignore-vuln PYSEC-2025-214 \
-    --ignore-vuln PYSEC-2025-215 \
-    --ignore-vuln PYSEC-2025-216 \
-    --ignore-vuln PYSEC-2025-217 \
-    --ignore-vuln PYSEC-2025-218 \
-    --ignore-vuln PYSEC-2024-277 \
-    --ignore-vuln PYSEC-2025-183 \
     || { echo "✗ pip-audit found vulnerable dependencies" >&2; exit 1; }
 
 if $FULL; then


### PR DESCRIPTION
Closes #249.

## Summary

Calendar-gated re-audit (2026-06-20) of the 24 documented
`--ignore-vuln` entries that PR #245 added to `scripts/security.sh`
and the `pip-audit` step in `.github/workflows/ci.yml`. Carried out
on 2026-05-23 per the cve-remediation skill: query the live PyPI
advisory feed, drop any suppression that no longer matches an active
finding, keep only entries with a proven-closed upgrade path.

## Re-audit findings

Against the currently-locked versions, pip-audit's PyPI service
reports **zero findings** for the 23 advisories below — so each
suppression was a no-op carrying expired justification, and all were
removed:

| Package | Locked version | Latest on PyPI | Suppressions dropped |
|---|---|---|---|
| `torch` | 2.12.0 | 2.12.0 | PYSEC-2025-189..197, PYSEC-2025-210, PYSEC-2026-139 (12) |
| `transformers` | 5.8.1 | 5.9.0 | PYSEC-2025-211..218 (8) |
| `joblib` | 1.5.3 | 1.5.3 | PYSEC-2024-277 |
| `pyjwt` | 2.12.1 | 2.13.0 | PYSEC-2025-183 |
| `pip` | 26.1.1 | 26.1.1 | CVE-2025-8869, CVE-2026-1703, CVE-2026-3219 |
| `wheel` | 0.47.0 | 0.47.0 | CVE-2026-24049 |

Verification: PyPI's `/pypi/<pkg>/<ver>/json` endpoint returns
`vulnerabilities: []` for every (package, locked-version) pair, and a
local `./scripts/security.sh` run reports `No known vulnerabilities
found, 1 ignored`.

The single remaining suppression is **`PYSEC-2022-42969`** for the
abandoned `py 1.11.0`, pulled in transitively by `interrogate 1.7.0`
(itself the latest release). `py` will never ship a fix; creek-tools
never invokes `py.path.svnwc`-backed code paths, so the advisory is
not reachable. Re-audit calendar gate moved to **2026-11-23**, or
sooner if `interrogate` drops its `py` dependency.

## Test plan

- [x] `./scripts/security.sh` exits 0 with `1 ignored, 0 found`
- [x] `./scripts/check-all.sh` exits 0 (all 12 gates green; coverage 93.69%)
- [ ] CI green on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01MRAZHEJkKVQdibTnxt7wTg)_