### PR TITLE
fix(ingest): populate authored_at from file mtime in GenericIngestor

### DIFF
--- a/creek-tools/creek/ingest/generic.py
+++ b/creek-tools/creek/ingest/generic.py
@@ -27,6 +27,7 @@ from creek.ingest.base import (
     Ingestor,
     ParsedFragment,
     RawDocument,
+    file_modified_time,
     normalize_encoding,
 )
 
@@ -44,6 +45,30 @@ _BINARY_CHECK_SIZE = 8192
 
 # If more than 10% of bytes are non-text control chars, treat as binary
 _BINARY_CONTROL_THRESHOLD = 0.10
+
+
+def _safe_file_mtime(path: Path) -> datetime | None:
+    """Return *path*'s mtime as a tz-aware datetime, or ``None`` defensively.
+
+    FEAT-031 (issue #335): the GenericIngestor's authored_at extraction
+    chain is filesystem mtime only — the lowest-fidelity honest answer
+    when nothing better is available. Synthetic :class:`RawDocument`
+    instances in tests (or any future caller that passes a path with no
+    file behind it) must not raise; this wrapper swallows
+    ``FileNotFoundError`` / ``OSError`` from :func:`Path.stat` and
+    surfaces ``None`` instead, matching the FEAT-031 contract that
+    ``authored_at`` is optional.
+
+    Args:
+        path: The filesystem path to stat.
+
+    Returns:
+        A tz-aware UTC datetime when the file exists, else ``None``.
+    """
+    try:
+        return file_modified_time(path)
+    except OSError:
+        return None
 
 
 def _is_binary_content(raw_bytes: bytes) -> bool:
@@ -194,6 +219,13 @@ class GenericIngestor(Ingestor):
         Attempts multi-encoding text decoding via ``_try_decode``.
         Binary files and empty files are skipped (return empty list).
 
+        FEAT-031 (issue #335): populates ``metadata['authored_at']``
+        from the file's mtime — the lowest-fidelity honest answer the
+        generic fallback can offer. Defensive against synthetic
+        :class:`RawDocument` instances whose ``path`` does not exist
+        on disk: those produce ``authored_at = None`` rather than
+        raising.
+
         Args:
             raw: The raw document to parse.
 
@@ -213,12 +245,14 @@ class GenericIngestor(Ingestor):
             return []
 
         now = datetime.now(tz=LA_TZ)
+        authored_at = _safe_file_mtime(raw.path)
         return [
             ParsedFragment(
                 content=text,
                 metadata={
                     "file_extension": raw.path.suffix.lower(),
                     "source_type": "generic",
+                    "authored_at": authored_at,
                 },
                 source_path=str(raw.path),
                 timestamp=now,
@@ -249,7 +283,10 @@ class GenericIngestor(Ingestor):
         """Generate YAML frontmatter for an unclaimed file.
 
         Sets ``source.platform`` to ``"unknown"`` and routes to
-        ``01-Fragments/Unsorted/``.
+        ``01-Fragments/Unsorted/``. FEAT-031 (issue #335): emits
+        ``authored_at`` as an ISO string when the parse stage
+        captured the file's mtime; omits the key when the metadata
+        value is missing or ``None`` (honest absence).
 
         Args:
             fragment: The parsed fragment.
@@ -258,7 +295,7 @@ class GenericIngestor(Ingestor):
             A dict of frontmatter key-value pairs.
         """
         title = Path(fragment.source_path).stem
-        return {
+        frontmatter_dict: dict[str, Any] = {
             "type": "fragment",
             "title": title,
             "source": {
@@ -268,3 +305,7 @@ class GenericIngestor(Ingestor):
             "created": fragment.timestamp.isoformat(),
             "routing": "01-Fragments/Unsorted/",
         }
+        authored_at: datetime | None = fragment.metadata.get("authored_at")
+        if authored_at is not None:
+            frontmatter_dict["authored_at"] = authored_at.isoformat()
+        return frontmatter_dict

--- a/creek-tools/tests/test_ingest_generic.py
+++ b/creek-tools/tests/test_ingest_generic.py
@@ -7,7 +7,8 @@ and frontmatter generation with ``source.platform: "unknown"``.
 
 from __future__ import annotations
 
-from datetime import datetime
+import os
+from datetime import UTC, datetime
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -453,3 +454,110 @@ class TestGenericIngestorIngest:
         )
         markdown = ingestor.convert_to_markdown(fragment)
         assert markdown.startswith("```\n")
+
+
+# ---- GenericIngestor authored_at Tests (FEAT-031 follow-up, issue #335) ----
+
+
+class TestGenericIngestorAuthoredAt:
+    """Tests for ``authored_at`` extraction from filesystem mtime.
+
+    FEAT-031 mandates that every concrete ingestor populates an
+    ``authored_at`` extraction chain. For ``GenericIngestor`` the
+    chain is intentionally the lowest-fidelity one possible —
+    filesystem mtime via :func:`creek.ingest.base.file_modified_time`
+    — so the unknown-platform fallback no longer emits a
+    perpetually-null ``authored_at`` when the file's mtime is a
+    perfectly valid honest answer.
+    """
+
+    def test_parse_sets_authored_at_to_file_mtime(
+        self, ingestor: GenericIngestor, tmp_path: Path
+    ) -> None:
+        """parse() populates ``metadata['authored_at']`` from the file mtime."""
+        file_path = tmp_path / "note.txt"
+        file_path.write_text("hello", encoding="utf-8")
+        # Pin to a deterministic moment in 2024 (UTC epoch seconds).
+        target = datetime(2024, 3, 15, 14, 30, 0, tzinfo=UTC)
+        epoch = target.timestamp()
+        os.utime(file_path, (epoch, epoch))
+
+        raw = RawDocument(
+            path=file_path,
+            content=file_path.read_bytes(),
+            metadata={"source_type": "generic"},
+            detected_encoding="utf-8",
+        )
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 1
+        authored_at = fragments[0].metadata["authored_at"]
+        assert isinstance(authored_at, datetime)
+        assert authored_at.tzinfo is not None
+        # Compare as UTC to avoid LA wall-clock drift assertions.
+        assert authored_at.astimezone(UTC) == target
+
+    def test_parse_returns_none_authored_at_for_nonexistent_path(
+        self, ingestor: GenericIngestor
+    ) -> None:
+        """Synthetic RawDocument with a non-existent path surfaces ``None``.
+
+        Tests with ``RawDocument(path=Path('/fake/...'))`` should not
+        raise just because there's no real file behind the path —
+        ``parse()`` must defensively land ``authored_at`` as ``None``
+        when ``stat()`` would fail.
+        """
+        raw = RawDocument(
+            path=Path("/nonexistent/synthetic/note.txt"),
+            content=b"some text",
+            metadata={"source_type": "generic"},
+            detected_encoding="utf-8",
+        )
+        fragments = ingestor.parse(raw)
+        assert len(fragments) == 1
+        assert fragments[0].metadata["authored_at"] is None
+
+    def test_generate_frontmatter_emits_authored_at_iso_when_present(
+        self, ingestor: GenericIngestor
+    ) -> None:
+        """Frontmatter includes ``authored_at`` as an ISO string when set."""
+        authored = datetime(2024, 3, 15, 14, 30, 0, tzinfo=UTC)
+        fragment = ParsedFragment(
+            content="content",
+            metadata={
+                "file_extension": ".txt",
+                "authored_at": authored,
+            },
+            source_path="/fake/note.txt",
+            timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ),
+        )
+        fm = ingestor.generate_frontmatter(fragment)
+        assert fm["authored_at"] == authored.isoformat()
+
+    def test_generate_frontmatter_omits_authored_at_when_none(
+        self, ingestor: GenericIngestor
+    ) -> None:
+        """Frontmatter omits ``authored_at`` when the metadata value is ``None``."""
+        fragment = ParsedFragment(
+            content="content",
+            metadata={
+                "file_extension": ".txt",
+                "authored_at": None,
+            },
+            source_path="/fake/note.txt",
+            timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ),
+        )
+        fm = ingestor.generate_frontmatter(fragment)
+        assert "authored_at" not in fm
+
+    def test_generate_frontmatter_omits_authored_at_when_missing(
+        self, ingestor: GenericIngestor
+    ) -> None:
+        """Frontmatter omits ``authored_at`` when the metadata key is absent."""
+        fragment = ParsedFragment(
+            content="content",
+            metadata={"file_extension": ".txt"},
+            source_path="/fake/note.txt",
+            timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ),
+        )
+        fm = ingestor.generate_frontmatter(fragment)
+        assert "authored_at" not in fm


### PR DESCRIPTION
## Summary

- FEAT-031 (#263) mandated a per-ingestor `authored_at` extraction chain for every concrete ingestor; the canonical implementation in PR #311 covered the others but left `GenericIngestor` on perpetually-null `authored_at`, even when the file's mtime is a perfectly valid honest answer.
- `GenericIngestor.parse()` now populates `metadata["authored_at"]` from the file mtime via `creek.ingest.base.file_modified_time`, defensively returning `None` when the path does not exist (synthetic `RawDocument` in tests).
- `generate_frontmatter()` emits the ISO string when the metadata key is non-None and omits it otherwise, matching the FEAT-031 honest-absence contract.

## Test plan

- [x] New `TestGenericIngestorAuthoredAt` class in `tests/test_ingest_generic.py` covers:
  - `parse()` sets `metadata["authored_at"]` to the file's mtime (deterministic via `os.utime`).
  - `parse()` returns `None` for synthetic `RawDocument` with a non-existent path.
  - `generate_frontmatter()` emits the ISO string when present, omits when `None`, and omits when the key is absent entirely.
- [x] Full `./scripts/check-all.sh` passes locally (all 12 gates green, 4120 tests passed, 93.74% coverage).

Closes #335

---
_Generated by [Claude Code](https://claude.ai/code/session_015jFVbqmaYeuDQi8fBetdRo)_