### PR TITLE
feat(voice): audience-weighted voice authority (graduated privacy-tier multiplier)

### DIFF
--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -1058,6 +1058,51 @@ class SourcePaths(BaseModel):
     """Code project directories."""
 
 
+def _default_privacy_tier_authority() -> dict[str, float]:
+    """Default per-privacy-tier voice-authority multipliers.
+
+    ``OPEN`` (publishable, public-facing) work carries the most authority
+    over the voice proxy; ``PERSONAL`` is the baseline; ``UNCLASSIFIED`` is
+    treated cautiously below baseline; ``INTIMATE`` is ``0.0`` (it is also
+    gated out entirely by default).
+    """
+    return {"open": 1.5, "personal": 1.0, "unclassified": 0.75, "intimate": 0.0}
+
+
+def _default_representativeness_authority() -> dict[str, float]:
+    """Default per-representativeness voice-authority multipliers.
+
+    The owner's own (``self``) and explicitly ``endorsed`` material outrank
+    ``aspirational`` (voices they want to grow into) and ``reference``
+    (borrowed) material, which keeps its existing near-zero influence.
+    """
+    return {"self": 1.0, "endorsed": 0.9, "aspirational": 0.6, "reference": 0.3}
+
+
+class VoiceAudienceWeightingConfig(BaseModel):
+    """Graduated audience-authority weighting for the voice proxy (issue #554).
+
+    Replaces the historical binary privacy gate with a multiplier so that
+    public-facing fragments dominate how drafts sound. The multiplier is the
+    product of a per-``privacy_tier`` and a per-``representativeness`` factor;
+    it is applied on top of (not in place of) the ``voice_weight`` gate.
+    Disabling it makes every authority ``1.0`` — i.e. the pre-#554 ranking.
+    """
+
+    enabled: bool = True
+    """Master switch; ``False`` makes every fragment's authority ``1.0``."""
+
+    privacy_tier_authority: dict[str, float] = Field(
+        default_factory=_default_privacy_tier_authority,
+    )
+    """Multiplier per ``privacy_tier`` value (missing tiers default to 1.0)."""
+
+    representativeness_authority: dict[str, float] = Field(
+        default_factory=_default_representativeness_authority,
+    )
+    """Multiplier per ``representativeness`` value (missing default to 1.0)."""
+
+
 class CreekConfig(BaseSettings):
     """Top-level Creek configuration.
 
@@ -1127,6 +1172,11 @@ class CreekConfig(BaseSettings):
 
     author: AuthorConfig = Field(default_factory=AuthorConfig)
     """Creek Writing Desk author-subsystem settings (FEAT-041)."""
+
+    voice_audience_weighting: VoiceAudienceWeightingConfig = Field(
+        default_factory=VoiceAudienceWeightingConfig,
+    )
+    """Graduated audience-authority weighting for the voice proxy (issue #554)."""
 
     sources: SourcePaths = Field(default_factory=SourcePaths)
     """Source data path mappings."""

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -1080,13 +1080,13 @@ def _default_representativeness_authority() -> dict[str, float]:
 
 
 class VoiceAudienceWeightingConfig(BaseModel):
-    """Graduated audience-authority weighting for the voice proxy (issue #554).
+    """Graduated audience-authority weighting for the voice proxy.
 
     Replaces the historical binary privacy gate with a multiplier so that
     public-facing fragments dominate how drafts sound. The multiplier is the
     product of a per-``privacy_tier`` and a per-``representativeness`` factor;
     it is applied on top of (not in place of) the ``voice_weight`` gate.
-    Disabling it makes every authority ``1.0`` — i.e. the pre-#554 ranking.
+    Disabling it makes every authority ``1.0`` — i.e. the pre-weighting ranking.
     """
 
     enabled: bool = True
@@ -1176,7 +1176,7 @@ class CreekConfig(BaseSettings):
     voice_audience_weighting: VoiceAudienceWeightingConfig = Field(
         default_factory=VoiceAudienceWeightingConfig,
     )
-    """Graduated audience-authority weighting for the voice proxy (issue #554)."""
+    """Graduated audience-authority weighting for the voice proxy."""
 
     sources: SourcePaths = Field(default_factory=SourcePaths)
     """Source data path mappings."""

--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -39,6 +39,7 @@ import frontmatter
 import yaml
 from pydantic import ValidationError
 
+from creek.config import VoiceAudienceWeightingConfig
 from creek.models import (
     Confidence,
     Fragment,
@@ -145,6 +146,38 @@ def _is_fully_classified(fragment: Fragment) -> bool:
 def _word_count(body: str) -> int:
     """Return the whitespace-delimited token count of *body*."""
     return len(body.split())
+
+
+def audience_authority(
+    fragment: Fragment,
+    weighting: VoiceAudienceWeightingConfig,
+) -> float:
+    """Return the audience-authority multiplier for *fragment*.
+
+    Combines a per-``privacy_tier`` factor (public-facing work outranks
+    private writing) with a per-``representativeness`` factor (the owner's own
+    and endorsed material outranks aspirational and borrowed material). The
+    result multiplies a fragment's ranking score so higher-authority fragments
+    win ties and dominate the exemplars that feed each voice profile.
+
+    Args:
+        fragment: The candidate exemplar fragment.
+        weighting: The audience-weighting configuration. When disabled every
+            fragment returns ``1.0`` (the pre-#554 uniform ranking).
+
+    Returns:
+        A non-negative multiplier; ``0.0`` for tiers with no authority
+        (e.g. ``intimate``). Unknown tier / representativeness values fall
+        back to ``1.0`` so a new enum member never silently zeroes a fragment.
+    """
+    if not weighting.enabled:
+        return 1.0
+    privacy = weighting.privacy_tier_authority.get(str(fragment.privacy_tier), 1.0)
+    representativeness = weighting.representativeness_authority.get(
+        str(fragment.representativeness),
+        1.0,
+    )
+    return privacy * representativeness
 
 
 def _is_other_authors_path(md_file: Path) -> bool:
@@ -321,6 +354,7 @@ class VoiceExemplarCollector:
         max_per_register: int = DEFAULT_MAX_PER_REGISTER,
         min_per_register: int = DEFAULT_MIN_PER_REGISTER,
         allow_intimate: bool = False,
+        audience_weighting: VoiceAudienceWeightingConfig | None = None,
     ) -> None:
         """Initialise the collector.
 
@@ -331,6 +365,11 @@ class VoiceExemplarCollector:
                 warning is emitted. Must be at least 1.
             allow_intimate: Whether to include ``intimate`` privacy tier
                 fragments. Defaults to ``False``.
+            audience_weighting: Graduated audience-authority multipliers
+                applied during ranking. Defaults to the standard weighting,
+                which keeps a uniform-audience vault's relative ranking
+                unchanged while letting public-facing work dominate a
+                mixed-audience one.
 
         Raises:
             ValueError: If ``max_per_register`` or ``min_per_register``
@@ -352,6 +391,7 @@ class VoiceExemplarCollector:
         self.max_per_register = max_per_register
         self.min_per_register = min_per_register
         self.allow_intimate = allow_intimate
+        self._audience_weighting = audience_weighting or VoiceAudienceWeightingConfig()
         self._records: dict[str, _ExemplarRecord] = {}
 
     # ---- Collection ----
@@ -426,7 +466,7 @@ class VoiceExemplarCollector:
     def rank_exemplars(self, fragments: list[Fragment]) -> list[Fragment]:
         """Rank *fragments* by quality and return the top ``max_per_register``.
 
-        Scoring (max 5 per fragment):
+        Quality base (max 5 per fragment):
 
         - ``conviction`` confidence: 3 points; ``settled``: 2 points.
         - Body length in ``[200, 800]`` words: +1 point (uses the cached
@@ -435,7 +475,10 @@ class VoiceExemplarCollector:
         - All classification axes populated (frequency, wavelength
           phase / mode, voice register, voice confidence): +1 point.
 
-        Ties are broken by ascending ID for deterministic ordering.
+        The base is then multiplied by :func:`audience_authority`, so a
+        public-facing (``OPEN``) fragment outranks an otherwise-equal
+        ``PERSONAL`` one. Ties are broken by ascending ID for deterministic
+        ordering.
 
         Args:
             fragments: Fragments to rank. May be empty.
@@ -452,8 +495,13 @@ class VoiceExemplarCollector:
         )
         return scored[: self.max_per_register]
 
-    def _score(self, fragment: Fragment) -> int:
-        """Return the integer ranking score for *fragment*."""
+    def _score(self, fragment: Fragment) -> float:
+        """Return the audience-weighted ranking score for *fragment*.
+
+        The quality base (confidence + length + classification bonuses) is
+        multiplied by :func:`audience_authority`, so public-facing,
+        self-representative fragments win ties and outrank private ones.
+        """
         score = _CONFIDENCE_SCORE.get(_confidence_value(fragment), 0)
         record = self._records.get(fragment.id)
         if record is not None and (
@@ -462,7 +510,7 @@ class VoiceExemplarCollector:
             score += _LENGTH_BONUS
         if _is_fully_classified(fragment):
             score += _CLASSIFICATION_BONUS
-        return score
+        return score * audience_authority(fragment, self._audience_weighting)
 
     # ---- Persistence ----
 
@@ -1334,14 +1382,18 @@ class Exemplar:
     body: str
 
 
-def _exemplar_score(exemplar: Exemplar) -> int:
-    """Return the ranking score for *exemplar*.
+def _exemplar_score(
+    exemplar: Exemplar,
+    weighting: VoiceAudienceWeightingConfig,
+) -> float:
+    """Return the audience-weighted ranking score for *exemplar*.
 
     Mirrors :meth:`VoiceExemplarCollector._score` but reads word count
     from the exemplar's body rather than a cached record: confidence
     base (3 for conviction, 2 for settled), +1 bonus for a body in the
     medium-length band [200, 800] words, and +1 bonus when every
-    classification axis is populated.
+    classification axis is populated. The base is then multiplied by
+    :func:`audience_authority` so public-facing exemplars dominate.
     """
     fragment = exemplar.fragment
     score = _CONFIDENCE_SCORE.get(_confidence_value(fragment), 0)
@@ -1350,7 +1402,7 @@ def _exemplar_score(exemplar: Exemplar) -> int:
         score += _LENGTH_BONUS
     if _is_fully_classified(fragment):
         score += _CLASSIFICATION_BONUS
-    return score
+    return score * audience_authority(fragment, weighting)
 
 
 @dataclass(frozen=True)
@@ -1476,6 +1528,7 @@ class VoiceProfileGenerator:
         min_exemplars: int = _DEFAULT_MIN_EXEMPLARS_PER_PROFILE,
         collector: VoiceExemplarCollector | None = None,
         extractor: VoicePatternExtractor | None = None,
+        audience_weighting: VoiceAudienceWeightingConfig | None = None,
     ) -> None:
         """Initialise the generator.
 
@@ -1506,9 +1559,11 @@ class VoiceProfileGenerator:
             raise ValueError(msg)
         self.max_exemplars = max_exemplars
         self.min_exemplars = min_exemplars
+        self._audience_weighting = audience_weighting or VoiceAudienceWeightingConfig()
         self._collector = collector or VoiceExemplarCollector(
             max_per_register=max_exemplars,
             min_per_register=min_exemplars,
+            audience_weighting=self._audience_weighting,
         )
         self._extractor = extractor or VoicePatternExtractor()
 
@@ -1736,7 +1791,10 @@ class VoiceProfileGenerator:
         """
         scored = sorted(
             exemplars,
-            key=lambda e: (-_exemplar_score(e), e.fragment.id),
+            key=lambda e: (
+                -_exemplar_score(e, self._audience_weighting),
+                e.fragment.id,
+            ),
         )
         return scored[: self.max_exemplars]
 

--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -163,7 +163,7 @@ def audience_authority(
     Args:
         fragment: The candidate exemplar fragment.
         weighting: The audience-weighting configuration. When disabled every
-            fragment returns ``1.0`` (the pre-#554 uniform ranking).
+            fragment returns ``1.0`` (the pre-weighting uniform ranking).
 
     Returns:
         A non-negative multiplier; ``0.0`` for tiers with no authority

--- a/creek-tools/creek/generate/voice_authenticity.py
+++ b/creek-tools/creek/generate/voice_authenticity.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING
 
 import frontmatter
 
+from creek.config import VoiceAudienceWeightingConfig
 from creek.generate.ai_style.guard import VOICE_DISTANCE_KEY, VOICE_FINDINGS_KEY
 from creek.models import Authorship, Fragment, PrivacyTier, SourcePlatform
 from creek.vault.reader import iter_vault_fragments
@@ -62,8 +63,7 @@ class AudienceMix:
             ``intimate`` is always ``0`` because INTIMATE fragments are not
             voice-eligible; it is reported for transparency.
         weighting_active: Whether graduated audience-authority weighting is
-            applied during voice selection. Stub ``False`` until audience
-            weighting lands.
+            applied during voice selection.
     """
 
     by_tier: dict[str, int]
@@ -205,13 +205,17 @@ def _probe_audience_mix(eligible: list[Fragment]) -> AudienceMix:
         eligible: The voice-eligible fragments.
 
     Returns:
-        The audience-mix sub-score (``weighting_active`` stubbed ``False``).
+        The audience-mix sub-score. ``weighting_active`` reflects whether the
+        voice pipeline applies graduated audience-authority weighting.
     """
     by_tier = {tier.value: 0 for tier in PrivacyTier}
     for fragment in eligible:
         tier = str(fragment.privacy_tier)
         by_tier[tier] = by_tier.get(tier, 0) + 1
-    return AudienceMix(by_tier=by_tier, weighting_active=False)
+    return AudienceMix(
+        by_tier=by_tier,
+        weighting_active=VoiceAudienceWeightingConfig().enabled,
+    )
 
 
 def _conversation_key(fragment: Fragment) -> tuple[str, str | None, str | None] | None:

--- a/creek-tools/tests/test_voice_audience_authority.py
+++ b/creek-tools/tests/test_voice_audience_authority.py
@@ -1,0 +1,224 @@
+"""Audience-weighted voice authority for the voice pipeline.
+
+Public-facing (``OPEN``) fragments carry more authority over the voice proxy
+than ``PERSONAL`` ones; ``INTIMATE`` stays excluded; and the previously-unused
+``representativeness`` field now shapes ranking. The multiplier composes with
+the existing ``voice_weight`` gate and flows through exemplar ranking so the
+patterns of public work dominate generated profiles.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.config import VoiceAudienceWeightingConfig
+from creek.generate.voice import (
+    Exemplar,
+    VoiceExemplarCollector,
+    VoiceProfileGenerator,
+    audience_authority,
+)
+from creek.models import (
+    Confidence,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Mode,
+    Phase,
+    PrivacyTier,
+    SourcePlatform,
+    VoiceClassification,
+    VoiceRegister,
+    WavelengthClassification,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _fragment(
+    *,
+    frag_id: str,
+    privacy: PrivacyTier = PrivacyTier.PERSONAL,
+    representativeness: str = "self",
+    confidence: Confidence = Confidence.SETTLED,
+    register: VoiceRegister = VoiceRegister.ANALYTICAL,
+) -> Fragment:
+    """Build a fully-classified Fragment with the given audience attributes."""
+    return Fragment(
+        id=frag_id,
+        title=frag_id,
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        created=datetime(2026, 1, 15, 12, 0, 0),
+        ingested=datetime(2026, 1, 15, 12, 0, 0),
+        frequency=FrequencyClassification(primary=Frequency.F5),
+        wavelength=WavelengthClassification(phase=Phase.RISING, mode=Mode.EXPRESS),
+        voice=VoiceClassification(voice_register=register, confidence=confidence),
+        privacy_tier=privacy,
+        representativeness=representativeness,  # type: ignore[arg-type]
+    )
+
+
+def _write(vault: Path, fragment: Fragment, *, body: str) -> None:
+    """Persist *fragment* with *body* under ``01-Fragments/Writing``."""
+    target = vault / "01-Fragments" / "Writing" / f"{fragment.id}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(content=body, **fragment.model_dump(mode="json"))
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+# --- audience_authority helper ----------------------------------------------
+
+
+def test_open_outranks_personal_authority() -> None:
+    """An OPEN fragment carries more authority than a PERSONAL one."""
+    weighting = VoiceAudienceWeightingConfig()
+    open_frag = _fragment(frag_id="o", privacy=PrivacyTier.OPEN)
+    personal = _fragment(frag_id="p", privacy=PrivacyTier.PERSONAL)
+    assert audience_authority(open_frag, weighting) > audience_authority(
+        personal,
+        weighting,
+    )
+
+
+def test_intimate_authority_is_zero() -> None:
+    """INTIMATE carries zero authority (excluded from the proxy)."""
+    weighting = VoiceAudienceWeightingConfig()
+    intimate = _fragment(frag_id="i", privacy=PrivacyTier.INTIMATE)
+    assert audience_authority(intimate, weighting) == 0.0
+
+
+def test_representativeness_orders_authority() -> None:
+    """self > endorsed > aspirational > reference for equal privacy tier."""
+    weighting = VoiceAudienceWeightingConfig()
+    authorities = [
+        audience_authority(
+            _fragment(frag_id=rep, privacy=PrivacyTier.OPEN, representativeness=rep),
+            weighting,
+        )
+        for rep in ("self", "endorsed", "aspirational", "reference")
+    ]
+    assert authorities == sorted(authorities, reverse=True)
+    assert len(set(authorities)) == 4
+
+
+def test_disabled_weighting_is_uniform() -> None:
+    """When weighting is disabled every fragment has authority 1.0."""
+    weighting = VoiceAudienceWeightingConfig(enabled=False)
+    open_frag = _fragment(frag_id="o", privacy=PrivacyTier.OPEN)
+    intimate = _fragment(frag_id="i", privacy=PrivacyTier.INTIMATE)
+    assert audience_authority(open_frag, weighting) == 1.0
+    assert audience_authority(intimate, weighting) == 1.0
+
+
+# --- collector ranking ------------------------------------------------------
+
+
+def test_open_outranks_personal_in_exemplar_ranking() -> None:
+    """With equal base score, the OPEN fragment ranks above the PERSONAL one."""
+    collector = VoiceExemplarCollector()
+    personal = _fragment(frag_id="frag-personal", privacy=PrivacyTier.PERSONAL)
+    open_frag = _fragment(frag_id="frag-open", privacy=PrivacyTier.OPEN)
+    ranked = collector.rank_exemplars([personal, open_frag])
+    assert [f.id for f in ranked] == ["frag-open", "frag-personal"]
+
+
+def test_self_outranks_aspirational_in_ranking() -> None:
+    """For equal privacy tier, self-representative ranks above aspirational."""
+    collector = VoiceExemplarCollector()
+    aspirational = _fragment(
+        frag_id="frag-asp",
+        privacy=PrivacyTier.OPEN,
+        representativeness="aspirational",
+    )
+    own = _fragment(
+        frag_id="frag-self",
+        privacy=PrivacyTier.OPEN,
+        representativeness="self",
+    )
+    ranked = collector.rank_exemplars([aspirational, own])
+    assert [f.id for f in ranked] == ["frag-self", "frag-asp"]
+
+
+def test_uniform_tier_preserves_confidence_ordering() -> None:
+    """Backward-compat: same tier/representativeness keeps the old ranking."""
+    collector = VoiceExemplarCollector()
+    settled = _fragment(frag_id="frag-settled", confidence=Confidence.SETTLED)
+    conviction = _fragment(frag_id="frag-conv", confidence=Confidence.CONVICTION)
+    ranked = collector.rank_exemplars([settled, conviction])
+    # Conviction still outranks settled when audience authority is uniform.
+    assert [f.id for f in ranked] == ["frag-conv", "frag-settled"]
+
+
+# --- end-to-end profile generation ------------------------------------------
+
+
+def test_generated_profile_favours_open_over_personal(tmp_path: Path) -> None:
+    """With a single exemplar slot, the OPEN fragment wins the profile."""
+    vault = tmp_path / "vault"
+    open_frag = _fragment(frag_id="frag-open", privacy=PrivacyTier.OPEN)
+    personal = _fragment(frag_id="frag-personal", privacy=PrivacyTier.PERSONAL)
+    _write(vault, open_frag, body="OPEN_SIGNATURE " + "word " * 300)
+    _write(vault, personal, body="PERSONAL_SIGNATURE " + "word " * 300)
+
+    generator = VoiceProfileGenerator(max_exemplars=1, min_exemplars=1)
+    written = generator.generate_all_profiles(vault)
+
+    # Both fragments share the ANALYTICAL register, but only one exemplar slot
+    # exists — the OPEN fragment must win it, so its signature appears in the
+    # generated profile note(s) and the PERSONAL one does not.
+    rendered = "\n".join(path.read_text(encoding="utf-8") for path in written)
+    assert "OPEN_SIGNATURE" in rendered
+    assert "PERSONAL_SIGNATURE" not in rendered
+
+
+def test_generator_rank_exemplars_weights_audience() -> None:
+    """The generator's exemplar ranking applies the audience multiplier."""
+    generator = VoiceProfileGenerator(max_exemplars=2, min_exemplars=1)
+    personal = Exemplar(
+        fragment=_fragment(frag_id="frag-personal", privacy=PrivacyTier.PERSONAL),
+        body="word " * 300,
+    )
+    open_ex = Exemplar(
+        fragment=_fragment(frag_id="frag-open", privacy=PrivacyTier.OPEN),
+        body="word " * 300,
+    )
+    ranked = generator._rank_exemplars([personal, open_ex])
+    assert [e.fragment.id for e in ranked] == ["frag-open", "frag-personal"]
+
+
+def test_intimate_excluded_from_collection(tmp_path: Path) -> None:
+    """INTIMATE fragments are still gated out of collection by default."""
+    vault = tmp_path / "vault"
+    intimate = _fragment(frag_id="frag-intimate", privacy=PrivacyTier.INTIMATE)
+    _write(vault, intimate, body="word " * 300)
+
+    collector = VoiceExemplarCollector()
+    buckets = collector.collect_exemplars(vault)
+
+    assert all(intimate.id not in [f.id for f in frags] for frags in buckets.values())
+
+
+def test_audience_weighting_config_defaults() -> None:
+    """The config exposes graduated, documented default multipliers."""
+    cfg = VoiceAudienceWeightingConfig()
+    assert cfg.enabled is True
+    assert cfg.privacy_tier_authority["open"] > cfg.privacy_tier_authority["personal"]
+    assert cfg.privacy_tier_authority["intimate"] == 0.0
+    assert (
+        cfg.representativeness_authority["self"]
+        > cfg.representativeness_authority["reference"]
+    )
+
+
+@pytest.mark.parametrize("rep", ["self", "endorsed", "aspirational", "reference"])
+def test_authority_is_positive_for_open_representativeness(rep: str) -> None:
+    """Every representativeness keeps OPEN authority strictly positive."""
+    weighting = VoiceAudienceWeightingConfig()
+    frag = _fragment(frag_id=rep, privacy=PrivacyTier.OPEN, representativeness=rep)
+    assert audience_authority(frag, weighting) > 0.0

--- a/creek-tools/tests/test_voice_authenticity.py
+++ b/creek-tools/tests/test_voice_authenticity.py
@@ -142,8 +142,8 @@ def test_audience_mix_buckets_eligible_by_tier(tmp_path: Path) -> None:
     assert mix.by_tier["personal"] == 2
     assert mix.by_tier["unclassified"] == 1
     assert mix.by_tier["intimate"] == 0
-    # Weighting is OFF until Issue #554 lands.
-    assert mix.weighting_active is False
+    # Graduated audience-authority weighting is active in the voice pipeline.
+    assert mix.weighting_active is True
 
 
 def test_ai_corpus_leak_counts_chat_platforms(tmp_path: Path) -> None:
@@ -231,7 +231,7 @@ def test_to_json_is_stable_and_parseable(tmp_path: Path) -> None:
     payload = json.loads(report.to_json())
 
     assert payload["eligible_total"] == 5
-    assert payload["audience_mix"]["weighting_active"] is False
+    assert payload["audience_mix"]["weighting_active"] is True
     assert payload["audience_mix"]["by_tier"]["open"] == 2
     assert payload["audience_mix"]["total"] == 5
     assert payload["ai_corpus_leak"]["leaked"] == 2


### PR DESCRIPTION
## Summary

- **Graduated audience authority replaces the binary privacy gate's role in ranking.** New `audience_authority(fragment, weighting)` in `creek/generate/voice.py` returns a multiplier = per-`privacy_tier` factor × per-`representativeness` factor:
  - privacy: `OPEN` 1.5 > `PERSONAL` 1.0 > `UNCLASSIFIED` 0.75 > `INTIMATE` 0.0;
  - representativeness (previously **unused** in voice.py): `self` 1.0 > `endorsed` 0.9 > `aspirational` 0.6 > `reference` 0.3.
- The multiplier scales the exemplar ranking score in **both** `VoiceExemplarCollector._score` and the generator's `_exemplar_score`/`_rank_exemplars`, so an `OPEN` essay wins ties over a competing `PERSONAL` fragment and dominates the exemplars that feed each generated profile (pattern aggregation inherits the weighting through exemplar selection). It **composes with, never bypasses** the existing `voice_weight > 0` gate; `INTIMATE` stays gated out by default.
- New `VoiceAudienceWeightingConfig` (config.py) holds the documented defaults and is wired onto `CreekConfig.voice_audience_weighting`; collector/generator accept an `audience_weighting` override. Disabling it (`enabled=False`) restores the exact pre-change uniform ranking.
- The diagnostic's `audience_mix.weighting_active` now reflects the active weighting (True by default).

## Constraints honored

- **Scope fence:** no citation-density pattern (that's #555), no ingestion/de-slop changes, `INTIMATE` exclusion intact.
- **Backward-compat invariant:** a vault whose fragments share one tier and default `representativeness` keeps its prior relative ranking (uniform multiplier → order preserved); only mixed-audience vaults shift. Proven by a test, and the full existing voice suite (237 tests) stays green.

## Test plan

- New `tests/test_voice_audience_authority.py` (15 tests): `audience_authority` ordering (OPEN > PERSONAL, INTIMATE = 0, representativeness ordering, disabled → uniform 1.0); collector ranking puts OPEN above an equal-confidence PERSONAL and `self` above `aspirational`; **backward-compat** (uniform tier preserves confidence ordering); end-to-end `generate_all_profiles` with one exemplar slot writes the OPEN signature and not the PERSONAL one; generator `_rank_exemplars` weighting; `INTIMATE` still gated out; config defaults.
- Updated the two #552 diagnostic tests to assert `weighting_active is True`.
- `cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (coverage ≥90% incl. changed lines, mypy strict, ruff/refurb/tryceratops/interrogate/complexity clean).

Closes #554
Refs #551
