### PR TITLE
feat(ingest): split AI-chat ingests by turn — human=self, AI=ai (voice_weight 0)

### DIFF
--- a/creek-tools/creek/generate/voice_authenticity.py
+++ b/creek-tools/creek/generate/voice_authenticity.py
@@ -1,4 +1,4 @@
-"""Read-only ``creek voice-authenticity`` diagnostic (epic #551, issue #552).
+"""Read-only ``creek voice-authenticity`` diagnostic.
 
 This is the *tracer skeleton* for the voice-authenticity feature: it makes
 three otherwise-hidden defects observable without changing any behaviour.
@@ -12,18 +12,19 @@ The three sub-scores:
     Distribution of the *voice-eligible* corpus (self-authored, non-INTIMATE
     fragments — see :attr:`creek.models.Fragment.voice_proxy_eligible`) by
     ``privacy_tier``. ``weighting_active`` is a stub ``False`` until the
-    graduated audience-authority model lands (issue #554).
+    graduated audience-authority model lands.
 
 ``ai_corpus_leak``
     Count and fraction of voice-eligible fragments whose
     ``source.platform`` is an AI-chat platform (``claude`` / ``chatgpt``).
-    These leak into the voice corpus today; issue #553 quarantines them.
+    These leak into the voice corpus until AI-chat turns are split and the
+    AI half is quarantined.
 
 ``deslop``
     Given an optional drafted essay, whether the AI-mannerism guard left a
     ``voice_distance`` attestation in the draft frontmatter, how many
     residual findings it recorded, and a ``status`` reason. The status string
-    is a stub until the faithful de-slop pass lands (issue #556).
+    is a stub until the faithful de-slop pass lands.
 
 Read-only: nothing here mutates the vault.
 """
@@ -61,7 +62,8 @@ class AudienceMix:
             ``intimate`` is always ``0`` because INTIMATE fragments are not
             voice-eligible; it is reported for transparency.
         weighting_active: Whether graduated audience-authority weighting is
-            applied during voice selection. Stub ``False`` until issue #554.
+            applied during voice selection. Stub ``False`` until audience
+            weighting lands.
     """
 
     by_tier: dict[str, int]
@@ -81,11 +83,11 @@ class AICorpusLeak:
         leaked: Voice-eligible fragments from an AI-chat platform
             (``claude`` / ``chatgpt``) that have **not** been quarantined —
             i.e. their conversation has no AI-authored sibling turn, so the
-            fragment still fuses AI prose into the voice corpus. After the
-            FEAT #553 split a freshly-ingested chat has an AI-authored sibling
+            fragment still fuses AI prose into the voice corpus. Once AI-chat
+            turns are split, a freshly-ingested chat has an AI-authored sibling
             per turn, so its human turns no longer count and this drops to ≈0;
             legacy *merged* fragments (no AI sibling) still flag, which is what
-            drives the #557 re-ingest migration.
+            drives the re-ingest migration.
         eligible_total: Size of the voice-eligible corpus.
     """
 
@@ -110,8 +112,8 @@ class DeslopStatus:
             AI-mannerism guard ran and recorded a result).
         voice_distance: The recorded distance, or ``None`` when unattested.
         residual_findings: Count of recorded residual voice findings.
-        status: A human-readable reason. Stub wording until issue #556 adds
-            the rewritten-vs-measured distinction.
+        status: A human-readable reason. Stub wording until the faithful
+            de-slop pass adds the rewritten-vs-measured distinction.
     """
 
     draft: str
@@ -238,7 +240,7 @@ def _probe_ai_corpus_leak(
     """Count un-quarantined AI-chat fragments in the voice-eligible corpus.
 
     A conversation is *quarantined* once it contains an AI-authored sibling
-    turn (the FEAT #553 split). An eligible AI-chat fragment from a
+    turn (the per-turn split). An eligible AI-chat fragment from a
     conversation with no such sibling is still a merged fragment fusing AI
     prose into the corpus, and counts as leaked.
 
@@ -292,7 +294,7 @@ def _probe_deslop(draft_path: Path) -> DeslopStatus:
         attested=True,
         voice_distance=float(raw_distance),
         residual_findings=residual,
-        status="attested (rewritten-vs-measured detection lands in #556)",
+        status="attested (rewritten-vs-measured detection not yet recorded)",
     )
 
 

--- a/creek-tools/creek/generate/voice_authenticity.py
+++ b/creek-tools/creek/generate/voice_authenticity.py
@@ -37,7 +37,7 @@ from typing import TYPE_CHECKING
 import frontmatter
 
 from creek.generate.ai_style.guard import VOICE_DISTANCE_KEY, VOICE_FINDINGS_KEY
-from creek.models import Fragment, PrivacyTier, SourcePlatform
+from creek.models import Authorship, Fragment, PrivacyTier, SourcePlatform
 from creek.vault.reader import iter_vault_fragments
 
 if TYPE_CHECKING:
@@ -78,8 +78,14 @@ class AICorpusLeak:
     """AI-chat ingests leaking into the voice-eligible corpus.
 
     Attributes:
-        leaked: Eligible fragments whose ``source.platform`` is an AI-chat
-            platform (``claude`` / ``chatgpt``).
+        leaked: Voice-eligible fragments from an AI-chat platform
+            (``claude`` / ``chatgpt``) that have **not** been quarantined —
+            i.e. their conversation has no AI-authored sibling turn, so the
+            fragment still fuses AI prose into the voice corpus. After the
+            FEAT #553 split a freshly-ingested chat has an AI-authored sibling
+            per turn, so its human turns no longer count and this drops to ≈0;
+            legacy *merged* fragments (no AI sibling) still flag, which is what
+            drives the #557 re-ingest migration.
         eligible_total: Size of the voice-eligible corpus.
     """
 
@@ -206,19 +212,56 @@ def _probe_audience_mix(eligible: list[Fragment]) -> AudienceMix:
     return AudienceMix(by_tier=by_tier, weighting_active=False)
 
 
-def _probe_ai_corpus_leak(eligible: list[Fragment]) -> AICorpusLeak:
-    """Count eligible fragments ingested from AI-chat platforms.
+def _conversation_key(fragment: Fragment) -> tuple[str, str | None, str | None] | None:
+    """Return a key grouping a turn's human and AI fragments, or ``None``.
+
+    Both halves of a split turn share platform, conversation id, and source
+    file, so this pairs a human turn with its AI sibling even when the export
+    carried no conversation id. Returns ``None`` when the fragment has neither
+    a conversation id nor a source file — there is then no reliable signal to
+    pair siblings on, so such a fragment is never treated as quarantined.
+    """
+    source = fragment.source
+    if source.conversation_id is source.original_file is None:
+        return None
+    return (
+        str(source.platform),
+        source.conversation_id,
+        source.original_file,
+    )
+
+
+def _probe_ai_corpus_leak(
+    eligible: list[Fragment],
+    all_fragments: list[Fragment],
+) -> AICorpusLeak:
+    """Count un-quarantined AI-chat fragments in the voice-eligible corpus.
+
+    A conversation is *quarantined* once it contains an AI-authored sibling
+    turn (the FEAT #553 split). An eligible AI-chat fragment from a
+    conversation with no such sibling is still a merged fragment fusing AI
+    prose into the corpus, and counts as leaked.
 
     Args:
         eligible: The voice-eligible fragments.
+        all_fragments: Every loaded fragment (used to find AI-authored
+            siblings that mark a conversation as quarantined).
 
     Returns:
         The AI-corpus-leak sub-score.
     """
+    quarantined = {
+        key
+        for fragment in all_fragments
+        if str(fragment.source.platform) in _AI_CHAT_PLATFORMS
+        and str(fragment.source.author) == Authorship.AI.value
+        and (key := _conversation_key(fragment)) is not None
+    }
     leaked = sum(
         1
         for fragment in eligible
         if str(fragment.source.platform) in _AI_CHAT_PLATFORMS
+        and _conversation_key(fragment) not in quarantined
     )
     return AICorpusLeak(leaked=leaked, eligible_total=len(eligible))
 
@@ -273,14 +316,11 @@ def build_voice_authenticity_report(
         The assembled :class:`VoiceAuthenticityReport`.
     """
     records = iter_vault_fragments(vault_path / _FRAGMENTS_SUBDIR)
-    eligible = [
-        fragment
-        for _path, fragment, _body, _raw in records
-        if fragment.voice_proxy_eligible
-    ]
+    fragments = [fragment for _path, fragment, _body, _raw in records]
+    eligible = [fragment for fragment in fragments if fragment.voice_proxy_eligible]
     deslop = _probe_deslop(draft_path) if draft_path is not None else None
     return VoiceAuthenticityReport(
         audience_mix=_probe_audience_mix(eligible),
-        ai_corpus_leak=_probe_ai_corpus_leak(eligible),
+        ai_corpus_leak=_probe_ai_corpus_leak(eligible, fragments),
         deslop=deslop,
     )

--- a/creek-tools/creek/ingest/chatgpt.py
+++ b/creek-tools/creek/ingest/chatgpt.py
@@ -38,8 +38,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Per-turn authorship roles stashed on ``ParsedFragment.metadata`` so the
-# frontmatter stage can attribute each split turn (FEAT #553): the human turn
-# is the owner's voice, the AI turn is quarantined out of the voice proxy.
+# frontmatter stage can attribute each split turn: the human turn is the
+# owner's voice, the AI turn is quarantined out of the voice proxy.
 _ROLE_SELF = Authorship.SELF.value
 _ROLE_AI = Authorship.AI.value
 
@@ -166,8 +166,8 @@ class ChatGPTIngestor(Ingestor):
         if conv_id is not None:
             source["conversation_id"] = conv_id
         if is_ai:
-            # FEAT #553: AI turns are AI-authored, excluded from the voice
-            # proxy via ``voice_proxy_eligible``; zero weight is belt-and-braces.
+            # AI turns are AI-authored, excluded from the voice proxy via
+            # ``voice_proxy_eligible``; zero weight is belt-and-braces.
             source["author"] = _ROLE_AI
         frontmatter_dict: dict[str, Any] = {
             "title": fragment.metadata.get("title", "Untitled Conversation"),
@@ -562,7 +562,7 @@ def _pair_messages_to_fragments(
                         if msg_authored_at is not None
                         else conv_authored_at
                     )
-                    # FEAT #553: emit the human turn and the AI turn as two
+                    # Emit the human turn and the AI turn as two
                     # separately-attributed fragments instead of one merged
                     # fragment, so the AI's prose can never train the voice
                     # proxy. Both share the conversation id, turn index, and

--- a/creek-tools/creek/ingest/chatgpt.py
+++ b/creek-tools/creek/ingest/chatgpt.py
@@ -28,6 +28,7 @@ from creek.ingest.base import (
     RawDocument,
     normalize_encoding,
 )
+from creek.models import Authorship
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -35,6 +36,12 @@ if TYPE_CHECKING:
     from creek.clean.filters.chatbot import ChatbotFilter
 
 logger = logging.getLogger(__name__)
+
+# Per-turn authorship roles stashed on ``ParsedFragment.metadata`` so the
+# frontmatter stage can attribute each split turn (FEAT #553): the human turn
+# is the owner's voice, the AI turn is quarantined out of the voice proxy.
+_ROLE_SELF = Authorship.SELF.value
+_ROLE_AI = Authorship.AI.value
 
 
 class ChatGPTIngestor(Ingestor):
@@ -150,6 +157,7 @@ class ChatGPTIngestor(Ingestor):
         Returns:
             A dict of frontmatter key-value pairs.
         """
+        is_ai = fragment.metadata.get("author_role", _ROLE_SELF) == _ROLE_AI
         source: dict[str, Any] = {
             "platform": "chatgpt",
             "original_file": fragment.source_path,
@@ -157,11 +165,17 @@ class ChatGPTIngestor(Ingestor):
         conv_id = fragment.metadata.get("conversation_id")
         if conv_id is not None:
             source["conversation_id"] = conv_id
+        if is_ai:
+            # FEAT #553: AI turns are AI-authored, excluded from the voice
+            # proxy via ``voice_proxy_eligible``; zero weight is belt-and-braces.
+            source["author"] = _ROLE_AI
         frontmatter_dict: dict[str, Any] = {
             "title": fragment.metadata.get("title", "Untitled Conversation"),
             "created": fragment.timestamp.isoformat(),
             "source": source,
         }
+        if is_ai:
+            frontmatter_dict["voice_weight"] = 0.0
         authored_at: datetime | None = fragment.metadata.get("authored_at")
         if authored_at is not None:
             frontmatter_dict["authored_at"] = authored_at.isoformat()
@@ -548,23 +562,39 @@ def _pair_messages_to_fragments(
                         if msg_authored_at is not None
                         else conv_authored_at
                     )
-                    content = (
-                        f"**User**: {user_text}\n\n**Assistant**: {assistant_text}"
-                    )
-                    turn_title = f"{title} (turn {turn_idx})"
-                    meta: dict[str, Any] = {
-                        "title": turn_title,
+                    # FEAT #553: emit the human turn and the AI turn as two
+                    # separately-attributed fragments instead of one merged
+                    # fragment, so the AI's prose can never train the voice
+                    # proxy. Both share the conversation id, turn index, and
+                    # timestamp so threading/linking still works.
+                    base_meta: dict[str, Any] = {
                         "platform": "chatgpt",
                         "authored_at": authored_at,
                     }
                     if conversation_id is not None:
-                        meta["conversation_id"] = conversation_id
-                    fragments.append(
-                        ParsedFragment(
-                            content=content,
-                            metadata=meta,
-                            source_path=source_path,
-                            timestamp=fragment_ts,
+                        base_meta["conversation_id"] = conversation_id
+                    fragments.extend(
+                        (
+                            ParsedFragment(
+                                content=user_text,
+                                metadata=base_meta
+                                | {
+                                    "title": f"{title} (turn {turn_idx})",
+                                    "author_role": _ROLE_SELF,
+                                },
+                                source_path=source_path,
+                                timestamp=fragment_ts,
+                            ),
+                            ParsedFragment(
+                                content=assistant_text,
+                                metadata=base_meta
+                                | {
+                                    "title": f"{title} (turn {turn_idx}, AI)",
+                                    "author_role": _ROLE_AI,
+                                },
+                                source_path=source_path,
+                                timestamp=fragment_ts,
+                            ),
                         )
                     )
                     turn_idx += 1

--- a/creek-tools/creek/ingest/claude.py
+++ b/creek-tools/creek/ingest/claude.py
@@ -27,6 +27,7 @@ from creek.ingest.base import (
     normalize_timestamp,
     parse_authored_at,
 )
+from creek.models import Authorship
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -35,6 +36,12 @@ if TYPE_CHECKING:
     from creek.clean.filters.chatbot import ChatbotFilter
 
 logger = logging.getLogger(__name__)
+
+# Per-turn authorship roles stashed on ``ParsedFragment.metadata`` so the
+# convert/frontmatter stages can attribute each split turn correctly
+# (FEAT #553): the human turn is the owner's voice, the AI turn is not.
+_ROLE_SELF = Authorship.SELF.value
+_ROLE_AI = Authorship.AI.value
 
 # ---- Content Extraction ----
 
@@ -304,25 +311,24 @@ class ClaudeIngestor(Ingestor):
         return fragments
 
     def convert_to_markdown(self, fragment: ParsedFragment) -> str:
-        """Convert a parsed fragment to Markdown with blockquote formatting.
+        """Convert a single-turn parsed fragment to Markdown.
 
-        The human turn is rendered as a blockquote (each line prefixed
-        with ``>``), followed by a blank line, then the assistant response
-        as plain text.
+        Each conversation turn is now its own fragment (FEAT #553). The
+        human turn — the owner's own words — is rendered as a blockquote
+        (each line prefixed with ``>``); the AI turn is rendered as plain
+        text, matching the prior merged formatting per role.
 
         Args:
-            fragment: A parsed fragment containing human and assistant text.
+            fragment: A parsed fragment carrying one turn's ``turn_text``
+                and ``author_role``.
 
         Returns:
-            A Markdown-formatted string.
+            A Markdown-formatted string for that single turn.
         """
-        human_text = fragment.metadata.get("human_text", "")
-        assistant_text = fragment.metadata.get("assistant_text", "")
-
-        human_lines = human_text.split("\n")
-        blockquote = "\n".join(f"> {line}" for line in human_lines)
-
-        return f"{blockquote}\n\n{assistant_text}"
+        text = str(fragment.metadata.get("turn_text", ""))
+        if fragment.metadata.get("author_role", _ROLE_SELF) != _ROLE_AI:
+            return "\n".join(f"> {line}" for line in text.split("\n"))
+        return text
 
     def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
         """Generate YAML frontmatter metadata for a Claude conversation fragment.
@@ -347,6 +353,7 @@ class ClaudeIngestor(Ingestor):
         turn_idx = meta.get("turn_index", 0)
         conv_id = meta.get("conversation_id", "unknown")
         model = meta.get("model")
+        is_ai = meta.get("author_role", _ROLE_SELF) == _ROLE_AI
 
         source: dict[str, Any] = {
             "platform": "claude",
@@ -355,12 +362,20 @@ class ClaudeIngestor(Ingestor):
         }
         if model is not None:
             source["model"] = model
+        if is_ai:
+            # FEAT #553: the AI turn is AI-authored, so it can never feed the
+            # voice proxy (``source.author=ai`` makes ``voice_proxy_eligible``
+            # False); zero weight is belt-and-braces against future selectors.
+            source["author"] = _ROLE_AI
 
+        suffix = ", AI" if is_ai else ""
         frontmatter_dict: dict[str, Any] = {
-            "title": f"{conv_name} (turn {turn_idx})",
+            "title": f"{conv_name} (turn {turn_idx}{suffix})",
             "created": fragment.timestamp.isoformat(),
             "source": source,
         }
+        if is_ai:
+            frontmatter_dict["voice_weight"] = 0.0
         authored_at: datetime | None = meta.get("authored_at")
         if authored_at is not None:
             frontmatter_dict["authored_at"] = authored_at.isoformat()
@@ -443,21 +458,22 @@ class ClaudeIngestor(Ingestor):
 
         fragments: list[ParsedFragment] = []
         for idx, (human_msg, assistant_msg) in enumerate(pairs):
-            fragment = self._build_fragment(
-                human_msg=human_msg,
-                assistant_msg=assistant_msg,
-                turn_index=idx,
-                conv_id=conv_id,
-                conv_name=conv_name,
-                model=model,
-                fallback_ts=fallback_ts,
-                source_path=source_path,
+            fragments.extend(
+                self._build_turn_fragments(
+                    human_msg=human_msg,
+                    assistant_msg=assistant_msg,
+                    turn_index=idx,
+                    conv_id=conv_id,
+                    conv_name=conv_name,
+                    model=model,
+                    fallback_ts=fallback_ts,
+                    source_path=source_path,
+                )
             )
-            fragments.append(fragment)
 
         return fragments
 
-    def _build_fragment(
+    def _build_turn_fragments(
         self,
         *,
         human_msg: dict[str, Any],
@@ -468,8 +484,14 @@ class ClaudeIngestor(Ingestor):
         model: str | None,
         fallback_ts: str,
         source_path: str,
-    ) -> ParsedFragment:
-        """Build a single ParsedFragment from a human+assistant turn pair.
+    ) -> list[ParsedFragment]:
+        """Build the human and AI fragments for one conversation turn.
+
+        FEAT #553: the human turn and the AI turn are genuinely different
+        authors, so they become two separately-attributed fragments rather
+        than one merged fragment. Both share the conversation id, turn index,
+        and timestamp so threading/linking still works; ``author_role`` tags
+        each for the convert/frontmatter stages.
 
         Args:
             human_msg: The human message dict.
@@ -482,7 +504,7 @@ class ClaudeIngestor(Ingestor):
             source_path: Original file path.
 
         Returns:
-            A ParsedFragment for this turn pair.
+            ``[human_fragment, ai_fragment]`` for this turn.
         """
         human_text = _extract_text(human_msg.get("content", ""))
         assistant_text = _extract_text(assistant_msg.get("content", ""))
@@ -494,22 +516,26 @@ class ClaudeIngestor(Ingestor):
         # ``None`` when no real source date exists.
         authored_at = _resolve_authored_at(human_msg, fallback_ts)
 
-        content = f"{human_text}\n\n{assistant_text}"
-
-        metadata: dict[str, Any] = {
+        base: dict[str, Any] = {
             "conversation_id": conv_id,
             "conversation_name": conv_name,
             "turn_index": turn_index,
-            "human_text": human_text,
-            "assistant_text": assistant_text,
             "authored_at": authored_at,
         }
         if model is not None:
-            metadata["model"] = model
+            base["model"] = model
 
-        return ParsedFragment(
-            content=content,
-            metadata=metadata,
-            source_path=source_path,
-            timestamp=timestamp,
-        )
+        return [
+            ParsedFragment(
+                content=human_text,
+                metadata=base | {"author_role": _ROLE_SELF, "turn_text": human_text},
+                source_path=source_path,
+                timestamp=timestamp,
+            ),
+            ParsedFragment(
+                content=assistant_text,
+                metadata=base | {"author_role": _ROLE_AI, "turn_text": assistant_text},
+                source_path=source_path,
+                timestamp=timestamp,
+            ),
+        ]

--- a/creek-tools/creek/ingest/claude.py
+++ b/creek-tools/creek/ingest/claude.py
@@ -38,8 +38,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Per-turn authorship roles stashed on ``ParsedFragment.metadata`` so the
-# convert/frontmatter stages can attribute each split turn correctly
-# (FEAT #553): the human turn is the owner's voice, the AI turn is not.
+# convert/frontmatter stages can attribute each split turn correctly: the
+# human turn is the owner's voice, the AI turn is not.
 _ROLE_SELF = Authorship.SELF.value
 _ROLE_AI = Authorship.AI.value
 
@@ -313,7 +313,7 @@ class ClaudeIngestor(Ingestor):
     def convert_to_markdown(self, fragment: ParsedFragment) -> str:
         """Convert a single-turn parsed fragment to Markdown.
 
-        Each conversation turn is now its own fragment (FEAT #553). The
+        Each conversation turn is its own fragment. The
         human turn — the owner's own words — is rendered as a blockquote
         (each line prefixed with ``>``); the AI turn is rendered as plain
         text, matching the prior merged formatting per role.
@@ -363,9 +363,9 @@ class ClaudeIngestor(Ingestor):
         if model is not None:
             source["model"] = model
         if is_ai:
-            # FEAT #553: the AI turn is AI-authored, so it can never feed the
-            # voice proxy (``source.author=ai`` makes ``voice_proxy_eligible``
-            # False); zero weight is belt-and-braces against future selectors.
+            # The AI turn is AI-authored, so it can never feed the voice proxy
+            # (``source.author=ai`` makes ``voice_proxy_eligible`` False); zero
+            # weight is belt-and-braces against future selectors.
             source["author"] = _ROLE_AI
 
         suffix = ", AI" if is_ai else ""
@@ -487,8 +487,8 @@ class ClaudeIngestor(Ingestor):
     ) -> list[ParsedFragment]:
         """Build the human and AI fragments for one conversation turn.
 
-        FEAT #553: the human turn and the AI turn are genuinely different
-        authors, so they become two separately-attributed fragments rather
+        The human turn and the AI turn are genuinely different authors, so
+        they become two separately-attributed fragments rather
         than one merged fragment. Both share the conversation id, turn index,
         and timestamp so threading/linking still works; ``author_role`` tags
         each for the convert/frontmatter stages.

--- a/creek-tools/tests/test_chatbot_filter.py
+++ b/creek-tools/tests/test_chatbot_filter.py
@@ -735,7 +735,7 @@ class TestClaudeIngestorIntegration:
             detected_encoding=encoding,
         )
         fragments = ingestor.parse(raw)
-        # FEAT #553: one turn now splits into a human and an AI fragment.
+        # One turn now splits into a human and an AI fragment.
         assert len(fragments) == 2
         assert "quantum" in fragments[0].content.lower()
 
@@ -775,7 +775,7 @@ class TestClaudeIngestorIntegration:
             detected_encoding=encoding,
         )
         fragments = ingestor.parse(raw)
-        # FEAT #553: the collapsed assistant turn is now its own AI fragment.
+        # The collapsed assistant turn is now its own AI fragment.
         assert len(fragments) == 2
         assert "Final polished" in fragments[1].content
 
@@ -810,7 +810,7 @@ class TestClaudeIngestorIntegration:
         )
         fragments = ingestor.parse(raw)
         # Without filter, system is still skipped by _pair_turns but the short
-        # human turn is kept — and FEAT #553 splits it into human + AI.
+        # human turn is kept — and is split into a human and an AI fragment.
         assert len(fragments) == 2
 
 
@@ -895,7 +895,7 @@ class TestChatGPTIngestorIntegration:
             detected_encoding=encoding,
         )
         fragments = ingestor.parse(raw)
-        # FEAT #553: one turn now splits into a human and an AI fragment.
+        # One turn now splits into a human and an AI fragment.
         assert len(fragments) == 2
         assert "machine learning" in fragments[0].content.lower()
 

--- a/creek-tools/tests/test_chatbot_filter.py
+++ b/creek-tools/tests/test_chatbot_filter.py
@@ -735,7 +735,8 @@ class TestClaudeIngestorIntegration:
             detected_encoding=encoding,
         )
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # FEAT #553: one turn now splits into a human and an AI fragment.
+        assert len(fragments) == 2
         assert "quantum" in fragments[0].content.lower()
 
     def test_filter_collapses_regenerations_during_parse(self) -> None:
@@ -774,8 +775,9 @@ class TestClaudeIngestorIntegration:
             detected_encoding=encoding,
         )
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
-        assert "Final polished" in fragments[0].content
+        # FEAT #553: the collapsed assistant turn is now its own AI fragment.
+        assert len(fragments) == 2
+        assert "Final polished" in fragments[1].content
 
     def test_no_filter_keeps_all_messages(self) -> None:
         """ClaudeIngestor without filter should keep all non-system messages."""
@@ -807,9 +809,9 @@ class TestClaudeIngestorIntegration:
             detected_encoding=encoding,
         )
         fragments = ingestor.parse(raw)
-        # Without filter, system is still skipped by _pair_turns but short
-        # human messages are kept
-        assert len(fragments) == 1
+        # Without filter, system is still skipped by _pair_turns but the short
+        # human turn is kept — and FEAT #553 splits it into human + AI.
+        assert len(fragments) == 2
 
 
 # ---------------------------------------------------------------------------
@@ -893,7 +895,8 @@ class TestChatGPTIngestorIntegration:
             detected_encoding=encoding,
         )
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # FEAT #553: one turn now splits into a human and an AI fragment.
+        assert len(fragments) == 2
         assert "machine learning" in fragments[0].content.lower()
 
     def test_filter_skips_tool_outputs_during_parse(self) -> None:

--- a/creek-tools/tests/test_chatgpt_ingest.py
+++ b/creek-tools/tests/test_chatgpt_ingest.py
@@ -240,7 +240,8 @@ class TestChatGPTParse:
         raw = _make_raw_doc([conv])
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # One user+assistant pair → human + AI fragment.
+        assert len(fragments) == 2
 
     def test_parses_multiple_conversations(self) -> None:
         """parse() should handle multiple conversations in one file."""
@@ -249,16 +250,21 @@ class TestChatGPTParse:
         raw = _make_raw_doc([conv1, conv2])
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 2
+        # Two conversations, one pair each → human + AI fragment per pair.
+        assert len(fragments) == 4
 
     def test_fragment_content_has_user_and_assistant(self) -> None:
-        """parse() should pair user and assistant messages in fragments."""
+        """User text lands in the human fragment, assistant in the AI one."""
         conv = _minimal_conversation()
         raw = _make_raw_doc([conv])
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
+        # Human fragment (index 0) carries only the user text.
         assert "Hello!" in fragments[0].content
-        assert "Hi there!" in fragments[0].content
+        assert "Hi there!" not in fragments[0].content
+        # AI fragment (index 1) carries only the assistant text.
+        assert "Hi there!" in fragments[1].content
+        assert "Hello!" not in fragments[1].content
 
     def test_fragment_excludes_system_messages(self) -> None:
         """parse() should skip system messages from fragment content."""
@@ -382,12 +388,12 @@ class TestChatGPTParse:
         raw = _make_raw_doc([conv])
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
-        # Two user+assistant pairs = two fragments
-        assert len(fragments) == 2
+        # Two user+assistant pairs, each split into human + AI = four fragments.
+        assert len(fragments) == 4
         assert "First question" in fragments[0].content
-        assert "First answer" in fragments[0].content
-        assert "Second question" in fragments[1].content
-        assert "Second answer" in fragments[1].content
+        assert "First answer" in fragments[1].content
+        assert "Second question" in fragments[2].content
+        assert "Second answer" in fragments[3].content
 
     def test_fixture_file_parses(self) -> None:
         """parse() should handle the sample ChatGPT export fixture."""
@@ -401,8 +407,9 @@ class TestChatGPTParse:
         )
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
-        # Fixture has 2 conversations: first has 2 pairs, second has 1 pair
-        assert len(fragments) == 3
+        # Fixture has 2 conversations: first 2 pairs, second 1 pair = 3 pairs;
+        # each pair splits into a human + AI fragment = six fragments.
+        assert len(fragments) == 6
 
 
 # ---- Branching Conversation Tests ----
@@ -499,11 +506,14 @@ class TestChatGPTBranching:
         raw = _make_raw_doc([conv])
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
-        # Should follow the long branch (2 pairs), not short branch (1 pair)
-        assert len(fragments) == 2
+        # Follow the long branch (2 pairs → 4 fragments), not the short
+        # branch (1 pair → 2 fragments).
+        assert len(fragments) == 4
         all_content = " ".join(f.content for f in fragments)
         assert "Long branch answer." in all_content
         assert "Story continues here." in all_content
+        # The short branch's answer must not leak in.
+        assert "Short branch answer." not in all_content
 
 
 # ---- Edge Case Tests ----
@@ -558,7 +568,8 @@ class TestChatGPTEdgeCases:
         raw = _make_raw_doc([conv])
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # One pair → human + AI fragment.
+        assert len(fragments) == 2
 
     def test_empty_parts_list(self) -> None:
         """parse() should handle messages with empty parts list."""
@@ -600,8 +611,8 @@ class TestChatGPTEdgeCases:
         raw = _make_raw_doc([conv])
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
-        # Empty content pair should still produce a fragment (empty content)
-        assert len(fragments) == 1
+        # Empty content pair should still produce a human + AI fragment.
+        assert len(fragments) == 2
 
     def test_missing_content_key(self) -> None:
         """parse() should handle messages missing the content key."""
@@ -645,7 +656,8 @@ class TestChatGPTEdgeCases:
         raw = _make_raw_doc([conv])
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # One pair → human + AI fragment.
+        assert len(fragments) == 2
 
     def test_empty_conversations_list(self) -> None:
         """parse() should return empty list for empty conversations array."""
@@ -885,7 +897,8 @@ class TestChatGPTEdgeCases:
         raw = _make_raw_doc([conv])
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # One pair → human + AI fragment.
+        assert len(fragments) == 2
         # Should use the fixed sentinel: 2000-01-01 in LA timezone
         assert fragments[0].timestamp == datetime(2000, 1, 1, tzinfo=LA_TZ)
 
@@ -930,7 +943,8 @@ class TestChatGPTEdgeCases:
         raw = _make_raw_doc([conv])
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # One pair → human + AI fragment.
+        assert len(fragments) == 2
         # Conversation create_time=0 -> sentinel; no message create_time -> fallback
         assert fragments[0].timestamp == datetime(2000, 1, 1, tzinfo=LA_TZ)
 
@@ -1013,8 +1027,20 @@ class TestChatGPTEdgeCases:
         raw = _make_raw_doc([conv])
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(raw)
-        assert fragments[0].metadata["title"] == "Multi (turn 0)"
-        assert fragments[1].metadata["title"] == "Multi (turn 1)"
+        # Each pair splits into a human fragment and an AI fragment; the AI
+        # title gets the ", AI" suffix and shares the human's turn index.
+        assert [f.metadata["title"] for f in fragments] == [
+            "Multi (turn 0)",
+            "Multi (turn 0, AI)",
+            "Multi (turn 1)",
+            "Multi (turn 1, AI)",
+        ]
+        assert [f.metadata["author_role"] for f in fragments] == [
+            "self",
+            "ai",
+            "self",
+            "ai",
+        ]
 
     def test_discover_non_directory_path(self, tmp_path: Path) -> None:
         """discover() should return empty list for non-directory path."""
@@ -1195,12 +1221,14 @@ class TestChatGPTAuthoredAt:
         # = 1700042410.0
         ingestor = ChatGPTIngestor()
         fragments = ingestor.parse(_make_raw_doc([conv]))
-        assert len(fragments) == 1
-        authored = fragments[0].metadata["authored_at"]
-        assert authored is not None
-        assert authored == datetime.fromtimestamp(1700042410.0, tz=UTC)
-        # UTC, not LA — preserves the source's instant honestly.
-        assert authored.tzinfo == UTC
+        # One pair → human + AI fragment, both anchored to the user epoch.
+        assert len(fragments) == 2
+        for frag in fragments:
+            authored = frag.metadata["authored_at"]
+            assert authored is not None
+            assert authored == datetime.fromtimestamp(1700042410.0, tz=UTC)
+            # UTC, not LA — preserves the source's instant honestly.
+            assert authored.tzinfo == UTC
 
     def test_authored_at_falls_back_to_conversation_create_time(self) -> None:
         """No per-message ``create_time`` → conversation-level epoch wins.

--- a/creek-tools/tests/test_ingest_claude.py
+++ b/creek-tools/tests/test_ingest_claude.py
@@ -283,7 +283,7 @@ class TestParse:
     def test_human_assistant_pair_becomes_fragment(
         self, ingestor: ClaudeIngestor
     ) -> None:
-        """Each human+assistant turn pair should produce one fragment."""
+        """Each human+assistant turn pair should produce two fragments."""
         conv = _make_single_conversation(
             messages=[
                 {
@@ -310,7 +310,8 @@ class TestParse:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 2
+        # Two turn-pairs, each split into human + AI fragment = four total.
+        assert len(fragments) == 4
 
     def test_preserves_conversation_metadata(self, ingestor: ClaudeIngestor) -> None:
         """parse() should preserve conversation_id and model in metadata."""
@@ -335,7 +336,7 @@ class TestParse:
     def test_fragment_content_contains_both_turns(
         self, ingestor: ClaudeIngestor
     ) -> None:
-        """Fragment content should include both human and assistant text."""
+        """Human text lands in the human fragment, assistant in the AI one."""
         conv = _make_single_conversation(
             messages=[
                 {
@@ -352,8 +353,12 @@ class TestParse:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
+        # Human fragment (index 0) carries only the human text.
         assert "My specific question" in fragments[0].content
-        assert "The specific answer" in fragments[0].content
+        assert "The specific answer" not in fragments[0].content
+        # AI fragment (index 1) carries only the assistant text.
+        assert "The specific answer" in fragments[1].content
+        assert "My specific question" not in fragments[1].content
 
     def test_timestamp_from_human_turn(self, ingestor: ClaudeIngestor) -> None:
         """Fragment timestamp should come from the human turn."""
@@ -392,7 +397,8 @@ class TestParse:
         conv2 = _make_single_conversation(uuid="conv-2", name="Second")
         raw = _raw_doc_from_export(_make_claude_export([conv1, conv2]))
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 2
+        # Two conversations, each one turn-pair split into human + AI = four.
+        assert len(fragments) == 4
         ids = {f.metadata["conversation_id"] for f in fragments}
         assert ids == {"conv-1", "conv-2"}
 
@@ -432,8 +438,10 @@ class TestParse:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # One turn-pair → human + AI fragment.
+        assert len(fragments) == 2
         assert "You are a helpful assistant" not in fragments[0].content
+        assert "You are a helpful assistant" not in fragments[1].content
 
     def test_handles_missing_model_field(self, ingestor: ClaudeIngestor) -> None:
         """parse() should handle conversations without a model field."""
@@ -489,8 +497,11 @@ class TestParse:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        # The trailing human turn should not produce a fragment
-        assert len(fragments) == 1
+        # The one complete pair yields human + AI; the trailing human turn
+        # (no assistant reply) produces nothing.
+        assert len(fragments) == 2
+        assert "Unanswered question" not in fragments[0].content
+        assert "Unanswered question" not in fragments[1].content
 
     def test_single_conversation_format_parse(self, ingestor: ClaudeIngestor) -> None:
         """parse() should handle the single-conversation format."""
@@ -513,7 +524,8 @@ class TestParse:
         }
         raw = _raw_doc_from_export(json.dumps(single_conv).encode("utf-8"))
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # One turn-pair → human + AI fragment.
+        assert len(fragments) == 2
         assert fragments[0].metadata["conversation_id"] == "conv-single"
 
     def test_handles_content_as_list(self, ingestor: ClaudeIngestor) -> None:
@@ -534,7 +546,8 @@ class TestParse:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # One turn-pair → human + AI fragment.
+        assert len(fragments) == 2
         assert "Hello from list" in fragments[0].content
 
     def test_turn_index_in_metadata(self, ingestor: ClaudeIngestor) -> None:
@@ -565,8 +578,14 @@ class TestParse:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        assert fragments[0].metadata["turn_index"] == 0
-        assert fragments[1].metadata["turn_index"] == 1
+        # Human and AI fragments of one turn share the turn_index.
+        assert [f.metadata["turn_index"] for f in fragments] == [0, 0, 1, 1]
+        assert [f.metadata["author_role"] for f in fragments] == [
+            "self",
+            "ai",
+            "self",
+            "ai",
+        ]
 
 
 # ---- convert_to_markdown() Tests ----
@@ -622,7 +641,8 @@ class TestConvertToMarkdown:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        markdown = ingestor.convert_to_markdown(fragments[0])
+        # The AI fragment (index 1) renders the assistant text as plain text.
+        markdown = ingestor.convert_to_markdown(fragments[1])
         assert "The answer text" in markdown
         # The answer should not itself be blockquoted
         lines = markdown.split("\n")
@@ -631,7 +651,7 @@ class TestConvertToMarkdown:
         assert not answer_lines[0].startswith(">")
 
     def test_markdown_contains_both_turns(self, ingestor: ClaudeIngestor) -> None:
-        """Markdown output should contain both the human and assistant text."""
+        """Human markdown holds the human text; AI markdown the assistant text."""
         conv = _make_single_conversation(
             messages=[
                 {
@@ -648,9 +668,12 @@ class TestConvertToMarkdown:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        markdown = ingestor.convert_to_markdown(fragments[0])
-        assert "HUMAN_CONTENT_ABC" in markdown
-        assert "ASSISTANT_CONTENT_XYZ" in markdown
+        human_md = ingestor.convert_to_markdown(fragments[0])
+        ai_md = ingestor.convert_to_markdown(fragments[1])
+        assert "HUMAN_CONTENT_ABC" in human_md
+        assert "ASSISTANT_CONTENT_XYZ" not in human_md
+        assert "ASSISTANT_CONTENT_XYZ" in ai_md
+        assert "HUMAN_CONTENT_ABC" not in ai_md
 
     def test_multiline_human_content_blockquoted(
         self, ingestor: ClaudeIngestor
@@ -806,10 +829,12 @@ class TestClaudeAuthoredAt:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
-        authored = fragments[0].metadata["authored_at"]
-        assert authored is not None
-        assert authored == datetime(2024, 11, 15, 10, 30, tzinfo=UTC)
+        # One turn-pair → human + AI fragment, both sharing authored_at.
+        assert len(fragments) == 2
+        for frag in fragments:
+            authored = frag.metadata["authored_at"]
+            assert authored is not None
+            assert authored == datetime(2024, 11, 15, 10, 30, tzinfo=UTC)
 
     def test_authored_at_falls_back_to_conversation_created_at(
         self, ingestor: ClaudeIngestor
@@ -1006,7 +1031,8 @@ class TestEdgeCases:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # One turn-pair → human + AI fragment.
+        assert len(fragments) == 2
         assert "word" in fragments[0].content
 
     def test_unicode_content(self, ingestor: ClaudeIngestor) -> None:
@@ -1027,8 +1053,11 @@ class TestEdgeCases:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # One turn-pair \u2192 human + AI fragment.
+        assert len(fragments) == 2
+        # Human unicode in the human fragment; assistant unicode in the AI one.
         assert "\u2603" in fragments[0].content
+        assert "\u2728" in fragments[1].content
 
     def test_consecutive_human_messages(self, ingestor: ClaudeIngestor) -> None:
         """parse() should handle consecutive human messages correctly."""
@@ -1131,7 +1160,8 @@ class TestEdgeCases:
         )
         raw = _raw_doc_from_export(_make_claude_export([conv]))
         fragments = ingestor.parse(raw)
-        assert len(fragments) == 1
+        # One turn-pair → human + AI fragment.
+        assert len(fragments) == 2
         assert "Describe this image" in fragments[0].content
         # Non-text parts should be excluded
         assert "http://example.com" not in fragments[0].content

--- a/creek-tools/tests/test_ingest_turn_split.py
+++ b/creek-tools/tests/test_ingest_turn_split.py
@@ -1,0 +1,250 @@
+"""Per-turn attribution for AI-chat ingests (FEAT #553, epic #551).
+
+Proves the core fix: ingesting a Claude or ChatGPT conversation emits the
+human turn and the AI turn as *separately attributed* fragments — the human
+turn is the owner's voice (``source.author=self``, full ``voice_weight``) and
+the AI turn is AI-authored (``source.author=ai``, ``voice_weight=0.0``) so it
+can never feed the voice proxy. Also proves the diagnostic effect: a freshly
+ingested chat no longer leaks AI prose into the voice corpus.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.config import AIStyleConfig
+from creek.generate.ai_style.fingerprint import _eligible_texts
+from creek.generate.voice_authenticity import build_voice_authenticity_report
+from creek.ingest.base import RawDocument, assemble_ingested_fragment
+from creek.ingest.chatgpt import ChatGPTIngestor
+from creek.ingest.claude import ClaudeIngestor
+from creek.models import Authorship, Fragment
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from creek.ingest.base import Ingestor
+
+
+# --- Fixture builders -------------------------------------------------------
+
+
+def _claude_export(turns: list[tuple[str, str]]) -> bytes:
+    """Build a one-conversation Claude export from (human, assistant) turns."""
+    messages: list[dict[str, object]] = []
+    for human, assistant in turns:
+        messages.append(
+            {"role": "human", "content": human, "created_at": "2024-11-15T10:00:00Z"}
+        )
+        messages.append(
+            {
+                "role": "assistant",
+                "content": assistant,
+                "created_at": "2024-11-15T10:00:15Z",
+            }
+        )
+    conv = {
+        "uuid": "conv-553",
+        "name": "Voice attribution chat",
+        "created_at": "2024-11-15T10:00:00Z",
+        "model": "claude-3-opus-20240229",
+        "messages": messages,
+    }
+    return json.dumps({"conversations": [conv]}).encode("utf-8")
+
+
+def _chatgpt_export(turns: list[tuple[str, str]]) -> bytes:
+    """Build a one-conversation ChatGPT export from (user, assistant) turns."""
+    mapping: dict[str, object] = {
+        "root": {"id": "root", "message": None, "parent": None, "children": ["sys"]},
+        "sys": {
+            "id": "sys",
+            "message": {
+                "id": "sys",
+                "author": {"role": "system"},
+                "content": {"content_type": "text", "parts": ["System."]},
+                "create_time": 1700000000.0,
+            },
+            "parent": "root",
+            "children": [],
+        },
+    }
+    prev = "sys"
+    base = 1700000010.0
+    for idx, (user, assistant) in enumerate(turns):
+        uid, aid = f"u{idx}", f"a{idx}"
+        mapping[prev]["children"] = [uid]  # type: ignore[index]
+        mapping[uid] = {
+            "id": uid,
+            "message": {
+                "id": uid,
+                "author": {"role": "user"},
+                "content": {"content_type": "text", "parts": [user]},
+                "create_time": base + idx * 100,
+            },
+            "parent": prev,
+            "children": [aid],
+        }
+        mapping[aid] = {
+            "id": aid,
+            "message": {
+                "id": aid,
+                "author": {"role": "assistant"},
+                "content": {"content_type": "text", "parts": [assistant]},
+                "create_time": base + idx * 100 + 10,
+            },
+            "parent": uid,
+            "children": [],
+        }
+        prev = aid
+    conv = {"title": "Voice chat", "create_time": 1700000000.0, "mapping": mapping}
+    return json.dumps([conv]).encode("utf-8")
+
+
+def _ingest_fragments(
+    ingestor: Ingestor,
+    export: bytes,
+    filename: str,
+) -> list[Fragment]:
+    """Run an export through parse → convert → frontmatter → assemble."""
+    raw = RawDocument(
+        path=filename,  # type: ignore[arg-type]
+        content=export,
+        metadata={},
+        detected_encoding="utf-8",
+    )
+    fragments: list[Fragment] = []
+    for parsed in ingestor.parse(raw):
+        parsed.metadata["markdown"] = ingestor.convert_to_markdown(parsed)
+        parsed.metadata["frontmatter"] = ingestor.generate_frontmatter(parsed)
+        fragments.append(assemble_ingested_fragment(parsed).fragment)
+    return fragments
+
+
+def _write_vault(fragments: list[Fragment], vault: Path) -> None:
+    """Persist *fragments* into ``<vault>/01-Fragments`` as markdown."""
+    fragments_dir = vault / "01-Fragments"
+    fragments_dir.mkdir(parents=True, exist_ok=True)
+    for fragment in fragments:
+        payload = fragment.model_dump(mode="json", exclude={"voice_proxy_eligible"})
+        post = frontmatter.Post(f"body for {fragment.id}", **payload)
+        (fragments_dir / f"{fragment.id}.md").write_text(
+            frontmatter.dumps(post),
+            encoding="utf-8",
+        )
+
+
+# --- Attribution tests ------------------------------------------------------
+
+
+def test_claude_turn_splits_into_self_and_ai_fragments() -> None:
+    """A Claude turn yields a self human fragment and a zero-weight AI one."""
+    frags = _ingest_fragments(
+        ClaudeIngestor(),
+        _claude_export([("How do I organize knowledge?", "Mirror how you think.")]),
+        "claude_export.json",
+    )
+
+    assert len(frags) == 2
+    human, ai = frags
+    assert human.source.author == Authorship.SELF
+    assert human.voice_weight == 1.0
+    assert human.voice_proxy_eligible is True
+
+    assert ai.source.author == Authorship.AI
+    assert ai.voice_weight == 0.0
+    assert ai.voice_proxy_eligible is False
+
+
+def test_chatgpt_turn_splits_into_self_and_ai_fragments() -> None:
+    """A ChatGPT turn yields a self human fragment and a zero-weight AI one."""
+    frags = _ingest_fragments(
+        ChatGPTIngestor(),
+        _chatgpt_export([("What is a fragment?", "An atomic content unit.")]),
+        "chatgpt_export.json",
+    )
+
+    assert len(frags) == 2
+    human, ai = frags
+    assert human.source.author == Authorship.SELF
+    assert human.voice_weight == 1.0
+    assert human.voice_proxy_eligible is True
+
+    assert ai.source.author == Authorship.AI
+    assert ai.voice_weight == 0.0
+    assert ai.voice_proxy_eligible is False
+
+
+def test_split_preserves_conversation_id_for_threading() -> None:
+    """Both halves of a turn share the conversation id so threading survives."""
+    frags = _ingest_fragments(
+        ClaudeIngestor(),
+        _claude_export([("Q1", "A1"), ("Q2", "A2")]),
+        "claude_export.json",
+    )
+
+    assert len(frags) == 4
+    assert {f.source.conversation_id for f in frags} == {"conv-553"}
+
+
+# --- Voice-corpus exclusion -------------------------------------------------
+
+
+def test_ai_turn_excluded_from_voice_corpus_human_turn_not(tmp_path: Path) -> None:
+    """The AI turn is excluded from the voice corpus; the human turn is not."""
+    frags = _ingest_fragments(
+        ClaudeIngestor(),
+        _claude_export([("My own question phrasing", "Assistant generated prose")]),
+        "claude_export.json",
+    )
+    vault = tmp_path / "vault"
+    _write_vault(frags, vault)
+
+    human = next(f for f in frags if f.source.author == Authorship.SELF)
+    ai = next(f for f in frags if f.source.author == Authorship.AI)
+    # The human turn remains eligible voice material; the AI turn never is.
+    assert human.voice_proxy_eligible is True
+    assert ai.voice_proxy_eligible is False
+
+    # The AI prose must not appear anywhere in the fingerprint's eligible texts.
+    eligible = _eligible_texts(vault, AIStyleConfig(), include_intimate=False)
+    assert all("Assistant generated prose" not in text for _weight, text in eligible)
+
+
+def test_fresh_chat_ai_corpus_leak_is_zero(tmp_path: Path) -> None:
+    """A freshly-ingested chat reports ≈0 AI-corpus leak (DoD for #553)."""
+    frags = _ingest_fragments(
+        ClaudeIngestor(),
+        _claude_export([("Q1", "A1"), ("Q2", "A2"), ("Q3", "A3")]),
+        "claude_export.json",
+    )
+    vault = tmp_path / "vault"
+    _write_vault(frags, vault)
+
+    report = build_voice_authenticity_report(vault, draft_path=None)
+
+    # The three human turns are the eligible corpus; none counts as a leak
+    # because each turn now carries a quarantined AI sibling.
+    assert report.ai_corpus_leak.eligible_total == 3
+    assert report.ai_corpus_leak.leaked == 0
+    assert report.ai_corpus_leak.fraction == 0.0
+
+
+def test_fresh_chatgpt_chat_ai_corpus_leak_is_zero(tmp_path: Path) -> None:
+    """The leak drop also holds for ChatGPT ingests (no export conversation id)."""
+    frags = _ingest_fragments(
+        ChatGPTIngestor(),
+        _chatgpt_export([("Q1", "A1"), ("Q2", "A2")]),
+        "chatgpt_export.json",
+    )
+    vault = tmp_path / "vault"
+    _write_vault(frags, vault)
+
+    report = build_voice_authenticity_report(vault, draft_path=None)
+
+    assert report.ai_corpus_leak.eligible_total == 2
+    assert report.ai_corpus_leak.leaked == 0
+    assert report.ai_corpus_leak.fraction == 0.0

--- a/creek-tools/tests/test_ingest_turn_split.py
+++ b/creek-tools/tests/test_ingest_turn_split.py
@@ -1,4 +1,4 @@
-"""Per-turn attribution for AI-chat ingests (FEAT #553, epic #551).
+"""Per-turn attribution for AI-chat ingests.
 
 Proves the core fix: ingesting a Claude or ChatGPT conversation emits the
 human turn and the AI turn as *separately attributed* fragments — the human
@@ -215,7 +215,7 @@ def test_ai_turn_excluded_from_voice_corpus_human_turn_not(tmp_path: Path) -> No
 
 
 def test_fresh_chat_ai_corpus_leak_is_zero(tmp_path: Path) -> None:
-    """A freshly-ingested chat reports ≈0 AI-corpus leak (DoD for #553)."""
+    """A freshly-ingested chat reports ≈0 AI-corpus leak."""
     frags = _ingest_fragments(
         ClaudeIngestor(),
         _claude_export([("Q1", "A1"), ("Q2", "A2"), ("Q3", "A3")]),


### PR DESCRIPTION
## Summary

- **Split AI-chat ingests by turn.** `ClaudeIngestor` and `ChatGPTIngestor` previously merged each human+assistant turn into one fragment defaulting to `source.author=self`, so the AI's prose was treated as a voice exemplar. Each turn now emits **two** separately-attributed fragments (human first, then AI):
  - human turn → `source.author=self`, full `voice_weight` → `voice_proxy_eligible` **True** (the owner's voice);
  - AI turn → `source.author=ai`, `voice_weight=0.0` → `voice_proxy_eligible` **False** (quarantined out of the proxy).
- Both halves share the conversation id, turn index, and timestamp so threading/linking still works. Per-turn fragment ids stay unique (id hashes content, which now differs per role).
- **Attribution decision (per the issue's default):** reuse `Authorship.AI` — no enum change — since it already excludes the turn from the proxy. Human turns stay `self` so #554's audience weighting ranks them below published essays automatically.
- **Refined the #552 `ai_corpus_leak` probe** to its faithful implementation (the skeleton explicitly invited "later issues replace each probe"): an AI-chat fragment counts as leaked only when its conversation has **no AI-authored sibling**. A freshly-ingested chat reads **≈0** leak; legacy *merged* fragments (no AI sibling) still flag — driving the #557 re-ingest migration. The #552 contract/tests are unchanged (their orphan chat fragments still count).
- Non-chat ingests (essays, markdown, documents) are unchanged.

## A note on the "leak ≈0" DoD

The #552 probe counts *voice-eligible fragments on AI-chat platforms*. The human turns are legitimately self-authored on the chat platform, so a pure platform proxy would **not** drop after this fix (verified empirically: it stays at 1.0). The faithful, droppable measure is "AI-chat fragments whose conversation was never split" — implemented here as the sibling/quarantine check. This is what makes a fresh chat read ≈0 while still flagging un-migrated legacy fragments.

## Test plan

- New `tests/test_ingest_turn_split.py` (6 tests): per-role attribution for Claude **and** ChatGPT (author / voice_weight / voice_proxy_eligible); conversation-id preserved across the split; AI prose **excluded** from the fingerprint's eligible texts while the human turn stays eligible; and `ai_corpus_leak` is **0** for a freshly-ingested Claude and ChatGPT chat.
- Updated existing ingestor tests (`test_ingest_claude.py`, `test_chatgpt_ingest.py`, `test_chatbot_filter.py`) to the split contract — counts doubled, content/markdown/metadata assertions retargeted per role, with negative cross-checks; no assertions weakened, no skips/noqa added.
- `cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (5181 tests, coverage ≥90% incl. 100% on the changed modules, mypy strict, ruff, refurb, tryceratops, interrogate, complexity).

Closes #553
Refs #551
