### PR TITLE
feat(crawdad): configurable agent-loop max_rounds via crawdad.yaml (FEAT-036)

### DIFF
--- a/crawdad/CLAUDE.md
+++ b/crawdad/CLAUDE.md
@@ -30,8 +30,10 @@ complete and ships:
 
 - Connection to `creek-tools-mcp` (FEAT-010/011/012) over stdio.
 - The two-LLM agent loop: Haiku router (FEAT-014) → MCP dispatcher →
-  Sonnet composer (FEAT-015), capped at 5 rounds with paradox auto-
-  routing to `10-Liminal/Paradoxes/`.
+  Sonnet composer (FEAT-015), capped at `MAX_LOOP_ROUNDS` (default 5;
+  operator-configurable via `crawdad.yaml::max_loop_rounds`, bounded
+  `[1, 50]` — FEAT-036) with paradox auto-routing to
+  `10-Liminal/Paradoxes/`.
 - Voice-skill activation per session from `<vault>/creek-skills/`
   (voice-core + phase + register).
 - Six `/crawdad` Discord slash commands (FEAT-016): `reflect`,
@@ -86,6 +88,8 @@ Four gates, each must pass before the next:
     `[creek-tools-mcp]`).
   - `allowed_user_ids` — Discord user ids that may message the bot.
   - `allowed_channel_ids` — channels the bot will respond in.
+  - `max_loop_rounds` — optional FEAT-036 override for the agent-loop
+    round cap (default `MAX_LOOP_ROUNDS = 5`, bounded `[1, 50]`).
 
 Both allowlists must be non-empty — an empty list is a configuration
 error, not "open to everyone".

--- a/crawdad/README.md
+++ b/crawdad/README.md
@@ -10,8 +10,10 @@ CrawDad v1.0 ships:
 - A `discord.py` client that connects to Discord and forwards messages
   to a pure-logic handler.
 - The two-LLM agent loop (FEAT-014 + FEAT-015) — Haiku for intent
-  extraction, Sonnet for voice-faithful composition, capped at 5
-  rounds with paradox routing to `10-Liminal/Paradoxes/`.
+  extraction, Sonnet for voice-faithful composition, capped at
+  `MAX_LOOP_ROUNDS` (default 5; operator-configurable via
+  `crawdad.yaml::max_loop_rounds`, bounded `[1, 50]` — FEAT-036) with
+  paradox routing to `10-Liminal/Paradoxes/`.
 - An async MCP stdio client wrapping the Anthropic `mcp` SDK.
 - Voice-skill activation per session from `<vault>/creek-skills/`.
 - The six `/crawdad` slash commands (FEAT-016): `reflect`, `checkin`,
@@ -44,7 +46,25 @@ allowed_user_ids:
   - 123456789012345678   # the developer's Discord user id
 allowed_channel_ids:
   - 234567890123456789   # the channel the bot will respond in
+# Optional FEAT-036 knob: raise the agent-loop round cap when a single
+# user turn legitimately needs more router/dispatcher passes (multi-
+# source ingest, large re-classification asks, long workflow chains).
+# Default 5; bounded [1, 50] — the upper bound prevents pathological
+# runaway loops. Omit the key to keep the v1 default.
+# max_loop_rounds: 12
 ```
+
+### Configuration keys
+
+| Key | Required | Default | Notes |
+|---|---|---|---|
+| `vault_path` | yes | — | Absolute path to the Obsidian vault root. |
+| `mcp_server_command` | no | `[creek-tools-mcp]` | argv for the MCP subprocess. |
+| `allowed_user_ids` | yes | — | Discord user ids permitted to message the bot. |
+| `allowed_channel_ids` | yes | — | Channels the bot will respond in. |
+| `attachments` | no | see source | Per-attachment limits, allow/deny lists, channel privacy tiers (FEAT-027/035). |
+| `consent` | no | see source | Conversational consent tokens + TTL (FEAT-034). |
+| `max_loop_rounds` | no | `5` | FEAT-036 agent-loop round cap, bounded `[1, 50]`. Raise when a single user turn legitimately needs more router/dispatcher passes (multi-source ingest, large re-classification asks, long workflow chains); the upper bound prevents pathological runaway loops. |
 
 ## Slash commands (FEAT-016)
 
@@ -87,7 +107,7 @@ CrawDadClient.{on_message, /crawdad <cmd>}  (crawdad/bot.py + slash_commands.py)
   ▼
 handle_message  /  loop_runner closure
   ▼
-loop.run_one_turn   (FEAT-015 agent loop, capped at 5 rounds)
+loop.run_one_turn   (FEAT-015 agent loop, capped at max_loop_rounds; default 5)
   ▼  ┌──────────────────────────────────────────────────────────┐
      │ Haiku router (FEAT-014)   →   JSON intents               │
      │ MCP dispatcher            →   creek.state / lint / ...   │

--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -8,7 +8,8 @@ decision lives here.
 FEAT-015 wires the full agent loop: the handler hands off to
 :func:`crawdad.loop.run_one_turn`, which orchestrates router →
 dispatcher → composer with a hard cap of
-:data:`crawdad.config.MAX_LOOP_ROUNDS`. The handler's other
+:attr:`CrawDadConfig.max_loop_rounds` (default
+:data:`crawdad.config.MAX_LOOP_ROUNDS`; FEAT-036). The handler's other
 responsibilities are the allowlist gate, the session-state fallback,
 posting the loop's reply, and (FEAT-027) processing Discord
 attachments through the safety pass before any ingest.
@@ -238,6 +239,7 @@ async def handle_message(
         session_state=session_state,
         skills=_resolve_skills(skill_registry, skills),
         skill_registry=skill_registry,
+        max_rounds=config.max_loop_rounds,
     )
     _LOGGER.info("loop outcome: %s", outcome.kind)
     await message.channel.send(_truncate_for_discord(outcome.reply))

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -113,6 +113,7 @@ def run_bot(config: CrawDadConfig) -> None:
         components=components,
         session_state=session_state,
         skill_registry=skill_registry,
+        max_rounds=config.max_loop_rounds,
     )
     client = CrawDadClient(
         config=config,
@@ -136,6 +137,7 @@ def _build_loop_runner(
     components: _AgentComponents,
     session_state: SessionState | None,
     skill_registry: SkillStackRegistry,
+    max_rounds: int,
 ) -> LoopRunner | None:
     """Return a closure that runs one loop turn end-to-end.
 
@@ -145,6 +147,10 @@ def _build_loop_runner(
 
     The closure captures the :class:`SkillStackRegistry` so FEAT-029
     register switches persist across turns within the same bot session.
+
+    ``max_rounds`` (FEAT-036) is forwarded to :func:`run_one_turn` so
+    the configured cap applies uniformly to free-text turns and slash
+    commands.
     """
     if components.router is None or components.composer is None:
         return None
@@ -177,6 +183,7 @@ def _build_loop_runner(
                 session_state=session_state,
                 skills=skill_registry.stack,
                 skill_registry=skill_registry,
+                max_rounds=max_rounds,
             )
             return _truncate_for_discord(outcome.reply)
         except Exception:

--- a/crawdad/crawdad/config.py
+++ b/crawdad/crawdad/config.py
@@ -328,6 +328,8 @@ class CrawDadConfig(BaseModel):
     allowed_channel_ids: tuple[int, ...]
     attachments: AttachmentConfig = Field(default_factory=AttachmentConfig)
     consent: ConsentConfig = Field(default_factory=ConsentConfig)
+    max_loop_rounds: int = Field(default=MAX_LOOP_ROUNDS, ge=1, le=50)
+    """Operator override for the FEAT-015 agent-loop round cap."""
 
     @field_validator("allowed_user_ids", "allowed_channel_ids")
     @classmethod

--- a/crawdad/crawdad/loop.py
+++ b/crawdad/crawdad/loop.py
@@ -1,4 +1,4 @@
-"""Five-round agent loop (FEAT-015).
+"""Bounded-round agent loop (FEAT-015, FEAT-036).
 
 Orchestrates the FEAT-014 router + dispatcher around the FEAT-015
 Sonnet composer. The loop's contract:
@@ -21,12 +21,16 @@ Sonnet composer. The loop's contract:
           dispatcher.dispatch(intents)  →  aggregate ToolResults
               │
               ▼
-       (loop until MAX_LOOP_ROUNDS rounds; the 6th attempt is refused)
+       (loop until ``max_rounds`` rounds; the next attempt is refused)
+
+The cap defaults to :data:`MAX_LOOP_ROUNDS` (5) and can be raised or
+lowered per deployment via the ``max_loop_rounds`` key in
+``crawdad.yaml`` (FEAT-036, bounded ``[1, 50]``).
 
 Side-effects: the loop appends ``user`` and ``assistant`` turns to the
 shared :class:`ConversationHistory` (the source the next router pass
-consumes). On the 6th-round refusal the history is cleared per FEAT-015
-§pre-decided choice §27.
+consumes). On a cap-exhaustion refusal the history is cleared per
+FEAT-015 §pre-decided choice §27.
 
 Paradox routing (§31): if any tool result mentions a paradox AND the
 advertised tool set includes ``creek.save``, the loop injects a
@@ -298,6 +302,7 @@ async def run_one_turn(
     session_state: SessionState | None,
     skills: VoiceSkillStack,
     skill_registry: SkillStackRegistry | None = None,
+    max_rounds: int = MAX_LOOP_ROUNDS,
 ) -> LoopOutcome:
     """Convenience wrapper the bot handler calls.
 
@@ -309,6 +314,11 @@ async def run_one_turn(
     active skill stack from the registry and routes
     ``crawdad.activate_register`` intents through it so the register
     switch persists across turns.
+
+    ``max_rounds`` (FEAT-036) — operator-configurable cap forwarded to
+    :class:`AgentLoop`. Defaults to :data:`MAX_LOOP_ROUNDS` so callers
+    that do not thread the config value preserve the pre-FEAT-036
+    behaviour.
     """
     loop = AgentLoop(
         router=router,
@@ -319,5 +329,6 @@ async def run_one_turn(
         session_state=session_state,
         skills=skills,
         skill_registry=skill_registry,
+        max_rounds=max_rounds,
     )
     return await loop.run(message)

--- a/crawdad/tests/test_bot.py
+++ b/crawdad/tests/test_bot.py
@@ -570,6 +570,63 @@ async def test_handle_message_truncates_long_composer_output(
     assert len(channel.sent[0]) < 5000
 
 
+async def test_handle_message_respects_configured_max_loop_rounds(
+    session_state: SessionState, tmp_path: Path
+) -> None:
+    """FEAT-036: a configured ``max_loop_rounds`` reaches the agent loop.
+
+    The router scripts three back-to-back tool-call rounds. With the
+    config-level cap pinned at 2, the loop must hit ``too_deep`` on the
+    third router pass rather than composing.
+    """
+    from crawdad.intents import Intent, RouterResponse
+
+    config = CrawDadConfig(
+        discord_bot_token="t",
+        anthropic_api_key="k",
+        vault_path=tmp_path,
+        allowed_user_ids=[111],
+        allowed_channel_ids=[999],
+        max_loop_rounds=2,
+    )
+
+    router_responses = iter(
+        [
+            RouterResponse(intents=[Intent(type="creek.state.read")]),
+            RouterResponse(intents=[Intent(type="creek.state.read")]),
+            RouterResponse(intents=[], compose=True),
+        ]
+    )
+
+    class _SeqRouter:
+        async def extract_intents(self, **_kwargs: Any) -> Any:
+            return next(router_responses)
+
+    composer = _StubComposer("(unused - cap should fire first)")
+    mcp_client = _StubMCPClient(_StubSession(replies={"creek.state.read": "body"}))
+    channel = _FakeChannel(id=999, sent=[])
+    message: Any = _FakeMessage(
+        author=_FakeAuthor(id=111),
+        channel=channel,
+        content="loop forever",
+    )
+
+    await handle_message(
+        message,
+        config=config,
+        session_state=session_state,
+        bot_user_id=42,
+        router=_SeqRouter(),  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=mcp_client,  # type: ignore[arg-type]
+        known_tools=("creek.state.read",),
+    )
+
+    assert len(channel.sent) == 1
+    assert "back up" in channel.sent[0].lower() or "reframe" in channel.sent[0].lower()
+    assert composer.calls == []
+
+
 async def test_handle_message_without_loop_components_uses_stub_reply(
     config: CrawDadConfig, session_state: SessionState
 ) -> None:

--- a/crawdad/tests/test_cli.py
+++ b/crawdad/tests/test_cli.py
@@ -275,6 +275,7 @@ def test_build_loop_runner_returns_none_when_loop_not_wired(
         components=components,
         session_state=None,
         skill_registry=_empty_registry(tmp_path),
+        max_rounds=5,
     )
 
     assert runner is None
@@ -301,6 +302,7 @@ def test_build_loop_runner_returns_callable_when_loop_wired(
         components=components,
         session_state=None,
         skill_registry=_empty_registry(tmp_path),
+        max_rounds=5,
     )
 
     assert runner is not None
@@ -345,6 +347,7 @@ async def test_loop_runner_truncates_long_replies(
         components=components,
         session_state=None,
         skill_registry=_empty_registry(tmp_path),
+        max_rounds=5,
     )
 
     assert runner is not None
@@ -388,11 +391,51 @@ async def test_loop_runner_returns_soft_error_on_exception(
         components=components,
         session_state=None,
         skill_registry=_empty_registry(tmp_path),
+        max_rounds=5,
     )
 
     assert runner is not None
     reply = await runner("anything")
     assert "creek-tools" in reply.lower() or "wrong" in reply.lower()
+
+
+async def test_loop_runner_forwards_max_rounds_into_run_one_turn(
+    patched_config: CrawDadConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """FEAT-036: ``_build_loop_runner``'s ``max_rounds`` reaches ``run_one_turn``."""
+    from crawdad.loop import LoopOutcome
+    from crawdad.mcp_client import ToolDetails
+
+    details = (
+        ToolDetails(
+            name="creek.state.read",
+            description="Read latest.md",
+            input_schema={"type": "object"},
+        ),
+    )
+    components = cli._build_agent_components(
+        config=patched_config, tool_details=details
+    )
+    captured: dict[str, Any] = {}
+
+    async def _capture(**kwargs: Any) -> LoopOutcome:
+        captured.update(kwargs)
+        return LoopOutcome(kind="composed", reply="ok")
+
+    monkeypatch.setattr(cli, "run_one_turn", _capture)
+
+    runner = cli._build_loop_runner(
+        components=components,
+        session_state=None,
+        skill_registry=_empty_registry(tmp_path),
+        max_rounds=17,
+    )
+
+    assert runner is not None
+    await runner("anything")
+    assert captured["max_rounds"] == 17
 
 
 def test_run_bot_wires_skill_registry_and_register_switcher(

--- a/crawdad/tests/test_config.py
+++ b/crawdad/tests/test_config.py
@@ -354,3 +354,124 @@ def test_load_config_parses_consent_overrides(
     assert config.consent.consent_tokens == frozenset({"do it"})
     assert config.consent.abandon_tokens == frozenset({"hold off"})
     assert config.consent.pending_batch_ttl_seconds == 60.0
+
+
+# ---------------------------------------------------------------------------
+# FEAT-036 — max_loop_rounds knob
+# ---------------------------------------------------------------------------
+
+
+def test_config_max_loop_rounds_defaults_to_module_constant(tmp_path: Path) -> None:
+    """Absent ``max_loop_rounds`` preserves the pre-FEAT-036 cap (5)."""
+    from crawdad.config import MAX_LOOP_ROUNDS
+
+    config = CrawDadConfig(
+        discord_bot_token="t",
+        anthropic_api_key="k",
+        vault_path=tmp_path,
+        allowed_user_ids=[1],
+        allowed_channel_ids=[2],
+    )
+
+    assert config.max_loop_rounds == MAX_LOOP_ROUNDS
+
+
+def test_config_accepts_max_loop_rounds_override(tmp_path: Path) -> None:
+    """An operator-supplied override survives the model boundary."""
+    config = CrawDadConfig(
+        discord_bot_token="t",
+        anthropic_api_key="k",
+        vault_path=tmp_path,
+        allowed_user_ids=[1],
+        allowed_channel_ids=[2],
+        max_loop_rounds=12,
+    )
+
+    assert config.max_loop_rounds == 12
+
+
+def test_config_accepts_max_loop_rounds_boundary_values() -> None:
+    """``max_loop_rounds`` accepts the inclusive bounds 1 and 50 (FEAT-036)."""
+    for boundary in (1, 50):
+        config = CrawDadConfig(
+            discord_bot_token="t",
+            anthropic_api_key="k",
+            vault_path=Path("."),
+            allowed_user_ids=(1,),
+            allowed_channel_ids=(2,),
+            max_loop_rounds=boundary,
+        )
+        assert config.max_loop_rounds == boundary
+
+
+def test_config_rejects_max_loop_rounds_below_lower_bound(tmp_path: Path) -> None:
+    """Zero and negative values fail validation with a clear pydantic error."""
+    for invalid in (0, -1):
+        with pytest.raises(ValidationError):
+            CrawDadConfig(
+                discord_bot_token="t",
+                anthropic_api_key="k",
+                vault_path=tmp_path,
+                allowed_user_ids=[1],
+                allowed_channel_ids=[2],
+                max_loop_rounds=invalid,
+            )
+
+
+def test_config_rejects_max_loop_rounds_above_upper_bound(tmp_path: Path) -> None:
+    """Values past the hard upper bound (50) fail validation."""
+    for invalid in (51, 1000):
+        with pytest.raises(ValidationError):
+            CrawDadConfig(
+                discord_bot_token="t",
+                anthropic_api_key="k",
+                vault_path=tmp_path,
+                allowed_user_ids=[1],
+                allowed_channel_ids=[2],
+                max_loop_rounds=invalid,
+            )
+
+
+def test_load_config_parses_max_loop_rounds_from_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A YAML override for ``max_loop_rounds`` round-trips through ``load_config``."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    yaml_path = tmp_path / "crawdad.yaml"
+    yaml_path.write_text(
+        "vault_path: " + str(vault) + "\n"
+        "allowed_user_ids: [111]\n"
+        "allowed_channel_ids: [222]\n"
+        "max_loop_rounds: 12\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "t")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    config = load_config(yaml_path)
+
+    assert config.max_loop_rounds == 12
+
+
+def test_load_config_max_loop_rounds_defaults_when_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A YAML without ``max_loop_rounds`` keeps the pre-FEAT-036 cap."""
+    from crawdad.config import MAX_LOOP_ROUNDS
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    yaml_path = tmp_path / "crawdad.yaml"
+    yaml_path.write_text(
+        "vault_path: " + str(vault) + "\n"
+        "allowed_user_ids: [111]\n"
+        "allowed_channel_ids: [222]\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "t")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "k")
+
+    config = load_config(yaml_path)
+
+    assert config.max_loop_rounds == MAX_LOOP_ROUNDS

--- a/crawdad/tests/test_loop.py
+++ b/crawdad/tests/test_loop.py
@@ -679,3 +679,68 @@ async def test_loop_uses_known_intent_handling(
     name, args = session.calls[0]
     assert name == "creek.state.read"
     assert args["privacy_tier_ceiling"] == "personal"
+
+
+async def test_run_one_turn_forwards_max_rounds_to_agent_loop(
+    state: SessionState, skills: VoiceSkillStack
+) -> None:
+    """FEAT-036: ``run_one_turn`` propagates ``max_rounds`` into the loop cap.
+
+    Two rounds of tool calls followed by a third would normally compose
+    fine — but with ``max_rounds=2`` the loop must refuse on the third
+    router pass with the ``too_deep`` outcome instead of composing.
+    """
+    scripted = [
+        RouterResponse(intents=[Intent(type="creek.state.read")]),
+        RouterResponse(intents=[Intent(type="creek.state.read")]),
+        RouterResponse(intents=[], compose=True),
+    ]
+    router = _ScriptedRouter(scripted)
+    composer = _ScriptedComposer("(unused - cap should fire first)")
+    history = ConversationHistory()
+
+    outcome = await run_one_turn(
+        message="loop forever",
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(
+            _ScriptedSession(replies={"creek.state.read": "body"})
+        ),  # type: ignore[arg-type]
+        known_tools=("creek.state.read",),
+        history=history,
+        session_state=state,
+        skills=skills,
+        max_rounds=2,
+    )
+
+    assert outcome.kind == "too_deep"
+    assert composer.calls == []
+    assert history.as_list() == []
+
+
+async def test_run_one_turn_default_max_rounds_uses_module_constant(
+    state: SessionState, skills: VoiceSkillStack
+) -> None:
+    """``run_one_turn`` without ``max_rounds`` inherits ``MAX_LOOP_ROUNDS``."""
+    scripted = [
+        RouterResponse(intents=[Intent(type="creek.state.read")])
+        for _ in range(MAX_LOOP_ROUNDS + 1)
+    ]
+    router = _ScriptedRouter(scripted)
+    composer = _ScriptedComposer("(unused)")
+
+    outcome = await run_one_turn(
+        message="loop forever",
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(
+            _ScriptedSession(replies={"creek.state.read": "body"})
+        ),  # type: ignore[arg-type]
+        known_tools=("creek.state.read",),
+        history=ConversationHistory(),
+        session_state=state,
+        skills=skills,
+    )
+
+    assert outcome.kind == "too_deep"
+    assert len(router.calls) == MAX_LOOP_ROUNDS


### PR DESCRIPTION
## Summary

FEAT-036 surfaces the FEAT-015 agent-loop round cap as a configurable knob in `crawdad.yaml` so operators can tune it without code changes. Bundles all four related issues into one PR.

- **#312 (FEAT-036)** — adds `CrawDadConfig.max_loop_rounds: int = Field(default=MAX_LOOP_ROUNDS, ge=1, le=50)` and threads it from `bot.handle_message` and `cli._build_loop_runner` through `run_one_turn(..., max_rounds=...)` into `AgentLoop(max_rounds=...)`. Absent key keeps the v1 cap of 5.
- **#314** — `crawdad/CLAUDE.md` and `crawdad/README.md` now describe the cap as `MAX_LOOP_ROUNDS` (default 5; operator-configurable via `crawdad.yaml::max_loop_rounds`, bounded `[1, 50]` — FEAT-036). README gains a configuration-keys table that includes `max_loop_rounds`.
- **#315** — the field docstring is one short line per the CLAUDE.md rule (`"""Operator override for the FEAT-015 agent-loop round cap."""`). All operational guidance (when to raise it, the upper-bound rationale) lives in the README configuration section and the inline YAML example comment, not in the source.
- **#316** — `tests/test_config.py` gains the boundary-value acceptance test at `1` and `50` and the symmetric rejection tests at `0`, `-1`, `51`, and `1000`, plus a YAML round-trip test and a default-when-absent regression test.

Integration tests verify the configured value reaches the loop end-to-end:

- `tests/test_loop.py::test_run_one_turn_forwards_max_rounds_to_agent_loop` (cap=2 → `too_deep` on 3rd router pass).
- `tests/test_bot.py::test_handle_message_respects_configured_max_loop_rounds` (`CrawDadConfig(max_loop_rounds=2)` flows through `handle_message`).
- `tests/test_cli.py::test_loop_runner_forwards_max_rounds_into_run_one_turn` (slash-command path captures the configured value via the closure).

## Test plan

- [x] `./scripts/check-all.sh` exits 0 (Ruff, MyPy strict, Bandit, interrogate 98.5%, complexity, pytest 314 passed, branch coverage 95.04%).
- [x] `./scripts/test.sh` passes including the new boundary tests at 1/50 and rejection tests at 0/-1/51/1000.
- [x] Manual sanity: `CrawDadConfig(..., max_loop_rounds=12)` constructs and `run_one_turn(..., max_rounds=cfg.max_loop_rounds)` drives `AgentLoop` to refuse with `too_deep` after exactly 12 rounds (`router.calls == 12`).
- [x] Manual sanity: `max_loop_rounds=0` and `max_loop_rounds=1000` both raise `pydantic.ValidationError`.
- [x] Existing `too_deep` outcome still fires correctly when the configured cap is reached.
- [x] YAML without the key keeps the v1 default of 5.

Closes #312
Closes #314
Closes #315
Closes #316

https://claude.ai/code/session_011e4q4ZQcwtP9zVEp21T6ki

---
_Generated by [Claude Code](https://claude.ai/code/session_011e4q4ZQcwtP9zVEp21T6ki)_