### PR TITLE
feat(classify): 11-Other-Authors attribution from manifest, fail-closed (#470)

### DIFF
--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -639,11 +639,12 @@ class FragmentSource(BaseModel):
         if value is None:
             return None
         if (
-            value in {".", ".."}
+            not value
+            or value in {".", ".."}
             or "/" in value
             or "\\" in value
             or "\x00" in value
-            or not value.strip()
+            or any(ch.isspace() for ch in value)
         ):
             msg = f"author_slug must be a single safe path segment, got {value!r}"
             raise ValueError(msg)

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -624,6 +624,31 @@ class FragmentSource(BaseModel):
     # ``author`` (the self|ai|other|collaborative axis), which is unchanged.
     author_slug: str | None = None
 
+    @field_validator("author_slug")
+    @classmethod
+    def _reject_unsafe_author_slug(cls, value: str | None) -> str | None:
+        """Reject an ``author_slug`` that is not a single safe path segment.
+
+        ``author_slug`` names an ``11-Other-Authors/<slug>/`` folder and is
+        interpolated into vault paths by the writer and the manifest loader, so
+        a value carrying a path separator or a ``.``/``..`` traversal token
+        could escape the vault. Such a value is rejected at the data boundary
+        (#470). ``None`` (a native fragment) is always valid; the vault reader
+        skips any on-disk fragment whose frontmatter fails this check.
+        """
+        if value is None:
+            return None
+        if (
+            value in {".", ".."}
+            or "/" in value
+            or "\\" in value
+            or "\x00" in value
+            or not value.strip()
+        ):
+            msg = f"author_slug must be a single safe path segment, got {value!r}"
+            raise ValueError(msg)
+        return value
+
 
 class FrequencyClassification(BaseModel):
     """APTITUDE frequency classification with primary and secondary frequencies."""

--- a/creek-tools/creek/vault/__init__.py
+++ b/creek-tools/creek/vault/__init__.py
@@ -1,6 +1,9 @@
 """Creek vault subpackage — read/write ontological primitives in an Obsidian vault."""
 
-from creek.vault.authors import load_author_manifest
+from creek.vault.authors import (
+    load_author_manifest,
+    load_author_manifest_or_default,
+)
 from creek.vault.reader import iter_vault_fragments, try_load_fragment
 from creek.vault.writer import VaultWriter
 
@@ -8,5 +11,6 @@ __all__ = [
     "VaultWriter",
     "iter_vault_fragments",
     "load_author_manifest",
+    "load_author_manifest_or_default",
     "try_load_fragment",
 ]

--- a/creek-tools/creek/vault/authors.py
+++ b/creek-tools/creek/vault/authors.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import frontmatter
 import yaml
+from pydantic import ValidationError
 
 from creek.models import AuthorManifest
 
@@ -76,7 +77,7 @@ def load_author_manifest_or_default(vault_path: Path, slug: str) -> AuthorManife
             slug,
             path,
         )
-    except (OSError, ValueError, yaml.YAMLError) as exc:
+    except (OSError, ValueError, ValidationError, yaml.YAMLError) as exc:
         logger.warning(
             "Author manifest unreadable for slug %r at %s (%s); "
             "failing closed to voice_weight=0.0 / human_source.",

--- a/creek-tools/creek/vault/authors.py
+++ b/creek-tools/creek/vault/authors.py
@@ -12,6 +12,7 @@ import logging
 from pathlib import Path
 
 import frontmatter
+import yaml
 
 from creek.models import AuthorManifest
 
@@ -75,7 +76,7 @@ def load_author_manifest_or_default(vault_path: Path, slug: str) -> AuthorManife
             slug,
             path,
         )
-    except (OSError, ValueError) as exc:
+    except (OSError, ValueError, yaml.YAMLError) as exc:
         logger.warning(
             "Author manifest unreadable for slug %r at %s (%s); "
             "failing closed to voice_weight=0.0 / human_source.",

--- a/creek-tools/creek/vault/authors.py
+++ b/creek-tools/creek/vault/authors.py
@@ -8,14 +8,17 @@ author's slug is its folder name, not the frontmatter value).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+from pathlib import Path
 
 import frontmatter
 
 from creek.models import AuthorManifest
 
-if TYPE_CHECKING:
-    from pathlib import Path
+logger = logging.getLogger(__name__)
+
+OTHER_AUTHORS_DIR = "11-Other-Authors"
+"""Top-level vault folder governing borrowed, non-owner author content."""
 
 
 def load_author_manifest(path: Path) -> AuthorManifest:
@@ -43,3 +46,41 @@ def load_author_manifest(path: Path) -> AuthorManifest:
     # Slug authority: the folder name is the identity key (FEAT-041 §7.1).
     data["author_slug"] = path.parent.name
     return AuthorManifest.model_validate(data)
+
+
+def load_author_manifest_or_default(vault_path: Path, slug: str) -> AuthorManifest:
+    """Load ``<vault>/11-Other-Authors/<slug>/_author.md``, failing closed (#470).
+
+    Resolves the manifest governing borrowed content under *slug*. When the
+    ``_author.md`` file is missing or cannot be parsed/validated, this returns a
+    default :class:`~creek.models.AuthorManifest` for *slug* — which already
+    defaults to ``human_source`` / ``voice_weight=0.0`` /
+    ``representativeness="reference"`` — so a borrowed fragment can never inherit
+    voice influence from an absent or corrupt manifest (fail-closed to 0.0).
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+        slug: The ``11-Other-Authors/<slug>/`` folder name.
+
+    Returns:
+        The parsed manifest, or a safe default manifest for *slug*.
+    """
+    path = Path(vault_path) / OTHER_AUTHORS_DIR / slug / "_author.md"
+    try:
+        return load_author_manifest(path)
+    except FileNotFoundError:
+        logger.warning(
+            "Author manifest missing for slug %r at %s; "
+            "failing closed to voice_weight=0.0 / human_source.",
+            slug,
+            path,
+        )
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "Author manifest unreadable for slug %r at %s (%s); "
+            "failing closed to voice_weight=0.0 / human_source.",
+            slug,
+            path,
+            exc,
+        )
+    return AuthorManifest(author_slug=slug)

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -31,9 +31,14 @@ import frontmatter
 
 from creek.audit import AuditLog
 from creek.models import (
+    Authorship,
     DecisionStatus,
     PraxisType,
     SourcePlatform,
+)
+from creek.vault.authors import (
+    OTHER_AUTHORS_DIR,
+    load_author_manifest_or_default,
 )
 
 if TYPE_CHECKING:
@@ -42,6 +47,7 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
     from creek.models import (
+        AuthorManifest,
         Decision,
         Eddy,
         Fragment,
@@ -69,6 +75,15 @@ _PLATFORM_SUBFOLDER: dict[str, str] = {
     SourcePlatform.PRESENTATION: "Decks",
     SourcePlatform.IMAGE_OCR: "Images",
     SourcePlatform.OTHER: "Unsorted",
+}
+
+# Map an AuthorManifest.author_kind -> the fragment's Authorship axis (#470).
+# Any unrecognised kind (the manifest already fails closed to ``human_source``)
+# resolves to OTHER via ``.get(..., Authorship.OTHER)`` at the call site.
+_AUTHOR_KIND_TO_AUTHORSHIP: dict[str, Authorship] = {
+    "ai_as_user": Authorship.AI,
+    "collaborator": Authorship.COLLABORATIVE,
+    "human_source": Authorship.OTHER,
 }
 
 # Map praxis type -> 04-Praxis subfolder
@@ -371,6 +386,41 @@ def _atomic_write_text(path: Path, content: str) -> None:
                 tmp_path.unlink()
 
 
+def _apply_other_author_attribution(
+    fragment: Fragment,
+    manifest: AuthorManifest,
+) -> None:
+    """Stamp borrowed-author attribution from *manifest* onto *fragment* (#470).
+
+    Mutates *fragment* in place (``Fragment``/``FragmentSource`` are mutable
+    Pydantic models, not frozen). Only the *attribution* axis changes — the
+    fragment's frequency / wavelength / voice (its IDEAS classification, set
+    upstream) is left untouched:
+
+    * ``source.author_slug`` ← the manifest slug (the folder name).
+    * ``source.author`` ← per :data:`_AUTHOR_KIND_TO_AUTHORSHIP`
+      (``ai_as_user`` → AI, ``collaborator`` → COLLABORATIVE, otherwise OTHER).
+    * ``representativeness`` ← ``"endorsed"`` forced for ``ai_as_user``,
+      otherwise the manifest's ``representativeness`` (default ``"reference"``).
+    * ``voice_weight`` ← the manifest's ``voice_weight`` (default ``0.0``, and
+      ``0.0`` when the manifest was loaded fail-closed from a missing file).
+
+    Args:
+        fragment: The fragment to stamp (mutated in place).
+        manifest: The governing ``11-Other-Authors/<slug>/`` manifest.
+    """
+    fragment.source.author_slug = manifest.author_slug
+    fragment.source.author = _AUTHOR_KIND_TO_AUTHORSHIP.get(
+        manifest.author_kind,
+        Authorship.OTHER,
+    )
+    if manifest.author_kind == "ai_as_user":
+        fragment.representativeness = "endorsed"
+    else:
+        fragment.representativeness = manifest.representativeness
+    fragment.voice_weight = manifest.voice_weight
+
+
 class VaultWriter:
     """Write Creek ontological primitives to an Obsidian vault.
 
@@ -443,13 +493,23 @@ class VaultWriter:
         )
 
     def write_fragment(self, fragment: Fragment, body: str = "") -> Path:
-        """Write a Fragment to the appropriate 01-Fragments/ subfolder.
+        """Write a Fragment to the correct vault folder, stamping attribution.
 
-        Maps the fragment's source platform to a subfolder via the total
-        ``_PLATFORM_SUBFOLDER`` mapping. The ``body`` parameter holds the
-        converted markdown content, which is written below the YAML
-        frontmatter — without it the fragment file would contain only
-        metadata (the historical bug).
+        A *native* fragment (``source.author_slug`` is ``None``/empty) routes by
+        source platform via the total ``_PLATFORM_SUBFOLDER`` mapping into
+        ``01-Fragments/<subfolder>/``, unchanged.
+
+        A *borrowed* fragment (``source.author_slug`` set) is other-author
+        content (#470): it routes into ``11-Other-Authors/<slug>/`` instead, and
+        its ATTRIBUTION (author / author_slug / representativeness / voice_weight)
+        is stamped from that slug's ``_author.md`` manifest via a fail-closed
+        loader — a missing/corrupt manifest yields ``voice_weight=0.0``. The
+        fragment's IDEAS classification (frequency / wavelength / voice, set
+        upstream) is never touched.
+
+        The ``body`` parameter holds the converted markdown content, which is
+        written below the YAML frontmatter — without it the fragment file would
+        contain only metadata (the historical bug).
 
         Args:
             fragment: The Fragment model to write.
@@ -461,6 +521,12 @@ class VaultWriter:
         Returns:
             Path to the written (or existing duplicate) markdown file.
         """
+        slug = fragment.source.author_slug
+        if slug:
+            manifest = load_author_manifest_or_default(self.vault_path, slug)
+            _apply_other_author_attribution(fragment, manifest)
+            target_dir = self.vault_path / OTHER_AUTHORS_DIR / slug
+            return self._write_model(fragment, target_dir, body=body)
         platform = fragment.source.platform
         subfolder = _PLATFORM_SUBFOLDER[str(platform)]
         target_dir = self.vault_path / "01-Fragments" / subfolder

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import frontmatter
+import yaml
 
 from creek.audit import AuditLog
 from creek.models import (
@@ -824,7 +825,10 @@ class VaultWriter:
         for md_file in target_dir.glob("*.md"):
             try:
                 post = frontmatter.load(str(md_file))
-            except (OSError, ValueError):
+            except (OSError, ValueError, yaml.YAMLError):
+                # A non-fragment or unparseable sibling (e.g. a corrupt
+                # ``_author.md`` manifest) must not crash the index rebuild —
+                # it simply has no fragment id to index (#470).
                 continue
             mid = post.get("id")
             if isinstance(mid, str):

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -524,10 +524,13 @@ class VaultWriter:
         """
         slug = fragment.source.author_slug
         if slug:
+            # Stamp on a deep copy so the caller's Fragment is never mutated —
+            # only the written file carries the manifest attribution (#470).
+            stamped = fragment.model_copy(deep=True)
             manifest = load_author_manifest_or_default(self.vault_path, slug)
-            _apply_other_author_attribution(fragment, manifest)
+            _apply_other_author_attribution(stamped, manifest)
             target_dir = self.vault_path / OTHER_AUTHORS_DIR / slug
-            return self._write_model(fragment, target_dir, body=body)
+            return self._write_model(stamped, target_dir, body=body)
         platform = fragment.source.platform
         subfolder = _PLATFORM_SUBFOLDER[str(platform)]
         target_dir = self.vault_path / "01-Fragments" / subfolder

--- a/creek-tools/tests/test_author_manifest.py
+++ b/creek-tools/tests/test_author_manifest.py
@@ -13,7 +13,10 @@ from typing import TYPE_CHECKING, get_args
 import pytest
 
 from creek.models import AuthorKind, AuthorManifest, PrivacyTier, Representativeness
-from creek.vault.authors import load_author_manifest
+from creek.vault.authors import (
+    load_author_manifest,
+    load_author_manifest_or_default,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -230,4 +233,24 @@ def test_model_validate_coerces_directly() -> None:
 
     assert manifest.voice_weight == 0.0
     assert manifest.author_kind == "human_source"
+    assert manifest.representativeness == "reference"
+
+
+def test_load_or_default_returns_parsed_manifest(tmp_path: Path) -> None:
+    """``load_author_manifest_or_default`` returns the parsed manifest when present."""
+    _write_manifest(tmp_path, "naval-ravikant", _FULL_MANIFEST)
+
+    manifest = load_author_manifest_or_default(tmp_path, "naval-ravikant")
+
+    assert manifest.author_slug == "naval-ravikant"
+    assert manifest.display_name == "Naval Ravikant"
+
+
+def test_load_or_default_fails_closed_when_missing(tmp_path: Path) -> None:
+    """A missing ``_author.md`` yields a safe default manifest, not a raise."""
+    manifest = load_author_manifest_or_default(tmp_path, "ghost-author")
+
+    assert manifest.author_slug == "ghost-author"
+    assert manifest.author_kind == "human_source"
+    assert manifest.voice_weight == 0.0
     assert manifest.representativeness == "reference"

--- a/creek-tools/tests/test_other_author_attribution.py
+++ b/creek-tools/tests/test_other_author_attribution.py
@@ -213,6 +213,26 @@ class TestOtherAuthorAttribution:
         assert post["voice_weight"] == 0.0
         assert post["source"]["author"] == "other"
 
+    def test_malformed_yaml_manifest_fails_closed_to_zero_weight(
+        self,
+        writer: VaultWriter,
+        vault_path: Path,
+    ) -> None:
+        """An _author.md with unparseable YAML fails closed, not crashes (#470)."""
+        # Unbalanced flow sequence -> yaml.YAMLError during frontmatter parse,
+        # raised before the model's per-field fail-closed validators run.
+        malformed = "---\nvoice_weight: [0.0\ndisplay_name: broken\n---\n# x\n"
+        _write_manifest(vault_path, "malformed", malformed)
+        frag = _classified_borrowed_fragment("malformed", "frag-malformed01")
+
+        result = writer.write_fragment(frag)
+
+        post = fm_mod.load(str(result))
+        assert post["voice_weight"] == 0.0
+        assert post["source"]["author"] == "other"
+        assert post["source"]["author_slug"] == "malformed"
+        assert post["representativeness"] == "reference"
+
     def test_native_write_is_unchanged(
         self,
         writer: VaultWriter,

--- a/creek-tools/tests/test_other_author_attribution.py
+++ b/creek-tools/tests/test_other_author_attribution.py
@@ -234,6 +234,24 @@ class TestOtherAuthorAttribution:
         assert post["source"]["author_slug"] == "malformed"
         assert post["representativeness"] == "reference"
 
+    def test_write_does_not_mutate_caller_fragment(
+        self,
+        writer: VaultWriter,
+        vault_path: Path,
+    ) -> None:
+        """Stamping attribution must not mutate the caller's Fragment (#470)."""
+        _write_manifest(vault_path, "mentor", _ASPIRATIONAL_MANIFEST)
+        frag = _classified_borrowed_fragment("mentor", "frag-nomutate01")
+
+        writer.write_fragment(frag)
+
+        # The caller's object keeps its pre-call (native-default) attribution —
+        # only the written file carries the stamped manifest values.
+        assert frag.voice_weight == 1.0
+        assert frag.representativeness == "self"
+        assert frag.source.author == "self"
+        assert frag.source.author_slug == "mentor"
+
     def test_native_write_is_unchanged(
         self,
         writer: VaultWriter,
@@ -278,6 +296,7 @@ class TestAuthorSlugPathSafety:
             ".",
             "",
             "   ",
+            "embedded space",
         ],
     )
     def test_unsafe_author_slug_is_rejected(self, bad_slug: str) -> None:

--- a/creek-tools/tests/test_other_author_attribution.py
+++ b/creek-tools/tests/test_other_author_attribution.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import frontmatter as fm_mod
 import pytest
+from pydantic import ValidationError
 
 from creek.models import (
     Fragment,
@@ -254,3 +255,43 @@ class TestOtherAuthorAttribution:
         assert post["source"]["author_slug"] is None
         assert post["voice_weight"] == 1.0
         assert post["representativeness"] == "self"
+
+
+class TestAuthorSlugPathSafety:
+    """``FragmentSource.author_slug`` is interpolated into vault paths (#470).
+
+    A slug carrying path separators or ``..`` could escape
+    ``11-Other-Authors/`` (path traversal), so the model rejects anything that
+    is not a single safe path segment at the data boundary.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_slug",
+        [
+            "../evil",
+            "../../etc/passwd",
+            "naval/../../escape",
+            "nested/slug",
+            "back\\slash",
+            "/absolute",
+            "..",
+            ".",
+            "",
+            "   ",
+        ],
+    )
+    def test_unsafe_author_slug_is_rejected(self, bad_slug: str) -> None:
+        """A traversal / multi-segment author_slug raises ValidationError."""
+        with pytest.raises(ValidationError):
+            FragmentSource(platform=SourcePlatform.SUBSTACK, author_slug=bad_slug)
+
+    @pytest.mark.parametrize("good_slug", ["naval-ravikant", "ai-as-user", "a_b.c1"])
+    def test_safe_author_slug_is_accepted(self, good_slug: str) -> None:
+        """A normal single-segment slug is accepted unchanged."""
+        source = FragmentSource(platform=SourcePlatform.SUBSTACK, author_slug=good_slug)
+        assert source.author_slug == good_slug
+
+    def test_none_author_slug_is_accepted(self) -> None:
+        """``None`` (a native fragment) is always valid."""
+        source = FragmentSource(platform=SourcePlatform.CLAUDE)
+        assert source.author_slug is None

--- a/creek-tools/tests/test_other_author_attribution.py
+++ b/creek-tools/tests/test_other_author_attribution.py
@@ -1,0 +1,236 @@
+"""Tests for other-author attribution on the vault-writer path (FEAT-041 #470).
+
+When a fragment carries ``source.author_slug`` it is borrowed content governed
+by ``11-Other-Authors/<slug>/_author.md``. The writer routes it under
+``11-Other-Authors/<slug>/`` and stamps its ATTRIBUTION (author / author_slug /
+representativeness / voice_weight) from that manifest, *failing closed* to
+``voice_weight=0.0`` when the manifest is absent or unreadable. The fragment's
+IDEAS classification (frequency / wavelength / voice, set upstream) is left
+untouched. Native (non-borrowed) writes are unchanged — the tracer invariant.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter as fm_mod
+import pytest
+
+from creek.models import (
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Phase,
+    SourcePlatform,
+    WavelengthClassification,
+)
+from creek.vault.writer import VaultWriter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_HUMAN_SOURCE_MANIFEST = """---
+type: author_manifest
+display_name: "Naval Ravikant"
+author_kind: human_source
+voice_weight: 0.0
+representativeness: reference
+default_privacy_tier: open
+attribution_required: true
+---
+
+# Naval Ravikant
+"""
+
+_AI_AS_USER_MANIFEST = """---
+type: author_manifest
+display_name: "House AI"
+author_kind: ai_as_user
+voice_weight: 0.0
+representativeness: reference
+---
+
+# House AI
+"""
+
+_ASPIRATIONAL_MANIFEST = """---
+type: author_manifest
+display_name: "Mentor"
+author_kind: human_source
+voice_weight: 0.3
+representativeness: aspirational
+---
+
+# Mentor
+"""
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture()
+def vault_path(tmp_path: Path) -> Path:
+    """Create a minimal vault structure with a native fragment subfolder."""
+    for d in (
+        "00-Creek-Meta/Processing-Log",
+        "01-Fragments/Conversations",
+    ):
+        (tmp_path / d).mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+@pytest.fixture()
+def writer(vault_path: Path) -> VaultWriter:
+    """Return a VaultWriter for the test vault."""
+    return VaultWriter(vault_path=vault_path)
+
+
+def _write_manifest(vault: Path, slug: str, frontmatter_body: str) -> None:
+    """Seed ``11-Other-Authors/<slug>/_author.md`` with *frontmatter_body*."""
+    folder = vault / "11-Other-Authors" / slug
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / "_author.md").write_text(frontmatter_body, encoding="utf-8")
+
+
+def _classified_borrowed_fragment(slug: str, frag_id: str) -> Fragment:
+    """Build a borrowed fragment with pre-set IDEAS classification."""
+    return Fragment(
+        id=frag_id,
+        title="Borrowed Idea",
+        source=FragmentSource(
+            platform=SourcePlatform.SUBSTACK,
+            author_slug=slug,
+        ),
+        frequency=FrequencyClassification(primary=Frequency.F3),
+        wavelength=WavelengthClassification(phase=Phase.RISING),
+    )
+
+
+# ---- Borrowed-author routing + stamping ----
+
+
+class TestOtherAuthorAttribution:
+    """Borrowed fragments route under 11-Other-Authors and inherit attribution."""
+
+    def test_human_source_routes_and_stamps_other(
+        self,
+        writer: VaultWriter,
+        vault_path: Path,
+    ) -> None:
+        """A human_source borrowed fragment lands under the slug folder as OTHER."""
+        _write_manifest(vault_path, "naval-ravikant", _HUMAN_SOURCE_MANIFEST)
+        frag = _classified_borrowed_fragment("naval-ravikant", "frag-naval0001")
+
+        result = writer.write_fragment(frag)
+
+        assert "11-Other-Authors/naval-ravikant" in str(result)
+        assert "01-Fragments" not in str(result)
+        post = fm_mod.load(str(result))
+        assert post["source"]["author"] == "other"
+        assert post["source"]["author_slug"] == "naval-ravikant"
+        assert post["voice_weight"] == 0.0
+
+    def test_human_source_preserves_ideas_classification(
+        self,
+        writer: VaultWriter,
+        vault_path: Path,
+    ) -> None:
+        """Stamping attribution does NOT clear the frequency/phase (ideas) tags."""
+        _write_manifest(vault_path, "naval-ravikant", _HUMAN_SOURCE_MANIFEST)
+        frag = _classified_borrowed_fragment("naval-ravikant", "frag-naval0002")
+
+        result = writer.write_fragment(frag)
+
+        post = fm_mod.load(str(result))
+        assert post["frequency"]["primary"] == "F3"
+        assert post["wavelength"]["phase"] == "rising"
+
+    def test_ai_as_user_stamps_ai_and_forces_endorsed(
+        self,
+        writer: VaultWriter,
+        vault_path: Path,
+    ) -> None:
+        """An ai_as_user manifest yields author=ai and forced representativeness."""
+        _write_manifest(vault_path, "house-ai", _AI_AS_USER_MANIFEST)
+        frag = _classified_borrowed_fragment("house-ai", "frag-houseai01")
+
+        result = writer.write_fragment(frag)
+
+        post = fm_mod.load(str(result))
+        assert post["source"]["author"] == "ai"
+        assert post["representativeness"] == "endorsed"
+        assert post["voice_weight"] == 0.0
+
+    def test_representativeness_and_weight_read_from_manifest(
+        self,
+        writer: VaultWriter,
+        vault_path: Path,
+    ) -> None:
+        """A human_source manifest's representativeness/voice_weight are inherited."""
+        _write_manifest(vault_path, "mentor", _ASPIRATIONAL_MANIFEST)
+        frag = _classified_borrowed_fragment("mentor", "frag-mentor001")
+
+        result = writer.write_fragment(frag)
+
+        post = fm_mod.load(str(result))
+        assert post["representativeness"] == "aspirational"
+        assert post["voice_weight"] == 0.3
+        assert post["source"]["author"] == "other"
+
+    def test_missing_manifest_fails_closed_to_zero_weight(
+        self,
+        writer: VaultWriter,
+    ) -> None:
+        """A slug with no _author.md still writes, fail-closed to voice_weight=0.0."""
+        frag = _classified_borrowed_fragment("no-manifest", "frag-nomani001")
+
+        result = writer.write_fragment(frag)
+
+        assert "11-Other-Authors/no-manifest" in str(result)
+        post = fm_mod.load(str(result))
+        assert post["voice_weight"] == 0.0
+        assert post["source"]["author"] == "other"
+        assert post["source"]["author_slug"] == "no-manifest"
+        assert post["representativeness"] == "reference"
+
+    def test_garbage_manifest_fails_closed_to_zero_weight(
+        self,
+        writer: VaultWriter,
+        vault_path: Path,
+    ) -> None:
+        """A garbage voice_weight in _author.md fails closed to 0.0, not a crash."""
+        body = _HUMAN_SOURCE_MANIFEST.replace(
+            "voice_weight: 0.0",
+            'voice_weight: "banana"',
+        )
+        _write_manifest(vault_path, "garbage", body)
+        frag = _classified_borrowed_fragment("garbage", "frag-garbage01")
+
+        result = writer.write_fragment(frag)
+
+        post = fm_mod.load(str(result))
+        assert post["voice_weight"] == 0.0
+        assert post["source"]["author"] == "other"
+
+    def test_native_write_is_unchanged(
+        self,
+        writer: VaultWriter,
+    ) -> None:
+        """A native fragment (author_slug=None) routes to 01-Fragments, untouched."""
+        frag = Fragment(
+            id="frag-native001",
+            title="Native Fragment",
+            source=FragmentSource(platform=SourcePlatform.CLAUDE),
+        )
+
+        result = writer.write_fragment(frag)
+
+        assert "01-Fragments/Conversations" in str(result)
+        assert "11-Other-Authors" not in str(result)
+        post = fm_mod.load(str(result))
+        # Native model defaults survive: SELF author, full voice weight.
+        assert post["source"]["author"] == "self"
+        assert post["source"]["author_slug"] is None
+        assert post["voice_weight"] == 1.0
+        assert post["representativeness"] == "self"


### PR DESCRIPTION
## Summary

When a fragment is written under `11-Other-Authors/<slug>/`, its **ideas** keep their full ontology classification (frequency/wavelength/voice, set upstream) but its **attribution** is stamped from that slug's `_author.md` manifest (FEAT-041 §7.3/§7.4) — the voice-fidelity counterpart to native ingestion.

- **`load_author_manifest_or_default(vault, slug)`** (`creek/vault/authors.py`): loads `11-Other-Authors/<slug>/_author.md`, **failing closed** to a default `AuthorManifest(slug)` (human_source / `voice_weight=0.0` / `representativeness=reference`) when the file is missing, unreadable, or invalid. Borrowed content can never inherit voice influence from an absent or corrupt manifest.
- **`VaultWriter.write_fragment` routes by attribution:** a *borrowed* fragment (`source.author_slug` set) lands under `11-Other-Authors/<slug>/` and is stamped via `_apply_other_author_attribution` — `source.author` per `author_kind` (ai_as_user→ai, collaborator→collaborative, else other), `representativeness` (ai_as_user forced to `endorsed`, else the manifest value), and `voice_weight` from the manifest. A *native* fragment (no slug) keeps the existing `01-Fragments/<subfolder>/` platform routing, **untouched** (tracer invariant).

### Design note
The trigger is `source.author_slug` being set — that's what marks a fragment as other-author content, so the writer routes + stamps accordingly without changing the ingest source types (scope fence). This is distinct from the #464 *save* path, which hard-codes the `ai-as-user` target in the save writer; #470 is the vault-writer path for arbitrary author slugs (e.g. `naval-ravikant`). Ideas classification is upstream and never touched here.

## Test plan
`cd creek-tools && ./scripts/check-all.sh` → **12/12 green**. New `tests/test_other_author_attribution.py` (+ loader tests in `test_author_manifest.py`):
- **human_source:** writes under `11-Other-Authors/<slug>/`, `source.author == "other"`, `voice_weight == 0.0`; frequency/phase tags **preserved** (`F3`/`rising`) — ideas still classified.
- **ai_as_user:** `source.author == "ai"`, `representativeness == "endorsed"`, `voice_weight == 0.0`.
- **manifest-read:** `representativeness == "aspirational"`, `voice_weight == 0.3` (proves it reads the manifest, not a hard-code).
- **Fail-closed (DoD):** a slug with a **missing** `_author.md` still writes, `voice_weight == 0.0` / `author == "other"` / `representativeness == "reference"`; plus a **garbage** manifest fails closed too.
- **Tracer invariant:** a native fragment writes to `01-Fragments/<platform>/` exactly as before.

Closes #470
Refs #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)