### PR TITLE
feat(crawdad): real step walker with error propagation (ADAPT-003 Phase 2)

### DIFF
--- a/crawdad/crawdad/workflows.py
+++ b/crawdad/crawdad/workflows.py
@@ -148,6 +148,12 @@ class WorkflowStepError(RuntimeError):
     *which* workflow blew up without scraping the message string. The
     underlying exception is preserved via ``__cause__``.
 
+    Invariant: this exception is ONLY ever raised with complete
+    metadata. The interpolation helpers that lack workflow / step
+    context raise the private :class:`_StepRefError` instead; the
+    walker catches that and rebrands into a fully-populated
+    :class:`WorkflowStepError`.
+
     Attributes:
         step_id: The ``id`` of the failing step.
         tool: The MCP tool name the step was about to call.
@@ -167,6 +173,24 @@ class WorkflowStepError(RuntimeError):
         self.step_id = step_id
         self.tool = tool
         self.workflow_name = workflow_name
+
+
+class _StepRefError(ValueError):
+    """Private — raised by :func:`_resolve_step`, wrapped by the walker.
+
+    The interpolation layer cannot construct a meaningful
+    :class:`WorkflowStepError` because it has no workflow or step
+    context — only the walker has those. Raising this distinct private
+    type lets the walker rebrand into a fully-populated
+    :class:`WorkflowStepError` while keeping :class:`WorkflowStepError`'s
+    contract (always has ``step_id`` / ``tool`` / ``workflow_name``)
+    intact for direct callers.
+
+    Subclasses :class:`ValueError` because a malformed step reference
+    really is a bad value — that placement keeps it discoverable to any
+    caller that already handles interpolation problems with a broad
+    ``except ValueError``.
+    """
 
 
 # ---------------------------------------------------------------------------
@@ -392,21 +416,24 @@ def _resolve_step(parts: list[str], step_results: dict[str, ToolResult]) -> str:
 
     Phase 2 (#326): step references are strict. A forward reference to
     a step that has not run yet, a bare ``{{step.<id>}}`` with no
-    field, or any field other than ``body`` raises
-    :class:`WorkflowStepError`. The walker catches the error to attach
-    workflow + offending-step metadata before re-raising.
+    field, or any field other than ``body`` raises the private
+    :class:`_StepRefError`. The walker catches the error and rebrands
+    it as a fully-populated :class:`WorkflowStepError` via
+    :func:`_rebrand_step_error`. Direct callers of this helper (or of
+    :func:`interpolate`) see :class:`_StepRefError`, which subclasses
+    :class:`ValueError`.
     """
     if not parts:
         msg = "step reference {{step}} is missing both id and field"
-        raise WorkflowStepError(msg, step_id="", tool="", workflow_name="")
+        raise _StepRefError(msg)
     if len(parts) < 2:
         step_id = parts[0]
         msg = (
             f"step reference {{step.{step_id}}} is missing a field; "
             "the only addressable field today is `body` "
-            "(e.g. {{step." + step_id + ".body}})"
+            f"(e.g. {{{{step.{step_id}.body}}}})"
         )
-        raise WorkflowStepError(msg, step_id="", tool="", workflow_name="")
+        raise _StepRefError(msg)
     step_id, field = parts[0], parts[1]
     result = step_results.get(step_id)
     if result is None:
@@ -416,13 +443,13 @@ def _resolve_step(parts: list[str], step_results: dict[str, ToolResult]) -> str:
             f"upstream step that has not run yet; available step ids: "
             f"{available}"
         )
-        raise WorkflowStepError(msg, step_id="", tool="", workflow_name="")
+        raise _StepRefError(msg)
     if field != "body":
         msg = (
             f"step reference {{step.{step_id}.{field}}} uses unknown "
             "field; the only addressable field today is `body`"
         )
-        raise WorkflowStepError(msg, step_id="", tool="", workflow_name="")
+        raise _StepRefError(msg)
     return result.body
 
 
@@ -668,7 +695,7 @@ class WorkflowWalker:
                 resolved_args, workflow.privacy_tier_floor
             )
             body = await session.call_tool(step.tool, arguments)
-        except WorkflowStepError as exc:
+        except (_StepRefError, WorkflowStepError) as exc:
             raise _rebrand_step_error(exc, workflow=workflow, step=step) from exc
         except Exception as exc:
             raise _wrap_step_failure(exc, workflow=workflow, step=step) from exc
@@ -680,17 +707,27 @@ class WorkflowWalker:
 
 
 def _rebrand_step_error(
-    exc: WorkflowStepError,
+    exc: _StepRefError | WorkflowStepError,
     *,
     workflow: WorkflowDefinition,
     step: WorkflowStep,
 ) -> WorkflowStepError:
     """Attach workflow + step metadata to an interpolation-time step error.
 
-    ``_resolve_step`` raises :class:`WorkflowStepError` without knowing
-    which workflow or step it is being called from — the walker has
-    that context, so it re-raises here with the metadata filled in and
-    the original (anonymous) message prefixed by the step location.
+    :func:`_resolve_step` raises :class:`_StepRefError` because it has
+    no workflow / step context to populate a full
+    :class:`WorkflowStepError`. The walker has that context, so it
+    re-raises here with the metadata filled in and the original
+    (anonymous) message prefixed by the step location. The original
+    exception is preserved via ``__cause__`` at the raise site so the
+    caller can ``isinstance(exc.__cause__, _StepRefError)`` to
+    distinguish "interpolation failed" from "MCP tool raised".
+
+    Accepts :class:`WorkflowStepError` too as defence-in-depth: if a
+    downstream helper ever surfaces one already populated, the walker
+    rebrands it under the current step's identity rather than letting
+    a stale identity leak through. In practice only
+    :class:`_StepRefError` reaches this path today.
     """
     location = f"workflow {workflow.name!r} step {step.id!r} (tool {step.tool!r})"
     return WorkflowStepError(
@@ -774,9 +811,20 @@ async def run_workflow_and_compose(
     registry (e.g. early unit tests) can hand a static stack in via
     ``skills``.
 
-    Returns the composer's text reply. Constraint failures bubble up as
-    :class:`WorkflowConstraintError`; the caller is responsible for
-    mapping them to a Discord soft error.
+    Returns:
+        The composer's text reply. Callers map this directly into a
+        Discord message body.
+
+    Raises:
+        WorkflowConstraintError: a declared constraint refused the run
+            (missing required input, wrong phase, unknown MCP tool).
+            Callers map these to a Discord soft error rather than
+            crashing the bot.
+        WorkflowStepError: the walker aborted mid-walk because a step
+            failed — either its interpolation references an
+            unresolvable upstream step or its MCP tool call raised.
+            The error names the failing step + tool + workflow and
+            chains the original exception via ``__cause__``.
     """
     from crawdad.history import ConversationHistory
 

--- a/crawdad/crawdad/workflows.py
+++ b/crawdad/crawdad/workflows.py
@@ -51,10 +51,23 @@ Step ``args`` strings may reference three namespaces inside ``{{...}}``::
     {{state.phase}}        -> phase slug extracted from latest.md (or "")
     {{state.wavelength}}   -> raw wavelength snapshot text (or "")
     {{input.<key>}}        -> caller-supplied input value (or "")
-    {{step.<id>.body}}     -> previous step's tool-result body (or "")
+    {{step.<id>.body}}     -> previous step's tool-result body (REQUIRED)
 
-Unknown namespaces are left in place verbatim — that surfaces a typo
-to the workflow author instead of silently swallowing it.
+``state`` and ``input`` references resolve to empty string when the
+referent is missing — both are best-effort context and the workflow's
+declared ``inputs:`` list / ``phase_aware`` flag already constrain
+required values up front.
+
+``step`` references are STRICT (Phase 2 / #326): a reference to an
+unknown step id, a missing field, or any field other than ``body``
+raises :class:`WorkflowStepError`. A step reference always pins a real
+upstream output, so an unresolvable one is an authoring bug worth
+failing loudly on.
+
+Unknown top-level namespaces (anything other than ``state`` / ``input``
+/ ``step``) are left in place verbatim — that surfaces a typo
+like ``{{statee.phase}}`` to the workflow author instead of silently
+swallowing it.
 """
 
 from __future__ import annotations
@@ -125,6 +138,35 @@ class WorkflowConstraintError(RuntimeError):
 
 class WorkflowNotFoundError(RuntimeError):
     """No workflow with the requested name was found in the registry."""
+
+
+class WorkflowStepError(RuntimeError):
+    """A step failed mid-run — either interpolation or the MCP tool call.
+
+    Raised by the walker so callers (the slash command surface, the
+    high-level runner, log analysers) can identify *which* step in
+    *which* workflow blew up without scraping the message string. The
+    underlying exception is preserved via ``__cause__``.
+
+    Attributes:
+        step_id: The ``id`` of the failing step.
+        tool: The MCP tool name the step was about to call.
+        workflow_name: The name of the workflow whose walk aborted.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        step_id: str,
+        tool: str,
+        workflow_name: str,
+    ) -> None:
+        """Record the message + structured metadata for the failing step."""
+        super().__init__(message)
+        self.step_id = step_id
+        self.tool = tool
+        self.workflow_name = workflow_name
 
 
 # ---------------------------------------------------------------------------
@@ -346,16 +388,42 @@ def _resolve_input(parts: list[str], inputs: dict[str, str]) -> str:
 
 
 def _resolve_step(parts: list[str], step_results: dict[str, ToolResult]) -> str:
-    """Resolve ``step.<id>.<field>`` references. Missing ids → empty string."""
+    """Resolve ``step.<id>.<field>`` references; raise on any miss.
+
+    Phase 2 (#326): step references are strict. A forward reference to
+    a step that has not run yet, a bare ``{{step.<id>}}`` with no
+    field, or any field other than ``body`` raises
+    :class:`WorkflowStepError`. The walker catches the error to attach
+    workflow + offending-step metadata before re-raising.
+    """
+    if not parts:
+        msg = "step reference {{step}} is missing both id and field"
+        raise WorkflowStepError(msg, step_id="", tool="", workflow_name="")
     if len(parts) < 2:
-        return ""
+        step_id = parts[0]
+        msg = (
+            f"step reference {{step.{step_id}}} is missing a field; "
+            "the only addressable field today is `body` "
+            "(e.g. {{step." + step_id + ".body}})"
+        )
+        raise WorkflowStepError(msg, step_id="", tool="", workflow_name="")
     step_id, field = parts[0], parts[1]
     result = step_results.get(step_id)
     if result is None:
-        return ""
-    if field == "body":
-        return result.body
-    return ""
+        available = sorted(step_results) or ["(none yet)"]
+        msg = (
+            f"step reference {{step.{step_id}.{field}}} points at an "
+            f"upstream step that has not run yet; available step ids: "
+            f"{available}"
+        )
+        raise WorkflowStepError(msg, step_id="", tool="", workflow_name="")
+    if field != "body":
+        msg = (
+            f"step reference {{step.{step_id}.{field}}} uses unknown "
+            "field; the only addressable field today is `body`"
+        )
+        raise WorkflowStepError(msg, step_id="", tool="", workflow_name="")
+    return result.body
 
 
 # ---------------------------------------------------------------------------
@@ -493,6 +561,10 @@ class WorkflowWalker:
         Raises:
             WorkflowConstraintError: a declared constraint refused the
                 run — missing input, wrong phase, unknown tool, etc.
+            WorkflowStepError: a step failed mid-walk — either its
+                ``args`` reference an unresolvable upstream step or
+                its MCP tool call raised. The error names the failing
+                step + tool and chains the original exception.
         """
         self._check_constraints(workflow, state=state, inputs=inputs)
         async with self._mcp_client.connect() as session:
@@ -553,10 +625,42 @@ class WorkflowWalker:
         state: SessionState | None,
         inputs: dict[str, str],
     ) -> list[ToolResult]:
-        """Walk each step in order, threading prior results into later args."""
+        """Walk each step in order, threading prior results into later args.
+
+        Phase 2 (#326): each step is wrapped in a single ``try/except``
+        so an interpolation error OR an MCP tool failure aborts the
+        workflow with a :class:`WorkflowStepError` that names the
+        workflow, the failing step's id, and the tool that was about
+        to be invoked. The original exception is preserved as the
+        cause.
+        """
         step_results: dict[str, ToolResult] = {}
         ordered: list[ToolResult] = []
         for step in workflow.steps:
+            result = await self._execute_one_step(
+                step,
+                workflow=workflow,
+                session=session,
+                state=state,
+                inputs=inputs,
+                step_results=step_results,
+            )
+            step_results[step.id] = result
+            ordered.append(result)
+        return ordered
+
+    async def _execute_one_step(
+        self,
+        step: WorkflowStep,
+        *,
+        workflow: WorkflowDefinition,
+        session: Any,
+        state: SessionState | None,
+        inputs: dict[str, str],
+        step_results: dict[str, ToolResult],
+    ) -> ToolResult:
+        """Resolve args, call the MCP tool, and wrap any failure with metadata."""
+        try:
             resolved_args = interpolate(
                 step.args, state=state, inputs=inputs, step_results=step_results
             )
@@ -564,14 +668,61 @@ class WorkflowWalker:
                 resolved_args, workflow.privacy_tier_floor
             )
             body = await session.call_tool(step.tool, arguments)
-            result = ToolResult(
-                intent_type=step.tool,
-                body=body,
-                privacy_tier_ceiling=workflow.privacy_tier_floor,
-            )
-            step_results[step.id] = result
-            ordered.append(result)
-        return ordered
+        except WorkflowStepError as exc:
+            raise _rebrand_step_error(exc, workflow=workflow, step=step) from exc
+        except Exception as exc:
+            raise _wrap_step_failure(exc, workflow=workflow, step=step) from exc
+        return ToolResult(
+            intent_type=step.tool,
+            body=body,
+            privacy_tier_ceiling=workflow.privacy_tier_floor,
+        )
+
+
+def _rebrand_step_error(
+    exc: WorkflowStepError,
+    *,
+    workflow: WorkflowDefinition,
+    step: WorkflowStep,
+) -> WorkflowStepError:
+    """Attach workflow + step metadata to an interpolation-time step error.
+
+    ``_resolve_step`` raises :class:`WorkflowStepError` without knowing
+    which workflow or step it is being called from — the walker has
+    that context, so it re-raises here with the metadata filled in and
+    the original (anonymous) message prefixed by the step location.
+    """
+    location = f"workflow {workflow.name!r} step {step.id!r} (tool {step.tool!r})"
+    return WorkflowStepError(
+        f"{location} aborted during arg interpolation: {exc}",
+        step_id=step.id,
+        tool=step.tool,
+        workflow_name=workflow.name,
+    )
+
+
+def _wrap_step_failure(
+    exc: BaseException,
+    *,
+    workflow: WorkflowDefinition,
+    step: WorkflowStep,
+) -> WorkflowStepError:
+    """Wrap an MCP tool failure so the operator can find the offending step.
+
+    The walker invokes one MCP tool per step; when that tool raises
+    (e.g. an :class:`crawdad.mcp_client.MCPUnavailableError`, a network
+    blip, a bad arg type), we re-raise as :class:`WorkflowStepError`
+    with the workflow name + step id + tool name baked into the
+    message and exposed as attributes. The original exception is
+    chained via ``__cause__`` for introspection.
+    """
+    location = f"workflow {workflow.name!r} step {step.id!r} (tool {step.tool!r})"
+    return WorkflowStepError(
+        f"{location} failed: {exc}",
+        step_id=step.id,
+        tool=step.tool,
+        workflow_name=workflow.name,
+    )
 
 
 def _build_call_arguments(

--- a/crawdad/tests/test_workflows.py
+++ b/crawdad/tests/test_workflows.py
@@ -30,6 +30,7 @@ from crawdad.workflows import (
     WorkflowParseError,
     WorkflowRegistry,
     WorkflowStep,
+    WorkflowStepError,
     WorkflowWalker,
     _synthesize_user_message,
     interpolate,
@@ -278,15 +279,20 @@ def test_interpolate_step_body() -> None:
     assert out == "previous: phase: rising"
 
 
-def test_interpolate_step_unknown_yields_empty() -> None:
-    """A reference to an unknown step id resolves to empty string."""
-    out = interpolate(
-        "nothing here: [{{step.missing.body}}]",
-        state=None,
-        inputs={},
-        step_results={},
-    )
-    assert out == "nothing here: []"
+def test_interpolate_step_unknown_id_raises_step_error() -> None:
+    """A reference to an unknown step id is a workflow bug — surface it loudly.
+
+    Phase 2 (#326) tightens this from the Phase 1 stub's empty-string
+    fallback: a step reference always pins a real upstream output, so a
+    forward / typo'd reference is an authoring error worth failing on.
+    """
+    with pytest.raises(WorkflowStepError, match=r"step\.missing"):
+        interpolate(
+            "nothing here: [{{step.missing.body}}]",
+            state=None,
+            inputs={},
+            step_results={},
+        )
 
 
 def test_interpolate_unknown_namespace_passes_through() -> None:
@@ -398,26 +404,46 @@ def test_interpolate_input_namespace_with_no_field_yields_empty() -> None:
     assert out == "[]"
 
 
-def test_interpolate_step_with_no_field_yields_empty() -> None:
-    """A ``{{step.<id>}}`` reference without a field resolves to empty string."""
-    out = interpolate(
-        "[{{step.read}}]",
-        state=None,
-        inputs={},
-        step_results={"read": ToolResult(intent_type="x", body="b")},
-    )
-    assert out == "[]"
+def test_interpolate_bare_step_namespace_raises_step_error() -> None:
+    """``{{step}}`` with no id at all is also a malformed reference."""
+    with pytest.raises(WorkflowStepError, match="step"):
+        interpolate(
+            "[{{step}}]",
+            state=None,
+            inputs={},
+            step_results={},
+        )
 
 
-def test_interpolate_step_with_unknown_field_yields_empty() -> None:
-    """``{{step.<id>.bogus}}`` (not ``body``) resolves to empty string."""
-    out = interpolate(
-        "[{{step.read.bogus}}]",
-        state=None,
-        inputs={},
-        step_results={"read": ToolResult(intent_type="x", body="b")},
-    )
-    assert out == "[]"
+def test_interpolate_step_with_no_field_raises_step_error() -> None:
+    """``{{step.<id>}}`` with no trailing field is a malformed reference.
+
+    Phase 2 (#326): the only valid step accessor today is ``.body``, so
+    omitting the field is an authoring bug; we surface it instead of
+    silently resolving to empty.
+    """
+    with pytest.raises(WorkflowStepError, match=r"step\.read"):
+        interpolate(
+            "[{{step.read}}]",
+            state=None,
+            inputs={},
+            step_results={"read": ToolResult(intent_type="x", body="b")},
+        )
+
+
+def test_interpolate_step_with_unknown_field_raises_step_error() -> None:
+    """``{{step.<id>.bogus}}`` (not ``body``) is a malformed reference.
+
+    Phase 2 (#326): the walker only exposes ``body`` on a step result;
+    any other field is a typo and must fail loudly.
+    """
+    with pytest.raises(WorkflowStepError, match="bogus"):
+        interpolate(
+            "[{{step.read.bogus}}]",
+            state=None,
+            inputs={},
+            step_results={"read": ToolResult(intent_type="x", body="b")},
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -717,6 +743,152 @@ async def test_walker_supplies_required_input() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Walker — error propagation (ADAPT-003 Phase 2 / #326)
+# ---------------------------------------------------------------------------
+
+
+class _FailingSession:
+    """An :class:`MCPSession`-shaped fake that fails on a specific tool name."""
+
+    def __init__(self, failing_tool: str, *, error: Exception) -> None:
+        """Configure which tool name raises and what exception to raise."""
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self._failing_tool = failing_tool
+        self._error = error
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any] | None = None
+    ) -> str:
+        """Record the call; raise the canned exception when *name* matches."""
+        self.calls.append((name, arguments or {}))
+        if name == self._failing_tool:
+            raise self._error
+        return ""
+
+
+async def test_walker_aborts_when_step_references_missing_upstream_step() -> None:
+    """A reference to a step id that has not run yet halts the walker loudly.
+
+    Phase 2 acceptance: a forward / typo'd ``{{step.<id>.body}}`` is an
+    authoring error. The walker raises :class:`WorkflowStepError` naming
+    the offending step so the operator can locate the typo.
+    """
+    wf = WorkflowDefinition(
+        name="bad-ref",
+        description="references a step that does not exist",
+        steps=(
+            WorkflowStep(
+                id="mine",
+                tool="creek.mine",
+                args={"echo": "{{step.notthere.body}}"},
+            ),
+        ),
+    )
+    session = _FakeSession()
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(session),
+        known_tools=("creek.mine",),
+    )
+
+    with pytest.raises(WorkflowStepError, match="mine") as excinfo:
+        await walker.run(wf, state=None, inputs={})
+
+    # The error message names BOTH the failing step id (so the operator
+    # can find it in the workflow file) AND the missing upstream id (so
+    # they know what to fix).
+    assert "notthere" in str(excinfo.value)
+    # The tool was never invoked — interpolation failed first.
+    assert session.calls == []
+
+
+async def test_walker_aborts_when_step_references_unknown_field() -> None:
+    """``{{step.<id>.bogus}}`` halts the walker with a clear error.
+
+    Only ``.body`` is exposed on a step result today; any other field is
+    a typo worth failing loudly on.
+    """
+    wf = WorkflowDefinition(
+        name="bad-field",
+        description="references a field that does not exist",
+        steps=(
+            WorkflowStep(id="read", tool="creek.state.read"),
+            WorkflowStep(
+                id="mine",
+                tool="creek.mine",
+                args={"echo": "{{step.read.bogus}}"},
+            ),
+        ),
+    )
+    session = _FakeSession(responses={"creek.state.read": "ok"})
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(session),
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+
+    with pytest.raises(WorkflowStepError, match="mine") as excinfo:
+        await walker.run(wf, state=None, inputs={})
+
+    assert "bogus" in str(excinfo.value)
+    # The first step ran successfully; the second step never reached
+    # the tool call because interpolation failed.
+    assert [name for name, _ in session.calls] == ["creek.state.read"]
+
+
+async def test_walker_aborts_on_mcp_tool_failure_mid_workflow() -> None:
+    """If an MCP tool raises mid-workflow, the walker halts and names the step.
+
+    The second step's ``creek.mine`` call fails — the walker must
+    surface that with a :class:`WorkflowStepError` naming the failing
+    step (``mine``) and embedding the upstream error message.
+    """
+    failing = _FailingSession(
+        "creek.mine", error=RuntimeError("mcp boom: tool exploded")
+    )
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(failing),  # type: ignore[arg-type]
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+
+    with pytest.raises(WorkflowStepError, match="mine") as excinfo:
+        await walker.run(_simple_workflow(), state=None, inputs={})
+
+    message = str(excinfo.value)
+    assert "creek.mine" in message
+    assert "mcp boom" in message
+    # The original exception is preserved as the chained cause so
+    # callers can introspect it (or surface the original type).
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    # The first step succeeded; the second step ran (failed) and the
+    # third step was never attempted.
+    assert [name for name, _ in failing.calls] == [
+        "creek.state.read",
+        "creek.mine",
+    ]
+
+
+async def test_walker_step_error_carries_step_and_tool_metadata() -> None:
+    """``WorkflowStepError`` exposes step id, tool name, and workflow name as attrs.
+
+    A structured error is more useful to callers than message-only
+    surfacing — the slash command may want to format the step id
+    differently, and tests/log analysers can pin on attributes rather
+    than scraping the message string.
+    """
+    failing = _FailingSession("creek.mine", error=ValueError("nope"))
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(failing),  # type: ignore[arg-type]
+        known_tools=("creek.state.read", "creek.mine"),
+    )
+
+    with pytest.raises(WorkflowStepError) as excinfo:
+        await walker.run(_simple_workflow(), state=None, inputs={})
+
+    assert excinfo.value.step_id == "mine"
+    assert excinfo.value.tool == "creek.mine"
+    assert excinfo.value.workflow_name == "test-flow"
+
+
+# ---------------------------------------------------------------------------
 # Reference workflows
 # ---------------------------------------------------------------------------
 
@@ -786,6 +958,82 @@ async def test_compost_surfacing_refuses_when_session_state_unavailable() -> Non
 
     with pytest.raises(WorkflowConstraintError, match="phase-aware"):
         await walker.run(wf, state=None, inputs={})
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: all reference workflows run against a mocked MCP client (#326)
+# ---------------------------------------------------------------------------
+
+
+# Canned responses for every MCP tool any reference workflow calls. The
+# values are placeholders — the e2e test asserts on the call sequence
+# (the wiring contract) not on the body text (which the composer owns).
+_REFERENCE_TOOL_RESPONSES: dict[str, str] = {
+    "creek.state.read": (
+        "## Wavelength snapshot\n- Phase: **rising** (confidence 0.84)\n"
+    ),
+    "creek.mine": "[]",
+    "creek.draft": "draft body",
+}
+
+
+@pytest.mark.parametrize(
+    ("workflow_filename", "expected_calls"),
+    [
+        (
+            "wavelength-checkin.workflow.yaml",
+            ["creek.state.read"],
+        ),
+        (
+            "compost-surfacing.workflow.yaml",
+            ["creek.state.read", "creek.mine"],
+        ),
+        (
+            "substack-draft-phase-transitions.workflow.yaml",
+            ["creek.state.read", "creek.mine", "creek.draft"],
+        ),
+    ],
+    ids=["wavelength-checkin", "compost-surfacing", "substack-draft"],
+)
+async def test_reference_workflows_walk_end_to_end_against_mocked_mcp(
+    workflow_filename: str,
+    expected_calls: list[str],
+    vault_with_state: Path,
+) -> None:
+    """Every shipped reference workflow walks to completion on a mocked MCP.
+
+    The mocked MCP client is the integration boundary called out in
+    issue #326's e2e recipe: we never spawn a real subprocess but we
+    DO exercise the full walker → tool dispatch → result chain →
+    constraint enforcement path for every step the reference workflow
+    declares. The phase-aware workflows are run with the populated
+    ``vault_with_state`` fixture so the ``state.phase`` interpolation
+    has a real ``rising`` slug to substitute.
+    """
+    from crawdad.state import load_session_state
+
+    path = BUILTIN_WORKFLOWS_DIR / workflow_filename
+    wf = load_workflow_from_yaml(path)
+    state = load_session_state(vault_with_state)
+    session = _FakeSession(responses=dict(_REFERENCE_TOOL_RESPONSES))
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(session),
+        known_tools=tuple(_REFERENCE_TOOL_RESPONSES),
+    )
+
+    results = await walker.run(wf, state=state, inputs={})
+
+    # Every declared step ran and yielded a ToolResult, in document order.
+    assert [name for name, _ in session.calls] == expected_calls
+    assert [r.intent_type for r in results] == expected_calls
+    # Phase-aware workflows must have had ``{{state.phase}}`` resolved
+    # against the live session (not left as a literal placeholder).
+    for _name, args in session.calls:
+        for value in args.values():
+            if isinstance(value, str):
+                assert "{{" not in value, (
+                    f"unresolved placeholder leaked into MCP call args: {args!r}"
+                )
 
 
 # ---------------------------------------------------------------------------

--- a/crawdad/tests/test_workflows.py
+++ b/crawdad/tests/test_workflows.py
@@ -32,6 +32,7 @@ from crawdad.workflows import (
     WorkflowStep,
     WorkflowStepError,
     WorkflowWalker,
+    _StepRefError,
     _synthesize_user_message,
     interpolate,
     load_workflow_from_yaml,
@@ -279,14 +280,20 @@ def test_interpolate_step_body() -> None:
     assert out == "previous: phase: rising"
 
 
-def test_interpolate_step_unknown_id_raises_step_error() -> None:
+def test_interpolate_step_unknown_id_raises_step_ref_error() -> None:
     """A reference to an unknown step id is a workflow bug — surface it loudly.
 
     Phase 2 (#326) tightens this from the Phase 1 stub's empty-string
     fallback: a step reference always pins a real upstream output, so a
     forward / typo'd reference is an authoring error worth failing on.
+
+    At the interpolation layer the public :class:`WorkflowStepError`
+    cannot be raised with valid metadata (interpolation has no workflow
+    or step context), so the private :class:`_StepRefError` is raised
+    and the walker rebrands it into a :class:`WorkflowStepError` with
+    full metadata before bubbling up.
     """
-    with pytest.raises(WorkflowStepError, match=r"step\.missing"):
+    with pytest.raises(_StepRefError, match=r"step\.missing"):
         interpolate(
             "nothing here: [{{step.missing.body}}]",
             state=None,
@@ -404,9 +411,9 @@ def test_interpolate_input_namespace_with_no_field_yields_empty() -> None:
     assert out == "[]"
 
 
-def test_interpolate_bare_step_namespace_raises_step_error() -> None:
+def test_interpolate_bare_step_namespace_raises_step_ref_error() -> None:
     """``{{step}}`` with no id at all is also a malformed reference."""
-    with pytest.raises(WorkflowStepError, match="step"):
+    with pytest.raises(_StepRefError, match="step"):
         interpolate(
             "[{{step}}]",
             state=None,
@@ -415,14 +422,14 @@ def test_interpolate_bare_step_namespace_raises_step_error() -> None:
         )
 
 
-def test_interpolate_step_with_no_field_raises_step_error() -> None:
+def test_interpolate_step_with_no_field_raises_step_ref_error() -> None:
     """``{{step.<id>}}`` with no trailing field is a malformed reference.
 
     Phase 2 (#326): the only valid step accessor today is ``.body``, so
     omitting the field is an authoring bug; we surface it instead of
     silently resolving to empty.
     """
-    with pytest.raises(WorkflowStepError, match=r"step\.read"):
+    with pytest.raises(_StepRefError, match=r"step\.read"):
         interpolate(
             "[{{step.read}}]",
             state=None,
@@ -431,19 +438,43 @@ def test_interpolate_step_with_no_field_raises_step_error() -> None:
         )
 
 
-def test_interpolate_step_with_unknown_field_raises_step_error() -> None:
+def test_interpolate_step_with_unknown_field_raises_step_ref_error() -> None:
     """``{{step.<id>.bogus}}`` (not ``body``) is a malformed reference.
 
     Phase 2 (#326): the walker only exposes ``body`` on a step result;
     any other field is a typo and must fail loudly.
     """
-    with pytest.raises(WorkflowStepError, match="bogus"):
+    with pytest.raises(_StepRefError, match="bogus"):
         interpolate(
             "[{{step.read.bogus}}]",
             state=None,
             inputs={},
             step_results={"read": ToolResult(intent_type="x", body="b")},
         )
+
+
+def test_step_ref_error_is_value_error_subclass() -> None:
+    """``_StepRefError`` is a :class:`ValueError` so callers can catch broadly.
+
+    Promised by the docstring: this is a private exception type, raised
+    only by :func:`_resolve_step` and rebranded by the walker into a
+    :class:`WorkflowStepError`. Inheriting from :class:`ValueError`
+    keeps it discoverable to any caller that was already handling
+    interpolation errors with a broad ``except ValueError`` clause.
+    """
+    assert issubclass(_StepRefError, ValueError)
+
+
+def test_step_ref_error_is_not_workflow_step_error() -> None:
+    """``_StepRefError`` and :class:`WorkflowStepError` are distinct types.
+
+    The boundary matters: :class:`WorkflowStepError` always carries
+    structured ``step_id`` / ``tool`` / ``workflow_name`` attributes;
+    :class:`_StepRefError` is the marker for the interpolation layer
+    that has none of that context yet.
+    """
+    assert not issubclass(_StepRefError, WorkflowStepError)
+    assert not issubclass(WorkflowStepError, _StepRefError)
 
 
 # ---------------------------------------------------------------------------
@@ -584,9 +615,17 @@ class _FakeSession:
 
 
 class _FakeMCPClient:
-    """An :class:`MCPClient`-shaped fake that yields :class:`_FakeSession`."""
+    """An :class:`MCPClient`-shaped fake that yields a session.
 
-    def __init__(self, session: _FakeSession) -> None:
+    The session is typed as :class:`typing.Any` so the same fake client
+    can wrap either a :class:`_FakeSession` (happy path) or a
+    :class:`_FailingSession` (error-path tests) without a ``# type:
+    ignore[arg-type]`` at every call site. Both fakes implement the
+    same ``call_tool`` shape; the walker only ever invokes that one
+    method.
+    """
+
+    def __init__(self, session: Any) -> None:
         """Stash the session that ``connect()`` will yield."""
         self._session = session
 
@@ -799,6 +838,48 @@ async def test_walker_aborts_when_step_references_missing_upstream_step() -> Non
     assert "notthere" in str(excinfo.value)
     # The tool was never invoked — interpolation failed first.
     assert session.calls == []
+    # The rebranded walker error preserves the original interpolation
+    # error as ``__cause__`` so log analysers and tests can pin on the
+    # interpolation-layer marker without scraping the message string.
+    assert isinstance(excinfo.value.__cause__, _StepRefError)
+
+
+async def test_walker_rebrands_interpolation_error_with_full_metadata() -> None:
+    """A `_StepRefError` is rebranded into a fully-populated WorkflowStepError.
+
+    The reviewer's blocker fix: the public :class:`WorkflowStepError`
+    must NEVER be raised with empty ``step_id`` / ``tool`` /
+    ``workflow_name`` attributes. When interpolation raises
+    :class:`_StepRefError`, the walker catches it and re-raises with
+    the workflow's name and the failing step's id + tool baked in.
+    """
+    wf = WorkflowDefinition(
+        name="rebrand-flow",
+        description="missing upstream reference triggers rebrand",
+        steps=(
+            WorkflowStep(
+                id="mine",
+                tool="creek.mine",
+                args={"echo": "{{step.ghost.body}}"},
+            ),
+        ),
+    )
+    walker = WorkflowWalker(
+        mcp_client=_FakeMCPClient(_FakeSession()),
+        known_tools=("creek.mine",),
+    )
+
+    with pytest.raises(WorkflowStepError) as excinfo:
+        await walker.run(wf, state=None, inputs={})
+
+    # All three metadata attributes are populated — never empty strings.
+    assert excinfo.value.step_id == "mine"
+    assert excinfo.value.tool == "creek.mine"
+    assert excinfo.value.workflow_name == "rebrand-flow"
+    # The cause chain preserves the private interpolation-layer marker
+    # so callers can disambiguate "interpolation aborted" from "MCP tool
+    # raised" by inspecting ``__cause__`` instead of the message text.
+    assert isinstance(excinfo.value.__cause__, _StepRefError)
 
 
 async def test_walker_aborts_when_step_references_unknown_field() -> None:
@@ -845,7 +926,7 @@ async def test_walker_aborts_on_mcp_tool_failure_mid_workflow() -> None:
         "creek.mine", error=RuntimeError("mcp boom: tool exploded")
     )
     walker = WorkflowWalker(
-        mcp_client=_FakeMCPClient(failing),  # type: ignore[arg-type]
+        mcp_client=_FakeMCPClient(failing),
         known_tools=("creek.state.read", "creek.mine"),
     )
 
@@ -876,7 +957,7 @@ async def test_walker_step_error_carries_step_and_tool_metadata() -> None:
     """
     failing = _FailingSession("creek.mine", error=ValueError("nope"))
     walker = WorkflowWalker(
-        mcp_client=_FakeMCPClient(failing),  # type: ignore[arg-type]
+        mcp_client=_FakeMCPClient(failing),
         known_tools=("creek.state.read", "creek.mine"),
     )
 


### PR DESCRIPTION
## Summary

Phase 2 of ADAPT-003 (#326): the workflow step walker now propagates failures with clear, structured errors instead of letting interpolation typos silently swallow values and tool failures surface as bare exceptions.

- **Step references are STRICT.** `{{step.<id>.body}}` references now raise `WorkflowStepError` when the upstream step has not run, the field is missing, or the field is anything other than `body`. State/input references stay lenient because the workflow's `inputs:` list and `phase_aware` flag already gate required values up front.
- **Structured step failures.** Each step is wrapped in a single `try/except` so an interpolation error OR an MCP tool failure aborts the workflow with a `WorkflowStepError` exposing `step_id`, `tool`, and `workflow_name` as attributes (plus the original exception via `__cause__`). The CLI and slash-command surface already catch `Exception` and map to a Discord soft-error, so the new error type plugs in without plumbing changes.
- **Tests.** Malformed step references (missing id / missing field / unknown field), missing-upstream forward references, MCP tool failure mid-walk, structured-attribute exposure, and a parametrized e2e walk of all three reference workflows (`wavelength-checkin`, `compost-surfacing`, `substack-draft-phase-transitions`) against a mocked MCP client.

## Test plan

- [x] `./scripts/check-all.sh` exits 0 (lint, format, typecheck strict, bandit, interrogate, xenon, pytest with coverage)
- [x] 390 tests pass (62 in `test_workflows.py`, including new error-propagation and reference-workflow e2e cases)
- [x] Branch coverage: 95.72% total / 98.69% on `crawdad/workflows.py`
- [x] Walker complexity stays under xenon's `B` ceiling (extracted `_execute_one_step` + two helper functions)
- [x] No `# noqa`, `# type: ignore`, or `--no-verify` shortcuts

Closes #326
Unblocks #327 (Phase 3 router intent)

https://claude.ai/code/session_015jFVbqmaYeuDQi8fBetdRo

---
_Generated by [Claude Code](https://claude.ai/code/session_015jFVbqmaYeuDQi8fBetdRo)_