### PR TITLE
fix(llm): replace cross-coupled mistral sentinel with explicit unset model (#621)

### DIFF
--- a/creek-tools/creek/author/client.py
+++ b/creek-tools/creek/author/client.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from creek.config import AuthorConfig, LLMConfig
 
 
-def resolve_voice_model(author: AuthorConfig, llm: LLMConfig) -> str:
+def resolve_voice_model(author: AuthorConfig, llm: LLMConfig) -> str | None:
     """Resolve the model id for the voice call from config, never hard-coded.
 
     The desk's per-agent model tiers (#474) let an operator point the voice
@@ -30,7 +30,9 @@ def resolve_voice_model(author: AuthorConfig, llm: LLMConfig) -> str:
         llm: The shared LLM config supplying the fallback model id.
 
     Returns:
-        :attr:`AuthorConfig.voice_model` when set, otherwise ``llm.model``.
+        :attr:`AuthorConfig.voice_model` when set, otherwise ``llm.model`` —
+        which may itself be ``None``, meaning "use the provider's default";
+        :meth:`AuthorLLMClient.from_config` passes ``None`` through untouched.
     """
     return author.voice_model or llm.model
 

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -66,6 +66,25 @@ Retained for back-compat; new code should call
 """
 
 
+def _resolve_configured_model(configured: str | None, default: str) -> str:
+    """Resolve a provider's model id from the config value and its own default.
+
+    "Unset" is explicit — ``None`` or blank — never a sentinel match against
+    another module's default literal, so each provider's resolution cannot be
+    broken by a change to ``LLMConfig``'s declared default and an explicit
+    model id is always honored verbatim.
+
+    Args:
+        configured: The ``LLMConfig.model`` value (``None`` means unset).
+        default: The calling provider's own default model id.
+
+    Returns:
+        *configured* stripped when it holds a non-blank value, else *default*.
+    """
+    model = (configured or "").strip()
+    return model or default
+
+
 class AnthropicProvider:
     """Anthropic API provider for cloud-based fragment classification.
 
@@ -100,9 +119,6 @@ class AnthropicProvider:
 
     MAX_TOKENS: int = 1024
     """Maximum tokens requested from the Anthropic API per call."""
-
-    _OLLAMA_DEFAULT_MODEL: str = "mistral"
-    """The ``LLMConfig`` default model name (indicates no Anthropic override)."""
 
     def __init__(self, config: LLMConfig) -> None:
         """Validate environment prerequisites and prepare the client.
@@ -165,16 +181,13 @@ class AnthropicProvider:
     def model(self) -> str:
         """The Anthropic model identifier to use for API calls.
 
-        Falls back to :attr:`DEFAULT_MODEL` when ``config.model`` still
-        holds the Ollama default (``"mistral"``) or is empty.
+        Falls back to :attr:`DEFAULT_MODEL` when ``config.model`` is unset
+        (``None`` or blank); an explicit value is honored verbatim.
 
         Returns:
             The resolved model identifier.
         """
-        model = self.config.model.strip()
-        if not model or model == self._OLLAMA_DEFAULT_MODEL:
-            return self.DEFAULT_MODEL
-        return model
+        return _resolve_configured_model(self.config.model, self.DEFAULT_MODEL)
 
     @property
     def client(self) -> anthropic.Anthropic:
@@ -377,6 +390,14 @@ def _extract_anthropic_usage(response: object) -> dict[str, int] | None:
     return counts or None
 
 
+_OLLAMA_DEFAULT_MODEL: str = "mistral"
+"""Ollama's own default model when ``config.model`` is unset.
+
+Local to the Ollama path; cloud providers each carry their own
+:attr:`DEFAULT_MODEL` and never reference this literal.
+"""
+
+
 def call_ollama(config: LLMConfig, prompt: str, *, timeout: float) -> str:
     """Send a prompt to a local Ollama instance and return the response text.
 
@@ -397,7 +418,7 @@ def call_ollama(config: LLMConfig, prompt: str, *, timeout: float) -> str:
         response = client.post(
             f"{config.ollama_url}/api/generate",
             json={
-                "model": config.model,
+                "model": _resolve_configured_model(config.model, _OLLAMA_DEFAULT_MODEL),
                 "prompt": prompt,
                 "stream": False,
             },
@@ -448,6 +469,9 @@ class OllamaProvider:
     PROVIDER_NAME: str = "Ollama"
     """Display name (local; never appears in a cloud-egress message)."""
 
+    DEFAULT_MODEL: str = _OLLAMA_DEFAULT_MODEL
+    """Default Ollama model when the config does not override it."""
+
     REQUEST_TIMEOUT: float = 30.0
     """HTTP request timeout for completion calls, in seconds."""
 
@@ -467,9 +491,10 @@ class OllamaProvider:
         """The configured Ollama model identifier.
 
         Returns:
-            ``config.model`` verbatim — Ollama has no cloud-model fallback.
+            ``config.model`` verbatim when set; :attr:`DEFAULT_MODEL` when
+            unset (``None`` or blank).
         """
-        return self.config.model
+        return _resolve_configured_model(self.config.model, self.DEFAULT_MODEL)
 
     @property
     def available(self) -> bool:
@@ -550,9 +575,6 @@ class OpenAIProvider:
     MAX_TOKENS: int = 1024
     """Maximum tokens requested from the OpenAI API per call."""
 
-    _OLLAMA_DEFAULT_MODEL: str = "mistral"
-    """The ``LLMConfig`` default model name (indicates no OpenAI override)."""
-
     def __init__(self, config: LLMConfig) -> None:
         """Validate environment prerequisites and prepare the client.
 
@@ -605,16 +627,13 @@ class OpenAIProvider:
     def model(self) -> str:
         """The OpenAI model identifier to use for API calls.
 
-        Falls back to :attr:`DEFAULT_MODEL` when ``config.model`` still holds
-        the Ollama default (``"mistral"``) or is empty.
+        Falls back to :attr:`DEFAULT_MODEL` when ``config.model`` is unset
+        (``None`` or blank); an explicit value is honored verbatim.
 
         Returns:
             The resolved model identifier.
         """
-        model = self.config.model.strip()
-        if not model or model == self._OLLAMA_DEFAULT_MODEL:
-            return self.DEFAULT_MODEL
-        return model
+        return _resolve_configured_model(self.config.model, self.DEFAULT_MODEL)
 
     @property
     def client(self) -> openai.OpenAI:
@@ -798,9 +817,6 @@ class GeminiProvider:
     MAX_TOKENS: int = 1024
     """Maximum output tokens requested from the Gemini API per call."""
 
-    _OLLAMA_DEFAULT_MODEL: str = "mistral"
-    """The ``LLMConfig`` default model name (indicates no Gemini override)."""
-
     def __init__(self, config: LLMConfig) -> None:
         """Validate environment prerequisites and prepare the client.
 
@@ -851,16 +867,13 @@ class GeminiProvider:
     def model(self) -> str:
         """The Gemini model identifier to use for API calls.
 
-        Falls back to :attr:`DEFAULT_MODEL` when ``config.model`` still holds
-        the Ollama default (``"mistral"``) or is empty.
+        Falls back to :attr:`DEFAULT_MODEL` when ``config.model`` is unset
+        (``None`` or blank); an explicit value is honored verbatim.
 
         Returns:
             The resolved model identifier.
         """
-        model = self.config.model.strip()
-        if not model or model == self._OLLAMA_DEFAULT_MODEL:
-            return self.DEFAULT_MODEL
-        return model
+        return _resolve_configured_model(self.config.model, self.DEFAULT_MODEL)
 
     @property
     def client(self) -> genai.Client:

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -95,8 +95,13 @@ class LLMConfig(BaseModel):
     provider: str = "ollama"
     """LLM backend — ``ollama`` (local), ``anthropic``, ``openai``, or ``gemini``."""
 
-    model: str = "mistral"
-    """Model identifier recognised by the chosen provider."""
+    model: str | None = None
+    """Model identifier recognised by the chosen provider.
+
+    ``None`` (the default) means "use the provider's own default model" —
+    each provider resolves it locally (e.g. ``mistral`` for Ollama). An
+    explicit value is always honored verbatim, whatever the provider.
+    """
 
     ollama_url: str = "http://localhost:11434"
     """Base URL for the Ollama API server."""

--- a/creek-tools/docs/classification.md
+++ b/creek-tools/docs/classification.md
@@ -93,7 +93,7 @@ classification:
 
 llm:
   provider: ollama                       # or "anthropic"
-  model: mistral
+  model: mistral                         # optional; omit for the provider default
   batch_size: 50
   max_concurrent: 5
   unclassified_threshold: 0.55           # FEAT-017: bias for Mode / Orientation / Dosage
@@ -185,7 +185,7 @@ ollama serve &
 ollama pull mistral
 ```
 
-Configure the model name in `LLMConfig.model` (default `mistral`). Latency on a CPU is ~2–4 s per fragment; expect a few hours for a vault of 10k fragments.
+Configure the model name in `LLMConfig.model` (when unset, Ollama defaults to `mistral`). Latency on a CPU is ~2–4 s per fragment; expect a few hours for a vault of 10k fragments.
 
 ### Anthropic API (opt-in)
 

--- a/creek-tools/docs/configuration.md
+++ b/creek-tools/docs/configuration.md
@@ -43,7 +43,7 @@ timezone: America/Los_Angeles
 ```yaml
 llm:
   provider: ollama
-  model: mistral
+  model: mistral          # optional; omit to use the provider's own default
   ollama_url: http://localhost:11434
   batch_size: 50
   max_concurrent: 5
@@ -52,7 +52,7 @@ llm:
 | Field            | Default   | Notes |
 |------------------|-----------|-------|
 | `provider`       | `ollama`  | `ollama` or `anthropic`. |
-| `model`          | `mistral` | Model id understood by the provider. |
+| `model`          | *(unset)* | Model id understood by the provider; when omitted each provider uses its own default (`mistral` for Ollama). An explicit value is always sent verbatim. |
 | `ollama_url`     | `http://localhost:11434` | Base URL when `provider: ollama`. |
 | `batch_size`     | `50`      | Items per batch call. |
 | `max_concurrent` | `5`       | Concurrent requests in flight. |

--- a/creek-tools/docs/getting-started.md
+++ b/creek-tools/docs/getting-started.md
@@ -40,7 +40,7 @@ A minimal starter `creek_config.yaml` (already written by `creek init`):
 ```yaml
 llm:
   provider: ollama
-  model: mistral
+  model: mistral                # optional; omit to use the provider's default
 embeddings:
   model: all-MiniLM-L6-v2
   similarity_threshold: 0.78    # cosine cutoff for a resonance edge

--- a/creek-tools/tests/test_author_cost.py
+++ b/creek-tools/tests/test_author_cost.py
@@ -265,6 +265,15 @@ def test_resolve_voice_model_prefers_override() -> None:
     assert resolve_voice_model(AuthorConfig(), llm) == "base-model"
 
 
+def test_resolve_voice_model_unset_means_provider_default() -> None:
+    """With neither tier set, resolution yields ``None`` = provider default (#621).
+
+    ``None`` flows into :meth:`AuthorLLMClient.from_config`, which leaves
+    ``config.model`` untouched so the provider applies its own default.
+    """
+    assert resolve_voice_model(AuthorConfig(), LLMConfig()) is None
+
+
 def test_author_client_from_config_threads_model_override() -> None:
     """``from_config(model=...)`` overrides the model id without hard-coding one."""
     from unittest.mock import patch

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -1404,14 +1404,32 @@ class TestAnthropicProviderInit:
 class TestAnthropicProviderModel:
     """Tests for AnthropicProvider.model resolution."""
 
-    def test_defaults_when_config_uses_ollama_default(
+    def test_defaults_when_config_model_unset(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """The Ollama default ``mistral`` should fall back to Anthropic default."""
+        """An unset ``config.model`` (``None``) falls back to the Anthropic default."""
         _set_anthropic_env(monkeypatch)
         provider = AnthropicProvider(LLMConfig(provider="anthropic"))
         assert provider.model == AnthropicProvider.DEFAULT_MODEL
+
+    def test_defaults_when_config_model_blank(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A whitespace-only ``config.model`` falls back to the Anthropic default."""
+        _set_anthropic_env(monkeypatch)
+        provider = AnthropicProvider(LLMConfig(provider="anthropic", model="   "))
+        assert provider.model == AnthropicProvider.DEFAULT_MODEL
+
+    def test_honors_explicit_mistral_verbatim(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An explicit ``model: mistral`` is sent verbatim, never swapped (#621)."""
+        _set_anthropic_env(monkeypatch)
+        provider = AnthropicProvider(LLMConfig(provider="anthropic", model="mistral"))
+        assert provider.model == "mistral"
 
     def test_uses_config_model_when_set(
         self,

--- a/creek-tools/tests/test_config.py
+++ b/creek-tools/tests/test_config.py
@@ -43,7 +43,7 @@ class TestLLMConfig:
         """LLMConfig should have sensible defaults."""
         cfg = LLMConfig()
         assert cfg.provider == "ollama"
-        assert cfg.model == "mistral"
+        assert cfg.model is None
         assert cfg.ollama_url == "http://localhost:11434"
         assert cfg.batch_size == 50
         assert cfg.max_concurrent == 5

--- a/creek-tools/tests/test_gemini_provider.py
+++ b/creek-tools/tests/test_gemini_provider.py
@@ -126,8 +126,8 @@ class TestGeminiModelResolution:
         """The default Gemini model literal lives on the provider."""
         assert GeminiProvider.DEFAULT_MODEL == "gemini-2.5-flash"
 
-    def test_falls_back_from_ollama_default(self, gemini_env: None) -> None:
-        """The Ollama default ``mistral`` falls back to the Gemini default."""
+    def test_falls_back_when_model_unset(self, gemini_env: None) -> None:
+        """An unset ``config.model`` (``None``) falls back to the Gemini default."""
         provider = GeminiProvider(LLMConfig(provider="gemini"))
         assert provider.model == GeminiProvider.DEFAULT_MODEL
 
@@ -135,6 +135,11 @@ class TestGeminiModelResolution:
         """An explicit config model is honoured."""
         provider = GeminiProvider(LLMConfig(provider="gemini", model="gemini-x"))
         assert provider.model == "gemini-x"
+
+    def test_honors_explicit_mistral_verbatim(self, gemini_env: None) -> None:
+        """An explicit ``model: mistral`` is sent verbatim, never swapped (#621)."""
+        provider = GeminiProvider(LLMConfig(provider="gemini", model="mistral"))
+        assert provider.model == "mistral"
 
 
 class TestGeminiComplete:

--- a/creek-tools/tests/test_llm_provider_factory.py
+++ b/creek-tools/tests/test_llm_provider_factory.py
@@ -23,7 +23,9 @@ from creek.classify.llm.base import LLMProvider
 from creek.classify.llm.completion import Completion
 from creek.classify.llm.providers import (
     AnthropicProvider,
+    GeminiProvider,
     OllamaProvider,
+    OpenAIProvider,
     build_provider,
     provider_is_cloud,
 )
@@ -127,6 +129,28 @@ class TestOllamaProvider:
         """``model`` is the configured Ollama model verbatim."""
         assert OllamaProvider(LLMConfig(model="llama3")).model == "llama3"
 
+    def test_model_defaults_to_mistral_when_unset(self) -> None:
+        """Ollama supplies its *own* ``mistral`` default for an unset model (#621)."""
+        assert OllamaProvider.DEFAULT_MODEL == "mistral"
+        assert OllamaProvider(LLMConfig()).model == OllamaProvider.DEFAULT_MODEL
+
+    @patch("creek.classify.llm.httpx.Client")
+    def test_complete_sends_own_default_model_when_unset(
+        self, mock_client_cls: MagicMock
+    ) -> None:
+        """``complete`` resolves an unset model to Ollama's own default (#621)."""
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"response": "ok"}
+        ctx = MagicMock()
+        ctx.post.return_value = mock_resp
+        mock_client_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+        mock_client_cls.return_value.__exit__ = MagicMock(return_value=False)
+
+        OllamaProvider(LLMConfig()).complete("prompt")
+
+        payload = ctx.post.call_args.kwargs["json"]
+        assert payload["model"] == OllamaProvider.DEFAULT_MODEL
+
     @patch("creek.classify.llm.httpx.Client")
     def test_available_true_on_200(self, mock_client_cls: MagicMock) -> None:
         """``available`` is ``True`` when the Ollama health check returns 200."""
@@ -181,6 +205,33 @@ class TestOllamaProvider:
 
         result = OllamaProvider(LLMConfig()).complete("p", max_tokens=99, system="sys")
         assert result.text == "ok"
+
+
+class TestUnsetModelDecoupling:
+    """Pins the #621 contract: "unset model" is explicit, never sentinel-matched.
+
+    The old design detected "the user left ``llm.model`` alone" by comparing
+    against another module's default literal (``"mistral"``), which silently
+    broke if that default ever changed and silently overrode a legitimate
+    cloud ``model: mistral``. These tests pin the decoupled contract.
+    """
+
+    def test_cloud_providers_carry_no_ollama_sentinel(self) -> None:
+        """No cloud provider references another module's default to detect unset."""
+        for provider_cls in (AnthropicProvider, OpenAIProvider, GeminiProvider):
+            assert not hasattr(provider_cls, "_OLLAMA_DEFAULT_MODEL")
+
+    def test_unset_representation_is_independent_of_config_default(
+        self, anthropic_env: None
+    ) -> None:
+        """Cloud resolution keys off ``None``, not ``LLMConfig``'s default literal.
+
+        ``model_construct`` injects ``None`` directly, bypassing the field
+        default — so this holds even if ``LLMConfig``'s declared default
+        changes, which is exactly the regression #621 guards against.
+        """
+        config = LLMConfig.model_construct(provider="anthropic", model=None)
+        assert AnthropicProvider(config).model == AnthropicProvider.DEFAULT_MODEL
 
 
 class _FakeProvider:

--- a/creek-tools/tests/test_openai_provider.py
+++ b/creek-tools/tests/test_openai_provider.py
@@ -103,14 +103,14 @@ class TestOpenAIFactoryRegistration:
 
 
 class TestOpenAIModelResolution:
-    """Model resolution mirrors the Anthropic sentinel logic."""
+    """Model resolution mirrors the Anthropic unset-fallback logic."""
 
     def test_default_model_literal(self) -> None:
         """The default OpenAI model literal lives on the provider."""
         assert OpenAIProvider.DEFAULT_MODEL == "gpt-4o"
 
-    def test_falls_back_from_ollama_default(self, openai_env: None) -> None:
-        """The Ollama default ``mistral`` falls back to the OpenAI default."""
+    def test_falls_back_when_model_unset(self, openai_env: None) -> None:
+        """An unset ``config.model`` (``None``) falls back to the OpenAI default."""
         provider = OpenAIProvider(LLMConfig(provider="openai"))
         assert provider.model == OpenAIProvider.DEFAULT_MODEL
 
@@ -118,6 +118,11 @@ class TestOpenAIModelResolution:
         """An explicit config model is honoured."""
         provider = OpenAIProvider(LLMConfig(provider="openai", model="gpt-x"))
         assert provider.model == "gpt-x"
+
+    def test_honors_explicit_mistral_verbatim(self, openai_env: None) -> None:
+        """An explicit ``model: mistral`` is sent verbatim, never swapped (#621)."""
+        provider = OpenAIProvider(LLMConfig(provider="openai", model="mistral"))
+        assert provider.model == "mistral"
 
 
 class TestOpenAIComplete:


### PR DESCRIPTION
## Summary
- `LLMConfig.model` is now `str | None = None` — `None` means "use the provider's own default model", replacing the cross-coupled sentinel that compared each cloud provider's config against another module's default literal (`"mistral"`).
- All four providers resolve an unset model locally via a shared `_resolve_configured_model` helper; Ollama supplies its `mistral` default from a literal local to the Ollama path, and the three cloud providers fall back to their own `DEFAULT_MODEL`.
- An explicit `model: mistral` with a cloud provider is now honored verbatim (no silent override), and regression tests pin that changing `LLMConfig`'s unset representation cannot silently break cloud model resolution. `resolve_voice_model` returns `str | None` accordingly, and the config docs describe the new unset semantics.

## Test plan
- New/updated unit tests: unset-`None` fallback per provider, whitespace-only fallback, `model: mistral` honored verbatim on Anthropic/OpenAI/Gemini, Ollama's own default (property + request payload), `model_construct(model=None)` decoupling pin, no `_OLLAMA_DEFAULT_MODEL` attr on cloud classes, and `resolve_voice_model` `None` passthrough.
- `./scripts/check-all.sh` exits 0 (12/12 checks: tests + coverage gates, mypy strict, ruff, pylint, bandit, complexity, docstrings).

Closes #621
Refs #603
