### PR TITLE
feat(classify): shared `WeightedFragmentClassification` model + Fragment field (#365)

### DIFF
--- a/creek-tools/creek/classify/prompt.py
+++ b/creek-tools/creek/classify/prompt.py
@@ -40,26 +40,34 @@ re-gloss in one place reaches both detectors.
 from __future__ import annotations
 
 import logging
-import math
 from dataclasses import dataclass, field
-from enum import StrEnum
-from typing import TYPE_CHECKING, Generic, TypeVar
+from typing import TYPE_CHECKING
 
-import yaml
-
-# Import the shared dimension blocks and parser helpers via the
-# ``creek.classify.llm`` package surface rather than the underlying
-# submodules. The package's ``__init__.py`` declares these as the
-# contracted import path, so a future reorganisation of ``parsing.py``
-# or ``prompts.py`` only needs to update the re-export — this module
-# stays untouched.
+# Import the shared dimension blocks via the ``creek.classify.llm``
+# package surface rather than the underlying submodules. The package's
+# ``__init__.py`` declares these as the contracted import path, so a
+# future reorganisation of ``parsing.py`` or ``prompts.py`` only needs
+# to update the re-export — this module stays untouched.
 from creek.classify.llm import (
     _COLOR_BLOCK,
     _FREQUENCY_BLOCK,
     _FREQUENCY_COLOR_BLOCK,
     _sanitise_for_prompt,
     _split_reasoning_and_yaml,
-    _strip_code_fences,
+)
+
+# Promoted in #365: the weighted-tuple primitive and the YAML parser
+# helpers now live in :mod:`creek.classify.weighted` so the
+# fragment-level classifier (#366) and the holonic combiner (#367) can
+# import them without depending on this prompt-detection module.
+# Re-export them here so PR #359's public surface (``from
+# creek.classify.prompt import WeightedDimension, ...``) keeps working
+# unchanged.
+from creek.classify.weighted import (
+    WeightedDimension,
+    _coerce_weight,
+    _load_yaml_dict,
+    _parse_dimension,
 )
 from creek.models import (
     Dosage,
@@ -74,29 +82,6 @@ if TYPE_CHECKING:
     from creek.config import LLMConfig
 
 logger = logging.getLogger(__name__)
-
-
-_DimT = TypeVar("_DimT", bound=StrEnum)
-
-
-@dataclass(frozen=True)
-class WeightedDimension(Generic[_DimT]):
-    """A single ontology-dimension value paired with a detection weight.
-
-    Used inside :class:`PromptOntology` to model "this prompt
-    activates Phase ``rising`` at strength 0.7 and Phase
-    ``bottoming_out`` at strength 0.4." Weights live in
-    ``[0.0, 1.0]``; the parser clamps any out-of-range value so a
-    misbehaving LLM cannot inject negative or super-unit weights into
-    downstream consumers.
-
-    Attributes:
-        value: The dimension's canonical enum member.
-        weight: Detection strength in ``[0.0, 1.0]``.
-    """
-
-    value: _DimT
-    weight: float
 
 
 @dataclass(frozen=True)
@@ -236,19 +221,6 @@ reaches this template automatically.
 """
 
 
-_ALLOWED_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
-    {
-        "frequencies",
-        "phases",
-        "modes",
-        "orientations",
-        "dosages",
-        "voice_registers",
-        "overall_confidence",
-    },
-)
-
-
 def build_prompt_ontology_prompt(
     prompt: str,
     *,
@@ -277,151 +249,6 @@ def build_prompt_ontology_prompt(
         threshold=unclassified_threshold,
         prompt=safe,
     )
-
-
-def _coerce_weight(value: object) -> float:
-    """Coerce a YAML-loaded weight value into ``[0.0, 1.0]``.
-
-    A non-numeric value is treated as zero rather than raising — the
-    parser is intentionally lenient on per-entry weights so one bad
-    entry cannot drop the whole detection. The clamp keeps downstream
-    composition arithmetic stable (negative weights would invert
-    rankings; weights > 1 would amplify a single dimension over the
-    others without bound).
-
-    Args:
-        value: Raw YAML scalar; expected to be a float-like number.
-
-    Returns:
-        A float in ``[0.0, 1.0]``.
-    """
-    if isinstance(value, bool):
-        return 0.0
-    if not isinstance(value, (int, float)):
-        return 0.0
-    weight = float(value)
-    if not math.isfinite(weight):
-        # NaN slips past both clamp branches because NaN comparisons
-        # always return False, and ±inf would amplify rankings without
-        # bound. Both collapse to zero so downstream composition stays
-        # finite.
-        return 0.0
-    if weight < 0.0:
-        return 0.0
-    if weight > 1.0:
-        return 1.0
-    return weight
-
-
-def _parse_enum_value(value: object, enum_type: type[_DimT]) -> _DimT | None:
-    """Resolve a YAML scalar to a :class:`StrEnum` member, or ``None``.
-
-    Used by :func:`_parse_dimension` to skip unknown values silently
-    rather than raise — the LLM may emit a value that doesn't map to
-    a canonical enum member (a typo, an outdated alias), and the
-    detector's job is to return what it can rather than abort.
-
-    Args:
-        value: Raw YAML scalar.
-        enum_type: The target :class:`StrEnum` subclass.
-
-    Returns:
-        The matching enum member, or ``None`` if no match exists.
-    """
-    if value is None:
-        return None
-    val_str = str(value).lower().strip()
-    if not val_str:
-        return None
-    for member in enum_type:
-        if member.value.lower() == val_str:
-            return member
-    return None
-
-
-def _parse_dimension(
-    data: dict[str, object],
-    key: str,
-    enum_type: type[_DimT],
-) -> tuple[WeightedDimension[_DimT], ...]:
-    """Parse a single dimension's list of ``{value, weight}`` entries.
-
-    Tolerates the common failure modes the LLM produces in practice:
-
-    * the dimension key is missing entirely (return empty tuple);
-    * the dimension's value is not a list (return empty tuple);
-    * an individual entry lacks a ``value`` field or has an unknown
-      value (drop the entry);
-    * an individual entry lacks a ``weight`` field (admit at zero so
-      the caller still sees the model picked it).
-
-    Entries are returned sorted by weight descending so the heaviest
-    signal sits at index 0; ties preserve the LLM's YAML response order
-    because :py:meth:`list.sort` is stable.
-
-    Args:
-        data: Parsed top-level YAML dict.
-        key: Top-level key for this dimension (``"frequencies"`` etc.).
-        enum_type: Target :class:`StrEnum` subclass for the dimension.
-
-    Returns:
-        Tuple of weighted entries, sorted by weight descending.
-    """
-    raw = data.get(key)
-    if not isinstance(raw, list):
-        return ()
-    parsed: list[WeightedDimension[_DimT]] = []
-    for entry in raw:
-        if not isinstance(entry, dict):
-            continue
-        enum_value = _parse_enum_value(entry.get("value"), enum_type)
-        if enum_value is None:
-            continue
-        weight = _coerce_weight(entry.get("weight"))
-        parsed.append(WeightedDimension(value=enum_value, weight=weight))
-    parsed.sort(key=lambda wd: wd.weight, reverse=True)
-    return tuple(parsed)
-
-
-def _load_yaml_dict(yaml_text: str) -> dict[str, object]:
-    """Parse the YAML payload and assert the documented shape.
-
-    Mirrors :func:`creek.classify.llm.parsing.validate_response` but
-    against the prompt-ontology schema. Strips markdown fences first
-    so a model that nests its YAML inside ```yaml ... ``` round-trips
-    correctly. Rejects multi-document payloads (a classic
-    LLM-output-spoofing vector) and any top-level keys outside
-    :data:`_ALLOWED_TOP_LEVEL_KEYS`.
-
-    Args:
-        yaml_text: The YAML body extracted from the LLM response.
-
-    Returns:
-        The parsed dict.
-
-    Raises:
-        ValueError: On multi-document payloads, non-dict roots, or
-            unexpected top-level keys.
-    """
-    text = _strip_code_fences(yaml_text)
-    try:
-        docs = list(yaml.safe_load_all(text))
-    except yaml.YAMLError as exc:
-        msg = f"Invalid YAML in prompt-ontology response: {exc}"
-        raise ValueError(msg) from exc
-    if len(docs) > 1:
-        msg = f"multi-document YAML response rejected ({len(docs)} documents)"
-        raise ValueError(msg)
-    parsed: object = docs[0] if docs else None
-    if not isinstance(parsed, dict):
-        msg = f"Expected YAML dict, got {type(parsed).__name__}"
-        raise ValueError(msg)  # noqa: TRY004  # ValueError matches the documented schema-validation contract on this function and on detect_ontology's caller; switching to TypeError would break the documented Raises section without functional benefit.
-    keys = {str(k) for k in parsed}
-    extras = keys - _ALLOWED_TOP_LEVEL_KEYS
-    if extras:
-        msg = f"unexpected top-level keys in prompt-ontology response: {sorted(extras)}"
-        raise ValueError(msg)
-    return {str(k): v for k, v in parsed.items()}
 
 
 def parse_prompt_ontology_response(

--- a/creek-tools/creek/classify/weighted.py
+++ b/creek-tools/creek/classify/weighted.py
@@ -1,0 +1,597 @@
+"""Shared weighted-classification model (issue #365).
+
+PR #359 (issue #350) introduced :class:`WeightedDimension` and a
+weighted-tuple-per-dimension schema for free-form essay prompts in
+:mod:`creek.classify.prompt`. This module promotes those primitives —
+the dataclass, the parser helpers, the allowed-top-level-keys set —
+to a shared location so fragment-level callers (atoms in the
+holarchy, sub-issues #366 / #367) can reuse them without inverting
+the dependency graph (epic #364).
+
+Public surface:
+
+- :class:`WeightedDimension` — frozen generic dataclass holding a
+  ``(value, weight)`` pair for a single ontology-dimension entry.
+- :class:`WeightedFragmentClassification` — Pydantic model that lives
+  on :class:`creek.models.Fragment.weighted`, mirroring
+  :class:`creek.classify.prompt.PromptOntology` minus the ``prompt``
+  field. Pydantic so it round-trips through vault YAML frontmatter via
+  ``Fragment.model_dump(mode="json")`` / ``Fragment.model_validate``
+  without bespoke serialiser plumbing.
+- Parser helpers (:func:`_coerce_weight`, :func:`_parse_enum_value`,
+  :func:`_parse_dimension`, :func:`_load_yaml_dict`) and the
+  :data:`_ALLOWED_TOP_LEVEL_KEYS` set are leading-underscore module
+  privates that :mod:`creek.classify.prompt` (and #366's
+  fragment-level classifier) import directly.
+
+The legacy single-pick fields on :class:`creek.models.Fragment`
+(``frequency``, ``wavelength``, ``voice``) remain authoritative for
+downstream consumers (compile, lint, voice-skill generation). When
+``weighted`` is populated, the two stay synchronised via the
+:meth:`WeightedFragmentClassification.from_single_pick` and
+:meth:`WeightedFragmentClassification.to_legacy` adapters; callers
+that populate ``weighted`` are responsible for keeping the legacy
+fields in sync until the broader epic completes and consumers migrate.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+import yaml
+from pydantic import BaseModel, ConfigDict
+
+# Import :func:`_strip_code_fences` from its defining submodule rather
+# than the :mod:`creek.classify.llm` package surface. The package's
+# ``__init__.py`` re-exports happen *after* every submodule loads, but
+# this module is itself imported during ``creek.models`` finalisation
+# while ``creek.classify.llm`` is still partially loaded — the package
+# re-export isn't yet visible. Going to ``parsing.py`` directly side-
+# steps the cycle without leaking the layering.
+from creek.classify.llm.parsing import _strip_code_fences
+from creek.models import (
+    Color,
+    Dosage,
+    Frequency,
+    FrequencyClassification,
+    Mode,
+    Orientation,
+    Phase,
+    VoiceClassification,
+    VoiceRegister,
+    WavelengthClassification,
+)
+
+if TYPE_CHECKING:
+    from creek.models import Fragment
+
+__all__ = [
+    "WeightedDimension",
+    "WeightedFragmentClassification",
+]
+
+
+_DimT = TypeVar("_DimT", bound=StrEnum)
+
+
+@dataclass(frozen=True)
+class WeightedDimension(Generic[_DimT]):
+    """A single ontology-dimension value paired with a detection weight.
+
+    Used inside :class:`WeightedFragmentClassification` and
+    :class:`creek.classify.prompt.PromptOntology` to model "this
+    fragment activates Phase ``rising`` at strength 0.7 and Phase
+    ``bottoming_out`` at strength 0.4." Weights live in
+    ``[0.0, 1.0]``; the parser clamps any out-of-range value so a
+    misbehaving LLM cannot inject negative or super-unit weights into
+    downstream consumers.
+
+    Attributes:
+        value: The dimension's canonical enum member.
+        weight: Detection strength in ``[0.0, 1.0]``.
+    """
+
+    value: _DimT
+    weight: float
+
+
+# YAML top-level keys accepted by :func:`_load_yaml_dict`. Shared
+# between the prompt-ontology detector (PR #359) and the fragment-level
+# classifier landing in #366 so the schema is enforced from one place.
+_ALLOWED_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
+    {
+        "frequencies",
+        "phases",
+        "modes",
+        "orientations",
+        "dosages",
+        "voice_registers",
+        "overall_confidence",
+    },
+)
+
+
+# Per-aspect weight applied to legacy ``secondary`` frequencies when
+# :meth:`WeightedFragmentClassification.from_single_pick` widens a
+# Fragment's legacy classification into weighted form. Chosen so the
+# primary's 1.0 weight clearly dominates after sorting while leaving
+# the secondaries above the 0.05 LLM template floor (PR #359) so
+# downstream composition does not silently drop them.
+_LEGACY_SECONDARY_WEIGHT: float = 0.5
+
+# Per-aspect weight applied to non-secondary legacy fields (phase,
+# mode, orientation, dosage, voice register) when widening: each is a
+# single canonical pick at full conviction.
+_LEGACY_SINGLE_WEIGHT: float = 1.0
+
+
+def _coerce_weight(value: object) -> float:
+    """Coerce a YAML-loaded weight value into ``[0.0, 1.0]``.
+
+    A non-numeric value is treated as zero rather than raising — the
+    parser is intentionally lenient on per-entry weights so one bad
+    entry cannot drop the whole detection. The clamp keeps downstream
+    composition arithmetic stable (negative weights would invert
+    rankings; weights > 1 would amplify a single dimension over the
+    others without bound).
+
+    Args:
+        value: Raw YAML scalar; expected to be a float-like number.
+
+    Returns:
+        A float in ``[0.0, 1.0]``.
+    """
+    if isinstance(value, bool):
+        return 0.0
+    if not isinstance(value, (int, float)):
+        return 0.0
+    weight = float(value)
+    if not math.isfinite(weight):
+        # NaN slips past both clamp branches because NaN comparisons
+        # always return False, and ±inf would amplify rankings without
+        # bound. Both collapse to zero so downstream composition stays
+        # finite.
+        return 0.0
+    if weight < 0.0:
+        return 0.0
+    if weight > 1.0:
+        return 1.0
+    return weight
+
+
+def _parse_enum_value(value: object, enum_type: type[_DimT]) -> _DimT | None:
+    """Resolve a YAML scalar to a :class:`StrEnum` member, or ``None``.
+
+    Used by :func:`_parse_dimension` to skip unknown values silently
+    rather than raise — the LLM may emit a value that doesn't map to
+    a canonical enum member (a typo, an outdated alias), and the
+    detector's job is to return what it can rather than abort.
+
+    Args:
+        value: Raw YAML scalar.
+        enum_type: The target :class:`StrEnum` subclass.
+
+    Returns:
+        The matching enum member, or ``None`` if no match exists.
+    """
+    if value is None:
+        return None
+    val_str = str(value).lower().strip()
+    if not val_str:
+        return None
+    for member in enum_type:
+        if member.value.lower() == val_str:
+            return member
+    return None
+
+
+def _parse_dimension(
+    data: dict[str, object],
+    key: str,
+    enum_type: type[_DimT],
+) -> tuple[WeightedDimension[_DimT], ...]:
+    """Parse a single dimension's list of ``{value, weight}`` entries.
+
+    Tolerates the common failure modes the LLM produces in practice:
+
+    * the dimension key is missing entirely (return empty tuple);
+    * the dimension's value is not a list (return empty tuple);
+    * an individual entry lacks a ``value`` field or has an unknown
+      value (drop the entry);
+    * an individual entry lacks a ``weight`` field (admit at zero so
+      the caller still sees the model picked it).
+
+    Entries are returned sorted by weight descending so the heaviest
+    signal sits at index 0; ties preserve the LLM's YAML response order
+    because :py:meth:`list.sort` is stable.
+
+    Args:
+        data: Parsed top-level YAML dict.
+        key: Top-level key for this dimension (``"frequencies"`` etc.).
+        enum_type: Target :class:`StrEnum` subclass for the dimension.
+
+    Returns:
+        Tuple of weighted entries, sorted by weight descending.
+    """
+    raw = data.get(key)
+    if not isinstance(raw, list):
+        return ()
+    parsed: list[WeightedDimension[_DimT]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        enum_value = _parse_enum_value(entry.get("value"), enum_type)
+        if enum_value is None:
+            continue
+        weight = _coerce_weight(entry.get("weight"))
+        parsed.append(WeightedDimension(value=enum_value, weight=weight))
+    parsed.sort(key=lambda wd: wd.weight, reverse=True)
+    return tuple(parsed)
+
+
+def _load_yaml_dict(yaml_text: str) -> dict[str, object]:
+    """Parse the YAML payload and assert the documented shape.
+
+    Mirrors :func:`creek.classify.llm.parsing.validate_response` but
+    against the weighted-classification schema. Strips markdown fences
+    first so a model that nests its YAML inside ```yaml ... ``` round-
+    trips correctly. Rejects multi-document payloads (a classic
+    LLM-output-spoofing vector) and any top-level keys outside
+    :data:`_ALLOWED_TOP_LEVEL_KEYS`.
+
+    Args:
+        yaml_text: The YAML body extracted from the LLM response.
+
+    Returns:
+        The parsed dict.
+
+    Raises:
+        ValueError: On multi-document payloads, non-dict roots, or
+            unexpected top-level keys.
+    """
+    text = _strip_code_fences(yaml_text)
+    try:
+        docs = list(yaml.safe_load_all(text))
+    except yaml.YAMLError as exc:
+        msg = f"Invalid YAML in weighted-classification response: {exc}"
+        raise ValueError(msg) from exc
+    if len(docs) > 1:
+        msg = f"multi-document YAML response rejected ({len(docs)} documents)"
+        raise ValueError(msg)
+    parsed: object = docs[0] if docs else None
+    if not isinstance(parsed, dict):
+        msg = f"Expected YAML dict, got {type(parsed).__name__}"
+        # TRY004 would have us raise TypeError, but ValueError matches
+        # the documented schema-validation contract on this helper and
+        # on every caller; switching to TypeError would break the
+        # documented Raises section without functional benefit.
+        raise ValueError(msg)  # noqa: TRY004
+    keys = {str(k) for k in parsed}
+    extras = keys - _ALLOWED_TOP_LEVEL_KEYS
+    if extras:
+        msg = (
+            "unexpected top-level keys in weighted-classification response: "
+            f"{sorted(extras)}"
+        )
+        raise ValueError(msg)
+    return {str(k): v for k, v in parsed.items()}
+
+
+class WeightedFragmentClassification(BaseModel):
+    """Weighted ontology profile attached to a :class:`Fragment`.
+
+    Mirrors :class:`creek.classify.prompt.PromptOntology` minus the
+    ``prompt`` field. Each dimension is a tuple of
+    :class:`WeightedDimension` entries sorted weight-descending so the
+    heaviest signal sits at index 0.
+
+    Lives on :attr:`Fragment.weighted` as ``WeightedFragmentClassification |
+    None``; ``None`` means "no weighted detection ran" (legacy vaults,
+    pre-#366 fragments). When set, the legacy single-pick fields
+    (:attr:`Fragment.frequency`, :attr:`Fragment.wavelength`,
+    :attr:`Fragment.voice`) can be derived from the top weighted pick
+    per dimension via :meth:`to_legacy`; the reverse widening lives in
+    :meth:`from_single_pick`.
+
+    Pydantic BaseModel rather than a frozen dataclass (the
+    :class:`PromptOntology` shape) so the field plugs into
+    :class:`Fragment` without bespoke serialiser plumbing — the
+    Pydantic v2 default of round-tripping ``tuple[<dataclass>, ...]``
+    through ``model_dump(mode="json")`` / ``model_validate`` is
+    sufficient.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    frequencies: tuple[WeightedDimension[Frequency], ...] = ()
+    phases: tuple[WeightedDimension[Phase], ...] = ()
+    modes: tuple[WeightedDimension[Mode], ...] = ()
+    orientations: tuple[WeightedDimension[Orientation], ...] = ()
+    dosages: tuple[WeightedDimension[Dosage], ...] = ()
+    voice_registers: tuple[WeightedDimension[VoiceRegister], ...] = ()
+    overall_confidence: float = 0.0
+    reasoning: str = ""
+
+    @classmethod
+    def from_single_pick(
+        cls,
+        fragment: Fragment,
+    ) -> WeightedFragmentClassification:
+        """Widen a legacy single-pick :class:`Fragment` into weighted form.
+
+        Each non-``UNCLASSIFIED`` legacy field becomes a single
+        :class:`WeightedDimension` entry; the primary frequency gets
+        weight 1.0 and each secondary frequency gets
+        :data:`_LEGACY_SECONDARY_WEIGHT`. ``UNCLASSIFIED`` fields are
+        dropped so :meth:`to_legacy` can distinguish "unset" from
+        "explicitly classified as unclassified".
+
+        The following legacy state does **not** round-trip back via
+        :meth:`to_legacy` (documented limitations):
+
+        * :attr:`WavelengthClassification.color` is **not** carried
+          across; :meth:`to_legacy` recomputes it from the top
+          frequency via :data:`_FREQUENCY_TO_COLOR`.
+        * :attr:`WavelengthClassification.descriptor` is a free-form
+          string with no weighted analogue; :meth:`to_legacy` returns
+          ``""``.
+        * :attr:`VoiceClassification.confidence` is a
+          :class:`Confidence` enum with no weighted analogue;
+          :meth:`to_legacy` returns ``None``.
+
+        Args:
+            fragment: A Pydantic ``Fragment`` instance.
+
+        Returns:
+            A :class:`WeightedFragmentClassification` reflecting every
+            non-``UNCLASSIFIED`` legacy field on the input.
+        """
+        frequencies = _widen_frequency(fragment.frequency)
+        phases = _widen_single(fragment.wavelength.phase, Phase)
+        modes = _widen_single(fragment.wavelength.mode, Mode)
+        orientations = _widen_single(fragment.wavelength.orientation, Orientation)
+        dosages = _widen_single(fragment.wavelength.dosage, Dosage)
+        voice_registers = _widen_voice_register(fragment.voice.voice_register)
+
+        return cls(
+            frequencies=frequencies,
+            phases=phases,
+            modes=modes,
+            orientations=orientations,
+            dosages=dosages,
+            voice_registers=voice_registers,
+        )
+
+    def to_legacy(
+        self,
+    ) -> tuple[FrequencyClassification, WavelengthClassification, VoiceClassification]:
+        """Collapse weighted tuples back into legacy single-pick form.
+
+        The top entry per dimension becomes the legacy single pick;
+        remaining frequencies become :attr:`FrequencyClassification.secondary`.
+        Empty tuples collapse to ``UNCLASSIFIED`` so a default-empty
+        :class:`WeightedFragmentClassification` round-trips to the
+        same default-empty legacy classifications.
+
+        See :meth:`from_single_pick` for the documented limitations
+        (color is recomputed; descriptor and voice confidence are
+        dropped).
+
+        Returns:
+            A 3-tuple of ``(FrequencyClassification,
+            WavelengthClassification, VoiceClassification)`` ready to
+            assign back onto a :class:`Fragment`.
+        """
+        primary, secondary = _split_frequencies(self.frequencies)
+        phase = _top_value(self.phases, Phase.UNCLASSIFIED)
+        mode = _top_value(self.modes, Mode.UNCLASSIFIED)
+        orientation = _top_value(self.orientations, Orientation.UNCLASSIFIED)
+        dosage = _top_value(self.dosages, Dosage.UNCLASSIFIED)
+        voice_register = _top_value_optional(self.voice_registers)
+        color = _FREQUENCY_TO_COLOR.get(primary, Color.UNCLASSIFIED)
+
+        return (
+            FrequencyClassification(primary=primary, secondary=secondary),
+            WavelengthClassification(
+                phase=phase,
+                mode=mode,
+                orientation=orientation,
+                dosage=dosage,
+                color=color,
+                descriptor="",
+            ),
+            VoiceClassification(
+                voice_register=voice_register,
+                confidence=None,
+            ),
+        )
+
+
+# ---- Adapter helpers -------------------------------------------------------
+
+
+# Canonical frequency → Spiral-Dynamics colour mapping. Mirrored from
+# the prompt-template constants in :mod:`creek.classify.llm.prompts`
+# but kept local here to avoid pulling the whole prompt-building
+# module into adapter code paths. The two must stay in sync; the
+# fragment-level classifier landing in #366 will exercise both, which
+# anchors the contract.
+_FREQUENCY_TO_COLOR: dict[Frequency, Color] = {
+    Frequency.F1: Color.BEIGE,
+    Frequency.F2: Color.PURPLE,
+    Frequency.F3: Color.RED,
+    Frequency.F4: Color.BLUE,
+    Frequency.F5: Color.ORANGE,
+    Frequency.F6: Color.GREEN,
+    Frequency.F7: Color.YELLOW,
+    Frequency.F8: Color.TEAL,
+    Frequency.F9: Color.ULTRAVIOLET,
+    Frequency.F10: Color.CLEAR_LIGHT,
+}
+
+
+def _widen_frequency(
+    legacy: FrequencyClassification,
+) -> tuple[WeightedDimension[Frequency], ...]:
+    """Widen a legacy frequency classification into weighted entries.
+
+    The primary gets weight 1.0 (or is dropped if ``UNCLASSIFIED``);
+    each non-``UNCLASSIFIED`` secondary gets
+    :data:`_LEGACY_SECONDARY_WEIGHT`. Duplicates between primary and
+    secondaries are deduplicated, preserving the primary's higher
+    weight — legacy vaults occasionally list the primary in
+    ``secondary`` too.
+
+    Args:
+        legacy: The Fragment's ``frequency`` field.
+
+    Returns:
+        A weight-descending tuple of weighted frequencies.
+    """
+    entries: list[WeightedDimension[Frequency]] = []
+    seen: set[Frequency] = set()
+    primary = _coerce_enum(legacy.primary, Frequency)
+    if primary is not None and primary is not Frequency.UNCLASSIFIED:
+        entries.append(WeightedDimension(value=primary, weight=_LEGACY_SINGLE_WEIGHT))
+        seen.add(primary)
+    for raw in legacy.secondary:
+        member = _coerce_enum(raw, Frequency)
+        if member is None or member is Frequency.UNCLASSIFIED or member in seen:
+            continue
+        entries.append(
+            WeightedDimension(value=member, weight=_LEGACY_SECONDARY_WEIGHT),
+        )
+        seen.add(member)
+    return tuple(entries)
+
+
+def _widen_single(
+    legacy: _DimT | str,
+    enum_type: type[_DimT],
+) -> tuple[WeightedDimension[_DimT], ...]:
+    """Widen a single legacy enum field into a one-entry weighted tuple.
+
+    ``UNCLASSIFIED`` collapses to the empty tuple so :meth:`to_legacy`
+    can distinguish "unset" from "explicitly classified as
+    unclassified". The legacy field arrives as either an enum member
+    (when constructed through Python) or its string value (when
+    loaded from YAML with ``use_enum_values=True``); both forms are
+    accepted.
+
+    Args:
+        legacy: The legacy enum value, possibly serialised as a string.
+        enum_type: The target :class:`StrEnum` subclass.
+
+    Returns:
+        A single-entry tuple at weight 1.0, or an empty tuple when
+        the input is ``UNCLASSIFIED`` / unresolvable.
+    """
+    member = _coerce_enum(legacy, enum_type)
+    unclassified = enum_type("unclassified")
+    if member is None or member is unclassified:
+        return ()
+    return (WeightedDimension(value=member, weight=_LEGACY_SINGLE_WEIGHT),)
+
+
+def _widen_voice_register(
+    legacy: VoiceRegister | str | None,
+) -> tuple[WeightedDimension[VoiceRegister], ...]:
+    """Widen :attr:`VoiceClassification.voice_register` into weighted form.
+
+    Voice register has no ``UNCLASSIFIED`` sentinel; its absence is
+    modelled as ``None``. ``None`` widens to the empty tuple so the
+    round-trip distinguishes "no voice signal" from "explicitly the
+    confessional register".
+
+    Args:
+        legacy: The voice register, possibly ``None``.
+
+    Returns:
+        A single-entry tuple at weight 1.0, or empty when ``None``.
+    """
+    if legacy is None:
+        return ()
+    member = _coerce_enum(legacy, VoiceRegister)
+    if member is None:
+        return ()
+    return (WeightedDimension(value=member, weight=_LEGACY_SINGLE_WEIGHT),)
+
+
+def _coerce_enum(value: object, enum_type: type[_DimT]) -> _DimT | None:
+    """Coerce a Pydantic-loaded legacy enum value back into the enum.
+
+    Pydantic's ``ConfigDict(use_enum_values=True)`` on :class:`Fragment`
+    means legacy enum fields come back as raw strings, not enum
+    members, after a YAML round-trip. The widening helpers need the
+    enum members to compare against ``UNCLASSIFIED`` and to anchor
+    :class:`WeightedDimension`'s ``value`` field, so this helper
+    normalises both forms.
+
+    Args:
+        value: An enum member or its string value.
+        enum_type: The target :class:`StrEnum` subclass.
+
+    Returns:
+        The matching enum member, or ``None`` for inputs that do not
+        round-trip cleanly (an unrelated string, an unrelated enum).
+    """
+    if isinstance(value, enum_type):
+        return value
+    if isinstance(value, str):
+        try:
+            return enum_type(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _split_frequencies(
+    weighted: tuple[WeightedDimension[Frequency], ...],
+) -> tuple[Frequency, list[Frequency]]:
+    """Split a weighted-frequency tuple into legacy ``(primary, secondary)``.
+
+    The top entry by weight becomes the primary; the rest become
+    secondaries in weight-descending order. An empty tuple collapses
+    to ``(UNCLASSIFIED, [])``.
+
+    Args:
+        weighted: A weight-descending tuple of weighted frequencies.
+
+    Returns:
+        ``(primary, secondary)`` ready for
+        :class:`FrequencyClassification`.
+    """
+    if not weighted:
+        return Frequency.UNCLASSIFIED, []
+    primary = weighted[0].value
+    secondary = [entry.value for entry in weighted[1:]]
+    return primary, secondary
+
+
+def _top_value(
+    weighted: tuple[WeightedDimension[_DimT], ...],
+    default: _DimT,
+) -> _DimT:
+    """Return the highest-weight entry's value, or ``default`` when empty."""
+    if not weighted:
+        return default
+    return weighted[0].value
+
+
+def _top_value_optional(
+    weighted: tuple[WeightedDimension[_DimT], ...],
+) -> _DimT | None:
+    """Return the highest-weight entry's value, or ``None`` when empty."""
+    if not weighted:
+        return None
+    return weighted[0].value
+
+
+# Fragment.weighted's forward reference is resolved at the bottom of
+# :mod:`creek.models` via a late import of this module; we do not call
+# ``Fragment.model_rebuild`` here ourselves so the rebuild has a single
+# source of truth and the import dependency stays models → weighted
+# rather than mutually recursive at runtime.

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -10,12 +10,21 @@ import uuid
 import warnings
 from datetime import UTC, date, datetime
 from enum import StrEnum
-from typing import Literal, TypeVar
+from typing import TYPE_CHECKING, Literal, TypeVar
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from creek.compile.provenance import CompileMethod, ProvenanceEntry
 from creek.time import now_la, today_la
+
+if TYPE_CHECKING:
+    # Type-only import to expose :class:`WeightedFragmentClassification`
+    # to mypy / IDEs. At runtime the symbol is resolved by the late
+    # import + ``Fragment.model_rebuild`` at the bottom of this module
+    # (issue #365); a runtime import here would re-introduce the
+    # circular import :mod:`creek.classify.weighted` imports back into
+    # :mod:`creek.models`.
+    from creek.classify.weighted import WeightedFragmentClassification
 
 CompileTargetKind = Literal["thread", "eddy", "frequency_index"]
 """The compiled-page surfaces ``creek compile`` may target (FEAT-003)."""
@@ -505,6 +514,15 @@ class Fragment(BaseModel):
     child_ids: list[str] = Field(default_factory=list)
     level: FragmentLevel = "document"
     structural_path: list[str] = Field(default_factory=list)
+    # Epic #364: optional weighted-ontology profile parallel to the
+    # legacy ``frequency`` / ``wavelength`` / ``voice`` fields.
+    # ``None`` means "no weighted detection ran" (legacy vaults,
+    # pre-#366 fragments); set by sub-issues #366 / #368 / #369. The
+    # forward reference is resolved at the bottom of this module via a
+    # late import of :mod:`creek.classify.weighted` so the
+    # circular-import risk between models and the classify package
+    # stays contained.
+    weighted: "WeightedFragmentClassification | None" = None
 
     # BUG-009: the ``[prop-decorator]`` suppression below is a known
     # mypy / Pydantic-v2 limitation when stacking ``@computed_field``
@@ -744,3 +762,27 @@ class CompiledPage(BaseModel):
     compile_method: CompileMethod = "llm"
     level_policy: str = "leaves"
     source_levels: list[str] = Field(default_factory=list)
+
+
+# Late import + ``Fragment.model_rebuild`` to resolve the
+# :attr:`Fragment.weighted` forward reference (epic #364). The import
+# lives at the bottom of the module so every name :mod:`creek.classify.weighted`
+# depends on (the enum types, the legacy classification models, the
+# Fragment class itself) is already defined; the partial-load state
+# is enough for ``weighted.py`` to import successfully and produce a
+# :class:`WeightedFragmentClassification` we can name in the rebuild.
+# The late import below is required to break the cycle between models
+# and the weighted-classification module. ``weighted.py`` needs Fragment
+# and the enum types from this module, so it must load AFTER them; that
+# puts our half of the cycle here at module bottom. The ``noqa: E402``
+# below marks the deliberate placement; a top-level import would fail
+# with ``ImportError``.
+from creek.classify.weighted import (  # noqa: E402  # wrong-import-position
+    WeightedFragmentClassification as _WeightedFragmentClassification,
+)
+
+Fragment.model_rebuild(
+    _types_namespace={
+        "WeightedFragmentClassification": _WeightedFragmentClassification,
+    },
+)

--- a/creek-tools/tests/test_weighted.py
+++ b/creek-tools/tests/test_weighted.py
@@ -1,0 +1,590 @@
+"""Tests for the shared weighted-classification model (issue #365).
+
+Covers :mod:`creek.classify.weighted` — the foundation laid by epic
+#364 that promotes PR #359's :class:`WeightedDimension` to a module
+both the prompt detector and the (forthcoming) fragment classifier
+share, and introduces :class:`WeightedFragmentClassification`, the
+Pydantic model that lives on :attr:`Fragment.weighted`.
+
+Three concerns get exercised here:
+
+1. **Public surface.** ``WeightedDimension`` and parser helpers are
+   re-exported from :mod:`creek.classify.prompt` so PR #359's import
+   path keeps working — verified via direct attribute access on the
+   prompt module.
+2. **Fragment integration.** ``Fragment.weighted`` defaults to ``None``,
+   round-trips byte-identically through Pydantic's JSON-mode
+   serialiser, and a legacy YAML payload without a ``weighted`` key
+   loads with ``weighted=None``.
+3. **Single-pick ↔ weighted adapters.** ``from_single_pick`` widens a
+   legacy ``Fragment`` and ``to_legacy`` collapses back; the pair is
+   inverse on non-``UNCLASSIFIED`` legacy fields modulo the documented
+   limitations (color is recomputed; descriptor and voice confidence
+   are dropped).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from creek.classify import prompt as prompt_module
+from creek.classify import weighted as weighted_module
+from creek.classify.weighted import (
+    _FREQUENCY_TO_COLOR,
+    _LEGACY_SECONDARY_WEIGHT,
+    _LEGACY_SINGLE_WEIGHT,
+    WeightedDimension,
+    WeightedFragmentClassification,
+    _coerce_weight,
+    _load_yaml_dict,
+    _parse_dimension,
+    _parse_enum_value,
+)
+from creek.models import (
+    Color,
+    Confidence,
+    Dosage,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Mode,
+    Orientation,
+    Phase,
+    SourcePlatform,
+    VoiceClassification,
+    VoiceRegister,
+    WavelengthClassification,
+)
+
+# ---- Fixtures --------------------------------------------------------------
+
+
+def _make_fragment(**overrides: object) -> Fragment:
+    """Build a minimal :class:`Fragment` with optional field overrides.
+
+    The default fragment is the same shape ``test_minimal_creation``
+    uses in :mod:`tests.test_models` so behaviour stays comparable
+    across the test suite.
+
+    Args:
+        **overrides: Field values to splice onto the default Fragment.
+
+    Returns:
+        A constructed :class:`Fragment` ready for use in a test body.
+    """
+    defaults: dict[str, object] = {
+        "id": "frag-000000000001",
+        "title": "Test Fragment",
+        "source": FragmentSource(platform=SourcePlatform.CLAUDE),
+    }
+    defaults.update(overrides)
+    return Fragment(**defaults)  # type: ignore[arg-type]
+
+
+# ---- Public-surface tests --------------------------------------------------
+
+
+class TestPublicSurface:
+    """The promoted symbols are exposed from both modules."""
+
+    def test_weighted_dimension_re_exported_from_prompt(self) -> None:
+        """PR #359's :class:`WeightedDimension` import path still works."""
+        # The class object on both modules is the same.
+        assert prompt_module.WeightedDimension is WeightedDimension
+
+    def test_parser_helpers_re_exported_from_prompt(self) -> None:
+        """Helper functions are accessible on the prompt module too."""
+        assert (
+            prompt_module._coerce_weight is _coerce_weight
+        )  # private re-export check matches the documented contract
+        assert prompt_module._parse_dimension is _parse_dimension
+        assert prompt_module._load_yaml_dict is _load_yaml_dict
+
+    def test_module_all_exports(self) -> None:
+        """``weighted.py``'s ``__all__`` names the public-API symbols."""
+        assert set(weighted_module.__all__) == {
+            "WeightedDimension",
+            "WeightedFragmentClassification",
+        }
+
+
+# ---- Parser helper tests ---------------------------------------------------
+
+
+class TestCoerceWeight:
+    """The leading-underscore parser helpers move cleanly to weighted.py."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (0.5, 0.5),
+            (0.0, 0.0),
+            (1.0, 1.0),
+            (-0.1, 0.0),
+            (1.5, 1.0),
+            (None, 0.0),
+            ("0.5", 0.0),
+            (True, 0.0),
+            (float("nan"), 0.0),
+            (float("inf"), 0.0),
+            (float("-inf"), 0.0),
+        ],
+    )
+    def test_clamps_and_rejects(self, value: object, expected: float) -> None:
+        """The clamp keeps weights inside ``[0.0, 1.0]`` for downstream math."""
+        assert _coerce_weight(value) == expected
+
+
+class TestParseEnumValue:
+    """Enum lookups are case-insensitive and tolerate unknown values."""
+
+    def test_resolves_known_value(self) -> None:
+        """A canonical string maps to its enum member."""
+        assert _parse_enum_value("F3", Frequency) is Frequency.F3
+
+    def test_returns_none_for_unknown(self) -> None:
+        """An unknown value falls through to ``None``."""
+        assert _parse_enum_value("not-a-frequency", Frequency) is None
+
+    def test_returns_none_for_none(self) -> None:
+        """Explicit ``None`` short-circuits to ``None``."""
+        assert _parse_enum_value(None, Frequency) is None
+
+    def test_case_insensitive(self) -> None:
+        """Case differences resolve to the canonical member."""
+        assert _parse_enum_value("RISING", Phase) is Phase.RISING
+
+    def test_empty_string_after_strip_returns_none(self) -> None:
+        """Whitespace-only input collapses to ``None`` rather than misresolving."""
+        assert _parse_enum_value("   ", Frequency) is None
+
+
+class TestLoadYamlDict:
+    """The dictionary validator rejects multi-doc payloads and stray keys."""
+
+    def test_extra_top_level_key_rejected(self) -> None:
+        """A stray top-level key produces a schema ``ValueError``."""
+        with pytest.raises(ValueError, match="unexpected top-level keys"):
+            _load_yaml_dict("frequencies: []\nbogus: 1")
+
+    def test_known_keys_pass(self) -> None:
+        """All canonical top-level keys are accepted."""
+        text = (
+            "frequencies: []\n"
+            "phases: []\n"
+            "modes: []\n"
+            "orientations: []\n"
+            "dosages: []\n"
+            "voice_registers: []\n"
+            "overall_confidence: 0.5\n"
+        )
+        parsed = _load_yaml_dict(text)
+        assert parsed["overall_confidence"] == 0.5
+
+    def test_non_dict_entry_dropped(self) -> None:
+        """``_parse_dimension`` skips non-dict entries silently."""
+        # A YAML list containing a scalar mixed with a valid entry —
+        # the scalar is dropped, the valid entry survives. Anchors the
+        # defensive ``isinstance(entry, dict)`` guard.
+        data: dict[str, object] = {
+            "frequencies": ["bogus", {"value": "F3", "weight": 0.7}],
+        }
+        parsed = _parse_dimension(data, "frequencies", Frequency)
+        assert parsed == (WeightedDimension(value=Frequency.F3, weight=0.7),)
+
+    def test_invalid_voice_register_widens_to_empty(self) -> None:
+        """A non-enum string on ``voice_register`` collapses to an empty tuple."""
+        # Bypass Pydantic's enum coercion by going through ``model_validate``
+        # with a typo — Pydantic would raise; we hand-roll the legacy
+        # widening helper directly to exercise the defensive branch.
+        from creek.classify.weighted import _widen_voice_register
+
+        assert _widen_voice_register("not-a-register") == ()  # type: ignore[arg-type]
+
+
+class TestCoerceEnumEdgeCases:
+    """``_coerce_enum`` tolerates enum members, strings, and outright junk."""
+
+    def test_unrelated_string_returns_none(self) -> None:
+        """A string that doesn't match any member of the enum returns ``None``."""
+        from creek.classify.weighted import _coerce_enum
+
+        assert _coerce_enum("not-a-frequency", Frequency) is None
+
+    def test_unrelated_object_returns_none(self) -> None:
+        """A non-string, non-enum input returns ``None`` rather than raising."""
+        from creek.classify.weighted import _coerce_enum
+
+        assert _coerce_enum(42, Frequency) is None
+
+
+# ---- WeightedFragmentClassification construction ---------------------------
+
+
+class TestWeightedFragmentClassificationConstruction:
+    """Direct construction matches PromptOntology's documented shape."""
+
+    def test_default_is_empty(self) -> None:
+        """Default-constructed instance has empty tuples and zero confidence."""
+        empty = WeightedFragmentClassification()
+        assert empty.frequencies == ()
+        assert empty.phases == ()
+        assert empty.modes == ()
+        assert empty.orientations == ()
+        assert empty.dosages == ()
+        assert empty.voice_registers == ()
+        assert empty.overall_confidence == 0.0
+        assert empty.reasoning == ""
+
+    def test_construct_with_dimensions(self) -> None:
+        """Explicit tuples flow through unchanged."""
+        weighted = WeightedFragmentClassification(
+            frequencies=(WeightedDimension(value=Frequency.F3, weight=0.8),),
+            phases=(WeightedDimension(value=Phase.RISING, weight=0.7),),
+            overall_confidence=0.75,
+            reasoning="brief reasoning",
+        )
+        assert weighted.frequencies[0].value is Frequency.F3
+        assert weighted.frequencies[0].weight == 0.8
+        assert weighted.phases[0].value is Phase.RISING
+        assert weighted.overall_confidence == 0.75
+        assert weighted.reasoning == "brief reasoning"
+
+    def test_frozen_blocks_mutation(self) -> None:
+        """The model is frozen so callers cannot mutate it in place."""
+        weighted = WeightedFragmentClassification(overall_confidence=0.5)
+        # Pydantic v2 raises ``ValidationError`` on a frozen-instance
+        # write; the test cares about the immutability contract, not
+        # the exact exception subclass.
+        with pytest.raises(ValidationError):
+            weighted.overall_confidence = 0.9
+
+
+# ---- Fragment.weighted integration -----------------------------------------
+
+
+class TestFragmentWeightedField:
+    """The ``weighted`` field defaults to ``None`` and round-trips clean."""
+
+    def test_default_is_none(self) -> None:
+        """A minimal Fragment carries ``weighted=None``."""
+        frag = _make_fragment()
+        assert frag.weighted is None
+
+    def test_explicit_weighted_is_carried(self) -> None:
+        """A constructed ``Fragment`` keeps the provided weighted value."""
+        wfc = WeightedFragmentClassification(
+            frequencies=(WeightedDimension(value=Frequency.F3, weight=0.8),),
+            overall_confidence=0.7,
+        )
+        frag = _make_fragment(weighted=wfc)
+        assert frag.weighted is wfc
+
+    def test_roundtrip_byte_identical_for_populated(self) -> None:
+        """``model_dump(mode='json')`` + ``model_validate`` is identity."""
+        wfc = WeightedFragmentClassification(
+            frequencies=(
+                WeightedDimension(value=Frequency.F3, weight=0.8),
+                WeightedDimension(value=Frequency.F5, weight=0.4),
+            ),
+            phases=(WeightedDimension(value=Phase.RISING, weight=0.6),),
+            modes=(WeightedDimension(value=Mode.EXPRESS, weight=0.5),),
+            orientations=(WeightedDimension(value=Orientation.DO_FEEL, weight=0.7),),
+            dosages=(
+                WeightedDimension(value=Dosage.TOXIC, weight=0.6),
+                WeightedDimension(value=Dosage.MEDICINE, weight=0.3),
+            ),
+            voice_registers=(
+                WeightedDimension(value=VoiceRegister.ANALYTICAL, weight=0.5),
+            ),
+            overall_confidence=0.7,
+            reasoning="A representative reasoning preamble",
+        )
+        frag = _make_fragment(weighted=wfc)
+        dumped = frag.model_dump(mode="json")
+        loaded = Fragment.model_validate(dumped)
+        assert loaded.weighted == frag.weighted
+
+    def test_roundtrip_byte_identical_for_none(self) -> None:
+        """A ``weighted=None`` Fragment also round-trips cleanly."""
+        frag = _make_fragment()
+        loaded = Fragment.model_validate(frag.model_dump(mode="json"))
+        assert loaded.weighted is None
+
+    def test_legacy_payload_without_weighted_key_loads(self) -> None:
+        """A YAML-style dict lacking ``weighted`` loads with ``weighted=None``.
+
+        Mirrors the on-disk reality of pre-#365 vault fragments where
+        the frontmatter does not contain a ``weighted`` block at all.
+        """
+        payload = {
+            "id": "frag-000000000099",
+            "title": "Legacy fragment",
+            "source": {"platform": "claude"},
+        }
+        loaded = Fragment.model_validate(payload)
+        assert loaded.weighted is None
+
+
+# ---- from_single_pick / to_legacy adapters ---------------------------------
+
+
+class TestFromSinglePick:
+    """Widening legacy single-pick fields into weighted form."""
+
+    def test_unclassified_widens_to_empty(self) -> None:
+        """A default Fragment (all-unclassified) widens to all-empty tuples."""
+        frag = _make_fragment()
+        widened = WeightedFragmentClassification.from_single_pick(frag)
+        assert widened.frequencies == ()
+        assert widened.phases == ()
+        assert widened.modes == ()
+        assert widened.orientations == ()
+        assert widened.dosages == ()
+        assert widened.voice_registers == ()
+
+    def test_primary_frequency_widens_to_single_full_weight(self) -> None:
+        """A primary-only frequency becomes one entry at weight 1.0."""
+        frag = _make_fragment(
+            frequency=FrequencyClassification(primary=Frequency.F3),
+        )
+        widened = WeightedFragmentClassification.from_single_pick(frag)
+        assert widened.frequencies == (
+            WeightedDimension(value=Frequency.F3, weight=_LEGACY_SINGLE_WEIGHT),
+        )
+
+    def test_secondaries_widen_at_secondary_weight(self) -> None:
+        """Secondary frequencies widen at the secondary weight, primary at 1.0."""
+        frag = _make_fragment(
+            frequency=FrequencyClassification(
+                primary=Frequency.F3,
+                secondary=[Frequency.F5, Frequency.F7],
+            ),
+        )
+        widened = WeightedFragmentClassification.from_single_pick(frag)
+        assert widened.frequencies == (
+            WeightedDimension(value=Frequency.F3, weight=_LEGACY_SINGLE_WEIGHT),
+            WeightedDimension(value=Frequency.F5, weight=_LEGACY_SECONDARY_WEIGHT),
+            WeightedDimension(value=Frequency.F7, weight=_LEGACY_SECONDARY_WEIGHT),
+        )
+
+    def test_secondaries_with_duplicate_of_primary_dedupe(self) -> None:
+        """A legacy ``secondary`` repeating the primary is deduplicated."""
+        frag = _make_fragment(
+            frequency=FrequencyClassification(
+                primary=Frequency.F3,
+                secondary=[Frequency.F3, Frequency.F5],
+            ),
+        )
+        widened = WeightedFragmentClassification.from_single_pick(frag)
+        assert widened.frequencies == (
+            WeightedDimension(value=Frequency.F3, weight=_LEGACY_SINGLE_WEIGHT),
+            WeightedDimension(value=Frequency.F5, weight=_LEGACY_SECONDARY_WEIGHT),
+        )
+
+    def test_wavelength_widens_each_dimension(self) -> None:
+        """Every non-unclassified wavelength axis becomes a one-entry tuple."""
+        frag = _make_fragment(
+            wavelength=WavelengthClassification(
+                phase=Phase.RISING,
+                mode=Mode.EXPRESS,
+                orientation=Orientation.DO_FEEL,
+                dosage=Dosage.MEDICINE,
+            ),
+        )
+        widened = WeightedFragmentClassification.from_single_pick(frag)
+        assert widened.phases == (
+            WeightedDimension(value=Phase.RISING, weight=_LEGACY_SINGLE_WEIGHT),
+        )
+        assert widened.modes == (
+            WeightedDimension(value=Mode.EXPRESS, weight=_LEGACY_SINGLE_WEIGHT),
+        )
+        assert widened.orientations == (
+            WeightedDimension(value=Orientation.DO_FEEL, weight=_LEGACY_SINGLE_WEIGHT),
+        )
+        assert widened.dosages == (
+            WeightedDimension(value=Dosage.MEDICINE, weight=_LEGACY_SINGLE_WEIGHT),
+        )
+
+    def test_voice_register_set_widens(self) -> None:
+        """An explicit voice_register widens; ``None`` collapses to empty."""
+        frag = _make_fragment(
+            voice=VoiceClassification(voice_register=VoiceRegister.ANALYTICAL),
+        )
+        widened = WeightedFragmentClassification.from_single_pick(frag)
+        assert widened.voice_registers == (
+            WeightedDimension(
+                value=VoiceRegister.ANALYTICAL,
+                weight=_LEGACY_SINGLE_WEIGHT,
+            ),
+        )
+
+    def test_voice_register_none_widens_to_empty(self) -> None:
+        """A Fragment without a voice register widens to an empty tuple."""
+        frag = _make_fragment()
+        widened = WeightedFragmentClassification.from_single_pick(frag)
+        assert widened.voice_registers == ()
+
+
+class TestToLegacy:
+    """Collapsing weighted tuples back into legacy classifications."""
+
+    def test_empty_collapses_to_unclassified(self) -> None:
+        """A default-empty weighted instance collapses to all-unclassified."""
+        empty = WeightedFragmentClassification()
+        frequency, wavelength, voice = empty.to_legacy()
+        assert frequency.primary == Frequency.UNCLASSIFIED
+        assert frequency.secondary == []
+        assert wavelength.phase == Phase.UNCLASSIFIED
+        assert wavelength.mode == Mode.UNCLASSIFIED
+        assert wavelength.orientation == Orientation.UNCLASSIFIED
+        assert wavelength.dosage == Dosage.UNCLASSIFIED
+        assert wavelength.color == Color.UNCLASSIFIED
+        assert wavelength.descriptor == ""
+        assert voice.voice_register is None
+        assert voice.confidence is None
+
+    def test_top_frequency_becomes_primary(self) -> None:
+        """The highest-weight frequency lands on ``primary``; rest on ``secondary``."""
+        wfc = WeightedFragmentClassification(
+            frequencies=(
+                WeightedDimension(value=Frequency.F3, weight=0.9),
+                WeightedDimension(value=Frequency.F5, weight=0.4),
+                WeightedDimension(value=Frequency.F7, weight=0.2),
+            ),
+        )
+        frequency, _wavelength, _voice = wfc.to_legacy()
+        assert frequency.primary == Frequency.F3
+        assert frequency.secondary == [Frequency.F5, Frequency.F7]
+
+    def test_color_derived_from_top_frequency(self) -> None:
+        """Color comes from the canonical frequency→color mapping."""
+        wfc = WeightedFragmentClassification(
+            frequencies=(WeightedDimension(value=Frequency.F3, weight=0.9),),
+        )
+        _frequency, wavelength, _voice = wfc.to_legacy()
+        assert wavelength.color == Color.RED  # F3 → red per the canonical map
+
+    @pytest.mark.parametrize(
+        "freq",
+        [
+            Frequency.F1,
+            Frequency.F2,
+            Frequency.F3,
+            Frequency.F4,
+            Frequency.F5,
+            Frequency.F6,
+            Frequency.F7,
+            Frequency.F8,
+            Frequency.F9,
+            Frequency.F10,
+        ],
+    )
+    def test_color_mapping_complete(self, freq: Frequency) -> None:
+        """Every concrete frequency has a colour assignment."""
+        assert _FREQUENCY_TO_COLOR[freq] is not Color.UNCLASSIFIED
+
+
+class TestRoundTrip:
+    """The widening / collapsing pair is inverse on non-unclassified fields."""
+
+    def test_widen_then_collapse_preserves_legacy_fields(self) -> None:
+        """``from_single_pick`` + ``to_legacy`` round-trip on the supported fields."""
+        original = _make_fragment(
+            frequency=FrequencyClassification(
+                primary=Frequency.F3,
+                secondary=[Frequency.F5, Frequency.F7],
+            ),
+            wavelength=WavelengthClassification(
+                phase=Phase.RISING,
+                mode=Mode.EXPRESS,
+                orientation=Orientation.DO_FEEL,
+                dosage=Dosage.MEDICINE,
+                color=Color.RED,
+            ),
+            voice=VoiceClassification(voice_register=VoiceRegister.ANALYTICAL),
+        )
+        widened = WeightedFragmentClassification.from_single_pick(original)
+        freq_out, wave_out, voice_out = widened.to_legacy()
+        assert freq_out.primary == Frequency.F3
+        assert freq_out.secondary == [Frequency.F5, Frequency.F7]
+        assert wave_out.phase == Phase.RISING
+        assert wave_out.mode == Mode.EXPRESS
+        assert wave_out.orientation == Orientation.DO_FEEL
+        assert wave_out.dosage == Dosage.MEDICINE
+        assert wave_out.color == Color.RED  # recomputed from primary, matches original
+        assert voice_out.voice_register == VoiceRegister.ANALYTICAL
+
+    def test_widen_drops_voice_confidence(self) -> None:
+        """``VoiceClassification.confidence`` does not round-trip (documented)."""
+        original = _make_fragment(
+            voice=VoiceClassification(
+                voice_register=VoiceRegister.PROPHETIC,
+                confidence=Confidence.SETTLED,
+            ),
+        )
+        widened = WeightedFragmentClassification.from_single_pick(original)
+        _freq, _wave, voice_out = widened.to_legacy()
+        # voice_register survives; confidence is dropped to None.
+        assert voice_out.voice_register == VoiceRegister.PROPHETIC
+        assert voice_out.confidence is None
+
+    def test_widen_drops_descriptor(self) -> None:
+        """``WavelengthClassification.descriptor`` does not round-trip."""
+        original = _make_fragment(
+            wavelength=WavelengthClassification(
+                phase=Phase.RISING,
+                descriptor="A free-form descriptor that has no weighted analogue",
+            ),
+        )
+        widened = WeightedFragmentClassification.from_single_pick(original)
+        _freq, wave_out, _voice = widened.to_legacy()
+        assert wave_out.phase == Phase.RISING
+        assert wave_out.descriptor == ""
+
+    def test_widen_drops_pre_existing_color(self) -> None:
+        """Color is recomputed from the top frequency, not preserved verbatim."""
+        # Constructing a fragment with a deliberately mismatched colour
+        # (F3 paired with TEAL — F3's canonical colour is RED) anchors
+        # the contract: ``to_legacy`` ignores the legacy colour field
+        # and recomputes from ``primary``.
+        original = _make_fragment(
+            frequency=FrequencyClassification(primary=Frequency.F3),
+            wavelength=WavelengthClassification(
+                phase=Phase.RISING,
+                color=Color.TEAL,
+            ),
+        )
+        widened = WeightedFragmentClassification.from_single_pick(original)
+        _freq, wave_out, _voice = widened.to_legacy()
+        assert wave_out.color == Color.RED  # recomputed from F3, not TEAL
+
+
+# ---- Generic enum-coercion edge cases --------------------------------------
+
+
+class TestEnumCoercionEdgeCases:
+    """The widening helpers tolerate both enum and string-valued inputs."""
+
+    def test_widen_frequency_handles_string_primary(self) -> None:
+        """A Fragment loaded from YAML keeps enum semantics through widening.
+
+        Pydantic's ``use_enum_values=True`` on Fragment means the
+        on-disk YAML stores enum strings, not enum members. After a
+        ``model_validate`` round-trip, ``frequency.primary`` comes back
+        as a plain string. The widening helpers must tolerate that.
+        """
+        # Round-trip through YAML so primary lands as a string.
+        original = _make_fragment(
+            frequency=FrequencyClassification(primary=Frequency.F3),
+        )
+        loaded = Fragment.model_validate(original.model_dump(mode="json"))
+        # ``primary`` is now a string per ``use_enum_values=True``.
+        assert loaded.frequency.primary == "F3"
+
+        widened = WeightedFragmentClassification.from_single_pick(loaded)
+        assert widened.frequencies == (
+            WeightedDimension(value=Frequency.F3, weight=_LEGACY_SINGLE_WEIGHT),
+        )


### PR DESCRIPTION
## Summary

Foundation for epic #364 (holonic weighted classifications across the fragment holarchy). Promotes the `WeightedDimension` primitive and YAML parser helpers from PR #359 into a new shared module `creek.classify.weighted` so the fragment-level classifier (#366) and the holonic combiner (#367) can reuse them without inverting the dependency graph between this epic's downstream sub-issues.

Introduces `WeightedFragmentClassification` (Pydantic BaseModel, mirrors `PromptOntology` minus the `prompt` field) and adds an optional `Fragment.weighted: WeightedFragmentClassification | None = None` field that round-trips byte-identically through `model_dump(mode="json")` / `model_validate` so vault YAML frontmatter stays the persistence path — no bespoke serialiser plumbing. Legacy fragments without a `weighted` key load with `weighted=None`.

## Stacked on PR #359

This branch is based on `claude/github-epic-parallel-work-2Kq9T` (PR #359). #365 promotes the symbols that #359 introduced, so it must merge after #359. The PR base will need to flip to `main` once #359 lands (a rebase, no content changes).

## What ships

- **`creek/classify/weighted.py`** (new): `WeightedDimension`, `WeightedFragmentClassification`, the moved parser helpers (`_coerce_weight`, `_parse_enum_value`, `_parse_dimension`, `_load_yaml_dict`), and the single-pick ↔ weighted adapters.
- **`creek/classify/prompt.py`** (updated): re-imports the moved symbols so PR #359's public surface (`from creek.classify.prompt import WeightedDimension, …`) keeps working unchanged.
- **`creek/models.py`** (updated): adds `Fragment.weighted` with a TYPE_CHECKING import for mypy; the forward reference is resolved by a late `Fragment.model_rebuild` at module bottom (the only way to break the models ↔ classify.weighted cycle).
- **`tests/test_weighted.py`** (new, 58 tests).

## Adapters

- `WeightedFragmentClassification.from_single_pick(fragment)` widens legacy primary/secondary frequency + single-pick wavelength + `voice_register` into the weighted shape (primary at weight 1.0, secondaries at 0.5; non-`UNCLASSIFIED` legacy single-picks at 1.0).
- `WeightedFragmentClassification.to_legacy()` collapses back: top frequency → `primary`, rest → `secondary`; color is recomputed from `primary` via the canonical mapping.
- **Documented limitations** (asserted by tests): `VoiceClassification.confidence` and `WavelengthClassification.descriptor` do not round-trip (no weighted analogues); the legacy color is recomputed rather than preserved verbatim.

## Acceptance criteria (#365)

- [x] `WeightedDimension` + `WeightedFragmentClassification` live in `creek.classify.weighted`; re-exported from `creek.classify.prompt`.
- [x] `Fragment.weighted` exists, defaults to `None`, type-checks under mypy strict.
- [x] Populated Fragment round-trips byte-identically through `model_dump(mode="json")` / `model_validate`.
- [x] Legacy YAML payload without a `weighted:` key loads cleanly with `weighted=None`.
- [x] `from_single_pick` / `to_legacy` are inverse on non-`UNCLASSIFIED` legacy fields (documented limitations covered by tests).
- [x] All 37 tests added by PR #359 still pass (no regression).
- [x] Quality gates all green (see below).

## Quality

- **Tests**: 58 new in `test_weighted.py`; 4313 total in the suite (1 pre-existing failure in `test_purge.py` unrelated to this work, deselected — see [#359 base](https://github.com/Geoffe-Ga/Creek-Vault/commit/7f481134)).
- **Branch coverage**: 99.06% on `weighted.py`; 93.78% aggregate.
- **Per-file coverage gate**: 148 files ≥ 80%, 2 waivered ≥ 65%.
- **Mypy strict**: 0 issues.
- **Pylint**: 9.92/10 (above 9.0 threshold).
- **Ruff lint + format**: clean.
- **Bandit / refurb / tryceratops / interrogate / xenon**: clean.

## Test plan

- [x] `uv run pytest tests/test_weighted.py tests/test_prompt_ontology.py -q` → 95 passed (no regression in PR #359 tests).
- [x] `uv run pytest tests/ --deselect tests/test_purge.py::test_cli_purge_vault_refuses_non_creek_directory` → 4313 passed.
- [x] `./scripts/coverage-per-file.sh` → 148 files ≥ 80%, 2 waivered ≥ 65%.
- [x] `uv run mypy creek/` → 0 issues, 130 files.
- [x] `uv run pylint creek/classify/weighted.py creek/models.py --fail-under=9.0` → 9.92/10.

Closes #365
Part of #364

https://claude.ai/code/session_01Rmvpqhr5ktg7abxiHMRdTj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rmvpqhr5ktg7abxiHMRdTj)_