### PR TITLE
refactor(llm): provider-neutral Completion + LLMProvider Protocol (#604)

### DIFF
--- a/creek-tools/creek/classify/llm/__init__.py
+++ b/creek-tools/creek/classify/llm/__init__.py
@@ -37,8 +37,15 @@ import time as time
 # call time, so the patches reach the inner code paths.
 import httpx as httpx
 
+from creek.classify.llm.base import LLMProvider
 from creek.classify.llm.batch import BatchStats
 from creek.classify.llm.calibration import _BIASED_DIMENSIONS as _BIASED_DIMENSIONS
+from creek.classify.llm.completion import (
+    AnthropicCompletion as AnthropicCompletion,
+)
+from creek.classify.llm.completion import (
+    Completion as Completion,
+)
 from creek.classify.llm.orchestrator import (
     LLMClassificationResult,
     LLMClassifier,
@@ -62,8 +69,11 @@ from creek.classify.llm.providers import ANTHROPIC_CLOUD_WARNING, AnthropicProvi
 __all__ = [
     "ANTHROPIC_CLOUD_WARNING",
     "CLASSIFICATION_PROMPT",
+    "AnthropicCompletion",
     "AnthropicProvider",
     "BatchStats",
+    "Completion",
     "LLMClassificationResult",
     "LLMClassifier",
+    "LLMProvider",
 ]

--- a/creek-tools/creek/classify/llm/base.py
+++ b/creek-tools/creek/classify/llm/base.py
@@ -1,0 +1,52 @@
+"""The provider-neutral contract every synchronous LLM backend satisfies.
+
+Defines :class:`LLMProvider`, the ``Protocol`` (#604) that the existing
+Anthropic path — and the OpenAI / Gemini paths to come — implement so the
+orchestrator and author desk can route through one structural type. The
+protocol is ``runtime_checkable`` so conformance can be asserted in tests;
+mypy enforces it statically wherever a provider is bound to this type.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from creek.classify.llm.completion import Completion
+
+
+@runtime_checkable
+class LLMProvider(Protocol):
+    """A synchronous, provider-neutral text-completion backend.
+
+    Implementations read their API key from the environment (never config),
+    expose the resolved model identifier, report whether their prerequisites
+    are met, and turn a prompt into a normalized :class:`Completion`.
+    """
+
+    @property
+    def model(self) -> str:
+        """The resolved model identifier used for completion calls."""
+
+    @property
+    def available(self) -> bool:
+        """Whether the backend's prerequisites (keys, consent, host) are met."""
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int | None = None,
+        system: str | None = None,
+    ) -> Completion:
+        """Send *prompt* and return its normalized :class:`Completion`.
+
+        Args:
+            prompt: The dynamic, fully-formatted user prompt.
+            max_tokens: Maximum tokens to request, or ``None`` for the
+                backend's default ceiling.
+            system: Optional static system prefix, or ``None``.
+
+        Returns:
+            The backend's :class:`Completion`.
+        """

--- a/creek-tools/creek/classify/llm/completion.py
+++ b/creek-tools/creek/classify/llm/completion.py
@@ -1,0 +1,45 @@
+"""Provider-neutral completion result for the classification pipeline.
+
+Extracted from :mod:`creek.classify.llm.providers` (#604) so every LLM
+backend — Anthropic today, OpenAI / Gemini next — returns one normalized
+shape. The fields are byte-for-byte identical to the historical
+``AnthropicCompletion``; the old name remains as a deprecated alias so no
+import site changes.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Completion:
+    """A model completion paired with its stop reason and token usage.
+
+    The classification path discards the stop reason; the draft path
+    needs it so a ``max_tokens`` ceiling can be surfaced instead of
+    truncating the essay mid-sentence without warning.
+
+    Attributes:
+        text: The concatenated textual content of the response.
+        stop_reason: The reason the model stopped generating. ``"end_turn"``
+            on a clean completion; ``"max_tokens"`` when the ceiling was hit.
+        usage: Token-usage counts from the SDK response, when available
+            (``input_tokens``, ``output_tokens`` and, when prompt caching is
+            active, ``cache_creation_input_tokens`` / ``cache_read_input_tokens``).
+            ``None`` when the SDK omitted usage. The author desk surfaces this on
+            :class:`~creek.author.models.AuthoredDraft` so a run's cost — and
+            cache-hit rate — is observable (#474).
+    """
+
+    text: str
+    stop_reason: str = "end_turn"
+    usage: dict[str, int] | None = None
+
+
+AnthropicCompletion = Completion
+"""Deprecated alias for :class:`Completion`.
+
+Retained so pre-#604 import sites (``from creek.classify.llm.providers import
+AnthropicCompletion``) keep resolving. New code should use :class:`Completion`.
+"""

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -17,10 +17,11 @@ from __future__ import annotations
 
 import logging
 import os
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import httpx
+
+from creek.classify.llm.completion import AnthropicCompletion, Completion
 
 if TYPE_CHECKING:
     import anthropic
@@ -29,30 +30,16 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
-@dataclass(frozen=True)
-class AnthropicCompletion:
-    """An Anthropic completion paired with its stop reason.
-
-    The classification path discards the stop reason; the draft path
-    needs it so a ``max_tokens`` ceiling can be surfaced instead of
-    truncating the essay mid-sentence without warning.
-
-    Attributes:
-        text: The concatenated textual content of the response.
-        stop_reason: The reason the model stopped generating. ``"end_turn"``
-            on a clean completion; ``"max_tokens"`` when the ceiling was hit.
-        usage: Token-usage counts from the SDK response, when available
-            (``input_tokens``, ``output_tokens`` and, when prompt caching is
-            active, ``cache_creation_input_tokens`` / ``cache_read_input_tokens``).
-            ``None`` when the SDK omitted usage. The author desk surfaces this on
-            :class:`~creek.author.models.AuthoredDraft` so a run's cost — and
-            cache-hit rate — is observable (#474).
-    """
-
-    text: str
-    stop_reason: str = "end_turn"
-    usage: dict[str, int] | None = None
+# ``AnthropicCompletion`` is the deprecated alias for :class:`Completion`,
+# imported here so the historical path
+# ``from creek.classify.llm.providers import AnthropicCompletion`` keeps
+# resolving after the type moved to :mod:`creek.classify.llm.completion` (#604).
+__all__ = [
+    "ANTHROPIC_CLOUD_WARNING",
+    "AnthropicCompletion",
+    "AnthropicProvider",
+    "Completion",
+]
 
 
 ANTHROPIC_CLOUD_WARNING: str = (
@@ -106,21 +93,50 @@ class AnthropicProvider:
                 variables are not set.
         """
         self.config = config
-        if not os.environ.get(self.API_KEY_ENV, "").strip():
-            msg = (
-                f"{self.API_KEY_ENV} environment variable is not set; "
+        unmet = self._missing_prerequisite()
+        if unmet is not None:
+            raise RuntimeError(unmet)
+        self._client: anthropic.Anthropic | None = None
+
+    @classmethod
+    def _missing_prerequisite(cls) -> str | None:
+        """Return why the Anthropic prerequisites are unmet, or ``None``.
+
+        The API key and the explicit cloud-egress consent are both read from
+        the environment at call time, so the check reflects the *current* env
+        rather than the env at construction. :meth:`__init__` raises the
+        returned message; :attr:`available` reports whether it is ``None``.
+
+        Returns:
+            A human-readable explanation when the key is missing or consent is
+            not affirmative; ``None`` when both prerequisites are satisfied.
+        """
+        if not os.environ.get(cls.API_KEY_ENV, "").strip():
+            return (
+                f"{cls.API_KEY_ENV} environment variable is not set; "
                 "required for the Anthropic provider."
             )
-            raise RuntimeError(msg)
-        consent = os.environ.get(self.CONSENT_ENV, "").strip().lower()
-        if consent not in self.CONSENT_TRUTHY:
-            msg = (
+        consent = os.environ.get(cls.CONSENT_ENV, "").strip().lower()
+        if consent not in cls.CONSENT_TRUTHY:
+            return (
                 "Anthropic cloud classification requires explicit consent. "
-                f"Set {self.CONSENT_ENV}=1 to confirm that fragment content "
+                f"Set {cls.CONSENT_ENV}=1 to confirm that fragment content "
                 "may be sent to Anthropic's servers."
             )
-            raise RuntimeError(msg)
-        self._client: anthropic.Anthropic | None = None
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Whether the Anthropic prerequisites (API key + consent) are met.
+
+        Delegates to :meth:`_missing_prerequisite`, the same check
+        :meth:`__init__` enforces, so the :class:`~creek.classify.llm.base.LLMProvider`
+        protocol's ``available`` contract reflects the live environment.
+
+        Returns:
+            ``True`` when the API key is set and consent is affirmative.
+        """
+        return self._missing_prerequisite() is None
 
     @property
     def model(self) -> str:
@@ -165,6 +181,35 @@ class AnthropicProvider:
                 its type name to avoid leaking sensitive request state.
         """
         return self.call_with_metadata(prompt).text
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int | None = None,
+        system: str | None = None,
+    ) -> Completion:
+        """Provider-neutral entry point: send *prompt*, return a ``Completion``.
+
+        Satisfies the :class:`~creek.classify.llm.base.LLMProvider` protocol by
+        delegating verbatim to :meth:`call_with_metadata`, the historical
+        Anthropic-named method existing callers still use. No behaviour change;
+        the two names are interchangeable while callers migrate (#604).
+
+        Args:
+            prompt: The dynamic, fully-formatted user prompt.
+            max_tokens: Maximum tokens to request, or ``None`` for the
+                historical :attr:`MAX_TOKENS` ceiling.
+            system: Optional static system prefix to cache, or ``None``.
+
+        Returns:
+            The :class:`Completion` produced by :meth:`call_with_metadata`.
+
+        Raises:
+            RuntimeError: Propagated from :meth:`call_with_metadata` when the
+                SDK raises; the original exception type name is preserved.
+        """
+        return self.call_with_metadata(prompt, max_tokens=max_tokens, system=system)
 
     def call_with_metadata(
         self,

--- a/creek-tools/tests/test_llm_provider_seam.py
+++ b/creek-tools/tests/test_llm_provider_seam.py
@@ -1,0 +1,146 @@
+"""Tests for the provider-neutral seam (#604).
+
+Locks the refactor that extracted a provider-neutral :class:`Completion`
+result type and an :class:`LLMProvider` ``Protocol`` the existing
+Anthropic path satisfies, without changing any behaviour. Covers:
+
+- the ``AnthropicCompletion`` deprecated alias still resolves to ``Completion``;
+- every historical import path (``providers`` and the package shim) still works;
+- :class:`AnthropicProvider` is a structural :class:`LLMProvider`;
+- the new :meth:`AnthropicProvider.complete` delegates to the historical
+  :meth:`AnthropicProvider.call_with_metadata` with no behaviour change;
+- :attr:`AnthropicProvider.available` reflects the env prerequisites.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from creek.classify.llm.base import LLMProvider
+from creek.classify.llm.completion import AnthropicCompletion, Completion
+from creek.classify.llm.providers import AnthropicProvider
+from creek.config import LLMConfig
+
+
+@pytest.fixture
+def anthropic_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set the API key and consent so an ``AnthropicProvider`` constructs."""
+    monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+    monkeypatch.setenv(AnthropicProvider.CONSENT_ENV, "1")
+
+
+def test_anthropic_completion_is_completion_alias() -> None:
+    """The deprecated ``AnthropicCompletion`` name is exactly ``Completion``."""
+    assert AnthropicCompletion is Completion
+
+
+def test_completion_keeps_normalized_fields() -> None:
+    """``Completion`` carries the historical text/stop_reason/usage shape."""
+    completion = Completion(
+        text="hi", stop_reason="max_tokens", usage={"input_tokens": 3}
+    )
+    assert completion.text == "hi"
+    assert completion.stop_reason == "max_tokens"
+    assert completion.usage == {"input_tokens": 3}
+
+
+def test_completion_defaults() -> None:
+    """``stop_reason`` defaults to ``end_turn`` and ``usage`` to ``None``."""
+    completion = Completion(text="x")
+    assert completion.stop_reason == "end_turn"
+    assert completion.usage is None
+
+
+def test_legacy_import_paths_still_resolve() -> None:
+    """Every pre-refactor import site keeps working (public surface intact)."""
+    from creek.classify.llm import (
+        AnthropicCompletion as PkgAnthropicCompletion,
+    )
+    from creek.classify.llm import (
+        Completion as PkgCompletion,
+    )
+    from creek.classify.llm import (
+        LLMProvider as PkgLLMProvider,
+    )
+    from creek.classify.llm.providers import (
+        AnthropicCompletion as ProvidersAnthropicCompletion,
+    )
+
+    assert PkgCompletion is Completion
+    assert PkgAnthropicCompletion is Completion
+    assert ProvidersAnthropicCompletion is Completion
+    assert PkgLLMProvider is LLMProvider
+
+
+def test_anthropic_provider_is_structural_llm_provider(
+    anthropic_env: None,
+) -> None:
+    """A constructed ``AnthropicProvider`` satisfies the ``LLMProvider`` protocol."""
+    provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+    assert isinstance(provider, LLMProvider)
+
+
+def test_complete_delegates_to_call_with_metadata(
+    anthropic_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``complete`` forwards prompt and kwargs verbatim to ``call_with_metadata``."""
+    provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+    captured: dict[str, object] = {}
+    sentinel = Completion(text="ok", stop_reason="end_turn")
+
+    def fake(
+        prompt: str,
+        *,
+        max_tokens: int | None = None,
+        system: str | None = None,
+    ) -> Completion:
+        captured["prompt"] = prompt
+        captured["max_tokens"] = max_tokens
+        captured["system"] = system
+        return sentinel
+
+    monkeypatch.setattr(provider, "call_with_metadata", fake)
+
+    result = provider.complete("hello", max_tokens=42, system="sys")
+
+    assert result is sentinel
+    assert captured == {"prompt": "hello", "max_tokens": 42, "system": "sys"}
+
+
+def test_complete_returns_completion(
+    anthropic_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``complete`` returns the provider-neutral ``Completion`` type."""
+    provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+    monkeypatch.setattr(
+        provider, "call_with_metadata", lambda *a, **k: Completion(text="z")
+    )
+    assert isinstance(provider.complete("p"), Completion)
+
+
+def test_available_true_when_prerequisites_met(anthropic_env: None) -> None:
+    """``available`` is ``True`` while key and consent are present."""
+    provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+    assert provider.available is True
+
+
+def test_available_false_when_key_removed(
+    anthropic_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``available`` re-checks env and flips ``False`` once the key is gone."""
+    provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+    monkeypatch.delenv(AnthropicProvider.API_KEY_ENV, raising=False)
+    assert provider.available is False
+
+
+def test_available_false_when_consent_revoked(
+    anthropic_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``available`` flips ``False`` when consent is no longer affirmative."""
+    provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+    monkeypatch.setenv(AnthropicProvider.CONSENT_ENV, "no")
+    assert provider.available is False


### PR DESCRIPTION
## Summary

- Extract a provider-neutral `Completion` dataclass and a `runtime_checkable` `LLMProvider` `Protocol` (`model` / `available` / `complete`) so future OpenAI/Gemini backends can plug into the synchronous pipeline. Sequence 1/8 of the swappable-providers epic.
- Pure refactor: `AnthropicProvider` gains a thin `complete()` delegating to the existing `call_with_metadata`, plus an `available` property delegating to a factored-out `_missing_prerequisite()` env check. **No behaviour change.**
- `AnthropicCompletion` is preserved as a deprecated alias for `Completion`; both names (plus `LLMProvider`) are re-exported from `creek.classify.llm`, so every prior import path still resolves.

## Test plan

- New `tests/test_llm_provider_seam.py`: asserts `AnthropicCompletion is Completion`, that all legacy import paths resolve, that `AnthropicProvider` is a structural `LLMProvider`, that `complete()` forwards verbatim to `call_with_metadata`, and that `available` reflects the live env (key removed / consent revoked).
- `./scripts/check-all.sh` → exit 0 (all 12 gates: ruff lint+format, mypy strict, pylint, bandit, refurb, tryceratops, interrogate, complexity, 5353 unit tests, 93.81% coverage, per-file gate).
- Existing affected suites (`test_classify`, `test_author_cost`, `test_synthesis_voice`, `test_author_desk`) unchanged and green.

Closes #604
Refs #603
