### PR TITLE
fix(lint): make "unnamed" check query content, not location

### DIFF
--- a/creek-tools/creek/lint/checks/unnamed.py
+++ b/creek-tools/creek/lint/checks/unnamed.py
@@ -1,10 +1,19 @@
-"""Semantic check: surface the size of ``10-Liminal/Unnamed/``.
+"""Semantic check: surface fragments the classifier could not name.
 
 The full UnnamedDigestGenerator runs as an ingestion step; lint only
-reports how many fragments currently sit in the Unnamed folder so the
-human notices when the backlog grows. It **never** auto-classifies
-those fragments or moves them out — that would violate liminal
-preservation (FEAT-008 non-negotiable rule).
+reports which fragments are currently *unnamed* so the human notices
+when the backlog grows or starts to cluster around a concept the
+ontology is missing.
+
+A fragment is *unnamed* when its primary frequency is
+``unclassified`` — regardless of where it physically lives. Files
+sitting directly under ``10-Liminal/Unnamed/`` are surfaced too, even
+when they do not parse as Creek fragments, so the historical
+folder-based behaviour never regresses. Results are de-duplicated.
+
+The check **never** auto-classifies those fragments or moves them out
+— that would violate liminal preservation (FEAT-008 non-negotiable
+rule).
 """
 
 from __future__ import annotations
@@ -13,29 +22,60 @@ from datetime import datetime  # noqa: TC003  # used at runtime as a parameter t
 from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
 
 from creek.lint._result import CheckResult
+from creek.models import Frequency
+from creek.vault.reader import iter_vault_fragments
 
+_FRAGMENTS_DIR: str = "01-Fragments"
 _UNNAMED_DIR: tuple[str, ...] = ("10-Liminal", "Unnamed")
 _DIGESTS_FOLDER: str = "Digests"
 
 
-def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
-    """Report fragment counts under ``10-Liminal/Unnamed/`` (no auto-classify)."""
-    del since
+def _unclassified_fragment_paths(vault_path: Path) -> list[Path]:
+    """Collect fragments whose primary frequency is ``unclassified``.
+
+    Walks both the fragments root and the Unnamed folder so an
+    unclassified fragment is found wherever it lives.
+    """
+    roots = (
+        vault_path / _FRAGMENTS_DIR,
+        vault_path.joinpath(*_UNNAMED_DIR),
+    )
+    paths: list[Path] = []
+    for root in roots:
+        for path, fragment, _body, _raw in iter_vault_fragments(root):
+            if fragment.frequency.primary == Frequency.UNCLASSIFIED:
+                paths.append(path)
+    return paths
+
+
+def _unnamed_folder_paths(vault_path: Path) -> list[Path]:
+    """Collect every markdown file physically under ``10-Liminal/Unnamed/``.
+
+    Digest pages are excluded; everything else is surfaced even when it
+    is not a parseable Creek fragment, preserving the legacy behaviour.
+    """
     unnamed_dir = vault_path.joinpath(*_UNNAMED_DIR)
     if not unnamed_dir.is_dir():
-        return CheckResult(
-            name="unnamed",
-            summary="0 unnamed fragments (no Unnamed folder yet)",
-            findings=[],
-        )
-    fragments = [
+        return []
+    return [
         md
-        for md in sorted(unnamed_dir.rglob("*.md"))
+        for md in unnamed_dir.rglob("*.md")
         if _DIGESTS_FOLDER not in md.relative_to(unnamed_dir).parts
     ]
+
+
+def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
+    """Report fragments with ``unclassified`` frequency (no auto-classify).
+
+    The ``since`` parameter is accepted for interface symmetry but
+    ignored — the unnamed check is cheap and always scans the vault.
+    """
+    del since
+    paths = set(_unclassified_fragment_paths(vault_path))
+    paths.update(_unnamed_folder_paths(vault_path))
     findings = [
         f"- `{md.relative_to(vault_path)}` (kept liminal; never auto-classified)"
-        for md in fragments
+        for md in sorted(paths)
     ]
-    summary = f"{len(fragments)} fragment(s) sitting in `10-Liminal/Unnamed/`"
+    summary = f"{len(findings)} fragment(s) with unclassified frequency"
     return CheckResult(name="unnamed", summary=summary, findings=findings)

--- a/creek-tools/docs/lint.md
+++ b/creek-tools/docs/lint.md
@@ -56,7 +56,8 @@ Semantic (run when `--since` or an explicit `--check` is passed):
 
 - `paradox` — contradictions routed to `10-Liminal/Paradoxes/`.
 - `synchronicity` — surprising cross-source resonances already on disk.
-- `unnamed` — fragments sitting in `10-Liminal/Unnamed/`.
+- `unnamed` — fragments whose primary frequency is `unclassified`,
+  wherever they live, plus anything physically under `10-Liminal/Unnamed/`.
 
 ## Output
 

--- a/creek-tools/tests/test_lint.py
+++ b/creek-tools/tests/test_lint.py
@@ -90,6 +90,7 @@ def _write_fragment(
     tags: list[str] | None = None,
     created: datetime | None = None,
     links: list[str] | None = None,
+    primary_frequency: str = "F1",
 ) -> Path:
     """Write a minimal fragment markdown file with optional wiki-links."""
     when = created or datetime(2026, 5, 1, tzinfo=UTC)
@@ -100,7 +101,7 @@ def _write_fragment(
         "created": when.isoformat(),
         "ingested": when.isoformat(),
         "source": {"platform": "journal", "author": "self"},
-        "frequency": {"primary": "F1", "secondary": []},
+        "frequency": {"primary": primary_frequency, "secondary": []},
         "tags": tags or [],
     }
     link_text = "\n".join(f"[[{target}]]" for target in (links or []))
@@ -436,18 +437,40 @@ class TestSemanticWrappers:
         result = paradox_check.run(tmp_path)
         assert len(result.findings) == 1
 
-    def test_unnamed_reports_zero_when_folder_missing(self, tmp_path: Path) -> None:
-        """Vault without an Unnamed folder reports zero, not an error."""
-        # Note: not calling _seed_vault — the Unnamed folder is absent.
+    def test_unnamed_reports_zero_for_empty_vault(self, tmp_path: Path) -> None:
+        """A vault with no unclassified fragments reports zero, not an error."""
+        # Note: not calling _seed_vault — nothing to surface.
         result = unnamed_check.run(tmp_path)
         assert result.findings == []
-        assert "no Unnamed folder" in result.summary
+        assert "0 fragment(s)" in result.summary
+
+    def test_unnamed_surfaces_unclassified_fragment_in_fragments_root(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An ``unclassified`` fragment under ``01-Fragments/`` is surfaced."""
+        _seed_vault(tmp_path)
+        _write_fragment(tmp_path, frag_id="51b", primary_frequency="unclassified")
+        result = unnamed_check.run(tmp_path)
+        assert any("51b" in line for line in result.findings)
+        assert "1 fragment(s)" in result.summary
+
+    def test_unnamed_ignores_classified_fragments(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A fragment with a real frequency is not surfaced as unnamed."""
+        _seed_vault(tmp_path)
+        _write_fragment(tmp_path, frag_id="named", primary_frequency="F1")
+        result = unnamed_check.run(tmp_path)
+        assert not any("named" in line for line in result.findings)
+        assert "0 fragment(s)" in result.summary
 
     def test_unnamed_counts_fragments_in_unnamed_folder(
         self,
         tmp_path: Path,
     ) -> None:
-        """Unnamed wrapper finds real fragments under ``10-Liminal/Unnamed``."""
+        """Files physically under ``10-Liminal/Unnamed`` are still surfaced."""
         _seed_vault(tmp_path)
         (tmp_path / "10-Liminal" / "Unnamed" / "lonely.md").write_text(
             "---\nid: lonely\n---\nbody",
@@ -461,6 +484,31 @@ class TestSemanticWrappers:
         result = unnamed_check.run(tmp_path)
         assert any("lonely" in line for line in result.findings)
         assert not any("Digests" in line for line in result.findings)
+
+    def test_unnamed_deduplicates_unclassified_fragment_in_unnamed_folder(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An unclassified fragment living in Unnamed is reported once."""
+        _seed_vault(tmp_path)
+        unnamed_dir = tmp_path / "10-Liminal" / "Unnamed"
+        meta = {
+            "type": "fragment",
+            "id": "drifting",
+            "title": "A note",
+            "created": "2026-05-01T00:00:00+00:00",
+            "ingested": "2026-05-01T00:00:00+00:00",
+            "source": {"platform": "journal", "author": "self"},
+            "frequency": {"primary": "unclassified", "secondary": []},
+            "tags": [],
+        }
+        (unnamed_dir / "drifting.md").write_text(
+            frontmatter.dumps(frontmatter.Post(content="body", **meta)),
+            encoding="utf-8",
+        )
+        result = unnamed_check.run(tmp_path)
+        assert sum("drifting" in line for line in result.findings) == 1
+        assert "1 fragment(s)" in result.summary
 
     def test_synchronicity_reads_recorded_notes(self, tmp_path: Path) -> None:
         """Synchronicity wrapper surfaces notes already on disk."""


### PR DESCRIPTION
## Summary

The `unnamed` semantic lint check previously counted only files physically located under `10-Liminal/Unnamed/`, so it reported `0 fragment(s)` even when fragments with `frequency.primary == unclassified` existed elsewhere (e.g. `01-Fragments/Writing/Substack/`). That was a silent failure of an honest-by-default check.

This implements **Option 1** from the issue: the check now introspects content, mirroring the orphan-compiled pattern.

## Changes

- `creek/lint/checks/unnamed.py`
  - Loads fragments via `iter_vault_fragments` over both the fragments root (`01-Fragments/`) and the Unnamed folder.
  - Surfaces every fragment whose `frequency.primary == Frequency.UNCLASSIFIED`, regardless of physical directory.
  - Still surfaces non-fragment markdown physically under `10-Liminal/Unnamed/` (legacy behavior preserved; `Digests/` still excluded).
  - De-duplicates results so an unclassified fragment living in `Unnamed/` is reported once.
  - Summary now reads `N fragment(s) with unclassified frequency`.
  - Liminal-preservation semantics unchanged: never auto-classifies or moves anything.
- `tests/test_lint.py`
  - Updated the existing `test_unnamed_*` cases to the content-based behavior.
  - Added a case proving an `unclassified` fragment under `01-Fragments/` is surfaced, plus an ignores-classified case and a de-duplication case.
- `docs/lint.md` — updated the one-line description of the `unnamed` check.

## Verification

- `pytest tests/test_lint.py -k unnamed -v` — green (red before the fix).
- `./scripts/check-all.sh` — exit 0 (all 12 gates pass).

Closes #339

https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU

---
_Generated by [Claude Code](https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU)_