### PR TITLE
test(ai-style): pin build_voice_rewrite_prompt structure (FEAT-040.9)

### DIFF
--- a/creek-tools/tests/generate/ai_style/test_guard.py
+++ b/creek-tools/tests/generate/ai_style/test_guard.py
@@ -17,9 +17,11 @@ from creek.config import AIStyleConfig
 from creek.generate.ai_style.guard import (
     VoiceFidelityReport,
     build_voice_fidelity_frontmatter,
+    build_voice_rewrite_prompt,
     run_voice_fidelity_guard,
 )
 from creek.generate.ai_style.model import FeatureStat, VoiceFingerprint
+from creek.generate.ai_style.scanner import scan
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -235,3 +237,34 @@ def test_frontmatter_stamps_distance_and_findings() -> None:
 def test_build_frontmatter_skips_empty() -> None:
     """A clean run with no distance/findings stamps nothing misleading."""
     assert build_voice_fidelity_frontmatter(voice_distance=None, findings=()) == {}
+
+
+def test_rewrite_prompt_orders_targets_divergences_ask_draft() -> None:
+    """The rewrite prompt carries targets, divergences, ask, and draft in order."""
+    report = scan(_TROPEY, fingerprint=_fingerprint(), config=AIStyleConfig())
+    assert report.findings  # the tropey body must surface divergences to repair
+    preamble = "## Voice targets\nuses em-dashes freely"
+    prompt = build_voice_rewrite_prompt(_TROPEY, report, style_preamble=preamble)
+    assert preamble in prompt
+    assert "## Voice divergences to repair" in prompt
+    assert "## Ask" in prompt
+    assert f"## Draft\n{_TROPEY}" in prompt
+    # The rewrite must move toward voice without fabricating or dropping content.
+    assert "Do not invent facts" in prompt
+    assert (
+        prompt.index(preamble)
+        < prompt.index("## Voice divergences to repair")
+        < prompt.index("## Ask")
+        < prompt.index("## Draft")
+    )
+
+
+def test_rewrite_prompt_omits_empty_blocks() -> None:
+    """With no preamble and no findings, only the ask + draft remain."""
+    report = scan(_PLAIN, fingerprint=_fingerprint(), config=AIStyleConfig())
+    assert not report.findings
+    prompt = build_voice_rewrite_prompt(_PLAIN, report)
+    assert "## Voice targets" not in prompt
+    assert "## Voice divergences to repair" not in prompt
+    assert prompt.startswith("## Ask")
+    assert f"## Draft\n{_PLAIN}" in prompt


### PR DESCRIPTION
## Summary

Follow-up from the #438 review. The rewrite-prompt assembler `build_voice_rewrite_prompt` was tested only indirectly (through `test_rewrite_lowers_distance`); its structure was unpinned.

## Test plan

- New `test_rewrite_prompt_orders_targets_divergences_ask_draft`: with a tropey scan report + a voice-targets preamble, asserts the prompt contains the preamble, a `## Voice divergences to repair` block, the `## Ask` (including the "Do not invent facts" guard), and the `## Draft` body — in that order.
- New `test_rewrite_prompt_omits_empty_blocks`: with no preamble and a clean (finding-free) report, asserts the targets/divergences blocks are absent and only the ask + draft remain.
- `./scripts/check-all.sh` green: 12/12 gates, ≥90% coverage.

Closes #442
Refs #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
