### PR TITLE
test: GAP-008 polish — mock_sleep assertion, ImportError wrap test, SIGTERM docstring

### DIFF
--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -942,6 +942,9 @@ class TestClassify:
         result = classifier.classify(frag)
         assert result.frequency.primary == Frequency.UNCLASSIFIED
         assert mock_call.call_count == 2
+        # One sleep between the two attempts; none after the final failure.
+        # Guards the `time.sleep(self.RETRY_DELAY)` backoff against removal.
+        assert mock_sleep.call_count == classifier.MAX_RETRIES - 1
 
     @patch.object(LLMClassifier, "_call_ollama")
     def test_logs_warning_when_unavailable(
@@ -1012,6 +1015,9 @@ class TestClassify:
         # Final WARN/ERROR line names "retries exhausted" so the operator
         # knows to investigate transport health rather than the fragment.
         assert any("retries exhausted" in r.message.lower() for r in caplog.records)
+        # One sleep between the two attempts; none after the final failure.
+        # Guards the `time.sleep(self.RETRY_DELAY)` backoff against removal.
+        assert mock_sleep.call_count == classifier.MAX_RETRIES - 1
 
     @patch.object(LLMClassifier, "_call_ollama")
     def test_classify_preserves_id_and_title(

--- a/creek-tools/tests/test_classify_engine_interrupt.py
+++ b/creek-tools/tests/test_classify_engine_interrupt.py
@@ -2,20 +2,26 @@
 
 The OPS-001 progress file at
 ``<vault>/00-Creek-Meta/Processing-Log/llm-progress.jsonl`` is what
-makes resume-after-crash a reliable contract. If a SIGINT (Ctrl-C),
-SIGTERM (laptop sleep / container reclamation), or a thrown exception
-catches the engine mid-write, the resulting file must still be
-line-by-line valid JSON — half-written lines would either corrupt
-``json.loads`` on resume or silently re-classify the partially-written
-fragment.
+makes resume-after-crash a reliable contract. If a ``KeyboardInterrupt``
+(SIGINT / Ctrl-C) or any other thrown exception catches the engine
+mid-write, the resulting file must still be line-by-line valid JSON —
+half-written lines would either corrupt ``json.loads`` on resume or
+silently re-classify the partially-written fragment. These exception
+paths are what the tests below pin directly.
 
-The per-line write in ``_record_llm_progress`` opens the file in
-append mode and writes ``{id} + \\n`` as a single ``handle.write``
-call. POSIX guarantees that an O_APPEND write of < ``PIPE_BUF`` bytes
-(typically 4096) is atomic across processes, and a per-fragment JSON
-line is ~30 bytes. So the file's invariant — every non-empty line
-parses as JSON — must survive any interruption between two write
-calls. This test pins that invariant explicitly.
+SIGTERM (laptop sleep / container reclamation) is a different case:
+Python does not raise ``KeyboardInterrupt`` — or anything else — into
+the interpreter on SIGTERM by default; the process simply terminates.
+So the SIGTERM guarantee is not test-pinned. It rests instead on the
+OS-level atomicity described below: the per-line write in
+``_record_llm_progress`` opens the file in append mode and writes
+``{id} + \\n`` as a single ``handle.write`` call. POSIX guarantees
+that an O_APPEND write of < ``PIPE_BUF`` bytes (typically 4096) is
+atomic across processes, and a per-fragment JSON line is ~30 bytes.
+So the file's invariant — every non-empty line parses as JSON —
+survives a hard SIGTERM between two write calls by construction, and
+the exception-path tests below additionally pin it for interruptions
+that *do* raise into Python.
 """
 
 from __future__ import annotations

--- a/creek-tools/tests/test_embeddings.py
+++ b/creek-tools/tests/test_embeddings.py
@@ -150,6 +150,36 @@ class TestLoadModelFailure:
         with pytest.raises(EmbeddingModelUnavailableError):
             linker.load_model()
 
+    def test_importerror_from_torch_is_wrapped(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An ``ImportError`` from the torch import also yields the typed error.
+
+        ``load_model`` and the ``EmbeddingModelUnavailableError`` docstring
+        both list a torch ``ImportError`` (a broken or partial torch install)
+        as a wrapped failure mode; this pins that contract alongside the
+        ``OSError`` and ``RuntimeError`` cases.
+        """
+        from creek.link.embeddings import EmbeddingModelUnavailableError
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            msg = "No module named 'torch'"
+            raise ImportError(msg)
+
+        monkeypatch.setattr(
+            "creek.link.embeddings._load_sentence_transformer",
+            boom,
+        )
+
+        linker = EmbeddingLinker(config=EmbeddingsConfig())
+        with pytest.raises(EmbeddingModelUnavailableError) as excinfo:
+            linker.load_model()
+
+        # The original ImportError is preserved as __cause__ so the operator
+        # can inspect the underlying failure if needed.
+        assert isinstance(excinfo.value.__cause__, ImportError)
+
     def test_message_mentions_cache_dir_when_configured(
         self,
         monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

GAP-008 follow-up polish bundle (from #386 review). Three small test/doc-accuracy items:

1. **Assert on `mock_sleep`** (`tests/test_classify.py`) — added `assert mock_sleep.call_count == MAX_RETRIES - 1` to both the 5xx retry test and `test_returns_unchanged_after_all_retries`, so removing the `time.sleep(RETRY_DELAY)` call would now be caught.
2. **`ImportError` wrapping test** (`tests/test_embeddings.py::TestLoadModelFailure`) — added `test_importerror_from_torch_is_wrapped`, mirroring the existing RuntimeError test, pinning the documented `ImportError → EmbeddingModelUnavailableError` wrap.
3. **SIGTERM vs SIGINT docstring** (`tests/test_classify_engine_interrupt.py`) — clarified that the tests cover SIGINT (`KeyboardInterrupt`); the SIGTERM durability guarantee is OS-level (atomic `O_APPEND` write), not test-pinned, since Python does not raise `KeyboardInterrupt` on SIGTERM by default.

Test-only change. `./scripts/check-all.sh` exits 0.

Closes #395

https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU

---
_Generated by [Claude Code](https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU)_