### PR TITLE
feat(link): hierarchy-aware resonance suppression (FEAT-024) (#255)

### DIFF
--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -117,6 +117,20 @@ class LinkingConfig(BaseModel):
     same ``session`` by the FEAT-022 aggregator. Inclusive boundary.
     """
 
+    hierarchy_sibling_skip_window: int = Field(default=2, ge=0)
+    """FEAT-024 sibling-suppression window for hierarchy-aware linking.
+
+    With re-atomization (FEAT-020..023) every parent fragment shares the
+    vault with its own children, and adjacent children of one parent are
+    usually topically continuous — so naive cosine similarity emits noise
+    instead of meaningful resonances. The embedding linker drops pairs
+    that are ancestor/descendant unconditionally, and pairs that share a
+    parent and sit within this many positions of each other in the
+    parent's ``child_ids`` list. ``0`` disables sibling suppression
+    entirely (ancestor suppression still applies); the default of ``2``
+    skips immediate and one-removed neighbours on either side.
+    """
+
 
 class ClassificationConfig(BaseModel):
     """Classification pipeline configuration."""

--- a/creek-tools/creek/generate/synchronicity.py
+++ b/creek-tools/creek/generate/synchronicity.py
@@ -23,12 +23,13 @@ from typing import TYPE_CHECKING
 
 import frontmatter
 
+from creek.link.embeddings import Resonance
 from creek.models import Synchronicity
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from creek.models import Fragment
+    from creek.models import Fragment, FragmentLevel
 
 DEFAULT_SIMILARITY_THRESHOLD: float = 0.9
 """Cosine similarity must exceed this value to qualify as a synchronicity."""
@@ -80,6 +81,45 @@ def _share_project(title_a: str, title_b: str) -> bool:
     return bool(_extract_proper_nouns(title_a) & _extract_proper_nouns(title_b))
 
 
+_LEGACY_TUPLE_ARITY: int = 3
+"""Pre-FEAT-024 resonance tuple shape: (id_a, id_b, similarity)."""
+
+
+def _normalise_resonance(
+    resonance: Resonance | tuple[str, str, float] | object,
+) -> tuple[str, str, float, FragmentLevel, FragmentLevel] | None:
+    """Unpack either resonance flavour into a uniform 5-tuple.
+
+    Accepting both the canonical :class:`Resonance` model and the
+    pre-FEAT-024 ``(id_a, id_b, similarity)`` tuple keeps existing
+    callers (and historical fixtures in test suites) working through
+    the transition. Any other shape is returned as ``None`` so the
+    detection loop can skip it without raising.
+
+    Args:
+        resonance: A :class:`Resonance`, a legacy 3-tuple, or some
+            other object.
+
+    Returns:
+        ``(fragment_a_id, fragment_b_id, similarity, from_level,
+        to_level)`` for recognised shapes; ``None`` otherwise.
+    """
+    if isinstance(resonance, Resonance):
+        # ``model_config`` is set to ``use_enum_values=False`` by default,
+        # so the level fields are already plain ``FragmentLevel`` strings.
+        return (
+            resonance.fragment_a_id,
+            resonance.fragment_b_id,
+            resonance.similarity,
+            resonance.from_level,
+            resonance.to_level,
+        )
+    if isinstance(resonance, tuple) and len(resonance) == _LEGACY_TUPLE_ARITY:
+        frag_a_id, frag_b_id, similarity = resonance
+        return (frag_a_id, frag_b_id, similarity, "document", "document")
+    return None
+
+
 class SynchronicityDetector:
     """Filter resonances down to meaningful cross-source synchronicities.
 
@@ -107,33 +147,57 @@ class SynchronicityDetector:
 
     def detect_synchronicities(
         self,
-        resonances: list[tuple[str, str, float]],
+        resonances: list[Resonance] | list[tuple[str, str, float]],
         fragments: dict[str, Fragment],
     ) -> list[Synchronicity]:
         """Filter *resonances* into :class:`Synchronicity` records.
 
+        FEAT-024 ranks cross-level pairs (``level_a != level_b``) ahead
+        of same-level pairs in the returned list — when a sentence-level
+        child resonates with an exchange-level fragment from a different
+        source, that asymmetry is itself a signal worth surfacing
+        deliberately rather than burying among same-level matches.
+
         Args:
-            resonances: Tuples of ``(fragment_id_a, fragment_id_b,
-                similarity)`` as emitted by
-                :class:`~creek.link.embeddings.EmbeddingLinker`.
+            resonances: :class:`Resonance` records (canonical) or the
+                legacy ``(fragment_id_a, fragment_id_b, similarity)``
+                tuple form, both emitted by
+                :class:`~creek.link.embeddings.EmbeddingLinker` across
+                FEAT-024's transition. Tuples carry no level metadata,
+                so synchronicities derived from them keep the default
+                ``"document"`` levels.
             fragments: Mapping of fragment ID to :class:`Fragment` used
                 to inspect metadata.  Resonances referencing unknown IDs
                 are silently skipped.
 
         Returns:
             A list of :class:`Synchronicity` objects, one per qualifying
-            resonance, with the earlier fragment stored in
-            ``fragment_a_id``.
+            resonance, sorted with cross-level pairs first (highest
+            similarity within each group).
         """
         results: list[Synchronicity] = []
-        for frag_a_id, frag_b_id, similarity in resonances:
+        for resonance in resonances:
+            normalised = _normalise_resonance(resonance)
+            if normalised is None:
+                continue
+            frag_a_id, frag_b_id, similarity, from_level, to_level = normalised
             frag_a = fragments.get(frag_a_id)
             frag_b = fragments.get(frag_b_id)
             if frag_a is None or frag_b is None:
                 continue
-            sync = self._evaluate_pair(frag_a, frag_b, similarity)
+            sync = self._evaluate_pair(
+                frag_a,
+                frag_b,
+                similarity,
+                from_level=from_level,
+                to_level=to_level,
+            )
             if sync is not None:
                 results.append(sync)
+        # Cross-level pairs (level_a != level_b) sort first; within each
+        # group, highest similarity wins. The boolean sort key works
+        # because Python sorts ``False`` before ``True``.
+        results.sort(key=lambda s: (s.level_a == s.level_b, -s.similarity))
         return results
 
     def _evaluate_pair(
@@ -141,6 +205,9 @@ class SynchronicityDetector:
         frag_a: Fragment,
         frag_b: Fragment,
         similarity: float,
+        *,
+        from_level: FragmentLevel,
+        to_level: FragmentLevel,
     ) -> Synchronicity | None:
         """Return a :class:`Synchronicity` if the pair passes every criterion.
 
@@ -148,6 +215,10 @@ class SynchronicityDetector:
             frag_a: First fragment in the resonance pair.
             frag_b: Second fragment in the resonance pair.
             similarity: Cosine similarity score for the pair.
+            from_level: Structural level recorded on the resonance for
+                ``frag_a`` (defaults to ``"document"`` for legacy tuples).
+            to_level: Structural level recorded on the resonance for
+                ``frag_b``.
 
         Returns:
             A :class:`Synchronicity` record, or ``None`` if any criterion
@@ -158,7 +229,12 @@ class SynchronicityDetector:
         if frag_a.source.platform == frag_b.source.platform:
             return None
 
-        earlier, later = self._chronological_pair(frag_a, frag_b)
+        earlier, later, level_earlier, level_later = self._chronological_pair(
+            frag_a,
+            frag_b,
+            from_level=from_level,
+            to_level=to_level,
+        )
         gap_days = (later.created - earlier.created).days
         if gap_days <= self.min_time_gap_days:
             return None
@@ -177,17 +253,37 @@ class SynchronicityDetector:
             time_gap_days=gap_days,
             source_a=earlier.source.platform,
             source_b=later.source.platform,
+            level_a=level_earlier,
+            level_b=level_later,
         )
 
     @staticmethod
     def _chronological_pair(
         frag_a: Fragment,
         frag_b: Fragment,
-    ) -> tuple[Fragment, Fragment]:
-        """Return the pair ordered ``(earlier, later)`` by creation time."""
+        *,
+        from_level: FragmentLevel,
+        to_level: FragmentLevel,
+    ) -> tuple[Fragment, Fragment, FragmentLevel, FragmentLevel]:
+        """Return the pair ordered ``(earlier, later, lvl_earlier, lvl_later)``.
+
+        Ordering by creation time matches what the synchronicity record
+        promises (``fragment_a_id`` is always the earlier of the two);
+        the levels follow the same flip so callers can attribute each
+        level to the right endpoint without re-checking timestamps.
+
+        Args:
+            frag_a: First fragment in the resonance pair.
+            frag_b: Second fragment in the resonance pair.
+            from_level: Resonance-recorded level of ``frag_a``.
+            to_level: Resonance-recorded level of ``frag_b``.
+
+        Returns:
+            ``(earlier, later, level_earlier, level_later)``.
+        """
         if frag_a.created <= frag_b.created:
-            return frag_a, frag_b
-        return frag_b, frag_a
+            return frag_a, frag_b, from_level, to_level
+        return frag_b, frag_a, to_level, from_level
 
     def create_synchronicity_note(
         self,

--- a/creek-tools/creek/generate/synchronicity.py
+++ b/creek-tools/creek/generate/synchronicity.py
@@ -18,6 +18,7 @@ The criteria are deliberately strict:
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import TYPE_CHECKING
 
@@ -30,6 +31,8 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from creek.models import Fragment, FragmentLevel
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_SIMILARITY_THRESHOLD: float = 0.9
 """Cosine similarity must exceed this value to qualify as a synchronicity."""
@@ -86,19 +89,18 @@ _LEGACY_TUPLE_ARITY: int = 3
 
 
 def _normalise_resonance(
-    resonance: Resonance | tuple[str, str, float] | object,
+    resonance: Resonance | tuple[str, str, float],
 ) -> tuple[str, str, float, FragmentLevel, FragmentLevel] | None:
     """Unpack either resonance flavour into a uniform 5-tuple.
 
     Accepting both the canonical :class:`Resonance` model and the
     pre-FEAT-024 ``(id_a, id_b, similarity)`` tuple keeps existing
     callers (and historical fixtures in test suites) working through
-    the transition. Any other shape is returned as ``None`` so the
-    detection loop can skip it without raising.
+    the transition. Any other shape is logged and returned as ``None``
+    so the detection loop can skip it without raising.
 
     Args:
-        resonance: A :class:`Resonance`, a legacy 3-tuple, or some
-            other object.
+        resonance: A :class:`Resonance` or a legacy 3-tuple.
 
     Returns:
         ``(fragment_a_id, fragment_b_id, similarity, from_level,
@@ -117,6 +119,11 @@ def _normalise_resonance(
     if isinstance(resonance, tuple) and len(resonance) == _LEGACY_TUPLE_ARITY:
         frag_a_id, frag_b_id, similarity = resonance
         return (frag_a_id, frag_b_id, similarity, "document", "document")
+    logger.warning(
+        "Unrecognised resonance shape %r; skipping. Pass a Resonance or "
+        "a (id_a, id_b, similarity) tuple.",
+        type(resonance).__name__,
+    )
     return None
 
 

--- a/creek-tools/creek/link/__init__.py
+++ b/creek-tools/creek/link/__init__.py
@@ -4,6 +4,7 @@ This package provides the four linking stages of the Creek pipeline.
 
 Public API:
     - ``EmbeddingLinker`` — generate embeddings and find semantic resonances
+    - ``Resonance`` — hierarchy-aware resonance edge (FEAT-024)
     - ``TemporalLink`` — scored temporal proximity link between two fragments
     - ``TemporalLinker`` — find temporal proximity links across sources
     - ``ThreadDetector`` — detect narrative threads
@@ -13,7 +14,7 @@ Public API:
 """
 
 from creek.link.eddies import EddyDetector
-from creek.link.embeddings import EmbeddingLinker
+from creek.link.embeddings import EmbeddingLinker, Resonance
 from creek.link.linker import LinkingPipeline, LinkingResult
 from creek.link.temporal import TemporalLink, TemporalLinker
 from creek.link.threads import ThreadDetector
@@ -23,6 +24,7 @@ __all__ = [
     "EmbeddingLinker",
     "LinkingPipeline",
     "LinkingResult",
+    "Resonance",
     "TemporalLink",
     "TemporalLinker",
     "ThreadDetector",

--- a/creek-tools/creek/link/embeddings.py
+++ b/creek-tools/creek/link/embeddings.py
@@ -17,7 +17,15 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Final, cast
 
+from pydantic import BaseModel
 from tqdm import tqdm
+
+# FragmentLevel is a Literal alias that Pydantic resolves at class-creation
+# time when building ``Resonance``'s field schema; moving it under
+# TYPE_CHECKING would leave the symbol undefined and crash the import.
+from creek.models import (
+    FragmentLevel,  # noqa: TC001  # Issue #255: Pydantic runtime resolution
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -28,6 +36,15 @@ if TYPE_CHECKING:
     from creek.config import EmbeddingsConfig
     from creek.models import Fragment
 
+_DEFAULT_LEVEL: Final[FragmentLevel] = "document"
+"""Fallback level for fragments not present in the supplied lookup map.
+
+When :meth:`EmbeddingLinker.find_resonances` is called without a
+``fragments`` argument (the flat-fragment / pre-FEAT-020 contract), every
+resonance reports both endpoints at ``"document"`` level — which matches
+``Fragment.level``'s own default and keeps the regression test honest.
+"""
+
 logger = logging.getLogger(__name__)
 
 EMBEDDINGS_CACHE_FILENAME: Final[str] = "embeddings.parquet"
@@ -35,6 +52,31 @@ EMBEDDINGS_CACHE_FILENAME: Final[str] = "embeddings.parquet"
 
 EMBEDDINGS_CACHE_DIR: Final[str] = "00-Creek-Meta"
 """Vault subdirectory that holds the embeddings cache."""
+
+
+class Resonance(BaseModel):
+    """A semantic resonance edge between two fragments (FEAT-024).
+
+    Replaces the old ``(fragment_a_id, fragment_b_id, similarity)`` tuple
+    so downstream surfaces (synchronicity detection, mining) can read
+    the structural level of each endpoint without re-joining against the
+    fragment table. The two ``*_level`` fields default to ``"document"``
+    so flat-fragment vaults — where no hierarchy has been carved —
+    report a stable, predictable value rather than ``None``.
+
+    Attributes:
+        fragment_a_id: ID of the first fragment in the resonance.
+        fragment_b_id: ID of the second fragment in the resonance.
+        similarity: Cosine similarity between the two embedding vectors.
+        from_level: Structural level of ``fragment_a_id``'s fragment.
+        to_level: Structural level of ``fragment_b_id``'s fragment.
+    """
+
+    fragment_a_id: str
+    fragment_b_id: str
+    similarity: float
+    from_level: FragmentLevel = _DEFAULT_LEVEL
+    to_level: FragmentLevel = _DEFAULT_LEVEL
 
 
 @dataclass(frozen=True)
@@ -120,6 +162,128 @@ def _load_sentence_transformer(
         "SentenceTransformerType",
         SentenceTransformer(model_name, cache_folder=cache_folder),
     )
+
+
+def _hierarchy_index(
+    fragments: Mapping[str, Fragment] | None,
+) -> tuple[dict[str, frozenset[str]], dict[str, tuple[str, int]]]:
+    """Precompute ancestor sets and sibling positions for hierarchy filtering.
+
+    Two derived structures keep the per-pair check in
+    :meth:`EmbeddingLinker.find_resonances` O(1) amortised:
+
+    - ``ancestors[fid]`` is the frozen set of every fragment ID reachable
+      by walking ``parent_id`` upward from *fid*. Used by the
+      ancestor/descendant pair check.
+    - ``sibling_positions[child_id] = (parent_id, index)`` records each
+      child's slot in its parent's ``child_ids`` list. Built from the
+      *parent's* declaration so the index is anchored in the canonical
+      sibling order (which the FEAT-021 splitter and FEAT-022 aggregator
+      both emit deterministically).
+
+    Args:
+        fragments: Mapping of fragment ID to :class:`Fragment`, or
+            ``None`` when no hierarchy data is available.
+
+    Returns:
+        A tuple ``(ancestors, sibling_positions)``. Both maps are empty
+        when *fragments* is ``None`` or empty — suppression then becomes
+        a no-op without special-casing in the caller.
+    """
+    if not fragments:
+        return {}, {}
+
+    sibling_positions: dict[str, tuple[str, int]] = {}
+    for parent_id, parent in fragments.items():
+        for index, child_id in enumerate(parent.child_ids):
+            sibling_positions[child_id] = (parent_id, index)
+
+    ancestors: dict[str, frozenset[str]] = {}
+    for fid, frag in fragments.items():
+        chain: set[str] = set()
+        current = frag.parent_id
+        # Cycle guard: ``current in chain`` catches a self-referential or
+        # circular parent_id link without raising. The vault writer never
+        # produces these, but a hand-edited fragment could.
+        while current and current not in chain:
+            chain.add(current)
+            next_frag = fragments.get(current)
+            current = next_frag.parent_id if next_frag is not None else None
+        ancestors[fid] = frozenset(chain)
+    return ancestors, sibling_positions
+
+
+def _level_lookup(
+    ids: list[str],
+    fragments: Mapping[str, Fragment] | None,
+) -> dict[str, FragmentLevel]:
+    """Return a level lookup for every embedded fragment ID.
+
+    Missing or absent entries fall back to ``"document"`` so the
+    resulting :class:`Resonance` records carry a meaningful value even
+    when the caller has not threaded a fragment map through.
+
+    Args:
+        ids: Fragment IDs that appeared in the embedding map.
+        fragments: Optional mapping of fragment ID to :class:`Fragment`.
+
+    Returns:
+        A mapping of fragment ID to its declared level.
+    """
+    if not fragments:
+        return dict.fromkeys(ids, _DEFAULT_LEVEL)
+    return {fid: _level_for(fid, fragments) for fid in ids}
+
+
+def _level_for(fid: str, fragments: Mapping[str, Fragment]) -> FragmentLevel:
+    """Return the level of *fid* in *fragments*, falling back to ``"document"``."""
+    frag = fragments.get(fid)
+    if frag is None:
+        return _DEFAULT_LEVEL
+    return frag.level
+
+
+def _is_hierarchy_suppressed(
+    a_id: str,
+    b_id: str,
+    *,
+    ancestors: dict[str, frozenset[str]],
+    sibling_positions: dict[str, tuple[str, int]],
+    sibling_skip_window: int,
+) -> bool:
+    """Return whether the pair ``(a_id, b_id)`` is hierarchy-trivial.
+
+    Suppression triggers when *either* fragment is an ancestor of the
+    other (via ``parent_id`` chain), *or* both fragments share a parent
+    and their indices in that parent's ``child_ids`` differ by at most
+    *sibling_skip_window*. A non-positive window disables the sibling
+    check; ancestor suppression always applies.
+
+    Args:
+        a_id: First fragment ID.
+        b_id: Second fragment ID.
+        ancestors: Precomputed ancestor sets (see :func:`_hierarchy_index`).
+        sibling_positions: Precomputed sibling positions (idem).
+        sibling_skip_window: Adjacent-sibling suppression radius (``>= 0``).
+
+    Returns:
+        ``True`` if the pair should be dropped from the resonance graph.
+    """
+    if b_id in ancestors.get(a_id, frozenset()):
+        return True
+    if a_id in ancestors.get(b_id, frozenset()):
+        return True
+    if sibling_skip_window <= 0:
+        return False
+    pos_a = sibling_positions.get(a_id)
+    pos_b = sibling_positions.get(b_id)
+    if pos_a is None or pos_b is None:
+        return False
+    parent_a, index_a = pos_a
+    parent_b, index_b = pos_b
+    if parent_a != parent_b:
+        return False
+    return abs(index_a - index_b) <= sibling_skip_window
 
 
 class EmbeddingLinker:
@@ -352,18 +516,38 @@ class EmbeddingLinker:
     def find_resonances(
         self,
         embeddings: dict[str, list[float]],
-    ) -> list[tuple[str, str, float]]:
+        fragments: Mapping[str, Fragment] | None = None,
+        *,
+        sibling_skip_window: int = 2,
+    ) -> list[Resonance]:
         """Find semantic resonances between fragments via cosine similarity.
 
         Computes pairwise cosine similarity for all embedding pairs and
-        returns those above the configured threshold.
+        returns those above the configured threshold. When *fragments*
+        is provided, FEAT-024 hierarchy-aware suppression applies:
+
+        - Pairs where one fragment is an ancestor of the other (via the
+          ``parent_id`` chain) are dropped — same text at two granularities
+          is not a resonance.
+        - Pairs sharing a ``parent_id`` whose positions in the parent's
+          ``child_ids`` differ by at most *sibling_skip_window* are
+          dropped as topically continuous neighbours.
+
+        With no *fragments* mapping (the flat-fragment contract) the
+        suppression is inert and behaviour is identical to pre-FEAT-024.
 
         Args:
             embeddings: Mapping of fragment IDs to their embedding vectors.
+            fragments: Optional mapping of fragment ID to :class:`Fragment`
+                used for hierarchy-aware suppression and level metadata.
+            sibling_skip_window: Adjacent-sibling suppression radius;
+                ``0`` disables sibling suppression (ancestor suppression
+                still applies).
 
         Returns:
-            A list of ``(fragment_id_a, fragment_id_b, similarity)`` tuples
-            for each resonance found.
+            A list of :class:`Resonance` records, one per qualifying pair,
+            in the deterministic insertion order of
+            :func:`itertools.combinations`.
         """
         ids = list(embeddings.keys())
         if len(ids) < 2:
@@ -383,7 +567,11 @@ class EmbeddingLinker:
         normalized = vectors / norms
         similarity_matrix = normalized @ normalized.T
 
-        resonances: list[tuple[str, str, float]] = []
+        ancestors, sibling_positions = _hierarchy_index(fragments)
+        levels = _level_lookup(ids, fragments)
+
+        resonances: list[Resonance] = []
+        suppressed = 0
         # OPS-004: pairwise loop is O(N²); on a 10k-fragment vault this
         # is ~50M iterations and runs for minutes. Show tqdm in TTYs and
         # stay silent in non-interactive runs (CI logs, pipes).
@@ -397,8 +585,33 @@ class EmbeddingLinker:
         )
         for i, j in pair_iter:
             sim = float(similarity_matrix[i, j])
-            if sim >= self.config.similarity_threshold:
-                resonances.append((ids[i], ids[j], sim))
+            if sim < self.config.similarity_threshold:
+                continue
+            if _is_hierarchy_suppressed(
+                ids[i],
+                ids[j],
+                ancestors=ancestors,
+                sibling_positions=sibling_positions,
+                sibling_skip_window=sibling_skip_window,
+            ):
+                suppressed += 1
+                continue
+            resonances.append(
+                Resonance(
+                    fragment_a_id=ids[i],
+                    fragment_b_id=ids[j],
+                    similarity=sim,
+                    from_level=levels[ids[i]],
+                    to_level=levels[ids[j]],
+                ),
+            )
 
+        if suppressed:
+            logger.info(
+                "Suppressed %d hierarchy-trivial resonance(s) "
+                "(ancestor/descendant or adjacent siblings within %d)",
+                suppressed,
+                sibling_skip_window,
+            )
         logger.info("Found %d resonance(s)", len(resonances))
         return resonances

--- a/creek-tools/creek/link/link_engine.py
+++ b/creek-tools/creek/link/link_engine.py
@@ -138,7 +138,14 @@ def _run_embeddings(
         cache_path=cache_path,
     )
 
-    resonances = EmbeddingLinker(config=config.embeddings).find_resonances(embeddings)
+    # FEAT-024: hierarchy-aware filtering needs both the fragment map
+    # (parent/child relations) and the configured sibling skip window.
+    fragments_by_id = {f.id: f for f in fragments}
+    resonances = EmbeddingLinker(config=config.embeddings).find_resonances(
+        embeddings,
+        fragments_by_id,
+        sibling_skip_window=config.linking.hierarchy_sibling_skip_window,
+    )
     return len(resonances)
 
 

--- a/creek-tools/creek/link/linker.py
+++ b/creek-tools/creek/link/linker.py
@@ -85,7 +85,15 @@ class LinkingPipeline:
         # Stage 1: Embeddings and resonances
         embedding_linker = EmbeddingLinker(config=self.config)
         embeddings = embedding_linker.generate_embeddings(fragments)
-        resonances = embedding_linker.find_resonances(embeddings)
+        # FEAT-024: thread the fragment map and configured sibling window
+        # through so hierarchy-trivial pairs (parent/child, adjacent
+        # siblings) are dropped from the resonance graph.
+        fragments_by_id = {f.id: f for f in fragments}
+        resonances = embedding_linker.find_resonances(
+            embeddings,
+            fragments_by_id,
+            sibling_skip_window=self.linking_config.hierarchy_sibling_skip_window,
+        )
 
         # Stage 2: Temporal proximity
         temporal_links = TemporalLinker().find_temporal_links(

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -671,6 +671,12 @@ class Synchronicity(BaseModel):
         source_a: Source platform of the first fragment.
         source_b: Source platform of the second fragment (must differ
             from ``source_a``).
+        level_a: Structural level of the earlier fragment (FEAT-024).
+            Defaults to ``"document"`` for flat-fragment vaults.
+        level_b: Structural level of the later fragment (FEAT-024).
+            When ``level_a != level_b`` the pair is *cross-level*, which
+            ranks above same-level pairs in
+            :class:`~creek.generate.synchronicity.SynchronicityDetector`.
         tags: Obsidian tags applied to the synchronicity note.
     """
 
@@ -684,6 +690,8 @@ class Synchronicity(BaseModel):
     time_gap_days: int
     source_a: SourcePlatform
     source_b: SourcePlatform
+    level_a: FragmentLevel = "document"
+    level_b: FragmentLevel = "document"
     tags: list[str] = Field(default_factory=lambda: ["synchronicity"])
 
 

--- a/creek-tools/tests/test_config.py
+++ b/creek-tools/tests/test_config.py
@@ -95,6 +95,21 @@ class TestLinkingConfig:
         assert cfg.thread_min_fragments == 3
         assert cfg.eddy_min_fragments == 5
 
+    def test_hierarchy_sibling_skip_window_default_is_two(self) -> None:
+        """FEAT-024 sibling-skip window defaults to 2 positions either side."""
+        cfg = LinkingConfig()
+        assert cfg.hierarchy_sibling_skip_window == 2
+
+    def test_hierarchy_sibling_skip_window_accepts_zero(self) -> None:
+        """A skip window of 0 disables sibling suppression (still valid)."""
+        cfg = LinkingConfig(hierarchy_sibling_skip_window=0)
+        assert cfg.hierarchy_sibling_skip_window == 0
+
+    def test_hierarchy_sibling_skip_window_rejects_negative(self) -> None:
+        """Negative skip windows are nonsensical and rejected by validation."""
+        with pytest.raises(ValueError, match="greater than or equal to 0"):
+            LinkingConfig(hierarchy_sibling_skip_window=-1)
+
 
 class TestClassificationConfig:
     """Tests for ClassificationConfig model."""

--- a/creek-tools/tests/test_embeddings.py
+++ b/creek-tools/tests/test_embeddings.py
@@ -23,7 +23,7 @@ from creek.link.embeddings import (
     embeddings_cache_path,
     fragment_embedding_text,
 )
-from creek.models import Fragment, FragmentSource, SourcePlatform
+from creek.models import Fragment, FragmentLevel, FragmentSource, SourcePlatform
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -480,7 +480,7 @@ def _hier_fragment(
     *,
     parent_id: str | None = None,
     child_ids: list[str] | None = None,
-    level: str = "document",
+    level: FragmentLevel = "document",
 ) -> Fragment:
     """Build a Fragment with explicit hierarchy fields for FEAT-024 tests."""
     return Fragment(
@@ -489,7 +489,7 @@ def _hier_fragment(
         source=FragmentSource(platform=SourcePlatform.CLAUDE),
         parent_id=parent_id,
         child_ids=child_ids or [],
-        level=level,  # type: ignore[arg-type]
+        level=level,
     )
 
 

--- a/creek-tools/tests/test_embeddings.py
+++ b/creek-tools/tests/test_embeddings.py
@@ -18,6 +18,7 @@ from creek.config import EmbeddingsConfig
 from creek.link.embeddings import (
     CachedEmbedding,
     EmbeddingLinker,
+    Resonance,
     content_hash_for_text,
     embeddings_cache_path,
     fragment_embedding_text,
@@ -367,9 +368,9 @@ class TestFindResonances:
         }
         result = linker.find_resonances(embeddings)
         assert len(result) == 1
-        assert result[0][0] == "a"
-        assert result[0][1] == "b"
-        assert abs(result[0][2] - 1.0) < 1e-6
+        assert result[0].fragment_a_id == "a"
+        assert result[0].fragment_b_id == "b"
+        assert abs(result[0].similarity - 1.0) < 1e-6
 
     def test_orthogonal_vectors_no_resonance(self) -> None:
         """Orthogonal vectors should not produce resonances."""
@@ -395,7 +396,7 @@ class TestFindResonances:
         }
         result = linker.find_resonances(embeddings)
         # a-b should be close to threshold, a-c and b-c should be below
-        pair_ids = {(r[0], r[1]) for r in result}
+        pair_ids = {(r.fragment_a_id, r.fragment_b_id) for r in result}
         assert ("a", "c") not in pair_ids
 
     def test_empty_embeddings_returns_empty(self) -> None:
@@ -410,8 +411,8 @@ class TestFindResonances:
         result = linker.find_resonances({"a": [1.0, 0.0]})
         assert result == []
 
-    def test_result_tuple_structure(self) -> None:
-        """Each resonance should be a (id_a, id_b, similarity) tuple."""
+    def test_result_record_structure(self) -> None:
+        """Each resonance should be a Resonance with id/sim/level fields."""
         linker = EmbeddingLinker(
             config=EmbeddingsConfig(similarity_threshold=0.0),
         )
@@ -421,11 +422,14 @@ class TestFindResonances:
         }
         result = linker.find_resonances(embeddings)
         assert len(result) >= 1
-        frag_a, frag_b, sim = result[0]
-        assert isinstance(frag_a, str)
-        assert isinstance(frag_b, str)
-        assert isinstance(sim, float)
-        assert 0.0 <= sim <= 1.0
+        edge = result[0]
+        assert isinstance(edge.fragment_a_id, str)
+        assert isinstance(edge.fragment_b_id, str)
+        assert isinstance(edge.similarity, float)
+        assert 0.0 <= edge.similarity <= 1.0
+        # Without a fragments map, both endpoints default to "document".
+        assert edge.from_level == "document"
+        assert edge.to_level == "document"
 
     def test_no_duplicate_pairs(self) -> None:
         """Each pair should appear only once (no (b,a) if (a,b) exists)."""
@@ -438,7 +442,7 @@ class TestFindResonances:
             "c": [0.8, 0.2],
         }
         result = linker.find_resonances(embeddings)
-        pairs = [(r[0], r[1]) for r in result]
+        pairs = [(r.fragment_a_id, r.fragment_b_id) for r in result]
         # Check no reverse duplicates
         for id_a, id_b in pairs:
             assert (id_b, id_a) not in pairs
@@ -466,3 +470,255 @@ class TestEmbeddingLinkerLogging:
         with caplog.at_level(logging.INFO, logger="creek.link.embeddings"):
             linker.find_resonances({"a": [1.0], "b": [0.0]})
         assert any("2" in r.message for r in caplog.records)
+
+
+# ---- FEAT-024 Hierarchy-aware Filtering ----
+
+
+def _hier_fragment(
+    fid: str,
+    *,
+    parent_id: str | None = None,
+    child_ids: list[str] | None = None,
+    level: str = "document",
+) -> Fragment:
+    """Build a Fragment with explicit hierarchy fields for FEAT-024 tests."""
+    return Fragment(
+        id=fid,
+        title=fid,
+        source=FragmentSource(platform=SourcePlatform.CLAUDE),
+        parent_id=parent_id,
+        child_ids=child_ids or [],
+        level=level,  # type: ignore[arg-type]
+    )
+
+
+class TestHierarchyAwareFiltering:
+    """Tests for FEAT-024 hierarchy-aware resonance suppression."""
+
+    def test_ancestor_descendant_pair_suppressed(self) -> None:
+        """Parent/child pairs never produce a resonance, even at sim=1.0."""
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(similarity_threshold=0.5),
+        )
+        fragments = {
+            "p": _hier_fragment(
+                "p",
+                child_ids=["c1"],
+                level="document",
+            ),
+            "c1": _hier_fragment("c1", parent_id="p", level="paragraph"),
+        }
+        embeddings = {"p": [1.0, 0.0], "c1": [1.0, 0.0]}
+        result = linker.find_resonances(embeddings, fragments)
+        assert not result
+
+    def test_deep_ancestor_descendant_suppressed(self) -> None:
+        """Suppression follows the parent_id chain past a single hop."""
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(similarity_threshold=0.5),
+        )
+        fragments = {
+            "root": _hier_fragment(
+                "root",
+                child_ids=["mid"],
+                level="document",
+            ),
+            "mid": _hier_fragment(
+                "mid",
+                parent_id="root",
+                child_ids=["leaf"],
+                level="paragraph",
+            ),
+            "leaf": _hier_fragment("leaf", parent_id="mid", level="sentence"),
+        }
+        embeddings = {"root": [1.0, 0.0], "mid": [1.0, 0.0], "leaf": [1.0, 0.0]}
+        result = linker.find_resonances(embeddings, fragments)
+        # No surviving pair — root-mid, mid-leaf, root-leaf are all ancestor edges.
+        assert not result
+
+    def test_adjacent_siblings_within_default_window_suppressed(self) -> None:
+        """Siblings within K=2 positions of each other are suppressed."""
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(similarity_threshold=0.5),
+        )
+        fragments = {
+            "p": _hier_fragment(
+                "p",
+                child_ids=["s0", "s1", "s2"],
+                level="document",
+            ),
+            "s0": _hier_fragment("s0", parent_id="p", level="sentence"),
+            "s1": _hier_fragment("s1", parent_id="p", level="sentence"),
+            "s2": _hier_fragment("s2", parent_id="p", level="sentence"),
+        }
+        embeddings = {
+            "s0": [1.0, 0.0],
+            "s1": [1.0, 0.0],
+            "s2": [1.0, 0.0],
+        }
+        result = linker.find_resonances(embeddings, fragments)
+        # All three sentence-siblings sit within window=2 of each other.
+        pair_ids = {(r.fragment_a_id, r.fragment_b_id) for r in result}
+        assert ("s0", "s1") not in pair_ids
+        assert ("s1", "s2") not in pair_ids
+        assert ("s0", "s2") not in pair_ids
+
+    def test_non_adjacent_siblings_kept(self) -> None:
+        """Siblings beyond the skip window keep their resonance edge."""
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(similarity_threshold=0.5),
+        )
+        fragments = {
+            "p": _hier_fragment(
+                "p",
+                child_ids=["c0", "c1", "c2", "c3"],
+                level="document",
+            ),
+            "c0": _hier_fragment("c0", parent_id="p", level="sentence"),
+            "c1": _hier_fragment("c1", parent_id="p", level="sentence"),
+            "c2": _hier_fragment("c2", parent_id="p", level="sentence"),
+            "c3": _hier_fragment("c3", parent_id="p", level="sentence"),
+        }
+        # Make only the (c0, c3) pair similar enough to survive.
+        embeddings = {
+            "c0": [1.0, 0.0],
+            "c1": [0.0, 1.0],
+            "c2": [0.0, 1.0],
+            "c3": [1.0, 0.0],
+        }
+        result = linker.find_resonances(embeddings, fragments)
+        pair_ids = {(r.fragment_a_id, r.fragment_b_id) for r in result}
+        # c0 and c3 are 3 positions apart — outside the default window of 2.
+        assert ("c0", "c3") in pair_ids
+
+    def test_cross_tree_pair_kept(self) -> None:
+        """Fragments under different parents are never suppressed."""
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(similarity_threshold=0.5),
+        )
+        fragments = {
+            "p1": _hier_fragment("p1", child_ids=["a"], level="document"),
+            "p2": _hier_fragment("p2", child_ids=["b"], level="document"),
+            "a": _hier_fragment("a", parent_id="p1", level="paragraph"),
+            "b": _hier_fragment("b", parent_id="p2", level="paragraph"),
+        }
+        embeddings = {"a": [1.0, 0.0], "b": [1.0, 0.0]}
+        result = linker.find_resonances(embeddings, fragments)
+        pair_ids = {(r.fragment_a_id, r.fragment_b_id) for r in result}
+        assert ("a", "b") in pair_ids
+
+    def test_resonance_records_endpoint_levels(self) -> None:
+        """Returned Resonance carries from_level / to_level from fragments."""
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(similarity_threshold=0.5),
+        )
+        fragments = {
+            "p1": _hier_fragment("p1", child_ids=["a"], level="exchange"),
+            "p2": _hier_fragment("p2", child_ids=["b"], level="document"),
+            "a": _hier_fragment("a", parent_id="p1", level="sentence"),
+            "b": _hier_fragment("b", parent_id="p2", level="paragraph"),
+        }
+        embeddings = {"a": [1.0, 0.0], "b": [1.0, 0.0]}
+        result = linker.find_resonances(embeddings, fragments)
+        assert len(result) == 1
+        edge = result[0]
+        assert edge.from_level == "sentence"
+        assert edge.to_level == "paragraph"
+
+    def test_flat_fragment_regression(self) -> None:
+        """No-hierarchy vaults produce the same edges as pre-FEAT-024.
+
+        Acceptance criterion: existing flat-fragment behaviour is
+        unchanged when no parent/child fields are populated.
+        """
+        baseline = EmbeddingLinker(
+            config=EmbeddingsConfig(similarity_threshold=0.5),
+        )
+        embeddings = {
+            "a": [1.0, 0.0],
+            "b": [0.95, 0.05],
+            "c": [0.0, 1.0],
+        }
+        without_fragments = baseline.find_resonances(embeddings)
+        flat_fragments = {
+            "a": _hier_fragment("a"),
+            "b": _hier_fragment("b"),
+            "c": _hier_fragment("c"),
+        }
+        with_fragments = baseline.find_resonances(embeddings, flat_fragments)
+        # Same pair set, in the same order.
+        pairs_a = [(r.fragment_a_id, r.fragment_b_id) for r in without_fragments]
+        pairs_b = [(r.fragment_a_id, r.fragment_b_id) for r in with_fragments]
+        assert pairs_a == pairs_b
+        # Levels default to "document" in both cases.
+        for edge in with_fragments:
+            assert edge.from_level == "document"
+            assert edge.to_level == "document"
+
+    def test_skip_window_zero_disables_sibling_suppression(self) -> None:
+        """A skip window of 0 leaves siblings in the graph."""
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(similarity_threshold=0.5),
+        )
+        fragments = {
+            "p": _hier_fragment(
+                "p",
+                child_ids=["s0", "s1"],
+                level="document",
+            ),
+            "s0": _hier_fragment("s0", parent_id="p", level="sentence"),
+            "s1": _hier_fragment("s1", parent_id="p", level="sentence"),
+        }
+        embeddings = {"s0": [1.0, 0.0], "s1": [1.0, 0.0]}
+        result = linker.find_resonances(
+            embeddings,
+            fragments,
+            sibling_skip_window=0,
+        )
+        pair_ids = {(r.fragment_a_id, r.fragment_b_id) for r in result}
+        assert ("s0", "s1") in pair_ids
+
+    def test_skip_window_zero_still_suppresses_ancestors(self) -> None:
+        """Skip window 0 does NOT relax the ancestor suppression."""
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(similarity_threshold=0.5),
+        )
+        fragments = {
+            "p": _hier_fragment("p", child_ids=["c"], level="document"),
+            "c": _hier_fragment("c", parent_id="p", level="paragraph"),
+        }
+        embeddings = {"p": [1.0, 0.0], "c": [1.0, 0.0]}
+        result = linker.find_resonances(
+            embeddings,
+            fragments,
+            sibling_skip_window=0,
+        )
+        assert not result
+
+    def test_cycle_in_parent_chain_is_tolerated(self) -> None:
+        """A malformed cyclic parent_id chain must not loop forever."""
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(similarity_threshold=0.5),
+        )
+        # Hand-crafted cycle: a -> b -> a. The linker should fall through
+        # without hanging, even though the data is broken.
+        fragments = {
+            "a": _hier_fragment("a", parent_id="b", level="paragraph"),
+            "b": _hier_fragment("b", parent_id="a", level="paragraph"),
+        }
+        embeddings = {"a": [1.0, 0.0], "b": [1.0, 0.0]}
+        # Each side sees the other in its ancestor set, so the pair is
+        # still suppressed — what matters is that we don't hang.
+        result = linker.find_resonances(embeddings, fragments)
+        assert not result
+
+    def test_resonance_model_default_levels(self) -> None:
+        """Constructing a Resonance with no level kwargs yields 'document'."""
+        edge = Resonance(
+            fragment_a_id="x",
+            fragment_b_id="y",
+            similarity=0.91,
+        )
+        assert edge.from_level == "document"
+        assert edge.to_level == "document"

--- a/creek-tools/tests/test_synchronicity.py
+++ b/creek-tools/tests/test_synchronicity.py
@@ -19,6 +19,7 @@ from creek.generate.synchronicity import (
     DEFAULT_SIMILARITY_THRESHOLD,
     SynchronicityDetector,
 )
+from creek.link.embeddings import Resonance
 from creek.models import (
     Fragment,
     FragmentSource,
@@ -424,6 +425,220 @@ class TestDetectSynchronicities:
         # Chronological order: frag-a (Discord) first, frag-b (Journal) second
         assert sync.source_a == SourcePlatform.DISCORD
         assert sync.source_b == SourcePlatform.JOURNAL
+
+
+# ---- FEAT-024 cross-level ranking ----
+
+
+def _level_fragment(
+    *,
+    frag_id: str,
+    title: str,
+    platform: SourcePlatform,
+    created: datetime,
+    level: str,
+) -> Fragment:
+    """Construct a test Fragment with an explicit structural level."""
+    return Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=platform),
+        created=created,
+        level=level,  # type: ignore[arg-type]
+    )
+
+
+class TestCrossLevelRanking:
+    """Tests for FEAT-024 cross-level synchronicity ranking."""
+
+    def test_accepts_resonance_objects(
+        self,
+        detector: SynchronicityDetector,
+        cross_source_pair: dict[str, Fragment],
+    ) -> None:
+        """Detector accepts the new Resonance record (FEAT-024)."""
+        resonances = [
+            Resonance(
+                fragment_a_id="frag-a",
+                fragment_b_id="frag-b",
+                similarity=0.95,
+                from_level="sentence",
+                to_level="document",
+            ),
+        ]
+        result = detector.detect_synchronicities(resonances, cross_source_pair)
+        assert len(result) == 1
+        # Chronological order keeps frag-a first, so its level is level_a.
+        assert result[0].level_a == "sentence"
+        assert result[0].level_b == "document"
+
+    def test_tuple_input_defaults_to_document_levels(
+        self,
+        detector: SynchronicityDetector,
+        cross_source_pair: dict[str, Fragment],
+    ) -> None:
+        """Legacy 3-tuple input keeps the default 'document' levels."""
+        resonances = [("frag-a", "frag-b", 0.95)]
+        result = detector.detect_synchronicities(resonances, cross_source_pair)
+        assert len(result) == 1
+        assert result[0].level_a == "document"
+        assert result[0].level_b == "document"
+
+    def test_cross_level_ranks_before_same_level(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """Cross-level pairs surface ahead of same-level pairs."""
+        fragments = {
+            "same-a": _level_fragment(
+                frag_id="same-a",
+                title="the wind through the long grass",
+                platform=SourcePlatform.DISCORD,
+                created=datetime(2025, 1, 1, 10, 0, 0),
+                level="document",
+            ),
+            "same-b": _level_fragment(
+                frag_id="same-b",
+                title="the wind through the long grass",
+                platform=SourcePlatform.JOURNAL,
+                created=datetime(2025, 4, 1, 10, 0, 0),
+                level="document",
+            ),
+            "cross-a": _level_fragment(
+                frag_id="cross-a",
+                title="silence has a shape",
+                platform=SourcePlatform.EMAIL,
+                created=datetime(2025, 1, 2, 10, 0, 0),
+                level="sentence",
+            ),
+            "cross-b": _level_fragment(
+                frag_id="cross-b",
+                title="silence has a shape",
+                platform=SourcePlatform.ESSAY,
+                created=datetime(2025, 5, 1, 10, 0, 0),
+                level="exchange",
+            ),
+        }
+        # Give the same-level pair a *higher* raw similarity to prove the
+        # cross-level boost overrides naive similarity ordering.
+        resonances = [
+            Resonance(
+                fragment_a_id="same-a",
+                fragment_b_id="same-b",
+                similarity=0.99,
+                from_level="document",
+                to_level="document",
+            ),
+            Resonance(
+                fragment_a_id="cross-a",
+                fragment_b_id="cross-b",
+                similarity=0.92,
+                from_level="sentence",
+                to_level="exchange",
+            ),
+        ]
+        result = detector.detect_synchronicities(resonances, fragments)
+        assert len(result) == 2
+        # Cross-level should come first.
+        assert result[0].fragment_a_id == "cross-a"
+        assert result[1].fragment_a_id == "same-a"
+
+    def test_within_group_sorted_by_similarity_descending(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """Two cross-level pairs are ranked by similarity descending."""
+        fragments = {
+            "x1": _level_fragment(
+                frag_id="x1",
+                title="cedar smoke at dusk",
+                platform=SourcePlatform.DISCORD,
+                created=datetime(2025, 1, 1, 10, 0, 0),
+                level="sentence",
+            ),
+            "x2": _level_fragment(
+                frag_id="x2",
+                title="cedar smoke at dusk",
+                platform=SourcePlatform.JOURNAL,
+                created=datetime(2025, 4, 1, 10, 0, 0),
+                level="exchange",
+            ),
+            "y1": _level_fragment(
+                frag_id="y1",
+                title="folding the laundry slowly",
+                platform=SourcePlatform.EMAIL,
+                created=datetime(2025, 1, 2, 10, 0, 0),
+                level="paragraph",
+            ),
+            "y2": _level_fragment(
+                frag_id="y2",
+                title="folding the laundry slowly",
+                platform=SourcePlatform.ESSAY,
+                created=datetime(2025, 5, 1, 10, 0, 0),
+                level="session",
+            ),
+        }
+        resonances = [
+            Resonance(
+                fragment_a_id="x1",
+                fragment_b_id="x2",
+                similarity=0.91,
+                from_level="sentence",
+                to_level="exchange",
+            ),
+            Resonance(
+                fragment_a_id="y1",
+                fragment_b_id="y2",
+                similarity=0.97,
+                from_level="paragraph",
+                to_level="session",
+            ),
+        ]
+        result = detector.detect_synchronicities(resonances, fragments)
+        assert len(result) == 2
+        # Both are cross-level — higher similarity wins.
+        assert result[0].fragment_a_id == "y1"
+        assert result[1].fragment_a_id == "x1"
+
+    def test_level_swaps_with_chronological_order(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """When the later fragment is listed first, its level follows."""
+        fragments = {
+            "early": _level_fragment(
+                frag_id="early",
+                title="moss on the north side of the stone",
+                platform=SourcePlatform.DISCORD,
+                created=datetime(2025, 1, 1, 10, 0, 0),
+                level="paragraph",
+            ),
+            "late": _level_fragment(
+                frag_id="late",
+                title="moss on the north side of the stone",
+                platform=SourcePlatform.JOURNAL,
+                created=datetime(2025, 5, 1, 10, 0, 0),
+                level="sentence",
+            ),
+        }
+        # Resonance lists later -> earlier; level_a / level_b on the
+        # synchronicity must still reflect the chronological order.
+        resonances = [
+            Resonance(
+                fragment_a_id="late",
+                fragment_b_id="early",
+                similarity=0.95,
+                from_level="sentence",
+                to_level="paragraph",
+            ),
+        ]
+        result = detector.detect_synchronicities(resonances, fragments)
+        assert len(result) == 1
+        sync = result[0]
+        assert sync.fragment_a_id == "early"
+        assert sync.fragment_b_id == "late"
+        assert sync.level_a == "paragraph"
+        assert sync.level_b == "sentence"
 
 
 # ---- create_synchronicity_note ----

--- a/creek-tools/tests/test_synchronicity.py
+++ b/creek-tools/tests/test_synchronicity.py
@@ -9,7 +9,7 @@ and create_synchronicity_note (writing reflection notes to
 from __future__ import annotations
 
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import frontmatter
 import pytest
@@ -22,6 +22,7 @@ from creek.generate.synchronicity import (
 from creek.link.embeddings import Resonance
 from creek.models import (
     Fragment,
+    FragmentLevel,
     FragmentSource,
     SourcePlatform,
     Synchronicity,
@@ -436,7 +437,7 @@ def _level_fragment(
     title: str,
     platform: SourcePlatform,
     created: datetime,
-    level: str,
+    level: FragmentLevel,
 ) -> Fragment:
     """Construct a test Fragment with an explicit structural level."""
     return Fragment(
@@ -444,7 +445,7 @@ def _level_fragment(
         title=title,
         source=FragmentSource(platform=platform),
         created=created,
-        level=level,  # type: ignore[arg-type]
+        level=level,
     )
 
 
@@ -671,6 +672,34 @@ def sample_sync_pair() -> tuple[Synchronicity, dict[str, Fragment]]:
         source_b=SourcePlatform.JOURNAL,
     )
     return sync, fragments
+
+
+class TestUnrecognisedResonanceShape:
+    """Tests for the unknown-shape fall-through in ``_normalise_resonance``."""
+
+    def test_alien_shape_is_skipped_with_warning(
+        self,
+        detector: SynchronicityDetector,
+        cross_source_pair: dict[str, Fragment],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A non-Resonance, non-3-tuple input is logged and dropped silently."""
+        # Exercise the runtime fall-through that the static signature
+        # rules out: a deliberate cast to the declared input type lets
+        # the runtime branch run without a bypass directive.
+        alien_items: list[object] = [
+            (42,),
+            "not a resonance",
+            ("a", "b", 0.9, "extra"),
+        ]
+        alien = cast("list[tuple[str, str, float]]", alien_items)
+        with caplog.at_level("WARNING", logger="creek.generate.synchronicity"):
+            result = detector.detect_synchronicities(alien, cross_source_pair)
+        assert not result
+        assert any(
+            "Unrecognised resonance shape" in record.message
+            for record in caplog.records
+        )
 
 
 class TestCreateSynchronicityNote:


### PR DESCRIPTION
Make the embedding linker hierarchy-aware so re-atomized vaults no
longer emit trivial parent/child or adjacent-sibling resonances. Each
resonance now carries the structural level of both endpoints, and the
synchronicity detector ranks cross-level pairs ahead of same-level
pairs so level-asymmetric matches surface deliberately.

- New ``LinkingConfig.hierarchy_sibling_skip_window`` (default 2).
- New ``Resonance`` Pydantic model with ``from_level`` / ``to_level``.
- ``EmbeddingLinker.find_resonances`` accepts a fragment lookup and
  skips ancestor/descendant pairs plus adjacent-sibling pairs within
  the configured window. Flat-fragment vaults are unchanged.
- ``Synchronicity`` gains ``level_a`` / ``level_b``; detector orders
  cross-level pairs first, then by similarity descending.
- Synchronicity detector accepts both ``Resonance`` and the legacy
  3-tuple format for transitional compatibility.

https://claude.ai/code/session_01TqnfRx7cXbE1HYq7qXZHXQ