### PR TITLE
feat(voice): gloss bespoke ontology terms in plain English on first mention

### DIFF
--- a/creek-tools/creek/author/checks.py
+++ b/creek-tools/creek/author/checks.py
@@ -23,6 +23,7 @@ import yaml
 from creek.author.models import ReflectionFinding
 from creek.generate.ai_style.scanner import scan
 from creek.generate.grounding import scan_biographical_sentences
+from creek.generate.jargon import detect_unglossed_jargon
 
 # Reuse the canonical INC-019 alias vocabulary (public constants) rather than
 # duplicating it, so the ontological-accuracy check and the model validators
@@ -271,6 +272,33 @@ def check_ontological_accuracy(body: str) -> list[ReflectionFinding]:
         )
         for alias, canonical in _LEGACY_ALIASES.items()
         if re.search(rf"\b{re.escape(alias)}\b", body, flags=re.IGNORECASE)
+    ]
+
+
+def check_unglossed_jargon(body: str) -> list[ReflectionFinding]:
+    """Flag bespoke ontology terms used on first mention without a gloss.
+
+    Wraps the conservative :func:`detect_unglossed_jargon` detector: each
+    un-glossed first mention of a bespoke term (a Frequency, Phase, Mode,
+    altitude, or named concept) becomes a ``MID`` ``unglossed_jargon`` finding so
+    a newcomer-facing draft can be revised to weave the gloss in. The detector is
+    biased toward false negatives (it never flags a term with any nearby
+    explanatory phrasing), so a finding here is a soft nudge, not a hard block.
+
+    Args:
+        body: The drafted prose under review.
+
+    Returns:
+        One ``MID`` finding per un-glossed first mention, dimension
+        ``"unglossed_jargon"``.
+    """
+    return [
+        ReflectionFinding(
+            dimension="unglossed_jargon",
+            severity="MID",
+            message=finding.message,
+        )
+        for finding in detect_unglossed_jargon(body)
     ]
 
 

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -39,6 +39,7 @@ FindingDimension = Literal[
     "paradox_preservation",
     "attribution_correctness",
     "biographical_grounding",
+    "unglossed_jargon",
 ]
 
 

--- a/creek-tools/creek/author/reflection.py
+++ b/creek-tools/creek/author/reflection.py
@@ -19,6 +19,7 @@ from creek.author.checks import (
     check_ontological_accuracy,
     check_paradox_preservation,
     check_privacy_compliance,
+    check_unglossed_jargon,
     check_voice_fidelity,
 )
 from creek.author.models import (
@@ -106,6 +107,7 @@ class ReflectionNode:
         findings.extend(check_citation_completeness(evidence))
         findings.extend(check_privacy_compliance(body, evidence, vault, contract))
         findings.extend(check_ontological_accuracy(body))
+        findings.extend(check_unglossed_jargon(body))
         findings.extend(check_paradox_preservation(body, evidence))
         findings.extend(check_attribution_correctness(body, evidence))
         findings.extend(check_voice_fidelity(body, fingerprint, ai_style_config))

--- a/creek-tools/creek/author/voice.py
+++ b/creek-tools/creek/author/voice.py
@@ -25,6 +25,7 @@ from creek.author.skills import (
     find_voice_core,
     read_skill,
 )
+from creek.generate.ontology_glossary import GLOSS_STEER
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -235,6 +236,7 @@ def _ask_section(
         "journal, note, or entry, and never narrate that you are quoting "
         "yourself. State the idea, not its provenance.",
         "Do not quote borrowed authors as my own words.",
+        GLOSS_STEER,
     ]
     if contract is not None and contract.structure:
         order = " → ".join(contract.structure)

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -66,6 +66,7 @@ from creek.generate.grounding import (
     scan_biographical_sentences,
     score_draft,
 )
+from creek.generate.ontology_glossary import GLOSS_STEER
 from creek.generate.outline import (
     OutlineSection,
     build_stitch_prompt,
@@ -2472,6 +2473,14 @@ _NO_PROVENANCE_STEER = (
     "State the idea, not its provenance."
 )
 
+#: Prompt steer asking the model to gloss each bespoke ontology term in the
+#: owner's voice on its first mention so a newcomer can follow. Appended to every
+#: ``## Ask`` variant and pinned by a structure test so it can never silently
+#: drop out of the prompt. Sourced from the glossary registry's
+#: :data:`~creek.generate.ontology_glossary.GLOSS_STEER` so the draft and voice
+#: surfaces carry identical wording.
+_GLOSS_STEER = GLOSS_STEER
+
 
 def _compose_ask_section(
     idea: IdeaSeed,
@@ -2489,10 +2498,10 @@ def _compose_ask_section(
     the original wording so existing tests and mined-idea drafts
     continue to compose identically.
 
-    Every variant ends with :data:`_NO_FABRICATION_STEER` and
-    :data:`_NO_PROVENANCE_STEER` so the draft prompt always carries the
-    issue #515 no-fabrication instruction and the issue #517 weave-the-source-in
-    instruction.
+    Every variant ends with :data:`_NO_FABRICATION_STEER`,
+    :data:`_NO_PROVENANCE_STEER` and :data:`_GLOSS_STEER` so the draft prompt
+    always carries the no-fabrication, weave-the-source-in, and
+    gloss-bespoke-terms-on-first-mention instructions.
     """
     if twist:
         return (
@@ -2505,7 +2514,7 @@ def _compose_ask_section(
             "verbatim — recombine across the corpus. Honour the "
             "activated skills. Write as the human — not as an AI. "
             "Cite source fragments by their IDs where relevant. "
-            f"{_NO_FABRICATION_STEER} {_NO_PROVENANCE_STEER}"
+            f"{_NO_FABRICATION_STEER} {_NO_PROVENANCE_STEER} {_GLOSS_STEER}"
         )
     if per_dimension:
         return (
@@ -2517,7 +2526,8 @@ def _compose_ask_section(
             "rather than treating any one section as the source of "
             "truth. Honour the activated skills. Write as the human — "
             "not as an AI. Cite source fragments by their IDs where "
-            f"relevant. {_NO_FABRICATION_STEER} {_NO_PROVENANCE_STEER}"
+            f"relevant. {_NO_FABRICATION_STEER} {_NO_PROVENANCE_STEER} "
+            f"{_GLOSS_STEER}"
         )
     return (
         "## Ask\n"
@@ -2525,7 +2535,7 @@ def _compose_ask_section(
         f"{idea.brief_description} "
         "Write as the human — not as an AI. Honour the activated "
         f"skills. Cite source fragments by their IDs where relevant. "
-        f"{_NO_FABRICATION_STEER} {_NO_PROVENANCE_STEER}"
+        f"{_NO_FABRICATION_STEER} {_NO_PROVENANCE_STEER} {_GLOSS_STEER}"
     )
 
 

--- a/creek-tools/creek/generate/jargon.py
+++ b/creek-tools/creek/generate/jargon.py
@@ -1,0 +1,142 @@
+"""Conservative detector for un-glossed bespoke ontology jargon.
+
+Scans a drafted body for the bespoke terms in
+:func:`~creek.generate.ontology_glossary.ontology_term_registry` and, for each
+term's **first** occurrence only, flags it when no explanatory gloss appears in
+a small window after it. A second occurrence is never flagged — the owner's
+contract is to gloss each term once, on first mention.
+
+The detector is deliberately biased toward **false negatives**: it would rather
+miss an un-glossed term than wrongly flag a term that already carries a nearby
+explanation. A first mention is considered glossed when the window after it
+holds any gloss signal — an em-dash, a parenthetical, an appositive comma, a
+``which is`` / ``the … where`` clause, or one of the term's own gloss-seed
+keywords. Surface forms are matched case-sensitively on a word boundary so an
+ordinary lower-case word (``rising`` the verb) or a capitalised non-term
+(``London``) never trips the scan.
+"""
+
+from __future__ import annotations
+
+import operator
+import re
+from dataclasses import dataclass
+
+from creek.generate.ontology_glossary import OntologyTerm, ontology_term_registry
+
+#: Characters/clauses that, appearing in the window after a first mention, count
+#: as an explanatory gloss signal (an appositive, parenthetical or relative
+#: clause). Kept small and high-precision so the detector errs toward misses.
+_GLOSS_MARKERS: tuple[str, ...] = (
+    "—",  # em-dash appositive: "Ultraviolet -- the altitude where ..."
+    "\u2013",  # en-dash, used the same way
+    " - ",  # spaced hyphen appositive
+    "(",  # parenthetical: "Peaking (the full expression …)"
+    "which is",
+    "which means",
+    ", the ",  # comma appositive: "F8, the voice of my higher self"
+    ": the ",  # colon appositive: "Peaking: the full expression …"
+    ", my ",  # comma appositive in first person: "F8, my true self speaking"
+)
+
+#: How many characters after a first mention to scan for a gloss signal. A gloss
+#: is an appositive or short clause, so it sits right next to the term; a wide
+#: window would let an unrelated later sentence falsely "explain" the term.
+_GLOSS_WINDOW: int = 90
+
+#: Minimum length for a gloss-seed word to count as a nearby-explanation signal.
+#: Short words (``the``, ``of``) carry no topical weight.
+_MIN_SEED_WORD: int = 4
+
+
+@dataclass(frozen=True)
+class UnglossedJargonFinding:
+    """One bespoke term used on first mention without a nearby gloss.
+
+    Attributes:
+        term: The surface form that was used un-glossed (e.g. ``"Ultraviolet"``).
+        severity: Always ``"MID"`` — a soft finding, since a false hit costs at
+            most one revise round, never a hard block.
+        message: A human-readable explanation naming the term and its gloss seed.
+    """
+
+    term: str
+    severity: str
+    message: str
+
+
+def _seed_keywords(term: OntologyTerm) -> set[str]:
+    """Return the significant (>= 4-char) lower-cased words of a term's seed."""
+    pattern = rf"[a-z]{{{_MIN_SEED_WORD},}}"
+    return set(re.findall(pattern, term.gloss_seed.lower()))
+
+
+def _window_has_gloss(window: str, term: OntologyTerm) -> bool:
+    """Return whether *window* (text just after a first mention) glosses *term*.
+
+    A gloss is present when the window carries any structural marker (em-dash,
+    parenthetical, appositive comma, ``which is`` clause) or mentions one of the
+    term's own gloss-seed keywords.
+    """
+    if any(marker in window for marker in _GLOSS_MARKERS):
+        return True
+    lowered = window.lower()
+    return any(keyword in lowered for keyword in _seed_keywords(term))
+
+
+def _first_match(body: str, surface: str) -> re.Match[str] | None:
+    """Return the first word-boundary, case-sensitive match of *surface*."""
+    return re.search(rf"\b{re.escape(surface)}\b", body)
+
+
+def _earliest_mention(body: str, term: OntologyTerm) -> re.Match[str] | None:
+    """Return the earliest match of any of *term*'s surface forms in *body*."""
+    best: re.Match[str] | None = None
+    for surface in (term.label, *term.aliases):
+        match = _first_match(body, surface)
+        if match is not None and (best is None or match.start() < best.start()):
+            best = match
+    return best
+
+
+def _build_finding(match: re.Match[str], term: OntologyTerm) -> UnglossedJargonFinding:
+    """Build the ``MID`` finding for an un-glossed first mention *match*."""
+    return UnglossedJargonFinding(
+        term=match.group(),
+        severity="MID",
+        message=(
+            f"Bespoke term {match.group()!r} is used on first mention "
+            "without a plain-English gloss a newcomer could follow; "
+            f"weave in a short clause (seed: {term.gloss_seed!r})."
+        ),
+    )
+
+
+def detect_unglossed_jargon(body: str) -> list[UnglossedJargonFinding]:
+    """Flag each bespoke term whose first mention carries no nearby gloss.
+
+    For every distinct registered term, the earliest surface form that appears
+    in *body* is located; if no gloss signal sits in the window after it, one
+    ``MID`` finding is raised. Only the first mention is considered, so a later
+    repeat of the same term is never separately flagged.
+
+    Args:
+        body: The drafted prose under review.
+
+    Returns:
+        One :class:`UnglossedJargonFinding` per un-glossed first mention,
+        ordered by where the term first appears in the body.
+    """
+    if not body.strip():
+        return []
+    # Collapse aliases: judge each term once, at its earliest surface form.
+    findings: list[tuple[int, UnglossedJargonFinding]] = []
+    for term in dict.fromkeys(ontology_term_registry().values()):
+        match = _earliest_mention(body, term)
+        if match is None:
+            continue
+        window = body[match.end() : match.end() + _GLOSS_WINDOW]
+        if _window_has_gloss(window, term):
+            continue
+        findings.append((match.start(), _build_finding(match, term)))
+    return [finding for _start, finding in sorted(findings, key=operator.itemgetter(0))]

--- a/creek-tools/creek/generate/ontology_glossary.py
+++ b/creek-tools/creek/generate/ontology_glossary.py
@@ -1,0 +1,220 @@
+"""Registry of bespoke Creek-ontology terms and their plain-English gloss seeds.
+
+Drafts written in the owner's voice lean on bespoke vocabulary — APTITUDE
+**Frequencies** (``F1`` through ``F10`` and their labels), Archetypal-Wavelength
+**Phases** (Rising, Peaking, …), engagement **Modes**, developmental
+**altitudes** (Teal, Ultraviolet), and named concepts (APTITUDE, the Whole
+Adept, the Archetypal Wavelength, the non-dual substrate). A newcomer cannot
+follow prose that uses these as if the reader were already an initiate.
+
+This module is the **single source of truth** for that vocabulary. Every
+:class:`OntologyTerm` is *derived* from the existing taxonomy constants — the
+``Frequency`` / ``Phase`` / ``Mode`` enums and the ``FREQUENCY_*`` / ``PHASE_*``
+description maps — rather than re-typed by hand, so the glossary cannot silently
+drift from the taxonomy. A drift-guard test asserts every enum member resolves
+to an entry, so a new enum member without a gloss seed fails the build.
+
+The seeds are short hints (a clause's worth), not dictionary definitions: they
+exist to ground the model so it can phrase the gloss *in the owner's voice* on
+first mention, and to give the conservative ``unglossed_jargon`` detector a
+keyword signal that an explanation is nearby.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from creek.generate.indexes import (
+    CANONICAL_FREQUENCY_NAMES,
+    FREQUENCY_COLORS,
+    FREQUENCY_THEMES,
+)
+from creek.generate.wavelength import _PHASE_DESCRIPTIONS
+from creek.models import Frequency, Mode, Phase
+
+#: Plain-English activation sense for each engagement mode, adapted from the
+#: ``_mode_activation_phrase`` base map in :mod:`creek.generate.skills`. Kept
+#: here as a short gloss seed (not the full activation phrasing).
+_MODE_SENSES: dict[Mode, str] = {
+    Mode.INHABIT: "living inside the frequency rather than performing it",
+    Mode.EXPRESS: "enacting the frequency outward, for others to feel",
+    Mode.COLLABORATE: "working a frequency alongside other people",
+    Mode.INTEGRATE: "metabolising a frequency into a coherent whole",
+    Mode.ABSORB: "receiving a frequency rather than producing it",
+    Mode.UNCLASSIFIED: "no dominant engagement mode is in play",
+}
+
+#: Developmental-altitude colour terms surfaced in prose (e.g. "Ultraviolet").
+#: Sourced from :data:`FREQUENCY_COLORS` (the ontology colour designations) so
+#: the altitude vocabulary tracks the frequency taxonomy. Each maps to the
+#: frequency whose theme grounds its gloss seed.
+_ALTITUDE_COLORS: dict[str, Frequency] = {
+    "Teal": Frequency.F8,
+    "Ultraviolet": Frequency.F9,
+}
+
+#: Named bespoke concepts that are not enum members but read as jargon to a
+#: newcomer. Each carries its own short gloss seed grounded in the ontology.
+_NAMED_CONCEPTS: dict[str, str] = {
+    "APTITUDE": (
+        "my ten-frequency map of human motivation, from raw survival up to "
+        "egoless emptiness"
+    ),
+    "Whole Adept": (
+        "someone fluent across the whole range of frequencies, able to move "
+        "between them at will"
+    ),
+    "Archetypal Wavelength": (
+        "the six-phase rise-and-fall cycle any current of energy moves through"
+    ),
+    "non-dual substrate": (
+        "the ground where the line between self and world stops feeling real"
+    ),
+}
+
+
+@dataclass(frozen=True)
+class OntologyTerm:
+    """One bespoke ontology term with the seed for its plain-English gloss.
+
+    Attributes:
+        label: The surface form a draft writes (e.g. ``"F8"``, ``"Peaking"``,
+            ``"Ultraviolet"``, ``"APTITUDE"``).
+        category: Which family the term belongs to — ``"frequency"``,
+            ``"phase"``, ``"mode"``, ``"altitude"`` or ``"concept"``.
+        gloss_seed: A short, owner-voiced hint the model can expand into an
+            appositive gloss on first mention; also the keyword signal the
+            detector looks for nearby.
+        aliases: Extra surface forms that name the same term (e.g. a frequency's
+            APTITUDE label alongside its ``F``-code).
+    """
+
+    label: str
+    category: str
+    gloss_seed: str
+    aliases: tuple[str, ...] = ()
+
+
+def _frequency_terms() -> list[OntologyTerm]:
+    """Build a term per ``Frequency`` member from the theme/name maps."""
+    terms: list[OntologyTerm] = []
+    for freq in Frequency:
+        if freq is Frequency.UNCLASSIFIED:
+            seed = "no dominant frequency signal is present"
+            aliases: tuple[str, ...] = ()
+        else:
+            seed = FREQUENCY_THEMES[freq]
+            aliases = (CANONICAL_FREQUENCY_NAMES[freq],)
+        terms.append(
+            OntologyTerm(
+                label=freq.value,
+                category="frequency",
+                gloss_seed=seed,
+                aliases=aliases,
+            )
+        )
+    return terms
+
+
+def _phase_terms() -> list[OntologyTerm]:
+    """Build a term per ``Phase`` member from the phase-description map."""
+    return [
+        OntologyTerm(
+            label=phase.name.replace("_", " ").title(),
+            category="phase",
+            gloss_seed=_PHASE_DESCRIPTIONS[phase.value],
+            aliases=(phase.value,),
+        )
+        for phase in Phase
+    ]
+
+
+def _mode_terms() -> list[OntologyTerm]:
+    """Build a term per ``Mode`` member from the activation-sense map."""
+    return [
+        OntologyTerm(
+            label=mode.value.title(),
+            category="mode",
+            gloss_seed=_MODE_SENSES[mode],
+            aliases=(mode.value,),
+        )
+        for mode in Mode
+    ]
+
+
+def _altitude_terms() -> list[OntologyTerm]:
+    """Build a term per developmental-altitude colour from the colour map."""
+    terms: list[OntologyTerm] = []
+    for label, freq in _ALTITUDE_COLORS.items():
+        # Cross-check the colour map so the altitude vocabulary cannot drift
+        # from the frequency taxonomy it is derived from.
+        if FREQUENCY_COLORS[freq] != label.lower():  # pragma: no cover
+            continue
+        terms.append(
+            OntologyTerm(
+                label=label,
+                category="altitude",
+                gloss_seed=(
+                    f"the altitude of {FREQUENCY_THEMES[freq].split(',')[0].lower()}"
+                ),
+            )
+        )
+    return terms
+
+
+def _concept_terms() -> list[OntologyTerm]:
+    """Build a term per named bespoke concept."""
+    return [
+        OntologyTerm(label=label, category="concept", gloss_seed=seed)
+        for label, seed in _NAMED_CONCEPTS.items()
+    ]
+
+
+def iter_ontology_terms() -> list[OntologyTerm]:
+    """Return every bespoke ontology term, derived from the taxonomy constants.
+
+    Returns:
+        The frequencies, phases, modes, altitudes and named concepts, each with
+        its plain-English gloss seed.
+    """
+    return [
+        *_frequency_terms(),
+        *_phase_terms(),
+        *_mode_terms(),
+        *_altitude_terms(),
+        *_concept_terms(),
+    ]
+
+
+def ontology_term_registry() -> dict[str, OntologyTerm]:
+    """Return a lookup of every term surface form (lower-cased) to its term.
+
+    Both each term's ``label`` and its ``aliases`` are registered under their
+    exact surface form *and* a lower-cased form, so a drift-guard test can assert
+    ``freq.value in registry`` for every enum member while case-insensitive
+    lookups (an altitude or named concept written mid-sentence) still resolve.
+
+    Returns:
+        A mapping from surface form (exact and lower-cased) to
+        :class:`OntologyTerm`.
+    """
+    registry: dict[str, OntologyTerm] = {}
+    for term in iter_ontology_terms():
+        for surface in (term.label, *term.aliases):
+            registry[surface] = term
+            registry[surface.lower()] = term
+    return registry
+
+
+#: Prompt steer asking the model to gloss each bespoke term in the owner's voice
+#: on its *first* mention. Appended to every ``## Ask`` variant on both the draft
+#: and voice surfaces and pinned by structure tests so it can never silently drop
+#: out of the prompt. Phrased as a request for an appositive/short clause — not a
+#: textbook definition — and explicitly first-mention-only ("only once").
+GLOSS_STEER: str = (
+    "The first time you use one of my bespoke terms (a Frequency, Phase, Mood, "
+    "altitude, or named concept like APTITUDE / Whole Adept / Archetypal "
+    "Wavelength), weave in a brief plain-English gloss in my voice so a newcomer "
+    "can follow — an appositive or short clause, not a dictionary definition, "
+    "and don't lecture. Gloss each term only once."
+)

--- a/creek-tools/tests/test_ontology_glossary.py
+++ b/creek-tools/tests/test_ontology_glossary.py
@@ -1,0 +1,172 @@
+"""Tests for the bespoke-ontology-term glossary registry and gloss detector.
+
+Three concerns are pinned here:
+
+* the registry is a *drift-guarded* single source of truth — every
+  ``Frequency`` / ``Phase`` / ``Mode`` enum member has a gloss-seed entry, so a
+  new enum member without a gloss fails the build;
+* the gloss prompt-steer is present in both ``## Ask`` builders (the draft and
+  voice surfaces), mirroring how the no-fabrication / no-provenance steers are
+  pinned;
+* the conservative ``unglossed_jargon`` detector flags a first-mention bespoke
+  term with no nearby gloss, never re-flags a second occurrence, and does not
+  over-flag a glossed term or an ordinary capitalised word.
+"""
+
+from __future__ import annotations
+
+from creek.author.checks import detect_unglossed_jargon
+from creek.generate.ontology_glossary import (
+    GLOSS_STEER,
+    OntologyTerm,
+    iter_ontology_terms,
+    ontology_term_registry,
+)
+from creek.models import Frequency, Mode, Phase
+
+
+class TestRegistryDriftGuard:
+    """Every taxonomy enum member must carry a gloss-seed entry."""
+
+    def test_every_frequency_member_has_a_registry_entry(self) -> None:
+        """Each ``Frequency`` member resolves to a registered term."""
+        registry = ontology_term_registry()
+        for freq in Frequency:
+            assert freq.value in registry, f"no gloss-seed for {freq!r}"
+
+    def test_every_phase_member_has_a_registry_entry(self) -> None:
+        """Each ``Phase`` member resolves to a registered term."""
+        registry = ontology_term_registry()
+        for phase in Phase:
+            assert phase.value in registry, f"no gloss-seed for {phase!r}"
+
+    def test_every_mode_member_has_a_registry_entry(self) -> None:
+        """Each ``Mode`` member resolves to a registered term."""
+        registry = ontology_term_registry()
+        for mode in Mode:
+            assert mode.value in registry, f"no gloss-seed for {mode!r}"
+
+    def test_every_term_carries_a_nonempty_gloss_seed(self) -> None:
+        """No registered term may have a blank gloss-seed."""
+        for term in iter_ontology_terms():
+            assert isinstance(term, OntologyTerm)
+            assert term.gloss_seed.strip(), f"empty gloss-seed for {term.label!r}"
+
+    def test_named_concepts_are_registered(self) -> None:
+        """The named bespoke concepts carry gloss seeds too."""
+        registry = ontology_term_registry()
+        for concept in (
+            "APTITUDE",
+            "Whole Adept",
+            "Archetypal Wavelength",
+            "non-dual substrate",
+        ):
+            assert concept.lower() in registry
+
+    def test_altitude_terms_are_registered(self) -> None:
+        """The developmental altitudes (e.g. Teal, Ultraviolet) are registered."""
+        registry = ontology_term_registry()
+        for altitude in ("Teal", "Ultraviolet"):
+            assert altitude.lower() in registry
+
+
+class TestGlossSteerPinned:
+    """The gloss instruction is present in both ``## Ask`` builders."""
+
+    def test_steer_text_mentions_first_mention_and_gloss_once(self) -> None:
+        """The steer constant names the first-mention, gloss-once contract."""
+        lowered = GLOSS_STEER.lower()
+        assert "first time" in lowered
+        assert "once" in lowered
+
+    def test_draft_ask_carries_gloss_steer_in_every_mode(self) -> None:
+        """Every ``_compose_ask_section`` variant carries the gloss steer."""
+        from creek.generate.drafts import _compose_ask_section
+        from creek.generate.mining import IdeaSeed, MiningStrategy
+
+        idea = IdeaSeed(
+            strategy=MiningStrategy.RESONANCE_CHAIN,
+            title="Christ",
+            source_fragments=("frag-a",),
+            threads=(),
+            eddies=(),
+            frequency_affinity=(),
+            brief_description="A draft about the pattern.",
+            score=0.8,
+        )
+        for kwargs in (
+            {"per_dimension": False},
+            {"per_dimension": True},
+            {"per_dimension": False, "twist": True},
+        ):
+            section = _compose_ask_section(idea, **kwargs)
+            assert _GLOSS_PHRASE in section
+
+    def test_voice_ask_carries_gloss_steer(self) -> None:
+        """The voice agent's ``## Ask`` block carries the gloss steer."""
+        from creek.author.voice import _ask_section
+
+        section = _ask_section("What is Christ?", None, None)
+        assert _GLOSS_PHRASE in section
+
+
+_GLOSS_PHRASE = "weave in a brief plain-English gloss"
+
+
+class TestUnglossedJargonDetector:
+    """The conservative first-mention gloss detector."""
+
+    def test_flags_each_unglossed_first_mention(self) -> None:
+        """Three bespoke terms with no nearby gloss each raise a finding."""
+        body = (
+            "The work moves toward Ultraviolet. By F8 the pattern is clear. "
+            "Everything resolves at Peaking, eventually."
+        )
+        findings = detect_unglossed_jargon(body)
+        flagged = {f.term for f in findings}
+        assert flagged == {"Ultraviolet", "F8", "Peaking"}
+        assert all(f.severity == "MID" for f in findings)
+
+    def test_glossed_first_mention_is_not_flagged(self) -> None:
+        """An appositive gloss on first mention suppresses the finding."""
+        body = (
+            "The work moves toward Ultraviolet — the altitude where your own "
+            "will quiets enough that something larger acts through you. "
+            "By F8, my true self speaking, the deep intuition that yields "
+            "alignment, the pattern is clear. Everything resolves at Peaking "
+            "(the full expression where output reaches its maximum), eventually."
+        )
+        findings = detect_unglossed_jargon(body)
+        assert findings == []
+
+    def test_only_first_mention_is_flagged(self) -> None:
+        """A second occurrence of a term is never separately flagged."""
+        body = (
+            "We rise toward Ultraviolet here. Later, Ultraviolet returns and "
+            "Ultraviolet stays."
+        )
+        findings = detect_unglossed_jargon(body)
+        terms = [f.term for f in findings]
+        assert terms.count("Ultraviolet") == 1
+
+    def test_which_is_clause_counts_as_a_gloss(self) -> None:
+        """A 'which is' explanatory clause suppresses the finding."""
+        body = "The arc bends to F8, which is the voice of my own higher self."
+        assert detect_unglossed_jargon(body) == []
+
+    def test_ordinary_capitalised_word_is_not_flagged(self) -> None:
+        """A non-bespoke capitalised word raises nothing (false-positive guard)."""
+        body = "On Tuesday I walked to London and thought about Everything."
+        assert detect_unglossed_jargon(body) == []
+
+    def test_empty_body_raises_nothing(self) -> None:
+        """An empty body produces no findings."""
+        assert detect_unglossed_jargon("") == []
+
+    def test_gloss_seed_keyword_nearby_suppresses(self) -> None:
+        """A gloss-seed keyword near the first mention counts as explanation."""
+        body = (
+            "He reaches Peaking: the full creative expression pours out, "
+            "maximum output, abundance everywhere."
+        )
+        assert detect_unglossed_jargon(body) == []

--- a/creek-tools/tests/test_reflection.py
+++ b/creek-tools/tests/test_reflection.py
@@ -83,6 +83,30 @@ def test_alias_misuse_revises_with_ontology_finding() -> None:
     assert "rising" in finding.message
 
 
+def test_unglossed_jargon_revises_with_jargon_finding() -> None:
+    """A bespoke term used without a gloss → REVISE + unglossed_jargon finding."""
+    body = "The whole arc climbs toward Ultraviolet and then settles."
+
+    result = ReflectionNode().review(body, _grounded())
+
+    assert result.decision == "REVISE"
+    finding = next(f for f in result.findings if f.dimension == "unglossed_jargon")
+    assert finding.severity == "MID"
+    assert "Ultraviolet" in finding.message
+
+
+def test_glossed_jargon_raises_no_jargon_finding() -> None:
+    """A bespoke term glossed on first mention → no unglossed_jargon finding."""
+    body = (
+        "The whole arc climbs toward Ultraviolet — the altitude where your own "
+        "will quiets and something larger acts through you."
+    )
+
+    result = ReflectionNode().review(body, _grounded())
+
+    assert not any(f.dimension == "unglossed_jargon" for f in result.findings)
+
+
 def test_privacy_leak_revises_with_privacy_finding(tmp_path: Path) -> None:
     """A cited intimate fragment leaked above the OPEN default → privacy finding."""
     secret = "the intimate confession nobody should publish"


### PR DESCRIPTION
## Summary
- Adds a **drift-guarded ontology-term registry** (`creek/generate/ontology_glossary.py`) as the single source of truth for bespoke vocabulary — Frequencies (F1–F10 + APTITUDE labels), Phases, Modes, developmental altitudes (Teal, Ultraviolet) and named concepts (APTITUDE, Whole Adept, Archetypal Wavelength, non-dual substrate). Each term carries a short gloss-seed *derived* from the existing `Frequency`/`Phase`/`Mode` enums and the `FREQUENCY_THEMES`/`FREQUENCY_COLORS`/`CANONICAL_FREQUENCY_NAMES`/`_PHASE_DESCRIPTIONS` maps, so it cannot silently drift from the taxonomy. A test asserts every enum member resolves to a registry entry.
- Adds a **gloss prompt-steer** (`GLOSS_STEER`) to both `## Ask` builders — `drafts._compose_ask_section` (per-dimension, twist, and default modes) and `voice._ask_section` — asking the model to weave a brief in-voice gloss on the *first* mention of any bespoke term, once each. Pinned by structure tests on both surfaces.
- Adds a conservative **`unglossed_jargon` detector** (`creek/generate/jargon.py`) that flags a bespoke term's *first* occurrence only when no gloss signal sits in the window after it; surfaced as a `MID` `unglossed_jargon` finding via `ReflectionNode.review`.

## Detector heuristic / over-flag guard
First-mention-only (a second occurrence is never flagged). A first mention counts as glossed — and is therefore **not** flagged — when the 90-char window after it holds any gloss signal: an em-dash/en-dash/spaced-hyphen appositive, a parenthetical `(`, a `which is`/`which means` clause, a comma/colon appositive (`, the `, `: the `, `, my `), or one of the term's own gloss-seed keywords. Surface forms are matched **case-sensitively** on a word boundary, so an ordinary lower-case verb (`rising`) or a capitalised non-term (`London`) never trips the scan. The detector is deliberately biased toward false negatives.

## Test plan
- `cd creek-tools && ./scripts/check-all.sh` → exit 0 (5129 passed; coverage 93.81%, both new modules 100%; per-file gate, mypy strict, ruff, complexity, refurb all green).
- New `tests/test_ontology_glossary.py`: registry drift guard (every Frequency/Phase/Mode member), named-concept/altitude registration, gloss-steer presence on both surfaces in every mode, and detector behaviour — flags `Ultraviolet`/`F8`/`Peaking` un-glossed, suppresses on appositive/parenthetical/`which is`/seed-keyword gloss, first-mention-only, and false-positive guards (glossed term + ordinary capitalised word).
- `tests/test_reflection.py`: a bespoke term without a gloss → `REVISE` + `unglossed_jargon` finding; glossed term → no such finding.

Closes #521
Refs #417
