### PR TITLE
test(author): extract shared write_raw_fragment_file helper (#491)

### DIFF
--- a/creek-tools/tests/helpers.py
+++ b/creek-tools/tests/helpers.py
@@ -60,3 +60,56 @@ def write_fragment_file(
         encoding="utf-8",
     )
     return path
+
+
+_RAW_FRAGMENT_FM = (
+    '---\ntype: fragment\nid: {id}\ntitle: "{title}"\n'
+    "source:\n  platform: {platform}\n  author: {author}\n{extra}---\n{body}\n"
+)
+
+
+def write_raw_fragment_file(
+    vault: Path,
+    subdir: str,
+    frag_id: str,
+    title: str,
+    *,
+    body: str = "body",
+    author: str = "self",
+    author_slug: str | None = None,
+    platform: str = "journal",
+) -> None:
+    """Write a minimal fragment markdown file under *subdir* of *vault*.
+
+    Builds the frontmatter from a literal template (not ``Fragment.model_dump``)
+    so ``author`` / ``author_slug`` / ``platform`` can be set to arbitrary raw
+    values — used by the medium / agent suites to seed self and other-author
+    corpora (an ``author_slug`` lands the fragment under ``11-Other-Authors/``).
+    For a fragment built from a :class:`~creek.models.Fragment` model, use
+    :func:`write_fragment_file` instead.
+
+    Args:
+        vault: The vault root to write under.
+        subdir: Vault subdirectory (e.g. ``01-Fragments/Notes`` or
+            ``11-Other-Authors/<slug>``).
+        frag_id: Fragment id (also the file stem).
+        title: Fragment title.
+        body: Fragment body text.
+        author: The authorship axis (``self`` / ``other`` / ...).
+        author_slug: The ``11-Other-Authors/`` slug, or ``None`` for self.
+        platform: The source platform string.
+    """
+    folder = vault / subdir
+    folder.mkdir(parents=True, exist_ok=True)
+    extra = f"  author_slug: {author_slug}\n" if author_slug else ""
+    (folder / f"{frag_id}.md").write_text(
+        _RAW_FRAGMENT_FM.format(
+            id=frag_id,
+            title=title,
+            platform=platform,
+            author=author,
+            extra=extra,
+            body=body,
+        ),
+        encoding="utf-8",
+    )

--- a/creek-tools/tests/test_book_report_medium.py
+++ b/creek-tools/tests/test_book_report_medium.py
@@ -24,56 +24,10 @@ from creek.author import (
     run_author,
 )
 from creek.author.conductor import build_default_conductor
+from tests.helpers import write_raw_fragment_file as _write
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-_FM = (
-    '---\ntype: fragment\nid: {id}\ntitle: "{title}"\n'
-    "source:\n  platform: {platform}\n  author: {author}\n{extra}---\n{body}\n"
-)
-
-
-def _write(
-    vault: Path,
-    subdir: str,
-    frag_id: str,
-    title: str,
-    *,
-    body: str = "body",
-    author: str = "self",
-    author_slug: str | None = None,
-    platform: str = "journal",
-) -> None:
-    """Write a minimal fragment markdown file under *subdir* of *vault*.
-
-    Mirrors the ``_write`` helper in ``test_real_agents.py`` so other-author
-    fragments are seeded the established way (``author_slug`` in frontmatter).
-
-    Args:
-        vault: The vault root to write under.
-        subdir: The vault subdirectory (e.g. ``11-Other-Authors/<slug>``).
-        frag_id: The fragment id (also the file stem).
-        title: The fragment title.
-        body: The fragment body text.
-        author: The authorship axis (``self``/``other``/...).
-        author_slug: The ``11-Other-Authors/`` slug, or ``None`` for self.
-        platform: The source platform string.
-    """
-    folder = vault / subdir
-    folder.mkdir(parents=True, exist_ok=True)
-    extra = f"  author_slug: {author_slug}\n" if author_slug else ""
-    (folder / f"{frag_id}.md").write_text(
-        _FM.format(
-            id=frag_id,
-            title=title,
-            platform=platform,
-            author=author,
-            extra=extra,
-            body=body,
-        ),
-        encoding="utf-8",
-    )
 
 
 def test_book_report_contract_loads_and_conforms(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_real_agents.py
+++ b/creek-tools/tests/test_real_agents.py
@@ -32,6 +32,7 @@ from creek.link.embeddings import (
     fragment_embedding_text,
 )
 from creek.models import Frequency, Phase, VoiceRegister
+from tests.helpers import write_raw_fragment_file as _write
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -41,40 +42,6 @@ if TYPE_CHECKING:
 def _isolate_config(monkeypatch: pytest.MonkeyPatch) -> None:
     """Clear any leaked ``CREEK_CONFIG`` so tests use vault discovery/defaults."""
     monkeypatch.delenv("CREEK_CONFIG", raising=False)
-
-
-_FM = (
-    '---\ntype: fragment\nid: {id}\ntitle: "{title}"\n'
-    "source:\n  platform: {platform}\n  author: {author}\n{extra}---\n{body}\n"
-)
-
-
-def _write(
-    vault: Path,
-    subdir: str,
-    frag_id: str,
-    title: str,
-    *,
-    body: str = "body",
-    author: str = "self",
-    author_slug: str | None = None,
-    platform: str = "journal",
-) -> None:
-    """Write a minimal fragment markdown file under *subdir*."""
-    folder = vault / subdir
-    folder.mkdir(parents=True, exist_ok=True)
-    extra = f"  author_slug: {author_slug}\n" if author_slug else ""
-    (folder / f"{frag_id}.md").write_text(
-        _FM.format(
-            id=frag_id,
-            title=title,
-            platform=platform,
-            author=author,
-            extra=extra,
-            body=body,
-        ),
-        encoding="utf-8",
-    )
 
 
 def test_retrieval_returns_cited_claims(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_research_piece_medium.py
+++ b/creek-tools/tests/test_research_piece_medium.py
@@ -21,56 +21,10 @@ from creek.author import (
     run_author,
 )
 from creek.author.conductor import build_default_conductor
+from tests.helpers import write_raw_fragment_file as _write
 
 if TYPE_CHECKING:
     from pathlib import Path
-
-_FM = (
-    '---\ntype: fragment\nid: {id}\ntitle: "{title}"\n'
-    "source:\n  platform: {platform}\n  author: {author}\n{extra}---\n{body}\n"
-)
-
-
-def _write(
-    vault: Path,
-    subdir: str,
-    frag_id: str,
-    title: str,
-    *,
-    body: str = "body",
-    author: str = "self",
-    author_slug: str | None = None,
-    platform: str = "journal",
-) -> None:
-    """Write a minimal fragment markdown file under *subdir* of *vault*.
-
-    Mirrors the ``_write`` helper in ``test_real_agents.py`` so other-author
-    fragments are seeded the established way (``author_slug`` in frontmatter).
-
-    Args:
-        vault: The vault root to write under.
-        subdir: The vault subdirectory (e.g. ``11-Other-Authors/<slug>``).
-        frag_id: The fragment id (also the file stem).
-        title: The fragment title.
-        body: The fragment body text.
-        author: The authorship axis (``self``/``other``/...).
-        author_slug: The ``11-Other-Authors/`` slug, or ``None`` for self.
-        platform: The source platform string.
-    """
-    folder = vault / subdir
-    folder.mkdir(parents=True, exist_ok=True)
-    extra = f"  author_slug: {author_slug}\n" if author_slug else ""
-    (folder / f"{frag_id}.md").write_text(
-        _FM.format(
-            id=frag_id,
-            title=title,
-            platform=platform,
-            author=author,
-            extra=extra,
-            body=body,
-        ),
-        encoding="utf-8",
-    )
 
 
 def test_research_piece_contract_loads_and_conforms(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Non-blocking test-refactor flagged on the #465 review (PR #490). `test_real_agents.py`, `test_book_report_medium.py`, and `test_research_piece_medium.py` each carried a **byte-identical** `_FM` template + `_write(vault, subdir, frag_id, title, *, body, author, author_slug, platform)` helper for seeding minimal fragment markdown (with optional `author_slug` for `11-Other-Authors/`).

Extracted it once into `tests/helpers.py` as `write_raw_fragment_file` — a sibling to the existing Fragment-model-based `write_fragment_file` (kept distinct because this one writes a literal template so `author`/`author_slug`/`platform` can be arbitrary raw strings). The three modules now `from tests.helpers import write_raw_fragment_file as _write`, so call sites are unchanged and the on-disk fixture shape lives in one place as more medium suites land.

Pure test-refactor — no production change.

## Test plan

- The three refactored modules + a `helpers.py` consumer (`test_classify_engine.py`) — 64 tests green.
- `cd creek-tools && ./scripts/check-all.sh` → **12/12 green** (ruff isort sorted the new import; format clean).

Closes #491
Refs #450
