### PR TITLE
fix(config): honour CREEK_CONFIG env var and --config flag (#293)

### DIFF
--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -10,6 +10,7 @@ file — they must come from environment variables.
 """
 
 import logging
+import os
 from pathlib import Path
 from typing import Literal
 from zoneinfo import ZoneInfo
@@ -19,6 +20,15 @@ from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
+
+CONFIG_PATH_ENV_VAR = "CREEK_CONFIG"
+"""Environment variable that, when set, supplies the default config path.
+
+Honoured by :func:`load_config` when no explicit ``config_path``
+argument is given. Subprocess-friendly: any spawned process inherits
+the variable, so callers (e.g. CrawDad spawning ``creek-tools-mcp``)
+can keep the configured vault config discoverable regardless of cwd.
+"""
 
 
 class LLMConfig(BaseModel):
@@ -711,17 +721,36 @@ def load_config(
     expected (e.g. ``creek init`` runs before any config exists).
 
     Args:
-        config_path: Path to a ``creek_config.yaml`` file.  Defaults to
-            ``creek_config.yaml`` in the current directory.
+        config_path: Path to a ``creek_config.yaml`` file. When ``None``
+            (the default), :func:`load_config` consults the
+            ``CREEK_CONFIG`` environment variable; if that is unset or
+            empty, it falls back to ``creek_config.yaml`` in the
+            current directory.
         warn_on_missing: When ``True`` (default), log a WARNING if the
             file does not exist. Suppress for CLI commands that
             legitimately operate in the no-config state.
 
     Returns:
         A fully-validated ``CreekConfig`` instance.
+
+    Raises:
+        FileNotFoundError: When ``CREEK_CONFIG`` is set to a path that
+            does not exist. The explicit env var declares intent, so a
+            silent fallback to defaults would mask the misconfiguration.
     """
     if config_path is None:
-        config_path = Path("creek_config.yaml")
+        env_value = os.environ.get(CONFIG_PATH_ENV_VAR, "").strip()
+        if env_value:
+            config_path = Path(env_value)
+            if not config_path.exists():
+                msg = (
+                    f"{CONFIG_PATH_ENV_VAR} points to {config_path}, "
+                    "but no file exists there. Unset the environment "
+                    "variable or correct the path."
+                )
+                raise FileNotFoundError(msg)
+        else:
+            config_path = Path("creek_config.yaml")
 
     if config_path.exists():
         with config_path.open() as f:
@@ -732,10 +761,12 @@ def load_config(
         logger.warning(
             "Config file %s not found; running with built-in defaults. "
             "Run `creek init --vault <vault>` to write a starter config, "
-            "or pass --config <path> to point at one explicitly. "
-            "Pipeline behaviour (privacy, redaction, cleaning) depends on "
-            "this file — silent defaults are usually not what you want.",
+            "set %s to an absolute config path, or pass --config <path> "
+            "explicitly. Pipeline behaviour (privacy, redaction, "
+            "cleaning) depends on this file — silent defaults are "
+            "usually not what you want.",
             config_path,
+            CONFIG_PATH_ENV_VAR,
         )
     return CreekConfig()
 

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -13,12 +13,14 @@ point (``main``).
 
 from __future__ import annotations
 
+import argparse
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from mcp.server.fastmcp import FastMCP
 
-from creek.config import load_config
+from creek.config import CONFIG_PATH_ENV_VAR, load_config
 from creek_mcp.tier_ceiling import TierCeiling
 from creek_mcp.tools import (
     classify_tool,
@@ -42,7 +44,6 @@ from creek_mcp.tools.draft import draft_tool
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-    from pathlib import Path
 
 SERVER_NAME = "creek-tools-mcp"
 
@@ -382,8 +383,52 @@ def build_server(
     return server
 
 
-def main() -> None:
-    """Run the MCP server over stdio (entry point for ``creek-tools-mcp``)."""
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the ``creek-tools-mcp`` entry point.
+
+    Exposed as a helper so tests can drive parsing without invoking the
+    stdio loop.
+
+    Returns:
+        A configured :class:`argparse.ArgumentParser` accepting an
+        optional ``--config <path>`` flag.
+    """
+    parser = argparse.ArgumentParser(
+        prog="creek-tools-mcp",
+        description=(
+            "Creek MCP server (stdio transport). Pass --config to "
+            "pin a config file regardless of the working directory "
+            "the server is launched from."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=None,
+        help=(
+            "Path to creek_config.yaml. When supplied, sets "
+            f"{CONFIG_PATH_ENV_VAR} in the process environment so every "
+            "tool handler picks it up regardless of cwd."
+        ),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run the MCP server over stdio (entry point for ``creek-tools-mcp``).
+
+    Args:
+        argv: Optional list of command-line arguments. When ``None``
+            (the default for the production entry point), the parser
+            reads :data:`sys.argv`. Tests supply an explicit list to
+            avoid mutating the process state.
+    """
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    if args.config is not None:
+        if not args.config.exists():
+            parser.error(f"--config: file not found: {args.config}")
+        os.environ[CONFIG_PATH_ENV_VAR] = str(args.config.resolve())
     build_server().run(transport="stdio")
 
 

--- a/creek-tools/tests/test_config.py
+++ b/creek-tools/tests/test_config.py
@@ -6,6 +6,7 @@ import pytest
 import yaml
 
 from creek.config import (
+    CONFIG_PATH_ENV_VAR,
     ChatbotCleaningConfig,
     ClassificationConfig,
     CleaningConfig,
@@ -512,6 +513,79 @@ class TestLoadConfig:
         # Unspecified sub-configs keep defaults
         assert cfg.cleaning.chatbot.filter_system_prompts is True
         assert cfg.cleaning.hygiene.staleness_days == 90
+
+
+class TestLoadConfigEnvVar:
+    """Tests for the ``CREEK_CONFIG`` env-var discovery path (INC-008)."""
+
+    def test_uses_creek_config_env_var(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """``CREEK_CONFIG`` is honoured when ``config_path`` is None."""
+        config_file = tmp_path / "vault-config.yaml"
+        config_file.write_text(yaml.dump({"timezone": "UTC"}))
+        monkeypatch.setenv(CONFIG_PATH_ENV_VAR, str(config_file))
+        # Ensure cwd has no fallback creek_config.yaml that could mask the env var.
+        monkeypatch.chdir(tmp_path)
+
+        cfg = load_config()
+        assert cfg.timezone == "UTC"
+
+    def test_explicit_config_path_overrides_env_var(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """An explicit ``config_path`` argument wins over the env var."""
+        env_file = tmp_path / "from-env.yaml"
+        env_file.write_text(yaml.dump({"timezone": "UTC"}))
+        cli_file = tmp_path / "from-cli.yaml"
+        cli_file.write_text(yaml.dump({"timezone": "Europe/London"}))
+        monkeypatch.setenv(CONFIG_PATH_ENV_VAR, str(env_file))
+
+        cfg = load_config(cli_file)
+        assert cfg.timezone == "Europe/London"
+
+    def test_env_var_pointing_to_missing_file_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A missing ``CREEK_CONFIG`` target raises rather than falling back."""
+        missing = tmp_path / "does-not-exist.yaml"
+        monkeypatch.setenv(CONFIG_PATH_ENV_VAR, str(missing))
+
+        with pytest.raises(FileNotFoundError, match=CONFIG_PATH_ENV_VAR):
+            load_config()
+
+    def test_empty_env_var_falls_through_to_cwd_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """An empty (or whitespace) env var behaves as if unset."""
+        monkeypatch.setenv(CONFIG_PATH_ENV_VAR, "   ")
+        monkeypatch.chdir(tmp_path)
+
+        cfg = load_config()
+        # No creek_config.yaml in tmp_path → defaults populated.
+        assert cfg.timezone == "America/Los_Angeles"
+
+    def test_unset_env_var_uses_cwd_default(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """When the env var is unset, behaviour matches the historical contract."""
+        monkeypatch.delenv(CONFIG_PATH_ENV_VAR, raising=False)
+        config_file = tmp_path / "creek_config.yaml"
+        config_file.write_text(yaml.dump({"timezone": "Asia/Tokyo"}))
+        monkeypatch.chdir(tmp_path)
+
+        cfg = load_config()
+        assert cfg.timezone == "Asia/Tokyo"
 
 
 # ---------------------------------------------------------------------------

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -295,5 +296,77 @@ def test_main_invokes_server_run(monkeypatch: pytest.MonkeyPatch) -> None:
             runs.append((transport,))
 
     monkeypatch.setattr(server_module, "build_server", lambda: _StubServer())
-    server_module.main()
+    server_module.main([])
     assert runs == [("stdio",)]
+
+
+def test_main_config_flag_sets_env_var_before_build_server(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``--config <path>`` sets ``CREEK_CONFIG`` before tools register (INC-008)."""
+    from creek.config import CONFIG_PATH_ENV_VAR
+    from creek_mcp import server as server_module
+
+    config_file = tmp_path / "vault-config.yaml"
+    config_file.write_text("timezone: UTC\n")
+    monkeypatch.delenv(CONFIG_PATH_ENV_VAR, raising=False)
+
+    captured_env: dict[str, str | None] = {}
+
+    class _StubServer:
+        def run(self, transport: str) -> None:
+            del transport
+
+    def _capture_build() -> _StubServer:
+        captured_env[CONFIG_PATH_ENV_VAR] = os.environ.get(CONFIG_PATH_ENV_VAR)
+        return _StubServer()
+
+    monkeypatch.setattr(server_module, "build_server", _capture_build)
+    server_module.main(["--config", str(config_file)])
+
+    assert captured_env[CONFIG_PATH_ENV_VAR] == str(config_file.resolve())
+
+
+def test_main_config_flag_missing_file_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--config`` pointing at a missing file exits nonzero with a clear message."""
+    from creek_mcp import server as server_module
+
+    missing = tmp_path / "no-such-config.yaml"
+
+    # build_server must not be called when --config is invalid.
+    def _explode() -> object:  # pragma: no cover - asserts non-invocation
+        msg = "build_server should not run when --config is missing"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(server_module, "build_server", _explode)
+
+    with pytest.raises(SystemExit) as exc_info:
+        server_module.main(["--config", str(missing)])
+
+    assert exc_info.value.code != 0
+    err = capsys.readouterr().err
+    assert "file not found" in err.lower()
+
+
+def test_main_without_config_flag_leaves_env_var_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Omitting ``--config`` does not modify ``CREEK_CONFIG``."""
+    from creek.config import CONFIG_PATH_ENV_VAR
+    from creek_mcp import server as server_module
+
+    monkeypatch.delenv(CONFIG_PATH_ENV_VAR, raising=False)
+
+    class _StubServer:
+        def run(self, transport: str) -> None:
+            del transport
+
+    monkeypatch.setattr(server_module, "build_server", lambda: _StubServer())
+    server_module.main([])
+
+    assert CONFIG_PATH_ENV_VAR not in os.environ


### PR DESCRIPTION
## Summary
- Closes the MCP-server config-discovery gap surfaced as #293 (INC-008).
- `creek/config.py::load_config()` now consults the `CREEK_CONFIG` environment variable before falling back to `./creek_config.yaml`.
- `creek-tools-mcp` accepts a new `--config <path>` CLI flag that sets `CREEK_CONFIG` in the process environment before any tool handler registers.
- Both layers are complementary: the env var works for any subprocess that inherits it (the common CrawDad case), and the flag works for explicit launches outside any env-var context.

## Why
Without this, any subprocess launched outside the vault — most notably CrawDad spawning `creek-tools-mcp` from its own launch directory — silently fell back to built-in defaults (Ollama on localhost). Every LLM-driven MCP tool call then failed with *"Ollama not available at http://localhost:11434"*, producing opaque *"creek-tools is unreachable"* replies in Discord or runaway-loop fallbacks. The reproduction lives in the issue body.

## Behaviour
| Situation | Result |
| --- | --- |
| `CREEK_CONFIG` unset, no `creek_config.yaml` in cwd | Warn + use defaults (unchanged). |
| `CREEK_CONFIG` empty / whitespace | Treated as unset; cwd default path used. |
| `CREEK_CONFIG=/abs/path/to/existing.yaml` | Loaded. |
| `CREEK_CONFIG=/abs/path/to/missing.yaml` | `FileNotFoundError` — explicit intent is never silently masked. |
| `creek-tools-mcp --config /abs/path.yaml` | Sets `CREEK_CONFIG`, then starts the server. Missing path errors via argparse before `build_server()` is touched. |
| `creek-tools-mcp` (no flag) | Existing behaviour preserved; `CREEK_CONFIG` left untouched. |

## Tests
Added one new test class and four new tests:

- `tests/test_config.py::TestLoadConfigEnvVar` (5 tests): env-var honoured, explicit `config_path` wins over env, missing target raises, empty value falls through, unset uses cwd default.
- `tests/test_mcp_server.py`: `main()` sets `CREEK_CONFIG` before `build_server()` runs; `--config` to a missing path exits non-zero with a clear error; omitting `--config` leaves `CREEK_CONFIG` untouched; updated existing `test_main_invokes_server_run` to pass an explicit empty `argv` (the new test seam).

Local: ruff format clean, ruff check clean, focused pytest 22/22 passing.

## Out of scope
- Auto-discovery from a `--vault` flag (fragile; documented as out-of-scope in #293).
- Pre-existing mypy errors in `creek_mcp/server.py:92, 94, 183`: a rename of `_default_llm` → `default_llm` in `creek/compile/engine.py` left a stale import. Discovered while running typecheck for this PR but unrelated to the discovery fix; left for a separate small PR to keep this one tight.

## Test plan
- [ ] CI: ruff format / lint clean.
- [ ] CI: unit tests pass (the five new `load_config` env-var tests + three new MCP `main()` tests + updated `test_main_invokes_server_run`).
- [ ] CI: coverage stays ≥90% on changed code paths.
- [ ] Manual: launch CrawDad from any cwd outside the vault with `crawdad.yaml` declaring `mcp_server_command: [creek-tools-mcp, --config, /path/to/vault/creek_config.yaml]`; verify the "Config file not found" and "Ollama not available" warnings disappear and that real tool calls (`/crawdad checkin`, `/crawdad save`) succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)