### PR TITLE
feat(crawdad): allowlist + graceful degradation for author routes (#468)

### DIFF
--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -810,6 +810,7 @@ class CrawDadClient(discord.Client):
             # ``test_register_wires_every_command_onto_tree`` test.
             register_slash_commands(
                 cast("Any", self.tree),
+                config=config,
                 loop_runner=loop_runner,
                 register_switcher=register_switcher,
                 workflow_lister=workflow_lister,

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -41,8 +41,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger("crawdad.slash_commands")
 
-# Issue #468: the documented soft-error shown when the desk / creek-tools
-# MCP surface is unreachable. Mirrors ``crawdad.loop._MCP_UNAVAILABLE_REPLY``
+# The documented soft-error shown when the desk / creek-tools MCP surface is
+# unreachable. Mirrors ``crawdad.loop._MCP_UNAVAILABLE_REPLY``
 # so the author routes degrade with the same wording as the agent loop.
 _MCP_UNAVAILABLE_REPLY = "creek-tools is unreachable; try again in a moment."
 
@@ -179,8 +179,8 @@ async def _run_and_reply(
 ) -> None:
     """Drive the loop runner and reply, degrading softly on MCP failure.
 
-    Issue #468: the author routes (`ask`/`draft`) own a resilience
-    contract — if the injected ``loop_runner`` ever lets an
+    The author routes (`ask`/`draft`) own a resilience contract — if the
+    injected ``loop_runner`` ever lets an
     :class:`~crawdad.mcp_client.MCPUnavailableError` escape (the loop
     normally converts it to a soft-reply string, but defense-in-depth
     keeps Discord from ever seeing a stack trace), reply with the
@@ -406,8 +406,8 @@ async def handle_help(replier: Replier) -> None:
 def _interaction_allowed(interaction: Any, config: CrawDadConfig) -> bool:
     """Return True when the interaction's user AND channel are allowlisted.
 
-    Issue #468: the author slash callbacks (`ask`/`draft`) must honour
-    CrawDad's personal-use allowlist (FEAT-013) the same way free-text
+    The author slash callbacks (`ask`/`draft`) must honour CrawDad's
+    personal-use allowlist (FEAT-013) the same way free-text
     messages do in :func:`crawdad.bot._passes_allowlist`. Delegates to
     :meth:`crawdad.config.CrawDadConfig.is_allowed` so the AND-gate
     semantics live in exactly one place.
@@ -452,8 +452,8 @@ def register(
     default to ``None`` (e.g. tests / no-tool-surface sessions); in
     that case the workflow command soft-errors instead of crashing.
 
-    ``config`` (issue #468) supplies the personal-use allowlist. The
-    author callbacks (`ask`/`draft`) gate on it BEFORE deferring so a
+    ``config`` supplies the personal-use allowlist. The author callbacks
+    (`ask`/`draft`) gate on it BEFORE deferring so a
     non-allowlisted user / channel gets no response at all (silent
     ignore, matching :func:`crawdad.bot._passes_allowlist`). The other
     callbacks are intentionally left ungated in this change (scope
@@ -521,8 +521,8 @@ def _register_draft(
         user fills it in. The runtime empty-string guard in
         :func:`handle_draft` stays as defense-in-depth.
 
-        Issue #468: a non-allowlisted user / channel is silently ignored
-        (no defer, no followup) BEFORE the interaction is deferred.
+        A non-allowlisted user / channel is silently ignored (no defer, no
+        followup) BEFORE the interaction is deferred.
         """
         if not _interaction_allowed(interaction, config):
             return
@@ -546,8 +546,8 @@ def _register_ask(
         user fills it in. The runtime empty-string guard in
         :func:`handle_ask` stays as defense-in-depth.
 
-        Issue #468: a non-allowlisted user / channel is silently ignored
-        (no defer, no followup) BEFORE the interaction is deferred.
+        A non-allowlisted user / channel is silently ignored (no defer, no
+        followup) BEFORE the interaction is deferred.
         """
         if not _interaction_allowed(interaction, config):
             return

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -32,9 +32,19 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+from crawdad.mcp_client import MCPUnavailableError
+
+if TYPE_CHECKING:
+    from crawdad.config import CrawDadConfig
 
 _LOGGER = logging.getLogger("crawdad.slash_commands")
+
+# Issue #468: the documented soft-error shown when the desk / creek-tools
+# MCP surface is unreachable. Mirrors ``crawdad.loop._MCP_UNAVAILABLE_REPLY``
+# so the author routes degrade with the same wording as the agent loop.
+_MCP_UNAVAILABLE_REPLY = "creek-tools is unreachable; try again in a moment."
 
 # A callable that drives one turn of the FEAT-015 loop and returns the
 # user-facing reply string. The CLI builds one by closing over the
@@ -164,6 +174,32 @@ async def handle_surface(replier: Replier, *, loop_runner: LoopRunner) -> None:
     await replier(reply)
 
 
+async def _run_and_reply(
+    replier: Replier, loop_runner: LoopRunner, prompt: str
+) -> None:
+    """Drive the loop runner and reply, degrading softly on MCP failure.
+
+    Issue #468: the author routes (`ask`/`draft`) own a resilience
+    contract — if the injected ``loop_runner`` ever lets an
+    :class:`~crawdad.mcp_client.MCPUnavailableError` escape (the loop
+    normally converts it to a soft-reply string, but defense-in-depth
+    keeps Discord from ever seeing a stack trace), reply with the
+    documented soft error instead of propagating.
+
+    Args:
+        replier: Async callable that posts the reply back to Discord.
+        loop_runner: The FEAT-015 agent-loop driver.
+        prompt: The pre-baked user message to run through the loop.
+    """
+    try:
+        reply = await loop_runner(prompt)
+    except MCPUnavailableError as exc:
+        _LOGGER.warning("author route degraded: %s", exc)
+        await replier(_MCP_UNAVAILABLE_REPLY)
+        return
+    await replier(reply)
+
+
 async def handle_draft(
     replier: Replier, *, topic: str, loop_runner: LoopRunner
 ) -> None:
@@ -184,8 +220,7 @@ async def handle_draft(
         "(AI-authored attribution: author=ai, representativeness=endorsed, "
         "voice_weight=0.0)."
     )
-    reply = await loop_runner(prompt)
-    await replier(reply)
+    await _run_and_reply(replier, loop_runner, prompt)
 
 
 async def handle_ask(
@@ -209,8 +244,7 @@ async def handle_ask(
         "attribution: author=ai, representativeness=endorsed, "
         "voice_weight=0.0)."
     )
-    reply = await loop_runner(prompt)
-    await replier(reply)
+    await _run_and_reply(replier, loop_runner, prompt)
 
 
 async def handle_save(
@@ -369,9 +403,33 @@ async def handle_help(replier: Replier) -> None:
 # -----------------------------------------------------------------------------
 
 
+def _interaction_allowed(interaction: Any, config: CrawDadConfig) -> bool:
+    """Return True when the interaction's user AND channel are allowlisted.
+
+    Issue #468: the author slash callbacks (`ask`/`draft`) must honour
+    CrawDad's personal-use allowlist (FEAT-013) the same way free-text
+    messages do in :func:`crawdad.bot._passes_allowlist`. Delegates to
+    :meth:`crawdad.config.CrawDadConfig.is_allowed` so the AND-gate
+    semantics live in exactly one place.
+
+    Args:
+        interaction: A ``discord.Interaction``-shaped object exposing
+            ``user.id`` and ``channel_id``.
+        config: The runtime config carrying the user / channel allowlists.
+
+    Returns:
+        ``True`` when the callback should proceed; ``False`` when it must
+        silently ignore the interaction (no defer, no reply).
+    """
+    return config.is_allowed(
+        user_id=interaction.user.id, channel_id=interaction.channel_id
+    )
+
+
 def register(
     tree: _TreeLike,
     *,
+    config: CrawDadConfig,
     loop_runner: LoopRunner,
     register_switcher: RegisterSwitcher | None = None,
     workflow_lister: Callable[[], list[str]] | None = None,
@@ -394,6 +452,13 @@ def register(
     default to ``None`` (e.g. tests / no-tool-surface sessions); in
     that case the workflow command soft-errors instead of crashing.
 
+    ``config`` (issue #468) supplies the personal-use allowlist. The
+    author callbacks (`ask`/`draft`) gate on it BEFORE deferring so a
+    non-allowlisted user / channel gets no response at all (silent
+    ignore, matching :func:`crawdad.bot._passes_allowlist`). The other
+    callbacks are intentionally left ungated in this change (scope
+    fence); the broader gap is tracked separately.
+
     Returns the count of advertised commands (always
     ``len(CRAWDAD_COMMANDS)`` since the registration helpers don't
     fail). The return value is a sanity-check signal callers can pin
@@ -402,8 +467,8 @@ def register(
     _register_reflect(tree, loop_runner=loop_runner)
     _register_checkin(tree, loop_runner=loop_runner)
     _register_surface(tree, loop_runner=loop_runner)
-    _register_draft(tree, loop_runner=loop_runner)
-    _register_ask(tree, loop_runner=loop_runner)
+    _register_draft(tree, config=config, loop_runner=loop_runner)
+    _register_ask(tree, config=config, loop_runner=loop_runner)
     _register_save(tree, loop_runner=loop_runner)
     _register_register(tree, register_switcher=register_switcher)
     _register_workflow(
@@ -442,7 +507,9 @@ def _register_surface(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
         await handle_surface(interaction.followup.send, loop_runner=loop_runner)
 
 
-def _register_draft(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
+def _register_draft(
+    tree: _TreeLike, *, config: CrawDadConfig, loop_runner: LoopRunner
+) -> None:
     """Wire the ``/crawdad draft`` Discord callback onto *tree*."""
 
     @tree.command(name="draft", description=_COMMAND_DESCRIPTIONS["draft"])
@@ -453,14 +520,21 @@ def _register_draft(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
         marks the parameter as required and disables submit until the
         user fills it in. The runtime empty-string guard in
         :func:`handle_draft` stays as defense-in-depth.
+
+        Issue #468: a non-allowlisted user / channel is silently ignored
+        (no defer, no followup) BEFORE the interaction is deferred.
         """
+        if not _interaction_allowed(interaction, config):
+            return
         await interaction.response.defer()
         await handle_draft(
             interaction.followup.send, topic=topic, loop_runner=loop_runner
         )
 
 
-def _register_ask(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
+def _register_ask(
+    tree: _TreeLike, *, config: CrawDadConfig, loop_runner: LoopRunner
+) -> None:
     """Wire the ``/crawdad ask`` Discord callback onto *tree*."""
 
     @tree.command(name="ask", description=_COMMAND_DESCRIPTIONS["ask"])
@@ -471,7 +545,12 @@ def _register_ask(tree: _TreeLike, *, loop_runner: LoopRunner) -> None:
         marks the parameter as required and disables submit until the
         user fills it in. The runtime empty-string guard in
         :func:`handle_ask` stays as defense-in-depth.
+
+        Issue #468: a non-allowlisted user / channel is silently ignored
+        (no defer, no followup) BEFORE the interaction is deferred.
         """
+        if not _interaction_allowed(interaction, config):
+            return
         await interaction.response.defer()
         await handle_ask(
             interaction.followup.send, question=question, loop_runner=loop_runner

--- a/crawdad/tests/test_slash_commands.py
+++ b/crawdad/tests/test_slash_commands.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
 
+from crawdad.config import CrawDadConfig
+from crawdad.mcp_client import MCPUnavailableError
 from crawdad.slash_commands import (
     CRAWDAD_COMMANDS,
+    _interaction_allowed,
     handle_ask,
     handle_checkin,
     handle_draft,
@@ -19,6 +23,22 @@ from crawdad.slash_commands import (
     handle_workflow,
     register,
 )
+
+_ALLOWED_USER_ID = 11
+_ALLOWED_CHANNEL_ID = 22
+_DENIED_USER_ID = 99
+_DENIED_CHANNEL_ID = 88
+
+
+def _make_config() -> CrawDadConfig:
+    """Build a minimal allowlisted config for slash-command gate tests."""
+    return CrawDadConfig(
+        discord_bot_token="t",
+        anthropic_api_key="k",
+        vault_path=Path("vault"),
+        allowed_user_ids=(_ALLOWED_USER_ID,),
+        allowed_channel_ids=(_ALLOWED_CHANNEL_ID,),
+    )
 
 
 class _FakeReplier:
@@ -493,7 +513,7 @@ def test_register_wires_every_command_onto_tree() -> None:
     """``register`` adds every command to a discord ``CommandTree``-like object."""
     tree = _FakeTree()
 
-    register(tree, loop_runner=_fake_loop_runner)
+    register(tree, config=_make_config(), loop_runner=_fake_loop_runner)
 
     assert set(tree.registered) == set(CRAWDAD_COMMANDS)
     for name, entry in tree.registered.items():
@@ -505,7 +525,7 @@ def test_register_returns_command_count() -> None:
     """``register`` returns the number of wired commands for sanity checks."""
     tree = _FakeTree()
 
-    count = register(tree, loop_runner=_fake_loop_runner)
+    count = register(tree, config=_make_config(), loop_runner=_fake_loop_runner)
 
     assert count == len(CRAWDAD_COMMANDS)
 
@@ -532,12 +552,31 @@ class _FakeResponse:
         self.deferred += 1
 
 
-class _FakeInteraction:
-    """``discord.Interaction``-shaped fake with the minimal surface we use."""
+class _FakeUser:
+    """``discord.Interaction.user``-shaped fake exposing just ``id``."""
 
-    def __init__(self) -> None:
+    def __init__(self, user_id: int) -> None:
+        self.id = user_id
+
+
+class _FakeInteraction:
+    """``discord.Interaction``-shaped fake with the minimal surface we use.
+
+    ``user_id`` and ``channel_id`` default to the allowlisted ids so the
+    pre-existing callback tests keep exercising the happy path without
+    change; the allowlist tests pass denied ids explicitly.
+    """
+
+    def __init__(
+        self,
+        *,
+        user_id: int = _ALLOWED_USER_ID,
+        channel_id: int = _ALLOWED_CHANNEL_ID,
+    ) -> None:
         self.response = _FakeResponse()
         self.followup = _FakeFollowup()
+        self.user = _FakeUser(user_id)
+        self.channel_id = channel_id
 
 
 @pytest.mark.parametrize(
@@ -561,7 +600,7 @@ async def test_every_loop_routed_callback_defers_and_replies(
     unreached so per-file coverage on slash_commands.py sat at 89.80%.
     """
     tree = _FakeTree()
-    register(tree, loop_runner=_fake_loop_runner)
+    register(tree, config=_make_config(), loop_runner=_fake_loop_runner)
     interaction = _FakeInteraction()
 
     await tree.registered[command_name]["callback"](interaction, **callback_kwargs)
@@ -581,7 +620,12 @@ async def test_register_callback_defers_and_invokes_switcher() -> None:
         return True
 
     tree = _FakeTree()
-    register(tree, loop_runner=_fake_loop_runner, register_switcher=_switcher)
+    register(
+        tree,
+        config=_make_config(),
+        loop_runner=_fake_loop_runner,
+        register_switcher=_switcher,
+    )
     interaction = _FakeInteraction()
 
     await tree.registered["register"]["callback"](interaction, name="praxis")
@@ -595,7 +639,7 @@ async def test_register_callback_defers_and_invokes_switcher() -> None:
 async def test_register_callback_without_switcher_replies_softly() -> None:
     """When no switcher is wired the callback still replies — does not crash."""
     tree = _FakeTree()
-    register(tree, loop_runner=_fake_loop_runner)
+    register(tree, config=_make_config(), loop_runner=_fake_loop_runner)
     interaction = _FakeInteraction()
 
     await tree.registered["register"]["callback"](interaction, name="praxis")
@@ -615,6 +659,7 @@ async def test_workflow_callback_defers_and_lists_when_wired() -> None:
     tree = _FakeTree()
     register(
         tree,
+        config=_make_config(),
         loop_runner=_spy_runner,
         workflow_lister=lambda: ["wavelength-checkin"],
         workflow_runner=None,
@@ -643,6 +688,7 @@ async def test_workflow_callback_runs_workflow_and_replies() -> None:
     tree = _FakeTree()
     register(
         tree,
+        config=_make_config(),
         loop_runner=_loop,
         workflow_lister=lambda: ["foo"],
         workflow_runner=_runner,
@@ -669,7 +715,7 @@ async def test_workflow_callback_soft_errors_when_unwired() -> None:
         return "should not be reached"
 
     tree = _FakeTree()
-    register(tree, loop_runner=_loop)
+    register(tree, config=_make_config(), loop_runner=_loop)
     interaction = _FakeInteraction()
 
     await tree.registered["workflow"]["callback"](interaction)
@@ -679,3 +725,122 @@ async def test_workflow_callback_soft_errors_when_unwired() -> None:
     body = interaction.followup.sent[0].lower()
     assert "registry" in body
     assert "walker" not in body
+
+
+# -----------------------------------------------------------------------------
+# Issue #468: allowlist gate + graceful degradation on the author routes.
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("user_id", "channel_id", "expected"),
+    [
+        (_ALLOWED_USER_ID, _ALLOWED_CHANNEL_ID, True),
+        (_DENIED_USER_ID, _ALLOWED_CHANNEL_ID, False),
+        (_ALLOWED_USER_ID, _DENIED_CHANNEL_ID, False),
+        (_DENIED_USER_ID, _DENIED_CHANNEL_ID, False),
+    ],
+)
+def test_interaction_allowed_gates_by_user_and_channel(
+    user_id: int, channel_id: int, expected: bool
+) -> None:
+    """``_interaction_allowed`` mirrors ``CrawDadConfig.is_allowed`` (AND gate)."""
+    interaction = _FakeInteraction(user_id=user_id, channel_id=channel_id)
+
+    assert _interaction_allowed(interaction, _make_config()) is expected
+
+
+@pytest.mark.parametrize("command_name", ["ask", "draft"])
+@pytest.mark.parametrize(
+    ("user_id", "channel_id"),
+    [
+        (_DENIED_USER_ID, _ALLOWED_CHANNEL_ID),
+        (_ALLOWED_USER_ID, _DENIED_CHANNEL_ID),
+    ],
+)
+async def test_author_callback_denies_non_allowlisted_silently(
+    command_name: str, user_id: int, channel_id: int
+) -> None:
+    """A non-allowlisted user/channel gets NO response: no defer, no followup."""
+    kwargs = {"ask": {"question": "q"}, "draft": {"topic": "t"}}[command_name]
+    tree = _FakeTree()
+    register(tree, config=_make_config(), loop_runner=_fake_loop_runner)
+    interaction = _FakeInteraction(user_id=user_id, channel_id=channel_id)
+
+    await tree.registered[command_name]["callback"](interaction, **kwargs)
+
+    assert interaction.response.deferred == 0
+    assert interaction.followup.sent == []
+
+
+@pytest.mark.parametrize(
+    ("command_name", "kwargs"),
+    [("ask", {"question": "what is emergence?"}), ("draft", {"topic": "phase"})],
+)
+async def test_author_callback_allows_allowlisted_interaction(
+    command_name: str, kwargs: dict[str, Any]
+) -> None:
+    """An allowlisted interaction defers and the handler runs (one reply)."""
+    tree = _FakeTree()
+    register(tree, config=_make_config(), loop_runner=_fake_loop_runner)
+    interaction = _FakeInteraction()
+
+    await tree.registered[command_name]["callback"](interaction, **kwargs)
+
+    assert interaction.response.deferred == 1
+    assert len(interaction.followup.sent) == 1
+    assert "composer received:" in interaction.followup.sent[0]
+
+
+async def _raising_loop_runner(_message: str) -> str:
+    """Loop runner that raises ``MCPUnavailableError`` to test degradation."""
+    msg = "creek-tools subprocess died"
+    raise MCPUnavailableError(msg)
+
+
+async def test_handle_ask_degrades_softly_when_runner_raises() -> None:
+    """``handle_ask`` maps an escaped ``MCPUnavailableError`` to a soft reply."""
+    replier = _FakeReplier()
+
+    await handle_ask(replier, question="why?", loop_runner=_raising_loop_runner)
+
+    assert len(replier.sent) == 1
+    assert "unreachable" in replier.sent[0].lower()
+
+
+async def test_handle_draft_degrades_softly_when_runner_raises() -> None:
+    """``handle_draft`` maps an escaped ``MCPUnavailableError`` to a soft reply."""
+    replier = _FakeReplier()
+
+    await handle_draft(replier, topic="drift", loop_runner=_raising_loop_runner)
+
+    assert len(replier.sent) == 1
+    assert "unreachable" in replier.sent[0].lower()
+
+
+async def test_handle_ask_relays_soft_error_string_from_runner() -> None:
+    """When the runner RETURNS a soft-error string, ``handle_ask`` relays it."""
+    soft = "creek-tools is unreachable; try again in a moment."
+
+    async def _soft_runner(_message: str) -> str:
+        return soft
+
+    replier = _FakeReplier()
+
+    await handle_ask(replier, question="why?", loop_runner=_soft_runner)
+
+    assert replier.sent == [soft]
+
+
+async def test_handle_draft_relays_soft_error_string_from_runner() -> None:
+    """When the runner RETURNS a soft-error string, ``handle_draft`` relays it."""
+    soft = "creek-tools is unreachable; try again in a moment."
+
+    async def _soft_runner(_message: str) -> str:
+        return soft
+
+    replier = _FakeReplier()
+
+    await handle_draft(replier, topic="drift", loop_runner=_soft_runner)
+
+    assert replier.sent == [soft]

--- a/crawdad/tests/test_slash_commands.py
+++ b/crawdad/tests/test_slash_commands.py
@@ -728,7 +728,7 @@ async def test_workflow_callback_soft_errors_when_unwired() -> None:
 
 
 # -----------------------------------------------------------------------------
-# Issue #468: allowlist gate + graceful degradation on the author routes.
+# Allowlist gate + graceful degradation on the author routes.
 # -----------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

Makes the new `/crawdad ask` and `/crawdad draft` routes (#464) obey CrawDad's security + resilience contract.

- **Allowlist (the real gap):** slash-command Discord callbacks bypass the free-text `_passes_allowlist` gate in `bot.py`, so the author callbacks were reachable by non-allowlisted users. New `_interaction_allowed(interaction, config)` — delegating to the single `CrawDadConfig.is_allowed` AND-gate — is called at the top of the `ask`/`draft` callbacks **before `defer()`**: a non-allowlisted user/channel is **silently ignored** (no defer, no reply), matching `bot._passes_allowlist`. `config` is threaded through `register()` and the `CrawDadClient` call site.
- **Graceful degradation:** both author handlers now route through a shared `_run_and_reply` helper that catches `MCPUnavailableError` and replies with the documented soft error (`"creek-tools is unreachable; try again in a moment."` — the same wording as `loop._MCP_UNAVAILABLE_REPLY`) instead of letting a stack trace reach Discord. The agent loop already converts MCP failures to a soft string; this is defense-in-depth at the route boundary, mirroring `_reply_workflow_run`.

### Scope note (follow-up)
The issue assumed existing commands already enforce the allowlist at the slash layer — they don't: **all** slash callbacks (reflect/checkin/surface/save/register/workflow) share this pre-existing callback-level gap. Per the scope fence ("only … the author routes"), this PR gates **only** `ask`+`draft`; I'll file a follow-up to extend `_interaction_allowed` to the rest. The `register(config=...)` plumbing to do so is now in place.

## Test plan
`cd crawdad && ./scripts/check-all.sh` → **7/7 green** (426 passed, slash_commands.py 99.03%). New negative-path tests:
- `_interaction_allowed` parametrized by user AND channel (the four AND-gate combinations).
- Author callbacks **deny non-allowlisted silently** (assert `defer` not called and nothing sent) and **allow allowlisted** (defer + one reply).
- `handle_ask`/`handle_draft` **degrade softly** when the runner raises `MCPUnavailableError` (one soft reply containing "unreachable", no exception propagates) and **relay** a soft-error string returned by the runner.

Closes #468
Refs #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)