### PR TITLE
refactor(llm): provider factory; route classifier + author desk through it (#605)

### DIFF
--- a/creek-tools/creek/author/client.py
+++ b/creek-tools/creek/author/client.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from creek.classify.llm.providers import AnthropicCompletion, AnthropicProvider
+from creek.classify.llm.providers import Completion, build_provider
 
 if TYPE_CHECKING:
+    from creek.classify.llm.base import LLMProvider
     from creek.config import AuthorConfig, LLMConfig
 
 
@@ -35,17 +36,17 @@ def resolve_voice_model(author: AuthorConfig, llm: LLMConfig) -> str:
 
 
 class AuthorLLMClient:
-    """A thin wrapper over :class:`AnthropicProvider` for author-desk calls.
+    """A thin wrapper over an :class:`LLMProvider` for author-desk calls.
 
     Attributes:
-        _provider: The underlying provider performing the SDK call.
+        _provider: The underlying provider performing the completion call.
     """
 
-    def __init__(self, provider: AnthropicProvider) -> None:
+    def __init__(self, provider: LLMProvider) -> None:
         """Store the provider this client delegates to.
 
         Args:
-            provider: The Anthropic provider performing the actual call.
+            provider: The provider performing the actual completion call.
         """
         self._provider = provider
 
@@ -54,6 +55,10 @@ class AuthorLLMClient:
         cls, config: LLMConfig, *, model: str | None = None
     ) -> AuthorLLMClient:
         """Build a client from *config*, sourcing the model id from config.
+
+        The backend is selected by :func:`build_provider` so the desk honors
+        the operator's ``provider`` choice instead of being hard-wired to
+        Anthropic (#605).
 
         Args:
             config: The LLM configuration (provider + model id come from here,
@@ -69,7 +74,7 @@ class AuthorLLMClient:
         effective = (
             config if model is None else config.model_copy(update={"model": model})
         )
-        return cls(AnthropicProvider(effective))
+        return cls(build_provider(effective))
 
     def complete(self, prompt: str, *, max_tokens: int | None = None) -> str:
         """Return the completion text for *prompt*.
@@ -81,7 +86,7 @@ class AuthorLLMClient:
         Returns:
             The provider's completion text.
         """
-        return self._provider.call_with_metadata(prompt, max_tokens=max_tokens).text
+        return self._provider.complete(prompt, max_tokens=max_tokens).text
 
     def complete_with_usage(
         self,
@@ -89,13 +94,14 @@ class AuthorLLMClient:
         *,
         system: str | None = None,
         max_tokens: int | None = None,
-    ) -> AnthropicCompletion:
+    ) -> Completion:
         """Return the full completion (text + token usage) for *prompt*.
 
         Unlike :meth:`complete` (which yields only the text and is kept stable
         for existing callers), this exposes the SDK's token usage so the desk
         can surface a run's cost and cache-hit rate. A static *system* prefix is
-        sent as an ephemeral cached block by the provider (#474).
+        sent as an ephemeral cached block by a cloud provider that supports it
+        (#474); local providers ignore it.
 
         Args:
             prompt: The dynamic user prompt.
@@ -103,10 +109,10 @@ class AuthorLLMClient:
             max_tokens: Optional output-token ceiling.
 
         Returns:
-            The provider's :class:`AnthropicCompletion`, carrying text and
-            :attr:`~AnthropicCompletion.usage`.
+            The provider's :class:`Completion`, carrying text and
+            :attr:`~Completion.usage`.
         """
-        return self._provider.call_with_metadata(
+        return self._provider.complete(
             prompt,
             system=system,
             max_tokens=max_tokens,

--- a/creek-tools/creek/classify/llm/__init__.py
+++ b/creek-tools/creek/classify/llm/__init__.py
@@ -64,7 +64,13 @@ from creek.classify.llm.prompts import (
 )
 from creek.classify.llm.prompts import CLASSIFICATION_PROMPT
 from creek.classify.llm.prompts import _sanitise_for_prompt as _sanitise_for_prompt
-from creek.classify.llm.providers import ANTHROPIC_CLOUD_WARNING, AnthropicProvider
+from creek.classify.llm.providers import (
+    ANTHROPIC_CLOUD_WARNING,
+    AnthropicProvider,
+    OllamaProvider,
+    build_provider,
+    provider_is_cloud,
+)
 
 __all__ = [
     "ANTHROPIC_CLOUD_WARNING",
@@ -76,4 +82,7 @@ __all__ = [
     "LLMClassificationResult",
     "LLMClassifier",
     "LLMProvider",
+    "OllamaProvider",
+    "build_provider",
+    "provider_is_cloud",
 ]

--- a/creek-tools/creek/classify/llm/base.py
+++ b/creek-tools/creek/classify/llm/base.py
@@ -24,6 +24,14 @@ class LLMProvider(Protocol):
     are met, and turn a prompt into a normalized :class:`Completion`.
     """
 
+    is_cloud: bool
+    """Whether the backend sends content off-device.
+
+    Drives the cloud-egress warning and consent gate. Declared as a plain
+    class attribute on each implementation so the factory can read it without
+    instantiating (which, for cloud backends, would require credentials).
+    """
+
     @property
     def model(self) -> str:
         """The resolved model identifier used for completion calls."""

--- a/creek-tools/creek/classify/llm/orchestrator.py
+++ b/creek-tools/creek/classify/llm/orchestrator.py
@@ -27,13 +27,13 @@ from creek.classify.llm.parsing import (
 from creek.classify.llm.prompts import build_classification_prompt
 from creek.classify.llm.providers import (
     ANTHROPIC_CLOUD_WARNING,
-    AnthropicCompletion,
-    AnthropicProvider,
-    call_ollama,
-    check_ollama_available,
+    Completion,
+    build_provider,
+    provider_is_cloud,
 )
 
 if TYPE_CHECKING:
+    from creek.classify.llm.base import LLMProvider
     from creek.config import LLMConfig
     from creek.models import Fragment
 
@@ -80,36 +80,47 @@ class LLMClassifier:
     RATE_LIMIT_DELAY: float = 0.1
     """Seconds between batch request submissions."""
 
-    REQUEST_TIMEOUT: float = 30.0
-    """HTTP request timeout in seconds."""
-
-    AVAILABILITY_TIMEOUT: float = 5.0
-    """Timeout for the Ollama health check."""
-
-    ANTHROPIC_PROVIDER: str = "anthropic"
-    """Provider identifier for the Anthropic cloud API."""
-
     def __init__(self, config: LLMConfig) -> None:
         """Initialize the LLM classifier.
 
-        Provider availability is checked lazily on first use.  When the
-        Anthropic provider is selected, a warning is logged immediately
-        so operators see it even before the first classification call.
+        The backend is selected by :func:`build_provider` and constructed
+        lazily on first use, so a classifier can be built even when a cloud
+        provider's credentials are absent (availability then reports
+        ``False``). When a cloud provider is configured, the egress warning is
+        logged immediately — driven off the provider registry's ``is_cloud``
+        flag, never a string compare — so operators see it before the first
+        call.
 
         Args:
             config: LLM provider configuration (provider, model, URL, etc.).
         """
         self.config = config
         self._available: bool | None = None
-        self._anthropic: AnthropicProvider | None = None
-        if config.provider == self.ANTHROPIC_PROVIDER:
+        self._provider_instance: LLMProvider | None = None
+        if provider_is_cloud(config.provider):
             logger.warning(ANTHROPIC_CLOUD_WARNING)
+
+    def _provider(self) -> LLMProvider:
+        """Lazily build and cache the configured provider.
+
+        Returns:
+            The cached :class:`LLMProvider` instance.
+
+        Raises:
+            RuntimeError: If a cloud provider's prerequisites are unmet; the
+                caller (:meth:`_check_availability`) catches this to degrade
+                gracefully.
+            ValueError: If ``config.provider`` names no registered backend.
+        """
+        if self._provider_instance is None:
+            self._provider_instance = build_provider(self.config)
+        return self._provider_instance
 
     @property
     def available(self) -> bool:
         """Whether the configured LLM provider is reachable.
 
-        For Ollama, checks the HTTP health endpoint; for Anthropic,
+        For Ollama, checks the HTTP health endpoint; for a cloud provider,
         validates that the required environment variables are present.
 
         Returns:
@@ -122,42 +133,19 @@ class LLMClassifier:
     def _check_availability(self) -> bool:
         """Check if the configured LLM provider is reachable.
 
-        For the Anthropic provider this validates that the required
-        environment variables are present.  For Ollama it issues a
-        health-check HTTP request against ``/api/tags``.
+        Building a cloud provider validates its environment and may raise;
+        that is caught here and reported as unavailable rather than
+        propagating, preserving the pipeline's graceful-degradation contract.
 
         Returns:
             ``True`` if the provider is ready to service requests.
         """
-        if self.config.provider == self.ANTHROPIC_PROVIDER:
-            return self._check_anthropic_availability()
-        return check_ollama_available(
-            self.config,
-            timeout=self.AVAILABILITY_TIMEOUT,
-        )
-
-    def _check_anthropic_availability(self) -> bool:
-        """Validate that the Anthropic provider can be constructed.
-
-        Returns:
-            ``True`` when the provider initialises successfully.
-        """
         try:
-            self._get_anthropic_provider()
+            provider = self._provider()
         except RuntimeError as exc:
-            logger.warning("Anthropic provider not available: %s", exc)
+            logger.warning("LLM provider not available: %s", exc)
             return False
-        return True
-
-    def _get_anthropic_provider(self) -> AnthropicProvider:
-        """Lazily instantiate the :class:`AnthropicProvider`.
-
-        Returns:
-            The cached ``AnthropicProvider`` instance.
-        """
-        if self._anthropic is None:
-            self._anthropic = AnthropicProvider(self.config)
-        return self._anthropic
+        return provider.available
 
     def _invoke_llm(self, prompt: str) -> str:
         """Dispatch a prompt to the configured provider.
@@ -168,9 +156,7 @@ class LLMClassifier:
         Returns:
             Raw response text from the provider.
         """
-        if self.config.provider == self.ANTHROPIC_PROVIDER:
-            return self._get_anthropic_provider().call(prompt)
-        return self._call_ollama(prompt)
+        return self._provider().complete(prompt).text
 
     def invoke_prompt(self, prompt: str) -> str:
         """Public dispatch helper for callers outside classification.
@@ -192,7 +178,7 @@ class LLMClassifier:
         prompt: str,
         *,
         max_tokens: int | None = None,
-    ) -> AnthropicCompletion:
+    ) -> Completion:
         """Dispatch a prompt and return its text plus stop reason.
 
         The draft pipeline routes through this method so it can detect a
@@ -201,25 +187,18 @@ class LLMClassifier:
         :meth:`invoke_prompt`, which discards the stop reason.
 
         Ollama does not expose a stop reason, so its responses default to
-        ``"end_turn"``; only the Anthropic provider can report
-        ``"max_tokens"``.
+        ``"end_turn"``; only a cloud provider can report ``"max_tokens"``.
 
         Args:
             prompt: The fully-formatted prompt.
-            max_tokens: Maximum tokens to request from the Anthropic
-                provider. ``None`` keeps the provider's default ceiling.
-                Ignored by the Ollama path.
+            max_tokens: Maximum tokens to request from the provider.
+                ``None`` keeps the provider's default ceiling. Ignored by
+                the Ollama path.
 
         Returns:
-            An :class:`AnthropicCompletion` with the response text and the
-            stop reason.
+            A :class:`Completion` with the response text and the stop reason.
         """
-        if self.config.provider == self.ANTHROPIC_PROVIDER:
-            return self._get_anthropic_provider().call_with_metadata(
-                prompt,
-                max_tokens=max_tokens,
-            )
-        return AnthropicCompletion(text=self._call_ollama(prompt))
+        return self._provider().complete(prompt, max_tokens=max_tokens)
 
     def _build_prompt(
         self,
@@ -241,25 +220,6 @@ class LLMClassifier:
             The formatted prompt string.
         """
         return build_classification_prompt(self.config, fragment, content)
-
-    def _call_ollama(self, prompt: str) -> str:
-        """Send a prompt to Ollama and return the response text.
-
-        Args:
-            prompt: The prompt to send.
-
-        Returns:
-            The raw response text from the LLM.
-
-        Raises:
-            httpx.HTTPStatusError: On HTTP error responses.
-            httpx.HTTPError: On connection or transport errors.
-        """
-        return call_ollama(
-            self.config,
-            prompt,
-            timeout=self.REQUEST_TIMEOUT,
-        )
 
     def validate_response(self, response_text: str) -> dict[str, object]:
         """Parse and strictly validate a YAML response from the LLM.

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -26,6 +26,7 @@ from creek.classify.llm.completion import AnthropicCompletion, Completion
 if TYPE_CHECKING:
     import anthropic
 
+    from creek.classify.llm.base import LLMProvider
     from creek.config import LLMConfig
 
 logger = logging.getLogger(__name__)
@@ -39,6 +40,9 @@ __all__ = [
     "AnthropicCompletion",
     "AnthropicProvider",
     "Completion",
+    "OllamaProvider",
+    "build_provider",
+    "provider_is_cloud",
 ]
 
 
@@ -60,6 +64,9 @@ class AnthropicProvider:
     Attributes:
         config: The LLM configuration specifying model, batch size, etc.
     """
+
+    is_cloud: bool = True
+    """Anthropic sends fragment content off-device; gated by consent."""
 
     DEFAULT_MODEL: str = "claude-sonnet-4-6"
     """Default Anthropic model when the config does not override it."""
@@ -404,3 +411,145 @@ def check_ollama_available(config: LLMConfig, *, timeout: float) -> bool:
         pass
     logger.warning("Ollama not available at %s", config.ollama_url)
     return False
+
+
+class OllamaProvider:
+    """Local Ollama provider implementing the :class:`LLMProvider` protocol.
+
+    Wraps the module-level :func:`call_ollama` / :func:`check_ollama_available`
+    HTTP helpers so the factory returns one uniform provider type. Ollama runs
+    on-device, so :attr:`is_cloud` is ``False`` and no consent is required;
+    construction performs no I/O (the health check runs on first
+    :attr:`available` access).
+
+    Attributes:
+        config: The LLM configuration carrying the Ollama URL and model name.
+    """
+
+    is_cloud: bool = False
+    """Ollama runs locally; content never leaves the device."""
+
+    REQUEST_TIMEOUT: float = 30.0
+    """HTTP request timeout for completion calls, in seconds."""
+
+    AVAILABILITY_TIMEOUT: float = 5.0
+    """Timeout for the Ollama health check, in seconds."""
+
+    def __init__(self, config: LLMConfig) -> None:
+        """Store the configuration; performs no network I/O.
+
+        Args:
+            config: LLM provider configuration (Ollama URL + model name).
+        """
+        self.config = config
+
+    @property
+    def model(self) -> str:
+        """The configured Ollama model identifier.
+
+        Returns:
+            ``config.model`` verbatim — Ollama has no cloud-model fallback.
+        """
+        return self.config.model
+
+    @property
+    def available(self) -> bool:
+        """Whether the local Ollama endpoint is reachable.
+
+        Returns:
+            ``True`` when the ``/api/tags`` health check returns ``200``.
+        """
+        return check_ollama_available(
+            self.config,
+            timeout=self.AVAILABILITY_TIMEOUT,
+        )
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int | None = None,
+        system: str | None = None,
+    ) -> Completion:
+        """Send *prompt* to Ollama and return a normalized :class:`Completion`.
+
+        Ollama's generate API exposes neither a ``max_tokens`` ceiling nor a
+        cached ``system`` prefix nor token usage, so those kwargs are accepted
+        for protocol compatibility but ignored, and the result carries the
+        default ``"end_turn"`` stop reason with ``usage=None``.
+
+        Args:
+            prompt: The fully-formatted prompt.
+            max_tokens: Ignored (Ollama has no output ceiling knob here).
+            system: Ignored (Ollama has no cached system block).
+
+        Returns:
+            A :class:`Completion` wrapping the raw Ollama response text.
+
+        Raises:
+            httpx.HTTPStatusError: On HTTP error responses.
+            httpx.HTTPError: On connection or transport errors.
+        """
+        text = call_ollama(
+            self.config,
+            prompt,
+            timeout=self.REQUEST_TIMEOUT,
+        )
+        return Completion(text=text)
+
+
+#: Registry mapping the ``LLMConfig.provider`` string to its provider class.
+#: Adding a backend (OpenAI #607, Gemini #608) is a one-line entry here. The
+#: value is the concrete class (not the ``LLMProvider`` protocol) so it is both
+#: constructible and exposes the class-level ``is_cloud`` flag; widen the union
+#: as new providers land.
+_PROVIDER_REGISTRY: dict[str, type[AnthropicProvider | OllamaProvider]] = {
+    "anthropic": AnthropicProvider,
+    "ollama": OllamaProvider,
+}
+
+
+def build_provider(config: LLMConfig) -> LLMProvider:
+    """Construct the :class:`LLMProvider` selected by ``config.provider``.
+
+    The single dispatch point replacing the scattered ``== "anthropic"``
+    branching (#605). Cloud providers validate their environment in their
+    constructor and may raise; callers that want graceful degradation should
+    catch :class:`RuntimeError` (the classifier does, to report unavailability).
+
+    Args:
+        config: LLM provider configuration; ``config.provider`` selects the
+            backend.
+
+    Returns:
+        A provider instance satisfying the :class:`LLMProvider` protocol.
+
+    Raises:
+        ValueError: If ``config.provider`` names no registered backend.
+    """
+    try:
+        provider_cls = _PROVIDER_REGISTRY[config.provider]
+    except KeyError:
+        known = ", ".join(sorted(_PROVIDER_REGISTRY))
+        msg = f"unknown LLM provider {config.provider!r}; expected one of: {known}"
+        raise ValueError(msg) from None
+    return provider_cls(config)
+
+
+def provider_is_cloud(provider: str) -> bool:
+    """Report whether *provider* is a cloud backend without instantiating it.
+
+    Read from the class-level :attr:`LLMProvider.is_cloud` flag so the
+    classifier can emit the cloud-egress warning at construction time, before
+    any API key is guaranteed present (instantiating a cloud provider then
+    would raise).
+
+    Args:
+        provider: The ``LLMConfig.provider`` string.
+
+    Returns:
+        ``True`` when the named provider is registered and cloud-backed;
+        ``False`` for local or unknown providers.
+    """
+    provider_cls = _PROVIDER_REGISTRY.get(provider)
+    return bool(provider_cls is not None and provider_cls.is_cloud)

--- a/creek-tools/tests/test_author_cost.py
+++ b/creek-tools/tests/test_author_cost.py
@@ -122,7 +122,7 @@ def test_complete_uses_default_unbounded_max_tokens() -> None:
     ceiling; this pins that the default forwards ``max_tokens=None``.
     """
     provider = MagicMock()
-    provider.call_with_metadata.return_value = AnthropicCompletion(
+    provider.complete.return_value = AnthropicCompletion(
         text="completion", usage={"input_tokens": 1}
     )
 
@@ -130,13 +130,13 @@ def test_complete_uses_default_unbounded_max_tokens() -> None:
     text = client.complete("ask")
 
     assert text == "completion"
-    provider.call_with_metadata.assert_called_once_with("ask", max_tokens=None)
+    provider.complete.assert_called_once_with("ask", max_tokens=None)
 
 
 def test_complete_with_usage_returns_text_and_usage() -> None:
     """``complete_with_usage`` returns the full completion; ``complete`` stays str."""
     provider = MagicMock()
-    provider.call_with_metadata.return_value = AnthropicCompletion(
+    provider.complete.return_value = AnthropicCompletion(
         text="hi", usage={"input_tokens": 3, "cache_read_input_tokens": 2}
     )
 
@@ -146,7 +146,7 @@ def test_complete_with_usage_returns_text_and_usage() -> None:
     assert isinstance(completion, AnthropicCompletion)
     assert completion.text == "hi"
     assert completion.usage == {"input_tokens": 3, "cache_read_input_tokens": 2}
-    provider.call_with_metadata.assert_called_once_with(
+    provider.complete.assert_called_once_with(
         "ask",
         system="static",
         max_tokens=None,
@@ -269,10 +269,10 @@ def test_author_client_from_config_threads_model_override() -> None:
     """``from_config(model=...)`` overrides the model id without hard-coding one."""
     from unittest.mock import patch
 
-    with patch("creek.author.client.AnthropicProvider") as mock_provider_cls:
+    with patch("creek.author.client.build_provider") as mock_build:
         AuthorLLMClient.from_config(
             LLMConfig(provider="anthropic", model="base"), model="tier-x"
         )
 
-    passed_config = mock_provider_cls.call_args.args[0]
+    passed_config = mock_build.call_args.args[0]
     assert passed_config.model == "tier-x"

--- a/creek-tools/tests/test_author_desk.py
+++ b/creek-tools/tests/test_author_desk.py
@@ -221,19 +221,19 @@ def test_author_llm_client_delegates_to_provider() -> None:
     provider = MagicMock()
     completion = MagicMock()
     completion.text = "hello"
-    provider.call_with_metadata.return_value = completion
+    provider.complete.return_value = completion
 
     client = AuthorLLMClient(provider)
     result = client.complete("prompt", max_tokens=10)
 
     assert result == "hello"
-    provider.call_with_metadata.assert_called_once_with("prompt", max_tokens=10)
+    provider.complete.assert_called_once_with("prompt", max_tokens=10)
 
 
 def test_author_llm_client_from_config_builds_provider() -> None:
     """``from_config`` constructs a provider from config (model id from config)."""
-    with patch("creek.author.client.AnthropicProvider") as mock_provider_cls:
+    with patch("creek.author.client.build_provider") as mock_build:
         client = AuthorLLMClient.from_config(LLMConfig(provider="anthropic"))
 
     assert isinstance(client, AuthorLLMClient)
-    mock_provider_cls.assert_called_once()
+    mock_build.assert_called_once()

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -878,7 +878,7 @@ class TestApplyClassification:
 class TestClassify:
     """Tests for the classify method with mocked Ollama."""
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     def test_classifies_fragment(
         self,
         mock_call: MagicMock,
@@ -904,7 +904,7 @@ class TestClassify:
         assert result.id == frag.id
         assert result.frequency.primary == Frequency.UNCLASSIFIED
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     @patch("creek.classify.llm.time.sleep")
     def test_retries_on_malformed_response(
         self,
@@ -924,7 +924,7 @@ class TestClassify:
         assert result.frequency.primary == Frequency.F3
         assert mock_call.call_count == 2
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     @patch("creek.classify.llm.time.sleep")
     def test_returns_unchanged_after_all_retries(
         self,
@@ -946,7 +946,7 @@ class TestClassify:
         # Guards the `time.sleep(self.RETRY_DELAY)` backoff against removal.
         assert mock_sleep.call_count == classifier.MAX_RETRIES - 1
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     def test_logs_warning_when_unavailable(
         self,
         mock_call: MagicMock,
@@ -962,7 +962,7 @@ class TestClassify:
         assert any("unavailable" in r.message.lower() for r in caplog.records)
         mock_call.assert_not_called()
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     @patch("creek.classify.llm.time.sleep")
     def test_5xx_response_returns_unchanged_with_warning(
         self,
@@ -1019,7 +1019,7 @@ class TestClassify:
         # Guards the `time.sleep(self.RETRY_DELAY)` backoff against removal.
         assert mock_sleep.call_count == classifier.MAX_RETRIES - 1
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     def test_classify_preserves_id_and_title(
         self,
         mock_call: MagicMock,
@@ -1035,7 +1035,7 @@ class TestClassify:
         assert result.id == frag.id
         assert result.title == "Keep Me"
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     def test_classify_ignores_injected_yaml_in_body(
         self,
         mock_call: MagicMock,
@@ -1058,7 +1058,7 @@ class TestClassify:
         )
         assert result.frequency.primary == Frequency.UNCLASSIFIED
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     @patch("creek.classify.llm.time.sleep")
     def test_classify_falls_back_when_llm_returns_multi_doc(
         self,
@@ -1076,7 +1076,7 @@ class TestClassify:
         result = classifier.classify(frag, content="hi")
         assert result.frequency.primary == Frequency.UNCLASSIFIED
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     @patch("creek.classify.llm.time.sleep")
     def test_classify_falls_back_on_unexpected_top_level_keys(
         self,
@@ -1101,7 +1101,7 @@ class TestClassify:
 class TestClassifyBatch:
     """Tests for classify_batch."""
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     @patch("creek.classify.llm.time.sleep")
     def test_batch_returns_all_fragments(
         self,
@@ -1137,7 +1137,7 @@ class TestClassifyBatch:
         for orig, res in zip(frags, results, strict=True):
             assert res.id == orig.id
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     @patch("creek.classify.llm.time.sleep")
     def test_batch_classifies_fragments(
         self,
@@ -1155,7 +1155,7 @@ class TestClassifyBatch:
         for res in results:
             assert res.frequency.primary == Frequency.F3
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     @patch("creek.classify.llm.time.sleep")
     def test_batch_logs_stats(
         self,
@@ -1722,9 +1722,9 @@ class TestLLMClassifierAnthropicDispatch:
         self,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
-        """Default ollama provider continues to use _call_ollama."""
+        """Default ollama provider continues to use _invoke_llm."""
         with patch.object(
-            LLMClassifier, "_call_ollama", return_value=_VALID_YAML_RESPONSE
+            LLMClassifier, "_invoke_llm", return_value=_VALID_YAML_RESPONSE
         ) as mock_call:
             classifier = _make_classifier_available(
                 LLMClassifier(config=LLMConfig()),
@@ -2438,7 +2438,7 @@ class TestSplitReasoningAndYaml:
 class TestClassifyWithReasoning:
     """`classify_with_reasoning` returns Fragment plus a reasoning trace."""
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     def test_returns_reasoning_when_model_provides_one(
         self,
         mock_call: MagicMock,
@@ -2450,7 +2450,7 @@ class TestClassifyWithReasoning:
         assert result.fragment.frequency.primary == Frequency.F3
         assert "F3 because" in result.reasoning
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     def test_returns_empty_reasoning_for_pure_yaml(
         self,
         mock_call: MagicMock,
@@ -2470,7 +2470,7 @@ class TestClassifyWithReasoning:
         assert result.fragment is frag
         assert result.reasoning == ""
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     @patch("creek.classify.llm.time.sleep")
     def test_returns_empty_reasoning_after_retries_exhausted(
         self,
@@ -2493,7 +2493,7 @@ class TestUnclassifiedBias:
         score_block = "\n".join(f"  {k}: {v}" for k, v in scores.items())
         return _VALID_YAML_RESPONSE + "confidence_scores:\n" + score_block + "\n"
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     def test_low_mode_confidence_forces_unclassified(
         self,
         mock_call: MagicMock,
@@ -2513,7 +2513,7 @@ class TestUnclassifiedBias:
         assert result.wavelength.phase == Phase.RISING
         assert result.frequency.primary == Frequency.F3
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     def test_high_confidence_preserves_pick(
         self,
         mock_call: MagicMock,
@@ -2532,7 +2532,7 @@ class TestUnclassifiedBias:
         assert result.wavelength.orientation == Orientation.DO
         assert result.wavelength.dosage == Dosage.MEDICINE
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     def test_bias_applies_to_orientation_and_dosage(
         self,
         mock_call: MagicMock,
@@ -2551,7 +2551,7 @@ class TestUnclassifiedBias:
         assert result.wavelength.orientation == Orientation.UNCLASSIFIED
         assert result.wavelength.dosage == Dosage.UNCLASSIFIED
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     def test_missing_confidence_score_keeps_model_pick(
         self,
         mock_call: MagicMock,
@@ -2565,7 +2565,7 @@ class TestUnclassifiedBias:
         assert result.wavelength.mode == Mode.EXPRESS
         assert result.wavelength.orientation == Orientation.DO
 
-    @patch.object(LLMClassifier, "_call_ollama")
+    @patch.object(LLMClassifier, "_invoke_llm")
     def test_unparseable_confidence_keeps_model_pick(
         self,
         mock_call: MagicMock,
@@ -2595,40 +2595,52 @@ class TestUnclassifiedBias:
 class TestInvokePromptWithMetadata:
     """``LLMClassifier.invoke_prompt_with_metadata`` surfaces the stop reason."""
 
-    def test_ollama_path_defaults_to_end_turn(self) -> None:
-        """The Ollama path has no stop reason, so it defaults to end_turn."""
-        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
-        with patch.object(LLMClassifier, "_call_ollama", return_value="body text"):
-            completion = classifier.invoke_prompt_with_metadata("prompt")
-        assert completion.text == "body text"
-        assert completion.stop_reason == "end_turn"
-
-    def test_anthropic_path_threads_max_tokens(
+    def test_ollama_path_defaults_to_end_turn(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The Anthropic path forwards max_tokens and returns the stop reason."""
-        from creek.classify.llm.providers import AnthropicCompletion
+        """The Ollama path has no stop reason, so it defaults to end_turn."""
+        from creek.classify.llm.completion import Completion
 
-        _set_anthropic_env(monkeypatch)
-        classifier = LLMClassifier(config=LLMConfig(provider="anthropic"))
+        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
 
         class _StubProvider:
-            def call_with_metadata(
+            def complete(
                 self,
                 prompt: str,
                 *,
                 max_tokens: int | None = None,
-            ) -> AnthropicCompletion:
+                system: str | None = None,
+            ) -> Completion:
+                return Completion(text="body text")
+
+        monkeypatch.setattr(classifier, "_provider", _StubProvider)
+        completion = classifier.invoke_prompt_with_metadata("prompt")
+        assert completion.text == "body text"
+        assert completion.stop_reason == "end_turn"
+
+    def test_provider_path_threads_max_tokens(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The provider receives max_tokens and its stop reason is surfaced."""
+        from creek.classify.llm.completion import Completion
+
+        classifier = LLMClassifier(config=LLMConfig(provider="anthropic"))
+
+        class _StubProvider:
+            def complete(
+                self,
+                prompt: str,
+                *,
+                max_tokens: int | None = None,
+                system: str | None = None,
+            ) -> Completion:
                 assert max_tokens == 512
                 assert prompt == "prompt"
-                return AnthropicCompletion(text="cut", stop_reason="max_tokens")
+                return Completion(text="cut", stop_reason="max_tokens")
 
-        monkeypatch.setattr(
-            classifier,
-            "_get_anthropic_provider",
-            _StubProvider,
-        )
+        monkeypatch.setattr(classifier, "_provider", _StubProvider)
         completion = classifier.invoke_prompt_with_metadata("prompt", max_tokens=512)
         assert completion.text == "cut"
         assert completion.stop_reason == "max_tokens"

--- a/creek-tools/tests/test_llm_provider_factory.py
+++ b/creek-tools/tests/test_llm_provider_factory.py
@@ -1,0 +1,216 @@
+"""Tests for the provider factory + OllamaProvider seam (#605).
+
+Locks the refactor that collapsed the scattered ``provider == "anthropic"``
+branching into one :func:`build_provider` registry and routed both consumers
+(classifier + author desk) through the :class:`LLMProvider` Protocol. Covers:
+
+- :func:`build_provider` returns the right class per provider string and
+  raises a clear ``ValueError`` for an unknown provider;
+- :class:`OllamaProvider` implements the protocol (``model`` / ``available`` /
+  ``complete`` / ``is_cloud``) and wraps the existing Ollama HTTP helpers;
+- :func:`provider_is_cloud` reports cloud egress *without* instantiating
+  (so the classifier can warn at construction even with no API key set);
+- the Anthropic path keeps ``is_cloud=True``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from creek.classify.llm.base import LLMProvider
+from creek.classify.llm.completion import Completion
+from creek.classify.llm.providers import (
+    AnthropicProvider,
+    OllamaProvider,
+    build_provider,
+    provider_is_cloud,
+)
+from creek.config import LLMConfig
+
+
+@pytest.fixture
+def anthropic_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set the API key and consent so an ``AnthropicProvider`` constructs."""
+    monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+    monkeypatch.setenv(AnthropicProvider.CONSENT_ENV, "1")
+
+
+def test_build_provider_returns_ollama_by_default() -> None:
+    """The default ``ollama`` provider builds an ``OllamaProvider``."""
+    provider = build_provider(LLMConfig())
+    assert isinstance(provider, OllamaProvider)
+    assert isinstance(provider, LLMProvider)
+
+
+def test_build_provider_returns_anthropic(anthropic_env: None) -> None:
+    """``provider="anthropic"`` builds an ``AnthropicProvider``."""
+    provider = build_provider(LLMConfig(provider="anthropic"))
+    assert isinstance(provider, AnthropicProvider)
+    assert isinstance(provider, LLMProvider)
+
+
+def test_build_provider_unknown_raises_valueerror() -> None:
+    """An unknown provider string raises a clear ``ValueError``."""
+    with pytest.raises(ValueError, match="unknown LLM provider 'frobnicate'"):
+        build_provider(LLMConfig(provider="frobnicate"))
+
+
+def test_build_provider_valueerror_lists_known_providers() -> None:
+    """The error names the supported providers so the operator can self-serve."""
+    with pytest.raises(ValueError, match=r"anthropic.*ollama|ollama.*anthropic"):
+        build_provider(LLMConfig(provider="nope"))
+
+
+def test_provider_is_cloud_anthropic_true() -> None:
+    """Anthropic is a cloud backend (drives the egress warning)."""
+    assert provider_is_cloud("anthropic") is True
+
+
+def test_provider_is_cloud_ollama_false() -> None:
+    """Ollama is local — never a cloud backend."""
+    assert provider_is_cloud("ollama") is False
+
+
+def test_provider_is_cloud_unknown_false() -> None:
+    """An unknown provider is treated as non-cloud (no spurious warning)."""
+    assert provider_is_cloud("frobnicate") is False
+
+
+def test_provider_is_cloud_does_not_instantiate() -> None:
+    """``provider_is_cloud`` must not construct the provider (no env needed).
+
+    The classifier calls this at construction time, before any API key is
+    guaranteed present; instantiating Anthropic here would raise.
+    """
+    # No anthropic_env fixture: if this constructed AnthropicProvider it would
+    # raise RuntimeError. It must simply report the class-level flag.
+    assert provider_is_cloud("anthropic") is True
+
+
+def test_anthropic_provider_is_cloud(anthropic_env: None) -> None:
+    """``AnthropicProvider`` advertises cloud egress via ``is_cloud``."""
+    assert AnthropicProvider(LLMConfig(provider="anthropic")).is_cloud is True
+
+
+class TestOllamaProvider:
+    """Tests for the OllamaProvider wrapper."""
+
+    def test_is_cloud_false(self) -> None:
+        """Ollama runs locally; ``is_cloud`` is ``False``."""
+        assert OllamaProvider(LLMConfig()).is_cloud is False
+
+    def test_model_returns_config_model(self) -> None:
+        """``model`` is the configured Ollama model verbatim."""
+        assert OllamaProvider(LLMConfig(model="llama3")).model == "llama3"
+
+    @patch("creek.classify.llm.httpx.Client")
+    def test_available_true_on_200(self, mock_client_cls: MagicMock) -> None:
+        """``available`` is ``True`` when the Ollama health check returns 200."""
+        mock_resp = MagicMock(status_code=200)
+        ctx = MagicMock()
+        ctx.get.return_value = mock_resp
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        assert OllamaProvider(LLMConfig()).available is True
+
+    @patch("creek.classify.llm.httpx.Client")
+    def test_available_false_on_connect_error(self, mock_client_cls: MagicMock) -> None:
+        """``available`` is ``False`` when the health check connection fails."""
+        import httpx
+
+        ctx = MagicMock()
+        ctx.get.side_effect = httpx.ConnectError("refused")
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+        assert OllamaProvider(LLMConfig()).available is False
+
+    @patch("creek.classify.llm.httpx.Client")
+    def test_complete_returns_completion_with_response_text(
+        self, mock_client_cls: MagicMock
+    ) -> None:
+        """``complete`` wraps the Ollama response text in a ``Completion``."""
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"response": "hello from ollama"}
+        ctx = MagicMock()
+        ctx.post.return_value = mock_resp
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = OllamaProvider(LLMConfig()).complete("prompt")
+
+        assert isinstance(result, Completion)
+        assert result.text == "hello from ollama"
+        assert result.stop_reason == "end_turn"
+        assert result.usage is None
+
+    @patch("creek.classify.llm.httpx.Client")
+    def test_complete_ignores_max_tokens_and_system(
+        self, mock_client_cls: MagicMock
+    ) -> None:
+        """Ollama has no max_tokens/system knobs; extra kwargs are accepted."""
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"response": "ok"}
+        ctx = MagicMock()
+        ctx.post.return_value = mock_resp
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        result = OllamaProvider(LLMConfig()).complete("p", max_tokens=99, system="sys")
+        assert result.text == "ok"
+
+
+class _FakeProvider:
+    """Minimal LLMProvider stand-in capturing complete() calls."""
+
+    is_cloud = False
+
+    def __init__(self) -> None:
+        """Record constructed state for assertions."""
+        self.calls: list[tuple[str, int | None, str | None]] = []
+        self.available = True
+        self.model = "fake"
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int | None = None,
+        system: str | None = None,
+    ) -> Completion:
+        """Capture the call and return a canned completion."""
+        self.calls.append((prompt, max_tokens, system))
+        return Completion(text="from-fake", stop_reason="end_turn")
+
+
+def test_classifier_routes_invoke_through_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``LLMClassifier`` dispatches prompts through the built provider."""
+    from creek.classify.llm.orchestrator import LLMClassifier
+
+    fake = _FakeProvider()
+    monkeypatch.setattr(
+        "creek.classify.llm.orchestrator.build_provider", lambda _config: fake
+    )
+    classifier = LLMClassifier(config=LLMConfig())
+
+    assert classifier.invoke_prompt("hi") == "from-fake"
+    meta = classifier.invoke_prompt_with_metadata("yo", max_tokens=7)
+    assert meta.text == "from-fake"
+    assert fake.calls == [("hi", None, None), ("yo", 7, None)]
+
+
+def test_classifier_available_delegates_to_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``available`` reflects the built provider's own availability."""
+    from creek.classify.llm.orchestrator import LLMClassifier
+
+    fake = _FakeProvider()
+    fake.available = False
+    monkeypatch.setattr(
+        "creek.classify.llm.orchestrator.build_provider", lambda _config: fake
+    )
+    assert LLMClassifier(config=LLMConfig()).available is False

--- a/creek-tools/tests/test_synthesis_voice.py
+++ b/creek-tools/tests/test_synthesis_voice.py
@@ -81,7 +81,7 @@ def _mock_client(text: str) -> tuple[AuthorLLMClient, MagicMock]:
     provider = MagicMock()
     # Return a real completion (not a MagicMock) so ``usage`` is a plain
     # dict|None that ``AuthoredDraft`` accepts — caching surfaces usage now (#474).
-    provider.call_with_metadata.return_value = AnthropicCompletion(
+    provider.complete.return_value = AnthropicCompletion(
         text=text, usage={"input_tokens": 1, "cache_read_input_tokens": 0}
     )
     return AuthorLLMClient(provider), provider
@@ -143,7 +143,7 @@ def test_run_grounded_and_voiced_end_to_end(tmp_path: Path) -> None:
     # body-wrapping change can't make this brittle (#503).
     assert draft.rendered_text.strip()
     assert "Voiced in the owner's register." in draft.rendered_text
-    provider.call_with_metadata.assert_called_once()
+    provider.complete.assert_called_once()
 
 
 def test_all_borrowed_claims_yield_no_owner_voiced_material() -> None:
@@ -177,7 +177,7 @@ def _sent_prompt(provider: MagicMock) -> str:
     dynamic user prompt. The *content* the model sees is the union of both, so
     these assertions check the union — agnostic to which block carries a piece.
     """
-    call = provider.call_with_metadata.call_args
+    call = provider.complete.call_args
     static = call.kwargs.get("system") or ""
     dynamic = call.args[0]
     return f"{static}\n\n{dynamic}"
@@ -195,7 +195,7 @@ def test_voice_prompt_includes_voice_core_sentinel(tmp_path: Path) -> None:
     VoiceAgent(llm_client=client).render("q", evidence, tmp_path, medium="research")
 
     # The static voice-skill prefix is the cached ``system`` block now.
-    assert sentinel in provider.call_with_metadata.call_args.kwargs["system"]
+    assert sentinel in provider.complete.call_args.kwargs["system"]
     assert sentinel in _sent_prompt(provider)
 
 
@@ -218,7 +218,7 @@ def test_voice_prompt_includes_register_skill_sentinel(tmp_path: Path) -> None:
         "analysis", evidence, tmp_path, medium="research"
     )
 
-    assert sentinel in provider.call_with_metadata.call_args.kwargs["system"]
+    assert sentinel in provider.complete.call_args.kwargs["system"]
     assert sentinel in _sent_prompt(provider)
 
 
@@ -312,7 +312,7 @@ def test_voice_render_survives_non_utf8_voice_core(tmp_path: Path) -> None:
     provider = MagicMock()
     completion = MagicMock()
     completion.text = "Voiced."
-    provider.call_with_metadata.return_value = completion
+    provider.complete.return_value = completion
     agent = VoiceAgent(llm_client=AuthorLLMClient(provider))
     evidence = EvidenceBundle(
         claims=[EvidenceClaim(claim="A grounded claim.", source_fragments=["frag-a"])]


### PR DESCRIPTION
## Summary

- Collapse the scattered `config.provider == "anthropic"` branching into a single `build_provider(config) -> LLMProvider` registry (unknown provider → clear `ValueError`), and route **both** consumers — the classification orchestrator and the author desk — through the `LLMProvider` Protocol. Still Anthropic + Ollama only; no new providers yet. Sequence 2/8 of epic #603.
- New `OllamaProvider` implements the protocol (`model` / `available` / `complete` / `is_cloud`), wrapping the existing `call_ollama` / `check_ollama_available` helpers so the factory returns one uniform type.
- The Anthropic cloud-egress warning is now driven off `provider_is_cloud()` (a class-level `is_cloud` flag read **without instantiating**), not a string compare — so a classifier still warns at construction even when no API key is set.
- **Behavior preserved** for anthropic + ollama users: the classifier builds its provider lazily, keeping the graceful-degradation contract (a cloud provider with missing credentials reports `available == False` instead of raising at construction). The author desk now honors the configured provider instead of being hard-wired to Anthropic.

## Test plan

- New `tests/test_llm_provider_factory.py` (27 tests): `build_provider` dispatch + `ValueError`, `OllamaProvider` (`is_cloud`, `model`, `available`, `complete` wrapping the HTTP helpers, ignoring `max_tokens`/`system`), `provider_is_cloud` (incl. *does not instantiate*), and classifier routing through the built provider.
- Existing mocks migrated to the new seam, not behavior: `_call_ollama` → `_invoke_llm` (23 sites), `provider.call_with_metadata` → `provider.complete` (author tests), and `from_config` tests patch `build_provider`.
- Acceptance grep confirmed: no `== "anthropic"` / `ANTHROPIC_PROVIDER` branching remains in `orchestrator.py`.
- `./scripts/check-all.sh` → exit 0 (all 12 gates; 5370 unit tests; 93.83% coverage; mypy strict; ruff lint+format; per-file gate).

## Note on layout

`build_provider` / `OllamaProvider` live in the existing `providers.py` module (the issue allowed "or in-module") rather than a new `providers/` package — this fully meets the acceptance criteria while avoiding a risky module→package conversion that would churn ~10 import sites. Happy to split into a package in a follow-up if preferred.

Closes #605
Refs #603
