### PR TITLE
feat(compost): fixture-driven recall/precision scoring (FEAT-028)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -31,6 +31,9 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from creek.config import CreekConfig
+    from creek.generate.compost_embedding import CompostExemplar
+    from creek.generate.compost_verifier import SupportsVerifyCompost
     from creek.generate.drafts import DraftLLM
     from creek.ingest.base import Ingestor
     from creek.models import CompileTargetKind, Phase
@@ -2490,9 +2493,11 @@ def compost_calibrate(
         None,
         "--fixture",
         help=(
-            "Path to a YAML calibration set of `{text, expected: bool}` "
-            "entries. When omitted, the command reports the packaged "
-            "exemplar set and explains how to author a fixture."
+            "Path to a YAML calibration set of `{id, title, body, expected: "
+            "bool}` entries. Defaults to "
+            "`tests/fixtures/compost-calibration.yaml`. When omitted *and* "
+            "the default fixture is missing, the command falls back to "
+            "exemplar-coverage reporting only."
         ),
     ),
     exemplars: Path | None = typer.Option(
@@ -2503,16 +2508,55 @@ def compost_calibrate(
             "`creek/generate/exemplars/compost.yaml`."
         ),
     ),
+    json_path: Path | None = typer.Option(
+        None,
+        "--json",
+        help=(
+            "Write a machine-readable JSON sidecar with the confusion "
+            "matrix, metrics, per-stage hit rates, and per-entry breakdown."
+        ),
+    ),
+    embedding_threshold: float = typer.Option(
+        0.6,
+        "--embedding-threshold",
+        help=(
+            "Override the embedding-gate cosine floor (default 0.6 — matches "
+            "CompostConfig.embedding_threshold). Tighten when scoring shows "
+            "the default under-precises against your corpus."
+        ),
+    ),
+    no_verifier: bool = typer.Option(
+        False,
+        "--no-verifier",
+        help=(
+            "Skip the LLM verifier stage — score with the embedding gate "
+            "only. Useful for offline calibration runs and CI suites with "
+            "no API key."
+        ),
+    ),
+    floor_recall: float | None = typer.Option(
+        None,
+        "--floor-recall",
+        help=("CI gate: exit non-zero when recall falls below this value (0.0-1.0)."),
+    ),
+    floor_precision: float | None = typer.Option(
+        None,
+        "--floor-precision",
+        help=(
+            "CI gate: exit non-zero when precision falls below this value (0.0-1.0)."
+        ),
+    ),
 ) -> None:
-    """Report exemplar coverage and (when supplied) fixture recall (FEAT-018).
+    """Score the compost detector against a labelled fixture (FEAT-028).
 
-    With ``--fixture`` omitted, prints the loaded exemplar count by
-    texture so operators can audit the curated set. With a fixture
-    supplied, scores recall + precision against the labelled set so
-    the operator can tune ``compost.embedding_threshold`` against
-    their corpus. The full calibration loop lands once a real fixture
-    is collected from the user's vault; today this command exists so
-    the workflow is discoverable.
+    Runs every fixture entry through the embedding gate + (optional) LLM
+    verifier, then reports the confusion matrix, recall, precision, F1,
+    false-positive rate, and per-stage hit counts. Pair with
+    ``--floor-recall`` and ``--floor-precision`` in CI to fail the build
+    when the pipeline regresses against the labelled set.
+
+    With no fixture available, falls back to the exemplar-coverage
+    summary so the command still surfaces useful state on first run.
     """
     from creek.generate.compost_embedding import load_exemplars
 
@@ -2529,17 +2573,114 @@ def compost_calibrate(
     for texture, count in sorted(by_texture.items()):
         console.print(f"  {texture:<20} {count}")
 
-    if fixture is None:
-        console.print(
-            "\nNo --fixture supplied. To score recall/precision, author a "
-            "YAML list of `{text, expected: bool}` entries from real vault "
-            "fragments and re-run with `--fixture path/to/fixture.yaml`.",
-        )
-        return
-
-    console.print(
-        f"\n[yellow]Fixture-driven scoring against {fixture} is not yet "
-        "implemented (FEAT-018 stub). The fixture format and recall/"
-        "precision report land in a follow-up once a real labelled set "
-        "is collected.[/yellow]",
+    _run_compost_calibration(
+        fixture=fixture,
+        exemplars_loaded=loaded,
+        json_path=json_path,
+        embedding_threshold=embedding_threshold,
+        no_verifier=no_verifier,
+        floor_recall=floor_recall,
+        floor_precision=floor_precision,
     )
+
+
+def _run_compost_calibration(
+    *,
+    fixture: Path | None,
+    exemplars_loaded: tuple[CompostExemplar, ...],
+    json_path: Path | None,
+    embedding_threshold: float,
+    no_verifier: bool,
+    floor_recall: float | None,
+    floor_precision: float | None,
+) -> None:
+    """Drive ``creek compost calibrate --fixture`` end-to-end (FEAT-028).
+
+    Resolves the fixture path (falling back to the packaged default),
+    wires the embedding similarity closure + LLM verifier (or skips the
+    verifier under ``--no-verifier``), scores the fixture, and prints
+    the report. Optionally writes a JSON sidecar and enforces
+    recall/precision floors for CI gating.
+    """
+    from creek.generate.compost_calibration import (
+        DEFAULT_FIXTURE_PATH,
+        CompostFloorBreachError,
+        assert_floors,
+        load_fixture,
+        score_compost,
+        write_json_sidecar,
+    )
+    from creek.generate.compost_embedding import make_similarity_fn
+
+    resolved = fixture or DEFAULT_FIXTURE_PATH
+    if not resolved.exists():
+        if fixture is None:
+            console.print(
+                "\nNo --fixture supplied and the packaged default at "
+                f"{DEFAULT_FIXTURE_PATH} was not found (this happens under a "
+                "wheel install). Pass --fixture path/to/fixture.yaml to score "
+                "against your own labelled set.",
+            )
+            return
+        console.print(f"[red]Compost fixture not found: {resolved}[/red]")
+        raise typer.Exit(code=2)
+
+    try:
+        entries = load_fixture(resolved)
+    except (FileNotFoundError, ValueError) as exc:
+        console.print(f"[red]Failed to load compost fixture: {exc}[/red]")
+        raise typer.Exit(code=2) from exc
+
+    config = load_config()
+    from creek.link.embeddings import EmbeddingLinker
+
+    linker = EmbeddingLinker(config=config.embeddings)
+    similarity_fn = make_similarity_fn(exemplars_loaded, linker)
+
+    verifier = None if no_verifier else _build_compost_verifier(config)
+
+    report = score_compost(
+        entries,
+        similarity_fn=similarity_fn,
+        verifier=verifier,
+        embedding_threshold=embedding_threshold,
+    )
+    console.print("")
+    console.print(report.render())
+
+    if json_path is not None:
+        write_json_sidecar(report, json_path)
+        console.print(f"\n[green]JSON sidecar written: {json_path}[/green]")
+
+    if floor_recall is not None or floor_precision is not None:
+        try:
+            assert_floors(
+                report,
+                floor_recall=floor_recall,
+                floor_precision=floor_precision,
+            )
+        except CompostFloorBreachError as exc:
+            console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(code=1) from None
+
+
+def _build_compost_verifier(config: CreekConfig) -> SupportsVerifyCompost | None:
+    """Construct the production LLM verifier, or ``None`` if it can't be built.
+
+    ``creek compost calibrate`` runs in environments where the
+    Anthropic credentials may or may not be present; rather than fail
+    loud, fall back to embedding-only scoring with a console note so
+    the operator can re-run with the verifier once credentials are in
+    place.
+    """
+    from creek.classify.llm import AnthropicProvider
+    from creek.generate.compost_verifier import LLMCompostVerifier
+
+    try:
+        provider = AnthropicProvider(config=config.llm)
+    except RuntimeError as exc:
+        console.print(
+            f"[yellow]Skipping LLM verifier — provider unavailable: {exc}[/yellow]",
+        )
+        return None
+    return LLMCompostVerifier(provider=provider)

--- a/creek-tools/creek/generate/__init__.py
+++ b/creek-tools/creek/generate/__init__.py
@@ -4,6 +4,25 @@ from creek.generate.compost import (
     CompostCandidate,
     CompostTracker,
 )
+from creek.generate.compost_calibration import (
+    DEFAULT_FIXTURE_PATH as COMPOST_CALIBRATION_FIXTURE_PATH,
+)
+from creek.generate.compost_calibration import (
+    CompostCalibrationEntry,
+    CompostCalibrationReport,
+    CompostEntryScore,
+    CompostFloorBreachError,
+    score_compost,
+)
+from creek.generate.compost_calibration import (
+    assert_floors as assert_compost_floors,
+)
+from creek.generate.compost_calibration import (
+    load_fixture as load_compost_fixture,
+)
+from creek.generate.compost_calibration import (
+    write_json_sidecar as write_compost_json_sidecar,
+)
 from creek.generate.compost_embedding import (
     PACKAGED_EXEMPLARS_PATH,
     CompostExemplar,
@@ -113,6 +132,7 @@ from creek.generate.wavelength import (
 )
 
 __all__ = [
+    "COMPOST_CALIBRATION_FIXTURE_PATH",
     "CONTRADICTION_KEYWORDS",
     "DECISION_KEYWORDS",
     "DEFAULT_MAX_EXEMPLARS",
@@ -153,8 +173,12 @@ __all__ = [
     "VOICE_REGISTERS",
     "BorrowedTermEntry",
     "CoinedTermEntry",
+    "CompostCalibrationEntry",
+    "CompostCalibrationReport",
     "CompostCandidate",
+    "CompostEntryScore",
     "CompostExemplar",
+    "CompostFloorBreachError",
     "CompostTracker",
     "CompostVerdict",
     "CompostVerifierResult",
@@ -198,7 +222,11 @@ __all__ = [
     "VoicePatterns",
     "WavelengthSnapshot",
     "WavelengthTracker",
+    "assert_compost_floors",
     "decision_from_note",
+    "load_compost_fixture",
     "load_exemplars",
     "make_similarity_fn",
+    "score_compost",
+    "write_compost_json_sidecar",
 ]

--- a/creek-tools/creek/generate/compost_calibration.py
+++ b/creek-tools/creek/generate/compost_calibration.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass, field
 from itertools import starmap
-from pathlib import Path  # used at runtime as a parameter type
+from pathlib import Path  # runtime: parameter types and DEFAULT_FIXTURE_PATH
 from typing import TYPE_CHECKING
 
 import yaml
@@ -247,14 +247,20 @@ def load_fixture(path: Path) -> tuple[CompostCalibrationEntry, ...]:
 
     Raises:
         FileNotFoundError: When *path* does not exist.
-        ValueError: When the file is not a list of dicts, or when any
-            entry is missing a required key or has a non-boolean
-            ``expected`` value.
+        ValueError: When the file is not parseable YAML, is not a list
+            of dicts, or when any entry is missing a required key or
+            has a non-boolean ``expected`` value. ``yaml.YAMLError`` is
+            wrapped so callers can rely on a single exception type for
+            schema-and-syntax failures.
     """
     if not path.exists():
         msg = f"Compost calibration fixture not found: {path}"
         raise FileNotFoundError(msg)
-    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+    except yaml.YAMLError as exc:
+        msg = f"compost-calibration fixture is not valid YAML: {exc}"
+        raise ValueError(msg) from exc
     if not isinstance(raw, list):
         msg = (
             "compost-calibration fixture must be a YAML list at top level, "

--- a/creek-tools/creek/generate/compost_calibration.py
+++ b/creek-tools/creek/generate/compost_calibration.py
@@ -1,0 +1,455 @@
+"""Recall/precision scoring for the compost detector (FEAT-028).
+
+The compost pipeline is a two-stage filter: an embedding-similarity
+gate (:mod:`creek.generate.compost_embedding`) followed by an LLM
+verifier (:mod:`creek.generate.compost_verifier`). FEAT-018 shipped the
+detector; FEAT-028 closes the calibration loop so the operator can
+answer the actual question — *given a labelled fixture, how well is the
+pipeline doing?* — and gate CI on regressions.
+
+The scoring path is classifier-agnostic via the same
+:class:`SupportsVerifyCompost` protocol the production detector uses,
+so tests wire in a deterministic stub and CI never makes live LLM
+calls.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from itertools import starmap
+from pathlib import Path  # used at runtime as a parameter type
+from typing import TYPE_CHECKING
+
+import yaml
+
+from creek.generate.compost_verifier import CompostVerdict
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterable, Sequence
+
+    from creek.generate.compost_verifier import SupportsVerifyCompost
+
+
+_REQUIRED_ENTRY_KEYS: frozenset[str] = frozenset({"id", "title", "body", "expected"})
+"""Top-level keys every compost-calibration entry must carry."""
+
+DEFAULT_FIXTURE_PATH: Path = (
+    Path(__file__).parent.parent.parent
+    / "tests"
+    / "fixtures"
+    / "compost-calibration.yaml"
+)
+"""Packaged calibration fixture; matches the classify-calibration convention.
+
+This sits inside the ``tests/`` tree because (like
+``classification/calibration_set.yaml``) it ships with the source
+distribution but is not part of a wheel install. Operators running from
+a wheel must pass ``--fixture`` explicitly.
+"""
+
+
+class CompostFloorBreachError(RuntimeError):
+    """Raised when the calibration report falls below a configured floor.
+
+    Mirrors :class:`creek.classify.calibration.CalibrationFloorBreachError`:
+    one exception listing every breached metric so a single CI run
+    surfaces all breaches at once rather than fixing-and-re-running.
+    """
+
+
+@dataclass(frozen=True)
+class CompostCalibrationEntry:
+    """One hand-labelled fragment from the compost-calibration fixture.
+
+    Attributes:
+        id: Stable per-entry identifier (e.g. ``cc-001``).
+        title: Short headline shown to the embedding gate / verifier.
+        body: Fragment body shown to the embedding gate / verifier.
+        expected: Hand-assigned label — ``True`` means the fragment is
+            real compost (the pipeline should flag it), ``False`` means
+            it is a false-positive-risk negative (the pipeline should
+            *not* flag it).
+    """
+
+    id: str
+    title: str
+    body: str
+    expected: bool
+
+
+@dataclass(frozen=True)
+class CompostEntryScore:
+    """One scored entry: ground-truth label vs. pipeline decision.
+
+    Attributes:
+        entry_id: The fixture entry's ``id``.
+        expected: Ground truth.
+        similarity: Cosine similarity from the embedding gate.
+        embedding_passed: Did the entry clear ``embedding_threshold``?
+        verifier_verdict: Verifier output, or ``None`` when the verifier
+            was skipped (embedding-only mode, or the entry was filtered
+            out before reaching the verifier).
+        flagged: Did the pipeline ultimately flag the entry as compost?
+            ``True`` for canonical compost OR review-queue verdicts
+            (``yes`` / ``ambiguous``); ``False`` otherwise. Mirrors how
+            the production :class:`~creek.generate.compost.CompostTracker`
+            treats ``ambiguous`` as still surfaced (for_review=True).
+        landed_in_review: ``True`` when the verifier returned
+            ``ambiguous`` and the entry would route to
+            ``10-Liminal/Compost/Review/``.
+    """
+
+    entry_id: str
+    expected: bool
+    similarity: float
+    embedding_passed: bool
+    verifier_verdict: CompostVerdict | None
+    flagged: bool
+    landed_in_review: bool
+
+
+@dataclass(frozen=True)
+class CompostCalibrationReport:
+    """Confusion matrix + recall/precision/F1/FPR for one calibration run.
+
+    Attributes:
+        entries: Total entries scored.
+        true_positives: Real compost the pipeline flagged.
+        false_positives: Non-compost the pipeline flagged (operator
+            noise).
+        true_negatives: Non-compost the pipeline correctly ignored.
+        false_negatives: Real compost the pipeline missed (silent loss).
+        embedding_passed: Count that cleared the embedding gate.
+        verified_yes: Count the verifier accepted (``yes``).
+        verified_no: Count the verifier rejected (``no``) — saved by
+            the second stage from being false positives.
+        verified_ambiguous: Count routed to the review queue.
+        per_entry: Per-entry breakdown for the JSON sidecar; not
+            included in the human-readable table.
+    """
+
+    entries: int
+    true_positives: int
+    false_positives: int
+    true_negatives: int
+    false_negatives: int
+    embedding_passed: int
+    verified_yes: int
+    verified_no: int
+    verified_ambiguous: int
+    per_entry: tuple[CompostEntryScore, ...] = field(default_factory=tuple)
+
+    @property
+    def recall(self) -> float:
+        """``TP / (TP + FN)``; ``0.0`` when no real positives exist."""
+        denominator = self.true_positives + self.false_negatives
+        return self.true_positives / denominator if denominator else 0.0
+
+    @property
+    def precision(self) -> float:
+        """``TP / (TP + FP)``; ``0.0`` when nothing was flagged."""
+        denominator = self.true_positives + self.false_positives
+        return self.true_positives / denominator if denominator else 0.0
+
+    @property
+    def f1(self) -> float:
+        """Harmonic mean of recall and precision; ``0.0`` when both are ``0``."""
+        if self.recall == 0.0 == self.precision:
+            return 0.0
+        return 2 * self.recall * self.precision / (self.recall + self.precision)
+
+    @property
+    def false_positive_rate(self) -> float:
+        """``FP / (FP + TN)``; ``0.0`` when no real negatives exist."""
+        denominator = self.false_positives + self.true_negatives
+        return self.false_positives / denominator if denominator else 0.0
+
+    def render(self) -> str:
+        """Render the report as a plain-text table for the CLI."""
+        lines = [
+            "Compost calibration",
+            "===================",
+            f"Entries scored:     {self.entries}",
+            "",
+            "Confusion matrix",
+            "----------------",
+            f"  True  positives:  {self.true_positives}",
+            f"  False positives:  {self.false_positives}",
+            f"  True  negatives:  {self.true_negatives}",
+            f"  False negatives:  {self.false_negatives}",
+            "",
+            "Metrics",
+            "-------",
+            f"  Recall:           {self.recall:.2%}",
+            f"  Precision:        {self.precision:.2%}",
+            f"  F1:               {self.f1:.2%}",
+            f"  False-pos. rate:  {self.false_positive_rate:.2%}",
+            "",
+            "Per-stage hits",
+            "--------------",
+            f"  Embedding gate:   {self.embedding_passed}/{self.entries}",
+            f"  Verifier yes:     {self.verified_yes}",
+            f"  Verifier no:      {self.verified_no} (saved from FP)",
+            f"  Verifier review:  {self.verified_ambiguous}",
+        ]
+        return "\n".join(lines)
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable summary plus per-entry breakdown."""
+        return {
+            "entries": self.entries,
+            "confusion_matrix": {
+                "true_positives": self.true_positives,
+                "false_positives": self.false_positives,
+                "true_negatives": self.true_negatives,
+                "false_negatives": self.false_negatives,
+            },
+            "metrics": {
+                "recall": self.recall,
+                "precision": self.precision,
+                "f1": self.f1,
+                "false_positive_rate": self.false_positive_rate,
+            },
+            "per_stage": {
+                "embedding_passed": self.embedding_passed,
+                "verified_yes": self.verified_yes,
+                "verified_no": self.verified_no,
+                "verified_ambiguous": self.verified_ambiguous,
+            },
+            "per_entry": [
+                {
+                    "id": entry.entry_id,
+                    "expected": entry.expected,
+                    "similarity": entry.similarity,
+                    "embedding_passed": entry.embedding_passed,
+                    "verifier_verdict": (
+                        entry.verifier_verdict.value
+                        if entry.verifier_verdict is not None
+                        else None
+                    ),
+                    "flagged": entry.flagged,
+                    "landed_in_review": entry.landed_in_review,
+                }
+                for entry in self.per_entry
+            ],
+        }
+
+
+def load_fixture(path: Path) -> tuple[CompostCalibrationEntry, ...]:
+    """Load and validate the compost-calibration fixture at *path*.
+
+    Args:
+        path: YAML file with a top-level list of entries.
+
+    Returns:
+        Tuple of :class:`CompostCalibrationEntry` in document order.
+
+    Raises:
+        FileNotFoundError: When *path* does not exist.
+        ValueError: When the file is not a list of dicts, or when any
+            entry is missing a required key or has a non-boolean
+            ``expected`` value.
+    """
+    if not path.exists():
+        msg = f"Compost calibration fixture not found: {path}"
+        raise FileNotFoundError(msg)
+    raw = yaml.safe_load(path.read_text(encoding="utf-8")) or []
+    if not isinstance(raw, list):
+        msg = (
+            "compost-calibration fixture must be a YAML list at top level, "
+            f"got {type(raw).__name__}"
+        )
+        raise ValueError(msg)  # noqa: TRY004  # public API contract: tests assert ValueError
+    return tuple(starmap(_coerce_entry, enumerate(raw)))
+
+
+def _coerce_entry(index: int, item: object) -> CompostCalibrationEntry:
+    """Validate one parsed fixture entry into a :class:`CompostCalibrationEntry`."""
+    if not isinstance(item, dict):
+        msg = (
+            f"compost-calibration entry #{index} is not a dict: "
+            f"got {type(item).__name__}"
+        )
+        raise ValueError(msg)  # noqa: TRY004  # public API contract: tests assert ValueError
+    missing = _REQUIRED_ENTRY_KEYS - {str(k) for k in item}
+    if missing:
+        msg = f"compost-calibration entry #{index} missing keys: {sorted(missing)}"
+        raise ValueError(msg)
+    expected = item["expected"]
+    if not isinstance(expected, bool):
+        msg = (
+            f"compost-calibration entry #{index} ('expected') must be a bool, "
+            f"got {type(expected).__name__}"
+        )
+        raise ValueError(msg)  # noqa: TRY004  # public API contract: tests assert ValueError
+    return CompostCalibrationEntry(
+        id=str(item["id"]),
+        title=str(item["title"]),
+        body=str(item["body"]),
+        expected=bool(expected),
+    )
+
+
+def score_compost(
+    entries: Iterable[CompostCalibrationEntry],
+    *,
+    similarity_fn: Callable[[str], float],
+    verifier: SupportsVerifyCompost | None,
+    embedding_threshold: float = 0.6,
+) -> CompostCalibrationReport:
+    """Run the compost pipeline on *entries* and tally recall / precision / F1 / FPR.
+
+    Mirrors the production
+    :meth:`creek.generate.compost.CompostTracker._detect_abandonment_fragments`
+    decision tree so the calibration matches what the detector actually
+    does: embedding gate → optional verifier → flagged (yes /
+    ambiguous) or not (below threshold, or verifier ``no``).
+
+    Args:
+        entries: Iterable of fixture entries to score.
+        similarity_fn: Closure mapping the entry's ``title\\nbody`` text to
+            its maximum cosine similarity against the exemplar set.
+        verifier: LLM verifier or stub. When ``None``, the embedding
+            gate alone determines the flag.
+        embedding_threshold: Minimum similarity to advance to the
+            verifier (matches
+            :class:`~creek.generate.compost.CompostTracker`'s default).
+
+    Returns:
+        A populated :class:`CompostCalibrationReport`.
+    """
+    per_entry = [
+        _score_one(
+            entry,
+            similarity_fn=similarity_fn,
+            verifier=verifier,
+            embedding_threshold=embedding_threshold,
+        )
+        for entry in entries
+    ]
+    return _summarise(per_entry)
+
+
+def _score_one(
+    entry: CompostCalibrationEntry,
+    *,
+    similarity_fn: Callable[[str], float],
+    verifier: SupportsVerifyCompost | None,
+    embedding_threshold: float,
+) -> CompostEntryScore:
+    """Score a single entry through the two-stage pipeline."""
+    text = f"{entry.title}\n{entry.body}".strip() if entry.body else entry.title
+    similarity = similarity_fn(text)
+    embedding_passed = similarity >= embedding_threshold
+    if not embedding_passed:
+        return CompostEntryScore(
+            entry_id=entry.id,
+            expected=entry.expected,
+            similarity=similarity,
+            embedding_passed=False,
+            verifier_verdict=None,
+            flagged=False,
+            landed_in_review=False,
+        )
+    if verifier is None:
+        return CompostEntryScore(
+            entry_id=entry.id,
+            expected=entry.expected,
+            similarity=similarity,
+            embedding_passed=True,
+            verifier_verdict=None,
+            flagged=True,
+            landed_in_review=False,
+        )
+    result = verifier.verify(title=entry.title, body=entry.body)
+    flagged = result.verdict in (CompostVerdict.YES, CompostVerdict.AMBIGUOUS)
+    return CompostEntryScore(
+        entry_id=entry.id,
+        expected=entry.expected,
+        similarity=similarity,
+        embedding_passed=True,
+        verifier_verdict=result.verdict,
+        flagged=flagged,
+        landed_in_review=result.verdict == CompostVerdict.AMBIGUOUS,
+    )
+
+
+_VERDICT_COUNT_KEYS: dict[CompostVerdict, str] = {
+    CompostVerdict.YES: "verified_yes",
+    CompostVerdict.NO: "verified_no",
+    CompostVerdict.AMBIGUOUS: "verified_ambiguous",
+}
+
+
+def _summarise(scores: Sequence[CompostEntryScore]) -> CompostCalibrationReport:
+    """Aggregate per-entry scores into the final report in a single pass."""
+    counts: dict[str, int] = {
+        "true_positives": 0,
+        "false_positives": 0,
+        "true_negatives": 0,
+        "false_negatives": 0,
+        "embedding_passed": 0,
+        "verified_yes": 0,
+        "verified_no": 0,
+        "verified_ambiguous": 0,
+    }
+    for score in scores:
+        counts[_confusion_key(score)] += 1
+        if score.embedding_passed:
+            counts["embedding_passed"] += 1
+        if score.verifier_verdict is not None:
+            counts[_VERDICT_COUNT_KEYS[score.verifier_verdict]] += 1
+    return CompostCalibrationReport(
+        entries=len(scores),
+        per_entry=tuple(scores),
+        **counts,
+    )
+
+
+def _confusion_key(score: CompostEntryScore) -> str:
+    """Return the matrix bucket name for *score* (TP / FP / TN / FN)."""
+    if score.flagged:
+        return "true_positives" if score.expected else "false_positives"
+    return "false_negatives" if score.expected else "true_negatives"
+
+
+def write_json_sidecar(report: CompostCalibrationReport, path: Path) -> None:
+    """Write the JSON sidecar to *path*, creating parent dirs as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(report.to_json_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def assert_floors(
+    report: CompostCalibrationReport,
+    *,
+    floor_recall: float | None = None,
+    floor_precision: float | None = None,
+) -> None:
+    """Raise :class:`CompostFloorBreachError` if any floor is violated.
+
+    Args:
+        report: Output of :func:`score_compost`.
+        floor_recall: Minimum acceptable recall in ``[0.0, 1.0]``, or
+            ``None`` to skip the recall gate.
+        floor_precision: Minimum acceptable precision in ``[0.0, 1.0]``,
+            or ``None`` to skip the precision gate.
+
+    Raises:
+        CompostFloorBreachError: When at least one floor is breached.
+            The message lists every breach so a single CI run surfaces
+            all of them.
+    """
+    breaches: list[str] = []
+    if floor_recall is not None and report.recall < floor_recall:
+        breaches.append(f"recall: {report.recall:.2%} < {floor_recall:.2%}")
+    if floor_precision is not None and report.precision < floor_precision:
+        breaches.append(
+            f"precision: {report.precision:.2%} < {floor_precision:.2%}",
+        )
+    if breaches:
+        msg = "compost calibration floors breached:\n  " + "\n  ".join(breaches)
+        raise CompostFloorBreachError(msg)

--- a/creek-tools/docs/emergence.md
+++ b/creek-tools/docs/emergence.md
@@ -94,7 +94,9 @@ The compost note records:
 - **Links to referencing fragments** — wiki-links so the compost stays reachable.
 - **Verifier metadata** — `embedding_similarity` and `verifier_reasoning` round-trip into frontmatter so the operator can audit decisions later.
 
-Output: `10-Liminal/Compost/<id>.md` (canonical) or `10-Liminal/Compost/Review/<id>.md` (ambiguous, awaiting triage). CLI: `creek report --type compost`. Calibration: `creek compost calibrate [--fixture FIXTURE.yaml]` (FEAT-018; full fixture-driven scoring lands once a real labelled set is collected).
+Output: `10-Liminal/Compost/<id>.md` (canonical) or `10-Liminal/Compost/Review/<id>.md` (ambiguous, awaiting triage). CLI: `creek report --type compost`.
+
+Calibration (FEAT-028): `creek compost calibrate [--fixture FIXTURE.yaml] [--json PATH] [--floor-recall 0.8] [--floor-precision 0.85] [--no-verifier]`. Runs the two-stage detector against a hand-labelled fixture (default: `tests/fixtures/compost-calibration.yaml`, 20+ positives × 20+ false-positive-risk negatives) and reports recall, precision, F1, false-positive rate, and per-stage hit counts (embedding-passed / verifier-yes / verifier-no / routed-to-review). `--floor-recall` and `--floor-precision` exit non-zero on a regression so a CI job can gate on detector quality. `--no-verifier` runs embedding-only for offline calibration.
 
 ---
 

--- a/creek-tools/tests/fixtures/compost-calibration.yaml
+++ b/creek-tools/tests/fixtures/compost-calibration.yaml
@@ -1,0 +1,334 @@
+# Compost calibration fixture (FEAT-028).
+#
+# Hand-labelled fragments for ``creek compost calibrate --fixture``.
+# Each entry: { id, title, body, expected }.
+#
+# ``expected: true`` — genuine idea / project abandonment. The pipeline
+# (embedding gate + verifier) SHOULD flag this entry as compost.
+# ``expected: false`` — false-positive-risk content. Reads superficially
+# like compost (loss of momentum, hesitation, taking a break) but is
+# really paused / pivoted / completed / mid-flow / paradox-holding.
+# The pipeline SHOULD NOT flag this entry.
+#
+# Positives cover the nine canonical abandonment textures from
+# ``creek/generate/exemplars/compost.yaml`` plus a few cross-texture
+# blends so the fixture exercises the embedding gate's interior
+# rather than only the exemplar bodies themselves.
+#
+# Negatives target the four "is NOT abandonment" categories named in
+# ``compost_verifier._PROMPT_TEMPLATE``: temporary frustration mid-flow,
+# taking a break, completing the work, and expressing a paradox. Plus
+# a handful of adjacent risks (delegation, pivot to active alternative,
+# rescoping, evaluating a side question, etc.) so the verifier has to
+# discriminate against realistic noise.
+
+# ---- Positives (idea / project abandonment) ----
+
+- id: cc-001
+  title: Circling a question for the third week
+  body: I sit down with this and it goes the same place every time. The same
+    circle opens, the same circle closes, and I walk away with nothing new.
+    The thread is the work, apparently, and the work refuses to crystallize.
+  expected: true
+
+- id: cc-002
+  title: Quiet release of the synth project
+  body: I am letting this one go. Not with any drama, not as a failure — it is
+    not mine anymore. It belonged to a version of me that is no longer the one
+    holding the pen.
+  expected: true
+
+- id: cc-003
+  title: Drifted out of the room
+  body: Looking at the notes I made three months ago I barely recognize the
+    person who was urgent about this. Whatever pulled me toward it pulled
+    past it. I am not interested anymore and I cannot honestly say why.
+  expected: true
+
+- id: cc-004
+  title: I no longer recognize this thread
+  body: The thread went somewhere I no longer recognize. The premise I started
+    with is not a premise I would write today. I could keep pulling on it out
+    of momentum but I would be performing continuity, not actually continuing.
+  expected: true
+
+- id: cc-005
+  title: Too tired to keep this alive
+  body: I do not have the energy to keep tending this. It needed weekly
+    attention to stay warm and I gave it three weeks of cold and now when I
+    open the file the room feels empty. Maybe later. Probably not.
+  expected: true
+
+- id: cc-006
+  title: Displaced by what came next
+  body: The project that ate this one has been alive for six months. There is
+    no room left for the older question, and honestly the new one is better.
+    Filing this under things that pointed somewhere.
+  expected: true
+
+- id: cc-007
+  title: The air went out of it
+  body: I was excited about this for about a week and then the air went out
+    of it. I keep waiting for the energy to come back. It has not. I am
+    starting to think the energy was never about this in the first place.
+  expected: true
+
+- id: cc-008
+  title: Indefinitely postponed
+  body: I keep telling myself I will come back to this when I have time and
+    the truthful version of that sentence is "when I have time" is a
+    euphemism for "never". I am allowed to just say I am not doing this.
+  expected: true
+
+- id: cc-009
+  title: Walked away without noticing
+  body: At some point I stopped working on this and I cannot point to when.
+    There was no decision, no moment, just the gap between the last entry
+    and now. The walking-away happened in the spaces between the notes.
+  expected: true
+
+- id: cc-010
+  title: The question dissolved
+  body: I went looking for the original question and I could not find it. Not
+    because I lost the notes — they are right here — but because the question
+    does not feel urgent anymore. Whatever shape it had has dissolved.
+  expected: true
+
+- id: cc-011
+  title: I keep promising I will get back to it
+  body: Three times this month I have told someone I will get back to this
+    project. Each time I meant it less. I am not going to. The promise was
+    performance, and the performance is the only part of this still alive.
+  expected: true
+
+- id: cc-012
+  title: Belonged to a self I am not anymore
+  body: Re-reading the early notes feels like reading someone else. The
+    voice is recognizable but the urgency is alien. I am not going to
+    finish what that version started. They can have the credit.
+  expected: true
+
+- id: cc-013
+  title: Started something else mid-sentence
+  body: I am three paragraphs into an essay about this and I just opened a
+    new document for something completely unrelated. That tells me where my
+    actual attention is. The essay can stay where it is.
+  expected: true
+
+- id: cc-014
+  title: Done pretending this is alive
+  body: I have been treating this like a live project for months when it
+    clearly is not. Every time I update the status I am performing for no one.
+    Calling it — this is compost. There is something in here worth keeping.
+  expected: true
+
+- id: cc-015
+  title: Newsletter that never launched
+  body: I drafted three issues and then never sent the first one. Every time
+    I open the queue I find a new reason it is not ready. The not-ready is
+    the answer. I am not going to launch this.
+  expected: true
+
+- id: cc-016
+  title: The reading list I will never read
+  body: Sixty books, ten years, three real reads. I am going to delete the
+    list. The shame of looking at it is the only thing it still produces.
+    Whatever I needed from those books I have already gotten elsewhere.
+  expected: true
+
+- id: cc-017
+  title: Old notebook closing on its own
+  body: I have not opened this notebook in eight months. When I do open it the
+    pages feel sealed. I am going to put it on the shelf and stop pretending
+    I am the kind of person who is going to come back to those questions.
+  expected: true
+
+- id: cc-018
+  title: The startup idea was never mine
+  body: I have been talking about this idea for two years. I have built two
+    prototypes. I never wanted to actually run the company. The idea was
+    interesting; the life it implied was someone else's life.
+  expected: true
+
+- id: cc-019
+  title: We stopped doing the standup
+  body: We stopped doing the weekly standup six months ago and nobody said
+    anything. The thing we were checking in about is not a thing anymore.
+    Honoring that by formally retiring the meeting instead of letting it ghost.
+  expected: true
+
+- id: cc-020
+  title: My grand unified theory is fan-fiction
+  body: I have been refining this framework for a decade and what I actually
+    have is a vocabulary, not a theory. The framework predicts nothing it
+    did not already describe. I am letting the framework be a vocabulary
+    and stopping the pretense of theory-building.
+  expected: true
+
+- id: cc-021
+  title: PhD I am not going to finish
+  body: I have known this for a year. I have not told anyone yet. Saying it
+    here so the silence stops being the place where the decision actually
+    lives. The committee can read this as a withdrawal letter; I am done.
+  expected: true
+
+- id: cc-022
+  title: The book that wants to be three essays
+  body: It wanted to be a book and it kept trying to be three essays. I have
+    been forcing it to be a book for two years. Letting it be three essays
+    means the book-shaped thing dies, and that is the right move.
+  expected: true
+
+# ---- Negatives (false-positive risk: NOT abandonment) ----
+
+- id: cc-023
+  title: Stuck on this design today
+  body: Spent four hours on the auth flow and got nowhere useful. Frustrated.
+    Going to sleep on it and come back tomorrow with fresh eyes. The
+    problem is real; I am just not seeing it tonight.
+  expected: false
+
+- id: cc-024
+  title: Taking the long weekend off
+  body: I am going to step back from the project for the long weekend. The
+    work is in a good state. When I come back Tuesday I will know better
+    where the gaps are. This is not stopping; this is letting the soup settle.
+  expected: false
+
+- id: cc-025
+  title: Shipped the migration
+  body: Two months of work and the migration is live. Old code deleted, new
+    code monitored, no incidents in 48 hours. Calling this done and moving
+    to the next thing on the list.
+  expected: false
+
+- id: cc-026
+  title: Holding the paradox open
+  body: My instinct says push harder; my experience says wait. Both are
+    right. I am not resolving this. The contradiction is the actual data —
+    the thing I will keep noticing every time the project asks for a decision.
+  expected: false
+
+- id: cc-027
+  title: Pivoting to the new approach
+  body: The old architecture is not going to scale and we know it. Starting
+    the redesign tomorrow. The work is not over — the angle of attack is
+    just different. Keeping every learning from the old approach.
+  expected: false
+
+- id: cc-028
+  title: Handing this off to L
+  body: L has more context for the front-end side than I do. I am handing
+    the dashboard work over to them so I can focus on the API. The work
+    continues; the assignment changes.
+  expected: false
+
+- id: cc-029
+  title: End of phase 1
+  body: We have hit the end of phase 1 and the planned deliverables are in.
+    Brief pause to write the phase 1 retro, then straight into phase 2.
+    The thing is not over; the chapter is.
+  expected: false
+
+- id: cc-030
+  title: Explicitly NOT doing this in Q3
+  body: Adding this to the Q4 backlog. Q3 is full and adding more is how we
+    miss the launch. The work is real and important; the timing is not now.
+  expected: false
+
+- id: cc-031
+  title: Hard week but worth it
+  body: Every part of this week was harder than I expected. I am tired but
+    I am not less convinced. The work is producing the thing I wanted. The
+    difficulty is information about scope, not a reason to stop.
+  expected: false
+
+- id: cc-032
+  title: Rescoping the launch
+  body: We are shipping a smaller version of this in three weeks instead of
+    the full version in three months. The big version is not dead — the
+    smaller version is the way we learn what the big one should actually be.
+  expected: false
+
+- id: cc-033
+  title: On pause until the budget question
+  body: I am pausing this until the budget question lands next quarter.
+    "On pause" not "abandoned" — I have the file open and the plan written
+    and as soon as we know the number I am back on it.
+  expected: false
+
+- id: cc-034
+  title: Side question, not the main thread
+  body: This is a fun thing I noticed while doing the real work. Writing it
+    down so I do not forget but I am not going to chase it now. The main
+    project is on track and that is where the attention belongs.
+  expected: false
+
+- id: cc-035
+  title: Retro on the migration
+  body: Now that the migration is done, three things to remember next time —
+    write the rollback first, test on staging for a week, and have an
+    on-call rota in place before launch day. The project closed cleanly.
+  expected: false
+
+- id: cc-036
+  title: Archiving the old design docs
+  body: Moving the v1 design docs into the reference folder. They are not
+    active but they are the record of what we learned. Anyone working on
+    v3 should read them before they re-invent any of the same wheels.
+  expected: false
+
+- id: cc-037
+  title: Sprint debrief
+  body: Hit our targets, shipped the feature on schedule, no major regressions.
+    The team did good work this week. Writing the demo script for the
+    Friday review.
+  expected: false
+
+- id: cc-038
+  title: This contradicts what I wrote in March
+  body: In March I said the framework requires four phases. Today I think it
+    needs three. I am not retracting March; the March version is the version
+    that thinks four. Holding both as the actual state of my thinking.
+  expected: false
+
+- id: cc-039
+  title: First milestone landed
+  body: The first milestone of the FEAT-009 sequence is in. Next two are
+    queued. Pace feels sustainable. Writing the release notes tonight, then
+    starting the second milestone tomorrow morning.
+  expected: false
+
+- id: cc-040
+  title: Reviewing the proposal one more time
+  body: Sending the proposal out tomorrow. Spending tonight on one more pass
+    to clean up the assumptions section. The work is done; this is polish.
+  expected: false
+
+- id: cc-041
+  title: Will revisit after the user interviews
+  body: I cannot answer this question without more data. Pausing the spec
+    work until the next batch of user interviews lands next week. Plan is
+    intact; I just need the inputs the spec depends on.
+  expected: false
+
+- id: cc-042
+  title: Three concrete next steps
+  body: Three things to do this week — finalize the schema, get the migration
+    PR reviewed, draft the rollout doc. All blockers identified, all owners
+    assigned. The work is active and on schedule.
+  expected: false
+
+- id: cc-043
+  title: A wonderful collaborator
+  body: R and I finally got the proposal to a place we both like. Their edits
+    on section three were exactly the move it needed. Continuing to lean on
+    their judgment for the rest of the rollout.
+  expected: false
+
+- id: cc-044
+  title: Still in this
+  body: Six months in and the work is still teaching me things I did not
+    expect. Pace is steady, motivation is fine, the question still has
+    enough air in it to keep me curious. No exit plan; this is where I am.
+  expected: false

--- a/creek-tools/tests/test_compost_calibration.py
+++ b/creek-tools/tests/test_compost_calibration.py
@@ -30,6 +30,7 @@ from creek.generate.compost_verifier import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -74,7 +75,11 @@ def _entry(
     )
 
 
-def _similarity_table(table: dict[str, float], *, default: float = 0.0) -> object:
+def _similarity_table(
+    table: dict[str, float],
+    *,
+    default: float = 0.0,
+) -> Callable[[str], float]:
     """Return a similarity_fn closure that looks ids up by title substring."""
 
     def fn(text: str) -> float:
@@ -153,6 +158,21 @@ class TestLoadFixture:
         with pytest.raises(ValueError, match="must be a bool"):
             load_fixture(target)
 
+    def test_invalid_yaml_raises_value_error(self, tmp_path: Path) -> None:
+        """A syntactically-broken YAML surfaces as ``ValueError``.
+
+        The CLI handler catches ``ValueError``; without this wrapper a
+        malformed fixture would produce an uncaught traceback instead
+        of the operator-facing ``[red]Failed to load…[/red]`` line. The
+        wrapper also gives callers a single exception type to handle
+        for both schema and syntax failures.
+        """
+        target = tmp_path / "broken.yaml"
+        # Unclosed bracket — yaml.safe_load raises ``yaml.YAMLError``.
+        target.write_text("- id: x\n  body: [\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="not valid YAML"):
+            load_fixture(target)
+
 
 # ---- Scoring ------------------------------------------------------------
 
@@ -167,7 +187,7 @@ class TestScoreCompost:
 
         report = score_compost(
             entries,
-            similarity_fn=sim,  # type: ignore[arg-type]
+            similarity_fn=sim,
             verifier=None,
             embedding_threshold=0.5,
         )
@@ -186,7 +206,7 @@ class TestScoreCompost:
 
         report = score_compost(
             entries,
-            similarity_fn=sim,  # type: ignore[arg-type]
+            similarity_fn=sim,
             verifier=None,
             embedding_threshold=0.5,
         )
@@ -204,7 +224,7 @@ class TestScoreCompost:
 
         report = score_compost(
             entries,
-            similarity_fn=sim,  # type: ignore[arg-type]
+            similarity_fn=sim,
             verifier=verifier,
             embedding_threshold=0.6,
         )
@@ -224,7 +244,7 @@ class TestScoreCompost:
 
         report = score_compost(
             entries,
-            similarity_fn=sim,  # type: ignore[arg-type]
+            similarity_fn=sim,
             verifier=verifier,
             embedding_threshold=0.6,
         )
@@ -242,7 +262,7 @@ class TestScoreCompost:
 
         report = score_compost(
             entries,
-            similarity_fn=sim,  # type: ignore[arg-type]
+            similarity_fn=sim,
             verifier=verifier,
             embedding_threshold=0.6,
         )
@@ -277,7 +297,7 @@ class TestScoreCompost:
 
         report = score_compost(
             entries,
-            similarity_fn=sim,  # type: ignore[arg-type]
+            similarity_fn=sim,
             verifier=verifier,
             embedding_threshold=0.5,
         )
@@ -297,7 +317,7 @@ class TestScoreCompost:
         """No entries → no division by zero; metrics are 0.0."""
         report = score_compost(
             [],
-            similarity_fn=_similarity_table({}),  # type: ignore[arg-type]
+            similarity_fn=_similarity_table({}),
             verifier=None,
         )
         assert report.entries == 0

--- a/creek-tools/tests/test_compost_calibration.py
+++ b/creek-tools/tests/test_compost_calibration.py
@@ -1,0 +1,727 @@
+"""Tests for ``creek.generate.compost_calibration`` (FEAT-028).
+
+Covers fixture loading, the two-stage scoring pipeline (embedding gate
++ optional verifier), confusion-matrix arithmetic, JSON sidecar
+emission, and the floor-gate assertions. The LLM verifier is mocked
+with a deterministic stub keyed by entry id — no live calls.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.generate.compost_calibration import (
+    DEFAULT_FIXTURE_PATH,
+    CompostCalibrationEntry,
+    CompostCalibrationReport,
+    CompostEntryScore,
+    CompostFloorBreachError,
+    assert_floors,
+    load_fixture,
+    score_compost,
+    write_json_sidecar,
+)
+from creek.generate.compost_verifier import (
+    CompostVerdict,
+    CompostVerifierResult,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class _StubVerifier:
+    """Returns a programmed verdict keyed by entry title.
+
+    The compost detector calls ``verify(title=..., body=...)``; we
+    look the title up in the response table so each test can shape
+    the verifier's behaviour without monkeypatching the LLM client.
+    """
+
+    def __init__(
+        self,
+        responses: dict[str, CompostVerdict],
+        *,
+        default: CompostVerdict = CompostVerdict.YES,
+    ) -> None:
+        self._responses = responses
+        self._default = default
+        self.calls: list[tuple[str, str]] = []
+
+    def verify(self, *, title: str, body: str) -> CompostVerifierResult:
+        """Look up the title in the response table, fall back to default."""
+        self.calls.append((title, body))
+        verdict = self._responses.get(title, self._default)
+        return CompostVerifierResult(verdict=verdict, reasoning="stub")
+
+
+def _entry(
+    *,
+    entry_id: str,
+    title: str = "title",
+    body: str = "body",
+    expected: bool = True,
+) -> CompostCalibrationEntry:
+    """Build a minimal entry for table-driven tests."""
+    return CompostCalibrationEntry(
+        id=entry_id,
+        title=title,
+        body=body,
+        expected=expected,
+    )
+
+
+def _similarity_table(table: dict[str, float], *, default: float = 0.0) -> object:
+    """Return a similarity_fn closure that looks ids up by title substring."""
+
+    def fn(text: str) -> float:
+        for key, score in table.items():
+            if key in text:
+                return score
+        return default
+
+    return fn
+
+
+# ---- Fixture loading ----------------------------------------------------
+
+
+class TestLoadFixture:
+    """``load_fixture`` validates the YAML shape and coerces entries."""
+
+    def test_packaged_default_loads(self) -> None:
+        """The packaged fixture exists and parses into the expected shape."""
+        entries = load_fixture(DEFAULT_FIXTURE_PATH)
+        assert len(entries) >= 40
+        positives = [e for e in entries if e.expected]
+        negatives = [e for e in entries if not e.expected]
+        assert len(positives) >= 20, "FEAT-028 requires 20+ positive examples"
+        assert len(negatives) >= 20, "FEAT-028 requires 20+ negative examples"
+
+    def test_packaged_default_uses_unique_ids(self) -> None:
+        """No duplicate IDs in the packaged fixture."""
+        entries = load_fixture(DEFAULT_FIXTURE_PATH)
+        ids = [e.id for e in entries]
+        assert len(ids) == len(set(ids))
+
+    def test_missing_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        """Absent fixture path raises ``FileNotFoundError`` with the path."""
+        target = tmp_path / "does-not-exist.yaml"
+        with pytest.raises(FileNotFoundError, match=str(target)):
+            load_fixture(target)
+
+    def test_non_list_top_level_raises(self, tmp_path: Path) -> None:
+        """A non-list YAML top level produces a ``ValueError``."""
+        target = tmp_path / "bad.yaml"
+        target.write_text("not_a_list: true\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="list at top level"):
+            load_fixture(target)
+
+    def test_empty_file_returns_empty_tuple(self, tmp_path: Path) -> None:
+        """An empty fixture file is valid and returns an empty tuple."""
+        target = tmp_path / "empty.yaml"
+        target.write_text("", encoding="utf-8")
+        assert load_fixture(target) == ()
+
+    def test_entry_missing_keys_raises(self, tmp_path: Path) -> None:
+        """An entry missing ``expected`` surfaces a clear ``ValueError``."""
+        target = tmp_path / "incomplete.yaml"
+        target.write_text(
+            "- id: x\n  title: t\n  body: b\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="missing keys"):
+            load_fixture(target)
+
+    def test_entry_not_a_dict_raises(self, tmp_path: Path) -> None:
+        """A non-dict entry surfaces a clear ``ValueError``."""
+        target = tmp_path / "scalar.yaml"
+        target.write_text("- scalar-not-a-dict\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="not a dict"):
+            load_fixture(target)
+
+    def test_non_bool_expected_raises(self, tmp_path: Path) -> None:
+        """``expected`` must be a bool; strings should fail loud."""
+        target = tmp_path / "string-expected.yaml"
+        target.write_text(
+            "- id: x\n  title: t\n  body: b\n  expected: yes-string\n",
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="must be a bool"):
+            load_fixture(target)
+
+
+# ---- Scoring ------------------------------------------------------------
+
+
+class TestScoreCompost:
+    """``score_compost`` runs the two-stage pipeline and tallies the matrix."""
+
+    def test_below_threshold_is_not_flagged(self) -> None:
+        """Entries that fail the embedding gate are never flagged."""
+        entries = [_entry(entry_id="lo", title="lo-title", expected=True)]
+        sim = _similarity_table({"lo-title": 0.1})
+
+        report = score_compost(
+            entries,
+            similarity_fn=sim,  # type: ignore[arg-type]
+            verifier=None,
+            embedding_threshold=0.5,
+        )
+
+        assert report.true_positives == 0
+        assert report.false_negatives == 1
+        assert report.embedding_passed == 0
+        # The single per-entry record should reflect a non-passing gate.
+        assert report.per_entry[0].embedding_passed is False
+        assert report.per_entry[0].verifier_verdict is None
+
+    def test_embedding_only_passes_without_verifier(self) -> None:
+        """When verifier is None the gate alone accepts above-threshold entries."""
+        entries = [_entry(entry_id="hi", title="hi-title", expected=True)]
+        sim = _similarity_table({"hi-title": 0.9})
+
+        report = score_compost(
+            entries,
+            similarity_fn=sim,  # type: ignore[arg-type]
+            verifier=None,
+            embedding_threshold=0.5,
+        )
+
+        assert report.true_positives == 1
+        assert report.embedding_passed == 1
+        assert report.verified_yes == 0  # verifier was None — nothing to count
+        assert report.per_entry[0].flagged is True
+
+    def test_verifier_yes_accepts_as_compost(self) -> None:
+        """A ``yes`` verifier verdict produces a flagged candidate."""
+        entries = [_entry(entry_id="x", title="x-title", expected=True)]
+        sim = _similarity_table({"x-title": 0.7})
+        verifier = _StubVerifier({"x-title": CompostVerdict.YES})
+
+        report = score_compost(
+            entries,
+            similarity_fn=sim,  # type: ignore[arg-type]
+            verifier=verifier,
+            embedding_threshold=0.6,
+        )
+
+        assert report.true_positives == 1
+        assert report.verified_yes == 1
+        assert report.per_entry[0].flagged is True
+        assert report.per_entry[0].landed_in_review is False
+
+    def test_verifier_no_saves_a_false_positive(self) -> None:
+        """A ``no`` verdict rescues a false-positive from the matrix."""
+        entries = [
+            _entry(entry_id="neg", title="neg-title", expected=False),
+        ]
+        sim = _similarity_table({"neg-title": 0.95})  # gate passes
+        verifier = _StubVerifier({"neg-title": CompostVerdict.NO})
+
+        report = score_compost(
+            entries,
+            similarity_fn=sim,  # type: ignore[arg-type]
+            verifier=verifier,
+            embedding_threshold=0.6,
+        )
+
+        assert report.false_positives == 0
+        assert report.true_negatives == 1
+        assert report.verified_no == 1
+        assert report.per_entry[0].flagged is False
+
+    def test_verifier_ambiguous_routes_to_review_and_still_flags(self) -> None:
+        """``ambiguous`` is treated as flagged (matches production tracker)."""
+        entries = [_entry(entry_id="amb", title="amb-title", expected=True)]
+        sim = _similarity_table({"amb-title": 0.8})
+        verifier = _StubVerifier({"amb-title": CompostVerdict.AMBIGUOUS})
+
+        report = score_compost(
+            entries,
+            similarity_fn=sim,  # type: ignore[arg-type]
+            verifier=verifier,
+            embedding_threshold=0.6,
+        )
+
+        assert report.true_positives == 1
+        assert report.verified_ambiguous == 1
+        assert report.per_entry[0].landed_in_review is True
+        assert report.per_entry[0].flagged is True
+
+    def test_full_confusion_matrix(self) -> None:
+        """Mix of TP / FP / TN / FN entries yields the expected tally."""
+        entries = [
+            _entry(entry_id="tp", title="tp-t", expected=True),
+            _entry(entry_id="fn", title="fn-t", expected=True),
+            _entry(entry_id="fp", title="fp-t", expected=False),
+            _entry(entry_id="tn", title="tn-t", expected=False),
+        ]
+        sim = _similarity_table(
+            {
+                "tp-t": 0.9,
+                "fn-t": 0.1,  # gate fails — false negative
+                "fp-t": 0.9,
+                "tn-t": 0.1,
+            },
+        )
+        verifier = _StubVerifier(
+            {
+                "tp-t": CompostVerdict.YES,
+                "fp-t": CompostVerdict.YES,
+            },
+        )
+
+        report = score_compost(
+            entries,
+            similarity_fn=sim,  # type: ignore[arg-type]
+            verifier=verifier,
+            embedding_threshold=0.5,
+        )
+
+        assert (
+            report.true_positives,
+            report.false_positives,
+            report.true_negatives,
+            report.false_negatives,
+        ) == (1, 1, 1, 1)
+        assert report.recall == pytest.approx(0.5)
+        assert report.precision == pytest.approx(0.5)
+        assert report.f1 == pytest.approx(0.5)
+        assert report.false_positive_rate == pytest.approx(0.5)
+
+    def test_empty_entries_yield_zero_metrics(self) -> None:
+        """No entries → no division by zero; metrics are 0.0."""
+        report = score_compost(
+            [],
+            similarity_fn=_similarity_table({}),  # type: ignore[arg-type]
+            verifier=None,
+        )
+        assert report.entries == 0
+        assert report.recall == 0.0
+        assert report.precision == 0.0
+        assert report.f1 == 0.0
+        assert report.false_positive_rate == 0.0
+
+    def test_text_is_title_only_when_body_is_empty(self) -> None:
+        """The similarity_fn sees only the title when the body is blank."""
+        captured: list[str] = []
+
+        def sim(text: str) -> float:
+            captured.append(text)
+            return 0.0
+
+        score_compost(
+            [_entry(entry_id="t", title="only-title", body="", expected=True)],
+            similarity_fn=sim,
+            verifier=None,
+        )
+        assert captured == ["only-title"]
+
+
+# ---- Report rendering ---------------------------------------------------
+
+
+class TestReportRendering:
+    """The CLI table and JSON sidecar reflect the report contents."""
+
+    def _sample_report(self) -> CompostCalibrationReport:
+        return CompostCalibrationReport(
+            entries=4,
+            true_positives=2,
+            false_positives=1,
+            true_negatives=0,
+            false_negatives=1,
+            embedding_passed=3,
+            verified_yes=2,
+            verified_no=0,
+            verified_ambiguous=1,
+            per_entry=(
+                CompostEntryScore(
+                    entry_id="e1",
+                    expected=True,
+                    similarity=0.91,
+                    embedding_passed=True,
+                    verifier_verdict=CompostVerdict.YES,
+                    flagged=True,
+                    landed_in_review=False,
+                ),
+            ),
+        )
+
+    def test_render_table_contains_each_metric(self) -> None:
+        """Every metric the operator needs appears in the rendered table."""
+        rendered = self._sample_report().render()
+        for marker in (
+            "Recall:",
+            "Precision:",
+            "F1:",
+            "False-pos. rate:",
+            "Embedding gate:",
+            "Verifier yes:",
+            "Verifier no:",
+            "Verifier review:",
+        ):
+            assert marker in rendered
+
+    def test_json_sidecar_round_trips(self, tmp_path: Path) -> None:
+        """The JSON sidecar parses back and matches the report state."""
+        target = tmp_path / "subdir" / "report.json"
+        report = self._sample_report()
+
+        write_json_sidecar(report, target)
+
+        parsed = json.loads(target.read_text(encoding="utf-8"))
+        assert parsed["entries"] == 4
+        assert parsed["confusion_matrix"]["true_positives"] == 2
+        assert parsed["metrics"]["recall"] == pytest.approx(2 / 3)
+        assert parsed["per_stage"]["verified_ambiguous"] == 1
+        assert parsed["per_entry"][0]["verifier_verdict"] == "yes"
+
+    def test_json_sidecar_handles_none_verdict(self, tmp_path: Path) -> None:
+        """``verifier_verdict=None`` serialises as JSON null, not the string."""
+        target = tmp_path / "report.json"
+        report = CompostCalibrationReport(
+            entries=1,
+            true_positives=0,
+            false_positives=0,
+            true_negatives=0,
+            false_negatives=1,
+            embedding_passed=0,
+            verified_yes=0,
+            verified_no=0,
+            verified_ambiguous=0,
+            per_entry=(
+                CompostEntryScore(
+                    entry_id="gate-miss",
+                    expected=True,
+                    similarity=0.1,
+                    embedding_passed=False,
+                    verifier_verdict=None,
+                    flagged=False,
+                    landed_in_review=False,
+                ),
+            ),
+        )
+
+        write_json_sidecar(report, target)
+
+        parsed = json.loads(target.read_text(encoding="utf-8"))
+        assert parsed["per_entry"][0]["verifier_verdict"] is None
+
+
+# ---- Floor gating -------------------------------------------------------
+
+
+class TestAssertFloors:
+    """``assert_floors`` raises a single error listing every breach."""
+
+    def _report(
+        self, *, tp: int, fp: int, tn: int, fn: int
+    ) -> CompostCalibrationReport:
+        return CompostCalibrationReport(
+            entries=tp + fp + tn + fn,
+            true_positives=tp,
+            false_positives=fp,
+            true_negatives=tn,
+            false_negatives=fn,
+            embedding_passed=tp + fp,
+            verified_yes=tp + fp,
+            verified_no=0,
+            verified_ambiguous=0,
+        )
+
+    def test_passes_when_above_floors(self) -> None:
+        """Both metrics above the floors → no exception."""
+        report = self._report(tp=8, fp=1, tn=10, fn=2)  # recall 0.8, precision 0.89
+        assert_floors(report, floor_recall=0.7, floor_precision=0.7)
+
+    def test_breaches_listed_in_message(self) -> None:
+        """A double breach surfaces both metrics in the error string."""
+        report = self._report(tp=2, fp=5, tn=5, fn=8)  # recall 0.2, precision 0.29
+        with pytest.raises(CompostFloorBreachError) as excinfo:
+            assert_floors(report, floor_recall=0.8, floor_precision=0.8)
+        message = str(excinfo.value)
+        assert "recall" in message
+        assert "precision" in message
+
+    def test_none_floor_is_skipped(self) -> None:
+        """Passing ``None`` for one floor disables that gate."""
+        report = self._report(tp=1, fp=0, tn=10, fn=9)  # recall 0.1, precision 1.0
+        # recall is dismal but the recall gate is disabled
+        assert_floors(report, floor_recall=None, floor_precision=0.8)
+        # The precision gate alone now fires
+        with pytest.raises(CompostFloorBreachError):
+            assert_floors(report, floor_recall=0.5, floor_precision=None)
+
+    def test_floors_unset_is_a_noop(self) -> None:
+        """No floors supplied means no enforcement."""
+        report = self._report(tp=0, fp=0, tn=0, fn=10)
+        assert_floors(report)
+
+
+# ---- CLI integration ----------------------------------------------------
+
+
+class TestCompostCalibrateCLI:
+    """End-to-end tests for ``creek compost calibrate`` (FEAT-028)."""
+
+    def _write_tiny_fixture(self, tmp_path: Path) -> Path:
+        """Write a two-entry fixture (one positive, one negative)."""
+        target = tmp_path / "fx.yaml"
+        target.write_text(
+            "- id: cc-p\n"
+            "  title: Quiet release\n"
+            "  body: I am letting this one go. It is not mine anymore.\n"
+            "  expected: true\n"
+            "- id: cc-n\n"
+            "  title: Shipped the migration\n"
+            "  body: Two months of work and the migration is live. Done.\n"
+            "  expected: false\n",
+            encoding="utf-8",
+        )
+        return target
+
+    def _patch_pipeline(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        similarities: dict[str, float],
+        verifier_responses: dict[str, CompostVerdict] | None = None,
+    ) -> None:
+        """Monkeypatch the embedding gate + verifier inside the CLI handler."""
+        from creek import cli as cli_module
+        from creek.generate import compost_embedding, compost_verifier
+
+        def _fake_make_similarity_fn(
+            _exemplars: object,
+            _linker: object,
+        ) -> object:
+            def fn(text: str) -> float:
+                for key, score in similarities.items():
+                    if key in text:
+                        return score
+                return 0.0
+
+            return fn
+
+        class _FakeLinker:
+            def __init__(self, **_kwargs: object) -> None:
+                pass
+
+        monkeypatch.setattr(
+            "creek.link.embeddings.EmbeddingLinker",
+            _FakeLinker,
+        )
+        monkeypatch.setattr(
+            compost_embedding,
+            "make_similarity_fn",
+            _fake_make_similarity_fn,
+        )
+
+        if verifier_responses is None:
+            monkeypatch.setattr(
+                cli_module,
+                "_build_compost_verifier",
+                lambda _config: None,
+            )
+        else:
+
+            class _FakeVerifier:
+                def verify(
+                    self,
+                    *,
+                    title: str,
+                    body: str,  # signature contract
+                ) -> compost_verifier.CompostVerifierResult:
+                    verdict = verifier_responses.get(title, CompostVerdict.YES)
+                    return compost_verifier.CompostVerifierResult(
+                        verdict=verdict,
+                        reasoning="stub",
+                    )
+
+            monkeypatch.setattr(
+                cli_module,
+                "_build_compost_verifier",
+                lambda _config: _FakeVerifier(),
+            )
+
+    def test_calibrate_prints_metrics_table(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The CLI prints the recall / precision / F1 / FPR block."""
+        from typer.testing import CliRunner
+
+        from creek.cli import app
+
+        fixture = self._write_tiny_fixture(tmp_path)
+        self._patch_pipeline(
+            monkeypatch,
+            similarities={"Quiet release": 0.95, "Shipped the migration": 0.1},
+        )
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "compost",
+                "calibrate",
+                "--fixture",
+                str(fixture),
+                "--no-verifier",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Recall:" in result.output
+        assert "Precision:" in result.output
+        assert "False-pos. rate:" in result.output
+        assert "Embedding gate:" in result.output
+
+    def test_calibrate_writes_json_sidecar(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--json writes a machine-readable sidecar that round-trips."""
+        from typer.testing import CliRunner
+
+        from creek.cli import app
+
+        fixture = self._write_tiny_fixture(tmp_path)
+        sidecar = tmp_path / "out" / "compost-calibration.json"
+        self._patch_pipeline(
+            monkeypatch,
+            similarities={"Quiet release": 0.95, "Shipped the migration": 0.1},
+        )
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "compost",
+                "calibrate",
+                "--fixture",
+                str(fixture),
+                "--no-verifier",
+                "--json",
+                str(sidecar),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert sidecar.exists()
+        parsed = json.loads(sidecar.read_text(encoding="utf-8"))
+        assert parsed["entries"] == 2
+        assert parsed["metrics"]["recall"] == pytest.approx(1.0)
+
+    def test_calibrate_exits_nonzero_on_floor_breach(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--floor-recall fails the run when recall is below the floor."""
+        from typer.testing import CliRunner
+
+        from creek.cli import app
+
+        fixture = self._write_tiny_fixture(tmp_path)
+        # Both entries fall below the embedding gate → recall = 0.
+        self._patch_pipeline(
+            monkeypatch,
+            similarities={"Quiet release": 0.1, "Shipped the migration": 0.1},
+        )
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "compost",
+                "calibrate",
+                "--fixture",
+                str(fixture),
+                "--no-verifier",
+                "--floor-recall",
+                "0.8",
+            ],
+        )
+
+        assert result.exit_code == 1
+        assert "recall" in result.output
+
+    def test_missing_fixture_path_exits_with_code_2(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A user-supplied missing fixture path is a configuration error."""
+        from typer.testing import CliRunner
+
+        from creek.cli import app
+
+        self._patch_pipeline(monkeypatch, similarities={})
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "compost",
+                "calibrate",
+                "--fixture",
+                str(tmp_path / "missing.yaml"),
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "not found" in result.output
+
+    def test_build_compost_verifier_falls_back_when_credentials_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No API key → ``_build_compost_verifier`` returns ``None`` (no raise)."""
+        from creek import cli as cli_module
+        from creek.classify.llm import AnthropicProvider
+        from creek.config import load_config
+
+        monkeypatch.delenv(AnthropicProvider.API_KEY_ENV, raising=False)
+        monkeypatch.delenv(AnthropicProvider.CONSENT_ENV, raising=False)
+
+        config = load_config()
+        assert cli_module._build_compost_verifier(config) is None
+
+    def test_calibrate_routes_to_verifier_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without --no-verifier the stub verifier is consulted and counted."""
+        from typer.testing import CliRunner
+
+        from creek.cli import app
+
+        fixture = self._write_tiny_fixture(tmp_path)
+        self._patch_pipeline(
+            monkeypatch,
+            similarities={"Quiet release": 0.95, "Shipped the migration": 0.95},
+            verifier_responses={
+                "Quiet release": CompostVerdict.YES,
+                "Shipped the migration": CompostVerdict.NO,
+            },
+        )
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "compost",
+                "calibrate",
+                "--fixture",
+                str(fixture),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        # One TP (Quiet release passes both stages), one TN (Shipped saved by NO).
+        assert "Verifier yes:     1" in result.output
+        assert "Verifier no:      1" in result.output


### PR DESCRIPTION
Closes #266.

## Summary

Implements the scoring path that PR #235 explicitly deferred: `creek compost calibrate --fixture FIXTURE.yaml` now runs every fixture entry through the production two-stage pipeline (embedding gate → optional LLM verifier) and reports the confusion matrix, recall, precision, F1, false-positive rate, and per-stage hit counts (embedding-passed / verified-yes / verified-no / routed-to-review).

## What landed

**`creek/generate/compost_calibration.py`** — new module
- `CompostCalibrationEntry` / `CompostEntryScore` / `CompostCalibrationReport` dataclasses with derived recall / precision / F1 / FPR properties.
- `score_compost(entries, *, similarity_fn, verifier, embedding_threshold)` — mirrors `CompostTracker._detect_abandonment_fragments` so calibration matches what the detector actually does.
- `write_json_sidecar(report, path)` — machine-readable record with full per-entry breakdown.
- `assert_floors(report, *, floor_recall, floor_precision)` raises `CompostFloorBreachError` listing every breach.

**`tests/fixtures/compost-calibration.yaml`** — new packaged fixture
- 22 positives across the nine canonical compost textures from `compost.yaml` (circling, releasing, drifting, identity-drift, exhaustion, displacement, deflation, postponement, quiet-walk-away) plus cross-texture blends.
- 22 false-positive-risk negatives targeting the four "is NOT abandonment" categories named in `compost_verifier._PROMPT_TEMPLATE` (temporary frustration mid-flow, taking a break, completing the work, expressing a paradox) plus delegation, pivot-to-alternative, rescoping, side-question evaluation, retros, etc.

**`creek/cli.py` — `creek compost calibrate` is no longer a stub**
- `--fixture` (defaults to the packaged fixture; falls back to exemplar-coverage-only when the default is missing under a wheel install)
- `--json` writes the JSON sidecar
- `--embedding-threshold` overrides the 0.6 default for tuning
- `--no-verifier` runs embedding-only (offline / no-API-key CI)
- `--floor-recall` / `--floor-precision` exit non-zero on breach for CI gating
- `_build_compost_verifier` falls back to `None` with a console warning when `ANTHROPIC_API_KEY` / `CREEK_ANTHROPIC_CONSENT` are unset, so the command stays usable in offline calibration runs.

**`tests/test_compost_calibration.py`** — 29 tests
- Fixture loading & validation (8); pipeline scoring with a deterministic stub verifier (8); report rendering + JSON sidecar round-trip (3); floor-gate combinations (4); CLI integration including no-verifier fallback (6). **No live LLM calls** — the stub verifier is keyed by entry title.

**`docs/emergence.md`** — calibration paragraph updated to list every CLI flag, the default fixture location, and what each gate enforces.

## Quality gates

All 12 `./scripts/check-all.sh` gates green:
- 3795 tests passing, 93.76% branch coverage
- `compost_calibration.py` at 98.11% lines / 96.88% branches
- Ruff lint + format clean, MyPy strict clean
- Cyclomatic complexity clean (all functions ≤ rank B)
- Per-file coverage gate green

## Test plan

- [x] `./scripts/check-all.sh` exit 0 locally
- [x] `creek compost calibrate --fixture tests/fixtures/compost-calibration.yaml --no-verifier --floor-recall 0.5 --floor-precision 0.5` runs and prints the table (verified via CLI integration tests)
- [ ] CI green
- [ ] LGTM

---
_Generated by [Claude Code](https://claude.ai/code/session_01JFvvez73NgeKgGyLyZM856)_