### PR TITLE
feat(crawdad): run-workflow intent in Haiku router (ADAPT-003 Phase 3)

### DIFF
--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -110,18 +110,19 @@ def run_bot(config: CrawDadConfig) -> None:
         ttl_seconds=config.consent.pending_batch_ttl_seconds,
     )
     components = _build_agent_components(config=config, tool_details=tool_details)
-    loop_runner = _build_loop_runner(
-        components=components,
-        session_state=session_state,
-        skill_registry=skill_registry,
-        max_rounds=config.max_loop_rounds,
-    )
     workflow_registry = WorkflowRegistry(vault_path=config.vault_path)
     workflow_runner = _build_workflow_runner(
         components=components,
         session_state=session_state,
         skill_registry=skill_registry,
         registry=workflow_registry,
+    )
+    loop_runner = _build_loop_runner(
+        components=components,
+        session_state=session_state,
+        skill_registry=skill_registry,
+        max_rounds=config.max_loop_rounds,
+        workflow_runner=workflow_runner,
     )
     client = CrawDadClient(
         config=config,
@@ -210,6 +211,7 @@ def _build_loop_runner(
     session_state: SessionState | None,
     skill_registry: SkillStackRegistry,
     max_rounds: int,
+    workflow_runner: WorkflowRunner | None = None,
 ) -> LoopRunner | None:
     """Return a closure that runs one loop turn end-to-end.
 
@@ -223,6 +225,10 @@ def _build_loop_runner(
     ``max_rounds`` (FEAT-036) is forwarded to :func:`run_one_turn` so
     the configured cap applies uniformly to free-text turns and slash
     commands.
+
+    ``workflow_runner`` (ADAPT-003) is forwarded to :func:`run_one_turn`
+    so a router-emitted ``crawdad.run_workflow`` intent dispatches to the
+    same workflow walk the ``/crawdad workflow run`` slash command uses.
     """
     if components.router is None or components.composer is None:
         return None
@@ -256,6 +262,7 @@ def _build_loop_runner(
                 skills=skill_registry.stack,
                 skill_registry=skill_registry,
                 max_rounds=max_rounds,
+                workflow_runner=workflow_runner,
             )
             return _truncate_for_discord(outcome.reply)
         except Exception:

--- a/crawdad/crawdad/dispatcher.py
+++ b/crawdad/crawdad/dispatcher.py
@@ -18,10 +18,14 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict
 
-from crawdad.intents import ACTIVATE_REGISTER_INTENT_TYPE, PrivacyTierCeiling
+from crawdad.intents import (
+    ACTIVATE_REGISTER_INTENT_TYPE,
+    RUN_WORKFLOW_INTENT_TYPE,
+    PrivacyTierCeiling,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Iterable
+    from collections.abc import Awaitable, Callable, Iterable
 
     from crawdad.intents import Intent, RouterResponse
     from crawdad.mcp_client import MCPSession
@@ -32,6 +36,15 @@ if TYPE_CHECKING:
     # the underlying :class:`SkillStackRegistry` and passes its
     # ``activate_register`` method down to the dispatcher.
     RegisterSwitcher = Callable[[str], bool]
+
+    # ADAPT-003: async callable that runs a named workflow end-to-end and
+    # returns the composed user-facing reply. Mirrors the slash-command
+    # ``crawdad.slash_commands.WorkflowRunner`` shape so the CLI can hand
+    # the same closure (built by ``crawdad.cli._build_workflow_runner``)
+    # to both the slash-command surface and the dispatcher. Receives the
+    # workflow ``name`` plus an ``inputs`` mapping for ``{{input.<key>}}``
+    # interpolation.
+    WorkflowDispatchRunner = Callable[[str, dict[str, str]], Awaitable[str]]
 
 _LOGGER = logging.getLogger("crawdad.dispatcher")
 
@@ -69,6 +82,7 @@ class IntentDispatcher:
         session: MCPSession,
         known_tools: Iterable[str],
         register_switcher: RegisterSwitcher | None = None,
+        workflow_runner: WorkflowDispatchRunner | None = None,
     ) -> None:
         """Cache the advertised tools so unknown intents fail fast.
 
@@ -83,10 +97,17 @@ class IntentDispatcher:
                 ``crawdad.activate_register`` intents to soft-error
                 rather than mutate the skill stack — useful in tests
                 and when the registry isn't wired (no vault layout).
+            workflow_runner: ADAPT-003 async callback that walks an
+                authored workflow by name and returns the composed
+                reply. ``None`` causes ``crawdad.run_workflow`` intents
+                to soft-error rather than crash — useful in tests and
+                when the workflow surface isn't wired (no composer /
+                no MCP tools advertised).
         """
         self._session = session
         self._known_tools = frozenset(known_tools)
         self._register_switcher = register_switcher
+        self._workflow_runner = workflow_runner
 
     async def dispatch(self, response: RouterResponse) -> list[ToolResult]:
         """Invoke each intent in order; collect the textual tool results.
@@ -107,6 +128,9 @@ class IntentDispatcher:
         for intent in response.intents:
             if intent.type == ACTIVATE_REGISTER_INTENT_TYPE:
                 results.append(self._handle_activate_register(intent))
+                continue
+            if intent.type == RUN_WORKFLOW_INTENT_TYPE:
+                results.append(await self._handle_run_workflow(intent))
                 continue
             if intent.type not in self._known_tools:
                 msg = (
@@ -156,6 +180,50 @@ class IntentDispatcher:
             body=body,
             privacy_tier_ceiling=intent.privacy_tier_ceiling,
         )
+
+    async def _handle_run_workflow(self, intent: Intent) -> ToolResult:
+        """Run the ADAPT-003 workflow walk for ``crawdad.run_workflow``.
+
+        The result body is the composer's user-facing reply (or a short
+        status line when the workflow surface is unavailable / the
+        intent is malformed). The privacy ceiling on the result mirrors
+        the intent's declared ceiling so downstream consumers see a
+        faithful echo of the router's authorisation.
+        """
+        name = intent.args.get("name")
+        if not isinstance(name, str) or not name:
+            _LOGGER.info("run_workflow intent missing 'name' arg")
+            body = "could not run workflow: no workflow name was provided"
+        elif self._workflow_runner is None:
+            _LOGGER.info("run_workflow intent for %r but no runner is wired", name)
+            body = (
+                f"workflow running is unavailable in this session; "
+                f"ignoring request to run {name!r}"
+            )
+        else:
+            inputs = _extract_workflow_inputs(intent.args.get("inputs"))
+            _LOGGER.info("running workflow %r with inputs %r", name, inputs)
+            body = await self._workflow_runner(name, inputs)
+        return ToolResult(
+            intent_type=intent.type,
+            body=body,
+            privacy_tier_ceiling=intent.privacy_tier_ceiling,
+        )
+
+
+def _extract_workflow_inputs(raw: object) -> dict[str, str]:
+    """Coerce a router-supplied ``inputs`` arg into a ``{str: str}`` mapping.
+
+    Haiku emits ``inputs`` as a free-form object; the workflow walker's
+    ``{{input.<key>}}`` interpolation only handles string values, so we
+    stringify every value and drop non-mapping payloads entirely. A
+    missing or malformed ``inputs`` arg yields an empty dict rather than
+    raising — required inputs are still enforced downstream by the
+    walker's constraint check.
+    """
+    if not isinstance(raw, dict):
+        return {}
+    return {str(key): str(value) for key, value in raw.items()}
 
 
 def _build_arguments(intent: Intent) -> dict[str, object]:

--- a/crawdad/crawdad/intents.py
+++ b/crawdad/crawdad/intents.py
@@ -28,6 +28,15 @@ from pydantic import BaseModel, ConfigDict, Field
 # from MCP ``creek.*`` tools and immune to a future MCP-side collision.
 ACTIVATE_REGISTER_INTENT_TYPE: str = "crawdad.activate_register"
 
+# ADAPT-003: client-side intent for running an authored workflow. Like
+# ``crawdad.activate_register`` the dispatcher recognises this type
+# *before* the MCP known-tools check and routes it to the workflow
+# walker (:func:`crawdad.workflows.run_workflow_and_compose`) instead of
+# an MCP tool call. The ``crawdad.`` namespace prefix keeps it visually
+# distinct from MCP ``creek.*`` tools and immune to a future MCP-side
+# collision.
+RUN_WORKFLOW_INTENT_TYPE: str = "crawdad.run_workflow"
+
 
 class PrivacyTierCeiling(StrEnum):
     """Per-intent privacy tier ceiling.
@@ -91,7 +100,11 @@ def build_intents_schema(tools: list[ToolInfo]) -> dict[str, Any]:
         verbatim and that a downstream JSON parser can validate against.
     """
     tool_names = [tool.name for tool in tools]
-    allowed_types = [*tool_names, ACTIVATE_REGISTER_INTENT_TYPE]
+    allowed_types = [
+        *tool_names,
+        ACTIVATE_REGISTER_INTENT_TYPE,
+        RUN_WORKFLOW_INTENT_TYPE,
+    ]
     return {
         "type": "object",
         "properties": {
@@ -104,9 +117,11 @@ def build_intents_schema(tools: list[ToolInfo]) -> dict[str, Any]:
                             "type": "string",
                             "enum": allowed_types,
                             "description": (
-                                "MCP tool name to invoke, or the client-side "
-                                f"intent {ACTIVATE_REGISTER_INTENT_TYPE!r} to "
-                                "switch the active voice register mid-session."
+                                "MCP tool name to invoke, or a client-side "
+                                f"intent: {ACTIVATE_REGISTER_INTENT_TYPE!r} to "
+                                "switch the active voice register mid-session, "
+                                f"or {RUN_WORKFLOW_INTENT_TYPE!r} to run an "
+                                "authored workflow by name."
                             ),
                         },
                         "privacy_tier_ceiling": {

--- a/crawdad/crawdad/loop.py
+++ b/crawdad/crawdad/loop.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from crawdad.composer import SonnetComposer
+    from crawdad.dispatcher import WorkflowDispatchRunner
     from crawdad.history import ConversationHistory
     from crawdad.mcp_client import MCPClient
     from crawdad.router import IntentRouter
@@ -129,6 +130,7 @@ class AgentLoop:
         skills: VoiceSkillStack,
         skill_registry: SkillStackRegistry | None = None,
         max_rounds: int = MAX_LOOP_ROUNDS,
+        workflow_runner: WorkflowDispatchRunner | None = None,
     ) -> None:
         """Cache injected components for the per-turn :meth:`run` call.
 
@@ -138,6 +140,11 @@ class AgentLoop:
         hands its ``activate_register`` method to the dispatcher so
         register switches persist across turns. Without it the loop
         falls back to the static ``skills`` argument.
+
+        ``workflow_runner`` (ADAPT-003) is the async callback backing
+        ``crawdad.run_workflow`` intents. When supplied, the loop hands
+        it to the dispatcher so natural-language phrasing can drive an
+        authored workflow walk. Without it those intents soft-error.
         """
         self._router = router
         self._composer = composer
@@ -148,6 +155,7 @@ class AgentLoop:
         self._skills = skills
         self._skill_registry = skill_registry
         self._max_rounds = max_rounds
+        self._workflow_runner = workflow_runner
 
     async def run(self, message: str) -> LoopOutcome:
         """Execute one user-turn loop end-to-end."""
@@ -215,6 +223,7 @@ class AgentLoop:
                 session=session,
                 known_tools=self._known_tools,
                 register_switcher=self._register_switcher(),
+                workflow_runner=self._workflow_runner,
             )
             return await dispatcher.dispatch(response)
 
@@ -303,6 +312,7 @@ async def run_one_turn(
     skills: VoiceSkillStack,
     skill_registry: SkillStackRegistry | None = None,
     max_rounds: int = MAX_LOOP_ROUNDS,
+    workflow_runner: WorkflowDispatchRunner | None = None,
 ) -> LoopOutcome:
     """Convenience wrapper the bot handler calls.
 
@@ -319,6 +329,10 @@ async def run_one_turn(
     :class:`AgentLoop`. Defaults to :data:`MAX_LOOP_ROUNDS` so callers
     that do not thread the config value preserve the pre-FEAT-036
     behaviour.
+
+    ``workflow_runner`` (ADAPT-003) — when supplied, the loop hands it
+    to the dispatcher so ``crawdad.run_workflow`` intents drive an
+    authored workflow walk instead of soft-erroring.
     """
     loop = AgentLoop(
         router=router,
@@ -330,5 +344,6 @@ async def run_one_turn(
         skills=skills,
         skill_registry=skill_registry,
         max_rounds=max_rounds,
+        workflow_runner=workflow_runner,
     )
     return await loop.run(message)

--- a/crawdad/crawdad/router.py
+++ b/crawdad/crawdad/router.py
@@ -36,6 +36,7 @@ from pydantic import ValidationError
 
 from crawdad.intents import (
     ACTIVATE_REGISTER_INTENT_TYPE,
+    RUN_WORKFLOW_INTENT_TYPE,
     RouterResponse,
     ToolInfo,
     build_intents_schema,
@@ -126,6 +127,16 @@ def build_router_prompt(
         "Use the lowercase, hyphenated register name (e.g. "
         "`confessional`, `praxis`, `analytic`). Do NOT call any MCP tool "
         "for register switches — the dispatcher handles them locally.\n\n"
+        "Workflow detection (ADAPT-003): when the user asks to run a "
+        "named, multi-step workflow — phrases like "
+        '"/draft phase-transitions", "run the substack-draft workflow", '
+        '"give me the weekly wavelength check-in" — emit a single intent '
+        f'with type "{RUN_WORKFLOW_INTENT_TYPE}" and '
+        '`args: {"name": "<workflow-name>", "inputs": {...}}` BEFORE '
+        "setting `compose: true`. Use the workflow's lowercase, hyphenated "
+        "name; put any free-text the workflow needs under `inputs`. Do NOT "
+        "call individual MCP tools to emulate a workflow — the dispatcher "
+        "drives the authored walk locally.\n\n"
         f"{phase_hint}\n\n"
         f"{wavelength_block}\n\n"
         f"{history_block}\n\n"

--- a/crawdad/tests/test_cli.py
+++ b/crawdad/tests/test_cli.py
@@ -438,6 +438,54 @@ async def test_loop_runner_forwards_max_rounds_into_run_one_turn(
     assert captured["max_rounds"] == 17
 
 
+async def test_loop_runner_forwards_workflow_runner_into_run_one_turn(
+    patched_config: CrawDadConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """ADAPT-003: ``_build_loop_runner`` threads ``workflow_runner`` through.
+
+    The router can emit ``crawdad.run_workflow`` during a free-text
+    turn, so the loop must receive the same workflow runner closure the
+    slash-command surface uses.
+    """
+    from crawdad.loop import LoopOutcome
+    from crawdad.mcp_client import ToolDetails
+
+    details = (
+        ToolDetails(
+            name="creek.state.read",
+            description="Read latest.md",
+            input_schema={"type": "object"},
+        ),
+    )
+    components = cli._build_agent_components(
+        config=patched_config, tool_details=details
+    )
+    captured: dict[str, Any] = {}
+
+    async def _capture(**kwargs: Any) -> LoopOutcome:
+        captured.update(kwargs)
+        return LoopOutcome(kind="composed", reply="ok")
+
+    monkeypatch.setattr(cli, "run_one_turn", _capture)
+
+    async def _workflow_runner(_name: str, _inputs: dict[str, str]) -> str:
+        return "ran"
+
+    runner = cli._build_loop_runner(
+        components=components,
+        session_state=None,
+        skill_registry=_empty_registry(tmp_path),
+        max_rounds=5,
+        workflow_runner=_workflow_runner,
+    )
+
+    assert runner is not None
+    await runner("anything")
+    assert captured["workflow_runner"] is _workflow_runner
+
+
 def test_run_bot_wires_skill_registry_and_register_switcher(
     patched_config: CrawDadConfig,
     monkeypatch: pytest.MonkeyPatch,

--- a/crawdad/tests/test_dispatcher.py
+++ b/crawdad/tests/test_dispatcher.py
@@ -11,7 +11,12 @@ from crawdad.dispatcher import (
     ToolResult,
     UnknownIntentError,
 )
-from crawdad.intents import ACTIVATE_REGISTER_INTENT_TYPE, Intent, RouterResponse
+from crawdad.intents import (
+    ACTIVATE_REGISTER_INTENT_TYPE,
+    RUN_WORKFLOW_INTENT_TYPE,
+    Intent,
+    RouterResponse,
+)
 from crawdad.mcp_client import MCPUnavailableError
 
 
@@ -263,3 +268,204 @@ async def test_dispatcher_intent_ceiling_overrides_conflicting_args() -> None:
     )
 
     assert session.calls[0][1]["privacy_tier_ceiling"] == "personal"
+
+
+async def test_dispatcher_routes_run_workflow_to_runner() -> None:
+    """ADAPT-003: ``run_workflow`` intents bypass MCP and call the runner.
+
+    The dispatcher hands the requested workflow name + inputs to the
+    injected ``workflow_runner`` callable and emits a
+    :class:`ToolResult` carrying the composed reply. No MCP call is
+    made.
+    """
+    calls: list[tuple[str, dict[str, str]]] = []
+
+    async def _runner(name: str, inputs: dict[str, str]) -> str:
+        calls.append((name, inputs))
+        return f"ran {name}"
+
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(
+        session=session,
+        known_tools=("creek.state.read",),
+        workflow_runner=_runner,
+    )
+
+    results = await dispatcher.dispatch(
+        RouterResponse(
+            intents=[
+                Intent(
+                    type=RUN_WORKFLOW_INTENT_TYPE,
+                    args={
+                        "name": "phase-transitions",
+                        "inputs": {"topic": "spirals"},
+                    },
+                )
+            ]
+        )
+    )
+
+    assert calls == [("phase-transitions", {"topic": "spirals"})]
+    assert session.calls == []
+    assert len(results) == 1
+    assert results[0].intent_type == RUN_WORKFLOW_INTENT_TYPE
+    assert results[0].body == "ran phase-transitions"
+
+
+async def test_dispatcher_run_workflow_defaults_inputs_to_empty() -> None:
+    """A run_workflow intent without ``inputs`` runs with an empty mapping."""
+    captured: dict[str, dict[str, str]] = {}
+
+    async def _runner(name: str, inputs: dict[str, str]) -> str:
+        captured[name] = inputs
+        return "ok"
+
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(
+        session=session,
+        known_tools=(),
+        workflow_runner=_runner,
+    )
+
+    await dispatcher.dispatch(
+        RouterResponse(
+            intents=[Intent(type=RUN_WORKFLOW_INTENT_TYPE, args={"name": "weekly"})]
+        )
+    )
+
+    assert captured == {"weekly": {}}
+
+
+async def test_dispatcher_run_workflow_coerces_non_string_inputs() -> None:
+    """Non-string ``inputs`` values are stringified for the walker."""
+    captured: dict[str, str] = {}
+
+    async def _runner(_name: str, inputs: dict[str, str]) -> str:
+        captured.update(inputs)
+        return "ok"
+
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(
+        session=session,
+        known_tools=(),
+        workflow_runner=_runner,
+    )
+
+    await dispatcher.dispatch(
+        RouterResponse(
+            intents=[
+                Intent(
+                    type=RUN_WORKFLOW_INTENT_TYPE,
+                    args={"name": "weekly", "inputs": {"count": 3}},
+                )
+            ]
+        )
+    )
+
+    assert captured == {"count": "3"}
+
+
+async def test_dispatcher_run_workflow_ignores_non_mapping_inputs() -> None:
+    """A malformed ``inputs`` arg (not an object) degrades to an empty dict."""
+    captured: dict[str, dict[str, str]] = {}
+
+    async def _runner(name: str, inputs: dict[str, str]) -> str:
+        captured[name] = inputs
+        return "ok"
+
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(
+        session=session,
+        known_tools=(),
+        workflow_runner=_runner,
+    )
+
+    await dispatcher.dispatch(
+        RouterResponse(
+            intents=[
+                Intent(
+                    type=RUN_WORKFLOW_INTENT_TYPE,
+                    args={"name": "weekly", "inputs": "not-a-mapping"},
+                )
+            ]
+        )
+    )
+
+    assert captured == {"weekly": {}}
+
+
+async def test_dispatcher_run_workflow_without_runner_soft_errors() -> None:
+    """If no runner is wired the dispatcher still produces a soft result.
+
+    Without the soft-fail path a ``run_workflow`` intent emitted by
+    Haiku in a test or misconfigured runtime would crash the loop.
+    """
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(session=session, known_tools=())
+
+    results = await dispatcher.dispatch(
+        RouterResponse(
+            intents=[Intent(type=RUN_WORKFLOW_INTENT_TYPE, args={"name": "weekly"})]
+        )
+    )
+
+    assert len(results) == 1
+    assert "weekly" in results[0].body
+    assert session.calls == []
+
+
+async def test_dispatcher_run_workflow_missing_name_arg_soft_errors() -> None:
+    """A malformed run_workflow intent (no ``name`` arg) soft-errors.
+
+    Defensive: Haiku could emit the intent type without filling the
+    expected ``args["name"]`` slot. The dispatcher must not raise and
+    must not invoke the runner.
+    """
+    invoked: list[str] = []
+
+    async def _runner(name: str, _inputs: dict[str, str]) -> str:
+        invoked.append(name)
+        return "ok"
+
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(
+        session=session,
+        known_tools=(),
+        workflow_runner=_runner,
+    )
+
+    results = await dispatcher.dispatch(
+        RouterResponse(intents=[Intent(type=RUN_WORKFLOW_INTENT_TYPE)])
+    )
+
+    assert invoked == []
+    assert len(results) == 1
+    assert "workflow" in results[0].body.lower()
+
+
+async def test_dispatcher_run_workflow_preserves_privacy_tier_ceiling() -> None:
+    """The result echoes the intent's declared privacy tier ceiling."""
+
+    async def _runner(_name: str, _inputs: dict[str, str]) -> str:
+        return "ok"
+
+    session: Any = _FakeSession()
+    dispatcher = IntentDispatcher(
+        session=session,
+        known_tools=(),
+        workflow_runner=_runner,
+    )
+
+    results = await dispatcher.dispatch(
+        RouterResponse(
+            intents=[
+                Intent(
+                    type=RUN_WORKFLOW_INTENT_TYPE,
+                    privacy_tier_ceiling="personal",
+                    args={"name": "weekly"},
+                )
+            ]
+        )
+    )
+
+    assert results[0].privacy_tier_ceiling == "personal"

--- a/crawdad/tests/test_intents.py
+++ b/crawdad/tests/test_intents.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 
 from crawdad.intents import (
     ACTIVATE_REGISTER_INTENT_TYPE,
+    RUN_WORKFLOW_INTENT_TYPE,
     Intent,
     PrivacyTierCeiling,
     RouterResponse,
@@ -124,17 +125,20 @@ def test_build_intents_schema_lists_each_tool() -> None:
 
 
 def test_build_intents_schema_empty_tool_list() -> None:
-    """Empty tool list still permits the client-side activate_register intent.
+    """Empty tool list still permits the client-side intents.
 
-    The FEAT-029 activate_register intent is handled locally by the
-    dispatcher — it doesn't require an MCP tool — so its type must
-    appear in the schema's ``enum`` regardless of which tools the MCP
-    server advertises.
+    The FEAT-029 activate_register and ADAPT-003 run_workflow intents
+    are handled locally by the dispatcher — they don't require an MCP
+    tool — so their types must appear in the schema's ``enum``
+    regardless of which tools the MCP server advertises.
     """
     schema = build_intents_schema([])
 
     intent_item = schema["properties"]["intents"]["items"]
-    assert intent_item["properties"]["type"]["enum"] == [ACTIVATE_REGISTER_INTENT_TYPE]
+    assert intent_item["properties"]["type"]["enum"] == [
+        ACTIVATE_REGISTER_INTENT_TYPE,
+        RUN_WORKFLOW_INTENT_TYPE,
+    ]
 
 
 def test_build_intents_schema_includes_activate_register_intent_type() -> None:
@@ -163,3 +167,31 @@ def test_activate_register_intent_type_constant_value() -> None:
     """
     assert ACTIVATE_REGISTER_INTENT_TYPE == "crawdad.activate_register"
     assert ACTIVATE_REGISTER_INTENT_TYPE.startswith("crawdad.")
+
+
+def test_build_intents_schema_includes_run_workflow_intent_type() -> None:
+    """ADAPT-003: the schema enumerates the client-side run-workflow intent."""
+    tools = [
+        ToolInfo(
+            name="creek.state.read",
+            description="Read latest.md",
+            input_schema={"type": "object"},
+        ),
+    ]
+
+    schema = build_intents_schema(tools)
+
+    enum = schema["properties"]["intents"]["items"]["properties"]["type"]["enum"]
+    assert RUN_WORKFLOW_INTENT_TYPE in enum
+    assert "creek.state.read" in enum
+
+
+def test_run_workflow_intent_type_constant_value() -> None:
+    """The constant uses the ``crawdad.`` prefix, mirroring activate_register.
+
+    MCP tools are namespaced ``creek.*`` so the prefix flip makes this
+    intent visually distinct in router output and immune to a future
+    MCP tool collision.
+    """
+    assert RUN_WORKFLOW_INTENT_TYPE == "crawdad.run_workflow"
+    assert RUN_WORKFLOW_INTENT_TYPE.startswith("crawdad.")

--- a/crawdad/tests/test_loop.py
+++ b/crawdad/tests/test_loop.py
@@ -619,6 +619,62 @@ async def test_loop_activate_register_unknown_register_soft_errors(
     assert registry.stack is initial
 
 
+async def test_loop_run_workflow_intent_invokes_workflow_runner(
+    state: SessionState, skills: VoiceSkillStack
+) -> None:
+    """ADAPT-003: a ``crawdad.run_workflow`` intent drives the workflow runner.
+
+    End-to-end through the loop: the router emits the intent, the
+    dispatcher calls the injected workflow runner with the requested
+    name + inputs, and the composer sees the workflow's reply as a tool
+    result before producing the final user-facing message.
+    """
+    from crawdad.intents import RUN_WORKFLOW_INTENT_TYPE
+
+    runner_calls: list[tuple[str, dict[str, str]]] = []
+
+    async def _workflow_runner(name: str, inputs: dict[str, str]) -> str:
+        runner_calls.append((name, inputs))
+        return f"workflow {name} done"
+
+    router = _ScriptedRouter(
+        [
+            RouterResponse(
+                intents=[
+                    Intent(
+                        type=RUN_WORKFLOW_INTENT_TYPE,
+                        args={
+                            "name": "phase-transitions",
+                            "inputs": {"topic": "spirals"},
+                        },
+                    )
+                ]
+            ),
+            RouterResponse(intents=[], compose=True),
+        ]
+    )
+    composer = _ScriptedComposer("composed reply")
+    loop = AgentLoop(
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(_ScriptedSession()),  # type: ignore[arg-type]
+        known_tools=(),
+        history=ConversationHistory(),
+        session_state=state,
+        skills=skills,
+        workflow_runner=_workflow_runner,
+    )
+
+    outcome = await loop.run("draft phase-transitions")
+
+    assert outcome.kind == "composed"
+    assert runner_calls == [("phase-transitions", {"topic": "spirals"})]
+    tool_results = composer.calls[0]["tool_results"]
+    assert len(tool_results) == 1
+    assert tool_results[0].intent_type == RUN_WORKFLOW_INTENT_TYPE
+    assert tool_results[0].body == "workflow phase-transitions done"
+
+
 async def test_loop_records_user_and_assistant_turns(
     state: SessionState, skills: VoiceSkillStack
 ) -> None:

--- a/crawdad/tests/test_router.py
+++ b/crawdad/tests/test_router.py
@@ -8,7 +8,12 @@ from typing import Any
 import pytest
 
 from crawdad.history import ConversationHistory
-from crawdad.intents import ACTIVATE_REGISTER_INTENT_TYPE, PrivacyTierCeiling, ToolInfo
+from crawdad.intents import (
+    ACTIVATE_REGISTER_INTENT_TYPE,
+    RUN_WORKFLOW_INTENT_TYPE,
+    PrivacyTierCeiling,
+    ToolInfo,
+)
 from crawdad.router import (
     IntentRouter,
     RouterParseError,
@@ -282,6 +287,74 @@ def test_build_router_prompt_mentions_register_switch_intent(
     assert ACTIVATE_REGISTER_INTENT_TYPE in prompt
     assert "register" in prompt.lower()
     assert "switch" in prompt.lower() or "activate" in prompt.lower()
+
+
+def test_build_router_prompt_mentions_run_workflow_intent(
+    tools: list[ToolInfo], session_state: SessionState
+) -> None:
+    """ADAPT-003: the prompt explains how to emit the run_workflow intent.
+
+    Without the instruction, Haiku will try to satisfy "run the weekly
+    check-in workflow" by hand-assembling individual MCP tool calls.
+    The prompt must name the client-side intent type explicitly so
+    natural phrasing dispatches the authored walk.
+    """
+    prompt = build_router_prompt(
+        message="give me the weekly wavelength check-in",
+        history=ConversationHistory(),
+        state=session_state,
+        tools=tools,
+    )
+
+    assert RUN_WORKFLOW_INTENT_TYPE in prompt
+    assert "workflow" in prompt.lower()
+
+
+async def test_router_emits_run_workflow_for_natural_language_phrase(
+    tools: list[ToolInfo], session_state: SessionState
+) -> None:
+    """A workflow phrase yields a run_workflow intent.
+
+    With the prompt updated to teach Haiku about the intent type, a
+    well-behaved Haiku reply emits ``crawdad.run_workflow`` with the
+    requested workflow name + inputs. We stub the model so the test
+    pins the parsing path, not the model's behavior.
+    """
+    fake_haiku = _FakeAnthropic(
+        json.dumps(
+            {
+                "intents": [
+                    {
+                        "type": RUN_WORKFLOW_INTENT_TYPE,
+                        "args": {
+                            "name": "phase-transitions",
+                            "inputs": {"topic": "spirals"},
+                        },
+                    }
+                ],
+                "compose": True,
+            }
+        )
+    )
+    router = IntentRouter(
+        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        model="claude-haiku-test",
+        tools=tools,
+    )
+
+    response = await router.extract_intents(
+        message="draft phase-transitions",
+        history=ConversationHistory(),
+        state=session_state,
+    )
+
+    assert len(response.intents) == 1
+    assert response.intents[0].type == RUN_WORKFLOW_INTENT_TYPE
+    assert response.intents[0].args == {
+        "name": "phase-transitions",
+        "inputs": {"topic": "spirals"},
+    }
+    assert response.compose is True
 
 
 async def test_router_emits_activate_register_for_natural_language_phrase(


### PR DESCRIPTION
## Summary

ADAPT-003 Phase 3: wires the authored-workflow walker (Phase 2) into the Haiku router so natural-language phrasing dispatches workflows without the `/crawdad workflow run` slash command. Follows the FEAT-029 `crawdad.activate_register` client-side-intent pattern end to end.

Closes #327

## Changes

- **intents.py** — add `RUN_WORKFLOW_INTENT_TYPE = "crawdad.run_workflow"` and include it in the `build_intents_schema(tools)` allowed-types enum, mirroring `ACTIVATE_REGISTER_INTENT_TYPE`.
- **dispatcher.py** — `IntentDispatcher.dispatch` now recognises `crawdad.run_workflow` *before* the MCP-tool check, extracts `name` + optional `inputs`, and invokes an injected async `workflow_runner` callback (added to the constructor). Soft-errors when the runner is unwired or `name` is missing; `inputs` are coerced to a `{str: str}` mapping for the walker's `{{input.<key>}}` interpolation. Returns a `ToolResult` echoing the intent's privacy ceiling.
- **loop.py** — thread `workflow_runner` through `AgentLoop` / `run_one_turn` into the per-round dispatcher so free-text turns reuse the same closure the slash command uses.
- **cli.py** — build the workflow runner before the loop runner and pass it into `_build_loop_runner` → `run_one_turn`.
- **router.py** — `build_router_prompt` now teaches Haiku to emit `crawdad.run_workflow` with `args.name` + `args.inputs` for phrases like "/draft phase-transitions" and "give me the weekly wavelength check-in".

## Tests

- New dispatcher tests: routing to the runner, default/coerced/malformed `inputs`, missing-name + unwired-runner soft errors, privacy-ceiling echo.
- New intents tests: schema enum inclusion + constant value.
- New router tests: prompt mention + parse path for a natural-language workflow phrase.
- New loop test: end-to-end run_workflow intent through `AgentLoop` invoking a fake runner.
- New cli test: `_build_loop_runner` forwards `workflow_runner` into `run_one_turn`.

`./scripts/check-all.sh` exits 0 (406 tests, 95.70% branch coverage; mypy strict, ruff, bandit, interrogate, xenon all clean). `uv run crawdad --help` loads.

https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU

---
_Generated by [Claude Code](https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU)_