### PR TITLE
docs(llm): ADR-0004 — embeddings stay local-only, hosted backends deferred (#624)

### DIFF
--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -185,6 +185,8 @@ The cloud LLM backend is selectable via `llm.provider` in `creek_config.yaml`. T
 
 The architectural decision to keep creek-tools' and CrawDad's provider abstractions decoupled is recorded in [ADR-0003](docs/architecture/ADR/0003-decoupled-provider-abstractions.md).
 
+**Embeddings are deliberately not provider-swappable.** `llm.provider` selects the *completion* backend only; the resonance/linking path always embeds locally via sentence-transformers (`embeddings.model`), so vault text never leaves the device for linking and the vector index stays stable. The decision and its reopening criteria are recorded in [ADR-0004](docs/architecture/ADR/0004-embeddings-stay-local.md).
+
 **Live smoke test (model onboarding).** Unit tests mock every vendor SDK, so a model id is only proven by a real call. With the provider's key (and consent) in the env, one command makes a single tiny live request and asserts the normalized round-trip:
 
 ```bash

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -159,10 +159,19 @@ class LLMConfig(BaseModel):
 
 
 class EmbeddingsConfig(BaseModel):
-    """Embedding model configuration."""
+    """Embedding model configuration.
+
+    Embeddings are local-only by design — unlike ``llm.provider``, there is no
+    cloud backend selection here, so vault text never leaves the device for
+    linking (see ``docs/architecture/ADR/0004-embeddings-stay-local.md``).
+    """
 
     model: str = "all-MiniLM-L6-v2"
-    """Sentence-transformer model used to generate embeddings."""
+    """Sentence-transformer model used to generate embeddings (always local).
+
+    Changing it invalidates the on-disk vector cache: every fragment must be
+    re-embedded and ``similarity_threshold`` re-calibrated for the new model.
+    """
 
     similarity_threshold: float = 0.75
     """Minimum cosine similarity for linking fragments."""

--- a/creek-tools/docs/architecture/ADR/0004-embeddings-stay-local.md
+++ b/creek-tools/docs/architecture/ADR/0004-embeddings-stay-local.md
@@ -1,0 +1,90 @@
+# ADR-0004: Embeddings stay local-only; hosted embedding backends deferred
+
+- **Status**: Accepted
+- **Date**: 2026-06-10
+- **Driving issue**: #624 (follow-up to epic #603, swappable LLM providers).
+
+## Context
+
+Epic #603 made the **completion** backend selectable (Anthropic / OpenAI /
+Gemini / Ollama) with keys from env and a cloud-egress consent gate. Embeddings
+were deliberately untouched: the resonance/linking path is hardwired to a local
+sentence-transformers model (`EmbeddingsConfig.model = "all-MiniLM-L6-v2"`,
+384 dimensions), cached on disk at `00-Creek-Meta/embeddings.parquet` inside
+the user's vault.
+
+Someone who sets `llm.provider: openai` might reasonably expect embeddings to
+follow. The question #624 poses: is hosted-embedding support (OpenAI
+`text-embedding-3-*`, Gemini `text-embedding-004`, …) wanted, or is local-only
+intentional?
+
+Facts that drive the decision:
+
+1. **Embeddings touch the entire vault, not a prompt at a time.** Completion
+   calls send one fragment's worth of content per request, gated by explicit
+   consent. Embedding ships *every fragment's full text* off-device on first
+   index and re-ships it on every re-embed. It is the largest possible privacy
+   egress surface in the pipeline, against the project's local-first posture.
+2. **Provider choice is index-defining, not call-defining.** A completion
+   provider can change per run with no migration. An embedding model defines
+   the vector space: switching models (or providers) changes dimensionality
+   (384 for MiniLM vs. 1536/3072 for `text-embedding-3-*` vs. 768 for
+   `text-embedding-004`) and invalidates `embeddings.parquet` wholesale —
+   every fragment must be re-embedded and every similarity threshold
+   re-calibrated (`embeddings.similarity_threshold` is tuned for MiniLM's
+   cosine distribution). Cross-model vectors must never be compared; a
+   half-migrated cache silently produces garbage resonances.
+3. **The known scaling pain is not embedding quality.** The O(n²) pairwise
+   linking pass is what fails on large vaults (#596 capped it); hosted
+   embeddings would not address that and would add per-token cost and latency
+   to a path that is currently free, offline, and private.
+4. **Recurring cost asymmetry.** Completions are occasional and user-triggered;
+   embedding is bulk and re-runs across the whole corpus. A 10k-fragment vault
+   re-embeds everything on any model change — hosted pricing turns a free
+   local operation into a metered one with little demonstrated quality need.
+
+## Decision
+
+**Embeddings remain local-only (sentence-transformers) by design.** No
+`EmbeddingsProvider` abstraction, factory, optional cloud SDK deps, or env-key
+discovery is introduced for embeddings at this time. `EmbeddingsConfig.model`
+continues to select among *local* sentence-transformers models only.
+
+Local-only is recorded here as a deliberate architectural property — privacy
+(vault text never leaves the device for linking), zero marginal cost, and
+offline operation — not as an unfinished half of #603.
+
+### Reopening criteria
+
+Supersede this ADR with a hosted-embeddings design when **any** of the
+following becomes true:
+
+- A measured resonance-quality gap on real vault content is attributed to the
+  local model (not to thresholds or the linking algorithm), with an evaluation
+  set demonstrating a hosted model closes it.
+- A vault-scale semantic feature is planned that local models demonstrably
+  cannot serve (e.g. cross-lingual resonance over a multilingual vault).
+- The linking path is re-architected (post-#596) such that embedding quality —
+  rather than pairwise comparison cost — becomes the binding constraint.
+
+Any successor design must include: the same cloud-egress consent gate as
+completions (`creek.classify.llm.consent` — bulk embedding is strictly more
+egress than a single completion), keys from env only, an explicit
+index-migration story (dimensionality change ⇒ full re-embed + threshold
+re-calibration + parquet invalidation), and local sentence-transformers
+remaining the default.
+
+## Consequences
+
+- **Positive**: vault content never leaves the device for linking; the
+  resonance path keeps working offline and free; no index-migration machinery
+  to build or maintain; `provider:`-swap expectations are documented instead
+  of silently divergent.
+- **Negative**: users wanting hosted embedding quality have no supported knob;
+  `llm.provider` and embeddings behavior are asymmetric (completion is
+  swappable, embeddings are not) — this ADR plus the README note are the
+  mitigation for that surprise.
+- **Neutral**: `EmbeddingsConfig.model` still allows choosing a different
+  *local* sentence-transformers model; doing so has the same re-embed
+  consequence documented above (the parquet cache must be deleted to force a
+  full re-index).


### PR DESCRIPTION
## Summary
- Records the #624 decision as [ADR-0004](creek-tools/docs/architecture/ADR/0004-embeddings-stay-local.md): **embeddings stay local-only (sentence-transformers); hosted embedding backends are deferred.** The issue explicitly asked for a decision before any build ("may legitimately be out of scope — local embeddings are private, free, and offline: a feature, not a deficiency"), and the ADR takes that position deliberately rather than leaving it implicit.
- Rationale captured in the ADR: embedding is the pipeline's largest privacy egress (whole-vault text, re-shipped on every re-embed) versus per-prompt completions; provider choice is *index-defining* (dimensionality changes invalidate `embeddings.parquet` wholesale and require threshold re-calibration); the known scaling pain (#596) is the O(n²) linking pass, not embedding quality; and hosted pricing turns a free bulk operation into a metered one. Explicit **reopening criteria** and the requirements for any successor design (consent gate, env keys, index-migration story, local default) are recorded so this is supersedable, not a dead end.
- Documents the asymmetry where users will see it: README's LLM-providers section now states `llm.provider` selects the completion backend only, and `EmbeddingsConfig`'s docstrings state embeddings are local by design and that changing the local model forces a full re-embed + threshold re-calibration (the issue's dimensionality/index-compatibility acceptance item).

## Test plan
- Docs + docstring change; no behavior. `./scripts/check-all.sh` exits 0 (12/12 — including interrogate docstring coverage and ruff over the touched `config.py`).

Closes #624
Refs #603
