### PR TITLE
feat(grounding): harden cosine guard and split grounding thresholds

### DIFF
--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -720,14 +720,22 @@ class DraftConfig(BaseModel):
     * **Too derivative** — at least one draft paragraph paraphrases a
       source-fragment paragraph closely (cosine similarity above
       :attr:`derivative_upper`).
-    * **Too ungrounded** — fewer than :attr:`grounding_lower` fraction of
-      draft paragraphs share *any* similarity with a source paragraph
-      above the same lower bound, i.e. the draft is conceptually
-      invented.
+    * **Too ungrounded** — fewer than :attr:`grounding_fraction_lower` of
+      the draft's paragraphs clear the per-paragraph :attr:`grounding_lower`
+      similarity floor against *any* source paragraph, i.e. the draft is
+      conceptually invented.
 
-    Defaults are deliberately lenient (0.85 / 0.30); operators tighten
-    once they have a calibration set for their own corpus. Both
-    thresholds are cosine similarities and so must live in ``[0.0, 1.0]``.
+    The two grounding knobs are independent: :attr:`grounding_lower`
+    decides whether a single paragraph counts as grounded, while
+    :attr:`grounding_fraction_lower` decides what share of the draft's
+    paragraphs must be grounded for the draft to pass. An operator can
+    demand a strict per-paragraph anchor (e.g. 0.4) while tolerating a
+    lenient grounded fraction (e.g. 0.2), or the reverse.
+
+    Defaults are deliberately lenient (0.85 / 0.30 / 0.30); operators
+    tighten once they have a calibration set for their own corpus. All
+    three knobs are cosine similarities or fractions and so must live in
+    ``[0.0, 1.0]``.
     """
 
     derivative_upper: float = Field(default=0.85, ge=0.0, le=1.0)
@@ -736,10 +744,16 @@ class DraftConfig(BaseModel):
     flagged ``too derivative``."""
 
     grounding_lower: float = Field(default=0.30, ge=0.0, le=1.0)
-    """Cosine-similarity floor a draft paragraph must clear against
-    *some* source paragraph to count as grounded. Doubles as the
-    minimum acceptable fraction of grounded paragraphs: drafts whose
-    grounded fraction sits below this value are flagged ``too ungrounded``."""
+    """Per-paragraph cosine-similarity floor a draft paragraph must clear
+    against *some* source paragraph to count as grounded. Independent of
+    :attr:`grounding_fraction_lower`, which governs the whole-draft
+    grounded fraction."""
+
+    grounding_fraction_lower: float = Field(default=0.30, ge=0.0, le=1.0)
+    """Minimum acceptable fraction of grounded paragraphs across the whole
+    draft. A draft whose grounded fraction sits below this value is
+    flagged ``too ungrounded``, even when every grounded paragraph
+    individually cleared :attr:`grounding_lower`."""
 
 
 class LintConfig(BaseModel):

--- a/creek-tools/creek/generate/grounding.py
+++ b/creek-tools/creek/generate/grounding.py
@@ -1,4 +1,4 @@
-"""Bidirectional grounding guard for ``creek draft`` (issue #355).
+"""Bidirectional grounding guard for ``creek draft``.
 
 A draft has two opposite failure modes that the guard surfaces after
 composition:
@@ -48,7 +48,7 @@ class ParagraphAnnotation(TypedDict):
     (which lives in the draft body itself). Declaring this as a
     ``TypedDict`` lets ``mypy --strict`` flag key typos and missing
     fields at the call site instead of waiting for a YAML-decode
-    failure downstream — see PR #380 review feedback.
+    failure downstream.
     """
 
     index: int
@@ -90,14 +90,19 @@ class GroundingThresholds:
     Attributes:
         derivative_upper: Cosine-similarity ceiling above which a draft
             paragraph is flagged as a paraphrase.
-        grounding_lower: Cosine-similarity floor a draft paragraph must
-            clear against *some* source paragraph to count as grounded.
-            The same value gates the grounded-fraction summary: drafts
-            whose grounded fraction sits below this value are flagged.
+        grounding_lower: Per-paragraph cosine-similarity floor a draft
+            paragraph must clear against *some* source paragraph to count
+            as grounded.
+        grounding_fraction_lower: Minimum acceptable fraction of grounded
+            paragraphs across the whole draft. Independent of
+            :attr:`grounding_lower`: the former decides whether one
+            paragraph is grounded, the latter how many grounded
+            paragraphs the draft as a whole must reach.
     """
 
     derivative_upper: float
     grounding_lower: float
+    grounding_fraction_lower: float
 
     def __post_init__(self) -> None:
         """Reject thresholds outside ``[0.0, 1.0]`` at construction time."""
@@ -107,6 +112,12 @@ class GroundingThresholds:
         if not 0.0 <= self.grounding_lower <= 1.0:
             msg = f"grounding_lower must be in [0.0, 1.0]; got {self.grounding_lower}"
             raise ValueError(msg)
+        if not 0.0 <= self.grounding_fraction_lower <= 1.0:
+            msg = (
+                "grounding_fraction_lower must be in [0.0, 1.0]; "
+                f"got {self.grounding_fraction_lower}"
+            )
+            raise ValueError(msg)
 
     @classmethod
     def from_config(cls, config: DraftConfig) -> GroundingThresholds:
@@ -114,6 +125,7 @@ class GroundingThresholds:
         return cls(
             derivative_upper=config.derivative_upper,
             grounding_lower=config.grounding_lower,
+            grounding_fraction_lower=config.grounding_fraction_lower,
         )
 
 
@@ -173,7 +185,9 @@ class GroundingReport:
             across the draft. ``0.0`` when the draft has no paragraphs.
         grounding_score: Fraction of paragraphs whose ``max_similarity``
             cleared :attr:`GroundingThresholds.grounding_lower`. ``0.0``
-            when the draft has no paragraphs.
+            when the draft has no paragraphs. Compared against
+            :attr:`GroundingThresholds.grounding_fraction_lower` to set
+            the grounding flag.
         paragraph_scores: One :class:`ParagraphScore` per draft
             paragraph, in document order.
         thresholds: Echo of the thresholds the scores were computed
@@ -194,7 +208,13 @@ class GroundingReport:
 
     @property
     def is_flagged_grounding(self) -> bool:
-        """``True`` when the grounded fraction fell below the lower bound.
+        """``True`` when the grounded fraction fell below the fraction floor.
+
+        Compares :attr:`grounding_score` against
+        :attr:`GroundingThresholds.grounding_fraction_lower`, the
+        whole-draft knob — distinct from the per-paragraph
+        :attr:`GroundingThresholds.grounding_lower` that decided which
+        paragraphs counted as grounded in the first place.
 
         Empty drafts (no paragraph scores) cannot be evaluated and so
         are never flagged — a paragraph-less body indicates an upstream
@@ -202,7 +222,7 @@ class GroundingReport:
         """
         if not self.paragraph_scores:
             return False
-        return self.grounding_score < self.thresholds.grounding_lower
+        return self.grounding_score < self.thresholds.grounding_fraction_lower
 
     @property
     def is_flagged(self) -> bool:
@@ -231,7 +251,7 @@ class GroundingReport:
             f"grounding guard: derivative={self.derivative_score:.2f} "
             f"(upper {self.thresholds.derivative_upper:.2f}), "
             f"grounding={self.grounding_score:.2f} "
-            f"(lower {self.thresholds.grounding_lower:.2f}) — {verdict}"
+            f"(lower {self.thresholds.grounding_fraction_lower:.2f}) — {verdict}"
         )
 
     def to_frontmatter(self) -> dict[str, object]:
@@ -314,19 +334,49 @@ def split_paragraphs(body: str) -> list[str]:
     return [p for p in paragraphs if p]
 
 
+_NORM_EPSILON = 1e-12
+"""Norm floor below which a vector is treated as zero-norm.
+
+An exact-zero check (``norm == 0.0``) only catches an all-zeros vector;
+a degenerate near-zero embedding (sum-of-squares ≈ 1e-30) would slip
+through and divide into a large but finite — and meaningless — cosine.
+Collapsing any sub-epsilon norm to "no resonance" keeps the guard's
+output bounded for every embedding the public :data:`EmbeddingFn`
+injection point might produce."""
+
+
+class GroundingDimensionError(ValueError):
+    """Raised when draft and source embeddings have mismatched dimensions.
+
+    The guard compares draft-paragraph vectors against source-paragraph
+    vectors with :func:`cosine_similarity`, which requires equal-length
+    inputs. A length mismatch means the injected :data:`EmbeddingFn`
+    returned vectors of different sizes for different texts — almost
+    always two different embedding models on the two code paths. Catching
+    the low-level length error here and re-raising this subclass turns a
+    bare ``Vector length mismatch: 384 vs 768`` into an actionable
+    message at the guard boundary instead of a raw traceback from deep in
+    the scoring loop.
+    """
+
+
 def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
     """Return cosine similarity in ``[-1.0, 1.0]`` for two equal-length vectors.
 
-    Zero-norm vectors collapse to ``0.0`` rather than raising — the
-    guard treats an embedding-less paragraph as "no resonance with
-    anything" without aborting the score for the whole draft.
+    Vectors whose norm falls below :data:`_NORM_EPSILON` collapse to
+    ``0.0`` rather than raising or dividing — the guard treats an
+    embedding-less (or degenerate near-zero) paragraph as "no resonance
+    with anything" without aborting the score for the whole draft.
+
+    Raises:
+        GroundingDimensionError: When *a* and *b* have different lengths.
     """
     if len(a) != len(b):
         msg = f"Vector length mismatch: {len(a)} vs {len(b)}"
-        raise ValueError(msg)
+        raise GroundingDimensionError(msg)
     norm_a = math.sqrt(sum(x * x for x in a))
     norm_b = math.sqrt(sum(x * x for x in b))
-    if 0.0 in (norm_a, norm_b):
+    if norm_a < _NORM_EPSILON or norm_b < _NORM_EPSILON:
         return 0.0
     dot = sum(x * y for x, y in zip(a, b, strict=True))
     return dot / (norm_a * norm_b)
@@ -394,6 +444,12 @@ def score_draft(
         A populated :class:`GroundingReport`. When *draft_body* contains
         no paragraphs the scores collapse to ``0.0`` and no flags fire
         — there is nothing to evaluate.
+
+    Raises:
+        GroundingDimensionError: When the injected ``embedding_fn``
+            returns vectors of differing lengths for draft and source
+            paragraphs — surfaced as a clean message rather than a raw
+            length-mismatch traceback from inside the scoring loop.
     """
     draft_paragraphs = split_paragraphs(draft_body)
     if not draft_paragraphs:
@@ -409,16 +465,25 @@ def score_draft(
         source_paragraphs.extend(split_paragraphs(text))
     source_vectors = [embedding_fn(p) for p in source_paragraphs]
 
-    scores = tuple(
-        _score_one_paragraph(
-            paragraph,
-            source_vectors,
-            embedding_fn=embedding_fn,
-            thresholds=thresholds,
-            index=index,
+    try:
+        scores = tuple(
+            _score_one_paragraph(
+                paragraph,
+                source_vectors,
+                embedding_fn=embedding_fn,
+                thresholds=thresholds,
+                index=index,
+            )
+            for index, paragraph in enumerate(draft_paragraphs)
         )
-        for index, paragraph in enumerate(draft_paragraphs)
-    )
+    except GroundingDimensionError as exc:
+        msg = (
+            "grounding guard could not score the draft: the embedding "
+            "function returned vectors of differing lengths for draft and "
+            "source paragraphs. This usually means two different embedding "
+            f"models were used on the same run ({exc})."
+        )
+        raise GroundingDimensionError(msg) from exc
 
     derivative = max((s.max_similarity for s in scores), default=0.0)
     grounded_count = sum(1 for s in scores if s.is_grounded)

--- a/creek-tools/creek/lint/checks/draft_grounding.py
+++ b/creek-tools/creek/lint/checks/draft_grounding.py
@@ -5,7 +5,8 @@ The :mod:`creek.generate.grounding` guard runs synchronously during
 ``derivative_score`` / ``grounding_score`` / ``paragraph_grounding``.
 This lint check is the audit pass that asks the operator to revisit
 any draft whose stored scores fall outside the configured
-``draft.derivative_upper`` / ``draft.grounding_lower`` thresholds.
+``draft.derivative_upper`` / ``draft.grounding_fraction_lower``
+thresholds.
 
 Drafts written before issue #355 (and any markdown file that simply
 lacks the scores) are skipped silently — re-running ``creek draft``
@@ -72,9 +73,9 @@ def _scan_draft(path: Path, draft_config: DraftConfig) -> str | None:
         failures.append(
             f"derivative={derivative:.2f} ≥ {draft_config.derivative_upper:.2f}",
         )
-    if grounding < draft_config.grounding_lower:
+    if grounding < draft_config.grounding_fraction_lower:
         failures.append(
-            f"grounding={grounding:.2f} < {draft_config.grounding_lower:.2f}",
+            f"grounding={grounding:.2f} < {draft_config.grounding_fraction_lower:.2f}",
         )
     if not failures:
         return None
@@ -107,6 +108,6 @@ def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
     summary = (
         f"{scanned} draft(s) scanned; {len(findings)} outside "
         f"derivative_upper={draft_config.derivative_upper:.2f} / "
-        f"grounding_lower={draft_config.grounding_lower:.2f}"
+        f"grounding_fraction_lower={draft_config.grounding_fraction_lower:.2f}"
     )
     return CheckResult(name="draft-grounding", summary=summary, findings=findings)

--- a/creek-tools/tests/test_draft_grounding.py
+++ b/creek-tools/tests/test_draft_grounding.py
@@ -31,6 +31,7 @@ from creek.generate.grounding import (
     GROUNDING_FRONTMATTER_KEY,
     PARAGRAPH_ANNOTATIONS_KEY,
     EmbeddingFn,
+    GroundingDimensionError,
     GroundingReport,
     GroundingThresholds,
     ParagraphScore,
@@ -170,6 +171,25 @@ class TestCosineSimilarity:
         assert cosine_similarity(zeros, other) == 0.0
         assert cosine_similarity(other, zeros) == 0.0
 
+    def test_near_zero_vector_returns_zero(self) -> None:
+        """A near-zero (norm ~1e-30) vector collapses to 0.0, not a huge cosine.
+
+        An exact-zero check would let a sum-of-squares ≈ 1e-30 vector
+        divide into an enormous but finite cosine; the epsilon floor
+        treats it as "no resonance" instead.
+        """
+        # Norm = sqrt(_VECTOR_DIM) * 1e-30 ≈ 5.7e-30, far below the
+        # 1e-12 epsilon — but emphatically not exactly zero.
+        tiny = [1e-30] * _VECTOR_DIM
+        unit = _hashed_vector("a normal paragraph")
+        assert cosine_similarity(tiny, unit) == 0.0
+        assert cosine_similarity(unit, tiny) == 0.0
+
+    def test_length_mismatch_raises_clean_error(self) -> None:
+        """Unequal-length vectors raise :class:`GroundingDimensionError`."""
+        with pytest.raises(GroundingDimensionError, match="length mismatch"):
+            cosine_similarity([1.0, 0.0], [1.0, 0.0, 0.0])
+
 
 # ---------------------------------------------------------------------------
 # DraftConfig wiring
@@ -180,10 +200,11 @@ class TestDraftConfig:
     """Thresholds must be configurable through the ``draft:`` YAML section."""
 
     def test_defaults_match_issue(self) -> None:
-        """The defaults pinned in issue #355 are 0.85 and 0.30."""
+        """The defaults are 0.85 / 0.30 / 0.30 (backwards-compatible)."""
         cfg = DraftConfig()
         assert cfg.derivative_upper == pytest.approx(0.85)
         assert cfg.grounding_lower == pytest.approx(0.30)
+        assert cfg.grounding_fraction_lower == pytest.approx(0.30)
 
     def test_thresholds_are_clamped_to_unit_interval(self) -> None:
         """Cosine-similarity thresholds must stay in [0.0, 1.0]."""
@@ -191,12 +212,25 @@ class TestDraftConfig:
             DraftConfig(derivative_upper=1.5)
         with pytest.raises(ValueError, match="grounding_lower"):
             DraftConfig(grounding_lower=-0.1)
+        with pytest.raises(ValueError, match="grounding_fraction_lower"):
+            DraftConfig(grounding_fraction_lower=1.1)
 
     def test_thresholds_can_be_overridden(self) -> None:
-        """Operators must be able to tighten or loosen both knobs."""
-        cfg = DraftConfig(derivative_upper=0.9, grounding_lower=0.5)
+        """Operators must be able to tighten or loosen all three knobs."""
+        cfg = DraftConfig(
+            derivative_upper=0.9,
+            grounding_lower=0.5,
+            grounding_fraction_lower=0.2,
+        )
         assert cfg.derivative_upper == pytest.approx(0.9)
         assert cfg.grounding_lower == pytest.approx(0.5)
+        assert cfg.grounding_fraction_lower == pytest.approx(0.2)
+
+    def test_grounding_knobs_are_independent(self) -> None:
+        """The per-paragraph floor and the fraction floor set independently."""
+        cfg = DraftConfig(grounding_lower=0.4, grounding_fraction_lower=0.2)
+        assert cfg.grounding_lower == pytest.approx(0.4)
+        assert cfg.grounding_fraction_lower == pytest.approx(0.2)
 
     def test_creekconfig_exposes_draft_section(self) -> None:
         """The top-level ``draft:`` section must hang off ``CreekConfig``."""
@@ -209,10 +243,15 @@ class TestDraftConfig:
     def test_thresholds_from_config(self) -> None:
         """``GroundingThresholds.from_config`` mirrors the :class:`DraftConfig`."""
         thresholds = GroundingThresholds.from_config(
-            DraftConfig(derivative_upper=0.72, grounding_lower=0.45),
+            DraftConfig(
+                derivative_upper=0.72,
+                grounding_lower=0.45,
+                grounding_fraction_lower=0.25,
+            ),
         )
         assert thresholds.derivative_upper == pytest.approx(0.72)
         assert thresholds.grounding_lower == pytest.approx(0.45)
+        assert thresholds.grounding_fraction_lower == pytest.approx(0.25)
 
 
 # ---------------------------------------------------------------------------
@@ -220,7 +259,11 @@ class TestDraftConfig:
 # ---------------------------------------------------------------------------
 
 
-_DEFAULT_THRESHOLDS = GroundingThresholds(derivative_upper=0.85, grounding_lower=0.30)
+_DEFAULT_THRESHOLDS = GroundingThresholds(
+    derivative_upper=0.85,
+    grounding_lower=0.30,
+    grounding_fraction_lower=0.30,
+)
 
 
 class TestScoreDraftDerivative:
@@ -325,8 +368,120 @@ class TestScoreDraftGrounding:
         )
         # One of two paragraphs is grounded → fraction = 0.5.
         assert report.grounding_score == pytest.approx(0.5, abs=1e-6)
-        # 0.5 is above the 0.30 lower → no grounding flag.
+        # 0.5 is above the 0.30 fraction floor → no grounding flag.
         assert report.is_flagged_grounding is False
+
+
+class TestGroundingKnobIndependence:
+    """The per-paragraph floor and the fraction floor act independently."""
+
+    def _half_grounded_report(
+        self,
+        thresholds: GroundingThresholds,
+    ) -> GroundingReport:
+        """Score a two-paragraph draft where exactly one paragraph is grounded.
+
+        The close paragraph blends 80% toward its source (cosine well
+        above 0.30 yet below 0.85); the far paragraph is orthogonal. So
+        the grounded *fraction* is exactly 0.5 regardless of the
+        fraction floor under test.
+        """
+        anchored_source = "Anchored source paragraph for independence"
+        close = "Mostly the anchored source paragraph for independence"
+        far = "Totally unrelated independence content"
+        table = {
+            anchored_source: _hashed_vector(anchored_source),
+            close: _blended_vector([anchored_source, close], [0.8, 0.2]),
+            far: _hashed_vector(far),
+        }
+        return score_draft(
+            f"{close}\n\n{far}",
+            source_texts=[anchored_source],
+            embedding_fn=_fixture_embedder(table),
+            thresholds=thresholds,
+        )
+
+    def test_fraction_floor_flags_when_per_paragraph_floor_passes(self) -> None:
+        """Every grounded paragraph clears the per-paragraph floor, yet the
+        grounded fraction (0.5) sits below a strict fraction floor (0.6) → flag."""
+        thresholds = GroundingThresholds(
+            derivative_upper=0.85,
+            grounding_lower=0.30,
+            grounding_fraction_lower=0.60,
+        )
+        report = self._half_grounded_report(thresholds)
+        assert report.grounding_score == pytest.approx(0.5, abs=1e-6)
+        # 0.5 < 0.60 fraction floor → flagged even though the grounded
+        # paragraph individually cleared the 0.30 per-paragraph floor.
+        assert report.is_flagged_grounding is True
+
+    def test_lenient_fraction_floor_passes_same_draft(self) -> None:
+        """The identical 0.5-grounded draft passes under a lenient fraction floor.
+
+        Holding the per-paragraph floor fixed and only loosening the
+        fraction floor flips the verdict — proving the fraction knob is
+        what drives the flag, independent of the per-paragraph knob.
+        """
+        thresholds = GroundingThresholds(
+            derivative_upper=0.85,
+            grounding_lower=0.30,
+            grounding_fraction_lower=0.40,
+        )
+        report = self._half_grounded_report(thresholds)
+        assert report.grounding_score == pytest.approx(0.5, abs=1e-6)
+        # 0.5 ≥ 0.40 fraction floor → not flagged.
+        assert report.is_flagged_grounding is False
+
+    def test_per_paragraph_floor_changes_fraction_independently(self) -> None:
+        """Tightening only the per-paragraph floor drops a paragraph out of
+        the grounded set, flipping the verdict while the fraction floor holds."""
+        # With grounding_lower=0.30 the close paragraph (cosine ~0.97) is
+        # grounded → fraction 0.5 ≥ 0.40 → not flagged.
+        lenient_para = GroundingThresholds(
+            derivative_upper=0.99,
+            grounding_lower=0.30,
+            grounding_fraction_lower=0.40,
+        )
+        assert self._half_grounded_report(lenient_para).is_flagged_grounding is False
+        # Raising the per-paragraph floor above the close paragraph's
+        # cosine (~0.97) un-grounds it → fraction 0.0 < 0.40 → flagged,
+        # even though the fraction floor never moved.
+        strict_para = GroundingThresholds(
+            derivative_upper=0.99,
+            grounding_lower=0.98,
+            grounding_fraction_lower=0.40,
+        )
+        strict_report = self._half_grounded_report(strict_para)
+        assert strict_report.grounding_score == pytest.approx(0.0, abs=1e-6)
+        assert strict_report.is_flagged_grounding is True
+
+
+class TestScoreDraftDimensionMismatch:
+    """A mismatched embedding callable surfaces a clean guard error."""
+
+    def test_dimension_mismatch_raises_clean_grounding_error(self) -> None:
+        """Vectors of differing lengths abort with an actionable message.
+
+        Simulates two embedding models on one run: source paragraphs get
+        a 4-dim vector, draft paragraphs a 3-dim vector. Rather than a
+        raw ``Vector length mismatch`` traceback from deep in the loop,
+        the guard raises :class:`GroundingDimensionError` with a message
+        an operator can act on.
+        """
+
+        def _ragged_embed(text: str) -> list[float]:
+            return [1.0, 0.0, 0.0, 0.0] if text == "src para" else [1.0, 0.0, 0.0]
+
+        with pytest.raises(GroundingDimensionError) as excinfo:
+            score_draft(
+                "draft para",
+                source_texts=["src para"],
+                embedding_fn=_ragged_embed,
+                thresholds=_DEFAULT_THRESHOLDS,
+            )
+        message = str(excinfo.value)
+        assert "differing lengths" in message
+        assert "embedding" in message.lower()
 
 
 class TestScoreDraftBalanced:

--- a/creek-tools/tests/test_lint_draft_grounding.py
+++ b/creek-tools/tests/test_lint_draft_grounding.py
@@ -58,16 +58,25 @@ def _write_config(
     *,
     derivative_upper: float,
     grounding_lower: float,
+    grounding_fraction_lower: float | None = None,
 ) -> None:
-    """Drop a ``creek_config.yaml`` with explicit draft thresholds."""
-    payload = {
-        "draft": {
-            "derivative_upper": derivative_upper,
-            "grounding_lower": grounding_lower,
-        },
+    """Drop a ``creek_config.yaml`` with explicit draft thresholds.
+
+    ``grounding_fraction_lower`` defaults to ``grounding_lower`` when not
+    supplied, matching the lenient 0.30/0.30 baseline so existing callers
+    keep the behaviour they relied on before the knob was split out.
+    """
+    draft: dict[str, float] = {
+        "derivative_upper": derivative_upper,
+        "grounding_lower": grounding_lower,
+        "grounding_fraction_lower": (
+            grounding_lower
+            if grounding_fraction_lower is None
+            else grounding_fraction_lower
+        ),
     }
     (vault / "00-Creek-Meta" / "creek_config.yaml").write_text(
-        yaml.safe_dump(payload),
+        yaml.safe_dump({"draft": draft}),
         encoding="utf-8",
     )
 
@@ -164,6 +173,61 @@ class TestDraftGroundingFindings:
         result = draft_grounding_check.run(tmp_path)
         assert len(result.findings) == 1
         assert "derivative" in result.findings[0].lower()
+
+    def test_grounding_fraction_lower_is_independent_knob(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The lint check compares the stored fraction against the *fraction*
+        floor, independent of the per-paragraph ``grounding_lower``.
+
+        A stored ``grounding_score`` of 0.50 sits above a strict
+        per-paragraph floor (0.90) yet below a tightened fraction floor
+        (0.60) — the check must flag it, proving it reads
+        ``grounding_fraction_lower`` and not ``grounding_lower``.
+        """
+        _seed_meta_dir(tmp_path)
+        _write_config(
+            tmp_path,
+            derivative_upper=0.85,
+            grounding_lower=0.90,
+            grounding_fraction_lower=0.60,
+        )
+        _write_draft(
+            tmp_path,
+            name="2026-05-27-fraction",
+            derivative_score=0.4,
+            grounding_score=0.50,
+        )
+        result = draft_grounding_check.run(tmp_path)
+        assert len(result.findings) == 1
+        finding = result.findings[0]
+        assert "grounding" in finding.lower()
+        assert "0.50" in finding
+        assert "0.60" in finding
+
+    def test_grounding_fraction_lower_lenient_passes(self, tmp_path: Path) -> None:
+        """The same 0.50-fraction draft passes when the fraction floor is lenient.
+
+        Holding ``grounding_lower`` strict (0.90) but loosening
+        ``grounding_fraction_lower`` to 0.40 flips the verdict to clean —
+        confirming the fraction floor alone drives the grounding finding.
+        """
+        _seed_meta_dir(tmp_path)
+        _write_config(
+            tmp_path,
+            derivative_upper=0.85,
+            grounding_lower=0.90,
+            grounding_fraction_lower=0.40,
+        )
+        _write_draft(
+            tmp_path,
+            name="2026-05-27-fraction-ok",
+            derivative_score=0.4,
+            grounding_score=0.50,
+        )
+        result = draft_grounding_check.run(tmp_path)
+        assert result.findings == []
 
     def test_drafts_dir_missing_is_a_no_op(self, tmp_path: Path) -> None:
         """A vault with no Drafts directory must produce a clean empty result."""


### PR DESCRIPTION
## Summary

Hardens the `creek draft` grounding guard and decouples its two grounding knobs.

### #388 — cosine guard hardening (`creek/generate/grounding.py`)
- Replaced the exact zero-norm guard (`if 0.0 in (norm_a, norm_b)`) with a `1e-12` epsilon floor (`if norm_a < 1e-12 or norm_b < 1e-12`) so a degenerate near-zero embedding (norm ~1e-30) collapses to `0.0` instead of dividing into a large-but-finite, meaningless cosine.
- A dimension-mismatch `ValueError` previously propagated uncaught through `_score_one_paragraph → score_draft → _build_guard_report` to a raw traceback. `cosine_similarity` now raises a dedicated `GroundingDimensionError` (a `ValueError` subclass, so the documented contract holds) and `score_draft` re-raises it with an operator-actionable message at the guard boundary.

### #387 — split grounding thresholds (`creek/config.py`, `creek/generate/grounding.py`, `creek/lint/checks/draft_grounding.py`)
- Kept `grounding_lower` as the per-paragraph cosine floor and added an independent `grounding_fraction_lower` (minimum fraction of grounded paragraphs, default `0.30`), placed immediately after `grounding_lower` in `DraftConfig`.
- Threaded the new knob through `GroundingThresholds`, `GroundingReport.is_flagged_grounding`, the stderr summary line, and the `draft-grounding` lint check (which now compares the stored fraction against `grounding_fraction_lower`).
- Defaults stay `0.30 / 0.30`, so behaviour is backwards-compatible.

### #393 (grounding.py portion)
- Stripped `(issue #355)` / `PR #380` references from `grounding.py` docstrings in favour of invariant-focused wording.

## Tests
- Near-zero (norm ~1e-30) cosine collapses to `0.0`.
- Mismatched embedding callable raises a clean `GroundingDimensionError`.
- Two-knob independence at both layers: a draft where every grounded paragraph clears the per-paragraph floor but the grounded fraction is below `grounding_fraction_lower` flags (and the reverse passes); the lint check exercises the same independence.

`./scripts/check-all.sh` passes (exit 0): 12/12 checks green, 4558 tests pass, coverage 93.52%.

Closes #387
Closes #388
Part of #393

https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU

---
_Generated by [Claude Code](https://claude.ai/code/session_011uEVKaHvU9qMDkZiGguDsU)_