### PR TITLE
chore(classify/llm): REFACTOR-001 LGTM follow-ups

### DIFF
--- a/creek-tools/creek/classify/llm/__init__.py
+++ b/creek-tools/creek/classify/llm/__init__.py
@@ -19,6 +19,12 @@ submodules — :mod:`prompts`, :mod:`providers`, :mod:`parsing`,
 changing any observable behaviour. This package's ``__init__`` is a
 thin re-export shim so existing imports
 (``from creek.classify.llm import …``) keep working.
+
+The underscore-prefixed names below (``_BIASED_DIMENSIONS``,
+``_parse_dosage`` etc.) are re-exported solely so that pre-refactor
+tests can keep monkey-patching them on the package namespace; they are
+deliberately absent from :data:`__all__` and are not part of the public
+API.
 """
 
 from __future__ import annotations
@@ -32,32 +38,26 @@ import time as time
 import httpx as httpx
 
 from creek.classify.llm.batch import BatchStats
-from creek.classify.llm.calibration import _BIASED_DIMENSIONS
+from creek.classify.llm.calibration import _BIASED_DIMENSIONS as _BIASED_DIMENSIONS
 from creek.classify.llm.orchestrator import (
     LLMClassificationResult,
     LLMClassifier,
 )
+from creek.classify.llm.parsing import _parse_dosage as _parse_dosage
+from creek.classify.llm.parsing import _parse_enum as _parse_enum
+from creek.classify.llm.parsing import _parse_optional_enum as _parse_optional_enum
 from creek.classify.llm.parsing import (
-    _parse_dosage,
-    _parse_enum,
-    _parse_optional_enum,
-    _split_reasoning_and_yaml,
-    _strip_code_fences,
+    _split_reasoning_and_yaml as _split_reasoning_and_yaml,
 )
+from creek.classify.llm.parsing import _strip_code_fences as _strip_code_fences
 from creek.classify.llm.prompts import CLASSIFICATION_PROMPT
 from creek.classify.llm.providers import ANTHROPIC_CLOUD_WARNING, AnthropicProvider
 
 __all__ = [
     "ANTHROPIC_CLOUD_WARNING",
     "CLASSIFICATION_PROMPT",
-    "_BIASED_DIMENSIONS",
     "AnthropicProvider",
     "BatchStats",
     "LLMClassificationResult",
     "LLMClassifier",
-    "_parse_dosage",
-    "_parse_enum",
-    "_parse_optional_enum",
-    "_split_reasoning_and_yaml",
-    "_strip_code_fences",
 ]

--- a/creek-tools/creek/classify/llm/orchestrator.py
+++ b/creek-tools/creek/classify/llm/orchestrator.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING
 import httpx
 import yaml
 
-from creek.classify.llm import providers
 from creek.classify.llm.batch import run_batch
 from creek.classify.llm.calibration import _apply_wavelength
 from creek.classify.llm.parsing import (
@@ -29,6 +28,8 @@ from creek.classify.llm.prompts import build_classification_prompt
 from creek.classify.llm.providers import (
     ANTHROPIC_CLOUD_WARNING,
     AnthropicProvider,
+    call_ollama,
+    check_ollama_available,
 )
 
 if TYPE_CHECKING:
@@ -129,7 +130,7 @@ class LLMClassifier:
         """
         if self.config.provider == self.ANTHROPIC_PROVIDER:
             return self._check_anthropic_availability()
-        return providers.check_ollama_available(
+        return check_ollama_available(
             self.config,
             timeout=self.AVAILABILITY_TIMEOUT,
         )
@@ -219,7 +220,7 @@ class LLMClassifier:
             httpx.HTTPStatusError: On HTTP error responses.
             httpx.HTTPError: On connection or transport errors.
         """
-        return providers.call_ollama(
+        return call_ollama(
             self.config,
             prompt,
             timeout=self.REQUEST_TIMEOUT,

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -48,7 +48,7 @@ class AnthropicProvider:
         config: The LLM configuration specifying model, batch size, etc.
     """
 
-    DEFAULT_MODEL: str = "claude-sonnet-4-5-20250929"
+    DEFAULT_MODEL: str = "claude-sonnet-4-6"
     """Default Anthropic model when the config does not override it."""
 
     API_KEY_ENV: str = "ANTHROPIC_API_KEY"

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -1171,13 +1171,13 @@ class TestAnthropicProviderModel:
         provider = AnthropicProvider(config)
         assert provider.model == "claude-custom-model"
 
-    def test_default_model_is_claude_sonnet_4_5(
+    def test_default_model_is_claude_sonnet_4_6(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The default model should be the documented Claude Sonnet 4.5."""
+        """The default model should be the documented Claude Sonnet 4.6."""
         _set_anthropic_env(monkeypatch)
-        assert AnthropicProvider.DEFAULT_MODEL == "claude-sonnet-4-5-20250929"
+        assert AnthropicProvider.DEFAULT_MODEL == "claude-sonnet-4-6"
 
 
 class TestAnthropicProviderCall:

--- a/docs/Ontology/creek_ontology_agent_prompt.md
+++ b/docs/Ontology/creek_ontology_agent_prompt.md
@@ -904,13 +904,13 @@ llm:
   # Cloud API is available as an explicit opt-in for higher-quality classification,
   # but sends your fragments to a third-party server. Use with awareness.
   provider: ollama  # ollama (local, default) | anthropic | openai
-  model: mistral    # for ollama; or claude-sonnet-4-5-20250929 for anthropic
+  model: mistral    # for ollama; or claude-sonnet-4-6 for anthropic
   ollama_url: "http://localhost:11434"
   batch_size: 50
   max_concurrent: 5
   # To enable cloud classification (opt-in, sends data externally):
   # provider: anthropic
-  # model: claude-sonnet-4-5-20250929
+  # model: claude-sonnet-4-6
   # api_key_env: ANTHROPIC_API_KEY  # read from environment variable, never stored in config
 
 embeddings:


### PR DESCRIPTION
## Summary

Bundles the three non-blocking code-quality items from Claude's LGTM review of PR #297 (REFACTOR-001). Each is a one-liner in a different file of the same package, so they ride together rather than as three separate PRs.

- **#299** — `creek/classify/llm/__init__.py`: drop the six underscore-prefixed names from `__all__` so the public-API list stops advertising private symbols. The re-exports themselves stay (now via `as`-aliased imports so vulture/ruff treat them as deliberate re-exports), so existing `from creek.classify.llm import _parse_enum` test patches continue to work — they just no longer masquerade as public API. The module docstring picks up a short note explaining the carve-out.
- **#300** — `creek/classify/llm/orchestrator.py`: collapse the duplicate `providers` import. `call_ollama` and `check_ollama_available` now come in by name alongside `ANTHROPIC_CLOUD_WARNING` / `AnthropicProvider`; the two call sites (`_check_availability`, `_call_ollama`) use the bare names.
- **#301** — `creek/classify/llm/providers.py`: bump `AnthropicProvider.DEFAULT_MODEL` from the pinned Sonnet 4.5 alias (`claude-sonnet-4-5-20250929`) to `claude-sonnet-4-6` so a default-config Anthropic run picks up the current Sonnet generation. The matching assertion in `tests/test_classify.py::TestAnthropicProviderModel::test_default_model_is_claude_sonnet_4_6` and the two example-config references in `docs/Ontology/creek_ontology_agent_prompt.md` are updated in lockstep.

No behaviour change beyond the model bump. The provider-availability and parsing tests already cover the orchestrator call sites and the package shim, so the existing unit suite exercises every touched path.

## Test plan

- [x] `./scripts/check-all.sh` exits 0 (12/12 gates green; 3,903 unit tests pass; 93.9% coverage).
- [x] `tests/test_classify.py::TestAnthropicProviderModel::test_default_model_is_claude_sonnet_4_6` asserts the new alias.
- [x] `tests/test_classify.py` continues to import `_parse_dosage`, `_parse_enum`, `_parse_optional_enum`, `_strip_code_fences`, and `_BIASED_DIMENSIONS` from `creek.classify.llm` (back-compat re-exports preserved).
- [x] `grep -r 'claude-sonnet-4-5-20250929'` returns no remaining hits in code or docs after the bump.

Closes #299
Closes #300
Closes #301

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFVPgsi28yuibHwYMXGUQn)_