### PR TITLE
fix(ingest): support current Discord data-package schema (capitalized ID/Timestamp/Contents) (#593)

### DIFF
--- a/creek-tools/creek/ingest/discord.py
+++ b/creek-tools/creek/ingest/discord.py
@@ -162,6 +162,56 @@ def _parse_msg_timestamp(msg: dict[str, Any]) -> datetime | None:
         return None
 
 
+_SELF_AUTHOR_NAME = "self"
+"""Author name for messages from the current data package (the owner's own)."""
+
+
+def _normalize_timestamp(timestamp: str) -> str:
+    """Coerce a data-package timestamp (``"YYYY-MM-DD HH:MM:SS"``) to ISO 8601.
+
+    The current Discord data package uses a space-separated, timezone-naive
+    timestamp; :func:`datetime.fromisoformat` wants a ``T`` separator and the
+    timestamps are UTC, so a ``+00:00`` offset is appended when none is present.
+    """
+    iso = timestamp.strip()
+    if not iso:
+        return iso
+    iso = iso.replace(" ", "T", 1)
+    if "+" not in iso[10:] and "Z" not in iso[10:]:
+        iso = f"{iso}+00:00"
+    return iso
+
+
+def _normalize_message(msg: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a Discord message to the canonical lowercase schema (#593).
+
+    The current Discord data package uses capitalized flat keys
+    (``ID`` / ``Timestamp`` / ``Contents``) and carries no author field — the
+    package contains only the requester's own messages. Map those to the
+    ``id`` / ``timestamp`` / ``content`` / ``author`` schema the rest of the
+    ingestor reads, normalising the timestamp to ISO 8601 and attributing the
+    message to the export owner. Messages already in the lowercase schema
+    (older exports / DiscordChatExporter) are returned unchanged.
+
+    Args:
+        msg: A raw Discord message dict.
+
+    Returns:
+        The message in the canonical lowercase schema.
+    """
+    if "content" in msg or "id" in msg:
+        return msg
+    normalized = msg.copy()
+    if "Contents" in msg:
+        normalized["content"] = msg.get("Contents", "")
+    if "ID" in msg:
+        normalized["id"] = str(msg.get("ID", ""))
+    if "Timestamp" in msg:
+        normalized["timestamp"] = _normalize_timestamp(str(msg.get("Timestamp", "")))
+    normalized.setdefault("author", {"name": _SELF_AUTHOR_NAME})
+    return normalized
+
+
 # ---- Grouping logic ----
 
 
@@ -449,11 +499,11 @@ class DiscordIngestor(Ingestor):
             return []
 
         if isinstance(data, list):
-            return data
+            return [_normalize_message(m) for m in data if isinstance(m, dict)]
         if isinstance(data, dict) and "messages" in data:
             msgs = data["messages"]
             if isinstance(msgs, list):
-                return msgs
+                return [_normalize_message(m) for m in msgs if isinstance(m, dict)]
         return []
 
     def _group_to_fragment(

--- a/creek-tools/tests/test_discord_ingest.py
+++ b/creek-tools/tests/test_discord_ingest.py
@@ -1252,3 +1252,63 @@ class TestDiscordIngestorEdgeCases:
         ingestor = DiscordIngestor()
         fragments = ingestor.parse(raw)
         assert "Reactions:" not in fragments[0].content
+
+
+def _current_msg(
+    msg_id: int,
+    contents: str,
+    timestamp: str = "2023-07-27 16:06:13",
+) -> dict[str, Any]:
+    """Build a message in Discord's CURRENT data-package schema (#593).
+
+    Capitalized flat keys, no author field — the package contains only the
+    requester's own messages.
+    """
+    return {
+        "ID": msg_id,
+        "Timestamp": timestamp,
+        "Contents": contents,
+        "Attachments": "",
+    }
+
+
+class TestCurrentDataPackageSchema:
+    """DiscordIngestor handles the current capitalized data-package schema (#593)."""
+
+    def test_normalize_message_maps_capitalized_keys(self) -> None:
+        """_normalize_message maps ID/Timestamp/Contents → id/timestamp/content."""
+        from creek.ingest.discord import _normalize_message
+
+        out = _normalize_message(_current_msg(1134154787915563169, "https://mctb.org"))
+
+        assert out["id"] == "1134154787915563169"
+        assert out["content"] == "https://mctb.org"
+        assert out["timestamp"] == "2023-07-27T16:06:13+00:00"
+        assert out["author"] == {"name": "self"}
+
+    def test_normalize_message_passes_lowercase_through(self) -> None:
+        """A canonical lowercase message is returned unchanged."""
+        from creek.ingest.discord import _normalize_message
+
+        msg = _make_msg(msg_id="m1", author="Alice", content="hi")
+        assert _normalize_message(msg) is msg
+
+    def test_pipeline_ingests_current_format(self, tmp_path: Path) -> None:
+        """End-to-end ingest of current-format messages produces fragments."""
+        _create_channel_dir(
+            tmp_path,
+            channel_id="c123",
+            channel_name="general",
+            messages=[
+                _current_msg(1, "First message"),
+                _current_msg(2, "Second message", "2023-07-27 16:06:20"),
+            ],
+        )
+
+        result = DiscordIngestor().ingest(tmp_path)
+
+        assert result.errors == []
+        assert len(result.fragments) >= 1
+        body = "\n".join(f.content for f in result.fragments)
+        assert "First message" in body
+        assert "Second message" in body


### PR DESCRIPTION
## Summary

The current official Discord **Data Package** stores `Messages/c<id>/messages.json` as flat, **capitalized** objects `{ID, Timestamp, Contents, Attachments}` with **no author** field (the package contains only the requester's own messages). The ingestor reads lowercase `id`/`timestamp`/`content`/`author.name`, so no key matched → **0 fragments**, silently. Found live: 805 channels / 137k messages → 0 until transformed.

Fix: `_normalize_message` (applied to each message in `_parse_messages_json`) maps `ID/Timestamp/Contents` → `id/timestamp/content` when the lowercase keys are absent, ISO-normalises the timestamp (`"YYYY-MM-DD HH:MM:SS"` → `...T...+00:00` for `datetime.fromisoformat`), and attributes the message to the export owner (`author = {"name": "self"}`). Canonical lowercase messages (older exports / DiscordChatExporter) are returned unchanged — backward compatible.

`channel.json` `{id, type}` with no `name` was already tolerated (falls back to dir name); the 5-min same-author grouping is unchanged.

## Test plan

`tests/test_discord_ingest.py` — new `TestCurrentDataPackageSchema`:
- `test_normalize_message_maps_capitalized_keys` — `ID/Timestamp/Contents` → `id/timestamp/content`, ISO timestamp, author=self.
- `test_normalize_message_passes_lowercase_through` — canonical message returned unchanged (identity).
- `test_pipeline_ingests_current_format` — end-to-end `ingest()` of a current-format channel produces fragments with the message content.
- All 144 existing Discord tests still pass → backward compatible.

Gates: TDD (red→green confirmed), `./scripts/check-all.sh` → 12/12 passed.

Refs #591

Closes #593