### PR TITLE
feat(generate): hierarchy-aware compile/state/lint (FEAT-025)

### DIFF
--- a/creek-tools/creek/compile/engine.py
+++ b/creek-tools/creek/compile/engine.py
@@ -31,6 +31,12 @@ import frontmatter
 
 from creek.audit import AuditLog
 from creek.compile.provenance import ProvenanceEntry, merge_provenance
+from creek.hierarchy import (
+    LevelPolicy,
+    select_by_policy,
+    source_levels,
+    structural_path_context,
+)
 from creek.models import CompiledPage, CompileTargetKind, Fragment, PrivacyTier
 from creek.vault.reader import iter_vault_fragments
 
@@ -91,6 +97,7 @@ def compile_fragments(
     target_title: str,
     existing_provenance: list[ProvenanceEntry] | None = None,
     compiled_at: datetime | None = None,
+    level_policy: LevelPolicy = "leaves",
 ) -> CompileResult:
     """Run one compile pass and return the compiled page plus any paradoxes.
 
@@ -106,6 +113,11 @@ def compile_fragments(
         existing_provenance: Provenance already on the target page, used
             to enforce idempotent re-runs.
         compiled_at: Override the run timestamp; defaults to ``now(UTC)``.
+        level_policy: FEAT-025 level policy applied to the input pairs.
+            ``"leaves"`` (default) keeps the most-atomic representation
+            and surfaces parents as ``structural_path`` context. ``"all"``
+            reproduces the pre-FEAT-025 path. ``"documents"`` keeps only
+            document- and session-level rows.
 
     Returns:
         A :class:`CompileResult` carrying the synthesised
@@ -116,6 +128,46 @@ def compile_fragments(
         ValueError: If *target_kind* is not one of the supported
             compiled-page surfaces.
     """
+    _validate_target_kind(target_kind)
+    pairs = list(fragments_with_bodies)
+    by_id: dict[str, Fragment] = {fragment.id: fragment for fragment, _ in pairs}
+    selected_fragments, selected_pairs = _apply_level_policy(pairs, level_policy)
+
+    timestamp = compiled_at or datetime.now(tz=UTC)
+    prompt = _build_prompt(
+        selected_pairs,
+        target_kind=target_kind,
+        target_title=target_title,
+        by_id=by_id,
+    )
+    payload = _parse_llm_payload(llm(prompt))
+    valid_claims = _filter_valid_claims(payload["claims"])
+    provenance = merge_provenance(
+        existing_provenance or [],
+        _claims_to_provenance(valid_claims, timestamp),
+    )
+    page = CompiledPage(
+        target_kind=target_kind,
+        target_id=target_id,
+        title=target_title,
+        body=_render_body(target_title, valid_claims),
+        provenance=provenance,
+        compiled_at=timestamp,
+        compile_method="llm",
+        level_policy=level_policy,
+        source_levels=source_levels(selected_fragments),
+    )
+    paradoxes = _payload_to_paradox_entries(
+        payload["paradoxes"],
+        target_kind=target_kind,
+        target_id=target_id,
+        timestamp=timestamp,
+    )
+    return CompileResult(page=page, paradoxes=paradoxes)
+
+
+def _validate_target_kind(target_kind: str) -> None:
+    """Reject any *target_kind* outside the published surface list."""
     if target_kind not in TARGET_KINDS:
         msg = (
             f"Unknown target_kind {target_kind!r}; "
@@ -123,16 +175,41 @@ def compile_fragments(
         )
         raise ValueError(msg)
 
-    pairs = list(fragments_with_bodies)
-    timestamp = compiled_at or datetime.now(tz=UTC)
-    prompt = _build_prompt(pairs, target_kind=target_kind, target_title=target_title)
-    raw = llm(prompt)
-    payload = _parse_llm_payload(raw)
 
-    # Drop malformed claims (missing/empty id) before they reach the page body;
-    # otherwise `_render_body` would emit a broken Markdown footnote `[^]`.
-    valid_claims = [c for c in payload["claims"] if str(c.get("id", "")).strip()]
-    new_provenance = [
+def _apply_level_policy(
+    pairs: list[tuple[Fragment, str]],
+    policy: LevelPolicy,
+) -> tuple[list[Fragment], list[tuple[Fragment, str]]]:
+    """Filter (fragment, body) pairs by *policy* and return the surviving subset.
+
+    Returns the selected fragments (for ``source_levels`` recording)
+    alongside the matching (fragment, body) pairs so the prompt builder
+    keeps body parity with the policy's choice of leaves.
+    """
+    fragments_only = [fragment for fragment, _ in pairs]
+    selected_fragments = select_by_policy(fragments_only, policy)
+    selected_ids = {fragment.id for fragment in selected_fragments}
+    selected_pairs = [pair for pair in pairs if pair[0].id in selected_ids]
+    return selected_fragments, selected_pairs
+
+
+def _filter_valid_claims(
+    claims: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Drop malformed claims (missing/empty id) before they reach the page body.
+
+    Otherwise ``_render_body`` would emit a broken Markdown footnote
+    ``[^]`` that downstream readers can't resolve.
+    """
+    return [c for c in claims if str(c.get("id", "")).strip()]
+
+
+def _claims_to_provenance(
+    claims: list[dict[str, object]],
+    timestamp: datetime,
+) -> list[ProvenanceEntry]:
+    """Build per-claim provenance entries for an LLM compile run."""
+    return [
         ProvenanceEntry(
             claim_id=str(claim["id"]),
             claim_excerpt=_excerpt(str(claim.get("text", ""))),
@@ -140,21 +217,19 @@ def compile_fragments(
             compiled_at=timestamp,
             compile_method="llm",
         )
-        for claim in valid_claims
+        for claim in claims
     ]
-    provenance = merge_provenance(existing_provenance or [], new_provenance)
-    body = _render_body(target_title, valid_claims)
 
-    page = CompiledPage(
-        target_kind=target_kind,
-        target_id=target_id,
-        title=target_title,
-        body=body,
-        provenance=provenance,
-        compiled_at=timestamp,
-        compile_method="llm",
-    )
-    paradoxes = [
+
+def _payload_to_paradox_entries(
+    items: list[dict[str, object]],
+    *,
+    target_kind: str,
+    target_id: str,
+    timestamp: datetime,
+) -> list[ParadoxLogEntry]:
+    """Map LLM-reported paradox dicts into structured log entries."""
+    return [
         ParadoxLogEntry(
             timestamp=timestamp,
             target_kind=target_kind,
@@ -162,9 +237,8 @@ def compile_fragments(
             description=str(item.get("description", "")),
             fragment_ids=_str_list(item.get("fragment_ids")),
         )
-        for item in payload["paradoxes"]
+        for item in items
     ]
-    return CompileResult(page=page, paradoxes=paradoxes)
 
 
 def compile_to_vault(
@@ -175,6 +249,7 @@ def compile_to_vault(
     target_id: str,
     target_title: str,
     llm: CompileLLM,
+    level_policy: LevelPolicy = "leaves",
 ) -> Path:
     """Compile *fragment_ids* into a compiled-layer page on disk.
 
@@ -190,6 +265,9 @@ def compile_to_vault(
         target_id: Stable ID of the synthesis target.
         target_title: Human-readable title for the page.
         llm: Compile LLM callable returning JSON.
+        level_policy: FEAT-025 level policy applied to the input
+            fragments. Passed through to :func:`compile_fragments`;
+            defaults to ``"leaves"``.
 
     Returns:
         The path of the written compiled-layer page.
@@ -207,6 +285,7 @@ def compile_to_vault(
         target_id=target_id,
         target_title=target_title,
         existing_provenance=existing,
+        level_policy=level_policy,
     )
     _write_compiled_page(target_path, result.page)
     if result.paradoxes:
@@ -256,8 +335,15 @@ def _build_prompt(
     *,
     target_kind: str,
     target_title: str,
+    by_id: dict[str, Fragment] | None = None,
 ) -> str:
-    """Assemble the compile prompt for the LLM."""
+    """Assemble the compile prompt for the LLM.
+
+    Surfaces each fragment's ``structural_path`` breadcrumb (FEAT-025)
+    as a separate field so the LLM treats parent context as orientation
+    rather than duplicate claim material.
+    """
+    lookup: dict[str, Fragment] = by_id or {f.id: f for f, _ in pairs}
     sections: list[str] = [
         f"You are compiling a {target_kind} note titled {target_title!r}.",
         "Return JSON with two arrays: 'claims' (each having 'id', 'text', "
@@ -269,13 +355,16 @@ def _build_prompt(
     ]
     for fragment, body in pairs:
         excerpt = _fragment_excerpt_for_prompt(fragment, body)
+        breadcrumb = structural_path_context(fragment, lookup)
         sections.extend(
             (
                 f"- id: {fragment.id}",
                 f"  title: {fragment.title}",
-                f"  body: {excerpt}",
             )
         )
+        if breadcrumb:
+            sections.append(f"  structural_path: {' > '.join(breadcrumb)}")
+        sections.append(f"  body: {excerpt}")
     return "\n".join(sections)
 
 

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -548,6 +548,28 @@ class CompostConfig(BaseModel):
     """
 
 
+class LintConfig(BaseModel):
+    """Configuration for ``creek lint`` checks (FEAT-008, FEAT-025).
+
+    Today only the paradox check carries a knob; this class exists so
+    additional check-level toggles can land without expanding the
+    top-level :class:`CreekConfig` surface.
+    """
+
+    paradox_cross_level: bool = False
+    """FEAT-025 opt-in for cross-level paradox detection.
+
+    ``False`` (default): the paradox check skips pairs whose
+    :attr:`creek.models.Fragment.level` values differ — a paragraph
+    contradicting the section it lives inside is rhetorical structure,
+    not the contradiction `10-Liminal/Paradoxes/` is for.
+
+    ``True``: restore the pre-FEAT-025 behaviour. Useful when the
+    operator wants the cross-level pairs surfaced (e.g. to audit a
+    re-atomized vault for splitter mistakes).
+    """
+
+
 class SourcePaths(BaseModel):
     """Source data paths (relative to ``source_drive``)."""
 
@@ -630,6 +652,9 @@ class CreekConfig(BaseSettings):
 
     compost: CompostConfig = Field(default_factory=CompostConfig)
     """Compost detection settings (FEAT-018: embedding gate + verifier)."""
+
+    lint: LintConfig = Field(default_factory=LintConfig)
+    """Lint check toggles (FEAT-008 / FEAT-025)."""
 
     sources: SourcePaths = Field(default_factory=SourcePaths)
     """Source data path mappings."""

--- a/creek-tools/creek/generate/paradox.py
+++ b/creek-tools/creek/generate/paradox.py
@@ -247,6 +247,7 @@ class ParadoxDetector:
         fragments: list[Fragment],
         *,
         embeddings: dict[str, list[float]] | None = None,
+        cross_level: bool = False,
     ) -> list[Paradox]:
         """Scan fragments for contradictory pairs.
 
@@ -262,6 +263,12 @@ class ParadoxDetector:
                 vector. When provided, it is used to compute cosine
                 similarity for the topic-sharing rules. When absent,
                 only the thread- and frequency-based rules can match.
+            cross_level: FEAT-025 opt-in. When ``False`` (default),
+                pairs at different structural levels (e.g. a paragraph
+                vs. the section enclosing it) are skipped — that kind
+                of contradiction is rhetorical structure, not a paradox.
+                Set ``True`` to restore the pre-FEAT-025 behaviour and
+                emit cross-level pairs as paradoxes too.
 
         Returns:
             List of :class:`Paradox` instances, one per contradictory
@@ -273,6 +280,8 @@ class ParadoxDetector:
         embeddings = embeddings or {}
         paradoxes: list[Paradox] = []
         for a, b in itertools.combinations(fragments, 2):
+            if not cross_level and str(a.level) != str(b.level):
+                continue
             similarity = self._pair_similarity(a, b, embeddings)
             paradox = self._detect_pair(a, b, similarity)
             if paradox is not None:

--- a/creek-tools/creek/generate/state.py
+++ b/creek-tools/creek/generate/state.py
@@ -45,6 +45,7 @@ from creek.generate.wavelength import (
     CurrentPhaseSummary,
     current_phase_summary,
 )
+from creek.hierarchy import select_by_policy
 from creek.models import Eddy, Fragment, Frequency, Praxis, Thread
 
 logger = logging.getLogger(__name__)
@@ -376,6 +377,17 @@ def _section(header: str, body_lines: list[str]) -> str:
     return header + "\n\n" + "\n".join(body_lines)
 
 
+def _level_annotation(level: str) -> str:
+    """FEAT-025: render the "level used" note that opens hierarchy-aware sections.
+
+    Italicised so it visually sits below the section header without
+    competing with body content; the trailing period keeps the line a
+    full sentence so downstream tools (state-budget, voice-proxy) don't
+    treat it as a heading.
+    """
+    return f"_Counted at: {level}._"
+
+
 def _seed_as_prompt(seed: IdeaSeed) -> str:
     """Format a phase-filtered :class:`IdeaSeed` as one bullet of prompt text.
 
@@ -431,6 +443,8 @@ class StateReportGenerator:
         self._state = _load_vault_state(vault_path)
         self._current_phase_override = current_phase
         self._wavelength_summary: CurrentPhaseSummary | None = None
+        self._leaf_fragments: list[Fragment] | None = None
+        self._leaf_ids: frozenset[str] | None = None
 
     # ---- Sections ---------------------------------------------------
 
@@ -442,6 +456,10 @@ class StateReportGenerator:
         adapted to Creek. The snapshot is descriptive only: no
         prescriptive ranking, no "should" language.
 
+        FEAT-025: the snapshot reads at ``documents`` granularity —
+        sentence- or paragraph-level wavelength readings would be noise
+        next to whole-source phase signal.
+
         Falls back to the empty-state placeholder when the vault has no
         classified fragments in the 28-day window.
         """
@@ -449,6 +467,8 @@ class StateReportGenerator:
         if summary.fragment_count == 0:
             return _section(_HEADER_WAVELENGTH, [])
         body = [
+            _level_annotation("documents"),
+            "",
             f"- Phase: **{summary.phase}** (confidence {summary.confidence:.2f})",
             f"- Mode: **{summary.mode}**",
             f"- Fragments observed: {summary.fragment_count} "
@@ -507,13 +527,42 @@ class StateReportGenerator:
         return _section(_HEADER_SUGGESTED_QUESTIONS, body)
 
     def _resolve_wavelength_summary(self) -> CurrentPhaseSummary:
-        """Compute the wavelength summary once per generator instance."""
+        """Compute the wavelength summary once per generator instance.
+
+        FEAT-025: reads at ``documents`` granularity so sentence- and
+        paragraph-level wavelength readings don't drown out the phase
+        signal a whole-source document carries.
+        """
         if self._wavelength_summary is None:
             self._wavelength_summary = current_phase_summary(
                 self.vault_path,
                 today=self.today,
+                level_policy="documents",
             )
         return self._wavelength_summary
+
+    def _leaves(self) -> list[Fragment]:
+        """Return the leaf-level slice of loaded fragments (memoised).
+
+        FEAT-025: a fragment is a "leaf" in the current vault when none
+        of its ``child_ids`` are present among the loaded fragments —
+        the same semantics used by :func:`creek.hierarchy.select_by_policy`.
+        """
+        if self._leaf_fragments is None:
+            self._leaf_fragments = select_by_policy(self._state.fragments, "leaves")
+            self._leaf_ids = frozenset(f.id for f in self._leaf_fragments)
+        return self._leaf_fragments
+
+    def _is_leaf(self, fragment_id: str) -> bool:
+        """Whether *fragment_id* is a leaf in the current vault load.
+
+        Returns ``False`` for IDs that aren't loaded — a fragment we
+        can't see can't be verified as a leaf, and conservatively
+        excluding it keeps cross-set rollups (synchronicities) honest.
+        """
+        self._leaves()
+        leaf_ids = self._leaf_ids or frozenset()
+        return fragment_id in leaf_ids
 
     def _resolve_current_phase(self) -> str:
         """Return the active phase value (override > derived > unclassified)."""
@@ -586,34 +635,74 @@ class StateReportGenerator:
         return _HEADER_PRE_LLM_YIELD + "\n\n" + "\n".join(body)
 
     def section_active_eddies(self) -> str:
-        """Render section 3: top eddies by ``fragment_count`` (capped at ten)."""
+        """Render section 3: top eddies by leaf-counted fragments (capped at ten).
+
+        FEAT-025: when any leaves are loaded, state recounts how many
+        link to each eddy via the fragment's ``eddies`` wikilinks — the
+        stored :attr:`creek.models.Eddy.fragment_count` is ignored. On
+        a vault with eddies but no loaded fragments at all, the stored
+        count is the only signal available and we fall back to it so
+        the placeholder behaviour of FEAT-006 is preserved.
+        """
+        leaf_counts = self._leaf_counts_by_link("eddies")
+        has_leaves = bool(self._leaves())
         eddies = sorted(
             self._state.eddies,
-            key=lambda e: (-e.fragment_count, e.title),
+            key=lambda e: (
+                -self._eddy_count(e, leaf_counts, has_leaves=has_leaves),
+                e.title,
+            ),
         )[:_TOP_N]
-        body = [
-            f"- {eddy.title} — {eddy.fragment_count} fragment(s)" for eddy in eddies
+        rows = [
+            f"- {eddy.title} — "
+            f"{self._eddy_count(eddy, leaf_counts, has_leaves=has_leaves)} "
+            "fragment(s)"
+            for eddy in eddies
         ]
-        return _section(_HEADER_ACTIVE_EDDIES, body)
+        return _section(
+            _HEADER_ACTIVE_EDDIES,
+            self._prepend_annotation(rows, "leaves"),
+        )
 
     def section_active_threads(self) -> str:
-        """Render section 4: most-recent threads by ``last_seen`` (capped at ten)."""
+        """Render section 4: most-recent threads by ``last_seen`` (capped at ten).
+
+        FEAT-025: the fragment count next to each thread is leaf-counted
+        the same way as :meth:`section_active_eddies`. The sort key
+        (``last_seen``) is unchanged — recency is independent of level.
+        """
+        leaf_counts = self._leaf_counts_by_link("threads")
+        has_leaves = bool(self._leaves())
         threads = sorted(
             self._state.threads,
             key=lambda t: (t.last_seen, t.title),
             reverse=True,
         )[:_TOP_N]
-        body = [
+        rows = [
             f"- {thread.title} — last seen {thread.last_seen.isoformat()} "
-            f"({thread.fragment_count} fragment(s))"
+            f"({self._thread_count(thread, leaf_counts, has_leaves=has_leaves)} "
+            "fragment(s))"
             for thread in threads
         ]
-        return _section(_HEADER_ACTIVE_THREADS, body)
+        return _section(
+            _HEADER_ACTIVE_THREADS,
+            self._prepend_annotation(rows, "leaves"),
+        )
 
     def section_synchronicities(self) -> str:
-        """Render section 5: surprising connections (synchronicities)."""
+        """Render section 5: surprising connections (synchronicities).
+
+        FEAT-025: synchronicities whose endpoints are not both leaves
+        are filtered out — a sync from a parent fragment is rhetorical
+        structure, not the surprising cross-source resonance the
+        section is meant to surface.
+        """
         rows = sorted(
-            self._state.synchronicities,
+            (
+                row
+                for row in self._state.synchronicities
+                if self._is_leaf(row.fragment_a_id) and self._is_leaf(row.fragment_b_id)
+            ),
             key=lambda r: (-r.similarity, r.sync_id),
         )[:_TOP_N]
         body = [
@@ -621,7 +710,69 @@ class StateReportGenerator:
             f"similarity {row.similarity:.2f}, gap {row.time_gap_days}d"
             for row in rows
         ]
-        return _section(_HEADER_SYNCHRONICITIES, body)
+        return _section(
+            _HEADER_SYNCHRONICITIES,
+            self._prepend_annotation(body, "leaves"),
+        )
+
+    @staticmethod
+    def _prepend_annotation(rows: list[str], level: str) -> list[str]:
+        """Insert the level annotation when *rows* has any content.
+
+        Keeps the FEAT-006 empty-state placeholder reachable: when the
+        section would otherwise be empty, ``_section`` renders
+        :data:`EMPTY_PLACEHOLDER` and the annotation is suppressed.
+        """
+        if not rows:
+            return rows
+        return [_level_annotation(level), "", *rows]
+
+    def _leaf_counts_by_link(self, attr: str) -> dict[str, int]:
+        """Count leaves grouped by their ``fragment.<attr>`` wiki-link targets.
+
+        Args:
+            attr: ``"eddies"`` or ``"threads"`` — the fragment attribute
+                holding the per-target wiki-link strings.
+
+        Returns:
+            ``{target_title: leaf_count}`` derived from the leaves slice.
+        """
+        counts: Counter[str] = Counter()
+        for frag in self._leaves():
+            for target in _wikilink_targets(getattr(frag, attr)):
+                counts[target] += 1
+        return dict(counts)
+
+    @staticmethod
+    def _eddy_count(
+        eddy: Eddy,
+        leaf_counts: dict[str, int],
+        *,
+        has_leaves: bool,
+    ) -> int:
+        """Resolve the displayed eddy count.
+
+        When the vault has any loaded leaf fragments, the leaf count
+        wins — including zero, which is the *honest* answer when no
+        leaves currently link to this eddy. When the vault has no
+        loaded fragments at all, the stored ``fragment_count`` is the
+        only signal we have and is used as a fallback.
+        """
+        if has_leaves:
+            return leaf_counts.get(eddy.title, 0)
+        return eddy.fragment_count
+
+    @staticmethod
+    def _thread_count(
+        thread: Thread,
+        leaf_counts: dict[str, int],
+        *,
+        has_leaves: bool,
+    ) -> int:
+        """Resolve the displayed thread count (see :meth:`_eddy_count`)."""
+        if has_leaves:
+            return leaf_counts.get(thread.title, 0)
+        return thread.fragment_count
 
     def section_hyperedges(self) -> str:
         """Render section 6: praxis whose source fragments span 2+ eddies.

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -23,6 +23,7 @@ import frontmatter
 import yaml
 from pydantic import ValidationError
 
+from creek.hierarchy import LevelPolicy, select_by_policy
 from creek.models import Dosage, Fragment, Frequency, Mode, Phase
 
 if TYPE_CHECKING:
@@ -1273,6 +1274,7 @@ def current_phase_summary(
     *,
     today: date | None = None,
     window_days: int = DEFAULT_CURRENT_PHASE_WINDOW_DAYS,
+    level_policy: LevelPolicy = "all",
 ) -> CurrentPhaseSummary:
     """Return a :class:`CurrentPhaseSummary` for the trailing *window_days*.
 
@@ -1291,6 +1293,10 @@ def current_phase_summary(
             day near midnight UTC on a non-UTC host.
         window_days: Lookback (inclusive). Defaults to 28 days — long
             enough that one quiet week does not flip the dominant phase.
+        level_policy: FEAT-025 level filter applied before aggregation.
+            ``"all"`` (default) reproduces the pre-FEAT-025 behaviour.
+            ``creek state`` passes ``"documents"`` so the snapshot is
+            read at whole-source granularity.
 
     Returns:
         A :class:`CurrentPhaseSummary`.
@@ -1298,6 +1304,7 @@ def current_phase_summary(
     anchor = today or datetime.now(tz=UTC).date()
     start = anchor - timedelta(days=window_days - 1)
     fragments = _load_fragments_from_vault(vault_path)
+    fragments = select_by_policy(fragments, level_policy)
     tracker = WavelengthTracker()
     snapshot = tracker.analyze_period(fragments, start, anchor)
     weekly = tracker.weekly_snapshots(fragments, start, anchor)

--- a/creek-tools/creek/hierarchy.py
+++ b/creek-tools/creek/hierarchy.py
@@ -1,0 +1,132 @@
+"""Level-policy helpers for hierarchy-aware generators (FEAT-025).
+
+The classify pipeline (FEAT-020..023) produces fragments at multiple
+structural levels for the same underlying material — sentences carved
+from paragraphs, paragraphs carved from sections, exchanges stitched
+from messages, sessions stitched from bursts. Generators that summarise
+or aggregate across the vault now need to pick a level: do they count
+every fragment, only the most-atomic leaves, or only whole-source
+documents (so sentence-level wavelength readings don't drown the signal)?
+
+This module is the single source of truth for that choice. Each public
+helper takes a list of :class:`~creek.models.Fragment` and a
+:data:`LevelPolicy` and returns the filtered subset — no I/O, no
+implicit vault scans, so callers can stay testable.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, get_args
+
+if TYPE_CHECKING:
+    from creek.models import Fragment
+
+LevelPolicy = Literal["leaves", "documents", "all"]
+"""Which structural level a generator operates on.
+
+- ``"leaves"``: keep only the most-atomic available representation
+  *within the input set*. A fragment is a leaf when none of its
+  ``child_ids`` appear among the inputs; this lets callers pass a
+  partial slice and still get the right answer without re-scanning
+  the vault.
+- ``"documents"``: keep fragments at ``document`` / ``session`` level —
+  the granularity at which whole-source phase reads make sense.
+- ``"all"``: pre-FEAT-025 passthrough — used for regression tests and
+  by callers that have already filtered upstream.
+"""
+
+_DOCUMENT_LEVELS: frozenset[str] = frozenset({"document", "session"})
+"""Structural levels treated as "whole-source"-grained.
+
+``document`` is the default for any flat ingestion; ``session`` is the
+coarsest level the FEAT-022 zoom-out aggregator produces. Anything
+finer (sentence, paragraph, subsection, section, exchange, burst) is
+explicitly *not* a document for wavelength-read purposes.
+"""
+
+
+def select_by_policy(
+    fragments: list[Fragment],
+    policy: LevelPolicy,
+) -> list[Fragment]:
+    """Return the subset of *fragments* selected by *policy*.
+
+    Args:
+        fragments: Input fragments (any order, any hierarchy mix).
+        policy: One of ``"leaves"``, ``"documents"``, ``"all"``.
+
+    Returns:
+        Fragments selected by *policy*, in input order.
+
+    Raises:
+        ValueError: If *policy* is not one of the documented values —
+            a silent passthrough on a typo would mask the bug.
+    """
+    if policy not in get_args(LevelPolicy):
+        msg = (
+            f"Unknown level_policy {policy!r}; "
+            f"expected one of {', '.join(get_args(LevelPolicy))}."
+        )
+        raise ValueError(msg)
+    if policy == "all":
+        return fragments.copy()
+    if policy == "documents":
+        return [f for f in fragments if str(f.level) in _DOCUMENT_LEVELS]
+    ids_in_set = {f.id for f in fragments}
+    return [
+        f
+        for f in fragments
+        if not any(child_id in ids_in_set for child_id in f.child_ids)
+    ]
+
+
+def source_levels(fragments: list[Fragment]) -> list[str]:
+    """Return the sorted distinct levels present in *fragments*.
+
+    Used by :mod:`creek.compile.engine` to record which structural
+    levels contributed to a compiled page in its frontmatter, so a
+    future re-compile can detect drift.
+    """
+    return sorted({str(f.level) for f in fragments})
+
+
+def structural_path_context(
+    leaf: Fragment,
+    by_id: dict[str, Fragment],
+) -> list[str]:
+    """Return the structural-path breadcrumb for *leaf*.
+
+    Prefers the leaf's own ``structural_path`` (FEAT-020 round-trips it
+    through frontmatter). Falls back to walking ``parent_id`` through
+    *by_id* and collecting parent titles — useful when the persisted
+    field is empty because the writer that produced this fragment
+    pre-dated FEAT-020.
+
+    Args:
+        leaf: The fragment whose ancestry to render.
+        by_id: Mapping of fragment ID → :class:`Fragment` for every
+            fragment available in the current context. Walks stop at
+            the first missing parent rather than raising.
+
+    Returns:
+        Breadcrumb from root to immediate parent, in display order.
+        Empty when *leaf* has no ancestry to surface.
+    """
+    if leaf.structural_path:
+        return leaf.structural_path.copy()
+    path: list[str] = []
+    current = leaf
+    while current.parent_id is not None and current.parent_id in by_id:
+        parent = by_id[current.parent_id]
+        path.append(parent.title or parent.id)
+        current = parent
+    path.reverse()
+    return path
+
+
+__all__ = [
+    "LevelPolicy",
+    "select_by_policy",
+    "source_levels",
+    "structural_path_context",
+]

--- a/creek-tools/creek/lint/checks/paradox.py
+++ b/creek-tools/creek/lint/checks/paradox.py
@@ -4,6 +4,11 @@ Lint **never** resolves paradoxes. Detected pairs are routed to
 ``10-Liminal/Paradoxes/`` via the existing
 :meth:`~creek.generate.paradox.ParadoxDetector.create_paradox_note`
 helper — the wrapper here only counts and summarises.
+
+FEAT-025: by default the wrapped detector skips cross-level pairs (a
+paragraph contradicting the section it sits inside is rhetorical
+structure). Set ``lint.paradox_cross_level: true`` in
+``creek_config.yaml`` to restore the pre-FEAT-025 behaviour.
 """
 
 from __future__ import annotations
@@ -14,6 +19,7 @@ from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
 import frontmatter
 from pydantic import ValidationError
 
+from creek.config import load_config
 from creek.generate.paradox import ParadoxDetector
 from creek.lint._result import CheckResult
 from creek.models import Fragment
@@ -37,11 +43,33 @@ def _load_fragments(vault_path: Path) -> list[Fragment]:
     return fragments
 
 
+def _resolve_cross_level(vault_path: Path) -> bool:
+    """Read the FEAT-025 ``lint.paradox_cross_level`` knob, defaulting to False.
+
+    Looks for ``00-Creek-Meta/creek_config.yaml`` inside *vault_path* —
+    the same canonical location ``creek init`` writes. A missing file
+    is silently treated as "use defaults"; config-load errors propagate
+    so an operator notices a malformed YAML rather than silently
+    getting the wrong policy.
+    """
+    config_path = vault_path / "00-Creek-Meta" / "creek_config.yaml"
+    config = load_config(config_path, warn_on_missing=False)
+    return config.lint.paradox_cross_level
+
+
 def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
-    """Detect contradiction pairs without resolving any of them."""
+    """Detect contradiction pairs without resolving any of them.
+
+    FEAT-025 honours ``lint.paradox_cross_level`` from the vault's
+    ``creek_config.yaml`` (defaults to ``False``).
+    """
     del since  # ParadoxDetector does not support incremental scans today
     fragments = _load_fragments(vault_path)
-    paradoxes = ParadoxDetector().detect_paradoxes(fragments)
+    cross_level = _resolve_cross_level(vault_path)
+    paradoxes = ParadoxDetector().detect_paradoxes(
+        fragments,
+        cross_level=cross_level,
+    )
     findings = [
         f"- {pair.contradiction_type}: "
         f"`{pair.fragment_ids[0]}` ↔ `{pair.fragment_ids[1]}` "

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -709,6 +709,14 @@ class CompiledPage(BaseModel):
         compiled_at: UTC timestamp of the most recent compile run.
         compile_method: How the page's claims were produced — one of
             ``"rules"``, ``"llm"``, or ``"manual"``.
+        level_policy: FEAT-025 level policy used to filter source
+            fragments. ``"leaves"`` is the default — parents serve as
+            ``structural_path`` context rather than duplicate content.
+            ``"all"`` reproduces the pre-FEAT-025 behaviour and is
+            recorded explicitly for re-compile audits.
+        source_levels: Sorted distinct ``Fragment.level`` values of the
+            fragments that actually fed the synthesis after the policy
+            filter ran. Empty on pre-FEAT-025 pages.
     """
 
     model_config = ConfigDict(use_enum_values=True)
@@ -721,3 +729,5 @@ class CompiledPage(BaseModel):
     provenance: list[ProvenanceEntry] = Field(default_factory=list)
     compiled_at: datetime = Field(default_factory=_utc_now)
     compile_method: CompileMethod = "llm"
+    level_policy: str = "leaves"
+    source_levels: list[str] = Field(default_factory=list)

--- a/creek-tools/tests/test_compile.py
+++ b/creek-tools/tests/test_compile.py
@@ -912,3 +912,243 @@ def test_cli_compile_unknown_target_kind_exits_2(vault: Path) -> None:
     )
     assert result.exit_code == 2
     assert "target-kind" in result.stdout.lower() or "kind" in result.stdout.lower()
+
+
+# ---- FEAT-025: hierarchy-aware compile -----------------------------------
+
+
+def _make_child_fragment(
+    *,
+    frag_id: str,
+    parent_id: str,
+    level: str = "paragraph",
+    title: str = "A child fragment",
+) -> Fragment:
+    """Build a child fragment that references a parent via parent_id."""
+    return Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        created=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        ingested=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        level=level,  # type: ignore[arg-type]
+        parent_id=parent_id,
+    )
+
+
+def test_compile_records_level_policy_and_source_levels_in_frontmatter() -> None:
+    """The CompiledPage records the level_policy + source_levels used."""
+    frag = _make_fragment(frag_id="frag-aaa")
+    response = _llm_response(
+        claims=[
+            {
+                "id": "claim-001",
+                "text": "A claim.",
+                "fragment_ids": ["frag-aaa"],
+            },
+        ],
+    )
+    llm, _ = _make_llm([response])
+
+    result = compile_fragments(
+        [(frag, "body")],
+        llm=llm,
+        target_kind="thread",
+        target_id="thread-l",
+        target_title="L",
+    )
+
+    assert result.page.level_policy == "leaves"
+    assert result.page.source_levels == ["document"]
+
+
+def test_compile_filters_to_leaves_by_default() -> None:
+    """Parents whose children are also in the set drop out of the synthesis."""
+    parent = Fragment(
+        id="frag-parent",
+        title="Whole document",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        created=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        ingested=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        level="document",
+        child_ids=["frag-child-1", "frag-child-2"],
+    )
+    child1 = _make_child_fragment(frag_id="frag-child-1", parent_id="frag-parent")
+    child2 = _make_child_fragment(
+        frag_id="frag-child-2",
+        parent_id="frag-parent",
+        title="A second child",
+    )
+    response = _llm_response(
+        claims=[
+            {
+                "id": "claim-001",
+                "text": "Synthesised from leaves.",
+                "fragment_ids": ["frag-child-1", "frag-child-2"],
+            },
+        ],
+    )
+    llm, prompts = _make_llm([response])
+
+    result = compile_fragments(
+        [
+            (parent, "the entire parent body that must not be duplicated"),
+            (child1, "child one body"),
+            (child2, "child two body"),
+        ],
+        llm=llm,
+        target_kind="thread",
+        target_id="thread-h",
+        target_title="H",
+    )
+
+    prompt = prompts[0]
+    # Parent body must NOT appear — it was rolled up via leaves.
+    assert "the entire parent body that must not be duplicated" not in prompt
+    # Both leaf bodies do appear.
+    assert "child one body" in prompt
+    assert "child two body" in prompt
+    # source_levels reflect what was actually used.
+    assert result.page.source_levels == ["paragraph"]
+
+
+def test_compile_surfaces_parent_as_structural_path_context() -> None:
+    """Parents appear in the prompt as structural-path context, not as bodies."""
+    parent = Fragment(
+        id="frag-parent",
+        title="The Capricorn Moon",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        created=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        ingested=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        level="document",
+        child_ids=["frag-child"],
+    )
+    child = _make_child_fragment(
+        frag_id="frag-child",
+        parent_id="frag-parent",
+        title="On grief",
+    )
+    response = _llm_response(
+        claims=[
+            {
+                "id": "claim-001",
+                "text": "A claim from the leaf.",
+                "fragment_ids": ["frag-child"],
+            },
+        ],
+    )
+    llm, prompts = _make_llm([response])
+
+    compile_fragments(
+        [(parent, "parent body"), (child, "child body")],
+        llm=llm,
+        target_kind="thread",
+        target_id="thread-c",
+        target_title="C",
+    )
+
+    prompt = prompts[0]
+    # The leaf body flows; the parent's title surfaces as breadcrumb context.
+    assert "child body" in prompt
+    assert "The Capricorn Moon" in prompt
+    assert "parent body" not in prompt
+
+
+def test_compile_level_policy_all_keeps_pre_feat025_behaviour() -> None:
+    """An explicit ``all`` policy mirrors the flat-vault path."""
+    parent = Fragment(
+        id="frag-parent",
+        title="A document",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        created=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        ingested=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        level="document",
+        child_ids=["frag-child"],
+    )
+    child = _make_child_fragment(frag_id="frag-child", parent_id="frag-parent")
+    response = _llm_response(
+        claims=[
+            {
+                "id": "claim-001",
+                "text": "A claim.",
+                "fragment_ids": ["frag-parent", "frag-child"],
+            },
+        ],
+    )
+    llm, prompts = _make_llm([response])
+
+    result = compile_fragments(
+        [(parent, "parent body"), (child, "child body")],
+        llm=llm,
+        target_kind="thread",
+        target_id="thread-a",
+        target_title="A",
+        level_policy="all",
+    )
+
+    prompt = prompts[0]
+    assert "parent body" in prompt
+    assert "child body" in prompt
+    assert result.page.level_policy == "all"
+    assert set(result.page.source_levels) == {"document", "paragraph"}
+
+
+def test_compile_to_vault_persists_level_policy_in_frontmatter(vault: Path) -> None:
+    """Frontmatter on disk carries the level_policy + source_levels fields."""
+    frag = _make_fragment(frag_id="frag-aaa")
+    _write_fragment_to_vault(vault, frag, body="body")
+    response = _llm_response(
+        claims=[
+            {
+                "id": "claim-001",
+                "text": "A claim.",
+                "fragment_ids": ["frag-aaa"],
+            },
+        ],
+    )
+    llm, _ = _make_llm([response])
+
+    written = compile_to_vault(
+        fragment_ids=["frag-aaa"],
+        vault_path=vault,
+        target_kind="thread",
+        target_id="thread-d",
+        target_title="D",
+        llm=llm,
+    )
+
+    post = frontmatter.load(str(written))
+    assert post.metadata["level_policy"] == "leaves"
+    assert post.metadata["source_levels"] == ["document"]
+
+
+def test_compile_flat_vault_regression(vault: Path) -> None:
+    """A flat-fragment vault produces the same provenance as before FEAT-025."""
+    frag_a = _make_fragment(frag_id="frag-aaa")
+    frag_b = _make_fragment(frag_id="frag-bbb")
+    _write_fragment_to_vault(vault, frag_a, body="body A")
+    _write_fragment_to_vault(vault, frag_b, body="body B")
+    response = _llm_response(
+        claims=[
+            {
+                "id": "claim-001",
+                "text": "Shared claim.",
+                "fragment_ids": ["frag-aaa", "frag-bbb"],
+            },
+        ],
+    )
+    llm, _ = _make_llm([response])
+
+    written = compile_to_vault(
+        fragment_ids=["frag-aaa", "frag-bbb"],
+        vault_path=vault,
+        target_kind="thread",
+        target_id="thread-flat",
+        target_title="Flat",
+        llm=llm,
+    )
+
+    post = frontmatter.load(str(written))
+    provenance = post.metadata["provenance"]
+    assert len(provenance) == 1
+    assert provenance[0]["fragment_ids"] == ["frag-aaa", "frag-bbb"]

--- a/creek-tools/tests/test_hierarchy.py
+++ b/creek-tools/tests/test_hierarchy.py
@@ -1,0 +1,210 @@
+"""Tests for :mod:`creek.hierarchy` — level-policy filtering (FEAT-025).
+
+Pin the single source of truth that compile / state / lint consult when
+deciding which structural levels they operate on. The helpers must:
+
+* default to "leaves" semantics that respect the input set (a leaf is
+  a fragment whose children are not currently being considered, not
+  one whose ``child_ids`` is unconditionally empty);
+* expose a "documents" projection that keeps the whole-source levels
+  (``document`` / ``session``) without leaking sentence/paragraph rows;
+* return a deterministic ``source_levels`` list suitable for compiled-
+  page frontmatter; and
+* derive a ``structural_path`` breadcrumb from in-memory ancestry when
+  the persisted field is empty.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from creek.hierarchy import (
+    LevelPolicy,
+    select_by_policy,
+    source_levels,
+    structural_path_context,
+)
+from creek.models import (
+    Authorship,
+    Fragment,
+    FragmentSource,
+    SourcePlatform,
+)
+
+
+def _frag(
+    frag_id: str,
+    *,
+    level: str = "document",
+    parent_id: str | None = None,
+    child_ids: list[str] | None = None,
+    structural_path: list[str] | None = None,
+    title: str | None = None,
+) -> Fragment:
+    """Build a minimal Fragment for hierarchy tests."""
+    return Fragment(
+        id=frag_id,
+        title=title or f"Title for {frag_id}",
+        source=FragmentSource(
+            platform=SourcePlatform.MARKDOWN,
+            author=Authorship.SELF,
+        ),
+        created=datetime(2026, 5, 1, tzinfo=UTC),
+        ingested=datetime(2026, 5, 1, tzinfo=UTC),
+        level=level,  # type: ignore[arg-type]
+        parent_id=parent_id,
+        child_ids=child_ids or [],
+        structural_path=structural_path or [],
+    )
+
+
+class TestSelectByPolicyLeaves:
+    """``leaves`` keeps the most-atomic fragments in the input set."""
+
+    def test_flat_vault_returns_everyone(self) -> None:
+        """A flat vault — every fragment is a leaf — passes through unchanged."""
+        a = _frag("a")
+        b = _frag("b")
+        result = select_by_policy([a, b], "leaves")
+        assert [f.id for f in result] == ["a", "b"]
+
+    def test_parent_dropped_when_children_in_set(self) -> None:
+        """A parent fragment is filtered out when its children are present."""
+        parent = _frag("p", level="document", child_ids=["c1", "c2"])
+        child1 = _frag("c1", level="paragraph", parent_id="p")
+        child2 = _frag("c2", level="paragraph", parent_id="p")
+        result = select_by_policy([parent, child1, child2], "leaves")
+        assert [f.id for f in result] == ["c1", "c2"]
+
+    def test_parent_retained_when_children_absent(self) -> None:
+        """A parent with no in-set children is itself a leaf for this slice."""
+        parent = _frag("p", level="document", child_ids=["c1"])
+        result = select_by_policy([parent], "leaves")
+        assert [f.id for f in result] == ["p"]
+
+    def test_three_level_hierarchy_keeps_grandchildren(self) -> None:
+        """Sentence-level grandchildren win against paragraph + section parents."""
+        section = _frag("sec", level="section", child_ids=["p1"])
+        paragraph = _frag("p1", level="paragraph", parent_id="sec", child_ids=["s1"])
+        sentence = _frag("s1", level="sentence", parent_id="p1")
+        result = select_by_policy([section, paragraph, sentence], "leaves")
+        assert [f.id for f in result] == ["s1"]
+
+    def test_preserves_input_order(self) -> None:
+        """Selected leaves retain their relative order from the input list."""
+        a = _frag("a")
+        b = _frag("b")
+        c = _frag("c")
+        result = select_by_policy([c, a, b], "leaves")
+        assert [f.id for f in result] == ["c", "a", "b"]
+
+
+class TestSelectByPolicyDocuments:
+    """``documents`` keeps whole-source granularity only."""
+
+    def test_keeps_document_and_session(self) -> None:
+        """``document`` and ``session`` survive; finer levels are dropped."""
+        doc = _frag("doc", level="document")
+        session = _frag("ses", level="session")
+        sentence = _frag("sen", level="sentence")
+        paragraph = _frag("par", level="paragraph")
+        result = select_by_policy([doc, session, sentence, paragraph], "documents")
+        assert {f.id for f in result} == {"doc", "ses"}
+
+    def test_empty_when_no_document_levels_present(self) -> None:
+        """A purely-sentence-level slice yields zero documents."""
+        result = select_by_policy([_frag("s", level="sentence")], "documents")
+        assert result == []
+
+
+class TestSelectByPolicyAll:
+    """``all`` is a passthrough — used by legacy / regression paths."""
+
+    def test_passthrough(self) -> None:
+        """Every fragment, regardless of level, is returned."""
+        a = _frag("a", level="sentence")
+        b = _frag("b", level="document")
+        result = select_by_policy([a, b], "all")
+        assert [f.id for f in result] == ["a", "b"]
+
+
+class TestSelectByPolicyRejectsUnknown:
+    """An unknown policy name is a programmer error, not a silent passthrough."""
+
+    def test_unknown_policy_raises(self) -> None:
+        """A typo should surface immediately rather than fall through."""
+        with pytest.raises(ValueError, match="level_policy"):
+            select_by_policy([_frag("a")], "everything")  # type: ignore[arg-type]
+
+
+class TestSourceLevels:
+    """``source_levels`` returns a deterministic sorted list of distinct levels."""
+
+    def test_distinct_levels_sorted(self) -> None:
+        """Mixed-level inputs collapse to a sorted set of strings."""
+        frags = [
+            _frag("a", level="paragraph"),
+            _frag("b", level="sentence"),
+            _frag("c", level="paragraph"),
+        ]
+        assert source_levels(frags) == ["paragraph", "sentence"]
+
+    def test_empty_inputs_returns_empty(self) -> None:
+        """An empty fragment list yields an empty levels list."""
+        assert source_levels([]) == []
+
+
+class TestStructuralPathContext:
+    """Breadcrumb derivation from the data model."""
+
+    def test_persisted_structural_path_wins(self) -> None:
+        """When the fragment carries its own breadcrumb, return that verbatim."""
+        leaf = _frag(
+            "s1",
+            level="sentence",
+            parent_id="p1",
+            structural_path=["Section A", "Paragraph 3"],
+        )
+        path = structural_path_context(leaf, {})
+        assert path == ["Section A", "Paragraph 3"]
+
+    def test_walks_parents_when_path_empty(self) -> None:
+        """Without a persisted path, walk ``parent_id`` and collect titles."""
+        grandparent = _frag(
+            "sec",
+            level="section",
+            child_ids=["p1"],
+            title="The Capricorn Moon",
+        )
+        parent = _frag(
+            "p1",
+            level="paragraph",
+            parent_id="sec",
+            child_ids=["s1"],
+            title="On grief",
+        )
+        leaf = _frag("s1", level="sentence", parent_id="p1")
+        by_id = {f.id: f for f in (grandparent, parent, leaf)}
+        path = structural_path_context(leaf, by_id)
+        assert path == ["The Capricorn Moon", "On grief"]
+
+    def test_missing_parent_terminates_walk(self) -> None:
+        """A dangling ``parent_id`` ends the walk without raising."""
+        leaf = _frag("s1", level="sentence", parent_id="missing")
+        assert structural_path_context(leaf, {"s1": leaf}) == []
+
+    def test_no_parent_returns_empty(self) -> None:
+        """A root fragment has no breadcrumb."""
+        assert structural_path_context(_frag("a"), {}) == []
+
+
+class TestLevelPolicyType:
+    """Sanity: the public literal accepts the documented strings."""
+
+    @pytest.mark.parametrize("policy", ["leaves", "documents", "all"])
+    def test_accepts_documented_values(self, policy: LevelPolicy) -> None:
+        """The literal must include every value the generators rely on."""
+        # The call must not raise for any documented policy.
+        select_by_policy([], policy)

--- a/creek-tools/tests/test_lint.py
+++ b/creek-tools/tests/test_lint.py
@@ -145,6 +145,55 @@ def _write_skill(vault: Path, *, stem: str, lines: int) -> Path:
     return target
 
 
+def _write_paradox_pair_cross_level(vault: Path) -> None:
+    """Write two fragments that share a thread but sit at different levels.
+
+    The pair has the same dosage-rule trigger (medicine vs. toxic on a
+    shared primary frequency) so the detector would emit a paradox if
+    the cross-level guard were off. FEAT-025: with the default policy,
+    the pair is skipped.
+    """
+    when = datetime(2026, 5, 1, tzinfo=UTC)
+    common: dict[str, object] = {
+        "type": "fragment",
+        "created": when.isoformat(),
+        "ingested": when.isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "F1", "secondary": []},
+        "threads": ["shared-thread"],
+        "tags": [],
+    }
+    section = {
+        **common,
+        "id": "frag-section",
+        "title": "Section-level take",
+        "wavelength": {
+            "phase": "rising",
+            "mode": "express",
+            "dosage": "medicine",
+        },
+        "level": "section",
+    }
+    sentence = {
+        **common,
+        "id": "frag-sentence",
+        "title": "Sentence-level take",
+        "wavelength": {
+            "phase": "rising",
+            "mode": "express",
+            "dosage": "toxic",
+        },
+        "level": "sentence",
+        "parent_id": "frag-section",
+    }
+    for record in (section, sentence):
+        target = vault / "01-Fragments" / "Notes" / f"{record['id']}.md"
+        target.write_text(
+            frontmatter.dumps(frontmatter.Post(content="body", **record)),
+            encoding="utf-8",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Module-level invariants
 # ---------------------------------------------------------------------------
@@ -360,6 +409,32 @@ class TestSemanticWrappers:
         )
         result = paradox_check.run(tmp_path)
         assert result.findings == []
+
+    def test_paradox_skips_cross_level_pairs_by_default(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """FEAT-025: cross-level paradox candidates are filtered by default."""
+        _seed_vault(tmp_path)
+        _write_paradox_pair_cross_level(tmp_path)
+        result = paradox_check.run(tmp_path)
+        # The pair is at different levels, so no paradox is recorded.
+        assert result.findings == []
+
+    def test_paradox_includes_cross_level_pairs_when_configured(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """FEAT-025: ``lint.paradox_cross_level: true`` opts the pair back in."""
+        _seed_vault(tmp_path)
+        _write_paradox_pair_cross_level(tmp_path)
+        config_path = tmp_path / "00-Creek-Meta" / "creek_config.yaml"
+        config_path.write_text(
+            "lint:\n  paradox_cross_level: true\n",
+            encoding="utf-8",
+        )
+        result = paradox_check.run(tmp_path)
+        assert len(result.findings) == 1
 
     def test_unnamed_reports_zero_when_folder_missing(self, tmp_path: Path) -> None:
         """Vault without an Unnamed folder reports zero, not an error."""

--- a/creek-tools/tests/test_paradox.py
+++ b/creek-tools/tests/test_paradox.py
@@ -482,3 +482,86 @@ class TestCreateParadoxNote:
         assert first == second
         files = list((tmp_path / "10-Liminal" / "Paradoxes").glob("*.md"))
         assert len(files) == 1
+
+
+# ---- FEAT-025: cross-level paradox filter --------------------------------
+
+
+def _leveled_fragment(
+    fid: str,
+    *,
+    level: str,
+    phase: Phase = Phase.UNCLASSIFIED,
+    confidence: Confidence | None = None,
+    threads: list[str] | None = None,
+) -> Fragment:
+    """Build a fragment with an explicit structural level."""
+    return Fragment(
+        id=fid,
+        title=f"Title for {fid}",
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        frequency=FrequencyClassification(),
+        wavelength=WavelengthClassification(phase=phase),
+        voice=VoiceClassification(confidence=confidence),
+        threads=threads or [],
+        level=level,  # type: ignore[arg-type]
+    )
+
+
+class TestCrossLevelFilter:
+    """Cross-level pairs default to *not* a paradox — they're rhetorical."""
+
+    def test_cross_level_phase_pair_dropped_by_default(self) -> None:
+        """A sentence vs. paragraph contradiction is structure, not paradox."""
+        sentence = _leveled_fragment("frag-s", level="sentence", phase=Phase.RISING)
+        section = _leveled_fragment("frag-x", level="section", phase=Phase.DIMINISHING)
+        embeddings = {"frag-s": unit_embedding(0), "frag-x": unit_embedding(0)}
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes(
+            [sentence, section],
+            embeddings=embeddings,
+        )
+        assert paradoxes == []
+
+    def test_same_level_phase_pair_still_a_paradox(self) -> None:
+        """The default policy doesn't suppress same-level paradoxes."""
+        a = _leveled_fragment("frag-a", level="paragraph", phase=Phase.RISING)
+        b = _leveled_fragment("frag-b", level="paragraph", phase=Phase.DIMINISHING)
+        embeddings = {"frag-a": unit_embedding(0), "frag-b": unit_embedding(0)}
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes([a, b], embeddings=embeddings)
+        assert len(paradoxes) == 1
+
+    def test_cross_level_pair_surfaces_when_opt_in(self) -> None:
+        """``cross_level=True`` opts back into the pre-FEAT-025 behaviour."""
+        sentence = _leveled_fragment("frag-s", level="sentence", phase=Phase.RISING)
+        section = _leveled_fragment("frag-x", level="section", phase=Phase.DIMINISHING)
+        embeddings = {"frag-s": unit_embedding(0), "frag-x": unit_embedding(0)}
+
+        detector = ParadoxDetector()
+        paradoxes = detector.detect_paradoxes(
+            [sentence, section],
+            embeddings=embeddings,
+            cross_level=True,
+        )
+        assert len(paradoxes) == 1
+
+    def test_cross_level_filter_applies_to_confidence_rule(self) -> None:
+        """The cross-level guard applies to every detection rule, not just phase."""
+        a = _leveled_fragment(
+            "frag-a",
+            level="sentence",
+            confidence=Confidence.MUSING,
+            threads=["thread-trust"],
+        )
+        b = _leveled_fragment(
+            "frag-b",
+            level="paragraph",
+            confidence=Confidence.SETTLED,
+            threads=["thread-trust"],
+        )
+        detector = ParadoxDetector()
+        assert detector.detect_paradoxes([a, b]) == []
+        assert len(detector.detect_paradoxes([a, b], cross_level=True)) == 1

--- a/creek-tools/tests/test_state.py
+++ b/creek-tools/tests/test_state.py
@@ -254,8 +254,19 @@ def populated_vault(tmp_path: Path) -> Path:
         frequency="F1",
         eddies=["[[Innovation Eddy]]"],
     )
-    _write_eddy(tmp_path, eddy_id="eddy-1", title="Receptivity Eddy", fragment_count=8)
-    _write_eddy(tmp_path, eddy_id="eddy-2", title="Innovation Eddy", fragment_count=5)
+    # frag-004 (FEAT-025) makes Receptivity outweigh Innovation in leaf counts —
+    # otherwise leaf-aware counting would tie and the sort would flip to
+    # alphabetical order.
+    _write_fragment(
+        tmp_path,
+        frag_id="frag-004",
+        title="D",
+        created=base + timedelta(days=6),
+        frequency="F1",
+        eddies=["[[Receptivity Eddy]]"],
+    )
+    _write_eddy(tmp_path, eddy_id="eddy-1", title="Receptivity Eddy", fragment_count=3)
+    _write_eddy(tmp_path, eddy_id="eddy-2", title="Innovation Eddy", fragment_count=2)
     _write_thread(
         tmp_path,
         thread_id="thread-old",
@@ -318,7 +329,7 @@ def test_section_vault_summary_includes_counts(populated_vault: Path) -> None:
     ).section_vault_summary()
 
     assert section.startswith("## Vault summary")
-    assert "Fragments: 3" in section
+    assert "Fragments: 4" in section
     assert "Eddies: 2" in section
     assert "Threads: 2" in section
 
@@ -344,8 +355,8 @@ def test_section_vault_summary_includes_frequency_distribution(
     ).section_vault_summary()
 
     assert "**Frequency distribution**" in section
-    # Two F1 fragments and one F2 fragment in the populated fixture.
-    assert "F1 (Agency/Survival): 2" in section
+    # Three F1 fragments and one F2 fragment in the populated fixture.
+    assert "F1 (Agency/Survival): 3" in section
     assert "F2 (Receptivity/Kinship): 1" in section
 
 
@@ -437,8 +448,8 @@ def test_section_active_eddies_sorts_by_fragment_count(populated_vault: Path) ->
     receptivity_idx = section.index("Receptivity Eddy")
     innovation_idx = section.index("Innovation Eddy")
     assert receptivity_idx < innovation_idx
-    assert "8" in section
-    assert "5" in section
+    assert "3 fragment(s)" in section
+    assert "2 fragment(s)" in section
 
 
 def test_section_active_eddies_caps_at_ten(empty_vault: Path) -> None:
@@ -1344,6 +1355,277 @@ def test_budget_result_largest_sections_is_immutable() -> None:
     result = BudgetResult(ok=True, tokens=0, largest_sections=(("## A", 1),))
     with pytest.raises(AttributeError):
         result.largest_sections.append(("## B", 2))  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# FEAT-025: hierarchy-aware state
+# ---------------------------------------------------------------------------
+
+
+def _write_hier_fragment(
+    vault: Path,
+    *,
+    frag_id: str,
+    level: str,
+    parent_id: str | None = None,
+    child_ids: list[str] | None = None,
+    eddies: list[str] | None = None,
+    threads: list[str] | None = None,
+    phase: str = "rising",
+    mode: str = "express",
+    dosage: str = "medicine",
+) -> Path:
+    """Write a fragment with explicit hierarchy fields for FEAT-025 tests."""
+    when = datetime(2026, 5, 1, tzinfo=UTC)
+    metadata = {
+        "type": "fragment",
+        "id": frag_id,
+        "title": f"Title {frag_id}",
+        "created": when.isoformat(),
+        "ingested": when.isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "F1", "secondary": []},
+        "wavelength": {"phase": phase, "mode": mode, "dosage": dosage},
+        "eddies": list(eddies or []),
+        "threads": list(threads or []),
+        "level": level,
+        "parent_id": parent_id,
+        "child_ids": list(child_ids or []),
+    }
+    target = vault / "01-Fragments" / "Notes" / f"{frag_id}.md"
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content="body", **metadata)),
+        encoding="utf-8",
+    )
+    return target
+
+
+def test_active_eddies_counts_leaves_not_parents(empty_vault: Path) -> None:
+    """A parent fragment with two children counts as 2 leaves, not 3."""
+    _write_hier_fragment(
+        empty_vault,
+        frag_id="frag-parent",
+        level="document",
+        child_ids=["frag-leaf-1", "frag-leaf-2"],
+        eddies=["[[Hierarchical Eddy]]"],
+    )
+    _write_hier_fragment(
+        empty_vault,
+        frag_id="frag-leaf-1",
+        level="paragraph",
+        parent_id="frag-parent",
+        eddies=["[[Hierarchical Eddy]]"],
+    )
+    _write_hier_fragment(
+        empty_vault,
+        frag_id="frag-leaf-2",
+        level="paragraph",
+        parent_id="frag-parent",
+        eddies=["[[Hierarchical Eddy]]"],
+    )
+    _write_eddy(
+        empty_vault,
+        eddy_id="eddy-h",
+        title="Hierarchical Eddy",
+        fragment_count=99,
+    )
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_active_eddies()
+
+    # 2 leaves link to the eddy. The stored fragment_count (99) is irrelevant
+    # — state recounts at leaf granularity.
+    assert "Hierarchical Eddy — 2 fragment(s)" in section
+
+
+def test_active_eddies_falls_back_to_stored_when_no_fragments(
+    empty_vault: Path,
+) -> None:
+    """When no fragments are loaded, stored fragment_count is the fallback."""
+    _write_eddy(empty_vault, eddy_id="eddy-x", title="Eddy X", fragment_count=7)
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_active_eddies()
+
+    assert "Eddy X — 7 fragment(s)" in section
+
+
+def test_active_eddies_shows_zero_when_leaves_present_but_unlinked(
+    empty_vault: Path,
+) -> None:
+    """An eddy with no leaves linking to it renders ``0``, not the stored count.
+
+    Regression: an earlier draft used ``leaf_counts.get(title) or stored`` which
+    conflated "zero leaves linked" with "no fragments loaded" and leaked a
+    stale stored count into the report.
+    """
+    _write_hier_fragment(
+        empty_vault,
+        frag_id="frag-other",
+        level="document",
+        eddies=["[[Some Other Eddy]]"],
+    )
+    _write_eddy(
+        empty_vault,
+        eddy_id="eddy-stale",
+        title="Stale Eddy",
+        fragment_count=42,
+    )
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_active_eddies()
+
+    assert "Stale Eddy — 0 fragment(s)" in section
+    assert "42" not in section
+
+
+def test_active_eddies_annotates_level(populated_vault: Path) -> None:
+    """Each list-style section opens with the level it counted from."""
+    section = StateReportGenerator(
+        vault_path=populated_vault,
+    ).section_active_eddies()
+    assert "_Counted at: leaves._" in section
+
+
+def test_active_threads_counts_leaves_not_parents(empty_vault: Path) -> None:
+    """Threads also recount by leaves when the hierarchy contains them."""
+    _write_hier_fragment(
+        empty_vault,
+        frag_id="frag-parent",
+        level="document",
+        child_ids=["frag-leaf"],
+        threads=["[[Thread X]]"],
+    )
+    _write_hier_fragment(
+        empty_vault,
+        frag_id="frag-leaf",
+        level="paragraph",
+        parent_id="frag-parent",
+        threads=["[[Thread X]]"],
+    )
+    _write_thread(
+        empty_vault,
+        thread_id="thread-x",
+        title="Thread X",
+        last_seen=date(2026, 5, 1),
+        fragment_count=99,
+    )
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_active_threads()
+
+    # 1 leaf links to Thread X (the parent is excluded).
+    assert "Thread X" in section
+    assert "(1 fragment(s))" in section
+    assert "_Counted at: leaves._" in section
+
+
+def test_synchronicities_drop_non_leaf_endpoints(empty_vault: Path) -> None:
+    """A sync between a parent and any other fragment is hidden in leaves view."""
+    _write_hier_fragment(
+        empty_vault,
+        frag_id="frag-parent",
+        level="document",
+        child_ids=["frag-leaf"],
+    )
+    _write_hier_fragment(
+        empty_vault,
+        frag_id="frag-leaf",
+        level="paragraph",
+        parent_id="frag-parent",
+    )
+    _write_hier_fragment(
+        empty_vault,
+        frag_id="frag-other",
+        level="document",
+    )
+    # Sync between the parent and an unrelated leaf — endpoint is non-leaf.
+    _write_synchronicity(
+        empty_vault,
+        sync_id="sync-bad",
+        frag_a="frag-parent",
+        frag_b="frag-other",
+    )
+    # Sync between two leaves — should survive.
+    _write_synchronicity(
+        empty_vault,
+        sync_id="sync-good",
+        frag_a="frag-leaf",
+        frag_b="frag-other",
+    )
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_synchronicities()
+
+    assert "frag-leaf" in section
+    assert "frag-other" in section
+    # The non-leaf sync is filtered out.
+    assert "frag-parent" not in section
+    assert "_Counted at: leaves._" in section
+
+
+def test_wavelength_snapshot_reads_at_documents(empty_vault: Path) -> None:
+    """Wavelength snapshot uses document/session-level fragments only."""
+    # Three sentence-level fragments tagged ``peaking``; should be ignored.
+    for idx in range(3):
+        _write_hier_fragment(
+            empty_vault,
+            frag_id=f"frag-sentence-{idx}",
+            level="sentence",
+            phase="peaking",
+        )
+    # One document-level fragment tagged ``rising``; this should dominate.
+    _write_hier_fragment(
+        empty_vault,
+        frag_id="frag-doc",
+        level="document",
+        phase="rising",
+    )
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+        today=date(2026, 5, 1),
+    ).section_wavelength_snapshot()
+
+    assert "_Counted at: documents._" in section
+    # Only one fragment passes the documents filter.
+    assert "Fragments observed: 1" in section
+    # The dominant phase reflects the single document, not the sentences.
+    assert "**rising**" in section
+
+
+def test_flat_vault_regression(empty_vault: Path) -> None:
+    """A vault with only flat ``document``-level fragments behaves as before."""
+    base = datetime(2026, 5, 1, tzinfo=UTC)
+    _write_fragment(
+        empty_vault,
+        frag_id="frag-flat-1",
+        title="Flat one",
+        created=base,
+        frequency="F1",
+        eddies=["[[Flat Eddy]]"],
+    )
+    _write_fragment(
+        empty_vault,
+        frag_id="frag-flat-2",
+        title="Flat two",
+        created=base + timedelta(days=1),
+        frequency="F2",
+        eddies=["[[Flat Eddy]]"],
+    )
+    _write_eddy(empty_vault, eddy_id="eddy-flat", title="Flat Eddy", fragment_count=2)
+
+    section = StateReportGenerator(
+        vault_path=empty_vault,
+    ).section_active_eddies()
+
+    # Counts and ordering are unchanged: all fragments are leaves.
+    assert "Flat Eddy — 2 fragment(s)" in section
 
 
 def test_cli_state_budget_fails_when_over_budget(populated_vault: Path) -> None:


### PR DESCRIPTION
## Summary

Makes `creek compile`, `creek state`, and `creek lint` hierarchy-aware now that FEAT-020..023 produce fragments at multiple structural levels for the same source material.

- **New `creek/hierarchy.py`** — single source of truth for `LevelPolicy` (`"leaves" | "documents" | "all"`), `select_by_policy`, `source_levels`, and `structural_path_context`. Leaf semantics respect the *input set*: a fragment counts as a leaf when none of its `child_ids` are present, so partial slices don't lie.
- **`creek compile`** — `compile_fragments` filters to leaves by default; parents become `structural_path:` prompt annotations instead of duplicated bodies. `CompiledPage` frontmatter carries the new `level_policy` and `source_levels` fields so a future re-compile stays consistent.
- **`creek state`** — `section_active_eddies` / `_threads` / `_synchronicities` recount from leaf-fragment wikilink joins (with stored `fragment_count` only used when no fragments are loaded at all — zero leaves linked renders honestly as `0`). `section_wavelength_snapshot` reads at `documents` granularity. Each affected section opens with `_Counted at: leaves._` or `_Counted at: documents._`. Cross-level synchronicity endpoints are filtered out.
- **`creek lint` paradox check** — skips cross-level pairs by default; new `lint.paradox_cross_level: bool` config knob restores the pre-FEAT-025 behaviour and is exercised in tests.
- **Models / config** — `CompiledPage.level_policy: str`, `CompiledPage.source_levels: list[str]`, `LintConfig.paradox_cross_level: bool = False`.

Out of scope per the issue: linker hierarchy awareness (FEAT-024), CLI tree-view, re-rendering pre-existing compiled pages. The issue's `orphan-compiled` sub-bullet ("treats a child as not-orphan if it has a parent referenced by some compiled page") was in Requirements but not in the Acceptance Criteria and its exact intent was ambiguous to me — `orphan-compiled` flags compiled *pages*, not fragments, and the wording reads like a fragment-side guard. Left that check unchanged for follow-up; flagging it here for the reviewer.

## Test plan

- [x] `./scripts/check-all.sh` passes (12/12 gates: lint, format, mypy strict, pylint, bandit + pip-audit, xenon ≤B, refurb, tryceratops, unit tests, coverage 93.74%, per-file gate, state-budget)
- [x] 3799 unit tests pass; 19 new tests cover hierarchy helpers, leaves-aware compile, level-annotated state sections, document-granularity wavelength, cross-level paradox skip + opt-in, and a flat-vault regression case.
- [x] `creek compile` still produces identical provenance for a flat vault (test_compile_flat_vault_regression).
- [x] `creek state` still renders the same fragment counts on a flat vault (test_flat_vault_regression).
- [x] An eddy with no linked leaves now shows `0 fragment(s)` instead of leaking the stored count (test_active_eddies_shows_zero_when_leaves_present_but_unlinked — regression for a self-review finding).
- [x] Self-review found 1 type-ignore (removed by importing `LevelPolicy` at module top), 1 truthiness bug (fixed + test added), 1 docstring inaccuracy (corrected).

Closes #256

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBj6hvcZr5hxgaxEwmmXAc)_