### PR TITLE
fix(ingest): ingest Substack exports lacking posts.csv (derive metadata from filenames + HTML) (#594)

### DIFF
--- a/creek-tools/creek/ingest/substack.py
+++ b/creek-tools/creek/ingest/substack.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import csv
 import logging
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -184,6 +185,50 @@ def _is_subscriber_csv(path: Path) -> bool:
     return any(name.endswith(suffix) for suffix in SUBSCRIBER_CSV_SUFFIXES)
 
 
+_DATEPUBLISHED_RE = re.compile(r'datePublished"\s*:\s*"(\d{4}-\d{2}-\d{2})')
+
+
+def _title_from_slug(slug: str) -> str:
+    """Render a human-ish title from a post slug (``hello-world`` → ``Hello world``)."""
+    cleaned = re.sub(r"[-_]+", " ", slug).strip()
+    return f"{cleaned[:1].upper()}{cleaned[1:]}" if cleaned else "Untitled"
+
+
+def _scrape_published_date(html_file: Path) -> str:
+    """Return the HTML's ``datePublished`` date (``YYYY-MM-DD``), or ``""``."""
+    try:
+        text = html_file.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return ""
+    match = _DATEPUBLISHED_RE.search(text)
+    return match.group(1) if match else ""
+
+
+def _derive_posts_metadata(source_path: Path) -> dict[str, dict[str, str]]:
+    """Synthesize ``posts.csv``-equivalent metadata from post HTML filenames.
+
+    Used when an export lacks ``posts.csv`` (#594): the title is derived from the
+    ``<post_id>.<slug>.html`` slug and the publication date is scraped from each
+    HTML's ``datePublished`` JSON-LD (blank when absent — never guessed). Shaped
+    identically to :func:`_parse_posts_csv` so the parse stage is unchanged.
+    """
+    metadata: dict[str, dict[str, str]] = {}
+    for html_file in sorted(source_path.rglob("*.html")):
+        if not html_file.is_file() or _is_subscriber_csv(html_file):
+            continue
+        post_id = extract_post_id(html_file.name)
+        if post_id is None:
+            continue
+        slug = html_file.name[len(post_id) + 1 : -len(".html")]
+        metadata[post_id] = {
+            "post_id": post_id,
+            "post_date": _scrape_published_date(html_file),
+            "title": _title_from_slug(slug),
+            "subtitle": "",
+        }
+    return metadata
+
+
 def _resolve_authored_at(
     row: dict[str, str] | None,
     file_path: Path,
@@ -245,10 +290,11 @@ class SubstackIngestor(Ingestor):
     def discover(self, source_path: Path) -> list[RawDocument]:
         """Find post HTML files inside a Substack export directory.
 
-        The export root must contain ``posts.csv``; otherwise the
-        ingestor refuses to emit anything (auto-detection failed and
-        the caller likely meant ``--type document``). Subscriber-PII
-        CSVs are filtered here so the parse stage cannot see them.
+        When the export root contains ``posts.csv`` its metadata is used;
+        otherwise (current exports often omit it) metadata is derived from the
+        ``<post_id>.<slug>.html`` filenames and each HTML's ``datePublished``
+        (#594), so the posts still ingest. Subscriber-PII CSVs are filtered
+        here so the parse stage cannot see them.
 
         ``_posts_metadata`` is reset unconditionally on every call so a
         reused ingestor instance cannot leak the previous export's
@@ -261,10 +307,13 @@ class SubstackIngestor(Ingestor):
             return []
 
         csv_path = source_path / POSTS_CSV_FILENAME
-        if not csv_path.is_file():
-            return []
-
-        self._posts_metadata = _parse_posts_csv(csv_path)
+        if csv_path.is_file():
+            self._posts_metadata = _parse_posts_csv(csv_path)
+        else:
+            # Current exports often ship per-post engagement CSVs but no
+            # posts.csv; derive titles from filenames + dates from each HTML's
+            # datePublished rather than emitting nothing (#594).
+            self._posts_metadata = _derive_posts_metadata(source_path)
 
         docs: list[RawDocument] = []
         for html_file in sorted(source_path.rglob("*.html")):

--- a/creek-tools/tests/test_ingest_substack.py
+++ b/creek-tools/tests/test_ingest_substack.py
@@ -382,16 +382,22 @@ class TestDiscoverEdgeCases:
         result = SubstackIngestor().ingest(sole)
         assert result.fragments == []
 
-    def test_export_without_posts_csv_emits_no_fragments(
+    def test_export_without_posts_csv_derives_metadata(
         self,
         tmp_path: Path,
     ) -> None:
+        """Without posts.csv, a post_id-prefixed HTML still ingests (#594).
+
+        Title is derived from the slug; this replaces the old behaviour of
+        emitting nothing (which silently dropped whole exports).
+        """
         (tmp_path / "111.foo.html").write_text(
             "<html><body><p>hi</p></body></html>",
             encoding="utf-8",
         )
         result = SubstackIngestor().ingest(tmp_path)
-        assert result.fragments == []
+        assert len(result.fragments) == 1
+        assert assemble_ingested_fragment(result.fragments[0]).fragment.title == "Foo"
 
     def test_html_files_without_post_id_prefix_are_skipped(
         self,
@@ -467,3 +473,58 @@ class TestSubscriberCsvHelpers:
         path = tmp_path / "posts.csv"
         path.write_text("post_id\n", encoding="utf-8")
         assert _is_subscriber_csv(path) is False
+
+
+class TestSubstackWithoutPostsCsv:
+    """Ingest current Substack exports that lack ``posts.csv`` (#594)."""
+
+    @staticmethod
+    def _write_export_no_csv(tmp_path: Path) -> Path:
+        posts = tmp_path / "posts"
+        posts.mkdir()
+        (posts / "111.hello-world.html").write_text(
+            '<html><head><script type="application/ld+json">'
+            '{"datePublished":"2024-03-15T08:30:00Z"}</script></head>'
+            "<body><h1>Hello World</h1><p>Body of the hello world essay.</p>"
+            "</body></html>",
+            encoding="utf-8",
+        )
+        (posts / "222.second-essay.html").write_text(
+            "<html><body><h1>Second</h1><p>Second body here.</p></body></html>",
+            encoding="utf-8",
+        )
+        # per-post engagement CSV present; NO posts.csv at the root.
+        (posts / "111.hello-world.delivers.csv").write_text(
+            "email,delivered\nu@e.com,true\n",
+            encoding="utf-8",
+        )
+        return tmp_path
+
+    def test_discover_without_posts_csv_finds_posts(self, tmp_path: Path) -> None:
+        """discover derives posts from filenames when posts.csv is absent."""
+        root = self._write_export_no_csv(tmp_path)
+        docs = SubstackIngestor().discover(root)
+        assert len(docs) == 2
+
+    def test_titles_derived_from_slug(self, tmp_path: Path) -> None:
+        """Titles come from the HTML filename slug when no posts.csv exists."""
+        root = self._write_export_no_csv(tmp_path)
+        result = SubstackIngestor().ingest(root)
+        assert result.errors == []
+        titles = sorted(
+            assemble_ingested_fragment(p).fragment.title for p in result.fragments
+        )
+        assert titles == ["Hello world", "Second essay"]
+
+    def test_authored_at_scraped_from_html_datepublished(self, tmp_path: Path) -> None:
+        """authored_at is scraped from the HTML datePublished when available."""
+        root = self._write_export_no_csv(tmp_path)
+        result = SubstackIngestor().ingest(root)
+        by_title = {
+            assemble_ingested_fragment(p).fragment.title: assemble_ingested_fragment(
+                p
+            ).fragment.authored_at
+            for p in result.fragments
+        }
+        assert by_title["Hello world"] is not None
+        assert by_title["Hello world"].date().isoformat() == "2024-03-15"

--- a/creek-tools/tests/test_ingest_substack.py
+++ b/creek-tools/tests/test_ingest_substack.py
@@ -528,3 +528,6 @@ class TestSubstackWithoutPostsCsv:
         }
         assert by_title["Hello world"] is not None
         assert by_title["Hello world"].date().isoformat() == "2024-03-15"
+        # The "never guessed" invariant: a post with no datePublished in its
+        # HTML must not get a fabricated date (#594).
+        assert by_title["Second essay"] is None


### PR DESCRIPTION
## Summary

`SubstackIngestor.discover` returned `[]` when `posts.csv` was absent — but current Substack exports often ship only per-post engagement CSVs (`<id>.<slug>.delivers.csv` / `.opens.csv`) plus the post HTML, with **no `posts.csv`**. So the entire export → **0 fragments**, silently. Found live: 436- and 15-file exports → 0 until a `posts.csv` was synthesized.

Fix: when `posts.csv` is missing, `_derive_posts_metadata` synthesizes the same `{post_id: {post_date, title, subtitle}}` shape from the `<post_id>.<slug>.html` filenames — **title from the slug**, **`post_date` scraped from each HTML's `datePublished` JSON-LD** (blank when absent — never guessed). The parse/assembly stage is unchanged, and `posts.csv` is still preferred when present.

Auto-detection (`is_substack_export`) deliberately stays gated on `posts.csv` so undated directories aren't stolen from the `document` ingestor — only the explicit `--type substack` path derives.

## Test plan

`tests/test_ingest_substack.py` — new `TestSubstackWithoutPostsCsv`:
- `test_discover_without_posts_csv_finds_posts` — both posts discovered with no `posts.csv`.
- `test_titles_derived_from_slug` — titles `["Hello world", "Second essay"]` from slugs.
- `test_authored_at_scraped_from_html_datepublished` — `authored_at` = `2024-03-15` scraped from the HTML.
- Updated `test_export_without_posts_csv_derives_metadata` (was `..._emits_no_fragments`) to assert the corrected behaviour.
- All other substack tests (with `posts.csv`) still pass; detection tests unchanged.

Gates: TDD (red→green confirmed), `./scripts/check-all.sh` → 12/12 passed.

Refs #591

Closes #594