### PR TITLE
feat(draft): ontology-twist composition (#352)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
     from creek.config import CreekConfig
     from creek.generate.compost_embedding import CompostExemplar
     from creek.generate.compost_verifier import SupportsVerifyCompost
-    from creek.generate.drafts import DraftLLM, SeedSpec
+    from creek.generate.drafts import DraftGenerator, DraftLLM, SeedSpec
     from creek.generate.mining import MiningRunReport
     from creek.ingest.base import Ingestor
     from creek.link.link_engine import LinkSummary
@@ -2004,6 +2004,43 @@ def _build_draft_llm() -> DraftLLM:
     return classifier.invoke_prompt
 
 
+def _run_seeded_draft(
+    generator: DraftGenerator,
+    *,
+    seed_spec: SeedSpec,
+    vault_path: Path,
+    current_phase: Phase,
+    override: PrivacyTierOverride | None,
+) -> None:
+    """Run the seeded-draft pipeline and surface errors as typer exits.
+
+    Extracted from :func:`draft` so the CLI command body stays under
+    the cyclomatic-complexity floor. The branches it owns are the two
+    expected error surfaces (``SeedResolutionError`` and
+    ``PluralitySourceError``) plus the happy-path save / audit.
+    """
+    from creek.generate.drafts import SeedResolutionError
+    from creek.generate.twist import PluralitySourceError
+
+    try:
+        draft_obj = generator.generate_seeded_draft(
+            seed_spec,
+            vault_path=vault_path,
+            current_phase=current_phase,
+        )
+    except (SeedResolutionError, PluralitySourceError) as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    _audit_privacy_override_if_needed(
+        vault_path=vault_path,
+        command="draft",
+        override=override,
+        fragment_ids=list(draft_obj.source_fragments),
+    )
+    saved_path = generator.save_draft(draft_obj, vault_path)
+    console.print(f"[bold green]Draft saved: {saved_path}[/bold green]")
+
+
 @app.command()
 def draft(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
@@ -2080,6 +2117,17 @@ def draft(
             "(inhabit, express, collaborate, integrate, absorb)."
         ),
     ),
+    ontology_twist: bool = typer.Option(
+        False,
+        "--ontology-twist",
+        help=(
+            "Issue #352: enable ontology-twist composition. Computes the "
+            "delta between the retrieved source profile and the operator's "
+            "target profile, names divergent dimensions in the prompt, and "
+            "forbids verbatim paraphrase. Requires >=2 source fragments. "
+            "Gated behind a flag while epic #349 is in development."
+        ),
+    ),
 ) -> None:
     """Draft an essay from a mined idea with the activated skill stack.
 
@@ -2096,8 +2144,15 @@ def draft(
     bypassed and the draft is generated from the matching fragments,
     with the seed flags recorded in the draft's frontmatter for
     reproducibility.
+
+    Issue #352: pass ``--ontology-twist`` alongside a seed flag to
+    enable ontology-twist composition — the draft's source / target
+    ontology profiles are recorded in frontmatter, divergent dimensions
+    are named in the prompt, and the LLM is instructed to recombine
+    across the corpus rather than paraphrase any single source.
+    Requires at least two source fragments.
     """
-    from creek.generate.drafts import DraftGenerator, SeedResolutionError
+    from creek.generate.drafts import DraftGenerator
     from creek.generate.mining import IdeaMiner
 
     vault_path = _resolve_vault(vault)
@@ -2112,6 +2167,12 @@ def draft(
         seed_phase=seed_phase,
         seed_mode=seed_mode,
     )
+    if ontology_twist and seed_spec is None:
+        console.print(
+            "[red]--ontology-twist requires a seed (use --seed-topic, "
+            "--seed-frequency, --seed-phase, or --seed-mode).[/red]",
+        )
+        raise typer.Exit(code=2)
     llm = _build_draft_llm()
     if bypass_compiled:
         _warn_bypass_compiled("draft")
@@ -2122,26 +2183,17 @@ def draft(
         voice_core=voice_text,
         privacy_override=override,
         bypass_compiled=bypass_compiled,
+        ontology_twist=ontology_twist,
     )
 
     if seed_spec is not None:
-        try:
-            draft_obj = generator.generate_seeded_draft(
-                seed_spec,
-                vault_path=vault_path,
-                current_phase=current_phase,
-            )
-        except SeedResolutionError as exc:
-            console.print(f"[red]{exc}[/red]")
-            raise typer.Exit(code=1) from exc
-        _audit_privacy_override_if_needed(
+        _run_seeded_draft(
+            generator,
+            seed_spec=seed_spec,
             vault_path=vault_path,
-            command="draft",
+            current_phase=current_phase,
             override=override,
-            fragment_ids=list(draft_obj.source_fragments),
         )
-        saved_path = generator.save_draft(draft_obj, vault_path)
-        console.print(f"[bold green]Draft saved: {saved_path}[/bold green]")
         return
 
     seeds = IdeaMiner(

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -53,6 +53,14 @@ from creek.generate.dimensional_retrieval import (
     raise_if_all_empty,
     union_fragment_ids,
 )
+from creek.generate.twist import (
+    OntologyProfile,
+    format_twist_directive,
+    require_plural_sources,
+    source_profile_from_fragments,
+    target_profile_from_spec,
+    twist_dimensions,
+)
 from creek.models import (
     CompiledPage,
     Eddy,
@@ -198,6 +206,22 @@ class SeedResolutionError(ValueError):
 
 
 @dataclass(frozen=True)
+class _TwistPayload:
+    """Bundle of twist-composition outputs threaded into :class:`Draft`.
+
+    The default-constructed instance represents "no twist": the
+    directive is empty so :meth:`DraftGenerator._compose_prompt` skips
+    the block, both profiles stay ``None`` so the frontmatter writer
+    omits them, and the dimensions tuple is empty.
+    """
+
+    directive: str = ""
+    source_profile: OntologyProfile | None = None
+    target_profile: OntologyProfile | None = None
+    dimensions: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class Draft:
     """An LLM-generated essay draft with full provenance.
 
@@ -221,6 +245,17 @@ class Draft:
             section. Empty when the draft used the legacy
             single-dimension path; populated whenever
             :func:`assemble_per_dimension_corpus` ran.
+        source_profile: Ontology profile aggregated from the retrieved
+            source fragments (issue #352). ``None`` when the draft did
+            not pass through the twist composition path.
+        target_profile: Ontology profile asked for by the operator
+            (explicit flags + detected :class:`PromptOntology`). ``None``
+            when the draft did not pass through the twist composition
+            path.
+        twist_dimensions: Ordered tuple of dimension names where the
+            source profile diverges from the target profile (issue
+            #352). Empty when the two profiles match (regression
+            baseline) or when twist composition was not requested.
     """
 
     title: str
@@ -234,6 +269,9 @@ class Draft:
     generated_date: datetime
     seed_spec: SeedSpec | None = None
     per_dimension_sources: tuple[tuple[str, tuple[str, ...]], ...] = ()
+    source_profile: OntologyProfile | None = None
+    target_profile: OntologyProfile | None = None
+    twist_dimensions: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         """Validate draft invariants."""
@@ -451,6 +489,7 @@ class DraftGenerator:
         voice_core: str = "",
         privacy_override: PrivacyTierOverride | None = None,
         bypass_compiled: bool = False,
+        ontology_twist: bool = False,
     ) -> None:
         """Initialise with an LLM client and skill tree root.
 
@@ -468,12 +507,20 @@ class DraftGenerator:
                 step skips the compiled layer and pulls fragments
                 directly. Default ``False`` honours the FEAT-004
                 compile-then-query discipline.
+            ontology_twist: When ``True``, activate the issue #352
+                composition path: compute source/target ontology
+                profiles, name the divergent dimensions in the prompt,
+                forbid verbatim paraphrase, and require ≥2 source
+                fragments. Default ``False`` keeps the legacy
+                composition path (epic #349 gates the flag while in
+                development).
         """
         self._llm = llm
         self.skills_root = skills_root
         self.voice_core = voice_core
         self.privacy_override = privacy_override
         self.bypass_compiled = bypass_compiled
+        self.ontology_twist = ontology_twist
 
     def present_idea(self, idea: IdeaSeed) -> str:
         """Format *idea* as an invitation rather than an imperative.
@@ -735,6 +782,8 @@ class DraftGenerator:
         source_material: str,
         *,
         per_dimension_material: str = "",
+        twist_directive: str = "",
+        twist_active: bool = False,
     ) -> str:
         """Assemble the LLM prompt from voice-core + skills + source + ask.
 
@@ -744,6 +793,10 @@ class DraftGenerator:
         them. Both blocks may co-exist — the per-dimension block carries
         the dimensional corpus slices, the legacy block still carries
         thread / eddy context for the synthetic IdeaSeed.
+
+        When *twist_directive* is supplied (issue #352), it is inserted
+        immediately before the ``## Ask`` block so the LLM sees the
+        recombination instruction as the last thing before its task.
         """
         parts: list[str] = []
         if self.voice_core:
@@ -755,8 +808,14 @@ class DraftGenerator:
             parts.append(per_dimension_material)
         if source_material:
             parts.append(f"## Source material\n{source_material}")
+        if twist_directive:
+            parts.append(twist_directive)
         parts.append(
-            _compose_ask_section(idea, per_dimension=bool(per_dimension_material)),
+            _compose_ask_section(
+                idea,
+                per_dimension=bool(per_dimension_material),
+                twist=twist_active,
+            ),
         )
         return "\n\n".join(parts)
 
@@ -1016,6 +1075,16 @@ class DraftGenerator:
         the caller did not pass ``current_phase``, the spec's phase is
         used so the activated phase skill matches the user's request.
 
+        When :attr:`ontology_twist` is enabled (issue #352), the
+        retrieved source material has its dominant ontology profile
+        compared against the operator's target profile; divergent
+        dimensions are named in a ``## Twist directive`` block and the
+        ``## Ask`` is rewritten to forbid verbatim paraphrase. The
+        helper :func:`require_plural_sources` raises
+        :class:`PluralitySourceError` when fewer than two source
+        fragments matched, since recombination requires more than one
+        input.
+
         Args:
             spec: The manual seed specification.
             vault_path: Vault root used for fragment loading, skill
@@ -1024,10 +1093,14 @@ class DraftGenerator:
 
         Returns:
             A :class:`Draft` whose ``seed_spec`` field records the
-            originating manual seed.
+            originating manual seed and (when twist composition is
+            active) whose ``source_profile`` / ``target_profile`` /
+            ``twist_dimensions`` fields record the ontology delta.
 
         Raises:
             SeedResolutionError: Propagated from :meth:`resolve_seed`.
+            PluralitySourceError: When twist composition is requested
+                but fewer than two source fragments matched.
             RuntimeError: When the LLM returns an empty body.
         """
         fragments = _load_fragments_by_id(
@@ -1052,6 +1125,7 @@ class DraftGenerator:
             confidence_threshold=spec.ontology_confidence_threshold,
         )
         per_dimension_material = _render_per_dimension_sections(slices, fragments)
+        twist_payload = self._build_twist_payload(spec, idea, fragments)
         source_material = self.gather_source_material(
             idea,
             vault_path=vault_path,
@@ -1064,6 +1138,8 @@ class DraftGenerator:
             skill_stack,
             source_material,
             per_dimension_material=per_dimension_material,
+            twist_directive=twist_payload.directive,
+            twist_active=bool(twist_payload.dimensions),
         )
         body = self._llm(prompt).strip()
         if not body:
@@ -1083,6 +1159,39 @@ class DraftGenerator:
             generated_date=datetime.now(tz=UTC),
             seed_spec=spec,
             per_dimension_sources=_slices_as_provenance(slices),
+            source_profile=twist_payload.source_profile,
+            target_profile=twist_payload.target_profile,
+            twist_dimensions=twist_payload.dimensions,
+        )
+
+    def _build_twist_payload(
+        self,
+        spec: SeedSpec,
+        idea: IdeaSeed,
+        fragments: dict[str, tuple[Fragment, str]],
+    ) -> _TwistPayload:
+        """Build the ontology-twist payload for :meth:`generate_seeded_draft`.
+
+        Returns an empty payload when :attr:`ontology_twist` is off so
+        the legacy composition path is byte-for-byte unchanged.
+        Otherwise enforces the plurality floor, computes source / target
+        profiles, and renders the twist directive block.
+        """
+        if not self.ontology_twist:
+            return _TwistPayload()
+        require_plural_sources(idea.source_fragments)
+        retrieved = [
+            fragments[fid][0] for fid in idea.source_fragments if fid in fragments
+        ]
+        source_profile = source_profile_from_fragments(retrieved)
+        target_profile = target_profile_from_spec(spec)
+        divergent = twist_dimensions(source_profile, target_profile)
+        directive = format_twist_directive(source_profile, target_profile, divergent)
+        return _TwistPayload(
+            directive=directive,
+            source_profile=source_profile,
+            target_profile=target_profile,
+            dimensions=tuple(divergent),
         )
 
     def save_draft(self, draft: Draft, vault_path: Path) -> Path:
@@ -1122,6 +1231,12 @@ class DraftGenerator:
             post["per_dimension_sources"] = _serialise_per_dimension_sources(
                 draft.per_dimension_sources,
             )
+        if draft.source_profile is not None:
+            post["source_profile"] = draft.source_profile.as_mapping()
+        if draft.target_profile is not None:
+            post["target_profile"] = draft.target_profile.as_mapping()
+        if draft.twist_dimensions:
+            post["twist_dimensions"] = list(draft.twist_dimensions)
         target.write_text(frontmatter.dumps(post), encoding="utf-8")
         return target
 
@@ -1268,15 +1383,34 @@ def _slices_as_provenance(
     )
 
 
-def _compose_ask_section(idea: IdeaSeed, *, per_dimension: bool) -> str:
-    """Return the ``## Ask`` block, switching wording for per-dimension mode.
+def _compose_ask_section(
+    idea: IdeaSeed,
+    *,
+    per_dimension: bool,
+    twist: bool = False,
+) -> str:
+    """Return the ``## Ask`` block, switching wording for per-dimension / twist mode.
 
     When per-dimension material is in play (issue #351), the ask
     explicitly invites the model to weave across the labelled slices
-    rather than treating them as one homogeneous corpus. Otherwise it
-    keeps the original wording so existing tests and mined-idea drafts
+    rather than treating them as one homogeneous corpus. When ontology
+    twist is also on (issue #352), the ask references the twist
+    directive so the LLM treats it as load-bearing. Otherwise it keeps
+    the original wording so existing tests and mined-idea drafts
     continue to compose identically.
     """
+    if twist:
+        return (
+            "## Ask\n"
+            f'Write a draft essay titled "{idea.title}". '
+            f"{idea.brief_description} "
+            "Follow the twist directive above: use the source musings "
+            "as ideas being explored, but voice them through the target "
+            "combination's style. Do not paraphrase any single source "
+            "verbatim — recombine across the corpus. Honour the "
+            "activated skills. Write as the human — not as an AI. "
+            "Cite source fragments by their IDs where relevant."
+        )
     if per_dimension:
         return (
             "## Ask\n"

--- a/creek-tools/creek/generate/twist.py
+++ b/creek-tools/creek/generate/twist.py
@@ -1,0 +1,416 @@
+"""Ontology-twist composition for ``creek draft`` (issue #352).
+
+The default composition path retrieves source material per-dimension
+(issue #351) and asks the LLM to weave it. That is enough when the
+operator wants a faithful synthesis of their own voice, but the epic
+goal (#349) is **"your ideas with a twist"** — drafts whose conceptual
+content comes from the user's vault but whose voice signatures (phase,
+mode, frequency, dosage, register) honour a *target* combination the
+operator has asked for.
+
+This module computes the ingredients the prompt template needs:
+
+* :class:`OntologyProfile` — a frozen snapshot of a dimensional signature
+  with one canonical value per dimension. Empty (``"unspecified"``) when
+  no signal exists for that dimension.
+* :func:`source_profile_from_fragments` — derive the source profile by
+  taking the dominant non-unclassified value across the retrieved
+  fragments. This is the "what the user actually wrote about" signal.
+* :func:`target_profile_from_spec` — derive the target profile from the
+  operator's explicit flags + detected :class:`PromptOntology`. This is
+  "what the operator wants the draft to sound like".
+* :func:`twist_dimensions` — the ordered list of dimensions where source
+  and target diverge. Empty list = no twist (the prompt collapses to the
+  legacy per-dimension composition; regression baseline).
+* :func:`format_twist_directive` — render the prompt block that names
+  the divergent dimensions and forbids verbatim paraphrase.
+* :class:`PluralitySourceError` — raised by
+  :func:`require_plural_sources` when twist composition is requested with
+  only one source fragment. Recombination requires more than one input;
+  failing loudly is the documented behaviour.
+
+The module is import-side-effect-free and has no LLM dependency, so the
+twist machinery is fully unit-testable independent of provider
+configuration.
+"""
+
+from __future__ import annotations
+
+import operator
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from creek.models import Dosage, Frequency, Mode, Phase
+
+if TYPE_CHECKING:
+    from creek.classify.prompt import PromptOntology
+    from creek.generate.drafts import SeedSpec
+    from creek.models import Fragment
+
+
+UNSPECIFIED: str = "unspecified"
+"""Sentinel value used when no signal exists for a dimension.
+
+The string form is friendly to YAML frontmatter and string equality
+checks against the StrEnum-backed dimension values stored on
+:class:`Fragment`. ``"unspecified"`` collides with no real enum value.
+"""
+
+
+_DIMENSION_ORDER: tuple[str, ...] = (
+    "phase",
+    "mode",
+    "frequency",
+    "dosage",
+    "voice_register",
+)
+"""Stable order for serialising and comparing dimensions.
+
+Used by :func:`twist_dimensions` to keep the diff order deterministic.
+"""
+
+
+_MIN_PLURAL_SOURCES: int = 2
+"""Minimum number of source fragments required for twist composition.
+
+Recombination across fewer than two sources collapses to single-source
+paraphrase, the failure mode the epic is escaping.
+"""
+
+
+@dataclass(frozen=True)
+class OntologyProfile:
+    """A canonical one-pick-per-dimension snapshot of an ontology signature.
+
+    Attributes:
+        phase: Wavelength phase value or :data:`UNSPECIFIED`.
+        mode: Engagement mode value or :data:`UNSPECIFIED`.
+        frequency: APTITUDE frequency code or :data:`UNSPECIFIED`.
+        dosage: Dosage value or :data:`UNSPECIFIED`.
+        voice_register: Voice register value or :data:`UNSPECIFIED`.
+    """
+
+    phase: str = UNSPECIFIED
+    mode: str = UNSPECIFIED
+    frequency: str = UNSPECIFIED
+    dosage: str = UNSPECIFIED
+    voice_register: str = UNSPECIFIED
+
+    def as_mapping(self) -> dict[str, str]:
+        """Return a plain dict for YAML frontmatter serialisation.
+
+        Returns:
+            ``{dimension_name: value}`` in :data:`_DIMENSION_ORDER`.
+        """
+        return {
+            "phase": self.phase,
+            "mode": self.mode,
+            "frequency": self.frequency,
+            "dosage": self.dosage,
+            "voice_register": self.voice_register,
+        }
+
+    def get(self, dimension: str) -> str:
+        """Return the value for *dimension* by name.
+
+        Args:
+            dimension: One of :data:`_DIMENSION_ORDER`.
+
+        Returns:
+            The dimension's value, or :data:`UNSPECIFIED` if the name is
+            unknown. Unknown-name graceful return keeps the diff helper
+            in :func:`twist_dimensions` simple.
+        """
+        return self.as_mapping().get(dimension, UNSPECIFIED)
+
+
+class PluralitySourceError(ValueError):
+    """Raised when twist composition has fewer than two source fragments.
+
+    Recombination requires more than one input. The CLI surfaces the
+    message verbatim so the operator can decide whether to widen the
+    filters or ingest more sources.
+    """
+
+
+def _dominant(values: list[str]) -> str:
+    """Return the most common non-empty / non-unclassified value, else UNSPECIFIED.
+
+    Ties resolve by lexical order on the value for deterministic output
+    across Python implementations. ``"unclassified"`` and empty strings
+    are filtered out before counting so they cannot win the vote when
+    the corpus carries a real signal alongside them.
+    """
+    counts: dict[str, int] = {}
+    for value in values:
+        if not value or value == "unclassified":
+            continue
+        counts[value] = counts.get(value, 0) + 1
+    if not counts:
+        return UNSPECIFIED
+    return max(counts.items(), key=operator.itemgetter(1, 0))[0]
+
+
+def source_profile_from_fragments(
+    fragments: list[Fragment],
+) -> OntologyProfile:
+    """Aggregate *fragments* into a single canonical :class:`OntologyProfile`.
+
+    The dominant non-unclassified value per dimension wins. When a
+    dimension has no classified value across the whole list, the field
+    is left as :data:`UNSPECIFIED` so :func:`twist_dimensions` can
+    treat it as "no signal" rather than a divergent pick.
+
+    Args:
+        fragments: The retrieved source fragments. Typically the union
+            of the per-dimension slices from issue #351.
+
+    Returns:
+        A frozen :class:`OntologyProfile` reflecting the corpus's
+        dominant signatures.
+    """
+    if not fragments:
+        return OntologyProfile()
+    return OntologyProfile(
+        phase=_dominant([str(f.wavelength.phase) for f in fragments]),
+        mode=_dominant([str(f.wavelength.mode) for f in fragments]),
+        frequency=_dominant([str(f.frequency.primary) for f in fragments]),
+        dosage=_dominant([str(f.wavelength.dosage) for f in fragments]),
+        voice_register=_dominant(
+            [
+                str(f.voice.voice_register)
+                for f in fragments
+                if f.voice.voice_register is not None
+            ],
+        ),
+    )
+
+
+def _heaviest_value(entries: tuple[object, ...], unclassified: object) -> str:
+    """Return the heaviest above-zero, non-unclassified value as a string.
+
+    The ``PromptOntology`` parser sorts entries by weight descending, so
+    the heaviest above-:data:`UNSPECIFIED` value is the first qualifying
+    entry. Returns :data:`UNSPECIFIED` when every entry is below or
+    equal to zero or every entry is the unclassified sentinel.
+    """
+    for entry in entries:
+        weight = getattr(entry, "weight", 0.0)
+        value = getattr(entry, "value", None)
+        if value is None or value == unclassified:
+            continue
+        if weight <= 0.0:
+            continue
+        return str(value)
+    return UNSPECIFIED
+
+
+def target_profile_from_spec(
+    spec: SeedSpec,
+    *,
+    ontology: PromptOntology | None = None,
+) -> OntologyProfile:
+    """Derive the target :class:`OntologyProfile` from *spec* and *ontology*.
+
+    Explicit flags win over the detected ontology: when both name the
+    same dimension, the explicit pick is used. Otherwise the heaviest
+    above-zero ontology entry per dimension is used. Dimensions with
+    neither an explicit flag nor an above-zero ontology entry stay as
+    :data:`UNSPECIFIED`.
+
+    The dosage and voice-register dimensions have no explicit-flag
+    counterpart today; they come entirely from the ontology. Adding
+    them to the profile lets the twist directive name those signals
+    when they diverge — the #352 issue body specifically mentions
+    different dosage and different register as twist axes.
+
+    Args:
+        spec: The operator's :class:`SeedSpec`.
+        ontology: Optional :class:`PromptOntology` augmenting the
+            explicit flags. Defaults to ``spec.ontology`` so callers can
+            omit the keyword when the spec carries its own ontology.
+
+    Returns:
+        The target :class:`OntologyProfile`.
+    """
+    resolved_ontology = ontology if ontology is not None else spec.ontology
+    phase = (
+        spec.phases[0].value
+        if spec.phases
+        else _heaviest_value(
+            resolved_ontology.phases if resolved_ontology else (),
+            Phase.UNCLASSIFIED,
+        )
+    )
+    mode = (
+        spec.modes[0].value
+        if spec.modes
+        else _heaviest_value(
+            resolved_ontology.modes if resolved_ontology else (),
+            Mode.UNCLASSIFIED,
+        )
+    )
+    frequency = (
+        spec.frequencies[0].value
+        if spec.frequencies
+        else _heaviest_value(
+            resolved_ontology.frequencies if resolved_ontology else (),
+            Frequency.UNCLASSIFIED,
+        )
+    )
+    dosage = _heaviest_value(
+        resolved_ontology.dosages if resolved_ontology else (),
+        Dosage.UNCLASSIFIED,
+    )
+    voice_register = _heaviest_value(
+        resolved_ontology.voice_registers if resolved_ontology else (),
+        # VoiceRegister has no UNCLASSIFIED member; pass a sentinel that
+        # cannot match any real value so every above-zero entry is kept.
+        object(),
+    )
+    return OntologyProfile(
+        phase=phase,
+        mode=mode,
+        frequency=frequency,
+        dosage=dosage,
+        voice_register=voice_register,
+    )
+
+
+def twist_dimensions(
+    source: OntologyProfile,
+    target: OntologyProfile,
+) -> list[str]:
+    """Return the ordered list of dimensions where source ≠ target.
+
+    A dimension is considered divergent only when **both** sides carry
+    a concrete value and the values differ. When either side is
+    :data:`UNSPECIFIED` the dimension is treated as "no signal" rather
+    than a divergence — naming a divergence the operator never asked
+    for would make the twist directive lie about the target.
+
+    Args:
+        source: Profile derived from the retrieved fragments.
+        target: Profile derived from spec + ontology.
+
+    Returns:
+        Dimension names from :data:`_DIMENSION_ORDER`, divergent
+        entries only, in stable order.
+    """
+    divergent: list[str] = []
+    for dim in _DIMENSION_ORDER:
+        src = source.get(dim)
+        tgt = target.get(dim)
+        if UNSPECIFIED in (src, tgt):
+            continue
+        if src != tgt:
+            divergent.append(dim)
+    return divergent
+
+
+_DIMENSION_LABEL_BY_NAME: dict[str, str] = {
+    "phase": "phase",
+    "mode": "stance",
+    "frequency": "frequency",
+    "dosage": "dosage",
+    "voice_register": "voice register",
+}
+"""Human-readable label per dimension for the twist directive.
+
+Mirrors the wording in :func:`format_dimension_label` from
+:mod:`creek.generate.dimensional_retrieval` so the prompt's twist
+sentence reads naturally next to the per-dimension section headers.
+"""
+
+
+def _format_one_dimension_diff(
+    dim: str,
+    source: OntologyProfile,
+    target: OntologyProfile,
+) -> str:
+    """Render one divergence line: ``phase: peaking → withdrawal``."""
+    label = _DIMENSION_LABEL_BY_NAME.get(dim, dim)
+    return f"- {label}: {source.get(dim)} -> {target.get(dim)}"
+
+
+def format_twist_directive(
+    source: OntologyProfile,
+    target: OntologyProfile,
+    divergent: list[str],
+) -> str:
+    """Render the ``## Twist directive`` prompt block.
+
+    When *divergent* is empty the directive collapses to a single line
+    that records the matching profile and asks the LLM to honour the
+    activated skills as usual — preserving the regression baseline the
+    #352 acceptance criterion calls for.
+
+    Args:
+        source: The source profile.
+        target: The target profile.
+        divergent: Dimensions where source and target diverge, as
+            returned by :func:`twist_dimensions`.
+
+    Returns:
+        A markdown-flavoured prompt block, ready to be concatenated
+        into :meth:`DraftGenerator._compose_prompt`.
+    """
+    header = "## Twist directive"
+    if not divergent:
+        return (
+            f"{header}\n"
+            "Source and target ontology profiles match on every detected "
+            "dimension; compose in the operator's requested voice without "
+            "additional re-framing."
+        )
+    diffs = "\n".join(
+        _format_one_dimension_diff(dim, source, target) for dim in divergent
+    )
+    body = (
+        "The source musings sit on a different ontology profile than the "
+        "target combination the operator asked for. The dimensions that "
+        "diverge are:\n"
+        f"{diffs}\n\n"
+        "Use the provided source musings as the ideas being explored, but "
+        "voice them through the target combination's style. Do not "
+        "paraphrase any single source verbatim. Recombine across the "
+        "corpus."
+    )
+    return f"{header}\n{body}"
+
+
+def require_plural_sources(source_fragments: tuple[str, ...]) -> None:
+    """Raise :class:`PluralitySourceError` when fewer than two sources matched.
+
+    The twist composition prompt explicitly asks the LLM to *recombine
+    across the corpus*. Composing across a single source collapses to
+    the legacy single-source paraphrase failure mode the epic is trying
+    to escape — failing here is more honest than producing a draft that
+    pretends to be a recombination.
+
+    Args:
+        source_fragments: The fragment IDs that will enter the prompt.
+
+    Raises:
+        PluralitySourceError: When ``len(source_fragments) < 2``.
+    """
+    if len(source_fragments) >= _MIN_PLURAL_SOURCES:
+        return
+    msg = (
+        "Ontology-twist composition requires at least two source "
+        f"fragments to recombine across; got {len(source_fragments)}. "
+        "Widen the filters or ingest more sources before re-running."
+    )
+    raise PluralitySourceError(msg)
+
+
+__all__ = [
+    "UNSPECIFIED",
+    "OntologyProfile",
+    "PluralitySourceError",
+    "format_twist_directive",
+    "require_plural_sources",
+    "source_profile_from_fragments",
+    "target_profile_from_spec",
+    "twist_dimensions",
+]

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -2548,3 +2548,121 @@ def test_draft_without_seed_flags_keeps_mining_behaviour(
     result = runner.invoke(app, ["draft", "--vault", str(vault)])
     assert result.exit_code == 0
     assert "No idea seeds surfaced" in result.output
+
+
+# ---- Issue #352: --ontology-twist CLI flag ---------------------------------
+
+
+def test_draft_ontology_twist_advertised_in_help() -> None:
+    """``creek draft --help`` documents ``--ontology-twist``."""
+    result = runner.invoke(app, ["draft", "--help"])
+    output = _strip_ansi(result.output)
+    assert result.exit_code == 0
+    assert "--ontology-twist" in output
+
+
+def test_draft_ontology_twist_without_seed_exits_with_clear_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--ontology-twist`` alone (no seed) exits 2 with a clear hint."""
+    from creek import cli as cli_module
+
+    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    result = runner.invoke(
+        app,
+        ["draft", "--vault", str(vault), "--ontology-twist"],
+    )
+    assert result.exit_code == 2
+    output = _strip_ansi(result.output)
+    assert "--ontology-twist requires a seed" in output
+
+
+def test_draft_ontology_twist_plurality_failure_exits_cleanly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single-source twist fails fast at the CLI with the plurality error.
+
+    Issue #352 acceptance: "fails loudly if only one source matches".
+    """
+    from creek import cli as cli_module
+
+    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    _write_seed_fragment(vault, frag_id="frag-only", primary="F1", phase="peaking")
+    result = runner.invoke(
+        app,
+        [
+            "draft",
+            "--vault",
+            str(vault),
+            "--seed-phase",
+            "peaking",
+            "--ontology-twist",
+        ],
+    )
+    assert result.exit_code == 1
+    output = _strip_ansi(result.output)
+    assert "at least two source fragments" in output
+
+
+def test_draft_ontology_twist_happy_path_writes_twist_frontmatter(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--ontology-twist`` with a plural source set records twist provenance.
+
+    Two withdrawal-phase fragments are retrieved by the explicit
+    ``--seed-phase withdrawal`` filter; the target profile takes the
+    withdrawal pick from the same flag, so divergence (if any) comes
+    from inspecting both profiles. The acceptance criterion is that the
+    frontmatter records source/target profiles + twist_dimensions.
+    """
+    import frontmatter as fm
+
+    from creek import cli as cli_module
+
+    monkeypatch.setattr(
+        cli_module,
+        "_build_draft_llm",
+        lambda: lambda _p: "Twisted draft body.",
+    )
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    # Two withdrawal-phase fragments so the WITHDRAWAL slice is plural;
+    # both also share mode=inhabit so source.mode is deterministic.
+    _write_seed_fragment(
+        vault, frag_id="frag-A", primary="F1", phase="withdrawal", mode="inhabit"
+    )
+    _write_seed_fragment(
+        vault, frag_id="frag-B", primary="F1", phase="withdrawal", mode="inhabit"
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "draft",
+            "--vault",
+            str(vault),
+            "--seed-phase",
+            "withdrawal",
+            "--seed-mode",
+            "express",
+            "--ontology-twist",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    drafts = list((vault / "07-Voice" / "Drafts").glob("*.md"))
+    assert len(drafts) == 1
+    post = fm.load(str(drafts[0]))
+    # Frontmatter records both profiles and the divergent dimensions.
+    assert post.metadata["source_profile"]["phase"] == "withdrawal"
+    assert post.metadata["source_profile"]["mode"] == "inhabit"
+    assert post.metadata["target_profile"]["phase"] == "withdrawal"
+    assert post.metadata["target_profile"]["mode"] == "express"
+    # Only mode diverges between source and target.
+    assert post.metadata["twist_dimensions"] == ["mode"]

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -18,6 +18,7 @@ from creek.generate.drafts import (
 from creek.generate.mining import IdeaSeed, MiningStrategy
 from creek.models import (
     Confidence,
+    Dosage,
     Eddy,
     Fragment,
     FragmentSource,
@@ -55,6 +56,7 @@ def _build_fragment(
     orientation: Orientation = Orientation.UNCLASSIFIED,
     register: VoiceRegister | None = None,
     phase: Phase = Phase.UNCLASSIFIED,
+    dosage: Dosage = Dosage.UNCLASSIFIED,
     threads: tuple[str, ...] = (),
     eddies: tuple[str, ...] = (),
 ) -> Fragment:
@@ -73,6 +75,7 @@ def _build_fragment(
             mode=mode,
             orientation=orientation,
             phase=phase,
+            dosage=dosage,
         ),
         voice=VoiceClassification(
             voice_register=register,
@@ -1939,3 +1942,656 @@ class TestSeedSpecOntologyField:
         )
         with pytest.raises(ValueError, match="mutually exclusive"):
             SeedSpec(fragment_id="frag-A", ontology=ontology)
+
+
+# ---- Issue #352: ontology-twist composition --------------------------------
+
+
+class TestOntologyTwistHelpers:
+    """Pure functions in :mod:`creek.generate.twist`."""
+
+    def test_source_profile_picks_dominant_value_per_dimension(self) -> None:
+        """The dominant non-unclassified value wins for each dimension."""
+        from creek.generate.twist import (
+            UNSPECIFIED,
+            source_profile_from_fragments,
+        )
+
+        fragments = [
+            _build_fragment(
+                frag_id="f1",
+                primary=Frequency.F7,
+                phase=Phase.PEAKING,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+                register=VoiceRegister.ANALYTICAL,
+            ),
+            _build_fragment(
+                frag_id="f2",
+                primary=Frequency.F7,
+                phase=Phase.PEAKING,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+                register=VoiceRegister.ANALYTICAL,
+            ),
+            _build_fragment(
+                frag_id="f3",
+                primary=Frequency.F3,
+                phase=Phase.RISING,
+                mode=Mode.EXPRESS,
+                dosage=Dosage.TOXIC,
+                register=VoiceRegister.PROPHETIC,
+            ),
+        ]
+
+        profile = source_profile_from_fragments(fragments)
+
+        assert profile.phase == "peaking"
+        assert profile.mode == "inhabit"
+        assert profile.frequency == "F7"
+        assert profile.dosage == "medicine"
+        assert profile.voice_register == "analytical"
+        assert UNSPECIFIED == "unspecified"
+
+    def test_source_profile_skips_unclassified_values(self) -> None:
+        """``unclassified`` is filtered before the dominance vote."""
+        from creek.generate.twist import (
+            UNSPECIFIED,
+            source_profile_from_fragments,
+        )
+
+        fragments = [
+            # First two fragments are unclassified on phase; only the third
+            # carries a real signal. The dominant pick should be that one
+            # rather than ``unclassified``.
+            _build_fragment(frag_id="f1"),
+            _build_fragment(frag_id="f2"),
+            _build_fragment(frag_id="f3", phase=Phase.WITHDRAWAL),
+        ]
+
+        profile = source_profile_from_fragments(fragments)
+
+        assert profile.phase == "withdrawal"
+        # Frequency is F1 across all three (default), so it wins.
+        assert profile.frequency == "F1"
+        # No fragment carried a mode, dosage, or register — leave them open.
+        assert profile.mode == UNSPECIFIED
+        assert profile.dosage == UNSPECIFIED
+        assert profile.voice_register == UNSPECIFIED
+
+    def test_source_profile_empty_fragments_yields_all_unspecified(self) -> None:
+        """An empty corpus leaves every dimension as :data:`UNSPECIFIED`."""
+        from creek.generate.twist import UNSPECIFIED, source_profile_from_fragments
+
+        profile = source_profile_from_fragments([])
+
+        assert profile.phase == UNSPECIFIED
+        assert profile.mode == UNSPECIFIED
+        assert profile.frequency == UNSPECIFIED
+        assert profile.dosage == UNSPECIFIED
+        assert profile.voice_register == UNSPECIFIED
+
+    def test_target_profile_explicit_flags_win(self) -> None:
+        """``SeedSpec.phases`` / ``modes`` / ``frequencies`` outrank ontology."""
+        from creek.classify.prompt import PromptOntology, WeightedDimension
+        from creek.generate.twist import target_profile_from_spec
+
+        # Ontology asks for rising/express/F2 but the operator's flags
+        # pin peaking/inhabit/F7. Explicit picks should win the duel.
+        ontology = PromptOntology(
+            prompt="x",
+            phases=(WeightedDimension(value=Phase.RISING, weight=0.9),),
+            modes=(WeightedDimension(value=Mode.EXPRESS, weight=0.8),),
+            frequencies=(WeightedDimension(value=Frequency.F2, weight=0.7),),
+        )
+        spec = SeedSpec(
+            phases=(Phase.PEAKING,),
+            modes=(Mode.INHABIT,),
+            frequencies=(Frequency.F7,),
+            ontology=ontology,
+        )
+
+        profile = target_profile_from_spec(spec)
+
+        assert profile.phase == "peaking"
+        assert profile.mode == "inhabit"
+        assert profile.frequency == "F7"
+
+    def test_target_profile_includes_dosage_and_register_from_ontology(self) -> None:
+        """Dosage and voice register come from the ontology heaviest pick."""
+        from creek.classify.prompt import PromptOntology, WeightedDimension
+        from creek.generate.twist import target_profile_from_spec
+
+        ontology = PromptOntology(
+            prompt="x",
+            dosages=(WeightedDimension(value=Dosage.TOXIC, weight=0.7),),
+            voice_registers=(
+                WeightedDimension(value=VoiceRegister.PROPHETIC, weight=0.8),
+            ),
+        )
+        spec = SeedSpec(ontology=ontology)
+
+        profile = target_profile_from_spec(spec)
+
+        assert profile.dosage == "toxic"
+        assert profile.voice_register == "prophetic"
+
+    def test_target_profile_no_signal_yields_unspecified(self) -> None:
+        """No flags and no ontology means every dimension is unspecified."""
+        from creek.generate.twist import UNSPECIFIED, target_profile_from_spec
+
+        spec = SeedSpec(topic="x")
+        profile = target_profile_from_spec(spec)
+
+        assert profile.phase == UNSPECIFIED
+        assert profile.mode == UNSPECIFIED
+        assert profile.frequency == UNSPECIFIED
+        assert profile.dosage == UNSPECIFIED
+        assert profile.voice_register == UNSPECIFIED
+
+    def test_twist_dimensions_lists_only_concrete_diffs(self) -> None:
+        """Divergence requires both sides to be specified and different."""
+        from creek.generate.twist import OntologyProfile, twist_dimensions
+
+        source = OntologyProfile(phase="peaking", mode="inhabit", frequency="F7")
+        target = OntologyProfile(
+            phase="withdrawal",
+            mode="inhabit",
+            frequency="F3",
+        )
+
+        diff = twist_dimensions(source, target)
+
+        # phase and frequency diverge; mode matches and is therefore omitted.
+        # dosage / voice_register are unspecified on both sides, so they too
+        # are omitted (we don't invent divergences the operator didn't ask
+        # for).
+        assert diff == ["phase", "frequency"]
+
+    def test_twist_dimensions_empty_when_profiles_match(self) -> None:
+        """source == target collapses to an empty divergence list."""
+        from creek.generate.twist import OntologyProfile, twist_dimensions
+
+        profile = OntologyProfile(phase="peaking", mode="inhabit", frequency="F7")
+        assert twist_dimensions(profile, profile) == []
+
+    def test_format_twist_directive_names_diverging_dimensions(self) -> None:
+        """The directive lists divergent dimensions with arrows."""
+        from creek.generate.twist import (
+            OntologyProfile,
+            format_twist_directive,
+        )
+
+        source = OntologyProfile(phase="peaking", frequency="F7")
+        target = OntologyProfile(phase="withdrawal", frequency="F3")
+
+        directive = format_twist_directive(
+            source,
+            target,
+            ["phase", "frequency"],
+        )
+
+        assert "## Twist directive" in directive
+        assert "phase: peaking -> withdrawal" in directive
+        assert "frequency: F7 -> F3" in directive
+        # Verbatim-paraphrase clause from the issue body must appear.
+        assert "Do not paraphrase any single source verbatim" in directive
+        assert "Recombine across the corpus" in directive
+
+    def test_format_twist_directive_no_twist_collapses_to_noop(self) -> None:
+        """No divergent dimensions yields a benign single-line directive."""
+        from creek.generate.twist import (
+            OntologyProfile,
+            format_twist_directive,
+        )
+
+        profile = OntologyProfile(phase="peaking")
+
+        directive = format_twist_directive(profile, profile, [])
+
+        assert "## Twist directive" in directive
+        # No "diverge" wording and no arrow lines.
+        assert "->" not in directive
+        assert "paraphrase" not in directive.lower()
+
+    def test_require_plural_sources_passes_with_two_or_more(self) -> None:
+        """Two or more sources is enough to recombine across."""
+        from creek.generate.twist import require_plural_sources
+
+        require_plural_sources(("frag-A", "frag-B"))
+        require_plural_sources(("frag-A", "frag-B", "frag-C"))
+
+    def test_require_plural_sources_raises_on_singleton(self) -> None:
+        """A single source fails loudly because recombination needs two."""
+        from creek.generate.twist import (
+            PluralitySourceError,
+            require_plural_sources,
+        )
+
+        with pytest.raises(PluralitySourceError, match="at least two"):
+            require_plural_sources(("frag-A",))
+
+    def test_require_plural_sources_raises_on_empty(self) -> None:
+        """Zero sources also fails — the message names the actual count."""
+        from creek.generate.twist import (
+            PluralitySourceError,
+            require_plural_sources,
+        )
+
+        with pytest.raises(PluralitySourceError, match="got 0"):
+            require_plural_sources(())
+
+
+class TestOntologyTwistComposition:
+    """End-to-end behaviour: ``DraftGenerator(ontology_twist=True)``."""
+
+    def _seed_two_peaking_inhabit_fragments(self, vault: Path) -> None:
+        """Seed two source fragments at ``phase=peaking, mode=inhabit, F7``.
+
+        Used by tests that need a plural source set with a known source
+        profile so the twist delta is predictable.
+        """
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-A",
+                primary=Frequency.F7,
+                phase=Phase.PEAKING,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+            ),
+            "A body about integration.",
+        )
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-B",
+                primary=Frequency.F7,
+                phase=Phase.PEAKING,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+            ),
+            "B body about empathy.",
+        )
+
+    def test_target_equals_source_collapses_to_baseline_prompt(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """When target==source the twist directive is a no-op (regression baseline).
+
+        Acceptance criterion: "when target == source, composition
+        behaves like today's draft." The prompt still carries the
+        ``## Twist directive`` header for transparency but does not
+        instruct any re-framing.
+        """
+        self._seed_two_peaking_inhabit_fragments(vault)
+
+        captured: dict[str, str] = {}
+
+        def llm(prompt: str) -> str:
+            """Capture the prompt for assertion and return a fixed body."""
+            captured["prompt"] = prompt
+            return "Drafted body."
+
+        generator = DraftGenerator(
+            llm=llm,
+            skills_root=skills_root,
+            ontology_twist=True,
+        )
+        # Operator targets peaking/inhabit — same as the source corpus.
+        spec = SeedSpec(
+            phases=(Phase.PEAKING,),
+            modes=(Mode.INHABIT,),
+        )
+
+        draft = generator.generate_seeded_draft(spec, vault_path=vault)
+
+        prompt = captured["prompt"]
+        assert "## Twist directive" in prompt
+        # No diff arrows and no paraphrase clause when profiles match.
+        assert "->" not in prompt
+        assert "Do not paraphrase" not in prompt
+        # Draft's twist_dimensions is empty because nothing diverged.
+        assert draft.twist_dimensions == ()
+        # Both profiles are recorded for transparency.
+        assert draft.source_profile is not None
+        assert draft.target_profile is not None
+        assert draft.source_profile.phase == "peaking"
+        assert draft.target_profile.phase == "peaking"
+
+    def test_partial_twist_names_diverging_dimensions(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A 1-2 dimension twist names exactly the divergent dimensions.
+
+        Acceptance criterion: "when target differs from source, the
+        prompt explicitly names the differing dimensions and instructs
+        the LLM to apply the target's style to the source's content."
+        """
+        self._seed_two_peaking_inhabit_fragments(vault)
+        # Also add a fragment in the WITHDRAWAL phase so the dimensional
+        # retrieval has material in that slice; the source profile will
+        # still be dominated by the peaking pair.
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-C",
+                primary=Frequency.F7,
+                phase=Phase.WITHDRAWAL,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+            ),
+            "Withdrawal body about shadow.",
+        )
+
+        captured: dict[str, str] = {}
+
+        def llm(prompt: str) -> str:
+            """Capture the prompt for assertion and return a fixed body."""
+            captured["prompt"] = prompt
+            return "Drafted body."
+
+        generator = DraftGenerator(
+            llm=llm,
+            skills_root=skills_root,
+            ontology_twist=True,
+        )
+        # Target asks for withdrawal+inhabit; source corpus is dominantly
+        # peaking+inhabit so only the phase dimension diverges.
+        spec = SeedSpec(
+            phases=(Phase.WITHDRAWAL,),
+            modes=(Mode.INHABIT,),
+        )
+
+        draft = generator.generate_seeded_draft(spec, vault_path=vault)
+
+        prompt = captured["prompt"]
+        assert "## Twist directive" in prompt
+        # The phase dimension diverges (peaking -> withdrawal) and that
+        # exact line is in the prompt.
+        assert "phase: peaking -> withdrawal" in prompt
+        assert "Do not paraphrase any single source verbatim" in prompt
+        # Mode matches on both sides so it is NOT named as divergent.
+        assert "mode:" not in prompt.split("## Twist directive")[1]
+        # Draft records the divergent dimensions.
+        assert draft.twist_dimensions == ("phase",)
+        assert draft.source_profile is not None
+        assert draft.target_profile is not None
+        assert draft.source_profile.phase == "peaking"
+        assert draft.target_profile.phase == "withdrawal"
+
+    def test_full_twist_names_every_diverging_dimension(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A full twist surfaces every divergent dimension in the prompt.
+
+        Acceptance criterion: "tests covering ... full twist (every
+        dimension diverges)."
+
+        Setup: source corpus is F7 / peaking / inhabit / medicine /
+        analytical. The vault also carries one out-of-profile fragment
+        on every divergent dimension so the per-dimension retrieval
+        finds material on each requested slice. The target profile is
+        driven entirely by the ontology so phase/mode/frequency can
+        diverge from the explicit retrieval flags.
+        """
+        from creek.classify.prompt import PromptOntology, WeightedDimension
+
+        # Two source-profile fragments — these drive the dominant source
+        # profile across every dimension.
+        for frag_id in ("frag-src-1", "frag-src-2"):
+            _write_fragment(
+                vault,
+                _build_fragment(
+                    frag_id=frag_id,
+                    primary=Frequency.F7,
+                    phase=Phase.PEAKING,
+                    mode=Mode.INHABIT,
+                    dosage=Dosage.MEDICINE,
+                    register=VoiceRegister.ANALYTICAL,
+                ),
+                f"{frag_id} body.",
+            )
+        # One off-profile fragment per divergent retrieval slice. These
+        # let the per-dimension OR retrieval find material on each
+        # requested dimension; they're outvoted in the source profile
+        # by the two source-profile fragments above.
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-withdrawal",
+                primary=Frequency.F7,
+                phase=Phase.WITHDRAWAL,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+                register=VoiceRegister.ANALYTICAL,
+            ),
+            "Withdrawal body.",
+        )
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-express",
+                primary=Frequency.F7,
+                phase=Phase.PEAKING,
+                mode=Mode.EXPRESS,
+                dosage=Dosage.MEDICINE,
+                register=VoiceRegister.ANALYTICAL,
+            ),
+            "Express body.",
+        )
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-f3",
+                primary=Frequency.F3,
+                phase=Phase.PEAKING,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+                register=VoiceRegister.ANALYTICAL,
+            ),
+            "F3 body.",
+        )
+
+        captured: dict[str, str] = {}
+
+        def llm(prompt: str) -> str:
+            """Capture the prompt for assertion and return a fixed body."""
+            captured["prompt"] = prompt
+            return "Drafted body."
+
+        generator = DraftGenerator(
+            llm=llm,
+            skills_root=skills_root,
+            ontology_twist=True,
+        )
+        ontology = PromptOntology(
+            prompt="x",
+            dosages=(WeightedDimension(value=Dosage.TOXIC, weight=0.8),),
+            voice_registers=(
+                WeightedDimension(value=VoiceRegister.PROPHETIC, weight=0.8),
+            ),
+        )
+        # Explicit flags drive both retrieval AND the target profile on
+        # phase/mode/frequency; the ontology supplies dosage + register
+        # for the target. All five target picks differ from the source
+        # corpus's dominant profile.
+        spec = SeedSpec(
+            phases=(Phase.WITHDRAWAL,),
+            modes=(Mode.EXPRESS,),
+            frequencies=(Frequency.F3,),
+            ontology=ontology,
+        )
+
+        draft = generator.generate_seeded_draft(spec, vault_path=vault)
+
+        prompt = captured["prompt"]
+        # All five dimensions diverge from source to target.
+        assert "phase: peaking -> withdrawal" in prompt
+        assert "stance: inhabit -> express" in prompt
+        assert "frequency: F7 -> F3" in prompt
+        assert "dosage: medicine -> toxic" in prompt
+        assert "voice register: analytical -> prophetic" in prompt
+        assert set(draft.twist_dimensions) == {
+            "phase",
+            "mode",
+            "frequency",
+            "dosage",
+            "voice_register",
+        }
+
+    def test_plurality_failure_raises_loudly(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """Single-source retrieval fails fast under twist composition.
+
+        Acceptance criterion: "Composition requires plurality of source
+        fragments — fails loudly if only one source matches."
+        """
+        from creek.generate.twist import PluralitySourceError
+
+        # Only one fragment matches the peaking phase.
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-only",
+                primary=Frequency.F7,
+                phase=Phase.PEAKING,
+                mode=Mode.INHABIT,
+            ),
+            "The only body.",
+        )
+
+        generator = DraftGenerator(
+            llm=lambda _p: "Drafted.",
+            skills_root=skills_root,
+            ontology_twist=True,
+        )
+        spec = SeedSpec(phases=(Phase.PEAKING,))
+
+        with pytest.raises(PluralitySourceError, match="at least two"):
+            generator.generate_seeded_draft(spec, vault_path=vault)
+
+    def test_frontmatter_records_source_target_and_twist_dimensions(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """Acceptance criterion: frontmatter records source/target profiles."""
+        self._seed_two_peaking_inhabit_fragments(vault)
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-C",
+                primary=Frequency.F7,
+                phase=Phase.WITHDRAWAL,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+            ),
+            "Withdrawal body.",
+        )
+
+        generator = DraftGenerator(
+            llm=lambda _p: "Drafted body.",
+            skills_root=skills_root,
+            ontology_twist=True,
+        )
+        spec = SeedSpec(
+            phases=(Phase.WITHDRAWAL,),
+            modes=(Mode.INHABIT,),
+        )
+
+        draft = generator.generate_seeded_draft(spec, vault_path=vault)
+        path = generator.save_draft(draft, vault)
+
+        post = frontmatter.load(str(path))
+        meta = post.metadata
+        assert meta["source_profile"]["phase"] == "peaking"
+        assert meta["target_profile"]["phase"] == "withdrawal"
+        assert meta["twist_dimensions"] == ["phase"]
+
+    def test_frontmatter_omits_twist_fields_when_flag_disabled(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """Default ``DraftGenerator`` (flag off) writes no twist fields.
+
+        The flag is gated while in development; opting out must leave
+        the existing frontmatter shape untouched.
+        """
+        self._seed_two_peaking_inhabit_fragments(vault)
+
+        generator = DraftGenerator(
+            llm=lambda _p: "Drafted body.",
+            skills_root=skills_root,
+        )
+        spec = SeedSpec(phases=(Phase.PEAKING,))
+
+        draft = generator.generate_seeded_draft(spec, vault_path=vault)
+        path = generator.save_draft(draft, vault)
+
+        post = frontmatter.load(str(path))
+        assert "source_profile" not in post.metadata
+        assert "target_profile" not in post.metadata
+        assert "twist_dimensions" not in post.metadata
+        # And the Draft itself carries the empty defaults.
+        assert draft.source_profile is None
+        assert draft.target_profile is None
+        assert draft.twist_dimensions == ()
+
+    def test_prompt_forbids_verbatim_paraphrase_under_twist(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """Acceptance criterion: the prompt forbids verbatim paraphrase.
+
+        The directive sentence from the issue body must appear in the
+        prompt whenever the twist composition path is active and any
+        dimension diverges.
+        """
+        self._seed_two_peaking_inhabit_fragments(vault)
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-C",
+                primary=Frequency.F7,
+                phase=Phase.WITHDRAWAL,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+            ),
+            "Withdrawal body.",
+        )
+
+        captured: dict[str, str] = {}
+
+        def llm(prompt: str) -> str:
+            """Capture the prompt for assertion and return a fixed body."""
+            captured["prompt"] = prompt
+            return "Drafted body."
+
+        generator = DraftGenerator(
+            llm=llm,
+            skills_root=skills_root,
+            ontology_twist=True,
+        )
+        spec = SeedSpec(
+            phases=(Phase.WITHDRAWAL,),
+            modes=(Mode.INHABIT,),
+        )
+
+        generator.generate_seeded_draft(spec, vault_path=vault)
+
+        prompt = captured["prompt"]
+        assert "Use the provided source musings" in prompt
+        assert "Do not paraphrase any single source verbatim" in prompt
+        assert "Recombine across the corpus" in prompt


### PR DESCRIPTION
## Summary

Implements issue #352 — the **ontology-twist composition** path for `creek draft`. A new `--ontology-twist` flag (gated off by default while epic #349 is in development) instructs the LLM to use the operator's actual vault musings as the conceptual content but voice them through a *target* ontology combination, naming the divergent dimensions and forbidding verbatim paraphrase.

- New `creek/generate/twist.py` module:
  - `OntologyProfile` — frozen one-pick-per-dimension snapshot (phase / mode / frequency / dosage / voice_register)
  - `source_profile_from_fragments()` — dominant-value aggregation across the retrieved corpus
  - `target_profile_from_spec()` — explicit-flag-wins-over-ontology resolution for the operator's target
  - `twist_dimensions()` — divergence diff (UNSPECIFIED on either side is treated as "no signal")
  - `format_twist_directive()` — renders the `## Twist directive` prompt block with the exact verbatim-paraphrase clause from the issue body
  - `require_plural_sources()` — fails loudly with `PluralitySourceError` when fewer than two sources matched
- `DraftGenerator.__init__` gains `ontology_twist: bool = False`; `generate_seeded_draft` computes the source/target profiles and threads a `## Twist directive` block into the prompt
- `Draft` dataclass extended with `source_profile`, `target_profile`, `twist_dimensions` (all optional, back-compat)
- `save_draft` emits the new fields in frontmatter only when populated
- `creek draft --ontology-twist` CLI flag; surfaces `PluralitySourceError` as a clean exit 1 and refuses to run without a seed

## Test plan

- [x] `./scripts/check-all.sh` exits 0 (4293 tests, coverage 93.66%, mypy strict, ruff clean, complexity ≤B, refurb/tryceratops clean)
- [x] **Acceptance: target == source** → `test_target_equals_source_collapses_to_baseline_prompt` confirms the twist directive collapses to a no-op
- [x] **Acceptance: partial twist** → `test_partial_twist_names_diverging_dimensions` confirms only divergent dimensions are named
- [x] **Acceptance: full twist** → `test_full_twist_names_every_diverging_dimension` confirms all five dimensions can diverge together
- [x] **Acceptance: plurality required** → `test_plurality_failure_raises_loudly` + CLI `test_draft_ontology_twist_plurality_failure_exits_cleanly`
- [x] **Acceptance: forbids verbatim paraphrase** → `test_prompt_forbids_verbatim_paraphrase_under_twist` confirms the exact clause from the issue body lands in the prompt
- [x] **Acceptance: frontmatter records profiles** → `test_frontmatter_records_source_target_and_twist_dimensions`
- [x] Default-off regression: `test_frontmatter_omits_twist_fields_when_flag_disabled`

Closes #352. Sub-issue of epic #349.

---
_Generated by [Claude Code](https://claude.ai/code/session_018XMbrkwQicpFoaSdaAmmEk)_