### PR TITLE
chore(scripts): actionable guard when the Python toolchain is missing (GAP-016)

### DIFF
--- a/creek-tools/scripts/_lib.sh
+++ b/creek-tools/scripts/_lib.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# scripts/_lib.sh - Shared helpers sourced by the creek-tools task scripts.
+#
+# Not executable on its own; `source` it from another script after that
+# script has set `set -euo pipefail`. Keep functions POSIX/bash-friendly
+# and shellcheck-clean (this file is checked with `# shellcheck shell=bash`).
+#
+# shellcheck shell=bash
+
+# creek_require_python_toolchain — guard against running the Python
+# toolchain (pytest/mypy/coverage/etc.) on a checkout that never had the
+# dev dependencies installed.
+#
+# On a fresh clone with only the system interpreter, a bare
+# `python -m pytest` fails with an opaque `No module named pytest` and no
+# pointer to the fix. This guard runs an explicit import probe and, on
+# failure, prints a single actionable line to stderr and returns non-zero
+# so the caller can exit before emitting the confusing native error.
+#
+# When the environment is set up correctly (`.venv` activated or deps
+# installed into the active interpreter) the probe succeeds and this
+# function is a no-op, so green runs stay green.
+#
+# Args:
+#   $1 (optional) — the Python module to probe for; defaults to "pytest".
+creek_require_python_toolchain() {
+    local module="${1:-pytest}"
+
+    if python -c "import ${module}" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    echo "error: Python toolchain not found (could not import ${module})." >&2
+    echo "       Run ./scripts/dev-setup.sh (or 'uv sync --all-extras' and" >&2
+    echo "       activate .venv) first." >&2
+    return 1
+}

--- a/creek-tools/scripts/check-all.sh
+++ b/creek-tools/scripts/check-all.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+# shellcheck source=scripts/_lib.sh
+source "$SCRIPT_DIR/_lib.sh"
+
 VERBOSE=false
 
 # Parse command line arguments
@@ -65,6 +68,11 @@ EOF
 done
 
 cd "$PROJECT_ROOT"
+
+# Fail fast (before churning through every gate) with an actionable message
+# if the Python toolchain is missing. The whole toolchain lives in the same
+# environment, so the pytest import probe is a sufficient proxy for it.
+creek_require_python_toolchain || exit 2
 
 # Set verbosity
 VERBOSE_FLAG=""

--- a/creek-tools/scripts/coverage.sh
+++ b/creek-tools/scripts/coverage.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+# shellcheck source=scripts/_lib.sh
+source "$SCRIPT_DIR/_lib.sh"
+
 HTML_REPORT=false
 XML_REPORT=false
 JSON_REPORT=false
@@ -65,6 +68,9 @@ EOF
 done
 
 cd "$PROJECT_ROOT"
+
+# Fail fast with an actionable message if the Python toolchain is missing.
+creek_require_python_toolchain || exit 2
 
 # Set verbosity
 if $VERBOSE; then

--- a/creek-tools/scripts/test.sh
+++ b/creek-tools/scripts/test.sh
@@ -8,6 +8,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+# shellcheck source=scripts/_lib.sh
+source "$SCRIPT_DIR/_lib.sh"
+
 TEST_TYPE="unit"
 COVERAGE=false
 VERBOSE=false
@@ -74,6 +77,10 @@ EOF
 done
 
 cd "$PROJECT_ROOT"
+
+# Fail fast with an actionable message if the Python toolchain is missing
+# (fresh checkout, never ran dev-setup) rather than an opaque ImportError.
+creek_require_python_toolchain || exit 2
 
 # Set verbosity
 if $VERBOSE; then


### PR DESCRIPTION
## Summary

On a fresh checkout, `scripts/test.sh` / `check-all.sh` / `coverage.sh` failed with an opaque `No module named pytest` and no pointer to the fix. This adds a DRY, actionable guard so the scripts fail fast with guidance instead.

## Changes

- `scripts/_lib.sh` (new, sourced not executed) — `creek_require_python_toolchain` probes `python -c "import pytest"`; on failure prints one actionable line to stderr and returns non-zero. No-op when the env is healthy.
- `scripts/test.sh`, `scripts/coverage.sh`, `scripts/check-all.sh` — source the helper and call the guard right after `cd "$PROJECT_ROOT"`, before invoking the toolchain. (One shared env, so the pytest probe is a sufficient proxy.)

Message: `error: Python toolchain not found (could not import pytest).` / `Run ./scripts/dev-setup.sh (or 'uv sync --all-extras' and activate .venv) first.`

## Test Plan

- [x] Fires on a broken env (no `.venv`): `test.sh`/`check-all.sh`/`coverage.sh` print the message, exit 2; `--help` still exits 0.
- [x] Silent + unchanged on a healthy env: real suite runs (4586 passed).
- [x] `shellcheck` clean on all four scripts.

Note: the unrelated `test_cli_process_prints_errors` flake seen on a clean tree is the terminal-width issue addressed by #413, not this change.

Closes #411

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLqPaALbB57e5hdtqgK1g)_