### PR TITLE
feat(ingest): FEAT-031 authored_at extraction across every ingestor

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -542,6 +542,17 @@ def ingest(
         "-y",
         help="Skip the consent prompt for first-time sources (logged).",
     ),
+    refresh_dates: bool = typer.Option(
+        False,
+        "--refresh-dates",
+        help=(
+            "One-shot ``authored_at`` backfill (FEAT-031 / #263). "
+            "Walks the vault, re-runs each ingestor's date-extraction "
+            "step against the original source file, and writes back. "
+            "Body content is preserved. Idempotent — a second run is "
+            "a no-op when no source dates have changed."
+        ),
+    ),
 ) -> None:
     """Ingest a specific source type into the vault.
 
@@ -551,13 +562,24 @@ def ingest(
     :class:`~creek.vault.writer.VaultWriter`. Re-running against the same
     input is idempotent: deterministic fragment IDs ensure existing
     files are recognised and skipped.
+
+    Passing ``--refresh-dates`` bypasses normal ingestion entirely and
+    instead walks the existing vault to backfill
+    :attr:`creek.models.Fragment.authored_at` from each source file's
+    in-band date. ``--type`` and ``--input`` are not required in that
+    mode; only ``--vault`` (or the configured default) is used.
     """
+    config = load_config()
+    vault_path = vault or config.vault_path
+
+    if refresh_dates:
+        _run_refresh_dates(vault_path)
+        return
+
     if type is None or input is None:
         console.print("[red]--type and --input are required.[/red]")
         raise typer.Exit(code=2)
 
-    config = load_config()
-    vault_path = vault or config.vault_path
     ingestor_cls = _resolve_ingestor(type)
 
     if not input.exists():
@@ -583,6 +605,24 @@ def ingest(
         console.print(f"[yellow]Errors: {len(errors)}[/yellow]")
         for err in errors:
             console.print(f"  [dim]{err}[/dim]")
+
+
+def _run_refresh_dates(vault_path: Path) -> None:
+    """Execute the ``--refresh-dates`` backfill and print a summary line."""
+    from creek.ingest.refresh import refresh_vault_authored_at
+
+    if not vault_path.exists():
+        console.print(f"[red]Vault path not found: {vault_path}[/red]")
+        raise typer.Exit(code=2)
+    summary = refresh_vault_authored_at(vault_path)
+    console.print(
+        f"[bold green]Refreshed authored_at on {summary.updated} fragment(s)."
+        f"[/bold green]"
+    )
+    console.print(
+        f"[dim]Inspected {summary.total}; unchanged {summary.unchanged}; "
+        f"missing source {summary.missing_source}; errors {summary.errors}.[/dim]"
+    )
 
 
 def _dispatch_redact(

--- a/creek-tools/creek/generate/compost.py
+++ b/creek-tools/creek/generate/compost.py
@@ -410,7 +410,7 @@ class CompostTracker:
         """Return a project candidate for *tag*, or ``None`` if still active."""
         if len(frags) < self.project_min_fragments:
             return None
-        last_seen = max(frag.created for frag in frags)
+        last_seen = max(frag.effective_at for frag in frags)
         if last_seen >= cutoff:
             return None
         days = (self._now - last_seen).days

--- a/creek-tools/creek/generate/synchronicity.py
+++ b/creek-tools/creek/generate/synchronicity.py
@@ -242,7 +242,11 @@ class SynchronicityDetector:
             from_level=from_level,
             to_level=to_level,
         )
-        gap_days = (later.created - earlier.created).days
+        # FEAT-031 (#263): gap is computed on ``effective_at`` so a
+        # cross-source pair separated by *authored* years (not just
+        # ingest order) surfaces as the rare synchronicity it actually
+        # is.
+        gap_days = (later.effective_at - earlier.effective_at).days
         if gap_days <= self.min_time_gap_days:
             return None
 
@@ -288,7 +292,10 @@ class SynchronicityDetector:
         Returns:
             ``(earlier, later, level_earlier, level_later)``.
         """
-        if frag_a.created <= frag_b.created:
+        # FEAT-031 (#263): chronology follows authored-date precedence
+        # so the "earlier" half of a sync is whichever fragment was
+        # *authored* first, not ingested first.
+        if frag_a.effective_at <= frag_b.effective_at:
             return frag_a, frag_b, from_level, to_level
         return frag_b, frag_a, to_level, from_level
 
@@ -359,9 +366,11 @@ class SynchronicityDetector:
         lines = [
             "## Fragment excerpts",
             "",
-            f"- **{frag_a.source.platform}** ({frag_a.created.date().isoformat()}): "
+            f"- **{frag_a.source.platform}** "
+            f"({frag_a.effective_at.date().isoformat()}): "
             f"{frag_a.title}",
-            f"- **{frag_b.source.platform}** ({frag_b.created.date().isoformat()}): "
+            f"- **{frag_b.source.platform}** "
+            f"({frag_b.effective_at.date().isoformat()}): "
             f"{frag_b.title}",
             "",
             "## Details",

--- a/creek-tools/creek/generate/unnamed.py
+++ b/creek-tools/creek/generate/unnamed.py
@@ -207,10 +207,15 @@ class UnnamedDigestGenerator:
             week_start: Monday of the target ISO week.
 
         Returns:
-            Fragments whose ``created`` date falls in the window.
+            Fragments whose ``effective_at`` date falls in the window.
         """
         week_end = week_start + timedelta(days=_WEEK_LENGTH_DAYS)
-        return [f for f in fragments if week_start <= f.created.date() < week_end]
+        # FEAT-031 (#263): bucket by authored date (with ``created``
+        # fallback via :attr:`Fragment.effective_at`) so a historical
+        # import doesn't get filed under the wrong week.
+        return [
+            f for f in fragments if week_start <= f.effective_at.date() < week_end
+        ]
 
     def detect_unnamed_clusters(
         self,
@@ -547,7 +552,7 @@ def _render_fragments_section(
         lines.append("No unnamed fragments recorded this week.\n")
         return "\n".join(lines) + "\n"
     for frag in fragments:
-        created = frag.created.date().isoformat()
+        created = frag.effective_at.date().isoformat()
         lines.extend(
             (
                 f"### {frag.title}\n",

--- a/creek-tools/creek/generate/unnamed.py
+++ b/creek-tools/creek/generate/unnamed.py
@@ -213,9 +213,7 @@ class UnnamedDigestGenerator:
         # FEAT-031 (#263): bucket by authored date (with ``created``
         # fallback via :attr:`Fragment.effective_at`) so a historical
         # import doesn't get filed under the wrong week.
-        return [
-            f for f in fragments if week_start <= f.effective_at.date() < week_end
-        ]
+        return [f for f in fragments if week_start <= f.effective_at.date() < week_end]
 
     def detect_unnamed_clusters(
         self,

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -293,16 +293,12 @@ def _week_start(day: date) -> date:
 def _fragment_effective_date(fragment: Fragment) -> date:
     """Return the date this fragment should be bucketed under.
 
-    Prefers :attr:`Fragment.authored_at` — when an ingestor extracts
-    the source's own timestamp (a Substack post's publish date, a
-    Discord message's ``timestamp``), that date is what every
-    time-bucket surface should see so a 2024 essay does not get
-    counted as part of *this week's* wavelength. Falls back to
-    :attr:`Fragment.created` when no authored date was extracted.
+    Thin wrapper around :attr:`Fragment.effective_at` that drops the
+    time component. Kept as a function so existing imports continue to
+    work; new call sites should use ``fragment.effective_at.date()``
+    directly.
     """
-    if fragment.authored_at is not None:
-        return fragment.authored_at.date()
-    return fragment.created.date()
+    return fragment.effective_at.date()
 
 
 def _fragment_in_window(fragment: Fragment, start: date, end: date) -> bool:
@@ -687,8 +683,8 @@ class WavelengthTracker:
         """
         if not fragments:
             return []
-        first = min(f.created.date() for f in fragments)
-        last = max(f.created.date() for f in fragments)
+        first = min(_fragment_effective_date(f) for f in fragments)
+        last = max(_fragment_effective_date(f) for f in fragments)
         start = _week_start(first)
         snapshots: list[WavelengthSnapshot] = []
         while start <= last:

--- a/creek-tools/creek/ingest/_authored_at.py
+++ b/creek-tools/creek/ingest/_authored_at.py
@@ -21,7 +21,8 @@ near-duplicate copies that drift apart.
 from __future__ import annotations
 
 import logging
-from datetime import UTC, date as date_cls, datetime
+from datetime import UTC, datetime
+from datetime import date as date_cls
 from typing import Any
 
 from creek.ingest.base import file_modified_time
@@ -84,6 +85,7 @@ def parse_authored_value(value: Any) -> datetime | None:
 
 def _parse_string_value(text: str) -> datetime | None:
     """Try ISO 8601 then the strict fallback patterns; anchor naive to UTC."""
+    parsed: datetime | None
     try:
         parsed = datetime.fromisoformat(text)
     except ValueError:
@@ -99,7 +101,7 @@ def _try_fallback_formats(text: str) -> datetime | None:
     """Return the first :data:`_FALLBACK_DATETIME_FORMATS` match, or ``None``."""
     for fmt in _FALLBACK_DATETIME_FORMATS:
         try:
-            return datetime.strptime(text, fmt)  # noqa: DTZ007 — anchored by caller
+            return datetime.strptime(text, fmt)
         except ValueError:
             continue
     return None
@@ -162,14 +164,17 @@ def ooxml_authored_at(path: Any) -> datetime | None:
         A timezone-aware datetime, or ``None`` when nothing is
         extractable.
     """
-    import xml.etree.ElementTree as ET  # noqa: S405 — XML is opt-in via FEAT-031
     import zipfile
+
+    # defusedxml hardens stdlib XML parsing against XXE / billion-laughs
+    # attacks — required by ``./scripts/security.sh`` (B405/B314).
+    from defusedxml.ElementTree import parse as defused_parse
 
     try:
         with zipfile.ZipFile(path) as zf:
             try:
                 with zf.open(_OOXML_CORE_PROPERTIES_PATH) as fp:
-                    tree = ET.parse(fp)  # noqa: S314 — trusted user file
+                    tree = defused_parse(fp)
             except KeyError:
                 return None
     except (OSError, zipfile.BadZipFile):

--- a/creek-tools/creek/ingest/_authored_at.py
+++ b/creek-tools/creek/ingest/_authored_at.py
@@ -1,0 +1,172 @@
+"""Shared authored-date extraction helpers (FEAT-031 / #263).
+
+Every ingestor must surface the source's *authored* date as
+:attr:`creek.models.Fragment.authored_at` — separately from the
+``created`` and ``ingested`` fields which describe when the vault saw
+the bytes. Each ingestor has its own fallback chain (frontmatter,
+EXIF, ``posts.csv``, git, …), but they all share two operations:
+
+* **Parse an opaque scalar** (string, ``date``, ``datetime``) into a
+  *timezone-aware* :class:`datetime.datetime` — naive values are
+  anchored to UTC per the issue's "UTC otherwise; never naive" rule
+  rather than localised to LA (which would silently shift the
+  calendar date for date-only sources).
+* **Honestly report absence** when nothing is extractable: ``None`` is
+  the contracted value, never a guess.
+
+These helpers live here so the ingestor modules don't accumulate
+near-duplicate copies that drift apart.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, date as date_cls, datetime
+from typing import Any
+
+from creek.ingest.base import file_modified_time
+
+logger = logging.getLogger(__name__)
+
+
+_FALLBACK_DATETIME_FORMATS: tuple[str, ...] = (
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%d %H:%M",
+    "%Y-%m-%d",
+    "%m/%d/%Y %H:%M:%S",
+    "%m/%d/%Y",
+)
+"""Strict ``datetime.strptime`` patterns tried after ISO 8601 parsing fails.
+
+Order matters: more specific formats come first so a leading
+``YYYY-MM-DD HH:MM:SS`` does not get re-parsed as a date-only value
+that drops the time component.
+"""
+
+
+def parse_authored_value(value: Any) -> datetime | None:
+    """Parse an opaque date value into a timezone-aware datetime.
+
+    The input may be a :class:`datetime`, :class:`date`, ISO 8601
+    string, or one of the common fallback patterns in
+    :data:`_FALLBACK_DATETIME_FORMATS`. Unparseable values return
+    ``None`` (the caller decides whether to fall back further or to
+    surface :class:`Fragment.authored_at` as ``None``).
+
+    Naive results are anchored to UTC rather than localised to LA so
+    a bare ``"2024-03-15"`` survives as the 15th in UTC instead of
+    drifting back to the 14th in LA local time. Sources that *do*
+    carry timezone info (``"2024-03-15T08:00:00+02:00"``) are
+    preserved verbatim — we never re-zone a tz-aware input.
+
+    Args:
+        value: The frontmatter/JSON/metadata field to parse. ``None``
+            and empty strings short-circuit to ``None``.
+
+    Returns:
+        A timezone-aware :class:`datetime`, or ``None`` if unparseable.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+    if isinstance(value, date_cls):
+        return datetime(value.year, value.month, value.day, tzinfo=UTC)
+    if isinstance(value, int | float):
+        return _epoch_to_utc(float(value))
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    return _parse_string_value(text)
+
+
+def _parse_string_value(text: str) -> datetime | None:
+    """Try ISO 8601 then the strict fallback patterns; anchor naive to UTC."""
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        parsed = _try_fallback_formats(text)
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _try_fallback_formats(text: str) -> datetime | None:
+    """Return the first :data:`_FALLBACK_DATETIME_FORMATS` match, or ``None``."""
+    for fmt in _FALLBACK_DATETIME_FORMATS:
+        try:
+            return datetime.strptime(text, fmt)  # noqa: DTZ007 — anchored by caller
+        except ValueError:
+            continue
+    return None
+
+
+def _epoch_to_utc(epoch: float) -> datetime | None:
+    """Convert a Unix-epoch number to a UTC datetime, or ``None`` on ``0``.
+
+    The ``0.0`` sentinel is what ChatGPT/Claude exports use when a
+    message lacks a real creation time. Treating it as 1970-01-01 would
+    poison time-bucket reports, so we surface it as ``None``.
+    """
+    if not epoch:
+        return None
+    return datetime.fromtimestamp(epoch, tz=UTC)
+
+
+def safe_file_modified_time(path: Any) -> datetime | None:
+    """Return ``file_modified_time(path)`` or ``None`` when unreadable.
+
+    Synthetic :class:`~creek.ingest.base.RawDocument` instances in
+    tests (and a vanished file mid-run) can produce ``OSError`` from
+    ``Path.stat`` — the honest answer per FEAT-031 is ``None``, not a
+    fabricated date.
+    """
+    try:
+        return file_modified_time(path)
+    except OSError:
+        return None
+
+
+def frontmatter_authored_at(
+    fm_data: dict[str, Any],
+    keys: tuple[str, ...],
+    file_path: Any,
+    *,
+    source_label: str = "ingestor",
+) -> datetime | None:
+    """Run a frontmatter fallback chain, ending in the filesystem mtime.
+
+    Walks ``keys`` in order; the first key whose value parses cleanly
+    wins. If a key is present but unparseable, the chain *stops* (we do
+    not silently skip a corrupt explicit date in favour of a less
+    authoritative one) and the filesystem mtime is consulted instead.
+
+    Args:
+        fm_data: Parsed frontmatter dictionary.
+        keys: Ordered tuple of frontmatter keys to consult.
+        file_path: Source file path for the mtime fallback.
+        source_label: Ingestor name used in warning messages so a stray
+            log line is traceable.
+
+    Returns:
+        A timezone-aware datetime, or ``None`` when nothing is extractable.
+    """
+    for key in keys:
+        if key not in fm_data:
+            continue
+        parsed = parse_authored_value(fm_data[key])
+        if parsed is not None:
+            return parsed
+        logger.warning(
+            "%s: unparseable %s=%r in frontmatter of %s",
+            source_label,
+            key,
+            fm_data[key],
+            file_path,
+        )
+        break
+    return safe_file_modified_time(file_path)

--- a/creek-tools/creek/ingest/_authored_at.py
+++ b/creek-tools/creek/ingest/_authored_at.py
@@ -131,6 +131,60 @@ def safe_file_modified_time(path: Any) -> datetime | None:
         return None
 
 
+_OOXML_CORE_PROPERTIES_PATH: str = "docProps/core.xml"
+"""ZIP entry inside an OOXML package that holds the Dublin Core properties.
+
+OOXML (DOCX/XLSX/PPTX) wraps a ``docProps/core.xml`` file in the ZIP
+package, carrying ``dcterms:created`` and ``dcterms:modified`` plus
+the Dublin Core ``title`` / ``creator`` fields. Reading it through
+``zipfile`` + ``xml.etree`` avoids pulling python-pptx / openpyxl just
+for the date extraction.
+"""
+
+_DCTERMS_NAMESPACE_URI: str = "http://purl.org/dc/terms/"
+"""XML namespace URI for ``dcterms:`` elements in OOXML core properties."""
+
+
+def ooxml_authored_at(path: Any) -> datetime | None:
+    """Return ``dcterms:created`` / ``dcterms:modified`` from an OOXML file.
+
+    Tries ``dcterms:created`` first (the document creation time recorded
+    by Word / Excel / PowerPoint when the file was first saved), then
+    falls back to ``dcterms:modified``. Returns ``None`` when the file
+    is not a valid OOXML package, has no core-properties part, or both
+    fields are missing — the caller then falls back to the filesystem
+    mtime per the FEAT-031 (#263) fallback chain.
+
+    Args:
+        path: Path to a ``.docx`` / ``.xlsx`` / ``.pptx`` file.
+
+    Returns:
+        A timezone-aware datetime, or ``None`` when nothing is
+        extractable.
+    """
+    import xml.etree.ElementTree as ET  # noqa: S405 — XML is opt-in via FEAT-031
+    import zipfile
+
+    try:
+        with zipfile.ZipFile(path) as zf:
+            try:
+                with zf.open(_OOXML_CORE_PROPERTIES_PATH) as fp:
+                    tree = ET.parse(fp)  # noqa: S314 — trusted user file
+            except KeyError:
+                return None
+    except (OSError, zipfile.BadZipFile):
+        return None
+    root = tree.getroot()
+    for field in ("created", "modified"):
+        element = root.find(f"{{{_DCTERMS_NAMESPACE_URI}}}{field}")
+        if element is None or not element.text:
+            continue
+        parsed = parse_authored_value(element.text)
+        if parsed is not None:
+            return parsed
+    return None
+
+
 def frontmatter_authored_at(
     fm_data: dict[str, Any],
     keys: tuple[str, ...],

--- a/creek-tools/creek/ingest/chatgpt.py
+++ b/creek-tools/creek/ingest/chatgpt.py
@@ -21,6 +21,7 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from creek.ingest._authored_at import parse_authored_value
 from creek.ingest.base import (
     LA_TZ,
     Ingestor,
@@ -155,11 +156,15 @@ class ChatGPTIngestor(Ingestor):
         conv_id = fragment.metadata.get("conversation_id")
         if conv_id is not None:
             source["conversation_id"] = conv_id
-        return {
+        fm: dict[str, Any] = {
             "title": fragment.metadata.get("title", "Untitled Conversation"),
             "created": fragment.timestamp.isoformat(),
             "source": source,
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            fm["authored_at"] = authored_at.isoformat()
+        return fm
 
     # ---- Private helpers ----
 
@@ -203,7 +208,12 @@ class ChatGPTIngestor(Ingestor):
             )
 
         return _pair_messages_to_fragments(
-            ordered_messages, title, timestamp, source_path, conversation_id
+            ordered_messages,
+            title,
+            timestamp,
+            source_path,
+            conversation_id,
+            conversation_create_time=create_time,
         )
 
 
@@ -461,6 +471,8 @@ def _pair_messages_to_fragments(
     conversation_timestamp: datetime,
     source_path: str,
     conversation_id: str | None = None,
+    *,
+    conversation_create_time: float | None = None,
 ) -> list[ParsedFragment]:
     """Pair consecutive user+assistant messages into fragments.
 
@@ -475,6 +487,9 @@ def _pair_messages_to_fragments(
         conversation_timestamp: The conversation creation timestamp.
         source_path: The source file path.
         conversation_id: Optional ChatGPT conversation ID for metadata.
+        conversation_create_time: Raw Unix-epoch ``create_time`` from
+            the conversation, used as the ``authored_at`` fallback when
+            a per-message ``create_time`` is missing.
 
     Returns:
         A list of ``ParsedFragment`` objects, one per pair.
@@ -504,6 +519,16 @@ def _pair_messages_to_fragments(
                         if user_time
                         else conversation_timestamp
                     )
+                    # FEAT-031 (#263): per-message ``create_time``
+                    # (Unix epoch) is the user turn's authored date.
+                    # When absent we fall back to the conversation's
+                    # own ``create_time``. ``parse_authored_value``
+                    # keeps the source's UTC instant intact (no LA
+                    # shift) so a turn timestamped 23:30 UTC on
+                    # 2024-11-15 does not silently bucket into 2024-11-14.
+                    authored_at = parse_authored_value(
+                        user_time,
+                    ) or parse_authored_value(conversation_create_time)
                     content = (
                         f"**User**: {user_text}\n\n**Assistant**: {assistant_text}"
                     )
@@ -511,6 +536,7 @@ def _pair_messages_to_fragments(
                     meta: dict[str, Any] = {
                         "title": turn_title,
                         "platform": "chatgpt",
+                        "authored_at": authored_at,
                     }
                     if conversation_id is not None:
                         meta["conversation_id"] = conversation_id

--- a/creek-tools/creek/ingest/claude.py
+++ b/creek-tools/creek/ingest/claude.py
@@ -19,6 +19,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from creek.ingest._authored_at import parse_authored_value
 from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
@@ -28,6 +29,7 @@ from creek.ingest.base import (
 )
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from pathlib import Path
 
     from creek.clean.filters.chatbot import ChatbotFilter
@@ -320,11 +322,15 @@ class ClaudeIngestor(Ingestor):
         if model is not None:
             source["model"] = model
 
-        return {
+        fm: dict[str, Any] = {
             "title": f"{conv_name} (turn {turn_idx})",
             "created": fragment.timestamp.isoformat(),
             "source": source,
         }
+        authored_at: datetime | None = meta.get("authored_at")
+        if authored_at is not None:
+            fm["authored_at"] = authored_at.isoformat()
+        return fm
 
     # ---- Private Helpers ----
 
@@ -449,6 +455,14 @@ class ClaudeIngestor(Ingestor):
 
         ts_string = _resolve_timestamp(human_msg, fallback_ts)
         timestamp = normalize_timestamp(ts_string, source_tz=None)
+        # FEAT-031 (#263): per-message ``create_time`` (Claude calls it
+        # ``created_at``) is the authored date. When absent we use the
+        # conversation's own ``created_at``; both are tz-aware ISO 8601
+        # values so :func:`parse_authored_value` preserves them
+        # without an LA shift that would drift the calendar date.
+        authored_at: datetime | None = parse_authored_value(
+            human_msg.get("created_at"),
+        ) or parse_authored_value(fallback_ts)
 
         content = f"{human_text}\n\n{assistant_text}"
 
@@ -458,6 +472,7 @@ class ClaudeIngestor(Ingestor):
             "turn_index": turn_index,
             "human_text": human_text,
             "assistant_text": assistant_text,
+            "authored_at": authored_at,
         }
         if model is not None:
             metadata["model"] = model

--- a/creek-tools/creek/ingest/code.py
+++ b/creek-tools/creek/ingest/code.py
@@ -23,6 +23,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from creek.ingest._authored_at import (
+    parse_authored_value,
+    safe_file_modified_time,
+)
 from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
@@ -373,6 +377,73 @@ def _get_file_timestamp(path: Path) -> datetime:
     return datetime.fromtimestamp(mtime, tz=LA_TZ)
 
 
+def _git_first_commit_author_date(path: Path) -> datetime | None:
+    """Return the file's first-commit author date, or ``None`` (FEAT-031 / #263).
+
+    Runs ``git log --diff-filter=A --follow --format=%aI -- <path>``
+    against the path's parent directory. The ``--follow`` flag tracks
+    renames so a file's authored date survives across a rename; ``%aI``
+    formats the author date as strict ISO 8601 which round-trips
+    losslessly through :func:`parse_authored_value`.
+
+    Returns ``None`` for any of the failure modes:
+
+    * git is not on ``PATH``,
+    * the path is not inside a git work tree,
+    * the file has never been committed (untracked / staged-only), or
+    * the subprocess exits non-zero or times out.
+
+    None is the contracted "honest absence" answer per the issue; the
+    caller falls back to filesystem mtime.
+    """
+    git_path = shutil.which("git")
+    if git_path is None:
+        return None
+    parent = path.parent if path.is_file() else path
+    try:
+        result = subprocess.run(  # nosec B603 — hardcoded args, path arg only
+            [
+                git_path,
+                "log",
+                "--diff-filter=A",
+                "--follow",
+                "--format=%aI",
+                "--",
+                path.name if path.is_file() else ".",
+            ],
+            cwd=str(parent),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    # ``%aI`` may emit one line per add-event for a file that has been
+    # deleted and re-added; the *earliest* (last line in git log
+    # reverse-chronological output) is the true creation date.
+    lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    if not lines:
+        return None
+    return parse_authored_value(lines[-1])
+
+
+def _resolve_authored_at(path: Path) -> datetime | None:
+    """Apply the CodeIngestor fallback chain: git first-commit, then mtime.
+
+    Mirrors the per-ingestor extraction contract from FEAT-031 (#263):
+    the source's authored date is the file's first-commit author date
+    when it is in a git repo; otherwise the filesystem mtime. ``None``
+    surfaces only when both fail (e.g. a synthetic in-memory path).
+    """
+    git_date = _git_first_commit_author_date(path)
+    if git_date is not None:
+        return git_date
+    return safe_file_modified_time(path)
+
+
 def _is_adr_file(path: Path) -> bool:
     """Check if a file is an Architecture Decision Record.
 
@@ -615,15 +686,23 @@ class CodeIngestor(Ingestor):
         artifact_type = raw.metadata.get("artifact_type", "other")
         text, _encoding = normalize_encoding(raw.content)
         timestamp = _get_file_timestamp(raw.path)
+        # FEAT-031 (#263): the file's first-commit author date is the
+        # authored date for code artifacts; mtime is the fallback.
+        # For the synthetic ``commits`` document the path *is* the repo
+        # root, so the same call returns the repo's first commit — the
+        # most honest answer available.
+        authored_at = _resolve_authored_at(raw.path)
 
         if artifact_type in ("readme", "claude_md", "adr"):
-            return self._parse_markdown_artifact(raw, text, timestamp, artifact_type)
+            return self._parse_markdown_artifact(
+                raw, text, timestamp, artifact_type, authored_at
+            )
 
         if artifact_type == "python":
-            return self._parse_python_file(raw, text, timestamp)
+            return self._parse_python_file(raw, text, timestamp, authored_at)
 
         if artifact_type == "commits":
-            return self._parse_commits(raw, text, timestamp)
+            return self._parse_commits(raw, text, timestamp, authored_at)
 
         return []
 
@@ -633,6 +712,7 @@ class CodeIngestor(Ingestor):
         text: str,
         timestamp: datetime,
         artifact_type: str,
+        authored_at: datetime | None,
     ) -> list[ParsedFragment]:
         """Parse a markdown-based artifact (README, CLAUDE.md, ADR).
 
@@ -641,6 +721,7 @@ class CodeIngestor(Ingestor):
             text: Decoded text content.
             timestamp: File timestamp.
             artifact_type: The artifact type identifier.
+            authored_at: Source-derived authored date (FEAT-031).
 
         Returns:
             A single-element list containing the parsed fragment.
@@ -648,7 +729,10 @@ class CodeIngestor(Ingestor):
         return [
             ParsedFragment(
                 content=text,
-                metadata={"artifact_type": artifact_type},
+                metadata={
+                    "artifact_type": artifact_type,
+                    "authored_at": authored_at,
+                },
                 source_path=str(raw.path),
                 timestamp=timestamp,
             )
@@ -659,6 +743,7 @@ class CodeIngestor(Ingestor):
         raw: RawDocument,
         text: str,
         timestamp: datetime,
+        authored_at: datetime | None,
     ) -> list[ParsedFragment]:
         """Parse a Python file for docstrings and significant comments.
 
@@ -666,6 +751,7 @@ class CodeIngestor(Ingestor):
             raw: The raw document.
             text: Decoded Python source text.
             timestamp: File timestamp.
+            authored_at: Source-derived authored date (FEAT-031).
 
         Returns:
             A list of fragments for each docstring and significant comment.
@@ -683,6 +769,7 @@ class CodeIngestor(Ingestor):
                         "kind": doc_info["kind"],
                         "name": doc_info["name"],
                         "line": doc_info["line"],
+                        "authored_at": authored_at,
                     },
                     source_path=source_path,
                     timestamp=timestamp,
@@ -694,6 +781,7 @@ class CodeIngestor(Ingestor):
             metadata: dict[str, Any] = {
                 "artifact_type": "comment",
                 "line": comment_info["line"],
+                "authored_at": authored_at,
             }
             if "marker" in comment_info:
                 metadata["marker"] = comment_info["marker"]
@@ -713,6 +801,7 @@ class CodeIngestor(Ingestor):
         raw: RawDocument,
         text: str,
         timestamp: datetime,
+        authored_at: datetime | None,
     ) -> list[ParsedFragment]:
         """Parse commit messages into a single fragment.
 
@@ -720,6 +809,7 @@ class CodeIngestor(Ingestor):
             raw: The raw document.
             text: The git log output text.
             timestamp: Repository timestamp.
+            authored_at: Source-derived authored date (FEAT-031).
 
         Returns:
             A single-element list containing the commit log fragment.
@@ -730,7 +820,10 @@ class CodeIngestor(Ingestor):
         return [
             ParsedFragment(
                 content=text,
-                metadata={"artifact_type": "commits"},
+                metadata={
+                    "artifact_type": "commits",
+                    "authored_at": authored_at,
+                },
                 source_path=str(raw.path),
                 timestamp=timestamp,
             )
@@ -831,7 +924,7 @@ class CodeIngestor(Ingestor):
         title = _derive_title(fragment)
         artifact_type = fragment.metadata.get("artifact_type", "")
 
-        return {
+        fm: dict[str, Any] = {
             "type": "fragment",
             "title": title,
             "source": {
@@ -841,3 +934,7 @@ class CodeIngestor(Ingestor):
             "created": fragment.timestamp.isoformat(),
             "artifact_type": artifact_type,
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            fm["authored_at"] = authored_at.isoformat()
+        return fm

--- a/creek-tools/creek/ingest/discord.py
+++ b/creek-tools/creek/ingest/discord.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 from creek.clean.filters.discord import DiscordFilter, DiscordFilterConfig
+from creek.ingest._authored_at import parse_authored_value
 from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
@@ -490,6 +491,12 @@ class DiscordIngestor(Ingestor):
         content = "\n\n".join(content_parts)
         first_ts = _safe_timestamp(group[0])
         timestamp = self._resolve_timestamp(first_ts)
+        # FEAT-031 (#263): the group's earliest message timestamp is the
+        # authored date. Discord exports stamp every message with a
+        # tz-aware ISO 8601 string, so :func:`parse_authored_value`
+        # preserves the UTC instant intact — no LA shift that would
+        # silently move a 23:30 UTC message into the previous day.
+        authored_at = parse_authored_value(first_ts)
 
         return ParsedFragment(
             content=content,
@@ -499,6 +506,7 @@ class DiscordIngestor(Ingestor):
                 "authors": sorted(authors),
                 "message_count": len(group),
                 "message_ids": [str(m.get("id", "")) for m in group],
+                "authored_at": authored_at,
             },
             source_path=source_path,
             timestamp=timestamp,
@@ -643,7 +651,7 @@ class DiscordIngestor(Ingestor):
         Returns:
             A dict of frontmatter key-value pairs.
         """
-        return {
+        fm: dict[str, Any] = {
             "source": {
                 "platform": "discord",
                 "channel": fragment.metadata.get("channel_name", "unknown"),
@@ -653,3 +661,7 @@ class DiscordIngestor(Ingestor):
             "authors": fragment.metadata.get("authors", []),
             "message_count": fragment.metadata.get("message_count", 0),
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            fm["authored_at"] = authored_at.isoformat()
+        return fm

--- a/creek-tools/creek/ingest/documents.py
+++ b/creek-tools/creek/ingest/documents.py
@@ -28,6 +28,13 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import json
+import re
+
+from creek.ingest._authored_at import (
+    parse_authored_value,
+    safe_file_modified_time,
+)
 from creek.ingest._detection import is_substack_export
 from creek.ingest.base import (
     Ingestor,
@@ -336,6 +343,315 @@ def _extract_pdf_metadata(pdf_bytes: bytes) -> dict[str, Any]:
     return _extract_pdf_metadata_from_bytes(pdf_bytes)
 
 
+_HTML_META_NAME_KEYS: tuple[str, ...] = (
+    "article:published_time",
+    "dcterms.created",
+    "dc.date.issued",
+    "date",
+    "dc.date",
+    "pubdate",
+    "publishdate",
+    "publication_date",
+    "sailthru.date",
+)
+"""``<meta property|name>`` keys consulted, in order, for HTML authored_at.
+
+Order is "most explicit first": ``article:published_time`` is set by
+modern CMSes; ``dcterms.created`` is the Dublin Core canonical;
+``date`` is the bare lower-bound that any HTML page might have.
+"""
+
+_HTML_META_RE = re.compile(
+    r"<meta\s+(?:[^>]*?\s)?(?:name|property)\s*=\s*[\"']([^\"']+)[\"']"
+    r"\s+content\s*=\s*[\"']([^\"']+)[\"']",
+    re.IGNORECASE,
+)
+"""Loose ``<meta>`` regex that handles both ``name=`` and ``property=``.
+
+A real HTML parser is over-engineered for the narrow date-extraction
+job; the issue's never-guess rule means a missed match is fine — we
+fall back to mtime. The regex tolerates either attribute order
+(content first, name first) by anchoring on the (name|property) key
+and a following content value.
+"""
+
+_JSON_LD_BLOCK_RE = re.compile(
+    r"<script[^>]*type\s*=\s*[\"']application/ld\+json[\"'][^>]*>(.*?)</script>",
+    re.IGNORECASE | re.DOTALL,
+)
+"""Match a ``<script type='application/ld+json'>...</script>`` block."""
+
+
+def _extract_html_authored_at(html: str) -> datetime | None:
+    """Return the HTML page's authored date, or ``None`` (FEAT-031 / #263).
+
+    Walks the fallback chain ``<meta>`` tags → JSON-LD ``datePublished``.
+    The mtime fallback lives in :func:`_resolve_document_authored_at`
+    so this function stays a pure parser.
+    """
+    meta_match = _extract_html_meta_date(html)
+    if meta_match is not None:
+        return meta_match
+    return _extract_html_json_ld_date(html)
+
+
+def _extract_html_meta_date(html: str) -> datetime | None:
+    """Try each :data:`_HTML_META_NAME_KEYS` key in order; ``None`` on miss."""
+    matches: dict[str, str] = {}
+    for key, value in _HTML_META_RE.findall(html):
+        normalised = key.strip().lower()
+        if normalised not in matches:
+            matches[normalised] = value.strip()
+    for candidate in _HTML_META_NAME_KEYS:
+        raw = matches.get(candidate.lower())
+        if raw is None:
+            continue
+        parsed = parse_authored_value(raw)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _extract_html_json_ld_date(html: str) -> datetime | None:
+    """Scan every JSON-LD block for ``datePublished``; ``None`` on miss."""
+    for block in _JSON_LD_BLOCK_RE.findall(html):
+        try:
+            payload = json.loads(block.strip())
+        except json.JSONDecodeError:
+            continue
+        for candidate in _iter_json_ld_objects(payload):
+            raw = candidate.get("datePublished") or candidate.get("dateCreated")
+            if not isinstance(raw, str):
+                continue
+            parsed = parse_authored_value(raw)
+            if parsed is not None:
+                return parsed
+    return None
+
+
+def _iter_json_ld_objects(payload: Any) -> "list[dict[str, Any]]":
+    """Yield every dict in a JSON-LD payload (top-level + ``@graph`` children).
+
+    Real-world JSON-LD blocks are either a single object, a list of
+    objects, or a single object with a ``@graph`` array of objects.
+    We surface them all so :func:`_extract_html_json_ld_date` can scan
+    each one without caring about the wrapper shape.
+    """
+    objects: list[dict[str, Any]] = []
+    candidates = payload if isinstance(payload, list) else [payload]
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        objects.append(item)
+        graph = item.get("@graph")
+        if isinstance(graph, list):
+            objects.extend(g for g in graph if isinstance(g, dict))
+    return objects
+
+
+_RTF_DATE_RE = re.compile(
+    r"\\(?P<which>creatim|revtim)"
+    r"(?=[\\}])"  # boundary before \yr group or block close
+    r"(?P<rest>(?:\\(?:yr|mo|dy|hr|min|sec)-?\d+)*)",
+    re.IGNORECASE,
+)
+"""Match an RTF ``\\creatim`` / ``\\revtim`` block and its component fields."""
+
+_RTF_FIELD_RE = re.compile(r"\\(yr|mo|dy|hr|min|sec)(-?\d+)", re.IGNORECASE)
+
+
+def _extract_rtf_authored_at(rtf_text: str) -> datetime | None:
+    """Return the RTF source's authored date, or ``None`` (FEAT-031 / #263).
+
+    Prefers ``\\creatim`` (the document's creation block) over
+    ``\\revtim`` (last revision). Each component (``\\yr``, ``\\mo``,
+    ``\\dy``, ``\\hr``, ``\\min``, ``\\sec``) is optional; missing
+    fields default to ``0`` per the RTF spec, which gives us at least
+    a date-precision answer when only ``\\yr\\mo\\dy`` is present.
+    """
+    found: dict[str, str] = {}
+    for match in _RTF_DATE_RE.finditer(rtf_text):
+        which = match.group("which").lower()
+        if which not in found:
+            found[which] = match.group("rest")
+    for key in ("creatim", "revtim"):
+        block = found.get(key)
+        if block is None:
+            continue
+        parsed = _parse_rtf_date_block(block)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _parse_rtf_date_block(block: str) -> datetime | None:
+    """Build a UTC datetime from an RTF ``\\creatim`` / ``\\revtim`` block."""
+    parts: dict[str, int] = {}
+    for name, value in _RTF_FIELD_RE.findall(block):
+        try:
+            parts[name.lower()] = int(value)
+        except ValueError:
+            continue
+    year = parts.get("yr")
+    month = parts.get("mo")
+    day = parts.get("dy")
+    if year is None or month is None or day is None:
+        return None
+    try:
+        from datetime import UTC
+
+        return datetime(
+            year=year,
+            month=month,
+            day=day,
+            hour=parts.get("hr", 0),
+            minute=parts.get("min", 0),
+            second=parts.get("sec", 0),
+            tzinfo=UTC,
+        )
+    except ValueError:
+        return None
+
+
+def _resolve_document_authored_at(
+    file_type: str,
+    raw_bytes: bytes,
+    text: str,
+    metadata: dict[str, Any],
+    file_path: Path,
+) -> datetime | None:
+    """Apply the DocumentIngestor per-format fallback chain (FEAT-031 / #263).
+
+    Each branch implements the chain documented on the issue body:
+
+    * HTML/HTM: ``<meta>`` keys + JSON-LD ``datePublished`` → mtime.
+    * PDF: ``/CreationDate`` from the document info → ``/ModDate`` → mtime.
+    * DOCX: ``dcterms:created`` → ``dcterms:modified`` → mtime.
+    * RTF: ``\\creatim`` → ``\\revtim`` → mtime.
+    * TXT (and anything unrecognised): mtime only.
+
+    ``metadata`` is the dict :meth:`DocumentIngestor._extract_metadata`
+    has already populated; we read PDF / DOCX fields out of it instead
+    of re-parsing the bytes.
+    """
+    extractor = _DOCUMENT_AUTHORED_AT_EXTRACTORS.get(file_type)
+    explicit = extractor(raw_bytes, text, metadata) if extractor is not None else None
+    if explicit is not None:
+        return explicit
+    return safe_file_modified_time(file_path)
+
+
+def _html_authored_at(
+    _raw_bytes: bytes,
+    text: str,
+    _metadata: dict[str, Any],
+) -> datetime | None:
+    """HTML extractor — delegates to :func:`_extract_html_authored_at`."""
+    return _extract_html_authored_at(text)
+
+
+def _pdf_authored_at(
+    _raw_bytes: bytes,
+    _text: str,
+    metadata: dict[str, Any],
+) -> datetime | None:
+    """PDF extractor — read ``/CreationDate`` then ``/ModDate`` from info."""
+    for key in ("creationdate", "moddate"):
+        raw = metadata.get(key)
+        if raw is None:
+            continue
+        parsed = _parse_pdf_date(raw)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _parse_pdf_date(value: object) -> datetime | None:
+    """Parse a PDF ``/CreationDate`` / ``/ModDate`` ``D:YYYYMMDD...`` string.
+
+    PDF dates are formatted ``D:YYYYMMDDHHmmSS+HH'mm'`` per ISO 32000.
+    The strict format makes :func:`parse_authored_value` (which expects
+    ISO 8601 or one of the fallback patterns) miss them, so we
+    normalise to ISO 8601 first.
+    """
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if text.startswith("D:"):
+        text = text[2:]
+    if len(text) < 4:
+        return None
+    parts: list[str] = []
+    pieces = (text[0:4], text[4:6], text[6:8], text[8:10], text[10:12], text[12:14])
+    for idx, piece in enumerate(pieces):
+        if not piece or not piece.isdigit():
+            break
+        parts.append(piece if idx else piece)
+    if len(parts) < 3:
+        # Need at least YYYYMMDD; surface what parse_authored_value can
+        # do with the raw string in case we got an already-ISO value.
+        return parse_authored_value(value)
+    iso = (
+        f"{parts[0]}-{parts[1]}-{parts[2]}"
+        + (f"T{parts[3]}" if len(parts) > 3 else "")
+        + (f":{parts[4]}" if len(parts) > 4 else "")
+        + (f":{parts[5]}" if len(parts) > 5 else "")
+    )
+    return parse_authored_value(iso)
+
+
+def _docx_authored_at(
+    raw_bytes: bytes,
+    _text: str,
+    metadata: dict[str, Any],
+) -> datetime | None:
+    """DOCX extractor — ``dcterms:created`` then ``dcterms:modified``."""
+    created = metadata.get("created_date")
+    parsed = parse_authored_value(created) if created is not None else None
+    if parsed is not None:
+        return parsed
+    modified = _extract_docx_modified(raw_bytes)
+    if modified is not None:
+        return parse_authored_value(modified)
+    return None
+
+
+def _extract_docx_modified(docx_bytes: bytes) -> str | None:
+    """Return the DOCX core ``dcterms:modified`` ISO string, or ``None``."""
+    try:
+        from docx import Document as DocxDocument
+    except ImportError:
+        return None
+    try:
+        doc = DocxDocument(io.BytesIO(docx_bytes))
+    except Exception:  # noqa: BLE001 — python-docx surfaces a heterogeneous set
+        logger.debug("Could not open DOCX for dcterms:modified extraction")
+        return None
+    modified = doc.core_properties.modified
+    if modified is None:
+        return None
+    return modified.isoformat()
+
+
+def _rtf_authored_at(
+    _raw_bytes: bytes,
+    text: str,
+    _metadata: dict[str, Any],
+) -> datetime | None:
+    """RTF extractor — delegates to :func:`_extract_rtf_authored_at`."""
+    return _extract_rtf_authored_at(text)
+
+
+_DOCUMENT_AUTHORED_AT_EXTRACTORS: dict[str, Any] = {
+    ".html": _html_authored_at,
+    ".htm": _html_authored_at,
+    ".pdf": _pdf_authored_at,
+    ".docx": _docx_authored_at,
+    ".rtf": _rtf_authored_at,
+}
+"""Per-file-type ``authored_at`` extractor. ``.txt`` is absent on purpose."""
+
+
 def _infer_document_platform(extension: str) -> SourcePlatform:
     """Map a file extension to a SourcePlatform value.
 
@@ -464,6 +780,13 @@ class DocumentIngestor(Ingestor):
         content = self._extract_content(file_type, raw.content, text)
         metadata = self._extract_metadata(file_type, raw.content, encoding)
         timestamp = self._resolve_timestamp(metadata, raw.path)
+        metadata["authored_at"] = _resolve_document_authored_at(
+            file_type,
+            raw.content,
+            text,
+            metadata,
+            raw.path,
+        )
 
         return [
             ParsedFragment(
@@ -618,9 +941,13 @@ class DocumentIngestor(Ingestor):
         if fragment.metadata.get("scanned"):
             source["scanned"] = True
 
-        return {
+        fm: dict[str, Any] = {
             "type": "fragment",
             "title": title,
             "source": source,
             "created": fragment.timestamp.isoformat(),
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            fm["authored_at"] = authored_at.isoformat()
+        return fm

--- a/creek-tools/creek/ingest/documents.py
+++ b/creek-tools/creek/ingest/documents.py
@@ -23,13 +23,13 @@ Exports:
 from __future__ import annotations
 
 import io
+import json
 import logging
+import re
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from typing import Any
-
-import json
-import re
 
 from creek.ingest._authored_at import (
     parse_authored_value,
@@ -429,7 +429,7 @@ def _extract_html_json_ld_date(html: str) -> datetime | None:
     return None
 
 
-def _iter_json_ld_objects(payload: Any) -> "list[dict[str, Any]]":
+def _iter_json_ld_objects(payload: Any) -> list[dict[str, Any]]:
     """Yield every dict in a JSON-LD payload (top-level + ``@graph`` children).
 
     Real-world JSON-LD blocks are either a single object, a list of
@@ -497,10 +497,10 @@ def _parse_rtf_date_block(block: str) -> datetime | None:
     day = parts.get("dy")
     if year is None or month is None or day is None:
         return None
-    try:
-        from datetime import UTC
+    from datetime import UTC
 
-        return datetime(
+    try:
+        result = datetime(
             year=year,
             month=month,
             day=day,
@@ -511,6 +511,15 @@ def _parse_rtf_date_block(block: str) -> datetime | None:
         )
     except ValueError:
         return None
+    else:
+        return result
+
+
+DocumentAuthoredAtExtractor = Callable[
+    [bytes, str, dict[str, Any]],
+    "datetime | None",
+]
+"""Signature shared by every per-format document ``authored_at`` extractor."""
 
 
 def _resolve_document_authored_at(
@@ -576,28 +585,38 @@ def _parse_pdf_date(value: object) -> datetime | None:
     """
     if not isinstance(value, str):
         return None
-    text = value.strip()
-    if text.startswith("D:"):
-        text = text[2:]
-    if len(text) < 4:
-        return None
-    parts: list[str] = []
-    pieces = (text[0:4], text[4:6], text[6:8], text[8:10], text[10:12], text[12:14])
-    for idx, piece in enumerate(pieces):
-        if not piece or not piece.isdigit():
-            break
-        parts.append(piece if idx else piece)
+    parts = _pdf_date_parts(value)
     if len(parts) < 3:
         # Need at least YYYYMMDD; surface what parse_authored_value can
         # do with the raw string in case we got an already-ISO value.
         return parse_authored_value(value)
-    iso = (
-        f"{parts[0]}-{parts[1]}-{parts[2]}"
-        + (f"T{parts[3]}" if len(parts) > 3 else "")
-        + (f":{parts[4]}" if len(parts) > 4 else "")
-        + (f":{parts[5]}" if len(parts) > 5 else "")
-    )
-    return parse_authored_value(iso)
+    return parse_authored_value(_pdf_parts_to_iso(parts))
+
+
+def _pdf_date_parts(value: str) -> list[str]:
+    """Slice a PDF ``D:YYYYMMDDHHmmSS`` value into its component digit groups."""
+    text = value.strip().removeprefix("D:")
+    if len(text) < 4:
+        return []
+    pieces = (text[0:4], text[4:6], text[6:8], text[8:10], text[10:12], text[12:14])
+    parts: list[str] = []
+    for piece in pieces:
+        if not piece or not piece.isdigit():
+            break
+        parts.append(piece)
+    return parts
+
+
+def _pdf_parts_to_iso(parts: list[str]) -> str:
+    """Assemble a partial PDF date tuple into an ISO 8601 string."""
+    iso = f"{parts[0]}-{parts[1]}-{parts[2]}"
+    if len(parts) > 3:
+        iso += f"T{parts[3]}"
+    if len(parts) > 4:
+        iso += f":{parts[4]}"
+    if len(parts) > 5:
+        iso += f":{parts[5]}"
+    return iso
 
 
 def _docx_authored_at(
@@ -622,15 +641,20 @@ def _extract_docx_modified(docx_bytes: bytes) -> str | None:
         from docx import Document as DocxDocument
     except ImportError:
         return None
+    return _read_docx_modified(DocxDocument, docx_bytes)
+
+
+def _read_docx_modified(docx_document: Any, docx_bytes: bytes) -> str | None:
+    """Open *docx_bytes* and return the ``dcterms:modified`` ISO string."""
     try:
-        doc = DocxDocument(io.BytesIO(docx_bytes))
-    except Exception:  # noqa: BLE001 — python-docx surfaces a heterogeneous set
+        doc = docx_document(io.BytesIO(docx_bytes))
+    except Exception:
         logger.debug("Could not open DOCX for dcterms:modified extraction")
         return None
     modified = doc.core_properties.modified
     if modified is None:
         return None
-    return modified.isoformat()
+    return str(modified.isoformat())
 
 
 def _rtf_authored_at(
@@ -642,7 +666,7 @@ def _rtf_authored_at(
     return _extract_rtf_authored_at(text)
 
 
-_DOCUMENT_AUTHORED_AT_EXTRACTORS: dict[str, Any] = {
+_DOCUMENT_AUTHORED_AT_EXTRACTORS: dict[str, DocumentAuthoredAtExtractor] = {
     ".html": _html_authored_at,
     ".htm": _html_authored_at,
     ".pdf": _pdf_authored_at,

--- a/creek-tools/creek/ingest/generic.py
+++ b/creek-tools/creek/ingest/generic.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import chardet
 
+from creek.ingest._authored_at import safe_file_modified_time
 from creek.ingest.base import (
     LA_TZ,
     Ingestor,
@@ -213,12 +214,18 @@ class GenericIngestor(Ingestor):
             return []
 
         now = datetime.now(tz=LA_TZ)
+        # FEAT-031 (#263): GenericIngestor is the lowest-fidelity tier —
+        # no in-band source date is available, so the file's mtime is
+        # the only honest answer. ``None`` when the path is unreadable
+        # (a synthetic ``RawDocument`` in tests, a vanished file mid-run).
+        authored_at = safe_file_modified_time(raw.path)
         return [
             ParsedFragment(
                 content=text,
                 metadata={
                     "file_extension": raw.path.suffix.lower(),
                     "source_type": "generic",
+                    "authored_at": authored_at,
                 },
                 source_path=str(raw.path),
                 timestamp=now,
@@ -258,7 +265,7 @@ class GenericIngestor(Ingestor):
             A dict of frontmatter key-value pairs.
         """
         title = Path(fragment.source_path).stem
-        return {
+        fm: dict[str, Any] = {
             "type": "fragment",
             "title": title,
             "source": {
@@ -268,3 +275,7 @@ class GenericIngestor(Ingestor):
             "created": fragment.timestamp.isoformat(),
             "routing": "01-Fragments/Unsorted/",
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            fm["authored_at"] = authored_at.isoformat()
+        return fm

--- a/creek-tools/creek/ingest/images.py
+++ b/creek-tools/creek/ingest/images.py
@@ -547,10 +547,23 @@ def _parse_exif_datetime(value: str) -> datetime | None:
     date/time and only adding the missing zone tag.
     """
     try:
-        parsed = datetime.strptime(value.strip(), _EXIF_DATETIME_FORMAT)  # noqa: DTZ007
+        parsed = datetime.strptime(value.strip(), _EXIF_DATETIME_FORMAT)
     except (TypeError, ValueError):
         return None
     return parsed.replace(tzinfo=UTC)
+
+
+def _read_exif_tags(
+    image_module: Any,
+    unidentified_error: type[Exception],
+    path: Path,
+) -> Any:
+    """Open *path* and return its EXIF dict, or ``None`` if unreadable."""
+    try:
+        with image_module.open(path) as img:
+            return img.getexif()
+    except (FileNotFoundError, OSError, unidentified_error):
+        return None
 
 
 def _extract_exif_authored_at(path: Path) -> datetime | None:
@@ -566,10 +579,8 @@ def _extract_exif_authored_at(path: Path) -> datetime | None:
         from PIL import Image, UnidentifiedImageError
     except ImportError:
         return None
-    try:
-        with Image.open(path) as img:
-            exif = img.getexif()
-    except (FileNotFoundError, OSError, UnidentifiedImageError):
+    exif = _read_exif_tags(Image, UnidentifiedImageError, path)
+    if exif is None:
         return None
     for tag in (_EXIF_DATETIME_ORIGINAL, _EXIF_DATETIME):
         raw = exif.get(tag)

--- a/creek-tools/creek/ingest/images.py
+++ b/creek-tools/creek/ingest/images.py
@@ -33,6 +33,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
+from creek.ingest._authored_at import safe_file_modified_time
 from creek.ingest.base import Ingestor, ParsedFragment, RawDocument
 from creek.models import SourcePlatform
 
@@ -411,6 +412,7 @@ class ImageIngestor(Ingestor):
             "ocr_confidence": result.confidence,
             "image_type": result.image_type,
             "language": self.language,
+            "authored_at": _resolve_image_authored_at(raw.path),
         }
         self._tag_low_confidence(metadata, result.confidence)
         return [
@@ -470,6 +472,9 @@ class ImageIngestor(Ingestor):
             "language": fragment.metadata.get("language", self.language),
             "ingested": fragment.timestamp.isoformat(),
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            frontmatter["authored_at"] = authored_at.isoformat()
         review_marker = fragment.metadata.get(_REVIEW_FRONTMATTER_KEY)
         if review_marker:
             frontmatter[_REVIEW_FRONTMATTER_KEY] = review_marker
@@ -521,6 +526,72 @@ class ImageIngestor(Ingestor):
 def _modified_time(path: Path) -> datetime:
     """Return the file's mtime as a timezone-aware UTC datetime."""
     return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+
+
+_EXIF_DATETIME_ORIGINAL: int = 36867
+"""EXIF tag ID for ``DateTimeOriginal`` — the time the photo was taken."""
+
+_EXIF_DATETIME: int = 306
+"""EXIF tag ID for ``DateTime`` — the file modification time inside EXIF."""
+
+_EXIF_DATETIME_FORMAT: str = "%Y:%m:%d %H:%M:%S"
+"""EXIF 2.32 §4.6.4: ``YYYY:MM:DD HH:MM:SS`` (note colons in date part)."""
+
+
+def _parse_exif_datetime(value: str) -> datetime | None:
+    """Parse an EXIF ``YYYY:MM:DD HH:MM:SS`` string into a UTC datetime.
+
+    EXIF dates are wall-clock with no timezone (the spec leaves
+    timezone implicit). Per FEAT-031 (#263) the never-naive rule, we
+    anchor the result to UTC — preserving the camera's calendar
+    date/time and only adding the missing zone tag.
+    """
+    try:
+        parsed = datetime.strptime(value.strip(), _EXIF_DATETIME_FORMAT)  # noqa: DTZ007
+    except (TypeError, ValueError):
+        return None
+    return parsed.replace(tzinfo=UTC)
+
+
+def _extract_exif_authored_at(path: Path) -> datetime | None:
+    """Return the image's EXIF authored date, or ``None`` (FEAT-031 / #263).
+
+    Walks the EXIF fallback chain ``DateTimeOriginal`` → ``DateTime``.
+    Returns ``None`` if Pillow is not installed, the file is not a
+    supported image, or neither tag is present/parseable — the caller
+    then falls back to filesystem mtime per the issue's documented
+    extraction chain.
+    """
+    try:
+        from PIL import Image, UnidentifiedImageError
+    except ImportError:
+        return None
+    try:
+        with Image.open(path) as img:
+            exif = img.getexif()
+    except (FileNotFoundError, OSError, UnidentifiedImageError):
+        return None
+    for tag in (_EXIF_DATETIME_ORIGINAL, _EXIF_DATETIME):
+        raw = exif.get(tag)
+        if not isinstance(raw, str):
+            continue
+        parsed = _parse_exif_datetime(raw)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _resolve_image_authored_at(path: Path) -> datetime | None:
+    """ImageIngestor fallback chain: EXIF dates, then filesystem mtime.
+
+    Mirrors FEAT-031 (#263). ``None`` only surfaces when both the EXIF
+    block and the filesystem mtime are unreadable — the contracted
+    "honest absence" answer.
+    """
+    exif = _extract_exif_authored_at(path)
+    if exif is not None:
+        return exif
+    return safe_file_modified_time(path)
 
 
 __all__ = [

--- a/creek-tools/creek/ingest/markdown.py
+++ b/creek-tools/creek/ingest/markdown.py
@@ -22,6 +22,7 @@ from typing import Any
 
 import frontmatter
 
+from creek.ingest._authored_at import frontmatter_authored_at
 from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
@@ -211,6 +212,15 @@ def _extract_timestamp_from_frontmatter(fm_data: dict[str, Any]) -> str | None:
     return None
 
 
+_AUTHORED_AT_FRONTMATTER_KEYS: tuple[str, ...] = ("published", "date", "created")
+"""Frontmatter keys consulted (in order) for ``authored_at`` extraction.
+
+Per FEAT-031 (#263) the chain is ``published`` → ``date`` → ``created``,
+then the filesystem mtime via
+:func:`creek.ingest._authored_at.frontmatter_authored_at`.
+"""
+
+
 def _get_file_creation_timestamp(path: Path) -> datetime:
     """Get the file creation timestamp from filesystem metadata.
 
@@ -323,6 +333,12 @@ class MarkdownIngestor(Ingestor):
         fm_data, content = self._parse_frontmatter(text)
         document_type = _detect_document_type(content)
         timestamp = self._resolve_timestamp(fm_data, raw.path)
+        authored_at = frontmatter_authored_at(
+            fm_data,
+            _AUTHORED_AT_FRONTMATTER_KEYS,
+            raw.path,
+            source_label="MarkdownIngestor",
+        )
 
         return [
             ParsedFragment(
@@ -330,6 +346,7 @@ class MarkdownIngestor(Ingestor):
                 metadata={
                     "existing_frontmatter": fm_data,
                     "document_type": document_type,
+                    "authored_at": authored_at,
                 },
                 source_path=str(raw.path),
                 timestamp=timestamp,
@@ -420,6 +437,9 @@ class MarkdownIngestor(Ingestor):
             },
             "created": fragment.timestamp.isoformat(),
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            creek_defaults["authored_at"] = authored_at.isoformat()
 
         return _merge_frontmatter(creek_defaults, existing_fm)
 

--- a/creek-tools/creek/ingest/presentations.py
+++ b/creek-tools/creek/ingest/presentations.py
@@ -24,6 +24,7 @@ import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+from creek.ingest._authored_at import ooxml_authored_at, safe_file_modified_time
 from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
@@ -33,6 +34,7 @@ from creek.ingest.base import (
 from creek.models import SourcePlatform
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -242,6 +244,11 @@ class PresentationIngestor(Ingestor):
             )
             return []
         timestamp = file_modified_time(raw.path)
+        # FEAT-031 (#263): try the .pptx package's core properties
+        # (``dcterms:created`` / ``dcterms:modified``) first; fall back
+        # to filesystem mtime when the package is malformed or the
+        # properties block is absent.
+        authored_at = ooxml_authored_at(raw.path) or safe_file_modified_time(raw.path)
         return [
             ParsedFragment(
                 content="",  # Markdown rendered in convert_to_markdown.
@@ -249,6 +256,7 @@ class PresentationIngestor(Ingestor):
                     "original_file": str(raw.path),
                     "title": data.title or raw.path.stem,
                     "slide_count": len(data.slides),
+                    "authored_at": authored_at,
                 },
                 source_path=str(raw.path),
                 timestamp=timestamp,
@@ -284,7 +292,7 @@ class PresentationIngestor(Ingestor):
 
     def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
         """Produce YAML frontmatter for a presentation fragment."""
-        return {
+        fm: dict[str, Any] = {
             "type": "fragment",
             "source": {
                 "platform": SourcePlatform.PRESENTATION.value,
@@ -297,6 +305,10 @@ class PresentationIngestor(Ingestor):
             "slide_count": fragment.metadata.get("slide_count", 0),
             "ingested": fragment.timestamp.isoformat(),
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            fm["authored_at"] = authored_at.isoformat()
+        return fm
 
 
 __all__ = [

--- a/creek-tools/creek/ingest/refresh.py
+++ b/creek-tools/creek/ingest/refresh.py
@@ -31,8 +31,8 @@ correct fallback chain for each:
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -44,7 +44,10 @@ from creek.models import Fragment, SourcePlatform
 from creek.vault.reader import try_load_fragment
 
 if TYPE_CHECKING:
-    pass
+    from datetime import datetime
+
+PlatformAuthoredAtExtractor = Callable[[Path], "datetime | None"]
+"""Signature shared by every per-platform ``authored_at`` extractor."""
 
 logger = logging.getLogger(__name__)
 
@@ -145,7 +148,7 @@ def _refresh_one(md_file: Path) -> RefreshOutcome | None:
         return None
     fragment, body, raw_metadata = loaded
     new_value = extract_authored_at_for_fragment(fragment)
-    if new_value is None and fragment.source.original_file is None:
+    if new_value is None is fragment.source.original_file:
         return RefreshOutcome(
             fragment_path=md_file,
             previous=fragment.authored_at,
@@ -203,11 +206,11 @@ def extract_authored_at_for_fragment(fragment: Fragment) -> datetime | None:
 
 def _document_extractor(path: Path) -> datetime | None:
     """Refresh extractor for HTML/PDF/DOCX/RTF/TXT files."""
+    from creek.ingest.base import normalize_encoding
     from creek.ingest.documents import (
         _extract_pdf_metadata,
         _resolve_document_authored_at,
     )
-    from creek.ingest.base import normalize_encoding
 
     raw = path.read_bytes()
     text, encoding = normalize_encoding(raw)
@@ -277,7 +280,7 @@ def _conversation_extractor(path: Path) -> datetime | None:
     return safe_file_modified_time(path)
 
 
-_PLATFORM_EXTRACTORS: dict[SourcePlatform, "object"] = {
+_PLATFORM_EXTRACTORS: dict[SourcePlatform, PlatformAuthoredAtExtractor] = {
     SourcePlatform.DOCUMENT: _document_extractor,
     SourcePlatform.MARKDOWN: _markdown_extractor,
     SourcePlatform.JOURNAL: _markdown_extractor,
@@ -302,19 +305,22 @@ def _rewrite_with_new_authored_at(
     raw_metadata: dict[str, object],
     new_value: datetime | None,
 ) -> None:
-    """Persist ``new_value`` into ``md_file``'s frontmatter; preserve body byte-for-byte.
+    """Persist ``new_value`` into ``md_file``'s frontmatter; preserve body.
 
     Reuses the raw metadata dict so non-Fragment keys (custom Obsidian
     fields, classification scratch space) survive the round-trip
     untouched. The body string we got from :func:`try_load_fragment`
     is fed straight back into :class:`frontmatter.Post`.
     """
-    updated = dict(raw_metadata)
+    updated = raw_metadata.copy()
     if new_value is None:
         updated.pop("authored_at", None)
     else:
         updated["authored_at"] = new_value.isoformat()
-    post = frontmatter.Post(content=body, **updated)
+    # frontmatter.Post's __init__ types ``**kwargs`` as ``BaseHandler``
+    # for legacy reasons even though dict-shaped metadata is what every
+    # caller actually passes; the runtime accepts the dict unchanged.
+    post = frontmatter.Post(content=body, **updated)  # type: ignore[arg-type]
     md_file.write_text(frontmatter.dumps(post), encoding="utf-8")
 
 

--- a/creek-tools/creek/ingest/refresh.py
+++ b/creek-tools/creek/ingest/refresh.py
@@ -1,0 +1,342 @@
+"""``creek ingest --refresh-dates`` backfill engine (FEAT-031 / #263).
+
+Walks every fragment in a vault, re-runs *only* the ``authored_at``
+extraction step against the original source file, and writes the
+updated date back into the fragment's frontmatter. Body content is
+left untouched — this is purely a date refresh, not a re-ingest.
+
+The operation is idempotent: a second run against the same vault
+extracts the same dates and writes nothing because the on-disk value
+already matches.
+
+Per-platform extractors live in their owning ingestor modules; this
+module routes by :attr:`Fragment.source.platform` and applies the
+correct fallback chain for each:
+
+* DOCUMENT (.html/.pdf/.docx/.rtf/.txt) →
+  :func:`creek.ingest.documents._resolve_document_authored_at`
+* MARKDOWN / JOURNAL / ESSAY →
+  :func:`creek.ingest._authored_at.frontmatter_authored_at`
+* CODE → :func:`creek.ingest.code._resolve_authored_at`
+* IMAGE_OCR → :func:`creek.ingest.images._resolve_image_authored_at`
+* SPREADSHEET → :func:`creek.ingest.spreadsheets._resolve_spreadsheet_authored_at`
+* PRESENTATION → OOXML core properties then mtime
+* CHATGPT / CLAUDE / DISCORD / SUBSTACK → source-file mtime fallback
+  only (per-message extraction requires re-parsing the export, which
+  is out of scope for a one-shot backfill — re-ingest those sources
+  through the normal pipeline for per-turn fidelity).
+* All other platforms → filesystem mtime.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import frontmatter
+import yaml
+
+from creek.ingest._authored_at import ooxml_authored_at, safe_file_modified_time
+from creek.models import Fragment, SourcePlatform
+from creek.vault.reader import try_load_fragment
+
+if TYPE_CHECKING:
+    pass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RefreshOutcome:
+    """Per-fragment outcome of a ``--refresh-dates`` pass.
+
+    Attributes:
+        fragment_path: Path to the fragment markdown file.
+        previous: The previous ``authored_at`` value (``None`` when
+            the field was absent).
+        new: The newly extracted value (``None`` when the source is
+            unreadable or has no extractable date).
+        changed: Whether the file was rewritten.
+        reason: Short human-readable status string. One of
+            ``"updated"``, ``"unchanged"``, ``"no-source"``,
+            ``"unsupported"``, or ``"error"``.
+    """
+
+    fragment_path: Path
+    previous: datetime | None
+    new: datetime | None
+    changed: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class RefreshSummary:
+    """Aggregate summary returned by :func:`refresh_vault_authored_at`.
+
+    Attributes:
+        outcomes: Per-fragment outcomes in walk order.
+        total: Number of fragments inspected.
+        updated: Number of fragments rewritten.
+        unchanged: Number of fragments where the value already matched.
+        missing_source: Number of fragments whose source file was absent.
+        errors: Number of fragments that failed to load or refresh.
+    """
+
+    outcomes: list[RefreshOutcome]
+    total: int
+    updated: int
+    unchanged: int
+    missing_source: int
+    errors: int
+
+
+def refresh_vault_authored_at(vault_path: Path) -> RefreshSummary:
+    """Backfill ``authored_at`` for every fragment under *vault_path*.
+
+    Walks ``<vault_path>/01-Fragments`` recursively, re-runs the
+    appropriate per-platform extractor against the original source
+    file, and rewrites the markdown only when the value changed.
+    Bodies are preserved byte-for-byte (the body string from the
+    loaded frontmatter is fed straight back to
+    :class:`frontmatter.Post`).
+
+    Args:
+        vault_path: Root of the Obsidian vault to refresh.
+
+    Returns:
+        A :class:`RefreshSummary` describing what changed.
+    """
+    fragments_root = vault_path / "01-Fragments"
+    outcomes: list[RefreshOutcome] = []
+    if not fragments_root.exists():
+        return RefreshSummary(
+            outcomes=[],
+            total=0,
+            updated=0,
+            unchanged=0,
+            missing_source=0,
+            errors=0,
+        )
+
+    for md_file in sorted(fragments_root.rglob("*.md")):
+        outcome = _refresh_one(md_file)
+        if outcome is not None:
+            outcomes.append(outcome)
+    return _summarise(outcomes)
+
+
+def _refresh_one(md_file: Path) -> RefreshOutcome | None:
+    """Refresh ``authored_at`` on one fragment file, or ``None`` for non-fragments."""
+    try:
+        loaded = try_load_fragment(md_file)
+    except (OSError, ValueError, yaml.YAMLError):
+        logger.warning("Could not read fragment for refresh: %s", md_file)
+        return RefreshOutcome(
+            fragment_path=md_file,
+            previous=None,
+            new=None,
+            changed=False,
+            reason="error",
+        )
+    if loaded is None:
+        return None
+    fragment, body, raw_metadata = loaded
+    new_value = extract_authored_at_for_fragment(fragment)
+    if new_value is None and fragment.source.original_file is None:
+        return RefreshOutcome(
+            fragment_path=md_file,
+            previous=fragment.authored_at,
+            new=None,
+            changed=False,
+            reason="no-source",
+        )
+    if new_value == fragment.authored_at:
+        return RefreshOutcome(
+            fragment_path=md_file,
+            previous=fragment.authored_at,
+            new=new_value,
+            changed=False,
+            reason="unchanged",
+        )
+    _rewrite_with_new_authored_at(md_file, body, raw_metadata, new_value)
+    return RefreshOutcome(
+        fragment_path=md_file,
+        previous=fragment.authored_at,
+        new=new_value,
+        changed=True,
+        reason="updated",
+    )
+
+
+def extract_authored_at_for_fragment(fragment: Fragment) -> datetime | None:
+    """Return the freshly-extracted ``authored_at`` for a stored fragment.
+
+    Dispatches by :attr:`Fragment.source.platform` to the per-ingestor
+    extraction chain. Returns ``None`` when the source file does not
+    exist or the platform has no file-based extractor (e.g. chat
+    exports whose authored date lives inside a JSON message blob and
+    cannot be located without re-parsing the whole conversation —
+    these surface as ``None`` from the ``mtime``-only branch unless a
+    source path is recorded).
+
+    Args:
+        fragment: The fragment whose ``authored_at`` should be refreshed.
+
+    Returns:
+        A timezone-aware datetime, or ``None`` when the source cannot
+        be located or carries no extractable date.
+    """
+    original = fragment.source.original_file
+    if not original:
+        return None
+    source_path = Path(original)
+    if not source_path.exists():
+        return None
+    extractor = _PLATFORM_EXTRACTORS.get(SourcePlatform(fragment.source.platform))
+    if extractor is None:
+        return safe_file_modified_time(source_path)
+    return extractor(source_path)
+
+
+def _document_extractor(path: Path) -> datetime | None:
+    """Refresh extractor for HTML/PDF/DOCX/RTF/TXT files."""
+    from creek.ingest.documents import (
+        _extract_pdf_metadata,
+        _resolve_document_authored_at,
+    )
+    from creek.ingest.base import normalize_encoding
+
+    raw = path.read_bytes()
+    text, encoding = normalize_encoding(raw)
+    file_type = path.suffix.lower()
+    metadata: dict[str, object] = {
+        "file_type": file_type,
+        "source_encoding": encoding,
+    }
+    if file_type == ".pdf":
+        metadata.update(_extract_pdf_metadata(raw))
+    elif file_type == ".docx":
+        from creek.ingest.documents import _extract_docx_metadata
+
+        metadata.update(_extract_docx_metadata(raw))
+    return _resolve_document_authored_at(file_type, raw, text, metadata, path)
+
+
+def _markdown_extractor(path: Path) -> datetime | None:
+    """Refresh extractor for ``.md`` files (frontmatter dates → mtime)."""
+    from creek.ingest._authored_at import frontmatter_authored_at
+    from creek.ingest.markdown import _AUTHORED_AT_FRONTMATTER_KEYS
+
+    post = frontmatter.load(str(path))
+    return frontmatter_authored_at(
+        post.metadata,
+        _AUTHORED_AT_FRONTMATTER_KEYS,
+        path,
+        source_label="MarkdownIngestor",
+    )
+
+
+def _code_extractor(path: Path) -> datetime | None:
+    """Refresh extractor for code files (git first-commit then mtime)."""
+    from creek.ingest.code import _resolve_authored_at
+
+    return _resolve_authored_at(path)
+
+
+def _image_extractor(path: Path) -> datetime | None:
+    """Refresh extractor for images (EXIF then mtime)."""
+    from creek.ingest.images import _resolve_image_authored_at
+
+    return _resolve_image_authored_at(path)
+
+
+def _spreadsheet_extractor(path: Path) -> datetime | None:
+    """Refresh extractor for spreadsheets (OOXML core then mtime)."""
+    from creek.ingest.spreadsheets import _resolve_spreadsheet_authored_at
+
+    return _resolve_spreadsheet_authored_at(path)
+
+
+def _presentation_extractor(path: Path) -> datetime | None:
+    """Refresh extractor for presentations (OOXML core then mtime)."""
+    return ooxml_authored_at(path) or safe_file_modified_time(path)
+
+
+def _conversation_extractor(path: Path) -> datetime | None:
+    """Refresh extractor for chat/conversation exports.
+
+    Per-message extraction would require re-parsing the entire JSON
+    export and matching by message ID — out of scope for a one-shot
+    backfill. Falls back to the source-file mtime so multi-year chat
+    logs at least get a date that's better than ``None`` when no
+    per-turn date was extracted at ingest time.
+    """
+    return safe_file_modified_time(path)
+
+
+_PLATFORM_EXTRACTORS: dict[SourcePlatform, "object"] = {
+    SourcePlatform.DOCUMENT: _document_extractor,
+    SourcePlatform.MARKDOWN: _markdown_extractor,
+    SourcePlatform.JOURNAL: _markdown_extractor,
+    SourcePlatform.ESSAY: _markdown_extractor,
+    SourcePlatform.CODE: _code_extractor,
+    SourcePlatform.IMAGE_OCR: _image_extractor,
+    SourcePlatform.SPREADSHEET: _spreadsheet_extractor,
+    SourcePlatform.PRESENTATION: _presentation_extractor,
+    SourcePlatform.SUBSTACK: _document_extractor,
+    SourcePlatform.CHATGPT: _conversation_extractor,
+    SourcePlatform.CLAUDE: _conversation_extractor,
+    SourcePlatform.DISCORD: _conversation_extractor,
+    SourcePlatform.EMAIL: _conversation_extractor,
+    SourcePlatform.OTHER: _conversation_extractor,
+}
+"""Routing table from :class:`SourcePlatform` to per-platform extractor."""
+
+
+def _rewrite_with_new_authored_at(
+    md_file: Path,
+    body: str,
+    raw_metadata: dict[str, object],
+    new_value: datetime | None,
+) -> None:
+    """Persist ``new_value`` into ``md_file``'s frontmatter; preserve body byte-for-byte.
+
+    Reuses the raw metadata dict so non-Fragment keys (custom Obsidian
+    fields, classification scratch space) survive the round-trip
+    untouched. The body string we got from :func:`try_load_fragment`
+    is fed straight back into :class:`frontmatter.Post`.
+    """
+    updated = dict(raw_metadata)
+    if new_value is None:
+        updated.pop("authored_at", None)
+    else:
+        updated["authored_at"] = new_value.isoformat()
+    post = frontmatter.Post(content=body, **updated)
+    md_file.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+def _summarise(outcomes: list[RefreshOutcome]) -> RefreshSummary:
+    """Aggregate per-file outcomes into a :class:`RefreshSummary`."""
+    updated = sum(1 for o in outcomes if o.reason == "updated")
+    unchanged = sum(1 for o in outcomes if o.reason == "unchanged")
+    missing = sum(1 for o in outcomes if o.reason == "no-source")
+    errors = sum(1 for o in outcomes if o.reason == "error")
+    return RefreshSummary(
+        outcomes=outcomes,
+        total=len(outcomes),
+        updated=updated,
+        unchanged=unchanged,
+        missing_source=missing,
+        errors=errors,
+    )
+
+
+__all__ = [
+    "RefreshOutcome",
+    "RefreshSummary",
+    "extract_authored_at_for_fragment",
+    "refresh_vault_authored_at",
+]

--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -31,6 +31,7 @@ from typing import Any, Protocol, runtime_checkable
 
 import chardet
 
+from creek.ingest._authored_at import ooxml_authored_at, safe_file_modified_time
 from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
@@ -375,6 +376,10 @@ class SpreadsheetIngestor(Ingestor):
         """
         workbook = self.backend.read_workbook(raw.path, has_header=has_header)
         timestamp = file_modified_time(raw.path)
+        # FEAT-031 (#263): .xlsx ships ``dcterms:created`` /
+        # ``dcterms:modified`` in the OOXML package; .csv has no
+        # in-band date so falls straight to filesystem mtime.
+        authored_at = _resolve_spreadsheet_authored_at(raw.path)
         fragments: list[ParsedFragment] = []
         for sheet in workbook.sheets:
             if sheet.is_empty:
@@ -392,6 +397,7 @@ class SpreadsheetIngestor(Ingestor):
                         "sheet": sheet.name,
                         "rows": len(sheet.rows),
                         "columns": column_count,
+                        "authored_at": authored_at,
                     },
                     source_path=str(raw.path),
                     timestamp=timestamp,
@@ -416,7 +422,7 @@ class SpreadsheetIngestor(Ingestor):
 
     def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
         """Produce YAML frontmatter for a spreadsheet fragment."""
-        return {
+        fm: dict[str, Any] = {
             "type": "fragment",
             "source": {
                 "platform": SourcePlatform.SPREADSHEET.value,
@@ -430,6 +436,24 @@ class SpreadsheetIngestor(Ingestor):
             "columns": fragment.metadata.get("columns", 0),
             "ingested": fragment.timestamp.isoformat(),
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            fm["authored_at"] = authored_at.isoformat()
+        return fm
+
+
+def _resolve_spreadsheet_authored_at(path: Path) -> "datetime | None":
+    """SpreadsheetIngestor authored_at chain (FEAT-031 / #263).
+
+    ``.xlsx`` carries Dublin Core date properties; ``.csv`` does not.
+    Both fall through to the filesystem mtime when no in-band date is
+    available — the ``None`` answer is reserved for an unreadable file.
+    """
+    if path.suffix.lower() == ".xlsx":
+        ooxml = ooxml_authored_at(path)
+        if ooxml is not None:
+            return ooxml
+    return safe_file_modified_time(path)
 
 
 def _extract_headers_and_rows(

--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -442,7 +442,7 @@ class SpreadsheetIngestor(Ingestor):
         return fm
 
 
-def _resolve_spreadsheet_authored_at(path: Path) -> "datetime | None":
+def _resolve_spreadsheet_authored_at(path: Path) -> datetime | None:
     """SpreadsheetIngestor authored_at chain (FEAT-031 / #263).
 
     ``.xlsx`` carries Dublin Core date properties; ``.csv`` does not.

--- a/creek-tools/creek/link/eddies.py
+++ b/creek-tools/creek/link/eddies.py
@@ -318,9 +318,11 @@ def _median_date(fragments: list[Fragment]) -> date:
     Returns:
         The median ``created`` date (lower-median for even counts).
     """
-    sorted_frags = sorted(fragments, key=lambda f: f.created)
+    # FEAT-031 (#263): median "formation" date uses authored precedence
+    # so an eddy formed of pre-2024 essays doesn't claim today's date.
+    sorted_frags = sorted(fragments, key=lambda f: f.effective_at)
     mid = len(sorted_frags) // 2
-    return sorted_frags[mid].created.date()
+    return sorted_frags[mid].effective_at.date()
 
 
 class EddyDetector:
@@ -554,7 +556,7 @@ class EddyDetector:
                 continue
             cluster_frags = sorted(
                 (frag_by_id[fid] for fid in members),
-                key=lambda f: f.created,
+                key=lambda f: f.effective_at,
             )
             if self._has_temporal_direction(cluster_frags):
                 continue

--- a/creek-tools/creek/link/temporal.py
+++ b/creek-tools/creek/link/temporal.py
@@ -156,12 +156,16 @@ class TemporalLinker:
         if len(fragments) < min_pair_size:
             return []
 
-        sorted_frags = sorted(fragments, key=lambda f: f.created)
+        # FEAT-031 (#263): sort and gap-score on ``effective_at`` so a
+        # multi-year corpus surfaces real cross-time threads. Pre-FEAT-031
+        # the linker bucketed by ``created`` which made historical
+        # exports look contemporaneous from each other's perspective.
+        sorted_frags = sorted(fragments, key=lambda f: f.effective_at)
         links: list[TemporalLink] = []
 
         for i, frag_a in enumerate(sorted_frags):
             for frag_b in sorted_frags[i + 1 :]:
-                delta = frag_b.created - frag_a.created
+                delta = frag_b.effective_at - frag_a.effective_at
                 delta_hours = delta.total_seconds() / 3600.0
 
                 if delta_hours > window_hours:

--- a/creek-tools/creek/link/threads.py
+++ b/creek-tools/creek/link/threads.py
@@ -382,7 +382,10 @@ class ThreadDetector:
             self._thread_members = {}
             return []
 
-        sorted_frags = sorted(fragments, key=lambda f: f.created)
+        # FEAT-031 (#263): every time-window comparison uses
+        # ``effective_at`` so threads emerge across multi-year corpora
+        # that were ingested in a single batch.
+        sorted_frags = sorted(fragments, key=lambda f: f.effective_at)
         frag_by_id = {f.id: f for f in sorted_frags}
         uf = self._cluster(sorted_frags)
         threads = self._materialise_threads(uf, frag_by_id, min_fragments)
@@ -395,7 +398,7 @@ class ThreadDetector:
         """Walk the sliding window, unioning topic-consistent pairs.
 
         Args:
-            sorted_frags: Fragments pre-sorted by ``created`` ascending.
+            sorted_frags: Fragments pre-sorted by ``effective_at`` ascending.
 
         Returns:
             A populated :class:`_UnionFind` covering every fragment ID.
@@ -416,7 +419,7 @@ class ThreadDetector:
         )
         for i, frag_a in outer:
             for frag_b in sorted_frags[i + 1 :]:
-                if frag_b.created - frag_a.created > window:
+                if frag_b.effective_at - frag_a.effective_at > window:
                     break
                 if self._topic_consistent(frag_a, frag_b):
                     uf.union(frag_a.id, frag_b.id)
@@ -446,7 +449,7 @@ class ThreadDetector:
                 continue
             cluster = sorted(
                 (frag_by_id[fid] for fid in member_ids),
-                key=lambda f: f.created,
+                key=lambda f: f.effective_at,
             )
             thread = self._build_thread(cluster)
             threads.append(thread)
@@ -507,8 +510,8 @@ class ThreadDetector:
         Returns:
             A populated :class:`~creek.models.Thread`.
         """
-        first_seen = min(f.created for f in frags).date()
-        last_seen = max(f.created for f in frags).date()
+        first_seen = min(f.effective_at for f in frags).date()
+        last_seen = max(f.effective_at for f in frags).date()
         return Thread(
             title=self._generate_title(frags),
             status=self._compute_status(last_seen),

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -506,6 +506,28 @@ class Fragment(BaseModel):
     level: FragmentLevel = "document"
     structural_path: list[str] = Field(default_factory=list)
 
+    @property
+    def effective_at(self) -> datetime:
+        """The fragment's authored date, or ``created`` as the fallback.
+
+        FEAT-031 (#263) precedence for *every* time-bucket surface:
+
+        1. :attr:`authored_at` — the source's own date (a Substack
+           post's publication, a Discord message's ``timestamp``, an
+           EXIF ``DateTimeOriginal``). Always preferred.
+        2. :attr:`created` — the filesystem-derived timestamp from
+           pre-FEAT-031 ingests, or the fallback for sources with no
+           extractable in-band date.
+
+        Downstream surfaces (state report, temporal linker, thread /
+        eddy windowing, synchronicity gap math) **must** use this
+        property instead of reaching for :attr:`created` directly so a
+        historical export does not silently count as current-week
+        activity. New surfaces inherit the same precedence by routing
+        through this property.
+        """
+        return self.authored_at if self.authored_at is not None else self.created
+
     # BUG-009: the ``[prop-decorator]`` suppression below is a known
     # mypy / Pydantic-v2 limitation when stacking ``@computed_field``
     # over ``@property`` — see

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
     "httpx>=0.27.0",
     "tqdm>=4.66.0",
     "mcp>=1.0.0,<2.0.0",
+    # defusedxml hardens stdlib XML parsing for the OOXML core-properties
+    # reader in creek.ingest._authored_at (B405/B314).
+    "defusedxml>=0.7",
     # Security: pin urllib3 above CVE-2026-44431 / CVE-2026-44432
     # (transitive via requests/conan). Both are fixed in 2.7.0.
     "urllib3>=2.7.0",
@@ -228,6 +231,10 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = ["openpyxl", "openpyxl.*", "pptx", "pptx.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = ["defusedxml", "defusedxml.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/creek-tools/tests/test_chatgpt_ingest.py
+++ b/creek-tools/tests/test_chatgpt_ingest.py
@@ -1284,3 +1284,53 @@ class TestCountDescendantsDeepTree:
 
         count = _count_descendants("node_0", mapping)
         assert count == depth
+
+
+# ---- authored_at extraction (FEAT-031) ----
+
+
+class TestChatGPTAuthoredAt:
+    """``ChatGPTIngestor`` carries per-turn ``authored_at`` from user ``create_time``.
+
+    FEAT-031 (#263): per-message ``create_time`` is the message-level
+    fragment's authored date; the conversation's ``create_time`` is the
+    fallback when the user message itself has no timestamp.
+    """
+
+    def test_authored_at_matches_user_message_create_time(self) -> None:
+        # 2024-11-15T18:00:00Z → 1731693600.0 (Unix epoch in UTC)
+        ingestor = ChatGPTIngestor()
+        conv = _minimal_conversation(create_time=1700042400.0)
+        # Override the user message's create_time to a known epoch.
+        conv["mapping"]["u1"]["message"]["create_time"] = 1731693600.0
+        raw = _make_raw_doc([conv])
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2024-11-15"
+        assert authored.tzinfo is not None
+
+    def test_authored_at_falls_back_to_conversation_create_time(self) -> None:
+        """User message lacks create_time → conversation create_time is used."""
+        ingestor = ChatGPTIngestor()
+        # 2023-05-04T12:00:00Z = 1683201600.0
+        conv = _minimal_conversation(create_time=1683201600.0)
+        # Strip the user message's create_time entirely.
+        conv["mapping"]["u1"]["message"].pop("create_time", None)
+        raw = _make_raw_doc([conv])
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2023-05-04"
+
+    def test_generate_frontmatter_emits_authored_at(self) -> None:
+        ingestor = ChatGPTIngestor()
+        conv = _minimal_conversation(create_time=1700042400.0)
+        conv["mapping"]["u1"]["message"]["create_time"] = 1731693600.0
+        raw = _make_raw_doc([conv])
+        fragments = ingestor.parse(raw)
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-11-15")

--- a/creek-tools/tests/test_discord_ingest.py
+++ b/creek-tools/tests/test_discord_ingest.py
@@ -1099,3 +1099,68 @@ class TestDiscordIngestorEdgeCases:
         ingestor = DiscordIngestor()
         fragments = ingestor.parse(raw)
         assert "Reactions:" not in fragments[0].content
+
+
+# ---- authored_at extraction (FEAT-031) ----
+
+
+class TestDiscordAuthoredAt:
+    """``DiscordIngestor`` extracts ``authored_at`` from message ``timestamp``.
+
+    FEAT-031 (#263): the first (earliest) message of a grouped fragment
+    carries the authored date. Discord timestamps are ISO 8601 with
+    timezone, so the value round-trips losslessly.
+    """
+
+    def test_authored_at_matches_first_message_timestamp(
+        self, tmp_path: Path
+    ) -> None:
+        ingestor = DiscordIngestor()
+        msgs = [
+            _make_msg(
+                msg_id="m1",
+                author="Alice",
+                content="Hello there how is it going",
+                timestamp="2024-11-15T10:30:00+00:00",
+            ),
+        ]
+        _create_channel_dir(tmp_path, messages=msgs)
+        result = ingestor.ingest(tmp_path)
+        assert len(result.fragments) == 1
+        authored = result.fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2024-11-15"
+        assert authored.tzinfo is not None
+
+    def test_authored_at_emitted_in_frontmatter(self, tmp_path: Path) -> None:
+        ingestor = DiscordIngestor()
+        msgs = [
+            _make_msg(
+                msg_id="m1",
+                content="Hello there how is it going",
+                timestamp="2024-11-15T10:30:00+00:00",
+            ),
+        ]
+        _create_channel_dir(tmp_path, messages=msgs)
+        result = ingestor.ingest(tmp_path)
+        fm = result.fragments[0].metadata["frontmatter"]
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-11-15")
+
+    def test_authored_at_none_when_message_lacks_timestamp(self) -> None:
+        """Honest absence: a message with no parseable timestamp → None."""
+        ingestor = DiscordIngestor()
+        msg = _make_msg(
+            msg_id="m1",
+            content="Hello there how is it going",
+            timestamp="",
+        )
+        raw = RawDocument(
+            path=Path("/fake/messages.json"),
+            content=json.dumps([msg]).encode("utf-8"),
+            metadata={"channel_name": "general", "channel_id": "1"},
+            detected_encoding="utf-8",
+        )
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 1
+        assert fragments[0].metadata.get("authored_at") is None

--- a/creek-tools/tests/test_discord_ingest.py
+++ b/creek-tools/tests/test_discord_ingest.py
@@ -1112,9 +1112,7 @@ class TestDiscordAuthoredAt:
     timezone, so the value round-trips losslessly.
     """
 
-    def test_authored_at_matches_first_message_timestamp(
-        self, tmp_path: Path
-    ) -> None:
+    def test_authored_at_matches_first_message_timestamp(self, tmp_path: Path) -> None:
         ingestor = DiscordIngestor()
         msgs = [
             _make_msg(

--- a/creek-tools/tests/test_images_ingestor.py
+++ b/creek-tools/tests/test_images_ingestor.py
@@ -732,3 +732,87 @@ class TestOcrMinConfidence:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# ---- authored_at extraction (FEAT-031) ----
+
+
+class TestImageAuthoredAt:
+    """``ImageIngestor`` extracts ``authored_at`` from EXIF date tags.
+
+    FEAT-031 (#263): the fallback chain is EXIF ``DateTimeOriginal``
+    (36867) → EXIF ``DateTime`` (306) → filesystem mtime. Naive EXIF
+    timestamps are anchored to UTC per the issue's never-naive rule.
+    """
+
+    def _write_jpeg_with_exif(
+        self,
+        path: "Path",
+        *,
+        date_time_original: str | None = None,
+        date_time: str | None = None,
+    ) -> None:
+        """Write a JPEG with the given EXIF date tags set."""
+        from PIL import Image
+
+        img = Image.new("RGB", (4, 4), color="white")
+        exif = img.getexif()
+        if date_time is not None:
+            exif[306] = date_time  # ``DateTime``
+        if date_time_original is not None:
+            exif[36867] = date_time_original  # ``DateTimeOriginal``
+        img.save(path, "jpeg", exif=exif)
+
+    def test_date_time_original_takes_priority(self, tmp_path: "Path") -> None:
+        path = tmp_path / "photo.jpg"
+        self._write_jpeg_with_exif(
+            path,
+            date_time_original="2024:03:15 10:30:00",
+            date_time="2023:01:01 00:00:00",
+        )
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2024-03-15"
+        assert authored.tzinfo is not None
+
+    def test_date_time_used_when_no_date_time_original(self, tmp_path: "Path") -> None:
+        path = tmp_path / "photo.jpg"
+        self._write_jpeg_with_exif(path, date_time="2023:08:09 12:00:00")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2023-08-09"
+
+    def test_falls_back_to_mtime_when_no_exif(self, tmp_path: "Path") -> None:
+        from PIL import Image
+        import os
+
+        path = tmp_path / "photo.png"
+        Image.new("RGB", (4, 4), color="white").save(path, "png")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored == expected
+
+    def test_authored_at_emitted_in_frontmatter(self, tmp_path: "Path") -> None:
+        path = tmp_path / "photo.jpg"
+        self._write_jpeg_with_exif(
+            path,
+            date_time_original="2024:03:15 10:30:00",
+        )
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-03-15")

--- a/creek-tools/tests/test_images_ingestor.py
+++ b/creek-tools/tests/test_images_ingestor.py
@@ -747,7 +747,7 @@ class TestImageAuthoredAt:
 
     def _write_jpeg_with_exif(
         self,
-        path: "Path",
+        path: Path,
         *,
         date_time_original: str | None = None,
         date_time: str | None = None,
@@ -763,7 +763,7 @@ class TestImageAuthoredAt:
             exif[36867] = date_time_original  # ``DateTimeOriginal``
         img.save(path, "jpeg", exif=exif)
 
-    def test_date_time_original_takes_priority(self, tmp_path: "Path") -> None:
+    def test_date_time_original_takes_priority(self, tmp_path: Path) -> None:
         path = tmp_path / "photo.jpg"
         self._write_jpeg_with_exif(
             path,
@@ -779,7 +779,7 @@ class TestImageAuthoredAt:
         assert authored.date().isoformat() == "2024-03-15"
         assert authored.tzinfo is not None
 
-    def test_date_time_used_when_no_date_time_original(self, tmp_path: "Path") -> None:
+    def test_date_time_used_when_no_date_time_original(self, tmp_path: Path) -> None:
         path = tmp_path / "photo.jpg"
         self._write_jpeg_with_exif(path, date_time="2023:08:09 12:00:00")
         ingestor = ImageIngestor(engine=StubOcrEngine())
@@ -789,9 +789,10 @@ class TestImageAuthoredAt:
         assert authored is not None
         assert authored.date().isoformat() == "2023-08-09"
 
-    def test_falls_back_to_mtime_when_no_exif(self, tmp_path: "Path") -> None:
-        from PIL import Image
+    def test_falls_back_to_mtime_when_no_exif(self, tmp_path: Path) -> None:
         import os
+
+        from PIL import Image
 
         path = tmp_path / "photo.png"
         Image.new("RGB", (4, 4), color="white").save(path, "png")
@@ -804,7 +805,7 @@ class TestImageAuthoredAt:
         authored = fragments[0].metadata["authored_at"]
         assert authored == expected
 
-    def test_authored_at_emitted_in_frontmatter(self, tmp_path: "Path") -> None:
+    def test_authored_at_emitted_in_frontmatter(self, tmp_path: Path) -> None:
         path = tmp_path / "photo.jpg"
         self._write_jpeg_with_exif(
             path,

--- a/creek-tools/tests/test_ingest_claude.py
+++ b/creek-tools/tests/test_ingest_claude.py
@@ -1003,3 +1003,71 @@ class TestEdgeCases:
         assert "Describe this image" in fragments[0].content
         # Non-text parts should be excluded
         assert "http://example.com" not in fragments[0].content
+
+
+# ---- authored_at extraction (FEAT-031) ----
+
+
+class TestClaudeIngestorAuthoredAt:
+    """``ClaudeIngestor`` carries per-turn ``authored_at`` from human ``created_at``.
+
+    FEAT-031 (#263): per-message ``create_time`` is the message-level
+    fragment's authored date; the conversation's ``created_at`` is the
+    fallback only when the message itself has no timestamp.
+    """
+
+    def test_authored_at_matches_human_message_created_at(
+        self, ingestor: ClaudeIngestor
+    ) -> None:
+        conv = _make_single_conversation(
+            uuid="conv-A",
+            created_at="2024-01-01T00:00:00Z",
+            messages=[
+                {
+                    "role": "human",
+                    "content": "Hi",
+                    "created_at": "2024-11-15T10:30:00Z",
+                },
+                {
+                    "role": "assistant",
+                    "content": "Hello",
+                    "created_at": "2024-11-15T10:30:05Z",
+                },
+            ],
+        )
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2024-11-15"
+        assert authored.tzinfo is not None
+
+    def test_authored_at_falls_back_to_conversation_created_at(
+        self, ingestor: ClaudeIngestor
+    ) -> None:
+        """Per-message create_time absent → use conversation created_at."""
+        conv = _make_single_conversation(
+            uuid="conv-B",
+            created_at="2023-05-04T12:00:00Z",
+            messages=[
+                {"role": "human", "content": "Hi"},
+                {"role": "assistant", "content": "Hello"},
+            ],
+        )
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2023-05-04"
+
+    def test_generate_frontmatter_emits_authored_at(
+        self, ingestor: ClaudeIngestor
+    ) -> None:
+        conv = _make_single_conversation()
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-11-15")

--- a/creek-tools/tests/test_ingest_code.py
+++ b/creek-tools/tests/test_ingest_code.py
@@ -958,3 +958,88 @@ class TestCodeIngestorRegistry:
         from creek.ingest import INGESTOR_REGISTRY
 
         assert INGESTOR_REGISTRY["code"] is CodeIngestor
+
+
+# ---- authored_at extraction (FEAT-031) ----
+
+
+class TestCodeAuthoredAt:
+    """``CodeIngestor`` extracts ``authored_at`` from git first-commit date.
+
+    FEAT-031 (#263): the fallback chain is
+    ``git log --diff-filter=A --follow --format=%aI -- <file>`` when
+    the file lives inside a git repo, then filesystem mtime.
+    """
+
+    def test_authored_at_uses_first_commit_author_date(
+        self, tmp_path: Path
+    ) -> None:
+        """When a real git repo backs the file, the first-commit ``%aI`` wins."""
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)  # noqa: S607,S603
+        subprocess.run(  # noqa: S607,S603
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo,
+            check=True,
+        )
+        subprocess.run(  # noqa: S607,S603
+            ["git", "config", "user.name", "Test"],
+            cwd=repo,
+            check=True,
+        )
+        readme = repo / "README.md"
+        readme.write_text("# Hi\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)  # noqa: S607,S603
+        env = {
+            "GIT_AUTHOR_DATE": "2024-03-15T12:00:00+00:00",
+            "GIT_COMMITTER_DATE": "2024-03-15T12:00:00+00:00",
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+            "PATH": __import__("os").environ.get("PATH", ""),
+        }
+        subprocess.run(  # noqa: S607,S603
+            ["git", "commit", "-q", "-m", "init"],
+            cwd=repo,
+            env=env,
+            check=True,
+        )
+
+        ingestor = CodeIngestor()
+        docs = ingestor.discover(readme)
+        fragments = ingestor.parse(docs[0])
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2024-03-15"
+        assert authored.tzinfo is not None
+
+    def test_authored_at_falls_back_to_mtime_when_not_in_git(
+        self, tmp_path: Path
+    ) -> None:
+        """Files outside a git repo fall back to filesystem mtime."""
+        from datetime import UTC
+        import os
+
+        path = tmp_path / "README.md"
+        path.write_text("# Hi\n", encoding="utf-8")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+
+        ingestor = CodeIngestor()
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored == expected
+
+    def test_authored_at_emitted_in_frontmatter(self, tmp_path: Path) -> None:
+        path = tmp_path / "README.md"
+        path.write_text("# Hi\n", encoding="utf-8")
+
+        ingestor = CodeIngestor()
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm

--- a/creek-tools/tests/test_ingest_code.py
+++ b/creek-tools/tests/test_ingest_code.py
@@ -971,26 +971,24 @@ class TestCodeAuthoredAt:
     the file lives inside a git repo, then filesystem mtime.
     """
 
-    def test_authored_at_uses_first_commit_author_date(
-        self, tmp_path: Path
-    ) -> None:
+    def test_authored_at_uses_first_commit_author_date(self, tmp_path: Path) -> None:
         """When a real git repo backs the file, the first-commit ``%aI`` wins."""
         repo = tmp_path / "repo"
         repo.mkdir()
-        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)  # noqa: S607,S603
-        subprocess.run(  # noqa: S607,S603
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        subprocess.run(
             ["git", "config", "user.email", "test@example.com"],
             cwd=repo,
             check=True,
         )
-        subprocess.run(  # noqa: S607,S603
+        subprocess.run(
             ["git", "config", "user.name", "Test"],
             cwd=repo,
             check=True,
         )
         readme = repo / "README.md"
         readme.write_text("# Hi\n", encoding="utf-8")
-        subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)  # noqa: S607,S603
+        subprocess.run(["git", "add", "README.md"], cwd=repo, check=True)
         env = {
             "GIT_AUTHOR_DATE": "2024-03-15T12:00:00+00:00",
             "GIT_COMMITTER_DATE": "2024-03-15T12:00:00+00:00",
@@ -1000,7 +998,7 @@ class TestCodeAuthoredAt:
             "GIT_COMMITTER_EMAIL": "test@example.com",
             "PATH": __import__("os").environ.get("PATH", ""),
         }
-        subprocess.run(  # noqa: S607,S603
+        subprocess.run(
             ["git", "commit", "-q", "-m", "init"],
             cwd=repo,
             env=env,
@@ -1020,8 +1018,8 @@ class TestCodeAuthoredAt:
         self, tmp_path: Path
     ) -> None:
         """Files outside a git repo fall back to filesystem mtime."""
-        from datetime import UTC
         import os
+        from datetime import UTC
 
         path = tmp_path / "README.md"
         path.write_text("# Hi\n", encoding="utf-8")

--- a/creek-tools/tests/test_ingest_documents.py
+++ b/creek-tools/tests/test_ingest_documents.py
@@ -739,3 +739,117 @@ class TestDocumentIngestorIngest:
         for entry in result.provenance:
             assert entry.ingestor_name == "DocumentIngestor"
             assert entry.status == "success"
+
+
+# ---- authored_at extraction (FEAT-031) ----
+
+
+class TestDocumentAuthoredAt:
+    """``DocumentIngestor`` extraction chains per file type.
+
+    FEAT-031 (#263):
+    - HTML/HTM: meta tags + JSON-LD ``datePublished`` → mtime.
+    - PDF: ``/CreationDate`` → ``/ModDate`` → mtime.
+    - DOCX: core ``dcterms:created`` → ``dcterms:modified`` → mtime.
+    - RTF: ``\\creatim`` → ``\\revtim`` → mtime.
+    - TXT: mtime only (lowest-fidelity tier).
+    """
+
+    def test_html_meta_published_time_wins(
+        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+    ) -> None:
+        path = tmp_path / "post.html"
+        path.write_text(
+            '<html><head>'
+            '<meta property="article:published_time" '
+            'content="2024-03-15T08:00:00Z">'
+            '</head><body><p>Hi</p></body></html>',
+            encoding="utf-8",
+        )
+        docs = doc_ingestor.discover(path)
+        fragments = doc_ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2024-03-15"
+
+    def test_html_json_ld_date_published_used(
+        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+    ) -> None:
+        path = tmp_path / "post.html"
+        path.write_text(
+            '<html><head>'
+            '<script type="application/ld+json">'
+            '{"@type": "Article", "datePublished": "2023-06-09T12:00:00Z"}'
+            '</script></head><body><p>Hi</p></body></html>',
+            encoding="utf-8",
+        )
+        docs = doc_ingestor.discover(path)
+        fragments = doc_ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2023-06-09"
+
+    def test_html_falls_back_to_mtime(
+        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+    ) -> None:
+        from datetime import UTC
+        import os
+
+        path = tmp_path / "post.html"
+        path.write_text("<html><body><p>Hi</p></body></html>", encoding="utf-8")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+        docs = doc_ingestor.discover(path)
+        fragments = doc_ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored == expected
+
+    def test_txt_falls_back_to_mtime_only(
+        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+    ) -> None:
+        from datetime import UTC
+        import os
+
+        path = tmp_path / "note.txt"
+        path.write_text("Meeting notes\n", encoding="utf-8")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+        docs = doc_ingestor.discover(path)
+        fragments = doc_ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored == expected
+
+    def test_rtf_creatim_used(
+        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+    ) -> None:
+        path = tmp_path / "doc.rtf"
+        path.write_text(
+            r"{\rtf1\ansi"
+            r"{\info"
+            r"{\creatim\yr2024\mo3\dy15\hr10\min30}"
+            r"{\revtim\yr2024\mo4\dy1\hr0\min0}"
+            r"}Hello}",
+            encoding="utf-8",
+        )
+        docs = doc_ingestor.discover(path)
+        fragments = doc_ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2024-03-15"
+
+    def test_authored_at_emitted_in_frontmatter(
+        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+    ) -> None:
+        path = tmp_path / "post.html"
+        path.write_text(
+            '<html><head>'
+            '<meta property="article:published_time" '
+            'content="2024-03-15T08:00:00Z">'
+            '</head><body><p>Hi</p></body></html>',
+            encoding="utf-8",
+        )
+        docs = doc_ingestor.discover(path)
+        fragments = doc_ingestor.parse(docs[0])
+        fm = doc_ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-03-15")

--- a/creek-tools/tests/test_ingest_documents.py
+++ b/creek-tools/tests/test_ingest_documents.py
@@ -756,14 +756,14 @@ class TestDocumentAuthoredAt:
     """
 
     def test_html_meta_published_time_wins(
-        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
     ) -> None:
         path = tmp_path / "post.html"
         path.write_text(
-            '<html><head>'
+            "<html><head>"
             '<meta property="article:published_time" '
             'content="2024-03-15T08:00:00Z">'
-            '</head><body><p>Hi</p></body></html>',
+            "</head><body><p>Hi</p></body></html>",
             encoding="utf-8",
         )
         docs = doc_ingestor.discover(path)
@@ -773,14 +773,14 @@ class TestDocumentAuthoredAt:
         assert authored.date().isoformat() == "2024-03-15"
 
     def test_html_json_ld_date_published_used(
-        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
     ) -> None:
         path = tmp_path / "post.html"
         path.write_text(
-            '<html><head>'
+            "<html><head>"
             '<script type="application/ld+json">'
             '{"@type": "Article", "datePublished": "2023-06-09T12:00:00Z"}'
-            '</script></head><body><p>Hi</p></body></html>',
+            "</script></head><body><p>Hi</p></body></html>",
             encoding="utf-8",
         )
         docs = doc_ingestor.discover(path)
@@ -790,10 +790,10 @@ class TestDocumentAuthoredAt:
         assert authored.date().isoformat() == "2023-06-09"
 
     def test_html_falls_back_to_mtime(
-        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
     ) -> None:
-        from datetime import UTC
         import os
+        from datetime import UTC
 
         path = tmp_path / "post.html"
         path.write_text("<html><body><p>Hi</p></body></html>", encoding="utf-8")
@@ -805,10 +805,10 @@ class TestDocumentAuthoredAt:
         assert authored == expected
 
     def test_txt_falls_back_to_mtime_only(
-        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
     ) -> None:
-        from datetime import UTC
         import os
+        from datetime import UTC
 
         path = tmp_path / "note.txt"
         path.write_text("Meeting notes\n", encoding="utf-8")
@@ -820,7 +820,7 @@ class TestDocumentAuthoredAt:
         assert authored == expected
 
     def test_rtf_creatim_used(
-        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
     ) -> None:
         path = tmp_path / "doc.rtf"
         path.write_text(
@@ -838,14 +838,14 @@ class TestDocumentAuthoredAt:
         assert authored.date().isoformat() == "2024-03-15"
 
     def test_authored_at_emitted_in_frontmatter(
-        self, doc_ingestor: DocumentIngestor, tmp_path: "Path"
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
     ) -> None:
         path = tmp_path / "post.html"
         path.write_text(
-            '<html><head>'
+            "<html><head>"
             '<meta property="article:published_time" '
             'content="2024-03-15T08:00:00Z">'
-            '</head><body><p>Hi</p></body></html>',
+            "</head><body><p>Hi</p></body></html>",
             encoding="utf-8",
         )
         docs = doc_ingestor.discover(path)

--- a/creek-tools/tests/test_ingest_generic.py
+++ b/creek-tools/tests/test_ingest_generic.py
@@ -453,3 +453,77 @@ class TestGenericIngestorIngest:
         )
         markdown = ingestor.convert_to_markdown(fragment)
         assert markdown.startswith("```\n")
+
+
+# ---- authored_at extraction (FEAT-031) ----
+
+
+class TestGenericIngestorAuthoredAt:
+    """``GenericIngestor`` authored_at falls back to filesystem mtime.
+
+    FEAT-031 (#263): the generic ingestor is the lowest-fidelity tier —
+    no in-band source date is available, so the file's mtime is the
+    only honest answer. ``authored_at`` is timezone-aware (UTC) and
+    flows through both the parsed metadata and the emitted frontmatter.
+    """
+
+    def test_parse_sets_authored_at_to_file_mtime(
+        self,
+        ingestor: GenericIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """``parse()`` stashes the file's mtime as authored_at on metadata."""
+        from datetime import UTC
+
+        path = tmp_path / "note.rst"
+        path.write_text("content", encoding="utf-8")
+        # Stamp a known mtime so the assertion does not depend on
+        # the wall-clock of the test machine.
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        import os
+
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+
+        raw = RawDocument(
+            path=path,
+            content=path.read_bytes(),
+            metadata={"source_type": "generic"},
+            detected_encoding="utf-8",
+        )
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored == expected
+        assert authored.tzinfo is not None
+
+    def test_generate_frontmatter_emits_authored_at(
+        self,
+        ingestor: GenericIngestor,
+    ) -> None:
+        """authored_at on metadata round-trips into the frontmatter dict."""
+        from datetime import UTC
+
+        ts = datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ)
+        authored = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
+        fragment = ParsedFragment(
+            content="content",
+            metadata={"file_extension": ".txt", "authored_at": authored},
+            source_path="/fake/note.txt",
+            timestamp=ts,
+        )
+        fm = ingestor.generate_frontmatter(fragment)
+        assert fm["authored_at"] == authored.isoformat()
+
+    def test_generate_frontmatter_omits_authored_at_when_none(
+        self,
+        ingestor: GenericIngestor,
+    ) -> None:
+        """A ``None`` authored_at is omitted (never guessed) from frontmatter."""
+        fragment = ParsedFragment(
+            content="content",
+            metadata={"file_extension": ".txt", "authored_at": None},
+            source_path="/fake/note.txt",
+            timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ),
+        )
+        fm = ingestor.generate_frontmatter(fragment)
+        assert "authored_at" not in fm

--- a/creek-tools/tests/test_ingest_markdown.py
+++ b/creek-tools/tests/test_ingest_markdown.py
@@ -853,8 +853,8 @@ class TestMarkdownIngestorAuthoredAt:
         self, md_ingestor: MarkdownIngestor, tmp_path: Path
     ) -> None:
         """When no frontmatter date is present, filesystem mtime is used."""
-        from datetime import UTC
         import os
+        from datetime import UTC
 
         path = tmp_path / "post.md"
         path.write_text("# Hi\n", encoding="utf-8")
@@ -899,8 +899,8 @@ class TestMarkdownIngestorAuthoredAt:
         self, md_ingestor: MarkdownIngestor, tmp_path: Path
     ) -> None:
         """Garbage frontmatter date does not crash; mtime is used."""
-        from datetime import UTC
         import os
+        from datetime import UTC
 
         path = tmp_path / "post.md"
         path.write_text(

--- a/creek-tools/tests/test_ingest_markdown.py
+++ b/creek-tools/tests/test_ingest_markdown.py
@@ -787,3 +787,130 @@ class TestMarkdownIngestorEdgeCases:
         # Should still get a valid timestamp (from filesystem)
         assert isinstance(fragments[0].timestamp, datetime)
         assert fragments[0].timestamp.tzinfo is not None
+
+
+# ---- authored_at extraction (FEAT-031) ----
+
+
+class TestMarkdownIngestorAuthoredAt:
+    """``MarkdownIngestor`` extracts ``authored_at`` from frontmatter dates.
+
+    FEAT-031 (#263): the fallback chain is
+    ``published`` → ``date`` → ``created``, then filesystem mtime.
+    """
+
+    def test_published_key_takes_priority(
+        self, md_ingestor: MarkdownIngestor, tmp_path: Path
+    ) -> None:
+        """``published`` wins over ``date`` and ``created``."""
+        path = tmp_path / "post.md"
+        path.write_text(
+            "---\n"
+            "published: 2024-03-15\n"
+            "date: 2023-01-01\n"
+            "created: 2022-06-01\n"
+            "---\n"
+            "# Hi\n",
+            encoding="utf-8",
+        )
+        docs = md_ingestor.discover(tmp_path)
+        fragments = md_ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2024-03-15"
+
+    def test_date_used_when_no_published(
+        self, md_ingestor: MarkdownIngestor, tmp_path: Path
+    ) -> None:
+        """``date`` is used when ``published`` is absent."""
+        path = tmp_path / "post.md"
+        path.write_text(
+            "---\ndate: 2023-08-09\ncreated: 2022-06-01\n---\n# Hi\n",
+            encoding="utf-8",
+        )
+        docs = md_ingestor.discover(tmp_path)
+        fragments = md_ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2023-08-09"
+
+    def test_created_used_when_no_date_or_published(
+        self, md_ingestor: MarkdownIngestor, tmp_path: Path
+    ) -> None:
+        """``created`` is used when neither ``published`` nor ``date`` exists."""
+        path = tmp_path / "post.md"
+        path.write_text(
+            "---\ncreated: 2022-06-01\n---\n# Hi\n",
+            encoding="utf-8",
+        )
+        docs = md_ingestor.discover(tmp_path)
+        fragments = md_ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2022-06-01"
+
+    def test_falls_back_to_mtime_when_no_frontmatter_date(
+        self, md_ingestor: MarkdownIngestor, tmp_path: Path
+    ) -> None:
+        """When no frontmatter date is present, filesystem mtime is used."""
+        from datetime import UTC
+        import os
+
+        path = tmp_path / "post.md"
+        path.write_text("# Hi\n", encoding="utf-8")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+
+        docs = md_ingestor.discover(tmp_path)
+        fragments = md_ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored == expected
+
+    def test_authored_at_emitted_in_frontmatter(
+        self, md_ingestor: MarkdownIngestor, tmp_path: Path
+    ) -> None:
+        """``authored_at`` round-trips into the generated frontmatter."""
+        path = tmp_path / "post.md"
+        path.write_text(
+            "---\npublished: 2024-03-15\n---\n# Hi\n",
+            encoding="utf-8",
+        )
+        docs = md_ingestor.discover(tmp_path)
+        fragments = md_ingestor.parse(docs[0])
+        fm = md_ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-03-15")
+
+    def test_authored_at_is_timezone_aware(
+        self, md_ingestor: MarkdownIngestor, tmp_path: Path
+    ) -> None:
+        """Extracted ``authored_at`` is never naive."""
+        path = tmp_path / "post.md"
+        path.write_text(
+            "---\npublished: 2024-03-15\n---\n# Hi\n",
+            encoding="utf-8",
+        )
+        docs = md_ingestor.discover(tmp_path)
+        fragments = md_ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored.tzinfo is not None
+
+    def test_unparseable_frontmatter_date_falls_back_to_mtime(
+        self, md_ingestor: MarkdownIngestor, tmp_path: Path
+    ) -> None:
+        """Garbage frontmatter date does not crash; mtime is used."""
+        from datetime import UTC
+        import os
+
+        path = tmp_path / "post.md"
+        path.write_text(
+            "---\npublished: definitely-not-a-date\n---\n# Hi\n",
+            encoding="utf-8",
+        )
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+
+        docs = md_ingestor.discover(tmp_path)
+        fragments = md_ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored == expected

--- a/creek-tools/tests/test_ingest_refresh.py
+++ b/creek-tools/tests/test_ingest_refresh.py
@@ -1,0 +1,297 @@
+"""Tests for ``creek ingest --refresh-dates`` (FEAT-031 / #263).
+
+Covers the one-shot ``authored_at`` backfill engine: per-platform
+extraction routing, idempotency, frontmatter rewrite preserving body
+content and non-Fragment keys, and the CLI summary line.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+import frontmatter
+import pytest
+
+from creek.ingest.refresh import (
+    RefreshOutcome,
+    RefreshSummary,
+    extract_authored_at_for_fragment,
+    refresh_vault_authored_at,
+)
+from creek.models import (
+    Fragment,
+    FragmentSource,
+    SourcePlatform,
+)
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    """Build a vault skeleton with the required scaffold dirs."""
+    (tmp_path / "00-Creek-Meta").mkdir()
+    (tmp_path / "01-Fragments").mkdir()
+    return tmp_path
+
+
+def _write_fragment(
+    vault_path: Path,
+    *,
+    fragment_id: str,
+    source_path: Path | None,
+    platform: SourcePlatform,
+    authored_at: datetime | None,
+    extra_metadata: dict[str, object] | None = None,
+    body: str = "Body content unchanged across the refresh.\n",
+) -> Path:
+    """Write a Fragment markdown file under ``01-Fragments/Generic/``."""
+    target_dir = vault_path / "01-Fragments" / "Generic"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / f"{fragment_id}.md"
+    fragment = Fragment(
+        id=fragment_id,
+        title="Test Fragment",
+        source=FragmentSource(
+            platform=platform,
+            original_file=str(source_path) if source_path is not None else None,
+        ),
+        authored_at=authored_at,
+    )
+    fm_data = fragment.model_dump(mode="json")
+    if extra_metadata:
+        fm_data.update(extra_metadata)
+    post = frontmatter.Post(content=body, **fm_data)
+    target_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target_path
+
+
+# ---- Engine tests ----
+
+
+class TestRefreshVault:
+    """End-to-end refresh against synthetic vault contents."""
+
+    def test_html_source_authored_at_is_backfilled(self, vault: Path) -> None:
+        html_source = vault / "post.html"
+        html_source.write_text(
+            '<html><head>'
+            '<meta property="article:published_time" '
+            'content="2024-03-15T08:00:00Z">'
+            '</head><body>Hi</body></html>',
+            encoding="utf-8",
+        )
+        frag_path = _write_fragment(
+            vault,
+            fragment_id="frag-abc",
+            source_path=html_source,
+            platform=SourcePlatform.DOCUMENT,
+            authored_at=None,
+        )
+        summary = refresh_vault_authored_at(vault)
+        assert summary.updated == 1
+        post = frontmatter.load(str(frag_path))
+        assert str(post["authored_at"]).startswith("2024-03-15")
+
+    def test_idempotent_second_run(self, vault: Path) -> None:
+        """A second pass against an unchanged source rewrites nothing."""
+        html_source = vault / "post.html"
+        html_source.write_text(
+            '<html><head>'
+            '<meta property="article:published_time" '
+            'content="2024-03-15T08:00:00Z">'
+            '</head><body>Hi</body></html>',
+            encoding="utf-8",
+        )
+        _write_fragment(
+            vault,
+            fragment_id="frag-abc",
+            source_path=html_source,
+            platform=SourcePlatform.DOCUMENT,
+            authored_at=None,
+        )
+        first = refresh_vault_authored_at(vault)
+        assert first.updated == 1
+        second = refresh_vault_authored_at(vault)
+        assert second.updated == 0
+        assert second.unchanged == 1
+
+    def test_body_preserved_byte_for_byte(self, vault: Path) -> None:
+        """Refresh does not perturb the markdown body of the fragment."""
+        html_source = vault / "post.html"
+        html_source.write_text(
+            '<html><head>'
+            '<meta property="article:published_time" '
+            'content="2024-03-15T08:00:00Z">'
+            '</head><body>Hi</body></html>',
+            encoding="utf-8",
+        )
+        original_body = "## Heading\n\nA paragraph with *emphasis* and a [link](x).\n"
+        frag_path = _write_fragment(
+            vault,
+            fragment_id="frag-body",
+            source_path=html_source,
+            platform=SourcePlatform.DOCUMENT,
+            authored_at=None,
+            body=original_body,
+        )
+        refresh_vault_authored_at(vault)
+        post = frontmatter.load(str(frag_path))
+        assert post.content == original_body.rstrip("\n")
+
+    def test_non_fragment_extra_keys_preserved(self, vault: Path) -> None:
+        """Custom frontmatter keys survive the rewrite untouched."""
+        html_source = vault / "post.html"
+        html_source.write_text(
+            '<html><head>'
+            '<meta property="article:published_time" '
+            'content="2024-03-15T08:00:00Z">'
+            '</head><body>Hi</body></html>',
+            encoding="utf-8",
+        )
+        frag_path = _write_fragment(
+            vault,
+            fragment_id="frag-keys",
+            source_path=html_source,
+            platform=SourcePlatform.DOCUMENT,
+            authored_at=None,
+            extra_metadata={
+                "obsidian_aliases": ["my-post"],
+                "custom_scratch": {"reviewer": "geoff"},
+            },
+        )
+        refresh_vault_authored_at(vault)
+        post = frontmatter.load(str(frag_path))
+        assert post["obsidian_aliases"] == ["my-post"]
+        assert post["custom_scratch"] == {"reviewer": "geoff"}
+
+    def test_missing_source_marked_no_source(self, vault: Path) -> None:
+        """A fragment whose source file vanished is flagged, not updated."""
+        _write_fragment(
+            vault,
+            fragment_id="frag-ghost",
+            source_path=vault / "gone.html",
+            platform=SourcePlatform.DOCUMENT,
+            authored_at=None,
+        )
+        summary = refresh_vault_authored_at(vault)
+        assert summary.updated == 0
+
+    def test_txt_source_uses_mtime(self, vault: Path) -> None:
+        path = vault / "note.txt"
+        path.write_text("Meeting notes\n", encoding="utf-8")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+        frag_path = _write_fragment(
+            vault,
+            fragment_id="frag-txt",
+            source_path=path,
+            platform=SourcePlatform.DOCUMENT,
+            authored_at=None,
+        )
+        refresh_vault_authored_at(vault)
+        post = frontmatter.load(str(frag_path))
+        assert str(post["authored_at"]).startswith("2024-05-01")
+
+    def test_summary_aggregate_counters(self, vault: Path) -> None:
+        """Counters tally updated / unchanged / missing buckets correctly."""
+        path = vault / "note.txt"
+        path.write_text("Hello\n", encoding="utf-8")
+        _write_fragment(
+            vault,
+            fragment_id="frag-1",
+            source_path=path,
+            platform=SourcePlatform.DOCUMENT,
+            authored_at=None,
+        )
+        _write_fragment(
+            vault,
+            fragment_id="frag-2",
+            source_path=vault / "missing.txt",
+            platform=SourcePlatform.DOCUMENT,
+            authored_at=None,
+        )
+        summary = refresh_vault_authored_at(vault)
+        assert summary.total == 2
+        assert isinstance(summary, RefreshSummary)
+        assert all(isinstance(o, RefreshOutcome) for o in summary.outcomes)
+
+
+# ---- Per-platform routing tests ----
+
+
+class TestExtractorRouting:
+    """Routing from :class:`SourcePlatform` to per-format extractor."""
+
+    def test_markdown_platform_uses_frontmatter_dates(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        md_source = tmp_path / "post.md"
+        md_source.write_text(
+            "---\npublished: 2024-03-15\n---\n# Hi\n",
+            encoding="utf-8",
+        )
+        fragment = Fragment(
+            id="frag-md",
+            title="Test",
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                original_file=str(md_source),
+            ),
+        )
+        result = extract_authored_at_for_fragment(fragment)
+        assert result is not None
+        assert result.date().isoformat() == "2024-03-15"
+
+    def test_unknown_source_path_returns_none(self) -> None:
+        fragment = Fragment(
+            id="frag-empty",
+            title="Test",
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                original_file=None,
+            ),
+        )
+        assert extract_authored_at_for_fragment(fragment) is None
+
+
+# ---- CLI integration ----
+
+
+class TestRefreshDatesCli:
+    """Integration check for ``creek ingest --refresh-dates``."""
+
+    def test_cli_runs_end_to_end(self, vault: Path) -> None:
+        """The CLI command rewrites the fragment when invoked via Typer."""
+        from typer.testing import CliRunner
+
+        from creek.cli import app
+
+        html_source = vault / "post.html"
+        html_source.write_text(
+            '<html><head>'
+            '<meta property="article:published_time" '
+            'content="2024-03-15T08:00:00Z">'
+            '</head><body>Hi</body></html>',
+            encoding="utf-8",
+        )
+        frag_path = _write_fragment(
+            vault,
+            fragment_id="frag-cli",
+            source_path=html_source,
+            platform=SourcePlatform.DOCUMENT,
+            authored_at=None,
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["ingest", "--refresh-dates", "--vault", str(vault)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Refreshed authored_at on 1" in result.output
+        post = frontmatter.load(str(frag_path))
+        assert str(post["authored_at"]).startswith("2024-03-15")

--- a/creek-tools/tests/test_ingest_refresh.py
+++ b/creek-tools/tests/test_ingest_refresh.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path  # noqa: TC003 — runtime use by pytest fixtures
 
 import frontmatter
 import pytest
@@ -25,7 +25,6 @@ from creek.models import (
     FragmentSource,
     SourcePlatform,
 )
-
 
 # ---- Fixtures ----
 
@@ -78,10 +77,10 @@ class TestRefreshVault:
     def test_html_source_authored_at_is_backfilled(self, vault: Path) -> None:
         html_source = vault / "post.html"
         html_source.write_text(
-            '<html><head>'
+            "<html><head>"
             '<meta property="article:published_time" '
             'content="2024-03-15T08:00:00Z">'
-            '</head><body>Hi</body></html>',
+            "</head><body>Hi</body></html>",
             encoding="utf-8",
         )
         frag_path = _write_fragment(
@@ -100,10 +99,10 @@ class TestRefreshVault:
         """A second pass against an unchanged source rewrites nothing."""
         html_source = vault / "post.html"
         html_source.write_text(
-            '<html><head>'
+            "<html><head>"
             '<meta property="article:published_time" '
             'content="2024-03-15T08:00:00Z">'
-            '</head><body>Hi</body></html>',
+            "</head><body>Hi</body></html>",
             encoding="utf-8",
         )
         _write_fragment(
@@ -123,10 +122,10 @@ class TestRefreshVault:
         """Refresh does not perturb the markdown body of the fragment."""
         html_source = vault / "post.html"
         html_source.write_text(
-            '<html><head>'
+            "<html><head>"
             '<meta property="article:published_time" '
             'content="2024-03-15T08:00:00Z">'
-            '</head><body>Hi</body></html>',
+            "</head><body>Hi</body></html>",
             encoding="utf-8",
         )
         original_body = "## Heading\n\nA paragraph with *emphasis* and a [link](x).\n"
@@ -146,10 +145,10 @@ class TestRefreshVault:
         """Custom frontmatter keys survive the rewrite untouched."""
         html_source = vault / "post.html"
         html_source.write_text(
-            '<html><head>'
+            "<html><head>"
             '<meta property="article:published_time" '
             'content="2024-03-15T08:00:00Z">'
-            '</head><body>Hi</body></html>',
+            "</head><body>Hi</body></html>",
             encoding="utf-8",
         )
         frag_path = _write_fragment(
@@ -258,6 +257,99 @@ class TestExtractorRouting:
         )
         assert extract_authored_at_for_fragment(fragment) is None
 
+    def test_image_platform_uses_mtime_for_png(self, tmp_path: Path) -> None:
+        from PIL import Image
+
+        path = tmp_path / "photo.png"
+        Image.new("RGB", (4, 4), color="white").save(path, "png")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+        fragment = Fragment(
+            id="frag-png",
+            title="Test",
+            source=FragmentSource(
+                platform=SourcePlatform.IMAGE_OCR,
+                original_file=str(path),
+            ),
+        )
+        result = extract_authored_at_for_fragment(fragment)
+        assert result == expected
+
+    def test_code_platform_uses_mtime_when_not_git(self, tmp_path: Path) -> None:
+        path = tmp_path / "README.md"
+        path.write_text("# Hi\n", encoding="utf-8")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+        fragment = Fragment(
+            id="frag-code",
+            title="Test",
+            source=FragmentSource(
+                platform=SourcePlatform.CODE,
+                original_file=str(path),
+            ),
+        )
+        result = extract_authored_at_for_fragment(fragment)
+        assert result == expected
+
+    def test_presentation_platform_uses_mtime_for_stub(self, tmp_path: Path) -> None:
+        path = tmp_path / "deck.pptx"
+        path.write_bytes(b"")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+        fragment = Fragment(
+            id="frag-pptx",
+            title="Test",
+            source=FragmentSource(
+                platform=SourcePlatform.PRESENTATION,
+                original_file=str(path),
+            ),
+        )
+        result = extract_authored_at_for_fragment(fragment)
+        assert result == expected
+
+    def test_spreadsheet_platform_uses_mtime_for_csv(self, tmp_path: Path) -> None:
+        path = tmp_path / "data.csv"
+        path.write_text("col\n", encoding="utf-8")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+        fragment = Fragment(
+            id="frag-csv",
+            title="Test",
+            source=FragmentSource(
+                platform=SourcePlatform.SPREADSHEET,
+                original_file=str(path),
+            ),
+        )
+        result = extract_authored_at_for_fragment(fragment)
+        assert result == expected
+
+    def test_chat_platform_uses_mtime_fallback(self, tmp_path: Path) -> None:
+        path = tmp_path / "export.json"
+        path.write_text('[{"a":1}]', encoding="utf-8")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+        fragment = Fragment(
+            id="frag-chat",
+            title="Test",
+            source=FragmentSource(
+                platform=SourcePlatform.CHATGPT,
+                original_file=str(path),
+            ),
+        )
+        result = extract_authored_at_for_fragment(fragment)
+        assert result == expected
+
+    def test_nonexistent_source_path_returns_none(self) -> None:
+        fragment = Fragment(
+            id="frag-ghost",
+            title="Test",
+            source=FragmentSource(
+                platform=SourcePlatform.DOCUMENT,
+                original_file="/no/such/path.html",
+            ),
+        )
+        assert extract_authored_at_for_fragment(fragment) is None
+
 
 # ---- CLI integration ----
 
@@ -273,10 +365,10 @@ class TestRefreshDatesCli:
 
         html_source = vault / "post.html"
         html_source.write_text(
-            '<html><head>'
+            "<html><head>"
             '<meta property="article:published_time" '
             'content="2024-03-15T08:00:00Z">'
-            '</head><body>Hi</body></html>',
+            "</head><body>Hi</body></html>",
             encoding="utf-8",
         )
         frag_path = _write_fragment(

--- a/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
+++ b/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
@@ -1128,3 +1128,190 @@ class TestModuleExports:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+# ---- authored_at extraction (FEAT-031) ----
+
+
+class TestPresentationAuthoredAt:
+    """``PresentationIngestor`` reads ``dcterms:created`` from the .pptx package.
+
+    FEAT-031 (#263): the chain is OOXML core properties → mtime.
+    """
+
+    def test_authored_at_falls_back_to_mtime_for_nonexistent_package(
+        self, tmp_path: "Path"
+    ) -> None:
+        """A non-OOXML file (an empty stub) falls back to mtime."""
+        from datetime import UTC, datetime
+        import os
+
+        path = tmp_path / "deck.pptx"
+        path.write_bytes(b"")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+
+        backend = StubPresentationBackend(
+            presentations={
+                "deck.pptx": PresentationData(
+                    title="Title",
+                    slides=(SlideData(index=1, title="A", body="b"),),
+                ),
+            },
+        )
+        ingestor = PresentationIngestor(backend=backend)
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored == expected
+
+    def test_authored_at_from_real_pptx_core_properties(
+        self, tmp_path: "Path"
+    ) -> None:
+        """Build a minimal valid .pptx and verify dcterms:created is read."""
+        import zipfile
+
+        path = tmp_path / "deck.pptx"
+        core_xml = (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            '<cp:coreProperties '
+            'xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/'
+            'core-properties" '
+            'xmlns:dc="http://purl.org/dc/elements/1.1/" '
+            'xmlns:dcterms="http://purl.org/dc/terms/">'
+            '<dcterms:created xsi:type="dcterms:W3CDTF" '
+            'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">'
+            "2024-03-15T10:30:00Z</dcterms:created>"
+            "</cp:coreProperties>"
+        )
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("docProps/core.xml", core_xml)
+
+        backend = StubPresentationBackend(
+            presentations={
+                "deck.pptx": PresentationData(
+                    title="Title",
+                    slides=(SlideData(index=1, title="A", body="b"),),
+                ),
+            },
+        )
+        ingestor = PresentationIngestor(backend=backend)
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2024-03-15"
+
+    def test_authored_at_emitted_in_frontmatter(self, tmp_path: "Path") -> None:
+        path = tmp_path / "deck.pptx"
+        path.write_bytes(b"")
+        backend = StubPresentationBackend(
+            presentations={
+                "deck.pptx": PresentationData(
+                    title="Title",
+                    slides=(SlideData(index=1, title="A", body="b"),),
+                ),
+            },
+        )
+        ingestor = PresentationIngestor(backend=backend)
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+
+
+class TestSpreadsheetAuthoredAt:
+    """``SpreadsheetIngestor`` reads ``dcterms:created`` from .xlsx packages.
+
+    FEAT-031 (#263): the chain is OOXML core properties → mtime; .csv
+    files skip straight to mtime since they have no in-band date.
+    """
+
+    def test_xlsx_authored_at_from_core_properties(
+        self, tmp_path: "Path"
+    ) -> None:
+        import zipfile
+
+        path = tmp_path / "book.xlsx"
+        core_xml = (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+            '<cp:coreProperties '
+            'xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/'
+            'core-properties" '
+            'xmlns:dcterms="http://purl.org/dc/terms/">'
+            "<dcterms:created>2024-03-15T10:30:00Z</dcterms:created>"
+            "</cp:coreProperties>"
+        )
+        with zipfile.ZipFile(path, "w") as zf:
+            zf.writestr("docProps/core.xml", core_xml)
+
+        backend = StubSpreadsheetBackend(
+            workbooks={
+                "book.xlsx": WorkbookData(
+                    sheets=(
+                        SheetData(
+                            name="Sheet1",
+                            headers=("col",),
+                            rows=(("v",),),
+                        ),
+                    ),
+                ),
+            },
+        )
+        ingestor = SpreadsheetIngestor(backend=backend)
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date().isoformat() == "2024-03-15"
+
+    def test_csv_authored_at_uses_mtime(self, tmp_path: "Path") -> None:
+        from datetime import UTC, datetime
+        import os
+
+        path = tmp_path / "data.csv"
+        path.write_text("col\nv\n", encoding="utf-8")
+        expected = datetime(2024, 5, 1, 12, 0, 0, tzinfo=UTC)
+        os.utime(path, (expected.timestamp(), expected.timestamp()))
+
+        backend = StubSpreadsheetBackend(
+            workbooks={
+                "data.csv": WorkbookData(
+                    sheets=(
+                        SheetData(
+                            name="Sheet1",
+                            headers=("col",),
+                            rows=(("v",),),
+                        ),
+                    ),
+                ),
+            },
+        )
+        ingestor = SpreadsheetIngestor(backend=backend)
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored == expected
+
+    def test_authored_at_emitted_in_frontmatter(self, tmp_path: "Path") -> None:
+        path = tmp_path / "data.csv"
+        path.write_text("col\nv\n", encoding="utf-8")
+        backend = StubSpreadsheetBackend(
+            workbooks={
+                "data.csv": WorkbookData(
+                    sheets=(
+                        SheetData(
+                            name="Sheet1",
+                            headers=("col",),
+                            rows=(("v",),),
+                        ),
+                    ),
+                ),
+            },
+        )
+        ingestor = SpreadsheetIngestor(backend=backend)
+        docs = ingestor.discover(path)
+        fragments = ingestor.parse(docs[0])
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm

--- a/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
+++ b/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
@@ -1140,11 +1140,11 @@ class TestPresentationAuthoredAt:
     """
 
     def test_authored_at_falls_back_to_mtime_for_nonexistent_package(
-        self, tmp_path: "Path"
+        self, tmp_path: Path
     ) -> None:
         """A non-OOXML file (an empty stub) falls back to mtime."""
-        from datetime import UTC, datetime
         import os
+        from datetime import UTC, datetime
 
         path = tmp_path / "deck.pptx"
         path.write_bytes(b"")
@@ -1165,16 +1165,14 @@ class TestPresentationAuthoredAt:
         authored = fragments[0].metadata["authored_at"]
         assert authored == expected
 
-    def test_authored_at_from_real_pptx_core_properties(
-        self, tmp_path: "Path"
-    ) -> None:
+    def test_authored_at_from_real_pptx_core_properties(self, tmp_path: Path) -> None:
         """Build a minimal valid .pptx and verify dcterms:created is read."""
         import zipfile
 
         path = tmp_path / "deck.pptx"
         core_xml = (
             '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-            '<cp:coreProperties '
+            "<cp:coreProperties "
             'xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/'
             'core-properties" '
             'xmlns:dc="http://purl.org/dc/elements/1.1/" '
@@ -1202,7 +1200,7 @@ class TestPresentationAuthoredAt:
         assert authored is not None
         assert authored.date().isoformat() == "2024-03-15"
 
-    def test_authored_at_emitted_in_frontmatter(self, tmp_path: "Path") -> None:
+    def test_authored_at_emitted_in_frontmatter(self, tmp_path: Path) -> None:
         path = tmp_path / "deck.pptx"
         path.write_bytes(b"")
         backend = StubPresentationBackend(
@@ -1227,15 +1225,13 @@ class TestSpreadsheetAuthoredAt:
     files skip straight to mtime since they have no in-band date.
     """
 
-    def test_xlsx_authored_at_from_core_properties(
-        self, tmp_path: "Path"
-    ) -> None:
+    def test_xlsx_authored_at_from_core_properties(self, tmp_path: Path) -> None:
         import zipfile
 
         path = tmp_path / "book.xlsx"
         core_xml = (
             '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
-            '<cp:coreProperties '
+            "<cp:coreProperties "
             'xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/'
             'core-properties" '
             'xmlns:dcterms="http://purl.org/dc/terms/">'
@@ -1266,9 +1262,9 @@ class TestSpreadsheetAuthoredAt:
         assert authored is not None
         assert authored.date().isoformat() == "2024-03-15"
 
-    def test_csv_authored_at_uses_mtime(self, tmp_path: "Path") -> None:
-        from datetime import UTC, datetime
+    def test_csv_authored_at_uses_mtime(self, tmp_path: Path) -> None:
         import os
+        from datetime import UTC, datetime
 
         path = tmp_path / "data.csv"
         path.write_text("col\nv\n", encoding="utf-8")
@@ -1294,7 +1290,7 @@ class TestSpreadsheetAuthoredAt:
         authored = fragments[0].metadata["authored_at"]
         assert authored == expected
 
-    def test_authored_at_emitted_in_frontmatter(self, tmp_path: "Path") -> None:
+    def test_authored_at_emitted_in_frontmatter(self, tmp_path: Path) -> None:
         path = tmp_path / "data.csv"
         path.write_text("col\nv\n", encoding="utf-8")
         backend = StubSpreadsheetBackend(

--- a/creek-tools/uv.lock
+++ b/creek-tools/uv.lock
@@ -525,6 +525,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },
+    { name = "defusedxml" },
     { name = "httpx" },
     { name = "idna" },
     { name = "mcp" },
@@ -576,6 +577,7 @@ dev = [
     { name = "pillow" },
     { name = "pip-audit" },
     { name = "pre-commit" },
+    { name = "pyarrow" },
     { name = "pylint" },
     { name = "pytesseract" },
     { name = "pytest" },
@@ -631,6 +633,7 @@ requires-dist = [
     { name = "chardet", specifier = ">=7.4.3" },
     { name = "creek-tools", extras = ["all"], marker = "extra == 'dev'" },
     { name = "creek-tools", extras = ["anthropic", "embeddings", "ocr", "documents", "spreadsheets", "presentations", "gdrive"], marker = "extra == 'all'" },
+    { name = "defusedxml", specifier = ">=0.7" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "google-api-python-client", marker = "extra == 'gdrive'", specifier = ">=2.0" },
     { name = "google-auth-oauthlib", marker = "extra == 'gdrive'", specifier = ">=1.0" },


### PR DESCRIPTION
## Summary

Implements [#263](https://github.com/Geoffe-Ga/Creek-Vault/issues/263) — every ingestor extracts the source's *authored* date and stores it as `Fragment.authored_at`, distinct from `created` (filesystem) and `ingested` (vault-write time).

Pre-FEAT-031 the vault couldn't tell that a 2024 essay was a 2024 essay — it bucketed under whatever date the filesystem mtime claimed, which made the State report file historical material as "this week's activity" and the temporal linker find zero cross-time threads. This PR fixes the root cause.

**Per-ingestor extraction chains** (every step covered by a unit test):

- **GenericIngestor**: filesystem mtime only.
- **MarkdownIngestor**: frontmatter `published` → `date` → `created` → mtime.
- **ChatGPTIngestor**: per-turn user `create_time` (Unix epoch) → conversation `create_time`.
- **ClaudeIngestor**: per-turn human `created_at` → conversation `created_at`.
- **DiscordIngestor**: earliest message `timestamp` from the JSON export.
- **CodeIngestor**: `git log --diff-filter=A --follow --format=%aI -- <file>` → mtime.
- **ImageIngestor**: EXIF `DateTimeOriginal` (36867) → EXIF `DateTime` (306) → mtime.
- **DocumentIngestor**:
  - HTML/HTM: `<meta>` keys + JSON-LD `datePublished` → mtime.
  - PDF: `/CreationDate` → `/ModDate` → mtime.
  - DOCX: core `dcterms:created` → `dcterms:modified` → mtime.
  - RTF: `\creatim` → `\revtim` → mtime.
  - TXT: mtime only.
- **PresentationIngestor / SpreadsheetIngestor**: OOXML `docProps/core.xml` → mtime; `.csv` straight to mtime.

**Downstream surfaces** now route every time-bucket comparison through a new `Fragment.effective_at` property (`authored_at if present else created`):
- `link/temporal.py`: chronological sort + window comparison.
- `link/threads.py`: thread clustering window + `first_seen` / `last_seen`.
- `link/eddies.py`: eddy formed date + clustering sort.
- `generate/synchronicity.py`: gap math + chronological ordering + rendered date.
- `generate/wavelength.py`: helper migrated to delegate to the property.
- `generate/unnamed.py`: weekly bucket + report line.
- `generate/compost.py`: project-silence cutoff.

**Backfill helper**: `creek ingest --refresh-dates` walks every fragment under `<vault>/01-Fragments`, dispatches to the appropriate per-platform extractor, and rewrites the markdown only when `authored_at` actually changed. Bodies are preserved byte-for-byte; non-Fragment frontmatter keys (Obsidian aliases, custom scratch) survive the round-trip. Idempotent — a second pass against unchanged sources rewrites nothing.

**Timezone handling**: every extracted `authored_at` is timezone-aware. Source-provided zones are preserved verbatim; naive values are anchored to UTC per the issue's never-naive rule (so a bare `2024-03-15` survives as the 15th in UTC, not the 14th in LA).

**Honest absence**: when no date is extractable, `authored_at` is `None` — never a guess.

**Security**: OOXML core-properties parsing routes through `defusedxml.ElementTree` so the new XML reader can't be weaponised by a malicious `.docx` / `.xlsx` / `.pptx`.

## Test plan

- [x] `./scripts/check-all.sh` exits 0 (all 12 gates green)
- [x] `./scripts/test.sh --all` — 4006 unit tests pass; aggregate coverage 93.47%
- [x] Per-file coverage gate clean (refresh.py at 85%+)
- [x] Each per-ingestor fallback step exercised by a dedicated test (see `TestXIngestorAuthoredAt` classes)
- [x] Round-trip test: `Fragment.authored_at` survives `model_dump` → `model_validate`
- [x] Idempotency test: second `--refresh-dates` run is a no-op
- [x] CLI integration test: Typer runner round-trips through `creek ingest --refresh-dates`
- [x] Body-preservation test: refresh does not perturb the markdown body
- [x] Custom-frontmatter-keys test: Obsidian aliases / custom scratch survive refresh

Closes #263

---
_Generated by [Claude Code](https://claude.ai/code/session_013cUWw5aqjKSAKJnmEcxZPZ)_