### PR TITLE
fix(crawdad): resolve voice-core from meta/ as well as voice-core/ (#538)

### DIFF
--- a/crawdad/crawdad/skill_loader.py
+++ b/crawdad/crawdad/skill_loader.py
@@ -8,9 +8,16 @@ error):
 ::
 
     <vault>/creek-skills/
-    ├── voice-core/SKILL.md           # always loaded
+    ├── voice-core/SKILL.md           # always loaded (crawdad-authored layout)
+    ├── meta/voice-core.SKILL.md      # always loaded (``creek skills generate`` layout)
     ├── phases/<phase>.SKILL.md       # matched against session wavelength
     └── registers/<register>.SKILL.md # ``confessional`` by default
+
+The voice-core skill is resolved against both candidate locations in
+order — ``voice-core/SKILL.md`` first, then ``meta/voice-core.SKILL.md``
+— and the first that exists is loaded as the load-bearing first entry.
+The canonical generator (``creek skills generate``) writes the second
+layout, so a generator-built vault still gets voice-core (#538).
 
 The session-state wavelength snapshot supplies the phase. The default
 register is :data:`crawdad.config.DEFAULT_REGISTER` ("confessional",
@@ -53,6 +60,16 @@ _PHASE_RE = re.compile(r"phase[:\s]*\*{0,2}([a-z_\-]+)", re.IGNORECASE)
 # register names so path construction can't be tricked into traversal.
 _SAFE_NAME_RE = re.compile(r"^[a-z][a-z\-]*$")
 _PROMPT_SEPARATOR = "\n\n---\n\n"
+
+# Candidate voice-core locations, resolved in order. The first existing
+# file wins. ``voice-core/SKILL.md`` is the crawdad-authored layout; the
+# canonical generator (``creek skills generate``) writes the second,
+# ``meta/voice-core.SKILL.md`` (#538). Kept self-contained — crawdad must
+# not depend on creek-tools.
+_VOICE_CORE_CANDIDATES: tuple[tuple[str, ...], ...] = (
+    ("voice-core", "SKILL.md"),
+    ("meta", "voice-core.SKILL.md"),
+)
 
 
 class VoiceSkill(BaseModel):
@@ -120,8 +137,9 @@ def load_skills_for_session(
         return VoiceSkillStack(skills=())
 
     collected: list[VoiceSkill] = []
-    voice_core = root / "voice-core" / "SKILL.md"
-    _append_if_present(collected, voice_core, name="voice-core")
+    voice_core = _resolve_voice_core(root)
+    if voice_core is not None:
+        _append_if_present(collected, voice_core, name="voice-core")
 
     phase = _phase_from_state(state)
     if phase:
@@ -219,6 +237,21 @@ class SkillStackRegistry:
         )
         _LOGGER.info("activated voice register %r", name)
         return True
+
+
+def _resolve_voice_core(root: Path) -> Path | None:
+    """Return the first existing voice-core ``SKILL.md`` under *root*, or ``None``.
+
+    Checks each :data:`_VOICE_CORE_CANDIDATES` location in order so a tree
+    authored by either crawdad (``voice-core/SKILL.md``) or the canonical
+    generator (``meta/voice-core.SKILL.md``) resolves, preserving the
+    crawdad-style location's precedence when both exist (#538).
+    """
+    for parts in _VOICE_CORE_CANDIDATES:
+        candidate = root.joinpath(*parts)
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def _append_if_present(target: list[VoiceSkill], path: Path, *, name: str) -> None:

--- a/crawdad/tests/test_skill_loader.py
+++ b/crawdad/tests/test_skill_loader.py
@@ -126,6 +126,63 @@ def test_load_skills_missing_phase_file_skips_it(tmp_path: Path) -> None:
     assert "Voice core only" in bodies[0]
 
 
+def test_load_skills_finds_voice_core_in_meta_dir(tmp_path: Path) -> None:
+    """The generator layout ``meta/voice-core.SKILL.md`` still loads voice-core (#538).
+
+    ``creek skills generate`` writes voice-core to
+    ``creek-skills/meta/voice-core.SKILL.md`` (no ``voice-core/`` dir),
+    whereas crawdad historically only looked at
+    ``creek-skills/voice-core/SKILL.md``. The loader must resolve both,
+    and voice-core must remain the first/load-bearing entry in the stack.
+    """
+    skills = tmp_path / "creek-skills"
+    (skills / "meta").mkdir(parents=True)
+    (skills / "meta" / "voice-core.SKILL.md").write_text(
+        "# Voice core (generator)\nThe load-bearing voice rules.", encoding="utf-8"
+    )
+    (skills / "registers").mkdir()
+    (skills / "registers" / "confessional.SKILL.md").write_text(
+        "# Confessional\nReflective, first-person, soft.", encoding="utf-8"
+    )
+    state = _make_state("rising")
+
+    stack = load_skills_for_session(vault_path=tmp_path, state=state)
+
+    names = stack.names()
+    assert "voice-core" in names
+    # voice-core is the first / load-bearing entry in the stack.
+    assert names[0] == "voice-core"
+    assert any("Voice core (generator)" in body for body in stack.bodies())
+
+
+def test_load_skills_voice_core_dir_takes_precedence_over_meta(
+    tmp_path: Path,
+) -> None:
+    """When both locations exist, ``voice-core/SKILL.md`` wins (#538).
+
+    The crawdad-style ``voice-core/SKILL.md`` is the first candidate, so
+    a tree carrying both layouts resolves to it and never double-loads.
+    """
+    skills = tmp_path / "creek-skills"
+    (skills / "voice-core").mkdir(parents=True)
+    (skills / "voice-core" / "SKILL.md").write_text(
+        "# Voice core (crawdad)\nPrimary location.", encoding="utf-8"
+    )
+    (skills / "meta").mkdir()
+    (skills / "meta" / "voice-core.SKILL.md").write_text(
+        "# Voice core (generator)\nFallback location.", encoding="utf-8"
+    )
+    state = _make_state("rising")
+
+    stack = load_skills_for_session(vault_path=tmp_path, state=state)
+
+    bodies = stack.bodies()
+    assert any("Voice core (crawdad)" in body for body in bodies)
+    assert not any("Voice core (generator)" in body for body in bodies)
+    # Exactly one voice-core entry — no double-load.
+    assert stack.names().count("voice-core") == 1
+
+
 def test_load_skills_handles_state_without_wavelength(
     vault_with_voice_tree: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

CrawDad's `skill_loader` only looked for the voice-core skill at `creek-skills/voice-core/SKILL.md`, but the canonical generator (`creek skills generate`) writes it to `creek-skills/meta/voice-core.SKILL.md`. Because `_append_if_present` skips missing files silently, a generator-built vault ran the conversational composer **without** the always-loaded, load-bearing voice-core layer even though the file existed on disk.

The fix resolves voice-core against both locations, in order, via a locally-defined `_VOICE_CORE_CANDIDATES` tuple:

- `voice-core/SKILL.md` (crawdad-authored layout) — first / takes precedence
- `meta/voice-core.SKILL.md` (generator layout) — fallback

The first existing file is appended and voice-core remains the first/load-bearing entry in the stack. The change is self-contained in crawdad — it does **not** import from creek-tools (it only mirrors the pattern in `creek/author/skills.py`). The module docstring's tree diagram was updated to document both locations.

## Test plan

Added two tests to `crawdad/tests/test_skill_loader.py` (TDD — the meta test was red before the fix, green after):

- `test_load_skills_finds_voice_core_in_meta_dir` — a `creek-skills/` tree containing only `meta/voice-core.SKILL.md` (generator layout, no `voice-core/` dir) loads voice-core as the first stack entry.
- `test_load_skills_voice_core_dir_takes_precedence_over_meta` — when both layouts exist, `voice-core/SKILL.md` wins and voice-core is loaded exactly once (no double-load).

Gate 2 (`./scripts/check-all.sh`) passes with all 7 checks green: 448 tests pass, branch coverage 95.63% (skill_loader.py 90.32%), mypy strict clean, ruff clean, bandit clean, docstrings/complexity within thresholds. No bypasses added.

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)
