### PR TITLE
feat(draft): bidirectional grounding guard (#355)

### DIFF
--- a/creek-tools/creek/classify/holonic.py
+++ b/creek-tools/creek/classify/holonic.py
@@ -402,6 +402,32 @@ def _mean_normalised_jsd(
     return sum(divergences) / len(divergences)
 
 
+def _contributing_distributions(
+    per_child_entries: Sequence[tuple[WeightedDimension[_DimT], ...]],
+    weights: Sequence[float],
+) -> tuple[list[dict[_DimT, float]], list[float]]:
+    """Build per-child sum-to-1 distributions, skipping non-contributors.
+
+    A child contributes to the JSD only when it carries a positive
+    effective weight *and* at least one entry on the dimension whose
+    weights sum positively. Children that fail either gate are
+    excluded so the divergence is computed over the actually-comparable
+    distributions rather than diluted by vacuous zeros.
+    """
+    distributions: list[dict[_DimT, float]] = []
+    contributing_weights: list[float] = []
+    for entries, weight in zip(per_child_entries, weights, strict=True):
+        if weight <= 0 or not entries:
+            continue
+        total_entry_weight = sum(entry.weight for entry in entries)
+        if total_entry_weight <= 0:
+            continue
+        dist = {entry.value: entry.weight / total_entry_weight for entry in entries}
+        distributions.append(dist)
+        contributing_weights.append(weight)
+    return distributions, contributing_weights
+
+
 def _per_dimension_jsd(
     per_child_entries: Sequence[tuple[WeightedDimension[_DimT], ...]],
     weights: Sequence[float],
@@ -414,32 +440,17 @@ def _per_dimension_jsd(
     definition, but we want to skip dimensions where no comparison is
     possible rather than dilute the average with vacuous zeros).
     """
-    # Build per-child distributions (sum-to-1 per child, zeros for
-    # values the child did not mention) only for children with at
-    # least one entry on this dimension and a positive effective
-    # weight; the rest do not contribute to the JSD.
-    distributions: list[dict[_DimT, float]] = []
-    contributing_weights: list[float] = []
-    for entries, weight in zip(per_child_entries, weights, strict=True):
-        if weight <= 0 or not entries:
-            continue
-        total_entry_weight = sum(entry.weight for entry in entries)
-        if total_entry_weight <= 0:
-            continue
-        dist = {entry.value: entry.weight / total_entry_weight for entry in entries}
-        distributions.append(dist)
-        contributing_weights.append(weight)
-
+    distributions, contributing_weights = _contributing_distributions(
+        per_child_entries,
+        weights,
+    )
     if len(distributions) < 2:
         return None
 
-    # All enum values that appear anywhere — the JSD is computed over
-    # this support so each child's distribution is zero-padded
-    # consistently. ``chain.from_iterable`` keeps the nested-iterable
-    # flattening explicit and dodges the FURB179 readability flag.
-    from itertools import (
-        chain,  # locally scoped to keep the import cost off the module hot path
-    )
+    # ``chain.from_iterable`` keeps the nested-iterable flattening
+    # explicit and dodges the FURB179 readability flag. Locally scoped
+    # to keep the import cost off the module hot path.
+    from itertools import chain
 
     support = sorted(
         set(chain.from_iterable(distributions)),

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -707,6 +707,37 @@ class MiningConfig(BaseModel):
     """
 
 
+class DraftConfig(BaseModel):
+    """Configuration for the ``creek draft`` grounding guard (issue #355).
+
+    The bidirectional grounding guard surfaces two failure modes after a
+    draft is generated:
+
+    * **Too derivative** — at least one draft paragraph paraphrases a
+      source-fragment paragraph closely (cosine similarity above
+      :attr:`derivative_upper`).
+    * **Too ungrounded** — fewer than :attr:`grounding_lower` fraction of
+      draft paragraphs share *any* similarity with a source paragraph
+      above the same lower bound, i.e. the draft is conceptually
+      invented.
+
+    Defaults are deliberately lenient (0.85 / 0.30); operators tighten
+    once they have a calibration set for their own corpus. Both
+    thresholds are cosine similarities and so must live in ``[0.0, 1.0]``.
+    """
+
+    derivative_upper: float = Field(default=0.85, ge=0.0, le=1.0)
+    """Paragraph cosine-similarity ceiling above which a draft paragraph
+    is treated as a paraphrase of a source paragraph and the draft is
+    flagged ``too derivative``."""
+
+    grounding_lower: float = Field(default=0.30, ge=0.0, le=1.0)
+    """Cosine-similarity floor a draft paragraph must clear against
+    *some* source paragraph to count as grounded. Doubles as the
+    minimum acceptable fraction of grounded paragraphs: drafts whose
+    grounded fraction sits below this value are flagged ``too ungrounded``."""
+
+
 class LintConfig(BaseModel):
     """Configuration for ``creek lint`` checks (FEAT-008, FEAT-025).
 
@@ -817,6 +848,9 @@ class CreekConfig(BaseSettings):
 
     mining: MiningConfig = Field(default_factory=MiningConfig)
     """Idea-mining thresholds (issue #340)."""
+
+    draft: DraftConfig = Field(default_factory=DraftConfig)
+    """Bidirectional grounding-guard thresholds (issue #355)."""
 
     sources: SourcePaths = Field(default_factory=SourcePaths)
     """Source data path mappings."""

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -24,8 +24,9 @@ from __future__ import annotations
 import logging
 import operator
 import re
+import sys
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -52,6 +53,15 @@ from creek.generate.dimensional_retrieval import (
     format_dimension_label,
     raise_if_all_empty,
     union_fragment_ids,
+)
+from creek.generate.grounding import (
+    DERIVATIVE_FRONTMATTER_KEY,
+    GROUNDING_FRONTMATTER_KEY,
+    PARAGRAPH_ANNOTATIONS_KEY,
+    EmbeddingFn,
+    GroundingReport,
+    GroundingThresholds,
+    score_draft,
 )
 from creek.generate.twist import (
     OntologyProfile,
@@ -256,6 +266,23 @@ class Draft:
             source profile diverges from the target profile (issue
             #352). Empty when the two profiles match (regression
             baseline) or when twist composition was not requested.
+        derivative_score: Bidirectional grounding guard's derivative
+            metric (issue #355). The maximum paragraph cosine
+            similarity recorded between the draft body and every
+            paragraph of the source fragments that fed the prompt.
+            ``None`` when the guard did not run (no embedding callable
+            wired) so the field reads as "not yet evaluated" rather
+            than "evaluated clean".
+        grounding_score: Bidirectional grounding guard's grounding
+            metric (issue #355). The fraction of draft paragraphs whose
+            ``max_similarity`` cleared
+            :attr:`creek.config.DraftConfig.grounding_lower` against
+            *some* source paragraph. ``None`` when the guard did not
+            run.
+        paragraph_grounding: Per-paragraph annotation list produced by
+            :class:`creek.generate.grounding.GroundingReport`. Each
+            entry carries ``{index, max_similarity, is_derivative,
+            is_grounded}``. Empty when the guard did not run.
     """
 
     title: str
@@ -272,6 +299,9 @@ class Draft:
     source_profile: OntologyProfile | None = None
     target_profile: OntologyProfile | None = None
     twist_dimensions: tuple[str, ...] = ()
+    derivative_score: float | None = None
+    grounding_score: float | None = None
+    paragraph_grounding: tuple[dict[str, object], ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
         """Validate draft invariants."""
@@ -490,6 +520,8 @@ class DraftGenerator:
         privacy_override: PrivacyTierOverride | None = None,
         bypass_compiled: bool = False,
         ontology_twist: bool = False,
+        embedding_fn: EmbeddingFn | None = None,
+        grounding_thresholds: GroundingThresholds | None = None,
     ) -> None:
         """Initialise with an LLM client and skill tree root.
 
@@ -514,6 +546,19 @@ class DraftGenerator:
                 fragments. Default ``False`` keeps the legacy
                 composition path (epic #349 gates the flag while in
                 development).
+            embedding_fn: Optional paragraph embedding callable for the
+                issue #355 bidirectional grounding guard. When
+                supplied, every generated draft is scored against its
+                source fragments and the scores are written to the
+                returned :class:`Draft` and the saved frontmatter. When
+                ``None`` (the default) the guard is skipped — existing
+                tests that construct a :class:`DraftGenerator` with a
+                stub LLM continue to work without dragging in the
+                sentence-transformer dependency.
+            grounding_thresholds: Optional resolved guard thresholds.
+                Required only when *embedding_fn* is supplied; ignored
+                otherwise. Callers typically build this with
+                :meth:`creek.generate.grounding.GroundingThresholds.from_config`.
         """
         self._llm = llm
         self.skills_root = skills_root
@@ -521,6 +566,8 @@ class DraftGenerator:
         self.privacy_override = privacy_override
         self.bypass_compiled = bypass_compiled
         self.ontology_twist = ontology_twist
+        self._embedding_fn = embedding_fn
+        self._grounding_thresholds = grounding_thresholds
 
     def present_idea(self, idea: IdeaSeed) -> str:
         """Format *idea* as an invitation rather than an imperative.
@@ -819,6 +866,53 @@ class DraftGenerator:
         )
         return "\n\n".join(parts)
 
+    def _build_guard_report(
+        self,
+        *,
+        body: str,
+        source_fragments: tuple[str, ...],
+        fragments: dict[str, tuple[Fragment, str]],
+    ) -> GroundingReport | None:
+        """Run the issue #355 grounding guard, or return ``None`` when disabled.
+
+        The guard runs only when both an embedding callable and a
+        :class:`GroundingThresholds` instance were supplied at
+        construction time. Otherwise the method short-circuits — the
+        legacy test suite constructs :class:`DraftGenerator` with a
+        stub LLM only, and must keep working without dragging in the
+        sentence-transformer dependency.
+
+        The guard also prints a one-line summary to stderr so an
+        operator running ``creek draft`` interactively sees the verdict
+        before the saved-path message appears on stdout.
+
+        Args:
+            body: The generated draft body that just returned from the
+                LLM.
+            source_fragments: Fragment IDs that fed the draft prompt.
+                Looked up in *fragments* to pull each source body for
+                paragraph-level cosine scoring.
+            fragments: Pre-loaded ``{id: (Fragment, body)}`` map (the
+                same one the caller already loaded).
+
+        Returns:
+            A :class:`GroundingReport`, or ``None`` when the guard is
+            not configured on this generator.
+        """
+        if self._embedding_fn is None or self._grounding_thresholds is None:
+            return None
+        source_texts = [
+            fragments[fid][1] for fid in source_fragments if fid in fragments
+        ]
+        report = score_draft(
+            body,
+            source_texts=source_texts,
+            embedding_fn=self._embedding_fn,
+            thresholds=self._grounding_thresholds,
+        )
+        print(report.summary_line(), file=sys.stderr)
+        return report
+
     def generate_draft(
         self,
         idea: IdeaSeed,
@@ -860,6 +954,11 @@ class DraftGenerator:
         if not body:
             msg = "LLM returned an empty draft body"
             raise RuntimeError(msg)
+        guard = self._build_guard_report(
+            body=body,
+            source_fragments=idea.source_fragments,
+            fragments=fragments,
+        )
         return Draft(
             title=idea.title,
             body=body,
@@ -872,6 +971,9 @@ class DraftGenerator:
             ),
             prompt=prompt,
             generated_date=datetime.now(tz=UTC),
+            derivative_score=guard.derivative_score if guard else None,
+            grounding_score=guard.grounding_score if guard else None,
+            paragraph_grounding=_guard_annotations(guard),
         )
 
     def resolve_seed(
@@ -1145,6 +1247,11 @@ class DraftGenerator:
         if not body:
             msg = "LLM returned an empty draft body"
             raise RuntimeError(msg)
+        guard = self._build_guard_report(
+            body=body,
+            source_fragments=idea.source_fragments,
+            fragments=fragments,
+        )
         return Draft(
             title=idea.title,
             body=body,
@@ -1162,6 +1269,9 @@ class DraftGenerator:
             source_profile=twist_payload.source_profile,
             target_profile=twist_payload.target_profile,
             twist_dimensions=twist_payload.dimensions,
+            derivative_score=guard.derivative_score if guard else None,
+            grounding_score=guard.grounding_score if guard else None,
+            paragraph_grounding=_guard_annotations(guard),
         )
 
     def _build_twist_payload(
@@ -1237,6 +1347,12 @@ class DraftGenerator:
             post["target_profile"] = draft.target_profile.as_mapping()
         if draft.twist_dimensions:
             post["twist_dimensions"] = list(draft.twist_dimensions)
+        if draft.derivative_score is not None:
+            post[DERIVATIVE_FRONTMATTER_KEY] = round(draft.derivative_score, 4)
+        if draft.grounding_score is not None:
+            post[GROUNDING_FRONTMATTER_KEY] = round(draft.grounding_score, 4)
+        if draft.paragraph_grounding:
+            post[PARAGRAPH_ANNOTATIONS_KEY] = list(draft.paragraph_grounding)
         target.write_text(frontmatter.dumps(post), encoding="utf-8")
         return target
 
@@ -1314,6 +1430,20 @@ def _serialise_seed_spec(spec: SeedSpec) -> dict[str, object]:
     if spec.modes:
         payload["modes"] = [md.value for md in spec.modes]
     return payload
+
+
+def _guard_annotations(
+    report: GroundingReport | None,
+) -> tuple[dict[str, object], ...]:
+    """Return the per-paragraph annotation tuple for the :class:`Draft` field.
+
+    Returns an empty tuple when *report* is ``None`` (guard disabled)
+    so the dataclass default is preserved and existing tests that
+    construct :class:`Draft` without the guard fields keep working.
+    """
+    if report is None:
+        return ()
+    return tuple(score.to_annotation() for score in report.paragraph_scores)
 
 
 def _serialise_per_dimension_sources(

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -55,12 +55,11 @@ from creek.generate.dimensional_retrieval import (
     union_fragment_ids,
 )
 from creek.generate.grounding import (
-    DERIVATIVE_FRONTMATTER_KEY,
-    GROUNDING_FRONTMATTER_KEY,
-    PARAGRAPH_ANNOTATIONS_KEY,
     EmbeddingFn,
     GroundingReport,
     GroundingThresholds,
+    ParagraphAnnotation,
+    build_grounding_frontmatter,
     score_draft,
 )
 from creek.generate.twist import (
@@ -301,7 +300,7 @@ class Draft:
     twist_dimensions: tuple[str, ...] = ()
     derivative_score: float | None = None
     grounding_score: float | None = None
-    paragraph_grounding: tuple[dict[str, object], ...] = field(default_factory=tuple)
+    paragraph_grounding: tuple[ParagraphAnnotation, ...] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
         """Validate draft invariants."""
@@ -1347,12 +1346,13 @@ class DraftGenerator:
             post["target_profile"] = draft.target_profile.as_mapping()
         if draft.twist_dimensions:
             post["twist_dimensions"] = list(draft.twist_dimensions)
-        if draft.derivative_score is not None:
-            post[DERIVATIVE_FRONTMATTER_KEY] = round(draft.derivative_score, 4)
-        if draft.grounding_score is not None:
-            post[GROUNDING_FRONTMATTER_KEY] = round(draft.grounding_score, 4)
-        if draft.paragraph_grounding:
-            post[PARAGRAPH_ANNOTATIONS_KEY] = list(draft.paragraph_grounding)
+        guard_fields = build_grounding_frontmatter(
+            derivative_score=draft.derivative_score,
+            grounding_score=draft.grounding_score,
+            paragraph_annotations=draft.paragraph_grounding,
+        )
+        for key, value in guard_fields.items():
+            post[key] = value
         target.write_text(frontmatter.dumps(post), encoding="utf-8")
         return target
 
@@ -1434,7 +1434,7 @@ def _serialise_seed_spec(spec: SeedSpec) -> dict[str, object]:
 
 def _guard_annotations(
     report: GroundingReport | None,
-) -> tuple[dict[str, object], ...]:
+) -> tuple[ParagraphAnnotation, ...]:
     """Return the per-paragraph annotation tuple for the :class:`Draft` field.
 
     Returns an empty tuple when *report* is ``None`` (guard disabled)

--- a/creek-tools/creek/generate/grounding.py
+++ b/creek-tools/creek/generate/grounding.py
@@ -34,11 +34,28 @@ from __future__ import annotations
 
 import math
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypedDict, final
 
 if TYPE_CHECKING:
     from creek.config import DraftConfig
+
+
+class ParagraphAnnotation(TypedDict):
+    """Frontmatter shape for a single paragraph's grounding annotation.
+
+    The four fields mirror :class:`ParagraphScore` minus the raw text
+    (which lives in the draft body itself). Declaring this as a
+    ``TypedDict`` lets ``mypy --strict`` flag key typos and missing
+    fields at the call site instead of waiting for a YAML-decode
+    failure downstream — see PR #380 review feedback.
+    """
+
+    index: int
+    max_similarity: float
+    is_derivative: bool
+    is_grounded: bool
+
 
 EmbeddingFn = Callable[[str], list[float]]
 """Signature for paragraph-level embedding callables.
@@ -123,7 +140,7 @@ class ParagraphScore:
     is_derivative: bool
     is_grounded: bool
 
-    def to_annotation(self) -> dict[str, object]:
+    def to_annotation(self) -> ParagraphAnnotation:
         """Return the frontmatter-friendly mapping for this paragraph.
 
         ``text`` is intentionally omitted; an operator who needs the
@@ -131,17 +148,25 @@ class ParagraphScore:
         annotations slim avoids ballooning every draft file with two
         copies of the body.
         """
-        return {
-            "index": self.index,
-            "max_similarity": round(self.max_similarity, 4),
-            "is_derivative": self.is_derivative,
-            "is_grounded": self.is_grounded,
-        }
+        return ParagraphAnnotation(
+            index=self.index,
+            max_similarity=round(self.max_similarity, 4),
+            is_derivative=self.is_derivative,
+            is_grounded=self.is_grounded,
+        )
 
 
+@final
 @dataclass(frozen=True)
 class GroundingReport:
     """The guard's verdict for one draft.
+
+    The flag booleans are always derived from ``derivative_score`` and
+    ``grounding_score`` via :attr:`is_flagged_derivative` /
+    :attr:`is_flagged_ungrounded` so a YAML round-trip in the lint
+    check never produces a stale verdict. The ``@final`` decorator
+    prevents subclasses from introducing fields that would silently
+    bypass that derivation.
 
     Attributes:
         derivative_score: Maximum :attr:`ParagraphScore.max_similarity`
@@ -161,11 +186,6 @@ class GroundingReport:
     grounding_score: float
     paragraph_scores: tuple[ParagraphScore, ...]
     thresholds: GroundingThresholds
-    # Deliberately field-less: the cached flag booleans are derived from
-    # ``derivative_score`` and ``grounding_score`` so re-deserialising
-    # the report (e.g. after a YAML round-trip in the lint check) never
-    # produces a stale verdict. See :attr:`is_flagged_derivative`.
-    _: tuple[()] = field(default=(), repr=False)
 
     @property
     def is_flagged_derivative(self) -> bool:
@@ -217,17 +237,59 @@ class GroundingReport:
     def to_frontmatter(self) -> dict[str, object]:
         """Render the report as the frontmatter payload ``save_draft`` writes.
 
-        The two scalar scores are rounded to four decimals so YAML diffs
-        do not churn on the trailing-precision noise that
-        sentence-transformer outputs naturally produce.
+        Delegates to :func:`build_grounding_frontmatter` so the
+        ``Draft``-stored fields (which the lint check reads) and the
+        live :class:`GroundingReport` (which the generator emits)
+        serialise identically.
         """
-        return {
-            DERIVATIVE_FRONTMATTER_KEY: round(self.derivative_score, 4),
-            GROUNDING_FRONTMATTER_KEY: round(self.grounding_score, 4),
-            PARAGRAPH_ANNOTATIONS_KEY: [
+        return build_grounding_frontmatter(
+            derivative_score=self.derivative_score,
+            grounding_score=self.grounding_score,
+            paragraph_annotations=tuple(
                 score.to_annotation() for score in self.paragraph_scores
-            ],
-        }
+            ),
+        )
+
+
+def build_grounding_frontmatter(
+    *,
+    derivative_score: float | None,
+    grounding_score: float | None,
+    paragraph_annotations: Sequence[ParagraphAnnotation],
+) -> dict[str, object]:
+    """Build the partial frontmatter payload for grounding guard fields.
+
+    Single source of truth for how the three grounding fields appear in
+    on-disk draft frontmatter: callers either pass a live
+    :class:`GroundingReport` via :meth:`GroundingReport.to_frontmatter`
+    or pass the previously-stored :class:`~creek.generate.drafts.Draft`
+    fields via ``save_draft``. Either path produces the same shape so a
+    rename of a frontmatter key only happens here.
+
+    ``None`` scalars and empty annotation tuples are skipped so a
+    pre-guard draft (saved before the guard ran) never grows zero-value
+    fields that would mislead the lint check into running on them.
+
+    Args:
+        derivative_score: Scalar from a finished guard run, or ``None``
+            when the guard did not run.
+        grounding_score: Scalar from a finished guard run, or ``None``
+            when the guard did not run.
+        paragraph_annotations: Per-paragraph annotation entries. Pass
+            an empty sequence (or ``()``) when the guard did not run.
+
+    Returns:
+        A dict carrying only the keys whose values are populated. The
+        caller merges this into the rest of the frontmatter post.
+    """
+    payload: dict[str, object] = {}
+    if derivative_score is not None:
+        payload[DERIVATIVE_FRONTMATTER_KEY] = round(derivative_score, 4)
+    if grounding_score is not None:
+        payload[GROUNDING_FRONTMATTER_KEY] = round(grounding_score, 4)
+    if paragraph_annotations:
+        payload[PARAGRAPH_ANNOTATIONS_KEY] = list(paragraph_annotations)
+    return payload
 
 
 def split_paragraphs(body: str) -> list[str]:

--- a/creek-tools/creek/generate/grounding.py
+++ b/creek-tools/creek/generate/grounding.py
@@ -1,0 +1,403 @@
+"""Bidirectional grounding guard for ``creek draft`` (issue #355).
+
+A draft has two opposite failure modes that the guard surfaces after
+composition:
+
+* **Too derivative** — at least one draft paragraph echoes a single
+  source-fragment paragraph closely. Voice-true paraphrase that adds
+  nothing the user has not already said.
+* **Too ungrounded** — a majority of the draft's paragraphs have no
+  conceptual anchor in any of the user's source fragments. Voice-true
+  on the surface, conceptually invented underneath.
+
+Both metrics are produced from the same paragraph-level cosine
+similarity scan against the source corpus that fed the draft, so the
+guard is deterministic, embedding-only, and adds no extra LLM hops to
+the pipeline. The thresholds live in :class:`creek.config.DraftConfig`
+under the ``draft:`` YAML section so an operator can calibrate them
+against their own corpus without touching code.
+
+Surfaces:
+
+* The :class:`GroundingReport.summary_line` is printed to stderr by
+  ``creek draft`` so the operator sees the verdict immediately.
+* The draft's frontmatter records the two scalar scores plus a
+  per-paragraph annotations list under the keys exported below — these
+  are also what the ``draft-grounding`` lint check reads.
+
+The module deliberately exposes its embedding callable so tests (and
+future callers) can inject a deterministic stub instead of loading the
+full sentence-transformer at unit-test time.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from creek.config import DraftConfig
+
+EmbeddingFn = Callable[[str], list[float]]
+"""Signature for paragraph-level embedding callables.
+
+The default implementation wraps :class:`creek.link.embeddings.EmbeddingLinker`
+but tests inject a deterministic in-memory function so the guard's
+math is exercised offline."""
+
+
+DERIVATIVE_FRONTMATTER_KEY = "derivative_score"
+"""Frontmatter key for the maximum paragraph similarity score."""
+
+GROUNDING_FRONTMATTER_KEY = "grounding_score"
+"""Frontmatter key for the grounded-paragraph fraction."""
+
+PARAGRAPH_ANNOTATIONS_KEY = "paragraph_grounding"
+"""Frontmatter key for the per-paragraph annotation list.
+
+Each entry is a mapping ``{index, max_similarity, is_derivative,
+is_grounded}`` so a reader can see *which* paragraph tripped a flag
+without re-running the guard."""
+
+
+@dataclass(frozen=True)
+class GroundingThresholds:
+    """Resolved grounding-guard thresholds, decoupled from Pydantic.
+
+    The dataclass form keeps the score-computation code free of
+    Pydantic imports (the grounding module is on the hot path during
+    ``creek draft``) while still validating bounds at construction time.
+
+    Attributes:
+        derivative_upper: Cosine-similarity ceiling above which a draft
+            paragraph is flagged as a paraphrase.
+        grounding_lower: Cosine-similarity floor a draft paragraph must
+            clear against *some* source paragraph to count as grounded.
+            The same value gates the grounded-fraction summary: drafts
+            whose grounded fraction sits below this value are flagged.
+    """
+
+    derivative_upper: float
+    grounding_lower: float
+
+    def __post_init__(self) -> None:
+        """Reject thresholds outside ``[0.0, 1.0]`` at construction time."""
+        if not 0.0 <= self.derivative_upper <= 1.0:
+            msg = f"derivative_upper must be in [0.0, 1.0]; got {self.derivative_upper}"
+            raise ValueError(msg)
+        if not 0.0 <= self.grounding_lower <= 1.0:
+            msg = f"grounding_lower must be in [0.0, 1.0]; got {self.grounding_lower}"
+            raise ValueError(msg)
+
+    @classmethod
+    def from_config(cls, config: DraftConfig) -> GroundingThresholds:
+        """Build thresholds from a :class:`~creek.config.DraftConfig` instance."""
+        return cls(
+            derivative_upper=config.derivative_upper,
+            grounding_lower=config.grounding_lower,
+        )
+
+
+@dataclass(frozen=True)
+class ParagraphScore:
+    """Per-paragraph annotation surfaced in the frontmatter.
+
+    Attributes:
+        index: Zero-based position of the paragraph in the draft body.
+        text: The paragraph's raw text — kept for human-readable lint
+            findings and not echoed in the frontmatter payload to avoid
+            doubling the file size.
+        max_similarity: Highest cosine similarity recorded between this
+            paragraph and *any* source-fragment paragraph.
+        is_derivative: ``True`` when :attr:`max_similarity` met or
+            exceeded :attr:`GroundingThresholds.derivative_upper`.
+        is_grounded: ``True`` when :attr:`max_similarity` met or
+            exceeded :attr:`GroundingThresholds.grounding_lower`.
+    """
+
+    index: int
+    text: str
+    max_similarity: float
+    is_derivative: bool
+    is_grounded: bool
+
+    def to_annotation(self) -> dict[str, object]:
+        """Return the frontmatter-friendly mapping for this paragraph.
+
+        ``text`` is intentionally omitted; an operator who needs the
+        paragraph body can read the draft itself. Keeping the
+        annotations slim avoids ballooning every draft file with two
+        copies of the body.
+        """
+        return {
+            "index": self.index,
+            "max_similarity": round(self.max_similarity, 4),
+            "is_derivative": self.is_derivative,
+            "is_grounded": self.is_grounded,
+        }
+
+
+@dataclass(frozen=True)
+class GroundingReport:
+    """The guard's verdict for one draft.
+
+    Attributes:
+        derivative_score: Maximum :attr:`ParagraphScore.max_similarity`
+            across the draft. ``0.0`` when the draft has no paragraphs.
+        grounding_score: Fraction of paragraphs whose ``max_similarity``
+            cleared :attr:`GroundingThresholds.grounding_lower`. ``0.0``
+            when the draft has no paragraphs.
+        paragraph_scores: One :class:`ParagraphScore` per draft
+            paragraph, in document order.
+        thresholds: Echo of the thresholds the scores were computed
+            against. Kept on the report so the lint check and the
+            stderr summary can describe *why* a flag fired without
+            re-loading the config.
+    """
+
+    derivative_score: float
+    grounding_score: float
+    paragraph_scores: tuple[ParagraphScore, ...]
+    thresholds: GroundingThresholds
+    # Deliberately field-less: the cached flag booleans are derived from
+    # ``derivative_score`` and ``grounding_score`` so re-deserialising
+    # the report (e.g. after a YAML round-trip in the lint check) never
+    # produces a stale verdict. See :attr:`is_flagged_derivative`.
+    _: tuple[()] = field(default=(), repr=False)
+
+    @property
+    def is_flagged_derivative(self) -> bool:
+        """``True`` when at least one paragraph crossed the upper bound."""
+        return self.derivative_score >= self.thresholds.derivative_upper
+
+    @property
+    def is_flagged_grounding(self) -> bool:
+        """``True`` when the grounded fraction fell below the lower bound.
+
+        Empty drafts (no paragraph scores) cannot be evaluated and so
+        are never flagged — a paragraph-less body indicates an upstream
+        bug, not a grounding failure.
+        """
+        if not self.paragraph_scores:
+            return False
+        return self.grounding_score < self.thresholds.grounding_lower
+
+    @property
+    def is_flagged(self) -> bool:
+        """Either failure mode trips the overall flag."""
+        return self.is_flagged_derivative or self.is_flagged_grounding
+
+    def summary_line(self) -> str:
+        """Return the stderr one-liner ``creek draft`` prints after composing.
+
+        The string is human-tuned to be glanceable: scores up front, a
+        bracketed verdict at the end. Stable wording is part of the
+        contract because the walkthrough and the integration tests
+        match on it.
+        """
+        verdict_parts: list[str] = []
+        if self.is_flagged_derivative:
+            verdict_parts.append("too derivative")
+        if self.is_flagged_grounding:
+            verdict_parts.append("too ungrounded")
+        verdict = (
+            f"flagged: {' + '.join(verdict_parts)}"
+            if verdict_parts
+            else "within bounds"
+        )
+        return (
+            f"grounding guard: derivative={self.derivative_score:.2f} "
+            f"(upper {self.thresholds.derivative_upper:.2f}), "
+            f"grounding={self.grounding_score:.2f} "
+            f"(lower {self.thresholds.grounding_lower:.2f}) — {verdict}"
+        )
+
+    def to_frontmatter(self) -> dict[str, object]:
+        """Render the report as the frontmatter payload ``save_draft`` writes.
+
+        The two scalar scores are rounded to four decimals so YAML diffs
+        do not churn on the trailing-precision noise that
+        sentence-transformer outputs naturally produce.
+        """
+        return {
+            DERIVATIVE_FRONTMATTER_KEY: round(self.derivative_score, 4),
+            GROUNDING_FRONTMATTER_KEY: round(self.grounding_score, 4),
+            PARAGRAPH_ANNOTATIONS_KEY: [
+                score.to_annotation() for score in self.paragraph_scores
+            ],
+        }
+
+
+def split_paragraphs(body: str) -> list[str]:
+    """Split *body* into non-empty paragraphs on blank-line boundaries.
+
+    A paragraph is any run of non-blank lines separated from its
+    neighbours by one or more blank lines. Surrounding whitespace is
+    stripped but inner indentation is preserved so quoted or fenced
+    blocks survive.
+    """
+    paragraphs: list[str] = []
+    buffer: list[str] = []
+    for line in body.splitlines():
+        if line.strip():
+            buffer.append(line)
+            continue
+        if buffer:
+            paragraphs.append("\n".join(buffer).strip())
+            buffer = []
+    if buffer:
+        paragraphs.append("\n".join(buffer).strip())
+    return [p for p in paragraphs if p]
+
+
+def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
+    """Return cosine similarity in ``[-1.0, 1.0]`` for two equal-length vectors.
+
+    Zero-norm vectors collapse to ``0.0`` rather than raising — the
+    guard treats an embedding-less paragraph as "no resonance with
+    anything" without aborting the score for the whole draft.
+    """
+    if len(a) != len(b):
+        msg = f"Vector length mismatch: {len(a)} vs {len(b)}"
+        raise ValueError(msg)
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if 0.0 in (norm_a, norm_b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    return dot / (norm_a * norm_b)
+
+
+def _score_one_paragraph(
+    paragraph: str,
+    source_vectors: list[list[float]],
+    *,
+    embedding_fn: EmbeddingFn,
+    thresholds: GroundingThresholds,
+    index: int,
+) -> ParagraphScore:
+    """Compute one :class:`ParagraphScore` against the pre-embedded sources."""
+    if not source_vectors:
+        return ParagraphScore(
+            index=index,
+            text=paragraph,
+            max_similarity=0.0,
+            is_derivative=False,
+            is_grounded=False,
+        )
+    draft_vec = embedding_fn(paragraph)
+    best = max(cosine_similarity(draft_vec, src) for src in source_vectors)
+    return ParagraphScore(
+        index=index,
+        text=paragraph,
+        max_similarity=best,
+        is_derivative=best >= thresholds.derivative_upper,
+        is_grounded=best >= thresholds.grounding_lower,
+    )
+
+
+def score_draft(
+    draft_body: str,
+    *,
+    source_texts: Sequence[str],
+    embedding_fn: EmbeddingFn,
+    thresholds: GroundingThresholds,
+) -> GroundingReport:
+    """Compute a :class:`GroundingReport` for *draft_body*.
+
+    Each paragraph of the draft is embedded once and compared against
+    the embeddings of every paragraph extracted from *source_texts*.
+    The maximum per-paragraph similarity drives both metrics:
+
+    * The draft's ``derivative_score`` is the maximum across all
+      paragraphs — one near-paraphrase trips the upper bound.
+    * The draft's ``grounding_score`` is the fraction of paragraphs
+      whose max similarity met or exceeded
+      :attr:`GroundingThresholds.grounding_lower`.
+
+    Args:
+        draft_body: The composed draft text (frontmatter excluded).
+        source_texts: Raw source-fragment bodies that fed the draft
+            prompt. They are paragraph-split internally so the caller
+            can pass whole fragment bodies without preprocessing.
+        embedding_fn: Callable returning a vector for one text string.
+            Tests inject a deterministic stub; production wires this
+            to :func:`default_embedding_fn`.
+        thresholds: Resolved guard thresholds. Echoed on the returned
+            report.
+
+    Returns:
+        A populated :class:`GroundingReport`. When *draft_body* contains
+        no paragraphs the scores collapse to ``0.0`` and no flags fire
+        — there is nothing to evaluate.
+    """
+    draft_paragraphs = split_paragraphs(draft_body)
+    if not draft_paragraphs:
+        return GroundingReport(
+            derivative_score=0.0,
+            grounding_score=0.0,
+            paragraph_scores=(),
+            thresholds=thresholds,
+        )
+
+    source_paragraphs: list[str] = []
+    for text in source_texts:
+        source_paragraphs.extend(split_paragraphs(text))
+    source_vectors = [embedding_fn(p) for p in source_paragraphs]
+
+    scores = tuple(
+        _score_one_paragraph(
+            paragraph,
+            source_vectors,
+            embedding_fn=embedding_fn,
+            thresholds=thresholds,
+            index=index,
+        )
+        for index, paragraph in enumerate(draft_paragraphs)
+    )
+
+    derivative = max((s.max_similarity for s in scores), default=0.0)
+    grounded_count = sum(1 for s in scores if s.is_grounded)
+    grounding = grounded_count / len(scores)
+
+    return GroundingReport(
+        derivative_score=derivative,
+        grounding_score=grounding,
+        paragraph_scores=scores,
+        thresholds=thresholds,
+    )
+
+
+def default_embedding_fn(
+    config: object | None = None,
+) -> EmbeddingFn:
+    """Build the production embedding callable for the grounding guard.
+
+    Wraps :class:`creek.link.embeddings.EmbeddingLinker` lazily so the
+    sentence-transformer is loaded only when ``creek draft`` actually
+    runs the guard — unit tests inject their own callable and never
+    pay the import cost.
+
+    Args:
+        config: Optional :class:`~creek.config.EmbeddingsConfig`. When
+            ``None`` the default Pydantic settings are used (``all-MiniLM-L6-v2``
+            with the standard similarity threshold). Typed as ``object``
+            to keep ``creek.link.embeddings`` an at-call-site import and
+            avoid a top-level dependency cycle.
+
+    Returns:
+        A callable conforming to :data:`EmbeddingFn` that returns a
+        single embedding vector per string.
+    """
+    from creek.config import EmbeddingsConfig
+    from creek.link.embeddings import EmbeddingLinker
+
+    cfg = config if isinstance(config, EmbeddingsConfig) else EmbeddingsConfig()
+    linker = EmbeddingLinker(cfg)
+
+    def _embed(text: str) -> list[float]:
+        return linker.generate_embedding(text)
+
+    return _embed

--- a/creek-tools/creek/lint/checks/draft_grounding.py
+++ b/creek-tools/creek/lint/checks/draft_grounding.py
@@ -1,0 +1,112 @@
+"""Deterministic check: surface drafts that failed the grounding guard.
+
+The :mod:`creek.generate.grounding` guard runs synchronously during
+``creek draft`` and stamps each saved draft's frontmatter with
+``derivative_score`` / ``grounding_score`` / ``paragraph_grounding``.
+This lint check is the audit pass that asks the operator to revisit
+any draft whose stored scores fall outside the configured
+``draft.derivative_upper`` / ``draft.grounding_lower`` thresholds.
+
+Drafts written before issue #355 (and any markdown file that simply
+lacks the scores) are skipped silently — re-running ``creek draft``
+will backfill the metric. The check never deletes, rewrites, or
+auto-redrafts: it only surfaces, in keeping with the non-negotiable
+lint rules pinned by :mod:`creek.lint`.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003  # used at runtime as a parameter type
+from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
+
+import frontmatter
+import yaml
+
+from creek.config import DraftConfig, load_config
+from creek.lint._result import CheckResult
+
+_DRAFTS_RELPATH = ("07-Voice", "Drafts")
+"""Vault-relative location of generated drafts.
+
+Mirrors :data:`creek.generate.drafts.DRAFTS_SUBDIR` but kept as a
+tuple here so the check can compose it with ``Path.joinpath`` without
+importing the heavier drafts module."""
+
+
+def _resolve_draft_config(vault_path: Path) -> DraftConfig:
+    """Load ``creek_config.yaml`` from *vault_path* and return its ``draft`` section.
+
+    Missing / malformed configs collapse to :class:`DraftConfig`
+    defaults so the check always has thresholds to compare against —
+    silently emitting the wrong findings would be worse than the
+    lenient default.
+    """
+    config_path = vault_path / "00-Creek-Meta" / "creek_config.yaml"
+    try:
+        return load_config(config_path, warn_on_missing=False).draft
+    except (OSError, ValueError, yaml.YAMLError):
+        return DraftConfig()
+
+
+def _scan_draft(path: Path, draft_config: DraftConfig) -> str | None:
+    """Inspect one draft and return a single finding line, or ``None`` if clean.
+
+    Drafts that do not yet carry the guard's frontmatter (legacy drafts
+    written before #355) are treated as clean — the operator can
+    regenerate them when convenient.
+    """
+    try:
+        post = frontmatter.load(str(path))
+    except (OSError, ValueError, yaml.YAMLError):
+        return None
+    metadata = post.metadata
+    derivative = metadata.get("derivative_score")
+    grounding = metadata.get("grounding_score")
+    if not isinstance(derivative, (int, float)) or not isinstance(
+        grounding,
+        (int, float),
+    ):
+        return None
+    failures: list[str] = []
+    if derivative >= draft_config.derivative_upper:
+        failures.append(
+            f"derivative={derivative:.2f} ≥ {draft_config.derivative_upper:.2f}",
+        )
+    if grounding < draft_config.grounding_lower:
+        failures.append(
+            f"grounding={grounding:.2f} < {draft_config.grounding_lower:.2f}",
+        )
+    if not failures:
+        return None
+    return f"- `{path.stem}`: " + "; ".join(failures)
+
+
+def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
+    """Surface drafts whose grounding scores fall outside the configured bounds.
+
+    Each finding lists the draft's filename stem (a stable identifier
+    operators recognise from ``07-Voice/Drafts/``) and the failing
+    metric(s) with their threshold so a reader can decide whether to
+    re-draft, re-prompt with different sources, or accept the verdict.
+    """
+    del since  # The check reads frontmatter snapshots, not timestamps.
+    drafts_dir = vault_path.joinpath(*_DRAFTS_RELPATH)
+    if not drafts_dir.is_dir():
+        return CheckResult(
+            name="draft-grounding",
+            summary="0 draft(s) scanned (07-Voice/Drafts missing)",
+        )
+    draft_config = _resolve_draft_config(vault_path)
+    findings: list[str] = []
+    scanned = 0
+    for md_file in sorted(drafts_dir.rglob("*.md")):
+        scanned += 1
+        finding = _scan_draft(md_file, draft_config)
+        if finding is not None:
+            findings.append(finding)
+    summary = (
+        f"{scanned} draft(s) scanned; {len(findings)} outside "
+        f"derivative_upper={draft_config.derivative_upper:.2f} / "
+        f"grounding_lower={draft_config.grounding_lower:.2f}"
+    )
+    return CheckResult(name="draft-grounding", summary=summary, findings=findings)

--- a/creek-tools/creek/lint/runner.py
+++ b/creek-tools/creek/lint/runner.py
@@ -22,6 +22,9 @@ from creek.lint.checks import (
     compost as compost_check,
 )
 from creek.lint.checks import (
+    draft_grounding as draft_grounding_check,
+)
+from creek.lint.checks import (
     paradox as paradox_check,
 )
 from creek.lint.checks import (
@@ -62,6 +65,7 @@ DETERMINISTIC_CHECKS: tuple[str, ...] = (
     "skill-size",
     "tags",
     "compost",
+    "draft-grounding",
 )
 """Cheap checks that always run by default (link graph + frontmatter only)."""
 
@@ -80,6 +84,7 @@ _REGISTRY: dict[str, _CheckCallable] = {
     "skill-size": skill_size_budget.run,
     "tags": tags_check.run,
     "compost": compost_check.run,
+    "draft-grounding": draft_grounding_check.run,
     "paradox": paradox_check.run,
     "synchronicity": synchronicity_check.run,
     "unnamed": unnamed_check.run,

--- a/creek-tools/tests/test_draft_grounding.py
+++ b/creek-tools/tests/test_draft_grounding.py
@@ -41,6 +41,7 @@ from creek.generate.grounding import (
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from pathlib import Path
 
 
 # ---------------------------------------------------------------------------
@@ -459,7 +460,7 @@ class TestReportSerialisation:
 # ---------------------------------------------------------------------------
 
 
-def _build_guard_vault(tmp_path: object, body: str) -> object:
+def _build_guard_vault(tmp_path: Path, body: str) -> Path:
     """Materialise a minimal vault with one fragment whose body is *body*.
 
     Centralised because every guard-wiring test below needs the same
@@ -467,7 +468,6 @@ def _build_guard_vault(tmp_path: object, body: str) -> object:
     test wants the source paragraph to be).
     """
     from datetime import UTC, datetime
-    from pathlib import Path
 
     import frontmatter
 
@@ -483,7 +483,7 @@ def _build_guard_vault(tmp_path: object, body: str) -> object:
         WavelengthClassification,
     )
 
-    vault = Path(str(tmp_path))
+    vault = tmp_path
     (vault / "01-Fragments").mkdir(parents=True, exist_ok=True)
     (vault / "07-Voice" / "Drafts").mkdir(parents=True, exist_ok=True)
     frag = Fragment(
@@ -525,13 +525,13 @@ def _make_idea(title: str = "Echo essay") -> object:
 class TestDraftGeneratorGuardWiring:
     """The guard must populate the new :class:`Draft` fields end-to-end."""
 
-    def test_guard_runs_when_embedding_fn_is_wired(self, tmp_path: object) -> None:
+    def test_guard_runs_when_embedding_fn_is_wired(self, tmp_path: Path) -> None:
         """A wired embedding callable populates the new ``Draft`` fields."""
         from creek.generate.drafts import DraftGenerator
 
         source_paragraph = "The source paragraph."
         vault = _build_guard_vault(tmp_path, source_paragraph)
-        skills_root = vault / "skills"  # type: ignore[operator]
+        skills_root = vault / "skills"
         skills_root.mkdir()
         table = {source_paragraph: _hashed_vector(source_paragraph)}
         gen = DraftGenerator(
@@ -546,12 +546,12 @@ class TestDraftGeneratorGuardWiring:
         assert len(draft.paragraph_grounding) == 1
         assert draft.paragraph_grounding[0]["is_derivative"] is True
 
-    def test_guard_skipped_when_no_embedding_fn(self, tmp_path: object) -> None:
+    def test_guard_skipped_when_no_embedding_fn(self, tmp_path: Path) -> None:
         """No embedding callable → the guard fields stay ``None``/empty."""
         from creek.generate.drafts import DraftGenerator
 
         vault = _build_guard_vault(tmp_path, "Source body.")
-        skills_root = vault / "skills"  # type: ignore[operator]
+        skills_root = vault / "skills"
         skills_root.mkdir()
         gen = DraftGenerator(
             llm=lambda _p: "An invented draft body.",
@@ -562,7 +562,7 @@ class TestDraftGeneratorGuardWiring:
         assert draft.grounding_score is None
         assert draft.paragraph_grounding == ()
 
-    def test_save_draft_writes_guard_frontmatter(self, tmp_path: object) -> None:
+    def test_save_draft_writes_guard_frontmatter(self, tmp_path: Path) -> None:
         """``save_draft`` mirrors the scores into the saved markdown frontmatter."""
         import frontmatter
 
@@ -570,7 +570,7 @@ class TestDraftGeneratorGuardWiring:
 
         source_paragraph = "Saved source paragraph."
         vault = _build_guard_vault(tmp_path, source_paragraph)
-        skills_root = vault / "skills"  # type: ignore[operator]
+        skills_root = vault / "skills"
         skills_root.mkdir()
         table = {source_paragraph: _hashed_vector(source_paragraph)}
         gen = DraftGenerator(
@@ -590,7 +590,7 @@ class TestDraftGeneratorGuardWiring:
 
     def test_save_draft_omits_guard_fields_when_unscored(
         self,
-        tmp_path: object,
+        tmp_path: Path,
     ) -> None:
         """Unscored drafts do not leak ``derivative_score`` keys into frontmatter."""
         import frontmatter
@@ -598,7 +598,7 @@ class TestDraftGeneratorGuardWiring:
         from creek.generate.drafts import DraftGenerator
 
         vault = _build_guard_vault(tmp_path, "Source.")
-        skills_root = vault / "skills"  # type: ignore[operator]
+        skills_root = vault / "skills"
         skills_root.mkdir()
         gen = DraftGenerator(
             llm=lambda _p: "An unscored draft body.",
@@ -613,14 +613,14 @@ class TestDraftGeneratorGuardWiring:
 
     def test_guard_prints_summary_to_stderr(
         self,
-        tmp_path: object,
+        tmp_path: Path,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
         """The guard prints a one-line summary to stderr for the operator."""
         from creek.generate.drafts import DraftGenerator
 
         vault = _build_guard_vault(tmp_path, "Source body.")
-        skills_root = vault / "skills"  # type: ignore[operator]
+        skills_root = vault / "skills"
         skills_root.mkdir()
         gen = DraftGenerator(
             llm=lambda _p: "An invented but distinct draft body.",

--- a/creek-tools/tests/test_draft_grounding.py
+++ b/creek-tools/tests/test_draft_grounding.py
@@ -1,0 +1,646 @@
+"""Tests for the bidirectional grounding guard (issue #355).
+
+The guard surfaces two failure modes after a draft is generated:
+
+* **Too derivative** — at least one draft paragraph is a near-paraphrase
+  of a single source-fragment paragraph (cosine similarity above the
+  ``derivative_upper`` threshold).
+* **Too ungrounded** — fewer than ``grounding_lower`` fraction of draft
+  paragraphs have *any* source-fragment paragraph above the
+  ``grounding_lower`` similarity floor.
+
+Both signals come from the same paragraph-level cosine-similarity scan;
+the tests pin the math, threshold plumbing, frontmatter shape, and
+lint-check surface against synthetic fixtures so the behaviour stays
+deterministic regardless of which sentence-transformer model is
+configured. A deterministic injected embedding callable keeps every
+test offline and reproducible.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.config import DraftConfig
+from creek.generate.grounding import (
+    DERIVATIVE_FRONTMATTER_KEY,
+    GROUNDING_FRONTMATTER_KEY,
+    PARAGRAPH_ANNOTATIONS_KEY,
+    EmbeddingFn,
+    GroundingReport,
+    GroundingThresholds,
+    ParagraphScore,
+    cosine_similarity,
+    score_draft,
+    split_paragraphs,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+# ---------------------------------------------------------------------------
+# Deterministic embedding helpers
+# ---------------------------------------------------------------------------
+
+
+_VECTOR_DIM = 32
+"""Dimensionality of the synthetic embeddings used in this file.
+
+Small enough to keep the test deterministic without numpy precision
+quirks; large enough that hashing-based vectors for distinct strings
+are reliably near-orthogonal."""
+
+
+def _hashed_vector(text: str) -> list[float]:
+    """Return a deterministic, normalised vector keyed off *text*'s hash.
+
+    Two identical strings always map to the same vector; two distinct
+    strings map to near-orthogonal vectors, so cosine similarity
+    cleanly separates "same paragraph" from "different paragraph"
+    without depending on a real embedding model.
+    """
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    # Stretch the 32-byte digest across the vector by hashing again
+    # with a counter; this keeps the math entirely in-stdlib while
+    # giving enough independent entropy to avoid accidental overlap.
+    raw: list[int] = []
+    counter = 0
+    while len(raw) < _VECTOR_DIM:
+        chunk = hashlib.sha256(digest + counter.to_bytes(2, "big")).digest()
+        raw.extend(chunk[: _VECTOR_DIM - len(raw)])
+        counter += 1
+    centred = [b - 127.5 for b in raw[:_VECTOR_DIM]]
+    norm = math.sqrt(sum(x * x for x in centred)) or 1.0
+    return [x / norm for x in centred]
+
+
+def _blended_vector(parts: Sequence[str], weights: Sequence[float]) -> list[float]:
+    """Return a normalised convex combination of hashed vectors for *parts*.
+
+    Used by tests that need to simulate "draft paragraph echoes source
+    paragraph at strength W" without hand-tuning floating-point
+    coordinates. The blend is convex (weights sum to 1) so the result
+    sits on the unit sphere after normalisation.
+    """
+    vectors = [_hashed_vector(part) for part in parts]
+    blended = [0.0] * _VECTOR_DIM
+    for vec, weight in zip(vectors, weights, strict=True):
+        for i, value in enumerate(vec):
+            blended[i] += weight * value
+    norm = math.sqrt(sum(x * x for x in blended)) or 1.0
+    return [x / norm for x in blended]
+
+
+def _fixture_embedder(table: dict[str, list[float]]) -> EmbeddingFn:
+    """Build an :class:`EmbeddingFn` backed by a deterministic lookup *table*.
+
+    Strings absent from *table* fall through to :func:`_hashed_vector`,
+    which keeps every test free to add an explicit blend for the
+    paragraphs whose similarity it cares about and leave the rest as
+    "noise" without enumerating every distractor.
+    """
+
+    def _embed(text: str) -> list[float]:
+        return table.get(text) or _hashed_vector(text)
+
+    return _embed
+
+
+# ---------------------------------------------------------------------------
+# Paragraph splitting + cosine helper
+# ---------------------------------------------------------------------------
+
+
+class TestSplitParagraphs:
+    """``split_paragraphs`` underpins both scores; pin its shape."""
+
+    def test_splits_on_blank_lines(self) -> None:
+        """A blank-line-separated body produces one entry per paragraph."""
+        body = (
+            "Para one.\n\nPara two with two sentences. Still para two.\n\nPara three."
+        )
+        assert split_paragraphs(body) == [
+            "Para one.",
+            "Para two with two sentences. Still para two.",
+            "Para three.",
+        ]
+
+    def test_skips_empty_segments(self) -> None:
+        """Triple-blank or trailing newlines must not yield empty paragraphs."""
+        body = "\n\nAlpha.\n\n\n\nBeta.\n\n\n"
+        assert split_paragraphs(body) == ["Alpha.", "Beta."]
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        """Indented paragraphs lose only the outer whitespace, not inner runs."""
+        body = "  Alpha\n  trailing.\n\n   Beta   "
+        assert split_paragraphs(body) == ["Alpha\n  trailing.", "Beta"]
+
+    def test_returns_empty_for_blank_body(self) -> None:
+        """A body of only whitespace produces no paragraphs at all."""
+        assert split_paragraphs("   \n\n\t\n") == []
+
+
+class TestCosineSimilarity:
+    """The guard's math is paragraph-level cosine; pin the helper."""
+
+    def test_identical_vectors_score_one(self) -> None:
+        """Cosine of a vector with itself is exactly 1.0."""
+        vec = _hashed_vector("alpha")
+        assert cosine_similarity(vec, vec) == pytest.approx(1.0, abs=1e-6)
+
+    def test_orthogonal_vectors_score_zero(self) -> None:
+        """Two unit vectors on perpendicular axes have cosine 0.0."""
+        zeros = [0.0] * _VECTOR_DIM
+        a = zeros.copy()
+        b = zeros.copy()
+        a[0] = 1.0
+        b[1] = 1.0
+        assert cosine_similarity(a, b) == pytest.approx(0.0, abs=1e-6)
+
+    def test_zero_vector_returns_zero(self) -> None:
+        """A zero-norm vector cannot resonate; cosine collapses to 0.0."""
+        zeros = [0.0] * _VECTOR_DIM
+        other = _hashed_vector("anything")
+        assert cosine_similarity(zeros, other) == 0.0
+        assert cosine_similarity(other, zeros) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# DraftConfig wiring
+# ---------------------------------------------------------------------------
+
+
+class TestDraftConfig:
+    """Thresholds must be configurable through the ``draft:`` YAML section."""
+
+    def test_defaults_match_issue(self) -> None:
+        """The defaults pinned in issue #355 are 0.85 and 0.30."""
+        cfg = DraftConfig()
+        assert cfg.derivative_upper == pytest.approx(0.85)
+        assert cfg.grounding_lower == pytest.approx(0.30)
+
+    def test_thresholds_are_clamped_to_unit_interval(self) -> None:
+        """Cosine-similarity thresholds must stay in [0.0, 1.0]."""
+        with pytest.raises(ValueError, match="derivative_upper"):
+            DraftConfig(derivative_upper=1.5)
+        with pytest.raises(ValueError, match="grounding_lower"):
+            DraftConfig(grounding_lower=-0.1)
+
+    def test_thresholds_can_be_overridden(self) -> None:
+        """Operators must be able to tighten or loosen both knobs."""
+        cfg = DraftConfig(derivative_upper=0.9, grounding_lower=0.5)
+        assert cfg.derivative_upper == pytest.approx(0.9)
+        assert cfg.grounding_lower == pytest.approx(0.5)
+
+    def test_creekconfig_exposes_draft_section(self) -> None:
+        """The top-level ``draft:`` section must hang off ``CreekConfig``."""
+        from creek.config import CreekConfig
+
+        cfg = CreekConfig()
+        assert isinstance(cfg.draft, DraftConfig)
+        assert cfg.draft.derivative_upper == pytest.approx(0.85)
+
+    def test_thresholds_from_config(self) -> None:
+        """``GroundingThresholds.from_config`` mirrors the :class:`DraftConfig`."""
+        thresholds = GroundingThresholds.from_config(
+            DraftConfig(derivative_upper=0.72, grounding_lower=0.45),
+        )
+        assert thresholds.derivative_upper == pytest.approx(0.72)
+        assert thresholds.grounding_lower == pytest.approx(0.45)
+
+
+# ---------------------------------------------------------------------------
+# score_draft
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_THRESHOLDS = GroundingThresholds(derivative_upper=0.85, grounding_lower=0.30)
+
+
+class TestScoreDraftDerivative:
+    """A draft that paraphrases a single source must score above the upper bound."""
+
+    def test_paraphrase_heavy_draft_is_flagged(self) -> None:
+        """A draft where every paragraph echoes one source scores ~1.0 derivative."""
+        source_para = "The compost folder catches abandoned drafts."
+        another_source = "Threads bind fragments into narrative currents."
+        # Each draft paragraph is the exact text of a source paragraph;
+        # the embedder maps them to the same vector, so cosine = 1.0.
+        draft_body = f"{source_para}\n\n{source_para}\n\n{another_source}"
+        table = {
+            source_para: _hashed_vector(source_para),
+            another_source: _hashed_vector(another_source),
+        }
+        report = score_draft(
+            draft_body,
+            source_texts=[source_para, another_source],
+            embedding_fn=_fixture_embedder(table),
+            thresholds=_DEFAULT_THRESHOLDS,
+        )
+        assert report.derivative_score == pytest.approx(1.0, abs=1e-6)
+        assert report.is_flagged_derivative is True
+        # All paragraphs are perfect echoes — grounding is also at 1.0.
+        assert report.grounding_score == pytest.approx(1.0, abs=1e-6)
+        assert report.is_flagged_grounding is False
+        assert report.is_flagged is True
+
+    def test_partial_paraphrase_picked_up_by_max(self) -> None:
+        """Even one near-paraphrase paragraph trips the derivative flag."""
+        echoed_source = "Resonances connect fragments by meaning."
+        novel_para = "An entirely new musing about composting."
+        unrelated_source = "Eddies cluster topics that recur."
+        # Two of three draft paragraphs are unrelated; one mirrors a
+        # source exactly. The derivative score is the *max*, so the
+        # flag fires even though most paragraphs are fine.
+        draft_body = f"{novel_para}\n\n{echoed_source}\n\nanother novel line"
+        table = {
+            echoed_source: _hashed_vector(echoed_source),
+            unrelated_source: _hashed_vector(unrelated_source),
+            novel_para: _hashed_vector(novel_para),
+            "another novel line": _hashed_vector("another novel line"),
+        }
+        report = score_draft(
+            draft_body,
+            source_texts=[echoed_source, unrelated_source],
+            embedding_fn=_fixture_embedder(table),
+            thresholds=_DEFAULT_THRESHOLDS,
+        )
+        assert report.derivative_score == pytest.approx(1.0, abs=1e-6)
+        assert report.is_flagged_derivative is True
+
+
+class TestScoreDraftGrounding:
+    """A draft built from voice signatures with no real source must trip grounding."""
+
+    def test_invented_draft_is_flagged_ungrounded(self) -> None:
+        """Three invented paragraphs, no source overlap → grounding = 0.0."""
+        # Sources exist, but the draft paragraphs do not echo them at all.
+        sources = ["source one body", "source two body"]
+        draft_body = (
+            "An invented opening untouched by any source.\n\n"
+            "A second invented paragraph still untouched.\n\n"
+            "And a third invented closing."
+        )
+        report = score_draft(
+            draft_body,
+            source_texts=sources,
+            embedding_fn=_fixture_embedder({}),
+            thresholds=_DEFAULT_THRESHOLDS,
+        )
+        # Synthetic hashes are near-orthogonal, so grounded fraction = 0.
+        assert report.grounding_score == pytest.approx(0.0, abs=1e-6)
+        assert report.is_flagged_grounding is True
+        assert report.is_flagged is True
+        # Derivative score is the max similarity — well below the upper bound.
+        assert report.derivative_score < _DEFAULT_THRESHOLDS.derivative_upper
+
+    def test_grounded_fraction_uses_lower_threshold(self) -> None:
+        """A paragraph counts as grounded once it crosses ``grounding_lower``."""
+        anchored_source = "Anchored source paragraph"
+        draft_paragraph_close = "Mostly the anchored source paragraph"
+        draft_paragraph_far = "Totally unrelated other content"
+        # Blend the close paragraph 80% toward the source so its cosine
+        # similarity comfortably clears the 0.30 lower bound without
+        # touching the 0.85 upper bound.
+        table = {
+            anchored_source: _hashed_vector(anchored_source),
+            draft_paragraph_close: _blended_vector(
+                [anchored_source, draft_paragraph_close],
+                [0.8, 0.2],
+            ),
+            draft_paragraph_far: _hashed_vector(draft_paragraph_far),
+        }
+        draft_body = f"{draft_paragraph_close}\n\n{draft_paragraph_far}"
+        report = score_draft(
+            draft_body,
+            source_texts=[anchored_source],
+            embedding_fn=_fixture_embedder(table),
+            thresholds=_DEFAULT_THRESHOLDS,
+        )
+        # One of two paragraphs is grounded → fraction = 0.5.
+        assert report.grounding_score == pytest.approx(0.5, abs=1e-6)
+        # 0.5 is above the 0.30 lower → no grounding flag.
+        assert report.is_flagged_grounding is False
+
+
+class TestScoreDraftBalanced:
+    """The happy path — every paragraph grounded, none paraphrased — must pass."""
+
+    def test_balanced_draft_passes_both_thresholds(self) -> None:
+        """Recombination above ``grounding_lower`` and below ``derivative_upper``."""
+        sources = [
+            "Source one about composting drafts",
+            "Source two about thread emergence",
+        ]
+        # Every draft paragraph is a 0.5/0.5 mix of one source and a
+        # novel string — both grounded and novel.
+        balanced_a = "Balanced paragraph alpha"
+        balanced_b = "Balanced paragraph beta"
+        table = {
+            sources[0]: _hashed_vector(sources[0]),
+            sources[1]: _hashed_vector(sources[1]),
+            balanced_a: _blended_vector([sources[0], balanced_a], [0.5, 0.5]),
+            balanced_b: _blended_vector([sources[1], balanced_b], [0.5, 0.5]),
+        }
+        draft_body = f"{balanced_a}\n\n{balanced_b}"
+        report = score_draft(
+            draft_body,
+            source_texts=sources,
+            embedding_fn=_fixture_embedder(table),
+            thresholds=_DEFAULT_THRESHOLDS,
+        )
+        assert report.grounding_score == pytest.approx(1.0, abs=1e-6)
+        # 0.5-blend cosine sits around 0.5 — between the two thresholds.
+        assert _DEFAULT_THRESHOLDS.grounding_lower < report.derivative_score
+        assert report.derivative_score < _DEFAULT_THRESHOLDS.derivative_upper
+        assert report.is_flagged is False
+
+
+class TestScoreDraftEdgeCases:
+    """Empty bodies and missing sources must degrade safely."""
+
+    def test_no_paragraphs_returns_zero_scores(self) -> None:
+        """An empty body produces a report with both scores at 0.0 and no flags."""
+        report = score_draft(
+            "",
+            source_texts=["any"],
+            embedding_fn=_fixture_embedder({}),
+            thresholds=_DEFAULT_THRESHOLDS,
+        )
+        assert report.derivative_score == 0.0
+        assert report.grounding_score == 0.0
+        assert report.paragraph_scores == ()
+        assert report.is_flagged is False
+
+    def test_no_sources_flags_grounding_only(self) -> None:
+        """Zero source paragraphs → grounding_score = 0 and the grounding flag fires."""
+        report = score_draft(
+            "A lone paragraph.",
+            source_texts=[],
+            embedding_fn=_fixture_embedder({}),
+            thresholds=_DEFAULT_THRESHOLDS,
+        )
+        assert report.derivative_score == 0.0
+        assert report.grounding_score == 0.0
+        assert report.is_flagged_grounding is True
+        assert report.is_flagged_derivative is False
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter shape + summary line
+# ---------------------------------------------------------------------------
+
+
+class TestReportSerialisation:
+    """Exact shape of the frontmatter additions the issue calls out."""
+
+    def test_to_frontmatter_has_expected_keys(self) -> None:
+        """The mapping contains every documented frontmatter key."""
+        report = GroundingReport(
+            derivative_score=0.42,
+            grounding_score=0.75,
+            paragraph_scores=(
+                ParagraphScore(
+                    index=0,
+                    text="alpha",
+                    max_similarity=0.42,
+                    is_derivative=False,
+                    is_grounded=True,
+                ),
+            ),
+            thresholds=_DEFAULT_THRESHOLDS,
+        )
+        payload = report.to_frontmatter()
+        assert payload[DERIVATIVE_FRONTMATTER_KEY] == pytest.approx(0.42)
+        assert payload[GROUNDING_FRONTMATTER_KEY] == pytest.approx(0.75)
+        annotations = payload[PARAGRAPH_ANNOTATIONS_KEY]
+        assert isinstance(annotations, list)
+        assert annotations[0]["index"] == 0
+        assert annotations[0]["max_similarity"] == pytest.approx(0.42)
+        assert annotations[0]["is_derivative"] is False
+        assert annotations[0]["is_grounded"] is True
+
+    def test_summary_line_includes_both_scores(self) -> None:
+        """The stderr one-liner must echo both scores and the flag verdict."""
+        report = GroundingReport(
+            derivative_score=0.91,
+            grounding_score=0.12,
+            paragraph_scores=(),
+            thresholds=_DEFAULT_THRESHOLDS,
+        )
+        line = report.summary_line()
+        assert "derivative" in line.lower()
+        assert "grounding" in line.lower()
+        assert "0.91" in line
+        assert "0.12" in line
+        # The summary must mention that the draft was flagged.
+        assert "flag" in line.lower()
+
+    def test_summary_line_passes_when_balanced(self) -> None:
+        """A balanced draft's summary must not claim a flag fired."""
+        report = GroundingReport(
+            derivative_score=0.4,
+            grounding_score=0.8,
+            paragraph_scores=(),
+            thresholds=_DEFAULT_THRESHOLDS,
+        )
+        line = report.summary_line()
+        # When no flag fires the line should mention "within bounds".
+        assert "within" in line.lower() or "ok" in line.lower()
+
+
+# ---------------------------------------------------------------------------
+# DraftGenerator integration — the guard wired into the draft pipeline
+# ---------------------------------------------------------------------------
+
+
+def _build_guard_vault(tmp_path: object, body: str) -> object:
+    """Materialise a minimal vault with one fragment whose body is *body*.
+
+    Centralised because every guard-wiring test below needs the same
+    layout (vault root → ``01-Fragments/frag-001.md`` with the body the
+    test wants the source paragraph to be).
+    """
+    from datetime import UTC, datetime
+    from pathlib import Path
+
+    import frontmatter
+
+    from creek.models import (
+        Confidence,
+        Fragment,
+        FragmentSource,
+        Frequency,
+        FrequencyClassification,
+        PraxisPotential,
+        SourcePlatform,
+        VoiceClassification,
+        WavelengthClassification,
+    )
+
+    vault = Path(str(tmp_path))
+    (vault / "01-Fragments").mkdir(parents=True, exist_ok=True)
+    (vault / "07-Voice" / "Drafts").mkdir(parents=True, exist_ok=True)
+    frag = Fragment(
+        id="frag-001",
+        title="Source title",
+        source=FragmentSource(
+            platform=SourcePlatform.CLAUDE,
+            original_file="scratch.md",
+        ),
+        created=datetime(2026, 3, 1, tzinfo=UTC),
+        ingested=datetime(2026, 3, 1, tzinfo=UTC),
+        frequency=FrequencyClassification(primary=Frequency.F1),
+        wavelength=WavelengthClassification(),
+        voice=VoiceClassification(confidence=Confidence.SETTLED),
+        praxis_potential=PraxisPotential.LATENT,
+    )
+    target = vault / "01-Fragments" / "frag-001.md"
+    post = frontmatter.Post(content=body, **frag.model_dump(mode="json"))
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return vault
+
+
+def _make_idea(title: str = "Echo essay") -> object:
+    """Return a synthetic :class:`IdeaSeed` for the wiring tests."""
+    from creek.generate.mining import IdeaSeed, MiningStrategy
+
+    return IdeaSeed(
+        strategy=MiningStrategy.RESONANCE_CHAIN,
+        title=title,
+        source_fragments=("frag-001",),
+        threads=(),
+        eddies=(),
+        frequency_affinity=(),
+        brief_description="Draft for the grounding guard wiring tests.",
+        score=0.0,
+    )
+
+
+class TestDraftGeneratorGuardWiring:
+    """The guard must populate the new :class:`Draft` fields end-to-end."""
+
+    def test_guard_runs_when_embedding_fn_is_wired(self, tmp_path: object) -> None:
+        """A wired embedding callable populates the new ``Draft`` fields."""
+        from creek.generate.drafts import DraftGenerator
+
+        source_paragraph = "The source paragraph."
+        vault = _build_guard_vault(tmp_path, source_paragraph)
+        skills_root = vault / "skills"  # type: ignore[operator]
+        skills_root.mkdir()
+        table = {source_paragraph: _hashed_vector(source_paragraph)}
+        gen = DraftGenerator(
+            llm=lambda _p: source_paragraph,
+            skills_root=skills_root,
+            embedding_fn=_fixture_embedder(table),
+            grounding_thresholds=_DEFAULT_THRESHOLDS,
+        )
+        draft = gen.generate_draft(_make_idea(), vault_path=vault)
+        assert draft.derivative_score == pytest.approx(1.0, abs=1e-6)
+        assert draft.grounding_score == pytest.approx(1.0, abs=1e-6)
+        assert len(draft.paragraph_grounding) == 1
+        assert draft.paragraph_grounding[0]["is_derivative"] is True
+
+    def test_guard_skipped_when_no_embedding_fn(self, tmp_path: object) -> None:
+        """No embedding callable → the guard fields stay ``None``/empty."""
+        from creek.generate.drafts import DraftGenerator
+
+        vault = _build_guard_vault(tmp_path, "Source body.")
+        skills_root = vault / "skills"  # type: ignore[operator]
+        skills_root.mkdir()
+        gen = DraftGenerator(
+            llm=lambda _p: "An invented draft body.",
+            skills_root=skills_root,
+        )
+        draft = gen.generate_draft(_make_idea(), vault_path=vault)
+        assert draft.derivative_score is None
+        assert draft.grounding_score is None
+        assert draft.paragraph_grounding == ()
+
+    def test_save_draft_writes_guard_frontmatter(self, tmp_path: object) -> None:
+        """``save_draft`` mirrors the scores into the saved markdown frontmatter."""
+        import frontmatter
+
+        from creek.generate.drafts import DraftGenerator
+
+        source_paragraph = "Saved source paragraph."
+        vault = _build_guard_vault(tmp_path, source_paragraph)
+        skills_root = vault / "skills"  # type: ignore[operator]
+        skills_root.mkdir()
+        table = {source_paragraph: _hashed_vector(source_paragraph)}
+        gen = DraftGenerator(
+            llm=lambda _p: source_paragraph,
+            skills_root=skills_root,
+            embedding_fn=_fixture_embedder(table),
+            grounding_thresholds=_DEFAULT_THRESHOLDS,
+        )
+        draft = gen.generate_draft(_make_idea(title="Saved echo"), vault_path=vault)
+        saved_path = gen.save_draft(draft, vault)
+        post = frontmatter.load(str(saved_path))
+        assert post.metadata["derivative_score"] == pytest.approx(1.0, abs=1e-3)
+        assert post.metadata["grounding_score"] == pytest.approx(1.0, abs=1e-3)
+        annotations = post.metadata["paragraph_grounding"]
+        assert isinstance(annotations, list)
+        assert annotations[0]["is_derivative"] is True
+
+    def test_save_draft_omits_guard_fields_when_unscored(
+        self,
+        tmp_path: object,
+    ) -> None:
+        """Unscored drafts do not leak ``derivative_score`` keys into frontmatter."""
+        import frontmatter
+
+        from creek.generate.drafts import DraftGenerator
+
+        vault = _build_guard_vault(tmp_path, "Source.")
+        skills_root = vault / "skills"  # type: ignore[operator]
+        skills_root.mkdir()
+        gen = DraftGenerator(
+            llm=lambda _p: "An unscored draft body.",
+            skills_root=skills_root,
+        )
+        draft = gen.generate_draft(_make_idea(), vault_path=vault)
+        saved_path = gen.save_draft(draft, vault)
+        post = frontmatter.load(str(saved_path))
+        assert "derivative_score" not in post.metadata
+        assert "grounding_score" not in post.metadata
+        assert "paragraph_grounding" not in post.metadata
+
+    def test_guard_prints_summary_to_stderr(
+        self,
+        tmp_path: object,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """The guard prints a one-line summary to stderr for the operator."""
+        from creek.generate.drafts import DraftGenerator
+
+        vault = _build_guard_vault(tmp_path, "Source body.")
+        skills_root = vault / "skills"  # type: ignore[operator]
+        skills_root.mkdir()
+        gen = DraftGenerator(
+            llm=lambda _p: "An invented but distinct draft body.",
+            skills_root=skills_root,
+            embedding_fn=_fixture_embedder({}),
+            grounding_thresholds=_DEFAULT_THRESHOLDS,
+        )
+        gen.generate_draft(_make_idea(), vault_path=vault)
+        captured = capsys.readouterr()
+        assert "grounding guard:" in captured.err
+        assert "derivative=" in captured.err
+        assert "grounding=" in captured.err
+
+
+class TestDefaultEmbeddingFn:
+    """``default_embedding_fn`` builds the production callable lazily."""
+
+    def test_returns_a_callable(self) -> None:
+        """The factory returns a callable without loading the transformer."""
+        from creek.generate.grounding import default_embedding_fn
+
+        fn = default_embedding_fn()
+        assert callable(fn)

--- a/creek-tools/tests/test_lint_draft_grounding.py
+++ b/creek-tools/tests/test_lint_draft_grounding.py
@@ -1,0 +1,174 @@
+"""Tests for the ``draft-grounding`` lint check (issue #355).
+
+The check scans ``07-Voice/Drafts/`` for drafts whose recorded
+``derivative_score`` / ``grounding_score`` frontmatter values fall
+outside the configured ``draft.derivative_upper`` / ``draft.grounding_lower``
+bounds and emits one finding per failing draft. Drafts that pre-date
+the guard (no scores in frontmatter) are skipped silently — the
+operator can re-run ``creek draft`` to backfill the metric.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+import yaml
+
+from creek.lint import ALL_CHECKS, DETERMINISTIC_CHECKS, LintRunner
+from creek.lint.checks import draft_grounding as draft_grounding_check
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _seed_meta_dir(vault: Path) -> None:
+    """Create the canonical meta + drafts folders the check needs."""
+    (vault / "00-Creek-Meta").mkdir(parents=True, exist_ok=True)
+    (vault / "07-Voice" / "Drafts").mkdir(parents=True, exist_ok=True)
+
+
+def _write_draft(
+    vault: Path,
+    *,
+    name: str,
+    derivative_score: float | None,
+    grounding_score: float | None,
+    title: str = "A draft",
+) -> None:
+    """Write a draft markdown file with the guard's frontmatter shape."""
+    meta: dict[str, object] = {
+        "type": "draft",
+        "title": title,
+        "status": "draft",
+    }
+    if derivative_score is not None:
+        meta["derivative_score"] = derivative_score
+    if grounding_score is not None:
+        meta["grounding_score"] = grounding_score
+    target = vault / "07-Voice" / "Drafts" / f"{name}.md"
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content="body", **meta)),
+        encoding="utf-8",
+    )
+
+
+def _write_config(
+    vault: Path,
+    *,
+    derivative_upper: float,
+    grounding_lower: float,
+) -> None:
+    """Drop a ``creek_config.yaml`` with explicit draft thresholds."""
+    payload = {
+        "draft": {
+            "derivative_upper": derivative_upper,
+            "grounding_lower": grounding_lower,
+        },
+    }
+    (vault / "00-Creek-Meta" / "creek_config.yaml").write_text(
+        yaml.safe_dump(payload),
+        encoding="utf-8",
+    )
+
+
+class TestDraftGroundingRegistry:
+    """The new check must be reachable through the public lint surface."""
+
+    def test_check_is_registered_as_deterministic(self) -> None:
+        """The check is cheap (frontmatter-only) — must live in the default set."""
+        assert "draft-grounding" in DETERMINISTIC_CHECKS
+        assert "draft-grounding" in ALL_CHECKS
+
+    def test_runner_dispatches_check(self, tmp_path: Path) -> None:
+        """The runner registry resolves the new name to its module callable."""
+        _seed_meta_dir(tmp_path)
+        report = LintRunner(tmp_path).run(checks=["draft-grounding"])
+        assert [r.name for r in report.results] == ["draft-grounding"]
+
+
+class TestDraftGroundingFindings:
+    """The check's logic boils down to two threshold comparisons."""
+
+    def test_clean_drafts_produce_no_findings(self, tmp_path: Path) -> None:
+        """Balanced scores produce a non-flagging summary."""
+        _seed_meta_dir(tmp_path)
+        _write_config(tmp_path, derivative_upper=0.85, grounding_lower=0.30)
+        _write_draft(
+            tmp_path,
+            name="2026-05-27-balanced",
+            derivative_score=0.5,
+            grounding_score=0.6,
+        )
+        result = draft_grounding_check.run(tmp_path)
+        assert result.name == "draft-grounding"
+        assert result.findings == []
+        # The summary must report that 0 drafts crossed either threshold.
+        assert "0 outside" in result.summary or "0 draft" in result.summary
+
+    def test_too_derivative_draft_is_flagged(self, tmp_path: Path) -> None:
+        """A draft above ``derivative_upper`` appears in the findings list."""
+        _seed_meta_dir(tmp_path)
+        _write_config(tmp_path, derivative_upper=0.85, grounding_lower=0.30)
+        _write_draft(
+            tmp_path,
+            name="2026-05-27-derivative",
+            derivative_score=0.94,
+            grounding_score=0.6,
+        )
+        result = draft_grounding_check.run(tmp_path)
+        assert len(result.findings) == 1
+        finding = result.findings[0]
+        assert "derivative" in finding.lower()
+        assert "0.94" in finding
+        assert "2026-05-27-derivative" in finding
+
+    def test_too_ungrounded_draft_is_flagged(self, tmp_path: Path) -> None:
+        """A draft below ``grounding_lower`` appears in the findings list."""
+        _seed_meta_dir(tmp_path)
+        _write_config(tmp_path, derivative_upper=0.85, grounding_lower=0.30)
+        _write_draft(
+            tmp_path,
+            name="2026-05-27-ungrounded",
+            derivative_score=0.4,
+            grounding_score=0.10,
+        )
+        result = draft_grounding_check.run(tmp_path)
+        assert len(result.findings) == 1
+        assert "grounding" in result.findings[0].lower()
+        assert "0.10" in result.findings[0]
+
+    def test_drafts_without_scores_are_skipped(self, tmp_path: Path) -> None:
+        """Pre-guard drafts (no scores in frontmatter) emit no finding."""
+        _seed_meta_dir(tmp_path)
+        _write_config(tmp_path, derivative_upper=0.85, grounding_lower=0.30)
+        _write_draft(
+            tmp_path,
+            name="2026-05-27-legacy",
+            derivative_score=None,
+            grounding_score=None,
+        )
+        result = draft_grounding_check.run(tmp_path)
+        assert result.findings == []
+
+    def test_uses_configured_thresholds(self, tmp_path: Path) -> None:
+        """Tightening ``derivative_upper`` flips an otherwise-clean draft."""
+        _seed_meta_dir(tmp_path)
+        _write_config(tmp_path, derivative_upper=0.5, grounding_lower=0.30)
+        _write_draft(
+            tmp_path,
+            name="2026-05-27-mid",
+            derivative_score=0.7,
+            grounding_score=0.6,
+        )
+        result = draft_grounding_check.run(tmp_path)
+        assert len(result.findings) == 1
+        assert "derivative" in result.findings[0].lower()
+
+    def test_drafts_dir_missing_is_a_no_op(self, tmp_path: Path) -> None:
+        """A vault with no Drafts directory must produce a clean empty result."""
+        # Only meta exists — no 07-Voice/Drafts.
+        (tmp_path / "00-Creek-Meta").mkdir(parents=True)
+        result = draft_grounding_check.run(tmp_path)
+        assert result.findings == []
+        assert result.name == "draft-grounding"


### PR DESCRIPTION
## Summary

After a draft is generated, the new guard runs paragraph-level cosine similarity against the source fragments that fed the prompt and surfaces two opposite failure modes called out by issue #355:

- **Too derivative** — at least one draft paragraph paraphrases a single source paragraph closely (max similarity above `draft.derivative_upper`, default `0.85`). Voice-true paraphrase that adds nothing new.
- **Too ungrounded** — fewer than `draft.grounding_lower` (default `0.30`) fraction of draft paragraphs have any meaningful overlap with a source paragraph. Voice-true on the surface, conceptually invented.

The guard's verdict is surfaced everywhere the issue asks for:

- **stderr** — one-line `grounding guard: derivative=… (upper …), grounding=… (lower …) — within bounds|flagged: too derivative + too ungrounded`.
- **Frontmatter** — `derivative_score`, `grounding_score`, plus per-paragraph annotations under `paragraph_grounding`.
- **Lint** — new deterministic `draft-grounding` check audits saved drafts whose stored scores fall outside the configured bounds; pre-guard drafts without scores are skipped.

## Architecture

- New `creek/generate/grounding.py` does the paragraph-split + cosine-scoring math with a swappable `EmbeddingFn` callable so tests stay offline and deterministic. `GroundingThresholds.from_config` resolves the YAML knobs; `default_embedding_fn` builds the production callable lazily so the sentence-transformer never imports at unit-test time.
- New `creek/lint/checks/draft_grounding.py` reads each saved draft's frontmatter and emits one finding per failure with the offending metric + threshold in the message.
- `creek/config.py` gains `DraftConfig` (`derivative_upper`, `grounding_lower`, both clamped to `[0.0, 1.0]`) under the `draft:` YAML section.
- `creek/generate/drafts.py` diff is the minimum needed to wire the guard: append `derivative_score`/`grounding_score`/`paragraph_grounding` fields to `Draft` (defaults preserve every existing test), accept an optional `embedding_fn` + `grounding_thresholds` on `DraftGenerator`, call the guard from both `generate_draft` and `generate_seeded_draft`, and stamp the scores into `save_draft`'s frontmatter. No existing logic mutated — the guard short-circuits when no embedding callable is wired so the historical test suite keeps passing without dragging in `sentence-transformers`.

The `Draft` dataclass additions are append-only with `None`/empty defaults, so the parallel #352 work (which adds `source_profile` / `target_profile` / `twist_dimensions`) can land alongside without churn — expect a trivial rebase merge.

## Test plan

- [x] `./scripts/check-all.sh` exits 0 (12/12 quality checks pass, total coverage 93.65%, new modules at 91.8% / 93.5%)
- [x] Paraphrase-heavy draft scores `derivative_score = 1.0` and trips the flag
- [x] Invented draft (no source overlap) scores `grounding_score = 0.0` and trips the flag
- [x] Balanced draft (every paragraph in the 0.30 ≤ sim < 0.85 band) passes both
- [x] Thresholds configurable via `creek_config.yaml` `draft:` section — confirmed via the lint test that tightens `derivative_upper` to `0.5` and watches an otherwise-clean draft trip the flag
- [x] `creek lint` registry includes `draft-grounding` and `LintRunner` dispatches it
- [x] `DraftGenerator` integration: guard fields populated when wired, stay `None` when not wired, frontmatter written/omitted accordingly, summary printed to stderr

Closes #355
Part of epic #349

---
_Generated by [Claude Code](https://claude.ai/code/session_018XMbrkwQicpFoaSdaAmmEk)_