### PR TITLE
feat(skills): `--signature-only` variant without quoted exemplars (#353)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1580,12 +1580,27 @@ def skills_generate(
         "--include-tier",
         help=_INCLUDE_TIER_HELP,
     ),
+    signature_only: bool = typer.Option(
+        False,
+        "--signature-only",
+        help=(
+            "Emit the signature-only variant (.SIGNATURE.md): abstract "
+            "voice patterns only, no quoted exemplar passages from "
+            "user writing. Coexists with the legacy .SKILL.md tree "
+            "(issue #353)."
+        ),
+    ),
 ) -> None:
     """Generate the Voice Skill Tree (Section 11.4).
 
-    Writes a tree of ``SKILL.md`` files under *output* (default
+    Writes a tree of skill files under *output* (default
     ``<vault>/creek-skills``) covering frequencies, phases, modes,
-    registers, threads, eddies, and two meta skills.
+    registers, threads, eddies, and two meta skills. The default
+    variant emits ``.SKILL.md`` files that include quoted exemplar
+    passages harvested from the vault. With ``--signature-only``,
+    ``.SIGNATURE.md`` files are emitted instead — same voice patterns,
+    anti-patterns, and writing instructions but zero quoted user
+    content. The two variants can coexist in the same output directory.
     """
     override = _parse_include_tier(include_tier)
     # Skill tree generation already excludes intimate exemplars; the
@@ -1610,10 +1625,13 @@ def skills_generate(
 
     vault_path = _resolve_vault(vault)
     output_dir = output if output is not None else vault_path / "creek-skills"
-    written = SkillTreeGenerator().generate_all_skills(vault_path, output_dir)
+    written = SkillTreeGenerator(
+        signature_only=signature_only,
+    ).generate_all_skills(vault_path, output_dir)
+    variant_label = "signature-only" if signature_only else "exemplar-bearing"
     console.print(
-        f"[bold green]Voice Skill Tree generated ({len(written)} files) "
-        f"at {output_dir}[/bold green]",
+        f"[bold green]Voice Skill Tree generated ({len(written)} "
+        f"{variant_label} files) at {output_dir}[/bold green]",
     )
 
 

--- a/creek-tools/creek/generate/skills.py
+++ b/creek-tools/creek/generate/skills.py
@@ -127,11 +127,18 @@ _SIGNATURE_HEADER_BODY: str = (
 _SKILL_HEADER_BODY: str = (
     "**Variant: SKILL.** This skill file is the legacy exemplar-bearing "
     "variant — it pairs voice patterns with quoted passages harvested "
-    "from the user's classified Fragments. For the abstract-only "
-    "alternative without quoted content, see the matching "
-    "``.SIGNATURE.md`` file."
+    "from the user's classified Fragments. The abstract-only alternative "
+    "without quoted content can be generated alongside this file via "
+    "``creek skills generate --signature-only`` (issue #353)."
 )
-"""Top-of-body banner that announces a legacy exemplar-bearing file."""
+"""Top-of-body banner that announces a legacy exemplar-bearing file.
+
+The banner points at the CLI invocation that generates the alternative
+``.SIGNATURE.md`` variant rather than at the file itself: a fresh
+default-only generation leaves no ``.SIGNATURE.md`` on disk, and the
+previous wording (\"see the matching ``.SIGNATURE.md`` file\") then
+read as a broken reference — PR #357 review feedback.
+"""
 
 _EXEMPLAR_WORDS_MIN: int = 30
 """Exemplar passages below this word count are skipped as too thin."""
@@ -808,7 +815,14 @@ def _write_skill(
         The path the file was written to.
     """
     target.parent.mkdir(parents=True, exist_ok=True)
-    tags = ["skill", category, variant, *extra_tags]
+    # ``"skill"`` already sits at position 0; appending ``variant`` when
+    # the variant string is also ``"skill"`` would duplicate the tag and
+    # confuse anything that counts occurrences in the raw frontmatter
+    # (PR #357 review). Frontmatter still carries the ``variant`` field
+    # unconditionally so the two variants stay distinguishable at the
+    # field level, not just the tag level.
+    variant_tags = [variant] if variant != _VARIANT_SKILL else []
+    tags = ["skill", category, *variant_tags, *extra_tags]
     full_body = _prepend_variant_banner(body.strip(), variant=variant)
     post = frontmatter.Post(
         content=full_body + "\n",

--- a/creek-tools/creek/generate/skills.py
+++ b/creek-tools/creek/generate/skills.py
@@ -106,6 +106,32 @@ _EDDIES_DIR: str = "eddies"
 _META_DIR: str = "meta"
 
 _SKILL_SUFFIX: str = ".SKILL.md"
+_SIGNATURE_SUFFIX: str = ".SIGNATURE.md"
+
+_VARIANT_SKILL: str = "skill"
+"""Frontmatter value for the legacy exemplar-bearing variant."""
+
+_VARIANT_SIGNATURE: str = "signature"
+"""Frontmatter value for the abstract, exemplar-free variant (issue #353)."""
+
+_SIGNATURE_HEADER_BODY: str = (
+    "**Variant: SIGNATURE.** This skill file is the *signature-only* "
+    "variant — it carries voice texture, anti-patterns, writing "
+    "instructions, and register prompts but no quoted user content. "
+    "Source material is expected to come from a separate retrieval "
+    "pathway so the language model is not biased toward replicating "
+    "specific passages. See issue #353."
+)
+"""Top-of-body banner that announces a signature-only file."""
+
+_SKILL_HEADER_BODY: str = (
+    "**Variant: SKILL.** This skill file is the legacy exemplar-bearing "
+    "variant — it pairs voice patterns with quoted passages harvested "
+    "from the user's classified Fragments. For the abstract-only "
+    "alternative without quoted content, see the matching "
+    "``.SIGNATURE.md`` file."
+)
+"""Top-of-body banner that announces a legacy exemplar-bearing file."""
 
 _EXEMPLAR_WORDS_MIN: int = 30
 """Exemplar passages below this word count are skipped as too thin."""
@@ -758,21 +784,77 @@ def _write_skill(
     title: str,
     body: str,
     extra_tags: Iterable[str] = (),
+    variant: str = _VARIANT_SKILL,
 ) -> Path:
-    """Persist a SKILL.md file with frontmatter and return its path."""
+    """Persist a skill markdown file with frontmatter and return its path.
+
+    Args:
+        target: Output file path. The caller chooses the suffix
+            (``.SKILL.md`` or ``.SIGNATURE.md``) so both variants can
+            coexist in the same directory.
+        category: Skill category (``frequency``, ``phase``, ...).
+        key: The dimension key (``F3``, ``rising``, ...).
+        title: Human-readable title.
+        body: Rendered markdown body. A variant banner is prepended.
+        extra_tags: Additional tag values appended after the canonical
+            ``skill``/category tags.
+        variant: Either :data:`_VARIANT_SKILL` (default, legacy
+            exemplar-bearing files) or :data:`_VARIANT_SIGNATURE`
+            (abstract-only files; issue #353). The value is recorded in
+            frontmatter and the corresponding banner is rendered at the
+            top of the body.
+
+    Returns:
+        The path the file was written to.
+    """
     target.parent.mkdir(parents=True, exist_ok=True)
-    tags = ["skill", category, *extra_tags]
+    tags = ["skill", category, variant, *extra_tags]
+    full_body = _prepend_variant_banner(body.strip(), variant=variant)
     post = frontmatter.Post(
-        content=body.strip() + "\n",
+        content=full_body + "\n",
         type="skill",
         category=category,
         key=key,
         title=title,
+        variant=variant,
         generated_date=datetime.now(tz=UTC).isoformat(),
         tags=tags,
     )
     target.write_text(frontmatter.dumps(post), encoding="utf-8")
     return target
+
+
+def _prepend_variant_banner(body: str, *, variant: str) -> str:
+    """Prepend the variant declaration banner to *body*.
+
+    The banner is the first block in every generated file so a human (or
+    a downstream loader) can immediately tell whether the file is the
+    legacy ``SKILL`` variant or the signature-only ``SIGNATURE`` variant
+    (issue #353).
+
+    Args:
+        body: The rendered markdown body without any banner.
+        variant: Either :data:`_VARIANT_SKILL` or
+            :data:`_VARIANT_SIGNATURE`.
+
+    Returns:
+        The body with the variant banner prepended.
+    """
+    banner = (
+        _SIGNATURE_HEADER_BODY if variant == _VARIANT_SIGNATURE else _SKILL_HEADER_BODY
+    )
+    return f"{banner}\n\n{body}"
+
+
+def _skill_filename(stem: str, *, signature_only: bool) -> str:
+    """Return the filename for a skill *stem* respecting the variant.
+
+    The signature-only variant uses ``.SIGNATURE.md`` so it can coexist
+    with the legacy ``.SKILL.md`` variant in the same directory
+    (issue #353).
+    """
+    suffix = _SIGNATURE_SUFFIX if signature_only else _SKILL_SUFFIX
+    return f"{stem}{suffix}"
 
 
 # ---- Generator ----
@@ -790,6 +872,12 @@ class SkillTreeGenerator:
             file. Defaults to five.
         allow_intimate: When ``True``, fragments tagged ``intimate``
             participate in exemplar harvesting. Defaults to ``False``.
+        signature_only: When ``True`` (issue #353), emit the
+            signature-only variant. Files are written under the
+            ``.SIGNATURE.md`` suffix, the exemplar section is omitted
+            entirely, and frontmatter records ``variant: signature`` so
+            downstream consumers can pick the variant deliberately.
+            Defaults to ``False`` (legacy exemplar-bearing behaviour).
     """
 
     def __init__(
@@ -799,6 +887,7 @@ class SkillTreeGenerator:
         min_eddy_fragments: int = DEFAULT_MIN_EDDY_FRAGMENTS,
         max_exemplars: int = DEFAULT_MAX_EXEMPLARS,
         allow_intimate: bool = False,
+        signature_only: bool = False,
     ) -> None:
         """Initialise the generator with the given configuration.
 
@@ -810,6 +899,10 @@ class SkillTreeGenerator:
             max_exemplars: Maximum exemplar passages per skill.
             allow_intimate: Whether to include ``intimate`` privacy
                 tier fragments during harvesting.
+            signature_only: When ``True``, write the signature-only
+                variant (issue #353) — abstract patterns only, no
+                quoted user content, ``.SIGNATURE.md`` suffix. The two
+                variants are designed to coexist in the same vault.
 
         Raises:
             ValueError: When any numeric threshold is negative.
@@ -827,6 +920,7 @@ class SkillTreeGenerator:
         self.min_eddy_fragments = min_eddy_fragments
         self.max_exemplars = max_exemplars
         self.allow_intimate = allow_intimate
+        self.signature_only = signature_only
 
     # -- Public surface ------------------------------------------------
 
@@ -962,25 +1056,32 @@ class SkillTreeGenerator:
             output_dir: Destination directory for the skill tree.
 
         Returns:
-            Paths to the two written meta SKILL files.
+            Paths to the two written meta skill files.
         """
         meta_dir = output_dir / _META_DIR
+        variant = self._variant_tag()
         written: list[Path] = [
             _write_skill(
-                meta_dir / f"voice-core{_SKILL_SUFFIX}",
+                meta_dir
+                / _skill_filename("voice-core", signature_only=self.signature_only),
                 category="meta",
                 key="voice-core",
                 title="Voice Core — Master Profile",
                 body=self._render_voice_core_body(),
                 extra_tags=("voice-core",),
+                variant=variant,
             ),
             _write_skill(
-                meta_dir / f"skill-activation-guide{_SKILL_SUFFIX}",
+                meta_dir
+                / _skill_filename(
+                    "skill-activation-guide", signature_only=self.signature_only
+                ),
                 category="meta",
                 key="skill-activation-guide",
                 title="Skill Activation Guide",
                 body=self._render_activation_guide_body(),
                 extra_tags=("activation-guide",),
+                variant=variant,
             ),
         ]
         return written
@@ -992,14 +1093,16 @@ class SkillTreeGenerator:
         snapshot: VaultSnapshot,
         output_dir: Path,
     ) -> list[Path]:
-        """Render one SKILL.md per frequency using *snapshot* exemplars."""
+        """Render one skill file per frequency using *snapshot* exemplars."""
         target_dir = output_dir / _FREQUENCIES_DIR
         by_frequency = _group_fragments_by_frequency(snapshot.fragments)
         written: list[Path] = []
         for freq_key in FREQUENCY_KEYS:
-            exemplars = self._pick_exemplars(by_frequency.get(freq_key, []))
+            exemplars = self._maybe_pick_exemplars(by_frequency.get(freq_key, []))
             body = self._render_frequency_body(freq_key, exemplars)
-            target = target_dir / f"{freq_key}{_SKILL_SUFFIX}"
+            target = target_dir / _skill_filename(
+                freq_key, signature_only=self.signature_only
+            )
             written.append(
                 _write_skill(
                     target,
@@ -1008,6 +1111,7 @@ class SkillTreeGenerator:
                     title=f"{freq_key}: {FREQUENCY_NAMES[Frequency(freq_key)]}",
                     body=body,
                     extra_tags=(freq_key,),
+                    variant=self._variant_tag(),
                 ),
             )
         return written
@@ -1017,14 +1121,16 @@ class SkillTreeGenerator:
         snapshot: VaultSnapshot,
         output_dir: Path,
     ) -> list[Path]:
-        """Render one SKILL.md per wavelength phase."""
+        """Render one skill file per wavelength phase."""
         target_dir = output_dir / _PHASES_DIR
         by_phase = _group_fragments_by_phase(snapshot.fragments)
         written: list[Path] = []
         for phase_key in PHASE_KEYS:
-            exemplars = self._pick_exemplars(by_phase.get(phase_key, []))
+            exemplars = self._maybe_pick_exemplars(by_phase.get(phase_key, []))
             body = self._render_phase_body(phase_key, exemplars)
-            target = target_dir / f"{phase_key}{_SKILL_SUFFIX}"
+            target = target_dir / _skill_filename(
+                phase_key, signature_only=self.signature_only
+            )
             written.append(
                 _write_skill(
                     target,
@@ -1033,6 +1139,7 @@ class SkillTreeGenerator:
                     title=f"Phase: {phase_key.replace('_', ' ').title()}",
                     body=body,
                     extra_tags=(phase_key,),
+                    variant=self._variant_tag(),
                 ),
             )
         return written
@@ -1042,26 +1149,28 @@ class SkillTreeGenerator:
         snapshot: VaultSnapshot,
         output_dir: Path,
     ) -> list[Path]:
-        """Render one SKILL.md per Mode/Orientation pair."""
+        """Render one skill file per Mode/Orientation pair."""
         target_dir = output_dir / _MODES_DIR
         by_pair = _group_fragments_by_mode_orientation(snapshot.fragments)
         written: list[Path] = []
         for mode_key, orientation_key in MODE_ORIENTATION_KEYS:
             pair = (mode_key, orientation_key)
-            exemplars = self._pick_exemplars(by_pair.get(pair, []))
+            exemplars = self._maybe_pick_exemplars(by_pair.get(pair, []))
             body = self._render_mode_body(mode_key, orientation_key, exemplars)
-            filename = _mode_orientation_key(mode_key, orientation_key)
+            stem = _mode_orientation_key(mode_key, orientation_key)
+            filename = _skill_filename(stem, signature_only=self.signature_only)
             title = (
                 f"{mode_key.capitalize()}-{orientation_key.replace('_', '/').title()}"
             )
             written.append(
                 _write_skill(
-                    target_dir / f"{filename}{_SKILL_SUFFIX}",
+                    target_dir / filename,
                     category="mode",
-                    key=filename,
+                    key=stem,
                     title=title,
                     body=body,
                     extra_tags=(mode_key, orientation_key),
+                    variant=self._variant_tag(),
                 ),
             )
         return written
@@ -1071,21 +1180,23 @@ class SkillTreeGenerator:
         snapshot: VaultSnapshot,
         output_dir: Path,
     ) -> list[Path]:
-        """Render one SKILL.md per voice register."""
+        """Render one skill file per voice register."""
         target_dir = output_dir / _REGISTERS_DIR
         by_register = _group_fragments_by_register(snapshot.fragments)
         written: list[Path] = []
         for register_key in REGISTER_KEYS:
-            exemplars = self._pick_exemplars(by_register.get(register_key, []))
+            exemplars = self._maybe_pick_exemplars(by_register.get(register_key, []))
             body = self._render_register_body(register_key, exemplars)
+            filename = _skill_filename(register_key, signature_only=self.signature_only)
             written.append(
                 _write_skill(
-                    target_dir / f"{register_key}{_SKILL_SUFFIX}",
+                    target_dir / filename,
                     category="register",
                     key=register_key,
                     title=f"Register: {register_key.title()}",
                     body=body,
                     extra_tags=(register_key,),
+                    variant=self._variant_tag(),
                 ),
             )
         return written
@@ -1095,7 +1206,7 @@ class SkillTreeGenerator:
         snapshot: VaultSnapshot,
         output_dir: Path,
     ) -> list[Path]:
-        """Render one SKILL.md per qualifying thread."""
+        """Render one skill file per qualifying thread."""
         target_dir = output_dir / _THREADS_DIR
         qualifying = [
             thread
@@ -1108,14 +1219,16 @@ class SkillTreeGenerator:
             body = self._render_thread_body(thread)
             slug = _unique_slug(_slugify(thread.title), thread.id, used_slugs)
             used_slugs.add(slug)
+            filename = _skill_filename(slug, signature_only=self.signature_only)
             written.append(
                 _write_skill(
-                    target_dir / f"{slug}{_SKILL_SUFFIX}",
+                    target_dir / filename,
                     category="thread",
                     key=thread.id,
                     title=f"Thread: {thread.title}",
                     body=body,
                     extra_tags=("thread",),
+                    variant=self._variant_tag(),
                 ),
             )
         return written
@@ -1125,7 +1238,7 @@ class SkillTreeGenerator:
         snapshot: VaultSnapshot,
         output_dir: Path,
     ) -> list[Path]:
-        """Render one SKILL.md per qualifying eddy."""
+        """Render one skill file per qualifying eddy."""
         target_dir = output_dir / _EDDIES_DIR
         qualifying = [
             eddy
@@ -1138,14 +1251,16 @@ class SkillTreeGenerator:
             body = self._render_eddy_body(eddy)
             slug = _unique_slug(_slugify(eddy.title), eddy.id, used_slugs)
             used_slugs.add(slug)
+            filename = _skill_filename(slug, signature_only=self.signature_only)
             written.append(
                 _write_skill(
-                    target_dir / f"{slug}{_SKILL_SUFFIX}",
+                    target_dir / filename,
                     category="eddy",
                     key=eddy.id,
                     title=f"Eddy: {eddy.title}",
                     body=body,
                     extra_tags=("eddy",),
+                    variant=self._variant_tag(),
                 ),
             )
         return written
@@ -1167,6 +1282,41 @@ class SkillTreeGenerator:
                 break
         return exemplars
 
+    def _maybe_pick_exemplars(
+        self,
+        candidates: list[tuple[Fragment, str]],
+    ) -> list[SkillExemplar]:
+        """Return exemplars, or an empty list when signature-only is set.
+
+        In signature-only mode the renderers must never see any
+        exemplars: this keeps the abstract-only contract enforceable at
+        a single chokepoint rather than relying on every renderer to
+        remember to filter (issue #353).
+        """
+        if self.signature_only:
+            return []
+        return self._pick_exemplars(candidates)
+
+    def _variant_tag(self) -> str:
+        """Return the frontmatter variant tag for the current mode."""
+        return _VARIANT_SIGNATURE if self.signature_only else _VARIANT_SKILL
+
+    def _maybe_render_exemplar_section(
+        self,
+        exemplars: list[SkillExemplar],
+    ) -> list[str]:
+        """Return the rendered exemplar section, or no sections at all.
+
+        Signature-only files (issue #353) must omit the exemplar
+        section entirely so no quoted user content — including the
+        placeholder fallback — appears in the output. Splat the return
+        value into the renderer's join sequence so callers do not need
+        to special-case the mode.
+        """
+        if self.signature_only:
+            return []
+        return [_render_exemplar_section(exemplars)]
+
     # -- Renderers ----------------------------------------------------
 
     def _render_frequency_body(
@@ -1174,7 +1324,7 @@ class SkillTreeGenerator:
         freq_key: str,
         exemplars: list[SkillExemplar],
     ) -> str:
-        """Render the full markdown body for a Frequency SKILL."""
+        """Render the full markdown body for a Frequency skill file."""
         freq = Frequency(freq_key)
         name = FREQUENCY_NAMES[freq]
         theme = FREQUENCY_THEMES[freq]
@@ -1204,7 +1354,7 @@ class SkillTreeGenerator:
             [
                 activation,
                 _render_section("Description", description),
-                _render_exemplar_section(exemplars),
+                *self._maybe_render_exemplar_section(exemplars),
                 _render_section("Writing Instructions", instructions),
                 _render_section("Anti-Patterns", anti_patterns),
                 _render_section("Combining With Other Skills", combination),
@@ -1241,7 +1391,7 @@ class SkillTreeGenerator:
             [
                 activation,
                 _render_section("Description", description),
-                _render_exemplar_section(exemplars),
+                *self._maybe_render_exemplar_section(exemplars),
                 _render_section("Writing Instructions", instructions),
                 _render_section("Anti-Patterns", anti_patterns),
                 _render_section("Combining With Other Skills", combination),
@@ -1282,7 +1432,7 @@ class SkillTreeGenerator:
             [
                 activation,
                 _render_section("Description", description),
-                _render_exemplar_section(exemplars),
+                *self._maybe_render_exemplar_section(exemplars),
                 _render_section("Writing Instructions", instructions),
                 _render_section("Anti-Patterns", anti_patterns),
                 _render_section("Combining With Other Skills", combination),
@@ -1316,7 +1466,7 @@ class SkillTreeGenerator:
             [
                 activation,
                 _render_section("Description", description),
-                _render_exemplar_section(exemplars),
+                *self._maybe_render_exemplar_section(exemplars),
                 _render_section(
                     "Writing Instructions",
                     instructions,

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1790,6 +1790,68 @@ def test_skills_command(tmp_path: Path) -> None:
     assert result.exit_code == 0
 
 
+def test_skills_signature_only_flag_emits_signature_files(tmp_path: Path) -> None:
+    """``--signature-only`` writes .SIGNATURE.md files alongside no SKILL ones."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    output = tmp_path / "out"
+    result = runner.invoke(
+        app,
+        [
+            "skills",
+            "generate",
+            "--generate",
+            "--signature-only",
+            "--vault",
+            str(vault),
+            "--output",
+            str(output),
+        ],
+    )
+    assert result.exit_code == 0
+    assert "signature-only" in result.output
+    signature_files = list(output.rglob("*.SIGNATURE.md"))
+    skill_files = list(output.rglob("*.SKILL.md"))
+    assert signature_files, "expected signature files to be written"
+    assert not skill_files, "signature-only run must not emit .SKILL.md"
+
+
+def test_skills_both_variants_can_coexist(tmp_path: Path) -> None:
+    """Running with and without ``--signature-only`` produces both trees."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    output = tmp_path / "out"
+    default_run = runner.invoke(
+        app,
+        [
+            "skills",
+            "generate",
+            "--generate",
+            "--vault",
+            str(vault),
+            "--output",
+            str(output),
+        ],
+    )
+    assert default_run.exit_code == 0
+    signature_run = runner.invoke(
+        app,
+        [
+            "skills",
+            "generate",
+            "--generate",
+            "--signature-only",
+            "--vault",
+            str(vault),
+            "--output",
+            str(output),
+        ],
+    )
+    assert signature_run.exit_code == 0
+    assert list(output.rglob("*.SKILL.md"))
+    assert list(output.rglob("*.SIGNATURE.md"))
+
+
 def test_mine_help() -> None:
     """Test that mine --help shows subcommand help."""
     result = runner.invoke(app, ["mine", "--help"])

--- a/creek-tools/tests/test_skills.py
+++ b/creek-tools/tests/test_skills.py
@@ -1358,3 +1358,330 @@ class TestSnapshotInvalidFragments:
         generator.generate_register_skills(vault, output_dir)
         body = (output_dir / "registers" / "prophetic.SKILL.md").read_text()
         assert "Prophetic line" in body
+
+
+# ---- Signature-only variant (issue #353) ----
+
+
+SIGNATURE_PASSAGE_MARKER = "Verbatim user prose: standing in my heat alone"
+
+
+def _populated_vault_for_signature_tests(vault_path: Path) -> Fragment:
+    """Write a single proxy-eligible fragment whose body is recognisable.
+
+    Used by signature-only tests to guarantee that the ``SKILL`` variant
+    contains a quoted exemplar while the ``SIGNATURE`` variant does not.
+    """
+    fragment = _build_fragment(
+        frag_id="frag-sig-marker",
+        title="Standing in my heat",
+        frequency=Frequency.F3,
+        phase=Phase.RISING,
+        mode=Mode.EXPRESS,
+        orientation=Orientation.DO,
+        register=VoiceRegister.CONFESSIONAL,
+    )
+    body = (
+        f"{SIGNATURE_PASSAGE_MARKER} for the very first sentence, with "
+        "more than the minimum number of words required to register as "
+        "substantive voice data inside the passage extractor. "
+        f"{SIGNATURE_PASSAGE_MARKER} once more in a second sentence so the "
+        "extractor has multiple sentences to choose between."
+    )
+    _write_fragment(vault_path, fragment, body)
+    return fragment
+
+
+class TestSignatureOnlyConstructor:
+    """``signature_only`` is exposed as a constructor flag."""
+
+    def test_default_signature_only_is_false(self) -> None:
+        """The default mode keeps backwards-compatible SKILL behaviour."""
+        generator = SkillTreeGenerator()
+        assert not generator.signature_only
+
+    def test_signature_only_flag_is_accepted(self) -> None:
+        """Passing ``signature_only=True`` is preserved on the instance."""
+        generator = SkillTreeGenerator(signature_only=True)
+        assert generator.signature_only
+
+
+class TestSignatureOnlyVariant:
+    """Signature-only generation strips quoted exemplars and fragment IDs."""
+
+    def test_signature_only_uses_signature_suffix(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """Signature files are written under ``F*.SIGNATURE.md``."""
+        paths = SkillTreeGenerator(
+            signature_only=True,
+        ).generate_frequency_skills(vault, output_dir)
+        assert all(p.name.endswith(".SIGNATURE.md") for p in paths)
+        assert not any(p.name.endswith(".SKILL.md") for p in paths)
+
+    def test_signature_only_skips_exemplar_section(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """Signature-only output omits the ``## Exemplar Passages`` heading."""
+        _populated_vault_for_signature_tests(vault)
+        generator = SkillTreeGenerator(signature_only=True)
+        generator.generate_frequency_skills(vault, output_dir)
+        body = (output_dir / "frequencies" / "F3.SIGNATURE.md").read_text()
+        assert "## Exemplar Passages" not in body
+
+    def test_signature_only_excludes_quoted_passages(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """No quoted prose from any fragment should reach the signature output."""
+        _populated_vault_for_signature_tests(vault)
+        generator = SkillTreeGenerator(signature_only=True)
+        generator.generate_frequency_skills(vault, output_dir)
+        body = (output_dir / "frequencies" / "F3.SIGNATURE.md").read_text()
+        assert SIGNATURE_PASSAGE_MARKER not in body
+
+    def test_signature_only_excludes_fragment_ids(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """Fragment IDs never appear in signature-only files."""
+        fragment = _populated_vault_for_signature_tests(vault)
+        generator = SkillTreeGenerator(signature_only=True)
+        generator.generate_frequency_skills(vault, output_dir)
+        body = (output_dir / "frequencies" / "F3.SIGNATURE.md").read_text()
+        assert fragment.id not in body
+
+    def test_signature_only_preserves_voice_texture(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """All non-exemplar dimension fields remain populated."""
+        generator = SkillTreeGenerator(signature_only=True)
+        generator.generate_frequency_skills(vault, output_dir)
+        body = (output_dir / "frequencies" / "F3.SIGNATURE.md").read_text()
+        # The non-exemplar sections must still be present.
+        assert "# Activation" in body
+        assert "## Description" in body
+        assert "## Writing Instructions" in body
+        assert "## Anti-Patterns" in body
+        assert "## Combining With Other Skills" in body
+        # Voice texture content (from FREQUENCY_VOICE_TEXTURES["F3"])
+        # must still drive the body so the LLM keeps signature guidance.
+        assert "Declarative first-person" in body
+
+    def test_signature_only_announces_variant_in_header(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """Each signature file begins with a variant declaration header."""
+        generator = SkillTreeGenerator(signature_only=True)
+        generator.generate_frequency_skills(vault, output_dir)
+        body = (output_dir / "frequencies" / "F3.SIGNATURE.md").read_text()
+        assert "Variant: SIGNATURE" in body
+        assert "no quoted user content" in body.lower()
+
+    def test_default_variant_announces_skill_header(
+        self,
+        vault: Path,
+        output_dir: Path,
+        generator: SkillTreeGenerator,
+    ) -> None:
+        """The legacy SKILL variant declares itself in its own header."""
+        generator.generate_frequency_skills(vault, output_dir)
+        body = (output_dir / "frequencies" / "F3.SKILL.md").read_text()
+        assert "Variant: SKILL" in body
+
+    def test_signature_only_frontmatter_records_variant(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """The frontmatter ``variant`` field distinguishes the two variants."""
+        generator = SkillTreeGenerator(signature_only=True)
+        generator.generate_frequency_skills(vault, output_dir)
+        post = frontmatter.load(
+            str(output_dir / "frequencies" / "F3.SIGNATURE.md"),
+        )
+        assert post.metadata["variant"] == "signature"
+
+    def test_default_variant_frontmatter_records_skill(
+        self,
+        vault: Path,
+        output_dir: Path,
+        generator: SkillTreeGenerator,
+    ) -> None:
+        """The default variant records ``variant: skill`` in frontmatter."""
+        generator.generate_frequency_skills(vault, output_dir)
+        post = frontmatter.load(
+            str(output_dir / "frequencies" / "F3.SKILL.md"),
+        )
+        assert post.metadata["variant"] == "skill"
+
+
+class TestSignatureOnlyCovering:
+    """Signature-only generation covers every category of skill."""
+
+    def test_signature_only_covers_phases(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """Phase skill files appear as ``<phase>.SIGNATURE.md``."""
+        paths = SkillTreeGenerator(
+            signature_only=True,
+        ).generate_phase_skills(vault, output_dir)
+        assert len(paths) == 6
+        assert all(p.name.endswith(".SIGNATURE.md") for p in paths)
+
+    def test_signature_only_covers_modes(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """Mode skill files appear with the SIGNATURE suffix."""
+        paths = SkillTreeGenerator(
+            signature_only=True,
+        ).generate_mode_skills(vault, output_dir)
+        assert len(paths) == 9
+        assert all(p.name.endswith(".SIGNATURE.md") for p in paths)
+
+    def test_signature_only_covers_registers(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """Register skill files appear with the SIGNATURE suffix."""
+        paths = SkillTreeGenerator(
+            signature_only=True,
+        ).generate_register_skills(vault, output_dir)
+        assert len(paths) == 7
+        assert all(p.name.endswith(".SIGNATURE.md") for p in paths)
+
+    def test_signature_only_covers_threads(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """Qualifying threads earn a SIGNATURE file (threads have no exemplars)."""
+        thread = Thread(
+            id="thread-sig",
+            title="Signature Thread",
+            status=ThreadStatus.ACTIVE,
+            fragment_count=25,
+            description="Spans many seasons.",
+        )
+        _write_thread(vault, thread)
+        paths = SkillTreeGenerator(
+            signature_only=True,
+        ).generate_thread_skills(vault, output_dir)
+        assert len(paths) == 1
+        assert paths[0].name.endswith(".SIGNATURE.md")
+        body = paths[0].read_text()
+        assert "Variant: SIGNATURE" in body
+
+    def test_signature_only_covers_eddies(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """Qualifying eddies earn a SIGNATURE file."""
+        eddy = Eddy(
+            id="eddy-sig",
+            title="Signature Eddy",
+            fragment_count=42,
+            threads=["thread-sig"],
+            description="Major cluster.",
+        )
+        _write_eddy(vault, eddy)
+        paths = SkillTreeGenerator(
+            signature_only=True,
+        ).generate_eddy_skills(vault, output_dir)
+        assert len(paths) == 1
+        assert paths[0].name.endswith(".SIGNATURE.md")
+
+    def test_signature_only_covers_meta(
+        self,
+        output_dir: Path,
+    ) -> None:
+        """Meta skills carry the SIGNATURE suffix in signature mode."""
+        paths = SkillTreeGenerator(
+            signature_only=True,
+        ).generate_meta_skills(output_dir)
+        assert len(paths) == 2
+        assert all(p.name.endswith(".SIGNATURE.md") for p in paths)
+        body = paths[0].read_text()
+        assert "Variant: SIGNATURE" in body
+
+    def test_signature_only_generate_all_writes_signature_tree(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """``generate_all_skills`` produces only SIGNATURE files when enabled."""
+        paths = SkillTreeGenerator(
+            signature_only=True,
+        ).generate_all_skills(vault, output_dir)
+        assert len(paths) == 34
+        assert all(p.name.endswith(".SIGNATURE.md") for p in paths)
+
+
+class TestSignatureAndSkillCoexist:
+    """Both variants live side-by-side in the same output directory."""
+
+    def test_both_variants_coexist_without_overwrite(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """Running both generators writes distinct files for each variant."""
+        SkillTreeGenerator().generate_frequency_skills(vault, output_dir)
+        SkillTreeGenerator(signature_only=True).generate_frequency_skills(
+            vault,
+            output_dir,
+        )
+        freq_dir = output_dir / "frequencies"
+        assert (freq_dir / "F3.SKILL.md").exists()
+        assert (freq_dir / "F3.SIGNATURE.md").exists()
+        skill_files = sorted(p.name for p in freq_dir.glob("F*.SKILL.md"))
+        signature_files = sorted(p.name for p in freq_dir.glob("F*.SIGNATURE.md"))
+        assert len(skill_files) == 10
+        assert len(signature_files) == 10
+
+    def test_skill_variant_contains_exemplars_when_available(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """The SKILL variant still quotes the user's prose."""
+        _populated_vault_for_signature_tests(vault)
+        SkillTreeGenerator().generate_frequency_skills(vault, output_dir)
+        skill_body = (output_dir / "frequencies" / "F3.SKILL.md").read_text()
+        assert SIGNATURE_PASSAGE_MARKER in skill_body
+        assert "## Exemplar Passages" in skill_body
+
+    def test_signature_variant_remains_clean_alongside_skill(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """The SIGNATURE variant must stay quote-free even when SKILL ran first."""
+        _populated_vault_for_signature_tests(vault)
+        SkillTreeGenerator().generate_frequency_skills(vault, output_dir)
+        SkillTreeGenerator(signature_only=True).generate_frequency_skills(
+            vault,
+            output_dir,
+        )
+        signature_body = (output_dir / "frequencies" / "F3.SIGNATURE.md").read_text()
+        assert SIGNATURE_PASSAGE_MARKER not in signature_body
+        assert "## Exemplar Passages" not in signature_body
+        # The legacy file remained intact across the second generation pass.
+        skill_body = (output_dir / "frequencies" / "F3.SKILL.md").read_text()
+        assert SIGNATURE_PASSAGE_MARKER in skill_body

--- a/creek-tools/tests/test_skills.py
+++ b/creek-tools/tests/test_skills.py
@@ -1525,6 +1525,67 @@ class TestSignatureOnlyVariant:
         )
         assert post.metadata["variant"] == "skill"
 
+    def test_default_variant_tags_do_not_duplicate_skill(
+        self,
+        vault: Path,
+        output_dir: Path,
+        generator: SkillTreeGenerator,
+    ) -> None:
+        """Legacy SKILL frontmatter ``tags`` list contains ``skill`` exactly once.
+
+        Regression for PR #357 review: the previous tag list expanded
+        ``[\"skill\", category, variant, ...]`` with ``variant == \"skill\"``,
+        yielding two identical ``\"skill\"`` entries that confuse any
+        downstream consumer that parses the raw frontmatter.
+        """
+        generator.generate_frequency_skills(vault, output_dir)
+        post = frontmatter.load(
+            str(output_dir / "frequencies" / "F3.SKILL.md"),
+        )
+        tags = post.metadata["tags"]
+        assert tags.count("skill") == 1
+        assert "frequency" in tags
+
+    def test_signature_variant_tags_include_signature_marker(
+        self,
+        vault: Path,
+        output_dir: Path,
+    ) -> None:
+        """The SIGNATURE variant gets a distinguishing ``signature`` tag.
+
+        The tag is what lets a downstream loader filter for the new
+        variant; dropping it would erase the only frontmatter-level
+        difference between the two trees beyond the filename suffix.
+        """
+        generator = SkillTreeGenerator(signature_only=True)
+        generator.generate_frequency_skills(vault, output_dir)
+        post = frontmatter.load(
+            str(output_dir / "frequencies" / "F3.SIGNATURE.md"),
+        )
+        tags = post.metadata["tags"]
+        assert "signature" in tags
+        assert tags.count("skill") == 1
+
+    def test_skill_header_does_not_reference_dead_signature_file(
+        self,
+        vault: Path,
+        output_dir: Path,
+        generator: SkillTreeGenerator,
+    ) -> None:
+        """Default SKILL banner does not point at a possibly-missing SIGNATURE file.
+
+        Regression for PR #357 review: the previous banner read \"see the
+        matching ``.SIGNATURE.md`` file\", which is a dead reference for
+        any operator who has only ever run the default command. The
+        replacement banner names the CLI invocation that produces the
+        alternative variant instead.
+        """
+        generator.generate_frequency_skills(vault, output_dir)
+        body = (output_dir / "frequencies" / "F3.SKILL.md").read_text()
+        assert "matching" not in body
+        assert "see the matching" not in body
+        assert "--signature-only" in body
+
 
 class TestSignatureOnlyCovering:
     """Signature-only generation covers every category of skill."""


### PR DESCRIPTION
## Summary

Adds a **signature-only** variant to `creek skills generate` (issue #353, part of epic #349). The new mode emits skill files containing only abstract voice patterns — voice texture, anti-patterns, writing instructions, register prompts — with **zero quoted exemplar passages** from the user's classified Fragments. The variant lives alongside the legacy `.SKILL.md` tree under `.SIGNATURE.md` filenames so downstream composition code can choose which variant to load without ambiguity.

The motivation, per the issue body: when the composition path pulls real source material separately, quoted exemplars inside the skill file become a third source of prose that biases the LLM toward replicating specific passages. Separating signature from exemplars lets style come from the SKILL and content come from retrieval.

## Changes

- `SkillTreeGenerator(signature_only=True)` switches every category (frequencies, phases, modes, registers, threads, eddies, meta) to the signature-only variant: the exemplar section is omitted entirely (including the "No qualifying exemplars" placeholder), `.SIGNATURE.md` filenames are used, and frontmatter records `variant: signature`.
- A variant declaration banner appears at the top of every generated file's body so a reader (or downstream loader) can tell at a glance which variant they have.
- New `--signature-only` flag on `creek skills generate` wires the feature through the CLI. The legacy `--generate` behaviour without the flag is unchanged.
- Both variants can coexist in the same output directory; running the generator twice (once without, once with `--signature-only`) produces two parallel trees of 34 files each, no collisions.

## Test plan

- [x] Unit tests verify no fragment IDs and no quoted exemplar paragraphs appear in `*.SIGNATURE.md` output
- [x] Unit tests verify voice-texture descriptors, writing instructions, anti-patterns, and combination guidance are still populated
- [x] Unit tests verify frontmatter `variant` field and the banner header on both variants
- [x] Unit tests verify that running the generator in default and then signature mode in the same output dir produces both file trees side-by-side without overwrites
- [x] CLI tests verify the `--signature-only` flag end-to-end on a fresh vault
- [x] `./scripts/check-all.sh` exits 0 (12 / 12 gates green; 4172 tests pass; aggregate branch coverage 93.73%)

## Touches

- `creek-tools/creek/generate/skills.py` — variant plumbing, banner, helpers
- `creek-tools/creek/cli.py` — `--signature-only` flag
- `creek-tools/tests/test_skills.py` — 21 new tests
- `creek-tools/tests/test_cli.py` — 2 new CLI tests

Closes #353
Part of #349

https://claude.ai/code/session_018XMbrkwQicpFoaSdaAmmEk

---
_Generated by [Claude Code](https://claude.ai/code/session_018XMbrkwQicpFoaSdaAmmEk)_