### PR TITLE
polish(voice): tidy ontology-gloss import, steer wording, registry cache

### DIFF
--- a/creek-tools/creek/generate/ontology_glossary.py
+++ b/creek-tools/creek/generate/ontology_glossary.py
@@ -23,6 +23,9 @@ keyword signal that an explanation is nearby.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cache
+from types import MappingProxyType
+from typing import TYPE_CHECKING
 
 from creek.generate.indexes import (
     CANONICAL_FREQUENCY_NAMES,
@@ -31,6 +34,9 @@ from creek.generate.indexes import (
 )
 from creek.generate.wavelength import _PHASE_DESCRIPTIONS
 from creek.models import Frequency, Mode, Phase
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 #: Plain-English activation sense for each engagement mode, adapted from the
 #: ``_mode_activation_phrase`` base map in :mod:`creek.generate.skills`. Kept
@@ -186,7 +192,8 @@ def iter_ontology_terms() -> list[OntologyTerm]:
     ]
 
 
-def ontology_term_registry() -> dict[str, OntologyTerm]:
+@cache
+def ontology_term_registry() -> Mapping[str, OntologyTerm]:
     """Return a lookup of every term surface form (lower-cased) to its term.
 
     Both each term's ``label`` and its ``aliases`` are registered under their
@@ -194,8 +201,13 @@ def ontology_term_registry() -> dict[str, OntologyTerm]:
     ``freq.value in registry`` for every enum member while case-insensitive
     lookups (an altitude or named concept written mid-sentence) still resolve.
 
+    The registry is derived from static enums and constants, so it is built once
+    and memoised. The result is wrapped in a read-only
+    :class:`~types.MappingProxyType` so a caller cannot mutate the shared cached
+    instance.
+
     Returns:
-        A mapping from surface form (exact and lower-cased) to
+        A read-only mapping from surface form (exact and lower-cased) to
         :class:`OntologyTerm`.
     """
     registry: dict[str, OntologyTerm] = {}
@@ -203,7 +215,7 @@ def ontology_term_registry() -> dict[str, OntologyTerm]:
         for surface in (term.label, *term.aliases):
             registry[surface] = term
             registry[surface.lower()] = term
-    return registry
+    return MappingProxyType(registry)
 
 
 #: Prompt steer asking the model to gloss each bespoke term in the owner's voice
@@ -212,7 +224,7 @@ def ontology_term_registry() -> dict[str, OntologyTerm]:
 #: out of the prompt. Phrased as a request for an appositive/short clause — not a
 #: textbook definition — and explicitly first-mention-only ("only once").
 GLOSS_STEER: str = (
-    "The first time you use one of my bespoke terms (a Frequency, Phase, Mood, "
+    "The first time you use one of my bespoke terms (a Frequency, Phase, Mode, "
     "altitude, or named concept like APTITUDE / Whole Adept / Archetypal "
     "Wavelength), weave in a brief plain-English gloss in my voice so a newcomer "
     "can follow — an appositive or short clause, not a dictionary definition, "

--- a/creek-tools/tests/test_ontology_glossary.py
+++ b/creek-tools/tests/test_ontology_glossary.py
@@ -15,7 +15,7 @@ Three concerns are pinned here:
 
 from __future__ import annotations
 
-from creek.author.checks import detect_unglossed_jargon
+from creek.generate.jargon import detect_unglossed_jargon
 from creek.generate.ontology_glossary import (
     GLOSS_STEER,
     OntologyTerm,
@@ -70,6 +70,14 @@ class TestRegistryDriftGuard:
             assert altitude.lower() in registry
 
 
+class TestRegistryMemoization:
+    """The registry is built once and reused across calls."""
+
+    def test_registry_is_memoized(self) -> None:
+        """Two calls return the same cached object (identity)."""
+        assert ontology_term_registry() is ontology_term_registry()
+
+
 class TestGlossSteerPinned:
     """The gloss instruction is present in both ``## Ask`` builders."""
 
@@ -78,6 +86,11 @@ class TestGlossSteerPinned:
         lowered = GLOSS_STEER.lower()
         assert "first time" in lowered
         assert "once" in lowered
+
+    def test_steer_names_mode_not_mood(self) -> None:
+        """The steer names ``Mode`` — the concept the registry/detector covers."""
+        assert "Mode" in GLOSS_STEER
+        assert "Mood" not in GLOSS_STEER
 
     def test_draft_ask_carries_gloss_steer_in_every_mode(self) -> None:
         """Every ``_compose_ask_section`` variant carries the gloss steer."""


### PR DESCRIPTION
## Summary

- Import `detect_unglossed_jargon` in `tests/test_ontology_glossary.py` from its canonical module `creek.generate.jargon` instead of the `creek.author.checks` re-export, so a re-export change can't silently break the test.
- Reconcile `GLOSS_STEER` wording: name **Mode** (the enum the registry/detector are built from) rather than "Mood", so the user-facing instruction names the same concept the system detects and glosses.
- Memoise `ontology_term_registry()` with `functools.cache` and return a read-only `MappingProxyType` — the registry is derived from static enums/constants, so it's built once, and the shared cached instance can't be mutated by callers.

## Test plan

- Added `test_steer_names_mode_not_mood` (steer names `Mode`, not `Mood`) and `test_registry_is_memoized` (two calls return the same cached object by identity).
- Updated the fragile import to the canonical module; the existing detector tests still exercise it.
- `cd creek-tools && ./scripts/check-all.sh` exits 0 (12 passed, 0 failed; 5147 tests, 93.83% coverage).

Closes #537
Refs #417
