### PR TITLE
fix(llm): fail-fast provider validation at config-load in both packages (#620)

### DIFF
--- a/crawdad/crawdad/config.py
+++ b/crawdad/crawdad/config.py
@@ -118,9 +118,9 @@ _COMPOSER_MODEL_DEFAULTS: dict[str, str] = {
 def _resolve_model(provider: str, override_env: str, defaults: dict[str, str]) -> str:
     """Resolve a model tier for *provider*, honoring an env override.
 
-    Raises on an unknown provider rather than silently falling back (#620) —
-    `load_config` validates the provider, so an unknown value here is a
-    programmer error, not an operator typo to paper over.
+    Raises on an unknown provider rather than silently falling back to the
+    Anthropic default — the load-time validator catches operator typos, so an
+    unknown value here is a programmer error, not something to paper over.
 
     Args:
         provider: The selected backend.
@@ -141,6 +141,7 @@ def _resolve_model(provider: str, override_env: str, defaults: dict[str, str]) -
     except KeyError:
         known = ", ".join(sorted(defaults))
         msg = f"unknown provider {provider!r}; expected one of: {known}"
+        # The KeyError adds no caller-useful context; suppress its chain.
         raise ValueError(msg) from None
 
 

--- a/crawdad/crawdad/config.py
+++ b/crawdad/crawdad/config.py
@@ -115,6 +115,35 @@ _COMPOSER_MODEL_DEFAULTS: dict[str, str] = {
 }
 
 
+def _resolve_model(provider: str, override_env: str, defaults: dict[str, str]) -> str:
+    """Resolve a model tier for *provider*, honoring an env override.
+
+    Raises on an unknown provider rather than silently falling back (#620) —
+    `load_config` validates the provider, so an unknown value here is a
+    programmer error, not an operator typo to paper over.
+
+    Args:
+        provider: The selected backend.
+        override_env: The env var that overrides the default tier when set.
+        defaults: The per-provider default model map.
+
+    Returns:
+        The override when set, else the provider's default tier.
+
+    Raises:
+        ValueError: When *provider* names no known backend.
+    """
+    override = os.environ.get(override_env)
+    if override:
+        return override
+    try:
+        return defaults[provider]
+    except KeyError:
+        known = ", ".join(sorted(defaults))
+        msg = f"unknown provider {provider!r}; expected one of: {known}"
+        raise ValueError(msg) from None
+
+
 def router_model_for(provider: str) -> str:
     """Resolve the router (intent-extraction) model for *provider*.
 
@@ -122,15 +151,12 @@ def router_model_for(provider: str) -> str:
         provider: The selected backend (``anthropic`` / ``openai`` / ``gemini``).
 
     Returns:
-        ``CRAWDAD_ROUTER_MODEL`` when set, else the provider's default tier
-        (falling back to the Anthropic default for an unknown provider).
+        ``CRAWDAD_ROUTER_MODEL`` when set, else the provider's default tier.
+
+    Raises:
+        ValueError: When *provider* names no known backend.
     """
-    override = os.environ.get(_ENV_ROUTER_MODEL)
-    if override:
-        return override
-    return _ROUTER_MODEL_DEFAULTS.get(
-        provider, _ROUTER_MODEL_DEFAULTS[DEFAULT_PROVIDER]
-    )
+    return _resolve_model(provider, _ENV_ROUTER_MODEL, _ROUTER_MODEL_DEFAULTS)
 
 
 def composer_model_for(provider: str) -> str:
@@ -140,15 +166,12 @@ def composer_model_for(provider: str) -> str:
         provider: The selected backend (``anthropic`` / ``openai`` / ``gemini``).
 
     Returns:
-        ``CRAWDAD_COMPOSER_MODEL`` when set, else the provider's default tier
-        (falling back to the Anthropic default for an unknown provider).
+        ``CRAWDAD_COMPOSER_MODEL`` when set, else the provider's default tier.
+
+    Raises:
+        ValueError: When *provider* names no known backend.
     """
-    override = os.environ.get(_ENV_COMPOSER_MODEL)
-    if override:
-        return override
-    return _COMPOSER_MODEL_DEFAULTS.get(
-        provider, _COMPOSER_MODEL_DEFAULTS[DEFAULT_PROVIDER]
-    )
+    return _resolve_model(provider, _ENV_COMPOSER_MODEL, _COMPOSER_MODEL_DEFAULTS)
 
 
 # History truncation knobs (ADOPT-008 hard cliff; FEAT-016 may refine).

--- a/crawdad/tests/test_config.py
+++ b/crawdad/tests/test_config.py
@@ -553,3 +553,37 @@ def test_router_and_composer_models_per_provider(
     monkeypatch.setenv("CRAWDAD_COMPOSER_MODEL", "override-composer")
     assert router_model_for("openai") == "override-router"
     assert composer_model_for("anthropic") == "override-composer"
+
+
+def test_model_resolvers_reject_unknown_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unknown provider raises instead of silently downgrading to Claude (#620)."""
+    from crawdad.config import composer_model_for, router_model_for
+
+    monkeypatch.delenv("CRAWDAD_ROUTER_MODEL", raising=False)
+    monkeypatch.delenv("CRAWDAD_COMPOSER_MODEL", raising=False)
+    with pytest.raises(ValueError, match="unknown provider 'frobnicate'"):
+        router_model_for("frobnicate")
+    with pytest.raises(ValueError, match="unknown provider 'frobnicate'"):
+        composer_model_for("frobnicate")
+
+
+def test_provider_registries_stay_in_sync() -> None:
+    """All provider maps cover the same backend set — no silent drift (#620).
+
+    The config-layer key/model maps and the llm-layer builder registry must
+    list identical providers; this regression is the single anti-drift guard
+    in place of a hand-maintained second list.
+    """
+    from crawdad.config import (
+        _COMPOSER_MODEL_DEFAULTS,
+        _PROVIDER_KEY_ENV,
+        _ROUTER_MODEL_DEFAULTS,
+    )
+    from crawdad.llm import _PROVIDER_BUILDERS
+
+    names = set(_PROVIDER_KEY_ENV)
+    assert set(_ROUTER_MODEL_DEFAULTS) == names
+    assert set(_COMPOSER_MODEL_DEFAULTS) == names
+    assert set(_PROVIDER_BUILDERS) == names

--- a/crawdad/tests/test_config.py
+++ b/crawdad/tests/test_config.py
@@ -576,6 +576,8 @@ def test_provider_registries_stay_in_sync() -> None:
     list identical providers; this regression is the single anti-drift guard
     in place of a hand-maintained second list.
     """
+    # Private internals are imported deliberately: this guard's whole job is
+    # to pin those provider maps together, so it must reference them by name.
     from crawdad.config import (
         _COMPOSER_MODEL_DEFAULTS,
         _PROVIDER_KEY_ENV,

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -1073,7 +1073,7 @@ def known_providers() -> tuple[str, ...]:
 
     The single source of truth for "which providers exist" — config validation
     reads this rather than re-listing the names, so the set can never drift from
-    the :data:`_PROVIDER_REGISTRY` the factory dispatches on (#620).
+    the :data:`_PROVIDER_REGISTRY` the factory dispatches on.
 
     Returns:
         The registered ``LLMConfig.provider`` strings, sorted.

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -52,6 +52,7 @@ __all__ = [
     "OpenAIProvider",
     "build_provider",
     "cloud_warning",
+    "known_providers",
     "provider_display_name",
     "provider_is_cloud",
 ]
@@ -1065,6 +1066,19 @@ def provider_is_cloud(provider: str) -> bool:
     """
     provider_cls = _PROVIDER_REGISTRY.get(provider)
     return bool(provider_cls is not None and provider_cls.is_cloud)
+
+
+def known_providers() -> tuple[str, ...]:
+    """Return the registered provider names, sorted.
+
+    The single source of truth for "which providers exist" — config validation
+    reads this rather than re-listing the names, so the set can never drift from
+    the :data:`_PROVIDER_REGISTRY` the factory dispatches on (#620).
+
+    Returns:
+        The registered ``LLMConfig.provider`` strings, sorted.
+    """
+    return tuple(sorted(_PROVIDER_REGISTRY))
 
 
 def provider_display_name(provider: str) -> str:

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -93,7 +93,7 @@ class LLMConfig(BaseModel):
     """LLM provider configuration."""
 
     provider: str = "ollama"
-    """LLM backend — ``ollama``, ``anthropic``, or ``openai``."""
+    """LLM backend — ``ollama`` (local), ``anthropic``, ``openai``, or ``gemini``."""
 
     model: str = "mistral"
     """Model identifier recognised by the chosen provider."""
@@ -122,6 +122,35 @@ class LLMConfig(BaseModel):
     lenient; tighten it once a calibration set exists (FEAT-017b) and
     the per-dimension agreement rate on your corpus is known.
     """
+
+    @field_validator("provider")
+    @classmethod
+    def _known_provider(cls, value: str) -> str:
+        """Fail fast at config-load on an unregistered provider (#620).
+
+        Validates against the live provider registry so a typo like
+        ``provider: anthropics`` raises here — at parse time — instead of
+        surfacing as a ``ValueError`` from ``build_provider`` mid-run. The
+        valid set is read from the registry, never re-listed, so it cannot
+        drift.
+
+        Args:
+            value: The configured provider string.
+
+        Returns:
+            *value* unchanged when it names a registered provider.
+
+        Raises:
+            ValueError: When *value* names no registered provider.
+        """
+        from creek.classify.llm.providers import known_providers
+
+        known = known_providers()
+        if value not in known:
+            joined = ", ".join(known)
+            msg = f"unknown LLM provider {value!r}; expected one of: {joined}"
+            raise ValueError(msg)
+        return value
 
 
 class EmbeddingsConfig(BaseModel):

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -126,7 +126,7 @@ class LLMConfig(BaseModel):
     @field_validator("provider")
     @classmethod
     def _known_provider(cls, value: str) -> str:
-        """Fail fast at config-load on an unregistered provider (#620).
+        """Fail fast at config-load on an unregistered provider.
 
         Validates against the live provider registry so a typo like
         ``provider: anthropics`` raises here — at parse time — instead of

--- a/creek-tools/tests/test_llm_provider_factory.py
+++ b/creek-tools/tests/test_llm_provider_factory.py
@@ -52,15 +52,37 @@ def test_build_provider_returns_anthropic(anthropic_env: None) -> None:
 
 
 def test_build_provider_unknown_raises_valueerror() -> None:
-    """An unknown provider string raises a clear ``ValueError``."""
+    """``build_provider`` guards unknown providers (defense-in-depth, #620).
+
+    ``LLMConfig`` now validates at construction, so bypass it with
+    ``model_construct`` to exercise the factory's own guard directly.
+    """
+    bad = LLMConfig.model_construct(provider="frobnicate")
     with pytest.raises(ValueError, match="unknown LLM provider 'frobnicate'"):
-        build_provider(LLMConfig(provider="frobnicate"))
+        build_provider(bad)
 
 
 def test_build_provider_valueerror_lists_known_providers() -> None:
     """The error names the supported providers so the operator can self-serve."""
+    bad = LLMConfig.model_construct(provider="nope")
     with pytest.raises(ValueError, match=r"anthropic.*ollama|ollama.*anthropic"):
-        build_provider(LLMConfig(provider="nope"))
+        build_provider(bad)
+
+
+def test_llmconfig_rejects_unknown_provider_at_construction() -> None:
+    """A typo'd provider fails fast at config-load, not at first classify call."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="unknown LLM provider 'anthropics'"):
+        LLMConfig(provider="anthropics")
+
+
+def test_llmconfig_accepts_every_registered_provider() -> None:
+    """Every registered provider name is a valid ``LLMConfig.provider``."""
+    from creek.classify.llm.providers import known_providers
+
+    for name in known_providers():
+        assert LLMConfig(provider=name).provider == name
 
 
 def test_provider_is_cloud_anthropic_true() -> None:


### PR DESCRIPTION
## Summary

Follow-up bug fix to epic #603: a mistyped provider should **fail fast and loudly at config-load**, not silently pick the wrong backend or crash mid-run.

- **creek-tools**: adds a `field_validator("provider")` on `LLMConfig` that rejects an unregistered provider **at construction** (so `provider: anthropics` in `creek_config.yaml` raises at parse time, not when classification first runs). The valid set is read from a new `providers.known_providers()` — the **single source**, derived from `_PROVIDER_REGISTRY`, so it can't drift from what `build_provider` dispatches on. `build_provider` keeps its own `ValueError` as defense-in-depth.
- **CrawDad**: `router_model_for` / `composer_model_for` no longer **silently fall back to the Anthropic tier** for an unknown provider — they raise a clear `ValueError` (factored into `_resolve_model`). `load_config` already validates `CRAWDAD_PROVIDER` (from #610); a new regression test pins `_PROVIDER_KEY_ENV` / `_ROUTER_MODEL_DEFAULTS` / `_COMPOSER_MODEL_DEFAULTS` and `llm._PROVIDER_BUILDERS` to the **same provider set** so the lists can't drift (the anti-drift guarantee in place of a hand-maintained second list).

## Test plan

- **creek-tools**: every registered provider loads; `LLMConfig(provider="anthropics")` raises `ValidationError` at construction (the new fail-fast); `build_provider`'s guard is still exercised via `model_construct` (defense-in-depth).
- **CrawDad**: `router_model_for("frobnicate")` / `composer_model_for(...)` raise instead of returning a Claude model; the provider-registry sync test ties all four provider maps together; existing load-fail-fast test (#610) still green.
- `./scripts/check-all.sh` → exit 0 in **both** packages (creek-tools 12 gates; crawdad 7 gates).

## Acceptance

- ✅ Unknown provider raises a clear error at config-load in both packages, naming the bad value and the valid set.
- ✅ Valid set derived from the registry/builders (creek: `known_providers()`; crawdad: drift-guard test), not a hand-maintained second list.
- ✅ CrawDad no longer silently downgrades an unknown provider to Claude.

Closes #620
Refs #603
