### PR TITLE
fix(voice): join soft-wrapped lines before sentence splitting

### DIFF
--- a/creek-tools/creek/generate/grounding.py
+++ b/creek-tools/creek/generate/grounding.py
@@ -347,11 +347,20 @@ a comma, so a multi-clause biographical sentence ("Not the LDS Christ I was
 handed as a kid—the one I actually believe in.") is scored as one unit rather
 than fragmented into clauses that each lose their grounding context.
 
-Note: newline handling is performed by the ``splitlines()`` pre-pass in
-:func:`split_sentences`, *before* this regex ever runs. A sentence
-soft-wrapped across two markdown lines is therefore split at the newline by
-that pre-pass — a known edge handled separately (see issue #522, a follow-up
-to #417)."""
+Note: newline handling is performed before this regex ever runs, in the
+soft-wrap join pass of :func:`split_sentences`. Consecutive non-blank lines
+inside one paragraph are folded into a single flowing block (joined on a
+space) first, so a sentence soft-wrapped across two markdown lines reaches
+this regex whole rather than truncated at the newline."""
+
+
+_STRUCTURAL_LINE_RE = re.compile(r"^(?:#{1,6}\s|\s*(?:[-*+]|\d+\.)\s)")
+"""A markdown line that is structural, not flowing prose.
+
+Matches an ATX heading (``# `` … ``###### ``) or a list item (``- ``, ``* ``,
+``+ ``, or ``1. ``). Such a line is a hard boundary: it is never folded into an
+adjacent text line by the soft-wrap join, so a heading stays dropped and a list
+marker stays separate from the paragraph beside it."""
 
 
 _BIOGRAPHICAL_PATTERNS: tuple[re.Pattern[str], ...] = (
@@ -416,30 +425,55 @@ class BiographicalGroundingFinding:
     max_similarity: float
 
 
+def _logical_blocks(body: str) -> list[str]:
+    """Fold *body*'s physical lines into flowing logical blocks.
+
+    Consecutive non-blank prose lines inside one paragraph are a single
+    soft-wrapped sentence-or-more and are joined on a space. A blank line is a
+    hard paragraph boundary that flushes the current block, and a structural
+    line — a heading or list marker (:data:`_STRUCTURAL_LINE_RE`) — is its own
+    boundary that is dropped from the prose stream rather than folded into a
+    neighbour.
+    """
+    blocks: list[str] = []
+    buffer: list[str] = []
+
+    def _flush() -> None:
+        if buffer:
+            blocks.append(" ".join(buffer))
+            buffer.clear()
+
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped or _STRUCTURAL_LINE_RE.match(stripped):
+            _flush()
+            continue
+        buffer.append(stripped)
+    _flush()
+    return blocks
+
+
 def split_sentences(body: str) -> list[str]:
     """Split *body* into trimmed, non-empty sentences.
 
     Sentences are separated on whitespace following terminal punctuation
-    (``.``, ``!``, ``?``); blank lines and headings collapse away. The split
-    is intentionally coarse — its only job is to isolate a first-person
-    biographical claim from the rest of an otherwise on-topic paragraph so
-    the grounding scan scores the claim, not the paragraph that hides it.
+    (``.``, ``!``, ``?``); blank lines, headings, and list markers collapse
+    away. The split is intentionally coarse — its only job is to isolate a
+    first-person biographical claim from the rest of an otherwise on-topic
+    paragraph so the grounding scan scores the claim, not the paragraph that
+    hides it.
 
-    Newline handling happens here, in the ``body.splitlines()`` pre-pass:
-    each physical line is processed independently and only then is
-    :data:`_SENTENCE_SPLIT_RE` applied. A single sentence that is
-    soft-wrapped across two markdown lines is therefore split at the newline
-    rather than kept whole — a known edge tracked in issue #522 (follow-up to
-    #417); the regex's own "never split on a newline" guarantee applies only
-    *within* a physical line.
+    Soft-wrapped lines are folded into logical blocks *before* splitting (see
+    :func:`_logical_blocks`): consecutive non-blank prose lines inside one
+    paragraph join on a space, so a sentence soft-wrapped across two markdown
+    lines reaches :data:`_SENTENCE_SPLIT_RE` whole rather than truncated at the
+    newline. Blank lines remain hard paragraph boundaries, and a heading or
+    list marker is its own boundary that never merges into adjacent prose.
     """
     sentences: list[str] = []
-    for line in body.splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
+    for block in _logical_blocks(body):
         sentences.extend(
-            part.strip() for part in _SENTENCE_SPLIT_RE.split(stripped) if part.strip()
+            part.strip() for part in _SENTENCE_SPLIT_RE.split(block) if part.strip()
         )
     return sentences
 

--- a/creek-tools/tests/test_biographical_grounding.py
+++ b/creek-tools/tests/test_biographical_grounding.py
@@ -115,6 +115,29 @@ class TestSentenceSplitting:
         body = "# Heading\n\nA real sentence here.\n\n## Another\n"
         assert split_sentences(body) == ["A real sentence here."]
 
+    def test_joins_soft_wrapped_sentence(self) -> None:
+        """A sentence soft-wrapped across two lines is kept whole.
+
+        Consecutive non-blank lines inside one paragraph are a single
+        flowing block, joined on a space, so the regex never splits a
+        biographical claim at the soft newline.
+        """
+        body = "I was raised in a very\nreligious household."
+        assert split_sentences(body) == ["I was raised in a very religious household."]
+
+    def test_blank_line_is_a_hard_sentence_boundary(self) -> None:
+        """A blank line still separates paragraphs into distinct sentences."""
+        body = "First paragraph here\nwrapped on.\n\nSecond paragraph stands alone."
+        assert split_sentences(body) == [
+            "First paragraph here wrapped on.",
+            "Second paragraph stands alone.",
+        ]
+
+    def test_heading_is_not_folded_into_adjacent_text(self) -> None:
+        """A heading line is dropped, not joined to the line beneath it."""
+        body = "# A Heading\nA real sentence here."
+        assert split_sentences(body) == ["A real sentence here."]
+
 
 class TestBiographicalHeuristic:
     """The heuristic is conservative: biography yes, opinion no."""
@@ -206,6 +229,23 @@ class TestScanBiographicalSentences:
         findings = scan_biographical_sentences(
             _GROUNDED_SENTENCE,
             source_texts=["prairie childhood source"],
+            embedding_fn=embedder,
+            threshold=0.30,
+        )
+        assert findings == []
+
+    def test_soft_wrapped_grounded_sentence_scored_whole(self) -> None:
+        """A grounded sentence wrapped across a soft newline is not flagged.
+
+        The full sentence aliases to its source (cosine 1.0); a truncated
+        first-fragment would fall through to a near-orthogonal vector and be
+        falsely flagged. Scoring the whole sentence keeps the finding empty.
+        """
+        whole = "I was raised in a very religious household."
+        embedder = _aliasing_embedder(alias=(whole, "religious-upbringing source"))
+        findings = scan_biographical_sentences(
+            "I was raised in a very\nreligious household.",
+            source_texts=["religious-upbringing source"],
             embedding_fn=embedder,
             threshold=0.30,
         )


### PR DESCRIPTION
## Summary

- `split_sentences` (`creek/generate/grounding.py`) ran a per-physical-line pre-pass before applying the sentence-boundary regex, so a first-person biographical sentence soft-wrapped across two markdown lines was split at the newline. The truncated first fragment scored a worse cosine against sources, inflating the ungrounded-biographical signal and quoting only half the sentence in findings.
- Fold consecutive non-blank prose lines into one flowing logical block (joined on a space) **before** sentence splitting. Blank lines remain hard paragraph boundaries; headings (`^#{1,6}\s`) and list markers (`^\s*([-*+]|\d+\.)\s`) stay structural and are never folded into adjacent prose. A wrapped biographical claim is now scored whole.

## Test plan

- TDD: added failing tests first, watched them fail on the line-isolated behaviour, then implemented.
  - `test_joins_soft_wrapped_sentence` — `"I was raised in a very\nreligious household."` splits into one sentence.
  - `test_blank_line_is_a_hard_sentence_boundary` — blank line still separates paragraphs.
  - `test_heading_is_not_folded_into_adjacent_text` — heading dropped, not merged.
  - `test_soft_wrapped_grounded_sentence_scored_whole` — a grounded wrapped sentence produces NO finding (the whole sentence aliases to its source; a truncated fragment would be falsely flagged).
- Existing `test_drops_headings_and_blank_lines` and `test_splits_on_terminal_punctuation` stay green; no regression in `tests/test_biographical_grounding.py` (30 passed).
- `cd creek-tools && ./scripts/check-all.sh` exits 0 — 12/12 checks pass, coverage 93.82%, complexity/mypy/ruff/interrogate clean.

Closes #522
Refs #417
