### PR TITLE
fix(ai-style): flag journal-sourcing provenance tells; weave sources in

### DIFF
--- a/creek-tools/creek/author/voice.py
+++ b/creek-tools/creek/author/voice.py
@@ -230,6 +230,10 @@ def _ask_section(
         "Do not assert biographical facts about me that are not present in the "
         "source fragments. You may draw connections between ideas, but never "
         "invent events, my upbringing, or another person's motives.",
+        "Use the source fragments as your own voice and memory. Weave them in as "
+        "your present-tense thinking — never reference that something came from a "
+        "journal, note, or entry, and never narrate that you are quoting "
+        "yourself. State the idea, not its provenance.",
         "Do not quote borrowed authors as my own words.",
     ]
     if contract is not None and contract.structure:

--- a/creek-tools/creek/generate/ai_style/discourse.py
+++ b/creek-tools/creek/generate/ai_style/discourse.py
@@ -7,12 +7,14 @@ collaborative-comm boilerplate. They point at structural habits rather than
 single words, so like the rhetorical tells they are **surface-only**: the
 scanner flags them for review/rewrite, never auto-strips.
 
-Every tell except :data:`KNOWLEDGE_CUTOFF` is **vault-relative** — a writer
-who genuinely loves a triad or opens with "Overall," has a high baseline and
-is not flagged for it. The knowledge-cutoff disclaimer is the exception: it
-fires regardless of the fingerprint (``margin`` and ``generic_prior`` both
-``0``) because phrases like "As of my last knowledge update" are never
-desirable in finished prose, and its caveat carries a fabrication-risk hint.
+Most tells are **vault-relative** — a writer who genuinely loves a triad or
+opens with "Overall," has a high baseline and is not flagged for it. Two are
+the exception: :data:`KNOWLEDGE_CUTOFF` and :data:`PROVENANCE_TELL` fire
+regardless of the fingerprint (``margin`` and ``generic_prior`` both ``0``)
+because phrases like "As of my last knowledge update" or "from one of my
+journals" are never desirable in finished prose. The knowledge-cutoff caveat
+carries a fabrication-risk hint; the provenance caveat steers the draft to
+state the idea, not its journal/note provenance.
 
 Each tell reuses the shared pattern + extractor from
 :mod:`creek.generate.ai_style.features`, so the locator highlights exactly
@@ -127,6 +129,27 @@ KNOWLEDGE_CUTOFF = register(
         "regardless of your fingerprint — verify the claim or cut it.",
         measure=features.knowledge_cutoff_density,
         locate=lambda text: _spans(features.KNOWLEDGE_CUTOFF_RE, text),
+        # Never legitimate: fire on any occurrence, independent of the voice.
+        generic_prior=0.0,
+        margin=0.0,
+    ),
+)
+
+PROVENANCE_TELL = register(
+    Tell(
+        id="provenance_tell",
+        category="discourse",
+        feature_key="provenance_density",
+        handling="surface",
+        polarity="avoid",
+        description="First-person sourcing announcement (my journals, one of them).",
+        caveat="The draft should weave source fragments in as the owner's own "
+        "present-tense thinking, never narrate that something came from a "
+        "journal/note/entry or that it is quoting itself. Never desirable in "
+        "finished prose, so flagged regardless of your fingerprint — state the "
+        "idea, not its provenance.",
+        measure=features.provenance_density,
+        locate=lambda text: _spans(features.PROVENANCE_RE, text),
         # Never legitimate: fire on any occurrence, independent of the voice.
         generic_prior=0.0,
         margin=0.0,

--- a/creek-tools/creek/generate/ai_style/features.py
+++ b/creek-tools/creek/generate/ai_style/features.py
@@ -322,6 +322,30 @@ KNOWLEDGE_CUTOFF_RE = re.compile(
     re.IGNORECASE,
 )
 
+# First-person sourcing / provenance announcements. The model narrates that
+# its prose was retrieved from the owner's journals/notes rather than weaving
+# the material in as the owner's own live thinking (issue #517). Generic-prior
+# tell: these should essentially never appear in finished prose. Kept
+# conservative — match self-referential SOURCING announcements, not ordinary
+# uses of "wrote"/"note" ("I wrote her a letter.", "Note the difference.").
+#   1. ``(in )?my journal(s)/notes/entries`` and the verb ``journaling``.
+#   2. ``I('ve| have)? been writing/journaling`` — narrating the act of
+#      keeping a journal.
+#   3. ``from one of (them|my journals/notes/entries)`` — quoting a source.
+#   4. ``as I wrote (in …)`` / ``one of my (journals|notes|entries)`` — pointing
+#      at a prior written-down source.
+#   5. ``my journals keep …`` — personifying the corpus as a source.
+PROVENANCE_RE = re.compile(
+    r"\bin my (?:journals?|notes|entries)\b"
+    r"|\bmy (?:journals?|notes|entries)\b"
+    r"|\bjournaling\b"
+    r"|\bi(?:'ve| have)? been (?:writing|journaling)\b"
+    r"|\bfrom one of (?:them|my (?:journals?|notes|entries))\b"
+    r"|\bas i wrote\b"
+    r"|\bone of my (?:journals?|notes|entries)\b",
+    re.IGNORECASE,
+)
+
 DIDACTIC_DISCLAIMER_RE = re.compile(
     r"\bit'?s important to note\b"
     r"|\bimportant to note that\b"
@@ -373,6 +397,11 @@ def knowledge_cutoff_density(text: str) -> float:
     return rate_per_kwords(len(KNOWLEDGE_CUTOFF_RE.findall(text)), text)
 
 
+def provenance_density(text: str) -> float:
+    """Return first-person sourcing/provenance announcements per 1000 words."""
+    return rate_per_kwords(len(PROVENANCE_RE.findall(text)), text)
+
+
 def didactic_disclaimer_density(text: str) -> float:
     """Return didactic disclaimers (important to note, may vary) per 1000 words."""
     return rate_per_kwords(len(DIDACTIC_DISCLAIMER_RE.findall(text)), text)
@@ -404,6 +433,7 @@ FINGERPRINT_FEATURES: dict[str, Extractor] = {
     "negative_parallelism_density": negative_parallelism_density,
     "challenges_section_density": challenges_section_density,
     "list_title_lead_density": list_title_lead_density,
+    "provenance_density": provenance_density,
     "didactic_disclaimer_density": didactic_disclaimer_density,
     "section_summary_density": section_summary_density,
     "comm_boilerplate_density": comm_boilerplate_density,

--- a/creek-tools/creek/generate/ai_style/features.py
+++ b/creek-tools/creek/generate/ai_style/features.py
@@ -328,18 +328,21 @@ KNOWLEDGE_CUTOFF_RE = re.compile(
 # tell: these should essentially never appear in finished prose. Kept
 # conservative — match self-referential SOURCING announcements, not ordinary
 # uses of "wrote"/"note" ("I wrote her a letter.", "Note the difference.").
-#   1. ``(in )?my journal(s)/notes/entries`` and the verb ``journaling``.
-#   2. ``I('ve| have)? been writing/journaling`` — narrating the act of
-#      keeping a journal.
+#   1. ``my journal(s)/notes/entries`` and the verb ``journaling`` (the
+#      ``my …`` branch also covers ``in my notes`` via the substring).
+#   2. ``I('ve| have)? been journaling`` / ``… been writing in my
+#      journals/notes/diary`` — narrating the act of keeping a journal as the
+#      source. Bare "been writing" is dropped: it matches ordinary prose
+#      ("I have been writing code.") without announcing a source (#525).
 #   3. ``from one of (them|my journals/notes/entries)`` — quoting a source.
 #   4. ``as I wrote (in …)`` / ``one of my (journals|notes|entries)`` — pointing
 #      at a prior written-down source.
 #   5. ``my journals keep …`` — personifying the corpus as a source.
 PROVENANCE_RE = re.compile(
-    r"\bin my (?:journals?|notes|entries)\b"
-    r"|\bmy (?:journals?|notes|entries)\b"
+    r"\bmy (?:journals?|notes|entries)\b"
     r"|\bjournaling\b"
-    r"|\bi(?:'ve| have)? been (?:writing|journaling)\b"
+    r"|\bi(?:'ve| have)? been journaling\b"
+    r"|\bi(?:'ve| have)? been writing in my (?:journals?|notes?|diary)\b"
     r"|\bfrom one of (?:them|my (?:journals?|notes|entries))\b"
     r"|\bas i wrote\b"
     r"|\bone of my (?:journals?|notes|entries)\b",

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -2302,6 +2302,18 @@ _NO_FABRICATION_STEER = (
     "invent events, my upbringing, or another person's motives."
 )
 
+#: Prompt steer that forbids announcing provenance (issue #517). The model must
+#: weave retrieved source fragments in as the owner's own present-tense thinking
+#: rather than narrating that the prose came from a journal/note/entry or that
+#: it is quoting itself. Appended to every ``## Ask`` variant and pinned by a
+#: structure test so it can never silently drop out of the prompt.
+_NO_PROVENANCE_STEER = (
+    "Use the source fragments as your own voice and memory. Weave them in as "
+    "your present-tense thinking — never reference that something came from a "
+    "journal, note, or entry, and never narrate that you are quoting yourself. "
+    "State the idea, not its provenance."
+)
+
 
 def _compose_ask_section(
     idea: IdeaSeed,
@@ -2319,8 +2331,10 @@ def _compose_ask_section(
     the original wording so existing tests and mined-idea drafts
     continue to compose identically.
 
-    Every variant ends with :data:`_NO_FABRICATION_STEER` so the draft
-    prompt always carries the issue #515 no-fabrication instruction.
+    Every variant ends with :data:`_NO_FABRICATION_STEER` and
+    :data:`_NO_PROVENANCE_STEER` so the draft prompt always carries the
+    issue #515 no-fabrication instruction and the issue #517 weave-the-source-in
+    instruction.
     """
     if twist:
         return (
@@ -2333,7 +2347,7 @@ def _compose_ask_section(
             "verbatim — recombine across the corpus. Honour the "
             "activated skills. Write as the human — not as an AI. "
             "Cite source fragments by their IDs where relevant. "
-            f"{_NO_FABRICATION_STEER}"
+            f"{_NO_FABRICATION_STEER} {_NO_PROVENANCE_STEER}"
         )
     if per_dimension:
         return (
@@ -2345,7 +2359,7 @@ def _compose_ask_section(
             "rather than treating any one section as the source of "
             "truth. Honour the activated skills. Write as the human — "
             "not as an AI. Cite source fragments by their IDs where "
-            f"relevant. {_NO_FABRICATION_STEER}"
+            f"relevant. {_NO_FABRICATION_STEER} {_NO_PROVENANCE_STEER}"
         )
     return (
         "## Ask\n"
@@ -2353,7 +2367,7 @@ def _compose_ask_section(
         f"{idea.brief_description} "
         "Write as the human — not as an AI. Honour the activated "
         f"skills. Cite source fragments by their IDs where relevant. "
-        f"{_NO_FABRICATION_STEER}"
+        f"{_NO_FABRICATION_STEER} {_NO_PROVENANCE_STEER}"
     )
 
 

--- a/creek-tools/tests/generate/ai_style/test_discourse.py
+++ b/creek-tools/tests/generate/ai_style/test_discourse.py
@@ -86,9 +86,19 @@ class TestProvenanceTellIsFingerprintIndependent:
         text = "I've been journaling about this."
         assert _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell")
 
+    def test_been_writing_in_my_journal(self) -> None:
+        """'I have been writing in my journal.' names a source; flagged."""
+        text = "I have been writing in my journal."
+        assert _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell")
+
     def test_coming_back_to_this_in_my_notes(self) -> None:
         """'I keep coming back to this in my notes.' is flagged."""
         text = "I keep coming back to this in my notes."
+        assert _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell")
+
+    def test_in_my_journals_still_matches_via_my_branch(self) -> None:
+        """'in my journals' still fires via the 'my …' branch (#525)."""
+        text = "I keep coming back to this in my journals."
         assert _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell")
 
 
@@ -112,6 +122,20 @@ class TestProvenanceTellFalsePositiveGuard:
     def test_note_in_non_sourcing_sense_not_flagged(self) -> None:
         """'Note the difference.' uses 'note' as an imperative; no fire."""
         text = "Note the difference between the two readings."
+        assert not _fired(
+            scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell"
+        )
+
+    def test_been_writing_code_not_flagged(self) -> None:
+        """'I have been writing code.' is ordinary prose, not sourcing (#525)."""
+        text = "I have been writing code."
+        assert not _fired(
+            scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell"
+        )
+
+    def test_been_writing_tests_not_flagged(self) -> None:
+        """\"I've been writing tests all morning.\" is not sourcing (#525)."""
+        text = "I've been writing tests all morning."
         assert not _fired(
             scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell"
         )

--- a/creek-tools/tests/generate/ai_style/test_discourse.py
+++ b/creek-tools/tests/generate/ai_style/test_discourse.py
@@ -39,7 +39,7 @@ def _message(report, tell_id: str) -> str:
 
 
 def test_discourse_tells_registered_and_surface() -> None:
-    """All eight discourse tells are registered and surface-handled."""
+    """All nine discourse tells are registered and surface-handled."""
     tells = {t.id: t for t in get_tells(["discourse"])}
     assert {
         "negative_parallelism",
@@ -50,8 +50,71 @@ def test_discourse_tells_registered_and_surface() -> None:
         "didactic_disclaimer",
         "section_summary",
         "comm_boilerplate",
+        "provenance_tell",
     } <= set(tells)
     assert all(tells[t].handling == "surface" for t in tells)
+
+
+class TestProvenanceTellIsFingerprintIndependent:
+    """First-person sourcing/provenance announcements fire regardless of voice.
+
+    These are a generic-prior tell: phrases that narrate that prose came from
+    the owner's journals/notes/entries should essentially never appear in
+    finished prose, so they fire even for an ornate baseline (issue #517).
+    """
+
+    def test_fires_for_plain_and_ornate(self) -> None:
+        """It fires for an ornate user too; provenance narration is never wanted."""
+        text = "My journals keep circling this. From one of them: it is true."
+        assert _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell")
+        assert _fired(
+            scan(text, fingerprint=_ORNATE, config=_CONFIG), "provenance_tell"
+        )
+
+    def test_my_journals_keep_circling(self) -> None:
+        """'My journals keep circling this.' is flagged."""
+        text = "My journals keep circling this."
+        assert _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell")
+
+    def test_from_one_of_them(self) -> None:
+        """'From one of them:' is flagged."""
+        text = "From one of them: the work is to be findable."
+        assert _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell")
+
+    def test_been_journaling_about_this(self) -> None:
+        """\"I've been journaling about this.\" is flagged."""
+        text = "I've been journaling about this."
+        assert _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell")
+
+    def test_coming_back_to_this_in_my_notes(self) -> None:
+        """'I keep coming back to this in my notes.' is flagged."""
+        text = "I keep coming back to this in my notes."
+        assert _fired(scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell")
+
+
+class TestProvenanceTellFalsePositiveGuard:
+    """Clean prose that expresses the idea without naming a source must not fire."""
+
+    def test_same_idea_without_source_not_flagged(self) -> None:
+        """The bare thought, with no journal/note reference, does not fire."""
+        text = "I keep coming back to this. It will not let me go."
+        assert not _fired(
+            scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell"
+        )
+
+    def test_wrote_in_non_sourcing_sense_not_flagged(self) -> None:
+        """'I wrote her a letter.' uses 'wrote' in an ordinary sense; no fire."""
+        text = "I wrote her a letter. We talked for hours."
+        assert not _fired(
+            scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell"
+        )
+
+    def test_note_in_non_sourcing_sense_not_flagged(self) -> None:
+        """'Note the difference.' uses 'note' as an imperative; no fire."""
+        text = "Note the difference between the two readings."
+        assert not _fired(
+            scan(text, fingerprint=_PLAIN, config=_CONFIG), "provenance_tell"
+        )
 
 
 class TestVaultRelative:

--- a/creek-tools/tests/generate/ai_style/test_features.py
+++ b/creek-tools/tests/generate/ai_style/test_features.py
@@ -177,4 +177,4 @@ def test_registry_exposes_all_extractors() -> None:
     assert "em_dash_density" in FINGERPRINT_FEATURES
     assert FINGERPRINT_FEATURES["ai_vocab_density"] is ai_vocab_density
     assert FINGERPRINT_FEATURES["concrete_density"] is concrete_density
-    assert len(FINGERPRINT_FEATURES) == 18
+    assert len(FINGERPRINT_FEATURES) == 19

--- a/creek-tools/tests/test_biographical_grounding.py
+++ b/creek-tools/tests/test_biographical_grounding.py
@@ -483,3 +483,41 @@ class TestPromptSteer:
         """The voice agent's ``## Ask`` block carries the steer."""
         section = _ask_section("What is Christ?", None, None)
         assert _STEER_PHRASE in section
+
+
+_PROVENANCE_PHRASE = (
+    "never reference that something came from a journal, note, or entry"
+)
+
+
+class TestProvenanceSteer:
+    """The weave-the-source-in steer is pinned into both prompt surfaces (#517)."""
+
+    def test_draft_ask_carries_provenance_steer_in_every_mode(self) -> None:
+        """Every ``_compose_ask_section`` variant carries the provenance steer."""
+        from creek.generate.drafts import _NO_PROVENANCE_STEER
+        from creek.generate.mining import IdeaSeed, MiningStrategy
+
+        idea = IdeaSeed(
+            strategy=MiningStrategy.RESONANCE_CHAIN,
+            title="Christ",
+            source_fragments=("frag-a",),
+            threads=(),
+            eddies=(),
+            frequency_affinity=(),
+            brief_description="A draft about the pattern.",
+            score=0.8,
+        )
+        for kwargs in (
+            {"per_dimension": False},
+            {"per_dimension": True},
+            {"per_dimension": False, "twist": True},
+        ):
+            section = _compose_ask_section(idea, **kwargs)
+            assert _PROVENANCE_PHRASE in section
+        assert _PROVENANCE_PHRASE in _NO_PROVENANCE_STEER
+
+    def test_voice_ask_carries_provenance_steer(self) -> None:
+        """The voice agent's ``## Ask`` block carries the provenance steer."""
+        section = _ask_section("What is Christ?", None, None)
+        assert _PROVENANCE_PHRASE in section


### PR DESCRIPTION
## Summary
- Add a `provenance_tell` discourse detector that flags first-person sourcing/provenance announcements ("My journals keep circling this.", "From one of them:") — a generic-prior tell that fires regardless of the voice fingerprint, mirroring `knowledge_cutoff`.
- Add a `_NO_PROVENANCE_STEER` instruction to BOTH `## Ask` builders (`drafts._compose_ask_section` and `author.voice._ask_section`) telling the model to weave source fragments in as the owner's own present-tense thinking and state the idea, not its provenance.

## Test plan
- `cd creek-tools && ./scripts/check-all.sh` → exit 0 (5059 passed; coverage 93.78%; ruff/mypy/interrogate/complexity/security all green).
- New tests (TDD, written first): the four reproduction phrases flag ("My journals keep circling this.", "From one of them:", "I've been journaling about this.", "I keep coming back to this in my notes."); false-positive guards confirm the bare idea ("I keep coming back to this.") and ordinary "wrote"/"note" uses ("I wrote her a letter.", "Note the difference.") do NOT flag.
- Structure tests pin the new steer in all three draft `## Ask` modes and the voice agent `## Ask`.
- No regression in existing discourse-tell tests; `FINGERPRINT_FEATURES` count bumped 18 → 19.

Closes #517
Refs #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
