### PR TITLE
feat(report): wire decisions → 08-Decisions/ notes (#581)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1294,15 +1294,26 @@ def _report_voice(vault_path: Path) -> None:
 
 
 def _report_decisions(vault_path: Path) -> None:
-    """Stub for the ``decisions`` report (skeleton; #579).
+    """Generate draft Decision notes from decision-signalling fragments (#581).
 
-    Routing tracer only — emits a typed "would generate" line and writes
-    nothing. The real ``DecisionDetector`` wiring lands in the follow-up that
-    persists ``08-Decisions/``; this proves the dispatch end-to-end first.
+    Scans the vault's fragments for decision signals and writes a draft note per
+    *new* candidate to ``08-Decisions/Active/``; re-running is idempotent (a
+    fragment already captured by a note is skipped). Prints a friendly message
+    when there are no new candidates.
     """
+    from creek.generate.decisions import generate_decisions
+
+    written_paths = generate_decisions(vault_path)
+    if not written_paths:
+        console.print(
+            "[yellow]No decision notes generated: "
+            "no new decision candidates found.[/yellow]",
+        )
+        return
+    rels = ", ".join(str(p.relative_to(vault_path)) for p in written_paths)
     console.print(
-        "[bold green]Would generate: decision notes at 08-Decisions/ "
-        "(not yet wired — see follow-up)[/bold green]",
+        f"[bold green]Decision notes generated ({len(written_paths)}): "
+        f"{rels}[/bold green]",
     )
 
 

--- a/creek-tools/creek/generate/decisions.py
+++ b/creek-tools/creek/generate/decisions.py
@@ -17,6 +17,7 @@ from datetime import date
 from typing import TYPE_CHECKING
 
 import frontmatter
+import yaml
 
 from creek.models import (
     Decision,
@@ -995,3 +996,71 @@ def decision_from_note(note_path: Path) -> Decision:
     else:
         metadata.pop("opened", None)
     return Decision.model_validate(metadata)
+
+
+def _existing_decision_fragment_ids(vault_path: Path) -> set[str]:
+    """Return the source fragment ids already captured by Decision notes (#581).
+
+    Scans ``08-Decisions/{Active,Archive}/`` and reads each note's first
+    ``## Source Fragments`` bullet — the source fragment id — so a re-run can
+    skip candidates whose decision note already exists. Unreadable notes are
+    skipped rather than crashing the report.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+
+    Returns:
+        The set of source fragment ids already recorded in Decision notes.
+    """
+    seen: set[str] = set()
+    decisions_dir = vault_path / "08-Decisions"
+    for subfolder in ("Active", "Archive"):
+        folder = decisions_dir / subfolder
+        if not folder.is_dir():
+            continue
+        for md_file in folder.rglob("*.md"):
+            try:
+                post = frontmatter.load(str(md_file))
+            except (OSError, ValueError, yaml.YAMLError):
+                continue
+            for line in post.content.splitlines():
+                stripped = line.strip()
+                if stripped.startswith("- "):
+                    seen.add(stripped[2:].strip())
+                    break
+    return seen
+
+
+def generate_decisions(vault_path: Path) -> list[Path]:
+    """Detect decision candidates across the vault and write new notes (#581).
+
+    Loads fragments via :func:`creek.vault.reader.iter_vault_fragments` (the
+    shared reader the other vault-iterating reports use), runs
+    :meth:`DecisionDetector.detect_decisions`, and writes one Decision note per
+    candidate whose source fragment is not already captured by an existing note
+    — so re-running is idempotent and never duplicates notes for one fragment.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+
+    Returns:
+        Paths of the newly written Decision notes; empty when there are no new
+        decision candidates.
+    """
+    from creek.vault.reader import iter_vault_fragments
+
+    fragments = [
+        fragment
+        for _path, fragment, _body, _raw in iter_vault_fragments(
+            vault_path / "01-Fragments",
+        )
+    ]
+    detector = DecisionDetector()
+    already = _existing_decision_fragment_ids(vault_path)
+    written: list[Path] = []
+    for candidate in detector.detect_decisions(fragments):
+        if candidate.fragment_id in already:
+            continue
+        written.append(detector.create_decision_note(candidate, vault_path))
+        already.add(candidate.fragment_id)
+    return written

--- a/creek-tools/creek/generate/decisions.py
+++ b/creek-tools/creek/generate/decisions.py
@@ -28,6 +28,7 @@ from creek.models import (
     PraxisPotential,
     _generate_decision_id,
 )
+from creek.vault.reader import iter_vault_fragments
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -1023,9 +1024,13 @@ def _existing_decision_fragment_ids(vault_path: Path) -> set[str]:
                 post = frontmatter.load(str(md_file))
             except (OSError, ValueError, yaml.YAMLError):
                 continue
+            in_source_section = False
             for line in post.content.splitlines():
                 stripped = line.strip()
-                if stripped.startswith("- "):
+                if stripped.startswith("## "):
+                    in_source_section = stripped.lower() == "## source fragments"
+                    continue
+                if in_source_section and stripped.startswith("- "):
                     seen.add(stripped[2:].strip())
                     break
     return seen
@@ -1047,8 +1052,6 @@ def generate_decisions(vault_path: Path) -> list[Path]:
         Paths of the newly written Decision notes; empty when there are no new
         decision candidates.
     """
-    from creek.vault.reader import iter_vault_fragments
-
     fragments = [
         fragment
         for _path, fragment, _body, _raw in iter_vault_fragments(

--- a/creek-tools/creek_mcp/tools/report.py
+++ b/creek-tools/creek_mcp/tools/report.py
@@ -2,19 +2,19 @@
 
 Wraps the CLI's report dispatcher. Generating report types exposed via
 MCP today: ``tags`` (the tag-garden generator), ``voice`` (the
-per-register voice profiles), and ``lexicon`` (the voice glossary +
-metaphor index, #580). ``decisions`` is wired as a skeleton (#579) —
-routable but not yet generating; it returns a typed "would generate"
-note and writes nothing. ``unnamed`` and ``wavelength`` are deferred to
-the CLI because they need date arithmetic the MCP shape should not own.
-The wrapper writes one audit entry per invocation including
-``created_path`` for the resulting report file(s).
+per-register voice profiles), ``lexicon`` (the voice glossary + metaphor
+index, #580), and ``decisions`` (draft Decision notes from
+decision-signalling fragments, #581). ``unnamed`` and ``wavelength`` are
+deferred to the CLI because they need date arithmetic the MCP shape
+should not own. The wrapper writes one audit entry per invocation
+including ``created_path`` for the resulting report file(s).
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from creek.generate.decisions import generate_decisions
 from creek.generate.lexicon import generate_lexicon
 from creek.generate.tags import TagGardenGenerator
 from creek.generate.voice import VoiceProfileGenerator
@@ -26,13 +26,6 @@ if TYPE_CHECKING:
 
 TOOL_NAME = "creek.report"
 _VALID_TYPES = ("tags", "voice", "decisions", "lexicon")
-
-#: Skeleton report types (#579): routing is wired, generation is not. Each maps
-#: to the human-readable target the follow-up will persist. Stubs write nothing.
-#: ``lexicon`` graduated to real generation in #580.
-_STUB_TYPES = {
-    "decisions": "decision notes at 08-Decisions/",
-}
 
 
 def report_tool(
@@ -57,35 +50,14 @@ def report_tool(
                 f"available via MCP: {', '.join(_VALID_TYPES)}"
             ),
         )
-    if report_type in _STUB_TYPES:
-        # Skeleton tracer (#579): the type is routable but its generator is not
-        # yet wired. Audit the invocation (nothing written) and report intent.
-        MCPAuditLog(vault_path).append(
-            tool=TOOL_NAME,
-            args={"report_type": report_type},
-            tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
-            created_path=None,
-            created_tier=None,
-            affected_fragment_ids=[],
-        )
-        return {
-            "status": "ok",
-            "tool": TOOL_NAME,
-            "tier_ceiling": privacy_tier_ceiling.value,
-            "report_type": report_type,
-            "report_paths": [],
-            "note": (
-                f"would generate: {_STUB_TYPES[report_type]} "
-                "(not yet wired — see follow-up)"
-            ),
-        }
     if report_type == "tags":
         written_paths = [
             TagGardenGenerator(vault_path=vault_path).generate_garden(),
         ]
     elif report_type == "lexicon":
         _lexicon, written_paths = generate_lexicon(vault_path)
+    elif report_type == "decisions":
+        written_paths = generate_decisions(vault_path)
     else:
         written_paths = list(
             VoiceProfileGenerator().generate_all_profiles(vault_path),

--- a/creek-tools/docs/slash-commands.md
+++ b/creek-tools/docs/slash-commands.md
@@ -37,15 +37,13 @@ body as the prompt when you type `/creek <name>`.
 ### `report` types
 
 `creek report --type <type>` (MCP: `creek.report`) supports `tags`, `voice`,
-`unnamed`, `wavelength`, `fingerprint`, and `lexicon` — the last persists the
-voice glossary + metaphor index to `07-Voice/Lexicon/`. One further type is
-**available as a skeleton** — routing is wired but generation lands in a
-follow-up:
+`unnamed`, `wavelength`, `fingerprint`, `lexicon`, and `decisions`:
 
-- `decisions` — will persist decision notes to `08-Decisions/`.
-
-Invoking a skeleton type prints/returns a "would generate …" message and writes
-nothing.
+- `lexicon` — persists the voice glossary + metaphor index to
+  `07-Voice/Lexicon/`.
+- `decisions` — writes draft Decision notes from decision-signalling fragments
+  to `08-Decisions/Active/` (idempotent: a fragment already captured is
+  skipped).
 
 ### Discoverability
 

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1232,10 +1232,16 @@ def test_report_unnamed_command(tmp_path: Path) -> None:
     assert (vault / "10-Liminal" / "Unnamed" / "Digests").is_dir()
 
 
-def test_report_decisions_skeleton_stub(tmp_path: Path) -> None:
-    """``report --type decisions`` routes to its stub handler and writes nothing."""
+def test_report_decisions_no_candidates_is_friendly(tmp_path: Path) -> None:
+    """``report --type decisions`` with no signalling fragments is friendly (#581).
+
+    The handler is now real (not the #579 stub): an empty corpus prints the
+    "no new decision candidates" message, writes nothing, and never emits the
+    old "Would generate" stub text.
+    """
     vault = tmp_path / "vault"
     (vault / "00-Creek-Meta").mkdir(parents=True)
+    (vault / "01-Fragments").mkdir(parents=True)
 
     result = runner.invoke(
         app,
@@ -1243,10 +1249,30 @@ def test_report_decisions_skeleton_stub(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert "Would generate" in result.output
-    assert "08-Decisions/" in result.output
-    # Scope fence: the stub creates nothing under the target folder.
-    assert not (vault / "08-Decisions").exists()
+    assert "No decision notes generated" in result.output
+    assert "Would generate" not in result.output
+
+
+def test_report_decisions_generates_note(tmp_path: Path) -> None:
+    """``report --type decisions`` writes a Decision note for a signalling fragment."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+    frags = vault / "01-Fragments" / "Conversations"
+    frags.mkdir(parents=True)
+    (frags / "frag-decide99.md").write_text(
+        '---\ntype: fragment\nid: frag-decide99\ntitle: "Should I move to the coast"\n'
+        "source:\n  platform: journal\n  author: self\n---\nbody\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["report", "--type", "decisions", "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Decision notes generated" in result.output
+    assert any((vault / "08-Decisions" / "Active").glob("*.md"))
 
 
 def test_report_lexicon_no_exemplars_is_friendly(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_decisions.py
+++ b/creek-tools/tests/test_decisions.py
@@ -56,6 +56,64 @@ def detector() -> DecisionDetector:
     return DecisionDetector()
 
 
+def _seed_fragment(vault: Path, fragment: Fragment, body: str = "body") -> None:
+    """Write *fragment* to ``01-Fragments/Conversations/`` for orchestrator tests."""
+    frags = vault / "01-Fragments" / "Conversations"
+    frags.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(content=body, **fragment.model_dump(mode="json"))
+    (frags / f"{fragment.id}.md").write_text(
+        frontmatter.dumps(post),
+        encoding="utf-8",
+    )
+
+
+def test_generate_decisions_writes_note(
+    vault_path: Path,
+    keyword_fragment: Fragment,
+) -> None:
+    """generate_decisions detects a candidate and writes a Decision note (#581)."""
+    from creek.generate.decisions import generate_decisions
+
+    _seed_fragment(vault_path, keyword_fragment)
+
+    written = generate_decisions(vault_path)
+
+    assert len(written) == 1
+    assert written[0].parent == vault_path / "08-Decisions" / "Active"
+    post = frontmatter.load(str(written[0]))
+    assert post["type"] == "decision"
+    assert keyword_fragment.id in post.content
+
+
+def test_generate_decisions_is_idempotent(
+    vault_path: Path,
+    keyword_fragment: Fragment,
+) -> None:
+    """A re-run writes no duplicate note for an already-captured fragment (#581)."""
+    from creek.generate.decisions import generate_decisions
+
+    _seed_fragment(vault_path, keyword_fragment)
+
+    first = generate_decisions(vault_path)
+    second = generate_decisions(vault_path)
+
+    assert len(first) == 1
+    assert second == []
+
+
+def test_generate_decisions_no_candidates(
+    vault_path: Path,
+    neutral_fragment: Fragment,
+) -> None:
+    """A vault with no decision signals yields no notes and writes nothing (#581)."""
+    from creek.generate.decisions import generate_decisions
+
+    _seed_fragment(vault_path, neutral_fragment)
+
+    assert generate_decisions(vault_path) == []
+    assert not any((vault_path / "08-Decisions" / "Active").glob("*.md"))
+
+
 @pytest.fixture()
 def keyword_fragment() -> Fragment:
     """Return a fragment containing decision keywords."""

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -493,23 +493,36 @@ def test_report_tags_writes_audit_entry(vault: Path) -> None:
     assert entries[-1]["tool"] == "creek.report"
 
 
-def test_report_decisions_stub_returns_would_generate(vault: Path) -> None:
-    """The ``decisions`` skeleton routes to a stub: ok, no paths, writes nothing."""
+def test_report_decisions_generates_note(vault: Path) -> None:
+    """The ``decisions`` report now generates a real Decision note (#581)."""
+    frags = vault / "01-Fragments" / "Notes"
+    frags.mkdir(parents=True, exist_ok=True)
+    (frags / "frag-decide50.md").write_text(
+        '---\ntype: fragment\nid: frag-decide50\ntitle: "Should I switch frameworks"\n'
+        "source:\n  platform: journal\n  author: self\n---\nbody\n",
+        encoding="utf-8",
+    )
+    result = report_tool(
+        vault_path=vault,
+        report_type="decisions",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+    assert result["status"] == "ok"
+    assert result["report_type"] == "decisions"
+    assert any("08-Decisions/Active" in p for p in result["report_paths"])
+    assert _read_audit(vault)[-1]["tool"] == "creek.report"
+
+
+def test_report_decisions_no_candidates_returns_empty_paths(vault: Path) -> None:
+    """A decisions report on a signal-free vault is ok with no paths, no file."""
     result = report_tool(
         vault_path=vault,
         report_type="decisions",
         privacy_tier_ceiling=TierCeiling.OPEN,
     )
     assert result["status"] == "ok"
-    assert result["report_type"] == "decisions"
     assert result["report_paths"] == []
-    assert "would generate" in result["note"].lower()
-    assert "08-Decisions/" in result["note"]
-    # The invocation is still audited, but nothing was written — the audit
-    # entry omits ``created_path`` entirely when no file is produced.
-    last = _read_audit(vault)[-1]
-    assert last["tool"] == "creek.report"
-    assert "created_path" not in last
 
 
 def _seed_voice_exemplar(vault: Path, frag_id: str, body: str) -> None:


### PR DESCRIPTION
## Summary

Replaces the #579 `decisions` stub with real generation — **completing epic #577** (all three children #579/#580/#581 done).

- **`decisions.py`** — `generate_decisions(vault_path) -> list[Path]` orchestrator: loads fragments via the shared `iter_vault_fragments` reader, runs `DecisionDetector.detect_decisions`, and writes one Decision note per **new** candidate to `08-Decisions/Active/`. Idempotent: `_existing_decision_fragment_ids` scans `08-Decisions/{Active,Archive}` for each note's source fragment and skips candidates already captured, so re-runs never duplicate notes.
- **CLI `_report_decisions`** and the **MCP `decisions` branch** both call it; an empty/already-captured corpus prints/returns the friendly "no new decision candidates" result with no file written.
- Removed the now-empty `_STUB_TYPES` machinery from the MCP report tool — both skeleton types have graduated (`lexicon` in #580, `decisions` here).
- Docs + module docstring updated: `decisions` now generates; no skeletons remain.

Reuses `DecisionDetector` and `iter_vault_fragments` (no detection heuristics or vault walk reimplemented); the detector's justified `# noqa: FURB123` is untouched. Lexicon / wavelength / voice writers untouched (scope fence).

## Test plan

- `tests/test_decisions.py`: `test_generate_decisions_writes_note` (note written, `type: decision`, source id in body), `test_generate_decisions_is_idempotent` (re-run → `[]`, no duplicate), `test_generate_decisions_no_candidates` (`[]`, no file).
- `tests/test_cli.py`: the #579 decisions stub test replaced by `test_report_decisions_no_candidates_is_friendly` and `test_report_decisions_generates_note`.
- `tests/test_mcp_write_tools.py`: the #579 decisions stub test replaced by `test_report_decisions_generates_note` (returns an `08-Decisions/Active` path, audited) and `test_report_decisions_no_candidates_returns_empty_paths`.

Gates: TDD (red→green confirmed), `./scripts/check-all.sh` → 12/12 passed.

Refs #577

Closes #581