### PR TITLE
refactor(author): ontology analysis polish (#494)

### DIFF
--- a/creek-tools/creek/author/agents.py
+++ b/creek-tools/creek/author/agents.py
@@ -27,7 +27,7 @@ from creek.author.models import (
 )
 from creek.classify.rules import RuleClassifier
 from creek.classify.weighted import WeightedDimension
-from creek.generate.paradox import OPPOSITE_PHASE_PAIRS
+from creek.generate.paradox import OPPOSITE_CONFIDENCE_PAIRS, OPPOSITE_PHASE_PAIRS
 from creek.link.embeddings import (
     EmbeddingLinker,
     EmbeddingModelUnavailableError,
@@ -35,7 +35,7 @@ from creek.link.embeddings import (
     embeddings_cache_path,
     fragment_embedding_text,
 )
-from creek.models import Dosage, Frequency, Mode, Phase, VoiceRegister
+from creek.models import Confidence, Dosage, Frequency, Mode, Phase, VoiceRegister
 from creek.vault.reader import iter_vault_fragments
 
 if TYPE_CHECKING:
@@ -441,17 +441,17 @@ def _aggregate_optional(
 class _FragmentSignal:
     """The canonical ontology signal a single corpus fragment carries."""
 
-    __slots__ = ("dosage", "frequency", "mode", "phase", "voice_register")
+    __slots__ = ("confidence", "dosage", "frequency", "mode", "phase", "voice_register")
 
     def __init__(self, fragment: Fragment, body: str) -> None:
         """Classify *fragment* deterministically, keeping any frontmatter dosage.
 
-        The rule classifier supplies frequency, phase, mode, and voice
-        register from ``title + body`` keyword signal; the rule classifier
-        does not detect dosage, so dosage is read from the fragment's existing
-        frontmatter (``wavelength.dosage``) instead. ``voice_register`` is
-        ``None`` when no register keyword fired (the enum has no
-        ``UNCLASSIFIED`` member).
+        The rule classifier supplies frequency, phase, mode, voice register,
+        and confidence from ``title + body`` keyword signal; the rule
+        classifier does not detect dosage, so dosage is read from the
+        fragment's existing frontmatter (``wavelength.dosage``) instead.
+        ``voice_register`` and ``confidence`` are ``None`` when no keyword
+        fired (neither enum has an ``UNCLASSIFIED`` member).
 
         Args:
             fragment: The corpus fragment to scan.
@@ -470,6 +470,12 @@ class _FragmentSignal:
         # canonical enum so aggregation sorts on ``.value`` like the other axes.
         self.voice_register: VoiceRegister | None = (
             VoiceRegister(register) if register is not None else None
+        )
+        # Confidence is likewise surfaced as a plain ``str`` (or ``None``);
+        # rewrap it so the confidence-paradox detector can compare enum members.
+        confidence = classified.voice.confidence
+        self.confidence: Confidence | None = (
+            Confidence(confidence) if confidence is not None else None
         )
 
 
@@ -510,6 +516,23 @@ def _detect_dosage_paradoxes(
     return paradoxes
 
 
+def _pair_sort_key(pair: frozenset[str]) -> list[str]:
+    """Deterministic sort key for an opposite-pair ``frozenset``.
+
+    Frozensets have no inherent order, so paradox detection iterates the
+    opposite pairs in a stable order keyed on each pair's sorted member list.
+    A named key spells out that intent (the equivalent bare ``key=sorted``
+    reads as a puzzle at the call site).
+
+    Args:
+        pair: One opposite pair (e.g. ``{"rising", "diminishing"}``).
+
+    Returns:
+        The pair's members sorted into a list, used purely as a sort key.
+    """
+    return sorted(pair)
+
+
 def _detect_phase_paradoxes(
     signals: list[tuple[str, _FragmentSignal]],
 ) -> list[OntologyParadox]:
@@ -530,7 +553,7 @@ def _detect_phase_paradoxes(
         if sig.phase is not Phase.UNCLASSIFIED:
             first_for_phase.setdefault(sig.phase, fid)
     paradoxes: list[OntologyParadox] = []
-    for pair in sorted(OPPOSITE_PHASE_PAIRS, key=sorted):
+    for pair in sorted(OPPOSITE_PHASE_PAIRS, key=_pair_sort_key):
         phases = [Phase(value) for value in pair]
         if all(phase in first_for_phase for phase in phases):
             lo, hi = sorted(phases, key=lambda p: p.value)
@@ -541,6 +564,46 @@ def _detect_phase_paradoxes(
                     description=(
                         f"The topic sits on opposite phases — {lo.value} in one "
                         f"fragment and {hi.value} in another."
+                    ),
+                )
+            )
+    return paradoxes
+
+
+def _detect_confidence_paradoxes(
+    signals: list[tuple[str, _FragmentSignal]],
+) -> list[OntologyParadox]:
+    """Surface opposite-confidence contradictions across fragments.
+
+    Reuses the canonical opposite-confidence pairs from
+    :data:`creek.generate.paradox.OPPOSITE_CONFIDENCE_PAIRS` — the same pairs
+    the generate-side paradox engine treats as opposites (e.g. musing vs
+    conviction), so the desk and the vault agree on what a confidence
+    contradiction is.
+
+    Args:
+        signals: ``(fragment_id, signal)`` pairs for the classified corpus.
+
+    Returns:
+        One :class:`OntologyParadox` per opposite-confidence pair present in the
+        corpus; the contradiction is named, never resolved.
+    """
+    first_for_confidence: dict[Confidence, str] = {}
+    for fid, sig in signals:
+        if sig.confidence is not None:
+            first_for_confidence.setdefault(sig.confidence, fid)
+    paradoxes: list[OntologyParadox] = []
+    for pair in sorted(OPPOSITE_CONFIDENCE_PAIRS, key=_pair_sort_key):
+        levels = [Confidence(value) for value in pair]
+        if all(level in first_for_confidence for level in levels):
+            lo, hi = sorted(levels, key=lambda c: c.value)
+            paradoxes.append(
+                OntologyParadox(
+                    kind="confidence",
+                    fragment_ids=(first_for_confidence[lo], first_for_confidence[hi]),
+                    description=(
+                        f"The topic is held at opposite confidence levels — "
+                        f"{lo.value} in one fragment and {hi.value} in another."
                     ),
                 )
             )
@@ -578,6 +641,47 @@ def _ontology_claim(
     return EvidenceClaim(claim=summary, source_fragments=fragment_ids.copy())
 
 
+_CONFIDENCE_SENTINELS: tuple[tuple[str, object], ...] = (
+    ("frequency", Frequency.UNCLASSIFIED),
+    ("phase", Phase.UNCLASSIFIED),
+    ("mode", Mode.UNCLASSIFIED),
+    ("dosage", Dosage.UNCLASSIFIED),
+)
+"""The sentinel-bearing axes whose classification rate feeds overall confidence."""
+
+
+def _overall_confidence(signals: list[tuple[str, _FragmentSignal]]) -> float:
+    """Aggregate corpus-wide classification coverage into a 0.0-1.0 confidence.
+
+    The score is the mean, across fragments, of the fraction of
+    sentinel-bearing axes (frequency / phase / mode / dosage) that resolved to
+    a non-``UNCLASSIFIED`` value. A fully-classified corpus scores 1.0; an
+    all-unclassified corpus scores 0.0; partial classification lands in
+    between — a real signal the prior ``1.0 if signals else 0.0`` placeholder
+    could not express. Voice register is excluded: it has no ``UNCLASSIFIED``
+    sentinel, so "did it classify" is not well-defined for that axis.
+
+    Args:
+        signals: ``(fragment_id, signal)`` pairs for the classified corpus.
+
+    Returns:
+        The mean axis-coverage fraction, rounded to four decimal places, or
+        ``0.0`` for an empty corpus.
+    """
+    if not signals:
+        return 0.0
+    axis_count = len(_CONFIDENCE_SENTINELS)
+    total = 0.0
+    for _fid, sig in signals:
+        classified = sum(
+            1
+            for axis, sentinel in _CONFIDENCE_SENTINELS
+            if getattr(sig, axis) is not sentinel
+        )
+        total += classified / axis_count
+    return round(total / len(signals), 4)
+
+
 def _build_analysis(
     signals: list[tuple[str, _FragmentSignal]],
 ) -> OntologyAnalysis:
@@ -585,14 +689,16 @@ def _build_analysis(
 
     Each axis is aggregated independently: frequency / phase / mode / dosage
     drop their ``UNCLASSIFIED`` sentinel, while voice register (no such
-    sentinel) drops the ``None`` picks via :func:`_aggregate_optional`. Dosage
-    and phase contradictions are surfaced — never resolved.
+    sentinel) drops the ``None`` picks via :func:`_aggregate_optional`. Dosage,
+    phase, and confidence contradictions are surfaced — never resolved — and
+    ``overall_confidence`` reflects the corpus-wide classification coverage
+    (see :func:`_overall_confidence`).
 
     Args:
         signals: ``(fragment_id, signal)`` pairs for the classified corpus.
 
     Returns:
-        The aggregated analysis with full confidence when any signal is present.
+        The aggregated analysis with confidence scaled to axis coverage.
     """
     return OntologyAnalysis(
         frequencies=_aggregate_dimension(
@@ -611,9 +717,11 @@ def _build_analysis(
             [sig.voice_register for _id, sig in signals]
         ),
         paradoxes=tuple(
-            _detect_dosage_paradoxes(signals) + _detect_phase_paradoxes(signals)
+            _detect_dosage_paradoxes(signals)
+            + _detect_phase_paradoxes(signals)
+            + _detect_confidence_paradoxes(signals)
         ),
-        overall_confidence=1.0 if signals else 0.0,
+        overall_confidence=_overall_confidence(signals),
     )
 
 

--- a/creek-tools/creek/generate/paradox.py
+++ b/creek-tools/creek/generate/paradox.py
@@ -79,7 +79,7 @@ OPPOSITE_PHASE_PAIRS: frozenset[frozenset[str]] = frozenset(
 """Archetypal Wavelength phase pairs treated as opposites for Rule 1."""
 
 
-_OPPOSITE_CONFIDENCE_PAIRS: frozenset[frozenset[str]] = frozenset(
+OPPOSITE_CONFIDENCE_PAIRS: frozenset[frozenset[str]] = frozenset(
     {
         frozenset({Confidence.MUSING.value, Confidence.SETTLED.value}),
         frozenset({Confidence.MUSING.value, Confidence.CONVICTION.value}),
@@ -423,7 +423,7 @@ class ParadoxDetector:
         if conf_a is None or conf_b is None:
             return False
         pair = frozenset({str(conf_a), str(conf_b)})
-        return pair in _OPPOSITE_CONFIDENCE_PAIRS
+        return pair in OPPOSITE_CONFIDENCE_PAIRS
 
     @staticmethod
     def _opposite_dosages(a: Fragment, b: Fragment) -> bool:

--- a/creek-tools/tests/test_real_agents.py
+++ b/creek-tools/tests/test_real_agents.py
@@ -183,6 +183,11 @@ _F6_BODY = "community empathy harmony inclusion caring sharing equality consensu
 _F3_BODY = "power dominance control conquest force aggression warrior rebellion"
 _RISING_BODY = "emerging building growing momentum ascending intensifying gathering"
 _DIMINISHING_BODY = "diminishing declining waning subsiding settling calming quieting"
+# Confidence-keyword bodies (CONFIDENCE_SIGNALS) drawn from an opposite pair —
+# MUSING vs CONVICTION — so the rule classifier resolves opposite confidence and
+# the Ontology agent surfaces a confidence paradox deterministically.
+_MUSING_BODY = "maybe perhaps wondering possibly might not sure could be"
+_CONVICTION_BODY = "absolutely undeniably fundamental non-negotiable i am certain"
 # Dense with analytical voice-register signals (VOICE_REGISTER_SIGNALS) so the
 # rule classifier resolves the fragment's register to ANALYTICAL deterministically.
 _ANALYTICAL_BODY = (
@@ -273,6 +278,43 @@ def test_ontology_surfaces_phase_paradox_without_resolving(tmp_path: Path) -> No
     assert {Phase.RISING, Phase.DIMINISHING} <= phase_values
 
 
+def test_ontology_surfaces_confidence_paradox_without_resolving(
+    tmp_path: Path,
+) -> None:
+    """Opposite confidence levels across fragments surface a confidence paradox."""
+    _write_classified(tmp_path, "frag-musing", "Tentative take", body=_MUSING_BODY)
+    _write_classified(tmp_path, "frag-sure", "Firm take", body=_CONVICTION_BODY)
+
+    bundle = OntologySpecialist().gather("take", tmp_path)
+
+    assert bundle.ontology is not None
+    confidence_paradoxes = [
+        p for p in bundle.ontology.paradoxes if p.kind == "confidence"
+    ]
+    assert confidence_paradoxes, "confidence contradiction must be surfaced"
+    assert set(confidence_paradoxes[0].fragment_ids) == {"frag-musing", "frag-sure"}
+
+
+def test_ontology_overall_confidence_scales_with_axis_coverage(
+    tmp_path: Path,
+) -> None:
+    """``overall_confidence`` is a real aggregate, not 1.0 whenever a signal exists.
+
+    A fragment keyworded only on frequency and phase leaves mode and dosage
+    UNCLASSIFIED, so corpus-wide axis coverage is strictly below full
+    confidence — a distinction the old ``1.0 if signals else 0.0`` placeholder
+    could not express.
+    """
+    _write_classified(
+        tmp_path, "frag-partial", "Rising power", body=f"{_F3_BODY} {_RISING_BODY}"
+    )
+
+    bundle = OntologySpecialist().gather("power", tmp_path)
+
+    assert bundle.ontology is not None
+    assert 0.0 < bundle.ontology.overall_confidence < 1.0
+
+
 def test_ontology_empty_vault_returns_empty_bundle(tmp_path: Path) -> None:
     """An empty corpus yields an empty bundle with no ontology and no crash."""
     bundle = OntologySpecialist().gather("q", tmp_path)
@@ -290,6 +332,7 @@ def test_ontology_unclassified_corpus_still_grounds_claim(tmp_path: Path) -> Non
     bundle = OntologySpecialist().gather("q", tmp_path)
 
     assert bundle.ontology is not None
+    assert bundle.ontology.overall_confidence == 0.0
     assert bundle.claims
     cited = {fid for claim in bundle.claims for fid in claim.source_fragments}
     assert cited == {"frag-a", "frag-b"}


### PR DESCRIPTION
## Summary

Closes the three polish items in #494 for the Ontology specialist's analysis aggregation (`creek/author/agents.py`):

1. **Real `overall_confidence`.** Replaces the `1.0 if signals else 0.0` placeholder with `_overall_confidence`: the mean, across fragments, of the fraction of the four sentinel-bearing axes (frequency / phase / mode / dosage) that resolved to a non-`UNCLASSIFIED` value. A fully-classified corpus → `1.0`, all-unclassified → `0.0`, partial classification lands in between (rounded to 4 dp). Voice register is excluded — it has no `UNCLASSIFIED` sentinel, so "did it classify" is undefined there.
2. **Wire the `confidence` paradox kind.** `OntologyParadox.kind` already advertised `"confidence"` but nothing emitted it. Added `_detect_confidence_paradoxes`, mirroring `_detect_phase_paradoxes`, reusing the now-public `OPPOSITE_CONFIDENCE_PAIRS` from `creek.generate.paradox` so the desk and the vault agree on what a confidence contradiction is. `_FragmentSignal` now also carries `confidence` (from the rule classifier's deterministic `voice.confidence`, rewrapped to the enum like `voice_register`). Chose to **wire** rather than drop, per the issue's stated preference.
3. **Clarify the sort idiom.** `sorted(OPPOSITE_PHASE_PAIRS, key=sorted)` is replaced by a named `_pair_sort_key(pair)` helper with a docstring explaining the deterministic-ordering intent. (A bare lambda would trip `FURB111`; a named key reads clearly and passes refurb.)

`OPPOSITE_CONFIDENCE_PAIRS` was renamed from the private `_OPPOSITE_CONFIDENCE_PAIRS` in `generate/paradox.py` (only internal caller updated) to mirror the already-public `OPPOSITE_PHASE_PAIRS`.

## Test plan

New/updated tests in `tests/test_real_agents.py`:
- `test_ontology_surfaces_confidence_paradox_without_resolving` — opposite confidence (musing vs conviction) across fragments surfaces a `kind="confidence"` paradox naming both fragments.
- `test_ontology_overall_confidence_scales_with_axis_coverage` — a fragment keyworded only on frequency+phase yields `0.0 < overall_confidence < 1.0` (the old placeholder could only return `1.0`).
- `test_ontology_unclassified_corpus_still_grounds_claim` — strengthened to assert `overall_confidence == 0.0`.

Gates: TDD (red→green confirmed), `./scripts/check-all.sh` → 12/12 passed (5285 tests, 93.82% coverage), refurb + ruff clean.

Refs #417

Closes #494