### PR TITLE
feat(cli): creek voice-check — score a markdown file against the vault voice fingerprint

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -33,7 +33,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from creek.classify.prompt import PromptOntology
-    from creek.config import CreekConfig
+    from creek.config import AIStyleConfig, CreekConfig
+    from creek.generate.ai_style.model import ScanReport, VoiceFingerprint
     from creek.generate.compost_embedding import CompostExemplar
     from creek.generate.compost_verifier import SupportsVerifyCompost
     from creek.generate.drafts import (
@@ -1300,6 +1301,206 @@ def _report_fingerprint(vault_path: Path) -> None:
         f"across {len(fingerprint.features)} features → {path}"
         f"[/bold green]{thin}",
     )
+
+
+def _default_voice_max_distance() -> float:
+    """Return the default ``voice-check`` distance ceiling from config.
+
+    Sources the threshold from
+    :attr:`creek.config.AIStyleConfig.voice_distance_upper` rather than
+    hard-coding a magic number, so the CLI default tracks the same
+    constant the draft guard and the lint check use.
+
+    Returns:
+        The configured ``voice_distance_upper`` default.
+    """
+    from creek.config import AIStyleConfig
+
+    return AIStyleConfig().voice_distance_upper
+
+
+_DEFAULT_VOICE_MAX_DISTANCE: float = _default_voice_max_distance()
+"""Default ``--max-distance`` for ``creek voice-check`` (config-sourced)."""
+
+
+def _resolve_voice_fingerprint(
+    vault_path: Path,
+    ai_style: AIStyleConfig,
+) -> VoiceFingerprint:
+    """Return the vault's voice fingerprint, persisted-first then built.
+
+    Mirrors how ``draft`` consumes the fingerprint: prefer the artefact
+    saved at ``<vault>/00-Creek-Meta/voice-fingerprint.json`` and fall back
+    to building one from the vault's self-authored fragments when no file
+    exists yet.
+
+    Args:
+        vault_path: Vault root.
+        ai_style: AI-style configuration (fingerprint path + weights).
+
+    Returns:
+        A :class:`VoiceFingerprint`; its ``fragment_count`` is ``0`` when
+        neither a persisted artefact nor eligible fragments exist.
+    """
+    from creek.generate.ai_style.fingerprint import (
+        build_fingerprint,
+        load_fingerprint,
+    )
+
+    fingerprint = load_fingerprint(vault_path, ai_style)
+    if fingerprint.fragment_count > 0:
+        return fingerprint
+    return build_fingerprint(vault_path, ai_style)
+
+
+def _print_voice_check_summary(
+    *,
+    report: ScanReport,
+    in_voice: bool,
+    max_distance: float,
+) -> None:
+    """Render the human-readable ``voice-check`` summary.
+
+    Args:
+        report: The scan report produced for the target file.
+        in_voice: Whether the file scored within bounds.
+        max_distance: The threshold the distance was compared against.
+    """
+    verdict = (
+        "[bold green]in voice[/bold green]"
+        if in_voice
+        else "[bold red]diverges from voice[/bold red]"
+    )
+    thin = " [dim](thin fingerprint — flagging softened)[/dim]"
+    console.print(
+        f"voice_distance: {report.voice_distance:.4f} "
+        f"(max {max_distance:.4f}) → {verdict}"
+        f"{thin if report.thin_fingerprint else ''}",
+    )
+    if not report.findings:
+        return
+    noun = "finding" if len(report.findings) == 1 else "findings"
+    console.print(f"[bold]{len(report.findings)} {noun}:[/bold]")
+    for finding in report.findings:
+        console.print(f"  [dim]L{finding.line}:[/dim] {finding.message}")
+
+
+def _emit_voice_check_json(
+    *,
+    target: Path,
+    report: ScanReport,
+    in_voice: bool,
+    max_distance: float,
+) -> None:
+    """Print a machine-readable JSON object for ``voice-check --json``.
+
+    Args:
+        target: The scanned file.
+        report: The scan report.
+        in_voice: Whether the file scored within bounds.
+        max_distance: The threshold compared against.
+    """
+    import json
+
+    payload = {
+        "file": str(target),
+        "voice_distance": report.voice_distance,
+        "max_distance": max_distance,
+        "in_voice": in_voice,
+        "thin_fingerprint": report.thin_fingerprint,
+        "findings": [
+            {
+                "line": finding.line,
+                "tell_id": finding.tell_id,
+                "category": str(finding.category),
+                "feature_key": finding.feature_key,
+                "direction": str(finding.direction),
+                "message": finding.message,
+            }
+            for finding in report.findings
+        ],
+    }
+    console.print(json.dumps(payload, indent=2))
+
+
+@app.command(name="voice-check")
+def voice_check(
+    file: Path = typer.Argument(..., help="Markdown file to score against your voice"),
+    vault: Path | None = typer.Option(None, "--vault", help="Obsidian vault path"),
+    max_distance: float = typer.Option(
+        _DEFAULT_VOICE_MAX_DISTANCE,
+        "--max-distance",
+        help=(
+            "Voice-distance ceiling. A file whose distance exceeds this is "
+            "treated as diverging and the command exits non-zero. Defaults to "
+            "the AI-style config's voice_distance_upper."
+        ),
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit a machine-readable JSON object instead of a text summary.",
+    ),
+) -> None:
+    """Score a markdown FILE against the vault voice fingerprint.
+
+    Loads the vault's voice fingerprint (the persisted
+    ``00-Creek-Meta/voice-fingerprint.json`` when present, otherwise built
+    from self-authored fragments — the same artefact ``creek report --type
+    fingerprint`` and ``creek draft`` consume), scans FILE's content, and
+    prints the resulting ``voice_distance`` plus any divergence findings.
+
+    Exit codes: ``0`` when the file is in voice (distance within
+    ``--max-distance``); ``1`` when it diverges; ``2`` for a missing file.
+    When no fingerprint can be resolved (no persisted artefact and no
+    eligible fragments) the command emits a notice pointing at ``creek
+    report --type fingerprint`` and exits ``0`` (nothing to compare
+    against — fail open so pre-commit / CI hooks do not block on an
+    un-profiled vault). The scan is fully offline; no LLM or consent is
+    involved.
+    """
+    from creek.generate.ai_style.scanner import scan
+
+    if not file.exists():
+        console.print(f"[red]File not found: {file}[/red]")
+        raise typer.Exit(code=2)
+
+    vault_path = _resolve_vault(vault)
+    ai_style = _load_config_for_vault(vault).ai_style
+    fingerprint = _resolve_voice_fingerprint(vault_path, ai_style)
+
+    if fingerprint.fragment_count == 0:
+        console.print(
+            "[yellow]No voice fingerprint available (no persisted "
+            "artefact and no self-authored fragments). Run "
+            "[bold]creek report --type fingerprint[/bold] to build one. "
+            "Skipping the check.[/yellow]",
+        )
+        return
+
+    report = scan(
+        file.read_text(encoding="utf-8"),
+        fingerprint=fingerprint,
+        config=ai_style,
+    )
+    in_voice = report.voice_distance <= max_distance
+
+    if json_out:
+        _emit_voice_check_json(
+            target=file,
+            report=report,
+            in_voice=in_voice,
+            max_distance=max_distance,
+        )
+    else:
+        _print_voice_check_summary(
+            report=report,
+            in_voice=in_voice,
+            max_distance=max_distance,
+        )
+
+    if not in_voice:
+        raise typer.Exit(code=1)
 
 
 _REPORT_DISPATCH: dict[str, Callable[[Path], None]] = {

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -20,7 +20,7 @@ from creek.classify.privacy_filter import (
     parse_include_tier,
     record_privacy_override,
 )
-from creek.config import load_config, resolve_config_path
+from creek.config import AIStyleConfig, load_config, resolve_config_path
 from creek.consent import ConsentManager
 from creek.models import PrivacyTier
 from creek.pipeline import Pipeline, RedactionRequiredError
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from creek.classify.prompt import PromptOntology
-    from creek.config import AIStyleConfig, CreekConfig
+    from creek.config import CreekConfig
     from creek.generate.ai_style.model import ScanReport, VoiceFingerprint
     from creek.generate.compost_embedding import CompostExemplar
     from creek.generate.compost_verifier import SupportsVerifyCompost
@@ -1303,24 +1303,13 @@ def _report_fingerprint(vault_path: Path) -> None:
     )
 
 
-def _default_voice_max_distance() -> float:
-    """Return the default ``voice-check`` distance ceiling from config.
+_DEFAULT_VOICE_MAX_DISTANCE: float = AIStyleConfig().voice_distance_upper
+"""Default ``--max-distance`` for ``creek voice-check`` (config-sourced).
 
-    Sources the threshold from
-    :attr:`creek.config.AIStyleConfig.voice_distance_upper` rather than
-    hard-coding a magic number, so the CLI default tracks the same
-    constant the draft guard and the lint check use.
-
-    Returns:
-        The configured ``voice_distance_upper`` default.
-    """
-    from creek.config import AIStyleConfig
-
-    return AIStyleConfig().voice_distance_upper
-
-
-_DEFAULT_VOICE_MAX_DISTANCE: float = _default_voice_max_distance()
-"""Default ``--max-distance`` for ``creek voice-check`` (config-sourced)."""
+Sourced directly from
+:attr:`creek.config.AIStyleConfig.voice_distance_upper` so the CLI default
+tracks the same constant the draft guard and the lint check use.
+"""
 
 
 def _resolve_voice_fingerprint(
@@ -1420,7 +1409,9 @@ def _emit_voice_check_json(
             for finding in report.findings
         ],
     }
-    console.print(json.dumps(payload, indent=2))
+    # Emit raw so Rich never interprets ``[...]`` in the content as markup
+    # and mangles the JSON (e.g. a finding message containing brackets).
+    typer.echo(json.dumps(payload, indent=2))
 
 
 @app.command(name="voice-check")

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1303,15 +1303,6 @@ def _report_fingerprint(vault_path: Path) -> None:
     )
 
 
-_DEFAULT_VOICE_MAX_DISTANCE: float = AIStyleConfig().voice_distance_upper
-"""Default ``--max-distance`` for ``creek voice-check`` (config-sourced).
-
-Sourced directly from
-:attr:`creek.config.AIStyleConfig.voice_distance_upper` so the CLI default
-tracks the same constant the draft guard and the lint check use.
-"""
-
-
 def _resolve_voice_fingerprint(
     vault_path: Path,
     ai_style: AIStyleConfig,
@@ -1418,13 +1409,14 @@ def _emit_voice_check_json(
 def voice_check(
     file: Path = typer.Argument(..., help="Markdown file to score against your voice"),
     vault: Path | None = typer.Option(None, "--vault", help="Obsidian vault path"),
-    max_distance: float = typer.Option(
-        _DEFAULT_VOICE_MAX_DISTANCE,
+    max_distance: float | None = typer.Option(
+        None,
         "--max-distance",
         help=(
             "Voice-distance ceiling. A file whose distance exceeds this is "
-            "treated as diverging and the command exits non-zero. Defaults to "
-            "the AI-style config's voice_distance_upper."
+            "treated as diverging and the command exits non-zero. When "
+            "omitted, defaults to the vault's configured "
+            "voice_distance_upper (the same ceiling creek draft enforces)."
         ),
     ),
     json_out: bool = typer.Option(
@@ -1458,6 +1450,11 @@ def voice_check(
 
     vault_path = _resolve_vault(vault)
     ai_style = _load_config_for_vault(vault).ai_style
+    # Resolve the ceiling from THIS vault's config at call time so a per-vault
+    # voice_distance_upper override is honoured; an explicit flag still wins.
+    effective_max_distance = (
+        max_distance if max_distance is not None else ai_style.voice_distance_upper
+    )
     fingerprint = _resolve_voice_fingerprint(vault_path, ai_style)
 
     if fingerprint.fragment_count == 0:
@@ -1474,20 +1471,20 @@ def voice_check(
         fingerprint=fingerprint,
         config=ai_style,
     )
-    in_voice = report.voice_distance <= max_distance
+    in_voice = report.voice_distance <= effective_max_distance
 
     if json_out:
         _emit_voice_check_json(
             target=file,
             report=report,
             in_voice=in_voice,
-            max_distance=max_distance,
+            max_distance=effective_max_distance,
         )
     else:
         _print_voice_check_summary(
             report=report,
             in_voice=in_voice,
-            max_distance=max_distance,
+            max_distance=effective_max_distance,
         )
 
     if not in_voice:

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -3298,7 +3298,8 @@ def test_voice_check_missing_fingerprint_is_graceful(
         ["voice-check", str(target), "--vault", str(vault)],
     )
 
-    assert result.exception is None or isinstance(result.exception, SystemExit)
+    # fail-open: an un-profiled vault must not block (exit 0, not 1/2).
+    assert result.exit_code == 0, result.output
     plain = _strip_ansi(result.output).lower()
     assert "fingerprint" in plain
     assert "report --type fingerprint" in plain
@@ -3351,6 +3352,64 @@ def test_voice_check_json_flag_emits_machine_output(
     assert "voice_distance" in payload
     assert payload["in_voice"] is True
     assert payload["max_distance"] == pytest.approx(0.35)
+
+
+def test_voice_check_json_survives_square_brackets_in_findings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--json`` stays valid JSON when a finding message contains ``[...]``.
+
+    Rich treats ``[...]`` as console markup; emitting the JSON through Rich
+    would mangle a finding message such as ``"saw [link] markup"``. The
+    output must be raw so ``json.loads`` round-trips the brackets intact.
+    """
+    import json
+
+    from creek.generate.ai_style.model import Finding, ScanReport, Span
+
+    bracketed = "over-used [citation] and [link] markup tells"
+    crafted = ScanReport(
+        findings=[
+            Finding(
+                tell_id="t1",
+                category="rhetorical",
+                feature_key="brackets",
+                span=Span(0, 0),
+                line=3,
+                excerpt="",
+                draft_rate=1.0,
+                user_rate=0.0,
+                direction="over",
+                message=bracketed,
+            ),
+        ],
+        deltas={},
+        voice_distance=0.99,
+        thin_fingerprint=False,
+    )
+    monkeypatch.setattr(
+        "creek.generate.ai_style.scanner.scan",
+        lambda *_args, **_kwargs: crafted,
+    )
+
+    vault = tmp_path / "vault"
+    _scaffold_voice_vault(vault)
+    _build_and_persist_fingerprint(vault)
+    monkeypatch.delenv("CREEK_CONFIG", raising=False)
+
+    target = tmp_path / "bracketed.md"
+    target.write_text("body with [brackets] in it\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["voice-check", str(target), "--vault", str(vault), "--json"],
+    )
+
+    # Diverging file exits 1, but the JSON body must still parse cleanly.
+    assert result.exit_code == 1, result.output
+    payload = json.loads(result.output)
+    assert payload["findings"][0]["message"] == bracketed
 
 
 def test_voice_check_builds_fingerprint_when_not_persisted(

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -3412,6 +3412,98 @@ def test_voice_check_json_survives_square_brackets_in_findings(
     assert payload["findings"][0]["message"] == bracketed
 
 
+def _write_voice_distance_config(vault: Path, upper: float) -> Path:
+    """Write a vault ``creek_config.yaml`` overriding ``voice_distance_upper``.
+
+    Args:
+        vault: Vault root whose ``00-Creek-Meta`` config dir receives the file.
+        upper: Custom ``ai_style.voice_distance_upper`` ceiling to persist.
+
+    Returns:
+        Path to the written ``creek_config.yaml``.
+    """
+    config_dir = vault / "00-Creek-Meta"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_path = config_dir / "creek_config.yaml"
+    config_path.write_text(
+        f"ai_style:\n  voice_distance_upper: {upper}\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def test_voice_check_default_threshold_honors_vault_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without ``--max-distance``, the vault's ``voice_distance_upper`` wins.
+
+    A vault config pins ``voice_distance_upper`` to 0.10 — far below the 0.35
+    default. A file whose distance sits between the two (~0.29) passes under
+    the default but must DIVERGE under the vault override. This pins that the
+    effective threshold is resolved from the loaded vault config at call time,
+    not frozen from the default config at module import.
+    """
+    vault = tmp_path / "vault"
+    _scaffold_voice_vault(vault)
+    _build_and_persist_fingerprint(vault)
+    config_path = _write_voice_distance_config(vault, 0.10)
+    monkeypatch.setenv("CREEK_CONFIG", str(config_path))
+
+    # ~0.29 distance: comfortably above the 0.10 override, below the 0.35 default.
+    target = tmp_path / "padded.md"
+    target.write_text(
+        (_voice_fixture_dir("slop") / "03_wiki_padding.md").read_text(
+            encoding="utf-8",
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["voice-check", str(target), "--vault", str(vault)],
+    )
+
+    assert result.exit_code != 0, result.output
+    plain = _strip_ansi(result.output)
+    # The summary reports the override (0.1000), not the 0.35 default.
+    assert "0.1000" in plain
+    assert "0.3500" not in plain
+
+
+def test_voice_check_explicit_max_distance_overrides_vault_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An explicit ``--max-distance`` beats the vault's configured ceiling.
+
+    The vault pins ``voice_distance_upper`` to 0.10, but passing
+    ``--max-distance 0.5`` must take precedence so the ~0.29 file passes.
+    """
+    vault = tmp_path / "vault"
+    _scaffold_voice_vault(vault)
+    _build_and_persist_fingerprint(vault)
+    config_path = _write_voice_distance_config(vault, 0.10)
+    monkeypatch.setenv("CREEK_CONFIG", str(config_path))
+
+    target = tmp_path / "padded.md"
+    target.write_text(
+        (_voice_fixture_dir("slop") / "03_wiki_padding.md").read_text(
+            encoding="utf-8",
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["voice-check", str(target), "--vault", str(vault), "--max-distance", "0.5"],
+    )
+
+    assert result.exit_code == 0, result.output
+    plain = _strip_ansi(result.output)
+    assert "0.5000" in plain
+
+
 def test_voice_check_builds_fingerprint_when_not_persisted(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -3146,3 +3146,232 @@ def test_build_draft_llm_falls_back_to_config_max_tokens(
     llm = cli_module._build_draft_llm()
     llm("a prompt")
     assert captured["max_tokens"] == 2048
+
+
+# ---- voice-check subcommand ------------------------------------------
+
+
+def _voice_fixture_dir(name: str) -> Path:
+    """Return the ``tests/fixtures/voice/<name>`` directory.
+
+    Args:
+        name: Sub-directory under the voice fixture root (``in_voice`` or
+            ``slop``).
+
+    Returns:
+        Absolute path to the requested fixture sub-directory.
+    """
+    return Path(__file__).resolve().parent / "fixtures" / "voice" / name
+
+
+def _scaffold_voice_vault(vault: Path) -> None:
+    """Write the in-voice exemplars into *vault* as self-authored fragments.
+
+    Mirrors the regression harness: each in-voice fixture becomes a minimal
+    ``source.author: self`` fragment so the production fingerprint builder
+    measures it. The set is large enough (six exemplars) to clear the
+    ``min_fingerprint_fragments`` floor, so the resulting fingerprint is not
+    treated as thin.
+
+    Args:
+        vault: Vault root to scaffold.
+    """
+    fragments_dir = vault / "01-Fragments"
+    fragments_dir.mkdir(parents=True, exist_ok=True)
+    for index, path in enumerate(sorted(_voice_fixture_dir("in_voice").glob("*.md"))):
+        body = path.read_text(encoding="utf-8")
+        fragment = (
+            "---\n"
+            "source:\n"
+            "  author: self\n"
+            "  platform: markdown\n"
+            "privacy_tier: open\n"
+            "---\n"
+            f"{body}\n"
+        )
+        (fragments_dir / f"exemplar_{index:02d}.md").write_text(
+            fragment,
+            encoding="utf-8",
+        )
+
+
+def _build_and_persist_fingerprint(vault: Path) -> None:
+    """Build and save the voice fingerprint for *vault* on disk.
+
+    Uses the same production API ``creek report --type fingerprint`` drives,
+    so ``voice-check`` can later load the persisted artefact.
+
+    Args:
+        vault: Vault root holding the self-authored fragments.
+    """
+    from creek.config import AIStyleConfig
+    from creek.generate.ai_style.fingerprint import (
+        build_fingerprint,
+        save_fingerprint,
+    )
+
+    config = AIStyleConfig()
+    fingerprint = build_fingerprint(vault, config)
+    save_fingerprint(fingerprint, vault, config)
+
+
+def test_voice_check_help_advertises_options() -> None:
+    """``creek voice-check --help`` documents its flags, ANSI/width-robust."""
+    # Render wide and strip ANSI so the rich help table cannot wrap or
+    # colour-split the option tokens (LESSON from #519/#529).
+    result = runner.invoke(app, ["voice-check", "--help"], env={"COLUMNS": "200"})
+    assert result.exit_code == 0
+    normalized = " ".join(_strip_ansi(result.output).split())
+    assert "--max-distance" in normalized
+    assert "--vault" in normalized
+    assert "--json" in normalized
+
+
+def test_voice_check_in_voice_file_exits_zero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An in-voice file scores below threshold and exits 0."""
+    vault = tmp_path / "vault"
+    _scaffold_voice_vault(vault)
+    _build_and_persist_fingerprint(vault)
+    monkeypatch.delenv("CREEK_CONFIG", raising=False)
+
+    target = tmp_path / "in_voice.md"
+    target.write_text(
+        (_voice_fixture_dir("in_voice") / "01_morning.md").read_text(
+            encoding="utf-8",
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["voice-check", str(target), "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    plain = _strip_ansi(result.output)
+    assert "voice_distance" in plain.lower()
+
+
+def test_voice_check_slop_file_exits_nonzero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An AI-slop file diverges past threshold and exits non-zero."""
+    vault = tmp_path / "vault"
+    _scaffold_voice_vault(vault)
+    _build_and_persist_fingerprint(vault)
+    monkeypatch.delenv("CREEK_CONFIG", raising=False)
+
+    target = tmp_path / "slop.md"
+    target.write_text(
+        (_voice_fixture_dir("slop") / "03_wiki_padding.md").read_text(
+            encoding="utf-8",
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["voice-check", str(target), "--vault", str(vault), "--max-distance", "0.1"],
+    )
+
+    assert result.exit_code != 0, result.output
+
+
+def test_voice_check_missing_fingerprint_is_graceful(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No fingerprint and no eligible fragments → clear notice, no traceback."""
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    monkeypatch.delenv("CREEK_CONFIG", raising=False)
+
+    target = tmp_path / "anything.md"
+    target.write_text("Some text to check.\n", encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        ["voice-check", str(target), "--vault", str(vault)],
+    )
+
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    plain = _strip_ansi(result.output).lower()
+    assert "fingerprint" in plain
+    assert "report --type fingerprint" in plain
+
+
+def test_voice_check_missing_file_exits_two(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-existent target file exits 2 with a clear error."""
+    vault = tmp_path / "vault"
+    _scaffold_voice_vault(vault)
+    _build_and_persist_fingerprint(vault)
+    monkeypatch.delenv("CREEK_CONFIG", raising=False)
+
+    result = runner.invoke(
+        app,
+        ["voice-check", str(tmp_path / "nope.md"), "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 2
+    assert "not found" in _strip_ansi(result.output).lower()
+
+
+def test_voice_check_json_flag_emits_machine_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--json`` emits a parseable object carrying voice_distance + verdict."""
+    import json
+
+    vault = tmp_path / "vault"
+    _scaffold_voice_vault(vault)
+    _build_and_persist_fingerprint(vault)
+    monkeypatch.delenv("CREEK_CONFIG", raising=False)
+
+    target = tmp_path / "in_voice.md"
+    target.write_text(
+        (_voice_fixture_dir("in_voice") / "02_boat.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["voice-check", str(target), "--vault", str(vault), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(_strip_ansi(result.output))
+    assert "voice_distance" in payload
+    assert payload["in_voice"] is True
+    assert payload["max_distance"] == pytest.approx(0.35)
+
+
+def test_voice_check_builds_fingerprint_when_not_persisted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no persisted artefact, voice-check builds from vault fragments."""
+    vault = tmp_path / "vault"
+    _scaffold_voice_vault(vault)  # fragments present, but fingerprint NOT saved
+    monkeypatch.delenv("CREEK_CONFIG", raising=False)
+
+    target = tmp_path / "in_voice.md"
+    target.write_text(
+        (_voice_fixture_dir("in_voice") / "05_shed.md").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["voice-check", str(target), "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "voice_distance" in _strip_ansi(result.output).lower()


### PR DESCRIPTION
## Summary

- Adds a `creek voice-check <file>` subcommand that scores any markdown file against the vault's voice fingerprint and exits non-zero when it diverges — usable as a pre-commit hook, a CI step, or a manual "does this sound like me?" check.
- Resolves the fingerprint persisted-first (loads `00-Creek-Meta/voice-fingerprint.json`, falls back to building from self-authored fragments — the same path `creek draft` uses), then `scan()`s the file via the existing offline AI-style scanner. No LLM or consent.
- `--max-distance` defaults to the AI-style config's `voice_distance_upper` (0.35) — reuses the existing constant rather than inventing a magic number. `--vault` reuses standard vault resolution; `--json` emits a machine-readable verdict. Missing fingerprint emits a notice pointing at `creek report --type fingerprint` and exits 0 (fail open). Missing file exits 2.

## Test plan

- `cd creek-tools && ./scripts/check-all.sh` → exit 0 (5142 passed, coverage 93.83%, per-file gate, mypy strict, ruff, complexity, interrogate all green).
- New `tests/test_cli.py` cases (TDD, written first/red→green): in-voice file → exit 0; slop (wiki-padding) file → non-zero; missing fingerprint → graceful notice, no traceback; missing file → exit 2; `--json` parseable payload; persisted-vs-built fingerprint paths.
- Help-advertisement test is ANSI/width-robust: invoked with `COLUMNS=200` and asserts against `" ".join(_strip_ansi(result.output).split())` (LESSON from #519/#529).

Closes #533
Refs #417
