### PR TITLE
fix(link,generate): route remaining time-buckets through effective_authored_at (FEAT-031)

### DIFF
--- a/creek-tools/creek/generate/compost.py
+++ b/creek-tools/creek/generate/compost.py
@@ -33,6 +33,7 @@ from creek.models import (
     Thread,
     ThreadStatus,
 )
+from creek.time import effective_authored_at
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -410,7 +411,10 @@ class CompostTracker:
         """Return a project candidate for *tag*, or ``None`` if still active."""
         if len(frags) < self.project_min_fragments:
             return None
-        last_seen = max(frag.created for frag in frags)
+        # FEAT-031: measure silence against the authored-date precedence
+        # so a project whose fragments were merely *ingested* recently
+        # but authored long ago is still recognised as silent.
+        last_seen = max(effective_authored_at(frag) for frag in frags)
         if last_seen >= cutoff:
             return None
         days = (self._now - last_seen).days

--- a/creek-tools/creek/generate/synchronicity.py
+++ b/creek-tools/creek/generate/synchronicity.py
@@ -11,7 +11,10 @@ The criteria are deliberately strict:
 
 1. Semantic similarity strictly greater than 0.9.
 2. The two fragments come from *different* source platforms.
-3. Their creation timestamps are separated by more than 30 days.
+3. Their authored timestamps are separated by more than 30 days
+   (FEAT-031: routed through :func:`creek.time.effective_authored_at`
+   so a multi-year corpus ingested in one batch still surfaces
+   cross-year pairs).
 4. The pair is not obviously about the same project/task (status-update
    phrases and shared proper-noun project names are filtered out).
 """
@@ -26,6 +29,7 @@ import frontmatter
 
 from creek.link.embeddings import Resonance
 from creek.models import Synchronicity
+from creek.time import effective_authored_at
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -242,7 +246,11 @@ class SynchronicityDetector:
             from_level=from_level,
             to_level=to_level,
         )
-        gap_days = (later.created - earlier.created).days
+        # FEAT-031: gap is measured against the authored-date
+        # precedence so cross-year synchronicities survive batch
+        # ingestion (which would otherwise collapse ``created`` to a
+        # single wall-clock moment and reduce the gap to zero).
+        gap_days = (effective_authored_at(later) - effective_authored_at(earlier)).days
         if gap_days <= self.min_time_gap_days:
             return None
 
@@ -288,7 +296,10 @@ class SynchronicityDetector:
         Returns:
             ``(earlier, later, level_earlier, level_later)``.
         """
-        if frag_a.created <= frag_b.created:
+        # FEAT-031: order by the authored-date precedence so the
+        # "earlier" fragment is the one actually authored first, even
+        # when both share an ingest-time ``created`` wall-clock.
+        if effective_authored_at(frag_a) <= effective_authored_at(frag_b):
             return frag_a, frag_b, from_level, to_level
         return frag_b, frag_a, to_level, from_level
 
@@ -356,13 +367,16 @@ class SynchronicityDetector:
             A markdown string with fragment excerpts, numeric details,
             the reflection prompt, and the ``#synchronicity`` tag.
         """
+        # FEAT-031: render the authored-date precedence so the body
+        # answers "when was this written?" rather than "when did Creek
+        # see it?".
+        date_a = effective_authored_at(frag_a).date().isoformat()
+        date_b = effective_authored_at(frag_b).date().isoformat()
         lines = [
             "## Fragment excerpts",
             "",
-            f"- **{frag_a.source.platform}** ({frag_a.created.date().isoformat()}): "
-            f"{frag_a.title}",
-            f"- **{frag_b.source.platform}** ({frag_b.created.date().isoformat()}): "
-            f"{frag_b.title}",
+            f"- **{frag_a.source.platform}** ({date_a}): {frag_a.title}",
+            f"- **{frag_b.source.platform}** ({date_b}): {frag_b.title}",
             "",
             "## Details",
             "",

--- a/creek-tools/creek/link/eddies.py
+++ b/creek-tools/creek/link/eddies.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING
 from tqdm import tqdm
 
 from creek.models import Eddy
+from creek.time import effective_authored_at, effective_authored_date
 
 if TYPE_CHECKING:
     from datetime import date
@@ -310,17 +311,22 @@ def _spearman_with_time(distances: list[float]) -> float:
 
 
 def _median_date(fragments: list[Fragment]) -> date:
-    """Return the median fragment creation date.
+    """Return the median fragment authored date.
+
+    Uses :func:`creek.time.effective_authored_at` /
+    :func:`creek.time.effective_authored_date` (FEAT-031) so the median
+    reflects when the fragments were *authored* — not the wall-clock
+    moment they were ingested into the vault.
 
     Args:
         fragments: Non-empty list of fragments.
 
     Returns:
-        The median ``created`` date (lower-median for even counts).
+        The median authored date (lower-median for even counts).
     """
-    sorted_frags = sorted(fragments, key=lambda f: f.created)
+    sorted_frags = sorted(fragments, key=effective_authored_at)
     mid = len(sorted_frags) // 2
-    return sorted_frags[mid].created.date()
+    return effective_authored_date(sorted_frags[mid])
 
 
 class EddyDetector:
@@ -554,7 +560,7 @@ class EddyDetector:
                 continue
             cluster_frags = sorted(
                 (frag_by_id[fid] for fid in members),
-                key=lambda f: f.created,
+                key=effective_authored_at,
             )
             if self._has_temporal_direction(cluster_frags):
                 continue

--- a/creek-tools/creek/link/threads.py
+++ b/creek-tools/creek/link/threads.py
@@ -7,6 +7,12 @@ consistent* (semantic similarity above a threshold AND frequency
 agreement) into clusters. Clusters that meet the configured minimum
 fragment count become :class:`~creek.models.Thread` instances.
 
+Time-bucketing routes through :func:`creek.time.effective_authored_at`
+and :func:`creek.time.effective_authored_date` (FEAT-031) so a multi-
+year corpus ingested in one batch produces honest first/last bounds
+and window comparisons — instead of collapsing every fragment to a
+single ingest-time wall-clock.
+
 The module also offers fragment-to-thread assignment (adding wiki-links
 to fragment ``threads`` frontmatter) and a heuristic for suggesting
 thread merges when two threads appear to cover the same topic.
@@ -24,7 +30,7 @@ from typing import TYPE_CHECKING
 from tqdm import tqdm
 
 from creek.models import Frequency, Thread, ThreadStatus
-from creek.time import now_la
+from creek.time import effective_authored_at, effective_authored_date, now_la
 
 if TYPE_CHECKING:
     from creek.models import Fragment
@@ -382,7 +388,7 @@ class ThreadDetector:
             self._thread_members = {}
             return []
 
-        sorted_frags = sorted(fragments, key=lambda f: f.created)
+        sorted_frags = sorted(fragments, key=effective_authored_at)
         frag_by_id = {f.id: f for f in sorted_frags}
         uf = self._cluster(sorted_frags)
         threads = self._materialise_threads(uf, frag_by_id, min_fragments)
@@ -395,7 +401,11 @@ class ThreadDetector:
         """Walk the sliding window, unioning topic-consistent pairs.
 
         Args:
-            sorted_frags: Fragments pre-sorted by ``created`` ascending.
+            sorted_frags: Fragments pre-sorted by
+                :func:`creek.time.effective_authored_at` ascending
+                (FEAT-031). Window comparisons use the same helper so
+                a multi-year corpus ingested in one batch does not
+                collapse into a single window.
 
         Returns:
             A populated :class:`_UnionFind` covering every fragment ID.
@@ -415,8 +425,9 @@ class ThreadDetector:
             disable=not sys.stderr.isatty(),
         )
         for i, frag_a in outer:
+            anchor_at = effective_authored_at(frag_a)
             for frag_b in sorted_frags[i + 1 :]:
-                if frag_b.created - frag_a.created > window:
+                if effective_authored_at(frag_b) - anchor_at > window:
                     break
                 if self._topic_consistent(frag_a, frag_b):
                     uf.union(frag_a.id, frag_b.id)
@@ -446,7 +457,7 @@ class ThreadDetector:
                 continue
             cluster = sorted(
                 (frag_by_id[fid] for fid in member_ids),
-                key=lambda f: f.created,
+                key=effective_authored_at,
             )
             thread = self._build_thread(cluster)
             threads.append(thread)
@@ -507,8 +518,11 @@ class ThreadDetector:
         Returns:
             A populated :class:`~creek.models.Thread`.
         """
-        first_seen = min(f.created for f in frags).date()
-        last_seen = max(f.created for f in frags).date()
+        # FEAT-031: bucket on the authored-date precedence so a multi-
+        # year corpus ingested in one batch surfaces honest first/last
+        # bounds instead of collapsing to today's wall-clock.
+        first_seen = min(effective_authored_date(f) for f in frags)
+        last_seen = max(effective_authored_date(f) for f in frags)
         return Thread(
             title=self._generate_title(frags),
             status=self._compute_status(last_seen),

--- a/creek-tools/tests/test_compost.py
+++ b/creek-tools/tests/test_compost.py
@@ -126,12 +126,21 @@ def _fragment(
     tags: list[str] | None = None,
     privacy_tier: PrivacyTier = PrivacyTier.UNCLASSIFIED,
 ) -> Fragment:
-    """Build a minimal fragment for testing."""
+    """Build a minimal fragment for testing.
+
+    The supplied ``created`` is mirrored into ``ingested`` so the
+    FEAT-031 ``effective_authored_at`` helper — which falls back to
+    ``ingested`` when ``authored_at`` is unset — sees the time the
+    test cares about. Without the mirror, every test fragment would
+    surface at construction-time wall-clock (tz-aware) and silence
+    calculations against a naive ``self._now`` would raise.
+    """
     return Fragment(
         id=frag_id,
         title=title,
         source=FragmentSource(platform=SourcePlatform.JOURNAL),
         created=created,
+        ingested=created,
         frequency=FrequencyClassification(primary=Frequency.F5),
         voice=VoiceClassification(confidence=confidence),
         praxis_potential=praxis_potential,
@@ -494,6 +503,42 @@ class TestDetectCompostCandidates:
         candidates = tracker.detect_compost_candidates([resolved_thread], [frag])
         thread_cand = next(c for c in candidates if c.source_type == "thread")
         assert frag.id in thread_cand.energy_fragment_ids
+
+    def test_project_silence_cutoff_uses_authored_at(
+        self,
+        reference_now: datetime,
+    ) -> None:
+        """FEAT-031: project silence is measured against ``authored_at``.
+
+        All fragments share the same recent ``created`` (they were
+        ingested today, in one batch), but they were *authored* years
+        ago — well past the dormancy threshold. Without FEAT-031 the
+        project would look active and silently escape compost; with the
+        fix the authored history surfaces it as a silent project.
+        """
+        ingest_moment = reference_now - timedelta(hours=1)
+        authored_dates = [
+            datetime(2024, 1, 15, 12, 0, 0),
+            datetime(2024, 2, 10, 12, 0, 0),
+            datetime(2024, 3, 5, 12, 0, 0),
+        ]
+        fragments = [
+            Fragment(
+                id=f"frag-feat031-proj-{i}",
+                title=f"Greenhouse notes {i}",
+                source=FragmentSource(platform=SourcePlatform.JOURNAL),
+                created=ingest_moment,
+                ingested=ingest_moment,
+                authored_at=authored,
+                frequency=FrequencyClassification(primary=Frequency.F5),
+                tags=["greenhouse"],
+            )
+            for i, authored in enumerate(authored_dates)
+        ]
+        tracker = CompostTracker(now=reference_now)
+        candidates = tracker.detect_compost_candidates([], fragments)
+        project_candidates = [c for c in candidates if c.source_type == "project"]
+        assert any(c.source_id == "greenhouse" for c in project_candidates)
 
 
 # ---- CompostTracker.create_compost_note ----

--- a/creek-tools/tests/test_link.py
+++ b/creek-tools/tests/test_link.py
@@ -1102,6 +1102,82 @@ class TestThreadDetector:
         detector.detect_threads([_make_fragment("Solo")])
         assert detector.thread_members == {}
 
+    def test_detect_threads_buckets_by_authored_at_not_created(self) -> None:
+        """FEAT-031: bucketing uses ``authored_at`` when present.
+
+        Three fragments share the same ``created`` (the wall-clock moment
+        Creek ingested them) but carry ``authored_at`` values spread
+        across two years. With a 30-day window, bucketing on ``created``
+        would happily fold them into one thread; bucketing on
+        ``authored_at`` correctly leaves them too far apart to link.
+        """
+        now = datetime(2026, 4, 1)
+        ingest_moment = now - timedelta(hours=1)
+        # All three appear at the same "ingested" wall-clock moment, but
+        # were authored years apart.
+        authored_dates = [
+            datetime(2024, 1, 15, 9, 0, 0),
+            datetime(2025, 2, 10, 9, 0, 0),
+            datetime(2026, 3, 20, 9, 0, 0),
+        ]
+        fragments = [
+            Fragment(
+                id=f"frag-feat031-thr-{i}",
+                title=f"Reading Practice {i}",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=ingest_moment,
+                ingested=ingest_moment,
+                authored_at=authored,
+                frequency=FrequencyClassification(primary=Frequency.F4),
+                wavelength=WavelengthClassification(phase=Phase.UNCLASSIFIED),
+            )
+            for i, authored in enumerate(authored_dates)
+        ]
+        detector = ThreadDetector(now=now, window_days=30)
+        result = detector.detect_threads(fragments)
+        # Spread across years; window is 30 days → no thread forms.
+        assert result == []
+
+    def test_detect_threads_first_last_seen_use_authored_at(self) -> None:
+        """FEAT-031: thread ``first_seen``/``last_seen`` use ``authored_at``.
+
+        Three fragments share the same ingest wall-clock but their
+        ``authored_at`` values span ~20 days, all within the 30-day
+        window so they unite into a single thread. The thread bounds
+        must reflect the authored dates, not the (identical) ingested
+        timestamp.
+        """
+        now = datetime(2026, 4, 1)
+        ingest_moment = now - timedelta(hours=1)
+        # Earliest authored 25 days ago, latest 5 days ago (within window).
+        authored_dates = [
+            now - timedelta(days=25),
+            now - timedelta(days=15),
+            now - timedelta(days=5),
+        ]
+        fragments = [
+            Fragment(
+                id=f"frag-feat031-bounds-{i}",
+                title=f"Reading {i}",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=ingest_moment,
+                ingested=ingest_moment,
+                authored_at=authored,
+                frequency=FrequencyClassification(primary=Frequency.F4),
+                wavelength=WavelengthClassification(phase=Phase.UNCLASSIFIED),
+            )
+            for i, authored in enumerate(authored_dates)
+        ]
+        detector = ThreadDetector(now=now, window_days=30)
+        result = detector.detect_threads(fragments)
+        assert len(result) == 1
+        thread = result[0]
+        # If bucketing used ``created``, both bounds would equal
+        # ingest_moment.date() — i.e. they would be equal. The authored
+        # range must surface explicit min/max separation.
+        assert thread.first_seen == authored_dates[0].date()
+        assert thread.last_seen == authored_dates[-1].date()
+
 
 class TestThreadAssignment:
     """Tests for assign_fragments_to_threads."""
@@ -1284,12 +1360,20 @@ def _eddy_fragment(
     created: datetime,
     threads: list[str] | None = None,
 ) -> Fragment:
-    """Build a Fragment with an explicit ID (needed to match embeddings)."""
+    """Build a Fragment with an explicit ID (needed to match embeddings).
+
+    Mirrors ``created`` into ``ingested`` so the FEAT-031
+    ``effective_authored_at`` helper — which falls back to ``ingested``
+    when ``authored_at`` is unset — sees the time the test cares about.
+    Without the mirror, eddy formation dates would anchor to
+    construction-time wall-clock instead of the configured offsets.
+    """
     return Fragment(
         id=frag_id,
         title=title,
         source=FragmentSource(platform=SourcePlatform.CLAUDE),
         created=created,
+        ingested=created,
         frequency=FrequencyClassification(primary=Frequency.F1),
         wavelength=WavelengthClassification(phase=Phase.UNCLASSIFIED),
         threads=threads or [],
@@ -1617,6 +1701,41 @@ class TestEddyDetector:
         result = detector.detect_eddies(fragments)
         assert len(result) == 1
         assert result[0].title == "!!"
+
+    def test_detect_eddies_formed_uses_authored_at_not_created(self) -> None:
+        """FEAT-031: ``Eddy.formed`` is the median ``authored_at`` date.
+
+        All six fragments share the same ``created`` (single ingest
+        moment) but were authored on widely separated dates. Bucketing
+        on ``created`` would put the formation date at "today"; correct
+        FEAT-031 behaviour anchors it to the median authored date.
+        """
+        now = datetime(2026, 4, 1, 12, 0, 0)
+        ingest_moment = now - timedelta(hours=1)
+        ids = [f"frag-feat031-eddy-{i}" for i in range(5)]
+        # Offsets sorted ascending: 5, 100, 250, 400, 700 days ago.
+        # Median index 2 → 250 days ago = expected ``formed`` date.
+        authored_offsets = [400, 5, 700, 250, 100]
+        fragments = [
+            Fragment(
+                id=fid,
+                title="Voicework Study",
+                source=FragmentSource(platform=SourcePlatform.CLAUDE),
+                created=ingest_moment,
+                ingested=ingest_moment,
+                authored_at=now - timedelta(days=authored_offsets[i]),
+                frequency=FrequencyClassification(primary=Frequency.F1),
+                wavelength=WavelengthClassification(phase=Phase.UNCLASSIFIED),
+            )
+            for i, fid in enumerate(ids)
+        ]
+        detector = EddyDetector(embeddings=_dense_embeddings(ids))
+        result = detector.detect_eddies(fragments)
+        assert len(result) == 1
+        # Without FEAT-031 the median would be ingest_moment.date(); the
+        # correct answer is 250 days before ``now``.
+        assert result[0].formed == (now - timedelta(days=250)).date()
+        assert result[0].formed != ingest_moment.date()
 
 
 class TestEddyAssignment:

--- a/creek-tools/tests/test_synchronicity.py
+++ b/creek-tools/tests/test_synchronicity.py
@@ -54,12 +54,20 @@ def _make_fragment(
     platform: SourcePlatform,
     created: datetime,
 ) -> Fragment:
-    """Construct a test Fragment with the given identifying fields."""
+    """Construct a test Fragment with the given identifying fields.
+
+    Mirrors ``created`` into ``ingested`` so the FEAT-031
+    ``effective_authored_at`` helper — which falls back to ``ingested``
+    when ``authored_at`` is unset — sees the time the test cares about.
+    Without the mirror, time-gap and chronological-pair assertions
+    would collapse to construction-time wall-clock.
+    """
     return Fragment(
         id=frag_id,
         title=title,
         source=FragmentSource(platform=platform),
         created=created,
+        ingested=created,
     )
 
 
@@ -428,6 +436,147 @@ class TestDetectSynchronicities:
         assert sync.source_b == SourcePlatform.JOURNAL
 
 
+# ---- FEAT-031 effective_authored_at precedence ----
+
+
+def _authored_fragment(
+    *,
+    frag_id: str,
+    title: str,
+    platform: SourcePlatform,
+    ingest_moment: datetime,
+    authored_at: datetime,
+) -> Fragment:
+    """Build a Fragment with split ``created`` vs ``authored_at`` timestamps.
+
+    Models the real-world ingestion case FEAT-031 was filed for: a
+    multi-year corpus ingested in one batch, where ``created`` /
+    ``ingested`` collapse to a single wall-clock moment but each
+    fragment's source-side authored date lives in its own past.
+    """
+    return Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=platform),
+        created=ingest_moment,
+        ingested=ingest_moment,
+        authored_at=authored_at,
+    )
+
+
+class TestEffectiveAuthoredAtPrecedence:
+    """FEAT-031: gap / chronological ordering / rendered body use authored_at."""
+
+    def test_time_gap_uses_authored_at_not_created(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """The synchronicity gap is computed from ``authored_at``.
+
+        Both fragments share the same ``created`` (ingested in the same
+        batch) but their ``authored_at`` values are 105 days apart on
+        different platforms. Without FEAT-031, the gap would collapse
+        to 0 and the synchronicity would be filtered out by the
+        ``min_time_gap_days`` rule.
+        """
+        ingest_moment = datetime(2026, 5, 1, 10, 0, 0)
+        fragments = {
+            "frag-a": _authored_fragment(
+                frag_id="frag-a",
+                title="the river remembers every stone it has touched",
+                platform=SourcePlatform.DISCORD,
+                ingest_moment=ingest_moment,
+                authored_at=datetime(2025, 1, 5, 10, 0, 0),
+            ),
+            "frag-b": _authored_fragment(
+                frag_id="frag-b",
+                title="the river remembers every stone it has touched",
+                platform=SourcePlatform.JOURNAL,
+                ingest_moment=ingest_moment,
+                authored_at=datetime(2025, 4, 20, 10, 0, 0),
+            ),
+        }
+        resonances = [("frag-a", "frag-b", 0.95)]
+        result = detector.detect_synchronicities(resonances, fragments)
+        assert len(result) == 1
+        assert result[0].time_gap_days == 105
+
+    def test_chronological_pair_uses_authored_at(
+        self,
+        detector: SynchronicityDetector,
+    ) -> None:
+        """Earlier-by-``authored_at`` becomes ``fragment_a_id``.
+
+        ``frag-late-creation`` is ``created`` *first* (in the ingest
+        order) but ``authored_at`` *later*. Chronological pairing must
+        therefore put ``frag-early-creation`` first.
+        """
+        fragments = {
+            "frag-late-creation": _authored_fragment(
+                frag_id="frag-late-creation",
+                title="the long quiet between voices",
+                platform=SourcePlatform.DISCORD,
+                ingest_moment=datetime(2026, 5, 1, 8, 0, 0),
+                authored_at=datetime(2026, 1, 10, 9, 0, 0),
+            ),
+            "frag-early-creation": _authored_fragment(
+                frag_id="frag-early-creation",
+                title="the long quiet between voices",
+                platform=SourcePlatform.JOURNAL,
+                ingest_moment=datetime(2026, 5, 1, 9, 0, 0),
+                authored_at=datetime(2024, 9, 1, 9, 0, 0),
+            ),
+        }
+        resonances = [("frag-late-creation", "frag-early-creation", 0.95)]
+        result = detector.detect_synchronicities(resonances, fragments)
+        assert len(result) == 1
+        # Earlier authored_at wins, regardless of ingest order.
+        assert result[0].fragment_a_id == "frag-early-creation"
+        assert result[0].fragment_b_id == "frag-late-creation"
+
+    def test_render_body_uses_authored_at_date(
+        self,
+        detector: SynchronicityDetector,
+        vault_path: Path,
+    ) -> None:
+        """The rendered note body shows authored dates, not ingest dates.
+
+        The body's bulleted excerpts include the date for each fragment.
+        FEAT-031 requires that date to be the authored date — the answer
+        to "when was this written?" — not the wall-clock moment the
+        vault wrote the fragment.
+        """
+        ingest_moment = datetime(2026, 5, 1, 10, 0, 0)
+        fragments = {
+            "frag-a": _authored_fragment(
+                frag_id="frag-a",
+                title="the river remembers every stone it has touched",
+                platform=SourcePlatform.DISCORD,
+                ingest_moment=ingest_moment,
+                authored_at=datetime(2025, 1, 5, 10, 0, 0),
+            ),
+            "frag-b": _authored_fragment(
+                frag_id="frag-b",
+                title="the river remembers every stone it has touched",
+                platform=SourcePlatform.JOURNAL,
+                ingest_moment=ingest_moment,
+                authored_at=datetime(2025, 4, 20, 10, 0, 0),
+            ),
+        }
+        resonances = [("frag-a", "frag-b", 0.95)]
+        syncs = detector.detect_synchronicities(resonances, fragments)
+        note_path = detector.create_synchronicity_note(
+            syncs[0],
+            fragments,
+            vault_path,
+        )
+        body = frontmatter.loads(note_path.read_text(encoding="utf-8")).content
+        # Authored dates are present; ingest date is not.
+        assert "2025-01-05" in body
+        assert "2025-04-20" in body
+        assert ingest_moment.date().isoformat() not in body
+
+
 # ---- FEAT-024 cross-level ranking ----
 
 
@@ -439,12 +588,18 @@ def _level_fragment(
     created: datetime,
     level: FragmentLevel,
 ) -> Fragment:
-    """Construct a test Fragment with an explicit structural level."""
+    """Construct a test Fragment with an explicit structural level.
+
+    Mirrors ``created`` into ``ingested`` so the FEAT-031
+    ``effective_authored_at`` helper resolves to the supplied time
+    when ``authored_at`` is unset.
+    """
     return Fragment(
         id=frag_id,
         title=title,
         source=FragmentSource(platform=platform),
         created=created,
+        ingested=created,
         level=level,
     )
 


### PR DESCRIPTION
## Summary

Finishes the FEAT-031 sweep started in PR #311. Four downstream time-bucket surfaces still reached for `fragment.created` directly, so a multi-year corpus ingested in one batch produced threads / eddies / synchronicities that all looked contemporaneous — exactly the bug FEAT-031 was filed to fix.

This change routes every remaining time-bucket through `creek.time.effective_authored_at` / `effective_authored_date`, matching the precedence pinned in #263:

- **`creek/link/threads.py`** — sort, sliding-window comparison, and `first_seen` / `last_seen` on `Thread` now use the authored-date precedence.
- **`creek/link/eddies.py`** — cluster sort and median formation date (`_median_date`).
- **`creek/generate/synchronicity.py`** — `gap_days`, chronological pairing, and the rendered note body.
- **`creek/generate/compost.py`** — project-silence cutoff in `_project_candidate`.

## Test plan

- [x] Added a behavioural test for each surface (`tests/test_link.py`, `tests/test_synchronicity.py`, `tests/test_compost.py`): seed fragments with the same `created` but very different `authored_at`; assert bucketing respects the authored date.
- [x] All 7 new tests fail against `main` and pass after the production fix (TDD red → green).
- [x] `rg -n '\.created\b' creek/link/threads.py creek/link/eddies.py creek/generate/synchronicity.py creek/generate/compost.py` returns zero hits.
- [x] `./scripts/check-all.sh` is fully green: 12/12 gates pass, 4,122 unit tests pass, branch coverage 93.74%.
- [x] Pre-existing test fixtures updated to mirror `created` into `ingested` (same pattern PR #311 used in `tests/test_link.py::_make_fragment`) so `effective_authored_at`'s `ingested` fallback resolves to the time the test cares about.

Closes #336

https://claude.ai/code/session_015jFVbqmaYeuDQi8fBetdRo

---
_Generated by [Claude Code](https://claude.ai/code/session_015jFVbqmaYeuDQi8fBetdRo)_