### PR TITLE
feat(ai-style): vault-relative lexical detectors (FEAT-040.5)

### DIFF
--- a/creek-tools/creek/generate/ai_style/__init__.py
+++ b/creek-tools/creek/generate/ai_style/__init__.py
@@ -22,6 +22,12 @@ from creek.generate.ai_style.fingerprint import (
     load_fingerprint,
     save_fingerprint,
 )
+from creek.generate.ai_style.lexical import (
+    AI_VOCABULARY,
+    CONCRETE_COMMENT,
+    COPULATIVE_AVOIDANCE,
+    TRANSITION_OPENER,
+)
 from creek.generate.ai_style.model import (
     Category,
     Direction,
@@ -48,8 +54,12 @@ from creek.generate.ai_style.tells import (
 )
 
 __all__ = [
+    "AI_VOCABULARY",
+    "CONCRETE_COMMENT",
+    "COPULATIVE_AVOIDANCE",
     "FINGERPRINT_FEATURES",
     "TELL_REGISTRY",
+    "TRANSITION_OPENER",
     "Category",
     "Direction",
     "FeatureContribution",

--- a/creek-tools/creek/generate/ai_style/features.py
+++ b/creek-tools/creek/generate/ai_style/features.py
@@ -31,7 +31,7 @@ _WORD_RE = re.compile(r"\b\w+\b")
 # killer features"), which can inflate the ratio in personal writing.
 # FEAT-040.5 (the lexical detector) narrows these to verb context; the
 # fingerprint only needs a consistent, if slightly noisy, baseline.
-_MARKETING_VERBS = (
+MARKETING_VERBS = (
     "serves as",
     "stands as",
     "boasts",
@@ -41,7 +41,7 @@ _MARKETING_VERBS = (
 )
 _COPULAS = (" is ", " are ", " was ", " were ", " has ", " have ")
 
-_TRANSITION_OPENERS = (
+TRANSITION_OPENERS = (
     "additionally",
     "moreover",
     "furthermore",
@@ -53,7 +53,7 @@ _TRANSITION_OPENERS = (
 # tunable catalog lands with the lexical detector (FEAT-040.5); the
 # fingerprint only needs a consistent measure of how often the user
 # reaches for these words.
-_AI_VOCAB = (
+AI_VOCAB = (
     "delve",
     "tapestry",
     "underscore",
@@ -101,7 +101,7 @@ def curly_quote_density(text: str) -> float:
 def ai_vocab_density(text: str) -> float:
     """Return AI-vocabulary word occurrences per 1000 words."""
     lowered = text.lower()
-    hits = sum(len(re.findall(rf"\b{re.escape(w)}\b", lowered)) for w in _AI_VOCAB)
+    hits = sum(len(re.findall(rf"\b{re.escape(w)}\b", lowered)) for w in AI_VOCAB)
     return rate_per_kwords(hits, text)
 
 
@@ -119,7 +119,7 @@ def marketing_verb_ratio(text: str) -> float:
         ``marketing / (marketing + copula)`` in ``[0, 1]``; ``0.0`` when the
         denominator is zero.
     """
-    marketing = _count_phrases(text, _MARKETING_VERBS)
+    marketing = _count_phrases(text, MARKETING_VERBS)
     copula = _count_phrases(text, _COPULAS)
     denom = marketing + copula
     return marketing / denom if denom else 0.0
@@ -158,7 +158,7 @@ def transition_opener_rate(text: str) -> float:
     hits = 0
     for sentence in sentences:
         first = _WORD_RE.findall(sentence)
-        if first and first[0].lower() in _TRANSITION_OPENERS:
+        if first and first[0].lower() in TRANSITION_OPENERS:
             hits += 1
     return rate_per_kwords(hits, text)
 

--- a/creek-tools/creek/generate/ai_style/features.py
+++ b/creek-tools/creek/generate/ai_style/features.py
@@ -49,10 +49,10 @@ TRANSITION_OPENERS = (
     "consequently",
 )
 
-# A small, era-spanning sample of the AI-vocabulary list. The full,
-# tunable catalog lands with the lexical detector (FEAT-040.5); the
-# fingerprint only needs a consistent measure of how often the user
-# reaches for these words.
+# A small, era-spanning sample of the AI-vocabulary list, shared with the
+# lexical detector. It is intentionally a representative sample (not an
+# exhaustive catalog); the fingerprint only needs a consistent measure of
+# how often the user reaches for these words.
 AI_VOCAB = (
     "delve",
     "tapestry",
@@ -65,6 +65,8 @@ AI_VOCAB = (
     "leverage",
     "robust",
 )
+
+CONCRETE_RE = re.compile(r"\bconcrete\b", re.IGNORECASE)
 
 # Baseline heuristic: matches single-word triads ("red, white, and blue")
 # but not multi-word items ("a vivid red, a soft white, and a deep blue").
@@ -168,6 +170,22 @@ def rule_of_three_rate(text: str) -> float:
     return rate_per_kwords(len(_TRIAD_RE.findall(text)), text)
 
 
+def concrete_density(text: str) -> float:
+    """Return occurrences of the word "concrete" per 1000 words.
+
+    Fingerprinted so the "concrete" tell (a comment-context AI tell) is
+    vault-relative: a writer who routinely says "concrete evidence" or
+    "concrete slab" has a high baseline and is not flagged for it.
+
+    Args:
+        text: The body to scan.
+
+    Returns:
+        Occurrences of "concrete" per 1000 words.
+    """
+    return rate_per_kwords(len(CONCRETE_RE.findall(text)), text)
+
+
 FINGERPRINT_FEATURES: dict[str, Extractor] = {
     "em_dash_density": em_dash_density,
     "curly_quote_density": curly_quote_density,
@@ -176,6 +194,7 @@ FINGERPRINT_FEATURES: dict[str, Extractor] = {
     "sentence_length_mean": sentence_length_mean,
     "transition_opener_rate": transition_opener_rate,
     "rule_of_three_rate": rule_of_three_rate,
+    "concrete_rate": concrete_density,
 }
 """The feature_key -> extractor map the fingerprint measures over the
 user's corpus. Detector tells (FEAT-040.3 through .7) query these same

--- a/creek-tools/creek/generate/ai_style/features.py
+++ b/creek-tools/creek/generate/ai_style/features.py
@@ -28,9 +28,10 @@ _SENTENCE_SPLIT_RE = re.compile(r"[.!?]+(?:\s+|$)")
 _WORD_RE = re.compile(r"\b\w+\b")
 
 # NOTE: substring matching means "features" also hits the noun ("three
-# killer features"), which can inflate the ratio in personal writing.
-# FEAT-040.5 (the lexical detector) narrows these to verb context; the
-# fingerprint only needs a consistent, if slightly noisy, baseline.
+# killer features"), which can inflate the ratio in personal writing. Both
+# the fingerprint and the lexical detector share this list and tolerate the
+# noise: it is vault-relative, so a noun-heavy writer's own baseline rises
+# with them. Verb-context narrowing is possible future work, not yet done.
 MARKETING_VERBS = (
     "serves as",
     "stands as",

--- a/creek-tools/creek/generate/ai_style/features.py
+++ b/creek-tools/creek/generate/ai_style/features.py
@@ -40,6 +40,13 @@ MARKETING_VERBS = (
     "offers",
     "maintains",
 )
+# Word-bounded marketing-verb matcher, shared by the measurer below and the
+# lexical locator, so both count/locate the same occurrences (e.g. neither
+# matches "features" inside "misfeatures").
+MARKETING_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(v) for v in MARKETING_VERBS) + r")\b",
+    re.IGNORECASE,
+)
 _COPULAS = (" is ", " are ", " was ", " were ", " has ", " have ")
 
 TRANSITION_OPENERS = (
@@ -122,7 +129,7 @@ def marketing_verb_ratio(text: str) -> float:
         ``marketing / (marketing + copula)`` in ``[0, 1]``; ``0.0`` when the
         denominator is zero.
     """
-    marketing = _count_phrases(text, MARKETING_VERBS)
+    marketing = len(MARKETING_RE.findall(text))
     copula = _count_phrases(text, _COPULAS)
     denom = marketing + copula
     return marketing / denom if denom else 0.0
@@ -195,7 +202,7 @@ FINGERPRINT_FEATURES: dict[str, Extractor] = {
     "sentence_length_mean": sentence_length_mean,
     "transition_opener_rate": transition_opener_rate,
     "rule_of_three_rate": rule_of_three_rate,
-    "concrete_rate": concrete_density,
+    "concrete_density": concrete_density,
 }
 """The feature_key -> extractor map the fingerprint measures over the
 user's corpus. Detector tells (FEAT-040.3 through .7) query these same

--- a/creek-tools/creek/generate/ai_style/lexical.py
+++ b/creek-tools/creek/generate/ai_style/lexical.py
@@ -1,0 +1,137 @@
+"""Lexical detectors (FEAT-040.5): vault-relative AI-vocabulary and friends.
+
+These tells *measure* lexical features using the same extractors the
+fingerprint uses (:mod:`creek.generate.ai_style.features`), so the scanner
+compares a draft's rate to the user's stored rate for the same key. A word
+or construction is only flagged when the draft over-uses it *relative to
+the user* — a user who genuinely writes "tapestry" or "serves as" is never
+flagged for it. Detection only; no rewriting.
+
+Importing this module registers its tells in the global registry.
+"""
+
+from __future__ import annotations
+
+import re
+
+from creek.generate.ai_style import features
+from creek.generate.ai_style.model import Span
+from creek.generate.ai_style.tells import Tell, rate_per_kwords, register
+
+
+def _word_alt(words: tuple[str, ...]) -> re.Pattern[str]:
+    """Compile a case-insensitive, word-bounded alternation of *words*."""
+    alt = "|".join(re.escape(w) for w in words)
+    return re.compile(rf"\b(?:{alt})\b", re.IGNORECASE)
+
+
+_AI_VOCAB_RE = _word_alt(features.AI_VOCAB)
+_MARKETING_RE = _word_alt(features.MARKETING_VERBS)
+# Sentence-initial transition word (start of text or after a terminator).
+_TRANSITION_RE = re.compile(
+    r"(?:^|[.!?]\s+)(" + "|".join(features.TRANSITION_OPENERS) + r")\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+# "concrete" as the WP:CONCRETE comment tell ("concrete evidence/examples").
+_CONCRETE_RE = re.compile(r"\bconcrete\b", re.IGNORECASE)
+
+
+def _spans(pattern: re.Pattern[str], text: str, *, group: int = 0) -> list[Span]:
+    """Return the spans of *pattern*'s *group* across *text*."""
+    return [Span(m.start(group), m.end(group)) for m in pattern.finditer(text)]
+
+
+def _locate_ai_vocab(text: str) -> list[Span]:
+    """Locate AI-vocabulary word occurrences."""
+    return _spans(_AI_VOCAB_RE, text)
+
+
+def _locate_marketing(text: str) -> list[Span]:
+    """Locate marketing-verb phrase occurrences."""
+    return _spans(_MARKETING_RE, text)
+
+
+def _locate_transitions(text: str) -> list[Span]:
+    """Locate sentence-initial transition openers (the word itself)."""
+    return _spans(_TRANSITION_RE, text, group=1)
+
+
+def _locate_concrete(text: str) -> list[Span]:
+    """Locate occurrences of the word "concrete"."""
+    return _spans(_CONCRETE_RE, text)
+
+
+def _measure_concrete(text: str) -> float:
+    """Return occurrences of "concrete" per 1000 words."""
+    return rate_per_kwords(len(_CONCRETE_RE.findall(text)), text)
+
+
+AI_VOCABULARY = register(
+    Tell(
+        id="ai_vocabulary",
+        category="lexical",
+        feature_key="ai_vocab_density",
+        handling="prevent",
+        polarity="avoid",
+        description="AI-vocabulary words used more than you do (delve, tapestry, ...).",
+        caveat="Only flagged above your own measured rate; a word you genuinely "
+        "use is your voice, not a tell.",
+        measure=features.ai_vocab_density,
+        locate=_locate_ai_vocab,
+        # Density, not single hits: require >~2 over-baseline AI words per
+        # 1000 words so one coincidental "robust" never flags (the guide:
+        # "one or two of these words may be coincidental").
+        margin=2.0,
+    ),
+)
+
+COPULATIVE_AVOIDANCE = register(
+    Tell(
+        id="copulative_avoidance",
+        category="lexical",
+        feature_key="marketing_verb_ratio",
+        handling="prevent",
+        polarity="avoid",
+        description="Marketing verbs (serves as, boasts, features) over plain is/has.",
+        caveat="A ratio relative to your own copula use; some writers genuinely "
+        "favour 'serves as'.",
+        measure=features.marketing_verb_ratio,
+        locate=_locate_marketing,
+        # Ratio feature in [0, 1]; a smaller margin than the per-1000-words default.
+        margin=0.15,
+    ),
+)
+
+TRANSITION_OPENER = register(
+    Tell(
+        id="transition_opener",
+        category="lexical",
+        feature_key="transition_opener_rate",
+        handling="prevent",
+        polarity="avoid",
+        description="Sentences opening with Additionally/Moreover/Furthermore/...",
+        caveat="A few transitions are normal; only an elevated rate above yours "
+        "is flagged.",
+        measure=features.transition_opener_rate,
+        locate=_locate_transitions,
+        # A single sentence-initial transition is normal prose; require an
+        # elevated rate above the user's before flagging.
+        margin=1.5,
+    ),
+)
+
+CONCRETE_COMMENT = register(
+    Tell(
+        id="concrete_comment",
+        category="lexical",
+        feature_key="concrete_rate",
+        handling="surface",
+        polarity="avoid",
+        description='Overuse of "concrete" (concrete evidence/examples) in comments.',
+        caveat="Comment context only; the material/literal senses of 'concrete' "
+        "are not the target.",
+        measure=_measure_concrete,
+        locate=_locate_concrete,
+        contexts=frozenset({"comment"}),
+    ),
+)

--- a/creek-tools/creek/generate/ai_style/lexical.py
+++ b/creek-tools/creek/generate/ai_style/lexical.py
@@ -26,13 +26,16 @@ def _word_alt(words: tuple[str, ...]) -> re.Pattern[str]:
 
 
 _AI_VOCAB_RE = _word_alt(features.AI_VOCAB)
-_MARKETING_RE = _word_alt(features.MARKETING_VERBS)
+# Shared with the measurer (features.MARKETING_RE) so locator and measurer
+# agree on exactly which marketing-verb occurrences exist.
+_MARKETING_RE = features.MARKETING_RE
 # Sentence-initial transition word (start of text or after a terminator).
-# Uses ``[.!?]+`` to match transition_opener_rate's sentence splitter, so the
-# locator finds exactly what the measurer counts (e.g. after "Done!!").
+# Uses ``[.!?]+`` to match transition_opener_rate's sentence splitter, and
+# NOT re.MULTILINE: the measurer never treats a bare newline as a sentence
+# boundary, so the locator must not either (else it over-locates in lists).
 _TRANSITION_RE = re.compile(
     r"(?:^|[.!?]+\s+)(" + "|".join(features.TRANSITION_OPENERS) + r")\b",
-    re.IGNORECASE | re.MULTILINE,
+    re.IGNORECASE,
 )
 
 
@@ -119,7 +122,7 @@ CONCRETE_COMMENT = register(
     Tell(
         id="concrete_comment",
         category="lexical",
-        feature_key="concrete_rate",
+        feature_key="concrete_density",
         handling="surface",
         polarity="avoid",
         description='Overuse of "concrete" (concrete evidence/examples) in comments.',

--- a/creek-tools/creek/generate/ai_style/lexical.py
+++ b/creek-tools/creek/generate/ai_style/lexical.py
@@ -128,5 +128,9 @@ CONCRETE_COMMENT = register(
         measure=features.concrete_density,
         locate=_locate_concrete,
         contexts=frozenset({"comment"}),
+        # Default per-1000-words margin: one stray "concrete" over the user's
+        # baseline is tolerated; a cluster ("concrete evidence ... concrete
+        # examples") in a comment is the tell.
+        margin=2.0,
     ),
 )

--- a/creek-tools/creek/generate/ai_style/lexical.py
+++ b/creek-tools/creek/generate/ai_style/lexical.py
@@ -16,7 +16,7 @@ import re
 
 from creek.generate.ai_style import features
 from creek.generate.ai_style.model import Span
-from creek.generate.ai_style.tells import Tell, rate_per_kwords, register
+from creek.generate.ai_style.tells import Tell, register
 
 
 def _word_alt(words: tuple[str, ...]) -> re.Pattern[str]:
@@ -28,12 +28,12 @@ def _word_alt(words: tuple[str, ...]) -> re.Pattern[str]:
 _AI_VOCAB_RE = _word_alt(features.AI_VOCAB)
 _MARKETING_RE = _word_alt(features.MARKETING_VERBS)
 # Sentence-initial transition word (start of text or after a terminator).
+# Uses ``[.!?]+`` to match transition_opener_rate's sentence splitter, so the
+# locator finds exactly what the measurer counts (e.g. after "Done!!").
 _TRANSITION_RE = re.compile(
-    r"(?:^|[.!?]\s+)(" + "|".join(features.TRANSITION_OPENERS) + r")\b",
+    r"(?:^|[.!?]+\s+)(" + "|".join(features.TRANSITION_OPENERS) + r")\b",
     re.IGNORECASE | re.MULTILINE,
 )
-# "concrete" as the WP:CONCRETE comment tell ("concrete evidence/examples").
-_CONCRETE_RE = re.compile(r"\bconcrete\b", re.IGNORECASE)
 
 
 def _spans(pattern: re.Pattern[str], text: str, *, group: int = 0) -> list[Span]:
@@ -58,12 +58,7 @@ def _locate_transitions(text: str) -> list[Span]:
 
 def _locate_concrete(text: str) -> list[Span]:
     """Locate occurrences of the word "concrete"."""
-    return _spans(_CONCRETE_RE, text)
-
-
-def _measure_concrete(text: str) -> float:
-    """Return occurrences of "concrete" per 1000 words."""
-    return rate_per_kwords(len(_CONCRETE_RE.findall(text)), text)
+    return _spans(features.CONCRETE_RE, text)
 
 
 AI_VOCABULARY = register(
@@ -130,7 +125,7 @@ CONCRETE_COMMENT = register(
         description='Overuse of "concrete" (concrete evidence/examples) in comments.',
         caveat="Comment context only; the material/literal senses of 'concrete' "
         "are not the target.",
-        measure=_measure_concrete,
+        measure=features.concrete_density,
         locate=_locate_concrete,
         contexts=frozenset({"comment"}),
     ),

--- a/creek-tools/tests/generate/ai_style/test_features.py
+++ b/creek-tools/tests/generate/ai_style/test_features.py
@@ -7,6 +7,7 @@ import pytest
 from creek.generate.ai_style.features import (
     FINGERPRINT_FEATURES,
     ai_vocab_density,
+    concrete_density,
     curly_quote_density,
     em_dash_density,
     marketing_verb_ratio,
@@ -73,8 +74,15 @@ def test_rule_of_three_rate_detects_triads() -> None:
     assert rule_of_three_rate("salt and pepper") == 0.0
 
 
+def test_concrete_density_counts_the_word() -> None:
+    """ "concrete" is counted; absent text scores zero."""
+    assert concrete_density("no concrete evidence and concrete examples") > 0.0
+    assert concrete_density("a plain sentence") == 0.0
+
+
 def test_registry_exposes_all_extractors() -> None:
     """Every extractor is registered under a stable key."""
     assert "em_dash_density" in FINGERPRINT_FEATURES
     assert FINGERPRINT_FEATURES["ai_vocab_density"] is ai_vocab_density
-    assert len(FINGERPRINT_FEATURES) == 7
+    assert FINGERPRINT_FEATURES["concrete_rate"] is concrete_density
+    assert len(FINGERPRINT_FEATURES) == 8

--- a/creek-tools/tests/generate/ai_style/test_features.py
+++ b/creek-tools/tests/generate/ai_style/test_features.py
@@ -84,5 +84,5 @@ def test_registry_exposes_all_extractors() -> None:
     """Every extractor is registered under a stable key."""
     assert "em_dash_density" in FINGERPRINT_FEATURES
     assert FINGERPRINT_FEATURES["ai_vocab_density"] is ai_vocab_density
-    assert FINGERPRINT_FEATURES["concrete_rate"] is concrete_density
+    assert FINGERPRINT_FEATURES["concrete_density"] is concrete_density
     assert len(FINGERPRINT_FEATURES) == 8

--- a/creek-tools/tests/generate/ai_style/test_lexical.py
+++ b/creek-tools/tests/generate/ai_style/test_lexical.py
@@ -1,0 +1,144 @@
+"""Tests for the vault-relative lexical detectors (FEAT-040.5)."""
+
+from __future__ import annotations
+
+from creek.config import AIStyleConfig
+from creek.generate.ai_style import scan
+from creek.generate.ai_style.lexical import (
+    _locate_ai_vocab,
+    _locate_marketing,
+    _locate_transitions,
+)
+from creek.generate.ai_style.model import FeatureStat, VoiceFingerprint
+from creek.generate.ai_style.tells import get_tells
+
+_CONFIG = AIStyleConfig()
+
+# A user who uses none of these constructions.
+_PLAIN = VoiceFingerprint(
+    features={
+        "ai_vocab_density": FeatureStat(rate=0.0, support=50),
+        "marketing_verb_ratio": FeatureStat(rate=0.0, support=50),
+        "transition_opener_rate": FeatureStat(rate=0.0, support=50),
+    },
+    fragment_count=50,
+)
+# A user who genuinely writes this way (very high baselines).
+_ORNATE = VoiceFingerprint(
+    features={
+        "ai_vocab_density": FeatureStat(rate=900.0, support=50),
+        "marketing_verb_ratio": FeatureStat(rate=0.99, support=50),
+        "transition_opener_rate": FeatureStat(rate=900.0, support=50),
+    },
+    fragment_count=50,
+)
+
+
+def _fired(report, tell_id: str) -> bool:
+    return any(f.tell_id == tell_id for f in report.findings)
+
+
+def test_lexical_tells_registered() -> None:
+    """All four lexical tells are in the registry under the lexical family."""
+    ids = {t.id for t in get_tells(["lexical"])}
+    assert {
+        "ai_vocabulary",
+        "copulative_avoidance",
+        "transition_opener",
+        "concrete_comment",
+    } <= ids
+
+
+class TestVaultRelative:
+    """Each tell fires above the user's baseline and is suppressed at/below."""
+
+    def test_ai_vocab_over_baseline_fires(self) -> None:
+        """AI-vocab-dense text flags for a user who avoids those words."""
+        text = "a vibrant tapestry that delve into the intricate, pivotal core"
+        assert _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "ai_vocabulary")
+
+    def test_ai_vocab_suppressed_for_ornate_user(self) -> None:
+        """The same text does not flag for a user who writes that way."""
+        text = "a vibrant tapestry that delve into the intricate, pivotal core"
+        assert not _fired(
+            scan(text, fingerprint=_ORNATE, config=_CONFIG),
+            "ai_vocabulary",
+        )
+
+    def test_marketing_verbs_over_baseline_fires(self) -> None:
+        """Marketing-verb prose flags for a plain user."""
+        text = "The hall serves as a hub. It boasts a pool and offers views."
+        assert _fired(
+            scan(text, fingerprint=_PLAIN, config=_CONFIG),
+            "copulative_avoidance",
+        )
+
+    def test_marketing_verbs_suppressed_for_ornate_user(self) -> None:
+        """The same prose is voice, not a tell, for an ornate user."""
+        text = "The hall serves as a hub. It boasts a pool and offers views."
+        assert not _fired(
+            scan(text, fingerprint=_ORNATE, config=_CONFIG),
+            "copulative_avoidance",
+        )
+
+    def test_transition_openers_fire_then_suppress(self) -> None:
+        """Sentence-initial transitions flag for plain, not for ornate."""
+        text = "Additionally, this. Moreover, that. Furthermore, more."
+        assert _fired(
+            scan(text, fingerprint=_PLAIN, config=_CONFIG),
+            "transition_opener",
+        )
+        assert not _fired(
+            scan(text, fingerprint=_ORNATE, config=_CONFIG),
+            "transition_opener",
+        )
+
+
+class TestConcreteContext:
+    """The 'concrete' tell is comment-context only."""
+
+    def test_not_in_article(self) -> None:
+        """'concrete' in article prose does not fire."""
+        report = scan(
+            "There is no concrete evidence of that yet.",
+            fingerprint=_PLAIN,
+            config=_CONFIG,
+            context="article",
+        )
+        assert not _fired(report, "concrete_comment")
+
+    def test_fires_in_comment(self) -> None:
+        """'concrete' fires in comment context."""
+        report = scan(
+            "Without concrete evidence and concrete examples, this fails.",
+            fingerprint=_PLAIN,
+            config=_CONFIG,
+            context="comment",
+        )
+        assert _fired(report, "concrete_comment")
+
+
+class TestLocators:
+    """Span locators point at the offending text."""
+
+    def test_locate_ai_vocab(self) -> None:
+        """AI-vocab words are located."""
+        spans = _locate_ai_vocab("a tapestry and a delve")
+        assert len(spans) == 2
+
+    def test_locate_marketing(self) -> None:
+        """Marketing verbs are located."""
+        assert _locate_marketing("it boasts and serves as") != []
+
+    def test_locate_transitions_sentence_initial_only(self) -> None:
+        """Only sentence-initial transitions are located."""
+        spans = _locate_transitions("Additionally, yes. I add moreover mid-sentence.")
+        assert len(spans) == 1
+        text = "Additionally, yes. I add moreover mid-sentence."
+        assert text[spans[0].start : spans[0].end].lower() == "additionally"
+
+
+def test_one_ai_vocab_word_below_margin_no_false_positive() -> None:
+    """A single AI-vocab word in a long human text stays under the margin."""
+    text = "robust " + " ".join(["plain"] * 999)
+    assert not _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "ai_vocabulary")

--- a/creek-tools/tests/generate/ai_style/test_lexical.py
+++ b/creek-tools/tests/generate/ai_style/test_lexical.py
@@ -6,6 +6,7 @@ from creek.config import AIStyleConfig
 from creek.generate.ai_style import scan
 from creek.generate.ai_style.lexical import (
     _locate_ai_vocab,
+    _locate_concrete,
     _locate_marketing,
     _locate_transitions,
 )
@@ -139,8 +140,18 @@ class TestLocators:
         assert len(spans) == 2
 
     def test_locate_marketing(self) -> None:
-        """Marketing verbs are located."""
-        assert _locate_marketing("it boasts and serves as") != []
+        """Each marketing verb phrase is located at its exact span."""
+        text = "it boasts and serves as"
+        spans = _locate_marketing(text)
+        located = sorted(text[s.start : s.end].lower() for s in spans)
+        assert located == ["boasts", "serves as"]
+
+    def test_locate_concrete(self) -> None:
+        """Each "concrete" occurrence is located."""
+        text = "concrete evidence and concrete examples"
+        spans = _locate_concrete(text)
+        assert len(spans) == 2
+        assert text[spans[0].start : spans[0].end] == "concrete"
 
     def test_locate_transitions_sentence_initial_only(self) -> None:
         """Only sentence-initial transitions are located."""

--- a/creek-tools/tests/generate/ai_style/test_lexical.py
+++ b/creek-tools/tests/generate/ai_style/test_lexical.py
@@ -20,6 +20,7 @@ _PLAIN = VoiceFingerprint(
         "ai_vocab_density": FeatureStat(rate=0.0, support=50),
         "marketing_verb_ratio": FeatureStat(rate=0.0, support=50),
         "transition_opener_rate": FeatureStat(rate=0.0, support=50),
+        "concrete_rate": FeatureStat(rate=0.0, support=50),
     },
     fragment_count=50,
 )
@@ -29,6 +30,7 @@ _ORNATE = VoiceFingerprint(
         "ai_vocab_density": FeatureStat(rate=900.0, support=50),
         "marketing_verb_ratio": FeatureStat(rate=0.99, support=50),
         "transition_opener_rate": FeatureStat(rate=900.0, support=50),
+        "concrete_rate": FeatureStat(rate=900.0, support=50),
     },
     fragment_count=50,
 )
@@ -108,7 +110,7 @@ class TestConcreteContext:
         assert not _fired(report, "concrete_comment")
 
     def test_fires_in_comment(self) -> None:
-        """'concrete' fires in comment context."""
+        """'concrete' fires in comment context for a user who avoids it."""
         report = scan(
             "Without concrete evidence and concrete examples, this fails.",
             fingerprint=_PLAIN,
@@ -116,6 +118,16 @@ class TestConcreteContext:
             context="comment",
         )
         assert _fired(report, "concrete_comment")
+
+    def test_suppressed_for_concrete_using_user(self) -> None:
+        """The same comment is suppressed when the user's baseline is high."""
+        report = scan(
+            "Without concrete evidence and concrete examples, this fails.",
+            fingerprint=_ORNATE,
+            config=_CONFIG,
+            context="comment",
+        )
+        assert not _fired(report, "concrete_comment")
 
 
 class TestLocators:

--- a/creek-tools/tests/generate/ai_style/test_lexical.py
+++ b/creek-tools/tests/generate/ai_style/test_lexical.py
@@ -21,7 +21,7 @@ _PLAIN = VoiceFingerprint(
         "ai_vocab_density": FeatureStat(rate=0.0, support=50),
         "marketing_verb_ratio": FeatureStat(rate=0.0, support=50),
         "transition_opener_rate": FeatureStat(rate=0.0, support=50),
-        "concrete_rate": FeatureStat(rate=0.0, support=50),
+        "concrete_density": FeatureStat(rate=0.0, support=50),
     },
     fragment_count=50,
 )
@@ -31,7 +31,7 @@ _ORNATE = VoiceFingerprint(
         "ai_vocab_density": FeatureStat(rate=900.0, support=50),
         "marketing_verb_ratio": FeatureStat(rate=0.99, support=50),
         "transition_opener_rate": FeatureStat(rate=900.0, support=50),
-        "concrete_rate": FeatureStat(rate=900.0, support=50),
+        "concrete_density": FeatureStat(rate=900.0, support=50),
     },
     fragment_count=50,
 )
@@ -160,8 +160,24 @@ class TestLocators:
         text = "Additionally, yes. I add moreover mid-sentence."
         assert text[spans[0].start : spans[0].end].lower() == "additionally"
 
+    def test_locate_transitions_not_at_bare_line_start(self) -> None:
+        """A list item without a terminator is NOT a located transition.
+
+        The measurer never counts a bare newline as a sentence boundary, so
+        (with re.MULTILINE dropped) the locator must not either.
+        """
+        spans = _locate_transitions("- item one\n- Moreover, item two")
+        assert spans == []
+
 
 def test_one_ai_vocab_word_below_margin_no_false_positive() -> None:
     """A single AI-vocab word in a long human text stays under the margin."""
     text = "robust " + " ".join(["plain"] * 999)
     assert not _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "ai_vocabulary")
+
+
+def test_one_concrete_word_below_margin_no_false_positive() -> None:
+    """A single "concrete" in a long comment stays under the margin."""
+    text = "concrete " + " ".join(["plain"] * 999)
+    report = scan(text, fingerprint=_PLAIN, config=_CONFIG, context="comment")
+    assert not _fired(report, "concrete_comment")


### PR DESCRIPTION
## Summary
Four `lexical` tells, each **vault-relative** — they fire only when the draft's measured rate exceeds the user's own fingerprint rate (+ margin), so a writer who genuinely uses these words/constructions is never flagged:
- **ai_vocabulary** (`ai_vocab_density`) — margin tuned (2.0/1k words) so a single coincidental word never flags; it's density, per the guide.
- **copulative_avoidance** (`marketing_verb_ratio`) — `serves as`/`boasts`/`features`/… relative to plain copulas.
- **transition_opener** (`transition_opener_rate`) — sentence-initial `Additionally`/`Moreover`/… above the user's opener rate.
- **concrete_comment** — overuse of "concrete", **comment context only**.

Reuses the FEAT-040.2 feature extractors (word lists now exposed from `features.py` — DRY), so the existing scanner does the divergence comparison generically. Detection only.

## Test plan
- `./scripts/check-all.sh` → 12/12; new module at 100% coverage.
- **Two-branch tests** for each tell: the same text flags for a plain-user fingerprint and is suppressed for an ornate-user fingerprint (the headline vault-relative property).
- `concrete` fires only in `comment` context; span locators verified; a single AI-vocab word in 1000 words does **not** false-positive.

Closes #422
Refs #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
