### PR TITLE
docs: strip issue-number refs from epic docstrings (outline, twist, dimensional_retrieval, prompt)

### DIFF
--- a/creek-tools/creek/classify/prompt.py
+++ b/creek-tools/creek/classify/prompt.py
@@ -1,4 +1,4 @@
-"""Prompt-level ontology detection (issue #350).
+"""Prompt-level ontology detection.
 
 The fragment classifier in :mod:`creek.classify` answers
 *what ontology dimensions does this **fragment** sit on?* Each
@@ -227,8 +227,8 @@ Placeholders:
 
 The Frequency / Colour / Frequency→Colour blocks are pulled directly
 from :mod:`creek.classify.llm.prompts` to honour the
-single-source-of-truth principle (issue #350 acceptance criterion).
-Re-naming a frequency or re-mapping a colour in the canonical prompt
+single-source-of-truth principle. Re-naming a frequency or re-mapping a
+colour in the canonical prompt
 reaches this template automatically.
 """
 

--- a/creek-tools/creek/generate/dimensional_retrieval.py
+++ b/creek-tools/creek/generate/dimensional_retrieval.py
@@ -1,4 +1,4 @@
-"""Per-dimension corpus retrieval for draft generation (issue #351).
+"""Per-dimension corpus retrieval for draft generation.
 
 The fragment classifier hands :mod:`creek.generate.drafts` one canonical
 ontology pick per dimension. The original draft pipeline ANDed those
@@ -223,7 +223,7 @@ def assemble_per_dimension_corpus(
     ontology: PromptOntology | None = None,
     confidence_threshold: float = 0.0,
 ) -> dict[DimensionKey, DimensionSlice]:
-    """Return one corpus slice per active dimension (issue #351).
+    """Return one corpus slice per active dimension.
 
     Each active dimension — explicit CLI flag or above-threshold
     :class:`~creek.classify.prompt.PromptOntology` entry — fetches its

--- a/creek-tools/creek/generate/outline.py
+++ b/creek-tools/creek/generate/outline.py
@@ -1,12 +1,12 @@
-"""Markdown outline parsing for multi-section drafts (issue #354).
+"""Markdown outline parsing for multi-section drafts.
 
 ``creek draft --seed-topic`` accepts a single phrase. Larger essays carry
-structure — an introduction, a few claims, a synthesis. Issue #354 lets
-the operator hand that structure in directly via ``--seed-outline`` (a
-file path) or ``--seed-outline-text`` (inline), and composes each section
-independently with its own detected ontology profile (issue #350),
-per-dimension retrieval (issue #351), and ontology-twist composition
-(issue #352), then stitches the sections together with a transition-only
+structure — an introduction, a few claims, a synthesis. The
+``--seed-outline`` (a file path) and ``--seed-outline-text`` (inline)
+flags let the operator hand that structure in directly, and the draft
+pipeline composes each section independently with its own detected
+ontology profile, per-dimension retrieval, and ontology-twist
+composition, then stitches the sections together with a transition-only
 smoothing pass.
 
 This module is the pure, LLM-free half of that feature:

--- a/creek-tools/creek/generate/twist.py
+++ b/creek-tools/creek/generate/twist.py
@@ -1,9 +1,9 @@
-"""Ontology-twist composition for ``creek draft`` (issue #352).
+"""Ontology-twist composition for ``creek draft``.
 
 The default composition path retrieves source material per-dimension
-(issue #351) and asks the LLM to weave it. That is enough when the
-operator wants a faithful synthesis of their own voice, but the epic
-goal (#349) is **"your ideas with a twist"** — drafts whose conceptual
+and asks the LLM to weave it. That is enough when the operator wants a
+faithful synthesis of their own voice, but the goal here is **"your
+ideas with a twist"** — drafts whose conceptual
 content comes from the user's vault but whose voice signatures (phase,
 mode, frequency, dosage, register) honour a *target* combination the
 operator has asked for.
@@ -163,7 +163,7 @@ def source_profile_from_fragments(
 
     Args:
         fragments: The retrieved source fragments. Typically the union
-            of the per-dimension slices from issue #351.
+            of the per-dimension corpus slices.
 
     Returns:
         A frozen :class:`OntologyProfile` reflecting the corpus's


### PR DESCRIPTION
## Summary

CLAUDE.md is explicit that docstrings should not reference the current task/fix/issue numbers, since "those belong in the PR description and rot as the codebase evolves." This PR sweeps the `(issue #NNN)` / `(#NNN)` references out of the docstrings in:

- `creek/generate/outline.py` (module docstring had several `(issue #354)` / `(issue #350/351/352)` refs)
- `creek/generate/twist.py` (module docstring + `source_profile_from_fragments` Args)
- `creek/generate/dimensional_retrieval.py` (module + `assemble_per_dimension_corpus` docstrings)
- `creek/classify/prompt.py` (module docstring + the template docstring's `single-source-of-truth` note)

References were reworded to keep the invariant-focused prose where the *why* is non-obvious, and dropped where the surrounding sentence already carries the meaning. PR descriptions and `git blame` retain the issue linkage.

This is docstring-only: no code or behavior changes.

## Scope note

This is the partial sweep for the files no sibling worker touches. The docstring cleanup for `creek/generate/grounding.py`, `creek/generate/drafts.py`, and `creek/cli.py` ships in sibling PRs as part of the same batch.

## Verification

`rg -n 'issue #|\(#[0-9]+\)'` over the four files returns no hits. `./scripts/check-all.sh` passes all gates except one pre-existing, environment-dependent failure (`test_cli_process_prints_errors`) that also fails on a clean `origin/main` checkout in this sandbox — the Rich/Typer rendered output line-wraps the `broken.bin` path across a newline due to terminal width. That test exercises `creek.cli` / `creek.pipeline`, neither of which this PR touches.

Part of #393

https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU

---
_Generated by [Claude Code](https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU)_