### PR TITLE
feat(classify): surface CREEK_ANTHROPIC_CONSENT before runtime failure

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -748,10 +748,67 @@ _LINK_METHODS = ("embeddings", "temporal", "eddies")
 _REATOMIZE_DIRECTIONS = ("auto", "split", "aggregate")
 
 
+_CLASSIFY_METHOD_HELP: str = (
+    "Classification method (rules|llm). "
+    "'rules' is local and offline. 'llm' calls the provider configured "
+    "under llm: in creek_config.yaml; the default 'ollama' provider is "
+    "local, while 'anthropic' requires both ANTHROPIC_API_KEY and "
+    "CREEK_ANTHROPIC_CONSENT=1 to be set in the environment before the "
+    "run (data-egress acknowledgement; see issue #320)."
+)
+
+
+def _preflight_anthropic_consent(config: CreekConfig) -> None:
+    """Abort early when ``--method llm`` will hit the Anthropic consent gate.
+
+    Issue #320: previously the consent requirement only surfaced once
+    :class:`creek.classify.llm.providers.AnthropicProvider` was
+    instantiated mid-classify run, after vault load and first-fragment
+    iteration. This pre-flight inspects the resolved config plus the
+    live process environment and surfaces the exact remediation BEFORE
+    any fragment work begins.
+
+    No-ops for any non-anthropic provider, and silent when consent is
+    already on file (the run continues normally).
+
+    Args:
+        config: Loaded :class:`CreekConfig` for the current invocation.
+
+    Raises:
+        typer.Exit: With code ``1`` when the Anthropic provider is
+            selected but ``CREEK_ANTHROPIC_CONSENT`` is missing or not
+            set to a truthy value.
+    """
+    from creek.classify.llm.providers import AnthropicProvider
+
+    if config.llm.provider.strip().lower() != "anthropic":
+        return
+    consent = os.environ.get(AnthropicProvider.CONSENT_ENV, "").strip().lower()
+    if consent in AnthropicProvider.CONSENT_TRUTHY:
+        return
+    console.print(
+        "[red]Anthropic provider selected in creek_config.yaml "
+        "(llm.provider: anthropic), but cloud classification requires "
+        "explicit consent.[/red]",
+    )
+    console.print(
+        f"[yellow]Set [bold]{AnthropicProvider.CONSENT_ENV}=1[/bold] "
+        "(also accepts 'true' or 'yes') to confirm that fragment "
+        "content may be sent to Anthropic's servers, then re-run "
+        "[bold]creek classify --method llm[/bold].[/yellow]",
+    )
+    console.print(
+        "[dim]To keep classification fully local instead, set "
+        "[bold]llm.provider: ollama[/bold] in your creek_config.yaml "
+        "or pass [bold]--method rules[/bold].[/dim]",
+    )
+    raise typer.Exit(code=1)
+
+
 @app.command()
 def classify(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
-    method: str = typer.Option("rules", help="Classification method (rules|llm)"),
+    method: str = typer.Option("rules", help=_CLASSIFY_METHOD_HELP),
     force: bool = typer.Option(
         False,
         "--force",
@@ -843,6 +900,12 @@ def classify(
         raise typer.Exit(code=2)
 
     config = _load_config_for_vault(vault)
+    if method == "llm":
+        # Issue #320: surface the Anthropic consent-env-var gate before
+        # any vault iteration. The provider's own __init__ also raises,
+        # but only after the engine has already started — by then the
+        # operator has waited through vault load and per-fragment setup.
+        _preflight_anthropic_consent(config)
     if reatomize:
         # Late-bind the FEAT-023 CLI overrides into the loaded config so
         # downstream call-sites only ever look at the config object, not

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -839,15 +839,48 @@ def load_config(
     return CreekConfig()
 
 
+_ANTHROPIC_CONSENT_NOTE: str = """\
+# -----------------------------------------------------------------------------
+# Anthropic cloud classification (opt-in) -- issue #320
+# -----------------------------------------------------------------------------
+# Switching ``llm.provider`` below to ``anthropic`` enables cloud-based
+# classification. Fragment content will be sent to Anthropic's servers,
+# so the provider refuses to start unless TWO environment variables are
+# set explicitly:
+#
+#   export ANTHROPIC_API_KEY=sk-ant-...        # your API key
+#   export CREEK_ANTHROPIC_CONSENT=1           # consent to data egress
+#
+# Without ``CREEK_ANTHROPIC_CONSENT`` the ``creek classify --method llm``
+# run will abort before iterating any fragments. The default provider
+# (``ollama``) is fully local and needs neither variable.
+# -----------------------------------------------------------------------------
+"""
+"""Operator-facing notice prepended to generated configs.
+
+Discoverability is the whole point: fresh users who flip
+``llm.provider`` to ``anthropic`` should learn about the
+``CREEK_ANTHROPIC_CONSENT`` gate from the config file itself rather
+than from a runtime failure mid-classify. The block is YAML-comment-
+only so it survives a round-trip through ``yaml.safe_load`` without
+introducing any new keys (issue #320).
+"""
+
+
 def generate_default_config(output_path: Path) -> None:
     """Generate a default ``creek_config.yaml`` file.
 
     Serialises the default ``CreekConfig`` to YAML and writes it to
     *output_path*, providing a starting template that users can customise.
 
+    The output is prefixed with :data:`_ANTHROPIC_CONSENT_NOTE` so a
+    first-time user sees the ``CREEK_ANTHROPIC_CONSENT`` requirement
+    before flipping ``llm.provider`` to ``anthropic`` (issue #320).
+
     Args:
         output_path: Destination file path for the generated YAML.
     """
     data: dict[str, object] = CreekConfig().model_dump(mode="json")
     with output_path.open("w") as f:
+        f.write(_ANTHROPIC_CONSENT_NOTE)
         yaml.dump(data, f, default_flow_style=False, sort_keys=False)

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -423,6 +423,144 @@ def test_classify_reatomize_help_lists_flag() -> None:
     assert "--reatomize-direction" in plain
 
 
+def test_classify_help_mentions_anthropic_consent_env() -> None:
+    """Issue #320: ``--method llm`` help must surface CREEK_ANTHROPIC_CONSENT.
+
+    The Anthropic provider blocks at runtime if the consent env var is
+    unset; the requirement was previously undiscoverable from the help
+    text. The help must now name the variable so users see the gate
+    before they kick off a doomed classify run.
+    """
+    result = runner.invoke(app, ["classify", "--help"])
+    assert result.exit_code == 0
+    plain = _strip_ansi(result.output)
+    # Rich may wrap long help text mid-token; normalise whitespace
+    # before substring asserts so a soft line break never hides the
+    # token from the assertion.
+    normalised = re.sub(r"\s+", " ", plain)
+    assert "CREEK_ANTHROPIC_CONSENT" in normalised
+
+
+def _write_anthropic_config(vault: Path) -> Path:
+    """Write a minimal ``creek_config.yaml`` selecting the anthropic provider."""
+    config_dir = vault / "00-Creek-Meta"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "creek_config.yaml"
+    config_path.write_text(
+        "llm:\n  provider: anthropic\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_classify_llm_anthropic_warns_when_consent_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #320: classify must pre-flight warn about missing consent.
+
+    When the config selects the Anthropic provider, the CLI must surface
+    the consent-env-var gate BEFORE iterating fragments. Today the gate
+    only fires inside ``AnthropicProvider.__init__`` once the engine
+    starts processing the first fragment — by then any setup time has
+    been wasted.
+    """
+    from creek.classify.llm.providers import AnthropicProvider
+
+    monkeypatch.delenv(AnthropicProvider.CONSENT_ENV, raising=False)
+    monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    config_path = _write_anthropic_config(vault)
+    monkeypatch.setenv("CREEK_CONFIG", str(config_path))
+
+    result = runner.invoke(app, ["classify", "--vault", str(vault), "--method", "llm"])
+
+    # The pre-flight gate aborts the run with a clear remediation hint.
+    assert result.exit_code != 0
+    plain = _strip_ansi(result.output)
+    normalised = re.sub(r"\s+", " ", plain)
+    assert "CREEK_ANTHROPIC_CONSENT" in normalised
+
+
+def test_classify_llm_anthropic_skips_warning_when_consent_set(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pre-flight gate is silent once consent is on file.
+
+    With ``CREEK_ANTHROPIC_CONSENT`` set, the pre-flight check must not
+    abort and must not print the consent remediation text — the user
+    has already acknowledged the data-egress decision.
+    """
+    from creek.classify.llm.providers import AnthropicProvider
+
+    monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+    monkeypatch.setenv(AnthropicProvider.CONSENT_ENV, "1")
+
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    config_path = _write_anthropic_config(vault)
+    monkeypatch.setenv("CREEK_CONFIG", str(config_path))
+
+    result = runner.invoke(app, ["classify", "--vault", str(vault), "--method", "llm"])
+
+    # Empty vault + consent on file → engine returns cleanly.
+    assert result.exit_code == 0, result.output
+    plain = _strip_ansi(result.output)
+    assert "Set CREEK_ANTHROPIC_CONSENT" not in plain
+
+
+def test_classify_rules_does_not_warn_about_anthropic_consent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--method rules`` never touches the cloud and must not nag.
+
+    Local-only runs must remain quiet even when the YAML's
+    ``llm.provider`` is ``anthropic`` and consent is unset, because
+    the rules path never opens a network connection.
+    """
+    from creek.classify.llm.providers import AnthropicProvider
+
+    monkeypatch.delenv(AnthropicProvider.CONSENT_ENV, raising=False)
+    monkeypatch.delenv(AnthropicProvider.API_KEY_ENV, raising=False)
+
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    config_path = _write_anthropic_config(vault)
+    monkeypatch.setenv("CREEK_CONFIG", str(config_path))
+
+    result = runner.invoke(
+        app, ["classify", "--vault", str(vault), "--method", "rules"]
+    )
+
+    assert result.exit_code == 0, result.output
+    plain = _strip_ansi(result.output)
+    assert "CREEK_ANTHROPIC_CONSENT" not in plain
+
+
+def test_classify_llm_ollama_does_not_warn_about_anthropic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An Ollama-configured vault must not surface the Anthropic gate."""
+    from creek.classify.llm.providers import AnthropicProvider
+
+    monkeypatch.delenv(AnthropicProvider.CONSENT_ENV, raising=False)
+
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    # No config written → defaults apply (provider=ollama).
+    monkeypatch.delenv("CREEK_CONFIG", raising=False)
+
+    result = runner.invoke(app, ["classify", "--vault", str(vault), "--method", "llm"])
+
+    plain = _strip_ansi(result.output)
+    assert "CREEK_ANTHROPIC_CONSENT" not in plain
+
+
 def test_classify_rules_writes_method_to_frontmatter(tmp_path: Path) -> None:
     """``creek classify --method rules`` stamps the method on each fragment."""
     import frontmatter

--- a/creek-tools/tests/test_config.py
+++ b/creek-tools/tests/test_config.py
@@ -656,3 +656,40 @@ class TestGenerateDefaultConfig:
         assert "cleaning" in data
         assert "discord" in data["cleaning"]
         assert "quality" in data["cleaning"]
+
+    def test_generated_config_mentions_anthropic_consent_env(
+        self, tmp_path: Path
+    ) -> None:
+        """Issue #320: the starter config must mention CREEK_ANTHROPIC_CONSENT.
+
+        First-time users who switch ``llm.provider`` to ``anthropic`` should
+        discover the consent-env-var requirement from the config file itself
+        rather than from a runtime failure mid-classify-run.
+        """
+        output = tmp_path / "creek_config.yaml"
+        generate_default_config(output)
+
+        text = output.read_text(encoding="utf-8")
+        # The note lives as a YAML comment near the llm: block, so it must
+        # survive a round-trip parse without changing the data shape.
+        assert "CREEK_ANTHROPIC_CONSENT" in text
+        assert "ANTHROPIC_API_KEY" in text
+        assert "anthropic" in text.lower()
+
+        # The note is purely a comment — it must not introduce new keys
+        # into the parsed config.
+        with output.open() as f:
+            data = yaml.safe_load(f)
+        assert "vault_path" in data
+        assert "llm" in data
+
+    def test_generated_config_round_trips_with_consent_note(
+        self, tmp_path: Path
+    ) -> None:
+        """The added consent comment must not break load_config round-trips."""
+        output = tmp_path / "creek_config.yaml"
+        generate_default_config(output)
+
+        cfg = load_config(output)
+        # The comment is informational — provider default still ollama.
+        assert cfg.llm.provider == "ollama"


### PR DESCRIPTION
Closes #320

## Summary

The Anthropic cloud-classification consent requirement was previously undiscoverable until users hit a runtime wall mid-classify run. This PR adds three discoverability fixes (matching the issue's recommended 1, 2, 4):

1. **`creek init` writes a consent note into the starter config.** A commented YAML block prefixed to the generated `creek_config.yaml` explains the `ANTHROPIC_API_KEY` + `CREEK_ANTHROPIC_CONSENT` requirement and points to the `llm.provider` switch the user is about to flip.
2. **`creek classify --method llm` pre-flights the consent gate.** When the resolved config selects `llm.provider: anthropic` and `CREEK_ANTHROPIC_CONSENT` is unset (or not truthy), the CLI aborts with a clear three-line remediation BEFORE iterating any fragments. The previous failure path only fired inside `AnthropicProvider.__init__` after vault load and per-fragment setup — by then the operator had already paid the wait.
3. **`creek classify --help` names the env var.** The `--method` help text now explicitly describes the `ANTHROPIC_API_KEY` + `CREEK_ANTHROPIC_CONSENT` requirement for the `anthropic` provider.

Suggestion #3 (persistent consent via `creek consent grant anthropic`) is intentionally deferred to a separate issue per the PR scope guidance.

## Behavior preserved

- `--method rules` runs are unaffected (no warnings, no aborts) even when `llm.provider: anthropic` and consent is unset.
- `llm.provider: ollama` (the default) is unaffected.
- Existing user configs are not rewritten — the consent note only appears in NEW configs generated by `creek init`.
- The YAML round-trip through `load_config()` is unchanged; the note is comment-only and introduces no new keys.

## Test plan

- [x] 5 new unit tests in `tests/test_cli.py` cover the pre-flight matrix: missing consent aborts, set consent runs cleanly, `--method rules` stays silent under anthropic config, and `--method llm` stays silent under ollama config.
- [x] 2 new unit tests in `tests/test_config.py` assert the generated config carries the `CREEK_ANTHROPIC_CONSENT` and `ANTHROPIC_API_KEY` strings as YAML comments and round-trips cleanly through `load_config`.
- [x] `./scripts/check-all.sh` exits 0 (4059 tests pass, 93.70% coverage, all 12 quality gates green).
- [x] End-to-end recipe from the issue:
  - `creek init --vault /tmp/v` → `grep -i "anthropic\|consent" /tmp/v/00-Creek-Meta/creek_config.yaml` returns the consent block.
  - `creek classify --help | grep CREEK_ANTHROPIC_CONSENT` returns the help line.
  - With provider flipped to `anthropic` and consent unset, `creek classify --method llm` prints the pre-flight remediation and aborts (exit 1) BEFORE any per-fragment work.

https://claude.ai/code/session_011e4q4ZQcwtP9zVEp21T6ki

---
_Generated by [Claude Code](https://claude.ai/code/session_011e4q4ZQcwtP9zVEp21T6ki)_