### PR TITLE
fix(generate): bucket unnamed digest by authored date (FEAT-031 residual)

### DIFF
--- a/creek-tools/creek/generate/unnamed.py
+++ b/creek-tools/creek/generate/unnamed.py
@@ -39,7 +39,7 @@ import frontmatter
 from pydantic import ValidationError
 
 from creek.models import Fragment
-from creek.time import effective_authored_date
+from creek.time import effective_authored_at, effective_authored_date
 
 if TYPE_CHECKING:
     from datetime import date
@@ -553,7 +553,7 @@ def _render_fragments_section(
         lines.append("No unnamed fragments recorded this week.\n")
         return "\n".join(lines) + "\n"
     for frag in fragments:
-        created = frag.created.date().isoformat()
+        created = effective_authored_at(frag).date().isoformat()
         lines.extend(
             (
                 f"### {frag.title}\n",

--- a/creek-tools/tests/test_unnamed_digest.py
+++ b/creek-tools/tests/test_unnamed_digest.py
@@ -18,7 +18,10 @@ import frontmatter
 import pytest
 
 from creek.config import EmbeddingsConfig
-from creek.generate.unnamed import UnnamedDigestGenerator
+from creek.generate.unnamed import (
+    UnnamedDigestGenerator,
+    _render_fragments_section,
+)
 from creek.link.embeddings import EmbeddingLinker
 from creek.models import Fragment, FragmentSource, SourcePlatform
 
@@ -612,3 +615,41 @@ class TestGenerateWeeklyDigest:
         assert second == first
         assert second.stat().st_mtime >= first_mtime
         assert "[[frag-beta]]" in second.read_text(encoding="utf-8")
+
+
+class TestRenderFragmentsSectionBucketsByAuthoredAt:
+    """FEAT-031: the rendered ``Created`` line uses the authored date."""
+
+    def test_rendered_created_uses_authored_at_not_created(self) -> None:
+        """The ``Created`` line reflects ``authored_at`` over ``created``.
+
+        Two fragments share the same wall-clock ``created`` (the moment
+        Creek ingested them) but carry ``authored_at`` values years
+        apart. The "Fragments This Week" listing must render each
+        fragment's *authored* date, not the shared ingest date — the
+        same class of bug FEAT-031 exists to fix on every time-bucketing
+        surface.
+        """
+        ingest_moment = datetime(2026, 5, 20, 14, 0, 0, tzinfo=UTC)
+        authored_dates = [
+            datetime(2024, 1, 1, 9, 0, 0, tzinfo=UTC),
+            datetime(2025, 6, 1, 9, 0, 0, tzinfo=UTC),
+        ]
+        fragments = [
+            Fragment(
+                id=f"frag-feat031-unnamed-{i}",
+                title=f"Unnamed Reflection {i}",
+                source=FragmentSource(platform=SourcePlatform.JOURNAL),
+                created=ingest_moment,
+                ingested=ingest_moment,
+                authored_at=authored,
+            )
+            for i, authored in enumerate(authored_dates)
+        ]
+        section = _render_fragments_section(fragments, excerpts={})
+        # Each fragment renders its own authored date, not the shared
+        # ingest date.
+        assert "- Created: 2024-01-01" in section
+        assert "- Created: 2025-06-01" in section
+        # The shared wall-clock ingest date must never leak in.
+        assert ingest_moment.date().isoformat() not in section


### PR DESCRIPTION
## What

The "Fragments This Week" listing in the unnamed weekly digest
(`creek/generate/unnamed.py`) rendered each fragment's `created`
(wall-clock ingest) date. For batch-ingested historical corpora this
showed the import date rather than the authored date — exactly the
FEAT-031 class of bug already fixed across the other `generate` and
`link` surfaces (PR #344, PR #311).

This is the final known residual `.created` bucketing site in
`creek/generate/`, flagged by the Claude review on #344.

## Change

- Route the rendered `Created:` line through
  `creek.time.effective_authored_at` (precedence: `authored_at` →
  `ingested`), matching the canonical pattern in `wavelength.py`.
- `rg -n '\.created\b' creek/generate/unnamed.py` now returns zero hits.

## Test

Added `TestRenderFragmentsSectionBucketsByAuthoredAt`, mirroring
`tests/test_link.py::test_detect_threads_buckets_by_authored_at_not_created`:
seeds two fragments sharing the same `created` but with `authored_at`
values years apart, renders the digest section, and asserts each
rendered date reflects its own `authored_at` and the shared ingest date
never leaks in.

## Verification

- `./scripts/check-all.sh`: all gates green except one pre-existing,
  environment-dependent CliRunner line-wrap failure in
  `tests/test_pipeline.py::TestPipelineErrorSurfacing::test_cli_process_prints_errors`
  (reproduces identically on clean `origin/main`; unrelated to this
  change, which only touches `unnamed.py`). 4549 tests pass, coverage
  93.52%.

Closes #347


---
_Generated by [Claude Code](https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU)_