### PR TITLE
fix(save): disambiguate ai-as-user fragment ids on title collision (#489)

### DIFF
--- a/creek-tools/creek/save/writer.py
+++ b/creek-tools/creek/save/writer.py
@@ -18,6 +18,7 @@ behaviour consistent.
 
 from __future__ import annotations
 
+import hashlib
 import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -162,14 +163,14 @@ def _shape_for_target(request: SaveRequest) -> dict[str, Any]:
     if request.target == SaveTarget.PRAXIS:
         return Praxis(title=title).model_dump(mode="json")
     if request.target == SaveTarget.AI_AS_USER:
-        return _shape_ai_as_user_fragment(title)
+        return _shape_ai_as_user_fragment(title, request.body)
     return {
         "title": title,
         "tags": [request.target.value],
     }
 
 
-def _shape_ai_as_user_fragment(title: str) -> dict[str, Any]:
+def _shape_ai_as_user_fragment(title: str, body: str) -> dict[str, Any]:
     """Shape kept AI output as an AI-attributed, voice-neutral fragment.
 
     The note is a real :class:`~creek.models.Fragment` (round-trippable through
@@ -178,10 +179,17 @@ def _shape_ai_as_user_fragment(title: str) -> dict[str, Any]:
     folder, ``voice_weight=0.0`` so it never colours the owner's generated
     voice, and ``representativeness=endorsed`` because the owner kept it on
     purpose.
+
+    The fragment ``id`` appends a short content digest to the title slug so two
+    kept outputs that share a title get distinct ids (the filename is already
+    de-duplicated by the writer's atomic collision-retry; this keeps the
+    in-frontmatter id unique too). Identical content under the same title yields
+    the same id — a harmless idempotent re-save.
     """
     slug = slugify_filename(title, max_length=_MAX_FILENAME_LENGTH) or "untitled"
+    digest = hashlib.sha256(body.encode("utf-8")).hexdigest()[:8]
     return Fragment(
-        id=f"{SaveTarget.AI_AS_USER.value}-{slug}",
+        id=f"{SaveTarget.AI_AS_USER.value}-{slug}-{digest}",
         title=title,
         source=FragmentSource(
             platform=SourcePlatform.CLAUDE,

--- a/creek-tools/tests/test_save.py
+++ b/creek-tools/tests/test_save.py
@@ -155,6 +155,44 @@ def test_ai_as_user_save_lands_attributed_fragment(vault: Path) -> None:
     assert post["representativeness"] == "endorsed"
 
 
+def test_ai_as_user_same_title_distinct_content_get_distinct_ids(vault: Path) -> None:
+    """Two same-titled AI saves with different bodies get distinct ids (#489).
+
+    The id appends a content digest to the title slug, so the in-frontmatter
+    ``id`` no longer collides when two kept outputs share a title (the filename
+    was already de-duplicated by the atomic collision-retry).
+    """
+    first = save_to_vault(
+        _make_request(SaveTarget.AI_AS_USER, title="Same Title", body="First body."),
+        vault_path=vault,
+    )
+    second = save_to_vault(
+        _make_request(SaveTarget.AI_AS_USER, title="Same Title", body="Second body."),
+        vault_path=vault,
+    )
+
+    first_id = frontmatter.load(str(first))["id"]
+    second_id = frontmatter.load(str(second))["id"]
+    assert first_id != second_id
+    assert first_id.startswith("ai-as-user-Same-Title-")
+
+
+def test_ai_as_user_same_title_same_content_is_idempotent_id(vault: Path) -> None:
+    """Identical title+body yields the same id — a harmless idempotent re-save."""
+    request = _make_request(
+        SaveTarget.AI_AS_USER, title="Same Title", body="Identical body."
+    )
+    first = save_to_vault(request, vault_path=vault)
+    second = save_to_vault(
+        _make_request(
+            SaveTarget.AI_AS_USER, title="Same Title", body="Identical body."
+        ),
+        vault_path=vault,
+    )
+
+    assert frontmatter.load(str(first))["id"] == frontmatter.load(str(second))["id"]
+
+
 def test_ai_as_user_save_round_trips_through_the_fragment_reader(vault: Path) -> None:
     """The saved note loads as a valid Fragment via the vault reader."""
     from creek.vault.reader import try_load_fragment


### PR DESCRIPTION
## Summary

Non-blocking hardening flagged on the #464 review (PR #488). The `ai-as-user` save target derived the fragment `id` from the title slug alone (`ai-as-user-<slug>`), so two kept AI outputs sharing a title produced the **same in-frontmatter `id`** — the *filename* was already de-duplicated by the writer's atomic collision-retry, but the `id` collided.

`_shape_ai_as_user_fragment` now appends a short SHA-256 **content digest** (`ai-as-user-<slug>-<sha8>`):
- same title + different body → **distinct ids**;
- identical title + body → **same id** (a harmless idempotent re-save).

`request.body` is threaded into the shaper for the digest. Detection only — no change to attribution (`author=ai`, `voice_weight=0.0`, `representativeness=endorsed`) or routing.

## Test plan

- New tests: two same-titled AI saves with different bodies get distinct ids; identical title+body yields the same id. Existing `ai-as-user` round-trip/attribution tests unaffected (they don't pin the exact id).
- Full save + other-author suites (72 tests) green; `cd creek-tools && ./scripts/check-all.sh` → **12/12 green**.

Closes #489
Refs #450
