### PR TITLE
fix(purge): actually remove embedding rows on purge, audit honestly (GAP-001)

### DIFF
--- a/creek-tools/creek/link/embeddings.py
+++ b/creek-tools/creek/link/embeddings.py
@@ -28,7 +28,7 @@ from creek.models import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Iterable, Mapping
     from pathlib import Path
 
     from sentence_transformers import SentenceTransformer as SentenceTransformerType
@@ -139,6 +139,99 @@ def embeddings_cache_path(vault_path: Path) -> Path:
         ``<vault>/00-Creek-Meta/embeddings.parquet``.
     """
     return vault_path / EMBEDDINGS_CACHE_DIR / EMBEDDINGS_CACHE_FILENAME
+
+
+def purge_fragment_ids_from_cache(
+    cache_path: Path,
+    fragment_ids: Iterable[str],
+    *,
+    dry_run: bool = False,
+) -> int:
+    """Remove rows whose ``fragment_id`` matches *fragment_ids* (GAP-001).
+
+    The purge engine deletes fragments from disk but, before this hook,
+    left their cached embedding vectors in
+    ``<vault>/00-Creek-Meta/embeddings.parquet``. That broke the
+    right-to-be-forgotten contract for intimate-tier content because
+    sentence-transformer embeddings are partially invertible. This helper
+    is the per-row scrubber the engine now calls.
+
+    A missing cache file is treated as zero rows removed (cache simply
+    has not been built yet) rather than an error, so the purge engine
+    can call this unconditionally without first probing the filesystem.
+
+    Args:
+        cache_path: Embeddings parquet path (typically the result of
+            :func:`embeddings_cache_path`).
+        fragment_ids: IDs whose rows should be dropped.
+        dry_run: When ``True``, count matches without rewriting the file.
+
+    Returns:
+        Number of rows actually removed (or that would be removed in a
+        dry run). Zero when the file is missing, the id set is empty,
+        or no rows match.
+    """
+    ids_set = set(fragment_ids)
+    if not ids_set or not cache_path.exists():
+        return 0
+
+    import pyarrow as pa  # lazy: pyarrow lives in the [embeddings] extra
+    import pyarrow.parquet as pq
+
+    table = pq.read_table(cache_path)
+    ids_in_cache = table["fragment_id"].to_pylist()
+    keep_mask = [fid not in ids_set for fid in ids_in_cache]
+    removed = len(ids_in_cache) - sum(keep_mask)
+    if removed == 0:
+        return 0
+
+    if not dry_run:
+        keep_array = pa.array(keep_mask, type=pa.bool_())
+        pq.write_table(
+            table.filter(keep_array),
+            cache_path,
+            compression="snappy",
+        )
+        logger.info(
+            "Purged %d row(s) from embeddings cache %s",
+            removed,
+            cache_path,
+        )
+    return removed
+
+
+def delete_embeddings_cache(cache_path: Path, *, dry_run: bool = False) -> int:
+    """Delete the entire embeddings cache file (GAP-001 vault path).
+
+    ``creek purge vault`` wipes every fragment, so a row-by-row scrub is
+    pointless overhead. Deleting the parquet file outright also matches
+    the threat model's expectation that nothing of intimate-tier content
+    survives a full-vault purge — including the embedding vectors,
+    which are partially invertible.
+
+    Args:
+        cache_path: Embeddings parquet path.
+        dry_run: When ``True``, count rows but leave the file alone.
+
+    Returns:
+        Number of rows that were in the file when it was deleted
+        (or that would be deleted in a dry run). Zero when the file
+        does not exist.
+    """
+    if not cache_path.exists():
+        return 0
+
+    import pyarrow.parquet as pq  # lazy: pyarrow lives in the [embeddings] extra
+
+    row_count = int(pq.read_metadata(cache_path).num_rows)
+    if not dry_run:
+        cache_path.unlink()
+        logger.info(
+            "Deleted embeddings cache %s (%d row(s) removed)",
+            cache_path,
+            row_count,
+        )
+    return row_count
 
 
 def _load_sentence_transformer(

--- a/creek-tools/creek/purge/audit.py
+++ b/creek-tools/creek/purge/audit.py
@@ -59,8 +59,10 @@ class PurgeAuditEntry(BaseModel):
         affected_fragments: Fragment IDs touched by the operation.
         fragments_deleted: Number of fragment files removed from disk.
         references_scrubbed: Number of wiki-link references removed.
-        embeddings_removed: Number of fragments whose embeddings should
-            be considered invalidated by the purge.
+        embeddings_removed: Real number of rows dropped from
+            ``<vault>/00-Creek-Meta/embeddings.parquet`` by the purge
+            (GAP-001). Zero when the cache had not been built yet or
+            when no rows matched; the actual row delta otherwise.
         operator: Who performed the purge.
         dry_run: Whether the purge was a dry-run preview.
         target: Legacy field preserved for backward compatibility on

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -99,6 +99,10 @@ class PurgeResult(BaseModel):
         threads_updated: Thread files whose metadata changed.
         eddies_updated: Eddy files whose metadata changed.
         classifications_reset: Fragments whose classifications were wiped.
+        embeddings_removed: Real count of embedding cache rows that were
+            removed (or would be removed in a dry run). Zero for
+            metadata-only operations and for runs where the cache had
+            no matching rows (GAP-001).
     """
 
     operation: str
@@ -112,6 +116,7 @@ class PurgeResult(BaseModel):
     threads_updated: int = 0
     eddies_updated: int = 0
     classifications_reset: int = 0
+    embeddings_removed: int = 0
 
 
 class PurgeEngine:
@@ -186,6 +191,9 @@ class PurgeEngine:
         if not self.dry_run:
             frag_file.unlink()
 
+        result.embeddings_removed = self._purge_cache_for(
+            result.affected_fragment_ids,
+        )
         self._write_audit(result)
         return result
 
@@ -210,6 +218,9 @@ class PurgeEngine:
         matches = self._fragments_from_source(source_type)
         for frag_file, post in matches:
             self._purge_single(frag_file, post, result)
+        result.embeddings_removed = self._purge_cache_for(
+            result.affected_fragment_ids,
+        )
         self._write_audit(result)
         return result
 
@@ -258,6 +269,9 @@ class PurgeEngine:
         matches = self._fragments_from_source_path(source_path, match=match)
         for frag_file, post in matches:
             self._purge_single(frag_file, post, result)
+        result.embeddings_removed = self._purge_cache_for(
+            result.affected_fragment_ids,
+        )
         self._write_audit(result)
         return result
 
@@ -352,6 +366,9 @@ class PurgeEngine:
             if created is None or not (start <= created <= end):
                 continue
             self._purge_single(frag_file, post, result)
+        result.embeddings_removed = self._purge_cache_for(
+            result.affected_fragment_ids,
+        )
         self._write_audit(result)
         return result
 
@@ -393,10 +410,55 @@ class PurgeEngine:
                 continue
             self._wipe_folder_contents(folder_path, result)
         result.fragments_affected = len(result.deleted_files)
+        result.embeddings_removed = self._delete_cache_file()
         self._write_audit(result)
         return result
 
     # -- Private helpers -------------------------------------------------
+
+    def _purge_cache_for(self, fragment_ids: list[str]) -> int:
+        """Drop matching rows from the embeddings cache (GAP-001).
+
+        Called by every file-deleting purge operation *after* the
+        fragments have been removed from disk so the audit entry's
+        ``embeddings_removed`` reflects what is now provably gone from
+        the parquet cache (or what *would* be gone in a dry run).
+
+        Args:
+            fragment_ids: Fragment IDs whose cached embedding rows
+                should be scrubbed.
+
+        Returns:
+            Number of cache rows removed (or counted-only in dry-run).
+        """
+        from creek.link.embeddings import (
+            embeddings_cache_path,
+            purge_fragment_ids_from_cache,
+        )
+
+        return purge_fragment_ids_from_cache(
+            embeddings_cache_path(self.vault_path),
+            fragment_ids,
+            dry_run=self.dry_run,
+        )
+
+    def _delete_cache_file(self) -> int:
+        """Delete the embeddings cache outright (GAP-001 vault path).
+
+        Returns:
+            Number of rows that were in the cache when it was removed
+            (or that would be removed in a dry run). Zero when the
+            cache file did not exist.
+        """
+        from creek.link.embeddings import (
+            delete_embeddings_cache,
+            embeddings_cache_path,
+        )
+
+        return delete_embeddings_cache(
+            embeddings_cache_path(self.vault_path),
+            dry_run=self.dry_run,
+        )
 
     def _purge_single(
         self,
@@ -658,10 +720,11 @@ class PurgeEngine:
         ``fragments_deleted`` counts only operations that remove files
         from disk (see :data:`_FILE_DELETING_OPERATIONS`);
         ``classifications`` resets metadata in place and therefore
-        reports zero deletions. ``embeddings_removed`` mirrors
-        ``fragments_deleted`` because every deleted fragment's cached
-        embedding is invalidated at the next ``creek link`` run; the
-        engine does not maintain the embedding cache directly.
+        reports zero deletions. ``embeddings_removed`` is the *real*
+        number of rows the engine just dropped from
+        ``<vault>/00-Creek-Meta/embeddings.parquet`` (GAP-001) — zero
+        when the cache had not been built yet, zero for metadata-only
+        operations, and the actual row delta otherwise.
 
         Args:
             result: The result whose metadata should be logged.
@@ -690,7 +753,7 @@ class PurgeEngine:
             affected_fragments=result.affected_fragment_ids.copy(),
             fragments_deleted=fragments_deleted,
             references_scrubbed=result.wikilinks_removed,
-            embeddings_removed=fragments_deleted,
+            embeddings_removed=result.embeddings_removed,
             dry_run=result.dry_run,
         )
         self.audit_log.append(entry)

--- a/creek-tools/docs/cleaning-and-purge.md
+++ b/creek-tools/docs/cleaning-and-purge.md
@@ -195,6 +195,17 @@ Every purge appends one JSONL line to `<vault>/00-Creek-Meta/audit/purge.jsonl`.
 }
 ```
 
+`embeddings_removed` is the real number of rows dropped from
+`<vault>/00-Creek-Meta/embeddings.parquet` in that call (GAP-001):
+
+- Zero when the embeddings cache has not been built yet (no `creek
+  link` run has materialised the parquet).
+- The exact row delta when the cache exists — *not* mirrored from
+  `fragments_deleted`. Purging a fragment that was never embedded
+  reports `embeddings_removed: 0` even though `fragments_deleted: 1`.
+- For `creek purge vault`, this counts every row that was in the
+  cache file the engine just deleted outright.
+
 `creek redact --apply` writes alongside it at `<vault>/00-Creek-Meta/audit/redact.jsonl`. Privacy-tier overrides (e.g. `creek mine --include-tier intimate`) write to `<vault>/00-Creek-Meta/audit/privacy.jsonl`. Operational provenance from ingestion stays at `<vault>/00-Creek-Meta/Processing-Log/provenance.jsonl` (separate location: not compliance-grade, allowed to be lossy).
 
 A pre-Batch-C `Processing-Log/purge-log.json` from older installs is migrated automatically on first read or write — every legacy entry is replayed into the new chain, a `purge.audit.migration` marker is recorded, and the old file is removed.

--- a/creek-tools/docs/security/threat-model.md
+++ b/creek-tools/docs/security/threat-model.md
@@ -120,9 +120,15 @@ from most to least likely:
 - **Use `creek purge` for right-to-be-forgotten requests.**
   Per-fragment, per-source, per-date-range, or full-vault — see
   [cleaning-and-purge](../cleaning-and-purge.md).
-- **Wipe the embedding cache** when you wipe vault content. It is
-  *not* automatically purged when you `creek purge vault`. Delete the
-  configured cache directory manually.
+- **Embedding cache hygiene is built into `creek purge`.** Per-fragment,
+  per-source, and per-date-range purges drop the matching rows from
+  `<vault>/00-Creek-Meta/embeddings.parquet`; `creek purge vault`
+  deletes the parquet file outright. The audit log's
+  `embeddings_removed` field carries the real row delta — zero when
+  the cache had not been built yet, otherwise the exact count
+  (GAP-001). If you maintain a *secondary* embedding cache outside
+  the vault (e.g. a notebook or experiment store), you still need to
+  wipe that one yourself.
 - **Rotate the OAuth token after exposure.** Run
   `creek gdrive --revoke` immediately if `token.json` was ever
   copied off the host. See [configuration → google_drive →

--- a/creek-tools/tests/test_embeddings.py
+++ b/creek-tools/tests/test_embeddings.py
@@ -351,6 +351,146 @@ class TestEmbeddingsCachePath:
         )
 
 
+class TestPurgeFragmentIdsFromCache:
+    """Tests for ``purge_fragment_ids_from_cache`` (GAP-001)."""
+
+    def _seed_cache(self, tmp_path: Path, ids: list[str]) -> Path:
+        """Write a parquet cache with one row per supplied fragment id."""
+        linker = EmbeddingLinker(config=EmbeddingsConfig())
+        cache_path = tmp_path / "embeddings.parquet"
+        linker.save_cache(
+            {fid: _entry(fid, vector=[0.1, 0.2]) for fid in ids},
+            cache_path,
+        )
+        return cache_path
+
+    def test_returns_zero_when_cache_missing(self, tmp_path: Path) -> None:
+        """A missing cache file is treated as zero rows removed, not an error."""
+        from creek.link.embeddings import purge_fragment_ids_from_cache
+
+        removed = purge_fragment_ids_from_cache(
+            tmp_path / "nonexistent.parquet",
+            ["frag-A"],
+        )
+        assert removed == 0
+
+    def test_returns_zero_for_empty_id_set(self, tmp_path: Path) -> None:
+        """An empty id collection is a no-op even when the cache exists."""
+        from creek.link.embeddings import purge_fragment_ids_from_cache
+
+        cache_path = self._seed_cache(tmp_path, ["frag-A", "frag-B"])
+        removed = purge_fragment_ids_from_cache(cache_path, [])
+        assert removed == 0
+        # Cache untouched.
+        linker = EmbeddingLinker(config=EmbeddingsConfig())
+        assert set(linker.load_cache(cache_path).keys()) == {"frag-A", "frag-B"}
+
+    def test_removes_matching_rows_only(self, tmp_path: Path) -> None:
+        """Only rows whose fragment_id appears in the purge set are removed."""
+        from creek.link.embeddings import purge_fragment_ids_from_cache
+
+        cache_path = self._seed_cache(
+            tmp_path,
+            ["frag-A", "frag-B", "frag-C"],
+        )
+
+        removed = purge_fragment_ids_from_cache(cache_path, ["frag-A", "frag-C"])
+
+        assert removed == 2
+        linker = EmbeddingLinker(config=EmbeddingsConfig())
+        survivors = linker.load_cache(cache_path)
+        assert set(survivors.keys()) == {"frag-B"}
+
+    def test_returns_zero_when_no_ids_match(self, tmp_path: Path) -> None:
+        """Purging IDs that aren't in the cache reports zero removals."""
+        from creek.link.embeddings import purge_fragment_ids_from_cache
+
+        cache_path = self._seed_cache(tmp_path, ["frag-A"])
+
+        removed = purge_fragment_ids_from_cache(cache_path, ["frag-missing"])
+
+        assert removed == 0
+        linker = EmbeddingLinker(config=EmbeddingsConfig())
+        assert set(linker.load_cache(cache_path).keys()) == {"frag-A"}
+
+    def test_purging_every_row_keeps_file(self, tmp_path: Path) -> None:
+        """Removing every row leaves an empty parquet on disk, not a missing file."""
+        from creek.link.embeddings import purge_fragment_ids_from_cache
+
+        cache_path = self._seed_cache(tmp_path, ["frag-A", "frag-B"])
+
+        removed = purge_fragment_ids_from_cache(cache_path, ["frag-A", "frag-B"])
+
+        assert removed == 2
+        assert cache_path.exists()
+        linker = EmbeddingLinker(config=EmbeddingsConfig())
+        assert linker.load_cache(cache_path) == {}
+
+    def test_dry_run_counts_without_writing(self, tmp_path: Path) -> None:
+        """``dry_run=True`` reports the would-be count without rewriting the file."""
+        from creek.link.embeddings import purge_fragment_ids_from_cache
+
+        cache_path = self._seed_cache(tmp_path, ["frag-A", "frag-B"])
+        before_bytes = cache_path.read_bytes()
+
+        removed = purge_fragment_ids_from_cache(
+            cache_path,
+            ["frag-A"],
+            dry_run=True,
+        )
+
+        assert removed == 1
+        assert cache_path.read_bytes() == before_bytes
+
+
+class TestDeleteEmbeddingsCache:
+    """Tests for ``delete_embeddings_cache`` (GAP-001 vault path)."""
+
+    def test_unlinks_existing_cache_and_returns_row_count(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The whole file is removed; the return value is the prior row count."""
+        from creek.link.embeddings import delete_embeddings_cache
+
+        linker = EmbeddingLinker(config=EmbeddingsConfig())
+        cache_path = tmp_path / "embeddings.parquet"
+        linker.save_cache(
+            {
+                "frag-A": _entry("frag-A", vector=[0.1]),
+                "frag-B": _entry("frag-B", vector=[0.2]),
+            },
+            cache_path,
+        )
+
+        removed = delete_embeddings_cache(cache_path)
+
+        assert removed == 2
+        assert not cache_path.exists()
+
+    def test_returns_zero_when_cache_missing(self, tmp_path: Path) -> None:
+        """A missing cache is a no-op, not an error."""
+        from creek.link.embeddings import delete_embeddings_cache
+
+        assert delete_embeddings_cache(tmp_path / "nope.parquet") == 0
+
+    def test_dry_run_preserves_cache_file(self, tmp_path: Path) -> None:
+        """``dry_run=True`` still reports the row count but keeps the file."""
+        from creek.link.embeddings import delete_embeddings_cache
+
+        linker = EmbeddingLinker(config=EmbeddingsConfig())
+        cache_path = tmp_path / "embeddings.parquet"
+        linker.save_cache(
+            {"frag-A": _entry("frag-A", vector=[0.1])},
+            cache_path,
+        )
+
+        removed = delete_embeddings_cache(cache_path, dry_run=True)
+
+        assert removed == 1
+        assert cache_path.exists()
+
+
 # ---- Find Resonances ----
 
 

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -305,7 +305,12 @@ def test_fragment_purge_dry_run_preserves_everything(tmp_path: Path) -> None:
 
 
 def test_fragment_purge_writes_audit(tmp_path: Path) -> None:
-    """A purge_fragment call appends exactly one audit entry."""
+    """A purge_fragment call appends exactly one audit entry.
+
+    ``embeddings_removed`` is *zero* here because no embeddings cache
+    was built (GAP-001). The honest-count contract is verified
+    end-to-end by the GAP-001 tests further down in this file.
+    """
     vault = _make_vault(tmp_path)
     _write_fragment(vault, "frag-A", "Alpha")
     engine = PurgeEngine(vault)
@@ -319,7 +324,7 @@ def test_fragment_purge_writes_audit(tmp_path: Path) -> None:
     assert entry.criteria == {"fragment_id": "frag-A"}
     assert entry.affected_fragments == ["frag-A"]
     assert entry.fragments_deleted == 1
-    assert entry.embeddings_removed == 1
+    assert entry.embeddings_removed == 0
     assert entry.operator == "human via CLI"
     assert entry.dry_run is False
 
@@ -1545,3 +1550,221 @@ def test_write_audit_rejects_unknown_operation(tmp_path: Path) -> None:
                 dry_run=False,
             ),
         )
+
+
+# ---------------------------------------------------------------------------
+# GAP-001 — purge actually removes embedding cache rows
+# ---------------------------------------------------------------------------
+
+
+def _seed_embeddings_cache(vault: Path, fragment_ids: list[str]) -> Path:
+    """Write a parquet cache with one row per supplied fragment ID.
+
+    Uses :meth:`EmbeddingLinker.save_cache` so the layout matches the
+    real one bit-for-bit; tests then assert on row presence via
+    :meth:`EmbeddingLinker.load_cache`.
+    """
+    from datetime import UTC, datetime
+
+    from creek.config import EmbeddingsConfig
+    from creek.link.embeddings import (
+        CachedEmbedding,
+        EmbeddingLinker,
+        embeddings_cache_path,
+    )
+
+    linker = EmbeddingLinker(config=EmbeddingsConfig())
+    cache_path = embeddings_cache_path(vault)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    entries = {
+        fid: CachedEmbedding(
+            fragment_id=fid,
+            content_hash="hash-" + fid,
+            model_name=linker.config.model,
+            vector=[0.1, 0.2, 0.3],
+            computed_at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        for fid in fragment_ids
+    }
+    linker.save_cache(entries, cache_path)
+    return cache_path
+
+
+def _load_cache_ids(vault: Path) -> set[str]:
+    """Return the set of fragment IDs currently in the embeddings cache."""
+    from creek.config import EmbeddingsConfig
+    from creek.link.embeddings import EmbeddingLinker, embeddings_cache_path
+
+    linker = EmbeddingLinker(config=EmbeddingsConfig())
+    return set(linker.load_cache(embeddings_cache_path(vault)).keys())
+
+
+def test_fragment_purge_removes_embedding_row(tmp_path: Path) -> None:
+    """``creek purge fragment <id>`` drops that fragment's row from the cache."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    _write_fragment(vault, "frag-B", "Bravo")
+    _seed_embeddings_cache(vault, ["frag-A", "frag-B"])
+
+    result = PurgeEngine(vault).purge_fragment("frag-A")
+
+    assert result.embeddings_removed == 1
+    assert _load_cache_ids(vault) == {"frag-B"}
+
+
+def test_source_purge_removes_embedding_rows_for_each_fragment(
+    tmp_path: Path,
+) -> None:
+    """Every fragment from the purged source is scrubbed from the cache."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha", platform="claude")
+    _write_fragment(vault, "frag-B", "Bravo", platform="claude")
+    _write_fragment(
+        vault,
+        "frag-C",
+        "Charlie",
+        platform="discord",
+        subfolder="Messages",
+    )
+    _seed_embeddings_cache(vault, ["frag-A", "frag-B", "frag-C"])
+
+    result = PurgeEngine(vault).purge_source("claude")
+
+    assert result.embeddings_removed == 2
+    assert _load_cache_ids(vault) == {"frag-C"}
+
+
+def test_daterange_purge_removes_embedding_rows_in_range(tmp_path: Path) -> None:
+    """Fragments inside the purged window lose their cache row; others stay."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(
+        vault,
+        "frag-old",
+        "Old",
+        created=datetime(2024, 1, 1, tzinfo=UTC),
+    )
+    _write_fragment(
+        vault,
+        "frag-mid",
+        "Mid",
+        created=datetime(2024, 6, 1, tzinfo=UTC),
+    )
+    _write_fragment(
+        vault,
+        "frag-new",
+        "New",
+        created=datetime(2025, 1, 1, tzinfo=UTC),
+    )
+    _seed_embeddings_cache(vault, ["frag-old", "frag-mid", "frag-new"])
+
+    result = PurgeEngine(vault).purge_daterange(
+        date(2024, 5, 1),
+        date(2024, 12, 31),
+    )
+
+    assert result.embeddings_removed == 1
+    assert _load_cache_ids(vault) == {"frag-old", "frag-new"}
+
+
+def test_vault_purge_deletes_embedding_cache_file(tmp_path: Path) -> None:
+    """``creek purge vault`` removes the parquet cache outright (criterion 4)."""
+    from creek.link.embeddings import embeddings_cache_path
+
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    cache_path = _seed_embeddings_cache(vault, ["frag-A"])
+
+    result = PurgeEngine(vault).purge_vault(VAULT_PURGE_CONFIRMATION)
+
+    assert result.embeddings_removed == 1
+    assert not cache_path.exists()
+    assert not embeddings_cache_path(vault).exists()
+
+
+def test_fragment_purge_embeddings_removed_zero_when_cache_missing(
+    tmp_path: Path,
+) -> None:
+    """Audit reports zero when the cache file has never been built (criterion 5)."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+
+    engine = PurgeEngine(vault)
+    result = engine.purge_fragment("frag-A")
+
+    assert result.embeddings_removed == 0
+    entries = engine.audit_log.read()
+    assert entries[-1].embeddings_removed == 0
+
+
+def test_fragment_purge_audit_reflects_real_cache_removal(tmp_path: Path) -> None:
+    """The audit entry's ``embeddings_removed`` equals the real row delta."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    _seed_embeddings_cache(vault, ["frag-A"])
+
+    engine = PurgeEngine(vault)
+    engine.purge_fragment("frag-A")
+
+    entries = engine.audit_log.read()
+    last = entries[-1]
+    assert last.embeddings_removed == 1
+    assert last.fragments_deleted == 1
+
+
+def test_fragment_purge_audit_zero_when_id_not_in_cache(tmp_path: Path) -> None:
+    """If the deleted fragment was never embedded, the audit is honest about it."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    # Cache contains other fragments but not frag-A.
+    _seed_embeddings_cache(vault, ["frag-B", "frag-C"])
+
+    engine = PurgeEngine(vault)
+    engine.purge_fragment("frag-A")
+
+    entries = engine.audit_log.read()
+    assert entries[-1].embeddings_removed == 0
+    # Untouched rows survive.
+    assert _load_cache_ids(vault) == {"frag-B", "frag-C"}
+
+
+def test_fragment_purge_dry_run_preserves_cache(tmp_path: Path) -> None:
+    """Dry-run reports the would-remove count without rewriting the cache."""
+    from creek.link.embeddings import embeddings_cache_path
+
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    cache_path = _seed_embeddings_cache(vault, ["frag-A"])
+    before_bytes = cache_path.read_bytes()
+
+    result = PurgeEngine(vault, dry_run=True).purge_fragment("frag-A")
+
+    assert result.embeddings_removed == 1
+    assert embeddings_cache_path(vault).read_bytes() == before_bytes
+
+
+def test_vault_purge_dry_run_preserves_cache_file(tmp_path: Path) -> None:
+    """Dry-run vault purge counts cache rows but keeps the parquet on disk."""
+    from creek.link.embeddings import embeddings_cache_path
+
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    _seed_embeddings_cache(vault, ["frag-A", "frag-B"])
+
+    result = PurgeEngine(vault, dry_run=True).purge_vault(
+        VAULT_PURGE_CONFIRMATION,
+    )
+
+    assert result.embeddings_removed == 2
+    assert embeddings_cache_path(vault).exists()
+
+
+def test_classifications_purge_does_not_touch_cache(tmp_path: Path) -> None:
+    """Classifications reset is metadata-only; embeddings stay valid (still 0)."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    _seed_embeddings_cache(vault, ["frag-A"])
+
+    result = PurgeEngine(vault).purge_classifications()
+
+    assert result.embeddings_removed == 0
+    assert _load_cache_ids(vault) == {"frag-A"}

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -1634,6 +1634,45 @@ def test_source_purge_removes_embedding_rows_for_each_fragment(
     assert _load_cache_ids(vault) == {"frag-C"}
 
 
+def test_source_path_purge_removes_embedding_rows(tmp_path: Path) -> None:
+    """``purge_source_path`` scrubs cache rows for matched fragments (GAP-001).
+
+    Closes the only file-deleting purge operation lacking an end-to-end
+    GAP-001 smoke test. Uses ``--match substring`` so a single call
+    catches more than one fragment, proving the shared
+    ``_purge_cache_for`` helper is reached from this entry point too.
+    """
+    vault = _make_vault(tmp_path)
+    _write_fragment_with_original(
+        vault,
+        "frag-A",
+        "Alpha",
+        original_file="/exports/2026-04-28.json",
+    )
+    _write_fragment_with_original(
+        vault,
+        "frag-B",
+        "Bravo",
+        original_file="/exports/2026-04-29.json",
+    )
+    _write_fragment_with_original(
+        vault,
+        "frag-C",
+        "Charlie",
+        original_file="/notes/diary.md",
+    )
+    _seed_embeddings_cache(vault, ["frag-A", "frag-B", "frag-C"])
+
+    engine = PurgeEngine(vault)
+    result = engine.purge_source_path("/exports/", match="substring")
+
+    assert result.embeddings_removed == 2
+    assert _load_cache_ids(vault) == {"frag-C"}
+    entries = engine.audit_log.read()
+    assert entries[-1].operation == "source-path"
+    assert entries[-1].embeddings_removed == 2
+
+
 def test_daterange_purge_removes_embedding_rows_in_range(tmp_path: Path) -> None:
     """Fragments inside the purged window lose their cache row; others stay."""
     vault = _make_vault(tmp_path)


### PR DESCRIPTION
The purge engine's audit log advertised `embeddings_removed` but the
field was a fabrication — it mirrored `fragments_deleted` while the
embeddings parquet cache was never touched. Right-to-be-forgotten on
intimate-tier content silently left the partially-invertible vectors
on disk, contradicting both the README's RTBF guarantee and the audit
log's role as the compliance record.

- Add `purge_fragment_ids_from_cache` and `delete_embeddings_cache`
  helpers in `creek.link.embeddings` to scrub the parquet by ID and
  to remove the file outright for vault-level purge.
- Wire those helpers into every file-deleting purge operation
  (`fragment`, `source`, `source-path`, `daterange`, `vault`),
  respecting dry-run.
- Promote `embeddings_removed` to a real `PurgeResult` field so the
  audit entry reports the actual row delta — zero when the cache
  had not been built yet, the exact count otherwise.
- Update the threat model and `cleaning-and-purge` docs so the
  contract matches the implementation.

Co-authored-by: geoff@creekmasons.com