### PR TITLE
fix(crawdad): accept underscores in phase-slug regex so bottoming_out resolves (#528)

### DIFF
--- a/crawdad/crawdad/skill_loader.py
+++ b/crawdad/crawdad/skill_loader.py
@@ -43,7 +43,12 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger("crawdad.skill_loader")
 
-_PHASE_RE = re.compile(r"phase[:\s]*\*{0,2}([a-z\-]+)", re.IGNORECASE)
+# Capture the phase slug verbatim. The canonical phase enum value is
+# ``bottoming_out`` (underscore — see the Creek ontology / ``creek.models.Phase``),
+# so the slug class accepts underscores as well as hyphens; otherwise the
+# snapshot ``Phase: bottoming_out`` is truncated to ``bottoming`` and the
+# loader silently drops ``phases/bottoming_out.SKILL.md`` (#528).
+_PHASE_RE = re.compile(r"phase[:\s]*\*{0,2}([a-z_\-]+)", re.IGNORECASE)
 # Same shape as the captured phase slug. Used to validate caller-supplied
 # register names so path construction can't be tricked into traversal.
 _SAFE_NAME_RE = re.compile(r"^[a-z][a-z\-]*$")

--- a/crawdad/crawdad/workflows.py
+++ b/crawdad/crawdad/workflows.py
@@ -111,7 +111,10 @@ _PLACEHOLDER_RE = re.compile(r"\{\{\s*([\w.]+)\s*\}\}")
 
 # Phase regex matches FEAT-015 / skill_loader extraction so a workflow's
 # ``state.phase`` reference is the same slug the voice-skill loader uses.
-_PHASE_RE = re.compile(r"phase[:\s]*\*{0,2}([a-z\-]+)", re.IGNORECASE)
+# The slug class accepts underscores so the canonical ``bottoming_out``
+# phase value survives intact rather than being truncated to ``bottoming``
+# (#528) — keep this in lockstep with ``skill_loader._PHASE_RE``.
+_PHASE_RE = re.compile(r"phase[:\s]*\*{0,2}([a-z_\-]+)", re.IGNORECASE)
 
 
 # ---------------------------------------------------------------------------

--- a/crawdad/tests/test_skill_loader.py
+++ b/crawdad/tests/test_skill_loader.py
@@ -36,7 +36,7 @@ def vault_with_voice_tree(tmp_path: Path) -> Path:
     (skills / "phases" / "rising.SKILL.md").write_text(
         "# Rising\nAct on energy; mine and draft are welcome.", encoding="utf-8"
     )
-    (skills / "phases" / "bottoming-out.SKILL.md").write_text(
+    (skills / "phases" / "bottoming_out.SKILL.md").write_text(
         "# Bottoming Out\nCompost; never urge action.", encoding="utf-8"
     )
     (skills / "registers").mkdir()
@@ -67,14 +67,24 @@ def test_load_skills_returns_voice_core_phase_and_register(
 def test_load_skills_picks_phase_matching_wavelength(
     vault_with_voice_tree: Path,
 ) -> None:
-    """A Bottoming-Out wavelength loads ``bottoming-out.SKILL.md``."""
-    state = _make_state("bottoming-out")
+    """A ``bottoming_out`` wavelength loads ``bottoming_out.SKILL.md`` (#528).
+
+    The canonical phase enum value is ``bottoming_out`` with an
+    underscore (see the Creek ontology + ``creek.models.Phase``), and
+    the wavelength snapshot renders that value verbatim. The phase
+    regex must capture the full underscored slug so the loader resolves
+    ``phases/bottoming_out.SKILL.md`` instead of silently dropping the
+    phase skill — a voice-fidelity regression with no error surfaced.
+    """
+    state = _make_state("bottoming_out")
 
     stack = load_skills_for_session(vault_path=vault_with_voice_tree, state=state)
 
     bodies = stack.bodies()
     assert any("Bottoming Out" in body for body in bodies)
     assert not any("Rising" in body for body in bodies)
+    # The phase skill is tagged with the intact underscored slug.
+    assert "phase:bottoming_out" in stack.names()
 
 
 def test_load_skills_supports_extra_registers(

--- a/crawdad/tests/test_workflows.py
+++ b/crawdad/tests/test_workflows.py
@@ -353,6 +353,26 @@ def test_resolve_phase_from_session_state(vault_with_state: Path) -> None:
     assert resolve_phase(state) == "rising"
 
 
+def test_resolve_phase_keeps_underscore_in_bottoming_out() -> None:
+    """``resolve_phase`` keeps the underscore in ``bottoming_out`` (#528).
+
+    The canonical phase enum value is ``bottoming_out`` and the
+    wavelength snapshot renders it verbatim. If the phase regex drops
+    the underscore, ``{{state.phase}}`` interpolates to ``bottoming``
+    and the loader (and any phase-aware workflow) silently misfires.
+    """
+    state = SessionState(
+        raw_markdown="",
+        wavelength_snapshot=(
+            "## Wavelength snapshot\n- Phase: **bottoming_out** (confidence 0.71)"
+        ),
+        eddies=(),
+        threads=(),
+        suggested_questions=(),
+    )
+    assert resolve_phase(state) == "bottoming_out"
+
+
 def test_resolve_phase_returns_none_on_missing_state() -> None:
     """No session state ⇒ no phase."""
     assert resolve_phase(None) is None
@@ -717,7 +737,7 @@ async def test_walker_refuses_phase_aware_with_disallowed_phase(
         known_tools=("creek.state.read", "creek.mine"),
     )
     wf = _simple_workflow(
-        phase_aware=True, allowed_phases=("bottoming-out", "withdrawal")
+        phase_aware=True, allowed_phases=("bottoming_out", "withdrawal")
     )
 
     with pytest.raises(WorkflowConstraintError, match="refuses to run in phase"):


### PR DESCRIPTION
## Summary

The phase-extraction regex in both `crawdad/skill_loader.py` and `crawdad/workflows.py` captured `[a-z\-]+` — lowercase plus hyphen only, no underscore. The canonical phase enum value is `bottoming_out` with an underscore (see the Creek ontology and `creek.models.Phase`), and the wavelength snapshot renders that value verbatim. The regex truncated `bottoming_out` to `bottoming`, so:

- `skill_loader` looked for `phases/bottoming.SKILL.md`, missed, and silently dropped the phase skill — a voice-fidelity regression surfaced as no error at all.
- phase-aware workflows interpolated the wrong `{{state.phase}}` slug.

The fix widens both regexes to `[a-z_\-]+` so the underscored slug survives intact and resolves to `phases/bottoming_out.SKILL.md`. No underscore→hyphen normalization exists anywhere else in the codebase, so the captured slug is used directly as the filename. The router's substring matching is unaffected. Test fixtures that used the INC-019 `bottoming-out` hyphen drift were corrected to the canonical underscore form.

## Test plan

- `test_load_skills_picks_phase_matching_wavelength` (test_skill_loader.py) — a `Phase: bottoming_out` snapshot now loads `bottoming_out.SKILL.md` and tags the stack `phase:bottoming_out` (was dropped before the fix).
- `test_resolve_phase_keeps_underscore_in_bottoming_out` (test_workflows.py) — `resolve_phase` returns the full `bottoming_out` slug, not the truncated `bottoming`.
- Hyphen/single-word phases (`rising`, `withdrawal`) and the router's substring tests still pass.
- `./scripts/check-all.sh` → all 7 gates green, 441 passed, 95.73% branch coverage.

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)
