### PR TITLE
feat(link): re-export EmbeddingModelUnavailableError + dedicated CLI catch

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1086,14 +1086,23 @@ def link(
     config = _load_config_for_vault(vault)
     vault_path = _resolve_vault(vault)
 
+    from creek.link import EmbeddingModelUnavailableError
     from creek.link.link_engine import run_link
 
-    summary = run_link(
-        vault_path=vault_path,
-        config=config,
-        method=method,
-        rebuild=rebuild,
-    )
+    try:
+        summary = run_link(
+            vault_path=vault_path,
+            config=config,
+            method=method,
+            rebuild=rebuild,
+        )
+    except EmbeddingModelUnavailableError as exc:
+        # The sentence-transformer model could not be loaded (GAP-008).
+        # The exception message already names the model and spells out
+        # the remediation, so surface it verbatim and exit non-zero
+        # rather than letting the generic handler swallow the guidance.
+        console.print(f"[red]Embedding linker aborted: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
     console.print(_format_link_summary(summary))
 
 

--- a/creek-tools/creek/link/__init__.py
+++ b/creek-tools/creek/link/__init__.py
@@ -4,6 +4,8 @@ This package provides the four linking stages of the Creek pipeline.
 
 Public API:
     - ``EmbeddingLinker`` — generate embeddings and find semantic resonances
+    - ``EmbeddingModelUnavailableError`` — typed failure when the
+      sentence-transformer model cannot be loaded
     - ``Resonance`` — hierarchy-aware resonance edge (FEAT-024)
     - ``TemporalLink`` — scored temporal proximity link between two fragments
     - ``TemporalLinker`` — find temporal proximity links across sources
@@ -14,7 +16,11 @@ Public API:
 """
 
 from creek.link.eddies import EddyDetector
-from creek.link.embeddings import EmbeddingLinker, Resonance
+from creek.link.embeddings import (
+    EmbeddingLinker,
+    EmbeddingModelUnavailableError,
+    Resonance,
+)
 from creek.link.linker import LinkingPipeline, LinkingResult
 from creek.link.temporal import TemporalLink, TemporalLinker
 from creek.link.threads import ThreadDetector
@@ -22,6 +28,7 @@ from creek.link.threads import ThreadDetector
 __all__ = [
     "EddyDetector",
     "EmbeddingLinker",
+    "EmbeddingModelUnavailableError",
     "LinkingPipeline",
     "LinkingResult",
     "Resonance",

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1127,6 +1127,54 @@ def test_link_embeddings_output_phrases_similarity_edges(tmp_path: Path) -> None
     assert "embeddings.parquet" in result.output
 
 
+def test_link_embeddings_model_unavailable_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A model-load failure aborts ``creek link`` with the remediation.
+
+    When ``sentence_transformers.SentenceTransformer(...)`` cannot be
+    constructed (weights missing offline, corrupt cache, …), the
+    embeddings linker raises ``EmbeddingModelUnavailableError`` whose
+    message names the model and spells out the fix. The CLI must catch
+    that typed error, print its remediation-rich message, and exit
+    non-zero rather than reporting a clean success.
+    """
+    from creek.models import Fragment, FragmentSource, SourcePlatform
+    from tests.helpers import write_fragment_file
+
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    write_fragment_file(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-00000000000c",
+            title="A fragment to embed",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+        ),
+        body="Body text.",
+    )
+
+    def _raise(_model_name: str, _cache_folder: str | None) -> object:
+        msg = "boom"
+        raise OSError(msg)
+
+    monkeypatch.setattr(
+        "creek.link.embeddings._load_sentence_transformer",
+        _raise,
+    )
+
+    result = runner.invoke(
+        app,
+        ["link", "--vault", str(vault), "--method", "embeddings"],
+    )
+    assert result.exit_code != 0
+    normalized = " ".join(_strip_ansi(result.output).split())
+    # The remediation string from EmbeddingModelUnavailableError.
+    assert "run `creek link --method embeddings` once" in normalized
+    assert "network access" in normalized
+
+
 def test_link_eddies_output_phrases_eddies_written(tmp_path: Path) -> None:
     """Eddies CLI output reports both detected and written counts.
 


### PR DESCRIPTION
## Summary

Follow-up from #386 (GAP-008) review, Code Quality item 4.

`EmbeddingModelUnavailableError` lived in `creek/link/embeddings.py` but was not re-exported, so callers had to import from the submodule, bypassing the public surface. The `creek link` CLI also had no dedicated catch — the typed error fell through to the generic handler.

## Changes

- Add `EmbeddingModelUnavailableError` to `creek/link/__init__.py` imports and `__all__`.
- Add a dedicated `except EmbeddingModelUnavailableError` in the `creek link` command that prints the error's (already remediation-rich) message and exits non-zero.
- CLI-level test: invoke `creek link --method embeddings` with the sentence-transformer loader monkeypatched to raise, asserting non-zero exit and the remediation string in output.

`./scripts/check-all.sh` exits 0.

Closes #394

https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU

---
_Generated by [Claude Code](https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU)_