### PR TITLE
fix(classify): split preserved counter so "manual" only counts human curation

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -62,8 +62,6 @@ the file.
 _PROCESSING_LOG_SUBDIR = ("00-Creek-Meta", "Processing-Log")
 """Per-vault subdirectory carrying the LLM progress + trace logs."""
 
-_RESUMABLE_METHODS: frozenset[str] = frozenset({MANUAL_METHOD, LLM_METHOD})
-
 if TYPE_CHECKING:
     from creek.config import CreekConfig
 
@@ -87,15 +85,20 @@ class ClassifySummary:
             ``--method llm`` run that short-circuits to the rule
             result still counts as classified — the work is real and
             the file is rewritten.
-        preserved_manual: Fragments left unchanged because a prior run
-            already settled the classification and ``--force`` was not
-            passed. Covers both ``classification_method: manual`` (the
-            original operator-curated case) and ``classification_method:
-            llm`` (OPS-001 resume — re-running ``--method llm`` after a
-            crash skips fragments already classified by the LLM so the
-            operator does not re-pay for tokens). The field name is
-            kept for backwards compatibility; rename to ``preserved`` is
-            tracked alongside the next CLI message refresh.
+        preserved_manual: Fragments left unchanged because a human
+            previously stamped ``classification_method: manual`` and
+            ``--force`` was not passed. This counter reflects genuine
+            operator curation only; fragments preserved by the OPS-001
+            LLM resume path are reported on ``preserved_llm`` so the
+            CLI summary can label the two reasons honestly (issue
+            #321).
+        preserved_llm: Fragments left unchanged because a prior
+            ``--method llm`` run already stamped them with
+            ``classification_method: llm`` and ``--force`` was not
+            passed. Re-running ``--method llm`` after a crash skips
+            these so the operator does not re-pay for tokens (OPS-001
+            resume contract). Distinct from :attr:`preserved_manual`
+            because the user never touched these files.
         skipped_high_confidence: Subset of ``classified`` for which
             the LLM was not invoked because the rule classifier
             produced a high-confidence answer. The fragment is still
@@ -106,6 +109,7 @@ class ClassifySummary:
     total: int
     classified: int
     preserved_manual: int
+    preserved_llm: int
     skipped_high_confidence: int
     errors: tuple[str, ...]
 
@@ -120,7 +124,8 @@ class _RunCounts:
 
     total: int = 0
     classified: int = 0
-    preserved: int = 0
+    preserved_manual: int = 0
+    preserved_llm: int = 0
     skipped: int = 0
     errors: list[str] = field(default_factory=list)
 
@@ -146,7 +151,7 @@ def run_classify(
     """
     fragments_root = vault_path / "01-Fragments"
     if not fragments_root.exists():
-        return ClassifySummary(0, 0, 0, 0, ())
+        return ClassifySummary(0, 0, 0, 0, 0, ())
 
     rules = RuleClassifier()
     llm = LLMClassifier(config=config.llm) if method == "llm" else None
@@ -178,13 +183,46 @@ def run_classify(
     return ClassifySummary(
         total=counts.total,
         classified=counts.classified,
-        preserved_manual=counts.preserved,
+        preserved_manual=counts.preserved_manual,
+        preserved_llm=counts.preserved_llm,
         skipped_high_confidence=counts.skipped,
         # Snapshot-by-tuple so the frozen dataclass is genuinely
         # immutable: the caller can't accidentally append to the
         # underlying list and reach into completed-run state.
         errors=tuple(counts.errors),
     )
+
+
+def _record_if_preserved(
+    raw: dict[str, object],
+    counts: _RunCounts,
+) -> bool:
+    """Update *counts* in place when *raw* names a preserved prior method.
+
+    Returns ``True`` (caller should short-circuit) when the fragment's
+    existing ``classification_method`` is either ``manual`` (operator
+    curation) or ``llm`` (paid LLM call from a prior OPS-001 resume
+    point). The two reasons are tallied separately so the CLI summary
+    can label them distinctly (issue #321) rather than blaming the
+    operator for state actually left behind by automation.
+
+    Args:
+        raw: Frontmatter dict for the fragment under consideration.
+        counts: Mutable per-run counters; mutated in place when the
+            fragment is preserved.
+
+    Returns:
+        ``True`` when the fragment is preserved (caller must not
+        re-classify it); ``False`` when classification should proceed.
+    """
+    existing_method = raw.get(CLASSIFICATION_METHOD_KEY)
+    if existing_method == MANUAL_METHOD:
+        counts.preserved_manual += 1
+        return True
+    if existing_method == LLM_METHOD:
+        counts.preserved_llm += 1
+        return True
+    return False
 
 
 def _process_file(
@@ -234,12 +272,11 @@ def _process_file(
     counts.total += 1
     fragment, body, raw = record
 
-    # Skip fragments whose previous run already settled the classification:
-    # ``manual`` is operator-curated; ``llm`` is a paid LLM call we don't
-    # want to repeat after a crash (OPS-001 resume contract). Pass
-    # ``--force`` to re-classify everything.
-    if not force and raw.get(CLASSIFICATION_METHOD_KEY) in _RESUMABLE_METHODS:
-        counts.preserved += 1
+    # Skip fragments whose previous run already settled the classification.
+    # Tracked on distinct counters so the CLI summary can label "manual
+    # preserved" and "previously LLM-classified preserved" honestly
+    # (issue #321).
+    if not force and _record_if_preserved(raw, counts):
         return
 
     new_fragment, was_skipped, reasoning = _classify_one(

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -867,10 +867,18 @@ def classify(
         method=method,
         force=force,
     )
+    # Issue #321: report manual-preserved and prior-LLM-preserved as
+    # distinct counts so the operator can tell genuine hand-curation
+    # ("a person tagged these") apart from the OPS-001 resume path
+    # ("we left them alone because a previous --method llm run already
+    # paid for them"). Collapsing both into "N manual preserved" was a
+    # bug: fragments touched only by a failed automated run were
+    # incorrectly attributed to a human.
     console.print(
         f"[bold green]Classified {summary.classified} of "
         f"{summary.total} fragment(s) "
         f"({summary.preserved_manual} manual preserved, "
+        f"{summary.preserved_llm} previously LLM-classified preserved, "
         f"{summary.skipped_high_confidence} skipped).[/bold green]",
     )
     if summary.errors:

--- a/creek-tools/creek_mcp/tools/classify.py
+++ b/creek-tools/creek_mcp/tools/classify.py
@@ -70,6 +70,11 @@ def classify_tool(
         "total": summary.total,
         "classified": summary.classified,
         "preserved_manual": summary.preserved_manual,
+        # Issue #321: prior-LLM-preserved fragments used to roll into
+        # ``preserved_manual``, misattributing automated state to the
+        # operator. Surface them as a separate field so downstream
+        # consumers can present the two reasons distinctly.
+        "preserved_llm": summary.preserved_llm,
         "skipped_high_confidence": summary.skipped_high_confidence,
         "errors": list(summary.errors),
     }

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -537,3 +537,84 @@ def test_rules_method_does_not_persist_reasoning(tmp_path: Path) -> None:
         str(vault / "01-Fragments" / "Notes" / "frag-rulesreas01.md"),
     )
     assert CLASSIFICATION_REASONING_KEY not in reloaded.metadata
+
+
+# ---- Issue #321: preserved counter splits manual vs prior-LLM ----
+
+
+def test_preserved_manual_counts_only_genuinely_manual_fragments(
+    tmp_path: Path,
+) -> None:
+    """``preserved_manual`` reflects only ``classification_method: manual``.
+
+    Issue #321: prior to the fix, a fragment stamped by a partial LLM
+    run inflated ``preserved_manual``, causing the CLI to report "N
+    manual preserved" even though no human had ever touched the file.
+    Pin the contract: the field name must match the data.
+    """
+    vault = tmp_path / "vault"
+    manual_frag = Fragment(
+        id="frag-trulymanual0",
+        title="Hand-tagged",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=manual_frag,
+        body="body",
+        method="manual",
+    )
+    llm_frag = Fragment(
+        id="frag-priorllm0001",
+        title="Prior LLM run",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=llm_frag,
+        body="body",
+        method="llm",
+    )
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    assert summary.preserved_manual == 1
+    assert summary.preserved_llm == 1
+    assert summary.classified == 0
+
+
+def test_preserved_llm_counts_only_prior_llm_runs(tmp_path: Path) -> None:
+    """``preserved_llm`` counts fragments preserved by the OPS-001 resume path.
+
+    A fragment carrying ``classification_method: llm`` from a previous
+    (possibly partial) run must be tallied separately from manual
+    decisions so the CLI message can distinguish the two.
+    """
+    vault = tmp_path / "vault"
+    frag = Fragment(
+        id="frag-priorllm0002",
+        title="Prior LLM only",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=frag,
+        body="body",
+        method="llm",
+    )
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    assert summary.preserved_manual == 0
+    assert summary.preserved_llm == 1
+    assert summary.classified == 0

--- a/creek-tools/tests/test_classify_engine_resume.py
+++ b/creek-tools/tests/test_classify_engine_resume.py
@@ -88,7 +88,12 @@ def test_already_llm_classified_fragment_is_skipped(tmp_path: Path) -> None:
         )
 
     mock_llm.assert_not_called()
-    assert summary.preserved_manual == 1
+    # Issue #321: a fragment stamped by a prior LLM run must NOT inflate
+    # the "manual preserved" counter — that field exists to report what
+    # a human curated. The OPS-001 resume path increments ``preserved_llm``
+    # instead so the CLI can label the two reasons honestly.
+    assert summary.preserved_manual == 0
+    assert summary.preserved_llm == 1
     assert summary.classified == 0
     reloaded = frontmatter.load(str(file))
     assert reloaded["classification_method"] == "llm"

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -532,6 +532,55 @@ def test_classify_force_overrides_manual(tmp_path: Path) -> None:
     assert reloaded["classification_method"] == "rules"
 
 
+def test_classify_summary_distinguishes_manual_and_prior_llm(tmp_path: Path) -> None:
+    """Issue #321: the summary line labels manual vs prior-LLM preservation distinctly.
+
+    A vault with one ``classification_method: manual`` fragment and one
+    ``classification_method: llm`` fragment (left over from a prior
+    partial LLM run) must produce a summary that shows ``1 manual
+    preserved`` and ``1 previously LLM-classified preserved`` rather
+    than collapsing both into a single misleading "2 manual preserved"
+    count.
+    """
+    import frontmatter
+
+    from creek.models import Fragment, FragmentSource, SourcePlatform
+
+    vault = tmp_path / "vault"
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True)
+
+    for frag_id, method in (
+        ("frag-cli-manual0", "manual"),
+        ("frag-cli-llmold0", "llm"),
+    ):
+        fragment = Fragment(
+            id=frag_id,
+            title=f"prior {method}",
+            source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        )
+        metadata = fragment.model_dump(mode="json")
+        metadata["classification_method"] = method
+        file = fragments_dir / f"{frag_id}.md"
+        file.write_text(
+            frontmatter.dumps(frontmatter.Post(content="body", **metadata)),
+            encoding="utf-8",
+        )
+
+    result = runner.invoke(
+        app,
+        ["classify", "--vault", str(vault), "--method", "rules"],
+    )
+    assert result.exit_code == 0, result.output
+    # Rich/Typer may hard-wrap the summary at terminal width, so
+    # collapse whitespace before substring matching — otherwise the
+    # assertion would fail when Rich inserts a newline mid-phrase
+    # (e.g. ``LLM-classified\npreserved``).
+    normalized = " ".join(_strip_ansi(result.output).split())
+    assert "1 manual preserved" in normalized
+    assert "1 previously LLM-classified preserved" in normalized
+
+
 # ---- FEAT-017b: --calibrate ----
 
 


### PR DESCRIPTION
## Summary

Closes #321.

The `creek classify` summary line previously reported every preserved fragment as "manual preserved", whether the operator had stamped it `classification_method: manual` or whether a prior (possibly partial) `--method llm` run had stamped it `classification_method: llm`. After a failed LLM run, operators saw `"N manual preserved"` attributing state to a human who had never touched the files.

### Investigation

The recommended approach in the issue was to investigate first. Findings:

- `ClassifySummary.preserved_manual` was already documented (engine docstring lines 90-98) as covering *both* manual and prior-LLM preservation — a labelling mismatch with the user-facing CLI string.
- `_RESUMABLE_METHODS = frozenset({MANUAL_METHOD, LLM_METHOD})` was the single bucket; the counter and CLI message simply lied about which side of that bucket each fragment came from.
- Nothing was incorrectly stamping `classification_method: manual` — the writer is honest, the labelling was the bug.

So this is the "split the counter" path from the issue.

### Change

- `ClassifySummary` gains a `preserved_llm: int` field; `preserved_manual` is now genuinely manual-only.
- `_process_file` (extracted into a `_record_if_preserved` helper to keep cyclomatic complexity under 10) bumps the right counter based on the existing `classification_method`.
- CLI summary now reads: `"Classified X of Y fragment(s) (A manual preserved, B previously LLM-classified preserved, C skipped)."`
- MCP `creek.classify` tool exposes `preserved_llm` alongside the existing `preserved_manual` so downstream consumers can report the two reasons distinctly.

### Manual sanity (e2e recipe)

On a vault with one `manual`-stamped, one `llm`-stamped, and one fresh fragment:

```
Classified 1 of 3 fragment(s) (1 manual preserved, 1 previously LLM-classified preserved, 0 skipped).
```

Genuine manual and prior-LLM preservation are now reported distinctly.

## Test plan

- [x] New unit test: `preserved_manual` counts only `classification_method: manual`
- [x] New unit test: `preserved_llm` counts only `classification_method: llm`
- [x] Updated OPS-001 resume test: a prior-LLM fragment increments `preserved_llm`, not `preserved_manual`
- [x] New CLI test: summary line shows both labels distinctly
- [x] `./scripts/check-all.sh` exits 0 (4055 tests pass, coverage 93.70%, complexity green)
- [x] Manual e2e on a mixed vault matches expectations

https://claude.ai/code/session_011e4q4ZQcwtP9zVEp21T6ki


---
_Generated by [Claude Code](https://claude.ai/code/session_011e4q4ZQcwtP9zVEp21T6ki)_