### PR TITLE
feat(author): real Ontology specialist agent (#467)

### DIFF
--- a/creek-tools/creek/author/agents.py
+++ b/creek-tools/creek/author/agents.py
@@ -1,9 +1,11 @@
 """Specialist agents for the Creek Writing Desk.
 
-The Graph and Retrieval specialists are real: Graph walks a bounded
-backlink graph over the vault; Retrieval ranks fragments by semantic similarity
-to the query, reusing :mod:`creek.link.embeddings`. The Ontology specialist
-remains a stub. Every specialist returns structured,
+The Graph, Retrieval, and Ontology specialists are real: Graph walks a
+bounded backlink graph over the vault; Retrieval ranks fragments by semantic
+similarity to the query, reusing :mod:`creek.link.embeddings`; Ontology runs
+the deterministic rule classifier over the corpus and aggregates canonical
+APTITUDE frequencies / phases / modes / dosages, surfacing — never resolving —
+the paradoxes it finds. Every specialist returns structured,
 provenance-tracked :class:`~creek.author.models.EvidenceBundle`s — claims paired
 with their ``source_fragments`` (and an ``author_slug`` for borrowed evidence).
 """
@@ -11,23 +13,37 @@ with their ``source_fragments`` (and an ``author_slug`` for borrowed evidence).
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from collections import Counter
+from typing import TYPE_CHECKING, Protocol, TypeVar, runtime_checkable
 
 import numpy as np
 
-from creek.author.models import EvidenceBundle, EvidenceClaim, WalkStats
+from creek.author.models import (
+    EvidenceBundle,
+    EvidenceClaim,
+    OntologyAnalysis,
+    OntologyParadox,
+    WalkStats,
+)
+from creek.classify.rules import RuleClassifier
+from creek.classify.weighted import WeightedDimension
+from creek.generate.paradox import OPPOSITE_PHASE_PAIRS
 from creek.link.embeddings import (
     EmbeddingLinker,
     EmbeddingModelUnavailableError,
     fragment_embedding_text,
 )
+from creek.models import Dosage, Frequency, Mode, Phase
 from creek.vault.reader import iter_vault_fragments
 
 if TYPE_CHECKING:
+    from enum import StrEnum
     from pathlib import Path
 
     from creek.config import CreekConfig, EmbeddingsConfig
     from creek.models import Fragment
+
+_DimT = TypeVar("_DimT", bound="StrEnum")
 
 #: Vault subtrees the specialists draw evidence from.
 _CORPUS_SUBDIRS: tuple[str, ...] = ("01-Fragments", "09-Reference", "11-Other-Authors")
@@ -240,20 +256,223 @@ class GraphSpecialist:
         )
 
 
+def _aggregate_dimension(
+    picks: list[_DimT],
+    unclassified: _DimT,
+) -> tuple[WeightedDimension[_DimT], ...]:
+    """Aggregate per-fragment canonical *picks* into weighted dimensions.
+
+    Counts each canonical value's occurrences across the corpus, drops the
+    ``unclassified`` sentinel, normalises counts into weights in ``[0.0, 1.0]``
+    (the most frequent value reaching weight 1.0), and sorts weight-descending
+    with the canonical value as a stable tie-break.
+
+    Args:
+        picks: One canonical enum pick per fragment (may include the
+            ``unclassified`` sentinel, which is dropped).
+        unclassified: The dimension's ``UNCLASSIFIED`` sentinel.
+
+    Returns:
+        A weight-descending tuple of :class:`WeightedDimension` entries.
+    """
+    counts = Counter(pick for pick in picks if pick is not unclassified)
+    if not counts:
+        return ()
+    top = max(counts.values())
+    entries = [
+        WeightedDimension(value=value, weight=count / top)
+        for value, count in counts.items()
+    ]
+    entries.sort(key=lambda wd: (-wd.weight, wd.value.value))
+    return tuple(entries)
+
+
+class _FragmentSignal:
+    """The canonical ontology signal a single corpus fragment carries."""
+
+    __slots__ = ("dosage", "frequency", "mode", "phase")
+
+    def __init__(self, fragment: Fragment, body: str) -> None:
+        """Classify *fragment* deterministically, keeping any frontmatter dosage.
+
+        The rule classifier supplies frequency, phase, and mode from
+        ``title + body`` keyword signal; the rule classifier does not detect
+        dosage, so dosage is read from the fragment's existing frontmatter
+        (``wavelength.dosage``) instead.
+
+        Args:
+            fragment: The corpus fragment to scan.
+            body: The fragment's markdown body.
+        """
+        classified = RuleClassifier().classify(
+            fragment, content=body, title=fragment.title
+        )
+        self.frequency: Frequency = Frequency(classified.frequency.primary)
+        self.phase: Phase = Phase(classified.wavelength.phase)
+        self.mode: Mode = Mode(classified.wavelength.mode)
+        self.dosage: Dosage = Dosage(fragment.wavelength.dosage)
+
+
+def _detect_dosage_paradoxes(
+    signals: list[tuple[str, _FragmentSignal]],
+) -> list[OntologyParadox]:
+    """Surface same-frequency medicine-vs-toxic contradictions across fragments.
+
+    Args:
+        signals: ``(fragment_id, signal)`` pairs for the classified corpus.
+
+    Returns:
+        One :class:`OntologyParadox` per frequency held as both medicine and
+        toxic; the contradiction is named, never resolved.
+    """
+    by_freq: dict[Frequency, dict[Dosage, str]] = {}
+    for fid, sig in signals:
+        if sig.frequency is Frequency.UNCLASSIFIED or sig.dosage not in (
+            Dosage.MEDICINE,
+            Dosage.TOXIC,
+        ):
+            continue
+        by_freq.setdefault(sig.frequency, {}).setdefault(sig.dosage, fid)
+    paradoxes: list[OntologyParadox] = []
+    for freq, seen in sorted(by_freq.items(), key=lambda item: item[0].value):
+        if Dosage.MEDICINE in seen and Dosage.TOXIC in seen:
+            ids = (seen[Dosage.MEDICINE], seen[Dosage.TOXIC])
+            paradoxes.append(
+                OntologyParadox(
+                    kind="dosage",
+                    fragment_ids=ids,
+                    description=(
+                        f"{freq.value} is held as medicine in one fragment "
+                        "and as toxic in another."
+                    ),
+                )
+            )
+    return paradoxes
+
+
+def _detect_phase_paradoxes(
+    signals: list[tuple[str, _FragmentSignal]],
+) -> list[OntologyParadox]:
+    """Surface opposite-phase contradictions across fragments.
+
+    Reuses the canonical opposite-phase pairs from
+    :data:`creek.generate.paradox.OPPOSITE_PHASE_PAIRS`.
+
+    Args:
+        signals: ``(fragment_id, signal)`` pairs for the classified corpus.
+
+    Returns:
+        One :class:`OntologyParadox` per opposite-phase pair present in the
+        corpus; the contradiction is named, never resolved.
+    """
+    first_for_phase: dict[Phase, str] = {}
+    for fid, sig in signals:
+        if sig.phase is not Phase.UNCLASSIFIED:
+            first_for_phase.setdefault(sig.phase, fid)
+    paradoxes: list[OntologyParadox] = []
+    for pair in sorted(OPPOSITE_PHASE_PAIRS, key=sorted):
+        phases = [Phase(value) for value in pair]
+        if all(phase in first_for_phase for phase in phases):
+            lo, hi = sorted(phases, key=lambda p: p.value)
+            paradoxes.append(
+                OntologyParadox(
+                    kind="phase",
+                    fragment_ids=(first_for_phase[lo], first_for_phase[hi]),
+                    description=(
+                        f"The topic sits on opposite phases — {lo.value} in one "
+                        f"fragment and {hi.value} in another."
+                    ),
+                )
+            )
+    return paradoxes
+
+
+def _ontology_claim(
+    analysis: OntologyAnalysis,
+    fragment_ids: list[str],
+) -> EvidenceClaim:
+    """Render a grounded, single-sentence summary claim from *analysis*.
+
+    The claim always traces to every scanned fragment so the desk's
+    fragment-grounding invariant holds even on an all-unclassified corpus.
+
+    Args:
+        analysis: The aggregated ontological analysis.
+        fragment_ids: Every scanned fragment id.
+
+    Returns:
+        One :class:`EvidenceClaim` summarising the dominant signal.
+    """
+    count = len(fragment_ids)
+    if analysis.frequencies:
+        freq = analysis.frequencies[0].value.value
+        phase = analysis.phases[0].value.value if analysis.phases else "no clear phase"
+        summary = (
+            f"Ontological scan of {count} fragments: dominant frequency {freq}, "
+            f"phase {phase}."
+        )
+    else:
+        summary = (
+            f"Ontological scan of {count} fragments; no dominant frequency detected."
+        )
+    return EvidenceClaim(claim=summary, source_fragments=fragment_ids.copy())
+
+
 class OntologySpecialist:
-    """Stub Ontology specialist — would ground claims in the APTITUDE model."""
+    """Ontology specialist — deterministic APTITUDE analytics over the corpus.
+
+    Classifies every corpus fragment with the deterministic
+    :class:`~creek.classify.rules.RuleClassifier` (no LLM, no embeddings),
+    aggregates canonical frequencies / phases / modes / dosages into weighted
+    dimensions, and surfaces — never resolves — the dosage and phase
+    contradictions it finds (Ontology §10.2; INC-019 canonical taxonomy only).
+    """
 
     name = "ontology"
 
     def gather(self, query: str, vault: Path) -> EvidenceBundle:
-        """Return a mock ontology-derived claim (stub)."""
+        """Return canonical ontological analysis grounded in corpus fragments.
+
+        Degrades to an empty bundle when the corpus is empty so the desk never
+        crashes on a thin vault. When the corpus is non-empty it always emits
+        at least one claim, traced to the scanned fragments.
+
+        Args:
+            query: The user query (unused — analysis is corpus-wide).
+            vault: The vault to scan.
+
+        Returns:
+            An :class:`EvidenceBundle` carrying the analysis and a grounded
+            summary claim, or an empty bundle for an empty corpus.
+        """
+        corpus = _load_corpus(vault)
+        if not corpus:
+            return EvidenceBundle()
+        signals = [
+            (fragment.id, _FragmentSignal(fragment, body)) for fragment, body in corpus
+        ]
+        analysis = OntologyAnalysis(
+            frequencies=_aggregate_dimension(
+                [sig.frequency for _id, sig in signals], Frequency.UNCLASSIFIED
+            ),
+            phases=_aggregate_dimension(
+                [sig.phase for _id, sig in signals], Phase.UNCLASSIFIED
+            ),
+            modes=_aggregate_dimension(
+                [sig.mode for _id, sig in signals], Mode.UNCLASSIFIED
+            ),
+            dosages=_aggregate_dimension(
+                [sig.dosage for _id, sig in signals], Dosage.UNCLASSIFIED
+            ),
+            paradoxes=tuple(
+                _detect_dosage_paradoxes(signals) + _detect_phase_paradoxes(signals)
+            ),
+            overall_confidence=1.0 if signals else 0.0,
+        )
+        fragment_ids = [fid for fid, _sig in signals]
         return EvidenceBundle(
-            claims=[
-                EvidenceClaim(
-                    claim=f"Ontology framing for {query!r} (stub).",
-                    source_fragments=["frag-ontology-0001"],
-                )
-            ]
+            claims=[_ontology_claim(analysis, fragment_ids)],
+            ontology=analysis,
         )
 
 

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -170,12 +170,16 @@ class Conductor:
             bundles: One evidence bundle per specialist.
 
         Returns:
-            A single :class:`EvidenceBundle` carrying every claim.
+            A single :class:`EvidenceBundle` carrying every claim and the
+            first ontological analysis any specialist produced.
         """
         claims: list[EvidenceClaim] = []
+        ontology = None
         for bundle in bundles:
             claims.extend(bundle.claims)
-        return EvidenceBundle(claims=claims)
+            if ontology is None and bundle.ontology is not None:
+                ontology = bundle.ontology
+        return EvidenceBundle(claims=claims, ontology=ontology)
 
     def run(self, *, medium: str, query: str, vault: Path) -> AuthoredDraft:
         """Run the full author pipeline and return a shaped draft.

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -11,7 +11,9 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 
+from creek.classify.weighted import WeightedDimension
 from creek.compile.provenance import ProvenanceEntry
+from creek.models import Dosage, Frequency, Mode, Phase
 
 #: Mediums the author desk can produce. ``research``/``chat``/``essay``/
 #: ``research-piece`` are wired; the others (book-report/how-to) arrive in later
@@ -56,18 +58,71 @@ class WalkStats(BaseModel):
     fragments_visited: int = 0
 
 
+class OntologyParadox(BaseModel):
+    """A surfaced (never resolved) contradiction across two fragments.
+
+    The Ontology specialist *names* a tension rather than collapsing it: a
+    paradox carries the contributing fragment ids and a neutral, canonical
+    description of the contradiction so downstream voicing keeps both
+    conflicting signals visible (FEAT-041 §6; Ontology §10.2).
+
+    Attributes:
+        kind: Which contradiction fired — ``"dosage"``, ``"phase"``, or
+            ``"confidence"``.
+        fragment_ids: The fragment ids in tension, in stable order.
+        description: A neutral one-sentence statement of the contradiction;
+            it names the tension, never resolves it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["dosage", "phase", "confidence"]
+    fragment_ids: tuple[str, ...] = ()
+    description: str = ""
+
+
+class OntologyAnalysis(BaseModel):
+    """Structured ontological analysis from the Ontology specialist (FEAT-041 §4.1).
+
+    Each axis is a weight-descending tuple of canonical
+    :class:`~creek.classify.weighted.WeightedDimension` entries (canonical
+    taxonomy only — no aliases, INC-019). Paradoxes are surfaced, not
+    resolved.
+
+    Attributes:
+        frequencies: Weighted APTITUDE frequencies (F1-F10) the corpus
+            resonates with.
+        phases: Weighted Archetypal Wavelength phases.
+        modes: Weighted engagement modes.
+        dosages: Weighted dosage framings (medicine/toxic/ambiguous).
+        paradoxes: Surfaced contradictions across fragments.
+        overall_confidence: Aggregate confidence in ``[0.0, 1.0]``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    frequencies: tuple[WeightedDimension[Frequency], ...] = ()
+    phases: tuple[WeightedDimension[Phase], ...] = ()
+    modes: tuple[WeightedDimension[Mode], ...] = ()
+    dosages: tuple[WeightedDimension[Dosage], ...] = ()
+    paradoxes: tuple[OntologyParadox, ...] = ()
+    overall_confidence: float = 0.0
+
+
 class EvidenceBundle(BaseModel):
     """The aggregated evidence the conductor hands to the voice agent.
 
     Attributes:
         claims: Every :class:`EvidenceClaim` gathered across specialists.
         walk_stats: Set by the Graph agent — the bounds its backlink walk hit.
+        ontology: Set by the Ontology agent — structured ontological analysis.
     """
 
     model_config = ConfigDict(frozen=True)
 
     claims: list[EvidenceClaim] = Field(default_factory=list)
     walk_stats: WalkStats | None = None
+    ontology: OntologyAnalysis | None = None
 
     def all_source_fragments(self) -> list[str]:
         """Return the order-preserving, deduplicated union of claim fragments.

--- a/creek-tools/creek/generate/paradox.py
+++ b/creek-tools/creek/generate/paradox.py
@@ -67,7 +67,7 @@ _EXCERPT_MAX_CHARS: int = 280
 """Maximum excerpt length written into a paradox note."""
 
 
-_OPPOSITE_PHASE_PAIRS: frozenset[frozenset[str]] = frozenset(
+OPPOSITE_PHASE_PAIRS: frozenset[frozenset[str]] = frozenset(
     {
         frozenset({Phase.RISING.value, Phase.DIMINISHING.value}),
         frozenset({Phase.RISING.value, Phase.BOTTOMING_OUT.value}),
@@ -413,7 +413,7 @@ class ParadoxDetector:
         phase_b = str(b.wavelength.phase)
         if not phase_a or not phase_b:
             return False
-        return frozenset({phase_a, phase_b}) in _OPPOSITE_PHASE_PAIRS
+        return frozenset({phase_a, phase_b}) in OPPOSITE_PHASE_PAIRS
 
     @staticmethod
     def _opposite_confidences(a: Fragment, b: Fragment) -> bool:

--- a/creek-tools/tests/test_author_desk.py
+++ b/creek-tools/tests/test_author_desk.py
@@ -39,6 +39,8 @@ from creek.author.voice import VoiceAgent
 
 def test_run_author_returns_shaped_draft(tmp_path: Path) -> None:
     """``run_author`` returns an ``AuthoredDraft`` with mock provenance + verdict."""
+    _seed_fragment(tmp_path, "frag-a", "F6 Pluralism and community")
+    _seed_fragment(tmp_path, "frag-b", "Agency and momentum")
     draft = run_author(medium="research", query="What is F6 Pluralism?", vault=tmp_path)
 
     assert isinstance(draft, AuthoredDraft)
@@ -149,6 +151,8 @@ def test_evidence_bundle_dedups_source_fragments() -> None:
 
 def test_conductor_synthesize_merges_bundles(tmp_path: Path) -> None:
     """The ``synthesize`` step merges every specialist bundle into one."""
+    _seed_fragment(tmp_path, "frag-a", "Alpha note about q")
+    _seed_fragment(tmp_path, "frag-b", "Beta note")
     conductor = build_default_conductor(max_rounds=1)
     bundles = [s.gather("q", tmp_path) for s in conductor.specialists]
 
@@ -161,6 +165,7 @@ def test_conductor_synthesize_merges_bundles(tmp_path: Path) -> None:
 
 def test_plan_steps_each_correspond_to_a_real_call(tmp_path: Path) -> None:
     """Every advertised plan step is exercised by a real run (no ghost steps)."""
+    _seed_fragment(tmp_path, "frag-a", "Alpha note about q")
     conductor = build_default_conductor(max_rounds=1)
     # ``synthesize`` must exist and run, not just appear in ``plan()``.
     assert "synthesize" in conductor.plan()

--- a/creek-tools/tests/test_mcp_tools.py
+++ b/creek-tools/tests/test_mcp_tools.py
@@ -399,6 +399,8 @@ def test_draft_refuses_for_out_of_range_index(
 
 def test_author_tool_returns_draft_envelope(vault: Path) -> None:
     """``creek.author`` returns the full draft envelope from the real desk."""
+    _write_fragment(vault, frag_id="frag-a", title="F6 Pluralism and community")
+    _write_fragment(vault, frag_id="frag-b", title="Agency and momentum")
     result = author_tool(
         vault_path=vault,
         query="What is F6 Pluralism?",
@@ -499,6 +501,8 @@ def test_author_tool_writes_audit_entry(vault: Path) -> None:
 
 def test_author_tool_returns_real_cited_draft(vault: Path) -> None:
     """``creek.author`` delegates to the real desk: cited claims + verdict (#460)."""
+    _write_fragment(vault, frag_id="frag-med", title="Power as medicine")
+    _write_fragment(vault, frag_id="frag-tox", title="Power as toxic")
     result = author_tool(
         vault_path=vault,
         query="F6 medicine vs toxic",
@@ -510,14 +514,15 @@ def test_author_tool_returns_real_cited_draft(vault: Path) -> None:
     assert result["verdict"] in {"PASS", "REVISE", "ESCALATE"}
     assert result["claims"]  # non-empty
     assert all(claim["source_fragments"] for claim in result["claims"])
-    # NOTE (#463): the claim *count* and verdict here reflect the stub
-    # specialists (which emit fixed mock claims, ignoring vault content). When
-    # #463 wires the real Graph/Retrieval agents, strengthen this to seed real
-    # fragments and assert the claims trace back to them.
+    # With the real specialists (#463/#467) every cited fragment is one the
+    # desk actually scanned in the seeded corpus.
+    cited = {fid for claim in result["claims"] for fid in claim["source_fragments"]}
+    assert cited <= {"frag-med", "frag-tox"}
 
 
 def test_author_tool_dry_run_returns_plan(vault: Path) -> None:
     """``dry_run`` returns the pipeline plan + evidence summary, not a draft."""
+    _write_fragment(vault, frag_id="frag-a", title="Alpha note about q")
     result = author_tool(
         vault_path=vault,
         query="q",
@@ -529,9 +534,8 @@ def test_author_tool_dry_run_returns_plan(vault: Path) -> None:
     assert result["status"] == "ok"
     assert result["dry_run"] is True
     assert result["plan"]
+    # The real specialists (#463/#467) ground evidence in the seeded corpus.
     assert result["evidence"]["claims"] >= 1
-    # NOTE (#463): evidence counts reflect the stub specialists; revisit to
-    # assert against seeded fragments once the real specialists land.
 
 
 def test_author_tool_forwards_max_rounds(

--- a/creek-tools/tests/test_real_agents.py
+++ b/creek-tools/tests/test_real_agents.py
@@ -13,9 +13,14 @@ from unittest.mock import patch
 
 import pytest
 
-from creek.author.agents import GraphSpecialist, RetrievalSpecialist
+from creek.author.agents import (
+    GraphSpecialist,
+    OntologySpecialist,
+    RetrievalSpecialist,
+)
 from creek.author.models import EvidenceBundle
 from creek.link.embeddings import EmbeddingModelUnavailableError
+from creek.models import Frequency, Phase
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -174,3 +179,120 @@ def test_graph_empty_vault_returns_empty_with_stats(tmp_path: Path) -> None:
     assert bundle.claims == []
     assert bundle.walk_stats is not None
     assert bundle.walk_stats.fragments_visited == 0
+
+
+def _write_classified(
+    vault: Path,
+    frag_id: str,
+    title: str,
+    *,
+    body: str,
+    frontmatter: str = "",
+) -> None:
+    """Write a fragment carrying optional pre-classified frontmatter blocks."""
+    folder = vault / "01-Fragments" / "Notes"
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / f"{frag_id}.md").write_text(
+        f'---\ntype: fragment\nid: {frag_id}\ntitle: "{title}"\n'
+        f"source:\n  platform: journal\n  author: self\n{frontmatter}---\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+# Bodies dense with rule-classifier signal keywords (creek/classify/rules.py)
+# so deterministic keyword classification fires without any LLM.
+_F6_BODY = "community empathy harmony inclusion caring sharing equality consensus"
+_F3_BODY = "power dominance control conquest force aggression warrior rebellion"
+_RISING_BODY = "emerging building growing momentum ascending intensifying gathering"
+_DIMINISHING_BODY = "diminishing declining waning subsiding settling calming quieting"
+
+
+def test_ontology_returns_canonical_taxonomy(tmp_path: Path) -> None:
+    """The Ontology agent emits only canonical F1-F10 frequencies and phases."""
+    _write_classified(tmp_path, "frag-f6", "Community and belonging", body=_F6_BODY)
+    _write_classified(tmp_path, "frag-rise", "Emerging momentum", body=_RISING_BODY)
+
+    bundle = OntologySpecialist().gather("community", tmp_path)
+
+    assert bundle.ontology is not None
+    canonical_freqs = {f"F{i}" for i in range(1, 11)}
+    assert bundle.ontology.frequencies  # F6 detected
+    for entry in bundle.ontology.frequencies:
+        assert isinstance(entry.value, Frequency)
+        assert entry.value.value in canonical_freqs
+    assert any(e.value is Frequency.F6 for e in bundle.ontology.frequencies)
+    canonical_phases = {p for p in Phase if p is not Phase.UNCLASSIFIED}
+    for entry in bundle.ontology.phases:
+        assert entry.value in canonical_phases
+    assert any(e.value is Phase.RISING for e in bundle.ontology.phases)
+    # Claims are grounded in the scanned fragments.
+    assert bundle.claims
+    assert all(claim.source_fragments for claim in bundle.claims)
+    cited = {fid for claim in bundle.claims for fid in claim.source_fragments}
+    assert cited == {"frag-f6", "frag-rise"}
+
+
+def test_ontology_surfaces_dosage_paradox_without_resolving(tmp_path: Path) -> None:
+    """Same frequency marked medicine vs toxic surfaces a paradox, both kept."""
+    _write_classified(
+        tmp_path,
+        "frag-med",
+        "Power as medicine",
+        body=_F3_BODY,
+        frontmatter="frequency:\n  primary: F3\nwavelength:\n  dosage: medicine\n",
+    )
+    _write_classified(
+        tmp_path,
+        "frag-tox",
+        "Power as toxic",
+        body=_F3_BODY,
+        frontmatter="frequency:\n  primary: F3\nwavelength:\n  dosage: toxic\n",
+    )
+
+    bundle = OntologySpecialist().gather("power", tmp_path)
+
+    assert bundle.ontology is not None
+    dosage_paradoxes = [p for p in bundle.ontology.paradoxes if p.kind == "dosage"]
+    assert dosage_paradoxes, "dosage contradiction must be surfaced"
+    paradox = dosage_paradoxes[0]
+    assert set(paradox.fragment_ids) == {"frag-med", "frag-tox"}
+    # The contradiction is preserved, not flattened to one dosage.
+    dosage_values = {e.value.value for e in bundle.ontology.dosages}
+    assert {"medicine", "toxic"} <= dosage_values
+
+
+def test_ontology_surfaces_phase_paradox_without_resolving(tmp_path: Path) -> None:
+    """Opposite phases across fragments surface a phase paradox, both kept."""
+    _write_classified(tmp_path, "frag-rise", "Rising tide", body=_RISING_BODY)
+    _write_classified(tmp_path, "frag-fall", "Falling away", body=_DIMINISHING_BODY)
+
+    bundle = OntologySpecialist().gather("tide", tmp_path)
+
+    assert bundle.ontology is not None
+    phase_paradoxes = [p for p in bundle.ontology.paradoxes if p.kind == "phase"]
+    assert phase_paradoxes, "phase contradiction must be surfaced"
+    assert set(phase_paradoxes[0].fragment_ids) == {"frag-rise", "frag-fall"}
+    phase_values = {e.value for e in bundle.ontology.phases}
+    assert {Phase.RISING, Phase.DIMINISHING} <= phase_values
+
+
+def test_ontology_empty_vault_returns_empty_bundle(tmp_path: Path) -> None:
+    """An empty corpus yields an empty bundle with no ontology and no crash."""
+    bundle = OntologySpecialist().gather("q", tmp_path)
+
+    assert bundle == EvidenceBundle()
+    assert bundle.ontology is None
+    assert bundle.claims == []
+
+
+def test_ontology_unclassified_corpus_still_grounds_claim(tmp_path: Path) -> None:
+    """Even an all-unclassified corpus emits a fragment-grounded claim."""
+    _write(tmp_path, "01-Fragments/Notes", "frag-a", "Alpha note about q")
+    _write(tmp_path, "01-Fragments/Notes", "frag-b", "Beta note")
+
+    bundle = OntologySpecialist().gather("q", tmp_path)
+
+    assert bundle.ontology is not None
+    assert bundle.claims
+    cited = {fid for claim in bundle.claims for fid in claim.source_fragments}
+    assert cited == {"frag-a", "frag-b"}


### PR DESCRIPTION
## Summary

Replaces the `OntologySpecialist` stub with a real, **deterministic** agent that supplies the writing desk's analytics layer (FEAT-041 §4.1) — no LLM, no embeddings, no new ML models. Graph + Retrieval (#463) feed it; it is the third real specialist.

- **New models** on `EvidenceBundle`: `OntologyAnalysis` (weight-descending tuples of canonical `WeightedDimension` entries for frequencies/phases/modes/dosages + surfaced paradoxes) and `OntologyParadox`. Attached via an optional `ontology` field, mirroring the Graph agent's `walk_stats`. **Canonical taxonomy only** — F1–F10, the six phases, the five modes, medicine/toxic/ambiguous dosages; never an alias (INC-019).
- **The agent** classifies every corpus fragment with the deterministic `RuleClassifier` (frequency/phase/mode from title+body keyword signal) and reads dosage from the fragment's frontmatter (the rule classifier doesn't detect dosage), aggregates per-axis occurrences into normalised `[0,1]` weights, and **always emits one grounded summary claim** traced to the scanned fragments. Empty corpus → empty bundle (graceful degradation, like Retrieval).
- **Paradoxes are surfaced, never resolved:** same-frequency *medicine-vs-toxic* flips and *opposite-phase* co-occurrences are named with both fragment ids + a neutral description, and **both conflicting signals are kept** in the analysis. Reuses the canonical opposite-phase pairs — I promoted `_OPPOSITE_PHASE_PAIRS` → public `OPPOSITE_PHASE_PAIRS` in `generate/paradox.py` rather than import a private symbol.
- `conductor.synthesize` now threads the first non-None ontology analysis through the merge (claim-count invariant unchanged).

### Scope / tracer invariant
Voice + Reflection remain stubs (ISSUE_05/06); the desk runs end-to-end with three real specialists. No final synthesis/voicing/judging here.

### Existing tests touched (not weakened)
Three `test_author_desk.py` and three `test_mcp_tools.py` tests previously passed only because the *stub* fabricated a claim referencing a nonexistent fragment id on an empty vault. The real agent degrades gracefully, so these now **seed real corpora** (the established `_seed_fragment`/`_write_fragment` pattern). One MCP test is **strengthened** to assert cited ids trace to the seeded fragments, retiring its stale `NOTE (#463)`. No assertion was weakened.

## Test plan
`cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (4908 passed, 93.74% cov). New tests in `tests/test_real_agents.py`:
- **Canonical taxonomy** — every frequency `isinstance(Frequency)` with value in `{F1..F10}`, `F6`/`Phase.RISING` detected, claims trace to exactly the seeded ids.
- **Dosage paradox surfaced, not resolved** — a `medicine`/`toxic` flip on one frequency yields a `kind="dosage"` paradox naming both fragments, and the analysis still carries `{medicine, toxic}`.
- **Phase paradox surfaced, not resolved** — opposite phases yield a `kind="phase"` paradox; analysis still carries `{RISING, DIMINISHING}`.
- **Graceful empty vault** and **grounded-claim-on-unclassified-corpus**.

Closes #467
Refs #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)