### PR TITLE
feat(crawdad): jig-style workflow DSL (ADAPT-003, #268)

### DIFF
--- a/crawdad/CLAUDE.md
+++ b/crawdad/CLAUDE.md
@@ -34,8 +34,12 @@ complete and ships:
   routing to `10-Liminal/Paradoxes/`.
 - Voice-skill activation per session from `<vault>/creek-skills/`
   (voice-core + phase + register).
-- Six `/crawdad` Discord slash commands (FEAT-016): `reflect`,
-  `checkin`, `surface`, `draft`, `save`, `workflow`.
+- Seven `/crawdad` Discord slash commands (FEAT-016 + FEAT-029 +
+  ADAPT-003): `reflect`, `checkin`, `surface`, `draft`, `save`,
+  `register`, `workflow`. `workflow` supports `list` (enumerate) and
+  `run <name>` (deterministic walk over a YAML file) — see
+  `crawdad/crawdad/workflows.py` and
+  `docs/adr/2026-05-24_workflow-file-location.md`.
 - A user + channel allowlist; non-allowlisted users get *no* response
   (silent ignore, per FEAT-013's personal-use scoping).
 - Session-state load from `<vault>/00-Creek-Meta/State/latest.md` at
@@ -59,7 +63,9 @@ crawdad/
 │   ├── router.py           # Haiku intent router (FEAT-014)
 │   ├── skill_loader.py     # Voice-skill stack loader (FEAT-015)
 │   ├── slash_commands.py   # /crawdad Discord slash commands (FEAT-016)
-│   └── state.py            # load_session_state — latest.md parser
+│   ├── state.py            # load_session_state — latest.md parser
+│   ├── workflows.py        # Authored workflow DSL (ADAPT-003)
+│   └── builtin_workflows/  # Reference workflows shipped with the package
 ├── tests/                  # One test file per source module
 ├── scripts/                # check-all, lint, test, etc.
 ├── docs/

--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -42,7 +42,7 @@ from crawdad.mcp_client import MCPUnavailableError
 from crawdad.slash_commands import register as register_slash_commands
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
     from pathlib import Path
 
     from crawdad.attachments import _AttachmentLike
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
     from crawdad.mcp_client import MCPClient
     from crawdad.router import IntentRouter
     from crawdad.skill_loader import SkillStackRegistry, VoiceSkillStack
-    from crawdad.slash_commands import LoopRunner, RegisterSwitcher
+    from crawdad.slash_commands import LoopRunner, RegisterSwitcher, WorkflowRunner
     from crawdad.state import SessionState, StateUnavailableError
 
 _LOGGER = logging.getLogger("crawdad.bot")
@@ -760,6 +760,8 @@ class CrawDadClient(discord.Client):
         loop_runner: LoopRunner | None = None,
         register_switcher: RegisterSwitcher | None = None,
         pending_batches: PendingBatchStore | None = None,
+        workflow_lister: Callable[[], list[str]] | None = None,
+        workflow_runner: WorkflowRunner | None = None,
         intents: discord.Intents | None = None,
     ) -> None:
         """Store config + agent-loop components; init the parent ``Client``.
@@ -779,6 +781,12 @@ class CrawDadClient(discord.Client):
         writes on every successful attachment turn. When ``None``, the
         consent flow is disabled and the user must fall back to the
         ``creek ingest`` CLI path.
+
+        ``workflow_lister`` and ``workflow_runner`` (ADAPT-003) are the
+        closures the ``/crawdad workflow`` command invokes for its
+        ``list`` and ``run`` subactions. Both default to ``None`` —
+        sessions without an MCP tool surface still register the
+        command but the handler soft-errors instead of crashing.
         """
         super().__init__(intents=intents or self._default_intents())
         self._config = config
@@ -802,6 +810,8 @@ class CrawDadClient(discord.Client):
                 cast("Any", self.tree),
                 loop_runner=loop_runner,
                 register_switcher=register_switcher,
+                workflow_lister=workflow_lister,
+                workflow_runner=workflow_runner,
             )
 
     @staticmethod

--- a/crawdad/crawdad/builtin_workflows/compost-surfacing.workflow.yaml
+++ b/crawdad/crawdad/builtin_workflows/compost-surfacing.workflow.yaml
@@ -1,0 +1,24 @@
+# Reference workflow: surface what's emerging across the vault for the
+# user's current phase. See ADAPT-003 (issue #268) for context.
+#
+# The "compost" framing in ADAPT-003's plan is a metaphor for the user's
+# liminal / unlinked material; the implementation uses ``creek.mine``'s
+# phase-scoped seed surface as the closest mechanical equivalent
+# available in v1.1's MCP tool set.
+name: compost-surfacing
+description: |
+  Surface ranked essay seeds — paradoxes, liminal fragments, and
+  thread terminals — for the user's current phase. The composer turns
+  the structured seed list into a short, voice-faithful summary.
+trigger: "/crawdad workflow run compost-surfacing"
+phase_aware: false
+privacy_tier_floor: personal
+steps:
+  - id: read
+    tool: creek.state.read
+    args: {}
+  - id: surface
+    tool: creek.mine
+    args:
+      phase: "{{state.phase}}"
+      limit: 10

--- a/crawdad/crawdad/builtin_workflows/compost-surfacing.workflow.yaml
+++ b/crawdad/crawdad/builtin_workflows/compost-surfacing.workflow.yaml
@@ -5,13 +5,20 @@
 # liminal / unlinked material; the implementation uses ``creek.mine``'s
 # phase-scoped seed surface as the closest mechanical equivalent
 # available in v1.1's MCP tool set.
+#
+# ``phase_aware: true`` is intentional even though no ``allowed_phases``
+# list is declared: the workflow interpolates ``{{state.phase}}`` into
+# the ``creek.mine`` step, so running without a cached session state
+# would silently pass ``phase: ""``. The phase-aware flag turns that
+# into a clean ``WorkflowConstraintError`` at the walker's constraint
+# check (PR #309 review feedback).
 name: compost-surfacing
 description: |
   Surface ranked essay seeds — paradoxes, liminal fragments, and
   thread terminals — for the user's current phase. The composer turns
   the structured seed list into a short, voice-faithful summary.
 trigger: "/crawdad workflow run compost-surfacing"
-phase_aware: false
+phase_aware: true
 privacy_tier_floor: personal
 steps:
   - id: read

--- a/crawdad/crawdad/builtin_workflows/substack-draft-phase-transitions.workflow.yaml
+++ b/crawdad/crawdad/builtin_workflows/substack-draft-phase-transitions.workflow.yaml
@@ -1,0 +1,30 @@
+# Reference workflow: draft a Substack-style post, scoped to the user's
+# current wavelength phase. See ADAPT-003 (issue #268) for context.
+#
+# The composer wraps the draft tool's structured response in the user's
+# voice register — voice fidelity for the draft *body* itself is owned
+# by ``creek.draft``'s in-tool skill stack (FEAT-005), not by this
+# workflow.
+name: substack-draft-phase-transitions
+description: |
+  Draft a phase-aware essay scoped to the user's current wavelength.
+  Reads latest state, mines essay seeds for the active phase, then
+  drafts the top-ranked seed via ``creek.draft``.
+trigger: "/crawdad workflow run substack-draft-phase-transitions"
+phase_aware: true
+privacy_tier_floor: personal
+inputs: []
+steps:
+  - id: read
+    tool: creek.state.read
+    args: {}
+  - id: mine
+    tool: creek.mine
+    args:
+      phase: "{{state.phase}}"
+      limit: 5
+  - id: draft
+    tool: creek.draft
+    args:
+      phase: "{{state.phase}}"
+      index: 0

--- a/crawdad/crawdad/builtin_workflows/wavelength-checkin.workflow.yaml
+++ b/crawdad/crawdad/builtin_workflows/wavelength-checkin.workflow.yaml
@@ -1,0 +1,18 @@
+# Reference workflow: a quick wavelength check-in for the last week.
+# See ADAPT-003 (issue #268) for context.
+#
+# ``creek.state.read`` is the FEAT-010 cheap path — it hands back the
+# pre-rendered ``00-Creek-Meta/State/latest.md`` so the composer's
+# wavelength summary doesn't pay for a full vault walk.
+name: wavelength-checkin
+description: |
+  Read the latest audit report and surface the current phase, dosage,
+  and recent transitions. The composer wraps the raw state read in the
+  user's voice register.
+trigger: "/crawdad workflow run wavelength-checkin"
+phase_aware: false
+privacy_tier_floor: open
+steps:
+  - id: read
+    tool: creek.state.read
+    args: {}

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -31,13 +31,14 @@ from crawdad.mcp_client import MCPClient, MCPUnavailableError
 from crawdad.router import IntentRouter
 from crawdad.skill_loader import SkillStackRegistry, load_skills_for_session
 from crawdad.state import StateUnavailableError, load_session_state
+from crawdad.workflows import WorkflowRegistry, run_workflow_and_compose
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
     from crawdad.config import CrawDadConfig
     from crawdad.mcp_client import ToolDetails
-    from crawdad.slash_commands import LoopRunner
+    from crawdad.slash_commands import LoopRunner, WorkflowRunner
     from crawdad.state import SessionState
 
 _LOGGER = logging.getLogger("crawdad.cli")
@@ -114,6 +115,13 @@ def run_bot(config: CrawDadConfig) -> None:
         session_state=session_state,
         skill_registry=skill_registry,
     )
+    workflow_registry = WorkflowRegistry(vault_path=config.vault_path)
+    workflow_runner = _build_workflow_runner(
+        components=components,
+        session_state=session_state,
+        skill_registry=skill_registry,
+        registry=workflow_registry,
+    )
     client = CrawDadClient(
         config=config,
         session_state=session_state,
@@ -127,8 +135,72 @@ def run_bot(config: CrawDadConfig) -> None:
         loop_runner=loop_runner,
         register_switcher=skill_registry.activate_register,
         pending_batches=pending_batches,
+        workflow_lister=_build_workflow_lister(workflow_registry),
+        workflow_runner=workflow_runner,
     )
     client.run(config.discord_bot_token)
+
+
+def _build_workflow_lister(
+    registry: WorkflowRegistry,
+) -> Callable[[], list[str]]:
+    """Return a closure that enumerates registry names for the slash command."""
+
+    def _lister() -> list[str]:
+        """Return discovered workflow names, sorted by name."""
+        return [wf.name for wf in registry.list()]
+
+    return _lister
+
+
+def _build_workflow_runner(
+    *,
+    components: _AgentComponents,
+    session_state: SessionState | None,
+    skill_registry: SkillStackRegistry,
+    registry: WorkflowRegistry,
+) -> WorkflowRunner | None:
+    """Return a closure that runs a named workflow end-to-end.
+
+    Returns ``None`` when the composer isn't wired (no MCP tools
+    advertised) — the slash command surface then soft-errors instead
+    of failing during workflow execution.
+    """
+    if components.composer is None:
+        return None
+    composer = components.composer
+    mcp_client = components.mcp_client
+    known_tools = components.known_tools
+
+    async def _runner(name: str, inputs: dict[str, str]) -> str:
+        """Run *name* by looking it up in the registry and composing the reply.
+
+        Surface failures (constraint errors, unknown name, composer
+        exceptions) as a single Discord-safe string so the slash command
+        can pass them through without translating again.
+        """
+        try:
+            workflow = registry.get(name)
+        except Exception as exc:
+            _LOGGER.warning("workflow lookup failed for %r: %s", name, exc)
+            return _truncate_for_discord(f"could not find workflow `{name}`: {exc}")
+        try:
+            reply = await run_workflow_and_compose(
+                workflow=workflow,
+                inputs=inputs,
+                state=session_state,
+                skills=skill_registry.stack,
+                skill_registry=skill_registry,
+                composer=composer,
+                mcp_client=mcp_client,
+                known_tools=known_tools,
+            )
+        except Exception as exc:
+            _LOGGER.warning("workflow %r failed mid-run: %s", name, exc)
+            return _truncate_for_discord(f"workflow `{name}` failed: {exc}")
+        return _truncate_for_discord(reply)
+
+    return _runner
 
 
 def _build_loop_runner(

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -113,6 +113,16 @@ _SURFACE_PROMPT = (
 WORKFLOW_ACTION_LIST = "list"
 WORKFLOW_ACTION_RUN = "run"
 _WORKFLOW_ACTIONS = (WORKFLOW_ACTION_LIST, WORKFLOW_ACTION_RUN)
+# Two missing-wiring strings so each action's failure mode is honest
+# about WHY it cannot proceed. ``list`` only reads the registry, so its
+# message talks about the registry; ``run`` drives the walker, so its
+# message talks about the walker. Conflating the two would have a
+# ``list`` failure claim "the walker has nothing to call" even when the
+# registry is the missing piece (PR #309 review feedback).
+_WORKFLOW_LISTER_MISSING_REPLY = (
+    "Workflows aren't available in this session — the registry wasn't wired "
+    "up (the MCP tool surface was empty at startup)."
+)
 _WORKFLOW_RUNNER_MISSING_REPLY = (
     "Workflows aren't wired up in this session — the MCP server probably "
     "advertised no tools, so the workflow walker has nothing to call."
@@ -264,7 +274,7 @@ async def _reply_workflow_list(
 ) -> None:
     """Format and send the workflow registry to the user."""
     if workflow_lister is None:
-        await replier(_WORKFLOW_RUNNER_MISSING_REPLY)
+        await replier(_WORKFLOW_LISTER_MISSING_REPLY)
         return
     names = workflow_lister()
     if not names:

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -1,4 +1,4 @@
-"""Discord slash commands for CrawDad (FEAT-016 + FEAT-029).
+"""Discord slash commands for CrawDad (FEAT-016 + FEAT-029 + ADAPT-003).
 
 The `/crawdad` family bundles `reflect`, `checkin`, `surface`, `draft`,
 `save`, `register`, and `workflow`. Most routes through the FEAT-015
@@ -8,14 +8,17 @@ wraps the tool results in the user's voice. ``register`` (FEAT-029)
 bypasses the loop and invokes the synchronous ``register_switcher``
 directly so voice-register changes are deterministic.
 
+``workflow`` (ADAPT-003 / issue #268) bypasses the router and uses a
+deterministic step walker over an authored YAML file. The slash
+command's ``action`` parameter switches between ``list`` (enumerate
+available workflows) and ``run`` (execute one by name).
+
 The handlers are free functions that take a tiny ``Replier`` callable
 (``async def (str) -> None``) so they can be unit-tested without
 discord.py. ``register()`` wraps each handler in a discord.py
 ``app_commands`` callback that ``defer()``s the interaction (LLM
 calls exceed Discord's 3-second response window), runs the handler,
 and ``followup.send()``s the reply.
-
-``/crawdad workflow`` is a v1.0 stub. Full workflow DSL ships in v1.1.
 
 Trust boundary: the user-supplied ``topic`` and ``content`` arguments
 are interpolated directly into LLM prompts. The personal-use allowlist
@@ -45,6 +48,15 @@ LoopRunner = Callable[[str], Awaitable[str]]
 # False on unknown / unsafe register names.
 RegisterSwitcher = Callable[[str], bool]
 
+# ADAPT-003: async callable that runs a named workflow end-to-end and
+# returns the user-facing reply. The CLI builds one by closing over the
+# per-session registry, walker, composer, and MCP client — see
+# :func:`crawdad.cli._build_workflow_runner`. Workflow runners receive
+# a ``name`` plus an ``inputs`` dict (currently always empty until the
+# Discord slash command grows a free-text input parameter; the kwarg
+# keeps the signature future-proof for FEAT-015-style follow-ups).
+WorkflowRunner = Callable[[str, dict[str, str]], Awaitable[str]]
+
 # Async callable that posts a message back to the Discord user.
 # Wraps ``discord.Interaction.followup.send`` in production; tests
 # substitute a list-appending fake.
@@ -68,7 +80,7 @@ _COMMAND_DESCRIPTIONS: dict[str, str] = {
     "draft": "Draft an essay on a topic (routes through creek.mine + creek.draft).",
     "save": "File the supplied content back to the vault via creek.save.",
     "register": "Switch the active voice register (FEAT-029).",
-    "workflow": "List or run named workflows (v1.0 stub — full DSL in v1.1).",
+    "workflow": "List or run named workflows (ADAPT-003).",
 }
 
 # Module-level invariant: every command name must have a description and
@@ -94,10 +106,16 @@ _SURFACE_PROMPT = (
     "Surface anything in my vault that's emerging — paradoxes, liminal items, or "
     "drift. Route paradoxes to 10-Liminal/Paradoxes/ via creek.save."
 )
-_WORKFLOW_STUB_REPLY = (
-    "no workflows yet — coming in v1.1.\n\n"
-    "The workflow DSL (ADAPT-003) will let you compose multi-step plans like "
-    "`/crawdad workflow run weekly-review`. v1.0 ships only this `list` stub."
+
+# ADAPT-003: workflow subaction names. Discord renders each command
+# parameter as a separate input field; ``action`` defaults to ``list``
+# so a bare ``/crawdad workflow`` enumerates the available workflows.
+WORKFLOW_ACTION_LIST = "list"
+WORKFLOW_ACTION_RUN = "run"
+_WORKFLOW_ACTIONS = (WORKFLOW_ACTION_LIST, WORKFLOW_ACTION_RUN)
+_WORKFLOW_RUNNER_MISSING_REPLY = (
+    "Workflows aren't wired up in this session — the MCP server probably "
+    "advertised no tools, so the workflow walker has nothing to call."
 )
 
 
@@ -207,27 +225,91 @@ async def handle_register(
     )
 
 
-async def handle_workflow(replier: Replier, *, subaction: str | None) -> None:
-    """``/crawdad workflow [list]`` — v1.0 stub.
+async def handle_workflow(
+    replier: Replier,
+    *,
+    action: str | None,
+    name: str,
+    workflow_lister: Callable[[], list[str]] | None,
+    workflow_runner: WorkflowRunner | None,
+) -> None:
+    """``/crawdad workflow [list|run] [name]`` — ADAPT-003 dispatcher.
 
-    ``list`` (the default) returns the documented placeholder. Any
-    other subaction returns scoped help — no MCP call, no stack trace.
+    Action semantics:
+
+    * ``list`` (default) — return the registered workflow names. No
+      MCP call. Always safe even when the agent loop is unwired.
+    * ``run <name>`` — execute the named workflow via the supplied
+      runner. ``name`` is required; the runner produces the final
+      composer reply or raises one of the workflow-module errors,
+      which this handler maps to a user-facing soft error.
+
+    Unknown actions return scoped help text.
     """
-    if subaction in (None, "list"):
-        await replier(_WORKFLOW_STUB_REPLY)
+    chosen = (action or WORKFLOW_ACTION_LIST).strip().lower()
+    if chosen == WORKFLOW_ACTION_LIST:
+        await _reply_workflow_list(replier, workflow_lister)
+        return
+    if chosen == WORKFLOW_ACTION_RUN:
+        await _reply_workflow_run(replier, name=name, workflow_runner=workflow_runner)
         return
     await replier(
-        f"unknown workflow subcommand: {subaction!r}. "
-        "Only `/crawdad workflow list` is available in v1.0."
+        f"unknown workflow action: {chosen!r}. "
+        f"Try one of: {', '.join(_WORKFLOW_ACTIONS)}."
     )
+
+
+async def _reply_workflow_list(
+    replier: Replier, workflow_lister: Callable[[], list[str]] | None
+) -> None:
+    """Format and send the workflow registry to the user."""
+    if workflow_lister is None:
+        await replier(_WORKFLOW_RUNNER_MISSING_REPLY)
+        return
+    names = workflow_lister()
+    if not names:
+        await replier(
+            "No workflows registered yet. Drop a `*.workflow.yaml` file under "
+            "`<vault>/00-Creek-Meta/Workflows/` to author one."
+        )
+        return
+    lines = ["**Workflows**"]
+    lines.extend(f"- `/crawdad workflow run {n}`" for n in names)
+    await replier("\n".join(lines))
+
+
+async def _reply_workflow_run(
+    replier: Replier,
+    *,
+    name: str,
+    workflow_runner: WorkflowRunner | None,
+) -> None:
+    """Drive a workflow run by name, mapping errors to soft replies."""
+    cleaned = name.strip()
+    if not cleaned:
+        await replier(
+            "I need a workflow name to run. Try "
+            "`/crawdad workflow list` to see the registered workflows."
+        )
+        return
+    if workflow_runner is None:
+        await replier(_WORKFLOW_RUNNER_MISSING_REPLY)
+        return
+    try:
+        reply = await workflow_runner(cleaned, {})
+    except Exception as exc:
+        _LOGGER.warning("workflow %r failed: %s", cleaned, exc)
+        await replier(f"workflow `{cleaned}` could not run: {exc}")
+        return
+    await replier(reply)
 
 
 async def handle_help(replier: Replier) -> None:
     """Compose a help summary listing every ``/crawdad`` command.
 
     Not registered as a Discord slash command — Discord's autocomplete
-    UI already surfaces the six registered commands and their
-    descriptions. ``handle_help`` is kept as a public helper so:
+    UI already surfaces the registered commands and their descriptions.
+    ``handle_help`` is kept as a public helper so:
 
     * Tests can drive the help-text format directly.
     * Future surfaces (a v1.1 ``/crawdad help`` variant, an operator
@@ -252,6 +334,8 @@ def register(
     *,
     loop_runner: LoopRunner,
     register_switcher: RegisterSwitcher | None = None,
+    workflow_lister: Callable[[], list[str]] | None = None,
+    workflow_runner: WorkflowRunner | None = None,
 ) -> int:
     """Register every ``/crawdad`` slash command on the supplied tree.
 
@@ -265,6 +349,11 @@ def register(
     register. ``None`` keeps the command wired but the handler short-
     circuits to a soft-error reply explaining the feature is unwired.
 
+    ``workflow_lister`` and ``workflow_runner`` (ADAPT-003) supply the
+    ``list`` and ``run`` subactions of ``/crawdad workflow``. Both
+    default to ``None`` (e.g. tests / no-tool-surface sessions); in
+    that case the workflow command soft-errors instead of crashing.
+
     Returns the count of advertised commands (always
     ``len(CRAWDAD_COMMANDS)`` since the registration helpers don't
     fail). The return value is a sanity-check signal callers can pin
@@ -276,7 +365,9 @@ def register(
     _register_draft(tree, loop_runner=loop_runner)
     _register_save(tree, loop_runner=loop_runner)
     _register_register(tree, register_switcher=register_switcher)
-    _register_workflow(tree)
+    _register_workflow(
+        tree, workflow_lister=workflow_lister, workflow_runner=workflow_runner
+    )
     return len(CRAWDAD_COMMANDS)
 
 
@@ -361,11 +452,22 @@ def _register_register(
         )
 
 
-def _register_workflow(tree: _TreeLike) -> None:
+def _register_workflow(
+    tree: _TreeLike,
+    *,
+    workflow_lister: Callable[[], list[str]] | None,
+    workflow_runner: WorkflowRunner | None,
+) -> None:
     """Wire the ``/crawdad workflow`` Discord callback onto *tree*."""
 
     @tree.command(name="workflow", description=_COMMAND_DESCRIPTIONS["workflow"])
-    async def _callback(interaction: Any, subaction: str = "list") -> None:
-        """Discord callback for ``/crawdad workflow [subaction]`` (deferred)."""
+    async def _callback(interaction: Any, action: str = "list", name: str = "") -> None:
+        """Discord callback for ``/crawdad workflow [action] [name]`` (deferred)."""
         await interaction.response.defer()
-        await handle_workflow(interaction.followup.send, subaction=subaction)
+        await handle_workflow(
+            interaction.followup.send,
+            action=action,
+            name=name,
+            workflow_lister=workflow_lister,
+            workflow_runner=workflow_runner,
+        )

--- a/crawdad/crawdad/workflows.py
+++ b/crawdad/crawdad/workflows.py
@@ -375,6 +375,14 @@ class WorkflowRegistry:
     Malformed files are logged at WARNING and skipped so a single typo
     in the vault directory does not deny access to every other
     workflow.
+
+    Caching: the first :meth:`list` / :meth:`get` call loads every file
+    and pins the result. Subsequent calls reuse the cache for the
+    lifetime of the registry instance, so a workflow added to the
+    vault directory mid-session is NOT visible until the bot is
+    restarted. This matches the FEAT-013 read-once startup pattern
+    used elsewhere in CrawDad and is intentional — workflows are
+    authored artifacts, not live state.
     """
 
     def __init__(
@@ -605,6 +613,15 @@ async def run_workflow_and_compose(
     The walker bypasses the FEAT-014 router but reuses the FEAT-015
     composer so workflow output sounds like every other CrawDad reply
     — voice-faithful, phase-aware, paradox-tolerant.
+
+    Skill-stack resolution mirrors the FEAT-029 ``AgentLoop`` pattern:
+    when ``skill_registry`` is supplied its ``.stack`` wins and the
+    ``skills`` argument is the fallback used only when the registry is
+    ``None``. The CLI runner always provides both (with ``skills``
+    defaulting to ``registry.stack``) so the registry's live, swap-
+    after-startup behaviour persists across turns; callers without a
+    registry (e.g. early unit tests) can hand a static stack in via
+    ``skills``.
 
     Returns the composer's text reply. Constraint failures bubble up as
     :class:`WorkflowConstraintError`; the caller is responsible for

--- a/crawdad/crawdad/workflows.py
+++ b/crawdad/crawdad/workflows.py
@@ -1,0 +1,647 @@
+"""Workflow DSL (ADAPT-003 / issue #268).
+
+CrawDad composite commands compile down to a deterministic walk over
+authored YAML files. Each file declares a named workflow: a list of
+:class:`WorkflowStep` entries that map one-to-one to MCP tool calls,
+plus first-class constraint metadata (``phase_aware`` /
+``privacy_tier_floor``) the walker enforces before any tool fires.
+
+File format
+-----------
+
+Plain YAML. No custom grammar, no Jinja2 dependency. A workflow file
+looks like::
+
+    name: substack-draft-phase-transitions
+    description: Draft a Substack post on phase transitions
+    trigger: "/crawdad workflow run substack-draft-phase-transitions"
+    phase_aware: true
+    allowed_phases: [rising, peak]
+    privacy_tier_floor: personal
+    inputs: [topic]
+    steps:
+      - id: read
+        tool: creek.state.read
+        args: { period: weekly }
+      - id: mine
+        tool: creek.mine
+        args:
+          strategy: thread-terminus
+          phase: "{{state.phase}}"
+          topic: "{{input.topic}}"
+
+File location
+-------------
+
+Two-source registry, decided in
+``docs/adr/2026-05-24_workflow-file-location.md``:
+
+1. Built-in reference workflows ship in
+   :data:`BUILTIN_WORKFLOWS_DIR` (this package). They are checked into
+   the repo and discoverable on every install.
+2. User-authored workflows live in
+   ``<vault>/00-Creek-Meta/Workflows/`` (see :data:`VAULT_WORKFLOWS_SUBPATH`).
+   A user file with the same ``name`` as a built-in wins.
+
+Interpolation
+-------------
+
+Step ``args`` strings may reference three namespaces inside ``{{...}}``::
+
+    {{state.phase}}        -> phase slug extracted from latest.md (or "")
+    {{state.wavelength}}   -> raw wavelength snapshot text (or "")
+    {{input.<key>}}        -> caller-supplied input value (or "")
+    {{step.<id>.body}}     -> previous step's tool-result body (or "")
+
+Unknown namespaces are left in place verbatim — that surfaces a typo
+to the workflow author instead of silently swallowing it.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from crawdad.dispatcher import ToolResult
+from crawdad.intents import PrivacyTierCeiling
+
+if TYPE_CHECKING:
+    from crawdad.mcp_client import MCPClient
+    from crawdad.skill_loader import SkillStackRegistry, VoiceSkillStack
+    from crawdad.state import SessionState
+
+_LOGGER = logging.getLogger("crawdad.workflows")
+
+# Built-in reference workflows are co-located with the package source so
+# they ship on every install and remain discoverable by the registry
+# without any vault layout. The directory contains one
+# ``*.workflow.yaml`` file per workflow.
+BUILTIN_WORKFLOWS_DIR: Path = Path(__file__).resolve().parent / "builtin_workflows"
+
+# Vault-relative subpath the registry scans for user-authored workflows.
+# Mirrors the existing ``00-Creek-Meta/State/`` convention so workflows
+# land in a single canonical Creek-Meta home.
+VAULT_WORKFLOWS_SUBPATH: Path = Path("00-Creek-Meta") / "Workflows"
+
+_WORKFLOW_FILE_SUFFIX = ".workflow.yaml"
+
+# ``\w`` matches the YAML-friendly subset we accept inside placeholder
+# tokens (alphanumerics, underscore). Dotted access is the only nesting
+# syntax — anything richer requires Jinja2 and pulls in a dependency the
+# v1.1 surface does not need yet.
+_PLACEHOLDER_RE = re.compile(r"\{\{\s*([\w.]+)\s*\}\}")
+
+# Phase regex matches FEAT-015 / skill_loader extraction so a workflow's
+# ``state.phase`` reference is the same slug the voice-skill loader uses.
+_PHASE_RE = re.compile(r"phase[:\s]*\*{0,2}([a-z\-]+)", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class WorkflowParseError(RuntimeError):
+    """A workflow YAML file could not be loaded or did not match the schema.
+
+    Surfaces YAML syntax errors and Pydantic validation errors as a
+    single error type so callers only need one ``except`` clause.
+    """
+
+
+class WorkflowConstraintError(RuntimeError):
+    """The walker refused to run a workflow because a declared constraint failed.
+
+    Raised for any of: missing required input, missing session-state
+    phase when ``phase_aware: true``, current phase not in
+    ``allowed_phases``, or a step referencing an unadvertised MCP tool.
+    """
+
+
+class WorkflowNotFoundError(RuntimeError):
+    """No workflow with the requested name was found in the registry."""
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class WorkflowStep(BaseModel):
+    """One MCP tool call inside a workflow.
+
+    ``id`` is the addressable handle later steps reference via
+    ``{{step.<id>.body}}``. ``tool`` is the MCP tool name, validated
+    against the live ``known_tools`` set at walk time. ``args`` is the
+    raw arg dict; any nested string is interpolated by the walker.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(min_length=1)
+    tool: str = Field(min_length=1)
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkflowDefinition(BaseModel):
+    """An authored workflow loaded from a ``*.workflow.yaml`` file.
+
+    ``phase_aware`` and ``privacy_tier_floor`` are the AC's first-class
+    constraint attributes. The walker treats them as soft-fail gates
+    rather than runtime errors so the slash-command surface can return
+    a clean user-facing message instead of a stack trace.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str = Field(min_length=1)
+    description: str
+    trigger: str | None = None
+    phase_aware: bool = False
+    allowed_phases: tuple[str, ...] = ()
+    privacy_tier_floor: PrivacyTierCeiling = PrivacyTierCeiling.OPEN
+    inputs: tuple[str, ...] = ()
+    steps: tuple[WorkflowStep, ...]
+
+    @field_validator("steps")
+    @classmethod
+    def _validate_steps(
+        cls, value: tuple[WorkflowStep, ...]
+    ) -> tuple[WorkflowStep, ...]:
+        """Refuse empty step lists and duplicate step ids."""
+        if not value:
+            msg = "workflow must declare at least one step"
+            raise ValueError(msg)
+        seen: set[str] = set()
+        for step in value:
+            if step.id in seen:
+                msg = f"duplicate step id {step.id!r} in workflow"
+                raise ValueError(msg)
+            seen.add(step.id)
+        return value
+
+
+# ---------------------------------------------------------------------------
+# Loader
+# ---------------------------------------------------------------------------
+
+
+def load_workflow_from_yaml(path: Path) -> WorkflowDefinition:
+    """Read and validate a workflow file.
+
+    Args:
+        path: Filesystem path to a ``*.workflow.yaml`` document.
+
+    Returns:
+        A frozen :class:`WorkflowDefinition`.
+
+    Raises:
+        WorkflowParseError: file missing, YAML invalid, or schema mismatch.
+    """
+    if not path.is_file():
+        msg = f"workflow file not found: {path}"
+        raise WorkflowParseError(msg)
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        msg = f"invalid YAML in {path}: {exc}"
+        raise WorkflowParseError(msg) from exc
+    if not isinstance(raw, dict):
+        msg = f"workflow document at {path} must be a mapping at the top level"
+        raise WorkflowParseError(msg)
+    try:
+        return WorkflowDefinition.model_validate(raw)
+    except ValidationError as exc:
+        msg = f"workflow schema validation failed for {path}: {exc}"
+        raise WorkflowParseError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# Phase resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_phase(state: SessionState | None) -> str | None:
+    """Extract the phase slug from a session state's wavelength snapshot.
+
+    Returns ``None`` when there is no state, no wavelength snapshot, or
+    no recognisable ``Phase: **<slug>**`` token. Mirrors the slug-shape
+    convention used in :mod:`crawdad.skill_loader` so a workflow's
+    ``{{state.phase}}`` value matches the voice-skill loader's phase.
+    """
+    if state is None or not state.wavelength_snapshot:
+        return None
+    match = _PHASE_RE.search(state.wavelength_snapshot)
+    if match is None:
+        return None
+    return match.group(1).lower()
+
+
+# ---------------------------------------------------------------------------
+# Interpolation
+# ---------------------------------------------------------------------------
+
+
+def interpolate(
+    value: Any,
+    *,
+    state: SessionState | None,
+    inputs: dict[str, str],
+    step_results: dict[str, ToolResult],
+) -> Any:
+    """Recursively resolve ``{{...}}`` placeholders inside *value*.
+
+    String values are scanned with :data:`_PLACEHOLDER_RE`; each match
+    is resolved against the supplied state, inputs, and prior step
+    results. Dicts and lists are recursed element-wise so a deeply
+    nested ``args`` block (e.g. ``{"filters": {"phase": "..."}}``) is
+    interpolated through.
+
+    Non-string scalars (int, bool, None, etc.) are returned unchanged.
+    Unknown namespaces are left in place verbatim — surfacing a typo
+    in MCP logs is more useful than silently swallowing it.
+    """
+    if isinstance(value, str):
+        return _interpolate_string(
+            value, state=state, inputs=inputs, step_results=step_results
+        )
+    if isinstance(value, dict):
+        return {
+            k: interpolate(v, state=state, inputs=inputs, step_results=step_results)
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            interpolate(item, state=state, inputs=inputs, step_results=step_results)
+            for item in value
+        ]
+    return value
+
+
+def _interpolate_string(
+    text: str,
+    *,
+    state: SessionState | None,
+    inputs: dict[str, str],
+    step_results: dict[str, ToolResult],
+) -> str:
+    """Scan *text* and substitute every recognised ``{{...}}`` placeholder."""
+
+    def _replace(match: re.Match[str]) -> str:
+        token = match.group(1)
+        resolved = _resolve_token(
+            token, state=state, inputs=inputs, step_results=step_results
+        )
+        if resolved is None:
+            # Unknown namespace — leave placeholder untouched so the
+            # author sees the typo in MCP logs rather than silently
+            # getting an empty string.
+            return match.group(0)
+        return resolved
+
+    return _PLACEHOLDER_RE.sub(_replace, text)
+
+
+def _resolve_token(
+    token: str,
+    *,
+    state: SessionState | None,
+    inputs: dict[str, str],
+    step_results: dict[str, ToolResult],
+) -> str | None:
+    """Return the resolved value for *token*, or ``None`` for unknown namespaces."""
+    parts = token.split(".")
+    namespace = parts[0]
+    if namespace == "state":
+        return _resolve_state(parts[1:], state)
+    if namespace == "input":
+        return _resolve_input(parts[1:], inputs)
+    if namespace == "step":
+        return _resolve_step(parts[1:], step_results)
+    return None
+
+
+def _resolve_state(parts: list[str], state: SessionState | None) -> str:
+    """Resolve ``state.<field>`` references. Missing values → empty string."""
+    if not parts or state is None:
+        return ""
+    field = parts[0]
+    if field == "phase":
+        return resolve_phase(state) or ""
+    if field == "wavelength":
+        return state.wavelength_snapshot or ""
+    return ""
+
+
+def _resolve_input(parts: list[str], inputs: dict[str, str]) -> str:
+    """Resolve ``input.<key>`` references. Missing keys → empty string."""
+    if not parts:
+        return ""
+    return inputs.get(parts[0], "")
+
+
+def _resolve_step(parts: list[str], step_results: dict[str, ToolResult]) -> str:
+    """Resolve ``step.<id>.<field>`` references. Missing ids → empty string."""
+    if len(parts) < 2:
+        return ""
+    step_id, field = parts[0], parts[1]
+    result = step_results.get(step_id)
+    if result is None:
+        return ""
+    if field == "body":
+        return result.body
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class WorkflowRegistry:
+    """Discover and look up workflow definitions.
+
+    The registry scans two sources in order:
+
+    1. :data:`BUILTIN_WORKFLOWS_DIR` — packaged reference workflows.
+    2. ``<vault>/00-Creek-Meta/Workflows/`` — user-authored files.
+
+    A user-authored workflow with the same ``name`` as a built-in wins.
+    Malformed files are logged at WARNING and skipped so a single typo
+    in the vault directory does not deny access to every other
+    workflow.
+    """
+
+    def __init__(
+        self,
+        *,
+        vault_path: Path,
+        builtin_dir: Path = BUILTIN_WORKFLOWS_DIR,
+    ) -> None:
+        """Cache the discovery paths. Workflows are loaded lazily on access."""
+        self._vault_path = vault_path
+        self._builtin_dir = builtin_dir
+        self._cache: dict[str, WorkflowDefinition] | None = None
+
+    def list(self) -> list[WorkflowDefinition]:
+        """Return every discovered workflow, sorted by name."""
+        return sorted(self._all().values(), key=lambda wf: wf.name)
+
+    def get(self, name: str) -> WorkflowDefinition:
+        """Return the workflow matching *name*.
+
+        Raises:
+            WorkflowNotFoundError: no workflow with that name exists.
+        """
+        workflows = self._all()
+        if name not in workflows:
+            available = ", ".join(sorted(workflows)) or "(none)"
+            msg = f"no workflow named {name!r}; available: {available}"
+            raise WorkflowNotFoundError(msg)
+        return workflows[name]
+
+    def _all(self) -> dict[str, WorkflowDefinition]:
+        """Return ``{name: workflow}`` for every discoverable workflow.
+
+        Built-ins first, then vault user-authored — the second write
+        wins, so a vault override replaces the built-in entry.
+        """
+        if self._cache is not None:
+            return self._cache
+        collected: dict[str, WorkflowDefinition] = {}
+        _absorb_dir(collected, self._builtin_dir)
+        _absorb_dir(collected, self._vault_path / VAULT_WORKFLOWS_SUBPATH)
+        self._cache = collected
+        return collected
+
+
+def _absorb_dir(target: dict[str, WorkflowDefinition], directory: Path) -> None:
+    """Load every ``*.workflow.yaml`` file from *directory* into *target*.
+
+    Missing or non-directory paths are silently ignored. Files that
+    fail to parse are logged at WARNING and skipped so one typo cannot
+    deny access to every other workflow.
+    """
+    if not directory.is_dir():
+        return
+    for path in sorted(directory.glob(f"*{_WORKFLOW_FILE_SUFFIX}")):
+        try:
+            wf = load_workflow_from_yaml(path)
+        except WorkflowParseError as exc:
+            _LOGGER.warning("skipping invalid workflow %s: %s", path, exc)
+            continue
+        target[wf.name] = wf
+
+
+# ---------------------------------------------------------------------------
+# Walker
+# ---------------------------------------------------------------------------
+
+
+class WorkflowWalker:
+    """Deterministic step walker for an authored workflow.
+
+    The walker opens a single MCP session per workflow run, calls each
+    step's tool with its interpolated args, and returns the ordered
+    list of :class:`ToolResult` envelopes. The LLM router is bypassed
+    entirely — the workflow file IS the routing decision.
+    """
+
+    def __init__(
+        self,
+        *,
+        mcp_client: MCPClient | Any,
+        known_tools: tuple[str, ...] | frozenset[str],
+    ) -> None:
+        """Cache the MCP client and the advertised tool surface."""
+        self._mcp_client = mcp_client
+        self._known_tools = frozenset(known_tools)
+
+    async def run(
+        self,
+        workflow: WorkflowDefinition,
+        *,
+        state: SessionState | None,
+        inputs: dict[str, str],
+    ) -> list[ToolResult]:
+        """Execute *workflow* against the current session.
+
+        Args:
+            workflow: The definition to run.
+            state: Session state for phase resolution / ``state.*``
+                interpolation. ``None`` is allowed for non-phase-aware
+                workflows.
+            inputs: User-supplied input values for ``{{input.<key>}}``
+                references.
+
+        Returns:
+            One :class:`ToolResult` per step, in document order.
+
+        Raises:
+            WorkflowConstraintError: a declared constraint refused the
+                run — missing input, wrong phase, unknown tool, etc.
+        """
+        self._check_constraints(workflow, state=state, inputs=inputs)
+        async with self._mcp_client.connect() as session:
+            return await self._execute_steps(
+                workflow, session=session, state=state, inputs=inputs
+            )
+
+    def _check_constraints(
+        self,
+        workflow: WorkflowDefinition,
+        *,
+        state: SessionState | None,
+        inputs: dict[str, str],
+    ) -> None:
+        """Validate phase, inputs, and tool surface before any tool fires."""
+        missing_inputs = [name for name in workflow.inputs if name not in inputs]
+        if missing_inputs:
+            msg = (
+                f"workflow {workflow.name!r} requires inputs {missing_inputs} "
+                "that were not provided"
+            )
+            raise WorkflowConstraintError(msg)
+        unknown_tools = [
+            step.tool for step in workflow.steps if step.tool not in self._known_tools
+        ]
+        if unknown_tools:
+            msg = (
+                f"workflow {workflow.name!r} references tools that are not "
+                f"advertised by the MCP server: {unknown_tools}"
+            )
+            raise WorkflowConstraintError(msg)
+        if workflow.phase_aware:
+            self._check_phase(workflow, state)
+
+    def _check_phase(
+        self, workflow: WorkflowDefinition, state: SessionState | None
+    ) -> None:
+        """Refuse phase-aware workflows when the current phase doesn't match."""
+        phase = resolve_phase(state)
+        if phase is None:
+            msg = (
+                f"workflow {workflow.name!r} is phase-aware but no session "
+                "phase is available — run `creek state` first"
+            )
+            raise WorkflowConstraintError(msg)
+        if workflow.allowed_phases and phase not in workflow.allowed_phases:
+            msg = (
+                f"workflow {workflow.name!r} refuses to run in phase "
+                f"{phase!r}; allowed phases: {list(workflow.allowed_phases)}"
+            )
+            raise WorkflowConstraintError(msg)
+
+    async def _execute_steps(
+        self,
+        workflow: WorkflowDefinition,
+        *,
+        session: Any,
+        state: SessionState | None,
+        inputs: dict[str, str],
+    ) -> list[ToolResult]:
+        """Walk each step in order, threading prior results into later args."""
+        step_results: dict[str, ToolResult] = {}
+        ordered: list[ToolResult] = []
+        for step in workflow.steps:
+            resolved_args = interpolate(
+                step.args, state=state, inputs=inputs, step_results=step_results
+            )
+            arguments = _build_call_arguments(
+                resolved_args, workflow.privacy_tier_floor
+            )
+            body = await session.call_tool(step.tool, arguments)
+            result = ToolResult(
+                intent_type=step.tool,
+                body=body,
+                privacy_tier_ceiling=workflow.privacy_tier_floor,
+            )
+            step_results[step.id] = result
+            ordered.append(result)
+        return ordered
+
+
+def _build_call_arguments(
+    resolved_args: Any, floor: PrivacyTierCeiling
+) -> dict[str, Any]:
+    """Merge interpolated args with the privacy floor, matching dispatcher semantics.
+
+    The MCP server reads ``privacy_tier_ceiling`` as a sibling argument
+    on every tool call (see :mod:`crawdad.dispatcher._build_arguments`).
+    The workflow's declared floor is the contract; any colliding key
+    in the user-authored args is overwritten so a workflow author
+    cannot accidentally smuggle a looser tier in through the args dict.
+    """
+    payload: dict[str, Any] = (
+        dict(resolved_args) if isinstance(resolved_args, dict) else {}
+    )
+    payload["privacy_tier_ceiling"] = floor.value
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# High-level runner
+# ---------------------------------------------------------------------------
+
+
+async def run_workflow_and_compose(
+    *,
+    workflow: WorkflowDefinition,
+    inputs: dict[str, str],
+    state: SessionState | None,
+    skills: VoiceSkillStack,
+    skill_registry: SkillStackRegistry | None,
+    composer: Any,
+    mcp_client: Any,
+    known_tools: tuple[str, ...],
+) -> str:
+    """Walk *workflow* end-to-end and ask the composer for the user-facing reply.
+
+    The walker bypasses the FEAT-014 router but reuses the FEAT-015
+    composer so workflow output sounds like every other CrawDad reply
+    — voice-faithful, phase-aware, paradox-tolerant.
+
+    Returns the composer's text reply. Constraint failures bubble up as
+    :class:`WorkflowConstraintError`; the caller is responsible for
+    mapping them to a Discord soft error.
+    """
+    from crawdad.history import ConversationHistory
+
+    walker = WorkflowWalker(mcp_client=mcp_client, known_tools=known_tools)
+    results = await walker.run(workflow, state=state, inputs=inputs)
+    active_skills = skills if skill_registry is None else skill_registry.stack
+    pseudo_message = _synthesize_user_message(workflow, inputs)
+    reply = await composer.compose(
+        user_message=pseudo_message,
+        tool_results=results,
+        history=ConversationHistory(),
+        state=state,
+        skills=active_skills,
+    )
+    return cast("str", reply)
+
+
+def _synthesize_user_message(
+    workflow: WorkflowDefinition, inputs: dict[str, str]
+) -> str:
+    """Return the synthetic user message the composer sees for a workflow run.
+
+    The composer expects a user message describing intent; for a
+    workflow run there is no free-text turn, so we fabricate one from
+    the workflow name + description + supplied inputs. This lets the
+    composer condition its reply on the right context without changing
+    its interface.
+    """
+    lines = [
+        f"Run workflow: {workflow.name}.",
+        workflow.description,
+    ]
+    if inputs:
+        rendered = ", ".join(f"{k}={v!r}" for k, v in sorted(inputs.items()))
+        lines.append(f"Inputs: {rendered}.")
+    return "\n".join(lines)

--- a/crawdad/docs/adr/2026-05-24_workflow-file-location.md
+++ b/crawdad/docs/adr/2026-05-24_workflow-file-location.md
@@ -1,0 +1,79 @@
+# ADR: Workflow file location
+
+- **Date**: 2026-05-24
+- **Issue**: #268 (ADAPT-003 — Jig-style workflow DSL for CrawDad)
+- **Status**: Accepted
+
+## Context
+
+ADAPT-003 introduces an authored workflow DSL for CrawDad's composite
+commands. The acceptance criteria require:
+
+1. At least three reference workflows ship with the project (Substack
+   draft, Wavelength check-in, Compost surfacing).
+2. Workflow files are checked into version control; modifications go
+   through normal review/PR flow.
+3. Users can author their own workflows.
+
+The issue body's implementation notes flagged the location as an open
+question, with two candidate homes:
+
+- **`crawdad/crawdad/workflows/` inside the package** — matches the
+  example in the original ADAPT-003 plan, ships with the install, but
+  forces users to edit installed package files to author their own
+  workflow.
+- **`<vault>/00-Creek-Meta/Workflows/` inside the vault** — composes
+  with the rest of the vault scaffolding (`State/`, `Inbound/`,
+  `Paradoxes/`), keeps user content out of the package, but does NOT
+  by itself satisfy the "checked into the repo" AC.
+
+## Decision
+
+**Two-source registry.** The :class:`crawdad.workflows.WorkflowRegistry`
+scans:
+
+1. `crawdad/crawdad/builtin_workflows/` — the three reference workflows
+   ship here, are version-controlled in the monorepo, and load on
+   every install. This satisfies AC 1 and AC 2.
+2. `<vault>/00-Creek-Meta/Workflows/` — user-authored workflows land
+   here, alongside the existing Creek-Meta substructure. The directory
+   is created lazily on first use. This satisfies AC 3.
+
+User-authored files with the same `name` as a built-in **win** — that
+gives the user an override path without having to edit the package.
+
+## Consequences
+
+- **Built-in reference workflows are immutable per install.** Editing
+  the bundled YAML files is technically possible but is not the
+  authoring path; bumping a reference workflow requires a PR.
+- **No cross-vault sharing of user workflows.** Two vaults on the same
+  machine have independent `Workflows/` directories. Acceptable for
+  the personal-use deployment target.
+- **The package gains a new data directory.** Setuptools `packages.find`
+  already includes the `crawdad` package; the YAML files ship as
+  package data automatically because they live under the package
+  source tree.
+- **Future migration path.** If we ever want a shared / cross-vault
+  workflow registry, the registry's two-source design extends cleanly
+  to a third source (e.g. `~/.config/crawdad/workflows/`) without
+  changing the call sites.
+
+## Rejected alternatives
+
+- **Vault-only.** Would require shipping reference workflows as part
+  of `creek init`-style scaffolding inside `creek-tools`. That couples
+  CrawDad's behaviour to `creek-tools` deployment timing and forces
+  re-scaffold for existing vaults — more friction than the two-source
+  registry resolves.
+- **Package-only.** Forces users to either fork the package or write
+  workflows into the install path, both of which break with package
+  upgrades. Rejected.
+
+## References
+
+- Issue #268 (this ADR's tracker).
+- ADAPT-003 plan, recovered from commit `3363e52`
+  (`plans/2026-05-05_comparative-analysis/candidates/ADAPT-003-jig-style-workflow-dsl.md`).
+- `crawdad/crawdad/workflows.py` — implementation.
+- `crawdad/crawdad/builtin_workflows/*.workflow.yaml` — reference workflows.

--- a/crawdad/pyproject.toml
+++ b/crawdad/pyproject.toml
@@ -53,6 +53,13 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 include = ["crawdad", "crawdad.*"]
 
+# ADAPT-003: ship the reference workflow YAML files alongside the
+# package so ``crawdad.workflows.BUILTIN_WORKFLOWS_DIR`` resolves to a
+# populated directory after ``pip install crawdad`` (not only in editable
+# / source installs).
+[tool.setuptools.package-data]
+crawdad = ["builtin_workflows/*.workflow.yaml"]
+
 [tool.pytest.ini_options]
 minversion = "7.0"
 addopts = [

--- a/crawdad/tests/test_cli.py
+++ b/crawdad/tests/test_cli.py
@@ -472,3 +472,172 @@ def test_run_bot_passes_loop_runner_when_loop_wired(
 
     assert captured["init_kwargs"]["loop_runner"] is not None
     assert callable(captured["init_kwargs"]["loop_runner"])
+
+
+def test_run_bot_passes_workflow_runner_and_lister_when_loop_wired(
+    patched_config: CrawDadConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    vault_with_state: Path,
+) -> None:
+    """``run_bot`` wires a workflow runner + lister alongside the loop runner."""
+    from crawdad.mcp_client import ToolDetails
+
+    config = patched_config.model_copy(update={"vault_path": vault_with_state})
+    captured: dict[str, Any] = {}
+
+    class _FakeClient:
+        def __init__(self, **kwargs: Any) -> None:
+            captured["init_kwargs"] = kwargs
+
+        def run(self, _token: str) -> None:
+            captured["ran"] = True
+
+    async def _ok_probe(_c: CrawDadConfig) -> tuple[ToolDetails, ...]:
+        return (
+            ToolDetails(
+                name="creek.state.read",
+                description="Read latest.md",
+                input_schema={"type": "object"},
+            ),
+        )
+
+    monkeypatch.setattr(cli, "CrawDadClient", _FakeClient)
+    monkeypatch.setattr(cli, "_startup_probe", _ok_probe)
+
+    cli.run_bot(config)
+
+    assert callable(captured["init_kwargs"]["workflow_lister"])
+    listed = captured["init_kwargs"]["workflow_lister"]()
+    assert "wavelength-checkin" in listed
+    assert captured["init_kwargs"]["workflow_runner"] is not None
+    assert callable(captured["init_kwargs"]["workflow_runner"])
+
+
+def test_build_workflow_runner_returns_none_when_composer_unset(
+    patched_config: CrawDadConfig, tmp_path: Path
+) -> None:
+    """No composer → no workflow runner (slash command will soft-error)."""
+    from crawdad.workflows import WorkflowRegistry
+
+    components = cli._build_agent_components(config=patched_config, tool_details=())
+    registry = WorkflowRegistry(vault_path=tmp_path)
+
+    runner = cli._build_workflow_runner(
+        components=components,
+        session_state=None,
+        skill_registry=_empty_registry(tmp_path),
+        registry=registry,
+    )
+
+    assert runner is None
+
+
+async def test_build_workflow_runner_returns_string_on_unknown_workflow(
+    patched_config: CrawDadConfig, tmp_path: Path
+) -> None:
+    """An unknown workflow name lands as a Discord-safe error string."""
+    from crawdad.mcp_client import ToolDetails
+    from crawdad.workflows import WorkflowRegistry
+
+    details = (
+        ToolDetails(
+            name="creek.state.read",
+            description="Read",
+            input_schema={"type": "object"},
+        ),
+    )
+    components = cli._build_agent_components(
+        config=patched_config, tool_details=details
+    )
+    registry = WorkflowRegistry(vault_path=tmp_path)
+
+    runner = cli._build_workflow_runner(
+        components=components,
+        session_state=None,
+        skill_registry=_empty_registry(tmp_path),
+        registry=registry,
+    )
+
+    assert runner is not None
+    reply = await runner("does-not-exist", {})
+    assert "does-not-exist" in reply
+    assert "could not find" in reply.lower()
+
+
+async def test_build_workflow_runner_returns_string_on_workflow_failure(
+    patched_config: CrawDadConfig,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A walker / composer error lands as a Discord-safe error string."""
+    from crawdad.mcp_client import ToolDetails
+    from crawdad.workflows import WorkflowRegistry
+
+    details = (
+        ToolDetails(
+            name="creek.state.read",
+            description="Read",
+            input_schema={"type": "object"},
+        ),
+    )
+    components = cli._build_agent_components(
+        config=patched_config, tool_details=details
+    )
+    registry = WorkflowRegistry(vault_path=tmp_path)
+
+    async def _boom(**_kwargs: Any) -> Any:
+        msg = "simulated boom"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(cli, "run_workflow_and_compose", _boom)
+
+    runner = cli._build_workflow_runner(
+        components=components,
+        session_state=None,
+        skill_registry=_empty_registry(tmp_path),
+        registry=registry,
+    )
+
+    assert runner is not None
+    reply = await runner("wavelength-checkin", {})
+    assert "wavelength-checkin" in reply
+    assert "failed" in reply.lower()
+
+
+async def test_build_workflow_runner_returns_composed_reply(
+    patched_config: CrawDadConfig,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful run forwards the composer reply through truncation only."""
+    from crawdad.mcp_client import ToolDetails
+    from crawdad.workflows import WorkflowRegistry
+
+    details = (
+        ToolDetails(
+            name="creek.state.read",
+            description="Read",
+            input_schema={"type": "object"},
+        ),
+    )
+    components = cli._build_agent_components(
+        config=patched_config, tool_details=details
+    )
+    registry = WorkflowRegistry(vault_path=tmp_path)
+
+    async def _ok(**_kwargs: Any) -> str:
+        return "x" * (cli._DISCORD_REPLY_LIMIT + 50)
+
+    monkeypatch.setattr(cli, "run_workflow_and_compose", _ok)
+
+    runner = cli._build_workflow_runner(
+        components=components,
+        session_state=None,
+        skill_registry=_empty_registry(tmp_path),
+        registry=registry,
+    )
+
+    assert runner is not None
+    reply = await runner("wavelength-checkin", {})
+    assert reply.endswith("...")
+    assert len(reply) <= cli._DISCORD_REPLY_LIMIT

--- a/crawdad/tests/test_slash_commands.py
+++ b/crawdad/tests/test_slash_commands.py
@@ -187,34 +187,168 @@ async def test_handle_register_without_switcher_returns_soft_error() -> None:
     assert "unavailable" in body or "wired" in body
 
 
-async def test_handle_workflow_list_returns_v11_placeholder() -> None:
-    """``/crawdad workflow list`` returns the documented v1.1 stub."""
+async def test_handle_workflow_list_enumerates_registered_workflows() -> None:
+    """``/crawdad workflow list`` enumerates the registry's workflow names."""
     replier = _FakeReplier()
 
-    await handle_workflow(replier, subaction="list")
+    await handle_workflow(
+        replier,
+        action="list",
+        name="",
+        workflow_lister=lambda: ["alpha", "beta"],
+        workflow_runner=None,
+    )
 
     assert len(replier.sent) == 1
-    assert "v1.1" in replier.sent[0] or "1.1" in replier.sent[0]
+    assert "alpha" in replier.sent[0]
+    assert "beta" in replier.sent[0]
 
 
-async def test_handle_workflow_unknown_subaction_returns_help() -> None:
-    """A workflow subaction other than ``list`` returns the help summary."""
+async def test_handle_workflow_list_with_no_workflows_explains_how_to_author() -> None:
+    """An empty registry returns a hint about authoring a workflow file."""
     replier = _FakeReplier()
 
-    await handle_workflow(replier, subaction="run")
+    await handle_workflow(
+        replier,
+        action="list",
+        name="",
+        workflow_lister=lambda: [],
+        workflow_runner=None,
+    )
 
     assert len(replier.sent) == 1
-    assert "list" in replier.sent[0].lower()
+    body = replier.sent[0].lower()
+    assert "no workflows" in body or "author" in body
 
 
-async def test_handle_workflow_default_returns_list_stub() -> None:
-    """``/crawdad workflow`` with no subaction is the same as ``list``."""
+async def test_handle_workflow_list_without_lister_returns_soft_error() -> None:
+    """A missing lister (no MCP tools surface) yields the soft-error reply."""
     replier = _FakeReplier()
 
-    await handle_workflow(replier, subaction=None)
+    await handle_workflow(
+        replier,
+        action="list",
+        name="",
+        workflow_lister=None,
+        workflow_runner=None,
+    )
 
     assert len(replier.sent) == 1
-    assert "v1.1" in replier.sent[0] or "1.1" in replier.sent[0]
+    assert "aren't wired" in replier.sent[0] or "unavailable" in replier.sent[0].lower()
+
+
+async def test_handle_workflow_default_action_is_list() -> None:
+    """``/crawdad workflow`` with no action behaves like ``list``."""
+    replier = _FakeReplier()
+
+    await handle_workflow(
+        replier,
+        action=None,
+        name="",
+        workflow_lister=lambda: ["alpha"],
+        workflow_runner=None,
+    )
+
+    assert len(replier.sent) == 1
+    assert "alpha" in replier.sent[0]
+
+
+async def test_handle_workflow_run_invokes_runner_with_name() -> None:
+    """``/crawdad workflow run <name>`` calls the runner with the cleaned name."""
+    captured: dict[str, object] = {}
+
+    async def _runner(name: str, inputs: dict[str, str]) -> str:
+        captured["name"] = name
+        captured["inputs"] = inputs
+        return "workflow done"
+
+    replier = _FakeReplier()
+    await handle_workflow(
+        replier,
+        action="run",
+        name="  wavelength-checkin  ",
+        workflow_lister=None,
+        workflow_runner=_runner,
+    )
+
+    assert captured["name"] == "wavelength-checkin"
+    assert captured["inputs"] == {}
+    assert replier.sent == ["workflow done"]
+
+
+async def test_handle_workflow_run_without_name_returns_help() -> None:
+    """``/crawdad workflow run`` with no name returns help — no runner call."""
+    calls: list[str] = []
+
+    async def _runner(name: str, _inputs: dict[str, str]) -> str:
+        calls.append(name)
+        return ""
+
+    replier = _FakeReplier()
+    await handle_workflow(
+        replier,
+        action="run",
+        name="",
+        workflow_lister=None,
+        workflow_runner=_runner,
+    )
+
+    assert calls == []
+    assert "name" in replier.sent[0].lower() or "list" in replier.sent[0].lower()
+
+
+async def test_handle_workflow_run_without_runner_returns_soft_error() -> None:
+    """A missing runner yields the soft-error reply (no crash)."""
+    replier = _FakeReplier()
+    await handle_workflow(
+        replier,
+        action="run",
+        name="wavelength-checkin",
+        workflow_lister=None,
+        workflow_runner=None,
+    )
+
+    assert len(replier.sent) == 1
+    assert "aren't wired" in replier.sent[0] or "unavailable" in replier.sent[0].lower()
+
+
+async def test_handle_workflow_run_maps_runner_exceptions_to_soft_reply() -> None:
+    """A runner exception lands as a soft Discord reply, not a stack trace."""
+
+    async def _boom(_name: str, _inputs: dict[str, str]) -> str:
+        msg = "no workflow named 'missing'"
+        raise RuntimeError(msg)
+
+    replier = _FakeReplier()
+    await handle_workflow(
+        replier,
+        action="run",
+        name="missing",
+        workflow_lister=None,
+        workflow_runner=_boom,
+    )
+
+    assert len(replier.sent) == 1
+    assert "missing" in replier.sent[0]
+    assert "could not run" in replier.sent[0]
+
+
+async def test_handle_workflow_unknown_action_returns_help() -> None:
+    """An action other than list/run lands a help summary."""
+    replier = _FakeReplier()
+
+    await handle_workflow(
+        replier,
+        action="frobnicate",
+        name="",
+        workflow_lister=None,
+        workflow_runner=None,
+    )
+
+    assert len(replier.sent) == 1
+    body = replier.sent[0].lower()
+    assert "list" in body
+    assert "run" in body
 
 
 async def test_handle_help_lists_every_command() -> None:
@@ -228,19 +362,27 @@ async def test_handle_help_lists_every_command() -> None:
         assert name in body
 
 
-async def test_handle_workflow_skips_loop() -> None:
-    """Workflow handler does NOT call the loop runner — it's a pure stub."""
-    runner_calls = 0
+async def test_handle_workflow_list_skips_loop_runner() -> None:
+    """The workflow list handler does NOT call the agent loop runner."""
+    loop_calls = 0
 
-    async def _counting_runner(_message: str) -> str:
-        nonlocal runner_calls
-        runner_calls += 1
+    async def _counting_loop(_message: str) -> str:
+        nonlocal loop_calls
+        loop_calls += 1
         return "should not be reached"
 
     replier = _FakeReplier()
-    await handle_workflow(replier, subaction="list")
+    await handle_workflow(
+        replier,
+        action="list",
+        name="",
+        workflow_lister=lambda: ["wavelength-checkin"],
+        workflow_runner=None,
+    )
 
-    assert runner_calls == 0
+    assert loop_calls == 0
+    # Sanity check: the loop fake exists only to prove no one called it.
+    assert _counting_loop is not None
 
 
 class _FakeTree:
@@ -373,26 +515,70 @@ async def test_register_callback_without_switcher_replies_softly() -> None:
     assert "unavailable" in body or "wired" in body
 
 
-async def test_workflow_callback_skips_loop_and_returns_stub() -> None:
-    """The workflow callback ``defer()``s but does NOT call the loop runner.
-
-    The workflow stub is the only registered callback that bypasses
-    the agent loop entirely (v1.0 ships only the `list` subaction).
-    """
-    runner_called = False
+async def test_workflow_callback_defers_and_lists_when_wired() -> None:
+    """``/crawdad workflow`` lists registered workflows when a lister is wired."""
 
     async def _spy_runner(_msg: str) -> str:
-        nonlocal runner_called
-        runner_called = True
         return "should not be reached"
 
     tree = _FakeTree()
-    register(tree, loop_runner=_spy_runner)
+    register(
+        tree,
+        loop_runner=_spy_runner,
+        workflow_lister=lambda: ["wavelength-checkin"],
+        workflow_runner=None,
+    )
     interaction = _FakeInteraction()
 
     await tree.registered["workflow"]["callback"](interaction)
 
     assert interaction.response.deferred == 1
     assert len(interaction.followup.sent) == 1
-    assert "v1.1" in interaction.followup.sent[0]
-    assert runner_called is False
+    assert "wavelength-checkin" in interaction.followup.sent[0]
+
+
+async def test_workflow_callback_runs_workflow_and_replies() -> None:
+    """``/crawdad workflow run <name>`` defers and invokes the workflow runner."""
+    captured: dict[str, object] = {}
+
+    async def _runner(name: str, inputs: dict[str, str]) -> str:
+        captured["name"] = name
+        captured["inputs"] = inputs
+        return "workflow output"
+
+    async def _loop(_msg: str) -> str:
+        return "should not be reached"
+
+    tree = _FakeTree()
+    register(
+        tree,
+        loop_runner=_loop,
+        workflow_lister=lambda: ["foo"],
+        workflow_runner=_runner,
+    )
+    interaction = _FakeInteraction()
+
+    await tree.registered["workflow"]["callback"](interaction, action="run", name="foo")
+
+    assert interaction.response.deferred == 1
+    assert captured["name"] == "foo"
+    assert captured["inputs"] == {}
+    assert interaction.followup.sent == ["workflow output"]
+
+
+async def test_workflow_callback_soft_errors_when_unwired() -> None:
+    """When no lister / runner is wired, the callback still defers and replies."""
+
+    async def _loop(_msg: str) -> str:
+        return "should not be reached"
+
+    tree = _FakeTree()
+    register(tree, loop_runner=_loop)
+    interaction = _FakeInteraction()
+
+    await tree.registered["workflow"]["callback"](interaction)
+
+    assert interaction.response.deferred == 1
+    assert len(interaction.followup.sent) == 1
+    body = interaction.followup.sent[0].lower()
+    assert "aren't wired" in body or "unavailable" in body

--- a/crawdad/tests/test_slash_commands.py
+++ b/crawdad/tests/test_slash_commands.py
@@ -222,7 +222,13 @@ async def test_handle_workflow_list_with_no_workflows_explains_how_to_author() -
 
 
 async def test_handle_workflow_list_without_lister_returns_soft_error() -> None:
-    """A missing lister (no MCP tools surface) yields the soft-error reply."""
+    """A missing lister names the registry, not the walker.
+
+    Closes PR #309 review feedback: the list action only reads the
+    registry — it never touches the walker — so its failure message
+    must talk about registry wiring, not "the walker has nothing to
+    call".
+    """
     replier = _FakeReplier()
 
     await handle_workflow(
@@ -234,7 +240,9 @@ async def test_handle_workflow_list_without_lister_returns_soft_error() -> None:
     )
 
     assert len(replier.sent) == 1
-    assert "aren't wired" in replier.sent[0] or "unavailable" in replier.sent[0].lower()
+    body = replier.sent[0].lower()
+    assert "registry" in body
+    assert "walker" not in body
 
 
 async def test_handle_workflow_default_action_is_list() -> None:
@@ -567,7 +575,12 @@ async def test_workflow_callback_runs_workflow_and_replies() -> None:
 
 
 async def test_workflow_callback_soft_errors_when_unwired() -> None:
-    """When no lister / runner is wired, the callback still defers and replies."""
+    """When no lister / runner is wired, the callback still defers and replies.
+
+    The default action is ``list``, which routes through
+    ``_reply_workflow_list``; the missing-lister reply mentions the
+    registry rather than the walker (PR #309 review feedback).
+    """
 
     async def _loop(_msg: str) -> str:
         return "should not be reached"
@@ -581,4 +594,5 @@ async def test_workflow_callback_soft_errors_when_unwired() -> None:
     assert interaction.response.deferred == 1
     assert len(interaction.followup.sent) == 1
     body = interaction.followup.sent[0].lower()
-    assert "aren't wired" in body or "unavailable" in body
+    assert "registry" in body
+    assert "walker" not in body

--- a/crawdad/tests/test_workflows.py
+++ b/crawdad/tests/test_workflows.py
@@ -1,0 +1,862 @@
+"""Tests for ``crawdad.workflows`` — ADAPT-003 workflow DSL.
+
+Covers:
+
+* Workflow model validation (parser happy + malformed)
+* Constraint enforcement (phase-aware refusal, privacy floor propagation)
+* Step-walker semantics (deterministic walk + interpolation)
+* Registry file discovery (built-in + vault)
+* The three reference workflows shipped with the package
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from crawdad.dispatcher import ToolResult
+from crawdad.intents import PrivacyTierCeiling
+from crawdad.state import SessionState
+from crawdad.workflows import (
+    BUILTIN_WORKFLOWS_DIR,
+    VAULT_WORKFLOWS_SUBPATH,
+    WorkflowConstraintError,
+    WorkflowDefinition,
+    WorkflowNotFoundError,
+    WorkflowParseError,
+    WorkflowRegistry,
+    WorkflowStep,
+    WorkflowWalker,
+    _synthesize_user_message,
+    interpolate,
+    load_workflow_from_yaml,
+    resolve_phase,
+    run_workflow_and_compose,
+)
+
+# ---------------------------------------------------------------------------
+# Models + parser
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_definition_minimal() -> None:
+    """A workflow with only the required fields parses with sane defaults."""
+    wf = WorkflowDefinition(
+        name="minimal",
+        description="just one step",
+        steps=(WorkflowStep(id="read", tool="creek.state.read"),),
+    )
+
+    assert wf.phase_aware is False
+    assert wf.privacy_tier_floor == PrivacyTierCeiling.OPEN
+    assert wf.allowed_phases == ()
+    assert wf.inputs == ()
+    assert wf.trigger is None
+    assert wf.steps[0].args == {}
+
+
+def test_workflow_definition_is_frozen() -> None:
+    """Workflows are immutable Pydantic models — re-assignment raises."""
+    wf = WorkflowDefinition(
+        name="frozen",
+        description="d",
+        steps=(WorkflowStep(id="r", tool="creek.state.read"),),
+    )
+    with pytest.raises(ValidationError):
+        wf.name = "renamed"  # type: ignore[misc]
+
+
+def test_workflow_definition_refuses_empty_step_list() -> None:
+    """A workflow must declare at least one step."""
+    with pytest.raises(ValidationError):
+        WorkflowDefinition(name="empty", description="", steps=())
+
+
+def test_workflow_definition_refuses_duplicate_step_ids() -> None:
+    """Step ids must be unique inside a workflow (interpolation references)."""
+    with pytest.raises(ValidationError):
+        WorkflowDefinition(
+            name="dupe",
+            description="",
+            steps=(
+                WorkflowStep(id="a", tool="creek.state.read"),
+                WorkflowStep(id="a", tool="creek.mine"),
+            ),
+        )
+
+
+def test_load_workflow_from_yaml_round_trip(tmp_path: Path) -> None:
+    """A YAML file with every field parses into the matching model."""
+    path = tmp_path / "demo.workflow.yaml"
+    path.write_text(
+        dedent(
+            """\
+            name: demo
+            description: A demo workflow
+            trigger: "/crawdad workflow run demo"
+            phase_aware: true
+            allowed_phases: [rising, peak]
+            privacy_tier_floor: personal
+            inputs: [topic]
+            steps:
+              - id: read
+                tool: creek.state.read
+                args:
+                  period: weekly
+              - id: mine
+                tool: creek.mine
+                args:
+                  strategy: thread-terminus
+                  phase: "{{state.phase}}"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    wf = load_workflow_from_yaml(path)
+
+    assert wf.name == "demo"
+    assert wf.trigger == "/crawdad workflow run demo"
+    assert wf.phase_aware is True
+    assert wf.allowed_phases == ("rising", "peak")
+    assert wf.privacy_tier_floor == PrivacyTierCeiling.PERSONAL
+    assert wf.inputs == ("topic",)
+    assert len(wf.steps) == 2
+    assert wf.steps[0].id == "read"
+    assert wf.steps[1].args["phase"] == "{{state.phase}}"
+
+
+def test_load_workflow_from_yaml_missing_file_raises(tmp_path: Path) -> None:
+    """Calling the loader on a non-existent path raises ``WorkflowParseError``."""
+    with pytest.raises(WorkflowParseError):
+        load_workflow_from_yaml(tmp_path / "missing.workflow.yaml")
+
+
+def test_load_workflow_from_yaml_invalid_yaml_raises(tmp_path: Path) -> None:
+    """A YAML syntax error surfaces as ``WorkflowParseError`` (not yaml.YAMLError)."""
+    path = tmp_path / "bad.workflow.yaml"
+    path.write_text("name: foo\nsteps: [: oops]\n", encoding="utf-8")
+
+    with pytest.raises(WorkflowParseError):
+        load_workflow_from_yaml(path)
+
+
+def test_load_workflow_from_yaml_invalid_schema_raises(tmp_path: Path) -> None:
+    """A YAML doc that doesn't match the schema surfaces as ``WorkflowParseError``."""
+    path = tmp_path / "schema.workflow.yaml"
+    path.write_text(
+        dedent(
+            """\
+            name: schema
+            description: missing steps key entirely
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WorkflowParseError):
+        load_workflow_from_yaml(path)
+
+
+def test_load_workflow_from_yaml_non_dict_raises(tmp_path: Path) -> None:
+    """A YAML doc whose top level is a list raises ``WorkflowParseError``."""
+    path = tmp_path / "list.workflow.yaml"
+    path.write_text("- name: nope\n- name: nope2\n", encoding="utf-8")
+
+    with pytest.raises(WorkflowParseError):
+        load_workflow_from_yaml(path)
+
+
+def test_load_workflow_from_yaml_empty_file_raises(tmp_path: Path) -> None:
+    """An empty file is not a workflow document."""
+    path = tmp_path / "empty.workflow.yaml"
+    path.write_text("", encoding="utf-8")
+
+    with pytest.raises(WorkflowParseError):
+        load_workflow_from_yaml(path)
+
+
+# ---------------------------------------------------------------------------
+# Interpolation
+# ---------------------------------------------------------------------------
+
+
+def test_interpolate_passes_through_when_no_placeholders() -> None:
+    """A value without ``{{...}}`` placeholders is returned unchanged."""
+    out = interpolate("plain string", state=None, inputs={}, step_results={})
+    assert out == "plain string"
+
+
+def test_interpolate_non_string_returns_self() -> None:
+    """Non-string values are returned verbatim — interpolation is text-only."""
+    out = interpolate(42, state=None, inputs={}, step_results={})
+    assert out == 42
+
+
+def test_interpolate_state_phase(vault_with_state: Path) -> None:
+    """``{{state.phase}}`` resolves to the slug extracted from the wavelength."""
+    from crawdad.state import load_session_state
+
+    state = load_session_state(vault_with_state)
+
+    out = interpolate(
+        "phase is {{state.phase}}",
+        state=state,
+        inputs={},
+        step_results={},
+    )
+
+    assert out == "phase is rising"
+
+
+def test_interpolate_state_wavelength_returns_full_snapshot(
+    vault_with_state: Path,
+) -> None:
+    """``{{state.wavelength}}`` resolves to the raw wavelength snapshot text."""
+    from crawdad.state import load_session_state
+
+    state = load_session_state(vault_with_state)
+
+    out = interpolate(
+        "{{state.wavelength}}",
+        state=state,
+        inputs={},
+        step_results={},
+    )
+
+    assert "Phase: **rising**" in out
+
+
+def test_interpolate_state_missing_yields_empty_string() -> None:
+    """A `{{state.X}}` placeholder with no state resolves to empty string."""
+    out = interpolate(
+        "phase=[{{state.phase}}]",
+        state=None,
+        inputs={},
+        step_results={},
+    )
+    assert out == "phase=[]"
+
+
+def test_interpolate_input_lookup() -> None:
+    """``{{input.<key>}}`` resolves from the supplied inputs dict."""
+    out = interpolate(
+        "topic={{input.topic}}",
+        state=None,
+        inputs={"topic": "phase transitions"},
+        step_results={},
+    )
+    assert out == "topic=phase transitions"
+
+
+def test_interpolate_input_missing_yields_empty() -> None:
+    """An ``{{input.X}}`` lookup with no such key resolves to empty string."""
+    out = interpolate(
+        "topic={{input.missing}}",
+        state=None,
+        inputs={},
+        step_results={},
+    )
+    assert out == "topic="
+
+
+def test_interpolate_step_body() -> None:
+    """``{{step.<id>.body}}`` resolves to the named step's result body."""
+    step_results = {
+        "read": ToolResult(intent_type="creek.state.read", body="phase: rising"),
+    }
+    out = interpolate(
+        "previous: {{step.read.body}}",
+        state=None,
+        inputs={},
+        step_results=step_results,
+    )
+    assert out == "previous: phase: rising"
+
+
+def test_interpolate_step_unknown_yields_empty() -> None:
+    """A reference to an unknown step id resolves to empty string."""
+    out = interpolate(
+        "nothing here: [{{step.missing.body}}]",
+        state=None,
+        inputs={},
+        step_results={},
+    )
+    assert out == "nothing here: []"
+
+
+def test_interpolate_unknown_namespace_passes_through() -> None:
+    """Placeholders in an unknown namespace are left untouched.
+
+    This avoids silently swallowing a typo like ``{{statee.phase}}``;
+    the literal placeholder lands in the args dict so the workflow
+    author can spot the typo in MCP logs.
+    """
+    out = interpolate(
+        "value={{weird.namespace}}",
+        state=None,
+        inputs={},
+        step_results={},
+    )
+    assert "{{weird.namespace}}" in out
+
+
+def test_interpolate_nested_dict_recurses() -> None:
+    """Dict values are interpolated recursively (for step args nesting)."""
+    out = interpolate(
+        {"phase": "{{input.phase}}", "nested": {"k": "{{input.phase}}"}},
+        state=None,
+        inputs={"phase": "rising"},
+        step_results={},
+    )
+    assert out == {"phase": "rising", "nested": {"k": "rising"}}
+
+
+def test_interpolate_list_recurses() -> None:
+    """List values are interpolated element-wise."""
+    out = interpolate(
+        ["{{input.x}}", "static", "{{input.y}}"],
+        state=None,
+        inputs={"x": "alpha", "y": "beta"},
+        step_results={},
+    )
+    assert out == ["alpha", "static", "beta"]
+
+
+# ---------------------------------------------------------------------------
+# Phase resolution helper
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_phase_from_session_state(vault_with_state: Path) -> None:
+    """``resolve_phase`` returns the slug extracted from the wavelength block."""
+    from crawdad.state import load_session_state
+
+    state = load_session_state(vault_with_state)
+    assert resolve_phase(state) == "rising"
+
+
+def test_resolve_phase_returns_none_on_missing_state() -> None:
+    """No session state ⇒ no phase."""
+    assert resolve_phase(None) is None
+
+
+def test_resolve_phase_returns_none_on_blank_wavelength() -> None:
+    """A state with no wavelength snapshot ⇒ no phase."""
+    state = SessionState(
+        raw_markdown="",
+        wavelength_snapshot=None,
+        eddies=(),
+        threads=(),
+        suggested_questions=(),
+    )
+    assert resolve_phase(state) is None
+
+
+def test_resolve_phase_returns_none_when_wavelength_has_no_phase_token() -> None:
+    """A wavelength snapshot without a recognisable phase slug ⇒ no phase."""
+    state = SessionState(
+        raw_markdown="",
+        wavelength_snapshot="just narrative — nothing addressable here",
+        eddies=(),
+        threads=(),
+        suggested_questions=(),
+    )
+    assert resolve_phase(state) is None
+
+
+def test_interpolate_state_unknown_field_yields_empty() -> None:
+    """``{{state.bogus}}`` (not phase/wavelength) resolves to empty string."""
+    state = SessionState(
+        raw_markdown="",
+        wavelength_snapshot="Phase: **rising**",
+        eddies=(),
+        threads=(),
+        suggested_questions=(),
+    )
+    out = interpolate(
+        "x={{state.bogus}}",
+        state=state,
+        inputs={},
+        step_results={},
+    )
+    assert out == "x="
+
+
+def test_interpolate_input_namespace_with_no_field_yields_empty() -> None:
+    """A bare ``{{input}}`` with no key resolves to empty string."""
+    out = interpolate(
+        "[{{input}}]",
+        state=None,
+        inputs={"topic": "X"},
+        step_results={},
+    )
+    assert out == "[]"
+
+
+def test_interpolate_step_with_no_field_yields_empty() -> None:
+    """A ``{{step.<id>}}`` reference without a field resolves to empty string."""
+    out = interpolate(
+        "[{{step.read}}]",
+        state=None,
+        inputs={},
+        step_results={"read": ToolResult(intent_type="x", body="b")},
+    )
+    assert out == "[]"
+
+
+def test_interpolate_step_with_unknown_field_yields_empty() -> None:
+    """``{{step.<id>.bogus}}`` (not ``body``) resolves to empty string."""
+    out = interpolate(
+        "[{{step.read.bogus}}]",
+        state=None,
+        inputs={},
+        step_results={"read": ToolResult(intent_type="x", body="b")},
+    )
+    assert out == "[]"
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def _write_workflow(path: Path, name: str, *, body: str | None = None) -> None:
+    """Helper: write a minimal workflow YAML file to *path*."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if body is None:
+        body = dedent(
+            f"""\
+            name: {name}
+            description: test workflow {name}
+            steps:
+              - id: read
+                tool: creek.state.read
+            """
+        )
+    path.write_text(body, encoding="utf-8")
+
+
+def test_registry_lists_builtin_workflows(tmp_path: Path) -> None:
+    """The registry discovers built-in workflows shipped with the package."""
+    registry = WorkflowRegistry(vault_path=tmp_path)
+    listed = registry.list()
+    names = {wf.name for wf in listed}
+    # The three reference workflows the AC requires.
+    assert "substack-draft-phase-transitions" in names
+    assert "wavelength-checkin" in names
+    assert "compost-surfacing" in names
+
+
+def test_registry_discovers_vault_workflows(tmp_path: Path) -> None:
+    """Workflows under ``<vault>/00-Creek-Meta/Workflows/`` are discovered."""
+    user_dir = tmp_path / VAULT_WORKFLOWS_SUBPATH
+    _write_workflow(user_dir / "custom.workflow.yaml", "custom")
+
+    registry = WorkflowRegistry(vault_path=tmp_path)
+    names = {wf.name for wf in registry.list()}
+
+    assert "custom" in names
+
+
+def test_registry_get_returns_named_workflow(tmp_path: Path) -> None:
+    """``get(name)`` returns the workflow definition for a known name."""
+    registry = WorkflowRegistry(vault_path=tmp_path)
+    wf = registry.get("wavelength-checkin")
+    assert wf.name == "wavelength-checkin"
+
+
+def test_registry_get_raises_for_unknown(tmp_path: Path) -> None:
+    """``get(name)`` raises ``WorkflowNotFoundError`` for unknown names."""
+    registry = WorkflowRegistry(vault_path=tmp_path)
+    with pytest.raises(WorkflowNotFoundError):
+        registry.get("does-not-exist")
+
+
+def test_registry_vault_workflow_overrides_builtin(tmp_path: Path) -> None:
+    """A vault workflow with the same name as a built-in wins."""
+    override_dir = tmp_path / VAULT_WORKFLOWS_SUBPATH
+    _write_workflow(
+        override_dir / "wavelength-checkin.workflow.yaml",
+        name="wavelength-checkin",
+        body=dedent(
+            """\
+            name: wavelength-checkin
+            description: USER OVERRIDE
+            steps:
+              - id: r
+                tool: creek.state.read
+            """
+        ),
+    )
+    registry = WorkflowRegistry(vault_path=tmp_path)
+    wf = registry.get("wavelength-checkin")
+    assert wf.description == "USER OVERRIDE"
+
+
+def test_registry_skips_invalid_workflow_files(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A malformed user workflow is logged and skipped — other workflows still load."""
+    user_dir = tmp_path / VAULT_WORKFLOWS_SUBPATH
+    user_dir.mkdir(parents=True)
+    (user_dir / "bad.workflow.yaml").write_text("not: a: workflow:\n", encoding="utf-8")
+    _write_workflow(user_dir / "good.workflow.yaml", "good")
+
+    caplog.set_level("WARNING", logger="crawdad.workflows")
+    registry = WorkflowRegistry(vault_path=tmp_path)
+    names = {wf.name for wf in registry.list()}
+
+    assert "good" in names
+    assert "bad" not in names
+    assert any("bad.workflow.yaml" in r.message for r in caplog.records)
+
+
+def test_registry_ignores_non_workflow_files(tmp_path: Path) -> None:
+    """Files without the ``.workflow.yaml`` suffix are ignored."""
+    user_dir = tmp_path / VAULT_WORKFLOWS_SUBPATH
+    user_dir.mkdir(parents=True)
+    (user_dir / "README.md").write_text("# notes\n", encoding="utf-8")
+    (user_dir / "extra.yaml").write_text("name: extra\n", encoding="utf-8")
+
+    registry = WorkflowRegistry(vault_path=tmp_path)
+    names = {wf.name for wf in registry.list()}
+
+    assert "extra" not in names
+
+
+def test_builtin_workflows_dir_exists() -> None:
+    """The package's built-in workflows directory is shipped with the source tree."""
+    assert BUILTIN_WORKFLOWS_DIR.is_dir()
+    files = list(BUILTIN_WORKFLOWS_DIR.glob("*.workflow.yaml"))
+    assert len(files) >= 3, f"expected at least 3 reference workflows, got {files}"
+
+
+# ---------------------------------------------------------------------------
+# Walker
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession:
+    """An :class:`MCPSession`-shaped fake that records every tool call."""
+
+    def __init__(self, responses: dict[str, str] | None = None) -> None:
+        """Record per-tool canned responses; missing tools return empty body."""
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self._responses = responses or {}
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any] | None = None
+    ) -> str:
+        """Record the call and return the canned body (or empty string)."""
+        self.calls.append((name, arguments or {}))
+        return self._responses.get(name, "")
+
+
+class _FakeMCPClient:
+    """An :class:`MCPClient`-shaped fake that yields :class:`_FakeSession`."""
+
+    def __init__(self, session: _FakeSession) -> None:
+        """Stash the session that ``connect()`` will yield."""
+        self._session = session
+
+    def connect(self) -> Any:
+        """Async-context-manager that yields the wrapped session."""
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _ctx() -> Any:
+            yield self._session
+
+        return _ctx()
+
+
+def _simple_workflow(**overrides: Any) -> WorkflowDefinition:
+    """Return a baseline workflow used by walker tests; override any field."""
+    base: dict[str, Any] = {
+        "name": "test-flow",
+        "description": "a test",
+        "steps": (
+            WorkflowStep(id="read", tool="creek.state.read"),
+            WorkflowStep(
+                id="mine",
+                tool="creek.mine",
+                args={"strategy": "thread-terminus", "echo": "{{step.read.body}}"},
+            ),
+        ),
+    }
+    base.update(overrides)
+    return WorkflowDefinition(**base)
+
+
+async def test_walker_runs_each_step_in_order() -> None:
+    """The walker invokes each step's tool with its (interpolated) args."""
+    session = _FakeSession(
+        responses={"creek.state.read": "phase: rising", "creek.mine": "[]"}
+    )
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(session),
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+
+    results = await walker.run(_simple_workflow(), state=None, inputs={})
+
+    assert [name for name, _ in session.calls] == ["creek.state.read", "creek.mine"]
+    # ``creek.mine`` saw the interpolated body of ``read``.
+    _, mine_args = session.calls[1]
+    assert mine_args["echo"] == "phase: rising"
+    assert len(results) == 2
+    assert results[0].body == "phase: rising"
+
+
+async def test_walker_propagates_privacy_floor_to_each_call() -> None:
+    """Every step receives ``privacy_tier_ceiling`` = the workflow's floor."""
+    session = _FakeSession()
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(session),
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+    wf = _simple_workflow(privacy_tier_floor=PrivacyTierCeiling.PERSONAL)
+
+    await walker.run(wf, state=None, inputs={})
+
+    for _name, args in session.calls:
+        assert args["privacy_tier_ceiling"] == "personal"
+
+
+async def test_walker_refuses_phase_aware_without_state() -> None:
+    """A ``phase_aware: true`` workflow with no session state soft-errors."""
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(_FakeSession()),
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+    wf = _simple_workflow(phase_aware=True)
+
+    with pytest.raises(WorkflowConstraintError, match="phase-aware"):
+        await walker.run(wf, state=None, inputs={})
+
+
+async def test_walker_refuses_phase_aware_with_disallowed_phase(
+    vault_with_state: Path,
+) -> None:
+    """A workflow with an ``allowed_phases`` list refuses unmatched phases."""
+    from crawdad.state import load_session_state
+
+    state = load_session_state(vault_with_state)  # phase: rising
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(_FakeSession()),
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+    wf = _simple_workflow(
+        phase_aware=True, allowed_phases=("bottoming-out", "withdrawal")
+    )
+
+    with pytest.raises(WorkflowConstraintError, match="refuses to run in phase"):
+        await walker.run(wf, state=state, inputs={})
+
+
+async def test_walker_runs_phase_aware_when_phase_matches(
+    vault_with_state: Path,
+) -> None:
+    """A workflow whose ``allowed_phases`` includes the current phase runs."""
+    from crawdad.state import load_session_state
+
+    state = load_session_state(vault_with_state)  # phase: rising
+    session = _FakeSession()
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(session),
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+    wf = _simple_workflow(phase_aware=True, allowed_phases=("rising",))
+
+    results = await walker.run(wf, state=state, inputs={})
+
+    assert len(results) == 2
+
+
+async def test_walker_refuses_step_with_unknown_tool() -> None:
+    """A step referencing an unadvertised tool soft-errors with constraint."""
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(_FakeSession()),
+        known_tools=("creek.state.read",),  # 'creek.mine' missing
+    )
+    wf = _simple_workflow()  # references creek.mine
+
+    with pytest.raises(WorkflowConstraintError):
+        await walker.run(wf, state=None, inputs={})
+
+
+async def test_walker_refuses_missing_required_input() -> None:
+    """An unsupplied required input soft-errors before any tool call."""
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(_FakeSession()),
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+    wf = _simple_workflow(inputs=("topic",))
+
+    with pytest.raises(WorkflowConstraintError):
+        await walker.run(wf, state=None, inputs={})
+
+
+async def test_walker_supplies_required_input() -> None:
+    """When all required inputs are present the walker proceeds."""
+    session = _FakeSession()
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(session),
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+    wf = _simple_workflow(inputs=("topic",))
+
+    results = await walker.run(wf, state=None, inputs={"topic": "phase transitions"})
+
+    assert len(results) == 2
+
+
+# ---------------------------------------------------------------------------
+# Reference workflows
+# ---------------------------------------------------------------------------
+
+
+def test_substack_draft_reference_workflow_parses() -> None:
+    """The substack-draft reference workflow loads and is well-formed."""
+    path = BUILTIN_WORKFLOWS_DIR / "substack-draft-phase-transitions.workflow.yaml"
+    wf = load_workflow_from_yaml(path)
+    assert wf.phase_aware is True
+    assert any(step.tool == "creek.draft" for step in wf.steps)
+
+
+def test_wavelength_checkin_reference_workflow_parses() -> None:
+    """The wavelength-checkin reference workflow loads and is well-formed."""
+    path = BUILTIN_WORKFLOWS_DIR / "wavelength-checkin.workflow.yaml"
+    wf = load_workflow_from_yaml(path)
+    assert any(step.tool == "creek.state.read" for step in wf.steps)
+
+
+def test_compost_surfacing_reference_workflow_parses() -> None:
+    """The compost-surfacing reference workflow loads and is well-formed."""
+    path = BUILTIN_WORKFLOWS_DIR / "compost-surfacing.workflow.yaml"
+    wf = load_workflow_from_yaml(path)
+    assert len(wf.steps) >= 1
+
+
+# ---------------------------------------------------------------------------
+# High-level runner
+# ---------------------------------------------------------------------------
+
+
+class _FakeComposer:
+    """Records the args the run_workflow_and_compose call passes through."""
+
+    def __init__(self, reply: str = "composed!") -> None:
+        """Record the canned reply the composer's ``compose`` will return."""
+        self._reply = reply
+        self.last_call: dict[str, Any] = {}
+
+    async def compose(self, **kwargs: Any) -> str:
+        """Record kwargs and return the canned reply string."""
+        self.last_call = kwargs
+        return self._reply
+
+
+async def test_run_workflow_and_compose_returns_composer_reply() -> None:
+    """The high-level runner walks the workflow and forwards the composer reply."""
+    from crawdad.skill_loader import VoiceSkillStack
+
+    composer = _FakeComposer(reply="all done")
+    session = _FakeSession(responses={"creek.state.read": "phase: rising"})
+    wf = WorkflowDefinition(
+        name="solo",
+        description="a one-step workflow",
+        steps=(WorkflowStep(id="read", tool="creek.state.read"),),
+    )
+
+    reply = await run_workflow_and_compose(
+        workflow=wf,
+        inputs={},
+        state=None,
+        skills=VoiceSkillStack(skills=()),
+        skill_registry=None,
+        composer=composer,
+        mcp_client=_FakeMCPClient(session),
+        known_tools=("creek.state.read",),
+    )
+
+    assert reply == "all done"
+    # Composer saw the synthesized user message and the walker's result.
+    assert composer.last_call["tool_results"][0].body == "phase: rising"
+    assert "Run workflow: solo" in composer.last_call["user_message"]
+
+
+async def test_run_workflow_and_compose_uses_registry_stack_when_provided(
+    vault_with_state: Path,
+) -> None:
+    """When a ``SkillStackRegistry`` is provided, the runner uses ``.stack``."""
+    from crawdad.skill_loader import SkillStackRegistry, VoiceSkillStack
+    from crawdad.state import load_session_state
+
+    state = load_session_state(vault_with_state)
+    registry = SkillStackRegistry(
+        stack=VoiceSkillStack(skills=()), vault_path=vault_with_state, state=state
+    )
+    composer = _FakeComposer()
+    session = _FakeSession()
+    wf = WorkflowDefinition(
+        name="solo",
+        description="d",
+        steps=(WorkflowStep(id="r", tool="creek.state.read"),),
+    )
+
+    await run_workflow_and_compose(
+        workflow=wf,
+        inputs={},
+        state=state,
+        skills=VoiceSkillStack(skills=()),
+        skill_registry=registry,
+        composer=composer,
+        mcp_client=_FakeMCPClient(session),
+        known_tools=("creek.state.read",),
+    )
+
+    # The composer saw the registry's stack, not the passed ``skills`` argument.
+    assert composer.last_call["skills"] is registry.stack
+
+
+def test_synthesize_user_message_includes_workflow_name_and_description() -> None:
+    """The synthetic message names the workflow + its description."""
+    wf = WorkflowDefinition(
+        name="solo",
+        description="a one-line description",
+        steps=(WorkflowStep(id="r", tool="creek.state.read"),),
+    )
+
+    msg = _synthesize_user_message(wf, inputs={})
+
+    assert "solo" in msg
+    assert "a one-line description" in msg
+    assert "Inputs" not in msg
+
+
+def test_synthesize_user_message_renders_inputs() -> None:
+    """When inputs are supplied, the synthetic message lists them."""
+    wf = WorkflowDefinition(
+        name="solo",
+        description="d",
+        steps=(WorkflowStep(id="r", tool="creek.state.read"),),
+    )
+
+    msg = _synthesize_user_message(wf, inputs={"topic": "phase transitions"})
+
+    assert "topic" in msg
+    assert "phase transitions" in msg
+
+
+def test_workflow_registry_cache_returns_same_dict(tmp_path: Path) -> None:
+    """A second registry call returns the cached dict without re-scanning."""
+    registry = WorkflowRegistry(vault_path=tmp_path)
+    first = registry.list()
+    second = registry.list()
+    assert {wf.name for wf in first} == {wf.name for wf in second}

--- a/crawdad/tests/test_workflows.py
+++ b/crawdad/tests/test_workflows.py
@@ -737,10 +737,55 @@ def test_wavelength_checkin_reference_workflow_parses() -> None:
 
 
 def test_compost_surfacing_reference_workflow_parses() -> None:
-    """The compost-surfacing reference workflow loads and is well-formed."""
+    """The compost-surfacing reference workflow loads and is well-formed.
+
+    Beyond the basic parse check, this pins three semantic invariants
+    that ``compost-surfacing`` must hold so a future edit cannot revert
+    the post-review fix:
+
+    * It MUST be ``phase_aware: true`` — the workflow interpolates
+      ``{{state.phase}}`` into ``creek.mine``'s ``phase`` arg, so
+      running without a session state would silently pass ``phase=""``.
+      The phase-aware flag turns that silent-bad-input path into a
+      clean ``WorkflowConstraintError`` at the walker's constraint
+      check.
+    * It MUST call ``creek.mine`` — the whole purpose is to surface
+      ranked seeds for the user's compost folder.
+    * The mine step MUST reference ``{{state.phase}}`` — otherwise the
+      ``phase_aware: true`` declaration is decorative.
+    """
     path = BUILTIN_WORKFLOWS_DIR / "compost-surfacing.workflow.yaml"
     wf = load_workflow_from_yaml(path)
-    assert len(wf.steps) >= 1
+
+    assert wf.phase_aware is True, (
+        "compost-surfacing must be phase_aware: true to refuse cleanly when "
+        "session state is unavailable (the workflow interpolates state.phase)"
+    )
+    mine_steps = [step for step in wf.steps if step.tool == "creek.mine"]
+    assert mine_steps, "compost-surfacing must surface seeds via creek.mine"
+    assert any(
+        "{{state.phase}}" in str(value) for value in mine_steps[0].args.values()
+    ), "compost-surfacing's creek.mine step must scope to the current phase"
+
+
+async def test_compost_surfacing_refuses_when_session_state_unavailable() -> None:
+    """End-to-end: compost-surfacing refuses cleanly with no session state.
+
+    Closes the gap the Claude reviewer flagged on PR #309: before
+    flipping ``phase_aware: true`` the workflow would silently pass
+    ``phase: ""`` to ``creek.mine`` when state was missing. With
+    ``phase_aware: true`` the walker's constraint check raises before
+    any MCP call fires.
+    """
+    path = BUILTIN_WORKFLOWS_DIR / "compost-surfacing.workflow.yaml"
+    wf = load_workflow_from_yaml(path)
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(_FakeSession()),
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+
+    with pytest.raises(WorkflowConstraintError, match="phase-aware"):
+        await walker.run(wf, state=None, inputs={})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements ADAPT-003 (issue #268): replaces the v1.0 `/crawdad workflow` placeholder with a real authored-YAML workflow DSL that compiles down to a deterministic step walker over the MCP tool surface, bypassing the FEAT-014 router.

- **New module `crawdad/crawdad/workflows.py`** — Pydantic models (`WorkflowDefinition`, `WorkflowStep`), YAML loader, two-source `WorkflowRegistry` (built-in package files + `<vault>/00-Creek-Meta/Workflows/`), `WorkflowWalker` with first-class constraint enforcement (`phase_aware`, `allowed_phases`, required `inputs`, `privacy_tier_floor` propagated as the per-step MCP `privacy_tier_ceiling`), and a minimal `{{state.*}} / {{input.<key>}} / {{step.<id>.body}}` Mustache-style interpolator (no Jinja2 dep).
- **Three reference workflows** ship in `crawdad/crawdad/builtin_workflows/`:
  - `substack-draft-phase-transitions` (phase-aware, personal floor — `state.read` → `mine` → `draft`)
  - `wavelength-checkin` (open floor — `state.read`)
  - `compost-surfacing` (personal floor — `state.read` → `mine`)
  Each uses only arguments that match the live `creek-mcp` tool signatures.
- **`/crawdad workflow` slash command** now exposes `action` (`list` / `run`) and `name` parameters. `list` enumerates the registry; `run <name>` drives the walker + composer. Registry / walker / composer errors land as soft Discord replies, never stack traces.
- **CLI wiring** builds a workflow-runner closure alongside the existing loop-runner closure; `bot.py` forwards both into `slash_commands.register`.
- **ADR** `crawdad/docs/adr/2026-05-24_workflow-file-location.md` documents the two-source registry decision and rejected alternatives (vault-only, package-only).
- **Packaging** — `pyproject.toml` adds `[tool.setuptools.package-data]` so the YAML files ship with wheels.
- **CLAUDE.md** — drops the "v1.0 stub" language; lists the new module and ADR.

Follow-ups (NOT in this PR):
- A `run-workflow` Haiku-router intent type so the free-text loop can dispatch workflows by name.
- Richer interpolation (structured-result dotted access beyond `.body`).
- Per-workflow consent envelopes (FEAT-028-style).

## Test plan

- [x] `cd crawdad && ./scripts/check-all.sh` — all 7 gates green
- [x] 299 tests passing (54 new workflow tests, 13 new slash-command tests, 4 new CLI tests)
- [x] Aggregate branch coverage 95.37% (workflows.py 98.6%)
- [x] Docstring coverage 98.1%
- [x] MyPy strict, Ruff lint + format, Bandit, Xenon all clean
- [x] Reference workflows parse + match real `creek-mcp` tool signatures
- [x] Registry skips malformed user workflows with a WARNING log
- [x] Vault-authored workflows override built-ins by name
- [x] Constraint refusals tested: missing input, unknown tool, no phase, wrong phase
- [x] Composer reply path tested with a `_FakeComposer`
- [x] CLI runner truncates long composer replies to Discord's 2000-char cap

Closes #268

https://claude.ai/code/session_01QJ7qCunBv9eQgQN8iP1BgT

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ7qCunBv9eQgQN8iP1BgT)_