### PR TITLE
feat(ingest): warn/fail when inputs are discovered but 0 fragments are produced (#595)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -309,7 +309,7 @@ def _run_ingest(
     source_type: str,
     input_path: Path,
     vault_path: Path,
-) -> tuple[int, list[str]]:
+) -> tuple[int, list[str], int]:
     """Run a single ingestor and persist its output to the vault.
 
     Args:
@@ -319,8 +319,9 @@ def _run_ingest(
         vault_path: Vault root for :class:`VaultWriter`.
 
     Returns:
-        Tuple of ``(written_count, errors)`` where ``errors`` is a list
-        of human-readable strings prefixed with ``[<source_type>]``.
+        Tuple of ``(written_count, errors, discovered)`` where ``errors`` is a
+        list of human-readable strings prefixed with ``[<source_type>]`` and
+        ``discovered`` is how many inputs the ingestor's ``discover()`` found.
 
     Raises:
         typer.Exit: With code ``1`` when the vault cannot be opened.
@@ -356,7 +357,34 @@ def _run_ingest(
             continue
         written += 1
 
-    return written, errors
+    return written, errors, ingest_result.discovered
+
+
+def _warn_if_discovered_but_empty(
+    *,
+    written: int,
+    discovered: int,
+    source_type: str,
+    strict: bool,
+) -> None:
+    """Warn (and optionally exit non-zero) when inputs parsed to 0 fragments.
+
+    The silent ``Ingested 0 fragment(s)`` is the symptom that masked the
+    ChatGPT/Discord/Substack export-format bugs (#595): ``discover()`` found
+    inputs but none parsed, signalling an unrecognized format. ``--strict``
+    turns the warning into a non-zero exit for pipelines/CI.
+
+    Raises:
+        typer.Exit: With code ``1`` when *strict* and the condition holds.
+    """
+    if written > 0 or discovered == 0:
+        return
+    console.print(
+        f"[yellow]WARNING: discovered {discovered} {source_type} input(s) but "
+        "produced 0 fragments — the export format may be unrecognized.[/yellow]",
+    )
+    if strict:
+        raise typer.Exit(code=1)
 
 
 def _guard_vault_path(vault: Path, allow_in_repo: bool) -> None:
@@ -569,6 +597,14 @@ def ingest(
             "Idempotent. --type / --input are ignored."
         ),
     ),
+    strict: bool = typer.Option(
+        False,
+        "--strict",
+        help=(
+            "Exit non-zero when inputs were discovered but produced 0 "
+            "fragments (likely an unrecognized export format)."
+        ),
+    ),
 ) -> None:
     """Ingest a specific source type into the vault.
 
@@ -612,7 +648,7 @@ def ingest(
         assume_yes=yes,
     )
 
-    written, errors = _run_ingest(
+    written, errors, discovered = _run_ingest(
         ingestor_cls=ingestor_cls,
         source_type=type,
         input_path=input,
@@ -624,6 +660,13 @@ def ingest(
         console.print(f"[yellow]Errors: {len(errors)}[/yellow]")
         for err in errors:
             console.print(f"  [dim]{err}[/dim]")
+
+    _warn_if_discovered_but_empty(
+        written=written,
+        discovered=discovered,
+        source_type=type,
+        strict=strict,
+    )
 
 
 def _run_refresh_dates(vault: Path | None) -> None:

--- a/creek-tools/creek/ingest/base.py
+++ b/creek-tools/creek/ingest/base.py
@@ -170,6 +170,13 @@ class IngestResult(BaseModel):
     errors: list[str] = Field(default_factory=list)
     """Error messages collected during ingest."""
 
+    discovered: int = 0
+    """Count of inputs ``discover()`` found.
+
+    Lets callers distinguish "no inputs found" (``discovered == 0``) from
+    "inputs found but nothing parsed" (``discovered > 0`` yet ``fragments``
+    empty) — the latter signals an unrecognized export format (#595)."""
+
 
 # ---- Shared Utility Functions ----
 
@@ -547,6 +554,7 @@ class Ingestor(abc.ABC):
 
         # Stage 1: Discover
         raw_docs = self._discover_safe(source_path, result)
+        result.discovered = len(raw_docs)
 
         # Stages 2-4: Parse, Convert, Frontmatter
         for raw_doc in raw_docs:

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from creek.cli import app
+from creek.ingest.base import IngestResult
 
 runner = CliRunner()
 
@@ -3669,3 +3670,108 @@ def test_voice_check_builds_fingerprint_when_not_persisted(
 
     assert result.exit_code == 0, result.output
     assert "voice_distance" in _strip_ansi(result.output).lower()
+
+
+# ---- ingest fail-loud on 0 fragments (#595) ----
+
+
+class _ZeroFragmentIngestor:
+    """Fake ingestor: discovers inputs but parses nothing (#595)."""
+
+    def ingest(self, _source_path: Path) -> IngestResult:
+        """Return a result with inputs discovered but no fragments."""
+        return IngestResult(discovered=2, fragments=[], errors=[])
+
+
+class _NoInputIngestor:
+    """Fake ingestor: nothing discovered at all."""
+
+    def ingest(self, _source_path: Path) -> IngestResult:
+        """Return an empty result with zero discovered inputs."""
+        return IngestResult(discovered=0, fragments=[], errors=[])
+
+
+def _scaffold_min_vault(tmp_path: Path) -> Path:
+    """Create the minimal vault dirs VaultWriter requires."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+    (vault / "01-Fragments").mkdir(parents=True)
+    return vault
+
+
+def test_ingest_warns_when_inputs_found_but_zero_fragments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inputs discovered but 0 fragments → loud warning, exit 0 by default (#595)."""
+    vault = _scaffold_min_vault(tmp_path)
+    src = tmp_path / "in"
+    src.mkdir()
+    monkeypatch.setattr("creek.cli._resolve_ingestor", lambda _t: _ZeroFragmentIngestor)
+
+    result = runner.invoke(
+        app,
+        ["ingest", "--type", "fake", "--input", str(src), "--vault", str(vault), "-y"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "WARNING" in result.output
+    assert "0 fragments" in result.output
+
+
+def test_ingest_strict_exits_nonzero_on_zero_fragments(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--strict makes the discovered-but-0-fragments case exit non-zero (#595)."""
+    vault = _scaffold_min_vault(tmp_path)
+    src = tmp_path / "in"
+    src.mkdir()
+    monkeypatch.setattr("creek.cli._resolve_ingestor", lambda _t: _ZeroFragmentIngestor)
+
+    result = runner.invoke(
+        app,
+        [
+            "ingest",
+            "--type",
+            "fake",
+            "--input",
+            str(src),
+            "--vault",
+            str(vault),
+            "-y",
+            "--strict",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "WARNING" in result.output
+
+
+def test_ingest_no_warning_when_no_inputs_discovered(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Nothing discovered → no false warning, exit 0 even under --strict (#595)."""
+    vault = _scaffold_min_vault(tmp_path)
+    src = tmp_path / "in"
+    src.mkdir()
+    monkeypatch.setattr("creek.cli._resolve_ingestor", lambda _t: _NoInputIngestor)
+
+    result = runner.invoke(
+        app,
+        [
+            "ingest",
+            "--type",
+            "fake",
+            "--input",
+            str(src),
+            "--vault",
+            str(vault),
+            "-y",
+            "--strict",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "WARNING" not in result.output


### PR DESCRIPTION
## Summary

The silent `Ingested 0 fragment(s)` (exit 0) is the symptom that masked the ChatGPT/Discord/Substack export-format bugs (#592/#593/#594): `discover()` found inputs but none parsed, and the CLI reported success with no warning.

- `IngestResult` gains a **`discovered`** count, set from `len(raw_docs)` in `Ingestor.ingest` — distinguishing "no inputs found" (`discovered == 0`) from "inputs found, 0 parsed" (`discovered > 0`, empty `fragments`).
- `_run_ingest` returns that count; the `ingest` command emits a loud **WARNING** when `discovered > 0` and `written == 0` (extracted into `_warn_if_discovered_but_empty` to keep the command under the complexity gate).
- New **`--strict`** flag turns that case into a non-zero exit for pipelines/CI.

## Test plan

`tests/test_cli.py` (3 new tests, fake ingestors):
- `test_ingest_warns_when_inputs_found_but_zero_fragments` — discovered=2, 0 fragments → WARNING, exit 0.
- `test_ingest_strict_exits_nonzero_on_zero_fragments` — same with `--strict` → exit 1.
- `test_ingest_no_warning_when_no_inputs_discovered` — discovered=0 → no warning, exit 0 even under `--strict`.

Gates: TDD, `./scripts/check-all.sh` → 12/12 passed.

Refs #591

Closes #595