### PR TITLE
chore: gitignore .claude/worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@
 **/.vscode/
 **/*.swp
 **/*.swo
+
+# Claude Code local worktrees
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `.claude/worktrees/` to `.gitignore` so local Claude Code worktree directories never get tracked.

## Test plan
- [x] `.gitignore` updated; no other files changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XTiWTjERme6uYE8HACrcQk)_