### PR TITLE
feat(voice): citation/quotation-density voice pattern (audience-weighted)

### DIFF
--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -761,7 +761,17 @@ _ATTRIBUTION_RE: re.Pattern[str] = re.compile(
 _REFERENCE_MARKER_RE: re.Pattern[str] = re.compile(
     r"\[\d+\]|\([A-Z][A-Za-z.-]+(?: et al\.?)?,?\s+\d{4}[a-z]?\)",
 )
-_OUTBOUND_LINK_RE: re.Pattern[str] = re.compile(r"https?://\S+")
+# Stop before terminal punctuation so a trailing ``.``/``,`` does not inflate
+# the match (e.g. "see https://example.com." counts one clean link).
+_OUTBOUND_LINK_RE: re.Pattern[str] = re.compile(r"https?://[^\s.,;:!?)]+")
+
+_MIN_QUOTE_WORDS: int = 4
+"""Minimum whitespace-token count for a quoted span to count as a citation.
+
+Quoting a *source* tends to span several words; short quoted spans are almost
+always dialogue tags, scare quotes (``the "obvious" fix``), or inline code
+(``"--verbose"``), so requiring at least this many words filters those false
+positives out of ``citation_density``."""
 
 _CITATION_PROMPT_THRESHOLD: float = 1.0
 """Citation density (signals per 1000 words) above which the generated voice
@@ -1062,14 +1072,36 @@ def _compute_punctuation(combined: str, total_words: int) -> PunctuationHabits:
     )
 
 
+def _count_quotation_spans(text: str) -> int:
+    """Count source-quotation spans (quoted spans of at least 4 words).
+
+    The word-count floor (:data:`_MIN_QUOTE_WORDS`) filters dialogue tags,
+    scare quotes, and inline code, which are short quoted spans rather than
+    quoted source material.
+    """
+    return sum(
+        1
+        for span in _QUOTATION_SPAN_RE.findall(text)
+        if len(span.split()) >= _MIN_QUOTE_WORDS
+    )
+
+
 def _count_citation_signals(text: str) -> int:
     """Return the number of citation / quotation / reference signals in *text*.
 
-    Counts quotation spans, blockquote lines, attribution phrases, reference
-    markers (``[1]`` / author-year), and outbound source links.
+    Sums five independent signal families: source-quotation spans (see
+    :func:`_count_quotation_spans`), blockquote lines, attribution phrases,
+    reference markers (``[1]`` / author-year), and outbound source links.
+
+    The families are counted **independently and by design** — a single dense
+    construct (e.g. a blockquote that both attributes a source and links to it)
+    legitimately fires several counters, because layering quotation, attribution
+    and a link *is* denser citation behaviour than any one alone. The signal is
+    a soft voice-shaping rate, not an exact count, so this compounding is the
+    intended behaviour rather than double-counting to be deduplicated.
     """
     return (
-        len(_QUOTATION_SPAN_RE.findall(text))
+        _count_quotation_spans(text)
         + len(_BLOCKQUOTE_LINE_RE.findall(text))
         + len(_ATTRIBUTION_RE.findall(text))
         + len(_REFERENCE_MARKER_RE.findall(text))
@@ -1085,20 +1117,23 @@ def _compute_citation_density(
 
     Each text contributes its own per-1000-word citation rate, combined as a
     weighted mean using *weights* (per-fragment audience authority). A
-    ``None`` or wrong-length *weights* falls back to uniform weighting; a
-    non-positive total weight yields ``0.0``.
+    ``None`` or wrong-length *weights* falls back to uniform weighting;
+    negative weights are clamped to ``0.0``; a non-positive total weight
+    yields ``0.0``.
 
     Args:
         texts: Exemplar body texts.
-        weights: Per-text audience-authority weights, or ``None``.
+        weights: Per-text non-negative audience-authority weights, or ``None``.
 
     Returns:
         The weighted citation density (signals per ~1000 words).
     """
     if not texts:
         return 0.0
-    effective = weights if weights is not None and len(weights) == len(texts) else None
-    resolved = effective if effective is not None else [1.0] * len(texts)
+    if weights is None or len(weights) != len(texts):
+        resolved = [1.0] * len(texts)
+    else:
+        resolved = [max(0.0, weight) for weight in weights]
     total_weight = sum(resolved)
     if total_weight <= 0:
         return 0.0

--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -748,6 +748,25 @@ _ELLIPSIS_RE: re.Pattern[str] = re.compile(r"\.{3}|\u2026")
 _PARENTHETICAL_RE: re.Pattern[str] = re.compile(r"\([^)]+\)")
 _EXCLAMATION_RE: re.Pattern[str] = re.compile(r"!")
 
+# Citation / quotation / reference signals. Each matched span is one
+# "citation signal"; their per-1000-word rate is ``citation_density``.
+_QUOTATION_SPAN_RE: re.Pattern[str] = re.compile(r'"[^"\n]+"|\u201c[^\u201d\n]+\u201d')
+_BLOCKQUOTE_LINE_RE: re.Pattern[str] = re.compile(r"^\s*>", re.MULTILINE)
+_ATTRIBUTION_RE: re.Pattern[str] = re.compile(
+    r"\baccording to\b"
+    r"|\bas [^,.\n]{1,40}? (?:notes|writes|argues|observes|put it|puts it|said|says)\b"
+    r"|\bin [^,.\n]{1,30}?'s words\b",
+    re.IGNORECASE,
+)
+_REFERENCE_MARKER_RE: re.Pattern[str] = re.compile(
+    r"\[\d+\]|\([A-Z][A-Za-z.-]+(?: et al\.?)?,?\s+\d{4}[a-z]?\)",
+)
+_OUTBOUND_LINK_RE: re.Pattern[str] = re.compile(r"https?://\S+")
+
+_CITATION_PROMPT_THRESHOLD: float = 1.0
+"""Citation density (signals per 1000 words) above which the generated voice
+skill explicitly instructs the writer to reference and quote sources."""
+
 _SHORT_SENTENCE_MAX: int = 9
 """Sentences with at most this many words are classified as *short*."""
 
@@ -879,6 +898,9 @@ class VoicePatterns:
         rhetorical_moves: Self-deprecation, paradox, and callback counts.
         vocabulary: Vocabulary fingerprint (TF-IDF, coinages, phrases).
         punctuation: Punctuation habit frequencies.
+        citation_density: Citation / quotation / reference signals per ~1000
+            words, aggregated across the corpus weighted by each text's
+            audience authority. ``0.0`` when the corpus cites nothing.
     """
 
     sentence_metrics: SentenceMetrics
@@ -888,6 +910,7 @@ class VoicePatterns:
     rhetorical_moves: RhetoricalMoves
     vocabulary: VocabularyFingerprint
     punctuation: PunctuationHabits
+    citation_density: float = 0.0
 
 
 # ---- Sentence helpers ----
@@ -1039,6 +1062,55 @@ def _compute_punctuation(combined: str, total_words: int) -> PunctuationHabits:
     )
 
 
+def _count_citation_signals(text: str) -> int:
+    """Return the number of citation / quotation / reference signals in *text*.
+
+    Counts quotation spans, blockquote lines, attribution phrases, reference
+    markers (``[1]`` / author-year), and outbound source links.
+    """
+    return (
+        len(_QUOTATION_SPAN_RE.findall(text))
+        + len(_BLOCKQUOTE_LINE_RE.findall(text))
+        + len(_ATTRIBUTION_RE.findall(text))
+        + len(_REFERENCE_MARKER_RE.findall(text))
+        + len(_OUTBOUND_LINK_RE.findall(text))
+    )
+
+
+def _compute_citation_density(
+    texts: list[str],
+    weights: list[float] | None,
+) -> float:
+    """Return the audience-weighted citation density across *texts*.
+
+    Each text contributes its own per-1000-word citation rate, combined as a
+    weighted mean using *weights* (per-fragment audience authority). A
+    ``None`` or wrong-length *weights* falls back to uniform weighting; a
+    non-positive total weight yields ``0.0``.
+
+    Args:
+        texts: Exemplar body texts.
+        weights: Per-text audience-authority weights, or ``None``.
+
+    Returns:
+        The weighted citation density (signals per ~1000 words).
+    """
+    if not texts:
+        return 0.0
+    effective = weights if weights is not None and len(weights) == len(texts) else None
+    resolved = effective if effective is not None else [1.0] * len(texts)
+    total_weight = sum(resolved)
+    if total_weight <= 0:
+        return 0.0
+    accumulated = 0.0
+    for text, weight in zip(texts, resolved, strict=True):
+        density = _frequency_per_thousand(
+            _count_citation_signals(text), _count_words(text)
+        )
+        accumulated += weight * density
+    return accumulated / total_weight
+
+
 # ---- TF-IDF helpers ----
 
 
@@ -1141,11 +1213,19 @@ class VoicePatternExtractor:
             else None
         )
 
-    def extract_patterns(self, texts: list[str]) -> VoicePatterns:
+    def extract_patterns(
+        self,
+        texts: list[str],
+        *,
+        weights: list[float] | None = None,
+    ) -> VoicePatterns:
         """Extract all voice patterns from exemplar body texts.
 
         Args:
             texts: Body texts of voice exemplar fragments.
+            weights: Optional per-text audience-authority weights, parallel
+                to *texts*. Used only for ``citation_density`` so public-work
+                citation habits dominate; ``None`` weights every text equally.
 
         Returns:
             A :class:`VoicePatterns` containing every extracted metric.
@@ -1161,6 +1241,7 @@ class VoicePatternExtractor:
             rhetorical_moves=_compute_rhetorical_moves(combined),
             vocabulary=self.extract_vocabulary(texts),
             punctuation=_compute_punctuation(combined, total_words),
+            citation_density=_compute_citation_density(texts, weights),
         )
 
     def extract_metaphors(self, texts: list[str]) -> list[MetaphorFamily]:
@@ -1492,6 +1573,12 @@ def _build_voice_prompt(
     if patterns.metaphor_families:
         domains = ", ".join(f.domain for f in patterns.metaphor_families)
         lines.append(f"Metaphors surface from: {domains}.")
+    if patterns.citation_density >= _CITATION_PROMPT_THRESHOLD:
+        lines.append(
+            "Reference and quote your sources — you cite at roughly "
+            f"{patterns.citation_density:.1f} markers per 1000 words; "
+            "ground claims in attributed quotations and references.",
+        )
     moves = patterns.rhetorical_moves
     if moves.paradox_count > 0:
         lines.append("Use paradox constructions to hold tension without resolving it.")
@@ -1690,7 +1777,11 @@ class VoiceProfileGenerator:
                     continue
                 ranked = self._rank_exemplars(register_exemplars)
                 bodies = [e.body for e in ranked]
-                patterns = self._extractor.extract_patterns(bodies)
+                weights = [
+                    audience_authority(e.fragment, self._audience_weighting)
+                    for e in ranked
+                ]
+                patterns = self._extractor.extract_patterns(bodies, weights=weights)
                 profile = self.generate_profile(register, ranked, patterns)
                 written.append(self.write_profile(profile, vault_path))
                 # Drop the per-register working set before moving on so

--- a/creek-tools/tests/test_voice_citation_density.py
+++ b/creek-tools/tests/test_voice_citation_density.py
@@ -1,0 +1,143 @@
+"""Citation/quotation-density voice pattern, audience-weighted.
+
+The voice proxy learns the owner's habit of referencing and quoting sources.
+``VoicePatternExtractor`` measures a ``citation_density`` (signals per ~1000
+words) and aggregates it with the per-fragment audience-authority weight, so
+the heavy-citation habit of public work dominates over citation-light private
+writing. The generated voice skill surfaces the tendency.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from creek.generate.voice import (
+    Exemplar,
+    VoicePatternExtractor,
+    VoiceProfileGenerator,
+)
+from creek.models import (
+    Confidence,
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Mode,
+    Phase,
+    PrivacyTier,
+    SourcePlatform,
+    VoiceClassification,
+    VoiceRegister,
+    WavelengthClassification,
+)
+
+_CITATION_HEAVY = (
+    'According to Smith, the river "shapes the valley over time" [1]. '
+    "As Jones writes, geology is slow (Jones, 2023). See https://example.com/geo "
+    "for the dataset.\n> The current never argues; it simply persists.\n"
+    'In Darwin\'s words, "endless forms most beautiful" remain.'
+)
+_CITATION_LIGHT = (
+    "I went for a walk this morning and thought about the project. "
+    "It felt good to move and let the ideas settle on their own."
+)
+
+
+def test_no_citations_yields_zero_density() -> None:
+    """A corpus with no citation signals has zero citation density."""
+    patterns = VoicePatternExtractor().extract_patterns([_CITATION_LIGHT])
+    assert patterns.citation_density == 0.0
+
+
+def test_other_patterns_unaffected_by_citation_metric() -> None:
+    """Adding the citation metric does not disturb the other patterns."""
+    patterns = VoicePatternExtractor().extract_patterns([_CITATION_LIGHT])
+    # The existing metrics are still populated for a citation-free corpus.
+    assert patterns.sentence_metrics.total_sentences > 0
+    assert patterns.citation_density == 0.0
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        'He said "this is a quote" clearly.',
+        "> a blockquote line",
+        "According to Smith, this holds.",
+        "The result is robust [1].",
+        "Prior work shows it (Smith, 2023).",
+        "See https://example.com for details.",
+    ],
+)
+def test_each_citation_signal_registers(text: str) -> None:
+    """Each citation signal family produces a positive density."""
+    patterns = VoicePatternExtractor().extract_patterns([text + " " + "word " * 50])
+    assert patterns.citation_density > 0.0
+
+
+def test_citation_heavy_corpus_exceeds_light_corpus() -> None:
+    """Citation-heavy public work yields a higher density than light work."""
+    heavy = VoicePatternExtractor().extract_patterns([_CITATION_HEAVY])
+    light = VoicePatternExtractor().extract_patterns([_CITATION_LIGHT])
+    assert heavy.citation_density > light.citation_density
+    assert light.citation_density == 0.0
+
+
+def test_audience_weighting_lifts_public_citation_signal() -> None:
+    """Weighting toward the citation-heavy public text raises the aggregate."""
+    texts = [_CITATION_HEAVY, _CITATION_LIGHT]
+    extractor = VoicePatternExtractor()
+    uniform = extractor.extract_patterns(texts)
+    # The public (citation-heavy) text carries more authority weight.
+    weighted = extractor.extract_patterns(texts, weights=[1.5, 1.0])
+    assert weighted.citation_density > uniform.citation_density
+
+
+def test_zero_weights_fall_back_to_zero_density() -> None:
+    """All-zero weights yield a safe zero density (no division by zero)."""
+    patterns = VoicePatternExtractor().extract_patterns(
+        [_CITATION_HEAVY],
+        weights=[0.0],
+    )
+    assert patterns.citation_density == 0.0
+
+
+def test_mismatched_weights_fall_back_to_uniform() -> None:
+    """A weights list of the wrong length falls back to uniform weighting."""
+    texts = [_CITATION_HEAVY, _CITATION_LIGHT]
+    extractor = VoicePatternExtractor()
+    uniform = extractor.extract_patterns(texts)
+    mismatched = extractor.extract_patterns(texts, weights=[1.0])
+    assert mismatched.citation_density == uniform.citation_density
+
+
+def _citation_fragment(frag_id: str, privacy: PrivacyTier) -> Fragment:
+    """Build a fully-classified analytical fragment at the given privacy tier."""
+    return Fragment(
+        id=frag_id,
+        title=frag_id,
+        source=FragmentSource(platform=SourcePlatform.ESSAY),
+        frequency=FrequencyClassification(primary=Frequency.F5),
+        wavelength=WavelengthClassification(phase=Phase.RISING, mode=Mode.EXPRESS),
+        voice=VoiceClassification(
+            voice_register=VoiceRegister.ANALYTICAL,
+            confidence=Confidence.CONVICTION,
+        ),
+        privacy_tier=privacy,
+    )
+
+
+def test_generated_skill_surfaces_citation_habit() -> None:
+    """The generated voice prompt mentions the owner's citation tendency."""
+    generator = VoiceProfileGenerator(max_exemplars=5, min_exemplars=1)
+    body = _CITATION_HEAVY + "\n\n" + "word " * 250
+    exemplars = [
+        Exemplar(fragment=_citation_fragment("frag-open", PrivacyTier.OPEN), body=body),
+    ]
+    patterns = VoicePatternExtractor().extract_patterns([body])
+    profile = generator.generate_profile(
+        VoiceRegister.ANALYTICAL.value,
+        exemplars,
+        patterns,
+    )
+    lowered = profile.voice_prompt.lower()
+    assert "cite" in lowered or "reference" in lowered or "quote" in lowered

--- a/creek-tools/tests/test_voice_citation_density.py
+++ b/creek-tools/tests/test_voice_citation_density.py
@@ -9,12 +9,15 @@ writing. The generated voice skill surfaces the tendency.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+import frontmatter
 import pytest
 
 from creek.generate.voice import (
-    Exemplar,
     VoicePatternExtractor,
     VoiceProfileGenerator,
+    _count_citation_signals,
 )
 from creek.models import (
     Confidence,
@@ -30,6 +33,9 @@ from creek.models import (
     VoiceRegister,
     WavelengthClassification,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 _CITATION_HEAVY = (
     'According to Smith, the river "shapes the valley over time" [1]. '
@@ -92,7 +98,7 @@ def test_audience_weighting_lifts_public_citation_signal() -> None:
     assert weighted.citation_density > uniform.citation_density
 
 
-def test_zero_weights_fall_back_to_zero_density() -> None:
+def test_all_zero_weights_yield_zero_density() -> None:
     """All-zero weights yield a safe zero density (no division by zero)."""
     patterns = VoicePatternExtractor().extract_patterns(
         [_CITATION_HEAVY],
@@ -108,6 +114,35 @@ def test_mismatched_weights_fall_back_to_uniform() -> None:
     uniform = extractor.extract_patterns(texts)
     mismatched = extractor.extract_patterns(texts, weights=[1.0])
     assert mismatched.citation_density == uniform.citation_density
+
+
+def test_negative_weights_are_clamped() -> None:
+    """A negative weight is clamped to 0, never producing a sub-zero density."""
+    patterns = VoicePatternExtractor().extract_patterns(
+        [_CITATION_HEAVY, _CITATION_LIGHT],
+        weights=[-5.0, 1.0],
+    )
+    # The citation-heavy text is clamped out; only the light text remains.
+    assert patterns.citation_density == 0.0
+
+
+def test_dialogue_and_scare_quotes_are_not_citations() -> None:
+    """Short quoted spans (dialogue, scare quotes) do not count as citations."""
+    prose = (
+        '"I\'ll be back," he said, choosing the "obvious" path. '
+        'She ran it with "--verbose" and moved on. ' + "word " * 40
+    )
+    patterns = VoicePatternExtractor().extract_patterns([prose])
+    assert patterns.citation_density == 0.0
+
+
+def test_overlapping_signals_compound_by_design() -> None:
+    """A dense line that quotes, attributes, and links fires every counter."""
+    # Blockquote + attribution ("according to") + outbound link on one line.
+    layered = "> According to Smith, see https://example.com/data"
+    assert _count_citation_signals(layered) == 3
+    # A plain blockquote with none of the other families fires only once.
+    assert _count_citation_signals("> just a quoted thought here") == 1
 
 
 def _citation_fragment(frag_id: str, privacy: PrivacyTier) -> Fragment:
@@ -126,18 +161,31 @@ def _citation_fragment(frag_id: str, privacy: PrivacyTier) -> Fragment:
     )
 
 
-def test_generated_skill_surfaces_citation_habit() -> None:
-    """The generated voice prompt mentions the owner's citation tendency."""
-    generator = VoiceProfileGenerator(max_exemplars=5, min_exemplars=1)
+def _write_fragment(vault: Path, fragment: Fragment, *, body: str) -> None:
+    """Persist *fragment* with *body* under ``01-Fragments/Writing``."""
+    target = vault / "01-Fragments" / "Writing" / f"{fragment.id}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(content=body, **fragment.model_dump(mode="json"))
+    target.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+def test_generated_skill_surfaces_citation_via_weighted_path(tmp_path: Path) -> None:
+    """The full weighted ``generate_all_profiles`` path surfaces the habit.
+
+    This exercises the production path (``extract_patterns(bodies,
+    weights=...)``) rather than an unweighted call, so the audience-weighted
+    feature is covered end-to-end at the prompt level.
+    """
+    vault = tmp_path / "vault"
     body = _CITATION_HEAVY + "\n\n" + "word " * 250
-    exemplars = [
-        Exemplar(fragment=_citation_fragment("frag-open", PrivacyTier.OPEN), body=body),
-    ]
-    patterns = VoicePatternExtractor().extract_patterns([body])
-    profile = generator.generate_profile(
-        VoiceRegister.ANALYTICAL.value,
-        exemplars,
-        patterns,
+    _write_fragment(
+        vault,
+        _citation_fragment("frag-open", PrivacyTier.OPEN),
+        body=body,
     )
-    lowered = profile.voice_prompt.lower()
-    assert "cite" in lowered or "reference" in lowered or "quote" in lowered
+
+    generator = VoiceProfileGenerator(max_exemplars=5, min_exemplars=1)
+    written = generator.generate_all_profiles(vault)
+
+    rendered = "\n".join(path.read_text(encoding="utf-8") for path in written).lower()
+    assert "cite" in rendered or "reference" in rendered or "quote" in rendered


### PR DESCRIPTION
## Summary

- **New `citation_density` voice pattern.** `VoicePatternExtractor` now measures the owner's referencing/quoting habit — quotation spans, blockquote lines, attribution phrases ("according to", "as X writes/argues"), reference markers (`[1]` / author-year), and outbound source links — normalized per ~1000 words and added to `VoicePatterns` (default `0.0`, additive).
- **Audience-weighted aggregation.** `extract_patterns(texts, *, weights=None)` combines per-text densities as a weighted mean; `VoiceProfileGenerator` passes each exemplar's `audience_authority` (from #554), so citation-heavy **public (OPEN)** work dominates the signal over citation-light private writing. Wrong-length/`None` weights → uniform; non-positive total → `0.0` (no division by zero).
- **Surfaced in the generated voice skill:** above a threshold the voice prompt instructs "Reference and quote your sources — you cite at roughly N markers per 1000 words…".

## Constraints honored

- **Scope fence:** detection + surfacing only — no citation insertion into drafts, no de-slop rule. Reuses #554's `audience_authority` (not re-derived).
- **Tracer invariant:** a corpus with no citations yields `citation_density == 0.0` and changes nothing else about the existing pattern output (181-test voice suite stays green).

## Test plan

- New `tests/test_voice_citation_density.py` (13 tests): zero density for citation-free text; each signal family (quote span, blockquote, attribution, `[1]`, author-year, URL) registers; citation-heavy > citation-light; **audience weighting** lifts the public citation signal above the uniform aggregate; zero-weights and mismatched-weights fallbacks; other patterns unaffected; the generated voice prompt surfaces the citation habit.
- `cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (coverage ≥90% incl. changed lines, mypy strict, ruff/refurb/tryceratops/interrogate/complexity clean).

Closes #555
Refs #551
