### PR TITLE
fix(ingest): ChatGPT export parent-only mapping yields 0 fragments (reconstruct children) (#592)

### DIFF
--- a/creek-tools/creek/ingest/chatgpt.py
+++ b/creek-tools/creek/ingest/chatgpt.py
@@ -327,6 +327,37 @@ def _epoch_to_la_datetime(epoch: float | None) -> datetime:
     return datetime.fromtimestamp(epoch, tz=UTC).astimezone(LA_TZ)
 
 
+def _node_create_time(mapping: dict[str, Any], node_id: str) -> float:
+    """Return a node's message ``create_time`` (``0.0`` when missing).
+
+    Used to order reconstructed children deterministically.
+    """
+    message = (mapping.get(node_id) or {}).get("message") or {}
+    create_time = message.get("create_time")
+    return float(create_time) if isinstance(create_time, (int, float)) else 0.0
+
+
+def _reconstruct_children_from_parents(mapping: dict[str, Any]) -> None:
+    """Rebuild each node's ``children`` from its ``parent`` pointer, in place.
+
+    Current ChatGPT exports omit ``children`` arrays, carrying only ``parent``
+    pointers; without reconstruction the walk in :func:`_linearize_tree` stalls
+    at the root and yields zero messages (#592). Children are ordered by message
+    ``create_time`` so the longest-branch walk stays deterministic.
+
+    Args:
+        mapping: The ``mapping`` dict from a ChatGPT conversation (mutated).
+    """
+    children: dict[str, list[str]] = {node_id: [] for node_id in mapping}
+    for node_id, node in mapping.items():
+        parent = node.get("parent")
+        if parent is not None and parent in children:
+            children[parent].append(node_id)
+    for parent_id, child_ids in children.items():
+        child_ids.sort(key=lambda cid: _node_create_time(mapping, cid))
+        mapping[parent_id]["children"] = child_ids
+
+
 def _linearize_tree(
     mapping: dict[str, Any],
 ) -> list[dict[str, Any]]:
@@ -334,7 +365,9 @@ def _linearize_tree(
 
     Finds the root node (parent is None), then walks the tree
     depth-first, always choosing the child branch with the most
-    descendants when branching occurs.
+    descendants when branching occurs. When the mapping carries no
+    ``children`` arrays (current export format — parent pointers only), the
+    children are first reconstructed from the ``parent`` links (#592).
 
     Args:
         mapping: The ``mapping`` dict from a ChatGPT conversation.
@@ -342,6 +375,8 @@ def _linearize_tree(
     Returns:
         An ordered list of message dicts (excluding null messages).
     """
+    if not any(node.get("children") for node in mapping.values()):
+        _reconstruct_children_from_parents(mapping)
     root_id = _find_root_id(mapping)
     if root_id is None:
         return []

--- a/creek-tools/tests/test_chatgpt_ingest.py
+++ b/creek-tools/tests/test_chatgpt_ingest.py
@@ -1389,3 +1389,75 @@ class TestCountDescendantsDeepTree:
 
         count = _count_descendants("node_0", mapping)
         assert count == depth
+
+
+class TestLinearizeTreeParentOnlyMapping:
+    """_linearize_tree reconstructs children from parent pointers (#592).
+
+    Current ChatGPT exports give nodes ``{id, message, parent}`` with no
+    ``children`` arrays. The walk must rebuild children from parents rather
+    than yielding 0 messages.
+    """
+
+    def test_parent_only_mapping_linearizes_in_order(self) -> None:
+        """A parent-only mapping still linearizes system -> user -> assistant."""
+        from creek.ingest.chatgpt import _linearize_tree
+
+        conv = _minimal_conversation()
+        mapping = conv["mapping"]
+        for node in mapping.values():
+            node.pop("children", None)  # mimic current export (parent-only)
+
+        ordered = _linearize_tree(mapping)
+
+        roles = [m["author"]["role"] for m in ordered]
+        assert roles == ["system", "user", "assistant"]
+
+    def test_parent_only_branch_picks_longest(self) -> None:
+        """With reconstructed children, the longest branch still wins."""
+        from creek.ingest.chatgpt import _linearize_tree
+
+        mapping: dict[str, Any] = {
+            "root": {"id": "root", "message": None, "parent": None},
+            "u1": {
+                "id": "u1",
+                "parent": "root",
+                "message": {
+                    "author": {"role": "user"},
+                    "content": {"parts": ["Q"]},
+                    "create_time": 1.0,
+                },
+            },
+            "a1": {
+                "id": "a1",
+                "parent": "u1",
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["short"]},
+                    "create_time": 2.0,
+                },
+            },
+            "a2": {
+                "id": "a2",
+                "parent": "u1",
+                "message": {
+                    "author": {"role": "assistant"},
+                    "content": {"parts": ["long"]},
+                    "create_time": 3.0,
+                },
+            },
+            "a3": {
+                "id": "a3",
+                "parent": "a2",
+                "message": {
+                    "author": {"role": "user"},
+                    "content": {"parts": ["follow"]},
+                    "create_time": 4.0,
+                },
+            },
+        }
+
+        ordered = _linearize_tree(mapping)
+
+        texts = [m["content"]["parts"][0] for m in ordered]
+        assert texts == ["Q", "long", "follow"]


### PR DESCRIPTION
## Summary

Current official ChatGPT exports give conversation `mapping` nodes `{id, message, parent}` with **no `children` arrays**. `_linearize_tree` walks from the root via `node["children"]`, so the root's empty children stalled traversal immediately → **0 fragments**, silently (exit 0). Found live while ingesting a real 908 MB export (472 conversations → 0 fragments until children were reconstructed).

Fix: when the mapping carries no `children` anywhere, `_reconstruct_children_from_parents` rebuilds each node's `children` from its `parent` pointer (ordering each parent's children by message `create_time` so the longest-branch walk stays deterministic), then the existing walk proceeds unchanged. Exports that already carry `children` (older format) are untouched — idempotent.

## Test plan

`tests/test_chatgpt_ingest.py` — new `TestLinearizeTreeParentOnlyMapping`:
- `test_parent_only_mapping_linearizes_in_order` — a parent-only mapping (children stripped) still linearizes system → user → assistant (0 → 3 messages).
- `test_parent_only_branch_picks_longest` — with reconstructed children, a regenerated branch still resolves to the longest branch.
- All 66 existing ChatGPT tests (children-present) still pass → idempotent.

Gates: TDD (red→green confirmed), `./scripts/check-all.sh` → 12/12 passed.

Refs #591

Closes #592