### PR TITLE
feat(llm): add synchronous OpenAIProvider + optional dependency (#607)

### DIFF
--- a/creek-tools/creek/classify/llm/__init__.py
+++ b/creek-tools/creek/classify/llm/__init__.py
@@ -77,6 +77,7 @@ from creek.classify.llm.providers import (
     ANTHROPIC_CLOUD_WARNING,
     AnthropicProvider,
     OllamaProvider,
+    OpenAIProvider,
     build_provider,
     provider_is_cloud,
 )
@@ -92,6 +93,7 @@ __all__ = [
     "LLMClassifier",
     "LLMProvider",
     "OllamaProvider",
+    "OpenAIProvider",
     "build_provider",
     "cloud_warning",
     "has_cloud_consent",

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -30,6 +30,7 @@ from creek.classify.llm.consent import (
 
 if TYPE_CHECKING:
     import anthropic
+    import openai
 
     from creek.classify.llm.base import LLMProvider
     from creek.config import LLMConfig
@@ -46,6 +47,7 @@ __all__ = [
     "AnthropicProvider",
     "Completion",
     "OllamaProvider",
+    "OpenAIProvider",
     "build_provider",
     "cloud_warning",
     "provider_display_name",
@@ -512,14 +514,266 @@ class OllamaProvider:
         return Completion(text=text)
 
 
+#: OpenAI ``finish_reason`` → normalized :class:`Completion` stop reason.
+_OPENAI_STOP_REASONS: dict[str, str] = {"stop": "end_turn", "length": "max_tokens"}
+
+
+class OpenAIProvider:
+    """OpenAI API provider for cloud-based fragment classification (#607).
+
+    Sends prompts to the OpenAI ``chat.completions`` API via the official SDK.
+    The API key is read exclusively from ``OPENAI_API_KEY`` by the SDK and is
+    never stored in config, logs, or error messages; an optional
+    OpenAI-compatible gateway base URL may be supplied via ``config.api_base``
+    (or the SDK's own ``OPENAI_BASE_URL``). Structure mirrors
+    :class:`AnthropicProvider` so the two stay legible.
+
+    Attributes:
+        config: The LLM configuration specifying model, batch size, etc.
+    """
+
+    is_cloud: bool = True
+    """OpenAI sends fragment content off-device; gated by consent."""
+
+    PROVIDER_NAME: str = "OpenAI"
+    """Display name woven into consent and cloud-egress messages."""
+
+    DEFAULT_MODEL: str = "gpt-4o"
+    """Default OpenAI model when the config does not override it."""
+
+    API_KEY_ENV: str = "OPENAI_API_KEY"
+    """Environment variable name for the OpenAI API key."""
+
+    MAX_TOKENS: int = 1024
+    """Maximum tokens requested from the OpenAI API per call."""
+
+    _OLLAMA_DEFAULT_MODEL: str = "mistral"
+    """The ``LLMConfig`` default model name (indicates no OpenAI override)."""
+
+    def __init__(self, config: LLMConfig) -> None:
+        """Validate environment prerequisites and prepare the client.
+
+        The SDK client is instantiated lazily on first use. The cloud-egress
+        consent gate is shared with every cloud provider (#606).
+
+        Args:
+            config: LLM provider configuration.
+
+        Raises:
+            RuntimeError: If the API key is unset or cloud consent is missing.
+        """
+        self.config = config
+        unmet = self._missing_prerequisite()
+        if unmet is not None:
+            raise RuntimeError(unmet)
+        self._client: openai.OpenAI | None = None
+
+    @classmethod
+    def _missing_prerequisite(cls) -> str | None:
+        """Return why the OpenAI prerequisites are unmet, or ``None``.
+
+        The key and the shared cloud-egress consent are read from the
+        environment at call time; :meth:`__init__` raises the returned message
+        and :attr:`available` reports whether it is ``None``.
+
+        Returns:
+            A human-readable explanation when the key is missing or consent is
+            not affirmative; ``None`` when both prerequisites are satisfied.
+        """
+        if not os.environ.get(cls.API_KEY_ENV, "").strip():
+            return (
+                f"{cls.API_KEY_ENV} environment variable is not set; "
+                "required for the OpenAI provider."
+            )
+        if not has_cloud_consent():
+            return consent_error_message(cls.PROVIDER_NAME)
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Whether the OpenAI prerequisites (API key + consent) are met.
+
+        Returns:
+            ``True`` when the API key is set and cloud consent is affirmative.
+        """
+        return self._missing_prerequisite() is None
+
+    @property
+    def model(self) -> str:
+        """The OpenAI model identifier to use for API calls.
+
+        Falls back to :attr:`DEFAULT_MODEL` when ``config.model`` still holds
+        the Ollama default (``"mistral"``) or is empty.
+
+        Returns:
+            The resolved model identifier.
+        """
+        model = self.config.model.strip()
+        if not model or model == self._OLLAMA_DEFAULT_MODEL:
+            return self.DEFAULT_MODEL
+        return model
+
+    @property
+    def client(self) -> openai.OpenAI:
+        """The lazily-initialised OpenAI SDK client.
+
+        The SDK reads ``OPENAI_API_KEY`` itself; ``config.api_base`` (when set)
+        is forwarded as ``base_url`` for an OpenAI-compatible gateway.
+
+        Returns:
+            An ``openai.OpenAI`` client instance.
+        """
+        if self._client is None:
+            import openai
+
+            if self.config.api_base:
+                self._client = openai.OpenAI(base_url=self.config.api_base)
+            else:
+                self._client = openai.OpenAI()
+        return self._client
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int | None = None,
+        system: str | None = None,
+    ) -> Completion:
+        """Send *prompt* to OpenAI and return a normalized :class:`Completion`.
+
+        Args:
+            prompt: The dynamic, fully-formatted user prompt.
+            max_tokens: Maximum tokens to request. ``None`` keeps the historical
+                :attr:`MAX_TOKENS` ceiling.
+            system: Optional static system prefix sent as a leading system
+                message. ``None`` sends the user prompt alone.
+
+        Returns:
+            A :class:`Completion` carrying the response text, the mapped stop
+            reason, and token usage when present.
+
+        Raises:
+            RuntimeError: If the SDK raises any ``OpenAIError``; re-raised with
+                only the exception type name so no request state leaks.
+        """
+        import openai
+
+        ceiling = self.MAX_TOKENS if max_tokens is None else max_tokens
+        try:
+            response = self._create_chat(prompt, ceiling, system)
+        except openai.OpenAIError as exc:
+            msg = f"OpenAI API call failed: {type(exc).__name__}"
+            raise RuntimeError(msg) from None
+        return Completion(
+            text=_extract_openai_text(response),
+            stop_reason=_map_openai_stop_reason(response),
+            usage=_extract_openai_usage(response),
+        )
+
+    def _create_chat(
+        self,
+        prompt: str,
+        ceiling: int,
+        system: str | None,
+    ) -> object:
+        """Call ``chat.completions.create``, adding a system message when given.
+
+        Keeping the two message shapes as inline literals (rather than a built
+        list) preserves the SDK's typed-param inference.
+
+        Args:
+            prompt: The dynamic user prompt.
+            ceiling: The resolved ``max_tokens`` value.
+            system: Optional static system prefix, or ``None``.
+
+        Returns:
+            The raw ``chat.completions.create`` response object.
+        """
+        if system is None:
+            return self.client.chat.completions.create(
+                model=self.model,
+                max_tokens=ceiling,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        return self.client.chat.completions.create(
+            model=self.model,
+            max_tokens=ceiling,
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": prompt},
+            ],
+        )
+
+
+def _extract_openai_text(response: object) -> str:
+    """Concatenate the textual content of an OpenAI chat response.
+
+    Args:
+        response: A ``chat.completions.create`` response object.
+
+    Returns:
+        The first choice's message content, or ``""`` when absent/non-string.
+    """
+    choices = getattr(response, "choices", None) or []
+    if not choices:
+        return ""
+    content = getattr(getattr(choices[0], "message", None), "content", None)
+    return content if isinstance(content, str) else ""
+
+
+def _map_openai_stop_reason(response: object) -> str:
+    """Map an OpenAI ``finish_reason`` to a normalized stop reason.
+
+    Args:
+        response: A ``chat.completions.create`` response object.
+
+    Returns:
+        ``"end_turn"`` for ``"stop"`` (and unknown/absent reasons),
+        ``"max_tokens"`` for ``"length"``.
+    """
+    choices = getattr(response, "choices", None) or []
+    if not choices:
+        return "end_turn"
+    reason = getattr(choices[0], "finish_reason", None)
+    if not isinstance(reason, str):
+        return "end_turn"
+    return _OPENAI_STOP_REASONS.get(reason, "end_turn")
+
+
+def _extract_openai_usage(response: object) -> dict[str, int] | None:
+    """Extract integer token-usage counts from an OpenAI chat response.
+
+    Args:
+        response: A ``chat.completions.create`` response object.
+
+    Returns:
+        A dict with ``input_tokens`` / ``output_tokens`` mirroring the
+        Anthropic usage shape, or ``None`` when the SDK omitted usage.
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return None
+    counts: dict[str, int] = {}
+    prompt_tokens = getattr(usage, "prompt_tokens", None)
+    completion_tokens = getattr(usage, "completion_tokens", None)
+    if isinstance(prompt_tokens, int):
+        counts["input_tokens"] = prompt_tokens
+    if isinstance(completion_tokens, int):
+        counts["output_tokens"] = completion_tokens
+    return counts or None
+
+
 #: Registry mapping the ``LLMConfig.provider`` string to its provider class.
-#: Adding a backend (OpenAI #607, Gemini #608) is a one-line entry here. The
-#: value is the concrete class (not the ``LLMProvider`` protocol) so it is both
+#: Adding a backend (Gemini #608) is a one-line entry here. The value is the
+#: concrete class (not the ``LLMProvider`` protocol) so it is both
 #: constructible and exposes the class-level ``is_cloud`` flag; widen the union
 #: as new providers land.
-_PROVIDER_REGISTRY: dict[str, type[AnthropicProvider | OllamaProvider]] = {
+_PROVIDER_REGISTRY: dict[
+    str, type[AnthropicProvider | OllamaProvider | OpenAIProvider]
+] = {
     "anthropic": AnthropicProvider,
     "ollama": OllamaProvider,
+    "openai": OpenAIProvider,
 }
 
 

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -101,6 +101,11 @@ class LLMConfig(BaseModel):
     ollama_url: str = "http://localhost:11434"
     """Base URL for the Ollama API server."""
 
+    api_base: str | None = None
+    """Optional base-URL override for a cloud provider's SDK (e.g. an
+    OpenAI-compatible gateway). ``None`` lets the SDK use its default endpoint
+    or its own ``*_BASE_URL`` environment variable. Never holds a secret."""
+
     batch_size: int = 50
     """Number of items to process per LLM batch call."""
 

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -44,6 +44,7 @@ creek-tools-mcp = "creek_mcp.server:main"
 
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.40.0"]
+openai = ["openai>=1.0"]
 embeddings = [
     "sentence-transformers>=2.2.0",
     "numpy>=2.4.4",
@@ -68,7 +69,7 @@ gdrive = [
 all = [
     # Self-referential extras (pip >= 21.2). Adding a new sub-extra
     # automatically flows into [all] without manual duplication.
-    "creek-tools[anthropic,embeddings,ocr,documents,spreadsheets,presentations,gdrive]",
+    "creek-tools[anthropic,openai,embeddings,ocr,documents,spreadsheets,presentations,gdrive]",
 ]
 dev = [
     # `tests/conftest.py` imports numpy, `tests/test_classify.py` mocks

--- a/creek-tools/tests/test_openai_provider.py
+++ b/creek-tools/tests/test_openai_provider.py
@@ -1,0 +1,220 @@
+"""Tests for the synchronous OpenAIProvider (#607).
+
+The ``openai`` SDK is mocked throughout — no live calls. Covers the consent +
+key gate, model resolution, the chat-completions call, ``finish_reason`` and
+usage mapping, error redaction, and a mocked end-to-end classify call.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from creek.classify.llm.base import LLMProvider
+from creek.classify.llm.completion import Completion
+from creek.classify.llm.consent import CLOUD_CONSENT_ENV, LEGACY_CONSENT_ENV
+from creek.classify.llm.providers import (
+    OpenAIProvider,
+    build_provider,
+    provider_is_cloud,
+)
+from creek.config import LLMConfig
+
+
+@pytest.fixture(autouse=True)
+def _clear_consent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each test with neither consent variable set."""
+    monkeypatch.delenv(CLOUD_CONSENT_ENV, raising=False)
+    monkeypatch.delenv(LEGACY_CONSENT_ENV, raising=False)
+
+
+@pytest.fixture
+def openai_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set the API key and cloud consent so an OpenAIProvider constructs."""
+    monkeypatch.setenv(OpenAIProvider.API_KEY_ENV, "sk-openai-not-real")
+    monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+
+
+def _make_mock_openai_client(
+    content: str,
+    *,
+    finish_reason: str = "stop",
+    prompt_tokens: int = 11,
+    completion_tokens: int = 7,
+) -> MagicMock:
+    """Build a mock ``openai.OpenAI`` client returning one chat completion."""
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = finish_reason
+    usage = MagicMock()
+    usage.prompt_tokens = prompt_tokens
+    usage.completion_tokens = completion_tokens
+    response = MagicMock()
+    response.choices = [choice]
+    response.usage = usage
+    client = MagicMock()
+    client.chat.completions.create.return_value = response
+    return client
+
+
+class TestOpenAIProviderConstruction:
+    """Consent + API-key gate at construction."""
+
+    def test_raises_when_api_key_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No ``OPENAI_API_KEY`` → RuntimeError naming the variable."""
+        monkeypatch.delenv(OpenAIProvider.API_KEY_ENV, raising=False)
+        monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+        with pytest.raises(RuntimeError, match=OpenAIProvider.API_KEY_ENV):
+            OpenAIProvider(LLMConfig(provider="openai"))
+
+    def test_raises_when_consent_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Key present but no consent → RuntimeError naming OpenAI."""
+        monkeypatch.setenv(OpenAIProvider.API_KEY_ENV, "sk-openai-not-real")
+        with pytest.raises(RuntimeError, match="OpenAI"):
+            OpenAIProvider(LLMConfig(provider="openai"))
+
+    def test_constructs_with_key_and_consent(self, openai_env: None) -> None:
+        """Key + consent → constructs and reports available."""
+        provider = OpenAIProvider(LLMConfig(provider="openai"))
+        assert provider.available is True
+
+    def test_is_cloud_and_provider_name(self, openai_env: None) -> None:
+        """OpenAI is a cloud backend with a display name."""
+        provider = OpenAIProvider(LLMConfig(provider="openai"))
+        assert provider.is_cloud is True
+        assert provider.PROVIDER_NAME == "OpenAI"
+
+
+class TestOpenAIFactoryRegistration:
+    """The factory knows the openai backend."""
+
+    def test_build_provider_returns_openai(self, openai_env: None) -> None:
+        """``build_provider`` constructs an OpenAIProvider for 'openai'."""
+        provider = build_provider(LLMConfig(provider="openai"))
+        assert isinstance(provider, OpenAIProvider)
+        assert isinstance(provider, LLMProvider)
+
+    def test_provider_is_cloud_openai(self) -> None:
+        """'openai' is registered as a cloud provider (no instantiation)."""
+        assert provider_is_cloud("openai") is True
+
+
+class TestOpenAIModelResolution:
+    """Model resolution mirrors the Anthropic sentinel logic."""
+
+    def test_default_model_literal(self) -> None:
+        """The default OpenAI model literal lives on the provider."""
+        assert OpenAIProvider.DEFAULT_MODEL == "gpt-4o"
+
+    def test_falls_back_from_ollama_default(self, openai_env: None) -> None:
+        """The Ollama default ``mistral`` falls back to the OpenAI default."""
+        provider = OpenAIProvider(LLMConfig(provider="openai"))
+        assert provider.model == OpenAIProvider.DEFAULT_MODEL
+
+    def test_honors_explicit_model(self, openai_env: None) -> None:
+        """An explicit config model is honoured."""
+        provider = OpenAIProvider(LLMConfig(provider="openai", model="gpt-x"))
+        assert provider.model == "gpt-x"
+
+
+class TestOpenAIComplete:
+    """The complete() call against a mocked SDK."""
+
+    def test_complete_returns_completion(self, openai_env: None) -> None:
+        """A successful call normalizes to a populated Completion."""
+        client = _make_mock_openai_client("hello world")
+        with patch("openai.OpenAI", return_value=client):
+            provider = OpenAIProvider(LLMConfig(provider="openai"))
+            result = provider.complete("a prompt")
+        assert isinstance(result, Completion)
+        assert result.text == "hello world"
+        assert result.stop_reason == "end_turn"
+        assert result.usage == {"input_tokens": 11, "output_tokens": 7}
+
+    def test_complete_calls_chat_completions(self, openai_env: None) -> None:
+        """The SDK is called with the resolved model and the prompt."""
+        client = _make_mock_openai_client("x")
+        with patch("openai.OpenAI", return_value=client):
+            provider = OpenAIProvider(LLMConfig(provider="openai"))
+            provider.complete("the prompt")
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == OpenAIProvider.DEFAULT_MODEL
+        assert {"role": "user", "content": "the prompt"} in kwargs["messages"]
+
+    def test_complete_maps_length_to_max_tokens(self, openai_env: None) -> None:
+        """``finish_reason='length'`` maps to the ``max_tokens`` stop reason."""
+        client = _make_mock_openai_client("cut", finish_reason="length")
+        with patch("openai.OpenAI", return_value=client):
+            provider = OpenAIProvider(LLMConfig(provider="openai"))
+            result = provider.complete("p")
+        assert result.stop_reason == "max_tokens"
+
+    def test_complete_threads_max_tokens(self, openai_env: None) -> None:
+        """An explicit max_tokens is forwarded to the SDK."""
+        client = _make_mock_openai_client("x")
+        with patch("openai.OpenAI", return_value=client):
+            provider = OpenAIProvider(LLMConfig(provider="openai"))
+            provider.complete("p", max_tokens=256)
+        assert client.chat.completions.create.call_args.kwargs["max_tokens"] == 256
+
+    def test_complete_includes_system_message(self, openai_env: None) -> None:
+        """A system prefix is sent as a leading system message."""
+        client = _make_mock_openai_client("x")
+        with patch("openai.OpenAI", return_value=client):
+            provider = OpenAIProvider(LLMConfig(provider="openai"))
+            provider.complete("p", system="be terse")
+        messages = client.chat.completions.create.call_args.kwargs["messages"]
+        assert messages[0] == {"role": "system", "content": "be terse"}
+        assert messages[-1] == {"role": "user", "content": "p"}
+
+    def test_complete_handles_null_content(self, openai_env: None) -> None:
+        """A ``None`` message content normalizes to empty text, not a crash."""
+        client = _make_mock_openai_client(None)  # type: ignore[arg-type]
+        with patch("openai.OpenAI", return_value=client):
+            provider = OpenAIProvider(LLMConfig(provider="openai"))
+            result = provider.complete("p")
+        assert result.text == ""
+
+    def test_complete_redacts_sdk_errors(self, openai_env: None) -> None:
+        """SDK errors surface only the exception type name, not request state."""
+        import openai
+
+        client = MagicMock()
+        client.chat.completions.create.side_effect = openai.OpenAIError(
+            "secret request payload and api details"
+        )
+        with patch("openai.OpenAI", return_value=client):
+            provider = OpenAIProvider(LLMConfig(provider="openai"))
+            with pytest.raises(RuntimeError) as exc:
+                provider.complete("p")
+        message = str(exc.value)
+        assert "OpenAIError" in message
+        assert "secret" not in message
+
+    def test_complete_uses_api_base_when_set(self, openai_env: None) -> None:
+        """``config.api_base`` is passed to the SDK client as ``base_url``."""
+        client = _make_mock_openai_client("x")
+        with patch("openai.OpenAI", return_value=client) as mock_ctor:
+            provider = OpenAIProvider(
+                LLMConfig(provider="openai", api_base="https://gw.example/v1")
+            )
+            provider.complete("p")
+        assert mock_ctor.call_args.kwargs.get("base_url") == "https://gw.example/v1"
+
+
+def test_openai_end_to_end_classify(
+    openai_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A mocked end-to-end classify via provider=openai returns a Completion."""
+    from creek.classify.llm.orchestrator import LLMClassifier
+
+    client = _make_mock_openai_client("response body")
+    with patch("openai.OpenAI", return_value=client):
+        classifier = LLMClassifier(config=LLMConfig(provider="openai"))
+        completion = classifier.invoke_prompt_with_metadata("classify this")
+    assert isinstance(completion, Completion)
+    assert completion.text == "response body"
+    assert completion.usage == {"input_tokens": 11, "output_tokens": 7}

--- a/creek-tools/uv.lock
+++ b/creek-tools/uv.lock
@@ -545,6 +545,7 @@ all = [
     { name = "google-auth-oauthlib" },
     { name = "markdownify" },
     { name = "numpy" },
+    { name = "openai" },
     { name = "openpyxl" },
     { name = "pdf2image" },
     { name = "pdfminer-six" },
@@ -570,6 +571,7 @@ dev = [
     { name = "markdownify" },
     { name = "mypy" },
     { name = "numpy" },
+    { name = "openai" },
     { name = "openpyxl" },
     { name = "pdf2image" },
     { name = "pdfminer-six" },
@@ -618,6 +620,9 @@ ocr = [
     { name = "pillow" },
     { name = "pytesseract" },
 ]
+openai = [
+    { name = "openai" },
+]
 presentations = [
     { name = "python-pptx" },
 ]
@@ -631,7 +636,7 @@ requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9.4,<2" },
     { name = "chardet", specifier = ">=7.4.3" },
     { name = "creek-tools", extras = ["all"], marker = "extra == 'dev'" },
-    { name = "creek-tools", extras = ["anthropic", "embeddings", "ocr", "documents", "spreadsheets", "presentations", "gdrive"], marker = "extra == 'all'" },
+    { name = "creek-tools", extras = ["anthropic", "openai", "embeddings", "ocr", "documents", "spreadsheets", "presentations", "gdrive"], marker = "extra == 'all'" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "google-api-python-client", marker = "extra == 'gdrive'", specifier = ">=2.0" },
     { name = "google-auth-oauthlib", marker = "extra == 'gdrive'", specifier = ">=1.0" },
@@ -644,6 +649,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.0.0,<2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.1.0,<2.2.0" },
     { name = "numpy", marker = "extra == 'embeddings'", specifier = ">=2.4.4" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0" },
     { name = "openpyxl", marker = "extra == 'spreadsheets'", specifier = ">=3.1" },
     { name = "pdf2image", marker = "extra == 'ocr'", specifier = ">=1.0" },
     { name = "pdfminer-six", marker = "extra == 'documents'", specifier = ">=20260107" },
@@ -681,7 +687,7 @@ requires-dist = [
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.10" },
     { name = "xenon", marker = "extra == 'dev'", specifier = ">=0.9.0" },
 ]
-provides-extras = ["anthropic", "embeddings", "ocr", "documents", "spreadsheets", "presentations", "gdrive", "all", "dev"]
+provides-extras = ["anthropic", "openai", "embeddings", "ocr", "documents", "spreadsheets", "presentations", "gdrive", "all", "dev"]
 
 [[package]]
 name = "cryptography"
@@ -2043,6 +2049,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/5815fe2e2aca74b36c650d1bd43b69827cee568073d0d2d9b6fc5aaac80c/openai-2.41.0.tar.gz", hash = "sha256:db5c362acd6604b84f076abbefa66826ea4b46ecba2954ed866e6a149a1352c0", size = 783525, upload-time = "2026-06-03T22:39:40.719Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/51/d82bb424e8aa372190c5233253a2ceb399a778747d18b42cff487411e663/openai-2.41.0-py3-none-any.whl", hash = "sha256:20cc7952e8501c7e5773dd2ef7be437bae9cb549044902e1041a83a54516e375", size = 1353378, upload-time = "2026-06-03T22:39:38.964Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add a synchronous **OpenAIProvider** so `provider: openai` in `creek_config.yaml` routes classification + author-desk calls to OpenAI, with the key read from `OPENAI_API_KEY` by the SDK. First *new* backend on the #605 seam — sequence 4/8 of epic #603.
- The provider mirrors `AnthropicProvider`: shared cloud-consent gate (#606) + `OPENAI_API_KEY` presence check in `__init__`; lazy `openai.OpenAI()` client honoring `config.api_base` / `OPENAI_BASE_URL`; `DEFAULT_MODEL` literal (`gpt-4o`) with the `mistral` sentinel fallback; `complete()` calls `chat.completions.create`, redacts SDK errors to `RuntimeError(type(exc).__name__)`, and maps `finish_reason` (`stop`→`end_turn`, `length`→`max_tokens`) + `prompt/completion_tokens`→`input/output_tokens` into a normalized `Completion`.
- Registered `"openai"` in `build_provider` (one-line registry entry); added optional `api_base: str | None` to `LLMConfig` (never a secret); added the `[openai]` extra (`openai>=1.0`) flowed into `[all]`; regenerated `uv.lock` (openai 2.41.0).

**Security:** key only from env — never logged, never on a config field; SDK errors surface only the exception type name.

## Test plan

- New `tests/test_openai_provider.py` (18 cases, SDK fully mocked — no live calls): env-missing → `RuntimeError`; consent enforced (names OpenAI); factory returns `OpenAIProvider`; model resolution; `complete` → populated `Completion`; `finish_reason` and usage mapping; `max_tokens` + `system` threading; null-content handling; **error redaction** (no request state leaks); `api_base` → `base_url`; and a mocked **end-to-end classify** via `provider=openai`.
- `./scripts/check-all.sh` → exit 0 (all 12 gates; 5411 unit tests; 93.82% coverage; mypy strict; ruff; bandit + pip-audit clean with the new dep; uv.lock consistency).

## Note on layout

`OpenAIProvider` lives in `providers.py` alongside `AnthropicProvider` / `OllamaProvider` rather than a `providers/openai.py` submodule — consistent with the in-module structure established and reviewed-LGTM in #605, keeping the three providers legible side by side. A package split can be a follow-up if preferred.

Closes #607
Refs #603
