### PR TITLE
perf(author): reuse EmbeddingLinker + embeddings cache in Retrieval agent (#486)

### DIFF
--- a/creek-tools/creek/author/agents.py
+++ b/creek-tools/creek/author/agents.py
@@ -189,6 +189,8 @@ class RetrievalSpecialist:
                 first :meth:`gather` and cached on the instance.
         """
         self._linker = linker
+        self._cache: dict[str, CachedEmbedding] | None = None
+        self._cache_vault: Path | None = None
 
     def _get_linker(self, config: CreekConfig) -> EmbeddingLinker:
         """Return the instance's linker, creating and caching it on first use.
@@ -203,6 +205,33 @@ class RetrievalSpecialist:
             self._linker = EmbeddingLinker(config.embeddings)
         return self._linker
 
+    def _get_cache(
+        self,
+        linker: EmbeddingLinker,
+        vault: Path,
+    ) -> dict[str, CachedEmbedding]:
+        """Return the persisted embeddings cache, read once per instance + vault.
+
+        The parquet is loaded on first use for a given vault and reused across
+        later :meth:`gather` calls so the desk does not re-read it every call.
+        Staleness is harmless: ``_fragment_vector`` validates each entry's
+        ``content_hash`` against the fragment's current text, so a fragment
+        re-embedded into the parquet after this instance cached the dict simply
+        falls back to a live embed — never a wrong vector. A different *vault*
+        reloads.
+
+        Args:
+            linker: The reused linker whose ``load_cache`` reads the parquet.
+            vault: The vault whose embeddings cache is read.
+
+        Returns:
+            The fragment-id keyed embedding cache (empty when absent).
+        """
+        if self._cache is None or self._cache_vault != vault:
+            self._cache = linker.load_cache(embeddings_cache_path(vault))
+            self._cache_vault = vault
+        return self._cache
+
     def gather(self, query: str, vault: Path) -> EvidenceBundle:
         """Return the top-``retrieval_top_k`` fragments most relevant to *query*.
 
@@ -216,7 +245,7 @@ class RetrievalSpecialist:
         if not corpus:
             return EvidenceBundle()
         linker = self._get_linker(config)
-        cache = linker.load_cache(embeddings_cache_path(vault))
+        cache = self._get_cache(linker, vault)
         try:
             ranked = _rank_fragments(query, corpus, linker, cache)
         except EmbeddingModelUnavailableError:

--- a/creek-tools/creek/author/agents.py
+++ b/creek-tools/creek/author/agents.py
@@ -31,6 +31,8 @@ from creek.generate.paradox import OPPOSITE_PHASE_PAIRS
 from creek.link.embeddings import (
     EmbeddingLinker,
     EmbeddingModelUnavailableError,
+    content_hash_for_text,
+    embeddings_cache_path,
     fragment_embedding_text,
 )
 from creek.models import Dosage, Frequency, Mode, Phase
@@ -40,7 +42,8 @@ if TYPE_CHECKING:
     from enum import StrEnum
     from pathlib import Path
 
-    from creek.config import CreekConfig, EmbeddingsConfig
+    from creek.config import CreekConfig
+    from creek.link.embeddings import CachedEmbedding
     from creek.models import Fragment
 
 _DimT = TypeVar("_DimT", bound="StrEnum")
@@ -103,47 +106,119 @@ def _cosine(left: list[float], right: list[float]) -> float:
     return float(a @ b / denom) if denom else 0.0
 
 
+def _fragment_vector(
+    fragment: Fragment,
+    linker: EmbeddingLinker,
+    cache: dict[str, CachedEmbedding],
+) -> list[float]:
+    """Return *fragment*'s embedding, reusing a fresh cached vector when present.
+
+    A cached vector is trusted only when the fragment id is in *cache* and its
+    stored ``content_hash`` still equals the SHA-256 of the fragment's current
+    :func:`fragment_embedding_text` — the exact freshness key
+    :meth:`EmbeddingLinker.build_cache_entries` writes. A miss or a stale hash
+    falls back to a live :meth:`EmbeddingLinker.generate_embedding`, so the
+    result is identical to embedding from scratch.
+
+    Args:
+        fragment: The corpus fragment to embed.
+        linker: The reused embedding linker (live-embed fallback).
+        cache: Persisted, model-filtered cache keyed by fragment id.
+
+    Returns:
+        The fragment's embedding vector.
+    """
+    text = fragment_embedding_text(fragment)
+    cached = cache.get(fragment.id)
+    if cached is not None and cached.content_hash == content_hash_for_text(text):
+        return cached.vector
+    return linker.generate_embedding(text)
+
+
 def _rank_fragments(
     query: str,
     corpus: list[tuple[Fragment, str]],
-    config: EmbeddingsConfig,
+    linker: EmbeddingLinker,
+    cache: dict[str, CachedEmbedding],
 ) -> list[Fragment]:
     """Rank *corpus* fragments by semantic similarity to *query* (descending).
 
-    Reuses :class:`EmbeddingLinker`. Ties break by fragment id for
-    determinism. Raises :class:`EmbeddingModelUnavailableError` when the
-    embedding model cannot load.
+    Embeds the query once with the reused *linker* and scores each fragment
+    against it, drawing fresh cached vectors from *cache* to avoid re-embedding
+    unchanged fragments (the cache is a pure optimisation — a hit yields the
+    same vector a live embed would). Ties break by fragment id for determinism.
+    Raises :class:`EmbeddingModelUnavailableError` when the embedding model
+    cannot load.
+
+    Args:
+        query: The user query to rank fragments against.
+        corpus: ``(fragment, body)`` records to score.
+        linker: The reused embedding linker.
+        cache: Persisted, model-filtered embedding cache keyed by fragment id.
+
+    Returns:
+        Fragments ordered by cosine similarity descending, id tie-break.
     """
-    # Perf: this builds a linker per call and re-embeds the corpus. Reusing a
-    # process-cached linker + the persisted embeddings cache is a tracked
-    # follow-up; correctness, not interactive latency, is the goal here.
-    linker = EmbeddingLinker(config)
     query_vec = linker.generate_embedding(query)
     scored: list[tuple[float, str, Fragment]] = []
     for fragment, _body in corpus:
-        vec = linker.generate_embedding(fragment_embedding_text(fragment))
+        vec = _fragment_vector(fragment, linker, cache)
         scored.append((_cosine(query_vec, vec), fragment.id, fragment))
     scored.sort(key=lambda item: (-item[0], item[1]))
     return [fragment for _score, _id, fragment in scored]
 
 
 class RetrievalSpecialist:
-    """Semantic-retrieval specialist over raw, reference, and other-author text."""
+    """Semantic-retrieval specialist over raw, reference, and other-author text.
+
+    Holds a lazily-created :class:`EmbeddingLinker` on the instance so a
+    long-lived specialist reused across :meth:`gather` calls loads the
+    sentence-transformer model only once. The linker is instance-level (never a
+    module global) so a fresh ``RetrievalSpecialist()`` per test starts cold and
+    the conftest model mock cannot leak across tests.
+    """
 
     name = "retrieval"
+
+    def __init__(self, *, linker: EmbeddingLinker | None = None) -> None:
+        """Initialise the specialist with an optional pre-built linker.
+
+        Args:
+            linker: An embedding linker to reuse; when ``None`` (the default,
+                as in :func:`default_specialists`) one is created lazily on
+                first :meth:`gather` and cached on the instance.
+        """
+        self._linker = linker
+
+    def _get_linker(self, config: CreekConfig) -> EmbeddingLinker:
+        """Return the instance's linker, creating and caching it on first use.
+
+        Args:
+            config: The loaded vault config supplying embeddings settings.
+
+        Returns:
+            The reused :class:`EmbeddingLinker` for this specialist instance.
+        """
+        if self._linker is None:
+            self._linker = EmbeddingLinker(config.embeddings)
+        return self._linker
 
     def gather(self, query: str, vault: Path) -> EvidenceBundle:
         """Return the top-``retrieval_top_k`` fragments most relevant to *query*.
 
         Degrades to an empty bundle when the corpus is empty or the embedding
         model is unavailable, so the desk never crashes on a thin/offline vault.
+        The persisted embeddings cache is loaded once and used to skip
+        re-embedding fragments whose text is unchanged.
         """
         config = _load_config(vault)
         corpus = _load_corpus(vault)
         if not corpus:
             return EvidenceBundle()
+        linker = self._get_linker(config)
+        cache = linker.load_cache(embeddings_cache_path(vault))
         try:
-            ranked = _rank_fragments(query, corpus, config.embeddings)
+            ranked = _rank_fragments(query, corpus, linker, cache)
         except EmbeddingModelUnavailableError:
             return EvidenceBundle()
         top = ranked[: config.author.retrieval_top_k]
@@ -183,8 +258,15 @@ def _build_link_graph(corpus: list[tuple[Fragment, str]]) -> dict[str, set[str]]
 
     Wikilink targets are resolved to fragment ids by id or by title; unresolved
     targets are dropped. Edges are bidirectional so the walk follows backlinks.
+
+    Duplicate-title resolution is **last-wins**: when two corpus fragments share
+    a title, the ``by_title`` map maps that title to the id of the *last*
+    fragment in corpus order, so a ``[[Shared Title]]`` wikilink targets it.
+    Ids are always preferred over titles — :func:`_wikilink_targets` checks
+    ``by_id`` first — so an exact-id link never falls through to title lookup.
     """
     by_id = {fragment.id for fragment, _ in corpus}
+    # Last-wins on duplicate titles (the comprehension keeps the final entry).
     by_title = {fragment.title: fragment.id for fragment, _ in corpus}
     graph: dict[str, set[str]] = {fragment.id: set() for fragment, _ in corpus}
     for fragment, body in corpus:

--- a/creek-tools/tests/test_real_agents.py
+++ b/creek-tools/tests/test_real_agents.py
@@ -8,8 +8,9 @@ other-author attribution, and degrade gracefully on a thin/offline vault.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -17,9 +18,19 @@ from creek.author.agents import (
     GraphSpecialist,
     OntologySpecialist,
     RetrievalSpecialist,
+    _build_link_graph,
+    _load_config,
+    _load_corpus,
 )
 from creek.author.models import EvidenceBundle
-from creek.link.embeddings import EmbeddingModelUnavailableError
+from creek.link.embeddings import (
+    CachedEmbedding,
+    EmbeddingLinker,
+    EmbeddingModelUnavailableError,
+    content_hash_for_text,
+    embeddings_cache_path,
+    fragment_embedding_text,
+)
 from creek.models import Frequency, Phase
 
 if TYPE_CHECKING:
@@ -296,3 +307,150 @@ def test_ontology_unclassified_corpus_still_grounds_claim(tmp_path: Path) -> Non
     assert bundle.claims
     cited = {fid for claim in bundle.claims for fid in claim.source_fragments}
     assert cited == {"frag-a", "frag-b"}
+
+
+def test_retrieval_reuses_linker_across_gather_calls(
+    tmp_path: Path, mock_sentence_transformer: MagicMock
+) -> None:
+    """One ``RetrievalSpecialist`` instance loads the model at most once.
+
+    A long-lived specialist reused across two ``gather()`` calls must not
+    re-instantiate the sentence-transformer — the per-instance lazy linker
+    holds the loaded model, so the underlying loader fires exactly once.
+    """
+    _write(tmp_path, "01-Fragments/Notes", "frag-a", "Alpha")
+    _write(tmp_path, "01-Fragments/Notes", "frag-b", "Beta")
+
+    specialist = RetrievalSpecialist()
+    specialist.gather("alpha", tmp_path)
+    specialist.gather("beta", tmp_path)
+
+    assert mock_sentence_transformer.call_count == 1
+
+
+def _seed_embeddings_cache(vault: Path, frag_ids: list[str]) -> None:
+    """Persist a real parquet cache covering *frag_ids* with fresh hashes."""
+    corpus = _load_corpus(vault)
+    by_id = {fragment.id: fragment for fragment, _ in corpus}
+    config = _load_config(vault)
+    linker = EmbeddingLinker(config.embeddings)
+    entries = {
+        fid: CachedEmbedding(
+            fragment_id=fid,
+            content_hash=content_hash_for_text(
+                fragment_embedding_text(by_id[fid]),
+            ),
+            model_name=config.embeddings.model,
+            vector=linker.generate_embedding(
+                fragment_embedding_text(by_id[fid]),
+            ),
+            computed_at=datetime.now(tz=UTC),
+        )
+        for fid in frag_ids
+    }
+    path = embeddings_cache_path(vault)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    linker.save_cache(entries, path)
+
+
+def test_retrieval_cache_hit_avoids_re_embedding(tmp_path: Path) -> None:
+    """A warm cache embeds only the query, never the cached fragments.
+
+    With a persisted parquet cache whose content hashes match the current
+    fragment text, ``gather`` reuses the cached vectors; the only
+    ``generate_embedding`` call is for the query itself.
+    """
+    _write(tmp_path, "01-Fragments/Notes", "frag-a", "Alpha")
+    _write(tmp_path, "01-Fragments/Notes", "frag-b", "Beta")
+    _seed_embeddings_cache(tmp_path, ["frag-a", "frag-b"])
+
+    with patch(
+        "creek.link.embeddings.EmbeddingLinker.generate_embedding",
+        autospec=True,
+        side_effect=EmbeddingLinker.generate_embedding,
+    ) as spy:
+        RetrievalSpecialist().gather("alpha", tmp_path)
+
+    embedded_texts = [call.args[1] for call in spy.call_args_list]
+    assert embedded_texts == ["alpha"]
+
+
+def test_retrieval_cache_is_pure_optimization(tmp_path: Path) -> None:
+    """Warm-cache ranking equals cold ranking — the cache changes nothing.
+
+    The cached vector for a fragment is the same deterministic vector the
+    mock produces on the embed path, so ids and order must be identical with
+    and without a cache file present.
+    """
+    _write(tmp_path, "01-Fragments/Notes", "frag-a", "Pluralism and F6")
+    _write(tmp_path, "01-Fragments/Notes", "frag-b", "Agency and F1")
+    _write(tmp_path, "01-Fragments/Notes", "frag-c", "Leverage and scale")
+
+    cold = RetrievalSpecialist().gather("What is F6 Pluralism?", tmp_path)
+    _seed_embeddings_cache(tmp_path, ["frag-a", "frag-b", "frag-c"])
+    warm = RetrievalSpecialist().gather("What is F6 Pluralism?", tmp_path)
+
+    assert cold == warm
+
+
+def test_retrieval_stale_cache_entry_is_recomputed(tmp_path: Path) -> None:
+    """A cache entry whose hash no longer matches falls back to a live embed.
+
+    Freshness is keyed on the SHA-256 of the current
+    ``fragment_embedding_text``; a stale hash must not be trusted, so the
+    fragment is re-embedded rather than served from the cache.
+    """
+    _write(tmp_path, "01-Fragments/Notes", "frag-a", "Alpha")
+    corpus = _load_corpus(tmp_path)
+    by_id = {fragment.id: fragment for fragment, _ in corpus}
+    config = _load_config(tmp_path)
+    linker = EmbeddingLinker(config.embeddings)
+    stale = {
+        "frag-a": CachedEmbedding(
+            fragment_id="frag-a",
+            content_hash=content_hash_for_text("a different, stale title"),
+            model_name=config.embeddings.model,
+            vector=linker.generate_embedding(
+                fragment_embedding_text(by_id["frag-a"]),
+            ),
+            computed_at=datetime.now(tz=UTC),
+        )
+    }
+    path = embeddings_cache_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    linker.save_cache(stale, path)
+
+    with patch(
+        "creek.link.embeddings.EmbeddingLinker.generate_embedding",
+        autospec=True,
+        side_effect=EmbeddingLinker.generate_embedding,
+    ) as spy:
+        RetrievalSpecialist().gather("alpha", tmp_path)
+
+    embedded_texts = [call.args[1] for call in spy.call_args_list]
+    assert "Alpha" in embedded_texts  # stale entry forced a live recompute
+
+
+def test_build_link_graph_duplicate_title_is_last_wins(tmp_path: Path) -> None:
+    """Duplicate titles resolve a wikilink to the LAST fragment in corpus order.
+
+    ``_build_link_graph`` builds its ``by_title`` map last-wins, so a wikilink
+    to a shared title targets the final fragment declaring that title; ids are
+    always preferred over titles when both could match.
+    """
+    _write(tmp_path, "01-Fragments/Notes", "frag-dup-1", "Shared Title")
+    _write(tmp_path, "01-Fragments/Notes", "frag-dup-2", "Shared Title")
+    _write(
+        tmp_path,
+        "01-Fragments/Notes",
+        "frag-link",
+        "Linker",
+        body="[[Shared Title]]",
+    )
+
+    corpus = sorted(_load_corpus(tmp_path), key=lambda rec: rec[0].id)
+    graph = _build_link_graph(corpus)
+
+    # corpus order is frag-dup-1, frag-dup-2, frag-link; last-wins -> dup-2.
+    assert "frag-dup-2" in graph["frag-link"]
+    assert "frag-dup-1" not in graph["frag-link"]

--- a/creek-tools/tests/test_real_agents.py
+++ b/creek-tools/tests/test_real_agents.py
@@ -329,7 +329,15 @@ def test_retrieval_reuses_linker_across_gather_calls(
 
 
 def _seed_embeddings_cache(vault: Path, frag_ids: list[str]) -> None:
-    """Persist a real parquet cache covering *frag_ids* with fresh hashes."""
+    """Persist a real parquet cache covering *frag_ids* with fresh hashes.
+
+    These are UNIT tests, not integration: the vectors come from the autouse
+    ``mock_sentence_transformer`` fixture (deterministic mock embeddings), so
+    both this seeding step and the agent under test use the same mock model and
+    never load the real sentence-transformer. That is why the cache vector for a
+    fragment equals the vector the agent would compute live — and why no
+    ``@pytest.mark.integration`` marker is needed.
+    """
     corpus = _load_corpus(vault)
     by_id = {fragment.id: fragment for fragment, _ in corpus}
     config = _load_config(vault)
@@ -373,6 +381,23 @@ def test_retrieval_cache_hit_avoids_re_embedding(tmp_path: Path) -> None:
 
     embedded_texts = [call.args[1] for call in spy.call_args_list]
     assert embedded_texts == ["alpha"]
+
+
+def test_retrieval_loads_cache_once_across_gather_calls(tmp_path: Path) -> None:
+    """The parquet cache is read once per instance + vault, not every gather()."""
+    _write(tmp_path, "01-Fragments/Notes", "frag-a", "Alpha")
+    _seed_embeddings_cache(tmp_path, ["frag-a"])
+    specialist = RetrievalSpecialist()
+
+    with patch(
+        "creek.link.embeddings.EmbeddingLinker.load_cache",
+        autospec=True,
+        side_effect=EmbeddingLinker.load_cache,
+    ) as spy:
+        specialist.gather("alpha", tmp_path)
+        specialist.gather("beta", tmp_path)
+
+    assert spy.call_count == 1
 
 
 def test_retrieval_cache_is_pure_optimization(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_real_agents.py
+++ b/creek-tools/tests/test_real_agents.py
@@ -453,7 +453,10 @@ def test_retrieval_stale_cache_entry_is_recomputed(tmp_path: Path) -> None:
         RetrievalSpecialist().gather("alpha", tmp_path)
 
     embedded_texts = [call.args[1] for call in spy.call_args_list]
-    assert "Alpha" in embedded_texts  # stale entry forced a live recompute
+    # Exactly the query plus the one stale fragment, re-embedded live (computed
+    # via fragment_embedding_text so the assertion survives a shape change and
+    # still proves the stale cache entry was NOT served).
+    assert embedded_texts == ["alpha", fragment_embedding_text(by_id["frag-a"])]
 
 
 def test_build_link_graph_duplicate_title_is_last_wins(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #463. `RetrievalSpecialist.gather` re-loaded the sentence-transformer model and re-embedded the whole corpus on every call; both are now amortised, with results **byte-for-byte identical** to before (the cache is a pure optimisation).

- **Linker reuse (instance-level, no module global):** the `EmbeddingLinker` is held lazily on `self._linker`, so a long-lived specialist reused across `gather()` calls loads the model once — while a fresh `RetrievalSpecialist()` per test starts cold, so the conftest model mock **cannot leak across tests**. `__init__(*, linker=None)` lets a caller inject/share one.
- **Embeddings cache for fragment vectors:** `_fragment_vector` draws from `load_cache(embeddings_cache_path(vault))`, trusting a cached vector only when the id is present AND its `content_hash` equals `content_hash_for_text(fragment_embedding_text(fragment))` (the cache writer's freshness key); a miss or stale hash falls back to a live embed. The query is embedded once. Absent cache file → exactly the prior behaviour.
- **`by_title` made explicit:** `_build_link_graph` documents duplicate-title handling as **last-wins** (ids always preferred over titles for wikilink resolution), pinned by a test. **Supersedes the `by_title` item of #487.**

## Test plan
`cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (4997 tests). New tests in `tests/test_real_agents.py`:
- Model loaded **once** across two `gather()` calls on one instance.
- A warm parquet cache → **zero per-fragment embeds** (only the query embedded).
- **Cold-vs-warm bundle parity** (cache changes nothing observable).
- A deliberately-wrong `content_hash` forces a **live recompute** (freshness validation).
- Graceful degradation (`EmbeddingModelUnavailableError` → empty bundle) preserved.
- `by_title` last-wins edge.

Closes #486
Refs #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)