### PR TITLE
feat(voice): add opt-in no-fabrication cohesion pass for single-topic drafts

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2362,6 +2362,18 @@ def draft(
             "rewrite pass (no extra network hop)."
         ),
     ),
+    cohesion: bool = typer.Option(
+        False,
+        "--cohesion",
+        help=(
+            "Opt in to the no-fabrication cohesion pass (issue #518): after "
+            "composing a single-topic draft, run an LLM pass that smooths "
+            "abrupt seams with transitions. A deterministic entity-preservation "
+            "guard rejects any output that introduces a new proper noun, "
+            "number, or ontology term, falling back to the original body. "
+            "Default off; requires the LLM, so it is skipped under --no-llm."
+        ),
+    ),
 ) -> None:
     """Draft an essay from a mined idea with the activated skill stack.
 
@@ -2407,7 +2419,11 @@ def draft(
     skills_dir = skills_root if skills_root is not None else vault_path / "creek-skills"
     current_phase = _parse_phase(phase)
     voice_text = _read_voice_core(voice_core)
-    ai_style = _load_config_for_vault(vault).ai_style
+    vault_config = _load_config_for_vault(vault)
+    ai_style = vault_config.ai_style
+    # The --cohesion flag opts the run in; draft.cohesion persists the default
+    # in config (default False). Either turning it on enables the pass (#518).
+    cohesion_enabled = cohesion or vault_config.draft.cohesion
     fingerprint = load_fingerprint(vault_path, ai_style)
     style_preamble = build_style_preamble(fingerprint, ai_style)
     override = _parse_include_tier(include_tier)
@@ -2439,6 +2455,7 @@ def draft(
         fingerprint=fingerprint,
         ai_style_config=ai_style,
         voice_guard_no_llm=no_llm,
+        cohesion=cohesion_enabled,
     )
 
     if outline_text is not None:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2366,7 +2366,7 @@ def draft(
         False,
         "--cohesion",
         help=(
-            "Opt in to the no-fabrication cohesion pass (issue #518): after "
+            "Opt in to the no-fabrication cohesion pass: after "
             "composing a single-topic draft, run an LLM pass that smooths "
             "abrupt seams with transitions. A deterministic entity-preservation "
             "guard rejects any output that introduces a new proper noun, "
@@ -2421,8 +2421,6 @@ def draft(
     voice_text = _read_voice_core(voice_core)
     vault_config = _load_config_for_vault(vault)
     ai_style = vault_config.ai_style
-    # The --cohesion flag opts the run in; draft.cohesion persists the default
-    # in config (default False). Either turning it on enables the pass (#518).
     cohesion_enabled = cohesion or vault_config.draft.cohesion
     fingerprint = load_fingerprint(vault_path, ai_style)
     style_preamble = build_style_preamble(fingerprint, ai_style)

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -765,6 +765,19 @@ class DraftConfig(BaseModel):
     CLI flag overrides it per invocation. A draft cut off at this ceiling
     is flagged ``truncated`` in frontmatter and warned about on stderr."""
 
+    cohesion: bool = Field(default=False)
+    """Opt-in switch for the no-fabrication cohesion pass (issue #518).
+
+    Default ``False`` so merging the pass changes no current behaviour: a
+    single-topic draft is composed exactly as before unless the operator
+    passes ``creek draft --cohesion`` (or sets this to ``true`` in
+    ``draft:``). When enabled — and only with the LLM available, never on
+    the ``--no-llm`` path — a post-composition pass smooths abrupt seams by
+    inserting transitions. The rewrite is gated by a deterministic
+    entity-preservation guard (no new proper noun, number, or bespoke
+    ontology term) plus a biographical-grounding re-check; any violation
+    falls back to the pre-cohesion body."""
+
 
 AIStyleCategory = Literal[
     "mechanical",

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -766,7 +766,7 @@ class DraftConfig(BaseModel):
     is flagged ``truncated`` in frontmatter and warned about on stderr."""
 
     cohesion: bool = Field(default=False)
-    """Opt-in switch for the no-fabrication cohesion pass (issue #518).
+    """Opt-in switch for the no-fabrication cohesion pass.
 
     Default ``False`` so merging the pass changes no current behaviour: a
     single-topic draft is composed exactly as before unless the operator

--- a/creek-tools/creek/generate/cohesion.py
+++ b/creek-tools/creek/generate/cohesion.py
@@ -1,0 +1,234 @@
+"""No-fabrication cohesion pass for single-topic drafts (issue #518).
+
+Single-topic drafts often read as disjointed — sections sit next to each
+other with abrupt seams and no connective tissue. This module adds an
+*opt-in* cohesion pass that asks the LLM to smooth those seams by inserting
+transitions, under a hard anti-fabrication constraint: it may introduce no
+new named entities, numbers, claims, events, or facts. Transitions only.
+
+The load-bearing, deterministic part is the **entity-preservation guard**
+(:func:`is_entity_preserving`): a pure function that compares the set of
+preservable tokens — proper nouns, numbers, and the owner's bespoke
+ontology terms — in the pre-cohesion text against the post-cohesion text.
+If the post text introduces any token absent before, the cohesion output
+is rejected and the caller falls back to the original body. Adding bridge
+words is fine; adding a new entity/number/fact is not.
+
+The pass is **default-off**: it runs only when explicitly enabled and a
+cohesion LLM is wired (it requires the LLM, so the ``--no-llm`` path skips
+it entirely). It mirrors the spirit of
+:func:`creek.generate.outline.format_stitch_directive` (content-frozen
+transitions) but allows light cross-seam smoothing of the owner's own
+voice — still no new content.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+
+#: Callable ``(prompt) -> body`` for the cohesion LLM hop. Reuses the draft
+#: LLM's plain-string contract so the same provider seam (and the same test
+#: stubs) drive it.
+CohesionLLM = Callable[[str], str]
+
+#: Callable ``(body) -> findings`` for the post-cohesion grounding re-check.
+#: Returns a non-empty sequence when the smoothed body smuggled in an
+#: ungrounded first-person claim (#515); the pass then falls back.
+GroundingCheck = Callable[[str], Sequence[object]]
+
+
+# A token worth preserving is either a number (a run of digits, optionally
+# with internal separators) or a "proper-noun" word: a capitalized word that
+# is NOT merely capitalized because it opens a sentence. We capture every
+# capitalized word here and discard sentence-initial ones in a second pass so
+# transition openers ("However,") never register as entities.
+_NUMBER_RE = re.compile(r"\b\d[\d,.]*\b")
+_WORD_RE = re.compile(r"\b[A-Za-z][A-Za-z'-]*\b")
+_SENTENCE_BOUNDARY_RE = re.compile(r"(?<=[.!?:;])\s+|\n+")
+
+
+def _capitalized_proper_nouns(text: str) -> set[str]:
+    """Return lowercased capitalized words that are not sentence-initial.
+
+    A word capitalized only because it opens a sentence (or the whole text)
+    is ordinary prose, not a named entity — excluding it keeps transition
+    openers like "However," from registering as fabricated entities. Every
+    other capitalized word is treated as a proper noun to preserve.
+    """
+    proper: set[str] = set()
+    for segment in _SENTENCE_BOUNDARY_RE.split(text):
+        stripped = segment.strip()
+        if not stripped:
+            continue
+        words = _WORD_RE.findall(stripped)
+        # Skip the first word of each sentence: its capital may be positional.
+        for word in words[1:]:
+            if word[0].isupper():
+                proper.add(word.lower())
+    return proper
+
+
+def extract_preservable_tokens(
+    text: str,
+    *,
+    bespoke_terms: Sequence[str] = (),
+) -> set[str]:
+    """Return the set of fabrication-sensitive tokens in *text*.
+
+    The set is the union of three families, all lowercased for a
+    case-insensitive comparison:
+
+    * **Numbers** — any run of digits. A new number is a new fact (a year,
+      a count, an age) and must not appear post-cohesion if it was absent.
+    * **Proper nouns** — capitalized words that are not merely
+      sentence-initial (see :func:`_capitalized_proper_nouns`). Names,
+      places, titles, brands.
+    * **Bespoke ontology terms** — the owner's vocabulary (Fragment,
+      Resonance, Thread, Eddy, Praxis, …) supplied by the caller, matched
+      case-insensitively on word boundaries even when lowercased in prose.
+
+    Args:
+        text: The body to scan.
+        bespoke_terms: Owner ontology terms to treat as preservable even
+            when they appear lowercased.
+
+    Returns:
+        A lowercased token set suitable for set-difference comparison.
+    """
+    tokens = _capitalized_proper_nouns(text)
+    tokens.update(_NUMBER_RE.findall(text))
+    lowered = text.lower()
+    for term in bespoke_terms:
+        term_lc = term.lower()
+        if re.search(rf"\b{re.escape(term_lc)}\b", lowered):
+            tokens.add(term_lc)
+    return tokens
+
+
+def is_entity_preserving(
+    *,
+    pre: str,
+    post: str,
+    bespoke_terms: Sequence[str] = (),
+) -> bool:
+    """Return whether *post* introduces no new preservable token over *pre*.
+
+    The deterministic, LLM-free heart of the cohesion guard. The cohesion
+    pass may freely *add transition words* and may even *drop* an entity,
+    but it must never **introduce** a proper noun, number, or bespoke
+    ontology term that the pre-cohesion text did not already contain — that
+    would be a fabricated named entity, date, or fact.
+
+    Args:
+        pre: The body before the cohesion rewrite.
+        post: The body the cohesion LLM returned.
+        bespoke_terms: Owner ontology terms to guard alongside proper nouns
+            and numbers.
+
+    Returns:
+        ``True`` when ``post``'s preservable-token set is a subset of
+        ``pre``'s (transitions-only); ``False`` when ``post`` added at least
+        one new token.
+    """
+    pre_tokens = extract_preservable_tokens(pre, bespoke_terms=bespoke_terms)
+    post_tokens = extract_preservable_tokens(post, bespoke_terms=bespoke_terms)
+    return post_tokens <= pre_tokens
+
+
+def format_cohesion_directive() -> str:
+    """Render the transitions-only directive for the cohesion pass.
+
+    Mirrors :func:`creek.generate.outline.format_stitch_directive` but for a
+    single-topic body: it permits light cross-seam smoothing of the owner's
+    own voice while forbidding any new content. The anti-fabrication
+    sentence is load-bearing — the deterministic guard enforces it, and the
+    directive tells the model the rule up front so it does not waste a hop
+    producing output that will be rejected.
+
+    Returns:
+        A markdown ``## Cohesion directive`` block.
+    """
+    return (
+        "## Cohesion directive\n"
+        "The draft below is a single essay whose sections were composed "
+        "with abrupt seams between them. Your only job is to make it read "
+        "as one continuous piece: add short transition sentences between "
+        "sections and lightly smooth the connective phrasing in the owner's "
+        "own voice. Introduce NO new named entities, numbers, dates, claims, "
+        "events, or facts — transitions only. Do not add a person, place, "
+        "title, or number that is not already present. Keep every existing "
+        "sentence's substance; you may add bridging phrases and nothing more."
+    )
+
+
+def build_cohesion_prompt(body: str, *, voice_core: str = "") -> str:
+    """Assemble the cohesion-pass prompt from a composed *body*.
+
+    Args:
+        body: The already-composed single-topic draft body to smooth.
+        voice_core: Optional voice-core description prepended so the
+            transitions are smoothed in the owner's voice; empty to omit.
+
+    Returns:
+        The full prompt: optional voice core, the cohesion directive, then
+        the body to smooth.
+    """
+    parts: list[str] = []
+    if voice_core.strip():
+        parts.append(f"## Voice core\n{voice_core.strip()}")
+    parts.extend(
+        (format_cohesion_directive(), f"## Draft to smooth\n{body}"),
+    )
+    return "\n\n".join(parts)
+
+
+def run_cohesion_pass(
+    body: str,
+    *,
+    cohesion_llm: CohesionLLM | None,
+    enabled: bool,
+    grounding_check: GroundingCheck,
+    voice_core: str = "",
+    bespoke_terms: Sequence[str] = (),
+) -> str:
+    """Run the opt-in cohesion pass, returning the smoothed or original body.
+
+    The pass is conservative by construction — any failure mode falls back
+    to *body* unchanged:
+
+    #. **Disabled / no LLM.** When ``enabled`` is ``False`` or
+       ``cohesion_llm`` is ``None`` (the deterministic ``--no-llm`` path),
+       the original body is returned and the LLM is never called.
+    #. **Empty output.** A blank cohesion response falls back rather than
+       blanking the draft.
+    #. **Fabricated entity.** When :func:`is_entity_preserving` rejects the
+       output — a new proper noun, number, or bespoke term appeared — the
+       original body is returned.
+    #. **Ungrounded claim.** When *grounding_check* flags the smoothed body
+       (a smuggled first-person biographical claim, #515), the original body
+       is returned.
+
+    Args:
+        body: The composed single-topic draft body.
+        cohesion_llm: The cohesion LLM seam, or ``None`` to skip the pass.
+        enabled: The opt-in flag; the pass is a no-op when ``False``.
+        grounding_check: Callable re-running the biographical grounding flag
+            on the smoothed body; a non-empty return triggers fallback.
+        voice_core: Optional voice-core text for the prompt.
+        bespoke_terms: Owner ontology terms guarded alongside proper nouns
+            and numbers.
+
+    Returns:
+        The smoothed body when every guard passes; otherwise *body*.
+    """
+    if not enabled or cohesion_llm is None:
+        return body
+    smoothed = cohesion_llm(build_cohesion_prompt(body, voice_core=voice_core)).strip()
+    if not smoothed:
+        return body
+    if not is_entity_preserving(pre=body, post=smoothed, bespoke_terms=bespoke_terms):
+        return body
+    if grounding_check(smoothed):
+        return body
+    return smoothed

--- a/creek-tools/creek/generate/cohesion.py
+++ b/creek-tools/creek/generate/cohesion.py
@@ -47,6 +47,28 @@ GroundingCheck = Callable[[str], Sequence[object]]
 _NUMBER_RE = re.compile(r"\b\d[\d,.]*\b")
 _WORD_RE = re.compile(r"\b[A-Za-z][A-Za-z'-]*\b")
 _SENTENCE_BOUNDARY_RE = re.compile(r"(?<=[.!?:;])\s+|\n+")
+#: A markdown header line (one to six leading ``#`` and the following text).
+#: Header text is structural, not prose, so it is excluded from proper-noun
+#: extraction — see :func:`_capitalized_proper_nouns`.
+_HEADER_LINE_RE = re.compile(r"^[ \t]*#{1,6}[ \t]+.*$", re.MULTILINE)
+#: Count of ``## `` (and deeper) top-level section headers in a body. Two or
+#: more means a multi-section outline draft, which the cohesion pass must skip.
+_SECTION_HEADER_RE = re.compile(r"^[ \t]*#{2,6}[ \t]+\S", re.MULTILINE)
+#: Minimum top-level section headers that mark a body as a multi-section
+#: outline draft (and so out of scope for the single-topic cohesion pass).
+_MULTI_SECTION_THRESHOLD = 2
+
+
+def _strip_header_lines(text: str) -> str:
+    """Blank out markdown header lines so their words are not scanned.
+
+    A header like ``## Rising Tide`` is structural, not prose; its title-cased
+    words ("Rising", "Tide") would otherwise register as fabricated proper
+    nouns when only one of pre/post happens to contain the header. Replacing
+    each header line with an empty line (preserving line count) removes that
+    structural noise before proper-noun extraction.
+    """
+    return _HEADER_LINE_RE.sub("", text)
 
 
 def _capitalized_proper_nouns(text: str) -> set[str]:
@@ -56,9 +78,12 @@ def _capitalized_proper_nouns(text: str) -> set[str]:
     is ordinary prose, not a named entity — excluding it keeps transition
     openers like "However," from registering as fabricated entities. Every
     other capitalized word is treated as a proper noun to preserve.
+
+    Markdown header lines (``^#{1,6}\\s+…``) are stripped first so structural,
+    title-cased header words are never captured as preservable proper nouns.
     """
     proper: set[str] = set()
-    for segment in _SENTENCE_BOUNDARY_RE.split(text):
+    for segment in _SENTENCE_BOUNDARY_RE.split(_strip_header_lines(text)):
         stripped = segment.strip()
         if not stripped:
             continue
@@ -74,25 +99,50 @@ def extract_preservable_tokens(
     text: str,
     *,
     bespoke_terms: Sequence[str] = (),
+    capitalized_terms: Sequence[str] = (),
 ) -> set[str]:
     """Return the set of fabrication-sensitive tokens in *text*.
 
-    The set is the union of three families, all lowercased for a
+    The set is the union of four families, all lowercased for a
     case-insensitive comparison:
 
     * **Numbers** — any run of digits. A new number is a new fact (a year,
       a count, an age) and must not appear post-cohesion if it was absent.
     * **Proper nouns** — capitalized words that are not merely
       sentence-initial (see :func:`_capitalized_proper_nouns`). Names,
-      places, titles, brands.
-    * **Bespoke ontology terms** — the owner's vocabulary (Fragment,
-      Resonance, Thread, Eddy, Praxis, …) supplied by the caller, matched
-      case-insensitively on word boundaries even when lowercased in prose.
+      places, titles, brands. Markdown header lines are excluded so
+      structural header words are not captured.
+    * **Distinctive bespoke terms** — the owner's *distinctive* vocabulary
+      (APTITUDE, Praxis, Wavelength, Resonance, Fragment, …) supplied via
+      ``bespoke_terms``, matched **case-insensitively** on word boundaries
+      even when lowercased in prose, because lowercasing them in prose is
+      still an unambiguous ontology reference.
+    * **Capitalized common terms** — ontology words that are *also* common
+      English words (Thread, Eddy and their plurals) supplied via
+      ``capitalized_terms``, matched **case-sensitively** so only their
+      Capitalized ontological form is guarded. A lowercase "eddies of
+      thought" transition is ordinary prose and is intentionally NOT
+      captured here; a capitalized ``Eddy`` is caught here (and would also
+      be caught as a proper noun).
+
+    Known limitations (intentional, documented):
+
+    * **Allcaps terms.** A distinctive allcaps term like ``APTITUDE`` is
+      captured both as a bespoke term and (incidentally) by the proper-noun
+      pass; this double-capture is harmless and intentional — allcaps tokens
+      are always treated as preservable.
+    * **Compound proper nouns.** A multi-word name like "New York" is split
+      into separate tokens ("new", "york"). The guard therefore preserves
+      the *parts* rather than the phrase; introducing either part anew is
+      still rejected, so the anti-fabrication contract holds, but the guard
+      does not model the compound as a single unit.
 
     Args:
         text: The body to scan.
-        bespoke_terms: Owner ontology terms to treat as preservable even
-            when they appear lowercased.
+        bespoke_terms: Distinctive owner ontology terms to treat as
+            preservable even when they appear lowercased (case-insensitive).
+        capitalized_terms: Common-word ontology terms guarded only in their
+            Capitalized ontological form (case-sensitive).
 
     Returns:
         A lowercased token set suitable for set-difference comparison.
@@ -104,6 +154,9 @@ def extract_preservable_tokens(
         term_lc = term.lower()
         if re.search(rf"\b{re.escape(term_lc)}\b", lowered):
             tokens.add(term_lc)
+    for term in capitalized_terms:
+        if re.search(rf"\b{re.escape(term)}\b", text):
+            tokens.add(term.lower())
     return tokens
 
 
@@ -112,6 +165,7 @@ def is_entity_preserving(
     pre: str,
     post: str,
     bespoke_terms: Sequence[str] = (),
+    capitalized_terms: Sequence[str] = (),
 ) -> bool:
     """Return whether *post* introduces no new preservable token over *pre*.
 
@@ -124,16 +178,22 @@ def is_entity_preserving(
     Args:
         pre: The body before the cohesion rewrite.
         post: The body the cohesion LLM returned.
-        bespoke_terms: Owner ontology terms to guard alongside proper nouns
-            and numbers.
+        bespoke_terms: Distinctive owner ontology terms to guard
+            case-insensitively alongside proper nouns and numbers.
+        capitalized_terms: Common-word ontology terms guarded only in their
+            Capitalized ontological form (case-sensitive).
 
     Returns:
         ``True`` when ``post``'s preservable-token set is a subset of
         ``pre``'s (transitions-only); ``False`` when ``post`` added at least
         one new token.
     """
-    pre_tokens = extract_preservable_tokens(pre, bespoke_terms=bespoke_terms)
-    post_tokens = extract_preservable_tokens(post, bespoke_terms=bespoke_terms)
+    pre_tokens = extract_preservable_tokens(
+        pre, bespoke_terms=bespoke_terms, capitalized_terms=capitalized_terms
+    )
+    post_tokens = extract_preservable_tokens(
+        post, bespoke_terms=bespoke_terms, capitalized_terms=capitalized_terms
+    )
     return post_tokens <= pre_tokens
 
 
@@ -197,6 +257,16 @@ def _warn_cohesion_fallback(reason: str) -> None:
     print(f"cohesion guard: {reason}; kept pre-cohesion body", file=sys.stderr)
 
 
+def _is_multi_section(body: str) -> bool:
+    """Return whether *body* has 2+ top-level section headers.
+
+    Two or more ``## `` (or deeper) headers mark a multi-section outline
+    draft, which carries its own seam stitch and must NOT be cohesion-smoothed
+    across its section boundaries (see :func:`run_cohesion_pass`).
+    """
+    return len(_SECTION_HEADER_RE.findall(body)) >= _MULTI_SECTION_THRESHOLD
+
+
 def run_cohesion_pass(
     body: str,
     *,
@@ -205,8 +275,18 @@ def run_cohesion_pass(
     grounding_check: GroundingCheck,
     voice_core: str = "",
     bespoke_terms: Sequence[str] = (),
+    capitalized_terms: Sequence[str] = (),
 ) -> str:
     """Run the opt-in cohesion pass, returning the smoothed or original body.
+
+    **Single-topic contract.** This pass operates on a **single-topic body**.
+    It must NOT be used on a multi-section outline draft (the
+    :func:`~creek.generate.outline` / ``compose_outline_draft`` path), which
+    carries its own content-frozen seam stitch — smoothing across section
+    seams here would blur deliberately distinct sections. As a defensive
+    guard, a body with two or more top-level ``## `` headers is detected as
+    multi-section and the pass no-ops (returning *body* unchanged) with a
+    ``cohesion guard: … multi-section`` stderr diagnostic.
 
     The pass is conservative by construction — any failure mode falls back
     to *body* unchanged:
@@ -214,6 +294,9 @@ def run_cohesion_pass(
     #. **Disabled / no LLM.** When ``enabled`` is ``False`` or
        ``cohesion_llm`` is ``None`` (the deterministic ``--no-llm`` path),
        the original body is returned and the LLM is never called.
+    #. **Multi-section body.** When the body has 2+ top-level ``## ``
+       headers it is an outline draft, out of scope; the pass no-ops before
+       the LLM is called.
     #. **Empty output.** A blank cohesion response falls back rather than
        blanking the draft.
     #. **Fabricated entity.** When :func:`is_entity_preserving` rejects the
@@ -223,9 +306,10 @@ def run_cohesion_pass(
        (a smuggled first-person biographical claim), the original body
        is returned.
 
-    Each fallback (empty response, fabricated entity, ungrounded claim) emits
-    a brief ``cohesion guard:`` warning on stderr so an operator who opted into
-    the pass learns why it had no effect. The return contract is unchanged.
+    Each fallback (multi-section skip, empty response, fabricated entity,
+    ungrounded claim) emits a brief ``cohesion guard:`` warning on stderr so an
+    operator who opted into the pass learns why it had no effect. The return
+    contract is unchanged.
 
     Args:
         body: The composed single-topic draft body.
@@ -234,19 +318,29 @@ def run_cohesion_pass(
         grounding_check: Callable re-running the biographical grounding flag
             on the smoothed body; a non-empty return triggers fallback.
         voice_core: Optional voice-core text for the prompt.
-        bespoke_terms: Owner ontology terms guarded alongside proper nouns
-            and numbers.
+        bespoke_terms: Distinctive owner ontology terms guarded
+            case-insensitively alongside proper nouns and numbers.
+        capitalized_terms: Common-word ontology terms guarded only in their
+            Capitalized ontological form (case-sensitive).
 
     Returns:
         The smoothed body when every guard passes; otherwise *body*.
     """
     if not enabled or cohesion_llm is None:
         return body
+    if _is_multi_section(body):
+        _warn_cohesion_fallback("skipped multi-section body (outline draft)")
+        return body
     smoothed = cohesion_llm(build_cohesion_prompt(body, voice_core=voice_core)).strip()
     if not smoothed:
         _warn_cohesion_fallback("empty cohesion response")
         return body
-    if not is_entity_preserving(pre=body, post=smoothed, bespoke_terms=bespoke_terms):
+    if not is_entity_preserving(
+        pre=body,
+        post=smoothed,
+        bespoke_terms=bespoke_terms,
+        capitalized_terms=capitalized_terms,
+    ):
         _warn_cohesion_fallback("cohesion output introduced a new entity/number/term")
         return body
     if grounding_check(smoothed):

--- a/creek-tools/creek/generate/cohesion.py
+++ b/creek-tools/creek/generate/cohesion.py
@@ -1,4 +1,4 @@
-"""No-fabrication cohesion pass for single-topic drafts (issue #518).
+"""No-fabrication cohesion pass for single-topic drafts.
 
 Single-topic drafts often read as disjointed — sections sit next to each
 other with abrupt seams and no connective tissue. This module adds an
@@ -25,6 +25,7 @@ voice — still no new content.
 from __future__ import annotations
 
 import re
+import sys
 from collections.abc import Callable, Sequence
 
 #: Callable ``(prompt) -> body`` for the cohesion LLM hop. Reuses the draft
@@ -34,7 +35,7 @@ CohesionLLM = Callable[[str], str]
 
 #: Callable ``(body) -> findings`` for the post-cohesion grounding re-check.
 #: Returns a non-empty sequence when the smoothed body smuggled in an
-#: ungrounded first-person claim (#515); the pass then falls back.
+#: ungrounded first-person claim; the pass then falls back.
 GroundingCheck = Callable[[str], Sequence[object]]
 
 
@@ -183,6 +184,19 @@ def build_cohesion_prompt(body: str, *, voice_core: str = "") -> str:
     return "\n\n".join(parts)
 
 
+def _warn_cohesion_fallback(reason: str) -> None:
+    """Print a brief cohesion-guard fallback diagnostic to stderr.
+
+    Mirrors the ``grounding guard:`` stderr warnings emitted by the draft
+    grounding checks so an operator who opted into ``--cohesion`` learns *why*
+    the pass had no effect.
+
+    Args:
+        reason: A short phrase naming which guard rejected the output.
+    """
+    print(f"cohesion guard: {reason}; kept pre-cohesion body", file=sys.stderr)
+
+
 def run_cohesion_pass(
     body: str,
     *,
@@ -206,8 +220,12 @@ def run_cohesion_pass(
        output — a new proper noun, number, or bespoke term appeared — the
        original body is returned.
     #. **Ungrounded claim.** When *grounding_check* flags the smoothed body
-       (a smuggled first-person biographical claim, #515), the original body
+       (a smuggled first-person biographical claim), the original body
        is returned.
+
+    Each fallback (empty response, fabricated entity, ungrounded claim) emits
+    a brief ``cohesion guard:`` warning on stderr so an operator who opted into
+    the pass learns why it had no effect. The return contract is unchanged.
 
     Args:
         body: The composed single-topic draft body.
@@ -226,9 +244,12 @@ def run_cohesion_pass(
         return body
     smoothed = cohesion_llm(build_cohesion_prompt(body, voice_core=voice_core)).strip()
     if not smoothed:
+        _warn_cohesion_fallback("empty cohesion response")
         return body
     if not is_entity_preserving(pre=body, post=smoothed, bespoke_terms=bespoke_terms):
+        _warn_cohesion_fallback("cohesion output introduced a new entity/number/term")
         return body
     if grounding_check(smoothed):
+        _warn_cohesion_fallback("cohesion output smuggled an ungrounded claim")
         return body
     return smoothed

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -127,10 +127,12 @@ _BESPOKE_ONTOLOGY_TERMS: tuple[str, ...] = (
     "eddy",
     "eddies",
     "praxis",
+    "praxes",
     "wavelength",
+    "wavelengths",
     "aptitude",
 )
-"""The owner's bespoke Creek ontology vocabulary (issue #518).
+"""The owner's bespoke Creek ontology vocabulary.
 
 Guarded by the cohesion entity-preservation check alongside proper nouns and
 numbers: a cohesion pass that introduces one of these terms where the
@@ -804,8 +806,8 @@ class DraftGenerator:
             voice_guard_no_llm: When ``True`` the voice-fidelity guard
                 sanitizes and measures only — no rewrite hop (honours the
                 ``creek draft --no-llm`` flag).
-            cohesion: Opt-in switch for the no-fabrication cohesion pass
-                (issue #518). Default ``False`` so the single-topic draft
+            cohesion: Opt-in switch for the no-fabrication cohesion pass.
+                Default ``False`` so the single-topic draft
                 path is byte-for-byte unchanged. When ``True`` — and the LLM
                 is available (skipped under ``voice_guard_no_llm``) — a
                 post-composition pass smooths seams with transitions, gated
@@ -1340,8 +1342,8 @@ class DraftGenerator:
 
         Used as the ``grounding_check`` seam for
         :func:`~creek.generate.cohesion.run_cohesion_pass` so the cohesion
-        pass cannot smuggle in an ungrounded first-person biographical claim
-        (#515). Returns no findings — which lets the smoothed body through —
+        pass cannot smuggle in an ungrounded first-person biographical claim.
+        Returns no findings — which lets the smoothed body through —
         when the grounding guard is not configured (no embedding callable),
         matching the dormant behaviour of the paragraph guard.
 
@@ -1392,7 +1394,7 @@ class DraftGenerator:
     ) -> str:
         """Run the opt-in cohesion pass, returning the smoothed or original body.
 
-        Default-off (issue #518): when :attr:`_cohesion` is ``False`` or the
+        Default-off: when :attr:`_cohesion` is ``False`` or the
         draft is running under ``--no-llm`` (:attr:`_voice_guard_no_llm`),
         the body is returned unchanged and no extra LLM hop fires. Otherwise
         :func:`~creek.generate.cohesion.run_cohesion_pass` smooths the seams,

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -122,23 +122,40 @@ _BESPOKE_ONTOLOGY_TERMS: tuple[str, ...] = (
     "fragments",
     "resonance",
     "resonances",
-    "thread",
-    "threads",
-    "eddy",
-    "eddies",
     "praxis",
     "praxes",
     "wavelength",
     "wavelengths",
     "aptitude",
 )
-"""The owner's bespoke Creek ontology vocabulary.
+"""The owner's *distinctive* bespoke Creek ontology vocabulary.
 
-Guarded by the cohesion entity-preservation check alongside proper nouns and
-numbers: a cohesion pass that introduces one of these terms where the
-pre-cohesion body had none is fabricating ontology structure, not adding a
-transition. Lowercased on purpose — the guard matches case-insensitively, so a
-mid-sentence ``Eddy`` and a lowercased ``eddy`` are both caught."""
+Guarded **case-insensitively** by the cohesion entity-preservation check
+alongside proper nouns and numbers: a cohesion pass that introduces one of
+these terms where the pre-cohesion body had none is fabricating ontology
+structure, not adding a transition. Lowercased on purpose — these terms are
+unambiguous ontology references even in lowercase prose, so a mid-sentence
+``Wavelength`` and a lowercased ``wavelength`` are both caught.
+
+Common English words that double as ontology terms (Thread, Eddy and their
+plurals) are *not* listed here; they live in
+:data:`_COMMON_CAPITALIZED_ONTOLOGY_TERMS` and are guarded case-sensitively so
+ordinary prose like "the eddies of thought" is not mistaken for fabrication."""
+
+_COMMON_CAPITALIZED_ONTOLOGY_TERMS: tuple[str, ...] = (
+    "Thread",
+    "Threads",
+    "Eddy",
+    "Eddies",
+)
+"""Ontology terms that are also common English words.
+
+Guarded **case-sensitively**, in their Capitalized ontological form only, by
+the cohesion entity-preservation check. ``Eddy``/``Thread`` introduced where
+the pre-cohesion body had none is fabricated ontology structure (and is also
+caught as a proper noun); but a lowercase transition like "the eddies of
+thought" is ordinary prose and must NOT be rejected — so the lowercase form is
+deliberately left unguarded here."""
 
 _MIN_TWIST_SOURCES: int = 2
 """Minimum source fragments before a section composes through the twist path.
@@ -1394,6 +1411,12 @@ class DraftGenerator:
     ) -> str:
         """Run the opt-in cohesion pass, returning the smoothed or original body.
 
+        **Single-topic only.** This is called from :meth:`generate_draft`,
+        whose body is a single-topic essay. The cohesion pass must NOT be used
+        on a multi-section outline draft (``compose_outline_draft``), which has
+        its own content-frozen seam stitch; ``run_cohesion_pass`` additionally
+        self-guards by no-opping on any body with 2+ top-level ``## `` headers.
+
         Default-off: when :attr:`_cohesion` is ``False`` or the
         draft is running under ``--no-llm`` (:attr:`_voice_guard_no_llm`),
         the body is returned unchanged and no extra LLM hop fires. Otherwise
@@ -1424,6 +1447,7 @@ class DraftGenerator:
             ),
             voice_core=self.voice_core,
             bespoke_terms=_BESPOKE_ONTOLOGY_TERMS,
+            capitalized_terms=_COMMON_CAPITALIZED_ONTOLOGY_TERMS,
         )
 
     def resolve_seed(

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -26,7 +26,7 @@ import logging
 import operator
 import re
 import sys
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -40,6 +40,7 @@ from creek.classify.privacy_filter import (
     filter_fragments_by_tier,
 )
 from creek.generate.ai_style.guard import run_voice_fidelity_guard
+from creek.generate.cohesion import run_cohesion_pass
 from creek.generate.compile_routing import (
     CompiledPageIndex,
     empty_index,
@@ -115,6 +116,27 @@ _MODES_DIR: str = "modes"
 _REGISTERS_DIR: str = "registers"
 
 _SLUG_MAX_LENGTH: int = 80
+
+_BESPOKE_ONTOLOGY_TERMS: tuple[str, ...] = (
+    "fragment",
+    "fragments",
+    "resonance",
+    "resonances",
+    "thread",
+    "threads",
+    "eddy",
+    "eddies",
+    "praxis",
+    "wavelength",
+    "aptitude",
+)
+"""The owner's bespoke Creek ontology vocabulary (issue #518).
+
+Guarded by the cohesion entity-preservation check alongside proper nouns and
+numbers: a cohesion pass that introduces one of these terms where the
+pre-cohesion body had none is fabricating ontology structure, not adding a
+transition. Lowercased on purpose — the guard matches case-insensitively, so a
+mid-sentence ``Eddy`` and a lowercased ``eddy`` are both caught."""
 
 _MIN_TWIST_SOURCES: int = 2
 """Minimum source fragments before a section composes through the twist path.
@@ -729,6 +751,7 @@ class DraftGenerator:
         fingerprint: VoiceFingerprint | None = None,
         ai_style_config: AIStyleConfig | None = None,
         voice_guard_no_llm: bool = False,
+        cohesion: bool = False,
     ) -> None:
         """Initialise with an LLM client and skill tree root.
 
@@ -781,6 +804,14 @@ class DraftGenerator:
             voice_guard_no_llm: When ``True`` the voice-fidelity guard
                 sanitizes and measures only — no rewrite hop (honours the
                 ``creek draft --no-llm`` flag).
+            cohesion: Opt-in switch for the no-fabrication cohesion pass
+                (issue #518). Default ``False`` so the single-topic draft
+                path is byte-for-byte unchanged. When ``True`` — and the LLM
+                is available (skipped under ``voice_guard_no_llm``) — a
+                post-composition pass smooths seams with transitions, gated
+                by the deterministic entity-preservation guard and a
+                biographical-grounding re-check; any violation falls back to
+                the pre-cohesion body.
         """
         self._llm = llm
         self.skills_root = skills_root
@@ -794,6 +825,7 @@ class DraftGenerator:
         self._fingerprint = fingerprint
         self._ai_style_config = ai_style_config
         self._voice_guard_no_llm = voice_guard_no_llm
+        self._cohesion = cohesion
 
     def present_idea(self, idea: IdeaSeed) -> str:
         """Format *idea* as an invitation rather than an imperative.
@@ -1237,6 +1269,11 @@ class DraftGenerator:
             prompt,
             empty_message="LLM returned an empty draft body",
         )
+        body = self._apply_cohesion(
+            body,
+            source_fragments=idea.source_fragments,
+            fragments=fragments,
+        )
         guard = self._build_guard_report(
             body=body,
             source_fragments=idea.source_fragments,
@@ -1291,6 +1328,101 @@ class DraftGenerator:
             raise RuntimeError(empty_message)
         truncated = _warn_if_truncated(response.stop_reason)
         return body, truncated
+
+    def _cohesion_grounding_check(
+        self,
+        body: str,
+        *,
+        source_fragments: tuple[str, ...],
+        fragments: dict[str, tuple[Fragment, str]],
+    ) -> Sequence[object]:
+        """Re-run the biographical grounding flag on a cohesion-smoothed body.
+
+        Used as the ``grounding_check`` seam for
+        :func:`~creek.generate.cohesion.run_cohesion_pass` so the cohesion
+        pass cannot smuggle in an ungrounded first-person biographical claim
+        (#515). Returns no findings — which lets the smoothed body through —
+        when the grounding guard is not configured (no embedding callable),
+        matching the dormant behaviour of the paragraph guard.
+
+        Args:
+            body: The cohesion-smoothed body to re-scan.
+            source_fragments: Fragment IDs that fed the draft prompt.
+            fragments: Pre-loaded ``{id: (Fragment, body)}`` map.
+
+        Returns:
+            One finding per ungrounded biographical sentence; empty when the
+            guard is dormant or the body is clean.
+        """
+        if self._embedding_fn is None or self._grounding_thresholds is None:
+            return []
+        corpus = [fragments[fid][1] for fid in source_fragments if fid in fragments]
+        if self.voice_core.strip():
+            corpus.append(self.voice_core)
+        return scan_biographical_sentences(
+            body,
+            source_texts=corpus,
+            embedding_fn=self._embedding_fn,
+            threshold=self._grounding_thresholds.grounding_lower,
+        )
+
+    def _cohesion_llm(self, prompt: str) -> str:
+        """Call the shared draft LLM for the cohesion hop, returning the body.
+
+        Reuses :attr:`_llm` so the cohesion pass shares the same provider seam
+        (and the same test stubs) as composition. The
+        :class:`DraftLLMResponse` wrapper is unwrapped to the plain body string
+        the cohesion guard expects; a truncated stop reason is irrelevant here
+        because the pass only adds transitions.
+
+        Args:
+            prompt: The cohesion prompt built by ``run_cohesion_pass``.
+
+        Returns:
+            The smoothed body text the LLM returned.
+        """
+        return _normalise_llm_response(self._llm(prompt)).text
+
+    def _apply_cohesion(
+        self,
+        body: str,
+        *,
+        source_fragments: tuple[str, ...],
+        fragments: dict[str, tuple[Fragment, str]],
+    ) -> str:
+        """Run the opt-in cohesion pass, returning the smoothed or original body.
+
+        Default-off (issue #518): when :attr:`_cohesion` is ``False`` or the
+        draft is running under ``--no-llm`` (:attr:`_voice_guard_no_llm`),
+        the body is returned unchanged and no extra LLM hop fires. Otherwise
+        :func:`~creek.generate.cohesion.run_cohesion_pass` smooths the seams,
+        gated by the entity-preservation guard and the biographical-grounding
+        re-check; any violation falls back to *body*.
+
+        Args:
+            body: The composed single-topic draft body.
+            source_fragments: Fragment IDs that fed the draft prompt; used to
+                build the grounding re-check corpus.
+            fragments: Pre-loaded ``{id: (Fragment, body)}`` map.
+
+        Returns:
+            The smoothed body when enabled and every guard passes; otherwise
+            *body* unchanged.
+        """
+        enabled = self._cohesion and not self._voice_guard_no_llm
+        cohesion_llm = self._cohesion_llm if enabled else None
+        return run_cohesion_pass(
+            body,
+            cohesion_llm=cohesion_llm,
+            enabled=enabled,
+            grounding_check=lambda smoothed: self._cohesion_grounding_check(
+                smoothed,
+                source_fragments=source_fragments,
+                fragments=fragments,
+            ),
+            voice_core=self.voice_core,
+            bespoke_terms=_BESPOKE_ONTOLOGY_TERMS,
+        )
 
     def resolve_seed(
         self,

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -2014,9 +2014,13 @@ def test_draft_command_happy_path(
 
 def test_draft_cohesion_flag_advertised_in_help() -> None:
     """The opt-in ``--cohesion`` flag is documented in ``creek draft --help``."""
-    result = runner.invoke(app, ["draft", "--help"])
+    # Render at a wide width so the option name cannot wrap, and strip ANSI
+    # so colour codes can't split the ``--cohesion`` token (CI renders the
+    # rich help table coloured and at ~80 cols, breaking literal matching).
+    result = runner.invoke(app, ["draft", "--help"], env={"COLUMNS": "200"})
     assert result.exit_code == 0
-    assert "--cohesion" in result.output
+    normalized = " ".join(_strip_ansi(result.output).split())
+    assert "--cohesion" in normalized
 
 
 def test_draft_cohesion_flag_smooths_body(

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -2012,6 +2012,76 @@ def test_draft_command_happy_path(
     assert drafts[0].name.endswith("-naming-what-orbits.md")
 
 
+def test_draft_cohesion_flag_advertised_in_help() -> None:
+    """The opt-in ``--cohesion`` flag is documented in ``creek draft --help``."""
+    result = runner.invoke(app, ["draft", "--help"])
+    assert result.exit_code == 0
+    assert "--cohesion" in result.output
+
+
+def test_draft_cohesion_flag_smooths_body(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``creek draft --cohesion`` runs the entity-preserving cohesion pass.
+
+    Stubs a two-phase LLM: the first call composes a seamed body, the
+    cohesion call (recognised by its ``## Cohesion directive`` block) returns
+    a transitions-only smoothed body. The saved draft must carry the smoothed
+    body — proving the flag wired the pass on.
+    """
+    from creek import cli as cli_module
+    from creek.generate.mining import IdeaSeed, MiningStrategy
+    from creek.models import Frequency
+
+    seed = IdeaSeed(
+        strategy=MiningStrategy.THREAD_TERMINUS,
+        title="Naming what orbits",
+        source_fragments=(),
+        threads=(),
+        eddies=(),
+        frequency_affinity=(Frequency.F1,),
+        brief_description="An essay waits here.",
+        score=0.8,
+    )
+    smoothed = "My dad watched Pluribus. And so, doubt is the spine."
+
+    def _two_phase(prompt: str) -> str:
+        if "## Cohesion directive" in prompt:
+            return smoothed
+        return "My dad watched Pluribus. Doubt is the spine."
+
+    monkeypatch.setattr(
+        cli_module,
+        "_build_draft_llm",
+        lambda *_a, **_k: _two_phase,
+    )
+
+    def _stub_mine_all(
+        _self: object,
+        _vault: object,
+        *,
+        current_phase: object,
+    ) -> list[IdeaSeed]:
+        del current_phase
+        return [seed]
+
+    monkeypatch.setattr(
+        "creek.generate.mining.IdeaMiner.mine_all",
+        _stub_mine_all,
+    )
+
+    vault = tmp_path / "vault"
+    for sub in ("01-Fragments", "02-Threads", "03-Eddies", "07-Voice/Drafts"):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+
+    result = runner.invoke(app, ["draft", "--vault", str(vault), "--cohesion"])
+    assert result.exit_code == 0, result.output
+    drafts = list((vault / "07-Voice" / "Drafts").glob("*.md"))
+    assert len(drafts) == 1
+    assert smoothed in drafts[0].read_text(encoding="utf-8")
+
+
 def test_draft_command_errors_when_llm_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/creek-tools/tests/test_cohesion.py
+++ b/creek-tools/tests/test_cohesion.py
@@ -1,4 +1,4 @@
-"""Tests for the no-fabrication cohesion pass (issue #518).
+"""Tests for the no-fabrication cohesion pass.
 
 The cohesion pass smooths seams between independently-composed sections of
 a single-topic draft by inserting transitions. It is gated behind a hard,
@@ -14,6 +14,8 @@ that runs the pass only when explicitly enabled.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from creek.generate.cohesion import (
     build_cohesion_prompt,
     extract_preservable_tokens,
@@ -21,6 +23,9 @@ from creek.generate.cohesion import (
     is_entity_preserving,
     run_cohesion_pass,
 )
+
+if TYPE_CHECKING:
+    import pytest
 
 
 class TestExtractPreservableTokens:
@@ -104,6 +109,24 @@ class TestIsEntityPreserving:
                 pre=pre,
                 post=post,
                 bespoke_terms=("eddy", "fragment", "praxis"),
+            )
+            is False
+        )
+
+    def test_new_pluralised_bespoke_term_is_rejected(self) -> None:
+        """A fabricated *plural* ontology term cannot slip the guard.
+
+        Without ``wavelengths`` in the preserve set a cohesion pass could
+        introduce the plural while ``wavelength`` was absent — fabricating
+        ontology structure. The plural must be guarded just like the singular.
+        """
+        pre = "The idea sits there, unmoving."
+        post = "The Wavelengths of the idea sit there, unmoving."
+        assert (
+            is_entity_preserving(
+                pre=pre,
+                post=post,
+                bespoke_terms=("wavelength", "wavelengths", "praxis", "praxes"),
             )
             is False
         )
@@ -235,3 +258,38 @@ class TestRunCohesionPass:
             grounding_check=_no_grounding_findings,
         )
         assert result == "Original body."
+
+    def test_rejected_output_warns_on_stderr(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A guard-rejected cohesion output emits a stderr fallback diagnostic.
+
+        An operator who opted into ``--cohesion`` should see *why* the pass
+        had no effect, mirroring the biographical grounding-guard warning.
+        """
+        pre = "My dad watched the show. Doubt is the spine."
+        fabricated = "In 1997, my dad watched the show in Provo. Doubt is the spine."
+
+        run_cohesion_pass(
+            pre,
+            cohesion_llm=lambda _p: fabricated,
+            enabled=True,
+            grounding_check=_no_grounding_findings,
+        )
+        err = capsys.readouterr().err
+        assert "cohesion guard" in err.lower()
+
+    def test_accepted_output_emits_no_warning(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An accepted cohesion output emits no fallback diagnostic."""
+        pre = "My dad watched Pluribus. Doubt is the spine."
+        smoothed = "My dad watched Pluribus. And so, doubt is the spine."
+
+        run_cohesion_pass(
+            pre,
+            cohesion_llm=lambda _p: smoothed,
+            enabled=True,
+            grounding_check=_no_grounding_findings,
+        )
+        assert capsys.readouterr().err == ""

--- a/creek-tools/tests/test_cohesion.py
+++ b/creek-tools/tests/test_cohesion.py
@@ -75,6 +75,35 @@ class TestExtractPreservableTokens:
         )
         assert "fragment" in tokens
 
+    def test_capitalized_common_term_captured_only_when_capitalized(self) -> None:
+        """A capitalized-only common term is caught in ontological form only.
+
+        ``Eddy``/``Eddies`` are common English words; only their capitalized
+        ontological form should register as a preservable bespoke token so a
+        lowercase prose transition ("the eddies of thought") is never treated
+        as a fabricated ontology term.
+        """
+        capped = extract_preservable_tokens(
+            "The Eddies of the mind.",
+            capitalized_terms=("Eddy", "Eddies"),
+        )
+        assert "eddies" in capped
+        lowered = extract_preservable_tokens(
+            "the eddies of thought",
+            capitalized_terms=("Eddy", "Eddies"),
+        )
+        assert "eddies" not in lowered
+
+    def test_markdown_header_word_not_captured_as_proper_noun(self) -> None:
+        """Structural header words are not preservable proper nouns.
+
+        A multi-word ``## Rising Tide`` header is structure, not prose; its
+        title-cased words must not register as fabricated proper nouns.
+        """
+        tokens = extract_preservable_tokens("Intro.\n\n## Rising Tide\n\nThe body.")
+        assert "tide" not in tokens
+        assert "rising" not in tokens
+
 
 class TestIsEntityPreserving:
     """The deterministic pre/post entity-preservation guard."""
@@ -136,6 +165,43 @@ class TestIsEntityPreserving:
         pre = "My dad watched Pluribus in Provo."
         post = "My dad watched Pluribus."
         assert is_entity_preserving(pre=pre, post=post) is True
+
+    def test_lowercase_common_ontology_transition_is_accepted(self) -> None:
+        """A lowercase "eddies" transition is not a fabricated ontology term.
+
+        ``eddy``/``eddies`` are common English words; introducing them lowercased
+        as connective prose ("the eddies of thought") must NOT be rejected as a
+        fabricated ontology term — only their capitalized form is guarded.
+        """
+        pre = "The idea sits there. Doubt is the spine."
+        post = "The idea sits there, one of the eddies of thought. Doubt is the spine."
+        assert (
+            is_entity_preserving(
+                pre=pre,
+                post=post,
+                capitalized_terms=("Eddy", "Eddies", "Thread", "Threads"),
+            )
+            is True
+        )
+
+    def test_fabricated_capitalized_common_term_is_rejected(self) -> None:
+        """A fabricated capitalized ``Eddy``/``Thread`` is still rejected.
+
+        When the pre-body had no eddy/Eddy at all, a post that introduces the
+        capitalized ontological ``Eddy`` is fabricating structure and must be
+        rejected — caught either as a capitalized bespoke term or as a proper
+        noun.
+        """
+        pre = "The idea sits there. Doubt is the spine."
+        post = "The Eddy of the idea sits there. Doubt is the spine."
+        assert (
+            is_entity_preserving(
+                pre=pre,
+                post=post,
+                capitalized_terms=("Eddy", "Eddies", "Thread", "Threads"),
+            )
+            is False
+        )
 
 
 class TestFormatCohesionDirective:
@@ -293,3 +359,53 @@ class TestRunCohesionPass:
             grounding_check=_no_grounding_findings,
         )
         assert capsys.readouterr().err == ""
+
+    def test_multi_section_body_skips_cohesion(self) -> None:
+        """A body with 2+ top-level ``## `` headers is returned unchanged.
+
+        Multi-section outline drafts carry their own seam stitch; the
+        single-topic cohesion pass must not smooth across section seams, so it
+        no-ops and never calls the LLM.
+        """
+        calls: list[str] = []
+
+        def llm(prompt: str) -> str:
+            calls.append(prompt)
+            return "SHOULD NOT RUN"
+
+        multi = "## Rising\n\nFirst part.\n\n## Falling\n\nSecond part."
+        result = run_cohesion_pass(
+            multi,
+            cohesion_llm=llm,
+            enabled=True,
+            grounding_check=_no_grounding_findings,
+        )
+        assert result == multi
+        assert calls == []
+
+    def test_multi_section_body_warns_skipped(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A skipped multi-section body emits the multi-section diagnostic."""
+        multi = "## Rising\n\nFirst part.\n\n## Falling\n\nSecond part."
+        run_cohesion_pass(
+            multi,
+            cohesion_llm=lambda _p: "x",
+            enabled=True,
+            grounding_check=_no_grounding_findings,
+        )
+        err = capsys.readouterr().err.lower()
+        assert "cohesion guard" in err
+        assert "multi-section" in err
+
+    def test_single_section_body_is_processed(self) -> None:
+        """A single-topic body (one or zero ``## `` headers) is smoothed."""
+        pre = "## Rising\n\nMy dad watched Pluribus. Doubt is the spine."
+        smoothed = "## Rising\n\nMy dad watched Pluribus. And so, doubt is the spine."
+        result = run_cohesion_pass(
+            pre,
+            cohesion_llm=lambda _p: smoothed,
+            enabled=True,
+            grounding_check=_no_grounding_findings,
+        )
+        assert result == smoothed

--- a/creek-tools/tests/test_cohesion.py
+++ b/creek-tools/tests/test_cohesion.py
@@ -1,0 +1,237 @@
+"""Tests for the no-fabrication cohesion pass (issue #518).
+
+The cohesion pass smooths seams between independently-composed sections of
+a single-topic draft by inserting transitions. It is gated behind a hard,
+deterministic *entity-preservation guard*: the post-cohesion text may not
+introduce any proper noun, multi-word name, number, or bespoke ontology
+term that was absent from the pre-cohesion text. Adding transition words
+("However," "And so") is allowed; smuggling in a new named entity, number,
+or fact is rejected and the pass falls back to the original body.
+
+These tests exercise the guard as a pure function (no LLM) and the wiring
+that runs the pass only when explicitly enabled.
+"""
+
+from __future__ import annotations
+
+from creek.generate.cohesion import (
+    build_cohesion_prompt,
+    extract_preservable_tokens,
+    format_cohesion_directive,
+    is_entity_preserving,
+    run_cohesion_pass,
+)
+
+
+class TestExtractPreservableTokens:
+    """``extract_preservable_tokens`` isolates the load-bearing tokens."""
+
+    def test_captures_capitalized_proper_nouns(self) -> None:
+        """A mid-sentence capitalized word is a proper noun to preserve."""
+        tokens = extract_preservable_tokens("My dad watched Pluribus last night.")
+        assert "pluribus" in tokens
+
+    def test_captures_numbers(self) -> None:
+        """Bare digits are preservable tokens — a fabricated year is a fact."""
+        tokens = extract_preservable_tokens("It happened in 1997 and again in 2003.")
+        assert "1997" in tokens
+        assert "2003" in tokens
+
+    def test_ignores_sentence_initial_lowercase_words(self) -> None:
+        """A lowercase ordinary word is not a preservable token."""
+        tokens = extract_preservable_tokens("the spine of the essay is doubt.")
+        assert "spine" not in tokens
+        assert "doubt" not in tokens
+
+    def test_sentence_initial_capital_is_not_a_proper_noun(self) -> None:
+        """A capital only because it starts a sentence is not an entity.
+
+        Otherwise every transition opener ("However,") would register as a
+        new entity and the guard would reject all cohesion output.
+        """
+        tokens = extract_preservable_tokens("However, the doubt remains.")
+        assert "however" not in tokens
+
+    def test_trailing_punctuation_yields_no_phantom_token(self) -> None:
+        """A trailing sentence boundary produces an empty segment, skipped cleanly.
+
+        The boundary split on text ending in terminal punctuation emits an
+        empty final segment; it must be ignored rather than crash on an empty
+        word list.
+        """
+        tokens = extract_preservable_tokens("My dad watched Pluribus. ")
+        assert "pluribus" in tokens
+
+    def test_bespoke_ontology_terms_are_captured(self) -> None:
+        """Owner ontology terms are preserved even when given explicitly."""
+        tokens = extract_preservable_tokens(
+            "The fragment resonates.",
+            bespoke_terms=("fragment", "resonance"),
+        )
+        assert "fragment" in tokens
+
+
+class TestIsEntityPreserving:
+    """The deterministic pre/post entity-preservation guard."""
+
+    def test_added_transitions_only_passes(self) -> None:
+        """Adding bridge words but no new entity passes the guard."""
+        pre = "My dad watched Pluribus. The spine of doubt is real."
+        post = (
+            "My dad watched Pluribus. And so, the spine of doubt is real. "
+            "However, it holds."
+        )
+        assert is_entity_preserving(pre=pre, post=post) is True
+
+    def test_new_proper_noun_is_rejected(self) -> None:
+        """A post that adds a brand-new proper noun is rejected."""
+        pre = "My dad watched the show."
+        post = "My dad, who lives in Provo, watched the show."
+        assert is_entity_preserving(pre=pre, post=post) is False
+
+    def test_new_number_is_rejected(self) -> None:
+        """A fabricated year/number in the post is rejected."""
+        pre = "It changed everything for him."
+        post = "In 1997, it changed everything for him."
+        assert is_entity_preserving(pre=pre, post=post) is False
+
+    def test_new_bespoke_ontology_term_is_rejected(self) -> None:
+        """Introducing an owner ontology term not present before is rejected."""
+        pre = "The idea sits there, unmoving."
+        post = "The Eddy of the idea sits there, unmoving."
+        assert (
+            is_entity_preserving(
+                pre=pre,
+                post=post,
+                bespoke_terms=("eddy", "fragment", "praxis"),
+            )
+            is False
+        )
+
+    def test_dropping_an_entity_still_passes(self) -> None:
+        """Removing (not adding) an entity is not a fabrication and passes."""
+        pre = "My dad watched Pluribus in Provo."
+        post = "My dad watched Pluribus."
+        assert is_entity_preserving(pre=pre, post=post) is True
+
+
+class TestFormatCohesionDirective:
+    """The transitions-only directive states the no-fabrication contract."""
+
+    def test_names_the_anti_fabrication_constraint(self) -> None:
+        """The directive forbids inventing entities/numbers/facts."""
+        directive = format_cohesion_directive()
+        lowered = directive.lower()
+        assert "transition" in lowered
+        assert "no new" in lowered or "do not" in lowered
+
+    def test_build_prompt_includes_body_and_directive(self) -> None:
+        """The cohesion prompt carries the body and the directive."""
+        prompt = build_cohesion_prompt("Body text here.", voice_core="My voice.")
+        assert "Body text here." in prompt
+        assert "My voice." in prompt
+        assert "transition" in prompt.lower()
+
+
+def _no_grounding_findings(_body: str) -> list[str]:
+    """Grounding check stub that finds nothing ungrounded."""
+    return []
+
+
+class TestRunCohesionPass:
+    """``run_cohesion_pass`` orchestrates LLM + guards + fallback."""
+
+    def test_disabled_returns_original_and_skips_llm(self) -> None:
+        """With cohesion off the original body returns and the LLM is untouched."""
+        calls: list[str] = []
+
+        def llm(prompt: str) -> str:
+            calls.append(prompt)
+            return "SHOULD NOT RUN"
+
+        result = run_cohesion_pass(
+            "Original body.",
+            cohesion_llm=llm,
+            enabled=False,
+            grounding_check=_no_grounding_findings,
+        )
+        assert result == "Original body."
+        assert calls == []
+
+    def test_no_llm_returns_original_and_skips(self) -> None:
+        """A ``None`` cohesion LLM (the --no-llm path) skips the pass."""
+        result = run_cohesion_pass(
+            "Original body.",
+            cohesion_llm=None,
+            enabled=True,
+            grounding_check=_no_grounding_findings,
+        )
+        assert result == "Original body."
+
+    def test_enabled_applies_smoothed_body(self) -> None:
+        """When enabled and the guard passes, the smoothed body is returned."""
+        pre = "My dad watched Pluribus. Doubt is the spine."
+        smoothed = "My dad watched Pluribus. And so, doubt is the spine."
+
+        result = run_cohesion_pass(
+            pre,
+            cohesion_llm=lambda _p: smoothed,
+            enabled=True,
+            grounding_check=_no_grounding_findings,
+        )
+        assert result == smoothed
+
+    def test_fabricated_entity_falls_back_to_original(self) -> None:
+        """A cohesion output adding a new entity is rejected; original returns."""
+        pre = "My dad watched the show. Doubt is the spine."
+        fabricated = "In 1997, my dad watched the show in Provo. Doubt is the spine."
+
+        result = run_cohesion_pass(
+            pre,
+            cohesion_llm=lambda _p: fabricated,
+            enabled=True,
+            grounding_check=_no_grounding_findings,
+        )
+        assert result == pre
+
+    def test_bespoke_term_fabrication_falls_back(self) -> None:
+        """A new bespoke ontology term in the output triggers fallback."""
+        pre = "The idea sits there. Doubt is the spine."
+        fabricated = "The Praxis idea sits there. Doubt is the spine."
+
+        result = run_cohesion_pass(
+            pre,
+            cohesion_llm=lambda _p: fabricated,
+            enabled=True,
+            grounding_check=_no_grounding_findings,
+            bespoke_terms=("praxis", "eddy", "fragment"),
+        )
+        assert result == pre
+
+    def test_ungrounded_biographical_claim_falls_back(self) -> None:
+        """A smoothed body that trips the grounding flag falls back."""
+        pre = "My dad watched the show. Doubt is the spine."
+        # Entity-preserving (no new proper noun / number) but smuggles in an
+        # ungrounded first-person biographical claim.
+        smoothed = "My dad watched the show. And so doubt is the spine."
+
+        def grounding_flags(_body: str) -> list[str]:
+            return ["ungrounded first-person claim"]
+
+        result = run_cohesion_pass(
+            pre,
+            cohesion_llm=lambda _p: smoothed,
+            enabled=True,
+            grounding_check=grounding_flags,
+        )
+        assert result == pre
+
+    def test_empty_llm_output_falls_back(self) -> None:
+        """An empty cohesion response falls back rather than blanking the draft."""
+        result = run_cohesion_pass(
+            "Original body.",
+            cohesion_llm=lambda _p: "   ",
+            enabled=True,
+            grounding_check=_no_grounding_findings,
+        )
+        assert result == "Original body."

--- a/creek-tools/tests/test_draft_grounding.py
+++ b/creek-tools/tests/test_draft_grounding.py
@@ -246,7 +246,7 @@ class TestDraftConfig:
         assert DraftConfig(max_tokens=4096).max_tokens == 4096
 
     def test_cohesion_defaults_off(self) -> None:
-        """The cohesion pass must default off so merging changes nothing (#518)."""
+        """The cohesion pass must default off so merging changes nothing."""
         assert DraftConfig().cohesion is False
 
     def test_cohesion_can_be_enabled(self) -> None:

--- a/creek-tools/tests/test_draft_grounding.py
+++ b/creek-tools/tests/test_draft_grounding.py
@@ -245,6 +245,14 @@ class TestDraftConfig:
         """Operators may pin a default token ceiling for longer drafts."""
         assert DraftConfig(max_tokens=4096).max_tokens == 4096
 
+    def test_cohesion_defaults_off(self) -> None:
+        """The cohesion pass must default off so merging changes nothing (#518)."""
+        assert DraftConfig().cohesion is False
+
+    def test_cohesion_can_be_enabled(self) -> None:
+        """Operators may persist the opt-in cohesion pass in ``draft:`` config."""
+        assert DraftConfig(cohesion=True).cohesion is True
+
     def test_creekconfig_exposes_draft_section(self) -> None:
         """The top-level ``draft:`` section must hang off ``CreekConfig``."""
         from creek.config import CreekConfig

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -654,6 +654,55 @@ class TestGenerateDraftCohesion:
 
         assert draft.body == original
 
+    def test_lowercase_eddies_transition_is_accepted(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A lowercase "eddies of thought" transition is not over-rejected.
+
+        ``eddy``/``eddies`` are common English words; introducing them
+        lowercased as connective prose must NOT be treated as a fabricated
+        ontology term, so the smoothed body is applied.
+        """
+        fragment = _build_fragment()
+        _write_fragment(vault, fragment, "A line about the show.")
+        _seed_skill_tree(skills_root, "frequencies/F1.SKILL.md")
+        original = "The idea sits there. Doubt is the spine."
+        smoothed = (
+            "The idea sits there, one of the eddies of thought. Doubt is the spine."
+        )
+        gen = DraftGenerator(
+            llm=self._two_phase_llm(original, smoothed),
+            skills_root=skills_root,
+            cohesion=True,
+        )
+        seed = _build_seed(source_fragments=(fragment.id,))
+        draft = gen.generate_draft(seed, vault_path=vault)
+
+        assert draft.body == smoothed
+
+    def test_fabricated_capitalized_eddy_falls_back(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A fabricated capitalized ``Eddy`` ontology term is still rejected."""
+        fragment = _build_fragment()
+        _write_fragment(vault, fragment, "A line about the show.")
+        _seed_skill_tree(skills_root, "frequencies/F1.SKILL.md")
+        original = "The idea sits there. Doubt is the spine."
+        fabricated = "The Eddy of the idea sits there. Doubt is the spine."
+        gen = DraftGenerator(
+            llm=self._two_phase_llm(original, fabricated),
+            skills_root=skills_root,
+            cohesion=True,
+        )
+        seed = _build_seed(source_fragments=(fragment.id,))
+        draft = gen.generate_draft(seed, vault_path=vault)
+
+        assert draft.body == original
+
     def test_ungrounded_biographical_smoothing_falls_back(
         self,
         vault: Path,

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -540,6 +540,162 @@ class TestGenerateDraft:
         assert "### F1.SKILL.md" in captured["prompt"]
 
 
+class TestGenerateDraftCohesion:
+    """The opt-in cohesion pass wiring in ``generate_draft`` (issue #518)."""
+
+    @staticmethod
+    def _two_phase_llm(
+        draft_body: str,
+        cohesion_body: str,
+    ) -> Callable[[str], str]:
+        """Return an LLM stub: first call composes, second smooths.
+
+        The cohesion prompt is recognised by its ``## Cohesion directive``
+        block; any other prompt is the initial composition.
+        """
+
+        def _call(prompt: str) -> str:
+            if "## Cohesion directive" in prompt:
+                return cohesion_body
+            return draft_body
+
+        return _call
+
+    def test_off_by_default_skips_cohesion_llm(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """With cohesion off (default) the cohesion hop never fires."""
+        fragment = _build_fragment()
+        _write_fragment(vault, fragment, "A line about Pluribus.")
+        _seed_skill_tree(skills_root, "frequencies/F1.SKILL.md")
+        prompts: list[str] = []
+
+        def llm(prompt: str) -> str:
+            prompts.append(prompt)
+            return "My dad watched Pluribus. Doubt is the spine."
+
+        gen = DraftGenerator(llm=llm, skills_root=skills_root)
+        seed = _build_seed(source_fragments=(fragment.id,))
+        draft = gen.generate_draft(seed, vault_path=vault)
+
+        assert draft.body == "My dad watched Pluribus. Doubt is the spine."
+        assert not any("## Cohesion directive" in p for p in prompts)
+
+    def test_enabled_applies_smoothed_body(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """With cohesion on, an entity-preserving smoothed body is applied."""
+        fragment = _build_fragment()
+        _write_fragment(vault, fragment, "A line about Pluribus.")
+        _seed_skill_tree(skills_root, "frequencies/F1.SKILL.md")
+        smoothed = "My dad watched Pluribus. And so, doubt is the spine."
+        gen = DraftGenerator(
+            llm=self._two_phase_llm(
+                "My dad watched Pluribus. Doubt is the spine.",
+                smoothed,
+            ),
+            skills_root=skills_root,
+            cohesion=True,
+        )
+        seed = _build_seed(source_fragments=(fragment.id,))
+        draft = gen.generate_draft(seed, vault_path=vault)
+
+        assert draft.body == smoothed
+
+    def test_enabled_but_no_llm_skips_cohesion(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """``voice_guard_no_llm`` (the --no-llm path) skips the pass entirely."""
+        fragment = _build_fragment()
+        _write_fragment(vault, fragment, "A line about Pluribus.")
+        _seed_skill_tree(skills_root, "frequencies/F1.SKILL.md")
+        prompts: list[str] = []
+
+        def llm(prompt: str) -> str:
+            prompts.append(prompt)
+            return "My dad watched Pluribus. Doubt is the spine."
+
+        gen = DraftGenerator(
+            llm=llm,
+            skills_root=skills_root,
+            cohesion=True,
+            voice_guard_no_llm=True,
+        )
+        seed = _build_seed(source_fragments=(fragment.id,))
+        draft = gen.generate_draft(seed, vault_path=vault)
+
+        assert draft.body == "My dad watched Pluribus. Doubt is the spine."
+        assert not any("## Cohesion directive" in p for p in prompts)
+
+    def test_fabricated_entity_falls_back_to_original(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A cohesion output adding a new entity is rejected; original kept."""
+        fragment = _build_fragment()
+        _write_fragment(vault, fragment, "A line about the show.")
+        _seed_skill_tree(skills_root, "frequencies/F1.SKILL.md")
+        original = "My dad watched the show. Doubt is the spine."
+        fabricated = "In 1997, my dad watched the show in Provo. Doubt is the spine."
+        gen = DraftGenerator(
+            llm=self._two_phase_llm(original, fabricated),
+            skills_root=skills_root,
+            cohesion=True,
+        )
+        seed = _build_seed(source_fragments=(fragment.id,))
+        draft = gen.generate_draft(seed, vault_path=vault)
+
+        assert draft.body == original
+
+    def test_ungrounded_biographical_smoothing_falls_back(
+        self,
+        vault: Path,
+        skills_root: Path,
+    ) -> None:
+        """A smoothed body tripping the grounding re-check falls back (#515).
+
+        The cohesion output is entity-preserving (no new proper noun /
+        number) but smuggles in a first-person biographical claim that the
+        source corpus does not support. With the grounding guard wired, the
+        re-check on the cohesion output rejects it and the original is kept.
+        """
+        fragment = _build_fragment()
+        _write_fragment(vault, fragment, "A line about doubt and the spine.")
+        _seed_skill_tree(skills_root, "frequencies/F1.SKILL.md")
+        original = "Doubt is the spine of it all."
+        # Entity-preserving but ungrounded: an invented upbringing.
+        smoothed = "Doubt is the spine of it all. And so I was raised on doubt."
+
+        # Orthogonal one-hot vectors: the biographical sentence shares no axis
+        # with the source, so its max cosine similarity is 0.0 < threshold.
+        def embed(text: str) -> list[float]:
+            return [1.0, 0.0] if "raised on doubt" in text else [0.0, 1.0]
+
+        thresholds = GroundingThresholds(
+            derivative_upper=0.85,
+            grounding_lower=0.30,
+            grounding_fraction_lower=0.30,
+        )
+        gen = DraftGenerator(
+            llm=self._two_phase_llm(original, smoothed),
+            skills_root=skills_root,
+            cohesion=True,
+            embedding_fn=embed,
+            grounding_thresholds=thresholds,
+        )
+        seed = _build_seed(source_fragments=(fragment.id,))
+        draft = gen.generate_draft(seed, vault_path=vault)
+
+        assert draft.body == original
+
+
 # ---- save_draft -------------------------------------------------------
 
 

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -541,7 +541,7 @@ class TestGenerateDraft:
 
 
 class TestGenerateDraftCohesion:
-    """The opt-in cohesion pass wiring in ``generate_draft`` (issue #518)."""
+    """The opt-in cohesion pass wiring in ``generate_draft``."""
 
     @staticmethod
     def _two_phase_llm(
@@ -659,7 +659,7 @@ class TestGenerateDraftCohesion:
         vault: Path,
         skills_root: Path,
     ) -> None:
-        """A smoothed body tripping the grounding re-check falls back (#515).
+        """A smoothed body tripping the grounding re-check falls back.
 
         The cohesion output is entity-preserving (no new proper noun /
         number) but smuggles in a first-person biographical claim that the


### PR DESCRIPTION
## Summary
- Adds an **opt-in, default-off** no-fabrication cohesion pass for single-topic drafts (`creek/generate/cohesion.py`). When enabled it asks the LLM to smooth abrupt section seams by inserting transitions — transitions only, no new content.
- Gates the rewrite behind a hard, deterministic **entity-preservation guard** (`is_entity_preserving`): it compares the set of {proper nouns, numbers, owner bespoke ontology terms} before vs after the rewrite and rejects (falls back to the original body) if the post-text introduces any token absent before.
- Re-runs the #515 biographical-grounding flag on the cohesion output, so the pass cannot smuggle in an ungrounded first-person claim.

### Default-off, behind `--cohesion`
The pass does **not** run unless explicitly enabled:
- New CLI flag `creek draft --cohesion` (and a `draft.cohesion` config boolean, default `False`).
- It requires the LLM and is **skipped entirely under `--no-llm`** and when the flag is off.
- Merging this changes no current behaviour: the single-topic draft path is byte-for-byte unchanged unless the operator opts in.

### Entity-preservation guard (the load-bearing part)
`extract_preservable_tokens` collects, case-insensitively: numbers (any digit run), proper nouns (capitalized words that are *not* merely sentence-initial, so transition openers like "However," don't count), and the owner's bespoke Creek ontology vocabulary (Fragment, Resonance, Thread, Eddy, Praxis, Wavelength, APTITUDE). `is_entity_preserving` returns `True` iff the post-cohesion token set is a subset of the pre-cohesion set — adding bridge words or *dropping* an entity passes; adding a new proper noun / number / ontology term is rejected. It is a pure function with no LLM dependency, unit-tested with fixtures: transitions-only pairs pass; a pair adding "In 1997, …" or a new place name or a new bespoke term is rejected.

## Test plan
- `tests/test_cohesion.py` — pure-function guard tests (transitions pass; new proper noun / number / bespoke term rejected; drop-entity passes) and `run_cohesion_pass` orchestration (disabled skips LLM; `None` LLM skips; smoothed body applied; fabricated entity falls back; ungrounded grounding finding falls back; empty output falls back).
- `tests/test_drafts.py::TestGenerateDraftCohesion` — wiring: off-by-default skips the cohesion hop; enabled applies an entity-preserving smoothed body; `--no-llm` skips; a fabricated entity falls back; an ungrounded biographical smoothing falls back via the wired grounding re-check.
- `tests/test_draft_grounding.py` — `DraftConfig.cohesion` defaults `False` / can be enabled.
- `tests/test_cli.py` — `--cohesion` advertised in help; `creek draft --cohesion` runs the pass and saves the smoothed body.
- `cd creek-tools && ./scripts/check-all.sh` exits 0 (12/12 checks: coverage 93.77%, cohesion.py 100%, interrogate, complexity, mypy strict, ruff, refurb all clean).

Closes #518
Refs #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)
