### PR TITLE
fix(link): materialize eddies inline and disambiguate linker counts (#338)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1093,12 +1093,11 @@ def link(
 def _format_link_summary(summary: LinkSummary) -> str:
     """Render a method-specific summary message for the ``creek link`` CLI.
 
-    Issue #338: the legacy message ("X fragment(s), Y link(s)") used the
-    word "link" for two incompatible things — pairwise cosine edges
-    cached in the parquet (embeddings) and topic clusters that may or
-    may not have been written to disk (eddies). The per-method
-    formatting below names the actual side effect so operators can
-    correlate the number with what they see on disk.
+    Each method gets its own phrasing because the word "link" used to mean
+    two incompatible things: pairwise cosine edges cached in the parquet
+    (embeddings) and topic clusters that may or may not have been written
+    to disk (eddies). Per-method strings name the actual side effect so
+    operators can correlate the number with what they see on disk.
 
     Args:
         summary: The link summary returned by
@@ -1106,6 +1105,9 @@ def _format_link_summary(summary: LinkSummary) -> str:
 
     Returns:
         A Rich-markup string ready for :func:`console.print`.
+
+    Raises:
+        ValueError: If ``summary.method`` is not a known linker name.
     """
     fragments = summary.fragment_count
     if summary.method == "embeddings":
@@ -1122,11 +1124,13 @@ def _format_link_summary(summary: LinkSummary) -> str:
             f"{summary.member_fragments_updated} fragment(s) updated with "
             f"`eddies:` wiki-links."
         )
-    else:
-        # Temporal (issue #338 scope: leave behaviour unchanged).
+    elif summary.method == "temporal":
         body = (
             f"Temporal linker: {fragments} fragment(s), {summary.link_count} link(s)."
         )
+    else:
+        msg = f"Unknown link method: {summary.method!r}"
+        raise ValueError(msg)
     return f"[bold green]{body}[/bold green]"
 
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from creek.generate.compost_verifier import SupportsVerifyCompost
     from creek.generate.drafts import DraftLLM, SeedSpec
     from creek.ingest.base import Ingestor
+    from creek.link.link_engine import LinkSummary
     from creek.models import CompileTargetKind, Frequency, Mode, Phase
     from creek.purge import PurgeEngine, PurgeResult
 
@@ -1086,11 +1087,47 @@ def link(
         method=method,
         rebuild=rebuild,
     )
-    console.print(
-        f"[bold green]{method.capitalize()} linker: "
-        f"{summary.fragment_count} fragment(s), "
-        f"{summary.link_count} link(s).[/bold green]",
-    )
+    console.print(_format_link_summary(summary))
+
+
+def _format_link_summary(summary: LinkSummary) -> str:
+    """Render a method-specific summary message for the ``creek link`` CLI.
+
+    Issue #338: the legacy message ("X fragment(s), Y link(s)") used the
+    word "link" for two incompatible things — pairwise cosine edges
+    cached in the parquet (embeddings) and topic clusters that may or
+    may not have been written to disk (eddies). The per-method
+    formatting below names the actual side effect so operators can
+    correlate the number with what they see on disk.
+
+    Args:
+        summary: The link summary returned by
+            :func:`creek.link.link_engine.run_link`.
+
+    Returns:
+        A Rich-markup string ready for :func:`console.print`.
+    """
+    fragments = summary.fragment_count
+    if summary.method == "embeddings":
+        body = (
+            f"Embeddings linker: {fragments} fragment(s) embedded, "
+            f"{summary.similarity_edges} similarity edge(s) cached in "
+            f"00-Creek-Meta/embeddings.parquet."
+        )
+    elif summary.method == "eddies":
+        body = (
+            f"Eddies linker: {fragments} fragment(s) scanned, "
+            f"{summary.eddies_detected} eddy(ies) detected, "
+            f"{summary.eddies_written} eddy file(s) written to 03-Eddies/, "
+            f"{summary.member_fragments_updated} fragment(s) updated with "
+            f"`eddies:` wiki-links."
+        )
+    else:
+        # Temporal (issue #338 scope: leave behaviour unchanged).
+        body = (
+            f"Temporal linker: {fragments} fragment(s), {summary.link_count} link(s)."
+        )
+    return f"[bold green]{body}[/bold green]"
 
 
 @app.command(name="compile")

--- a/creek-tools/creek/link/link_engine.py
+++ b/creek-tools/creek/link/link_engine.py
@@ -6,12 +6,11 @@ resulting link count back to the CLI. Honours ``--rebuild`` by deleting
 the cached embeddings parquet so the embedding linker recomputes from
 scratch.
 
-Issue #338: the eddies linker materialises its output inline — it
-writes an ``Eddy`` markdown file per detected cluster under
-``03-Eddies/`` and updates each member fragment's ``eddies:``
-frontmatter with the corresponding wiki-link. The CLI's summary reports
-the same numbers operators can see on disk so "1 link reported" can no
-longer disagree with "0 files written".
+The eddies linker materialises its output inline — it writes an
+``Eddy`` markdown file per detected cluster under ``03-Eddies/`` and
+updates each member fragment's ``eddies:`` frontmatter with the
+corresponding wiki-link, so the CLI's summary counts match what
+operators see on disk.
 """
 
 from __future__ import annotations
@@ -50,8 +49,8 @@ class LinkSummary:
     CLI can phrase what actually happened — pairwise similarity edges
     cached in a parquet are *not* per-fragment frontmatter links, and an
     eddy cluster *detected* in memory is not the same as an eddy file
-    *written* to disk. Issue #338 was filed because the original
-    ``link_count`` field overloaded both concepts under one label.
+    *written* to disk. ``link_count`` is preserved as a back-compat
+    mirror of the method-specific count.
 
     Attributes:
         method: Linker that was run (``embeddings`` / ``temporal`` /
@@ -158,16 +157,16 @@ def _run_eddies(
     cache_path: Path,
     vault_path: Path,
 ) -> LinkSummary:
-    """Detect eddies and materialise them inline (issue #338).
+    """Detect eddies and materialise them inline.
 
-    Issue #338 picked inline materialisation over deferring to
-    ``creek compile`` for two reasons:
+    Inline materialisation is chosen over deferring to ``creek compile``
+    for two reasons:
 
     1. The detector already produces fully-formed :class:`Eddy` models
-       and a membership map; the only missing step was the filesystem
+       and a membership map; the only missing step is the filesystem
        write — :meth:`VaultWriter.write_eddy` already exists.
     2. The ``creek compile`` flow is a per-target manual invocation; it
-       was never the bulk persistence path for detected eddies.
+       is not the bulk persistence path for detected eddies.
 
     The function:
 
@@ -207,9 +206,6 @@ def _run_eddies(
             method="eddies",
             fragment_count=len(fragments),
             link_count=0,
-            eddies_detected=0,
-            eddies_written=0,
-            member_fragments_updated=0,
         )
 
     updated_fragments = detector.assign_fragments_to_eddies(fragments, eddies)
@@ -300,12 +296,13 @@ def _persist_fragment_eddy_updates(
     Returns:
         Number of fragment files that were successfully rewritten.
     """
-    records = iter_vault_fragments(vault_path / "01-Fragments")
-    path_by_id: dict[str, Path] = {frag.id: path for path, frag, _, _ in records}
-    raw_by_id: dict[str, dict[str, object]] = {
-        frag.id: raw for _, frag, _, raw in records
-    }
-    body_by_id: dict[str, str] = {frag.id: body for _, frag, body, _ in records}
+    path_by_id: dict[str, Path] = {}
+    raw_by_id: dict[str, dict[str, object]] = {}
+    body_by_id: dict[str, str] = {}
+    for path, frag, body, raw in iter_vault_fragments(vault_path / "01-Fragments"):
+        path_by_id[frag.id] = path
+        raw_by_id[frag.id] = raw
+        body_by_id[frag.id] = body
 
     written = 0
     for before, after in zip(original, updated, strict=True):

--- a/creek-tools/creek/link/link_engine.py
+++ b/creek-tools/creek/link/link_engine.py
@@ -5,6 +5,13 @@ chosen linker stage (embeddings, temporal, or eddies), and reports the
 resulting link count back to the CLI. Honours ``--rebuild`` by deleting
 the cached embeddings parquet so the embedding linker recomputes from
 scratch.
+
+Issue #338: the eddies linker materialises its output inline — it
+writes an ``Eddy`` markdown file per detected cluster under
+``03-Eddies/`` and updates each member fragment's ``eddies:``
+frontmatter with the corresponding wiki-link. The CLI's summary reports
+the same numbers operators can see on disk so "1 link reported" can no
+longer disagree with "0 files written".
 """
 
 from __future__ import annotations
@@ -13,6 +20,8 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003  # no issue: runtime dataclass field
 from typing import TYPE_CHECKING
+
+import frontmatter
 
 from creek.link.eddies import EddyDetector
 from creek.link.embeddings import (
@@ -24,10 +33,11 @@ from creek.link.embeddings import (
 )
 from creek.link.temporal import TemporalLinker
 from creek.vault.reader import iter_vault_fragments
+from creek.vault.writer import VaultWriter
 
 if TYPE_CHECKING:
     from creek.config import CreekConfig
-    from creek.models import Fragment
+    from creek.models import Eddy, Fragment
 
 logger = logging.getLogger(__name__)
 
@@ -36,17 +46,42 @@ logger = logging.getLogger(__name__)
 class LinkSummary:
     """Counts produced by a single ``creek link`` run.
 
+    The structured fields make the contract per-method explicit so the
+    CLI can phrase what actually happened — pairwise similarity edges
+    cached in a parquet are *not* per-fragment frontmatter links, and an
+    eddy cluster *detected* in memory is not the same as an eddy file
+    *written* to disk. Issue #338 was filed because the original
+    ``link_count`` field overloaded both concepts under one label.
+
     Attributes:
         method: Linker that was run (``embeddings`` / ``temporal`` /
             ``eddies``).
         fragment_count: Number of fragments loaded from the vault.
-        link_count: Edges or clusters produced (resonances, temporal
-            links, or eddy clusters depending on ``method``).
+        link_count: Generic count for back-compat; mirrors the
+            method-specific count (resonance edges, temporal links, or
+            eddies detected).
+        similarity_edges: Pairwise cosine-similarity edges cached in the
+            embeddings parquet. Only populated for ``method ==
+            "embeddings"`` (zero elsewhere).
+        eddies_detected: Eddy clusters returned by the detector. Only
+            populated for ``method == "eddies"``.
+        eddies_written: Eddy markdown files persisted under
+            ``03-Eddies/`` by the materialisation step. Equal to
+            ``eddies_detected`` when every write succeeds; smaller when
+            duplicate-id collisions short-circuit a write or the writer
+            fails. Only populated for ``method == "eddies"``.
+        member_fragments_updated: Fragments whose on-disk ``eddies:``
+            frontmatter was rewritten to include a new wiki-link. Only
+            populated for ``method == "eddies"``.
     """
 
     method: str
     fragment_count: int
     link_count: int
+    similarity_edges: int = 0
+    eddies_detected: int = 0
+    eddies_written: int = 0
+    member_fragments_updated: int = 0
 
 
 def run_link(
@@ -89,31 +124,220 @@ def run_link(
             config=config,
             cache_path=cache_path,
         )
-    elif method == "temporal":
+        return LinkSummary(
+            method=method,
+            fragment_count=len(fragments),
+            link_count=link_count,
+            similarity_edges=link_count,
+        )
+    if method == "temporal":
         temporal = TemporalLinker()
         links = temporal.find_temporal_links(
             fragments,
             window_hours=config.linking.temporal_window_hours,
         )
-        link_count = len(links)
-    else:
-        embeddings = _load_or_compute_embeddings(
-            fragments=fragments,
-            config=config,
-            cache_path=cache_path,
+        return LinkSummary(
+            method=method,
+            fragment_count=len(fragments),
+            link_count=len(links),
         )
-        detector = EddyDetector(embeddings=embeddings)
-        eddies = detector.detect_eddies(
-            fragments,
-            min_fragments=config.linking.eddy_min_fragments,
+
+    # method == "eddies"
+    return _run_eddies(
+        fragments=fragments,
+        config=config,
+        cache_path=cache_path,
+        vault_path=vault_path,
+    )
+
+
+def _run_eddies(
+    *,
+    fragments: list[Fragment],
+    config: CreekConfig,
+    cache_path: Path,
+    vault_path: Path,
+) -> LinkSummary:
+    """Detect eddies and materialise them inline (issue #338).
+
+    Issue #338 picked inline materialisation over deferring to
+    ``creek compile`` for two reasons:
+
+    1. The detector already produces fully-formed :class:`Eddy` models
+       and a membership map; the only missing step was the filesystem
+       write — :meth:`VaultWriter.write_eddy` already exists.
+    2. The ``creek compile`` flow is a per-target manual invocation; it
+       was never the bulk persistence path for detected eddies.
+
+    The function:
+
+    * runs DBSCAN over the cached embeddings,
+    * writes one ``Eddy`` markdown file per detected cluster under
+      ``03-Eddies/``,
+    * rewrites each member fragment's ``eddies:`` frontmatter to include
+      the corresponding ``[[Eddy Title]]`` wiki-link (no rewrites for
+      fragments that already carried the link).
+
+    Disk failures degrade gracefully: a write that raises ``OSError`` is
+    logged and skipped so a single bad file cannot block the rest of
+    the run, and the returned summary reflects the partial work.
+
+    Args:
+        fragments: Fragments loaded from the vault.
+        config: Loaded Creek configuration.
+        cache_path: Embeddings parquet path.
+        vault_path: Vault root.
+
+    Returns:
+        A populated :class:`LinkSummary` for the eddies method.
+    """
+    embeddings = _load_or_compute_embeddings(
+        fragments=fragments,
+        config=config,
+        cache_path=cache_path,
+    )
+    detector = EddyDetector(embeddings=embeddings)
+    eddies = detector.detect_eddies(
+        fragments,
+        min_fragments=config.linking.eddy_min_fragments,
+    )
+
+    if not eddies:
+        return LinkSummary(
+            method="eddies",
+            fragment_count=len(fragments),
+            link_count=0,
+            eddies_detected=0,
+            eddies_written=0,
+            member_fragments_updated=0,
         )
-        link_count = len(eddies)
+
+    updated_fragments = detector.assign_fragments_to_eddies(fragments, eddies)
+    written_paths = _write_eddy_files(eddies, vault_path)
+    fragments_updated = _persist_fragment_eddy_updates(
+        original=fragments,
+        updated=updated_fragments,
+        vault_path=vault_path,
+    )
 
     return LinkSummary(
-        method=method,
+        method="eddies",
         fragment_count=len(fragments),
-        link_count=link_count,
+        link_count=len(eddies),
+        eddies_detected=len(eddies),
+        eddies_written=len(written_paths),
+        member_fragments_updated=fragments_updated,
     )
+
+
+def _write_eddy_files(eddies: list[Eddy], vault_path: Path) -> list[Path]:
+    """Persist each eddy as a markdown file under ``03-Eddies/``.
+
+    Uses :class:`VaultWriter` so per-directory ID indexing, atomic
+    create, and provenance logging all behave consistently with the rest
+    of the pipeline. A failed write (``OSError`` from a full disk or
+    read-only volume) is logged and the remaining eddies are still
+    attempted — losing one eddy file should not break the others.
+
+    Args:
+        eddies: Eddies returned by :meth:`EddyDetector.detect_eddies`.
+        vault_path: Vault root.
+
+    Returns:
+        Paths of the eddy files that were successfully written.
+    """
+    try:
+        writer = VaultWriter(vault_path=vault_path)
+    except FileNotFoundError:
+        # The vault scaffold is incomplete (no ``00-Creek-Meta`` or
+        # ``01-Fragments`` yet). The link engine is invoked against
+        # whatever the operator points at; we shouldn't crash on a
+        # half-set-up vault when there's nothing to materialise into.
+        logger.warning(
+            "Skipping eddy materialisation: vault %s is missing required dirs",
+            vault_path,
+        )
+        return []
+
+    written: list[Path] = []
+    for eddy in eddies:
+        try:
+            path = writer.write_eddy(eddy)
+        except OSError as exc:
+            logger.warning(
+                "Failed to write eddy %s (%s) under %s: %s",
+                eddy.id,
+                eddy.title,
+                vault_path / "03-Eddies",
+                exc,
+            )
+            continue
+        written.append(path)
+    return written
+
+
+def _persist_fragment_eddy_updates(
+    *,
+    original: list[Fragment],
+    updated: list[Fragment],
+    vault_path: Path,
+) -> int:
+    """Rewrite fragment frontmatter when the ``eddies:`` list changed.
+
+    Re-reads each fragment file so non-Fragment frontmatter keys (e.g.
+    operator-applied tags, ``classification_method``) are preserved
+    verbatim — the same approach the classify engine uses for in-place
+    fragment rewrites. Only fragments whose ``eddies`` list actually
+    grew are touched.
+
+    Args:
+        original: Fragments as loaded from disk.
+        updated: Fragments returned by
+            :meth:`EddyDetector.assign_fragments_to_eddies`. Must be
+            the same length as *original* and in the same order.
+        vault_path: Vault root.
+
+    Returns:
+        Number of fragment files that were successfully rewritten.
+    """
+    records = iter_vault_fragments(vault_path / "01-Fragments")
+    path_by_id: dict[str, Path] = {frag.id: path for path, frag, _, _ in records}
+    raw_by_id: dict[str, dict[str, object]] = {
+        frag.id: raw for _, frag, _, raw in records
+    }
+    body_by_id: dict[str, str] = {frag.id: body for _, frag, body, _ in records}
+
+    written = 0
+    for before, after in zip(original, updated, strict=True):
+        if before.eddies == after.eddies:
+            continue
+        md_path = path_by_id.get(after.id)
+        if md_path is None:
+            # The fragment landed in the detector via the in-memory
+            # path but doesn't have a backing file (test scenario or
+            # the file was unlinked between load and rewrite). Skip
+            # rather than crash — there is nothing to update.
+            logger.debug(
+                "Skipping fragment frontmatter update for %s: no file on disk",
+                after.id,
+            )
+            continue
+        raw = raw_by_id.get(after.id, {}).copy()
+        raw.update(after.model_dump(mode="json"))
+        post = frontmatter.Post(content=body_by_id.get(after.id, ""))
+        post.metadata.update(raw)
+        try:
+            md_path.write_text(frontmatter.dumps(post), encoding="utf-8")
+        except OSError as exc:
+            logger.warning(
+                "Failed to rewrite fragment %s at %s: %s",
+                after.id,
+                md_path,
+                exc,
+            )
+            continue
+        written += 1
+    return written
 
 
 def _run_embeddings(

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1146,7 +1146,7 @@ def test_link_eddies_output_phrases_eddies_written(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     output_lower = result.output.lower()
-    assert "edd" in output_lower  # mentions eddies
+    assert "eddies" in output_lower
     # Both halves of the contract are surfaced explicitly.
     assert "detected" in output_lower
     assert "written" in output_lower

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1108,6 +1108,51 @@ def test_link_rebuild_clears_embeddings_cache(tmp_path: Path) -> None:
     assert not cache_path.exists()
 
 
+def test_link_embeddings_output_phrases_similarity_edges(tmp_path: Path) -> None:
+    """Embeddings CLI output explicitly says "similarity edges", not "links".
+
+    Issue #338 Problem B: the pre-fix output used "link(s)" for pairwise
+    similarity edges stored only in the parquet cache. That implied a
+    user-visible side effect in fragment frontmatter that did not exist.
+    The fix is to phrase the count accurately as similarity edges
+    cached in the parquet so operators know what they're being shown.
+    """
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        ["link", "--vault", str(vault), "--method", "embeddings"],
+    )
+    assert result.exit_code == 0, result.output
+    # New phrasing — accurate to what the embeddings method does.
+    assert "similarity edge" in result.output.lower()
+    assert "embeddings.parquet" in result.output
+
+
+def test_link_eddies_output_phrases_eddies_written(tmp_path: Path) -> None:
+    """Eddies CLI output reports both detected and written counts.
+
+    Issue #338 Problem A: the pre-fix output said ``1 link(s)`` even when
+    nothing materialised in the vault. The fix is to make the side
+    effect (an eddy .md under ``03-Eddies/``) explicit in the count.
+    """
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        ["link", "--vault", str(vault), "--method", "eddies"],
+    )
+    assert result.exit_code == 0, result.output
+    output_lower = result.output.lower()
+    assert "edd" in output_lower  # mentions eddies
+    # Both halves of the contract are surfaced explicitly.
+    assert "detected" in output_lower
+    assert "written" in output_lower
+    assert "03-eddies" in output_lower
+
+
 def test_report_help() -> None:
     """Test that report --help shows subcommand help."""
     result = runner.invoke(app, ["report", "--help"])

--- a/creek-tools/tests/test_link_engine.py
+++ b/creek-tools/tests/test_link_engine.py
@@ -634,10 +634,22 @@ def test_run_link_eddies_fragment_write_oserror_is_logged(tmp_path: Path) -> Non
     # the eddy file itself still lands.
     real_write_text = _Path.write_text
 
-    def _selective_write(self: _Path, *args: object, **kwargs: object) -> int:
+    def _selective_write(
+        self: _Path,
+        data: str,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> int:
         if self.suffix == ".md" and self.parent.name == "Notes":
             raise OSError("read-only volume")
-        return real_write_text(self, *args, **kwargs)  # type: ignore[arg-type]
+        return real_write_text(
+            self,
+            data,
+            encoding=encoding,
+            errors=errors,
+            newline=newline,
+        )
 
     with patch.object(_Path, "write_text", _selective_write):
         summary = run_link(
@@ -651,3 +663,67 @@ def test_run_link_eddies_fragment_write_oserror_is_logged(tmp_path: Path) -> Non
     # fragment frontmatter was rewritten.
     assert summary.eddies_written >= 1
     assert summary.member_fragments_updated == 0
+
+
+def test_run_link_eddies_preserves_extra_frontmatter_and_body(
+    tmp_path: Path,
+) -> None:
+    """Rewriting a fragment's ``eddies:`` list does not drop other keys.
+
+    The fragment-rewrite path re-reads the raw YAML so operator-applied
+    keys (``classification_method``, custom tags) and the markdown body
+    survive verbatim. Without this guarantee a future refactor that
+    dropped the ``raw.copy()`` step would silently corrupt user vaults.
+    """
+    from datetime import datetime, timedelta
+
+    import frontmatter
+
+    vault = tmp_path / "vault"
+    base = datetime(2026, 4, 1)
+    day_offsets = [600, 45, 400, 120, 500, 15]
+    fragments: list[Fragment] = []
+    custom_body = "Body paragraph one.\n\nBody paragraph two with [[link]]."
+    for i in range(6):
+        frag = Fragment(
+            id=f"frag-extras-{i:03d}",
+            title="Ceramics studio practice",
+            source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+            created=base - timedelta(days=day_offsets[i]),
+        )
+        _write_fragment(
+            vault=vault,
+            fragment=frag,
+            body=custom_body,
+            method="manual",
+            extras={"operator_tags": ["studio", "ritual"], "custom_key": "preserved"},
+        )
+        fragments.append(frag)
+
+    config = CreekConfig()
+    linker = EmbeddingLinker(config=config.embeddings)
+    vectors = {frag.id: [1.0, 0.0, 0.0] for frag in fragments}
+    entries = linker.build_cache_entries(fragments, vectors)
+    cache_path = embeddings_cache_path(vault)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    linker.save_cache(entries, cache_path)
+
+    summary = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="eddies",
+        rebuild=False,
+    )
+    assert summary.member_fragments_updated == len(fragments)
+
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    for frag in fragments:
+        post = frontmatter.load(str(fragments_dir / f"{frag.id}.md"))
+        assert post.get("classification_method") == "manual"
+        assert post.get("operator_tags") == ["studio", "ritual"]
+        assert post.get("custom_key") == "preserved"
+        assert post.content == custom_body
+        eddies_field = post.get("eddies") or []
+        assert any(
+            isinstance(entry, str) and entry.startswith("[[") for entry in eddies_field
+        ), f"Fragment {frag.id} lost its eddy wiki-link"

--- a/creek-tools/tests/test_link_engine.py
+++ b/creek-tools/tests/test_link_engine.py
@@ -344,3 +344,310 @@ def test_run_link_unreadable_cache_recomputes(tmp_path: Path) -> None:
     # Cache was rewritten as a valid parquet.
     loaded = EmbeddingLinker(config=CreekConfig().embeddings).load_cache(cache_path)
     assert fragment.id in loaded
+
+
+# ----- Issue #338: eddy materialization tests --------------------------------
+
+
+def _embedded_eddy_fragments(
+    vault: Path,
+    *,
+    count: int = 6,
+) -> list[Fragment]:
+    """Seed *vault* with *count* fragments and matching tight-cluster embeddings.
+
+    Mirrors the production layout: each fragment lives under
+    ``01-Fragments/Notes/`` and there is a parquet cache at
+    ``00-Creek-Meta/embeddings.parquet`` with near-identical vectors so
+    DBSCAN forms one dense, temporally scattered cluster (an eddy).
+
+    Args:
+        vault: Vault root.
+        count: Number of fragments to seed (defaults to 6, above the
+            default ``min_fragments`` of 5).
+
+    Returns:
+        The list of created fragments in creation order.
+    """
+    from datetime import datetime, timedelta
+
+    # Two-year spread keeps the Spearman correlation low so the cluster
+    # qualifies as a scattered eddy rather than a directional thread.
+    base = datetime(2026, 4, 1)
+    day_offsets = [600, 45, 400, 120, 500, 15, 250, 75]
+    fragments: list[Fragment] = []
+    for i in range(count):
+        frag = Fragment(
+            id=f"frag-issue338-{i:03d}",
+            title="Ceramics studio practice",
+            source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+            created=base - timedelta(days=day_offsets[i % len(day_offsets)]),
+        )
+        _write_fragment(vault=vault, fragment=frag, body="body")
+        fragments.append(frag)
+
+    # Persist the embeddings cache so the eddies linker can consume it
+    # without invoking the sentence-transformer.
+    config = CreekConfig()
+    linker = EmbeddingLinker(config=config.embeddings)
+    vectors = {frag.id: [1.0, 0.0, 0.0] for frag in fragments}
+    entries = linker.build_cache_entries(fragments, vectors)
+    cache_path = embeddings_cache_path(vault)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    linker.save_cache(entries, cache_path)
+    return fragments
+
+
+def test_run_link_eddies_materialises_eddy_files(tmp_path: Path) -> None:
+    """The eddies linker writes a markdown file under ``03-Eddies/`` per detected eddy.
+
+    Issue #338 Problem A: the linker previously reported eddy counts but
+    never persisted the eddy notes to disk. The user-visible vault stayed
+    empty even when ``1 link(s)`` was reported.
+    """
+    vault = tmp_path / "vault"
+    _embedded_eddy_fragments(vault)
+
+    summary = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="eddies",
+        rebuild=False,
+    )
+
+    eddy_dir = vault / "03-Eddies"
+    # At least one eddy file landed on disk.
+    md_files = [p for p in eddy_dir.rglob("*.md") if p.name != ".gitkeep"]
+    assert md_files, (
+        f"Expected eddies linker to write at least one .md file under "
+        f"{eddy_dir}, found none. Summary: {summary}"
+    )
+    # The reported count matches the number of files written.
+    assert summary.eddies_written == len(md_files)
+    assert summary.eddies_detected == len(md_files)
+
+
+def test_run_link_eddies_updates_member_fragment_frontmatter(tmp_path: Path) -> None:
+    """Member fragments have the eddy's wikilink in their ``eddies:`` frontmatter.
+
+    Without this the eddy file is unreachable from the fragments that
+    compose it — operators see a stub note but the constituent fragments
+    do not point at the eddy from their YAML headers.
+    """
+    import frontmatter
+
+    vault = tmp_path / "vault"
+    seeded = _embedded_eddy_fragments(vault)
+
+    run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="eddies",
+        rebuild=False,
+    )
+
+    # Read the eddy file back to get the expected wikilink target.
+    eddy_dir = vault / "03-Eddies"
+    eddy_files = [p for p in eddy_dir.rglob("*.md") if p.name != ".gitkeep"]
+    assert eddy_files, "eddies linker must materialize at least one eddy file"
+    eddy_post = frontmatter.load(str(eddy_files[0]))
+    eddy_title = eddy_post.get("title")
+    assert isinstance(eddy_title, str) and eddy_title
+
+    expected_link = f"[[{eddy_title}]]"
+
+    # Every seeded fragment is a cluster member, so every fragment file
+    # should now reference the eddy by wikilink.
+    fragments_dir = vault / "01-Fragments" / "Notes"
+    seen_links = 0
+    for frag in seeded:
+        path = fragments_dir / f"{frag.id}.md"
+        assert path.exists(), f"Seeded fragment {frag.id} should still exist on disk"
+        post = frontmatter.load(str(path))
+        eddies_field = post.get("eddies") or []
+        if expected_link in eddies_field:
+            seen_links += 1
+    assert seen_links == len(seeded), (
+        f"Expected every member fragment to reference the eddy "
+        f"{expected_link!r}; only {seen_links}/{len(seeded)} did."
+    )
+
+
+def test_run_link_eddies_summary_reports_zero_when_no_clusters(
+    tmp_path: Path,
+) -> None:
+    """A sparse vault produces a summary with zero detected, zero written.
+
+    Pins the symmetric "nothing happened" contract: when the linker
+    finds no eddies the user-visible vault is unchanged and the counters
+    both read zero.
+    """
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-noeddy00000",
+        title="Lonely note",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    summary = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="eddies",
+        rebuild=False,
+    )
+
+    assert summary.eddies_detected == 0
+    assert summary.eddies_written == 0
+    eddy_dir = vault / "03-Eddies"
+    if eddy_dir.exists():
+        assert [p for p in eddy_dir.rglob("*.md") if p.name != ".gitkeep"] == []
+
+
+def test_run_link_embeddings_summary_exposes_edge_count(tmp_path: Path) -> None:
+    """The embeddings summary exposes a ``similarity_edges`` count.
+
+    Issue #338 Problem B: the previous output called pairwise similarity
+    edges "link(s)", implying a per-fragment frontmatter side effect
+    that never happened. The structured summary now exposes a
+    method-specific field so the CLI can phrase the side effect
+    accurately.
+    """
+    vault = tmp_path / "vault"
+    fragment = Fragment(
+        id="frag-edges00000",
+        title="Edge fragment",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(vault=vault, fragment=fragment, body="body")
+
+    summary = run_link(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="embeddings",
+        rebuild=False,
+    )
+
+    # The new field always exists for the embeddings method.
+    assert summary.similarity_edges == summary.link_count
+
+
+def test_run_link_eddies_persists_even_when_writer_dispatch_changes(
+    tmp_path: Path,
+) -> None:
+    """The materialization path delegates through ``VaultWriter.write_eddy``.
+
+    Pins the architectural decision (inline materialization, not deferral
+    to ``creek compile``) so a future refactor cannot silently regress by
+    swapping the writer for a no-op.
+    """
+    from unittest.mock import patch
+
+    vault = tmp_path / "vault"
+    _embedded_eddy_fragments(vault)
+
+    with patch(
+        "creek.link.link_engine.VaultWriter.write_eddy",
+        autospec=True,
+    ) as mock_write:
+        mock_write.side_effect = lambda self, eddy: (
+            self.vault_path / "03-Eddies" / f"{eddy.id}.md"
+        )
+        run_link(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="eddies",
+            rebuild=False,
+        )
+
+    assert mock_write.called, (
+        "The eddies linker must persist detected eddies via VaultWriter.write_eddy"
+    )
+
+
+def test_run_link_eddies_write_oserror_does_not_crash(tmp_path: Path) -> None:
+    """An ``OSError`` while persisting an eddy is logged and skipped.
+
+    Disk full, read-only volume, or permission errors must not propagate
+    — the rest of the linker has nothing to roll back and a single bad
+    write should not block the entire run.
+    """
+    from unittest.mock import patch
+
+    vault = tmp_path / "vault"
+    _embedded_eddy_fragments(vault)
+
+    with patch(
+        "creek.link.link_engine.VaultWriter.write_eddy",
+        side_effect=OSError("disk full"),
+    ):
+        summary = run_link(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="eddies",
+            rebuild=False,
+        )
+
+    # Detected count survives but written count is zero because every
+    # write failed.
+    assert summary.eddies_detected >= 1
+    assert summary.eddies_written == 0
+
+
+def test_run_link_eddies_skips_missing_vault_scaffold(tmp_path: Path) -> None:
+    """A vault missing ``00-Creek-Meta`` does not crash the eddy materialiser.
+
+    The link engine is invoked against whatever path the operator
+    provides; a half-set-up vault should produce a clean warning rather
+    than a ``FileNotFoundError`` traceback.
+    """
+    from unittest.mock import patch
+
+    vault = tmp_path / "vault"
+    _embedded_eddy_fragments(vault)
+
+    with patch(
+        "creek.link.link_engine.VaultWriter",
+        side_effect=FileNotFoundError("missing dir"),
+    ):
+        summary = run_link(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="eddies",
+            rebuild=False,
+        )
+
+    # Detection still ran; persistence was skipped wholesale.
+    assert summary.eddies_detected >= 1
+    assert summary.eddies_written == 0
+
+
+def test_run_link_eddies_fragment_write_oserror_is_logged(tmp_path: Path) -> None:
+    """A failed fragment rewrite is counted as not-updated; no crash."""
+    from pathlib import Path as _Path
+    from unittest.mock import patch
+
+    vault = tmp_path / "vault"
+    _embedded_eddy_fragments(vault)
+
+    # Force every fragment rewrite to fail. write_eddy is left intact so
+    # the eddy file itself still lands.
+    real_write_text = _Path.write_text
+
+    def _selective_write(self: _Path, *args: object, **kwargs: object) -> int:
+        if self.suffix == ".md" and self.parent.name == "Notes":
+            raise OSError("read-only volume")
+        return real_write_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    with patch.object(_Path, "write_text", _selective_write):
+        summary = run_link(
+            vault_path=vault,
+            config=CreekConfig(),
+            method="eddies",
+            rebuild=False,
+        )
+
+    # Eddy file landed (write_eddy uses os.open, not write_text) but no
+    # fragment frontmatter was rewritten.
+    assert summary.eddies_written >= 1
+    assert summary.member_fragments_updated == 0


### PR DESCRIPTION
## Summary

Closes #338.

Two related defects in `creek link`:

- **Problem A — eddies materialization gap:** the `eddies` linker reported `1 link(s)` but persisted nothing to disk. `03-Eddies/` stayed empty; every fragment kept `eddies: []`.
- **Problem B — opaque counters:** the CLI used "link(s)" both for parquet-internal pairwise similarity edges (embeddings) and for the user-visible per-fragment cross-references (eddies). Operators couldn't reconcile the reported number with what they could see on disk.

## Design decision: inline materialization (not deferral)

I picked **inline materialization** over deferring to `creek compile`. Documented in the `_run_eddies` docstring. Rationale:

1. `VaultWriter.write_eddy` already existed (used by tests, no production caller) and writes `Eddy` notes to `03-Eddies/` with `type: eddy` — exactly the format `_load_pages` was scanning for as the eddy compiled-layer surface.
2. `EddyDetector.assign_fragments_to_eddies` already produced fully-formed updated `Fragment` instances; the only missing step was the on-disk rewrite.
3. `creek compile --target-kind eddy --target-id <id> --target-title <title>` is a **per-target manual invocation** that LLM-synthesises a `type: compiled_page` note. It was never the bulk persistence path for detected eddies; treating it as such would have changed `compile` semantics, not fixed the linker.

So the linker now:

- writes one `Eddy` markdown file per detected cluster under `03-Eddies/`,
- rewrites each member fragment's `eddies:` frontmatter with the `[[Eddy Title]]` wiki-link (preserving non-`Fragment` frontmatter keys — same approach the classify engine uses for in-place rewrites),
- degrades gracefully on disk failures (`OSError` on a per-eddy or per-fragment write, or `FileNotFoundError` from a half-set-up vault scaffold) by logging a warning and continuing with partial counts.

## CLI output (Problem B fix)

`LinkSummary` gained structured fields (`similarity_edges`, `eddies_detected`, `eddies_written`, `member_fragments_updated`); `link_count` is preserved for back-compat with the MCP tool. The CLI now phrases each method explicitly:

```
Embeddings linker: 188 fragment(s) embedded, 1212 similarity edge(s) cached in 00-Creek-Meta/embeddings.parquet.
Eddies linker: 188 fragment(s) scanned, 1 eddy(ies) detected, 1 eddy file(s) written to 03-Eddies/, 6 fragment(s) updated with `eddies:` wiki-links.
Temporal linker: 188 fragment(s), 0 link(s).   # unchanged per issue scope
```

## Scope guardrails honoured

- **Did not touch** `creek/link/eddies.py` `.created` → `effective_authored_at` sort/median sites (lines 321, 557) — that's #336's territory. The eddy-materialisation code lives in `link_engine.py`.
- **Did not touch** the temporal linker output or behaviour.

## Test plan

- [x] Failing test exercises the eddies linker on a 6-fragment fixture with cached embeddings and asserts (1) at least one `.md` lands under `03-Eddies/`, (2) every member fragment's `eddies:` frontmatter names the eddy via wiki-link.
- [x] Pinning tests for the new CLI output strings (`"similarity edge"`, `"embeddings.parquet"` for embeddings; `"detected"`, `"written"`, `"03-eddies"` for eddies).
- [x] Symmetric zero-case test: a sparse vault reports `eddies_detected == 0` and `eddies_written == 0`, no files appear.
- [x] OSError-on-write tests for both eddy-file writes and fragment frontmatter rewrites — the run completes with honest partial counts.
- [x] FileNotFoundError test for half-set-up vaults — the run continues without crashing.
- [x] `./scripts/check-all.sh` green (12/12: 4122 tests passed, coverage 93.68%, mypy strict, ruff clean, bandit clean, complexity ≤ B, etc.).

https://claude.ai/code/session_015jFVbqmaYeuDQi8fBetdRo

---
_Generated by [Claude Code](https://claude.ai/code/session_015jFVbqmaYeuDQi8fBetdRo)_