### PR TITLE
feat(atomize): cross-source aggregation knob (FEAT-027, #264)

### DIFF
--- a/creek-tools/creek/atomize/aggregate.py
+++ b/creek-tools/creek/atomize/aggregate.py
@@ -80,6 +80,7 @@ def aggregate(
     *,
     level: AggregateLevel,
     config: AggregationConfig,
+    cross_source: bool = False,
 ) -> list[Fragment]:
     """Aggregate fragments upward to the requested ``level``.
 
@@ -89,9 +90,12 @@ def aggregate(
     and aggregated; pass-through fragments are returned unchanged.
 
     Idempotency: re-running on the same input produces parents with
-    identical IDs and identical concatenated text. Cross-source
-    grouping is out of scope in v1 — only fragments sharing a
-    ``(platform, channel, conversation_id)`` key combine.
+    identical IDs and identical concatenated text. Single-source
+    grouping is the default (v1, FEAT-022); pass ``cross_source=True``
+    to opt into FEAT-027 cross-source aggregation, where the
+    source-identity gate is dropped and the temporal/similarity
+    thresholds alone decide grouping. Cross-source parents record every
+    contributing source key as a ``source/<key>`` tag.
 
     Args:
         fragments: Fragments to aggregate. Mixed levels are allowed;
@@ -99,13 +103,17 @@ def aggregate(
         level: Target aggregation level (``exchange``, ``burst``, or
             ``session``).
         config: Aggregator knobs.
+        cross_source: When ``True`` (FEAT-027), eligible fragments are
+            chronologically interleaved across sources before grouping;
+            when ``False`` (default), fragments only combine within a
+            shared ``(platform, channel, conversation_id)`` key.
 
     Returns:
         A new list containing aggregated parents followed by any
         pass-through fragments (in their original relative order).
-        Parents within the same source key are time-ordered, but two
-        source keys are emitted in dict-insertion order — not
-        interleaved chronologically.
+        In single-source mode, parents within the same source key are
+        time-ordered but two source keys are emitted in dict-insertion
+        order. In cross-source mode, all parents are time-ordered.
     """
     if not fragments:
         return []
@@ -122,7 +130,7 @@ def aggregate(
     if not eligible:
         return fragments.copy()
 
-    parents = _aggregate_eligible(eligible, level, config)
+    parents = _aggregate_eligible(eligible, level, config, cross_source=cross_source)
     return parents + passthrough
 
 
@@ -130,8 +138,19 @@ def _aggregate_eligible(
     eligible: list[Fragment],
     level: AggregateLevel,
     config: AggregationConfig,
+    *,
+    cross_source: bool,
 ) -> list[Fragment]:
-    """Group eligible fragments by source key and dispatch the transition."""
+    """Group eligible fragments and dispatch the per-level transition.
+
+    In cross-source mode (FEAT-027) every eligible fragment lands in a
+    single chronologically-sorted bucket. Otherwise fragments are
+    partitioned by ``_source_key`` first (FEAT-022).
+    """
+    if cross_source:
+        sorted_frags = sorted(eligible, key=lambda f: (f.created, f.id))
+        return _group_by_level(sorted_frags, level, config, cross_source=True)
+
     by_source: dict[str, list[Fragment]] = {}
     for frag in eligible:
         key = _source_key(frag.source)
@@ -140,7 +159,9 @@ def _aggregate_eligible(
     parents: list[Fragment] = []
     for source_frags in by_source.values():
         sorted_frags = sorted(source_frags, key=lambda f: f.created)
-        parents.extend(_group_by_level(sorted_frags, level, config))
+        parents.extend(
+            _group_by_level(sorted_frags, level, config, cross_source=False),
+        )
     return parents
 
 
@@ -148,6 +169,8 @@ def _group_by_level(
     fragments: list[Fragment],
     level: AggregateLevel,
     config: AggregationConfig,
+    *,
+    cross_source: bool,
 ) -> list[Fragment]:
     """Dispatch grouping to the per-level transition and build parents."""
     if level == "exchange":
@@ -156,7 +179,7 @@ def _group_by_level(
         groups = _group_to_bursts(fragments, config)
     else:
         groups = _group_to_sessions(fragments, config)
-    return [_build_parent(g, level, config) for g in groups]
+    return [_build_parent(g, level, config, cross_source=cross_source) for g in groups]
 
 
 def _group_to_exchanges(
@@ -232,20 +255,29 @@ def _build_parent(
     children: list[Fragment],
     level: AggregateLevel,
     config: AggregationConfig,
+    *,
+    cross_source: bool,
 ) -> Fragment:
     """Assemble an aggregated parent Fragment from an ordered child list.
 
-    Carries a deterministic ID from ``(source_key, level, child_ids)``,
-    ``child_ids`` in input order, joiner-concatenated titles, inherited
-    source (with ``author`` promoted to ``COLLABORATIVE`` on multi-speaker
-    groups), and tags for the date-range and participants.
+    Carries a deterministic ID from ``(parent_source_key, level,
+    child_ids)``, ``child_ids`` in input order, joiner-concatenated
+    titles, inherited source (with ``author`` promoted to
+    ``COLLABORATIVE`` on multi-speaker groups), and tags for the
+    date-range, participants, and — under FEAT-027 cross-source mode —
+    every contributing source key.
     """
     child_ids = [c.id for c in children]
     source = _inherit_source(children)
-    parent_id = _aggregate_id(_source_key(source), level, child_ids)
+    parent_id = _aggregate_id(
+        _parent_source_key(children, cross_source=cross_source),
+        level,
+        child_ids,
+    )
     title = config.joiner.join(c.title for c in children)
     earliest = min(c.created for c in children)
     latest = max(c.created for c in children)
+    source_keys = _contributing_source_keys(children) if cross_source else None
     return Fragment(
         id=parent_id,
         title=title,
@@ -253,7 +285,13 @@ def _build_parent(
         created=earliest,
         child_ids=child_ids,
         level=level,
-        tags=_parent_tags(level, earliest, latest, _speakers(children)),
+        tags=_parent_tags(
+            level,
+            earliest,
+            latest,
+            _speakers(children),
+            source_keys=source_keys,
+        ),
     )
 
 
@@ -288,14 +326,45 @@ def _parent_tags(
     earliest: datetime,
     latest: datetime,
     speakers: set[str],
+    *,
+    source_keys: list[str] | None = None,
 ) -> list[str]:
-    """Build deterministic parent tags (level marker, date-range, speakers)."""
+    """Build deterministic parent tags (level, date-range, speakers, sources).
+
+    ``source_keys`` is ``None`` for single-source parents (the source is
+    already captured in :attr:`Fragment.source`) and a sorted list of
+    distinct contributing source keys for FEAT-027 cross-source parents.
+    """
     tags = [
         f"aggregated/{level}",
         f"daterange/{earliest.date().isoformat()}_{latest.date().isoformat()}",
     ]
     tags.extend(f"speaker/{s}" for s in sorted(speakers))
+    if source_keys is not None:
+        tags.extend(f"source/{key}" for key in source_keys)
     return tags
+
+
+def _contributing_source_keys(children: list[Fragment]) -> list[str]:
+    """Return the sorted distinct source keys contributing to a parent."""
+    return sorted({_source_key(c.source) for c in children})
+
+
+def _parent_source_key(
+    children: list[Fragment],
+    *,
+    cross_source: bool,
+) -> str:
+    """Resolve the source-key seed used to derive the parent's ID.
+
+    Single-source parents reuse :func:`_source_key` on the inherited
+    source. Cross-source parents combine every contributing key into a
+    deterministic ``cross-source:`` prefix so the parent ID remains
+    stable across re-runs and distinct from any single-source parent.
+    """
+    if not cross_source:
+        return _source_key(children[0].source)
+    return "cross-source:" + "|".join(_contributing_source_keys(children))
 
 
 def _speakers(fragments: list[Fragment]) -> set[str]:

--- a/creek-tools/creek/atomize/aggregate.py
+++ b/creek-tools/creek/atomize/aggregate.py
@@ -298,11 +298,15 @@ def _build_parent(
 def _inherit_source(children: list[Fragment]) -> FragmentSource:
     """Build the parent's :class:`FragmentSource` from its children.
 
-    Channel, platform, conversation_id, and original_file are inherited
-    from the first child (callers guarantee a shared source key).
-    ``author`` is promoted to ``COLLABORATIVE`` when ≥2 distinct authors
-    appear; ``interlocutor`` is the comma-joined sorted set of child
-    interlocutors.
+    In single-source mode (FEAT-022) every child shares a source key, so
+    channel, platform, conversation_id, and original_file are simply
+    inherited from the first child. In cross-source mode (FEAT-027) the
+    first child's values become a representative anchor — the full set
+    of contributing sources is captured separately as ``source/<key>``
+    tags on the parent, and each child still points at its origin via
+    its own :class:`FragmentSource`. ``author`` is promoted to
+    ``COLLABORATIVE`` when ≥2 distinct authors appear; ``interlocutor``
+    is the comma-joined sorted set of child interlocutors.
     """
     first = children[0].source
     authors = {c.source.author for c in children}

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -117,6 +117,16 @@ class LinkingConfig(BaseModel):
     same ``session`` by the FEAT-022 aggregator. Inclusive boundary.
     """
 
+    cross_source_aggregation: bool = False
+    """When ``True``, the FEAT-027 aggregator drops the source-identity
+    gate so a single exchange/burst/session may span multiple sources
+    once the temporal/similarity thresholds permit. Each parent records
+    every contributing source key as a ``source/<key>`` tag while child
+    fragments retain their original :class:`~creek.models.FragmentSource`
+    pointers. ``False`` (default) preserves the single-source behaviour
+    introduced by FEAT-022.
+    """
+
 
 class ClassificationConfig(BaseModel):
     """Classification pipeline configuration."""

--- a/creek-tools/tests/test_atomize_aggregate.py
+++ b/creek-tools/tests/test_atomize_aggregate.py
@@ -21,7 +21,9 @@ import pytest
 from creek.atomize.aggregate import (
     AggregationConfig,
     _aggregate_id,
+    _contributing_source_keys,
     _cosine,
+    _parent_source_key,
     _source_key,
     aggregate,
 )
@@ -525,3 +527,315 @@ def _roll_up(docs: list[Fragment], cfg: AggregationConfig) -> Fragment:
     [burst] = aggregate([exchange], level="burst", config=cfg)
     [session] = aggregate([burst], level="session", config=cfg)
     return session
+
+
+# ---- Cross-source aggregation (FEAT-027) ----
+
+
+class TestCrossSourceDefault:
+    """``cross_source`` defaults to False and preserves FEAT-022 behaviour."""
+
+    def test_default_is_false_matches_single_source_behaviour(self) -> None:
+        """Omitting the flag keeps two-source inputs split into two parents."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        src_a = _src(channel="alpha")
+        src_b = _src(channel="beta")
+        docs = [
+            _frag(id_="d1", title="x", minute=0, source=src_a),
+            _frag(id_="d2", title="y", minute=10, source=src_b),
+        ]
+        parents = aggregate(docs, level="exchange", config=cfg)
+        assert len(parents) == 2
+
+    def test_explicit_false_matches_default(self) -> None:
+        """``cross_source=False`` yields the same parents as omitting it."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        docs = [
+            _frag(id_="d1", title="x", minute=0, source=_src(channel="alpha")),
+            _frag(id_="d2", title="y", minute=10, source=_src(channel="beta")),
+        ]
+        default = aggregate(docs, level="exchange", config=cfg)
+        explicit = aggregate(docs, level="exchange", config=cfg, cross_source=False)
+        assert [p.id for p in default] == [p.id for p in explicit]
+        assert [p.child_ids for p in default] == [p.child_ids for p in explicit]
+
+    def test_single_source_parents_omit_source_tag(self) -> None:
+        """Single-source parents must NOT carry ``source/<key>`` tags."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        docs = [
+            _frag(id_="d1", title="x", minute=0),
+            _frag(id_="d2", title="y", minute=10),
+        ]
+        [parent] = aggregate(docs, level="exchange", config=cfg)
+        assert not any(tag.startswith("source/") for tag in parent.tags)
+
+
+class TestCrossSourceExchange:
+    """``cross_source=True`` drops the source-identity gate at exchange level."""
+
+    def test_two_channels_merge_into_one_exchange(self) -> None:
+        """Two channels within gap form a single cross-source exchange."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        src_a = _src(channel="alpha", interlocutor="alice")
+        src_b = _src(channel="beta", interlocutor="alice")
+        docs = [
+            _frag(id_="d1", title="x", minute=0, source=src_a),
+            _frag(id_="d2", title="y", minute=10, source=src_b),
+        ]
+        [parent] = aggregate(docs, level="exchange", config=cfg, cross_source=True)
+        assert parent.child_ids == ["d1", "d2"]
+        assert parent.level == "exchange"
+
+    def test_two_platforms_merge_into_one_exchange(self) -> None:
+        """Different platforms within gap form a single cross-source exchange."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        src_d = _src(platform=SourcePlatform.DISCORD, channel="dev")
+        src_c = _src(platform=SourcePlatform.CLAUDE, channel="dev")
+        docs = [
+            _frag(id_="d1", title="x", minute=0, source=src_d),
+            _frag(id_="d2", title="y", minute=10, source=src_c),
+        ]
+        [parent] = aggregate(docs, level="exchange", config=cfg, cross_source=True)
+        assert parent.child_ids == ["d1", "d2"]
+
+    def test_parent_tags_record_every_contributing_source(self) -> None:
+        """Parent tags list every distinct source key under ``source/...``."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        src_d = _src(platform=SourcePlatform.DISCORD, channel="dev")
+        src_c = _src(platform=SourcePlatform.CLAUDE, channel="dev")
+        docs = [
+            _frag(id_="d1", title="x", minute=0, source=src_d),
+            _frag(id_="d2", title="y", minute=10, source=src_c),
+        ]
+        [parent] = aggregate(docs, level="exchange", config=cfg, cross_source=True)
+        source_tags = sorted(t for t in parent.tags if t.startswith("source/"))
+        assert source_tags == [
+            "source/claude|dev|conv-1",
+            "source/discord|dev|conv-1",
+        ]
+
+    def test_children_retain_their_original_sources(self) -> None:
+        """Provenance: child fragments are returned untouched (not mutated)."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        src_a = _src(channel="alpha")
+        src_b = _src(channel="beta")
+        docs = [
+            _frag(id_="d1", title="x", minute=0, source=src_a),
+            _frag(id_="d2", title="y", minute=10, source=src_b),
+        ]
+        aggregate(docs, level="exchange", config=cfg, cross_source=True)
+        assert docs[0].source.channel == "alpha"
+        assert docs[1].source.channel == "beta"
+
+    def test_gap_still_breaks_cross_source_exchange(self) -> None:
+        """Cross-source mode still honours ``exchange_max_gap_minutes``."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=10)
+        src_a = _src(channel="alpha")
+        src_b = _src(channel="beta")
+        docs = [
+            _frag(id_="d1", title="x", minute=0, source=src_a),
+            _frag(id_="d2", title="y", minute=100, source=src_b),
+        ]
+        parents = aggregate(docs, level="exchange", config=cfg, cross_source=True)
+        assert [p.child_ids for p in parents] == [["d1"], ["d2"]]
+
+    def test_speaker_rule_still_applies_across_sources(self) -> None:
+        """≤2 speakers still holds even when sources are interleaved."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=120)
+        a = _src(channel="alpha", interlocutor="alice", author=Authorship.SELF)
+        b = _src(channel="beta", interlocutor="alice", author=Authorship.OTHER)
+        c = _src(channel="gamma", interlocutor="bob", author=Authorship.OTHER)
+        docs = [
+            _frag(id_="d1", title="me", minute=0, source=a),
+            _frag(id_="d2", title="alice", minute=5, source=b),
+            _frag(id_="d3", title="bob", minute=10, source=c),
+        ]
+        parents = aggregate(docs, level="exchange", config=cfg, cross_source=True)
+        assert [p.child_ids for p in parents] == [["d1", "d2"], ["d3"]]
+
+
+class TestCrossSourceSession:
+    """Session-level cross-source merging is purely time-gap based."""
+
+    def test_close_cross_source_bursts_merge_into_one_session(self) -> None:
+        """Bursts from two sources within the window collapse to one session."""
+        cfg = AggregationConfig(session_max_gap_minutes=120)
+        src_a = _src(channel="alpha")
+        src_b = _src(channel="beta")
+        bursts = [
+            _frag(id_="b1", title="a", minute=0, level="burst", source=src_a),
+            _frag(id_="b2", title="b", minute=60, level="burst", source=src_b),
+            _frag(id_="b3", title="c", minute=180, level="burst", source=src_a),
+        ]
+        [session] = aggregate(bursts, level="session", config=cfg, cross_source=True)
+        assert session.child_ids == ["b1", "b2", "b3"]
+        assert session.level == "session"
+
+
+class TestCrossSourceBurst:
+    """Burst-level cross-source merging still requires topical continuity."""
+
+    def test_high_similarity_collapses_cross_source_exchanges(self) -> None:
+        """Same-topic exchanges from two sources merge into one burst."""
+        cfg = AggregationConfig(
+            burst_similarity_threshold=0.7,
+            embedder=_fake_embedder(
+                {"a": [1.0, 0.0], "b": [0.99, 0.1]},
+            ),
+        )
+        src_a = _src(channel="alpha")
+        src_b = _src(channel="beta")
+        exchanges = [
+            _frag(id_="e1", title="a", minute=0, level="exchange", source=src_a),
+            _frag(id_="e2", title="b", minute=30, level="exchange", source=src_b),
+        ]
+        [burst] = aggregate(exchanges, level="burst", config=cfg, cross_source=True)
+        assert burst.child_ids == ["e1", "e2"]
+
+
+class TestCrossSourceIdempotency:
+    """FEAT-027 cross-source aggregation is deterministic across runs."""
+
+    def test_cross_source_ids_stable_across_runs(self) -> None:
+        """Re-running cross-source aggregation yields identical parent IDs."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        docs = [
+            _frag(id_="d1", title="x", minute=0, source=_src(channel="alpha")),
+            _frag(id_="d2", title="y", minute=10, source=_src(channel="beta")),
+        ]
+        first = aggregate(docs, level="exchange", config=cfg, cross_source=True)
+        second = aggregate(docs, level="exchange", config=cfg, cross_source=True)
+        assert [p.id for p in first] == [p.id for p in second]
+        assert [p.child_ids for p in first] == [p.child_ids for p in second]
+        assert [p.tags for p in first] == [p.tags for p in second]
+
+    def test_cross_source_id_differs_from_single_source(self) -> None:
+        """Same children grouped cross-source carry a different parent ID."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        docs = [
+            _frag(id_="d1", title="x", minute=0),
+            _frag(id_="d2", title="y", minute=10),
+        ]
+        [single] = aggregate(docs, level="exchange", config=cfg, cross_source=False)
+        [cross] = aggregate(docs, level="exchange", config=cfg, cross_source=True)
+        assert single.id != cross.id
+
+    def test_cross_source_orders_chronologically_regardless_of_input(self) -> None:
+        """Permuted input still produces a chronologically-ordered parent."""
+        cfg = AggregationConfig(exchange_max_gap_minutes=60)
+        d1 = _frag(id_="d1", title="x", minute=0, source=_src(channel="alpha"))
+        d2 = _frag(id_="d2", title="y", minute=10, source=_src(channel="beta"))
+        ordered = aggregate([d1, d2], level="exchange", config=cfg, cross_source=True)
+        reversed_ = aggregate([d2, d1], level="exchange", config=cfg, cross_source=True)
+        assert [p.id for p in ordered] == [p.id for p in reversed_]
+        assert [p.child_ids for p in ordered] == [p.child_ids for p in reversed_]
+
+
+class TestCrossSourceHelpers:
+    """Direct tests for the FEAT-027 helper functions."""
+
+    def test_contributing_source_keys_returns_sorted_unique(self) -> None:
+        """The helper deduplicates and sorts contributing source keys."""
+        src_a = _src(channel="alpha")
+        src_b = _src(channel="beta")
+        children = [
+            _frag(id_="d1", title="x", minute=0, source=src_a),
+            _frag(id_="d2", title="y", minute=5, source=src_b),
+            _frag(id_="d3", title="z", minute=10, source=src_a),
+        ]
+        keys = _contributing_source_keys(children)
+        assert keys == [
+            "discord|alpha|conv-1",
+            "discord|beta|conv-1",
+        ]
+
+    def test_parent_source_key_single_source_uses_source_key(self) -> None:
+        """Single-source mode reuses ``_source_key`` of the first child."""
+        children = [_frag(id_="d1", title="x", minute=0)]
+        key = _parent_source_key(children, cross_source=False)
+        assert key == _source_key(children[0].source)
+
+    def test_parent_source_key_cross_source_uses_canonical_prefix(self) -> None:
+        """Cross-source mode prefixes with ``cross-source:`` for stable IDs."""
+        children = [
+            _frag(id_="d1", title="x", minute=0, source=_src(channel="alpha")),
+            _frag(id_="d2", title="y", minute=10, source=_src(channel="beta")),
+        ]
+        key = _parent_source_key(children, cross_source=True)
+        assert key.startswith("cross-source:")
+        assert "discord|alpha|conv-1" in key
+        assert "discord|beta|conv-1" in key
+
+
+# ---- Property test (FEAT-027 acceptance criterion) ----
+
+
+class TestCrossSourceMergeInvariant:
+    """At session level the cross-source mode can only merge, never split.
+
+    Session grouping is purely time-gap based — no speaker rule, no
+    similarity gate — so dropping the source-identity boundary always
+    yields ≤ the number of single-source parents. This is the strongest
+    direction of the FEAT-027 invariant that holds independent of input
+    shape, and the acceptance-criterion property test relies on it.
+    """
+
+    @pytest.mark.parametrize(
+        ("layout", "session_max_gap_minutes"),
+        [
+            # Two sources, small gap → cross merges, single keeps split.
+            ([(0, "alpha"), (30, "beta")], 60),
+            # Three sources, all close → cross merges to 1, single keeps 3.
+            ([(0, "alpha"), (10, "beta"), (20, "gamma")], 60),
+            # Two sources, alternating timestamps → cross merges to 1.
+            (
+                [(0, "alpha"), (15, "beta"), (30, "alpha"), (45, "beta")],
+                60,
+            ),
+            # Wide gaps → both modes produce the same parents.
+            (
+                [(0, "alpha"), (500, "alpha"), (1000, "beta")],
+                60,
+            ),
+            # Single source → cross_source has no effect.
+            ([(0, "alpha"), (5, "alpha"), (10, "alpha")], 60),
+        ],
+    )
+    def test_cross_source_never_produces_more_session_parents(
+        self,
+        layout: list[tuple[int, str]],
+        session_max_gap_minutes: int,
+    ) -> None:
+        """Across diverse layouts, cross-source ≤ single-source parent count."""
+        cfg = AggregationConfig(session_max_gap_minutes=session_max_gap_minutes)
+        bursts = [
+            _frag(
+                id_=f"b{i}",
+                title=f"t{i}",
+                minute=minute,
+                level="burst",
+                source=_src(channel=channel),
+            )
+            for i, (minute, channel) in enumerate(layout)
+        ]
+        single = aggregate(bursts, level="session", config=cfg, cross_source=False)
+        cross = aggregate(bursts, level="session", config=cfg, cross_source=True)
+        assert len(cross) <= len(single)
+
+    def test_cross_source_idempotent_under_session_invariant(self) -> None:
+        """Re-running cross-source twice yields the same parent count."""
+        cfg = AggregationConfig(session_max_gap_minutes=60)
+        bursts = [
+            _frag(
+                id_=f"b{i}",
+                title=f"t{i}",
+                minute=i * 10,
+                level="burst",
+                source=_src(channel=("alpha" if i % 2 == 0 else "beta")),
+            )
+            for i in range(6)
+        ]
+        run1 = aggregate(bursts, level="session", config=cfg, cross_source=True)
+        run2 = aggregate(bursts, level="session", config=cfg, cross_source=True)
+        assert len(run1) == len(run2)
+        assert [p.id for p in run1] == [p.id for p in run2]

--- a/creek-tools/tests/test_config.py
+++ b/creek-tools/tests/test_config.py
@@ -95,6 +95,16 @@ class TestLinkingConfig:
         assert cfg.thread_min_fragments == 3
         assert cfg.eddy_min_fragments == 5
 
+    def test_cross_source_aggregation_default_is_false(self) -> None:
+        """FEAT-027: cross-source aggregation is opt-in (default False)."""
+        cfg = LinkingConfig()
+        assert cfg.cross_source_aggregation is False
+
+    def test_cross_source_aggregation_accepts_true(self) -> None:
+        """FEAT-027: operators can flip cross-source aggregation on."""
+        cfg = LinkingConfig(cross_source_aggregation=True)
+        assert cfg.cross_source_aggregation is True
+
 
 class TestClassificationConfig:
     """Tests for ClassificationConfig model."""
@@ -477,6 +487,15 @@ class TestLoadConfig:
         assert cfg.ocr.engine == "pytesseract"  # default preserved
         assert cfg.linking.temporal_window_hours == 48
         assert cfg.linking.thread_min_fragments == 3  # default preserved
+
+    def test_loads_cross_source_aggregation_flag(self, tmp_path: Path) -> None:
+        """YAML ``linking.cross_source_aggregation: true`` is honoured."""
+        config_file = tmp_path / "creek_config.yaml"
+        config_data = {"linking": {"cross_source_aggregation": True}}
+        config_file.write_text(yaml.dump(config_data))
+
+        cfg = load_config(config_file)
+        assert cfg.linking.cross_source_aggregation is True
 
     def test_loads_cleaning_section(self, tmp_path: Path) -> None:
         """load_config() should load cleaning section from YAML."""


### PR DESCRIPTION
Extend the conversational aggregator with a ``cross_source: bool``
parameter (default False). When True, the exchange/burst/session
boundary heuristics drop the source-identity gate so a single parent
can span multiple platforms/channels; the parent records every
contributing source key as a ``source/<key>`` tag while child fragments
retain their original ``FragmentSource`` pointers. Cross-source parent
IDs derive from a stable ``cross-source:`` prefix joining every
distinct source key so re-runs stay idempotent.

Adds ``LinkingConfig.cross_source_aggregation`` (default False) so the
behaviour can be flipped from ``creek_config.yaml`` for whole-pipeline
runs. The single-source path remains the unchanged default.

Covered by new unit tests, idempotency tests, helper tests, and a
parametrised property test asserting that at session level
(gap-only, no speaker / similarity gate) cross-source mode never
produces more parents than single-source mode on the same input.

https://claude.ai/code/session_013wQEnMZJfRRrkAZbG7SxUp