### PR TITLE
refactor(crawdad): async provider abstraction + factory (Anthropic only) (#609)

### DIFF
--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -14,8 +14,6 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import anthropic
-
 from crawdad.bot import CrawDadClient
 from crawdad.composer import SonnetComposer
 from crawdad.config import (
@@ -26,6 +24,7 @@ from crawdad.config import (
 from crawdad.consent import PendingBatchStore
 from crawdad.history import ConversationHistory
 from crawdad.intents import ToolInfo
+from crawdad.llm import build_async_provider
 from crawdad.loop import run_one_turn
 from crawdad.mcp_client import MCPClient, MCPUnavailableError
 from crawdad.router import IntentRouter
@@ -326,7 +325,7 @@ def _build_agent_components(
             known_tools=known_tools,
             history=history,
         )
-    anthropic_client = anthropic.AsyncAnthropic(api_key=config.anthropic_api_key)
+    provider = build_async_provider(config)
     router_tools = [
         ToolInfo(
             name=tool.name,
@@ -336,12 +335,12 @@ def _build_agent_components(
         for tool in tool_details
     ]
     router = IntentRouter(
-        anthropic_client=anthropic_client,
+        provider=provider,
         model=DEFAULT_ROUTER_MODEL,
         tools=router_tools,
     )
     composer = SonnetComposer(
-        anthropic_client=anthropic_client,
+        provider=provider,
         model=DEFAULT_COMPOSER_MODEL,
     )
     return _AgentComponents(

--- a/crawdad/crawdad/composer.py
+++ b/crawdad/crawdad/composer.py
@@ -31,13 +31,12 @@ documented soft reply rather than crashing ``on_message``.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
-
-import anthropic
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from crawdad.dispatcher import ToolResult
     from crawdad.history import ConversationHistory
+    from crawdad.llm.base import AsyncLLMProvider
     from crawdad.skill_loader import VoiceSkillStack
     from crawdad.state import SessionState
 
@@ -164,21 +163,21 @@ class SonnetComposer:
     def __init__(
         self,
         *,
-        anthropic_client: Any,
+        provider: AsyncLLMProvider,
         model: str,
         max_tokens: int = 1024,
     ) -> None:
-        """Store the injected client and model identifier.
+        """Store the injected provider and model identifier.
 
         Args:
-            anthropic_client: An :class:`anthropic.AsyncAnthropic`
-                instance (or a test double with the same shape).
+            provider: An :class:`~crawdad.llm.base.AsyncLLMProvider`
+                instance (or a test double with the same ``complete`` shape).
             model: The Sonnet model identifier — resolved from
                 :data:`crawdad.config.DEFAULT_COMPOSER_MODEL` by the
                 caller, NEVER a literal in this module.
             max_tokens: Hard cap on the composer's reply length.
         """
-        self._client = anthropic_client
+        self._provider = provider
         self._model = model
         self._max_tokens = max_tokens
 
@@ -205,29 +204,17 @@ class SonnetComposer:
             skills=skills,
         )
         try:
-            response = await self._client.messages.create(
+            completion = await self._provider.complete(
+                [{"role": "user", "content": prompt}],
                 model=self._model,
                 max_tokens=self._max_tokens,
-                messages=[{"role": "user", "content": prompt}],
             )
-        except anthropic.AnthropicError as exc:
-            _LOGGER.warning(
-                "Sonnet composer call failed: %s: %r", type(exc).__name__, exc
-            )
-            msg = f"Sonnet composer call failed: {type(exc).__name__}"
+        except RuntimeError as exc:
+            _LOGGER.warning("Sonnet composer call failed: %s", exc)
+            msg = f"Sonnet composer call failed: {exc}"
             raise ComposerFailureError(msg) from exc
-        reply = _extract_text(response)
+        reply = completion.text
         if not reply.strip():
             msg = "Sonnet composer returned an empty body"
             raise ComposerFailureError(msg)
         return reply
-
-
-def _extract_text(response: Any) -> str:
-    """Pull the concatenated text from a (possibly multi-block) reply."""
-    parts: list[str] = []
-    for block in getattr(response, "content", []) or []:
-        text = getattr(block, "text", None)
-        if text is not None:
-            parts.append(str(text))
-    return "\n".join(parts)

--- a/crawdad/crawdad/llm/__init__.py
+++ b/crawdad/crawdad/llm/__init__.py
@@ -1,0 +1,44 @@
+"""CrawDad's async LLM provider seam (#609).
+
+Exposes the provider-neutral :class:`AsyncLLMProvider` protocol and
+:class:`Completion` shape, the Anthropic implementation, and the
+:func:`build_async_provider` factory the CLI uses to wire the router and
+composer to a backend. Anthropic is the only provider for now; #610 registers
+OpenAI and Gemini here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from crawdad.llm.anthropic import AnthropicAsyncProvider
+from crawdad.llm.base import AsyncLLMProvider, Completion
+
+if TYPE_CHECKING:
+    from crawdad.config import CrawDadConfig
+
+__all__ = [
+    "AnthropicAsyncProvider",
+    "AsyncLLMProvider",
+    "Completion",
+    "build_async_provider",
+]
+
+
+def build_async_provider(config: CrawDadConfig) -> AsyncLLMProvider:
+    """Construct the async LLM provider selected by *config*.
+
+    The single place CrawDad chooses a backend; Anthropic only for now. The
+    API key is read from ``config.anthropic_api_key`` and handed to the SDK,
+    never logged.
+
+    Args:
+        config: The loaded CrawDad configuration.
+
+    Returns:
+        An :class:`AsyncLLMProvider` ready to back the router and composer.
+    """
+    import anthropic
+
+    client = anthropic.AsyncAnthropic(api_key=config.anthropic_api_key)
+    return AnthropicAsyncProvider(client)

--- a/crawdad/crawdad/llm/anthropic.py
+++ b/crawdad/crawdad/llm/anthropic.py
@@ -1,0 +1,91 @@
+"""The Anthropic async provider for CrawDad (#609).
+
+Wraps ``anthropic.AsyncAnthropic`` behind the :class:`AsyncLLMProvider`
+protocol, owning the ``messages.create`` call shape and the
+``AnthropicError`` → ``RuntimeError(type name)`` redaction that previously
+lived inline in the router and composer. No model identifier is referenced
+here — callers pass the resolved model (see ``tests/test_no_model_literals.py``).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
+
+import anthropic
+
+from crawdad.llm.base import Completion
+
+if TYPE_CHECKING:
+    from anthropic.types import MessageParam
+
+
+class AnthropicAsyncProvider:
+    """An :class:`~crawdad.llm.base.AsyncLLMProvider` backed by Anthropic.
+
+    Attributes:
+        _client: The injected ``anthropic.AsyncAnthropic`` client (or a test
+            double with the same ``messages.create`` shape).
+    """
+
+    def __init__(self, client: anthropic.AsyncAnthropic) -> None:
+        """Store the async Anthropic client this provider delegates to.
+
+        Args:
+            client: An ``anthropic.AsyncAnthropic`` instance.
+        """
+        self._client = client
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        max_tokens: int,
+    ) -> Completion:
+        """Send *messages* to Anthropic and return a normalized completion.
+
+        Args:
+            messages: The chat messages payload.
+            model: The resolved model identifier.
+            max_tokens: Hard cap on the reply length.
+
+        Returns:
+            A :class:`Completion` wrapping the concatenated response text and
+            the reported stop reason.
+
+        Raises:
+            RuntimeError: If the SDK raises any ``AnthropicError``; re-raised
+                with only the exception type name so no request state leaks.
+        """
+        try:
+            response = await self._client.messages.create(
+                model=model,
+                max_tokens=max_tokens,
+                # Bridge the provider-neutral messages shape to the SDK's typed
+                # param at the vendor boundary; callers build role/content dicts.
+                messages=cast("list[MessageParam]", messages),
+            )
+        except anthropic.AnthropicError as exc:
+            raise RuntimeError(type(exc).__name__) from None
+        stop_reason = getattr(response, "stop_reason", None) or "end_turn"
+        return Completion(
+            text=_extract_text(response),
+            stop_reason=str(stop_reason),
+        )
+
+
+def _extract_text(response: Any) -> str:
+    """Pull the concatenated text from a (possibly multi-block) reply.
+
+    Args:
+        response: A ``messages.create`` response object.
+
+    Returns:
+        The joined ``text`` of each content block.
+    """
+    parts: list[str] = []
+    for block in getattr(response, "content", []) or []:
+        text = getattr(block, "text", None)
+        if text is not None:
+            parts.append(str(text))
+    return "\n".join(parts)

--- a/crawdad/crawdad/llm/base.py
+++ b/crawdad/crawdad/llm/base.py
@@ -1,0 +1,65 @@
+"""The async, provider-neutral contract for CrawDad's LLM backends (#609).
+
+CrawDad stays decoupled from ``creek-tools`` (FEAT-013): this module deliberately
+mirrors creek-tools' normalized ``Completion`` shape and provider protocol
+*without* importing anything from it. The contract is **async** here (CrawDad is
+discord.py + MCP) whereas creek-tools' sibling is synchronous.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class Completion:
+    """A model completion paired with its stop reason and token usage.
+
+    Mirrors the creek-tools normalized result so both packages speak the same
+    shape across the MCP boundary, without sharing a module.
+
+    Attributes:
+        text: The concatenated textual content of the response.
+        stop_reason: Why the model stopped. ``"end_turn"`` on a clean
+            completion; ``"max_tokens"`` when the ceiling was hit.
+        usage: Token-usage counts from the SDK response when available, or
+            ``None`` when the SDK omitted usage.
+    """
+
+    text: str
+    stop_reason: str = "end_turn"
+    usage: dict[str, int] | None = None
+
+
+@runtime_checkable
+class AsyncLLMProvider(Protocol):
+    """An asynchronous, provider-neutral chat-completion backend.
+
+    Implementations wrap a vendor SDK, hold the request/response shape and the
+    error redaction, and turn a messages list into a normalized
+    :class:`Completion`. Routing through this protocol lets the router and
+    composer stay backend-agnostic (Anthropic today; #610 adds more).
+    """
+
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        max_tokens: int,
+    ) -> Completion:
+        """Send *messages* and return the normalized :class:`Completion`.
+
+        Args:
+            messages: The chat messages payload (``role`` / ``content`` dicts).
+            model: The resolved model identifier (never a literal in callers).
+            max_tokens: Hard cap on the reply length.
+
+        Returns:
+            The backend's :class:`Completion`.
+
+        Raises:
+            RuntimeError: On any SDK failure, re-raised with only the original
+                exception's type name so request state never leaks.
+        """

--- a/crawdad/crawdad/router.py
+++ b/crawdad/crawdad/router.py
@@ -29,9 +29,8 @@ from __future__ import annotations
 import json
 import logging
 import re
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import anthropic
 from pydantic import ValidationError
 
 from crawdad.intents import (
@@ -44,6 +43,7 @@ from crawdad.intents import (
 
 if TYPE_CHECKING:
     from crawdad.history import ConversationHistory
+    from crawdad.llm.base import AsyncLLMProvider
     from crawdad.state import SessionState
 
 _LOGGER = logging.getLogger("crawdad.router")
@@ -165,16 +165,16 @@ class IntentRouter:
     def __init__(
         self,
         *,
-        anthropic_client: Any,
+        provider: AsyncLLMProvider,
         model: str,
         tools: list[ToolInfo],
         max_tokens: int = 1024,
     ) -> None:
-        """Store the injected client and the cached tools schema.
+        """Store the injected provider and the cached tools schema.
 
         Args:
-            anthropic_client: An :class:`anthropic.AsyncAnthropic`
-                instance (or a test double with the same shape).
+            provider: An :class:`~crawdad.llm.base.AsyncLLMProvider`
+                instance (or a test double with the same ``complete`` shape).
             model: The Haiku model identifier — resolved from
                 :data:`crawdad.config.DEFAULT_ROUTER_MODEL` by the
                 caller, NEVER a literal in this module.
@@ -182,7 +182,7 @@ class IntentRouter:
                 session start by :meth:`MCPSession.list_tool_details`.
             max_tokens: Hard cap on the router's reply length.
         """
-        self._client = anthropic_client
+        self._provider = provider
         self._model = model
         self._tools = tools
         self._max_tokens = max_tokens
@@ -210,27 +210,16 @@ class IntentRouter:
             tools=self._tools,
         )
         try:
-            response = await self._client.messages.create(
+            completion = await self._provider.complete(
+                [{"role": "user", "content": prompt}],
                 model=self._model,
                 max_tokens=self._max_tokens,
-                messages=[{"role": "user", "content": prompt}],
             )
-        except anthropic.AnthropicError as exc:
-            _LOGGER.warning("Haiku API call failed: %s: %r", type(exc).__name__, exc)
-            msg = f"Haiku API call failed: {type(exc).__name__}"
+        except RuntimeError as exc:
+            _LOGGER.warning("Haiku API call failed: %s", exc)
+            msg = f"Haiku API call failed: {exc}"
             raise RouterParseError(msg) from exc
-        raw_text = _extract_text(response)
-        return _parse_router_payload(raw_text)
-
-
-def _extract_text(response: Any) -> str:
-    """Pull the concatenated text from a (possibly multi-block) reply."""
-    parts: list[str] = []
-    for block in getattr(response, "content", []) or []:
-        text = getattr(block, "text", None)
-        if text is not None:
-            parts.append(str(text))
-    return "\n".join(parts)
+        return _parse_router_payload(completion.text)
 
 
 def _parse_router_payload(raw: str) -> RouterResponse:

--- a/crawdad/tests/test_composer.py
+++ b/crawdad/tests/test_composer.py
@@ -13,6 +13,7 @@ from crawdad.composer import (
 )
 from crawdad.dispatcher import ToolResult
 from crawdad.history import ConversationHistory
+from crawdad.llm.base import Completion
 from crawdad.skill_loader import VoiceSkill, VoiceSkillStack
 from crawdad.state import SessionState
 
@@ -48,30 +49,27 @@ def tool_results() -> list[ToolResult]:
     ]
 
 
-class _FakeAnthropic:
-    """Minimal stand-in for ``anthropic.AsyncAnthropic``."""
+class _FakeProvider:
+    """Minimal ``AsyncLLMProvider`` double; returns a reply or raises."""
 
     def __init__(self, reply: str | Exception) -> None:
         self._reply = reply
         self.calls: list[dict[str, Any]] = []
-        self.messages = self
 
-    async def create(self, **kwargs: Any) -> Any:
-        self.calls.append(kwargs)
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        max_tokens: int,
+    ) -> Completion:
+        """Record the call and return a canned completion (or raise)."""
+        self.calls.append(
+            {"messages": messages, "model": model, "max_tokens": max_tokens}
+        )
         if isinstance(self._reply, Exception):
             raise self._reply
-        return _FakeResponse(self._reply)
-
-
-class _FakeResponse:
-    def __init__(self, text: str) -> None:
-        self.content = [_FakeBlock(text)]
-
-
-class _FakeBlock:
-    def __init__(self, text: str) -> None:
-        self.type = "text"
-        self.text = text
+        return Completion(text=self._reply)
 
 
 def test_build_composer_prompt_embeds_skills_and_results(
@@ -173,9 +171,9 @@ async def test_composer_returns_reply(
     tool_results: list[ToolResult],
 ) -> None:
     """A successful Sonnet call returns the model's text body."""
-    fake = _FakeAnthropic("Here's what's surfacing this week...")
+    fake = _FakeProvider("Here's what's surfacing this week...")
     composer = SonnetComposer(
-        anthropic_client=fake,  # type: ignore[arg-type]
+        provider=fake,
         model="claude-sonnet-test",
     )
 
@@ -195,9 +193,9 @@ async def test_composer_uses_configured_model(
     skills: VoiceSkillStack,
 ) -> None:
     """The injected model name is the one passed to the Anthropic SDK."""
-    fake = _FakeAnthropic("ok")
+    fake = _FakeProvider("ok")
     composer = SonnetComposer(
-        anthropic_client=fake,  # type: ignore[arg-type]
+        provider=fake,
         model="custom-sonnet-id",
     )
 
@@ -212,15 +210,17 @@ async def test_composer_uses_configured_model(
     assert fake.calls[0]["model"] == "custom-sonnet-id"
 
 
-async def test_composer_translates_anthropic_errors(
+async def test_composer_translates_provider_errors(
     session_state: SessionState, skills: VoiceSkillStack
 ) -> None:
-    """SDK errors surface as ``ComposerFailureError`` so the loop can recover."""
-    import anthropic
+    """Redacted provider errors surface as ``ComposerFailureError`` to recover.
 
-    fake = _FakeAnthropic(anthropic.AnthropicError("simulated rate-limit"))
+    The provider has already redacted the SDK failure to a ``RuntimeError``
+    carrying only the exception type name; the composer wraps it.
+    """
+    fake = _FakeProvider(RuntimeError("AnthropicError"))
     composer = SonnetComposer(
-        anthropic_client=fake,  # type: ignore[arg-type]
+        provider=fake,
         model="claude-sonnet-test",
     )
 
@@ -238,9 +238,9 @@ async def test_composer_handles_empty_response(
     session_state: SessionState, skills: VoiceSkillStack
 ) -> None:
     """A response with no text blocks raises ``ComposerFailureError``."""
-    fake = _FakeAnthropic("")
+    fake = _FakeProvider("")
     composer = SonnetComposer(
-        anthropic_client=fake,  # type: ignore[arg-type]
+        provider=fake,
         model="claude-sonnet-test",
     )
 

--- a/crawdad/tests/test_llm_provider.py
+++ b/crawdad/tests/test_llm_provider.py
@@ -1,0 +1,125 @@
+"""Tests for CrawDad's async LLM provider seam (#609).
+
+The Anthropic SDK is mocked throughout — no live calls. Covers the normalized
+``Completion`` shape, the ``AnthropicAsyncProvider`` request/response mapping
+and error redaction, and the ``build_async_provider`` factory.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from crawdad.llm import (
+    AnthropicAsyncProvider,
+    AsyncLLMProvider,
+    build_async_provider,
+)
+from crawdad.llm.base import Completion
+
+
+class _FakeMessages:
+    """Records the create kwargs and returns a canned response/exception."""
+
+    def __init__(self, result: Any) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._result = result
+
+    async def create(self, **kwargs: Any) -> Any:
+        """Record the call and return the canned result (or raise it)."""
+        self.calls.append(kwargs)
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+class _FakeAsyncClient:
+    """Minimal stand-in for ``anthropic.AsyncAnthropic``."""
+
+    def __init__(self, result: Any) -> None:
+        self.messages = _FakeMessages(result)
+
+
+def _response(text: str, *, stop_reason: str = "end_turn") -> SimpleNamespace:
+    """Build a fake messages response with one text block."""
+    block = SimpleNamespace(type="text", text=text)
+    return SimpleNamespace(content=[block], stop_reason=stop_reason)
+
+
+def test_completion_defaults() -> None:
+    """``Completion`` defaults to an end_turn stop reason and no usage."""
+    completion = Completion(text="hi")
+    assert completion.stop_reason == "end_turn"
+    assert completion.usage is None
+
+
+async def test_complete_returns_completion() -> None:
+    """A successful call maps the SDK reply to a normalized Completion."""
+    client = _FakeAsyncClient(_response("hello", stop_reason="max_tokens"))
+    provider = AnthropicAsyncProvider(client)  # type: ignore[arg-type]
+
+    result = await provider.complete(
+        [{"role": "user", "content": "hi"}], model="claude-x", max_tokens=64
+    )
+
+    assert isinstance(result, Completion)
+    assert result.text == "hello"
+    assert result.stop_reason == "max_tokens"
+    assert client.messages.calls[0]["model"] == "claude-x"
+    assert client.messages.calls[0]["max_tokens"] == 64
+
+
+async def test_complete_concatenates_blocks() -> None:
+    """Multiple content blocks are joined in order."""
+    response = SimpleNamespace(
+        content=[
+            SimpleNamespace(text="part-a"),
+            SimpleNamespace(text="part-b"),
+        ],
+        stop_reason="end_turn",
+    )
+    provider = AnthropicAsyncProvider(_FakeAsyncClient(response))  # type: ignore[arg-type]
+    result = await provider.complete([], model="m", max_tokens=1)
+    assert result.text == "part-a\npart-b"
+
+
+async def test_complete_defaults_stop_reason_when_absent() -> None:
+    """A missing stop reason defaults to end_turn."""
+    response = SimpleNamespace(content=[SimpleNamespace(text="x")], stop_reason=None)
+    provider = AnthropicAsyncProvider(_FakeAsyncClient(response))  # type: ignore[arg-type]
+    result = await provider.complete([], model="m", max_tokens=1)
+    assert result.stop_reason == "end_turn"
+
+
+async def test_complete_redacts_sdk_errors() -> None:
+    """``AnthropicError`` becomes ``RuntimeError`` carrying only the type name."""
+    import anthropic
+
+    client = _FakeAsyncClient(
+        anthropic.AnthropicError("secret request payload and key state")
+    )
+    provider = AnthropicAsyncProvider(client)  # type: ignore[arg-type]
+
+    with pytest.raises(RuntimeError) as exc:
+        await provider.complete([], model="m", max_tokens=1)
+    message = str(exc.value)
+    assert message == "AnthropicError"
+    assert "secret" not in message
+
+
+def test_provider_satisfies_protocol() -> None:
+    """``AnthropicAsyncProvider`` is a structural ``AsyncLLMProvider``."""
+    provider = AnthropicAsyncProvider(_FakeAsyncClient(_response("x")))  # type: ignore[arg-type]
+    assert isinstance(provider, AsyncLLMProvider)
+
+
+def test_build_async_provider_constructs_anthropic() -> None:
+    """The factory wires an AnthropicAsyncProvider with the configured key."""
+    config = SimpleNamespace(anthropic_api_key="sk-not-real")
+    with patch("anthropic.AsyncAnthropic") as mock_client_cls:
+        provider = build_async_provider(config)  # type: ignore[arg-type]
+    assert isinstance(provider, AnthropicAsyncProvider)
+    assert mock_client_cls.call_args.kwargs["api_key"] == "sk-not-real"

--- a/crawdad/tests/test_router.py
+++ b/crawdad/tests/test_router.py
@@ -14,6 +14,7 @@ from crawdad.intents import (
     PrivacyTierCeiling,
     ToolInfo,
 )
+from crawdad.llm.base import Completion
 from crawdad.router import (
     IntentRouter,
     RouterParseError,
@@ -52,28 +53,42 @@ def session_state() -> SessionState:
     )
 
 
-class _FakeAnthropic:
-    """Minimal stand-in for ``anthropic.AsyncAnthropic`` used in tests."""
+class _FakeProvider:
+    """Minimal ``AsyncLLMProvider`` double recording ``complete`` calls."""
 
     def __init__(self, response_text: str) -> None:
         self._response_text = response_text
         self.calls: list[dict[str, Any]] = []
-        self.messages = self  # so router can call client.messages.create
 
-    async def create(self, **kwargs: Any) -> Any:
-        self.calls.append(kwargs)
-        return _FakeResponse(self._response_text)
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        max_tokens: int,
+    ) -> Completion:
+        """Record the call and return a canned completion."""
+        self.calls.append(
+            {"messages": messages, "model": model, "max_tokens": max_tokens}
+        )
+        return Completion(text=self._response_text)
 
 
-class _FakeResponse:
-    def __init__(self, text: str) -> None:
-        self.content = [_FakeBlock(text)]
+class _RaisingProvider:
+    """``complete`` raises an injected exception, modeling a redacted SDK error."""
 
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
 
-class _FakeBlock:
-    def __init__(self, text: str) -> None:
-        self.type = "text"
-        self.text = text
+    async def complete(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str,
+        max_tokens: int,
+    ) -> Completion:
+        """Raise the injected exception."""
+        raise self._exc
 
 
 def test_build_router_prompt_includes_wavelength_and_history(
@@ -138,7 +153,7 @@ async def test_router_extract_intents_parses_valid_json(
     tools: list[ToolInfo], session_state: SessionState
 ) -> None:
     """A well-formed Haiku reply lands on a :class:`RouterResponse`."""
-    fake_haiku = _FakeAnthropic(
+    fake_haiku = _FakeProvider(
         json.dumps(
             {
                 "intents": [
@@ -151,7 +166,7 @@ async def test_router_extract_intents_parses_valid_json(
         )
     )
     router = IntentRouter(
-        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        provider=fake_haiku,
         model="claude-haiku-test",
         tools=tools,
     )
@@ -171,9 +186,9 @@ async def test_router_uses_configured_model(
     tools: list[ToolInfo], session_state: SessionState
 ) -> None:
     """The injected model name is the one passed to the Anthropic SDK."""
-    fake_haiku = _FakeAnthropic(json.dumps({"intents": []}))
+    fake_haiku = _FakeProvider(json.dumps({"intents": []}))
     router = IntentRouter(
-        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        provider=fake_haiku,
         model="custom-haiku-id",
         tools=tools,
     )
@@ -191,9 +206,9 @@ async def test_router_rejects_non_json_response(
     tools: list[ToolInfo], session_state: SessionState
 ) -> None:
     """A non-JSON Haiku reply raises ``RouterParseError``."""
-    fake_haiku = _FakeAnthropic("here is some prose, not JSON")
+    fake_haiku = _FakeProvider("here is some prose, not JSON")
     router = IntentRouter(
-        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        provider=fake_haiku,
         model="claude-haiku-test",
         tools=tools,
     )
@@ -210,9 +225,9 @@ async def test_router_rejects_missing_intents_key(
     tools: list[ToolInfo], session_state: SessionState
 ) -> None:
     """JSON without the ``intents`` array is malformed router output."""
-    fake_haiku = _FakeAnthropic(json.dumps({"reply": "hi"}))
+    fake_haiku = _FakeProvider(json.dumps({"reply": "hi"}))
     router = IntentRouter(
-        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        provider=fake_haiku,
         model="claude-haiku-test",
         tools=tools,
     )
@@ -225,37 +240,20 @@ async def test_router_rejects_missing_intents_key(
         )
 
 
-class _RaisingAnthropic:
-    """``messages.create`` raises an injected exception, modeling SDK errors."""
-
-    def __init__(self, exc: Exception) -> None:
-        self._exc = exc
-        self.messages = self
-
-    async def create(self, **_kwargs: Any) -> Any:
-        raise self._exc
-
-
-async def test_router_translates_anthropic_api_error_to_parse_error(
+async def test_router_translates_provider_error_to_parse_error(
     tools: list[ToolInfo], session_state: SessionState
 ) -> None:
-    """Rate-limit / connection / auth errors surface as ``RouterParseError``.
+    """A redacted provider ``RuntimeError`` surfaces as ``RouterParseError``.
 
     The bot maps ``RouterParseError`` to a user-visible reply; without
     this translation the SDK error would propagate through
     ``handle_message`` into discord.py and the user would receive no
-    reply at all.
+    reply at all. The provider has already redacted the SDK error to a
+    ``RuntimeError`` carrying only the exception type name.
     """
-    import anthropic
-
-    # ``APIError`` requires a request kwarg in modern SDK versions; we
-    # construct a minimal subclass exception that still belongs to the
-    # base ``AnthropicError`` hierarchy.
-    fake_haiku = _RaisingAnthropic(
-        anthropic.AnthropicError("simulated rate-limit / API failure")
-    )
+    fake_haiku = _RaisingProvider(RuntimeError("AnthropicError"))
     router = IntentRouter(
-        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        provider=fake_haiku,
         model="claude-haiku-test",
         tools=tools,
     )
@@ -320,7 +318,7 @@ async def test_router_emits_run_workflow_for_natural_language_phrase(
     requested workflow name + inputs. We stub the model so the test
     pins the parsing path, not the model's behavior.
     """
-    fake_haiku = _FakeAnthropic(
+    fake_haiku = _FakeProvider(
         json.dumps(
             {
                 "intents": [
@@ -337,7 +335,7 @@ async def test_router_emits_run_workflow_for_natural_language_phrase(
         )
     )
     router = IntentRouter(
-        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        provider=fake_haiku,
         model="claude-haiku-test",
         tools=tools,
     )
@@ -367,7 +365,7 @@ async def test_router_emits_activate_register_for_natural_language_phrase(
     the requested register name. We stub the model so the test pins
     the parsing path, not the model's behavior.
     """
-    fake_haiku = _FakeAnthropic(
+    fake_haiku = _FakeProvider(
         json.dumps(
             {
                 "intents": [
@@ -381,7 +379,7 @@ async def test_router_emits_activate_register_for_natural_language_phrase(
         )
     )
     router = IntentRouter(
-        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        provider=fake_haiku,
         model="claude-haiku-test",
         tools=tools,
     )
@@ -403,11 +401,11 @@ async def test_router_extracts_fenced_json_blocks(
 ) -> None:
     """Markdown fences around the JSON are tolerated."""
     payload = json.dumps({"intents": [{"type": "creek.state.read"}]})
-    fake_haiku = _FakeAnthropic(
+    fake_haiku = _FakeProvider(
         f"Sure, here is the result:\n\n```json\n{payload}\n```\n"
     )
     router = IntentRouter(
-        anthropic_client=fake_haiku,  # type: ignore[arg-type]
+        provider=fake_haiku,
         model="claude-haiku-test",
         tools=tools,
     )


### PR DESCRIPTION
## Summary

- Introduce an **async LLM provider seam** inside CrawDad and route the Haiku router + Sonnet composer through it, with **Anthropic as the only provider** — a pure refactor that ships green and sets up #610 (OpenAI/Gemini on the CrawDad side). Sequence 6/8 of epic #603. CrawDad stays **decoupled** from creek-tools (FEAT-013): the `Completion` shape + provider protocol are mirrored, never imported.
- `crawdad/llm/base.py`: normalized `Completion` + `AsyncLLMProvider` `Protocol` (`async complete(messages, *, model, max_tokens) -> Completion`).
- `crawdad/llm/anthropic.py`: `AnthropicAsyncProvider` wrapping `AsyncAnthropic`, owning the `messages.create` call shape and the `AnthropicError → RuntimeError(type(exc).__name__)` redaction that previously lived inline in the router and composer.
- `crawdad/llm/__init__.py`: `build_async_provider(config)` factory (Anthropic only for now).
- `router.py` / `composer.py`: take a `provider` via DI and call `self._provider.complete(...)`; dropped the direct `anthropic` import, the `messages.create` call, the `AnthropicError` catch, and the local `_extract_text`. They now catch the provider's `RuntimeError` and wrap to `RouterParseError` / `ComposerFailureError` exactly as before.
- `cli.py`: build the provider via the factory and inject it into both; dropped the `anthropic` import.

**Zero behavior change:** same model selection, same soft-error replies, same redaction. No new provider yet.

## Test plan

- New `tests/test_llm_provider.py` (7 cases, SDK mocked): `Completion` defaults; `complete` maps reply → Completion (text + stop_reason, multi-block join, default stop reason); `AnthropicError` → `RuntimeError` carrying only the type name (no request state); protocol conformance; factory wires the configured key.
- Migrated `test_router.py` / `test_composer.py` to the provider seam (fakes expose `complete`, not `messages.create`) **without changing asserted behavior** — model threading, JSON parse failures, and SDK-error → soft-error translation all still pinned.
- `./scripts/check-all.sh` (in `crawdad/`) → exit 0 (all 7 gates; 462 tests; 95.50% coverage; mypy strict; ruff; bandit; interrogate).
- Acceptance grep: `router.py` / `composer.py` no longer reference `anthropic` directly; `test_no_model_literals.py` still green.

Closes #609
Refs #603
