### PR TITLE
test(voice): end-to-end voice-fidelity regression harness (#520)

### DIFF
--- a/creek-tools/tests/e2e/test_voice_fidelity_e2e.py
+++ b/creek-tools/tests/e2e/test_voice_fidelity_e2e.py
@@ -1,0 +1,199 @@
+"""Voice-fidelity regression harness — Layer B, opt-in true E2E (issue #520).
+
+The end-to-end backstop: it runs the *real* draft path
+(:meth:`creek.generate.drafts.DraftGenerator.generate_draft`) on a fixed
+seed in a throwaway vault, then scores the produced draft body with the
+production :func:`creek.generate.ai_style.scan` / ``voice_distance`` metric
+against a :class:`VoiceFingerprint` built from that vault. This is the layer
+that would have caught the bad draft for real, not just in fixtures.
+
+A genuine network run requires ``CREEK_ANTHROPIC_CONSENT`` and is
+non-deterministic, so it cannot be hermetic or assert on exact text. Per the
+issue, this test therefore **stubs the LLM** (no network) while keeping the
+``e2e`` marker and the full threshold-assertion structure: the draft flows
+through ``generate_draft`` exactly as in production, and only the model hop
+is replaced by a fixed emitter. Two emitters are exercised:
+
+* an *in-voice* emitter, whose draft must score ``voice_distance <=
+  DRAFT_MAX_VOICE_DISTANCE`` and fire no HARD tell above baseline; and
+* a *slop* emitter, whose draft the harness must *catch* (distance above the
+  in-voice ceiling) — proving the backstop actually fires end to end.
+
+Marked ``@pytest.mark.e2e`` so it is **excluded from the default
+``./scripts/test.sh`` gate** (which runs ``-m "not e2e"``, CI-003) and only
+runs under ``--all`` / ``--e2e``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.config import AIStyleConfig
+from creek.generate.ai_style import build_fingerprint, scan
+from creek.generate.drafts import DraftGenerator
+from creek.generate.mining import IdeaSeed, MiningStrategy
+from creek.models import Frequency
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.e2e
+
+DRAFT_MAX_VOICE_DISTANCE = 0.03
+"""Upper bound on a generated draft's ``voice_distance`` for the in-voice
+emitter. Matches the Layer A in-voice ceiling: a draft that genuinely sounds
+like the owner must land in the same band as the owner's own prose. Bounded
+threshold (not exact text) because LLM output is non-deterministic in a real
+run; the stub stays well inside it."""
+
+SLOP_DRAFT_MIN_VOICE_DISTANCE = 0.05
+"""Lower bound the slop emitter's draft must exceed so the harness is proven
+to *catch* divergence end to end (the regression tripwire), not merely pass
+trivially. Matches the Layer A slop floor."""
+
+_IN_VOICE_DRAFT = (
+    "I sat with the cold coffee again this morning and did not do much. "
+    "The dog needed walking and I did not feel like it, so I went anyway. "
+    "The air helped, the way it usually does. Nothing was solved but I felt "
+    "a little steadier by the time I came back in.\n"
+)
+
+_SLOP_DRAFT = (
+    "Not metaphorically. Functionally. The work isn't to save everyone. "
+    "The work is to be findable. My journals keep circling this. From one of "
+    "them: this pivotal moment serves as a testament to the intricate "
+    "tapestry of resilience. It is important to note that this represents a "
+    "significant shift.\n"
+)
+
+_OWNER_EXEMPLARS = (
+    "I woke up early and sat with the coffee going cold. Nothing dramatic. "
+    "I just wanted to write down that the dog needed walking.",
+    "We talked for a long time about the boat. He wants to fix the engine "
+    "himself. I told him that was a bad idea but he is stubborn and so am I.",
+    "The kids were loud at dinner. I lost my temper over something small and "
+    "felt bad after. Some days I manage to slow down. Today I did not.",
+    "I have been reading the same book for a month. A few pages a night. It "
+    "is slow but I like it and there is no hurry.",
+    "Spent the afternoon clearing the shed. Found my father's old tools at "
+    "the back and sat on the floor for a while holding the hammer.",
+    "Rain again. The garden is a mess and I cannot get out to it. I made soup "
+    "instead and it was fine, a bit too salty.",
+)
+
+
+def _scaffold_vault(vault: Path) -> None:
+    """Create the vault folders and self-authored seed fragments.
+
+    Args:
+        vault: The throwaway vault root.
+    """
+    for sub in ("01-Fragments", "02-Threads", "03-Eddies", "07-Voice/Drafts"):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+    fragments = vault / "01-Fragments"
+    for index, body in enumerate(_OWNER_EXEMPLARS):
+        front = (
+            "---\n"
+            f"id: frag-{index:03d}\n"
+            "source:\n"
+            "  author: self\n"
+            "  platform: markdown\n"
+            "privacy_tier: open\n"
+            "---\n"
+            f"{body}\n"
+        )
+        (fragments / f"frag-{index:03d}.md").write_text(front, encoding="utf-8")
+
+
+def _skill_tree(vault: Path) -> Path:
+    """Create an empty skill tree and return its root.
+
+    Args:
+        vault: The throwaway vault root.
+
+    Returns:
+        The skills-root directory.
+    """
+    root = vault / "skills"
+    for sub in ("frequencies", "phases", "modes", "registers"):
+        (root / sub).mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _seed() -> IdeaSeed:
+    """Return the fixed idea seed every emitter drafts from."""
+    return IdeaSeed(
+        strategy=MiningStrategy.LIMINAL_CROSS_EDDY,
+        title="A quiet morning",
+        source_fragments=("frag-000",),
+        threads=(),
+        eddies=(),
+        frequency_affinity=(Frequency.F1,),
+        brief_description="An ordinary morning, written plainly.",
+        score=0.8,
+    )
+
+
+def _generate_body(vault: Path, emitted: str) -> str:
+    """Run the real draft path with a fixed LLM emitter and return the body.
+
+    Args:
+        vault: The scaffolded throwaway vault.
+        emitted: The exact draft body the stubbed LLM returns.
+
+    Returns:
+        The generated :class:`~creek.generate.drafts.Draft` body.
+    """
+    generator = DraftGenerator(
+        llm=lambda _prompt: emitted,
+        skills_root=_skill_tree(vault),
+    )
+    draft = generator.generate_draft(_seed(), vault_path=vault)
+    return draft.body
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Path:
+    """Return a scaffolded throwaway vault with owner exemplar fragments."""
+    _scaffold_vault(tmp_path)
+    return tmp_path
+
+
+class TestDraftVoiceFidelityE2E:
+    """End-to-end: real draft path scored by the production voice metric."""
+
+    def test_in_voice_draft_scores_within_threshold(self, vault: Path) -> None:
+        """An owner-sounding draft lands in the in-voice band with no findings."""
+        config = AIStyleConfig()
+        fingerprint = build_fingerprint(vault, config)
+        assert not fingerprint.is_thin(config.min_fingerprint_fragments)
+        body = _generate_body(vault, _IN_VOICE_DRAFT)
+        report = scan(body, fingerprint=fingerprint, config=config)
+        assert report.voice_distance <= DRAFT_MAX_VOICE_DISTANCE
+        assert report.findings == []
+
+    def test_slop_draft_is_caught(self, vault: Path) -> None:
+        """A slop draft from the same path is flagged above the in-voice ceiling.
+
+        Proves the backstop fires end to end: had the bad draft come through
+        ``generate_draft``, this assertion would have caught it.
+        """
+        config = AIStyleConfig()
+        fingerprint = build_fingerprint(vault, config)
+        body = _generate_body(vault, _SLOP_DRAFT)
+        report = scan(body, fingerprint=fingerprint, config=config)
+        assert report.voice_distance >= SLOP_DRAFT_MIN_VOICE_DISTANCE
+        assert report.findings
+
+    def test_saved_draft_body_is_what_was_scored(self, vault: Path) -> None:
+        """The body flowing through the draft path is the prose under test.
+
+        A guard against the harness silently scoring an empty or
+        frontmatter-only body and passing for the wrong reason.
+        """
+        body = _generate_body(vault, _IN_VOICE_DRAFT)
+        post = frontmatter.loads(body)
+        assert post.content.strip()

--- a/creek-tools/tests/fixtures/voice/README.md
+++ b/creek-tools/tests/fixtures/voice/README.md
@@ -1,0 +1,22 @@
+# Voice-fidelity regression fixtures
+
+Hand-written, representative snippets used by
+`tests/generate/ai_style/test_voice_regression_harness.py` (issue #520) to
+prove the `ai_style` scanner separates the owner's voice from AI slop.
+
+**This repo holds no vault content (FEAT-019).** Nothing here is a real
+journal export. The `in_voice/` snippets are short, hand-authored,
+plain-prose stand-ins for the owner's reflective first-person writing; they
+exist only to seed a `VoiceFingerprint` and to act as a held-out
+no-false-reject control. The `slop/` snippets are hand-authored caricatures
+of the real failure modes that motivated the issue (antithesis saturation,
+the journal-meta provenance tell, and Wikipedia-style peacock/significance
+padding).
+
+- `in_voice/*.md` — plain, reflective, first-person prose. Must score
+  **below** the in-voice distance threshold.
+- `slop/*.md` — AI-slop caricatures. Must score **above** the slop distance
+  threshold, with a margin over the in-voice band.
+
+Each file is a bare prose snippet (no frontmatter); the harness loads the
+raw text.

--- a/creek-tools/tests/fixtures/voice/in_voice/01_morning.md
+++ b/creek-tools/tests/fixtures/voice/in_voice/01_morning.md
@@ -1,0 +1,3 @@
+I woke up early and sat with the coffee going cold. Nothing dramatic. I
+just wanted to write down that the dog needed walking and I did not feel
+like it. So I went anyway and the cold air helped, the way it usually does.

--- a/creek-tools/tests/fixtures/voice/in_voice/02_boat.md
+++ b/creek-tools/tests/fixtures/voice/in_voice/02_boat.md
@@ -1,0 +1,3 @@
+We talked for a long time about the boat. He wants to fix the engine
+himself. I told him I thought that was a bad idea but he is stubborn and so
+am I. We left it there, the way we always do, half-decided.

--- a/creek-tools/tests/fixtures/voice/in_voice/03_dinner.md
+++ b/creek-tools/tests/fixtures/voice/in_voice/03_dinner.md
@@ -1,0 +1,3 @@
+The kids were loud at dinner. I lost my temper over something small and
+felt bad after. I keep telling myself to slow down before I snap. Some days
+I manage it. Today I did not.

--- a/creek-tools/tests/fixtures/voice/in_voice/04_book.md
+++ b/creek-tools/tests/fixtures/voice/in_voice/04_book.md
@@ -1,0 +1,3 @@
+I have been reading the same book for a month now. A few pages a night. It
+is slow but I like it. There is no hurry and that feels like a small kind of
+luxury.

--- a/creek-tools/tests/fixtures/voice/in_voice/05_shed.md
+++ b/creek-tools/tests/fixtures/voice/in_voice/05_shed.md
@@ -1,0 +1,3 @@
+Spent the afternoon clearing the shed. Found my father's old tools at the
+back. I sat on the floor and held the hammer for a while and did not do much
+else. It was quiet out there and I did not mind the dust.

--- a/creek-tools/tests/fixtures/voice/in_voice/06_rain.md
+++ b/creek-tools/tests/fixtures/voice/in_voice/06_rain.md
@@ -1,0 +1,3 @@
+Rain again. The garden is a mess and I cannot get out to it. I made soup
+instead and it was fine, a bit too salty. The house smelled good though, and
+that was enough for the day.

--- a/creek-tools/tests/fixtures/voice/slop/01_antithesis.md
+++ b/creek-tools/tests/fixtures/voice/slop/01_antithesis.md
@@ -1,0 +1,2 @@
+Not metaphorically. Functionally. The work isn't to save everyone. The work
+is to be findable. It's not about being seen, it's about being legible.

--- a/creek-tools/tests/fixtures/voice/slop/02_journal_meta.md
+++ b/creek-tools/tests/fixtures/voice/slop/02_journal_meta.md
@@ -1,0 +1,3 @@
+My journals keep circling this. From one of them: the question was never
+about belief, it was about attention. As I wrote, the answer is not in the
+noise but in the silence.

--- a/creek-tools/tests/fixtures/voice/slop/03_wiki_padding.md
+++ b/creek-tools/tests/fixtures/voice/slop/03_wiki_padding.md
@@ -1,0 +1,4 @@
+This pivotal moment serves as a testament to the intricate tapestry of human
+resilience, underscoring the profound nature of our shared journey. It is
+important to note that this represents a significant shift. In conclusion,
+the broader narrative endures.

--- a/creek-tools/tests/generate/ai_style/test_voice_regression_harness.py
+++ b/creek-tools/tests/generate/ai_style/test_voice_regression_harness.py
@@ -1,0 +1,269 @@
+"""Voice-fidelity regression harness — Layer A (issue #520).
+
+The deterministic, offline backstop that would have caught the bad draft:
+it proves the existing :mod:`creek.generate.ai_style` scanner actually
+*discriminates* the owner's plain reflective prose from AI slop, and that
+it does so without rejecting the owner himself.
+
+Two properties are pinned here, both using the real production API
+(:func:`creek.generate.ai_style.build_fingerprint` to build a
+:class:`VoiceFingerprint` and :func:`creek.generate.ai_style.scan` to score
+text — the same ``voice_distance`` metric ``creek report --type
+fingerprint`` and the draft guard consume; no invented metric):
+
+1. **Discrimination.** Every in-voice fixture scores *below*
+   :data:`IN_VOICE_MAX_DISTANCE` (and fires no findings), while every
+   AI-slop fixture scores *above* :data:`SLOP_MIN_DISTANCE` (and fires at
+   least one finding), with a clear :data:`DISCRIMINATION_MARGIN` band
+   between the two thresholds.
+2. **Calibration / no-false-reject.** One in-voice exemplar is *held out*
+   of the fingerprint-training set; the held-out genuine snippet must still
+   score as in-voice. This guards against a metric tuned so strict that it
+   would flag the owner's own writing.
+
+The fixtures live under ``tests/fixtures/voice/`` and are short,
+hand-written stand-ins (this repo holds no vault content per FEAT-019); the
+slop set reproduces the real failure modes — antithesis saturation
+(``"Not metaphorically. Functionally."``), the journal-meta provenance tell
+(``"My journals keep circling this. From one of them:"``), and
+Wikipedia-style significance/peacock padding.
+
+Pure, deterministic, offline → runs in the normal ``./scripts/check-all.sh``
+gate. As the sibling detectors (#515-#518) sharpen, the observed margin
+should only widen; these thresholds pin the floor.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.config import AIStyleConfig
+from creek.generate.ai_style import build_fingerprint, scan
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from creek.generate.ai_style import VoiceFingerprint
+
+# --- Calibration constants -------------------------------------------------
+# All three are derived empirically from the shipped fixtures (see the
+# module docstring). The owner's plain prose diverges from his own
+# fingerprint by exactly 0.0 (it *is* the baseline); the slop fixtures land
+# at 0.057 (antithesis), 0.061 (journal-meta) and 0.295 (wiki padding). The
+# thresholds carve a generous dead-band around the weakest discriminator so
+# the test fails loudly if a future change collapses the separation, while
+# never sitting so close to the in-voice band that ordinary prose could trip
+# it.
+
+IN_VOICE_MAX_DISTANCE = 0.03
+"""Upper bound on ``voice_distance`` for genuine owner prose. Observed
+value is 0.0; the headroom absorbs benign drift in the fixtures or the
+feature extractors without ever approaching the slop band."""
+
+SLOP_MIN_DISTANCE = 0.05
+"""Lower bound on ``voice_distance`` for AI slop. The weakest slop fixture
+(antithesis saturation) measures ~0.057, so 0.05 is the floor every slop
+sample must clear — the regression tripwire if a detector regresses."""
+
+DISCRIMINATION_MARGIN = SLOP_MIN_DISTANCE - IN_VOICE_MAX_DISTANCE
+"""The required dead-band between the in-voice ceiling and the slop floor.
+A non-trivial gap (0.02) is the whole point: it certifies the metric does
+not merely rank slop higher, it separates the two populations cleanly."""
+
+# Minimum eligible fragments below which the fingerprint is "thin" and
+# distance is softened (mirrors ``AIStyleConfig.min_fingerprint_fragments``).
+# The held-out training set must stay above this so the calibration check
+# scores against a *trusted* fingerprint, not a softened one.
+_MIN_TRUSTED_FRAGMENTS = AIStyleConfig().min_fingerprint_fragments
+
+_FIXTURE_ROOT_PARTS = ("fixtures", "voice")
+
+
+def _voice_fixture_root(request: pytest.FixtureRequest) -> Path:
+    """Return the ``tests/fixtures/voice`` directory for this test module.
+
+    Args:
+        request: The active pytest request (used to locate ``tests/``).
+
+    Returns:
+        The absolute path to the voice fixture root.
+    """
+    tests_dir = request.config.rootpath / "tests"
+    return tests_dir.joinpath(*_FIXTURE_ROOT_PARTS)
+
+
+def _load_snippets(directory: Path) -> list[tuple[str, str]]:
+    """Return ``(name, text)`` for every ``*.md`` snippet under *directory*.
+
+    Args:
+        directory: A fixture subdirectory (``in_voice`` or ``slop``).
+
+    Returns:
+        Sorted ``(filename, raw prose)`` pairs.
+    """
+    return [
+        (path.name, path.read_text(encoding="utf-8"))
+        for path in sorted(directory.glob("*.md"))
+    ]
+
+
+def _fingerprint_from_texts(
+    texts: list[str],
+    tmp_path: Path,
+    config: AIStyleConfig,
+) -> VoiceFingerprint:
+    """Build a :class:`VoiceFingerprint` from in-memory exemplar *texts*.
+
+    Each text is written as a minimal self-authored fragment into a throwaway
+    vault so the real :func:`build_fingerprint` (the production profiler)
+    measures them — no metric is reimplemented here.
+
+    Args:
+        texts: The in-voice exemplar bodies.
+        tmp_path: A unique throwaway directory to scaffold the vault under.
+        config: The AI-style configuration to profile with.
+
+    Returns:
+        The fingerprint built from *texts*.
+    """
+    fragments_dir = tmp_path / "01-Fragments"
+    fragments_dir.mkdir(parents=True, exist_ok=True)
+    for index, text in enumerate(texts):
+        fragment = (
+            "---\n"
+            "source:\n"
+            "  author: self\n"
+            "  platform: markdown\n"
+            "privacy_tier: open\n"
+            "---\n"
+            f"{text}\n"
+        )
+        (fragments_dir / f"exemplar_{index:02d}.md").write_text(
+            fragment,
+            encoding="utf-8",
+        )
+    return build_fingerprint(tmp_path, config)
+
+
+@pytest.fixture
+def config() -> AIStyleConfig:
+    """Return the default AI-style configuration used by every assertion."""
+    return AIStyleConfig()
+
+
+@pytest.fixture
+def in_voice_snippets(request: pytest.FixtureRequest) -> list[tuple[str, str]]:
+    """Return the in-voice ``(name, text)`` fixtures."""
+    return _load_snippets(_voice_fixture_root(request) / "in_voice")
+
+
+@pytest.fixture
+def slop_snippets(request: pytest.FixtureRequest) -> list[tuple[str, str]]:
+    """Return the AI-slop ``(name, text)`` fixtures."""
+    return _load_snippets(_voice_fixture_root(request) / "slop")
+
+
+class TestFixtureSanity:
+    """Guard the fixtures themselves so the harness can't silently no-op."""
+
+    def test_threshold_band_is_well_formed(self) -> None:
+        """The slop floor sits strictly above the in-voice ceiling."""
+        assert IN_VOICE_MAX_DISTANCE < SLOP_MIN_DISTANCE
+        assert DISCRIMINATION_MARGIN > 0.0
+
+    def test_enough_in_voice_fixtures_for_holdout(
+        self,
+        in_voice_snippets: list[tuple[str, str]],
+    ) -> None:
+        """Holding one out must still leave a trusted (non-thin) fingerprint."""
+        assert len(in_voice_snippets) - 1 >= _MIN_TRUSTED_FRAGMENTS
+
+    def test_slop_fixtures_present(
+        self,
+        slop_snippets: list[tuple[str, str]],
+    ) -> None:
+        """The known failure modes are all represented."""
+        names = {name for name, _ in slop_snippets}
+        assert {"01_antithesis.md", "02_journal_meta.md", "03_wiki_padding.md"} <= names
+
+
+class TestDiscrimination:
+    """Property 1: in-voice scores low, slop scores high, with a margin."""
+
+    def test_in_voice_scores_below_threshold(
+        self,
+        in_voice_snippets: list[tuple[str, str]],
+        tmp_path: Path,
+        config: AIStyleConfig,
+    ) -> None:
+        """Every in-voice fixture lands in the in-voice band with no findings."""
+        texts = [text for _, text in in_voice_snippets]
+        fingerprint = _fingerprint_from_texts(texts, tmp_path, config)
+        assert not fingerprint.is_thin(_MIN_TRUSTED_FRAGMENTS)
+        for name, text in in_voice_snippets:
+            report = scan(text, fingerprint=fingerprint, config=config)
+            assert report.voice_distance <= IN_VOICE_MAX_DISTANCE, name
+            assert report.findings == [], name
+
+    def test_slop_scores_above_threshold(
+        self,
+        in_voice_snippets: list[tuple[str, str]],
+        slop_snippets: list[tuple[str, str]],
+        tmp_path: Path,
+        config: AIStyleConfig,
+    ) -> None:
+        """Every slop fixture clears the slop floor and fires ≥1 finding."""
+        texts = [text for _, text in in_voice_snippets]
+        fingerprint = _fingerprint_from_texts(texts, tmp_path, config)
+        for name, text in slop_snippets:
+            report = scan(text, fingerprint=fingerprint, config=config)
+            assert report.voice_distance >= SLOP_MIN_DISTANCE, name
+            assert report.findings, name
+
+    def test_every_slop_beats_every_in_voice_with_margin(
+        self,
+        in_voice_snippets: list[tuple[str, str]],
+        slop_snippets: list[tuple[str, str]],
+        tmp_path: Path,
+        config: AIStyleConfig,
+    ) -> None:
+        """The worst slop still out-distances the worst in-voice by the margin."""
+        texts = [text for _, text in in_voice_snippets]
+        fingerprint = _fingerprint_from_texts(texts, tmp_path, config)
+        in_voice_scores = [
+            scan(text, fingerprint=fingerprint, config=config).voice_distance
+            for _, text in in_voice_snippets
+        ]
+        slop_scores = [
+            scan(text, fingerprint=fingerprint, config=config).voice_distance
+            for _, text in slop_snippets
+        ]
+        assert min(slop_scores) - max(in_voice_scores) >= DISCRIMINATION_MARGIN
+
+
+class TestCalibration:
+    """Property 2: a held-out genuine exemplar is not falsely rejected."""
+
+    def test_held_out_owner_exemplar_scores_in_voice(
+        self,
+        in_voice_snippets: list[tuple[str, str]],
+        tmp_path: Path,
+        config: AIStyleConfig,
+    ) -> None:
+        """Train on all but one exemplar; the held-out real snippet stays low.
+
+        This is the no-false-reject guard: a metric so strict it would flag
+        the owner's own unseen writing would fail here even while passing
+        discrimination.
+        """
+        held_out_name, held_out_text = in_voice_snippets[-1]
+        training_texts = [text for _, text in in_voice_snippets[:-1]]
+        fingerprint = _fingerprint_from_texts(training_texts, tmp_path, config)
+        # The held-out exemplar must be scored against a *trusted* (non-thin)
+        # fingerprint, else softening — not genuine similarity — would carry it.
+        assert not fingerprint.is_thin(_MIN_TRUSTED_FRAGMENTS)
+        report = scan(held_out_text, fingerprint=fingerprint, config=config)
+        assert report.voice_distance <= IN_VOICE_MAX_DISTANCE, held_out_name
+        assert report.findings == [], held_out_name


### PR DESCRIPTION
## Summary
- Adds the end-to-end voice-fidelity regression backstop from #520, built on the existing `ai_style` scanner (`build_fingerprint` + `scan` / `voice_distance`) — no invented metric. This is the test that would have caught a draft that stopped sounding like the owner.
- **Layer A (CI-safe, no LLM, runs in the default gate):** `tests/generate/ai_style/test_voice_regression_harness.py` builds a `VoiceFingerprint` from hand-written in-voice exemplars under `tests/fixtures/voice/` and asserts **discrimination** (every in-voice snippet scores below the in-voice ceiling with 0 findings; every slop snippet — antithesis saturation, the journal-meta provenance tell, and Wikipedia-style padding — scores above the slop floor with a margin) and **calibration / no-false-reject** (one real exemplar is held out of training and must still score in-voice). Thresholds are named, docstring-calibrated constants.
- **Layer B (opt-in `@pytest.mark.e2e`, excluded from the default gate):** `tests/e2e/test_voice_fidelity_e2e.py` runs the real `DraftGenerator.generate_draft` path on a fixed seed in a throwaway vault and scores the produced draft with the production `voice_distance` metric, asserting bounded thresholds (not exact text) and that a slop draft is caught. Per the issue, the LLM hop is stubbed (no network) to make the run hermetic while keeping the `e2e` marker and the full threshold-assertion structure.
- Deferred the optional `creek voice-check <file>` subcommand to follow-up #533 to keep this PR test-only.

## Calibration
Built from the shipped fixtures: in-voice prose scores `voice_distance` 0.0 (it *is* the baseline); slop scores 0.057 (antithesis), 0.061 (journal-meta), 0.295 (wiki padding). Constants: `IN_VOICE_MAX_DISTANCE = 0.03`, `SLOP_MIN_DISTANCE = 0.05`, `DISCRIMINATION_MARGIN = 0.02` — a generous dead-band around the weakest discriminator so a future regression that collapses the separation fails loudly, without sitting close enough to the in-voice band to trip on ordinary prose.

## Test plan
- `cd creek-tools && ./scripts/check-all.sh` → exit 0 (5111 passed, 23 deselected; coverage 93.78%; all 12 quality gates green).
- Confirmed Layer B is **not** collected under the default `-m "not integration and not e2e and not slow"` run (0 items) and Layer A (7 items) is.
- Ran `pytest tests/e2e/test_voice_fidelity_e2e.py -m e2e` → 3 passed (the opt-in path).

Closes #520
Refs #417
