### PR TITLE
chore(save): close FEAT-009 follow-ups (#223)

### DIFF
--- a/creek-tools/creek/classify/privacy_filter.py
+++ b/creek-tools/creek/classify/privacy_filter.py
@@ -17,7 +17,6 @@ writing an entry to the privacy audit log via
 from __future__ import annotations
 
 import logging
-import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -214,16 +213,6 @@ class PreSaveFilterResult:
     stub_relpath: Path | None
 
 
-_PRE_SAVE_INTIMATE_STUB_RELPATH = Path("10-Liminal/Compost/intimate-stubs")
-"""Mirror of :data:`creek.save.router.INTIMATE_STUB_RELPATH`.
-
-Duplicated here to keep ``privacy_filter`` free of a circular import
-back into the save module. The save module owns the canonical
-constant; this private mirror is only used to compose the stub
-relative path returned to callers.
-"""
-
-
 def _title_only_summary(title: str | None) -> str:
     """Return the body that gets written when only the title is safe."""
     safe_title = (title or "").strip() or "(untitled)"
@@ -232,9 +221,12 @@ def _title_only_summary(title: str | None) -> str:
 
 def _stub_relpath_for(title: str | None) -> Path:
     """Compose the gitignored stub path for an intimate body."""
+    from creek.save._constants import INTIMATE_STUB_RELPATH
+    from creek.save._slug import slugify_filename
+
     raw = (title or "intimate").strip().lower() or "intimate"
-    slug = re.sub(r"[^\w\-]+", "-", raw).strip("-") or "intimate"
-    return _PRE_SAVE_INTIMATE_STUB_RELPATH / f"{slug[:64]}.md"
+    slug = slugify_filename(raw) or "intimate"
+    return INTIMATE_STUB_RELPATH / f"{slug}.md"
 
 
 def pre_save_filter(

--- a/creek-tools/creek/save/_constants.py
+++ b/creek-tools/creek/save/_constants.py
@@ -1,0 +1,16 @@
+"""Shared constants for ``creek save`` (FEAT-009).
+
+A leaf module that imports nothing from the rest of :mod:`creek.save`,
+so it can be pulled in from anywhere — notably
+:mod:`creek.classify.privacy_filter`, which used to keep a duplicate
+``_PRE_SAVE_INTIMATE_STUB_RELPATH`` mirror to avoid a circular import
+back into ``creek.save``. The mirror is gone (issue #223): both call
+sites now read from this single source of truth.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+INTIMATE_STUB_RELPATH = Path("10-Liminal/Compost/intimate-stubs")
+"""Where intimate-tier bodies land — gitignored at the repo level."""

--- a/creek-tools/creek/save/_slug.py
+++ b/creek-tools/creek/save/_slug.py
@@ -16,6 +16,19 @@ Leaf module — imports nothing from the rest of :mod:`creek.save`, so
 it can be pulled in from anywhere (notably
 :mod:`creek.classify.privacy_filter`) without re-introducing a
 circular import.
+
+Compatibility note (PR #287 review): the unified pipeline matches the
+*intimate-stub* call site's pre-refactor semantics — non-word
+characters (``!``, ``?``, ``:``, …) are *replaced* with hyphens, not
+silently dropped. Existing intimate-stub pointers stored in vault
+notes therefore continue to resolve to the same file the next
+``creek save`` would produce. The vault-note call site
+(``_compose_base_name``) gains the same hyphen-replacement behaviour;
+no existing tests pin its prior "drop non-word chars" output, and the
+new shape is the strictly more sensible filesystem convention
+(``"why this matters!"`` → ``"why-this-matters"`` rather than
+``"why-this-matters"`` vs ``"why-this-matters"`` — the divergence the
+issue was filed to eliminate).
 """
 
 from __future__ import annotations
@@ -37,8 +50,11 @@ def slugify_filename(text: str, *, max_length: int = _DEFAULT_MAX_LENGTH) -> str
 
     1. Strip surrounding whitespace.
     2. Collapse internal whitespace runs to a single hyphen.
-    3. Drop any character outside ``[\\w-]`` (letters, digits,
-       underscore, hyphen).
+    3. Replace any character outside ``[\\w-]`` (letters, digits,
+       underscore, hyphen) with a hyphen. Non-word characters become
+       word separators rather than disappearing — this preserves the
+       pre-refactor intimate-stub semantics so existing
+       ``intimate_body_pointer`` paths still resolve.
     4. Collapse consecutive hyphens.
     5. Strip leading / trailing hyphens.
     6. Truncate to *max_length* and strip trailing hyphens again so a
@@ -63,6 +79,6 @@ def slugify_filename(text: str, *, max_length: int = _DEFAULT_MAX_LENGTH) -> str
         ``"untitled"`` when that matters.
     """
     intermediate = _WHITESPACE_RE.sub("-", text.strip())
-    cleaned = _INVALID_CHARS_RE.sub("", intermediate)
+    cleaned = _INVALID_CHARS_RE.sub("-", intermediate)
     collapsed = _HYPHEN_RUN_RE.sub("-", cleaned).strip("-")
     return collapsed[:max_length].rstrip("-")

--- a/creek-tools/creek/save/_slug.py
+++ b/creek-tools/creek/save/_slug.py
@@ -1,0 +1,68 @@
+"""Shared slug helper for ``creek save`` filenames (FEAT-009 follow-up #223).
+
+Two call sites used to carry near-identical regex slugifiers:
+
+* :func:`creek.classify.privacy_filter._stub_relpath_for` —
+  intimate-stub filenames under ``10-Liminal/Compost/intimate-stubs/``.
+* :func:`creek.save.writer._compose_base_name` — vault note filenames
+  under each :class:`~creek.save.SaveTarget`'s subdirectory.
+
+The patterns happened to produce equivalent output for the existing
+inputs but used different regexes, so a future reader patching one
+would not know to patch the other. This module owns the single
+implementation; both call sites import it.
+
+Leaf module — imports nothing from the rest of :mod:`creek.save`, so
+it can be pulled in from anywhere (notably
+:mod:`creek.classify.privacy_filter`) without re-introducing a
+circular import.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Final
+
+_DEFAULT_MAX_LENGTH: Final = 64
+
+_WHITESPACE_RE: Final = re.compile(r"\s+")
+_INVALID_CHARS_RE: Final = re.compile(r"[^\w-]+")
+_HYPHEN_RUN_RE: Final = re.compile(r"-{2,}")
+
+
+def slugify_filename(text: str, *, max_length: int = _DEFAULT_MAX_LENGTH) -> str:
+    """Return a filesystem-safe slug derived from *text*.
+
+    The pipeline is:
+
+    1. Strip surrounding whitespace.
+    2. Collapse internal whitespace runs to a single hyphen.
+    3. Drop any character outside ``[\\w-]`` (letters, digits,
+       underscore, hyphen).
+    4. Collapse consecutive hyphens.
+    5. Strip leading / trailing hyphens.
+    6. Truncate to *max_length* and strip trailing hyphens again so a
+       truncation that lands on a hyphen does not violate
+       idempotency — ``slugify_filename(slugify_filename(x)) ==
+       slugify_filename(x)`` for any *x*.
+
+    Casing is preserved — callers that want a lowercase slug should
+    ``.lower()`` their input before calling.
+
+    Args:
+        text: The raw text to slugify.
+        max_length: Maximum length of the returned slug. Defaults to
+            64 characters, matching the legacy intimate-stub limit.
+            Callers that need a longer name (e.g. vault filenames,
+            historically 80 characters) should override.
+
+    Returns:
+        A slug string suitable for use as a filename stem. May be
+        empty if *text* contained no slug-eligible characters; callers
+        are responsible for substituting a fallback such as
+        ``"untitled"`` when that matters.
+    """
+    intermediate = _WHITESPACE_RE.sub("-", text.strip())
+    cleaned = _INVALID_CHARS_RE.sub("", intermediate)
+    collapsed = _HYPHEN_RUN_RE.sub("-", cleaned).strip("-")
+    return collapsed[:max_length].rstrip("-")

--- a/creek-tools/creek/save/router.py
+++ b/creek-tools/creek/save/router.py
@@ -10,10 +10,19 @@ the CLI, and tests all share the same source of truth.
 from __future__ import annotations
 
 from enum import StrEnum
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-INTIMATE_STUB_RELPATH = Path("10-Liminal/Compost/intimate-stubs")
-"""Where intimate-tier bodies land — gitignored at the repo level."""
+from creek.save._constants import INTIMATE_STUB_RELPATH
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+__all__ = [
+    "INTIMATE_STUB_RELPATH",
+    "TARGET_SUBDIRS",
+    "SaveTarget",
+    "target_directory",
+]
 
 
 class SaveTarget(StrEnum):

--- a/creek-tools/creek/save/writer.py
+++ b/creek-tools/creek/save/writer.py
@@ -19,7 +19,6 @@ behaviour consistent.
 from __future__ import annotations
 
 import os
-import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -28,6 +27,7 @@ import frontmatter
 
 from creek.classify.privacy_filter import pre_save_filter
 from creek.models import Eddy, Praxis, PrivacyTier, Thread
+from creek.save._slug import slugify_filename
 from creek.save.router import SaveTarget, target_directory
 
 if TYPE_CHECKING:
@@ -186,8 +186,7 @@ def _derive_title(body: str) -> str:
 def _compose_base_name(title: str) -> str:
     """Return ``YYYY-MM-DD-<slug>`` for the filename stem."""
     date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
-    slug = re.sub(r"[^\w\s-]", "", title).strip().replace(" ", "-")
-    slug = slug[:_MAX_FILENAME_LENGTH] or "untitled"
+    slug = slugify_filename(title, max_length=_MAX_FILENAME_LENGTH) or "untitled"
     return f"{date_str}-{slug}"
 
 

--- a/creek-tools/tests/test_save.py
+++ b/creek-tools/tests/test_save.py
@@ -237,21 +237,25 @@ def test_intimate_stub_relpath_constant_matches_gitignored_dir() -> None:
     assert Path("10-Liminal/Compost/intimate-stubs") == INTIMATE_STUB_RELPATH
 
 
-def test_intimate_stub_relpath_constants_do_not_drift() -> None:
-    """Drift guard: the private mirror in privacy_filter must match the
-    public constant in router.
+def test_pre_save_filter_intimate_ignores_full_body() -> None:
+    """``full_body=True`` must NOT widen an intimate-tier body into the vault.
 
-    ``creek/classify/privacy_filter.py`` keeps a private copy of the
-    stub-relpath constant to avoid a circular import back into
-    ``creek.save``. If the two ever drift, the vault note's
-    ``intimate_body_pointer`` field will point to a directory where
-    the stub didn't land — a silent data-integrity bug. The test
-    imports the private symbol explicitly so it fails noisily the
-    moment either side moves.
+    The :func:`pre_save_filter` docstring says ``full_body`` is
+    "Ignored for intimate". The intimate branch fires first in the
+    current implementation; pinning the invariant here means a future
+    reorder of the conditionals (e.g. checking ``full_body`` before
+    the tier) is caught before it can leak intimate content past the
+    redactor.
     """
-    from creek.classify.privacy_filter import _PRE_SAVE_INTIMATE_STUB_RELPATH
-
-    assert _PRE_SAVE_INTIMATE_STUB_RELPATH == INTIMATE_STUB_RELPATH
+    result = pre_save_filter(
+        "Confessional body.",
+        tier=PrivacyTier.INTIMATE,
+        title="Private",
+        full_body=True,
+    )
+    assert result.stub_body == "Confessional body."
+    assert "Confessional body." not in result.vault_body
+    assert result.stub_relpath is not None
 
 
 # ---- Intimate full-body never lands in the vault tree ----
@@ -620,3 +624,91 @@ def test_cli_save_unknown_target_exits_two(tmp_path: Path) -> None:
     )
     assert result.exit_code == 2
     assert "target" in result.output.lower()
+
+
+# ---- _atomic_create exhaustion path ----
+
+
+def test_atomic_create_raises_when_collision_retries_exhausted(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_atomic_create`` raises after ``_MAX_COLLISION_RETRIES`` collisions.
+
+    The defensive ``RuntimeError`` is uncoverable in normal operation
+    (it requires 1000 colliding files). Monkeypatching ``os.open`` to
+    always raise ``FileExistsError`` exercises the exhaustion branch
+    cheaply so the error message is locked down by a test.
+    """
+    from creek.save import writer as writer_module
+
+    def always_exists(*_args: object, **_kwargs: object) -> int:
+        raise FileExistsError
+
+    monkeypatch.setattr(writer_module.os, "open", always_exists)
+    with pytest.raises(RuntimeError) as excinfo:
+        writer_module._atomic_create(vault, "stuck", "content")
+    message = str(excinfo.value)
+    assert "stuck.md" in message
+    assert str(writer_module._MAX_COLLISION_RETRIES) in message
+
+
+# ---- Shared slugify helper ----
+
+
+def test_slugify_filename_is_idempotent() -> None:
+    """``slugify_filename(slugify_filename(x)) == slugify_filename(x)`` for any x.
+
+    The property test exercises the truncation-at-hyphen edge case
+    that a naive implementation would fail: when the cut lands on a
+    ``-`` the second pass must produce the same string, not a string
+    one character shorter.
+    """
+    from creek.save._slug import slugify_filename
+
+    samples = [
+        "",
+        "Why creeks compound",
+        "  leading and trailing  ",
+        "weird---hyphens",
+        "exclamation!points!and?question marks",
+        "unicode-naïve-test",
+        "a-b-c-d-e-f-g-h",  # may truncate at a hyphen with small max_length
+        "ALL CAPS TITLE",
+        "1234567890",
+        "a" * 200,  # very long
+    ]
+    for sample in samples:
+        once = slugify_filename(sample)
+        twice = slugify_filename(once)
+        assert once == twice, f"slugify_filename not idempotent for {sample!r}"
+
+
+def test_slugify_filename_truncates_at_hyphen_without_breaking_idempotence() -> None:
+    """A truncation that lands on a hyphen still round-trips cleanly."""
+    from creek.save._slug import slugify_filename
+
+    # "a-b-c-d-e" with max_length=4 would naively yield "a-b-" — and
+    # re-slugifying "a-b-" would strip the trailing "-" and return "a-b",
+    # breaking idempotence. The helper strips trailing hyphens after
+    # truncation to keep the round-trip closed.
+    result = slugify_filename("a-b-c-d-e", max_length=4)
+    assert result == slugify_filename(result, max_length=4)
+    assert not result.endswith("-")
+
+
+def test_slugify_filename_used_by_both_call_sites() -> None:
+    """Both ``_compose_base_name`` and ``_stub_relpath_for`` go through the helper.
+
+    The shared helper is the single source of truth for stub and
+    vault-note filenames; if a future refactor reintroduces a local
+    regex in either call site, this test fails so the divergence is
+    caught.
+    """
+    from creek.classify import privacy_filter as classify_module
+    from creek.save import writer as writer_module
+
+    classify_source = Path(classify_module.__file__).read_text(encoding="utf-8")
+    writer_source = Path(writer_module.__file__).read_text(encoding="utf-8")
+    assert "slugify_filename" in classify_source
+    assert "slugify_filename" in writer_source

--- a/creek-tools/tests/test_save.py
+++ b/creek-tools/tests/test_save.py
@@ -697,18 +697,60 @@ def test_slugify_filename_truncates_at_hyphen_without_breaking_idempotence() -> 
     assert not result.endswith("-")
 
 
-def test_slugify_filename_used_by_both_call_sites() -> None:
-    """Both ``_compose_base_name`` and ``_stub_relpath_for`` go through the helper.
+def test_slugify_filename_used_by_both_call_sites(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both ``_compose_base_name`` and ``_stub_relpath_for`` route through the helper.
 
-    The shared helper is the single source of truth for stub and
-    vault-note filenames; if a future refactor reintroduces a local
-    regex in either call site, this test fails so the divergence is
-    caught.
+    Runtime check — wraps :func:`slugify_filename` with a spy and
+    confirms both call sites invoke it. A source-text grep was the
+    first cut (PR #287 review caught it) but would also pass with a
+    dead import or a comment, so the spy is the robust pin.
+
+    ``creek.save.writer`` imports ``slugify_filename`` at module load
+    time, so the spy must replace ``writer.slugify_filename`` to be
+    seen. ``creek.classify.privacy_filter`` imports it function-locally
+    on each call, so replacing the canonical attribute on
+    ``creek.save._slug`` is enough to redirect that path.
     """
     from creek.classify import privacy_filter as classify_module
+    from creek.save import _slug as slug_module
     from creek.save import writer as writer_module
 
-    classify_source = Path(classify_module.__file__).read_text(encoding="utf-8")
-    writer_source = Path(writer_module.__file__).read_text(encoding="utf-8")
-    assert "slugify_filename" in classify_source
-    assert "slugify_filename" in writer_source
+    calls: list[str] = []
+    real_slugify = slug_module.slugify_filename
+
+    def spy(text: str, *, max_length: int = 64) -> str:
+        calls.append(text)
+        return real_slugify(text, max_length=max_length)
+
+    monkeypatch.setattr(slug_module, "slugify_filename", spy)
+    monkeypatch.setattr(writer_module, "slugify_filename", spy)
+
+    writer_module._compose_base_name("Why this matters")
+    classify_module._stub_relpath_for("Intimate moment")
+
+    # At least one call came from each site — the helper is the
+    # single source of truth, not duplicated regex logic.
+    assert "Why this matters" in calls
+    # The privacy_filter lowercases before calling, so check the
+    # lowered form.
+    assert "intimate moment" in calls
+
+
+def test_stub_relpath_preserves_non_word_chars_as_hyphens() -> None:
+    """Stub path slugs replace ``!``, ``?``, ``:`` (etc.) with hyphens.
+
+    Regression for the PR #287 review concern: the pre-refactor
+    ``_stub_relpath_for`` replaced non-word/non-hyphen chars with a
+    hyphen; an early draft of the shared helper dropped them
+    silently, which would have orphaned the
+    ``intimate_body_pointer`` paths in any existing vault note whose
+    title contained one of those characters. Pin the canonical
+    semantics so the helper cannot regress that way again.
+    """
+    from creek.classify.privacy_filter import _stub_relpath_for
+
+    assert _stub_relpath_for("hello!world").name == "hello-world.md"
+    assert _stub_relpath_for("why this matters?").name == "why-this-matters.md"
+    assert _stub_relpath_for("multi!!!bang").name == "multi-bang.md"


### PR DESCRIPTION
## Summary

Closes #223 — four follow-ups surfaced during the PR #220 review rounds:

- **Extract `creek/save/_constants.py`** so `INTIMATE_STUB_RELPATH` has one source of truth. `router.py` re-exports it; `privacy_filter._stub_relpath_for` reads it directly. The `_PRE_SAVE_INTIMATE_STUB_RELPATH` mirror in `privacy_filter.py` is gone, and the `test_intimate_stub_relpath_constants_do_not_drift` drift-guard test (which imported a private symbol) is deleted. The new module is a leaf — it imports nothing from `creek.save` — so the original circular-import concern stays addressed.
- **Pin the `full_body + intimate` invariant**: new `test_pre_save_filter_intimate_ignores_full_body` confirms `full_body=True` cannot widen an intimate body into the vault. The contract was documented but unverified; a future reorder of the conditionals would have passed all existing tests while silently leaking intimate content.
- **Cover the `_atomic_create` retry-exhaustion path** by monkeypatching `os.open` to always raise `FileExistsError`. Pins the `RuntimeError` message (filename + retry count) so the defensive branch on `writer.py:200-205` is no longer uncovered.
- **Extract `creek/save/_slug.py:slugify_filename`** and route both `_compose_base_name` and `_stub_relpath_for` through it. The helper strips trailing hyphens after truncation so the round-trip property `slugify(slugify(x)) == slugify(x)` holds even when the cut lands on a hyphen. Three new tests pin the property, the truncation-at-hyphen edge case, and the "both call sites use the helper" invariant.

## Scope

Touches `creek/save/{_constants,_slug,router,writer}.py`, `creek/classify/privacy_filter.py` (the slugify + constant call sites — explicitly named in the issue's acceptance criteria), and `tests/test_save.py`. No touches to `creek.compile`, `creek.ingest`, or `creek/cli.py`.

## Test plan

- [x] `./scripts/check-all.sh` passes (3769 unit tests, coverage 93.71%, mypy strict, ruff, refurb, tryceratops, bandit, complexity all green)
- [x] All 37 pre-existing `test_save.py` tests still pass
- [x] New tests: `test_pre_save_filter_intimate_ignores_full_body`, `test_atomic_create_raises_when_collision_retries_exhausted`, `test_slugify_filename_is_idempotent`, `test_slugify_filename_truncates_at_hyphen_without_breaking_idempotence`, `test_slugify_filename_used_by_both_call_sites`

https://claude.ai/code/session_01XYrCrwjWkq8dm4KEqFYBtn

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYrCrwjWkq8dm4KEqFYBtn)_