### PR TITLE
test+fix: failure-mode coverage + typed embedding-load error (GAP-008)

### DIFF
--- a/creek-tools/creek/link/embeddings.py
+++ b/creek-tools/creek/link/embeddings.py
@@ -54,6 +54,19 @@ EMBEDDINGS_CACHE_DIR: Final[str] = "00-Creek-Meta"
 """Vault subdirectory that holds the embeddings cache."""
 
 
+class EmbeddingModelUnavailableError(RuntimeError):
+    """The configured sentence-transformer model could not be loaded (GAP-008).
+
+    Raised by :meth:`EmbeddingLinker.load_model` when the underlying
+    ``sentence_transformers.SentenceTransformer(...)`` call fails — most
+    commonly because the model weights have not been downloaded and the
+    host has no network access, but also covers torch/transformers
+    import-time failures or a corrupt cache directory. The exception
+    message names the requested model so the operator can act without
+    rummaging through a stack trace deep inside torch.
+    """
+
+
 class Resonance(BaseModel):
     """A semantic resonance edge between two fragments (FEAT-024).
 
@@ -405,13 +418,44 @@ class EmbeddingLinker:
 
         Returns:
             The loaded SentenceTransformer model instance.
+
+        Raises:
+            EmbeddingModelUnavailableError: When the underlying
+                ``sentence_transformers.SentenceTransformer(...)`` call
+                fails (model weights missing and no network, corrupt
+                cache, torch import error, …). The message names the
+                model and points at the remediation so the operator does
+                not have to read a torch stack trace (GAP-008).
         """
         if self._model is None:
             logger.info("Loading embedding model '%s'", self.config.model)
-            self._model = _load_sentence_transformer(
-                self.config.model,
-                self.config.cache_dir,
-            )
+            try:
+                self._model = _load_sentence_transformer(
+                    self.config.model,
+                    self.config.cache_dir,
+                )
+            except Exception as exc:
+                # GAP-008: any underlying-library failure (OSError,
+                # RuntimeError, ImportError from torch, …) becomes a
+                # typed error so callers can branch on identity rather
+                # than parsing third-party messages.
+                cache_hint = (
+                    f"cache directory {self.config.cache_dir!r}"
+                    if self.config.cache_dir
+                    else "the default sentence-transformers cache directory"
+                )
+                msg = (
+                    f"sentence-transformers could not load embedding model "
+                    f"{self.config.model!r}. The model weights are usually "
+                    f"downloaded automatically on first use; this failure "
+                    f"typically means the host has no network access on the "
+                    f"first run, or the weights in {cache_hint} are corrupt. "
+                    f"Remediation: run `creek link --method embeddings` once "
+                    f"on a machine with network access to populate the cache, "
+                    f"then copy the cache directory to the offline host. "
+                    f"Underlying error: {exc!s}"
+                )
+                raise EmbeddingModelUnavailableError(msg) from exc
         return self._model
 
     def generate_embedding(self, text: str) -> list[float]:

--- a/creek-tools/docs/classification.md
+++ b/creek-tools/docs/classification.md
@@ -161,6 +161,19 @@ Pass `--force` if you genuinely want to re-classify everything (for example, aft
 
 The engine also appends each classified fragment ID to `<vault>/00-Creek-Meta/Processing-Log/llm-progress.jsonl` for observability (newline-delimited JSON, one `{"id": ...}` object per line). The file is informational — the per-fragment frontmatter is the source of truth.
 
+## Failure modes and the documented contract (GAP-008)
+
+These are the dynamic failure modes the engine handles, and what each looks like to the operator:
+
+| Failure | Contract | Observable |
+|---------|----------|------------|
+| **Ctrl-C / SIGTERM mid-run** (laptop sleep, container reclamation, manual abort) | Per-fragment frontmatter is fsync-implicit through `Path.write_text`; the progress JSONL line is written atomically (O_APPEND, single short `write`). On exit, every line in `llm-progress.jsonl` is well-formed JSON. | `KeyboardInterrupt` propagates; the next `creek classify --method llm` resumes from where it stopped. Test: `tests/test_classify_engine_interrupt.py`. |
+| **LLM transport failure** (Anthropic 5xx, Ollama connection refused, timeout) | The orchestrator retries up to `MAX_RETRIES` with a `RETRY_DELAY` sleep between attempts, logging a `WARNING` per attempt (`[fragment=<id> path=<source> provider=<provider>] Classify attempt N/M failed for '<title>': <error>`). After the final retry it logs `All N retries exhausted for '<title>' — returning unchanged` at `ERROR` and returns the fragment with its existing (probably `unclassified`) classification. The run continues; the fragment is left in the review queue for re-classification on the next run. | The fragment file on disk is **not** stamped with `classification_method: llm`, so the next run will retry it. The progress JSONL only records successful classifications. Tests: `tests/test_classify.py::TestClassify::test_5xx_response_returns_unchanged_with_warning` and `::test_returns_unchanged_after_all_retries`. |
+| **Embedding model load failure** (first run, no network; corrupt cache; torch import error) | `EmbeddingLinker.load_model` raises `EmbeddingModelUnavailableError` with a message that names the configured model and points at the remediation (`creek link --method embeddings` on a host with network access). The underlying exception is preserved as `__cause__`. | `creek link` exits non-zero with the typed error; the operator sees the model name and the remediation in the error, not a torch stack trace. Tests: `tests/test_embeddings.py::TestLoadModelFailure`. |
+| **Encrypted / corrupt PDF passed to the document ingestor** | The ingestor logs a `WARNING` and skips the file; the run continues. | The file does not appear in the vault; the run summary reports it as skipped. (No GAP-008 test added — covered by existing ingestor-failure-mode coverage in `tests/test_ingest_failure_modes.py`.) |
+
+If you encounter a failure mode not listed here that surfaces as a stack trace rather than an actionable error message, that's a bug — file an issue with the `BUG-*` prefix and the failing command output.
+
 ## LLM provider details
 
 ### Ollama (default, local)

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -960,6 +960,60 @@ class TestClassify:
         mock_call.assert_not_called()
 
     @patch.object(LLMClassifier, "_call_ollama")
+    @patch("creek.classify.llm.time.sleep")
+    def test_5xx_response_returns_unchanged_with_warning(
+        self,
+        mock_sleep: MagicMock,
+        mock_call: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A 500 from the LLM retries then degrades cleanly (GAP-008).
+
+        Pins the existing record-and-continue contract for transport-level
+        failures (cf. `creek/classify/llm/orchestrator.py` retry loop):
+        every retry attempt logs a WARNING with the fragment ID + provider,
+        and after `MAX_RETRIES` the fragment is returned unchanged rather
+        than raising. Distinguished from
+        `test_returns_unchanged_after_all_retries` which uses ConnectError
+        (no HTTP response at all); this test uses ``HTTPStatusError``
+        because a 5xx is qualitatively different — the server reached us
+        and answered, just with an error code — and operators reading the
+        log line need to know that path is also covered.
+        """
+        response = httpx.Response(
+            500,
+            request=httpx.Request("POST", "http://localhost:11434/api/generate"),
+        )
+        mock_call.side_effect = httpx.HTTPStatusError(
+            "Server error",
+            request=response.request,
+            response=response,
+        )
+        config = LLMConfig()
+        classifier = _make_classifier_available(LLMClassifier(config=config))
+        classifier.MAX_RETRIES = 2
+
+        with caplog.at_level(logging.WARNING):
+            frag = _make_fragment(title="5xx Test")
+            result = classifier.classify(frag)
+
+        # Contract: degrade to unchanged after exhausting retries, never raise.
+        assert result.id == frag.id
+        assert result.frequency.primary == Frequency.UNCLASSIFIED
+        # Two attempts because MAX_RETRIES=2 and both failed.
+        assert mock_call.call_count == 2
+        # Each attempt logs a WARNING the operator can grep on.
+        attempt_warnings = [
+            r
+            for r in caplog.records
+            if r.levelno == logging.WARNING and "Classify attempt" in r.message
+        ]
+        assert len(attempt_warnings) == 2
+        # Final WARN/ERROR line names "retries exhausted" so the operator
+        # knows to investigate transport health rather than the fragment.
+        assert any("retries exhausted" in r.message.lower() for r in caplog.records)
+
+    @patch.object(LLMClassifier, "_call_ollama")
     def test_classify_preserves_id_and_title(
         self,
         mock_call: MagicMock,

--- a/creek-tools/tests/test_classify_engine_interrupt.py
+++ b/creek-tools/tests/test_classify_engine_interrupt.py
@@ -1,0 +1,176 @@
+"""GAP-008: KeyboardInterrupt mid-classify must leave the progress JSONL well-formed.
+
+The OPS-001 progress file at
+``<vault>/00-Creek-Meta/Processing-Log/llm-progress.jsonl`` is what
+makes resume-after-crash a reliable contract. If a SIGINT (Ctrl-C),
+SIGTERM (laptop sleep / container reclamation), or a thrown exception
+catches the engine mid-write, the resulting file must still be
+line-by-line valid JSON — half-written lines would either corrupt
+``json.loads`` on resume or silently re-classify the partially-written
+fragment.
+
+The per-line write in ``_record_llm_progress`` opens the file in
+append mode and writes ``{id} + \\n`` as a single ``handle.write``
+call. POSIX guarantees that an O_APPEND write of < ``PIPE_BUF`` bytes
+(typically 4096) is atomic across processes, and a per-fragment JSON
+line is ~30 bytes. So the file's invariant — every non-empty line
+parses as JSON — must survive any interruption between two write
+calls. This test pins that invariant explicitly.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+from unittest.mock import PropertyMock, patch
+
+import pytest
+
+from creek.classify.classify_engine import (
+    LLM_PROGRESS_FILENAME,
+    LLMClassifier,
+    run_classify,
+)
+from creek.classify.llm import LLMClassificationResult
+from creek.config import CreekConfig
+from creek.models import Fragment, FragmentSource, SourcePlatform
+from tests.helpers import write_fragment_file as _write_fragment
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture(autouse=True)
+def _force_llm_available() -> object:
+    """Bypass the LLM-availability gate (mirrors the resume-test fixture)."""
+    with patch.object(
+        LLMClassifier,
+        "available",
+        new_callable=PropertyMock,
+        return_value=True,
+    ) as patched:
+        yield patched
+
+
+def _llm_low_confidence_config() -> CreekConfig:
+    """Force the engine to invoke the LLM on every fragment."""
+    config = CreekConfig()
+    config.classification.confidence_threshold = 1.0
+    return config
+
+
+def _seed_fragment(vault: Path, *, idx: int) -> None:
+    """Write fragment ``idx`` with no rule signal so the LLM path runs."""
+    fragment = Fragment(
+        id=f"frag-interrupt-{idx:04d}",
+        title=f"interrupt test {idx}",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(vault=vault, fragment=fragment, body="ambiguous body")
+
+
+def test_keyboard_interrupt_mid_run_leaves_well_formed_progress_jsonl(
+    tmp_path: Path,
+) -> None:
+    """``KeyboardInterrupt`` after N successful fragments leaves N valid JSONL lines.
+
+    GAP-008 acceptance criterion 1. The user laptop-sleeps mid-run,
+    SIGTERM kills the python process between fragments. On resume,
+    every line in the progress file must parse as JSON — otherwise the
+    next ``creek classify`` invocation either crashes on
+    ``json.loads`` or silently re-classifies a partially-written
+    fragment.
+    """
+    vault = tmp_path / "vault"
+    for i in range(5):
+        _seed_fragment(vault, idx=i)
+
+    call_count = {"n": 0}
+    interrupt_after = 3
+
+    def flaky_classify(
+        self: LLMClassifier,
+        frag: Fragment,
+        content: str = "",
+    ) -> LLMClassificationResult:
+        """Stub: succeed N times, then raise KeyboardInterrupt."""
+        del self, content
+        call_count["n"] += 1
+        if call_count["n"] > interrupt_after:
+            raise KeyboardInterrupt
+        return LLMClassificationResult(fragment=frag, reasoning="")
+
+    with (
+        patch.object(
+            LLMClassifier,
+            "classify_with_reasoning",
+            new=flaky_classify,
+        ),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        run_classify(
+            vault_path=vault,
+            config=_llm_low_confidence_config(),
+            method="llm",
+            force=False,
+        )
+
+    progress_path = vault / "00-Creek-Meta" / "Processing-Log" / LLM_PROGRESS_FILENAME
+    assert progress_path.is_file()
+
+    raw = progress_path.read_text(encoding="utf-8")
+    # File must end on a newline — never a half-written line.
+    assert raw.endswith("\n"), (
+        "progress JSONL must not end mid-line; last char was "
+        f"{raw[-1]!r}, file ends with: {raw[-20:]!r}"
+    )
+
+    lines = [line for line in raw.splitlines() if line]
+    assert len(lines) == interrupt_after, (
+        f"expected {interrupt_after} progress lines (one per successful "
+        f"classification before the interrupt), got {len(lines)}"
+    )
+    # Every line parses as JSON and contains the expected fragment-ID
+    # shape. A torn write would fail this assertion.
+    for line in lines:
+        entry = json.loads(line)
+        assert "id" in entry
+        assert isinstance(entry["id"], str)
+        assert entry["id"].startswith("frag-interrupt-")
+
+
+def test_keyboard_interrupt_before_first_fragment_writes_no_progress(
+    tmp_path: Path,
+) -> None:
+    """If the interrupt fires before any LLM call completes, the JSONL stays empty.
+
+    Edge case: Ctrl-C on the very first fragment. The progress directory
+    is created up-front (so its creation is not gated on a successful
+    classification), but the JSONL itself stays empty.
+    """
+    vault = tmp_path / "vault"
+    _seed_fragment(vault, idx=0)
+
+    def always_interrupt(*_args: object, **_kwargs: object) -> object:
+        raise KeyboardInterrupt
+
+    with (
+        patch.object(
+            LLMClassifier,
+            "classify_with_reasoning",
+            new=always_interrupt,
+        ),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        run_classify(
+            vault_path=vault,
+            config=_llm_low_confidence_config(),
+            method="llm",
+            force=False,
+        )
+
+    progress_path = vault / "00-Creek-Meta" / "Processing-Log" / LLM_PROGRESS_FILENAME
+    # Either the file does not exist (open-on-first-write) or it exists
+    # but is empty. Both are valid "nothing succeeded" signals.
+    if progress_path.is_file():
+        assert progress_path.read_text(encoding="utf-8") == ""

--- a/creek-tools/tests/test_embeddings.py
+++ b/creek-tools/tests/test_embeddings.py
@@ -9,10 +9,12 @@ conftest.py to avoid model downloads.
 from __future__ import annotations
 
 import logging
+import re
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 import numpy as np
+import pytest
 
 from creek.config import EmbeddingsConfig
 from creek.link.embeddings import (
@@ -28,8 +30,6 @@ from creek.models import Fragment, FragmentLevel, FragmentSource, SourcePlatform
 if TYPE_CHECKING:
     from pathlib import Path
     from unittest.mock import MagicMock
-
-    import pytest
 
 _DIMS = 384  # all-MiniLM-L6-v2 output dimensions
 
@@ -86,6 +86,95 @@ class TestLoadModel:
             "all-MiniLM-L6-v2",
             cache_dir,
         )
+
+
+class TestLoadModelFailure:
+    """GAP-008: ``EmbeddingModelUnavailableError`` wraps underlying failures."""
+
+    def test_oserror_is_wrapped_in_typed_error(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An ``OSError`` from sentence-transformers becomes a typed error.
+
+        The most common production failure mode — model weights missing
+        and no network access on first run — surfaces as an ``OSError``
+        from deep inside the sentence-transformers / torch stack. The
+        typed error must name the model so the operator can act on the
+        error message alone (GAP-008 acceptance criterion 3).
+        """
+        from creek.link.embeddings import EmbeddingModelUnavailableError
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            msg = "model not downloaded and network unreachable"
+            raise OSError(msg)
+
+        monkeypatch.setattr(
+            "creek.link.embeddings._load_sentence_transformer",
+            boom,
+        )
+
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(model="all-MiniLM-L6-v2"),
+        )
+        with pytest.raises(
+            EmbeddingModelUnavailableError,
+            match="all-MiniLM-L6-v2",
+        ) as excinfo:
+            linker.load_model()
+
+        # Message names the remediation surface: `creek link
+        # --method embeddings` on a host with network access.
+        assert "creek link" in str(excinfo.value)
+        # The original OSError is preserved as __cause__ so the operator
+        # can inspect the underlying failure if needed.
+        assert isinstance(excinfo.value.__cause__, OSError)
+
+    def test_runtimeerror_from_torch_is_wrapped(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Torch-level ``RuntimeError`` (e.g. CUDA OOM) also yields the typed error."""
+        from creek.link.embeddings import EmbeddingModelUnavailableError
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            msg = "CUDA out of memory"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr(
+            "creek.link.embeddings._load_sentence_transformer",
+            boom,
+        )
+
+        linker = EmbeddingLinker(config=EmbeddingsConfig())
+        with pytest.raises(EmbeddingModelUnavailableError):
+            linker.load_model()
+
+    def test_message_mentions_cache_dir_when_configured(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Operators with a non-default cache_dir see it in the error message."""
+        from creek.link.embeddings import EmbeddingModelUnavailableError
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise OSError("missing")
+
+        monkeypatch.setattr(
+            "creek.link.embeddings._load_sentence_transformer",
+            boom,
+        )
+
+        cache_dir = str(tmp_path / "models")
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(cache_dir=cache_dir),
+        )
+        with pytest.raises(
+            EmbeddingModelUnavailableError,
+            match=re.escape(cache_dir),
+        ):
+            linker.load_model()
 
 
 # ---- Single Embedding ----


### PR DESCRIPTION
## Summary

Closes GAP-008 (failure-mode test coverage) and the **pre-existing complexity regression** that's been blocking CI on main and the GAP-007 PR (#385). One PR rather than two because the complexity fix is needed to get GAP-008's own CI green.

### GAP-008 acceptance criteria coverage

| Criterion | Implementation |
|-----------|----------------|
| **1.** `KeyboardInterrupt` mid-run; progress JSONL stays line-by-line valid | `tests/test_classify_engine_interrupt.py` — two tests (after-N-fragments and on-first-fragment). Asserts every non-empty line parses as JSON and the file ends on a newline. |
| **2.** LLM transport (5xx / timeout); record-and-continue contract | `TestClassify::test_5xx_response_returns_unchanged_with_warning` pins the existing retry-then-degrade contract for `httpx.HTTPStatusError(500)`. Complements `test_returns_unchanged_after_all_retries` (which covers `ConnectError`, a different code path). Documented in `docs/classification.md`. |
| **3.** `sentence-transformers` model-load failure → typed error | New `EmbeddingModelUnavailableError` in `creek/link/embeddings.py`. `load_model` wraps the underlying `OSError`/`RuntimeError`/`ImportError` and emits a message naming the model + cache_dir + remediation (`creek link --method embeddings` on a host with network access). `__cause__` preserved. Three tests: OSError wrap, RuntimeError wrap, cache_dir-in-message. |
| **4.** Documented behaviour on each failure mode | New "Failure modes and the documented contract" section in `docs/classification.md` with a one-row-per-failure table. |
| **5. (optional)** Encrypted PDF skip-with-error | Out of scope — already covered by existing `tests/test_ingest_failure_modes.py`; noted in the docs table. |

### Bonus: complexity regression fix

`creek/classify/holonic.py::_per_dimension_jsd` was rank C (one notch over the rank-B gate), failing `xenon` in CI on `main` and blocking both PR #385 (GAP-007) and this PR. Pure refactor: extract the distribution-build loop into `_build_child_distributions`. Semantics unchanged; the JSD computation drops below the threshold.

## Test plan

- [x] `./scripts/check-all.sh` exits 0 — **all 12 CI-aligned gates pass**.
- [x] 4300+ tests pass.
- [x] New tests: 2 (interrupt) + 1 (5xx) + 3 (embedding-load) = 6.
- [x] CI workflow untouched.

## Files affected

- `creek-tools/creek/link/embeddings.py` — typed `EmbeddingModelUnavailableError`, wrapped `load_model`.
- `creek-tools/creek/classify/holonic.py` — extracted `_build_child_distributions` helper.
- `creek-tools/tests/test_classify_engine_interrupt.py` *(new)* — KeyboardInterrupt safety.
- `creek-tools/tests/test_classify.py` — new 5xx test case.
- `creek-tools/tests/test_embeddings.py` — `TestLoadModelFailure` class.
- `creek-tools/docs/classification.md` — "Failure modes" section.

Closes the GAP-008 finding in `plans/v1-readiness/findings/GAP-008-no-tests-for-interrupt-llm-5xx-model-load.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT7kujEN2GdwvbznHyh5Cu)_