### PR TITLE
feat(mediums): essay medium contract + rubric (#461)

### DIFF
--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -33,9 +33,9 @@ if TYPE_CHECKING:
     from creek.author.client import AuthorLLMClient
     from creek.models import MediumContract
 
-#: Mediums the conductor will run. ``research`` and ``chat`` are wired; the
-#: remaining mediums (essay/research-piece/book-report/how-to) arrive later.
-SUPPORTED_MEDIUMS: frozenset[str] = frozenset({"research", "chat"})
+#: Mediums the conductor will run. ``research``/``chat``/``essay`` are wired;
+#: the remaining mediums (research-piece/book-report/how-to) arrive later.
+SUPPORTED_MEDIUMS: frozenset[str] = frozenset({"research", "chat", "essay"})
 
 #: Fixed pipeline steps that follow the specialist roster, in order.
 _DOWNSTREAM_STEPS: tuple[str, ...] = ("synthesize", "voice", "reflect")

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -13,9 +13,9 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from creek.compile.provenance import ProvenanceEntry
 
-#: Mediums the author desk can produce. ``research`` and ``chat`` are wired;
-#: the others (essay/research-piece/book-report/how-to) arrive in later issues.
-Medium = Literal["research", "chat"]
+#: Mediums the author desk can produce. ``research``/``chat``/``essay`` are
+#: wired; the others (research-piece/book-report/how-to) arrive in later issues.
+Medium = Literal["research", "chat", "essay"]
 
 #: The reflection node's bounded verdict over a drafted body.
 ReflectionVerdict = Literal["PASS", "REVISE", "ESCALATE"]

--- a/creek-tools/creek/templates/skills/mediums/essay.MEDIUM.md
+++ b/creek-tools/creek/templates/skills/mediums/essay.MEDIUM.md
@@ -58,5 +58,10 @@ The reflection node weights **voice fidelity** highest (0.45) — register drift
 AI tells, or phase-inappropriate tone are the cardinal failures here. Narrative
 coherence is judged as part of voice fidelity (does the piece hold together and
 *turn*?). Ontological accuracy (0.2) and privacy compliance (0.15) follow;
-citation completeness is light (0.1). A voice-broken or incoherent draft →
-`REVISE`; exhausting the round budget → `ESCALATE`.
+citation completeness is light (0.1). The two small weights still bind:
+**paradox preservation** (0.05) means contradictions surfaced from
+`10-Liminal/` are kept, not tidied away; **attribution correctness** (0.05)
+means any borrowed idea is credited to its `11-Other-Authors/` source and the
+owner's voice never claims a `reference`-weighted idea as its own. A
+voice-broken or incoherent draft → `REVISE`; exhausting the round budget →
+`ESCALATE`.

--- a/creek-tools/creek/templates/skills/mediums/essay.MEDIUM.md
+++ b/creek-tools/creek/templates/skills/mediums/essay.MEDIUM.md
@@ -1,0 +1,62 @@
+---
+medium: essay
+structure:
+  - hook
+  - exploration
+  - turn
+  - landing
+specialist_weights:
+  voice: 0.35
+  retrieval: 0.35
+  graph: 0.15
+  ontology: 0.15
+citation_norm: light
+default_privacy_tier: open
+reflection_rubric:
+  voice_fidelity: 0.45
+  ontological_accuracy: 0.2
+  privacy_compliance: 0.15
+  citation_completeness: 0.1
+  paradox_preservation: 0.05
+  attribution_correctness: 0.05
+---
+
+# essay.MEDIUM.md
+
+**Medium:** `essay`
+**Budget:** ≤1500 tokens
+**Loaded by:** the Creek Writing Desk Conductor (FEAT-041)
+
+## What the `essay` medium is for
+
+Long-form, thought-provoking, Substack-style writing in the owner's voice. Where
+`research` answers a question, an essay *thinks* — it opens a tension, explores
+it, turns on a realization, and lands somewhere earned. Voice and coherence
+matter more than citation density.
+
+## Structure
+
+Move through **hook → exploration → turn → landing.** Open with a concrete hook,
+explore the tension honestly, let it *turn* on an insight, and land on an earned
+(often unresolved) close. No section headers — an essay reads as one piece.
+
+## Specialist weighting
+
+Voice and Retrieval are weighted highest (0.35 each): the essay must sound like
+the owner and draw on their own fragments for texture. Graph (0.15) and Ontology
+(0.15) keep the ontology language accurate without dominating — an essay is not
+an encyclopedia entry.
+
+## Citation norm — `light`
+
+Cite only where a claim genuinely leans on a fragment or the ontology. An essay
+earns trust through voice and coherence, not footnote density.
+
+## Reflection rubric (§8)
+
+The reflection node weights **voice fidelity** highest (0.45) — register drift,
+AI tells, or phase-inappropriate tone are the cardinal failures here. Narrative
+coherence is judged as part of voice fidelity (does the piece hold together and
+*turn*?). Ontological accuracy (0.2) and privacy compliance (0.15) follow;
+citation completeness is light (0.1). A voice-broken or incoherent draft →
+`REVISE`; exhausting the round budget → `ESCALATE`.

--- a/creek-tools/tests/test_essay_medium.py
+++ b/creek-tools/tests/test_essay_medium.py
@@ -1,0 +1,52 @@
+"""Tests for the essay medium contract (FEAT-041 #461).
+
+``essay`` is the third concrete medium — long-form, voiced Substack-style
+writing. Its contract weights Voice + Retrieval and a reflection rubric that
+prioritizes voice fidelity. These tests reuse the #457 conformance harness.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.author import (
+    assert_contract_conformant,
+    load_medium_contract,
+    run_author,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_essay_contract_loads_and_conforms(tmp_path: Path) -> None:
+    """The essay contract loads and passes the conformance harness."""
+    contract = load_medium_contract("essay", tmp_path)
+
+    assert_contract_conformant(contract)
+    assert contract.medium == "essay"
+    assert contract.structure  # non-empty
+
+
+def test_essay_rubric_prioritises_voice_fidelity(tmp_path: Path) -> None:
+    """The essay reflection rubric weights voice fidelity highest (SPEC §8)."""
+    rubric = load_medium_contract("essay", tmp_path).reflection_rubric
+
+    assert rubric["voice_fidelity"] == max(rubric.values())
+
+
+def test_essay_weights_voice_and_retrieval(tmp_path: Path) -> None:
+    """Essay weights Voice and Retrieval at least as high as Graph/Ontology."""
+    weights = load_medium_contract("essay", tmp_path).specialist_weights
+
+    assert weights["voice"] >= weights["graph"]
+    assert weights["retrieval"] >= weights["ontology"]
+
+
+def test_run_author_essay_returns_draft(tmp_path: Path) -> None:
+    """``run_author(medium='essay')`` returns a voiced draft (tracer invariant)."""
+    draft = run_author(medium="essay", query="leverage vs. presence", vault=tmp_path)
+
+    assert draft.medium == "essay"
+    assert draft.body.strip()
+    assert draft.verdict in {"PASS", "REVISE", "ESCALATE"}


### PR DESCRIPTION
## Summary

Adds the third concrete medium, **`essay`** — long-form, thought-provoking, voiced Substack-style writing (FEAT-041 epic #453). Contract-only: it reuses the #457 conformance harness and the contract-driven Conductor, with no desk-internal logic changed.

- **`essay.MEDIUM.md`** (`templates/skills/mediums/`): a `hook → exploration → turn → landing` structure; **Voice + Retrieval** weighted highest (0.35 each); `citation_norm: light`; and a reflection rubric that weights **voice fidelity** highest (0.45 — the max), with narrative coherence judged as part of voice fidelity, per SPEC §8. 286 words, within the ≤1500 budget.
- `Medium` literal and `SUPPORTED_MEDIUMS` gain `essay` (comments updated to list all wired mediums).

Demo:
```python
c = load_medium_contract("essay", vault)
assert_contract_conformant(c)                                   # passes the harness
assert c.reflection_rubric["voice_fidelity"] == max(c.reflection_rubric.values())  # True
run_author(medium="essay", query="leverage vs. presence", vault=vault)  # → medium=essay, verdict PASS
```

## Test plan

`tests/test_essay_medium.py` (4 tests): the essay contract loads and **passes the conformance harness**; its reflection rubric weights `voice_fidelity` highest; Voice/Retrieval are weighted ≥ Graph/Ontology; and `run_author(medium="essay")` returns a draft with `medium == "essay"`. The research/chat/MCP/author suites stay green (the validator message now lists all three wired mediums).

Gates: `./scripts/check-all.sh` → **12/12 green** first-pass, aggregate branch coverage ≥90%. MyPy strict, ruff, interrogate, complexity — no bypasses.

Refs #453
Closes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)
