### PR TITLE
feat(skills): Add crawdad-launch skill to start the bot for any vault

### DIFF
--- a/.claude/skills/crawdad-launch/SKILL.md
+++ b/.claude/skills/crawdad-launch/SKILL.md
@@ -9,6 +9,9 @@ description: >-
   secrets, allowlists) and starts the bot in the background. Do NOT use for
   driving the `creek` CLI / writing essays (use creek-cli) or editing
   crawdad/creek-tools source (use stay-green/work-issue).
+metadata:
+  author: Geoff
+  version: 1.0.0
 ---
 
 # crawdad-launch
@@ -19,8 +22,8 @@ per turn and runs a Haiku-router → MCP → Sonnet-composer agent loop.
 
 ## Step 1 — Ask which vault (always)
 
-Do **not** assume the vault. Ask the user for the vault directory. Offer the
-known options as a sensible default:
+Do **not** assume the vault. Ask the user for the vault directory. On this
+machine the known options (examples — substitute the user's actual vaults) are:
 
 - Demo / prod: `/Users/geoffgallinger/Documents/creek-demo-2026-05-30`
 - Primary: `/Users/geoffgallinger/Documents/creek`
@@ -30,10 +33,11 @@ Run unattended against the **demo** vault unless told otherwise.
 ## Step 2 — Preflight + write the launch config
 
 Run the bundled script with the chosen vault. It validates the vault, ensures
-the env secrets, fixes the known gotchas, and writes `crawdad/crawdad.yaml`:
+the env secrets, fixes the known gotchas, and writes `crawdad/crawdad.yaml`.
+Resolve the script via the repo root so this works on any checkout:
 
 ```bash
-bash /Users/geoffgallinger/Projects/creek-tools/.claude/skills/crawdad-launch/launch.sh <VAULT>
+bash "$(git rev-parse --show-toplevel)/.claude/skills/crawdad-launch/launch.sh" <VAULT>
 ```
 
 What it checks/fixes (each is a real launch failure mode):
@@ -53,12 +57,14 @@ If the script prints `ERROR:`, stop and fix what it reports before launching.
 
 ## Step 3 — Launch the bot (background)
 
-On `READY`, start the bot as a **background** Bash process (it's a long-running
-Discord client, not a one-shot):
+On success the script prints a `READY` block ending with the exact, fully
+resolved launch command under `Launch with:`. Run **that** command verbatim
+(it already contains the right repo-derived absolute paths — don't hand-write
+paths) as a **background** Bash process, since it's a long-running Discord
+client, not a one-shot. The shape is:
 
 ```bash
-cd /Users/geoffgallinger/Projects/creek-tools/crawdad && \
-  uv run crawdad run --config /Users/geoffgallinger/Projects/creek-tools/crawdad/crawdad.yaml
+cd <REPO>/crawdad && uv run crawdad run --config <REPO>/crawdad/crawdad.yaml
 ```
 
 Use `run_in_background: true`. Then read the background output to confirm it

--- a/.claude/skills/crawdad-launch/SKILL.md
+++ b/.claude/skills/crawdad-launch/SKILL.md
@@ -22,13 +22,24 @@ per turn and runs a Haiku-router → MCP → Sonnet-composer agent loop.
 
 ## Step 1 — Ask which vault (always)
 
-Do **not** assume the vault. Ask the user for the vault directory. On this
-machine the known options (examples — substitute the user's actual vaults) are:
+Always ask the user which vault directory to launch against — never assume one.
+To help them choose:
 
-- Demo / prod: `/Users/geoffgallinger/Documents/creek-demo-2026-05-30`
-- Primary: `/Users/geoffgallinger/Documents/creek`
+- **Discover the Creek vaults on this machine** (a vault is any dir with a
+  `00-Creek-Meta/creek_config.yaml`):
+  ```bash
+  find ~ -maxdepth 5 -path '*/00-Creek-Meta/creek_config.yaml' 2>/dev/null \
+    | sed 's#/00-Creek-Meta/creek_config.yaml##'
+  ```
+- **Offer the last-launched vault as the default.** If `crawdad/crawdad.yaml`
+  already exists, its `vault_path` is the vault CrawDad last ran against — a
+  sensible default when the user has no preference. Read it with:
+  ```bash
+  sed -n "s/^vault_path:[[:space:]]*//p" "$(git rev-parse --show-toplevel)/crawdad/crawdad.yaml" | tr -d "\"'"
+  ```
 
-Run unattended against the **demo** vault unless told otherwise.
+If a non-interactive run gives you no vault and no prior config exists, stop and
+ask rather than guessing.
 
 ## Step 2 — Preflight + write the launch config
 
@@ -50,8 +61,11 @@ What it checks/fixes (each is a real launch failure mode):
   free-text replies + session-state load at startup).
 - **`creek-skills/voice-core/SKILL.md`** — mirrors `meta/voice-core.SKILL.md`
   into it (bug #538) so replies sound like the vault owner, not generic.
-- **Discord allowlists** — preserved from the existing config, else the known
-  single-user defaults. Both lists must be non-empty or the bot won't start.
+- **Discord allowlists** — all ids preserved from the existing `crawdad.yaml`,
+  else taken from `CRAWDAD_DEFAULT_USER` / `CRAWDAD_DEFAULT_CHANNEL` in the env.
+  A fresh vault with no prior config and no env defaults fails with a clear
+  message (both lists must be non-empty or the bot won't start) — export those
+  two vars or hand-edit the allowlists before retrying.
 
 If the script prints `ERROR:`, stop and fix what it reports before launching.
 

--- a/.claude/skills/crawdad-launch/SKILL.md
+++ b/.claude/skills/crawdad-launch/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: crawdad-launch
+description: >-
+  Launch the CrawDad Discord bot against a Creek vault. Use when the user asks
+  to "launch CrawDad", "start the bot", "run CrawDad", "fire up the Discord
+  bot", or otherwise bring the Discord-side interface online for a vault.
+  ALWAYS ask which vault directory to run against first. Handles every launch
+  gotcha (absolute vault_path, State/latest.md, voice-core mirroring, env
+  secrets, allowlists) and starts the bot in the background. Do NOT use for
+  driving the `creek` CLI / writing essays (use creek-cli) or editing
+  crawdad/creek-tools source (use stay-green/work-issue).
+---
+
+# crawdad-launch
+
+Brings the CrawDad Discord bot online against a chosen Creek vault. CrawDad is
+the Discord-side interface to a vault; it spawns the `creek-tools-mcp` server
+per turn and runs a Haiku-router → MCP → Sonnet-composer agent loop.
+
+## Step 1 — Ask which vault (always)
+
+Do **not** assume the vault. Ask the user for the vault directory. Offer the
+known options as a sensible default:
+
+- Demo / prod: `/Users/geoffgallinger/Documents/creek-demo-2026-05-30`
+- Primary: `/Users/geoffgallinger/Documents/creek`
+
+Run unattended against the **demo** vault unless told otherwise.
+
+## Step 2 — Preflight + write the launch config
+
+Run the bundled script with the chosen vault. It validates the vault, ensures
+the env secrets, fixes the known gotchas, and writes `crawdad/crawdad.yaml`:
+
+```bash
+bash /Users/geoffgallinger/Projects/creek-tools/.claude/skills/crawdad-launch/launch.sh <VAULT>
+```
+
+What it checks/fixes (each is a real launch failure mode):
+- **Env secrets** `DISCORD_BOT_TOKEN` + `ANTHROPIC_API_KEY` — the bot refuses to
+  start without them. They are normally already in the shell env.
+- **Absolute `vault_path`** in `<vault>/00-Creek-Meta/creek_config.yaml` — a
+  relative path makes every MCP tool (`state.read`, `mine`, …) silently read the
+  MCP process cwd instead of the vault. The script rewrites it to absolute.
+- **`State/latest.md`** — runs `creek state` to generate it if missing (unblocks
+  free-text replies + session-state load at startup).
+- **`creek-skills/voice-core/SKILL.md`** — mirrors `meta/voice-core.SKILL.md`
+  into it (bug #538) so replies sound like the vault owner, not generic.
+- **Discord allowlists** — preserved from the existing config, else the known
+  single-user defaults. Both lists must be non-empty or the bot won't start.
+
+If the script prints `ERROR:`, stop and fix what it reports before launching.
+
+## Step 3 — Launch the bot (background)
+
+On `READY`, start the bot as a **background** Bash process (it's a long-running
+Discord client, not a one-shot):
+
+```bash
+cd /Users/geoffgallinger/Projects/creek-tools/crawdad && \
+  uv run crawdad run --config /Users/geoffgallinger/Projects/creek-tools/crawdad/crawdad.yaml
+```
+
+Use `run_in_background: true`. Then read the background output to confirm it
+connected to Discord (look for the gateway/ready log line) and report the
+channel it's listening in. Both `crawdad` and `creek-tools-mcp` run from source
+via `uv run`, so **to pick up merged/edited code just restart the bot** — no
+reinstall needed.
+
+## Notes
+
+- A running bot is frozen at launch-time code; restart after pulling new `main`.
+- `crawdad.yaml` is trusted input (its `mcp_server_command` is executed verbatim
+  as a subprocess argv) — keep it out of untrusted-writable directories.
+- To stop the bot, kill the background process.

--- a/.claude/skills/crawdad-launch/launch.sh
+++ b/.claude/skills/crawdad-launch/launch.sh
@@ -51,8 +51,10 @@ echo "[ok] DISCORD_BOT_TOKEN and ANTHROPIC_API_KEY present"
 VP="$(sed -n 's/^vault_path:[[:space:]]*//p' "$VAULT_CONFIG" | head -1 | tr -d '"'"'"' ')"
 if [[ "$VP" != /* ]]; then
   echo "[fix] vault_path in $VAULT_CONFIG is '$VP' (relative) — rewriting to absolute"
-  # macOS/BSD sed in-place
-  sed -i '' "s|^vault_path:.*|vault_path: $VAULT|" "$VAULT_CONFIG"
+  # Portable in-place edit: GNU sed needs no suffix, BSD/macOS sed requires one.
+  # `-i.bak` works on both; the .bak also serves as a backup of the prior config.
+  sed -i.bak "s|^vault_path:.*|vault_path: $VAULT|" "$VAULT_CONFIG" \
+    && rm -f "${VAULT_CONFIG}.bak"
 else
   echo "[ok] vault_path is absolute ($VP)"
 fi
@@ -82,37 +84,51 @@ else
   echo "       build one with: (cd $CREEK_PROJECT && uv run creek skills generate --vault $VAULT)"
 fi
 
-# 6. Preserve existing Discord allowlists if a config is already present;
-#    otherwise fall back to the known single-user defaults.
+# 6. Preserve existing Discord allowlists if a config is already present.
+#    Read ALL numeric ids under each key (not just the first), validate each is
+#    a snowflake, and fall back to the known single-user defaults when empty.
+#    NOTE: these defaults are the repo author's own Discord ids — replace them
+#    with your own user/channel ids when running a different deployment.
 DEFAULT_USER="579188864804192268"
 DEFAULT_CHANNEL="860198841784205325"
-USER_ID="$DEFAULT_USER"
-CHANNEL_ID="$DEFAULT_CHANNEL"
+
+# read_list <file> <key> -> one numeric id per line for that YAML sequence
+read_list() {
+  awk -v k="$2:" '
+    $0 ~ "^"k"[[:space:]]*$" {f=1; next}   # enter the target sequence
+    /^[^[:space:]-]/         {f=0}          # any new top-level key ends it
+    f && /^[[:space:]]*-/    {gsub(/[^0-9]/, ""); if (length($0)) print}
+  ' "$1"
+}
+
+USER_IDS=()
+CHAN_IDS=()
 if [[ -f "$CONFIG_OUT" ]]; then
-  EXIST_USER="$(awk '/^allowed_user_ids:/{f=1;next} /^[^[:space:]-]/{f=0} f && /-/{gsub(/[^0-9]/,"");print;exit}' "$CONFIG_OUT")"
-  EXIST_CHAN="$(awk '/^allowed_channel_ids:/{f=1;next} /^[^[:space:]-]/{f=0} f && /-/{gsub(/[^0-9]/,"");print;exit}' "$CONFIG_OUT")"
-  [[ -n "$EXIST_USER" ]] && USER_ID="$EXIST_USER"
-  [[ -n "$EXIST_CHAN" ]] && CHANNEL_ID="$EXIST_CHAN"
+  while IFS= read -r id; do [[ "$id" =~ ^[0-9]+$ ]] && USER_IDS+=("$id"); done \
+    < <(read_list "$CONFIG_OUT" allowed_user_ids)
+  while IFS= read -r id; do [[ "$id" =~ ^[0-9]+$ ]] && CHAN_IDS+=("$id"); done \
+    < <(read_list "$CONFIG_OUT" allowed_channel_ids)
 fi
-echo "[ok] allowlist: user=$USER_ID channel=$CHANNEL_ID"
+[[ ${#USER_IDS[@]} -eq 0 ]] && USER_IDS=("$DEFAULT_USER")
+[[ ${#CHAN_IDS[@]} -eq 0 ]] && CHAN_IDS=("$DEFAULT_CHANNEL")
+echo "[ok] allowlist: ${#USER_IDS[@]} user(s), ${#CHAN_IDS[@]} channel(s)"
 
 # 7. Write the launch config. mcp_server_command must point at the creek-tools
-#    project (absolute) and the vault's own config.
-cat > "$CONFIG_OUT" <<YAML
-vault_path: $VAULT
-mcp_server_command:
-  - uv
-  - run
-  - --project
-  - $CREEK_PROJECT
-  - creek-tools-mcp
-  - --config
-  - $VAULT_CONFIG
-allowed_user_ids:
-  - $USER_ID
-allowed_channel_ids:
-  - $CHANNEL_ID
-YAML
+#    project (absolute) and the vault's own config. Path values are single-quoted
+#    so a path containing YAML-reserved chars (: # & *) can't corrupt the config
+#    or inject into the executed mcp_server_command argv.
+{
+  printf "vault_path: '%s'\n" "$VAULT"
+  printf "mcp_server_command:\n"
+  printf "  - uv\n  - run\n  - --project\n"
+  printf "  - '%s'\n" "$CREEK_PROJECT"
+  printf "  - creek-tools-mcp\n  - --config\n"
+  printf "  - '%s'\n" "$VAULT_CONFIG"
+  printf "allowed_user_ids:\n"
+  for id in "${USER_IDS[@]}"; do printf "  - %s\n" "$id"; done
+  printf "allowed_channel_ids:\n"
+  for id in "${CHAN_IDS[@]}"; do printf "  - %s\n" "$id"; done
+} > "$CONFIG_OUT"
 echo "[ok] wrote $CONFIG_OUT"
 
 echo

--- a/.claude/skills/crawdad-launch/launch.sh
+++ b/.claude/skills/crawdad-launch/launch.sh
@@ -51,10 +51,11 @@ echo "[ok] DISCORD_BOT_TOKEN and ANTHROPIC_API_KEY present"
 VP="$(sed -n 's/^vault_path:[[:space:]]*//p' "$VAULT_CONFIG" | head -1 | tr -d '"'"'"' ')"
 if [[ "$VP" != /* ]]; then
   echo "[fix] vault_path in $VAULT_CONFIG is '$VP' (relative) — rewriting to absolute"
-  # Portable in-place edit: GNU sed needs no suffix, BSD/macOS sed requires one.
-  # `-i.bak` works on both; the .bak also serves as a backup of the prior config.
-  sed -i.bak "s|^vault_path:.*|vault_path: $VAULT|" "$VAULT_CONFIG" \
-    && rm -f "${VAULT_CONFIG}.bak"
+  # Atomic, portable rewrite: write to a temp file then mv into place. Avoids the
+  # GNU-vs-BSD `sed -i` suffix split, and the original survives if sed fails.
+  TMP_CFG="$(mktemp)"
+  sed "s|^vault_path:.*|vault_path: $VAULT|" "$VAULT_CONFIG" > "$TMP_CFG" \
+    && mv "$TMP_CFG" "$VAULT_CONFIG"
 else
   echo "[ok] vault_path is absolute ($VP)"
 fi
@@ -84,13 +85,12 @@ else
   echo "       build one with: (cd $CREEK_PROJECT && uv run creek skills generate --vault $VAULT)"
 fi
 
-# 6. Preserve existing Discord allowlists if a config is already present.
-#    Read ALL numeric ids under each key (not just the first), validate each is
-#    a snowflake, and fall back to the known single-user defaults when empty.
-#    NOTE: these defaults are the repo author's own Discord ids — replace them
-#    with your own user/channel ids when running a different deployment.
-DEFAULT_USER="579188864804192268"
-DEFAULT_CHANNEL="860198841784205325"
+# 6. Determine the Discord allowlists. Preferred source is the existing config
+#    (preserve ALL numeric ids, not just the first); otherwise fall back to the
+#    CRAWDAD_DEFAULT_USER / CRAWDAD_DEFAULT_CHANNEL env vars. No personal ids are
+#    baked into this script — a fresh vault with no prior config must supply them.
+DEFAULT_USER="${CRAWDAD_DEFAULT_USER:-}"
+DEFAULT_CHANNEL="${CRAWDAD_DEFAULT_CHANNEL:-}"
 
 # read_list <file> <key> -> one numeric id per line for that YAML sequence
 read_list() {
@@ -109,21 +109,32 @@ if [[ -f "$CONFIG_OUT" ]]; then
   while IFS= read -r id; do [[ "$id" =~ ^[0-9]+$ ]] && CHAN_IDS+=("$id"); done \
     < <(read_list "$CONFIG_OUT" allowed_channel_ids)
 fi
-[[ ${#USER_IDS[@]} -eq 0 ]] && USER_IDS=("$DEFAULT_USER")
-[[ ${#CHAN_IDS[@]} -eq 0 ]] && CHAN_IDS=("$DEFAULT_CHANNEL")
+if [[ ${#USER_IDS[@]} -eq 0 ]]; then
+  [[ "$DEFAULT_USER" =~ ^[0-9]+$ ]] \
+    || fail "no allowed_user_ids in $CONFIG_OUT and CRAWDAD_DEFAULT_USER is unset/invalid — export it as your Discord user id"
+  USER_IDS=("$DEFAULT_USER")
+fi
+if [[ ${#CHAN_IDS[@]} -eq 0 ]]; then
+  [[ "$DEFAULT_CHANNEL" =~ ^[0-9]+$ ]] \
+    || fail "no allowed_channel_ids in $CONFIG_OUT and CRAWDAD_DEFAULT_CHANNEL is unset/invalid — export it as your Discord channel id"
+  CHAN_IDS=("$DEFAULT_CHANNEL")
+fi
 echo "[ok] allowlist: ${#USER_IDS[@]} user(s), ${#CHAN_IDS[@]} channel(s)"
 
 # 7. Write the launch config. mcp_server_command must point at the creek-tools
 #    project (absolute) and the vault's own config. Path values are single-quoted
-#    so a path containing YAML-reserved chars (: # & *) can't corrupt the config
-#    or inject into the executed mcp_server_command argv.
+#    (with embedded single quotes doubled per YAML) so a path containing
+#    YAML-reserved chars (: # & *) or a quote can't corrupt the config or inject
+#    into the executed mcp_server_command argv.
+# Emit a YAML single-quoted scalar, doubling any embedded single quote per spec.
+sq() { local q="'" s="$1"; s="${s//$q/$q$q}"; printf '%s%s%s' "$q" "$s" "$q"; }
 {
-  printf "vault_path: '%s'\n" "$VAULT"
+  printf "vault_path: %s\n" "$(sq "$VAULT")"
   printf "mcp_server_command:\n"
   printf "  - uv\n  - run\n  - --project\n"
-  printf "  - '%s'\n" "$CREEK_PROJECT"
+  printf "  - %s\n" "$(sq "$CREEK_PROJECT")"
   printf "  - creek-tools-mcp\n  - --config\n"
-  printf "  - '%s'\n" "$VAULT_CONFIG"
+  printf "  - %s\n" "$(sq "$VAULT_CONFIG")"
   printf "allowed_user_ids:\n"
   for id in "${USER_IDS[@]}"; do printf "  - %s\n" "$id"; done
   printf "allowed_channel_ids:\n"

--- a/.claude/skills/crawdad-launch/launch.sh
+++ b/.claude/skills/crawdad-launch/launch.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Preflight + config generation for launching CrawDad against a chosen vault.
+# Does everything EXCEPT the final `crawdad run` — prints the exact launch
+# command on success so the caller can start the bot in the background.
+#
+# Usage: launch.sh <vault-dir>
+set -euo pipefail
+
+VAULT="${1:-}"
+if [[ -z "$VAULT" ]]; then
+  echo "ERROR: no vault directory given. Usage: launch.sh <vault-dir>" >&2
+  exit 2
+fi
+
+# Resolve to an absolute, real path (CrawDad/MCP need absolute paths).
+VAULT="$(cd "$VAULT" 2>/dev/null && pwd)" || {
+  echo "ERROR: vault directory does not exist: $1" >&2
+  exit 2
+}
+
+# Repo layout, derived from this script's location:
+#   <repo>/.claude/skills/crawdad-launch/launch.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CREEK_PROJECT="$REPO/creek-tools"      # the Python subproject (uv project)
+CRAWDAD_DIR="$REPO/crawdad"            # CrawDad lives beside creek-tools
+META="$VAULT/00-Creek-Meta"
+VAULT_CONFIG="$META/creek_config.yaml"
+CONFIG_OUT="$CRAWDAD_DIR/crawdad.yaml"
+
+fail() { echo "ERROR: $*" >&2; exit 1; }
+
+echo "== CrawDad launch preflight =="
+echo "vault:         $VAULT"
+echo "creek project: $CREEK_PROJECT"
+echo "crawdad dir:   $CRAWDAD_DIR"
+echo
+
+# 1. Vault must be a Creek vault.
+[[ -d "$META" ]]            || fail "not a Creek vault — missing $META (run 'creek init --vault $VAULT')"
+[[ -f "$VAULT_CONFIG" ]]   || fail "missing vault config $VAULT_CONFIG (run 'creek init --vault $VAULT')"
+[[ -d "$CRAWDAD_DIR" ]]    || fail "cannot find CrawDad project at $CRAWDAD_DIR"
+
+# 2. Secrets must be in the environment (CrawDad refuses to start without them).
+[[ -n "${DISCORD_BOT_TOKEN:-}" ]] || fail "DISCORD_BOT_TOKEN is not set in the environment"
+[[ -n "${ANTHROPIC_API_KEY:-}" ]] || fail "ANTHROPIC_API_KEY is not set in the environment"
+echo "[ok] DISCORD_BOT_TOKEN and ANTHROPIC_API_KEY present"
+
+# 3. vault_path in the vault config MUST be absolute, or every MCP tool reads
+#    the wrong directory (resolved against the MCP process cwd, not the config).
+VP="$(sed -n 's/^vault_path:[[:space:]]*//p' "$VAULT_CONFIG" | head -1 | tr -d '"'"'"' ')"
+if [[ "$VP" != /* ]]; then
+  echo "[fix] vault_path in $VAULT_CONFIG is '$VP' (relative) — rewriting to absolute"
+  # macOS/BSD sed in-place
+  sed -i '' "s|^vault_path:.*|vault_path: $VAULT|" "$VAULT_CONFIG"
+else
+  echo "[ok] vault_path is absolute ($VP)"
+fi
+
+# 4. State/latest.md unblocks free-text replies and session-state load.
+if [[ -f "$META/State/latest.md" ]]; then
+  echo "[ok] State/latest.md present"
+else
+  echo "[fix] State/latest.md missing — generating with 'creek state'"
+  ( cd "$CREEK_PROJECT" && \
+    CREEK_CONFIG="$VAULT_CONFIG" uv run creek state --vault "$VAULT" >/dev/null ) \
+    || echo "[warn] 'creek state' failed; the bot still runs but free-text may be limited"
+fi
+
+# 5. Voice-core skill: CrawDad's skill_loader reads creek-skills/voice-core/SKILL.md
+#    (bug #538), but 'creek skills generate' writes meta/voice-core.SKILL.md.
+#    Mirror it so replies sound like the vault owner, not a generic assistant.
+VC_DIR="$VAULT/creek-skills/voice-core"
+if [[ -f "$VC_DIR/SKILL.md" ]]; then
+  echo "[ok] creek-skills/voice-core/SKILL.md present"
+elif [[ -f "$VAULT/creek-skills/meta/voice-core.SKILL.md" ]]; then
+  echo "[fix] mirroring meta/voice-core.SKILL.md -> voice-core/SKILL.md (#538 workaround)"
+  mkdir -p "$VC_DIR"
+  cp "$VAULT/creek-skills/meta/voice-core.SKILL.md" "$VC_DIR/SKILL.md"
+else
+  echo "[warn] no voice-core skill found — replies will use a generic voice."
+  echo "       build one with: (cd $CREEK_PROJECT && uv run creek skills generate --vault $VAULT)"
+fi
+
+# 6. Preserve existing Discord allowlists if a config is already present;
+#    otherwise fall back to the known single-user defaults.
+DEFAULT_USER="579188864804192268"
+DEFAULT_CHANNEL="860198841784205325"
+USER_ID="$DEFAULT_USER"
+CHANNEL_ID="$DEFAULT_CHANNEL"
+if [[ -f "$CONFIG_OUT" ]]; then
+  EXIST_USER="$(awk '/^allowed_user_ids:/{f=1;next} /^[^[:space:]-]/{f=0} f && /-/{gsub(/[^0-9]/,"");print;exit}' "$CONFIG_OUT")"
+  EXIST_CHAN="$(awk '/^allowed_channel_ids:/{f=1;next} /^[^[:space:]-]/{f=0} f && /-/{gsub(/[^0-9]/,"");print;exit}' "$CONFIG_OUT")"
+  [[ -n "$EXIST_USER" ]] && USER_ID="$EXIST_USER"
+  [[ -n "$EXIST_CHAN" ]] && CHANNEL_ID="$EXIST_CHAN"
+fi
+echo "[ok] allowlist: user=$USER_ID channel=$CHANNEL_ID"
+
+# 7. Write the launch config. mcp_server_command must point at the creek-tools
+#    project (absolute) and the vault's own config.
+cat > "$CONFIG_OUT" <<YAML
+vault_path: $VAULT
+mcp_server_command:
+  - uv
+  - run
+  - --project
+  - $CREEK_PROJECT
+  - creek-tools-mcp
+  - --config
+  - $VAULT_CONFIG
+allowed_user_ids:
+  - $USER_ID
+allowed_channel_ids:
+  - $CHANNEL_ID
+YAML
+echo "[ok] wrote $CONFIG_OUT"
+
+echo
+echo "READY"
+echo "Launch with:"
+echo "  cd $CRAWDAD_DIR && uv run crawdad run --config $CONFIG_OUT"


### PR DESCRIPTION
## Summary

Adds a `crawdad-launch` Claude Code skill that brings the CrawDad Discord bot
online against a **user-chosen** Creek vault. The skill always asks for the
vault directory first, then runs a preflight script that fixes every known
launch failure mode before starting the bot in the background.

## Why

Launching CrawDad by hand means remembering a pile of non-obvious gotchas
(absolute `vault_path`, `State/latest.md`, the #538 voice-core mirroring, env
secrets, non-empty allowlists). This skill encodes all of them so the bot comes
up correctly against any vault, first try.

## Changes

- `.claude/skills/crawdad-launch/SKILL.md` — triggers on "launch CrawDad / start
  the bot / run CrawDad"; mandates asking for the vault, documents the
  background-launch + restart-to-update model.
- `.claude/skills/crawdad-launch/launch.sh` — preflight + config generator:
  - requires `DISCORD_BOT_TOKEN` + `ANTHROPIC_API_KEY`
  - rewrites a relative `vault_path` to absolute (else MCP tools read the wrong dir)
  - generates `State/latest.md` via `creek state` if missing
  - mirrors `meta/voice-core.SKILL.md` -> `voice-core/SKILL.md` (#538)
  - preserves Discord allowlists, writes `crawdad/crawdad.yaml`
  - derives repo / creek-tools / crawdad paths from its own location (portable)

## Test Plan

- [x] `shellcheck launch.sh` — clean
- [x] Ran preflight against `creek-demo-2026-05-30`: passed, auto-mirrored
      voice-core, wrote a correct `crawdad.yaml`
- [x] Launched the bot: `crawdad connected as CrawDad#1656`, `/crawdad`
      commands synced, MCP tools advertised
