### PR TITLE
feat(ai-style): Markdown-structure sanitizer (FEAT-040.4)

### DIFF
--- a/creek-tools/creek/generate/ai_style/__init__.py
+++ b/creek-tools/creek/generate/ai_style/__init__.py
@@ -31,6 +31,7 @@ from creek.generate.ai_style.model import (
     Span,
     VoiceFingerprint,
 )
+from creek.generate.ai_style.sanitize_structure import sanitize_structure
 from creek.generate.ai_style.sanitize_typography import (
     normalize_typography,
     sanitize,
@@ -67,6 +68,7 @@ __all__ = [
     "rate_per_kwords",
     "register",
     "sanitize",
+    "sanitize_structure",
     "save_fingerprint",
     "scan",
     "strip_markup_artifacts",

--- a/creek-tools/creek/generate/ai_style/_text.py
+++ b/creek-tools/creek/generate/ai_style/_text.py
@@ -1,0 +1,25 @@
+"""Shared text utilities for the AI-style sanitizers.
+
+Single source of truth for whitespace tidying used by both the typography
+and structure sanitizers (DRY).
+"""
+
+from __future__ import annotations
+
+import re
+
+_MULTISPACE_RE = re.compile(r"[ \t]{2,}")
+_TRAILING_WS_RE = re.compile(r"[ \t]+$", re.MULTILINE)
+
+
+def tidy_whitespace(body: str) -> str:
+    """Collapse runs of spaces/tabs to one and strip trailing line whitespace.
+
+    Args:
+        body: Text to tidy.
+
+    Returns:
+        The text with internal multi-space runs collapsed and trailing
+        per-line whitespace removed.
+    """
+    return _TRAILING_WS_RE.sub("", _MULTISPACE_RE.sub(" ", body))

--- a/creek-tools/creek/generate/ai_style/sanitize_structure.py
+++ b/creek-tools/creek/generate/ai_style/sanitize_structure.py
@@ -7,7 +7,8 @@ What remains are the meaning-preserving structural tells:
 
 * a whole-body fenced code block wrapping the essay (an LLM "here is your
   article" artifact),
-* a thematic break (``---`` / ``***``) sitting directly above a heading,
+* a thematic break (``---`` / ``***`` / ``___``) sitting directly above a
+  heading,
 * canned ``- **Header:** text`` vertical lists (the bold-colon is mechanical
   emphasis the user did not add),
 * decorative leading emoji on headings and bullets,
@@ -37,6 +38,9 @@ _WHOLE_FENCE_RE = re.compile(
 # blank line (or start of document) is REQUIRED so this never matches a
 # setext heading underline (``Title\n---``), which would silently demote a
 # real heading to a paragraph. The boundary is captured and preserved.
+# Known limitation: two consecutive breaks before a heading
+# (``---\n---\n## H``) are not fully repaired, since the lookahead needs a
+# heading immediately after the consumed break. LLMs rarely emit those.
 _BREAK_BEFORE_HEADING_RE = re.compile(
     r"(?P<lead>\A|\n\n)(?:-{3,}|\*{3,}|_{3,})[ \t]*\n(?=#{1,6}[ \t])",
 )
@@ -115,10 +119,13 @@ def flatten_inline_header_lists(body: str) -> str:
     Returns:
         The body with inline-header bold removed.
     """
-    return _INLINE_HEADER_RE.sub(
+    flattened = _INLINE_HEADER_RE.sub(
         lambda m: f"{m.group('marker')}{m.group('header').rstrip(':').rstrip()}: ",
         body,
     )
+    # tidy so a header with no following text ("- **Note:**") does not leak a
+    # trailing space when this is called standalone (not just in the pipeline).
+    return tidy_whitespace(flattened)
 
 
 def strip_leading_emoji(body: str) -> str:

--- a/creek-tools/creek/generate/ai_style/sanitize_structure.py
+++ b/creek-tools/creek/generate/ai_style/sanitize_structure.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 
 import re
 
+from creek.generate.ai_style._text import tidy_whitespace
+
 # Whole-body fenced code block: ``` or ```lang ... ``` spanning the entire
 # text (optionally with surrounding blank lines).
 _WHOLE_FENCE_RE = re.compile(
@@ -31,16 +33,19 @@ _WHOLE_FENCE_RE = re.compile(
     re.DOTALL,
 )
 
-# A thematic break line immediately followed by an ATX heading.
+# A thematic break line immediately followed by an ATX heading. The leading
+# blank line (or start of document) is REQUIRED so this never matches a
+# setext heading underline (``Title\n---``), which would silently demote a
+# real heading to a paragraph. The boundary is captured and preserved.
 _BREAK_BEFORE_HEADING_RE = re.compile(
-    r"^(?:-{3,}|\*{3,}|_{3,})[ \t]*\n(?=#{1,6}[ \t])",
-    re.MULTILINE,
+    r"(?P<lead>\A|\n\n)(?:-{3,}|\*{3,}|_{3,})[ \t]*\n(?=#{1,6}[ \t])",
 )
 
 # Canned inline-header list item: "- **Header:** text" or "1. **Header**: text".
+# A colon after the bold is optionally consumed but not captured; the
+# replacement re-adds a single normalised colon from the header text.
 _INLINE_HEADER_RE = re.compile(
-    r"^(?P<marker>[ \t]*(?:[-*+]|\d+\.)[ \t]+)"
-    r"\*\*(?P<header>[^*\n]+?)\*\*(?P<colon>:?)[ \t]*",
+    r"^(?P<marker>[ \t]*(?:[-*+]|\d+\.)[ \t]+)\*\*(?P<header>[^*\n]+?)\*\*:?[ \t]*",
     re.MULTILINE,
 )
 
@@ -64,9 +69,6 @@ _PLACEHOLDER_RES: tuple[re.Pattern[str], ...] = (
     re.compile(r"\[Describe[^\]]*\]"),
     re.compile(r"↩"),
 )
-
-_MULTISPACE_RE = re.compile(r"[ \t]{2,}")
-_TRAILING_WS_RE = re.compile(r"[ \t]+$", re.MULTILINE)
 
 
 def unwrap_code_fence(body: str) -> str:
@@ -94,9 +96,10 @@ def strip_breaks_before_headings(body: str) -> str:
 
     Returns:
         The body without ``---`` / ``***`` / ``___`` lines that precede a
-        heading (a Markdown-output AI habit).
+        heading (a Markdown-output AI habit). The preceding blank line is
+        preserved; setext heading underlines are left untouched.
     """
-    return _BREAK_BEFORE_HEADING_RE.sub("", body)
+    return _BREAK_BEFORE_HEADING_RE.sub(r"\g<lead>", body)
 
 
 def flatten_inline_header_lists(body: str) -> str:
@@ -142,8 +145,7 @@ def strip_placeholders(body: str) -> str:
     """
     for pattern in _PLACEHOLDER_RES:
         body = pattern.sub("", body)
-    body = _MULTISPACE_RE.sub(" ", body)
-    return _TRAILING_WS_RE.sub("", body)
+    return tidy_whitespace(body)
 
 
 def sanitize_structure(body: str) -> str:

--- a/creek-tools/creek/generate/ai_style/sanitize_structure.py
+++ b/creek-tools/creek/generate/ai_style/sanitize_structure.py
@@ -1,0 +1,162 @@
+"""Deterministic repair: Markdown structure, emoji, and placeholders.
+
+The pairing module for :mod:`creek.generate.ai_style.sanitize_typography`.
+creek's vault is **Obsidian markdown**, so markdown headings, bold, italic,
+and links are the *correct* target — there is no wikitext conversion to do.
+What remains are the meaning-preserving structural tells:
+
+* a whole-body fenced code block wrapping the essay (an LLM "here is your
+  article" artifact),
+* a thematic break (``---`` / ``***``) sitting directly above a heading,
+* canned ``- **Header:** text`` vertical lists (the bold-colon is mechanical
+  emphasis the user did not add),
+* decorative leading emoji on headings and bullets,
+* unfilled placeholders (``INSERT_…``, ``PASTE_…``, ``[Your Name]``,
+  ``2025-xx-xx``, ``↩``).
+
+Heading-case rewriting (Title Case → sentence case) is intentionally **not**
+done here: safely preserving proper nouns is not deterministic, so that tell
+is surfaced by the detector layer rather than auto-rewritten. Everything
+here operates on the body only and is idempotent.
+"""
+
+from __future__ import annotations
+
+import re
+
+# Whole-body fenced code block: ``` or ```lang ... ``` spanning the entire
+# text (optionally with surrounding blank lines).
+_WHOLE_FENCE_RE = re.compile(
+    r"\A\s*```[^\n]*\n(?P<body>.*?)\n```\s*\Z",
+    re.DOTALL,
+)
+
+# A thematic break line immediately followed by an ATX heading.
+_BREAK_BEFORE_HEADING_RE = re.compile(
+    r"^(?:-{3,}|\*{3,}|_{3,})[ \t]*\n(?=#{1,6}[ \t])",
+    re.MULTILINE,
+)
+
+# Canned inline-header list item: "- **Header:** text" or "1. **Header**: text".
+_INLINE_HEADER_RE = re.compile(
+    r"^(?P<marker>[ \t]*(?:[-*+]|\d+\.)[ \t]+)"
+    r"\*\*(?P<header>[^*\n]+?)\*\*(?P<colon>:?)[ \t]*",
+    re.MULTILINE,
+)
+
+# Decorative emoji (symbols + pictographs) at the start of a heading/bullet's
+# content. Ranges expressed as escapes to avoid ambiguous-literal lint.
+_EMOJI = (
+    "\U0001f300-\U0001faff"  # symbols & pictographs, supplemental + extended
+    "\u2600-\u27bf"  # misc symbols + dingbats
+    "\ufe0f"  # variation selector-16
+)
+_LEADING_EMOJI_RE = re.compile(
+    r"^(?P<prefix>[ \t]*(?:#{1,6}[ \t]+|(?:[-*+]|\d+\.)[ \t]+))"
+    rf"[{_EMOJI}]+[ \t]*",
+    re.MULTILINE,
+)
+
+_PLACEHOLDER_RES: tuple[re.Pattern[str], ...] = (
+    re.compile(r"\b\d{4}-[xX]{2}-[xX]{2}\b"),
+    re.compile(r"\b(?:INSERT|PASTE)_[A-Z0-9_]*\b"),
+    re.compile(r"\[Your Name\]"),
+    re.compile(r"\[Describe[^\]]*\]"),
+    re.compile(r"↩"),
+)
+
+_MULTISPACE_RE = re.compile(r"[ \t]{2,}")
+_TRAILING_WS_RE = re.compile(r"[ \t]+$", re.MULTILINE)
+
+
+def unwrap_code_fence(body: str) -> str:
+    """Unwrap a fenced code block that wraps the entire body.
+
+    LLMs often emit a whole essay inside a ```` ``` ```` block. When the
+    *entire* body is one fence, its contents are the real text.
+
+    Args:
+        body: Prose to inspect.
+
+    Returns:
+        The fence contents when the whole body is one fenced block, else
+        *body* unchanged.
+    """
+    match = _WHOLE_FENCE_RE.match(body)
+    return match.group("body") if match is not None else body
+
+
+def strip_breaks_before_headings(body: str) -> str:
+    """Remove a thematic break line sitting directly above a heading.
+
+    Args:
+        body: Prose to clean.
+
+    Returns:
+        The body without ``---`` / ``***`` / ``___`` lines that precede a
+        heading (a Markdown-output AI habit).
+    """
+    return _BREAK_BEFORE_HEADING_RE.sub("", body)
+
+
+def flatten_inline_header_lists(body: str) -> str:
+    """Strip the mechanical bold-colon from canned inline-header list items.
+
+    ``- **Setup:** do the thing`` becomes ``- Setup: do the thing`` — the
+    list survives, but the formulaic boldface the user did not write is
+    removed.
+
+    Args:
+        body: Prose to normalise.
+
+    Returns:
+        The body with inline-header bold removed.
+    """
+    return _INLINE_HEADER_RE.sub(
+        lambda m: f"{m.group('marker')}{m.group('header').rstrip(':').rstrip()}: ",
+        body,
+    )
+
+
+def strip_leading_emoji(body: str) -> str:
+    """Remove decorative emoji at the start of headings and bullets.
+
+    Args:
+        body: Prose to clean.
+
+    Returns:
+        The body with leading decorative emoji removed from heading/bullet
+        lines (the list marker or heading hashes are preserved).
+    """
+    return _LEADING_EMOJI_RE.sub(lambda m: m.group("prefix"), body)
+
+
+def strip_placeholders(body: str) -> str:
+    """Remove unfilled LLM placeholders (``INSERT_…``, ``2025-xx-xx``, …).
+
+    Args:
+        body: Prose to clean.
+
+    Returns:
+        The body with placeholder tokens removed and whitespace tidied.
+    """
+    for pattern in _PLACEHOLDER_RES:
+        body = pattern.sub("", body)
+    body = _MULTISPACE_RE.sub(" ", body)
+    return _TRAILING_WS_RE.sub("", body)
+
+
+def sanitize_structure(body: str) -> str:
+    """Apply every structural repair to *body* in order.
+
+    Args:
+        body: Prose (frontmatter already removed by the caller).
+
+    Returns:
+        The structurally sanitized body. Idempotent.
+    """
+    body = unwrap_code_fence(body)
+    body = strip_breaks_before_headings(body)
+    body = flatten_inline_header_lists(body)
+    body = strip_leading_emoji(body)
+    return strip_placeholders(body)

--- a/creek-tools/creek/generate/ai_style/sanitize_typography.py
+++ b/creek-tools/creek/generate/ai_style/sanitize_typography.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from creek.generate.ai_style.sanitize_structure import sanitize_structure
+
 if TYPE_CHECKING:
     from creek.config import AIStyleConfig
     from creek.generate.ai_style.model import VoiceFingerprint
@@ -196,5 +198,6 @@ def sanitize(
     """
     front, body = _split_frontmatter(text)
     body = strip_markup_artifacts(body)
+    body = sanitize_structure(body)
     body = normalize_typography(body, fingerprint=fingerprint, config=config)
     return front + body

--- a/creek-tools/creek/generate/ai_style/sanitize_typography.py
+++ b/creek-tools/creek/generate/ai_style/sanitize_typography.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+from creek.generate.ai_style._text import tidy_whitespace
 from creek.generate.ai_style.sanitize_structure import sanitize_structure
 
 if TYPE_CHECKING:
@@ -78,9 +79,6 @@ def _strip_utm(match: re.Match[str]) -> str:
     return ""
 
 
-_MULTISPACE_RE = re.compile(r"[ \t]{2,}")
-_TRAILING_WS_RE = re.compile(r"[ \t]+$", re.MULTILINE)
-
 # --- typography ------------------------------------------------------------
 _CURLY_TO_STRAIGHT = {
     0x2018: "'",
@@ -119,8 +117,7 @@ def strip_markup_artifacts(body: str) -> str:
     for pattern in _ARTIFACT_PATTERNS:
         body = pattern.sub("", body)
     body = _UTM_RE.sub(_strip_utm, body)
-    body = _MULTISPACE_RE.sub(" ", body)
-    return _TRAILING_WS_RE.sub("", body)
+    return tidy_whitespace(body)
 
 
 def _uses_feature(
@@ -182,11 +179,11 @@ def sanitize(
     fingerprint: VoiceFingerprint,
     config: AIStyleConfig,
 ) -> str:
-    """Frontmatter-safe, idempotent typography + artifact sanitizer.
+    """Frontmatter-safe, idempotent sanitizer: artifacts, structure, typography.
 
-    Splits off any YAML frontmatter, strips markup artifacts, normalises
-    typography against the fingerprint, and recombines. (Issue #421 extends
-    this aggregator with the Markdown-structure stage.)
+    Splits off any YAML frontmatter, strips markup artifacts and structural
+    LLM tells, normalises typography against the voice fingerprint, and
+    recombines.
 
     Args:
         text: The full text (body, optionally with frontmatter).

--- a/creek-tools/tests/generate/ai_style/test_sanitize_structure.py
+++ b/creek-tools/tests/generate/ai_style/test_sanitize_structure.py
@@ -1,0 +1,110 @@
+"""Tests for the Markdown-structure sanitizer (FEAT-040.4)."""
+
+from __future__ import annotations
+
+from creek.generate.ai_style.sanitize_structure import (
+    flatten_inline_header_lists,
+    sanitize_structure,
+    strip_breaks_before_headings,
+    strip_leading_emoji,
+    strip_placeholders,
+    unwrap_code_fence,
+)
+
+
+class TestUnwrapCodeFence:
+    """A whole-body fence is unwrapped; partial fences are left alone."""
+
+    def test_whole_body_fence_unwrapped(self) -> None:
+        """An essay wrapped in ```markdown ... ``` is unwrapped."""
+        body = "```markdown\n# Title\n\nReal prose here.\n```"
+        out = unwrap_code_fence(body)
+        assert out == "# Title\n\nReal prose here."
+
+    def test_inline_fence_untouched(self) -> None:
+        """A code block inside real prose is not unwrapped."""
+        body = "Here is code:\n\n```py\nx = 1\n```\n\nand more prose."
+        assert unwrap_code_fence(body) == body
+
+
+class TestThematicBreaks:
+    """Breaks directly above headings are AI artifacts."""
+
+    def test_break_before_heading_removed(self) -> None:
+        """A --- line directly above a heading is removed."""
+        body = "Intro paragraph.\n\n----\n## History\n\nText."
+        out = strip_breaks_before_headings(body)
+        assert "----" not in out
+        assert "## History" in out
+
+    def test_standalone_break_kept(self) -> None:
+        """A thematic break not followed by a heading is preserved."""
+        body = "Section one.\n\n---\n\nSection two prose, no heading."
+        assert strip_breaks_before_headings(body) == body
+
+
+class TestInlineHeaderLists:
+    """Canned bold-colon list items are flattened."""
+
+    def test_bold_colon_inside(self) -> None:
+        """`- **Setup:** text` loses the mechanical bold."""
+        out = flatten_inline_header_lists("- **Setup:** do the thing")
+        assert out == "- Setup: do the thing"
+
+    def test_bold_then_colon(self) -> None:
+        """`1. **Setup**: text` is flattened and keeps its colon."""
+        out = flatten_inline_header_lists("1. **Setup**: do it")
+        assert out == "1. Setup: do it"
+
+    def test_ordinary_bold_untouched(self) -> None:
+        """Mid-sentence bold (not a list-item header) is left alone."""
+        body = "This is **important** to me."
+        assert flatten_inline_header_lists(body) == body
+
+
+class TestEmoji:
+    """Decorative leading emoji are stripped, markers preserved."""
+
+    def test_emoji_on_heading(self) -> None:
+        """A heading's leading emoji is removed; the hashes remain."""
+        out = strip_leading_emoji("## \U0001f680 Launch plan")
+        assert out == "## Launch plan"
+
+    def test_emoji_on_bullet(self) -> None:
+        """A bullet's leading emoji is removed; the marker remains."""
+        out = strip_leading_emoji("- \U0001f9e0 think hard")
+        assert out == "- think hard"
+
+    def test_no_emoji_untouched(self) -> None:
+        """Ordinary heading text is unchanged."""
+        assert strip_leading_emoji("## Plan") == "## Plan"
+
+
+class TestPlaceholders:
+    """Unfilled placeholders are stripped."""
+
+    def test_insert_paste_tokens(self) -> None:
+        """INSERT_/PASTE_ tokens are removed."""
+        out = strip_placeholders("url INSERT_SOURCE_URL_30 and PASTE_SPOTIFY_URL_HERE")
+        assert "INSERT_" not in out
+        assert "PASTE_" not in out
+
+    def test_placeholder_date_and_your_name(self) -> None:
+        """2025-xx-xx and [Your Name] are removed."""
+        out = strip_placeholders("dated 2025-xx-xx by [Your Name] today")
+        assert "2025-xx-xx" not in out
+        assert "Your Name" not in out
+
+
+class TestSanitizeStructure:
+    """The composed, idempotent structure pass."""
+
+    def test_composes_and_is_idempotent(self) -> None:
+        """All repairs apply together and running twice equals once."""
+        body = "```markdown\nIntro.\n\n----\n## \U0001f680 Plan\n\n- **Step:** go\n```"
+        once = sanitize_structure(body)
+        assert "```" not in once
+        assert "----" not in once
+        assert "## Plan" in once
+        assert "- Step: go" in once
+        assert sanitize_structure(once) == once

--- a/creek-tools/tests/generate/ai_style/test_sanitize_structure.py
+++ b/creek-tools/tests/generate/ai_style/test_sanitize_structure.py
@@ -52,6 +52,12 @@ class TestThematicBreaks:
         out = strip_breaks_before_headings("Intro.\n\n----\n## H\n\nx")
         assert out == "Intro.\n\n## H\n\nx"
 
+    def test_break_at_document_start_removed(self) -> None:
+        """A break opening the document (the \\A branch) is removed."""
+        out = strip_breaks_before_headings("---\n## Opening\n\nText.")
+        assert "---" not in out
+        assert "## Opening" in out
+
 
 class TestInlineHeaderLists:
     """Canned bold-colon list items are flattened."""
@@ -70,6 +76,10 @@ class TestInlineHeaderLists:
         """Mid-sentence bold (not a list-item header) is left alone."""
         body = "This is **important** to me."
         assert flatten_inline_header_lists(body) == body
+
+    def test_header_with_no_following_text_no_trailing_space(self) -> None:
+        """`- **Note:**` with nothing after leaves no trailing space."""
+        assert flatten_inline_header_lists("- **Note:**") == "- Note:"
 
 
 class TestEmoji:

--- a/creek-tools/tests/generate/ai_style/test_sanitize_structure.py
+++ b/creek-tools/tests/generate/ai_style/test_sanitize_structure.py
@@ -42,6 +42,16 @@ class TestThematicBreaks:
         body = "Section one.\n\n---\n\nSection two prose, no heading."
         assert strip_breaks_before_headings(body) == body
 
+    def test_setext_heading_not_destroyed(self) -> None:
+        """A setext underline (Title\\n---) above a heading is left intact."""
+        body = "My Section Title\n---\n## Subsection\n\nText."
+        assert strip_breaks_before_headings(body) == body
+
+    def test_blank_line_preserved_after_removal(self) -> None:
+        """Removing the break keeps the blank line separating prose/heading."""
+        out = strip_breaks_before_headings("Intro.\n\n----\n## H\n\nx")
+        assert out == "Intro.\n\n## H\n\nx"
+
 
 class TestInlineHeaderLists:
     """Canned bold-colon list items are flattened."""
@@ -94,6 +104,16 @@ class TestPlaceholders:
         out = strip_placeholders("dated 2025-xx-xx by [Your Name] today")
         assert "2025-xx-xx" not in out
         assert "Your Name" not in out
+
+    def test_describe_placeholder_removed(self) -> None:
+        """A [Describe ...] mad-lib placeholder is removed."""
+        out = strip_placeholders("For [Describe the specific section] here.")
+        assert "[Describe" not in out
+
+    def test_return_arrow_removed(self) -> None:
+        """The footnote return arrow is removed."""
+        out = strip_placeholders("See footnote 1. ↩")
+        assert "↩" not in out
 
 
 class TestSanitizeStructure:

--- a/creek-tools/tests/generate/ai_style/test_text.py
+++ b/creek-tools/tests/generate/ai_style/test_text.py
@@ -1,0 +1,15 @@
+"""Tests for the shared text utilities (FEAT-040)."""
+
+from __future__ import annotations
+
+from creek.generate.ai_style._text import tidy_whitespace
+
+
+def test_collapses_internal_runs() -> None:
+    """Runs of 2+ spaces/tabs collapse to a single space."""
+    assert tidy_whitespace("a   b\t\tc") == "a b c"
+
+
+def test_strips_trailing_line_whitespace() -> None:
+    """Trailing per-line whitespace is removed, newlines preserved."""
+    assert tidy_whitespace("a  \nb \n") == "a\nb\n"


### PR DESCRIPTION
## Summary
Meaning-preserving structural repairs pairing with the typography sanitizer (#420). **Design note:** creek's vault is **Obsidian markdown**, so the issue's wikitext conversions (`##`→`==`, bold→`'''`) do not apply — markdown *is* the target. What's repaired:
- `unwrap_code_fence` — unwrap a whole-body ```` ``` ```` block (LLM "here is your article" wrapper); inline code blocks are untouched.
- `strip_breaks_before_headings` — drop a `---`/`***`/`___` line directly above a heading; standalone breaks survive.
- `flatten_inline_header_lists` — `- **Setup:** text` → `- Setup: text` (drops the mechanical bold-colon, keeps the list); mid-sentence bold is untouched.
- `strip_leading_emoji` — remove decorative emoji from heading/bullet starts, preserving the marker.
- `strip_placeholders` — `INSERT_*`/`PASTE_*`, `[Your Name]`, `2025-xx-xx`, `↩`.

`sanitize()` composes typography + structure; frontmatter-safe and idempotent.

**Heading-case rewriting is intentionally out of scope** — safely preserving proper nouns isn't deterministic, so Title-Case→sentence-case is left to the detector/surface layer rather than auto-rewritten.

## Test plan
- `./scripts/check-all.sh` → 12/12; new module at 100% coverage.
- Per-repair tests + negative fixtures (inline code fence, standalone break, mid-sentence bold, plain heading all untouched); composed `sanitize_structure` is idempotent.

Closes #421
Refs #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
