### PR TITLE
feat(aggregate): bubble UP weighted classifications when zooming out (#369)

### DIFF
--- a/creek-tools/creek/atomize/aggregate.py
+++ b/creek-tools/creek/atomize/aggregate.py
@@ -67,6 +67,12 @@ class AggregationConfig:
             strings; required for multi-exchange ``burst`` runs. Injected
             so tests and calibration scripts can stub the
             sentence-transformers dependency.
+        weighted_fill_floor: Minimum fraction of children that must
+            carry a non-``None`` :attr:`Fragment.weighted` before the
+            aggregator calls the holonic combiner. Must be in
+            ``[0.0, 1.0]``; below the floor the parent's ``weighted``
+            stays ``None`` rather than being fabricated from too-thin
+            input.
     """
 
     exchange_max_gap_minutes: int = 30
@@ -74,10 +80,21 @@ class AggregationConfig:
     session_max_gap_minutes: int = 360
     joiner: str = "\n\n"
     embedder: Callable[[list[str]], list[list[float]]] | None = None
-    # Minimum fraction of children that must carry weighted before we
-    # call the combiner; below this, the parent's ``weighted`` is None
-    # rather than a fabricated no-signal profile.
     weighted_fill_floor: float = 0.5
+
+    def __post_init__(self) -> None:
+        """Validate ``weighted_fill_floor`` stays inside ``[0.0, 1.0]``.
+
+        Catches typos (negative floor = combiner always fires; floor >
+        1.0 = combiner never fires) at construction time rather than
+        letting them silently change aggregation behaviour.
+        """
+        if not 0.0 <= self.weighted_fill_floor <= 1.0:
+            msg = (
+                "weighted_fill_floor must be in [0.0, 1.0], "
+                f"got {self.weighted_fill_floor}"
+            )
+            raise ValueError(msg)
 
 
 def aggregate(

--- a/creek-tools/creek/atomize/aggregate.py
+++ b/creek-tools/creek/atomize/aggregate.py
@@ -74,14 +74,9 @@ class AggregationConfig:
     session_max_gap_minutes: int = 360
     joiner: str = "\n\n"
     embedder: Callable[[list[str]], list[list[float]]] | None = None
-    # Issue #369: structural gate for weighted bubble-up. When the
-    # fraction of children that carry a non-``None`` ``Fragment.weighted``
-    # falls below this floor, the aggregated parent's ``weighted`` is
-    # ``None`` rather than the combiner's no-signal fallback — the
-    # vault is too sparsely classified for this aggregation to be
-    # meaningful. Confidence-based dampening is handled by the combiner
-    # itself (#367); this floor only decides whether to *call* the
-    # combiner.
+    # Minimum fraction of children that must carry weighted before we
+    # call the combiner; below this, the parent's ``weighted`` is None
+    # rather than a fabricated no-signal profile.
     weighted_fill_floor: float = 0.5
 
 
@@ -311,49 +306,17 @@ def _combine_children_weighted(
     children: list[Fragment],
     fill_floor: float,
 ) -> WeightedFragmentClassification | None:
-    """Combine children's weighted profiles into an aggregated-parent profile.
-
-    Issue #369: the zoom-out twin of #368's split bubble-up. Five terse
-    chat messages that classify as ``unclassified`` in isolation should
-    nonetheless aggregate into an exchange whose combined weighted
-    profile is non-empty and consistent — at least when enough of the
-    children carry any classification at all.
-
-    Two gates apply, in order:
-
-    1. **Structural fill floor**: the fraction of children with
-       non-``None`` ``Fragment.weighted`` must reach
-       ``config.weighted_fill_floor`` (default 0.5). The vault is too
-       sparsely classified for this aggregation to be meaningful
-       otherwise — return ``None`` honestly.
-    2. **Confidence-driven combine**: the holonic combiner (#367) takes
-       over, treating each child's ``overall_confidence`` as its mass
-       per the conviction x confidence contract. No explicit ``weights``
-       are passed, so length is nowhere in this call path.
-
-    Args:
-        children: Aggregated children.
-        fill_floor: Minimum fraction of children that must carry
-            ``Fragment.weighted``; below this the parent's ``weighted``
-            is ``None``.
-
-    Returns:
-        The combined :class:`WeightedFragmentClassification`, or
-        ``None`` when the fill-floor gate fires.
-    """
-    # Local import dodges the import-graph cycle:
-    # creek.models -> creek.classify.weighted -> creek.atomize ...
-    # at module-load time. Aggregation runs strictly after model
-    # construction, so a function-scoped import is safe.
+    """Return the combined weighted profile, or ``None`` below the fill floor."""
+    # Function-scoped import avoids the models -> classify -> atomize load-time cycle.
     from creek.classify.holonic import combine
 
-    weighted_children = [c.weighted for c in children if c.weighted is not None]
     if not children:
+        return None
+    weighted_children = [c.weighted for c in children if c.weighted is not None]
+    if not weighted_children:
         return None
     fraction_with_weighted = len(weighted_children) / len(children)
     if fraction_with_weighted < fill_floor:
-        return None
-    if not weighted_children:
         return None
     return combine(weighted_children)
 

--- a/creek-tools/creek/atomize/aggregate.py
+++ b/creek-tools/creek/atomize/aggregate.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from datetime import datetime
 
+    from creek.classify.weighted import WeightedFragmentClassification
     from creek.models import FragmentLevel
 
 __all__ = ["AggregateLevel", "AggregationConfig", "aggregate"]
@@ -73,6 +74,15 @@ class AggregationConfig:
     session_max_gap_minutes: int = 360
     joiner: str = "\n\n"
     embedder: Callable[[list[str]], list[list[float]]] | None = None
+    # Issue #369: structural gate for weighted bubble-up. When the
+    # fraction of children that carry a non-``None`` ``Fragment.weighted``
+    # falls below this floor, the aggregated parent's ``weighted`` is
+    # ``None`` rather than the combiner's no-signal fallback — the
+    # vault is too sparsely classified for this aggregation to be
+    # meaningful. Confidence-based dampening is handled by the combiner
+    # itself (#367); this floor only decides whether to *call* the
+    # combiner.
+    weighted_fill_floor: float = 0.5
 
 
 def aggregate(
@@ -278,6 +288,7 @@ def _build_parent(
     earliest = min(c.created for c in children)
     latest = max(c.created for c in children)
     source_keys = _contributing_source_keys(children) if cross_source else None
+    weighted = _combine_children_weighted(children, config.weighted_fill_floor)
     return Fragment(
         id=parent_id,
         title=title,
@@ -292,7 +303,59 @@ def _build_parent(
             _speakers(children),
             source_keys=source_keys,
         ),
+        weighted=weighted,
     )
+
+
+def _combine_children_weighted(
+    children: list[Fragment],
+    fill_floor: float,
+) -> WeightedFragmentClassification | None:
+    """Combine children's weighted profiles into an aggregated-parent profile.
+
+    Issue #369: the zoom-out twin of #368's split bubble-up. Five terse
+    chat messages that classify as ``unclassified`` in isolation should
+    nonetheless aggregate into an exchange whose combined weighted
+    profile is non-empty and consistent — at least when enough of the
+    children carry any classification at all.
+
+    Two gates apply, in order:
+
+    1. **Structural fill floor**: the fraction of children with
+       non-``None`` ``Fragment.weighted`` must reach
+       ``config.weighted_fill_floor`` (default 0.5). The vault is too
+       sparsely classified for this aggregation to be meaningful
+       otherwise — return ``None`` honestly.
+    2. **Confidence-driven combine**: the holonic combiner (#367) takes
+       over, treating each child's ``overall_confidence`` as its mass
+       per the conviction x confidence contract. No explicit ``weights``
+       are passed, so length is nowhere in this call path.
+
+    Args:
+        children: Aggregated children.
+        fill_floor: Minimum fraction of children that must carry
+            ``Fragment.weighted``; below this the parent's ``weighted``
+            is ``None``.
+
+    Returns:
+        The combined :class:`WeightedFragmentClassification`, or
+        ``None`` when the fill-floor gate fires.
+    """
+    # Local import dodges the import-graph cycle:
+    # creek.models -> creek.classify.weighted -> creek.atomize ...
+    # at module-load time. Aggregation runs strictly after model
+    # construction, so a function-scoped import is safe.
+    from creek.classify.holonic import combine
+
+    weighted_children = [c.weighted for c in children if c.weighted is not None]
+    if not children:
+        return None
+    fraction_with_weighted = len(weighted_children) / len(children)
+    if fraction_with_weighted < fill_floor:
+        return None
+    if not weighted_children:
+        return None
+    return combine(weighted_children)
 
 
 def _inherit_source(children: list[Fragment]) -> FragmentSource:

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -502,8 +502,8 @@ def _classify_one(
         llm: :class:`LLMClassifier` instance when ``method == "llm"``.
         confidence_threshold: Threshold below which the LLM is invoked
             during ``--method llm`` runs.
-        weighted_classification: When ``True`` (issue #366), the LLM
-            path dispatches through
+        weighted_classification: When ``True``, the LLM path
+            dispatches through
             :func:`creek.classify.weighted.classify_weighted`, persists
             the resulting weighted profile to
             :attr:`Fragment.weighted`, and derives the legacy
@@ -511,7 +511,8 @@ def _classify_one(
             :meth:`WeightedFragmentClassification.to_legacy` so
             downstream consumers stay synchronised. Has no effect on
             the rules path or on ``--method llm`` runs where the rule
-            classifier already cleared the confidence floor.
+            classifier already cleared the confidence floor; for those
+            fragments :attr:`Fragment.weighted` stays ``None``.
 
     Returns:
         ``(updated_fragment, skipped, reasoning)``. ``skipped`` is
@@ -543,7 +544,7 @@ def _classify_one_weighted(
     body: str,
     llm_config: LLMConfig,
 ) -> tuple[Fragment, bool, str]:
-    """Dispatch the LLM call through the #366 weighted classifier.
+    """Dispatch the LLM call through the weighted classifier.
 
     Replaces the single-pick LLM path when
     :attr:`ClassificationConfig.weighted_classification` is set.
@@ -675,11 +676,8 @@ def _maybe_reatomize_and_persist(
         classifier,
         config=reatomize_config,
     )
-    # Issue #368: when weighted classification is on, bubble each
-    # internal node's ``Fragment.weighted`` up from its children via
-    # the holonic combiner before persisting. The legacy fields on
-    # each fragment are unaffected by this pass — they already
-    # carry the per-node single-pick result from #366's adapter.
+    # Legacy single-pick fields on each fragment are untouched here;
+    # only ``Fragment.weighted`` is rolled up via the holonic combiner.
     if classification_config.weighted_classification:
         tree = bubble_up_weighted(tree)
     _persist_reatomized_children(

--- a/creek-tools/creek/classify/holonic.py
+++ b/creek-tools/creek/classify/holonic.py
@@ -1,12 +1,9 @@
-"""Holonic combine / decompose math for weighted classifications (#367).
+"""Holonic combine / decompose math for weighted classifications.
 
-This module is the heart of epic #364: the pure-math operators that
-combine a set of children's weighted classifications upward into a
-parent. The split (#368) and aggregate (#369) sub-issues call into
-:func:`combine` from the FEAT-023 reatomize orchestrator and the
-FEAT-022 aggregator respectively; this module performs no IO, no LLM
-calls, no file reads — just numerical aggregation over the dataclasses
-landed by #365.
+Pure-math operators that combine a set of children's weighted
+classifications upward into a parent, and that produce a soft prior
+for atoms decomposed from a parent. No IO, no LLM calls, no file
+reads — just numerical aggregation over weighted dataclasses.
 
 Why not length
 ==============
@@ -35,21 +32,19 @@ Confidence and divergence
 =========================
 
 Parent ``overall_confidence`` = ``confidence_weighted_mean x (1 -
-divergence_penalty x jsd_norm)`` where:
+divergence_penalty x jsd_norm x confidence_weighted_mean)`` where:
 
 - ``confidence_weighted_mean`` = ``sum_i(c_i x c_i) / sum_i(c_i)``.
   Children with higher confidence pull the mean toward themselves —
   a chorus of hedges does not manufacture parent confidence.
 - ``jsd_norm`` = mean Jensen-Shannon divergence across per-dimension
-  distributions, normalised to [0, 1]. Two hedged guesses pointing
-  different ways produce low JSD (they are hedging, not
-  disagreeing); two confident children pointing different ways
-  produce high JSD.
+  distributions, normalised to [0, 1].
+- The extra ``x mean_confidence`` scales the JSD penalty so hedged
+  disagreement dampens less than confident disagreement.
 
-Calibration of raw ``overall_confidence`` (FEAT-017 territory) is out
-of scope here — the combiner assumes the confidences it receives are
-already on a meaningful scale; if they are not, the fix lives in the
-classifier (#366), not the combiner.
+Calibration of the raw ``overall_confidence`` upstream of this module
+is out of scope; the combiner assumes confidences are already on a
+meaningful scale and propagates them faithfully.
 
 Limitations
 ===========
@@ -60,15 +55,16 @@ Limitations
   but unsure about Mode). This module is structured so adding that
   would be a per-dimension change without touching call sites.
 - Choosing the "intelligently sized basic unit" (the holarchy level
-  to surface from a reatomized tree) lives in #368, not here. This
+  to surface from a reatomized tree) is the integrator's job; this
   module returns a single :class:`WeightedFragmentClassification`
-  per ``combine`` call; the tree walk is the integrator's job.
+  per ``combine`` call.
 """
 
 from __future__ import annotations
 
 import math
 from enum import StrEnum
+from itertools import chain
 from typing import TYPE_CHECKING, TypeVar
 
 from creek.classify.weighted import (
@@ -215,16 +211,23 @@ def decompose_prior(
 
     Args:
         parent: The parent profile being decomposed.
-        n_atoms: How many atoms the parent is being split into.
-            Accepted today for forward compatibility; see the
-            limitations section in the module docstring.
+        n_atoms: How many atoms the parent is being split into; must
+            be a positive integer. Accepted today for forward
+            compatibility — see the limitations section in the module
+            docstring.
 
     Returns:
         A :class:`WeightedFragmentClassification` whose per-dimension
         tuples mirror the parent's and whose ``overall_confidence``
         is half the parent's (clamped to ``[0.0, 1.0]``).
+
+    Raises:
+        ValueError: When ``n_atoms`` is less than 1 (decomposing into
+            zero or negative atoms is a caller bug).
     """
-    del n_atoms  # accepted for forward compatibility; see docstring
+    if n_atoms < 1:
+        msg = f"n_atoms must be >= 1, got {n_atoms}"
+        raise ValueError(msg)
     return WeightedFragmentClassification(
         frequencies=parent.frequencies,
         phases=parent.phases,
@@ -352,17 +355,11 @@ def _combine_confidence(
         return _clamp(mean_confidence)
 
     jsd_norm = _mean_normalised_jsd(children, weights)
-    # The penalty is scaled by ``mean_confidence`` so hedged children
-    # disagreeing dampen less than confident children disagreeing
-    # (the user's load-bearing intent on epic #364): two children at
-    # confidence 0.3 pointing different ways are hedging — the
-    # divergence is real but the parent is still entitled to its
-    # already-low mean confidence. Two children at confidence 0.9
-    # pointing different ways are an actual conflict — the parent
-    # should drop further from the mean. Scaling by ``mean_confidence``
-    # gives the dampening factor an interpretation in
-    # ``[1 - divergence_penalty x mean_confidence², 1]``, which is
-    # what the unit tests anchor under ``TestDivergenceDampening``.
+    # Scale the penalty by ``mean_confidence`` so hedged children
+    # disagreeing dampen less than confident children disagreeing:
+    # confidence 0.3 vs 0.3 is hedging (real divergence, low stakes);
+    # confidence 0.9 vs 0.9 pointing different ways is a real conflict
+    # that should drop the parent further from the mean.
     damping_factor = 1.0 - divergence_penalty * jsd_norm * mean_confidence
     return _clamp(mean_confidence * damping_factor)
 
@@ -435,15 +432,12 @@ def _per_dimension_jsd(
 
     # All enum values that appear anywhere — the JSD is computed over
     # this support so each child's distribution is zero-padded
-    # consistently. ``chain.from_iterable`` keeps the nested-iterable
-    # flattening explicit and dodges the FURB179 readability flag.
-    from itertools import (
-        chain,  # locally scoped to keep the import cost off the module hot path
-    )
-
+    # consistently. Build an order map once so sorting is O(K log K)
+    # rather than O(K^2) via per-comparison ``list(enum_type).index``.
+    enum_order = {member: idx for idx, member in enumerate(enum_type)}
     support = sorted(
         set(chain.from_iterable(distributions)),
-        key=lambda v: list(enum_type).index(v),
+        key=enum_order.__getitem__,
     )
     total = sum(contributing_weights)
     mixture: dict[_DimT, float] = {

--- a/creek-tools/creek/classify/holonic.py
+++ b/creek-tools/creek/classify/holonic.py
@@ -399,6 +399,42 @@ def _mean_normalised_jsd(
     return sum(divergences) / len(divergences)
 
 
+def _contributing_distributions(
+    per_child_entries: Sequence[tuple[WeightedDimension[_DimT], ...]],
+    weights: Sequence[float],
+) -> tuple[list[dict[_DimT, float]], list[float]]:
+    """Build per-child probability distributions for the JSD computation.
+
+    Keeps only children with a positive effective weight and at least
+    one entry whose convictions sum above zero; each surviving child's
+    entries are normalised to sum to 1. Pulled out of
+    :func:`_per_dimension_jsd` so that function stays under the
+    cyclomatic-complexity gate.
+
+    Args:
+        per_child_entries: One tuple of weighted entries per child.
+        weights: Per-child effective weight vector, aligned with
+            ``per_child_entries``.
+
+    Returns:
+        ``(distributions, contributing_weights)`` — the normalised
+        per-child distributions and their matching effective weights,
+        both filtered to the contributing children only.
+    """
+    distributions: list[dict[_DimT, float]] = []
+    contributing_weights: list[float] = []
+    for entries, weight in zip(per_child_entries, weights, strict=True):
+        if weight <= 0 or not entries:
+            continue
+        total_entry_weight = sum(entry.weight for entry in entries)
+        if total_entry_weight <= 0:
+            continue
+        dist = {entry.value: entry.weight / total_entry_weight for entry in entries}
+        distributions.append(dist)
+        contributing_weights.append(weight)
+    return distributions, contributing_weights
+
+
 def _per_dimension_jsd(
     per_child_entries: Sequence[tuple[WeightedDimension[_DimT], ...]],
     weights: Sequence[float],
@@ -411,22 +447,10 @@ def _per_dimension_jsd(
     definition, but we want to skip dimensions where no comparison is
     possible rather than dilute the average with vacuous zeros).
     """
-    # Build per-child distributions (sum-to-1 per child, zeros for
-    # values the child did not mention) only for children with at
-    # least one entry on this dimension and a positive effective
-    # weight; the rest do not contribute to the JSD.
-    distributions: list[dict[_DimT, float]] = []
-    contributing_weights: list[float] = []
-    for entries, weight in zip(per_child_entries, weights, strict=True):
-        if weight <= 0 or not entries:
-            continue
-        total_entry_weight = sum(entry.weight for entry in entries)
-        if total_entry_weight <= 0:
-            continue
-        dist = {entry.value: entry.weight / total_entry_weight for entry in entries}
-        distributions.append(dist)
-        contributing_weights.append(weight)
-
+    distributions, contributing_weights = _contributing_distributions(
+        per_child_entries,
+        weights,
+    )
     if len(distributions) < 2:
         return None
 

--- a/creek-tools/creek/classify/holonic.py
+++ b/creek-tools/creek/classify/holonic.py
@@ -407,9 +407,7 @@ def _contributing_distributions(
 
     Keeps only children with a positive effective weight and at least
     one entry whose convictions sum above zero; each surviving child's
-    entries are normalised to sum to 1. Pulled out of
-    :func:`_per_dimension_jsd` so that function stays under the
-    cyclomatic-complexity gate.
+    entries are normalised to sum to 1.
 
     Args:
         per_child_entries: One tuple of weighted entries per child.

--- a/creek-tools/creek/classify/prompt.py
+++ b/creek-tools/creek/classify/prompt.py
@@ -55,19 +55,17 @@ from creek.classify.llm import (
     _sanitise_for_prompt,
 )
 
-# Promoted in #365: the weighted-tuple primitive and the YAML parser
-# helpers now live in :mod:`creek.classify.weighted` so the
-# fragment-level classifier (#366) and the holonic combiner (#367) can
-# import them without depending on this prompt-detection module.
-# Re-export them here so PR #359's public surface (``from
-# creek.classify.prompt import WeightedDimension, ...``) keeps working
-# unchanged. ``parse_weighted_yaml`` is the shared YAML parser core
-# that both this prompt-detection module and the fragment-level
-# classifier (#366) dispatch through.
-# Underscore-prefixed re-exports preserve the PR #359 import contract
-# (``from creek.classify.prompt import _coerce_weight``, etc.) for
-# tests and downstream callers that still target this module's
-# private namespace. The ``as`` aliases convert the imports into the
+# The weighted-tuple primitive and the YAML parser helpers live in
+# :mod:`creek.classify.weighted` and are re-exported here so callers
+# that imported them from :mod:`creek.classify.prompt` historically
+# keep working unchanged. ``parse_weighted_yaml`` is the shared YAML
+# parser core that both this prompt-detection module and the
+# fragment-level weighted classifier dispatch through.
+# Underscore-prefixed re-exports preserve the original import
+# contract (``from creek.classify.prompt import _coerce_weight``,
+# etc.) for tests and downstream callers that still target this
+# module's private namespace. The ``as`` aliases convert the imports
+# into the
 # re-export form ruff/pylint recognises so they do not trip on
 # unused-import.
 from creek.classify.weighted import (
@@ -290,11 +288,9 @@ def parse_prompt_ontology_response(
         ValueError: When the YAML payload is malformed, multi-document,
             or contains unexpected top-level keys.
     """
-    # The actual parsing lives on
-    # :func:`creek.classify.weighted.parse_weighted_yaml` so the
-    # prompt-level and fragment-level paths share one source of truth
-    # (issue #366). The wrapper here only adds the ``prompt`` echo
-    # onto the resulting dataclass.
+    # Parsing lives on :func:`creek.classify.weighted.parse_weighted_yaml`
+    # so the prompt-level and fragment-level paths share one source of
+    # truth; this wrapper only adds the ``prompt`` echo onto the result.
     parsed = parse_weighted_yaml(response)
     return PromptOntology(
         prompt=prompt,

--- a/creek-tools/creek/classify/reatomize.py
+++ b/creek-tools/creek/classify/reatomize.py
@@ -549,7 +549,7 @@ def _tree_for_parent(
     )
 
 
-# ---- Weighted bubble-up (issue #368) ---------------------------------------
+# ---- Weighted bubble-up ----------------------------------------------------
 
 
 def bubble_up_weighted(tree: ClassificationTree) -> ClassificationTree:
@@ -557,23 +557,22 @@ def bubble_up_weighted(tree: ClassificationTree) -> ClassificationTree:
 
     Walks the tree depth-first, combining each non-leaf node's
     children via :func:`creek.classify.holonic.combine` (which
-    enforces the conviction x confidence contract from #367 — length
-    is never the default mass) and stamping the combined
+    enforces the conviction x confidence contract — length is never
+    the default mass) and stamping the combined
     :class:`~creek.classify.weighted.WeightedFragmentClassification`
     onto the parent fragment's :attr:`weighted` field. Leaves flow
     through unchanged.
 
     Children whose :attr:`Fragment.weighted` is ``None`` are excluded
-    from the combine (zero-confidence pass-through, #367 invariant) —
-    they do not pollute the parent's profile. When every child's
-    weighted is ``None``, the parent's weighted stays ``None`` too
-    (honest "no signal" rather than fabricating one).
+    from the combine; they do not pollute the parent's profile. When
+    every child's weighted is ``None``, the parent's weighted stays
+    ``None`` too (honest "no signal" rather than fabricating one).
 
     Args:
         tree: The classification tree produced by
             :func:`classify_reatomize`. Each leaf is expected to
             already carry a :attr:`Fragment.weighted` populated by
-            #366's classifier; missing ``weighted`` is treated as
+            the LLM classifier; missing ``weighted`` is treated as
             "no signal" and skipped.
 
     Returns:

--- a/creek-tools/creek/classify/weighted.py
+++ b/creek-tools/creek/classify/weighted.py
@@ -1,37 +1,25 @@
-"""Shared weighted-classification model (issue #365).
-
-PR #359 (issue #350) introduced :class:`WeightedDimension` and a
-weighted-tuple-per-dimension schema for free-form essay prompts in
-:mod:`creek.classify.prompt`. This module promotes those primitives —
-the dataclass, the parser helpers, the allowed-top-level-keys set —
-to a shared location so fragment-level callers (atoms in the
-holarchy, sub-issues #366 / #367) can reuse them without inverting
-the dependency graph (epic #364).
+"""Shared weighted-classification model for the holonic classifier holarchy.
 
 Public surface:
 
 - :class:`WeightedDimension` — frozen generic dataclass holding a
   ``(value, weight)`` pair for a single ontology-dimension entry.
 - :class:`WeightedFragmentClassification` — Pydantic model that lives
-  on :class:`creek.models.Fragment.weighted`, mirroring
-  :class:`creek.classify.prompt.PromptOntology` minus the ``prompt``
-  field. Pydantic so it round-trips through vault YAML frontmatter via
+  on :class:`creek.models.Fragment.weighted`. Pydantic so it round-
+  trips through vault YAML frontmatter via
   ``Fragment.model_dump(mode="json")`` / ``Fragment.model_validate``
   without bespoke serialiser plumbing.
 - Parser helpers (:func:`_coerce_weight`, :func:`_parse_enum_value`,
   :func:`_parse_dimension`, :func:`_load_yaml_dict`) and the
-  :data:`_ALLOWED_TOP_LEVEL_KEYS` set are leading-underscore module
-  privates that :mod:`creek.classify.prompt` (and #366's
-  fragment-level classifier) import directly.
+  :data:`_ALLOWED_TOP_LEVEL_KEYS` set are shared between this module
+  and :mod:`creek.classify.prompt`.
 
 The legacy single-pick fields on :class:`creek.models.Fragment`
 (``frequency``, ``wavelength``, ``voice``) remain authoritative for
 downstream consumers (compile, lint, voice-skill generation). When
 ``weighted`` is populated, the two stay synchronised via the
 :meth:`WeightedFragmentClassification.from_single_pick` and
-:meth:`WeightedFragmentClassification.to_legacy` adapters; callers
-that populate ``weighted`` are responsible for keeping the legacy
-fields in sync until the broader epic completes and consumers migrate.
+:meth:`WeightedFragmentClassification.to_legacy` adapters.
 """
 
 from __future__ import annotations
@@ -117,8 +105,10 @@ class WeightedDimension(Generic[_DimT]):
 
 
 # YAML top-level keys accepted by :func:`_load_yaml_dict`. Shared
-# between the prompt-ontology detector (PR #359) and the fragment-level
-# classifier landing in #366 so the schema is enforced from one place.
+# between the prompt-ontology detector and the fragment-level
+# classifier so the schema is enforced from one place. ``reasoning``
+# is populated outside the YAML path (via :func:`_split_reasoning_and_yaml`)
+# and therefore is not a permitted top-level YAML key here.
 _ALLOWED_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
     {
         "frequencies",
@@ -253,10 +243,13 @@ def _parse_dimension(
 def _load_yaml_dict(yaml_text: str) -> dict[str, object]:
     """Parse the YAML payload and assert the documented shape.
 
-    Mirrors :func:`creek.classify.llm.parsing.validate_response` but
-    against the weighted-classification schema. Strips markdown fences
-    first so a model that nests its YAML inside ```yaml ... ``` round-
-    trips correctly. Rejects multi-document payloads (a classic
+    Shared schema validator for the weighted-classification YAML
+    surface — used by both the prompt-ontology detector and the
+    fragment-level classifier. Mirrors the role
+    :func:`creek.classify.llm.parsing.validate_response` plays for the
+    single-pick fragment classifier. Strips markdown fences first so
+    a model that nests its YAML inside ```yaml ... ``` round-trips
+    correctly. Rejects multi-document payloads (a classic
     LLM-output-spoofing vector) and any top-level keys outside
     :data:`_ALLOWED_TOP_LEVEL_KEYS`.
 
@@ -307,8 +300,8 @@ class WeightedFragmentClassification(BaseModel):
     heaviest signal sits at index 0.
 
     Lives on :attr:`Fragment.weighted` as ``WeightedFragmentClassification |
-    None``; ``None`` means "no weighted detection ran" (legacy vaults,
-    pre-#366 fragments). When set, the legacy single-pick fields
+    None``; ``None`` means "no weighted detection ran" (legacy
+    fragments). When set, the legacy single-pick fields
     (:attr:`Fragment.frequency`, :attr:`Fragment.wavelength`,
     :attr:`Fragment.voice`) can be derived from the top weighted pick
     per dimension via :meth:`to_legacy`; the reverse widening lives in
@@ -434,9 +427,9 @@ class WeightedFragmentClassification(BaseModel):
 # Canonical frequency → Spiral-Dynamics colour mapping. Mirrored from
 # the prompt-template constants in :mod:`creek.classify.llm.prompts`
 # but kept local here to avoid pulling the whole prompt-building
-# module into adapter code paths. The two must stay in sync; the
-# fragment-level classifier landing in #366 will exercise both, which
-# anchors the contract.
+# module into adapter code paths. ``test_weighted.py`` includes a
+# sync test that asserts the two maps agree, so a rename in one place
+# breaks the build at test time rather than silently drifting.
 _FREQUENCY_TO_COLOR: dict[Frequency, Color] = {
     Frequency.F1: Color.BEIGE,
     Frequency.F2: Color.PURPLE,
@@ -615,7 +608,7 @@ def _top_value_optional(
 # rather than mutually recursive at runtime.
 
 
-# ---- LLM-driven fragment classifier (issue #366) ---------------------------
+# ---- LLM-driven fragment classifier ----------------------------------------
 
 
 WEIGHTED_CLASSIFICATION_TEMPLATE: str = (
@@ -703,7 +696,7 @@ FRAGMENT CONTENT:
     .replace("__COLOR_BLOCK__", _COLOR_BLOCK)
     .replace("__FREQUENCY_COLOR_BLOCK__", _FREQUENCY_COLOR_BLOCK)
 )
-"""LLM prompt template for fragment-level weighted classification (#366).
+"""LLM prompt template for fragment-level weighted classification.
 
 Placeholders:
 
@@ -805,7 +798,7 @@ def classify_weighted(
     fragment: IngestedFragment,
     config: LLMConfig,
 ) -> WeightedFragmentClassification:
-    """Classify a fragment, returning a weighted ontology profile (#366).
+    """Classify a fragment, returning a weighted ontology profile.
 
     Fragment-level twin of
     :func:`creek.classify.prompt.detect_ontology`. Same dispatch path

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -265,21 +265,25 @@ class ClassificationConfig(BaseModel):
     """
 
     weighted_classification: bool = False
-    """Opt-in switch for epic-#364 / sub-issue-#366 weighted classification.
+    """Opt-in switch for weighted classification across the holarchy.
 
-    When ``False`` (default) the classify pipeline behaves exactly as
-    it did before #366: a single canonical pick per dimension lands on
+    When ``False`` (default) the classify pipeline writes a single
+    canonical pick per dimension to
     :attr:`Fragment.frequency` / :attr:`Fragment.wavelength` /
-    :attr:`Fragment.voice`, and :attr:`Fragment.weighted` stays
-    ``None``. When ``True``, every LLM-classified fragment also gets a
+    :attr:`Fragment.voice` and leaves :attr:`Fragment.weighted` as
+    ``None``. When ``True``, every fragment whose classification
+    actually reaches the LLM also gets a
     :class:`~creek.classify.weighted.WeightedFragmentClassification`
     persisted to :attr:`Fragment.weighted`; the legacy single-pick
     fields are derived from the top weighted entries via
     :meth:`WeightedFragmentClassification.to_legacy` so downstream
     consumers (lint, compile, voice-skill generation) keep working
-    unchanged. The rule-based classifier path is unaffected — only
-    LLM-classified fragments carry the weighted profile in this
-    sub-issue.
+    unchanged.
+
+    Rule-confident fragments are NOT re-classified —
+    :attr:`Fragment.weighted` stays ``None`` for those even with this
+    flag on. This preserves the FEAT-017 cost gate that already keeps
+    the LLM from re-running over high-confidence rule picks.
     """
 
 

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -20,10 +20,9 @@ from creek.time import now_la, today_la
 if TYPE_CHECKING:
     # Type-only import to expose :class:`WeightedFragmentClassification`
     # to mypy / IDEs. At runtime the symbol is resolved by the late
-    # import + ``Fragment.model_rebuild`` at the bottom of this module
-    # (issue #365); a runtime import here would re-introduce the
-    # circular import :mod:`creek.classify.weighted` imports back into
-    # :mod:`creek.models`.
+    # import + ``Fragment.model_rebuild`` at the bottom of this module;
+    # a runtime import here would re-introduce the circular import
+    # :mod:`creek.classify.weighted` imports back into :mod:`creek.models`.
     from creek.classify.weighted import WeightedFragmentClassification
 
 CompileTargetKind = Literal["thread", "eddy", "frequency_index"]
@@ -514,14 +513,12 @@ class Fragment(BaseModel):
     child_ids: list[str] = Field(default_factory=list)
     level: FragmentLevel = "document"
     structural_path: list[str] = Field(default_factory=list)
-    # Epic #364: optional weighted-ontology profile parallel to the
-    # legacy ``frequency`` / ``wavelength`` / ``voice`` fields.
-    # ``None`` means "no weighted detection ran" (legacy vaults,
-    # pre-#366 fragments); set by sub-issues #366 / #368 / #369. The
-    # forward reference is resolved at the bottom of this module via a
-    # late import of :mod:`creek.classify.weighted` so the
-    # circular-import risk between models and the classify package
-    # stays contained.
+    # Optional weighted-ontology profile parallel to the legacy
+    # ``frequency`` / ``wavelength`` / ``voice`` fields. ``None``
+    # means "no weighted detection ran" (legacy vaults). The forward
+    # reference is resolved at the bottom of this module via a late
+    # import of :mod:`creek.classify.weighted` so the circular-import
+    # risk between models and the classify package stays contained.
     weighted: "WeightedFragmentClassification | None" = None
 
     # BUG-009: the ``[prop-decorator]`` suppression below is a known
@@ -765,17 +762,11 @@ class CompiledPage(BaseModel):
 
 
 # Late import + ``Fragment.model_rebuild`` to resolve the
-# :attr:`Fragment.weighted` forward reference (epic #364). The import
-# lives at the bottom of the module so every name :mod:`creek.classify.weighted`
-# depends on (the enum types, the legacy classification models, the
-# Fragment class itself) is already defined; the partial-load state
-# is enough for ``weighted.py`` to import successfully and produce a
-# :class:`WeightedFragmentClassification` we can name in the rebuild.
-# The late import below is required to break the cycle between models
-# and the weighted-classification module. ``weighted.py`` needs Fragment
-# and the enum types from this module, so it must load AFTER them; that
-# puts our half of the cycle here at module bottom. The ``noqa: E402``
-# below marks the deliberate placement; a top-level import would fail
+# :attr:`Fragment.weighted` forward reference. ``weighted.py`` needs
+# Fragment and the enum types from this module, so it must load AFTER
+# them; that puts our half of the cycle here at module bottom. The
+# ``noqa: E402`` below marks the deliberate placement; a top-level
+# import would fail
 # with ``ImportError``.
 from creek.classify.weighted import (  # noqa: E402  # wrong-import-position
     WeightedFragmentClassification as _WeightedFragmentClassification,

--- a/creek-tools/tests/test_aggregate_bubble_up.py
+++ b/creek-tools/tests/test_aggregate_bubble_up.py
@@ -1,19 +1,4 @@
-"""Tests for the aggregate-path weighted bubble-up (issue #369).
-
-Covers the wiring of :func:`creek.classify.holonic.combine` into
-:func:`creek.atomize.aggregate.aggregate` so chat-style aggregations
-produce parents whose ``weighted`` field reflects the combined
-profile of their (per-message) children. The user's load-bearing
-intent — five terse messages individually classified as
-``unclassified`` aggregate into an exchange whose combined weighted
-profile is non-empty when enough of them carry signal, while five
-hedged-but-divergent messages dampen the parent's confidence — is
-exercised here alongside the conviction-over-length contract.
-
-These tests target :func:`_build_parent` directly via the public
-:func:`aggregate` entry point so the production code path matches
-the test path; building parents by hand would bypass the wiring.
-"""
+"""Tests for the aggregate-path weighted bubble-up."""
 
 from __future__ import annotations
 
@@ -171,8 +156,13 @@ class TestConvictionOverLengthAggregate:
 class TestFillFloorGate:
     """``weighted_fill_floor`` filters thinly-classified aggregations."""
 
-    def test_majority_unweighted_children_produces_none(self) -> None:
-        """3 of 5 children unweighted → parent.weighted is None (default 0.5 floor)."""
+    def test_below_fill_floor_produces_none(self) -> None:
+        """Fill fraction below the default 0.5 floor → parent.weighted is None.
+
+        Two of five children carry ``weighted``; that's 40% fill,
+        below the default ``weighted_fill_floor=0.5``, so the parent
+        stays ``None`` rather than carrying a thinly-sourced profile.
+        """
         children = [
             _message(0, weighted=_wfc(frequencies=((Frequency.F2, 0.8),))),
             _message(1, weighted=_wfc(frequencies=((Frequency.F2, 0.8),))),

--- a/creek-tools/tests/test_aggregate_bubble_up.py
+++ b/creek-tools/tests/test_aggregate_bubble_up.py
@@ -1,0 +1,291 @@
+"""Tests for the aggregate-path weighted bubble-up (issue #369).
+
+Covers the wiring of :func:`creek.classify.holonic.combine` into
+:func:`creek.atomize.aggregate.aggregate` so chat-style aggregations
+produce parents whose ``weighted`` field reflects the combined
+profile of their (per-message) children. The user's load-bearing
+intent — five terse messages individually classified as
+``unclassified`` aggregate into an exchange whose combined weighted
+profile is non-empty when enough of them carry signal, while five
+hedged-but-divergent messages dampen the parent's confidence — is
+exercised here alongside the conviction-over-length contract.
+
+These tests target :func:`_build_parent` directly via the public
+:func:`aggregate` entry point so the production code path matches
+the test path; building parents by hand would bypass the wiring.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from creek.atomize.aggregate import AggregationConfig, aggregate
+from creek.classify.weighted import (
+    WeightedDimension,
+    WeightedFragmentClassification,
+)
+from creek.models import (
+    Fragment,
+    FragmentSource,
+    Frequency,
+    Phase,
+    SourcePlatform,
+)
+
+# ---- Fixture helpers -------------------------------------------------------
+
+
+_BASE_TIME = datetime(2026, 1, 1, 9, 0, tzinfo=UTC)
+
+
+def _wfc(
+    *,
+    frequencies: tuple[tuple[Frequency, float], ...] = (),
+    phases: tuple[tuple[Phase, float], ...] = (),
+    overall_confidence: float = 0.7,
+) -> WeightedFragmentClassification:
+    """Build a :class:`WeightedFragmentClassification` from concise tuples."""
+    return WeightedFragmentClassification(
+        frequencies=tuple(WeightedDimension(value=v, weight=w) for v, w in frequencies),
+        phases=tuple(WeightedDimension(value=v, weight=w) for v, w in phases),
+        overall_confidence=overall_confidence,
+    )
+
+
+def _message(
+    idx: int,
+    *,
+    weighted: WeightedFragmentClassification | None = None,
+    minutes_offset: int = 0,
+) -> Fragment:
+    """Build a chat-style :class:`Fragment` at level ``document``."""
+    return Fragment(
+        id=f"frag-msg00{idx:09d}",
+        title=f"Message {idx}",
+        source=FragmentSource(
+            platform=SourcePlatform.DISCORD,
+            channel="#testing",
+            conversation_id="conv-1",
+        ),
+        created=_BASE_TIME + timedelta(minutes=minutes_offset),
+        level="document",
+        weighted=weighted,
+    )
+
+
+# ---- _build_parent populates weighted on aggregated parent -----------------
+
+
+class TestAggregateBubbleUpHappyPaths:
+    """When children carry signal, the aggregated parent reflects it."""
+
+    def test_five_agreeing_messages_produce_f2_dominant_exchange(self) -> None:
+        """Five high-confidence F2 chats aggregate into an F2-dominant exchange."""
+        children = [
+            _message(
+                i,
+                weighted=_wfc(
+                    frequencies=((Frequency.F2, 0.8),),
+                    overall_confidence=0.85,
+                ),
+                minutes_offset=i,
+            )
+            for i in range(5)
+        ]
+        parents = aggregate(children, level="exchange", config=AggregationConfig())
+        assert len(parents) == 1
+        parent_weighted = parents[0].weighted
+        assert parent_weighted is not None
+        assert parent_weighted.frequencies[0].value is Frequency.F2
+
+    def test_five_divergent_messages_dampens_confidence(self) -> None:
+        """Confident messages across F1/F3/F5/F7/F9 dampen the parent confidence."""
+        diverged_freqs = (
+            Frequency.F1,
+            Frequency.F3,
+            Frequency.F5,
+            Frequency.F7,
+            Frequency.F9,
+        )
+        children = [
+            _message(
+                i,
+                weighted=_wfc(
+                    frequencies=((freq, 0.9),),
+                    overall_confidence=0.9,
+                ),
+                minutes_offset=i,
+            )
+            for i, freq in enumerate(diverged_freqs)
+        ]
+        parents = aggregate(children, level="exchange", config=AggregationConfig())
+        assert len(parents) == 1
+        weighted = parents[0].weighted
+        assert weighted is not None
+        assert weighted.overall_confidence < 0.9
+
+
+# ---- The user's load-bearing case ------------------------------------------
+
+
+class TestConvictionOverLengthAggregate:
+    """One confident-short F3 message beats four hedged-long F5 messages."""
+
+    def test_confident_short_beats_hedged_long_in_aggregation(self) -> None:
+        """Load-bearing fixture for #369 — see PR conversation."""
+        confident_short = _message(
+            0,
+            weighted=_wfc(
+                frequencies=((Frequency.F3, 0.9),),
+                overall_confidence=0.9,
+            ),
+            minutes_offset=0,
+        )
+        hedged_long = [
+            _message(
+                i + 1,
+                weighted=_wfc(
+                    frequencies=((Frequency.F5, 0.3),),
+                    overall_confidence=0.2,
+                ),
+                minutes_offset=i + 1,
+            )
+            for i in range(4)
+        ]
+        parents = aggregate(
+            [confident_short, *hedged_long],
+            level="exchange",
+            config=AggregationConfig(),
+        )
+        assert len(parents) == 1
+        weighted = parents[0].weighted
+        assert weighted is not None
+        assert weighted.frequencies[0].value is Frequency.F3
+
+
+# ---- The fill-floor structural gate ----------------------------------------
+
+
+class TestFillFloorGate:
+    """``weighted_fill_floor`` filters thinly-classified aggregations."""
+
+    def test_majority_unweighted_children_produces_none(self) -> None:
+        """3 of 5 children unweighted → parent.weighted is None (default 0.5 floor)."""
+        children = [
+            _message(0, weighted=_wfc(frequencies=((Frequency.F2, 0.8),))),
+            _message(1, weighted=_wfc(frequencies=((Frequency.F2, 0.8),))),
+            _message(2, weighted=None, minutes_offset=2),
+            _message(3, weighted=None, minutes_offset=3),
+            _message(4, weighted=None, minutes_offset=4),
+        ]
+        parents = aggregate(children, level="exchange", config=AggregationConfig())
+        assert parents[0].weighted is None
+
+    def test_majority_weighted_passes_the_gate(self) -> None:
+        """3 of 5 children weighted → parent.weighted is non-None."""
+        children = [
+            _message(
+                0,
+                weighted=_wfc(frequencies=((Frequency.F2, 0.8),)),
+                minutes_offset=0,
+            ),
+            _message(
+                1,
+                weighted=_wfc(frequencies=((Frequency.F2, 0.8),)),
+                minutes_offset=1,
+            ),
+            _message(
+                2,
+                weighted=_wfc(frequencies=((Frequency.F2, 0.8),)),
+                minutes_offset=2,
+            ),
+            _message(3, weighted=None, minutes_offset=3),
+            _message(4, weighted=None, minutes_offset=4),
+        ]
+        parents = aggregate(children, level="exchange", config=AggregationConfig())
+        assert parents[0].weighted is not None
+
+    def test_all_unweighted_produces_none(self) -> None:
+        """Every child unweighted → no fabrication."""
+        children = [_message(i, weighted=None, minutes_offset=i) for i in range(3)]
+        parents = aggregate(children, level="exchange", config=AggregationConfig())
+        assert parents[0].weighted is None
+
+
+# ---- Zero-confidence pass-through (signal-side gate via #367 invariant) ----
+
+
+class TestZeroConfidencePassThrough:
+    """Zero-confidence children contribute nothing to the combine."""
+
+    def test_zero_confidence_children_passed_floor_yield_no_signal(self) -> None:
+        """All weighted but ``overall_confidence=0`` → parent profile empty."""
+        children = [
+            _message(
+                i,
+                weighted=_wfc(
+                    frequencies=((Frequency.F2, 0.8),),
+                    overall_confidence=0.0,
+                ),
+                minutes_offset=i,
+            )
+            for i in range(3)
+        ]
+        parents = aggregate(children, level="exchange", config=AggregationConfig())
+        weighted = parents[0].weighted
+        # The fill-floor gate accepts (all children have non-None
+        # weighted), but the combiner returns the empty WFC because
+        # every child carries zero confidence.
+        assert weighted is not None
+        assert weighted.frequencies == ()
+        assert weighted.overall_confidence == 0.0
+
+
+# ---- Single-child aggregation is idempotent (combiner invariant) -----------
+
+
+class TestSingleChildAggregation:
+    """A one-child aggregation reproduces the child's weighted profile."""
+
+    def test_single_message_aggregation_mirrors_child(self) -> None:
+        """Idempotence on N=1 holds through the wiring."""
+        child = _message(
+            0,
+            weighted=_wfc(
+                frequencies=((Frequency.F3, 0.8),),
+                phases=((Phase.RISING, 0.7),),
+                overall_confidence=0.85,
+            ),
+        )
+        parents = aggregate([child], level="exchange", config=AggregationConfig())
+        parent = parents[0]
+        assert parent.weighted is not None
+        assert parent.weighted.frequencies[0].value is Frequency.F3
+        assert parent.weighted.overall_confidence == pytest.approx(0.85)
+
+
+# ---- Idempotence of aggregate() with weighted children ---------------------
+
+
+class TestAggregateIdempotence:
+    """Re-running aggregate produces parents with identical ``weighted`` fields."""
+
+    def test_re_aggregate_produces_byte_identical_weighted(self) -> None:
+        """FEAT-022 idempotence holds for the new ``weighted`` field too."""
+        children = [
+            _message(
+                i,
+                weighted=_wfc(
+                    frequencies=((Frequency.F2, 0.8),),
+                    overall_confidence=0.85,
+                ),
+                minutes_offset=i,
+            )
+            for i in range(5)
+        ]
+        first = aggregate(children, level="exchange", config=AggregationConfig())
+        second = aggregate(children, level="exchange", config=AggregationConfig())
+        # Both runs produce one parent each; their ``weighted`` is equal.
+        assert first[0].weighted == second[0].weighted

--- a/creek-tools/tests/test_aggregate_bubble_up.py
+++ b/creek-tools/tests/test_aggregate_bubble_up.py
@@ -279,3 +279,19 @@ class TestAggregateIdempotence:
         second = aggregate(children, level="exchange", config=AggregationConfig())
         # Both runs produce one parent each; their ``weighted`` is equal.
         assert first[0].weighted == second[0].weighted
+
+
+class TestAggregationConfigValidation:
+    """``AggregationConfig`` rejects out-of-range ``weighted_fill_floor`` values."""
+
+    @pytest.mark.parametrize("bad_floor", [-0.01, -1.0, 1.01, 2.0])
+    def test_out_of_range_fill_floor_raises(self, bad_floor: float) -> None:
+        """A floor outside ``[0.0, 1.0]`` fails fast at construction time."""
+        with pytest.raises(ValueError, match="weighted_fill_floor must be in"):
+            AggregationConfig(weighted_fill_floor=bad_floor)
+
+    @pytest.mark.parametrize("good_floor", [0.0, 0.5, 1.0])
+    def test_in_range_fill_floor_accepted(self, good_floor: float) -> None:
+        """Boundary values 0.0 and 1.0 are both accepted; mid-range works."""
+        config = AggregationConfig(weighted_fill_floor=good_floor)
+        assert config.weighted_fill_floor == good_floor

--- a/creek-tools/tests/test_holonic.py
+++ b/creek-tools/tests/test_holonic.py
@@ -550,15 +550,19 @@ class TestDecomposePrior:
 class TestDefensiveBranches:
     """Defensive code paths covering pathological inputs."""
 
-    def test_clamp_handles_nan_confidence(self) -> None:
-        """A NaN per-child confidence produces a finite parent confidence."""
+    def test_nan_confidence_collapses_to_zero(self) -> None:
+        """A NaN per-child confidence does not propagate to the parent."""
         import math
 
         child = _wfc(overall_confidence=float("nan"))
         parent = combine([child, child])
-        # NaN <= 0 is False, so the effective weight stays NaN; the
-        # downstream clamp catches the non-finite value and returns 0.
+        # ``max(0.0, nan) == 0.0`` in CPython (nan > 0.0 is False), so
+        # ``_resolve_weights`` silences the NaN at the door: the
+        # effective weight becomes 0.0, the sum is 0.0, and the
+        # all-zero-weights short-circuit returns a zero-confidence
+        # parent. The clamp is therefore never reached on this path.
         assert math.isfinite(parent.overall_confidence)
+        assert parent.overall_confidence == 0.0
 
     def test_explicit_zero_weights_returns_empty_dimensions(self) -> None:
         """All-zero explicit weights collapse the parent to no signal."""

--- a/creek-tools/tests/test_reatomize_bubble_up.py
+++ b/creek-tools/tests/test_reatomize_bubble_up.py
@@ -22,6 +22,7 @@ import pytest
 
 from creek.classify.reatomize import (
     ClassificationTree,
+    StopReason,
     bubble_up_weighted,
     choose_intelligent_unit,
 )
@@ -32,6 +33,7 @@ from creek.classify.weighted import (
 from creek.ingest.base import IngestedFragment
 from creek.models import (
     Fragment,
+    FragmentLevel,
     FragmentSource,
     Frequency,
     Phase,
@@ -62,22 +64,22 @@ def _make_node(
     children: tuple[ClassificationTree, ...] = (),
     confidence: float = 0.7,
     depth: int = 0,
-    level: str = "paragraph",
+    level: FragmentLevel = "paragraph",
 ) -> ClassificationTree:
     """Build a :class:`ClassificationTree` node with a fragment + weighted."""
     fragment = Fragment(
         id=fragment_id,
         title=fragment_id,
         source=FragmentSource(platform=SourcePlatform.MARKDOWN),
-        level=level,  # type: ignore[arg-type]
+        level=level,
         weighted=weighted,
     )
     ingested = IngestedFragment(fragment=fragment, body="(test body)")
-    stop = "accepted" if not children else "split"
+    stop: StopReason = "accepted" if not children else "split"
     return ClassificationTree(
         fragment=ingested,
         confidence=confidence,
-        stop_reason=stop,  # type: ignore[arg-type]
+        stop_reason=stop,
         children=children,
         depth=depth,
     )
@@ -307,8 +309,8 @@ class TestChooseIntelligentUnit:
         chosen = choose_intelligent_unit(parent, threshold=0.6)
         assert chosen.fragment.fragment.id == "frag-child0000001"
 
-    def test_parent_materially_beats_child(self) -> None:
-        """When the parent materially exceeds the child, the parent wins."""
+    def test_below_threshold_child_returns_parent(self) -> None:
+        """A child below the threshold yields the parent as the chosen unit."""
         weak_child = _make_node(
             fragment_id="frag-weak00000001",
             weighted=_wfc(overall_confidence=0.5),
@@ -321,6 +323,54 @@ class TestChooseIntelligentUnit:
         chosen = choose_intelligent_unit(strong_parent, threshold=0.6)
         # Child at 0.5 is below threshold; the parent at 0.85 wins.
         assert chosen.fragment.fragment.id == "frag-strong000001"
+
+    def test_parent_materially_beats_above_threshold_child(self) -> None:
+        """Parent that materially outperforms an above-threshold child wins.
+
+        Anchors the ``node_confidence - desc_confidence > material_delta``
+        branch in :func:`_choose_intelligent_unit_recursive`. Both
+        candidates clear the threshold; the parent's confidence is far
+        enough above the child's to count as a material improvement,
+        so the parent is the better grain.
+        """
+        # Child clears threshold (0.6) at 0.65; parent at 0.85.
+        # Delta is 0.20, comfortably above the default material_delta=0.05.
+        clearing_child = _make_node(
+            fragment_id="frag-cclear000001",
+            weighted=_wfc(overall_confidence=0.65),
+        )
+        much_stronger_parent = _make_node(
+            fragment_id="frag-pstrong00001",
+            weighted=_wfc(overall_confidence=0.85),
+            children=(clearing_child,),
+        )
+        chosen = choose_intelligent_unit(much_stronger_parent, threshold=0.6)
+        assert chosen.fragment.fragment.id == "frag-pstrong00001"
+
+    def test_material_delta_tunable_promotes_child(self) -> None:
+        """A larger ``material_delta`` lets the descendant win on the same fixture.
+
+        The previous test pins the parent because the default
+        ``material_delta=0.05`` is much smaller than the parent/child
+        gap. Bumping ``material_delta`` past the gap should flip the
+        outcome: the parent no longer materially beats the child, and
+        the finer-grained descendant wins.
+        """
+        clearing_child = _make_node(
+            fragment_id="frag-cclear000002",
+            weighted=_wfc(overall_confidence=0.65),
+        )
+        parent = _make_node(
+            fragment_id="frag-pgapwide0001",
+            weighted=_wfc(overall_confidence=0.85),
+            children=(clearing_child,),
+        )
+        chosen = choose_intelligent_unit(
+            parent,
+            threshold=0.6,
+            material_delta=0.5,
+        )
+        assert chosen.fragment.fragment.id == "frag-cclear000002"
 
     def test_no_descendant_clears_threshold(self) -> None:
         """When nothing reaches the threshold the root is returned."""

--- a/creek-tools/tests/test_weighted.py
+++ b/creek-tools/tests/test_weighted.py
@@ -25,7 +25,7 @@ Three concerns get exercised here:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
@@ -55,6 +55,7 @@ from creek.models import (
     Confidence,
     Dosage,
     Fragment,
+    FragmentLevel,
     FragmentSource,
     Frequency,
     FrequencyClassification,
@@ -73,12 +74,15 @@ if TYPE_CHECKING:
 # ---- Fixtures --------------------------------------------------------------
 
 
-def _make_fragment(**overrides: object) -> Fragment:
+def _make_fragment(**overrides: Any) -> Fragment:
     """Build a minimal :class:`Fragment` with optional field overrides.
 
     The default fragment is the same shape ``test_minimal_creation``
     uses in :mod:`tests.test_models` so behaviour stays comparable
-    across the test suite.
+    across the test suite. Pydantic validates every keyword at
+    construction time, so the broad ``Any`` typing on ``**overrides``
+    is safe — a wrong field name or value fails fast on the
+    constructor call.
 
     Args:
         **overrides: Field values to splice onto the default Fragment.
@@ -86,13 +90,15 @@ def _make_fragment(**overrides: object) -> Fragment:
     Returns:
         A constructed :class:`Fragment` ready for use in a test body.
     """
-    defaults: dict[str, object] = {
-        "id": "frag-000000000001",
-        "title": "Test Fragment",
-        "source": FragmentSource(platform=SourcePlatform.CLAUDE),
-    }
-    defaults.update(overrides)
-    return Fragment(**defaults)  # type: ignore[arg-type]
+    return Fragment(
+        id=overrides.pop("id", "frag-000000000001"),
+        title=overrides.pop("title", "Test Fragment"),
+        source=overrides.pop(
+            "source",
+            FragmentSource(platform=SourcePlatform.CLAUDE),
+        ),
+        **overrides,
+    )
 
 
 # ---- Public-surface tests --------------------------------------------------
@@ -502,6 +508,21 @@ class TestToLegacy:
         """Every concrete frequency has a colour assignment."""
         assert _FREQUENCY_TO_COLOR[freq] is not Color.UNCLASSIFIED
 
+    def test_color_mapping_matches_canonical_source(self) -> None:
+        """``_FREQUENCY_TO_COLOR`` agrees with ``indexes.FREQUENCY_COLORS``.
+
+        The two maps must stay in sync — a rename in one place that
+        does not reach the other would silently mis-colour a fragment
+        on the boundary between the classify and generate paths.
+        """
+        from creek.generate.indexes import FREQUENCY_COLORS
+
+        # Every key in the classify-side map appears in the
+        # generate-side map and points at the same colour string.
+        assert set(_FREQUENCY_TO_COLOR) == set(FREQUENCY_COLORS)
+        for freq, color in _FREQUENCY_TO_COLOR.items():
+            assert color.value == FREQUENCY_COLORS[freq]
+
 
 class TestRoundTrip:
     """The widening / collapsing pair is inverse on non-unclassified fields."""
@@ -655,7 +676,7 @@ def _make_ingested(
     body: str,
     *,
     title: str = "Test fragment",
-    level: str = "document",
+    level: FragmentLevel = "document",
 ) -> IngestedFragment:
     """Build a minimal :class:`IngestedFragment` for use in classifier tests.
 
@@ -672,7 +693,7 @@ def _make_ingested(
             id="frag-classify00001",
             title=title,
             source=FragmentSource(platform=SourcePlatform.CLAUDE),
-            level=level,  # type: ignore[arg-type]
+            level=level,
         ),
         body=body,
     )
@@ -1001,3 +1022,88 @@ class TestClassifyEngineWiring:
         # And the rest of the contract: not skipped, reasoning carries.
         assert was_skipped is False
         assert "F3 / Red" in reasoning
+
+    def test_rule_confident_short_circuit_leaves_weighted_none(
+        self,
+        llm_config: LLMConfig,
+    ) -> None:
+        """Rule-confident fragments bypass the weighted path entirely.
+
+        When the rule classifier already clears the confidence floor,
+        ``_classify_one`` returns the rule result with
+        ``was_skipped=True`` *before* dispatching to either the legacy
+        or weighted LLM paths. ``Fragment.weighted`` therefore stays
+        ``None`` even when ``weighted_classification`` is on. This
+        preserves the FEAT-017 cost gate.
+        """
+        from creek.classify.classify_engine import _classify_one
+
+        fragment = Fragment(
+            id="frag-conf0000001",
+            title="Confident fragment",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+        )
+
+        # Stub the rule classifier so the test does not depend on real
+        # keyword rules. Returns a F3-primary fragment at maximum
+        # confidence, which is the contract the FEAT-017 short-circuit
+        # checks before either LLM path fires.
+        class _ConfidentRules:
+            """Always returns a confident F3 classification."""
+
+            def classify(self, frag: Fragment, content: str = "") -> Fragment:
+                """Return *frag* with frequency.primary forced to F3."""
+                del content
+                return frag.model_copy(
+                    update={
+                        "frequency": FrequencyClassification(
+                            primary=Frequency.F3,
+                        ),
+                    },
+                )
+
+            def confidence_score(
+                self,
+                frag: Fragment,
+                content: str = "",
+            ) -> float:
+                """Always-confident floor that clears any threshold."""
+                del frag, content
+                return 1.0
+
+        class _DispatchedLLM:
+            """Records whether the weighted LLM path was hit."""
+
+            def __init__(self, config: LLMConfig) -> None:
+                """Capture the config and zero the dispatched counter."""
+                self.config = config
+                self.dispatched = False
+
+            def classify_with_reasoning(
+                self,
+                frag: Fragment,
+                content: str = "",
+            ) -> object:
+                """Mark dispatch and raise — must not be invoked here."""
+                del frag, content
+                self.dispatched = True
+                msg = "legacy classify_with_reasoning should not be invoked"
+                raise AssertionError(msg)
+
+        stub_llm = _DispatchedLLM(llm_config)
+        updated, was_skipped, reasoning = _classify_one(
+            fragment=fragment,
+            body="(test body)",
+            method="llm",
+            rules=_ConfidentRules(),  # type: ignore[arg-type]
+            llm=stub_llm,  # type: ignore[arg-type]
+            confidence_threshold=0.5,
+            weighted_classification=True,
+        )
+
+        # The rule path took the fragment; weighted stays None.
+        assert was_skipped is True
+        assert updated.weighted is None
+        assert reasoning == ""
+        # And the weighted LLM stub was never called.
+        assert stub_llm.dispatched is False


### PR DESCRIPTION
## Summary

The zoom-out twin of #368. When FEAT-022's `aggregate()` stitches `document`-level chats into `exchange` / `burst` / `session` parents, this PR wires the holonic combiner (#367) into `_build_parent` so each aggregated parent carries a `Fragment.weighted` derived from its children's weighted profiles — conviction × confidence weighted, per the #367 contract. Length is nowhere in the call path.

## Stacked on #383 (#368)

Branch base is `claude/issue-368-split-bubble-up` (PR #383 ← #382 ← #379 ← #378 ← PR #359). #369 calls `holonic.combine` (introduced in #367, available since #382 landed in the stack); no overlap with #368's split-path changes, so the two are siblings under #367 in terms of code dependency but stacked here for review-order simplicity.

## What ships

- **`AggregationConfig.weighted_fill_floor: float = 0.5`** — structural gate. When the fraction of children with non-`None` `Fragment.weighted` falls below this floor, the parent's `weighted` is `None` (the vault is too sparsely classified for this aggregation to be meaningful). Confidence-based dampening is left to the combiner; this gate only decides whether to *call* it.
- **`_combine_children_weighted(children, fill_floor)`** helper: filters `None`-weighted children, applies the fill-floor, calls `holonic.combine` with **no** `weights` override (the default per-child weight is each child's `overall_confidence`).
- **Wiring in `_build_parent`**: the aggregated parent's `Fragment.weighted` is now populated by the helper above. All other behaviour (deterministic ID, `child_ids` order, joiner-concatenated titles, source inheritance, tags) is unchanged.

## Tests (9 new, all green)

- Five high-confidence F2 chats aggregate into an F2-dominant exchange.
- Five confident-but-divergent F1/F3/F5/F7/F9 messages dampen confidence below 0.9 (divergence penalty fires).
- **Conviction-over-length**: 1 confident-short F3 message beats 4 hedged-long F5 messages in the exchange's top frequency.
- Fill-floor gate: 3-of-5 unweighted → `parent.weighted is None`.
- Fill-floor gate: 3-of-5 weighted → `parent.weighted is not None`.
- All-unweighted → no fabrication (`parent.weighted is None`).
- Zero-confidence pass-through: every child weighted at `overall_confidence=0` yields a non-`None` parent profile that is empty (honest "no signal").
- Single-child aggregation: combiner idempotence holds end-to-end.
- FEAT-022 idempotence preserved — re-aggregating the same children yields byte-identical `parent.weighted`.

## Acceptance criteria (#369)

- [x] `_build_parent` populates `parent.weighted` per the documented rules.
- [x] All 6 of the issue's test scenarios pass (and 3 extras for invariants).
- [x] **Conviction-over-length** load-bearing test passes.
- [x] All-`None`-weighted children → `parent.weighted is None`.
- [x] All-weighted-but-zero-confidence → empty `parent.weighted` with confidence 0.
- [x] FEAT-022 idempotence preserved.
- [x] The combiner is invoked with no `weights` override; length/char-count/token-count is nowhere in the call path.

## Quality

- **Tests**: 4385 pass.
- **Aggregate coverage**: 93.72% (above 90% gate).
- **Mypy strict**: 0 issues across 132 source files.
- **Pylint**: 9.93/10.
- **Ruff lint + format / bandit / refurb / tryceratops**: clean.

## Test plan

- [x] `uv run pytest tests/test_aggregate_bubble_up.py -q` → 9 passed.
- [x] `uv run pytest tests/ --deselect tests/test_purge.py::test_cli_purge_vault_refuses_non_creek_directory` → 4385 passed.
- [x] `uv run mypy creek/ tests/test_aggregate_bubble_up.py` → 0 issues.
- [x] `uv run pylint creek/atomize/aggregate.py --fail-under=9.0` → 9.93/10.

Closes #369
Part of #364

https://claude.ai/code/session_01Rmvpqhr5ktg7abxiHMRdTj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rmvpqhr5ktg7abxiHMRdTj)_