### PR TITLE
fix(crawdad): forward ANTHROPIC_API_KEY to the MCP subprocess

### DIFF
--- a/crawdad/crawdad/mcp_client.py
+++ b/crawdad/crawdad/mcp_client.py
@@ -17,17 +17,54 @@ Both ``connect`` failures and mid-session subprocess deaths surface as
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Final
 
 from mcp import ClientSession
-from mcp.client.stdio import StdioServerParameters, stdio_client
+from mcp.client.stdio import (
+    StdioServerParameters,
+    get_default_environment,
+    stdio_client,
+)
 from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Mapping
 
 _LOGGER = logging.getLogger("crawdad.mcp_client")
+
+#: Credential env vars the stdio SDK scrubs but the in-MCP cloud tools need.
+#: ``CREEK_ANTHROPIC_CONSENT`` gates cloud egress, so it is forwarded only when
+#: explicitly set in CrawDad's own environment (opt-in). See issue #549.
+_FORWARDED_ENV_VARS: Final = ("ANTHROPIC_API_KEY", "CREEK_ANTHROPIC_CONSENT")
+
+
+def _subprocess_env(source: Mapping[str, str]) -> dict[str, str]:
+    """Build the environment for the spawned ``creek-tools-mcp`` subprocess.
+
+    The stdio SDK launches the server with a scrubbed environment limited to
+    a small safe allowlist (:func:`get_default_environment`). That allowlist
+    drops ``ANTHROPIC_API_KEY``, so in-MCP cloud tools
+    (``draft``/``author``/``mine``/``classify``) silently fall back to
+    non-cloud behaviour — issue #549. Re-add the forwarded credential vars
+    that are present (and non-empty) in *source* on top of the safe defaults.
+
+    Args:
+        source: The parent environment to forward credentials from, normally
+            :data:`os.environ`.
+
+    Returns:
+        The SDK safe-default environment augmented with any forwarded
+        credentials. Absent or blank credentials are omitted entirely so the
+        subprocess never sees an empty value.
+    """
+    env = dict(get_default_environment())
+    for name in _FORWARDED_ENV_VARS:
+        value = source.get(name)
+        if value:
+            env[name] = value
+    return env
 
 
 class MCPUnavailableError(RuntimeError):
@@ -138,6 +175,7 @@ class MCPClient:
         params = StdioServerParameters(
             command=self._command[0],
             args=list(self._command[1:]),
+            env=_subprocess_env(os.environ),
         )
         try:
             async with (

--- a/crawdad/tests/test_mcp_client.py
+++ b/crawdad/tests/test_mcp_client.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from mcp.client.stdio import get_default_environment
 
+import crawdad.mcp_client as mcp_client
 from crawdad.mcp_client import MCPClient, MCPSession, MCPUnavailableError
 
 
@@ -123,3 +125,80 @@ async def test_list_tool_details_translates_underlying_failure() -> None:
 
     with pytest.raises(MCPUnavailableError, match="list_tool_details"):
         await session.list_tool_details()
+
+
+# --- Issue #549: forward credentials the stdio SDK would otherwise scrub ------
+
+
+def test_subprocess_env_forwards_anthropic_api_key() -> None:
+    """The API key the stdio SDK drops is re-added from the source env."""
+    env = mcp_client._subprocess_env({"ANTHROPIC_API_KEY": "sk-test-123"})
+
+    assert env["ANTHROPIC_API_KEY"] == "sk-test-123"
+
+
+def test_subprocess_env_keeps_sdk_safe_defaults() -> None:
+    """Forwarding augments, never replaces, the SDK default-environment allowlist."""
+    env = mcp_client._subprocess_env({"ANTHROPIC_API_KEY": "sk-test-123"})
+
+    for key, value in get_default_environment().items():
+        assert env[key] == value
+
+
+def test_subprocess_env_omits_absent_credentials() -> None:
+    """A source env without the credentials yields no key — no blank entry."""
+    env = mcp_client._subprocess_env({})
+
+    assert "ANTHROPIC_API_KEY" not in env
+    assert "CREEK_ANTHROPIC_CONSENT" not in env
+
+
+def test_subprocess_env_treats_blank_value_as_unset() -> None:
+    """An empty-string credential is not forwarded (would disable the provider)."""
+    env = mcp_client._subprocess_env({"ANTHROPIC_API_KEY": ""})
+
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_subprocess_env_forwards_consent_only_when_present() -> None:
+    """Cloud-egress consent is opt-in: forwarded iff set in the source env."""
+    without = mcp_client._subprocess_env({"ANTHROPIC_API_KEY": "sk"})
+    assert "CREEK_ANTHROPIC_CONSENT" not in without
+
+    with_consent = mcp_client._subprocess_env(
+        {"ANTHROPIC_API_KEY": "sk", "CREEK_ANTHROPIC_CONSENT": "1"},
+    )
+    assert with_consent["CREEK_ANTHROPIC_CONSENT"] == "1"
+
+
+def test_subprocess_env_ignores_unlisted_vars() -> None:
+    """Only the documented allowlist is forwarded; other env vars never leak."""
+    env = mcp_client._subprocess_env(
+        {"SECRET_TOKEN": "nope", "ANTHROPIC_API_KEY": "sk"},
+    )
+
+    assert "SECRET_TOKEN" not in env
+
+
+async def test_connect_passes_forwarded_env_to_subprocess(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``connect`` hands StdioServerParameters an env carrying the API key.
+
+    Regression guard for issue #549: without an explicit ``env=``, the stdio
+    SDK scrubs ANTHROPIC_API_KEY and in-MCP cloud tools silently degrade.
+    """
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-connect-test")
+    captured: dict[str, Any] = {}
+    real_params = mcp_client.StdioServerParameters
+
+    def _spy(**kwargs: Any) -> Any:
+        captured.update(kwargs)
+        return real_params(**kwargs)
+
+    monkeypatch.setattr(mcp_client, "StdioServerParameters", _spy)
+
+    async with MCPClient(_fixture_command()).connect() as session:
+        await session.list_tools()
+
+    assert captured["env"]["ANTHROPIC_API_KEY"] == "sk-connect-test"


### PR DESCRIPTION
## Summary

Fixes #549. CrawDad spawned `creek-tools-mcp` via `StdioServerParameters` with **no `env=`** (`crawdad/mcp_client.py`), so the MCP stdio SDK launched the server with a scrubbed environment (its safe allowlist) that drops `ANTHROPIC_API_KEY`. In-MCP cloud tools (`creek.draft`/`author`/`mine`/`classify`) then logged *"Anthropic provider not available"* and silently degraded — observed on the demo deployment.

## Changes

- Add `_subprocess_env(source)` — augments the SDK's `get_default_environment()` safe allowlist with a small **forwarded credential allowlist** (`ANTHROPIC_API_KEY`, and opt-in `CREEK_ANTHROPIC_CONSENT`) taken from the parent env. Absent/blank values are omitted so the subprocess never sees an empty credential.
- Pass `env=_subprocess_env(os.environ)` in `MCPClient.connect()`.
- `CREEK_ANTHROPIC_CONSENT` is forwarded **only when explicitly set**, so the change never silently enables cloud egress. Secrets stay in-process — nothing is written to `crawdad.yaml`.

Once this lands, the `crawdad-launch` login-shell wrapper (PR #547) is no longer required to recover the key — a plain `mcp_server_command` suffices.

## Test Plan

- [x] 6 unit tests for `_subprocess_env`: forwards the key, preserves SDK safe defaults, omits absent creds, treats blank as unset, forwards consent only when present, ignores unlisted vars
- [x] `connect()` regression test spies on `StdioServerParameters` and asserts `env["ANTHROPIC_API_KEY"]` is the forwarded value
- [x] Existing `connect()` tests still pass with the explicit `env=` (no spawn regression)
- [x] `./scripts/check-all.sh` green — 455 passed, 95.66% coverage (mcp_client.py 93.75%)

Closes #549
