### PR TITLE
fix(crawdad): run free-text turns without session state and forward workflow_runner (#527)

### DIFF
--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -168,6 +168,7 @@ async def handle_message(
     skills: VoiceSkillStack | None = None,
     skill_registry: SkillStackRegistry | None = None,
     pending_batches: PendingBatchStore | None = None,
+    workflow_runner: WorkflowRunner | None = None,
 ) -> None:
     """Process one Discord message.
 
@@ -192,15 +193,29 @@ async def handle_message(
             the store and the next non-attachment message in the same
             channel is inspected for a consent / abandonment token
             *before* the agent loop runs.
+        workflow_runner: ADAPT-003 async callback backing
+            ``crawdad.run_workflow`` intents. Threaded through to
+            :func:`run_one_turn` so a free-text request to run an
+            authored workflow dispatches the same walk the
+            ``/crawdad workflow run`` slash command uses (#527). When
+            ``None``, those intents soft-error.
 
     When ``router``, ``composer``, or ``mcp_client`` is ``None``, the
     handler falls back to the FEAT-013 stub reply — useful for tests
     that don't exercise the full loop.
 
+    Session-state note (#527): the loop and composer tolerate
+    ``session_state=None`` everywhere (e.g. ``_wavelength_block``,
+    ``_phase_hint_for``), so a free-text turn runs even when
+    ``latest.md`` is absent — matching the slash-command contract,
+    which never gates on session state. The bot no longer dead-ends
+    free-text on a "session unavailable" reply; ``creek state`` guidance
+    is surfaced only at startup (see ``cli._safe_load_state``) and via
+    :func:`render_state_unavailable_reply`.
+
     Gate ordering note (FEAT-027): attachments are handled *before* the
-    session-state check so a user dropping a file during a degraded
-    session-state condition still gets their file staged with a clear
-    safety report, instead of a misleading "session unavailable" reply.
+    loop so a user dropping a file during a degraded session-state
+    condition still gets their file staged with a clear safety report.
     The attachment path does not need ``session_state``.
     """
     if not _passes_allowlist(message, config=config, bot_user_id=bot_user_id):
@@ -222,9 +237,6 @@ async def handle_message(
         pending_batches=pending_batches,
     ):
         return
-    if session_state is None:
-        await message.channel.send(_STATE_UNAVAILABLE_REPLY)
-        return
     if router is None or composer is None or mcp_client is None:
         await message.channel.send(_stub_reply())
         return
@@ -240,6 +252,7 @@ async def handle_message(
         skills=_resolve_skills(skill_registry, skills),
         skill_registry=skill_registry,
         max_rounds=config.max_loop_rounds,
+        workflow_runner=workflow_runner,
     )
     _LOGGER.info("loop outcome: %s", outcome.kind)
     await message.channel.send(_truncate_for_discord(outcome.reply))
@@ -789,6 +802,10 @@ class CrawDadClient(discord.Client):
         ``list`` and ``run`` subactions. Both default to ``None`` —
         sessions without an MCP tool surface still register the
         command but the handler soft-errors instead of crashing.
+        ``workflow_runner`` is additionally forwarded to the free-text
+        :func:`handle_message` path (#527) so a router-emitted
+        ``crawdad.run_workflow`` intent on a natural-language turn
+        dispatches the same walk as the slash command.
         """
         super().__init__(intents=intents or self._default_intents())
         self._config = config
@@ -802,6 +819,7 @@ class CrawDadClient(discord.Client):
         self._skill_registry = skill_registry
         self._loop_runner = loop_runner
         self._pending_batches = pending_batches
+        self._workflow_runner = workflow_runner
         self.tree = app_commands.CommandTree(self)
         if loop_runner is not None:
             # discord.py's ``CommandTree.command`` signature is wider than
@@ -857,4 +875,5 @@ class CrawDadClient(discord.Client):
             skills=self._skills,
             skill_registry=self._skill_registry,
             pending_batches=self._pending_batches,
+            workflow_runner=self._workflow_runner,
         )

--- a/crawdad/tests/test_bot.py
+++ b/crawdad/tests/test_bot.py
@@ -154,10 +154,23 @@ def test_render_state_unavailable_reply_directs_to_creek_state() -> None:
     assert "no audit report" in reply.lower()
 
 
-async def test_handle_message_uses_state_unavailable_reply(
+async def test_handle_message_with_none_state_does_not_dead_end(
     config: CrawDadConfig,
 ) -> None:
-    """When session_state is None the allowlisted user gets the guidance reply."""
+    """#527: ``session_state=None`` no longer hard-blocks free-text.
+
+    Previously the handler dead-ended every free-text turn on the
+    "no audit report yet — run ``creek state``" reply whenever
+    ``latest.md`` was absent, diverging from the slash-command path
+    that never gates on session state. With loop components absent the
+    handler now falls through to the FEAT-013 stub reply (and, when the
+    loop is wired, runs the loop with ``state=None`` — see
+    ``test_handle_message_runs_full_loop_when_session_state_is_none``).
+    The ``creek state`` guidance is still surfaced by
+    :func:`render_state_unavailable_reply`.
+    """
+    from crawdad.bot import _STATE_UNAVAILABLE_REPLY
+
     channel = _FakeChannel(id=999, sent=[])
     message = _FakeMessage(
         author=_FakeAuthor(id=111),
@@ -173,7 +186,8 @@ async def test_handle_message_uses_state_unavailable_reply(
     )
 
     assert len(channel.sent) == 1
-    assert "creek state" in channel.sent[0]
+    assert channel.sent[0] != _STATE_UNAVAILABLE_REPLY
+    assert "scaffold" in channel.sent[0].lower()
 
 
 async def test_handle_subprocess_unavailable_replies_gracefully(
@@ -271,6 +285,52 @@ async def test_crawdad_client_on_message_delegates(
 
     assert seen["message"] is message
     assert seen["kwargs"]["bot_user_id"] == 7
+
+
+async def test_crawdad_client_on_message_forwards_workflow_runner(
+    config: CrawDadConfig,
+    session_state: SessionState,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bug #527-B: the client threads ``workflow_runner`` into ``handle_message``.
+
+    Without this wiring a free-text ``crawdad.run_workflow`` intent
+    soft-errors even though the runner the slash-command path uses exists.
+    """
+    from crawdad.bot import CrawDadClient
+
+    seen: dict[str, Any] = {}
+
+    async def _spy(_message: Any, **kwargs: Any) -> None:
+        seen["kwargs"] = kwargs
+
+    monkeypatch.setattr("crawdad.bot.handle_message", _spy)
+
+    async def _workflow_runner(_name: str, _inputs: dict[str, str]) -> str:
+        return "ran"  # pragma: no cover - identity check only
+
+    client = CrawDadClient(
+        config=config,
+        session_state=session_state,
+        workflow_runner=_workflow_runner,
+    )
+
+    class _User:
+        id = 7
+
+    object.__setattr__(client, "_connection", None)
+    monkeypatch.setattr(type(client), "user", property(lambda _self: _User()))
+
+    channel = _FakeChannel(id=999, sent=[])
+    message: Any = _FakeMessage(
+        author=_FakeAuthor(id=111),
+        channel=channel,
+        content="run a workflow",
+    )
+
+    await client.on_message(message)
+
+    assert seen["kwargs"]["workflow_runner"] is _workflow_runner
 
 
 async def test_crawdad_client_on_message_skips_when_not_ready(
@@ -625,6 +685,120 @@ async def test_handle_message_respects_configured_max_loop_rounds(
     assert len(channel.sent) == 1
     assert "back up" in channel.sent[0].lower() or "reframe" in channel.sent[0].lower()
     assert composer.calls == []
+
+
+async def test_handle_message_runs_full_loop_when_session_state_is_none(
+    config: CrawDadConfig,
+) -> None:
+    """Bug #527-A: free-text with ``session_state=None`` reaches the loop.
+
+    Previously the handler hard-stopped on ``_STATE_UNAVAILABLE_REPLY``
+    whenever ``latest.md`` was absent, dead-ending every free-text turn
+    while slash commands (which never gate on state) ran fine. The loop
+    and composer tolerate ``state=None`` everywhere, so a free-text turn
+    must compose a reply instead of bailing.
+    """
+    from crawdad.bot import _STATE_UNAVAILABLE_REPLY
+    from crawdad.history import ConversationHistory
+    from crawdad.intents import RouterResponse
+
+    router = _StubRouter(RouterResponse(intents=[], compose=True))
+    composer = _StubComposer("voice-faithful reply without state")
+    history = ConversationHistory()
+    channel = _FakeChannel(id=999, sent=[])
+    message: Any = _FakeMessage(
+        author=_FakeAuthor(id=111),
+        channel=channel,
+        content="what's surfacing?",
+    )
+
+    await handle_message(
+        message,
+        config=config,
+        session_state=None,
+        bot_user_id=42,
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_StubMCPClient(_StubSession()),  # type: ignore[arg-type]
+        known_tools=("creek.state.read",),
+        history=history,
+    )
+
+    assert len(channel.sent) == 1
+    assert channel.sent[0] == "voice-faithful reply without state"
+    assert channel.sent[0] != _STATE_UNAVAILABLE_REPLY
+    # The composer was invoked with ``state=None`` — the loop ran.
+    assert composer.calls and composer.calls[0]["state"] is None
+
+
+async def test_handle_message_forwards_workflow_runner_to_loop(
+    config: CrawDadConfig, session_state: SessionState
+) -> None:
+    """Bug #527-B: a free-text ``crawdad.run_workflow`` intent invokes the runner.
+
+    The handler must thread the ``workflow_runner`` closure through to
+    :func:`run_one_turn` exactly as the slash command path does, so a
+    natural-language request to run a workflow actually dispatches the
+    runner instead of soft-erroring with "workflow running is
+    unavailable".
+    """
+    from crawdad.history import ConversationHistory
+    from crawdad.intents import (
+        RUN_WORKFLOW_INTENT_TYPE,
+        Intent,
+        RouterResponse,
+    )
+
+    runner_calls: list[tuple[str, dict[str, str]]] = []
+
+    async def _workflow_runner(name: str, inputs: dict[str, str]) -> str:
+        runner_calls.append((name, inputs))
+        return "workflow walked: morning-pages"
+
+    # Router emits a run_workflow intent, then signals compose.
+    router_responses = iter(
+        [
+            RouterResponse(
+                intents=[
+                    Intent(
+                        type=RUN_WORKFLOW_INTENT_TYPE,
+                        args={"name": "morning-pages", "inputs": {"mood": "low"}},
+                    )
+                ]
+            ),
+            RouterResponse(intents=[], compose=True),
+        ]
+    )
+
+    class _SeqRouter:
+        async def extract_intents(self, **_kwargs: Any) -> Any:
+            return next(router_responses)
+
+    composer = _StubComposer("composed after workflow")
+    history = ConversationHistory()
+    channel = _FakeChannel(id=999, sent=[])
+    message: Any = _FakeMessage(
+        author=_FakeAuthor(id=111),
+        channel=channel,
+        content="run the morning pages workflow",
+    )
+
+    await handle_message(
+        message,
+        config=config,
+        session_state=session_state,
+        bot_user_id=42,
+        router=_SeqRouter(),  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_StubMCPClient(_StubSession()),  # type: ignore[arg-type]
+        known_tools=(RUN_WORKFLOW_INTENT_TYPE,),
+        history=history,
+        workflow_runner=_workflow_runner,
+    )
+
+    assert runner_calls == [("morning-pages", {"mood": "low"})]
+    assert len(channel.sent) == 1
+    assert channel.sent[0] == "composed after workflow"
 
 
 async def test_handle_message_without_loop_components_uses_stub_reply(


### PR DESCRIPTION
## Summary

Fixes #527 — the free-text (natural-language) message path in **crawdad** had diverged from the slash-command path in two ways:

- **Bug A — free-text hard-blocked when session state is missing.** `cli._safe_load_state` downgrades a missing `<vault>/00-Creek-Meta/State/latest.md` to `session_state=None` by design, so every free-text message dead-ended on `_STATE_UNAVAILABLE_REPLY`, while slash commands (routed through `_build_loop_runner`, which never gates on session state) ran the loop fine. The loop and composer already tolerate `state=None` everywhere (`_wavelength_block`, `_phase_hint_for`, etc.), so the hard stop in `handle_message` is removed. Free-text now runs the loop with `state=None`, matching the slash-command contract. The `creek state` guidance is still surfaced via `render_state_unavailable_reply`.
- **Bug B — free-text handler never forwarded `workflow_runner`.** A router-emitted `crawdad.run_workflow` intent on a free-text turn soft-errored with "workflow running is unavailable" even though the runner the slash path uses exists. The `workflow_runner` closure is now threaded `CrawDadClient.__init__` → `on_message` → `handle_message` → `run_one_turn`, mirroring `cli._build_loop_runner` exactly so both paths stay consistent.

## Test plan

TDD — failing tests written first, then the fix. New tests in `crawdad/tests/test_bot.py`:

- `test_handle_message_runs_full_loop_when_session_state_is_none` — a free-text turn with `session_state=None` reaches the loop and returns the composed reply (composer invoked with `state=None`) instead of `_STATE_UNAVAILABLE_REPLY`.
- `test_handle_message_forwards_workflow_runner_to_loop` — a free-text turn whose router emits a `crawdad.run_workflow` intent actually invokes the forwarded `workflow_runner` with the parsed name/inputs.
- `test_crawdad_client_on_message_forwards_workflow_runner` — `CrawDadClient.on_message` threads the `workflow_runner` it was constructed with into `handle_message`.
- `test_handle_message_with_none_state_does_not_dead_end` — repurposed the obsolete state-dead-end test: `session_state=None` no longer hard-blocks free-text (falls through to the stub reply when loop components are absent).

`./scripts/check-all.sh` passes fully: lint, format, type check (mypy strict), security, docstrings, complexity, and tests + coverage. 443 tests pass; branch coverage 95.72% (gate ≥90%). No bypasses added.

Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)
