### PR TITLE
feat(report): generate 05-Wavelength/Mode-Profiles/ + mode-profiles report (#583)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1365,6 +1365,28 @@ def _report_rhetorical_patterns(vault_path: Path) -> None:
     )
 
 
+def _report_mode_profiles(vault_path: Path) -> None:
+    """Generate per-mode wavelength profiles to 05-Wavelength/Mode-Profiles/ (#583).
+
+    Writes one note per engagement mode that has fragments; prints a friendly
+    message when no fragment carries a classified mode.
+    """
+    from creek.generate.wavelength import ModeProfileGenerator
+
+    written_paths = ModeProfileGenerator().generate_mode_profiles(vault_path)
+    if not written_paths:
+        console.print(
+            "[yellow]No mode profiles written: "
+            "no classified-mode fragments found.[/yellow]",
+        )
+        return
+    names = ", ".join(str(p.relative_to(vault_path)) for p in written_paths)
+    console.print(
+        f"[bold green]Mode profiles written ({len(written_paths)}): "
+        f"{names}[/bold green]",
+    )
+
+
 def _report_wavelength(vault_path: Path, period: str | None) -> None:
     """Generate weekly or monthly wavelength reports."""
     from datetime import date as _date
@@ -1664,6 +1686,7 @@ _REPORT_DISPATCH: dict[str, Callable[[Path], None]] = {
     "decisions": _report_decisions,
     "lexicon": _report_lexicon,
     "rhetorical-patterns": _report_rhetorical_patterns,
+    "mode-profiles": _report_mode_profiles,
 }
 
 

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -1321,6 +1321,93 @@ def current_phase_summary(
     )
 
 
+_MODE_PROFILE_SUBPATH: tuple[str, str] = ("05-Wavelength", "Mode-Profiles")
+"""Vault subdirectory where per-mode profile notes are persisted (#583)."""
+
+_MODE_PROFILE_SAMPLE_LIMIT: int = 5
+"""Maximum sample fragments listed in a mode profile note."""
+
+
+class ModeProfileGenerator:
+    """Write per-mode engagement profiles to ``05-Wavelength/Mode-Profiles/``.
+
+    Aggregates the corpus by engagement :class:`~creek.models.Mode` — modes are
+    derived from the enum, never hardcoded — and writes one note per mode that
+    has at least one fragment, summarising its fragment count and dominant
+    frequency / phase. Modes with no fragments are skipped (no empty notes), so
+    an unclassified corpus produces no files at all (#583).
+    """
+
+    def generate_mode_profiles(self, vault_path: Path) -> list[Path]:
+        """Write one profile note per non-empty engagement mode.
+
+        Args:
+            vault_path: Path to the root of the Obsidian vault.
+
+        Returns:
+            Paths written, in canonical :class:`~creek.models.Mode` order; empty
+            when no fragment carries a classified mode.
+        """
+        by_mode: dict[str, list[Fragment]] = defaultdict(list)
+        for fragment in _load_fragments_from_vault(vault_path):
+            mode = str(fragment.wavelength.mode)
+            if mode != Mode.UNCLASSIFIED:
+                by_mode[mode].append(fragment)
+        written: list[Path] = []
+        for mode in Mode:
+            if mode is Mode.UNCLASSIFIED:
+                continue
+            fragments = by_mode.get(mode.value)
+            if fragments:
+                written.append(
+                    self._write_mode_profile(mode.value, fragments, vault_path),
+                )
+        return written
+
+    @staticmethod
+    def _write_mode_profile(
+        mode: str,
+        fragments: list[Fragment],
+        vault_path: Path,
+    ) -> Path:
+        """Render and write a single mode's profile note; return its path."""
+        target_dir = vault_path.joinpath(*_MODE_PROFILE_SUBPATH)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        dominant_frequency = _most_common_classified(
+            [str(f.frequency.primary) for f in fragments],
+            Frequency.UNCLASSIFIED,
+        )
+        dominant_phase = _most_common_classified(
+            [str(f.wavelength.phase) for f in fragments],
+            Phase.UNCLASSIFIED,
+        )
+        lines = [
+            f"# Mode Profile — {mode}",
+            "",
+            f"- Fragments in this mode: {len(fragments)}",
+            f"- Dominant frequency: {dominant_frequency}",
+            f"- Dominant phase: {dominant_phase}",
+            "",
+            "## Sample Fragments",
+            "",
+            *(f"- {f.title} ({f.id})" for f in fragments[:_MODE_PROFILE_SAMPLE_LIMIT]),
+            "",
+        ]
+        post = frontmatter.Post(
+            content="\n".join(lines),
+            type="mode_profile",
+            mode=mode,
+            fragment_count=len(fragments),
+            dominant_frequency=dominant_frequency,
+            dominant_phase=dominant_phase,
+            generated_date=datetime.now(tz=UTC).isoformat(),
+            tags=["wavelength", "mode-profile", mode],
+        )
+        target = target_dir / f"{mode}.md"
+        target.write_text(frontmatter.dumps(post), encoding="utf-8")
+        return target
+
+
 __all__ = [
     "DEFAULT_CURRENT_PHASE_WINDOW_DAYS",
     "DEFAULT_ROLLING_WEEKS",
@@ -1330,6 +1417,7 @@ __all__ = [
     "PHASE_DOMAIN_MAPPINGS",
     "CurrentPhaseSummary",
     "DosageTrend",
+    "ModeProfileGenerator",
     "PhaseTransition",
     "WavelengthSnapshot",
     "WavelengthTracker",

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -1348,10 +1348,15 @@ class ModeProfileGenerator:
             Paths written, in canonical :class:`~creek.models.Mode` order; empty
             when no fragment carries a classified mode.
         """
+        # ``WavelengthClassification`` sets ``use_enum_values=True``, so
+        # ``fragment.wavelength.mode`` is already the canonical slug *string*
+        # (not a ``Mode`` member). Key the buckets by that string and iterate the
+        # enum's ``.value``s below, so the comparison stays string-to-string
+        # throughout rather than mixing enum identity with string lookups.
         by_mode: dict[str, list[Fragment]] = defaultdict(list)
         for fragment in _load_fragments_from_vault(vault_path):
             mode = str(fragment.wavelength.mode)
-            if mode != Mode.UNCLASSIFIED:
+            if mode != Mode.UNCLASSIFIED.value:
                 by_mode[mode].append(fragment)
         written: list[Path] = []
         for mode in Mode:

--- a/creek-tools/creek_mcp/tools/report.py
+++ b/creek-tools/creek_mcp/tools/report.py
@@ -4,8 +4,9 @@ Wraps the CLI's report dispatcher. Generating report types exposed via
 MCP today: ``tags`` (the tag-garden generator), ``voice`` (the
 per-register voice profiles), ``lexicon`` (the voice glossary + metaphor
 index, #580), and ``decisions`` (draft Decision notes from
-decision-signalling fragments, #581), and ``rhetorical-patterns``
-(per-register rhetorical-move notes, #582). ``unnamed`` and ``wavelength`` are
+decision-signalling fragments, #581), ``rhetorical-patterns``
+(per-register rhetorical-move notes, #582), and ``mode-profiles``
+(per-mode engagement profiles, #583). ``unnamed`` and ``wavelength`` are
 deferred to the CLI because they need date arithmetic the MCP shape
 should not own. The wrapper writes one audit entry per invocation
 including ``created_path`` for the resulting report file(s).
@@ -19,6 +20,7 @@ from creek.generate.decisions import generate_decisions
 from creek.generate.lexicon import generate_lexicon
 from creek.generate.tags import TagGardenGenerator
 from creek.generate.voice import VoiceProfileGenerator
+from creek.generate.wavelength import ModeProfileGenerator
 from creek_mcp.audit import MCPAuditLog
 from creek_mcp.tier_ceiling import TierCeiling, refusal_response
 
@@ -26,7 +28,14 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 TOOL_NAME = "creek.report"
-_VALID_TYPES = ("tags", "voice", "decisions", "lexicon", "rhetorical-patterns")
+_VALID_TYPES = (
+    "tags",
+    "voice",
+    "decisions",
+    "lexicon",
+    "rhetorical-patterns",
+    "mode-profiles",
+)
 
 
 def report_tool(
@@ -63,6 +72,8 @@ def report_tool(
         written_paths = list(
             VoiceProfileGenerator().generate_rhetorical_patterns(vault_path),
         )
+    elif report_type == "mode-profiles":
+        written_paths = list(ModeProfileGenerator().generate_mode_profiles(vault_path))
     else:
         written_paths = list(
             VoiceProfileGenerator().generate_all_profiles(vault_path),

--- a/creek-tools/docs/slash-commands.md
+++ b/creek-tools/docs/slash-commands.md
@@ -47,6 +47,8 @@ body as the prompt when you type `/creek <name>`.
   skipped).
 - `rhetorical-patterns` — writes a per-register rhetorical-moves note to
   `07-Voice/Rhetorical-Patterns/`.
+- `mode-profiles` — writes a per-engagement-mode profile to
+  `05-Wavelength/Mode-Profiles/`.
 
 ### Discoverability
 

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1336,6 +1336,45 @@ def test_report_rhetorical_patterns_generates(tmp_path: Path) -> None:
     assert (vault / "07-Voice" / "Rhetorical-Patterns" / "confessional.md").exists()
 
 
+def test_report_mode_profiles_no_data_is_friendly(tmp_path: Path) -> None:
+    """``report --type mode-profiles`` with no classified modes is friendly (#583)."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+    (vault / "01-Fragments").mkdir(parents=True)
+
+    result = runner.invoke(
+        app,
+        ["report", "--type", "mode-profiles", "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "No mode profiles written" in result.output
+
+
+def test_report_mode_profiles_generates(tmp_path: Path) -> None:
+    """``report --type mode-profiles`` writes a per-mode note (#583)."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+    frags = vault / "01-Fragments"
+    frags.mkdir(parents=True)
+    (frags / "m1.md").write_text(
+        '---\ntype: fragment\nid: m1\ntitle: "Building momentum"\n'
+        "source:\n  platform: journal\n  author: self\n"
+        "wavelength:\n  mode: express\n  phase: rising\n"
+        "frequency:\n  primary: F3\n---\nbody\n",
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(
+        app,
+        ["report", "--type", "mode-profiles", "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Mode profiles written" in result.output
+    assert (vault / "05-Wavelength" / "Mode-Profiles" / "express.md").exists()
+
+
 def test_report_voice_command(tmp_path: Path) -> None:
     """Test that report --type voice generates register profiles."""
     from datetime import UTC, datetime

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -588,6 +588,7 @@ def test_report_mode_profiles_no_data_returns_empty_paths(vault: Path) -> None:
         vault_path=vault,
         report_type="mode-profiles",
         privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
     )
     assert result["status"] == "ok"
     assert result["report_paths"] == []

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -560,6 +560,39 @@ def test_report_rhetorical_patterns_no_exemplars_returns_empty_paths(
     assert result["report_paths"] == []
 
 
+def test_report_mode_profiles_generates(vault: Path) -> None:
+    """The ``mode-profiles`` report writes a per-mode note (#583)."""
+    frags = vault / "01-Fragments" / "Notes"
+    frags.mkdir(parents=True, exist_ok=True)
+    (frags / "m1.md").write_text(
+        '---\ntype: fragment\nid: m1\ntitle: "Building momentum"\n'
+        "source:\n  platform: journal\n  author: self\n"
+        "wavelength:\n  mode: express\n  phase: rising\n"
+        "frequency:\n  primary: F3\n---\nbody\n",
+        encoding="utf-8",
+    )
+    result = report_tool(
+        vault_path=vault,
+        report_type="mode-profiles",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+    assert result["status"] == "ok"
+    assert any("05-Wavelength/Mode-Profiles" in p for p in result["report_paths"])
+    assert _read_audit(vault)[-1]["tool"] == "creek.report"
+
+
+def test_report_mode_profiles_no_data_returns_empty_paths(vault: Path) -> None:
+    """A mode-profiles report on a vault with no classified modes is ok, no paths."""
+    result = report_tool(
+        vault_path=vault,
+        report_type="mode-profiles",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    assert result["report_paths"] == []
+
+
 def _seed_voice_exemplar(vault: Path, frag_id: str, body: str) -> None:
     """Write a qualifying voice-exemplar fragment (settled + register) on disk."""
     fm = (

--- a/creek-tools/tests/test_wavelength_reports.py
+++ b/creek-tools/tests/test_wavelength_reports.py
@@ -15,6 +15,7 @@ import pytest
 
 from creek.generate.wavelength import (
     PHASE_DOMAIN_MAPPINGS,
+    ModeProfileGenerator,
     WavelengthTracker,
 )
 from creek.models import (
@@ -596,3 +597,74 @@ class TestGenerateMonthlyReport:
         )
         body = frontmatter.load(str(path)).content
         assert "(empty)" in body
+
+
+def _seed_fragments(vault: Path, fragments: list[Fragment]) -> None:
+    """Write *fragments* to ``01-Fragments/`` for ModeProfileGenerator tests."""
+    frags_dir = vault / "01-Fragments"
+    frags_dir.mkdir(parents=True, exist_ok=True)
+    for fragment in fragments:
+        post = frontmatter.Post(
+            content=fragment.title,
+            **fragment.model_dump(mode="json"),
+        )
+        (frags_dir / f"{fragment.id}.md").write_text(
+            frontmatter.dumps(post),
+            encoding="utf-8",
+        )
+
+
+class TestModeProfileGenerator:
+    """Per-mode profile notes under ``05-Wavelength/Mode-Profiles/`` (#583)."""
+
+    def test_writes_one_note_per_nonempty_mode(self, vault_path: Path) -> None:
+        """One note per engagement mode that has fragments; aggregates counts."""
+        base = datetime(2026, 4, 20, 12, 0, tzinfo=UTC)
+        _seed_fragments(
+            vault_path,
+            [
+                _make_fragment(
+                    frag_id="m1",
+                    created=base,
+                    mode=Mode.EXPRESS,
+                    frequency=Frequency.F3,
+                    phase=Phase.RISING,
+                ),
+                _make_fragment(
+                    frag_id="m2",
+                    created=base,
+                    mode=Mode.EXPRESS,
+                    frequency=Frequency.F3,
+                    phase=Phase.RISING,
+                ),
+                _make_fragment(
+                    frag_id="m3",
+                    created=base,
+                    mode=Mode.INHABIT,
+                    frequency=Frequency.F6,
+                    phase=Phase.PEAKING,
+                ),
+            ],
+        )
+
+        written = ModeProfileGenerator().generate_mode_profiles(vault_path)
+
+        assert {p.name for p in written} == {"express.md", "inhabit.md"}
+        express = vault_path / "05-Wavelength" / "Mode-Profiles" / "express.md"
+        post = frontmatter.load(str(express))
+        assert post["type"] == "mode_profile"
+        assert post["fragment_count"] == 2
+        assert "m1" in post.content
+        assert "m2" in post.content
+
+    def test_no_classified_modes_writes_nothing(self, vault_path: Path) -> None:
+        """An all-unclassified-mode corpus produces no notes and no folder."""
+        _seed_fragments(
+            vault_path,
+            [_make_fragment(frag_id="u1", created=datetime(2026, 4, 20, tzinfo=UTC))],
+        )
+
+        written = ModeProfileGenerator().generate_mode_profiles(vault_path)
+
+        assert written == []
+        assert not (vault_path / "05-Wavelength" / "Mode-Profiles").exists()


### PR DESCRIPTION
## Summary

Epic #578 — gives the previously-writer-less `05-Wavelength/Mode-Profiles/` folder a generator, exposed via `creek report --type mode-profiles` (CLI + MCP).

- **`wavelength.py`** — new `ModeProfileGenerator.generate_mode_profiles(vault_path)`: aggregates the corpus by engagement `Mode` (**derived from the enum, never hardcoded**), reusing `_load_fragments_from_vault` + `_most_common_classified`. Writes one note per mode that has fragments — count, dominant frequency, dominant phase, and up to 5 sample fragments — to `05-Wavelength/Mode-Profiles/<mode>.md`. Modes with no fragments are skipped, so an all-`UNCLASSIFIED`-mode (or empty) corpus produces no files and no folder.
- **CLI `_report_mode_profiles`** + `_REPORT_DISPATCH`; **MCP** `mode-profiles` branch + `_VALID_TYPES`.
- Docs + module docstring updated.

Reuses `WavelengthTracker`'s module-level loaders/helpers (no new vault walk). Scope fence: `Observations/` untouched (its #584 follow-up needs a product decision first).

## Test plan

- `tests/test_wavelength_reports.py` (`TestModeProfileGenerator`): `test_writes_one_note_per_nonempty_mode` (one note per mode with fragments; `type: mode_profile`, correct `fragment_count`, sample ids in body) and `test_no_classified_modes_writes_nothing` (`[]`, no folder).
- `tests/test_cli.py`: `test_report_mode_profiles_generates` and `..._no_data_is_friendly`.
- `tests/test_mcp_write_tools.py`: `test_report_mode_profiles_generates` (returns a `05-Wavelength/Mode-Profiles` path, audited) and `..._no_data_returns_empty_paths`.

Gates: TDD (red→green confirmed), `./scripts/check-all.sh` → 12/12 passed.

Refs #578

Closes #583