### PR TITLE
feat(crawdad): surface agent-loop max_rounds as a crawdad.yaml knob (FEAT-036, #312)

### DIFF
--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -191,6 +191,7 @@ async def handle_message(
         session_state=session_state,
         skills=_resolve_skills(skill_registry, skills),
         skill_registry=skill_registry,
+        max_rounds=config.max_loop_rounds,
     )
     _LOGGER.info("loop outcome: %s", outcome.kind)
     await message.channel.send(_truncate_for_discord(outcome.reply))

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -21,6 +21,7 @@ from crawdad.composer import SonnetComposer
 from crawdad.config import (
     DEFAULT_COMPOSER_MODEL,
     DEFAULT_ROUTER_MODEL,
+    MAX_LOOP_ROUNDS,
     load_config,
 )
 from crawdad.history import ConversationHistory
@@ -109,6 +110,7 @@ def run_bot(config: CrawDadConfig) -> None:
         components=components,
         session_state=session_state,
         skill_registry=skill_registry,
+        max_rounds=config.max_loop_rounds,
     )
     client = CrawDadClient(
         config=config,
@@ -131,6 +133,7 @@ def _build_loop_runner(
     components: _AgentComponents,
     session_state: SessionState | None,
     skill_registry: SkillStackRegistry,
+    max_rounds: int = MAX_LOOP_ROUNDS,
 ) -> LoopRunner | None:
     """Return a closure that runs one loop turn end-to-end.
 
@@ -139,7 +142,9 @@ def _build_loop_runner(
     agent loop isn't wired (no router → no slash commands).
 
     The closure captures the :class:`SkillStackRegistry` so FEAT-029
-    register switches persist across turns within the same bot session.
+    register switches persist across turns within the same bot session,
+    and the operator-configured ``max_rounds`` (FEAT-036) so slash-command
+    turns honour the same cap as plain-message turns.
     """
     if components.router is None or components.composer is None:
         return None
@@ -172,6 +177,7 @@ def _build_loop_runner(
                 session_state=session_state,
                 skills=skill_registry.stack,
                 skill_registry=skill_registry,
+                max_rounds=max_rounds,
             )
             return _truncate_for_discord(outcome.reply)
         except Exception:

--- a/crawdad/crawdad/config.py
+++ b/crawdad/crawdad/config.py
@@ -245,6 +245,15 @@ class CrawDadConfig(BaseModel):
     allowed_user_ids: tuple[int, ...]
     allowed_channel_ids: tuple[int, ...]
     attachments: AttachmentConfig = Field(default_factory=AttachmentConfig)
+    max_loop_rounds: int = Field(default=MAX_LOOP_ROUNDS, ge=1, le=50)
+    """Hard cap on the FEAT-015 agent loop (FEAT-036 / #312).
+
+    Raise this when legitimate multi-step requests trip the default
+    ceiling — re-ingesting a multi-source vault, large re-classification
+    asks, long workflows — and produce the ``too_deep`` fallback in
+    Discord. The upper bound of 50 prevents runaway loops and cost; the
+    lower bound of 1 keeps the engine sane.
+    """
 
     @field_validator("allowed_user_ids", "allowed_channel_ids")
     @classmethod

--- a/crawdad/crawdad/loop.py
+++ b/crawdad/crawdad/loop.py
@@ -298,6 +298,7 @@ async def run_one_turn(
     session_state: SessionState | None,
     skills: VoiceSkillStack,
     skill_registry: SkillStackRegistry | None = None,
+    max_rounds: int = MAX_LOOP_ROUNDS,
 ) -> LoopOutcome:
     """Convenience wrapper the bot handler calls.
 
@@ -309,6 +310,9 @@ async def run_one_turn(
     active skill stack from the registry and routes
     ``crawdad.activate_register`` intents through it so the register
     switch persists across turns.
+
+    ``max_rounds`` (FEAT-036) — overrides the module default for callers
+    that surface the cap via :class:`~crawdad.config.CrawDadConfig`.
     """
     loop = AgentLoop(
         router=router,
@@ -319,5 +323,6 @@ async def run_one_turn(
         session_state=session_state,
         skills=skills,
         skill_registry=skill_registry,
+        max_rounds=max_rounds,
     )
     return await loop.run(message)

--- a/crawdad/tests/test_config.py
+++ b/crawdad/tests/test_config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from crawdad.config import CrawDadConfig, load_config
+from crawdad.config import MAX_LOOP_ROUNDS, CrawDadConfig, load_config
 
 
 def test_config_requires_discord_token_and_anthropic_key(tmp_path: Path) -> None:
@@ -248,3 +248,75 @@ def test_load_config_reject_on_mime_mismatch_defaults_false_when_absent(
 
     config = load_config(yaml_path)
     assert config.attachments.reject_on_mime_mismatch is False
+
+
+def test_config_max_loop_rounds_defaults_to_module_constant() -> None:
+    """When absent, ``max_loop_rounds`` mirrors :data:`MAX_LOOP_ROUNDS` (FEAT-036)."""
+    config = CrawDadConfig(
+        discord_bot_token="t",
+        anthropic_api_key="k",
+        vault_path=Path("."),
+        allowed_user_ids=(1,),
+        allowed_channel_ids=(2,),
+    )
+    assert config.max_loop_rounds == MAX_LOOP_ROUNDS
+
+
+def test_config_accepts_max_loop_rounds_override() -> None:
+    """An explicit ``max_loop_rounds`` value is honoured (FEAT-036)."""
+    config = CrawDadConfig(
+        discord_bot_token="t",
+        anthropic_api_key="k",
+        vault_path=Path("."),
+        allowed_user_ids=(1,),
+        allowed_channel_ids=(2,),
+        max_loop_rounds=12,
+    )
+    assert config.max_loop_rounds == 12
+
+
+def test_config_rejects_max_loop_rounds_below_one() -> None:
+    """``max_loop_rounds`` < 1 fails validation (FEAT-036)."""
+    with pytest.raises(ValidationError):
+        CrawDadConfig(
+            discord_bot_token="t",
+            anthropic_api_key="k",
+            vault_path=Path("."),
+            allowed_user_ids=(1,),
+            allowed_channel_ids=(2,),
+            max_loop_rounds=0,
+        )
+
+
+def test_config_rejects_max_loop_rounds_above_fifty() -> None:
+    """``max_loop_rounds`` > 50 fails validation — runaway-loop guard (FEAT-036)."""
+    with pytest.raises(ValidationError):
+        CrawDadConfig(
+            discord_bot_token="t",
+            anthropic_api_key="k",
+            vault_path=Path("."),
+            allowed_user_ids=(1,),
+            allowed_channel_ids=(2,),
+            max_loop_rounds=51,
+        )
+
+
+def test_load_config_parses_max_loop_rounds_from_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A YAML-supplied ``max_loop_rounds`` flows through ``load_config`` (FEAT-036)."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    yaml_path = tmp_path / "crawdad.yaml"
+    yaml_path.write_text(
+        "vault_path: " + str(vault) + "\n"
+        "allowed_user_ids: [111]\n"
+        "allowed_channel_ids: [222]\n"
+        "max_loop_rounds: 15\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "t")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    config = load_config(yaml_path)
+    assert config.max_loop_rounds == 15

--- a/crawdad/tests/test_loop.py
+++ b/crawdad/tests/test_loop.py
@@ -679,3 +679,69 @@ async def test_loop_uses_known_intent_handling(
     name, args = session.calls[0]
     assert name == "creek.state.read"
     assert args["privacy_tier_ceiling"] == "personal"
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_honours_explicit_max_rounds(
+    state: SessionState, skills: VoiceSkillStack
+) -> None:
+    """``run_one_turn`` threads ``max_rounds`` into the underlying loop (FEAT-036).
+
+    Scripts ``max_rounds + 1`` non-composing router passes; with the
+    explicit override the cap should fire at the configured round, well
+    before the default :data:`MAX_LOOP_ROUNDS`.
+    """
+    custom_cap = 2
+    scripted = [
+        RouterResponse(intents=[Intent(type="creek.state.read")])
+        for _ in range(custom_cap + 1)
+    ]
+    router = _ScriptedRouter(scripted)
+    composer = _ScriptedComposer("(unused — custom cap should fire first)")
+    session = _ScriptedSession(replies={"creek.state.read": "body"})
+    history = ConversationHistory()
+
+    outcome: LoopOutcome = await run_one_turn(
+        message="re-ingest everything",
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(session),  # type: ignore[arg-type]
+        known_tools=("creek.state.read",),
+        history=history,
+        session_state=state,
+        skills=skills,
+        max_rounds=custom_cap,
+    )
+
+    assert outcome.kind == "too_deep"
+    # Router was called exactly ``custom_cap`` times — not ``MAX_LOOP_ROUNDS``.
+    assert len(router.calls) == custom_cap
+    assert composer.calls == []
+
+
+@pytest.mark.asyncio
+async def test_run_one_turn_defaults_max_rounds_to_module_constant(
+    state: SessionState, skills: VoiceSkillStack
+) -> None:
+    """Omitting ``max_rounds`` preserves the default :data:`MAX_LOOP_ROUNDS` cap."""
+    scripted = [
+        RouterResponse(intents=[Intent(type="creek.state.read")])
+        for _ in range(MAX_LOOP_ROUNDS + 1)
+    ]
+    router = _ScriptedRouter(scripted)
+    composer = _ScriptedComposer("(unused)")
+    session = _ScriptedSession(replies={"creek.state.read": "body"})
+
+    outcome = await run_one_turn(
+        message="loop",
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(session),  # type: ignore[arg-type]
+        known_tools=("creek.state.read",),
+        history=ConversationHistory(),
+        session_state=state,
+        skills=skills,
+    )
+
+    assert outcome.kind == "too_deep"
+    assert len(router.calls) == MAX_LOOP_ROUNDS


### PR DESCRIPTION
## Summary
Closes #312. Surfaces the previously-hard-coded 5-round agent-loop cap as a configurable knob in `crawdad.yaml`.

```yaml
max_loop_rounds: 12   # raise when re-ingest / re-classify / long workflows trip the default cap
```

## Why
CrawDad's `MAX_LOOP_ROUNDS: int = 5` cap was parameterised at the `AgentLoop` level but not surfaced to operators. Legitimate multi-step requests — *"Can you re-submit the 188 fragments? Start over fresh with them?"* — trip the default ceiling and the bot replies with the generic *"I went too deep on this — let's back up. Can you reframe what you're looking for?"* fallback. Operators currently have no recourse short of editing source.

## Change shape
- `crawdad/config.py` — `CrawDadConfig.max_loop_rounds: int = Field(default=MAX_LOOP_ROUNDS, ge=1, le=50)`. The bounds keep the engine sane and prevent runaway cost.
- `crawdad/loop.py::run_one_turn` — new `max_rounds: int = MAX_LOOP_ROUNDS` kwarg, threaded into the underlying `AgentLoop(max_rounds=...)`.
- `crawdad/cli.py::_build_loop_runner` — accepts `max_rounds` (default `MAX_LOOP_ROUNDS` preserves existing test callers); the slash-command runner closure threads it into `run_one_turn`. The `run_bot` flow passes `config.max_loop_rounds`.
- `crawdad/bot.py::handle_message` — passes `config.max_loop_rounds` to `run_one_turn`.

## Behaviour
| `crawdad.yaml` | Result |
| --- | --- |
| Absent | Cap = 5 (unchanged). |
| `max_loop_rounds: 12` | Cap = 12. |
| `max_loop_rounds: 0` | `ValidationError` at startup — clear message. |
| `max_loop_rounds: 99` | `ValidationError` (upper bound 50). |

The `too_deep` outcome path is unchanged; it just fires at the operator-configured cap rather than the hard-coded constant.

## Tests
- `tests/test_config.py` — defaults to `MAX_LOOP_ROUNDS`, accepts explicit override, rejects `0` and `>50`, parses from YAML.
- `tests/test_loop.py` — `run_one_turn` honours an explicit `max_rounds` (asserts `too_deep` at the configured round and the router was called exactly that many times); omitting `max_rounds` preserves the module-default cap.

All existing `test_cli.py` (4 callers of `_build_loop_runner`) and `test_bot.py` tests continue to pass — the new parameter defaults preserve backwards compatibility.

Local: ruff format clean, ruff check clean, focused pytest 37/37 passing on changed test files + 53/53 on cli+bot tests.

## Out of scope
- Per-intent or per-tool round budgeting.
- Smarter Haiku batching so re-ingest doesn't *need* many rounds in the first place.
- Updating `crawdad/CLAUDE.md`'s reference to the 5-round cap (a documentation cleanup that belongs in a small follow-up).

## Test plan
- [ ] CI: ruff format + lint clean across both subprojects.
- [ ] CI: unit tests pass — five new config tests + two new loop tests + unchanged cli/bot tests.
- [ ] CI: coverage ≥90% on changed code paths.
- [ ] Manual: with `max_loop_rounds: 12` in `crawdad.yaml`, the prompt *"Can you re-submit the 188 fragments? Start over fresh with them?"* no longer trips `too_deep` (assuming MCP is wired post-#303).

🤖 Generated with [Claude Code](https://claude.com/claude-code)