### PR TITLE
test(llm): add opt-in live smoke test per provider for model onboarding (#623)

### DIFF
--- a/crawdad/README.md
+++ b/crawdad/README.md
@@ -89,9 +89,11 @@ CrawDad's provider abstraction is intentionally **decoupled** from creek-tools' 
 **Live smoke test (model onboarding).** Unit tests mock every vendor SDK, so a model tier is only proven by a real call. With the provider's key in the env, one command makes a single tiny live request and asserts the normalized round-trip:
 
 ```bash
-./scripts/test.sh -m integration --no-cov -k openai                                       # smoke the composer's default tier
-CRAWDAD_COMPOSER_MODEL=some-new-model ./scripts/test.sh -m integration --no-cov -k gemini # smoke a candidate model id
+./scripts/test.sh -m integration -k openai                                       # smoke the composer's default tier
+CRAWDAD_COMPOSER_MODEL=some-new-model ./scripts/test.sh -m integration -k gemini # smoke a candidate model id
 ```
+
+(`test.sh` injects `--no-cov` for integration runs so the project-wide coverage gate doesn't bury the smoke output.)
 
 Each smoke skips cleanly when its key is absent; the default `./scripts/test.sh` run deselects the `integration` marker, so CI never makes (or bills) a live call.
 

--- a/crawdad/README.md
+++ b/crawdad/README.md
@@ -86,6 +86,15 @@ Starting the bot with the selected provider's key unset fails fast with a messag
 
 CrawDad's provider abstraction is intentionally **decoupled** from creek-tools' (sibling packages, no shared module) — see [ADR-0003](../creek-tools/docs/architecture/ADR/0003-decoupled-provider-abstractions.md).
 
+**Live smoke test (model onboarding).** Unit tests mock every vendor SDK, so a model tier is only proven by a real call. With the provider's key in the env, one command makes a single tiny live request and asserts the normalized round-trip:
+
+```bash
+./scripts/test.sh -m integration --no-cov -k openai                                       # smoke the composer's default tier
+CRAWDAD_COMPOSER_MODEL=some-new-model ./scripts/test.sh -m integration --no-cov -k gemini # smoke a candidate model id
+```
+
+Each smoke skips cleanly when its key is absent; the default `./scripts/test.sh` run deselects the `integration` marker, so CI never makes (or bills) a live call.
+
 ## Slash commands (FEAT-016)
 
 The `/crawdad` family registers automatically with Discord on startup.

--- a/crawdad/scripts/test.sh
+++ b/crawdad/scripts/test.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 # scripts/test.sh — Pytest with branch coverage gate.
+#
+# With no arguments, integration tests (live API smokes) are deselected so
+# the default run and CI never make — or bill — a real vendor call. Pass
+# pytest args explicitly to opt in, e.g.:
+#   ./scripts/test.sh -m integration --no-cov -k openai
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$(dirname "$SCRIPT_DIR")"
 
+if [[ $# -eq 0 ]]; then
+    set -- -m "not integration"
+fi
 pytest "$@"

--- a/crawdad/scripts/test.sh
+++ b/crawdad/scripts/test.sh
@@ -13,4 +13,14 @@ cd "$(dirname "$SCRIPT_DIR")"
 if [[ $# -eq 0 ]]; then
     set -- -m "not integration"
 fi
+# Inject --no-cov when explicitly targeting integration tests: the
+# project-wide --cov-fail-under=90 would otherwise trip on a handful of
+# live smokes and bury their output under a coverage failure. The negated
+# default selection ("not integration") must keep its coverage gate.
+for arg in "$@"; do
+    if [[ "$arg" == *integration* && "$arg" != *"not integration"* ]]; then
+        set -- "$@" --no-cov
+        break
+    fi
+done
 pytest "$@"

--- a/crawdad/tests/test_live_smoke.py
+++ b/crawdad/tests/test_live_smoke.py
@@ -5,10 +5,10 @@ until the first live run. Each test here proves the full round-trip
 (auth → request → normalized ``Completion``) against the live API using the
 composer tier resolved by :func:`crawdad.config.composer_model_for` — which
 honors the ``CRAWDAD_COMPOSER_MODEL`` env override, so onboarding a new model
-is one command::
+is one command (``test.sh`` injects ``--no-cov`` for integration runs)::
 
-    ./scripts/test.sh -m integration --no-cov -k openai
-    CRAWDAD_COMPOSER_MODEL=new-model ./scripts/test.sh -m integration --no-cov
+    ./scripts/test.sh -m integration -k openai
+    CRAWDAD_COMPOSER_MODEL=new-model ./scripts/test.sh -m integration
 
 These tests are ``integration``-marked (deselected by the default
 ``./scripts/test.sh`` run) and each skips cleanly when its provider's API key
@@ -17,6 +17,7 @@ is absent, so normal CI never runs or bills them.
 
 from __future__ import annotations
 
+import asyncio
 import os
 
 import pytest
@@ -33,18 +34,18 @@ pytestmark = pytest.mark.integration
 
 _PROMPT = "Reply with exactly the word OK and nothing else."
 
+_MESSAGES: list[dict[str, str]] = [{"role": "user", "content": _PROMPT}]
+"""The single-turn smoke payload."""
 
-def _messages() -> list[dict[str, str]]:
-    """Build the single-turn smoke payload.
-
-    Returns:
-        A one-element user message list carrying :data:`_PROMPT`.
-    """
-    return [{"role": "user", "content": _PROMPT}]
+_TIMEOUT_SECONDS = 30.0
+"""Wall-clock cap per live call so a hung endpoint cannot stall the suite."""
 
 
 def _assert_live_completion(completion: Completion) -> None:
     """Assert the normalized shape every live round-trip must produce.
+
+    All three cloud vendors report token usage on a successful completion,
+    so the smoke pins ``usage`` as populated alongside text and stop reason.
 
     Args:
         completion: The provider's normalized result for :data:`_PROMPT`.
@@ -53,6 +54,7 @@ def _assert_live_completion(completion: Completion) -> None:
     assert completion.stop_reason in {"end_turn", "max_tokens"}, (
         f"unrecognized stop reason {completion.stop_reason!r}"
     )
+    assert completion.usage is not None
 
 
 @pytest.mark.skipif(
@@ -63,8 +65,11 @@ async def test_anthropic_live_smoke() -> None:
     import anthropic
 
     provider = AnthropicAsyncProvider(anthropic.AsyncAnthropic())
-    completion = await provider.complete(
-        _messages(), model=composer_model_for("anthropic"), max_tokens=16
+    completion = await asyncio.wait_for(
+        provider.complete(
+            _MESSAGES, model=composer_model_for("anthropic"), max_tokens=16
+        ),
+        timeout=_TIMEOUT_SECONDS,
     )
     _assert_live_completion(completion)
 
@@ -77,8 +82,9 @@ async def test_openai_live_smoke() -> None:
     import openai
 
     provider = OpenAIAsyncProvider(openai.AsyncOpenAI())
-    completion = await provider.complete(
-        _messages(), model=composer_model_for("openai"), max_tokens=16
+    completion = await asyncio.wait_for(
+        provider.complete(_MESSAGES, model=composer_model_for("openai"), max_tokens=16),
+        timeout=_TIMEOUT_SECONDS,
     )
     _assert_live_completion(completion)
 
@@ -91,7 +97,8 @@ async def test_gemini_live_smoke() -> None:
     from google import genai
 
     provider = GeminiAsyncProvider(genai.Client())
-    completion = await provider.complete(
-        _messages(), model=composer_model_for("gemini"), max_tokens=16
+    completion = await asyncio.wait_for(
+        provider.complete(_MESSAGES, model=composer_model_for("gemini"), max_tokens=16),
+        timeout=_TIMEOUT_SECONDS,
     )
     _assert_live_completion(completion)

--- a/crawdad/tests/test_live_smoke.py
+++ b/crawdad/tests/test_live_smoke.py
@@ -1,0 +1,97 @@
+"""Opt-in live smoke tests: one tiny real API call per async LLM provider.
+
+CrawDad's provider tests mock every vendor SDK, so a model tier is unverified
+until the first live run. Each test here proves the full round-trip
+(auth → request → normalized ``Completion``) against the live API using the
+composer tier resolved by :func:`crawdad.config.composer_model_for` — which
+honors the ``CRAWDAD_COMPOSER_MODEL`` env override, so onboarding a new model
+is one command::
+
+    ./scripts/test.sh -m integration --no-cov -k openai
+    CRAWDAD_COMPOSER_MODEL=new-model ./scripts/test.sh -m integration --no-cov
+
+These tests are ``integration``-marked (deselected by the default
+``./scripts/test.sh`` run) and each skips cleanly when its provider's API key
+is absent, so normal CI never runs or bills them.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from crawdad.config import composer_model_for
+from crawdad.llm import (
+    AnthropicAsyncProvider,
+    Completion,
+    GeminiAsyncProvider,
+    OpenAIAsyncProvider,
+)
+
+pytestmark = pytest.mark.integration
+
+_PROMPT = "Reply with exactly the word OK and nothing else."
+
+
+def _messages() -> list[dict[str, str]]:
+    """Build the single-turn smoke payload.
+
+    Returns:
+        A one-element user message list carrying :data:`_PROMPT`.
+    """
+    return [{"role": "user", "content": _PROMPT}]
+
+
+def _assert_live_completion(completion: Completion) -> None:
+    """Assert the normalized shape every live round-trip must produce.
+
+    Args:
+        completion: The provider's normalized result for :data:`_PROMPT`.
+    """
+    assert completion.text.strip(), "live completion returned empty text"
+    assert completion.stop_reason in {"end_turn", "max_tokens"}, (
+        f"unrecognized stop reason {completion.stop_reason!r}"
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set"
+)
+async def test_anthropic_live_smoke() -> None:
+    """One real Anthropic call normalizes to a populated ``Completion``."""
+    import anthropic
+
+    provider = AnthropicAsyncProvider(anthropic.AsyncAnthropic())
+    completion = await provider.complete(
+        _messages(), model=composer_model_for("anthropic"), max_tokens=16
+    )
+    _assert_live_completion(completion)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
+)
+async def test_openai_live_smoke() -> None:
+    """One real OpenAI call normalizes to a populated ``Completion``."""
+    import openai
+
+    provider = OpenAIAsyncProvider(openai.AsyncOpenAI())
+    completion = await provider.complete(
+        _messages(), model=composer_model_for("openai"), max_tokens=16
+    )
+    _assert_live_completion(completion)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("GOOGLE_API_KEY"), reason="GOOGLE_API_KEY not set"
+)
+async def test_gemini_live_smoke() -> None:
+    """One real Gemini call normalizes to a populated ``Completion``."""
+    from google import genai
+
+    provider = GeminiAsyncProvider(genai.Client())
+    completion = await provider.complete(
+        _messages(), model=composer_model_for("gemini"), max_tokens=16
+    )
+    _assert_live_completion(completion)

--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -185,6 +185,15 @@ The cloud LLM backend is selectable via `llm.provider` in `creek_config.yaml`. T
 
 The architectural decision to keep creek-tools' and CrawDad's provider abstractions decoupled is recorded in [ADR-0003](docs/architecture/ADR/0003-decoupled-provider-abstractions.md).
 
+**Live smoke test (model onboarding).** Unit tests mock every vendor SDK, so a model id is only proven by a real call. With the provider's key (and consent) in the env, one command makes a single tiny live request and asserts the normalized round-trip:
+
+```bash
+./scripts/test.sh --integration -k openai                                  # smoke the provider's default model
+CREEK_SMOKE_MODEL=some-new-model ./scripts/test.sh --integration -k gemini # smoke a candidate model id
+```
+
+Each smoke skips cleanly when its key is absent, and the `integration` marker keeps them out of the default test selection and CI entirely.
+
 ---
 
 ## Source platforms

--- a/creek-tools/scripts/test.sh
+++ b/creek-tools/scripts/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # scripts/test.sh - Run tests with Pytest
 # Usage: ./scripts/test.sh [--unit|--integration|--e2e|--all] [--coverage]
-#                          [--verbose] [--help]
+#                          [-k EXPRESSION] [--verbose] [--help]
 
 set -euo pipefail
 
@@ -14,6 +14,7 @@ source "$SCRIPT_DIR/_lib.sh"
 TEST_TYPE="unit"
 COVERAGE=false
 VERBOSE=false
+KEYWORD=""
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
@@ -38,6 +39,14 @@ while [[ $# -gt 0 ]]; do
             COVERAGE=true
             shift
             ;;
+        -k)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: -k requires an expression argument" >&2
+                exit 2
+            fi
+            KEYWORD="$2"
+            shift 2
+            ;;
         --verbose)
             VERBOSE=true
             shift
@@ -50,10 +59,11 @@ Run tests using Pytest.
 
 OPTIONS:
     --unit          Run unit tests only (default)
-    --integration   Run integration tests only
-    --e2e           Run end-to-end tests only
+    --integration   Run integration tests only (live smokes; coverage gate off)
+    --e2e           Run end-to-end tests only (coverage gate off)
     --all           Run all test types
     --coverage      Generate coverage report
+    -k EXPRESSION   Only run tests matching the pytest keyword expression
     --verbose       Show detailed output
     --help          Display this help message
 
@@ -97,16 +107,23 @@ case "$TEST_TYPE" in
         ;;
     integration)
         echo "=== Running Integration Tests ==="
-        PYTEST_ARGS+=(-m "integration")
+        # A marker-only selection runs a handful of tests, so the project-wide
+        # --cov-fail-under from pyproject addopts would always fail; live
+        # smokes are about API round-trips, not coverage.
+        PYTEST_ARGS+=(-m "integration" --no-cov)
         ;;
     e2e)
         echo "=== Running End-to-End Tests ==="
-        PYTEST_ARGS+=(-m "e2e")
+        PYTEST_ARGS+=(-m "e2e" --no-cov)
         ;;
     all)
         echo "=== Running All Tests ==="
         ;;
 esac
+
+if [[ -n "$KEYWORD" ]]; then
+    PYTEST_ARGS+=(-k "$KEYWORD")
+fi
 
 # Add coverage if requested
 if $COVERAGE; then

--- a/creek-tools/tests/test_live_smoke.py
+++ b/creek-tools/tests/test_live_smoke.py
@@ -1,0 +1,121 @@
+"""Opt-in live smoke tests: one tiny real API call per LLM provider.
+
+Every other provider test mocks the vendor SDK, which is right for unit
+coverage but means a model id is unverified until the first live run — and
+the things mocks paper over (valid model ids, stop-reason enums, usage field
+names) are exactly what drift. Each test here proves the full round-trip
+(auth → request → normalized ``Completion``) against the live API.
+
+These tests are ``integration``-marked, so the default test selection and CI
+never run (or bill) them. Each one also skips cleanly when its provider's
+API key is absent. To smoke a provider when onboarding a new model id::
+
+    ./scripts/test.sh --integration -k openai
+    CREEK_SMOKE_MODEL=some-new-model ./scripts/test.sh --integration -k openai
+
+``CREEK_SMOKE_MODEL`` overrides the provider's default model for the run;
+unset, each provider exercises its own ``DEFAULT_MODELS`` entry.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.classify.llm.consent import CLOUD_CONSENT_ENV
+from creek.classify.llm.providers import (
+    AnthropicProvider,
+    GeminiProvider,
+    OllamaProvider,
+    OpenAIProvider,
+)
+from creek.config import LLMConfig
+
+if TYPE_CHECKING:
+    from creek.classify.llm.completion import Completion
+
+pytestmark = pytest.mark.integration
+
+_PROMPT = "Reply with exactly the word OK and nothing else."
+
+_SMOKE_MODEL_ENV = "CREEK_SMOKE_MODEL"
+"""Env var overriding the model id under test (unset → provider default)."""
+
+
+def _smoke_config(provider: str) -> LLMConfig:
+    """Build the config for a smoke run, honoring the model override.
+
+    Args:
+        provider: The registered provider name to smoke.
+
+    Returns:
+        An ``LLMConfig`` whose model is :data:`_SMOKE_MODEL_ENV` when set,
+        else ``None`` so the provider applies its own default.
+    """
+    return LLMConfig(provider=provider, model=os.environ.get(_SMOKE_MODEL_ENV))
+
+
+def _assert_live_completion(completion: Completion) -> None:
+    """Assert the normalized shape every live round-trip must produce.
+
+    Args:
+        completion: The provider's normalized result for :data:`_PROMPT`.
+    """
+    assert completion.text.strip(), "live completion returned empty text"
+    assert completion.stop_reason in {"end_turn", "max_tokens"}, (
+        f"unrecognized stop reason {completion.stop_reason!r}"
+    )
+
+
+@pytest.mark.skipif(
+    not os.environ.get("ANTHROPIC_API_KEY"), reason="ANTHROPIC_API_KEY not set"
+)
+def test_anthropic_live_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One real Anthropic call normalizes to a populated ``Completion``."""
+    monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+    provider = AnthropicProvider(_smoke_config("anthropic"))
+    completion = provider.complete(_PROMPT, max_tokens=16)
+    _assert_live_completion(completion)
+    assert completion.usage is not None
+
+
+@pytest.mark.skipif(
+    not os.environ.get("OPENAI_API_KEY"), reason="OPENAI_API_KEY not set"
+)
+def test_openai_live_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One real OpenAI call normalizes to a populated ``Completion``."""
+    monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+    provider = OpenAIProvider(_smoke_config("openai"))
+    completion = provider.complete(_PROMPT, max_tokens=16)
+    _assert_live_completion(completion)
+    assert completion.usage is not None
+
+
+@pytest.mark.skipif(
+    not any(os.environ.get(var) for var in GeminiProvider.API_KEY_ENVS),
+    reason="neither GOOGLE_API_KEY nor GEMINI_API_KEY is set",
+)
+def test_gemini_live_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One real Gemini call normalizes to a populated ``Completion``."""
+    monkeypatch.setenv(CLOUD_CONSENT_ENV, "1")
+    provider = GeminiProvider(_smoke_config("gemini"))
+    completion = provider.complete(_PROMPT, max_tokens=16)
+    _assert_live_completion(completion)
+    assert completion.usage is not None
+
+
+def test_ollama_live_smoke() -> None:
+    """One real local Ollama call normalizes to a populated ``Completion``.
+
+    Gated on endpoint reachability rather than a key — Ollama is local and
+    keyless. Ollama's generate API reports no token usage, so ``usage`` stays
+    ``None`` by contract.
+    """
+    provider = OllamaProvider(_smoke_config("ollama"))
+    if not provider.available:
+        pytest.skip("Ollama endpoint not reachable")
+    completion = provider.complete(_PROMPT, max_tokens=16)
+    _assert_live_completion(completion)
+    assert completion.usage is None


### PR DESCRIPTION
## Summary
- Adds one `integration`-marked live smoke test per provider in **both packages**: creek-tools (`tests/test_live_smoke.py` — anthropic / openai / gemini / ollama) and CrawDad (`tests/test_live_smoke.py` — anthropic / openai / gemini, async). Each makes a single tiny real `complete()` call and asserts the normalized `Completion` round-trip (non-empty text, recognized stop reason, per-provider usage semantics). Every smoke skips cleanly when its provider's key is absent (Ollama gates on endpoint reachability instead).
- Makes the smoke a one-command model-onboarding check, documented in both READMEs: `CREEK_SMOKE_MODEL=<id> ./scripts/test.sh --integration -k <provider>` (creek-tools) and `CRAWDAD_COMPOSER_MODEL=<id> ./scripts/test.sh -m integration --no-cov` (CrawDad, via the existing env override).
- Keeps default runs and CI live-call-free: CrawDad's `test.sh` now deselects the `integration` marker on bare invocation (previously bare `pytest` would have selected it), and creek-tools' `--integration`/`--e2e` selections pass `--no-cov` — fixing a pre-existing breakage where the project-wide `--cov-fail-under=90` from pyproject `addopts` made any marker-only run fail unconditionally. `test.sh` also gains `-k` passthrough, which the issue's own proposed command assumed.

## Test plan
- With all vendor keys explicitly blanked: creek-tools `./scripts/test.sh --integration -k live_smoke` → 4 skipped, 5467 deselected; CrawDad `./scripts/test.sh -m integration --no-cov -k live_smoke` → 3 skipped.
- CrawDad bare `./scripts/test.sh` → 481 passed, 3 deselected, coverage 94.87% (default behavior preserved, smokes excluded).
- `./scripts/check-all.sh` exits 0 in both packages (12/12 and 7/7).
- Live-call paths exercised by design only when an operator opts in with keys present (no keys available in this session — see #623's thread for the first verification target).

Closes #623
Refs #603
