### PR TITLE
fix(purge): require Creek vault marker before destructive wipe (GAP-003)

### DIFF
--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -64,6 +64,18 @@ _VAULT_CONTENT_FOLDERS: tuple[str, ...] = (
 VAULT_PURGE_CONFIRMATION = "I understand this is irreversible"
 """Exact phrase required to confirm a full-vault purge."""
 
+VAULT_MARKER_RELPATH = ("00-Creek-Meta", "creek_config.yaml")
+"""Relative path to the file that proves a directory is a Creek vault (GAP-003).
+
+The vault marker is the per-vault config file ``creek init`` deploys at
+``<vault>/00-Creek-Meta/creek_config.yaml``. It survives every purge
+operation (``purge_vault`` preserves ``00-Creek-Meta/`` and the audit
+log is mandated non-purgeable), so its absence is a reliable signal
+that the supplied path was never ``creek init``-ed — most likely a
+typo on ``--vault`` that points at an unrelated directory with
+coincidentally numeric-prefix folders.
+"""
+
 _CLASSIFICATION_RESET_FIELDS: tuple[str, ...] = (
     "frequency",
     "wavelength",
@@ -417,7 +429,10 @@ class PurgeEngine:
             A :class:`PurgeResult` describing the destruction.
 
         Raises:
-            ValueError: If ``confirmation`` does not match.
+            ValueError: If ``confirmation`` does not match, or if
+                ``self.vault_path`` does not look like a Creek vault
+                (no ``00-Creek-Meta/creek_config.yaml`` marker file —
+                GAP-003).
         """
         if confirmation != VAULT_PURGE_CONFIRMATION:
             msg = (
@@ -425,6 +440,7 @@ class PurgeEngine:
                 f"{VAULT_PURGE_CONFIRMATION!r}"
             )
             raise ValueError(msg)
+        self._require_vault_marker()
 
         result = PurgeResult(
             operation="vault",
@@ -446,6 +462,32 @@ class PurgeEngine:
         return self._run_audited(result, body)
 
     # -- Private helpers -------------------------------------------------
+
+    def _require_vault_marker(self) -> None:
+        """Refuse to operate on a directory that is not a Creek vault (GAP-003).
+
+        Looks for ``<vault>/00-Creek-Meta/creek_config.yaml`` — the
+        per-vault config file that ``creek init`` deploys and that
+        survives every purge operation. Its absence almost always
+        means the operator typoed ``--vault`` and is pointing at an
+        unrelated directory with coincidentally numeric-prefix
+        folders. Raising here, *before* the intent audit line is
+        written, prevents an entry from being committed to a
+        non-vault's would-be audit log.
+
+        Raises:
+            ValueError: When the marker file is not present. The
+                message names the absolute path of the file the engine
+                looked for so the operator can diagnose the typo.
+        """
+        marker = self.vault_path.joinpath(*VAULT_MARKER_RELPATH)
+        if not marker.is_file():
+            msg = (
+                f"{self.vault_path} does not appear to be a Creek vault "
+                f"(missing marker file {marker}). Run `creek init "
+                f"--vault <path>` first, or fix the --vault argument."
+            )
+            raise ValueError(msg)
 
     def _purge_cache_for(self, fragment_ids: list[str]) -> int:
         """Drop matching rows from the embeddings cache (GAP-001).

--- a/creek-tools/docs/cleaning-and-purge.md
+++ b/creek-tools/docs/cleaning-and-purge.md
@@ -130,7 +130,9 @@ creek purge daterange --start 2025-01-01 --end 2025-01-31 --vault ~/Obsidian/Cre
 
 Nuclear option: destroys every fragment, thread, eddy, and resonance. Leaves the directory structure and `00-Creek-Meta/` intact. This is **never** undoable.
 
-Outside of `--dry-run`, the command refuses to proceed unless one of these is true:
+Before the wipe loop runs, the engine verifies that the target directory is a Creek vault by checking for the `00-Creek-Meta/creek_config.yaml` marker file that `creek init` deploys (GAP-003). The check runs *before* the intent audit line is written, so a refusal leaves the audit log untouched. Both the interactive and `--force-non-interactive` paths go through the same check — no carve-out. A `--vault` typo that points at an unrelated directory with coincidentally numeric-prefix folders therefore exits non-zero with a clear message naming the marker the engine looked for, rather than silently wiping the wrong tree.
+
+Outside of `--dry-run`, the command then refuses to proceed unless one of these is true:
 
 - **Interactive run.** stdin is attached to a real TTY and the operator types the **absolute path** of the vault when prompted (not the literal string `"yes"`). Typing the wrong path aborts.
 - **Explicit non-interactive opt-in.** The command was invoked with `--force-non-interactive` *and* a valid `--confirm-text "I understand this is irreversible"`. This path emits a `WARNING` log entry so the audit trail records the bypass.

--- a/creek-tools/tests/test_mcp_purge.py
+++ b/creek-tools/tests/test_mcp_purge.py
@@ -45,6 +45,11 @@ def vault(tmp_path: Path) -> Iterator[Path]:
         ("03-Eddies",),
     ):
         (tmp_path.joinpath(*relparts)).mkdir(parents=True, exist_ok=True)
+    # GAP-003 marker so `purge_vault` recognises this as a Creek vault.
+    (tmp_path / "00-Creek-Meta" / "creek_config.yaml").write_text(
+        "# minimal marker for GAP-003\n",
+        encoding="utf-8",
+    )
     metadata = {
         "type": "fragment",
         "id": "frag-001",

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -33,6 +33,11 @@ runner = CliRunner()
 def _make_vault(tmp_path: Path) -> Path:
     """Create a minimal vault with the directories purge needs.
 
+    Also seeds ``00-Creek-Meta/creek_config.yaml`` — the marker file
+    ``purge_vault`` checks for under GAP-003. Tests that want to
+    simulate a non-Creek directory create their own decoy without
+    going through this helper.
+
     Args:
         tmp_path: Pytest temporary directory.
 
@@ -49,6 +54,10 @@ def _make_vault(tmp_path: Path) -> Path:
         "04-Praxis",
     ]:
         (vault / d).mkdir(parents=True, exist_ok=True)
+    (vault / "00-Creek-Meta" / "creek_config.yaml").write_text(
+        "# minimal marker for GAP-003\n",
+        encoding="utf-8",
+    )
     return vault
 
 
@@ -664,6 +673,115 @@ def test_vault_purge_dry_run_preserves(tmp_path: Path) -> None:
     assert result.dry_run is True
     assert result.fragments_affected >= 1
     assert frag.exists()
+
+
+# ---------------------------------------------------------------------------
+# GAP-003 — purge_vault refuses directories that are not Creek vaults
+# ---------------------------------------------------------------------------
+
+
+def test_vault_purge_refuses_directory_with_no_meta_folder(
+    tmp_path: Path,
+) -> None:
+    """A directory missing ``00-Creek-Meta/`` is not a Creek vault (GAP-003).
+
+    The decoy looks vault-ish (numeric-prefix folders, ``.md`` files
+    inside) but was never ``creek init``-ed. Engine must refuse and the
+    decoy files must survive.
+    """
+    decoy = tmp_path / "not-a-vault"
+    (decoy / "01-Fragments").mkdir(parents=True)
+    important = decoy / "01-Fragments" / "important.md"
+    important.write_text("hello", encoding="utf-8")
+    engine = PurgeEngine(decoy)
+
+    with pytest.raises(ValueError, match="does not appear to be a Creek vault"):
+        engine.purge_vault(VAULT_PURGE_CONFIRMATION)
+
+    assert important.exists()
+
+
+def test_vault_purge_refuses_directory_with_meta_but_no_config(
+    tmp_path: Path,
+) -> None:
+    """``00-Creek-Meta/`` alone isn't enough — ``creek_config.yaml`` is the marker."""
+    decoy = tmp_path / "half-vault"
+    (decoy / "00-Creek-Meta").mkdir(parents=True)
+    (decoy / "01-Fragments").mkdir(parents=True)
+    important = decoy / "01-Fragments" / "important.md"
+    important.write_text("hello", encoding="utf-8")
+    engine = PurgeEngine(decoy)
+
+    with pytest.raises(ValueError, match="does not appear to be a Creek vault"):
+        engine.purge_vault(VAULT_PURGE_CONFIRMATION)
+
+    assert important.exists()
+
+
+def test_vault_purge_error_message_names_the_marker_file(
+    tmp_path: Path,
+) -> None:
+    """The error names the marker file the engine looked for (criterion 2)."""
+    decoy = tmp_path / "decoy"
+    decoy.mkdir()
+    engine = PurgeEngine(decoy)
+
+    with pytest.raises(ValueError, match=r"creek_config\.yaml"):
+        engine.purge_vault(VAULT_PURGE_CONFIRMATION)
+
+
+def test_vault_purge_accepts_directory_with_marker(tmp_path: Path) -> None:
+    """A directory carrying the marker is recognised as a Creek vault."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+
+    # No exception raised — the marker created by _make_vault suffices.
+    PurgeEngine(vault).purge_vault(VAULT_PURGE_CONFIRMATION)
+
+
+def test_vault_purge_writes_no_audit_when_marker_missing(
+    tmp_path: Path,
+) -> None:
+    """Marker check runs *before* the intent audit entry (criterion 1).
+
+    A refusal must leave the audit log untouched; otherwise an operator
+    can't tell the marker-missing case apart from a successful purge by
+    looking at the log alone.
+    """
+    decoy = tmp_path / "decoy"
+    decoy.mkdir()
+    engine = PurgeEngine(decoy)
+
+    with pytest.raises(ValueError, match="does not appear to be a Creek vault"):
+        engine.purge_vault(VAULT_PURGE_CONFIRMATION)
+
+    audit_path = decoy / "00-Creek-Meta" / "audit" / "purge.jsonl"
+    assert not audit_path.exists()
+
+
+def test_cli_purge_vault_refuses_non_creek_directory(tmp_path: Path) -> None:
+    """``creek purge vault`` exits non-zero with a clear message (criterion 2)."""
+    decoy = tmp_path / "decoy"
+    (decoy / "01-Fragments").mkdir(parents=True)
+    survivor = decoy / "01-Fragments" / "x.md"
+    survivor.write_text("hi", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "purge",
+            "vault",
+            "--vault",
+            str(decoy),
+            "--confirm-text",
+            VAULT_PURGE_CONFIRMATION,
+            "--force-non-interactive",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "does not appear to be a Creek vault" in result.output
+    assert survivor.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`creek purge vault` previously wiped any directory whose layout
happened to include `01-Fragments` through `10-Liminal` — including
unrelated trees a user accidentally pointed at via a `--vault` typo.
The interactive "type the absolute path back" prompt did not help,
because the prompt was *derived* from the typo and echoed it for
typed confirmation.

`PurgeEngine.purge_vault` now checks for the
`00-Creek-Meta/creek_config.yaml` marker file that `creek init`
deploys (and that every other purge operation preserves) **before**
writing the GAP-002 intent audit line and **before** the wipe loop.
A missing marker raises `ValueError` naming the file the engine
looked for; the CLI's existing ValueError handler surfaces it as
`typer.Exit(code=1)` with an actionable message.

The check lives inside the engine so both the interactive and
`--force-non-interactive` paths flow through the same guard — no
carve-out. Refusals leave the audit log untouched, so an operator
can tell a marker-missing refusal apart from a successful purge by
looking at the log alone.

Tests cover: non-Creek directory rejected, half-vault (folder
present but no config) rejected, fresh init-style vault accepted,
audit log untouched on refusal, and the CLI exit-code contract.
The existing `_make_vault` test fixture now seeds the marker so
the 90 prior vault-purge tests continue to pass unchanged.