### PR TITLE
chore(ontology): reconcile frequency naming to canonical names (ONTOLOGY-001)

### DIFF
--- a/creek-tools/creek/classify/examples/frequency.yaml
+++ b/creek-tools/creek/classify/examples/frequency.yaml
@@ -1,52 +1,74 @@
 # Few-shot examples for APTITUDE frequency classification (F1..F10).
 # Each entry: title (short), body (representative excerpt), label (one of F1..F10), rationale (why).
+#
+# Naming convention (ONTOLOGY-001, 2026-05): rationales use the canonical
+# F-names from §6.1 of ``docs/Ontology/creek_ontology_agent_prompt.md`` —
+# F1 Agency, F2 Receptivity, F3 Self-Love / Power, F4 Community Love /
+# Conformity, F5 Achievism, F6 Pluralism, F7 Integration, F8 True Self /
+# Transcendence, F9 Unity, F10 Emptiness. Earlier drafts of this file
+# used drifted glosses (F1 "survival", F2 "tribal-belonging", F8
+# "ecological holism"); those glosses were retired in favour of the
+# canonical names. See ``docs/decisions/2026-05-23-frequency-naming.md``.
 - title: Locked out again
   body: My keys are gone and I cannot get into the apartment tonight. Stomach is in
     a knot. I keep checking my pockets like that will change something.
   label: F1
-  rationale: Bodily safety and shelter rupture; survival texture, not strategy.
-- title: Team retro
-  body: We circled the same complaint three times and never landed. People want to
-    belong to a competent group more than they want to be right.
+  rationale: F1 Agency — the fragment lives in the bodily-safety / basic-needs
+    register that Agency picks up; the operator is reckoning with shelter and
+    initiative under stress, not strategising.
+- title: Letting the silence sit
+  body: She talked for a long time and I did not try to answer or fix anything. I
+    let the quiet be there afterwards. Something in me trusted that the right thing
+    would surface if I did not reach for it.
   label: F2
-  rationale: Tribal-belonging concern; whose group, whose loyalty.
+  rationale: F2 Receptivity — kinship, surrender, and trust in what arises rather
+    than asserting an answer; the gesture is receiving rather than producing.
 - title: Saying no to the contract
   body: I am the one with the authority to walk away. If I do not exercise it now,
     I never will.
   label: F3
-  rationale: Power and agency over a decision; F3 is about owning the choice.
+  rationale: F3 Self-Love / Power — owning the decision from a grounded sense of
+    one's authority; self-love as the foundation of healthy power.
 - title: Inbox triage rules
   body: I need three folders, a daily clearing time, and a hard rule about not
     checking after 7pm. Order will save me here.
   label: F4
-  rationale: Order and structure as the medicine for the problem.
+  rationale: F4 Community Love / Conformity — rules and structure as the medicine;
+    discipline and order as the path through.
 - title: Roadmap stake
   body: If the launch slips past Q3 the whole funding round shifts. I have to plan
     backwards from the demo date.
   label: F5
-  rationale: Achievement and strategy under a deadline; explicit goal framing.
+  rationale: F5 Achievism — strategy under a deadline; explicit goal framing,
+    material stakes, planning backwards from a target.
 - title: Sitting with grief
   body: She just needed someone to be in the room while she cried. I did not try
     to fix anything.
   label: F6
-  rationale: Community and empathy without a fix; presence as the gift.
+  rationale: F6 Pluralism — empathy and embodied presence without a fix; the
+    relational stance is what's offered.
 - title: Wiring two services
   body: The auth proxy and the billing API have to agree on the customer ID space.
     The whole system breaks otherwise.
   label: F7
-  rationale: Integration of multiple systems; thinking in interfaces.
+  rationale: F7 Integration — systems thinking, holding multiple components in one
+    interface; the unit of attention is the connection between parts.
 - title: Watershed walk
   body: The creek I grew up beside is gone. The aquifer it fed is the same one
     under the new development.
   label: F8
-  rationale: Ecological holism; the personal and the planetary as one body.
+  rationale: F8 True Self / Transcendence — pattern recognition from a transcendent
+    vantage; the personal memory and the planetary system are seen as one body,
+    which is the True-Self / higher-self way of holding scale.
 - title: Just watching
   body: I sat on the back step and the cat came over. I did not need anything
     to happen.
   label: F9
-  rationale: Witness mode, being rather than doing.
+  rationale: F9 Unity — source-connection texture; being rather than doing, the
+    quiet flow with what's already here.
 - title: One thing
   body: There is no separation between the dishwasher humming and the question
     I am sitting with.
   label: F10
-  rationale: Non-dual, unity texture; F10 collapses subject and object.
+  rationale: F10 Emptiness — no-self / non-dual collapse of subject and object;
+    the impermanence register where distinctions soften.

--- a/creek-tools/tests/fixtures/classification/calibration_set.yaml
+++ b/creek-tools/tests/fixtures/classification/calibration_set.yaml
@@ -50,7 +50,7 @@
     dosage: ambiguous
     voice_register: raw
 - id: cal-002
-  title: Team retro
+  title: Letting the meeting breathe
   body: I noticed I had been pushing for an hour and stopped. I let the meeting
     breathe and listened to what was underneath the words people were repeating.
     The thing we needed was already in the room — I had been talking past it.

--- a/creek-tools/tests/fixtures/classification/calibration_set.yaml
+++ b/creek-tools/tests/fixtures/classification/calibration_set.yaml
@@ -6,6 +6,17 @@
 # creek.classify.calibration.DEFAULT_FLOORS; a drop below floor signals the
 # prompt/example set has regressed.
 #
+# Frequency naming convention (ONTOLOGY-001, 2026-05): labels are interpreted
+# against the canonical F-names in §6.1 of
+# ``docs/Ontology/creek_ontology_agent_prompt.md`` — F1 Agency, F2 Receptivity,
+# F3 Self-Love / Power, F4 Community Love / Conformity, F5 Achievism,
+# F6 Pluralism, F7 Integration, F8 True Self / Transcendence, F9 Unity,
+# F10 Emptiness. Pre-ONTOLOGY-001 entries that read more naturally under
+# drifted glosses (F2 "tribal-belonging", F8 "ecological holism") have been
+# rewritten so each entry's body is a defensible instance of its canonical
+# label. See ``docs/decisions/2026-05-23-frequency-naming.md`` for the
+# decision record.
+#
 # Format (per entry):
 #   id:              stable cal-NNN identifier
 #   title:           short headline (LLM sees this)
@@ -40,8 +51,9 @@
     voice_register: raw
 - id: cal-002
   title: Team retro
-  body: We circled the same complaint three times and never landed. People want to
-    belong to a competent group more than they want to be right.
+  body: I noticed I had been pushing for an hour and stopped. I let the meeting
+    breathe and listened to what was underneath the words people were repeating.
+    The thing we needed was already in the room — I had been talking past it.
   expected:
     frequency: F2
     phase: withdrawal
@@ -215,9 +227,10 @@
     dosage: toxic
     voice_register: confessional
 - id: cal-018
-  title: Picking the fight again
-  body: I knew where it would go before I said the first sentence. I said it
-    anyway and we both lost the evening.
+  title: Reaching for closeness the wrong way
+  body: I tried to force the closeness I wanted by saying the hardest thing I could
+    think of. I knew it would not land before I said it. We both lost the evening,
+    and what I was actually asking for never made it into the room.
   expected:
     frequency: F2
     phase: peaking

--- a/docs/decisions/2026-05-23-frequency-naming.md
+++ b/docs/decisions/2026-05-23-frequency-naming.md
@@ -103,9 +103,10 @@ every other surface.
   the inline prompt header. This is the most operationally
   consequential drift because it goes directly into every classifier
   call, but updating it is a Python source change and so falls
-  outside ONTOLOGY-001's scope (which is data + docs only). File as a
-  follow-up if the calibration floor gate breaks after this change
-  lands.
+  outside ONTOLOGY-001's scope (which is data + docs only). Tracked
+  as **ONTOLOGY-002** (issue #298) so the prompt-header rename does
+  not slip; the issue carries the canonical names, the acceptance
+  criteria, and a regression-test requirement.
 - **Re-classifying already-labelled vault fragments.** The frequency
   IDs (`F1`..`F10`) are stable; only the human-readable interpretation
   changes. If the operator finds vault content that now reads

--- a/docs/decisions/2026-05-23-frequency-naming.md
+++ b/docs/decisions/2026-05-23-frequency-naming.md
@@ -1,0 +1,158 @@
+# Frequency Naming: Canonical Names Win
+
+- **Status**: Accepted
+- **Date**: 2026-05-23
+- **Driving issue**: ONTOLOGY-001 (#265)
+- **Surfaced by**: PR #244 (calibration rebalance) flagged a substantive
+  naming drift between the canonical taxonomy and the few-shot
+  rationales the LLM classifier sees.
+
+## Context
+
+The Creek Ontology defines ten APTITUDE frequencies (F1..F10) in
+§6.1 of [`docs/Ontology/creek_ontology_agent_prompt.md`](../Ontology/creek_ontology_agent_prompt.md).
+The canonical names there are:
+
+| Code | Canonical name | Core theme (one-liner) |
+|------|----------------|------------------------|
+| F1 | **Agency** | Survival, intentional action, willpower, initiative |
+| F2 | **Receptivity** | Kinship, receptivity to pleasure and Source, intuitive divination, surrender, trust |
+| F3 | Self-Love / Power | Self-love as the foundation of healthy power |
+| F4 | Community Love / Conformity | Community love, devotion, moral grounding, hierarchy |
+| F5 | Achievism | Innovation, analysis, goal-setting, material success |
+| F6 | Pluralism | Empathy, inclusivity, embodied connection, shadow work |
+| F7 | Integration | Systems thinking, synthesis, holistic understanding |
+| F8 | **True Self / Transcendence** | Higher self, monad, gnosis, alignment, pattern recognition from a transcendent vantage |
+| F9 | Unity | Source connection, cosmic harmony, non-dual awareness |
+| F10 | Emptiness | Impermanence, no-self, egolessness |
+
+Two downstream artefacts had drifted from these names:
+
+1. **Few-shot rationales** in `creek/classify/examples/frequency.yaml`
+   used `F1: survival`, `F2: tribal-belonging`, `F8: ecological holism`.
+   The first compresses the canonical theme; the latter two pick a
+   nearby-but-different reading.
+2. **Calibration entries** in
+   `tests/fixtures/classification/calibration_set.yaml` were labelled
+   to match the few-shot framing. `cal-002 "Team retro"` and
+   `cal-018 "Picking the fight again"` are clear cases — both labelled
+   F2 but describing tribal-belonging dynamics, not Receptivity.
+
+The classifier currently sees the drifted framing; the canonical
+taxonomy spec sees the canonical framing; reports and consumers read
+whichever happened to land in their corner of the codebase. This is
+the kind of silent disagreement that erodes trust in classification
+outputs over time.
+
+## Decision
+
+**Keep the canonical names** (Agency / Receptivity / True Self /
+Transcendence). They are already used in:
+
+- `docs/Ontology/creek_ontology_agent_prompt.md` (the spec)
+- `tests/fixtures/canonical_taxonomy.yaml` (the regression anchor)
+- `creek/generate/indexes.py` (`FREQUENCY_NAMES`, `FREQUENCY_THEMES`)
+- `creek/templates/vault/06-Frequencies/F1-Agency/` …
+  `/F8-True-Self/` (the deployed scaffold)
+- Every `creek/templates/skills/*.SKILL.md` (the agent contract)
+
+The drifted glosses ("survival", "tribal-belonging", "ecological
+holism") only live in the few-shot rationale text and a handful of
+calibration entries. Aligning those is much cheaper than re-renaming
+every other surface.
+
+### Why these names, not the drifted ones
+
+- **Agency vs survival.** Agency includes survival texture (the first
+  content signal in the canonical spec is "basic needs"), but it is
+  not limited to it — initiative, willpower, and proactive action are
+  the broader register. The drifted "survival" gloss collapses the
+  fuller meaning.
+- **Receptivity vs tribal-belonging.** F2 is about *receiving* —
+  receptivity to pleasure, to Source, to kinship bonds, to intuitive
+  insight. Tribal-belonging slides toward conformity dynamics that
+  belong to F4 (Community Love / Conformity), not F2. The drift
+  hollows out the spiritual texture (Source, surrender, trust) the
+  canonical name carries.
+- **True Self / Transcendence vs ecological holism.** F8 is "the
+  aspect of Source incarnated as you … pattern recognition from a
+  transcendent vantage." Ecological holism is *an instance* of that
+  vantage (seeing the personal and planetary as one body), not the
+  category itself. The drifted gloss promotes the example to the
+  definition.
+
+### Changes in this PR
+
+- `creek/classify/examples/frequency.yaml`: every rationale rewritten
+  to use the canonical name in the form `F<n> <Canonical Name> — …`.
+  The F2 example body was rewritten to better fit Receptivity (the
+  "Team retro" example is preserved in the calibration set under
+  Receptivity-aligned text). The F8 example body (watershed walk) was
+  preserved and its rationale recast as "pattern recognition from a
+  transcendent vantage."
+- `tests/fixtures/classification/calibration_set.yaml`: `cal-002` and
+  `cal-018` bodies rewritten to fit canonical Receptivity. Other
+  dimensions (phase / mode / orientation / dosage / register) were
+  preserved so the calibration coverage profile does not shift.
+- This decision record.
+
+## Out of scope (deliberately deferred)
+
+- **`creek/classify/llm.py`'s `CLASSIFICATION_PROMPT`** still names
+  frequencies as `F1: Survival/Safety, F2: Belonging/Tribe, ...` in
+  the inline prompt header. This is the most operationally
+  consequential drift because it goes directly into every classifier
+  call, but updating it is a Python source change and so falls
+  outside ONTOLOGY-001's scope (which is data + docs only). File as a
+  follow-up if the calibration floor gate breaks after this change
+  lands.
+- **Re-classifying already-labelled vault fragments.** The frequency
+  IDs (`F1`..`F10`) are stable; only the human-readable interpretation
+  changes. If the operator finds vault content that now reads
+  awkwardly under the canonical name, that is content-curation work,
+  not schema migration.
+- **F9 vs F10 boundary.** Auditing the rest of the ten surfaced a
+  borderline reading on F9 ("Just watching") and F10 ("One thing")
+  where Unity and Emptiness rationales touch. The canonical spec
+  distinguishes them (F9 = source-connection / cosmic harmony,
+  F10 = no-self / impermanence); the existing examples were kept
+  with rationale text that names the canonical distinction. A future
+  audit can tighten further if real classifier behaviour shows
+  confusion.
+
+## Consequences
+
+**Positive**
+
+- One name per frequency across the entire toolchain — spec,
+  templates, indexes, skills, few-shots, calibration set.
+- Future contributors reading the canonical spec see the same
+  vocabulary the classifier uses; no translation table needed.
+- Calibration metrics become interpretable: a drop in F2 agreement
+  means "the model is confusing Receptivity with something else,"
+  not "the model is using a different gloss for F2 than we are."
+
+**Negative**
+
+- The `CLASSIFICATION_PROMPT` in `creek/classify/llm.py` still names
+  F1/F2/F8 with the older terminology. This may show up as a
+  calibration-floor regression on the next `creek classify
+  --calibrate` run; the follow-up to align the prompt is filed
+  separately because ONTOLOGY-001 was scoped to data + docs.
+- Two calibration entries (cal-002, cal-018) carry rewritten bodies.
+  Anyone with a personal mental cache of "cal-002 = team retro" will
+  need to refresh.
+
+## Alternatives considered
+
+- **Adopt the drifted glosses as canonical.** Rejected: the spec is
+  the older, more developed surface; the ecosystem already uses the
+  canonical names; the spiritual texture of "Receptivity" and "True
+  Self" would be lost.
+- **Carry both names as synonyms.** Rejected: classification systems
+  work best with single canonical labels per category. Synonyms in
+  the prompt train the model to be ambivalent.
+- **Defer until a model-level recalibration.** Rejected: the drift
+  was actively misleading consumers of the canonical taxonomy file;
+  fixing the data while the issue is on the radar costs little and
+  removes a confusion source today.


### PR DESCRIPTION
Closes #265.

## Summary

Picks **Agency / Receptivity / True Self / Transcendence** as the canonical names for F1 / F2 / F8 — the names already used by the spec, the scaffold, the indexes module, the SKILL.md tree, and the templates — and retires the drifted glosses ("survival", "tribal-belonging", "ecological holism") that lived in the few-shot rationales and a handful of calibration entries.

## Why these names

The canonical names live in §6.1 of `docs/Ontology/creek_ontology_agent_prompt.md` and propagate to almost every surface:

- `tests/fixtures/canonical_taxonomy.yaml` (regression anchor)
- `creek/generate/indexes.py` (`FREQUENCY_NAMES`, `FREQUENCY_THEMES`)
- `creek/templates/vault/06-Frequencies/F1-Agency/` … `/F8-True-Self/`
- Every `creek/templates/skills/*.SKILL.md`
- `creek/templates/AGENTS.md`

The drift was concentrated in two places: the few-shot rationale text shown to the LLM, and two calibration entries (cal-002 "Team retro", cal-018 "Picking the fight again") whose bodies described tribal-belonging dynamics that fit F4 (Conformity) far better than F2 (Receptivity).

The full rationale, alternatives considered, and consequences are in [`docs/decisions/2026-05-23-frequency-naming.md`](https://github.com/Geoffe-Ga/Creek-Vault/blob/chore/ontology-001-frequency-naming-265/docs/decisions/2026-05-23-frequency-naming.md).

## Changes (data + docs only, no Python source per ONTOLOGY-001 scope)

- **`creek/classify/examples/frequency.yaml`** — every rationale rewritten to use the canonical name in the form `F<n> <Canonical Name> — …`. F2's example body was reworked from a tribal-belonging frame to a kinship/surrender/trust frame; F8's watershed-walk body is preserved and its rationale recast as "pattern recognition from a transcendent vantage."
- **`tests/fixtures/classification/calibration_set.yaml`** — `cal-002` and `cal-018` bodies rewritten to fit canonical Receptivity. All other dimensions (phase / mode / orientation / dosage / register) preserved so the calibration coverage profile does not shift. Header docstring now points at the canonical naming convention and the decision record.
- **`docs/decisions/2026-05-23-frequency-naming.md`** — new ADR-style decision record.

## Out of scope (filed as follow-up)

The inline `CLASSIFICATION_PROMPT` in `creek/classify/llm.py` still names frequencies as `F1: Survival/Safety, F2: Belonging/Tribe, F3: Power/Agency, F8: Holistic/Ecology, …`. This is the most operationally consequential drift because it goes into every classifier call, but updating it is a Python source change and falls outside ONTOLOGY-001's "data + docs only" scope.

The calibration floor gate (`creek classify --calibrate --enforce-floors`) was not runnable in this environment because it needs a live LLM call. The decision record explicitly notes the llm.py follow-up; the next CI calibration run will surface any regression.

## Quality gates

All 12 `./scripts/check-all.sh` gates green:
- 3793 tests passing, 93.70% branch coverage
- Ruff lint + format clean, MyPy strict clean
- Per-file coverage gate green
- `test_classify_few_shot`, `test_calibration`, `test_taxonomy_alignment`, `test_taxonomy_aliases`, `test_taxonomy_docs_drift` — all 95 pass

## Test plan

- [x] `./scripts/check-all.sh` exit 0 locally
- [ ] CI green
- [ ] LGTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFvvez73NgeKgGyLyZM856)_