### PR TITLE
feat(report): wire lexicon → 07-Voice/Lexicon/ glossary (#580)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1307,15 +1307,26 @@ def _report_decisions(vault_path: Path) -> None:
 
 
 def _report_lexicon(vault_path: Path) -> None:
-    """Stub for the ``lexicon`` report (skeleton; #579).
+    """Generate the voice lexicon glossary + metaphor index (#580).
 
-    Routing tracer only — emits a typed "would generate" line and writes
-    nothing. The real ``LexiconGenerator`` wiring lands in the follow-up that
-    persists ``07-Voice/Lexicon/``; this proves the dispatch end-to-end first.
+    Collects the vault's voice exemplars (sharing the voice report's eligibility
+    gate), builds a :class:`~creek.generate.lexicon.Lexicon`, and persists it to
+    ``07-Voice/Lexicon/``. Mirrors ``_report_voice``'s friendly "no qualifying
+    exemplars" message when the corpus is empty.
     """
+    from creek.generate.lexicon import generate_lexicon
+
+    lexicon, written_paths = generate_lexicon(vault_path)
+    if lexicon is None or not written_paths:
+        console.print(
+            "[yellow]No lexicon generated: no qualifying exemplars found.[/yellow]",
+        )
+        return
+    glossary = written_paths[0]
     console.print(
-        "[bold green]Would generate: lexicon glossary at 07-Voice/Lexicon/ "
-        "(not yet wired — see follow-up)[/bold green]",
+        f"[bold green]Lexicon generated: {glossary.relative_to(vault_path)} "
+        f"({len(lexicon.coined_terms)} coined terms, "
+        f"{len(lexicon.metaphors)} metaphors)[/bold green]",
     )
 
 

--- a/creek-tools/creek/generate/lexicon.py
+++ b/creek-tools/creek/generate/lexicon.py
@@ -743,6 +743,40 @@ class LexiconGenerator:
         return "\n".join(lines)
 
 
+def generate_lexicon(vault_path: Path) -> tuple[Lexicon | None, list[Path]]:
+    """Collect the voice corpus, build the lexicon, and persist it (#580).
+
+    Reuses :meth:`creek.generate.voice.VoiceExemplarCollector.collect_all_exemplars`
+    (the same eligibility gate the voice-profile report uses) so the lexicon and
+    voice reports draw on one exemplar source of truth, extracts voice patterns
+    from their bodies, builds a :class:`Lexicon`, and writes the glossary plus
+    the per-domain metaphor index under ``07-Voice/Lexicon/``.
+
+    Coinage detection is reference-corpus gated (see
+    :class:`LexiconGenerator`); with no corpus configured the glossary still
+    fills from metaphors, distinctive phrases, and borrowed terms.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+
+    Returns:
+        ``(lexicon, written_paths)``. When the vault has no qualifying
+        exemplars, returns ``(None, [])`` and writes nothing — the caller
+        renders a friendly "no exemplars" message.
+    """
+    from creek.generate.voice import VoiceExemplarCollector, VoicePatternExtractor
+
+    exemplars = VoiceExemplarCollector().collect_all_exemplars(vault_path)
+    if not exemplars:
+        return None, []
+    patterns = VoicePatternExtractor().extract_patterns([e.body for e in exemplars])
+    generator = LexiconGenerator()
+    lexicon = generator.build_lexicon(exemplars, patterns)
+    glossary_path = generator.write_lexicon(lexicon, vault_path)
+    metaphor_paths = generator.write_metaphor_index(lexicon, vault_path)
+    return lexicon, [glossary_path, *metaphor_paths]
+
+
 __all__ = [
     "TRADITION_GLOSSARIES",
     "BorrowedTermEntry",
@@ -752,4 +786,5 @@ __all__ = [
     "LexiconContext",
     "LexiconGenerator",
     "MetaphorInventory",
+    "generate_lexicon",
 ]

--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -442,6 +442,39 @@ class VoiceExemplarCollector:
         self._warn_below_minimum(buckets)
         return buckets
 
+    def collect_all_exemplars(self, vault_path: Path) -> list[Exemplar]:
+        """Collect every qualifying exemplar across all registers, with bodies.
+
+        Shares the eligibility gate with :meth:`collect_exemplars` (``settled``
+        or ``conviction`` confidence, a set register, intimate filtered unless
+        :attr:`allow_intimate`, ``11-Other-Authors`` excluded) but returns a
+        flat :class:`Exemplar` list — fragment paired with its on-disk body —
+        rather than per-register ``Fragment`` buckets. Consumers that need the
+        whole voice corpus as one unit (e.g. the lexicon) use this so they share
+        a single source of truth for *which* fragments count as exemplars.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            Every qualifying exemplar with its body, in on-disk discovery order.
+        """
+        fragments_dir = vault_path / _FRAGMENTS_SUBDIR
+        exemplars: list[Exemplar] = []
+        if not fragments_dir.is_dir():
+            return exemplars
+        for md_file in sorted(fragments_dir.rglob("*.md")):
+            if _is_other_authors_path(md_file):
+                continue
+            loaded = _load_fragment_with_body(md_file)
+            if loaded is None:
+                continue
+            fragment, body = loaded
+            if self._eligible_register(fragment) is None:
+                continue
+            exemplars.append(Exemplar(fragment=fragment, body=body))
+        return exemplars
+
     def _eligible_register(self, fragment: Fragment) -> str | None:
         """Return the fragment's register if it qualifies, else ``None``."""
         return _eligible_register(fragment, allow_intimate=self.allow_intimate)

--- a/creek-tools/creek_mcp/tools/report.py
+++ b/creek-tools/creek_mcp/tools/report.py
@@ -1,19 +1,21 @@
 """``creek.report`` MCP tool — produce a vault-state report (FEAT-011).
 
 Wraps the CLI's report dispatcher. Generating report types exposed via
-MCP today: ``tags`` (the tag-garden generator) and ``voice`` (the
-per-register voice profiles). ``decisions`` and ``lexicon`` are wired as
-skeletons (#579) — routable but not yet generating; they return a typed
-"would generate" note and write nothing. ``unnamed`` and ``wavelength``
-are deferred to the CLI because they need date arithmetic the MCP shape
-should not own. The wrapper writes one audit entry per invocation
-including ``created_path`` for the resulting report file(s).
+MCP today: ``tags`` (the tag-garden generator), ``voice`` (the
+per-register voice profiles), and ``lexicon`` (the voice glossary +
+metaphor index, #580). ``decisions`` is wired as a skeleton (#579) —
+routable but not yet generating; it returns a typed "would generate"
+note and writes nothing. ``unnamed`` and ``wavelength`` are deferred to
+the CLI because they need date arithmetic the MCP shape should not own.
+The wrapper writes one audit entry per invocation including
+``created_path`` for the resulting report file(s).
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from creek.generate.lexicon import generate_lexicon
 from creek.generate.tags import TagGardenGenerator
 from creek.generate.voice import VoiceProfileGenerator
 from creek_mcp.audit import MCPAuditLog
@@ -27,9 +29,9 @@ _VALID_TYPES = ("tags", "voice", "decisions", "lexicon")
 
 #: Skeleton report types (#579): routing is wired, generation is not. Each maps
 #: to the human-readable target the follow-up will persist. Stubs write nothing.
+#: ``lexicon`` graduated to real generation in #580.
 _STUB_TYPES = {
     "decisions": "decision notes at 08-Decisions/",
-    "lexicon": "lexicon glossary at 07-Voice/Lexicon/",
 }
 
 
@@ -82,6 +84,8 @@ def report_tool(
         written_paths = [
             TagGardenGenerator(vault_path=vault_path).generate_garden(),
         ]
+    elif report_type == "lexicon":
+        _lexicon, written_paths = generate_lexicon(vault_path)
     else:
         written_paths = list(
             VoiceProfileGenerator().generate_all_profiles(vault_path),

--- a/creek-tools/docs/slash-commands.md
+++ b/creek-tools/docs/slash-commands.md
@@ -37,11 +37,12 @@ body as the prompt when you type `/creek <name>`.
 ### `report` types
 
 `creek report --type <type>` (MCP: `creek.report`) supports `tags`, `voice`,
-`unnamed`, `wavelength`, and `fingerprint`. Two further types are **available
-as skeletons** — routing is wired but generation lands in follow-ups:
+`unnamed`, `wavelength`, `fingerprint`, and `lexicon` — the last persists the
+voice glossary + metaphor index to `07-Voice/Lexicon/`. One further type is
+**available as a skeleton** — routing is wired but generation lands in a
+follow-up:
 
 - `decisions` — will persist decision notes to `08-Decisions/`.
-- `lexicon` — will persist a glossary to `07-Voice/Lexicon/`.
 
 Invoking a skeleton type prints/returns a "would generate …" message and writes
 nothing.

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1249,10 +1249,16 @@ def test_report_decisions_skeleton_stub(tmp_path: Path) -> None:
     assert not (vault / "08-Decisions").exists()
 
 
-def test_report_lexicon_skeleton_stub(tmp_path: Path) -> None:
-    """``report --type lexicon`` routes to its stub handler and writes nothing."""
+def test_report_lexicon_no_exemplars_is_friendly(tmp_path: Path) -> None:
+    """``report --type lexicon`` on a vault with no exemplars is friendly (#580).
+
+    The handler is now real (not the #579 stub), so an empty corpus prints the
+    "no qualifying exemplars" message, writes no glossary, and never falls back
+    to the old "Would generate" stub text.
+    """
     vault = tmp_path / "vault"
     (vault / "00-Creek-Meta").mkdir(parents=True)
+    (vault / "01-Fragments").mkdir(parents=True)
 
     result = runner.invoke(
         app,
@@ -1260,8 +1266,8 @@ def test_report_lexicon_skeleton_stub(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert "Would generate" in result.output
-    assert "07-Voice/Lexicon/" in result.output
+    assert "No lexicon generated" in result.output
+    assert "Would generate" not in result.output
     assert not (vault / "07-Voice" / "Lexicon").exists()
 
 

--- a/creek-tools/tests/test_lexicon.py
+++ b/creek-tools/tests/test_lexicon.py
@@ -23,6 +23,7 @@ from creek.generate.lexicon import (
     LexiconContext,
     LexiconGenerator,
     MetaphorInventory,
+    generate_lexicon,
 )
 from creek.generate.voice import (
     Exemplar,
@@ -80,6 +81,61 @@ def _make_fragment(frag_id: str, title: str = "Untitled") -> Fragment:
 def _exemplar(frag_id: str, body: str) -> Exemplar:
     """Build an Exemplar with a default fragment and the given body."""
     return Exemplar(fragment=_make_fragment(frag_id), body=body)
+
+
+def _seed_exemplar_file(vault: Path, frag_id: str, body: str) -> None:
+    """Write a qualifying voice-exemplar fragment file under the vault."""
+    fragments_dir = vault / "01-Fragments" / "Journal"
+    fragments_dir.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(
+        content=body,
+        **_make_fragment(frag_id).model_dump(mode="json"),
+    )
+    (fragments_dir / f"{frag_id}.md").write_text(
+        frontmatter.dumps(post),
+        encoding="utf-8",
+    )
+
+
+def test_generate_lexicon_writes_populated_glossary(tmp_path: Path) -> None:
+    """generate_lexicon collects vault exemplars and writes a filled glossary.
+
+    Bodies carry Buddhist tradition keywords (``dharma`` / ``karma``) and a
+    twice-repeated phrase so the borrowed-term and distinctive-phrase
+    inventories are non-empty (#580).
+    """
+    _seed_exemplar_file(
+        tmp_path,
+        "ex-1",
+        "The dharma teaches that the river flows toward the sea; the river flows on.",
+    )
+    _seed_exemplar_file(
+        tmp_path,
+        "ex-2",
+        "With karma in mind, the river flows again and the river flows still.",
+    )
+
+    lexicon, paths = generate_lexicon(tmp_path)
+
+    assert lexicon is not None
+    glossary = tmp_path / "07-Voice" / "Lexicon" / "glossary.md"
+    assert glossary.exists()
+    assert glossary == paths[0]
+    text = glossary.read_text(encoding="utf-8").lower()
+    assert "voice lexicon" in text
+    # The Buddhist borrowed terms were detected — a non-empty glossary section.
+    assert "dharma" in text
+
+
+def test_generate_lexicon_empty_vault_returns_none(tmp_path: Path) -> None:
+    """A vault with no qualifying exemplars yields (None, []) and writes nothing."""
+    (tmp_path / "01-Fragments").mkdir(parents=True)
+
+    lexicon, paths = generate_lexicon(tmp_path)
+
+    assert lexicon is None
+    assert paths == []
+    assert not (tmp_path / "07-Voice" / "Lexicon").exists()
 
 
 def _empty_patterns() -> VoicePatterns:

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -512,18 +512,52 @@ def test_report_decisions_stub_returns_would_generate(vault: Path) -> None:
     assert "created_path" not in last
 
 
-def test_report_lexicon_stub_returns_would_generate(vault: Path) -> None:
-    """The ``lexicon`` skeleton routes to a stub: ok, no paths, writes nothing."""
+def _seed_voice_exemplar(vault: Path, frag_id: str, body: str) -> None:
+    """Write a qualifying voice-exemplar fragment (settled + register) on disk."""
+    fm = (
+        f'type: fragment\nid: {frag_id}\ntitle: "T {frag_id}"\n'
+        "source:\n  platform: journal\n  author: self\n"
+        "frequency:\n  primary: F5\n"
+        "wavelength:\n  phase: rising\n  mode: express\n"
+        "voice:\n  voice_register: confessional\n  confidence: settled\n"
+        "privacy_tier: personal\n"
+    )
+    (vault / "01-Fragments" / "Notes" / f"{frag_id}.md").write_text(
+        f"---\n{fm}---\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_report_lexicon_generates_glossary(vault: Path) -> None:
+    """The ``lexicon`` report now generates a real glossary (#580), not a stub."""
+    _seed_voice_exemplar(
+        vault,
+        "ex-1",
+        "The dharma teaches that the river flows; the river flows toward the sea.",
+    )
+    result = report_tool(
+        vault_path=vault,
+        report_type="lexicon",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+    assert result["status"] == "ok"
+    assert result["report_type"] == "lexicon"
+    assert any("glossary.md" in p for p in result["report_paths"])
+    assert (vault / "07-Voice" / "Lexicon" / "glossary.md").exists()
+    assert _read_audit(vault)[-1]["tool"] == "creek.report"
+
+
+def test_report_lexicon_no_exemplars_returns_empty_paths(vault: Path) -> None:
+    """A lexicon report on an exemplar-free vault is ok with no paths, no file."""
     result = report_tool(
         vault_path=vault,
         report_type="lexicon",
         privacy_tier_ceiling=TierCeiling.OPEN,
     )
     assert result["status"] == "ok"
-    assert result["report_type"] == "lexicon"
     assert result["report_paths"] == []
-    assert "would generate" in result["note"].lower()
-    assert "07-Voice/Lexicon/" in result["note"]
+    assert not (vault / "07-Voice" / "Lexicon").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/creek-tools/tests/test_voice_profiles.py
+++ b/creek-tools/tests/test_voice_profiles.py
@@ -200,6 +200,37 @@ def vault(tmp_path: Path) -> Path:
     return tmp_path
 
 
+def test_collect_all_exemplars_returns_flat_bodies(vault: Path) -> None:
+    """collect_all_exemplars flattens every qualifying exemplar, with bodies.
+
+    Shares the eligibility gate with ``collect_exemplars`` — a ``musing``
+    fragment is excluded — but returns one flat list across registers for
+    consumers like the lexicon (#580).
+    """
+    from creek.generate.voice import VoiceExemplarCollector
+
+    _write_fragment_file(
+        vault,
+        _make_fragment("ex-1", "T1", VoiceRegister.CONFESSIONAL, Confidence.CONVICTION),
+        "First exemplar body about tides and rivers.",
+    )
+    _write_fragment_file(
+        vault,
+        _make_fragment("ex-2", "T2", VoiceRegister.ANALYTICAL, Confidence.SETTLED),
+        "Second exemplar body, analytical and measured.",
+    )
+    _write_fragment_file(
+        vault,
+        _make_fragment("ex-3", "T3", VoiceRegister.CONFESSIONAL, Confidence.MUSING),
+        "Ineligible musing body.",
+    )
+
+    exemplars = VoiceExemplarCollector().collect_all_exemplars(vault)
+
+    assert {e.fragment.id for e in exemplars} == {"ex-1", "ex-2"}
+    assert all(e.body for e in exemplars)
+
+
 # ---- Module surface ----
 
 


### PR DESCRIPTION
## Summary

Replaces the #579 `lexicon` stub with real generation on both the CLI and MCP surfaces, so `07-Voice/Lexicon/glossary.md` (and the per-domain metaphor index) actually fills.

- **`voice.py`** — `VoiceExemplarCollector.collect_all_exemplars(vault_path)` returns a flat `list[Exemplar]` (fragment + body) across all registers, reusing the **exact** eligibility gate `collect_exemplars` uses (`settled`/`conviction` confidence, set register, intimate filtered, `11-Other-Authors` excluded). One source of truth for what counts as an exemplar.
- **`lexicon.py`** — new `generate_lexicon(vault_path) -> (Lexicon | None, list[Path])` orchestrator: collect exemplars → `VoicePatternExtractor.extract_patterns` → `LexiconGenerator.build_lexicon` → `write_lexicon` + `write_metaphor_index`. Returns `(None, [])` for an empty corpus.
- **CLI `_report_lexicon`** and the **MCP `lexicon` branch** both call `generate_lexicon`; an empty corpus prints/returns the friendly "no qualifying exemplars" result with no file written.
- **Docs + docstrings** updated: `lexicon` now generates; `decisions` is the lone remaining skeleton.

`LexiconGenerator` is reused as-is — no term/metaphor detection reimplemented. Coinage detection stays reference-corpus gated (none configured), so the glossary fills from metaphors, distinctive phrases, and borrowed terms. The `decisions` path is untouched (scope fence).

## Test plan

- `tests/test_lexicon.py`: `test_generate_lexicon_writes_populated_glossary` (seeded vault → glossary written, Buddhist borrowed terms present) and `test_generate_lexicon_empty_vault_returns_none` (`(None, [])`, no file).
- `tests/test_voice_profiles.py`: `test_collect_all_exemplars_returns_flat_bodies` (flat exemplars with bodies; a `musing` fragment excluded).
- `tests/test_cli.py`: the #579 lexicon stub test replaced by `test_report_lexicon_no_exemplars_is_friendly` (real handler, friendly empty message, no `Would generate`).
- `tests/test_mcp_write_tools.py`: the #579 lexicon stub test replaced by `test_report_lexicon_generates_glossary` (seeded → glossary path returned, audited) and `test_report_lexicon_no_exemplars_returns_empty_paths`.

Gates: TDD (red→green confirmed), `./scripts/check-all.sh` → 12/12 passed.

Refs #577

Closes #580