### PR TITLE
fix(ai-style): detect bare "not X but Y" antithesis tic

### DIFF
--- a/creek-tools/creek/generate/ai_style/features.py
+++ b/creek-tools/creek/generate/ai_style/features.py
@@ -277,6 +277,11 @@ def vague_attribution_density(text: str) -> float:
 #   4. Cross-sentence subject restatement ``X isn't/weren't Y. <subject>
 #      is/are/was/were/makes Z`` — the negated claim then its affirming echo,
 #      e.g. "The parables weren't instruction manuals. They were field reports."
+#      The echoed subject must be a *genuine* restatement: either a pronoun
+#      (they/it/he/she/we) or the SAME noun repeated (``the <noun>`` …
+#      ``the <noun>`` via the ``xnoun`` backreference). A fresh ``The <word>``
+#      with a different noun is not antithesis and must not match, e.g.
+#      "The algorithm doesn't converge. The teacher is patient."
 #   5. Em-dash antithesis ``it doesn't … — it …``.
 #   6. ``no X, no Y, just/but``.
 # Calibration: every alternation requires a contrasting second clause (a bare
@@ -288,8 +293,9 @@ NEGATIVE_PARALLELISM_RE = re.compile(
     r"[^.!?\n]{1,80}?,?\s*\bbut (?P=prep)\b"
     r"|\bit'?s not (?:just |merely |only )?[^.!?\n]{1,60}?,\s*it'?s\b"
     r"|\bit is not (?:just |merely |only |about )?[^.!?\n]{1,60}?,?\s*it is\b"
-    r"|\b(?:is|are|was|were|do|does)n'?t\b[^.!?\n]{1,80}?[.!?]\s+"
-    r"(?:they|it|he|she|we|the [a-z]+)\b[^.!?\n]{0,12}?"
+    r"|\b(?:the (?P<xnoun>[a-z]+) )?"
+    r"(?:is|are|was|were|do|does)n'?t\b[^.!?\n]{1,80}?[.!?]\s+"
+    r"(?:(?:they|it|he|she|we)|the (?P=xnoun))\b[^.!?\n]{0,12}?"
     r"\b(?:is|are|was|were|do|does|make|makes)\b"
     r"|\b(?:is|are|was|were|do|does)n'?t\b[^.!?\n]{1,60}?—"
     r"\s*it\b[^.!?\n]{0,40}?\b(?:is|makes?|does)\b"

--- a/creek-tools/creek/generate/ai_style/features.py
+++ b/creek-tools/creek/generate/ai_style/features.py
@@ -264,9 +264,35 @@ def vague_attribution_density(text: str) -> float:
 # Each pattern matches the offending phrase as group 0 (no lead-in capture)
 # unless noted, so a plain ``finditer`` span is the thing to surface.
 
+# Antithesis / negative-parallelism. The alternations, in order:
+#   1. ``not only X but [also] Y``.
+#   2. Bare ``not <prep> X[,] but <prep> Y`` — antithesis built from parallel
+#      prepositional phrases, the dominant AI tell from issue #516, e.g.
+#      "Not through bliss, necessarily, but through outrage". The shared
+#      preposition is what makes it *parallel* antithesis rather than a casual
+#      concessive ("Not my best work but it is honest"), which must not flag.
+#   3. ``it's not X, it's Y`` (contracted, comma-then-``it's``) and its
+#      uncontracted twin ``it is not X[,] it is Y`` / ``it is not about X[,]
+#      it is about Y``.
+#   4. Cross-sentence subject restatement ``X isn't/weren't Y. <subject>
+#      is/are/was/were/makes Z`` — the negated claim then its affirming echo,
+#      e.g. "The parables weren't instruction manuals. They were field reports."
+#   5. Em-dash antithesis ``it doesn't … — it …``.
+#   6. ``no X, no Y, just/but``.
+# Calibration: every alternation requires a contrasting second clause (a bare
+# negation never matches), so a single deliberate antithesis registers as one
+# count and is gated by the surface margin, not a hard failure.
 NEGATIVE_PARALLELISM_RE = re.compile(
     r"\bnot only\b[^.!?\n]{1,80}?\bbut(?: also)?\b"
+    r"|\bnot (?P<prep>through|by|with|for|about|in|of|from|because)\b"
+    r"[^.!?\n]{1,80}?,?\s*\bbut (?P=prep)\b"
     r"|\bit'?s not (?:just |merely |only )?[^.!?\n]{1,60}?,\s*it'?s\b"
+    r"|\bit is not (?:just |merely |only |about )?[^.!?\n]{1,60}?,?\s*it is\b"
+    r"|\b(?:is|are|was|were|do|does)n'?t\b[^.!?\n]{1,80}?[.!?]\s+"
+    r"(?:they|it|he|she|we|the [a-z]+)\b[^.!?\n]{0,12}?"
+    r"\b(?:is|are|was|were|do|does|make|makes)\b"
+    r"|\b(?:is|are|was|were|do|does)n'?t\b[^.!?\n]{1,60}?—"
+    r"\s*it\b[^.!?\n]{0,40}?\b(?:is|makes?|does)\b"
     r"|\bno [a-z]+, no [a-z]+,?\s+(?:just|but)\b",
     re.IGNORECASE,
 )

--- a/creek-tools/tests/generate/ai_style/test_discourse.py
+++ b/creek-tools/tests/generate/ai_style/test_discourse.py
@@ -167,6 +167,32 @@ def test_single_triad_below_margin_no_false_positive() -> None:
     )
 
 
+def test_single_antithesis_below_margin_no_false_positive() -> None:
+    """One deliberate antithesis in a long clean paragraph stays under the margin.
+
+    The owner uses antithesis occasionally; a single rhetorical turn must not
+    trip the surface margin (issue #516 calibration).
+    """
+    text = "We win not through force but through patience. " + " ".join(["plain"] * 999)
+    assert not _fired(
+        scan(text, fingerprint=_PLAIN, config=_CONFIG), "negative_parallelism"
+    )
+
+
+def test_saturated_antithesis_fires_for_plain_user() -> None:
+    """A cluster of `not X but Y` antithesis flags for a plain user (issue #516)."""
+    text = (
+        "Not through bliss, necessarily, but through outrage. "
+        "The parables weren't instruction manuals. They were field reports. "
+        "The work isn't to save everyone. The work is to be findable. "
+        "It doesn't make you easier to manipulate—it makes you ungovernable. "
+        "It is not about winning, it is about showing up."
+    )
+    assert _fired(
+        scan(text, fingerprint=_PLAIN, config=_CONFIG), "negative_parallelism"
+    )
+
+
 def test_findings_carry_a_span_and_message() -> None:
     """A fired discourse finding locates the offending text and hints why."""
     text = "The work was hard. In summary, it succeeded."

--- a/creek-tools/tests/generate/ai_style/test_features.py
+++ b/creek-tools/tests/generate/ai_style/test_features.py
@@ -6,11 +6,13 @@ import pytest
 
 from creek.generate.ai_style.features import (
     FINGERPRINT_FEATURES,
+    NEGATIVE_PARALLELISM_RE,
     ai_vocab_density,
     concrete_density,
     curly_quote_density,
     em_dash_density,
     marketing_verb_ratio,
+    negative_parallelism_density,
     rule_of_three_rate,
     sentence_length_mean,
     transition_opener_rate,
@@ -78,6 +80,70 @@ def test_concrete_density_counts_the_word() -> None:
     """ "concrete" is counted; absent text scores zero."""
     assert concrete_density("no concrete evidence and concrete examples") > 0.0
     assert concrete_density("a plain sentence") == 0.0
+
+
+class TestNegativeParallelismRegex:
+    """The broadened antithesis pattern (issue #516)."""
+
+    # Existing constructions must keep matching.
+    _LEGACY = (
+        "It's not only fast, but also cheap.",
+        "It's not a bug, it's a feature.",
+        "No gods, no masters, just us.",
+    )
+    # The bare `not X, but Y` family and cross-sentence subject restatement
+    # that the old pattern missed (reproduction sentences from issue #516).
+    _NEW = (
+        "Not through bliss, necessarily, but through outrage, the sticky ones.",
+        "We win not through force but through patience.",
+        "The parables weren't instruction manuals. They were field reports.",
+        "The work isn't to save everyone. The work is to be findable.",
+        "It doesn't make you easier to manipulate—it makes you ungovernable.",
+        "It is not about winning, it is about showing up.",
+        "It's not about the money, it's about the principle.",
+    )
+
+    @pytest.mark.parametrize("text", _LEGACY)
+    def test_legacy_constructions_still_match(self, text: str) -> None:
+        """The constructions the original regex caught keep firing."""
+        assert NEGATIVE_PARALLELISM_RE.search(text) is not None
+
+    @pytest.mark.parametrize("text", _NEW)
+    def test_new_constructions_match(self, text: str) -> None:
+        """Each issue #516 reproduction sentence is now matched."""
+        assert NEGATIVE_PARALLELISM_RE.search(text) is not None
+
+    def test_ordinary_sentence_does_not_match(self) -> None:
+        """A plain sentence with no antithesis must not match."""
+        plain = "The river flowed quietly downhill."
+        assert NEGATIVE_PARALLELISM_RE.search(plain) is None
+
+    def test_plain_negation_alone_does_not_match(self) -> None:
+        """A bare negation with no contrasting clause must not match."""
+        assert NEGATIVE_PARALLELISM_RE.search("I do not like the rain at all.") is None
+
+
+class TestNegativeParallelismDensity:
+    """The density extractor over the broadened pattern (issue #516)."""
+
+    _SATURATED = (
+        "Not through bliss, necessarily, but through outrage. "
+        "The parables weren't instruction manuals. They were field reports. "
+        "The work isn't to save everyone. The work is to be findable. "
+        "It doesn't make you easier to manipulate—it makes you ungovernable. "
+        "It is not about winning, it is about showing up."
+    )
+    _CONTROL = "The river flowed downhill. " + " ".join(["plain"] * 40)
+
+    def test_density_higher_on_saturated_than_clean(self) -> None:
+        """A paragraph dense with antithesis scores well above a clean control."""
+        saturated = negative_parallelism_density(self._SATURATED)
+        clean = negative_parallelism_density(self._CONTROL)
+        assert saturated > clean
+
+    def test_clean_control_is_zero(self) -> None:
+        """The clean control has no antithesis density."""
+        assert negative_parallelism_density(self._CONTROL) == 0.0
 
 
 def test_registry_exposes_all_extractors() -> None:

--- a/creek-tools/tests/generate/ai_style/test_features.py
+++ b/creek-tools/tests/generate/ai_style/test_features.py
@@ -85,11 +85,14 @@ def test_concrete_density_counts_the_word() -> None:
 class TestNegativeParallelismRegex:
     """The broadened antithesis pattern (issue #516)."""
 
-    # Existing constructions must keep matching.
+    # Existing constructions must keep matching. The contracted
+    # `it's not X, it's Y` family was matched by the original regex, so it
+    # belongs here, not in the broadened-pattern fixtures.
     _LEGACY = (
         "It's not only fast, but also cheap.",
         "It's not a bug, it's a feature.",
         "No gods, no masters, just us.",
+        "It's not about the money, it's about the principle.",
     )
     # The bare `not X, but Y` family and cross-sentence subject restatement
     # that the old pattern missed (reproduction sentences from issue #516).
@@ -100,7 +103,6 @@ class TestNegativeParallelismRegex:
         "The work isn't to save everyone. The work is to be findable.",
         "It doesn't make you easier to manipulate—it makes you ungovernable.",
         "It is not about winning, it is about showing up.",
-        "It's not about the money, it's about the principle.",
     )
 
     @pytest.mark.parametrize("text", _LEGACY)
@@ -122,6 +124,25 @@ class TestNegativeParallelismRegex:
         """A bare negation with no contrasting clause must not match."""
         assert NEGATIVE_PARALLELISM_RE.search("I do not like the rain at all.") is None
 
+    def test_cross_sentence_different_subjects_does_not_match(self) -> None:
+        """A negation sentence followed by an unrelated `The <word>` is not antithesis.
+
+        The cross-sentence arm must only fire on a genuinely repeated subject
+        (a pronoun echo or the same noun restated), not on any new `The <word>`.
+        """
+        pair = "The algorithm doesn't converge. The teacher is patient."
+        assert NEGATIVE_PARALLELISM_RE.search(pair) is None
+
+    def test_casual_concessive_does_not_match(self) -> None:
+        """A casual concessive (`Not X but Y`, no shared preposition) must not flag.
+
+        Pins the boundary the PR body claims: the shared-preposition design
+        keeps a concessive aside out of the antithesis count.
+        """
+        assert (
+            NEGATIVE_PARALLELISM_RE.search("Not my best work but it is honest") is None
+        )
+
 
 class TestNegativeParallelismDensity:
     """The density extractor over the broadened pattern (issue #516)."""
@@ -140,6 +161,11 @@ class TestNegativeParallelismDensity:
         saturated = negative_parallelism_density(self._SATURATED)
         clean = negative_parallelism_density(self._CONTROL)
         assert saturated > clean
+        # Magnitude floor so a silent drop in match count is caught. The
+        # saturated fixture currently scores ~76.9 per 1000 words (5 matches /
+        # 65 words); 30.0 leaves generous headroom while still flagging a
+        # regression that loses several of those matches.
+        assert saturated > 30.0
 
     def test_clean_control_is_zero(self) -> None:
         """The clean control has no antithesis density."""


### PR DESCRIPTION
## Summary
- Broaden `NEGATIVE_PARALLELISM_RE` to detect the dominant AI antithesis tell the old pattern missed: bare parallel-prepositional `not <prep> X but <prep> Y`, uncontracted `it is not … it is …` / `it is not about … it is about …`, cross-sentence subject restatement (`X weren't Y. They were Z`), and em-dash antithesis (`it doesn't … — it …`).
- Retain every existing match (`not only … but [also]`, contracted `it's not X, it's Y`, `no X, no Y, just/but`).
- Keep the tell MID/`surface` with the `_PHRASE_MARGIN=1.5`/1k-word gate — no escalation to a hard gate; saturation (a cluster) fires, a single rhetorical turn does not.

## Calibration against the owner's deliberate antithesis
The bare `not … but …` alternation requires a **shared preposition** (`not through X but through Y`), so a parallel rhetorical antithesis matches while a casual concessive ("Not my best work but it is honest") does not. This keeps the calibration harness (`test_calibration.py`, which uses that exact concessive as a clean-user fixture) green. Because the density feature is vault-relative and surface-only, one deliberate antithesis in a clean paragraph stays under the 1.5/1k-word margin (asserted) while a saturated paragraph clears it (asserted) — we catch saturation, not the occasional turn. The minimal change (broadened regex + the existing margin) was sufficient; no `antithesis_rate` generic prior was needed.

## Test plan
- New `tests/generate/ai_style/test_features.py::TestNegativeParallelismRegex` — each issue #516 reproduction sentence now matches; legacy constructions still match; an ordinary sentence and a bare negation do not.
- New `TestNegativeParallelismDensity` — saturated paragraph scores measurably higher than a clean control; clean control is zero.
- New `tests/generate/ai_style/test_discourse.py` calibration tests — one antithesis below the surface margin does **not** fire; a saturated cluster **does** fire for a plain user.
- No regression in existing `tests/test_ai_style*` / `tests/generate/ai_style/*` discourse-tell tests.
- `cd creek-tools && ./scripts/check-all.sh` → exit 0 (coverage 93.78%, all 12 gates pass, 5047 tests).

Closes #516
Refs #417
