### PR TITLE
fix(classify): exit non-zero when --method llm provider is unavailable

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -78,6 +78,41 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class LLMProviderUnavailableError(RuntimeError):
+    """Raised when ``creek classify --method llm`` cannot reach its provider.
+
+    Surfaced by :func:`run_classify` *before* any fragment is rewritten
+    so that:
+
+    1. The CLI can exit non-zero instead of pretending the run
+       succeeded with zero work done.
+    2. The vault stays clean — no fragments end up stamped with
+       ``classification_method: llm`` when the LLM never actually ran.
+
+    The configured provider name is preserved on the exception so the
+    CLI message can name it ("anthropic" / "ollama") and point the
+    operator at the right environment variable to fix.
+
+    Attributes:
+        provider: The configured ``llm.provider`` (e.g. ``"anthropic"``).
+    """
+
+    def __init__(self, provider: str, detail: str) -> None:
+        """Build the exception with a CLI-ready message.
+
+        Args:
+            provider: The configured LLM provider name.
+            detail: Provider-specific reason (env var missing, health
+                check failed, etc.) — embedded in the message so the
+                operator does not have to scroll back through warnings
+                to see what went wrong.
+        """
+        self.provider = provider
+        super().__init__(
+            f"LLM provider {provider!r} is unavailable: {detail}",
+        )
+
+
 @dataclass(frozen=True)
 class ClassifySummary:
     """Counts produced by a single ``creek classify`` run.
@@ -158,6 +193,13 @@ def run_classify(
 
     Returns:
         A :class:`ClassifySummary` reporting per-method counts.
+
+    Raises:
+        LLMProviderUnavailableError: When ``method == "llm"`` and the
+            configured provider fails its availability check. Raised
+            *before* any fragment is processed so the vault is not
+            polluted with bogus ``classification_method: llm`` stamps
+            when the LLM never ran.
     """
     fragments_root = vault_path / "01-Fragments"
     if not fragments_root.exists():
@@ -165,6 +207,18 @@ def run_classify(
 
     rules = RuleClassifier()
     llm = LLMClassifier(config=config.llm) if method == "llm" else None
+    if llm is not None and not llm.available:
+        # Refuse to iterate when the provider is unreachable so the
+        # vault is never stamped with ``classification_method: llm``
+        # for fragments the LLM never actually saw. The orchestrator
+        # already logged the provider-specific reason (missing API
+        # key, missing consent env var, Ollama down) as a WARNING;
+        # we capture it here for the operator-facing message so the
+        # remediation hint is not buried in stderr.
+        raise LLMProviderUnavailableError(
+            provider=config.llm.provider,
+            detail=_describe_llm_unavailability(config.llm.provider),
+        )
     counts = _RunCounts()
     progress_path: Path | None = None
     trace_log_path: Path | None = None
@@ -768,6 +822,36 @@ def _write_fragment(
     post = frontmatter.Post(content=body)
     post.metadata.update(new_metadata)
     md_file.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+def _describe_llm_unavailability(provider: str) -> str:
+    """Build a remediation hint for :class:`LLMProviderUnavailableError`.
+
+    The hint is provider-specific so a first-time user can act on it
+    without scrolling back through orchestrator WARNING logs. Anthropic
+    needs two env vars (API key + consent); Ollama needs the local
+    daemon to be reachable.
+
+    Args:
+        provider: ``llm.provider`` from the loaded config.
+
+    Returns:
+        Human-readable sentence the CLI can render verbatim.
+    """
+    if provider == "anthropic":
+        return (
+            "set ANTHROPIC_API_KEY and CREEK_ANTHROPIC_CONSENT=1 to "
+            "authorise sending fragment content to Anthropic's servers"
+        )
+    if provider == "ollama":
+        return (
+            "ensure the Ollama daemon is running and reachable at the "
+            "URL configured under `llm.url` in creek_config.yaml"
+        )
+    return (
+        "check the `llm.*` settings in creek_config.yaml and the "
+        "provider-specific credentials / health-check requirements"
+    )
 
 
 def _record_llm_progress(progress_path: Path, fragment_id: str) -> None:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -923,14 +923,27 @@ def classify(
         )
     vault_path = _resolve_vault(vault)
 
-    from creek.classify.classify_engine import run_classify
-
-    summary = run_classify(
-        vault_path=vault_path,
-        config=config,
-        method=method,
-        force=force,
+    from creek.classify.classify_engine import (
+        LLMProviderUnavailableError,
+        run_classify,
     )
+
+    try:
+        summary = run_classify(
+            vault_path=vault_path,
+            config=config,
+            method=method,
+            force=force,
+        )
+    except LLMProviderUnavailableError as exc:
+        # The engine refused to iterate because the configured LLM
+        # provider is unreachable. Surface the provider-specific
+        # remediation hint and exit non-zero so a shell pipeline does
+        # NOT see "Classified N of N" plus a clean exit when zero
+        # fragments were actually classified.
+        console.print(f"[red]Classification aborted: {exc}.[/red]")
+        raise typer.Exit(code=1) from exc
+
     # Issue #321: report manual-preserved and prior-LLM-preserved as
     # distinct counts so the operator can tell genuine hand-curation
     # ("a person tagged these") apart from the OPS-001 resume path

--- a/creek-tools/creek_mcp/tools/classify.py
+++ b/creek-tools/creek_mcp/tools/classify.py
@@ -11,7 +11,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from creek.classify.classify_engine import run_classify
+from creek.classify.classify_engine import (
+    LLMProviderUnavailableError,
+    run_classify,
+)
 from creek.config import load_config
 from creek_mcp.audit import MCPAuditLog
 from creek_mcp.tier_ceiling import TierCeiling, refusal_response
@@ -47,12 +50,23 @@ def classify_tool(
             ),
         )
     config = load_config()
-    summary = run_classify(
-        vault_path=vault_path,
-        config=config,
-        method=method,
-        force=force,
-    )
+    try:
+        summary = run_classify(
+            vault_path=vault_path,
+            config=config,
+            method=method,
+            force=force,
+        )
+    except LLMProviderUnavailableError as exc:
+        # The engine refuses to iterate when the configured LLM
+        # provider is unreachable. Translate to a structured refusal
+        # so MCP clients see a stable shape instead of an unhandled
+        # ``RuntimeError`` traceback.
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason=str(exc),
+        )
     # Classify rewrites existing frontmatter in place; it does not
     # produce a new file, so ``created_path`` is omitted from the audit
     # entry (per the audit-schema convention documented in docs/mcp.md).

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -9,18 +9,41 @@ files.
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import frontmatter
+import pytest
 
-from creek.classify.classify_engine import run_classify
-from creek.classify.llm import LLMClassificationResult
+from creek.classify.classify_engine import (
+    LLMProviderUnavailableError,
+    _describe_llm_unavailability,
+    run_classify,
+)
+from creek.classify.llm import LLMClassificationResult, LLMClassifier
 from creek.config import CreekConfig
 from creek.models import Fragment, FragmentSource, SourcePlatform
 from tests.helpers import write_fragment_file as _write_fragment
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _force_llm_available() -> object:
+    """Bypass the LLM-availability gate for engine tests by default.
+
+    Most engine tests mock the LLM at the ``classify_with_reasoning``
+    boundary and rely on the availability gate being open. Tests that
+    exercise the unavailable path (issue #317) re-patch ``available``
+    locally to return ``False``.
+    """
+    with patch.object(
+        LLMClassifier,
+        "available",
+        new_callable=PropertyMock,
+        return_value=True,
+    ) as patched:
+        yield patched
 
 
 def test_run_classify_returns_zeroes_when_no_fragments_dir(tmp_path: Path) -> None:
@@ -851,3 +874,221 @@ def test_run_classify_reatomize_invokes_orchestrator(tmp_path: Path) -> None:
         )
 
     spy.assert_called()
+
+
+# ---- --method llm fails loudly when the provider is unavailable ----
+
+
+def test_run_classify_llm_unavailable_raises_before_processing(
+    tmp_path: Path,
+) -> None:
+    """``--method llm`` raises when the provider is unavailable.
+
+    Symptom from the bug report: when the Anthropic provider is
+    configured but ``CREEK_ANTHROPIC_CONSENT`` is unset, the engine
+    iterated over every fragment, the LLM short-circuited to "return
+    unchanged", and the summary lied that "Classified N of N"
+    succeeded. Worse, the process exited 0 — a shell pipeline reading
+    the exit code saw a clean success.
+
+    Fix contract: when the engine is asked for ``--method llm`` and the
+    classifier reports ``available is False``, it raises
+    :class:`LLMProviderUnavailableError` **before** rewriting any
+    fragments. The CLI translates this to a non-zero exit.
+    """
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-llmunavail01",
+        title="placeholder",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="ordinary content with no signal keywords at all",
+    )
+    original_text = file.read_text(encoding="utf-8")
+
+    with (
+        patch.object(
+            LLMClassifier,
+            "available",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        pytest.raises(LLMProviderUnavailableError),
+    ):
+        run_classify(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="llm",
+            force=False,
+        )
+
+    # Fragments on disk are untouched — no spurious ``classification_method:
+    # llm`` stamp gets written when the LLM never actually ran.
+    assert file.read_text(encoding="utf-8") == original_text
+
+
+def test_run_classify_llm_unavailable_message_names_provider(
+    tmp_path: Path,
+) -> None:
+    """The unavailable error mentions the configured provider name.
+
+    A first-time user staring at ``creek classify --method llm`` failing
+    needs to know which provider Creek tried to reach so they can fix
+    the right environment variable. Pin the provider name into the
+    error message.
+    """
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-llmunavail02",
+        title="placeholder",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="content",
+    )
+    config = CreekConfig()
+    config.llm.provider = "anthropic"
+
+    with (
+        patch.object(
+            LLMClassifier,
+            "available",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        pytest.raises(LLMProviderUnavailableError, match="anthropic"),
+    ):
+        run_classify(
+            vault_path=vault,
+            config=config,
+            method="llm",
+            force=False,
+        )
+
+
+def test_run_classify_llm_unavailable_skips_progress_dir_writes(
+    tmp_path: Path,
+) -> None:
+    """The progress log file is not created when the LLM never runs.
+
+    A non-zero-exit failure path should leave the vault clean: no
+    bookkeeping artefacts that suggest a partial run. The progress
+    directory (00-Creek-Meta/Processing-Log) gets created up-front, but
+    the ``llm-progress.jsonl`` file inside it should never appear when
+    the LLM never executes.
+    """
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-llmunavail03",
+        title="placeholder",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="content",
+    )
+
+    with (
+        patch.object(
+            LLMClassifier,
+            "available",
+            new_callable=PropertyMock,
+            return_value=False,
+        ),
+        pytest.raises(LLMProviderUnavailableError),
+    ):
+        run_classify(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="llm",
+            force=False,
+        )
+
+    progress_file = vault / "00-Creek-Meta" / "Processing-Log" / "llm-progress.jsonl"
+    assert not progress_file.exists()
+
+
+# ---- _describe_llm_unavailability: per-provider remediation hint ----
+
+
+def test_describe_llm_unavailability_anthropic_mentions_api_key_and_consent() -> None:
+    """The Anthropic hint names both env vars the operator must set.
+
+    Pinning both names so a search for either ``ANTHROPIC_API_KEY`` or
+    ``CREEK_ANTHROPIC_CONSENT`` in the codebase keeps surfacing the
+    user-facing remediation copy. If a future refactor splits these into
+    separate sentences the test still passes; if either disappears the
+    test fails loudly.
+    """
+    message = _describe_llm_unavailability("anthropic")
+    assert "ANTHROPIC_API_KEY" in message
+    assert "CREEK_ANTHROPIC_CONSENT" in message
+
+
+def test_describe_llm_unavailability_ollama_mentions_daemon_and_url() -> None:
+    """The Ollama hint points at the local daemon and the config URL key.
+
+    Ollama failures are local-process failures (daemon not running, wrong
+    port), so the remediation has to direct the operator at the daemon
+    and the ``llm.url`` setting that controls where Creek looks for it.
+    """
+    message = _describe_llm_unavailability("ollama")
+    assert "Ollama" in message or "ollama" in message
+    assert "llm.url" in message
+
+
+def test_describe_llm_unavailability_unknown_provider_falls_back_to_generic() -> None:
+    """Unknown providers get a generic ``creek_config.yaml`` pointer.
+
+    Pins the fallback branch so adding a third provider to
+    ``orchestrator.py`` without updating this helper does not silently
+    swallow the operator-facing remediation hint — instead they get the
+    generic message until the helper is taught about the new provider.
+    """
+    message = _describe_llm_unavailability("vertex")
+    assert "creek_config.yaml" in message
+    # The generic branch must NOT leak provider-specific env-var names
+    # that would be misleading for the unknown provider.
+    assert "ANTHROPIC_API_KEY" not in message
+    assert "Ollama" not in message
+
+
+def test_run_classify_rules_does_not_construct_llm(
+    tmp_path: Path,
+) -> None:
+    """``--method rules`` never constructs the LLM classifier.
+
+    The availability gate must not bleed into the rules-only path —
+    a vault without any LLM credentials configured must classify with
+    rules cleanly.
+    """
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-rulesonly001",
+        title="rules only",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="power dominance bold rage warrior conquest",
+    )
+
+    with patch(
+        "creek.classify.classify_engine.LLMClassifier",
+    ) as mock_cls:
+        summary = run_classify(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="rules",
+            force=False,
+        )
+
+    mock_cls.assert_not_called()
+    assert summary.classified == 1

--- a/creek-tools/tests/test_classify_engine_resume.py
+++ b/creek-tools/tests/test_classify_engine_resume.py
@@ -12,11 +12,16 @@ from __future__ import annotations
 
 import json
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import frontmatter
+import pytest
 
-from creek.classify.classify_engine import LLM_PROGRESS_FILENAME, run_classify
+from creek.classify.classify_engine import (
+    LLM_PROGRESS_FILENAME,
+    LLMClassifier,
+    run_classify,
+)
 from creek.classify.llm import LLMClassificationResult
 from creek.config import CreekConfig
 from creek.models import Fragment, FragmentSource, SourcePlatform
@@ -27,6 +32,25 @@ def _stub_llm_result(frag: Fragment, content: str = "") -> LLMClassificationResu
     """Stub for ``classify_with_reasoning`` used across resume tests."""
     del content
     return LLMClassificationResult(fragment=frag, reasoning="")
+
+
+@pytest.fixture(autouse=True)
+def _force_llm_available() -> object:
+    """Bypass the LLM-availability gate for resume-contract tests.
+
+    The OPS-001 resume tests exercise the engine with ``--method llm``
+    but rely on the LLM being mocked out at the
+    ``classify_with_reasoning`` boundary. Without this patch the
+    availability check fires first (no Ollama daemon in the test env)
+    and the engine aborts before the resume logic runs.
+    """
+    with patch.object(
+        LLMClassifier,
+        "available",
+        new_callable=PropertyMock,
+        return_value=True,
+    ) as patched:
+        yield patched
 
 
 if TYPE_CHECKING:

--- a/creek-tools/tests/test_classify_few_shot.py
+++ b/creek-tools/tests/test_classify_few_shot.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import pytest
 
 from creek.classify import few_shot
 from creek.classify.few_shot import (
@@ -13,9 +13,6 @@ from creek.classify.few_shot import (
     render_block,
     sample_examples,
 )
-
-if TYPE_CHECKING:
-    import pytest
 
 
 class TestExamplesLoad:
@@ -212,9 +209,7 @@ class TestCoerceGuard:
 
     def test_coerce_rejects_non_dict(self) -> None:
         """The TypeError branch fires when the gate is bypassed."""
-        import pytest as _pytest
-
-        with _pytest.raises(TypeError, match="non-dict"):
+        with pytest.raises(TypeError, match="non-dict"):
             few_shot._coerce("not a dict")  # type: ignore[arg-type]
 
 

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -719,6 +719,139 @@ def test_classify_summary_distinguishes_manual_and_prior_llm(tmp_path: Path) -> 
     assert "1 previously LLM-classified preserved" in normalized
 
 
+# ---- Issue #317: --method llm exits non-zero on unavailable provider ----
+
+
+def _seed_single_fragment(vault: Path) -> Path:
+    """Write one minimal Creek fragment under *vault* and return its path.
+
+    Local CLI-test seed. The engine-test suite has a richer
+    :func:`tests.helpers.write_fragment_file` helper; this one is kept
+    minimal so the CLI tests can assert on a known-clean
+    ``ordinary content`` body without inheriting engine-test fixtures.
+    """
+    import frontmatter
+
+    from creek.models import Fragment, FragmentSource, SourcePlatform
+
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True)
+    fragment = Fragment(
+        id="frag-cliseed00001",
+        title="placeholder",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = fragments_dir / "frag.md"
+    file.write_text(
+        frontmatter.dumps(
+            frontmatter.Post(
+                content="ordinary content",
+                **fragment.model_dump(mode="json"),
+            ),
+        ),
+        encoding="utf-8",
+    )
+    return file
+
+
+def test_classify_llm_unavailable_exits_non_zero(tmp_path: Path) -> None:
+    """``creek classify --method llm`` exits non-zero when provider is down.
+
+    Reproduces the reported symptom: prior to the fix the CLI printed
+    ``Classified N of N`` and exited 0 even when the LLM provider had
+    not run a single classification. The shell pipeline could not
+    distinguish success from silent failure.
+    """
+    from unittest.mock import PropertyMock, patch
+
+    from creek.classify.classify_engine import LLMClassifier
+
+    vault = tmp_path / "vault"
+    _seed_single_fragment(vault)
+
+    with patch.object(
+        LLMClassifier,
+        "available",
+        new_callable=PropertyMock,
+        return_value=False,
+    ):
+        result = runner.invoke(
+            app,
+            ["classify", "--vault", str(vault), "--method", "llm"],
+        )
+
+    assert result.exit_code != 0, result.output
+    # The misleading "Classified N of N" summary must NOT appear when
+    # zero fragments were classified — that is the second half of the
+    # bug report.
+    assert "Classified" not in result.output
+
+
+def test_classify_llm_unavailable_message_names_provider(
+    tmp_path: Path,
+) -> None:
+    """The aborted-run message names the provider so the user can fix it."""
+    from unittest.mock import PropertyMock, patch
+
+    from creek.classify.classify_engine import LLMClassifier
+
+    vault = tmp_path / "vault"
+    _seed_single_fragment(vault)
+
+    # CreekConfig defaults to provider="ollama"; the message must say so.
+    with patch.object(
+        LLMClassifier,
+        "available",
+        new_callable=PropertyMock,
+        return_value=False,
+    ):
+        result = runner.invoke(
+            app,
+            ["classify", "--vault", str(vault), "--method", "llm"],
+        )
+
+    plain = _strip_ansi(result.output)
+    assert "ollama" in plain
+    assert "aborted" in plain.lower() or "unavailable" in plain.lower()
+
+
+def test_classify_llm_unavailable_leaves_fragment_unstamped(
+    tmp_path: Path,
+) -> None:
+    """No fragment ends up stamped with ``classification_method: llm``.
+
+    The pre-fix bug rewrote every fragment with ``classification_method:
+    llm`` even when the LLM never ran — corrupting the resume contract
+    (next run would skip them, thinking they were already classified).
+    Pin the fix: when the provider is unavailable, fragments are left
+    completely untouched.
+    """
+    from unittest.mock import PropertyMock, patch
+
+    import frontmatter
+
+    from creek.classify.classify_engine import LLMClassifier
+
+    vault = tmp_path / "vault"
+    file = _seed_single_fragment(vault)
+    before = frontmatter.load(str(file))
+    assert "classification_method" not in before.metadata
+
+    with patch.object(
+        LLMClassifier,
+        "available",
+        new_callable=PropertyMock,
+        return_value=False,
+    ):
+        runner.invoke(
+            app,
+            ["classify", "--vault", str(vault), "--method", "llm"],
+        )
+
+    after = frontmatter.load(str(file))
+    assert "classification_method" not in after.metadata
+
+
 # ---- FEAT-017b: --calibrate ----
 
 

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -381,6 +381,58 @@ def test_classify_runs_rules_on_empty_vault(vault: Path) -> None:
     assert entries[-1]["affected_fragment_ids"] == []
 
 
+def test_classify_refuses_when_llm_provider_unavailable(vault: Path) -> None:
+    """MCP classify returns a structured refusal, not a traceback.
+
+    The fail-fast gate in :func:`run_classify` raises
+    ``LLMProviderUnavailableError`` when the LLM cannot be reached. The
+    MCP wrapper must translate that to the standard ``status: refused``
+    payload so callers see a stable shape, never an unhandled
+    ``RuntimeError`` propagating through the MCP transport.
+    """
+    from unittest.mock import PropertyMock, patch
+
+    from creek.classify.classify_engine import LLMClassifier
+    from creek.models import Fragment, FragmentSource, SourcePlatform
+
+    # Seed at least one fragment so the engine reaches the gate (an
+    # empty 01-Fragments early-returns before the availability check).
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    fragments_dir.mkdir(parents=True, exist_ok=True)
+    fragment = Fragment(
+        id="frag-mcpunavail01",
+        title="placeholder",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    file = fragments_dir / "frag.md"
+    file.write_text(
+        frontmatter.dumps(
+            frontmatter.Post(
+                content="content",
+                **fragment.model_dump(mode="json"),
+            ),
+        ),
+        encoding="utf-8",
+    )
+
+    with patch.object(
+        LLMClassifier,
+        "available",
+        new_callable=PropertyMock,
+        return_value=False,
+    ):
+        result = classify_tool(
+            vault_path=vault,
+            method="llm",
+            privacy_tier_ceiling=TierCeiling.OPEN,
+            consumer="crawdad",
+        )
+
+    assert result["status"] == "refused"
+    assert result["tool"] == "creek.classify"
+    assert "unavailable" in result["reason"]
+
+
 # ---------------------------------------------------------------------------
 # link
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `LLMProviderUnavailableError` raised by `run_classify` before the per-fragment loop when the configured LLM provider fails its availability check, so the CLI can exit non-zero with a clear remediation hint instead of pretending "Classified 188 of 188" succeeded.
- CLI prints `Classification aborted: LLM provider 'anthropic' is unavailable: set ANTHROPIC_API_KEY and CREEK_ANTHROPIC_CONSENT=1 ...` and exits with code 1.
- MCP `classify_tool` wrapper catches the same exception and returns the standard `status: refused` payload so MCP clients keep their stable response shape.
- Fragments are left completely untouched on this failure path, preserving the OPS-001 resume contract (no bogus `classification_method: llm` stamps when the LLM never ran).

## Test plan

- [x] New unit tests in `tests/test_classify_engine.py` covering the raise path, provider name in the error, no progress-log artefacts, and that `--method rules` never constructs the LLM.
- [x] New CLI tests in `tests/test_cli.py` asserting non-zero exit code, that "Classified" no longer appears, and that fragments stay unstamped on disk.
- [x] New MCP test in `tests/test_mcp_write_tools.py` confirming the refusal payload shape.
- [x] Existing OPS-001 resume tests updated to bypass the new gate via an autouse fixture (they mock `classify_with_reasoning` so the gate would otherwise short-circuit them).
- [x] `./scripts/check-all.sh` exits 0 (12/12 checks pass, coverage 93.69%).
- [x] Manual e2e per the issue recipe: `creek classify --vault /tmp/v --method llm` with `CREEK_ANTHROPIC_CONSENT` unset now prints the abort message and exits with code 1; the seeded fragment on disk is untouched.

Closes #317

https://claude.ai/code/session_011e4q4ZQcwtP9zVEp21T6ki

---
_Generated by [Claude Code](https://claude.ai/code/session_011e4q4ZQcwtP9zVEp21T6ki)_