### PR TITLE
perf(ai-style): short-circuit _voice_grounding_check on empty fragments

### DIFF
--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -1869,6 +1869,10 @@ class DraftGenerator:
         the draft below its grounding floor — so voice fidelity is never
         bought at the cost of grounding.
         """
+        if not source_fragments:
+            # Nothing to ground against (e.g. the outline-draft path): skip the
+            # vault scan rather than build a trivially-passing no-op veto.
+            return None
         if self._embedding_fn is None or self._grounding_thresholds is None:
             return None
         fragments = _load_fragments_by_id(

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -19,6 +19,7 @@ from creek.generate.drafts import (
     SeedResolutionError,
     SeedSpec,
 )
+from creek.generate.grounding import GroundingThresholds
 from creek.generate.mining import IdeaSeed, MiningStrategy
 from creek.generate.outline import OutlineSection, build_stitch_prompt
 from creek.models import (
@@ -3416,3 +3417,36 @@ class TestVoiceFidelityGuardWiring:
         assert meta["voice_distance"] > 0.0
         assert isinstance(meta["voice_findings"], list)
         assert meta["voice_findings"]
+
+    def test_grounding_check_short_circuits_on_empty_fragments(
+        self,
+        vault: Path,
+        skills_root: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Empty source fragments skip the vault scan and yield no grounding veto."""
+        called = {"n": 0}
+
+        def _fake_loader(*_args: object, **_kwargs: object) -> dict[str, object]:
+            called["n"] += 1
+            return {}
+
+        monkeypatch.setattr(
+            "creek.generate.drafts._load_fragments_by_id",
+            _fake_loader,
+        )
+        gen = DraftGenerator(
+            llm=lambda _p: "x",
+            skills_root=skills_root,
+            embedding_fn=lambda _t: [1.0, 0.0],
+            grounding_thresholds=GroundingThresholds(
+                derivative_upper=0.85,
+                grounding_lower=0.3,
+                grounding_fraction_lower=0.3,
+            ),
+        )
+        # Even with grounding fully wired, an empty source list means there is
+        # nothing to ground against — so no vault scan and no veto closure.
+        result = gen._voice_grounding_check(vault, ())
+        assert result is None
+        assert called["n"] == 0


### PR DESCRIPTION
## Summary

Follow-up from the #438 review. When `source_fragments` is empty — as the `save_outline_draft` path always passes — `_voice_grounding_check` still ran a full `_load_fragments_by_id` vault scan before building a closure whose `source_texts` was the empty tuple (a trivially-passing no-op veto).

Add an early `if not source_fragments: return None` so the outline path skips the I/O entirely and the intent ("nothing to ground against") is explicit.

## Test plan

- New `test_grounding_check_short_circuits_on_empty_fragments`: monkeypatches `_load_fragments_by_id`, constructs a generator with grounding fully wired (embedding_fn + thresholds), calls `_voice_grounding_check(vault, ())`, and asserts the result is `None` and the loader was **not** called (Red before the fix, Green after).
- `./scripts/check-all.sh` green: 12/12 gates, ≥90% coverage.

Closes #441
Refs #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
