### PR TITLE
refactor(author): skip ambiguous-title links + clarify walk loop var (#487)

### DIFF
--- a/creek-tools/creek/author/agents.py
+++ b/creek-tools/creek/author/agents.py
@@ -282,21 +282,37 @@ def _wikilink_targets(
     return resolved
 
 
+def _resolve_titles(corpus: list[tuple[Fragment, str]]) -> dict[str, str]:
+    """Map each *unambiguous* title to its fragment id (collisions dropped).
+
+    A title shared by two or more corpus fragments is omitted, so a wikilink to
+    it resolves to nothing rather than silently linking the wrong fragment.
+    """
+    title_counts = Counter(fragment.title for fragment, _ in corpus)
+    return {
+        fragment.title: fragment.id
+        for fragment, _ in corpus
+        if title_counts[fragment.title] == 1
+    }
+
+
 def _build_link_graph(corpus: list[tuple[Fragment, str]]) -> dict[str, set[str]]:
     """Build an undirected adjacency map from wikilinks and parent/child edges.
 
     Wikilink targets are resolved to fragment ids by id or by title; unresolved
     targets are dropped. Edges are bidirectional so the walk follows backlinks.
 
-    Duplicate-title resolution is **last-wins**: when two corpus fragments share
-    a title, the ``by_title`` map maps that title to the id of the *last*
-    fragment in corpus order, so a ``[[Shared Title]]`` wikilink targets it.
-    Ids are always preferred over titles — :func:`_wikilink_targets` checks
-    ``by_id`` first — so an exact-id link never falls through to title lookup.
+    Duplicate-title resolution is **skip-on-collision**: when two or more corpus
+    fragments share a title, that title is omitted from the ``by_title`` map, so
+    a ``[[Shared Title]]`` wikilink resolves to nothing rather than silently
+    linking the wrong fragment. Ids are always preferred over titles —
+    :func:`_wikilink_targets` checks ``by_id`` first — so an exact-id link still
+    resolves even when the fragment's title is ambiguous.
     """
     by_id = {fragment.id for fragment, _ in corpus}
-    # Last-wins on duplicate titles (the comprehension keeps the final entry).
-    by_title = {fragment.title: fragment.id for fragment, _ in corpus}
+    # Drop ambiguous titles (see _resolve_titles): a shared title resolves to no
+    # id, since mis-linking the wrong fragment is worse than dropping the link.
+    by_title = _resolve_titles(corpus)
     graph: dict[str, set[str]] = {fragment.id: set() for fragment, _ in corpus}
     for fragment, body in corpus:
         neighbours = {fragment.parent_id, *fragment.child_ids}
@@ -322,7 +338,7 @@ def _bounded_walk(
     seen = {seed}
     frontier = [seed]
     max_depth = 0
-    for current in range(1, depth + 1):
+    for hop in range(1, depth + 1):
         candidates = sorted(
             {n for node in frontier for n in graph.get(node, set()) if n not in seen}
         )
@@ -332,7 +348,7 @@ def _bounded_walk(
         seen.update(layer)
         visited.extend(layer)
         frontier = layer
-        max_depth = current
+        max_depth = hop
     return visited, max_depth
 
 

--- a/creek-tools/tests/test_real_agents.py
+++ b/creek-tools/tests/test_real_agents.py
@@ -478,26 +478,36 @@ def test_retrieval_stale_cache_entry_is_recomputed(tmp_path: Path) -> None:
     assert embedded_texts == ["alpha", fragment_embedding_text(by_id["frag-a"])]
 
 
-def test_build_link_graph_duplicate_title_is_last_wins(tmp_path: Path) -> None:
-    """Duplicate titles resolve a wikilink to the LAST fragment in corpus order.
+def test_build_link_graph_skips_ambiguous_title(tmp_path: Path) -> None:
+    """A wikilink to a title shared by 2+ fragments resolves to NEITHER (#487).
 
-    ``_build_link_graph`` builds its ``by_title`` map last-wins, so a wikilink
-    to a shared title targets the final fragment declaring that title; ids are
-    always preferred over titles when both could match.
+    Silently picking one (the old last-wins behaviour) could link the wrong
+    fragment, so an ambiguous title is dropped from the resolver. An exact-id
+    wikilink still resolves even when the fragment's title is ambiguous, since
+    ids are preferred over titles.
     """
     _write(tmp_path, "01-Fragments/Notes", "frag-dup-1", "Shared Title")
     _write(tmp_path, "01-Fragments/Notes", "frag-dup-2", "Shared Title")
     _write(
         tmp_path,
         "01-Fragments/Notes",
-        "frag-link",
-        "Linker",
+        "frag-title-link",
+        "TitleLinker",
         body="[[Shared Title]]",
+    )
+    _write(
+        tmp_path,
+        "01-Fragments/Notes",
+        "frag-id-link",
+        "IdLinker",
+        body="[[frag-dup-1]]",
     )
 
     corpus = sorted(_load_corpus(tmp_path), key=lambda rec: rec[0].id)
     graph = _build_link_graph(corpus)
 
-    # corpus order is frag-dup-1, frag-dup-2, frag-link; last-wins -> dup-2.
-    assert "frag-dup-2" in graph["frag-link"]
-    assert "frag-dup-1" not in graph["frag-link"]
+    # Ambiguous title → no edge to either duplicate (no silent mis-link).
+    assert "frag-dup-1" not in graph["frag-title-link"]
+    assert "frag-dup-2" not in graph["frag-title-link"]
+    # Exact id still resolves despite the shared, ambiguous title.
+    assert "frag-dup-1" in graph["frag-id-link"]


### PR DESCRIPTION
## Summary

Non-blocking cleanups flagged on the #463 review (PR #485), in `creek/author/agents.py`:

1. **`by_title` collision fix.** `_build_link_graph` resolved a `[[wikilink]]` by title using a *last-wins* map, so two fragments sharing a title could silently link the wrong one. Title resolution now **skips collisions** — a title shared by 2+ fragments is dropped from the resolver (extracted to a small `_resolve_titles` helper), so an ambiguous `[[Shared Title]]` resolves to nothing. Exact-id links still resolve (ids are preferred over titles), even when the title is ambiguous.
2. **Loop-var clarity.** Renamed `_bounded_walk`'s `current` → `hop`; it holds the depth/hop index (`1..depth`), not the current node.

Both are readability/robustness only — no correctness regression for realistic single-title vaults (per the #485 verdict).

## Test plan

- Updated `test_build_link_graph_skips_ambiguous_title` (was `…_is_last_wins`) to assert the new behaviour: an ambiguous title links to **neither** duplicate, while an exact-id wikilink still resolves despite the shared title.
- Kept `_build_link_graph` under the complexity gate by extracting `_resolve_titles` (the added collision check would otherwise have tipped it to rank C).
- Author/agents suites (36 tests) green; `cd creek-tools && ./scripts/check-all.sh` → **12/12 green**.

Closes #487
Refs #450
