### PR TITLE
feat(ai-style): voice-fidelity lint check, CLI wiring, and docs (FEAT-040.10)

### DIFF
--- a/creek-tools/creek/lint/checks/voice_fidelity.py
+++ b/creek-tools/creek/lint/checks/voice_fidelity.py
@@ -1,0 +1,154 @@
+"""Deterministic check: surface drafts that diverge from the user's voice.
+
+The FEAT-040.9 guard runs synchronously during ``creek draft`` and stamps
+each saved draft's frontmatter with ``voice_distance`` / ``voice_findings``.
+This lint check is the audit pass that asks the operator to revisit any
+draft whose distance exceeds the configured
+:attr:`creek.config.AIStyleConfig.voice_distance_upper`. Drafts that lack the
+stamp (written before the guard, or hand-authored) are re-scanned against the
+voice fingerprint so the check still has a measurement.
+
+**Epistemics — read this before acting on a finding.** Voice distance is a
+*probabilistic, vault-relative* signal: it measures how far a draft sits from
+the user's *own measured writing*, not whether it "is AI". A high distance
+means "this reads less like you than your baseline" — a prompt to revise
+toward your voice, never proof of authorship and never an accusation. Humans
+and tools are poor at AI detection; this check exists to surface for review,
+not to convict. It only reads: it never deletes, rewrites, or re-drafts.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003  # used at runtime as a parameter type
+from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
+from typing import TYPE_CHECKING
+
+import frontmatter
+import yaml
+
+from creek.config import AIStyleConfig, load_config
+from creek.generate.ai_style.fingerprint import load_fingerprint
+from creek.generate.ai_style.scanner import scan
+from creek.lint._result import CheckResult
+
+if TYPE_CHECKING:
+    from creek.generate.ai_style.model import VoiceFingerprint
+
+_DRAFTS_RELPATH = ("07-Voice", "Drafts")
+"""Vault-relative location of generated drafts (mirrors ``DRAFTS_SUBDIR``)."""
+
+_MAX_DIVERGENCES = 3
+"""How many top divergences to name per flagged draft, to keep findings terse."""
+
+_REMEDIATION = "re-run `creek draft` or revise toward your measured voice"
+"""The non-accusatory remediation hint appended to every finding."""
+
+
+def _resolve_ai_style_config(vault_path: Path) -> AIStyleConfig:
+    """Return the vault's ``ai_style`` config, or defaults on a missing config.
+
+    A missing / malformed ``creek_config.yaml`` collapses to
+    :class:`AIStyleConfig` defaults so the check always has a ceiling to
+    compare against rather than failing the run.
+    """
+    config_path = vault_path / "00-Creek-Meta" / "creek_config.yaml"
+    try:
+        return load_config(config_path, warn_on_missing=False).ai_style
+    except (OSError, ValueError, yaml.YAMLError):
+        return AIStyleConfig()
+
+
+def _stamped_divergences(raw: object) -> str:
+    """Format the top stamped ``voice_findings`` entries as ``dir-use feature``."""
+    if not isinstance(raw, list):
+        return ""
+    parts: list[str] = []
+    for entry in raw[:_MAX_DIVERGENCES]:
+        if isinstance(entry, dict):
+            direction = entry.get("direction", "?")
+            feature = entry.get("feature_key", "?")
+            parts.append(f"{direction}-use {feature}")
+    return ", ".join(parts)
+
+
+def _measure_draft(
+    post: frontmatter.Post,
+    fingerprint: VoiceFingerprint,
+    config: AIStyleConfig,
+) -> tuple[float, str]:
+    """Return ``(voice_distance, divergences)`` for one draft.
+
+    Reads the stamped ``voice_distance`` / ``voice_findings`` when present;
+    otherwise re-scans the body against the fingerprint so unstamped drafts
+    are still measured.
+    """
+    stamped = post.metadata.get("voice_distance")
+    if isinstance(stamped, (int, float)):
+        return float(stamped), _stamped_divergences(post.metadata.get("voice_findings"))
+    report = scan(post.content, fingerprint=fingerprint, config=config)
+    divergences = ", ".join(
+        f"{finding.direction}-use {finding.feature_key}"
+        for finding in report.findings[:_MAX_DIVERGENCES]
+    )
+    return report.voice_distance, divergences
+
+
+def _scan_draft(
+    path: Path,
+    fingerprint: VoiceFingerprint,
+    config: AIStyleConfig,
+) -> str | None:
+    """Inspect one draft, returning a finding line or ``None`` when on-voice."""
+    try:
+        post = frontmatter.load(str(path))
+    except (OSError, ValueError, yaml.YAMLError):
+        return None
+    distance, divergences = _measure_draft(post, fingerprint, config)
+    if distance <= config.voice_distance_upper:
+        return None
+    detail = f"; top divergences: {divergences}" if divergences else ""
+    return (
+        f"- `{path.stem}`: voice_distance={distance:.2f} > "
+        f"{config.voice_distance_upper:.2f}{detail} ({_REMEDIATION})"
+    )
+
+
+def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
+    """Surface drafts whose voice distance exceeds the configured ceiling.
+
+    Loads the voice fingerprint and walks ``07-Voice/Drafts/``. When no
+    fingerprint exists the check emits a single informational finding rather
+    than failing — the operator must build the profile before drafts can be
+    measured. The check never modifies a file.
+    """
+    del since  # The check reads frontmatter / body snapshots, not timestamps.
+    config = _resolve_ai_style_config(vault_path)
+    fingerprint = load_fingerprint(vault_path, config)
+    if fingerprint.fragment_count == 0:
+        return CheckResult(
+            name="voice-fidelity",
+            summary="no voice fingerprint found — cannot measure drafts",
+            findings=[
+                "- No voice fingerprint found. Run `creek report --type "
+                "fingerprint` to profile your writing before the voice-fidelity "
+                "check can measure drafts.",
+            ],
+        )
+    drafts_dir = vault_path.joinpath(*_DRAFTS_RELPATH)
+    if not drafts_dir.is_dir():
+        return CheckResult(
+            name="voice-fidelity",
+            summary="0 draft(s) scanned (07-Voice/Drafts missing)",
+        )
+    findings: list[str] = []
+    scanned = 0
+    for md_file in sorted(drafts_dir.rglob("*.md")):
+        scanned += 1
+        finding = _scan_draft(md_file, fingerprint, config)
+        if finding is not None:
+            findings.append(finding)
+    summary = (
+        f"{scanned} draft(s) scanned; {len(findings)} above "
+        f"voice_distance_upper={config.voice_distance_upper:.2f}"
+    )
+    return CheckResult(name="voice-fidelity", summary=summary, findings=findings)

--- a/creek-tools/creek/lint/runner.py
+++ b/creek-tools/creek/lint/runner.py
@@ -36,6 +36,9 @@ from creek.lint.checks import (
 from creek.lint.checks import (
     unnamed as unnamed_check,
 )
+from creek.lint.checks import (
+    voice_fidelity as voice_fidelity_check,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -66,6 +69,7 @@ DETERMINISTIC_CHECKS: tuple[str, ...] = (
     "tags",
     "compost",
     "draft-grounding",
+    "voice-fidelity",
 )
 """Cheap checks that always run by default (link graph + frontmatter only)."""
 
@@ -85,6 +89,7 @@ _REGISTRY: dict[str, _CheckCallable] = {
     "tags": tags_check.run,
     "compost": compost_check.run,
     "draft-grounding": draft_grounding_check.run,
+    "voice-fidelity": voice_fidelity_check.run,
     "paradox": paradox_check.run,
     "synchronicity": synchronicity_check.run,
     "unnamed": unnamed_check.run,

--- a/creek-tools/docs/generation.md
+++ b/creek-tools/docs/generation.md
@@ -195,6 +195,16 @@ draft:
 
 This means every draft can be **re-run** later from the same seed and skill stack — useful for tracking how the same idea drafts differently as the vault grows.
 
+### Voice fidelity (FEAT-040)
+
+The goal of generation is text that sounds like **you**, measured from your own writing — not text that merely avoids a generic "AI" checklist. Three pieces make that vault-relative:
+
+- **The fingerprint.** `creek report --type fingerprint` profiles your genuinely-authored vault content into a `VoiceFingerprint` (`00-Creek-Meta/voice-fingerprint.json`): a per-feature rate (em-dash density, transition-opener rate, AI-vocabulary rate, triad rate, …) plus the fragment support behind each. An **authorship filter** weights sources by how much of the text is really yours — journal and long-form markdown count fully; only the *your-turn* side of chat exports survives, and at a lower weight — so the baseline reflects you, not the assistants you talked to.
+- **The guard.** During `creek draft`, after composition the draft is sanitized, scored for **voice distance** against the fingerprint, and — when distance exceeds `ai_style.voice_distance_upper` — rewritten *toward* your measured voice (bounded, regression-guarded, and never at the cost of grounding). Pass `--no-llm` to sanitize and measure only, with no rewrite hop.
+- **The stamp.** The final `voice_distance` and the residual `voice_findings` are written into the draft's frontmatter, so the `voice-fidelity` lint check (and you) can later see how far each draft sits from your voice without re-measuring.
+
+> **Voice distance is not an AI detector.** It is a *probabilistic, vault-relative* signal — how far a draft sits from **your own measured writing**, not whether text "is AI". A high distance is a prompt to revise toward your voice, never proof of authorship. Humans and tools are unreliable at AI detection; these scores are for *your* review, never an accusation.
+
 ## Local-first ergonomics
 
 All generation flows (`mine`, `draft`, `report`, `skills`) respect the privacy tier configuration via the shared filter in `creek/classify/privacy_filter.py`. By default:

--- a/creek-tools/docs/lint.md
+++ b/creek-tools/docs/lint.md
@@ -51,6 +51,11 @@ Deterministic (always run by default):
   enforces ≤3000 words on root `AGENTS.md`.
 - `tags` — single-use tags surfaced as orphans (never auto-deleted).
 - `compost` — counts of recorded compost notes under `10-Liminal/Compost/`.
+- `draft-grounding` — drafts whose stamped grounding scores
+  (`derivative_score` / `grounding_score`) fall outside the configured
+  `draft.derivative_upper` / `draft.grounding_fraction_lower` bounds.
+- `voice-fidelity` — drafts whose distance from your *measured voice*
+  exceeds `ai_style.voice_distance_upper` (see below).
 
 Semantic (run when `--since` or an explicit `--check` is passed):
 
@@ -58,6 +63,28 @@ Semantic (run when `--since` or an explicit `--check` is passed):
 - `synchronicity` — surprising cross-source resonances already on disk.
 - `unnamed` — fragments whose primary frequency is `unclassified`,
   wherever they live, plus anything physically under `10-Liminal/Unnamed/`.
+
+### Voice fidelity (FEAT-040)
+
+The `voice-fidelity` check walks `07-Voice/Drafts/`, reads the
+`voice_distance` / `voice_findings` frontmatter stamped by the
+generation-time guard (and re-scans any draft that lacks the stamp against
+your voice fingerprint), and surfaces one finding per draft whose
+`voice_distance` exceeds `ai_style.voice_distance_upper` (default `0.35`).
+Each finding names the top over- and under-used features and a remediation
+hint — re-run `creek draft` or revise toward your voice. It runs by default,
+or on demand with `creek lint --check voice-fidelity`. If no fingerprint
+exists yet it emits a single informational finding (run the profiler first)
+rather than failing. Like every lint check it only **reads** — it never
+rewrites or deletes a draft.
+
+> **This is not an AI detector.** Voice distance is a *probabilistic,
+> vault-relative* signal: it measures how far a draft sits from **your own
+> measured writing**, not whether text "is AI". A high distance means "this
+> reads less like you than your baseline" — a prompt to revise toward your
+> voice, never proof of authorship and never an accusation. Humans and tools
+> are unreliable at AI detection; this check exists to surface drafts for
+> *your* review, not to convict. Do not use it to accuse anyone of using AI.
 
 ## Output
 

--- a/creek-tools/tests/test_lint_voice_fidelity.py
+++ b/creek-tools/tests/test_lint_voice_fidelity.py
@@ -1,0 +1,169 @@
+"""Tests for the ``voice-fidelity`` lint check (FEAT-040.10).
+
+The check is the audit surface for the voice-fidelity subsystem: it walks
+``07-Voice/Drafts/``, reads the ``voice_distance`` / ``voice_findings``
+frontmatter stamped by the FEAT-040.9 guard (re-scanning unstamped files
+against the fingerprint), and surfaces any draft whose distance exceeds
+``ai_style.voice_distance_upper``. It is framed as "this diverges from your
+voice", never as AI accusation, and it never mutates a file.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+import yaml
+
+from creek.config import AIStyleConfig
+from creek.generate.ai_style.fingerprint import save_fingerprint
+from creek.generate.ai_style.model import FeatureStat, VoiceFingerprint
+from creek.lint import ALL_CHECKS, DETERMINISTIC_CHECKS, LintRunner
+from creek.lint.checks import voice_fidelity as voice_fidelity_check
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_TROPEY = (
+    "Additionally, this delves into the rich tapestry of the subject. "
+    "Moreover, it is important to note the vibrant and multifaceted nuances. "
+    "Furthermore, the landscape stands as a testament to its significance."
+)
+
+
+def _seed(vault: Path) -> None:
+    """Create the meta + drafts folders the check needs."""
+    (vault / "00-Creek-Meta").mkdir(parents=True, exist_ok=True)
+    (vault / "07-Voice" / "Drafts").mkdir(parents=True, exist_ok=True)
+
+
+def _write_fingerprint(vault: Path, *, fragments: int = 20) -> None:
+    """Persist a non-thin fingerprint with near-zero AI-ish rates."""
+    save_fingerprint(
+        VoiceFingerprint(
+            features={"em_dash_density": FeatureStat(rate=0.0, support=fragments)},
+            fragment_count=fragments,
+        ),
+        vault,
+        AIStyleConfig(),
+    )
+
+
+def _write_config(vault: Path, *, voice_distance_upper: float) -> None:
+    """Drop a creek_config.yaml with an explicit voice-distance ceiling."""
+    (vault / "00-Creek-Meta" / "creek_config.yaml").write_text(
+        yaml.safe_dump({"ai_style": {"voice_distance_upper": voice_distance_upper}}),
+        encoding="utf-8",
+    )
+
+
+def _write_draft(
+    vault: Path,
+    *,
+    name: str,
+    body: str = "A plain body.",
+    voice_distance: float | None = None,
+    voice_findings: list[dict[str, object]] | None = None,
+) -> Path:
+    """Write a draft markdown file with optional guard frontmatter."""
+    meta: dict[str, object] = {"type": "draft", "title": name, "status": "draft"}
+    if voice_distance is not None:
+        meta["voice_distance"] = voice_distance
+    if voice_findings is not None:
+        meta["voice_findings"] = voice_findings
+    target = vault / "07-Voice" / "Drafts" / f"{name}.md"
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content=body, **meta)),
+        encoding="utf-8",
+    )
+    return target
+
+
+class TestVoiceFidelityRegistry:
+    """The check must be reachable through the public lint surface."""
+
+    def test_registered_as_deterministic(self) -> None:
+        """Frontmatter-read + regex re-scan is cheap — it runs by default."""
+        assert "voice-fidelity" in DETERMINISTIC_CHECKS
+        assert "voice-fidelity" in ALL_CHECKS
+
+    def test_runner_dispatches_check(self, tmp_path: Path) -> None:
+        """The registry resolves the name to its module callable."""
+        _seed(tmp_path)
+        _write_fingerprint(tmp_path)
+        report = LintRunner(tmp_path).run(checks=["voice-fidelity"])
+        assert [r.name for r in report.results] == ["voice-fidelity"]
+
+
+class TestVoiceFidelityFindings:
+    """Threshold comparison over stamped and unstamped drafts."""
+
+    def test_high_distance_stamped_is_flagged(self, tmp_path: Path) -> None:
+        """A stamped draft above the ceiling appears in the findings."""
+        _seed(tmp_path)
+        _write_fingerprint(tmp_path)
+        _write_config(tmp_path, voice_distance_upper=0.1)
+        _write_draft(
+            tmp_path,
+            name="2026-05-30-divergent",
+            voice_distance=0.5,
+            voice_findings=[
+                {"feature_key": "ai_vocab_density", "direction": "over"},
+            ],
+        )
+        result = voice_fidelity_check.run(tmp_path)
+        assert result.name == "voice-fidelity"
+        assert len(result.findings) == 1
+        finding = result.findings[0]
+        assert "2026-05-30-divergent" in finding
+        assert "0.50" in finding
+        assert "ai_vocab_density" in finding
+
+    def test_on_voice_stamped_is_silent(self, tmp_path: Path) -> None:
+        """A stamped draft under the ceiling produces no finding."""
+        _seed(tmp_path)
+        _write_fingerprint(tmp_path)
+        _write_config(tmp_path, voice_distance_upper=0.35)
+        _write_draft(tmp_path, name="2026-05-30-onvoice", voice_distance=0.05)
+        result = voice_fidelity_check.run(tmp_path)
+        assert result.findings == []
+        assert "0 " in result.summary
+
+    def test_unstamped_draft_is_rescanned(self, tmp_path: Path) -> None:
+        """A draft with no stamped distance is re-scanned against the fingerprint."""
+        _seed(tmp_path)
+        _write_fingerprint(tmp_path)
+        _write_config(tmp_path, voice_distance_upper=0.05)
+        _write_draft(tmp_path, name="2026-05-30-unstamped", body=_TROPEY)
+        result = voice_fidelity_check.run(tmp_path)
+        assert len(result.findings) == 1
+        assert "2026-05-30-unstamped" in result.findings[0]
+
+    def test_missing_fingerprint_is_informational(self, tmp_path: Path) -> None:
+        """No fingerprint yields one informational finding, not an error."""
+        _seed(tmp_path)
+        _write_draft(tmp_path, name="2026-05-30-anything", body=_TROPEY)
+        result = voice_fidelity_check.run(tmp_path)
+        assert result.name == "voice-fidelity"
+        assert len(result.findings) == 1
+        assert "fingerprint" in result.findings[0].lower()
+
+    def test_drafts_dir_missing_is_a_no_op(self, tmp_path: Path) -> None:
+        """A vault with a fingerprint but no Drafts dir is a clean no-op."""
+        (tmp_path / "00-Creek-Meta").mkdir(parents=True)
+        _write_fingerprint(tmp_path)
+        result = voice_fidelity_check.run(tmp_path)
+        assert result.findings == []
+        assert result.name == "voice-fidelity"
+
+    def test_does_not_mutate_files(self, tmp_path: Path) -> None:
+        """The check must leave every scanned draft byte-identical."""
+        _seed(tmp_path)
+        _write_fingerprint(tmp_path)
+        _write_config(tmp_path, voice_distance_upper=0.05)
+        stamped = _write_draft(tmp_path, name="2026-05-30-stamped", voice_distance=0.5)
+        unstamped = _write_draft(tmp_path, name="2026-05-30-plain", body=_TROPEY)
+        before = {p: p.read_bytes() for p in (stamped, unstamped)}
+        voice_fidelity_check.run(tmp_path)
+        after = {p: p.read_bytes() for p in (stamped, unstamped)}
+        assert before == after


### PR DESCRIPTION
## Summary

The audit surface for the voice-fidelity subsystem, mirroring `creek/lint/checks/draft_grounding.py`. Framed as *"this diverges from your measured voice,"* never as AI accusation — detection-and-surface only; the check never rewrites or deletes.

- **New `creek/lint/checks/voice_fidelity.py`** — `run(vault_path, *, since=None) -> CheckResult`:
  - Loads the `VoiceFingerprint` and walks `07-Voice/Drafts/`. Reads the `voice_distance` / `voice_findings` frontmatter stamped by the FEAT-040.9 guard; **re-scans** any unstamped draft against the fingerprint so it's still measured.
  - Emits one finding per draft over `ai_style.voice_distance_upper` (default `0.35`), naming the top over-/under-used features + a remediation hint. **Missing fingerprint → a single informational finding** (run the profiler first), not an error. **Never mutates a file** (byte-identical after run, asserted).
- **Registered** `"voice-fidelity"` in `runner.py` `DETERMINISTIC_CHECKS` + `_REGISTRY` — runs by default; `creek lint --check voice-fidelity` selects it.
- **Docs:** `docs/generation.md` gains a *Voice fidelity* section (the fingerprint, authorship filter, the guard, distance stamping); `docs/lint.md` documents the check + threshold. Both carry the epistemics prominently: voice distance is a **probabilistic, vault-relative** signal — matching *your measured voice*, **not proof of AI** — and must never be used to accuse anyone.

## Test plan

- New `tests/test_lint_voice_fidelity.py` (8 cases): registry/runner dispatch; high-distance stamped draft flagged; on-voice stamped draft silent; **unstamped draft re-scanned**; **missing fingerprint → informational, not error**; drafts-dir-missing no-op; **no-mutation (byte-identical)**.
- No regressions in `test_lint.py` / `test_lint_draft_grounding.py` (registration count).
- `./scripts/check-all.sh` green locally: 4788 passed, 93.68% coverage, all 12 gates pass.

Closes #427
Refs #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
