### PR TITLE
chore(deps): bump pip to >=26.1.2 (PYSEC-2026-196)

### DIFF
--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -139,7 +139,7 @@ build-backend = "setuptools.build_meta"
 constraint-dependencies = [
     "cryptography>=48.0.0",
     "pyjwt>=2.13.0",
-    "pip>=26.1.1",
+    "pip>=26.1.2",
     "setuptools>=78.1.1",
     "wheel>=0.47.0",
 ]

--- a/creek-tools/uv.lock
+++ b/creek-tools/uv.lock
@@ -11,7 +11,7 @@ resolution-markers = [
 [manifest]
 constraints = [
     { name = "cryptography", specifier = ">=48.0.0" },
-    { name = "pip", specifier = ">=26.1.1" },
+    { name = "pip", specifier = ">=26.1.2" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "setuptools", specifier = ">=78.1.1" },
     { name = "wheel", specifier = ">=0.47.0" },
@@ -2198,11 +2198,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`pip 26.1.1` is flagged by **PYSEC-2026-196**; the fix is published as **pip 26.1.2**. The advisory landed today and now fails the `pip-audit` gate on **every branch (including `main`)** — it is unrelated to any code change and currently blocks all PRs.

## Fix

Raise the `pip` floor in `constraint-dependencies` (the section that exists precisely so `uv lock` can't regress onto a vulnerable build/dev version) from `>=26.1.1` to `>=26.1.2`, and regenerate `uv.lock` (pip `26.1.1` → `26.1.2`). Upgrade, not suppress, per the project's pip-audit policy (DEP-003).

## Test Plan

- [x] `uv lock` → `Updated pip v26.1.1 -> v26.1.2`
- [x] `uv run pip-audit --ignore-vuln PYSEC-2022-42969` → **"No known vulnerabilities found, 1 ignored"**
- [ ] CI green (this PR unblocks the gate for all branches)
