### PR TITLE
fix(tests): pin console width so the suite is deterministic on a fresh checkout (GAP-013)

### DIFF
--- a/creek-tools/tests/conftest.py
+++ b/creek-tools/tests/conftest.py
@@ -1,7 +1,11 @@
 """Shared test fixtures for creek-tools.
 
-Provides an auto-use fixture that mocks the sentence-transformer model
-loading so tests never download models or require GPU access.
+Provides auto-use fixtures that:
+
+- mock the sentence-transformer model loading so tests never download
+  models or require GPU access, and
+- pin the terminal width so Rich/Typer CLI output renders deterministically
+  regardless of the ambient terminal or whether stdout is a TTY (GAP-013).
 """
 
 from __future__ import annotations
@@ -15,7 +19,28 @@ import pytest
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+# Pin a wide terminal so Rich/Typer never wrap CLI output mid-word. Rich
+# defaults to 80 columns whenever stdout is not a TTY (pipes, fresh
+# containers, CI), which wraps substrings the tests assert on (GAP-013).
+_TEST_TERMINAL_COLUMNS = "200"
+_TEST_TERMINAL_LINES = "50"
+
 _DIMS = 384
+
+
+@pytest.fixture(autouse=True)
+def _pin_terminal_width(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin terminal width/height so Rich CLI output never wraps (GAP-013).
+
+    Rich resolves its render width from the ``COLUMNS`` environment variable
+    on every render (not just at ``Console`` construction), so setting it here
+    deterministically controls output width for the module-level ``Console``
+    in :mod:`creek.cli` and any other Rich/Typer output -- whether stdout is a
+    real TTY or a pipe. ``monkeypatch`` restores the prior environment after
+    each test.
+    """
+    monkeypatch.setenv("COLUMNS", _TEST_TERMINAL_COLUMNS)
+    monkeypatch.setenv("LINES", _TEST_TERMINAL_LINES)
 
 
 def _make_mock_model(dims: int = _DIMS) -> MagicMock:


### PR DESCRIPTION
## Summary

Two CLI-output assertions failed on any non-TTY / 80-column run because Rich wraps output mid-word at its 80-col default, splitting the asserted substrings (`does not appear to be a Creek vault`, `broken.bin`). The suite's pass/fail therefore depended on ambient terminal width — green in CI, red on a fresh checkout or when `check-all.sh` output is piped to a log. This contradicted `CLAUDE.md §2.1`.

## Fix (root cause)

Added an autouse fixture `_pin_terminal_width` in `tests/conftest.py` that `monkeypatch`-sets `COLUMNS=200` / `LINES=50` for every test. Verified that Rich resolves render width from `COLUMNS` on every render (even for the module-level `Console` singleton constructed at import), so the env pin deterministically controls width regardless of TTY. `monkeypatch` restores the environment after each test. No test assertions were edited, nothing skipped, no `noqa`/`type: ignore`.

## Test Plan

- [x] RED reproduced at ambient width 80; GREEN with `env -u COLUMNS` and piped (non-TTY) stdout: the two tests pass.
- [x] Broader slice (`test_purge.py test_pipeline.py test_cli.py`) → 294 passed, no regressions.
- [x] `lint.sh` / `format.sh --check` / `typecheck.sh` all green.

Closes #408

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLqPaALbB57e5hdtqgK1g)_