### PR TITLE
test(ai-style): cover save_outline_draft voice-fidelity wiring (FEAT-040.9)

### DIFF
--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -3391,3 +3391,28 @@ class TestVoiceFidelityGuardWiring:
         assert called["n"] == 0
         assert "tapestry" in post.content
         assert isinstance(post.metadata["voice_distance"], float)
+
+    def test_save_outline_draft_stamps_voice_fields(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """The symmetric ``save_outline_draft`` path also runs the guard."""
+        gen = DraftGenerator(
+            llm=lambda _p: _TROPEY_BODY,
+            skills_root=skills_root,
+            fingerprint=_voice_fingerprint(),
+            ai_style_config=_eager_ai_style(),
+            voice_guard_no_llm=True,
+        )
+        draft = gen.generate_outline_draft(
+            "## One\nFirst section.\n\n## Two\nSecond section.\n",
+            vault_path=vault,
+            detect_ontology=_empty_detector(),
+        )
+        path = gen.save_outline_draft(draft, vault)
+        meta = frontmatter.load(str(path)).metadata
+        assert isinstance(meta["voice_distance"], float)
+        assert meta["voice_distance"] > 0.0
+        assert isinstance(meta["voice_findings"], list)
+        assert meta["voice_findings"]


### PR DESCRIPTION
## Summary

Follow-up from the #438 review. `TestVoiceFidelityGuardWiring` covered five `save_draft` paths but exercised the symmetric `save_outline_draft` guard wiring only indirectly. This adds a direct regression guard.

## Test plan

- New `test_save_outline_draft_stamps_voice_fields`: generates an outline draft with a tropey stitched body against a fixture fingerprint (`voice_guard_no_llm=True`), saves it via `save_outline_draft`, and asserts `voice_distance` (float, > 0) and `voice_findings` (non-empty list) land in the frontmatter — exercising the `save_outline_draft` → `_apply_voice_fidelity` path directly.
- `./scripts/check-all.sh` green: 12/12 gates, ≥90% coverage.

Closes #440
Refs #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
