### PR TITLE
fix(skills): crawdad-launch MCP wrapper — forward ANTHROPIC_API_KEY, fix uv-spawn flakiness

### DIFF
--- a/.claude/skills/crawdad-launch/SKILL.md
+++ b/.claude/skills/crawdad-launch/SKILL.md
@@ -79,6 +79,12 @@ What it checks/fixes (each is a real launch failure mode):
   `uv run` if the venv binary isn't built yet (`uv sync` in `creek-tools`).
   **`CREEK_ANTHROPIC_CONSENT=1` means vault content egresses to Anthropic on the
   user's key** when those tools run — intended for the user's own vault.
+  Because the login shell only sources *login* profiles (`~/.zprofile`,
+  `~/.zshenv`, `~/.bash_profile`, `~/.profile`) and **not** interactive rc files
+  (`~/.zshrc`, `~/.bashrc`), `ANTHROPIC_API_KEY` must be exported in a login
+  file. The script probes for this under a scrubbed env and prints a `[warn]`
+  (with the fix) if the key is only in an rc file — heed it or the cloud tools
+  degrade exactly as before.
 
 If the script prints `ERROR:`, stop and fix what it reports before launching.
 

--- a/.claude/skills/crawdad-launch/SKILL.md
+++ b/.claude/skills/crawdad-launch/SKILL.md
@@ -96,9 +96,11 @@ cd <REPO>/crawdad && uv run crawdad run --config <REPO>/crawdad/crawdad.yaml
 
 Use `run_in_background: true`. Then read the background output to confirm it
 connected to Discord (look for the gateway/ready log line) and report the
-channel it's listening in. Both `crawdad` and `creek-tools-mcp` run from source
-via `uv run`, so **to pick up merged/edited code just restart the bot** — no
-reinstall needed.
+channel it's listening in. `crawdad` runs from source via `uv run`, and
+`creek-tools-mcp` runs from its pre-built editable venv binary (or `uv run` in
+the fallback) — both reflect source edits, so **to pick up merged/edited code
+just restart the bot**, no reinstall needed. Only a *dependency* change needs a
+`uv sync` in `creek-tools` first.
 
 ## Notes
 

--- a/.claude/skills/crawdad-launch/SKILL.md
+++ b/.claude/skills/crawdad-launch/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   crawdad/creek-tools source (use stay-green/work-issue).
 metadata:
   author: Geoff
-  version: 1.0.0
+  version: 1.1.0
 ---
 
 # crawdad-launch
@@ -66,6 +66,19 @@ What it checks/fixes (each is a real launch failure mode):
   A fresh vault with no prior config and no env defaults fails with a clear
   message (both lists must be non-empty or the bot won't start) — export those
   two vars or hand-edit the allowlists before retrying.
+- **MCP launch wrapper** — `mcp_server_command` is generated as a **login shell**
+  wrapper (`$SHELL -lc 'export CREEK_ANTHROPIC_CONSENT=1; exec <venv>/creek-tools-mcp …'`)
+  rather than a bare `uv run`. This fixes two real failures: (1) CrawDad spawns
+  the MCP server through the stdio SDK, which **scrubs the environment** and drops
+  `ANTHROPIC_API_KEY`, so in-MCP cloud tools (`draft`/`author`/`mine`/`classify`)
+  silently degrade — the login shell re-establishes the key from your profile;
+  and (2) spawning `uv run` every turn is slow and contends on uv's project lock
+  across agent-loop rounds, surfacing as `could not start … ('uv')` →
+  `mcp_unavailable` replies — `exec`ing the creek-tools venv entry point directly
+  is fast, lock-free, and keeps the JSON-RPC stdout stream clean. Falls back to
+  `uv run` if the venv binary isn't built yet (`uv sync` in `creek-tools`).
+  **`CREEK_ANTHROPIC_CONSENT=1` means vault content egresses to Anthropic on the
+  user's key** when those tools run — intended for the user's own vault.
 
 If the script prints `ERROR:`, stop and fix what it reports before launching.
 

--- a/.claude/skills/crawdad-launch/launch.sh
+++ b/.claude/skills/crawdad-launch/launch.sh
@@ -121,20 +121,46 @@ if [[ ${#CHAN_IDS[@]} -eq 0 ]]; then
 fi
 echo "[ok] allowlist: ${#USER_IDS[@]} user(s), ${#CHAN_IDS[@]} channel(s)"
 
-# 7. Write the launch config. mcp_server_command must point at the creek-tools
-#    project (absolute) and the vault's own config. Path values are single-quoted
-#    (with embedded single quotes doubled per YAML) so a path containing
-#    YAML-reserved chars (: # & *) or a quote can't corrupt the config or inject
-#    into the executed mcp_server_command argv.
+# 7. Build the MCP server command.
+#
+#    CrawDad spawns this per turn via the MCP stdio SDK, which (a) scrubs the
+#    environment down to a safe allowlist — dropping ANTHROPIC_API_KEY, so
+#    in-MCP cloud tools (draft/author/mine/classify) silently degrade — and
+#    (b) inherits whatever start-up cost the command has. Spawning `uv run`
+#    every turn is slow and contends on uv's project lock when the agent loop
+#    fires several rounds, which surfaces as "could not start ... ('uv')".
+#
+#    Fix both by wrapping the command in a LOGIN shell that re-establishes the
+#    user's exported secrets (ANTHROPIC_API_KEY) from their profile and sets
+#    CREEK_ANTHROPIC_CONSENT=1, then `exec`s the creek-tools venv entry point
+#    DIRECTLY (no `uv run`: deterministic, fast, no lock contention, and `exec`
+#    hands stdio straight to the server so the MCP JSON-RPC stream stays clean).
+#    Falls back to `uv run` if the venv binary isn't present yet.
+LOGIN_SHELL="${SHELL:-/bin/zsh}"
+MCP_BIN="$CREEK_PROJECT/.venv/bin/creek-tools-mcp"
+
+# shq: POSIX shell single-quote (embedded ' becomes '\'') — safe argv for the -lc string.
+shq() { local q="'" s="$1"; s="${s//$q/$q\\$q$q}"; printf '%s%s%s' "$q" "$s" "$q"; }
+if [[ -x "$MCP_BIN" ]]; then
+  echo "[ok] using direct MCP entry point $MCP_BIN"
+  MCP_EXEC="exec $(shq "$MCP_BIN") --config $(shq "$VAULT_CONFIG")"
+else
+  echo "[warn] $MCP_BIN missing — falling back to 'uv run' (slower; run 'uv sync' in creek-tools)"
+  MCP_EXEC="exec uv run --project $(shq "$CREEK_PROJECT") creek-tools-mcp --config $(shq "$VAULT_CONFIG")"
+fi
+MCP_INNER="export CREEK_ANTHROPIC_CONSENT=1; $MCP_EXEC"
+
+# 8. Write the launch config. Every scalar is a YAML single-quoted string (with
+#    embedded single quotes doubled per spec) so a path with YAML-reserved chars
+#    (: # & *) or a quote can't corrupt the config or inject into the argv.
 # Emit a YAML single-quoted scalar, doubling any embedded single quote per spec.
 sq() { local q="'" s="$1"; s="${s//$q/$q$q}"; printf '%s%s%s' "$q" "$s" "$q"; }
 {
   printf "vault_path: %s\n" "$(sq "$VAULT")"
   printf "mcp_server_command:\n"
-  printf "  - uv\n  - run\n  - --project\n"
-  printf "  - %s\n" "$(sq "$CREEK_PROJECT")"
-  printf "  - creek-tools-mcp\n  - --config\n"
-  printf "  - %s\n" "$(sq "$VAULT_CONFIG")"
+  printf "  - %s\n" "$(sq "$LOGIN_SHELL")"
+  printf "  - %s\n" "$(sq "-lc")"
+  printf "  - %s\n" "$(sq "$MCP_INNER")"
   printf "allowed_user_ids:\n"
   for id in "${USER_IDS[@]}"; do printf "  - %s\n" "$id"; done
   printf "allowed_channel_ids:\n"

--- a/.claude/skills/crawdad-launch/launch.sh
+++ b/.claude/skills/crawdad-launch/launch.sh
@@ -136,7 +136,7 @@ echo "[ok] allowlist: ${#USER_IDS[@]} user(s), ${#CHAN_IDS[@]} channel(s)"
 #    DIRECTLY (no `uv run`: deterministic, fast, no lock contention, and `exec`
 #    hands stdio straight to the server so the MCP JSON-RPC stream stays clean).
 #    Falls back to `uv run` if the venv binary isn't present yet.
-# /bin/bash is the universal fallback (always present, POSIX `export`/`;`/`exec`).
+# /bin/bash is the universal fallback (always present, POSIX `export`/`;`/`exec`);
 # fish can't run the `export VAR=val; exec …` wrapper, so coerce it to bash too.
 LOGIN_SHELL="${SHELL:-/bin/bash}"
 if [[ "$LOGIN_SHELL" == *fish ]]; then
@@ -144,6 +144,21 @@ if [[ "$LOGIN_SHELL" == *fish ]]; then
   LOGIN_SHELL=/bin/bash
 fi
 MCP_BIN="$CREEK_PROJECT/.venv/bin/creek-tools-mcp"
+
+# The wrapper recovers ANTHROPIC_API_KEY by sourcing the LOGIN profile
+# (~/.zprofile, ~/.zshenv, ~/.bash_profile, ~/.profile) — NOT an interactive rc
+# (~/.zshrc, ~/.bashrc). Verify that actually works by probing the login shell
+# under a scrubbed env (mimicking the MCP SDK, which drops the key): if the key
+# only lives in an rc file, the wrapper can't recover it and cloud tools degrade.
+if env -i HOME="$HOME" PATH="$PATH" TERM="${TERM:-xterm}" \
+     "$LOGIN_SHELL" -lc 'printenv ANTHROPIC_API_KEY' >/dev/null 2>&1; then
+  echo "[ok] $LOGIN_SHELL login profile exposes ANTHROPIC_API_KEY to the MCP wrapper"
+else
+  echo "[warn] $LOGIN_SHELL login profile does NOT export ANTHROPIC_API_KEY —"
+  echo "       in-MCP cloud tools (draft/author/mine/classify) will degrade."
+  echo "       Add 'export ANTHROPIC_API_KEY=…' to a LOGIN file (~/.zprofile,"
+  echo "       ~/.zshenv or ~/.bash_profile), not ~/.zshrc / ~/.bashrc, then relaunch."
+fi
 
 # shq: POSIX shell single-quote (embedded ' becomes '\'') — safe argv for the -lc string.
 shq() { local q="'" s="$1"; s="${s//$q/$q\\$q$q}"; printf '%s%s%s' "$q" "$s" "$q"; }
@@ -155,6 +170,7 @@ else
   MCP_EXEC="exec uv run --project $(shq "$CREEK_PROJECT") creek-tools-mcp --config $(shq "$VAULT_CONFIG")"
 fi
 MCP_INNER="export CREEK_ANTHROPIC_CONSENT=1; $MCP_EXEC"
+echo "[ok] CREEK_ANTHROPIC_CONSENT=1 in MCP wrapper — cloud tools (draft/author/mine/classify) egress vault content to Anthropic on your key"
 
 # 8. Write the launch config. Every scalar is a YAML single-quoted string (with
 #    embedded single quotes doubled per spec) so a path with YAML-reserved chars

--- a/.claude/skills/crawdad-launch/launch.sh
+++ b/.claude/skills/crawdad-launch/launch.sh
@@ -136,7 +136,13 @@ echo "[ok] allowlist: ${#USER_IDS[@]} user(s), ${#CHAN_IDS[@]} channel(s)"
 #    DIRECTLY (no `uv run`: deterministic, fast, no lock contention, and `exec`
 #    hands stdio straight to the server so the MCP JSON-RPC stream stays clean).
 #    Falls back to `uv run` if the venv binary isn't present yet.
-LOGIN_SHELL="${SHELL:-/bin/zsh}"
+# /bin/bash is the universal fallback (always present, POSIX `export`/`;`/`exec`).
+# fish can't run the `export VAR=val; exec …` wrapper, so coerce it to bash too.
+LOGIN_SHELL="${SHELL:-/bin/bash}"
+if [[ "$LOGIN_SHELL" == *fish ]]; then
+  echo "[warn] \$SHELL is fish, which can't run the POSIX MCP wrapper — using /bin/bash"
+  LOGIN_SHELL=/bin/bash
+fi
 MCP_BIN="$CREEK_PROJECT/.venv/bin/creek-tools-mcp"
 
 # shq: POSIX shell single-quote (embedded ' becomes '\'') — safe argv for the -lc string.
@@ -153,7 +159,7 @@ MCP_INNER="export CREEK_ANTHROPIC_CONSENT=1; $MCP_EXEC"
 # 8. Write the launch config. Every scalar is a YAML single-quoted string (with
 #    embedded single quotes doubled per spec) so a path with YAML-reserved chars
 #    (: # & *) or a quote can't corrupt the config or inject into the argv.
-# Emit a YAML single-quoted scalar, doubling any embedded single quote per spec.
+# sq: YAML single-quoted scalar (embedded ' becomes '') — safe scalar for crawdad.yaml.
 sq() { local q="'" s="$1"; s="${s//$q/$q$q}"; printf '%s%s%s' "$q" "$s" "$q"; }
 {
   printf "vault_path: %s\n" "$(sq "$VAULT")"


### PR DESCRIPTION
## Summary

Fixes two real CrawDad launch failures observed on the demo deployment, both
rooted in how CrawDad spawns the MCP server. `crawdad/crawdad/mcp_client.py:138`
builds `StdioServerParameters` with **no `env=`**, so the MCP stdio SDK launches
the subprocess with a scrubbed environment and a bare `uv run` command.

**Symptom 1 — degraded voice/cloud tools.** The scrubbed env drops
`ANTHROPIC_API_KEY`, so in-MCP cloud tools (`creek.draft`/`author`/`mine`/
`classify`) silently fall back to non-cloud behaviour and log *"Anthropic
provider not available"*. CrawDad's own composer has the key; the spawned tool
server doesn't.

**Symptom 2 — `mcp_unavailable` replies.** Spawning `uv run … creek-tools-mcp`
every turn is slow and contends on uv's project lock when the agent loop runs
several rounds, surfacing as `could not start or connect to the MCP subprocess
('uv')` → the user sees *"creek-tools is unreachable; try again in a moment."*

## Fix

The `crawdad-launch` skill now generates `mcp_server_command` as a **login-shell
wrapper**:

```yaml
mcp_server_command:
  - '/bin/zsh'
  - '-lc'
  - 'export CREEK_ANTHROPIC_CONSENT=1; exec ''<creek-tools>/.venv/bin/creek-tools-mcp'' --config ''<vault>/00-Creek-Meta/creek_config.yaml'''
```

- **Login shell** re-establishes the user's exported `ANTHROPIC_API_KEY` from
  their profile, surviving the SDK's env scrub (no secret is written to any file).
- **`exec`s the venv entry point directly** instead of `uv run`: deterministic,
  no lock contention, and `exec` hands stdio straight to the server so the
  JSON-RPC stream stays clean. Falls back to `uv run` if the venv binary isn't
  built yet.
- **`CREEK_ANTHROPIC_CONSENT=1`** enables the cloud tools; documented that this
  egresses vault content to Anthropic on the user's own key (intended use).

Skill bumped to 1.1.0; SKILL.md documents the wrapper and the consent trade-off.

## Test Plan

- [x] `shellcheck launch.sh` — clean
- [x] Generated config round-trips through `crawdad.config.load_config` (argv
      parses to the 3-element `zsh -lc …` wrapper)
- [x] Under a scrubbed env (`env -i HOME=… PATH=/usr/bin:/bin`), the wrapper
      restores `ANTHROPIC_API_KEY` (True) and `CREEK_ANTHROPIC_CONSENT` (1)
- [x] Real server boots under the scrubbed env with **0 bytes on stdout** (no
      JSON-RPC corruption)
- [x] Live bot restarted on the new config: `MCP tools advertised: …` (handshake
      via the wrapper succeeded) and `connected as CrawDad#1656`
