### PR TITLE
chore(compile): FEAT-004 follow-ups — shared factory, perf, lazy load, tests

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1478,7 +1478,7 @@ def _warn_bypass_compiled(verb: str) -> None:
     routing introduced in FEAT-004. Warning loudly is the contract:
     bypass should be a deliberate, visible choice, not silent.
     """
-    print(  # operator-facing CLI warning
+    print(
         f"[creek {verb}] WARNING: --bypass-compiled is set; "
         "the compiled-layer-first contract is being side-stepped.",
         file=sys.stderr,

--- a/creek-tools/creek/generate/compile_routing.py
+++ b/creek-tools/creek/generate/compile_routing.py
@@ -10,6 +10,14 @@ compile-gaps.jsonl`` so ``creek lint`` can surface the gap later.
 This module is the single read-side surface for the compiled layer.
 Mining and drafting both consume it; the CLI's ``--bypass-compiled``
 escape hatch short-circuits the index load entirely.
+
+Trust assumption: the scanned directories ``02-Threads/``,
+``03-Eddies/``, and ``06-Frequencies/`` are treated as trusted output
+written by ``creek compile`` (FEAT-003). ``_load_pages`` uses
+``rglob("*.md")``, which follows symlinks; the ``type: compiled_page``
+sentinel plus Pydantic validation make planted non-pages a no-op in
+practice, but the routing layer should not be pointed at untrusted
+content.
 """
 
 from __future__ import annotations
@@ -77,13 +85,18 @@ class CompiledPageIndex:
         return self.frequency_indexes.get(target_id)
 
     def fragment_ids_for(self, page: CompiledPage) -> tuple[str, ...]:
-        """Return the unique fragment IDs traced by *page*'s provenance."""
-        seen: list[str] = []
-        for entry in page.provenance:
-            for fid in entry.fragment_ids:
-                if fid and fid not in seen:
-                    seen.append(fid)
-        return tuple(seen)
+        """Return the unique fragment IDs traced by *page*'s provenance.
+
+        ``dict.fromkeys`` preserves insertion order in O(n) total — the
+        previous list-based dedup paid an O(n) membership check per
+        insertion. The :class:`TestLoadCompiledPages` suite pins the
+        ordering invariant.
+        """
+        return tuple(
+            dict.fromkeys(
+                fid for entry in page.provenance for fid in entry.fragment_ids if fid
+            ),
+        )
 
 
 def empty_index(*, bypassed: bool = False) -> CompiledPageIndex:

--- a/creek-tools/creek/generate/compile_routing.py
+++ b/creek-tools/creek/generate/compile_routing.py
@@ -87,10 +87,8 @@ class CompiledPageIndex:
     def fragment_ids_for(self, page: CompiledPage) -> tuple[str, ...]:
         """Return the unique fragment IDs traced by *page*'s provenance.
 
-        ``dict.fromkeys`` preserves insertion order in O(n) total — the
-        previous list-based dedup paid an O(n) membership check per
-        insertion. The :class:`TestLoadCompiledPages` suite pins the
-        ordering invariant.
+        Uses ``dict.fromkeys`` for O(n) deduplication; insertion order
+        is guaranteed by the Python 3.7+ language spec.
         """
         return tuple(
             dict.fromkeys(

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -462,10 +462,15 @@ class DraftGenerator:
         vault_path: Path,
         compiled: CompiledPageIndex,
     ) -> str:
-        """Render the ``## Threads`` block, compile-first."""
+        """Render the ``## Threads`` block, compile-first.
+
+        The frontmatter scan ``_load_threads_by_id`` is deferred until a
+        cache miss actually needs it, so fully-compiled vaults skip the
+        disk walk entirely.
+        """
         if not idea.threads:
             return ""
-        threads = _load_threads_by_id(vault_path / _THREADS_SUBDIR)
+        threads: dict[str, Thread] | None = None
         entries: list[str] = []
         for tid in idea.threads:
             page = compiled.thread(tid)
@@ -480,6 +485,8 @@ class DraftGenerator:
                     surfaced_by="draft",
                     reason="missing",
                 )
+            if threads is None:
+                threads = _load_threads_by_id(vault_path / _THREADS_SUBDIR)
             thread = threads.get(tid)
             if thread is not None:
                 desc = thread.description.strip() or "(no description)"
@@ -494,10 +501,15 @@ class DraftGenerator:
         vault_path: Path,
         compiled: CompiledPageIndex,
     ) -> str:
-        """Render the ``## Eddies`` block, compile-first."""
+        """Render the ``## Eddies`` block, compile-first.
+
+        The frontmatter scan ``_load_eddies_by_id`` is deferred until a
+        cache miss actually needs it, so fully-compiled vaults skip the
+        disk walk entirely.
+        """
         if not idea.eddies:
             return ""
-        eddies = _load_eddies_by_id(vault_path / _EDDIES_SUBDIR)
+        eddies: dict[str, Eddy] | None = None
         entries: list[str] = []
         for eid in idea.eddies:
             page = compiled.eddy(eid)
@@ -512,6 +524,8 @@ class DraftGenerator:
                     surfaced_by="draft",
                     reason="missing",
                 )
+            if eddies is None:
+                eddies = _load_eddies_by_id(vault_path / _EDDIES_SUBDIR)
             eddy = eddies.get(eid)
             if eddy is not None:
                 desc = eddy.description.strip() or "(no description)"

--- a/creek-tools/tests/factories/__init__.py
+++ b/creek-tools/tests/factories/__init__.py
@@ -1,0 +1,7 @@
+"""Shared test factories for creek-tools.
+
+Centralising on-disk fixture construction so the canonical shape of a
+test artefact lives in one place. Test modules import these helpers
+instead of defining their own per-module copies, which used to drift
+silently when the underlying schema evolved.
+"""

--- a/creek-tools/tests/factories/compiled.py
+++ b/creek-tools/tests/factories/compiled.py
@@ -19,12 +19,15 @@ The factory exposes two layers:
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from pathlib import Path  # noqa: TC003  # runtime use in signatures
+from typing import TYPE_CHECKING
 
 import frontmatter
 
 from creek.compile.provenance import ProvenanceEntry
 from creek.models import CompiledPage
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _DEFAULT_COMPILED_AT = datetime(2026, 4, 1, tzinfo=UTC)
 _DEFAULT_COMPILED_SUBFOLDER = "Compiled"

--- a/creek-tools/tests/factories/compiled.py
+++ b/creek-tools/tests/factories/compiled.py
@@ -1,0 +1,148 @@
+"""Compiled-layer page factories for tests (FEAT-004 follow-up #215).
+
+Three independent test modules (``test_compile_routing``,
+``test_mining``, ``test_drafts``) previously each defined their own
+``_write_compiled_*_page`` helpers with subtly different signatures and
+target paths. When ``CompiledPage`` grows a new field the per-module
+copies all need to learn it; consolidating them here keeps the on-disk
+shape in one place.
+
+The factory exposes two layers:
+
+* :func:`build_compiled_page` — pure constructor that returns a
+  :class:`~creek.models.CompiledPage` with deterministic provenance.
+* :func:`write_compiled_page` (plus the per-kind ``write_compiled_*``
+  convenience wrappers) — persists a page to a vault path the way
+  ``creek compile`` does (frontmatter + body).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path  # noqa: TC003  # runtime use in signatures
+
+import frontmatter
+
+from creek.compile.provenance import ProvenanceEntry
+from creek.models import CompiledPage
+
+_DEFAULT_COMPILED_AT = datetime(2026, 4, 1, tzinfo=UTC)
+_DEFAULT_COMPILED_SUBFOLDER = "Compiled"
+
+
+def build_compiled_page(
+    *,
+    target_kind: str,
+    target_id: str,
+    title: str | None = None,
+    body: str | None = None,
+    fragment_ids: tuple[str, ...] = (),
+    compiled_at: datetime = _DEFAULT_COMPILED_AT,
+) -> CompiledPage:
+    """Return a :class:`CompiledPage` with deterministic provenance.
+
+    Args:
+        target_kind: One of ``"thread" | "eddy" | "frequency_index"``.
+        target_id: Stable ID of the compiled surface.
+        title: Page title; defaults to ``target_id`` when omitted.
+        body: Page body; defaults to a ``# {title}\\n`` heading.
+        fragment_ids: Each ID becomes its own
+            :class:`~creek.compile.provenance.ProvenanceEntry`, so the
+            length determines how many claims the page carries.
+        compiled_at: Timestamp stamped on every provenance entry.
+    """
+    page_title = title if title is not None else target_id
+    page_body = body if body is not None else f"# {page_title}\n"
+    provenance = [
+        ProvenanceEntry(
+            claim_id=f"claim-{i}",
+            claim_excerpt=f"excerpt {i}",
+            fragment_ids=[fid],
+            compiled_at=compiled_at,
+            compile_method="llm",
+        )
+        for i, fid in enumerate(fragment_ids, start=1)
+    ]
+    return CompiledPage(
+        target_kind=target_kind,
+        target_id=target_id,
+        title=page_title,
+        body=page_body,
+        provenance=provenance,
+    )
+
+
+def write_compiled_page(page: CompiledPage, target: Path) -> Path:
+    """Persist *page* at *target* in the same shape ``creek compile`` writes."""
+    metadata = page.model_dump(mode="json", exclude={"body"})
+    target.parent.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(content=page.body, **metadata)
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+def write_compiled_thread_page(
+    vault: Path,
+    *,
+    target_id: str,
+    title: str | None = None,
+    body: str | None = None,
+    fragment_ids: tuple[str, ...] = (),
+    subfolder: str = _DEFAULT_COMPILED_SUBFOLDER,
+) -> Path:
+    """Persist a compiled thread page under ``02-Threads/<subfolder>/``.
+
+    The default ``subfolder="Compiled"`` keeps the compiled page from
+    colliding with a thread-frontmatter file that lives at the canonical
+    ``02-Threads/Active/`` path in the same fixture.
+    """
+    page = build_compiled_page(
+        target_kind="thread",
+        target_id=target_id,
+        title=title,
+        body=body,
+        fragment_ids=fragment_ids,
+    )
+    target = vault / "02-Threads" / subfolder / f"{target_id}.md"
+    return write_compiled_page(page, target)
+
+
+def write_compiled_eddy_page(
+    vault: Path,
+    *,
+    target_id: str,
+    title: str | None = None,
+    body: str | None = None,
+    fragment_ids: tuple[str, ...] = (),
+    subfolder: str = _DEFAULT_COMPILED_SUBFOLDER,
+) -> Path:
+    """Persist a compiled eddy page under ``03-Eddies/<subfolder>/``."""
+    page = build_compiled_page(
+        target_kind="eddy",
+        target_id=target_id,
+        title=title,
+        body=body,
+        fragment_ids=fragment_ids,
+    )
+    target = vault / "03-Eddies" / subfolder / f"{target_id}.md"
+    return write_compiled_page(page, target)
+
+
+def write_compiled_frequency_page(
+    vault: Path,
+    *,
+    target_id: str,
+    title: str | None = None,
+    body: str | None = None,
+    fragment_ids: tuple[str, ...] = (),
+) -> Path:
+    """Persist a compiled frequency-index page under ``06-Frequencies/``."""
+    page = build_compiled_page(
+        target_kind="frequency_index",
+        target_id=target_id,
+        title=title if title is not None else f"{target_id} index",
+        body=body,
+        fragment_ids=fragment_ids,
+    )
+    target = vault / "06-Frequencies" / f"{target_id}.md"
+    return write_compiled_page(page, target)

--- a/creek-tools/tests/test_compile_routing.py
+++ b/creek-tools/tests/test_compile_routing.py
@@ -17,6 +17,7 @@ from creek.generate.compile_routing import (
     log_compile_gap,
 )
 from creek.models import CompiledPage
+from tests.factories.compiled import build_compiled_page, write_compiled_page
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -31,28 +32,15 @@ def _write_compiled_page(
     fragment_ids: tuple[str, ...] = (),
     body: str = "# Body\n",
 ) -> None:
-    """Persist a compiled-layer page at *target*."""
-    provenance = [
-        ProvenanceEntry(
-            claim_id=f"claim-{i}",
-            claim_excerpt=f"excerpt-{i}",
-            fragment_ids=[fid],
-            compiled_at=datetime(2026, 4, 1, tzinfo=UTC),
-            compile_method="llm",
-        )
-        for i, fid in enumerate(fragment_ids, start=1)
-    ]
-    page = CompiledPage(
+    """Persist a compiled-layer page at *target* via the shared factory."""
+    page = build_compiled_page(
         target_kind=target_kind,
         target_id=target_id,
         title=title,
         body=body,
-        provenance=provenance,
+        fragment_ids=fragment_ids,
     )
-    metadata = page.model_dump(mode="json", exclude={"body"})
-    target.parent.mkdir(parents=True, exist_ok=True)
-    post = frontmatter.Post(content=body, **metadata)
-    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    write_compiled_page(page, target)
 
 
 class TestLoadCompiledPages:
@@ -101,6 +89,18 @@ class TestLoadCompiledPages:
         target.parent.mkdir(parents=True, exist_ok=True)
         post = frontmatter.Post(content="not a compiled page", title="Stray")
         target.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+        index = load_compiled_pages(tmp_path)
+
+        assert index.threads == {}
+
+    def test_skips_malformed_yaml(self, tmp_path: Path) -> None:
+        """A page with broken YAML frontmatter is skipped silently."""
+        target = tmp_path / "02-Threads" / "bad.md"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        # Unbalanced ``[`` inside the YAML block triggers ``yaml.YAMLError``
+        # when ``frontmatter.load`` attempts to parse it.
+        target.write_text("---\nkey: [\n---\nbody\n", encoding="utf-8")
 
         index = load_compiled_pages(tmp_path)
 

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -32,6 +32,12 @@ from creek.models import (
     VoiceRegister,
     WavelengthClassification,
 )
+from tests.factories.compiled import (
+    write_compiled_eddy_page as _write_compiled_eddy_page,
+)
+from tests.factories.compiled import (
+    write_compiled_thread_page as _write_compiled_thread_page,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -643,61 +649,6 @@ class TestSaveDraft:
 # ---- FEAT-004 compiled-layer routing ---------------------------------
 
 
-def _write_compiled_thread_page(
-    vault: Path,
-    *,
-    target_id: str,
-    title: str,
-    body: str,
-    fragment_ids: tuple[str, ...] = (),
-) -> Path:
-    """Persist a compiled-layer thread page in a non-colliding subfolder."""
-    from creek.compile.provenance import ProvenanceEntry
-    from creek.models import CompiledPage
-
-    page = CompiledPage(
-        target_kind="thread",
-        target_id=target_id,
-        title=title,
-        body=body,
-        provenance=[
-            ProvenanceEntry(
-                claim_id=f"claim-{i}",
-                claim_excerpt=f"excerpt {i}",
-                fragment_ids=[fid],
-                compiled_at=datetime(2026, 4, 1, tzinfo=UTC),
-                compile_method="llm",
-            )
-            for i, fid in enumerate(fragment_ids, start=1)
-        ],
-    )
-    metadata = page.model_dump(mode="json", exclude={"body"})
-    target = vault / "02-Threads" / "Compiled" / f"{target_id}.md"
-    target.parent.mkdir(parents=True, exist_ok=True)
-    post = frontmatter.Post(content=body, **metadata)
-    target.write_text(frontmatter.dumps(post), encoding="utf-8")
-    return target
-
-
-def _write_compiled_eddy_page(
-    vault: Path,
-    *,
-    target_id: str,
-    title: str,
-    body: str,
-) -> Path:
-    """Persist a compiled-layer eddy page in a non-colliding subfolder."""
-    from creek.models import CompiledPage
-
-    page = CompiledPage(target_kind="eddy", target_id=target_id, title=title, body=body)
-    metadata = page.model_dump(mode="json", exclude={"body"})
-    target = vault / "03-Eddies" / "Compiled" / f"{target_id}.md"
-    target.parent.mkdir(parents=True, exist_ok=True)
-    post = frontmatter.Post(content=body, **metadata)
-    target.write_text(frontmatter.dumps(post), encoding="utf-8")
-    return target
-
-
 class TestGatherSourceMaterialCompileFirst:
     """``gather_source_material`` reads the compiled layer before fragments."""
 
@@ -824,3 +775,197 @@ class TestGatherSourceMaterialCompileFirst:
         assert "bypass should NOT see" not in block
         gaps_log = vault / "00-Creek-Meta/Processing-Log/compile-gaps.jsonl"
         assert not gaps_log.exists()
+
+
+class TestRenderCompiledEntry:
+    """Pin the heading-strip heuristic in :func:`_render_compiled_entry`."""
+
+    def test_strips_matching_title_header(self) -> None:
+        """A leading ``# {title}`` line that matches ``page.title`` is stripped."""
+        from creek.generate.drafts import _render_compiled_entry
+        from creek.models import CompiledPage
+
+        page = CompiledPage(
+            target_kind="thread",
+            target_id="thread-A",
+            title="Listening practice",
+            body="# Listening practice\nThe body proper begins here.\n",
+        )
+
+        rendered = _render_compiled_entry("thread-A", page)
+
+        expected = "### thread-A: Listening practice\nThe body proper begins here."
+        assert rendered == expected
+
+    def test_preserves_non_matching_first_line(self) -> None:
+        """A non-title first line is kept verbatim."""
+        from creek.generate.drafts import _render_compiled_entry
+        from creek.models import CompiledPage
+
+        page = CompiledPage(
+            target_kind="eddy",
+            target_id="eddy-B",
+            title="Water as teacher",
+            body="A reflective lede paragraph.\nFollowed by more.\n",
+        )
+
+        rendered = _render_compiled_entry("eddy-B", page)
+
+        expected = (
+            "### eddy-B: Water as teacher\n"
+            "A reflective lede paragraph.\n"
+            "Followed by more."
+        )
+        assert rendered == expected
+
+    def test_empty_body_after_strip_uses_placeholder(self) -> None:
+        """When the body collapses to nothing, the fallback placeholder appears."""
+        from creek.generate.drafts import _render_compiled_entry
+        from creek.models import CompiledPage
+
+        page = CompiledPage(
+            target_kind="thread",
+            target_id="thread-empty",
+            title="Empty",
+            body="# Empty\n",
+        )
+
+        rendered = _render_compiled_entry("thread-empty", page)
+
+        assert rendered == "### thread-empty: Empty\n(compiled page has no body)"
+
+
+class TestComposeSectionLazyLoad:
+    """Full compiled-cache hits skip the frontmatter directory scan."""
+
+    def test_compose_thread_section_skips_load_when_all_hits(
+        self,
+        vault: Path,
+        skills_root: Path,
+        llm_echo: Callable[[str], str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A fully-compiled vault never reads ``02-Threads`` frontmatter."""
+        from creek.generate import drafts as drafts_module
+
+        _write_compiled_thread_page(
+            vault,
+            target_id="thread-A",
+            title="Listening practice",
+            body="# Listening practice\nCompiled body.\n",
+        )
+
+        scans: list[Path] = []
+
+        def _spy(root: Path) -> dict[str, Thread]:
+            scans.append(root)
+            return {}
+
+        monkeypatch.setattr(drafts_module, "_load_threads_by_id", _spy)
+
+        gen = DraftGenerator(llm=llm_echo, skills_root=skills_root)
+        seed = _build_seed(threads=("thread-A",))
+
+        block = gen.gather_source_material(seed, vault_path=vault)
+
+        assert "Compiled body" in block
+        assert scans == []
+
+    def test_compose_thread_section_loads_on_first_miss(
+        self,
+        vault: Path,
+        skills_root: Path,
+        llm_echo: Callable[[str], str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A single missing ID triggers exactly one frontmatter scan, reused."""
+        from creek.generate import drafts as drafts_module
+
+        _write_compiled_thread_page(
+            vault,
+            target_id="thread-A",
+            title="Listening practice",
+            body="# Listening practice\nCompiled body.\n",
+        )
+
+        scans: list[Path] = []
+        original = drafts_module._load_threads_by_id
+
+        def _spy(root: Path) -> dict[str, Thread]:
+            scans.append(root)
+            return original(root)
+
+        monkeypatch.setattr(drafts_module, "_load_threads_by_id", _spy)
+
+        gen = DraftGenerator(llm=llm_echo, skills_root=skills_root)
+        seed = _build_seed(threads=("thread-A", "thread-missing-1", "thread-missing-2"))
+
+        gen.gather_source_material(seed, vault_path=vault)
+
+        assert len(scans) == 1
+
+    def test_compose_eddy_section_skips_load_when_all_hits(
+        self,
+        vault: Path,
+        skills_root: Path,
+        llm_echo: Callable[[str], str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A fully-compiled vault never reads ``03-Eddies`` frontmatter."""
+        from creek.generate import drafts as drafts_module
+
+        _write_compiled_eddy_page(
+            vault,
+            target_id="eddy-A",
+            title="Water as teacher",
+            body="# Water as teacher\nWater is the teacher.\n",
+        )
+
+        scans: list[Path] = []
+
+        def _spy(root: Path) -> dict[str, Eddy]:
+            scans.append(root)
+            return {}
+
+        monkeypatch.setattr(drafts_module, "_load_eddies_by_id", _spy)
+
+        gen = DraftGenerator(llm=llm_echo, skills_root=skills_root)
+        seed = _build_seed(eddies=("eddy-A",))
+
+        block = gen.gather_source_material(seed, vault_path=vault)
+
+        assert "Water is the teacher" in block
+        assert scans == []
+
+    def test_compose_eddy_section_loads_on_first_miss(
+        self,
+        vault: Path,
+        skills_root: Path,
+        llm_echo: Callable[[str], str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A single missing eddy ID triggers exactly one frontmatter scan, reused."""
+        from creek.generate import drafts as drafts_module
+
+        _write_compiled_eddy_page(
+            vault,
+            target_id="eddy-A",
+            title="Water as teacher",
+            body="# Water as teacher\nWater is the teacher.\n",
+        )
+
+        scans: list[Path] = []
+        original = drafts_module._load_eddies_by_id
+
+        def _spy(root: Path) -> dict[str, Eddy]:
+            scans.append(root)
+            return original(root)
+
+        monkeypatch.setattr(drafts_module, "_load_eddies_by_id", _spy)
+
+        gen = DraftGenerator(llm=llm_echo, skills_root=skills_root)
+        seed = _build_seed(eddies=("eddy-A", "eddy-missing-1", "eddy-missing-2"))
+
+        gen.gather_source_material(seed, vault_path=vault)
+
+        assert len(scans) == 1

--- a/creek-tools/tests/test_mining.py
+++ b/creek-tools/tests/test_mining.py
@@ -42,6 +42,15 @@ from creek.models import (
     ThreadStatus,
     WavelengthClassification,
 )
+from tests.factories.compiled import (
+    write_compiled_eddy_page as _write_compiled_eddy_page,
+)
+from tests.factories.compiled import (
+    write_compiled_frequency_page as _write_compiled_frequency_page,
+)
+from tests.factories.compiled import (
+    write_compiled_thread_page as _write_compiled_thread_page,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -908,98 +917,6 @@ class TestMineAll:
 
 
 # ---- FEAT-004 compiled-layer routing -------------------------------------
-
-
-def _write_compiled_thread_page(
-    vault: Path,
-    *,
-    target_id: str,
-    title: str,
-    fragment_ids: tuple[str, ...],
-) -> Path:
-    """Persist a compiled-layer thread page under ``02-Threads/Active``."""
-    from creek.compile.provenance import ProvenanceEntry
-    from creek.models import CompiledPage
-
-    page = CompiledPage(
-        target_kind="thread",
-        target_id=target_id,
-        title=title,
-        body=f"# {title}\n",
-        provenance=[
-            ProvenanceEntry(
-                claim_id=f"claim-{i}",
-                claim_excerpt=f"excerpt {i}",
-                fragment_ids=[fid],
-                compiled_at=datetime(2026, 4, 1, tzinfo=UTC),
-                compile_method="llm",
-            )
-            for i, fid in enumerate(fragment_ids, start=1)
-        ],
-    )
-    metadata = page.model_dump(mode="json", exclude={"body"})
-    # Use a distinct subfolder so the test fixture can coexist with the
-    # Thread-frontmatter note ``_write_thread`` places under Active/.
-    target = vault / "02-Threads" / "Compiled" / f"{target_id}.md"
-    target.parent.mkdir(parents=True, exist_ok=True)
-    post = frontmatter.Post(content=page.body, **metadata)
-    target.write_text(frontmatter.dumps(post), encoding="utf-8")
-    return target
-
-
-def _write_compiled_eddy_page(
-    vault: Path,
-    *,
-    target_id: str,
-    title: str,
-    body: str,
-) -> Path:
-    """Persist a compiled-layer eddy page under ``03-Eddies``."""
-    from creek.models import CompiledPage
-
-    page = CompiledPage(target_kind="eddy", target_id=target_id, title=title, body=body)
-    metadata = page.model_dump(mode="json", exclude={"body"})
-    # Distinct subfolder so the eddy frontmatter file at the canonical
-    # path coexists with the compiled page.
-    target = vault / "03-Eddies" / "Compiled" / f"{target_id}.md"
-    target.parent.mkdir(parents=True, exist_ok=True)
-    post = frontmatter.Post(content=body, **metadata)
-    target.write_text(frontmatter.dumps(post), encoding="utf-8")
-    return target
-
-
-def _write_compiled_frequency_page(
-    vault: Path,
-    *,
-    target_id: str,
-    fragment_ids: tuple[str, ...],
-) -> Path:
-    """Persist a compiled frequency-index page under ``06-Frequencies``."""
-    from creek.compile.provenance import ProvenanceEntry
-    from creek.models import CompiledPage
-
-    page = CompiledPage(
-        target_kind="frequency_index",
-        target_id=target_id,
-        title=f"{target_id} index",
-        body=f"# {target_id}\n",
-        provenance=[
-            ProvenanceEntry(
-                claim_id=f"claim-{i}",
-                claim_excerpt=f"excerpt {i}",
-                fragment_ids=[fid],
-                compiled_at=datetime(2026, 4, 1, tzinfo=UTC),
-                compile_method="llm",
-            )
-            for i, fid in enumerate(fragment_ids, start=1)
-        ],
-    )
-    metadata = page.model_dump(mode="json", exclude={"body"})
-    target = vault / "06-Frequencies" / f"{target_id}.md"
-    target.parent.mkdir(parents=True, exist_ok=True)
-    post = frontmatter.Post(content=page.body, **metadata)
-    target.write_text(frontmatter.dumps(post), encoding="utf-8")
-    return target
 
 
 class TestCompileFirstThreadTerminus:


### PR DESCRIPTION
Closes #215.

## Summary

Seven minor follow-ups surfaced in the PR #211 LGTM re-review:

1. **Test-helper consolidation.** Three test modules each defined their own `_write_compiled_*_page` helpers with subtly different signatures and target paths. They're now imported from a new shared `tests/factories/compiled.py` (`build_compiled_page`, `write_compiled_page`, `write_compiled_thread_page`, `write_compiled_eddy_page`, `write_compiled_frequency_page`). `grep _write_compiled_thread_page tests/` now returns one definition.
2. **`fragment_ids_for` perf.** Replaces the `if fid not in seen: seen.append(fid)` O(n²) dedup with `dict.fromkeys(...)` (O(n) total, preserves insertion order). Pinned by the existing `test_fragment_ids_for_dedupes_provenance` regression test.
3. **Lazy frontmatter load.** `_compose_thread_section` and `_compose_eddy_section` no longer call `_load_threads_by_id` / `_load_eddies_by_id` when every requested ID hits the compiled cache. New monkeypatched-spy tests pin the optimisation for both kinds, plus a "loads-on-first-miss" variant that proves the scan happens exactly once and is reused.
4. **`_render_compiled_entry` unit tests.** Three new tests pin the heading-strip heuristic (matching title stripped, non-title preserved, empty-body placeholder). Function coverage is now 100% lines / 100% branches.
5. **`yaml.YAMLError` branch.** New `test_skips_malformed_yaml` covers the previously-uncovered `yaml.YAMLError` arm in `_load_pages` via a deliberately-broken YAML frontmatter file.
6. **Drop noisy comment.** `print(  # operator-facing CLI warning` → `print(`. The function name and docstring already say it; the inline comment was just noise.
7. **Document trust assumption.** `compile_routing.py` module docstring now states that `02-Threads/`, `03-Eddies/`, and `06-Frequencies/` are trusted output written by `creek compile` — `_load_pages` uses `rglob` which follows symlinks, and that's safe only because the routing layer is never pointed at untrusted content.

## Quality gates

All 12 `./scripts/check-all.sh` gates green:
- 3793 tests passing, 93.72% branch coverage
- Ruff lint + format clean, MyPy strict clean
- Per-file coverage gate green (134 ≥ 80%, 2 waivered ≥ 65%)

## Test plan

- [x] `./scripts/check-all.sh` exit 0 locally
- [ ] CI green
- [ ] LGTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFvvez73NgeKgGyLyZM856)_