### PR TITLE
fix(clean): break clean.dedup ↔ ingest.base circular import

### DIFF
--- a/creek-tools/creek/clean/dedup.py
+++ b/creek-tools/creek/clean/dedup.py
@@ -175,10 +175,7 @@ class Deduplicator:
         if result.is_duplicate:
             return result
 
-        # Imported lazily to break the import cycle clean.dedup ->
-        # ingest.base -> models -> classify -> generate -> clean.dedup:
-        # a module-level import re-enters ingest.base before
-        # generate_fragment_id is defined.
+        # Lazy import breaks the dedup -> ingest.base cycle (test_import_cycles.py).
         from creek.ingest.base import generate_fragment_id
 
         fragment_id = generate_fragment_id(source, timestamp, content)

--- a/creek-tools/creek/clean/dedup.py
+++ b/creek-tools/creek/clean/dedup.py
@@ -23,8 +23,6 @@ from typing import Literal
 
 from pydantic import BaseModel
 
-from creek.ingest.base import generate_fragment_id
-
 _MANIFEST_RELATIVE = Path("00-Creek-Meta") / "dedup-manifest.json"
 """Relative path from vault root to the deduplication manifest file."""
 
@@ -176,6 +174,12 @@ class Deduplicator:
         result = self._check_hashes(exact_hash, normalized_hash)
         if result.is_duplicate:
             return result
+
+        # Imported lazily to break the import cycle clean.dedup ->
+        # ingest.base -> models -> classify -> generate -> clean.dedup:
+        # a module-level import re-enters ingest.base before
+        # generate_fragment_id is defined.
+        from creek.ingest.base import generate_fragment_id
 
         fragment_id = generate_fragment_id(source, timestamp, content)
         self._exact_index[exact_hash] = fragment_id

--- a/creek-tools/tests/test_import_cycles.py
+++ b/creek-tools/tests/test_import_cycles.py
@@ -1,0 +1,57 @@
+"""Regression tests guarding against package-level circular imports.
+
+The Creek package has several deep import chains that cross subsystem
+boundaries (``ingest`` → ``models`` → ``classify`` → ``generate`` →
+``clean`` → back to ``ingest``). A circular import in that chain only
+manifests when a specific module is imported *first* in a fresh
+interpreter — once any earlier import populates ``sys.modules``, the
+partially-initialised module is already cached and the cycle is
+masked. The in-process pytest session imports dozens of modules during
+collection, so it cannot reliably catch these.
+
+Each test here therefore spawns a fresh subprocess that imports a
+single entry-point module and nothing else, reproducing the
+clean-interpreter import order an operator hits when they run, e.g.,
+``python -c "import creek.consent"`` or a CLI entry point.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+# Entry-point modules that each sit at the head of a cross-subsystem
+# import chain. Importing any of these first in a clean interpreter
+# must not raise — a regression here means a new circular import was
+# introduced somewhere along the chain.
+_ENTRY_POINT_MODULES = [
+    "creek.consent",
+    "creek.clean.dedup",
+    "creek.ingest.base",
+    "creek.generate.state",
+    "creek.classify.llm.prompts",
+]
+
+
+@pytest.mark.parametrize("module_name", _ENTRY_POINT_MODULES)
+def test_module_imports_cleanly_in_fresh_interpreter(module_name: str) -> None:
+    """Importing *module_name* first in a clean interpreter must not raise.
+
+    Runs ``python -c "import <module_name>"`` in a subprocess so the
+    import order matches a cold start rather than the warmed-up
+    ``sys.modules`` of the pytest session. A non-zero exit code
+    (typically an ``ImportError`` from a partially-initialised module)
+    means a circular import regressed.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", f"import {module_name}"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"importing {module_name!r} in a fresh interpreter failed "
+        f"(circular import?):\n{result.stderr}"
+    )

--- a/creek-tools/tests/test_import_cycles.py
+++ b/creek-tools/tests/test_import_cycles.py
@@ -50,6 +50,7 @@ def test_module_imports_cleanly_in_fresh_interpreter(module_name: str) -> None:
         capture_output=True,
         text=True,
         check=False,
+        timeout=30,
     )
     assert result.returncode == 0, (
         f"importing {module_name!r} in a fresh interpreter failed "


### PR DESCRIPTION
## Summary

A cold-start `import creek.consent` (or any first-import of `creek.ingest.base`) currently raises on `main`:

```
ImportError: cannot import name 'generate_fragment_id' from partially
initialized module 'creek.ingest.base'
```

This is a cross-subsystem circular import that only trips when `ingest.base` is imported **first** in a clean interpreter. The in-process pytest session masks it (earlier-collected modules warm `sys.modules` in a safe order), which is why it slipped through — but a cold CLI start or `python -c "import creek.consent"` hits it every time.

## Root cause

```
ingest.base
  -> models                       (base.py:29)
  -> classify.weighted            (models.py late import, Fragment.weighted forward-ref)
  -> classify.__init__ -> llm -> llm.prompts
  -> generate.indexes -> generate.__init__ -> generate.state
  -> clean.__init__ -> clean.dedup
  -> ingest.base                  (dedup.py:26 — re-entry while partially initialised)
```

`clean/dedup.py` imported `generate_fragment_id` at module top. When the chain re-enters `ingest.base`, only its first 29 lines have run — `generate_fragment_id` (defined at `base.py:322`) doesn't exist yet → `ImportError`.

This cycle was introduced incrementally as the `generate → clean` and `classify → generate` edges were added (the recent draft-composition PRs wired `generate.state → clean.hygiene`), combining with the pre-existing `models → classify.weighted` late import.

## Fix

Move the single `generate_fragment_id` import into the one method that uses it (`Deduplicator._register`, `dedup.py:180`), breaking the back-edge of the cycle. `generate_fragment_id` is referenced exactly once, so the lazy import is a minimal, behaviour-preserving change. The pattern matches the late-import already used in `creek/models.py` for the same family of reasons.

## Regression guard

`tests/test_import_cycles.py` spawns a **fresh subprocess** per cross-subsystem entry-point module and asserts each imports cleanly. A subprocess is required because the in-process session cannot reproduce a cold import order once `sys.modules` is warm. Parametrised over `creek.consent`, `creek.clean.dedup`, `creek.ingest.base`, `creek.generate.state`, `creek.classify.llm.prompts` — two were red before this fix (`creek.consent`, `creek.ingest.base`), all five green after.

## Why now

This blocks PR #384 (the last of the holonic-weighted stack, #369): its merge of current `main` exposes the cycle in the test-collection order. Filing the fix as a standalone bugfix PR (per the maintainer's call) keeps it cleanly separated from the #369 feature; #384 will rebase on top once this lands.

## Test plan

- [x] `uv run pytest tests/test_import_cycles.py -q` → 5 passed (2 red pre-fix).
- [x] `uv run pytest tests/` (wide terminal) → 4541 passed, 1 skipped (Ollama); the pre-existing `test_purge.py` sandbox-`COLUMNS` artifact deselected — unrelated, green in CI.
- [x] `uv run mypy creek/` → 0 issues, 136 files.
- [x] Ruff lint + format, pylint (9.88/10 on `dedup.py`), xenon, refurb, tryceratops, bandit, interrogate (100%) — all clean.

https://claude.ai/code/session_01Rmvpqhr5ktg7abxiHMRdTj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rmvpqhr5ktg7abxiHMRdTj)_