### PR TITLE
feat(save): add observation save target → 05-Wavelength/Observations/ (#584)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2897,9 +2897,11 @@ def draft(
 
 
 _SAVE_TARGET_HELP = (
-    "Destination type: thread, eddy, praxis, paradox, unnamed, draft, or "
-    "ai-as-user. Paradox always routes to 10-Liminal/Paradoxes/ regardless of "
-    "other inputs; ai-as-user files kept AI output to 11-Other-Authors/ai-as-user/."
+    "Destination type: thread, eddy, praxis, paradox, unnamed, draft, "
+    "ai-as-user, or observation. Paradox always routes to 10-Liminal/Paradoxes/ "
+    "regardless of other inputs; ai-as-user files kept AI output to "
+    "11-Other-Authors/ai-as-user/; observation files raw wavelength reflections "
+    "to 05-Wavelength/Observations/."
 )
 _SAVE_TIER_HELP = (
     "Privacy tier (open|personal|intimate). Required when stdin is the body "

--- a/creek-tools/creek/save/router.py
+++ b/creek-tools/creek/save/router.py
@@ -41,6 +41,7 @@ class SaveTarget(StrEnum):
     UNNAMED = "unnamed"
     DRAFT = "draft"
     AI_AS_USER = "ai-as-user"
+    OBSERVATION = "observation"
 
 
 TARGET_SUBDIRS: dict[SaveTarget, tuple[str, ...]] = {
@@ -51,6 +52,7 @@ TARGET_SUBDIRS: dict[SaveTarget, tuple[str, ...]] = {
     SaveTarget.UNNAMED: ("10-Liminal", "Unnamed"),
     SaveTarget.DRAFT: ("07-Voice", "Drafts"),
     SaveTarget.AI_AS_USER: ("11-Other-Authors", "ai-as-user"),
+    SaveTarget.OBSERVATION: ("05-Wavelength", "Observations"),
 }
 """Canonical mapping of save targets to vault subdirectories.
 

--- a/creek-tools/docs/slash-commands.md
+++ b/creek-tools/docs/slash-commands.md
@@ -27,7 +27,7 @@ body as the prompt when you type `/creek <name>`.
 | `/creek lint [--checks ...] [--since DATE]` | `creek.lint` | Vault hygiene + drift + paradox surfacing. |
 | `/creek mine [--phase ...] [--limit N]` | `creek.mine` | Surface essay seeds. |
 | `/creek draft [--phase ...] [--index N]` | `creek.draft` | Generate a voice-faithful draft from a mined seed. |
-| `/creek save --target ...` | `creek.save` | File an answer / paradox / draft / liminal item. |
+| `/creek save --target ...` | `creek.save` | File an answer / paradox / draft / liminal item, or an `observation` (raw wavelength reflection → `05-Wavelength/Observations/`). |
 | `/creek explain [SUBCOMMAND]` | none (help) | List commands or render one in detail. |
 | `/creek phase` | `creek.state.read` | Shorthand for the wavelength snapshot only. |
 | `/creek wavelength` | `creek.state.read` | Alias for `/creek phase`. |

--- a/creek-tools/tests/test_save.py
+++ b/creek-tools/tests/test_save.py
@@ -459,6 +459,49 @@ def test_cli_save_thread_round_trip(tmp_path: Path) -> None:
     assert "A thoughtful synthesis." in post.content
 
 
+def test_cli_save_observation_round_trip(tmp_path: Path) -> None:
+    """Integration: --target observation files into the Observations folder (#584)."""
+    vault = _scaffold_vault(tmp_path / "vault")
+    body_file = tmp_path / "obs.md"
+    body_file.write_text("Felt the F2 to F7 turn today.", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        [
+            "save",
+            "--target",
+            "observation",
+            "--body",
+            str(body_file),
+            "--title",
+            "Afternoon turn",
+            "--tier",
+            "open",
+            "--vault",
+            str(vault),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    written = list((vault / "05-Wavelength" / "Observations").glob("*.md"))
+    assert len(written) == 1
+    post = frontmatter.load(str(written[0]))
+    assert post["type"] == "observation"
+    assert "Felt the F2 to F7 turn today." in post.content
+
+
+def test_saved_observation_lands_in_decision_context_read_dir(tmp_path: Path) -> None:
+    """A saved observation lands exactly where DecisionContextGatherer reads (#584).
+
+    ``DecisionContextGatherer._current_wavelength`` scans
+    ``05-Wavelength/Observations/``; routing a save there closes the
+    producer→consumer loop the folder previously lacked.
+    """
+    vault = _scaffold_vault(tmp_path / "vault")
+
+    path = save_to_vault(_make_request(SaveTarget.OBSERVATION), vault_path=vault)
+
+    assert path.parent == vault / "05-Wavelength" / "Observations"
+
+
 def test_cli_save_paradox_routing(tmp_path: Path) -> None:
     """A paradox save lands in 10-Liminal/Paradoxes via the CLI too."""
     vault = _scaffold_vault(tmp_path / "vault")


### PR DESCRIPTION
## Summary

Closes epic #578's final child. **Product decision (recorded on the issue thread): option 1 — save target.** Observations are user-authored "raw reflections", so the gap was a *save* surface, not auto-generation.

- **`save/router.py`** — `SaveTarget.OBSERVATION` + `TARGET_SUBDIRS` mapping to `("05-Wavelength", "Observations")`. Both the CLI (`_parse_save_target`) and the MCP save tool resolve targets via `SaveTarget(value)`, so **both surfaces accept `--target observation` with no further plumbing**; the writer's existing unmodelled-target path stamps `type: observation`.
- **`cli.py`** — lists `observation` in the `--target` help (keeps the "help lists every target" test exhaustive).
- **`docs/slash-commands.md`** — documents the observation save target.

This closes the producer→consumer loop: `DecisionContextGatherer` already reads `05-Wavelength/Observations/` but nothing ever wrote there. No `ObservationGenerator` / report type (option 2 declined). Scope fence: Observations only.

## Test plan

- `tests/test_save.py`:
  - `test_cli_save_observation_round_trip` — `creek save --target observation --body … --tier open` exits 0 and files a `type: observation` note under `05-Wavelength/Observations/` with the body.
  - `test_saved_observation_lands_in_decision_context_read_dir` — `save_to_vault(OBSERVATION)` lands in exactly the directory `DecisionContextGatherer._current_wavelength` scans (producer↔consumer linkage).
  - The existing target-parametrized tests (`list(SaveTarget)` / `TARGET_SUBDIRS.items()`) and `test_cli_save_help_lists_targets` now cover the new target automatically.

Gates: TDD (red→green confirmed — the help-lists-targets test failed before the help string was updated), `./scripts/check-all.sh` → 12/12 passed.

Refs #578

Closes #584