### PR TITLE
feat(llm): generalise the cloud-egress consent gate (provider-neutral) (#606)

### DIFF
--- a/creek-tools/creek/classify/llm/__init__.py
+++ b/creek-tools/creek/classify/llm/__init__.py
@@ -46,6 +46,15 @@ from creek.classify.llm.completion import (
 from creek.classify.llm.completion import (
     Completion as Completion,
 )
+from creek.classify.llm.consent import (
+    cloud_warning as cloud_warning,
+)
+from creek.classify.llm.consent import (
+    has_cloud_consent as has_cloud_consent,
+)
+from creek.classify.llm.consent import (
+    require_cloud_consent as require_cloud_consent,
+)
 from creek.classify.llm.orchestrator import (
     LLMClassificationResult,
     LLMClassifier,
@@ -84,5 +93,8 @@ __all__ = [
     "LLMProvider",
     "OllamaProvider",
     "build_provider",
+    "cloud_warning",
+    "has_cloud_consent",
     "provider_is_cloud",
+    "require_cloud_consent",
 ]

--- a/creek-tools/creek/classify/llm/consent.py
+++ b/creek-tools/creek/classify/llm/consent.py
@@ -1,0 +1,89 @@
+"""Provider-neutral cloud-egress consent gate (#606).
+
+Centralises the "fragment content is leaving the device" acknowledgement so it
+covers *any* cloud provider — Anthropic today, OpenAI / Gemini next — rather
+than being hard-wired to Anthropic. Local providers (Ollama) are exempt and
+never call into this module.
+
+Consent is granted by setting :data:`CLOUD_CONSENT_ENV` (the legacy
+:data:`LEGACY_CONSENT_ENV` is still honored as an alias for back-compat) to one
+of :data:`CONSENT_TRUTHY`. The key itself is read from each provider's own SDK
+env var and never appears here.
+"""
+
+from __future__ import annotations
+
+import os
+
+CONSENT_TRUTHY: frozenset[str] = frozenset({"1", "true", "yes"})
+"""Environment-variable values accepted as affirmative consent."""
+
+CLOUD_CONSENT_ENV: str = "CREEK_CLOUD_CONSENT"
+"""Provider-neutral cloud-egress consent variable."""
+
+LEGACY_CONSENT_ENV: str = "CREEK_ANTHROPIC_CONSENT"
+"""Deprecated Anthropic-specific consent variable, still honored as an alias."""
+
+
+def has_cloud_consent() -> bool:
+    """Report whether cloud egress has been consented to.
+
+    Reads both the neutral and legacy variables so existing
+    ``CREEK_ANTHROPIC_CONSENT=1`` setups keep working unchanged.
+
+    Returns:
+        ``True`` when either variable holds an affirmative
+        (:data:`CONSENT_TRUTHY`) value.
+    """
+    for var in (CLOUD_CONSENT_ENV, LEGACY_CONSENT_ENV):
+        if os.environ.get(var, "").strip().lower() in CONSENT_TRUTHY:
+            return True
+    return False
+
+
+def consent_error_message(provider_name: str) -> str:
+    """Build the remediation message for a missing cloud-consent gate.
+
+    Args:
+        provider_name: Display name of the active cloud provider (e.g.
+            ``"Anthropic"``), surfaced so the operator knows whose servers
+            content would reach.
+
+    Returns:
+        A one-paragraph message naming the provider and the variable to set.
+    """
+    return (
+        f"{provider_name} cloud classification requires explicit consent. "
+        f"Set {CLOUD_CONSENT_ENV}=1 (also accepts 'true'/'yes'; the legacy "
+        f"{LEGACY_CONSENT_ENV} is still honored) to confirm that fragment "
+        f"content may be sent to {provider_name}'s servers."
+    )
+
+
+def require_cloud_consent(provider_name: str) -> None:
+    """Raise unless cloud egress has been consented to.
+
+    Args:
+        provider_name: Display name of the active cloud provider, woven into
+            the error so the acknowledgement is unambiguous.
+
+    Raises:
+        RuntimeError: When neither consent variable is affirmatively set.
+    """
+    if not has_cloud_consent():
+        raise RuntimeError(consent_error_message(provider_name))
+
+
+def cloud_warning(provider_name: str) -> str:
+    """Build the provider-neutral cloud-egress warning banner.
+
+    Args:
+        provider_name: Display name of the active cloud provider.
+
+    Returns:
+        The warning string logged when a cloud provider is selected.
+    """
+    return (
+        "WARNING: Cloud classification enabled. "
+        f"Fragment content will be sent to {provider_name}'s servers."
+    )

--- a/creek-tools/creek/classify/llm/orchestrator.py
+++ b/creek-tools/creek/classify/llm/orchestrator.py
@@ -26,9 +26,10 @@ from creek.classify.llm.parsing import (
 )
 from creek.classify.llm.prompts import build_classification_prompt
 from creek.classify.llm.providers import (
-    ANTHROPIC_CLOUD_WARNING,
     Completion,
     build_provider,
+    cloud_warning,
+    provider_display_name,
     provider_is_cloud,
 )
 
@@ -98,7 +99,7 @@ class LLMClassifier:
         self._available: bool | None = None
         self._provider_instance: LLMProvider | None = None
         if provider_is_cloud(config.provider):
-            logger.warning(ANTHROPIC_CLOUD_WARNING)
+            logger.warning(cloud_warning(provider_display_name(config.provider)))
 
     def _provider(self) -> LLMProvider:
         """Lazily build and cache the configured provider.

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -22,6 +22,11 @@ from typing import TYPE_CHECKING
 import httpx
 
 from creek.classify.llm.completion import AnthropicCompletion, Completion
+from creek.classify.llm.consent import (
+    cloud_warning,
+    consent_error_message,
+    has_cloud_consent,
+)
 
 if TYPE_CHECKING:
     import anthropic
@@ -42,15 +47,18 @@ __all__ = [
     "Completion",
     "OllamaProvider",
     "build_provider",
+    "cloud_warning",
+    "provider_display_name",
     "provider_is_cloud",
 ]
 
 
-ANTHROPIC_CLOUD_WARNING: str = (
-    "WARNING: Cloud classification enabled. "
-    "Fragment content will be sent to Anthropic's servers."
-)
-"""Warning displayed when the Anthropic cloud provider is selected."""
+ANTHROPIC_CLOUD_WARNING: str = cloud_warning("Anthropic")
+"""Deprecated: the cloud-egress warning bound to Anthropic.
+
+Retained for back-compat; new code should call
+:func:`creek.classify.llm.consent.cloud_warning` with the active provider name.
+"""
 
 
 class AnthropicProvider:
@@ -68,6 +76,9 @@ class AnthropicProvider:
     is_cloud: bool = True
     """Anthropic sends fragment content off-device; gated by consent."""
 
+    PROVIDER_NAME: str = "Anthropic"
+    """Display name woven into consent and cloud-egress messages."""
+
     DEFAULT_MODEL: str = "claude-sonnet-4-6"
     """Default Anthropic model when the config does not override it."""
 
@@ -75,10 +86,12 @@ class AnthropicProvider:
     """Environment variable name for the Anthropic API key."""
 
     CONSENT_ENV: str = "CREEK_ANTHROPIC_CONSENT"
-    """Environment variable name for cloud-classification consent."""
+    """Deprecated: the legacy consent variable, still honored as an alias.
 
-    CONSENT_TRUTHY: frozenset[str] = frozenset({"1", "true", "yes"})
-    """String values accepted as affirmative consent."""
+    Retained so existing setups and tests that reference
+    ``AnthropicProvider.CONSENT_ENV`` keep working; the consent check itself now
+    lives in :mod:`creek.classify.llm.consent` and accepts ``CREEK_CLOUD_CONSENT``.
+    """
 
     MAX_TOKENS: int = 1024
     """Maximum tokens requested from the Anthropic API per call."""
@@ -111,8 +124,11 @@ class AnthropicProvider:
 
         The API key and the explicit cloud-egress consent are both read from
         the environment at call time, so the check reflects the *current* env
-        rather than the env at construction. :meth:`__init__` raises the
-        returned message; :attr:`available` reports whether it is ``None``.
+        rather than the env at construction. The consent half delegates to the
+        provider-neutral :mod:`creek.classify.llm.consent` gate (#606), which
+        accepts ``CREEK_CLOUD_CONSENT`` or the legacy ``CREEK_ANTHROPIC_CONSENT``.
+        :meth:`__init__` raises the returned message; :attr:`available` reports
+        whether it is ``None``.
 
         Returns:
             A human-readable explanation when the key is missing or consent is
@@ -123,13 +139,8 @@ class AnthropicProvider:
                 f"{cls.API_KEY_ENV} environment variable is not set; "
                 "required for the Anthropic provider."
             )
-        consent = os.environ.get(cls.CONSENT_ENV, "").strip().lower()
-        if consent not in cls.CONSENT_TRUTHY:
-            return (
-                "Anthropic cloud classification requires explicit consent. "
-                f"Set {cls.CONSENT_ENV}=1 to confirm that fragment content "
-                "may be sent to Anthropic's servers."
-            )
+        if not has_cloud_consent():
+            return consent_error_message(cls.PROVIDER_NAME)
         return None
 
     @property
@@ -429,6 +440,9 @@ class OllamaProvider:
     is_cloud: bool = False
     """Ollama runs locally; content never leaves the device."""
 
+    PROVIDER_NAME: str = "Ollama"
+    """Display name (local; never appears in a cloud-egress message)."""
+
     REQUEST_TIMEOUT: float = 30.0
     """HTTP request timeout for completion calls, in seconds."""
 
@@ -553,3 +567,20 @@ def provider_is_cloud(provider: str) -> bool:
     """
     provider_cls = _PROVIDER_REGISTRY.get(provider)
     return bool(provider_cls is not None and provider_cls.is_cloud)
+
+
+def provider_display_name(provider: str) -> str:
+    """Return the human-readable display name for a provider string.
+
+    Used to name the active provider in cloud-egress warnings and consent
+    errors (e.g. ``"anthropic"`` → ``"Anthropic"``).
+
+    Args:
+        provider: The ``LLMConfig.provider`` string.
+
+    Returns:
+        The registered provider's ``PROVIDER_NAME``, or *provider* verbatim
+        when it names no registered backend.
+    """
+    provider_cls = _PROVIDER_REGISTRY.get(provider)
+    return provider_cls.PROVIDER_NAME if provider_cls is not None else provider

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -847,50 +847,62 @@ _CLASSIFY_METHOD_HELP: str = (
     "Classification method (rules|llm). "
     "'rules' is local and offline. 'llm' calls the provider configured "
     "under llm: in creek_config.yaml; the default 'ollama' provider is "
-    "local, while 'anthropic' requires both ANTHROPIC_API_KEY and "
-    "CREEK_ANTHROPIC_CONSENT=1 to be set in the environment before the "
-    "run (data-egress acknowledgement; see issue #320)."
+    "local, while any cloud provider (e.g. 'anthropic') requires its API "
+    "key plus CREEK_CLOUD_CONSENT=1 (the legacy CREEK_ANTHROPIC_CONSENT is "
+    "still honored) to be set in the environment before the run "
+    "(data-egress acknowledgement; see issue #320)."
 )
 
 
-def _preflight_anthropic_consent(config: CreekConfig) -> None:
-    """Abort early when ``--method llm`` will hit the Anthropic consent gate.
+def _preflight_cloud_consent(config: CreekConfig) -> None:
+    """Abort early when ``--method llm`` will hit a cloud-consent gate.
 
-    Issue #320: previously the consent requirement only surfaced once
-    :class:`creek.classify.llm.providers.AnthropicProvider` was
-    instantiated mid-classify run, after vault load and first-fragment
-    iteration. This pre-flight inspects the resolved config plus the
-    live process environment and surfaces the exact remediation BEFORE
-    any fragment work begins.
+    Issue #320: previously the consent requirement only surfaced once the
+    cloud provider was instantiated mid-classify run, after vault load and
+    first-fragment iteration. This pre-flight inspects the resolved config
+    plus the live process environment and surfaces the exact remediation
+    BEFORE any fragment work begins.
 
-    No-ops for any non-anthropic provider, and silent when consent is
-    already on file (the run continues normally).
+    Provider-neutral (#606): it fires for *any* cloud provider via
+    :func:`~creek.classify.llm.providers.provider_is_cloud` and accepts the
+    neutral ``CREEK_CLOUD_CONSENT`` or the legacy ``CREEK_ANTHROPIC_CONSENT``.
+    No-ops for local providers (Ollama), and silent when consent is already on
+    file (the run continues normally).
 
     Args:
         config: Loaded :class:`CreekConfig` for the current invocation.
 
     Raises:
-        typer.Exit: With code ``1`` when the Anthropic provider is
-            selected but ``CREEK_ANTHROPIC_CONSENT`` is missing or not
-            set to a truthy value.
+        typer.Exit: With code ``1`` when a cloud provider is selected but
+            cloud-egress consent is missing.
     """
-    from creek.classify.llm.providers import AnthropicProvider
+    from creek.classify.llm.consent import (
+        CLOUD_CONSENT_ENV,
+        LEGACY_CONSENT_ENV,
+        has_cloud_consent,
+    )
+    from creek.classify.llm.providers import (
+        provider_display_name,
+        provider_is_cloud,
+    )
 
-    if config.llm.provider.strip().lower() != "anthropic":
+    provider = config.llm.provider.strip().lower()
+    if not provider_is_cloud(provider):
         return
-    consent = os.environ.get(AnthropicProvider.CONSENT_ENV, "").strip().lower()
-    if consent in AnthropicProvider.CONSENT_TRUTHY:
+    if has_cloud_consent():
         return
+    name = provider_display_name(provider)
     console.print(
-        "[red]Anthropic provider selected in creek_config.yaml "
-        "(llm.provider: anthropic), but cloud classification requires "
+        f"[red]{name} provider selected in creek_config.yaml "
+        f"(llm.provider: {provider}), but cloud classification requires "
         "explicit consent.[/red]",
     )
     console.print(
-        f"[yellow]Set [bold]{AnthropicProvider.CONSENT_ENV}=1[/bold] "
-        "(also accepts 'true' or 'yes') to confirm that fragment "
-        "content may be sent to Anthropic's servers, then re-run "
-        "[bold]creek classify --method llm[/bold].[/yellow]",
+        f"[yellow]Set [bold]{CLOUD_CONSENT_ENV}=1[/bold] "
+        "(also accepts 'true' or 'yes'; the legacy "
+        f"[bold]{LEGACY_CONSENT_ENV}[/bold] is still honored) to confirm "
+        f"that fragment content may be sent to {name}'s servers, then "
+        "re-run [bold]creek classify --method llm[/bold].[/yellow]",
     )
     console.print(
         "[dim]To keep classification fully local instead, set "
@@ -996,11 +1008,11 @@ def classify(
 
     config = _load_config_for_vault(vault)
     if method == "llm":
-        # Issue #320: surface the Anthropic consent-env-var gate before
+        # Issue #320 / #606: surface the cloud-egress consent gate before
         # any vault iteration. The provider's own __init__ also raises,
         # but only after the engine has already started — by then the
         # operator has waited through vault load and per-fragment setup.
-        _preflight_anthropic_consent(config)
+        _preflight_cloud_consent(config)
     if reatomize:
         # Late-bind the FEAT-023 CLI overrides into the loaded config so
         # downstream call-sites only ever look at the config object, not

--- a/creek-tools/tests/test_cloud_consent.py
+++ b/creek-tools/tests/test_cloud_consent.py
@@ -1,0 +1,155 @@
+"""Tests for the provider-neutral cloud-egress consent gate (#606).
+
+Locks the generalisation of the Anthropic-specific consent gate into a shared
+helper that covers any cloud provider (OpenAI/Gemini next), keyed off the new
+``CREEK_CLOUD_CONSENT`` env var with the legacy ``CREEK_ANTHROPIC_CONSENT``
+accepted as an alias. Ollama (local) never requires consent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from creek.classify.llm.consent import (
+    CLOUD_CONSENT_ENV,
+    LEGACY_CONSENT_ENV,
+    cloud_warning,
+    consent_error_message,
+    has_cloud_consent,
+    require_cloud_consent,
+)
+from creek.classify.llm.providers import (
+    ANTHROPIC_CLOUD_WARNING,
+    AnthropicProvider,
+    OllamaProvider,
+)
+from creek.config import LLMConfig
+
+
+@pytest.fixture(autouse=True)
+def _clear_consent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each test with neither consent variable set (hermetic)."""
+    monkeypatch.delenv(CLOUD_CONSENT_ENV, raising=False)
+    monkeypatch.delenv(LEGACY_CONSENT_ENV, raising=False)
+
+
+class TestHasCloudConsent:
+    """Tests for has_cloud_consent across both env vars."""
+
+    def test_false_when_neither_set(self) -> None:
+        """No consent variable set means no consent."""
+        assert has_cloud_consent() is False
+
+    def test_true_for_new_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The new ``CREEK_CLOUD_CONSENT`` grants consent."""
+        monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+        assert has_cloud_consent() is True
+
+    def test_true_for_legacy_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The legacy ``CREEK_ANTHROPIC_CONSENT`` still grants consent."""
+        monkeypatch.setenv(LEGACY_CONSENT_ENV, "1")
+        assert has_cloud_consent() is True
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "Yes", "yes"])
+    def test_accepts_truthy_words_case_insensitively(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        """``true``/``yes`` (any case) are affirmative."""
+        monkeypatch.setenv(CLOUD_CONSENT_ENV, value)
+        assert has_cloud_consent() is True
+
+    @pytest.mark.parametrize("value", ["", "0", "no", "false", "  "])
+    def test_rejects_falsy_values(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        """Anything outside the truthy set is not consent."""
+        monkeypatch.setenv(CLOUD_CONSENT_ENV, value)
+        assert has_cloud_consent() is False
+
+
+class TestRequireCloudConsent:
+    """Tests for the raising consent gate."""
+
+    def test_raises_naming_provider_when_absent(self) -> None:
+        """The error names the active provider and the new env var."""
+        with pytest.raises(RuntimeError) as exc:
+            require_cloud_consent("OpenAI")
+        message = str(exc.value)
+        assert "OpenAI" in message
+        assert CLOUD_CONSENT_ENV in message
+
+    def test_silent_when_consent_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No exception once consent is on file."""
+        monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+        require_cloud_consent("OpenAI")  # must not raise
+
+    def test_silent_with_legacy_consent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The legacy variable also satisfies the gate."""
+        monkeypatch.setenv(LEGACY_CONSENT_ENV, "yes")
+        require_cloud_consent("Gemini")  # must not raise
+
+
+def test_consent_error_message_mentions_both_vars() -> None:
+    """The remediation surfaces the new var and honors the legacy one."""
+    message = consent_error_message("Anthropic")
+    assert "Anthropic" in message
+    assert CLOUD_CONSENT_ENV in message
+    assert LEGACY_CONSENT_ENV in message
+
+
+def test_cloud_warning_names_provider() -> None:
+    """The neutral warning names the provider and flags cloud egress."""
+    warning = cloud_warning("Gemini")
+    assert "Gemini" in warning
+    assert "cloud" in warning.lower()
+
+
+def test_anthropic_cloud_warning_is_neutral_warning_for_anthropic() -> None:
+    """The deprecated constant equals the neutral warning bound to Anthropic."""
+    assert cloud_warning("Anthropic") == ANTHROPIC_CLOUD_WARNING
+
+
+class TestAnthropicProviderConsent:
+    """Anthropic provider routes through the shared consent gate."""
+
+    def test_constructs_with_new_consent_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``CREEK_CLOUD_CONSENT`` satisfies the Anthropic consent gate."""
+        monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+        monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+        provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+        assert provider.available is True
+
+    def test_constructs_with_legacy_consent_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The legacy ``CREEK_ANTHROPIC_CONSENT`` still works unchanged."""
+        monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+        monkeypatch.setenv(LEGACY_CONSENT_ENV, "1")
+        provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+        assert provider.available is True
+
+    def test_raises_naming_anthropic_when_consent_absent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With a key but no consent, construction raises naming Anthropic."""
+        monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+        with pytest.raises(RuntimeError, match="Anthropic"):
+            AnthropicProvider(LLMConfig(provider="anthropic"))
+
+    def test_consent_message_references_new_var(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The Anthropic consent failure points at the neutral var."""
+        monkeypatch.setenv(AnthropicProvider.API_KEY_ENV, "sk-test-not-real")
+        with pytest.raises(RuntimeError, match=CLOUD_CONSENT_ENV):
+            AnthropicProvider(LLMConfig(provider="anthropic"))
+
+
+def test_ollama_never_requires_consent() -> None:
+    """The local Ollama provider constructs and is usable with no consent."""
+    provider = OllamaProvider(LLMConfig())
+    # No consent env set (autouse fixture cleared both); must not raise and
+    # is_cloud stays False so no gate ever applies.
+    assert provider.is_cloud is False


### PR DESCRIPTION
## Summary

- Generalise the "fragment content is leaving the device" consent gate + warning so they cover **any** cloud provider (OpenAI/Gemini land next), not just Anthropic. Ollama (local) stays exempt. Sequence 3/8 of epic #603.
- New `creek/classify/llm/consent.py`: `has_cloud_consent()` reads the neutral **`CREEK_CLOUD_CONSENT`** and still honors the legacy **`CREEK_ANTHROPIC_CONSENT`** as an alias; `require_cloud_consent(provider)` / `consent_error_message(provider)` raise/format a message that names the active provider; `cloud_warning(provider)` replaces the static `ANTHROPIC_CLOUD_WARNING` (kept as a deprecated alias bound to `"Anthropic"`, byte-identical to the old text).
- `AnthropicProvider` routes its consent check through the shared helper (gains `PROVIDER_NAME`; `CONSENT_ENV` kept as a back-compat alias). The orchestrator logs the neutral warning for any cloud provider via `provider_is_cloud` — no string compare.
- The CLI `_preflight_anthropic_consent` → `_preflight_cloud_consent`: gated on `provider_is_cloud` and using the shared check, so the early-abort UX (#320) now covers future cloud providers too. Remediation names the provider and surfaces `CREEK_CLOUD_CONSENT` while still mentioning the legacy var.

**Back-compat:** existing `CREEK_ANTHROPIC_CONSENT=1` setups keep working unchanged (verified by tests). README env-var matrix update lands in epic child #611.

## Test plan

- New `tests/test_cloud_consent.py` (24 cases): both env vars grant consent (case-insensitive truthy set); neither set → `RuntimeError` naming the provider + `CREEK_CLOUD_CONSENT`; `cloud_warning` names the provider; `ANTHROPIC_CLOUD_WARNING == cloud_warning("Anthropic")`; Anthropic constructs via new **or** legacy var; Ollama never requires consent.
- Existing Anthropic consent + cloud-warning tests (`test_classify.py`) and CLI gate tests (`test_cli.py`, incl. the `CREEK_ANTHROPIC_CONSENT` help/remediation assertions) stay green via the shared helper.
- `./scripts/check-all.sh` → exit 0 (all 12 gates; 5393 unit tests; 93.84% coverage; mypy strict; ruff lint+format; per-file gate).

Closes #606
Refs #603
