### PR TITLE
feat(author): wire voice register selection into the Voice agent (#502)

### DIFF
--- a/creek-tools/creek/author/agents.py
+++ b/creek-tools/creek/author/agents.py
@@ -35,7 +35,7 @@ from creek.link.embeddings import (
     embeddings_cache_path,
     fragment_embedding_text,
 )
-from creek.models import Dosage, Frequency, Mode, Phase
+from creek.models import Dosage, Frequency, Mode, Phase, VoiceRegister
 from creek.vault.reader import iter_vault_fragments
 
 if TYPE_CHECKING:
@@ -369,7 +369,7 @@ class GraphSpecialist:
 
 def _aggregate_dimension(
     picks: list[_DimT],
-    unclassified: _DimT,
+    unclassified: _DimT | None,
 ) -> tuple[WeightedDimension[_DimT], ...]:
     """Aggregate per-fragment canonical *picks* into weighted dimensions.
 
@@ -381,7 +381,9 @@ def _aggregate_dimension(
     Args:
         picks: One canonical enum pick per fragment (may include the
             ``unclassified`` sentinel, which is dropped).
-        unclassified: The dimension's ``UNCLASSIFIED`` sentinel.
+        unclassified: The dimension's ``UNCLASSIFIED`` sentinel, or ``None``
+            for dimensions whose enum has no such member (the caller has
+            already dropped the absent picks; nothing further is filtered).
 
     Returns:
         A weight-descending tuple of :class:`WeightedDimension` entries.
@@ -398,18 +400,42 @@ def _aggregate_dimension(
     return tuple(entries)
 
 
+def _aggregate_optional(
+    picks: list[_DimT | None],
+) -> tuple[WeightedDimension[_DimT], ...]:
+    """Aggregate per-fragment *picks* whose unclassified sentinel is ``None``.
+
+    Sibling of :func:`_aggregate_dimension` for dimensions (e.g. voice register)
+    whose enum has no ``UNCLASSIFIED`` member and signals an absent
+    classification with ``None``. ``None`` picks are dropped, then the present
+    values are aggregated with a ``None`` sentinel (which matches nothing
+    real), so the weighting/sorting stay identical to the other axes.
+
+    Args:
+        picks: One canonical enum pick per fragment, or ``None`` when the
+            fragment carried no classification for this dimension.
+
+    Returns:
+        A weight-descending tuple of :class:`WeightedDimension` entries.
+    """
+    present = [pick for pick in picks if pick is not None]
+    return _aggregate_dimension(present, None)
+
+
 class _FragmentSignal:
     """The canonical ontology signal a single corpus fragment carries."""
 
-    __slots__ = ("dosage", "frequency", "mode", "phase")
+    __slots__ = ("dosage", "frequency", "mode", "phase", "voice_register")
 
     def __init__(self, fragment: Fragment, body: str) -> None:
         """Classify *fragment* deterministically, keeping any frontmatter dosage.
 
-        The rule classifier supplies frequency, phase, and mode from
-        ``title + body`` keyword signal; the rule classifier does not detect
-        dosage, so dosage is read from the fragment's existing frontmatter
-        (``wavelength.dosage``) instead.
+        The rule classifier supplies frequency, phase, mode, and voice
+        register from ``title + body`` keyword signal; the rule classifier
+        does not detect dosage, so dosage is read from the fragment's existing
+        frontmatter (``wavelength.dosage``) instead. ``voice_register`` is
+        ``None`` when no register keyword fired (the enum has no
+        ``UNCLASSIFIED`` member).
 
         Args:
             fragment: The corpus fragment to scan.
@@ -422,6 +448,13 @@ class _FragmentSignal:
         self.phase: Phase = Phase(classified.wavelength.phase)
         self.mode: Mode = Mode(classified.wavelength.mode)
         self.dosage: Dosage = Dosage(fragment.wavelength.dosage)
+        register = classified.voice.voice_register
+        # ``use_enum_values=True`` on ``VoiceClassification`` surfaces the
+        # register as its plain ``str`` value (or ``None``); rewrap it into the
+        # canonical enum so aggregation sorts on ``.value`` like the other axes.
+        self.voice_register: VoiceRegister | None = (
+            VoiceRegister(register) if register is not None else None
+        )
 
 
 def _detect_dosage_paradoxes(
@@ -529,14 +562,54 @@ def _ontology_claim(
     return EvidenceClaim(claim=summary, source_fragments=fragment_ids.copy())
 
 
+def _build_analysis(
+    signals: list[tuple[str, _FragmentSignal]],
+) -> OntologyAnalysis:
+    """Aggregate classified *signals* into a canonical :class:`OntologyAnalysis`.
+
+    Each axis is aggregated independently: frequency / phase / mode / dosage
+    drop their ``UNCLASSIFIED`` sentinel, while voice register (no such
+    sentinel) drops the ``None`` picks via :func:`_aggregate_optional`. Dosage
+    and phase contradictions are surfaced — never resolved.
+
+    Args:
+        signals: ``(fragment_id, signal)`` pairs for the classified corpus.
+
+    Returns:
+        The aggregated analysis with full confidence when any signal is present.
+    """
+    return OntologyAnalysis(
+        frequencies=_aggregate_dimension(
+            [sig.frequency for _id, sig in signals], Frequency.UNCLASSIFIED
+        ),
+        phases=_aggregate_dimension(
+            [sig.phase for _id, sig in signals], Phase.UNCLASSIFIED
+        ),
+        modes=_aggregate_dimension(
+            [sig.mode for _id, sig in signals], Mode.UNCLASSIFIED
+        ),
+        dosages=_aggregate_dimension(
+            [sig.dosage for _id, sig in signals], Dosage.UNCLASSIFIED
+        ),
+        voice_registers=_aggregate_optional(
+            [sig.voice_register for _id, sig in signals]
+        ),
+        paradoxes=tuple(
+            _detect_dosage_paradoxes(signals) + _detect_phase_paradoxes(signals)
+        ),
+        overall_confidence=1.0 if signals else 0.0,
+    )
+
+
 class OntologySpecialist:
     """Ontology specialist — deterministic APTITUDE analytics over the corpus.
 
     Classifies every corpus fragment with the deterministic
     :class:`~creek.classify.rules.RuleClassifier` (no LLM, no embeddings),
-    aggregates canonical frequencies / phases / modes / dosages into weighted
-    dimensions, and surfaces — never resolves — the dosage and phase
-    contradictions it finds (Ontology §10.2; INC-019 canonical taxonomy only).
+    aggregates canonical frequencies / phases / modes / dosages / voice
+    registers into weighted dimensions, and surfaces — never resolves — the
+    dosage and phase contradictions it finds (Ontology §10.2; INC-019 canonical
+    taxonomy only).
     """
 
     name = "ontology"
@@ -562,24 +635,7 @@ class OntologySpecialist:
         signals = [
             (fragment.id, _FragmentSignal(fragment, body)) for fragment, body in corpus
         ]
-        analysis = OntologyAnalysis(
-            frequencies=_aggregate_dimension(
-                [sig.frequency for _id, sig in signals], Frequency.UNCLASSIFIED
-            ),
-            phases=_aggregate_dimension(
-                [sig.phase for _id, sig in signals], Phase.UNCLASSIFIED
-            ),
-            modes=_aggregate_dimension(
-                [sig.mode for _id, sig in signals], Mode.UNCLASSIFIED
-            ),
-            dosages=_aggregate_dimension(
-                [sig.dosage for _id, sig in signals], Dosage.UNCLASSIFIED
-            ),
-            paradoxes=tuple(
-                _detect_dosage_paradoxes(signals) + _detect_phase_paradoxes(signals)
-            ),
-            overall_confidence=1.0 if signals else 0.0,
-        )
+        analysis = _build_analysis(signals)
         fragment_ids = [fid for fid, _sig in signals]
         return EvidenceBundle(
             claims=[_ontology_claim(analysis, fragment_ids)],

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from creek.classify.weighted import WeightedDimension
 from creek.compile.provenance import ProvenanceEntry
-from creek.models import Dosage, Frequency, Mode, Phase
+from creek.models import Dosage, Frequency, Mode, Phase, VoiceRegister
 
 #: Mediums the author desk can produce. ``research``/``chat``/``essay``/
 #: ``research-piece``/``book-report``/``how-to`` are all wired — ``how-to``
@@ -144,6 +144,8 @@ class OntologyAnalysis(BaseModel):
         phases: Weighted Archetypal Wavelength phases.
         modes: Weighted engagement modes.
         dosages: Weighted dosage framings (medicine/toxic/ambiguous).
+        voice_registers: Weighted voice registers the corpus speaks in
+            (confessional/analytical/playful/…).
         paradoxes: Surfaced contradictions across fragments.
         overall_confidence: Aggregate confidence in ``[0.0, 1.0]``.
     """
@@ -154,6 +156,7 @@ class OntologyAnalysis(BaseModel):
     phases: tuple[WeightedDimension[Phase], ...] = ()
     modes: tuple[WeightedDimension[Mode], ...] = ()
     dosages: tuple[WeightedDimension[Dosage], ...] = ()
+    voice_registers: tuple[WeightedDimension[VoiceRegister], ...] = ()
     paradoxes: tuple[OntologyParadox, ...] = ()
     overall_confidence: float = 0.0
 

--- a/creek-tools/creek/author/voice.py
+++ b/creek-tools/creek/author/voice.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 from creek.author.skills import (
     find_phase_skill,
+    find_register_skill,
     find_voice_core,
     read_skill,
 )
@@ -158,16 +159,16 @@ def _split_voice_prompt(
 
 
 def _skill_sections(vault: Path, evidence: EvidenceBundle) -> list[str]:
-    """Return the voice-core and phase skill sections, in order.
+    """Return the voice-core, phase, and register skill sections, in order.
 
     Missing skill files are skipped silently. The phase is taken from the
-    synthesized ontology's dominant phase when present. Register selection is
-    deferred — the synthesized ontology carries no dominant voice register yet
-    (tracked as #502; the ``find_register_skill`` seam is ready for it).
+    synthesized ontology's dominant phase, and the register from its dominant
+    voice register, when present (#502).
     """
     paths = [
         find_voice_core(vault),
         find_phase_skill(vault, _dominant_phase(evidence)),
+        find_register_skill(vault, _dominant_register(evidence)),
     ]
     sections: list[str] = []
     for path in paths:
@@ -185,6 +186,14 @@ def _dominant_phase(evidence: EvidenceBundle) -> str | None:
     if ontology is None or not ontology.phases:
         return None
     return ontology.phases[0].value.value
+
+
+def _dominant_register(evidence: EvidenceBundle) -> str | None:
+    """Return the dominant voice-register slug from the ontology, if any."""
+    ontology = evidence.ontology
+    if ontology is None or not ontology.voice_registers:
+        return None
+    return ontology.voice_registers[0].value.value
 
 
 def _evidence_section(evidence: EvidenceBundle) -> str:

--- a/creek-tools/tests/test_real_agents.py
+++ b/creek-tools/tests/test_real_agents.py
@@ -31,7 +31,7 @@ from creek.link.embeddings import (
     embeddings_cache_path,
     fragment_embedding_text,
 )
-from creek.models import Frequency, Phase
+from creek.models import Frequency, Phase, VoiceRegister
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -216,6 +216,25 @@ _F6_BODY = "community empathy harmony inclusion caring sharing equality consensu
 _F3_BODY = "power dominance control conquest force aggression warrior rebellion"
 _RISING_BODY = "emerging building growing momentum ascending intensifying gathering"
 _DIMINISHING_BODY = "diminishing declining waning subsiding settling calming quieting"
+# Dense with analytical voice-register signals (VOICE_REGISTER_SIGNALS) so the
+# rule classifier resolves the fragment's register to ANALYTICAL deterministically.
+_ANALYTICAL_BODY = (
+    "analyze examine consider therefore evidence hypothesis framework "
+    "systematically data observe"
+)
+
+
+def test_ontology_surfaces_dominant_voice_register(tmp_path: Path) -> None:
+    """The Ontology agent aggregates a weighted, non-empty voice register."""
+    _write_classified(
+        tmp_path, "frag-an", "Analytical examination", body=_ANALYTICAL_BODY
+    )
+
+    bundle = OntologySpecialist().gather("analysis", tmp_path)
+
+    assert bundle.ontology is not None
+    assert bundle.ontology.voice_registers  # a register was surfaced
+    assert bundle.ontology.voice_registers[0].value is VoiceRegister.ANALYTICAL
 
 
 def test_ontology_returns_canonical_taxonomy(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_synthesis_voice.py
+++ b/creek-tools/tests/test_synthesis_voice.py
@@ -43,6 +43,32 @@ def _seed_voice_core(vault: Path, sentinel: str) -> None:
     (core / "SKILL.md").write_text(sentinel, encoding="utf-8")
 
 
+def _seed_register_skill(vault: Path, register: str, sentinel: str) -> None:
+    """Seed ``creek-skills/registers/<register>.SKILL.md`` with a sentinel."""
+    registers = vault / "creek-skills" / "registers"
+    registers.mkdir(parents=True, exist_ok=True)
+    (registers / f"{register}.SKILL.md").write_text(sentinel, encoding="utf-8")
+
+
+# Dense with analytical voice-register signals (VOICE_REGISTER_SIGNALS) so the
+# real Ontology specialist resolves a dominant ``analytical`` register.
+_ANALYTICAL_BODY = (
+    "analyze examine consider therefore evidence hypothesis framework "
+    "systematically data observe"
+)
+
+
+def _seed_classified_fragment(vault: Path, frag_id: str, title: str, body: str) -> None:
+    """Write a fragment whose body carries dense rule-classifier signal."""
+    folder = vault / "01-Fragments" / "Notes"
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / f"{frag_id}.md").write_text(
+        f'---\ntype: fragment\nid: {frag_id}\ntitle: "{title}"\n'
+        f"source:\n  platform: journal\n  author: self\n---\n{body}\n",
+        encoding="utf-8",
+    )
+
+
 def _mock_client(text: str) -> tuple[AuthorLLMClient, MagicMock]:
     """Return a client over a mock provider returning *text*, and the provider."""
     from creek.classify.llm.providers import AnthropicCompletion
@@ -139,6 +165,45 @@ def test_voice_prompt_includes_voice_core_sentinel(tmp_path: Path) -> None:
     # The static voice-skill prefix is the cached ``system`` block now.
     assert sentinel in provider.call_with_metadata.call_args.kwargs["system"]
     assert sentinel in _sent_prompt(provider)
+
+
+def test_voice_prompt_includes_register_skill_sentinel(tmp_path: Path) -> None:
+    """The register SKILL.md selected from the ontology reaches the voice prompt."""
+    from creek.author.agents import OntologySpecialist
+
+    sentinel = "ANALYTICAL-REGISTER-SENTINEL-XYZ"
+    _seed_classified_fragment(
+        tmp_path, "frag-an", "Analytical examination", _ANALYTICAL_BODY
+    )
+    _seed_register_skill(tmp_path, "analytical", sentinel)
+    evidence = OntologySpecialist().gather("analysis", tmp_path)
+    # Precondition: the ontology surfaced the analytical register the skill keys on.
+    assert evidence.ontology is not None
+    assert evidence.ontology.voice_registers[0].value.value == "analytical"
+    client, provider = _mock_client("voiced output")
+
+    VoiceAgent(llm_client=client).render(
+        "analysis", evidence, tmp_path, medium="research"
+    )
+
+    assert sentinel in provider.call_with_metadata.call_args.kwargs["system"]
+    assert sentinel in _sent_prompt(provider)
+
+
+def test_voice_prompt_without_register_skips_register_skill(tmp_path: Path) -> None:
+    """Evidence with no ontology resolves no register and still builds a prompt."""
+    _seed_register_skill(tmp_path, "analytical", "UNWANTED-REGISTER-SENTINEL")
+    client, provider = _mock_client("voiced output")
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a grounded claim", source_fragments=["f1"])]
+    )
+
+    body = VoiceAgent(llm_client=client).render(
+        "q", evidence, tmp_path, medium="research"
+    )
+
+    assert body == "voiced output"
+    assert "UNWANTED-REGISTER-SENTINEL" not in _sent_prompt(provider)
 
 
 def test_voice_prompt_honours_contract_structure(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to #471. The Voice agent loaded voice-core + phase skills but never a register skill — `find_register_skill` was dormant because no register signal existed in the desk's evidence. This surfaces a dominant voice register from the synthesized ontology and feeds the existing seam, **mirroring the phase path exactly**.

- **`OntologyAnalysis`** gains a `voice_registers` axis (weighted `VoiceRegister` tuple) alongside frequencies/phases/modes/dosages (defaults to `()`, so existing constructions are unaffected).
- **`_FragmentSignal`** captures the rule classifier's `voice.voice_register`; **`OntologySpecialist`** aggregates the non-`None` registers. `VoiceRegister` has no `UNCLASSIFIED` member, so a new `_aggregate_optional` drops `None` picks (the `_aggregate_dimension` sentinel was widened to `_DimT | None`); `gather`'s body was extracted to `_build_analysis` to stay under the complexity bound.
- **`VoiceAgent._dominant_register`** reads `ontology.voice_registers[0]` (mirroring `_dominant_phase`) and `_skill_sections` passes it to `find_register_skill(vault, <slug>)`, inlining `registers/<slug>.SKILL.md` into the cached static prompt block. No register → seam returns `None` → no register skill (graceful).

## Test plan
`cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (5001 tests). New tests:
- The ontology surfaces the expected dominant `VoiceRegister` from classifier keywords.
- A seeded `creek-skills/registers/<r>.SKILL.md` sentinel reaches the cached `system` block of the voice prompt **end-to-end** — built via real `OntologySpecialist().gather` output (not a hand-built bundle), proving the full ontology→`_dominant_register`→`find_register_skill`→prompt wiring.
- A register-less run skips the register skill without crashing and doesn't leak the sentinel.

No existing tests modified.

Closes #502
Refs #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)