### PR TITLE
feat(mediums): research-piece medium contract + rubric (#465)

### DIFF
--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -33,9 +33,12 @@ if TYPE_CHECKING:
     from creek.author.client import AuthorLLMClient
     from creek.models import MediumContract
 
-#: Mediums the conductor will run. ``research``/``chat``/``essay`` are wired;
-#: the remaining mediums (research-piece/book-report/how-to) arrive later.
-SUPPORTED_MEDIUMS: frozenset[str] = frozenset({"research", "chat", "essay"})
+#: Mediums the conductor will run. ``research``/``chat``/``essay``/
+#: ``research-piece`` are wired; the remaining mediums (book-report/how-to)
+#: arrive later.
+SUPPORTED_MEDIUMS: frozenset[str] = frozenset(
+    {"research", "chat", "essay", "research-piece"}
+)
 
 #: Fixed pipeline steps that follow the specialist roster, in order.
 _DOWNSTREAM_STEPS: tuple[str, ...] = ("synthesize", "voice", "reflect")

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -13,9 +13,10 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from creek.compile.provenance import ProvenanceEntry
 
-#: Mediums the author desk can produce. ``research``/``chat``/``essay`` are
-#: wired; the others (research-piece/book-report/how-to) arrive in later issues.
-Medium = Literal["research", "chat", "essay"]
+#: Mediums the author desk can produce. ``research``/``chat``/``essay``/
+#: ``research-piece`` are wired; the others (book-report/how-to) arrive in later
+#: issues.
+Medium = Literal["research", "chat", "essay", "research-piece"]
 
 #: The reflection node's bounded verdict over a drafted body.
 ReflectionVerdict = Literal["PASS", "REVISE", "ESCALATE"]

--- a/creek-tools/creek/templates/skills/mediums/research-piece.MEDIUM.md
+++ b/creek-tools/creek/templates/skills/mediums/research-piece.MEDIUM.md
@@ -1,0 +1,72 @@
+---
+medium: research-piece
+structure:
+  - thesis
+  - evidence
+  - analysis
+  - citations
+specialist_weights:
+  retrieval: 0.35
+  ontology: 0.3
+  graph: 0.2
+  voice: 0.15
+citation_norm: every-claim
+default_privacy_tier: open
+reflection_rubric:
+  citation_completeness: 0.35
+  ontological_accuracy: 0.25
+  attribution_correctness: 0.15
+  voice_fidelity: 0.1
+  privacy_compliance: 0.1
+  paradox_preservation: 0.05
+---
+
+# research-piece.MEDIUM.md
+
+**Medium:** `research-piece`
+**Budget:** ≤1500 tokens
+**Loaded by:** the Creek Writing Desk Conductor (FEAT-041)
+
+## What the `research-piece` medium is for
+
+An externally-facing, analytical piece — the kind of grounded long-read that
+goes out under the owner's name to readers who do not share the vault. Where
+`essay` *thinks* in the owner's voice and `research` answers a question
+wiki-style, a research-piece *argues a thesis from evidence* and holds itself to
+a stricter citation bar than either. It may lean on `11-Other-Authors/` source
+material, but only **with explicit attribution** to the borrowed author.
+
+## Structure
+
+Compose in this order: **thesis → evidence → analysis → citations.** State the
+thesis plainly, marshal grounded evidence (the owner's fragments and any
+attributed other-author material), analyse what it means, then list the sources
+every claim rests on.
+
+## Specialist weighting
+
+Retrieval is weighted highest (0.35) — a research-piece lives on the evidence it
+can surface, including attributed other-author fragments. Ontology (0.3) and
+Graph (0.2) keep the canonical taxonomy and neighbouring concepts correct. Voice
+(0.15) is present but subordinate: the register is analytical and externally
+legible, not a personal-voice performance.
+
+## Citation norm — `every-claim`
+
+Every substantive claim must cite its source: the ontology spec under
+`00-Creek-Meta/Ontology/`, an index page, specific `source_fragments`, or — for
+a borrowed idea — its `11-Other-Authors/<slug>/` origin credited by name. An
+uncited claim, or a borrowed claim presented as the owner's own, is a defect.
+
+## Reflection rubric (§8)
+
+The reflection node weights **citation completeness** highest (0.35) — this is
+the cardinal failure mode for an externally-facing piece. **Ontological
+accuracy** (0.25) follows. **Attribution correctness** is weighted unusually
+high here (0.15): any idea drawn from `11-Other-Authors/` must be credited to
+its source, and the owner's voice must never claim a borrowed,
+`reference`-weighted idea as its own. Voice fidelity (0.1) and privacy
+compliance (0.1) round out the body; **paradox preservation** (0.05) keeps
+contradictions surfaced from `10-Liminal/` intact rather than tidied away. An
+uncited or mis-attributed claim → `REVISE`; exhausting the round budget without
+a `PASS` → `ESCALATE`.

--- a/creek-tools/tests/test_research_piece_medium.py
+++ b/creek-tools/tests/test_research_piece_medium.py
@@ -1,0 +1,153 @@
+"""Tests for the research-piece medium contract (FEAT-041 #465).
+
+``research-piece`` is externally-facing analytical writing with heavier
+citation discipline than ``essay``: it may draw on ``11-Other-Authors/`` source
+material *with explicit attribution*. Its contract weights Retrieval + Ontology
+and a reflection rubric that prioritises citation completeness. These tests
+reuse the #457 conformance harness, mirror the essay/research medium tests, and
+pin the key Definition-of-Done invariant: a run over a vault with an
+``11-Other-Authors/<slug>/`` work surfaces a claim attributed to that author.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.author import (
+    SUPPORTED_MEDIUMS,
+    assert_contract_conformant,
+    load_medium_contract,
+    require_supported_medium,
+    run_author,
+)
+from creek.author.conductor import build_default_conductor
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_FM = (
+    '---\ntype: fragment\nid: {id}\ntitle: "{title}"\n'
+    "source:\n  platform: {platform}\n  author: {author}\n{extra}---\n{body}\n"
+)
+
+
+def _write(
+    vault: Path,
+    subdir: str,
+    frag_id: str,
+    title: str,
+    *,
+    body: str = "body",
+    author: str = "self",
+    author_slug: str | None = None,
+    platform: str = "journal",
+) -> None:
+    """Write a minimal fragment markdown file under *subdir* of *vault*.
+
+    Mirrors the ``_write`` helper in ``test_real_agents.py`` so other-author
+    fragments are seeded the established way (``author_slug`` in frontmatter).
+
+    Args:
+        vault: The vault root to write under.
+        subdir: The vault subdirectory (e.g. ``11-Other-Authors/<slug>``).
+        frag_id: The fragment id (also the file stem).
+        title: The fragment title.
+        body: The fragment body text.
+        author: The authorship axis (``self``/``other``/...).
+        author_slug: The ``11-Other-Authors/`` slug, or ``None`` for self.
+        platform: The source platform string.
+    """
+    folder = vault / subdir
+    folder.mkdir(parents=True, exist_ok=True)
+    extra = f"  author_slug: {author_slug}\n" if author_slug else ""
+    (folder / f"{frag_id}.md").write_text(
+        _FM.format(
+            id=frag_id,
+            title=title,
+            platform=platform,
+            author=author,
+            extra=extra,
+            body=body,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_research_piece_contract_loads_and_conforms(tmp_path: Path) -> None:
+    """The research-piece contract loads and passes the conformance harness."""
+    contract = load_medium_contract("research-piece", tmp_path)
+
+    assert_contract_conformant(contract)
+    assert contract.medium == "research-piece"
+    assert contract.structure  # non-empty ordered sections
+
+
+def test_research_piece_citation_is_strictest(tmp_path: Path) -> None:
+    """research-piece cites every claim — stricter than essay's ``light``."""
+    contract = load_medium_contract("research-piece", tmp_path)
+    essay = load_medium_contract("essay", tmp_path)
+
+    assert contract.citation_norm == "every-claim"
+    assert essay.citation_norm == "light"
+
+
+def test_research_piece_rubric_prioritises_citation(tmp_path: Path) -> None:
+    """The rubric weights citation completeness highest (SPEC §8)."""
+    rubric = load_medium_contract("research-piece", tmp_path).reflection_rubric
+
+    assert rubric["citation_completeness"] == max(rubric.values())
+    assert rubric["citation_completeness"] >= rubric["voice_fidelity"]
+
+
+def test_research_piece_weights_retrieval_and_ontology(tmp_path: Path) -> None:
+    """research-piece weights Retrieval/Ontology at least as high as Voice."""
+    weights = load_medium_contract("research-piece", tmp_path).specialist_weights
+
+    assert weights["retrieval"] >= weights["voice"]
+    assert weights["ontology"] >= weights["voice"]
+
+
+def test_require_supported_medium_accepts_research_piece() -> None:
+    """``require_supported_medium`` accepts ``research-piece`` (it is wired)."""
+    assert "research-piece" in SUPPORTED_MEDIUMS
+    assert require_supported_medium("research-piece") == "research-piece"
+
+
+def test_run_author_research_piece_returns_draft(tmp_path: Path) -> None:
+    """``run_author(medium='research-piece')`` returns a draft (no ValueError)."""
+    draft = run_author(
+        medium="research-piece", query="leverage and judgement", vault=tmp_path
+    )
+
+    assert draft.medium == "research-piece"
+    assert draft.body.strip()
+    assert draft.verdict in {"PASS", "REVISE", "ESCALATE"}
+
+
+def test_research_piece_surfaces_attributed_other_author_claim(
+    tmp_path: Path,
+) -> None:
+    """A run over an ``11-Other-Authors/`` work surfaces an attributed claim.
+
+    This is the key Definition-of-Done invariant: research-piece may draw on
+    borrowed source material, and the borrowed claim travels with its
+    ``author_slug`` so downstream citation attributes it correctly.
+    """
+    _write(
+        tmp_path,
+        "11-Other-Authors/naval-ravikant",
+        "frag-naval",
+        "On leverage",
+        body="Leverage is the force multiplier of judgement.",
+        author="other",
+        author_slug="naval-ravikant",
+        platform="markdown",
+    )
+
+    conductor = build_default_conductor(
+        max_rounds=1, contract=load_medium_contract("research-piece", tmp_path)
+    )
+    evidence = conductor.gather_evidence("leverage", tmp_path)
+
+    attributed = [c for c in evidence.claims if c.author_slug == "naval-ravikant"]
+    assert attributed, "expected a claim attributed to naval-ravikant"


### PR DESCRIPTION
## Summary

Adds the externally-facing **`research-piece`** medium (FEAT-041 §5, medium #4) — analytical writing that argues a thesis from evidence and holds a stricter citation bar than `essay`, drawing on `11-Other-Authors/` material only with explicit attribution.

- **New `research-piece.MEDIUM.md` contract:** `citation_norm: every-claim` (vs essay's `light`), retrieval/ontology-weighted specialists, externally-legible voice, `open` privacy default, and a reflection rubric that raises `attribution_correctness` to **0.15** (vs 0.05 elsewhere). Both weight maps sum to 1.0 and pass the contract conformance harness.
- **Wires the medium:** adds `research-piece` to `SUPPORTED_MEDIUMS` (`conductor.py`) and the `Medium` literal (`author/models.py`). Purely additive — existing mediums and all desk internals are untouched.

### Scope note — the "reflection flags missing attribution" half
The DoD lists *"reflection flags a missing attribution."* The `ReflectionNode` is today an explicit **stub owned by #473** — its `review()` only checks non-empty-body + ≥1-claim and never returns `REVISE`. Teaching it to flag missing attribution requires modifying that desk-internal node, which this issue's scope fence ("No desk-internal changes") forbids. So this PR:
- Proves the **attribution-presence** half end-to-end (below), and
- **Encodes** the expectation in the contract (high `attribution_correctness` weight + `every-claim` norm) for #473's real reflection scorer to act on.

Recommend the missing-attribution `REVISE` check land with **#473**.

## Test plan
`cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (4897 passed, 93.72% cov). New `tests/test_research_piece_medium.py`:
- Contract loads & conforms; `citation_norm` is strictest (`every-claim` vs essay `light`); rubric prioritises citation completeness; retrieval/ontology out-weight voice.
- `require_supported_medium("research-piece")` and `run_author(medium="research-piece", …)` accepted.
- **Attribution-correctness proof:** a run over a vault seeded with an `11-Other-Authors/naval-ravikant/` work surfaces a claim carrying `author_slug="naval-ravikant"` through the conductor's `gather_evidence`.

Closes #465
Refs #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)