### PR TITLE
fix(purge): emit pre-destruction intent + post-destruction outcome audit pair (GAP-002, GAP-010)

### DIFF
--- a/creek-tools/creek/purge/audit.py
+++ b/creek-tools/creek/purge/audit.py
@@ -6,6 +6,15 @@ entry captures the timestamp, operation, criteria dict, affected
 fragment IDs, deletion counts, references scrubbed, embeddings removed,
 operator, and dry-run flag.
 
+Phase pairing (GAP-002): every purge operation emits **two** entries —
+an ``intent`` line written *before* the first destructive op, then an
+``outcome`` line written *after* the destructive section completes
+(``status="complete"``) or after an exception aborts it
+(``status="partial"``). Both entries share a UUID4 ``operation_id`` so
+a recovery tool can pair them. Pre-GAP-002 entries have no ``phase``
+field; they read back as ``phase="outcome"`` with an empty
+``operation_id`` and ``status=None``.
+
 Timezone (BUG-002): purge-audit entries deliberately stamp ``UTC``
 rather than ``America/Los_Angeles`` (the rest of the pipeline). The
 audit chain is forensic infrastructure — its consumers are operators
@@ -30,7 +39,7 @@ import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -45,6 +54,12 @@ LEGACY_PURGE_LOG_RELPATH = Path("00-Creek-Meta/Processing-Log/purge-log.json")
 
 PURGE_AUDIT_RELPATH = Path("00-Creek-Meta/audit/purge.jsonl")
 """Canonical Batch-C purge audit log location."""
+
+PurgePhase = Literal["intent", "outcome"]
+"""GAP-002 phase discriminator on each purge audit entry."""
+
+PurgeOutcomeStatus = Literal["complete", "partial"]
+"""``outcome`` entries set this to record whether the body ran to completion."""
 
 
 class PurgeAuditEntry(BaseModel):
@@ -65,6 +80,17 @@ class PurgeAuditEntry(BaseModel):
             when no rows matched; the actual row delta otherwise.
         operator: Who performed the purge.
         dry_run: Whether the purge was a dry-run preview.
+        phase: GAP-002 discriminator. ``"intent"`` is written before
+            any destructive op; ``"outcome"`` is written after. Pre-
+            GAP-002 entries default to ``"outcome"`` since that's what
+            they always semantically were.
+        operation_id: UUID4 that pairs an intent entry with its
+            matching outcome. Empty string for pre-GAP-002 entries.
+        status: For outcome entries only — ``"complete"`` if the body
+            ran without raising, ``"partial"`` if it aborted partway.
+            ``None`` for intent entries and for pre-GAP-002 outcomes.
+        failure_reason: Short string capturing the exception type and
+            message when ``status="partial"``; ``None`` otherwise.
         target: Legacy field preserved for backward compatibility on
             read; populated only when reading pre-Batch-C entries.
         count: Legacy fragment count preserved for backward compatibility
@@ -82,6 +108,11 @@ class PurgeAuditEntry(BaseModel):
     embeddings_removed: int = 0
     operator: str = _DEFAULT_OPERATOR
     dry_run: bool = False
+
+    phase: PurgePhase = "outcome"
+    operation_id: str = ""
+    status: PurgeOutcomeStatus | None = None
+    failure_reason: str | None = None
 
     target: str | None = None
     count: int | None = None
@@ -106,6 +137,9 @@ def _coerce_legacy_entry(raw: dict[str, Any]) -> dict[str, Any]:
     upgraded.setdefault("affected_fragments", [])
     upgraded.setdefault("references_scrubbed", 0)
     upgraded.setdefault("embeddings_removed", 0)
+    # GAP-002 fields take their schema defaults via Pydantic when
+    # absent, so we leave them out here rather than fabricating a
+    # phase / operation_id that doesn't correspond to anything on disk.
     return upgraded
 
 

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING
 import frontmatter
 from pydantic import BaseModel, Field
 
-from creek.purge.audit import PurgeAuditEntry, PurgeAuditLog
+from creek.purge.audit import PurgeAuditEntry, PurgeAuditLog, PurgeOutcomeStatus
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -820,7 +820,7 @@ class PurgeEngine:
         result: PurgeResult,
         operation_id: str,
         *,
-        status: str,
+        status: PurgeOutcomeStatus,
         failure_reason: str | None = None,
     ) -> None:
         """Append the GAP-002 ``outcome`` entry for *result*.
@@ -860,7 +860,7 @@ class PurgeEngine:
             dry_run=result.dry_run,
             phase="outcome",
             operation_id=operation_id,
-            status=status,  # type: ignore[arg-type]
+            status=status,
             failure_reason=failure_reason,
         )
         self.audit_log.append(entry)

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -9,8 +9,22 @@ Implements the five purge operations required by issue #46:
 - **purge_vault**: destroy all vault content, preserving folder structure.
 
 Every operation supports a dry-run mode that previews changes without
-writing to disk, and writes an entry to the
-:class:`~creek.purge.audit.PurgeAuditLog` recording what happened.
+writing to disk. Each call emits a **pair** of audit entries (GAP-002):
+an ``intent`` line *before* the first destructive op, then an
+``outcome`` line *after* the body completes (``status="complete"``) or
+after an exception aborts it (``status="partial"``). The pair shares a
+UUID4 ``operation_id`` so a crash recovery tool can reconstruct what
+was being attempted from the intent line alone.
+
+The engine is **not** transactional: a SIGKILL between two ``unlink``
+calls leaves the filesystem in a partial state. The intent log is the
+recovery contract — an operator inspecting
+``<vault>/00-Creek-Meta/audit/purge.jsonl`` after a crash will see the
+intent entry naming what was being attempted, and (if the process got
+that far) an outcome entry with ``status="partial"`` recording how far
+the work had progressed. A staging-directory rename pattern would
+deliver real atomicity at the cost of doubling the I/O budget for
+every purge; it is deferred to a future hardening pass.
 """
 
 from __future__ import annotations
@@ -18,6 +32,7 @@ from __future__ import annotations
 import logging
 import re
 import shutil
+import uuid
 from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING
 
@@ -166,36 +181,37 @@ class PurgeEngine:
             criteria={"fragment_id": fragment_id},
             dry_run=self.dry_run,
         )
-        frag_file, post = self._find_fragment_by_id(fragment_id)
-        if frag_file is None or post is None:
-            self._write_audit(result)
-            return result
 
-        title = str(post.get("title", frag_file.stem))
-        thread_ids = _str_list(post.get("threads"))
-        eddy_ids = _str_list(post.get("eddies"))
+        def body() -> None:
+            """Run the per-fragment destructive ops, mutating ``result``."""
+            frag_file, post = self._find_fragment_by_id(fragment_id)
+            if frag_file is None or post is None:
+                return
+            title = str(post.get("title", frag_file.stem))
+            thread_ids = _str_list(post.get("threads"))
+            eddy_ids = _str_list(post.get("eddies"))
+            result.deleted_files.append(str(frag_file))
+            result.affected_fragment_ids.append(fragment_id)
+            result.fragments_affected = 1
+            result.wikilinks_removed = self._scrub_wikilinks(
+                title,
+                exclude=frag_file,
+            )
+            result.threads_updated = self._decrement_counts(
+                "02-Threads",
+                thread_ids,
+            )
+            result.eddies_updated = self._decrement_counts(
+                "03-Eddies",
+                eddy_ids,
+            )
+            if not self.dry_run:
+                frag_file.unlink()
+            result.embeddings_removed = self._purge_cache_for(
+                result.affected_fragment_ids,
+            )
 
-        result.deleted_files.append(str(frag_file))
-        result.affected_fragment_ids.append(fragment_id)
-        result.fragments_affected = 1
-        result.wikilinks_removed = self._scrub_wikilinks(title, exclude=frag_file)
-        result.threads_updated = self._decrement_counts(
-            "02-Threads",
-            thread_ids,
-        )
-        result.eddies_updated = self._decrement_counts(
-            "03-Eddies",
-            eddy_ids,
-        )
-
-        if not self.dry_run:
-            frag_file.unlink()
-
-        result.embeddings_removed = self._purge_cache_for(
-            result.affected_fragment_ids,
-        )
-        self._write_audit(result)
-        return result
+        return self._run_audited(result, body)
 
     # -- Source purge -----------------------------------------------------
 
@@ -215,14 +231,17 @@ class PurgeEngine:
             criteria={"source_type": source_type},
             dry_run=self.dry_run,
         )
-        matches = self._fragments_from_source(source_type)
-        for frag_file, post in matches:
-            self._purge_single(frag_file, post, result)
-        result.embeddings_removed = self._purge_cache_for(
-            result.affected_fragment_ids,
-        )
-        self._write_audit(result)
-        return result
+
+        def body() -> None:
+            """Run the per-source destructive ops, mutating ``result``."""
+            matches = self._fragments_from_source(source_type)
+            for frag_file, post in matches:
+                self._purge_single(frag_file, post, result)
+            result.embeddings_removed = self._purge_cache_for(
+                result.affected_fragment_ids,
+            )
+
+        return self._run_audited(result, body)
 
     def count_fragments_from_source(self, source_type: str) -> int:
         """Count fragments currently attributed to a source platform.
@@ -266,14 +285,17 @@ class PurgeEngine:
             criteria={"source_path": source_path, "match": match},
             dry_run=self.dry_run,
         )
-        matches = self._fragments_from_source_path(source_path, match=match)
-        for frag_file, post in matches:
-            self._purge_single(frag_file, post, result)
-        result.embeddings_removed = self._purge_cache_for(
-            result.affected_fragment_ids,
-        )
-        self._write_audit(result)
-        return result
+
+        def body() -> None:
+            """Run the source-path destructive ops, mutating ``result``."""
+            matches = self._fragments_from_source_path(source_path, match=match)
+            for frag_file, post in matches:
+                self._purge_single(frag_file, post, result)
+            result.embeddings_removed = self._purge_cache_for(
+                result.affected_fragment_ids,
+            )
+
+        return self._run_audited(result, body)
 
     def count_fragments_from_source_path(
         self,
@@ -310,23 +332,26 @@ class PurgeEngine:
             criteria={"scope": "all"},
             dry_run=self.dry_run,
         )
-        for frag_file in self._list_fragment_files():
-            post = self._load_frontmatter(frag_file)
-            if post is None:
-                continue
-            if self._reset_classifications(post):
-                result.classifications_reset += 1
-                frag_id = post.get("id")
-                if isinstance(frag_id, str):
-                    result.affected_fragment_ids.append(frag_id)
-                if not self.dry_run:
-                    frag_file.write_text(
-                        frontmatter.dumps(post),
-                        encoding="utf-8",
-                    )
-        result.fragments_affected = result.classifications_reset
-        self._write_audit(result)
-        return result
+
+        def body() -> None:
+            """Reset classification fields on every fragment, mutating ``result``."""
+            for frag_file in self._list_fragment_files():
+                post = self._load_frontmatter(frag_file)
+                if post is None:
+                    continue
+                if self._reset_classifications(post):
+                    result.classifications_reset += 1
+                    frag_id = post.get("id")
+                    if isinstance(frag_id, str):
+                        result.affected_fragment_ids.append(frag_id)
+                    if not self.dry_run:
+                        frag_file.write_text(
+                            frontmatter.dumps(post),
+                            encoding="utf-8",
+                        )
+            result.fragments_affected = result.classifications_reset
+
+        return self._run_audited(result, body)
 
     # -- Daterange purge -------------------------------------------------
 
@@ -358,19 +383,22 @@ class PurgeEngine:
             criteria={"start": start.isoformat(), "end": end.isoformat()},
             dry_run=self.dry_run,
         )
-        for frag_file in self._list_fragment_files():
-            post = self._load_frontmatter(frag_file)
-            if post is None:
-                continue
-            created = _coerce_date(post.get("created"))
-            if created is None or not (start <= created <= end):
-                continue
-            self._purge_single(frag_file, post, result)
-        result.embeddings_removed = self._purge_cache_for(
-            result.affected_fragment_ids,
-        )
-        self._write_audit(result)
-        return result
+
+        def body() -> None:
+            """Run the date-range destructive ops, mutating ``result``."""
+            for frag_file in self._list_fragment_files():
+                post = self._load_frontmatter(frag_file)
+                if post is None:
+                    continue
+                created = _coerce_date(post.get("created"))
+                if created is None or not (start <= created <= end):
+                    continue
+                self._purge_single(frag_file, post, result)
+            result.embeddings_removed = self._purge_cache_for(
+                result.affected_fragment_ids,
+            )
+
+        return self._run_audited(result, body)
 
     # -- Vault purge ------------------------------------------------------
 
@@ -404,15 +432,18 @@ class PurgeEngine:
             criteria={"scope": "entire vault"},
             dry_run=self.dry_run,
         )
-        for folder in _VAULT_CONTENT_FOLDERS:
-            folder_path = self.vault_path / folder
-            if not folder_path.is_dir():
-                continue
-            self._wipe_folder_contents(folder_path, result)
-        result.fragments_affected = len(result.deleted_files)
-        result.embeddings_removed = self._delete_cache_file()
-        self._write_audit(result)
-        return result
+
+        def body() -> None:
+            """Wipe every vault-content folder, mutating ``result``."""
+            for folder in _VAULT_CONTENT_FOLDERS:
+                folder_path = self.vault_path / folder
+                if not folder_path.is_dir():
+                    continue
+                self._wipe_folder_contents(folder_path, result)
+            result.fragments_affected = len(result.deleted_files)
+            result.embeddings_removed = self._delete_cache_file()
+
+        return self._run_audited(result, body)
 
     # -- Private helpers -------------------------------------------------
 
@@ -714,8 +745,85 @@ class PurgeEngine:
             else:
                 entry.unlink()
 
-    def _write_audit(self, result: PurgeResult) -> None:
-        """Append a :class:`PurgeAuditEntry` for a completed purge.
+    def _run_audited(
+        self,
+        result: PurgeResult,
+        body: Callable[[], None],
+    ) -> PurgeResult:
+        """Wrap a purge body in the GAP-002 intent → outcome audit pair.
+
+        Emits an ``intent`` entry before invoking *body*, then an
+        ``outcome`` entry after — ``status="complete"`` on success,
+        ``status="partial"`` (with the exception type + message in
+        ``failure_reason``) when *body* raises. The exception then
+        propagates so callers see the failure.
+
+        The intent entry is the engine's recovery contract: even a
+        SIGKILL between the intent write and the first destructive op
+        leaves a forensic trail naming what was being attempted.
+
+        Args:
+            result: Result accumulator the body will populate.
+            body: Callable that does the actual destructive work and
+                mutates *result* in place.
+
+        Returns:
+            The same ``result`` with counts populated.
+
+        Raises:
+            Exception: Whatever *body* raises, after the partial
+                outcome line has been written.
+        """
+        operation_id = uuid.uuid4().hex
+        self._write_intent_audit(result, operation_id)
+        try:
+            body()
+        except BaseException as exc:
+            failure_reason = f"{type(exc).__name__}: {exc}"
+            self._write_outcome_audit(
+                result,
+                operation_id,
+                status="partial",
+                failure_reason=failure_reason,
+            )
+            raise
+        self._write_outcome_audit(result, operation_id, status="complete")
+        return result
+
+    def _write_intent_audit(
+        self,
+        result: PurgeResult,
+        operation_id: str,
+    ) -> None:
+        """Append the GAP-002 ``intent`` entry for *result*.
+
+        The intent line captures the *planned* scope (operation name,
+        criteria, dry-run flag). Counts are deliberately zero — they
+        are not known until the body runs.
+
+        Args:
+            result: Result accumulator carrying the planned criteria.
+            operation_id: UUID4 hex linking this intent to its outcome.
+        """
+        self._validate_operation(result.operation)
+        entry = PurgeAuditEntry(
+            operation=result.operation,
+            criteria=result.criteria.copy(),
+            dry_run=result.dry_run,
+            phase="intent",
+            operation_id=operation_id,
+        )
+        self.audit_log.append(entry)
+
+    def _write_outcome_audit(
+        self,
+        result: PurgeResult,
+        operation_id: str,
+        *,
+        status: str,
+        failure_reason: str | None = None,
+    ) -> None:
+        """Append the GAP-002 ``outcome`` entry for *result*.
 
         ``fragments_deleted`` counts only operations that remove files
         from disk (see :data:`_FILE_DELETING_OPERATIONS`);
@@ -728,6 +836,11 @@ class PurgeEngine:
 
         Args:
             result: The result whose metadata should be logged.
+            operation_id: UUID4 hex matching the paired intent entry.
+            status: ``"complete"`` if the body ran to the end, or
+                ``"partial"`` if it raised.
+            failure_reason: Short ``"<ExceptionType>: <message>"`` when
+                ``status="partial"``; ``None`` otherwise.
 
         Raises:
             ValueError: If ``result.operation`` is not a known purge
@@ -735,17 +848,7 @@ class PurgeEngine:
                 so a new operation type cannot silently default to
                 ``deletes_files=True``.
         """
-        if result.operation in _FILE_DELETING_OPERATIONS:
-            deletes_files = True
-        elif result.operation == "classifications":
-            deletes_files = False
-        else:
-            msg = (
-                f"Unknown purge operation {result.operation!r}; classify it "
-                f"explicitly in _FILE_DELETING_OPERATIONS or add a metadata-only "
-                f"branch before logging."
-            )
-            raise ValueError(msg)
+        deletes_files = self._validate_operation(result.operation)
         fragments_deleted = result.fragments_affected if deletes_files else 0
         entry = PurgeAuditEntry(
             operation=result.operation,
@@ -755,8 +858,53 @@ class PurgeEngine:
             references_scrubbed=result.wikilinks_removed,
             embeddings_removed=result.embeddings_removed,
             dry_run=result.dry_run,
+            phase="outcome",
+            operation_id=operation_id,
+            status=status,  # type: ignore[arg-type]
+            failure_reason=failure_reason,
         )
         self.audit_log.append(entry)
+
+    def _validate_operation(self, operation: str) -> bool:
+        """Confirm *operation* is known and return whether it deletes files.
+
+        Args:
+            operation: The operation name to validate.
+
+        Returns:
+            ``True`` when the operation removes files from disk,
+            ``False`` for metadata-only operations.
+
+        Raises:
+            ValueError: When *operation* is neither in
+                :data:`_FILE_DELETING_OPERATIONS` nor the metadata-only
+                allowlist.
+        """
+        if operation in _FILE_DELETING_OPERATIONS:
+            return True
+        if operation == "classifications":
+            return False
+        msg = (
+            f"Unknown purge operation {operation!r}; classify it "
+            f"explicitly in _FILE_DELETING_OPERATIONS or add a metadata-only "
+            f"branch before logging."
+        )
+        raise ValueError(msg)
+
+    def _write_audit(self, result: PurgeResult) -> None:
+        """Backward-compat shim that writes a single outcome entry.
+
+        Pre-existing callers (and a small handful of tests) treat
+        ``_write_audit`` as "emit one final audit line". The GAP-002
+        contract has the engine emit *two* lines per operation via
+        :meth:`_run_audited`. This shim is preserved so direct callers
+        keep working: they get an outcome line with a fresh
+        ``operation_id`` and ``status="complete"``, no paired intent.
+
+        Args:
+            result: Result whose metadata should be logged.
+        """
+        self._write_outcome_audit(result, uuid.uuid4().hex, status="complete")
 
 
 _CLASSIFICATION_DEFAULTS: dict[str, dict[str, object]] = {

--- a/creek-tools/docs/cleaning-and-purge.md
+++ b/creek-tools/docs/cleaning-and-purge.md
@@ -178,24 +178,41 @@ The `WARNING` log entry written when `--force-non-interactive` is used will surf
 
 ## Audit trail
 
-Every purge appends one JSONL line to `<vault>/00-Creek-Meta/audit/purge.jsonl`. Each entry carries an inline `prev_hash` (sha256 of the previous line) so a tampered or truncated log can be detected via the verification API:
+Every purge writes **two** JSONL lines to `<vault>/00-Creek-Meta/audit/purge.jsonl`: an `intent` line *before* the first destructive op, then an `outcome` line *after* the body completes (or after an exception aborts it). Both lines share a UUID4 `operation_id` so a recovery tool can pair them, and both extend the `prev_hash` sha256 chain so a tampered or truncated log can be detected via the verification API:
 
 ```json
 {
-  "operation": "source",
-  "criteria": {"source_type": "claude"},
-  "affected_fragments": ["frag-...", "frag-..."],
+  "operation": "vault",
+  "criteria": {"scope": "entire vault"},
   "operator": "sgsg",
   "timestamp": "2026-04-28T18:01:23Z",
+  "phase": "intent",
+  "operation_id": "9f1c…",
+  "dry_run": false,
+  "prev_hash": "0000…"
+}
+{
+  "operation": "vault",
+  "criteria": {"scope": "entire vault"},
+  "affected_fragments": ["frag-…", "frag-…"],
+  "operator": "sgsg",
+  "timestamp": "2026-04-28T18:01:24Z",
+  "phase": "outcome",
+  "operation_id": "9f1c…",
+  "status": "complete",
   "fragments_deleted": 47,
   "references_scrubbed": 312,
   "embeddings_removed": 47,
   "dry_run": false,
-  "prev_hash": "0000…"
+  "prev_hash": "abcd…"
 }
 ```
 
-`embeddings_removed` is the real number of rows dropped from
+If the process is killed *between* the two writes (SIGKILL, power loss, OOM kill), the intent line is on disk and the outcome line is not. An operator inspecting the log knows that vault `<id>` was being attempted at `<timestamp>` and can reconcile against the filesystem. If the body raises a Python exception, the engine writes an outcome line with `status="partial"` and a `failure_reason` field naming the exception type and message; the original exception then propagates.
+
+`creek purge` is **not** transactional — there is no staging-directory rename pattern, so a crash partway through `_wipe_folder_contents` can still leave the filesystem half-deleted. The intent + outcome pair is the recovery contract: it tells you *what was attempted* and *how far it got*, but does not roll back. Pre-GAP-002 entries (no `phase` field) read back as `phase="outcome"` with `operation_id=""` and `status=null` for backward compatibility.
+
+The outcome line's `embeddings_removed` is the real number of rows dropped from
 `<vault>/00-Creek-Meta/embeddings.parquet` in that call (GAP-001):
 
 - Zero when the embeddings cache has not been built yet (no `creek

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -305,11 +305,11 @@ def test_fragment_purge_dry_run_preserves_everything(tmp_path: Path) -> None:
 
 
 def test_fragment_purge_writes_audit(tmp_path: Path) -> None:
-    """A purge_fragment call appends exactly one audit entry.
+    """A purge_fragment call appends one intent + one outcome entry (GAP-002).
 
-    ``embeddings_removed`` is *zero* here because no embeddings cache
-    was built (GAP-001). The honest-count contract is verified
-    end-to-end by the GAP-001 tests further down in this file.
+    ``embeddings_removed`` is *zero* on the outcome here because no
+    embeddings cache was built (GAP-001). The intent line carries the
+    planned scope; the outcome line carries the real counts.
     """
     vault = _make_vault(tmp_path)
     _write_fragment(vault, "frag-A", "Alpha")
@@ -318,15 +318,20 @@ def test_fragment_purge_writes_audit(tmp_path: Path) -> None:
     engine.purge_fragment("frag-A")
 
     entries = PurgeAuditLog(vault).read()
-    assert len(entries) == 1
-    entry = entries[0]
-    assert entry.operation == "fragment"
-    assert entry.criteria == {"fragment_id": "frag-A"}
-    assert entry.affected_fragments == ["frag-A"]
-    assert entry.fragments_deleted == 1
-    assert entry.embeddings_removed == 0
-    assert entry.operator == "human via CLI"
-    assert entry.dry_run is False
+    assert len(entries) == 2
+    intent, outcome = entries
+    assert intent.phase == "intent"
+    assert intent.operation == "fragment"
+    assert intent.criteria == {"fragment_id": "frag-A"}
+    assert outcome.phase == "outcome"
+    assert outcome.status == "complete"
+    assert outcome.operation == "fragment"
+    assert outcome.criteria == {"fragment_id": "frag-A"}
+    assert outcome.affected_fragments == ["frag-A"]
+    assert outcome.fragments_deleted == 1
+    assert outcome.embeddings_removed == 0
+    assert outcome.operator == "human via CLI"
+    assert outcome.dry_run is False
 
 
 # ---------------------------------------------------------------------------
@@ -1807,3 +1812,282 @@ def test_classifications_purge_does_not_touch_cache(tmp_path: Path) -> None:
 
     assert result.embeddings_removed == 0
     assert _load_cache_ids(vault) == {"frag-A"}
+
+
+# ---------------------------------------------------------------------------
+# GAP-002 — pre-destruction intent + post-destruction outcome audit pairs
+# ---------------------------------------------------------------------------
+
+
+def _entries_for_run(vault: Path) -> list[PurgeAuditEntry]:
+    """Return non-migration purge entries from the audit log."""
+    return [
+        e for e in PurgeAuditLog(vault).read() if e.operation != "purge.audit.migration"
+    ]
+
+
+def test_purge_vault_writes_intent_before_destruction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``purge_vault`` records an intent entry before unlinking anything.
+
+    GAP-002 acceptance criterion #1: the intent entry must be on disk
+    *before* the first destructive operation, so a SIGKILL mid-wipe
+    still leaves a forensic trail naming what was being attempted.
+    """
+    import shutil as shutil_mod
+
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    (vault / "01-Fragments" / "sub").mkdir(parents=True, exist_ok=True)
+    (vault / "01-Fragments" / "sub" / "x.md").write_text("x", encoding="utf-8")
+
+    captured_entries_at_first_rmtree: list[PurgeAuditEntry] = []
+    real_rmtree = shutil_mod.rmtree
+
+    def spy_rmtree(*args: object, **kwargs: object) -> None:
+        # First time rmtree is invoked, snapshot the audit log so we
+        # can prove the intent line was already there.
+        if not captured_entries_at_first_rmtree:
+            captured_entries_at_first_rmtree.extend(_entries_for_run(vault))
+        real_rmtree(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("creek.purge.engine.shutil.rmtree", spy_rmtree)
+    PurgeEngine(vault).purge_vault(VAULT_PURGE_CONFIRMATION)
+
+    assert captured_entries_at_first_rmtree, "rmtree was never called"
+    first_seen = captured_entries_at_first_rmtree[0]
+    assert first_seen.phase == "intent"
+    assert first_seen.operation == "vault"
+    assert first_seen.operation_id
+
+
+def test_purge_vault_emits_intent_then_outcome_pair(tmp_path: Path) -> None:
+    """On success, two entries (intent + complete outcome) share operation_id."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+
+    PurgeEngine(vault).purge_vault(VAULT_PURGE_CONFIRMATION)
+
+    entries = _entries_for_run(vault)
+    assert len(entries) == 2
+    intent, outcome = entries
+    assert intent.phase == "intent"
+    assert outcome.phase == "outcome"
+    assert outcome.status == "complete"
+    assert intent.operation_id == outcome.operation_id
+    assert intent.operation == "vault" == outcome.operation
+
+
+def test_purge_vault_outcome_status_partial_on_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the wipe loop raises, outcome records ``status="partial"``.
+
+    GAP-002 acceptance criterion #3: the exception propagates *and* the
+    log gets an outcome line saying what survived (intent already wrote
+    what was being attempted; outcome closes the trail with the partial
+    state).
+    """
+    import shutil as shutil_mod
+
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    _write_thread(vault, "thread-1", "Waves")
+    # Add a subdirectory to 02-Threads so rmtree gets called there.
+    (vault / "02-Threads" / "sub").mkdir(parents=True, exist_ok=True)
+    (vault / "02-Threads" / "sub" / "x.md").write_text("x", encoding="utf-8")
+
+    real_rmtree = shutil_mod.rmtree
+    call_count = {"n": 0}
+
+    def flaky_rmtree(*args: object, **kwargs: object) -> None:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            msg = "simulated mid-purge OSError"
+            raise OSError(msg)
+        real_rmtree(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("creek.purge.engine.shutil.rmtree", flaky_rmtree)
+
+    with pytest.raises(OSError, match="simulated mid-purge"):
+        PurgeEngine(vault).purge_vault(VAULT_PURGE_CONFIRMATION)
+
+    entries = _entries_for_run(vault)
+    assert len(entries) == 2
+    intent, outcome = entries
+    assert intent.phase == "intent"
+    assert outcome.phase == "outcome"
+    assert outcome.status == "partial"
+    assert intent.operation_id == outcome.operation_id
+    assert outcome.failure_reason
+    assert "simulated mid-purge" in outcome.failure_reason
+
+
+def test_purge_fragment_emits_intent_then_outcome_pair(tmp_path: Path) -> None:
+    """Per-fragment purge follows the same intent/outcome contract."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+
+    PurgeEngine(vault).purge_fragment("frag-A")
+
+    entries = _entries_for_run(vault)
+    assert len(entries) == 2
+    intent, outcome = entries
+    assert intent.phase == "intent"
+    assert outcome.phase == "outcome"
+    assert outcome.status == "complete"
+    assert intent.operation_id == outcome.operation_id
+    # Intent carries the scope; outcome carries the counts.
+    assert intent.criteria == outcome.criteria == {"fragment_id": "frag-A"}
+    assert outcome.fragments_deleted == 1
+
+
+def test_purge_source_emits_intent_then_outcome_pair(tmp_path: Path) -> None:
+    """``purge_source`` writes intent before, outcome after."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha", platform="claude")
+    _write_fragment(vault, "frag-B", "Bravo", platform="claude")
+
+    PurgeEngine(vault).purge_source("claude")
+
+    entries = _entries_for_run(vault)
+    assert len(entries) == 2
+    intent, outcome = entries
+    assert intent.phase == "intent"
+    assert outcome.status == "complete"
+    assert intent.operation_id == outcome.operation_id
+    assert outcome.fragments_deleted == 2
+
+
+def test_purge_source_path_emits_intent_then_outcome_pair(tmp_path: Path) -> None:
+    """``purge_source_path`` writes intent before, outcome after."""
+    vault = _make_vault(tmp_path)
+    _write_fragment_with_original(
+        vault,
+        "frag-A",
+        "Alpha",
+        original_file="/exports/2026-04-28.json",
+    )
+
+    PurgeEngine(vault).purge_source_path("/exports/", match="substring")
+
+    entries = _entries_for_run(vault)
+    assert len(entries) == 2
+    intent, outcome = entries
+    assert intent.phase == "intent"
+    assert outcome.phase == "outcome"
+    assert outcome.status == "complete"
+    assert intent.operation_id == outcome.operation_id
+
+
+def test_purge_daterange_emits_intent_then_outcome_pair(tmp_path: Path) -> None:
+    """``purge_daterange`` writes intent before, outcome after."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(
+        vault,
+        "frag-mid",
+        "Mid",
+        created=datetime(2024, 6, 1, tzinfo=UTC),
+    )
+
+    PurgeEngine(vault).purge_daterange(date(2024, 1, 1), date(2024, 12, 31))
+
+    entries = _entries_for_run(vault)
+    assert len(entries) == 2
+    intent, outcome = entries
+    assert intent.phase == "intent"
+    assert outcome.status == "complete"
+    assert intent.operation_id == outcome.operation_id
+
+
+def test_purge_classifications_emits_intent_then_outcome_pair(
+    tmp_path: Path,
+) -> None:
+    """Even metadata-only ops emit the pair; recovery still depends on intent."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+
+    PurgeEngine(vault).purge_classifications()
+
+    entries = _entries_for_run(vault)
+    assert len(entries) == 2
+    intent, outcome = entries
+    assert intent.phase == "intent"
+    assert outcome.phase == "outcome"
+    assert outcome.status == "complete"
+    assert intent.operation_id == outcome.operation_id
+
+
+def test_audit_chain_intact_across_intent_outcome_pairs(tmp_path: Path) -> None:
+    """Two pairs in a row leave a verifiable four-entry hash chain."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    _write_fragment(vault, "frag-B", "Bravo")
+
+    engine = PurgeEngine(vault)
+    engine.purge_fragment("frag-A")
+    engine.purge_fragment("frag-B")
+
+    PurgeAuditLog(vault).verify()  # raises if chain is broken
+    entries = _entries_for_run(vault)
+    assert [e.phase for e in entries] == ["intent", "outcome", "intent", "outcome"]
+    # Each pair's operation_ids match; the two pairs differ.
+    assert entries[0].operation_id == entries[1].operation_id
+    assert entries[2].operation_id == entries[3].operation_id
+    assert entries[0].operation_id != entries[2].operation_id
+
+
+def test_purge_fragment_intent_logged_even_when_target_missing(
+    tmp_path: Path,
+) -> None:
+    """A no-op purge (target not found) still emits the intent/outcome pair.
+
+    Forensic value: an operator who fat-fingers a fragment ID should
+    still see *that* they tried to purge it. The outcome reports zero
+    deletions but the intent records the attempt.
+    """
+    vault = _make_vault(tmp_path)
+
+    PurgeEngine(vault).purge_fragment("frag-missing")
+
+    entries = _entries_for_run(vault)
+    assert len(entries) == 2
+    intent, outcome = entries
+    assert intent.phase == "intent"
+    assert outcome.phase == "outcome"
+    assert outcome.status == "complete"
+    assert outcome.fragments_deleted == 0
+
+
+def test_legacy_audit_entries_default_to_outcome_phase(tmp_path: Path) -> None:
+    """Pre-GAP-002 entries (no phase/operation_id) read back as outcomes.
+
+    Backward compatibility: an audit log that predates the schema change
+    must keep reading cleanly; missing fields take sensible defaults
+    (``phase="outcome"`` because that's what those entries always were
+    de-facto, even though the field didn't exist).
+    """
+    vault = _make_vault(tmp_path)
+    log = PurgeAuditLog(vault)
+    # Append an entry the pre-GAP-002 way — directly through the
+    # underlying AuditLog so it lands without phase/operation_id.
+    from creek.audit import AuditLog
+
+    AuditLog(log.log_path).append(
+        {
+            "timestamp": "2025-01-01T00:00:00+00:00",
+            "operation": "fragment",
+            "criteria": {"fragment_id": "frag-old"},
+            "affected_fragments": ["frag-old"],
+            "fragments_deleted": 1,
+        },
+    )
+
+    entries = PurgeAuditLog(vault).read()
+    assert len(entries) == 1
+    assert entries[0].phase == "outcome"
+    assert entries[0].operation_id == ""
+    assert entries[0].status is None


### PR DESCRIPTION
The purge engine used to write its audit line *after* the wipe loop
completed. A SIGKILL, OSError, OOM kill, or Ctrl-C mid-loop left the
filesystem in a partial state with zero audit trail: the operator had
no record of what was being attempted, let alone how far it got.

This change splits every purge operation into a pair of audit entries
sharing a UUID4 `operation_id`:

- An **intent** entry is written *before* the first destructive op,
  capturing the planned scope (operation, criteria, dry-run flag).
  Pure pre-destruction forensic trail — even if the process dies
  between the intent write and the first unlink, the trail exists.
- An **outcome** entry is written *after* the body runs. On success
  it carries `status="complete"` with the real counts; on any
  exception it carries `status="partial"` with the partial counts and
  a `failure_reason` field naming the exception type and message,
  then the original exception propagates.

The pattern wraps every purge entry point — `purge_fragment`,
`purge_source`, `purge_source_path`, `purge_daterange`,
`purge_classifications`, and `purge_vault` — via the shared
`_run_audited(result, body)` helper, closing the GAP-002/GAP-010
"after-destruction audit" pattern across the engine in one PR.

The engine is **not** transactional: there is no staging-directory
rename pattern, so a crash partway through `_wipe_folder_contents`
still leaves the filesystem half-deleted. The intent + outcome pair
is the recovery contract, documented explicitly in the module
docstring and in `docs/cleaning-and-purge.md`.

Backward compatibility: pre-GAP-002 audit entries (no `phase` field)
read back as `phase="outcome"` with `operation_id=""` and
`status=None`. The legacy `_write_audit(result)` shim is preserved
for the small number of direct callers in the test suite.