### PR TITLE
docs(llm): provider/env-var matrix + ADR-0003 decoupling decision (#611)

### DIFF
--- a/crawdad/CLAUDE.md
+++ b/crawdad/CLAUDE.md
@@ -87,7 +87,16 @@ Four gates, each must pass before the next:
 
 ## 5. Configuration
 
-- Secrets ONLY via env: `DISCORD_BOT_TOKEN`, `ANTHROPIC_API_KEY`.
+- Secrets ONLY via env: `DISCORD_BOT_TOKEN` plus the selected provider's API
+  key. The backend is chosen by `CRAWDAD_PROVIDER` (default `anthropic`;
+  also `openai`, `gemini` — #610); the matching key
+  (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY`) must be set and
+  is validated at load time but **never stored** on `CrawDadConfig` — each SDK
+  reads it from env. A missing provider key fails fast naming the variable.
+  Per-provider router/composer model tiers live in `config.py`, overridable via
+  `CRAWDAD_ROUTER_MODEL` / `CRAWDAD_COMPOSER_MODEL`. See the
+  [README provider-selection table](README.md#llm-provider-selection) and
+  [ADR-0003](../creek-tools/docs/architecture/ADR/0003-decoupled-provider-abstractions.md).
 - Everything else in `crawdad.yaml`:
   - `vault_path` — Obsidian vault root.
   - `mcp_server_command` — argv for the MCP subprocess (default

--- a/crawdad/README.md
+++ b/crawdad/README.md
@@ -30,7 +30,11 @@ pip install -e ".[dev]"
 
 # Required env vars
 export DISCORD_BOT_TOKEN="…"
-export ANTHROPIC_API_KEY="…"
+export ANTHROPIC_API_KEY="…"          # the key for the selected provider (default: anthropic)
+
+# Optional: pick a different backend (see "LLM provider selection" below)
+# export CRAWDAD_PROVIDER=openai      # then set OPENAI_API_KEY instead
+# export CRAWDAD_PROVIDER=gemini      # then set GOOGLE_API_KEY instead
 
 # Edit crawdad.yaml — see the example below
 crawdad run --config ./crawdad.yaml
@@ -65,6 +69,22 @@ allowed_channel_ids:
 | `attachments` | no | see source | Per-attachment limits, allow/deny lists, channel privacy tiers (FEAT-027/035). |
 | `consent` | no | see source | Conversational consent tokens + TTL (FEAT-034). |
 | `max_loop_rounds` | no | `5` | FEAT-036 agent-loop round cap, bounded `[1, 50]`. Raise when a single user turn legitimately needs more router/dispatcher passes (multi-source ingest, large re-classification asks, long workflow chains); the upper bound prevents pathological runaway loops. |
+
+Secrets are **never** in `crawdad.yaml` — they come only from the environment.
+
+### LLM provider selection
+
+CrawDad's backend is chosen by the `CRAWDAD_PROVIDER` environment variable (default `anthropic`). The selected provider's API key must be present in the environment; each SDK reads its own key — CrawDad **never** stores a key on its config object or in `crawdad.yaml`.
+
+| `CRAWDAD_PROVIDER` | Required env key |
+|---|---|
+| `anthropic` (default) | `ANTHROPIC_API_KEY` |
+| `openai` | `OPENAI_API_KEY` |
+| `gemini` | `GOOGLE_API_KEY` |
+
+Starting the bot with the selected provider's key unset fails fast with a message naming the missing variable. Per-provider router/composer model tiers live in `crawdad/config.py`; override globally with `CRAWDAD_ROUTER_MODEL` / `CRAWDAD_COMPOSER_MODEL`.
+
+CrawDad's provider abstraction is intentionally **decoupled** from creek-tools' (sibling packages, no shared module) — see [ADR-0003](../creek-tools/docs/architecture/ADR/0003-decoupled-provider-abstractions.md).
 
 ## Slash commands (FEAT-016)
 

--- a/creek-tools/CLAUDE.md
+++ b/creek-tools/CLAUDE.md
@@ -190,7 +190,7 @@ pip install -e '.[dev]'         # [dev] depends on [all]; this is self-contained
 pre-commit install
 ```
 
-`[dev]` deliberately pulls in `[all]` (anthropic, embeddings, ocr, documents, spreadsheets, presentations, gdrive) because `tests/conftest.py` imports numpy, `tests/test_classify.py` mocks the anthropic SDK, and `tests/test_ingest_documents.py` parses DOCX/PDF/HTML — so the optional code paths are not optional at test-collection time (issue #206). The mypy floor in `[dev]` is pinned to the same major.minor as `uv.lock` and `.pre-commit-config.yaml` so the three install paths agree.
+`[dev]` deliberately pulls in `[all]` (anthropic, openai, gemini, embeddings, ocr, documents, spreadsheets, presentations, gdrive) because `tests/conftest.py` imports numpy, `tests/test_classify.py` / `tests/test_openai_provider.py` / `tests/test_gemini_provider.py` mock the cloud LLM SDKs, and `tests/test_ingest_documents.py` parses DOCX/PDF/HTML — so the optional code paths are not optional at test-collection time (issue #206). The selectable cloud LLM backend (`anthropic` / `openai` / `gemini`, each its own optional extra; `ollama` is the local default needing no extra) is documented in the [README's LLM providers matrix](README.md#llm-providers) and [ADR-0003](docs/architecture/ADR/0003-decoupled-provider-abstractions.md). The mypy floor in `[dev]` is pinned to the same major.minor as `uv.lock` and `.pre-commit-config.yaml` so the three install paths agree.
 
 ---
 

--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -27,7 +27,12 @@ Optional dependencies are imported lazily, so you only need to install the ones 
 | Image OCR              | `pytesseract`, `pdf2image`, system-level `tesseract` and `poppler` |
 | Google Drive           | `google-api-python-client`, `google-auth-oauthlib` |
 | Embeddings             | `sentence-transformers`      |
-| LLM classification     | Ollama running locally, or `ANTHROPIC_API_KEY` for the cloud path |
+| LLM classification — Anthropic | `anthropic` (the `[anthropic]` extra) |
+| LLM classification — OpenAI    | `openai` (the `[openai]` extra) |
+| LLM classification — Gemini    | `google-genai` (the `[gemini]` extra) |
+| LLM classification — local     | Ollama running locally — no extra, no key |
+
+The cloud LLM backend is selectable — see [LLM providers](#llm-providers) below. `[all]` (and therefore `[dev]`) pulls in every cloud extra so the test suite can mock each SDK.
 
 To install everything required for development plus the full quality toolchain:
 
@@ -153,7 +158,7 @@ read the threat model below before doing anything else.
 
 | Section | Class | What it controls |
 |---------|-------|------------------|
-| `llm`            | `LLMConfig`            | Provider (`ollama` or `anthropic`), model name, batch size, retries. |
+| `llm`            | `LLMConfig`            | Provider (`ollama` / `anthropic` / `openai` / `gemini`), model name, optional `api_base`, batch size, retries. See [LLM providers](#llm-providers). |
 | `embeddings`     | `EmbeddingsConfig`     | Sentence-transformer model, similarity thresholds. |
 | `ocr`            | `OCRConfig`            | Tesseract path, languages, PSM mode. |
 | `linking`        | `LinkingConfig`        | Embedding/temporal/eddy thresholds. |
@@ -164,6 +169,21 @@ read the threat model below before doing anything else.
 | `cleaning`       | `CleaningConfig`       | Per-source filters (Discord, ChatGPT, Drive, Markdown) plus `validation`, `quality`, `deduplication`, `hygiene` sub-sections. |
 
 See [`docs/configuration.md`](docs/configuration.md) for the full schema with examples.
+
+### LLM providers
+
+The cloud LLM backend is selectable via `llm.provider` in `creek_config.yaml`. The default `ollama` runs fully locally and needs no key or consent. Each cloud provider's **API key is read from the environment by its SDK** — it must **never** be written into `creek_config.yaml`, committed to the repo, or logged. Cloud egress additionally requires explicit consent (Ollama is exempt).
+
+| Provider | `llm.provider` | Env key | Cloud-egress consent |
+|---|---|---|---|
+| Ollama (local) | `ollama` | — | not required |
+| Anthropic | `anthropic` | `ANTHROPIC_API_KEY` | `CREEK_CLOUD_CONSENT=1` |
+| OpenAI | `openai` | `OPENAI_API_KEY` (+ optional `OPENAI_BASE_URL`, or `llm.api_base`) | `CREEK_CLOUD_CONSENT=1` |
+| Gemini | `gemini` | `GOOGLE_API_KEY` or `GEMINI_API_KEY` | `CREEK_CLOUD_CONSENT=1` |
+
+`CREEK_CLOUD_CONSENT=1` (also accepts `true` / `yes`) acknowledges that fragment content leaves the device; the legacy `CREEK_ANTHROPIC_CONSENT` is still honored as an alias. `llm.api_base` is OpenAI-specific (an OpenAI-compatible gateway); other providers ignore it. Install the matching optional extra (`[openai]` / `[gemini]`) for the cloud SDKs — see [Install](#install).
+
+The architectural decision to keep creek-tools' and CrawDad's provider abstractions decoupled is recorded in [ADR-0003](docs/architecture/ADR/0003-decoupled-provider-abstractions.md).
 
 ---
 

--- a/creek-tools/docs/architecture/ADR/0003-decoupled-provider-abstractions.md
+++ b/creek-tools/docs/architecture/ADR/0003-decoupled-provider-abstractions.md
@@ -1,0 +1,69 @@
+# ADR-0003: Two parallel LLM-provider abstractions, no shared package
+
+- **Status**: Accepted
+- **Date**: 2026-06-09
+- **Driving issues**: Epic #603 (swappable LLM providers) and its children
+  #604–#611.
+
+## Context
+
+Both `creek-tools` and CrawDad needed a selectable cloud LLM backend
+(Anthropic / OpenAI / Gemini, with Ollama as the local default in
+`creek-tools`) instead of a hard-wired provider. The obvious DRY instinct is to
+extract one shared `creek.llm` package that both import.
+
+Two facts make that the wrong call here:
+
+1. **They are siblings, not parent/child (FEAT-013).** CrawDad imports *nothing*
+   from `creek-tools`; it talks to it only over MCP stdio. Introducing a shared
+   importable module would create a source-level coupling the architecture has
+   deliberately avoided.
+2. **The two pipelines have different concurrency models.** `creek-tools` is
+   synchronous (batch ingestion/classification); CrawDad is asynchronous
+   (discord.py + MCP). A shared `complete()` contract would have to be either
+   sync or async, forcing one side into awkward bridging.
+
+The repeated surface is small: a normalized `Completion` result type and a
+per-provider wrapper (~30–40 lines each) that maps the vendor SDK's
+request/response shape, redacts errors to `RuntimeError(type(exc).__name__)`,
+and maps `finish_reason`/usage. That overlap is structural, not behavioral —
+the bodies are short and stable.
+
+## Decision
+
+Keep **two parallel provider abstractions, one per package, with no shared
+module:**
+
+- `creek-tools`: `creek/classify/llm/` — a **synchronous** `LLMProvider`
+  Protocol, a normalized `Completion`, a `build_provider(config)` registry, and
+  per-provider classes (Anthropic, Ollama, OpenAI, Gemini). Selection is via
+  `creek_config.yaml::llm.provider`. The cloud-egress consent gate
+  (`CREEK_CLOUD_CONSENT`, legacy `CREEK_ANTHROPIC_CONSENT` alias) is
+  provider-neutral and shared *within* the package.
+- CrawDad: `crawdad/crawdad/llm/` — an **asynchronous** `AsyncLLMProvider`
+  Protocol mirroring the same `Completion` shape, a `build_async_provider(config)`
+  factory, and per-provider async classes. Selection is via the
+  `CRAWDAD_PROVIDER` env var.
+
+Each package owns its model-ID literals (in its `config`/config module) and
+reads keys from the environment via the vendor SDK — keys are never stored on a
+config object, written to YAML, committed, or logged.
+
+DRY holds *within* each package; the cross-package wrapper duplication is the
+accepted price of the clean sibling boundary.
+
+## Consequences
+
+- **Positive**: the FEAT-013 decoupling stays intact; each side picks the
+  concurrency model that fits; adding a provider is a one-line registry entry
+  plus a short wrapper on each side; no cross-package version lockstep.
+- **Negative**: ~30–40 lines of conceptually-similar wrapper code exist twice,
+  and a new provider must be added in both places to reach both surfaces.
+
+## Revisit when
+
+The duplicated wrapper bodies grow **real, divergent logic** (retry/backoff
+policy, streaming, tool-calling, prompt-cache orchestration) rather than thin
+SDK-shape mapping. At that point a shared library — published and versioned,
+*not* a direct import across the sibling boundary — becomes worth the coupling
+cost. Until then, the duplication is cheaper than the abstraction.


### PR DESCRIPTION
## Summary

- **Closes out epic #603** (swappable LLM providers): documents how to select a provider and supply its key from the environment across both packages, and records the architectural decision to keep the two provider abstractions decoupled. Sequence 8/8.
- **`creek-tools/README.md`**: an **LLM-providers matrix** (ollama / anthropic / openai / gemini → `llm.provider`, env key, `CREEK_CLOUD_CONSENT`), the optional `[openai]` / `[gemini]` install extras, and an explicit "keys are read from env by the SDK and must **never** be written into `creek_config.yaml` or the repo" note.
- **`creek-tools/CLAUDE.md`**: notes the `[openai]` / `[gemini]` extras flow into `[all]` / `[dev]` for test collection; links the README matrix + ADR.
- **`crawdad/README.md` + `crawdad/CLAUDE.md` §5**: document `CRAWDAD_PROVIDER` and the provider-conditional key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY`); the key is never stored on config and a missing one fails fast naming the variable.
- **ADR-0003** (`creek-tools/docs/architecture/ADR/`): "two parallel provider abstractions, no shared package" — the FEAT-013 sibling boundary, the sync/async rationale, the accepted ~30–40-line wrapper duplication, and the trigger to revisit (duplicated bodies growing real logic). Both READMEs and both `CLAUDE.md` files link to it (DRY — link, don't duplicate).

No secret material in any example — placeholder var names only.

## Test plan

- Docs-only change (Markdown + one ADR); no source touched.
- `./scripts/check-all.sh` → exit 0 in **both** packages (creek-tools: 12 gates; crawdad: 7 gates) — confirming nothing regressed.
- Verified the cross-package relative links resolve (crawdad → `../creek-tools/docs/architecture/ADR/0003-...`) and the README anchors (`#llm-providers`, `#llm-provider-selection`) match their headings.

Closes #611
Refs #603
