### PR TITLE
feat(ai-style): voice-fidelity guard + revision loop in `creek draft` (FEAT-040.9)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2353,6 +2353,15 @@ def draft(
             "flagged truncated in frontmatter and warned about on stderr."
         ),
     ),
+    no_llm: bool = typer.Option(
+        False,
+        "--no-llm",
+        help=(
+            "FEAT-040.9: run the voice-fidelity guard in measure-only mode — "
+            "sanitize and score the draft against your voice fingerprint, but "
+            "skip the LLM rewrite pass (no extra network hop)."
+        ),
+    ),
 ) -> None:
     """Draft an essay from a mined idea with the activated skill stack.
 
@@ -2399,10 +2408,8 @@ def draft(
     current_phase = _parse_phase(phase)
     voice_text = _read_voice_core(voice_core)
     ai_style = _load_config_for_vault(vault).ai_style
-    style_preamble = build_style_preamble(
-        load_fingerprint(vault_path, ai_style),
-        ai_style,
-    )
+    fingerprint = load_fingerprint(vault_path, ai_style)
+    style_preamble = build_style_preamble(fingerprint, ai_style)
     override = _parse_include_tier(include_tier)
     seed_spec = _build_seed_spec(
         seed_fragment=seed_fragment,
@@ -2429,6 +2436,9 @@ def draft(
         privacy_override=override,
         bypass_compiled=bypass_compiled,
         ontology_twist=ontology_twist,
+        fingerprint=fingerprint,
+        ai_style_config=ai_style,
+        voice_guard_no_llm=no_llm,
     )
 
     if outline_text is not None:

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -922,6 +922,15 @@ class AIStyleConfig(BaseModel):
     avoid-list never induces the stilted "evasion" voice we are escaping.
     ``0`` disables the cap."""
 
+    max_revision_passes: int = Field(default=1, ge=0)
+    """Maximum FEAT-040.9 voice-fidelity rewrite passes after composition.
+    Each pass measures voice distance, rewrites toward the user's measured
+    voice, then re-measures; the loop stops early once distance falls under
+    :attr:`voice_distance_upper` or a pass fails to improve. ``0`` disables
+    the rewrite loop (sanitize + measure only). Kept small (default ``1``)
+    because rewriting is bounded and regression-guarded, not iterative
+    polishing."""
+
     def weight_for(self, *, category: str, feature_key: str) -> float:
         """Resolve the divergence weight for a feature.
 

--- a/creek-tools/creek/generate/ai_style/__init__.py
+++ b/creek-tools/creek/generate/ai_style/__init__.py
@@ -32,6 +32,11 @@ from creek.generate.ai_style.fingerprint import (
     load_fingerprint,
     save_fingerprint,
 )
+from creek.generate.ai_style.guard import (
+    VoiceFidelityReport,
+    build_voice_fidelity_frontmatter,
+    run_voice_fidelity_guard,
+)
 from creek.generate.ai_style.lexical import (
     AI_VOCABULARY,
     CONCRETE_COMMENT,
@@ -97,16 +102,19 @@ __all__ = [
     "ScanReport",
     "Span",
     "Tell",
+    "VoiceFidelityReport",
     "VoiceFingerprint",
     "bad_direction_magnitude",
     "build_fingerprint",
     "build_style_preamble",
+    "build_voice_fidelity_frontmatter",
     "extract_user_turns",
     "get_tells",
     "load_fingerprint",
     "normalize_typography",
     "rate_per_kwords",
     "register",
+    "run_voice_fidelity_guard",
     "sanitize",
     "sanitize_structure",
     "save_fingerprint",

--- a/creek-tools/creek/generate/ai_style/guard.py
+++ b/creek-tools/creek/generate/ai_style/guard.py
@@ -1,0 +1,316 @@
+"""Voice-fidelity guard + bounded revision loop for ``creek draft`` (FEAT-040.9).
+
+The integration capstone. After a draft is composed, this guard:
+
+1. **Sanitizes** (FEAT-040.3/.4) — mechanical and markup tells repaired,
+   typography normalised only against the user's own grain.
+2. **Scans** (FEAT-040.5/.6/.7) against the voice fingerprint, producing a
+   :class:`~creek.generate.ai_style.model.ScanReport` with a scalar
+   ``voice_distance`` and directional (over/under-use) findings.
+3. **Revises** — when the distance exceeds
+   :attr:`~creek.config.AIStyleConfig.voice_distance_upper` and a rewrite LLM
+   is available, runs a bounded loop that rewrites *toward the user's measured
+   voice* (the directional deltas and the fingerprint-derived voice targets),
+   re-sanitizes, and re-scans. The objective is **minimising voice distance**,
+   not zeroing a tell checklist.
+
+It mirrors :mod:`creek.generate.grounding`: deterministic-first, frontmatter
+stamped, surfaced on stderr. Three invariants keep it safe:
+
+* **Regression-guarded** — a rewrite is kept only when it *lowers* distance;
+  a pass that raises (or fails to lower) distance is discarded.
+* **Never trade grounding for voice** — an optional grounding check vetoes a
+  rewrite that drops the draft below its grounding floor, so the guard
+  composes with FEAT-032 rather than fighting it.
+* **Bounded** — at most :attr:`~creek.config.AIStyleConfig.max_revision_passes`
+  rewrites, and ``no_llm`` (or a disabled subsystem) reduces the guard to
+  sanitize-and-measure with no network hop.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, TypedDict
+
+from creek.generate.ai_style.sanitize_typography import sanitize
+from creek.generate.ai_style.scanner import scan
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from creek.config import AIStyleConfig
+    from creek.generate.ai_style.model import Finding, ScanReport, VoiceFingerprint
+
+VoiceRewriteLLM = Callable[[str], str]
+"""Signature for the rewrite LLM: ``(prompt) -> revised body``."""
+
+GroundingCheck = Callable[[str], bool]
+"""Signature for the optional grounding veto: ``(body) -> still grounded?``.
+
+Returns ``True`` when the candidate body still clears its grounding floor.
+A rewrite for which this returns ``False`` is discarded so voice fidelity is
+never bought at the cost of grounding (compose with FEAT-032, don't fight it).
+"""
+
+VOICE_DISTANCE_KEY = "voice_distance"
+"""Frontmatter key for the final scalar voice distance."""
+
+VOICE_FINDINGS_KEY = "voice_findings"
+"""Frontmatter key for the residual per-finding list."""
+
+
+class VoiceFindingEntry(TypedDict):
+    """Frontmatter shape for one residual voice-fidelity finding.
+
+    Mirrors :class:`~creek.generate.ai_style.model.Finding` minus the raw
+    span (redundant with ``line``/``excerpt``). A ``TypedDict`` lets
+    ``mypy --strict`` catch key typos at the call site.
+    """
+
+    tell_id: str
+    category: str
+    feature_key: str
+    line: int
+    excerpt: str
+    draft_rate: float
+    user_rate: float | None
+    direction: str
+    message: str
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    """A body paired with its scan report, threaded through the revision loop."""
+
+    body: str
+    report: ScanReport
+
+
+@dataclass(frozen=True)
+class VoiceFidelityReport:
+    """The guard's verdict for one draft.
+
+    Attributes:
+        body: The final body — sanitized, and rewritten toward voice when a
+            rewrite lowered the distance. This is what ``save_draft`` writes.
+        voice_distance: The final aggregate distance from the user's voice
+            in ``[0, 1)``. ``0.0`` means the draft matches the user's profile.
+        findings: The residual directional divergences after the final pass.
+        thin_fingerprint: ``True`` when the fingerprint was below the
+            configured minimum and the distance was softened accordingly.
+        passes: How many rewrite passes were actually attempted (``0`` when
+            the draft was already within bounds, ``no_llm``, or disabled).
+    """
+
+    body: str
+    voice_distance: float
+    findings: tuple[Finding, ...]
+    thin_fingerprint: bool
+    passes: int
+
+    def summary_line(self) -> str:
+        """Return the stderr one-liner ``creek draft`` prints after composing.
+
+        Stable wording is part of the contract — the walkthrough and the
+        integration tests match on it.
+        """
+        count = len(self.findings)
+        noun = "divergence" if count == 1 else "divergences"
+        return (
+            f"voice-fidelity: distance {self.voice_distance:.2f} "
+            f"({count} residual {noun}) — see frontmatter"
+        )
+
+    def to_frontmatter(self) -> dict[str, object]:
+        """Render the report as the frontmatter payload ``save_draft`` writes."""
+        return build_voice_fidelity_frontmatter(
+            voice_distance=self.voice_distance,
+            findings=self.findings,
+        )
+
+
+def _finding_entry(finding: Finding) -> VoiceFindingEntry:
+    """Convert a :class:`Finding` to its frontmatter-friendly mapping."""
+    user_rate = finding.user_rate
+    return VoiceFindingEntry(
+        tell_id=finding.tell_id,
+        category=finding.category,
+        feature_key=finding.feature_key,
+        line=finding.line,
+        excerpt=finding.excerpt,
+        draft_rate=round(finding.draft_rate, 4),
+        user_rate=None if user_rate is None else round(user_rate, 4),
+        direction=finding.direction,
+        message=finding.message,
+    )
+
+
+def build_voice_fidelity_frontmatter(
+    *,
+    voice_distance: float | None,
+    findings: Sequence[Finding],
+) -> dict[str, object]:
+    """Build the partial frontmatter payload for voice-fidelity fields.
+
+    Single source of truth for how the guard's fields appear on disk.
+    ``None`` distance and an empty findings sequence are skipped so a draft
+    saved without the guard never grows misleading zero-value fields.
+
+    Args:
+        voice_distance: The final scalar distance, or ``None`` when the guard
+            did not run.
+        findings: The residual findings (empty sequence when none).
+
+    Returns:
+        A dict carrying only the populated keys, for the caller to merge.
+    """
+    payload: dict[str, object] = {}
+    if voice_distance is not None:
+        payload[VOICE_DISTANCE_KEY] = round(voice_distance, 4)
+    if findings:
+        payload[VOICE_FINDINGS_KEY] = [_finding_entry(f) for f in findings]
+    return payload
+
+
+def build_voice_rewrite_prompt(
+    body: str,
+    report: ScanReport,
+    *,
+    style_preamble: str = "",
+) -> str:
+    """Assemble the targeted-rewrite prompt for one revision pass.
+
+    The prompt names the directional divergences (over-used AI tells *and*
+    under-used signature moves to restore), echoes the fingerprint-derived
+    voice targets, and forbids inventing facts or dropping grounded content —
+    the rewrite must move toward the user's voice, not toward emptiness.
+
+    Args:
+        body: The current (sanitized) draft body.
+        report: The scan report whose findings drive the instruction.
+        style_preamble: The FEAT-040.8 ``## Voice targets`` preamble; empty
+            string to omit.
+
+    Returns:
+        The full rewrite prompt.
+    """
+    parts: list[str] = []
+    if style_preamble.strip():
+        parts.append(style_preamble.strip())
+    if report.findings:
+        divergences = "\n".join(
+            f"- ({finding.direction}-use) {finding.message}"
+            for finding in report.findings
+        )
+        parts.append(f"## Voice divergences to repair\n{divergences}")
+    parts.extend(
+        (
+            "## Ask\n"
+            "Revise the draft below to move toward the writer's measured voice: "
+            "use their plain copulas and sentence rhythm, cut the puffery and "
+            "transitions they do not use, de-pad triads, and restore any "
+            "characteristic moves flagged as under-used. Do not invent facts and "
+            "do not drop any grounded content — change how it reads, not what it "
+            "claims. Return only the revised draft.",
+            f"## Draft\n{body}",
+        ),
+    )
+    return "\n\n".join(parts)
+
+
+def _revise_toward_voice(
+    best: _Candidate,
+    *,
+    fingerprint: VoiceFingerprint,
+    config: AIStyleConfig,
+    llm: VoiceRewriteLLM,
+    style_preamble: str,
+    grounding_check: GroundingCheck | None,
+    context: str,
+) -> tuple[_Candidate, int]:
+    """Run the bounded rewrite loop, returning the best candidate and pass count.
+
+    A pass is kept only when it strictly lowers distance and (when a check is
+    supplied) preserves grounding; otherwise the loop stops with the current
+    best. The deterministic rewrite means a non-improving pass would repeat,
+    so stopping on the first non-improvement is both correct and cheap.
+    """
+    passes = 0
+    while (
+        best.report.voice_distance > config.voice_distance_upper
+        and passes < config.max_revision_passes
+    ):
+        passes += 1
+        prompt = build_voice_rewrite_prompt(
+            best.body, best.report, style_preamble=style_preamble
+        )
+        candidate_body = sanitize(llm(prompt), fingerprint=fingerprint, config=config)
+        candidate_report = scan(
+            candidate_body, fingerprint=fingerprint, config=config, context=context
+        )
+        if candidate_report.voice_distance >= best.report.voice_distance:
+            break
+        if grounding_check is not None and not grounding_check(candidate_body):
+            break
+        best = _Candidate(candidate_body, candidate_report)
+    return best, passes
+
+
+def run_voice_fidelity_guard(
+    body: str,
+    *,
+    fingerprint: VoiceFingerprint,
+    config: AIStyleConfig,
+    llm: VoiceRewriteLLM | None = None,
+    no_llm: bool = False,
+    style_preamble: str = "",
+    grounding_check: GroundingCheck | None = None,
+    context: str = "article",
+) -> VoiceFidelityReport:
+    """Sanitize, measure, and bounded-rewrite *body* toward the user's voice.
+
+    Args:
+        body: The composed draft body (frontmatter excluded).
+        fingerprint: The user's voice fingerprint.
+        config: The AI-style configuration (ceiling, pass cap, toggles).
+        llm: The rewrite LLM ``(prompt) -> body``; ``None`` skips the rewrite.
+        no_llm: When ``True``, sanitize and measure only — no rewrite hop.
+        style_preamble: The FEAT-040.8 voice-targets preamble for the rewrite.
+        grounding_check: Optional veto rejecting a rewrite that drops grounding.
+        context: Scan context (``"article"`` or ``"comment"``).
+
+    Returns:
+        A :class:`VoiceFidelityReport` carrying the final body, distance,
+        residual findings, and pass count. When the subsystem is disabled the
+        body is returned untouched with a zero distance and no findings.
+    """
+    if not config.enabled:
+        return VoiceFidelityReport(
+            body=body,
+            voice_distance=0.0,
+            findings=(),
+            thin_fingerprint=False,
+            passes=0,
+        )
+    sanitized = sanitize(body, fingerprint=fingerprint, config=config)
+    report = scan(sanitized, fingerprint=fingerprint, config=config, context=context)
+    best = _Candidate(sanitized, report)
+    passes = 0
+    if llm is not None and not no_llm:
+        best, passes = _revise_toward_voice(
+            best,
+            fingerprint=fingerprint,
+            config=config,
+            llm=llm,
+            style_preamble=style_preamble,
+            grounding_check=grounding_check,
+            context=context,
+        )
+    return VoiceFidelityReport(
+        body=best.body,
+        voice_distance=best.report.voice_distance,
+        findings=tuple(best.report.findings),
+        thin_fingerprint=best.report.thin_fingerprint,
+        passes=passes,
+    )

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -39,6 +39,7 @@ from creek.classify.privacy_filter import (
     PrivacyTierOverride,
     filter_fragments_by_tier,
 )
+from creek.generate.ai_style.guard import run_voice_fidelity_guard
 from creek.generate.compile_routing import (
     CompiledPageIndex,
     empty_index,
@@ -90,6 +91,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from creek.classify.prompt import PromptOntology
+    from creek.config import AIStyleConfig
+    from creek.generate.ai_style.guard import GroundingCheck
+    from creek.generate.ai_style.model import VoiceFingerprint
     from creek.generate.mining import IdeaSeed
 
 
@@ -721,6 +725,9 @@ class DraftGenerator:
         ontology_twist: bool = False,
         embedding_fn: EmbeddingFn | None = None,
         grounding_thresholds: GroundingThresholds | None = None,
+        fingerprint: VoiceFingerprint | None = None,
+        ai_style_config: AIStyleConfig | None = None,
+        voice_guard_no_llm: bool = False,
     ) -> None:
         """Initialise with an LLM client and skill tree root.
 
@@ -762,6 +769,17 @@ class DraftGenerator:
                 Required only when *embedding_fn* is supplied; ignored
                 otherwise. Callers typically build this with
                 :meth:`creek.generate.grounding.GroundingThresholds.from_config`.
+            fingerprint: The user's voice fingerprint (FEAT-040.2). When
+                supplied alongside *ai_style_config* the FEAT-040.9
+                voice-fidelity guard runs at save time: sanitize, measure
+                distance, and bounded-rewrite toward the user's voice. When
+                ``None`` the guard is skipped.
+            ai_style_config: The AI-style configuration. Required for the
+                voice-fidelity guard; when ``None`` (or ``enabled`` is
+                ``False``) the guard is skipped.
+            voice_guard_no_llm: When ``True`` the voice-fidelity guard
+                sanitizes and measures only — no rewrite hop (honours the
+                ``creek draft --no-llm`` flag).
         """
         self._llm = llm
         self.skills_root = skills_root
@@ -772,6 +790,9 @@ class DraftGenerator:
         self.ontology_twist = ontology_twist
         self._embedding_fn = embedding_fn
         self._grounding_thresholds = grounding_thresholds
+        self._fingerprint = fingerprint
+        self._ai_style_config = ai_style_config
+        self._voice_guard_no_llm = voice_guard_no_llm
 
     def present_idea(self, idea: IdeaSeed) -> str:
         """Format *idea* as an invitation rather than an imperative.
@@ -1824,6 +1845,84 @@ class DraftGenerator:
             empty_message="LLM returned an empty section body",
         )
 
+    def _voice_rewrite_llm(self) -> Callable[[str], str]:
+        """Adapt the draft LLM to the guard's ``(prompt) -> body`` signature."""
+
+        def _rewrite(prompt: str) -> str:
+            body, _ = self._invoke_draft_llm(
+                prompt,
+                empty_message="LLM returned an empty voice rewrite",
+            )
+            return body
+
+        return _rewrite
+
+    def _voice_grounding_check(
+        self,
+        vault_path: Path,
+        source_fragments: tuple[str, ...],
+    ) -> GroundingCheck | None:
+        """Build the grounding veto, or ``None`` when grounding is not wired.
+
+        The check re-scores a candidate rewrite against the same source
+        fragments the grounding guard uses and rejects any rewrite that drops
+        the draft below its grounding floor — so voice fidelity is never
+        bought at the cost of grounding.
+        """
+        if self._embedding_fn is None or self._grounding_thresholds is None:
+            return None
+        fragments = _load_fragments_by_id(
+            vault_path / _FRAGMENTS_SUBDIR,
+            privacy_override=self.privacy_override,
+        )
+        source_texts = tuple(
+            fragments[fid][1] for fid in source_fragments if fid in fragments
+        )
+        embedding_fn = self._embedding_fn
+        thresholds = self._grounding_thresholds
+
+        def _still_grounded(body: str) -> bool:
+            report = score_draft(
+                body,
+                source_texts=source_texts,
+                embedding_fn=embedding_fn,
+                thresholds=thresholds,
+            )
+            return not report.is_flagged_grounding
+
+        return _still_grounded
+
+    def _apply_voice_fidelity(
+        self,
+        body: str,
+        *,
+        vault_path: Path,
+        source_fragments: tuple[str, ...],
+    ) -> tuple[str, dict[str, object]]:
+        """Run the voice-fidelity guard, returning ``(body, frontmatter)``.
+
+        A no-op (returns *body* unchanged and an empty payload) when the
+        fingerprint or AI-style config is absent or the subsystem is
+        disabled. Otherwise sanitizes, measures, and bounded-rewrites *body*
+        toward the user's voice, prints the guard's summary to stderr, and
+        returns the guarded body plus its frontmatter fields.
+        """
+        config = self._ai_style_config
+        fingerprint = self._fingerprint
+        if config is None or fingerprint is None or not config.enabled:
+            return body, {}
+        report = run_voice_fidelity_guard(
+            body,
+            fingerprint=fingerprint,
+            config=config,
+            llm=self._voice_rewrite_llm(),
+            no_llm=self._voice_guard_no_llm,
+            style_preamble=self.style_preamble,
+            grounding_check=self._voice_grounding_check(vault_path, source_fragments),
+        )
+        print(report.summary_line(), file=sys.stderr)
+        return report.body, report.to_frontmatter()
+
     def save_outline_draft(
         self,
         draft: OutlineDraft,
@@ -1854,8 +1953,13 @@ class DraftGenerator:
         slug = _slugify(draft.title)
         date_prefix = draft.generated_date.strftime("%Y-%m-%d")
         target = _next_available_draft_path(drafts_dir, date_prefix, slug)
+        body, voice_fields = self._apply_voice_fidelity(
+            draft.body,
+            vault_path=vault_path,
+            source_fragments=(),
+        )
         post = frontmatter.Post(
-            content=_draft_file_body(draft.body, truncated=draft.truncated),
+            content=_draft_file_body(body, truncated=draft.truncated),
             type="draft",
             title=draft.title,
             status="draft",
@@ -1866,6 +1970,8 @@ class DraftGenerator:
             truncated=draft.truncated,
             sections=[_serialise_section(section) for section in draft.sections],
         )
+        for key, value in voice_fields.items():
+            post[key] = value
         target.write_text(frontmatter.dumps(post), encoding="utf-8")
         return target
 
@@ -1887,8 +1993,13 @@ class DraftGenerator:
         slug = _slugify(draft.title)
         date_prefix = draft.generated_date.strftime("%Y-%m-%d")
         target = _next_available_draft_path(drafts_dir, date_prefix, slug)
+        body, voice_fields = self._apply_voice_fidelity(
+            draft.body,
+            vault_path=vault_path,
+            source_fragments=draft.source_fragments,
+        )
         post = frontmatter.Post(
-            content=_draft_file_body(draft.body, truncated=draft.truncated),
+            content=_draft_file_body(body, truncated=draft.truncated),
             type="draft",
             title=draft.title,
             status="draft",
@@ -1919,6 +2030,8 @@ class DraftGenerator:
             paragraph_annotations=draft.paragraph_grounding,
         )
         for key, value in guard_fields.items():
+            post[key] = value
+        for key, value in voice_fields.items():
             post[key] = value
         target.write_text(frontmatter.dumps(post), encoding="utf-8")
         return target

--- a/creek-tools/tests/generate/ai_style/test_guard.py
+++ b/creek-tools/tests/generate/ai_style/test_guard.py
@@ -1,0 +1,237 @@
+"""Tests for the voice-fidelity guard + revision loop (FEAT-040.9).
+
+The guard sanitizes a composed draft, measures its distance from the user's
+voice fingerprint, and — when over the configured ceiling — runs a bounded
+rewrite *toward* that voice. These tests pin the contract the acceptance
+criteria name: a tropey body is rewritten lower, ``no_llm`` measures without
+a rewrite, a distance-raising rewrite is discarded, a grounding-dropping
+rewrite is rejected, the pass count is capped, and the report stamps clean
+frontmatter.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.config import AIStyleConfig
+from creek.generate.ai_style.guard import (
+    VoiceFidelityReport,
+    build_voice_fidelity_frontmatter,
+    run_voice_fidelity_guard,
+)
+from creek.generate.ai_style.model import FeatureStat, VoiceFingerprint
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# A body dense with registry tells: transition openers, AI vocabulary,
+# didactic disclaimers, significance puffery.
+_TROPEY = (
+    "Additionally, this delves into the rich tapestry of the subject. "
+    "Moreover, it is important to note the vibrant and multifaceted nuances. "
+    "Furthermore, the landscape stands as a testament to its significance."
+)
+# Plain prose with no tells.
+_PLAIN = "The cat sat by the window. Rain fell on the roof. I made tea and read."
+
+
+def _fingerprint(*, fragments: int = 20) -> VoiceFingerprint:
+    """A non-thin fingerprint whose measured rates are all ~zero.
+
+    With no AI-ish features in the user's own writing, any tell the draft
+    over-uses diverges from the user — exactly the case the guard exists for.
+    """
+    return VoiceFingerprint(
+        features={"em_dash_density": FeatureStat(rate=0.0, support=fragments)},
+        fragment_count=fragments,
+    )
+
+
+def _eager_config(**overrides: object) -> AIStyleConfig:
+    """A config that wants to rewrite almost any divergence."""
+    base: dict[str, object] = {"voice_distance_upper": 0.001, "max_revision_passes": 1}
+    base.update(overrides)
+    return AIStyleConfig(**base)
+
+
+def _counting_llm(*returns: str) -> tuple[Callable[[str], str], dict[str, int]]:
+    """Return an LLM stub yielding *returns* in order, plus a call counter."""
+    seq = iter(returns)
+    calls = {"n": 0}
+
+    def _call(_prompt: str) -> str:
+        calls["n"] += 1
+        return next(seq)
+
+    return _call, calls
+
+
+def test_no_llm_measures_without_rewrite() -> None:
+    """``no_llm`` sanitizes and measures but never calls the rewrite LLM."""
+    llm, calls = _counting_llm(_PLAIN)
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=_eager_config(),
+        llm=llm,
+        no_llm=True,
+    )
+    assert calls["n"] == 0
+    assert report.passes == 0
+    assert report.voice_distance > 0.0
+
+
+def test_rewrite_lowers_distance() -> None:
+    """A tropey body is rewritten once toward voice and re-measured lower."""
+    fingerprint = _fingerprint()
+    config = _eager_config()
+    baseline = run_voice_fidelity_guard(
+        _TROPEY, fingerprint=fingerprint, config=config, no_llm=True
+    )
+    llm, calls = _counting_llm(_PLAIN)
+    report = run_voice_fidelity_guard(
+        _TROPEY, fingerprint=fingerprint, config=config, llm=llm
+    )
+    assert calls["n"] == 1
+    assert report.passes == 1
+    assert report.voice_distance < baseline.voice_distance
+    assert "tapestry" not in report.body
+
+
+def test_distance_raising_rewrite_discarded() -> None:
+    """A rewrite that raises distance is discarded; the original is kept."""
+    fingerprint = _fingerprint()
+    config = _eager_config()
+    baseline = run_voice_fidelity_guard(
+        _TROPEY, fingerprint=fingerprint, config=config, no_llm=True
+    )
+    # Fires many more features than the baseline, so it scans strictly higher.
+    worse = (
+        _TROPEY + " It is not only vibrant but also profound. As of my last "
+        "knowledge update, it serves as a testament. In summary, the red, white, "
+        "and blue significance is important to note. Not only does it delve, but "
+        "it also boasts a tapestry."
+    )
+    llm, _ = _counting_llm(worse)
+    report = run_voice_fidelity_guard(
+        _TROPEY, fingerprint=fingerprint, config=config, llm=llm
+    )
+    # The lower-distance (original sanitized) version wins.
+    assert report.voice_distance == baseline.voice_distance
+    assert "As of my last" not in report.body
+
+
+def test_grounding_dropping_rewrite_rejected() -> None:
+    """A lower-distance rewrite that fails the grounding check is rejected."""
+    fingerprint = _fingerprint()
+    config = _eager_config()
+    baseline = run_voice_fidelity_guard(
+        _TROPEY, fingerprint=fingerprint, config=config, no_llm=True
+    )
+    llm, _ = _counting_llm(_PLAIN)
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=fingerprint,
+        config=config,
+        llm=llm,
+        grounding_check=lambda _body: False,
+    )
+    # Even though _PLAIN scores lower, dropping grounding vetoes it.
+    assert report.voice_distance == baseline.voice_distance
+    assert "tapestry" in report.body
+
+
+def test_grounding_passing_rewrite_accepted() -> None:
+    """A lower-distance rewrite that passes the grounding check is accepted."""
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=_eager_config(),
+        llm=lambda _p: _PLAIN,
+        grounding_check=lambda _body: True,
+    )
+    assert report.passes == 1
+    assert "tapestry" not in report.body
+
+
+def test_revision_passes_capped() -> None:
+    """The loop never exceeds ``max_revision_passes`` even if still divergent."""
+    # Each rewrite improves but never reaches zero distance, and the ceiling
+    # is 0 so the loop always "wants" another pass — the cap must stop it.
+    llm, calls = _counting_llm(
+        "Additionally a. Additionally b.",
+        "Additionally a.",
+        _PLAIN,
+    )
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(voice_distance_upper=0.0, max_revision_passes=2),
+        llm=llm,
+    )
+    assert calls["n"] == 2
+    assert report.passes == 2
+
+
+def test_disabled_config_returns_body_unchanged() -> None:
+    """When the subsystem is disabled the guard is a no-op."""
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(enabled=False),
+        llm=lambda _p: _PLAIN,
+    )
+    assert report.body == _TROPEY
+    assert report.voice_distance == 0.0
+    assert report.findings == ()
+    assert report.passes == 0
+
+
+def test_under_ceiling_skips_rewrite() -> None:
+    """A draft already within the ceiling is not rewritten."""
+    llm, calls = _counting_llm(_PLAIN)
+    report = run_voice_fidelity_guard(
+        _PLAIN,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(voice_distance_upper=0.35, max_revision_passes=2),
+        llm=llm,
+    )
+    assert calls["n"] == 0
+    assert report.passes == 0
+
+
+def test_summary_line_wording() -> None:
+    """The stderr summary matches the documented contract wording."""
+    report = VoiceFidelityReport(
+        body="x",
+        voice_distance=0.22,
+        findings=(),
+        thin_fingerprint=False,
+        passes=1,
+    )
+    assert report.summary_line() == (
+        "voice-fidelity: distance 0.22 (0 residual divergences) — see frontmatter"
+    )
+
+
+def test_frontmatter_stamps_distance_and_findings() -> None:
+    """The report serialises voice_distance and per-finding entries."""
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=_eager_config(),
+        no_llm=True,
+    )
+    payload = report.to_frontmatter()
+    assert "voice_distance" in payload
+    assert isinstance(payload["voice_distance"], float)
+    findings = payload.get("voice_findings")
+    assert isinstance(findings, list)
+    assert findings  # the tropey body produced at least one finding
+    entry = findings[0]
+    assert {"tell_id", "feature_key", "direction", "message"} <= set(entry)
+
+
+def test_build_frontmatter_skips_empty() -> None:
+    """A clean run with no distance/findings stamps nothing misleading."""
+    assert build_voice_fidelity_frontmatter(voice_distance=None, findings=()) == {}

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -10,6 +10,8 @@ import frontmatter
 import pytest
 import yaml
 
+from creek.config import AIStyleConfig
+from creek.generate.ai_style.model import FeatureStat, VoiceFingerprint
 from creek.generate.drafts import (
     DRAFTS_SUBDIR,
     Draft,
@@ -3255,3 +3257,137 @@ class TestStylePreambleInjection:
         # Section bodies survive intact through the stitch pass.
         assert "First section." in prompt
         assert prompt.index("## Voice core") < prompt.index("## Voice targets")
+
+
+_TROPEY_BODY = (
+    "Additionally, this delves into the rich tapestry of the subject. "
+    "Moreover, it is important to note the vibrant and multifaceted nuances. "
+    "Furthermore, the landscape stands as a testament to its significance."
+)
+
+
+def _voice_fingerprint() -> VoiceFingerprint:
+    """A non-thin fingerprint with near-zero AI-ish rates."""
+    return VoiceFingerprint(
+        features={"em_dash_density": FeatureStat(rate=0.0, support=20)},
+        fragment_count=20,
+    )
+
+
+def _eager_ai_style(**overrides: object) -> AIStyleConfig:
+    """AI-style config that wants to rewrite almost any divergence."""
+    base: dict[str, object] = {"voice_distance_upper": 0.001, "max_revision_passes": 1}
+    base.update(overrides)
+    return AIStyleConfig(**base)
+
+
+def _tropey_draft() -> Draft:
+    """A draft whose body is dense with AI tells."""
+    return Draft(
+        title="On the tapestry",
+        body=_TROPEY_BODY,
+        idea_strategy=MiningStrategy.THREAD_TERMINUS.value,
+        source_fragments=(),
+        threads=(),
+        eddies=(),
+        skill_stack=(),
+        prompt="p",
+        generated_date=datetime(2026, 4, 20, tzinfo=UTC),
+    )
+
+
+class TestVoiceFidelityGuardWiring:
+    """The FEAT-040.9 guard runs at save time and stamps frontmatter."""
+
+    def test_save_draft_stamps_voice_fields(
+        self,
+        vault: Path,
+        skills_root: Path,
+        llm_echo: Callable[[str], str],
+    ) -> None:
+        """A guarded save records voice_distance and voice_findings."""
+        gen = DraftGenerator(
+            llm=llm_echo,
+            skills_root=skills_root,
+            fingerprint=_voice_fingerprint(),
+            ai_style_config=_eager_ai_style(),
+            voice_guard_no_llm=True,
+        )
+        path = gen.save_draft(_tropey_draft(), vault)
+        meta = frontmatter.load(str(path)).metadata
+        assert isinstance(meta["voice_distance"], float)
+        assert meta["voice_distance"] > 0.0
+        assert isinstance(meta["voice_findings"], list)
+        assert meta["voice_findings"]
+
+    def test_save_draft_without_config_stamps_nothing(
+        self,
+        vault: Path,
+        skills_root: Path,
+        llm_echo: Callable[[str], str],
+    ) -> None:
+        """No fingerprint/config means the guard is skipped entirely."""
+        gen = DraftGenerator(llm=llm_echo, skills_root=skills_root)
+        path = gen.save_draft(_tropey_draft(), vault)
+        meta = frontmatter.load(str(path)).metadata
+        assert "voice_distance" not in meta
+        assert "voice_findings" not in meta
+
+    def test_save_draft_disabled_subsystem_stamps_nothing(
+        self,
+        vault: Path,
+        skills_root: Path,
+        llm_echo: Callable[[str], str],
+    ) -> None:
+        """An explicitly disabled subsystem stamps no voice fields."""
+        gen = DraftGenerator(
+            llm=llm_echo,
+            skills_root=skills_root,
+            fingerprint=_voice_fingerprint(),
+            ai_style_config=AIStyleConfig(enabled=False),
+        )
+        path = gen.save_draft(_tropey_draft(), vault)
+        assert "voice_distance" not in frontmatter.load(str(path)).metadata
+
+    def test_save_draft_rewrites_body_toward_voice(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A lower-distance rewrite replaces the saved body."""
+        plain = "The cat sat by the window. Rain fell. I made tea and read."
+        gen = DraftGenerator(
+            llm=lambda _p: plain,
+            skills_root=skills_root,
+            fingerprint=_voice_fingerprint(),
+            ai_style_config=_eager_ai_style(),
+        )
+        path = gen.save_draft(_tropey_draft(), vault)
+        content = frontmatter.load(str(path)).content
+        assert "tapestry" not in content
+        assert "cat sat" in content
+
+    def test_save_draft_no_llm_keeps_body_but_measures(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """``--no-llm`` measures and stamps but does not rewrite the body."""
+        called = {"n": 0}
+
+        def _llm(_prompt: str) -> str:
+            called["n"] += 1
+            return "should not be used"
+
+        gen = DraftGenerator(
+            llm=_llm,
+            skills_root=skills_root,
+            fingerprint=_voice_fingerprint(),
+            ai_style_config=_eager_ai_style(),
+            voice_guard_no_llm=True,
+        )
+        path = gen.save_draft(_tropey_draft(), vault)
+        post = frontmatter.load(str(path))
+        assert called["n"] == 0
+        assert "tapestry" in post.content
+        assert isinstance(post.metadata["voice_distance"], float)


### PR DESCRIPTION
## Summary

The FEAT-040 integration capstone. After a draft is composed, the guard **sanitizes → measures distance to the user's voice fingerprint → bounded-rewrites toward that voice → stamps the result into frontmatter**, mirroring `creek/generate/grounding.py`. The objective is *minimising voice distance*, not zeroing a tell checklist.

- **New `creek/generate/ai_style/guard.py`** — `run_voice_fidelity_guard(body, *, fingerprint, config, llm, no_llm, style_preamble, grounding_check) -> VoiceFidelityReport`:
  1. **Sanitize** (FEAT-040.3/.4) — mechanical/markup repaired, typography normalised against the user's own grain.
  2. **Scan** (FEAT-040.5/.6/.7) → `voice_distance` + directional (over/under-use) findings.
  3. **Revise** — when distance exceeds `voice_distance_upper` and a rewrite LLM is available, run up to `max_revision_passes` targeted rewrites given the flagged divergences + the FEAT-040.8 voice targets, re-sanitizing and re-scanning each pass.
- **Bounded, deterministic-first, regression-guarded** — a rewrite is kept only when it *strictly lowers* distance; a distance-raising (or non-improving) pass is discarded.
- **Never trades grounding for voice** — an optional `grounding_check` vetoes a rewrite that drops below the grounding floor, composing with FEAT-032 rather than fighting it.
- `build_voice_fidelity_frontmatter()` mirrors `build_grounding_frontmatter()`; `summary_line()` emits `voice-fidelity: distance 0.22 (3 residual divergences) — see frontmatter`.
- **Wired into** `DraftGenerator.save_draft()` + `save_outline_draft()` via `_apply_voice_fidelity()`: runs the guard on the composed body, writes the guarded body, merges `voice_distance`/`voice_findings` into frontmatter. Honours `--no-llm` (sanitize + measure only) and `AIStyleConfig.enabled`. The CLI loads the fingerprint once and passes it + config + the no-llm flag to the generator.
- **Config:** `AIStyleConfig` gains `max_revision_passes` (default `1`, `>= 0`).

## Test plan

- New `tests/generate/ai_style/test_guard.py` (11 cases): tropey body rewritten lower; `no_llm` measures without calling the LLM; distance-raising rewrite discarded; grounding-dropping rewrite rejected / grounding-passing accepted; pass count capped at `max_revision_passes`; disabled subsystem is a no-op; under-ceiling skips rewrite; summary-line wording; frontmatter stamping.
- `tests/test_drafts.py::TestVoiceFidelityGuardWiring` (5 cases): save stamps `voice_distance`/`voice_findings`; no fingerprint/config or disabled subsystem stamps nothing; a lower-distance rewrite replaces the saved body; `--no-llm` measures + stamps but keeps the body.
- `tests/generate/ai_style/test_model_config.py`: `max_revision_passes` already covered by config defaults checks.
- `./scripts/check-all.sh` green locally: 4780 passed, 93.68% coverage, all 12 gates pass.

Closes #426
Refs #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
