### PR TITLE
fix(crawdad): feed tool results back to the router each loop round (#526)

### DIFF
--- a/crawdad/crawdad/loop.py
+++ b/crawdad/crawdad/loop.py
@@ -185,6 +185,7 @@ class AgentLoop:
                 _LOGGER.warning("MCP unavailable mid-loop: %s", exc)
                 return LoopOutcome(kind="mcp_unavailable", reply=_MCP_UNAVAILABLE_REPLY)
             aggregated.extend(results)
+            self._record_tool_round(results)
         else:
             # Exhausted max_rounds without the router setting compose=true.
             _LOGGER.warning(
@@ -226,6 +227,22 @@ class AgentLoop:
                 workflow_runner=self._workflow_runner,
             )
             return await dispatcher.dispatch(response)
+
+    def _record_tool_round(self, results: list[ToolResult]) -> None:
+        """Thread this round's tool results back into the router's context.
+
+        The router's prompt (:func:`crawdad.router.build_router_prompt`)
+        renders the conversation history, and its instructions reference
+        "prior tool results in the history". Without this turn the router
+        sees byte-identical inputs every round and cannot converge to
+        ``compose=true`` (#526). Recording a synthetic ``tool`` turn here
+        lets the next :meth:`IntentRouter.extract_intents` observe that
+        the tools already ran and stop re-dispatching. Empty rounds are
+        skipped so the history stays meaningful.
+        """
+        if not results:
+            return
+        self._history.append("tool", _render_tool_results(results))
 
     def _current_skills(self) -> VoiceSkillStack:
         """Return the active skill stack, preferring the registry when wired."""
@@ -277,6 +294,17 @@ class AgentLoop:
             _LOGGER.debug("creek.save dispatch race; skipping paradox routing")
             return results
         return [*results, *saved]
+
+
+def _render_tool_results(results: list[ToolResult]) -> str:
+    """Render tool results into a compact transcript line for the router.
+
+    Each result becomes a ``<intent_type>: <body>`` line so the router
+    can see both which tool ran and what it returned. The body is left
+    untruncated here — :meth:`ConversationHistory.append` enforces the
+    per-entry character budget.
+    """
+    return "\n".join(f"{result.intent_type}: {result.body}" for result in results)
 
 
 def _max_ceiling_from(results: list[ToolResult]) -> PrivacyTierCeiling:

--- a/crawdad/tests/test_bot.py
+++ b/crawdad/tests/test_bot.py
@@ -440,9 +440,11 @@ async def test_handle_message_runs_full_loop(
 
     assert len(channel.sent) == 1
     assert channel.sent[0] == "voice-faithful reply"
-    # History records the user turn and the assistant reply.
+    # History records the user turn, the round-1 tool result fed back to
+    # the router (#526), and the assistant reply.
     entries = history.as_list()
-    assert [e.role for e in entries] == ["user", "assistant"]
+    assert [e.role for e in entries] == ["user", "tool", "assistant"]
+    assert "state body" in entries[1].content
 
 
 async def test_handle_message_router_parse_error_uses_soft_reply(

--- a/crawdad/tests/test_loop.py
+++ b/crawdad/tests/test_loop.py
@@ -800,3 +800,97 @@ async def test_run_one_turn_default_max_rounds_uses_module_constant(
 
     assert outcome.kind == "too_deep"
     assert len(router.calls) == MAX_LOOP_ROUNDS
+
+
+class _ConvergingRouter:
+    """A deterministic router that converges once it sees tool results.
+
+    Models the real Haiku router's documented contract (#526): it keeps
+    asking for the same tool until it observes that round's results
+    threaded back into the conversation history, then sets
+    ``compose=true``. If the loop never feeds tool results into the
+    router's context, this router loops forever — exactly the bug.
+    """
+
+    def __init__(self, *, tool: str) -> None:
+        """Record the tool to request until results land in history."""
+        self._tool = tool
+        self.calls: list[dict[str, Any]] = []
+
+    async def extract_intents(self, **kwargs: Any) -> RouterResponse:
+        """Compose once the requested tool's body appears in history."""
+        self.calls.append(kwargs)
+        history: ConversationHistory = kwargs["history"]
+        seen_results = any(
+            self._tool in entry.content
+            for entry in history.as_list()
+            if entry.role not in {"user", "assistant"}
+        )
+        if seen_results:
+            return RouterResponse(intents=[], compose=True)
+        return RouterResponse(intents=[Intent(type=self._tool)])
+
+
+async def test_loop_converges_when_tool_results_feed_back_to_router(
+    state: SessionState, skills: VoiceSkillStack
+) -> None:
+    """#526: round-1 tool results reach the router so round 2 composes.
+
+    A deterministic router that only composes after it observes the
+    dispatched tool's results in history must converge to a composed
+    reply — not exhaust the round cap and fall back to ``too_deep``.
+    """
+    router = _ConvergingRouter(tool="creek.state.read")
+    session = _ScriptedSession(replies={"creek.state.read": "state body"})
+    composer = _ScriptedComposer("converged reply")
+    history = ConversationHistory()
+    loop = AgentLoop(
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(session),  # type: ignore[arg-type]
+        known_tools=("creek.state.read",),
+        history=history,
+        session_state=state,
+        skills=skills,
+    )
+
+    outcome = await loop.run("what's my state?")
+
+    assert outcome.kind == "composed"
+    assert outcome.reply == "converged reply"
+    # Round 1 dispatched the tool; round 2 saw the result and composed.
+    assert len(router.calls) == 2
+    # Round 2's router pass observed round 1's tool result in history.
+    round_two_history = router.calls[1]["history"].as_list()
+    assert any(
+        "state body" in entry.content and entry.role not in {"user", "assistant"}
+        for entry in round_two_history
+    )
+    # The composer still received the aggregated results exactly once.
+    assert {r.intent_type for r in composer.calls[0]["tool_results"]} == {
+        "creek.state.read"
+    }
+
+
+def test_record_tool_round_skips_empty_results(
+    state: SessionState, skills: VoiceSkillStack
+) -> None:
+    """An empty dispatch round records nothing in the router's history.
+
+    Guards against polluting the transcript (and the next router pass)
+    with an empty ``tool`` turn when a round produced no results.
+    """
+    history = ConversationHistory()
+    loop = AgentLoop(
+        router=_ScriptedRouter([]),  # type: ignore[arg-type]
+        composer=_ScriptedComposer("unused"),  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(_ScriptedSession()),  # type: ignore[arg-type]
+        known_tools=(),
+        history=history,
+        session_state=state,
+        skills=skills,
+    )
+
+    loop._record_tool_round([])
+
+    assert history.as_list() == []


### PR DESCRIPTION
## Summary

The CrawDad agent loop could not converge: `AgentLoop.run` appended the user turn once before the round loop, then called `router.extract_intents` every round with the **same** `message` and a `history` that was never mutated inside the loop. Each round's tool results were accumulated only into a local `aggregated` list that was never threaded back to the router. The router therefore saw byte-identical inputs on every pass and kept returning `compose=false` with non-empty intents until the round cap fired, yielding the `_TOO_DEEP_REPLY`. Turns only succeeded by router non-determinism.

This PR records each dispatch round's results as a synthetic `tool` turn in the shared `ConversationHistory` (new `_record_tool_round` helper + `_render_tool_results` formatter). The next `extract_intents` renders that turn through `build_router_prompt`, so the router can see the tools already ran and converge to `compose=true`. This makes the router prompt's existing "prior tool results in the history" reference real. Empty rounds are skipped so the transcript stays meaningful. The happy path and all existing behavior are preserved.

## Test plan

- New TDD test `test_loop_converges_when_tool_results_feed_back_to_router` drives a deterministic `_ConvergingRouter` that only sets `compose=true` after it observes the dispatched tool's body in history. Without the fix it exhausts the cap and returns `too_deep`; with the fix it converges to a composed reply in 2 rounds. Verified red before the fix, green after.
- New `test_record_tool_round_skips_empty_results` covers the empty-round guard.
- Updated `test_handle_message_runs_full_loop` to assert the now-correct `["user", "tool", "assistant"]` history (round-1 tool result is fed back).
- Full local gate green: `./scripts/check-all.sh` passes all 7 checks — 442 tests pass, 95.74% branch coverage, mypy strict clean, ruff lint+format clean, bandit clean, interrogate docstrings clean. No bypasses added.

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)
