### PR TITLE
feat(mediums): how-to (agentic-coding) medium contract + rubric (#472)

### DIFF
--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -37,10 +37,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 #: Mediums the conductor will run. ``research``/``chat``/``essay``/
-#: ``research-piece``/``book-report`` are wired; the remaining mediums (how-to)
-#: arrive later.
+#: ``research-piece``/``book-report``/``how-to`` are all wired — ``how-to``
+#: completes the medium set.
 SUPPORTED_MEDIUMS: frozenset[str] = frozenset(
-    {"research", "chat", "essay", "research-piece", "book-report"}
+    {"research", "chat", "essay", "research-piece", "book-report", "how-to"}
 )
 
 #: Fixed pipeline steps that follow the specialist roster, in order.

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -16,9 +16,9 @@ from creek.compile.provenance import ProvenanceEntry
 from creek.models import Dosage, Frequency, Mode, Phase
 
 #: Mediums the author desk can produce. ``research``/``chat``/``essay``/
-#: ``research-piece``/``book-report`` are wired; the others (how-to) arrive in
-#: later issues.
-Medium = Literal["research", "chat", "essay", "research-piece", "book-report"]
+#: ``research-piece``/``book-report``/``how-to`` are all wired — ``how-to``
+#: completes the medium set.
+Medium = Literal["research", "chat", "essay", "research-piece", "book-report", "how-to"]
 
 #: The reflection node's bounded verdict over a drafted body.
 ReflectionVerdict = Literal["PASS", "REVISE", "ESCALATE"]

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2707,8 +2707,8 @@ def author(
         "research",
         "--medium",
         help=(
-            "Output medium: research, chat, essay, research-piece, or "
-            "book-report (FEAT-041)."
+            "Output medium: research, chat, essay, research-piece, "
+            "book-report, or how-to (FEAT-041)."
         ),
     ),
     work: Path | None = typer.Option(

--- a/creek-tools/creek/templates/skills/mediums/how-to.MEDIUM.md
+++ b/creek-tools/creek/templates/skills/mediums/how-to.MEDIUM.md
@@ -1,0 +1,84 @@
+---
+medium: how-to
+structure:
+  - goal
+  - prerequisites
+  - steps
+  - example
+  - verification
+  - pitfalls
+specialist_weights:
+  graph: 0.35
+  ontology: 0.3
+  retrieval: 0.2
+  voice: 0.15
+citation_norm: light
+default_privacy_tier: open
+reflection_rubric:
+  runnability: 0.35
+  ontological_accuracy: 0.25
+  citation_completeness: 0.15
+  voice_fidelity: 0.1
+  privacy_compliance: 0.1
+  paradox_preservation: 0.05
+---
+
+# how-to.MEDIUM.md
+
+**Medium:** `how-to`
+**Budget:** ≤1500 tokens
+**Loaded by:** the Creek Writing Desk Conductor (FEAT-041)
+
+## What the `how-to` medium is for
+
+An externally-shareable **agentic-coding guide** — the kind of structured,
+example-driven walkthrough that turns the owner's Technical fragments and the
+Praxis they imply into steps another agent (or person) can actually follow.
+Where `research-piece` *argues a thesis from evidence* and `book-report`
+synthesises a borrowed work, a how-to *instructs*: it states a concrete goal,
+lists what must already be true, walks ordered steps, shows a worked example,
+proves the result, and names the traps. The cardinal failure mode is not a
+missing citation but a step that does not run.
+
+## Structure
+
+Compose in this order: **goal → prerequisites → steps → example →
+verification → pitfalls.** State the goal plainly and concretely. List the
+prerequisites a reader must satisfy first. Walk the steps in dependency order,
+each one runnable on its own. Show a worked **example** — a real command,
+snippet, or invocation, not a paraphrase. Give a **verification** the reader can
+run to confirm success. Close with the **pitfalls**: the failure modes the
+owner's fragments and Praxis warn against. The example and verification sections
+are load-bearing: a how-to without them is a description, not a guide.
+
+## Specialist weighting
+
+Graph is weighted highest (0.35) and Ontology next (0.3): together they surface
+the owner's **Technical** fragments and the **Praxis** linkage between them —
+the connected procedure the guide is made of, not isolated facts. Retrieval
+(0.2) is present to pull the concrete fragments (commands, snippets, configs)
+each step rests on. Voice (0.15) is deliberately low: a how-to is legible and
+imperative, not a personal-voice performance — clarity and correctness outrank
+register.
+
+## Citation norm — `light`
+
+A how-to favours **runnable steps over dense citation**. Where
+`research-piece`/`book-report` demand `every-claim`, a guide cites *lightly*:
+ground the procedure in the owner's `source_fragments` and any Praxis it
+realises, but do not interrupt the steps with a citation per sentence. The bar a
+how-to must clear is that the steps *work*, not that every clause is footnoted —
+so citation is `light` and the reflection weight shifts onto runnability.
+
+## Reflection rubric (§8)
+
+The reflection node weights **runnability** highest (0.35) — for a guide,
+steps that do not actually run (a missing prerequisite, an out-of-order step, an
+example that errors) are the cardinal failure, ahead of any citation gap.
+**Ontological accuracy** (0.25) follows: the Technical/Praxis mapping the steps
+lean on must be canonically correct. **Citation completeness** (0.15) keeps the
+light grounding honest without demanding a footnote per line. Voice fidelity
+(0.1) and privacy compliance (0.1) round out the body; **paradox preservation**
+(0.05) keeps any surfaced "it depends" caveat intact rather than flattened into
+false certainty. A step that cannot be run as written → `REVISE`; exhausting the
+round budget without a `PASS` → `ESCALATE`.

--- a/creek-tools/tests/test_how_to_medium.py
+++ b/creek-tools/tests/test_how_to_medium.py
@@ -1,0 +1,98 @@
+"""Tests for the how-to medium contract (FEAT-041 #472).
+
+``how-to`` is the agentic-coding-guide medium: structured, example-driven
+technical writing that weights the **Graph + Ontology** specialists toward
+Technical fragments and Praxis linkage. Its reflection rubric carries an
+explicit **accuracy/runnability** dimension — the cardinal failure mode for a
+guide is steps that do not actually run. These tests reuse the #457 conformance
+harness, mirror ``test_book_report_medium.py``, and pin the Definition-of-Done
+invariant: the structure is example-driven and the rubric weights runnability
+meaningfully.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.author import (
+    SUPPORTED_MEDIUMS,
+    assert_contract_conformant,
+    load_medium_contract,
+    require_supported_medium,
+    run_author,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_how_to_contract_loads_and_conforms(tmp_path: Path) -> None:
+    """The how-to contract loads and passes the conformance harness."""
+    contract = load_medium_contract("how-to", tmp_path)
+
+    assert_contract_conformant(contract)
+    assert contract.medium == "how-to"
+    assert contract.structure  # non-empty ordered sections
+
+
+def test_how_to_structure_is_example_driven(tmp_path: Path) -> None:
+    """The structure is concrete + example-driven (example/verification/steps)."""
+    structure = load_medium_contract("how-to", tmp_path).structure
+
+    assert "example" in structure
+    assert "verification" in structure
+    assert "steps" in structure
+
+
+def test_how_to_weights_graph_and_ontology_highest(tmp_path: Path) -> None:
+    """Graph + Ontology each outweigh retrieval and voice (Technical + Praxis)."""
+    weights = load_medium_contract("how-to", tmp_path).specialist_weights
+
+    assert weights["graph"] >= weights["retrieval"]
+    assert weights["graph"] >= weights["voice"]
+    assert weights["ontology"] >= weights["retrieval"]
+    assert weights["ontology"] >= weights["voice"]
+
+
+def test_how_to_specialist_weights_sum_to_one(tmp_path: Path) -> None:
+    """The specialist weights sum to ~1.0 (conformance invariant, SPEC §5)."""
+    weights = load_medium_contract("how-to", tmp_path).specialist_weights
+
+    assert abs(sum(weights.values()) - 1.0) < 0.01
+
+
+def test_how_to_rubric_weights_runnability_meaningfully(tmp_path: Path) -> None:
+    """The rubric carries a meaningfully-weighted runnability dimension (the DoD)."""
+    rubric = load_medium_contract("how-to", tmp_path).reflection_rubric
+
+    assert "runnability" in rubric
+    # The cardinal failure mode → it must carry real weight, not a token sliver.
+    assert rubric["runnability"] >= 0.25
+    assert rubric["runnability"] >= rubric["voice_fidelity"]
+    assert abs(sum(rubric.values()) - 1.0) < 0.01
+
+
+def test_how_to_citation_norm_is_light(tmp_path: Path) -> None:
+    """how-to favours runnable steps over dense citation (``light``)."""
+    contract = load_medium_contract("how-to", tmp_path)
+
+    assert contract.citation_norm == "light"
+
+
+def test_require_supported_medium_accepts_how_to() -> None:
+    """``require_supported_medium`` accepts ``how-to`` (it is wired)."""
+    assert "how-to" in SUPPORTED_MEDIUMS
+    assert require_supported_medium("how-to") == "how-to"
+
+
+def test_run_author_how_to_returns_draft(tmp_path: Path) -> None:
+    """``run_author(medium='how-to')`` returns a draft (no ValueError)."""
+    draft = run_author(
+        medium="how-to",
+        query="How do I wire the classifier end to end?",
+        vault=tmp_path,
+    )
+
+    assert draft.medium == "how-to"
+    assert draft.body.strip()
+    assert draft.verdict in {"PASS", "REVISE", "ESCALATE"}


### PR DESCRIPTION
## Summary

Adds the **`how-to`** medium (FEAT-041 §5, medium #6) — agentic-coding guides that weight **Graph + Ontology** toward Technical fragments + Praxis, produce **structured, example-driven** output, and add an **accuracy/runnability** reflection dimension. This **completes the medium set**.

- **New `how-to.MEDIUM.md` contract:** structure `goal → prerequisites → steps → example → verification → pitfalls` (example-driven); `specialist_weights` **graph 0.35 / ontology 0.3** highest (Technical + Praxis linkage), retrieval 0.2, voice 0.15 (sum 1.0); `citation_norm: light` (runnable steps over dense citation); `open` privacy default; `reflection_rubric` led by **`runnability: 0.35`** (steps that don't run are a how-to's cardinal failure mode), summing to 1.0.
- **Wires the medium:** `how-to` added to `SUPPORTED_MEDIUMS` and the `Medium` literal (doc comments refreshed — the set is now complete); CLI `--medium` help refreshed. Additive — existing mediums and the desk are untouched.

## Test plan
`cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (4963 tests). New `tests/test_how_to_medium.py`:
- Contract conformance; `medium == "how-to"`.
- **Structured/example-driven:** `example` + `verification` + `steps` all in `structure`.
- Graph and Ontology each ≥ retrieval and ≥ voice; weights sum to 1.0.
- **Runnability dimension (DoD):** `runnability` present, weight ≥ 0.25 and ≥ `voice_fidelity`; rubric sums to 1.0.
- `require_supported_medium("how-to")` and end-to-end `run_author(medium="how-to", …)` accept it.

Closes #472
Refs #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)