### PR TITLE
feat(crawdad): dynamic voice-register switching (FEAT-029, #270)

### DIFF
--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -30,8 +30,8 @@ if TYPE_CHECKING:
     from crawdad.config import CrawDadConfig
     from crawdad.mcp_client import MCPClient, MCPUnavailableError
     from crawdad.router import IntentRouter
-    from crawdad.skill_loader import VoiceSkillStack
-    from crawdad.slash_commands import LoopRunner
+    from crawdad.skill_loader import SkillStackRegistry, VoiceSkillStack
+    from crawdad.slash_commands import LoopRunner, RegisterSwitcher
     from crawdad.state import SessionState, StateUnavailableError
 
 _LOGGER = logging.getLogger("crawdad.bot")
@@ -87,6 +87,7 @@ async def handle_message(
     known_tools: tuple[str, ...] = (),
     history: ConversationHistory | None = None,
     skills: VoiceSkillStack | None = None,
+    skill_registry: SkillStackRegistry | None = None,
 ) -> None:
     """Process one Discord message.
 
@@ -102,6 +103,10 @@ async def handle_message(
         known_tools: MCP tool names snapshotted at session start.
         history: Conversation transcript appended in place.
         skills: Voice-skill stack loaded at session start.
+        skill_registry: FEAT-029 mutable registry. When provided it
+            takes precedence over ``skills`` and routes
+            ``crawdad.activate_register`` intents through to a live
+            stack swap.
 
     When ``router``, ``composer``, or ``mcp_client`` is ``None``, the
     handler falls back to the FEAT-013 stub reply — useful for tests
@@ -126,7 +131,8 @@ async def handle_message(
         known_tools=known_tools,
         history=history or ConversationHistory(),
         session_state=session_state,
-        skills=skills or _empty_skills(),
+        skills=_resolve_skills(skill_registry, skills),
+        skill_registry=skill_registry,
     )
     _LOGGER.info("loop outcome: %s", outcome.kind)
     await message.channel.send(_truncate_for_discord(outcome.reply))
@@ -137,6 +143,19 @@ def _empty_skills() -> VoiceSkillStack:
     from crawdad.skill_loader import VoiceSkillStack
 
     return VoiceSkillStack(skills=())
+
+
+def _resolve_skills(
+    registry: SkillStackRegistry | None, fallback: VoiceSkillStack | None
+) -> VoiceSkillStack:
+    """Return the active skill stack, preferring the registry when wired.
+
+    Extracted out of :func:`handle_message` so the message-handling
+    branch stays under the project's cyclomatic-complexity cap.
+    """
+    if registry is not None:
+        return registry.stack
+    return fallback or _empty_skills()
 
 
 def _truncate_for_discord(text: str) -> str:
@@ -180,7 +199,9 @@ class CrawDadClient(discord.Client):
         known_tools: tuple[str, ...] = (),
         history: ConversationHistory | None = None,
         skills: VoiceSkillStack | None = None,
+        skill_registry: SkillStackRegistry | None = None,
         loop_runner: LoopRunner | None = None,
+        register_switcher: RegisterSwitcher | None = None,
         intents: discord.Intents | None = None,
     ) -> None:
         """Store config + agent-loop components; init the parent ``Client``.
@@ -188,6 +209,12 @@ class CrawDadClient(discord.Client):
         ``loop_runner`` (FEAT-016) is the closure the slash command
         callbacks invoke to enter the FEAT-015 loop with a pre-baked
         user message. When ``None``, slash commands are not registered.
+
+        ``skill_registry`` and ``register_switcher`` (FEAT-029) thread
+        the mutable voice-register state through the free-text handler
+        and the ``/crawdad register`` slash command respectively, so
+        register switches survive across turns within the bot's
+        lifetime.
         """
         super().__init__(intents=intents or self._default_intents())
         self._config = config
@@ -198,6 +225,7 @@ class CrawDadClient(discord.Client):
         self._known_tools = known_tools
         self._history = history
         self._skills = skills
+        self._skill_registry = skill_registry
         self._loop_runner = loop_runner
         self.tree = app_commands.CommandTree(self)
         if loop_runner is not None:
@@ -205,7 +233,11 @@ class CrawDadClient(discord.Client):
             # the ``_TreeLike`` Protocol the registration function uses,
             # so cast to Any at the boundary. Verified by the structural
             # ``test_register_wires_every_command_onto_tree`` test.
-            register_slash_commands(cast("Any", self.tree), loop_runner=loop_runner)
+            register_slash_commands(
+                cast("Any", self.tree),
+                loop_runner=loop_runner,
+                register_switcher=register_switcher,
+            )
 
     @staticmethod
     def _default_intents() -> discord.Intents:
@@ -245,4 +277,5 @@ class CrawDadClient(discord.Client):
             known_tools=self._known_tools,
             history=self._history,
             skills=self._skills,
+            skill_registry=self._skill_registry,
         )

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -28,7 +28,7 @@ from crawdad.intents import ToolInfo
 from crawdad.loop import run_one_turn
 from crawdad.mcp_client import MCPClient, MCPUnavailableError
 from crawdad.router import IntentRouter
-from crawdad.skill_loader import load_skills_for_session
+from crawdad.skill_loader import SkillStackRegistry, load_skills_for_session
 from crawdad.state import StateUnavailableError, load_session_state
 
 if TYPE_CHECKING:
@@ -36,7 +36,6 @@ if TYPE_CHECKING:
 
     from crawdad.config import CrawDadConfig
     from crawdad.mcp_client import ToolDetails
-    from crawdad.skill_loader import VoiceSkillStack
     from crawdad.slash_commands import LoopRunner
     from crawdad.state import SessionState
 
@@ -91,18 +90,25 @@ def run_bot(config: CrawDadConfig) -> None:
 
     FEAT-015 adds the composer + voice-skill stack to the wiring. The
     skill stack is loaded once at session start from
-    ``<vault>/creek-skills/`` per the FEAT-015 plan; FEAT-016 will
-    introduce dynamic register switching.
+    ``<vault>/creek-skills/`` per the FEAT-015 plan; FEAT-029 introduced
+    the :class:`SkillStackRegistry` so the active register can be
+    swapped mid-session via natural language or
+    ``/crawdad register <name>`` without restarting the bot.
     """
     logging.basicConfig(level=logging.INFO)
     session_state = _safe_load_state(config.vault_path)
     tool_details = asyncio.run(_startup_probe(config))
-    skills = load_skills_for_session(vault_path=config.vault_path, state=session_state)
+    initial_skills = load_skills_for_session(
+        vault_path=config.vault_path, state=session_state
+    )
+    skill_registry = SkillStackRegistry(
+        stack=initial_skills, vault_path=config.vault_path, state=session_state
+    )
     components = _build_agent_components(config=config, tool_details=tool_details)
     loop_runner = _build_loop_runner(
         components=components,
         session_state=session_state,
-        skills=skills,
+        skill_registry=skill_registry,
     )
     client = CrawDadClient(
         config=config,
@@ -112,8 +118,10 @@ def run_bot(config: CrawDadConfig) -> None:
         mcp_client=components.mcp_client,
         known_tools=components.known_tools,
         history=components.history,
-        skills=skills,
+        skills=skill_registry.stack,
+        skill_registry=skill_registry,
         loop_runner=loop_runner,
+        register_switcher=skill_registry.activate_register,
     )
     client.run(config.discord_bot_token)
 
@@ -122,13 +130,16 @@ def _build_loop_runner(
     *,
     components: _AgentComponents,
     session_state: SessionState | None,
-    skills: VoiceSkillStack,
+    skill_registry: SkillStackRegistry,
 ) -> LoopRunner | None:
     """Return a closure that runs one loop turn end-to-end.
 
     The returned callable is what :mod:`crawdad.slash_commands` invokes
     when a Discord user types `/crawdad <command>`. ``None`` when the
     agent loop isn't wired (no router → no slash commands).
+
+    The closure captures the :class:`SkillStackRegistry` so FEAT-029
+    register switches persist across turns within the same bot session.
     """
     if components.router is None or components.composer is None:
         return None
@@ -159,7 +170,8 @@ def _build_loop_runner(
                 known_tools=known_tools,
                 history=history,
                 session_state=session_state,
-                skills=skills,
+                skills=skill_registry.stack,
+                skill_registry=skill_registry,
             )
             return _truncate_for_discord(outcome.reply)
         except Exception:

--- a/crawdad/crawdad/dispatcher.py
+++ b/crawdad/crawdad/dispatcher.py
@@ -18,13 +18,20 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
-from crawdad.intents import PrivacyTierCeiling
+from crawdad.intents import ACTIVATE_REGISTER_INTENT_TYPE, PrivacyTierCeiling
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
     from crawdad.intents import Intent, RouterResponse
     from crawdad.mcp_client import MCPSession
+
+    # FEAT-029: synchronous callable that swaps the active voice-skill
+    # register. Returns True on success (register file present, stack
+    # reloaded), False on unknown / unsafe register names. The loop owns
+    # the underlying :class:`SkillStackRegistry` and passes its
+    # ``activate_register`` method down to the dispatcher.
+    RegisterSwitcher = Callable[[str], bool]
 
 _LOGGER = logging.getLogger("crawdad.dispatcher")
 
@@ -61,6 +68,7 @@ class IntentDispatcher:
         *,
         session: MCPSession,
         known_tools: Iterable[str],
+        register_switcher: RegisterSwitcher | None = None,
     ) -> None:
         """Cache the advertised tools so unknown intents fail fast.
 
@@ -70,9 +78,15 @@ class IntentDispatcher:
             known_tools: The MCP tool names snapshotted at session
                 start. Intent types outside this set raise
                 :class:`UnknownIntentError`.
+            register_switcher: FEAT-029 callback that swaps the loop's
+                active voice register. ``None`` causes
+                ``crawdad.activate_register`` intents to soft-error
+                rather than mutate the skill stack — useful in tests
+                and when the registry isn't wired (no vault layout).
         """
         self._session = session
         self._known_tools = frozenset(known_tools)
+        self._register_switcher = register_switcher
 
     async def dispatch(self, response: RouterResponse) -> list[ToolResult]:
         """Invoke each intent in order; collect the textual tool results.
@@ -91,6 +105,9 @@ class IntentDispatcher:
         """
         results: list[ToolResult] = []
         for intent in response.intents:
+            if intent.type == ACTIVATE_REGISTER_INTENT_TYPE:
+                results.append(self._handle_activate_register(intent))
+                continue
             if intent.type not in self._known_tools:
                 msg = (
                     f"router emitted intent type {intent.type!r} which is not "
@@ -107,6 +124,38 @@ class IntentDispatcher:
                 )
             )
         return results
+
+    def _handle_activate_register(self, intent: Intent) -> ToolResult:
+        """Run the FEAT-029 register switch for ``crawdad.activate_register``.
+
+        The result body is a short status line the composer can quote
+        verbatim (or summarise) for the user. The privacy ceiling on the
+        result mirrors the intent's declared ceiling so downstream
+        consumers see a faithful echo of the router's authorisation.
+        """
+        register = intent.args.get("register")
+        if not isinstance(register, str) or not register:
+            _LOGGER.info("activate_register intent missing 'register' arg")
+            body = "could not switch voice register: no register name was provided"
+        elif self._register_switcher is None:
+            _LOGGER.info(
+                "activate_register intent for %r but no switcher is wired", register
+            )
+            body = (
+                f"voice register switching is unavailable in this session; "
+                f"ignoring request to activate {register!r}"
+            )
+        elif self._register_switcher(register):
+            _LOGGER.info("voice register switched to %r", register)
+            body = f"voice register switched to {register!r}"
+        else:
+            _LOGGER.info("voice register switch refused for %r", register)
+            body = f"unknown voice register {register!r}; keeping the current register"
+        return ToolResult(
+            intent_type=intent.type,
+            body=body,
+            privacy_tier_ceiling=intent.privacy_tier_ceiling,
+        )
 
 
 def _build_arguments(intent: Intent) -> dict[str, object]:

--- a/crawdad/crawdad/intents.py
+++ b/crawdad/crawdad/intents.py
@@ -21,6 +21,13 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
+# FEAT-029: client-side intent for dynamic voice-register switching. The
+# dispatcher recognises this type *before* the MCP known-tools check and
+# routes it to the loop's :class:`SkillStackRegistry` instead of an MCP
+# tool call. The ``crawdad.`` namespace prefix keeps it visually distinct
+# from MCP ``creek.*`` tools and immune to a future MCP-side collision.
+ACTIVATE_REGISTER_INTENT_TYPE: str = "crawdad.activate_register"
+
 
 class PrivacyTierCeiling(StrEnum):
     """Per-intent privacy tier ceiling.
@@ -84,6 +91,7 @@ def build_intents_schema(tools: list[ToolInfo]) -> dict[str, Any]:
         verbatim and that a downstream JSON parser can validate against.
     """
     tool_names = [tool.name for tool in tools]
+    allowed_types = [*tool_names, ACTIVATE_REGISTER_INTENT_TYPE]
     return {
         "type": "object",
         "properties": {
@@ -94,10 +102,11 @@ def build_intents_schema(tools: list[ToolInfo]) -> dict[str, Any]:
                     "properties": {
                         "type": {
                             "type": "string",
-                            "enum": tool_names,
+                            "enum": allowed_types,
                             "description": (
-                                "MCP tool name to invoke; must match one "
-                                "of the advertised tools."
+                                "MCP tool name to invoke, or the client-side "
+                                f"intent {ACTIVATE_REGISTER_INTENT_TYPE!r} to "
+                                "switch the active voice register mid-session."
                             ),
                         },
                         "privacy_tier_ceiling": {

--- a/crawdad/crawdad/loop.py
+++ b/crawdad/crawdad/loop.py
@@ -59,11 +59,13 @@ from crawdad.mcp_client import MCPUnavailableError
 from crawdad.router import RouterParseError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from crawdad.composer import SonnetComposer
     from crawdad.history import ConversationHistory
     from crawdad.mcp_client import MCPClient
     from crawdad.router import IntentRouter
-    from crawdad.skill_loader import VoiceSkillStack
+    from crawdad.skill_loader import SkillStackRegistry, VoiceSkillStack
     from crawdad.state import SessionState
 
 _LOGGER = logging.getLogger("crawdad.loop")
@@ -121,9 +123,18 @@ class AgentLoop:
         history: ConversationHistory,
         session_state: SessionState | None,
         skills: VoiceSkillStack,
+        skill_registry: SkillStackRegistry | None = None,
         max_rounds: int = MAX_LOOP_ROUNDS,
     ) -> None:
-        """Cache injected components for the per-turn :meth:`run` call."""
+        """Cache injected components for the per-turn :meth:`run` call.
+
+        ``skill_registry`` (FEAT-029) is the mutable holder backing
+        ``crawdad.activate_register`` intents. When supplied, the loop
+        reads the current stack from the registry on each compose and
+        hands its ``activate_register`` method to the dispatcher so
+        register switches persist across turns. Without it the loop
+        falls back to the static ``skills`` argument.
+        """
         self._router = router
         self._composer = composer
         self._mcp_client = mcp_client
@@ -131,6 +142,7 @@ class AgentLoop:
         self._history = history
         self._session_state = session_state
         self._skills = skills
+        self._skill_registry = skill_registry
         self._max_rounds = max_rounds
 
     async def run(self, message: str) -> LoopOutcome:
@@ -183,7 +195,7 @@ class AgentLoop:
                 tool_results=aggregated,
                 history=self._history,
                 state=self._session_state,
-                skills=self._skills,
+                skills=self._current_skills(),
             )
         except ComposerFailureError as exc:
             _LOGGER.warning("composer failed: %s", exc)
@@ -196,9 +208,23 @@ class AgentLoop:
         """Open one MCP session, dispatch this round's intents, return results."""
         async with self._mcp_client.connect() as session:
             dispatcher = IntentDispatcher(
-                session=session, known_tools=self._known_tools
+                session=session,
+                known_tools=self._known_tools,
+                register_switcher=self._register_switcher(),
             )
             return await dispatcher.dispatch(response)
+
+    def _current_skills(self) -> VoiceSkillStack:
+        """Return the active skill stack, preferring the registry when wired."""
+        if self._skill_registry is not None:
+            return self._skill_registry.stack
+        return self._skills
+
+    def _register_switcher(self) -> Callable[[str], bool] | None:
+        """Return the dispatcher's register-switch callback or ``None``."""
+        if self._skill_registry is None:
+            return None
+        return self._skill_registry.activate_register
 
     async def _maybe_route_paradox(self, results: list[ToolResult]) -> list[ToolResult]:
         """If results mention a paradox, ensure a save call to liminal land.
@@ -271,12 +297,18 @@ async def run_one_turn(
     history: ConversationHistory,
     session_state: SessionState | None,
     skills: VoiceSkillStack,
+    skill_registry: SkillStackRegistry | None = None,
 ) -> LoopOutcome:
     """Convenience wrapper the bot handler calls.
 
     Constructs an :class:`AgentLoop` from the per-session components and
     runs it for one user turn. Returns the structured :class:`LoopOutcome`
     so callers can branch on ``kind`` for logging / metrics.
+
+    ``skill_registry`` (FEAT-029) — when supplied, the loop reads the
+    active skill stack from the registry and routes
+    ``crawdad.activate_register`` intents through it so the register
+    switch persists across turns.
     """
     loop = AgentLoop(
         router=router,
@@ -286,5 +318,6 @@ async def run_one_turn(
         history=history,
         session_state=session_state,
         skills=skills,
+        skill_registry=skill_registry,
     )
     return await loop.run(message)

--- a/crawdad/crawdad/router.py
+++ b/crawdad/crawdad/router.py
@@ -34,7 +34,12 @@ from typing import TYPE_CHECKING, Any
 import anthropic
 from pydantic import ValidationError
 
-from crawdad.intents import RouterResponse, ToolInfo, build_intents_schema
+from crawdad.intents import (
+    ACTIVATE_REGISTER_INTENT_TYPE,
+    RouterResponse,
+    ToolInfo,
+    build_intents_schema,
+)
 
 if TYPE_CHECKING:
     from crawdad.history import ConversationHistory
@@ -111,6 +116,16 @@ def build_router_prompt(
         "include a paradox surfacing, include a `creek.save` intent "
         "(target=paradox) BEFORE setting `compose: true` so paradoxes are "
         "routed to `10-Liminal/Paradoxes/`. Never propose paradox resolution.\n\n"
+        "Register-switch detection (FEAT-029): when the user asks you to "
+        "switch voice register, change voice, or activate a different "
+        'voice — phrases like "switch to the analytic register", "use '
+        'confessional voice", "speak in praxis mode", "can you talk like '
+        'the X register now" — emit a single intent with '
+        f'type "{ACTIVATE_REGISTER_INTENT_TYPE}" and '
+        '`args: {"register": "<name>"}` BEFORE setting `compose: true`. '
+        "Use the lowercase, hyphenated register name (e.g. "
+        "`confessional`, `praxis`, `analytic`). Do NOT call any MCP tool "
+        "for register switches — the dispatcher handles them locally.\n\n"
         f"{phase_hint}\n\n"
         f"{wavelength_block}\n\n"
         f"{history_block}\n\n"

--- a/crawdad/crawdad/skill_loader.py
+++ b/crawdad/crawdad/skill_loader.py
@@ -15,9 +15,10 @@ error):
 The session-state wavelength snapshot supplies the phase. The default
 register is :data:`crawdad.config.DEFAULT_REGISTER` ("confessional",
 the long-term-memory reflective register from the ontology). Callers
-can ask for extra registers via ``extra_registers=...`` — FEAT-016's
-slash commands will use this to switch into ``praxis`` for actionable
-turns.
+can ask for extra registers via ``extra_registers=...``. FEAT-029 adds
+the :class:`SkillStackRegistry` so the active register can be swapped
+mid-session by the dispatcher's ``crawdad.activate_register`` branch or
+the ``/crawdad register`` slash command.
 
 The loader is forgiving: a vault without a fleshed-out voice tree
 still produces a :class:`VoiceSkillStack`, just an empty one, and the
@@ -140,6 +141,79 @@ def load_skills_for_session(
         _append_if_present(collected, register_path, name=f"register:{register}")
 
     return VoiceSkillStack(skills=tuple(collected))
+
+
+class SkillStackRegistry:
+    """Mutable holder for the active :class:`VoiceSkillStack` (FEAT-029).
+
+    The default stack is built at session start by
+    :func:`load_skills_for_session`. The dispatcher's
+    ``crawdad.activate_register`` branch (and the ``/crawdad register``
+    slash command) call :meth:`activate_register` to swap the stack in
+    place; the same registry instance lives in the loop runner closure
+    so the switch persists across turns within a single bot session.
+
+    The registry validates register names with the same regex the loader
+    uses for ``extra_registers`` and checks file existence before
+    reloading, so unknown / unsafe names soft-fail rather than mutate.
+    """
+
+    def __init__(
+        self,
+        *,
+        stack: VoiceSkillStack,
+        vault_path: Path,
+        state: SessionState | None,
+    ) -> None:
+        """Cache the initial stack and the inputs needed to reload it.
+
+        Args:
+            stack: The stack produced by :func:`load_skills_for_session`
+                at session start.
+            vault_path: Root of the user's Obsidian vault — passed
+                verbatim into subsequent reload calls.
+            state: Session-state snapshot for phase resolution. Pinned
+                at construction so a register switch keeps the same
+                phase skill even if the wavelength evolves later.
+        """
+        self._stack = stack
+        self._vault_path = vault_path
+        self._state = state
+
+    @property
+    def stack(self) -> VoiceSkillStack:
+        """Return the currently active skill stack."""
+        return self._stack
+
+    def activate_register(self, name: str) -> bool:
+        """Reload the stack with *name* as an additional active register.
+
+        Returns ``True`` when the swap succeeded (the stack now reflects
+        the requested register) and ``False`` when the name is unsafe
+        or the corresponding ``registers/<name>.SKILL.md`` file is
+        missing. On failure the previous stack is preserved untouched —
+        the caller is free to surface a user-facing soft error.
+        """
+        if not _SAFE_NAME_RE.match(name):
+            _LOGGER.warning("refusing register %r: must match [a-z][a-z-]*", name)
+            return False
+        register_path = (
+            self._vault_path / CREEK_SKILLS_DIRNAME / "registers" / f"{name}.SKILL.md"
+        )
+        if not register_path.is_file():
+            _LOGGER.info(
+                "register %r not found at %s; soft-failing the switch",
+                name,
+                register_path,
+            )
+            return False
+        self._stack = load_skills_for_session(
+            vault_path=self._vault_path,
+            state=self._state,
+            extra_registers=(name,),
+        )
+        _LOGGER.info("activated voice register %r", name)
+        return True
 
 
 def _append_if_present(target: list[VoiceSkill], path: Path, *, name: str) -> None:

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -1,10 +1,12 @@
-"""Discord slash commands for CrawDad (FEAT-016).
+"""Discord slash commands for CrawDad (FEAT-016 + FEAT-029).
 
-Six commands form the `/crawdad` family — `reflect`, `checkin`,
-`surface`, `draft`, `save`, `workflow`. Each routes through the
-FEAT-015 agent loop by constructing a pre-baked user message and
-running it through an injected ``loop_runner`` callable. The Sonnet
-composer wraps the tool results in the user's voice.
+The `/crawdad` family bundles `reflect`, `checkin`, `surface`, `draft`,
+`save`, `register`, and `workflow`. Most routes through the FEAT-015
+agent loop by constructing a pre-baked user message and running it
+through an injected ``loop_runner`` callable; the Sonnet composer
+wraps the tool results in the user's voice. ``register`` (FEAT-029)
+bypasses the loop and invokes the synchronous ``register_switcher``
+directly so voice-register changes are deterministic.
 
 The handlers are free functions that take a tiny ``Replier`` callable
 (``async def (str) -> None``) so they can be unit-tested without
@@ -37,6 +39,12 @@ _LOGGER = logging.getLogger("crawdad.slash_commands")
 # components — see :func:`crawdad.cli._build_loop_runner`.
 LoopRunner = Callable[[str], Awaitable[str]]
 
+# FEAT-029: synchronous callable that swaps the active voice register.
+# The slash-command handler invokes it directly so the user gets a
+# deterministic switch (no LLM round-trip). Returns True on success,
+# False on unknown / unsafe register names.
+RegisterSwitcher = Callable[[str], bool]
+
 # Async callable that posts a message back to the Discord user.
 # Wraps ``discord.Interaction.followup.send`` in production; tests
 # substitute a list-appending fake.
@@ -49,6 +57,7 @@ CRAWDAD_COMMANDS: tuple[str, ...] = (
     "surface",
     "draft",
     "save",
+    "register",
     "workflow",
 )
 
@@ -58,6 +67,7 @@ _COMMAND_DESCRIPTIONS: dict[str, str] = {
     "surface": "Surface paradoxes, liminal content, or emerging themes.",
     "draft": "Draft an essay on a topic (routes through creek.mine + creek.draft).",
     "save": "File the supplied content back to the vault via creek.save.",
+    "register": "Switch the active voice register (FEAT-029).",
     "workflow": "List or run named workflows (v1.0 stub — full DSL in v1.1).",
 }
 
@@ -165,6 +175,38 @@ async def handle_save(
     await replier(reply)
 
 
+async def handle_register(
+    replier: Replier, *, name: str, register_switcher: RegisterSwitcher | None
+) -> None:
+    """``/crawdad register <name>`` — swap the active voice register.
+
+    Bypasses the agent loop and calls ``register_switcher`` directly so
+    the user gets a deterministic, single-step switch with a clear
+    success / soft-error reply.
+    """
+    cleaned = name.strip().lower()
+    if not cleaned:
+        await replier(
+            "What register should I activate? Try `/crawdad register <name>` — "
+            "for example, `/crawdad register analytic`."
+        )
+        return
+    if register_switcher is None:
+        _LOGGER.info("register switcher unavailable; ignoring %r", cleaned)
+        await replier(
+            "Voice register switching is unavailable in this session. "
+            "(The vault's `creek-skills/` tree wasn't wired up.)"
+        )
+        return
+    if register_switcher(cleaned):
+        await replier(f"Voice register switched to `{cleaned}`.")
+        return
+    await replier(
+        f"Unknown voice register `{cleaned}` — check that "
+        f"`creek-skills/registers/{cleaned}.SKILL.md` exists in your vault."
+    )
+
+
 async def handle_workflow(replier: Replier, *, subaction: str | None) -> None:
     """``/crawdad workflow [list]`` — v1.0 stub.
 
@@ -205,13 +247,23 @@ async def handle_help(replier: Replier) -> None:
 # -----------------------------------------------------------------------------
 
 
-def register(tree: _TreeLike, *, loop_runner: LoopRunner) -> int:
+def register(
+    tree: _TreeLike,
+    *,
+    loop_runner: LoopRunner,
+    register_switcher: RegisterSwitcher | None = None,
+) -> int:
     """Register every ``/crawdad`` slash command on the supplied tree.
 
     Each callback ``defer()``s the Discord interaction so the loop has
     its full :data:`crawdad.config.MAX_LOOP_ROUNDS` budget before the
     SDK times out at 3 seconds. The actual reply lands via
     ``interaction.followup.send``.
+
+    ``register_switcher`` (FEAT-029) is the synchronous callback the
+    ``/crawdad register`` command invokes to swap the active voice
+    register. ``None`` keeps the command wired but the handler short-
+    circuits to a soft-error reply explaining the feature is unwired.
 
     Returns the count of advertised commands (always
     ``len(CRAWDAD_COMMANDS)`` since the registration helpers don't
@@ -223,6 +275,7 @@ def register(tree: _TreeLike, *, loop_runner: LoopRunner) -> int:
     _register_surface(tree, loop_runner=loop_runner)
     _register_draft(tree, loop_runner=loop_runner)
     _register_save(tree, loop_runner=loop_runner)
+    _register_register(tree, register_switcher=register_switcher)
     _register_workflow(tree)
     return len(CRAWDAD_COMMANDS)
 
@@ -289,6 +342,22 @@ def _register_save(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
         await interaction.response.defer()
         await handle_save(
             interaction.followup.send, content=content, loop_runner=loop_runner
+        )
+
+
+def _register_register(
+    tree: _TreeLike, *, register_switcher: RegisterSwitcher | None
+) -> None:
+    """Wire the ``/crawdad register`` Discord callback onto *tree* (FEAT-029)."""
+
+    @tree.command(name="register", description=_COMMAND_DESCRIPTIONS["register"])
+    async def _callback(interaction: Any, name: str) -> None:
+        """Discord callback for ``/crawdad register <name>`` (deferred)."""
+        await interaction.response.defer()
+        await handle_register(
+            interaction.followup.send,
+            name=name,
+            register_switcher=register_switcher,
         )
 
 

--- a/crawdad/tests/test_cli.py
+++ b/crawdad/tests/test_cli.py
@@ -256,29 +256,35 @@ def test_build_agent_components_wires_router_and_composer(
     assert components.known_tools == ("creek.state.read",)
 
 
+def _empty_registry(vault: Path) -> Any:
+    """Build an empty SkillStackRegistry for use as a test fixture."""
+    from crawdad.skill_loader import SkillStackRegistry, VoiceSkillStack
+
+    return SkillStackRegistry(
+        stack=VoiceSkillStack(skills=()), vault_path=vault, state=None
+    )
+
+
 def test_build_loop_runner_returns_none_when_loop_not_wired(
-    patched_config: CrawDadConfig,
+    patched_config: CrawDadConfig, tmp_path: Path
 ) -> None:
     """No router/composer → no loop runner → slash commands stay unregistered."""
-    from crawdad.skill_loader import VoiceSkillStack
-
     components = cli._build_agent_components(config=patched_config, tool_details=())
 
     runner = cli._build_loop_runner(
         components=components,
         session_state=None,
-        skills=VoiceSkillStack(skills=()),
+        skill_registry=_empty_registry(tmp_path),
     )
 
     assert runner is None
 
 
 def test_build_loop_runner_returns_callable_when_loop_wired(
-    patched_config: CrawDadConfig,
+    patched_config: CrawDadConfig, tmp_path: Path
 ) -> None:
     """A wired loop produces a callable suitable for slash-command dispatch."""
     from crawdad.mcp_client import ToolDetails
-    from crawdad.skill_loader import VoiceSkillStack
 
     details = (
         ToolDetails(
@@ -294,7 +300,7 @@ def test_build_loop_runner_returns_callable_when_loop_wired(
     runner = cli._build_loop_runner(
         components=components,
         session_state=None,
-        skills=VoiceSkillStack(skills=()),
+        skill_registry=_empty_registry(tmp_path),
     )
 
     assert runner is not None
@@ -304,6 +310,7 @@ def test_build_loop_runner_returns_callable_when_loop_wired(
 async def test_loop_runner_truncates_long_replies(
     patched_config: CrawDadConfig,
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """Replies over Discord's 2000-char limit are truncated with an ellipsis.
 
@@ -315,7 +322,6 @@ async def test_loop_runner_truncates_long_replies(
     """
     from crawdad.loop import LoopOutcome
     from crawdad.mcp_client import ToolDetails
-    from crawdad.skill_loader import VoiceSkillStack
 
     details = (
         ToolDetails(
@@ -338,7 +344,7 @@ async def test_loop_runner_truncates_long_replies(
     runner = cli._build_loop_runner(
         components=components,
         session_state=None,
-        skills=VoiceSkillStack(skills=()),
+        skill_registry=_empty_registry(tmp_path),
     )
 
     assert runner is not None
@@ -351,6 +357,7 @@ async def test_loop_runner_truncates_long_replies(
 async def test_loop_runner_returns_soft_error_on_exception(
     patched_config: CrawDadConfig,
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
     """A crash inside ``run_one_turn`` yields the documented soft reply.
 
@@ -360,7 +367,6 @@ async def test_loop_runner_returns_soft_error_on_exception(
     a friendly soft error instead.
     """
     from crawdad.mcp_client import ToolDetails
-    from crawdad.skill_loader import VoiceSkillStack
 
     details = (
         ToolDetails(
@@ -381,12 +387,55 @@ async def test_loop_runner_returns_soft_error_on_exception(
     runner = cli._build_loop_runner(
         components=components,
         session_state=None,
-        skills=VoiceSkillStack(skills=()),
+        skill_registry=_empty_registry(tmp_path),
     )
 
     assert runner is not None
     reply = await runner("anything")
     assert "creek-tools" in reply.lower() or "wrong" in reply.lower()
+
+
+def test_run_bot_wires_skill_registry_and_register_switcher(
+    patched_config: CrawDadConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    vault_with_state: Path,
+) -> None:
+    """FEAT-029: ``run_bot`` builds a SkillStackRegistry and forwards the switcher.
+
+    The CrawDadClient must receive both the registry (so the free-text
+    handler routes activate_register intents through it) and the
+    register_switcher callback (so ``/crawdad register`` can call it
+    directly without going through the LLM loop).
+    """
+    from crawdad.mcp_client import ToolDetails
+    from crawdad.skill_loader import SkillStackRegistry
+
+    config = patched_config.model_copy(update={"vault_path": vault_with_state})
+    captured: dict[str, Any] = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["init_kwargs"] = kwargs
+
+        def run(self, _token: str) -> None:
+            captured["ran"] = True
+
+    async def _ok_probe(_c: CrawDadConfig) -> tuple[ToolDetails, ...]:
+        return (
+            ToolDetails(
+                name="creek.state.read",
+                description="Read latest.md",
+                input_schema={"type": "object"},
+            ),
+        )
+
+    monkeypatch.setattr(cli, "CrawDadClient", _FakeClient)
+    monkeypatch.setattr(cli, "_startup_probe", _ok_probe)
+
+    cli.run_bot(config)
+
+    assert isinstance(captured["init_kwargs"]["skill_registry"], SkillStackRegistry)
+    assert callable(captured["init_kwargs"]["register_switcher"])
 
 
 def test_run_bot_passes_loop_runner_when_loop_wired(

--- a/crawdad/tests/test_dispatcher.py
+++ b/crawdad/tests/test_dispatcher.py
@@ -11,7 +11,7 @@ from crawdad.dispatcher import (
     ToolResult,
     UnknownIntentError,
 )
-from crawdad.intents import Intent, RouterResponse
+from crawdad.intents import ACTIVATE_REGISTER_INTENT_TYPE, Intent, RouterResponse
 from crawdad.mcp_client import MCPUnavailableError
 
 
@@ -118,6 +118,125 @@ async def test_dispatcher_preserves_privacy_tier_ceiling() -> None:
     )
 
     assert session.calls[0][1]["privacy_tier_ceiling"] == "personal"
+
+
+async def test_dispatcher_routes_activate_register_to_switcher() -> None:
+    """FEAT-029: ``activate_register`` intents bypass MCP and call the switcher.
+
+    The dispatcher hands the requested register name to the injected
+    ``register_switcher`` callable and emits a :class:`ToolResult`
+    describing the outcome. No MCP call is made.
+    """
+    switched: list[str] = []
+
+    def _switcher(name: str) -> bool:
+        switched.append(name)
+        return True
+
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(
+        session=session,
+        known_tools=("creek.state.read",),
+        register_switcher=_switcher,
+    )
+
+    results = await dispatcher.dispatch(
+        RouterResponse(
+            intents=[
+                Intent(
+                    type=ACTIVATE_REGISTER_INTENT_TYPE,
+                    args={"register": "analytic"},
+                )
+            ]
+        )
+    )
+
+    assert switched == ["analytic"]
+    assert session.calls == []
+    assert len(results) == 1
+    assert results[0].intent_type == ACTIVATE_REGISTER_INTENT_TYPE
+    assert "analytic" in results[0].body
+
+
+async def test_dispatcher_activate_register_soft_errors_on_unknown_name() -> None:
+    """Switcher returning ``False`` produces a soft-error result (no crash)."""
+
+    def _switcher(_name: str) -> bool:
+        return False
+
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(
+        session=session,
+        known_tools=(),
+        register_switcher=_switcher,
+    )
+
+    results = await dispatcher.dispatch(
+        RouterResponse(
+            intents=[
+                Intent(
+                    type=ACTIVATE_REGISTER_INTENT_TYPE,
+                    args={"register": "nonexistent"},
+                )
+            ]
+        )
+    )
+
+    assert len(results) == 1
+    body = results[0].body.lower()
+    assert "nonexistent" in results[0].body
+    assert "unknown" in body or "not" in body or "could not" in body
+
+
+async def test_dispatcher_activate_register_without_switcher_soft_errors() -> None:
+    """If no switcher is wired the dispatcher still produces a soft result.
+
+    Without the soft-fail path an ``activate_register`` intent emitted
+    by Haiku in a test or misconfigured runtime would crash the loop.
+    """
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(session=session, known_tools=())
+
+    results = await dispatcher.dispatch(
+        RouterResponse(
+            intents=[
+                Intent(
+                    type=ACTIVATE_REGISTER_INTENT_TYPE,
+                    args={"register": "praxis"},
+                )
+            ]
+        )
+    )
+
+    assert len(results) == 1
+    assert "praxis" in results[0].body or "register" in results[0].body.lower()
+    assert session.calls == []
+
+
+async def test_dispatcher_activate_register_missing_register_arg_soft_errors() -> None:
+    """A malformed activate_register intent (no ``register`` arg) soft-errors.
+
+    Defensive: Haiku could emit the intent type without filling the
+    expected ``args["register"]`` slot. The dispatcher must not raise.
+    """
+
+    def _switcher(_name: str) -> bool:
+        return True
+
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(
+        session=session,
+        known_tools=(),
+        register_switcher=_switcher,
+    )
+
+    results = await dispatcher.dispatch(
+        RouterResponse(intents=[Intent(type=ACTIVATE_REGISTER_INTENT_TYPE)])
+    )
+
+    assert len(results) == 1
+    body = results[0].body.lower()
+    assert "register" in body
 
 
 async def test_dispatcher_intent_ceiling_overrides_conflicting_args() -> None:

--- a/crawdad/tests/test_intents.py
+++ b/crawdad/tests/test_intents.py
@@ -8,6 +8,7 @@ import pytest
 from pydantic import ValidationError
 
 from crawdad.intents import (
+    ACTIVATE_REGISTER_INTENT_TYPE,
     Intent,
     PrivacyTierCeiling,
     RouterResponse,
@@ -117,15 +118,48 @@ def test_build_intents_schema_lists_each_tool() -> None:
     assert schema["type"] == "object"
     assert "intents" in schema["properties"]
     intent_item = schema["properties"]["intents"]["items"]
-    assert sorted(intent_item["properties"]["type"]["enum"]) == [
-        "creek.mine",
-        "creek.state.read",
-    ]
+    enum = intent_item["properties"]["type"]["enum"]
+    assert "creek.mine" in enum
+    assert "creek.state.read" in enum
 
 
 def test_build_intents_schema_empty_tool_list() -> None:
-    """An empty registry produces a schema that allows no intent types."""
+    """Empty tool list still permits the client-side activate_register intent.
+
+    The FEAT-029 activate_register intent is handled locally by the
+    dispatcher — it doesn't require an MCP tool — so its type must
+    appear in the schema's ``enum`` regardless of which tools the MCP
+    server advertises.
+    """
     schema = build_intents_schema([])
 
     intent_item = schema["properties"]["intents"]["items"]
-    assert intent_item["properties"]["type"]["enum"] == []
+    assert intent_item["properties"]["type"]["enum"] == [ACTIVATE_REGISTER_INTENT_TYPE]
+
+
+def test_build_intents_schema_includes_activate_register_intent_type() -> None:
+    """FEAT-029: the schema enumerates the client-side register-switch intent."""
+    tools = [
+        ToolInfo(
+            name="creek.state.read",
+            description="Read latest.md",
+            input_schema={"type": "object"},
+        ),
+    ]
+
+    schema = build_intents_schema(tools)
+
+    enum = schema["properties"]["intents"]["items"]["properties"]["type"]["enum"]
+    assert ACTIVATE_REGISTER_INTENT_TYPE in enum
+    assert "creek.state.read" in enum
+
+
+def test_activate_register_intent_type_constant_value() -> None:
+    """The constant uses the ``crawdad.`` prefix to distinguish from MCP tools.
+
+    MCP tools are namespaced ``creek.*`` so the prefix flip makes this
+    intent visually distinct in router output and immune to a future
+    MCP tool collision.
+    """
+    assert ACTIVATE_REGISTER_INTENT_TYPE == "crawdad.activate_register"
+    assert ACTIVATE_REGISTER_INTENT_TYPE.startswith("crawdad.")

--- a/crawdad/tests/test_loop.py
+++ b/crawdad/tests/test_loop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -503,6 +504,119 @@ async def test_loop_paradox_save_inherits_max_ceiling(
 
     save_call = next((args for name, args in session.calls if name == "creek.save"))
     assert save_call["privacy_tier_ceiling"] == "intimate"
+
+
+async def test_loop_activate_register_intent_swaps_composer_skills(
+    state: SessionState, tmp_path: Path
+) -> None:
+    """FEAT-029: a ``crawdad.activate_register`` intent re-wires the composer.
+
+    Before the switch the composer sees the initial (empty) stack; after
+    the dispatch the registry holds the new stack and the composer call
+    receives the loaded register file.
+    """
+    from crawdad.intents import ACTIVATE_REGISTER_INTENT_TYPE
+    from crawdad.skill_loader import (
+        SkillStackRegistry,
+        VoiceSkillStack,
+        load_skills_for_session,
+    )
+
+    skills_dir = tmp_path / "creek-skills"
+    (skills_dir / "voice-core").mkdir(parents=True)
+    (skills_dir / "voice-core" / "SKILL.md").write_text(
+        "voice core body", encoding="utf-8"
+    )
+    (skills_dir / "registers").mkdir()
+    (skills_dir / "registers" / "analytic.SKILL.md").write_text(
+        "# Analytic register\nPrecise, taxonomy-leaning.",
+        encoding="utf-8",
+    )
+
+    initial = load_skills_for_session(vault_path=tmp_path, state=None)
+    registry = SkillStackRegistry(stack=initial, vault_path=tmp_path, state=None)
+
+    router = _ScriptedRouter(
+        [
+            RouterResponse(
+                intents=[
+                    Intent(
+                        type=ACTIVATE_REGISTER_INTENT_TYPE,
+                        args={"register": "analytic"},
+                    )
+                ]
+            ),
+            RouterResponse(intents=[], compose=True),
+        ]
+    )
+    session_obj = _ScriptedSession()
+    composer = _ScriptedComposer("switched")
+    loop = AgentLoop(
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(session_obj),  # type: ignore[arg-type]
+        known_tools=(),
+        history=ConversationHistory(),
+        session_state=state,
+        skills=VoiceSkillStack(skills=()),
+        skill_registry=registry,
+    )
+
+    outcome = await loop.run("use the analytic voice")
+
+    assert outcome.kind == "composed"
+    assert composer.calls, "composer must be called after register switch"
+    composer_skills = composer.calls[0]["skills"]
+    bodies = composer_skills.bodies()
+    assert any("Analytic" in body for body in bodies)
+    # The registry's stack now matches what the composer saw.
+    assert registry.stack is composer_skills
+
+
+async def test_loop_activate_register_unknown_register_soft_errors(
+    state: SessionState, tmp_path: Path
+) -> None:
+    """An unknown register yields a soft-error dispatch result, no crash.
+
+    The composer still runs and the original skill stack is preserved.
+    """
+    from crawdad.intents import ACTIVATE_REGISTER_INTENT_TYPE
+    from crawdad.skill_loader import SkillStackRegistry, VoiceSkillStack
+
+    # Empty vault — no registers/ tree, so any register name will miss.
+    initial = VoiceSkillStack(skills=())
+    registry = SkillStackRegistry(stack=initial, vault_path=tmp_path, state=None)
+
+    router = _ScriptedRouter(
+        [
+            RouterResponse(
+                intents=[
+                    Intent(
+                        type=ACTIVATE_REGISTER_INTENT_TYPE,
+                        args={"register": "nonexistent"},
+                    )
+                ]
+            ),
+            RouterResponse(intents=[], compose=True),
+        ]
+    )
+    composer = _ScriptedComposer("did not crash")
+    loop = AgentLoop(
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(_ScriptedSession()),  # type: ignore[arg-type]
+        known_tools=(),
+        history=ConversationHistory(),
+        session_state=state,
+        skills=initial,
+        skill_registry=registry,
+    )
+
+    outcome = await loop.run("switch to a register that doesn't exist")
+
+    assert outcome.kind == "composed"
+    # Registry untouched on soft failure.
+    assert registry.stack is initial
 
 
 async def test_loop_records_user_and_assistant_turns(

--- a/crawdad/tests/test_router.py
+++ b/crawdad/tests/test_router.py
@@ -8,7 +8,7 @@ from typing import Any
 import pytest
 
 from crawdad.history import ConversationHistory
-from crawdad.intents import PrivacyTierCeiling, ToolInfo
+from crawdad.intents import ACTIVATE_REGISTER_INTENT_TYPE, PrivacyTierCeiling, ToolInfo
 from crawdad.router import (
     IntentRouter,
     RouterParseError,
@@ -261,6 +261,68 @@ async def test_router_translates_anthropic_api_error_to_parse_error(
             history=ConversationHistory(),
             state=session_state,
         )
+
+
+def test_build_router_prompt_mentions_register_switch_intent(
+    tools: list[ToolInfo], session_state: SessionState
+) -> None:
+    """FEAT-029: the prompt explains how to emit the activate_register intent.
+
+    Without the instruction, Haiku will try to satisfy "switch to the
+    analytic register" by hallucinating an MCP tool name. The prompt
+    must name the client-side intent type explicitly.
+    """
+    prompt = build_router_prompt(
+        message="switch to the analytic register",
+        history=ConversationHistory(),
+        state=session_state,
+        tools=tools,
+    )
+
+    assert ACTIVATE_REGISTER_INTENT_TYPE in prompt
+    assert "register" in prompt.lower()
+    assert "switch" in prompt.lower() or "activate" in prompt.lower()
+
+
+async def test_router_emits_activate_register_for_natural_language_phrase(
+    tools: list[ToolInfo], session_state: SessionState
+) -> None:
+    """A switch phrase yields an activate_register intent.
+
+    With the prompt updated to teach Haiku about the intent type, a
+    well-behaved Haiku reply emits ``crawdad.activate_register`` with
+    the requested register name. We stub the model so the test pins
+    the parsing path, not the model's behavior.
+    """
+    fake_haiku = _FakeAnthropic(
+        json.dumps(
+            {
+                "intents": [
+                    {
+                        "type": ACTIVATE_REGISTER_INTENT_TYPE,
+                        "args": {"register": "analytic"},
+                    }
+                ],
+                "compose": True,
+            }
+        )
+    )
+    router = IntentRouter(
+        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        model="claude-haiku-test",
+        tools=tools,
+    )
+
+    response = await router.extract_intents(
+        message="switch to the analytic voice",
+        history=ConversationHistory(),
+        state=session_state,
+    )
+
+    assert len(response.intents) == 1
+    assert response.intents[0].type == ACTIVATE_REGISTER_INTENT_TYPE
+    assert response.intents[0].args == {"register": "analytic"}
+    assert response.compose is True
 
 
 async def test_router_extracts_fenced_json_blocks(

--- a/crawdad/tests/test_skill_loader.py
+++ b/crawdad/tests/test_skill_loader.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from crawdad.skill_loader import (
+    SkillStackRegistry,
     VoiceSkillStack,
     load_skills_for_session,
 )
@@ -152,6 +153,91 @@ def test_load_skills_refuses_unsafe_register_name(
     assert "register:../../etc/passwd" not in names
     assert "register:Praxis" not in names
     assert any("must match" in record.message for record in caplog.records)
+
+
+def test_skill_stack_registry_exposes_initial_stack(
+    vault_with_voice_tree: Path,
+) -> None:
+    """A fresh registry surfaces whatever stack the caller initialised it with."""
+    state = _make_state("rising")
+    initial = load_skills_for_session(vault_path=vault_with_voice_tree, state=state)
+
+    registry = SkillStackRegistry(
+        stack=initial, vault_path=vault_with_voice_tree, state=state
+    )
+
+    assert registry.stack is initial
+
+
+def test_skill_stack_registry_activate_register_reloads_with_new_register(
+    vault_with_voice_tree: Path,
+) -> None:
+    """``activate_register('praxis')`` swaps the stack to include that file."""
+    state = _make_state("rising")
+    initial = load_skills_for_session(vault_path=vault_with_voice_tree, state=state)
+    registry = SkillStackRegistry(
+        stack=initial, vault_path=vault_with_voice_tree, state=state
+    )
+    assert not any("Praxis" in body for body in registry.stack.bodies())
+
+    activated = registry.activate_register("praxis")
+
+    assert activated is True
+    assert any("Praxis" in body for body in registry.stack.bodies())
+
+
+def test_skill_stack_registry_activate_unknown_register_returns_false(
+    vault_with_voice_tree: Path,
+) -> None:
+    """A register file that does not exist soft-fails — no exception, no mutation."""
+    state = _make_state("rising")
+    initial = load_skills_for_session(vault_path=vault_with_voice_tree, state=state)
+    registry = SkillStackRegistry(
+        stack=initial, vault_path=vault_with_voice_tree, state=state
+    )
+
+    activated = registry.activate_register("nonexistent-register")
+
+    assert activated is False
+    # Original stack still in place.
+    assert registry.stack is initial
+
+
+def test_skill_stack_registry_activate_unsafe_name_returns_false(
+    vault_with_voice_tree: Path,
+) -> None:
+    """Path-traversal / unsafe register names are refused without crashing.
+
+    Mirrors the guard inside :func:`load_skills_for_session` so the
+    same protection applies to slash-command-driven switches.
+    """
+    state = _make_state("rising")
+    initial = load_skills_for_session(vault_path=vault_with_voice_tree, state=state)
+    registry = SkillStackRegistry(
+        stack=initial, vault_path=vault_with_voice_tree, state=state
+    )
+
+    activated = registry.activate_register("../../etc/passwd")
+
+    assert activated is False
+    assert registry.stack is initial
+
+
+def test_skill_stack_registry_activate_default_register_is_idempotent(
+    vault_with_voice_tree: Path,
+) -> None:
+    """Activating the default register (``confessional``) succeeds quietly."""
+    state = _make_state("rising")
+    initial = load_skills_for_session(vault_path=vault_with_voice_tree, state=state)
+    registry = SkillStackRegistry(
+        stack=initial, vault_path=vault_with_voice_tree, state=state
+    )
+
+    activated = registry.activate_register("confessional")
+
+    assert activated is True
+    # Stack still contains the confessional register.
+    assert any("Confessional" in body for body in registry.stack.bodies())
 
 
 def test_voice_skill_stack_as_prompt_context(vault_with_voice_tree: Path) -> None:

--- a/crawdad/tests/test_slash_commands.py
+++ b/crawdad/tests/test_slash_commands.py
@@ -12,6 +12,7 @@ from crawdad.slash_commands import (
     handle_draft,
     handle_help,
     handle_reflect,
+    handle_register,
     handle_save,
     handle_surface,
     handle_workflow,
@@ -34,14 +35,15 @@ async def _fake_loop_runner(message: str) -> str:
     return f"composer received: {message}"
 
 
-def test_crawdad_commands_lists_the_six_documented_names() -> None:
-    """The exported registry matches the FEAT-016 §pre-decided choice list."""
+def test_crawdad_commands_lists_the_documented_names() -> None:
+    """The exported registry matches the FEAT-016 + FEAT-029 set."""
     assert set(CRAWDAD_COMMANDS) == {
         "reflect",
         "checkin",
         "surface",
         "draft",
         "save",
+        "register",
         "workflow",
     }
 
@@ -125,6 +127,64 @@ async def test_handle_save_refuses_empty_content() -> None:
 
     assert len(replier.sent) == 1
     assert "content" in replier.sent[0].lower() or "what" in replier.sent[0].lower()
+
+
+async def test_handle_register_invokes_switcher_with_cleaned_name() -> None:
+    """``/crawdad register <name>`` calls the switcher with a normalised name."""
+    seen: list[str] = []
+
+    def _switcher(name: str) -> bool:
+        seen.append(name)
+        return True
+
+    replier = _FakeReplier()
+    await handle_register(replier, name="  Analytic  ", register_switcher=_switcher)
+
+    assert seen == ["analytic"]
+    assert len(replier.sent) == 1
+    assert "analytic" in replier.sent[0].lower()
+    assert "switched" in replier.sent[0].lower()
+
+
+async def test_handle_register_soft_errors_on_unknown_register() -> None:
+    """A switcher returning ``False`` produces a soft-error reply (no crash)."""
+
+    def _switcher(_name: str) -> bool:
+        return False
+
+    replier = _FakeReplier()
+    await handle_register(replier, name="nonexistent", register_switcher=_switcher)
+
+    assert len(replier.sent) == 1
+    body = replier.sent[0].lower()
+    assert "unknown" in body
+    assert "nonexistent" in replier.sent[0]
+
+
+async def test_handle_register_refuses_empty_name() -> None:
+    """An empty register name returns a help reply, not a switcher call."""
+    calls: list[str] = []
+
+    def _switcher(name: str) -> bool:
+        calls.append(name)
+        return True
+
+    replier = _FakeReplier()
+    await handle_register(replier, name="   ", register_switcher=_switcher)
+
+    assert calls == []
+    assert len(replier.sent) == 1
+    assert "register" in replier.sent[0].lower()
+
+
+async def test_handle_register_without_switcher_returns_soft_error() -> None:
+    """A missing switcher (no registry wired) yields the unavailable reply."""
+    replier = _FakeReplier()
+    await handle_register(replier, name="analytic", register_switcher=None)
+
+    assert len(replier.sent) == 1
+    body = replier.sent[0].lower()
+    assert "unavailable" in body or "wired" in body
 
 
 async def test_handle_workflow_list_returns_v11_placeholder() -> None:
@@ -277,6 +337,40 @@ async def test_every_loop_routed_callback_defers_and_replies(
     assert len(interaction.followup.sent) == 1
     # Every routed callback yields the loop's reply text.
     assert "composer received:" in interaction.followup.sent[0]
+
+
+async def test_register_callback_defers_and_invokes_switcher() -> None:
+    """``/crawdad register <name>`` defers the interaction and calls the switcher."""
+    switched: list[str] = []
+
+    def _switcher(name: str) -> bool:
+        switched.append(name)
+        return True
+
+    tree = _FakeTree()
+    register(tree, loop_runner=_fake_loop_runner, register_switcher=_switcher)
+    interaction = _FakeInteraction()
+
+    await tree.registered["register"]["callback"](interaction, name="praxis")
+
+    assert interaction.response.deferred == 1
+    assert switched == ["praxis"]
+    assert len(interaction.followup.sent) == 1
+    assert "praxis" in interaction.followup.sent[0].lower()
+
+
+async def test_register_callback_without_switcher_replies_softly() -> None:
+    """When no switcher is wired the callback still replies — does not crash."""
+    tree = _FakeTree()
+    register(tree, loop_runner=_fake_loop_runner)
+    interaction = _FakeInteraction()
+
+    await tree.registered["register"]["callback"](interaction, name="praxis")
+
+    assert interaction.response.deferred == 1
+    assert len(interaction.followup.sent) == 1
+    body = interaction.followup.sent[0].lower()
+    assert "unavailable" in body or "wired" in body
 
 
 async def test_workflow_callback_skips_loop_and_returns_stub() -> None:


### PR DESCRIPTION
Adds a client-side `crawdad.activate_register` intent so a CrawDad
session can swap voice registers mid-conversation without restarting
the bot. The router detects natural-language switch phrases ("switch
to analytic register", "use confessional voice"), the dispatcher
hands the request to a SkillStackRegistry that reloads the skill
stack via skill_loader.load_skills_for_session(), and the new
`/crawdad register <name>` slash command exposes the same operation
deterministically. Unknown / unsafe register names soft-error rather
than crash; the previous stack is preserved on failure.

https://claude.ai/code/session_011LRgwMS9gdwHuB1qWQATKt