### PR TITLE
feat(draft): --seed-outline multi-section composition (#354)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -32,10 +32,16 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from creek.classify.prompt import PromptOntology
     from creek.config import CreekConfig
     from creek.generate.compost_embedding import CompostExemplar
     from creek.generate.compost_verifier import SupportsVerifyCompost
-    from creek.generate.drafts import DraftGenerator, DraftLLM, SeedSpec
+    from creek.generate.drafts import (
+        DraftGenerator,
+        DraftLLM,
+        OntologyDetector,
+        SeedSpec,
+    )
     from creek.generate.mining import MiningRunReport
     from creek.ingest.base import Ingestor
     from creek.link.link_engine import LinkSummary
@@ -2041,6 +2047,122 @@ def _run_seeded_draft(
     console.print(f"[bold green]Draft saved: {saved_path}[/bold green]")
 
 
+def _read_outline_input(
+    seed_outline: Path | None,
+    seed_outline_text: str | None,
+) -> str | None:
+    """Resolve the outline input from the file/inline flags (issue #354).
+
+    Returns ``None`` when neither flag is set so the caller falls back to
+    the single-topic / mining paths. Exits 2 when both flags are set
+    (mutually exclusive) or when the outline file cannot be read.
+    """
+    if seed_outline is not None and seed_outline_text is not None:
+        console.print(
+            "[red]--seed-outline and --seed-outline-text are mutually "
+            "exclusive; pass only one.[/red]",
+        )
+        raise typer.Exit(code=2)
+    if seed_outline_text is not None:
+        return seed_outline_text
+    if seed_outline is None:
+        return None
+    try:
+        return seed_outline.read_text(encoding="utf-8")
+    except OSError as exc:
+        console.print(f"[red]Could not read --seed-outline {seed_outline}: {exc}[/red]")
+        raise typer.Exit(code=2) from exc
+
+
+def _build_ontology_detector(vault: Path | None) -> OntologyDetector:
+    """Return an :data:`OntologyDetector` bound to the vault's LLM config.
+
+    The returned closure runs :func:`creek.classify.prompt.detect_ontology`
+    against the resolved :class:`~creek.config.LLMConfig` so each outline
+    section's ontology is detected with the same provider the rest of the
+    pipeline uses.
+    """
+    from creek.classify.prompt import detect_ontology
+
+    config = _load_config_for_vault(vault)
+
+    def _detect(prompt: str) -> PromptOntology:
+        return detect_ontology(prompt, config.llm)
+
+    return _detect
+
+
+def _run_outline_draft(
+    generator: DraftGenerator,
+    *,
+    outline_text: str,
+    vault: Path | None,
+    vault_path: Path,
+    current_phase: Phase,
+    override: PrivacyTierOverride | None,
+) -> None:
+    """Run the multi-section outline pipeline and surface errors as exits.
+
+    Extracted from :func:`draft` so the command body stays under the
+    cyclomatic-complexity floor. Owns the outline-parse error surface
+    plus the happy-path save / audit.
+    """
+    from creek.generate.outline import OutlineParseError
+
+    detector = _build_ontology_detector(vault)
+    try:
+        outline_draft = generator.generate_outline_draft(
+            outline_text,
+            vault_path=vault_path,
+            detect_ontology=detector,
+            current_phase=current_phase,
+        )
+    except OutlineParseError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=2) from exc
+    fragment_ids = [
+        fid for section in outline_draft.sections for fid in section.source_fragments
+    ]
+    _audit_privacy_override_if_needed(
+        vault_path=vault_path,
+        command="draft",
+        override=override,
+        fragment_ids=fragment_ids,
+    )
+    saved_path = generator.save_outline_draft(outline_draft, vault_path)
+    console.print(f"[bold green]Draft saved: {saved_path}[/bold green]")
+
+
+def _validate_draft_mode(
+    *,
+    outline_text: str | None,
+    seed_spec: SeedSpec | None,
+    ontology_twist: bool,
+) -> None:
+    """Validate the mutually-exclusive draft modes, exiting 2 on conflict.
+
+    The outline path (issue #354) owns the whole composition, so it
+    cannot be combined with the single-topic seed flags. ``--ontology-twist``
+    still requires a single-topic seed because the outline path applies
+    its twist composition per section automatically.
+    """
+    if outline_text is not None and seed_spec is not None:
+        console.print(
+            "[red]--seed-outline / --seed-outline-text cannot be combined "
+            "with --seed-fragment / --seed-topic / --seed-frequency / "
+            "--seed-phase / --seed-mode.[/red]",
+        )
+        raise typer.Exit(code=2)
+    has_seed = outline_text is not None or seed_spec is not None
+    if ontology_twist and not has_seed:
+        console.print(
+            "[red]--ontology-twist requires a seed (use --seed-topic, "
+            "--seed-frequency, --seed-phase, or --seed-mode) or an outline "
+            "(--seed-outline / --seed-outline-text).[/red]",
+        )
+        raise typer.Exit(code=2)
+
+
 @app.command()
 def draft(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
@@ -2128,6 +2250,24 @@ def draft(
             "Gated behind a flag while epic #349 is in development."
         ),
     ),
+    seed_outline: Path | None = typer.Option(
+        None,
+        "--seed-outline",
+        help=(
+            "Issue #354: path to a markdown outline file. Each header-rooted "
+            "section is composed independently with its own detected ontology, "
+            "then stitched together with transition-only smoothing. Mutually "
+            "exclusive with --seed-outline-text."
+        ),
+    ),
+    seed_outline_text: str | None = typer.Option(
+        None,
+        "--seed-outline-text",
+        help=(
+            "Issue #354: inline markdown outline (same per-section composition "
+            "as --seed-outline). Mutually exclusive with --seed-outline."
+        ),
+    ),
 ) -> None:
     """Draft an essay from a mined idea with the activated skill stack.
 
@@ -2151,6 +2291,14 @@ def draft(
     are named in the prompt, and the LLM is instructed to recombine
     across the corpus rather than paraphrase any single source.
     Requires at least two source fragments.
+
+    Issue #354: pass ``--seed-outline <file>`` or ``--seed-outline-text
+    "..."`` to compose a multi-section essay from a markdown outline.
+    Each header-rooted section is detected, retrieved, and composed
+    independently with its own ontology profile, then stitched together
+    with a transition-only smoothing pass. Outline mode is mutually
+    exclusive with the single-topic seed flags; a header-less outline is
+    rejected with a clear error.
     """
     from creek.generate.drafts import DraftGenerator
     from creek.generate.mining import IdeaMiner
@@ -2167,12 +2315,12 @@ def draft(
         seed_phase=seed_phase,
         seed_mode=seed_mode,
     )
-    if ontology_twist and seed_spec is None:
-        console.print(
-            "[red]--ontology-twist requires a seed (use --seed-topic, "
-            "--seed-frequency, --seed-phase, or --seed-mode).[/red]",
-        )
-        raise typer.Exit(code=2)
+    outline_text = _read_outline_input(seed_outline, seed_outline_text)
+    _validate_draft_mode(
+        outline_text=outline_text,
+        seed_spec=seed_spec,
+        ontology_twist=ontology_twist,
+    )
     llm = _build_draft_llm()
     if bypass_compiled:
         _warn_bypass_compiled("draft")
@@ -2185,6 +2333,17 @@ def draft(
         bypass_compiled=bypass_compiled,
         ontology_twist=ontology_twist,
     )
+
+    if outline_text is not None:
+        _run_outline_draft(
+            generator,
+            outline_text=outline_text,
+            vault=vault,
+            vault_path=vault_path,
+            current_phase=current_phase,
+            override=override,
+        )
+        return
 
     if seed_spec is not None:
         _run_seeded_draft(

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -62,6 +62,11 @@ from creek.generate.grounding import (
     build_grounding_frontmatter,
     score_draft,
 )
+from creek.generate.outline import (
+    OutlineSection,
+    build_stitch_prompt,
+    parse_outline,
+)
 from creek.generate.twist import (
     OntologyProfile,
     format_twist_directive,
@@ -105,9 +110,30 @@ _REGISTERS_DIR: str = "registers"
 
 _SLUG_MAX_LENGTH: int = 80
 
+_MIN_TWIST_SOURCES: int = 2
+"""Minimum source fragments before a section composes through the twist path.
+
+Mirrors the plurality floor in :mod:`creek.generate.twist`. A section with
+fewer matched fragments drops the twist directive and composes plainly so
+it still appears in the outline draft (issue #354) rather than aborting
+the whole essay the way the single-topic path does.
+"""
+
 
 DraftLLM = Callable[[str], str]
 """Signature for draft LLM clients: takes a prompt, returns the draft body."""
+
+
+OntologyDetector = Callable[[str], "PromptOntology"]
+"""Signature for prompt-ontology detectors (issue #350).
+
+Takes a section's free-form seed text, returns a
+:class:`~creek.classify.prompt.PromptOntology`. Injected into
+:meth:`DraftGenerator.generate_outline_draft` so the module stays
+deterministic and provider-free — the CLI passes a closure over
+:func:`creek.classify.prompt.detect_ontology` bound to the resolved
+:class:`~creek.config.LLMConfig`.
+"""
 
 
 @dataclass(frozen=True)
@@ -228,6 +254,75 @@ class _TwistPayload:
     source_profile: OntologyProfile | None = None
     target_profile: OntologyProfile | None = None
     dimensions: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SectionComposition:
+    """One composed outline section with its per-section ontology profiles.
+
+    Attributes:
+        heading: The section header text (``#`` markers stripped).
+        level: The header depth (1-6).
+        body: The LLM-composed section body before the stitch pass.
+        source_profile: Ontology profile aggregated from the section's
+            retrieved source fragments (issue #352). :data:`None` when
+            the section matched no source material.
+        target_profile: Ontology profile asked for by the section's
+            detected :class:`~creek.classify.prompt.PromptOntology`
+            (issue #350). Always populated — the detector runs on every
+            section.
+        twist_dimensions: Ordered dimension names where the section's
+            source profile diverges from its target profile. Empty when
+            the profiles match or no source material was found.
+        source_fragments: Fragment IDs that fed this section's prompt.
+    """
+
+    heading: str
+    level: int
+    body: str
+    target_profile: OntologyProfile
+    source_profile: OntologyProfile | None = None
+    twist_dimensions: tuple[str, ...] = ()
+    source_fragments: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OutlineDraft:
+    """A multi-section draft composed from a markdown outline (issue #354).
+
+    The per-section bodies are composed independently (detect → retrieve
+    → compose) and then stitched into one continuous essay with a
+    transition-only smoothing pass.
+
+    Attributes:
+        title: The draft title (the first section's heading).
+        body: The stitched essay body.
+        sections: The composed sections in document order, each carrying
+            its own ontology profiles for frontmatter provenance.
+        generated_date: When the outline draft was generated.
+        outline_text: The original outline input, recorded verbatim for
+            reproducibility.
+        stitch_prompt: The full stitch-pass prompt sent to the LLM.
+    """
+
+    title: str
+    body: str
+    sections: tuple[SectionComposition, ...]
+    generated_date: datetime
+    outline_text: str
+    stitch_prompt: str
+
+    def __post_init__(self) -> None:
+        """Validate outline-draft invariants."""
+        if not self.title.strip():
+            msg = "OutlineDraft.title must be non-empty"
+            raise ValueError(msg)
+        if not self.body.strip():
+            msg = "OutlineDraft.body must be non-empty"
+            raise ValueError(msg)
+        if not self.sections:
+            msg = "OutlineDraft.sections must be non-empty"
+            raise ValueError(msg)
 
 
 @dataclass(frozen=True)
@@ -1303,6 +1398,304 @@ class DraftGenerator:
             dimensions=tuple(divergent),
         )
 
+    def generate_outline_draft(
+        self,
+        outline_text: str,
+        *,
+        vault_path: Path,
+        detect_ontology: OntologyDetector,
+        current_phase: Phase | None = None,
+    ) -> OutlineDraft:
+        """Compose a multi-section draft from a markdown *outline_text* (issue #354).
+
+        Each outline section is composed independently — its ontology is
+        detected (issue #350), its source material is retrieved per
+        dimension (issue #351), and it is voiced through the
+        ontology-twist path (issue #352) when at least two source
+        fragments match. A final stitch pass smooths transitions between
+        the sections without paraphrasing or inventing content
+        (connective tissue only).
+
+        Args:
+            outline_text: The markdown outline (file contents or inline).
+                Must contain at least one ATX header.
+            vault_path: Vault root used for per-section fragment loading,
+                skill resolution, and source-material gathering.
+            detect_ontology: Callable mapping a section's seed text to a
+                :class:`~creek.classify.prompt.PromptOntology`. Injected
+                so the module stays provider-free; the CLI binds it to
+                :func:`creek.classify.prompt.detect_ontology`.
+            current_phase: Optional phase override applied to every
+                section's skill selection.
+
+        Returns:
+            An :class:`OutlineDraft` whose ``sections`` carry per-section
+            ontology profiles and whose ``body`` is the stitched essay.
+
+        Raises:
+            OutlineParseError: When *outline_text* has no markdown
+                headers (surfaced unchanged from
+                :func:`creek.generate.outline.parse_outline`).
+            RuntimeError: When the stitch pass returns an empty body.
+        """
+        parsed = parse_outline(outline_text)
+        fragments = _load_fragments_by_id(
+            vault_path / _FRAGMENTS_SUBDIR,
+            privacy_override=self.privacy_override,
+        )
+        sections = tuple(
+            self._compose_section(
+                section,
+                vault_path=vault_path,
+                detect_ontology=detect_ontology,
+                current_phase=current_phase,
+                fragments=fragments,
+            )
+            for section in parsed
+        )
+        stitch_prompt = build_stitch_prompt(
+            [(section.heading, section.body) for section in sections],
+            voice_core=self.voice_core,
+        )
+        body = self._llm(stitch_prompt).strip()
+        if not body:
+            msg = "LLM returned an empty stitched draft body"
+            raise RuntimeError(msg)
+        return OutlineDraft(
+            title=parsed[0].heading,
+            body=body,
+            sections=sections,
+            generated_date=datetime.now(tz=UTC),
+            outline_text=outline_text,
+            stitch_prompt=stitch_prompt,
+        )
+
+    def _compose_section(
+        self,
+        section: OutlineSection,
+        *,
+        vault_path: Path,
+        detect_ontology: OntologyDetector,
+        current_phase: Phase | None,
+        fragments: dict[str, tuple[Fragment, str]],
+    ) -> SectionComposition:
+        """Detect, retrieve, and compose one outline *section* (issue #354).
+
+        The section's ontology is detected from its seed text and folded
+        into a topic-plus-ontology :class:`SeedSpec`. When the spec
+        resolves to source material the section is composed through the
+        seeded-draft pipeline; otherwise it falls back to a bare
+        skill-stack compose so the section still appears in the draft
+        (the #354 acceptance criterion). The target profile is always
+        recorded from the detected ontology.
+        """
+        ontology = detect_ontology(section.seed_text)
+        spec = _section_seed_spec(section, ontology)
+        target_profile = target_profile_from_spec(spec)
+        try:
+            idea = self.resolve_seed(spec, vault_path=vault_path, fragments=fragments)
+        except SeedResolutionError:
+            body = self._compose_bare_section(section, current_phase)
+            return SectionComposition(
+                heading=section.heading,
+                level=section.level,
+                body=body,
+                target_profile=target_profile,
+            )
+        return self._compose_resolved_section(
+            section,
+            spec=spec,
+            idea=idea,
+            target_profile=target_profile,
+            vault_path=vault_path,
+            current_phase=current_phase,
+            fragments=fragments,
+        )
+
+    def _compose_resolved_section(
+        self,
+        section: OutlineSection,
+        *,
+        spec: SeedSpec,
+        idea: IdeaSeed,
+        target_profile: OntologyProfile,
+        vault_path: Path,
+        current_phase: Phase | None,
+        fragments: dict[str, tuple[Fragment, str]],
+    ) -> SectionComposition:
+        """Compose a section that resolved to source material.
+
+        Builds the per-dimension prompt and (when at least two source
+        fragments matched) the twist directive, then calls the LLM. A
+        single-source section drops the twist directive rather than
+        failing — a section is a sub-part of the essay, so the
+        plurality floor is relaxed to keep the section in the draft.
+        """
+        twist = self._section_twist_payload(spec, idea, fragments)
+        source_profile = source_profile_from_fragments(
+            [fragments[fid][0] for fid in idea.source_fragments if fid in fragments],
+        )
+        body = self._render_section_body(
+            idea,
+            spec=spec,
+            twist=twist,
+            vault_path=vault_path,
+            current_phase=current_phase,
+            fragments=fragments,
+        )
+        return SectionComposition(
+            heading=section.heading,
+            level=section.level,
+            body=body,
+            target_profile=target_profile,
+            source_profile=source_profile,
+            twist_dimensions=twist.dimensions,
+            source_fragments=idea.source_fragments,
+        )
+
+    def _section_twist_payload(
+        self,
+        spec: SeedSpec,
+        idea: IdeaSeed,
+        fragments: dict[str, tuple[Fragment, str]],
+    ) -> _TwistPayload:
+        """Return the twist payload for a section, or empty when not applicable.
+
+        Twist composition needs the flag enabled and at least two source
+        fragments. A single-source section returns an empty payload so it
+        still composes (the plurality floor is a hard error only on the
+        single-topic ``generate_seeded_draft`` path).
+        """
+        if not self.ontology_twist or len(idea.source_fragments) < _MIN_TWIST_SOURCES:
+            return _TwistPayload()
+        retrieved = [
+            fragments[fid][0] for fid in idea.source_fragments if fid in fragments
+        ]
+        source_profile = source_profile_from_fragments(retrieved)
+        target_profile = target_profile_from_spec(spec)
+        divergent = twist_dimensions(source_profile, target_profile)
+        directive = format_twist_directive(source_profile, target_profile, divergent)
+        return _TwistPayload(
+            directive=directive,
+            source_profile=source_profile,
+            target_profile=target_profile,
+            dimensions=tuple(divergent),
+        )
+
+    def _render_section_body(
+        self,
+        idea: IdeaSeed,
+        *,
+        spec: SeedSpec,
+        twist: _TwistPayload,
+        vault_path: Path,
+        current_phase: Phase | None,
+        fragments: dict[str, tuple[Fragment, str]],
+    ) -> str:
+        """Build the per-section prompt and return the composed body."""
+        effective_phase = current_phase
+        if effective_phase is None and spec.phases:
+            effective_phase = spec.phases[0]
+        skill_stack = self.select_skill_stack(
+            idea,
+            vault_path=vault_path,
+            current_phase=effective_phase,
+            fragments=fragments,
+        )
+        slices = assemble_per_dimension_corpus(
+            spec,
+            fragments,
+            ontology=spec.ontology,
+            confidence_threshold=spec.ontology_confidence_threshold,
+        )
+        per_dimension_material = _render_per_dimension_sections(slices, fragments)
+        source_material = self.gather_source_material(
+            idea,
+            vault_path=vault_path,
+            fragments=fragments,
+            include_fragments=not slices,
+        )
+        prompt = self._compose_prompt(
+            idea,
+            skill_stack,
+            source_material,
+            per_dimension_material=per_dimension_material,
+            twist_directive=twist.directive,
+            twist_active=bool(twist.dimensions),
+        )
+        return self._invoke_section_llm(prompt)
+
+    def _compose_bare_section(
+        self,
+        section: OutlineSection,
+        current_phase: Phase | None,
+    ) -> str:
+        """Compose a section with no source material from its seed text alone.
+
+        The section still gets the voice core and (when classified) the
+        phase skill, but the ask is built directly from the section's
+        heading and body so the section appears in the draft even when
+        the vault has nothing to retrieve.
+        """
+        parts: list[str] = []
+        if self.voice_core:
+            parts.append(f"## Voice core\n{self.voice_core.strip()}")
+        phase_path = self._phase_skill(current_phase)
+        if phase_path is not None and phase_path.exists():
+            parts.append("## Activated skills\n\n" + _render_skill_section(phase_path))
+        parts.append(
+            "## Ask\n"
+            f'Write the section titled "{section.heading}". '
+            f"{section.body.strip()} "
+            "Write as the human — not as an AI. Honour the activated skills.",
+        )
+        return self._invoke_section_llm("\n\n".join(parts))
+
+    def _invoke_section_llm(self, prompt: str) -> str:
+        """Call the LLM for one section, failing loudly on an empty body."""
+        body = self._llm(prompt).strip()
+        if not body:
+            msg = "LLM returned an empty section body"
+            raise RuntimeError(msg)
+        return body
+
+    def save_outline_draft(
+        self,
+        draft: OutlineDraft,
+        vault_path: Path,
+    ) -> Path:
+        """Write an :class:`OutlineDraft` to ``07-Voice/Drafts/`` (issue #354).
+
+        The frontmatter records each section's heading, level, source
+        fragments, and detected/target ontology profiles so a reader can
+        trace every section back to its ontology and sources.
+
+        Args:
+            draft: The outline draft to persist.
+            vault_path: Vault root under which ``07-Voice/Drafts`` lives.
+
+        Returns:
+            The absolute path of the written markdown file.
+        """
+        drafts_dir = vault_path / DRAFTS_SUBDIR
+        drafts_dir.mkdir(parents=True, exist_ok=True)
+        slug = _slugify(draft.title)
+        date_prefix = draft.generated_date.strftime("%Y-%m-%d")
+        target = _next_available_draft_path(drafts_dir, date_prefix, slug)
+        post = frontmatter.Post(
+            content=draft.body.strip() + "\n",
+            type="draft",
+            title=draft.title,
+            status="draft",
+            idea_strategy="seed_outline",
+            generated_date=draft.generated_date.isoformat(),
+            outline=draft.outline_text,
+            stitch_prompt=draft.stitch_prompt,
+            sections=[_serialise_section(section) for section in draft.sections],
+        )
+        target.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return target
+
     def save_draft(self, draft: Draft, vault_path: Path) -> Path:
         """Write *draft* to ``07-Voice/Drafts/YYYY-MM-DD-{slug}.md``.
 
@@ -1429,6 +1822,43 @@ def _serialise_seed_spec(spec: SeedSpec) -> dict[str, object]:
         payload["phases"] = [ph.value for ph in spec.phases]
     if spec.modes:
         payload["modes"] = [md.value for md in spec.modes]
+    return payload
+
+
+def _section_seed_spec(
+    section: OutlineSection,
+    ontology: PromptOntology,
+) -> SeedSpec:
+    """Build a topic-plus-ontology :class:`SeedSpec` for one outline section.
+
+    The section's seed text becomes the topic so the per-dimension
+    retrieval and the legacy substring fallback both have a phrase to
+    work with, and the detected ontology drives the dimensional blend.
+    """
+    return SeedSpec(topic=section.seed_text, ontology=ontology)
+
+
+def _serialise_section(section: SectionComposition) -> dict[str, object]:
+    """Render a :class:`SectionComposition` as frontmatter-friendly YAML.
+
+    Records the section's heading, level, target ontology profile, and —
+    when source material was found — its source profile, divergent
+    twist dimensions, and source fragment IDs. The target profile is
+    always present (the detector runs on every section), satisfying the
+    #354 acceptance criterion that each section's ontology profile is
+    recorded in frontmatter.
+    """
+    payload: dict[str, object] = {
+        "heading": section.heading,
+        "level": section.level,
+        "target_profile": section.target_profile.as_mapping(),
+    }
+    if section.source_profile is not None:
+        payload["source_profile"] = section.source_profile.as_mapping()
+    if section.twist_dimensions:
+        payload["twist_dimensions"] = list(section.twist_dimensions)
+    if section.source_fragments:
+        payload["source_fragments"] = list(section.source_fragments)
     return payload
 
 

--- a/creek-tools/creek/generate/outline.py
+++ b/creek-tools/creek/generate/outline.py
@@ -1,0 +1,228 @@
+"""Markdown outline parsing for multi-section drafts (issue #354).
+
+``creek draft --seed-topic`` accepts a single phrase. Larger essays carry
+structure — an introduction, a few claims, a synthesis. Issue #354 lets
+the operator hand that structure in directly via ``--seed-outline`` (a
+file path) or ``--seed-outline-text`` (inline), and composes each section
+independently with its own detected ontology profile (issue #350),
+per-dimension retrieval (issue #351), and ontology-twist composition
+(issue #352), then stitches the sections together with a transition-only
+smoothing pass.
+
+This module is the pure, LLM-free half of that feature:
+
+* :class:`OutlineSection` — one header plus the body text beneath it.
+* :func:`parse_outline` — split a markdown document into ordered
+  sections. Every ATX header opens a section; its body runs until the
+  next header of any level. The header's depth is recorded as the
+  section level so callers can tell a ``#`` title from a ``##`` claim,
+  but each header — at whatever depth — composes as its own section so
+  the worked example (a ``#`` title plus three ``##`` claims) yields the
+  four sections the operator wrote.
+* :class:`OutlineParseError` — raised when the document carries no
+  markdown headers (the #354 acceptance criterion: "an outline with no
+  markdown headers is rejected with a clear error").
+* :func:`format_stitch_directive` / :func:`build_stitch_prompt` — render
+  the connective-tissue-only smoothing prompt. The directive forbids
+  paraphrasing or inventing section content; the stitch pass may only add
+  transitions.
+
+The orchestration that drives detect → retrieve → compose → stitch lives
+in :mod:`creek.generate.drafts` so this module stays import-side-effect
+free and free of any provider dependency.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# ATX headers only: 1-6 leading hashes, at least one space, then text.
+# Setext (underline) headers and bare ``#tag`` runs are intentionally
+# excluded — the latter has no space after the hashes and is body text.
+_HEADER_RE = re.compile(r"^(#{1,6})[ \t]+(\S.*)$")
+
+
+class OutlineParseError(ValueError):
+    """Raised when an outline carries no markdown headers.
+
+    The CLI surfaces the message verbatim so the operator learns that
+    ``--seed-outline`` needs at least one ``#`` header to delimit a
+    section, rather than silently drafting a single unstructured blob.
+    """
+
+
+@dataclass(frozen=True)
+class OutlineSection:
+    """One outline section: a header plus the body text beneath it.
+
+    Attributes:
+        heading: The header text with the leading ``#`` markers stripped.
+        level: The header depth (number of leading hashes, ``1``-``6``).
+        body: The text beneath the header up to the next header of any
+            level. Empty string when the header has no body before the
+            following header.
+    """
+
+    heading: str
+    level: int
+    body: str
+
+    @property
+    def seed_text(self) -> str:
+        """Return the heading + body joined, for ontology detection.
+
+        The detector (:func:`creek.classify.prompt.detect_ontology`)
+        reads a free-form prompt; concatenating the heading with its
+        body gives the richest signal for the section while keeping the
+        heading's framing in play.
+
+        Returns:
+            ``"{heading}\\n\\n{body}"`` when a body exists, otherwise the
+            heading alone.
+        """
+        if not self.body.strip():
+            return self.heading.strip()
+        return f"{self.heading.strip()}\n\n{self.body.strip()}"
+
+
+def _match_header(line: str) -> tuple[int, str] | None:
+    """Return ``(level, heading_text)`` for an ATX header line, else ``None``."""
+    match = _HEADER_RE.match(line)
+    if match is None:
+        return None
+    hashes, text = match.groups()
+    return len(hashes), text.strip()
+
+
+@dataclass
+class _OpenSection:
+    """Mutable accumulator for a section under construction."""
+
+    heading: str
+    level: int
+    body_lines: list[str]
+
+    def finish(self) -> OutlineSection:
+        """Freeze the accumulator into an immutable :class:`OutlineSection`."""
+        body = "\n".join(self.body_lines).strip()
+        return OutlineSection(heading=self.heading, level=self.level, body=body)
+
+
+def parse_outline(text: str) -> list[OutlineSection]:
+    """Split *text* into ordered :class:`OutlineSection` records.
+
+    Every ATX header (``#``..``######`` followed by a space) opens a new
+    section. The section's body is the text beneath the header up to the
+    next header of *any* level — so a ``#`` title and the three ``##``
+    claims beneath it compose as four sections, each with its own
+    detected ontology, in document order.
+
+    Text appearing before the first header is dropped: it belongs to no
+    section. ``#tag`` runs (no space after the hashes) and setext
+    underline headers are treated as body text, not section breaks.
+
+    Args:
+        text: The raw markdown outline (file contents or inline string).
+
+    Returns:
+        The sections in document order. Always non-empty on success.
+
+    Raises:
+        OutlineParseError: When *text* contains no ATX markdown headers.
+    """
+    sections: list[OutlineSection] = []
+    current: _OpenSection | None = None
+    for line in text.splitlines():
+        header = _match_header(line)
+        if header is None:
+            if current is not None:
+                current.body_lines.append(line)
+            continue
+        if current is not None:
+            sections.append(current.finish())
+        level, heading = header
+        current = _OpenSection(heading=heading, level=level, body_lines=[])
+    if current is not None:
+        sections.append(current.finish())
+    if not sections:
+        msg = (
+            "Outline contains no markdown headers; --seed-outline needs at "
+            "least one '#' header to delimit a section."
+        )
+        raise OutlineParseError(msg)
+    return sections
+
+
+def format_stitch_directive(section_count: int) -> str:
+    """Render the connective-tissue-only directive for the stitch pass.
+
+    The stitch pass smooths transitions between independently-composed
+    sections. It must not paraphrase or invent section content — the
+    #354 acceptance criterion. The directive states that contract
+    explicitly so the LLM treats it as load-bearing.
+
+    Args:
+        section_count: How many sections the draft has; named so the
+            model knows exactly how many bodies must survive unchanged.
+
+    Returns:
+        A markdown ``## Stitch directive`` block.
+    """
+    return (
+        "## Stitch directive\n"
+        f"The draft below is assembled from {section_count} sections that "
+        "were composed independently. Your only job is to add connective "
+        "tissue — short transition sentences between sections — so the "
+        "essay reads as one continuous piece. Do NOT paraphrase, rewrite, "
+        "summarise, condense, reorder, or invent any section content. "
+        "Every section's substance must survive verbatim; you may add "
+        "bridging sentences between sections and nothing more. Keep all "
+        f"{section_count} sections, in their original order."
+    )
+
+
+def build_stitch_prompt(
+    sections: list[tuple[str, str]],
+    *,
+    voice_core: str,
+) -> str:
+    """Assemble the stitch-pass prompt from per-section bodies.
+
+    Args:
+        sections: Ordered ``(heading, body)`` pairs — each body is an
+            already-composed section that must survive the stitch pass
+            unchanged save for added transitions.
+        voice_core: Optional voice-core description prepended to the
+            prompt; empty string to omit.
+
+    Returns:
+        The full stitch prompt: voice core (if any), the directive, the
+        labelled section bodies, and the ask.
+    """
+    parts: list[str] = []
+    if voice_core.strip():
+        parts.append(f"## Voice core\n{voice_core.strip()}")
+    parts.append(format_stitch_directive(len(sections)))
+    rendered = "\n\n".join(
+        f"### {heading}\n{body.strip()}" for heading, body in sections
+    )
+    parts.extend(
+        (
+            f"## Sections\n\n{rendered}",
+            "## Ask\n"
+            "Return the full essay with smooth transitions between the "
+            "sections above. Add only connective tissue; leave each "
+            "section's content intact.",
+        ),
+    )
+    return "\n\n".join(parts)
+
+
+__all__ = [
+    "OutlineParseError",
+    "OutlineSection",
+    "build_stitch_prompt",
+    "format_stitch_directive",
+    "parse_outline",
+]

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -2208,6 +2208,174 @@ def test_draft_seed_flags_advertised_in_help() -> None:
         assert flag in output, f"missing {flag} in draft help"
 
 
+def test_draft_outline_flags_advertised_in_help() -> None:
+    """``creek draft --help`` documents the issue #354 outline flags."""
+    result = runner.invoke(app, ["draft", "--help"])
+    output = _strip_ansi(result.output)
+    assert result.exit_code == 0
+    assert "--seed-outline" in output
+    assert "--seed-outline-text" in output
+
+
+def _stub_outline_detector(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub the LLM and ontology detector for outline CLI happy-path tests."""
+    from creek import cli as cli_module
+    from creek.classify.prompt import PromptOntology
+
+    monkeypatch.setattr(
+        cli_module,
+        "_build_draft_llm",
+        lambda: lambda _p: "Stitched body.",
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "_build_ontology_detector",
+        lambda _vault: lambda prompt: PromptOntology(prompt=prompt),
+    )
+
+
+def test_draft_seed_outline_text_happy_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--seed-outline-text`` composes a multi-section draft and saves it."""
+    _stub_outline_detector(monkeypatch)
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    result = runner.invoke(
+        app,
+        [
+            "draft",
+            "--vault",
+            str(vault),
+            "--seed-outline-text",
+            "# Title\n\n## One\nFirst.\n\n## Two\nSecond.\n",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Draft saved" in result.output
+    drafts = list((vault / "07-Voice" / "Drafts").glob("*.md"))
+    assert len(drafts) == 1
+
+
+def test_draft_seed_outline_file_happy_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--seed-outline <file>`` reads the outline from disk and composes it."""
+    _stub_outline_detector(monkeypatch)
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    outline_file = tmp_path / "outline.md"
+    outline_file.write_text("## Alpha\nA.\n\n## Beta\nB.\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        ["draft", "--vault", str(vault), "--seed-outline", str(outline_file)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Draft saved" in result.output
+
+
+def test_draft_seed_outline_no_headers_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An outline with no markdown headers exits 2 with a clear error."""
+    _stub_outline_detector(monkeypatch)
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    result = runner.invoke(
+        app,
+        [
+            "draft",
+            "--vault",
+            str(vault),
+            "--seed-outline-text",
+            "Just a paragraph, no headers.",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "no markdown headers" in result.output
+
+
+def test_draft_seed_outline_mutually_exclusive_inline_and_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Passing both --seed-outline and --seed-outline-text exits 2."""
+    from creek import cli as cli_module
+
+    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    outline_file = tmp_path / "outline.md"
+    outline_file.write_text("## H\nB.\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "draft",
+            "--vault",
+            str(vault),
+            "--seed-outline",
+            str(outline_file),
+            "--seed-outline-text",
+            "## H\nB.\n",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "mutually exclusive" in result.output
+
+
+def test_draft_seed_outline_mutually_exclusive_with_topic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Combining outline mode with --seed-topic exits 2."""
+    from creek import cli as cli_module
+
+    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    result = runner.invoke(
+        app,
+        [
+            "draft",
+            "--vault",
+            str(vault),
+            "--seed-outline-text",
+            "## H\nB.\n",
+            "--seed-topic",
+            "X",
+        ],
+    )
+    assert result.exit_code == 2
+    assert "cannot be combined" in result.output
+
+
+def test_draft_seed_outline_file_read_error_exits_two(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing outline file exits 2 with a read error."""
+    from creek import cli as cli_module
+
+    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    result = runner.invoke(
+        app,
+        [
+            "draft",
+            "--vault",
+            str(vault),
+            "--seed-outline",
+            str(tmp_path / "does-not-exist.md"),
+        ],
+    )
+    assert result.exit_code == 2
+    assert "Could not read --seed-outline" in result.output
+
+
 def test_draft_seed_fragment_mutually_exclusive_with_topic(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -2595,3 +2595,288 @@ class TestOntologyTwistComposition:
         assert "Use the provided source musings" in prompt
         assert "Do not paraphrase any single source verbatim" in prompt
         assert "Recombine across the corpus" in prompt
+
+
+# ---- Issue #354: --seed-outline multi-section composition -------------------
+
+
+def _ontology_detector_by_phase(
+    phase_by_keyword: dict[str, Phase],
+    *,
+    default_phase: Phase = Phase.PEAKING,
+    weight: float = 0.9,
+) -> Callable[[str], object]:
+    """Return a deterministic detector keyed on a section's text.
+
+    Maps a substring keyword to a detected :class:`Phase` so a test can
+    give different sections different ontologies without any LLM. Every
+    other dimension is left empty so the target profile is driven by the
+    phase pick alone.
+    """
+    from creek.classify.prompt import PromptOntology, WeightedDimension
+
+    def _detect(prompt: str) -> object:
+        lowered = prompt.lower()
+        chosen = default_phase
+        for keyword, phase in phase_by_keyword.items():
+            if keyword.lower() in lowered:
+                chosen = phase
+                break
+        return PromptOntology(
+            prompt=prompt,
+            phases=(WeightedDimension(value=chosen, weight=weight),),
+        )
+
+    return _detect
+
+
+def _empty_detector() -> Callable[[str], object]:
+    """Return a detector that always reports an empty ontology."""
+    from creek.classify.prompt import PromptOntology
+
+    def _detect(prompt: str) -> object:
+        return PromptOntology(prompt=prompt)
+
+    return _detect
+
+
+class TestGenerateOutlineDraft:
+    """``generate_outline_draft`` composes each section, then stitches."""
+
+    def test_two_section_outline_sections_appear_in_order(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """Acceptance: each outline section appears in the draft, in order."""
+        outline = (
+            "## Alpha claim\nThe first movement.\n\n"
+            "## Omega claim\nThe closing movement.\n"
+        )
+
+        def llm(prompt: str) -> str:
+            # Section composition echoes the heading so we can assert
+            # order; the stitch pass returns its input unchanged.
+            if "Alpha claim" in prompt and "Omega claim" in prompt:
+                return prompt  # stitch pass — keep both bodies
+            if "Alpha claim" in prompt:
+                return "BODY-ALPHA"
+            return "BODY-OMEGA"
+
+        gen = DraftGenerator(llm=llm, skills_root=skills_root)
+        draft = gen.generate_outline_draft(
+            outline,
+            vault_path=vault,
+            detect_ontology=_empty_detector(),
+        )
+
+        assert len(draft.sections) == 2
+        assert [s.heading for s in draft.sections] == ["Alpha claim", "Omega claim"]
+        # Both composed bodies survive into the stitched draft, in order.
+        alpha_at = draft.body.index("BODY-ALPHA")
+        omega_at = draft.body.index("BODY-OMEGA")
+        assert alpha_at < omega_at
+
+    def test_five_section_outline(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """Acceptance: a five-section outline yields five ordered sections."""
+        outline = "\n\n".join(f"## Section {n}\nBody {n}." for n in range(1, 6))
+
+        def llm(prompt: str) -> str:
+            return prompt  # echo so each body and the stitch survive
+
+        gen = DraftGenerator(llm=llm, skills_root=skills_root)
+        draft = gen.generate_outline_draft(
+            outline,
+            vault_path=vault,
+            detect_ontology=_empty_detector(),
+        )
+
+        assert len(draft.sections) == 5
+        assert [s.heading for s in draft.sections] == [
+            f"Section {n}" for n in range(1, 6)
+        ]
+
+    def test_mixed_ontologies_recorded_per_section(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """Acceptance: each section records its own detected ontology profile.
+
+        Two sections detect different phases; the per-section target
+        profiles must differ accordingly.
+        """
+        # Source material so each section can retrieve real fragments.
+        for frag_id, phase in (
+            ("frag-rise-1", Phase.RISING),
+            ("frag-rise-2", Phase.RISING),
+            ("frag-with-1", Phase.WITHDRAWAL),
+            ("frag-with-2", Phase.WITHDRAWAL),
+        ):
+            _write_fragment(
+                vault,
+                _build_fragment(
+                    frag_id=frag_id,
+                    primary=Frequency.F7,
+                    phase=phase,
+                    mode=Mode.INHABIT,
+                ),
+                f"{frag_id} body about the work.",
+            )
+        outline = (
+            "## The ascent\nThe rising movement of the work.\n\n"
+            "## The retreat\nThe withdrawal that follows.\n"
+        )
+        detector = _ontology_detector_by_phase(
+            {"ascent": Phase.RISING, "retreat": Phase.WITHDRAWAL},
+        )
+
+        gen = DraftGenerator(llm=lambda p: p, skills_root=skills_root)
+        draft = gen.generate_outline_draft(
+            outline,
+            vault_path=vault,
+            detect_ontology=detector,
+        )
+
+        assert draft.sections[0].target_profile is not None
+        assert draft.sections[1].target_profile is not None
+        assert draft.sections[0].target_profile.phase == "rising"
+        assert draft.sections[1].target_profile.phase == "withdrawal"
+
+    def test_section_with_no_source_material_still_appears(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A section that matches no fragments is still composed and kept."""
+        outline = "## Lonely section\nNothing in the vault matches this.\n"
+
+        gen = DraftGenerator(llm=lambda _p: "FALLBACK BODY", skills_root=skills_root)
+        draft = gen.generate_outline_draft(
+            outline,
+            vault_path=vault,
+            detect_ontology=_empty_detector(),
+        )
+
+        assert len(draft.sections) == 1
+        assert draft.sections[0].heading == "Lonely section"
+        assert "FALLBACK BODY" in draft.body
+
+    def test_no_header_outline_rejected(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """Acceptance: a header-less outline is rejected with a clear error."""
+        from creek.generate.outline import OutlineParseError
+
+        gen = DraftGenerator(llm=lambda _p: "x", skills_root=skills_root)
+        with pytest.raises(OutlineParseError, match="no markdown headers"):
+            gen.generate_outline_draft(
+                "Just a paragraph, no headers at all.\n",
+                vault_path=vault,
+                detect_ontology=_empty_detector(),
+            )
+
+    def test_stitch_pass_receives_connective_tissue_directive(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """Acceptance: the stitch directive forbids paraphrase / invention."""
+        outline = "## One\nFirst.\n\n## Two\nSecond.\n"
+        captured: dict[str, str] = {}
+
+        def llm(prompt: str) -> str:
+            if "Stitch directive" in prompt:
+                captured["stitch"] = prompt
+                return prompt
+            return "section body"
+
+        gen = DraftGenerator(llm=llm, skills_root=skills_root)
+        gen.generate_outline_draft(
+            outline,
+            vault_path=vault,
+            detect_ontology=_empty_detector(),
+        )
+
+        stitch = captured["stitch"]
+        lowered = stitch.lower()
+        assert "transition" in lowered
+        assert "do not" in lowered
+        assert "invent" in lowered
+
+    def test_empty_llm_body_raises(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """An empty stitched body fails loudly rather than saving a blank draft."""
+        outline = "## One\nFirst.\n"
+
+        gen = DraftGenerator(llm=lambda _p: "   ", skills_root=skills_root)
+        with pytest.raises(RuntimeError, match="empty"):
+            gen.generate_outline_draft(
+                outline,
+                vault_path=vault,
+                detect_ontology=_empty_detector(),
+            )
+
+
+class TestSaveOutlineDraft:
+    """``save_outline_draft`` records per-section profiles in frontmatter."""
+
+    def test_frontmatter_records_per_section_profiles(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """Acceptance: per-section ontology profiles land in frontmatter."""
+        outline = (
+            "## The ascent\nThe rising movement.\n\n"
+            "## The retreat\nThe withdrawal that follows.\n"
+        )
+        detector = _ontology_detector_by_phase(
+            {"ascent": Phase.RISING, "retreat": Phase.WITHDRAWAL},
+        )
+
+        gen = DraftGenerator(llm=lambda p: p, skills_root=skills_root)
+        draft = gen.generate_outline_draft(
+            outline,
+            vault_path=vault,
+            detect_ontology=detector,
+        )
+        path = gen.save_outline_draft(draft, vault)
+
+        post = frontmatter.load(str(path))
+        sections_meta = post.metadata["sections"]
+        assert isinstance(sections_meta, list)
+        assert len(sections_meta) == 2
+        assert sections_meta[0]["heading"] == "The ascent"
+        assert sections_meta[0]["target_profile"]["phase"] == "rising"
+        assert sections_meta[1]["target_profile"]["phase"] == "withdrawal"
+
+    def test_saved_draft_is_typed_and_titled(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """The saved file carries the draft type and the outline title."""
+        outline = "# My Essay Title\n\n## Body\nContent here.\n"
+
+        gen = DraftGenerator(llm=lambda _p: "stitched body", skills_root=skills_root)
+        draft = gen.generate_outline_draft(
+            outline,
+            vault_path=vault,
+            detect_ontology=_empty_detector(),
+        )
+        path = gen.save_outline_draft(draft, vault)
+
+        post = frontmatter.load(str(path))
+        assert post.metadata["type"] == "draft"
+        assert post.metadata["title"] == "My Essay Title"
+        assert (vault / DRAFTS_SUBDIR) in path.parents

--- a/creek-tools/tests/test_outline.py
+++ b/creek-tools/tests/test_outline.py
@@ -1,0 +1,243 @@
+"""Tests for the markdown outline parser (issue #354).
+
+The parser is the pure, LLM-free half of the ``--seed-outline`` feature:
+it turns a markdown document with ATX headers into an ordered list of
+:class:`~creek.generate.outline.OutlineSection` records, each one a
+header plus the body text beneath it up to the next header of any level.
+The per-section orchestration that detects, retrieves, composes, and
+stitches lives in :mod:`creek.generate.drafts` and is exercised in
+``test_drafts.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from creek.generate.outline import (
+    OutlineParseError,
+    OutlineSection,
+    build_stitch_prompt,
+    format_stitch_directive,
+    parse_outline,
+)
+
+# ---------------------------------------------------------------------------
+# parse_outline — header detection & body capture
+# ---------------------------------------------------------------------------
+
+
+class TestParseOutline:
+    """``parse_outline`` splits markdown into header-rooted sections."""
+
+    def test_two_section_outline(self) -> None:
+        """Two sibling headers yield two sections, in order."""
+        text = (
+            "## I. The first claim\n"
+            "Riff on the opening thesis.\n\n"
+            "## II. The second claim\n"
+            "The complication that follows.\n"
+        )
+        sections = parse_outline(text)
+        assert [s.heading for s in sections] == [
+            "I. The first claim",
+            "II. The second claim",
+        ]
+        assert sections[0].body == "Riff on the opening thesis."
+        assert sections[1].body == "The complication that follows."
+
+    def test_five_section_outline_preserves_order(self) -> None:
+        """A five-section outline keeps every section in document order."""
+        text = "\n\n".join(
+            f"## Section {n}\nBody for section {n}." for n in range(1, 6)
+        )
+        sections = parse_outline(text)
+        assert len(sections) == 5
+        assert [s.heading for s in sections] == [f"Section {n}" for n in range(1, 6)]
+        assert sections[2].body == "Body for section 3."
+
+    def test_title_header_then_sections(self) -> None:
+        """A ``#`` title plus two ``##`` claims yields three sections.
+
+        Matches the issue's worked example: the title and each claim
+        compose independently and appear in document order.
+        """
+        text = (
+            "# Paranoia's purpose, revisited\n\n"
+            "## I. The paranoia I once explained\n"
+            "Paranoia translates unmet needs.\n\n"
+            "## II. What the explanation missed\n"
+            "The deeper question is what the message is.\n"
+        )
+        sections = parse_outline(text)
+        headings = [s.heading for s in sections]
+        assert headings == [
+            "Paranoia's purpose, revisited",
+            "I. The paranoia I once explained",
+            "II. What the explanation missed",
+        ]
+        assert sections[0].level == 1
+        assert sections[0].body == ""
+        assert sections[1].level == 2
+        assert sections[2].body == "The deeper question is what the message is."
+
+    def test_every_header_opens_its_own_section(self) -> None:
+        """Each header — at any depth — composes as its own section."""
+        text = (
+            "## Parent claim\n"
+            "Intro line.\n\n"
+            "### Supporting point\n"
+            "A nested detail.\n\n"
+            "## Sibling claim\n"
+            "Standalone.\n"
+        )
+        sections = parse_outline(text)
+        headings = [s.heading for s in sections]
+        # Every header opens a section so each composes independently.
+        assert headings == ["Parent claim", "Supporting point", "Sibling claim"]
+        assert sections[0].body == "Intro line."
+        assert sections[1].body == "A nested detail."
+        assert sections[1].level == 3
+
+    def test_any_header_closes_the_current_section(self) -> None:
+        """A following header (any depth) ends the current section's body."""
+        text = "### Deep start\nDeep body.\n\n## Shallower header\nShallow body.\n"
+        sections = parse_outline(text)
+        assert [s.heading for s in sections] == ["Deep start", "Shallower header"]
+        assert sections[0].body == "Deep body."
+
+    def test_section_with_empty_body(self) -> None:
+        """A header with no body produces an empty-body section."""
+        text = "## Heading only\n\n## Next heading\nBody.\n"
+        sections = parse_outline(text)
+        assert sections[0].heading == "Heading only"
+        assert sections[0].body == ""
+
+    def test_records_header_level(self) -> None:
+        """The hash depth is recorded as the section level."""
+        text = "# Title\nbody\n## Sub\nmore\n"
+        sections = parse_outline(text)
+        assert sections[0].level == 1
+        assert sections[1].level == 2
+
+    def test_strips_setext_is_not_treated_as_header(self) -> None:
+        """Only ATX (``#``) headers count; underline syntax is body text."""
+        text = "## Real header\nUnderline title\n=====\nbody\n"
+        sections = parse_outline(text)
+        assert len(sections) == 1
+        assert "Underline title" in sections[0].body
+        assert "=====" in sections[0].body
+
+    def test_ignores_leading_preamble_before_first_header(self) -> None:
+        """Text before the first header is dropped (it has no section)."""
+        text = "Some loose preamble.\n\n## First header\nReal body.\n"
+        sections = parse_outline(text)
+        assert len(sections) == 1
+        assert sections[0].heading == "First header"
+        assert "preamble" not in sections[0].body
+
+    def test_hash_without_space_is_not_a_header(self) -> None:
+        """``#tag`` (no space after hashes) is body, not a header."""
+        text = "## Real\n#hashtag is just text\nbody\n"
+        sections = parse_outline(text)
+        assert len(sections) == 1
+        assert "#hashtag is just text" in sections[0].body
+
+
+class TestParseOutlineErrors:
+    """``parse_outline`` rejects outlines that carry no headers."""
+
+    def test_no_headers_raises(self) -> None:
+        """A header-less document is rejected with a clear error."""
+        with pytest.raises(OutlineParseError, match="no markdown headers"):
+            parse_outline("Just a paragraph.\nAnd another line.\n")
+
+    def test_empty_string_raises(self) -> None:
+        """An empty outline is rejected."""
+        with pytest.raises(OutlineParseError, match="no markdown headers"):
+            parse_outline("")
+
+    def test_whitespace_only_raises(self) -> None:
+        """A whitespace-only outline is rejected."""
+        with pytest.raises(OutlineParseError, match="no markdown headers"):
+            parse_outline("   \n\n\t\n")
+
+    def test_hash_only_without_text_raises(self) -> None:
+        """A line of bare hashes with no heading text is not a header."""
+        with pytest.raises(OutlineParseError, match="no markdown headers"):
+            parse_outline("##\n###\nbody\n")
+
+
+class TestOutlineSection:
+    """The :class:`OutlineSection` value object."""
+
+    def test_seed_text_joins_heading_and_body(self) -> None:
+        """``seed_text`` concatenates heading and body for detection."""
+        section = OutlineSection(heading="The claim", level=2, body="The detail.")
+        assert "The claim" in section.seed_text
+        assert "The detail." in section.seed_text
+
+    def test_seed_text_handles_empty_body(self) -> None:
+        """An empty body leaves only the heading in ``seed_text``."""
+        section = OutlineSection(heading="Just a heading", level=1, body="")
+        assert section.seed_text.strip() == "Just a heading"
+
+    def test_section_is_frozen(self) -> None:
+        """Sections are immutable value objects."""
+        section = OutlineSection(heading="x", level=1, body="y")
+        with pytest.raises(AttributeError):
+            section.heading = "changed"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# stitch directive — connective tissue only
+# ---------------------------------------------------------------------------
+
+
+class TestStitchDirective:
+    """``format_stitch_directive`` forbids paraphrase / invention."""
+
+    def test_directive_forbids_rewriting_content(self) -> None:
+        """The directive constrains the stitch pass to transitions only."""
+        lowered = format_stitch_directive(3).lower()
+        assert "transition" in lowered
+        # The connective-tissue-only contract must be explicit.
+        assert "do not" in lowered
+        assert "paraphrase" in lowered or "rewrite" in lowered
+        assert "invent" in lowered
+
+    def test_directive_mentions_section_count(self) -> None:
+        """The directive names how many sections must survive unchanged."""
+        directive = format_stitch_directive(5)
+        assert "5" in directive
+
+
+class TestBuildStitchPrompt:
+    """``build_stitch_prompt`` assembles the smoothing-pass prompt."""
+
+    def test_prompt_includes_every_section_body(self) -> None:
+        """Each section body appears in the stitch prompt verbatim."""
+        prompt = build_stitch_prompt(
+            [
+                ("First heading", "First body content."),
+                ("Second heading", "Second body content."),
+            ],
+            voice_core="A calm voice.",
+        )
+        assert "First body content." in prompt
+        assert "Second body content." in prompt
+        assert "First heading" in prompt
+        assert "Second heading" in prompt
+
+    def test_prompt_includes_voice_core_when_present(self) -> None:
+        """The voice core is prepended when supplied."""
+        prompt = build_stitch_prompt(
+            [("H", "B")],
+            voice_core="My baseline voice.",
+        )
+        assert "My baseline voice." in prompt
+
+    def test_prompt_carries_the_stitch_directive(self) -> None:
+        """The connective-tissue-only directive is part of the prompt."""
+        prompt = build_stitch_prompt([("H", "B")], voice_core="")
+        assert "transition" in prompt.lower()
+        assert "do not" in prompt.lower()


### PR DESCRIPTION
## Summary

Adds `--seed-outline <file>` and `--seed-outline-text "..."` to `creek draft`, completing the implementation set of epic #349 ("your ideas with a twist").

A markdown outline is parsed into header-rooted sections; each section is composed independently and the sections are stitched into one essay:

1. **Detect** — every section's ontology is detected from its seed text (`detect_ontology`, #350).
2. **Retrieve** — source material is gathered per dimension (`assemble_per_dimension_corpus`, #351).
3. **Compose** — the section is voiced through the ontology-twist path (`twist.py`, #352) when ≥2 source fragments match; otherwise it composes plainly so the section still appears.
4. **Stitch** — a final transition-only pass joins the sections. The stitch directive explicitly forbids paraphrasing, rewriting, condensing, reordering, or inventing content; it may only add connective tissue.

The merged building blocks (#350/#351/#352) are imported and called, not reimplemented. `generate_seeded_draft` and the single-topic path are byte-for-byte unchanged — the outline path is purely additive.

### What changed
- **New `creek/generate/outline.py`** — `parse_outline` (every ATX header opens a section; body runs to the next header of any level), `OutlineSection`, `OutlineParseError`, `format_stitch_directive`, `build_stitch_prompt`. LLM-free, 100% covered.
- **`creek/generate/drafts.py`** — `generate_outline_draft` / `save_outline_draft`, `OutlineDraft` + `SectionComposition` dataclasses, `OntologyDetector` type alias, and small per-section helpers (each < cyclomatic 10). Frontmatter records each section's heading, level, detected/target ontology profile, twist dimensions, and source fragments.
- **`creek/cli.py`** — the two new flags, mutual-exclusion validation (outline vs single-topic seed; inline vs file), the per-vault ontology-detector closure, and the outline-draft runner. Privacy-override auditing runs over the union of per-section source fragments.

### Acceptance criteria
- [x] Each outline section appears in the draft, in order.
- [x] Each section's ontology profile is recorded in frontmatter.
- [x] Stitching adds connective tissue only — it does not paraphrase or invent section content.
- [x] An outline with no markdown headers is rejected with a clear error.

## Test plan
- [x] Parser: 2-section, 5-section, `#` title + `##` claims, nested sub-headers, empty bodies, preamble drop, `#tag` / setext non-headers, and all no-header rejection cases.
- [x] Orchestration: 2-section in order, 5-section, mixed ontologies recorded per section, no-source-material fallback, header-less rejection, stitch directive contents, empty-body guard.
- [x] Save: per-section profiles in frontmatter, draft type + outline title.
- [x] CLI: `--seed-outline` (file) and `--seed-outline-text` (inline) happy paths, no-header rejection, file/inline mutual exclusion, outline/seed mutual exclusion, file-read error, flags advertised in `--help`.
- [x] `./scripts/check-all.sh` — 12/12 gates green, 4518 tests pass, 93.52% total coverage; `outline.py` 100%, new `drafts.py`/`cli.py` code at 100%/99%.

Closes #354. Closes out the implementation set of epic #349.

https://claude.ai/code/session_018XMbrkwQicpFoaSdaAmmEk

---
_Generated by [Claude Code](https://claude.ai/code/session_018XMbrkwQicpFoaSdaAmmEk)_