### PR TITLE
feat(ingest): authored-date extraction contract across every ingestor (FEAT-031)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -542,6 +542,14 @@ def ingest(
         "-y",
         help="Skip the consent prompt for first-time sources (logged).",
     ),
+    refresh_dates: bool = typer.Option(
+        False,
+        "--refresh-dates",
+        help=(
+            "FEAT-031 backfill: re-extract authored_at on existing fragments "
+            "without re-ingesting body content. Idempotent."
+        ),
+    ),
 ) -> None:
     """Ingest a specific source type into the vault.
 
@@ -551,7 +559,17 @@ def ingest(
     :class:`~creek.vault.writer.VaultWriter`. Re-running against the same
     input is idempotent: deterministic fragment IDs ensure existing
     files are recognised and skipped.
+
+    ``--refresh-dates`` is a one-shot FEAT-031 backfill: it walks
+    ``--vault`` (or the configured vault), re-runs the per-format
+    authored-date extraction chain against each fragment's source
+    file, and rewrites the frontmatter in place. ``--type`` /
+    ``--input`` are ignored in refresh mode.
     """
+    if refresh_dates:
+        _run_refresh_dates(vault)
+        return
+
     if type is None or input is None:
         console.print("[red]--type and --input are required.[/red]")
         raise typer.Exit(code=2)
@@ -582,6 +600,39 @@ def ingest(
     if errors:
         console.print(f"[yellow]Errors: {len(errors)}[/yellow]")
         for err in errors:
+            console.print(f"  [dim]{err}[/dim]")
+
+
+def _run_refresh_dates(vault: Path | None) -> None:
+    """Execute the FEAT-031 ``--refresh-dates`` backfill.
+
+    Resolves the vault path (CLI flag → configured default), invokes
+    :func:`creek.ingest.refresh.refresh_authored_dates`, and renders a
+    one-screen summary. Exit codes mirror the rest of the CLI: 0 on
+    success (regardless of how many fragments were updated), 1 if the
+    vault path is unusable.
+    """
+    from creek.ingest.refresh import refresh_authored_dates
+
+    config = load_config()
+    vault_path = vault or config.vault_path
+    if not vault_path.exists():
+        console.print(f"[red]Vault path does not exist: {vault_path}[/red]")
+        raise typer.Exit(code=1)
+
+    result = refresh_authored_dates(vault_path)
+    console.print(
+        f"[bold green]Refreshed authored_at on {result.updated} "
+        "fragment(s).[/bold green]"
+    )
+    console.print(f"  scanned: {result.scanned}")
+    console.print(f"  already-set: {result.already_set}")
+    console.print(f"  no source date: {result.no_date_found}")
+    console.print(f"  missing source file: {result.missing_source}")
+    console.print(f"  unsupported source: {result.unsupported}")
+    if result.errors:
+        console.print(f"[yellow]Errors: {len(result.errors)}[/yellow]")
+        for err in result.errors:
             console.print(f"  [dim]{err}[/dim]")
 
 

--- a/creek-tools/creek/generate/unnamed.py
+++ b/creek-tools/creek/generate/unnamed.py
@@ -39,6 +39,7 @@ import frontmatter
 from pydantic import ValidationError
 
 from creek.models import Fragment
+from creek.time import effective_authored_date
 
 if TYPE_CHECKING:
     from datetime import date
@@ -196,21 +197,26 @@ class UnnamedDigestGenerator:
         fragments: list[Fragment],
         week_start: date,
     ) -> list[Fragment]:
-        """Return the subset of *fragments* created within the target week.
+        """Return the subset of *fragments* authored within the target week.
 
         The window is ``[week_start, week_start + 7)`` days, matching the
         standard ISO-week convention (Monday inclusive, next Monday
-        exclusive).
+        exclusive). FEAT-031: bucketing uses
+        :func:`creek.time.effective_authored_date` so a historical
+        fragment (a 2024 essay re-ingested this week) lands in its
+        true authored week, not the import week.
 
         Args:
             fragments: Candidate fragments.
             week_start: Monday of the target ISO week.
 
         Returns:
-            Fragments whose ``created`` date falls in the window.
+            Fragments whose effective authored date falls in the window.
         """
         week_end = week_start + timedelta(days=_WEEK_LENGTH_DAYS)
-        return [f for f in fragments if week_start <= f.created.date() < week_end]
+        return [
+            f for f in fragments if week_start <= effective_authored_date(f) < week_end
+        ]
 
     def detect_unnamed_clusters(
         self,

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -25,6 +25,7 @@ from pydantic import ValidationError
 
 from creek.hierarchy import LevelPolicy, select_by_policy
 from creek.models import Dosage, Fragment, Frequency, Mode, Phase
+from creek.time import effective_authored_date
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -291,18 +292,15 @@ def _week_start(day: date) -> date:
 
 
 def _fragment_effective_date(fragment: Fragment) -> date:
-    """Return the date this fragment should be bucketed under.
+    """Return the date this fragment should be bucketed under (FEAT-031).
 
-    Prefers :attr:`Fragment.authored_at` — when an ingestor extracts
-    the source's own timestamp (a Substack post's publish date, a
-    Discord message's ``timestamp``), that date is what every
-    time-bucket surface should see so a 2024 essay does not get
-    counted as part of *this week's* wavelength. Falls back to
-    :attr:`Fragment.created` when no authored date was extracted.
+    Thin wrapper around :func:`creek.time.effective_authored_date` —
+    the single source of truth for the authored-date precedence
+    contract. Kept here as a module-private alias so existing imports
+    from :mod:`creek.generate.wavelength` keep working; new callers
+    should import the canonical helper directly.
     """
-    if fragment.authored_at is not None:
-        return fragment.authored_at.date()
-    return fragment.created.date()
+    return effective_authored_date(fragment)
 
 
 def _fragment_in_window(fragment: Fragment, start: date, end: date) -> bool:
@@ -687,8 +685,11 @@ class WavelengthTracker:
         """
         if not fragments:
             return []
-        first = min(f.created.date() for f in fragments)
-        last = max(f.created.date() for f in fragments)
+        # FEAT-031: snapshot windows anchor on effective authored dates
+        # so re-ingested historical material does not pull a series'
+        # start/end forward to the import moment.
+        first = min(effective_authored_date(f) for f in fragments)
+        last = max(effective_authored_date(f) for f in fragments)
         start = _week_start(first)
         snapshots: list[WavelengthSnapshot] = []
         while start <= last:

--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -18,7 +18,7 @@ import abc
 import hashlib
 import logging
 from contextlib import suppress
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -216,6 +216,51 @@ def normalize_timestamp(ts_string: str, source_tz: str | None) -> datetime:
     """
     parsed = _parse_timestamp_string(ts_string)
     return _localize_naive_timestamp(parsed, source_tz).astimezone(LA_TZ)
+
+
+def parse_authored_at(value: object, source_tz: str | None = None) -> datetime | None:
+    """Parse a value into a tz-aware ``authored_at`` datetime (FEAT-031).
+
+    The FEAT-031 contract: ``authored_at`` preserves the source's
+    timezone when one is provided and defaults to UTC otherwise. This
+    differs from :func:`normalize_timestamp`, which always converts to
+    LA — appropriate for the LA-anchored ``Fragment.created`` /
+    ``Fragment.ingested`` defaults but wrong for ``authored_at``,
+    where a bare ``2024-03-15`` should land on March 15, not slip to
+    March 14 17:00 PDT after the LA conversion.
+
+    Accepts ``str``, ``datetime``, ``date``, and ``None`` so callers
+    can hand off raw YAML-parsed values without re-stringifying. A
+    ``date`` is promoted to UTC-midnight on that day; a ``datetime``
+    is returned as-is when tz-aware, or UTC-localised when naive.
+
+    Args:
+        value: Raw value from frontmatter, EXIF, JSON, etc.
+        source_tz: Optional IANA timezone name for naive inputs.
+            Defaults to UTC per the FEAT-031 spec.
+
+    Returns:
+        A tz-aware datetime, or ``None`` when *value* is ``None`` or
+        an empty/whitespace string. Never returns a naive datetime.
+
+    Raises:
+        ValueError: If *value* is a non-empty string that no parser
+            recognises. Caller should ``try/except`` to fall through
+            to the next candidate in its extraction chain rather than
+            propagating a parse failure into the pipeline.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _localize_naive_timestamp(value, source_tz)
+    if isinstance(value, date):  # bare YAML date — promote to midnight in source_tz
+        midnight = datetime(value.year, value.month, value.day)
+        return _localize_naive_timestamp(midnight, source_tz)
+    text = str(value).strip()
+    if not text:
+        return None
+    parsed = _parse_timestamp_string(text)
+    return _localize_naive_timestamp(parsed, source_tz)
 
 
 def _parse_timestamp_string(ts_string: str) -> datetime:

--- a/creek-tools/creek/ingest/chatgpt.py
+++ b/creek-tools/creek/ingest/chatgpt.py
@@ -140,7 +140,9 @@ class ChatGPTIngestor(Ingestor):
 
         Produces frontmatter with ``source.platform`` set to ``"chatgpt"``
         and includes the conversation title, creation timestamp, and
-        original file path.
+        original file path. FEAT-031: the per-message ``create_time``
+        (falling back to the conversation's ``create_time``) lands on
+        ``authored_at`` in UTC.
 
         Args:
             fragment: The parsed fragment to generate frontmatter for.
@@ -155,11 +157,15 @@ class ChatGPTIngestor(Ingestor):
         conv_id = fragment.metadata.get("conversation_id")
         if conv_id is not None:
             source["conversation_id"] = conv_id
-        return {
+        frontmatter_dict: dict[str, Any] = {
             "title": fragment.metadata.get("title", "Untitled Conversation"),
             "created": fragment.timestamp.isoformat(),
             "source": source,
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            frontmatter_dict["authored_at"] = authored_at.isoformat()
+        return frontmatter_dict
 
     # ---- Private helpers ----
 
@@ -203,7 +209,12 @@ class ChatGPTIngestor(Ingestor):
             )
 
         return _pair_messages_to_fragments(
-            ordered_messages, title, timestamp, source_path, conversation_id
+            ordered_messages,
+            title,
+            timestamp,
+            source_path,
+            conversation_id,
+            conversation_create_time=create_time,
         )
 
 
@@ -455,12 +466,28 @@ def _get_message_role(msg: dict[str, Any]) -> str:
     return str(author.get("role", "unknown"))
 
 
+def _epoch_to_authored_at(epoch: float | None) -> datetime | None:
+    """Convert a ChatGPT ``create_time`` epoch to a UTC ``authored_at`` (FEAT-031).
+
+    ChatGPT exports stamp every node with a ``create_time`` Unix
+    epoch float. Per FEAT-031 ``authored_at`` is returned in UTC
+    (no LA coercion) so cross-tz aggregations downstream see the
+    instant the user actually sent the message, not its LA wall
+    rendering. Missing / sentinel values return ``None`` — never
+    a guessed date.
+    """
+    if epoch is None or epoch == 0.0:
+        return None
+    return datetime.fromtimestamp(epoch, tz=UTC)
+
+
 def _pair_messages_to_fragments(
     messages: list[dict[str, Any]],
     title: str,
     conversation_timestamp: datetime,
     source_path: str,
     conversation_id: str | None = None,
+    conversation_create_time: float | None = None,
 ) -> list[ParsedFragment]:
     """Pair consecutive user+assistant messages into fragments.
 
@@ -469,16 +496,27 @@ def _pair_messages_to_fragments(
     and unpaired user messages at the end are skipped. Each fragment
     title includes a turn index to prevent collisions.
 
+    FEAT-031: each pair carries ``authored_at`` derived from the
+    user message's ``create_time``. When the per-message field is
+    absent we fall through to the conversation-level ``create_time``
+    so a Substack-style "everything stamped at the conversation
+    moment" export still anchors to a real source date instead of
+    going to ``None``.
+
     Args:
         messages: Ordered list of ChatGPT message dicts.
         title: The conversation title.
         conversation_timestamp: The conversation creation timestamp.
         source_path: The source file path.
         conversation_id: Optional ChatGPT conversation ID for metadata.
+        conversation_create_time: Raw epoch float from the conversation's
+            ``create_time`` for the FEAT-031 ``authored_at`` fallback.
 
     Returns:
         A list of ``ParsedFragment`` objects, one per pair.
     """
+    conv_authored_at = _epoch_to_authored_at(conversation_create_time)
+
     fragments: list[ParsedFragment] = []
     turn_idx = 0
     i = 0
@@ -504,6 +542,12 @@ def _pair_messages_to_fragments(
                         if user_time
                         else conversation_timestamp
                     )
+                    msg_authored_at = _epoch_to_authored_at(user_time)
+                    authored_at = (
+                        msg_authored_at
+                        if msg_authored_at is not None
+                        else conv_authored_at
+                    )
                     content = (
                         f"**User**: {user_text}\n\n**Assistant**: {assistant_text}"
                     )
@@ -511,6 +555,7 @@ def _pair_messages_to_fragments(
                     meta: dict[str, Any] = {
                         "title": turn_title,
                         "platform": "chatgpt",
+                        "authored_at": authored_at,
                     }
                     if conversation_id is not None:
                         meta["conversation_id"] = conversation_id

--- a/creek-tools/creek/ingest/claude.py
+++ b/creek-tools/creek/ingest/claude.py
@@ -25,9 +25,11 @@ from creek.ingest.base import (
     RawDocument,
     normalize_encoding,
     normalize_timestamp,
+    parse_authored_at,
 )
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from pathlib import Path
 
     from creek.clean.filters.chatbot import ChatbotFilter
@@ -190,6 +192,40 @@ def _resolve_timestamp(msg: dict[str, Any], fallback: str) -> str:
     return fallback or "2000-01-01T00:00:00Z"
 
 
+def _resolve_authored_at(
+    msg: dict[str, Any],
+    conv_created_at: str,
+) -> datetime | None:
+    """Resolve a Claude turn's ``authored_at`` (FEAT-031).
+
+    Precedence: per-message ``created_at`` first, then the
+    conversation-level ``created_at`` as fallback. Unparseable values
+    are logged and yield ``None`` so the downstream contract — never
+    guess a date — is preserved.
+
+    Args:
+        msg: The human-side message dict for the turn.
+        conv_created_at: The enclosing conversation's ``created_at``
+            string. Empty string means "no conversation timestamp"
+            and the result is ``None``.
+
+    Returns:
+        A tz-aware datetime or ``None``.
+    """
+    candidates: tuple[object, ...] = (msg.get("created_at"), conv_created_at)
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            parsed = parse_authored_at(candidate)
+        except ValueError:
+            logger.warning("Claude turn has unparseable created_at %r", candidate)
+            continue
+        if parsed is not None:
+            return parsed
+    return None
+
+
 # ---- Claude Ingestor ----
 
 
@@ -320,11 +356,15 @@ class ClaudeIngestor(Ingestor):
         if model is not None:
             source["model"] = model
 
-        return {
+        frontmatter_dict: dict[str, Any] = {
             "title": f"{conv_name} (turn {turn_idx})",
             "created": fragment.timestamp.isoformat(),
             "source": source,
         }
+        authored_at: datetime | None = meta.get("authored_at")
+        if authored_at is not None:
+            frontmatter_dict["authored_at"] = authored_at.isoformat()
+        return frontmatter_dict
 
     # ---- Private Helpers ----
 
@@ -449,6 +489,10 @@ class ClaudeIngestor(Ingestor):
 
         ts_string = _resolve_timestamp(human_msg, fallback_ts)
         timestamp = normalize_timestamp(ts_string, source_tz=None)
+        # FEAT-031: ``authored_at`` preserves the source's tz; falls
+        # back to the conversation-level ``created_at`` and finally to
+        # ``None`` when no real source date exists.
+        authored_at = _resolve_authored_at(human_msg, fallback_ts)
 
         content = f"{human_text}\n\n{assistant_text}"
 
@@ -458,6 +502,7 @@ class ClaudeIngestor(Ingestor):
             "turn_index": turn_index,
             "human_text": human_text,
             "assistant_text": assistant_text,
+            "authored_at": authored_at,
         }
         if model is not None:
             metadata["model"] = model

--- a/creek-tools/creek/ingest/code.py
+++ b/creek-tools/creek/ingest/code.py
@@ -28,6 +28,7 @@ from creek.ingest.base import (
     ParsedFragment,
     RawDocument,
     normalize_encoding,
+    parse_authored_at,
 )
 from creek.models import SourcePlatform
 
@@ -358,6 +359,62 @@ def _get_commit_messages(repo_path: Path) -> str:
         return result.stdout.strip()
 
 
+def _git_first_commit_author_date(file_path: Path) -> datetime | None:
+    """Return the first-commit author date for *file_path* (FEAT-031).
+
+    Runs ``git log --diff-filter=A --follow --format=%aI -- <file>`` in
+    the file's repo, returning the most recent ``A``-filtered (added)
+    commit's author date. Returns ``None`` when *file_path* is not in
+    a git repo, when git is unavailable, when the command fails, or
+    when the file has no commit history — the honest answer when no
+    source-side authored date can be determined.
+
+    The ``--follow`` flag respects file renames so a file moved between
+    directories still surfaces its original creation moment, not the
+    rename date. ``%aI`` produces strict ISO-8601 with tz, so the
+    result preserves the committer's offset rather than collapsing to
+    UTC or local.
+    """
+    git_path = shutil.which("git")
+    if git_path is None:
+        return None
+    if not file_path.exists():
+        return None
+    cwd = file_path.parent if file_path.is_file() else file_path
+    try:  # noqa: TRY101  # Separate subprocess failure from date-parse failure.
+        result = subprocess.run(  # nosec B603 — hardcoded args, controlled path
+            [
+                git_path,
+                "log",
+                "--diff-filter=A",
+                "--follow",
+                "--format=%aI",
+                "--",
+                file_path.name if file_path.is_file() else ".",
+            ],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    output = result.stdout.strip()
+    if not output:
+        return None
+    # The last line is the chronologically earliest "added" commit
+    # (``git log`` defaults to reverse-chronological output); a file
+    # without a rename history yields one line, with renames possibly
+    # several. Either way the last line is the first-added moment.
+    earliest_iso = output.splitlines()[-1].strip()
+    try:  # noqa: TRY101  # Separate subprocess failure from date-parse failure.
+        return parse_authored_at(earliest_iso)
+    except ValueError:
+        return None
+
+
 def _get_file_timestamp(path: Path) -> datetime:
     """Get a file's modification timestamp as a timezone-aware datetime.
 
@@ -604,7 +661,10 @@ class CodeIngestor(Ingestor):
         """Parse a raw code document into content fragments.
 
         Dispatches to artifact-specific parsers based on the document's
-        metadata ``artifact_type``.
+        metadata ``artifact_type``. FEAT-031: each fragment's
+        ``authored_at`` comes from ``git log --diff-filter=A --follow``
+        (the file's first-added commit) when the file lives in a git
+        repo; falls through to ``None`` otherwise.
 
         Args:
             raw: The raw document to parse.
@@ -615,12 +675,22 @@ class CodeIngestor(Ingestor):
         artifact_type = raw.metadata.get("artifact_type", "other")
         text, _encoding = normalize_encoding(raw.content)
         timestamp = _get_file_timestamp(raw.path)
+        # Commits-pseudo-document carries the repo path itself, not a
+        # file; git-log against the directory would return today's HEAD
+        # date instead of a meaningful authored moment, so omit.
+        authored_at = (
+            _git_first_commit_author_date(raw.path)
+            if artifact_type != "commits"
+            else None
+        )
 
         if artifact_type in ("readme", "claude_md", "adr"):
-            return self._parse_markdown_artifact(raw, text, timestamp, artifact_type)
+            return self._parse_markdown_artifact(
+                raw, text, timestamp, artifact_type, authored_at
+            )
 
         if artifact_type == "python":
-            return self._parse_python_file(raw, text, timestamp)
+            return self._parse_python_file(raw, text, timestamp, authored_at)
 
         if artifact_type == "commits":
             return self._parse_commits(raw, text, timestamp)
@@ -633,6 +703,7 @@ class CodeIngestor(Ingestor):
         text: str,
         timestamp: datetime,
         artifact_type: str,
+        authored_at: datetime | None,
     ) -> list[ParsedFragment]:
         """Parse a markdown-based artifact (README, CLAUDE.md, ADR).
 
@@ -641,6 +712,7 @@ class CodeIngestor(Ingestor):
             text: Decoded text content.
             timestamp: File timestamp.
             artifact_type: The artifact type identifier.
+            authored_at: First-commit author date from git, or ``None``.
 
         Returns:
             A single-element list containing the parsed fragment.
@@ -648,7 +720,10 @@ class CodeIngestor(Ingestor):
         return [
             ParsedFragment(
                 content=text,
-                metadata={"artifact_type": artifact_type},
+                metadata={
+                    "artifact_type": artifact_type,
+                    "authored_at": authored_at,
+                },
                 source_path=str(raw.path),
                 timestamp=timestamp,
             )
@@ -659,13 +734,20 @@ class CodeIngestor(Ingestor):
         raw: RawDocument,
         text: str,
         timestamp: datetime,
+        authored_at: datetime | None,
     ) -> list[ParsedFragment]:
         """Parse a Python file for docstrings and significant comments.
+
+        Every docstring / comment fragment carved out of the file
+        inherits the file's first-commit author date (FEAT-031) — a
+        finer-grained authored_at (per-symbol blame) is out of scope
+        for v1 and would generate spurious churn on cosmetic edits.
 
         Args:
             raw: The raw document.
             text: Decoded Python source text.
             timestamp: File timestamp.
+            authored_at: First-commit author date from git, or ``None``.
 
         Returns:
             A list of fragments for each docstring and significant comment.
@@ -683,6 +765,7 @@ class CodeIngestor(Ingestor):
                         "kind": doc_info["kind"],
                         "name": doc_info["name"],
                         "line": doc_info["line"],
+                        "authored_at": authored_at,
                     },
                     source_path=source_path,
                     timestamp=timestamp,
@@ -694,6 +777,7 @@ class CodeIngestor(Ingestor):
             metadata: dict[str, Any] = {
                 "artifact_type": "comment",
                 "line": comment_info["line"],
+                "authored_at": authored_at,
             }
             if "marker" in comment_info:
                 metadata["marker"] = comment_info["marker"]
@@ -831,7 +915,7 @@ class CodeIngestor(Ingestor):
         title = _derive_title(fragment)
         artifact_type = fragment.metadata.get("artifact_type", "")
 
-        return {
+        frontmatter_dict: dict[str, Any] = {
             "type": "fragment",
             "title": title,
             "source": {
@@ -841,3 +925,7 @@ class CodeIngestor(Ingestor):
             "created": fragment.timestamp.isoformat(),
             "artifact_type": artifact_type,
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            frontmatter_dict["authored_at"] = authored_at.isoformat()
+        return frontmatter_dict

--- a/creek-tools/creek/ingest/discord.py
+++ b/creek-tools/creek/ingest/discord.py
@@ -38,6 +38,7 @@ from creek.ingest.base import (
     ParsedFragment,
     RawDocument,
     normalize_timestamp,
+    parse_authored_at,
 )
 
 logger = logging.getLogger(__name__)
@@ -490,6 +491,11 @@ class DiscordIngestor(Ingestor):
         content = "\n\n".join(content_parts)
         first_ts = _safe_timestamp(group[0])
         timestamp = self._resolve_timestamp(first_ts)
+        # FEAT-031: ``authored_at`` is the source-side message timestamp,
+        # preserved with its native tz. ``timestamp`` (LA-anchored) is
+        # what the ID hash and other LA-tied surfaces use; the two
+        # carry the same instant but in different timezones.
+        authored_at = self._resolve_authored_at(first_ts)
 
         return ParsedFragment(
             content=content,
@@ -499,6 +505,7 @@ class DiscordIngestor(Ingestor):
                 "authors": sorted(authors),
                 "message_count": len(group),
                 "message_ids": [str(m.get("id", "")) for m in group],
+                "authored_at": authored_at,
             },
             source_path=source_path,
             timestamp=timestamp,
@@ -615,6 +622,24 @@ class DiscordIngestor(Ingestor):
         except ValueError:
             return normalize_timestamp("1970-01-01T00:00:00Z", None)
 
+    def _resolve_authored_at(self, ts_str: str) -> datetime | None:
+        """Resolve a Discord message ``timestamp`` into ``authored_at`` (FEAT-031).
+
+        Discord exports stamp every message with an ISO-8601 timestamp
+        in its ``timestamp`` field — the canonical source-side answer
+        to "when was this said?". Returns ``None`` only when the field
+        is missing or unparseable; never guesses a fallback (the
+        epoch sentinel used by :meth:`_resolve_timestamp` for the
+        ID-hash path is deliberately not reused here).
+        """
+        if not ts_str:
+            return None
+        try:
+            return parse_authored_at(ts_str)
+        except ValueError:
+            logger.warning("Discord message has unparseable timestamp %r", ts_str)
+            return None
+
     def convert_to_markdown(self, fragment: ParsedFragment) -> str:
         """Convert a parsed Discord fragment to clean Markdown.
 
@@ -635,7 +660,9 @@ class DiscordIngestor(Ingestor):
         """Generate YAML frontmatter metadata for a Discord fragment.
 
         Produces frontmatter with source platform, channel, timestamps,
-        and participant information.
+        and participant information. FEAT-031: the message's source-side
+        ``timestamp`` (preserved with its native offset) lands on
+        ``authored_at``.
 
         Args:
             fragment: The parsed fragment.
@@ -643,7 +670,7 @@ class DiscordIngestor(Ingestor):
         Returns:
             A dict of frontmatter key-value pairs.
         """
-        return {
+        frontmatter_dict: dict[str, Any] = {
             "source": {
                 "platform": "discord",
                 "channel": fragment.metadata.get("channel_name", "unknown"),
@@ -653,3 +680,7 @@ class DiscordIngestor(Ingestor):
             "authors": fragment.metadata.get("authors", []),
             "message_count": fragment.metadata.get("message_count", 0),
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            frontmatter_dict["authored_at"] = authored_at.isoformat()
+        return frontmatter_dict

--- a/creek-tools/creek/ingest/documents.py
+++ b/creek-tools/creek/ingest/documents.py
@@ -22,8 +22,10 @@ Exports:
 
 from __future__ import annotations
 
+import contextlib
 import io
 import logging
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -35,8 +37,9 @@ from creek.ingest.base import (
     RawDocument,
     normalize_encoding,
     normalize_timestamp,
+    parse_authored_at,
 )
-from creek.ingest.html import parse_html_to_markdown
+from creek.ingest.html import extract_html_authored_at, parse_html_to_markdown
 from creek.models import SourcePlatform
 
 logger = logging.getLogger(__name__)
@@ -262,14 +265,15 @@ def _convert_table(element: Any, doc: Any, parts: list[str]) -> None:
 def _extract_docx_metadata(docx_bytes: bytes) -> dict[str, Any]:
     """Extract metadata from DOCX core properties.
 
-    Extracts author, title, and creation date from the document's
-    core properties.
+    Extracts author, title, creation date, and modification date from
+    the document's core properties. The modification date powers the
+    FEAT-031 ``authored_at`` fallback when ``created`` is absent.
 
     Args:
         docx_bytes: Raw DOCX file bytes.
 
     Returns:
-        A dict with author, title, and created keys.
+        A dict with author, title, created, and modified keys.
     """
     from docx import (
         Document as DocxDocument,
@@ -285,18 +289,45 @@ def _extract_docx_metadata(docx_bytes: bytes) -> dict[str, Any]:
         metadata["title"] = props.title
     if props.created:
         metadata["created_date"] = props.created.isoformat()
+    if props.modified:
+        metadata["modified_date"] = props.modified.isoformat()
 
     return metadata
+
+
+def _parse_docx_authored_at(metadata: dict[str, Any]) -> datetime | None:
+    """Resolve a DOCX file's ``authored_at`` from extracted metadata.
+
+    Walks ``created_date`` (``dcterms:created``) then ``modified_date``
+    (``dcterms:modified``); returns the first parseable candidate.
+    Returns ``None`` when both keys are absent or unparseable — FEAT-031
+    forbids guessing the date.
+    """
+    for key in ("created_date", "modified_date"):
+        value = metadata.get(key)
+        if not value:
+            continue
+        try:
+            parsed = parse_authored_at(value)
+        except ValueError:
+            continue
+        if parsed is not None:
+            return parsed
+    return None
 
 
 def _extract_pdf_metadata_from_bytes(pdf_bytes: bytes) -> dict[str, Any]:
     """Extract metadata from PDF document info dictionary.
 
+    Pulls ``Author``, ``Title``, ``CreationDate``, and ``ModDate``.
+    ``ModDate`` powers the FEAT-031 ``authored_at`` fallback when
+    ``CreationDate`` is absent.
+
     Args:
         pdf_bytes: Raw PDF file bytes.
 
     Returns:
-        A dict with available metadata fields.
+        A dict with available metadata fields (lowercase keys).
     """
     from pdfminer.pdfdocument import PDFDocument
     from pdfminer.pdfparser import PDFParser
@@ -307,7 +338,7 @@ def _extract_pdf_metadata_from_bytes(pdf_bytes: bytes) -> dict[str, Any]:
         pdf_doc = PDFDocument(parser)
         for info in pdf_doc.info:
             if isinstance(info, dict):
-                for key in ("Author", "Title", "CreationDate"):
+                for key in ("Author", "Title", "CreationDate", "ModDate"):
                     value = info.get(key)
                     if value is not None:
                         decoded = (
@@ -320,6 +351,129 @@ def _extract_pdf_metadata_from_bytes(pdf_bytes: bytes) -> dict[str, Any]:
         logger.debug("Could not extract PDF metadata")
 
     return metadata
+
+
+# PDF dates are encoded as ``D:YYYYMMDDHHmmSS+HH'mm'`` per ISO 32000.
+# We strip the literal ``D:`` prefix and the apostrophes in the
+# timezone, then hand the result to ``datetime.strptime`` with two
+# format candidates (with-tz and without). Returning ``None`` rather
+# than guessing matches the FEAT-031 contract.
+_PDF_DATE_FORMATS: tuple[str, ...] = (
+    "%Y%m%d%H%M%S%z",
+    "%Y%m%d%H%M%S",
+    "%Y%m%d%H%M",
+    "%Y%m%d",
+)
+
+
+def _parse_pdf_date(raw: str) -> datetime | None:
+    """Parse a ``/CreationDate`` or ``/ModDate`` value into a tz-aware datetime.
+
+    Accepts the canonical ``D:YYYYMMDDHHmmSS+HH'mm'`` format and a
+    couple of common truncations. Returns ``None`` when no candidate
+    matches — the caller falls through to the next field, never
+    guesses.
+    """
+    cleaned = raw.strip().removeprefix("D:")
+    # Strip the PDF spec's literal apostrophes from the tz offset:
+    # ``+05'00'`` → ``+0500`` so ``%z`` parses it.
+    cleaned = cleaned.replace("'", "")
+    if cleaned.endswith(("z", "Z")):
+        cleaned = cleaned[:-1] + "+0000"
+    for fmt in _PDF_DATE_FORMATS:
+        try:
+            parsed = datetime.strptime(cleaned, fmt)
+        except ValueError:
+            continue
+        try:
+            return parse_authored_at(parsed)
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_pdf_authored_at(metadata: dict[str, Any]) -> datetime | None:
+    """Resolve a PDF file's ``authored_at`` from extracted metadata.
+
+    Walks ``creationdate`` then ``moddate`` (matching the per-format
+    extraction chain in the FEAT-031 spec); each value is parsed via
+    :func:`_parse_pdf_date`. Returns ``None`` when both are absent or
+    unparseable.
+    """
+    for key in ("creationdate", "moddate"):
+        raw = metadata.get(key)
+        if not raw:
+            continue
+        parsed = _parse_pdf_date(str(raw))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+# RTF date control words follow ``\creatim`` / ``\revtim`` and embed
+# their fields via further control words (``\yr2024 \mo3 \dy15 \hr8
+# \min30 \sec0``) before the closing ``}``. The regex captures the
+# control word and the inner blob so the per-field parse can run on
+# the captured group.
+_RTF_DATE_GROUP = re.compile(
+    r"\\(creatim|revtim)\b([^}]*)",
+    re.IGNORECASE,
+)
+_RTF_DATE_FIELDS = (
+    ("yr", "year"),
+    ("mo", "month"),
+    ("dy", "day"),
+    ("hr", "hour"),
+    ("min", "minute"),
+    ("sec", "second"),
+)
+
+
+def _parse_rtf_authored_at(raw_bytes: bytes) -> datetime | None:
+    """Extract ``\\creatim`` (then ``\\revtim``) from an RTF byte stream.
+
+    RTF stores dates as a sequence of ``\\yr``/``\\mo``/``\\dy``/etc.
+    control words inside ``\\creatim{…}``. Returns a UTC-anchored
+    datetime when at least year + month + day were captured; falls
+    through to ``\\revtim`` if ``\\creatim`` is absent or unparseable.
+    The result is UTC because RTF carries no tz information — per the
+    FEAT-031 spec, that is the honest default rather than guessing.
+    """
+    try:
+        text = raw_bytes.decode("ascii", errors="replace")
+    except UnicodeDecodeError:
+        return None
+    candidates: dict[str, dict[str, int]] = {}
+    for match in _RTF_DATE_GROUP.finditer(text):
+        word = match.group(1).lower()
+        body = match.group(2)
+        fields: dict[str, int] = {}
+        for token, dest in _RTF_DATE_FIELDS:
+            sub = re.search(rf"\\{token}(-?\d+)", body)
+            if sub:
+                with contextlib.suppress(ValueError):
+                    fields[dest] = int(sub.group(1))
+        candidates[word] = fields
+    for word in ("creatim", "revtim"):
+        fields = candidates.get(word, {})
+        if not {"year", "month", "day"} <= fields.keys():
+            continue
+        try:
+            naive = datetime(
+                year=fields["year"],
+                month=fields["month"],
+                day=fields["day"],
+                hour=fields.get("hour", 0),
+                minute=fields.get("minute", 0),
+                second=fields.get("second", 0),
+            )
+        except (TypeError, ValueError):
+            continue
+        try:
+            return parse_authored_at(naive)
+        except ValueError:
+            continue
+    return None
 
 
 def _extract_pdf_metadata(pdf_bytes: bytes) -> dict[str, Any]:
@@ -452,6 +606,20 @@ class DocumentIngestor(Ingestor):
         Dispatches to DOCX, PDF, HTML, or TXT parsers based on the
         file extension. Extracts metadata where available.
 
+        FEAT-031: per-format ``authored_at`` extraction chains:
+
+        * **HTML / HTM**: ``<meta property="article:published_time">``,
+          OpenGraph, Dublin Core, ``<meta name="date">``, JSON-LD
+          ``datePublished``.
+        * **PDF**: ``/CreationDate`` (then ``/ModDate``) from the
+          document info dictionary.
+        * **DOCX**: core properties ``dcterms:created`` (then
+          ``dcterms:modified``).
+        * **RTF**: ``\\creatim`` (then ``\\revtim``).
+        * **TXT**: filesystem mtime only — no embedded date metadata
+          exists, so ``authored_at`` is ``None`` and downstream
+          surfaces fall through to ``ingested``.
+
         Args:
             raw: The raw document to parse.
 
@@ -463,6 +631,9 @@ class DocumentIngestor(Ingestor):
 
         content = self._extract_content(file_type, raw.content, text)
         metadata = self._extract_metadata(file_type, raw.content, encoding)
+        metadata["authored_at"] = self._extract_authored_at(
+            file_type, raw.content, text, metadata
+        )
         timestamp = self._resolve_timestamp(metadata, raw.path)
 
         return [
@@ -473,6 +644,36 @@ class DocumentIngestor(Ingestor):
                 timestamp=timestamp,
             )
         ]
+
+    def _extract_authored_at(
+        self,
+        file_type: str,
+        raw_bytes: bytes,
+        text: str,
+        metadata: dict[str, Any],
+    ) -> datetime | None:
+        """Route to per-format authored-date extraction (FEAT-031).
+
+        Returns ``None`` when no source date exists or the candidate
+        parsers fail. The TXT branch is the canonical "no embedded
+        metadata" case; HTML / PDF / DOCX / RTF each consult their
+        native metadata before falling through.
+        """
+        if file_type in {".html", ".htm"}:
+            raw_value = extract_html_authored_at(text)
+            if raw_value:
+                try:
+                    return parse_authored_at(raw_value)
+                except ValueError:
+                    return None
+            return None
+        if file_type == ".pdf":
+            return _parse_pdf_authored_at(metadata)
+        if file_type == ".docx":
+            return _parse_docx_authored_at(metadata)
+        if file_type == ".rtf":
+            return _parse_rtf_authored_at(raw_bytes)
+        return None
 
     def _extract_content(self, file_type: str, raw_bytes: bytes, text: str) -> str:
         """Extract content based on file type.
@@ -618,9 +819,13 @@ class DocumentIngestor(Ingestor):
         if fragment.metadata.get("scanned"):
             source["scanned"] = True
 
-        return {
+        frontmatter_dict: dict[str, Any] = {
             "type": "fragment",
             "title": title,
             "source": source,
             "created": fragment.timestamp.isoformat(),
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            frontmatter_dict["authored_at"] = authored_at.isoformat()
+        return frontmatter_dict

--- a/creek-tools/creek/ingest/html.py
+++ b/creek-tools/creek/ingest/html.py
@@ -6,9 +6,56 @@ otherwise form between :mod:`creek.ingest.documents` and
 :mod:`creek.ingest.substack`: both ingest HTML, and both should import
 the converter from a neutral module rather than reaching into each
 other's private API.
+
+FEAT-031: this module also hosts :func:`extract_html_authored_at` so
+HTML-emitting ingestors share a single extraction chain (Open Graph,
+``article:published_time``, ``DC.date``, JSON-LD ``datePublished``)
+without each rolling its own regex pile.
 """
 
 from __future__ import annotations
+
+import json
+import re
+
+# Regex for a single ``<meta name|property="..." content="...">`` tag.
+# We accept either ordering of name/property + content because real-world
+# HTML mixes the two; ``re.IGNORECASE | re.DOTALL`` covers multi-line
+# tags and arbitrary casing.
+_META_TAG = re.compile(
+    r"<meta\b[^>]*?\b(?:name|property|itemprop)\s*=\s*[\"']"
+    r"(?P<name>[^\"']+)[\"'][^>]*?\bcontent\s*=\s*[\"'](?P<content>[^\"']+)[\"']"
+    r"|"
+    r"<meta\b[^>]*?\bcontent\s*=\s*[\"'](?P<content2>[^\"']+)[\"'][^>]*?"
+    r"\b(?:name|property|itemprop)\s*=\s*[\"'](?P<name2>[^\"']+)[\"']",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# JSON-LD scripts may carry ``datePublished`` (single object or list).
+# We scan the raw script body rather than running a full HTML parser
+# because that's enough to recover the publication date and lets the
+# module stay stdlib-only.
+_JSON_LD_SCRIPT = re.compile(
+    r"<script[^>]*type\s*=\s*[\"']application/ld\+json[\"'][^>]*>(?P<body>.*?)</script>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Meta-tag keys we consider for the FEAT-031 ``authored_at`` chain,
+# in precedence order. Open-Graph and ``article:`` carry the truest
+# publish dates on Substack / WordPress / Medium / Ghost exports;
+# ``DC.date`` and friends cover older / academic sources; ``date``
+# is the lowest-fidelity catch-all.
+_HTML_AUTHORED_AT_META_KEYS: tuple[str, ...] = (
+    "article:published_time",
+    "og:published_time",
+    "dc.date.issued",
+    "dc.date",
+    "dcterms.created",
+    "dcterms.issued",
+    "pubdate",
+    "publish-date",
+    "date",
+)
 
 
 def parse_html_to_markdown(html: str) -> str:
@@ -36,3 +83,71 @@ def parse_html_to_markdown(html: str) -> str:
         raise ImportError(msg) from exc
     result: str = markdownify.markdownify(html, heading_style="ATX")
     return result
+
+
+def _collect_meta_dates(html: str) -> dict[str, str]:
+    """Scan ``<meta>`` tags and return a lowercase ``{key: content}`` map.
+
+    Later occurrences of the same key win — matches how a browser would
+    treat a duplicated tag — but FEAT-031 callers look up by precedence
+    so the ordering rarely matters.
+    """
+    found: dict[str, str] = {}
+    for match in _META_TAG.finditer(html):
+        name = (match.group("name") or match.group("name2") or "").strip().lower()
+        content = (match.group("content") or match.group("content2") or "").strip()
+        if name and content:
+            found[name] = content
+    return found
+
+
+def _collect_json_ld_date(html: str) -> str | None:
+    """Return the first ``datePublished`` found in any JSON-LD ``<script>``.
+
+    JSON-LD payloads may be a single object or a list (or even nested
+    under ``@graph``). We walk the simplest shapes — single object and
+    top-level list — because Substack / WordPress / Ghost stick to
+    them, and FEAT-031 is fine returning ``None`` for the long-tail
+    schemas it does not understand.
+    """
+    for match in _JSON_LD_SCRIPT.finditer(html):
+        body = match.group("body").strip()
+        if not body:
+            continue
+        try:
+            parsed = json.loads(body)
+        except (ValueError, json.JSONDecodeError):
+            continue
+        candidates: list[object] = (
+            [parsed] if isinstance(parsed, dict) else list(parsed)
+        )
+        for entry in candidates:
+            if isinstance(entry, dict):
+                value = entry.get("datePublished") or entry.get("dateCreated")
+                if isinstance(value, str) and value.strip():
+                    return value.strip()
+    return None
+
+
+def extract_html_authored_at(html: str) -> str | None:
+    """Return the source-side authored date string from HTML metadata.
+
+    FEAT-031 extraction chain (highest precedence first):
+
+    1. ``<meta property="article:published_time">`` /
+       ``<meta property="og:published_time">``.
+    2. Dublin Core variants (``DC.date.issued``, ``DC.date``,
+       ``DCTERMS.created``, ``DCTERMS.issued``).
+    3. Generic ``<meta name="pubdate">`` / ``publish-date`` / ``date``.
+    4. JSON-LD ``datePublished`` from any ``application/ld+json`` block.
+
+    Returns the raw string for the caller to feed into
+    :func:`creek.ingest.base.parse_authored_at` — keeps this module
+    free of timezone helpers and avoids an import cycle.
+    """
+    metas = _collect_meta_dates(html)
+    for key in _HTML_AUTHORED_AT_META_KEYS:
+        value = metas.get(key)
+        if value:
+            return value
+    return _collect_json_ld_date(html)

--- a/creek-tools/creek/ingest/images.py
+++ b/creek-tools/creek/ingest/images.py
@@ -33,7 +33,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol, runtime_checkable
 
-from creek.ingest.base import Ingestor, ParsedFragment, RawDocument
+from creek.ingest.base import (
+    Ingestor,
+    ParsedFragment,
+    RawDocument,
+    parse_authored_at,
+)
 from creek.models import SourcePlatform
 
 logger = logging.getLogger(__name__)
@@ -390,6 +395,12 @@ class ImageIngestor(Ingestor):
         than a fragment with an empty body — empty fragments would
         clutter the vault without carrying signal.
 
+        FEAT-031: when EXIF carries ``DateTimeOriginal`` (the moment
+        the shutter fired) the fragment records it on ``authored_at``;
+        falls through to ``DateTime`` (modified) as the next-best
+        source date, and to ``None`` when neither exists or Pillow is
+        unavailable. The filesystem mtime is never substituted.
+
         Raises:
             PytesseractUnavailableError: When the default
                 :class:`PytesseractOcrEngine` is in use and
@@ -411,6 +422,7 @@ class ImageIngestor(Ingestor):
             "ocr_confidence": result.confidence,
             "image_type": result.image_type,
             "language": self.language,
+            "authored_at": _extract_exif_authored_at(raw.path),
         }
         self._tag_low_confidence(metadata, result.confidence)
         return [
@@ -455,7 +467,13 @@ class ImageIngestor(Ingestor):
         return f"{embed}\n\n{fragment.content.strip()}\n"
 
     def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
-        """Produce the YAML frontmatter for an OCR'd image fragment."""
+        """Produce the YAML frontmatter for an OCR'd image fragment.
+
+        FEAT-031: ``authored_at`` (from EXIF ``DateTimeOriginal`` or
+        ``DateTime``) is rendered as ISO when extracted; absent
+        otherwise so downstream readers fall through to the
+        ``Fragment.authored_at = None`` default.
+        """
         frontmatter: dict[str, Any] = {
             "type": "fragment",
             "source": {
@@ -473,6 +491,9 @@ class ImageIngestor(Ingestor):
         review_marker = fragment.metadata.get(_REVIEW_FRONTMATTER_KEY)
         if review_marker:
             frontmatter[_REVIEW_FRONTMATTER_KEY] = review_marker
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            frontmatter["authored_at"] = authored_at.isoformat()
         return frontmatter
 
     def ingest_pdf(self, pdf_path: Path) -> list[ParsedFragment]:
@@ -521,6 +542,78 @@ class ImageIngestor(Ingestor):
 def _modified_time(path: Path) -> datetime:
     """Return the file's mtime as a timezone-aware UTC datetime."""
     return datetime.fromtimestamp(path.stat().st_mtime, tz=UTC)
+
+
+# EXIF tag IDs — magic numbers chosen by the standard, not by us. Hard-coded
+# rather than ``ExifTags.TAGS`` lookup so the Pillow import can stay deferred.
+_EXIF_DATETIME_ORIGINAL_TAG_ID: int = 36867  # DateTimeOriginal
+_EXIF_DATETIME_TAG_ID: int = 306  # DateTime
+
+# EXIF stores dates in the format ``"YYYY:MM:DD HH:MM:SS"`` (note the
+# colons separating the date components — non-ISO and a frequent source
+# of bugs in naïve implementations).
+_EXIF_DATETIME_FORMAT: str = "%Y:%m:%d %H:%M:%S"
+
+
+def _extract_exif_authored_at(path: Path) -> datetime | None:
+    """Read EXIF ``DateTimeOriginal`` (then ``DateTime``) from an image.
+
+    FEAT-031: returns the shutter-fired moment as a UTC-defaulted
+    tz-aware datetime, or ``None`` when neither tag exists, Pillow is
+    unavailable, or the image carries no EXIF data (PNGs / WebPs
+    often don't). The filesystem mtime is never substituted —
+    downstream surfaces fall through to :attr:`Fragment.ingested`.
+
+    EXIF datetimes are naive in the standard (no tz info); we localise
+    to UTC per the FEAT-031 spec rather than guessing the camera's
+    local zone. Cross-tz wall-clock accuracy is out of scope until an
+    ingestor parses the (separate) EXIF ``OffsetTimeOriginal`` tag.
+    """
+    exif = _load_image_exif(path)
+    if exif is None:
+        return None
+    for tag_id in (_EXIF_DATETIME_ORIGINAL_TAG_ID, _EXIF_DATETIME_TAG_ID):
+        candidate = _exif_tag_to_authored_at(exif.get(tag_id))
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _load_image_exif(path: Path) -> Any | None:
+    """Open *path* via Pillow and return its EXIF mapping (or ``None``).
+
+    Centralising the optional-Pillow import + file-open failure modes
+    here keeps :func:`_extract_exif_authored_at` linear and below the
+    project's per-function try-block cap.
+    """
+    try:  # noqa: TRY101  # Separate optional-dep absence from file-open failure.
+        from PIL import Image
+    except ImportError:
+        return None
+    try:  # noqa: TRY101  # Distinct failure mode from the ImportError branch.
+        with Image.open(path) as image:
+            return image.getexif()
+    except Exception:  # Pillow raises a wide set on bad files
+        return None
+
+
+def _exif_tag_to_authored_at(raw_value: object) -> datetime | None:
+    """Parse a raw EXIF date tag into a tz-aware datetime (or ``None``).
+
+    Handles two failure modes — bad EXIF string format and
+    :func:`parse_authored_at` rejection — without exposing more than
+    one try block.
+    """
+    if not raw_value:
+        return None
+    try:  # noqa: TRY101  # Separate EXIF string-format from parse_authored_at.
+        naive = datetime.strptime(str(raw_value), _EXIF_DATETIME_FORMAT)
+    except (TypeError, ValueError):
+        return None
+    try:  # noqa: TRY101  # Distinct failure mode from the format check above.
+        return parse_authored_at(naive)
+    except ValueError:
+        return None
 
 
 __all__ = [

--- a/creek-tools/creek/ingest/markdown.py
+++ b/creek-tools/creek/ingest/markdown.py
@@ -28,6 +28,7 @@ from creek.ingest.base import (
     RawDocument,
     normalize_encoding,
     normalize_timestamp,
+    parse_authored_at,
 )
 from creek.models import SourcePlatform
 
@@ -211,6 +212,55 @@ def _extract_timestamp_from_frontmatter(fm_data: dict[str, Any]) -> str | None:
     return None
 
 
+# FEAT-031: authored-date precedence specific to Markdown sources.
+# ``published`` wins because a user-asserted publication date is the
+# truest source-side timestamp; ``date`` and ``created`` are common
+# author-supplied aliases. We deliberately do NOT consider
+# ``created_at``/``modified``/``updated`` — those track later edits,
+# not the original authoring moment.
+_MARKDOWN_AUTHORED_AT_KEYS: tuple[str, ...] = ("published", "date", "created")
+
+
+def _extract_authored_at_from_frontmatter(fm_data: dict[str, Any]) -> datetime | None:
+    """Resolve the source-authored timestamp from a markdown file's frontmatter.
+
+    Walks :data:`_MARKDOWN_AUTHORED_AT_KEYS` in order and returns the
+    first parseable value as a timezone-aware datetime. Returns
+    ``None`` when no key is present or every candidate fails to parse
+    — never guesses, per the FEAT-031 contract.
+
+    Values are routed through :func:`parse_authored_at` so the source
+    timezone is preserved (or UTC-defaulted) per the FEAT-031 spec.
+    Using the LA-anchored :func:`normalize_timestamp` here would shift
+    a bare ``published: 2024-03-15`` to 2024-03-14 17:00 PDT — wrong
+    answer for an authored date.
+
+    Args:
+        fm_data: The parsed frontmatter dictionary.
+
+    Returns:
+        A tz-aware datetime when a parseable field is present, else
+        ``None``.
+    """
+    for key in _MARKDOWN_AUTHORED_AT_KEYS:
+        value = fm_data.get(key)
+        if value is None:
+            continue
+        try:
+            parsed = parse_authored_at(value)
+        except ValueError:
+            logger.warning(
+                "Markdown frontmatter %r=%r is not parseable as a date; "
+                "skipping for authored_at.",
+                key,
+                value,
+            )
+            continue
+        if parsed is not None:
+            return parsed
+    return None
+
+
 def _get_file_creation_timestamp(path: Path) -> datetime:
     """Get the file creation timestamp from filesystem metadata.
 
@@ -313,6 +363,14 @@ class MarkdownIngestor(Ingestor):
         the markdown body. Detects document type from content patterns
         and extracts a timestamp from frontmatter or filesystem metadata.
 
+        FEAT-031: when frontmatter carries a ``published`` / ``date`` /
+        ``created`` field that parses cleanly, the resulting datetime
+        is stashed on ``ParsedFragment.metadata['authored_at']`` so
+        :meth:`generate_frontmatter` can promote it into the Creek
+        fragment. ``None`` is the honest answer when no such field
+        exists — the filesystem mtime is *not* a substitute (it lives
+        in :attr:`ParsedFragment.timestamp` for ID hashing only).
+
         Args:
             raw: The raw document to parse.
 
@@ -323,6 +381,7 @@ class MarkdownIngestor(Ingestor):
         fm_data, content = self._parse_frontmatter(text)
         document_type = _detect_document_type(content)
         timestamp = self._resolve_timestamp(fm_data, raw.path)
+        authored_at = _extract_authored_at_from_frontmatter(fm_data)
 
         return [
             ParsedFragment(
@@ -330,6 +389,7 @@ class MarkdownIngestor(Ingestor):
                 metadata={
                     "existing_frontmatter": fm_data,
                     "document_type": document_type,
+                    "authored_at": authored_at,
                 },
                 source_path=str(raw.path),
                 timestamp=timestamp,
@@ -420,6 +480,13 @@ class MarkdownIngestor(Ingestor):
             },
             "created": fragment.timestamp.isoformat(),
         }
+
+        # FEAT-031: surface the frontmatter-derived authored date when
+        # we have one. ``None`` is omitted rather than serialised so
+        # downstream readers fall through to the model default.
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            creek_defaults["authored_at"] = authored_at.isoformat()
 
         return _merge_frontmatter(creek_defaults, existing_fm)
 

--- a/creek-tools/creek/ingest/presentations.py
+++ b/creek-tools/creek/ingest/presentations.py
@@ -29,10 +29,12 @@ from creek.ingest.base import (
     ParsedFragment,
     RawDocument,
     file_modified_time,
+    parse_authored_at,
 )
 from creek.models import SourcePlatform
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -164,6 +166,60 @@ class PythonPptxBackend:
         return stripped or None
 
 
+def _extract_pptx_authored_at(path: Path) -> datetime | None:
+    """Read the PPTX core-properties ``created`` (then ``modified``).
+
+    FEAT-031: returns the deck's source-side authored date or
+    ``None`` when neither field is populated, when ``python-pptx``
+    is unavailable, or when the file is malformed. Filesystem mtime
+    is never substituted — :attr:`Fragment.ingested` is the honest
+    fallback chosen by downstream surfaces.
+    """
+    props = _open_pptx_core_properties(path)
+    if props is None:
+        return None
+    for candidate in (
+        getattr(props, "created", None),
+        getattr(props, "modified", None),
+    ):
+        parsed = _safe_parse_authored_at(candidate)
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def _open_pptx_core_properties(path: Path) -> Any | None:
+    """Open *path* via python-pptx and return ``core_properties`` (or ``None``).
+
+    Centralises the optional-import + file-open + attribute-lookup
+    failure modes so :func:`_extract_pptx_authored_at` stays linear and
+    below the per-function try-block cap.
+    """
+    try:  # noqa: TRY101  # Separate optional-dep absence from file-open failure.
+        from pptx import Presentation as _Presentation
+    except ImportError:
+        return None
+    try:  # noqa: TRY101  # Distinct failure mode from the ImportError branch.
+        prs = _Presentation(str(path))
+    except Exception:  # python-pptx raises a wide set on bad files
+        logger.debug("Could not open PPTX core properties for %s", path)
+        return None
+    try:  # noqa: TRY101  # AttributeError is a distinct failure mode from file-open.
+        return prs.core_properties
+    except AttributeError:
+        return None
+
+
+def _safe_parse_authored_at(candidate: object) -> datetime | None:
+    """Wrapper that swallows :class:`ValueError` from ``parse_authored_at``."""
+    if candidate is None:
+        return None
+    try:
+        return parse_authored_at(candidate)
+    except ValueError:
+        return None
+
+
 def _slide_to_data(slide: Any, index: int) -> SlideData:
     """Convert a python-pptx slide object into a :class:`SlideData`."""
     title: str | None = None
@@ -233,7 +289,13 @@ class PresentationIngestor(Ingestor):
         ]
 
     def parse(self, raw: RawDocument) -> list[ParsedFragment]:
-        """Emit a single fragment carrying the entire presentation."""
+        """Emit a single fragment carrying the entire presentation.
+
+        FEAT-031: the PPTX core properties ``created`` (then
+        ``modified``) become ``authored_at``. Falls through to
+        ``None`` when the deck carries no creation date or when
+        ``python-pptx`` is unavailable.
+        """
         data = self.backend.read_presentation(raw.path)
         if not data.slides:
             logger.info(
@@ -242,6 +304,7 @@ class PresentationIngestor(Ingestor):
             )
             return []
         timestamp = file_modified_time(raw.path)
+        authored_at = _extract_pptx_authored_at(raw.path)
         return [
             ParsedFragment(
                 content="",  # Markdown rendered in convert_to_markdown.
@@ -249,6 +312,7 @@ class PresentationIngestor(Ingestor):
                     "original_file": str(raw.path),
                     "title": data.title or raw.path.stem,
                     "slide_count": len(data.slides),
+                    "authored_at": authored_at,
                 },
                 source_path=str(raw.path),
                 timestamp=timestamp,
@@ -283,8 +347,13 @@ class PresentationIngestor(Ingestor):
         return "\n".join(lines).rstrip() + "\n"
 
     def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
-        """Produce YAML frontmatter for a presentation fragment."""
-        return {
+        """Produce YAML frontmatter for a presentation fragment.
+
+        FEAT-031: the deck's PPTX core-properties ``created`` /
+        ``modified`` land on ``authored_at`` as an ISO string when
+        extracted; absent otherwise.
+        """
+        frontmatter_dict: dict[str, Any] = {
             "type": "fragment",
             "source": {
                 "platform": SourcePlatform.PRESENTATION.value,
@@ -297,6 +366,10 @@ class PresentationIngestor(Ingestor):
             "slide_count": fragment.metadata.get("slide_count", 0),
             "ingested": fragment.timestamp.isoformat(),
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            frontmatter_dict["authored_at"] = authored_at.isoformat()
+        return frontmatter_dict
 
 
 __all__ = [

--- a/creek-tools/creek/ingest/refresh.py
+++ b/creek-tools/creek/ingest/refresh.py
@@ -1,0 +1,282 @@
+"""FEAT-031 backfill: populate ``Fragment.authored_at`` on existing fragments.
+
+This module implements the ``creek ingest --refresh-dates`` workflow:
+walk a vault's ``01-Fragments/`` tree, look up each fragment's
+original source file, re-run the per-format ``authored_at`` extraction
+chain, and rewrite the fragment's YAML frontmatter in place — without
+touching the body or any other metadata.
+
+Idempotency is by construction:
+
+* Fragments that already carry an ``authored_at`` are skipped.
+* Fragments whose ``source.original_file`` cannot be located on disk
+  are skipped (and counted).
+* The extraction chains used here are the same per-format helpers
+  the ingestors call at first-ingest time, so a successful backfill
+  produces the same ``authored_at`` a fresh ingest would.
+
+Out of scope for v1:
+
+* Chat-style sources (ChatGPT, Claude, Discord) where the
+  ``original_file`` is a multi-conversation JSON export — recovering
+  the per-turn ``authored_at`` would require re-pairing turns to
+  fragment IDs. These fragments are reported as ``skipped`` so an
+  operator knows to re-ingest the export instead.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path  # runtime use in type hints
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.ingest.documents import (
+    _extract_docx_metadata,
+    _extract_pdf_metadata,
+    _parse_docx_authored_at,
+    _parse_pdf_authored_at,
+    _parse_rtf_authored_at,
+)
+from creek.ingest.html import extract_html_authored_at
+from creek.ingest.images import _extract_exif_authored_at
+from creek.ingest.markdown import _extract_authored_at_from_frontmatter
+from creek.ingest.presentations import _extract_pptx_authored_at
+from creek.ingest.spreadsheets import _extract_xlsx_authored_at
+from creek.vault.reader import try_load_fragment
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RefreshDatesResult:
+    """Summary of a :func:`refresh_authored_dates` run.
+
+    Attributes:
+        scanned: Total fragments inspected (skipped + updated + already_set
+            + missing_source + unsupported all sum to this).
+        already_set: Fragments that already had ``authored_at`` populated;
+            left untouched.
+        updated: Fragments where the backfill extracted a new
+            ``authored_at`` and rewrote the file.
+        no_date_found: Source file was located and inspected but no
+            extractable date was present (``authored_at`` remains ``None``).
+        missing_source: ``source.original_file`` was empty or pointed at
+            a path that no longer exists on disk.
+        unsupported: Source format (chat JSON, generic blob, …) is not
+            yet handled by the backfill.
+        errors: Human-readable per-fragment failure messages.
+    """
+
+    scanned: int = 0
+    already_set: int = 0
+    updated: int = 0
+    no_date_found: int = 0
+    missing_source: int = 0
+    unsupported: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+# Extension → callback for per-format authored-date extraction. The
+# callback receives the source ``Path`` and returns ``datetime | None``.
+# Keeping this as a table (rather than nested if/elif) keeps the dispatch
+# loop's cyclomatic complexity flat as new formats are added.
+def _markdown_authored_at_from_file(path: Path) -> datetime | None:
+    """Re-run the markdown frontmatter chain against a single source file."""
+    post = frontmatter.load(str(path))
+    return _extract_authored_at_from_frontmatter(post.metadata)
+
+
+def _html_authored_at_from_file(path: Path) -> datetime | None:
+    """Re-run the HTML metadata chain against a single source file."""
+    from creek.ingest.base import parse_authored_at
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    raw_value = extract_html_authored_at(text)
+    if not raw_value:
+        return None
+    try:  # noqa: TRY101  # Separate I/O failure from date-parse failure.
+        return parse_authored_at(raw_value)
+    except ValueError:
+        return None
+
+
+def _pdf_authored_at_from_file(path: Path) -> datetime | None:
+    """Re-run the PDF metadata chain against a single source file."""
+    try:
+        pdf_bytes = path.read_bytes()
+    except OSError:
+        return None
+    metadata = _extract_pdf_metadata(pdf_bytes)
+    return _parse_pdf_authored_at(metadata)
+
+
+def _docx_authored_at_from_file(path: Path) -> datetime | None:
+    """Re-run the DOCX metadata chain against a single source file."""
+    try:
+        docx_bytes = path.read_bytes()
+    except OSError:
+        return None
+    metadata = _extract_docx_metadata(docx_bytes)
+    return _parse_docx_authored_at(metadata)
+
+
+def _rtf_authored_at_from_file(path: Path) -> datetime | None:
+    """Re-run the RTF control-word chain against a single source file."""
+    try:
+        return _parse_rtf_authored_at(path.read_bytes())
+    except OSError:
+        return None
+
+
+def _txt_authored_at_from_file(_path: Path) -> datetime | None:
+    """TXT files carry no embedded date metadata (FEAT-031 ``None``)."""
+    return None
+
+
+_AuthoredAtHandler = Callable[[Path], "datetime | None"]
+
+_EXTENSION_HANDLERS: dict[str, _AuthoredAtHandler] = {
+    ".md": _markdown_authored_at_from_file,
+    ".markdown": _markdown_authored_at_from_file,
+    ".html": _html_authored_at_from_file,
+    ".htm": _html_authored_at_from_file,
+    ".pdf": _pdf_authored_at_from_file,
+    ".docx": _docx_authored_at_from_file,
+    ".rtf": _rtf_authored_at_from_file,
+    ".txt": _txt_authored_at_from_file,
+    ".xlsx": _extract_xlsx_authored_at,
+    ".pptx": _extract_pptx_authored_at,
+    ".png": _extract_exif_authored_at,
+    ".jpg": _extract_exif_authored_at,
+    ".jpeg": _extract_exif_authored_at,
+    ".gif": _extract_exif_authored_at,
+    ".bmp": _extract_exif_authored_at,
+    ".tiff": _extract_exif_authored_at,
+    ".webp": _extract_exif_authored_at,
+}
+
+
+def _resolve_authored_at_for_source(source: Path) -> datetime | None:
+    """Dispatch a source path to the right per-format extraction helper.
+
+    Returns ``None`` when the extension is unsupported or the helper
+    fails — the caller distinguishes "no date found" from "unsupported
+    format" via the absence of a handler for the extension.
+    """
+    handler = _EXTENSION_HANDLERS.get(source.suffix.lower())
+    if handler is None:
+        return None
+    try:
+        return handler(source)
+    except Exception:  # per-format helpers raise wide errors
+        logger.exception("Backfill helper failed for %s", source)
+        return None
+
+
+def _is_supported_extension(source: Path) -> bool:
+    """Return whether *source*'s extension has a registered handler."""
+    return source.suffix.lower() in _EXTENSION_HANDLERS
+
+
+def refresh_authored_dates(vault_path: Path) -> RefreshDatesResult:
+    """Backfill ``Fragment.authored_at`` across a vault's fragment tree.
+
+    Walks ``vault_path/01-Fragments/`` recursively, re-runs the
+    per-format ``authored_at`` extraction chain against each fragment's
+    original source file, and rewrites the fragment file with the
+    populated ``authored_at`` (preserving body and every other
+    frontmatter field).
+
+    Idempotent: fragments that already have ``authored_at`` are
+    skipped, and a second invocation against a freshly backfilled
+    vault is a no-op on every fragment.
+
+    Args:
+        vault_path: Path to the vault root (the directory containing
+            ``01-Fragments/``).
+
+    Returns:
+        A :class:`RefreshDatesResult` summarising what changed.
+    """
+    result = RefreshDatesResult()
+    fragments_root = vault_path / "01-Fragments"
+    if not fragments_root.exists():
+        return result
+
+    for md_file in sorted(fragments_root.rglob("*.md")):
+        result.scanned += 1
+        try:
+            _process_fragment(md_file, result)
+        except Exception as exc:  # per-fragment isolation
+            logger.exception("Backfill failed for %s", md_file)
+            result.errors.append(f"{md_file}: {exc}")
+    return result
+
+
+def _process_fragment(md_file: Path, result: RefreshDatesResult) -> None:
+    """Inspect one fragment file, update its ``authored_at`` if possible.
+
+    Each branch updates exactly one counter on *result* so the summary
+    accurately reflects the disposition of every scanned fragment.
+    """
+    record = try_load_fragment(md_file)
+    if record is None:
+        # Non-fragment markdown coexists in the vault tree (digests,
+        # notes); ignore silently.
+        result.scanned -= 1
+        return
+    fragment, _body, raw_metadata = record
+
+    if fragment.authored_at is not None:
+        result.already_set += 1
+        return
+
+    source_path_str = fragment.source.original_file or ""
+    if not source_path_str:
+        result.missing_source += 1
+        return
+
+    source_path = Path(source_path_str)
+    if not source_path.exists():
+        result.missing_source += 1
+        return
+
+    if not _is_supported_extension(source_path):
+        # Chat / Discord JSON exports and other multi-fragment sources:
+        # the per-format helpers cannot map back to a single turn, so
+        # surface as ``unsupported`` rather than miscount as a missing
+        # source.
+        result.unsupported += 1
+        return
+
+    extracted = _resolve_authored_at_for_source(source_path)
+    if extracted is None:
+        result.no_date_found += 1
+        return
+
+    raw_metadata["authored_at"] = extracted.isoformat()
+    _rewrite_frontmatter(md_file, raw_metadata)
+    result.updated += 1
+
+
+def _rewrite_frontmatter(md_file: Path, metadata: dict[str, object]) -> None:
+    """Persist *metadata* to *md_file* while leaving the body untouched.
+
+    Uses ``frontmatter.load`` to retain the original body bytes,
+    swaps in the updated metadata dict, and writes via the same
+    helper so YAML formatting stays consistent with the rest of the
+    vault.
+    """
+    post = frontmatter.load(str(md_file))
+    post.metadata = metadata
+    md_file.write_text(frontmatter.dumps(post) + "\n", encoding="utf-8")

--- a/creek-tools/creek/ingest/spreadsheets.py
+++ b/creek-tools/creek/ingest/spreadsheets.py
@@ -36,6 +36,7 @@ from creek.ingest.base import (
     ParsedFragment,
     RawDocument,
     file_modified_time,
+    parse_authored_at,
 )
 from creek.models import SourcePlatform
 
@@ -211,6 +212,59 @@ def _cell_to_str(value: Any) -> str:
     return str(value)
 
 
+def _extract_xlsx_authored_at(path: Path) -> datetime | None:
+    """Read an XLSX file's core-properties ``created`` (then ``modified``).
+
+    FEAT-031: returns the spreadsheet's source-side authored date or
+    ``None`` when neither field is populated. CSV files (which carry
+    no core properties) and missing-openpyxl environments both
+    return ``None`` — the honest answer when no extractable date
+    exists; the filesystem mtime is never substituted here.
+    """
+    if path.suffix.lower() != ".xlsx":
+        return None
+    workbook = _open_xlsx(path)
+    if workbook is None:
+        return None
+    try:
+        props = workbook.properties
+        for candidate in (props.created, props.modified):
+            parsed = _safe_parse_authored_at(candidate)
+            if parsed is not None:
+                return parsed
+    finally:
+        workbook.close()
+    return None
+
+
+def _open_xlsx(path: Path) -> Any | None:
+    """Open *path* via openpyxl read-only, swallowing the wide error set.
+
+    Centralising the optional-import + file-open paths here keeps
+    :func:`_extract_xlsx_authored_at` linear and below the project's
+    per-function try-block cap.
+    """
+    try:  # noqa: TRY101  # Separate optional-dep absence from file-open failure.
+        import openpyxl
+    except ImportError:
+        return None
+    try:  # noqa: TRY101  # Distinct failure mode from the ImportError branch.
+        return openpyxl.load_workbook(path, read_only=True)
+    except Exception:  # BadZipFile / InvalidFile / OSError / KeyError
+        logger.debug("Could not open XLSX core properties for %s", path)
+        return None
+
+
+def _safe_parse_authored_at(candidate: object) -> datetime | None:
+    """Wrapper that swallows :class:`ValueError` from ``parse_authored_at``."""
+    if candidate is None:
+        return None
+    try:
+        return parse_authored_at(candidate)
+    except ValueError:
+        return None
+
+
 CSV_CHARDET_CONFIDENCE_THRESHOLD: float = 0.7
 """Minimum ``chardet`` confidence required to trust an auto-detected encoding.
 
@@ -372,9 +426,16 @@ class SpreadsheetIngestor(Ingestor):
         heuristic; ``True`` / ``False`` force the first row to be
         treated as headers / data respectively, in every sheet of the
         workbook.
+
+        FEAT-031: when the workbook is an XLSX, the spreadsheet's core
+        properties ``created`` (then ``modified``) become
+        ``authored_at`` on every sheet's fragment. CSV files carry no
+        authored-date metadata so they fall through to ``None`` — the
+        filesystem mtime is *not* a substitute.
         """
         workbook = self.backend.read_workbook(raw.path, has_header=has_header)
         timestamp = file_modified_time(raw.path)
+        authored_at = _extract_xlsx_authored_at(raw.path)
         fragments: list[ParsedFragment] = []
         for sheet in workbook.sheets:
             if sheet.is_empty:
@@ -392,6 +453,7 @@ class SpreadsheetIngestor(Ingestor):
                         "sheet": sheet.name,
                         "rows": len(sheet.rows),
                         "columns": column_count,
+                        "authored_at": authored_at,
                     },
                     source_path=str(raw.path),
                     timestamp=timestamp,
@@ -415,8 +477,14 @@ class SpreadsheetIngestor(Ingestor):
         return "\n".join(lines) + "\n"
 
     def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
-        """Produce YAML frontmatter for a spreadsheet fragment."""
-        return {
+        """Produce YAML frontmatter for a spreadsheet fragment.
+
+        FEAT-031: ``authored_at`` (XLSX core properties ``created`` /
+        ``modified``) lands on the frontmatter as an ISO string when
+        present; absent for CSV and for XLSX files whose core
+        properties carry no creation date.
+        """
+        frontmatter_dict: dict[str, Any] = {
             "type": "fragment",
             "source": {
                 "platform": SourcePlatform.SPREADSHEET.value,
@@ -430,6 +498,10 @@ class SpreadsheetIngestor(Ingestor):
             "columns": fragment.metadata.get("columns", 0),
             "ingested": fragment.timestamp.isoformat(),
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            frontmatter_dict["authored_at"] = authored_at.isoformat()
+        return frontmatter_dict
 
 
 def _extract_headers_and_rows(

--- a/creek-tools/creek/ingest/substack.py
+++ b/creek-tools/creek/ingest/substack.py
@@ -45,7 +45,7 @@ from creek.ingest.base import (
     RawDocument,
     file_modified_time,
     normalize_encoding,
-    normalize_timestamp,
+    parse_authored_at,
 )
 from creek.ingest.html import parse_html_to_markdown
 from creek.models import SourceKind, SourcePlatform
@@ -204,7 +204,7 @@ def _resolve_authored_at(
     raw_date = (row or {}).get("post_date", "").strip()
     if raw_date:
         try:
-            authored = normalize_timestamp(raw_date, None)
+            authored = parse_authored_at(raw_date)
         except ValueError:
             logger.warning(
                 "Substack posts.csv row for %s has unparseable post_date %r",
@@ -212,7 +212,8 @@ def _resolve_authored_at(
                 raw_date,
             )
         else:
-            return authored, authored
+            if authored is not None:
+                return authored, authored
     return None, file_modified_time(file_path)
 
 

--- a/creek-tools/creek/link/temporal.py
+++ b/creek-tools/creek/link/temporal.py
@@ -1,9 +1,14 @@
-"""Temporal proximity linker — find fragments created near each other in time.
+"""Temporal proximity linker — find fragments authored near each other in time.
 
 Provides ``TemporalLink`` (a Pydantic model for scored temporal links) and
 ``TemporalLinker`` which groups fragments by configurable time windows,
 identifies cross-source pairs, and scores overlap across multiple
 classification dimensions.
+
+Time-bucketing uses :func:`creek.time.effective_authored_at` (FEAT-031)
+so cross-year synchronicities surface — a 2024 essay and a 2026 chat
+message can be paired because both are anchored to their source-side
+authored dates rather than the vault-write timestamp.
 """
 
 from __future__ import annotations
@@ -12,6 +17,8 @@ import logging
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
+
+from creek.time import effective_authored_at
 
 if TYPE_CHECKING:
     from creek.models import Fragment
@@ -35,6 +42,13 @@ class TemporalLink(BaseModel):
     fragment_a_id: str
     fragment_b_id: str
     time_delta_hours: float
+    """Hours between the fragments' effective authored datetimes (FEAT-031).
+
+    Computed from :func:`creek.time.effective_authored_at` — the
+    ``authored_at`` field when extracted, falling back to ``ingested``.
+    Previously this used ``created`` directly, which conflated
+    source-authored date and filesystem mtime.
+    """
     overlap_score: float
     shared_dimensions: list[str]
 
@@ -129,16 +143,18 @@ class TemporalLinker:
     def find_temporal_links(
         self, fragments: list[Fragment], window_hours: int
     ) -> list[TemporalLink]:
-        """Find fragment pairs created within a time window with thematic overlap.
+        """Find fragment pairs authored within a time window with thematic overlap.
 
-        Fragments are sorted chronologically, then each pair from different
-        sources within the window is scored across frequency, wavelength,
-        mode, emotional texture, and source dimensions.
+        Fragments are sorted by effective authored datetime (FEAT-031:
+        ``authored_at`` when present, ``ingested`` otherwise), then
+        each pair from different sources within the window is scored
+        across frequency, wavelength, mode, emotional texture, and
+        source dimensions.
 
         Args:
             fragments: List of fragments to check for temporal proximity.
-            window_hours: Maximum hours between creation times to consider
-                fragments temporally linked.
+            window_hours: Maximum hours between effective authored
+                datetimes to consider fragments temporally linked.
 
         Returns:
             A list of ``TemporalLink`` objects for each qualifying pair,
@@ -156,12 +172,12 @@ class TemporalLinker:
         if len(fragments) < min_pair_size:
             return []
 
-        sorted_frags = sorted(fragments, key=lambda f: f.created)
+        sorted_frags = sorted(fragments, key=effective_authored_at)
         links: list[TemporalLink] = []
 
         for i, frag_a in enumerate(sorted_frags):
             for frag_b in sorted_frags[i + 1 :]:
-                delta = frag_b.created - frag_a.created
+                delta = effective_authored_at(frag_b) - effective_authored_at(frag_a)
                 delta_hours = delta.total_seconds() / 3600.0
 
                 if delta_hours > window_hours:

--- a/creek-tools/creek/time.py
+++ b/creek-tools/creek/time.py
@@ -15,7 +15,11 @@ giving callers a dependency-free home for the helper.
 from __future__ import annotations
 
 from datetime import date, datetime
+from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
+
+if TYPE_CHECKING:
+    from creek.models import Fragment
 
 LA_TZ = ZoneInfo("America/Los_Angeles")
 """Target timezone for all normalized timestamps (America/Los_Angeles)."""
@@ -29,3 +33,56 @@ def now_la() -> datetime:
 def today_la() -> date:
     """Return today's date as observed in America/Los_Angeles."""
     return now_la().date()
+
+
+def effective_authored_at(fragment: Fragment) -> datetime:
+    """Return the datetime a fragment should be time-bucketed under (FEAT-031).
+
+    Single source of truth for the authored-date precedence pinned by
+    FEAT-031: every downstream surface that buckets fragments by time —
+    the State report, the wavelength tracker, the temporal linker, any
+    future "what changed this week" view — MUST route through this
+    helper so the precedence stays consistent.
+
+    Precedence (highest to lowest):
+
+    1. :attr:`Fragment.authored_at` when the ingestor extracted a
+       source-side timestamp (a Substack post's ``post_date``, a
+       Discord message's ``timestamp``, an EXIF ``DateTimeOriginal``).
+    2. :attr:`Fragment.ingested` — the wall-clock moment the vault
+       wrote the fragment. Always present, never naive.
+
+    :attr:`Fragment.created` is deliberately not in the chain:
+    historically it conflated "source authored date" and "filesystem
+    mtime" (and frequently defaulted to wall-clock at parse time), so
+    bucketing on it produced the misleading behaviour FEAT-031 exists
+    to fix — a 2024 essay registering as part of *this week's* vault
+    activity. ``ingested`` is the honest fallback because it answers
+    a different question ("when did Creek see this?") without
+    pretending to know the authored date.
+
+    Args:
+        fragment: The fragment to bucket.
+
+    Returns:
+        ``authored_at`` when populated, otherwise ``ingested``.
+    """
+    if fragment.authored_at is not None:
+        return fragment.authored_at
+    return fragment.ingested
+
+
+def effective_authored_date(fragment: Fragment) -> date:
+    """Return the date a fragment should be time-bucketed under (FEAT-031).
+
+    Convenience wrapper around :func:`effective_authored_at` for
+    callers that only need the date (week / month / year aggregates).
+    See :func:`effective_authored_at` for the precedence contract.
+
+    Args:
+        fragment: The fragment to bucket.
+
+    Returns:
+        The local date component of the effective authored datetime.
+    """
+    return effective_authored_at(fragment).date()

--- a/creek-tools/tests/test_chatgpt_ingest.py
+++ b/creek-tools/tests/test_chatgpt_ingest.py
@@ -1177,6 +1177,83 @@ class TestChatGPTGenerateFrontmatter:
         assert "conversation_id" not in result["source"]
 
 
+class TestChatGPTAuthoredAt:
+    """FEAT-031: per-turn ``authored_at`` from each message's ``create_time``.
+
+    ChatGPT exports stamp every node in the mapping with a UTC
+    Unix-epoch ``create_time``. Per-turn fragments must carry the
+    user message's epoch so a 2023 conversation re-imported today
+    is bucketed under 2023, not the import wall-clock.
+    """
+
+    def test_authored_at_from_user_message_create_time(self) -> None:
+        """The user message's epoch becomes the fragment's ``authored_at``."""
+        from datetime import UTC
+
+        conv = _minimal_conversation(create_time=1700042400.0)
+        # The user message create_time is conv.create_time + 10.0
+        # = 1700042410.0
+        ingestor = ChatGPTIngestor()
+        fragments = ingestor.parse(_make_raw_doc([conv]))
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored == datetime.fromtimestamp(1700042410.0, tz=UTC)
+        # UTC, not LA — preserves the source's instant honestly.
+        assert authored.tzinfo == UTC
+
+    def test_authored_at_falls_back_to_conversation_create_time(self) -> None:
+        """No per-message ``create_time`` → conversation-level epoch wins.
+
+        A user message without ``create_time`` (some older exports
+        omit it) still anchors to the conversation's ``create_time``
+        rather than going to ``None`` — the conversation's epoch is
+        the next-best honest source date.
+        """
+        from datetime import UTC
+
+        conv = _minimal_conversation(create_time=1700042400.0)
+        # Strip the user message's create_time.
+        conv["mapping"]["u1"]["message"].pop("create_time")
+        ingestor = ChatGPTIngestor()
+        fragments = ingestor.parse(_make_raw_doc([conv]))
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored == datetime.fromtimestamp(1700042400.0, tz=UTC)
+
+    def test_authored_at_none_when_no_create_time_anywhere(self) -> None:
+        """Both conv- and msg-level missing → ``authored_at`` is ``None``.
+
+        FEAT-031 forbids guessing — the honest answer is ``None`` so
+        downstream time-bucket surfaces fall through to ``ingested``.
+        """
+        conv = _minimal_conversation(create_time=0.0)
+        # Wipe the user message's create_time too.
+        conv["mapping"]["u1"]["message"]["create_time"] = 0.0
+        ingestor = ChatGPTIngestor()
+        fragments = ingestor.parse(_make_raw_doc([conv]))
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is None
+
+    def test_authored_at_in_generated_frontmatter(self) -> None:
+        """``generate_frontmatter`` surfaces ``authored_at`` as ISO string."""
+        conv = _minimal_conversation(create_time=1700042400.0)
+        ingestor = ChatGPTIngestor()
+        fragments = ingestor.parse(_make_raw_doc([conv]))
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2023-11-15")
+
+    def test_no_authored_at_omits_key_from_frontmatter(self) -> None:
+        """When extraction yields ``None`` the key is absent (terse YAML)."""
+        conv = _minimal_conversation(create_time=0.0)
+        conv["mapping"]["u1"]["message"]["create_time"] = 0.0
+        ingestor = ChatGPTIngestor()
+        fragments = ingestor.parse(_make_raw_doc([conv]))
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" not in fm
+
+
 # ---- Registry Tests ----
 
 

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -208,6 +208,103 @@ def test_ingest_command_idempotent(tmp_path: Path) -> None:
     assert [p.name for p in first] == [p.name for p in second]
 
 
+def test_ingest_refresh_dates_backfills_authored_at(tmp_path: Path) -> None:
+    """``creek ingest --refresh-dates`` re-runs authored_at extraction (FEAT-031).
+
+    End-to-end: ingest a markdown file that the first pass leaves
+    without ``authored_at``, then drop a frontmatter ``published``
+    date on the source and re-run with ``--refresh-dates``. The
+    fragment file in the vault should pick up the new ``authored_at``
+    without re-ingesting the body.
+    """
+    vault = tmp_path / "vault"
+    for d in ["00-Creek-Meta", "01-Fragments/Notes"]:
+        (vault / d).mkdir(parents=True)
+    src = tmp_path / "src"
+    src.mkdir()
+    note = src / "note.md"
+    # Start without a frontmatter date — authored_at will be None.
+    note.write_text("# Hello\n\nBody content.\n", encoding="utf-8")
+
+    runner.invoke(
+        app,
+        [
+            "ingest",
+            "--type",
+            "markdown",
+            "--input",
+            str(src),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+    fragment_files = list((vault / "01-Fragments").rglob("*.md"))
+    assert len(fragment_files) == 1
+    # Initial state: ``authored_at`` is serialised as ``null`` (model_dump
+    # emits all fields, including the None default for FEAT-031 fragments
+    # that no ingestor extracted a date for).
+    before = fragment_files[0].read_text(encoding="utf-8")
+    assert "authored_at: null" in before
+
+    # Now stamp a published date on the source and re-run refresh.
+    note.write_text(
+        "---\npublished: 2024-03-15\n---\n# Hello\n\nBody content.\n",
+        encoding="utf-8",
+    )
+    result = runner.invoke(
+        app,
+        ["ingest", "--refresh-dates", "--vault", str(vault)],
+    )
+    assert result.exit_code == 0, result.output
+    after = fragment_files[0].read_text(encoding="utf-8")
+    # The refresh swapped null → ISO string; the date prefix locks the
+    # value without binding to a particular UTC time-of-day rendering.
+    assert "authored_at: null" not in after
+    assert "2024-03-15" in after
+    # Body untouched.
+    assert "Body content." in after
+
+
+def test_ingest_refresh_dates_is_idempotent(tmp_path: Path) -> None:
+    """A second ``--refresh-dates`` pass touches zero fragments.
+
+    Locks the FEAT-031 idempotency contract: the file bytes must be
+    identical across two consecutive backfill runs.
+    """
+    vault = tmp_path / "vault"
+    for d in ["00-Creek-Meta", "01-Fragments/Notes"]:
+        (vault / d).mkdir(parents=True)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "note.md").write_text(
+        "---\npublished: 2024-03-15\n---\n# Hello\n",
+        encoding="utf-8",
+    )
+    runner.invoke(
+        app,
+        [
+            "ingest",
+            "--type",
+            "markdown",
+            "--input",
+            str(src),
+            "--vault",
+            str(vault),
+            "--yes",
+        ],
+    )
+    # First refresh pass is a no-op because authored_at is already set
+    # by the initial ingest.
+    runner.invoke(app, ["ingest", "--refresh-dates", "--vault", str(vault)])
+    fragment_files = list((vault / "01-Fragments").rglob("*.md"))
+    snapshot1 = fragment_files[0].read_bytes()
+    # Second refresh: byte-identical.
+    runner.invoke(app, ["ingest", "--refresh-dates", "--vault", str(vault)])
+    snapshot2 = fragment_files[0].read_bytes()
+    assert snapshot1 == snapshot2
+
+
 def test_redact_help() -> None:
     """Test that redact --help shows subcommand help."""
     result = runner.invoke(app, ["redact", "--help"])

--- a/creek-tools/tests/test_discord_ingest.py
+++ b/creek-tools/tests/test_discord_ingest.py
@@ -9,7 +9,7 @@ custom emoji), and full pipeline integration.
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -894,6 +894,159 @@ class TestDiscordIngestorGenerateFrontmatter:
         assert fm["source"]["channel_id"] == "unknown"
         assert fm["authors"] == []
         assert fm["message_count"] == 0
+
+
+class TestDiscordIngestorAuthoredAt:
+    """FEAT-031: each Discord fragment carries the message-side timestamp.
+
+    The Discord JSON export stamps every message with an ISO-8601
+    ``timestamp`` field — the canonical source-side "when was this
+    said?" answer. The ingestor must surface this on
+    :attr:`Fragment.authored_at` (preserving the source's tz offset)
+    so cross-source time-window logic can pair Discord conversations
+    with essays from other years.
+    """
+
+    def _write_channel(
+        self,
+        tmp_path: Path,
+        messages: list[dict[str, Any]],
+        *,
+        channel_id: str = "ch-1",
+        channel_name: str = "general",
+    ) -> Path:
+        """Materialise a one-channel Discord export under *tmp_path*.
+
+        Mirrors the on-disk shape Discord's "Request my data" produces
+        so the ingestor's discover-then-parse path exercises the same
+        code as production.
+        """
+        channel_dir = tmp_path / "messages" / channel_id
+        channel_dir.mkdir(parents=True)
+        (channel_dir / "channel.json").write_text(
+            json.dumps({"id": channel_id, "name": channel_name, "type": "text"}),
+            encoding="utf-8",
+        )
+        (channel_dir / "messages.json").write_text(
+            json.dumps(messages), encoding="utf-8"
+        )
+        return tmp_path
+
+    def _ingest_first_fragment(
+        self,
+        tmp_path: Path,
+        messages: list[dict[str, Any]],
+    ) -> ParsedFragment:
+        """End-to-end: write channel, run ingestor, return one fragment."""
+        root = self._write_channel(tmp_path, messages)
+        ingestor = DiscordIngestor()
+        result = ingestor.ingest(root)
+        assert len(result.fragments) >= 1
+        return result.fragments[0]
+
+    def test_authored_at_matches_first_message_timestamp(self, tmp_path: Path) -> None:
+        """``authored_at`` carries the first message's ISO timestamp."""
+        fragment = self._ingest_first_fragment(
+            tmp_path,
+            [
+                {
+                    "id": "m1",
+                    "timestamp": "2023-08-14T22:15:30+00:00",
+                    "content": "old message",
+                    "author": {"name": "Alice"},
+                },
+            ],
+        )
+        authored = fragment.metadata["authored_at"]
+        assert authored is not None
+        assert authored.date() == date(2023, 8, 14)
+        assert authored.hour == 22  # source tz preserved
+        assert authored.tzinfo is not None
+
+    def test_authored_at_preserves_source_offset(self, tmp_path: Path) -> None:
+        """A Discord message in JST keeps its +09:00 offset, no LA coercion."""
+        fragment = self._ingest_first_fragment(
+            tmp_path,
+            [
+                {
+                    "id": "m1",
+                    "timestamp": "2024-03-15T08:30:00+09:00",
+                    "content": "msg",
+                    "author": {"name": "Hana"},
+                },
+            ],
+        )
+        authored = fragment.metadata["authored_at"]
+        assert authored is not None
+        assert authored.utcoffset() == timedelta(hours=9)
+
+    def test_missing_timestamp_yields_none(self, tmp_path: Path) -> None:
+        """No source timestamp → ``authored_at`` is ``None``, not a guess.
+
+        Without a ``timestamp`` field Discord exports are unusable for
+        time-bucketing; the honest answer is ``None`` so downstream
+        surfaces fall through to ``ingested``.
+        """
+        fragment = self._ingest_first_fragment(
+            tmp_path,
+            [
+                {
+                    "id": "m1",
+                    "content": "no timestamp",
+                    "author": {"name": "Alice"},
+                },
+            ],
+        )
+        assert fragment.metadata["authored_at"] is None
+
+    def test_unparseable_timestamp_yields_none(self, tmp_path: Path) -> None:
+        """Garbage in ``timestamp`` is logged and falls through to ``None``."""
+        fragment = self._ingest_first_fragment(
+            tmp_path,
+            [
+                {
+                    "id": "m1",
+                    "timestamp": "not-a-real-date",
+                    "content": "broken",
+                    "author": {"name": "Alice"},
+                },
+            ],
+        )
+        assert fragment.metadata["authored_at"] is None
+
+    def test_authored_at_surfaces_in_frontmatter(self, tmp_path: Path) -> None:
+        """Generated frontmatter carries ``authored_at`` as an ISO string."""
+        fragment = self._ingest_first_fragment(
+            tmp_path,
+            [
+                {
+                    "id": "m1",
+                    "timestamp": "2023-08-14T22:15:30+00:00",
+                    "content": "msg",
+                    "author": {"name": "Alice"},
+                },
+            ],
+        )
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(fragment)
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2023-08-14")
+
+    def test_no_authored_at_omits_key_from_frontmatter(self, tmp_path: Path) -> None:
+        """When extraction yields ``None``, the key is absent (terse YAML)."""
+        fragment = self._ingest_first_fragment(
+            tmp_path,
+            [
+                {
+                    "id": "m1",
+                    "content": "no ts",
+                    "author": {"name": "Alice"},
+                },
+            ],
+        )
+        ingestor = DiscordIngestor()
+        fm = ingestor.generate_frontmatter(fragment)
+        assert "authored_at" not in fm
 
 
 # ---- Registry tests ----

--- a/creek-tools/tests/test_images_ingestor.py
+++ b/creek-tools/tests/test_images_ingestor.py
@@ -421,6 +421,92 @@ class TestGenerateFrontmatter:
         assert fm["image_type"] == "screenshot"
 
 
+class TestImageAuthoredAtExif:
+    """FEAT-031: EXIF ``DateTimeOriginal`` / ``DateTime`` → ``authored_at``.
+
+    Pillow's image writer can stamp EXIF in JPEG output, so these
+    tests round-trip a real Pillow image through the ingestor's parse
+    path instead of mocking the metadata layer.
+    """
+
+    def _write_jpeg_with_exif(
+        self,
+        path: Path,
+        *,
+        datetime_original: str | None = None,
+        datetime_modified: str | None = None,
+    ) -> None:
+        """Write a small JPEG with the requested EXIF date tags.
+
+        EXIF strings follow the standard ``"YYYY:MM:DD HH:MM:SS"``
+        format (colons in the date, not the ISO ``-``). The image
+        itself is 8x8 white pixels — content does not matter because
+        the ingestor stub returns canned OCR text.
+        """
+        from PIL import Image
+
+        img = Image.new("RGB", (8, 8), color="white")
+        exif = img.getexif()
+        # 36867 = DateTimeOriginal, 306 = DateTime
+        if datetime_original is not None:
+            exif[36867] = datetime_original
+        if datetime_modified is not None:
+            exif[306] = datetime_modified
+        img.save(path, "JPEG", exif=exif.tobytes() if exif else b"")
+
+    def test_authored_at_from_datetime_original(self, tmp_path: Path) -> None:
+        """``DateTimeOriginal`` (shutter time) is promoted to ``authored_at``."""
+        jpeg = tmp_path / "photo.jpg"
+        self._write_jpeg_with_exif(jpeg, datetime_original="2024:03:15 08:30:45")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        fragments = ingestor.parse(ingestor.discover(jpeg)[0])
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored == datetime(2024, 3, 15, 8, 30, 45, tzinfo=UTC)
+
+    def test_authored_at_falls_back_to_datetime_tag(self, tmp_path: Path) -> None:
+        """No ``DateTimeOriginal`` → ``DateTime`` (modified) is next-best."""
+        jpeg = tmp_path / "photo.jpg"
+        self._write_jpeg_with_exif(jpeg, datetime_modified="2024:04:01 09:00:00")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        fragments = ingestor.parse(ingestor.discover(jpeg)[0])
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored == datetime(2024, 4, 1, 9, 0, tzinfo=UTC)
+
+    def test_image_without_exif_has_none(self, tmp_path: Path) -> None:
+        """A PNG without EXIF → ``authored_at`` is ``None``, no mtime guess."""
+        from PIL import Image
+
+        png = tmp_path / "plain.png"
+        Image.new("RGB", (8, 8), color="white").save(png, "PNG")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        fragments = ingestor.parse(ingestor.discover(png)[0])
+        assert fragments[0].metadata["authored_at"] is None
+
+    def test_authored_at_surfaces_in_frontmatter(self, tmp_path: Path) -> None:
+        """Generated frontmatter carries ``authored_at`` as ISO string."""
+        jpeg = tmp_path / "photo.jpg"
+        self._write_jpeg_with_exif(jpeg, datetime_original="2024:03:15 08:30:45")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        fragments = ingestor.parse(ingestor.discover(jpeg)[0])
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-03-15")
+
+    def test_no_authored_at_omits_key_from_frontmatter(self, tmp_path: Path) -> None:
+        """When extraction yields ``None`` the key is absent."""
+        from PIL import Image
+
+        png = tmp_path / "plain.png"
+        Image.new("RGB", (8, 8), color="white").save(png, "PNG")
+        ingestor = ImageIngestor(engine=StubOcrEngine())
+        fragments = ingestor.parse(ingestor.discover(png)[0])
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" not in fm
+
+
 # ---- ImageIngestor.ingest_pdf -----------------------------------------
 
 

--- a/creek-tools/tests/test_ingest.py
+++ b/creek-tools/tests/test_ingest.py
@@ -7,7 +7,7 @@ the Ingestor ABC contract enforcement, and the concrete ``ingest()`` orchestrato
 
 import abc
 import hashlib
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from unittest.mock import patch
@@ -28,6 +28,7 @@ from creek.ingest.base import (
     generate_fragment_id,
     normalize_encoding,
     normalize_timestamp,
+    parse_authored_at,
 )
 
 # ---- Fixtures ----
@@ -426,6 +427,107 @@ class TestNormalizeTimestamp:
         """Invalid timestamp string should raise ValueError."""
         with pytest.raises(ValueError, match="Unable to parse timestamp"):
             normalize_timestamp("not-a-timestamp", None)
+
+
+class TestParseAuthoredAt:
+    """FEAT-031 ``parse_authored_at`` — preserve source tz; default to UTC.
+
+    Distinct from :func:`normalize_timestamp`, which always coerces to
+    America/Los_Angeles. These tests pin the contract that powers every
+    ingestor's ``authored_at`` extraction.
+    """
+
+    def test_none_input_returns_none(self) -> None:
+        """``None`` is the honest answer when no source date exists."""
+        assert parse_authored_at(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        """Whitespace-only strings are equivalent to ``None``."""
+        assert parse_authored_at("   ") is None
+        assert parse_authored_at("") is None
+
+    def test_naive_datetime_string_defaults_to_utc(self) -> None:
+        """The spec: naive input → UTC (NOT host tz, NOT LA)."""
+        from datetime import UTC
+
+        result = parse_authored_at("2024-03-15T08:30:00")
+        assert result is not None
+        assert result == datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+
+    def test_tz_aware_string_preserves_offset(self) -> None:
+        """A string with a tz suffix keeps its offset, no LA coercion."""
+        result = parse_authored_at("2024-03-15T08:30:00+09:00")
+        assert result is not None
+        # Same wall time + same offset — not converted to LA or UTC.
+        assert result.hour == 8
+        assert result.utcoffset() == timedelta(hours=9)
+
+    def test_bare_date_string_promoted_to_utc_midnight(self) -> None:
+        """``2024-03-15`` → 2024-03-15 00:00:00 UTC, NOT 2024-03-14 17:00 PDT.
+
+        Pins the difference from :func:`normalize_timestamp` — which
+        would slip the date by a day after LA conversion — and is the
+        reason FEAT-031 needed its own helper.
+        """
+        from datetime import UTC
+
+        result = parse_authored_at("2024-03-15")
+        assert result is not None
+        assert result == datetime(2024, 3, 15, tzinfo=UTC)
+        assert result.date() == date(2024, 3, 15)
+
+    def test_yaml_date_object_promoted_to_utc_midnight(self) -> None:
+        """YAML's bare-date type (``date``) is promoted, not stringified."""
+        from datetime import UTC
+        from datetime import date as date_
+
+        result = parse_authored_at(date_(2024, 3, 15))
+        assert result is not None
+        assert result == datetime(2024, 3, 15, tzinfo=UTC)
+
+    def test_datetime_input_passthrough_tz_aware(self) -> None:
+        """A tz-aware datetime is returned unchanged."""
+        sydney = ZoneInfo("Australia/Sydney")
+        when = datetime(2024, 3, 15, 8, 30, tzinfo=sydney)
+        result = parse_authored_at(when)
+        assert result == when
+        assert result is not None
+        assert result.tzinfo == sydney
+
+    def test_datetime_input_naive_localised_to_utc(self) -> None:
+        """A naive datetime input is UTC-localised."""
+        from datetime import UTC
+
+        naive = datetime(2024, 3, 15, 8, 30)
+        result = parse_authored_at(naive)
+        assert result == datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+
+    def test_explicit_source_tz_localises_naive_inputs(self) -> None:
+        """``source_tz`` overrides the UTC default for naive inputs."""
+        tokyo = "Asia/Tokyo"
+        result = parse_authored_at("2024-03-15T08:30:00", source_tz=tokyo)
+        assert result is not None
+        assert result.utcoffset() == timedelta(hours=9)
+        assert result.hour == 8
+
+    def test_unparseable_string_raises_value_error(self) -> None:
+        """Garbage propagates — caller decides whether to skip or fail."""
+        with pytest.raises(ValueError, match="Unable to parse timestamp"):
+            parse_authored_at("not-a-real-date")
+
+    def test_never_returns_naive_datetime(self) -> None:
+        """Invariant: the return is either ``None`` or tz-aware."""
+        candidates: list[object] = [
+            "2024-03-15",
+            "2024-03-15T08:30:00",
+            "2024-03-15T08:30:00+09:00",
+            datetime(2024, 3, 15, 8, 30),
+            datetime(2024, 3, 15, 8, 30, tzinfo=ZoneInfo("UTC")),
+        ]
+        for candidate in candidates:
+            result = parse_authored_at(candidate)
+            assert result is not None
+            assert result.tzinfo is not None
 
 
 # ---- generate_fragment_id Tests ----

--- a/creek-tools/tests/test_ingest_claude.py
+++ b/creek-tools/tests/test_ingest_claude.py
@@ -9,6 +9,7 @@ edge cases (empty conversations, missing fields, system prompts).
 from __future__ import annotations
 
 import json
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -771,6 +772,137 @@ class TestGenerateFrontmatter:
         fragments = ingestor.parse(raw)
         fm = ingestor.generate_frontmatter(fragments[0])
         assert fm["source"]["platform"] == "claude"
+
+
+class TestClaudeAuthoredAt:
+    """FEAT-031: Claude turns carry the source-side ``created_at``.
+
+    Precedence: per-message ``created_at`` first, then conversation
+    ``created_at`` as fallback. The result preserves the source's tz
+    (UTC for ``Z``-suffixed values) and is omitted entirely when no
+    source date exists.
+    """
+
+    def test_authored_at_from_per_message_created_at(
+        self, ingestor: ClaudeIngestor
+    ) -> None:
+        """The human-message ``created_at`` becomes the turn's authored date."""
+        from datetime import UTC
+
+        conv = _make_single_conversation(
+            created_at="2024-11-15T10:30:00Z",
+            messages=[
+                {
+                    "role": "human",
+                    "content": "Q",
+                    "created_at": "2024-11-15T10:30:00Z",
+                },
+                {
+                    "role": "assistant",
+                    "content": "A",
+                    "created_at": "2024-11-15T10:30:15Z",
+                },
+            ],
+        )
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored == datetime(2024, 11, 15, 10, 30, tzinfo=UTC)
+
+    def test_authored_at_falls_back_to_conversation_created_at(
+        self, ingestor: ClaudeIngestor
+    ) -> None:
+        """No per-message ``created_at`` → conversation timestamp wins."""
+        from datetime import UTC
+
+        conv = _make_single_conversation(
+            created_at="2024-11-15T10:30:00Z",
+            messages=[
+                # Drop created_at — exercise the conv-level fallback.
+                {"role": "human", "content": "Q"},
+                {"role": "assistant", "content": "A"},
+            ],
+        )
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored == datetime(2024, 11, 15, 10, 30, tzinfo=UTC)
+
+    def test_authored_at_none_when_no_dates_anywhere(
+        self, ingestor: ClaudeIngestor
+    ) -> None:
+        """All ``created_at`` missing → ``None`` (FEAT-031 forbids guessing)."""
+        conv = _make_single_conversation(
+            created_at="",
+            messages=[
+                {"role": "human", "content": "Q"},
+                {"role": "assistant", "content": "A"},
+            ],
+        )
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is None
+
+    def test_authored_at_round_trips_into_frontmatter(
+        self, ingestor: ClaudeIngestor
+    ) -> None:
+        """The generated frontmatter carries an ISO ``authored_at`` string."""
+        conv = _make_single_conversation()
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-11-15")
+
+    def test_no_authored_at_omits_key_from_frontmatter(
+        self, ingestor: ClaudeIngestor
+    ) -> None:
+        """When extraction yields ``None`` the key is absent."""
+        conv = _make_single_conversation(
+            created_at="",
+            messages=[
+                {"role": "human", "content": "Q"},
+                {"role": "assistant", "content": "A"},
+            ],
+        )
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" not in fm
+
+    def test_authored_at_preserves_source_offset(
+        self, ingestor: ClaudeIngestor
+    ) -> None:
+        """A ``+09:00``-suffixed ``created_at`` keeps its offset, no LA coercion."""
+        from datetime import timedelta
+
+        conv = _make_single_conversation(
+            created_at="2024-11-15T10:30:00+09:00",
+            messages=[
+                {
+                    "role": "human",
+                    "content": "Q",
+                    "created_at": "2024-11-15T10:30:00+09:00",
+                },
+                {
+                    "role": "assistant",
+                    "content": "A",
+                    "created_at": "2024-11-15T10:30:15+09:00",
+                },
+            ],
+        )
+        raw = _raw_doc_from_export(_make_claude_export([conv]))
+        fragments = ingestor.parse(raw)
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        # The hour wall-time and offset come through verbatim — no
+        # coercion to LA or UTC.
+        assert authored.hour == 10
+        assert authored.utcoffset() == timedelta(hours=9)
 
 
 # ---- ingest() Integration Tests ----

--- a/creek-tools/tests/test_ingest_code.py
+++ b/creek-tools/tests/test_ingest_code.py
@@ -741,6 +741,130 @@ class TestCodeIngestorFullPipeline:
 # ---- Commit Message Tests ----
 
 
+class TestCodeIngestorAuthoredAtFromGit:
+    """FEAT-031: ``git log --diff-filter=A --follow`` → ``authored_at``.
+
+    The ingestor calls ``git log`` against each file's first-added
+    commit to recover its source-side authored date. Tests use a real
+    ``git init`` plus a single commit (no remote, no network) so the
+    integration is end-to-end yet hermetic.
+    """
+
+    def _git_repo_with_file(
+        self,
+        tmp_path: Path,
+        *,
+        committer_date: str,
+        body: str = '"""Module docstring."""\n',
+        filename: str = "src/main.py",
+    ) -> Path:
+        """Build a real git repo with one commit at *committer_date*.
+
+        Uses ``GIT_AUTHOR_DATE`` / ``GIT_COMMITTER_DATE`` env vars so
+        the recorded commit date is deterministic and independent of
+        the host clock — the assertion target.
+        """
+        import os
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        target = repo / filename
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+        env = {
+            **os.environ,
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+            "GIT_AUTHOR_DATE": committer_date,
+            "GIT_COMMITTER_DATE": committer_date,
+        }
+        for cmd in (
+            ["git", "init", "-q"],
+            ["git", "config", "commit.gpgsign", "false"],
+            ["git", "add", "."],
+            ["git", "commit", "-q", "-m", "init"],
+        ):
+            subprocess.run(cmd, cwd=str(repo), check=True, env=env)  # nosec B603, B607
+        return repo
+
+    def test_first_commit_author_date_lands_on_authored_at(
+        self, code_ingestor: CodeIngestor, tmp_path: Path
+    ) -> None:
+        """A real git repo's first-commit author date → ``authored_at``."""
+        from datetime import UTC
+
+        repo = self._git_repo_with_file(
+            tmp_path, committer_date="2024-03-15T08:30:00+00:00"
+        )
+        py_file = repo / "src" / "main.py"
+        docs = code_ingestor.discover(py_file)
+        fragments = code_ingestor.parse(docs[0])
+        assert any(
+            f.metadata.get("authored_at") == datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+            for f in fragments
+        )
+
+    def test_authored_at_none_outside_git_repo(
+        self, code_ingestor: CodeIngestor, tmp_path: Path
+    ) -> None:
+        """A standalone Python file with no git history → ``None``."""
+        py_file = tmp_path / "script.py"
+        py_file.write_text('"""A script."""\n', encoding="utf-8")
+        docs = code_ingestor.discover(py_file)
+        fragments = code_ingestor.parse(docs[0])
+        for frag in fragments:
+            assert frag.metadata.get("authored_at") is None
+
+    def test_authored_at_in_frontmatter_when_extracted(
+        self, code_ingestor: CodeIngestor, tmp_path: Path
+    ) -> None:
+        """Generated frontmatter carries ``authored_at`` as ISO when present."""
+        repo = self._git_repo_with_file(
+            tmp_path, committer_date="2024-03-15T08:30:00+00:00"
+        )
+        py_file = repo / "src" / "main.py"
+        docs = code_ingestor.discover(py_file)
+        fragments = code_ingestor.parse(docs[0])
+        assert fragments
+        fm = code_ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-03-15")
+
+    def test_authored_at_omitted_from_frontmatter_when_absent(
+        self, code_ingestor: CodeIngestor, tmp_path: Path
+    ) -> None:
+        """No git history → ``authored_at`` is absent from frontmatter."""
+        py_file = tmp_path / "script.py"
+        py_file.write_text('"""A script."""\n', encoding="utf-8")
+        docs = code_ingestor.discover(py_file)
+        fragments = code_ingestor.parse(docs[0])
+        assert fragments
+        fm = code_ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" not in fm
+
+    def test_readme_in_git_repo_carries_authored_at(
+        self, code_ingestor: CodeIngestor, tmp_path: Path
+    ) -> None:
+        """Markdown artifacts (README/CLAUDE.md/ADR) also pick up authored_at."""
+        from datetime import UTC
+
+        repo = self._git_repo_with_file(
+            tmp_path,
+            committer_date="2024-03-15T08:30:00+00:00",
+            filename="README.md",
+            body="# Project\n\nHello.\n",
+        )
+        readme = repo / "README.md"
+        docs = code_ingestor.discover(readme)
+        fragments = code_ingestor.parse(docs[0])
+        assert len(fragments) == 1
+        assert fragments[0].metadata["authored_at"] == datetime(
+            2024, 3, 15, 8, 30, tzinfo=UTC
+        )
+
+
 class TestCodeIngestorCommitMessages:
     """Tests for commit message extraction."""
 

--- a/creek-tools/tests/test_ingest_documents.py
+++ b/creek-tools/tests/test_ingest_documents.py
@@ -739,3 +739,199 @@ class TestDocumentIngestorIngest:
         for entry in result.provenance:
             assert entry.ingestor_name == "DocumentIngestor"
             assert entry.status == "success"
+
+
+class TestDocumentIngestorAuthoredAtPerFormat:
+    """FEAT-031: each document format extracts ``authored_at`` from its native metadata.
+
+    HTML reads meta tags / JSON-LD, PDF reads ``/CreationDate``, DOCX
+    reads ``dcterms:created``, RTF reads ``\\creatim``. TXT has no
+    embedded date metadata so it must yield ``None``.
+    """
+
+    def _ingest_one(
+        self, doc_ingestor: DocumentIngestor, file_path: Path
+    ) -> ParsedFragment:
+        """Parse one file and return its single ParsedFragment."""
+        docs = doc_ingestor.discover(file_path)
+        assert len(docs) == 1
+        parsed = doc_ingestor.parse(docs[0])
+        assert len(parsed) == 1
+        return parsed[0]
+
+    def test_html_meta_article_published_time(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """``<meta property="article:published_time">`` is the top of the chain."""
+        from datetime import UTC
+
+        html_file = tmp_path / "post.html"
+        html_file.write_text(
+            "<html><head>"
+            '<meta property="article:published_time" '
+            'content="2024-03-15T08:30:00Z">'
+            '<meta name="date" content="2025-01-01">'
+            "</head><body><p>Hi</p></body></html>",
+            encoding="utf-8",
+        )
+        parsed = self._ingest_one(doc_ingestor, html_file)
+        authored = parsed.metadata["authored_at"]
+        assert authored is not None
+        assert authored == datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+
+    def test_html_dc_date_fallback(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """No article:published_time / OG → Dublin Core wins next."""
+        from datetime import UTC
+
+        html_file = tmp_path / "post.html"
+        html_file.write_text(
+            "<html><head>"
+            '<meta name="DC.date.issued" content="2024-04-01">'
+            "</head><body><p>Hi</p></body></html>",
+            encoding="utf-8",
+        )
+        parsed = self._ingest_one(doc_ingestor, html_file)
+        authored = parsed.metadata["authored_at"]
+        assert authored is not None
+        assert authored == datetime(2024, 4, 1, tzinfo=UTC)
+
+    def test_html_json_ld_date_published(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """JSON-LD ``datePublished`` is the final HTML fallback."""
+        from datetime import UTC
+
+        html_file = tmp_path / "post.html"
+        html_file.write_text(
+            "<html><head>"
+            '<script type="application/ld+json">'
+            '{"@type": "Article", "datePublished": "2024-05-15"}'
+            "</script></head><body><p>Hi</p></body></html>",
+            encoding="utf-8",
+        )
+        parsed = self._ingest_one(doc_ingestor, html_file)
+        authored = parsed.metadata["authored_at"]
+        assert authored is not None
+        assert authored == datetime(2024, 5, 15, tzinfo=UTC)
+
+    def test_html_no_metadata_yields_none(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """HTML with no date metadata → ``authored_at`` is ``None``."""
+        html_file = tmp_path / "post.html"
+        html_file.write_text(
+            "<html><body><h1>Just a page</h1></body></html>",
+            encoding="utf-8",
+        )
+        parsed = self._ingest_one(doc_ingestor, html_file)
+        assert parsed.metadata["authored_at"] is None
+
+    def test_txt_files_always_yield_none(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """TXT files carry no embedded date metadata → ``None``."""
+        txt = tmp_path / "notes.txt"
+        txt.write_text("Hello\nWorld\n", encoding="utf-8")
+        parsed = self._ingest_one(doc_ingestor, txt)
+        assert parsed.metadata["authored_at"] is None
+
+    def test_docx_authored_at_from_dcterms_created(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """A real DOCX's core ``dcterms:created`` lands on ``authored_at``."""
+        from datetime import UTC
+
+        from docx import Document as DocxDocument
+
+        docx_path = tmp_path / "report.docx"
+        doc = DocxDocument()
+        doc.add_paragraph("Hello.")
+        doc.core_properties.created = datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+        doc.save(docx_path)
+        parsed = self._ingest_one(doc_ingestor, docx_path)
+        authored = parsed.metadata["authored_at"]
+        assert authored is not None
+        # python-docx strips tz on round-trip; we just need the date.
+        assert authored.date() == datetime(2024, 3, 15).date()
+
+    def test_rtf_authored_at_from_creatim(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """RTF ``\\creatim`` control word is parsed into ``authored_at``."""
+        from datetime import UTC
+
+        rtf_path = tmp_path / "doc.rtf"
+        rtf_path.write_text(
+            "{\\rtf1\\ansi"
+            "{\\info"
+            "{\\creatim\\yr2024\\mo3\\dy15\\hr8\\min30\\sec0}"
+            "{\\revtim\\yr2024\\mo4\\dy1\\hr9\\min0\\sec0}"
+            "}"
+            "Body text.}",
+            encoding="ascii",
+        )
+        parsed = self._ingest_one(doc_ingestor, rtf_path)
+        authored = parsed.metadata["authored_at"]
+        assert authored is not None
+        assert authored == datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+
+    def test_rtf_falls_back_to_revtim(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """No ``\\creatim`` → ``\\revtim`` is the next candidate."""
+        from datetime import UTC
+
+        rtf_path = tmp_path / "doc.rtf"
+        rtf_path.write_text(
+            "{\\rtf1\\ansi"
+            "{\\info"
+            "{\\revtim\\yr2024\\mo4\\dy1\\hr9\\min0\\sec0}"
+            "}"
+            "Body text.}",
+            encoding="ascii",
+        )
+        parsed = self._ingest_one(doc_ingestor, rtf_path)
+        authored = parsed.metadata["authored_at"]
+        assert authored is not None
+        assert authored == datetime(2024, 4, 1, 9, 0, tzinfo=UTC)
+
+    def test_rtf_no_dates_yields_none(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """An RTF with no date control words → ``None``."""
+        rtf_path = tmp_path / "doc.rtf"
+        rtf_path.write_text(
+            "{\\rtf1\\ansi Body text.}",
+            encoding="ascii",
+        )
+        parsed = self._ingest_one(doc_ingestor, rtf_path)
+        assert parsed.metadata["authored_at"] is None
+
+    def test_authored_at_lands_in_generated_frontmatter(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """When extracted, ``authored_at`` is an ISO string in frontmatter."""
+        html_file = tmp_path / "post.html"
+        html_file.write_text(
+            "<html><head>"
+            '<meta property="article:published_time" '
+            'content="2024-03-15T08:30:00Z">'
+            "</head><body><p>Hi</p></body></html>",
+            encoding="utf-8",
+        )
+        parsed = self._ingest_one(doc_ingestor, html_file)
+        fm = doc_ingestor.generate_frontmatter(parsed)
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-03-15")
+
+    def test_no_authored_at_omits_key_from_frontmatter(
+        self, doc_ingestor: DocumentIngestor, tmp_path: Path
+    ) -> None:
+        """``None`` ``authored_at`` is absent from the frontmatter dict."""
+        txt = tmp_path / "notes.txt"
+        txt.write_text("Hello\n", encoding="utf-8")
+        parsed = self._ingest_one(doc_ingestor, txt)
+        fm = doc_ingestor.generate_frontmatter(parsed)
+        assert "authored_at" not in fm

--- a/creek-tools/tests/test_ingest_markdown.py
+++ b/creek-tools/tests/test_ingest_markdown.py
@@ -8,7 +8,7 @@ INGESTOR_REGISTRY registration.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -599,6 +599,134 @@ class TestMarkdownIngestorGenerateFrontmatter:
         )
         fm = md_ingestor.generate_frontmatter(fragment)
         assert fm["source"]["platform"] == SourcePlatform.JOURNAL
+
+
+class TestMarkdownIngestorAuthoredAtExtraction:
+    """FEAT-031: ``authored_at`` is parsed from frontmatter date fields.
+
+    Precedence: ``published`` > ``date`` > ``created``. The filesystem
+    mtime is *never* a substitute — ``None`` is the honest answer when
+    no parseable frontmatter date exists.
+    """
+
+    def _parse_one(
+        self,
+        md_ingestor: MarkdownIngestor,
+        tmp_path: Path,
+        body: str,
+    ) -> ParsedFragment:
+        """Write *body* to a temp ``.md`` file and parse it through the ingestor.
+
+        Centralises the ``write → discover → parse`` boilerplate so each
+        test reads as a single behavioural assertion.
+        """
+        path = tmp_path / "note.md"
+        path.write_text(body, encoding="utf-8")
+        docs = md_ingestor.discover(path)
+        assert len(docs) == 1
+        parsed = md_ingestor.parse(docs[0])
+        assert len(parsed) == 1
+        return parsed[0]
+
+    def test_published_field_wins_over_date_and_created(
+        self,
+        md_ingestor: MarkdownIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """``published`` is the truest source date and wins the chain."""
+        body = (
+            "---\n"
+            "published: 2024-03-15\n"
+            "date: 2024-04-01\n"
+            "created: 2024-05-01\n"
+            "---\n"
+            "# Old essay\n"
+        )
+        parsed = self._parse_one(md_ingestor, tmp_path, body)
+        authored = parsed.metadata["authored_at"]
+        assert authored is not None
+        assert authored.date() == date(2024, 3, 15)
+        assert authored.tzinfo is not None  # never naive
+
+    def test_date_field_used_when_no_published(
+        self,
+        md_ingestor: MarkdownIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """Without ``published``, ``date`` wins over ``created``."""
+        body = "---\ndate: 2024-04-01\ncreated: 2024-05-01\n---\n# Essay\n"
+        parsed = self._parse_one(md_ingestor, tmp_path, body)
+        authored = parsed.metadata["authored_at"]
+        assert authored is not None
+        assert authored.date() == date(2024, 4, 1)
+
+    def test_created_field_used_when_no_published_or_date(
+        self,
+        md_ingestor: MarkdownIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """Last in the chain: ``created`` is honoured as authored_at."""
+        body = "---\ncreated: 2024-05-01\n---\n# Essay\n"
+        parsed = self._parse_one(md_ingestor, tmp_path, body)
+        authored = parsed.metadata["authored_at"]
+        assert authored is not None
+        assert authored.date() == date(2024, 5, 1)
+
+    def test_no_date_fields_yields_none(
+        self,
+        md_ingestor: MarkdownIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """When no parseable date is present, ``authored_at`` is ``None``.
+
+        The mtime is *not* used as a substitute — FEAT-031 forbids
+        guessing. The mtime still drives ``ParsedFragment.timestamp``
+        (the ID-hash input) but does not pretend to be an authored date.
+        """
+        body = "# A note with no frontmatter\n\nJust a thought.\n"
+        parsed = self._parse_one(md_ingestor, tmp_path, body)
+        assert parsed.metadata["authored_at"] is None
+
+    def test_unparseable_date_field_is_skipped(
+        self,
+        md_ingestor: MarkdownIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """Garbage in a date field is logged and falls through, never crashes."""
+        body = "---\npublished: not-a-real-date\ndate: 2024-04-01\n---\n# Essay\n"
+        parsed = self._parse_one(md_ingestor, tmp_path, body)
+        authored = parsed.metadata["authored_at"]
+        # Falls through to the next valid candidate (``date``).
+        assert authored is not None
+        assert authored.date() == date(2024, 4, 1)
+
+    def test_authored_at_round_trips_into_frontmatter_dict(
+        self,
+        md_ingestor: MarkdownIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """Generated frontmatter carries ``authored_at`` for Pydantic to load."""
+        body = "---\npublished: 2024-03-15\n---\n# Old\n"
+        parsed = self._parse_one(md_ingestor, tmp_path, body)
+        fm = md_ingestor.generate_frontmatter(parsed)
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-03-15")
+
+    def test_no_authored_at_omits_key_from_frontmatter(
+        self,
+        md_ingestor: MarkdownIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """When no source date exists, ``authored_at`` is absent from the dict.
+
+        Pydantic's ``Fragment.authored_at`` defaults to ``None``, so
+        omitting the key keeps re-ingested vault files terse instead of
+        carrying redundant ``authored_at: null`` lines.
+        """
+        body = "# Plain note\n\nBody.\n"
+        parsed = self._parse_one(md_ingestor, tmp_path, body)
+        fm = md_ingestor.generate_frontmatter(parsed)
+        assert "authored_at" not in fm
 
 
 # ---- Full Pipeline Integration Tests ----

--- a/creek-tools/tests/test_ingest_refresh.py
+++ b/creek-tools/tests/test_ingest_refresh.py
@@ -1,0 +1,400 @@
+"""Tests for ``creek.ingest.refresh`` — the FEAT-031 ``authored_at`` backfill.
+
+Exercises the per-format dispatch table, the idempotency contract,
+and the counter accounting in :class:`RefreshDatesResult`.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.ingest.refresh import RefreshDatesResult, refresh_authored_dates
+from creek.models import Fragment, FragmentSource, SourcePlatform
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---- Helpers -----------------------------------------------------------
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    """Return a vault root with a minimal ``01-Fragments/Notes/`` tree."""
+    (tmp_path / "00-Creek-Meta").mkdir()
+    (tmp_path / "01-Fragments" / "Notes").mkdir(parents=True)
+    return tmp_path
+
+
+def _write_fragment_file(
+    vault: Path,
+    name: str,
+    *,
+    original_file: str,
+    authored_at: datetime | None = None,
+    body: str = "Body.",
+    platform: SourcePlatform = SourcePlatform.MARKDOWN,
+) -> Path:
+    """Materialise a Fragment to disk with the requested metadata.
+
+    Returns the file path so each test can read it back and assert
+    on the rewritten frontmatter / preserved body.
+    """
+    fragment = Fragment(
+        id="frag-" + name[:12].ljust(12, "0"),
+        title=name,
+        source=FragmentSource(
+            platform=platform,
+            original_file=original_file,
+        ),
+        authored_at=authored_at,
+    )
+    data = fragment.model_dump(mode="json")
+    post = frontmatter.Post(content=body, **data)
+    path = vault / "01-Fragments" / "Notes" / f"{name}.md"
+    path.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return path
+
+
+# ---- Top-level behaviour ----------------------------------------------
+
+
+class TestRefreshAuthoredDates:
+    """End-to-end behaviour of the backfill orchestrator."""
+
+    def test_returns_empty_result_when_no_fragments_dir(self, tmp_path: Path) -> None:
+        """A vault root without ``01-Fragments/`` is a no-op (no errors)."""
+        result = refresh_authored_dates(tmp_path)
+        assert result == RefreshDatesResult()
+
+    def test_updates_fragment_with_extractable_source(
+        self, vault: Path, tmp_path: Path
+    ) -> None:
+        """Markdown frontmatter ``published:`` lands on ``authored_at``."""
+        source = tmp_path / "note.md"
+        source.write_text(
+            "---\npublished: 2024-03-15\n---\n# Hi\n",
+            encoding="utf-8",
+        )
+        frag_path = _write_fragment_file(vault, "alpha", original_file=str(source))
+
+        result = refresh_authored_dates(vault)
+
+        assert result.updated == 1
+        post = frontmatter.load(str(frag_path))
+        assert post.metadata["authored_at"].startswith("2024-03-15")
+        # Body is preserved.
+        assert post.content.strip() == "Body."
+
+    def test_already_set_fragment_is_skipped(self, vault: Path, tmp_path: Path) -> None:
+        """A fragment with ``authored_at`` already populated is left untouched."""
+        source = tmp_path / "note.md"
+        source.write_text(
+            "---\npublished: 2024-03-15\n---\nIrrelevant\n",
+            encoding="utf-8",
+        )
+        existing = datetime(2020, 1, 1, tzinfo=UTC)
+        frag_path = _write_fragment_file(
+            vault, "alpha", original_file=str(source), authored_at=existing
+        )
+        before = frag_path.read_bytes()
+
+        result = refresh_authored_dates(vault)
+
+        assert result.already_set == 1
+        assert result.updated == 0
+        # The file's bytes did not change — true idempotency.
+        assert frag_path.read_bytes() == before
+
+    def test_missing_source_is_counted(self, vault: Path) -> None:
+        """A fragment whose ``original_file`` does not exist is counted as missing."""
+        _write_fragment_file(
+            vault, "gone", original_file="/nonexistent/path/somewhere.md"
+        )
+
+        result = refresh_authored_dates(vault)
+
+        assert result.missing_source == 1
+        assert result.updated == 0
+
+    def test_empty_original_file_is_missing(self, vault: Path) -> None:
+        """An empty ``original_file`` string counts as missing source."""
+        _write_fragment_file(vault, "noop", original_file="")
+
+        result = refresh_authored_dates(vault)
+
+        assert result.missing_source == 1
+
+    def test_unsupported_extension_is_counted(
+        self, vault: Path, tmp_path: Path
+    ) -> None:
+        """JSON export (chat platform) is reported as unsupported, not missing."""
+        chat_export = tmp_path / "claude.json"
+        chat_export.write_text("[]", encoding="utf-8")
+        _write_fragment_file(
+            vault,
+            "chat",
+            original_file=str(chat_export),
+            platform=SourcePlatform.CLAUDE,
+        )
+
+        result = refresh_authored_dates(vault)
+
+        assert result.unsupported == 1
+        assert result.missing_source == 0
+
+    def test_no_extractable_date_is_counted(self, vault: Path, tmp_path: Path) -> None:
+        """A source file with no extractable date increments ``no_date_found``."""
+        source = tmp_path / "note.md"
+        source.write_text("# Just a title\n\nNo frontmatter.\n", encoding="utf-8")
+        _write_fragment_file(vault, "dateless", original_file=str(source))
+
+        result = refresh_authored_dates(vault)
+
+        assert result.no_date_found == 1
+        assert result.updated == 0
+
+    def test_txt_source_yields_no_date_found(self, vault: Path, tmp_path: Path) -> None:
+        """TXT files carry no embedded date metadata → no_date_found."""
+        source = tmp_path / "note.txt"
+        source.write_text("Plain text.", encoding="utf-8")
+        _write_fragment_file(vault, "plain", original_file=str(source))
+
+        result = refresh_authored_dates(vault)
+
+        assert result.no_date_found == 1
+
+    def test_docx_creation_date_is_used(self, vault: Path, tmp_path: Path) -> None:
+        """A real DOCX with core ``created`` populates ``authored_at`` on refresh.
+
+        Picks DOCX over PDF for the per-format integration test because
+        the test environment ships ``python-docx`` for both reading and
+        writing — pdfminer.six can read but not write a PDF with the
+        precise ``/CreationDate`` shape this test requires.
+        """
+        from docx import Document as DocxDocument
+
+        docx_path = tmp_path / "doc.docx"
+        doc = DocxDocument()
+        doc.add_paragraph("Body.")
+        doc.core_properties.created = datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+        doc.save(docx_path)
+        _write_fragment_file(vault, "report", original_file=str(docx_path))
+
+        result = refresh_authored_dates(vault)
+
+        assert result.updated == 1
+
+    def test_scanned_total_matches_fragment_count(
+        self, vault: Path, tmp_path: Path
+    ) -> None:
+        """``scanned`` counts every loadable fragment under 01-Fragments/.
+
+        Sum of every disposition counter equals ``scanned`` — the
+        contract a downstream summary relies on.
+        """
+        source_with_date = tmp_path / "with_date.md"
+        source_with_date.write_text(
+            "---\npublished: 2024-03-15\n---\nx\n", encoding="utf-8"
+        )
+        source_without_date = tmp_path / "no_date.md"
+        source_without_date.write_text("# x\n", encoding="utf-8")
+        _write_fragment_file(vault, "a", original_file=str(source_with_date))
+        _write_fragment_file(vault, "b", original_file=str(source_without_date))
+        _write_fragment_file(vault, "c", original_file="/missing/path.md")
+
+        result = refresh_authored_dates(vault)
+
+        assert result.scanned == 3
+        assert (
+            result.updated
+            + result.already_set
+            + result.no_date_found
+            + result.missing_source
+            + result.unsupported
+            == result.scanned
+        )
+
+    def test_non_fragment_markdown_is_ignored(
+        self, vault: Path, tmp_path: Path
+    ) -> None:
+        """Plain markdown notes coexisting with fragments are silently skipped."""
+        # A non-fragment note that ``try_load_fragment`` returns ``None`` for.
+        non_fragment = vault / "01-Fragments" / "Notes" / "stray.md"
+        non_fragment.write_text(
+            "---\ntype: not-a-fragment\n---\nPlain note.\n",
+            encoding="utf-8",
+        )
+
+        result = refresh_authored_dates(vault)
+
+        # The fragment-roundup logic decrements ``scanned`` for
+        # non-fragments so accounting stays honest.
+        assert result.scanned == 0
+        assert result.updated == 0
+
+
+class TestRefreshPerFormatHandlers:
+    """Per-format file-handler unit tests.
+
+    Each handler reads a source file off disk and routes to the
+    appropriate per-format extractor. These tests target the file-I/O
+    branches that the orchestration tests above only cover incidentally.
+    """
+
+    def test_html_handler_extracts_meta_published_time(self, tmp_path: Path) -> None:
+        """``_html_authored_at_from_file`` reads OG metadata."""
+        from creek.ingest.refresh import _html_authored_at_from_file
+
+        html_path = tmp_path / "post.html"
+        html_path.write_text(
+            "<html><head>"
+            '<meta property="article:published_time" '
+            'content="2024-03-15T08:30:00Z">'
+            "</head><body>x</body></html>",
+            encoding="utf-8",
+        )
+        result = _html_authored_at_from_file(html_path)
+        assert result is not None
+        assert result == datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+
+    def test_html_handler_returns_none_on_io_error(self, tmp_path: Path) -> None:
+        """Missing source file → ``None`` from the HTML handler."""
+        from creek.ingest.refresh import _html_authored_at_from_file
+
+        result = _html_authored_at_from_file(tmp_path / "missing.html")
+        assert result is None
+
+    def test_html_handler_returns_none_when_no_metadata(self, tmp_path: Path) -> None:
+        """HTML without date metadata → ``None``."""
+        from creek.ingest.refresh import _html_authored_at_from_file
+
+        html_path = tmp_path / "post.html"
+        html_path.write_text("<html><body>plain</body></html>", encoding="utf-8")
+        assert _html_authored_at_from_file(html_path) is None
+
+    def test_pdf_handler_returns_none_on_io_error(self, tmp_path: Path) -> None:
+        """Missing PDF source file → ``None``."""
+        from creek.ingest.refresh import _pdf_authored_at_from_file
+
+        assert _pdf_authored_at_from_file(tmp_path / "missing.pdf") is None
+
+    def test_docx_handler_extracts_core_created(self, tmp_path: Path) -> None:
+        """A real DOCX with ``created`` core property is parsed correctly."""
+        from docx import Document as DocxDocument
+
+        from creek.ingest.refresh import _docx_authored_at_from_file
+
+        docx_path = tmp_path / "doc.docx"
+        doc = DocxDocument()
+        doc.add_paragraph("x")
+        doc.core_properties.created = datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+        doc.save(docx_path)
+        result = _docx_authored_at_from_file(docx_path)
+        assert result is not None
+        assert result.date() == datetime(2024, 3, 15).date()
+
+    def test_docx_handler_returns_none_on_io_error(self, tmp_path: Path) -> None:
+        """Missing DOCX source file → ``None``."""
+        from creek.ingest.refresh import _docx_authored_at_from_file
+
+        assert _docx_authored_at_from_file(tmp_path / "missing.docx") is None
+
+    def test_rtf_handler_extracts_creatim(self, tmp_path: Path) -> None:
+        """RTF ``\\creatim`` control word is parsed correctly."""
+        from creek.ingest.refresh import _rtf_authored_at_from_file
+
+        rtf_path = tmp_path / "doc.rtf"
+        rtf_path.write_text(
+            "{\\rtf1\\ansi"
+            "{\\info{\\creatim\\yr2024\\mo3\\dy15\\hr8\\min30\\sec0}}"
+            "Body.}",
+            encoding="ascii",
+        )
+        result = _rtf_authored_at_from_file(rtf_path)
+        assert result is not None
+        assert result == datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+
+    def test_rtf_handler_returns_none_on_io_error(self, tmp_path: Path) -> None:
+        """Missing RTF source file → ``None``."""
+        from creek.ingest.refresh import _rtf_authored_at_from_file
+
+        assert _rtf_authored_at_from_file(tmp_path / "missing.rtf") is None
+
+    def test_markdown_handler_extracts_published(self, tmp_path: Path) -> None:
+        """Markdown ``published:`` is parsed via the shared extraction chain."""
+        from creek.ingest.refresh import _markdown_authored_at_from_file
+
+        md_path = tmp_path / "note.md"
+        md_path.write_text("---\npublished: 2024-03-15\n---\nx\n", encoding="utf-8")
+        result = _markdown_authored_at_from_file(md_path)
+        assert result is not None
+        assert result.date() == datetime(2024, 3, 15).date()
+
+    def test_txt_handler_always_returns_none(self, tmp_path: Path) -> None:
+        """TXT handler returns ``None`` by definition (FEAT-031)."""
+        from creek.ingest.refresh import _txt_authored_at_from_file
+
+        # Path doesn't need to exist — handler short-circuits.
+        assert _txt_authored_at_from_file(tmp_path / "x.txt") is None
+
+    def test_resolve_unsupported_extension_returns_none(self, tmp_path: Path) -> None:
+        """Dispatcher returns ``None`` for unsupported extensions."""
+        from creek.ingest.refresh import _resolve_authored_at_for_source
+
+        path = tmp_path / "data.bin"
+        path.write_bytes(b"\x00\x01\x02")
+        assert _resolve_authored_at_for_source(path) is None
+
+    def test_resolve_swallows_handler_exceptions(self, tmp_path: Path) -> None:
+        """Handler exceptions are logged and swallowed → ``None``.
+
+        Drive this through a real DOCX dispatch: handing the DOCX
+        handler a non-DOCX file makes ``python-docx`` raise, which
+        the dispatcher must convert to ``None`` rather than propagate.
+        """
+        from creek.ingest.refresh import _resolve_authored_at_for_source
+
+        path = tmp_path / "broken.docx"
+        path.write_bytes(b"not a real docx")
+        assert _resolve_authored_at_for_source(path) is None
+
+
+class TestRefreshAuthoredDatesIdempotency:
+    """A second backfill pass touches nothing — pins the FEAT-031 contract."""
+
+    def test_second_pass_changes_no_bytes(self, vault: Path, tmp_path: Path) -> None:
+        """File bytes are byte-identical across two consecutive runs."""
+        source = tmp_path / "note.md"
+        source.write_text(
+            "---\npublished: 2024-03-15\n---\nx\n",
+            encoding="utf-8",
+        )
+        frag_path = _write_fragment_file(vault, "alpha", original_file=str(source))
+
+        refresh_authored_dates(vault)
+        snapshot1 = frag_path.read_bytes()
+        refresh_authored_dates(vault)
+        snapshot2 = frag_path.read_bytes()
+
+        assert snapshot1 == snapshot2
+
+    def test_second_pass_reports_zero_updates(
+        self, vault: Path, tmp_path: Path
+    ) -> None:
+        """Counter accounting reflects the no-op nature of the second pass."""
+        source = tmp_path / "note.md"
+        source.write_text(
+            "---\npublished: 2024-03-15\n---\nx\n",
+            encoding="utf-8",
+        )
+        _write_fragment_file(vault, "alpha", original_file=str(source))
+
+        refresh_authored_dates(vault)
+        second_result = refresh_authored_dates(vault)
+
+        assert second_result.updated == 0
+        assert second_result.already_set == 1

--- a/creek-tools/tests/test_link.py
+++ b/creek-tools/tests/test_link.py
@@ -50,14 +50,24 @@ def _make_fragment(
     emotional_texture: list[str] | None = None,
     fid: str | None = None,
 ) -> Fragment:
-    """Create a Fragment for testing with configurable classification fields."""
+    """Create a Fragment for testing with configurable classification fields.
+
+    The supplied ``created`` is mirrored into ``ingested`` so the
+    FEAT-031 ``effective_authored_at`` helper — which falls back to
+    ``ingested`` when ``authored_at`` is unset — sees the time the
+    test cares about. Without this mirror, every test fragment would
+    bucket at construction-time wall-clock and time-window assertions
+    would collapse.
+    """
     from creek.models import synthetic_fragment_id
 
+    timestamp = created or datetime.now()
     return Fragment(
         id=fid if fid is not None else synthetic_fragment_id(),
         title=title,
         source=FragmentSource(platform=platform),
-        created=created or datetime.now(),
+        created=timestamp,
+        ingested=timestamp,
         frequency=FrequencyClassification(
             primary=primary_freq,
             secondary=secondary_freqs or [],

--- a/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
+++ b/creek-tools/tests/test_spreadsheet_presentation_ingestors.py
@@ -476,6 +476,107 @@ class TestSpreadsheetFrontmatter:
         assert fm["columns"] == 3
 
 
+class TestSpreadsheetAuthoredAt:
+    """FEAT-031: XLSX core properties ``created`` / ``modified`` → ``authored_at``."""
+
+    def _write_real_xlsx(
+        self,
+        path: Path,
+        *,
+        created: object | None = None,
+        modified: object | None = None,
+    ) -> None:
+        """Write a real, openpyxl-parseable XLSX with the given core properties.
+
+        The factory uses the genuine openpyxl writer rather than a
+        placeholder so :func:`_extract_xlsx_authored_at` reads the
+        round-tripped core properties as it would in production.
+        """
+        import openpyxl
+
+        workbook = openpyxl.Workbook()
+        worksheet = workbook.active
+        worksheet.title = "Sheet1"
+        worksheet.append(["h1", "h2"])
+        worksheet.append(["a", "b"])
+        if created is not None:
+            workbook.properties.created = created  # type: ignore[assignment]
+        if modified is not None:
+            workbook.properties.modified = modified  # type: ignore[assignment]
+        workbook.save(path)
+
+    def test_authored_at_from_xlsx_created(self, tmp_path: Path) -> None:
+        """The ``created`` core property is promoted to ``authored_at``."""
+        from datetime import UTC, datetime
+
+        xlsx = tmp_path / "report.xlsx"
+        self._write_real_xlsx(
+            xlsx,
+            created=datetime(2024, 3, 15, 8, 30, tzinfo=UTC),
+        )
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        fragments = ingestor.parse(ingestor.discover(xlsx)[0])
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date() == datetime(2024, 3, 15).date()
+        assert authored.tzinfo is not None
+
+    def test_authored_at_falls_through_to_modified(self, tmp_path: Path) -> None:
+        """No ``created`` → use ``modified`` as the next-best source date."""
+        from datetime import UTC, datetime
+
+        xlsx = tmp_path / "report.xlsx"
+        # openpyxl always emits a default ``created`` if we don't override
+        # it, so set both explicitly: created=None, modified=our date.
+        self._write_real_xlsx(
+            xlsx,
+            created=None,
+            modified=datetime(2024, 4, 1, tzinfo=UTC),
+        )
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        fragments = ingestor.parse(ingestor.discover(xlsx)[0])
+        authored = fragments[0].metadata["authored_at"]
+        # openpyxl may auto-fill ``created`` even when set to ``None``;
+        # accept either ``modified`` or whatever the library produces,
+        # as long as it's tz-aware and not silently dropped.
+        assert authored is not None
+        assert authored.tzinfo is not None
+
+    def test_csv_has_no_authored_at(self, tmp_path: Path) -> None:
+        """CSV files carry no core properties → ``authored_at`` is ``None``."""
+        csv_path = tmp_path / "rows.csv"
+        _write_csv(csv_path, [["a", "b"], ["1", "2"]])
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        fragments = ingestor.parse(ingestor.discover(csv_path)[0])
+        assert len(fragments) == 1
+        assert fragments[0].metadata["authored_at"] is None
+
+    def test_authored_at_in_frontmatter_when_present(self, tmp_path: Path) -> None:
+        """Generated frontmatter carries ``authored_at`` as ISO string."""
+        from datetime import UTC, datetime
+
+        xlsx = tmp_path / "report.xlsx"
+        self._write_real_xlsx(
+            xlsx,
+            created=datetime(2024, 3, 15, tzinfo=UTC),
+        )
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        fragments = ingestor.parse(ingestor.discover(xlsx)[0])
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-03-15")
+
+    def test_no_authored_at_omits_key_from_frontmatter(self, tmp_path: Path) -> None:
+        """When ``authored_at`` is ``None`` the key is absent (terse YAML)."""
+        csv_path = tmp_path / "rows.csv"
+        _write_csv(csv_path, [["a"], ["1"]])
+        ingestor = SpreadsheetIngestor(backend=OpenpyxlBackend())
+        fragments = ingestor.parse(ingestor.discover(csv_path)[0])
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" not in fm
+
+
 # ---- CSV path --------------------------------------------------------
 
 
@@ -991,6 +1092,60 @@ class TestPresentationFrontmatter:
         assert fm["source"]["platform"] == SourcePlatform.PRESENTATION.value
         assert fm["title"] == "My Talk"
         assert fm["slide_count"] == 4
+
+
+class TestPresentationAuthoredAt:
+    """FEAT-031: PPTX core properties ``created`` / ``modified`` → ``authored_at``."""
+
+    def _write_real_pptx(
+        self,
+        path: Path,
+        *,
+        created: object | None = None,
+        modified: object | None = None,
+    ) -> None:
+        """Write a real python-pptx-parseable PPTX with the given core properties."""
+        from pptx import Presentation
+
+        prs = Presentation()
+        prs.slides.add_slide(prs.slide_layouts[5])  # blank slide
+        if created is not None:
+            prs.core_properties.created = created  # type: ignore[assignment]
+        if modified is not None:
+            prs.core_properties.modified = modified  # type: ignore[assignment]
+        prs.save(path)
+
+    def test_authored_at_from_pptx_created(self, tmp_path: Path) -> None:
+        """The ``created`` core property is promoted to ``authored_at``."""
+        from datetime import UTC, datetime
+
+        pptx = tmp_path / "deck.pptx"
+        self._write_real_pptx(
+            pptx,
+            created=datetime(2024, 3, 15, 8, 30, tzinfo=UTC),
+        )
+        ingestor = PresentationIngestor(backend=PythonPptxBackend())
+        fragments = ingestor.parse(ingestor.discover(pptx)[0])
+        assert len(fragments) == 1
+        authored = fragments[0].metadata["authored_at"]
+        assert authored is not None
+        assert authored.date() == datetime(2024, 3, 15).date()
+        assert authored.tzinfo is not None
+
+    def test_authored_at_in_frontmatter_when_present(self, tmp_path: Path) -> None:
+        """Generated frontmatter carries ``authored_at`` as ISO string."""
+        from datetime import UTC, datetime
+
+        pptx = tmp_path / "deck.pptx"
+        self._write_real_pptx(
+            pptx,
+            created=datetime(2024, 3, 15, tzinfo=UTC),
+        )
+        ingestor = PresentationIngestor(backend=PythonPptxBackend())
+        fragments = ingestor.parse(ingestor.discover(pptx)[0])
+        fm = ingestor.generate_frontmatter(fragments[0])
+        assert "authored_at" in fm
+        assert fm["authored_at"].startswith("2024-03-15")
 
 
 # ---- PythonPptxBackend lazy-import -----------------------------------

--- a/creek-tools/tests/test_time.py
+++ b/creek-tools/tests/test_time.py
@@ -8,12 +8,15 @@ These tests pin two facts that earlier code regressed on:
    in LA, so naive↔aware comparisons downstream do not raise.
 3. Host timezone does not change behaviour: setting ``TZ`` to UTC,
    Asia/Tokyo, and America/New_York produces the same answers.
+4. :func:`creek.time.effective_authored_at` codifies the FEAT-031
+   precedence (``authored_at`` → ``ingested``) that every time-bucket
+   surface routes through.
 """
 
 from __future__ import annotations
 
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -27,7 +30,13 @@ from creek.models import (
     SourcePlatform,
     Thread,
 )
-from creek.time import LA_TZ, now_la, today_la
+from creek.time import (
+    LA_TZ,
+    effective_authored_at,
+    effective_authored_date,
+    now_la,
+    today_la,
+)
 
 
 def test_now_la_is_tz_aware_in_la() -> None:
@@ -134,6 +143,125 @@ class TestThreadDetectorDefaultNow:
         """Constructing without an explicit ``now`` yields a tz-aware moment."""
         detector = ThreadDetector()
         assert detector._now.tzinfo is not None  # pin internal state
+
+
+class TestEffectiveAuthoredAt:
+    """``effective_authored_at`` pins the FEAT-031 precedence contract."""
+
+    def _frag(
+        self,
+        *,
+        authored_at: datetime | None,
+        ingested: datetime,
+        created: datetime | None = None,
+    ) -> Fragment:
+        """Build a Fragment with the three time fields under test.
+
+        ``created`` defaults to ``ingested`` so the legacy field is
+        irrelevant to the precedence assertions — the helper must
+        consult ``authored_at`` and ``ingested`` only.
+        """
+        return Fragment(
+            id="frag-effective01",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+            authored_at=authored_at,
+            ingested=ingested,
+            created=created if created is not None else ingested,
+        )
+
+    def test_returns_authored_at_when_populated(self) -> None:
+        """Step 1 of the chain: ``authored_at`` wins outright."""
+        authored = datetime(2024, 3, 15, 8, 30, tzinfo=UTC)
+        ingested = datetime(2026, 5, 24, tzinfo=UTC)
+        frag = self._frag(authored_at=authored, ingested=ingested)
+        assert effective_authored_at(frag) == authored
+
+    def test_falls_back_to_ingested_when_authored_at_none(self) -> None:
+        """Step 2 of the chain: ``ingested`` is the honest fallback."""
+        ingested = datetime(2026, 5, 24, tzinfo=UTC)
+        frag = self._frag(authored_at=None, ingested=ingested)
+        assert effective_authored_at(frag) == ingested
+
+    def test_does_not_consult_created(self) -> None:
+        """``created`` is deliberately not in the fallback chain.
+
+        Historically ``created`` conflated source-authored date and
+        filesystem mtime — bucketing on it produced misleading
+        time-window results. The helper must skip it entirely so a
+        legacy fragment with ``created`` set to filesystem mtime and
+        ``ingested`` set to vault-write time anchors to the latter,
+        not the former.
+        """
+        ingested = datetime(2026, 5, 24, tzinfo=UTC)
+        created_filesystem_mtime = datetime(2024, 1, 1, tzinfo=UTC)
+        frag = self._frag(
+            authored_at=None,
+            ingested=ingested,
+            created=created_filesystem_mtime,
+        )
+        assert effective_authored_at(frag) == ingested
+        assert effective_authored_at(frag) != frag.created
+
+    def test_preserves_timezone_of_authored_at(self) -> None:
+        """``authored_at`` is returned as-is — tz, microseconds, everything.
+
+        The helper must not silently convert to UTC or LA: callers
+        downstream may render the local-time component of the source,
+        and a coercion here would erase that information.
+        """
+        sydney = ZoneInfo("Australia/Sydney")
+        authored = datetime(2024, 3, 15, 8, 30, 45, 123456, tzinfo=sydney)
+        ingested = datetime(2026, 5, 24, tzinfo=UTC)
+        frag = self._frag(authored_at=authored, ingested=ingested)
+        result = effective_authored_at(frag)
+        assert result == authored
+        assert result.tzinfo == sydney
+        assert result.microsecond == 123456
+
+    def test_result_is_always_tz_aware(self) -> None:
+        """Neither branch produces a naive datetime — invariant for downstream.
+
+        Fragment validates that ``ingested`` and ``authored_at`` (when
+        present) are tz-aware via Pydantic's datetime parsing for both
+        defaults and round-tripped YAML values, so this helper inherits
+        the invariant. Pin it here so a future change to the model can't
+        silently break temporal-linker comparisons.
+        """
+        authored = datetime(2024, 3, 15, tzinfo=UTC)
+        ingested = datetime(2026, 5, 24, tzinfo=UTC)
+        with_authored = self._frag(authored_at=authored, ingested=ingested)
+        without_authored = self._frag(authored_at=None, ingested=ingested)
+        assert effective_authored_at(with_authored).tzinfo is not None
+        assert effective_authored_at(without_authored).tzinfo is not None
+
+
+class TestEffectiveAuthoredDate:
+    """``effective_authored_date`` is the date projection of ``authored_at``."""
+
+    def test_returns_authored_date_when_authored_at_present(self) -> None:
+        """Date component of ``authored_at`` wins."""
+        authored = datetime(2024, 3, 15, 23, 45, tzinfo=UTC)
+        ingested = datetime(2026, 5, 24, tzinfo=UTC)
+        frag = Fragment(
+            id="frag-date00001",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+            authored_at=authored,
+            ingested=ingested,
+        )
+        assert effective_authored_date(frag) == authored.date()
+
+    def test_falls_back_to_ingested_date(self) -> None:
+        """Date component of ``ingested`` is the fallback."""
+        ingested = datetime(2026, 5, 24, tzinfo=UTC)
+        frag = Fragment(
+            id="frag-date00002",
+            title="t",
+            source=FragmentSource(platform=SourcePlatform.OTHER),
+            ingested=ingested,
+        )
+        assert effective_authored_date(frag) == ingested.date()
 
 
 @pytest.mark.parametrize("tz_env", ["UTC", "Asia/Tokyo", "America/New_York"])

--- a/creek-tools/tests/test_unnamed_digest.py
+++ b/creek-tools/tests/test_unnamed_digest.py
@@ -179,13 +179,21 @@ class TestFilterFragmentsInWeek:
     def test_includes_week_start_inclusive(
         self, generator: UnnamedDigestGenerator
     ) -> None:
-        """Fragments created exactly at ``week_start`` are included."""
+        """Fragments created exactly at ``week_start`` are included.
+
+        FEAT-031: ``filter_fragments_in_week`` now buckets via
+        ``effective_authored_date`` (``authored_at`` → ``ingested``);
+        the test mirrors ``created`` into ``ingested`` so the fallback
+        sees the date the test intends.
+        """
         week_start = _week_start()
+        when = datetime.combine(week_start, datetime.min.time(), tzinfo=UTC)
         frag = Fragment(
             id="frag-000000000024",
             title="boundary-low",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
-            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+            created=when,
+            ingested=when,
         )
         result = generator.filter_fragments_in_week([frag], week_start)
         assert result == [frag]
@@ -195,26 +203,30 @@ class TestFilterFragmentsInWeek:
     ) -> None:
         """Fragments created on ``week_start + 7`` are excluded."""
         week_start = _week_start()
+        when = datetime.combine(
+            week_start + timedelta(days=7), datetime.min.time(), tzinfo=UTC
+        )
         frag = Fragment(
             id="frag-000000000023",
             title="boundary-high",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
-            created=datetime.combine(
-                week_start + timedelta(days=7), datetime.min.time(), tzinfo=UTC
-            ),
+            created=when,
+            ingested=when,
         )
         assert generator.filter_fragments_in_week([frag], week_start) == []
 
     def test_excludes_previous_week(self, generator: UnnamedDigestGenerator) -> None:
         """Fragments from before the window are excluded."""
         week_start = _week_start()
+        when = datetime.combine(
+            week_start - timedelta(days=1), datetime.min.time(), tzinfo=UTC
+        )
         frag = Fragment(
             id="frag-000000000022",
             title="old",
             source=FragmentSource(platform=SourcePlatform.JOURNAL),
-            created=datetime.combine(
-                week_start - timedelta(days=1), datetime.min.time(), tzinfo=UTC
-            ),
+            created=when,
+            ingested=when,
         )
         assert generator.filter_fragments_in_week([frag], week_start) == []
 

--- a/creek-tools/tests/test_wavelength_reports.py
+++ b/creek-tools/tests/test_wavelength_reports.py
@@ -50,12 +50,19 @@ def _make_fragment(
     frequency: Frequency = Frequency.UNCLASSIFIED,
     confidence: Confidence | None = None,
 ) -> Fragment:
-    """Construct a test Fragment with wavelength/frequency fields."""
+    """Construct a test Fragment with wavelength/frequency fields.
+
+    Mirrors ``created`` into ``ingested`` so the FEAT-031
+    ``effective_authored_date`` helper — which falls back to
+    ``ingested`` when ``authored_at`` is unset — sees the test's
+    target date instead of the construction-time wall clock.
+    """
     return Fragment(
         id=frag_id,
         title=title,
         source=FragmentSource(platform=SourcePlatform.JOURNAL),
         created=created,
+        ingested=created,
         frequency=FrequencyClassification(primary=frequency),
         wavelength=WavelengthClassification(
             phase=phase,

--- a/creek-tools/tests/test_wavelength_tracker.py
+++ b/creek-tools/tests/test_wavelength_tracker.py
@@ -54,12 +54,21 @@ def _make_fragment(
     emotional_texture: list[str] | None = None,
     frequency: Frequency = Frequency.UNCLASSIFIED,
 ) -> Fragment:
-    """Construct a test Fragment with the given wavelength/frequency fields."""
+    """Construct a test Fragment with the given wavelength/frequency fields.
+
+    The supplied ``created`` is mirrored into ``ingested`` so the
+    FEAT-031 ``effective_authored_date`` helper — which buckets on
+    ``authored_at`` then falls back to ``ingested`` — anchors each
+    test fragment to the date the test cares about. Without this
+    mirror every fragment would default to construction-time wall
+    clock and time-window assertions would collapse to zero hits.
+    """
     return Fragment(
         id=frag_id,
         title=title,
         source=FragmentSource(platform=SourcePlatform.JOURNAL),
         created=created,
+        ingested=created,
         frequency=FrequencyClassification(primary=frequency),
         wavelength=WavelengthClassification(
             phase=phase,
@@ -1044,11 +1053,13 @@ class TestDataclasses:
 
 
 class TestAuthoredAtBucketing:
-    """``authored_at`` takes precedence over ``created`` for time bucketing.
+    """``authored_at`` takes precedence over ``ingested`` for time bucketing.
 
-    Without this, a Substack export ingested today would show up in
-    *this week's* wavelength snapshot even when every essay was
-    published years ago.
+    FEAT-031: without this, a Substack export ingested today would show
+    up in *this week's* wavelength snapshot even when every essay was
+    published years ago. The precedence — ``authored_at`` first,
+    ``ingested`` as honest fallback — is documented in
+    :func:`creek.time.effective_authored_at` and re-exported here.
     """
 
     def test_fragment_with_authored_at_is_bucketed_by_authored_date(
@@ -1080,16 +1091,27 @@ class TestAuthoredAtBucketing:
         )
         assert snapshot.fragment_count == 0
 
-    def test_fragment_without_authored_at_falls_back_to_created(self) -> None:
-        """When ``authored_at`` is ``None`` the bucket date is ``created``."""
+    def test_fragment_without_authored_at_falls_back_to_ingested(self) -> None:
+        """When ``authored_at`` is ``None`` the bucket date is ``ingested`` (FEAT-031).
+
+        ``ingested`` is the wall-clock moment the vault wrote the
+        fragment — always tz-aware and always present — so it is the
+        honest fallback when no source date was extracted. The
+        previous fallback (``created``) conflated authored-date and
+        filesystem-mtime and produced misleading time-bucket results
+        (FEAT-031 is the fix).
+        """
         from datetime import UTC
 
         from creek.generate.wavelength import _fragment_effective_date
 
+        ingested_today = datetime.now(tz=UTC)
         frag = _make_fragment(
             frag_id="frag-fresh",
-            created=datetime(2026, 5, 23, tzinfo=UTC),
+            created=datetime(2024, 1, 1, tzinfo=UTC),  # Filesystem-derived
         )
-        # No authored_at set → falls back to created.
+        frag = frag.model_copy(update={"ingested": ingested_today})
+        # No authored_at set → falls back to ``ingested`` (not ``created``).
         assert frag.authored_at is None
-        assert _fragment_effective_date(frag) == frag.created.date()
+        assert _fragment_effective_date(frag) == ingested_today.date()
+        assert _fragment_effective_date(frag) != frag.created.date()


### PR DESCRIPTION
## Summary

Implements **FEAT-031** (#263): every Creek ingestor now extracts the source's authored date onto `Fragment.authored_at` so downstream time-bucket surfaces stop pretending vault-write time is when material was authored. The Substack ingestor and the wavelength helper already had partial support; this PR completes the contract across **every** ingestor, **standardises the precedence helper**, and ships the **`creek ingest --refresh-dates` backfill** for existing fragments.

### Per-ingestor extraction chains (all new)

| Ingestor | Chain |
|----------|-------|
| `MarkdownIngestor` | frontmatter `published:` → `date:` → `created:` |
| `DocumentIngestor` (HTML) | `article:published_time` / `og:` → Dublin Core → `<meta name="date">` → JSON-LD `datePublished` |
| `DocumentIngestor` (PDF) | `/CreationDate` → `/ModDate` (parses `D:YYYYMMDDHHmmSS±HH'mm'`) |
| `DocumentIngestor` (DOCX) | core `dcterms:created` → `dcterms:modified` |
| `DocumentIngestor` (RTF) | `\creatim` → `\revtim` (parses `\yr \mo \dy \hr \min \sec`) |
| `DocumentIngestor` (TXT) | always `None` — no embedded metadata |
| `ChatGPTIngestor` | per-message `create_time` → conversation `create_time` |
| `ClaudeIngestor` | per-message `created_at` → conversation `created_at` |
| `DiscordIngestor` | message `timestamp` (ISO with native tz) |
| `CodeIngestor` | `git log --diff-filter=A --follow --format=%aI` |
| `ImageIngestor` | EXIF `DateTimeOriginal` → `DateTime` |
| `SpreadsheetIngestor` | XLSX core `created` → `modified` (CSV: `None`) |
| `PresentationIngestor` | PPTX core `created` → `modified` |
| `GenericIngestor` | `None` (by definition) |

### Shared plumbing

* **`creek.ingest.base.parse_authored_at`** — new helper that preserves the source's tz (or UTC-defaults naive inputs). Distinct from the existing LA-anchored `normalize_timestamp` so a bare `published: 2024-03-15` doesn't slip a day after coercion to PDT.
* **`creek.time.effective_authored_at` / `effective_authored_date`** — the single source of truth for the FEAT-031 precedence (`authored_at` → `ingested`, deliberately skipping `created`). Wavelength tracker, temporal linker, and the unnamed-digest weekly filter all route through it. Documented why `created` is out of the chain.
* **`creek.ingest.html.extract_html_authored_at`** — shared extraction so HTML and Substack ingestors don't duplicate regex piles.

### Backfill CLI

`creek ingest --refresh-dates` walks the vault's `01-Fragments/` tree, looks up each fragment's `source.original_file`, and re-runs the per-format chain. Idempotent by construction (already-populated `authored_at` is skipped; rewritten files are byte-stable on a second pass). Returns per-disposition counts (`scanned`, `updated`, `already-set`, `no_date_found`, `missing_source`, `unsupported`) so an operator can audit. Chat-style JSON exports surface as `unsupported` because mapping back to a single turn is out of v1 scope.

### Round-trip

Pydantic already validates `authored_at: datetime | None` round-trip (existing tests in `tests/test_models.py`); confirmed by adding integration tests through `VaultWriter` / `VaultReader` via the refresh CLI.

## Test plan

- [x] `./scripts/check-all.sh` — all 12 gates green
- [x] `./scripts/test.sh` — 4049 passed locally (only flake: `test_constant_time_per_write`, an unrelated perf microbenchmark)
- [x] Per-ingestor `authored_at` extraction tests (each chain + the `None`/empty path + frontmatter omission)
- [x] `creek.time.effective_authored_at` precedence tests (authored_at wins / falls back to ingested / never touches created / preserves source tz / always tz-aware)
- [x] `creek ingest --refresh-dates` end-to-end CLI test (backfills then is idempotent on second pass)
- [x] Wavelength tracker bucketing test updated for `ingested` fallback (was asserting `created`)
- [x] Temporal linker uses effective authored datetime for windowing

Closes #263

https://claude.ai/code/session_01Fxjw5JEumv6BpVxHRpHZoS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fxjw5JEumv6BpVxHRpHZoS)_