### PR TITLE
feat(crawdad): MIME-type verification for Discord attachments (FEAT-035, #285)

### DIFF
--- a/crawdad/crawdad/attachments.py
+++ b/crawdad/crawdad/attachments.py
@@ -81,56 +81,69 @@ _EXTENSION_TO_INGESTOR_TYPE: dict[str, str] = {
     ".webp": "image",
 }
 
-# FEAT-035: extensions whose declared content type can be verified by
-# ``filetype.guess`` against the first kilobyte of the downloaded body.
-# Each entry lists every MIME string the library may legitimately return
-# for that extension — OOXML containers, for example, are zip files at
-# the byte level so ``filetype`` correctly reports ``application/zip``
-# unless the runtime libmagic version has dedicated OOXML detection.
-_EXTENSION_TO_ACCEPTABLE_MIMES: dict[str, frozenset[str]] = {
-    ".pdf": frozenset({"application/pdf"}),
-    ".png": frozenset({"image/png"}),
-    ".jpg": frozenset({"image/jpeg"}),
-    ".jpeg": frozenset({"image/jpeg"}),
-    ".gif": frozenset({"image/gif"}),
-    ".webp": frozenset({"image/webp"}),
-    ".docx": frozenset(
-        {
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            "application/zip",
-        }
-    ),
-    ".xlsx": frozenset(
-        {
-            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            "application/zip",
-        }
-    ),
-    ".pptx": frozenset(
-        {
-            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-            "application/zip",
-        }
-    ),
-}
 
-# Canonical (first-choice) MIME per extension — used as the ``expected``
-# label in the verification report. Order does not matter for the
-# membership check; this lookup is purely cosmetic so the user-facing
-# summary names the format they probably recognise.
-_EXTENSION_TO_CANONICAL_MIME: dict[str, str] = {
-    ".pdf": "application/pdf",
-    ".png": "image/png",
-    ".jpg": "image/jpeg",
-    ".jpeg": "image/jpeg",
-    ".gif": "image/gif",
-    ".webp": "image/webp",
-    ".docx": (
-        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+# FEAT-035: per-extension MIME contract for the binary-signature
+# verifier. ``canonical`` is the MIME string surfaced to the user as the
+# expected type; ``acceptable`` is the set of MIME strings any of which
+# ``filetype.guess`` may legitimately return for that extension — OOXML
+# containers, for example, are zip files at the byte level, so
+# ``filetype`` correctly reports ``application/zip`` unless the runtime
+# library has dedicated OOXML detection. Bundling both fields under one
+# key prevents the canonical/acceptable maps drifting out of sync (an
+# unchecked second lookup would raise ``KeyError`` at runtime today
+# rather than ``ImportError`` at module load).
+@dataclass(frozen=True)
+class _ExtensionMimeSpec:
+    """Per-extension MIME contract for the binary verifier."""
+
+    canonical: str
+    acceptable: frozenset[str]
+
+
+_OOXML_DOCX_MIME = (
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+)
+_OOXML_XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+_OOXML_PPTX_MIME = (
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+)
+
+_EXTENSION_MIME_SPECS: dict[str, _ExtensionMimeSpec] = {
+    ".pdf": _ExtensionMimeSpec(
+        canonical="application/pdf",
+        acceptable=frozenset({"application/pdf"}),
     ),
-    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-    ".pptx": (
-        "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    ".png": _ExtensionMimeSpec(
+        canonical="image/png",
+        acceptable=frozenset({"image/png"}),
+    ),
+    ".jpg": _ExtensionMimeSpec(
+        canonical="image/jpeg",
+        acceptable=frozenset({"image/jpeg"}),
+    ),
+    ".jpeg": _ExtensionMimeSpec(
+        canonical="image/jpeg",
+        acceptable=frozenset({"image/jpeg"}),
+    ),
+    ".gif": _ExtensionMimeSpec(
+        canonical="image/gif",
+        acceptable=frozenset({"image/gif"}),
+    ),
+    ".webp": _ExtensionMimeSpec(
+        canonical="image/webp",
+        acceptable=frozenset({"image/webp"}),
+    ),
+    ".docx": _ExtensionMimeSpec(
+        canonical=_OOXML_DOCX_MIME,
+        acceptable=frozenset({_OOXML_DOCX_MIME, "application/zip"}),
+    ),
+    ".xlsx": _ExtensionMimeSpec(
+        canonical=_OOXML_XLSX_MIME,
+        acceptable=frozenset({_OOXML_XLSX_MIME, "application/zip"}),
+    ),
+    ".pptx": _ExtensionMimeSpec(
+        canonical=_OOXML_PPTX_MIME,
+        acceptable=frozenset({_OOXML_PPTX_MIME, "application/zip"}),
     ),
 }
 
@@ -139,27 +152,32 @@ _EXTENSION_TO_CANONICAL_MIME: dict[str, str] = {
 # in this set are expected to be plain text, so a NUL byte or undecodable
 # bytes in the first ``_TEXT_SAMPLE_BYTES`` of the body are treated as
 # evidence that the file is actually a binary blob renamed to a text
-# extension (the polyglot case the issue calls out).
-_TEXT_EXTENSIONS: frozenset[str] = frozenset(
-    {
-        ".md",
-        ".markdown",
-        ".txt",
-        ".html",
-        ".htm",
-        ".json",
-        ".csv",
-    }
-)
+# extension (the polyglot case the issue calls out). The dict carries
+# the canonical text MIME per extension so a successful match surfaces
+# the right label (``text/markdown`` for ``.md``, ``application/json``
+# for ``.json``, etc.) instead of a generic ``text/plain`` blanket.
+#
+# This path is heuristic — see ADR-0002 §"Negative" for the false-
+# negative surface and future hardening directions (tolerant HTML
+# parser, full JSON round-trip for ``.json``).
+_TEXT_EXTENSION_TO_MIME: dict[str, str] = {
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
+    ".txt": "text/plain",
+    ".html": "text/html",
+    ".htm": "text/html",
+    ".json": "application/json",
+    ".csv": "text/csv",
+}
+_TEXT_EXTENSIONS: frozenset[str] = frozenset(_TEXT_EXTENSION_TO_MIME)
 
 # Sample size for the text-content heuristic. One kilobyte is enough to
 # catch every common binary header (PE / ELF / OLE / PDF / ZIP) without
 # materially extending the download path's CPU cost.
 _TEXT_SAMPLE_BYTES: int = 1024
 
-# Canonical MIME strings used by the text path so the Discord reply
-# names something meaningful when a sample fails the heuristic.
-_TEXT_CANONICAL_MIME: str = "text/plain"
+# Canonical MIME the text verifier uses when it has to label something
+# as binary (NUL bytes or invalid UTF-8 in the sample window).
 _BINARY_CANONICAL_MIME: str = "application/octet-stream"
 
 MimeStatus = Literal["match", "mismatch", "unknown"]
@@ -220,50 +238,51 @@ def verify_mime_type(filename: str, data: bytes) -> MimeVerification:
         to warn or skip the soft-error path.
     """
     suffix = Path(filename).suffix.lower()
-    if suffix in _TEXT_EXTENSIONS:
-        return _verify_text_sample(data)
-    if suffix in _EXTENSION_TO_ACCEPTABLE_MIMES:
+    if suffix in _TEXT_EXTENSION_TO_MIME:
+        return _verify_text_sample(suffix, data)
+    if suffix in _EXTENSION_MIME_SPECS:
         return _verify_binary_signature(suffix, data)
     return _UNKNOWN_VERIFICATION
 
 
 def _verify_binary_signature(suffix: str, data: bytes) -> MimeVerification:
     """Run ``filetype.guess`` against *data* and compare to *suffix*'s claim."""
+    spec = _EXTENSION_MIME_SPECS[suffix]
     guess = filetype.guess(data)
     detected = guess.mime if guess is not None else None
-    acceptable = _EXTENSION_TO_ACCEPTABLE_MIMES[suffix]
-    expected = _EXTENSION_TO_CANONICAL_MIME[suffix]
-    if detected is not None and detected in acceptable:
+    if detected is not None and detected in spec.acceptable:
         return MimeVerification(
-            status="match", detected_mime=detected, expected_mime=expected
+            status="match", detected_mime=detected, expected_mime=spec.canonical
         )
     return MimeVerification(
-        status="mismatch", detected_mime=detected, expected_mime=expected
+        status="mismatch", detected_mime=detected, expected_mime=spec.canonical
     )
 
 
-def _verify_text_sample(data: bytes) -> MimeVerification:
+def _verify_text_sample(suffix: str, data: bytes) -> MimeVerification:
     """Sample-check that *data* is plausibly UTF-8 text with no NUL bytes."""
+    expected = _TEXT_EXTENSION_TO_MIME[suffix]
     sample = data[:_TEXT_SAMPLE_BYTES]
-    if b"\x00" in sample:
+    if b"\x00" in sample or not _decodes_as_utf8(sample):
         return MimeVerification(
             status="mismatch",
             detected_mime=_BINARY_CANONICAL_MIME,
-            expected_mime=_TEXT_CANONICAL_MIME,
-        )
-    try:
-        sample.decode("utf-8")
-    except UnicodeDecodeError:
-        return MimeVerification(
-            status="mismatch",
-            detected_mime=_BINARY_CANONICAL_MIME,
-            expected_mime=_TEXT_CANONICAL_MIME,
+            expected_mime=expected,
         )
     return MimeVerification(
         status="match",
-        detected_mime=_TEXT_CANONICAL_MIME,
-        expected_mime=_TEXT_CANONICAL_MIME,
+        detected_mime=expected,
+        expected_mime=expected,
     )
+
+
+def _decodes_as_utf8(sample: bytes) -> bool:
+    """Return ``True`` when *sample* is fully decodable as UTF-8."""
+    try:
+        sample.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
 
 
 class _AttachmentLike(Protocol):

--- a/crawdad/crawdad/attachments.py
+++ b/crawdad/crawdad/attachments.py
@@ -1,4 +1,4 @@
-"""Discord attachment handling (FEAT-027).
+"""Discord attachment handling (FEAT-027 + FEAT-035).
 
 CrawDad's promise is *"Discord is the door you already use."* FEAT-027
 closes the gap that prevented attachments from flowing through that
@@ -7,6 +7,14 @@ staging directory under the vault, enforces configurable per-attachment
 size + extension limits, applies idempotency, infers an ingestor type
 from the file extension, and surfaces a human-readable summary suitable
 for embedding in a Discord reply.
+
+FEAT-035 adds magic-byte content-type verification on top of the
+extension allow list: after a successful download every attachment is
+sniffed with :mod:`filetype` (binary signatures) or with a UTF-8 +
+NUL-byte content sample (text formats), and the detected MIME is
+compared against what the extension claims. Mismatches surface in the
+safety report by default; the :attr:`AttachmentConfig.reject_on_mime_mismatch`
+knob flips the soft warning into a hard rejection.
 
 The module is deliberately UI- and MCP-agnostic. The bot handler is
 responsible for calling :func:`process_attachments` once attachments are
@@ -23,7 +31,9 @@ import logging
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol
+
+import filetype
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -70,6 +80,190 @@ _EXTENSION_TO_INGESTOR_TYPE: dict[str, str] = {
     ".gif": "image",
     ".webp": "image",
 }
+
+# FEAT-035: extensions whose declared content type can be verified by
+# ``filetype.guess`` against the first kilobyte of the downloaded body.
+# Each entry lists every MIME string the library may legitimately return
+# for that extension — OOXML containers, for example, are zip files at
+# the byte level so ``filetype`` correctly reports ``application/zip``
+# unless the runtime libmagic version has dedicated OOXML detection.
+_EXTENSION_TO_ACCEPTABLE_MIMES: dict[str, frozenset[str]] = {
+    ".pdf": frozenset({"application/pdf"}),
+    ".png": frozenset({"image/png"}),
+    ".jpg": frozenset({"image/jpeg"}),
+    ".jpeg": frozenset({"image/jpeg"}),
+    ".gif": frozenset({"image/gif"}),
+    ".webp": frozenset({"image/webp"}),
+    ".docx": frozenset(
+        {
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/zip",
+        }
+    ),
+    ".xlsx": frozenset(
+        {
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/zip",
+        }
+    ),
+    ".pptx": frozenset(
+        {
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+            "application/zip",
+        }
+    ),
+}
+
+# Canonical (first-choice) MIME per extension — used as the ``expected``
+# label in the verification report. Order does not matter for the
+# membership check; this lookup is purely cosmetic so the user-facing
+# summary names the format they probably recognise.
+_EXTENSION_TO_CANONICAL_MIME: dict[str, str] = {
+    ".pdf": "application/pdf",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".docx": (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    ),
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".pptx": (
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    ),
+}
+
+# FEAT-035: extensions that have no magic-byte signature. The verifier
+# falls back to a content sample (UTF-8 decode + NUL-byte check) — files
+# in this set are expected to be plain text, so a NUL byte or undecodable
+# bytes in the first ``_TEXT_SAMPLE_BYTES`` of the body are treated as
+# evidence that the file is actually a binary blob renamed to a text
+# extension (the polyglot case the issue calls out).
+_TEXT_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".md",
+        ".markdown",
+        ".txt",
+        ".html",
+        ".htm",
+        ".json",
+        ".csv",
+    }
+)
+
+# Sample size for the text-content heuristic. One kilobyte is enough to
+# catch every common binary header (PE / ELF / OLE / PDF / ZIP) without
+# materially extending the download path's CPU cost.
+_TEXT_SAMPLE_BYTES: int = 1024
+
+# Canonical MIME strings used by the text path so the Discord reply
+# names something meaningful when a sample fails the heuristic.
+_TEXT_CANONICAL_MIME: str = "text/plain"
+_BINARY_CANONICAL_MIME: str = "application/octet-stream"
+
+MimeStatus = Literal["match", "mismatch", "unknown"]
+
+
+@dataclass(frozen=True)
+class MimeVerification:
+    """Result of comparing a downloaded body to its extension's claim.
+
+    Attributes:
+        status: ``"match"`` when the detected (or sampled) content type
+            agrees with the extension's claim; ``"mismatch"`` when they
+            disagree (the polyglot case the FEAT-035 issue calls out);
+            ``"unknown"`` when the extension is outside both the binary
+            signature table and the text-extension whitelist, so no
+            verification could be performed.
+        detected_mime: The MIME string the verifier observed. ``None``
+            when the binary path could not match a signature and the
+            extension was not on the text list — the verifier had
+            nothing concrete to report.
+        expected_mime: The MIME string the extension claims. ``None``
+            for the ``"unknown"`` status (no canonical claim exists).
+    """
+
+    status: MimeStatus
+    detected_mime: str | None
+    expected_mime: str | None
+
+    @property
+    def is_mismatch(self) -> bool:
+        """Return ``True`` when the verification flagged a content/extension drift."""
+        return self.status == "mismatch"
+
+
+_UNKNOWN_VERIFICATION: MimeVerification = MimeVerification(
+    status="unknown",
+    detected_mime=None,
+    expected_mime=None,
+)
+
+
+def verify_mime_type(filename: str, data: bytes) -> MimeVerification:
+    """Verify *data*'s content type against *filename*'s extension claim.
+
+    Args:
+        filename: The original (raw) attachment filename. Only the
+            lowercased suffix is consulted.
+        data: The downloaded body. The verifier looks at the first
+            :data:`_TEXT_SAMPLE_BYTES` bytes for the text-extension path
+            and hands the whole buffer to :mod:`filetype` for the
+            binary path — ``filetype`` reads only the leading bytes it
+            needs, so passing the full body is cheap.
+
+    Returns:
+        A :class:`MimeVerification` describing the outcome. Extensions
+        outside the verifiable allow list return
+        :data:`_UNKNOWN_VERIFICATION` so the caller can decide whether
+        to warn or skip the soft-error path.
+    """
+    suffix = Path(filename).suffix.lower()
+    if suffix in _TEXT_EXTENSIONS:
+        return _verify_text_sample(data)
+    if suffix in _EXTENSION_TO_ACCEPTABLE_MIMES:
+        return _verify_binary_signature(suffix, data)
+    return _UNKNOWN_VERIFICATION
+
+
+def _verify_binary_signature(suffix: str, data: bytes) -> MimeVerification:
+    """Run ``filetype.guess`` against *data* and compare to *suffix*'s claim."""
+    guess = filetype.guess(data)
+    detected = guess.mime if guess is not None else None
+    acceptable = _EXTENSION_TO_ACCEPTABLE_MIMES[suffix]
+    expected = _EXTENSION_TO_CANONICAL_MIME[suffix]
+    if detected is not None and detected in acceptable:
+        return MimeVerification(
+            status="match", detected_mime=detected, expected_mime=expected
+        )
+    return MimeVerification(
+        status="mismatch", detected_mime=detected, expected_mime=expected
+    )
+
+
+def _verify_text_sample(data: bytes) -> MimeVerification:
+    """Sample-check that *data* is plausibly UTF-8 text with no NUL bytes."""
+    sample = data[:_TEXT_SAMPLE_BYTES]
+    if b"\x00" in sample:
+        return MimeVerification(
+            status="mismatch",
+            detected_mime=_BINARY_CANONICAL_MIME,
+            expected_mime=_TEXT_CANONICAL_MIME,
+        )
+    try:
+        sample.decode("utf-8")
+    except UnicodeDecodeError:
+        return MimeVerification(
+            status="mismatch",
+            detected_mime=_BINARY_CANONICAL_MIME,
+            expected_mime=_TEXT_CANONICAL_MIME,
+        )
+    return MimeVerification(
+        status="match",
+        detected_mime=_TEXT_CANONICAL_MIME,
+        expected_mime=_TEXT_CANONICAL_MIME,
+    )
 
 
 class _AttachmentLike(Protocol):
@@ -122,6 +316,10 @@ class AcceptedAttachment:
             file extension, or ``None`` when the extension is unknown.
         already_present: ``True`` when an identical file existed at the
             staged path before this download (idempotent re-upload).
+        mime_verification: FEAT-035 content-type check result. Set to
+            :data:`_UNKNOWN_VERIFICATION` when verification was not
+            performed (extension outside the verifiable list, or the
+            file was rejected upstream before download).
     """
 
     filename: str
@@ -131,6 +329,7 @@ class AcceptedAttachment:
     content_hash: str
     inferred_type: str | None
     already_present: bool
+    mime_verification: MimeVerification = _UNKNOWN_VERIFICATION
 
 
 @dataclass(frozen=True)
@@ -368,6 +567,28 @@ async def _process_one(
             ),
         )
 
+    verification = verify_mime_type(attachment.filename, data)
+    if verification.is_mismatch and config.reject_on_mime_mismatch:
+        _LOGGER.info(
+            "rejecting attachment %r: MIME mismatch (expected %s, detected %s)",
+            attachment.filename,
+            verification.expected_mime,
+            verification.detected_mime,
+        )
+        return RejectedAttachment(
+            filename=attachment.filename,
+            size=len(data),
+            reason=_format_mime_mismatch_reason(verification),
+        )
+    if verification.is_mismatch:
+        _LOGGER.warning(
+            "MIME mismatch for attachment %r: extension claims %s, content "
+            "detected as %s (staging anyway; reject_on_mime_mismatch=False)",
+            attachment.filename,
+            verification.expected_mime,
+            verification.detected_mime,
+        )
+
     safe_name = sanitize_filename(attachment.filename)
     staging.mkdir(parents=True, exist_ok=True)
     target = staging / safe_name
@@ -395,7 +616,15 @@ async def _process_one(
         content_hash=content_hash,
         inferred_type=infer_ingestor_type(attachment.filename),
         already_present=already_present,
+        mime_verification=verification,
     )
+
+
+def _format_mime_mismatch_reason(verification: MimeVerification) -> str:
+    """Render a Discord-friendly rejection reason for a MIME mismatch."""
+    detected = verification.detected_mime or "unknown"
+    expected = verification.expected_mime or "unknown"
+    return f"MIME mismatch: extension claims {expected}, content detected as {detected}"
 
 
 def format_attachment_summary(
@@ -440,12 +669,33 @@ def format_attachment_summary(
             lines.append(
                 f"- `{a.filename}` — {_format_size(a.size)}, {type_hint}{marker}"
             )
+            mismatch_line = _format_mime_mismatch_warning(a.mime_verification)
+            if mismatch_line is not None:
+                lines.append(mismatch_line)
     if processed.rejected:
         lines.append("")
         lines.append("**Rejected:**")
         for r in processed.rejected:
             lines.append(f"- `{r.filename}` — {r.reason}")
     return "\n".join(lines)
+
+
+def _format_mime_mismatch_warning(verification: MimeVerification) -> str | None:
+    """Return a Discord-friendly soft-warning line, or ``None`` when not needed.
+
+    Only mismatches surface in the summary — the ``match`` and
+    ``unknown`` cases would only add noise. The warning indents under
+    the accepted-file bullet so the relationship reads clearly even
+    when several attachments are in the same batch.
+    """
+    if not verification.is_mismatch:
+        return None
+    detected = verification.detected_mime or "unknown"
+    expected = verification.expected_mime or "unknown"
+    return (
+        f"  - ⚠ MIME mismatch: extension claims `{expected}`, "
+        f"content detected as `{detected}`"
+    )
 
 
 def _format_size(num_bytes: int) -> str:

--- a/crawdad/crawdad/config.py
+++ b/crawdad/crawdad/config.py
@@ -27,6 +27,13 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 # the channel is on a boosted server.
 _DEFAULT_MAX_ATTACHMENT_BYTES: int = 25 * 1024 * 1024
 
+# FEAT-035: the default allow list is narrowed to extensions whose content
+# type can be verified — either by magic-byte signature (PDF, OOXML, common
+# images) or by text sampling (UTF-8 + no NUL bytes in the first KiB). The
+# pre-FEAT-035 list also accepted legacy Office formats (.doc/.xls/.ppt),
+# which the ``filetype`` library cannot reliably detect from magic bytes
+# and which carry an additional macro-execution risk. Operators who need
+# them can re-add the extensions in ``crawdad.yaml``.
 _DEFAULT_ALLOWED_EXTENSIONS: tuple[str, ...] = (
     ".md",
     ".markdown",
@@ -35,13 +42,10 @@ _DEFAULT_ALLOWED_EXTENSIONS: tuple[str, ...] = (
     ".htm",
     ".pdf",
     ".docx",
-    ".doc",
     ".json",
     ".csv",
     ".xlsx",
-    ".xls",
     ".pptx",
-    ".ppt",
     ".png",
     ".jpg",
     ".jpeg",
@@ -136,6 +140,15 @@ class AttachmentConfig(BaseModel):
             default per FEAT-011, so a missing entry never silently
             downgrades. Tier strings are validated at config-parse time;
             unknown values raise ``ValueError``.
+        reject_on_mime_mismatch: FEAT-035 knob. When ``True`` the bot
+            refuses an attachment whose downloaded bytes do not match
+            the MIME type implied by its extension; when ``False``
+            (default) the mismatch is surfaced as a soft warning in the
+            Discord safety report but the file still lands in staging.
+            Soft-warning mode preserves the v1 user-consent gate; flip
+            to ``True`` when a stricter deployment wants the bot to hard
+            reject polyglots (zip-disguised-as-pdf, executable-renamed-
+            to-md, etc.) before the user is even asked to ingest.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -152,6 +165,7 @@ class AttachmentConfig(BaseModel):
     )
     staging_subpath: Path = Field(default=_DEFAULT_STAGING_SUBPATH)
     channel_privacy_tiers: dict[int, str] = Field(default_factory=dict)
+    reject_on_mime_mismatch: bool = Field(default=False)
 
     @field_validator("allowed_extensions", "denied_extensions")
     @classmethod

--- a/crawdad/pyproject.toml
+++ b/crawdad/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "anthropic>=0.40.0",
     "pydantic>=2.0.0",
     "pyyaml>=6.0.0",
+    "filetype>=1.2.0",
 ]
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -101,6 +102,16 @@ disallow_any_unimported = false
 [[tool.mypy.overrides]]
 module = "tests.*"
 disallow_untyped_defs = false
+
+# FEAT-035: ``filetype`` is a small pure-Python magic-byte sniffer that
+# does not ship a ``py.typed`` marker. The ADR documents why we picked
+# it over ``python-magic`` (no libmagic system dep, fewer moving parts);
+# the trade-off is that we cannot get static types from the upstream
+# package. We use it from a single call site (``verify_mime_type``)
+# behind a typed dataclass, so the missing-stubs surface is contained.
+[[tool.mypy.overrides]]
+module = "filetype"
+ignore_missing_imports = true
 
 [tool.ruff]
 line-length = 88

--- a/crawdad/tests/test_attachments.py
+++ b/crawdad/tests/test_attachments.py
@@ -1,4 +1,4 @@
-"""Tests for ``crawdad.attachments`` (FEAT-027).
+"""Tests for ``crawdad.attachments`` (FEAT-027 + FEAT-035).
 
 Covers the acceptance-criteria scenarios:
 
@@ -11,6 +11,16 @@ Covers the acceptance-criteria scenarios:
 - Filename sanitisation refuses path traversal.
 - Inferred ingestor type for known + unknown extensions.
 - Summary formatting renders relative paths.
+
+FEAT-035 adds:
+
+- Matched binary content (PDF / PNG bytes under ``.pdf`` / ``.png`` ext).
+- Matched text content (plain ASCII under ``.md`` / ``.txt``).
+- Mismatched binary (ZIP bytes under ``.pdf`` — the polyglot case).
+- Mismatched text (PE/ELF/NUL bytes under ``.md`` — disguised executable).
+- Unknown extension (``.xyz`` — no verifier, status="unknown").
+- ``reject_on_mime_mismatch=True`` flips soft warning into hard reject.
+- Summary surfaces the mismatch warning line for accepted-but-suspect files.
 """
 
 from __future__ import annotations
@@ -22,6 +32,7 @@ import pytest
 
 from crawdad.attachments import (
     AcceptedAttachment,
+    MimeVerification,
     ProcessedAttachments,
     RejectedAttachment,
     format_attachment_summary,
@@ -29,6 +40,7 @@ from crawdad.attachments import (
     process_attachments,
     sanitize_filename,
     staging_dir_for,
+    verify_mime_type,
 )
 from crawdad.config import AttachmentConfig
 
@@ -480,3 +492,315 @@ def test_format_attachment_summary_outside_vault_renders_absolute(
     processed = ProcessedAttachments(staging_dir=elsewhere, accepted=(), rejected=())
     summary = format_attachment_summary(processed, vault_path=tmp_path)
     assert str(elsewhere) in summary
+
+
+# ---------------------------------------------------------------------------
+# FEAT-035: MIME-type / magic-byte verification
+# ---------------------------------------------------------------------------
+
+# Real PDF, PNG, JPEG, GIF magic bytes — the verifier hands these straight
+# to ``filetype.guess`` so the constants need to match the canonical file
+# headers, not just look-alikes.
+_PDF_HEADER = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"
+_PNG_HEADER = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+_JPEG_HEADER = b"\xff\xd8\xff\xe0\x00\x10JFIF\x00\x01"
+_GIF_HEADER = b"GIF89a" + b"\x00" * 16
+_ZIP_HEADER = b"PK\x03\x04\x14\x00\x06\x00" + b"\x00" * 16
+_PE_HEADER = b"MZ\x90\x00\x03\x00\x00\x00\x04\x00\x00\x00\xff\xff\x00\x00"
+
+
+def test_verify_mime_type_matched_pdf_signature_returns_match() -> None:
+    """A real PDF header under a ``.pdf`` extension verifies as ``match``."""
+    result = verify_mime_type("doc.pdf", _PDF_HEADER + b"rest of body")
+    assert result.status == "match"
+    assert result.detected_mime == "application/pdf"
+    assert result.expected_mime == "application/pdf"
+    assert result.is_mismatch is False
+
+
+def test_verify_mime_type_matched_png_signature_returns_match() -> None:
+    """A real PNG header under a ``.png`` extension verifies as ``match``."""
+    result = verify_mime_type("photo.PNG", _PNG_HEADER)
+    assert result.status == "match"
+    assert result.detected_mime == "image/png"
+
+
+def test_verify_mime_type_matched_text_sample_returns_match() -> None:
+    """Plain UTF-8 text under a ``.md`` extension passes the text sample check."""
+    result = verify_mime_type("notes.md", b"# Hello\n\nSome notes.\n")
+    assert result.status == "match"
+    assert result.detected_mime == "text/plain"
+
+
+def test_verify_mime_type_zip_disguised_as_pdf_is_mismatch() -> None:
+    """The polyglot case: ZIP bytes claimed as a PDF flag as ``mismatch``.
+
+    This is the canonical FEAT-035 scenario — a ``.pdf`` filename with
+    a zip container body. The verifier reports the detected MIME so the
+    user-facing summary can name the actual format.
+    """
+    result = verify_mime_type("invoice.pdf", _ZIP_HEADER)
+    assert result.status == "mismatch"
+    assert result.detected_mime == "application/zip"
+    assert result.expected_mime == "application/pdf"
+    assert result.is_mismatch is True
+
+
+def test_verify_mime_type_executable_disguised_as_markdown_is_mismatch() -> None:
+    """A PE / EXE header renamed to ``.md`` trips the NUL-byte heuristic."""
+    result = verify_mime_type("evil.md", _PE_HEADER + b"\x00" * 100)
+    assert result.status == "mismatch"
+    assert result.detected_mime == "application/octet-stream"
+    assert result.expected_mime == "text/plain"
+
+
+def test_verify_mime_type_invalid_utf8_under_text_extension_is_mismatch() -> None:
+    """Garbage bytes that aren't valid UTF-8 flag a mismatch under .txt."""
+    invalid_utf8 = b"\xff\xfe\xfd\xfc" * 50
+    result = verify_mime_type("garbled.txt", invalid_utf8)
+    assert result.status == "mismatch"
+    assert result.detected_mime == "application/octet-stream"
+
+
+def test_verify_mime_type_unknown_extension_returns_unknown_status() -> None:
+    """An extension outside both tables can't be verified — status=unknown."""
+    result = verify_mime_type("weird.xyz", b"any bytes here")
+    assert result.status == "unknown"
+    assert result.detected_mime is None
+    assert result.expected_mime is None
+    assert result.is_mismatch is False
+
+
+def test_verify_mime_type_unrecognised_signature_under_binary_ext_mismatches() -> None:
+    """A binary extension whose body has no matching magic bytes is a mismatch.
+
+    ``filetype.guess`` returns ``None`` when no signature matches. The
+    verifier treats that as a mismatch under a binary extension so the
+    summary still surfaces the discrepancy.
+    """
+    result = verify_mime_type("photo.png", b"random non-PNG content here")
+    assert result.status == "mismatch"
+    assert result.detected_mime is None
+    assert result.expected_mime == "image/png"
+
+
+def test_verify_mime_type_docx_zip_is_match() -> None:
+    """A real DOCX (which is a ZIP container) verifies as ``match`` under .docx."""
+    result = verify_mime_type("report.docx", _ZIP_HEADER)
+    assert result.status == "match"
+    # The library may report either the canonical OOXML MIME or the
+    # generic ZIP MIME depending on signature depth — both are acceptable.
+    assert result.detected_mime in {
+        "application/zip",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    }
+
+
+async def test_process_attachment_with_matching_mime_lands_with_match_status(
+    tmp_path: Path, attachment_config: AttachmentConfig
+) -> None:
+    """A well-formed PDF lands in staging with mime_verification.status='match'."""
+    attachment = _FakeAttachment(
+        filename="contract.pdf",
+        size=len(_PDF_HEADER),
+        payload=_PDF_HEADER,
+    )
+    result = await process_attachments(
+        attachments=[attachment],
+        vault_path=tmp_path,
+        channel_id=1,
+        message_id=2,
+        config=attachment_config,
+    )
+    assert len(result.accepted) == 1
+    assert result.accepted[0].mime_verification.status == "match"
+    assert result.accepted[0].staged_path.exists()
+
+
+async def test_process_attachment_with_mismatched_mime_still_stages_by_default(
+    tmp_path: Path, attachment_config: AttachmentConfig
+) -> None:
+    """Soft-warning mode: a polyglot still lands, but carries the mismatch flag.
+
+    Default config has ``reject_on_mime_mismatch=False`` — the bot
+    surfaces the warning in the Discord reply and keeps the file staged
+    so the user-consent gate stays the authoritative refusal point.
+    """
+    attachment = _FakeAttachment(
+        filename="invoice.pdf",
+        size=len(_ZIP_HEADER),
+        payload=_ZIP_HEADER,
+    )
+    result = await process_attachments(
+        attachments=[attachment],
+        vault_path=tmp_path,
+        channel_id=1,
+        message_id=2,
+        config=attachment_config,
+    )
+    assert len(result.accepted) == 1
+    assert result.accepted[0].mime_verification.is_mismatch is True
+    assert result.accepted[0].mime_verification.detected_mime == "application/zip"
+    # File still lands on disk — soft warning, not hard reject.
+    assert result.accepted[0].staged_path.exists()
+
+
+async def test_process_attachment_with_mismatched_mime_rejected_when_configured(
+    tmp_path: Path,
+) -> None:
+    """``reject_on_mime_mismatch=True`` hard-rejects polyglots at the gate."""
+    config = AttachmentConfig(reject_on_mime_mismatch=True)
+    attachment = _FakeAttachment(
+        filename="invoice.pdf",
+        size=len(_ZIP_HEADER),
+        payload=_ZIP_HEADER,
+    )
+    result = await process_attachments(
+        attachments=[attachment],
+        vault_path=tmp_path,
+        channel_id=1,
+        message_id=2,
+        config=config,
+    )
+    assert result.accepted == ()
+    assert len(result.rejected) == 1
+    assert "MIME mismatch" in result.rejected[0].reason
+    assert "application/pdf" in result.rejected[0].reason
+    assert "application/zip" in result.rejected[0].reason
+    # The polyglot never landed on disk in reject mode.
+    staged = tmp_path / "00-Creek-Meta" / "Inbound" / "1" / "2" / "invoice.pdf"
+    assert not staged.exists()
+
+
+async def test_process_attachment_text_polyglot_rejected_when_configured(
+    tmp_path: Path,
+) -> None:
+    """An EXE-disguised-as-markdown polyglot is rejected when reject mode is on."""
+    config = AttachmentConfig(reject_on_mime_mismatch=True)
+    attachment = _FakeAttachment(
+        filename="evil.md",
+        size=64,
+        payload=_PE_HEADER + b"\x00" * 48,
+    )
+    result = await process_attachments(
+        attachments=[attachment],
+        vault_path=tmp_path,
+        channel_id=1,
+        message_id=2,
+        config=config,
+    )
+    assert result.accepted == ()
+    assert len(result.rejected) == 1
+    assert "MIME mismatch" in result.rejected[0].reason
+
+
+async def test_process_attachment_unknown_extension_still_accepts(
+    tmp_path: Path,
+) -> None:
+    """Unknown extension types accept silently — no verifier, no warning.
+
+    ``reject_on_mime_mismatch`` only fires on detected mismatches; an
+    ``unknown`` verification status is treated as "no information" and
+    must not trigger rejection (otherwise the knob would secretly
+    narrow the allow list).
+    """
+    config = AttachmentConfig(
+        allowed_extensions=frozenset(),
+        reject_on_mime_mismatch=True,
+    )
+    attachment = _FakeAttachment(
+        filename="config.toml",
+        size=8,
+        payload=b"key = 1\n",
+    )
+    result = await process_attachments(
+        attachments=[attachment],
+        vault_path=tmp_path,
+        channel_id=1,
+        message_id=2,
+        config=config,
+    )
+    assert len(result.accepted) == 1
+    assert result.accepted[0].mime_verification.status == "unknown"
+
+
+def test_format_attachment_summary_surfaces_mime_mismatch_warning(
+    tmp_path: Path,
+) -> None:
+    """A mismatch flag on an accepted file shows up as a ⚠ line in the summary."""
+    staging = tmp_path / "00-Creek-Meta" / "Inbound" / "1" / "2"
+    accepted = AcceptedAttachment(
+        filename="invoice.pdf",
+        original_filename="invoice.pdf",
+        size=128,
+        staged_path=staging / "invoice.pdf",
+        content_hash="a" * 64,
+        inferred_type="document",
+        already_present=False,
+        mime_verification=MimeVerification(
+            status="mismatch",
+            detected_mime="application/zip",
+            expected_mime="application/pdf",
+        ),
+    )
+    processed = ProcessedAttachments(
+        staging_dir=staging,
+        accepted=(accepted,),
+        rejected=(),
+    )
+    summary = format_attachment_summary(processed, vault_path=tmp_path)
+    assert "⚠ MIME mismatch" in summary
+    assert "application/zip" in summary
+    assert "application/pdf" in summary
+
+
+def test_format_attachment_summary_hides_warning_when_mime_matches(
+    tmp_path: Path,
+) -> None:
+    """A match (or unknown) verification adds no warning line — no false noise."""
+    staging = tmp_path / "00-Creek-Meta" / "Inbound" / "1" / "2"
+    accepted = AcceptedAttachment(
+        filename="contract.pdf",
+        original_filename="contract.pdf",
+        size=128,
+        staged_path=staging / "contract.pdf",
+        content_hash="a" * 64,
+        inferred_type="document",
+        already_present=False,
+        mime_verification=MimeVerification(
+            status="match",
+            detected_mime="application/pdf",
+            expected_mime="application/pdf",
+        ),
+    )
+    processed = ProcessedAttachments(
+        staging_dir=staging,
+        accepted=(accepted,),
+        rejected=(),
+    )
+    summary = format_attachment_summary(processed, vault_path=tmp_path)
+    assert "⚠" not in summary
+    assert "MIME mismatch" not in summary
+
+
+def test_attachment_config_reject_on_mime_mismatch_defaults_false() -> None:
+    """The knob defaults to soft-warning mode so the v1 consent gate is unchanged."""
+    config = AttachmentConfig()
+    assert config.reject_on_mime_mismatch is False
+
+
+def test_attachment_config_default_allowed_extensions_omits_legacy_office() -> None:
+    """FEAT-035 narrows the default allow list to verifiable extensions only.
+
+    Legacy Office formats (``.doc`` / ``.xls`` / ``.ppt``) are not in
+    :data:`crawdad.attachments._EXTENSION_TO_ACCEPTABLE_MIMES` because
+    ``filetype`` does not reliably detect OLE compound documents, so
+    they no longer ship in the default allow list. Operators who need
+    them can re-add the extensions explicitly in ``crawdad.yaml``.
+    """
+    config = AttachmentConfig()
+    for legacy in (".doc", ".xls", ".ppt"):
+        assert legacy not in config.allowed_extensions
+    # The verifiable types are still allowed by default.
+    for verifiable in (".pdf", ".docx", ".xlsx", ".pptx", ".png", ".md"):
+        assert verifiable in config.allowed_extensions

--- a/crawdad/tests/test_attachments.py
+++ b/crawdad/tests/test_attachments.py
@@ -526,10 +526,30 @@ def test_verify_mime_type_matched_png_signature_returns_match() -> None:
 
 
 def test_verify_mime_type_matched_text_sample_returns_match() -> None:
-    """Plain UTF-8 text under a ``.md`` extension passes the text sample check."""
+    """Plain UTF-8 text under a ``.md`` extension passes the text sample check.
+
+    The reported MIME is per-extension (``text/markdown`` for ``.md``,
+    ``application/json`` for ``.json``, etc.) so the user-facing summary
+    does not lie about format identity when a match surfaces.
+    """
     result = verify_mime_type("notes.md", b"# Hello\n\nSome notes.\n")
     assert result.status == "match"
-    assert result.detected_mime == "text/plain"
+    assert result.detected_mime == "text/markdown"
+
+
+def test_verify_mime_type_text_match_uses_per_extension_mime() -> None:
+    """``.json`` / ``.html`` / ``.csv`` matches report their specific MIMEs."""
+    json_result = verify_mime_type("config.json", b'{"key": "value"}\n')
+    assert json_result.status == "match"
+    assert json_result.detected_mime == "application/json"
+
+    html_result = verify_mime_type("page.html", b"<!doctype html><p>hi</p>\n")
+    assert html_result.status == "match"
+    assert html_result.detected_mime == "text/html"
+
+    csv_result = verify_mime_type("data.csv", b"a,b,c\n1,2,3\n")
+    assert csv_result.status == "match"
+    assert csv_result.detected_mime == "text/csv"
 
 
 def test_verify_mime_type_zip_disguised_as_pdf_is_mismatch() -> None:
@@ -551,7 +571,7 @@ def test_verify_mime_type_executable_disguised_as_markdown_is_mismatch() -> None
     result = verify_mime_type("evil.md", _PE_HEADER + b"\x00" * 100)
     assert result.status == "mismatch"
     assert result.detected_mime == "application/octet-stream"
-    assert result.expected_mime == "text/plain"
+    assert result.expected_mime == "text/markdown"
 
 
 def test_verify_mime_type_invalid_utf8_under_text_extension_is_mismatch() -> None:
@@ -560,6 +580,7 @@ def test_verify_mime_type_invalid_utf8_under_text_extension_is_mismatch() -> Non
     result = verify_mime_type("garbled.txt", invalid_utf8)
     assert result.status == "mismatch"
     assert result.detected_mime == "application/octet-stream"
+    assert result.expected_mime == "text/plain"
 
 
 def test_verify_mime_type_unknown_extension_returns_unknown_status() -> None:
@@ -702,10 +723,13 @@ async def test_process_attachment_unknown_extension_still_accepts(
     ``reject_on_mime_mismatch`` only fires on detected mismatches; an
     ``unknown`` verification status is treated as "no information" and
     must not trigger rejection (otherwise the knob would secretly
-    narrow the allow list).
+    narrow the allow list). The fixture explicitly allow-lists
+    ``.toml`` so the test pins the MIME-gate behaviour — not the
+    extension-gate behaviour (covered by
+    :func:`test_empty_allowed_extensions_passes_anything_not_denied`).
     """
     config = AttachmentConfig(
-        allowed_extensions=frozenset(),
+        allowed_extensions=frozenset({".toml"}),
         reject_on_mime_mismatch=True,
     )
     attachment = _FakeAttachment(
@@ -787,6 +811,24 @@ def test_attachment_config_reject_on_mime_mismatch_defaults_false() -> None:
     """The knob defaults to soft-warning mode so the v1 consent gate is unchanged."""
     config = AttachmentConfig()
     assert config.reject_on_mime_mismatch is False
+
+
+def test_extension_mime_specs_canonical_is_member_of_acceptable() -> None:
+    """Structural integrity: every spec's ``canonical`` MIME is also acceptable.
+
+    Guards against a future contributor adding an entry where the
+    user-facing ``canonical`` label drifts away from the membership
+    set used to decide ``match`` vs ``mismatch`` — a real file of the
+    right type would otherwise be flagged as a mismatch against its
+    own canonical name.
+    """
+    from crawdad.attachments import _EXTENSION_MIME_SPECS
+
+    for suffix, spec in _EXTENSION_MIME_SPECS.items():
+        assert spec.canonical in spec.acceptable, (
+            f"{suffix}: canonical {spec.canonical!r} missing from "
+            f"acceptable set {sorted(spec.acceptable)!r}"
+        )
 
 
 def test_attachment_config_default_allowed_extensions_omits_legacy_office() -> None:

--- a/crawdad/tests/test_config.py
+++ b/crawdad/tests/test_config.py
@@ -200,3 +200,51 @@ def test_load_config_parses_attachment_overrides(
     assert config.attachments.allowed_extensions == frozenset({".md", ".txt"})
     assert config.attachments.denied_extensions == frozenset({".exe", ".sh"})
     assert config.attachments.channel_privacy_tiers[222] == "intimate"
+
+
+def test_load_config_parses_reject_on_mime_mismatch_from_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """FEAT-035: ``attachments.reject_on_mime_mismatch: true`` round-trips.
+
+    Operators flip this knob in ``crawdad.yaml`` to harden the gate
+    from the documented soft-warning default. The field has to survive
+    the YAML → Pydantic boundary unchanged or the runtime behaviour
+    silently won't match the configured policy.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    yaml_path = tmp_path / "crawdad.yaml"
+    yaml_path.write_text(
+        "vault_path: " + str(vault) + "\n"
+        "allowed_user_ids: [111]\n"
+        "allowed_channel_ids: [222]\n"
+        "attachments:\n"
+        "  reject_on_mime_mismatch: true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "t")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    config = load_config(yaml_path)
+    assert config.attachments.reject_on_mime_mismatch is True
+
+
+def test_load_config_reject_on_mime_mismatch_defaults_false_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A YAML without the knob keeps the v1 soft-warning default."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    yaml_path = tmp_path / "crawdad.yaml"
+    yaml_path.write_text(
+        "vault_path: " + str(vault) + "\n"
+        "allowed_user_ids: [111]\n"
+        "allowed_channel_ids: [222]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "t")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    config = load_config(yaml_path)
+    assert config.attachments.reject_on_mime_mismatch is False

--- a/creek-tools/docs/architecture/ADR/0002-mime-verification-library.md
+++ b/creek-tools/docs/architecture/ADR/0002-mime-verification-library.md
@@ -1,0 +1,156 @@
+# ADR-0002: MIME-verification library choice for CrawDad attachments
+
+- **Status**: Accepted
+- **Date**: 2026-05-24
+- **Driving issue**: FEAT-035 (#285)
+- **Scope**: `crawdad/crawdad/attachments.py` only — the bot-side
+  attachment gate. The `creek.ingest` pipeline (creek-tools side) does
+  not perform a redundant check (explicit out-of-scope in #285).
+
+## Context
+
+FEAT-033 (PR #280) shipped extension-only gating in the CrawDad
+attachment pipeline. A reviewer flagged the v1 limitation: a renamed
+executable (`evil.exe` → `evil.md`) passes the allow list and reaches
+the staging directory. The bot still requires user consent before any
+`creek.ingest` call, and `creek.redact.scan` runs in between, so the
+gap is bounded for the personal-tool deployment target. But the
+"`ingest` was typed" signal is not the same as "the user knew what was
+in the file". FEAT-035 adds a second, content-based check on top of
+the extension allow list.
+
+The bot is a small Python package shipped via `pip install crawdad`
+into the operator's local environment. It runs on whatever the
+operator has (a Raspberry Pi, a Docker container, a laptop). It must
+not pull in a system-level library dependency that turns "I cloned the
+repo" into a multi-step setup.
+
+## Decision
+
+CrawDad uses [`filetype`](https://pypi.org/project/filetype/) (pure
+Python, BSD-3) for magic-byte detection on binary file types.
+
+For text-extension files (`.md`, `.markdown`, `.txt`, `.html`,
+`.htm`, `.json`, `.csv` — which have no magic byte signature) the
+verifier runs a content sample instead: the first 1 KiB must decode
+as UTF-8 and contain no NUL bytes. This catches the polyglot case the
+issue calls out (executable or other binary blob renamed to a text
+extension) without false-flagging legitimate UTF-8-encoded text.
+
+The default `allowed_extensions` list shipped in `AttachmentConfig` is
+narrowed to extensions whose content type the verifier can check:
+
+- **Magic-byte verifiable**: `.pdf`, `.docx`, `.xlsx`, `.pptx`,
+  `.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`.
+- **Text content-sampled**: `.md`, `.markdown`, `.txt`, `.html`,
+  `.htm`, `.json`, `.csv`.
+
+Legacy Office formats (`.doc`, `.xls`, `.ppt`) are dropped from the
+default — `filetype` cannot reliably recognise OLE Compound documents
+from their header, and the formats also carry macro-execution risk
+that the personal-tool deployment target rightly avoids by default.
+Operators who genuinely need them can re-add the extensions in
+`crawdad.yaml`.
+
+## Alternatives considered
+
+### `python-magic` (libmagic wrapper)
+
+- **Pros**: Mature, accurate, the canonical reference. Detects far
+  more file types than `filetype`, and uses the same magic database as
+  the venerable `file(1)` Unix tool.
+- **Cons**: Requires the `libmagic` system library at runtime
+  (`apt-get install libmagic1`, `brew install libmagic`, etc.). The
+  `python-magic` package on PyPI does *not* bundle libmagic — that is
+  `python-magic-bin`, which is Windows-only. So a Linux operator has
+  to install a system package; a minimal Docker image needs a tweaked
+  Dockerfile; CI matrix entries need an extra setup step. The bot has
+  to fail clearly when libmagic is absent, adding error-handling
+  surface.
+- **Verdict**: Rejected. The cross-platform setup burden outweighs the
+  marginal accuracy win for the file types CrawDad actually accepts.
+  The Discord attachment surface is a short list of common formats —
+  PDF, OOXML, images, text — all of which `filetype` handles correctly.
+
+### `filetype` (pure Python)
+
+- **Pros**: Pure Python, no system dependencies. Small (≈100 file
+  types in its built-in signature table — exactly the common set
+  CrawDad cares about). MIT-licensed, actively maintained. Two-call
+  surface (`filetype.guess(data) → Type | None`) that fits behind the
+  typed `MimeVerification` dataclass cleanly.
+- **Cons**: Smaller signature set than `libmagic`. Cannot detect
+  text-format mime types (which is why the verifier falls back to UTF-8
+  + NUL-byte sampling for those). Does not have OOXML-specific
+  detection — DOCX/XLSX/PPTX bytes are reported as `application/zip`
+  (correct at the byte level; the verifier accepts both the canonical
+  OOXML MIME and `application/zip` as a match for those extensions).
+- **Verdict**: **Accepted.** Matches the CrawDad deployment target
+  (small, single-user, pip-installable) without the system-package
+  overhead.
+
+### Custom signature table
+
+- **Pros**: Zero dependencies. Full control over what is and isn't
+  recognised.
+- **Cons**: Re-implements a solved problem badly. Easy to get edge
+  cases (RIFF / WEBP header parsing, OLE compound layout, PE
+  signatures) subtly wrong. Every new format CrawDad accepts in future
+  adds maintenance debt.
+- **Verdict**: Rejected. Reinventing magic-byte detection for nine
+  extensions earns nothing over a 50 KB dependency that handles them
+  correctly already.
+
+### `puremagic`
+
+- **Pros**: Also pure Python, no system deps.
+- **Cons**: Less actively maintained than `filetype` (last release
+  March 2024 vs `filetype`'s May 2024 at writing). Returns a list of
+  possible matches rather than a single best guess, which complicates
+  the call site.
+- **Verdict**: Rejected. `filetype` is the closer ergonomic fit.
+
+## Consequences
+
+**Positive**
+
+- No system-package install step. `pip install crawdad` continues to
+  produce a working bot.
+- The polyglot case (zip-disguised-as-PDF, exe-renamed-to-md) now
+  surfaces as a warning in the Discord safety report; operators can
+  flip `reject_on_mime_mismatch: true` in `crawdad.yaml` to harden
+  the gate further.
+- Legacy Office (`.doc` / `.xls` / `.ppt`) removed from the default
+  allow list — operators who don't actively need them no longer ship
+  the macro-execution risk.
+
+**Negative**
+
+- The default text-extension verifier is heuristic (UTF-8 + NUL-byte
+  check). A genuinely binary file that happens to contain no NUL bytes
+  in its first 1 KiB and decodes as UTF-8 would pass — extremely
+  unlikely in practice for the formats the operator is allow-listing,
+  but not zero. A future hardening could parse a JSON file end-to-end
+  for `.json`, run an HTML parser tolerantly over `.html`, etc., at
+  the cost of more CPU and a wider failure surface.
+- `filetype` does not ship `py.typed`, so MyPy needs an
+  `ignore_missing_imports` override for the one module that imports
+  it. The override is documented in `crawdad/pyproject.toml` next to
+  the existing test-only override.
+- DOCX / XLSX / PPTX may be reported by `filetype` as
+  `application/zip` rather than their canonical OOXML MIME, depending
+  on the runtime version. The verifier's acceptable-MIME set for
+  those extensions includes both, so this is invisible to the user.
+
+## Out of scope
+
+- Anti-malware scanning (out of scope for a personal knowledge tool).
+- Full archive inspection (zip / tar contents).
+- MIME verification on the `creek.ingest` side — explicitly excluded
+  by FEAT-035. The check stays at the bot's download gate where the
+  file is first introduced.
+- Cross-bot audit logging through `MCPAuditLog`. The bot logs every
+  mismatch at WARNING via the standard Python logger; a future
+  iteration may extend `creek.redact.scan` to accept structured
+  mismatch metadata and persist it through the existing `MCPAuditLog`
+  surface. Tracked as a follow-up; not blocking for FEAT-035.


### PR DESCRIPTION
Add magic-byte / content-sample content-type verification on top of the
extension allow list shipped in FEAT-033. After download, every
attachment is sniffed with ``filetype`` (binary signatures) or with a
UTF-8 + NUL-byte content sample (text formats), and the detected MIME
is compared against the extension's claim. Mismatches surface as a
soft-warning ⚠ line in the Discord safety report; the new
``attachments.reject_on_mime_mismatch`` knob in ``crawdad.yaml`` flips
the warning into a hard rejection at the same gate ``_process_one``
uses today.

Narrows the default ``allowed_extensions`` to the set whose content
type can be verified: legacy Office formats (``.doc``/``.xls``/``.ppt``)
drop out because ``filetype`` cannot reliably detect OLE compound
documents and the formats carry macro-execution risk. Operators who
need them can re-add the extensions in ``crawdad.yaml``.

Adds ADR-0002 documenting the library choice (``filetype`` over
``python-magic``: no libmagic system dep, smaller surface, fits the
single-user / pip-installable deployment target).

Tests cover the AC scenarios: matched binary, matched text, polyglot
(zip-disguised-as-PDF), executable-disguised-as-markdown, unknown
extension, the configurable reject mode, and the summary surfacing.