### PR TITLE
harden(author): _TIER_RANK fail-closed on future PrivacyTier extension (#509)

### DIFF
--- a/creek-tools/creek/author/checks.py
+++ b/creek-tools/creek/author/checks.py
@@ -55,6 +55,21 @@ _TIER_RANK: dict[PrivacyTier, int] = {
     PrivacyTier.UNCLASSIFIED: 3,
 }
 
+_MOST_RESTRICTIVE_RANK = max(_TIER_RANK.values())
+"""Fail-closed rank for an unranked *fragment* tier (#509).
+
+A future :class:`~creek.models.PrivacyTier` not yet added to ``_TIER_RANK`` is
+treated as the most restrictive — so an unknown cited tier still trips the
+leak gate rather than raising ``KeyError`` (consistent with the
+``UNCLASSIFIED = most-restrictive`` convention)."""
+
+_LEAST_RESTRICTIVE_RANK = min(_TIER_RANK.values())
+"""Fail-closed rank for an unranked *ceiling* tier (#509).
+
+An unrecognised contract ``default_privacy_tier`` gates as strictly as
+possible (the lowest ceiling), so more cited tiers count as over-tier rather
+than fewer — the conservative direction for a HARD gate."""
+
 #: Legacy alias keys whose presence in a body signals non-canonical taxonomy
 #: (INC-019). Maps each deprecated alias to its canonical replacement.
 _LEGACY_ALIASES: dict[str, str] = (
@@ -261,7 +276,7 @@ def check_privacy_compliance(
     # Pydantic stores tiers as the underlying str; coerce back to the enum so
     # the ordering lookup and display are well-defined.
     ceiling_tier = PrivacyTier(contract.default_privacy_tier)
-    ceiling = _TIER_RANK[ceiling_tier]
+    ceiling = _TIER_RANK.get(ceiling_tier, _LEAST_RESTRICTIVE_RANK)
     findings: list[ReflectionFinding] = []
     for frag_id, (raw_tier, frag_body) in _resolve_cited_tiers(evidence, vault).items():
         tier = PrivacyTier(raw_tier)
@@ -270,7 +285,8 @@ def check_privacy_compliance(
         # protected body (see :func:`_is_verbatim_leak`). A paraphrase of
         # over-tier content — or a snippet too short to be a reliable signal —
         # is NOT caught here; that needs the semantic LLM judge (#474).
-        if _TIER_RANK[tier] > ceiling and _is_verbatim_leak(protected, body):
+        rank = _TIER_RANK.get(tier, _MOST_RESTRICTIVE_RANK)
+        if rank > ceiling and _is_verbatim_leak(protected, body):
             findings.append(
                 ReflectionFinding(
                     dimension="privacy_compliance",

--- a/creek-tools/tests/test_reflection.py
+++ b/creek-tools/tests/test_reflection.py
@@ -10,7 +10,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from creek.author.checks import check_voice_fidelity
+import pytest
+
+from creek.author.checks import (
+    _TIER_RANK,
+    check_privacy_compliance,
+    check_voice_fidelity,
+)
 from creek.author.conductor import Conductor
 from creek.author.models import (
     EvidenceBundle,
@@ -259,6 +265,40 @@ def test_privacy_skips_cited_fragment_absent_from_vault(tmp_path: Path) -> None:
 
     assert result.decision == "PASS"
     assert not any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_every_privacy_tier_has_a_rank() -> None:
+    """Every PrivacyTier member is ranked, so the privacy gate never KeyErrors.
+
+    Adding a tier without updating ``_TIER_RANK`` would otherwise raise at
+    review time; this fails loudly at test time instead (#509).
+    """
+    for tier in PrivacyTier:
+        assert tier in _TIER_RANK
+
+
+def test_privacy_unranked_fragment_tier_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unranked cited fragment tier fails closed to most-restrictive, not KeyError.
+
+    Simulates a future ``PrivacyTier`` missing from ``_TIER_RANK`` by deleting
+    an existing entry: the cited fragment is still treated as over-tier
+    (flagged) and the rank lookup does not raise (#509).
+    """
+    monkeypatch.delitem(_TIER_RANK, PrivacyTier.INTIMATE)
+    secret = "my private therapy session notes"
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = f"leaked: {secret}"
+
+    findings = check_privacy_compliance(body, evidence, tmp_path, contract)
+
+    assert any(f.dimension == "privacy_compliance" for f in findings)
 
 
 def test_legacy_alias_maps_have_no_key_collisions() -> None:


### PR DESCRIPTION
## Summary

Closes #509 (non-blocking hardening from the #473 / PR #505 review).

`check_privacy_compliance` indexed `_TIER_RANK[tier]` directly. If a future `PrivacyTier` member were added without updating `_TIER_RANK`, the lookup would raise `KeyError` at review time — turning a forgotten map update into a hard crash on the privacy gate.

Both rank lookups now fail closed via `.get`, with **opposite** defaults so each errs toward the safe (more-restrictive) direction:

- **Unranked cited fragment tier** → `_MOST_RESTRICTIVE_RANK` (`max`): an unknown tier is treated as maximally restrictive, so it still trips the leak gate (consistent with the `UNCLASSIFIED = most-restrictive` convention).
- **Unranked ceiling tier** → `_LEAST_RESTRICTIVE_RANK` (`min`): an unrecognised contract `default_privacy_tier` gates as strictly as possible (lowest ceiling), so *more* cited tiers count as over-tier, not fewer.

## Test plan

New tests in `tests/test_reflection.py`:
- `test_every_privacy_tier_has_a_rank` — asserts every `PrivacyTier` member is present in `_TIER_RANK` (fails loudly at test time if a tier is added without a rank).
- `test_privacy_unranked_fragment_tier_fails_closed` — monkeypatches a member out of `_TIER_RANK` and confirms the cited fragment is still flagged (over-tier) and the lookup does **not** raise `KeyError`.

Gates: TDD (red→green confirmed — the second test KeyError'd before the fix), `./scripts/check-all.sh` → 12/12 passed.

Refs #417

Closes #509