### PR TITLE
feat(author): scaffold creek author desk end-to-end with stubs (#455)

### DIFF
--- a/creek-tools/creek/author/__init__.py
+++ b/creek-tools/creek/author/__init__.py
@@ -1,0 +1,39 @@
+"""Creek Writing Desk — multi-agent authoring package (FEAT-041).
+
+This package wires the author desk end-to-end with typed stubs (#455): a
+:class:`~creek.author.conductor.Conductor` drives stub specialist agents, a
+stub voice agent, and a stub reflection node to return a shaped
+:class:`~creek.author.models.AuthoredDraft`. Later FEAT-041 issues replace the
+stub bodies with real retrieval, synthesis, voicing, and judging behind the
+same seams.
+"""
+
+from __future__ import annotations
+
+from creek.author.client import AuthorLLMClient
+from creek.author.conductor import (
+    SUPPORTED_MEDIUMS,
+    Conductor,
+    build_default_conductor,
+    run_author,
+)
+from creek.author.models import (
+    AuthoredDraft,
+    EvidenceBundle,
+    EvidenceClaim,
+    Medium,
+    ReflectionVerdict,
+)
+
+__all__ = [
+    "SUPPORTED_MEDIUMS",
+    "AuthorLLMClient",
+    "AuthoredDraft",
+    "Conductor",
+    "EvidenceBundle",
+    "EvidenceClaim",
+    "Medium",
+    "ReflectionVerdict",
+    "build_default_conductor",
+    "run_author",
+]

--- a/creek-tools/creek/author/agents.py
+++ b/creek-tools/creek/author/agents.py
@@ -1,0 +1,87 @@
+"""Stub specialist agents for the Creek Writing Desk (FEAT-041, #455).
+
+Each specialist gathers a slice of structured evidence for the conductor. In
+the skeleton they return deterministic mock claims; issues #463/#467 replace
+the bodies with real Graph, Retrieval, and Ontology logic while preserving
+this interface.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from creek.author.models import EvidenceBundle, EvidenceClaim
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@runtime_checkable
+class Specialist(Protocol):
+    """A specialist agent that contributes structured evidence.
+
+    Implementations expose a stable :attr:`name` (used in the conductor's
+    plan) and a :meth:`gather` method returning an :class:`EvidenceBundle`.
+    """
+
+    name: str
+
+    def gather(self, query: str, vault: Path) -> EvidenceBundle:
+        """Return structured evidence for *query* drawn from *vault*."""
+        ...
+
+
+class GraphSpecialist:
+    """Stub Graph specialist — would walk the resonance/link graph."""
+
+    name = "graph"
+
+    def gather(self, query: str, vault: Path) -> EvidenceBundle:
+        """Return a mock graph-derived claim (skeleton)."""
+        return EvidenceBundle(
+            claims=[
+                EvidenceClaim(
+                    claim=f"Graph neighbours relevant to {query!r} (stub).",
+                    source_fragments=["frag-graph-0001"],
+                )
+            ]
+        )
+
+
+class RetrievalSpecialist:
+    """Stub Retrieval specialist — would fetch the most relevant fragments."""
+
+    name = "retrieval"
+
+    def gather(self, query: str, vault: Path) -> EvidenceBundle:
+        """Return a mock retrieval-derived claim (skeleton)."""
+        return EvidenceBundle(
+            claims=[
+                EvidenceClaim(
+                    claim=f"Top retrieved passage for {query!r} (stub).",
+                    source_fragments=["frag-retrieval-0001"],
+                )
+            ]
+        )
+
+
+class OntologySpecialist:
+    """Stub Ontology specialist — would ground claims in the APTITUDE model."""
+
+    name = "ontology"
+
+    def gather(self, query: str, vault: Path) -> EvidenceBundle:
+        """Return a mock ontology-derived claim (skeleton)."""
+        return EvidenceBundle(
+            claims=[
+                EvidenceClaim(
+                    claim=f"Ontology framing for {query!r} (stub).",
+                    source_fragments=["frag-ontology-0001"],
+                )
+            ]
+        )
+
+
+def default_specialists() -> list[Specialist]:
+    """Return the ordered default specialist roster (graph, retrieval, ontology)."""
+    return [GraphSpecialist(), RetrievalSpecialist(), OntologySpecialist()]

--- a/creek-tools/creek/author/client.py
+++ b/creek-tools/creek/author/client.py
@@ -1,0 +1,57 @@
+"""Thin, mockable Anthropic client wrapper for the author desk (FEAT-041, #455).
+
+The Writing Desk's only seam onto the network goes through this wrapper, so
+unit tests inject a mock provider and never make a live call. The skeleton's
+specialists/voice/reflection are pure stubs and do not yet call it; issue #460
+wires it into the real Conductor.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.classify.llm.providers import AnthropicProvider
+
+if TYPE_CHECKING:
+    from creek.config import LLMConfig
+
+
+class AuthorLLMClient:
+    """A thin wrapper over :class:`AnthropicProvider` for author-desk calls.
+
+    Attributes:
+        _provider: The underlying provider performing the SDK call.
+    """
+
+    def __init__(self, provider: AnthropicProvider) -> None:
+        """Store the provider this client delegates to.
+
+        Args:
+            provider: The Anthropic provider performing the actual call.
+        """
+        self._provider = provider
+
+    @classmethod
+    def from_config(cls, config: LLMConfig) -> AuthorLLMClient:
+        """Build a client from *config*, sourcing the model id from config.
+
+        Args:
+            config: The LLM configuration (provider + model id come from here,
+                never hard-coded).
+
+        Returns:
+            An :class:`AuthorLLMClient` wrapping a configured provider.
+        """
+        return cls(AnthropicProvider(config))
+
+    def complete(self, prompt: str, *, max_tokens: int | None = None) -> str:
+        """Return the completion text for *prompt*.
+
+        Args:
+            prompt: The prompt to send.
+            max_tokens: Optional output-token ceiling.
+
+        Returns:
+            The provider's completion text.
+        """
+        return self._provider.call_with_metadata(prompt, max_tokens=max_tokens).text

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -11,7 +11,7 @@ behind these same seams.
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 
 from creek.author.agents import Specialist, default_specialists
 from creek.author.models import (
@@ -75,7 +75,9 @@ def _require_supported_medium(medium: str) -> Medium:
             "wired in the Writing Desk skeleton (FEAT-041)."
         )
         raise ValueError(msg)
-    return "research"
+    # Echo back the validated medium rather than a hard-coded literal so that
+    # adding a medium to SUPPORTED_MEDIUMS cannot silently mislabel a draft.
+    return cast("Medium", medium)
 
 
 def _claims_to_provenance(claims: Sequence[EvidenceClaim]) -> list[ProvenanceEntry]:
@@ -133,7 +135,7 @@ class Conductor:
         return [s.name for s in self.specialists] + list(_DOWNSTREAM_STEPS)
 
     def gather_evidence(self, query: str, vault: Path) -> EvidenceBundle:
-        """Merge every specialist's evidence into one bundle.
+        """Run the specialist roster then the synthesize step.
 
         Args:
             query: The user query.
@@ -142,9 +144,21 @@ class Conductor:
         Returns:
             The synthesized :class:`EvidenceBundle`.
         """
+        bundles = [specialist.gather(query, vault) for specialist in self.specialists]
+        return self.synthesize(bundles)
+
+    def synthesize(self, bundles: Sequence[EvidenceBundle]) -> EvidenceBundle:
+        """Merge per-specialist *bundles* into one (the ``synthesize`` step).
+
+        Args:
+            bundles: One evidence bundle per specialist.
+
+        Returns:
+            A single :class:`EvidenceBundle` carrying every claim.
+        """
         claims: list[EvidenceClaim] = []
-        for specialist in self.specialists:
-            claims.extend(specialist.gather(query, vault).claims)
+        for bundle in bundles:
+            claims.extend(bundle.claims)
         return EvidenceBundle(claims=claims)
 
     def run(self, *, medium: str, query: str, vault: Path) -> AuthoredDraft:

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -1,0 +1,234 @@
+"""The Conductor that orchestrates the Creek Writing Desk (FEAT-041, #455).
+
+The conductor drives the end-to-end flow: each specialist gathers structured
+evidence, the bundles are synthesized, the voice agent renders a draft, and the
+reflection node judges it — looping on ``REVISE`` up to ``max_rounds`` before
+returning a shaped :class:`~creek.author.models.AuthoredDraft`. In the skeleton
+every collaborator is a typed stub; later issues swap in real implementations
+behind these same seams.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Protocol
+
+from creek.author.agents import Specialist, default_specialists
+from creek.author.models import (
+    AuthoredDraft,
+    EvidenceBundle,
+    EvidenceClaim,
+    Medium,
+    ReflectionVerdict,
+)
+from creek.author.reflection import ReflectionNode
+from creek.author.voice import VoiceAgent
+from creek.compile.provenance import ProvenanceEntry
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from creek.author.client import AuthorLLMClient
+
+#: Mediums the conductor will run. Only ``research`` is wired in the skeleton.
+SUPPORTED_MEDIUMS: frozenset[str] = frozenset({"research"})
+
+#: Fixed pipeline steps that follow the specialist roster, in order.
+_DOWNSTREAM_STEPS: tuple[str, ...] = ("synthesize", "voice", "reflect")
+
+#: Excerpt length kept on each provenance entry's ``claim_excerpt``.
+_EXCERPT_LEN: int = 80
+
+
+class VoiceRenderer(Protocol):
+    """Anything that renders evidence into a draft body."""
+
+    def render(self, query: str, evidence: EvidenceBundle) -> str:
+        """Return draft prose for *query* from *evidence*."""
+        ...
+
+
+class Reflector(Protocol):
+    """Anything that judges a draft body against its evidence."""
+
+    def review(self, body: str, evidence: EvidenceBundle) -> ReflectionVerdict:
+        """Return a verdict for *body* given *evidence*."""
+        ...
+
+
+def _require_supported_medium(medium: str) -> Medium:
+    """Validate *medium* and return it as a :data:`Medium` literal.
+
+    Args:
+        medium: The requested medium.
+
+    Returns:
+        The validated medium literal.
+
+    Raises:
+        ValueError: When *medium* is not wired in the skeleton.
+    """
+    if medium not in SUPPORTED_MEDIUMS:
+        msg = (
+            f"Unsupported medium {medium!r}; only the 'research' medium is "
+            "wired in the Writing Desk skeleton (FEAT-041)."
+        )
+        raise ValueError(msg)
+    return "research"
+
+
+def _claims_to_provenance(claims: Sequence[EvidenceClaim]) -> list[ProvenanceEntry]:
+    """Render evidence *claims* into mock provenance entries.
+
+    Args:
+        claims: The claims to trace.
+
+    Returns:
+        One :class:`ProvenanceEntry` per claim, numbered ``claim-001`` up.
+    """
+    stamped = datetime.now(tz=UTC)
+    return [
+        ProvenanceEntry(
+            claim_id=f"claim-{index:03d}",
+            claim_excerpt=claim.claim[:_EXCERPT_LEN],
+            fragment_ids=claim.source_fragments.copy(),
+            compiled_at=stamped,
+            compile_method="manual",
+        )
+        for index, claim in enumerate(claims, start=1)
+    ]
+
+
+class Conductor:
+    """Orchestrates specialists, the voice agent, and the reflection node.
+
+    Attributes:
+        specialists: The ordered specialist roster.
+        voice: The agent that renders evidence into a draft.
+        reflection: The node that judges each drafted body.
+        max_rounds: Upper bound on voice/reflect rounds.
+        llm_client: Optional network seam; unused by the stub collaborators
+            but injected here so issue #460 can wire real LLM calls.
+    """
+
+    def __init__(
+        self,
+        specialists: Sequence[Specialist],
+        voice: VoiceRenderer,
+        reflection: Reflector,
+        *,
+        max_rounds: int,
+        llm_client: AuthorLLMClient | None = None,
+    ) -> None:
+        """Store collaborators and the round bound."""
+        self.specialists = list(specialists)
+        self.voice = voice
+        self.reflection = reflection
+        self.max_rounds = max_rounds
+        self.llm_client = llm_client
+
+    def plan(self) -> list[str]:
+        """Return the ordered pipeline step names for display/dry-run."""
+        return [s.name for s in self.specialists] + list(_DOWNSTREAM_STEPS)
+
+    def gather_evidence(self, query: str, vault: Path) -> EvidenceBundle:
+        """Merge every specialist's evidence into one bundle.
+
+        Args:
+            query: The user query.
+            vault: The vault the specialists read from.
+
+        Returns:
+            The synthesized :class:`EvidenceBundle`.
+        """
+        claims: list[EvidenceClaim] = []
+        for specialist in self.specialists:
+            claims.extend(specialist.gather(query, vault).claims)
+        return EvidenceBundle(claims=claims)
+
+    def run(self, *, medium: str, query: str, vault: Path) -> AuthoredDraft:
+        """Run the full author pipeline and return a shaped draft.
+
+        Args:
+            medium: The requested medium (only ``research`` is wired).
+            query: The user query.
+            vault: The vault to author from.
+
+        Returns:
+            The :class:`AuthoredDraft` with mock provenance and a verdict.
+
+        Raises:
+            ValueError: When *medium* is unsupported.
+        """
+        validated = _require_supported_medium(medium)
+        evidence = self.gather_evidence(query, vault)
+
+        body = ""
+        verdict: ReflectionVerdict = "ESCALATE"
+        rounds = 0
+        for attempt in range(1, self.max_rounds + 1):
+            rounds = attempt
+            body = self.voice.render(query, evidence)
+            verdict = self.reflection.review(body, evidence)
+            if verdict != "REVISE":
+                break
+
+        return AuthoredDraft(
+            medium=validated,
+            query=query,
+            body=body,
+            provenance=_claims_to_provenance(evidence.claims),
+            verdict=verdict,
+            rounds=rounds,
+        )
+
+
+def build_default_conductor(
+    *,
+    max_rounds: int,
+    llm_client: AuthorLLMClient | None = None,
+) -> Conductor:
+    """Build a conductor wired with the default stub collaborators.
+
+    Args:
+        max_rounds: Upper bound on voice/reflect rounds.
+        llm_client: Optional network seam passed through to the conductor.
+
+    Returns:
+        A ready-to-run :class:`Conductor`.
+    """
+    return Conductor(
+        specialists=default_specialists(),
+        voice=VoiceAgent(),
+        reflection=ReflectionNode(),
+        max_rounds=max_rounds,
+        llm_client=llm_client,
+    )
+
+
+def run_author(
+    *,
+    medium: str,
+    query: str,
+    vault: Path,
+    max_rounds: int | None = None,
+) -> AuthoredDraft:
+    """Author *query* for *medium* against *vault* with the default desk.
+
+    Args:
+        medium: The requested medium (only ``research`` is wired).
+        query: The user query.
+        vault: The vault to author from.
+        max_rounds: Optional override for the round bound; defaults to the
+            ``author.max_author_rounds`` config default.
+
+    Returns:
+        The shaped :class:`AuthoredDraft`.
+    """
+    from creek.config import AuthorConfig
+
+    rounds = max_rounds if max_rounds is not None else AuthorConfig().max_author_rounds
+    return build_default_conductor(max_rounds=rounds).run(
+        medium=medium, query=query, vault=vault
+    )

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -1,0 +1,85 @@
+"""Typed data models for the Creek Writing Desk (FEAT-041).
+
+These are the shapes that flow through the author desk: specialists emit
+:class:`EvidenceClaim` records (a claim traced to its source fragments),
+the conductor aggregates them into an :class:`EvidenceBundle`, and one run
+yields an :class:`AuthoredDraft`. Real retrieval/synthesis/judging fill these
+shapes in later FEAT-041 issues; the skeleton populates them with mock data.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from creek.compile.provenance import ProvenanceEntry
+
+#: Mediums the author desk can produce. Only ``research`` is wired in the
+#: skeleton; the others (chat/essay/book-report/how-to) arrive in later issues.
+Medium = Literal["research"]
+
+#: The reflection node's bounded verdict over a drafted body.
+ReflectionVerdict = Literal["PASS", "REVISE", "ESCALATE"]
+
+
+class EvidenceClaim(BaseModel):
+    """A single structured claim from a specialist, traced to fragments.
+
+    Specialists return *structured evidence*, never free prose: each claim is
+    one assertion paired with the fragment ids that support it.
+
+    Attributes:
+        claim: The asserted statement, in one short sentence.
+        source_fragments: Ordered fragment ids backing the claim.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    claim: str
+    source_fragments: list[str] = Field(default_factory=list)
+
+
+class EvidenceBundle(BaseModel):
+    """The aggregated evidence the conductor hands to the voice agent.
+
+    Attributes:
+        claims: Every :class:`EvidenceClaim` gathered across specialists.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    claims: list[EvidenceClaim] = Field(default_factory=list)
+
+    def all_source_fragments(self) -> list[str]:
+        """Return the order-preserving, deduplicated union of claim fragments.
+
+        Returns:
+            Fragment ids in first-seen order, with duplicates removed.
+        """
+        seen: dict[str, None] = {}
+        for claim in self.claims:
+            for fragment_id in claim.source_fragments:
+                seen.setdefault(fragment_id, None)
+        return list(seen)
+
+
+class AuthoredDraft(BaseModel):
+    """The shaped output of one author-desk run.
+
+    Attributes:
+        medium: The medium the draft was authored for.
+        query: The originating user query.
+        body: The drafted prose (mock text in the skeleton).
+        provenance: Per-claim provenance entries, reusing the compile-layer
+            :class:`~creek.compile.provenance.ProvenanceEntry` shape.
+        verdict: The reflection node's verdict for this draft.
+        rounds: How many voice/reflect rounds ran (``>= 1``).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    medium: Medium
+    query: str
+    body: str
+    provenance: list[ProvenanceEntry] = Field(default_factory=list)
+    verdict: ReflectionVerdict
+    rounds: int = Field(ge=1)

--- a/creek-tools/creek/author/reflection.py
+++ b/creek-tools/creek/author/reflection.py
@@ -1,0 +1,35 @@
+"""Stub Reflection node for the Creek Writing Desk (FEAT-041, #455).
+
+Judges a drafted body and returns a bounded verdict. The skeleton uses a
+trivial groundedness heuristic; issue #473 replaces it with the real
+reflection logic plus bounded retries and escalation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from creek.author.models import EvidenceBundle, ReflectionVerdict
+
+
+class ReflectionNode:
+    """Stub Reflection node that judges a draft against its evidence."""
+
+    def review(self, body: str, evidence: EvidenceBundle) -> ReflectionVerdict:
+        """Return a verdict for *body* given its *evidence*.
+
+        The stub heuristic: a non-empty body grounded in at least one claim
+        passes; anything else escalates. It never returns ``REVISE`` — the
+        real reflection logic (issue #473) owns the revise/retry loop.
+
+        Args:
+            body: The drafted prose under review.
+            evidence: The evidence the draft was rendered from.
+
+        Returns:
+            ``"PASS"`` when grounded and non-empty, else ``"ESCALATE"``.
+        """
+        if body.strip() and evidence.claims:
+            return "PASS"
+        return "ESCALATE"

--- a/creek-tools/creek/author/voice.py
+++ b/creek-tools/creek/author/voice.py
@@ -1,0 +1,31 @@
+"""Stub Voice agent for the Creek Writing Desk (FEAT-041, #455).
+
+Renders an :class:`~creek.author.models.EvidenceBundle` into draft prose. The
+skeleton emits deterministic mock text that simply lists the evidence; issue
+#471 replaces this with the real voice-grounded rendering.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from creek.author.models import EvidenceBundle
+
+
+class VoiceAgent:
+    """Stub Voice agent that turns evidence into a (mock) drafted body."""
+
+    def render(self, query: str, evidence: EvidenceBundle) -> str:
+        """Render *evidence* into draft prose for *query*.
+
+        Args:
+            query: The originating user query.
+            evidence: The aggregated evidence to render.
+
+        Returns:
+            A non-empty mock draft body listing each claim.
+        """
+        lines = [f"# {query} (stub draft)", ""]
+        lines.extend(f"- {claim.claim}" for claim in evidence.claims)
+        return "\n".join(lines)

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2640,6 +2640,70 @@ def _resolve_save_tier(
     return PrivacyTier.OPEN
 
 
+@app.command()
+def author(
+    query: str = typer.Option(..., "--query", help="What to author about."),
+    medium: str = typer.Option(
+        "research",
+        "--medium",
+        help="Output medium. Only 'research' is wired in the skeleton (FEAT-041).",
+    ),
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print the pipeline plan and stub evidence summary without authoring.",
+    ),
+    max_rounds: int | None = typer.Option(
+        None,
+        "--max-rounds",
+        min=1,
+        max=10,
+        help=(
+            "Override the Conductor's voice/reflect round bound. Defaults to "
+            "the vault's author.max_author_rounds config (3)."
+        ),
+    ),
+) -> None:
+    """Author a piece with the Creek Writing Desk (FEAT-041 stub skeleton).
+
+    Drives an end-to-end author desk — stub Graph/Retrieval/Ontology
+    specialists, a stub Voice agent, and a stub Reflection node — and prints a
+    shaped :class:`~creek.author.models.AuthoredDraft`. ``--dry-run`` prints the
+    plan and a stub evidence summary instead. Only the ``research`` medium is
+    wired; real retrieval/synthesis/voicing arrive in later FEAT-041 issues.
+    """
+    from creek.author import SUPPORTED_MEDIUMS, build_default_conductor
+
+    if medium not in SUPPORTED_MEDIUMS:
+        console.print(
+            f"[red]Unsupported --medium {medium!r}; only 'research' is wired "
+            "in the Writing Desk skeleton (FEAT-041).[/red]",
+        )
+        raise typer.Exit(code=2)
+
+    config = _load_config_for_vault(vault)
+    vault_path = _resolve_vault(vault if vault is not None else config.vault_path)
+    rounds = max_rounds if max_rounds is not None else config.author.max_author_rounds
+    conductor = build_default_conductor(max_rounds=rounds)
+
+    if dry_run:
+        evidence = conductor.gather_evidence(query, vault_path)
+        console.print(f"PLAN: {' → '.join(conductor.plan())}")
+        console.print(
+            f"EVIDENCE (stub): {len(evidence.claims)} claims, "
+            f"{len(evidence.all_source_fragments())} source_fragments",
+        )
+        return
+
+    draft_result = conductor.run(medium=medium, query=query, vault=vault_path)
+    console.print(
+        f"medium={draft_result.medium} verdict={draft_result.verdict} "
+        f"rounds={draft_result.rounds} provenance={len(draft_result.provenance)}",
+    )
+    console.print(draft_result.body)
+
+
 @app.command(name="save")
 def save_cmd(
     target: str = typer.Option(

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -823,6 +823,16 @@ def _default_authorship_weights() -> dict[str, float]:
     }
 
 
+class AuthorConfig(BaseModel):
+    """Configuration for the FEAT-041 Creek Writing Desk author subsystem."""
+
+    max_author_rounds: int = Field(default=3, ge=1, le=10)
+    """Maximum Conductor voice/reflect rounds before escalation (bounded
+    ``[1, 10]``). The Conductor loops on a ``REVISE`` verdict up to this many
+    times; model ids for the desk's LLM calls come from the ``llm`` section,
+    never hard-coded."""
+
+
 class AIStyleConfig(BaseModel):
     """Configuration for the FEAT-040 AI-style / voice-fidelity subsystem.
 
@@ -1071,6 +1081,9 @@ class CreekConfig(BaseSettings):
 
     ai_style: AIStyleConfig = Field(default_factory=AIStyleConfig)
     """AI-style / voice-fidelity thresholds and weights (FEAT-040)."""
+
+    author: AuthorConfig = Field(default_factory=AuthorConfig)
+    """Creek Writing Desk author-subsystem settings (FEAT-041)."""
 
     sources: SourcePaths = Field(default_factory=SourcePaths)
     """Source data path mappings."""

--- a/creek-tools/tests/test_author_desk.py
+++ b/creek-tools/tests/test_author_desk.py
@@ -129,6 +129,39 @@ def test_evidence_bundle_dedups_source_fragments() -> None:
     assert bundle.all_source_fragments() == ["f1", "f2", "f3"]
 
 
+def test_conductor_synthesize_merges_bundles(tmp_path: Path) -> None:
+    """The ``synthesize`` step merges every specialist bundle into one."""
+    conductor = build_default_conductor(max_rounds=1)
+    bundles = [s.gather("q", tmp_path) for s in conductor.specialists]
+
+    merged = conductor.synthesize(bundles)
+
+    expected = sum(len(b.claims) for b in bundles)
+    assert len(merged.claims) == expected
+    assert merged.claims  # non-empty
+
+
+def test_plan_steps_each_correspond_to_a_real_call(tmp_path: Path) -> None:
+    """Every advertised plan step is exercised by a real run (no ghost steps)."""
+    conductor = build_default_conductor(max_rounds=1)
+    # ``synthesize`` must exist and run, not just appear in ``plan()``.
+    assert "synthesize" in conductor.plan()
+    evidence = conductor.gather_evidence("q", tmp_path)
+    assert evidence.claims  # gather_evidence runs the synthesize step
+
+
+def test_require_supported_medium_returns_validated_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Validation echoes back the *requested* medium, not a hard-coded literal."""
+    from creek.author import conductor as conductor_mod
+
+    monkeypatch.setattr(
+        conductor_mod, "SUPPORTED_MEDIUMS", frozenset({"research", "essay"})
+    )
+    assert conductor_mod._require_supported_medium("essay") == "essay"
+
+
 def test_run_author_rejects_unknown_medium(tmp_path: Path) -> None:
     """Only the ``research`` medium is wired; others raise a clear error."""
     with pytest.raises(ValueError, match="research"):

--- a/creek-tools/tests/test_author_desk.py
+++ b/creek-tools/tests/test_author_desk.py
@@ -1,0 +1,158 @@
+"""Smoke tests for the Creek Writing Desk author skeleton (FEAT-041, #455).
+
+Every surface here is a typed *stub*: the conductor drives stub specialists,
+a stub voice agent, and a stub reflection node, returning a shaped
+:class:`~creek.author.AuthoredDraft`. These tests pin the *shapes* and the
+orchestration contract — not real retrieval, synthesis, or judging (those are
+issues #460/#463/#467/#471).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from creek.config import LLMConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from creek.author import (
+    AuthoredDraft,
+    AuthorLLMClient,
+    Conductor,
+    EvidenceBundle,
+    build_default_conductor,
+    run_author,
+)
+from creek.author.agents import (
+    GraphSpecialist,
+    OntologySpecialist,
+    RetrievalSpecialist,
+)
+from creek.author.models import EvidenceClaim
+from creek.author.reflection import ReflectionNode
+from creek.author.voice import VoiceAgent
+
+
+def test_run_author_returns_shaped_draft(tmp_path: Path) -> None:
+    """``run_author`` returns an ``AuthoredDraft`` with mock provenance + verdict."""
+    draft = run_author(medium="research", query="What is F6 Pluralism?", vault=tmp_path)
+
+    assert isinstance(draft, AuthoredDraft)
+    assert draft.medium == "research"
+    assert draft.body.strip()
+    assert draft.provenance  # non-empty mock provenance
+    assert draft.verdict in {"PASS", "REVISE", "ESCALATE"}
+    assert draft.rounds >= 1
+
+
+@pytest.mark.parametrize(
+    "specialist",
+    [GraphSpecialist(), RetrievalSpecialist(), OntologySpecialist()],
+)
+def test_each_specialist_returns_structured_evidence(
+    specialist: GraphSpecialist | RetrievalSpecialist | OntologySpecialist,
+    tmp_path: Path,
+) -> None:
+    """Each stub specialist returns structured evidence, never free prose."""
+    bundle = specialist.gather("q", tmp_path)
+
+    assert isinstance(bundle, EvidenceBundle)
+    assert bundle.claims
+    for claim in bundle.claims:
+        assert claim.claim.strip()
+        assert claim.source_fragments  # claims are traced to fragments
+
+
+def test_conductor_plan_lists_pipeline() -> None:
+    """``plan`` names the specialist steps followed by synthesize/voice/reflect."""
+    conductor = build_default_conductor(max_rounds=3)
+
+    assert conductor.plan() == [
+        "graph",
+        "retrieval",
+        "ontology",
+        "synthesize",
+        "voice",
+        "reflect",
+    ]
+
+
+def test_voice_stub_renders_body_from_evidence(tmp_path: Path) -> None:
+    """The stub voice agent renders a non-empty body from the evidence."""
+    evidence = GraphSpecialist().gather("q", tmp_path)
+
+    body = VoiceAgent().render("q", evidence)
+
+    assert body.strip()
+
+
+def test_reflection_passes_grounded_and_escalates_ungrounded(tmp_path: Path) -> None:
+    """The stub reflection node passes grounded drafts and escalates empty ones."""
+    evidence = GraphSpecialist().gather("q", tmp_path)
+
+    assert ReflectionNode().review("a real body", evidence) == "PASS"
+    assert ReflectionNode().review("   ", evidence) == "ESCALATE"
+    assert ReflectionNode().review("body", EvidenceBundle()) == "ESCALATE"
+
+
+def test_conductor_respects_max_rounds(tmp_path: Path) -> None:
+    """A REVISE verdict loops up to ``max_rounds`` then returns that verdict."""
+    revising = MagicMock()
+    revising.review.return_value = "REVISE"
+    conductor = Conductor(
+        specialists=[GraphSpecialist()],
+        voice=VoiceAgent(),
+        reflection=revising,
+        max_rounds=2,
+    )
+
+    draft = conductor.run(medium="research", query="q", vault=tmp_path)
+
+    assert draft.rounds == 2
+    assert draft.verdict == "REVISE"
+    assert revising.review.call_count == 2
+
+
+def test_evidence_bundle_dedups_source_fragments() -> None:
+    """``all_source_fragments`` is an order-preserving, deduplicated union."""
+    bundle = EvidenceBundle(
+        claims=[
+            EvidenceClaim(claim="a", source_fragments=["f1", "f2"]),
+            EvidenceClaim(claim="b", source_fragments=["f2", "f3"]),
+        ]
+    )
+
+    assert bundle.all_source_fragments() == ["f1", "f2", "f3"]
+
+
+def test_run_author_rejects_unknown_medium(tmp_path: Path) -> None:
+    """Only the ``research`` medium is wired; others raise a clear error."""
+    with pytest.raises(ValueError, match="research"):
+        run_author(medium="book-report", query="q", vault=tmp_path)
+
+
+def test_author_llm_client_delegates_to_provider() -> None:
+    """The thin client wrapper delegates to the provider with no live network."""
+    provider = MagicMock()
+    completion = MagicMock()
+    completion.text = "hello"
+    provider.call_with_metadata.return_value = completion
+
+    client = AuthorLLMClient(provider)
+    result = client.complete("prompt", max_tokens=10)
+
+    assert result == "hello"
+    provider.call_with_metadata.assert_called_once_with("prompt", max_tokens=10)
+
+
+def test_author_llm_client_from_config_builds_provider() -> None:
+    """``from_config`` constructs a provider from config (model id from config)."""
+    with patch("creek.author.client.AnthropicProvider") as mock_provider_cls:
+        client = AuthorLLMClient.from_config(LLMConfig(provider="anthropic"))
+
+    assert isinstance(client, AuthorLLMClient)
+    mock_provider_cls.assert_called_once()

--- a/creek-tools/tests/test_cli_author.py
+++ b/creek-tools/tests/test_cli_author.py
@@ -1,0 +1,94 @@
+"""CLI tests for ``creek author`` (FEAT-041 Writing Desk skeleton, #455)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from creek.cli import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+def _vault(tmp_path: Path) -> Path:
+    """Create and return an empty vault directory under *tmp_path*."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    return vault
+
+
+def test_author_dry_run_prints_plan_and_evidence(tmp_path: Path) -> None:
+    """``--dry-run`` prints the pipeline plan and a stub evidence summary."""
+    result = runner.invoke(
+        app,
+        [
+            "author",
+            "--medium",
+            "research",
+            "--query",
+            "What is F6 Pluralism?",
+            "--vault",
+            str(_vault(tmp_path)),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "PLAN:" in result.output
+    assert "graph" in result.output
+    assert "reflect" in result.output
+    assert "EVIDENCE (stub):" in result.output
+    assert "claims" in result.output
+    assert "source_fragments" in result.output
+
+
+def test_author_run_prints_verdict(tmp_path: Path) -> None:
+    """A full (stub) run prints the verdict and a body."""
+    result = runner.invoke(
+        app,
+        ["author", "--query", "q", "--vault", str(_vault(tmp_path))],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "verdict=" in result.output
+
+
+def test_author_rejects_unknown_medium(tmp_path: Path) -> None:
+    """An unsupported medium exits non-zero with a clear message."""
+    result = runner.invoke(
+        app,
+        [
+            "author",
+            "--medium",
+            "book-report",
+            "--query",
+            "q",
+            "--vault",
+            str(_vault(tmp_path)),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "research" in result.output
+
+
+def test_author_max_rounds_out_of_range(tmp_path: Path) -> None:
+    """``--max-rounds`` outside [1, 10] is rejected by the CLI."""
+    result = runner.invoke(
+        app,
+        [
+            "author",
+            "--query",
+            "q",
+            "--vault",
+            str(_vault(tmp_path)),
+            "--max-rounds",
+            "0",
+        ],
+    )
+
+    assert result.exit_code != 0


### PR DESCRIPTION
## Summary

Wires the **Creek Writing Desk** end-to-end with typed stubs (FEAT-041 epic #451) — the tracer-skeleton for EPIC_02. A new `creek/author/` package and `creek author` command run the full desk pipeline against a vault and return a shaped (mock) draft, demoable from day one.

**Pipeline (all stubs, real seams):**
- **Conductor** (`conductor.py`) orchestrates: `graph → retrieval → ontology → synthesize → voice → reflect`, looping on a `REVISE` verdict up to `author.max_author_rounds` (new config, default **3**, bounds **[1,10]**).
- **Specialists** (`agents.py`) — stub Graph / Retrieval / Ontology agents return **structured** `EvidenceClaim`s (claim + `source_fragments`), never free prose.
- **Voice agent** (`voice.py`) + **Reflection node** (`reflection.py`) — stubs returning a mock body and a bounded `PASS | REVISE | ESCALATE` verdict.
- **`AuthoredDraft`** (`models.py`) carries mock `provenance` reusing the compile layer's `ProvenanceEntry`, plus the verdict and round count.
- **`AuthorLLMClient`** (`client.py`) — the desk's single, mockable seam onto the Anthropic SDK; model id comes from the `llm` config, never hard-coded. No live network in unit tests.

**CLI:** `creek author --medium research --query "..." [--vault P] [--dry-run] [--max-rounds N]`
- `--dry-run` prints the plan + stub evidence summary; a full run prints `verdict=… rounds=… provenance=…` and the body.
- Only the `research` medium is wired; others exit non-zero with a clear message. `--max-rounds` is range-checked [1,10] by Typer.

**Scope fence respected:** every specialist/voice/reflection body is a stub returning typed mock data — real retrieval/synthesis/voicing/judging are #460/#463/#467/#471/#473. No existing CLI surface changed.

Demo:
```
$ creek author --medium research --query "What is F6 Pluralism?" --vault ./v --dry-run
PLAN: graph → retrieval → ontology → synthesize → voice → reflect
EVIDENCE (stub): 3 claims, 3 source_fragments
$ creek author --query "What is F6 Pluralism?" --vault ./v
medium=research verdict=PASS rounds=1 provenance=3
# What is F6 Pluralism? (stub draft)
- Graph neighbours relevant to 'What is F6 Pluralism?' (stub).
...
```

## Test plan

- `tests/test_author_desk.py` (smoke): `run_author` returns a shaped `AuthoredDraft` (non-empty provenance, valid verdict); each specialist returns structured evidence; `plan()` lists the pipeline; voice renders a body; reflection passes-grounded / escalates-empty; **conductor honours `max_rounds`** (a `REVISE`-returning mock loops exactly N times); `EvidenceBundle.all_source_fragments` dedups; unknown medium raises `ValueError`; `AuthorLLMClient` (both `complete` and `from_config`) is exercised with a **mocked** provider — no network.
- `tests/test_cli_author.py`: dry-run prints PLAN + EVIDENCE; full run prints the verdict; unknown medium and out-of-range `--max-rounds` exit non-zero.
- Gates: `./scripts/check-all.sh` → **12/12 green**, aggregate branch coverage **93.68%**, `4813 passed`. MyPy strict, ruff, interrogate (≥95% docstrings), complexity ≤10 all clean — no bypasses.

Refs #451
Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)
