### PR TITLE
chore: gitignore .claude/worktrees/ from background-agent isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@
 # Issue plans are author-private; the directory exists per-package.
 **/git-issues/
 
+# Background-agent worktrees (Claude Code harness isolation directory).
+.claude/worktrees/
+
 # ============================================================
 # DEVELOPMENT ARTIFACTS
 # ============================================================


### PR DESCRIPTION
The Claude Code harness creates per-agent worktrees under
.claude/worktrees/ when spawning background agents with
isolation: worktree. These are runtime artefacts that share the
parent .git directory and should never be tracked.