### PR TITLE
refactor(ingest): typed payload slot replaces dict round-trip (#166)

### DIFF
--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -65,19 +65,50 @@ class ParsedFragment(BaseModel):
 
     Represents one logical unit of content after parsing, with its
     source provenance and timestamp.
+
+    Ingestors with rich structured backend output (workbooks, slide
+    decks, etc.) should stash that output on :attr:`payload` as a
+    typed dataclass and use :attr:`metadata` only for the small set of
+    frontmatter-relevant scalars. See the class docstring of
+    :class:`Ingestor` for the migration story.
     """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     content: str
     """The extracted text content."""
 
     metadata: dict[str, Any]
-    """Arbitrary metadata from parsing (e.g., headers, tags)."""
+    """Frontmatter-relevant scalars from parsing.
+
+    Kept as an untyped dict so YAML serialisation in
+    :meth:`Ingestor.generate_frontmatter` stays trivial. Reach for
+    :attr:`payload` when you need to round-trip structured data
+    between :meth:`Ingestor.parse` and :meth:`Ingestor.convert_to_markdown`
+    without erasing types or duplicating the schema in two places.
+    """
 
     source_path: str
     """Path to the original source file."""
 
     timestamp: datetime
     """Timestamp associated with this fragment."""
+
+    payload: Any = None
+    """Optional typed intermediate from the ingestor backend.
+
+    Carry the backend's structured dataclass (``SheetData``,
+    ``PresentationData``, etc.) here instead of flattening it into
+    :attr:`metadata`. :meth:`Ingestor.convert_to_markdown` reads the
+    typed payload directly — no string-keyed dict access, no implicit
+    schema duplicated between the parse and convert sites, and mypy
+    catches a renamed field at the call site rather than letting it
+    silently flow through.
+
+    Defaults to ``None`` so the pre-FEAT-024 ingestors (chatgpt,
+    markdown, html, code, …) that don't need structured payloads are
+    not forced to set a slot they don't use.
+    """
 
 
 class ProvenanceEntry(BaseModel):

--- a/creek-tools/creek/ingest/presentations.py
+++ b/creek-tools/creek/ingest/presentations.py
@@ -249,18 +249,10 @@ class PresentationIngestor(Ingestor):
                     "original_file": str(raw.path),
                     "title": data.title or raw.path.stem,
                     "slide_count": len(data.slides),
-                    "slides": [
-                        {
-                            "index": slide.index,
-                            "title": slide.title or "",
-                            "body": slide.body,
-                            "notes": slide.notes,
-                        }
-                        for slide in data.slides
-                    ],
                 },
                 source_path=str(raw.path),
                 timestamp=timestamp,
+                payload=data,
             ),
         ]
 
@@ -269,22 +261,25 @@ class PresentationIngestor(Ingestor):
 
         One ``## Slide N: Title`` block per slide with the body inlined
         and speaker notes (when present) under a ``**Speaker notes:**``
-        sub-section.
+        sub-section. Reads the typed :class:`PresentationData` off
+        :attr:`~creek.ingest.base.ParsedFragment.payload` rather than
+        re-parsing a dict mirror in ``metadata`` (issue #166).
         """
         title = str(fragment.metadata.get("title", "Presentation"))
-        slides: list[dict[str, Any]] = list(fragment.metadata.get("slides", []))
+        data = fragment.payload
+        slides: tuple[SlideData, ...] = (
+            data.slides if isinstance(data, PresentationData) else ()
+        )
         lines: list[str] = [f"# {title}", ""]
         for slide in slides:
-            heading = f"## Slide {slide['index']}"
-            if slide.get("title"):
-                heading = f"{heading}: {slide['title']}"
+            heading = f"## Slide {slide.index}"
+            if slide.title:
+                heading = f"{heading}: {slide.title}"
             lines.extend((heading, ""))
-            body = str(slide.get("body", ""))
-            if body:
-                lines.extend((body, ""))
-            notes = str(slide.get("notes", ""))
-            if notes:
-                lines.extend(("**Speaker notes:**", "", notes, ""))
+            if slide.body:
+                lines.extend((slide.body, ""))
+            if slide.notes:
+                lines.extend(("**Speaker notes:**", "", slide.notes, ""))
         return "\n".join(lines).rstrip() + "\n"
 
     def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:

--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -392,11 +392,10 @@ class SpreadsheetIngestor(Ingestor):
                         "sheet": sheet.name,
                         "rows": len(sheet.rows),
                         "columns": column_count,
-                        "headers": list(sheet.headers) if sheet.headers else [],
-                        "row_data": [list(row) for row in sheet.rows],
                     },
                     source_path=str(raw.path),
                     timestamp=timestamp,
+                    payload=sheet,
                 ),
             )
         return fragments
@@ -436,9 +435,18 @@ class SpreadsheetIngestor(Ingestor):
 def _extract_headers_and_rows(
     fragment: ParsedFragment,
 ) -> tuple[list[str], list[list[str]]]:
-    """Return ``(headers, rows)`` from a parsed fragment's metadata."""
-    headers: list[str] = list(fragment.metadata.get("headers", []))
-    rows: list[list[str]] = [list(row) for row in fragment.metadata.get("row_data", [])]
+    """Return ``(headers, rows)`` from a parsed fragment's typed payload.
+
+    Reads the typed :class:`SheetData` off
+    :attr:`~creek.ingest.base.ParsedFragment.payload` to avoid the
+    string-keyed metadata round-trip ``"headers"`` / ``"row_data"``
+    that the pre-refactor code paid (issue #166).
+    """
+    sheet = fragment.payload
+    if not isinstance(sheet, SheetData):
+        return [], []
+    headers: list[str] = list(sheet.headers) if sheet.headers else []
+    rows: list[list[str]] = [list(row) for row in sheet.rows]
     if not headers and rows:
         headers = [f"col{i + 1}" for i in range(len(rows[0]))]
     return headers, rows

--- a/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
+++ b/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
@@ -281,6 +281,38 @@ class TestSpreadsheetParse:
         fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
         assert fragments == []
 
+    def test_parsed_fragment_carries_typed_sheetdata_payload(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Sheet structure is carried as a typed :class:`SheetData`, not a dict.
+
+        Issue #166 — the pre-refactor code flattened the backend's
+        ``SheetData`` into ``metadata["headers"]`` /
+        ``metadata["row_data"]`` and ``convert_to_markdown`` re-read
+        them. The new contract puts the typed object on
+        :attr:`ParsedFragment.payload` so the schema lives in one
+        place and mypy can catch a rename at the call site.
+        """
+        path = tmp_path / "typed.xlsx"
+        _write_xlsx_placeholder(path)
+        original = SheetData(
+            name="Typed",
+            headers=("a", "b"),
+            rows=(("1", "2"),),
+        )
+        backend = StubSpreadsheetBackend(
+            workbooks={"typed.xlsx": WorkbookData(sheets=(original,))},
+        )
+        ingestor = SpreadsheetIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert fragments[0].payload is original
+        # The structured fields are NOT mirrored back into the dict,
+        # so a refactor that drops the mirror later does not regress
+        # this test.
+        assert "headers" not in fragments[0].metadata
+        assert "row_data" not in fragments[0].metadata
+
 
 # ---- convert_to_markdown ----------------------------------------------
 
@@ -582,8 +614,10 @@ class TestHasHeaderOverride:
         ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
         fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
         # The heuristic promotes the first row, so "France" lands in headers.
-        assert fragments[0].metadata["headers"] == ["France", "Germany", "Spain"]
-        assert fragments[0].metadata["row_data"] == [
+        sheet = fragments[0].payload
+        assert isinstance(sheet, SheetData)
+        assert list(sheet.headers or ()) == ["France", "Germany", "Spain"]
+        assert [list(row) for row in sheet.rows] == [
             ["Italy", "Greece", "Portugal"],
         ]
 
@@ -604,8 +638,10 @@ class TestHasHeaderOverride:
         ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
         raws = ingestor.discover(tmp_path)
         fragments = ingestor.parse(raws[0], has_header=False)
-        assert fragments[0].metadata["headers"] == []
-        assert fragments[0].metadata["row_data"] == [
+        sheet = fragments[0].payload
+        assert isinstance(sheet, SheetData)
+        assert sheet.headers in (None, ())
+        assert [list(row) for row in sheet.rows] == [
             ["France", "Germany", "Spain"],
             ["Italy", "Greece", "Portugal"],
         ]
@@ -629,8 +665,10 @@ class TestHasHeaderOverride:
         ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
         raws = ingestor.discover(tmp_path)
         fragments = ingestor.parse(raws[0], has_header=True)
-        assert fragments[0].metadata["headers"] == ["name", "", "city"]
-        assert fragments[0].metadata["row_data"] == [["Alice", "30", "NYC"]]
+        sheet = fragments[0].payload
+        assert isinstance(sheet, SheetData)
+        assert list(sheet.headers or ()) == ["name", "", "city"]
+        assert [list(row) for row in sheet.rows] == [["Alice", "30", "NYC"]]
 
     def test_csv_has_header_none_matches_default_call(
         self,
@@ -643,8 +681,12 @@ class TestHasHeaderOverride:
         raws = ingestor.discover(tmp_path)
         default = ingestor.parse(raws[0])
         explicit_none = ingestor.parse(raws[0], has_header=None)
-        assert default[0].metadata["headers"] == explicit_none[0].metadata["headers"]
-        assert default[0].metadata["row_data"] == explicit_none[0].metadata["row_data"]
+        default_sheet = default[0].payload
+        explicit_sheet = explicit_none[0].payload
+        assert isinstance(default_sheet, SheetData)
+        assert isinstance(explicit_sheet, SheetData)
+        assert default_sheet.headers == explicit_sheet.headers
+        assert default_sheet.rows == explicit_sheet.rows
 
     def test_stub_backend_receives_has_header(self, tmp_path: Path) -> None:
         """``has_header`` propagates from ingestor.parse to backend.read_workbook.
@@ -717,8 +759,10 @@ class TestHasHeaderOverride:
         ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
         raws = ingestor.discover(tmp_path)
         fragments = ingestor.parse(raws[0], has_header=False)
-        assert fragments[0].metadata["headers"] == []
-        assert fragments[0].metadata["row_data"] == [
+        sheet = fragments[0].payload
+        assert isinstance(sheet, SheetData)
+        assert sheet.headers in (None, ())
+        assert [list(row) for row in sheet.rows] == [
             ["France", "Germany", "Spain"],
             ["Italy", "Greece", "Portugal"],
         ]
@@ -844,6 +888,28 @@ class TestPresentationParse:
         assert len(fragments) == 1
         assert fragments[0].metadata["slide_count"] == 2
         assert fragments[0].metadata["title"] == "My Talk"
+
+    def test_parsed_fragment_carries_typed_presentationdata_payload(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Slide structure rides on a typed :class:`PresentationData` payload.
+
+        Issue #166 — the pre-refactor code dict-ified every slide into
+        ``metadata["slides"]`` and ``convert_to_markdown`` re-parsed
+        the list of dicts. The typed payload eliminates that round-trip.
+        """
+        path = tmp_path / "typed.pptx"
+        _write_pptx_placeholder(path)
+        original = PresentationData(
+            title="Typed Deck",
+            slides=(SlideData(index=1, title="A", body="B"),),
+        )
+        backend = StubPresentationBackend(presentations={"typed.pptx": original})
+        ingestor = PresentationIngestor(backend=backend)
+        fragments = ingestor.parse(ingestor.discover(tmp_path)[0])
+        assert fragments[0].payload is original
+        assert "slides" not in fragments[0].metadata
 
     def test_markdown_renders_one_section_per_slide(
         self,


### PR DESCRIPTION
## Summary

Closes #166. Replaces the implicit-dict-schema round-trip between `parse()` and `convert_to_markdown()` with a typed payload slot on `ParsedFragment`.

- **`ParsedFragment.payload: Any = None`** — opt-in slot for the ingestor backend's frozen dataclass. `arbitrary_types_allowed=True` on the model so backends can stash their dataclass directly. The class docstring documents the migration contract (use `payload` for typed structured data; keep `metadata` for frontmatter-relevant scalars).
- **`SpreadsheetIngestor`** — `SheetData` lands on `payload`. `_extract_headers_and_rows` reads it with `isinstance`. `metadata["headers"]` and `metadata["row_data"]` are gone; the dict only carries `original_file`, `sheet`, `rows`, `columns` (the fields YAML frontmatter actually needs).
- **`PresentationIngestor`** — `PresentationData` lands on `payload`. `convert_to_markdown` iterates `SlideData` directly. The `metadata["slides"]` dict mirror is gone.
- **Tests** — every assertion that read structured data from `metadata` now reads from `payload`. Two new regression tests (one per ingestor) pin the typed-payload contract: `test_parsed_fragment_carries_typed_sheetdata_payload`, `test_parsed_fragment_carries_typed_presentationdata_payload`. Both assert the dict mirror is *absent* so a future drift back to the round-trip is caught.

Per the issue's "out of scope" note, `metadata` is preserved for frontmatter generation — the YAML serialiser keeps consuming the dict. Other ingestors that have no structured backend output (chatgpt, markdown, html, code, …) are untouched; they can migrate incrementally if a need arises.

## Scope

Stays inside `creek.ingest` — `creek/ingest/base.py`, `creek/ingest/spreadsheets.py`, `creek/ingest/presentations.py`, and `tests/test_spreadsheet_presentation_ingestors.py`. No touches to `creek.compile`, `creek.save`, or `creek/cli.py`.

## Test plan

- [x] `./scripts/check-all.sh` passes (3767 unit tests, coverage 93.69%, mypy strict, ruff, refurb, tryceratops, bandit, complexity all green)
- [x] All 47 pre-existing spreadsheet/presentation tests still pass
- [x] New regression tests: `test_parsed_fragment_carries_typed_sheetdata_payload`, `test_parsed_fragment_carries_typed_presentationdata_payload`

https://claude.ai/code/session_01XYrCrwjWkq8dm4KEqFYBtn

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYrCrwjWkq8dm4KEqFYBtn)_