### PR TITLE
test(author): FEAT-041 deferred test-hardening + polish (#481)

### DIFF
--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -558,9 +558,17 @@ class AuthorManifest(BaseModel):
     @field_validator("attribution_required", mode="before")
     @classmethod
     def _coerce_attribution_required(cls, value: object) -> bool:
-        """Fail closed to ``True`` (require attribution) for a non-boolean value."""
+        """Fail closed to ``True`` (require attribution) for a non-boolean value.
+
+        YAML/JSON commonly write a boolean as the integer ``1`` / ``0``; those
+        carry unambiguous intent, so they are honoured (``1`` → require, ``0``
+        → not required) rather than failing closed. Any other non-boolean value
+        is ambiguous and resolves to ``True``.
+        """
         if isinstance(value, bool):
             return value
+        if isinstance(value, int) and value in (0, 1):
+            return bool(value)
         _warn_fail_closed(
             "attribution_required", value, "True", reason="is not a boolean"
         )

--- a/creek-tools/creek_mcp/audit.py
+++ b/creek-tools/creek_mcp/audit.py
@@ -91,11 +91,12 @@ def _content_hash(entry: dict[str, Any]) -> str:
 def summarise_args(args: dict[str, Any]) -> dict[str, Any]:
     """Return a privacy-safe summary of *args* for the audit log.
 
-    Strings are kept up to a short prefix length so the audit log never
-    captures a fragment body or draft prompt; long fields are reported
-    as ``{"len": N}`` instead. Pure scalars and short strings pass
-    through unchanged so the audit entry still names *which* skill /
-    phase / index a tool was invoked with.
+    A string of at most 64 characters passes through verbatim; a longer one
+    (which could be a fragment body or draft prompt) is replaced by its length
+    as ``{"len": N}`` — never truncated to a prefix — so the log never captures
+    sensitive content. Lists/tuples report a ``{"count": N}``, dicts their
+    sorted keys, and pure scalars pass through, so the entry still names *which*
+    skill / phase / index a tool was invoked with.
     """
     summary: dict[str, Any] = {}
     for key, value in args.items():

--- a/creek-tools/tests/test_author_cost.py
+++ b/creek-tools/tests/test_author_cost.py
@@ -115,6 +115,24 @@ def test_provider_omits_system_when_none(monkeypatch: pytest.MonkeyPatch) -> Non
     assert kwargs["messages"] == [{"role": "user", "content": "just the prompt"}]
 
 
+def test_complete_uses_default_unbounded_max_tokens() -> None:
+    """``complete`` with no ``max_tokens`` passes ``None`` through (#455).
+
+    The default (unbounded) path was previously only exercised with an explicit
+    ceiling; this pins that the default forwards ``max_tokens=None``.
+    """
+    provider = MagicMock()
+    provider.call_with_metadata.return_value = AnthropicCompletion(
+        text="completion", usage={"input_tokens": 1}
+    )
+
+    client = AuthorLLMClient(provider)
+    text = client.complete("ask")
+
+    assert text == "completion"
+    provider.call_with_metadata.assert_called_once_with("ask", max_tokens=None)
+
+
 def test_complete_with_usage_returns_text_and_usage() -> None:
     """``complete_with_usage`` returns the full completion; ``complete`` stays str."""
     provider = MagicMock()

--- a/creek-tools/tests/test_author_manifest.py
+++ b/creek-tools/tests/test_author_manifest.py
@@ -146,14 +146,25 @@ def test_default_privacy_tier_fails_closed_on_garbage(tmp_path: Path) -> None:
     assert load_author_manifest(path).default_privacy_tier == PrivacyTier.OPEN
 
 
-def test_attribution_required_fails_closed_on_non_bool(tmp_path: Path) -> None:
-    """A non-boolean ``attribution_required`` fails closed to True (require it)."""
+def test_attribution_required_fails_closed_on_non_bool(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A non-boolean ``attribution_required`` fails closed to True, loudly."""
     body = _FULL_MANIFEST.replace(
         "attribution_required: true", "attribution_required: maybe"
     )
     path = _write_manifest(tmp_path, "bad-attr", body)
 
-    assert load_author_manifest(path).attribution_required is True
+    with caplog.at_level("WARNING"):
+        manifest = load_author_manifest(path)
+
+    assert manifest.attribution_required is True
+    # The fail-closed path is loud, never silent.
+    assert any(
+        "attribution_required" in record.message and "failing closed" in record.message
+        for record in caplog.records
+    )
 
 
 def test_attribution_required_false_is_preserved(tmp_path: Path) -> None:
@@ -164,6 +175,36 @@ def test_attribution_required_false_is_preserved(tmp_path: Path) -> None:
     path = _write_manifest(tmp_path, "attr-false", body)
 
     assert load_author_manifest(path).attribution_required is False
+
+
+def test_attribution_required_numeric_one_is_true(tmp_path: Path) -> None:
+    """YAML integer ``1`` is honoured as ``True`` (require attribution), not coerced."""
+    body = _FULL_MANIFEST.replace(
+        "attribution_required: true", "attribution_required: 1"
+    )
+    path = _write_manifest(tmp_path, "attr-one", body)
+
+    assert load_author_manifest(path).attribution_required is True
+
+
+def test_attribution_required_numeric_zero_is_false(tmp_path: Path) -> None:
+    """YAML integer ``0`` carries unambiguous intent and is honoured as ``False``."""
+    body = _FULL_MANIFEST.replace(
+        "attribution_required: true", "attribution_required: 0"
+    )
+    path = _write_manifest(tmp_path, "attr-zero", body)
+
+    assert load_author_manifest(path).attribution_required is False
+
+
+def test_attribution_required_other_int_fails_closed(tmp_path: Path) -> None:
+    """An out-of-domain integer (e.g. ``2``) is ambiguous and fails closed to True."""
+    body = _FULL_MANIFEST.replace(
+        "attribution_required: true", "attribution_required: 2"
+    )
+    path = _write_manifest(tmp_path, "attr-two", body)
+
+    assert load_author_manifest(path).attribution_required is True
 
 
 def test_null_privacy_tier_fails_closed(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_chat_medium.py
+++ b/creek-tools/tests/test_chat_medium.py
@@ -92,6 +92,27 @@ def test_harness_rejects_out_of_range_weight() -> None:
         assert_contract_conformant(bad)
 
 
+def test_harness_rejects_out_of_range_rubric() -> None:
+    """A reflection-rubric weight outside [0, 1] is non-conformant (#457).
+
+    Mirrors :func:`test_harness_rejects_out_of_range_weight` for the rubric
+    map: the values sum to ~1.0 and every required key is present, so only the
+    range branch can fire.
+    """
+    bad = MediumContract(
+        medium="bad",
+        structure=["reply"],
+        specialist_weights={"voice": 1.0},
+        reflection_rubric={
+            "ontological_accuracy": 1.5,
+            "citation_completeness": 0.0,
+            "voice_fidelity": -0.5,
+        },
+    )
+    with pytest.raises(ContractConformanceError, match="outside"):
+        assert_contract_conformant(bad)
+
+
 def test_harness_rejects_missing_rubric_keys() -> None:
     """A rubric missing a required dimension is non-conformant."""
     bad = MediumContract(


### PR DESCRIPTION
## Summary

Addresses the consolidated, non-blocking FEAT-041 skeleton-PR follow-ups (#481). The acceptance is "address any subset with a focused, tested change"; this clears the concrete, still-relevant items:

- **#458** — `AuthorManifest.attribution_required` now honours a YAML integer `1`/`0` as a boolean (`1` → require, `0` → not required; unambiguous intent), keeping the fail-closed-to-`True` path for genuinely ambiguous values. Added `caplog` coverage proving the fail-closed path is **loud**, plus `1`/`0`/`2` edge-case tests.
- **#457** — new `test_harness_rejects_out_of_range_rubric`, mirroring the specialist-weight out-of-range conformance test for the structurally identical `reflection_rubric` range branch.
- **#455** — pin `AuthorLLMClient.complete`'s default (unbounded) path forwards `max_tokens=None` (previously only the explicit-ceiling path was exercised).
- **#456** — corrected `summarise_args`' docstring (strings ≤64 chars pass through **verbatim**; longer ones become `{"len": N}` — not a truncated prefix).

### Deferred (with rationale)

- **#459** is intentionally **not** done. Moving `specialist_weights`/`reflection_rubric` range validation onto `MediumContract` would defeat the conformance harness that exists to *report* those problems (and break its tests — it would never see an out-of-range value). And dropping `run_author`'s `require_supported_medium` is declined: it guards the `load_medium_contract` step's ordering, so it is not truly redundant — a clear early "unsupported medium" error beats a downstream file-not-found.
- **#455/#456** are also flagged in the issue as superseded by #463/#471 and #460 respectively; the small wins above are landed now regardless.

## Test plan

- `tests/test_author_manifest.py` (+caplog & numeric coercion), `tests/test_chat_medium.py` (+rubric range), `tests/test_author_cost.py` (+default max_tokens) — 62 affected tests green.
- `cd creek-tools && ./scripts/check-all.sh` → **12/12 green**.

Closes #481
