### PR TITLE
fix(voice): flag ungrounded first-person biographical claims in drafts (#515)

### DIFF
--- a/creek-tools/creek/author/checks.py
+++ b/creek-tools/creek/author/checks.py
@@ -22,6 +22,7 @@ import yaml
 
 from creek.author.models import ReflectionFinding
 from creek.generate.ai_style.scanner import scan
+from creek.generate.grounding import scan_biographical_sentences
 
 # Reuse the canonical INC-019 alias vocabulary (public constants) rather than
 # duplicating it, so the ontological-accuracy check and the model validators
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
     from creek.author.models import EvidenceBundle
     from creek.config import AIStyleConfig
     from creek.generate.ai_style.model import VoiceFingerprint
+    from creek.generate.grounding import EmbeddingFn
     from creek.models import MediumContract
 
 #: Privacy tiers from least to most restrictive; index = restrictiveness rank.
@@ -81,6 +83,67 @@ def check_citation_completeness(evidence: EvidenceBundle) -> list[ReflectionFind
         )
         for claim in evidence.claims
         if not claim.source_fragments
+    ]
+
+
+def check_biographical_grounding(
+    body: str,
+    evidence: EvidenceBundle,
+    *,
+    embedding_fn: EmbeddingFn | None,
+    grounding_lower: float,
+    voice_core: str | None = None,
+) -> list[ReflectionFinding]:
+    """Flag invented first-person biographical claims in the body (HARD).
+
+    A research/desk draft must not assert a biographical fact about the owner
+    (an event, an upbringing, a past state) that no source supports — e.g.
+    amplifying a brief's "the LDS Christ I was handed" into a childhood the
+    corpus never mentions (issue #515). Each grounded claim's text plus the
+    optional voice-core brief form the source corpus; a first-person
+    biographical sentence whose cosine similarity falls below *grounding_lower*
+    against all of them is fabrication.
+
+    The check is dormant — and returns no findings — when *embedding_fn* is
+    ``None``, mirroring how :func:`check_voice_fidelity` stays dormant without
+    a fingerprint. This keeps the deterministic reflection node free of the
+    sentence-transformer import unless a caller wires the embedder in.
+
+    Args:
+        body: The drafted prose under review.
+        evidence: The evidence the draft was rendered from; each claim's text
+            is a legitimate grounding source.
+        embedding_fn: Embedding callable, or ``None`` to skip the check.
+        grounding_lower: Cosine floor a biographical sentence must clear
+            against some source to count as grounded.
+        voice_core: The voice-core brief text, treated as tone guidance the
+            claim may also trace to, or ``None``.
+
+    Returns:
+        One ``HIGH`` ``biographical_grounding`` finding per ungrounded
+        biographical sentence.
+    """
+    if embedding_fn is None:
+        return []
+    source_texts = [claim.claim for claim in evidence.claims]
+    if voice_core:
+        source_texts.append(voice_core)
+    return [
+        ReflectionFinding(
+            dimension="biographical_grounding",
+            severity="HIGH",
+            message=(
+                "First-person biographical claim is not grounded in any "
+                f"source (similarity {finding.max_similarity:.2f} < "
+                f"{grounding_lower:.2f}): {finding.sentence!r}."
+            ),
+        )
+        for finding in scan_biographical_sentences(
+            body,
+            source_texts=source_texts,
+            embedding_fn=embedding_fn,
+            threshold=grounding_lower,
+        )
     ]
 
 

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -27,8 +27,10 @@ ReflectionVerdict = Literal["PASS", "REVISE", "ESCALATE"]
 #: breach (citation/privacy), ``MID`` a softer rubric divergence, ``LOW`` a hint.
 FindingSeverity = Literal["LOW", "MID", "HIGH"]
 
-#: The six research-rubric dimensions a reflection finding can fire on (#473).
+#: The research-rubric dimensions a reflection finding can fire on (#473).
 #: Typed so strict mypy catches a mistyped dimension at the construction site.
+#: ``biographical_grounding`` (#515) is the seventh: a HARD gate flagging a
+#: first-person biographical claim that no source supports.
 FindingDimension = Literal[
     "voice_fidelity",
     "ontological_accuracy",
@@ -36,6 +38,7 @@ FindingDimension = Literal[
     "privacy_compliance",
     "paradox_preservation",
     "attribution_correctness",
+    "biographical_grounding",
 ]
 
 

--- a/creek-tools/creek/author/reflection.py
+++ b/creek-tools/creek/author/reflection.py
@@ -1,7 +1,7 @@
 """The Reflection node for the Creek Writing Desk (FEAT-041, #473).
 
 A *deterministic* judge — no LLM, so the mutation tests can assert exact
-verdicts — scores a drafted body against the six research-rubric dimensions and
+verdicts — scores a drafted body against the research-rubric dimensions and
 returns a structured :class:`~creek.author.models.ReflectionResult`
 (``PASS | REVISE | ESCALATE`` plus findings). Citation completeness and privacy
 compliance are HARD gates for research. The conductor (#473) owns the retry loop
@@ -27,6 +27,7 @@ from creek.author.models import (
     ReflectionResult,
     ReflectionVerdict,
 )
+from creek.config import DraftConfig
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -37,14 +38,17 @@ if TYPE_CHECKING:
     from creek.models import MediumContract
 
 #: Default cosine floor a first-person biographical sentence must clear to count
-#: as grounded when no explicit threshold is wired in (issue #515). Mirrors the
-#: ``DraftConfig.grounding_lower`` default so the desk and draft paths agree on
-#: what "grounded enough" means for a single sentence.
-_DEFAULT_BIOGRAPHICAL_GROUNDING_LOWER = 0.30
+#: as grounded when no explicit threshold is wired in (issue #515). Derived from
+#: the ``DraftConfig.grounding_lower`` field default — the single source of truth
+#: — so the desk and draft paths can never drift on what "grounded enough" means
+#: for a single sentence.
+_DEFAULT_BIOGRAPHICAL_GROUNDING_LOWER: float = DraftConfig.model_fields[
+    "grounding_lower"
+].default
 
 
 class ReflectionNode:
-    """A deterministic judge that scores a draft against the six dimensions."""
+    """A deterministic judge scoring a draft against the research rubric dimensions."""
 
     def review(
         self,

--- a/creek-tools/creek/author/reflection.py
+++ b/creek-tools/creek/author/reflection.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 from creek.author.checks import (
     check_attribution_correctness,
+    check_biographical_grounding,
     check_citation_completeness,
     check_ontological_accuracy,
     check_paradox_preservation,
@@ -32,7 +33,14 @@ if TYPE_CHECKING:
 
     from creek.config import AIStyleConfig
     from creek.generate.ai_style.model import VoiceFingerprint
+    from creek.generate.grounding import EmbeddingFn
     from creek.models import MediumContract
+
+#: Default cosine floor a first-person biographical sentence must clear to count
+#: as grounded when no explicit threshold is wired in (issue #515). Mirrors the
+#: ``DraftConfig.grounding_lower`` default so the desk and draft paths agree on
+#: what "grounded enough" means for a single sentence.
+_DEFAULT_BIOGRAPHICAL_GROUNDING_LOWER = 0.30
 
 
 class ReflectionNode:
@@ -48,6 +56,9 @@ class ReflectionNode:
         vault: Path | None = None,
         fingerprint: VoiceFingerprint | None = None,
         ai_style_config: AIStyleConfig | None = None,
+        embedding_fn: EmbeddingFn | None = None,
+        grounding_lower: float = _DEFAULT_BIOGRAPHICAL_GROUNDING_LOWER,
+        voice_core: str | None = None,
     ) -> ReflectionResult:
         """Judge *body* against *evidence* and return a structured result.
 
@@ -72,6 +83,13 @@ class ReflectionNode:
                 fidelity (the voice cannot be measured without it).
             ai_style_config: The AI-style configuration. ``None`` skips voice
                 fidelity.
+            embedding_fn: Embedding callable for the biographical-grounding
+                check (issue #515). ``None`` skips it — the check is dormant
+                unless a caller wires an embedder in.
+            grounding_lower: Cosine floor a first-person biographical sentence
+                must clear against the evidence to count as grounded.
+            voice_core: The voice-core brief text, treated as tone guidance a
+                biographical claim may also trace to, or ``None``.
 
         Returns:
             A :class:`ReflectionResult` with the verdict and any findings.
@@ -87,6 +105,15 @@ class ReflectionNode:
         findings.extend(check_paradox_preservation(body, evidence))
         findings.extend(check_attribution_correctness(body, evidence))
         findings.extend(check_voice_fidelity(body, fingerprint, ai_style_config))
+        findings.extend(
+            check_biographical_grounding(
+                body,
+                evidence,
+                embedding_fn=embedding_fn,
+                grounding_lower=grounding_lower,
+                voice_core=voice_core,
+            )
+        )
 
         decision: ReflectionVerdict = "PASS" if not findings else "REVISE"
         return ReflectionResult(decision=decision, findings=findings)

--- a/creek-tools/creek/author/voice.py
+++ b/creek-tools/creek/author/voice.py
@@ -227,6 +227,9 @@ def _ask_section(
         "Write in my (the vault owner's) voice.",
         "Every statement must trace to the provided source fragments — do not "
         "invent facts and do not add claims.",
+        "Do not assert biographical facts about me that are not present in the "
+        "source fragments. You may draw connections between ideas, but never "
+        "invent events, my upbringing, or another person's motives.",
         "Do not quote borrowed authors as my own words.",
     ]
     if contract is not None and contract.structure:

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -62,6 +62,7 @@ from creek.generate.grounding import (
     GroundingThresholds,
     ParagraphAnnotation,
     build_grounding_frontmatter,
+    scan_biographical_sentences,
     score_draft,
 )
 from creek.generate.outline import (
@@ -1138,7 +1139,58 @@ class DraftGenerator:
             thresholds=self._grounding_thresholds,
         )
         print(report.summary_line(), file=sys.stderr)
+        self._warn_ungrounded_biographical(
+            body=body,
+            source_texts=source_texts,
+            embedding_fn=self._embedding_fn,
+            thresholds=self._grounding_thresholds,
+        )
         return report
+
+    def _warn_ungrounded_biographical(
+        self,
+        *,
+        body: str,
+        source_texts: list[str],
+        embedding_fn: EmbeddingFn,
+        thresholds: GroundingThresholds,
+    ) -> None:
+        """Surface ungrounded first-person biographical sentences on stderr.
+
+        Reuses the same cosine machinery as the paragraph guard but at
+        sentence granularity (issue #515): a single invented first-person
+        biographical claim — e.g. an upbringing the corpus never mentions —
+        rides inside an otherwise on-topic paragraph and so escapes the
+        paragraph-level grounding score. Each flagged sentence is printed as
+        a ``grounding guard:`` warning so the operator sees it next to the
+        paragraph verdict. The voice-core brief is added to the source corpus
+        so a claim that legitimately traces to the brief is not flagged.
+
+        Args:
+            body: The generated draft body to scan.
+            source_texts: Source-fragment bodies already resolved by the
+                caller. The voice-core brief is appended internally.
+            embedding_fn: The resolved (non-``None``) embedding callable the
+                caller already established the guard is configured with.
+            thresholds: The resolved grounding thresholds; its
+                ``grounding_lower`` is the per-sentence floor.
+        """
+        corpus = source_texts.copy()
+        if self.voice_core.strip():
+            corpus.append(self.voice_core)
+        findings = scan_biographical_sentences(
+            body,
+            source_texts=corpus,
+            embedding_fn=embedding_fn,
+            threshold=thresholds.grounding_lower,
+        )
+        for finding in findings:
+            print(
+                "grounding guard: ungrounded first-person biographical claim "
+                f"(similarity {finding.max_similarity:.2f} < "
+                f"{thresholds.grounding_lower:.2f}): {finding.sentence!r}",
+                file=sys.stderr,
+            )
 
     def generate_draft(
         self,
@@ -2235,6 +2287,18 @@ def _slices_as_provenance(
     )
 
 
+#: Prompt steer that forbids inventing biographical facts or another person's
+#: motives (issue #515). Appended to every ``## Ask`` variant so the model is
+#: told — regardless of mode — that it may connect ideas but never fabricate
+#: the owner's upbringing, events, or someone else's motives. Pinned by a
+#: structure test so the instruction can never silently drop out of the prompt.
+_NO_FABRICATION_STEER = (
+    "Do not assert biographical facts about me that are not present in the "
+    "source fragments. You may draw connections between ideas, but never "
+    "invent events, my upbringing, or another person's motives."
+)
+
+
 def _compose_ask_section(
     idea: IdeaSeed,
     *,
@@ -2250,6 +2314,9 @@ def _compose_ask_section(
     directive so the LLM treats it as load-bearing. Otherwise it keeps
     the original wording so existing tests and mined-idea drafts
     continue to compose identically.
+
+    Every variant ends with :data:`_NO_FABRICATION_STEER` so the draft
+    prompt always carries the issue #515 no-fabrication instruction.
     """
     if twist:
         return (
@@ -2261,7 +2328,8 @@ def _compose_ask_section(
             "combination's style. Do not paraphrase any single source "
             "verbatim — recombine across the corpus. Honour the "
             "activated skills. Write as the human — not as an AI. "
-            "Cite source fragments by their IDs where relevant."
+            "Cite source fragments by their IDs where relevant. "
+            f"{_NO_FABRICATION_STEER}"
         )
     if per_dimension:
         return (
@@ -2272,14 +2340,16 @@ def _compose_ask_section(
             "sections above; weave them together at composition time "
             "rather than treating any one section as the source of "
             "truth. Honour the activated skills. Write as the human — "
-            "not as an AI. Cite source fragments by their IDs where relevant."
+            "not as an AI. Cite source fragments by their IDs where "
+            f"relevant. {_NO_FABRICATION_STEER}"
         )
     return (
         "## Ask\n"
         f'Write a draft essay titled "{idea.title}". '
         f"{idea.brief_description} "
         "Write as the human — not as an AI. Honour the activated "
-        "skills. Cite source fragments by their IDs where relevant."
+        f"skills. Cite source fragments by their IDs where relevant. "
+        f"{_NO_FABRICATION_STEER}"
     )
 
 

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -1139,6 +1139,10 @@ class DraftGenerator:
             thresholds=self._grounding_thresholds,
         )
         print(report.summary_line(), file=sys.stderr)
+        # The non-``None`` invariant is established by the guard above; assert
+        # it so ``_warn_ungrounded_biographical``'s non-optional
+        # ``embedding_fn`` contract is explicit and mypy's narrowing is pinned.
+        assert self._embedding_fn is not None
         self._warn_ungrounded_biographical(
             body=body,
             source_texts=source_texts,

--- a/creek-tools/creek/generate/grounding.py
+++ b/creek-tools/creek/generate/grounding.py
@@ -33,6 +33,7 @@ full sentence-transformer at unit-test time.
 from __future__ import annotations
 
 import math
+import re
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, TypedDict, final
@@ -332,6 +333,156 @@ def split_paragraphs(body: str) -> list[str]:
     if buffer:
         paragraphs.append("\n".join(buffer).strip())
     return [p for p in paragraphs if p]
+
+
+# ---------------------------------------------------------------------------
+# Sentence-level biographical grounding (issue #515)
+# ---------------------------------------------------------------------------
+
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+"""Boundary between sentences: whitespace following terminal punctuation.
+
+Conservative on purpose — it never splits on a bare newline or a comma, so
+a multi-clause biographical sentence ("Not the LDS Christ I was handed as a
+kid—the one I actually believe in.") is scored as one unit rather than
+fragmented into clauses that each lose their grounding context."""
+
+
+_BIOGRAPHICAL_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # First-person subject + a being / having / experience predicate. The
+    # patterns are deliberately narrow: a generic "I think" or "I want"
+    # opinion is NOT biographical, so only being/having/raising verbs and a
+    # handful of childhood time-markers qualify. Keeping the surface small
+    # is what keeps the false-positive rate low on grounded first-person
+    # prose that merely states an opinion.
+    re.compile(r"\bi was\b", re.IGNORECASE),
+    re.compile(r"\bi grew up\b", re.IGNORECASE),
+    re.compile(r"\bi was raised\b", re.IGNORECASE),
+    re.compile(r"\bi was handed\b", re.IGNORECASE),
+    re.compile(r"\bi had\b", re.IGNORECASE),
+    re.compile(r"\bi used to\b", re.IGNORECASE),
+    re.compile(r"\bas a kid\b", re.IGNORECASE),
+    re.compile(r"\bas a child\b", re.IGNORECASE),
+    re.compile(r"\bwhen i was\b", re.IGNORECASE),
+    re.compile(r"\bgrowing up\b", re.IGNORECASE),
+    re.compile(r"\bmy childhood\b", re.IGNORECASE),
+    re.compile(r"\bmy upbringing\b", re.IGNORECASE),
+)
+"""First-person biographical surface markers (issue #515).
+
+A sentence matching any of these is treated as asserting a biographical fact
+about the owner — an event, an upbringing, a past state — that must trace to
+a source. Opinions ("I think", "I believe", "I love") deliberately do not
+match: those are voice, not unverifiable biography."""
+
+
+@final
+@dataclass(frozen=True)
+class BiographicalGroundingFinding:
+    """One first-person biographical sentence that no source supports.
+
+    Attributes:
+        sentence: The exact biographical sentence flagged, verbatim from the
+            draft body, so the operator (or a downstream finding) can quote it.
+        max_similarity: Highest cosine similarity recorded between the
+            sentence and any source paragraph (sources + the voice-core brief).
+            ``0.0`` when there were no sources to score against.
+    """
+
+    sentence: str
+    max_similarity: float
+
+
+def split_sentences(body: str) -> list[str]:
+    """Split *body* into trimmed, non-empty sentences.
+
+    Sentences are separated on whitespace following terminal punctuation
+    (``.``, ``!``, ``?``); blank lines and headings collapse away. The split
+    is intentionally coarse — its only job is to isolate a first-person
+    biographical claim from the rest of an otherwise on-topic paragraph so
+    the grounding scan scores the claim, not the paragraph that hides it.
+    """
+    sentences: list[str] = []
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        sentences.extend(
+            part.strip() for part in _SENTENCE_SPLIT_RE.split(stripped) if part.strip()
+        )
+    return sentences
+
+
+def is_biographical_sentence(sentence: str) -> bool:
+    """Return whether *sentence* asserts a first-person biographical fact.
+
+    Conservative heuristic (issue #515): a first-person subject paired with a
+    being / having / experience predicate, or a childhood time-marker (see
+    :data:`_BIOGRAPHICAL_PATTERNS`). Bare opinions ("I think the world is
+    cruel") are not biographical and never match, which keeps grounded
+    first-person voice from tripping the guard.
+    """
+    return any(pattern.search(sentence) for pattern in _BIOGRAPHICAL_PATTERNS)
+
+
+def scan_biographical_sentences(
+    body: str,
+    *,
+    source_texts: Sequence[str],
+    embedding_fn: EmbeddingFn,
+    threshold: float,
+) -> list[BiographicalGroundingFinding]:
+    """Flag first-person biographical sentences ungrounded in any source.
+
+    For each sentence in *body* that :func:`is_biographical_sentence`
+    matches, embed it and take its maximum cosine similarity against every
+    paragraph of *source_texts* (the source fragments plus the voice-core
+    brief). A sentence whose best similarity falls *below* *threshold* is
+    surfaced as a :class:`BiographicalGroundingFinding`.
+
+    The scan reuses the same cosine machinery as :func:`score_draft` but at
+    sentence granularity, so a single invented first-person claim riding
+    inside an otherwise on-topic paragraph is caught (the paragraph-level
+    guard misses it). It adds no LLM hop — only embedding calls.
+
+    Args:
+        body: The composed draft / review body (frontmatter excluded).
+        source_texts: Source-fragment bodies plus any voice-core brief text
+            the claim may legitimately trace to. Paragraph-split internally.
+        embedding_fn: Callable returning a vector for one text string.
+        threshold: Cosine floor a biographical sentence must clear against
+            some source paragraph to count as grounded. Typically the
+            configured per-paragraph ``grounding_lower``.
+
+    Returns:
+        One finding per ungrounded biographical sentence, in document order.
+        An empty list when no biographical sentence is below threshold.
+
+    Raises:
+        GroundingDimensionError: When *embedding_fn* returns vectors of
+            differing lengths for sentence and source paragraphs.
+    """
+    candidates = [s for s in split_sentences(body) if is_biographical_sentence(s)]
+    if not candidates:
+        return []
+    source_paragraphs: list[str] = []
+    for text in source_texts:
+        source_paragraphs.extend(split_paragraphs(text))
+    source_vectors = [embedding_fn(p) for p in source_paragraphs]
+    findings: list[BiographicalGroundingFinding] = []
+    for sentence in candidates:
+        best = (
+            max(
+                cosine_similarity(embedding_fn(sentence), src) for src in source_vectors
+            )
+            if source_vectors
+            else 0.0
+        )
+        if best < threshold:
+            findings.append(
+                BiographicalGroundingFinding(sentence=sentence, max_similarity=best)
+            )
+    return findings
 
 
 _NORM_EPSILON = 1e-12

--- a/creek-tools/creek/generate/grounding.py
+++ b/creek-tools/creek/generate/grounding.py
@@ -342,10 +342,16 @@ def split_paragraphs(body: str) -> list[str]:
 _SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
 """Boundary between sentences: whitespace following terminal punctuation.
 
-Conservative on purpose — it never splits on a bare newline or a comma, so
-a multi-clause biographical sentence ("Not the LDS Christ I was handed as a
-kid—the one I actually believe in.") is scored as one unit rather than
-fragmented into clauses that each lose their grounding context."""
+Conservative on purpose — this regex itself never splits on a bare newline or
+a comma, so a multi-clause biographical sentence ("Not the LDS Christ I was
+handed as a kid—the one I actually believe in.") is scored as one unit rather
+than fragmented into clauses that each lose their grounding context.
+
+Note: newline handling is performed by the ``splitlines()`` pre-pass in
+:func:`split_sentences`, *before* this regex ever runs. A sentence
+soft-wrapped across two markdown lines is therefore split at the newline by
+that pre-pass — a known edge handled separately (see issue #522, a follow-up
+to #417)."""
 
 
 _BIOGRAPHICAL_PATTERNS: tuple[re.Pattern[str], ...] = (
@@ -353,8 +359,12 @@ _BIOGRAPHICAL_PATTERNS: tuple[re.Pattern[str], ...] = (
     # ordinary first-person prose never trips the guard. A bare "I was wrong"
     # or "I had an idea" is opinion, not biography — so "i was" / "i had" only
     # qualify in specific biographical forms (raised, born, brought up, handed,
-    # a <kid/child/...>). Childhood time-markers ("as a kid", "growing up")
-    # round out the set. Opinions ("I think", "I want") never match.
+    # a <kid/child/...>). The bare "i was brought" and non-first-person
+    # "growing up" forms were removed (#519): they matched non-biographical
+    # idioms ("brought here by my editor", "growing up shapes identity") that
+    # the narrower "i was brought up" / "i grew up" patterns already cover.
+    # Childhood time-markers ("as a kid", "when i was") round out the set.
+    # Opinions ("I think", "I want") never match.
     re.compile(r"\bi was raised\b", re.IGNORECASE),
     re.compile(r"\bi was born\b", re.IGNORECASE),
     re.compile(r"\bi was brought up\b", re.IGNORECASE),
@@ -365,12 +375,10 @@ _BIOGRAPHICAL_PATTERNS: tuple[re.Pattern[str], ...] = (
         re.IGNORECASE,
     ),
     re.compile(r"\bi grew up\b", re.IGNORECASE),
-    re.compile(r"\bi was brought\b", re.IGNORECASE),
     re.compile(r"\bi used to\b", re.IGNORECASE),
     re.compile(r"\bas a kid\b", re.IGNORECASE),
     re.compile(r"\bas a child\b", re.IGNORECASE),
     re.compile(r"\bwhen i was\b", re.IGNORECASE),
-    re.compile(r"\bgrowing up\b", re.IGNORECASE),
     re.compile(r"\bmy childhood\b", re.IGNORECASE),
     re.compile(r"\bmy upbringing\b", re.IGNORECASE),
 )
@@ -381,11 +389,14 @@ about the owner — an upbringing, a birth, a childhood state, a past habit —
 that must trace to a source. The patterns are deliberately narrow: bare
 ``i was`` / ``i had`` are excluded because they cover ordinary first-person
 prose ("I was wrong", "I had an idea"); only their genuinely biographical
-forms (``i was raised/born/handed``, ``i was a kid``, ``i grew up``, ``i used
-to``) and childhood time-markers (``as a kid``, ``when i was``, ``growing
-up``, ``my childhood/upbringing``) qualify. Opinions ("I think", "I believe",
-"I love") deliberately never match: those are voice, not unverifiable
-biography."""
+forms (``i was raised/born/brought up/handed``, ``i was a kid``, ``i grew
+up``, ``i used to``) and childhood time-markers (``as a kid``, ``when i was``,
+``my childhood/upbringing``) qualify. The bare ``i was brought`` and
+non-first-person ``growing up`` were dropped (#519) as false-positive prone:
+they matched non-biographical idioms ("brought here by my editor", "growing up
+shapes identity") already covered by ``i was brought up`` / ``i grew up``.
+Opinions ("I think", "I believe", "I love") deliberately never match: those
+are voice, not unverifiable biography."""
 
 
 @final
@@ -413,6 +424,14 @@ def split_sentences(body: str) -> list[str]:
     is intentionally coarse — its only job is to isolate a first-person
     biographical claim from the rest of an otherwise on-topic paragraph so
     the grounding scan scores the claim, not the paragraph that hides it.
+
+    Newline handling happens here, in the ``body.splitlines()`` pre-pass:
+    each physical line is processed independently and only then is
+    :data:`_SENTENCE_SPLIT_RE` applied. A single sentence that is
+    soft-wrapped across two markdown lines is therefore split at the newline
+    rather than kept whole — a known edge tracked in issue #522 (follow-up to
+    #417); the regex's own "never split on a newline" guarantee applies only
+    *within* a physical line.
     """
     sentences: list[str] = []
     for line in body.splitlines():

--- a/creek-tools/creek/generate/grounding.py
+++ b/creek-tools/creek/generate/grounding.py
@@ -349,17 +349,23 @@ fragmented into clauses that each lose their grounding context."""
 
 
 _BIOGRAPHICAL_PATTERNS: tuple[re.Pattern[str], ...] = (
-    # First-person subject + a being / having / experience predicate. The
-    # patterns are deliberately narrow: a generic "I think" or "I want"
-    # opinion is NOT biographical, so only being/having/raising verbs and a
-    # handful of childhood time-markers qualify. Keeping the surface small
-    # is what keeps the false-positive rate low on grounded first-person
-    # prose that merely states an opinion.
-    re.compile(r"\bi was\b", re.IGNORECASE),
-    re.compile(r"\bi grew up\b", re.IGNORECASE),
+    # First-person upbringing / past-state markers, deliberately narrow so
+    # ordinary first-person prose never trips the guard. A bare "I was wrong"
+    # or "I had an idea" is opinion, not biography — so "i was" / "i had" only
+    # qualify in specific biographical forms (raised, born, brought up, handed,
+    # a <kid/child/...>). Childhood time-markers ("as a kid", "growing up")
+    # round out the set. Opinions ("I think", "I want") never match.
     re.compile(r"\bi was raised\b", re.IGNORECASE),
+    re.compile(r"\bi was born\b", re.IGNORECASE),
+    re.compile(r"\bi was brought up\b", re.IGNORECASE),
     re.compile(r"\bi was handed\b", re.IGNORECASE),
-    re.compile(r"\bi had\b", re.IGNORECASE),
+    re.compile(
+        r"\bi was an? (?:kid|child|boy|girl|teenager|teen"
+        r"|baby|infant|toddler|youngster)\b",
+        re.IGNORECASE,
+    ),
+    re.compile(r"\bi grew up\b", re.IGNORECASE),
+    re.compile(r"\bi was brought\b", re.IGNORECASE),
     re.compile(r"\bi used to\b", re.IGNORECASE),
     re.compile(r"\bas a kid\b", re.IGNORECASE),
     re.compile(r"\bas a child\b", re.IGNORECASE),
@@ -371,9 +377,15 @@ _BIOGRAPHICAL_PATTERNS: tuple[re.Pattern[str], ...] = (
 """First-person biographical surface markers (issue #515).
 
 A sentence matching any of these is treated as asserting a biographical fact
-about the owner — an event, an upbringing, a past state — that must trace to
-a source. Opinions ("I think", "I believe", "I love") deliberately do not
-match: those are voice, not unverifiable biography."""
+about the owner — an upbringing, a birth, a childhood state, a past habit —
+that must trace to a source. The patterns are deliberately narrow: bare
+``i was`` / ``i had`` are excluded because they cover ordinary first-person
+prose ("I was wrong", "I had an idea"); only their genuinely biographical
+forms (``i was raised/born/handed``, ``i was a kid``, ``i grew up``, ``i used
+to``) and childhood time-markers (``as a kid``, ``when i was``, ``growing
+up``, ``my childhood/upbringing``) qualify. Opinions ("I think", "I believe",
+"I love") deliberately never match: those are voice, not unverifiable
+biography."""
 
 
 @final
@@ -416,11 +428,14 @@ def split_sentences(body: str) -> list[str]:
 def is_biographical_sentence(sentence: str) -> bool:
     """Return whether *sentence* asserts a first-person biographical fact.
 
-    Conservative heuristic (issue #515): a first-person subject paired with a
-    being / having / experience predicate, or a childhood time-marker (see
-    :data:`_BIOGRAPHICAL_PATTERNS`). Bare opinions ("I think the world is
-    cruel") are not biographical and never match, which keeps grounded
-    first-person voice from tripping the guard.
+    Conservative heuristic (issue #515): only genuinely biographical
+    upbringing / childhood / past-state forms match — "I was raised", "I was
+    born", "I was handed", "I grew up", "I used to", "I was a kid", and
+    childhood time-markers like "as a kid" or "when I was" (see
+    :data:`_BIOGRAPHICAL_PATTERNS`). Ordinary first-person prose ("I was
+    wrong", "I had an idea") and bare opinions ("I think the world is cruel")
+    deliberately never match, which keeps grounded first-person voice from
+    tripping the guard.
     """
     return any(pattern.search(sentence) for pattern in _BIOGRAPHICAL_PATTERNS)
 
@@ -471,13 +486,11 @@ def scan_biographical_sentences(
     source_vectors = [embedding_fn(p) for p in source_paragraphs]
     findings: list[BiographicalGroundingFinding] = []
     for sentence in candidates:
-        best = (
-            max(
-                cosine_similarity(embedding_fn(sentence), src) for src in source_vectors
-            )
-            if source_vectors
-            else 0.0
-        )
+        if source_vectors:
+            sentence_vec = embedding_fn(sentence)
+            best = max(cosine_similarity(sentence_vec, src) for src in source_vectors)
+        else:
+            best = 0.0
         if best < threshold:
             findings.append(
                 BiographicalGroundingFinding(sentence=sentence, max_similarity=best)

--- a/creek-tools/tests/test_biographical_grounding.py
+++ b/creek-tools/tests/test_biographical_grounding.py
@@ -150,6 +150,32 @@ class TestBiographicalHeuristic:
         assert is_biographical_sentence("I was born in 1980.") is True
         assert is_biographical_sentence("I was a kid then.") is True
 
+    def test_bare_i_was_brought_not_biographical(self) -> None:
+        """``i was brought`` without ``up`` is not biographical (#519).
+
+        The bare form matches non-biographical idioms ("brought here by my
+        editor", "brought in to consult"); only the upbringing form
+        ``i was brought up`` qualifies.
+        """
+        assert is_biographical_sentence("I was brought here by my editor.") is False
+        assert is_biographical_sentence("I was brought in to consult.") is False
+        assert is_biographical_sentence("I was brought up Catholic.") is True
+
+    def test_non_first_person_growing_up_not_biographical(self) -> None:
+        """Bare ``growing up`` matches third-person/thematic prose (#519).
+
+        Only the first-person ``i grew up`` should flag; ``growing up`` on its
+        own appears in third-person or thematic sentences about other people.
+        """
+        assert (
+            is_biographical_sentence(
+                "Growing up in a religious household shapes identity."
+            )
+            is False
+        )
+        assert is_biographical_sentence("She described growing up on a farm.") is False
+        assert is_biographical_sentence("I grew up in Ohio.") is True
+
 
 # ---------------------------------------------------------------------------
 # scan_biographical_sentences

--- a/creek-tools/tests/test_biographical_grounding.py
+++ b/creek-tools/tests/test_biographical_grounding.py
@@ -1,0 +1,421 @@
+"""Tests for the ungrounded-biographical-fact guard (issue #515).
+
+Drafts invent first-person biographical facts ("Not the LDS Christ I was
+handed as a kid—") that no source fragment supports. The paragraph-level
+grounding guard (#355) misses these because a single invented sentence rides
+inside an otherwise on-topic paragraph. This module pins:
+
+* :func:`creek.generate.grounding.split_sentences` /
+  :func:`creek.generate.grounding.is_biographical_sentence` — the conservative
+  first-person biographical heuristic.
+* :func:`creek.generate.grounding.scan_biographical_sentences` — the
+  sentence-level cosine scan that flags an ungrounded biographical claim and,
+  crucially, does NOT flag a grounded one (no false positive).
+* :func:`creek.author.checks.check_biographical_grounding` and its wiring into
+  :meth:`creek.author.reflection.ReflectionNode.review` (the desk path).
+* The no-fabrication prompt steer in both the draft and voice ``## Ask``
+  blocks (structure tests).
+
+A deterministic injected embedding callable keeps every test offline.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from typing import TYPE_CHECKING
+
+from creek.author.checks import check_biographical_grounding
+from creek.author.models import EvidenceBundle, EvidenceClaim
+from creek.author.reflection import ReflectionNode
+from creek.author.voice import _ask_section
+from creek.generate.drafts import _NO_FABRICATION_STEER, _compose_ask_section
+from creek.generate.grounding import (
+    BiographicalGroundingFinding,
+    is_biographical_sentence,
+    scan_biographical_sentences,
+    split_sentences,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+    from creek.generate.drafts import DraftGenerator
+    from creek.generate.grounding import EmbeddingFn
+
+# The literal fabrication from the issue body — the canonical fixture sentence.
+_LDS_SENTENCE = "Not the LDS Christ I was handed as a kid."
+
+# A grounded first-person biographical claim that DOES trace to a source.
+_GROUNDED_SENTENCE = "I grew up in a small town on the prairie."
+
+
+_VECTOR_DIM = 32
+
+
+def _hashed_vector(text: str) -> list[float]:
+    """Return a deterministic, normalised vector keyed off *text*'s hash.
+
+    Identical strings map to the same vector; distinct strings map to
+    near-orthogonal vectors so cosine cleanly separates "grounded" from
+    "ungrounded" without a real embedding model.
+    """
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    raw: list[int] = []
+    counter = 0
+    while len(raw) < _VECTOR_DIM:
+        chunk = hashlib.sha256(digest + counter.to_bytes(2, "big")).digest()
+        raw.extend(chunk[: _VECTOR_DIM - len(raw)])
+        counter += 1
+    centred = [b - 127.5 for b in raw[:_VECTOR_DIM]]
+    norm = math.sqrt(sum(x * x for x in centred)) or 1.0
+    return [x / norm for x in centred]
+
+
+def _aliasing_embedder(*, alias: tuple[str, str]) -> EmbeddingFn:
+    """Embed two texts identically so they score cosine 1.0 against each other.
+
+    *alias* is a ``(a, b)`` pair both mapped to the same vector; every other
+    string falls through to :func:`_hashed_vector` and stays near-orthogonal.
+    This lets a test declare "this sentence is grounded by this source" without
+    hand-tuning coordinates.
+    """
+    a, b = alias
+    shared = _hashed_vector(a)
+
+    def _embed(text: str) -> list[float]:
+        if text in (a, b):
+            return shared
+        return _hashed_vector(text)
+
+    return _embed
+
+
+# ---------------------------------------------------------------------------
+# split_sentences + is_biographical_sentence
+# ---------------------------------------------------------------------------
+
+
+class TestSentenceSplitting:
+    """``split_sentences`` isolates a claim from the paragraph hiding it."""
+
+    def test_splits_on_terminal_punctuation(self) -> None:
+        """A run-on paragraph splits into one entry per sentence."""
+        body = "The wave rises. Then it falls! Does it return?"
+        assert split_sentences(body) == [
+            "The wave rises.",
+            "Then it falls!",
+            "Does it return?",
+        ]
+
+    def test_drops_headings_and_blank_lines(self) -> None:
+        """Markdown headings and blank lines collapse away."""
+        body = "# Heading\n\nA real sentence here.\n\n## Another\n"
+        assert split_sentences(body) == ["A real sentence here."]
+
+
+class TestBiographicalHeuristic:
+    """The heuristic is conservative: biography yes, opinion no."""
+
+    def test_matches_lds_fixture_sentence(self) -> None:
+        """The issue's literal fixture sentence is biographical."""
+        assert is_biographical_sentence(_LDS_SENTENCE) is True
+
+    def test_matches_grew_up_and_childhood_markers(self) -> None:
+        """``I grew up`` / ``as a kid`` / ``when I was`` are biographical."""
+        assert is_biographical_sentence("I grew up on a farm.") is True
+        assert is_biographical_sentence("Back when I was a child.") is True
+        assert is_biographical_sentence("As a kid, the world felt huge.") is True
+
+    def test_opinion_is_not_biographical(self) -> None:
+        """A bare first-person opinion must NOT match (false-positive guard)."""
+        assert is_biographical_sentence("I think pluralism matters.") is False
+        assert is_biographical_sentence("I love this idea.") is False
+        assert is_biographical_sentence("I want to explore the tension.") is False
+
+
+# ---------------------------------------------------------------------------
+# scan_biographical_sentences
+# ---------------------------------------------------------------------------
+
+
+class TestScanBiographicalSentences:
+    """The sentence-level cosine scan flags fabrication, spares grounded prose."""
+
+    def test_flags_ungrounded_biographical_claim(self) -> None:
+        """The LDS fixture, absent from all sources, is flagged."""
+        body = f"Christ is a pattern, not a person. {_LDS_SENTENCE}"
+        findings = scan_biographical_sentences(
+            body,
+            source_texts=["Christ shows up as a recurring pattern in my notes."],
+            embedding_fn=_hashed_vector,
+            threshold=0.30,
+        )
+        assert [f.sentence for f in findings] == [_LDS_SENTENCE]
+        assert isinstance(findings[0], BiographicalGroundingFinding)
+        assert findings[0].max_similarity < 0.30
+
+    def test_grounded_biographical_claim_not_flagged(self) -> None:
+        """A biographical claim that IS in a source produces NO finding."""
+        embedder = _aliasing_embedder(
+            alias=(_GROUNDED_SENTENCE, "prairie childhood source")
+        )
+        findings = scan_biographical_sentences(
+            _GROUNDED_SENTENCE,
+            source_texts=["prairie childhood source"],
+            embedding_fn=embedder,
+            threshold=0.30,
+        )
+        assert findings == []
+
+    def test_no_biographical_sentence_short_circuits(self) -> None:
+        """A body with only opinions never touches the embedder."""
+
+        def _boom(_text: str) -> list[float]:
+            msg = "embedder must not be called when no sentence is biographical"
+            raise AssertionError(msg)
+
+        findings = scan_biographical_sentences(
+            "I think the wave is beautiful. I love the idea.",
+            source_texts=["anything"],
+            embedding_fn=_boom,
+            threshold=0.30,
+        )
+        assert findings == []
+
+    def test_no_sources_scores_zero_and_flags(self) -> None:
+        """With no sources a biographical claim is ungrounded by definition."""
+        findings = scan_biographical_sentences(
+            _LDS_SENTENCE,
+            source_texts=[],
+            embedding_fn=_hashed_vector,
+            threshold=0.30,
+        )
+        assert len(findings) == 1
+        assert findings[0].max_similarity == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Desk path: check_biographical_grounding + ReflectionNode.review
+# ---------------------------------------------------------------------------
+
+
+class TestDeskBiographicalCheck:
+    """The desk check turns ungrounded biography into a HIGH finding."""
+
+    def test_flags_lds_fixture(self) -> None:
+        """The LDS fixture, absent from the evidence, yields a HIGH finding."""
+        evidence = EvidenceBundle(
+            claims=[
+                EvidenceClaim(
+                    claim="Christ recurs as a pattern in the corpus.",
+                    source_fragments=["frag-a"],
+                )
+            ]
+        )
+        findings = check_biographical_grounding(
+            f"A pattern, not a person. {_LDS_SENTENCE}",
+            evidence,
+            embedding_fn=_hashed_vector,
+            grounding_lower=0.30,
+        )
+        assert len(findings) == 1
+        assert findings[0].dimension == "biographical_grounding"
+        assert findings[0].severity == "HIGH"
+        assert "LDS" in findings[0].message
+
+    def test_grounded_claim_no_finding(self) -> None:
+        """A biographical claim matching a claim's text produces no finding."""
+        evidence = EvidenceBundle(
+            claims=[
+                EvidenceClaim(claim=_GROUNDED_SENTENCE, source_fragments=["frag-a"])
+            ]
+        )
+        embedder = _aliasing_embedder(alias=(_GROUNDED_SENTENCE, _GROUNDED_SENTENCE))
+        findings = check_biographical_grounding(
+            _GROUNDED_SENTENCE,
+            evidence,
+            embedding_fn=embedder,
+            grounding_lower=0.30,
+        )
+        assert findings == []
+
+    def test_dormant_without_embedder(self) -> None:
+        """No embedder → the check is dormant (mirrors voice fidelity)."""
+        evidence = EvidenceBundle(
+            claims=[EvidenceClaim(claim="x", source_fragments=["f"])]
+        )
+        assert (
+            check_biographical_grounding(
+                _LDS_SENTENCE,
+                evidence,
+                embedding_fn=None,
+                grounding_lower=0.30,
+            )
+            == []
+        )
+
+    def test_voice_core_grounds_the_claim(self) -> None:
+        """A claim that traces only to the voice-core brief is not flagged."""
+        evidence = EvidenceBundle(
+            claims=[EvidenceClaim(claim="unrelated", source_fragments=["f"])]
+        )
+        brief = "the voice-core brief that grounds the claim"
+        embedder = _aliasing_embedder(alias=(_GROUNDED_SENTENCE, brief))
+        findings = check_biographical_grounding(
+            _GROUNDED_SENTENCE,
+            evidence,
+            embedding_fn=embedder,
+            grounding_lower=0.30,
+            voice_core=brief,
+        )
+        assert findings == []
+
+
+class TestReflectionNodeWiring:
+    """The reflection node surfaces the biographical finding end-to-end."""
+
+    def test_review_revises_on_lds_fixture(self) -> None:
+        """``review`` returns REVISE with a biographical_grounding finding."""
+        evidence = EvidenceBundle(
+            claims=[
+                EvidenceClaim(
+                    claim="Christ is a recurring pattern.",
+                    source_fragments=["frag-a"],
+                )
+            ]
+        )
+        result = ReflectionNode().review(
+            f"Christ is a recurring pattern. {_LDS_SENTENCE}",
+            evidence,
+            embedding_fn=_hashed_vector,
+            grounding_lower=0.30,
+        )
+        assert result.decision == "REVISE"
+        assert any(f.dimension == "biographical_grounding" for f in result.findings)
+
+    def test_review_dormant_without_embedder(self) -> None:
+        """Without an embedder the node never raises a biographical finding."""
+        evidence = EvidenceBundle(
+            claims=[
+                EvidenceClaim(
+                    claim="Christ is a recurring pattern.",
+                    source_fragments=["frag-a"],
+                )
+            ]
+        )
+        result = ReflectionNode().review(
+            f"Christ is a recurring pattern. {_LDS_SENTENCE}",
+            evidence,
+        )
+        assert not any(f.dimension == "biographical_grounding" for f in result.findings)
+
+
+# ---------------------------------------------------------------------------
+# Draft path: DraftGenerator._build_guard_report surfaces the warning
+# ---------------------------------------------------------------------------
+
+
+class TestDraftGuardWarning:
+    """The draft path warns on an ungrounded biographical sentence (stderr)."""
+
+    def _generator(self, tmp_path: Path, *, voice_core: str) -> DraftGenerator:
+        """Build a :class:`DraftGenerator` wired with the test embedder."""
+        from creek.generate.drafts import DraftGenerator
+        from creek.generate.grounding import GroundingThresholds
+
+        return DraftGenerator(
+            llm=lambda _prompt: "unused",
+            skills_root=tmp_path,
+            voice_core=voice_core,
+            embedding_fn=_hashed_vector,
+            grounding_thresholds=GroundingThresholds(
+                derivative_upper=0.9,
+                grounding_lower=0.30,
+                grounding_fraction_lower=0.5,
+            ),
+        )
+
+    def test_flagged_sentence_prints_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An ungrounded LDS sentence prints a ``grounding guard:`` warning."""
+        from creek.generate.grounding import GroundingThresholds
+
+        generator = self._generator(tmp_path, voice_core="")
+        generator._warn_ungrounded_biographical(
+            body=f"Christ is a pattern.\n\n{_LDS_SENTENCE}",
+            source_texts=["Christ is a recurring pattern."],
+            embedding_fn=_hashed_vector,
+            thresholds=GroundingThresholds(
+                derivative_upper=0.9,
+                grounding_lower=0.30,
+                grounding_fraction_lower=0.5,
+            ),
+        )
+        err = capsys.readouterr().err
+        assert "ungrounded first-person biographical claim" in err
+        assert "LDS" in err
+
+    def test_voice_core_grounds_and_suppresses_warning(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A claim grounded by the voice-core brief prints no warning."""
+        from creek.generate.grounding import GroundingThresholds
+
+        embedder = _aliasing_embedder(alias=(_GROUNDED_SENTENCE, _GROUNDED_SENTENCE))
+        generator = self._generator(tmp_path, voice_core=_GROUNDED_SENTENCE)
+        generator._warn_ungrounded_biographical(
+            body=_GROUNDED_SENTENCE,
+            source_texts=["unrelated source body"],
+            embedding_fn=embedder,
+            thresholds=GroundingThresholds(
+                derivative_upper=0.9,
+                grounding_lower=0.30,
+                grounding_fraction_lower=0.5,
+            ),
+        )
+        err = capsys.readouterr().err
+        assert "biographical claim" not in err
+
+
+# ---------------------------------------------------------------------------
+# Prompt steer structure tests
+# ---------------------------------------------------------------------------
+
+
+_STEER_PHRASE = "never invent events, my upbringing, or another person's motives"
+
+
+class TestPromptSteer:
+    """The no-fabrication instruction is pinned into both prompt surfaces."""
+
+    def test_draft_ask_carries_steer_in_every_mode(self) -> None:
+        """Every ``_compose_ask_section`` variant ends with the steer."""
+        from creek.generate.mining import IdeaSeed, MiningStrategy
+
+        idea = IdeaSeed(
+            strategy=MiningStrategy.RESONANCE_CHAIN,
+            title="Christ",
+            source_fragments=("frag-a",),
+            threads=(),
+            eddies=(),
+            frequency_affinity=(),
+            brief_description="A draft about the pattern.",
+            score=0.8,
+        )
+        for kwargs in (
+            {"per_dimension": False},
+            {"per_dimension": True},
+            {"per_dimension": False, "twist": True},
+        ):
+            section = _compose_ask_section(idea, **kwargs)
+            assert _STEER_PHRASE in section
+        assert _STEER_PHRASE in _NO_FABRICATION_STEER
+
+    def test_voice_ask_carries_steer(self) -> None:
+        """The voice agent's ``## Ask`` block carries the steer."""
+        section = _ask_section("What is Christ?", None, None)
+        assert _STEER_PHRASE in section

--- a/creek-tools/tests/test_biographical_grounding.py
+++ b/creek-tools/tests/test_biographical_grounding.py
@@ -135,6 +135,21 @@ class TestBiographicalHeuristic:
         assert is_biographical_sentence("I love this idea.") is False
         assert is_biographical_sentence("I want to explore the tension.") is False
 
+    def test_ordinary_first_person_prose_not_biographical(self) -> None:
+        """Bare ``i was`` / ``i had`` prose is opinion, not biography."""
+        assert is_biographical_sentence("I was wrong.") is False
+        assert is_biographical_sentence("I was just thinking.") is False
+        assert is_biographical_sentence("I had an idea.") is False
+        assert is_biographical_sentence("I had a coffee.") is False
+
+    def test_genuine_biographical_claims_match(self) -> None:
+        """Upbringing / childhood-state claims still match after narrowing."""
+        assert is_biographical_sentence("I was raised Catholic.") is True
+        assert is_biographical_sentence("I grew up in Ohio.") is True
+        assert is_biographical_sentence("I was handed this faith as a kid.") is True
+        assert is_biographical_sentence("I was born in 1980.") is True
+        assert is_biographical_sentence("I was a kid then.") is True
+
 
 # ---------------------------------------------------------------------------
 # scan_biographical_sentences
@@ -184,6 +199,29 @@ class TestScanBiographicalSentences:
             threshold=0.30,
         )
         assert findings == []
+
+    def test_embeds_each_candidate_sentence_once(self) -> None:
+        """Each candidate sentence is embedded exactly once, not per source paragraph.
+
+        Regression for the O(M) re-embedding bug: the sentence vector must be
+        hoisted out of the ``max(... for src in source_vectors)`` loop so adding
+        more source paragraphs never multiplies the per-sentence embedding cost.
+        """
+        calls: dict[str, int] = {}
+
+        def _counting_embedder(text: str) -> list[float]:
+            calls[text] = calls.get(text, 0) + 1
+            return _hashed_vector(text)
+
+        scan_biographical_sentences(
+            _LDS_SENTENCE,
+            # Three distinct source paragraphs: a naive impl would embed the
+            # candidate sentence three times (once per source).
+            source_texts=["alpha source", "beta source", "gamma source"],
+            embedding_fn=_counting_embedder,
+            threshold=0.30,
+        )
+        assert calls[_LDS_SENTENCE] == 1
 
     def test_no_sources_scores_zero_and_flags(self) -> None:
         """With no sources a biographical claim is ungrounded by definition."""

--- a/creek-tools/tests/test_reflection.py
+++ b/creek-tools/tests/test_reflection.py
@@ -365,6 +365,14 @@ def test_empty_body_or_no_evidence_escalates() -> None:
     assert ReflectionNode().review("body", EvidenceBundle()).decision == "ESCALATE"
 
 
+def test_default_biographical_grounding_lower_tracks_draft_config() -> None:
+    """The desk default cannot silently drift from ``DraftConfig.grounding_lower``."""
+    from creek.author.reflection import _DEFAULT_BIOGRAPHICAL_GROUNDING_LOWER
+    from creek.config import DraftConfig
+
+    assert DraftConfig().grounding_lower == _DEFAULT_BIOGRAPHICAL_GROUNDING_LOWER
+
+
 def test_conductor_escalates_on_exhaustion(tmp_path: Path) -> None:
     """A reflection that always REVISEs exhausts the budget → ESCALATE at round 2."""
 


### PR DESCRIPTION
## Summary
- Adds a deterministic, sentence-level grounding flag for **first-person biographical claims** that no source supports (e.g. "Not the LDS Christ I was handed as a kid"). Reuses the existing cosine machinery in `creek/generate/grounding.py` at sentence granularity so an invented sentence riding inside an on-topic paragraph no longer escapes the paragraph-level guard.
- **Desk path:** new `check_biographical_grounding` in `creek/author/checks.py`, wired into `ReflectionNode.review` as a HARD `biographical_grounding` finding (dormant without an injected embedder, mirroring the voice-fidelity check). **Draft path:** `DraftGenerator` surfaces flagged sentences as a `grounding guard:` stderr warning next to the paragraph verdict.
- **Prompt steer:** both the draft (`_compose_ask_section`) and VoiceAgent (`_ask_section`) `## Ask` blocks now instruct the model never to invent biographical facts, events, upbringing, or another person's motives — pinned by structure tests.

## Test plan
- New `tests/test_biographical_grounding.py` (TDD, written first): the LDS fixture sentence produces a finding/warning on both paths; a biographical claim grounded by a source (or the voice-core brief) produces **no** finding (false-positive guard); bare opinions never match; the prompt steer is present in every `## Ask` variant.
- `cd creek-tools && ./scripts/check-all.sh` → exit 0, all 12 checks pass, coverage 93.78% (>=90%), 5023 passed.

The heuristic is conservative on purpose: only a first-person subject paired with a being/having/experience predicate or a childhood time-marker qualifies, so grounded first-person voice and opinions ("I think", "I love") do not trip it.

Closes #515
Refs #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
