### PR TITLE
docs: scrub broken plans/git-issues cross-references (GAP-006)

### DIFF
--- a/creek-tools/CHANGELOG.md
+++ b/creek-tools/CHANGELOG.md
@@ -1,8 +1,11 @@
 # Changelog
 
 All notable changes to `creek-tools` are documented here. Versioning is
-loose during pre-1.0 development; the headings below track FEAT IDs from
-`plans/git-issues/`.
+loose during pre-1.0 development; the headings below track design-trace
+IDs (`FEAT-*`, `INC-*`, `BUG-*`, …) embedded in commit messages and
+inline code annotations. The original `plans/git-issues/` directory of
+long-form spec files was retired in #243; use `git log --grep='<ID>'`
+to locate the originating commit for any reference below.
 
 ## Unreleased
 

--- a/creek-tools/docs/cleaning-pipeline.md
+++ b/creek-tools/docs/cleaning-pipeline.md
@@ -66,14 +66,14 @@ Decides what to do with non-self content. Three configurable modes (set `cleanin
 
 Universal constraints applied across all modes:
 
-- Non-self fragments are **never** voice-proxy eligible (the field is now a derived property — see [BUG-009](../../plans/git-issues/BUG-009-voice-proxy-eligible-flag-stale.md)).
+- Non-self fragments are **never** voice-proxy eligible (the field is now a derived property — see `BUG-009`; use `git log --grep='BUG-009'` for the origin commit).
 - Non-self fragments are **never** classified `intimate`; an `intimate` tier on a non-self fragment is downgraded to `personal`.
 
 ### [`validator.py`](../creek/clean/validator.py) — `FragmentValidator`
 
 Checks required fields, UTF-8 encoding, ISO-8601 timestamps, and a configurable minimum content length. Invalid fragments are routed to the review queue rather than discarded — see `cleaning.validation`.
 
-Failure mode: a fragment with mojibake (e.g. CSV decoded as cp1252 by mistake — see [BUG-010](../../plans/git-issues/BUG-010-csv-cp1252-fallback-silent-mojibake.md)) lands in review, where you can re-ingest with the right encoding.
+Failure mode: a fragment with mojibake (e.g. CSV decoded as cp1252 by mistake — see `BUG-010`; use `git log --grep='BUG-010'` for the origin commit) lands in review, where you can re-ingest with the right encoding.
 
 ### [`quality.py`](../creek/clean/quality.py) — `QualityScorer`
 
@@ -126,8 +126,8 @@ Most config sections have a `enabled: bool` (or per-rule `skip_*` toggles). To d
 | 30 % of fragments dropped silently | `QualityScorer` skip threshold too high | `cleaning.quality.skip_threshold` |
 | Real human turns missing from chatbot exports | `ChatbotFilter` over-aggressive | `cleaning.chatbot.min_human_turn_chars`, `skip_short_human` |
 | Discord short replies missing | `DiscordFilter` short-text rule | `cleaning.discord.min_chars`, `preserve_replies` |
-| Mojibake in CSV-derived fragments | `cp1252` fallback fired ([BUG-010](../../plans/git-issues/BUG-010-csv-cp1252-fallback-silent-mojibake.md)) | Re-ingest with explicit encoding; check the WARNING log line for the offending file |
-| Voice-proxy eligibility wrong | Stale `voice_proxy_eligible` field | Pull from a build that includes [BUG-009](../../plans/git-issues/BUG-009-voice-proxy-eligible-flag-stale.md) — the field is now a derived property |
+| Mojibake in CSV-derived fragments | `cp1252` fallback fired (`BUG-010`) | Re-ingest with explicit encoding; check the WARNING log line for the offending file |
+| Voice-proxy eligibility wrong | Stale `voice_proxy_eligible` field | Pull from a build that includes `BUG-009` — the field is now a derived property |
 | Duplicate fragments accepted | Stale `dedup-manifest.json` from earlier run | Delete `<vault>/00-Creek-Meta/dedup-manifest.json` and re-ingest |
 
 ---

--- a/creek-tools/docs/emergence.md
+++ b/creek-tools/docs/emergence.md
@@ -124,7 +124,7 @@ Every numeric threshold above is pinned by a regression test in `tests/`. Change
 - The Unnamed-Digest similarity floor (0.7)
 - The Tag-Garden growth detection deltas
 
-require the corresponding test and this doc to move together. If you find a §10 criterion you cannot locate in code, file a `BUG-*` under `plans/git-issues/` rather than letting the gap go un-tracked.
+require the corresponding test and this doc to move together. If you find a §10 criterion you cannot locate in code, open a GitHub issue (use a `BUG-*` prefix in the title so the design-trace lineage stays grep-able) rather than letting the gap go un-tracked.
 
 ---
 

--- a/creek-tools/docs/lint.md
+++ b/creek-tools/docs/lint.md
@@ -85,5 +85,5 @@ appends it to the audit report under the `## Lint summary` section
   unifies.
 - [`00-Creek-Meta/Skills/lint.SKILL.md`](../../00-Creek-Meta/Skills/lint.SKILL.md)
   — the schema skill that load-bears these rules.
-- [FEAT-008](../../plans/git-issues/done/FEAT-008-creek-lint-unified-hygiene.md)
-  — the implementation plan.
+- `FEAT-008` — the implementation plan (use `git log --grep='FEAT-008'`
+  for the originating commits; `plans/git-issues/` was retired in #243).

--- a/creek-tools/docs/security/threat-model.md
+++ b/creek-tools/docs/security/threat-model.md
@@ -147,7 +147,9 @@ Creek **does not** aim to provide:
 
 ## Cross-references
 
-Issue files live at the repository root under `plans/git-issues/`:
+The codebase annotates design-trace work with short IDs: `SEC-*`, `INC-*`, `OPS-*`, `BUG-*`, `FEAT-*`, `TEST-*`. The original `plans/git-issues/` directory of long-form spec files was retired in #243; the IDs survive as commit-message tags and inline code annotations. To locate the originating context for an ID, search the commit history (`git log --grep='SEC-005'` etc.) or the GitHub issue tracker for `geoffe-ga/creek-vault`.
+
+Notable threat-model-adjacent IDs that have shipped or are in flight:
 
 - **SEC-002** — Redaction pattern coverage gaps
 - **SEC-003** — Symlink refusal in redaction (resolved)
@@ -156,6 +158,3 @@ Issue files live at the repository root under `plans/git-issues/`:
 - **SEC-006** — Privacy-tier enforcement in mine/draft
 - **SEC-008** — OAuth token hygiene (resolved)
 - **OPS-002** — Non-interactive purge refusal (resolved)
-
-Each is filed under its short ID; search the issue tracker or the
-in-repo `plans/git-issues/` directory for the full text.

--- a/creek-tools/docs/slash-commands.md
+++ b/creek-tools/docs/slash-commands.md
@@ -83,4 +83,4 @@ elevated token in `mcp.json`.
 
 - `creek-tools/docs/mcp.md` — MCP tool surface and privacy tier rules.
 - `crawdad/CLAUDE.md` — CrawDad architecture and quality bar.
-- [`plans/git-issues/FEAT-016-slash-command-grammar.md`](../../plans/git-issues/FEAT-016-slash-command-grammar.md) — the FEAT spec.
+- `FEAT-016` — the original slash-command-grammar spec; the `plans/git-issues/` directory was retired in #243, so use `git log --grep='FEAT-016'` for the implementing commits.

--- a/creek-tools/scripts/coverage-waivers.txt
+++ b/creek-tools/scripts/coverage-waivers.txt
@@ -15,5 +15,5 @@
 # Adding a file to this list is a deliberate, time-bounded decision.
 # Each entry should reference an open issue tracking the work to bring
 # that file up to the strict threshold and remove it from this list.
-creek/ingest/presentations.py 67% baseline; raise to 80% per plans/git-issues/TEST-002-coverage-aggregate-hides-low-modules.md
-creek/ingest/documents.py 77% baseline; raise to 80% per plans/git-issues/TEST-002-coverage-aggregate-hides-low-modules.md
+creek/ingest/presentations.py 67% baseline; raise to 80% per TEST-002 (use `git log --grep=TEST-002` for context; the plans/git-issues/ directory was retired in #243)
+creek/ingest/documents.py 77% baseline; raise to 80% per TEST-002 (use `git log --grep=TEST-002` for context; the plans/git-issues/ directory was retired in #243)

--- a/creek-tools/tests/fixtures/canonical_taxonomy.yaml
+++ b/creek-tools/tests/fixtures/canonical_taxonomy.yaml
@@ -15,11 +15,12 @@
 # updated in lockstep — that is the point of the test.
 #
 # Drift values listed under ``deprecated_aliases`` come from the
-# pre-INC-019 documentation drift documented in
-# ``plans/git-issues/INC-019-spec-impl-drift-phase-mode-frequency-taxonomy.md``.
-# They are mapped to the canonical names so vaults written by older
-# tool versions remain loadable for one release with a deprecation
-# warning, after which the alias hooks will be removed.
+# pre-INC-019 documentation drift; the long-form ``plans/git-issues/``
+# directory was retired in #243, so use ``git log --grep='INC-019'``
+# to locate the originating commits. They are mapped to the canonical
+# names so vaults written by older tool versions remain loadable for
+# one release with a deprecation warning, after which the alias hooks
+# will be removed.
 phases:
   canonical:
     - rising

--- a/creek-tools/tests/test_taxonomy_docs_drift.py
+++ b/creek-tools/tests/test_taxonomy_docs_drift.py
@@ -5,9 +5,10 @@ strings in ``creek-tools/creek/`` must use the canonical taxonomy
 verbatim. These tests grep the relevant files and assert the drifted
 phase / mode / frequency strings do not reappear.
 
-Drift values are taken from
-``plans/git-issues/INC-019-spec-impl-drift-phase-mode-frequency-taxonomy.md``.
-The canonical names are pinned in
+Drift values originated in the INC-019 spec; the long-form
+``plans/git-issues/`` directory was retired in #243, so use
+``git log --grep='INC-019'`` to locate the originating commits. The
+canonical names are pinned in
 ``tests/fixtures/canonical_taxonomy.yaml``.
 """
 


### PR DESCRIPTION
## Summary

The `plans/git-issues/` directory was deliberately retired in #243, but several user-facing docs and a couple of code-adjacent files still pointed into it — either with markdown links that 404'd or with "live under `plans/git-issues/`" prose that a fresh-clone reader would chase to nothing. This PR takes the GAP-006 acceptance criterion **B** path (rewrite cross-references, don't restore the directory) since the original deletion was intentional.

### Edits

- `docs/security/threat-model.md` "Cross-references" section: replaces the "live at the repository root under `plans/git-issues/`" sentence with a paragraph explaining the IDs are commit-message tags + inline code annotations, and that `git log --grep='<ID>'` is the canonical lookup. SEC/OPS list kept (the IDs are real design-trace markers).
- `docs/cleaning-pipeline.md`: BUG-009 / BUG-010 markdown links → bare-ID mentions with a git-grep hint.
- `docs/slash-commands.md`, `docs/lint.md`: FEAT-016 / FEAT-008 links → bare-ID + retirement note.
- `docs/emergence.md`: "file a BUG-* under `plans/git-issues/`" → "open a GitHub issue with a BUG-* prefix in the title".
- `scripts/coverage-waivers.txt`: TEST-002 path → bare-ID + git-grep hint.
- `tests/test_taxonomy_docs_drift.py`, `tests/fixtures/canonical_taxonomy.yaml`: INC-019 path → same.
- `CHANGELOG.md` header: acknowledges the retirement and points at `git log`.

### What's intentionally **not** in scope

- Inline code comments naming bare IDs (e.g. `creek/classify/privacy_filter.py:78` mentions SEC-006). Those are forensic design-trace tags, not dead links — removing them would lose context. They stay.
- The GAP-006 finding doc itself (`plans/v1-readiness/findings/GAP-006-*.md`) retains the `plans/git-issues/` references because the doc *is the description of the problem*.

## Test plan

- [x] `grep -rn "plans/git-issues" ...` outside the GAP finding doc returns only narrative explanations of the retirement (no broken paths or `[link](...)` syntax).
- [x] `pytest tests/test_taxonomy_docs_drift.py tests/test_taxonomy_alignment.py` — 32/32 pass after the docstring tweak.
- [x] Full suite: `pytest --no-cov` — 4286 pass, 1 skipped (Ollama). No regressions.

Closes the GAP-006 finding in `plans/v1-readiness/findings/GAP-006-doc-cross-references-to-missing-issue-directory.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT7kujEN2GdwvbznHyh5Cu)_