### PR TITLE
feat(voice): `creek voice-authenticity` diagnostic skeleton

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1491,6 +1491,56 @@ def voice_check(
         raise typer.Exit(code=1)
 
 
+@app.command(name="voice-authenticity")
+def voice_authenticity(
+    vault: Path | None = typer.Option(None, "--vault", help="Obsidian vault path"),
+    draft: Path | None = typer.Option(
+        None,
+        "--draft",
+        help=(
+            "Optional drafted essay to audit. Reads its voice-fidelity "
+            "attestation (voice_distance) from the frontmatter for the "
+            "de-slop sub-score."
+        ),
+    ),
+    json_out: bool = typer.Option(
+        False,
+        "--json",
+        help="Emit a machine-readable JSON object instead of a text summary.",
+    ),
+) -> None:
+    """Audit a vault's voice corpus (and optionally a draft) for authenticity.
+
+    Read-only diagnostic that makes three voice defects observable:
+
+    * **audience mix** — the voice-eligible corpus bucketed by privacy tier
+      (and whether graduated audience weighting is active yet);
+    * **AI-corpus leak** — the fraction of eligible fragments that are
+      ``claude`` / ``chatgpt`` ingests (these leak into the voice corpus
+      today);
+    * **de-slop** — when ``--draft`` is given, whether the AI-mannerism guard
+      left a ``voice_distance`` attestation and how many residual findings
+      it recorded.
+
+    The command mutates nothing and always exits ``0`` on success; a missing
+    ``--draft`` file exits ``2``.
+    """
+    from creek.generate.voice_authenticity import build_voice_authenticity_report
+
+    vault_path = _resolve_vault(vault)
+    if draft is not None and not draft.exists():
+        console.print(f"[red]Draft not found: {draft}[/red]")
+        raise typer.Exit(code=2)
+
+    report = build_voice_authenticity_report(vault_path, draft_path=draft)
+
+    if json_out:
+        # Emit raw so Rich never interprets ``[...]`` in the content as markup.
+        typer.echo(report.to_json())
+    else:
+        console.print(report.summary_line(), markup=False)
+
+
 _REPORT_DISPATCH: dict[str, Callable[[Path], None]] = {
     "tags": _report_tags,
     "unnamed": _report_unnamed,

--- a/creek-tools/creek/generate/voice_authenticity.py
+++ b/creek-tools/creek/generate/voice_authenticity.py
@@ -1,0 +1,286 @@
+"""Read-only ``creek voice-authenticity`` diagnostic (epic #551, issue #552).
+
+This is the *tracer skeleton* for the voice-authenticity feature: it makes
+three otherwise-hidden defects observable without changing any behaviour.
+Each sub-score is backed by a minimal-but-real probe over the data that
+exists today; later issues in the epic deepen each probe in place without
+re-wiring this surface.
+
+The three sub-scores:
+
+``audience_mix``
+    Distribution of the *voice-eligible* corpus (self-authored, non-INTIMATE
+    fragments — see :attr:`creek.models.Fragment.voice_proxy_eligible`) by
+    ``privacy_tier``. ``weighting_active`` is a stub ``False`` until the
+    graduated audience-authority model lands (issue #554).
+
+``ai_corpus_leak``
+    Count and fraction of voice-eligible fragments whose
+    ``source.platform`` is an AI-chat platform (``claude`` / ``chatgpt``).
+    These leak into the voice corpus today; issue #553 quarantines them.
+
+``deslop``
+    Given an optional drafted essay, whether the AI-mannerism guard left a
+    ``voice_distance`` attestation in the draft frontmatter, how many
+    residual findings it recorded, and a ``status`` reason. The status string
+    is a stub until the faithful de-slop pass lands (issue #556).
+
+Read-only: nothing here mutates the vault.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.generate.ai_style.guard import VOICE_DISTANCE_KEY, VOICE_FINDINGS_KEY
+from creek.models import Fragment, PrivacyTier, SourcePlatform
+from creek.vault.reader import iter_vault_fragments
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_FRAGMENTS_SUBDIR = "01-Fragments"
+
+#: Platforms whose ingests are AI-chat conversations (they leak in today).
+_AI_CHAT_PLATFORMS = frozenset(
+    {SourcePlatform.CLAUDE.value, SourcePlatform.CHATGPT.value},
+)
+
+
+@dataclass(frozen=True)
+class AudienceMix:
+    """Distribution of the voice-eligible corpus by privacy tier.
+
+    Attributes:
+        by_tier: Count of eligible fragments per ``privacy_tier`` value
+            (``open`` / ``personal`` / ``intimate`` / ``unclassified``).
+            ``intimate`` is always ``0`` because INTIMATE fragments are not
+            voice-eligible; it is reported for transparency.
+        weighting_active: Whether graduated audience-authority weighting is
+            applied during voice selection. Stub ``False`` until issue #554.
+    """
+
+    by_tier: dict[str, int]
+    weighting_active: bool
+
+    @property
+    def total(self) -> int:
+        """Total eligible fragments across all tiers."""
+        return sum(self.by_tier.values())
+
+
+@dataclass(frozen=True)
+class AICorpusLeak:
+    """AI-chat ingests leaking into the voice-eligible corpus.
+
+    Attributes:
+        leaked: Eligible fragments whose ``source.platform`` is an AI-chat
+            platform (``claude`` / ``chatgpt``).
+        eligible_total: Size of the voice-eligible corpus.
+    """
+
+    leaked: int
+    eligible_total: int
+
+    @property
+    def fraction(self) -> float:
+        """Leaked fraction of the eligible corpus; ``0.0`` for an empty corpus."""
+        if self.eligible_total == 0:
+            return 0.0
+        return self.leaked / self.eligible_total
+
+
+@dataclass(frozen=True)
+class DeslopStatus:
+    """De-slop attestation read from a drafted essay's frontmatter.
+
+    Attributes:
+        draft: The drafted-essay path that was probed.
+        attested: Whether a ``voice_distance`` attestation is present (the
+            AI-mannerism guard ran and recorded a result).
+        voice_distance: The recorded distance, or ``None`` when unattested.
+        residual_findings: Count of recorded residual voice findings.
+        status: A human-readable reason. Stub wording until issue #556 adds
+            the rewritten-vs-measured distinction.
+    """
+
+    draft: str
+    attested: bool
+    voice_distance: float | None
+    residual_findings: int
+    status: str
+
+
+@dataclass(frozen=True)
+class VoiceAuthenticityReport:
+    """The full voice-authenticity audit for one vault (and optional draft).
+
+    Attributes:
+        audience_mix: The audience-mix sub-score.
+        ai_corpus_leak: The AI-corpus-leak sub-score.
+        deslop: The de-slop sub-score, or ``None`` when no draft was probed.
+    """
+
+    audience_mix: AudienceMix
+    ai_corpus_leak: AICorpusLeak
+    deslop: DeslopStatus | None
+
+    def _deslop_line(self) -> str:
+        """Render the de-slop summary fragment."""
+        if self.deslop is None:
+            return "(no --draft given)"
+        if self.deslop.attested:
+            return (
+                f"voice_distance {self.deslop.voice_distance:.4f}, "
+                f"{self.deslop.residual_findings} residual finding(s) "
+                f"— {self.deslop.status}"
+            )
+        return f"no attestation — {self.deslop.status}"
+
+    def summary_line(self) -> str:
+        """Return the human-readable multi-line summary of the report."""
+        mix = self.audience_mix
+        leak = self.ai_corpus_leak
+        weighting = "ON" if mix.weighting_active else "OFF"
+        pct = f"{leak.fraction * 100:.1f}"
+        return (
+            f"Voice authenticity — corpus of {mix.total} eligible fragments\n"
+            f"  audience mix:  OPEN {mix.by_tier['open']}  "
+            f"PERSONAL {mix.by_tier['personal']}  "
+            f"INTIMATE {mix.by_tier['intimate']} (excluded)  "
+            f"UNCLASSIFIED {mix.by_tier['unclassified']}   "
+            f"weighting: {weighting}\n"
+            f"  AI-corpus leak: {leak.leaked}/{leak.eligible_total} ({pct}%) "
+            f"fragments are claude/chatgpt ingests\n"
+            f"  de-slop:       {self._deslop_line()}"
+        )
+
+    def to_json_dict(self) -> dict[str, object]:
+        """Return the JSON-serialisable representation of the report."""
+        deslop: dict[str, object] | None = None
+        if self.deslop is not None:
+            deslop = {
+                "draft": self.deslop.draft,
+                "attested": self.deslop.attested,
+                "voice_distance": self.deslop.voice_distance,
+                "residual_findings": self.deslop.residual_findings,
+                "status": self.deslop.status,
+            }
+        return {
+            "eligible_total": self.audience_mix.total,
+            "audience_mix": {
+                "weighting_active": self.audience_mix.weighting_active,
+                "by_tier": self.audience_mix.by_tier.copy(),
+                "total": self.audience_mix.total,
+            },
+            "ai_corpus_leak": {
+                "leaked": self.ai_corpus_leak.leaked,
+                "eligible_total": self.ai_corpus_leak.eligible_total,
+                "fraction": self.ai_corpus_leak.fraction,
+            },
+            "deslop": deslop,
+        }
+
+    def to_json(self) -> str:
+        """Return the report as a stable, indented JSON string."""
+        return json.dumps(self.to_json_dict(), indent=2)
+
+
+def _probe_audience_mix(eligible: list[Fragment]) -> AudienceMix:
+    """Bucket the eligible corpus by ``privacy_tier``.
+
+    Args:
+        eligible: The voice-eligible fragments.
+
+    Returns:
+        The audience-mix sub-score (``weighting_active`` stubbed ``False``).
+    """
+    by_tier = {tier.value: 0 for tier in PrivacyTier}
+    for fragment in eligible:
+        tier = str(fragment.privacy_tier)
+        by_tier[tier] = by_tier.get(tier, 0) + 1
+    return AudienceMix(by_tier=by_tier, weighting_active=False)
+
+
+def _probe_ai_corpus_leak(eligible: list[Fragment]) -> AICorpusLeak:
+    """Count eligible fragments ingested from AI-chat platforms.
+
+    Args:
+        eligible: The voice-eligible fragments.
+
+    Returns:
+        The AI-corpus-leak sub-score.
+    """
+    leaked = sum(
+        1
+        for fragment in eligible
+        if str(fragment.source.platform) in _AI_CHAT_PLATFORMS
+    )
+    return AICorpusLeak(leaked=leaked, eligible_total=len(eligible))
+
+
+def _probe_deslop(draft_path: Path) -> DeslopStatus:
+    """Read a draft's voice-fidelity attestation from its frontmatter.
+
+    Args:
+        draft_path: The drafted-essay markdown file.
+
+    Returns:
+        The de-slop sub-score for *draft_path*.
+    """
+    post = frontmatter.load(str(draft_path))
+    raw_distance = post.metadata.get(VOICE_DISTANCE_KEY)
+    findings = post.metadata.get(VOICE_FINDINGS_KEY, [])
+    residual = len(findings) if isinstance(findings, list) else 0
+    if not isinstance(raw_distance, (int, float)):
+        return DeslopStatus(
+            draft=str(draft_path),
+            attested=False,
+            voice_distance=None,
+            residual_findings=residual,
+            status="no voice-fidelity attestation in draft frontmatter",
+        )
+    return DeslopStatus(
+        draft=str(draft_path),
+        attested=True,
+        voice_distance=float(raw_distance),
+        residual_findings=residual,
+        status="attested (rewritten-vs-measured detection lands in #556)",
+    )
+
+
+def build_voice_authenticity_report(
+    vault_path: Path,
+    *,
+    draft_path: Path | None,
+) -> VoiceAuthenticityReport:
+    """Build the voice-authenticity report for *vault_path*.
+
+    Walks the vault's ``01-Fragments`` tree via the canonical
+    :func:`creek.vault.reader.iter_vault_fragments` loader, filters to the
+    voice-eligible corpus, and runs the three skeleton probes. When
+    *draft_path* is given its frontmatter is read for the de-slop sub-score.
+
+    Args:
+        vault_path: Vault root.
+        draft_path: Optional drafted essay to probe for de-slop attestation.
+
+    Returns:
+        The assembled :class:`VoiceAuthenticityReport`.
+    """
+    records = iter_vault_fragments(vault_path / _FRAGMENTS_SUBDIR)
+    eligible = [
+        fragment
+        for _path, fragment, _body, _raw in records
+        if fragment.voice_proxy_eligible
+    ]
+    deslop = _probe_deslop(draft_path) if draft_path is not None else None
+    return VoiceAuthenticityReport(
+        audience_mix=_probe_audience_mix(eligible),
+        ai_corpus_leak=_probe_ai_corpus_leak(eligible),
+        deslop=deslop,
+    )

--- a/creek-tools/tests/test_voice_authenticity.py
+++ b/creek-tools/tests/test_voice_authenticity.py
@@ -1,0 +1,373 @@
+"""Tests for the ``creek voice-authenticity`` diagnostic skeleton (FEAT #552).
+
+These cover the read-only :mod:`creek.generate.voice_authenticity` probes and
+the Typer command surface. The skeleton only *measures* current behaviour, so
+the assertions pin the report *shape* (mix counts reconcile to the eligible
+corpus, leak fraction stays in ``[0, 1]``, ``--draft`` populates the de-slop
+sub-score) rather than any fixed numbers.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.generate.voice_authenticity import (
+    build_voice_authenticity_report,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+
+
+def _strip_ansi(text: str) -> str:
+    """Return *text* with ANSI escape sequences removed."""
+    return _ANSI_ESCAPE_RE.sub("", text)
+
+
+def _write_fragment(
+    fragments_dir: Path,
+    name: str,
+    *,
+    platform: str,
+    author: str = "self",
+    privacy_tier: str = "open",
+) -> None:
+    """Write one fragment markdown file into *fragments_dir*.
+
+    Args:
+        fragments_dir: The vault's ``01-Fragments`` directory.
+        name: File stem and fragment id/title.
+        platform: ``source.platform`` value (e.g. ``"markdown"``, ``"claude"``).
+        author: ``source.author`` value; defaults to ``"self"``.
+        privacy_tier: The fragment's ``privacy_tier``; defaults to ``"open"``.
+    """
+    post = frontmatter.Post(
+        f"Body text for {name}.",
+        type="fragment",
+        id=name,
+        title=name,
+        source={"platform": platform, "author": author},
+        privacy_tier=privacy_tier,
+    )
+    (fragments_dir / f"{name}.md").write_text(
+        frontmatter.dumps(post),
+        encoding="utf-8",
+    )
+
+
+def _scaffold_mixed_vault(vault: Path) -> Path:
+    """Create a vault whose eligible corpus mixes native and AI-chat ingests.
+
+    Eligible (self-authored, non-intimate):
+      - two native ``markdown`` fragments (one OPEN, one PERSONAL),
+      - one ``claude`` ingest (OPEN) and one ``chatgpt`` ingest (PERSONAL),
+      - one UNCLASSIFIED native fragment.
+    Excluded:
+      - one INTIMATE self fragment (privacy excludes it),
+      - one AI-authored ``claude`` fragment (authorship excludes it).
+
+    Returns:
+        The ``01-Fragments`` directory that was populated.
+    """
+    fragments_dir = vault / "01-Fragments"
+    fragments_dir.mkdir(parents=True, exist_ok=True)
+    _write_fragment(fragments_dir, "native_open", platform="markdown")
+    _write_fragment(
+        fragments_dir,
+        "native_personal",
+        platform="markdown",
+        privacy_tier="personal",
+    )
+    _write_fragment(fragments_dir, "claude_open", platform="claude")
+    _write_fragment(
+        fragments_dir,
+        "chatgpt_personal",
+        platform="chatgpt",
+        privacy_tier="personal",
+    )
+    _write_fragment(
+        fragments_dir,
+        "native_unclassified",
+        platform="markdown",
+        privacy_tier="unclassified",
+    )
+    _write_fragment(
+        fragments_dir,
+        "intimate_excluded",
+        platform="markdown",
+        privacy_tier="intimate",
+    )
+    _write_fragment(
+        fragments_dir,
+        "ai_authored_excluded",
+        platform="claude",
+        author="ai",
+    )
+    return fragments_dir
+
+
+def test_report_shape_reconciles_to_eligible_corpus(tmp_path: Path) -> None:
+    """Mix counts sum to the eligible total and the leak fraction is bounded."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+
+    report = build_voice_authenticity_report(vault, draft_path=None)
+
+    # Five eligible fragments; the intimate and AI-authored ones are excluded.
+    assert report.audience_mix.total == 5
+    assert report.audience_mix.total == report.ai_corpus_leak.eligible_total
+    assert sum(report.audience_mix.by_tier.values()) == report.audience_mix.total
+    assert 0.0 <= report.ai_corpus_leak.fraction <= 1.0
+
+
+def test_audience_mix_buckets_eligible_by_tier(tmp_path: Path) -> None:
+    """Eligible fragments bucket by tier; INTIMATE stays zero (excluded)."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+
+    mix = build_voice_authenticity_report(vault, draft_path=None).audience_mix
+
+    assert mix.by_tier["open"] == 2
+    assert mix.by_tier["personal"] == 2
+    assert mix.by_tier["unclassified"] == 1
+    assert mix.by_tier["intimate"] == 0
+    # Weighting is OFF until Issue #554 lands.
+    assert mix.weighting_active is False
+
+
+def test_ai_corpus_leak_counts_chat_platforms(tmp_path: Path) -> None:
+    """Only eligible claude/chatgpt ingests count toward the leak."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+
+    leak = build_voice_authenticity_report(vault, draft_path=None).ai_corpus_leak
+
+    # claude_open + chatgpt_personal are eligible AI-chat ingests.
+    assert leak.leaked == 2
+    assert leak.eligible_total == 5
+    assert leak.fraction == pytest.approx(2 / 5)
+
+
+def test_empty_vault_is_well_formed(tmp_path: Path) -> None:
+    """A vault with no fragments yields a zeroed, division-safe report."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    report = build_voice_authenticity_report(vault, draft_path=None)
+
+    assert report.audience_mix.total == 0
+    assert report.ai_corpus_leak.eligible_total == 0
+    assert report.ai_corpus_leak.fraction == 0.0
+    assert report.deslop is None
+
+
+def test_deslop_none_without_draft(tmp_path: Path) -> None:
+    """Without ``--draft`` the de-slop sub-score is absent."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+
+    report = build_voice_authenticity_report(vault, draft_path=None)
+
+    assert report.deslop is None
+
+
+def test_deslop_attested_when_voice_distance_present(tmp_path: Path) -> None:
+    """A draft carrying voice-fidelity frontmatter reports attestation."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+    draft = tmp_path / "draft.md"
+    post = frontmatter.Post(
+        "Drafted essay body.",
+        voice_distance=0.4213,
+        voice_findings=[{"tell_id": "t1"}, {"tell_id": "t2"}],
+    )
+    draft.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    deslop = build_voice_authenticity_report(vault, draft_path=draft).deslop
+
+    assert deslop is not None
+    assert deslop.attested is True
+    assert deslop.voice_distance == pytest.approx(0.4213)
+    assert deslop.residual_findings == 2
+    assert deslop.status  # a non-empty (stubbed) reason string
+
+
+def test_deslop_unattested_when_no_voice_distance(tmp_path: Path) -> None:
+    """A draft without voice-fidelity frontmatter reports no attestation."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+    draft = tmp_path / "plain_draft.md"
+    draft.write_text(
+        frontmatter.dumps(frontmatter.Post("Just a body, no guard ran.")),
+        encoding="utf-8",
+    )
+
+    deslop = build_voice_authenticity_report(vault, draft_path=draft).deslop
+
+    assert deslop is not None
+    assert deslop.attested is False
+    assert deslop.voice_distance is None
+    assert deslop.residual_findings == 0
+    assert deslop.status
+
+
+def test_to_json_is_stable_and_parseable(tmp_path: Path) -> None:
+    """``to_json`` emits a documented, parseable schema with all sub-scores."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+
+    report = build_voice_authenticity_report(vault, draft_path=None)
+    payload = json.loads(report.to_json())
+
+    assert payload["eligible_total"] == 5
+    assert payload["audience_mix"]["weighting_active"] is False
+    assert payload["audience_mix"]["by_tier"]["open"] == 2
+    assert payload["audience_mix"]["total"] == 5
+    assert payload["ai_corpus_leak"]["leaked"] == 2
+    assert 0.0 <= payload["ai_corpus_leak"]["fraction"] <= 1.0
+    assert payload["deslop"] is None
+
+
+def test_summary_line_reports_all_three_subscores(tmp_path: Path) -> None:
+    """The human summary names the corpus size, mix, leak, and de-slop."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+
+    summary = build_voice_authenticity_report(vault, draft_path=None).summary_line()
+
+    assert "5 eligible" in summary
+    assert "audience mix" in summary
+    assert "AI-corpus leak" in summary
+    assert "de-slop" in summary
+    assert "(no --draft given)" in summary
+
+
+def test_summary_line_renders_attested_deslop(tmp_path: Path) -> None:
+    """With an attested draft the summary names the distance and findings."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+    draft = tmp_path / "draft.md"
+    post = frontmatter.Post(
+        "Body.",
+        voice_distance=0.51,
+        voice_findings=[{"tell_id": "t1"}],
+    )
+    draft.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    summary = build_voice_authenticity_report(
+        vault,
+        draft_path=draft,
+    ).summary_line()
+
+    assert "voice_distance 0.5100" in summary
+    assert "1 residual finding(s)" in summary
+
+
+def test_summary_line_renders_unattested_deslop(tmp_path: Path) -> None:
+    """With an unattested draft the summary reports no attestation."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+    draft = tmp_path / "plain.md"
+    draft.write_text(
+        frontmatter.dumps(frontmatter.Post("Body, no guard.")),
+        encoding="utf-8",
+    )
+
+    summary = build_voice_authenticity_report(
+        vault,
+        draft_path=draft,
+    ).summary_line()
+
+    assert "no attestation" in summary
+
+
+# --- CLI smoke tests --------------------------------------------------------
+
+
+def test_cli_text_output(tmp_path: Path) -> None:
+    """The command runs end-to-end and prints all three sub-scores."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+
+    result = runner.invoke(
+        app,
+        ["voice-authenticity", "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    plain = _strip_ansi(result.output)
+    assert "audience mix" in plain
+    assert "AI-corpus leak" in plain
+    assert "de-slop" in plain
+
+
+def test_cli_json_output(tmp_path: Path) -> None:
+    """``--json`` emits a parseable object instead of the text summary."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+
+    result = runner.invoke(
+        app,
+        ["voice-authenticity", "--vault", str(vault), "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(_strip_ansi(result.output))
+    assert payload["eligible_total"] == 5
+    assert payload["deslop"] is None
+
+
+def test_cli_draft_populates_deslop(tmp_path: Path) -> None:
+    """Passing ``--draft`` populates the de-slop sub-score in JSON."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+    draft = tmp_path / "draft.md"
+    post = frontmatter.Post("Body.", voice_distance=0.3)
+    draft.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    result = runner.invoke(
+        app,
+        [
+            "voice-authenticity",
+            "--vault",
+            str(vault),
+            "--draft",
+            str(draft),
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(_strip_ansi(result.output))
+    assert payload["deslop"]["attested"] is True
+    assert payload["deslop"]["voice_distance"] == pytest.approx(0.3)
+
+
+def test_cli_missing_draft_exits_two(tmp_path: Path) -> None:
+    """A ``--draft`` path that does not exist exits with code 2."""
+    vault = tmp_path / "vault"
+    _scaffold_mixed_vault(vault)
+
+    result = runner.invoke(
+        app,
+        [
+            "voice-authenticity",
+            "--vault",
+            str(vault),
+            "--draft",
+            str(tmp_path / "nope.md"),
+        ],
+    )
+
+    assert result.exit_code == 2


### PR DESCRIPTION
## Summary

- Adds a read-only `creek voice-authenticity [--vault] [--draft] [--json]` command and a frozen `VoiceAuthenticityReport` (`creek/generate/voice_authenticity.py`) — the **tracer skeleton** for epic #551.
- Emits three sub-scores, each backed by a minimal-but-real probe over existing data:
  - **audience_mix** — voice-eligible corpus bucketed by `privacy_tier`; `weighting_active` stubbed `False` until #554.
  - **ai_corpus_leak** — count/fraction of eligible fragments that are `claude`/`chatgpt` ingests (these leak into the corpus today; quarantined by #553).
  - **deslop** — with `--draft`, reads the draft frontmatter's `voice_distance` attestation + residual findings; `status` string stubbed until #556.
- Reuses the canonical `iter_vault_fragments` loader and the `Fragment.voice_proxy_eligible` predicate; **mutates nothing**. Numbers are designed to *expose* the defects (high AI-leak, `weighting: OFF`), not fix them.

## Test plan

- `tests/test_voice_authenticity.py` — 15 tests: report-shape reconciliation (`audience_mix.total == ai_corpus_leak.eligible_total == sum(by_tier)`), tier bucketing, AI-leak counting, bounded fraction, empty-vault safety, de-slop attested/unattested/none, stable `--json` schema, summary rendering, and CLI smoke tests (text, `--json`, `--draft` populates de-slop, missing-draft exits 2).
- `cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (tests 5169 passed, coverage 93.85%, mypy strict, ruff, refurb, tryceratops, interrogate, complexity all clean).
- Manual end-to-end run on a fixture vault confirms the command prints all three sub-scores and exposes the AI-corpus leak.

Closes #552
Refs #551
