### PR TITLE
fix(hygiene): skip absolute-URL targets and guard OSError in BrokenLinkScanner (#543)

### DIFF
--- a/creek-tools/creek/clean/hygiene.py
+++ b/creek-tools/creek/clean/hygiene.py
@@ -148,9 +148,12 @@ _WIKILINK_PATTERN: re.Pattern[str] = re.compile(
 """Matches Obsidian wiki-links like ``[[Target]]`` or ``[[Target|Alias]]``."""
 
 _RELATIVE_LINK_PATTERN: re.Pattern[str] = re.compile(
-    r"\[([^\]]*)\]\((?!https?://)(?!#)([^)]+)\)",
+    r"\[([^\]]*)\]\((?!#)([^)]+)\)",
 )
-"""Matches markdown relative links like ``[text](path/to/file.md)``."""
+"""Matches markdown links like ``[text](path/to/file.md)`` (excluding anchors)."""
+
+_URL_SCHEME_PATTERN: re.Pattern[str] = re.compile(r"^[a-z][a-z0-9+.-]*:", re.IGNORECASE)
+"""Matches a leading URI scheme such as ``http:``, ``https:``, or ``mailto:``."""
 
 
 # ---------------------------------------------------------------------------
@@ -197,16 +200,45 @@ def _extract_wikilinks(content: str) -> list[str]:
     return _WIKILINK_PATTERN.findall(content)
 
 
+def _is_external_target(target: str) -> bool:
+    """Determine whether a link target points outside the local filesystem.
+
+    External targets are out of scope for a broken *local file* link scan:
+    absolute URLs with a scheme (``https://``, ``mailto:``, ``ftp://``, ...)
+    and protocol-relative URLs (``//host/path``).
+
+    Args:
+        target: A whitespace-stripped link target.
+
+    Returns:
+        True if the target is an external URL rather than a local path.
+    """
+    return target.startswith("//") or bool(_URL_SCHEME_PATTERN.match(target))
+
+
 def _extract_relative_links(content: str) -> list[str]:
-    """Extract relative link targets from markdown content.
+    """Extract relative (local file) link targets from markdown content.
+
+    The raw target captured by the pattern may carry an optional title
+    suffix (``path "title"``); only the URL portion is considered. External
+    targets (URLs with a scheme, or protocol-relative ``//host`` targets)
+    are excluded, since they are not local file references.
 
     Args:
         content: Raw markdown text.
 
     Returns:
-        List of relative link target strings.
+        List of relative link target strings, with external URLs removed.
     """
-    return [match[1] for match in _RELATIVE_LINK_PATTERN.findall(content)]
+    targets: list[str] = []
+    for match in _RELATIVE_LINK_PATTERN.findall(content):
+        # A markdown link target may be ``path "optional title"``; the URL
+        # is the first whitespace-delimited token.
+        target = match[1].strip().split(maxsplit=1)[0] if match[1].strip() else ""
+        if not target or _is_external_target(target):
+            continue
+        targets.append(target)
+    return targets
 
 
 class OrphanScanner:
@@ -506,13 +538,46 @@ class BrokenLinkScanner:
             if target not in all_stems
         ]
 
-        for target in _extract_relative_links(content):
-            resolved = (frag_file.parent / target).resolve()
-            vault_resolved = (vault_path / target).resolve()
-            if not resolved.exists() and not vault_resolved.exists():
-                broken.append(target)
+        broken.extend(
+            target
+            for target in _extract_relative_links(content)
+            if self._is_broken_local_link(target, frag_file, vault_path)
+        )
 
         return broken
+
+    @staticmethod
+    def _is_broken_local_link(
+        target: str,
+        frag_file: Path,
+        vault_path: Path,
+    ) -> bool:
+        """Check whether a relative target resolves to no existing file.
+
+        Resolution is wrapped defensively: a pathological target (e.g. one
+        with an over-long path segment) makes ``Path.exists()`` raise
+        ``OSError`` (``ENAMETOOLONG``, ``ELOOP``, ...) rather than returning
+        ``False``. Such targets cannot name a real local file, so they are
+        treated as not-broken (skipped) instead of aborting the whole scan.
+
+        Args:
+            target: A relative link target (no URL scheme).
+            frag_file: The fragment file containing the link.
+            vault_path: Root of the vault for resolving relative paths.
+
+        Returns:
+            True if the target resolves to no existing file under either
+            the fragment's directory or the vault root.
+        """
+        try:
+            resolved = (frag_file.parent / target).resolve()
+            vault_resolved = (vault_path / target).resolve()
+            missing = not resolved.exists() and not vault_resolved.exists()
+        except OSError:
+            logger.debug("Skipping unresolvable link target %r", target)
+            return False
+        else:
+            return missing
 
 
 class DuplicateScanner:

--- a/creek-tools/tests/test_hygiene.py
+++ b/creek-tools/tests/test_hygiene.py
@@ -353,6 +353,68 @@ class TestBrokenLinkScanner:
         result = scanner.scan(vault)
         assert result.total_broken == 3
 
+    def test_long_absolute_image_url_with_title_not_broken(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A long absolute image URL with a title does not crash or report (#543)."""
+        vault = _make_vault(tmp_path)
+        long_url = "https://substackcdn.com/image/fetch/" + "a" * 4000 + ".png"
+        _write_fragment(
+            vault,
+            "substack-image",
+            content=f'![alt text]({long_url} "an image title")',
+        )
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        assert result.total_broken == 0
+
+    def test_protocol_relative_url_ignored(self, tmp_path: Path) -> None:
+        """Protocol-relative (``//host/...``) URLs are not treated as local (#543)."""
+        vault = _make_vault(tmp_path)
+        long_target = "//substackcdn.com/image/" + "b" * 5000 + ".png"
+        _write_fragment(
+            vault,
+            "proto-rel",
+            content=f"![img]({long_target})",
+        )
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        assert result.total_broken == 0
+
+    def test_mailto_link_ignored(self, tmp_path: Path) -> None:
+        """``mailto:`` links are external and not reported as broken (#543)."""
+        vault = _make_vault(tmp_path)
+        _write_fragment(
+            vault,
+            "mail",
+            content="Reach me at [email](mailto:geoff@example.com).",
+        )
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        assert result.total_broken == 0
+
+    def test_pathological_relative_target_does_not_crash(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An over-long relative file target degrades gracefully (#543).
+
+        A target with no URL scheme but an over-long path segment would
+        raise ``OSError`` from ``Path.exists()``; the scan must not crash.
+        """
+        vault = _make_vault(tmp_path)
+        long_name = "c" * 5000 + ".md"
+        _write_fragment(
+            vault,
+            "pathological",
+            content=f"See [doc]({long_name}) for more.",
+        )
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        # Must not raise; the unresolvable target is treated as not-a-file.
+        assert result.total_broken == 0
+
 
 # ---------------------------------------------------------------------------
 # DuplicateScanner tests
@@ -539,4 +601,27 @@ class TestLinkExtraction:
         from creek.clean.hygiene import _extract_relative_links
 
         content = "See [section](#heading) for details."
+        assert _extract_relative_links(content) == []
+
+    def test_extract_relative_links_protocol_relative_ignored(self) -> None:
+        """Protocol-relative (``//host``) targets are excluded (#543)."""
+        from creek.clean.hygiene import _extract_relative_links
+
+        content = "![img](//cdn.example.com/x.png)"
+        assert _extract_relative_links(content) == []
+
+    def test_extract_relative_links_mailto_ignored(self) -> None:
+        """``mailto:`` targets are excluded (#543)."""
+        from creek.clean.hygiene import _extract_relative_links
+
+        content = "[mail](mailto:foo@bar.com)"
+        assert _extract_relative_links(content) == []
+
+    def test_extract_relative_links_scheme_with_leading_space_ignored(
+        self,
+    ) -> None:
+        """A scheme target with leading whitespace is still excluded (#543)."""
+        from creek.clean.hygiene import _extract_relative_links
+
+        content = "[x]( https://example.com/y)"
         assert _extract_relative_links(content) == []


### PR DESCRIPTION
## Summary

`creek state` crashed with an unhandled `OSError: [Errno 63] File name too long` whenever a fragment body contained a markdown image/link whose target was a long absolute URL (for example a Substack-ingested S3 image URL with an embedded title). `BrokenLinkScanner` treated the URL as a relative file link, built a `Path` from it, and called `.exists()`, which raised `ENAMETOOLONG` on macOS instead of returning `False` — aborting the entire scan.

Two compounding defects, both fixed here:

1. **Absolute / external targets were path-resolved.** The old `_RELATIVE_LINK_PATTERN` only excluded a leading `https?://`, so `mailto:`, protocol-relative `//cdn/...`, other URI schemes, and scheme targets with leading whitespace all leaked through and got treated as local file paths. `_extract_relative_links` now strips the optional `"title"` suffix and excludes any target with a URI scheme (`http:`, `https:`, `mailto:`, `ftp:`, ...) or a protocol-relative `//host` prefix, via a new `_is_external_target` helper.

2. **Existence checks were unguarded.** The resolution + `.exists()` is now wrapped in `try/except OSError` (new `_is_broken_local_link` helper), so any remaining pathological local target (over-long segment, symlink loop) degrades gracefully and is skipped instead of crashing `creek state`.

External link behaviour for the existing broken-*local*-link scan is unchanged; external URLs were never in scope.

## Test plan

Added to `creek-tools/tests/test_hygiene.py`:

- `TestBrokenLinkScanner::test_long_absolute_image_url_with_title_not_broken` — long `https://` S3-style image URL with a `"title"` is not crashed on and not reported.
- `TestBrokenLinkScanner::test_protocol_relative_url_ignored` — long `//host/...` target is not treated as local.
- `TestBrokenLinkScanner::test_mailto_link_ignored` — `mailto:` links are not reported as broken.
- `TestBrokenLinkScanner::test_pathological_relative_target_does_not_crash` — over-long relative file target degrades gracefully (no `OSError`).
- `TestLinkExtraction::test_extract_relative_links_protocol_relative_ignored`, `..._mailto_ignored`, `..._scheme_with_leading_space_ignored` — extraction-level guards.

Watched the new tests fail (red), implemented, green. Full local gate `./scripts/check-all.sh` passes (12/12: 93.82% branch coverage + per-file gate, mypy strict, ruff lint+format, bandit, pylint, refurb, tryceratops, interrogate, complexity). 5142 tests pass.

Closes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
