### PR TITLE
feat(author): wire voice-fidelity into the reflection node (#506)

### DIFF
--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from creek.author.client import AuthorLLMClient
+    from creek.config import AIStyleConfig
+    from creek.generate.ai_style.model import VoiceFingerprint
     from creek.models import MediumContract
 
 logger = logging.getLogger(__name__)
@@ -86,6 +88,8 @@ class Reflector(Protocol):
         *,
         contract: MediumContract | None = None,
         vault: Path | None = None,
+        fingerprint: VoiceFingerprint | None = None,
+        ai_style_config: AIStyleConfig | None = None,
     ) -> ReflectionResult:
         """Return a structured result for *body* given *evidence* and *rubric*."""
         ...
@@ -241,6 +245,44 @@ class Conductor:
                 )
         return kept
 
+    @staticmethod
+    def _load_voice_inputs(
+        vault: Path,
+    ) -> tuple[AIStyleConfig | None, VoiceFingerprint | None]:
+        """Load the owner's AI-style config and persisted voice fingerprint.
+
+        Threads the voice-fidelity inputs the reflection node needs (#506).
+        Loads the vault's :class:`~creek.config.CreekConfig`, takes its
+        ``ai_style`` block, and loads the persisted fingerprint from
+        ``config.ai_style.fingerprint_path``. An EMPTY fingerprint (one that was
+        never built — ``fragment_count == 0``) is returned as ``None`` so the
+        voice check stays dormant on a vault with no built fingerprint, leaving
+        behaviour identical to before the check was wired. Loading is
+        best-effort: any error (a thin/offline/malformed vault) degrades to
+        ``(None, None)`` so the desk never crashes.
+
+        Args:
+            vault: The vault to load voice inputs from.
+
+        Returns:
+            ``(ai_style_config, fingerprint)``. The fingerprint is ``None`` when
+            absent/empty; both are ``None`` when config loading failed.
+        """
+        from creek.config import load_config, resolve_config_path
+        from creek.generate.ai_style import load_fingerprint
+
+        try:
+            config = load_config(
+                resolve_config_path(vault, None), warn_on_missing=False
+            )
+        except (OSError, ValueError):
+            return (None, None)
+        ai_style = config.ai_style
+        fingerprint = load_fingerprint(vault, ai_style)
+        if fingerprint.fragment_count == 0:
+            return (ai_style, None)
+        return (ai_style, fingerprint)
+
     def run(self, *, medium: str, query: str, vault: Path) -> AuthoredDraft:
         """Run the full author pipeline and return a shaped draft.
 
@@ -260,6 +302,11 @@ class Conductor:
         validated = require_supported_medium(medium)
         evidence = self.gather_evidence(query, vault)
         rubric = self.contract.reflection_rubric if self.contract else None
+        # Voice-fidelity is wired from the owner's persisted fingerprint (#506):
+        # loaded once before the loop. When no fingerprint has been built the
+        # fingerprint is ``None``, so the reflection node's voice check stays
+        # dormant — behaviour identical to a vault with no fingerprint.
+        ai_style_config, fingerprint = self._load_voice_inputs(vault)
 
         body = ""
         verdict: ReflectionVerdict = "ESCALATE"
@@ -270,12 +317,14 @@ class Conductor:
             body = self.voice.render(
                 query, evidence, vault, medium=validated, contract=self.contract
             )
-            # voice_fidelity is implemented in the reflection node but stays
-            # dormant here: the owner's fingerprint + AIStyleConfig are not yet
-            # threaded into the desk. Wiring them (and an e2e voice test) is
-            # tracked as #506.
             result = self.reflection.review(
-                body, evidence, rubric, contract=self.contract, vault=vault
+                body,
+                evidence,
+                rubric,
+                contract=self.contract,
+                vault=vault,
+                fingerprint=fingerprint,
+                ai_style_config=ai_style_config,
             )
             verdict = result.decision
             findings = result.findings

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -268,6 +268,8 @@ class Conductor:
             ``(ai_style_config, fingerprint)``. The fingerprint is ``None`` when
             absent/empty; both are ``None`` when config loading failed.
         """
+        from pydantic import ValidationError
+
         from creek.config import load_config, resolve_config_path
         from creek.generate.ai_style import load_fingerprint
 
@@ -275,7 +277,10 @@ class Conductor:
             config = load_config(
                 resolve_config_path(vault, None), warn_on_missing=False
             )
-        except (OSError, ValueError):
+        except (OSError, ValueError, ValidationError):
+            # A malformed config must not crash the desk: voice-fidelity simply
+            # stays dormant. ``ValidationError`` is not a ``ValueError`` subclass
+            # in Pydantic v2, so it is named explicitly (#506 review).
             return (None, None)
         ai_style = config.ai_style
         fingerprint = load_fingerprint(vault, ai_style)

--- a/creek-tools/tests/test_voice_fidelity_wiring.py
+++ b/creek-tools/tests/test_voice_fidelity_wiring.py
@@ -28,6 +28,8 @@ from creek.generate.ai_style import (
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
     from creek.author.models import EvidenceBundle, Medium
     from creek.models import MediumContract
 
@@ -170,3 +172,28 @@ def test_load_voice_inputs_returns_none_fingerprint_when_absent(tmp_path: Path) 
 
     assert isinstance(config, AIStyleConfig)
     assert fingerprint is None
+
+
+def test_load_voice_inputs_degrades_on_malformed_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A config that fails Pydantic validation degrades to ``(None, None)``.
+
+    `ValidationError` is not a `ValueError` subclass in Pydantic v2, so the desk
+    must name it explicitly; otherwise a malformed `creek_config.yaml` would
+    crash the conductor (#506 review).
+    """
+    config_path = tmp_path / "00-Creek-Meta" / "creek_config.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    # ``max_author_rounds`` is bound [1, 10]; 99 fails validation.
+    config_path.write_text("author:\n  max_author_rounds: 99\n", encoding="utf-8")
+    # Pin the config path so a leaked CREEK_CONFIG can't shadow this fixture.
+    monkeypatch.setenv("CREEK_CONFIG", str(config_path))
+    conductor = Conductor(
+        specialists=[],
+        voice=VoiceAgent(),
+        reflection=ReflectionNode(),
+        max_rounds=1,
+    )
+
+    assert conductor._load_voice_inputs(tmp_path) == (None, None)

--- a/creek-tools/tests/test_voice_fidelity_wiring.py
+++ b/creek-tools/tests/test_voice_fidelity_wiring.py
@@ -1,0 +1,172 @@
+"""Voice-fidelity is wired through the conductor's primary path (#506).
+
+The reflection node's ``check_voice_fidelity`` was implemented and unit-tested
+under #471/#473 but stayed *dormant* in :meth:`Conductor.run`: the review call
+never received the owner's persisted ``VoiceFingerprint`` or the
+``AIStyleConfig``, so the check always short-circuited. These tests pin the
+wiring: ``run`` loads the owner's fingerprint + config once, threads them into
+``reflection.review``, and surfaces ``voice_fidelity`` findings on the draft —
+while degrading gracefully (and identically to before) when no fingerprint has
+been built.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.author.agents import default_specialists
+from creek.author.conductor import Conductor
+from creek.author.reflection import ReflectionNode
+from creek.author.voice import VoiceAgent
+from creek.config import AIStyleConfig
+from creek.generate.ai_style import (
+    FeatureStat,
+    VoiceFingerprint,
+    save_fingerprint,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from creek.author.models import EvidenceBundle, Medium
+    from creek.models import MediumContract
+
+
+def _seed_fragment(vault: Path, frag_id: str, title: str) -> None:
+    """Write a minimal self-authored fragment so the specialists have a corpus."""
+    folder = vault / "01-Fragments" / "Notes"
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / f"{frag_id}.md").write_text(
+        f'---\ntype: fragment\nid: {frag_id}\ntitle: "{title}"\n'
+        f"source:\n  platform: journal\n  author: self\n---\nbody\n",
+        encoding="utf-8",
+    )
+
+
+def _persist_fingerprint(vault: Path, fragment_count: int = 5) -> VoiceFingerprint:
+    """Persist a non-empty voice fingerprint under *vault* and return it.
+
+    The fingerprint carries an em-dash feature stat so it is a genuine,
+    non-empty fingerprint (``fragment_count`` >= 1) that ``check_voice_fidelity``
+    will measure against rather than skip.
+
+    Args:
+        vault: The vault root to persist under.
+        fragment_count: How many fragments the fingerprint claims to rest on.
+
+    Returns:
+        The persisted fingerprint.
+    """
+    fingerprint = VoiceFingerprint(
+        features={"em_dash_rate": FeatureStat(rate=4.0, support=fragment_count)},
+        fragment_count=fragment_count,
+    )
+    save_fingerprint(fingerprint, vault, AIStyleConfig())
+    return fingerprint
+
+
+class _FixedVoice:
+    """A voice renderer that always returns a chosen body (test double)."""
+
+    last_usage: dict[str, int] | None = None
+
+    def __init__(self, body: str) -> None:
+        """Store the body every :meth:`render` will return.
+
+        Args:
+            body: The draft body to emit on each render.
+        """
+        self._body = body
+
+    def render(
+        self,
+        query: str,
+        evidence: EvidenceBundle,
+        vault: Path | None = None,
+        *,
+        medium: Medium | None = None,
+        contract: MediumContract | None = None,
+    ) -> str:
+        """Return the fixed body, ignoring the query and evidence."""
+        del query, evidence, vault, medium, contract
+        return self._body
+
+
+def test_run_surfaces_voice_fidelity_finding_via_real_scanner(tmp_path: Path) -> None:
+    """A divergent body fires a real ``voice_fidelity`` finding through ``run``.
+
+    The draft carries an unfilled ``2025-xx-xx`` placeholder date — the
+    ``placeholder_date`` mechanical tell has a fixed-0 margin and fires on any
+    occurrence regardless of fingerprint, so the *real* scanner (not a mock)
+    produces the divergence. This proves ``review`` received a non-None
+    fingerprint + config and the finding reached the draft.
+    """
+    _seed_fragment(tmp_path, "frag-a", "Alpha note about q")
+    _persist_fingerprint(tmp_path)
+    # The deterministic VoiceAgent path would never emit a placeholder date, so
+    # a fixed voice double supplies the divergent body the scanner flags.
+    divergent = "A claim about q, citing source 2025-xx-xx for the figure."
+    conductor = Conductor(
+        specialists=default_specialists(),
+        voice=_FixedVoice(divergent),
+        reflection=ReflectionNode(),
+        max_rounds=1,
+    )
+
+    draft = conductor.run(medium="research", query="q", vault=tmp_path)
+
+    assert any(f.dimension == "voice_fidelity" for f in draft.findings)
+
+
+def test_run_dormant_without_built_fingerprint(tmp_path: Path) -> None:
+    """No persisted fingerprint → no ``voice_fidelity`` finding and no crash.
+
+    Behaviour is identical to before #506: the empty-fingerprint path returns
+    ``None``, so ``check_voice_fidelity`` skips entirely.
+    """
+    _seed_fragment(tmp_path, "frag-a", "Alpha note about q")
+    # Same divergent body — but with NO fingerprint persisted the voice check
+    # must stay dormant.
+    divergent = "A claim about q, citing source 2025-xx-xx for the figure."
+    conductor = Conductor(
+        specialists=default_specialists(),
+        voice=_FixedVoice(divergent),
+        reflection=ReflectionNode(),
+        max_rounds=1,
+    )
+
+    draft = conductor.run(medium="research", query="q", vault=tmp_path)
+
+    assert all(f.dimension != "voice_fidelity" for f in draft.findings)
+
+
+def test_load_voice_inputs_returns_fingerprint_when_persisted(tmp_path: Path) -> None:
+    """``_load_voice_inputs`` returns ``(config, fingerprint)`` for a real one."""
+    persisted = _persist_fingerprint(tmp_path, fragment_count=3)
+    conductor = Conductor(
+        specialists=[],
+        voice=VoiceAgent(),
+        reflection=ReflectionNode(),
+        max_rounds=1,
+    )
+
+    config, fingerprint = conductor._load_voice_inputs(tmp_path)
+
+    assert isinstance(config, AIStyleConfig)
+    assert fingerprint is not None
+    assert fingerprint.fragment_count == persisted.fragment_count
+
+
+def test_load_voice_inputs_returns_none_fingerprint_when_absent(tmp_path: Path) -> None:
+    """``_load_voice_inputs`` returns ``(config, None)`` when no fingerprint exists."""
+    conductor = Conductor(
+        specialists=[],
+        voice=VoiceAgent(),
+        reflection=ReflectionNode(),
+        max_rounds=1,
+    )
+
+    config, fingerprint = conductor._load_voice_inputs(tmp_path)
+
+    assert isinstance(config, AIStyleConfig)
+    assert fingerprint is None


### PR DESCRIPTION
## Summary

Follow-up to #471/#473 — the **last** writing-desk follow-up. The reflection node's `check_voice_fidelity` was implemented + unit-tested but **dormant**: the Conductor never passed `fingerprint=`/`ai_style_config=` into `review`, so the check always skipped.

- **New `Conductor._load_voice_inputs(vault)`** loads the vault's `AIStyleConfig` (`config.ai_style`) and the owner's persisted `VoiceFingerprint` (`load_fingerprint`, reading `00-Creek-Meta/voice-fingerprint.json`). Config loading is **best-effort** (any error → `(None, None)`, so the desk never crashes on a thin/offline vault), and an **empty fingerprint** (`fragment_count == 0`, none built) is returned as `None` so voice-fidelity stays **dormant exactly as before** on a vault without a built fingerprint.
- **`run()`** computes the voice inputs once before the voice/reflect loop and threads them into every `reflection.review(...)` call. Behaviour is unchanged when no fingerprint exists; otherwise the check now fires.

## Test plan
`cd creek-tools && ./scripts/check-all.sh` → **12/12 green**. New `tests/test_voice_fidelity_wiring.py`:
- **End-to-end (DoD):** a run with a **real persisted fingerprint + the real AI-style scanner** surfaces a `voice_fidelity` finding on `draft.findings` — proving `review` now receives a non-`None` fingerprint+config and the check fires through `run()`.
- **Dormant when unbuilt:** a vault with no `voice-fingerprint.json` produces no voice-fidelity finding and doesn't crash.
- **`_load_voice_inputs`** returns the fingerprint only when a non-empty one is persisted.

No existing tests modified.

Closes #506
Refs #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)