### PR TITLE
feat(classify): align CLASSIFICATION_PROMPT frequency names with spec (#298)

### DIFF
--- a/creek-tools/creek/classify/llm/prompts.py
+++ b/creek-tools/creek/classify/llm/prompts.py
@@ -11,10 +11,43 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from creek.classify import few_shot
+from creek.generate.indexes import CANONICAL_FREQUENCY_NAMES, FREQUENCY_THEMES
+from creek.models import Frequency
 
 if TYPE_CHECKING:
     from creek.config import LLMConfig
     from creek.models import Fragment
+
+
+def _build_frequency_block() -> str:
+    """Render the frequency dimension lines for the classification prompt.
+
+    Pairs each canonical APTITUDE name (per §6.1 of the ontology spec)
+    with the matching Core Theme gloss. Sourcing the glosses from
+    :data:`creek.generate.indexes.FREQUENCY_THEMES` and the names from
+    :data:`creek.generate.indexes.CANONICAL_FREQUENCY_NAMES` keeps the
+    prompt header in lockstep with the rest of the toolchain — see
+    ONTOLOGY-001 / ONTOLOGY-002 and the
+    ``docs/decisions/2026-05-23-frequency-naming.md`` record.
+
+    Returns:
+        A newline-joined list of indented ``- F<n>: Name — Gloss`` lines
+        ready for substitution into :data:`CLASSIFICATION_PROMPT`.
+    """
+    lines = [
+        (
+            f"   - {freq.value}: {CANONICAL_FREQUENCY_NAMES[freq]}"
+            f" — {FREQUENCY_THEMES[freq]}"
+        )
+        for freq in Frequency
+        if freq is not Frequency.UNCLASSIFIED
+    ]
+    return "\n".join(lines)
+
+
+_FREQUENCY_BLOCK: str = _build_frequency_block()
+"""Pre-rendered frequency-dimension lines baked into the prompt template."""
+
 
 CLASSIFICATION_PROMPT: str = """\
 You are a classification assistant for the Creek knowledge organization system.
@@ -22,10 +55,7 @@ You are a classification assistant for the Creek knowledge organization system.
 Given a fragment of content, classify it along the following dimensions:
 
 1. **Frequency** (APTITUDE F1-F10): Which frequency best describes the content?
-   - F1: Survival/Safety, F2: Belonging/Tribe, F3: Power/Agency,
-   - F4: Order/Structure, F5: Achievement/Strategy, F6: Community/Empathy,
-   - F7: Systems/Integration, F8: Holistic/Ecology, F9: Witness/Being,
-   - F10: Unity/Non-dual
+__FREQUENCY_BLOCK__
 
 2. **Wavelength Phase**: rising, peaking, withdrawal, diminishing, \
 bottoming_out, restoration
@@ -82,7 +112,7 @@ so calibrate honestly.
 Fragment title: {title}
 Fragment content:
 {content}
-"""
+""".replace("__FREQUENCY_BLOCK__", _FREQUENCY_BLOCK)
 """Prompt template for two-step LLM-based fragment classification (FEAT-017).
 
 Placeholders:

--- a/creek-tools/creek/generate/indexes.py
+++ b/creek-tools/creek/generate/indexes.py
@@ -29,6 +29,26 @@ FREQUENCY_NAMES: dict[Frequency, str] = {
 }
 """Mapping from Frequency enum values to human-readable APTITUDE names."""
 
+CANONICAL_FREQUENCY_NAMES: dict[Frequency, str] = {
+    Frequency.F1: "Agency",
+    Frequency.F2: "Receptivity",
+    Frequency.F3: "Self-Love / Power",
+    Frequency.F4: "Community Love / Conformity",
+    Frequency.F5: "Achievism",
+    Frequency.F6: "Pluralism",
+    Frequency.F7: "Integration",
+    Frequency.F8: "True Self / Transcendence",
+    Frequency.F9: "Unity",
+    Frequency.F10: "Emptiness",
+}
+"""Canonical APTITUDE frequency names from §6.1 of the ontology spec.
+
+Single source of truth for the names the LLM classifier sees and that
+the decision record (``docs/decisions/2026-05-23-frequency-naming.md``)
+ratifies. Distinct from :data:`FREQUENCY_NAMES`, which carries
+slash-joined display labels for vault index notes.
+"""
+
 FREQUENCY_COLORS: dict[Frequency, str] = {
     Frequency.F1: "beige",
     Frequency.F2: "purple",

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -501,9 +501,9 @@ class TestClassificationPrompt:
             "Witness/Being",
             "Unity/Non-dual",
         ):
-            assert (
-                drifted not in CLASSIFICATION_PROMPT
-            ), f"Pre-ONTOLOGY-002 drift {drifted!r} should not appear in prompt"
+            assert drifted not in CLASSIFICATION_PROMPT, (
+                f"Pre-ONTOLOGY-002 drift {drifted!r} should not appear in prompt"
+            )
 
     def test_frequency_lines_include_core_theme_glosses(self) -> None:
         """Each canonical name should be paired with its Core Theme gloss.

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -467,6 +467,58 @@ class TestClassificationPrompt:
         assert "{title}" in CLASSIFICATION_PROMPT
         assert "{content}" in CLASSIFICATION_PROMPT
 
+    def test_uses_canonical_frequency_names(self) -> None:
+        """ONTOLOGY-002: the prompt names every frequency per spec §6.1.
+
+        Drift in any of these labels — historically ``F2: Belonging/Tribe``
+        or ``F8: Holistic/Ecology`` — would silently contradict the
+        bundled few-shot rationales and erode classifier agreement on
+        every call. This regression guards the prompt against returning
+        to drifted glosses.
+        """
+        assert "F1: Agency" in CLASSIFICATION_PROMPT
+        assert "F2: Receptivity" in CLASSIFICATION_PROMPT
+        assert "F3: Self-Love / Power" in CLASSIFICATION_PROMPT
+        assert "F4: Community Love / Conformity" in CLASSIFICATION_PROMPT
+        assert "F5: Achievism" in CLASSIFICATION_PROMPT
+        assert "F6: Pluralism" in CLASSIFICATION_PROMPT
+        assert "F7: Integration" in CLASSIFICATION_PROMPT
+        assert "F8: True Self / Transcendence" in CLASSIFICATION_PROMPT
+        assert "F9: Unity" in CLASSIFICATION_PROMPT
+        assert "F10: Emptiness" in CLASSIFICATION_PROMPT
+
+    def test_excludes_pre_ontology_001_drifted_glosses(self) -> None:
+        """The pre-ONTOLOGY-002 drifted glosses must not reappear in the prompt."""
+        for drifted in (
+            "Survival/Safety",
+            "Belonging/Tribe",
+            "Power/Agency",
+            "Order/Structure",
+            "Achievement/Strategy",
+            "Community/Empathy",
+            "Systems/Integration",
+            "Holistic/Ecology",
+            "Witness/Being",
+            "Unity/Non-dual",
+        ):
+            assert (
+                drifted not in CLASSIFICATION_PROMPT
+            ), f"Pre-ONTOLOGY-002 drift {drifted!r} should not appear in prompt"
+
+    def test_frequency_lines_include_core_theme_glosses(self) -> None:
+        """Each canonical name should be paired with its Core Theme gloss.
+
+        The glosses are pulled from
+        :data:`creek.generate.indexes.FREQUENCY_THEMES`; this assertion
+        spot-checks that the prompt actually carries them rather than
+        leaving the model with bare labels.
+        """
+        from creek.generate.indexes import FREQUENCY_THEMES
+
+        assert FREQUENCY_THEMES[Frequency.F1] in CLASSIFICATION_PROMPT
+        assert FREQUENCY_THEMES[Frequency.F8] in CLASSIFICATION_PROMPT
+        assert FREQUENCY_THEMES[Frequency.F10] in CLASSIFICATION_PROMPT
+
 
 # ---- Validate Response ----
 


### PR DESCRIPTION
## Summary

ONTOLOGY-002 (closes #298): The inline `CLASSIFICATION_PROMPT` in
`creek/classify/llm/prompts.py` still named F1-F10 with the pre-ONTOLOGY-001
glosses (`F2: Belonging/Tribe`, `F8: Holistic/Ecology`, …) — a contradiction
the LLM saw on every classifier call because the bundled few-shot rationales
in the same prompt already used the canonical names (Receptivity, True Self
/ Transcendence, …) per the §6.1 spec and PR #294.

- **`creek/classify/llm/prompts.py`** — rewrite the Frequency dimension
  block from drifted glosses to canonical APTITUDE names paired with the
  Core Theme one-liner so the model still sees discriminating texture, not
  just a label.
- **`creek/generate/indexes.py`** — add `CANONICAL_FREQUENCY_NAMES` next to
  the existing `FREQUENCY_THEMES` so both the name and the gloss have a
  single source of truth (the prompt imports both). Distinct from the
  pre-existing slash-joined `FREQUENCY_NAMES` used for vault index-note
  titles.
- **`tests/test_classify.py`** — extend `TestClassificationPrompt` with
  three regressions: (1) the prompt names every frequency with the
  canonical name from §6.1, (2) none of the pre-ONTOLOGY-002 drifted
  glosses reappear, and (3) the per-frequency Core Theme gloss is present
  so a future refactor cannot silently strip the discriminating texture.

## Test plan

- [x] `./scripts/check-all.sh` — all 12 gates green (3906 tests passing,
  93.90% coverage).
- [x] `uv run pytest tests/test_classify.py::TestClassificationPrompt -v`
  — all 7 prompt tests pass, including the three new regressions.
- [x] Verified rendered prompt by importing `CLASSIFICATION_PROMPT` and
  printing — every line uses the canonical name + Core Theme.
- [ ] **Acceptance gate deferred to CI / a real LLM environment**:
  `creek classify --calibrate --enforce-floors` against
  `tests/fixtures/classification/calibration_set.yaml` cannot be run in
  this sandbox (no Ollama daemon, no Anthropic key + consent). The 0%
  rate seen locally is "LLM unavailable → fragment returned unchanged",
  not a real `frequency` floor regression. The issue's acceptance
  criterion anticipates this: if the rename does regress the floor on a
  real run, file a sub-issue to re-baseline or tune.

No calibration fixture was touched (PR #294 already aligned it under
ONTOLOGY-001).

Closes #298

---
_Generated by [Claude Code](https://claude.ai/code/session_01Awa3eD4CnTMhooaPoEPkfg)_