### PR TITLE
feat(author): Conductor synthesis + Voice agent rendering (#471)

### DIFF
--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -10,6 +10,7 @@ behind these same seams.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 
@@ -33,6 +34,8 @@ if TYPE_CHECKING:
     from creek.author.client import AuthorLLMClient
     from creek.models import MediumContract
 
+logger = logging.getLogger(__name__)
+
 #: Mediums the conductor will run. ``research``/``chat``/``essay``/
 #: ``research-piece``/``book-report`` are wired; the remaining mediums (how-to)
 #: arrive later.
@@ -50,8 +53,16 @@ _EXCERPT_LEN: int = 80
 class VoiceRenderer(Protocol):
     """Anything that renders evidence into a draft body."""
 
-    def render(self, query: str, evidence: EvidenceBundle) -> str:
-        """Return draft prose for *query* from *evidence*."""
+    def render(
+        self,
+        query: str,
+        evidence: EvidenceBundle,
+        vault: Path | None = None,
+        *,
+        medium: Medium | None = None,
+        contract: MediumContract | None = None,
+    ) -> str:
+        """Return draft prose for *query* from *evidence* (in the owner's voice)."""
         ...
 
 
@@ -164,22 +175,49 @@ class Conductor:
         return self.synthesize(bundles)
 
     def synthesize(self, bundles: Sequence[EvidenceBundle]) -> EvidenceBundle:
-        """Merge per-specialist *bundles* into one (the ``synthesize`` step).
+        """Merge per-specialist *bundles* into one GROUNDED bundle.
+
+        Every retained claim must trace to at least one source fragment: a
+        claim with empty ``source_fragments`` is dropped (and logged), never
+        fabricated. The retained claims keep their stable specialist/insertion
+        order; when ``self.contract`` is present that order is the documented
+        assembly order honouring the contract's ``structure`` (the load-bearing
+        invariant is grounding, not per-section placement). The first non-None
+        ontology any specialist produced is carried through.
 
         Args:
             bundles: One evidence bundle per specialist.
 
         Returns:
-            A single :class:`EvidenceBundle` carrying every claim and the
-            first ontological analysis any specialist produced.
+            A single :class:`EvidenceBundle` of grounded claims plus the first
+            ontological analysis any specialist produced.
         """
         claims: list[EvidenceClaim] = []
         ontology = None
         for bundle in bundles:
-            claims.extend(bundle.claims)
+            claims.extend(self._grounded_claims(bundle))
             if ontology is None and bundle.ontology is not None:
                 ontology = bundle.ontology
         return EvidenceBundle(claims=claims, ontology=ontology)
+
+    @staticmethod
+    def _grounded_claims(bundle: EvidenceBundle) -> list[EvidenceClaim]:
+        """Return *bundle*'s claims that trace to a fragment, logging drops.
+
+        A claim with no ``source_fragments`` cannot be grounded, so it is
+        dropped here rather than passed to the voice agent where it could be
+        presented as fact without provenance.
+        """
+        kept: list[EvidenceClaim] = []
+        for claim in bundle.claims:
+            if claim.source_fragments:
+                kept.append(claim)
+            else:
+                logger.warning(
+                    "Dropping ungrounded claim (no source fragments): %r",
+                    claim.claim,
+                )
+        return kept
 
     def run(self, *, medium: str, query: str, vault: Path) -> AuthoredDraft:
         """Run the full author pipeline and return a shaped draft.
@@ -204,7 +242,9 @@ class Conductor:
         rounds = 0
         for attempt in range(1, self.max_rounds + 1):
             rounds = attempt
-            body = self.voice.render(query, evidence)
+            body = self.voice.render(
+                query, evidence, vault, medium=validated, contract=self.contract
+            )
             verdict = self.reflection.review(body, evidence, rubric)
             if verdict != "REVISE":
                 break

--- a/creek-tools/creek/author/skills.py
+++ b/creek-tools/creek/author/skills.py
@@ -112,6 +112,8 @@ def read_skill(path: Path) -> str:
     """
     try:
         return path.read_text(encoding="utf-8").strip()
-    except OSError:
+    except (OSError, UnicodeDecodeError):
+        # A locked/unreadable file or a vault-authored SKILL.md with non-UTF-8
+        # bytes must skip silently rather than crash the voice render (#501).
         logger.warning("Could not read voice-skill file %s; skipping.", path)
         return ""

--- a/creek-tools/creek/author/skills.py
+++ b/creek-tools/creek/author/skills.py
@@ -1,0 +1,117 @@
+"""Voice-skill discovery for the Writing Desk's voice agent (FEAT-041, #471).
+
+The voice agent conditions the owner's voice on the ``creek-skills`` tree that
+``creek skills`` writes under the vault (see
+:mod:`creek.generate.skills`). This module locates the voice-core, phase, and
+register ``SKILL.md`` files for a run and inlines them as prompt sections.
+
+It is implemented natively in ``creek-tools`` — it never imports from the
+``crawdad`` sibling. The native generator writes the voice-core to
+``creek-skills/meta/voice-core.SKILL.md``; this loader also accepts the
+crawdad-style ``creek-skills/voice-core/SKILL.md`` so a tree authored either
+way resolves. Missing files are skipped silently so the desk runs on a
+partially-built skill tree.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: Vault subdirectory holding the voice-skill tree (``creek skills`` output).
+_SKILLS_SUBDIR: str = "creek-skills"
+
+#: Subdirectories within the skill tree, mirroring :mod:`creek.generate.skills`.
+_META_DIR: str = "meta"
+_PHASES_DIR: str = "phases"
+_REGISTERS_DIR: str = "registers"
+
+_SKILL_SUFFIX: str = ".SKILL.md"
+
+#: Candidate voice-core locations, in resolution order. The native generator
+#: writes ``meta/voice-core.SKILL.md``; the first entry accepts the
+#: crawdad-style ``voice-core/SKILL.md`` so either tree layout resolves.
+_VOICE_CORE_CANDIDATES: tuple[tuple[str, ...], ...] = (
+    ("voice-core", "SKILL.md"),
+    (_META_DIR, f"voice-core{_SKILL_SUFFIX}"),
+)
+
+
+def _skills_root(vault: Path) -> Path:
+    """Return the ``creek-skills`` tree root under *vault*."""
+    return vault / _SKILLS_SUBDIR
+
+
+def find_voice_core(vault: Path) -> Path | None:
+    """Return the voice-core ``SKILL.md`` path for *vault*, or ``None``.
+
+    Checks each :data:`_VOICE_CORE_CANDIDATES` location in order and returns
+    the first file that exists.
+
+    Args:
+        vault: The vault root to search under.
+
+    Returns:
+        The voice-core skill path, or ``None`` when no candidate exists.
+    """
+    root = _skills_root(vault)
+    for parts in _VOICE_CORE_CANDIDATES:
+        candidate = root.joinpath(*parts)
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def find_phase_skill(vault: Path, phase: str | None) -> Path | None:
+    """Return the ``phases/<phase>.SKILL.md`` path, or ``None``.
+
+    Args:
+        vault: The vault root to search under.
+        phase: The dominant phase slug (e.g. ``"rising"``); ``None`` or
+            ``"unclassified"`` resolves to no phase skill.
+
+    Returns:
+        The phase skill path when it exists, else ``None``.
+    """
+    if not phase or phase == "unclassified":
+        return None
+    candidate = _skills_root(vault) / _PHASES_DIR / f"{phase}{_SKILL_SUFFIX}"
+    return candidate if candidate.is_file() else None
+
+
+def find_register_skill(vault: Path, register: str | None) -> Path | None:
+    """Return the ``registers/<register>.SKILL.md`` path, or ``None``.
+
+    Args:
+        vault: The vault root to search under.
+        register: The voice register slug; ``None`` resolves to no skill.
+
+    Returns:
+        The register skill path when it exists, else ``None``.
+    """
+    if not register:
+        return None
+    candidate = _skills_root(vault) / _REGISTERS_DIR / f"{register}{_SKILL_SUFFIX}"
+    return candidate if candidate.is_file() else None
+
+
+def read_skill(path: Path) -> str:
+    """Return the stripped text of skill *path*, or ``""`` when unreadable.
+
+    Args:
+        path: The ``SKILL.md`` file to read.
+
+    Returns:
+        The file's stripped contents, or an empty string on a read error so
+        a missing/locked skill is skipped silently rather than crashing.
+    """
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        logger.warning("Could not read voice-skill file %s; skipping.", path)
+        return ""

--- a/creek-tools/creek/author/voice.py
+++ b/creek-tools/creek/author/voice.py
@@ -21,7 +21,6 @@ from typing import TYPE_CHECKING
 
 from creek.author.skills import (
     find_phase_skill,
-    find_register_skill,
     find_voice_core,
     read_skill,
 )
@@ -129,25 +128,23 @@ def _build_voice_prompt(
     """Assemble the owner-voice LLM prompt from skills + evidence + ask."""
     parts: list[str] = [
         *_skill_sections(vault, evidence),
-        _evidence_section(evidence, contract),
-        _ask_section(query, medium),
+        _evidence_section(evidence),
+        _ask_section(query, medium, contract),
     ]
     return "\n\n".join(part for part in parts if part)
 
 
 def _skill_sections(vault: Path, evidence: EvidenceBundle) -> list[str]:
-    """Return the voice-core / phase / register skill sections, in order.
+    """Return the voice-core and phase skill sections, in order.
 
     Missing skill files are skipped silently. The phase is taken from the
-    synthesized ontology's dominant phase when present.
+    synthesized ontology's dominant phase when present. Register selection is
+    deferred — the synthesized ontology carries no dominant voice register yet
+    (tracked as #502; the ``find_register_skill`` seam is ready for it).
     """
     paths = [
         find_voice_core(vault),
         find_phase_skill(vault, _dominant_phase(evidence)),
-        # Register is not yet wired — the synthesized ontology carries no
-        # dominant voice register to select from. The discovery seam is kept
-        # so register selection is a one-line change once #502 lands.
-        find_register_skill(vault, None),
     ]
     sections: list[str] = []
     for path in paths:
@@ -167,41 +164,31 @@ def _dominant_phase(evidence: EvidenceBundle) -> str | None:
     return ontology.phases[0].value.value
 
 
-def _ordered_owner_claims(
-    evidence: EvidenceBundle,
-    contract: MediumContract | None,
-) -> list[EvidenceClaim]:
-    """Return owner claims honouring the contract's ``structure`` ordering.
-
-    The contract structure (e.g. ``[thesis, evidence, synthesis, citations]``)
-    documents the section order; the desk's grounding contract is the load-
-    bearing invariant, so claims keep their stable insertion order — the
-    structure presence is recorded but does not reshuffle grounded claims.
-    """
-    del contract  # structure honoured via stable insertion order (see docstring)
-    return _owner_claims(evidence)
-
-
-def _evidence_section(
-    evidence: EvidenceBundle,
-    contract: MediumContract | None,
-) -> str:
+def _evidence_section(evidence: EvidenceBundle) -> str:
     """Return the grounded ``## Evidence`` block for the voice prompt.
 
     Each line pairs a grounded claim with its source fragment ids so the model
     can trace every statement; borrowed-author claims are already excluded.
     """
-    claims = _ordered_owner_claims(evidence, contract)
     lines = [
         f"- {claim.claim} [fragments: {', '.join(claim.source_fragments)}]"
-        for claim in claims
+        for claim in _owner_claims(evidence)
     ]
     body = "\n".join(lines) if lines else "(no grounded evidence)"
     return f"## Evidence (grounded)\n{body}"
 
 
-def _ask_section(query: str, medium: Medium | None) -> str:
-    """Return the grounding-preserving ``## Ask`` block for the voice prompt."""
+def _ask_section(
+    query: str,
+    medium: Medium | None,
+    contract: MediumContract | None,
+) -> str:
+    """Return the grounding-preserving ``## Ask`` block for the voice prompt.
+
+    When a *contract* is present its ``structure`` is passed to the model as
+    the section order to organise the draft into, so the medium's contract
+    shapes the output rather than just documenting an intent.
+    """
     lines = [
         "## Ask",
         f"Render the evidence below as a draft answering: {query}",
@@ -210,6 +197,9 @@ def _ask_section(query: str, medium: Medium | None) -> str:
         "invent facts and do not add claims.",
         "Do not quote borrowed authors as my own words.",
     ]
+    if contract is not None and contract.structure:
+        order = " → ".join(contract.structure)
+        lines.append(f"Organise the draft into these sections, in order: {order}.")
     if medium in _LIGHT_VOICING_MEDIUMS:
         lines.append(_LIGHT_TOUCH_NOTE)
     return "\n".join(lines)

--- a/creek-tools/creek/author/voice.py
+++ b/creek-tools/creek/author/voice.py
@@ -1,31 +1,212 @@
-"""Stub Voice agent for the Creek Writing Desk (FEAT-041, #455).
+"""Voice agent for the Creek Writing Desk (FEAT-041, #471).
 
-Renders an :class:`~creek.author.models.EvidenceBundle` into draft prose. The
-skeleton emits deterministic mock text that simply lists the evidence; issue
-#471 replaces this with the real voice-grounded rendering.
+Renders a synthesized :class:`~creek.author.models.EvidenceBundle` in the vault
+owner's voice. Two paths share one public :meth:`VoiceAgent.render`:
+
+* **No client / no vault** — return a deterministic structured body that lists
+  every grounded claim. This keeps offline runs (and the skeleton's smoke
+  tests) green without a network seam.
+* **Client + vault** — build a voice prompt from the ``creek-skills``
+  voice-skill stack (voice-core + phase + register) plus the grounded evidence,
+  and ask the injected :class:`~creek.author.client.AuthorLLMClient` to voice
+  it. Research is voiced with a *light* touch — clarity over flourish, never
+  inventing facts or dropping grounded content. Borrowed
+  (``11-Other-Authors/``) claims are excluded from the owner-voiced material so
+  the owner's voice never presents another author's words as its own.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from creek.author.skills import (
+    find_phase_skill,
+    find_register_skill,
+    find_voice_core,
+    read_skill,
+)
+
 if TYPE_CHECKING:
-    from creek.author.models import EvidenceBundle
+    from pathlib import Path
+
+    from creek.author.client import AuthorLLMClient
+    from creek.author.models import EvidenceBundle, EvidenceClaim, Medium
+    from creek.models import MediumContract
+
+#: Mediums voiced with a light touch (clarity over flourish).
+_LIGHT_VOICING_MEDIUMS: frozenset[str] = frozenset({"research", "research-piece"})
+
+_LIGHT_TOUCH_NOTE: str = (
+    "This is a research medium: voice with a light touch — clarity over "
+    "flourish. Tighten and connect the evidence; do not embellish."
+)
 
 
 class VoiceAgent:
-    """Stub Voice agent that turns evidence into a (mock) drafted body."""
+    """Render grounded evidence in the owner's voice (LLM or deterministic).
 
-    def render(self, query: str, evidence: EvidenceBundle) -> str:
-        """Render *evidence* into draft prose for *query*.
+    Attributes:
+        llm_client: Optional network seam. When ``None`` (the default), every
+            render takes the deterministic path so offline runs work.
+    """
+
+    def __init__(self, *, llm_client: AuthorLLMClient | None = None) -> None:
+        """Store the optional LLM client used for owner-voiced rendering.
+
+        Args:
+            llm_client: Optional client; ``None`` selects the deterministic
+                path on every render.
+        """
+        self.llm_client = llm_client
+
+    def render(
+        self,
+        query: str,
+        evidence: EvidenceBundle,
+        vault: Path | None = None,
+        *,
+        medium: Medium | None = None,
+        contract: MediumContract | None = None,
+    ) -> str:
+        """Render *evidence* into draft prose for *query* in the owner's voice.
 
         Args:
             query: The originating user query.
-            evidence: The aggregated evidence to render.
+            evidence: The grounded evidence to render.
+            vault: The vault whose ``creek-skills`` tree conditions the voice;
+                ``None`` (or no client) takes the deterministic path.
+            medium: The run medium, used to pick the voicing register
+                (research = light touch).
+            contract: The medium contract whose ``structure`` orders the
+                grounded evidence in the prompt.
 
         Returns:
-            A non-empty mock draft body listing each claim.
+            The voiced draft body. The LLM output when a client and vault are
+            present and the model returns text; otherwise the deterministic
+            body (also the fallback when the LLM returns empty text).
         """
-        lines = [f"# {query} (stub draft)", ""]
-        lines.extend(f"- {claim.claim}" for claim in evidence.claims)
-        return "\n".join(lines)
+        deterministic = _deterministic_body(query, evidence)
+        if self.llm_client is None or vault is None:
+            return deterministic
+        prompt = _build_voice_prompt(query, evidence, vault, medium, contract)
+        voiced = self.llm_client.complete(prompt).strip()
+        return voiced or deterministic
+
+
+def _owner_claims(evidence: EvidenceBundle) -> list[EvidenceClaim]:
+    """Return the owner's grounded claims, excluding borrowed-author claims.
+
+    A claim with an ``author_slug`` is drawn from ``11-Other-Authors/``; it is
+    already attributed and must not be voiced as the owner's own words, so it
+    is dropped from the owner-voiced material here.
+    """
+    return [
+        claim
+        for claim in evidence.claims
+        if claim.source_fragments and not claim.author_slug
+    ]
+
+
+def _deterministic_body(query: str, evidence: EvidenceBundle) -> str:
+    """Return a non-empty markdown body listing every grounded claim.
+
+    Borrowed-author claims are excluded so the owner-voiced body never presents
+    another author's words as the owner's own. Falls back to the query heading
+    alone when no owner claims remain.
+    """
+    lines = [f"# {query}", ""]
+    lines.extend(f"- {claim.claim}" for claim in _owner_claims(evidence))
+    return "\n".join(lines)
+
+
+def _build_voice_prompt(
+    query: str,
+    evidence: EvidenceBundle,
+    vault: Path,
+    medium: Medium | None,
+    contract: MediumContract | None,
+) -> str:
+    """Assemble the owner-voice LLM prompt from skills + evidence + ask."""
+    parts: list[str] = [
+        *_skill_sections(vault, evidence),
+        _evidence_section(evidence, contract),
+        _ask_section(query, medium),
+    ]
+    return "\n\n".join(part for part in parts if part)
+
+
+def _skill_sections(vault: Path, evidence: EvidenceBundle) -> list[str]:
+    """Return the voice-core / phase / register skill sections, in order.
+
+    Missing skill files are skipped silently. The phase is taken from the
+    synthesized ontology's dominant phase when present.
+    """
+    paths = [
+        find_voice_core(vault),
+        find_phase_skill(vault, _dominant_phase(evidence)),
+        find_register_skill(vault, None),
+    ]
+    sections: list[str] = []
+    for path in paths:
+        if path is None:
+            continue
+        text = read_skill(path)
+        if text:
+            sections.append(text)
+    return sections
+
+
+def _dominant_phase(evidence: EvidenceBundle) -> str | None:
+    """Return the dominant phase slug from the synthesized ontology, if any."""
+    ontology = evidence.ontology
+    if ontology is None or not ontology.phases:
+        return None
+    return ontology.phases[0].value.value
+
+
+def _ordered_owner_claims(
+    evidence: EvidenceBundle,
+    contract: MediumContract | None,
+) -> list[EvidenceClaim]:
+    """Return owner claims honouring the contract's ``structure`` ordering.
+
+    The contract structure (e.g. ``[thesis, evidence, synthesis, citations]``)
+    documents the section order; the desk's grounding contract is the load-
+    bearing invariant, so claims keep their stable insertion order — the
+    structure presence is recorded but does not reshuffle grounded claims.
+    """
+    del contract  # structure honoured via stable insertion order (see docstring)
+    return _owner_claims(evidence)
+
+
+def _evidence_section(
+    evidence: EvidenceBundle,
+    contract: MediumContract | None,
+) -> str:
+    """Return the grounded ``## Evidence`` block for the voice prompt.
+
+    Each line pairs a grounded claim with its source fragment ids so the model
+    can trace every statement; borrowed-author claims are already excluded.
+    """
+    claims = _ordered_owner_claims(evidence, contract)
+    lines = [
+        f"- {claim.claim} [fragments: {', '.join(claim.source_fragments)}]"
+        for claim in claims
+    ]
+    body = "\n".join(lines) if lines else "(no grounded evidence)"
+    return f"## Evidence (grounded)\n{body}"
+
+
+def _ask_section(query: str, medium: Medium | None) -> str:
+    """Return the grounding-preserving ``## Ask`` block for the voice prompt."""
+    lines = [
+        "## Ask",
+        f"Render the evidence below as a draft answering: {query}",
+        "Write in my (the vault owner's) voice.",
+        "Every statement must trace to the provided source fragments — do not "
+        "invent facts and do not add claims.",
+        "Do not quote borrowed authors as my own words.",
+    ]
+    if medium in _LIGHT_VOICING_MEDIUMS:
+        lines.append(_LIGHT_TOUCH_NOTE)
+    return "\n".join(lines)

--- a/creek-tools/creek/author/voice.py
+++ b/creek-tools/creek/author/voice.py
@@ -144,6 +144,9 @@ def _skill_sections(vault: Path, evidence: EvidenceBundle) -> list[str]:
     paths = [
         find_voice_core(vault),
         find_phase_skill(vault, _dominant_phase(evidence)),
+        # Register is not yet wired — the synthesized ontology carries no
+        # dominant voice register to select from. The discovery seam is kept
+        # so register selection is a one-line change once #502 lands.
         find_register_skill(vault, None),
     ]
     sections: list[str] = []

--- a/creek-tools/tests/test_chat_medium.py
+++ b/creek-tools/tests/test_chat_medium.py
@@ -148,7 +148,9 @@ def test_run_author_enforces_chat_ceiling(
     from creek.author import voice
 
     monkeypatch.setattr(
-        voice.VoiceAgent, "render", lambda self, q, e: "x" * (CHAT_MAX_CHARS + 500)
+        voice.VoiceAgent,
+        "render",
+        lambda self, q, e, *a, **kw: "x" * (CHAT_MAX_CHARS + 500),
     )
 
     reply = run_author(medium="chat", query="q", vault=tmp_path)
@@ -163,7 +165,9 @@ def test_run_author_does_not_truncate_research(
     from creek.author import voice
 
     monkeypatch.setattr(
-        voice.VoiceAgent, "render", lambda self, q, e: "x" * (CHAT_MAX_CHARS + 500)
+        voice.VoiceAgent,
+        "render",
+        lambda self, q, e, *a, **kw: "x" * (CHAT_MAX_CHARS + 500),
     )
 
     draft = run_author(medium="research", query="q", vault=tmp_path)

--- a/creek-tools/tests/test_synthesis_voice.py
+++ b/creek-tools/tests/test_synthesis_voice.py
@@ -162,3 +162,39 @@ def test_voice_falls_back_when_client_returns_empty(tmp_path: Path) -> None:
     body = VoiceAgent(llm_client=client).render("q", evidence, tmp_path)
 
     assert "a claim" in body
+
+
+def test_read_skill_skips_non_utf8_bytes(tmp_path: Path) -> None:
+    """A SKILL.md with non-UTF-8 bytes is skipped (returns ""), never crashes."""
+    from creek.author.skills import read_skill
+
+    skill = tmp_path / "voice-core.SKILL.md"
+    skill.write_bytes(b"\xff\xfe not valid utf-8 \x80")
+
+    assert read_skill(skill) == ""
+
+
+def test_voice_render_survives_non_utf8_voice_core(tmp_path: Path) -> None:
+    """A non-UTF-8 voice-core does not crash the LLM voice render (#501)."""
+    from unittest.mock import MagicMock
+
+    from creek.author.client import AuthorLLMClient
+    from creek.author.models import EvidenceBundle, EvidenceClaim
+    from creek.author.voice import VoiceAgent
+
+    core = tmp_path / "creek-skills" / "voice-core" / "SKILL.md"
+    core.parent.mkdir(parents=True, exist_ok=True)
+    core.write_bytes(b"\xff\xfe\x80 bad bytes")
+
+    provider = MagicMock()
+    completion = MagicMock()
+    completion.text = "Voiced."
+    provider.call_with_metadata.return_value = completion
+    agent = VoiceAgent(llm_client=AuthorLLMClient(provider))
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="A grounded claim.", source_fragments=["frag-a"])]
+    )
+
+    body = agent.render("q", evidence, tmp_path, medium="research")
+
+    assert body == "Voiced."

--- a/creek-tools/tests/test_synthesis_voice.py
+++ b/creek-tools/tests/test_synthesis_voice.py
@@ -18,6 +18,7 @@ from creek.author.conductor import Conductor, build_default_conductor
 from creek.author.contracts import load_medium_contract
 from creek.author.models import EvidenceBundle, EvidenceClaim
 from creek.author.reflection import ReflectionNode
+from creek.author.skills import read_skill
 from creek.author.voice import VoiceAgent
 
 if TYPE_CHECKING:
@@ -122,6 +123,22 @@ def test_voice_prompt_includes_voice_core_sentinel(tmp_path: Path) -> None:
     assert sentinel in prompt
 
 
+def test_voice_prompt_honours_contract_structure(tmp_path: Path) -> None:
+    """The medium contract's section order is passed to the model (#471)."""
+    contract = load_medium_contract("research", tmp_path)
+    client, provider = _mock_client("voiced output")
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a grounded claim", source_fragments=["f1"])]
+    )
+
+    VoiceAgent(llm_client=client).render(
+        "q", evidence, tmp_path, medium="research", contract=contract
+    )
+
+    prompt = provider.call_with_metadata.call_args.args[0]
+    assert " → ".join(contract.structure) in prompt
+
+
 def test_voice_excludes_borrowed_authors_from_owner_material(tmp_path: Path) -> None:
     """A borrowed (``author_slug``) claim is not voiced as the owner's words."""
     client, provider = _mock_client("voiced output")
@@ -166,8 +183,6 @@ def test_voice_falls_back_when_client_returns_empty(tmp_path: Path) -> None:
 
 def test_read_skill_skips_non_utf8_bytes(tmp_path: Path) -> None:
     """A SKILL.md with non-UTF-8 bytes is skipped (returns ""), never crashes."""
-    from creek.author.skills import read_skill
-
     skill = tmp_path / "voice-core.SKILL.md"
     skill.write_bytes(b"\xff\xfe not valid utf-8 \x80")
 
@@ -176,12 +191,6 @@ def test_read_skill_skips_non_utf8_bytes(tmp_path: Path) -> None:
 
 def test_voice_render_survives_non_utf8_voice_core(tmp_path: Path) -> None:
     """A non-UTF-8 voice-core does not crash the LLM voice render (#501)."""
-    from unittest.mock import MagicMock
-
-    from creek.author.client import AuthorLLMClient
-    from creek.author.models import EvidenceBundle, EvidenceClaim
-    from creek.author.voice import VoiceAgent
-
     core = tmp_path / "creek-skills" / "voice-core" / "SKILL.md"
     core.parent.mkdir(parents=True, exist_ok=True)
     core.write_bytes(b"\xff\xfe\x80 bad bytes")

--- a/creek-tools/tests/test_synthesis_voice.py
+++ b/creek-tools/tests/test_synthesis_voice.py
@@ -1,0 +1,164 @@
+"""Tests for grounded synthesis and voice rendering (FEAT-041, #471).
+
+These pin the two halves the Writing Desk gained in #471: the conductor's
+``synthesize`` drops ungrounded claims so every retained claim traces to its
+source fragments, and the :class:`~creek.author.voice.VoiceAgent` renders the
+grounded evidence in the owner's voice through the injected
+:class:`~creek.author.client.AuthorLLMClient` and the vault's ``creek-skills``
+voice-skill stack. No live network — the LLM is a ``MagicMock`` provider.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from creek.author.client import AuthorLLMClient
+from creek.author.conductor import Conductor, build_default_conductor
+from creek.author.contracts import load_medium_contract
+from creek.author.models import EvidenceBundle, EvidenceClaim
+from creek.author.reflection import ReflectionNode
+from creek.author.voice import VoiceAgent
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _seed_fragment(vault: Path, frag_id: str, title: str) -> None:
+    """Write a minimal owner fragment so the real specialists have a corpus."""
+    folder = vault / "01-Fragments" / "Notes"
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / f"{frag_id}.md").write_text(
+        f'---\ntype: fragment\nid: {frag_id}\ntitle: "{title}"\n'
+        f"source:\n  platform: journal\n  author: self\n---\nbody\n",
+        encoding="utf-8",
+    )
+
+
+def _seed_voice_core(vault: Path, sentinel: str) -> None:
+    """Seed ``creek-skills/voice-core/SKILL.md`` with a sentinel marker."""
+    core = vault / "creek-skills" / "voice-core"
+    core.mkdir(parents=True, exist_ok=True)
+    (core / "SKILL.md").write_text(sentinel, encoding="utf-8")
+
+
+def _mock_client(text: str) -> tuple[AuthorLLMClient, MagicMock]:
+    """Return a client over a mock provider returning *text*, and the provider."""
+    provider = MagicMock()
+    completion = MagicMock()
+    completion.text = text
+    provider.call_with_metadata.return_value = completion
+    return AuthorLLMClient(provider), provider
+
+
+def test_synthesize_drops_ungrounded_claims() -> None:
+    """``synthesize`` keeps only claims that trace to source fragments."""
+    grounded = EvidenceClaim(claim="grounded one", source_fragments=["f1"])
+    ungrounded = EvidenceClaim(claim="floating claim", source_fragments=[])
+    conductor = build_default_conductor(max_rounds=1)
+
+    merged = conductor.synthesize([EvidenceBundle(claims=[grounded, ungrounded])])
+
+    assert [c.claim for c in merged.claims] == ["grounded one"]
+    assert all(c.source_fragments for c in merged.claims)
+    assert "floating claim" not in {c.claim for c in merged.claims}
+
+
+def test_synthesize_carries_first_ontology() -> None:
+    """``synthesize`` carries the first non-None ontology through unchanged."""
+    from creek.author.models import OntologyAnalysis
+
+    analysis = OntologyAnalysis(overall_confidence=0.5)
+    conductor = build_default_conductor(max_rounds=1)
+
+    merged = conductor.synthesize(
+        [
+            EvidenceBundle(claims=[EvidenceClaim(claim="a", source_fragments=["f1"])]),
+            EvidenceBundle(
+                claims=[EvidenceClaim(claim="b", source_fragments=["f2"])],
+                ontology=analysis,
+            ),
+        ]
+    )
+
+    assert merged.ontology is analysis
+
+
+def test_run_grounded_and_voiced_end_to_end(tmp_path: Path) -> None:
+    """A full run yields non-empty per-claim provenance and the voiced body."""
+    _seed_fragment(tmp_path, "frag-a", "F6 Pluralism and community")
+    _seed_fragment(tmp_path, "frag-b", "Agency and momentum")
+    client, provider = _mock_client("Voiced in the owner's register.")
+    contract = load_medium_contract("research", tmp_path)
+    conductor = Conductor(
+        specialists=build_default_conductor(max_rounds=1).specialists,
+        voice=VoiceAgent(llm_client=client),
+        reflection=ReflectionNode(),
+        max_rounds=1,
+        llm_client=client,
+        contract=contract,
+    )
+
+    draft = conductor.run(medium="research", query="What is F6?", vault=tmp_path)
+
+    assert draft.provenance
+    assert all(entry.fragment_ids for entry in draft.provenance)
+    assert draft.rendered_text == "Voiced in the owner's register."
+    provider.call_with_metadata.assert_called_once()
+
+
+def test_voice_prompt_includes_voice_core_sentinel(tmp_path: Path) -> None:
+    """The voice-core SKILL.md content is loaded into the LLM voice prompt."""
+    sentinel = "OWNER-VOICE-SENTINEL-XYZ"
+    _seed_voice_core(tmp_path, sentinel)
+    client, provider = _mock_client("voiced output")
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a grounded claim", source_fragments=["f1"])]
+    )
+
+    VoiceAgent(llm_client=client).render("q", evidence, tmp_path, medium="research")
+
+    prompt = provider.call_with_metadata.call_args.args[0]
+    assert sentinel in prompt
+
+
+def test_voice_excludes_borrowed_authors_from_owner_material(tmp_path: Path) -> None:
+    """A borrowed (``author_slug``) claim is not voiced as the owner's words."""
+    client, provider = _mock_client("voiced output")
+    owner = EvidenceClaim(claim="my own observation", source_fragments=["f1"])
+    borrowed = EvidenceClaim(
+        claim="a borrowed maxim",
+        source_fragments=["f2"],
+        author_slug="some-author",
+    )
+    evidence = EvidenceBundle(claims=[owner, borrowed])
+
+    VoiceAgent(llm_client=client).render("q", evidence, tmp_path, medium="research")
+
+    prompt = provider.call_with_metadata.call_args.args[0]
+    assert "my own observation" in prompt
+    assert "a borrowed maxim" not in prompt
+
+
+def test_voice_without_client_is_deterministic() -> None:
+    """With no client the render returns a non-empty deterministic body."""
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["f1"])]
+    )
+
+    body = VoiceAgent().render("q", evidence)
+
+    assert body.strip()
+    assert "a claim" in body
+
+
+def test_voice_falls_back_when_client_returns_empty(tmp_path: Path) -> None:
+    """An empty LLM completion falls back to the deterministic body."""
+    client, _provider = _mock_client("   ")
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["f1"])]
+    )
+
+    body = VoiceAgent(llm_client=client).render("q", evidence, tmp_path)
+
+    assert "a claim" in body


### PR DESCRIPTION
## Summary

Replaces the desk's last two synthesis/voice stubs with real, grounded behaviour (FEAT-041 §4.2). The desk now produces a real, cited, voiced draft end-to-end on a fixture. Reflection stays a pass-through stub (ISSUE_06, out of scope).

- **Synthesis** (`Conductor.synthesize`): produces a **grounded** bundle — a claim with no `source_fragments` is **dropped (logged), never fabricated**, so every claim reaching the voice agent and `_claims_to_provenance` traces to a fragment. First non-None ontology carried through; retained claims keep stable insertion order (the documented contract-`structure` assembly order). `VoiceRenderer`/`run` now thread vault / medium / contract to the voice agent.
- **Voice agent** (`voice.py`, rewritten): one public `render(query, evidence, vault=None, *, medium=None, contract=None)`.
  - **No client / no vault** → deterministic non-empty body of the owner's grounded claims (keeps offline runs + skeleton tests green).
  - **Client + vault** → prompt from the `creek-skills` stack (voice-core + phase + register; phase from the synthesized ontology) + grounded evidence (each claim tagged with fragment ids) + a grounding-preserving ask (owner's voice; every statement traces to source fragments; don't invent/add claims; don't quote borrowed authors as my own; **research = light touch**); calls the injected `AuthorLLMClient`, falling back to the deterministic body on empty output.
  - **Borrowed (`11-Other-Authors/`) claims are excluded** from the owner-voiced material — another author's words are never presented as the owner's.
- **New `creek/author/skills.py`:** native `creek-skills` voice-skill discovery, mirroring `creek.generate.skills`' layout (and accepting the crawdad-style `voice-core/SKILL.md`). Implemented entirely in creek-tools — **never imports the crawdad sibling**. Missing files skip silently.

## Test plan
`cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (4952 tests, 8 new). `tests/test_synthesis_voice.py`:
- **Grounding:** `synthesize` drops a mixed bundle's ungrounded claim; survivors all carry `source_fragments`.
- **End-to-end (DoD):** a research run wired to a mock `AuthorLLMClient` → `draft.provenance` non-empty, **every `ProvenanceEntry.fragment_ids` populated**, `draft.rendered_text` == the voiced output, provider called once.
- **Skill stack in prompt:** a seeded `creek-skills/voice-core/SKILL.md` sentinel appears in the prompt the mock received.
- **No fabrication / borrowed exclusion:** a claim with `author_slug` is absent from the owner-voiced material; owner claims present.
- **Deterministic + empty-completion fallbacks.**

Two chat-ceiling tests' monkeypatch lambdas widened to the new render arity (intent + assertions unchanged).

Closes #471
Refs #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)