### PR TITLE
fix(voice): make the de-slop pass faithful and loud on the real draft path

### DIFF
--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -16,7 +16,7 @@ from typing import Literal
 from zoneinfo import ZoneInfo
 
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 logger = logging.getLogger(__name__)
@@ -898,6 +898,15 @@ class AIStyleConfig(BaseModel):
     1.0 because ``voice_distance`` is always ``< 1.0``; a higher threshold
     would silently disable the check."""
 
+    voice_distance_target: float = Field(default=0.25, ge=0.0, le=1.0)
+    """Target distance the de-slop rewrite loop drives toward — distinct from
+    the accepted-divergence ceiling :attr:`voice_distance_upper`. The loop
+    keeps rewriting while distance exceeds this target (up to
+    :attr:`max_revision_passes`), so a mannered draft below the permissive
+    ceiling is still stripped rather than merely measured. Clamped to
+    ``voice_distance_upper`` when configured above it (the target never exceeds
+    the ceiling), so lowering the ceiling reproduces the pre-target behaviour."""
+
     default_margin: float = Field(default=0.5, ge=0.0)
     """Default divergence margin, in absolute rate units, a feature must
     exceed before it produces a :class:`~creek.generate.ai_style.model.Finding`.
@@ -1006,6 +1015,18 @@ class AIStyleConfig(BaseModel):
             if key == category:
                 return weight
         return 1.0
+
+    @model_validator(mode="after")
+    def _clamp_target_to_ceiling(self) -> "AIStyleConfig":
+        """Keep ``voice_distance_target`` at or below ``voice_distance_upper``.
+
+        Clamping (rather than rejecting) means a config that lowers the ceiling
+        below the default target reproduces the pre-target behaviour — the loop
+        simply drives to the ceiling — instead of raising a validation error.
+        """
+        if self.voice_distance_target > self.voice_distance_upper:
+            self.voice_distance_target = self.voice_distance_upper
+        return self
 
 
 class LintConfig(BaseModel):

--- a/creek-tools/creek/generate/ai_style/guard.py
+++ b/creek-tools/creek/generate/ai_style/guard.py
@@ -59,6 +59,16 @@ VOICE_DISTANCE_KEY = "voice_distance"
 VOICE_FINDINGS_KEY = "voice_findings"
 """Frontmatter key for the residual per-finding list."""
 
+VOICE_GUARD_STATUS_KEY = "voice_guard_status"
+"""Frontmatter key for the machine-readable guard outcome.
+
+Always present once the guard (or its draft-path caller) has run, so a draft
+never carries silently-unchanged prose without a recorded reason. Values:
+``skipped:disabled`` / ``skipped:no_fingerprint`` / ``skipped:thin_fingerprint``
+(the draft-path skip reasons), ``measured_only:no_llm`` /
+``measured_only:no_rewriter`` / ``measured_only:below_target`` /
+``measured_only:above_target`` (ran but did not rewrite), and ``rewritten``."""
+
 
 class VoiceFindingEntry(TypedDict):
     """Frontmatter shape for one residual voice-fidelity finding.
@@ -101,6 +111,8 @@ class VoiceFidelityReport:
             configured minimum and the distance was softened accordingly.
         passes: How many rewrite passes were actually attempted (``0`` when
             the draft was already within bounds, ``no_llm``, or disabled).
+        status: The machine-readable guard outcome stamped on the draft
+            (see :data:`VOICE_GUARD_STATUS_KEY`) — never silently empty.
     """
 
     body: str
@@ -108,6 +120,7 @@ class VoiceFidelityReport:
     findings: tuple[Finding, ...]
     thin_fingerprint: bool
     passes: int
+    status: str
 
     def summary_line(self) -> str:
         """Return the stderr one-liner ``creek draft`` prints after composing.
@@ -118,8 +131,8 @@ class VoiceFidelityReport:
         count = len(self.findings)
         noun = "divergence" if count == 1 else "divergences"
         return (
-            f"voice-fidelity: distance {self.voice_distance:.2f} "
-            f"({count} residual {noun}) — see frontmatter"
+            f"voice-fidelity: {self.status} — distance "
+            f"{self.voice_distance:.2f} ({count} residual {noun}) — see frontmatter"
         )
 
     def to_frontmatter(self) -> dict[str, object]:
@@ -127,6 +140,7 @@ class VoiceFidelityReport:
         return build_voice_fidelity_frontmatter(
             voice_distance=self.voice_distance,
             findings=self.findings,
+            status=self.status,
         )
 
 
@@ -150,17 +164,22 @@ def build_voice_fidelity_frontmatter(
     *,
     voice_distance: float | None,
     findings: Sequence[Finding],
+    status: str | None = None,
 ) -> dict[str, object]:
     """Build the partial frontmatter payload for voice-fidelity fields.
 
     Single source of truth for how the guard's fields appear on disk.
     ``None`` distance and an empty findings sequence are skipped so a draft
-    saved without the guard never grows misleading zero-value fields.
+    saved without the guard never grows misleading zero-value fields. The
+    *status*, when given, is always recorded — a guarded draft never lacks a
+    machine-readable outcome.
 
     Args:
         voice_distance: The final scalar distance, or ``None`` when the guard
             did not run.
         findings: The residual findings (empty sequence when none).
+        status: The machine-readable guard outcome (see
+            :data:`VOICE_GUARD_STATUS_KEY`), or ``None`` to omit.
 
     Returns:
         A dict carrying only the populated keys, for the caller to merge.
@@ -170,6 +189,8 @@ def build_voice_fidelity_frontmatter(
         payload[VOICE_DISTANCE_KEY] = round(voice_distance, 4)
     if findings:
         payload[VOICE_FINDINGS_KEY] = [_finding_entry(f) for f in findings]
+    if status is not None:
+        payload[VOICE_GUARD_STATUS_KEY] = status
     return payload
 
 
@@ -238,7 +259,7 @@ def _revise_toward_voice(
     """
     passes = 0
     while (
-        best.report.voice_distance > config.voice_distance_upper
+        best.report.voice_distance > config.voice_distance_target
         and passes < config.max_revision_passes
     ):
         passes += 1
@@ -255,6 +276,38 @@ def _revise_toward_voice(
             break
         best = _Candidate(candidate_body, candidate_report)
     return best, passes
+
+
+def _guard_status(
+    *,
+    passes: int,
+    no_llm: bool,
+    has_llm: bool,
+    distance: float,
+    target: float,
+) -> str:
+    """Return the machine-readable guard outcome for a draft that was scanned.
+
+    Args:
+        passes: Rewrite passes actually applied.
+        no_llm: Whether the rewrite hop was suppressed (``--no-llm``).
+        has_llm: Whether a rewrite LLM was supplied.
+        distance: The final measured voice distance.
+        target: The de-slop target the rewrite loop drives toward.
+
+    Returns:
+        ``rewritten`` when a pass was applied, otherwise a ``measured_only:*``
+        reason explaining why no rewrite occurred.
+    """
+    if passes > 0:
+        return "rewritten"
+    if no_llm:
+        return "measured_only:no_llm"
+    if not has_llm:
+        return "measured_only:no_rewriter"
+    if distance <= target:
+        return "measured_only:below_target"
+    return "measured_only:above_target"
 
 
 def run_voice_fidelity_guard(
@@ -292,6 +345,7 @@ def run_voice_fidelity_guard(
             findings=(),
             thin_fingerprint=False,
             passes=0,
+            status="skipped:disabled",
         )
     sanitized = sanitize(body, fingerprint=fingerprint, config=config)
     report = scan(sanitized, fingerprint=fingerprint, config=config, context=context)
@@ -313,4 +367,11 @@ def run_voice_fidelity_guard(
         findings=tuple(best.report.findings),
         thin_fingerprint=best.report.thin_fingerprint,
         passes=passes,
+        status=_guard_status(
+            passes=passes,
+            no_llm=no_llm,
+            has_llm=llm is not None,
+            distance=best.report.voice_distance,
+            target=config.voice_distance_target,
+        ),
     )

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -39,7 +39,10 @@ from creek.classify.privacy_filter import (
     PrivacyTierOverride,
     filter_fragments_by_tier,
 )
-from creek.generate.ai_style.guard import run_voice_fidelity_guard
+from creek.generate.ai_style.guard import (
+    VOICE_GUARD_STATUS_KEY,
+    run_voice_fidelity_guard,
+)
 from creek.generate.cohesion import run_cohesion_pass
 from creek.generate.compile_routing import (
     CompiledPageIndex,
@@ -2111,6 +2114,23 @@ class DraftGenerator:
 
         return _still_grounded
 
+    @staticmethod
+    def _skipped_voice_guard(
+        body: str,
+        reason: str,
+    ) -> tuple[str, dict[str, object]]:
+        """Report a skipped de-slop pass loudly and stamp its reason.
+
+        Args:
+            body: The unchanged draft body.
+            reason: A ``skipped:*`` :data:`VOICE_GUARD_STATUS_KEY` value.
+
+        Returns:
+            The unchanged *body* and a frontmatter payload carrying the reason.
+        """
+        print(f"voice-fidelity: skipped — {reason}", file=sys.stderr)
+        return body, {VOICE_GUARD_STATUS_KEY: reason}
+
     def _apply_voice_fidelity(
         self,
         body: str,
@@ -2120,16 +2140,21 @@ class DraftGenerator:
     ) -> tuple[str, dict[str, object]]:
         """Run the voice-fidelity guard, returning ``(body, frontmatter)``.
 
-        A no-op (returns *body* unchanged and an empty payload) when the
-        fingerprint or AI-style config is absent or the subsystem is
-        disabled. Otherwise sanitizes, measures, and bounded-rewrites *body*
-        toward the user's voice, prints the guard's summary to stderr, and
-        returns the guarded body plus its frontmatter fields.
+        Never a *silent* no-op: when the subsystem is disabled or the
+        fingerprint is absent / thin, the body is returned unchanged but a
+        loud ``voice_guard_status`` reason is stamped on the frontmatter and
+        echoed to stderr. Otherwise it sanitizes, measures, and bounded-
+        rewrites *body* toward the user's voice and returns the guarded body
+        plus its frontmatter fields (which always carry a status).
         """
         config = self._ai_style_config
         fingerprint = self._fingerprint
-        if config is None or fingerprint is None or not config.enabled:
-            return body, {}
+        if config is None or not config.enabled:
+            return self._skipped_voice_guard(body, "skipped:disabled")
+        if fingerprint is None or fingerprint.fragment_count == 0:
+            return self._skipped_voice_guard(body, "skipped:no_fingerprint")
+        if fingerprint.is_thin(config.min_fingerprint_fragments):
+            return self._skipped_voice_guard(body, "skipped:thin_fingerprint")
         report = run_voice_fidelity_guard(
             body,
             fingerprint=fingerprint,

--- a/creek-tools/creek/generate/voice_authenticity.py
+++ b/creek-tools/creek/generate/voice_authenticity.py
@@ -112,12 +112,15 @@ class DeslopStatus:
 
     Attributes:
         draft: The drafted-essay path that was probed.
-        attested: Whether a ``voice_distance`` attestation is present (the
-            AI-mannerism guard ran and recorded a result).
-        voice_distance: The recorded distance, or ``None`` when unattested.
+        attested: Whether the AI-mannerism guard left any outcome on the
+            draft — a ``voice_guard_status`` and/or a measured ``voice_distance``
+            (so a loud skip such as ``skipped:thin_fingerprint`` still attests).
+        voice_distance: The recorded distance, or ``None`` when none was
+            measured (e.g. a skip path).
         residual_findings: Count of recorded residual voice findings.
-        status: A human-readable reason. Stub wording until the faithful
-            de-slop pass adds the rewritten-vs-measured distinction.
+        status: The guard's recorded ``voice_guard_status`` (e.g. ``rewritten``,
+            ``measured_only:below_target``, ``skipped:thin_fingerprint``) when
+            present, otherwise a message noting no attestation was found.
     """
 
     draft: str

--- a/creek-tools/creek/generate/voice_authenticity.py
+++ b/creek-tools/creek/generate/voice_authenticity.py
@@ -38,7 +38,11 @@ from typing import TYPE_CHECKING
 import frontmatter
 
 from creek.config import VoiceAudienceWeightingConfig
-from creek.generate.ai_style.guard import VOICE_DISTANCE_KEY, VOICE_FINDINGS_KEY
+from creek.generate.ai_style.guard import (
+    VOICE_DISTANCE_KEY,
+    VOICE_FINDINGS_KEY,
+    VOICE_GUARD_STATUS_KEY,
+)
 from creek.models import Authorship, Fragment, PrivacyTier, SourcePlatform
 from creek.vault.reader import iter_vault_fragments
 
@@ -283,22 +287,25 @@ def _probe_deslop(draft_path: Path) -> DeslopStatus:
     """
     post = frontmatter.load(str(draft_path))
     raw_distance = post.metadata.get(VOICE_DISTANCE_KEY)
+    guard_status = post.metadata.get(VOICE_GUARD_STATUS_KEY)
     findings = post.metadata.get(VOICE_FINDINGS_KEY, [])
     residual = len(findings) if isinstance(findings, list) else 0
-    if not isinstance(raw_distance, (int, float)):
-        return DeslopStatus(
-            draft=str(draft_path),
-            attested=False,
-            voice_distance=None,
-            residual_findings=residual,
-            status="no voice-fidelity attestation in draft frontmatter",
-        )
+    distance = float(raw_distance) if isinstance(raw_distance, (int, float)) else None
+    # The guard attests by stamping a status (even on a loud skip) and/or a
+    # measured distance; either one means the de-slop pass ran on this draft.
+    attested = isinstance(guard_status, str) or distance is not None
+    if not attested:
+        status = "no voice-fidelity attestation in draft frontmatter"
+    elif isinstance(guard_status, str):
+        status = guard_status
+    else:
+        status = "attested (no guard status recorded)"
     return DeslopStatus(
         draft=str(draft_path),
-        attested=True,
-        voice_distance=float(raw_distance),
+        attested=attested,
+        voice_distance=distance,
         residual_findings=residual,
-        status="attested (rewritten-vs-measured detection not yet recorded)",
+        status=status,
     )
 
 

--- a/creek-tools/tests/generate/ai_style/test_guard.py
+++ b/creek-tools/tests/generate/ai_style/test_guard.py
@@ -203,16 +203,18 @@ def test_under_ceiling_skips_rewrite() -> None:
 
 
 def test_summary_line_wording() -> None:
-    """The stderr summary matches the documented contract wording."""
+    """The stderr summary names the status and the measured distance."""
     report = VoiceFidelityReport(
         body="x",
         voice_distance=0.22,
         findings=(),
         thin_fingerprint=False,
         passes=1,
+        status="rewritten",
     )
     assert report.summary_line() == (
-        "voice-fidelity: distance 0.22 (0 residual divergences) — see frontmatter"
+        "voice-fidelity: rewritten — distance 0.22 "
+        "(0 residual divergences) — see frontmatter"
     )
 
 

--- a/creek-tools/tests/test_voice_deslop_faithful.py
+++ b/creek-tools/tests/test_voice_deslop_faithful.py
@@ -130,6 +130,22 @@ def test_status_below_target() -> None:
     assert report.status == "measured_only:below_target"
 
 
+def test_status_above_target() -> None:
+    """A mannered draft with the rewrite loop disabled records above_target.
+
+    With ``max_revision_passes=0`` an LLM is present but never invoked, so a
+    draft still over the target is measured but not rewritten.
+    """
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(voice_distance_upper=0.001, max_revision_passes=0),
+        llm=_const_llm(_PLAIN),
+    )
+    assert report.passes == 0
+    assert report.status == "measured_only:above_target"
+
+
 def test_frontmatter_always_stamps_status() -> None:
     """``to_frontmatter`` always carries the guard status."""
     report = run_voice_fidelity_guard(

--- a/creek-tools/tests/test_voice_deslop_faithful.py
+++ b/creek-tools/tests/test_voice_deslop_faithful.py
@@ -1,0 +1,294 @@
+"""The de-slop voice-fidelity guard runs faithfully and loudly.
+
+Pins the contract: a distinct ``voice_distance_target`` drives the rewrite loop
+(so mannered drafts below the permissive ceiling are still stripped), every
+outcome stamps a machine-readable ``voice_guard_status`` (no silent no-ops),
+the real ``save_draft`` path strips planted tells, and the diagnostic surfaces
+the recorded status.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.config import AIStyleConfig
+from creek.generate.ai_style.guard import (
+    VOICE_GUARD_STATUS_KEY,
+    run_voice_fidelity_guard,
+)
+from creek.generate.ai_style.model import FeatureStat, VoiceFingerprint
+from creek.generate.drafts import Draft, DraftGenerator
+from creek.generate.voice_authenticity import build_voice_authenticity_report
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+_TROPEY = (
+    "Additionally, this delves into the rich tapestry of the subject. "
+    "Moreover, it is important to note the vibrant and multifaceted nuances. "
+    "Furthermore, the landscape stands as a testament to its significance."
+)
+_PLAIN = "The cat sat by the window. Rain fell on the roof. I made tea and read."
+
+
+def _fingerprint(*, fragments: int = 20) -> VoiceFingerprint:
+    """A non-thin fingerprint whose measured rates are all ~zero."""
+    return VoiceFingerprint(
+        features={"em_dash_density": FeatureStat(rate=0.0, support=fragments)},
+        fragment_count=fragments,
+    )
+
+
+def _const_llm(text: str) -> Callable[[str], str]:
+    """An LLM stub that returns *text* for any prompt."""
+    return lambda _prompt: text
+
+
+# --- config: voice_distance_target ------------------------------------------
+
+
+def test_target_defaults_below_ceiling() -> None:
+    """The default target is distinct from and below the accepted ceiling."""
+    config = AIStyleConfig()
+    assert config.voice_distance_target == 0.25
+    assert config.voice_distance_target < config.voice_distance_upper
+
+
+def test_target_clamped_to_ceiling() -> None:
+    """A ceiling below the default target clamps the target down to it."""
+    config = AIStyleConfig(voice_distance_upper=0.1)
+    assert config.voice_distance_target == 0.1
+
+
+def test_explicit_target_below_ceiling_is_preserved() -> None:
+    """An explicit target at or below the ceiling is kept as-is."""
+    config = AIStyleConfig(voice_distance_upper=0.4, voice_distance_target=0.3)
+    assert config.voice_distance_target == 0.3
+
+
+# --- guard status -----------------------------------------------------------
+
+
+def test_status_rewritten() -> None:
+    """A rewrite pass records ``rewritten``."""
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(voice_distance_upper=0.001),
+        llm=_const_llm(_PLAIN),
+    )
+    assert report.passes == 1
+    assert report.status == "rewritten"
+
+
+def test_status_no_llm() -> None:
+    """Measure-only mode records ``measured_only:no_llm``."""
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(voice_distance_upper=0.001),
+        llm=_const_llm(_PLAIN),
+        no_llm=True,
+    )
+    assert report.status == "measured_only:no_llm"
+
+
+def test_status_no_rewriter() -> None:
+    """A missing rewrite LLM records ``measured_only:no_rewriter``."""
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(voice_distance_upper=0.001),
+        llm=None,
+    )
+    assert report.status == "measured_only:no_rewriter"
+
+
+def test_status_disabled() -> None:
+    """A disabled subsystem records ``skipped:disabled``."""
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(enabled=False),
+    )
+    assert report.status == "skipped:disabled"
+
+
+def test_status_below_target() -> None:
+    """A clean draft already within target records ``measured_only:below_target``."""
+    report = run_voice_fidelity_guard(
+        _PLAIN,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(),
+        llm=_const_llm(_PLAIN),
+    )
+    assert report.passes == 0
+    assert report.status == "measured_only:below_target"
+
+
+def test_frontmatter_always_stamps_status() -> None:
+    """``to_frontmatter`` always carries the guard status."""
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(voice_distance_upper=0.001),
+        llm=_const_llm(_PLAIN),
+    )
+    assert report.to_frontmatter()[VOICE_GUARD_STATUS_KEY] == "rewritten"
+
+
+def test_target_drives_rewrite_below_ceiling() -> None:
+    """A draft below the permissive ceiling is still rewritten toward target.
+
+    With a high ceiling but a low target, a mannered draft whose distance sits
+    between the two is now stripped — the rewrite loop is gated on the target,
+    not the ceiling (the pre-target behaviour would have left it merely measured).
+    """
+    report = run_voice_fidelity_guard(
+        _TROPEY,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(voice_distance_upper=0.9, voice_distance_target=0.01),
+        llm=_const_llm(_PLAIN),
+    )
+    assert report.passes == 1
+    assert report.status == "rewritten"
+    assert "tapestry" not in report.body
+
+
+# --- draft-path skip reasons (loud, never silent) ---------------------------
+
+
+def _generator(
+    tmp_path: Path,
+    *,
+    fingerprint: VoiceFingerprint | None,
+    config: AIStyleConfig | None,
+) -> DraftGenerator:
+    """Build a DraftGenerator with the given voice-guard wiring."""
+    return DraftGenerator(
+        llm=_const_llm(_PLAIN),
+        skills_root=tmp_path / "skills",
+        fingerprint=fingerprint,
+        ai_style_config=config,
+    )
+
+
+def test_apply_voice_fidelity_skipped_disabled(tmp_path: Path) -> None:
+    """A disabled subsystem yields a loud ``skipped:disabled`` status."""
+    gen = _generator(
+        tmp_path,
+        fingerprint=_fingerprint(),
+        config=AIStyleConfig(enabled=False),
+    )
+    _body, fields = gen._apply_voice_fidelity(
+        _TROPEY,
+        vault_path=tmp_path,
+        source_fragments=(),
+    )
+    assert fields[VOICE_GUARD_STATUS_KEY] == "skipped:disabled"
+
+
+def test_apply_voice_fidelity_skipped_no_fingerprint(tmp_path: Path) -> None:
+    """A missing fingerprint yields a loud ``skipped:no_fingerprint`` status."""
+    gen = _generator(tmp_path, fingerprint=None, config=AIStyleConfig())
+    _body, fields = gen._apply_voice_fidelity(
+        _TROPEY,
+        vault_path=tmp_path,
+        source_fragments=(),
+    )
+    assert fields[VOICE_GUARD_STATUS_KEY] == "skipped:no_fingerprint"
+
+
+def test_apply_voice_fidelity_skipped_thin(tmp_path: Path) -> None:
+    """A thin fingerprint is reported, never silently swallowed."""
+    gen = _generator(
+        tmp_path,
+        fingerprint=_fingerprint(fragments=1),
+        config=AIStyleConfig(),
+    )
+    _body, fields = gen._apply_voice_fidelity(
+        _TROPEY,
+        vault_path=tmp_path,
+        source_fragments=(),
+    )
+    assert fields[VOICE_GUARD_STATUS_KEY] == "skipped:thin_fingerprint"
+
+
+# --- integration: real save_draft path --------------------------------------
+
+
+def _draft(body: str) -> Draft:
+    """Build a minimal Draft carrying *body*."""
+    return Draft(
+        title="Tells on parade",
+        body=body,
+        idea_strategy="thread_terminus",
+        source_fragments=(),
+        threads=(),
+        eddies=(),
+        skill_stack=(),
+        prompt="prompt",
+        generated_date=datetime(2026, 6, 6, 12, 0, tzinfo=UTC),
+    )
+
+
+def test_real_save_draft_strips_planted_tells(tmp_path: Path) -> None:
+    """An essay seeded with tells comes out of save_draft with them removed."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    gen = DraftGenerator(
+        llm=_const_llm(_PLAIN),
+        skills_root=tmp_path / "skills",
+        fingerprint=_fingerprint(),
+        ai_style_config=AIStyleConfig(voice_distance_upper=0.001),
+    )
+
+    path = gen.save_draft(_draft(_TROPEY), vault)
+    text = path.read_text(encoding="utf-8")
+
+    assert "rich tapestry" not in text
+    assert "delve" not in text
+    post = frontmatter.loads(text)
+    assert post[VOICE_GUARD_STATUS_KEY] == "rewritten"
+
+
+# --- diagnostic surfacing ---------------------------------------------------
+
+
+def test_diagnostic_surfaces_guard_status(tmp_path: Path) -> None:
+    """The voice-authenticity ``deslop.status`` reflects the recorded status."""
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    draft = tmp_path / "draft.md"
+    post = frontmatter.Post(
+        "Body.",
+        **{VOICE_GUARD_STATUS_KEY: "rewritten", "voice_distance": 0.12},
+    )
+    draft.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    report = build_voice_authenticity_report(vault, draft_path=draft)
+
+    assert report.deslop is not None
+    assert report.deslop.attested is True
+    assert report.deslop.status == "rewritten"
+
+
+def test_diagnostic_surfaces_skip_status(tmp_path: Path) -> None:
+    """A skipped guard is still attested in the diagnostic, never swallowed."""
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    draft = tmp_path / "draft.md"
+    post = frontmatter.Post(
+        "Body.", **{VOICE_GUARD_STATUS_KEY: "skipped:thin_fingerprint"}
+    )
+    draft.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    deslop = build_voice_authenticity_report(vault, draft_path=draft).deslop
+
+    assert deslop is not None
+    assert deslop.attested is True
+    assert deslop.status == "skipped:thin_fingerprint"


### PR DESCRIPTION
## Summary

Make the final AI-mannerism de-slop guard **execute faithfully and loudly** on the real draft path. Previously it could silently no-op (thin/absent fingerprint or disabled config → `return body, {}`) and only rewrote above the permissive `voice_distance_upper=0.35` ceiling — so a mannered draft was measured and stamped but never stripped.

- **Distinct de-slop target.** New `AIStyleConfig.voice_distance_target` (default `0.25`) drives the rewrite loop, which now continues while distance exceeds the *target* rather than only firing above the *ceiling*. A `model_validator` **clamps** the target to `voice_distance_upper` (never raises), so any config that lowers the ceiling reproduces the pre-change behaviour and no existing config/test breaks.
- **No silent no-ops.** Every outcome stamps a machine-readable `voice_guard_status` on the draft frontmatter and echoes it to stderr:
  - draft-path skips (now loud): `skipped:disabled`, `skipped:no_fingerprint`, `skipped:thin_fingerprint`;
  - guard ran: `measured_only:no_llm` / `:no_rewriter` / `:below_target` / `:above_target`, or `rewritten`.
- **Diagnostic wired through.** The voice-authenticity `deslop.status` now reflects the recorded `voice_guard_status` and treats it as attestation.

## Constraints honored

- **Scope fence:** no change to the distance metric / scanner internals or the tell catalog — only faithful execution + observability.
- **Determinism invariant:** `--no-llm` still sanitizes + scans + stamps a status and performs no LLM rewrite.

## Test plan

- New `tests/test_voice_deslop_faithful.py` (16 tests): target default/clamp/preserve; guard status for every branch (rewritten / no_llm / no_rewriter / disabled / below_target); `to_frontmatter` always stamps the status; **target drives a rewrite below the permissive ceiling**; the three draft-path skip reasons via `_apply_voice_fidelity` (incl. thin fingerprint reported, never swallowed); an **integration test on the real `save_draft` path** proving planted tells ("rich tapestry", "delve") are removed and `voice_guard_status == rewritten`; and the diagnostic surfacing the recorded status (rewritten and skip).
- Updated `test_guard.py`'s summary-line wording test for the louder status-bearing line.
- `cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (coverage ≥90% incl. changed lines, mypy strict, ruff/refurb/tryceratops/interrogate/complexity clean).

Closes #556
Refs #551
