### PR TITLE
feat(report): persist 07-Voice/Rhetorical-Patterns/ + rhetorical-patterns report (#582)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1341,6 +1341,30 @@ def _report_lexicon(vault_path: Path) -> None:
     )
 
 
+def _report_rhetorical_patterns(vault_path: Path) -> None:
+    """Persist per-register rhetorical-pattern notes (#582).
+
+    Writes the ontology's "### Rhetorical Moves" section per voice register to
+    ``07-Voice/Rhetorical-Patterns/``, reusing the voice subsystem's existing
+    move detection. Mirrors ``_report_voice``'s friendly "no qualifying
+    exemplars" message when the corpus is empty.
+    """
+    from creek.generate.voice import VoiceProfileGenerator
+
+    written_paths = VoiceProfileGenerator().generate_rhetorical_patterns(vault_path)
+    if not written_paths:
+        console.print(
+            "[yellow]No rhetorical patterns written: "
+            "no qualifying exemplars found.[/yellow]",
+        )
+        return
+    names = ", ".join(str(p.relative_to(vault_path)) for p in written_paths)
+    console.print(
+        f"[bold green]Rhetorical patterns written ({len(written_paths)}): "
+        f"{names}[/bold green]",
+    )
+
+
 def _report_wavelength(vault_path: Path, period: str | None) -> None:
     """Generate weekly or monthly wavelength reports."""
     from datetime import date as _date
@@ -1639,6 +1663,7 @@ _REPORT_DISPATCH: dict[str, Callable[[Path], None]] = {
     "fingerprint": _report_fingerprint,
     "decisions": _report_decisions,
     "lexicon": _report_lexicon,
+    "rhetorical-patterns": _report_rhetorical_patterns,
 }
 
 

--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -1427,6 +1427,9 @@ _PROFILE_SUBDIR: str = "07-Voice"
 _PROFILE_FILENAME_SUFFIX: str = "-profile.md"
 """Filename suffix for register profile markdown files."""
 
+_RHETORICAL_SUBDIR: tuple[str, str] = ("07-Voice", "Rhetorical-Patterns")
+"""Vault subdirectory where per-register rhetorical-pattern notes are persisted."""
+
 _DEFAULT_MAX_EXEMPLARS_PER_PROFILE: int = 10
 """Default maximum number of exemplar passages included in a profile."""
 
@@ -1835,6 +1838,53 @@ class VoiceProfileGenerator:
             List of paths written, one per register with exemplars.
         """
         written: list[Path] = []
+        for register, ranked, patterns in self._iter_register_patterns(vault_path):
+            profile = self.generate_profile(register, ranked, patterns)
+            written.append(self.write_profile(profile, vault_path))
+        return written
+
+    def generate_rhetorical_patterns(self, vault_path: Path) -> list[Path]:
+        """Persist a per-register rhetorical-patterns note (#582).
+
+        Reuses the same streaming exemplar collection and pattern extraction as
+        :meth:`generate_all_profiles` (via :meth:`_iter_register_patterns`), but
+        writes only the ontology's "### Rhetorical Moves" section — computed by
+        :func:`_compute_rhetorical_moves` through the pattern extractor — to
+        ``07-Voice/Rhetorical-Patterns/<register>.md``. No move-detection logic
+        is duplicated.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            List of paths written, one per register with exemplars.
+        """
+        return [
+            self._write_rhetorical_note(register, patterns, vault_path)
+            for register, _ranked, patterns in self._iter_register_patterns(vault_path)
+        ]
+
+    # ---- Private helpers ----
+
+    def _iter_register_patterns(
+        self,
+        vault_path: Path,
+    ) -> Iterator[tuple[str, list[Exemplar], VoicePatterns]]:
+        """Yield ``(register, ranked_exemplars, patterns)`` per non-empty register.
+
+        The single streaming exemplar-collection + ranking + pattern-extraction
+        path shared by :meth:`generate_all_profiles` and
+        :meth:`generate_rhetorical_patterns`. Memory peaks at the largest single
+        register: each register's working set is released before the next is
+        loaded (PERF-004).
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+
+        Yields:
+            ``(register, ranked exemplars, extracted patterns)`` for every
+            register that has qualifying exemplars.
+        """
         with self._streaming_accumulator(vault_path) as register_paths:
             for register in VOICE_REGISTERS:
                 jsonl_path = register_paths.get(register)
@@ -1850,14 +1900,38 @@ class VoiceProfileGenerator:
                     for e in ranked
                 ]
                 patterns = self._extractor.extract_patterns(bodies, weights=weights)
-                profile = self.generate_profile(register, ranked, patterns)
-                written.append(self.write_profile(profile, vault_path))
-                # Drop the per-register working set before moving on so
-                # the next register's load does not stack on top of it.
-                del register_exemplars, ranked, bodies, patterns, profile
-        return written
+                yield register, ranked, patterns
+                del register_exemplars, ranked, bodies, patterns
 
-    # ---- Private helpers ----
+    def _write_rhetorical_note(
+        self,
+        register: str,
+        patterns: VoicePatterns,
+        vault_path: Path,
+    ) -> Path:
+        """Write *register*'s rhetorical-moves note and return its path."""
+        target_dir = vault_path.joinpath(*_RHETORICAL_SUBDIR)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target = target_dir / f"{register}.md"
+        body = "\n".join(
+            [
+                f"# Rhetorical Patterns — {register}",
+                "",
+                "### Rhetorical Moves",
+                "",
+                *_format_rhetorical_moves(patterns),
+                "",
+            ],
+        )
+        post = frontmatter.Post(
+            content=body,
+            type="rhetorical_patterns",
+            register=register,
+            generated_date=datetime.now(tz=UTC).isoformat(),
+            tags=["voice", "rhetorical-patterns", register],
+        )
+        target.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return target
 
     @contextmanager
     def _streaming_accumulator(

--- a/creek-tools/creek_mcp/tools/report.py
+++ b/creek-tools/creek_mcp/tools/report.py
@@ -4,7 +4,8 @@ Wraps the CLI's report dispatcher. Generating report types exposed via
 MCP today: ``tags`` (the tag-garden generator), ``voice`` (the
 per-register voice profiles), ``lexicon`` (the voice glossary + metaphor
 index, #580), and ``decisions`` (draft Decision notes from
-decision-signalling fragments, #581). ``unnamed`` and ``wavelength`` are
+decision-signalling fragments, #581), and ``rhetorical-patterns``
+(per-register rhetorical-move notes, #582). ``unnamed`` and ``wavelength`` are
 deferred to the CLI because they need date arithmetic the MCP shape
 should not own. The wrapper writes one audit entry per invocation
 including ``created_path`` for the resulting report file(s).
@@ -25,7 +26,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 TOOL_NAME = "creek.report"
-_VALID_TYPES = ("tags", "voice", "decisions", "lexicon")
+_VALID_TYPES = ("tags", "voice", "decisions", "lexicon", "rhetorical-patterns")
 
 
 def report_tool(
@@ -58,6 +59,10 @@ def report_tool(
         _lexicon, written_paths = generate_lexicon(vault_path)
     elif report_type == "decisions":
         written_paths = generate_decisions(vault_path)
+    elif report_type == "rhetorical-patterns":
+        written_paths = list(
+            VoiceProfileGenerator().generate_rhetorical_patterns(vault_path),
+        )
     else:
         written_paths = list(
             VoiceProfileGenerator().generate_all_profiles(vault_path),

--- a/creek-tools/docs/slash-commands.md
+++ b/creek-tools/docs/slash-commands.md
@@ -37,13 +37,16 @@ body as the prompt when you type `/creek <name>`.
 ### `report` types
 
 `creek report --type <type>` (MCP: `creek.report`) supports `tags`, `voice`,
-`unnamed`, `wavelength`, `fingerprint`, `lexicon`, and `decisions`:
+`unnamed`, `wavelength`, `fingerprint`, `lexicon`, `decisions`, and
+`rhetorical-patterns`:
 
 - `lexicon` — persists the voice glossary + metaphor index to
   `07-Voice/Lexicon/`.
 - `decisions` — writes draft Decision notes from decision-signalling fragments
   to `08-Decisions/Active/` (idempotent: a fragment already captured is
   skipped).
+- `rhetorical-patterns` — writes a per-register rhetorical-moves note to
+  `07-Voice/Rhetorical-Patterns/`.
 
 ### Discoverability
 

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1297,6 +1297,45 @@ def test_report_lexicon_no_exemplars_is_friendly(tmp_path: Path) -> None:
     assert not (vault / "07-Voice" / "Lexicon").exists()
 
 
+def test_report_rhetorical_patterns_no_exemplars_is_friendly(tmp_path: Path) -> None:
+    """``report --type rhetorical-patterns`` with no exemplars is friendly (#582)."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+    (vault / "01-Fragments").mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        ["report", "--type", "rhetorical-patterns", "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "No rhetorical patterns written" in result.output
+
+
+def test_report_rhetorical_patterns_generates(tmp_path: Path) -> None:
+    """``report --type rhetorical-patterns`` writes a per-register note (#582)."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+    frags = vault / "01-Fragments" / "Journal"
+    frags.mkdir(parents=True)
+    (frags / "ex-1.md").write_text(
+        '---\ntype: fragment\nid: ex-1\ntitle: "T"\n'
+        "source:\n  platform: journal\n  author: self\n"
+        "voice:\n  voice_register: confessional\n  confidence: conviction\n"
+        "---\nThe truth is we rise; as I said before, we rise.\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["report", "--type", "rhetorical-patterns", "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Rhetorical patterns written" in result.output
+    assert (vault / "07-Voice" / "Rhetorical-Patterns" / "confessional.md").exists()
+
+
 def test_report_voice_command(tmp_path: Path) -> None:
     """Test that report --type voice generates register profiles."""
     from datetime import UTC, datetime

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -525,6 +525,41 @@ def test_report_decisions_no_candidates_returns_empty_paths(vault: Path) -> None
     assert result["report_paths"] == []
 
 
+def test_report_rhetorical_patterns_generates(vault: Path) -> None:
+    """The ``rhetorical-patterns`` report writes a per-register note (#582)."""
+    frags = vault / "01-Fragments" / "Notes"
+    frags.mkdir(parents=True, exist_ok=True)
+    (frags / "ex-1.md").write_text(
+        '---\ntype: fragment\nid: ex-1\ntitle: "T"\n'
+        "source:\n  platform: journal\n  author: self\n"
+        "voice:\n  voice_register: confessional\n  confidence: conviction\n"
+        "---\nThe truth is we rise; as I said before, we rise.\n",
+        encoding="utf-8",
+    )
+    result = report_tool(
+        vault_path=vault,
+        report_type="rhetorical-patterns",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+    assert result["status"] == "ok"
+    assert any("07-Voice/Rhetorical-Patterns" in p for p in result["report_paths"])
+    assert _read_audit(vault)[-1]["tool"] == "creek.report"
+
+
+def test_report_rhetorical_patterns_no_exemplars_returns_empty_paths(
+    vault: Path,
+) -> None:
+    """A rhetorical-patterns report on an exemplar-free vault is ok with no paths."""
+    result = report_tool(
+        vault_path=vault,
+        report_type="rhetorical-patterns",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    assert result["report_paths"] == []
+
+
 def _seed_voice_exemplar(vault: Path, frag_id: str, body: str) -> None:
     """Write a qualifying voice-exemplar fragment (settled + register) on disk."""
     fm = (

--- a/creek-tools/tests/test_voice_profiles.py
+++ b/creek-tools/tests/test_voice_profiles.py
@@ -231,6 +231,38 @@ def test_collect_all_exemplars_returns_flat_bodies(vault: Path) -> None:
     assert all(e.body for e in exemplars)
 
 
+def test_generate_rhetorical_patterns_writes_per_register_notes(vault: Path) -> None:
+    """generate_rhetorical_patterns writes a per-register moves note (#582)."""
+    _write_fragment_file(
+        vault,
+        _make_fragment("ex-1", "T1", VoiceRegister.CONFESSIONAL, Confidence.CONVICTION),
+        "Maybe I am wrong, but the truth is we rise. As I said before, we rise.",
+    )
+    _write_fragment_file(
+        vault,
+        _make_fragment("ex-2", "T2", VoiceRegister.CONFESSIONAL, Confidence.SETTLED),
+        "I could be mistaken. Yet it is both true and false. Back to my point.",
+    )
+
+    written = VoiceProfileGenerator().generate_rhetorical_patterns(vault)
+
+    note = vault / "07-Voice" / "Rhetorical-Patterns" / "confessional.md"
+    assert note in written
+    text = note.read_text(encoding="utf-8")
+    assert "### Rhetorical Moves" in text
+    post = frontmatter.load(str(note))
+    assert post["type"] == "rhetorical_patterns"
+    assert post["register"] == "confessional"
+
+
+def test_generate_rhetorical_patterns_empty_vault_writes_nothing(vault: Path) -> None:
+    """A vault with no qualifying exemplars writes no notes and no folder (#582)."""
+    written = VoiceProfileGenerator().generate_rhetorical_patterns(vault)
+
+    assert written == []
+    assert not (vault / "07-Voice" / "Rhetorical-Patterns").exists()
+
+
 # ---- Module surface ----
 
 


### PR DESCRIPTION
## Summary

Epic #578 tracer — persists the already-computed rhetorical-move analysis as standalone notes, exposed via `creek report --type rhetorical-patterns` (CLI + MCP).

- **`voice.py`** — extracted `_iter_register_patterns` (the shared streaming exemplar-collection + ranking + pattern-extraction loop) and had `generate_all_profiles` consume it; added `generate_rhetorical_patterns` + `_write_rhetorical_note`, which write a per-register "### Rhetorical Moves" note to `07-Voice/Rhetorical-Patterns/<register>.md`. Reuses `_format_rhetorical_moves` / `_compute_rhetorical_moves` — **no move-detection logic duplicated**.
- **CLI `_report_rhetorical_patterns`** + `_REPORT_DISPATCH` registration; **MCP** `rhetorical-patterns` branch + `_VALID_TYPES`.
- Empty corpus → friendly "no qualifying exemplars" message / empty paths.
- Docs + module docstring updated.

`generate_all_profiles` was refactored to share the new generator; its 51 existing tests still pass (behaviour-preserving). Scope fence: Mode-Profiles / Observations untouched.

## Test plan

- `tests/test_voice_profiles.py`: `test_generate_rhetorical_patterns_writes_per_register_notes` (note written with the "### Rhetorical Moves" shape + `type: rhetorical_patterns`), `test_generate_rhetorical_patterns_empty_vault_writes_nothing` (`[]`, no folder); full existing profile suite still green.
- `tests/test_cli.py`: `test_report_rhetorical_patterns_generates` and `..._no_exemplars_is_friendly`.
- `tests/test_mcp_write_tools.py`: `test_report_rhetorical_patterns_generates` (returns a `07-Voice/Rhetorical-Patterns` path, audited) and `..._no_exemplars_returns_empty_paths`.

Gates: TDD (red→green confirmed), `./scripts/check-all.sh` → 12/12 passed.

Refs #578

Closes #582