### PR TITLE
refactor(cli): author --work path-existence check + explicit query invariant (#498)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2989,12 +2989,22 @@ def _compose_author_query(query: str | None, work: Path | None) -> str:
 
     Returns:
         The effective query string to author from.
+
+    Raises:
+        ValueError: If both ``query`` and ``work`` are ``None`` — the
+            upstream-validated invariant has been violated.
     """
     if work is not None:
         derived = f"Report on the work at {work}, relating it to my threads and eddies."
         return f"{derived} {query}" if query else derived
-    # Validation guarantees a non-None query for non-book-report mediums.
-    return query or ""
+    if query is None:
+        # Unreachable via the CLI: ``_validate_author_inputs`` requires a query
+        # for every non-book-report medium, and book-report always supplies
+        # ``--work`` (handled above). Make that contract explicit instead of
+        # silently authoring from an empty query.
+        msg = "--query or --work must be provided to compose an author query."
+        raise ValueError(msg)
+    return query
 
 
 @app.command()
@@ -3011,6 +3021,9 @@ def author(
     work: Path | None = typer.Option(
         None,
         "--work",
+        exists=True,
+        file_okay=False,
+        dir_okay=True,
         help="For book-report: the 11-Other-Authors/<author>/<work> path to report on.",
     ),
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),

--- a/creek-tools/tests/test_cli_author.py
+++ b/creek-tools/tests/test_cli_author.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import pytest
 from typer.testing import CliRunner
 
-from creek.cli import app
+from creek.cli import _compose_author_query, app
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -130,6 +131,63 @@ def test_author_book_report_runs_from_work_without_query(tmp_path: Path) -> None
 
     assert result.exit_code == 0, result.output
     assert "verdict=" in result.output
+
+
+def test_author_book_report_rejects_missing_work(tmp_path: Path) -> None:
+    """``--work`` pointing at a non-existent path fails fast with a typer error."""
+    vault = _vault(tmp_path)
+    missing = vault / "11-Other-Authors" / "nobody" / "no-such-work"
+    result = runner.invoke(
+        app,
+        [
+            "author",
+            "--medium",
+            "book-report",
+            "--work",
+            str(missing),
+            "--vault",
+            str(vault),
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "--work" in result.output
+    assert "does not exist" in result.output
+
+
+def test_author_book_report_rejects_file_work(tmp_path: Path) -> None:
+    """``--work`` pointing at a file (not a work directory) is rejected."""
+    vault = _vault(tmp_path)
+    work_file = vault / "11-Other-Authors" / "naval-ravikant" / "on-leverage.md"
+    work_file.parent.mkdir(parents=True)
+    work_file.write_text("not a directory", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "author",
+            "--medium",
+            "book-report",
+            "--work",
+            str(work_file),
+            "--vault",
+            str(vault),
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "--work" in result.output
+
+
+def test_compose_author_query_requires_query_or_work() -> None:
+    """The composer makes its upstream-validated invariant explicit.
+
+    ``_validate_author_inputs`` guarantees a non-None query for every
+    non-book-report medium (and book-report always carries ``--work``), so
+    reaching the composer with both ``None`` is a programming error — it raises
+    rather than silently authoring from an empty query.
+    """
+    with pytest.raises(ValueError, match="--query or --work"):
+        _compose_author_query(None, None)
 
 
 def test_author_max_rounds_out_of_range(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes the two non-blocking polish notes in #498 (from the #469 review, PR #497), both in `creek/cli.py`'s `author` command:

1. **`--work` path existence.** The `--work` option now carries typer's `exists=True, file_okay=False, dir_okay=True`. A missing path (or a file where a work *directory* is expected — the canonical `11-Other-Authors/<author>/<work>/` layout) now fails fast with a clear typer error (exit 2) instead of silently producing an empty book report from a nonexistent path.
2. **Drop the unreachable `query or ""` fallback.** `_validate_author_inputs` already guarantees a non-None query for every non-book-report medium, and book-report always supplies `--work` (handled by the earlier branch), so the `return query or ""` fallback was dead. `_compose_author_query` now raises `ValueError` when both `query` and `work` are `None`, making the upstream-validated invariant explicit and testable rather than masking a contract violation with an empty query.

## Test plan

New tests in `tests/test_cli_author.py`:
- `test_author_book_report_rejects_missing_work` — non-existent `--work` exits 2 with a "does not exist" typer error.
- `test_author_book_report_rejects_file_work` — a file passed as `--work` is rejected (`file_okay=False`).
- `test_compose_author_query_requires_query_or_work` — `_compose_author_query(None, None)` raises `ValueError` (direct unit test of the now-explicit invariant).

Existing `test_author_book_report_runs_from_work_without_query` (which creates the work directory) still passes.

Gates: TDD (red→green confirmed), `./scripts/check-all.sh` → 12/12 passed.

Refs #417

Closes #498