### PR TITLE
refactor(vault): pure attribution helper + loader fail-closed branch tests (#500)

### DIFF
--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -390,13 +390,13 @@ def _atomic_write_text(path: Path, content: str) -> None:
 def _apply_other_author_attribution(
     fragment: Fragment,
     manifest: AuthorManifest,
-) -> None:
-    """Stamp borrowed-author attribution from *manifest* onto *fragment* (#470).
+) -> Fragment:
+    """Return a copy of *fragment* stamped with *manifest* attribution (#470).
 
-    Mutates *fragment* in place (``Fragment``/``FragmentSource`` are mutable
-    Pydantic models, not frozen). Only the *attribution* axis changes — the
+    Pure function — *fragment* is never mutated; a new ``Fragment`` (with a new
+    ``FragmentSource``) is returned. Only the *attribution* axis changes — the
     fragment's frequency / wavelength / voice (its IDEAS classification, set
-    upstream) is left untouched:
+    upstream) is carried over untouched:
 
     * ``source.author_slug`` ← the manifest slug (the folder name).
     * ``source.author`` ← per :data:`_AUTHOR_KIND_TO_AUTHORSHIP`
@@ -406,20 +406,38 @@ def _apply_other_author_attribution(
     * ``voice_weight`` ← the manifest's ``voice_weight`` (default ``0.0``, and
       ``0.0`` when the manifest was loaded fail-closed from a missing file).
 
+    Returning a copy (rather than mutating in place) means a future caller can't
+    reintroduce the caller-mutation bug the writer's deep copy used to guard
+    against (#500).
+
     Args:
-        fragment: The fragment to stamp (mutated in place).
+        fragment: The fragment to stamp (read-only).
         manifest: The governing ``11-Other-Authors/<slug>/`` manifest.
+
+    Returns:
+        A new ``Fragment`` carrying the borrowed-author attribution.
     """
-    fragment.source.author_slug = manifest.author_slug
-    fragment.source.author = _AUTHOR_KIND_TO_AUTHORSHIP.get(
-        manifest.author_kind,
-        Authorship.OTHER,
+    representativeness = (
+        "endorsed"
+        if manifest.author_kind == "ai_as_user"
+        else manifest.representativeness
     )
-    if manifest.author_kind == "ai_as_user":
-        fragment.representativeness = "endorsed"
-    else:
-        fragment.representativeness = manifest.representativeness
-    fragment.voice_weight = manifest.voice_weight
+    source = fragment.source.model_copy(
+        update={
+            "author_slug": manifest.author_slug,
+            "author": _AUTHOR_KIND_TO_AUTHORSHIP.get(
+                manifest.author_kind,
+                Authorship.OTHER,
+            ),
+        },
+    )
+    return fragment.model_copy(
+        update={
+            "source": source,
+            "representativeness": representativeness,
+            "voice_weight": manifest.voice_weight,
+        },
+    )
 
 
 class VaultWriter:
@@ -524,11 +542,11 @@ class VaultWriter:
         """
         slug = fragment.source.author_slug
         if slug:
-            # Stamp on a deep copy so the caller's Fragment is never mutated —
-            # only the written file carries the manifest attribution (#470).
-            stamped = fragment.model_copy(deep=True)
+            # The helper returns a stamped copy, so the caller's Fragment is
+            # never mutated — only the written file carries the manifest
+            # attribution (#470).
             manifest = load_author_manifest_or_default(self.vault_path, slug)
-            _apply_other_author_attribution(stamped, manifest)
+            stamped = _apply_other_author_attribution(fragment, manifest)
             target_dir = self.vault_path / OTHER_AUTHORS_DIR / slug
             return self._write_model(stamped, target_dir, body=body)
         platform = fragment.source.platform

--- a/creek-tools/tests/test_author_manifest.py
+++ b/creek-tools/tests/test_author_manifest.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, get_args
 
 import pytest
+import yaml
+from pydantic import ValidationError
 
 from creek.models import AuthorKind, AuthorManifest, PrivacyTier, Representativeness
+from creek.vault import authors
 from creek.vault.authors import (
     load_author_manifest,
     load_author_manifest_or_default,
@@ -20,6 +23,16 @@ from creek.vault.authors import (
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+_MALFORMED_YAML = "---\nauthor_kind: human_source\n  bad: indent\n: : :\n---\n# body\n"
+
+
+def _a_validation_error() -> ValidationError:
+    """Capture a genuine ``ValidationError`` to exercise the loader branch."""
+    with pytest.raises(ValidationError) as exc_info:
+        AuthorManifest.model_validate(123)
+    return exc_info.value
+
 
 _FULL_MANIFEST = """---
 type: author_manifest
@@ -295,3 +308,62 @@ def test_load_or_default_fails_closed_when_missing(tmp_path: Path) -> None:
     assert manifest.author_kind == "human_source"
     assert manifest.voice_weight == 0.0
     assert manifest.representativeness == "reference"
+
+
+def test_load_or_default_fails_closed_on_malformed_yaml(tmp_path: Path) -> None:
+    """Malformed manifest YAML fails closed to a safe default, not a raise."""
+    _write_manifest(tmp_path, "garbled", _MALFORMED_YAML)
+
+    manifest = load_author_manifest_or_default(tmp_path, "garbled")
+
+    assert manifest == AuthorManifest(author_slug="garbled")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [OSError("disk"), yaml.YAMLError("bad"), _a_validation_error()],
+    ids=["oserror", "yamlerror", "validationerror"],
+)
+def test_load_or_default_fails_closed_on_loader_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error: Exception,
+) -> None:
+    """Every fail-closed branch resolves to a safe default manifest (#500).
+
+    Drives each ``except`` arm of ``load_author_manifest_or_default`` directly
+    at the loader level (rather than only end-to-end through the writer) by
+    making the inner parse raise the corresponding error.
+    """
+
+    def _raise(_path: Path) -> AuthorManifest:
+        raise error
+
+    monkeypatch.setattr(authors, "load_author_manifest", _raise)
+
+    manifest = load_author_manifest_or_default(tmp_path, "slug")
+
+    assert manifest == AuthorManifest(author_slug="slug")
+
+
+def test_load_or_default_fails_closed_when_present_but_unreadable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A present-but-unreadable ``_author.md`` fails closed like a missing one.
+
+    ``is_file()`` returns True for a permission-locked file, so the *read* (not
+    the existence check) is what fails. The resulting ``PermissionError`` (an
+    ``OSError``) is caught and normalised to the same safe default a missing
+    manifest produces — confirming the two paths agree (#500 item 3).
+    """
+    _write_manifest(tmp_path, "locked", _FULL_MANIFEST)
+
+    def _deny(_path: str) -> object:
+        raise PermissionError("locked")
+
+    monkeypatch.setattr(authors.frontmatter, "load", _deny)
+
+    manifest = load_author_manifest_or_default(tmp_path, "locked")
+
+    assert manifest == AuthorManifest(author_slug="locked")

--- a/creek-tools/tests/test_other_author_attribution.py
+++ b/creek-tools/tests/test_other_author_attribution.py
@@ -18,6 +18,7 @@ import pytest
 from pydantic import ValidationError
 
 from creek.models import (
+    AuthorManifest,
     Fragment,
     FragmentSource,
     Frequency,
@@ -26,7 +27,7 @@ from creek.models import (
     SourcePlatform,
     WavelengthClassification,
 )
-from creek.vault.writer import VaultWriter
+from creek.vault.writer import VaultWriter, _apply_other_author_attribution
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -273,6 +274,38 @@ class TestOtherAuthorAttribution:
         assert post["source"]["author_slug"] is None
         assert post["voice_weight"] == 1.0
         assert post["representativeness"] == "self"
+
+
+def test_apply_other_author_attribution_returns_new_fragment_without_mutating() -> None:
+    """The helper is pure: it returns a stamped copy and never mutates its input.
+
+    The writer's deep-copy guard (#470) already protected callers end-to-end,
+    but the helper itself was an in-place mutator — a footgun for any future
+    caller. It now returns a fresh Fragment so caller-mutation can't be
+    reintroduced (#500).
+    """
+    frag = _classified_borrowed_fragment("mentor", "frag-pure0001")
+    manifest = AuthorManifest(
+        author_slug="mentor",
+        author_kind="human_source",
+        voice_weight=0.3,
+        representativeness="aspirational",
+    )
+
+    stamped = _apply_other_author_attribution(frag, manifest)
+
+    # A distinct object (and distinct nested source) is returned.
+    assert stamped is not frag
+    assert stamped.source is not frag.source
+    # The returned copy carries the manifest attribution.
+    assert stamped.voice_weight == 0.3
+    assert stamped.representativeness == "aspirational"
+    assert stamped.source.author == "other"
+    assert stamped.source.author_slug == "mentor"
+    # The caller's fragment keeps its native defaults — never mutated.
+    assert frag.voice_weight == 1.0
+    assert frag.representativeness == "self"
+    assert frag.source.author == "self"
 
 
 class TestAuthorSlugPathSafety:


### PR DESCRIPTION
## Summary

Closes the three non-blocking follow-ups in #500 (from the #470 review, PR #499):

1. **Loader-level fail-closed branch tests.** `load_author_manifest_or_default`'s fail-closed branches were only exercised end-to-end through the writer. Added direct loader-level tests for each arm: malformed YAML (real file), `OSError`, `yaml.YAMLError`, and `ValidationError` (the latter three via a patched parse so each `except` arm is covered deterministically).
2. **`_apply_other_author_attribution` is now pure.** The helper used to mutate its `Fragment` argument in place; `write_fragment` guarded callers with a deep copy, but the helper itself remained a footgun. It now returns a stamped copy (new `Fragment` + new `FragmentSource`), and `write_fragment` drops its defensive deep copy and uses the returned value — so the caller-mutation bug can't be reintroduced by a future caller.
3. **`is_file()` permission edge confirmed/normalised.** `is_file()` returns True for a permission-locked file, so the *read* (not the existence check) fails. The resulting `PermissionError` (an `OSError`) is caught by the loader's existing fail-closed arm and normalised to the same safe default a missing manifest produces. No code change needed — behaviour was already correct; locked in with an explicit test.

## Test plan

- `tests/test_author_manifest.py`:
  - `test_load_or_default_fails_closed_on_malformed_yaml` — real bad-YAML file → safe default.
  - `test_load_or_default_fails_closed_on_loader_error` — parametrized over `OSError` / `yaml.YAMLError` / `ValidationError`.
  - `test_load_or_default_fails_closed_when_present_but_unreadable` — present-but-unreadable file → same default as missing (item 3).
- `tests/test_other_author_attribution.py`:
  - `test_apply_other_author_attribution_returns_new_fragment_without_mutating` — helper returns a distinct object and never mutates its input.
- Existing `test_write_does_not_mutate_caller_fragment` (the #470 end-to-end guard) and the full attribution suite still pass.

Gates: TDD (red→green confirmed), `./scripts/check-all.sh` → 12/12 passed.

Refs #417

Closes #500