### PR TITLE
feat(report): register decisions + lexicon report types as skeletons (#579)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1293,6 +1293,32 @@ def _report_voice(vault_path: Path) -> None:
     )
 
 
+def _report_decisions(vault_path: Path) -> None:
+    """Stub for the ``decisions`` report (skeleton; #579).
+
+    Routing tracer only — emits a typed "would generate" line and writes
+    nothing. The real ``DecisionDetector`` wiring lands in the follow-up that
+    persists ``08-Decisions/``; this proves the dispatch end-to-end first.
+    """
+    console.print(
+        "[bold green]Would generate: decision notes at 08-Decisions/ "
+        "(not yet wired — see follow-up)[/bold green]",
+    )
+
+
+def _report_lexicon(vault_path: Path) -> None:
+    """Stub for the ``lexicon`` report (skeleton; #579).
+
+    Routing tracer only — emits a typed "would generate" line and writes
+    nothing. The real ``LexiconGenerator`` wiring lands in the follow-up that
+    persists ``07-Voice/Lexicon/``; this proves the dispatch end-to-end first.
+    """
+    console.print(
+        "[bold green]Would generate: lexicon glossary at 07-Voice/Lexicon/ "
+        "(not yet wired — see follow-up)[/bold green]",
+    )
+
+
 def _report_wavelength(vault_path: Path, period: str | None) -> None:
     """Generate weekly or monthly wavelength reports."""
     from datetime import date as _date
@@ -1589,6 +1615,8 @@ _REPORT_DISPATCH: dict[str, Callable[[Path], None]] = {
     "unnamed": _report_unnamed,
     "voice": _report_voice,
     "fingerprint": _report_fingerprint,
+    "decisions": _report_decisions,
+    "lexicon": _report_lexicon,
 }
 
 

--- a/creek-tools/creek_mcp/tools/report.py
+++ b/creek-tools/creek_mcp/tools/report.py
@@ -1,9 +1,11 @@
 """``creek.report`` MCP tool — produce a vault-state report (FEAT-011).
 
-Wraps the CLI's report dispatcher. Two report types are exposed via
+Wraps the CLI's report dispatcher. Generating report types exposed via
 MCP today: ``tags`` (the tag-garden generator) and ``voice`` (the
-per-register voice profiles). ``unnamed`` and ``wavelength`` are
-deferred to the CLI because they need date arithmetic the MCP shape
+per-register voice profiles). ``decisions`` and ``lexicon`` are wired as
+skeletons (#579) — routable but not yet generating; they return a typed
+"would generate" note and write nothing. ``unnamed`` and ``wavelength``
+are deferred to the CLI because they need date arithmetic the MCP shape
 should not own. The wrapper writes one audit entry per invocation
 including ``created_path`` for the resulting report file(s).
 """
@@ -21,7 +23,14 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 TOOL_NAME = "creek.report"
-_VALID_TYPES = ("tags", "voice")
+_VALID_TYPES = ("tags", "voice", "decisions", "lexicon")
+
+#: Skeleton report types (#579): routing is wired, generation is not. Each maps
+#: to the human-readable target the follow-up will persist. Stubs write nothing.
+_STUB_TYPES = {
+    "decisions": "decision notes at 08-Decisions/",
+    "lexicon": "lexicon glossary at 07-Voice/Lexicon/",
+}
 
 
 def report_tool(
@@ -46,6 +55,29 @@ def report_tool(
                 f"available via MCP: {', '.join(_VALID_TYPES)}"
             ),
         )
+    if report_type in _STUB_TYPES:
+        # Skeleton tracer (#579): the type is routable but its generator is not
+        # yet wired. Audit the invocation (nothing written) and report intent.
+        MCPAuditLog(vault_path).append(
+            tool=TOOL_NAME,
+            args={"report_type": report_type},
+            tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+            created_path=None,
+            created_tier=None,
+            affected_fragment_ids=[],
+        )
+        return {
+            "status": "ok",
+            "tool": TOOL_NAME,
+            "tier_ceiling": privacy_tier_ceiling.value,
+            "report_type": report_type,
+            "report_paths": [],
+            "note": (
+                f"would generate: {_STUB_TYPES[report_type]} "
+                "(not yet wired — see follow-up)"
+            ),
+        }
     if report_type == "tags":
         written_paths = [
             TagGardenGenerator(vault_path=vault_path).generate_garden(),

--- a/creek-tools/docs/slash-commands.md
+++ b/creek-tools/docs/slash-commands.md
@@ -34,6 +34,18 @@ body as the prompt when you type `/creek <name>`.
 | `/creek skills [--refresh]` | `creek.skills` / `creek.skills.refresh` | Inspect or regenerate the voice-skill tree. |
 | `/creek ingest --type ... --input ...` | `creek.ingest` | Run the ingestion pipeline on a new source. |
 
+### `report` types
+
+`creek report --type <type>` (MCP: `creek.report`) supports `tags`, `voice`,
+`unnamed`, `wavelength`, and `fingerprint`. Two further types are **available
+as skeletons** — routing is wired but generation lands in follow-ups:
+
+- `decisions` — will persist decision notes to `08-Decisions/`.
+- `lexicon` — will persist a glossary to `07-Voice/Lexicon/`.
+
+Invoking a skeleton type prints/returns a "would generate …" message and writes
+nothing.
+
 ### Discoverability
 
 `/creek explain` lists every subcommand. Bare `/creek` runs the default

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1232,6 +1232,39 @@ def test_report_unnamed_command(tmp_path: Path) -> None:
     assert (vault / "10-Liminal" / "Unnamed" / "Digests").is_dir()
 
 
+def test_report_decisions_skeleton_stub(tmp_path: Path) -> None:
+    """``report --type decisions`` routes to its stub handler and writes nothing."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        ["report", "--type", "decisions", "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Would generate" in result.output
+    assert "08-Decisions/" in result.output
+    # Scope fence: the stub creates nothing under the target folder.
+    assert not (vault / "08-Decisions").exists()
+
+
+def test_report_lexicon_skeleton_stub(tmp_path: Path) -> None:
+    """``report --type lexicon`` routes to its stub handler and writes nothing."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        ["report", "--type", "lexicon", "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Would generate" in result.output
+    assert "07-Voice/Lexicon/" in result.output
+    assert not (vault / "07-Voice" / "Lexicon").exists()
+
+
 def test_report_voice_command(tmp_path: Path) -> None:
     """Test that report --type voice generates register profiles."""
     from datetime import UTC, datetime

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -493,6 +493,39 @@ def test_report_tags_writes_audit_entry(vault: Path) -> None:
     assert entries[-1]["tool"] == "creek.report"
 
 
+def test_report_decisions_stub_returns_would_generate(vault: Path) -> None:
+    """The ``decisions`` skeleton routes to a stub: ok, no paths, writes nothing."""
+    result = report_tool(
+        vault_path=vault,
+        report_type="decisions",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    assert result["report_type"] == "decisions"
+    assert result["report_paths"] == []
+    assert "would generate" in result["note"].lower()
+    assert "08-Decisions/" in result["note"]
+    # The invocation is still audited, but nothing was written — the audit
+    # entry omits ``created_path`` entirely when no file is produced.
+    last = _read_audit(vault)[-1]
+    assert last["tool"] == "creek.report"
+    assert "created_path" not in last
+
+
+def test_report_lexicon_stub_returns_would_generate(vault: Path) -> None:
+    """The ``lexicon`` skeleton routes to a stub: ok, no paths, writes nothing."""
+    result = report_tool(
+        vault_path=vault,
+        report_type="lexicon",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    assert result["report_type"] == "lexicon"
+    assert result["report_paths"] == []
+    assert "would generate" in result["note"].lower()
+    assert "07-Voice/Lexicon/" in result["note"]
+
+
 # ---------------------------------------------------------------------------
 # skills.refresh
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Tracer skeleton for epic #577 — proves the `report` routing end-to-end for two new types before any generation logic is wired (the real generators land in the #580/#581 follow-ups).

- **CLI** (`creek/cli.py`): `_report_decisions` / `_report_lexicon` stub handlers that emit a typed `Would generate: …` line and write nothing, registered in `_REPORT_DISPATCH`.
- **MCP** (`creek_mcp/tools/report.py`): `decisions` + `lexicon` added to `_VALID_TYPES`, with a `_STUB_TYPES` branch in `report_tool` that audits the invocation (`created_path` omitted — nothing produced) and returns a `would generate …` note with empty `report_paths`.
- **Docs** (`docs/slash-commands.md`): both documented as available skeletons; module docstring updated.

**Scope fence honoured:** `DecisionDetector` / `LexiconGenerator` are not imported or called here.

## Test plan

- `tests/test_cli.py`: `test_report_decisions_skeleton_stub`, `test_report_lexicon_skeleton_stub` — route to the stub, exit 0, print the would-generate line, and create no target folder.
- `tests/test_mcp_write_tools.py`: `test_report_decisions_stub_returns_would_generate`, `test_report_lexicon_stub_returns_would_generate` — status ok, empty `report_paths`, `note` present, audit entry written with no `created_path`.
- Existing `test_report_refuses_unsupported_type` (still refuses `wavelength`) and `test_report_tags_writes_audit_entry` unaffected.

Gates: TDD (red→green confirmed), `./scripts/check-all.sh` → 12/12 passed.

Refs #577

Closes #579