### PR TITLE
feat(author): Reflection node + bounded retries + escalation (#473)

### DIFF
--- a/creek-tools/creek/author/__init__.py
+++ b/creek-tools/creek/author/__init__.py
@@ -31,6 +31,8 @@ from creek.author.models import (
     EvidenceBundle,
     EvidenceClaim,
     Medium,
+    ReflectionFinding,
+    ReflectionResult,
     ReflectionVerdict,
 )
 
@@ -45,6 +47,8 @@ __all__ = [
     "EvidenceBundle",
     "EvidenceClaim",
     "Medium",
+    "ReflectionFinding",
+    "ReflectionResult",
     "ReflectionVerdict",
     "assert_contract_conformant",
     "build_default_conductor",

--- a/creek-tools/creek/author/checks.py
+++ b/creek-tools/creek/author/checks.py
@@ -23,8 +23,8 @@ from creek.generate.ai_style.scanner import scan
 
 # The legacy-alias maps are module-private in creek.models; importing them here
 # reuses the single canonical INC-019 source rather than duplicating the alias
-# vocabulary (kept private as they are an internal taxonomy detail). Promote to
-# a public constant if a third consumer appears.
+# vocabulary. This is the second consumer across the module boundary, so
+# promoting them to a public constant is tracked as #507.
 from creek.models import (
     _FREQUENCY_LEGACY_ALIASES,
     _MODE_LEGACY_ALIASES,
@@ -118,7 +118,9 @@ def check_privacy_compliance(
     contract's ``default_privacy_tier``, the draft breaches privacy iff the body
     still contains that fragment's protected text. The check is deterministic;
     when *vault* or *contract* is ``None`` there is nothing to resolve against,
-    so no finding is raised.
+    so no finding is raised. A cited fragment id with no matching file in the
+    vault is unresolvable (its tier cannot be known) and is skipped rather than
+    guessed — the hard citation gate still requires every claim to carry an id.
 
     Args:
         body: The drafted prose under review.
@@ -165,6 +167,11 @@ def check_ontological_accuracy(body: str) -> list[ReflectionFinding]:
     A word-boundary regex match of any deprecated phase/mode/frequency alias
     key in the body raises a ``MID`` finding naming the canonical replacement.
 
+    Caveat: a few alias keys are ordinary English words (e.g. ``"origins"``),
+    so this word-boundary match can false-positive on non-ontological prose. It
+    is a ``MID`` (soft) finding, so a false hit costs at most one revise round,
+    not a hard block; semantic disambiguation is deferred to #474.
+
     Args:
         body: The drafted prose under review.
 
@@ -172,10 +179,6 @@ def check_ontological_accuracy(body: str) -> list[ReflectionFinding]:
         One ``MID`` finding per legacy alias used, dimension
         ``"ontological_accuracy"``.
     """
-    # Caveat: a few alias keys are ordinary English words (e.g. "origins"), so
-    # this word-boundary match can false-positive on non-ontological prose. It
-    # is a MID (soft) finding, so a false hit costs at most one revise round,
-    # not a hard block; semantic disambiguation is deferred to #474.
     return [
         ReflectionFinding(
             dimension="ontological_accuracy",

--- a/creek-tools/creek/author/checks.py
+++ b/creek-tools/creek/author/checks.py
@@ -1,0 +1,333 @@
+"""The six deterministic reflection checks for the Creek Writing Desk (#473).
+
+Each check inspects a drafted body (and its evidence) for exactly one rubric
+dimension and returns zero or more :class:`~creek.author.models.ReflectionFinding`
+records. The checks are *deterministic* — no LLM — so the mutation tests in
+``tests/test_reflection.py`` can assert the exact verdict and dimension a defect
+produces. Citation completeness and privacy compliance are HARD gates for the
+research medium; the rest are softer rubric divergences.
+
+The privacy check reuses the vault fragment loader
+(:func:`creek.vault.reader.iter_vault_fragments`) to resolve each cited
+fragment's :class:`~creek.models.PrivacyTier`; the voice check reuses the
+FEAT-040.x AI-style scanner (:func:`creek.generate.ai_style.scanner.scan`).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from creek.author.models import ReflectionFinding
+from creek.generate.ai_style.scanner import scan
+from creek.models import (
+    _FREQUENCY_LEGACY_ALIASES,
+    _MODE_LEGACY_ALIASES,
+    _PHASE_LEGACY_ALIASES,
+    PrivacyTier,
+)
+from creek.vault.reader import iter_vault_fragments
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from creek.author.models import EvidenceBundle
+    from creek.config import AIStyleConfig
+    from creek.generate.ai_style.model import VoiceFingerprint
+    from creek.models import MediumContract
+
+#: Privacy tiers from least to most restrictive; index = restrictiveness rank.
+#: ``UNCLASSIFIED`` is treated as the most restrictive (fail closed), matching
+#: :mod:`creek.classify.privacy_filter`.
+_TIER_RANK: dict[PrivacyTier, int] = {
+    PrivacyTier.OPEN: 0,
+    PrivacyTier.PERSONAL: 1,
+    PrivacyTier.INTIMATE: 2,
+    PrivacyTier.UNCLASSIFIED: 3,
+}
+
+#: Legacy alias keys whose presence in a body signals non-canonical taxonomy
+#: (INC-019). Maps each deprecated alias to its canonical replacement.
+_LEGACY_ALIASES: dict[str, str] = (
+    _PHASE_LEGACY_ALIASES | _MODE_LEGACY_ALIASES | _FREQUENCY_LEGACY_ALIASES
+)
+
+
+def check_citation_completeness(evidence: EvidenceBundle) -> list[ReflectionFinding]:
+    """Flag any claim that asserts something without a source fragment (HARD).
+
+    A research draft may make no unsupported assertion: a claim whose
+    ``source_fragments`` is empty is an uncited claim and fails the hard
+    citation gate.
+
+    Args:
+        evidence: The evidence the draft was rendered from.
+
+    Returns:
+        One ``HIGH`` finding per uncited claim, dimension
+        ``"citation_completeness"``.
+    """
+    return [
+        ReflectionFinding(
+            dimension="citation_completeness",
+            severity="HIGH",
+            message=f"Uncited claim has no source fragments: {claim.claim!r}.",
+        )
+        for claim in evidence.claims
+        if not claim.source_fragments
+    ]
+
+
+def _resolve_cited_tiers(
+    evidence: EvidenceBundle,
+    vault: Path,
+) -> dict[str, tuple[PrivacyTier, str]]:
+    """Map each cited fragment id to its ``(privacy_tier, body)`` from *vault*.
+
+    Args:
+        evidence: The evidence whose cited fragment ids are resolved.
+        vault: The vault root to load fragments from.
+
+    Returns:
+        A mapping of cited fragment id to its tier and stored body. Fragments
+        not found in the vault are omitted.
+    """
+    cited = set(evidence.all_source_fragments())
+    fragments_root = vault / "01-Fragments"
+    resolved: dict[str, tuple[PrivacyTier, str]] = {}
+    for _path, fragment, body, _raw in iter_vault_fragments(fragments_root):
+        if fragment.id in cited:
+            resolved[fragment.id] = (fragment.privacy_tier, body)
+    return resolved
+
+
+def check_privacy_compliance(
+    body: str,
+    evidence: EvidenceBundle,
+    vault: Path | None,
+    contract: MediumContract | None,
+) -> list[ReflectionFinding]:
+    """Flag a draft that leaks text above the contract's privacy tier (HARD).
+
+    For each cited fragment whose resolved tier is *more restrictive* than the
+    contract's ``default_privacy_tier``, the draft breaches privacy iff the body
+    still contains that fragment's protected text. The check is deterministic;
+    when *vault* or *contract* is ``None`` there is nothing to resolve against,
+    so no finding is raised.
+
+    Args:
+        body: The drafted prose under review.
+        evidence: The evidence the draft was rendered from.
+        vault: The vault root, or ``None`` to skip the check.
+        contract: The medium contract whose ``default_privacy_tier`` is the
+            ceiling, or ``None`` to skip.
+
+    Returns:
+        One ``HIGH`` finding per leaked over-tier fragment, dimension
+        ``"privacy_compliance"``.
+    """
+    if vault is None or contract is None:
+        return []
+    # Pydantic stores tiers as the underlying str; coerce back to the enum so
+    # the ordering lookup and display are well-defined.
+    ceiling_tier = PrivacyTier(contract.default_privacy_tier)
+    ceiling = _TIER_RANK[ceiling_tier]
+    findings: list[ReflectionFinding] = []
+    for frag_id, (raw_tier, frag_body) in _resolve_cited_tiers(evidence, vault).items():
+        tier = PrivacyTier(raw_tier)
+        protected = frag_body.strip()
+        if _TIER_RANK[tier] > ceiling and protected and protected in body:
+            findings.append(
+                ReflectionFinding(
+                    dimension="privacy_compliance",
+                    severity="HIGH",
+                    message=(
+                        f"Cited fragment {frag_id!r} is {tier.value!r} "
+                        f"(above the {ceiling_tier.value!r} "
+                        "default) yet its protected text appears in the draft."
+                    ),
+                )
+            )
+    return findings
+
+
+def check_ontological_accuracy(body: str) -> list[ReflectionFinding]:
+    """Flag legacy (non-canonical) taxonomy terms in the body (INC-019).
+
+    A word-boundary regex match of any deprecated phase/mode/frequency alias
+    key in the body raises a ``MID`` finding naming the canonical replacement.
+
+    Args:
+        body: The drafted prose under review.
+
+    Returns:
+        One ``MID`` finding per legacy alias used, dimension
+        ``"ontological_accuracy"``.
+    """
+    return [
+        ReflectionFinding(
+            dimension="ontological_accuracy",
+            severity="MID",
+            message=(
+                f"Legacy taxonomy term {alias!r} used; the canonical "
+                f"term is {canonical!r} (INC-019)."
+            ),
+        )
+        for alias, canonical in _LEGACY_ALIASES.items()
+        if re.search(rf"\b{re.escape(alias)}\b", body, flags=re.IGNORECASE)
+    ]
+
+
+def _paradox_is_preserved(body: str, description: str) -> bool:
+    """Return whether *body* keeps the tension of a paradox *description*.
+
+    Deterministic heuristic: the paradox is preserved iff the draft body
+    carries a contrast/tension cue — either an explicit contrast marker
+    (``but``, ``yet``, ``however``, ``while``, ``although``, ``tension``,
+    ``paradox``, ``both``) or every significant (>=4-char) word of the
+    paradox description. A body that surfaces only one side, with no contrast,
+    has flattened the tension.
+
+    Args:
+        body: The drafted prose under review.
+        description: The paradox's neutral one-sentence description.
+
+    Returns:
+        ``True`` when the tension is preserved, ``False`` when flattened.
+    """
+    lowered = body.lower()
+    contrast_cues = (
+        "but",
+        "yet",
+        "however",
+        "while",
+        "although",
+        "tension",
+        "paradox",
+        "both",
+    )
+    if any(re.search(rf"\b{cue}\b", lowered) for cue in contrast_cues):
+        return True
+    key_terms = re.findall(r"[a-z]{4,}", description.lower())
+    return bool(key_terms) and all(term in lowered for term in key_terms)
+
+
+def check_paradox_preservation(
+    body: str,
+    evidence: EvidenceBundle,
+) -> list[ReflectionFinding]:
+    """Flag a surfaced paradox the draft flattened to one side.
+
+    The Ontology specialist *names* tensions rather than resolving them; the
+    draft must keep both sides visible. For each
+    :class:`~creek.author.models.OntologyParadox`, a flattened tension (per
+    :func:`_paradox_is_preserved`) raises a ``MID`` finding.
+
+    Args:
+        body: The drafted prose under review.
+        evidence: The evidence whose ``ontology.paradoxes`` are checked.
+
+    Returns:
+        One ``MID`` finding per flattened paradox, dimension
+        ``"paradox_preservation"``.
+    """
+    if evidence.ontology is None:
+        return []
+    return [
+        ReflectionFinding(
+            dimension="paradox_preservation",
+            severity="MID",
+            message=(
+                f"Paradox flattened — the draft surfaces only one side "
+                f"of: {paradox.description!r}."
+            ),
+        )
+        for paradox in evidence.ontology.paradoxes
+        if not _paradox_is_preserved(body, paradox.description)
+    ]
+
+
+def check_attribution_correctness(
+    body: str,
+    evidence: EvidenceBundle,
+) -> list[ReflectionFinding]:
+    """Flag a borrowed idea presented as the owner's own.
+
+    A claim carrying an ``author_slug`` (drawn from ``11-Other-Authors/``)
+    must be attributed in the body: if neither the slug nor its de-slugged
+    name appears, the borrowed idea is uncredited.
+
+    Args:
+        body: The drafted prose under review.
+        evidence: The evidence whose attributed claims are checked.
+
+    Returns:
+        One ``HIGH`` finding per unattributed borrowed claim, dimension
+        ``"attribution_correctness"``.
+    """
+    lowered = body.lower()
+    findings: list[ReflectionFinding] = []
+    for claim in evidence.claims:
+        slug = claim.author_slug
+        if slug is None:
+            continue
+        name = slug.replace("-", " ").lower()
+        if slug.lower() not in lowered and name not in lowered:
+            findings.append(
+                ReflectionFinding(
+                    dimension="attribution_correctness",
+                    severity="HIGH",
+                    message=(
+                        f"Claim borrowed from {slug!r} is presented without "
+                        f"attribution: {claim.claim!r}."
+                    ),
+                )
+            )
+    return findings
+
+
+def check_voice_fidelity(
+    body: str,
+    fingerprint: VoiceFingerprint | None,
+    config: AIStyleConfig | None,
+) -> list[ReflectionFinding]:
+    """Flag voice divergences via the FEAT-040.x AI-style scanner.
+
+    Reuses :func:`creek.generate.ai_style.scanner.scan`: each
+    :class:`~creek.generate.ai_style.model.Finding` becomes a ``MID``
+    ``voice_fidelity`` finding, and a ``voice_distance`` over the config's
+    ``voice_distance_upper`` bound adds one ``HIGH`` finding. When no
+    fingerprint or config is available the voice cannot be measured, so no
+    finding is raised.
+
+    Args:
+        body: The drafted prose under review.
+        fingerprint: The owner's voice fingerprint, or ``None`` to skip.
+        config: The AI-style configuration, or ``None`` to skip.
+
+    Returns:
+        ``voice_fidelity`` findings mapped from the scan report.
+    """
+    if fingerprint is None or config is None:
+        return []
+    report = scan(body, fingerprint=fingerprint, config=config)
+    findings = [
+        ReflectionFinding(
+            dimension="voice_fidelity",
+            severity="MID",
+            message=finding.message,
+        )
+        for finding in report.findings
+    ]
+    if report.voice_distance > config.voice_distance_upper:
+        findings.append(
+            ReflectionFinding(
+                dimension="voice_fidelity",
+                severity="HIGH",
+                message=(
+                    f"Voice distance {report.voice_distance:.2f} exceeds the "
+                    f"configured ceiling {config.voice_distance_upper:.2f}."
+                ),
+            )
+        )
+    return findings

--- a/creek-tools/creek/author/checks.py
+++ b/creek-tools/creek/author/checks.py
@@ -21,14 +21,13 @@ from typing import TYPE_CHECKING
 from creek.author.models import ReflectionFinding
 from creek.generate.ai_style.scanner import scan
 
-# The legacy-alias maps are module-private in creek.models; importing them here
-# reuses the single canonical INC-019 source rather than duplicating the alias
-# vocabulary. This is the second consumer across the module boundary, so
-# promoting them to a public constant is tracked as #507.
+# Reuse the canonical INC-019 alias vocabulary (public constants) rather than
+# duplicating it, so the ontological-accuracy check and the model validators
+# stay in sync.
 from creek.models import (
-    _FREQUENCY_LEGACY_ALIASES,
-    _MODE_LEGACY_ALIASES,
-    _PHASE_LEGACY_ALIASES,
+    FREQUENCY_LEGACY_ALIASES,
+    MODE_LEGACY_ALIASES,
+    PHASE_LEGACY_ALIASES,
     PrivacyTier,
 )
 from creek.vault.reader import iter_vault_fragments
@@ -54,7 +53,7 @@ _TIER_RANK: dict[PrivacyTier, int] = {
 #: Legacy alias keys whose presence in a body signals non-canonical taxonomy
 #: (INC-019). Maps each deprecated alias to its canonical replacement.
 _LEGACY_ALIASES: dict[str, str] = (
-    _PHASE_LEGACY_ALIASES | _MODE_LEGACY_ALIASES | _FREQUENCY_LEGACY_ALIASES
+    PHASE_LEGACY_ALIASES | MODE_LEGACY_ALIASES | FREQUENCY_LEGACY_ALIASES
 )
 
 
@@ -196,12 +195,18 @@ def check_ontological_accuracy(body: str) -> list[ReflectionFinding]:
 def _paradox_is_preserved(body: str, description: str) -> bool:
     """Return whether *body* keeps the tension of a paradox *description*.
 
-    Deterministic heuristic: the paradox is preserved iff the draft body
-    carries a contrast/tension cue — either an explicit contrast marker
-    (``but``, ``yet``, ``however``, ``while``, ``although``, ``tension``,
-    ``paradox``, ``both``) or every significant (>=4-char) word of the
-    paradox description. A body that surfaces only one side, with no contrast,
-    has flattened the tension.
+    Deterministic heuristic: the paradox is preserved iff the body engages the
+    paradox's own vocabulary in a both-sides way — either (a) it carries a
+    contrast/tension cue (``but``, ``yet``, ``however``, ``while``,
+    ``although``, ``tension``, ``paradox``, ``both``) AND mentions at least one
+    significant (>=4-char) word of the paradox description, or (b) it mentions
+    every significant word of the description. Requiring topical overlap
+    alongside the contrast cue closes the bare-conjunction bypass — a stray
+    "but" elsewhere in the draft no longer counts as preserving *this* tension.
+
+    This is a deterministic approximation; genuine semantic both-sides
+    detection is deferred to the LLM judge (#474). It can still miss a paraphrase
+    that reframes the tension without the description's words.
 
     Args:
         body: The drafted prose under review.
@@ -211,6 +216,10 @@ def _paradox_is_preserved(body: str, description: str) -> bool:
         ``True`` when the tension is preserved, ``False`` when flattened.
     """
     lowered = body.lower()
+    key_terms = re.findall(r"[a-z]{4,}", description.lower())
+    if not key_terms:
+        return True  # no vocabulary to check against — don't flag spuriously
+    mentions_topic = any(term in lowered for term in key_terms)
     contrast_cues = (
         "but",
         "yet",
@@ -221,10 +230,10 @@ def _paradox_is_preserved(body: str, description: str) -> bool:
         "paradox",
         "both",
     )
-    if any(re.search(rf"\b{cue}\b", lowered) for cue in contrast_cues):
+    has_contrast = any(re.search(rf"\b{cue}\b", lowered) for cue in contrast_cues)
+    if has_contrast and mentions_topic:
         return True
-    key_terms = re.findall(r"[a-z]{4,}", description.lower())
-    return bool(key_terms) and all(term in lowered for term in key_terms)
+    return all(term in lowered for term in key_terms)
 
 
 def check_paradox_preservation(

--- a/creek-tools/creek/author/checks.py
+++ b/creek-tools/creek/author/checks.py
@@ -98,16 +98,18 @@ def _resolve_cited_tiers(
         A mapping of cited fragment id to its tier and stored body. Fragments
         not found in the vault are omitted.
 
-    The scan is lazy and exits as soon as every cited fragment is resolved, so
-    a draft citing a handful of fragments does not pay an O(vault) cost on every
-    ``review`` call inside the retry loop.
+    The walk is lazy — ``rglob`` is iterated directly (not materialised) and
+    exits as soon as every cited fragment is resolved, so a draft citing a
+    handful of fragments stops early instead of parsing the whole vault on every
+    ``review`` call inside the retry loop. Iteration order is therefore the
+    filesystem's; that is irrelevant here since results are keyed by fragment id.
     """
     cited = set(evidence.all_source_fragments())
     resolved: dict[str, tuple[PrivacyTier, str]] = {}
     fragments_root = vault / "01-Fragments"
     if not cited or not fragments_root.is_dir():
         return resolved
-    for md_file in sorted(fragments_root.rglob("*.md")):
+    for md_file in fragments_root.rglob("*.md"):
         try:
             record = try_load_fragment(md_file)
         except (OSError, ValueError, yaml.YAMLError):
@@ -296,7 +298,14 @@ def check_attribution_correctness(
 
     A claim carrying an ``author_slug`` (drawn from ``11-Other-Authors/``)
     must be attributed in the body: if neither the slug nor its de-slugged
-    name appears, the borrowed idea is uncredited.
+    full name appears (on a word boundary), the borrowed idea is uncredited.
+
+    Limitation: only the slug and its full de-slugged form are recognised — an
+    attribution by partial name alone (e.g. surname-only "Ravikant" for
+    ``naval-ravikant``) is not matched and would still flag. Tightening this to
+    accept partial-name attribution is a semantic concern for the LLM judge
+    (#474); the deterministic check intentionally errs toward demanding the full
+    name a borrowed-author folder is keyed on.
 
     Args:
         body: The drafted prose under review.

--- a/creek-tools/creek/author/checks.py
+++ b/creek-tools/creek/author/checks.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING
 
+import yaml
+
 from creek.author.models import ReflectionFinding
 from creek.generate.ai_style.scanner import scan
 
@@ -30,7 +32,7 @@ from creek.models import (
     PHASE_LEGACY_ALIASES,
     PrivacyTier,
 )
-from creek.vault.reader import iter_vault_fragments
+from creek.vault.reader import try_load_fragment
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -95,13 +97,28 @@ def _resolve_cited_tiers(
     Returns:
         A mapping of cited fragment id to its tier and stored body. Fragments
         not found in the vault are omitted.
+
+    The scan is lazy and exits as soon as every cited fragment is resolved, so
+    a draft citing a handful of fragments does not pay an O(vault) cost on every
+    ``review`` call inside the retry loop.
     """
     cited = set(evidence.all_source_fragments())
-    fragments_root = vault / "01-Fragments"
     resolved: dict[str, tuple[PrivacyTier, str]] = {}
-    for _path, fragment, body, _raw in iter_vault_fragments(fragments_root):
+    fragments_root = vault / "01-Fragments"
+    if not cited or not fragments_root.is_dir():
+        return resolved
+    for md_file in sorted(fragments_root.rglob("*.md")):
+        try:
+            record = try_load_fragment(md_file)
+        except (OSError, ValueError, yaml.YAMLError):
+            continue
+        if record is None:
+            continue
+        fragment, body, _raw = record
         if fragment.id in cited:
             resolved[fragment.id] = (fragment.privacy_tier, body)
+            if len(resolved) == len(cited):
+                break  # every cited fragment found — stop scanning the vault
     return resolved
 
 
@@ -295,8 +312,15 @@ def check_attribution_correctness(
         slug = claim.author_slug
         if slug is None:
             continue
+        # Word-boundary match (not substring) so a slug appearing inside a
+        # longer word — e.g. "naval" within "navalny" — is not mistaken for an
+        # attribution, mirroring check_ontological_accuracy.
         name = slug.replace("-", " ").lower()
-        if slug.lower() not in lowered and name not in lowered:
+        attributed = any(
+            re.search(rf"\b{re.escape(token)}\b", lowered)
+            for token in (slug.lower(), name)
+        )
+        if not attributed:
             findings.append(
                 ReflectionFinding(
                     dimension="attribution_correctness",

--- a/creek-tools/creek/author/checks.py
+++ b/creek-tools/creek/author/checks.py
@@ -20,6 +20,11 @@ from typing import TYPE_CHECKING
 
 from creek.author.models import ReflectionFinding
 from creek.generate.ai_style.scanner import scan
+
+# The legacy-alias maps are module-private in creek.models; importing them here
+# reuses the single canonical INC-019 source rather than duplicating the alias
+# vocabulary (kept private as they are an internal taxonomy detail). Promote to
+# a public constant if a third consumer appears.
 from creek.models import (
     _FREQUENCY_LEGACY_ALIASES,
     _MODE_LEGACY_ALIASES,
@@ -136,6 +141,9 @@ def check_privacy_compliance(
     for frag_id, (raw_tier, frag_body) in _resolve_cited_tiers(evidence, vault).items():
         tier = PrivacyTier(raw_tier)
         protected = frag_body.strip()
+        # Deterministic scope: this catches verbatim leakage of the protected
+        # body. A paraphrase of over-tier content is NOT caught here — that
+        # needs the semantic LLM judge tracked under #474.
         if _TIER_RANK[tier] > ceiling and protected and protected in body:
             findings.append(
                 ReflectionFinding(
@@ -164,6 +172,10 @@ def check_ontological_accuracy(body: str) -> list[ReflectionFinding]:
         One ``MID`` finding per legacy alias used, dimension
         ``"ontological_accuracy"``.
     """
+    # Caveat: a few alias keys are ordinary English words (e.g. "origins"), so
+    # this word-boundary match can false-positive on non-ontological prose. It
+    # is a MID (soft) finding, so a false hit costs at most one revise round,
+    # not a hard block; semantic disambiguation is deferred to #474.
     return [
         ReflectionFinding(
             dimension="ontological_accuracy",

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -23,6 +23,7 @@ from creek.author.models import (
     EvidenceBundle,
     EvidenceClaim,
     Medium,
+    ReflectionFinding,
     ReflectionResult,
     ReflectionVerdict,
 )
@@ -257,6 +258,7 @@ class Conductor:
 
         body = ""
         verdict: ReflectionVerdict = "ESCALATE"
+        findings: list[ReflectionFinding] = []
         rounds = 0
         for attempt in range(1, self.max_rounds + 1):
             rounds = attempt
@@ -271,12 +273,19 @@ class Conductor:
                 body, evidence, rubric, contract=self.contract, vault=vault
             )
             verdict = result.decision
+            findings = result.findings
             if verdict != "REVISE":
                 break
 
         # Never ship a sub-threshold draft: a still-REVISE verdict after the
-        # round budget is exhausted escalates to a human (#473).
+        # round budget is exhausted escalates to a human (#473). Carry the
+        # findings on the draft (and log them) so the escalation is actionable.
         if verdict == "REVISE":
+            logger.warning(
+                "Escalating draft after %d round(s); unresolved dimensions: %s",
+                rounds,
+                sorted({finding.dimension for finding in findings}),
+            )
             verdict = "ESCALATE"
 
         return AuthoredDraft(
@@ -286,6 +295,7 @@ class Conductor:
             provenance=_claims_to_provenance(evidence.claims),
             verdict=verdict,
             rounds=rounds,
+            findings=findings,
         )
 
 

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -155,7 +155,17 @@ class Conductor:
         llm_client: AuthorLLMClient | None = None,
         contract: MediumContract | None = None,
     ) -> None:
-        """Store collaborators, the round bound, and the medium contract."""
+        """Store collaborators, the round bound, and the medium contract.
+
+        Raises:
+            ValueError: When *max_rounds* is below 1 — the voice/reflect loop
+                must run at least once, otherwise ``run`` could not produce a
+                judged draft (``AuthorConfig.max_author_rounds`` is bound
+                ``[1, 10]``; this guards a direct construction with ``0``).
+        """
+        if max_rounds < 1:
+            msg = f"max_rounds must be >= 1, got {max_rounds}"
+            raise ValueError(msg)
         self.specialists = list(specialists)
         self.voice = voice
         self.reflection = reflection
@@ -253,6 +263,10 @@ class Conductor:
             body = self.voice.render(
                 query, evidence, vault, medium=validated, contract=self.contract
             )
+            # voice_fidelity is implemented in the reflection node but stays
+            # dormant here: the owner's fingerprint + AIStyleConfig are not yet
+            # threaded into the desk. Wiring them (and an e2e voice test) is
+            # tracked as #506.
             result = self.reflection.review(
                 body, evidence, rubric, contract=self.contract, vault=vault
             )

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -2,10 +2,12 @@
 
 The conductor drives the end-to-end flow: each specialist gathers structured
 evidence, the bundles are synthesized, the voice agent renders a draft, and the
-reflection node judges it — looping on ``REVISE`` up to ``max_rounds`` before
-returning a shaped :class:`~creek.author.models.AuthoredDraft`. In the skeleton
-every collaborator is a typed stub; later issues swap in real implementations
-behind these same seams.
+reflection node judges it — looping on ``REVISE`` up to ``max_rounds``. A draft
+still in ``REVISE`` once the round budget is exhausted is escalated to a human
+(``ESCALATE``) rather than shipped (#473), then returned as a shaped
+:class:`~creek.author.models.AuthoredDraft`. The reflection node is a real
+deterministic judge; the remaining collaborators are typed stubs that later
+issues swap behind these same seams.
 """
 
 from __future__ import annotations
@@ -21,6 +23,7 @@ from creek.author.models import (
     EvidenceBundle,
     EvidenceClaim,
     Medium,
+    ReflectionResult,
     ReflectionVerdict,
 )
 from creek.author.reflection import ReflectionNode
@@ -74,8 +77,11 @@ class Reflector(Protocol):
         body: str,
         evidence: EvidenceBundle,
         rubric: dict[str, float] | None = None,
-    ) -> ReflectionVerdict:
-        """Return a verdict for *body* given *evidence* and the medium *rubric*."""
+        *,
+        contract: MediumContract | None = None,
+        vault: Path | None = None,
+    ) -> ReflectionResult:
+        """Return a structured result for *body* given *evidence* and *rubric*."""
         ...
 
 
@@ -228,7 +234,9 @@ class Conductor:
             vault: The vault to author from.
 
         Returns:
-            The :class:`AuthoredDraft` with mock provenance and a verdict.
+            The :class:`AuthoredDraft` with mock provenance and a verdict. A
+            draft that never cleared ``REVISE`` within ``max_rounds`` carries
+            an ``ESCALATE`` verdict rather than the sub-threshold ``REVISE``.
 
         Raises:
             ValueError: When *medium* is unsupported.
@@ -245,9 +253,17 @@ class Conductor:
             body = self.voice.render(
                 query, evidence, vault, medium=validated, contract=self.contract
             )
-            verdict = self.reflection.review(body, evidence, rubric)
+            result = self.reflection.review(
+                body, evidence, rubric, contract=self.contract, vault=vault
+            )
+            verdict = result.decision
             if verdict != "REVISE":
                 break
+
+        # Never ship a sub-threshold draft: a still-REVISE verdict after the
+        # round budget is exhausted escalates to a human (#473).
+        if verdict == "REVISE":
+            verdict = "ESCALATE"
 
         return AuthoredDraft(
             medium=validated,

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -27,6 +27,17 @@ ReflectionVerdict = Literal["PASS", "REVISE", "ESCALATE"]
 #: breach (citation/privacy), ``MID`` a softer rubric divergence, ``LOW`` a hint.
 FindingSeverity = Literal["LOW", "MID", "HIGH"]
 
+#: The six research-rubric dimensions a reflection finding can fire on (#473).
+#: Typed so strict mypy catches a mistyped dimension at the construction site.
+FindingDimension = Literal[
+    "voice_fidelity",
+    "ontological_accuracy",
+    "citation_completeness",
+    "privacy_compliance",
+    "paradox_preservation",
+    "attribution_correctness",
+]
+
 
 class ReflectionFinding(BaseModel):
     """One scored defect the reflection node found in a drafted body (#473).
@@ -41,7 +52,7 @@ class ReflectionFinding(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    dimension: str
+    dimension: FindingDimension
     severity: FindingSeverity
     message: str
 

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -197,6 +197,10 @@ class AuthoredDraft(BaseModel):
             :class:`~creek.compile.provenance.ProvenanceEntry` shape.
         verdict: The reflection node's verdict for this draft.
         rounds: How many voice/reflect rounds ran (``>= 1``).
+        findings: The reflection findings from the final round. Carried so an
+            ``ESCALATE`` (or ``REVISE``) verdict is actionable — a human can see
+            exactly which dimensions failed rather than being told only that the
+            draft was escalated.
     """
 
     model_config = ConfigDict(frozen=True)
@@ -207,6 +211,7 @@ class AuthoredDraft(BaseModel):
     provenance: list[ProvenanceEntry] = Field(default_factory=list)
     verdict: ReflectionVerdict
     rounds: int = Field(ge=1)
+    findings: list[ReflectionFinding] = Field(default_factory=list)
 
     # BUG-009: the ``[prop-decorator]`` suppression is the known mypy /
     # Pydantic-v2 limitation when stacking ``@computed_field`` over

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -23,6 +23,44 @@ Medium = Literal["research", "chat", "essay", "research-piece", "book-report", "
 #: The reflection node's bounded verdict over a drafted body.
 ReflectionVerdict = Literal["PASS", "REVISE", "ESCALATE"]
 
+#: Severity of a single reflection finding (#473). ``HIGH`` marks a hard-gate
+#: breach (citation/privacy), ``MID`` a softer rubric divergence, ``LOW`` a hint.
+FindingSeverity = Literal["LOW", "MID", "HIGH"]
+
+
+class ReflectionFinding(BaseModel):
+    """One scored defect the reflection node found in a drafted body (#473).
+
+    Attributes:
+        dimension: Which of the six rubric dimensions fired (e.g.
+            ``"citation_completeness"``).
+        severity: How serious the defect is — ``HIGH`` for a hard-gate
+            breach, ``MID`` for a rubric divergence, ``LOW`` for a hint.
+        message: A human-readable explanation naming the concrete defect.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    dimension: str
+    severity: FindingSeverity
+    message: str
+
+
+class ReflectionResult(BaseModel):
+    """The structured outcome of judging one drafted body (#473).
+
+    Attributes:
+        decision: The bounded verdict — ``PASS`` (ship), ``REVISE`` (one or
+            more findings; retry), or ``ESCALATE`` (cannot author at all).
+        findings: Every :class:`ReflectionFinding` the checks raised; empty
+            on a clean ``PASS``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    decision: ReflectionVerdict
+    findings: list[ReflectionFinding] = Field(default_factory=list)
+
 
 class EvidenceClaim(BaseModel):
     """A single structured claim from a specialist, traced to fragments.

--- a/creek-tools/creek/author/reflection.py
+++ b/creek-tools/creek/author/reflection.py
@@ -1,44 +1,92 @@
-"""Stub Reflection node for the Creek Writing Desk (FEAT-041, #455).
+"""The Reflection node for the Creek Writing Desk (FEAT-041, #473).
 
-Judges a drafted body and returns a bounded verdict. The skeleton uses a
-trivial groundedness heuristic; issue #473 replaces it with the real
-reflection logic plus bounded retries and escalation.
+A *deterministic* judge — no LLM, so the mutation tests can assert exact
+verdicts — scores a drafted body against the six research-rubric dimensions and
+returns a structured :class:`~creek.author.models.ReflectionResult`
+(``PASS | REVISE | ESCALATE`` plus findings). Citation completeness and privacy
+compliance are HARD gates for research. The conductor (#473) owns the retry loop
+and the exhaustion → ESCALATE policy; this node decides only one round.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from creek.author.checks import (
+    check_attribution_correctness,
+    check_citation_completeness,
+    check_ontological_accuracy,
+    check_paradox_preservation,
+    check_privacy_compliance,
+    check_voice_fidelity,
+)
+from creek.author.models import (
+    EvidenceBundle,
+    ReflectionFinding,
+    ReflectionResult,
+    ReflectionVerdict,
+)
+
 if TYPE_CHECKING:
-    from creek.author.models import EvidenceBundle, ReflectionVerdict
+    from pathlib import Path
+
+    from creek.config import AIStyleConfig
+    from creek.generate.ai_style.model import VoiceFingerprint
+    from creek.models import MediumContract
 
 
 class ReflectionNode:
-    """Stub Reflection node that judges a draft against its evidence."""
+    """A deterministic judge that scores a draft against the six dimensions."""
 
     def review(
         self,
         body: str,
         evidence: EvidenceBundle,
         rubric: dict[str, float] | None = None,
-    ) -> ReflectionVerdict:
-        """Return a verdict for *body* given its *evidence*.
+        *,
+        contract: MediumContract | None = None,
+        vault: Path | None = None,
+        fingerprint: VoiceFingerprint | None = None,
+        ai_style_config: AIStyleConfig | None = None,
+    ) -> ReflectionResult:
+        """Judge *body* against *evidence* and return a structured result.
 
-        The stub heuristic: a non-empty body grounded in at least one claim
-        passes; anything else escalates. It never returns ``REVISE`` — the
-        real reflection logic (issue #473) owns the revise/retry loop and will
-        score against *rubric*, which the medium contract supplies (FEAT-041).
+        When the draft cannot be authored at all — an empty body or no
+        grounded claims — the node ``ESCALATE``s immediately. Otherwise it runs
+        every check whose inputs are present, collects the findings, and
+        decides ``PASS`` (no findings) or ``REVISE`` (at least one). Single-call
+        ``ESCALATE`` is reserved for the no-draft case; escalation on retry
+        exhaustion is the conductor's responsibility.
 
         Args:
             body: The drafted prose under review.
             evidence: The evidence the draft was rendered from.
-            rubric: The medium's per-dimension reflection weights (§8); the
-                stub accepts but does not yet score against it.
+            rubric: The medium's per-dimension reflection weights (§8). The
+                deterministic checks gate on hard rules rather than weights, so
+                this is accepted for interface stability but not scored.
+            contract: The medium contract; its ``default_privacy_tier`` is the
+                privacy ceiling. ``None`` skips the privacy check.
+            vault: The vault root used to resolve cited fragments' privacy
+                tiers. ``None`` skips the privacy check.
+            fingerprint: The owner's voice fingerprint. ``None`` skips voice
+                fidelity (the voice cannot be measured without it).
+            ai_style_config: The AI-style configuration. ``None`` skips voice
+                fidelity.
 
         Returns:
-            ``"PASS"`` when grounded and non-empty, else ``"ESCALATE"``.
+            A :class:`ReflectionResult` with the verdict and any findings.
         """
-        del rubric  # scored by the real reflection node (#473)
-        if body.strip() and evidence.claims:
-            return "PASS"
-        return "ESCALATE"
+        del rubric  # deterministic checks gate on hard rules, not weights
+        if not body.strip() or not evidence.claims:
+            return ReflectionResult(decision="ESCALATE")
+
+        findings: list[ReflectionFinding] = []
+        findings.extend(check_citation_completeness(evidence))
+        findings.extend(check_privacy_compliance(body, evidence, vault, contract))
+        findings.extend(check_ontological_accuracy(body))
+        findings.extend(check_paradox_preservation(body, evidence))
+        findings.extend(check_attribution_correctness(body, evidence))
+        findings.extend(check_voice_fidelity(body, fingerprint, ai_style_config))
+
+        decision: ReflectionVerdict = "PASS" if not findings else "REVISE"
+        return ReflectionResult(decision=decision, findings=findings)

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -68,21 +68,21 @@ def _utc_now() -> datetime:
 
 
 # INC-019 one-release migration aliases — see the INC doc for context.
-_PHASE_LEGACY_ALIASES = {
+PHASE_LEGACY_ALIASES = {
     "origins": "rising",
     "cresting": "withdrawal",
     "receding": "diminishing",
     "composting": "restoration",
 }
 
-_MODE_LEGACY_ALIASES = {
+MODE_LEGACY_ALIASES = {
     "solo": "inhabit",
     "dialogue": "express",
     "reflective": "integrate",
     "analytic": "collaborate",
 }
 
-_FREQUENCY_LEGACY_ALIASES = {
+FREQUENCY_LEGACY_ALIASES = {
     "amplitude": "F1",
     "pitch": "F2",
 }
@@ -130,7 +130,7 @@ class Frequency(StrEnum):
     @classmethod
     def _missing_(cls, value: object) -> "Frequency | None":
         """Map legacy INC-019 wave-physics strings to canonical F-codes."""
-        return _legacy_alias_lookup(cls, value, _FREQUENCY_LEGACY_ALIASES)
+        return _legacy_alias_lookup(cls, value, FREQUENCY_LEGACY_ALIASES)
 
 
 class Phase(StrEnum):
@@ -147,7 +147,7 @@ class Phase(StrEnum):
     @classmethod
     def _missing_(cls, value: object) -> "Phase | None":
         """Map legacy INC-019 drift phase strings to canonical phases."""
-        return _legacy_alias_lookup(cls, value, _PHASE_LEGACY_ALIASES)
+        return _legacy_alias_lookup(cls, value, PHASE_LEGACY_ALIASES)
 
 
 class Mode(StrEnum):
@@ -163,7 +163,7 @@ class Mode(StrEnum):
     @classmethod
     def _missing_(cls, value: object) -> "Mode | None":
         """Map legacy INC-019 drift mode strings to canonical modes."""
-        return _legacy_alias_lookup(cls, value, _MODE_LEGACY_ALIASES)
+        return _legacy_alias_lookup(cls, value, MODE_LEGACY_ALIASES)
 
 
 class Orientation(StrEnum):

--- a/creek-tools/tests/test_author_desk.py
+++ b/creek-tools/tests/test_author_desk.py
@@ -32,7 +32,7 @@ from creek.author.agents import (
     OntologySpecialist,
     RetrievalSpecialist,
 )
-from creek.author.models import EvidenceClaim
+from creek.author.models import EvidenceClaim, ReflectionResult
 from creek.author.reflection import ReflectionNode
 from creek.author.voice import VoiceAgent
 
@@ -109,20 +109,20 @@ def test_voice_stub_renders_body_from_evidence() -> None:
 
 
 def test_reflection_passes_grounded_and_escalates_ungrounded() -> None:
-    """The stub reflection node passes grounded drafts and escalates empty ones."""
+    """The reflection node passes a clean grounded draft and escalates no-draft."""
     evidence = EvidenceBundle(
         claims=[EvidenceClaim(claim="a claim", source_fragments=["f1"])]
     )
 
-    assert ReflectionNode().review("a real body", evidence) == "PASS"
-    assert ReflectionNode().review("   ", evidence) == "ESCALATE"
-    assert ReflectionNode().review("body", EvidenceBundle()) == "ESCALATE"
+    assert ReflectionNode().review("a real body", evidence).decision == "PASS"
+    assert ReflectionNode().review("   ", evidence).decision == "ESCALATE"
+    assert ReflectionNode().review("body", EvidenceBundle()).decision == "ESCALATE"
 
 
 def test_conductor_respects_max_rounds(tmp_path: Path) -> None:
-    """A REVISE verdict loops up to ``max_rounds`` then returns that verdict."""
+    """REVISE loops up to ``max_rounds``; exhaustion escalates, never ships REVISE."""
     revising = MagicMock()
-    revising.review.return_value = "REVISE"
+    revising.review.return_value = ReflectionResult(decision="REVISE")
     conductor = Conductor(
         specialists=[GraphSpecialist()],
         voice=VoiceAgent(),
@@ -133,7 +133,9 @@ def test_conductor_respects_max_rounds(tmp_path: Path) -> None:
     draft = conductor.run(medium="research", query="q", vault=tmp_path)
 
     assert draft.rounds == 2
-    assert draft.verdict == "REVISE"
+    # New contract (#473): a still-REVISE draft after exhausting the round
+    # budget escalates to a human rather than shipping sub-threshold.
+    assert draft.verdict == "ESCALATE"
     assert revising.review.call_count == 2
 
 

--- a/creek-tools/tests/test_author_desk.py
+++ b/creek-tools/tests/test_author_desk.py
@@ -139,6 +139,17 @@ def test_conductor_respects_max_rounds(tmp_path: Path) -> None:
     assert revising.review.call_count == 2
 
 
+def test_conductor_rejects_zero_max_rounds() -> None:
+    """``max_rounds`` below 1 is rejected — the voice/reflect loop must run (#473)."""
+    with pytest.raises(ValueError, match="max_rounds must be >= 1"):
+        Conductor(
+            specialists=[GraphSpecialist()],
+            voice=VoiceAgent(),
+            reflection=ReflectionNode(),
+            max_rounds=0,
+        )
+
+
 def test_evidence_bundle_dedups_source_fragments() -> None:
     """``all_source_fragments`` is an order-preserving, deduplicated union."""
     bundle = EvidenceBundle(

--- a/creek-tools/tests/test_author_desk.py
+++ b/creek-tools/tests/test_author_desk.py
@@ -32,7 +32,7 @@ from creek.author.agents import (
     OntologySpecialist,
     RetrievalSpecialist,
 )
-from creek.author.models import EvidenceClaim, ReflectionResult
+from creek.author.models import EvidenceClaim, ReflectionFinding, ReflectionResult
 from creek.author.reflection import ReflectionNode
 from creek.author.voice import VoiceAgent
 
@@ -122,7 +122,16 @@ def test_reflection_passes_grounded_and_escalates_ungrounded() -> None:
 def test_conductor_respects_max_rounds(tmp_path: Path) -> None:
     """REVISE loops up to ``max_rounds``; exhaustion escalates, never ships REVISE."""
     revising = MagicMock()
-    revising.review.return_value = ReflectionResult(decision="REVISE")
+    revising.review.return_value = ReflectionResult(
+        decision="REVISE",
+        findings=[
+            ReflectionFinding(
+                dimension="citation_completeness",
+                severity="HIGH",
+                message="uncited",
+            )
+        ],
+    )
     conductor = Conductor(
         specialists=[GraphSpecialist()],
         voice=VoiceAgent(),
@@ -137,6 +146,9 @@ def test_conductor_respects_max_rounds(tmp_path: Path) -> None:
     # budget escalates to a human rather than shipping sub-threshold.
     assert draft.verdict == "ESCALATE"
     assert revising.review.call_count == 2
+    # The escalation must be actionable: the final round's findings are carried
+    # on the draft so a human can see which dimensions failed (#505 review).
+    assert [f.dimension for f in draft.findings] == ["citation_completeness"]
 
 
 def test_conductor_rejects_zero_max_rounds() -> None:

--- a/creek-tools/tests/test_medium_contract.py
+++ b/creek-tools/tests/test_medium_contract.py
@@ -16,6 +16,7 @@ import pytest
 from creek.author.agents import GraphSpecialist
 from creek.author.conductor import Conductor
 from creek.author.contracts import load_medium_contract
+from creek.author.models import ReflectionResult
 from creek.author.voice import VoiceAgent
 from creek.lint.checks import skill_size_budget
 from creek.models import MediumContract, PrivacyTier
@@ -100,7 +101,7 @@ def test_conductor_exposes_rubric_to_reflection(tmp_path: Path) -> None:
     """The Conductor passes the contract's reflection rubric to the reflection node."""
     contract = MediumContract(medium="research", reflection_rubric={"accuracy": 1.0})
     reflection = MagicMock()
-    reflection.review.return_value = "PASS"
+    reflection.review.return_value = ReflectionResult(decision="PASS")
     conductor = Conductor(
         specialists=[GraphSpecialist()],
         voice=VoiceAgent(),

--- a/creek-tools/tests/test_reflection.py
+++ b/creek-tools/tests/test_reflection.py
@@ -138,6 +138,32 @@ def test_privacy_skips_cited_fragment_absent_from_vault(tmp_path: Path) -> None:
     assert not any(f.dimension == "privacy_compliance" for f in result.findings)
 
 
+def test_paradox_bare_conjunction_off_topic_is_flattened() -> None:
+    """A contrast cue unrelated to the paradox's vocabulary does not preserve it.
+
+    Closes the bare-conjunction bypass (#505 review): a stray "but" with no
+    topical overlap is treated as a flattened tension, not a preserved one.
+    """
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])],
+        ontology=OntologyAnalysis(
+            paradoxes=(
+                OntologyParadox(
+                    kind="dosage",
+                    fragment_ids=("frag-a",),
+                    description="solitude nourishes while crowds drain",
+                ),
+            )
+        ),
+    )
+    body = "I went to the store but forgot the milk."
+
+    result = ReflectionNode().review(body, evidence)
+
+    assert result.decision == "REVISE"
+    assert any(f.dimension == "paradox_preservation" for f in result.findings)
+
+
 def test_resolved_paradox_revises_with_paradox_finding() -> None:
     """A flattened paradox (no contrast cue) → REVISE + paradox_preservation."""
     evidence = EvidenceBundle(

--- a/creek-tools/tests/test_reflection.py
+++ b/creek-tools/tests/test_reflection.py
@@ -138,6 +138,23 @@ def test_privacy_skips_cited_fragment_absent_from_vault(tmp_path: Path) -> None:
     assert not any(f.dimension == "privacy_compliance" for f in result.findings)
 
 
+def test_legacy_alias_maps_have_no_key_collisions() -> None:
+    """The merged alias map keeps every key — no phase/mode/frequency collision."""
+    from creek.author.checks import _LEGACY_ALIASES
+    from creek.models import (
+        FREQUENCY_LEGACY_ALIASES,
+        MODE_LEGACY_ALIASES,
+        PHASE_LEGACY_ALIASES,
+    )
+
+    expected = (
+        len(PHASE_LEGACY_ALIASES)
+        + len(MODE_LEGACY_ALIASES)
+        + len(FREQUENCY_LEGACY_ALIASES)
+    )
+    assert len(_LEGACY_ALIASES) == expected
+
+
 def test_paradox_bare_conjunction_off_topic_is_flattened() -> None:
     """A contrast cue unrelated to the paradox's vocabulary does not preserve it.
 

--- a/creek-tools/tests/test_reflection.py
+++ b/creek-tools/tests/test_reflection.py
@@ -1,0 +1,320 @@
+"""Mutation-grade tests for the deterministic Reflection node (#473).
+
+Each rubric dimension gets a test that injects *exactly* that defect and asserts
+the EXACT verdict plus a finding for the right dimension — not merely "not
+PASS". A clean draft passes; a no-draft input escalates; and the Conductor
+escalates rather than ships when the round budget is exhausted on REVISE.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.author.checks import check_voice_fidelity
+from creek.author.conductor import Conductor
+from creek.author.models import (
+    EvidenceBundle,
+    EvidenceClaim,
+    OntologyAnalysis,
+    OntologyParadox,
+    ReflectionResult,
+)
+from creek.author.reflection import ReflectionNode
+from creek.author.voice import VoiceAgent
+from creek.config import AIStyleConfig
+from creek.generate.ai_style.model import (
+    Finding,
+    ScanReport,
+    Span,
+    VoiceFingerprint,
+)
+from creek.models import MediumContract, PrivacyTier
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+
+def _grounded() -> EvidenceBundle:
+    """Return a single grounded, attributed-free, paradox-free evidence bundle."""
+    return EvidenceBundle(
+        claims=[EvidenceClaim(claim="F6 names pluralism", source_fragments=["frag-a"])]
+    )
+
+
+def _seed_fragment(
+    vault: Path,
+    frag_id: str,
+    body: str,
+    tier: PrivacyTier = PrivacyTier.OPEN,
+) -> None:
+    """Write a minimal fragment file with *body* and *tier* into the vault."""
+    folder = vault / "01-Fragments" / "Notes"
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / f"{frag_id}.md").write_text(
+        f'---\ntype: fragment\nid: {frag_id}\ntitle: "t"\n'
+        f"privacy_tier: {tier.value}\n"
+        f"source:\n  platform: journal\n  author: self\n---\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_uncited_claim_revises_with_citation_finding() -> None:
+    """An uncited claim → REVISE with a citation_completeness finding."""
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="bold unsupported assertion", source_fragments=[])]
+    )
+
+    result = ReflectionNode().review("A clean body about ideas.", evidence)
+
+    assert result.decision == "REVISE"
+    assert any(f.dimension == "citation_completeness" for f in result.findings)
+
+
+def test_alias_misuse_revises_with_ontology_finding() -> None:
+    """A legacy alias ("origins" not "rising") → REVISE + ontological_accuracy."""
+    body = "The piece traces the origins of the wave."
+
+    result = ReflectionNode().review(body, _grounded())
+
+    assert result.decision == "REVISE"
+    finding = next(f for f in result.findings if f.dimension == "ontological_accuracy")
+    assert "rising" in finding.message
+
+
+def test_privacy_leak_revises_with_privacy_finding(tmp_path: Path) -> None:
+    """A cited intimate fragment leaked above the OPEN default → privacy finding."""
+    secret = "the intimate confession nobody should publish"
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = f"Here is the leak: {secret}"
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    assert result.decision == "REVISE"
+    assert any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_privacy_open_fragment_passes(tmp_path: Path) -> None:
+    """An OPEN cited fragment at the OPEN default → no privacy finding (PASS)."""
+    text = "an openly publishable observation"
+    _seed_fragment(tmp_path, "frag-a", text, tier=PrivacyTier.OPEN)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+
+    result = ReflectionNode().review(
+        f"Body: {text}", evidence, contract=contract, vault=tmp_path
+    )
+
+    assert result.decision == "PASS"
+    assert result.findings == []
+
+
+def test_resolved_paradox_revises_with_paradox_finding() -> None:
+    """A flattened paradox (no contrast cue) → REVISE + paradox_preservation."""
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])],
+        ontology=OntologyAnalysis(
+            paradoxes=(
+                OntologyParadox(
+                    kind="dosage",
+                    fragment_ids=("frag-a", "frag-b"),
+                    description="solitude nourishes while crowds drain",
+                ),
+            )
+        ),
+    )
+    # Body surfaces only one side, with no contrast/tension marker.
+    body = "Solitude is purely nourishing and good for everyone always."
+
+    result = ReflectionNode().review(body, evidence)
+
+    assert result.decision == "REVISE"
+    assert any(f.dimension == "paradox_preservation" for f in result.findings)
+
+
+def test_preserved_paradox_passes_on_contrast_cue() -> None:
+    """A body carrying a contrast cue keeps the tension → no paradox finding."""
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])],
+        ontology=OntologyAnalysis(
+            paradoxes=(
+                OntologyParadox(
+                    kind="dosage",
+                    fragment_ids=("frag-a",),
+                    description="solitude nourishes while crowds drain",
+                ),
+            )
+        ),
+    )
+    body = "Solitude nourishes, but crowds can drain — both are true at once."
+
+    result = ReflectionNode().review(body, evidence)
+
+    assert result.decision == "PASS"
+
+
+def test_false_attribution_revises_with_attribution_finding() -> None:
+    """A claim borrowed from an author, unattributed in the body → attribution."""
+    evidence = EvidenceBundle(
+        claims=[
+            EvidenceClaim(
+                claim="Specific knowledge cannot be taught.",
+                source_fragments=["frag-a"],
+                author_slug="naval-ravikant",
+            )
+        ]
+    )
+    body = "Specific knowledge cannot be taught, only learned through apprenticeship."
+
+    result = ReflectionNode().review(body, evidence)
+
+    assert result.decision == "REVISE"
+    assert any(f.dimension == "attribution_correctness" for f in result.findings)
+
+
+def test_attributed_claim_passes() -> None:
+    """Naming the borrowed author in the body clears the attribution gate."""
+    evidence = EvidenceBundle(
+        claims=[
+            EvidenceClaim(
+                claim="Specific knowledge cannot be taught.",
+                source_fragments=["frag-a"],
+                author_slug="naval-ravikant",
+            )
+        ]
+    )
+    body = "As Naval Ravikant argues, specific knowledge cannot be taught."
+
+    assert ReflectionNode().review(body, evidence).decision == "PASS"
+
+
+def test_voice_fidelity_maps_scan_findings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``check_voice_fidelity`` maps a ScanReport's findings to voice_fidelity."""
+    report = ScanReport(
+        findings=[
+            Finding(
+                tell_id="t",
+                category="lexical_tics",
+                feature_key="k",
+                span=Span(0, 0),
+                line=1,
+                excerpt="",
+                draft_rate=2.0,
+                user_rate=0.0,
+                direction="over",
+                message="over-uses em dashes",
+            )
+        ],
+        voice_distance=0.9,
+    )
+
+    def _fake_scan(
+        _text: str,
+        *,
+        fingerprint: VoiceFingerprint,
+        config: AIStyleConfig,
+        context: str = "article",
+    ) -> ScanReport:
+        del fingerprint, config, context
+        return report
+
+    monkeypatch.setattr("creek.author.checks.scan", _fake_scan)
+
+    findings = check_voice_fidelity(
+        "some body", VoiceFingerprint(fragment_count=5), AIStyleConfig()
+    )
+
+    assert findings  # non-empty
+    assert all(f.dimension == "voice_fidelity" for f in findings)
+    # The over-ceiling distance (0.9 > 0.35) adds a HIGH finding.
+    assert any(f.severity == "HIGH" for f in findings)
+
+
+def test_voice_fidelity_within_ceiling_adds_no_high(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scan under the distance ceiling yields no HIGH voice finding."""
+    report = ScanReport(findings=[], voice_distance=0.1)
+
+    def _fake_scan(
+        _text: str,
+        *,
+        fingerprint: VoiceFingerprint,
+        config: AIStyleConfig,
+        context: str = "article",
+    ) -> ScanReport:
+        del fingerprint, config, context
+        return report
+
+    monkeypatch.setattr("creek.author.checks.scan", _fake_scan)
+
+    findings = check_voice_fidelity(
+        "body", VoiceFingerprint(fragment_count=5), AIStyleConfig()
+    )
+
+    assert findings == []
+
+
+def test_voice_fidelity_skips_without_fingerprint() -> None:
+    """No fingerprint/config → voice cannot be measured → no findings."""
+    assert check_voice_fidelity("body", None, None) == []
+
+
+def test_privacy_skips_uncited_vault_fragment(tmp_path: Path) -> None:
+    """An intimate fragment present in the vault but NOT cited is not flagged."""
+    secret = "an intimate note nobody cited"
+    _seed_fragment(tmp_path, "frag-uncited", secret, tier=PrivacyTier.INTIMATE)
+    _seed_fragment(tmp_path, "frag-a", "an open cited note", tier=PrivacyTier.OPEN)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+
+    result = ReflectionNode().review(
+        f"Body mentions {secret}", evidence, contract=contract, vault=tmp_path
+    )
+
+    # The intimate fragment is uncited, so its presence is not a privacy breach.
+    assert result.decision == "PASS"
+    assert not any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_clean_draft_passes() -> None:
+    """A grounded, canonical, attributed, leak-free draft → PASS, no findings."""
+    result = ReflectionNode().review("A grounded, canonical observation.", _grounded())
+
+    assert result.decision == "PASS"
+    assert result.findings == []
+
+
+def test_empty_body_or_no_evidence_escalates() -> None:
+    """An empty body or claim-less evidence cannot be authored → ESCALATE."""
+    assert ReflectionNode().review("   ", _grounded()).decision == "ESCALATE"
+    assert ReflectionNode().review("body", EvidenceBundle()).decision == "ESCALATE"
+
+
+def test_conductor_escalates_on_exhaustion(tmp_path: Path) -> None:
+    """A reflection that always REVISEs exhausts the budget → ESCALATE at round 2."""
+
+    class _AlwaysRevise:
+        def review(self, *_args: object, **_kwargs: object) -> ReflectionResult:
+            return ReflectionResult(decision="REVISE")
+
+    conductor = Conductor(
+        specialists=[],
+        voice=VoiceAgent(),
+        reflection=_AlwaysRevise(),
+        max_rounds=2,
+    )
+
+    draft = conductor.run(medium="research", query="q", vault=tmp_path)
+
+    assert draft.rounds == 2
+    assert draft.verdict == "ESCALATE"

--- a/creek-tools/tests/test_reflection.py
+++ b/creek-tools/tests/test_reflection.py
@@ -116,6 +116,28 @@ def test_privacy_open_fragment_passes(tmp_path: Path) -> None:
     assert result.findings == []
 
 
+def test_privacy_skips_cited_fragment_absent_from_vault(tmp_path: Path) -> None:
+    """A claim citing a fragment id not present in the vault raises no privacy finding.
+
+    The privacy check can only resolve the tier of fragments it can load; a
+    cited id with no matching vault file is unresolvable, so it is skipped
+    rather than guessed (no crash, no fabricated finding). The claim still
+    carries a source-fragment id, so the hard citation gate is satisfied.
+    """
+    (tmp_path / "01-Fragments").mkdir(parents=True, exist_ok=True)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-missing"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+
+    result = ReflectionNode().review(
+        "a body with no leak", evidence, contract=contract, vault=tmp_path
+    )
+
+    assert result.decision == "PASS"
+    assert not any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
 def test_resolved_paradox_revises_with_paradox_finding() -> None:
     """A flattened paradox (no contrast cue) → REVISE + paradox_preservation."""
     evidence = EvidenceBundle(


### PR DESCRIPTION
## Summary

Replaces the desk's **last stub** (the pass-through Reflection node) with a real, **deterministic** judge — no LLM, so the mutation tests assert exact verdicts — and gives the Conductor its quality gate (FEAT-041 §4.2/§8). The desk now ships only PASS drafts; a failing draft loops, then escalates.

- **New models:** `ReflectionFinding` (dimension/severity/message) + `ReflectionResult` (decision + findings). `AuthoredDraft.verdict` stays the literal; the conductor extracts `result.decision`.
- **New `creek/author/checks.py` — six deterministic checks:**
  - **citation_completeness** (HARD): a claim with no `source_fragments` → HIGH.
  - **privacy_compliance** (HARD): resolves cited fragments' privacy tiers from the vault (reuses `iter_vault_fragments`); a cited tier above the contract's `default_privacy_tier` whose protected text still leaks into the draft → HIGH.
  - **ontological_accuracy**: legacy-alias word-boundary match (INC-019) → MID, naming the canonical term.
  - **paradox_preservation**: a surfaced `OntologyParadox` flattened in the body (no contrast cue / missing description terms) → MID.
  - **attribution_correctness**: a claim with `author_slug` unattributed in the body → HIGH.
  - **voice_fidelity**: reuses the FEAT-040.x AI-style `scan`; findings + an over-ceiling `voice_distance` → MID/HIGH.
- **`ReflectionNode.review(...) -> ReflectionResult`:** empty body / no claims → ESCALATE (can't author); otherwise run the applicable checks → PASS (no findings) or REVISE. Optional `contract`/`vault`/`fingerprint`/`ai_style_config` kwargs keep positional callers working.
- **Conductor:** `Reflector` protocol returns `ReflectionResult`; `run()` extracts `.decision`, threads contract/vault into review, and — **never shipping a sub-threshold draft** — rewrites a still-REVISE verdict to **ESCALATE** once `max_author_rounds` (bound [1,10]) is exhausted.

Scope: deterministic checks only — no LLM-judge / model-tiering (that's ISSUE_07/#474).

## Test plan
`cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (4978 tests). New `tests/test_reflection.py` — **15 mutation-grade tests**: each injected defect (uncited claim → `citation_completeness`; "origins" alias → `ontological_accuracy`; intimate cited+leaked → `privacy_compliance`; flattened paradox → `paradox_preservation`; omitted `author_slug` → `attribution_correctness`; over-ceiling scan → `voice_fidelity`) asserts the **exact** `REVISE` verdict + the right-dimension finding, with paired **PASS** cases; plus the **DoD escalation test** (always-REVISE + `max_rounds=2` → `verdict == "ESCALATE"`, `rounds == 2`) and no-draft → ESCALATE.

Updated the two desk tests + one contract test to the structured result; the max-rounds test is **strengthened** to assert the new ESCALATE-on-exhaustion contract (was `REVISE`). No assertion weakened.

Closes #473
Refs #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)