### PR TITLE
feat(mediums): book-report medium contract + --work input (#469)

### DIFF
--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -34,10 +34,10 @@ if TYPE_CHECKING:
     from creek.models import MediumContract
 
 #: Mediums the conductor will run. ``research``/``chat``/``essay``/
-#: ``research-piece`` are wired; the remaining mediums (book-report/how-to)
+#: ``research-piece``/``book-report`` are wired; the remaining mediums (how-to)
 #: arrive later.
 SUPPORTED_MEDIUMS: frozenset[str] = frozenset(
-    {"research", "chat", "essay", "research-piece"}
+    {"research", "chat", "essay", "research-piece", "book-report"}
 )
 
 #: Fixed pipeline steps that follow the specialist roster, in order.

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -16,9 +16,9 @@ from creek.compile.provenance import ProvenanceEntry
 from creek.models import Dosage, Frequency, Mode, Phase
 
 #: Mediums the author desk can produce. ``research``/``chat``/``essay``/
-#: ``research-piece`` are wired; the others (book-report/how-to) arrive in later
-#: issues.
-Medium = Literal["research", "chat", "essay", "research-piece"]
+#: ``research-piece``/``book-report`` are wired; the others (how-to) arrive in
+#: later issues.
+Medium = Literal["research", "chat", "essay", "research-piece", "book-report"]
 
 #: The reflection node's bounded verdict over a drafted body.
 ReflectionVerdict = Literal["PASS", "REVISE", "ESCALATE"]

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2641,13 +2641,80 @@ def _resolve_save_tier(
     return PrivacyTier.OPEN
 
 
+def _validate_author_inputs(
+    medium: str, query: str | None, work: Path | None, supported: frozenset[str]
+) -> None:
+    """Validate the ``author`` command's medium/query/work combination.
+
+    Enforces the per-medium input contract: a known medium, ``--work`` required
+    for ``book-report``, and ``--query`` required for every other medium.
+
+    Args:
+        medium: The requested output medium.
+        query: The optional ``--query`` value.
+        work: The optional ``--work`` path (book-report only).
+        supported: The set of wired mediums.
+
+    Raises:
+        typer.Exit: With code 2 when the combination is invalid.
+    """
+    if medium not in supported:
+        wired = ", ".join(repr(m) for m in sorted(supported))
+        console.print(
+            f"[red]Unsupported --medium {medium!r}; wired mediums are {wired} "
+            "(FEAT-041).[/red]",
+        )
+        raise typer.Exit(code=2)
+    if medium == "book-report" and work is None:
+        console.print(
+            "[red]--work is required for --medium book-report: pass the "
+            "11-Other-Authors/<author>/<work> path to report on.[/red]",
+        )
+        raise typer.Exit(code=2)
+    if medium != "book-report" and query is None:
+        console.print(
+            f"[red]--query is required for --medium {medium}.[/red]",
+        )
+        raise typer.Exit(code=2)
+
+
+def _compose_author_query(query: str | None, work: Path | None) -> str:
+    """Compose the effective query string the conductor receives.
+
+    For ``book-report`` the query is derived from the ``--work`` path (so
+    ``--work`` is a CLI-layer convenience and the conductor signature is
+    unchanged), with any explicit ``--query`` appended. Otherwise the validated
+    ``--query`` is used verbatim.
+
+    Args:
+        query: The optional ``--query`` value.
+        work: The optional ``--work`` path (book-report only).
+
+    Returns:
+        The effective query string to author from.
+    """
+    if work is not None:
+        derived = f"Report on the work at {work}, relating it to my threads and eddies."
+        return f"{derived} {query}" if query else derived
+    # Validation guarantees a non-None query for non-book-report mediums.
+    return query or ""
+
+
 @app.command()
 def author(
-    query: str = typer.Option(..., "--query", help="What to author about."),
+    query: str | None = typer.Option(None, "--query", help="What to author about."),
     medium: str = typer.Option(
         "research",
         "--medium",
-        help="Output medium. Only 'research' is wired in the skeleton (FEAT-041).",
+        help=(
+            "Output medium: research, chat, essay, research-piece, or "
+            "book-report (FEAT-041)."
+        ),
+    ),
+    work: Path | None = typer.Option(
+        None,
+        "--work",
+        help="For book-report: the 11-Other-Authors/<author>/<work> path to report on.",
     ),
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
     dry_run: bool = typer.Option(
@@ -2671,17 +2738,14 @@ def author(
     Drives an end-to-end author desk — stub Graph/Retrieval/Ontology
     specialists, a stub Voice agent, and a stub Reflection node — and prints a
     shaped :class:`~creek.author.models.AuthoredDraft`. ``--dry-run`` prints the
-    plan and a stub evidence summary instead. Only the ``research`` medium is
-    wired; real retrieval/synthesis/voicing arrive in later FEAT-041 issues.
+    plan and a stub evidence summary instead. ``book-report`` takes ``--work``
+    (the 11-Other-Authors path) instead of ``--query``; every other medium
+    requires ``--query``.
     """
     from creek.author import SUPPORTED_MEDIUMS, build_default_conductor
 
-    if medium not in SUPPORTED_MEDIUMS:
-        console.print(
-            f"[red]Unsupported --medium {medium!r}; only 'research' is wired "
-            "in the Writing Desk skeleton (FEAT-041).[/red]",
-        )
-        raise typer.Exit(code=2)
+    _validate_author_inputs(medium, query, work, SUPPORTED_MEDIUMS)
+    effective_query = _compose_author_query(query, work)
 
     config = _load_config_for_vault(vault)
     vault_path = _resolve_vault(vault if vault is not None else config.vault_path)
@@ -2689,7 +2753,7 @@ def author(
     conductor = build_default_conductor(max_rounds=rounds)
 
     if dry_run:
-        evidence = conductor.gather_evidence(query, vault_path)
+        evidence = conductor.gather_evidence(effective_query, vault_path)
         console.print(f"PLAN: {' → '.join(conductor.plan())}")
         console.print(
             f"EVIDENCE (stub): {len(evidence.claims)} claims, "
@@ -2697,7 +2761,7 @@ def author(
         )
         return
 
-    draft_result = conductor.run(medium=medium, query=query, vault=vault_path)
+    draft_result = conductor.run(medium=medium, query=effective_query, vault=vault_path)
     console.print(
         f"medium={draft_result.medium} verdict={draft_result.verdict} "
         f"rounds={draft_result.rounds} provenance={len(draft_result.provenance)}",

--- a/creek-tools/creek/templates/skills/mediums/book-report.MEDIUM.md
+++ b/creek-tools/creek/templates/skills/mediums/book-report.MEDIUM.md
@@ -1,0 +1,78 @@
+---
+medium: book-report
+structure:
+  - the-work
+  - resonance
+  - tension
+  - synthesis
+  - citations
+specialist_weights:
+  graph: 0.3
+  retrieval: 0.3
+  ontology: 0.25
+  voice: 0.15
+citation_norm: every-claim
+default_privacy_tier: open
+reflection_rubric:
+  attribution_correctness: 0.3
+  citation_completeness: 0.25
+  ontological_accuracy: 0.2
+  voice_fidelity: 0.1
+  privacy_compliance: 0.1
+  paradox_preservation: 0.05
+---
+
+# book-report.MEDIUM.md
+
+**Medium:** `book-report`
+**Budget:** ≤1500 tokens
+**Loaded by:** the Creek Writing Desk Conductor (FEAT-041)
+
+## What the `book-report` medium is for
+
+A synthesis of one specific other-author work — an
+`11-Other-Authors/<author>/<work>` — read *against the owner's own threads and
+eddies*. The animating question is **"how does this book resonate with what I
+already believe?"** Where `research-piece` argues the owner's thesis from
+evidence, a book-report holds a borrowed work up to the owner's existing
+currents: where it confirms them, where it strains against them, what new turn
+it suggests. The work is attributed throughout — its every claim is the
+*author's*, never quietly absorbed into the owner's voice.
+
+## Structure
+
+Compose in this order: **the-work → resonance → tension → synthesis →
+citations.** Name the work and its author plainly, surface where it *resonates*
+with the owner's threads/eddies, hold the *tension* where it pushes back,
+synthesise what the encounter changes, then list every source. The register is
+externally legible but owner-anchored: it reads as the owner thinking *with* a
+book, not as the book ventriloquised.
+
+## Specialist weighting
+
+Graph and Retrieval are weighted highest (0.3 each): Graph surfaces the owner's
+threads/eddies the work links into (the resonance), Retrieval surfaces the work
+itself and its attributed fragments. Ontology (0.25) keeps the canonical
+APTITUDE/Wavelength mapping correct across both the work and the owner's
+currents — and surfaces, never resolves, the tensions between them. Voice
+(0.15) is present but subordinate: this is analysis, not a personal-voice
+performance.
+
+## Citation norm — `every-claim`
+
+Every substantive claim must cite its source: the owner's `source_fragments`
+and threads/eddies for what the owner already believes, and — for anything drawn
+from the work — its `11-Other-Authors/<author>/` origin credited by name. A
+borrowed claim presented as the owner's own is a defect, not a stylistic choice.
+
+## Reflection rubric (§8)
+
+The reflection node weights **attribution correctness** highest (0.3) — for a
+report *about* a borrowed work, mis-attributing the author (or absorbing the
+work's ideas into the owner's voice) is the cardinal failure. **Citation
+completeness** (0.25) follows: every claim, owner's or borrowed, must trace to a
+source. **Ontological accuracy** (0.2) keeps the canonical taxonomy correct.
+Voice fidelity (0.1) and privacy compliance (0.1) round out the body; **paradox
+preservation** (0.05) keeps the tensions between the work and the owner's
+threads surfaced rather than tidied away. A mis-attributed or uncited claim →
+`REVISE`; exhausting the round budget without a `PASS` → `ESCALATE`.

--- a/creek-tools/tests/test_author_desk.py
+++ b/creek-tools/tests/test_author_desk.py
@@ -186,9 +186,9 @@ def test_require_supported_medium_returns_validated_value(
 
 
 def test_run_author_rejects_unknown_medium(tmp_path: Path) -> None:
-    """Only the ``research`` medium is wired; others raise a clear error."""
+    """An unwired medium raises a clear error naming the wired set."""
     with pytest.raises(ValueError, match="research"):
-        run_author(medium="book-report", query="q", vault=tmp_path)
+        run_author(medium="not-a-medium", query="q", vault=tmp_path)
 
 
 def test_author_llm_client_delegates_to_provider() -> None:

--- a/creek-tools/tests/test_book_report_medium.py
+++ b/creek-tools/tests/test_book_report_medium.py
@@ -1,0 +1,187 @@
+"""Tests for the book-report medium contract (FEAT-041 #469).
+
+``book-report`` synthesizes a specific ``11-Other-Authors/<author>/<work>`` work
+against the owner's existing threads/eddies — "how does this book resonate with
+what I already believe?" — attributing the work throughout. Its contract is
+attribution-heavy (every claim cited, the rubric weighting attribution unusually
+high) and weights Graph (thread/eddy linkage) + Retrieval (the work) +
+Ontology. These tests reuse the #457 conformance harness, mirror
+``test_research_piece_medium.py``, and pin the Definition-of-Done invariant: a
+run over a vault carrying an ``11-Other-Authors/`` work *and* the owner's
+thread/eddy fragments the work links to surfaces both an attributed claim and
+the owner's fragments.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.author import (
+    SUPPORTED_MEDIUMS,
+    assert_contract_conformant,
+    load_medium_contract,
+    require_supported_medium,
+    run_author,
+)
+from creek.author.conductor import build_default_conductor
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_FM = (
+    '---\ntype: fragment\nid: {id}\ntitle: "{title}"\n'
+    "source:\n  platform: {platform}\n  author: {author}\n{extra}---\n{body}\n"
+)
+
+
+def _write(
+    vault: Path,
+    subdir: str,
+    frag_id: str,
+    title: str,
+    *,
+    body: str = "body",
+    author: str = "self",
+    author_slug: str | None = None,
+    platform: str = "journal",
+) -> None:
+    """Write a minimal fragment markdown file under *subdir* of *vault*.
+
+    Mirrors the ``_write`` helper in ``test_real_agents.py`` so other-author
+    fragments are seeded the established way (``author_slug`` in frontmatter).
+
+    Args:
+        vault: The vault root to write under.
+        subdir: The vault subdirectory (e.g. ``11-Other-Authors/<slug>``).
+        frag_id: The fragment id (also the file stem).
+        title: The fragment title.
+        body: The fragment body text.
+        author: The authorship axis (``self``/``other``/...).
+        author_slug: The ``11-Other-Authors/`` slug, or ``None`` for self.
+        platform: The source platform string.
+    """
+    folder = vault / subdir
+    folder.mkdir(parents=True, exist_ok=True)
+    extra = f"  author_slug: {author_slug}\n" if author_slug else ""
+    (folder / f"{frag_id}.md").write_text(
+        _FM.format(
+            id=frag_id,
+            title=title,
+            platform=platform,
+            author=author,
+            extra=extra,
+            body=body,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_book_report_contract_loads_and_conforms(tmp_path: Path) -> None:
+    """The book-report contract loads and passes the conformance harness."""
+    contract = load_medium_contract("book-report", tmp_path)
+
+    assert_contract_conformant(contract)
+    assert contract.medium == "book-report"
+    assert contract.structure  # non-empty ordered sections
+
+
+def test_book_report_citation_is_strict(tmp_path: Path) -> None:
+    """book-report cites every claim — stricter than essay's ``light``."""
+    contract = load_medium_contract("book-report", tmp_path)
+    essay = load_medium_contract("essay", tmp_path)
+
+    assert contract.citation_norm == "every-claim"
+    assert essay.citation_norm == "light"
+
+
+def test_book_report_rubric_weights_attribution_heavily(tmp_path: Path) -> None:
+    """The rubric weights attribution unusually high — heavier than essay (SPEC §8)."""
+    rubric = load_medium_contract("book-report", tmp_path).reflection_rubric
+    essay = load_medium_contract("essay", tmp_path).reflection_rubric
+
+    assert rubric["attribution_correctness"] > essay["attribution_correctness"]
+    assert rubric["citation_completeness"] >= rubric["voice_fidelity"]
+
+
+def test_book_report_weights_graph_retrieval_ontology_over_voice(
+    tmp_path: Path,
+) -> None:
+    """book-report favours Graph/Retrieval/Ontology over Voice (thread/eddy linkage)."""
+    weights = load_medium_contract("book-report", tmp_path).specialist_weights
+
+    assert weights["graph"] >= weights["voice"]
+    assert weights["retrieval"] >= weights["voice"]
+    assert weights["ontology"] >= weights["voice"]
+
+
+def test_book_report_specialist_weights_sum_to_one(tmp_path: Path) -> None:
+    """The specialist weights sum to ~1.0 (conformance invariant, SPEC §5)."""
+    weights = load_medium_contract("book-report", tmp_path).specialist_weights
+
+    assert abs(sum(weights.values()) - 1.0) < 0.01
+
+
+def test_require_supported_medium_accepts_book_report() -> None:
+    """``require_supported_medium`` accepts ``book-report`` (it is wired)."""
+    assert "book-report" in SUPPORTED_MEDIUMS
+    assert require_supported_medium("book-report") == "book-report"
+
+
+def test_run_author_book_report_returns_draft(tmp_path: Path) -> None:
+    """``run_author(medium='book-report')`` returns a draft (no ValueError)."""
+    draft = run_author(
+        medium="book-report",
+        query="Report on the work, relating it to my threads and eddies.",
+        vault=tmp_path,
+    )
+
+    assert draft.medium == "book-report"
+    assert draft.body.strip()
+    assert draft.verdict in {"PASS", "REVISE", "ESCALATE"}
+
+
+def test_book_report_resonance_attributes_work_and_references_owner_threads(
+    tmp_path: Path,
+) -> None:
+    """A book-report run attributes the work AND references the owner's threads.
+
+    The Definition-of-Done invariant: seed (a) an ``11-Other-Authors/<author>/``
+    work and (b) the owner's thread fragment the work wikilinks to, then assert a
+    claim attributes the work (``author_slug``) AND the owner thread fragment id
+    appears in the evidence's source fragments. Concrete id assertions, not
+    vacuous truthiness.
+    """
+    _write(
+        tmp_path,
+        "01-Fragments/Threads",
+        "frag-owner-leverage",
+        "leverage and judgement",
+        body="Leverage is how I already think about compounding judgement.",
+        author="self",
+    )
+    _write(
+        tmp_path,
+        "11-Other-Authors/naval-ravikant",
+        "frag-naval-leverage",
+        "leverage report",
+        body="Leverage multiplies judgement. [[frag-owner-leverage]]",
+        author="other",
+        author_slug="naval-ravikant",
+        platform="markdown",
+    )
+
+    conductor = build_default_conductor(
+        max_rounds=1, contract=load_medium_contract("book-report", tmp_path)
+    )
+    effective_query = "leverage report relating it to my threads and eddies"
+    evidence = conductor.gather_evidence(effective_query, tmp_path)
+
+    attributed = [c for c in evidence.claims if c.author_slug == "naval-ravikant"]
+    assert attributed, "expected a claim attributed to naval-ravikant"
+    assert any("frag-naval-leverage" in c.source_fragments for c in attributed), (
+        "the attributed claim must cite the other-author work fragment"
+    )
+    referenced = evidence.all_source_fragments()
+    assert "frag-owner-leverage" in referenced, (
+        "the owner's thread fragment must surface via thread/eddy linkage"
+    )

--- a/creek-tools/tests/test_cli_author.py
+++ b/creek-tools/tests/test_cli_author.py
@@ -64,7 +64,7 @@ def test_author_rejects_unknown_medium(tmp_path: Path) -> None:
         [
             "author",
             "--medium",
-            "book-report",
+            "not-a-medium",
             "--query",
             "q",
             "--vault",
@@ -73,7 +73,63 @@ def test_author_rejects_unknown_medium(tmp_path: Path) -> None:
     )
 
     assert result.exit_code != 0
-    assert "research" in result.output
+    assert "not-a-medium" in result.output
+
+
+def test_author_book_report_requires_work(tmp_path: Path) -> None:
+    """``--medium book-report`` without ``--work`` exits 2 with a clear error."""
+    result = runner.invoke(
+        app,
+        [
+            "author",
+            "--medium",
+            "book-report",
+            "--vault",
+            str(_vault(tmp_path)),
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "--work" in result.output
+
+
+def test_author_non_book_report_requires_query(tmp_path: Path) -> None:
+    """A non-book-report medium without ``--query`` exits 2 with a clear error."""
+    result = runner.invoke(
+        app,
+        [
+            "author",
+            "--medium",
+            "essay",
+            "--vault",
+            str(_vault(tmp_path)),
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "--query" in result.output
+
+
+def test_author_book_report_runs_from_work_without_query(tmp_path: Path) -> None:
+    """``--medium book-report --work <path>`` (no ``--query``) prints a draft."""
+    vault = _vault(tmp_path)
+    work = vault / "11-Other-Authors" / "naval-ravikant" / "on-leverage"
+    work.mkdir(parents=True)
+    result = runner.invoke(
+        app,
+        [
+            "author",
+            "--medium",
+            "book-report",
+            "--work",
+            str(work),
+            "--vault",
+            str(vault),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "verdict=" in result.output
 
 
 def test_author_max_rounds_out_of_range(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_mcp_tools.py
+++ b/creek-tools/tests/test_mcp_tools.py
@@ -427,7 +427,7 @@ def test_author_tool_rejects_unknown_medium(vault: Path) -> None:
     result = author_tool(
         vault_path=vault,
         query="q",
-        medium="book-report",
+        medium="not-a-medium",
         consumer="test",
     )
     assert result["status"] == "error"
@@ -442,7 +442,7 @@ def test_author_tool_error_envelope_includes_dry_run(vault: Path) -> None:
     result = author_tool(
         vault_path=vault,
         query="q",
-        medium="book-report",
+        medium="not-a-medium",
         dry_run=True,
         consumer="test",
     )


### PR DESCRIPTION
## Summary

Adds the **`book-report`** medium (FEAT-041 §5, medium #5): synthesizes a specific `11-Other-Authors/<author>/<work>` against the owner's existing threads/eddies — "how does this book resonate with what I already believe?" — attributing the work throughout.

- **New `book-report.MEDIUM.md` contract:** `citation_norm: every-claim`; graph + retrieval co-weighted (thread/eddy linkage + the work) plus ontology; **`attribution_correctness` rubric weight 0.3** (vs essay's 0.05) — attribution is the cardinal dimension. Weight maps sum to 1.0 and pass the conformance harness.
- **Wires the medium:** `book-report` added to `SUPPORTED_MEDIUMS` and the `Medium` literal. Additive — existing mediums and all desk internals untouched.
- **CLI `creek author`:** `--query` is now optional and a new `--work <path>` is accepted. Two CLI-layer helpers keep the command simple and the conductor signature **unchanged** (no desk-internal change): `_validate_author_inputs` (book-report requires `--work`; every other medium requires `--query`; unknown medium → exit 2 naming the wired set) and `_compose_author_query` (derives the effective query from the work path, appending any explicit `--query`). So `--work` is a pure CLI convenience that the conductor never sees as a new parameter.

## Test plan
`cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (4919 passed, 93.75% cov). New `tests/test_book_report_medium.py` + CLI cases:
- Contract conformance; `every-claim` vs essay's `light`; attribution-heavy rubric; graph/retrieval/ontology out-weight voice; weights sum to 1.0; `require_supported_medium("book-report")`.
- **DoD resonance test:** a book-report over a vault seeded with an `11-Other-Authors/naval-ravikant/` work that wikilinks an owner thread fragment surfaces a claim attributing the work (`author_slug="naval-ravikant"`, with the work's id) **and** the owner thread fragment id in the evidence (surfaced via the Graph walk).
- **CLI:** `--medium book-report --work <path>` (no `--query`) exits 0 and prints the draft; missing `--work` for book-report and missing `--query` for other mediums both exit 2 with clear errors.

Three existing tests that used `book-report` as their *unwired-medium* stand-in are repointed to a still-unsupported placeholder (intent preserved, no assertion weakened).

Closes #469
Refs #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)