### PR TITLE
perf(link): embeddings resonance is O(n²) and does not scale past ~10k fragments (#596)

### DIFF
--- a/creek-tools/creek/link/embeddings.py
+++ b/creek-tools/creek/link/embeddings.py
@@ -10,15 +10,12 @@ runs (INC-006).
 from __future__ import annotations
 
 import hashlib
-import itertools
 import logging
-import sys
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Final, cast
 
 from pydantic import BaseModel
-from tqdm import tqdm
 
 # FragmentLevel is a Literal alias that Pydantic resolves at class-creation
 # time when building ``Resonance``'s field schema; moving it under
@@ -52,6 +49,13 @@ EMBEDDINGS_CACHE_FILENAME: Final[str] = "embeddings.parquet"
 
 EMBEDDINGS_CACHE_DIR: Final[str] = "00-Creek-Meta"
 """Vault subdirectory that holds the embeddings cache."""
+
+_RESONANCE_BLOCK_ROWS: Final[int] = 512
+"""Row-block size for chunked resonance similarity (#596).
+
+Similarities are computed one block of rows at a time so peak memory is
+``block_rows x N`` floats rather than the full ``N x N`` matrix — keeping
+resonance discovery tractable at ≥50k fragments."""
 
 
 class EmbeddingModelUnavailableError(RuntimeError):
@@ -683,8 +687,7 @@ class EmbeddingLinker:
 
         Returns:
             A list of :class:`Resonance` records, one per qualifying pair,
-            in the deterministic insertion order of
-            :func:`itertools.combinations`.
+            in ascending ``(i, j)`` fragment-index order.
         """
         ids = list(embeddings.keys())
         if len(ids) < 2:
@@ -702,46 +705,49 @@ class EmbeddingLinker:
         norms = np.linalg.norm(vectors, axis=1, keepdims=True)
         norms = np.maximum(norms, 1e-10)
         normalized = vectors / norms
-        similarity_matrix = normalized @ normalized.T
 
         ancestors, sibling_positions = _hierarchy_index(fragments)
         levels = _level_lookup(ids, fragments)
+        threshold = self.config.similarity_threshold
 
         resonances: list[Resonance] = []
         suppressed = 0
-        # OPS-004: pairwise loop is O(N²); on a 10k-fragment vault this
-        # is ~50M iterations and runs for minutes. Show tqdm in TTYs and
-        # stay silent in non-interactive runs (CI logs, pipes).
-        n_pairs = len(ids) * (len(ids) - 1) // 2
-        pair_iter = tqdm(
-            itertools.combinations(range(len(ids)), 2),
-            total=n_pairs,
-            desc="Resonances",
-            unit="pair",
-            disable=not sys.stderr.isatty(),
-        )
-        for i, j in pair_iter:
-            sim = float(similarity_matrix[i, j])
-            if sim < self.config.similarity_threshold:
-                continue
-            if _is_hierarchy_suppressed(
-                ids[i],
-                ids[j],
-                ancestors=ancestors,
-                sibling_positions=sibling_positions,
-                sibling_skip_window=sibling_skip_window,
-            ):
-                suppressed += 1
-                continue
-            resonances.append(
-                Resonance(
-                    fragment_a_id=ids[i],
-                    fragment_b_id=ids[j],
-                    similarity=sim,
-                    from_level=levels[ids[i]],
-                    to_level=levels[ids[j]],
-                ),
-            )
+        # Resonance discovery compares every pair, but similarities are computed
+        # one block of rows at a time via vectorized matmul (never materializing
+        # the full NxN matrix) and thresholded with numpy, so only
+        # above-threshold pairs reach Python. Peak memory is block_rows x N,
+        # which scales to ≥50k fragments — unlike the old full-matrix +
+        # itertools.combinations loop (OPS-004 / #596). Pairs are still emitted
+        # in ascending ``(i, j)`` index order.
+        n = len(ids)
+        for start in range(0, n, _RESONANCE_BLOCK_ROWS):
+            stop = min(start + _RESONANCE_BLOCK_ROWS, n)
+            block_sims = normalized[start:stop] @ normalized.T
+            for local_index, i in enumerate(range(start, stop)):
+                row = block_sims[local_index]
+                # Upper triangle only: fragment i against each j > i.
+                above = np.nonzero(row[i + 1 :] >= threshold)[0]
+                for offset in above:
+                    j = i + 1 + int(offset)
+                    if _is_hierarchy_suppressed(
+                        ids[i],
+                        ids[j],
+                        ancestors=ancestors,
+                        sibling_positions=sibling_positions,
+                        sibling_skip_window=sibling_skip_window,
+                    ):
+                        suppressed += 1
+                        continue
+                    resonances.append(
+                        Resonance(
+                            fragment_a_id=ids[i],
+                            fragment_b_id=ids[j],
+                            similarity=float(row[j]),
+                            from_level=levels[ids[i]],
+                            to_level=levels[ids[j]],
+                        ),
+                    )
+            del block_sims
 
         if suppressed:
             logger.info(

--- a/creek-tools/tests/test_embeddings.py
+++ b/creek-tools/tests/test_embeddings.py
@@ -616,6 +616,35 @@ class TestDeleteEmbeddingsCache:
 class TestFindResonances:
     """Tests for the find_resonances cosine similarity method."""
 
+    def test_resonances_found_across_chunk_boundary(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Chunked similarity still finds cross-block pairs, in (i, j) order (#596).
+
+        With a tiny block size the 5 fragments span multiple row blocks; the
+        rewrite must still find the f0/f4 pair (different blocks) and emit
+        results in ascending fragment-index order.
+        """
+        monkeypatch.setattr("creek.link.embeddings._RESONANCE_BLOCK_ROWS", 2)
+        linker = EmbeddingLinker(
+            config=EmbeddingsConfig(similarity_threshold=0.9),
+        )
+        embeddings = {
+            "f0": [1.0, 0.0],
+            "f1": [0.0, 1.0],
+            "f2": [0.0, 1.0],
+            "f3": [0.0, 1.0],
+            "f4": [1.0, 0.0],
+        }
+
+        result = linker.find_resonances(embeddings)
+
+        pairs = [(r.fragment_a_id, r.fragment_b_id) for r in result]
+        assert ("f0", "f4") in pairs  # spans block [0:2] and block [4:5]
+        # Ascending (i, j) order preserved across block boundaries.
+        assert pairs == [("f0", "f4"), ("f1", "f2"), ("f1", "f3"), ("f2", "f3")]
+
     def test_identical_vectors_have_similarity_one(self) -> None:
         """Identical vectors should have cosine similarity of 1.0."""
         linker = EmbeddingLinker(


### PR DESCRIPTION
## Summary

`find_resonances` materialized the full **N×N** similarity matrix (≈10 GB at 50k fragments) and then iterated **every pair in Python** via `itertools.combinations` — the code itself flagged 10k as concerning (OPS-004). On a 35k-fragment vault the resonance pass was **killed mid-run** during a real bootstrap; the 30k short Discord fragments dominated and drove the blowup.

Fix: compute similarities **one row-block at a time** (`block_rows × N`) via vectorized matmul, threshold each block with numpy, and only let above-threshold pairs reach Python. Peak memory is now `block_rows × N` (≈100 MB at 50k with the default 512-row block) instead of `N × N`, and there's no per-pair Python loop — so resonance discovery scales to ≥50k fragments. The O(n) embedding-cache build path is untouched.

**Behaviour is preserved exactly**: same pairs, same ascending `(i, j)` order, same similarity values, same FEAT-024 hierarchy/sibling suppression. Removed the now-unused `itertools` / `sys` / `tqdm` imports.

## Test plan

- **Parity:** all 58 existing `test_embeddings.py` tests (threshold, orthogonality, ordering, hierarchy/sibling suppression, empty/single, logging) pass unchanged — they guard exact behaviour.
- **New** `test_resonances_found_across_chunk_boundary`: with `_RESONANCE_BLOCK_ROWS` monkeypatched to 2, fragments span multiple blocks; asserts a cross-block pair (`f0`/`f4`) is found and the full result list is in ascending `(i, j)` order — the specific risk the chunking introduces.

Gates: `./scripts/check-all.sh` → 12/12 passed.

Refs #591
Closes #596