### PR TITLE
feat(crawdad): /crawdad ask + draft route to the author desk; ai-as-user save (#464)

### DIFF
--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -68,6 +68,7 @@ CRAWDAD_COMMANDS: tuple[str, ...] = (
     "checkin",
     "surface",
     "draft",
+    "ask",
     "save",
     "register",
     "workflow",
@@ -77,7 +78,8 @@ _COMMAND_DESCRIPTIONS: dict[str, str] = {
     "reflect": "Open reflective conversation mode (FEAT-015 loop).",
     "checkin": "Wavelength check-in — read the current phase + dosage state.",
     "surface": "Surface paradoxes, liminal content, or emerging themes.",
-    "draft": "Draft an essay on a topic (routes through creek.mine + creek.draft).",
+    "draft": "Draft an essay on a topic (routes through creek.author, essay medium).",
+    "ask": "Ask a question; get a cited, voiced answer (routes through creek.author).",
     "save": "File the supplied content back to the vault via creek.save.",
     "register": "Switch the active voice register (FEAT-029).",
     "workflow": "List or run named workflows (ADAPT-003).",
@@ -165,7 +167,7 @@ async def handle_surface(replier: Replier, *, loop_runner: LoopRunner) -> None:
 async def handle_draft(
     replier: Replier, *, topic: str, loop_runner: LoopRunner
 ) -> None:
-    """``/crawdad draft <topic>`` — mine + draft on the supplied topic."""
+    """``/crawdad draft <topic>`` — author an essay on the supplied topic."""
     cleaned = topic.strip()
     if not cleaned:
         await replier(
@@ -175,9 +177,37 @@ async def handle_draft(
         return
     prompt = (
         f"Draft an essay on the following topic: {cleaned}.\n\n"
-        "Route through creek.mine to surface relevant seeds first, then "
-        "creek.draft to generate the essay. Voice fidelity is owned by "
-        "creek.draft's skill stack — don't re-draft inline."
+        "Call creek.author with medium: essay to generate the essay in my "
+        "voice. Voice fidelity is owned by creek.author's skill stack — "
+        "don't re-draft inline. If I choose to keep the result, file it via "
+        "creek.save with target ai-as-user into 11-Other-Authors/ai-as-user/ "
+        "(AI-authored attribution: author=ai, representativeness=endorsed, "
+        "voice_weight=0.0)."
+    )
+    reply = await loop_runner(prompt)
+    await replier(reply)
+
+
+async def handle_ask(
+    replier: Replier, *, question: str, loop_runner: LoopRunner
+) -> None:
+    """``/crawdad ask <question>`` — answer the question, cited and voiced."""
+    cleaned = question.strip()
+    if not cleaned:
+        await replier(
+            "I need a question to answer. Try `/crawdad ask <question>` — for "
+            "example, `/crawdad ask how do phase transitions show up in my "
+            "writing?`."
+        )
+        return
+    prompt = (
+        f"Answer the following question: {cleaned}.\n\n"
+        "Call creek.author with medium: research to produce a cited answer "
+        "grounded in my vault and voiced in my register. Return that answer. "
+        "If I choose to keep it, file it via creek.save with target "
+        "ai-as-user into 11-Other-Authors/ai-as-user/ (AI-authored "
+        "attribution: author=ai, representativeness=endorsed, "
+        "voice_weight=0.0)."
     )
     reply = await loop_runner(prompt)
     await replier(reply)
@@ -373,6 +403,7 @@ def register(
     _register_checkin(tree, loop_runner=loop_runner)
     _register_surface(tree, loop_runner=loop_runner)
     _register_draft(tree, loop_runner=loop_runner)
+    _register_ask(tree, loop_runner=loop_runner)
     _register_save(tree, loop_runner=loop_runner)
     _register_register(tree, register_switcher=register_switcher)
     _register_workflow(
@@ -426,6 +457,24 @@ def _register_draft(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
         await interaction.response.defer()
         await handle_draft(
             interaction.followup.send, topic=topic, loop_runner=loop_runner
+        )
+
+
+def _register_ask(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
+    """Wire the ``/crawdad ask`` Discord callback onto *tree*."""
+
+    @tree.command(name="ask", description=_COMMAND_DESCRIPTIONS["ask"])
+    async def _callback(interaction: Any, question: str) -> None:
+        """Discord callback for ``/crawdad ask <question>`` (deferred).
+
+        ``question`` has no default value so Discord's autocomplete UI
+        marks the parameter as required and disables submit until the
+        user fills it in. The runtime empty-string guard in
+        :func:`handle_ask` stays as defense-in-depth.
+        """
+        await interaction.response.defer()
+        await handle_ask(
+            interaction.followup.send, question=question, loop_runner=loop_runner
         )
 
 

--- a/crawdad/tests/test_bot.py
+++ b/crawdad/tests/test_bot.py
@@ -655,7 +655,7 @@ async def test_handle_message_without_loop_components_uses_stub_reply(
 def test_crawdad_client_registers_slash_commands_when_loop_runner_provided(
     config: CrawDadConfig, session_state: SessionState
 ) -> None:
-    """FEAT-016: providing a ``loop_runner`` registers the six /crawdad commands."""
+    """FEAT-016: providing a ``loop_runner`` registers the /crawdad commands."""
     from crawdad.bot import CrawDadClient
     from crawdad.slash_commands import CRAWDAD_COMMANDS
 

--- a/crawdad/tests/test_slash_commands.py
+++ b/crawdad/tests/test_slash_commands.py
@@ -8,6 +8,7 @@ import pytest
 
 from crawdad.slash_commands import (
     CRAWDAD_COMMANDS,
+    handle_ask,
     handle_checkin,
     handle_draft,
     handle_help,
@@ -42,6 +43,7 @@ def test_crawdad_commands_lists_the_documented_names() -> None:
         "checkin",
         "surface",
         "draft",
+        "ask",
         "save",
         "register",
         "workflow",
@@ -95,6 +97,35 @@ async def test_handle_draft_passes_topic_to_loop() -> None:
     assert "phase transitions" in replier.sent[0]
 
 
+async def test_handle_draft_routes_through_author_essay() -> None:
+    """``/crawdad draft`` routes through creek.author with the essay medium."""
+    replier = _FakeReplier()
+
+    await handle_draft(
+        replier, topic="phase transitions", loop_runner=_fake_loop_runner
+    )
+
+    body = replier.sent[0]
+    assert "creek.author" in body
+    assert "essay" in body
+    # The old creek.mine / creek.draft routing is gone.
+    assert "creek.mine" not in body
+    assert "creek.draft" not in body
+
+
+async def test_handle_draft_includes_save_attribution_path() -> None:
+    """``/crawdad draft`` names the keep→save path to ai-as-user."""
+    replier = _FakeReplier()
+
+    await handle_draft(
+        replier, topic="phase transitions", loop_runner=_fake_loop_runner
+    )
+
+    body = replier.sent[0]
+    assert "creek.save" in body
+    assert "ai-as-user" in body
+
+
 async def test_handle_draft_refuses_empty_topic() -> None:
     """An empty draft topic gets a help reply, not a stack trace."""
     replier = _FakeReplier()
@@ -103,6 +134,56 @@ async def test_handle_draft_refuses_empty_topic() -> None:
 
     assert len(replier.sent) == 1
     assert "topic" in replier.sent[0].lower()
+
+
+async def test_handle_ask_passes_question_to_author_research() -> None:
+    """``/crawdad ask <question>`` routes via creek.author research medium."""
+    replier = _FakeReplier()
+
+    await handle_ask(
+        replier,
+        question="what is the relationship between drift and emergence?",
+        loop_runner=_fake_loop_runner,
+    )
+
+    assert len(replier.sent) == 1
+    body = replier.sent[0]
+    assert "what is the relationship between drift and emergence?" in body
+    assert "creek.author" in body
+    assert "research" in body
+
+
+async def test_handle_ask_includes_save_attribution_path() -> None:
+    """``/crawdad ask`` names the keep→save path to ai-as-user."""
+    replier = _FakeReplier()
+
+    await handle_ask(
+        replier,
+        question="why does the creek meander?",
+        loop_runner=_fake_loop_runner,
+    )
+
+    body = replier.sent[0]
+    assert "creek.save" in body
+    assert "ai-as-user" in body
+
+
+async def test_handle_ask_refuses_empty_question() -> None:
+    """A blank question gets a help reply and never calls the loop."""
+    loop_calls = 0
+
+    async def _counting_loop(_message: str) -> str:
+        nonlocal loop_calls
+        loop_calls += 1
+        return "should not be reached"
+
+    replier = _FakeReplier()
+
+    await handle_ask(replier, question="   ", loop_runner=_counting_loop)
+
+    assert loop_calls == 0
+    assert len(replier.sent) == 1
+    assert "question" in replier.sent[0].lower()
 
 
 async def test_handle_save_passes_content_to_loop() -> None:
@@ -360,7 +441,7 @@ async def test_handle_workflow_unknown_action_returns_help() -> None:
 
 
 async def test_handle_help_lists_every_command() -> None:
-    """``/crawdad help`` (or any unknown subcommand) lists the six commands."""
+    """``/crawdad help`` (or any unknown subcommand) lists every command."""
     replier = _FakeReplier()
 
     await handle_help(replier)
@@ -368,6 +449,7 @@ async def test_handle_help_lists_every_command() -> None:
     body = replier.sent[0]
     for name in CRAWDAD_COMMANDS:
         assert name in body
+    assert "ask" in body
 
 
 async def test_handle_workflow_list_skips_loop_runner() -> None:
@@ -408,7 +490,7 @@ class _FakeTree:
 
 
 def test_register_wires_every_command_onto_tree() -> None:
-    """``register`` adds all six commands to a discord ``CommandTree``-like object."""
+    """``register`` adds every command to a discord ``CommandTree``-like object."""
     tree = _FakeTree()
 
     register(tree, loop_runner=_fake_loop_runner)
@@ -465,6 +547,7 @@ class _FakeInteraction:
         ("checkin", {}),
         ("surface", {}),
         ("draft", {"topic": "phase transitions"}),
+        ("ask", {"question": "what is emergence?"}),
         ("save", {"content": "a fragment to file"}),
     ],
 )

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2502,8 +2502,9 @@ def draft(
 
 
 _SAVE_TARGET_HELP = (
-    "Destination type: thread, eddy, praxis, paradox, unnamed, or draft. "
-    "Paradox always routes to 10-Liminal/Paradoxes/ regardless of other inputs."
+    "Destination type: thread, eddy, praxis, paradox, unnamed, draft, or "
+    "ai-as-user. Paradox always routes to 10-Liminal/Paradoxes/ regardless of "
+    "other inputs; ai-as-user files kept AI output to 11-Other-Authors/ai-as-user/."
 )
 _SAVE_TIER_HELP = (
     "Privacy tier (open|personal|intimate). Required when stdin is the body "

--- a/creek-tools/creek/save/router.py
+++ b/creek-tools/creek/save/router.py
@@ -26,7 +26,13 @@ __all__ = [
 
 
 class SaveTarget(StrEnum):
-    """The six target types ``creek save --target`` accepts."""
+    """The target types ``creek save --target`` accepts.
+
+    ``ai-as-user`` (FEAT-041 §7) is special: it files AI-authored output the
+    owner chose to keep into ``11-Other-Authors/ai-as-user/`` as a real,
+    AI-attributed fragment, so the Retrieval specialist can read it back
+    without it ever counting as the owner's own voice.
+    """
 
     THREAD = "thread"
     EDDY = "eddy"
@@ -34,6 +40,7 @@ class SaveTarget(StrEnum):
     PARADOX = "paradox"
     UNNAMED = "unnamed"
     DRAFT = "draft"
+    AI_AS_USER = "ai-as-user"
 
 
 TARGET_SUBDIRS: dict[SaveTarget, tuple[str, ...]] = {
@@ -43,6 +50,7 @@ TARGET_SUBDIRS: dict[SaveTarget, tuple[str, ...]] = {
     SaveTarget.PARADOX: ("10-Liminal", "Paradoxes"),
     SaveTarget.UNNAMED: ("10-Liminal", "Unnamed"),
     SaveTarget.DRAFT: ("07-Voice", "Drafts"),
+    SaveTarget.AI_AS_USER: ("11-Other-Authors", "ai-as-user"),
 }
 """Canonical mapping of save targets to vault subdirectories.
 

--- a/creek-tools/creek/save/writer.py
+++ b/creek-tools/creek/save/writer.py
@@ -26,7 +26,16 @@ from typing import TYPE_CHECKING, Any
 import frontmatter
 
 from creek.classify.privacy_filter import pre_save_filter
-from creek.models import Eddy, Praxis, PrivacyTier, Thread
+from creek.models import (
+    Authorship,
+    Eddy,
+    Fragment,
+    FragmentSource,
+    Praxis,
+    PrivacyTier,
+    SourcePlatform,
+    Thread,
+)
 from creek.save._slug import slugify_filename
 from creek.save.router import SaveTarget, target_directory
 
@@ -126,7 +135,9 @@ def _compose_metadata(
 ) -> dict[str, Any]:
     """Build the frontmatter dict for *request*."""
     metadata = _shape_for_target(request)
-    metadata["type"] = request.target.value
+    # Most targets are typed by their target name; ``ai-as-user`` shapes a real
+    # fragment and supplies its own ``type: fragment`` — don't clobber it.
+    metadata.setdefault("type", request.target.value)
     metadata["privacy_tier"] = effective_tier.value
     metadata["saved_from"] = _saved_from_block(
         request,
@@ -150,10 +161,36 @@ def _shape_for_target(request: SaveRequest) -> dict[str, Any]:
         return Eddy(title=title).model_dump(mode="json")
     if request.target == SaveTarget.PRAXIS:
         return Praxis(title=title).model_dump(mode="json")
+    if request.target == SaveTarget.AI_AS_USER:
+        return _shape_ai_as_user_fragment(title)
     return {
         "title": title,
         "tags": [request.target.value],
     }
+
+
+def _shape_ai_as_user_fragment(title: str) -> dict[str, Any]:
+    """Shape kept AI output as an AI-attributed, voice-neutral fragment.
+
+    The note is a real :class:`~creek.models.Fragment` (round-trippable through
+    the vault reader so the Retrieval specialist can cite it) carrying the
+    FEAT-041 §7 attribution: ``author=ai`` from the ``ai-as-user`` other-author
+    folder, ``voice_weight=0.0`` so it never colours the owner's generated
+    voice, and ``representativeness=endorsed`` because the owner kept it on
+    purpose.
+    """
+    slug = slugify_filename(title, max_length=_MAX_FILENAME_LENGTH) or "untitled"
+    return Fragment(
+        id=f"{SaveTarget.AI_AS_USER.value}-{slug}",
+        title=title,
+        source=FragmentSource(
+            platform=SourcePlatform.CLAUDE,
+            author=Authorship.AI,
+            author_slug=SaveTarget.AI_AS_USER.value,
+        ),
+        voice_weight=0.0,
+        representativeness="endorsed",
+    ).model_dump(mode="json")
 
 
 def _saved_from_block(

--- a/creek-tools/tests/test_save.py
+++ b/creek-tools/tests/test_save.py
@@ -92,7 +92,11 @@ def test_save_writes_note_under_correct_directory(
     assert path.parent == expected_dir
     assert path.suffix == ".md"
     post = frontmatter.load(str(path))
-    assert post["type"] == target.value
+    # AI-as-user saves are real fragments (so the retrieval corpus can read
+    # them back), not notes typed by their target name — see the dedicated
+    # ``test_ai_as_user_*`` cases below.
+    expected_type = "fragment" if target is SaveTarget.AI_AS_USER else target.value
+    assert post["type"] == expected_type
     assert post["title"]
     saved_from = post["saved_from"]
     assert saved_from["source_kind"] == "manual"
@@ -128,6 +132,46 @@ def test_praxis_save_carries_praxis_model_fields(vault: Path) -> None:
     assert post["type"] == "praxis"
     assert post["praxis_type"] == "insight"
     assert post["status"] == "proposed"
+
+
+# ---- AI-as-user (FEAT-041 §7) ----
+
+
+def test_ai_as_user_save_lands_attributed_fragment(vault: Path) -> None:
+    """An ``ai-as-user`` save files an AI-attributed fragment under 11-Other-Authors."""
+    path = save_to_vault(
+        _make_request(SaveTarget.AI_AS_USER, title="On leverage and luck"),
+        vault_path=vault,
+    )
+    assert path.parent == vault / "11-Other-Authors" / "ai-as-user"
+    post = frontmatter.load(str(path))
+    # The note is a real fragment so the Retrieval specialist can read it back.
+    assert post["type"] == "fragment"
+    assert post["source"]["author"] == "ai"
+    assert post["source"]["author_slug"] == "ai-as-user"
+    # Borrowed AI voice: it must never bleed into the owner's generated voice,
+    # but it is an endorsed stand-in for the owner's views (kept on purpose).
+    assert post["voice_weight"] == 0.0
+    assert post["representativeness"] == "endorsed"
+
+
+def test_ai_as_user_save_round_trips_through_the_fragment_reader(vault: Path) -> None:
+    """The saved note loads as a valid Fragment via the vault reader."""
+    from creek.vault.reader import try_load_fragment
+
+    path = save_to_vault(
+        _make_request(SaveTarget.AI_AS_USER, title="Compounding attention"),
+        vault_path=vault,
+    )
+
+    record = try_load_fragment(path)
+
+    assert record is not None
+    fragment, _body, _raw = record
+    assert fragment.source.author == "ai"
+    assert fragment.source.author_slug == "ai-as-user"
+    assert fragment.voice_weight == 0.0
+    assert fragment.representativeness == "endorsed"
 
 
 # ---- Paradox routing regression ----
@@ -311,7 +355,7 @@ def _scaffold_vault(root: Path) -> Path:
 
 
 def test_cli_save_help_lists_targets() -> None:
-    """``creek save --help`` advertises the six target types."""
+    """``creek save --help`` advertises every target type."""
     result = runner.invoke(app, ["save", "--help"])
     assert result.exit_code == 0
     for target in SaveTarget:


### PR DESCRIPTION
## Summary

Wires CrawDad's authoring commands to the FEAT-041 writing desk and gives kept AI output a correct, voice-neutral home in the vault.

**crawdad/**
- New **`/crawdad ask <question>`** routes through the `creek.author` MCP verb (**research** medium) for a cited, voiced answer.
- **`/crawdad draft <topic>`** now routes through `creek.author` (**essay** medium) instead of composing inline via `creek.mine` + `creek.draft`.
- Both command prompts instruct the loop to file *kept* output via `creek.save` with target `ai-as-user` into `11-Other-Authors/ai-as-user/`.

**creek-tools/ (the existing save path)**
- New `SaveTarget.AI_AS_USER` → `11-Other-Authors/ai-as-user/`.
- The save writer shapes that target as a **real, AI-attributed `Fragment`**: `author=ai`, `author_slug=ai-as-user`, `voice_weight=0.0`, `representativeness=endorsed`. It is `type: fragment` and round-trips through the vault reader, so the Retrieval specialist can cite it back — while `voice_weight=0.0` guarantees it never colours the owner's generated voice.
- `_compose_metadata` now `setdefault`s `type` so a target that shapes its own fragment isn't clobbered with the target name (behaviour unchanged for every existing target).
- CLI `--target` help lists the new destination.

### Design notes
- **Why a real fragment, not a typed note?** `try_load_fragment` skips any note whose `type != "fragment"`. For kept AI output to be usable by the Retrieval agent (FEAT-041 §7), the saved note must be a fragment — hence the new target legitimately differs from the `type == target.value` shape of the other targets (the parametrized writer test now asserts `fragment` for this one target, with two dedicated cases covering attribution + reader round-trip).
- **Routing is prompt-level.** CrawDad slash commands drive the Haiku→dispatcher→Sonnet loop; the dispatcher already forwards any advertised MCP verb, so `creek.author` needs no dispatcher change — the handlers name the verb + medium in their prompt.
- The per-`<slug>/` subfolder in the issue text is realised as the standard `YYYY-MM-DD-<slug>.md` filename directly under `ai-as-user/`, consistent with every other save target's flat layout; the reader walks the tree recursively either way.

## Test plan
- **creek-tools** (`./scripts/check-all.sh` → 12/12, 4890 passed): new `test_ai_as_user_save_lands_attributed_fragment` (attribution + location) and `test_ai_as_user_save_round_trips_through_the_fragment_reader` (loads as a valid Fragment); parametrized writer/router tests extended to the new target.
- **crawdad** (`./scripts/check-all.sh` → 7/7, 412 passed): `handle_ask` routes via `creek.author`/research + save→`ai-as-user`, blank-question guard skips the loop; `handle_draft` now routes via `creek.author`/essay and no longer names `creek.mine`/`creek.draft`; command set + help updated to include `ask` (8 commands).

Closes #464
Refs #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)