### PR TITLE
feat(draft): surface max_tokens truncation and harden draft CLI

### DIFF
--- a/creek-tools/creek/classify/llm/orchestrator.py
+++ b/creek-tools/creek/classify/llm/orchestrator.py
@@ -27,6 +27,7 @@ from creek.classify.llm.parsing import (
 from creek.classify.llm.prompts import build_classification_prompt
 from creek.classify.llm.providers import (
     ANTHROPIC_CLOUD_WARNING,
+    AnthropicCompletion,
     AnthropicProvider,
     call_ollama,
     check_ollama_available,
@@ -185,6 +186,40 @@ class LLMClassifier:
             Raw response text from the provider.
         """
         return self._invoke_llm(prompt)
+
+    def invoke_prompt_with_metadata(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int | None = None,
+    ) -> AnthropicCompletion:
+        """Dispatch a prompt and return its text plus stop reason.
+
+        The draft pipeline routes through this method so it can detect a
+        ``max_tokens`` truncation and warn the operator instead of saving
+        a silently cut-off essay. The classification path keeps calling
+        :meth:`invoke_prompt`, which discards the stop reason.
+
+        Ollama does not expose a stop reason, so its responses default to
+        ``"end_turn"``; only the Anthropic provider can report
+        ``"max_tokens"``.
+
+        Args:
+            prompt: The fully-formatted prompt.
+            max_tokens: Maximum tokens to request from the Anthropic
+                provider. ``None`` keeps the provider's default ceiling.
+                Ignored by the Ollama path.
+
+        Returns:
+            An :class:`AnthropicCompletion` with the response text and the
+            stop reason.
+        """
+        if self.config.provider == self.ANTHROPIC_PROVIDER:
+            return self._get_anthropic_provider().call_with_metadata(
+                prompt,
+                max_tokens=max_tokens,
+            )
+        return AnthropicCompletion(text=self._call_ollama(prompt))
 
     def _build_prompt(
         self,

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 import os
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import httpx
@@ -27,6 +28,24 @@ if TYPE_CHECKING:
     from creek.config import LLMConfig
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class AnthropicCompletion:
+    """An Anthropic completion paired with its stop reason.
+
+    The classification path discards the stop reason; the draft path
+    needs it so a ``max_tokens`` ceiling can be surfaced instead of
+    truncating the essay mid-sentence without warning.
+
+    Attributes:
+        text: The concatenated textual content of the response.
+        stop_reason: The reason the model stopped generating. ``"end_turn"``
+            on a clean completion; ``"max_tokens"`` when the ceiling was hit.
+    """
+
+    text: str
+    stop_reason: str = "end_turn"
 
 
 ANTHROPIC_CLOUD_WARNING: str = (
@@ -138,18 +157,53 @@ class AnthropicProvider:
                 original exception is re-raised as ``RuntimeError`` with
                 its type name to avoid leaking sensitive request state.
         """
+        return self.call_with_metadata(prompt).text
+
+    def call_with_metadata(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int | None = None,
+    ) -> AnthropicCompletion:
+        """Send a prompt and return its text alongside the stop reason.
+
+        The draft pipeline needs the ``stop_reason`` so it can detect a
+        ``max_tokens`` truncation; the classification path discards it by
+        calling :meth:`call` instead.
+
+        Args:
+            prompt: The fully-formatted prompt.
+            max_tokens: Maximum tokens to request. ``None`` (the default)
+                keeps the historical :attr:`MAX_TOKENS` ceiling so the
+                classification path is unchanged.
+
+        Returns:
+            An :class:`AnthropicCompletion` carrying the concatenated text
+            and the response ``stop_reason`` (``"end_turn"`` when the SDK
+            omits one).
+
+        Raises:
+            RuntimeError: If the SDK raises any ``AnthropicError``; the
+                original exception is re-raised as ``RuntimeError`` with
+                its type name to avoid leaking sensitive request state.
+        """
         import anthropic
 
+        ceiling = self.MAX_TOKENS if max_tokens is None else max_tokens
         try:
             response = self.client.messages.create(
                 model=self.model,
-                max_tokens=self.MAX_TOKENS,
+                max_tokens=ceiling,
                 messages=[{"role": "user", "content": prompt}],
             )
         except anthropic.AnthropicError as exc:
             msg = f"Anthropic API call failed: {type(exc).__name__}"
             raise RuntimeError(msg) from None
-        return _extract_anthropic_text(response)
+        stop_reason = getattr(response, "stop_reason", None) or "end_turn"
+        return AnthropicCompletion(
+            text=_extract_anthropic_text(response),
+            stop_reason=str(stop_reason),
+        )
 
 
 def _extract_anthropic_text(response: object) -> str:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1981,25 +1981,43 @@ def _build_seed_spec(
     )
 
 
-def _build_draft_llm() -> DraftLLM:
+def _build_draft_llm(max_tokens: int | None = None) -> DraftLLM:
     """Construct a :data:`DraftLLM` callable from the configured LLM provider.
 
     Uses the Ollama/Anthropic adapter already wired up for classification.
     Reads the vault-resolved config via :func:`load_config` so the helper
-    keeps a stable zero-arg signature; the ``draft`` command pre-warms
+    keeps a stable signature; the ``draft`` command pre-warms
     ``CREEK_CONFIG`` resolution by calling :func:`_load_config_for_vault`
-    upstream (issue #322).
+    upstream.
+
+    The returned callable yields a
+    :class:`~creek.generate.drafts.DraftLLMResponse` so the draft
+    generator can detect a ``max_tokens`` truncation via the provider's
+    stop reason instead of saving a silently cut-off essay.
+
+    Args:
+        max_tokens: Explicit per-invocation token ceiling (the
+            ``--max-tokens`` flag). ``None`` falls back to the loaded
+            ``draft.max_tokens`` config, then to the provider's built-in
+            default. The Ollama path ignores it.
 
     Returns:
-        A callable ``(prompt) -> response`` ready to feed to
+        A callable ``(prompt) -> DraftLLMResponse`` ready to feed to
         :class:`DraftGenerator`.
 
     Raises:
         typer.Exit: If the configured LLM provider is not reachable.
     """
     from creek.classify.llm import LLMClassifier
+    from creek.generate.drafts import DraftLLMResponse
 
     config = load_config()
+    # The explicit flag wins; otherwise honour the config default. Both
+    # the provider settings and this ceiling come from the same loaded
+    # config so they cannot diverge.
+    effective_max_tokens = (
+        max_tokens if max_tokens is not None else config.draft.max_tokens
+    )
     classifier = LLMClassifier(config.llm)
     if not classifier.available:
         console.print(
@@ -2007,7 +2025,18 @@ def _build_draft_llm() -> DraftLLM:
             "Check Ollama or ANTHROPIC_API_KEY configuration.[/red]",
         )
         raise typer.Exit(code=1)
-    return classifier.invoke_prompt
+
+    def _invoke(prompt: str) -> DraftLLMResponse:
+        completion = classifier.invoke_prompt_with_metadata(
+            prompt,
+            max_tokens=effective_max_tokens,
+        )
+        return DraftLLMResponse(
+            text=completion.text,
+            stop_reason=completion.stop_reason,
+        )
+
+    return _invoke
 
 
 def _run_seeded_draft(
@@ -2021,9 +2050,10 @@ def _run_seeded_draft(
     """Run the seeded-draft pipeline and surface errors as typer exits.
 
     Extracted from :func:`draft` so the CLI command body stays under
-    the cyclomatic-complexity floor. The branches it owns are the two
-    expected error surfaces (``SeedResolutionError`` and
-    ``PluralitySourceError``) plus the happy-path save / audit.
+    the cyclomatic-complexity floor. The branches it owns are the
+    expected error surfaces (``SeedResolutionError``,
+    ``PluralitySourceError``, and a ``RuntimeError`` from an empty LLM
+    body) plus the happy-path save / audit.
     """
     from creek.generate.drafts import SeedResolutionError
     from creek.generate.twist import PluralitySourceError
@@ -2034,7 +2064,7 @@ def _run_seeded_draft(
             vault_path=vault_path,
             current_phase=current_phase,
         )
-    except (SeedResolutionError, PluralitySourceError) as exc:
+    except (SeedResolutionError, PluralitySourceError, RuntimeError) as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=1) from exc
     _audit_privacy_override_if_needed(
@@ -2105,7 +2135,9 @@ def _run_outline_draft(
 
     Extracted from :func:`draft` so the command body stays under the
     cyclomatic-complexity floor. Owns the outline-parse error surface
-    plus the happy-path save / audit.
+    (exit 2, a malformed-input error) and the empty-LLM-body
+    ``RuntimeError`` surface (exit 1, a runtime failure), plus the
+    happy-path save / audit.
     """
     from creek.generate.outline import OutlineParseError
 
@@ -2120,6 +2152,9 @@ def _run_outline_draft(
     except OutlineParseError as exc:
         console.print(f"[red]{exc}[/red]")
         raise typer.Exit(code=2) from exc
+    except RuntimeError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
     fragment_ids = [
         fid for section in outline_draft.sections for fid in section.source_fragments
     ]
@@ -2243,18 +2278,17 @@ def draft(
         False,
         "--ontology-twist",
         help=(
-            "Issue #352: enable ontology-twist composition. Computes the "
+            "Enable ontology-twist composition. Computes the "
             "delta between the retrieved source profile and the operator's "
             "target profile, names divergent dimensions in the prompt, and "
-            "forbids verbatim paraphrase. Requires >=2 source fragments. "
-            "Gated behind a flag while epic #349 is in development."
+            "forbids verbatim paraphrase. Requires >=2 source fragments."
         ),
     ),
     seed_outline: Path | None = typer.Option(
         None,
         "--seed-outline",
         help=(
-            "Issue #354: path to a markdown outline file. Each header-rooted "
+            "Path to a markdown outline file. Each header-rooted "
             "section is composed independently with its own detected ontology, "
             "then stitched together with transition-only smoothing. Mutually "
             "exclusive with --seed-outline-text."
@@ -2264,8 +2298,19 @@ def draft(
         None,
         "--seed-outline-text",
         help=(
-            "Issue #354: inline markdown outline (same per-section composition "
+            "Inline markdown outline (same per-section composition "
             "as --seed-outline). Mutually exclusive with --seed-outline."
+        ),
+    ),
+    max_tokens: int | None = typer.Option(
+        None,
+        "--max-tokens",
+        min=1,
+        help=(
+            "Maximum tokens the draft LLM may generate. Raise this for longer "
+            "essays. Defaults to the vault's draft.max_tokens config (or the "
+            "provider default when unset). A draft cut off at this ceiling is "
+            "flagged truncated in frontmatter and warned about on stderr."
         ),
     ),
 ) -> None:
@@ -2285,20 +2330,24 @@ def draft(
     with the seed flags recorded in the draft's frontmatter for
     reproducibility.
 
-    Issue #352: pass ``--ontology-twist`` alongside a seed flag to
-    enable ontology-twist composition — the draft's source / target
-    ontology profiles are recorded in frontmatter, divergent dimensions
-    are named in the prompt, and the LLM is instructed to recombine
-    across the corpus rather than paraphrase any single source.
-    Requires at least two source fragments.
+    Pass ``--ontology-twist`` alongside a seed flag to enable
+    ontology-twist composition — the draft's source / target ontology
+    profiles are recorded in frontmatter, divergent dimensions are named
+    in the prompt, and the LLM is instructed to recombine across the
+    corpus rather than paraphrase any single source. Requires at least
+    two source fragments.
 
-    Issue #354: pass ``--seed-outline <file>`` or ``--seed-outline-text
-    "..."`` to compose a multi-section essay from a markdown outline.
-    Each header-rooted section is detected, retrieved, and composed
+    Pass ``--seed-outline <file>`` or ``--seed-outline-text "..."`` to
+    compose a multi-section essay from a markdown outline. Each
+    header-rooted section is detected, retrieved, and composed
     independently with its own ontology profile, then stitched together
     with a transition-only smoothing pass. Outline mode is mutually
     exclusive with the single-topic seed flags; a header-less outline is
     rejected with a clear error.
+
+    Pass ``--max-tokens`` to raise the draft LLM's output ceiling for
+    longer essays; a draft cut off at the ceiling is flagged
+    ``truncated`` in frontmatter and warned about on stderr.
     """
     from creek.generate.drafts import DraftGenerator
     from creek.generate.mining import IdeaMiner
@@ -2321,7 +2370,7 @@ def draft(
         seed_spec=seed_spec,
         ontology_twist=ontology_twist,
     )
-    llm = _build_draft_llm()
+    llm = _build_draft_llm(max_tokens)
     if bypass_compiled:
         _warn_bypass_compiled("draft")
 

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -712,10 +712,11 @@ class MiningConfig(BaseModel):
 
 
 class DraftConfig(BaseModel):
-    """Configuration for the ``creek draft`` grounding guard (issue #355).
+    """Configuration for the ``creek draft`` command.
 
-    The bidirectional grounding guard surfaces two failure modes after a
-    draft is generated:
+    Carries the bidirectional grounding-guard thresholds and the default
+    LLM ``max_tokens`` ceiling. The grounding guard surfaces two failure
+    modes after a draft is generated:
 
     * **Too derivative** — at least one draft paragraph paraphrases a
       source-fragment paragraph closely (cosine similarity above
@@ -740,6 +741,15 @@ class DraftConfig(BaseModel):
     *some* source paragraph to count as grounded. Doubles as the
     minimum acceptable fraction of grounded paragraphs: drafts whose
     grounded fraction sits below this value are flagged ``too ungrounded``."""
+
+    max_tokens: int | None = Field(default=None, gt=0)
+    """Default ``max_tokens`` ceiling for the draft LLM call.
+
+    ``None`` keeps the provider's built-in default (1024 for the
+    Anthropic provider). Operators who routinely want longer essays set
+    this so they don't have to pass ``--max-tokens`` on every run; the
+    CLI flag overrides it per invocation. A draft cut off at this ceiling
+    is flagged ``truncated`` in frontmatter and warned about on stderr."""
 
 
 class LintConfig(BaseModel):

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -21,6 +21,7 @@ module.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import operator
 import re
@@ -115,17 +116,44 @@ _MIN_TWIST_SOURCES: int = 2
 
 Mirrors the plurality floor in :mod:`creek.generate.twist`. A section with
 fewer matched fragments drops the twist directive and composes plainly so
-it still appears in the outline draft (issue #354) rather than aborting
-the whole essay the way the single-topic path does.
+it still appears in the outline draft rather than aborting the whole essay
+the way the single-topic path does.
 """
 
 
-DraftLLM = Callable[[str], str]
-"""Signature for draft LLM clients: takes a prompt, returns the draft body."""
+@dataclass(frozen=True)
+class DraftLLMResponse:
+    """A draft LLM response paired with the model's stop reason.
+
+    A draft LLM may return either a plain ``str`` (legacy callers and
+    tests) or this richer object. The text is the draft body; the stop
+    reason lets the generator tell a clean completion apart from a
+    ``max_tokens`` truncation so a cut-off essay is flagged rather than
+    saved silently.
+
+    Attributes:
+        text: The draft body returned by the model.
+        stop_reason: Why the model stopped. ``"end_turn"`` on a clean
+            completion; ``"max_tokens"`` when the ceiling was hit.
+    """
+
+    text: str
+    stop_reason: str = "end_turn"
+
+
+DraftLLM = Callable[[str], "str | DraftLLMResponse"]
+"""Signature for draft LLM clients.
+
+Takes a prompt and returns either the draft body as a plain ``str`` or a
+:class:`DraftLLMResponse` carrying the body plus the model's stop reason.
+A bare string is treated as a clean (``"end_turn"``) completion so legacy
+callers keep working; the CLI adapter returns the richer object so a
+``max_tokens`` truncation can be surfaced.
+"""
 
 
 OntologyDetector = Callable[[str], "PromptOntology"]
-"""Signature for prompt-ontology detectors (issue #350).
+"""Signature for prompt-ontology detectors.
 
 Takes a section's free-form seed text, returns a
 :class:`~creek.classify.prompt.PromptOntology`. Injected into
@@ -134,6 +162,67 @@ deterministic and provider-free — the CLI passes a closure over
 :func:`creek.classify.prompt.detect_ontology` bound to the resolved
 :class:`~creek.config.LLMConfig`.
 """
+
+
+_MAX_TOKENS_STOP_REASON: str = "max_tokens"
+"""Stop reason the LLM reports when output was cut off at the token ceiling."""
+
+_TRUNCATION_WARNING: str = (
+    "[creek draft] WARNING: draft truncated at max_tokens; "
+    "raise --max-tokens or simplify the prompt"
+)
+"""Stderr warning emitted when a draft is cut off at the token ceiling."""
+
+_TRUNCATION_FOOTER: str = "\n\n---\n*(truncated — see frontmatter)*"
+"""Footer appended to a truncated draft body so the file is self-describing."""
+
+
+def _normalise_llm_response(raw: str | DraftLLMResponse) -> DraftLLMResponse:
+    """Coerce a draft LLM return value into a :class:`DraftLLMResponse`.
+
+    A bare ``str`` is wrapped as a clean ``"end_turn"`` completion so the
+    legacy callable signature keeps working unchanged.
+    """
+    if isinstance(raw, DraftLLMResponse):
+        return raw
+    return DraftLLMResponse(text=raw)
+
+
+def _warn_if_truncated(stop_reason: str) -> bool:
+    """Return whether *stop_reason* marks a truncation, warning on stderr.
+
+    Prints :data:`_TRUNCATION_WARNING` to stderr when the model hit the
+    ``max_tokens`` ceiling so an operator running ``creek draft`` sees the
+    essay is incomplete before the saved-path message appears.
+    """
+    if stop_reason != _MAX_TOKENS_STOP_REASON:
+        return False
+    print(_TRUNCATION_WARNING, file=sys.stderr)
+    return True
+
+
+def _draft_file_body(body: str, *, truncated: bool) -> str:
+    """Return the persisted body, appending the truncation footer when cut off.
+
+    The footer makes a truncated file self-describing when opened later
+    without the frontmatter in view.
+    """
+    text = body.strip() + "\n"
+    if truncated:
+        text += _TRUNCATION_FOOTER + "\n"
+    return text
+
+
+def _stitch_prompt_digest(stitch_prompt: str) -> str:
+    """Return a short content hash of *stitch_prompt* for frontmatter.
+
+    The full stitch prompt embeds every section body and can run to
+    10-15 KB; persisting it verbatim bloats the YAML frontmatter enough
+    to slow Obsidian's parse. A content-addressable digest keeps the
+    provenance link without the bulk — the outline input is already
+    recorded verbatim, so the prompt stays reproducible.
+    """
+    return hashlib.sha256(stitch_prompt.encode("utf-8")).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -157,10 +246,10 @@ class SeedSpec:
         phases: Wavelength phases to restrict candidates to.
         modes: Wavelength modes (stances) to restrict candidates to.
         ontology: Optional :class:`~creek.classify.prompt.PromptOntology`
-            from prompt-level detection (issue #350). When set, its
-            weighted dimensions augment the explicit-flag dimensions
-            during per-dimension corpus retrieval (issue #351). An
-            empty ontology is equivalent to ``None``.
+            from prompt-level detection. When set, its weighted
+            dimensions augment the explicit-flag dimensions during
+            per-dimension corpus retrieval. An empty ontology is
+            equivalent to ``None``.
         ontology_confidence_threshold: Minimum weight an ontology
             entry must carry to participate in the per-dimension blend.
             Defaults to ``0.0`` so every parsed entry is honoured;
@@ -220,7 +309,7 @@ class SeedSpec:
 
         Includes prompt-detected :class:`PromptOntology` dimensions so a
         purely-ontology-driven spec still flips into the per-dimension
-        retrieval path (issue #351).
+        retrieval path.
         """
         if self.frequencies or self.phases or self.modes:
             return True
@@ -265,16 +354,17 @@ class SectionComposition:
         level: The header depth (1-6).
         body: The LLM-composed section body before the stitch pass.
         source_profile: Ontology profile aggregated from the section's
-            retrieved source fragments (issue #352). :data:`None` when
-            the section matched no source material.
+            retrieved source fragments. :data:`None` when the section
+            matched no source material.
         target_profile: Ontology profile asked for by the section's
-            detected :class:`~creek.classify.prompt.PromptOntology`
-            (issue #350). Always populated — the detector runs on every
-            section.
+            detected :class:`~creek.classify.prompt.PromptOntology`.
+            Always populated — the detector runs on every section.
         twist_dimensions: Ordered dimension names where the section's
             source profile diverges from its target profile. Empty when
             the profiles match or no source material was found.
         source_fragments: Fragment IDs that fed this section's prompt.
+        truncated: Whether this section's body was cut off at the LLM's
+            ``max_tokens`` ceiling.
     """
 
     heading: str
@@ -284,11 +374,12 @@ class SectionComposition:
     source_profile: OntologyProfile | None = None
     twist_dimensions: tuple[str, ...] = ()
     source_fragments: tuple[str, ...] = ()
+    truncated: bool = False
 
 
 @dataclass(frozen=True)
 class OutlineDraft:
-    """A multi-section draft composed from a markdown outline (issue #354).
+    """A multi-section draft composed from a markdown outline.
 
     The per-section bodies are composed independently (detect → retrieve
     → compose) and then stitched into one continuous essay with a
@@ -302,7 +393,15 @@ class OutlineDraft:
         generated_date: When the outline draft was generated.
         outline_text: The original outline input, recorded verbatim for
             reproducibility.
-        stitch_prompt: The full stitch-pass prompt sent to the LLM.
+        stitch_prompt: The full stitch-pass prompt sent to the LLM. Kept
+            on the in-memory object for inspection but deliberately *not*
+            persisted verbatim — the stitched bodies make it 10-15 KB,
+            large enough to slow Obsidian's frontmatter parse. The saved
+            file records only a short content hash (see
+            :meth:`DraftGenerator.save_outline_draft`); the outline input
+            already captured above makes the prompt reproducible.
+        truncated: Whether the stitch pass was cut off at the LLM's
+            ``max_tokens`` ceiling, or any section body was truncated.
     """
 
     title: str
@@ -311,6 +410,7 @@ class OutlineDraft:
     generated_date: datetime
     outline_text: str
     stitch_prompt: str
+    truncated: bool = False
 
     def __post_init__(self) -> None:
         """Validate outline-draft invariants."""
@@ -342,33 +442,31 @@ class Draft:
         seed_spec: Manual-seed specification (FEAT-032) when the draft
             was produced via ``creek draft --seed-*`` flags; ``None``
             for drafts surfaced via the idea miner.
-        per_dimension_sources: Per-dimension corpus attribution (issue
-            #351). Maps a ``"kind:value"`` label (e.g.,
-            ``"phase:peaking"``) to the tuple of fragment IDs that
-            entered the LLM prompt as that dimension's labelled
-            section. Empty when the draft used the legacy
-            single-dimension path; populated whenever
+        per_dimension_sources: Per-dimension corpus attribution. Maps a
+            ``"kind:value"`` label (e.g., ``"phase:peaking"``) to the
+            tuple of fragment IDs that entered the LLM prompt as that
+            dimension's labelled section. Empty when the draft used the
+            legacy single-dimension path; populated whenever
             :func:`assemble_per_dimension_corpus` ran.
         source_profile: Ontology profile aggregated from the retrieved
-            source fragments (issue #352). ``None`` when the draft did
-            not pass through the twist composition path.
+            source fragments. ``None`` when the draft did not pass
+            through the twist composition path.
         target_profile: Ontology profile asked for by the operator
             (explicit flags + detected :class:`PromptOntology`). ``None``
             when the draft did not pass through the twist composition
             path.
         twist_dimensions: Ordered tuple of dimension names where the
-            source profile diverges from the target profile (issue
-            #352). Empty when the two profiles match (regression
-            baseline) or when twist composition was not requested.
+            source profile diverges from the target profile. Empty when
+            the two profiles match or when twist composition was not
+            requested.
         derivative_score: Bidirectional grounding guard's derivative
-            metric (issue #355). The maximum paragraph cosine
-            similarity recorded between the draft body and every
-            paragraph of the source fragments that fed the prompt.
-            ``None`` when the guard did not run (no embedding callable
-            wired) so the field reads as "not yet evaluated" rather
-            than "evaluated clean".
+            metric. The maximum paragraph cosine similarity recorded
+            between the draft body and every paragraph of the source
+            fragments that fed the prompt. ``None`` when the guard did
+            not run (no embedding callable wired) so the field reads as
+            "not yet evaluated" rather than "evaluated clean".
         grounding_score: Bidirectional grounding guard's grounding
-            metric (issue #355). The fraction of draft paragraphs whose
+            metric. The fraction of draft paragraphs whose
             ``max_similarity`` cleared
             :attr:`creek.config.DraftConfig.grounding_lower` against
             *some* source paragraph. ``None`` when the guard did not
@@ -377,6 +475,8 @@ class Draft:
             :class:`creek.generate.grounding.GroundingReport`. Each
             entry carries ``{index, max_similarity, is_derivative,
             is_grounded}``. Empty when the guard did not run.
+        truncated: Whether the draft body was cut off at the LLM's
+            ``max_tokens`` ceiling.
     """
 
     title: str
@@ -396,6 +496,7 @@ class Draft:
     derivative_score: float | None = None
     grounding_score: float | None = None
     paragraph_grounding: tuple[ParagraphAnnotation, ...] = field(default_factory=tuple)
+    truncated: bool = False
 
     def __post_init__(self) -> None:
         """Validate draft invariants."""
@@ -633,15 +734,14 @@ class DraftGenerator:
                 step skips the compiled layer and pulls fragments
                 directly. Default ``False`` honours the FEAT-004
                 compile-then-query discipline.
-            ontology_twist: When ``True``, activate the issue #352
+            ontology_twist: When ``True``, activate the twist
                 composition path: compute source/target ontology
                 profiles, name the divergent dimensions in the prompt,
                 forbid verbatim paraphrase, and require ≥2 source
                 fragments. Default ``False`` keeps the legacy
-                composition path (epic #349 gates the flag while in
-                development).
+                composition path.
             embedding_fn: Optional paragraph embedding callable for the
-                issue #355 bidirectional grounding guard. When
+                bidirectional grounding guard. When
                 supplied, every generated draft is scored against its
                 source fragments and the scores are written to the
                 returned :class:`Draft` and the saved frontmatter. When
@@ -796,7 +896,7 @@ class DraftGenerator:
                 :attr:`bypass_compiled`.
             include_fragments: When ``True`` (default), render the
                 ``## Source fragments`` block. The per-dimension path
-                (issue #351) sets this ``False`` because the fragments
+                sets this ``False`` because the fragments
                 are already laid out in the labelled per-dimension
                 sections; double-rendering would amplify the heaviest
                 ontology corner over the others.
@@ -928,16 +1028,16 @@ class DraftGenerator:
     ) -> str:
         """Assemble the LLM prompt from voice-core + skills + source + ask.
 
-        When *per_dimension_material* is supplied (issue #351), it is
-        inserted ahead of the legacy ``## Source material`` block so the
-        LLM sees the labelled per-dimension sections first and can weave
-        them. Both blocks may co-exist — the per-dimension block carries
-        the dimensional corpus slices, the legacy block still carries
-        thread / eddy context for the synthetic IdeaSeed.
+        When *per_dimension_material* is supplied, it is inserted ahead
+        of the legacy ``## Source material`` block so the LLM sees the
+        labelled per-dimension sections first and can weave them. Both
+        blocks may co-exist — the per-dimension block carries the
+        dimensional corpus slices, the legacy block still carries thread
+        / eddy context for the synthetic IdeaSeed.
 
-        When *twist_directive* is supplied (issue #352), it is inserted
-        immediately before the ``## Ask`` block so the LLM sees the
-        recombination instruction as the last thing before its task.
+        When *twist_directive* is supplied, it is inserted immediately
+        before the ``## Ask`` block so the LLM sees the recombination
+        instruction as the last thing before its task.
         """
         parts: list[str] = []
         if self.voice_core:
@@ -967,7 +1067,7 @@ class DraftGenerator:
         source_fragments: tuple[str, ...],
         fragments: dict[str, tuple[Fragment, str]],
     ) -> GroundingReport | None:
-        """Run the issue #355 grounding guard, or return ``None`` when disabled.
+        """Run the grounding guard, or return ``None`` when disabled.
 
         The guard runs only when both an embedding callable and a
         :class:`GroundingThresholds` instance were supplied at
@@ -1044,10 +1144,10 @@ class DraftGenerator:
             compiled_pages=compiled_pages,
         )
         prompt = self._compose_prompt(idea, skill_stack, source_material)
-        body = self._llm(prompt).strip()
-        if not body:
-            msg = "LLM returned an empty draft body"
-            raise RuntimeError(msg)
+        body, truncated = self._invoke_draft_llm(
+            prompt,
+            empty_message="LLM returned an empty draft body",
+        )
         guard = self._build_guard_report(
             body=body,
             source_fragments=idea.source_fragments,
@@ -1068,7 +1168,40 @@ class DraftGenerator:
             derivative_score=guard.derivative_score if guard else None,
             grounding_score=guard.grounding_score if guard else None,
             paragraph_grounding=_guard_annotations(guard),
+            truncated=truncated,
         )
+
+    def _invoke_draft_llm(
+        self,
+        prompt: str,
+        *,
+        empty_message: str,
+    ) -> tuple[str, bool]:
+        """Call the draft LLM, returning ``(body, truncated)``.
+
+        Normalises the legacy ``str`` return into a
+        :class:`DraftLLMResponse`, strips the body, fails loudly on an
+        empty body, and warns on stderr when the model stopped at the
+        ``max_tokens`` ceiling.
+
+        Args:
+            prompt: The fully-composed prompt to send.
+            empty_message: Error message for the :class:`RuntimeError`
+                raised when the body is empty.
+
+        Returns:
+            A ``(body, truncated)`` tuple where *truncated* is ``True``
+            when the stop reason was ``max_tokens``.
+
+        Raises:
+            RuntimeError: When the LLM returns an empty body.
+        """
+        response = _normalise_llm_response(self._llm(prompt))
+        body = response.text.strip()
+        if not body:
+            raise RuntimeError(empty_message)
+        truncated = _warn_if_truncated(response.stop_reason)
+        return body, truncated
 
     def resolve_seed(
         self,
@@ -1104,8 +1237,7 @@ class DraftGenerator:
             SeedResolutionError: When *spec* is empty, the requested
                 ``fragment_id`` is not in the vault, the dimensional /
                 topic filters match zero fragments, or every active
-                dimension produced an empty per-dimension slice (issue
-                #351).
+                dimension produced an empty per-dimension slice.
         """
         if spec.is_empty:
             msg = "SeedSpec is empty — cannot resolve an idea seed"
@@ -1152,13 +1284,12 @@ class DraftGenerator:
         slices: dict[DimensionKey, DimensionSlice],
         loaded: dict[str, tuple[Fragment, str]],
     ) -> IdeaSeed:
-        """Build an IdeaSeed from per-dimension slices (issue #351, OR path).
+        """Build an IdeaSeed from per-dimension slices (OR-semantics path).
 
         Emits a logger warning naming each empty dimension and proceeds
-        whenever at least one slice has matches, per the #351
-        acceptance criterion. Raises :class:`SeedResolutionError` when
-        every dimension is empty so the CLI's existing error path
-        prints a clear diagnostic.
+        whenever at least one slice has matches. Raises
+        :class:`SeedResolutionError` when every dimension is empty so the
+        CLI's existing error path prints a clear diagnostic.
         """
         try:
             raise_if_all_empty(slices)
@@ -1271,7 +1402,7 @@ class DraftGenerator:
         the caller did not pass ``current_phase``, the spec's phase is
         used so the activated phase skill matches the user's request.
 
-        When :attr:`ontology_twist` is enabled (issue #352), the
+        When :attr:`ontology_twist` is enabled, the
         retrieved source material has its dominant ontology profile
         compared against the operator's target profile; divergent
         dimensions are named in a ``## Twist directive`` block and the
@@ -1337,10 +1468,10 @@ class DraftGenerator:
             twist_directive=twist_payload.directive,
             twist_active=bool(twist_payload.dimensions),
         )
-        body = self._llm(prompt).strip()
-        if not body:
-            msg = "LLM returned an empty draft body"
-            raise RuntimeError(msg)
+        body, truncated = self._invoke_draft_llm(
+            prompt,
+            empty_message="LLM returned an empty draft body",
+        )
         guard = self._build_guard_report(
             body=body,
             source_fragments=idea.source_fragments,
@@ -1366,6 +1497,7 @@ class DraftGenerator:
             derivative_score=guard.derivative_score if guard else None,
             grounding_score=guard.grounding_score if guard else None,
             paragraph_grounding=_guard_annotations(guard),
+            truncated=truncated,
         )
 
     def _build_twist_payload(
@@ -1406,14 +1538,13 @@ class DraftGenerator:
         detect_ontology: OntologyDetector,
         current_phase: Phase | None = None,
     ) -> OutlineDraft:
-        """Compose a multi-section draft from a markdown *outline_text* (issue #354).
+        """Compose a multi-section draft from a markdown *outline_text*.
 
         Each outline section is composed independently — its ontology is
-        detected (issue #350), its source material is retrieved per
-        dimension (issue #351), and it is voiced through the
-        ontology-twist path (issue #352) when at least two source
-        fragments match. A final stitch pass smooths transitions between
-        the sections without paraphrasing or inventing content
+        detected, its source material is retrieved per dimension, and it
+        is voiced through the ontology-twist path when at least two
+        source fragments match. A final stitch pass smooths transitions
+        between the sections without paraphrasing or inventing content
         (connective tissue only).
 
         Args:
@@ -1457,10 +1588,11 @@ class DraftGenerator:
             [(section.heading, section.body) for section in sections],
             voice_core=self.voice_core,
         )
-        body = self._llm(stitch_prompt).strip()
-        if not body:
-            msg = "LLM returned an empty stitched draft body"
-            raise RuntimeError(msg)
+        body, stitch_truncated = self._invoke_draft_llm(
+            stitch_prompt,
+            empty_message="LLM returned an empty stitched draft body",
+        )
+        truncated = stitch_truncated or any(section.truncated for section in sections)
         return OutlineDraft(
             title=parsed[0].heading,
             body=body,
@@ -1468,6 +1600,7 @@ class DraftGenerator:
             generated_date=datetime.now(tz=UTC),
             outline_text=outline_text,
             stitch_prompt=stitch_prompt,
+            truncated=truncated,
         )
 
     def _compose_section(
@@ -1479,15 +1612,14 @@ class DraftGenerator:
         current_phase: Phase | None,
         fragments: dict[str, tuple[Fragment, str]],
     ) -> SectionComposition:
-        """Detect, retrieve, and compose one outline *section* (issue #354).
+        """Detect, retrieve, and compose one outline *section*.
 
         The section's ontology is detected from its seed text and folded
         into a topic-plus-ontology :class:`SeedSpec`. When the spec
         resolves to source material the section is composed through the
         seeded-draft pipeline; otherwise it falls back to a bare
-        skill-stack compose so the section still appears in the draft
-        (the #354 acceptance criterion). The target profile is always
-        recorded from the detected ontology.
+        skill-stack compose so the section still appears in the draft.
+        The target profile is always recorded from the detected ontology.
         """
         ontology = detect_ontology(section.seed_text)
         spec = _section_seed_spec(section, ontology)
@@ -1495,12 +1627,13 @@ class DraftGenerator:
         try:
             idea = self.resolve_seed(spec, vault_path=vault_path, fragments=fragments)
         except SeedResolutionError:
-            body = self._compose_bare_section(section, current_phase)
+            body, truncated = self._compose_bare_section(section, current_phase)
             return SectionComposition(
                 heading=section.heading,
                 level=section.level,
                 body=body,
                 target_profile=target_profile,
+                truncated=truncated,
             )
         return self._compose_resolved_section(
             section,
@@ -1530,12 +1663,17 @@ class DraftGenerator:
         single-source section drops the twist directive rather than
         failing — a section is a sub-part of the essay, so the
         plurality floor is relaxed to keep the section in the draft.
+
+        The section's source profile is aggregated once here and threaded
+        into :meth:`_section_twist_payload` so the dominant-value
+        aggregation is not recomputed when ontology-twist is active.
         """
-        twist = self._section_twist_payload(spec, idea, fragments)
-        source_profile = source_profile_from_fragments(
-            [fragments[fid][0] for fid in idea.source_fragments if fid in fragments],
-        )
-        body = self._render_section_body(
+        retrieved = [
+            fragments[fid][0] for fid in idea.source_fragments if fid in fragments
+        ]
+        source_profile = source_profile_from_fragments(retrieved)
+        twist = self._section_twist_payload(spec, idea, source_profile=source_profile)
+        body, truncated = self._render_section_body(
             idea,
             spec=spec,
             twist=twist,
@@ -1551,13 +1689,15 @@ class DraftGenerator:
             source_profile=source_profile,
             twist_dimensions=twist.dimensions,
             source_fragments=idea.source_fragments,
+            truncated=truncated,
         )
 
     def _section_twist_payload(
         self,
         spec: SeedSpec,
         idea: IdeaSeed,
-        fragments: dict[str, tuple[Fragment, str]],
+        *,
+        source_profile: OntologyProfile,
     ) -> _TwistPayload:
         """Return the twist payload for a section, or empty when not applicable.
 
@@ -1565,13 +1705,20 @@ class DraftGenerator:
         fragments. A single-source section returns an empty payload so it
         still composes (the plurality floor is a hard error only on the
         single-topic ``generate_seeded_draft`` path).
+
+        Args:
+            spec: The section's seed specification.
+            idea: The resolved idea seed for the section.
+            source_profile: The section's source profile, aggregated once
+                by the caller and threaded in to avoid recomputing the
+                dominant-value aggregation.
+
+        Returns:
+            A populated :class:`_TwistPayload` when twist composition
+            applies, otherwise the empty default payload.
         """
         if not self.ontology_twist or len(idea.source_fragments) < _MIN_TWIST_SOURCES:
             return _TwistPayload()
-        retrieved = [
-            fragments[fid][0] for fid in idea.source_fragments if fid in fragments
-        ]
-        source_profile = source_profile_from_fragments(retrieved)
         target_profile = target_profile_from_spec(spec)
         divergent = twist_dimensions(source_profile, target_profile)
         directive = format_twist_directive(source_profile, target_profile, divergent)
@@ -1591,8 +1738,8 @@ class DraftGenerator:
         vault_path: Path,
         current_phase: Phase | None,
         fragments: dict[str, tuple[Fragment, str]],
-    ) -> str:
-        """Build the per-section prompt and return the composed body."""
+    ) -> tuple[str, bool]:
+        """Build the per-section prompt and return ``(body, truncated)``."""
         effective_phase = current_phase
         if effective_phase is None and spec.phases:
             effective_phase = spec.phases[0]
@@ -1629,8 +1776,8 @@ class DraftGenerator:
         self,
         section: OutlineSection,
         current_phase: Phase | None,
-    ) -> str:
-        """Compose a section with no source material from its seed text alone.
+    ) -> tuple[str, bool]:
+        """Compose a source-less section, returning ``(body, truncated)``.
 
         The section still gets the voice core and (when classified) the
         phase skill, but the ask is built directly from the section's
@@ -1651,24 +1798,34 @@ class DraftGenerator:
         )
         return self._invoke_section_llm("\n\n".join(parts))
 
-    def _invoke_section_llm(self, prompt: str) -> str:
-        """Call the LLM for one section, failing loudly on an empty body."""
-        body = self._llm(prompt).strip()
-        if not body:
-            msg = "LLM returned an empty section body"
-            raise RuntimeError(msg)
-        return body
+    def _invoke_section_llm(self, prompt: str) -> tuple[str, bool]:
+        """Call the LLM for one section, returning ``(body, truncated)``.
+
+        Fails loudly on an empty body and warns on stderr when the
+        section was cut off at the ``max_tokens`` ceiling.
+        """
+        return self._invoke_draft_llm(
+            prompt,
+            empty_message="LLM returned an empty section body",
+        )
 
     def save_outline_draft(
         self,
         draft: OutlineDraft,
         vault_path: Path,
     ) -> Path:
-        """Write an :class:`OutlineDraft` to ``07-Voice/Drafts/`` (issue #354).
+        """Write an :class:`OutlineDraft` to ``07-Voice/Drafts/``.
 
         The frontmatter records each section's heading, level, source
         fragments, and detected/target ontology profiles so a reader can
         trace every section back to its ontology and sources.
+
+        The stitch prompt is recorded as a ``stitch_prompt_sha256``
+        content hash rather than verbatim: the full prompt embeds every
+        section body and can run to 10-15 KB, large enough to slow
+        Obsidian's frontmatter parse. The verbatim outline input is still
+        stored, so the prompt remains reproducible. A truncated draft is
+        flagged with ``truncated: true`` and gets a footer in the body.
 
         Args:
             draft: The outline draft to persist.
@@ -1683,14 +1840,15 @@ class DraftGenerator:
         date_prefix = draft.generated_date.strftime("%Y-%m-%d")
         target = _next_available_draft_path(drafts_dir, date_prefix, slug)
         post = frontmatter.Post(
-            content=draft.body.strip() + "\n",
+            content=_draft_file_body(draft.body, truncated=draft.truncated),
             type="draft",
             title=draft.title,
             status="draft",
             idea_strategy="seed_outline",
             generated_date=draft.generated_date.isoformat(),
             outline=draft.outline_text,
-            stitch_prompt=draft.stitch_prompt,
+            stitch_prompt_sha256=_stitch_prompt_digest(draft.stitch_prompt),
+            truncated=draft.truncated,
             sections=[_serialise_section(section) for section in draft.sections],
         )
         target.write_text(frontmatter.dumps(post), encoding="utf-8")
@@ -1715,7 +1873,7 @@ class DraftGenerator:
         date_prefix = draft.generated_date.strftime("%Y-%m-%d")
         target = _next_available_draft_path(drafts_dir, date_prefix, slug)
         post = frontmatter.Post(
-            content=draft.body.strip() + "\n",
+            content=_draft_file_body(draft.body, truncated=draft.truncated),
             type="draft",
             title=draft.title,
             status="draft",
@@ -1726,6 +1884,7 @@ class DraftGenerator:
             activated_skills=list(draft.skill_stack),
             generated_date=draft.generated_date.isoformat(),
             prompt=draft.prompt,
+            truncated=draft.truncated,
         )
         if draft.seed_spec is not None:
             post["seed"] = _serialise_seed_spec(draft.seed_spec)
@@ -1844,9 +2003,9 @@ def _serialise_section(section: SectionComposition) -> dict[str, object]:
     Records the section's heading, level, target ontology profile, and —
     when source material was found — its source profile, divergent
     twist dimensions, and source fragment IDs. The target profile is
-    always present (the detector runs on every section), satisfying the
-    #354 acceptance criterion that each section's ontology profile is
-    recorded in frontmatter.
+    always present (the detector runs on every section), so each
+    section's ontology profile is recorded in frontmatter. A truncated
+    section is flagged with ``truncated: true``.
     """
     payload: dict[str, object] = {
         "heading": section.heading,
@@ -1859,6 +2018,8 @@ def _serialise_section(section: SectionComposition) -> dict[str, object]:
         payload["twist_dimensions"] = list(section.twist_dimensions)
     if section.source_fragments:
         payload["source_fragments"] = list(section.source_fragments)
+    if section.truncated:
+        payload["truncated"] = True
     return payload
 
 
@@ -1886,7 +2047,7 @@ def _serialise_per_dimension_sources(
     slices are omitted because the operator already has the explicit-
     flag echo in ``seed.frequencies`` / ``seed.phases`` / ``seed.modes``
     — the per-dimension mapping is specifically about *which fragments
-    came from which dimension*, the #351 acceptance criterion.
+    came from which dimension*.
     """
     return {label: list(ids) for label, ids in entries if ids}
 
@@ -1899,10 +2060,9 @@ def _render_per_dimension_sections(
 
     Empty slices contribute a one-line ``(no source material)`` note
     so the model still sees that the dimension was attempted — the
-    visible absence is part of the per-dimension warning surface that
-    the #351 issue asks for. Non-empty slices render each matched
-    fragment with its ID and title, just like the legacy
-    ``## Source fragments`` block.
+    visible absence is part of the per-dimension warning surface.
+    Non-empty slices render each matched fragment with its ID and title,
+    just like the legacy ``## Source fragments`` block.
     """
     if not slices:
         return ""
@@ -1951,10 +2111,10 @@ def _compose_ask_section(
 ) -> str:
     """Return the ``## Ask`` block, switching wording for per-dimension / twist mode.
 
-    When per-dimension material is in play (issue #351), the ask
-    explicitly invites the model to weave across the labelled slices
-    rather than treating them as one homogeneous corpus. When ontology
-    twist is also on (issue #352), the ask references the twist
+    When per-dimension material is in play, the ask explicitly invites
+    the model to weave across the labelled slices rather than treating
+    them as one homogeneous corpus. When ontology twist is also on, the
+    ask references the twist
     directive so the LLM treats it as load-bearing. Otherwise it keeps
     the original wording so existing tests and mined-idea drafts
     continue to compose identically.

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -1533,6 +1533,37 @@ class TestAnthropicProviderCall:
             provider.call("p2")
         assert mock_ctor.call_count == 1
 
+    def test_call_with_metadata_surfaces_stop_reason(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """call_with_metadata returns the response text and its stop reason."""
+        _set_anthropic_env(monkeypatch)
+        mock_client = _make_mock_anthropic_client("hello body")
+        mock_client.messages.create.return_value.stop_reason = "max_tokens"
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+            completion = provider.call_with_metadata("prompt", max_tokens=2048)
+        assert completion.text == "hello body"
+        assert completion.stop_reason == "max_tokens"
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs["max_tokens"] == 2048
+
+    def test_call_with_metadata_defaults_stop_reason(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A missing stop_reason defaults to end_turn and keeps MAX_TOKENS."""
+        _set_anthropic_env(monkeypatch)
+        mock_client = _make_mock_anthropic_client("body")
+        mock_client.messages.create.return_value.stop_reason = None
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+            completion = provider.call_with_metadata("prompt")
+        assert completion.stop_reason == "end_turn"
+        kwargs = mock_client.messages.create.call_args.kwargs
+        assert kwargs["max_tokens"] == AnthropicProvider.MAX_TOKENS
+
 
 # ---- LLMClassifier with Anthropic provider ----
 
@@ -2553,3 +2584,45 @@ class TestUnclassifiedBias:
         assert "mode" in _BIASED_DIMENSIONS
         assert "orientation" in _BIASED_DIMENSIONS
         assert "dosage" in _BIASED_DIMENSIONS
+
+
+class TestInvokePromptWithMetadata:
+    """``LLMClassifier.invoke_prompt_with_metadata`` surfaces the stop reason."""
+
+    def test_ollama_path_defaults_to_end_turn(self) -> None:
+        """The Ollama path has no stop reason, so it defaults to end_turn."""
+        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
+        with patch.object(LLMClassifier, "_call_ollama", return_value="body text"):
+            completion = classifier.invoke_prompt_with_metadata("prompt")
+        assert completion.text == "body text"
+        assert completion.stop_reason == "end_turn"
+
+    def test_anthropic_path_threads_max_tokens(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The Anthropic path forwards max_tokens and returns the stop reason."""
+        from creek.classify.llm.providers import AnthropicCompletion
+
+        _set_anthropic_env(monkeypatch)
+        classifier = LLMClassifier(config=LLMConfig(provider="anthropic"))
+
+        class _StubProvider:
+            def call_with_metadata(
+                self,
+                prompt: str,
+                *,
+                max_tokens: int | None = None,
+            ) -> AnthropicCompletion:
+                assert max_tokens == 512
+                assert prompt == "prompt"
+                return AnthropicCompletion(text="cut", stop_reason="max_tokens")
+
+        monkeypatch.setattr(
+            classifier,
+            "_get_anthropic_provider",
+            _StubProvider,
+        )
+        completion = classifier.invoke_prompt_with_metadata("prompt", max_tokens=512)
+        assert completion.text == "cut"
+        assert completion.stop_reason == "max_tokens"

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1897,7 +1897,9 @@ def test_draft_command_no_seeds(
     """Test that draft on an empty vault reports no seeds and exits 0."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     vault.mkdir()
     result = runner.invoke(app, ["draft", "--vault", str(vault)])
@@ -1933,7 +1935,7 @@ def test_draft_command_happy_path(
     monkeypatch.setattr(
         cli_module,
         "_build_draft_llm",
-        lambda: lambda _p: "Generated draft body.",
+        lambda *_a, **_k: lambda _p: "Generated draft body.",
     )
 
     def _stub_mine_all(
@@ -2182,7 +2184,9 @@ def test_draft_seed_empty_topic_falls_back_to_mining(
     """``--seed-topic ''`` is a no-op; mining behaviour is preserved."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     result = runner.invoke(
@@ -2225,7 +2229,7 @@ def _stub_outline_detector(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         cli_module,
         "_build_draft_llm",
-        lambda: lambda _p: "Stitched body.",
+        lambda *_a, **_k: lambda _p: "Stitched body.",
     )
     monkeypatch.setattr(
         cli_module,
@@ -2305,7 +2309,9 @@ def test_draft_seed_outline_mutually_exclusive_inline_and_file(
     """Passing both --seed-outline and --seed-outline-text exits 2."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     outline_file = tmp_path / "outline.md"
@@ -2333,7 +2339,9 @@ def test_draft_seed_outline_mutually_exclusive_with_topic(
     """Combining outline mode with --seed-topic exits 2."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     result = runner.invoke(
@@ -2359,7 +2367,9 @@ def test_draft_seed_outline_file_read_error_exits_two(
     """A missing outline file exits 2 with a read error."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     result = runner.invoke(
@@ -2383,7 +2393,9 @@ def test_draft_seed_fragment_mutually_exclusive_with_topic(
     """``--seed-fragment`` plus ``--seed-topic`` exits 2 with a clear message."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     result = runner.invoke(
@@ -2409,7 +2421,9 @@ def test_draft_seed_fragment_mutually_exclusive_with_frequency(
     """``--seed-fragment`` plus ``--seed-frequency`` exits 2."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     result = runner.invoke(
@@ -2435,7 +2449,9 @@ def test_draft_seed_invalid_frequency_lists_options(
     """An unknown ``--seed-frequency`` exits 2 and lists valid codes + labels."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     result = runner.invoke(
@@ -2461,7 +2477,9 @@ def test_draft_seed_invalid_phase_lists_options(
     """An unknown ``--seed-phase`` exits 2 with the valid phases listed."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     result = runner.invoke(
@@ -2485,7 +2503,9 @@ def test_draft_seed_invalid_mode_lists_options(
     """An unknown ``--seed-mode`` exits 2 with the valid stances listed."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     result = runner.invoke(
@@ -2514,7 +2534,7 @@ def test_draft_seed_fragment_happy_path(
     monkeypatch.setattr(
         cli_module,
         "_build_draft_llm",
-        lambda: lambda _p: "Body composed from frag-keep.",
+        lambda *_a, **_k: lambda _p: "Body composed from frag-keep.",
     )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
@@ -2543,7 +2563,9 @@ def test_draft_seed_unknown_fragment_errors_cleanly(
     """An unknown ``--seed-fragment`` exits 1 with an honest message."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     result = runner.invoke(
@@ -2572,7 +2594,7 @@ def test_draft_seed_dimensional_filters_combine(
     monkeypatch.setattr(
         cli_module,
         "_build_draft_llm",
-        lambda: lambda _p: "Composed from the per-dimension blend.",
+        lambda *_a, **_k: lambda _p: "Composed from the per-dimension blend.",
     )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
@@ -2635,7 +2657,9 @@ def test_draft_seed_zero_match_exits_with_honest_message(
     """
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     _write_seed_fragment(vault, frag_id="frag-A", primary="F1")
@@ -2663,7 +2687,9 @@ def test_draft_seed_topic_with_frequency_filters_candidates(
 
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "Draft.")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "Draft."
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     _write_seed_fragment(
@@ -2710,7 +2736,9 @@ def test_draft_without_seed_flags_keeps_mining_behaviour(
     """Default behaviour is unchanged when no seed flags are passed."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     result = runner.invoke(app, ["draft", "--vault", str(vault)])
@@ -2736,7 +2764,9 @@ def test_draft_ontology_twist_without_seed_exits_with_clear_message(
     """``--ontology-twist`` alone (no seed) exits 2 with a clear hint."""
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     result = runner.invoke(
@@ -2758,7 +2788,9 @@ def test_draft_ontology_twist_plurality_failure_exits_cleanly(
     """
     from creek import cli as cli_module
 
-    monkeypatch.setattr(cli_module, "_build_draft_llm", lambda: lambda _p: "body")
+    monkeypatch.setattr(
+        cli_module, "_build_draft_llm", lambda *_a, **_k: lambda _p: "body"
+    )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
     _write_seed_fragment(vault, frag_id="frag-only", primary="F1", phase="peaking")
@@ -2797,7 +2829,7 @@ def test_draft_ontology_twist_happy_path_writes_twist_frontmatter(
     monkeypatch.setattr(
         cli_module,
         "_build_draft_llm",
-        lambda: lambda _p: "Twisted draft body.",
+        lambda *_a, **_k: lambda _p: "Twisted draft body.",
     )
     vault = tmp_path / "vault"
     _seed_test_vault(vault)
@@ -2834,3 +2866,161 @@ def test_draft_ontology_twist_happy_path_writes_twist_frontmatter(
     assert post.metadata["target_profile"]["mode"] == "express"
     # Only mode diverges between source and target.
     assert post.metadata["twist_dimensions"] == ["mode"]
+
+
+def test_draft_max_tokens_flag_advertised_in_help() -> None:
+    """``creek draft --help`` documents the --max-tokens flag."""
+    result = runner.invoke(app, ["draft", "--help"])
+    output = _strip_ansi(result.output)
+    assert result.exit_code == 0
+    assert "--max-tokens" in output
+
+
+def test_draft_seed_empty_body_exits_cleanly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A seeded draft whose LLM returns an empty body exits 1 (no traceback)."""
+    from creek import cli as cli_module
+
+    monkeypatch.setattr(
+        cli_module,
+        "_build_draft_llm",
+        lambda *_a, **_k: lambda _p: "   ",
+    )
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    _write_seed_fragment(vault, frag_id="frag-X", title="Topic seed", body="seedable")
+    result = runner.invoke(
+        app,
+        ["draft", "--vault", str(vault), "--seed-topic", "seedable"],
+    )
+    assert result.exit_code == 1, result.output
+    assert "empty" in _strip_ansi(result.output).lower()
+
+
+def test_draft_outline_empty_section_body_exits_cleanly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An outline section with an empty LLM body exits 1 with a readable message."""
+    from creek import cli as cli_module
+    from creek.classify.prompt import PromptOntology
+
+    monkeypatch.setattr(
+        cli_module,
+        "_build_draft_llm",
+        lambda *_a, **_k: lambda _p: "   ",
+    )
+    monkeypatch.setattr(
+        cli_module,
+        "_build_ontology_detector",
+        lambda _vault: lambda prompt: PromptOntology(prompt=prompt),
+    )
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    result = runner.invoke(
+        app,
+        [
+            "draft",
+            "--vault",
+            str(vault),
+            "--seed-outline-text",
+            "## One\nFirst.\n",
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    output = _strip_ansi(result.output).lower()
+    assert "empty" in output
+    assert "traceback" not in output
+
+
+def test_draft_max_tokens_threaded_to_builder(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--max-tokens`` is forwarded to the draft-LLM factory."""
+    from creek import cli as cli_module
+    from creek.generate.drafts import DraftLLMResponse
+
+    captured: dict[str, object] = {}
+
+    def _fake_builder(max_tokens: int | None = None) -> object:
+        captured["max_tokens"] = max_tokens
+        return lambda _p: DraftLLMResponse(text="Generated draft body.")
+
+    monkeypatch.setattr(cli_module, "_build_draft_llm", _fake_builder)
+
+    def _stub_mine_all(
+        _self: object,
+        _vault: object,
+        *,
+        current_phase: object,
+    ) -> list[object]:
+        del current_phase
+        from creek.generate.mining import IdeaSeed, MiningStrategy
+
+        return [
+            IdeaSeed(
+                strategy=MiningStrategy.RESONANCE_CHAIN,
+                title="An idea",
+                source_fragments=(),
+                threads=(),
+                eddies=(),
+                frequency_affinity=(),
+                brief_description="A draftable idea.",
+                score=0.5,
+            ),
+        ]
+
+    monkeypatch.setattr(
+        "creek.generate.mining.IdeaMiner.mine_all",
+        _stub_mine_all,
+    )
+    vault = tmp_path / "vault"
+    _seed_test_vault(vault)
+    result = runner.invoke(
+        app,
+        ["draft", "--vault", str(vault), "--max-tokens", "4096"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured["max_tokens"] == 4096
+
+
+def test_build_draft_llm_falls_back_to_config_max_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no flag, _build_draft_llm uses the loaded config's draft.max_tokens."""
+    from creek import cli as cli_module
+    from creek.classify.llm.providers import AnthropicCompletion
+    from creek.config import CreekConfig, DraftConfig
+
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        cli_module,
+        "load_config",
+        lambda *_a, **_k: CreekConfig(draft=DraftConfig(max_tokens=2048)),
+    )
+
+    class _Classifier:
+        available = True
+
+        def __init__(self, _config: object) -> None:
+            pass
+
+        def invoke_prompt_with_metadata(
+            self,
+            prompt: str,
+            *,
+            max_tokens: int | None = None,
+        ) -> AnthropicCompletion:
+            captured["max_tokens"] = max_tokens
+            del prompt
+            return AnthropicCompletion(text="body")
+
+    monkeypatch.setattr("creek.classify.llm.LLMClassifier", _Classifier)
+
+    llm = cli_module._build_draft_llm()
+    llm("a prompt")
+    assert captured["max_tokens"] == 2048

--- a/creek-tools/tests/test_draft_grounding.py
+++ b/creek-tools/tests/test_draft_grounding.py
@@ -198,6 +198,19 @@ class TestDraftConfig:
         assert cfg.derivative_upper == pytest.approx(0.9)
         assert cfg.grounding_lower == pytest.approx(0.5)
 
+    def test_max_tokens_defaults_to_none(self) -> None:
+        """``max_tokens`` defaults to None so the provider default is kept."""
+        assert DraftConfig().max_tokens is None
+
+    def test_max_tokens_must_be_positive(self) -> None:
+        """A non-positive ``max_tokens`` is rejected at config-parse time."""
+        with pytest.raises(ValueError, match="max_tokens"):
+            DraftConfig(max_tokens=0)
+
+    def test_max_tokens_can_be_set(self) -> None:
+        """Operators may pin a default token ceiling for longer drafts."""
+        assert DraftConfig(max_tokens=4096).max_tokens == 4096
+
     def test_creekconfig_exposes_draft_section(self) -> None:
         """The top-level ``draft:`` section must hang off ``CreekConfig``."""
         from creek.config import CreekConfig

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import hashlib
 from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING
 
 import frontmatter
 import pytest
+import yaml
 
 from creek.generate.drafts import (
     DRAFTS_SUBDIR,
@@ -2880,3 +2882,296 @@ class TestSaveOutlineDraft:
         assert post.metadata["type"] == "draft"
         assert post.metadata["title"] == "My Essay Title"
         assert (vault / DRAFTS_SUBDIR) in path.parents
+
+
+class TestDraftTruncation:
+    """Drafts surface a ``max_tokens`` cutoff instead of truncating silently."""
+
+    def _seed_one_fragment(self, vault: Path) -> Fragment:
+        """Seed and return a single fragment for the single-topic draft path."""
+        fragment = _build_fragment()
+        _write_fragment(vault, fragment, "A line.")
+        return fragment
+
+    def test_truncated_response_flags_draft(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A ``max_tokens`` stop reason marks the returned draft truncated."""
+        from creek.generate.drafts import DraftLLMResponse
+
+        self._seed_one_fragment(vault)
+        gen = DraftGenerator(
+            llm=lambda _p: DraftLLMResponse(
+                text="Cut off here", stop_reason="max_tokens"
+            ),
+            skills_root=skills_root,
+        )
+        seed = _build_seed()
+        draft = gen.generate_draft(seed, vault_path=vault)
+        assert draft.truncated is True
+
+    def test_clean_response_is_not_truncated(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A clean ``end_turn`` completion leaves the draft un-flagged."""
+        from creek.generate.drafts import DraftLLMResponse
+
+        self._seed_one_fragment(vault)
+        gen = DraftGenerator(
+            llm=lambda _p: DraftLLMResponse(text="All done.", stop_reason="end_turn"),
+            skills_root=skills_root,
+        )
+        draft = gen.generate_draft(_build_seed(), vault_path=vault)
+        assert draft.truncated is False
+
+    def test_plain_string_response_defaults_to_not_truncated(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A legacy ``str`` return is treated as a clean completion."""
+        self._seed_one_fragment(vault)
+        gen = DraftGenerator(llm=lambda _p: "Plain body.", skills_root=skills_root)
+        draft = gen.generate_draft(_build_seed(), vault_path=vault)
+        assert draft.truncated is False
+
+    def test_truncation_warns_on_stderr(
+        self,
+        vault: Path,
+        skills_root: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """A truncated draft prints a clear warning to stderr."""
+        from creek.generate.drafts import DraftLLMResponse
+
+        self._seed_one_fragment(vault)
+        gen = DraftGenerator(
+            llm=lambda _p: DraftLLMResponse(text="Cut", stop_reason="max_tokens"),
+            skills_root=skills_root,
+        )
+        gen.generate_draft(_build_seed(), vault_path=vault)
+        captured = capsys.readouterr()
+        assert "truncated at max_tokens" in captured.err
+        assert "--max-tokens" in captured.err
+
+    def test_saved_draft_records_truncation_and_footer(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A truncated draft writes ``truncated: true`` plus a body footer."""
+        from creek.generate.drafts import DraftLLMResponse
+
+        self._seed_one_fragment(vault)
+        gen = DraftGenerator(
+            llm=lambda _p: DraftLLMResponse(text="Cut off", stop_reason="max_tokens"),
+            skills_root=skills_root,
+        )
+        draft = gen.generate_draft(_build_seed(), vault_path=vault)
+        path = gen.save_draft(draft, vault)
+        post = frontmatter.load(str(path))
+        assert post.metadata["truncated"] is True
+        assert "truncated — see frontmatter" in post.content
+
+    def test_saved_clean_draft_has_no_footer(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A clean draft records ``truncated: false`` and no footer."""
+        self._seed_one_fragment(vault)
+        gen = DraftGenerator(llm=lambda _p: "All done.", skills_root=skills_root)
+        draft = gen.generate_draft(_build_seed(), vault_path=vault)
+        path = gen.save_draft(draft, vault)
+        post = frontmatter.load(str(path))
+        assert post.metadata["truncated"] is False
+        assert "truncated — see frontmatter" not in post.content
+
+    def test_outline_draft_truncation_propagates(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A truncated stitch pass flags the whole outline draft."""
+        from creek.generate.drafts import DraftLLMResponse
+
+        outline = "## One\nFirst.\n"
+
+        def llm(prompt: str) -> DraftLLMResponse:
+            if "Stitch directive" in prompt:
+                return DraftLLMResponse(text="Stitched", stop_reason="max_tokens")
+            return DraftLLMResponse(text="section body")
+
+        gen = DraftGenerator(llm=llm, skills_root=skills_root)
+        draft = gen.generate_outline_draft(
+            outline,
+            vault_path=vault,
+            detect_ontology=_empty_detector(),
+        )
+        assert draft.truncated is True
+        path = gen.save_outline_draft(draft, vault)
+        post = frontmatter.load(str(path))
+        assert post.metadata["truncated"] is True
+        assert "truncated — see frontmatter" in post.content
+
+    def test_outline_section_truncation_propagates(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A truncated section body flags the outline draft even if stitch is clean."""
+        from creek.generate.drafts import DraftLLMResponse
+
+        outline = "## One\nFirst.\n"
+
+        def llm(prompt: str) -> DraftLLMResponse:
+            if "Stitch directive" in prompt:
+                return DraftLLMResponse(text="Stitched", stop_reason="end_turn")
+            return DraftLLMResponse(text="section body", stop_reason="max_tokens")
+
+        gen = DraftGenerator(llm=llm, skills_root=skills_root)
+        draft = gen.generate_outline_draft(
+            outline,
+            vault_path=vault,
+            detect_ontology=_empty_detector(),
+        )
+        assert draft.truncated is True
+        assert draft.sections[0].truncated is True
+
+
+class TestStitchPromptNotPersistedVerbatim:
+    """``save_outline_draft`` stores a stitch-prompt hash, not the full text."""
+
+    def test_frontmatter_size_independent_of_body_word_count(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """Frontmatter size does not grow with section-body length."""
+        outline = "## One\nFirst.\n\n## Two\nSecond.\n"
+
+        def _frontmatter_size(section_words: int) -> int:
+            body = " ".join(["word"] * section_words)
+
+            def llm(prompt: str) -> str:
+                if "Stitch directive" in prompt:
+                    return "stitched essay body"
+                return body
+
+            gen = DraftGenerator(llm=llm, skills_root=skills_root)
+            draft = gen.generate_outline_draft(
+                outline,
+                vault_path=vault,
+                detect_ontology=_empty_detector(),
+            )
+            path = gen.save_outline_draft(draft, vault)
+            post = frontmatter.load(str(path))
+            # Re-dump only the metadata so body length is excluded.
+            return len(yaml.safe_dump(post.metadata))
+
+        small = _frontmatter_size(5)
+        large = _frontmatter_size(5000)
+        assert small == large
+
+    def test_stitch_prompt_stored_as_hash(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """The full stitch prompt is not persisted; only its sha256 hash is."""
+        outline = "## One\nFirst.\n"
+
+        def llm(prompt: str) -> str:
+            if "Stitch directive" in prompt:
+                return "stitched"
+            return "section body"
+
+        gen = DraftGenerator(llm=llm, skills_root=skills_root)
+        draft = gen.generate_outline_draft(
+            outline,
+            vault_path=vault,
+            detect_ontology=_empty_detector(),
+        )
+        path = gen.save_outline_draft(draft, vault)
+        post = frontmatter.load(str(path))
+        assert "stitch_prompt" not in post.metadata
+        digest = post.metadata["stitch_prompt_sha256"]
+        assert (
+            digest
+            == hashlib.sha256(
+                draft.stitch_prompt.encode("utf-8"),
+            ).hexdigest()
+        )
+
+
+class TestSourceProfileComputedOncePerSection:
+    """A resolved section aggregates its source profile exactly once."""
+
+    def test_source_profile_not_recomputed_under_twist(
+        self,
+        vault: Path,
+        skills_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``source_profile_from_fragments`` runs once per resolved section."""
+        import creek.generate.drafts as drafts_module
+
+        # A header-only section makes its seed text just the heading, so
+        # the per-dimension topic-substring filter has a phrase that the
+        # fragment bodies contain — the section then resolves to source
+        # material and reaches the deduplicated profile aggregation.
+        topic = "peaking inhabit"
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-A",
+                primary=Frequency.F7,
+                phase=Phase.PEAKING,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+            ),
+            f"A {topic} body about integration.",
+        )
+        _write_fragment(
+            vault,
+            _build_fragment(
+                frag_id="frag-B",
+                primary=Frequency.F7,
+                phase=Phase.PEAKING,
+                mode=Mode.INHABIT,
+                dosage=Dosage.MEDICINE,
+            ),
+            f"A {topic} body about empathy.",
+        )
+
+        real = drafts_module.source_profile_from_fragments
+        calls = {"n": 0}
+
+        def _counting(fragments: object) -> object:
+            calls["n"] += 1
+            return real(fragments)
+
+        monkeypatch.setattr(
+            drafts_module,
+            "source_profile_from_fragments",
+            _counting,
+        )
+
+        # One header-only section (no body) so seed_text == heading.
+        outline = "## peaking inhabit\n"
+        detector = _ontology_detector_by_phase({"peaking": Phase.PEAKING})
+        gen = DraftGenerator(
+            llm=lambda _p: "body",
+            skills_root=skills_root,
+            ontology_twist=True,
+        )
+        gen.generate_outline_draft(
+            outline,
+            vault_path=vault,
+            detect_ontology=detector,
+        )
+        assert calls["n"] == 1


### PR DESCRIPTION
## Summary

The DRAFTS-core unit of the batch close-out. Drafts previously truncated mid-sentence and silently when the LLM hit its `max_tokens` ceiling, because the draft LLM abstraction returned only a string and dropped the Anthropic `stop_reason`. The draft path now carries the stop reason end to end and surfaces a truncation to the operator and the saved file.

## Changes

### Truncation detection (#348)
- New frozen `DraftLLMResponse(text, stop_reason)`; `DraftLLM` widened to `Callable[[str], str | DraftLLMResponse]` so legacy callables and test fixtures keep working (a bare `str` is normalised to a clean `end_turn` completion).
- `AnthropicProvider.call_with_metadata` and `LLMClassifier.invoke_prompt_with_metadata` surface `stop_reason` and accept a configurable `max_tokens`. The classification path (`invoke_prompt` / `call`) is unchanged and still returns a plain `str`. Ollama has no stop reason, so it defaults to `end_turn`.
- `generate_draft`, `generate_seeded_draft`, and the outline section + stitch passes detect truncation through a shared `_invoke_draft_llm` helper, warn on stderr (`[creek draft] WARNING: draft truncated at max_tokens; raise --max-tokens or simplify the prompt`), and set the new `truncated` field on `Draft` / `OutlineDraft` / `SectionComposition`.
- `save_draft` / `save_outline_draft` write `truncated: true` to frontmatter and append a `\n\n---\n*(truncated — see frontmatter)*` footer when cut off.
- New `DraftConfig.max_tokens` (defaults `None` → provider default) and a `--max-tokens` CLI option. Both the provider settings and the ceiling come from a single loaded config so they cannot diverge; the explicit flag overrides the config default. The `--continue` resume feature is intentionally out of scope.

### Friendly empty-body errors (#390)
- Both draft CLI runners (`_run_seeded_draft`, `_run_outline_draft`) now catch `RuntimeError` (e.g. "LLM returned an empty section body") and exit cleanly with a red message and `typer.Exit(code=1)` instead of a raw traceback.

### Frontmatter hygiene (#391)
- `save_outline_draft` stops persisting the full `stitch_prompt` verbatim (it could be 10–15 KB) and instead stores a `stitch_prompt_sha256` content hash. The verbatim outline input is still recorded, so the prompt stays reproducible. A regression test asserts saved frontmatter size is independent of section-body word count.

### Micro-optimisation (#392)
- `_compose_resolved_section` now aggregates each section's `source_profile` once and threads it into `_section_twist_payload`, removing the duplicate `source_profile_from_fragments` call when ontology-twist is active. A call-count assertion locks it in.

### Docstring hygiene (#393, drafts.py / draft CLI portion)
- Stripped `(issue #NNN)` / `(#NNN)` references from the touched docstrings in `creek/generate/drafts.py` and the draft command / runners in `creek/cli.py`.

## Testing
- New tests cover: truncation detection + stderr warning + frontmatter/footer (draft, seeded, outline section, stitch), the legacy `str` return path, `--max-tokens` flag wiring and config-default fallback, empty-body CLI exits for both runners, stitch-prompt hashing + frontmatter-size invariance, the source_profile call-count dedup, provider/orchestrator `*_with_metadata` methods, and `DraftConfig.max_tokens` validation.
- Full local suite: 4591 passed, 1 skipped. `./scripts/check-all.sh` gates pass individually (ruff, mypy strict, pylint 9.72, complexity, refurb, tryceratops, interrogate 99.5%, security, coverage 93.5% aggregate + per-file gate). `creek draft --help` shows `--max-tokens`.

Closes #348
Closes #390
Closes #391
Closes #392
Part of #393

https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU

---
_Generated by [Claude Code](https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU)_