### PR TITLE
chore(llm): centralize + refresh creek-tools default model IDs into one matrix (#622)

### DIFF
--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -93,9 +93,9 @@ def _resolve_configured_model(configured: str | None, default: str) -> str:
 # so "introduce another model" is a one-place edit in both packages.
 DEFAULT_MODELS: dict[str, str] = {
     "anthropic": "claude-sonnet-4-6",
-    "openai": "gpt-5.4",
     "gemini": "gemini-3.5-flash",
     "ollama": "mistral",
+    "openai": "gpt-5.4",
 }
 
 
@@ -425,7 +425,7 @@ def call_ollama(config: LLMConfig, prompt: str, *, timeout: float) -> str:
             f"{config.ollama_url}/api/generate",
             json={
                 "model": _resolve_configured_model(
-                    config.model, OllamaProvider.DEFAULT_MODEL
+                    config.model, DEFAULT_MODELS["ollama"]
                 ),
                 "prompt": prompt,
                 "stream": False,

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -425,7 +425,7 @@ def call_ollama(config: LLMConfig, prompt: str, *, timeout: float) -> str:
             f"{config.ollama_url}/api/generate",
             json={
                 "model": _resolve_configured_model(
-                    config.model, DEFAULT_MODELS["ollama"]
+                    config.model, OllamaProvider.DEFAULT_MODEL
                 ),
                 "prompt": prompt,
                 "stream": False,

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -44,6 +44,7 @@ logger = logging.getLogger(__name__)
 # resolving after the type moved to :mod:`creek.classify.llm.completion` (#604).
 __all__ = [
     "ANTHROPIC_CLOUD_WARNING",
+    "DEFAULT_MODELS",
     "AnthropicCompletion",
     "AnthropicProvider",
     "Completion",
@@ -85,6 +86,19 @@ def _resolve_configured_model(configured: str | None, default: str) -> str:
     return model or default
 
 
+# Per-provider default model IDs. This matrix is the ONLY place model literals
+# live in the package — provider classes read their ``DEFAULT_MODEL`` from it
+# and other modules read the resolved value, never a literal (enforced by
+# ``tests/test_no_model_literals.py``). Mirrors CrawDad's ``config.py`` dicts
+# so "introduce another model" is a one-place edit in both packages.
+DEFAULT_MODELS: dict[str, str] = {
+    "anthropic": "claude-sonnet-4-6",
+    "openai": "gpt-5.4",
+    "gemini": "gemini-3.5-flash",
+    "ollama": "mistral",
+}
+
+
 class AnthropicProvider:
     """Anthropic API provider for cloud-based fragment classification.
 
@@ -103,7 +117,7 @@ class AnthropicProvider:
     PROVIDER_NAME: str = "Anthropic"
     """Display name woven into consent and cloud-egress messages."""
 
-    DEFAULT_MODEL: str = "claude-sonnet-4-6"
+    DEFAULT_MODEL: str = DEFAULT_MODELS["anthropic"]
     """Default Anthropic model when the config does not override it."""
 
     API_KEY_ENV: str = "ANTHROPIC_API_KEY"
@@ -390,14 +404,6 @@ def _extract_anthropic_usage(response: object) -> dict[str, int] | None:
     return counts or None
 
 
-_OLLAMA_DEFAULT_MODEL: str = "mistral"
-"""Ollama's own default model when ``config.model`` is unset.
-
-Local to the Ollama path; cloud providers each carry their own
-:attr:`DEFAULT_MODEL` and never reference this literal.
-"""
-
-
 def call_ollama(config: LLMConfig, prompt: str, *, timeout: float) -> str:
     """Send a prompt to a local Ollama instance and return the response text.
 
@@ -418,7 +424,9 @@ def call_ollama(config: LLMConfig, prompt: str, *, timeout: float) -> str:
         response = client.post(
             f"{config.ollama_url}/api/generate",
             json={
-                "model": _resolve_configured_model(config.model, _OLLAMA_DEFAULT_MODEL),
+                "model": _resolve_configured_model(
+                    config.model, DEFAULT_MODELS["ollama"]
+                ),
                 "prompt": prompt,
                 "stream": False,
             },
@@ -469,7 +477,7 @@ class OllamaProvider:
     PROVIDER_NAME: str = "Ollama"
     """Display name (local; never appears in a cloud-egress message)."""
 
-    DEFAULT_MODEL: str = _OLLAMA_DEFAULT_MODEL
+    DEFAULT_MODEL: str = DEFAULT_MODELS["ollama"]
     """Default Ollama model when the config does not override it."""
 
     REQUEST_TIMEOUT: float = 30.0
@@ -566,7 +574,7 @@ class OpenAIProvider:
     PROVIDER_NAME: str = "OpenAI"
     """Display name woven into consent and cloud-egress messages."""
 
-    DEFAULT_MODEL: str = "gpt-4o"
+    DEFAULT_MODEL: str = DEFAULT_MODELS["openai"]
     """Default OpenAI model when the config does not override it."""
 
     API_KEY_ENV: str = "OPENAI_API_KEY"
@@ -808,7 +816,7 @@ class GeminiProvider:
     PROVIDER_NAME: str = "Gemini"
     """Display name woven into consent and cloud-egress messages."""
 
-    DEFAULT_MODEL: str = "gemini-2.5-flash"
+    DEFAULT_MODEL: str = DEFAULT_MODELS["gemini"]
     """Default Gemini model when the config does not override it."""
 
     API_KEY_ENVS: tuple[str, ...] = ("GOOGLE_API_KEY", "GEMINI_API_KEY")

--- a/creek-tools/tests/test_gemini_provider.py
+++ b/creek-tools/tests/test_gemini_provider.py
@@ -123,7 +123,7 @@ class TestGeminiModelResolution:
     """Model resolution mirrors the other providers."""
 
     def test_default_model_literal(self) -> None:
-        """The default Gemini model is the current stable flash tier (#622)."""
+        """The default Gemini model is the current stable flash tier."""
         assert GeminiProvider.DEFAULT_MODEL == "gemini-3.5-flash"
 
     def test_falls_back_when_model_unset(self, gemini_env: None) -> None:

--- a/creek-tools/tests/test_gemini_provider.py
+++ b/creek-tools/tests/test_gemini_provider.py
@@ -123,8 +123,8 @@ class TestGeminiModelResolution:
     """Model resolution mirrors the other providers."""
 
     def test_default_model_literal(self) -> None:
-        """The default Gemini model literal lives on the provider."""
-        assert GeminiProvider.DEFAULT_MODEL == "gemini-2.5-flash"
+        """The default Gemini model is the current stable flash tier (#622)."""
+        assert GeminiProvider.DEFAULT_MODEL == "gemini-3.5-flash"
 
     def test_falls_back_when_model_unset(self, gemini_env: None) -> None:
         """An unset ``config.model`` (``None``) falls back to the Gemini default."""

--- a/creek-tools/tests/test_llm_provider_factory.py
+++ b/creek-tools/tests/test_llm_provider_factory.py
@@ -88,7 +88,7 @@ def test_llmconfig_accepts_every_registered_provider() -> None:
 
 
 class TestDefaultModelsMatrix:
-    """Pins the #622 contract: one matrix holds every default model ID.
+    """One matrix holds every default model ID.
 
     Mirrors CrawDad's ``config.py`` model dicts — "introduce another model"
     must be a one-place edit, and the matrix can never drift from the

--- a/creek-tools/tests/test_llm_provider_factory.py
+++ b/creek-tools/tests/test_llm_provider_factory.py
@@ -22,11 +22,13 @@ import pytest
 from creek.classify.llm.base import LLMProvider
 from creek.classify.llm.completion import Completion
 from creek.classify.llm.providers import (
+    DEFAULT_MODELS,
     AnthropicProvider,
     GeminiProvider,
     OllamaProvider,
     OpenAIProvider,
     build_provider,
+    known_providers,
     provider_is_cloud,
 )
 from creek.config import LLMConfig
@@ -81,10 +83,28 @@ def test_llmconfig_rejects_unknown_provider_at_construction() -> None:
 
 def test_llmconfig_accepts_every_registered_provider() -> None:
     """Every registered provider name is a valid ``LLMConfig.provider``."""
-    from creek.classify.llm.providers import known_providers
-
     for name in known_providers():
         assert LLMConfig(provider=name).provider == name
+
+
+class TestDefaultModelsMatrix:
+    """Pins the #622 contract: one matrix holds every default model ID.
+
+    Mirrors CrawDad's ``config.py`` model dicts — "introduce another model"
+    must be a one-place edit, and the matrix can never drift from the
+    provider registry.
+    """
+
+    def test_matrix_covers_every_registered_provider(self) -> None:
+        """``DEFAULT_MODELS`` and the provider registry name the same set."""
+        assert set(DEFAULT_MODELS) == set(known_providers())
+
+    def test_provider_classes_read_from_matrix(self) -> None:
+        """Each provider class's ``DEFAULT_MODEL`` is the matrix entry."""
+        assert DEFAULT_MODELS["anthropic"] == AnthropicProvider.DEFAULT_MODEL
+        assert DEFAULT_MODELS["openai"] == OpenAIProvider.DEFAULT_MODEL
+        assert DEFAULT_MODELS["gemini"] == GeminiProvider.DEFAULT_MODEL
+        assert DEFAULT_MODELS["ollama"] == OllamaProvider.DEFAULT_MODEL
 
 
 def test_provider_is_cloud_anthropic_true() -> None:

--- a/creek-tools/tests/test_no_model_literals.py
+++ b/creek-tools/tests/test_no_model_literals.py
@@ -1,0 +1,40 @@
+"""Static check: no LLM model-ID literals live outside the provider module.
+
+Model IDs move, so the per-provider ``DEFAULT_MODELS`` matrix in
+:mod:`creek.classify.llm.providers` is the contract. Other modules must read
+the resolved value (or accept a model argument), never reference the literal
+string — for Claude, OpenAI ``gpt-*``, or Gemini ``gemini-*``. Mirrors
+CrawDad's ``test_no_model_literals.py`` so both packages enforce the same
+one-place-edit rule.
+
+The check is a simple grep so it remains fast and trivially debuggable
+when it fires.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent.parent / "creek"
+_ALLOWED_FILE = _PACKAGE_ROOT / "classify" / "llm" / "providers.py"
+_MODEL_PATTERN = re.compile(
+    r"claude-(?:haiku|sonnet|opus)-\d|gpt-\d|gemini-\d", re.IGNORECASE
+)
+
+
+def test_no_model_id_literals_outside_providers() -> None:
+    """No ``creek/*.py`` (except the provider module) contains a model ID."""
+    offenders: list[str] = []
+    for path in _PACKAGE_ROOT.rglob("*.py"):
+        if path == _ALLOWED_FILE:
+            continue
+        text = path.read_text(encoding="utf-8")
+        match = _MODEL_PATTERN.search(text)
+        if match:
+            offenders.append(f"{path.relative_to(_PACKAGE_ROOT)}: {match.group(0)!r}")
+    assert not offenders, (
+        "model-ID literals found outside the provider module: "
+        + ", ".join(offenders)
+        + " — read DEFAULT_MODELS from creek.classify.llm.providers instead."
+    )

--- a/creek-tools/tests/test_no_model_literals.py
+++ b/creek-tools/tests/test_no_model_literals.py
@@ -19,7 +19,7 @@ from pathlib import Path
 _PACKAGE_ROOT = Path(__file__).resolve().parent.parent / "creek"
 _ALLOWED_FILE = _PACKAGE_ROOT / "classify" / "llm" / "providers.py"
 _MODEL_PATTERN = re.compile(
-    r"claude-(?:haiku|sonnet|opus)-\d|gpt-\d|gemini-\d", re.IGNORECASE
+    r"claude-(?:haiku|sonnet|opus|fable)-\d|gpt-\d|gemini-\d", re.IGNORECASE
 )
 
 

--- a/creek-tools/tests/test_no_model_literals.py
+++ b/creek-tools/tests/test_no_model_literals.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 _PACKAGE_ROOT = Path(__file__).resolve().parent.parent / "creek"
 _ALLOWED_FILE = _PACKAGE_ROOT / "classify" / "llm" / "providers.py"
+# Known gap: OpenAI's o-series names (o1/o3/o4-mini) are not matched; widen
+# the alternation if an o-series default is ever added to the matrix.
 _MODEL_PATTERN = re.compile(
     r"claude-(?:haiku|sonnet|opus|fable)-\d|gpt-\d|gemini-\d", re.IGNORECASE
 )

--- a/creek-tools/tests/test_openai_provider.py
+++ b/creek-tools/tests/test_openai_provider.py
@@ -106,8 +106,8 @@ class TestOpenAIModelResolution:
     """Model resolution mirrors the Anthropic unset-fallback logic."""
 
     def test_default_model_literal(self) -> None:
-        """The default OpenAI model literal lives on the provider."""
-        assert OpenAIProvider.DEFAULT_MODEL == "gpt-4o"
+        """The default OpenAI model is the current balanced tier (#622)."""
+        assert OpenAIProvider.DEFAULT_MODEL == "gpt-5.4"
 
     def test_falls_back_when_model_unset(self, openai_env: None) -> None:
         """An unset ``config.model`` (``None``) falls back to the OpenAI default."""

--- a/creek-tools/tests/test_openai_provider.py
+++ b/creek-tools/tests/test_openai_provider.py
@@ -106,7 +106,7 @@ class TestOpenAIModelResolution:
     """Model resolution mirrors the Anthropic unset-fallback logic."""
 
     def test_default_model_literal(self) -> None:
-        """The default OpenAI model is the current balanced tier (#622)."""
+        """The default OpenAI model is the current balanced tier."""
         assert OpenAIProvider.DEFAULT_MODEL == "gpt-5.4"
 
     def test_falls_back_when_model_unset(self, openai_env: None) -> None:


### PR DESCRIPTION
## Summary
- Adds `DEFAULT_MODELS: dict[str, str]` in `creek/classify/llm/providers.py` as the single source of truth for per-provider default model IDs, mirroring CrawDad's `config.py` matrix pattern. All four provider classes read their `DEFAULT_MODEL` from it, and "introduce another model" is now a one-place edit.
- Refreshes the cloud defaults to current model IDs (see verification below): OpenAI `gpt-4o` → `gpt-5.4`, Gemini `gemini-2.5-flash` → `gemini-3.5-flash`. Anthropic stays `claude-sonnet-4-6` and Ollama stays `mistral`.
- Ports CrawDad's `test_no_model_literals.py` guard so future model IDs can only land in the matrix, and adds an anti-drift test pinning `set(DEFAULT_MODELS) == set(known_providers())`.

## Model ID verification (for reviewers whose training data predates these releases)
Both new IDs postdate late-2025 training cutoffs, so they will look anomalous from memory — they are verified against live official sources:

| ID | Status | Official sources |
|---|---|---|
| `gpt-5.4` | Released 2026-03-05 | [Introducing GPT-5.4](https://openai.com/index/introducing-gpt-5-4/) (OpenAI announcement) · [GPT-5.4 model page](https://developers.openai.com/api/docs/models/gpt-5.4) (API docs) · [models catalog](https://developers.openai.com/api/docs/models) lists GPT-5.5 / GPT-5.4 / GPT-5.4-mini as the current lineup, with `gpt-4o` absent (legacy) |
| `gemini-3.5-flash` | GA/stable since 2026-05-19 | [Gemini 3.5 announcement](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-5/) (Google blog) · [gemini-3.5-flash model page](https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash) · [models catalog](https://ai.google.dev/gemini-api/docs/models) lists it Stable, with 2.5-flash superseded |

`gpt-4o` no longer appears in OpenAI's current-models catalog at all — keeping it would be exactly the aging-default problem #622 was filed to fix.

## Test plan
- New tests: matrix/registry anti-drift, provider classes read from the matrix, refreshed default-ID pins per provider, package-wide no-model-literals grep guard (now covering `claude-fable-*`).
- `./scripts/check-all.sh` exits 0 (12/12 checks: tests + coverage gates, mypy strict, ruff, pylint, bandit, complexity, docstrings).

Closes #622
Refs #603
