### PR TITLE
feat(llm): add synchronous GeminiProvider + optional dependency (#608)

### DIFF
--- a/creek-tools/creek/classify/llm/__init__.py
+++ b/creek-tools/creek/classify/llm/__init__.py
@@ -76,6 +76,7 @@ from creek.classify.llm.prompts import _sanitise_for_prompt as _sanitise_for_pro
 from creek.classify.llm.providers import (
     ANTHROPIC_CLOUD_WARNING,
     AnthropicProvider,
+    GeminiProvider,
     OllamaProvider,
     OpenAIProvider,
     build_provider,
@@ -89,6 +90,7 @@ __all__ = [
     "AnthropicProvider",
     "BatchStats",
     "Completion",
+    "GeminiProvider",
     "LLMClassificationResult",
     "LLMClassifier",
     "LLMProvider",

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -31,6 +31,7 @@ from creek.classify.llm.consent import (
 if TYPE_CHECKING:
     import anthropic
     import openai
+    from google import genai
 
     from creek.classify.llm.base import LLMProvider
     from creek.config import LLMConfig
@@ -46,6 +47,7 @@ __all__ = [
     "AnthropicCompletion",
     "AnthropicProvider",
     "Completion",
+    "GeminiProvider",
     "OllamaProvider",
     "OpenAIProvider",
     "build_provider",
@@ -763,17 +765,259 @@ def _extract_openai_usage(response: object) -> dict[str, int] | None:
     return counts or None
 
 
+#: Gemini ``finish_reason`` → normalized :class:`Completion` stop reason.
+_GEMINI_STOP_REASONS: dict[str, str] = {"STOP": "end_turn", "MAX_TOKENS": "max_tokens"}
+
+
+class GeminiProvider:
+    """Google Gemini provider for cloud-based fragment classification (#608).
+
+    Sends prompts to the Gemini ``generate_content`` API via the current
+    ``google-genai`` SDK (``from google import genai``). The API key is read by
+    the SDK from ``GOOGLE_API_KEY`` or ``GEMINI_API_KEY`` and is never stored in
+    config, logs, or error messages. Structure mirrors :class:`OpenAIProvider`
+    and :class:`AnthropicProvider` so the providers stay legible.
+
+    Attributes:
+        config: The LLM configuration specifying model, batch size, etc.
+    """
+
+    is_cloud: bool = True
+    """Gemini sends fragment content off-device; gated by consent."""
+
+    PROVIDER_NAME: str = "Gemini"
+    """Display name woven into consent and cloud-egress messages."""
+
+    DEFAULT_MODEL: str = "gemini-2.5-flash"
+    """Default Gemini model when the config does not override it."""
+
+    API_KEY_ENVS: tuple[str, ...] = ("GOOGLE_API_KEY", "GEMINI_API_KEY")
+    """Environment variables the SDK reads for the key; either suffices."""
+
+    MAX_TOKENS: int = 1024
+    """Maximum output tokens requested from the Gemini API per call."""
+
+    _OLLAMA_DEFAULT_MODEL: str = "mistral"
+    """The ``LLMConfig`` default model name (indicates no Gemini override)."""
+
+    def __init__(self, config: LLMConfig) -> None:
+        """Validate environment prerequisites and prepare the client.
+
+        The SDK client is instantiated lazily on first use. The cloud-egress
+        consent gate is shared with every cloud provider (#606).
+
+        Args:
+            config: LLM provider configuration.
+
+        Raises:
+            RuntimeError: If no key variable is set or cloud consent is missing.
+        """
+        self.config = config
+        unmet = self._missing_prerequisite()
+        if unmet is not None:
+            raise RuntimeError(unmet)
+        self._client: genai.Client | None = None
+
+    @classmethod
+    def _missing_prerequisite(cls) -> str | None:
+        """Return why the Gemini prerequisites are unmet, or ``None``.
+
+        Requires one of :attr:`API_KEY_ENVS` plus the shared cloud consent;
+        both are read from the environment at call time so :attr:`available`
+        reflects the live env.
+
+        Returns:
+            A human-readable explanation when no key is present or consent is
+            not affirmative; ``None`` when both prerequisites are satisfied.
+        """
+        if not any(os.environ.get(var, "").strip() for var in cls.API_KEY_ENVS):
+            joined = " or ".join(cls.API_KEY_ENVS)
+            return f"Neither {joined} is set; one is required for the Gemini provider."
+        if not has_cloud_consent():
+            return consent_error_message(cls.PROVIDER_NAME)
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Whether the Gemini prerequisites (a key + consent) are met.
+
+        Returns:
+            ``True`` when a key variable is set and cloud consent is affirmative.
+        """
+        return self._missing_prerequisite() is None
+
+    @property
+    def model(self) -> str:
+        """The Gemini model identifier to use for API calls.
+
+        Falls back to :attr:`DEFAULT_MODEL` when ``config.model`` still holds
+        the Ollama default (``"mistral"``) or is empty.
+
+        Returns:
+            The resolved model identifier.
+        """
+        model = self.config.model.strip()
+        if not model or model == self._OLLAMA_DEFAULT_MODEL:
+            return self.DEFAULT_MODEL
+        return model
+
+    @property
+    def client(self) -> genai.Client:
+        """The lazily-initialised ``google-genai`` client.
+
+        The SDK reads ``GOOGLE_API_KEY`` / ``GEMINI_API_KEY`` itself.
+
+        Returns:
+            A ``google.genai.Client`` instance.
+        """
+        if self._client is None:
+            from google import genai
+
+            self._client = genai.Client()
+        return self._client
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int | None = None,
+        system: str | None = None,
+    ) -> Completion:
+        """Send *prompt* to Gemini and return a normalized :class:`Completion`.
+
+        Args:
+            prompt: The dynamic, fully-formatted user prompt.
+            max_tokens: Maximum output tokens. ``None`` keeps the historical
+                :attr:`MAX_TOKENS` ceiling.
+            system: Optional system instruction. ``None`` sends none.
+
+        Returns:
+            A :class:`Completion` carrying the response text, the mapped stop
+            reason, and token usage when present.
+
+        Raises:
+            RuntimeError: If the SDK raises any ``APIError``; re-raised with
+                only the exception type name so no request state leaks.
+        """
+        from google.genai import errors
+
+        ceiling = self.MAX_TOKENS if max_tokens is None else max_tokens
+        try:
+            response = self._generate(prompt, ceiling, system)
+        except errors.APIError as exc:
+            msg = f"Gemini API call failed: {type(exc).__name__}"
+            raise RuntimeError(msg) from None
+        return Completion(
+            text=_extract_gemini_text(response),
+            stop_reason=_map_gemini_stop_reason(response),
+            usage=_extract_gemini_usage(response),
+        )
+
+    def _generate(self, prompt: str, ceiling: int, system: str | None) -> object:
+        """Call ``models.generate_content`` with a configured generation request.
+
+        Args:
+            prompt: The dynamic user prompt sent as ``contents``.
+            ceiling: The resolved ``max_output_tokens`` value.
+            system: Optional system instruction, or ``None``.
+
+        Returns:
+            The raw ``generate_content`` response object.
+        """
+        from google.genai import types
+
+        config = types.GenerateContentConfig(
+            max_output_tokens=ceiling,
+            system_instruction=system,
+        )
+        return self.client.models.generate_content(
+            model=self.model,
+            contents=prompt,
+            config=config,
+        )
+
+
+def _extract_gemini_text(response: object) -> str:
+    """Concatenate the textual parts of a Gemini response's first candidate.
+
+    Args:
+        response: A ``generate_content`` response object.
+
+    Returns:
+        The joined ``text`` of each content part, or ``""`` when absent.
+    """
+    candidates = getattr(response, "candidates", None) or []
+    if not candidates:
+        return ""
+    content = getattr(candidates[0], "content", None)
+    parts = getattr(content, "parts", None) or []
+    out: list[str] = []
+    for part in parts:
+        text = getattr(part, "text", None)
+        if isinstance(text, str):
+            out.append(text)
+    return "".join(out)
+
+
+def _map_gemini_stop_reason(response: object) -> str:
+    """Map a Gemini ``finish_reason`` to a normalized stop reason.
+
+    Accepts both the SDK's ``FinishReason`` enum (via ``.name``) and a plain
+    string.
+
+    Args:
+        response: A ``generate_content`` response object.
+
+    Returns:
+        ``"end_turn"`` for ``STOP`` (and unknown/absent reasons),
+        ``"max_tokens"`` for ``MAX_TOKENS``.
+    """
+    candidates = getattr(response, "candidates", None) or []
+    if not candidates:
+        return "end_turn"
+    reason = getattr(candidates[0], "finish_reason", None)
+    if reason is None:
+        return "end_turn"
+    name = getattr(reason, "name", None)
+    key = name if isinstance(name, str) else str(reason)
+    return _GEMINI_STOP_REASONS.get(key, "end_turn")
+
+
+def _extract_gemini_usage(response: object) -> dict[str, int] | None:
+    """Extract integer token-usage counts from a Gemini response.
+
+    Args:
+        response: A ``generate_content`` response object.
+
+    Returns:
+        A dict with ``input_tokens`` / ``output_tokens`` mirroring the other
+        providers' usage shape, or ``None`` when the SDK omitted usage.
+    """
+    usage = getattr(response, "usage_metadata", None)
+    if usage is None:
+        return None
+    counts: dict[str, int] = {}
+    prompt_tokens = getattr(usage, "prompt_token_count", None)
+    candidate_tokens = getattr(usage, "candidates_token_count", None)
+    if isinstance(prompt_tokens, int):
+        counts["input_tokens"] = prompt_tokens
+    if isinstance(candidate_tokens, int):
+        counts["output_tokens"] = candidate_tokens
+    return counts or None
+
+
 #: Registry mapping the ``LLMConfig.provider`` string to its provider class.
-#: Adding a backend (Gemini #608) is a one-line entry here. The value is the
-#: concrete class (not the ``LLMProvider`` protocol) so it is both
-#: constructible and exposes the class-level ``is_cloud`` flag; widen the union
-#: as new providers land.
+#: The value is the concrete class (not the ``LLMProvider`` protocol) so it is
+#: both constructible and exposes the class-level ``is_cloud`` flag; widen the
+#: union as new providers land.
 _PROVIDER_REGISTRY: dict[
-    str, type[AnthropicProvider | OllamaProvider | OpenAIProvider]
+    str,
+    type[AnthropicProvider | OllamaProvider | OpenAIProvider | GeminiProvider],
 ] = {
     "anthropic": AnthropicProvider,
     "ollama": OllamaProvider,
     "openai": OpenAIProvider,
+    "gemini": GeminiProvider,
 }
 
 

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -45,6 +45,7 @@ creek-tools-mcp = "creek_mcp.server:main"
 [project.optional-dependencies]
 anthropic = ["anthropic>=0.40.0"]
 openai = ["openai>=1.0"]
+gemini = ["google-genai>=1.0"]
 embeddings = [
     "sentence-transformers>=2.2.0",
     "numpy>=2.4.4",
@@ -69,7 +70,7 @@ gdrive = [
 all = [
     # Self-referential extras (pip >= 21.2). Adding a new sub-extra
     # automatically flows into [all] without manual duplication.
-    "creek-tools[anthropic,openai,embeddings,ocr,documents,spreadsheets,presentations,gdrive]",
+    "creek-tools[anthropic,openai,gemini,embeddings,ocr,documents,spreadsheets,presentations,gdrive]",
 ]
 dev = [
     # `tests/conftest.py` imports numpy, `tests/test_classify.py` mocks

--- a/creek-tools/tests/test_gemini_provider.py
+++ b/creek-tools/tests/test_gemini_provider.py
@@ -1,0 +1,225 @@
+"""Tests for the synchronous GeminiProvider (#608).
+
+The ``google-genai`` SDK is mocked throughout — no live calls. Covers the
+consent + key gate (either ``GOOGLE_API_KEY`` or ``GEMINI_API_KEY``), model
+resolution, the ``generate_content`` call, ``finish_reason`` and usage mapping,
+error redaction, and a mocked end-to-end classify call.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from creek.classify.llm.base import LLMProvider
+from creek.classify.llm.completion import Completion
+from creek.classify.llm.consent import CLOUD_CONSENT_ENV, LEGACY_CONSENT_ENV
+from creek.classify.llm.providers import (
+    GeminiProvider,
+    build_provider,
+    provider_is_cloud,
+)
+from creek.config import LLMConfig
+
+_KEY_VARS = ("GOOGLE_API_KEY", "GEMINI_API_KEY")
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each test with no consent and no Gemini key variables set."""
+    monkeypatch.delenv(CLOUD_CONSENT_ENV, raising=False)
+    monkeypatch.delenv(LEGACY_CONSENT_ENV, raising=False)
+    for var in _KEY_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.fixture
+def gemini_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set GOOGLE_API_KEY and cloud consent so a GeminiProvider constructs."""
+    monkeypatch.setenv("GOOGLE_API_KEY", "g-not-real")
+    monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+
+
+def _make_mock_genai_client(
+    text: str,
+    *,
+    finish_reason: object = "STOP",
+    prompt_tokens: int = 12,
+    candidate_tokens: int = 8,
+) -> MagicMock:
+    """Build a mock ``genai.Client`` returning one generate_content response."""
+    part = MagicMock()
+    part.text = text
+    content = MagicMock()
+    content.parts = [part]
+    candidate = MagicMock()
+    candidate.content = content
+    candidate.finish_reason = finish_reason
+    usage = MagicMock()
+    usage.prompt_token_count = prompt_tokens
+    usage.candidates_token_count = candidate_tokens
+    response = MagicMock()
+    response.candidates = [candidate]
+    response.usage_metadata = usage
+    client = MagicMock()
+    client.models.generate_content.return_value = response
+    return client
+
+
+class TestGeminiConstruction:
+    """Consent + API-key gate at construction."""
+
+    def test_raises_when_no_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Neither key var set → RuntimeError mentioning the key vars."""
+        monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+        with pytest.raises(RuntimeError, match=r"GOOGLE_API_KEY|GEMINI_API_KEY"):
+            GeminiProvider(LLMConfig(provider="gemini"))
+
+    def test_constructs_with_google_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``GOOGLE_API_KEY`` satisfies the key requirement."""
+        monkeypatch.setenv("GOOGLE_API_KEY", "g-not-real")
+        monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+        assert GeminiProvider(LLMConfig(provider="gemini")).available is True
+
+    def test_constructs_with_gemini_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The alternate ``GEMINI_API_KEY`` also satisfies the requirement."""
+        monkeypatch.setenv("GEMINI_API_KEY", "g-not-real")
+        monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+        assert GeminiProvider(LLMConfig(provider="gemini")).available is True
+
+    def test_raises_when_consent_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Key present but no consent → RuntimeError naming Gemini."""
+        monkeypatch.setenv("GOOGLE_API_KEY", "g-not-real")
+        with pytest.raises(RuntimeError, match="Gemini"):
+            GeminiProvider(LLMConfig(provider="gemini"))
+
+    def test_is_cloud_and_provider_name(self, gemini_env: None) -> None:
+        """Gemini is a cloud backend with a display name."""
+        provider = GeminiProvider(LLMConfig(provider="gemini"))
+        assert provider.is_cloud is True
+        assert provider.PROVIDER_NAME == "Gemini"
+
+
+class TestGeminiFactoryRegistration:
+    """The factory knows the gemini backend."""
+
+    def test_build_provider_returns_gemini(self, gemini_env: None) -> None:
+        """``build_provider`` constructs a GeminiProvider for 'gemini'."""
+        provider = build_provider(LLMConfig(provider="gemini"))
+        assert isinstance(provider, GeminiProvider)
+        assert isinstance(provider, LLMProvider)
+
+    def test_provider_is_cloud_gemini(self) -> None:
+        """'gemini' is registered as a cloud provider (no instantiation)."""
+        assert provider_is_cloud("gemini") is True
+
+
+class TestGeminiModelResolution:
+    """Model resolution mirrors the other providers."""
+
+    def test_default_model_literal(self) -> None:
+        """The default Gemini model literal lives on the provider."""
+        assert GeminiProvider.DEFAULT_MODEL == "gemini-2.5-flash"
+
+    def test_falls_back_from_ollama_default(self, gemini_env: None) -> None:
+        """The Ollama default ``mistral`` falls back to the Gemini default."""
+        provider = GeminiProvider(LLMConfig(provider="gemini"))
+        assert provider.model == GeminiProvider.DEFAULT_MODEL
+
+    def test_honors_explicit_model(self, gemini_env: None) -> None:
+        """An explicit config model is honoured."""
+        provider = GeminiProvider(LLMConfig(provider="gemini", model="gemini-x"))
+        assert provider.model == "gemini-x"
+
+
+class TestGeminiComplete:
+    """The complete() call against a mocked SDK."""
+
+    def test_complete_returns_completion(self, gemini_env: None) -> None:
+        """A successful call normalizes to a populated Completion."""
+        client = _make_mock_genai_client("hi gemini")
+        with patch("google.genai.Client", return_value=client):
+            provider = GeminiProvider(LLMConfig(provider="gemini"))
+            result = provider.complete("a prompt")
+        assert isinstance(result, Completion)
+        assert result.text == "hi gemini"
+        assert result.stop_reason == "end_turn"
+        assert result.usage == {"input_tokens": 12, "output_tokens": 8}
+
+    def test_complete_calls_generate_content(self, gemini_env: None) -> None:
+        """The SDK is called with the resolved model and the prompt contents."""
+        client = _make_mock_genai_client("x")
+        with patch("google.genai.Client", return_value=client):
+            provider = GeminiProvider(LLMConfig(provider="gemini"))
+            provider.complete("the prompt")
+        kwargs = client.models.generate_content.call_args.kwargs
+        assert kwargs["model"] == GeminiProvider.DEFAULT_MODEL
+        assert kwargs["contents"] == "the prompt"
+
+    def test_complete_maps_max_tokens_string(self, gemini_env: None) -> None:
+        """A string ``MAX_TOKENS`` finish reason maps to ``max_tokens``."""
+        client = _make_mock_genai_client("cut", finish_reason="MAX_TOKENS")
+        with patch("google.genai.Client", return_value=client):
+            provider = GeminiProvider(LLMConfig(provider="gemini"))
+            assert provider.complete("p").stop_reason == "max_tokens"
+
+    def test_complete_maps_enum_finish_reason(self, gemini_env: None) -> None:
+        """An enum finish reason (``.name``) maps correctly too."""
+        from google.genai.types import FinishReason
+
+        client = _make_mock_genai_client("ok", finish_reason=FinishReason.STOP)
+        with patch("google.genai.Client", return_value=client):
+            provider = GeminiProvider(LLMConfig(provider="gemini"))
+            assert provider.complete("p").stop_reason == "end_turn"
+
+    def test_complete_threads_max_tokens_into_config(self, gemini_env: None) -> None:
+        """An explicit max_tokens flows into the generation config."""
+        client = _make_mock_genai_client("x")
+        with patch("google.genai.Client", return_value=client):
+            provider = GeminiProvider(LLMConfig(provider="gemini"))
+            provider.complete("p", max_tokens=321)
+        config = client.models.generate_content.call_args.kwargs["config"]
+        assert config.max_output_tokens == 321
+
+    def test_complete_passes_system_instruction(self, gemini_env: None) -> None:
+        """A system prefix flows into the config's system_instruction."""
+        client = _make_mock_genai_client("x")
+        with patch("google.genai.Client", return_value=client):
+            provider = GeminiProvider(LLMConfig(provider="gemini"))
+            provider.complete("p", system="be terse")
+        config = client.models.generate_content.call_args.kwargs["config"]
+        assert config.system_instruction == "be terse"
+
+    def test_complete_redacts_sdk_errors(self, gemini_env: None) -> None:
+        """SDK errors surface only the exception type name, not request state."""
+        from google.genai import errors
+
+        client = MagicMock()
+        client.models.generate_content.side_effect = errors.APIError(
+            503, {"error": {"message": "secret request payload"}}
+        )
+        with patch("google.genai.Client", return_value=client):
+            provider = GeminiProvider(LLMConfig(provider="gemini"))
+            with pytest.raises(RuntimeError) as exc:
+                provider.complete("p")
+        message = str(exc.value)
+        assert "APIError" in message
+        assert "secret" not in message
+
+
+def test_gemini_end_to_end_classify(gemini_env: None) -> None:
+    """A mocked end-to-end classify via provider=gemini returns a Completion."""
+    from creek.classify.llm.orchestrator import LLMClassifier
+
+    client = _make_mock_genai_client("response body")
+    with patch("google.genai.Client", return_value=client):
+        classifier = LLMClassifier(config=LLMConfig(provider="gemini"))
+        completion = classifier.invoke_prompt_with_metadata("classify this")
+    assert isinstance(completion, Completion)
+    assert completion.text == "response body"
+    assert completion.usage == {"input_tokens": 12, "output_tokens": 8}

--- a/creek-tools/uv.lock
+++ b/creek-tools/uv.lock
@@ -543,6 +543,7 @@ all = [
     { name = "anthropic" },
     { name = "google-api-python-client" },
     { name = "google-auth-oauthlib" },
+    { name = "google-genai" },
     { name = "markdownify" },
     { name = "numpy" },
     { name = "openai" },
@@ -565,6 +566,7 @@ dev = [
     { name = "detect-secrets" },
     { name = "google-api-python-client" },
     { name = "google-auth-oauthlib" },
+    { name = "google-genai" },
     { name = "hypothesis" },
     { name = "interrogate" },
     { name = "lxml-stubs" },
@@ -615,6 +617,9 @@ gdrive = [
     { name = "google-api-python-client" },
     { name = "google-auth-oauthlib" },
 ]
+gemini = [
+    { name = "google-genai" },
+]
 ocr = [
     { name = "pdf2image" },
     { name = "pillow" },
@@ -636,10 +641,11 @@ requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.9.4,<2" },
     { name = "chardet", specifier = ">=7.4.3" },
     { name = "creek-tools", extras = ["all"], marker = "extra == 'dev'" },
-    { name = "creek-tools", extras = ["anthropic", "openai", "embeddings", "ocr", "documents", "spreadsheets", "presentations", "gdrive"], marker = "extra == 'all'" },
+    { name = "creek-tools", extras = ["anthropic", "openai", "gemini", "embeddings", "ocr", "documents", "spreadsheets", "presentations", "gdrive"], marker = "extra == 'all'" },
     { name = "detect-secrets", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "google-api-python-client", marker = "extra == 'gdrive'", specifier = ">=2.0" },
     { name = "google-auth-oauthlib", marker = "extra == 'gdrive'", specifier = ">=1.0" },
+    { name = "google-genai", marker = "extra == 'gemini'", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.92.0" },
     { name = "idna", specifier = ">=3.15" },
@@ -687,7 +693,7 @@ requires-dist = [
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.10" },
     { name = "xenon", marker = "extra == 'dev'", specifier = ">=0.9.0" },
 ]
-provides-extras = ["anthropic", "openai", "embeddings", "ocr", "documents", "spreadsheets", "presentations", "gdrive", "all", "dev"]
+provides-extras = ["anthropic", "openai", "gemini", "embeddings", "ocr", "documents", "spreadsheets", "presentations", "gdrive", "all", "dev"]
 
 [[package]]
 name = "cryptography"
@@ -971,6 +977,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
 ]
 
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
 [[package]]
 name = "google-auth-httplib2"
 version = "0.4.0"
@@ -995,6 +1006,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/70/18/90c7fac516e63cf2058166fce0c88c353647c677b51cc036c09c49bb5cbb/google_auth_oauthlib-1.4.0.tar.gz", hash = "sha256:18b5e28880eb8eba9065c436becdc0ee8e4b59117a73a510679c82f70cd363d2", size = 21675, upload-time = "2026-05-07T08:03:47.816Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/d3/d7dff0d58a9e9244b48044bfb6a898bfcc8ecc42e0031d1bebc695344725/google_auth_oauthlib-1.4.0-py3-none-any.whl", hash = "sha256:251314f213a9ee46a5ae73988e84fd7cca8bb68e7ecf4bfd45940f9e7f51d070", size = 19261, upload-time = "2026-05-07T08:02:13.798Z" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/52/0244e310812f3063d09d60b30ae29ab7df9343bd005744cd5eeaa6ba39b4/google_genai-2.8.0.tar.gz", hash = "sha256:37a9b3cb127d763e7f4ca47452ae3562c87728773bd1b149f7b559c239da2bc1", size = 564955, upload-time = "2026-06-03T22:55:38.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/de/747ad1aa49e902da9a4699081c282a1ed8ceed3b4d295fd99a6d286e09e4/google_genai-2.8.0-py3-none-any.whl", hash = "sha256:4da0a223a100f4b37f609a68b835e3326ab0fa313314dc0fd9d34e76ee293844", size = 832497, upload-time = "2026-06-03T22:55:36.598Z" },
 ]
 
 [[package]]
@@ -3447,6 +3479,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "threadpoolctl"
 version = "3.6.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3805,6 +3846,65 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/db/de907251b4ff46ae804ad0409809504153b3f30984daf82a1d84a9875830/websockets-16.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:31a52addea25187bde0797a97d6fc3d2f92b6f72a9370792d65a6e84615ac8a8", size = 177340, upload-time = "2026-01-10T09:22:34.539Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/fa/abe89019d8d8815c8781e90d697dec52523fb8ebe308bf11664e8de1877e/websockets-16.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:417b28978cdccab24f46400586d128366313e8a96312e4b9362a4af504f3bbad", size = 175022, upload-time = "2026-01-10T09:22:36.332Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5d/88ea17ed1ded2079358b40d31d48abe90a73c9e5819dbcde1606e991e2ad/websockets-16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:af80d74d4edfa3cb9ed973a0a5ba2b2a549371f8a741e0800cb07becdd20f23d", size = 175319, upload-time = "2026-01-10T09:22:37.602Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ae/0ee92b33087a33632f37a635e11e1d99d429d3d323329675a6022312aac2/websockets-16.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:08d7af67b64d29823fed316505a89b86705f2b7981c07848fb5e3ea3020c1abe", size = 184631, upload-time = "2026-01-10T09:22:38.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/27178df583b6c5b31b29f526ba2da5e2f864ecc79c99dae630a85d68c304/websockets-16.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7be95cfb0a4dae143eaed2bcba8ac23f4892d8971311f1b06f3c6b78952ee70b", size = 185870, upload-time = "2026-01-10T09:22:39.893Z" },
+    { url = "https://files.pythonhosted.org/packages/87/05/536652aa84ddc1c018dbb7e2c4cbcd0db884580bf8e95aece7593fde526f/websockets-16.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d6297ce39ce5c2e6feb13c1a996a2ded3b6832155fcfc920265c76f24c7cceb5", size = 185361, upload-time = "2026-01-10T09:22:41.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/e2/d5332c90da12b1e01f06fb1b85c50cfc489783076547415bf9f0a659ec19/websockets-16.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1c1b30e4f497b0b354057f3467f56244c603a79c0d1dafce1d16c283c25f6e64", size = 184615, upload-time = "2026-01-10T09:22:42.442Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fb/d3f9576691cae9253b51555f841bc6600bf0a983a461c79500ace5a5b364/websockets-16.0-cp311-cp311-win32.whl", hash = "sha256:5f451484aeb5cafee1ccf789b1b66f535409d038c56966d6101740c1614b86c6", size = 178246, upload-time = "2026-01-10T09:22:43.654Z" },
+    { url = "https://files.pythonhosted.org/packages/54/67/eaff76b3dbaf18dcddabc3b8c1dba50b483761cccff67793897945b37408/websockets-16.0-cp311-cp311-win_amd64.whl", hash = "sha256:8d7f0659570eefb578dacde98e24fb60af35350193e4f56e11190787bee77dac", size = 178684, upload-time = "2026-01-10T09:22:44.941Z" },
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/72/07/c98a68571dcf256e74f1f816b8cc5eae6eb2d3d5cfa44d37f801619d9166/websockets-16.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:349f83cd6c9a415428ee1005cadb5c2c56f4389bc06a9af16103c3bc3dcc8b7d", size = 174947, upload-time = "2026-01-10T09:23:36.166Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/52/93e166a81e0305b33fe416338be92ae863563fe7bce446b0f687b9df5aea/websockets-16.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:4a1aba3340a8dca8db6eb5a7986157f52eb9e436b74813764241981ca4888f03", size = 175260, upload-time = "2026-01-10T09:23:37.409Z" },
+    { url = "https://files.pythonhosted.org/packages/56/0c/2dbf513bafd24889d33de2ff0368190a0e69f37bcfa19009ef819fe4d507/websockets-16.0-pp311-pypy311_pp73-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f4a32d1bd841d4bcbffdcb3d2ce50c09c3909fbead375ab28d0181af89fd04da", size = 176071, upload-time = "2026-01-10T09:23:39.158Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968, upload-time = "2026-01-10T09:23:41.031Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735, upload-time = "2026-01-10T09:23:42.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add a synchronous **GeminiProvider** so `provider: gemini` routes classification + author-desk calls to Google Gemini, with the key read from `GOOGLE_API_KEY` or `GEMINI_API_KEY` by the SDK. With this, **creek-tools is now fully swappable** across ollama / anthropic / openai / gemini — sequence 5/8 of epic #603.
- Mirrors the OpenAI/Anthropic providers: shared cloud-consent gate (#606) + either-key check in `__init__`; lazy `genai.Client()` via the current **`google-genai`** SDK (`from google import genai`); `DEFAULT_MODEL` literal (`gemini-2.5-flash`) with the `mistral` sentinel fallback; `complete()` calls `models.generate_content` with a `GenerateContentConfig` (`max_output_tokens` + `system_instruction`), redacts SDK errors to `RuntimeError(type(exc).__name__)`, and maps `finish_reason` (`STOP`→`end_turn`, `MAX_TOKENS`→`max_tokens`; handles both the enum and a string) + `prompt/candidates_token_count`→`input/output_tokens` into a normalized `Completion`.
- Registered `"gemini"` in `build_provider`; added the `[gemini]` extra (`google-genai>=1.0`) flowed into `[all]`; regenerated `uv.lock` (google-genai 2.8.0).

**Resolves the #607-review `api_base` flag:** Gemini's `genai.Client()` takes no OpenAI-style `base_url`, so `LLMConfig.api_base` stays OpenAI-specific and Gemini ignores it — no silent collision. Per-provider config semantics will be documented in epic child #611.

**Security:** key only from env — never logged, never on a config field; SDK errors surface only the exception type name.

## Test plan

- New `tests/test_gemini_provider.py` (18 cases, SDK fully mocked — no live calls): no-key → `RuntimeError`; constructs with **either** `GOOGLE_API_KEY` or `GEMINI_API_KEY`; consent enforced (names Gemini); factory returns `GeminiProvider`; model resolution; `complete` → populated `Completion`; `finish_reason` mapping (string **and** real `FinishReason` enum); usage mapping; `max_tokens` + `system` into the config; **error redaction** (no request state leaks); and a mocked **end-to-end classify** via `provider=gemini`.
- `./scripts/check-all.sh` → exit 0 (all 12 gates; 5429 unit tests; 93.79% coverage; mypy strict; ruff; bandit + pip-audit clean with the new dep; uv.lock consistency).

Closes #608
Refs #603
