### PR TITLE
chore(compile): close FEAT-003 follow-ups (#212)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -979,7 +979,7 @@ def compile_(
     side-channel log under ``00-Creek-Meta/Processing-Log/`` rather
     than flattened into the synthesis page.
     """
-    from creek.compile.engine import TARGET_KINDS, _default_llm, compile_to_vault
+    from creek.compile.engine import TARGET_KINDS, compile_to_vault, default_llm
 
     if target_kind not in TARGET_KINDS:
         console.print(
@@ -997,7 +997,7 @@ def compile_(
         target_kind=kind,
         target_id=target_id,
         target_title=target_title,
-        llm=_default_llm(config.llm),
+        llm=default_llm(config.llm),
     )
     console.print(
         f"[bold green]Compiled {fragment_id} -> {written}[/bold green]",

--- a/creek-tools/creek/compile/engine.py
+++ b/creek-tools/creek/compile/engine.py
@@ -403,11 +403,36 @@ def _resolve_target_path(
     target_kind: CompileTargetKind,
     target_id: str,
 ) -> Path:
-    """Resolve the on-disk path for a compiled-layer target."""
+    """Resolve the on-disk path for a compiled-layer target.
+
+    Raises:
+        ValueError: If *target_id* resolves to a path outside the
+            compiled-layer subdirectory (e.g. ``"../escape"``). The
+            CLI passes ``target_id`` straight through from operator
+            input, so a one-line guard here prevents accidental
+            traversal regardless of upstream validation.
+    """
     subdir = _TARGET_DIRS[target_kind]
     target_dir = vault_path / subdir
     target_dir.mkdir(parents=True, exist_ok=True)
-    return target_dir / f"{target_id}.md"
+    candidate = (target_dir / f"{target_id}.md").resolve()
+    if candidate.parent != target_dir.resolve():
+        msg = f"target_id {target_id!r} escapes the compiled-layer directory"
+        raise ValueError(msg)
+    return candidate
+
+
+def default_llm(config: LLMConfig) -> CompileLLM:
+    """Return the default cloud LLM client for the CLI entry point.
+
+    Tests monkeypatch this hook to inject a deterministic stub. The
+    production path constructs an Anthropic client lazily so the import
+    cost (and the API-key check) stays out of the unit-test surface.
+    """
+    from creek.classify.llm import AnthropicProvider
+
+    provider = AnthropicProvider(config)
+    return provider.call
 
 
 def _load_existing_provenance(target_path: Path) -> list[ProvenanceEntry]:
@@ -442,16 +467,3 @@ def _append_paradox_log(vault_path: Path, entries: list[ParadoxLogEntry]) -> Non
         record = asdict(entry)
         record["timestamp"] = entry.timestamp.isoformat()
         log.append(record)
-
-
-def _default_llm(config: LLMConfig) -> CompileLLM:
-    """Return the default cloud LLM client for the CLI entry point.
-
-    Tests monkeypatch this hook to inject a deterministic stub. The
-    production path constructs an Anthropic client lazily so the import
-    cost (and the API-key check) stays out of the unit-test surface.
-    """
-    from creek.classify.llm import AnthropicProvider
-
-    provider = AnthropicProvider(config)
-    return provider.call

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -713,7 +713,12 @@ class CompiledPage(BaseModel):
 
     model_config = ConfigDict(use_enum_values=True)
 
-    type: str = "compiled_page"
+    type: Literal["compiled_page"] = "compiled_page"
+    """Discriminator field. Reserved for future ``Annotated[Union[...],
+    Field(discriminator="type")]`` dispatch when the compiled layer
+    grows beyond ``CompiledPage`` — pinning the literal here means
+    mypy will narrow correctly once the union exists.
+    """
     target_kind: CompileTargetKind
     target_id: str
     title: str

--- a/creek-tools/tests/test_compile.py
+++ b/creek-tools/tests/test_compile.py
@@ -467,7 +467,7 @@ def test_cli_compile_writes_thread_with_provenance(
     def fake_llm(_prompt: str) -> str:
         return response
 
-    monkeypatch.setattr("creek.compile.engine._default_llm", lambda _config: fake_llm)
+    monkeypatch.setattr("creek.compile.engine.default_llm", lambda _config: fake_llm)
     runner = CliRunner()
     result = runner.invoke(
         app,
@@ -780,6 +780,11 @@ def test_compile_fragments_skips_empty_claim_text() -> None:
     )
     assert "claim-001" not in result.page.body
     assert "claim-002" in result.page.body
+    # The engine filters empty-text claims out of the rendered body but
+    # keeps them in provenance (the filter key is ``id``, not ``text``);
+    # pin both halves of that contract so a future reorder is caught.
+    assert any(p.claim_id == "claim-001" for p in result.page.provenance)
+    assert any(p.claim_id == "claim-002" for p in result.page.provenance)
 
 
 def test_compile_to_vault_skips_extra_fragments_in_directory(vault: Path) -> None:
@@ -803,6 +808,42 @@ def test_compile_to_vault_skips_extra_fragments_in_directory(vault: Path) -> Non
         llm=llm,
     )
     assert "extra body" not in prompts[0]
+
+
+def test_resolve_target_path_rejects_escaping_target_id(vault: Path) -> None:
+    """``target_id`` that resolves outside the compiled-layer dir is rejected.
+
+    The CLI passes ``target_id`` straight through from operator input;
+    a value like ``"../escape"`` would land the synthesis page outside
+    the intended ``02-Threads/Active/`` directory. The guard fires
+    before any write touches disk.
+    """
+    from creek.compile import engine as engine_module
+
+    with pytest.raises(ValueError, match="escapes the compiled-layer directory"):
+        engine_module._resolve_target_path(vault, "thread", "../escape")
+    # No file should have been written under the target directory.
+    assert not (vault / "02-Threads" / "Active" / "..escape.md").exists()
+    assert not (vault / "02-Threads" / "escape.md").exists()
+
+
+def test_compile_to_vault_rejects_escaping_target_id(vault: Path) -> None:
+    """The high-level entry point surfaces the escape guard's ValueError."""
+    frag = _make_fragment(frag_id="frag-aaa")
+    _write_fragment_to_vault(vault, frag, "body")
+    response = _llm_response(
+        claims=[{"id": "claim-001", "text": "X", "fragment_ids": ["frag-aaa"]}],
+    )
+    llm, _ = _make_llm([response])
+    with pytest.raises(ValueError, match="escapes the compiled-layer directory"):
+        compile_to_vault(
+            fragment_ids=["frag-aaa"],
+            vault_path=vault,
+            target_kind="thread",
+            target_id="../escape",
+            target_title="X",
+            llm=llm,
+        )
 
 
 def test_load_existing_provenance_handles_unreadable_page(
@@ -886,7 +927,7 @@ def test_default_llm_returns_callable(monkeypatch: pytest.MonkeyPatch) -> None:
         _StubProvider,
     )
     sentinel = object()
-    llm = engine_module._default_llm(sentinel)
+    llm = engine_module.default_llm(sentinel)
     assert callable(llm)
     assert llm("hi") == "echo:hi"
     assert captured["config"] is sentinel


### PR DESCRIPTION
## Summary

Closes #212 — four non-blocking follow-ups from the PR #210 re-review:

- **Rename `_default_llm` → `default_llm`** in `creek/compile/engine.py` so `creek/cli.py` no longer imports a private symbol across the module boundary. The function is the documented monkeypatch seam, so the leading underscore was misleading.
- **Tighten `CompiledPage.type` to `Literal["compiled_page"]`** in `creek/models.py` so mypy will narrow correctly once a future `Annotated[Union[...], Field(discriminator="type")]` dispatch is added on the compiled layer.
- **Path-escape guard in `_resolve_target_path`**: a `target_id` like `"../escape"` (CLI input flows straight through) used to resolve outside the compiled-layer directory. Now raises `ValueError` before any disk write. Regression tests added at both the helper and `compile_to_vault` levels.
- **Test assertion fix** in `test_compile_fragments_skips_empty_claim_text`: the docstring promised "still tracked in provenance" but only asserted on the body. Both halves are now pinned.

## Scope

Stays inside `creek.compile` and its consumers — `creek/compile/engine.py`, `creek/models.py`, `creek/cli.py` (single-line import + call rename), and `tests/test_compile.py`. No touches to `creek.save` or `creek.ingest`.

## Test plan

- [x] `./scripts/check-all.sh` passes (3767 unit tests, coverage 93.70%, mypy strict, ruff, refurb, tryceratops, bandit, complexity all green)
- [x] New regression tests: `test_resolve_target_path_rejects_escaping_target_id`, `test_compile_to_vault_rejects_escaping_target_id`
- [x] Existing CLI compile test still passes after the `default_llm` rename

https://claude.ai/code/session_01XYrCrwjWkq8dm4KEqFYBtn

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYrCrwjWkq8dm4KEqFYBtn)_