### PR TITLE
fix(config): CREEK_CONFIG env-var fallback + --config flag for MCP (#293)

### DIFF
--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -10,6 +10,7 @@ file — they must come from environment variables.
 """
 
 import logging
+import os
 from pathlib import Path
 from typing import Literal
 from zoneinfo import ZoneInfo
@@ -712,26 +713,53 @@ def load_config(
 ) -> CreekConfig:
     """Load configuration from a YAML file with environment variable overrides.
 
-    If *config_path* does not exist, returns a ``CreekConfig`` populated
-    entirely from defaults and environment variables and (per ARCH-002)
-    emits a ``WARNING`` so the operator knows their data-handling
-    decisions are being made by the defaults rather than their own
-    config. Pass ``warn_on_missing=False`` to silence the warning when
-    the caller has already established that the missing file is
-    expected (e.g. ``creek init`` runs before any config exists).
+    Discovery order when *config_path* is ``None``:
+
+    1. ``CREEK_CONFIG`` environment variable (INC-008) — set by every
+       subprocess that inherits it, e.g. ``creek-tools-mcp`` launched
+       by CrawDad from a cwd other than the vault.
+    2. ``./creek_config.yaml`` in the current directory (legacy
+       fallback).
+
+    If *config_path* does not exist (after that resolution), returns a
+    ``CreekConfig`` populated entirely from defaults and environment
+    variables and (per ARCH-002) emits a ``WARNING`` so the operator
+    knows their data-handling decisions are being made by the defaults
+    rather than their own config. Pass ``warn_on_missing=False`` to
+    silence the warning when the caller has already established that
+    the missing file is expected (e.g. ``creek init`` runs before any
+    config exists).
 
     Args:
-        config_path: Path to a ``creek_config.yaml`` file.  Defaults to
-            ``creek_config.yaml`` in the current directory.
+        config_path: Path to a ``creek_config.yaml`` file. When ``None``
+            (default), ``CREEK_CONFIG`` is consulted before falling back
+            to ``creek_config.yaml`` in the current directory.
         warn_on_missing: When ``True`` (default), log a WARNING if the
             file does not exist. Suppress for CLI commands that
             legitimately operate in the no-config state.
 
     Returns:
         A fully-validated ``CreekConfig`` instance.
+
+    Raises:
+        FileNotFoundError: When ``CREEK_CONFIG`` is set to a path that
+            does not exist. A misconfigured env var must fail loudly so
+            the operator sees the typo instead of getting silent
+            built-in defaults.
     """
     if config_path is None:
-        config_path = Path("creek_config.yaml")
+        env_value = os.environ.get("CREEK_CONFIG")
+        if env_value:
+            env_path = Path(env_value)
+            if not env_path.exists():
+                msg = (
+                    f"CREEK_CONFIG points to {env_path}, which does not exist. "
+                    "Set CREEK_CONFIG to a path that exists or unset it."
+                )
+                raise FileNotFoundError(msg)
+            config_path = env_path
+        else:
+            config_path = Path("creek_config.yaml")
 
     if config_path.exists():
         with config_path.open() as f:
@@ -742,7 +770,8 @@ def load_config(
         logger.warning(
             "Config file %s not found; running with built-in defaults. "
             "Run `creek init --vault <vault>` to write a starter config, "
-            "or pass --config <path> to point at one explicitly. "
+            "pass --config <path> to point at one explicitly, "
+            "or set CREEK_CONFIG=<path> in the environment. "
             "Pipeline behaviour (privacy, redaction, cleaning) depends on "
             "this file — silent defaults are usually not what you want.",
             config_path,

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -13,6 +13,7 @@ point (``main``).
 
 from __future__ import annotations
 
+import argparse
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -396,8 +397,34 @@ def build_server(
     return server
 
 
-def main() -> None:
-    """Run the MCP server over stdio (entry point for ``creek-tools-mcp``)."""
+def main(argv: list[str] | None = None) -> None:
+    """Run the MCP server over stdio (entry point for ``creek-tools-mcp``).
+
+    Accepts ``--config <path>`` (INC-008). When provided, the path is
+    exported as ``CREEK_CONFIG`` in the process environment so every
+    later ``config.load_config()`` call inside the server — and every
+    subprocess the server spawns — discovers the vault's config
+    regardless of cwd.
+
+    Args:
+        argv: Command-line arguments (defaults to ``sys.argv[1:]``).
+    """
+    parser = argparse.ArgumentParser(
+        prog="creek-tools-mcp",
+        description="Run the creek-tools MCP server over stdio.",
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help=(
+            "Path to creek_config.yaml. Overrides CREEK_CONFIG for this "
+            "process. Without this flag, CREEK_CONFIG and then "
+            "./creek_config.yaml are consulted in that order."
+        ),
+    )
+    args = parser.parse_args(argv)
+    if args.config is not None:
+        os.environ["CREEK_CONFIG"] = args.config
     build_server().run(transport="stdio")
 
 

--- a/creek-tools/tests/test_config_env_var.py
+++ b/creek-tools/tests/test_config_env_var.py
@@ -1,0 +1,102 @@
+"""Regression tests for INC-008: ``CREEK_CONFIG`` env-var discovery in ``load_config``.
+
+The MCP server previously discovered ``creek_config.yaml`` only from
+the current working directory, so subprocesses launched from a non-vault
+cwd (e.g. CrawDad spawning ``creek-tools-mcp``) silently fell back to
+built-in defaults. INC-008 adds a ``CREEK_CONFIG`` env-var fallback
+to :func:`creek.config.load_config` so any inherited environment
+delivers the operator's real configuration to every caller.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from creek.config import load_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_load_config_honors_creek_config_env_var(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``config_path is None`` + ``CREEK_CONFIG`` set → that path wins."""
+    config_file = tmp_path / "vault" / "creek_config.yaml"
+    config_file.parent.mkdir(parents=True)
+    config_file.write_text(
+        yaml.dump({"llm": {"provider": "anthropic", "model": "claude-sonnet-4-6"}}),
+    )
+    monkeypatch.setenv("CREEK_CONFIG", str(config_file))
+    monkeypatch.chdir(tmp_path)  # ensure no ./creek_config.yaml masks the env var
+
+    cfg = load_config()
+
+    assert cfg.llm.provider == "anthropic"
+    assert cfg.llm.model == "claude-sonnet-4-6"
+
+
+def test_load_config_env_var_nonexistent_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A misconfigured ``CREEK_CONFIG`` raises, not silent defaults."""
+    missing = tmp_path / "does-not-exist.yaml"
+    monkeypatch.setenv("CREEK_CONFIG", str(missing))
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="CREEK_CONFIG"):
+        load_config()
+
+
+def test_load_config_explicit_path_overrides_env_var(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``config_path`` wins over the env var."""
+    env_file = tmp_path / "env.yaml"
+    env_file.write_text(yaml.dump({"llm": {"provider": "ollama"}}))
+    explicit_file = tmp_path / "explicit.yaml"
+    explicit_file.write_text(yaml.dump({"llm": {"provider": "anthropic"}}))
+    monkeypatch.setenv("CREEK_CONFIG", str(env_file))
+
+    cfg = load_config(explicit_file)
+
+    assert cfg.llm.provider == "anthropic"
+
+
+def test_load_config_warning_mentions_creek_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The discovery-failure warning names ``CREEK_CONFIG``."""
+    monkeypatch.delenv("CREEK_CONFIG", raising=False)
+    monkeypatch.chdir(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="creek.config"):
+        load_config()
+
+    assert any("CREEK_CONFIG" in r.message for r in caplog.records)
+
+
+def test_load_config_empty_env_var_falls_through_to_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An empty ``CREEK_CONFIG`` is treated like an unset one."""
+    monkeypatch.setenv("CREEK_CONFIG", "")
+    monkeypatch.chdir(tmp_path)
+
+    with caplog.at_level(logging.WARNING, logger="creek.config"):
+        cfg = load_config()
+
+    assert cfg.vault_path.name == ""  # defaults preserved
+    # And the warning still fires — we're in the "neither set" path.
+    assert any("not found" in r.message for r in caplog.records)

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import TYPE_CHECKING
 
 import pytest
@@ -285,16 +286,71 @@ def test_build_draft_llm_returns_invoke_prompt_when_available(
     assert llm("hi") == "drafted body"
 
 
+class _RecordingStubServer:
+    """In-process stand-in for ``FastMCP`` used by ``main()`` tests."""
+
+    def __init__(self) -> None:
+        """Initialise the transport log."""
+        self.transports: list[str] = []
+
+    def run(self, transport: str) -> None:
+        """Record the requested transport instead of starting an MCP loop."""
+        self.transports.append(transport)
+
+
 def test_main_invokes_server_run(monkeypatch: pytest.MonkeyPatch) -> None:
     """``main()`` calls ``FastMCP.run(transport='stdio')``."""
     from creek_mcp import server as server_module
 
-    runs: list[tuple[object, ...]] = []
+    stub = _RecordingStubServer()
+    monkeypatch.setattr(server_module, "build_server", lambda: stub)
+    server_module.main([])
+    assert stub.transports == ["stdio"]
 
-    class _StubServer:
-        def run(self, transport: str) -> None:
-            runs.append((transport,))
 
-    monkeypatch.setattr(server_module, "build_server", lambda: _StubServer())
-    server_module.main()
-    assert runs == [("stdio",)]
+def test_main_config_flag_sets_creek_config_env_var(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--config <path>`` exports ``CREEK_CONFIG`` for later loads (INC-008)."""
+    from creek_mcp import server as server_module
+
+    config_file = tmp_path / "creek_config.yaml"
+    config_file.write_text("llm:\n  provider: anthropic\n", encoding="utf-8")
+    monkeypatch.delenv("CREEK_CONFIG", raising=False)
+    monkeypatch.setattr(server_module, "build_server", _RecordingStubServer)
+
+    server_module.main(["--config", str(config_file)])
+
+    assert os.environ.get("CREEK_CONFIG") == str(config_file)
+
+
+def test_main_without_config_flag_leaves_env_var_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without ``--config``, ``main()`` does not mutate ``CREEK_CONFIG`` (INC-008)."""
+    from creek_mcp import server as server_module
+
+    monkeypatch.setenv("CREEK_CONFIG", "/etc/preexisting.yaml")
+    monkeypatch.setattr(server_module, "build_server", _RecordingStubServer)
+
+    server_module.main([])
+
+    assert os.environ.get("CREEK_CONFIG") == "/etc/preexisting.yaml"
+
+
+def test_main_config_flag_overrides_existing_env_var(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When both env var and ``--config`` are set, the CLI flag wins (INC-008)."""
+    from creek_mcp import server as server_module
+
+    config_file = tmp_path / "explicit.yaml"
+    config_file.write_text("llm:\n  provider: anthropic\n", encoding="utf-8")
+    monkeypatch.setenv("CREEK_CONFIG", "/etc/from-environment.yaml")
+    monkeypatch.setattr(server_module, "build_server", _RecordingStubServer)
+
+    server_module.main(["--config", str(config_file)])
+
+    assert os.environ.get("CREEK_CONFIG") == str(config_file)


### PR DESCRIPTION
## Summary

Closes #293 (INC-008).

`creek_config.yaml` was previously discovered only when it lived in the current working directory. Anything that spawned `creek-tools-mcp` from a non-vault cwd — most importantly **CrawDad**, which spawns it from its own launch cwd — silently fell back to built-in defaults (Ollama on localhost, no redaction config, no privacy config), breaking every LLM-backed tool call with `"creek-tools is unreachable"` or the loop-runaway fallback.

The fix is the small two-layer fix proposed in the issue:

1. **`creek/config.py::load_config()`** consults `CREEK_CONFIG` before falling back to `./creek_config.yaml`. A misconfigured env var (pointing at a nonexistent file) raises `FileNotFoundError` rather than silently using defaults. An explicit `config_path=` argument still wins over the env var so existing callers are unaffected.
2. **`creek_mcp/server.py::main()`** grows a `--config <path>` argparse flag. When provided, the path is exported as `CREEK_CONFIG` in the process environment so every later `config.load_config()` call — inside the server and in any subprocess it spawns — picks up the same config uniformly.

The discovery-failure warning is updated to name `CREEK_CONFIG` alongside `--config` and `creek init`.

## Acceptance Criteria

- [x] `config.load()` honors `CREEK_CONFIG` env var as a fallback when `config_path is None` and the env var points to an existing file.
- [x] `creek-tools-mcp --config <path>` resolves the file and uses it for all tool calls during the server's lifetime.
- [x] When neither is set and `./creek_config.yaml` doesn't exist, the current behavior (warn + use defaults) is preserved.
- [x] When `CREEK_CONFIG` points to a nonexistent file, raise a clear error rather than silently falling back.
- [x] The discovery-failure warning message is updated to mention `CREEK_CONFIG` alongside `--config` and `creek init`.
- [x] Tests cover: env-var-only, CLI-only, both set, neither set, env-var-points-to-nonexistent (plus the empty-string edge case).
- [x] Tests with >=90% branch coverage on the changed code paths.
- [x] MyPy strict, Ruff zero violations.

## Test plan

- [x] `./scripts/check-all.sh` — 12/12 gates green
- [x] `pytest tests/test_config_env_var.py` — 5 new tests pass
- [x] `pytest tests/test_mcp_server.py` — 17 tests pass (3 new `main()` tests + 14 pre-existing)
- [x] Full unit suite — 3911 passed, 93.90% branch coverage
- [ ] Smoke test in CrawDad: launch `creek-tools-mcp --config ~/Documents/creek/00-Creek-Meta/creek_config.yaml` from a non-vault cwd and confirm Discord `/crawdad checkin` no longer reports `"creek-tools is unreachable"`

## Out of scope (per the issue)

- Auto-discovery from a `--vault` flag — fragile and needs careful design; deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BxyYioL7sEjXzHfr1nXqch)_