### PR TITLE
feat(crawdad): Jig-style workflow DSL skeleton (ADAPT-003 Phase 1)

### DIFF
--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -12,7 +12,7 @@ import argparse
 import asyncio
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import anthropic
 
@@ -31,6 +31,13 @@ from crawdad.mcp_client import MCPClient, MCPUnavailableError
 from crawdad.router import IntentRouter
 from crawdad.skill_loader import SkillStackRegistry, load_skills_for_session
 from crawdad.state import StateUnavailableError, load_session_state
+from crawdad.workflows import (
+    WorkflowConstraintError,
+    WorkflowNotFoundError,
+    WorkflowRegistry,
+    bundled_workflows_dir,
+    dry_run_workflow,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -55,13 +62,23 @@ def _truncate_for_discord(text: str) -> str:
     return text[: _DISCORD_REPLY_LIMIT - 3] + "..."
 
 
-def main(argv: Sequence[str] | None = None) -> None:
-    """Parse *argv*, resolve config, and start the runtime."""
+def main(argv: Sequence[str] | None = None) -> int:
+    """Parse *argv*, resolve config, and dispatch to the requested subcommand.
+
+    Returns:
+        Process exit code. ``0`` on success, non-zero when a subcommand
+        (e.g. ``workflows run``) declines to execute because a declared
+        constraint isn't satisfied.
+    """
     parser = _build_parser()
     args = parser.parse_args(argv)
     if args.subcommand == "run":
         config = load_config(args.config)
         run_bot(config)
+        return 0
+    if args.subcommand == "workflows":
+        return _dispatch_workflows(args)
+    return 0
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -75,7 +92,84 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to crawdad.yaml (defaults to ./crawdad.yaml).",
     )
+    _add_workflows_parser(sub)
     return parser
+
+
+def _add_workflows_parser(sub: argparse._SubParsersAction[Any]) -> None:
+    """Wire the ``crawdad workflows {list,run}`` subcommands (ADAPT-003 Phase 1)."""
+    workflows = sub.add_parser(
+        "workflows",
+        help="List or dry-run Jig-style workflows (ADAPT-003 Phase 1).",
+    )
+    workflow_actions = workflows.add_subparsers(dest="workflow_action", required=True)
+    workflow_actions.add_parser("list", help="List the bundled workflows.")
+    run_action = workflow_actions.add_parser(
+        "run",
+        help="Dry-run a workflow by name (Phase 1: prints steps; no dispatch).",
+    )
+    run_action.add_argument("name", help="Workflow name (see `workflows list`).")
+    run_action.add_argument(
+        "--current-phase",
+        default=None,
+        help="Current Wavelength phase (required for phase_aware workflows).",
+    )
+    run_action.add_argument(
+        "--allow-intimate",
+        action="store_true",
+        help="Override the privacy_tier_floor=intimate constraint.",
+    )
+
+
+def _dispatch_workflows(args: argparse.Namespace) -> int:
+    """Dispatch the ``crawdad workflows ...`` subcommand to its handler."""
+    registry = WorkflowRegistry.from_directory(bundled_workflows_dir())
+    if args.workflow_action == "list":
+        return _workflows_list(registry)
+    return _workflows_run(
+        registry,
+        name=args.name,
+        current_phase=args.current_phase,
+        allow_intimate=args.allow_intimate,
+    )
+
+
+def _workflows_list(registry: WorkflowRegistry) -> int:
+    """Print every registered workflow as ``name — description``."""
+    workflows = registry.workflows()
+    if not workflows:
+        print("No workflows registered.")
+        return 0
+    for workflow in workflows:
+        print(f"{workflow.name} — {workflow.description}")
+    return 0
+
+
+def _workflows_run(
+    registry: WorkflowRegistry,
+    *,
+    name: str,
+    current_phase: str | None,
+    allow_intimate: bool,
+) -> int:
+    """Dry-run *name*; return ``0`` on success or ``1`` on constraint refusal."""
+    try:
+        workflow = registry.get(name)
+    except WorkflowNotFoundError as exc:
+        print(f"error: {exc}")
+        return 1
+    try:
+        lines = dry_run_workflow(
+            workflow,
+            current_phase=current_phase,
+            allow_intimate=allow_intimate,
+        )
+    except WorkflowConstraintError as exc:
+        print(f"refused: {exc}")
+        return 1
+    for line in lines:
+        print(line)
+    return 0
 
 
 def run_bot(config: CrawDadConfig) -> None:

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -97,10 +97,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _add_workflows_parser(sub: argparse._SubParsersAction[Any]) -> None:
-    """Wire the ``crawdad workflows {list,run}`` subcommands (ADAPT-003 Phase 1)."""
+    """Wire the ``crawdad workflows {list,run}`` subcommands."""
     workflows = sub.add_parser(
         "workflows",
-        help="List or dry-run Jig-style workflows (ADAPT-003 Phase 1).",
+        help="List or dry-run Jig-style workflows.",
     )
     workflow_actions = workflows.add_subparsers(dest="workflow_action", required=True)
     workflow_actions.add_parser("list", help="List the bundled workflows.")

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -1,4 +1,4 @@
-"""Discord slash commands for CrawDad (FEAT-016 + FEAT-029).
+"""Discord slash commands for CrawDad (FEAT-016 + FEAT-029 + ADAPT-003).
 
 The `/crawdad` family bundles `reflect`, `checkin`, `surface`, `draft`,
 `save`, `register`, and `workflow`. Most routes through the FEAT-015
@@ -15,7 +15,10 @@ discord.py. ``register()`` wraps each handler in a discord.py
 calls exceed Discord's 3-second response window), runs the handler,
 and ``followup.send()``s the reply.
 
-``/crawdad workflow`` is a v1.0 stub. Full workflow DSL ships in v1.1.
+``/crawdad workflow`` (ADAPT-003 Phase 1) mirrors the ``crawdad
+workflows ...`` CLI surface: ``list`` enumerates the bundled
+workflows, ``run <name>`` dry-runs the named workflow's step list
+without dispatching MCP tools. Phase 2 wires the real walker in.
 
 Trust boundary: the user-supplied ``topic`` and ``content`` arguments
 are interpolated directly into LLM prompts. The personal-use allowlist
@@ -30,6 +33,14 @@ from __future__ import annotations
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any, Protocol
+
+from crawdad.workflows import (
+    WorkflowConstraintError,
+    WorkflowNotFoundError,
+    WorkflowRegistry,
+    bundled_workflows_dir,
+    dry_run_workflow,
+)
 
 _LOGGER = logging.getLogger("crawdad.slash_commands")
 
@@ -68,7 +79,7 @@ _COMMAND_DESCRIPTIONS: dict[str, str] = {
     "draft": "Draft an essay on a topic (routes through creek.mine + creek.draft).",
     "save": "File the supplied content back to the vault via creek.save.",
     "register": "Switch the active voice register (FEAT-029).",
-    "workflow": "List or run named workflows (v1.0 stub — full DSL in v1.1).",
+    "workflow": "List or dry-run named workflows (ADAPT-003 Phase 1).",
 }
 
 # Module-level invariant: every command name must have a description and
@@ -94,10 +105,9 @@ _SURFACE_PROMPT = (
     "Surface anything in my vault that's emerging — paradoxes, liminal items, or "
     "drift. Route paradoxes to 10-Liminal/Paradoxes/ via creek.save."
 )
-_WORKFLOW_STUB_REPLY = (
-    "no workflows yet — coming in v1.1.\n\n"
-    "The workflow DSL (ADAPT-003) will let you compose multi-step plans like "
-    "`/crawdad workflow run weekly-review`. v1.0 ships only this `list` stub."
+_WORKFLOW_RUN_MISSING_NAME_REPLY = (
+    "Which workflow should I run? Try `/crawdad workflow run <name>` — "
+    "see `/crawdad workflow list` for the bundled set."
 )
 
 
@@ -207,19 +217,92 @@ async def handle_register(
     )
 
 
-async def handle_workflow(replier: Replier, *, subaction: str | None) -> None:
-    """``/crawdad workflow [list]`` — v1.0 stub.
+async def handle_workflow(
+    replier: Replier,
+    *,
+    subaction: str | None,
+    name: str | None = None,
+    current_phase: str | None = None,
+    allow_intimate: bool = False,
+    registry_loader: Callable[[], WorkflowRegistry] | None = None,
+) -> None:
+    """``/crawdad workflow {list,run}`` — ADAPT-003 Phase 1 surface.
 
-    ``list`` (the default) returns the documented placeholder. Any
-    other subaction returns scoped help — no MCP call, no stack trace.
+    ``list`` (the default) enumerates the bundled workflows. ``run
+    <name>`` dry-runs the named workflow's step list, applying the
+    same constraint checks as the CLI surface. ``registry_loader`` is
+    injected so tests can substitute an in-memory registry; production
+    defaults to the bundled ``crawdad/workflows/`` directory.
     """
-    if subaction in (None, "list"):
-        await replier(_WORKFLOW_STUB_REPLY)
+    action = subaction or "list"
+    if action == "list":
+        await _workflow_list_reply(replier, registry_loader=registry_loader)
+        return
+    if action == "run":
+        await _workflow_run_reply(
+            replier,
+            name=name,
+            current_phase=current_phase,
+            allow_intimate=allow_intimate,
+            registry_loader=registry_loader,
+        )
         return
     await replier(
-        f"unknown workflow subcommand: {subaction!r}. "
-        "Only `/crawdad workflow list` is available in v1.0."
+        f"unknown workflow subcommand: {action!r}. "
+        "Try `/crawdad workflow list` or `/crawdad workflow run <name>`."
     )
+
+
+def _load_default_registry() -> WorkflowRegistry:
+    """Return the bundled-directory registry (separate fn for monkey-patching)."""
+    return WorkflowRegistry.from_directory(bundled_workflows_dir())
+
+
+async def _workflow_list_reply(
+    replier: Replier,
+    *,
+    registry_loader: Callable[[], WorkflowRegistry] | None,
+) -> None:
+    """Render ``/crawdad workflow list`` against *registry_loader*."""
+    registry = (registry_loader or _load_default_registry)()
+    workflows = registry.workflows()
+    if not workflows:
+        await replier("No workflows registered.")
+        return
+    lines = ["**Workflows**"]
+    lines.extend(f"- `{w.name}` — {w.description}" for w in workflows)
+    await replier("\n".join(lines))
+
+
+async def _workflow_run_reply(
+    replier: Replier,
+    *,
+    name: str | None,
+    current_phase: str | None,
+    allow_intimate: bool,
+    registry_loader: Callable[[], WorkflowRegistry] | None,
+) -> None:
+    """Render ``/crawdad workflow run <name>`` against *registry_loader*."""
+    cleaned = (name or "").strip()
+    if not cleaned:
+        await replier(_WORKFLOW_RUN_MISSING_NAME_REPLY)
+        return
+    registry = (registry_loader or _load_default_registry)()
+    try:
+        workflow = registry.get(cleaned)
+    except WorkflowNotFoundError as exc:
+        await replier(f"error: {exc}")
+        return
+    try:
+        lines = dry_run_workflow(
+            workflow,
+            current_phase=current_phase,
+            allow_intimate=allow_intimate,
+        )
+    except WorkflowConstraintError as exc:
+        await replier(f"refused: {exc}")
+        return
+    await replier("\n".join(lines))
 
 
 async def handle_help(replier: Replier) -> None:
@@ -365,7 +448,24 @@ def _register_workflow(tree: _TreeLike) -> None:
     """Wire the ``/crawdad workflow`` Discord callback onto *tree*."""
 
     @tree.command(name="workflow", description=_COMMAND_DESCRIPTIONS["workflow"])
-    async def _callback(interaction: Any, subaction: str = "list") -> None:
-        """Discord callback for ``/crawdad workflow [subaction]`` (deferred)."""
+    async def _callback(
+        interaction: Any,
+        subaction: str = "list",
+        name: str = "",
+        current_phase: str = "",
+        allow_intimate: bool = False,
+    ) -> None:
+        """Discord callback for ``/crawdad workflow [subaction]`` (deferred).
+
+        ``name``, ``current_phase`` default to empty strings rather than
+        ``None`` so discord.py treats them as optional parameters. The
+        handler interprets empty strings as "not supplied".
+        """
         await interaction.response.defer()
-        await handle_workflow(interaction.followup.send, subaction=subaction)
+        await handle_workflow(
+            interaction.followup.send,
+            subaction=subaction,
+            name=name or None,
+            current_phase=current_phase or None,
+            allow_intimate=allow_intimate,
+        )

--- a/crawdad/crawdad/workflows.py
+++ b/crawdad/crawdad/workflows.py
@@ -1,0 +1,273 @@
+"""Jig-style workflow DSL for CrawDad (ADAPT-003 Phase 1).
+
+The workflow surface is intentionally tiny: a YAML file declares a
+named pipeline of MCP tool calls (each step names its ``tool`` and
+``args``), the registry discovers every workflow under a directory,
+and the runner walks the steps. Phase 1 ships the file format,
+registry, constraint enforcement, and a *dry-run* walker that prints
+each step instead of dispatching it. Phase 2 replaces the dry-run
+walker with a real MCP-tool walker; Phase 3 wires the walker into the
+Haiku router as a ``run-workflow`` intent.
+
+Workflows live in ``crawdad/workflows/`` under the bot's own config —
+see ``crawdad/docs/adr/2026-05-24-jig-workflows-location.md`` for the
+ADR documenting that decision.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+# Reason strings exported so the test suite (and any future reviewer)
+# can match the exact text without re-typing it.
+PHASE_AWARE_WITHOUT_CURRENT_PHASE: str = (
+    "workflow is phase_aware but no --current-phase was supplied"
+)
+PRIVACY_FLOOR_INTIMATE_WITHOUT_OVERRIDE: str = (
+    "workflow's privacy_tier_floor is intimate; pass --allow-intimate to run it"
+)
+
+_NAME_PATTERN = re.compile(r"^[a-z][a-z0-9-]*$")
+
+
+class PrivacyTierFloor(StrEnum):
+    """Minimum tier a workflow may operate at.
+
+    Mirrors :class:`creek_mcp.tier_ceiling.TierCeiling` (minus the
+    catch-all ``all`` value, which makes no sense as a *floor*) so the
+    workflow DSL stays in lock-step with the MCP boundary.
+    """
+
+    OPEN = "open"
+    PERSONAL = "personal"
+    INTIMATE = "intimate"
+
+
+class WorkflowStep(BaseModel):
+    """One MCP tool call in a workflow pipeline."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    id: str = Field(min_length=1)
+    tool: str = Field(min_length=1)
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class Workflow(BaseModel):
+    """A named, composable pipeline of MCP tool calls.
+
+    See :mod:`crawdad.workflows` and the ADAPT-003 plan for the rationale.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(min_length=1)
+    description: str = Field(min_length=1)
+    trigger: str | None = None
+    phase_aware: bool = False
+    privacy_tier_floor: PrivacyTierFloor = PrivacyTierFloor.OPEN
+    steps: list[WorkflowStep]
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name_pattern(cls, value: str) -> str:
+        """Reject names that do not match ``[a-z][a-z0-9-]*``."""
+        if not _NAME_PATTERN.match(value):
+            msg = (
+                f"workflow name {value!r} must match [a-z][a-z0-9-]* "
+                "(lowercase, start with a letter, hyphens allowed)"
+            )
+            raise ValueError(msg)
+        return value
+
+    @field_validator("steps")
+    @classmethod
+    def _validate_steps_non_empty(cls, value: list[WorkflowStep]) -> list[WorkflowStep]:
+        """A zero-step workflow has nothing to walk."""
+        if not value:
+            msg = "workflow must declare at least one step"
+            raise ValueError(msg)
+        return value
+
+    @model_validator(mode="after")
+    def _validate_unique_step_ids(self) -> Workflow:
+        """Step IDs must be unique so Phase 2 interpolation works."""
+        ids = [step.id for step in self.steps]
+        if len(set(ids)) != len(ids):
+            duplicates = sorted({sid for sid in ids if ids.count(sid) > 1})
+            msg = f"duplicate step ids in workflow {self.name!r}: {duplicates}"
+            raise ValueError(msg)
+        return self
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class WorkflowConstraintError(Exception):
+    """Raised when a workflow's declared constraints aren't satisfied."""
+
+
+class WorkflowNotFoundError(Exception):
+    """Raised when a registry lookup misses.
+
+    Inherits from :class:`Exception` rather than :class:`KeyError` so the
+    error message renders cleanly when interpolated into user output —
+    ``str(KeyError("x"))`` wraps the message in extra quotes.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Parser + registry
+# ---------------------------------------------------------------------------
+
+
+def load_workflow(path: Path) -> Workflow:
+    """Load a YAML workflow file and validate it as a :class:`Workflow`.
+
+    Args:
+        path: Absolute or relative path to a ``.yaml`` workflow file.
+
+    Returns:
+        The parsed :class:`Workflow`.
+
+    Raises:
+        FileNotFoundError: When *path* does not exist.
+        ValueError: When the YAML document is not a mapping.
+        pydantic.ValidationError: When Pydantic rejects the payload.
+    """
+    text = path.read_text(encoding="utf-8")
+    raw = yaml.safe_load(text)
+    if not isinstance(raw, dict):
+        msg = f"workflow file {path} must be a YAML mapping at the document root"
+        raise ValueError(msg)
+    return Workflow.model_validate(raw)
+
+
+class WorkflowRegistry:
+    """In-memory registry of workflows discovered from a directory."""
+
+    def __init__(self, workflows: dict[str, Workflow]) -> None:
+        """Wrap *workflows* keyed by ``Workflow.name``."""
+        self._workflows = dict(workflows)
+
+    @classmethod
+    def from_directory(cls, directory: Path) -> WorkflowRegistry:
+        """Discover every ``*.yaml`` workflow under *directory*.
+
+        A nonexistent directory yields an empty registry rather than an
+        error — this lets the CLI surface a friendly empty-list message
+        on first run instead of crashing on a missing path.
+        """
+        if not directory.is_dir():
+            return cls({})
+        workflows: dict[str, Workflow] = {}
+        for path in sorted(directory.glob("*.yaml")):
+            workflow = load_workflow(path)
+            if workflow.name in workflows:
+                msg = (
+                    f"duplicate workflow name {workflow.name!r} in {directory}: "
+                    f"already registered from a sibling YAML file"
+                )
+                raise ValueError(msg)
+            workflows[workflow.name] = workflow
+        return cls(workflows)
+
+    def workflows(self) -> tuple[Workflow, ...]:
+        """Return every registered workflow, sorted by name."""
+        return tuple(self._workflows[name] for name in sorted(self._workflows))
+
+    def get(self, name: str) -> Workflow:
+        """Look up a workflow by ``name`` or raise :class:`WorkflowNotFoundError`."""
+        try:
+            return self._workflows[name]
+        except KeyError as exc:
+            msg = f"unknown workflow {name!r} — check `workflows list`"
+            raise WorkflowNotFoundError(msg) from exc
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 dry-run walker
+# ---------------------------------------------------------------------------
+
+
+def dry_run_workflow(
+    workflow: Workflow,
+    *,
+    current_phase: str | None,
+    allow_intimate: bool,
+) -> list[str]:
+    """Return the human-readable Phase 1 dry-run trace for *workflow*.
+
+    Enforces the two Phase 1 constraints before walking:
+
+    * ``phase_aware: true`` workflows refuse to run without a current
+      phase (Phase 1 accepts any non-empty string as satisfying — phase
+      *matching* lands in Phase 2/3 alongside the real walker).
+    * ``privacy_tier_floor: intimate`` workflows refuse without an
+      explicit ``allow_intimate`` override.
+
+    Returns:
+        A list of output lines explicitly labelled as a Phase 1 dry-run
+        so the caller can print or log them without ambiguity.
+
+    Raises:
+        WorkflowConstraintError: When a declared constraint isn't met.
+    """
+    _enforce_constraints(
+        workflow, current_phase=current_phase, allow_intimate=allow_intimate
+    )
+    return _render_dry_run(workflow, current_phase=current_phase)
+
+
+def _enforce_constraints(
+    workflow: Workflow,
+    *,
+    current_phase: str | None,
+    allow_intimate: bool,
+) -> None:
+    """Reject the workflow if a declared constraint isn't satisfied."""
+    if workflow.phase_aware and not current_phase:
+        raise WorkflowConstraintError(PHASE_AWARE_WITHOUT_CURRENT_PHASE)
+    if workflow.privacy_tier_floor is PrivacyTierFloor.INTIMATE and not allow_intimate:
+        raise WorkflowConstraintError(PRIVACY_FLOOR_INTIMATE_WITHOUT_OVERRIDE)
+
+
+def _render_dry_run(workflow: Workflow, *, current_phase: str | None) -> list[str]:
+    """Format the dry-run trace as a list of plain-text lines."""
+    phase_marker = current_phase or "n/a"
+    lines = [
+        (
+            f"[Phase 1 dry-run] workflow={workflow.name} "
+            f"phase_aware={workflow.phase_aware} "
+            f"privacy_tier_floor={workflow.privacy_tier_floor.value} "
+            f"current_phase={phase_marker}"
+        )
+    ]
+    for index, step in enumerate(workflow.steps, start=1):
+        lines.append(f"  step {index}: id={step.id} tool={step.tool} args={step.args}")
+    lines.append(
+        "[Phase 1 dry-run] no MCP tools dispatched — Phase 2 wires the real walker."
+    )
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Bundled-workflows directory
+# ---------------------------------------------------------------------------
+
+
+def bundled_workflows_dir() -> Path:
+    """Return the absolute path to the bundled ``crawdad/workflows/`` directory.
+
+    The CLI uses this as its default registry source. Tests use it to
+    sanity-check the three reference workflows that ship in the repo.
+    """
+    return Path(__file__).resolve().parents[1] / "workflows"

--- a/crawdad/crawdad/workflows.py
+++ b/crawdad/crawdad/workflows.py
@@ -233,7 +233,14 @@ def _enforce_constraints(
     current_phase: str | None,
     allow_intimate: bool,
 ) -> None:
-    """Reject the workflow if a declared constraint isn't satisfied."""
+    """Reject the workflow if a declared constraint isn't satisfied.
+
+    Phase 1 enforces the ``intimate`` privacy-tier floor only;
+    ``personal`` is advisory and runs without an override, because
+    real privacy enforcement (consent prompts, audit log) lands with
+    the live walker. Treat the ``personal`` branch as a deliberate
+    no-op, not a forgotten check.
+    """
     if workflow.phase_aware and not current_phase:
         raise WorkflowConstraintError(PHASE_AWARE_WITHOUT_CURRENT_PHASE)
     if workflow.privacy_tier_floor is PrivacyTierFloor.INTIMATE and not allow_intimate:

--- a/crawdad/docs/adr/2026-05-24-jig-workflows-location.md
+++ b/crawdad/docs/adr/2026-05-24-jig-workflows-location.md
@@ -1,0 +1,61 @@
+# ADR: Jig workflows live under `crawdad/workflows/`, not the vault
+
+**Date:** 2026-05-24
+**Status:** Accepted
+**Issue:** [#268 — ADAPT-003 Jig-style workflow DSL](https://github.com/Geoffe-Ga/creek-vault/issues/268)
+**Phase:** 1 (parallelizable skeleton)
+
+## Context
+
+ADAPT-003 introduces a YAML workflow DSL for CrawDad's composite
+commands. The implementation notes on #268 flagged the placement
+decision explicitly: workflows could live (a) under the bot's own
+config at `crawdad/workflows/`, or (b) inside the user's vault at
+`<vault>/00-Creek-Meta/Workflows/`. The example file path in the
+recovered ADAPT-003 plan implies (a); vault-located workflows would
+otherwise compose more naturally with the `creek init` scaffolding.
+
+## Decision
+
+Workflows ship as YAML files under **`crawdad/workflows/`** in the
+crawdad subproject, alongside the bot's own source. The bundled
+location is the canonical default; the workflow registry takes a
+directory at construction time so a future iteration can layer a
+user-supplied directory on top.
+
+## Rationale
+
+1. **CLI invocation cannot assume a vault is wired.** `crawdad
+   workflows list` and `crawdad workflows run <name>` must work
+   immediately after `pip install`, before any `crawdad.yaml` exists
+   and before the bot has been pointed at a vault. Sourcing the
+   registry from the vault would couple Phase 1 to a wiring step that
+   belongs in the runtime, not in the CLI surface.
+2. **Phase 1 is parallelizable scaffolding.** The dry-run walker
+   prints each step's `tool:` identifier; it does not yet touch the
+   MCP surface, the vault, or any user state. Bundling the three
+   reference workflows with the code keeps the test suite hermetic
+   and the smoke test (`uv run crawdad workflows list`) zero-config.
+3. **Version control naturally lives with the bot.** The acceptance
+   criteria require "workflow files are checked into the repo;
+   modifications go through the normal review/version-control flow."
+   The bundled location satisfies that; the vault is intentionally
+   not checked in (FEAT-019).
+4. **Future vault layering remains open.** `WorkflowRegistry` takes
+   a `Path` at construction time, so the runtime can later merge a
+   vault-side directory (e.g.  `<vault>/00-Creek-Meta/Workflows/`)
+   on top of the bundled defaults without changing the file format.
+   Phase 2 or a later FEAT can introduce that layering once the real
+   walker exists; revisit this ADR then if requirements change.
+
+## Consequences
+
+- The three reference workflows ship in `crawdad/workflows/` and are
+  imported by the registry via `bundled_workflows_dir()`.
+- Tests can assert against the bundled set directly without a tmp
+  vault fixture.
+- A future `--workflows-dir <path>` CLI flag (or vault-merging logic)
+  is a non-breaking additive change.
+- Operators who edit the bundled YAML files are editing the bot's
+  trusted-config surface — the same trust boundary that already
+  applies to `crawdad.yaml`.

--- a/crawdad/tests/test_cli.py
+++ b/crawdad/tests/test_cli.py
@@ -472,3 +472,131 @@ def test_run_bot_passes_loop_runner_when_loop_wired(
 
     assert captured["init_kwargs"]["loop_runner"] is not None
     assert callable(captured["init_kwargs"]["loop_runner"])
+
+
+# ---------------------------------------------------------------------------
+# ADAPT-003 Phase 1: ``crawdad workflows`` subcommand
+# ---------------------------------------------------------------------------
+
+
+def test_workflows_list_prints_each_bundled_workflow(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``crawdad workflows list`` enumerates the three reference workflows."""
+    exit_code = cli.main(["workflows", "list"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "substack-draft-phase-transitions" in out
+    assert "wavelength-checkin" in out
+    assert "compost-surfacing" in out
+
+
+def test_workflows_list_empty_registry_prints_friendly_message(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """Empty bundled directory yields a friendly empty-list message."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setattr(cli, "bundled_workflows_dir", lambda: empty)
+
+    exit_code = cli.main(["workflows", "list"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "No workflows" in out
+
+
+def test_workflows_run_dry_runs_open_workflow(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A non-phase-aware, open workflow dry-runs cleanly with no overrides."""
+    exit_code = cli.main(["workflows", "run", "wavelength-checkin"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Phase 1 dry-run" in out
+    assert "creek.state.read" in out
+
+
+def test_workflows_run_refuses_phase_aware_without_current_phase(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The Substack workflow refuses without ``--current-phase``."""
+    exit_code = cli.main(["workflows", "run", "substack-draft-phase-transitions"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "refused" in out
+    assert "phase_aware" in out
+
+
+def test_workflows_run_accepts_phase_aware_with_current_phase(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Supplying ``--current-phase`` satisfies the constraint."""
+    exit_code = cli.main(
+        [
+            "workflows",
+            "run",
+            "substack-draft-phase-transitions",
+            "--current-phase",
+            "Withdrawal",
+        ]
+    )
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Withdrawal" in out
+    assert "creek.draft" in out
+
+
+def test_workflows_run_unknown_workflow_returns_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An unknown workflow name yields a clear error and non-zero exit code."""
+    exit_code = cli.main(["workflows", "run", "no-such-workflow"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "error" in out
+    assert "no-such-workflow" in out
+
+
+def test_workflows_run_intimate_workflow_requires_override(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    """An intimate-tier workflow refuses without ``--allow-intimate``."""
+    yaml_path = tmp_path / "secret.yaml"
+    yaml_path.write_text(
+        "name: secret\n"
+        "description: Private.\n"
+        "privacy_tier_floor: intimate\n"
+        "steps:\n"
+        "  - id: s\n"
+        "    tool: creek.state.read\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cli, "bundled_workflows_dir", lambda: tmp_path)
+
+    exit_code = cli.main(["workflows", "run", "secret"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "intimate" in out
+
+    exit_code = cli.main(["workflows", "run", "secret", "--allow-intimate"])
+
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "Phase 1 dry-run" in out
+
+
+def test_workflows_requires_subaction() -> None:
+    """``crawdad workflows`` with no action exits via argparse usage error."""
+    with pytest.raises(SystemExit):
+        cli.main(["workflows"])

--- a/crawdad/tests/test_slash_commands.py
+++ b/crawdad/tests/test_slash_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -285,7 +286,7 @@ async def test_handle_workflow_run_requires_name() -> None:
 
 
 async def test_handle_workflow_run_intimate_requires_override(
-    tmp_path: Any,
+    tmp_path: Path,
 ) -> None:
     """An intimate-floor workflow refuses without ``allow_intimate=True``."""
     from crawdad.workflows import WorkflowRegistry
@@ -322,7 +323,7 @@ async def test_handle_workflow_run_intimate_requires_override(
 
 
 async def test_handle_workflow_empty_registry_replies_friendly(
-    tmp_path: Any,
+    tmp_path: Path,
 ) -> None:
     """``list`` with no workflows returns a friendly empty message."""
     from crawdad.workflows import WorkflowRegistry

--- a/crawdad/tests/test_slash_commands.py
+++ b/crawdad/tests/test_slash_commands.py
@@ -187,34 +187,154 @@ async def test_handle_register_without_switcher_returns_soft_error() -> None:
     assert "unavailable" in body or "wired" in body
 
 
-async def test_handle_workflow_list_returns_v11_placeholder() -> None:
-    """``/crawdad workflow list`` returns the documented v1.1 stub."""
+async def test_handle_workflow_list_enumerates_bundled_workflows() -> None:
+    """``/crawdad workflow list`` enumerates the three bundled workflows."""
     replier = _FakeReplier()
 
     await handle_workflow(replier, subaction="list")
 
     assert len(replier.sent) == 1
-    assert "v1.1" in replier.sent[0] or "1.1" in replier.sent[0]
+    body = replier.sent[0]
+    assert "substack-draft-phase-transitions" in body
+    assert "wavelength-checkin" in body
+    assert "compost-surfacing" in body
 
 
 async def test_handle_workflow_unknown_subaction_returns_help() -> None:
-    """A workflow subaction other than ``list`` returns the help summary."""
+    """A workflow subaction other than ``list`` / ``run`` returns help."""
     replier = _FakeReplier()
 
-    await handle_workflow(replier, subaction="run")
+    await handle_workflow(replier, subaction="frobnicate")
 
     assert len(replier.sent) == 1
-    assert "list" in replier.sent[0].lower()
+    body = replier.sent[0].lower()
+    assert "list" in body
+    assert "run" in body
 
 
-async def test_handle_workflow_default_returns_list_stub() -> None:
-    """``/crawdad workflow`` with no subaction is the same as ``list``."""
+async def test_handle_workflow_default_returns_list() -> None:
+    """``/crawdad workflow`` with no subaction defaults to ``list``."""
     replier = _FakeReplier()
 
     await handle_workflow(replier, subaction=None)
 
     assert len(replier.sent) == 1
-    assert "v1.1" in replier.sent[0] or "1.1" in replier.sent[0]
+    assert "wavelength-checkin" in replier.sent[0]
+
+
+async def test_handle_workflow_run_dry_runs_open_workflow() -> None:
+    """``run wavelength-checkin`` dry-runs cleanly with no overrides."""
+    replier = _FakeReplier()
+
+    await handle_workflow(replier, subaction="run", name="wavelength-checkin")
+
+    assert len(replier.sent) == 1
+    body = replier.sent[0]
+    assert "Phase 1 dry-run" in body
+    assert "creek.state.read" in body
+
+
+async def test_handle_workflow_run_refuses_phase_aware_without_phase() -> None:
+    """The Substack workflow refuses without a current phase."""
+    replier = _FakeReplier()
+
+    await handle_workflow(
+        replier, subaction="run", name="substack-draft-phase-transitions"
+    )
+
+    assert len(replier.sent) == 1
+    body = replier.sent[0]
+    assert "refused" in body
+    assert "phase_aware" in body
+
+
+async def test_handle_workflow_run_accepts_current_phase() -> None:
+    """Supplying ``current_phase`` satisfies the phase-aware constraint."""
+    replier = _FakeReplier()
+
+    await handle_workflow(
+        replier,
+        subaction="run",
+        name="substack-draft-phase-transitions",
+        current_phase="Withdrawal",
+    )
+
+    assert len(replier.sent) == 1
+    assert "Withdrawal" in replier.sent[0]
+
+
+async def test_handle_workflow_run_unknown_name_returns_error() -> None:
+    """An unknown workflow name yields a clear error reply."""
+    replier = _FakeReplier()
+
+    await handle_workflow(replier, subaction="run", name="no-such-workflow")
+
+    assert len(replier.sent) == 1
+    assert "error" in replier.sent[0]
+    assert "no-such-workflow" in replier.sent[0]
+
+
+async def test_handle_workflow_run_requires_name() -> None:
+    """``run`` with an empty / missing name returns a help reply."""
+    replier = _FakeReplier()
+
+    await handle_workflow(replier, subaction="run", name="   ")
+
+    assert len(replier.sent) == 1
+    assert "workflow" in replier.sent[0].lower()
+
+
+async def test_handle_workflow_run_intimate_requires_override(
+    tmp_path: Any,
+) -> None:
+    """An intimate-floor workflow refuses without ``allow_intimate=True``."""
+    from crawdad.workflows import WorkflowRegistry
+
+    yaml_path = tmp_path / "secret.yaml"
+    yaml_path.write_text(
+        "name: secret\n"
+        "description: Private.\n"
+        "privacy_tier_floor: intimate\n"
+        "steps:\n"
+        "  - id: s\n"
+        "    tool: creek.state.read\n",
+        encoding="utf-8",
+    )
+
+    def _loader() -> WorkflowRegistry:
+        return WorkflowRegistry.from_directory(tmp_path)
+
+    replier = _FakeReplier()
+    await handle_workflow(
+        replier, subaction="run", name="secret", registry_loader=_loader
+    )
+    assert "intimate" in replier.sent[0]
+
+    replier2 = _FakeReplier()
+    await handle_workflow(
+        replier2,
+        subaction="run",
+        name="secret",
+        allow_intimate=True,
+        registry_loader=_loader,
+    )
+    assert "Phase 1 dry-run" in replier2.sent[0]
+
+
+async def test_handle_workflow_empty_registry_replies_friendly(
+    tmp_path: Any,
+) -> None:
+    """``list`` with no workflows returns a friendly empty message."""
+    from crawdad.workflows import WorkflowRegistry
+
+    def _loader() -> WorkflowRegistry:
+        return WorkflowRegistry.from_directory(tmp_path)
+
+    replier = _FakeReplier()
+    await handle_workflow(replier, subaction="list", registry_loader=_loader)
+
+    assert len(replier.sent) == 1
+    assert "No workflows" in replier.sent[0]
 
 
 async def test_handle_help_lists_every_command() -> None:
@@ -229,7 +349,7 @@ async def test_handle_help_lists_every_command() -> None:
 
 
 async def test_handle_workflow_skips_loop() -> None:
-    """Workflow handler does NOT call the loop runner — it's a pure stub."""
+    """Workflow handler does NOT call the loop runner — the registry is local."""
     runner_calls = 0
 
     async def _counting_runner(_message: str) -> str:
@@ -373,11 +493,11 @@ async def test_register_callback_without_switcher_replies_softly() -> None:
     assert "unavailable" in body or "wired" in body
 
 
-async def test_workflow_callback_skips_loop_and_returns_stub() -> None:
-    """The workflow callback ``defer()``s but does NOT call the loop runner.
+async def test_workflow_callback_skips_loop_and_lists_workflows() -> None:
+    """The workflow callback ``defer()``s, skips the loop, and lists workflows.
 
-    The workflow stub is the only registered callback that bypasses
-    the agent loop entirely (v1.0 ships only the `list` subaction).
+    The workflow callback bypasses the agent loop entirely — ADAPT-003
+    Phase 1 runs the registry + dry-run walker directly.
     """
     runner_called = False
 
@@ -394,5 +514,23 @@ async def test_workflow_callback_skips_loop_and_returns_stub() -> None:
 
     assert interaction.response.deferred == 1
     assert len(interaction.followup.sent) == 1
-    assert "v1.1" in interaction.followup.sent[0]
+    # The default subaction is ``list`` — bundled names appear in the body.
+    assert "wavelength-checkin" in interaction.followup.sent[0]
     assert runner_called is False
+
+
+async def test_workflow_callback_run_dispatches_dry_run() -> None:
+    """``workflow`` callback with ``run`` + ``name`` dry-runs the workflow."""
+    tree = _FakeTree()
+    register(tree, loop_runner=_fake_loop_runner)
+    interaction = _FakeInteraction()
+
+    await tree.registered["workflow"]["callback"](
+        interaction, subaction="run", name="wavelength-checkin"
+    )
+
+    assert interaction.response.deferred == 1
+    assert len(interaction.followup.sent) == 1
+    body = interaction.followup.sent[0]
+    assert "Phase 1 dry-run" in body
+    assert "creek.state.read" in body

--- a/crawdad/tests/test_workflows.py
+++ b/crawdad/tests/test_workflows.py
@@ -391,6 +391,24 @@ def test_dry_run_open_workflow_with_no_overrides() -> None:
     assert "period" in body  # args rendered too
 
 
+def test_dry_run_personal_workflow_runs_without_overrides() -> None:
+    """A ``personal``-floor workflow dry-runs without any override flags.
+
+    Phase 1 only gates the ``intimate`` floor; ``personal`` is
+    advisory until Phase 2 wires real privacy enforcement. This test
+    pins the current intent so that a future contributor doesn't
+    silently add a half-built gate or wonder if the omission is a bug.
+    """
+    workflow = _build(privacy_tier_floor=PrivacyTierFloor.PERSONAL)
+
+    lines = dry_run_workflow(workflow, current_phase=None, allow_intimate=False)
+
+    body = "\n".join(lines)
+    assert "Phase 1 dry-run" in body
+    assert "personal" in body  # tier surfaced in the header
+    assert "creek.state.read" in body
+
+
 def test_dry_run_labels_output_as_phase_1_dry_run() -> None:
     """Every dry-run output is explicitly labelled — no one mistakes it for live."""
     workflow = _build()

--- a/crawdad/tests/test_workflows.py
+++ b/crawdad/tests/test_workflows.py
@@ -1,0 +1,419 @@
+"""Tests for ``crawdad.workflows`` — ADAPT-003 Phase 1.
+
+Covers the Pydantic workflow file model, the YAML parser, the registry,
+and the dry-run constraint-enforcement walker. The walker itself is a
+stub in Phase 1 — it only inspects each step's ``tool`` / ``args`` and
+prints them. Phase 2 wires the real MCP dispatcher in.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+from pydantic import ValidationError
+
+from crawdad.workflows import (
+    PHASE_AWARE_WITHOUT_CURRENT_PHASE,
+    PRIVACY_FLOOR_INTIMATE_WITHOUT_OVERRIDE,
+    PrivacyTierFloor,
+    Workflow,
+    WorkflowConstraintError,
+    WorkflowNotFoundError,
+    WorkflowRegistry,
+    WorkflowStep,
+    dry_run_workflow,
+    load_workflow,
+)
+
+
+def _write_yaml(path: Path, body: str) -> Path:
+    """Write *body* (dedented) to *path* and return it for chaining."""
+    path.write_text(dedent(body), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Pydantic model
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_step_defaults_args_to_empty_dict() -> None:
+    """A step with no ``args:`` defaults to ``{}`` rather than ``None``."""
+    step = WorkflowStep(id="read", tool="creek.state.read")
+
+    assert step.args == {}
+
+
+def test_workflow_accepts_minimal_valid_payload() -> None:
+    """The smallest valid workflow has name, description, and at least one step."""
+    workflow = Workflow(
+        name="checkin",
+        description="Quick check-in.",
+        steps=[WorkflowStep(id="state", tool="creek.state.read")],
+    )
+
+    assert workflow.name == "checkin"
+    assert workflow.phase_aware is False
+    assert workflow.privacy_tier_floor == PrivacyTierFloor.OPEN
+    assert workflow.trigger is None
+
+
+def test_workflow_rejects_uppercase_name() -> None:
+    """``name`` must match ``[a-z][a-z0-9-]*`` — uppercase is a typo."""
+    with pytest.raises(ValidationError):
+        Workflow(
+            name="Checkin",
+            description="x",
+            steps=[WorkflowStep(id="s", tool="t")],
+        )
+
+
+def test_workflow_rejects_name_starting_with_digit() -> None:
+    """Workflow names must start with a lowercase letter."""
+    with pytest.raises(ValidationError):
+        Workflow(
+            name="1-checkin",
+            description="x",
+            steps=[WorkflowStep(id="s", tool="t")],
+        )
+
+
+def test_workflow_rejects_empty_steps_list() -> None:
+    """A zero-step workflow has nothing to walk — refuse at load time."""
+    with pytest.raises(ValidationError):
+        Workflow(name="empty", description="x", steps=[])
+
+
+def test_workflow_rejects_duplicate_step_ids() -> None:
+    """Two steps with the same ``id`` would break Phase 2's interpolation."""
+    with pytest.raises(ValidationError):
+        Workflow(
+            name="dup",
+            description="x",
+            steps=[
+                WorkflowStep(id="a", tool="t1"),
+                WorkflowStep(id="a", tool="t2"),
+            ],
+        )
+
+
+def test_workflow_rejects_unknown_privacy_floor() -> None:
+    """Only ``open`` / ``personal`` / ``intimate`` are valid tier floors."""
+    with pytest.raises(ValidationError):
+        Workflow(
+            name="x",
+            description="x",
+            privacy_tier_floor="public",  # type: ignore[arg-type]
+            steps=[WorkflowStep(id="s", tool="t")],
+        )
+
+
+# ---------------------------------------------------------------------------
+# YAML parser
+# ---------------------------------------------------------------------------
+
+
+def test_load_workflow_parses_minimal_yaml(tmp_path: Path) -> None:
+    """A round-trip YAML file produces the expected ``Workflow`` instance."""
+    path = _write_yaml(
+        tmp_path / "checkin.yaml",
+        """\
+        name: checkin
+        description: A simple check-in.
+        steps:
+          - id: read
+            tool: creek.state.read
+        """,
+    )
+
+    workflow = load_workflow(path)
+
+    assert workflow.name == "checkin"
+    assert len(workflow.steps) == 1
+    assert workflow.steps[0].tool == "creek.state.read"
+
+
+def test_load_workflow_parses_full_yaml(tmp_path: Path) -> None:
+    """Every supported field round-trips through YAML."""
+    path = _write_yaml(
+        tmp_path / "full.yaml",
+        """\
+        name: full-example
+        description: Every field exercised.
+        trigger: "/draft phase-transitions"
+        phase_aware: true
+        privacy_tier_floor: personal
+        steps:
+          - id: read
+            tool: creek.state.read
+            args:
+              period: weekly
+          - id: mine
+            tool: creek.mine
+            args:
+              strategy: thread-terminus
+        """,
+    )
+
+    workflow = load_workflow(path)
+
+    assert workflow.trigger == "/draft phase-transitions"
+    assert workflow.phase_aware is True
+    assert workflow.privacy_tier_floor == PrivacyTierFloor.PERSONAL
+    assert workflow.steps[0].args == {"period": "weekly"}
+
+
+def test_load_workflow_surfaces_validation_error(tmp_path: Path) -> None:
+    """A YAML file that fails Pydantic validation raises a clear error."""
+    path = _write_yaml(
+        tmp_path / "bad.yaml",
+        """\
+        name: BadName
+        description: x
+        steps:
+          - id: s
+            tool: t
+        """,
+    )
+
+    with pytest.raises(ValidationError):
+        load_workflow(path)
+
+
+def test_load_workflow_rejects_non_mapping_yaml(tmp_path: Path) -> None:
+    """A YAML list at the document root is not a workflow."""
+    path = _write_yaml(
+        tmp_path / "list.yaml",
+        """\
+        - just a list
+        - not a mapping
+        """,
+    )
+
+    with pytest.raises(ValueError, match="must be a YAML mapping"):
+        load_workflow(path)
+
+
+def test_load_workflow_rejects_missing_file(tmp_path: Path) -> None:
+    """Loading a nonexistent path raises ``FileNotFoundError``."""
+    with pytest.raises(FileNotFoundError):
+        load_workflow(tmp_path / "nope.yaml")
+
+
+# ---------------------------------------------------------------------------
+# Registry discovery
+# ---------------------------------------------------------------------------
+
+
+def test_registry_discovers_yaml_files(tmp_path: Path) -> None:
+    """``from_directory`` returns every ``*.yaml`` workflow in the tree."""
+    _write_yaml(
+        tmp_path / "one.yaml",
+        """\
+        name: one
+        description: First.
+        steps:
+          - id: s
+            tool: t
+        """,
+    )
+    _write_yaml(
+        tmp_path / "two.yaml",
+        """\
+        name: two
+        description: Second.
+        steps:
+          - id: s
+            tool: t
+        """,
+    )
+
+    registry = WorkflowRegistry.from_directory(tmp_path)
+
+    assert {w.name for w in registry.workflows()} == {"one", "two"}
+
+
+def test_registry_ignores_non_yaml_files(tmp_path: Path) -> None:
+    """Plain ``.md`` / ``.txt`` siblings are skipped — they're not workflows."""
+    _write_yaml(
+        tmp_path / "real.yaml",
+        """\
+        name: real
+        description: Y.
+        steps:
+          - id: s
+            tool: t
+        """,
+    )
+    (tmp_path / "README.md").write_text("not a workflow", encoding="utf-8")
+    (tmp_path / "scratch.txt").write_text("nope", encoding="utf-8")
+
+    registry = WorkflowRegistry.from_directory(tmp_path)
+
+    assert {w.name for w in registry.workflows()} == {"real"}
+
+
+def test_registry_get_returns_workflow_by_name(tmp_path: Path) -> None:
+    """``get`` looks up a workflow by its declared ``name``."""
+    _write_yaml(
+        tmp_path / "x.yaml",
+        """\
+        name: target
+        description: Find me.
+        steps:
+          - id: s
+            tool: t
+        """,
+    )
+    registry = WorkflowRegistry.from_directory(tmp_path)
+
+    workflow = registry.get("target")
+
+    assert workflow.name == "target"
+
+
+def test_registry_get_raises_for_unknown_workflow(tmp_path: Path) -> None:
+    """``get`` on a missing name raises ``WorkflowNotFoundError``."""
+    registry = WorkflowRegistry.from_directory(tmp_path)
+
+    with pytest.raises(WorkflowNotFoundError, match="missing"):
+        registry.get("missing")
+
+
+def test_registry_rejects_duplicate_workflow_names(tmp_path: Path) -> None:
+    """Two YAML files declaring the same ``name`` is a configuration error."""
+    _write_yaml(
+        tmp_path / "a.yaml",
+        """\
+        name: clash
+        description: First.
+        steps:
+          - id: s
+            tool: t
+        """,
+    )
+    _write_yaml(
+        tmp_path / "b.yaml",
+        """\
+        name: clash
+        description: Second.
+        steps:
+          - id: s
+            tool: t
+        """,
+    )
+
+    with pytest.raises(ValueError, match="duplicate workflow name"):
+        WorkflowRegistry.from_directory(tmp_path)
+
+
+def test_registry_missing_directory_yields_empty_registry(tmp_path: Path) -> None:
+    """A nonexistent directory produces an empty registry (not an error)."""
+    registry = WorkflowRegistry.from_directory(tmp_path / "does-not-exist")
+
+    assert list(registry.workflows()) == []
+
+
+# ---------------------------------------------------------------------------
+# Constraint enforcement (dry-run walker)
+# ---------------------------------------------------------------------------
+
+
+def _build(
+    *,
+    phase_aware: bool = False,
+    privacy_tier_floor: PrivacyTierFloor = PrivacyTierFloor.OPEN,
+) -> Workflow:
+    """Return a small workflow with tunable constraint flags."""
+    return Workflow(
+        name="sample",
+        description="Sample.",
+        phase_aware=phase_aware,
+        privacy_tier_floor=privacy_tier_floor,
+        steps=[
+            WorkflowStep(id="read", tool="creek.state.read", args={"period": "weekly"}),
+            WorkflowStep(id="respond", tool="crawdad.respond", args={}),
+        ],
+    )
+
+
+def test_dry_run_refuses_phase_aware_workflow_without_current_phase() -> None:
+    """A ``phase_aware: true`` workflow refuses if no current phase is supplied."""
+    workflow = _build(phase_aware=True)
+
+    with pytest.raises(
+        WorkflowConstraintError, match=PHASE_AWARE_WITHOUT_CURRENT_PHASE
+    ):
+        dry_run_workflow(workflow, current_phase=None, allow_intimate=False)
+
+
+def test_dry_run_accepts_phase_aware_workflow_with_current_phase() -> None:
+    """A current phase satisfies the phase-aware constraint."""
+    workflow = _build(phase_aware=True)
+
+    lines = dry_run_workflow(workflow, current_phase="Withdrawal", allow_intimate=False)
+
+    assert any("Withdrawal" in line for line in lines)
+
+
+def test_dry_run_refuses_intimate_workflow_without_override() -> None:
+    """A ``privacy_tier_floor: intimate`` workflow refuses without override."""
+    workflow = _build(privacy_tier_floor=PrivacyTierFloor.INTIMATE)
+
+    with pytest.raises(
+        WorkflowConstraintError, match=PRIVACY_FLOOR_INTIMATE_WITHOUT_OVERRIDE
+    ):
+        dry_run_workflow(workflow, current_phase=None, allow_intimate=False)
+
+
+def test_dry_run_accepts_intimate_workflow_with_override() -> None:
+    """``allow_intimate=True`` satisfies the privacy floor constraint."""
+    workflow = _build(privacy_tier_floor=PrivacyTierFloor.INTIMATE)
+
+    lines = dry_run_workflow(workflow, current_phase=None, allow_intimate=True)
+
+    # The walker should emit at least one line per step plus a header.
+    assert any("creek.state.read" in line for line in lines)
+
+
+def test_dry_run_open_workflow_with_no_overrides() -> None:
+    """An ``open`` workflow with no phase-awareness runs without overrides."""
+    workflow = _build()
+
+    lines = dry_run_workflow(workflow, current_phase=None, allow_intimate=False)
+
+    body = "\n".join(lines)
+    assert "Phase 1 dry-run" in body
+    assert "creek.state.read" in body
+    assert "crawdad.respond" in body
+    assert "period" in body  # args rendered too
+
+
+def test_dry_run_labels_output_as_phase_1_dry_run() -> None:
+    """Every dry-run output is explicitly labelled — no one mistakes it for live."""
+    workflow = _build()
+
+    lines = dry_run_workflow(workflow, current_phase=None, allow_intimate=False)
+
+    assert "Phase 1 dry-run" in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# Reference workflows shipped in this PR
+# ---------------------------------------------------------------------------
+
+
+def test_reference_workflows_load_cleanly() -> None:
+    """The three reference YAMLs validate as ``Workflow`` instances."""
+    workflows_dir = Path(__file__).resolve().parents[1] / "workflows"
+    registry = WorkflowRegistry.from_directory(workflows_dir)
+
+    names = {w.name for w in registry.workflows()}
+
+    assert names == {
+        "substack-draft-phase-transitions",
+        "wavelength-checkin",
+        "compost-surfacing",
+    }

--- a/crawdad/workflows/compost-surfacing.yaml
+++ b/crawdad/workflows/compost-surfacing.yaml
@@ -1,0 +1,19 @@
+# ADAPT-003 reference workflow — Compost folder surfacing.
+#
+# Surfaces drift, paradoxes, and emerging items from the Compost folder
+# and responds with a digest. Personal-tier floor because Compost items
+# can lean diaristic.
+name: compost-surfacing
+description: Surface what is emerging in the Compost folder — drift, paradoxes, liminal items.
+trigger: "/surface compost"
+phase_aware: false
+privacy_tier_floor: personal
+steps:
+  - id: mine
+    tool: creek.mine
+    args:
+      strategy: compost
+  - id: respond
+    tool: crawdad.respond
+    args:
+      message: compost surfaced

--- a/crawdad/workflows/substack-draft-phase-transitions.yaml
+++ b/crawdad/workflows/substack-draft-phase-transitions.yaml
@@ -1,0 +1,34 @@
+# ADAPT-003 reference workflow — Substack draft pipeline.
+#
+# Reads the current Wavelength state, mines for thread-terminus seeds,
+# picks the top idea, drafts an essay in the confessional register,
+# and posts a confirmation back to Discord.
+#
+# Phase 1 dispatches none of these tools — the dry-run walker only
+# prints them. Phase 2 wires the real MCP dispatcher in.
+name: substack-draft-phase-transitions
+description: Draft a Substack post about phase transitions, scoped to recent material.
+trigger: "/draft phase-transitions"
+phase_aware: true
+privacy_tier_floor: open
+steps:
+  - id: read-state
+    tool: creek.state.read
+    args:
+      period: weekly
+  - id: mine
+    tool: creek.mine
+    args:
+      strategy: thread-terminus
+  - id: select
+    tool: creek.mine.select
+    args:
+      index: 0
+  - id: draft
+    tool: creek.draft
+    args:
+      register: confessional
+  - id: respond
+    tool: crawdad.respond
+    args:
+      message: drafted essay filed

--- a/crawdad/workflows/wavelength-checkin.yaml
+++ b/crawdad/workflows/wavelength-checkin.yaml
@@ -1,0 +1,19 @@
+# ADAPT-003 reference workflow — Weekly Wavelength check-in.
+#
+# Reads the current state, summarises the phase + dosage, and posts a
+# concise response. Open-tier — safe to run at any time, no overrides
+# required.
+name: wavelength-checkin
+description: Weekly Wavelength check-in — read the current phase and dosage state.
+trigger: "/checkin"
+phase_aware: false
+privacy_tier_floor: open
+steps:
+  - id: read-state
+    tool: creek.state.read
+    args:
+      period: weekly
+  - id: respond
+    tool: crawdad.respond
+    args:
+      message: wavelength check-in


### PR DESCRIPTION
## Summary

**This is Phase 1 of 3 for ADAPT-003.** It ships the parallelizable
skeleton slice: the workflow file format, registry, three reference
workflows, CLI + slash surfaces, and constraint enforcement. The
walker is a dry-run stub (prints each step's `tool` + `args` and
clearly labels itself as Phase 1); real MCP-tool dispatch lands in
Phase 2; the Haiku-router `run-workflow` intent lands in Phase 3.

Refs #268 (Phase 1 of 3) — the umbrella issue stays open until all
three phases ship.

**Follow-up issues filed alongside this PR:**
- Phase 2 (real step walker + MCP dispatch): **#326**
- Phase 3 (`run-workflow` intent in Haiku router): **#327**

## Phase 1 scope (in this PR)

- **`crawdad/crawdad/workflows.py`** — Pydantic `Workflow` /
  `WorkflowStep` models with strict validation (name regex,
  non-empty steps, unique step IDs, `extra="forbid"`).
  `load_workflow(Path)`, `WorkflowRegistry.from_directory(Path)`,
  `dry_run_workflow(workflow, current_phase, allow_intimate)`.
- **`crawdad/workflows/`** — Three reference YAMLs:
  - `substack-draft-phase-transitions.yaml`
  - `wavelength-checkin.yaml`
  - `compost-surfacing.yaml`
- **`crawdad/docs/adr/2026-05-24-jig-workflows-location.md`** — ADR
  documenting why workflows live under `crawdad/workflows/` rather
  than in the vault (CLI must work pre-vault; future vault-layering
  remains an additive change).
- **`crawdad/crawdad/cli.py`** — `crawdad workflows list` and
  `crawdad workflows run <name> [--current-phase X] [--allow-intimate]`.
  Constraint refusals return exit code 1.
- **`crawdad/crawdad/slash_commands.py`** — `/crawdad workflow`
  placeholder removed; replaced with `list` / `run` subactions
  mirroring the CLI. `_WORKFLOW_STUB_REPLY` constant and all
  "v1.1 placeholder" language deleted.
- **Tests** — 25 new workflow unit tests, 8 new CLI tests, 9 new
  slash-command tests (parser happy/sad paths, registry discovery,
  duplicate-name detection, phase-aware refusal, intimate-tier
  refusal, dry-run output labelling, registry injection).

## Out of scope (deferred to follow-ups)

| Item | Tracked in |
|---|---|
| Real step walker (variable interpolation, step chaining, MCP dispatch) | #326 (Phase 2) |
| Haiku-router `run-workflow` intent | #327 (Phase 3) |
| Vault-located workflow alternative | ADR documents decision; revisit only if requirements change |

## Quality gate

`./scripts/check-all.sh` — all 7 gates green (lint, format,
typecheck, security, docstrings, complexity, tests). 344 tests
pass; total branch coverage 95.50%.

## Test plan

- [x] `cd crawdad && ./scripts/check-all.sh` exits 0
- [x] `uv run crawdad workflows list` lists all three reference workflows
- [x] `uv run crawdad workflows run substack-draft-phase-transitions` refuses (phase_aware + no `--current-phase`)
- [x] `uv run crawdad workflows run substack-draft-phase-transitions --current-phase Withdrawal` prints dry-run steps
- [x] `uv run crawdad workflows run wavelength-checkin` dry-runs cleanly (no phase, no override)
- [ ] Slash surface manually exercised in a Discord session once Phase 1 merges
- [ ] CI green on PR

## Possible merge conflict

Another parallel PR (#270, dynamic register switching) also touches
`crawdad/crawdad/slash_commands.py`. This PR's edits are scoped to the
`workflow` handler / registration to minimise conflict surface; a
mechanical rebase should resolve cleanly.

🤖 Generated with Claude Code