### PR TITLE
feat(voice): exclude 11-Other-Authors/ from the voice corpus (#466)

### DIFF
--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -66,6 +66,14 @@ DEFAULT_MIN_PER_REGISTER: int = 5
 _FRAGMENTS_SUBDIR: str = "01-Fragments"
 """Vault subdirectory scanned for fragment markdown files."""
 
+_OTHER_AUTHORS_SEGMENT: str = "11-Other-Authors"
+"""Vault path segment holding borrowed / AI-authored content (Issue #466).
+
+Any fragment whose source path contains this segment is excluded from the
+voice corpus regardless of its ``voice_weight``, as a defensive backstop
+against voice drift.
+"""
+
 _SAMPLES_SUBPATH: tuple[str, str] = ("07-Voice", "Register-Samples")
 """Vault path where ranked exemplars are persisted."""
 
@@ -139,6 +147,26 @@ def _word_count(body: str) -> int:
     return len(body.split())
 
 
+def _is_other_authors_path(md_file: Path) -> bool:
+    """Return whether *md_file* lives under an ``11-Other-Authors`` segment.
+
+    Borrowed and AI-authored content is captured under
+    ``11-Other-Authors/`` and must never seed the voice corpus (Issue
+    #466). The check matches whole path *segments* (via ``Path.parts``)
+    rather than a substring of the full path, so a folder merely
+    *containing* the text — e.g. ``my-11-Other-Authors-notes`` — does not
+    trigger a false exclusion.
+
+    Args:
+        md_file: Path to a candidate fragment markdown file.
+
+    Returns:
+        ``True`` when any path component equals the
+        ``11-Other-Authors`` segment, otherwise ``False``.
+    """
+    return _OTHER_AUTHORS_SEGMENT in md_file.parts
+
+
 def _eligible_register(
     fragment: Fragment,
     *,
@@ -153,9 +181,15 @@ def _eligible_register(
 
     Returns:
         The canonical register string when the fragment has qualifying
-        confidence, allowed privacy tier, and a canonical register;
-        otherwise ``None``.
+        confidence, a positive ``voice_weight``, allowed privacy tier,
+        and a canonical register; otherwise ``None``.
     """
+    # Voice-fidelity fail-closed gate (Issue #466): borrowed / AI-authored
+    # text (notably ``ai-as-user`` content with ``voice_weight=0.0``) must
+    # never train the voice proxy. ``voice_weight`` is already coerced to a
+    # float in ``[0, 1]`` by the model, so a plain comparison is safe.
+    if fragment.voice_weight <= 0:
+        return None
     if _confidence_value(fragment) not in _QUALIFYING_CONFIDENCE:
         return None
     if not allow_intimate and str(fragment.privacy_tier) == PrivacyTier.INTIMATE.value:
@@ -346,6 +380,12 @@ class VoiceExemplarCollector:
             return buckets
 
         for md_file in sorted(fragments_dir.rglob("*.md")):
+            # Defensive path gate (Issue #466): skip borrowed / AI-authored
+            # content under ``11-Other-Authors`` before parsing, so it never
+            # reaches the voice corpus even if symlinked or the scan root
+            # later broadens.
+            if _is_other_authors_path(md_file):
+                continue
             loaded = _load_fragment_with_body(md_file)
             if loaded is None:
                 continue
@@ -1651,6 +1691,11 @@ class VoiceProfileGenerator:
     ) -> None:
         """Walk *fragments_dir* and append eligible exemplars to JSONL files."""
         for md_file in sorted(fragments_dir.rglob("*.md")):
+            # Defensive path gate (Issue #466): skip borrowed / AI-authored
+            # content under ``11-Other-Authors`` so it never reaches the
+            # streaming voice-profile corpus, mirroring ``collect_exemplars``.
+            if _is_other_authors_path(md_file):
+                continue
             loaded = _load_fragment_with_body(md_file)
             if loaded is None:
                 continue

--- a/creek-tools/tests/test_voice_exemplars.py
+++ b/creek-tools/tests/test_voice_exemplars.py
@@ -20,6 +20,7 @@ from creek.generate.voice import (
     DEFAULT_MIN_PER_REGISTER,
     VOICE_REGISTERS,
     VoiceExemplarCollector,
+    _is_other_authors_path,
 )
 from creek.models import (
     Confidence,
@@ -70,6 +71,7 @@ def _build_fragment(
     confidence: Confidence | None,
     privacy: PrivacyTier = PrivacyTier.PERSONAL,
     fully_classified: bool = True,
+    voice_weight: float = 1.0,
 ) -> Fragment:
     """Build a Fragment with the desired voice / privacy / classification state."""
     if fully_classified:
@@ -91,6 +93,7 @@ def _build_fragment(
         wavelength=wavelength,
         voice=VoiceClassification(voice_register=register, confidence=confidence),
         privacy_tier=privacy,
+        voice_weight=voice_weight,
     )
 
 
@@ -106,6 +109,7 @@ def _write_fragment(
     data = fragment.model_dump(mode="json")
     post = frontmatter.Post(content=body, **data)
     target = vault_path / "01-Fragments" / subfolder / f"{fragment.id}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(frontmatter.dumps(post), encoding="utf-8")
     return target
 
@@ -305,6 +309,131 @@ class TestCollectExemplars:
         _write_fragment(vault, good, body_words=400)
         exemplars = collector.collect_exemplars(vault)
         assert [f.id for f in exemplars["confessional"]] == ["frag-good"]
+
+
+class TestVoiceCorpusExcludesBorrowedContent:
+    """Issue #466: borrowed / AI-authored text must never reach the voice corpus.
+
+    Two additive gates protect voice fidelity, mirroring the privacy
+    fail-closed rule:
+
+    1. ``voice_weight > 0`` — a fragment with ``voice_weight <= 0`` (the
+       ``ai-as-user`` analogue with ``voice_weight=0.0``) is ineligible.
+    2. ``11-Other-Authors/`` path exclusion — any fragment whose source
+       path contains that segment is skipped regardless of weight.
+    """
+
+    def test_excludes_zero_voice_weight_and_other_authors_path(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """Only native, positive-weight fragments outside 11-Other-Authors survive."""
+        native = _build_fragment(
+            frag_id="frag-native",
+            title="Native voice",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.SETTLED,
+        )
+        borrowed = _build_fragment(
+            frag_id="frag-ai-as-user",
+            title="AI as user",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.SETTLED,
+            voice_weight=0.0,
+        )
+        other_author = _build_fragment(
+            frag_id="frag-other-author",
+            title="Borrowed by path",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.SETTLED,
+        )
+        _write_fragment(vault, native, body_words=400)
+        # Weight gate: ai-as-user content sits in the scanned corpus.
+        _write_fragment(vault, borrowed, body_words=400)
+        # Path gate: a full-weight fragment nested under an
+        # ``11-Other-Authors`` segment inside the scanned tree.
+        _write_fragment(
+            vault,
+            other_author,
+            body_words=400,
+            subfolder="11-Other-Authors/some-author",
+        )
+
+        exemplars = collector.collect_exemplars(vault)
+        ids = {f.id for f in exemplars["confessional"]}
+        assert ids == {"frag-native"}
+        assert "frag-ai-as-user" not in ids
+        assert "frag-other-author" not in ids
+
+    def test_zero_voice_weight_excluded(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """An ai-as-user-style fragment (voice_weight=0.0) is dropped by the gate."""
+        borrowed = _build_fragment(
+            frag_id="frag-zero",
+            title="Zero weight",
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.CONVICTION,
+            voice_weight=0.0,
+        )
+        _write_fragment(vault, borrowed, body_words=400)
+        exemplars = collector.collect_exemplars(vault)
+        assert exemplars["analytical"] == []
+
+    def test_positive_voice_weight_is_kept(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """A reduced-but-positive voice_weight still qualifies for the corpus."""
+        weighted = _build_fragment(
+            frag_id="frag-half",
+            title="Half weight",
+            register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.SETTLED,
+            voice_weight=0.5,
+        )
+        _write_fragment(vault, weighted, body_words=400)
+        exemplars = collector.collect_exemplars(vault)
+        assert [f.id for f in exemplars["analytical"]] == ["frag-half"]
+
+    def test_path_helper_rejects_other_authors_segment(self, tmp_path: Path) -> None:
+        """The path-exclusion helper rejects an 11-Other-Authors path segment."""
+        other = tmp_path / "01-Fragments" / "11-Other-Authors" / "x" / "f.md"
+        native = tmp_path / "01-Fragments" / "Journal" / "f.md"
+        assert _is_other_authors_path(other) is True
+        assert _is_other_authors_path(native) is False
+
+    def test_path_helper_no_substring_false_positive(self, tmp_path: Path) -> None:
+        """A folder merely containing the text is not excluded (segment match only)."""
+        lookalike = tmp_path / "01-Fragments" / "my-11-Other-Authors-notes" / "f.md"
+        assert _is_other_authors_path(lookalike) is False
+
+    def test_tracer_invariant_no_other_authors_unchanged(
+        self,
+        vault: Path,
+        collector: VoiceExemplarCollector,
+    ) -> None:
+        """A vault with no 11-Other-Authors and default weights behaves as before."""
+        a = _build_fragment(
+            frag_id="frag-a",
+            title="Native A",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.SETTLED,
+        )
+        b = _build_fragment(
+            frag_id="frag-b",
+            title="Native B",
+            register=VoiceRegister.CONFESSIONAL,
+            confidence=Confidence.CONVICTION,
+        )
+        _write_fragment(vault, a, body_words=400)
+        _write_fragment(vault, b, body_words=400)
+        exemplars = collector.collect_exemplars(vault)
+        assert {f.id for f in exemplars["confessional"]} == {"frag-a", "frag-b"}
 
 
 # ---- rank_exemplars ----


### PR DESCRIPTION
## Summary

Stops the voice proxy from ever training on borrowed or AI-authored text — the voice-fidelity analogue of the privacy fail-closed rule (FEAT-041 §7.5), preventing voice drift / model collapse. Two **additive** gates in `creek/generate/voice.py`:

- **`voice_weight` gate:** `_eligible_register` early-returns `None` for any fragment with `voice_weight <= 0` — notably the `ai-as-user` content from #464 (`voice_weight=0.0`). Every corpus-selection path routes through this gate. The value is already coerced to `[0, 1]` by the model, so the comparison is safe.
- **Path gate:** a new `_is_other_authors_path` helper — **segment** match via `Path.parts`, not substring, so `my-11-Other-Authors-notes` is *not* a false hit — skips any file under an `11-Other-Authors` segment before parsing. Applied to **both** scan loops: `VoiceExemplarCollector.collect_exemplars` *and* `VoiceProfileGenerator._stream_into` (the loop that actually feeds the voice-proxy profiles), so the two can't drift.

Scope fence respected: raising `ai-as-user` weight is an explicit, audited opt-in (future work) — this just honours whatever `voice_weight` is set. Tracer invariant: a vault without `11-Other-Authors/` behaves exactly as before.

## Test plan
`cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (4903 passed, voice.py per-file 96.81%). New tests in `tests/test_voice_exemplars.py`:
- End-to-end exclusion — native fragment kept; a `voice_weight=0.0` fragment and a positive-weight fragment nested under `11-Other-Authors/` both dropped (asserted by exact fragment id, so each gate is proven independently).
- Isolated weight-gate cases (`0.0` excluded, `0.5` kept).
- Focused path-helper unit tests, including the substring false-positive guard.
- Tracer invariant — no `11-Other-Authors/`, all default weights → unchanged corpus.

Closes #466
Refs #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)