### PR TITLE
feat(ai-style): citation-integrity detectors (FEAT-040.11)

### DIFF
--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -794,13 +794,19 @@ create an import cycle, since ``ai_style`` imports this module. The
 
 
 def _default_enabled_categories() -> list[AIStyleCategory]:
-    """Return the default set of enabled tell categories (all five)."""
+    """Return the default enabled tell categories — the four *voice* families.
+
+    ``citation`` is intentionally excluded by default: citation-integrity tells
+    are voice-neutral (factual integrity, not idiolect), so mixing their
+    zero contributions into the scalar ``voice_distance`` would dilute the
+    idiolect signal. They register normally and are surfaced by enabling the
+    ``citation`` category explicitly (e.g. a "lint my draft" surface).
+    """
     categories: list[AIStyleCategory] = [
         "mechanical",
         "lexical",
         "rhetorical",
         "discourse",
-        "citation",
     ]
     return categories
 
@@ -897,6 +903,14 @@ class AIStyleConfig(BaseModel):
     user's voice enough to warrant a rewrite pass / lint finding. Capped at
     1.0 because ``voice_distance`` is always ``< 1.0``; a higher threshold
     would silently disable the check."""
+
+    citation_network_checks: bool = False
+    """Opt-in toggle for live external-link checking by the ``citation`` tells.
+
+    Off by default so the scanner is fully offline (ISBN/DOI checksum +
+    syntax only). When ``True``, a wired resolver may probe outbound links
+    (cached, rate-limited, timeout-bounded); documented false-positive hosts
+    (paywalls, libraries, the low-PMID artefact) are never reported."""
 
     voice_distance_target: float = Field(default=0.25, ge=0.0, le=1.0)
     """Target distance the de-slop rewrite loop drives toward — distinct from

--- a/creek-tools/creek/generate/ai_style/__init__.py
+++ b/creek-tools/creek/generate/ai_style/__init__.py
@@ -10,6 +10,15 @@ catalogs and add the sanitizer, prompt prevention, guard, and lint check.
 
 from __future__ import annotations
 
+from creek.generate.ai_style.citations import (
+    INVALID_DOI,
+    INVALID_ISBN,
+    PAGELESS_BOOK,
+    TRACKING_PARAM,
+    UNDEFINED_REF,
+    check_external_links,
+    extract_urls,
+)
 from creek.generate.ai_style.discourse import (
     CHALLENGES_SECTION,
     COMM_BOILERPLATE,
@@ -83,16 +92,21 @@ __all__ = [
     "COPULATIVE_AVOIDANCE",
     "DIDACTIC_DISCLAIMER",
     "FINGERPRINT_FEATURES",
+    "INVALID_DOI",
+    "INVALID_ISBN",
     "KNOWLEDGE_CUTOFF",
     "LIST_TITLE_LEAD",
     "NEGATIVE_PARALLELISM",
+    "PAGELESS_BOOK",
     "PEACOCK",
     "RULE_OF_THREE_PADDING",
     "SECTION_SUMMARY",
     "SIGNIFICANCE",
     "SUPERFICIAL_ING",
     "TELL_REGISTRY",
+    "TRACKING_PARAM",
     "TRANSITION_OPENER",
+    "UNDEFINED_REF",
     "VAGUE_ATTRIBUTION",
     "Category",
     "Direction",
@@ -108,6 +122,8 @@ __all__ = [
     "build_fingerprint",
     "build_style_preamble",
     "build_voice_fidelity_frontmatter",
+    "check_external_links",
+    "extract_urls",
     "extract_user_turns",
     "get_tells",
     "load_fingerprint",

--- a/creek-tools/creek/generate/ai_style/citations.py
+++ b/creek-tools/creek/generate/ai_style/citations.py
@@ -1,0 +1,330 @@
+"""Citation-integrity detectors (FEAT-040.11, category ``citation``).
+
+These tells are **voice-neutral**: they target factual-integrity failures the
+field guide's Citations section (WP:AIFICTREF) names — fabricated or broken
+references — rather than idiolect. They catch the most policy-dangerous LLM
+failure mode (hallucinated sources): invalid ISBN/DOI checksums, references to
+undefined footnotes, ``utm_source=chatgpt.com`` provenance tracking params, and
+book citations missing a page locator.
+
+Everything here is **detection only** — a fired tell surfaces a finding; it
+never rewrites or deletes a citation. All detectors are offline and
+deterministic. Live link-checking is opt-in and lives in
+:func:`check_external_links`, gated by config so the default path makes no
+network calls.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+from creek.generate.ai_style.model import Span
+from creek.generate.ai_style.tells import Tell, rate_per_kwords, register
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+# --- ISBN -------------------------------------------------------------------
+
+_ISBN_CANDIDATE_RE = re.compile(
+    r"\bISBN(?:-1[03])?:?\s*([0-9][0-9Xx\- ]{8,16}[0-9Xx])",
+)
+
+
+def _normalise_isbn(raw: str) -> str:
+    """Strip hyphens and spaces from a candidate ISBN string."""
+    return re.sub(r"[\- ]", "", raw)
+
+
+def _is_valid_isbn10(digits: str) -> bool:
+    """Return whether *digits* (length 10) is a checksum-valid ISBN-10."""
+    if len(digits) != 10:
+        return False
+    total = 0
+    for index, char in enumerate(digits):
+        if char in "Xx" and index == 9:
+            value = 10
+        elif char.isdigit():
+            value = int(char)
+        else:
+            return False
+        total += value * (10 - index)
+    return total % 11 == 0
+
+
+def _is_valid_isbn13(digits: str) -> bool:
+    """Return whether *digits* (length 13) is a checksum-valid ISBN-13."""
+    if len(digits) != 13 or not digits.isdigit():
+        return False
+    total = sum(
+        int(char) * (1 if index % 2 == 0 else 3) for index, char in enumerate(digits)
+    )
+    return total % 10 == 0
+
+
+def _is_valid_isbn(raw: str) -> bool:
+    """Return whether a normalised ISBN candidate passes its checksum."""
+    digits = _normalise_isbn(raw)
+    if len(digits) == 10:
+        return _is_valid_isbn10(digits)
+    if len(digits) == 13:
+        return _is_valid_isbn13(digits)
+    return False
+
+
+def _locate_invalid_isbn(text: str) -> list[Span]:
+    """Return spans of ISBNs whose checksum does not validate."""
+    return [
+        Span(match.start(), match.end())
+        for match in _ISBN_CANDIDATE_RE.finditer(text)
+        if not _is_valid_isbn(match.group(1))
+    ]
+
+
+def _measure_invalid_isbn(text: str) -> float:
+    """Return the per-1000-word rate of checksum-invalid ISBNs."""
+    return rate_per_kwords(len(_locate_invalid_isbn(text)), text)
+
+
+# --- DOI --------------------------------------------------------------------
+
+# A reference that announces itself as a DOI (``doi:`` prefix or a doi.org URL)
+# but whose body is not a syntactically valid DOI (``10.<registrant>/<suffix>``).
+_DOI_REFERENCE_RE = re.compile(
+    r"(?:doi:\s*|https?://(?:dx\.)?doi\.org/)(\S+)",
+    re.IGNORECASE,
+)
+_VALID_DOI_RE = re.compile(r"^10\.\d{4,9}/\S+$")
+
+
+def _locate_invalid_doi(text: str) -> list[Span]:
+    """Return spans of DOI references whose syntax is malformed."""
+    spans: list[Span] = []
+    for match in _DOI_REFERENCE_RE.finditer(text):
+        body = match.group(1).rstrip(".,;)")
+        if not _VALID_DOI_RE.match(body):
+            spans.append(Span(match.start(), match.end()))
+    return spans
+
+
+def _measure_invalid_doi(text: str) -> float:
+    """Return the per-1000-word rate of malformed DOI references."""
+    return rate_per_kwords(len(_locate_invalid_doi(text)), text)
+
+
+# --- Undefined / unused named references ------------------------------------
+
+_REF_DEFINITION_RE = re.compile(r"""<ref\s+name\s*=\s*["']([^"']+)["']\s*>""")
+_REF_USE_RE = re.compile(r"""<ref\s+name\s*=\s*["']([^"']+)["']\s*/>""")
+_CITE_ERROR_RE = re.compile(r"Cite error:[^\n]*", re.IGNORECASE)
+
+
+def _locate_undefined_ref(text: str) -> list[Span]:
+    """Return spans of self-closing ref uses naming an undefined ref.
+
+    A ``<ref name="x"/>`` use whose name is never defined by a
+    ``<ref name="x">…</ref>`` is the ``Cite error: … is not used`` family —
+    a hallucinated footnote. Literal ``Cite error:`` text is flagged too.
+    """
+    defined = {m.group(1) for m in _REF_DEFINITION_RE.finditer(text)}
+    spans = [
+        Span(m.start(), m.end())
+        for m in _REF_USE_RE.finditer(text)
+        if m.group(1) not in defined
+    ]
+    spans.extend(Span(m.start(), m.end()) for m in _CITE_ERROR_RE.finditer(text))
+    return spans
+
+
+def _measure_undefined_ref(text: str) -> float:
+    """Return the per-1000-word rate of undefined-reference uses."""
+    return rate_per_kwords(len(_locate_undefined_ref(text)), text)
+
+
+# --- Tracking-parameter provenance ------------------------------------------
+
+# ``utm_source=chatgpt.com`` (and the openai variant) left on a pasted URL is a
+# strong AI-involvement signal. Detection only — stripping lives in ingestion.
+_TRACKING_PARAM_RE = re.compile(
+    r"utm_source=(?:chatgpt\.com|openai\.com|chat\.openai\.com)",
+    re.IGNORECASE,
+)
+
+
+def _locate_tracking_param(text: str) -> list[Span]:
+    """Return spans of AI-provenance tracking parameters."""
+    return [Span(m.start(), m.end()) for m in _TRACKING_PARAM_RE.finditer(text)]
+
+
+def _measure_tracking_param(text: str) -> float:
+    """Return the per-1000-word rate of AI-provenance tracking params."""
+    return rate_per_kwords(len(_locate_tracking_param(text)), text)
+
+
+# --- Page-less book citations -----------------------------------------------
+
+_PAGE_LOCATOR_RE = re.compile(r"\bp{1,2}\.?\s*\d|\bpages?\b", re.IGNORECASE)
+
+
+def _locate_pageless_book(text: str) -> list[Span]:
+    """Return spans of book citations (ISBN-bearing lines) lacking a page.
+
+    A line carrying a valid ISBN but no page locator (``p.``/``pp.``/``page``)
+    is a general-topic book citation with no verifiable locator. Surfaced, not
+    failed: some citations legitimately omit pages.
+    """
+    spans: list[Span] = []
+    offset = 0
+    for line in text.splitlines(keepends=True):
+        if _ISBN_CANDIDATE_RE.search(line) and not _PAGE_LOCATOR_RE.search(line):
+            stripped = line.rstrip("\n")
+            spans.append(Span(offset, offset + len(stripped)))
+        offset += len(line)
+    return spans
+
+
+def _measure_pageless_book(text: str) -> float:
+    """Return the per-1000-word rate of page-less book citations."""
+    return rate_per_kwords(len(_locate_pageless_book(text)), text)
+
+
+# --- Tell registration ------------------------------------------------------
+
+INVALID_ISBN = register(
+    Tell(
+        id="invalid_isbn",
+        category="citation",
+        feature_key="invalid_isbn_rate",
+        handling="surface",
+        polarity="avoid",
+        description="ISBN whose checksum does not validate (likely fabricated).",
+        caveat="OCR'd or hand-typed ISBNs can carry a transposition typo; verify "
+        "against the book before assuming fabrication.",
+        measure=_measure_invalid_isbn,
+        locate=_locate_invalid_isbn,
+        generic_prior=0.0,
+        margin=0.0,
+    ),
+)
+
+INVALID_DOI = register(
+    Tell(
+        id="invalid_doi",
+        category="citation",
+        feature_key="invalid_doi_rate",
+        handling="surface",
+        polarity="avoid",
+        description="A doi: / doi.org reference whose syntax is not a valid DOI.",
+        caveat="Live resolution is opt-in; a syntactically valid DOI can still be "
+        "dead or point at an unrelated article — format validity is necessary, "
+        "not sufficient.",
+        measure=_measure_invalid_doi,
+        locate=_locate_invalid_doi,
+        generic_prior=0.0,
+        margin=0.0,
+    ),
+)
+
+UNDEFINED_REF = register(
+    Tell(
+        id="undefined_ref",
+        category="citation",
+        feature_key="undefined_ref_rate",
+        handling="surface",
+        polarity="avoid",
+        description="A named <ref/> use whose definition is missing (Cite error).",
+        caveat="A ref defined later in a longer document the scanner only saw a "
+        "slice of can false-positive; check the whole source.",
+        measure=_measure_undefined_ref,
+        locate=_locate_undefined_ref,
+        generic_prior=0.0,
+        margin=0.0,
+    ),
+)
+
+TRACKING_PARAM = register(
+    Tell(
+        id="tracking_param_provenance",
+        category="citation",
+        feature_key="tracking_param_rate",
+        handling="surface",
+        polarity="avoid",
+        description="A URL carrying utm_source=chatgpt.com / openai provenance.",
+        caveat="A signal of AI involvement in sourcing, not proof the content is "
+        "wrong; strip the param (handled at ingestion) rather than the citation.",
+        measure=_measure_tracking_param,
+        locate=_locate_tracking_param,
+        generic_prior=0.0,
+        margin=0.0,
+    ),
+)
+
+PAGELESS_BOOK = register(
+    Tell(
+        id="pageless_book_cite",
+        category="citation",
+        feature_key="pageless_book_rate",
+        handling="surface",
+        polarity="avoid",
+        description="A book citation (ISBN present) with no page locator.",
+        caveat="Many legitimate citations of a whole work omit a page; surface "
+        "for review, never auto-fail.",
+        measure=_measure_pageless_book,
+        locate=_locate_pageless_book,
+        generic_prior=0.0,
+        margin=0.0,
+    ),
+)
+
+
+# --- Opt-in live link checking ----------------------------------------------
+
+_URL_RE = re.compile(r"https?://[^\s)>\]]+")
+# The 2018-2023 VisualEditor low-PMID artefact and paywalled/library hosts are
+# field-guide false positives: a dead-looking link there is not AI fabrication.
+_LINK_CHECK_SKIP_HOSTS: frozenset[str] = frozenset(
+    {"jstor.org", "sci-hub", "libgen", "doi.org", "ncbi.nlm.nih.gov"},
+)
+
+
+def _should_skip_link(url: str) -> bool:
+    """Return whether *url* is a documented false-positive host (skip it)."""
+    return any(host in url for host in _LINK_CHECK_SKIP_HOSTS)
+
+
+def extract_urls(text: str) -> list[str]:
+    """Return the outbound HTTP(S) URLs in *text*, in order."""
+    return [m.group(0).rstrip(".,;)") for m in _URL_RE.finditer(text)]
+
+
+def check_external_links(
+    text: str,
+    *,
+    enabled: bool,
+    checker: Iterable[tuple[str, bool]] | None = None,
+) -> list[str]:
+    """Return URLs that a live check found broken — opt-in and offline-safe.
+
+    Args:
+        text: The body whose links to check.
+        enabled: When ``False`` (the default config path) no network call is
+            made and an empty list is returned — offline mode skips cleanly.
+        checker: Pre-resolved ``(url, ok)`` pairs (used by tests / a cached
+            resolver) instead of a live HTTP probe. ``None`` with
+            ``enabled=True`` means "no resolver wired"; nothing is reported.
+
+    Returns:
+        The broken (and not skip-listed) URLs. Documented false-positive hosts
+        (paywalls, libraries, the low-PMID artefact) are never reported.
+    """
+    if not enabled:
+        return []
+    results = dict(checker) if checker is not None else {}
+    broken: list[str] = []
+    for url in extract_urls(text):
+        if _should_skip_link(url):
+            continue
+        if results.get(url, True) is False:
+            broken.append(url)
+    return broken

--- a/creek-tools/tests/generate/ai_style/test_citations.py
+++ b/creek-tools/tests/generate/ai_style/test_citations.py
@@ -1,0 +1,202 @@
+"""Tests for the citation-integrity tells (FEAT-040.11).
+
+Voice-neutral factual-integrity detectors: invalid ISBN/DOI, undefined named
+references, AI-provenance tracking params, page-less book citations, and an
+opt-in, offline-safe live-link checker. Detection only — never rewrites or
+deletes a citation.
+"""
+
+from __future__ import annotations
+
+from creek.generate.ai_style.citations import (
+    check_external_links,
+    extract_urls,
+)
+from creek.generate.ai_style.tells import TELL_REGISTRY
+
+
+def _fire(tell_id: str, text: str) -> int:
+    """Return the number of findings *tell_id* locates in *text*."""
+    return len(TELL_REGISTRY[tell_id].locate(text))
+
+
+# --- ISBN -------------------------------------------------------------------
+
+
+def test_valid_isbn13_does_not_fire() -> None:
+    """A checksum-valid ISBN-13 is not flagged."""
+    # 9780306406157 is a canonical valid ISBN-13.
+    assert _fire("invalid_isbn", "See ISBN 978-0-306-40615-7 for details.") == 0
+
+
+def test_valid_isbn10_does_not_fire() -> None:
+    """A checksum-valid ISBN-10 (incl. an X check digit) is not flagged."""
+    # 0-306-40615-2 is the matching valid ISBN-10.
+    assert _fire("invalid_isbn", "ISBN 0-306-40615-2 in the bibliography.") == 0
+
+
+def test_invalid_isbn_checksum_fires() -> None:
+    """An ISBN whose checksum fails is flagged as likely fabricated."""
+    assert _fire("invalid_isbn", "ISBN 978-0-306-40615-0 is bogus.") == 1
+
+
+def test_invalid_isbn_rate_is_positive() -> None:
+    """The measure returns a positive rate when an invalid ISBN is present."""
+    assert TELL_REGISTRY["invalid_isbn"].measure("ISBN 1234567890 here.") > 0.0
+
+
+# --- DOI --------------------------------------------------------------------
+
+
+def test_valid_doi_does_not_fire() -> None:
+    """A syntactically valid DOI reference is not flagged."""
+    assert _fire("invalid_doi", "doi:10.1000/xyz123 and more text") == 0
+    assert _fire("invalid_doi", "https://doi.org/10.1038/nature12373 ok") == 0
+
+
+def test_malformed_doi_fires() -> None:
+    """A doi: reference that is not a valid DOI is flagged."""
+    assert _fire("invalid_doi", "doi: not-a-real-doi here") == 1
+
+
+# --- Undefined references ---------------------------------------------------
+
+
+def test_defined_ref_does_not_fire() -> None:
+    """A self-closing ref whose name is defined is not flagged."""
+    text = '<ref name="a">Source A</ref> ... later <ref name="a"/>'
+    assert _fire("undefined_ref", text) == 0
+
+
+def test_undefined_ref_fires() -> None:
+    """A self-closing ref naming an undefined reference is flagged."""
+    assert _fire("undefined_ref", 'text <ref name="ghost"/> more') == 1
+
+
+def test_literal_cite_error_fires() -> None:
+    """Literal ``Cite error:`` text is flagged."""
+    assert _fire("undefined_ref", "Cite error: ref 'x' is not used") == 1
+
+
+# --- Tracking-param provenance ----------------------------------------------
+
+
+def test_chatgpt_tracking_param_fires() -> None:
+    """A utm_source=chatgpt.com provenance param is flagged."""
+    assert (
+        _fire("tracking_param_provenance", "https://x.com/a?utm_source=chatgpt.com")
+        == 1
+    )
+
+
+def test_clean_url_does_not_fire() -> None:
+    """A URL with no AI-provenance tracking param is not flagged."""
+    assert (
+        _fire("tracking_param_provenance", "https://x.com/a?utm_source=newsletter") == 0
+    )
+
+
+# --- Page-less book citations -----------------------------------------------
+
+
+def test_pageless_book_fires() -> None:
+    """A book citation with an ISBN but no page locator is flagged."""
+    assert (
+        _fire("pageless_book_cite", "Smith, A Big Book, ISBN 978-0-306-40615-7.") == 1
+    )
+
+
+def test_book_with_page_does_not_fire() -> None:
+    """A book citation carrying a page locator is not flagged."""
+    text = "Smith, A Big Book, ISBN 978-0-306-40615-7, p. 42."
+    assert _fire("pageless_book_cite", text) == 0
+
+
+# --- Registration -----------------------------------------------------------
+
+
+def test_all_citation_tells_registered_in_category() -> None:
+    """Every citation detector registers under the ``citation`` category."""
+    expected = {
+        "invalid_isbn",
+        "invalid_doi",
+        "undefined_ref",
+        "tracking_param_provenance",
+        "pageless_book_cite",
+    }
+    for tell_id in expected:
+        assert TELL_REGISTRY[tell_id].category == "citation"
+        assert TELL_REGISTRY[tell_id].handling == "surface"
+        # Integrity tells never rewrite/delete — margin 0 fires on any hit.
+        assert TELL_REGISTRY[tell_id].margin == 0.0
+
+
+# --- Opt-in live-link checking ----------------------------------------------
+
+
+def test_link_check_disabled_makes_no_calls() -> None:
+    """Offline mode (enabled=False) returns no broken links."""
+    text = "See https://dead.example.com/x for more."
+    assert (
+        check_external_links(
+            text, enabled=False, checker=[("https://dead.example.com/x", False)]
+        )
+        == []
+    )
+
+
+def test_link_check_reports_broken_when_enabled() -> None:
+    """With a resolver wired, broken links are reported."""
+    text = "Good https://ok.example.com and bad https://dead.example.com/x ."
+    broken = check_external_links(
+        text,
+        enabled=True,
+        checker=[
+            ("https://ok.example.com", True),
+            ("https://dead.example.com/x", False),
+        ],
+    )
+    assert broken == ["https://dead.example.com/x"]
+
+
+def test_link_check_skips_false_positive_hosts() -> None:
+    """Paywall / low-PMID hosts are never reported even if the probe fails."""
+    text = "Paywalled https://www.jstor.org/stable/123 reference."
+    broken = check_external_links(
+        text,
+        enabled=True,
+        checker=[("https://www.jstor.org/stable/123", False)],
+    )
+    assert broken == []
+
+
+def test_extract_urls_strips_trailing_punctuation() -> None:
+    """URL extraction trims a trailing period from a sentence-final link."""
+    assert extract_urls("Visit https://example.com/page.") == [
+        "https://example.com/page"
+    ]
+
+
+def test_citation_findings_surface_only_when_category_enabled() -> None:
+    """Citation tells are off the default voice scan but opt-in via the category."""
+    from creek.config import AIStyleConfig
+    from creek.generate.ai_style.model import FeatureStat, VoiceFingerprint
+    from creek.generate.ai_style.scanner import scan
+
+    fingerprint = VoiceFingerprint(
+        features={"em_dash_density": FeatureStat(rate=0.0, support=20)},
+        fragment_count=20,
+    )
+    text = "A claim with ISBN 978-0-306-40615-0 (bad checksum)."
+
+    default = scan(text, fingerprint=fingerprint, config=AIStyleConfig())
+    assert not any(f.category == "citation" for f in default.findings)
+
+    opt_in = scan(
+        text,
+        fingerprint=fingerprint,
+        config=AIStyleConfig(
+            enabled_categories=["lexical", "rhetorical", "discourse", "citation"],
+        ),
+    )
+    assert any(f.tell_id == "invalid_isbn" for f in opt_in.findings)


### PR DESCRIPTION
## Summary

Adds voice-neutral **citation-integrity detectors** (FEAT-040.11) under the existing `citation` tell category — targeting the field guide's WP:AIFICTREF failure mode (fabricated/broken references, the most policy-dangerous LLM error). New `creek/generate/ai_style/citations.py` registers five tells:

| Tell | Detects |
|------|---------|
| `invalid_isbn` | ISBN-10/13 checksum failures |
| `invalid_doi` | `doi:` / `doi.org` references with malformed DOI syntax |
| `undefined_ref` | self-closing `<ref name="x"/>` with no definition + literal `Cite error:` text |
| `tracking_param_provenance` | `utm_source=chatgpt.com` / openai provenance params |
| `pageless_book_cite` | ISBN-bearing citations with no page locator |

- **Detection/surface only** (`handling="surface"`, `margin=0`) — never rewrites or deletes a citation. Offline and deterministic; each tell encodes the guide's false-positive caveat.
- **Opt-in live link checking** (`check_external_links`, gated by new `AIStyleConfig.citation_network_checks`, default off): returns nothing offline, and never reports documented false-positive hosts (paywalls, libraries, the 2018-2023 low-PMID artefact).
- **Voice-neutral, so opt-in for the voice scan:** citation is orthogonal to the idiolect fingerprint, so I removed `citation` from the *default* enabled categories — its zero contributions would otherwise dilute the scalar `voice_distance` (which it did: a slop fixture dropped from 0.0500 to 0.0489). It registers normally and is surfaced by enabling the category explicitly (the future lint surface), proven by a scan-integration test.

## Test plan

- New `tests/generate/ai_style/test_citations.py` (19 tests): valid vs invalid ISBN-10/13 (incl. X check digit) and DOI; defined vs undefined ref + `Cite error:`; tracking-param hit/miss; page-less vs paged book; registration invariants (category/handling/margin); opt-in link check (offline no-op, broken-link reporting, false-positive-host skip, URL extraction); and the scan-integration opt-in path.
- `cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (full voice/scanner suite stays green after the default-category change; mypy strict, ruff/refurb/tryceratops/interrogate/complexity clean).

Closes #428
Refs #417
