### PR TITLE
fix(purge): scrub fragment-ID references vault-wide, not just in 02/03 (GAP-004)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2638,7 +2638,14 @@ def purge_fragment(
         help="Skip interactive confirmation",
     ),
 ) -> None:
-    """Delete a fragment and scrub every reference to it."""
+    """Delete a fragment and scrub every reference to it.
+
+    Scrubbing covers (GAP-004): wiki-links by title removed from every
+    `.md` file in the vault, plus YAML provenance lists and bare body
+    mentions of the fragment ID replaced with ``[purged]`` across
+    01-Fragments through 10-Liminal and the deployed Skills tree.
+    Embedding-cache rows for the fragment are also dropped (GAP-001).
+    """
     engine = _build_engine(vault, dry_run=dry_run)
     if not dry_run and not _confirm(
         f"Purge fragment {fragment_id!r} and all references?",
@@ -2705,7 +2712,10 @@ def purge_source(
       a configurable ``--match`` mode (INC-008): ``exact`` (default),
       ``substring``, or ``regex``.
 
-    The two are mutually exclusive; pass exactly one.
+    The two are mutually exclusive; pass exactly one. Reference
+    scrubbing (GAP-004) runs for every matched fragment: wiki-links
+    by title plus word-boundary ID mentions replaced with
+    ``[purged]`` across the whole vault.
     """
     if (source_type is None) == (source_path is None):
         console.print(

--- a/creek-tools/creek/purge/audit.py
+++ b/creek-tools/creek/purge/audit.py
@@ -78,6 +78,11 @@ class PurgeAuditEntry(BaseModel):
             ``<vault>/00-Creek-Meta/embeddings.parquet`` by the purge
             (GAP-001). Zero when the cache had not been built yet or
             when no rows matched; the actual row delta otherwise.
+        provenance_scrubbed: Number of bare fragment-ID mentions
+            replaced with ``[purged]`` across derived content (GAP-004).
+            Counts YAML provenance lists (e.g. ``source_fragments`` in
+            drafts) plus body-text mentions of the ID. Wiki-link
+            removals stay on ``references_scrubbed``.
         operator: Who performed the purge.
         dry_run: Whether the purge was a dry-run preview.
         phase: GAP-002 discriminator. ``"intent"`` is written before
@@ -106,6 +111,7 @@ class PurgeAuditEntry(BaseModel):
     fragments_deleted: int = 0
     references_scrubbed: int = 0
     embeddings_removed: int = 0
+    provenance_scrubbed: int = 0
     operator: str = _DEFAULT_OPERATOR
     dry_run: bool = False
 
@@ -137,6 +143,7 @@ def _coerce_legacy_entry(raw: dict[str, Any]) -> dict[str, Any]:
     upgraded.setdefault("affected_fragments", [])
     upgraded.setdefault("references_scrubbed", 0)
     upgraded.setdefault("embeddings_removed", 0)
+    upgraded.setdefault("provenance_scrubbed", 0)
     # GAP-002 fields take their schema defaults via Pydantic when
     # absent, so we leave them out here rather than fabricating a
     # phase / operation_id that doesn't correspond to anything on disk.
@@ -303,6 +310,7 @@ class PurgeAuditLog:
             "fragments_deleted": 0,
             "references_scrubbed": 0,
             "embeddings_removed": 0,
+            "provenance_scrubbed": 0,
             "operator": "system",
             "dry_run": False,
             "migrated_entries": migrated_count,

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -95,6 +95,16 @@ must be classified explicitly here — defaulting unknown operations to
 "deletes files" would risk over-counting deletions in audit entries.
 """
 
+PURGED_MARKER = "[purged]"
+"""GAP-004 replacement string for scrubbed fragment-ID references.
+
+Used by :meth:`PurgeEngine._scrub_provenance` for both YAML frontmatter
+list entries (e.g. ``source_fragments: [...]`` in drafts) and bare
+fragment-ID mentions in body text. A literal placeholder leaves a
+forensic trail — the user can see *that* a reference existed — without
+exposing the original ID, satisfying the RTBF contract.
+"""
+
 
 def _str_list(value: object) -> list[str]:
     """Coerce a frontmatter list value into a list of strings.
@@ -130,6 +140,11 @@ class PurgeResult(BaseModel):
             removed (or would be removed in a dry run). Zero for
             metadata-only operations and for runs where the cache had
             no matching rows (GAP-001).
+        provenance_scrubbed: Number of fragment-ID mentions replaced
+            with ``[purged]`` across the vault (GAP-004). Counts YAML
+            list entries (e.g. ``source_fragments``) and bare body-text
+            mentions in every ``.md`` file; the wiki-link count stays
+            on :attr:`wikilinks_removed`.
     """
 
     operation: str
@@ -144,6 +159,7 @@ class PurgeResult(BaseModel):
     eddies_updated: int = 0
     classifications_reset: int = 0
     embeddings_removed: int = 0
+    provenance_scrubbed: int = 0
 
 
 class PurgeEngine:
@@ -207,6 +223,10 @@ class PurgeEngine:
             result.fragments_affected = 1
             result.wikilinks_removed = self._scrub_wikilinks(
                 title,
+                exclude=frag_file,
+            )
+            result.provenance_scrubbed += self._scrub_provenance(
+                fragment_id,
                 exclude=frag_file,
             )
             result.threads_updated = self._decrement_counts(
@@ -559,6 +579,11 @@ class PurgeEngine:
             title,
             exclude=frag_file,
         )
+        if isinstance(frag_id, str):
+            result.provenance_scrubbed += self._scrub_provenance(
+                frag_id,
+                exclude=frag_file,
+            )
         result.threads_updated += self._decrement_counts(
             "02-Threads",
             thread_ids,
@@ -713,6 +738,51 @@ class PurgeEngine:
         if count and not self.dry_run:
             md_file.write_text(new_text, encoding="utf-8")
         return count
+
+    def _scrub_provenance(self, fragment_id: str, *, exclude: Path) -> int:
+        """Replace word-boundary ``fragment_id`` mentions with ``[purged]`` (GAP-004).
+
+        Walks every ``.md`` file in the vault — derived content under
+        ``04-Praxis``, ``05-Wavelength``, ``07-Voice/Drafts``,
+        ``08-Decisions``, the deployed skill tree under
+        ``00-Creek-Meta/Skills``, etc. — and replaces bare
+        fragment-ID occurrences with the :data:`PURGED_MARKER`
+        placeholder. Catches both YAML provenance list entries
+        (``source_fragments: [frag-…]`` in drafts and mining ideas)
+        and prose mentions of the ID in the body in a single pass.
+
+        The compliance audit log at
+        ``00-Creek-Meta/audit/purge.jsonl`` is a JSONL file (not
+        Markdown) so the recursive walk naturally excludes it — the
+        audit's ``affected_fragments`` list keeps the real ID for
+        compliance reconstruction.
+
+        Wiki-links to the fragment's *title* are still scrubbed by
+        :meth:`_scrub_wikilinks` because they match by name, not by ID.
+
+        Args:
+            fragment_id: The exact fragment ID to scrub.
+            exclude: Path to skip (the file currently being deleted).
+
+        Returns:
+            Total number of replacements across the vault.
+        """
+        if not fragment_id:
+            return 0
+        pattern = re.compile(rf"\b{re.escape(fragment_id)}\b")
+        total_removed = 0
+        for md_file in self._list_vault_md_files():
+            if md_file == exclude:
+                continue
+            try:
+                text = md_file.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            new_text, count = pattern.subn(PURGED_MARKER, text)
+            if count and not self.dry_run:
+                md_file.write_text(new_text, encoding="utf-8")
+            total_removed += count
+        return total_removed
 
     def _decrement_counts(
         self,
@@ -899,6 +969,7 @@ class PurgeEngine:
             fragments_deleted=fragments_deleted,
             references_scrubbed=result.wikilinks_removed,
             embeddings_removed=result.embeddings_removed,
+            provenance_scrubbed=result.provenance_scrubbed,
             dry_run=result.dry_run,
             phase="outcome",
             operation_id=operation_id,

--- a/creek-tools/docs/cleaning-and-purge.md
+++ b/creek-tools/docs/cleaning-and-purge.md
@@ -70,8 +70,8 @@ creek clean report --vault ~/Obsidian/Creek-Vault
 
 1. **Refuses without confirmation** unless you pass `--yes`.
 2. **Records an audit entry** by appending one JSONL line to `<vault>/00-Creek-Meta/audit/purge.jsonl` with the criteria, the affected fragment IDs, and the operator. The file is hash-chained — see [Audit trail](#audit-trail) for the integrity guarantees.
-3. **Scrubs every reference** — wiki-links pointing at the deleted fragment(s) are removed from every other fragment's frontmatter and body.
-4. **Removes embeddings** from the cache at the next `creek link` run so the deleted content is no longer surfaceable through resonances.
+3. **Scrubs every reference** — wiki-links pointing at the deleted fragment(s) are removed from every other `.md` file in the vault (matched by title), and every word-boundary mention of the deleted fragment ID is replaced with the `[purged]` placeholder across YAML frontmatter (e.g. `source_fragments: […]` in drafts and mining ideas) and body text. The walk covers `04-Praxis/`, `05-Wavelength/`, `06-Frequencies/`, `07-Voice/Drafts/`, `08-Decisions/`, `09-Reference/`, `10-Liminal/`, and `00-Creek-Meta/Skills/` (deployed skill tree). The compliance audit log itself (`00-Creek-Meta/audit/purge.jsonl`) is JSONL, not Markdown, and is intentionally excluded — `affected_fragments` in audit entries keeps the real ID for forensic reconstruction (GAP-004).
+4. **Removes embeddings** from `<vault>/00-Creek-Meta/embeddings.parquet` (GAP-001). Per-fragment / per-source / per-date-range purges drop matching rows; `creek purge vault` deletes the file outright.
 
 ### `creek purge fragment`
 

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -2209,3 +2209,218 @@ def test_legacy_audit_entries_default_to_outcome_phase(tmp_path: Path) -> None:
     assert entries[0].phase == "outcome"
     assert entries[0].operation_id == ""
     assert entries[0].status is None
+
+
+# ---------------------------------------------------------------------------
+# GAP-004 — purge scrubs YAML provenance + bare-ID body mentions vault-wide
+# ---------------------------------------------------------------------------
+
+
+def _write_derived_note(
+    vault: Path,
+    *,
+    subfolder: str,
+    name: str,
+    body: str,
+    metadata: dict[str, object] | None = None,
+) -> Path:
+    """Write an arbitrary derived note (praxis / draft / etc.) under *subfolder*."""
+    target_dir = vault / subfolder
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / f"{name}.md"
+    post = frontmatter.Post(content=body, **(metadata or {}))
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return target
+
+
+@pytest.mark.parametrize(
+    "subfolder",
+    [
+        "04-Praxis",
+        "05-Wavelength",
+        "06-Frequencies",
+        "07-Voice/Drafts",
+        "08-Decisions",
+        "09-Reference",
+        "10-Liminal",
+        "00-Creek-Meta/Skills",
+    ],
+)
+def test_fragment_purge_scrubs_source_fragments_in_every_relevant_folder(
+    tmp_path: Path,
+    subfolder: str,
+) -> None:
+    """``source_fragments`` YAML list entries are scrubbed vault-wide (GAP-004).
+
+    Verifies the new contract across every folder named in the GAP-004
+    issue — derived content in 04-Praxis, weekly wavelength reports,
+    Voice drafts, decisions/reference/liminal note trees, and the
+    deployed skill tree.
+
+    The contract is grep-based: the operator runs ``grep -r <id>`` and
+    expects no match. We assert on the raw file text rather than the
+    YAML-parsed structure because the literal placeholder ``[purged]``
+    is itself bracket-flavoured and YAML re-parses it as a one-element
+    nested list. That detail is downstream; the file content is the
+    user-facing forensic surface.
+    """
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    note = _write_derived_note(
+        vault,
+        subfolder=subfolder,
+        name="derived",
+        body="A derived note referencing the soon-deleted fragment.",
+        metadata={"source_fragments": ["frag-A", "frag-B"]},
+    )
+
+    PurgeEngine(vault).purge_fragment("frag-A")
+
+    text = note.read_text(encoding="utf-8")
+    assert "frag-A" not in text
+    assert "[purged]" in text
+    assert "frag-B" in text
+
+
+def test_fragment_purge_scrubs_bare_id_mentions_in_body(tmp_path: Path) -> None:
+    """Body-text mentions of the fragment ID are replaced with ``[purged]``."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    draft = _write_derived_note(
+        vault,
+        subfolder="07-Voice/Drafts",
+        name="d1",
+        body="A draft built from frag-A. See also frag-A for details.",
+        metadata={"type": "draft"},
+    )
+
+    PurgeEngine(vault).purge_fragment("frag-A")
+
+    text = draft.read_text(encoding="utf-8")
+    assert "frag-A" not in text
+    assert text.count("[purged]") == 2  # two body mentions
+
+
+def test_fragment_purge_does_not_match_id_as_substring(tmp_path: Path) -> None:
+    """Word-boundary regex avoids over-matching ``frag-A`` inside ``frag-ABC``."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    sibling = _write_derived_note(
+        vault,
+        subfolder="07-Voice/Drafts",
+        name="d2",
+        body="The fragments frag-A and frag-ABC are different.",
+        metadata={"source_fragments": ["frag-A", "frag-ABC"]},
+    )
+
+    PurgeEngine(vault).purge_fragment("frag-A")
+
+    text = sibling.read_text(encoding="utf-8")
+    assert "frag-ABC" in text  # the longer ID survives
+    # Word-boundary regex matches frag-A but not the prefix of frag-ABC.
+    # Two "frag-A" occurrences (YAML list + body) both get scrubbed.
+    assert "[purged]" in text
+    # Plain "frag-A" with a trailing word boundary should not appear.
+    import re
+
+    assert not re.search(r"\bfrag-A\b", text)
+
+
+def test_fragment_purge_leaves_audit_log_untouched(tmp_path: Path) -> None:
+    """The compliance audit log (00-Creek-Meta/audit/purge.jsonl) is not scrubbed.
+
+    JSONL files aren't ``.md`` so the recursive walk excludes them — but
+    pin the invariant explicitly so a future refactor that broadens the
+    scrubber surface cannot silently mutate the compliance record.
+    """
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+
+    PurgeEngine(vault).purge_fragment("frag-A")
+
+    audit_path = vault / "00-Creek-Meta" / "audit" / "purge.jsonl"
+    audit_text = audit_path.read_text(encoding="utf-8")
+    assert "frag-A" in audit_text  # affected_fragments retains the real ID
+
+
+def test_fragment_purge_records_provenance_scrubs_in_result(tmp_path: Path) -> None:
+    """``PurgeResult.provenance_scrubbed`` tallies the scrubbed mentions."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    _write_derived_note(
+        vault,
+        subfolder="04-Praxis",
+        name="p1",
+        body="See frag-A.",
+        metadata={"source_fragments": ["frag-A"]},
+    )
+
+    result = PurgeEngine(vault).purge_fragment("frag-A")
+
+    # YAML list entry + one body mention = 2 substitutions in the praxis
+    # file. The deleted fragment file itself is excluded from the scrub.
+    assert result.provenance_scrubbed >= 2
+
+
+def test_fragment_purge_audit_outcome_records_provenance_scrubs(
+    tmp_path: Path,
+) -> None:
+    """The GAP-002 outcome line carries the provenance-scrub count."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    _write_derived_note(
+        vault,
+        subfolder="07-Voice/Drafts",
+        name="d1",
+        body="From frag-A.",
+        metadata={"source_fragments": ["frag-A"]},
+    )
+
+    PurgeEngine(vault).purge_fragment("frag-A")
+
+    entries = [
+        e for e in PurgeAuditLog(vault).read() if e.operation != "purge.audit.migration"
+    ]
+    outcome = entries[-1]
+    assert outcome.phase == "outcome"
+    assert outcome.provenance_scrubbed >= 1
+
+
+def test_fragment_purge_dry_run_does_not_scrub(tmp_path: Path) -> None:
+    """Dry-run reports the would-be count without writing to derived files."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    draft = _write_derived_note(
+        vault,
+        subfolder="07-Voice/Drafts",
+        name="d1",
+        body="From frag-A.",
+        metadata={"source_fragments": ["frag-A"]},
+    )
+    before = draft.read_text(encoding="utf-8")
+
+    result = PurgeEngine(vault, dry_run=True).purge_fragment("frag-A")
+
+    assert result.provenance_scrubbed >= 1
+    assert draft.read_text(encoding="utf-8") == before
+
+
+def test_source_purge_scrubs_provenance_for_each_fragment(tmp_path: Path) -> None:
+    """``purge_source`` scrubs every purged fragment's references."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha", platform="claude")
+    _write_fragment(vault, "frag-B", "Bravo", platform="claude")
+    derived = _write_derived_note(
+        vault,
+        subfolder="04-Praxis",
+        name="p1",
+        body="Built from frag-A and frag-B.",
+        metadata={"source_fragments": ["frag-A", "frag-B"]},
+    )
+
+    PurgeEngine(vault).purge_source("claude")
+
+    text = derived.read_text(encoding="utf-8")
+    assert "frag-A" not in text
+    assert "frag-B" not in text
+    assert text.count("[purged]") == 4  # 2 YAML + 2 body


### PR DESCRIPTION
`creek purge` advertised "scrubbing every reference along the way" but
only walked 02-Threads and 03-Eddies via `_decrement_counts`, plus
wiki-link removal vault-wide via `_scrub_wikilinks`. Derived content
under 04-Praxis, 05-Wavelength, 07-Voice/Drafts, 08-Decisions,
09-Reference, 10-Liminal and the deployed Skills tree silently kept
references to purged fragments — in particular YAML provenance lists
like `source_fragments: [frag-…]` in draft files, and bare ID mentions
in body text. A user purging an intimate-tier fragment would still
find its synthesized draft (with both YAML provenance and prose body
copied from the original fragment) on disk after purge — `grep -r
<frag_id>` lit it up.

This change adds `_scrub_provenance(fragment_id)`: a word-boundary
regex pass over every `.md` file in the vault that replaces matching
fragment-ID mentions with the literal `[purged]` placeholder. One
pass catches both YAML list entries and prose mentions because the
substitution is text-level. Wiki-link removal (by title) stays on
`_scrub_wikilinks` since it matches by name not ID.

The compliance audit log at `00-Creek-Meta/audit/purge.jsonl` is
JSONL, not Markdown, so the recursive `.md` walk excludes it
naturally — `affected_fragments` in audit entries keeps the real ID
for forensic reconstruction. A new test pins this invariant.

Wires into:
- `purge_fragment` — direct call
- `_purge_single` (used by `purge_source`, `purge_source_path`,
  `purge_daterange`) — call per matched fragment

`PurgeResult.provenance_scrubbed` and `PurgeAuditEntry.provenance_scrubbed`
record the count. Pre-GAP-004 audit entries default to 0 via Pydantic
and the legacy coercer.

Docs (`cleaning-and-purge.md`) and CLI `--help` for `purge fragment`
/ `purge source` now enumerate the scrubbed folders explicitly.