### PR TITLE
fix(classify): populate wavelength color and descriptor from LLM (#319)

### DIFF
--- a/creek-tools/creek/classify/llm/calibration.py
+++ b/creek-tools/creek/classify/llm/calibration.py
@@ -16,8 +16,13 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import TypeVar
 
-from creek.classify.llm.parsing import _parse_dosage, _parse_enum
+from creek.classify.llm.parsing import (
+    _parse_descriptor,
+    _parse_dosage,
+    _parse_enum,
+)
 from creek.models import (
+    Color,
     Dosage,
     Mode,
     Orientation,
@@ -116,8 +121,14 @@ def _apply_wavelength(
     the model's pick intact — the bias only fires when the model
     explicitly reports low confidence.
 
-    Phase is **not** gated by the bias (FEAT-017 calls phase a stable
-    signal; gating it would be more cost than benefit).
+    Phase, Color, and Descriptor are **not** gated by the bias.
+    FEAT-017 calls phase a stable signal (gating it would be more
+    cost than benefit); issue #319 added color and descriptor to the
+    extracted set so the wavelength block reaches disk complete.
+    Color tracks the primary frequency (a stable signal) and
+    descriptor is a free-form label, not a categorical pick — neither
+    benefits from the confidence-bias gating that protects the noisy
+    mode/orientation/dosage axes.
 
     Args:
         data: Parsed LLM response.
@@ -151,4 +162,16 @@ def _apply_wavelength(
             score=_confidence_score(scores, "dosage"),
             threshold=unclassified_threshold,
         ),
+        # Issue #319: color + descriptor were silently dropped pre-fix,
+        # so every classified fragment landed with
+        # ``wavelength.color: unclassified`` and
+        # ``wavelength.descriptor: ''``. Neither is gated by the FEAT-017
+        # confidence bias — color tracks frequency (a stable signal) and
+        # descriptor is a free-form label, not a categorical pick.
+        color=_parse_enum(
+            wave_data.get("color"),
+            Color,
+            Color.UNCLASSIFIED,
+        ),
+        descriptor=_parse_descriptor(wave_data.get("descriptor")),
     )

--- a/creek-tools/creek/classify/llm/parsing.py
+++ b/creek-tools/creek/classify/llm/parsing.py
@@ -41,6 +41,16 @@ _DOSAGE_AMBIGUOUS_MARKERS: frozenset[str] = frozenset(
 """String values treated as ``Dosage.AMBIGUOUS``."""
 
 
+_MAX_DESCRIPTOR_CHARS: int = 128
+"""Cap on the length of the wavelength descriptor accepted from the LLM.
+
+The descriptor is a short phrase from the Mode map (``"Gnosis"``,
+``"Power-With"``, etc.); 128 characters comfortably covers every
+documented value while bounding pathological responses that would
+otherwise bloat fragment frontmatter on disk. See issue #319.
+"""
+
+
 _ALLOWED_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
     {"frequency", "wavelength", "voice", "confidence_scores"},
 )
@@ -139,6 +149,35 @@ def _parse_optional_enum(
         if member.value.lower() == val_str:
             return member
     return None
+
+
+def _parse_descriptor(value: object) -> str:
+    """Parse and normalise the wavelength ``descriptor`` field (issue #319).
+
+    The descriptor is the only free-form field in
+    :class:`creek.models.WavelengthClassification` — it carries a
+    short phrase from the Mode map like ``"Gnosis"`` or
+    ``"Power-With"``. Stripping whitespace prevents indexers from
+    treating ``" Gnosis"`` and ``"Gnosis"`` as two distinct values,
+    capping the length protects against pathological model output
+    that would bloat the on-disk YAML, and the non-string fallback
+    keeps a single junk response from crashing the entire batch.
+
+    Args:
+        value: Raw value from the LLM's ``wavelength.descriptor``
+            field. May be any YAML scalar (str, int, None, bool, …).
+
+    Returns:
+        A whitespace-stripped string of at most
+        :data:`_MAX_DESCRIPTOR_CHARS` characters. Empty string when
+        the input is ``None`` or not a string.
+    """
+    if not isinstance(value, str):
+        return ""
+    stripped = value.strip()
+    if len(stripped) > _MAX_DESCRIPTOR_CHARS:
+        return stripped[:_MAX_DESCRIPTOR_CHARS]
+    return stripped
 
 
 def _parse_dosage(value: object) -> Dosage:

--- a/creek-tools/creek/classify/llm/prompts.py
+++ b/creek-tools/creek/classify/llm/prompts.py
@@ -11,8 +11,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from creek.classify import few_shot
-from creek.generate.indexes import CANONICAL_FREQUENCY_NAMES, FREQUENCY_THEMES
-from creek.models import Frequency
+from creek.generate.indexes import (
+    CANONICAL_FREQUENCY_NAMES,
+    FREQUENCY_COLORS,
+    FREQUENCY_THEMES,
+)
+from creek.models import Color, Frequency
 
 if TYPE_CHECKING:
     from creek.config import LLMConfig
@@ -49,6 +53,54 @@ _FREQUENCY_BLOCK: str = _build_frequency_block()
 """Pre-rendered frequency-dimension lines baked into the prompt template."""
 
 
+def _build_color_block() -> str:
+    """Render the Spiral Dynamics color vocabulary for the prompt.
+
+    The wavelength's ``color`` field carries the Spiral Dynamics color
+    associated with the primary frequency (§7.2 of the ontology spec).
+    Listing the canonical values inline lets the LLM pick from the
+    documented vocabulary rather than guessing free-form strings like
+    ``"blueish"`` that the parser would silently drop to
+    ``unclassified`` — closing the issue #319 gap that left every
+    classified fragment with ``wavelength.color: unclassified``.
+
+    Returns:
+        A single comma-joined list of every non-unclassified
+        :class:`Color` value, suitable for embedding mid-sentence in
+        :data:`CLASSIFICATION_PROMPT`.
+    """
+    return ", ".join(
+        color.value for color in Color if color is not Color.UNCLASSIFIED
+    )
+
+
+_COLOR_BLOCK: str = _build_color_block()
+"""Pre-rendered Spiral Dynamics color vocabulary for the prompt."""
+
+
+def _build_frequency_color_block() -> str:
+    """Render the Frequency-to-Color mapping for the prompt.
+
+    Shows the model the canonical F1=beige / F2=purple / ... mapping
+    so its ``wavelength.color`` pick is anchored to its
+    ``frequency.primary`` pick instead of drifting independently. This
+    is the explicit linkage the ontology spec (§7.2, §6.1) calls out
+    but the original prompt left to the model's prior knowledge.
+
+    Returns:
+        A newline-joined list of ``- F<n>: <color>`` lines.
+    """
+    return "\n".join(
+        f"   - {freq.value}: {FREQUENCY_COLORS[freq]}"
+        for freq in Frequency
+        if freq is not Frequency.UNCLASSIFIED
+    )
+
+
+_FREQUENCY_COLOR_BLOCK: str = _build_frequency_color_block()
+"""Pre-rendered Frequency-to-Color mapping baked into the prompt template."""
+
+
 CLASSIFICATION_PROMPT: str = """\
 You are a classification assistant for the Creek knowledge organization system.
 
@@ -66,10 +118,19 @@ bottoming_out, restoration
 
 5. **Dosage**: medicine, toxic, ambiguous
 
-6. **Voice Register**: confessional, analytical, playful, prophetic, \
+6. **Wavelength Color** (Spiral Dynamics color of the primary frequency): \
+__COLOR_BLOCK__. The canonical mapping is:
+__FREQUENCY_COLOR_BLOCK__
+
+7. **Wavelength Descriptor**: a single short phrase from the Mode map that
+   best names this fragment's stance (e.g. ``"Gnosis"``, ``"Power-With"``,
+   ``"Social Anxiety"``, ``"Introspectivity"``). Leave as an empty string
+   only when no descriptor fits — never invent one.
+
+8. **Voice Register**: confessional, analytical, playful, prophetic, \
 instructional, raw, conversational
 
-7. **Confidence**: musing, exploring, forming, settled, conviction
+9. **Confidence**: musing, exploring, forming, settled, conviction
 
 A few labelled examples (do not include these in your YAML output):
 
@@ -79,12 +140,17 @@ Two-step protocol (FEAT-017):
 
 Step 1 — Reason briefly. Walk through which frequency this most resonates
 with and why, then which phase, then which mode, orientation, and dosage,
-and finally the voice register. Two to four short sentences total.
+which color and descriptor follow from those, and finally the voice
+register. Two to four short sentences total.
 
 Step 2 — Emit your classification as valid YAML inside a fenced
-```yaml ... ``` block. The YAML must follow this exact schema (do not
-include any other keys; ``confidence_scores`` reports how certain you
-are about each gated dimension, on a 0.0-1.0 scale):
+```yaml ... ``` block. **You MUST emit the full ``wavelength:`` block
+with all six sub-fields (phase, mode, orientation, dosage, color,
+descriptor) on every response — omitting any of them leaves the
+fragment with ``unclassified`` defaults and is treated as a
+regression (issue #319).** The YAML must follow this exact schema (do
+not include any other keys; ``confidence_scores`` reports how certain
+you are about each gated dimension, on a 0.0-1.0 scale):
 
 ```yaml
 frequency:
@@ -95,6 +161,8 @@ wavelength:
   mode: express
   orientation: do
   dosage: medicine
+  color: red
+  descriptor: Power-With
 voice:
   voice_register: analytical
   confidence: forming
@@ -105,14 +173,17 @@ confidence_scores:
 ```
 
 If a dimension is genuinely unclear, set ``unclassified`` rather than
-guessing. For Mode / Orientation / Dosage we will treat any
-``confidence_scores`` entry below {threshold:.2f} as ``unclassified``,
-so calibrate honestly.
+guessing (use an empty string ``""`` for descriptor when none fits).
+For Mode / Orientation / Dosage we will treat any ``confidence_scores``
+entry below {threshold:.2f} as ``unclassified``, so calibrate honestly.
 
 Fragment title: {title}
 Fragment content:
 {content}
-""".replace("__FREQUENCY_BLOCK__", _FREQUENCY_BLOCK)
+""".replace("__FREQUENCY_BLOCK__", _FREQUENCY_BLOCK).replace(
+    "__COLOR_BLOCK__",
+    _COLOR_BLOCK,
+).replace("__FREQUENCY_COLOR_BLOCK__", _FREQUENCY_COLOR_BLOCK)
 """Prompt template for two-step LLM-based fragment classification (FEAT-017).
 
 Placeholders:
@@ -123,6 +194,13 @@ Placeholders:
   rewarded rather than penalised.
 - ``{title}``, ``{content}``: the fragment being classified, after
   :func:`_sanitise_for_prompt` neutralises injection vectors.
+
+Issue #319: the ``wavelength`` schema example carries all six
+sub-fields (phase, mode, orientation, dosage, color, descriptor)
+because models follow the explicit YAML far more reliably than the
+bullet-point list above it. Drop a field from the schema and the
+classifier silently regresses to the pre-fix state where every
+fragment had ``wavelength.color: unclassified``.
 """
 
 

--- a/creek-tools/creek/classify/llm/prompts.py
+++ b/creek-tools/creek/classify/llm/prompts.py
@@ -69,9 +69,7 @@ def _build_color_block() -> str:
         :class:`Color` value, suitable for embedding mid-sentence in
         :data:`CLASSIFICATION_PROMPT`.
     """
-    return ", ".join(
-        color.value for color in Color if color is not Color.UNCLASSIFIED
-    )
+    return ", ".join(color.value for color in Color if color is not Color.UNCLASSIFIED)
 
 
 _COLOR_BLOCK: str = _build_color_block()
@@ -101,7 +99,8 @@ _FREQUENCY_COLOR_BLOCK: str = _build_frequency_color_block()
 """Pre-rendered Frequency-to-Color mapping baked into the prompt template."""
 
 
-CLASSIFICATION_PROMPT: str = """\
+CLASSIFICATION_PROMPT: str = (
+    """\
 You are a classification assistant for the Creek knowledge organization system.
 
 Given a fragment of content, classify it along the following dimensions:
@@ -180,10 +179,13 @@ entry below {threshold:.2f} as ``unclassified``, so calibrate honestly.
 Fragment title: {title}
 Fragment content:
 {content}
-""".replace("__FREQUENCY_BLOCK__", _FREQUENCY_BLOCK).replace(
-    "__COLOR_BLOCK__",
-    _COLOR_BLOCK,
-).replace("__FREQUENCY_COLOR_BLOCK__", _FREQUENCY_COLOR_BLOCK)
+""".replace("__FREQUENCY_BLOCK__", _FREQUENCY_BLOCK)
+    .replace(
+        "__COLOR_BLOCK__",
+        _COLOR_BLOCK,
+    )
+    .replace("__FREQUENCY_COLOR_BLOCK__", _FREQUENCY_COLOR_BLOCK)
+)
 """Prompt template for two-step LLM-based fragment classification (FEAT-017).
 
 Placeholders:

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -35,6 +35,7 @@ from creek.classify.rules import (
 from creek.classify.rules import RuleClassifier as RuleClassifierDirect
 from creek.config import ClassificationConfig, LLMConfig
 from creek.models import (
+    Color,
     Confidence,
     Dosage,
     Fragment,
@@ -519,6 +520,52 @@ class TestClassificationPrompt:
         assert FREQUENCY_THEMES[Frequency.F8] in CLASSIFICATION_PROMPT
         assert FREQUENCY_THEMES[Frequency.F10] in CLASSIFICATION_PROMPT
 
+    def test_prompt_lists_all_six_wavelength_dimensions(self) -> None:
+        """Issue #319: every Wavelength sub-field must be named in the prompt.
+
+        Before the fix, ``color`` and ``descriptor`` were absent from
+        both the dimensions list and the YAML schema example, so the
+        LLM had no reason to emit them and every fragment ended up with
+        ``wavelength.color: unclassified`` / ``wavelength.descriptor:
+        ''``. The ontology spec (§5.1) defines all six sub-fields, so
+        the prompt must request all six.
+        """
+        prompt_lower = CLASSIFICATION_PROMPT.lower()
+        assert "phase" in prompt_lower
+        assert "mode" in prompt_lower
+        assert "orientation" in prompt_lower
+        assert "dosage" in prompt_lower
+        assert "color" in prompt_lower
+        assert "descriptor" in prompt_lower
+
+    def test_prompt_yaml_example_includes_color_and_descriptor(self) -> None:
+        """Issue #319: the YAML schema example must show color + descriptor.
+
+        Anthropic and Ollama both follow the explicit YAML example far
+        more reliably than the bullet-point list above it. If the schema
+        block does not name ``color:`` and ``descriptor:`` the model
+        omits them, and the resulting fragment frontmatter is missing
+        the spiral-dynamics color / mode-map descriptor the ontology
+        depends on.
+        """
+        assert "color:" in CLASSIFICATION_PROMPT
+        assert "descriptor:" in CLASSIFICATION_PROMPT
+
+    def test_prompt_lists_all_spiral_dynamics_colors(self) -> None:
+        """Issue #319: every :class:`Color` value should be advertised.
+
+        Listing the enum values inline lets the LLM pick from the
+        documented vocabulary rather than guessing free-form strings
+        like ``"blueish"`` that the parser would silently drop to
+        ``unclassified``.
+        """
+        for color in Color:
+            if color is Color.UNCLASSIFIED:
+                continue
+            assert color.value in CLASSIFICATION_PROMPT, (
+                f"Color {color.value!r} missing from CLASSIFICATION_PROMPT"
+            )
+
 
 # ---- Validate Response ----
 
@@ -671,6 +718,99 @@ class TestApplyClassification:
         assert result.wavelength.mode == Mode.EXPRESS
         assert result.wavelength.orientation == Orientation.DO
         assert result.wavelength.dosage == Dosage.MEDICINE
+
+    def test_applies_wavelength_color_and_descriptor(self) -> None:
+        """Issue #319: ``color`` and ``descriptor`` round-trip from LLM YAML.
+
+        Before the fix, the parser only read four of the six
+        :class:`WavelengthClassification` fields, so a model that
+        correctly emitted ``color`` and ``descriptor`` saw both values
+        silently dropped on the floor.
+        """
+        config = LLMConfig()
+        classifier = LLMClassifier(config=config)
+        frag = _make_fragment()
+        data: dict[str, object] = {
+            "wavelength": {
+                "phase": "peaking",
+                "mode": "express",
+                "orientation": "do",
+                "dosage": "medicine",
+                "color": "red",
+                "descriptor": "Power-With",
+            },
+        }
+        result = classifier._apply_classification(frag, data)
+        assert result.wavelength.color == Color.RED
+        assert result.wavelength.descriptor == "Power-With"
+
+    def test_applies_wavelength_descriptor_strips_whitespace(self) -> None:
+        """Issue #319: descriptor is normalised, not stored raw.
+
+        Stripping leading/trailing whitespace prevents indexers and
+        downstream skill loaders from treating ``" Gnosis"`` and
+        ``"Gnosis"`` as two distinct descriptors.
+        """
+        config = LLMConfig()
+        classifier = LLMClassifier(config=config)
+        frag = _make_fragment()
+        data: dict[str, object] = {
+            "wavelength": {"descriptor": "  Gnosis  "},
+        }
+        result = classifier._apply_classification(frag, data)
+        assert result.wavelength.descriptor == "Gnosis"
+
+    def test_applies_wavelength_unknown_color_falls_back(self) -> None:
+        """Issue #319: a free-form color value defaults to ``unclassified``.
+
+        Defends against a model that emits ``"blueish"`` or ``"#ff0000"``
+        instead of one of the canonical Spiral Dynamics colors — the
+        fragment should fail honestly rather than carry a junk value.
+        """
+        config = LLMConfig()
+        classifier = LLMClassifier(config=config)
+        frag = _make_fragment()
+        data: dict[str, object] = {
+            "wavelength": {"color": "blueish-not-real"},
+        }
+        result = classifier._apply_classification(frag, data)
+        assert result.wavelength.color == Color.UNCLASSIFIED
+
+    def test_applies_wavelength_non_string_descriptor_falls_back(self) -> None:
+        """Issue #319: a non-string descriptor must not crash the parser.
+
+        Models occasionally emit ``descriptor: 42`` or ``descriptor:
+        null`` — we coerce to empty string so the fragment is still
+        writable rather than raising mid-batch.
+        """
+        config = LLMConfig()
+        classifier = LLMClassifier(config=config)
+        frag = _make_fragment()
+        data: dict[str, object] = {
+            "wavelength": {"descriptor": None},
+        }
+        result = classifier._apply_classification(frag, data)
+        assert result.wavelength.descriptor == ""
+
+    def test_applies_wavelength_descriptor_caps_runaway_length(self) -> None:
+        """Issue #319: an absurdly long descriptor is truncated, not dropped.
+
+        A pathological LLM response that emits a 50 KiB descriptor
+        would otherwise bloat the YAML frontmatter and disk footprint
+        of every fragment. Capping at a sensible ceiling keeps the
+        signal while bounding the damage.
+        """
+        from creek.classify.llm.parsing import _MAX_DESCRIPTOR_CHARS
+
+        config = LLMConfig()
+        classifier = LLMClassifier(config=config)
+        frag = _make_fragment()
+        runaway = "X" * (_MAX_DESCRIPTOR_CHARS * 5)
+        data: dict[str, object] = {
+            "wavelength": {"descriptor": runaway},
+        }
+        result = classifier._apply_classification(frag, data)
+        assert len(result.wavelength.descriptor) == _MAX_DESCRIPTOR_CHARS
 
     def test_applies_voice(self) -> None:
         """Voice fields should be applied to fragment."""

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -618,3 +618,85 @@ def test_preserved_llm_counts_only_prior_llm_runs(tmp_path: Path) -> None:
     assert summary.preserved_manual == 0
     assert summary.preserved_llm == 1
     assert summary.classified == 0
+
+
+# ---- Issue #319: wavelength round-trips end-to-end through --method llm ----
+
+
+_WAVELENGTH_FULL_YAML: str = """\
+frequency:
+  primary: F3
+  secondary: []
+wavelength:
+  phase: peaking
+  mode: express
+  orientation: do
+  dosage: medicine
+  color: red
+  descriptor: Power-With
+voice:
+  voice_register: prophetic
+  confidence: settled
+confidence_scores:
+  mode: 0.9
+  orientation: 0.9
+  dosage: 0.9
+"""
+"""Reference LLM response covering every Wavelength sub-field.
+
+Lives next to its consumer so a regression in the prompt/parser
+contract is visible alongside the round-trip assertion that catches
+it, rather than buried in a fixtures directory.
+"""
+
+
+def test_run_classify_llm_persists_all_wavelength_fields(tmp_path: Path) -> None:
+    """Issue #319: wavelength.color and wavelength.descriptor reach disk.
+
+    Reproduces the user-visible bug end-to-end with a mocked LLM
+    response: a fragment classified via ``--method llm`` must persist
+    ``color`` and ``descriptor`` to its frontmatter, not just the
+    historical four-field subset (phase / mode / orientation / dosage).
+    Asserts on the on-disk YAML — not the in-memory ``Fragment`` —
+    because that is what the user inspects after the run.
+    """
+    from creek.classify.llm import LLMClassifier
+
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-wavefull001",
+        title="exuberant declaration",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=fragment,
+        body="ordinary content with no rule-classifier signal keywords",
+    )
+
+    config = CreekConfig()
+    config.classification.confidence_threshold = 1.0  # force LLM path
+
+    with (
+        patch.object(LLMClassifier, "_check_availability", return_value=True),
+        patch.object(LLMClassifier, "_invoke_llm", return_value=_WAVELENGTH_FULL_YAML),
+    ):
+        summary = run_classify(
+            vault_path=vault,
+            config=config,
+            method="llm",
+            force=False,
+        )
+
+    assert summary.classified == 1
+    reloaded = frontmatter.load(
+        str(vault / "01-Fragments" / "Notes" / "frag-wavefull001.md"),
+    )
+    wavelength = reloaded["wavelength"]
+    assert isinstance(wavelength, dict)
+    assert wavelength["phase"] == "peaking"
+    assert wavelength["mode"] == "express"
+    assert wavelength["orientation"] == "do"
+    assert wavelength["dosage"] == "medicine"
+    assert wavelength["color"] == "red"
+    assert wavelength["descriptor"] == "Power-With"


### PR DESCRIPTION
## Summary

Closes #319.

`creek classify --method llm` was leaving every fragment with `wavelength.color: unclassified` and `wavelength.descriptor: ''`, even when the rest of the wavelength block (phase / mode / orientation / dosage) classified cleanly. Root cause was a two-sided gap: the LLM prompt never advertised `color` or `descriptor` as required fields, and the response parser would have dropped them on the floor even if the model had emitted them.

Three coordinated changes:

1. **`prompts.py`** — render the canonical Spiral Dynamics color vocabulary (`Color` enum minus `unclassified`) and the `Frequency → Color` mapping inline, add `color` + `descriptor` to the numbered dimensions list, include them in the YAML schema example, and add an explicit "you MUST emit all six wavelength sub-fields" instruction. Models follow the YAML example far more reliably than the prose list, so the schema-block change is what actually moves the needle.
2. **`parsing.py`** — add `_parse_descriptor` (whitespace strip, non-string fallback, length cap at `_MAX_DESCRIPTOR_CHARS = 128` to bound pathological responses).
3. **`calibration.py`** — extend `_apply_wavelength` to extract `color` (via `_parse_enum` against `Color`, defaulting to `UNCLASSIFIED` on unknown vocabulary) and `descriptor`. Neither field is gated by the FEAT-017 confidence bias — color tracks the primary frequency (a stable signal) and descriptor is free-form.

## Test plan

- [x] New unit tests cover parser fallbacks (unknown color → unclassified, non-string descriptor → "", whitespace strip, length cap).
- [x] New prompt-contract tests assert all six wavelength sub-fields are named, the YAML example includes `color:` and `descriptor:`, and every `Color` value is advertised.
- [x] New end-to-end test (`test_run_classify_llm_persists_all_wavelength_fields`) runs `run_classify` with a mocked LLM response and asserts every wavelength sub-field reaches the on-disk frontmatter (the exact thing the user inspects).
- [x] `./scripts/check-all.sh` passes locally (12/12 quality gates green, 4061 tests passing, 93.70% coverage).

https://claude.ai/code/session_011e4q4ZQcwtP9zVEp21T6ki

---
_Generated by [Claude Code](https://claude.ai/code/session_011e4q4ZQcwtP9zVEp21T6ki)_