### PR TITLE
fix(ingest): detect missing tesseract binary and surface the curated error (GAP-015)

### DIFF
--- a/creek-tools/creek/ingest/images.py
+++ b/creek-tools/creek/ingest/images.py
@@ -28,6 +28,7 @@ itself raises :class:`PytesseractUnavailableError` at OCR time.
 from __future__ import annotations
 
 import logging
+import shutil
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -131,6 +132,39 @@ class PytesseractUnavailableError(RuntimeError):
     """Raised when an OCR call is made but pytesseract is not installed."""
 
 
+_TESSERACT_BINARY_MISSING_MSG: str = (
+    "The `tesseract` system binary was not found on PATH. The pytesseract "
+    "Python package is a thin wrapper that shells out to it, so OCR cannot "
+    "run without it. Install Tesseract via your OS package manager (e.g. "
+    "`brew install tesseract`, `apt-get install tesseract-ocr`, or see "
+    "https://github.com/tesseract-ocr/tesseract) and ensure it is on PATH "
+    "(or set `pytesseract.pytesseract.tesseract_cmd` to its location)."
+)
+"""Actionable remediation message for the missing-binary case (GAP-015)."""
+
+
+def _tesseract_binary_available(pytesseract: Any) -> bool:
+    """Return ``True`` when the configured ``tesseract`` binary is runnable.
+
+    ``pytesseract`` is only a wrapper around the ``tesseract`` system
+    binary; importing the Python package succeeds even when the binary
+    is absent. We honour any configured command path
+    (``pytesseract.pytesseract.tesseract_cmd``, which defaults to
+    ``"tesseract"``) and resolve it via :func:`shutil.which`, falling
+    back to :func:`pytesseract.get_tesseract_version` when ``which``
+    cannot resolve it (e.g. an absolute ``tesseract_cmd`` path that is
+    on PATH-lookup-immune but still executable).
+    """
+    cmd = getattr(pytesseract.pytesseract, "tesseract_cmd", "tesseract")
+    if shutil.which(cmd) is not None:
+        return True
+    try:
+        pytesseract.get_tesseract_version()
+    except Exception:  # pytesseract raises TesseractNotFoundError and others here
+        return False
+    return True
+
+
 # ---- Default OCR engine --------------------------------------------------
 
 
@@ -155,13 +189,20 @@ class PytesseractOcrEngine:
         self.language = language
 
     def is_available(self) -> bool:
-        """Return ``True`` when both pytesseract and Pillow import cleanly."""
+        """Return ``True`` when OCR can actually run right now.
+
+        Both the Python packages (``pytesseract``, ``Pillow``) **and**
+        the ``tesseract`` system binary they wrap must be present.
+        Importing ``pytesseract`` succeeds even when the binary is
+        missing (GAP-015), so the import guard alone would wrongly
+        report availability; we additionally probe the binary.
+        """
         try:
-            import pytesseract  # noqa: F401
+            import pytesseract
             from PIL import Image  # noqa: F401
         except ImportError:
             return False
-        return True
+        return _tesseract_binary_available(pytesseract)
 
     def extract_text(self, image_path: Path) -> OcrResult:
         """Run OCR on *image_path* and return the resulting text.
@@ -175,7 +216,8 @@ class PytesseractOcrEngine:
 
         Raises:
             PytesseractUnavailableError: When ``pytesseract`` or
-                ``Pillow`` cannot be imported.
+                ``Pillow`` cannot be imported, or when the ``tesseract``
+                system binary they wrap is not installed (GAP-015).
         """
         try:
             import pytesseract
@@ -208,7 +250,9 @@ class PytesseractOcrEngine:
 
         Raises:
             PytesseractUnavailableError: When ``pdf2image``,
-                ``pytesseract``, or ``Pillow`` cannot be imported.
+                ``pytesseract``, or ``Pillow`` cannot be imported, or
+                when the ``tesseract`` system binary is not installed
+                (GAP-015).
         """
         try:
             import pytesseract
@@ -221,7 +265,14 @@ class PytesseractOcrEngine:
             )
             raise PytesseractUnavailableError(msg) from exc
 
-        pages = convert_from_path(str(pdf_path))
+        return self._ocr_pdf_pages(pytesseract, convert_from_path(str(pdf_path)))
+
+    def _ocr_pdf_pages(
+        self,
+        pytesseract: Any,
+        pages: list[Any],
+    ) -> list[OcrResult]:
+        """OCR each pre-rendered PDF page image into an :class:`OcrResult`."""
         results: list[OcrResult] = []
         for index, page_image in enumerate(pages, start=1):
             preprocessed = self._preprocess(page_image)
@@ -250,13 +301,25 @@ class PytesseractOcrEngine:
         return ImageEnhance.Contrast(image.convert("RGB")).enhance(2.0)
 
     def _ocr_image(self, pytesseract: Any, image: Any) -> tuple[str, float]:
-        """Run tesseract on a preprocessed image, returning ``(text, confidence)``."""
-        text = pytesseract.image_to_string(image, lang=self.language)
-        data = pytesseract.image_to_data(
-            image,
-            lang=self.language,
-            output_type=pytesseract.Output.DICT,
-        )
+        """Run tesseract on a preprocessed image, returning ``(text, confidence)``.
+
+        Translates the raw ``pytesseract.TesseractNotFoundError`` (raised
+        when the ``tesseract`` system binary is absent — distinct from the
+        ``ImportError`` raised when the Python package is missing) into the
+        curated :class:`PytesseractUnavailableError` carrying the
+        install-the-binary remediation message (GAP-015). This is the single
+        choke point both :meth:`extract_text` and :meth:`extract_pdf_pages`
+        funnel through, so neither leaks the raw error.
+        """
+        try:
+            text = pytesseract.image_to_string(image, lang=self.language)
+            data = pytesseract.image_to_data(
+                image,
+                lang=self.language,
+                output_type=pytesseract.Output.DICT,
+            )
+        except pytesseract.TesseractNotFoundError as exc:
+            raise PytesseractUnavailableError(_TESSERACT_BINARY_MISSING_MSG) from exc
         confidence = _average_confidence(data.get("conf", []))
         return text.strip(), confidence
 

--- a/creek-tools/tests/test_images_ingestor.py
+++ b/creek-tools/tests/test_images_ingestor.py
@@ -222,6 +222,19 @@ def _write_image(path: Path) -> None:
     path.write_bytes(b"\x89PNG\r\n\x1a\n")
 
 
+def _write_real_png(path: Path) -> None:
+    """Write a genuine 1x1 PNG that ``PIL.Image.open`` can decode.
+
+    The :func:`_write_image` placeholder only carries the PNG signature
+    and cannot be opened; tests that exercise the real
+    :class:`PytesseractOcrEngine` OCR path (mocking only the
+    ``image_to_*`` calls, not ``Image.open``) need a decodable file.
+    """
+    from PIL import Image
+
+    Image.new("RGB", (1, 1), color=(255, 255, 255)).save(path, format="PNG")
+
+
 class TestParseAndIngest:
     """Parse runs OCR and produces a ParsedFragment with body + metadata."""
 
@@ -655,6 +668,121 @@ class TestPytesseractOcrEngine:
         engine = PytesseractOcrEngine()
         with pytest.raises(PytesseractUnavailableError):
             engine.extract_pdf_pages(pdf_path)
+
+    def test_is_available_returns_false_when_binary_missing(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """pytesseract present but tesseract binary absent → unavailable (GAP-015)."""
+        import shutil as shutil_module
+
+        import pytesseract
+
+        monkeypatch.setattr(shutil_module, "which", lambda _cmd: None)
+
+        def _raise_version() -> object:
+            raise pytesseract.TesseractNotFoundError
+
+        monkeypatch.setattr(pytesseract, "get_tesseract_version", _raise_version)
+        engine = PytesseractOcrEngine()
+        assert not engine.is_available()
+
+    def test_is_available_true_when_binary_on_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When shutil.which resolves the configured binary, the engine is available."""
+        import shutil as shutil_module
+
+        monkeypatch.setattr(shutil_module, "which", lambda _cmd: "/usr/bin/tesseract")
+        engine = PytesseractOcrEngine()
+        assert engine.is_available()
+
+    def test_is_available_true_when_version_probe_succeeds(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When ``which`` misses but ``get_tesseract_version`` succeeds, stay available.
+
+        Covers a configured absolute ``tesseract_cmd`` that ``shutil.which``
+        cannot resolve but pytesseract can still execute.
+        """
+        import shutil as shutil_module
+
+        import pytesseract
+
+        monkeypatch.setattr(shutil_module, "which", lambda _cmd: None)
+        monkeypatch.setattr(pytesseract, "get_tesseract_version", lambda: "5.3.0")
+        engine = PytesseractOcrEngine()
+        assert engine.is_available()
+
+    def test_is_available_honours_configured_tesseract_cmd(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The probe resolves the configured ``tesseract_cmd``, not a fixed name."""
+        import shutil as shutil_module
+
+        import pytesseract
+
+        seen: list[str] = []
+
+        def _which(cmd: str) -> str | None:
+            seen.append(cmd)
+            return "/opt/tess/mytess" if cmd == "/opt/tess/mytess" else None
+
+        monkeypatch.setattr(shutil_module, "which", _which)
+        monkeypatch.setattr(
+            pytesseract.pytesseract,
+            "tesseract_cmd",
+            "/opt/tess/mytess",
+        )
+        engine = PytesseractOcrEngine()
+        assert engine.is_available()
+        assert seen == ["/opt/tess/mytess"]
+
+    def test_extract_text_maps_binary_missing_to_curated_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A raw TesseractNotFoundError becomes the curated install-the-binary error."""
+        import pytesseract
+
+        def _raise(*_args: object, **_kwargs: object) -> str:
+            raise pytesseract.TesseractNotFoundError
+
+        monkeypatch.setattr(pytesseract, "image_to_string", _raise)
+        image_path = tmp_path / "x.png"
+        _write_real_png(image_path)
+        engine = PytesseractOcrEngine()
+        with pytest.raises(PytesseractUnavailableError, match="tesseract"):
+            engine.extract_text(image_path)
+
+    def test_extract_text_returns_result_when_all_present(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Regression: with deps and binary present, extract_text returns OCR'd text."""
+        import pytesseract
+
+        monkeypatch.setattr(
+            pytesseract,
+            "image_to_string",
+            lambda *_a, **_k: "decoded body",
+        )
+        monkeypatch.setattr(
+            pytesseract,
+            "image_to_data",
+            lambda *_a, **_k: {"conf": [90, 95]},
+        )
+        image_path = tmp_path / "screenshot.png"
+        _write_real_png(image_path)
+        engine = PytesseractOcrEngine()
+        result = engine.extract_text(image_path)
+        assert result.text == "decoded body"
+        assert result.confidence == pytest.approx(0.925)
 
 
 # ---- Helper function unit tests ---------------------------------------


### PR DESCRIPTION
## Summary

The OCR ingestor's availability probe only caught `ImportError`, so with `pytesseract` installed but the `tesseract` **system binary** absent, `is_available()` wrongly returned `True` and the raw `TesseractNotFoundError` escaped instead of the curated `PytesseractUnavailableError` — turning a folder of screenshots into per-file parse errors with no actionable message.

## Changes

- `creek/ingest/images.py`:
  - New `_tesseract_binary_available()` helper probes the binary via `shutil.which()` on the configured command path, falling back to `pytesseract.get_tesseract_version()`. `is_available()` returns it after the existing `ImportError` guard. Honors a user-set `pytesseract.pytesseract.tesseract_cmd` (incl. absolute paths).
  - Maps `TesseractNotFoundError` → curated `PytesseractUnavailableError` (with install instructions) at the single `_ocr_image` choke point both `extract_text` and `extract_pdf_pages` funnel through, so the raw error never escapes (and no second `try` block / TRY101).
  - Existing missing-Python-package behavior unchanged.
- `tests/test_images_ingestor.py`: 6 new tests (binary-missing → unavailable; on-path / version-probe / configured-cmd → available; extract maps to curated error asserting the message; success regression) + a real-PNG helper.

## Test Plan

- [x] `pytest tests/test_images_ingestor.py` → 66 passed
- [x] `lint.sh` / `format.sh --check` / `typecheck.sh` / `lint-tryceratops.sh` / `lint-refurb.sh` / `complexity.sh` all exit 0
- [x] Real-env smoke (binary genuinely absent): `is_available()` → False
- [x] No `noqa` / `type: ignore` / skips

Closes #410

---
_Generated by [Claude Code](https://claude.ai/code/session_01MTLqPaALbB57e5hdtqgK1g)_