### PR TITLE
polish(author): voice agent minor cleanups from #471 review (#503)

### DIFF
--- a/creek-tools/creek/author/voice.py
+++ b/creek-tools/creek/author/voice.py
@@ -186,6 +186,8 @@ def _dominant_phase(evidence: EvidenceBundle) -> str | None:
     ontology = evidence.ontology
     if ontology is None or not ontology.phases:
         return None
+    # Double ``.value`` is intentional: ``WeightedDimension.value`` is the enum
+    # member (a ``Phase``), and *its* ``.value`` is the canonical slug string.
     return ontology.phases[0].value.value
 
 
@@ -194,6 +196,8 @@ def _dominant_register(evidence: EvidenceBundle) -> str | None:
     ontology = evidence.ontology
     if ontology is None or not ontology.voice_registers:
         return None
+    # Double ``.value``: the ``WeightedDimension.value`` enum member, then its
+    # ``.value`` slug — see :func:`_dominant_phase`.
     return ontology.voice_registers[0].value.value
 
 

--- a/creek-tools/tests/test_synthesis_voice.py
+++ b/creek-tools/tests/test_synthesis_voice.py
@@ -19,7 +19,12 @@ from creek.author.contracts import load_medium_contract
 from creek.author.models import EvidenceBundle, EvidenceClaim
 from creek.author.reflection import ReflectionNode
 from creek.author.skills import read_skill
-from creek.author.voice import VoiceAgent
+from creek.author.voice import (
+    VoiceAgent,
+    _deterministic_body,
+    _evidence_section,
+    _owner_claims,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -134,8 +139,35 @@ def test_run_grounded_and_voiced_end_to_end(tmp_path: Path) -> None:
 
     assert draft.provenance
     assert all(entry.fragment_ids for entry in draft.provenance)
-    assert draft.rendered_text == "Voiced in the owner's register."
+    # Structural / containment assertions (not exact equality) so a future
+    # body-wrapping change can't make this brittle (#503).
+    assert draft.rendered_text.strip()
+    assert "Voiced in the owner's register." in draft.rendered_text
     provider.call_with_metadata.assert_called_once()
+
+
+def test_all_borrowed_claims_yield_no_owner_voiced_material() -> None:
+    """All-borrowed evidence leaves the owner nothing of their own to voice.
+
+    When every claim carries an ``author_slug`` it is already attributed to
+    another author and must never be voiced as the owner's words, so
+    ``_owner_claims`` is empty. The deterministic body degrades to the query
+    heading alone and the evidence section to the ``(no grounded evidence)``
+    placeholder. This pins that intended degradation explicitly (#503).
+    """
+    bundle = EvidenceBundle(
+        claims=[
+            EvidenceClaim(
+                claim="A borrowed insight",
+                source_fragments=["frag-x"],
+                author_slug="naval-ravikant",
+            ),
+        ],
+    )
+
+    assert _owner_claims(bundle) == []
+    assert _deterministic_body("What do I think?", bundle) == "# What do I think?\n"
+    assert "(no grounded evidence)" in _evidence_section(bundle)
 
 
 def _sent_prompt(provider: MagicMock) -> str:


### PR DESCRIPTION
## Summary

Closes the three non-blocking cleanups in #503 (from the #471 review, PR #501), all in `creek/author/voice.py`:

1. **Clarify the double `.value`.** `_dominant_phase` / `_dominant_register` read `ontology.phases[0].value.value`, which looks like a typo at a glance. Added a short comment to each explaining it is intentional — `WeightedDimension.value` is the enum member (`Phase` / `VoiceRegister`), and *its* `.value` is the canonical slug string. (Kept as a comment rather than a generic accessor to avoid TypeVar/`.value`-typing churn for a cosmetic item.)
2. **Pin the all-borrowed-claims edge.** When every claim carries an `author_slug`, `_owner_claims` is empty (borrowed claims are already attributed and must never be voiced as the owner's words), so the deterministic body degrades to the query heading alone and the evidence section to `(no grounded evidence)`. This was implicit; now an explicit test confirms it as intended behaviour.
3. **Harden the end-to-end assertion.** `test_run_grounded_and_voiced_end_to_end` asserted exact string equality against the mock output; switched to non-empty + containment assertions so a future body-wrapping change can't make it brittle.

No production behaviour change — item 1 is a comment, items 2–3 are characterization/robustness tests.

## Test plan

- New `test_all_borrowed_claims_yield_no_owner_voiced_material` — drives `_owner_claims` / `_deterministic_body` / `_evidence_section` with an all-borrowed bundle and pins the degraded output.
- `test_run_grounded_and_voiced_end_to_end` now asserts `draft.rendered_text.strip()` is non-empty and contains the voiced text (instead of `==`).

Gates: `./scripts/check-all.sh` → 12/12 passed (full voice-synthesis suite green).

Refs #417

Closes #503