### PR TITLE
fix(llm): honor rate-limit backoff; document caching/streaming asymmetry (#625)

### DIFF
--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -187,6 +187,12 @@ The architectural decision to keep creek-tools' and CrawDad's provider abstracti
 
 **Embeddings are deliberately not provider-swappable.** `llm.provider` selects the *completion* backend only; the resonance/linking path always embeds locally via sentence-transformers (`embeddings.model`), so vault text never leaves the device for linking and the vector index stays stable. The decision and its reopening criteria are recorded in [ADR-0004](docs/architecture/ADR/0004-embeddings-stay-local.md).
 
+**Provider capability notes.** The abstraction normalizes text, stop reason, and usage — three behaviors intentionally remain per-provider:
+
+- **Rate limits**: a vendor 429 surfaces with the server's `Retry-After` hint preserved (never request state), and the classifier's retry loop honors it instead of retrying on the fixed delay.
+- **Prompt caching** (cost asymmetry): Anthropic gets an explicit ephemeral `cache_control` block on the static system prefix; OpenAI relies on its vendor-side automatic prompt caching; Gemini sends the prefix plain (no explicit caching wired). Repeated static prefixes therefore bill differently per provider.
+- **Streaming**: the abstraction is non-streaming by design — fine for batch classification and current consumers; a token-streaming UX would need a protocol extension.
+
 **Live smoke test (model onboarding).** Unit tests mock every vendor SDK, so a model id is only proven by a real call. With the provider's key (and consent) in the env, one command makes a single tiny live request and asserts the normalized round-trip:
 
 ```bash

--- a/creek-tools/creek/classify/llm/orchestrator.py
+++ b/creek-tools/creek/classify/llm/orchestrator.py
@@ -27,6 +27,7 @@ from creek.classify.llm.parsing import (
 from creek.classify.llm.prompts import build_classification_prompt
 from creek.classify.llm.providers import (
     Completion,
+    ProviderRateLimitError,
     build_provider,
     cloud_warning,
     provider_display_name,
@@ -350,7 +351,7 @@ class LLMClassifier:
                     exc,
                 )
                 if attempt < self.MAX_RETRIES - 1:
-                    time.sleep(self.RETRY_DELAY)
+                    time.sleep(self._retry_delay_for(exc))
             else:
                 # _apply_classification is a pure transform (no network I/O)
                 # and lives in the else block intentionally: a failure here
@@ -371,6 +372,25 @@ class LLMClassifier:
             fragment.title,
         )
         return LLMClassificationResult(fragment=fragment, reasoning="")
+
+    def _retry_delay_for(self, exc: Exception) -> float:
+        """Resolve the backoff before the next retry attempt.
+
+        Honors the server's ``Retry-After`` hint on a rate-limited call —
+        retrying sooner than the server asked makes the rate-limiting worse —
+        clamped to at least :attr:`RETRY_DELAY` so a tiny hint never speeds
+        retries up beyond the fixed baseline. Every other failure keeps the
+        historical fixed delay.
+
+        Args:
+            exc: The exception that failed the attempt.
+
+        Returns:
+            Seconds to sleep before the next attempt.
+        """
+        if isinstance(exc, ProviderRateLimitError) and exc.retry_after is not None:
+            return max(exc.retry_after, self.RETRY_DELAY)
+        return self.RETRY_DELAY
 
     def classify_batch(
         self,

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -51,6 +51,7 @@ __all__ = [
     "GeminiProvider",
     "OllamaProvider",
     "OpenAIProvider",
+    "ProviderRateLimitError",
     "build_provider",
     "cloud_warning",
     "known_providers",
@@ -84,6 +85,60 @@ def _resolve_configured_model(configured: str | None, default: str) -> str:
     """
     model = (configured or "").strip()
     return model or default
+
+
+_HTTP_TOO_MANY_REQUESTS: int = 429
+"""The HTTP status code for a rate-limited request."""
+
+
+class ProviderRateLimitError(RuntimeError):
+    """A vendor rate-limit (429) response, with the server's backoff hint.
+
+    Subclasses :class:`RuntimeError` so every existing retry/except path keeps
+    catching it; the message stays redacted to the exception type name like
+    any other provider error. The only extra information carried is the
+    ``Retry-After`` value — never request state or response bodies — so the
+    retry loop can honor the server's backoff instead of retrying blind.
+
+    Attributes:
+        retry_after: Seconds the server asked clients to wait before retrying,
+            or ``None`` when the response carried no usable hint.
+    """
+
+    def __init__(self, message: str, *, retry_after: float | None = None) -> None:
+        """Store the redacted message and the optional backoff hint.
+
+        Args:
+            message: The redacted, provider-prefixed error message.
+            retry_after: Seconds from the response's ``Retry-After`` header,
+                or ``None`` when absent.
+        """
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
+def _retry_after_seconds(exc: object) -> float | None:
+    """Extract a ``Retry-After`` hint (in seconds) from a vendor exception.
+
+    Every supported SDK attaches the underlying ``httpx.Response`` to its
+    rate-limit exception; the header is read defensively so a missing
+    response, missing header, or HTTP-date form (which ``float`` rejects)
+    degrades to ``None`` rather than raising.
+
+    Args:
+        exc: The vendor SDK exception.
+
+    Returns:
+        The non-negative seconds value, or ``None`` when unavailable.
+    """
+    headers = getattr(getattr(exc, "response", None), "headers", None)
+    if headers is None:
+        return None
+    raw = headers.get("retry-after")
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        return None
 
 
 # Per-provider default model IDs. This matrix is the ONLY place model literals
@@ -305,6 +360,11 @@ class AnthropicProvider:
         ceiling = self.MAX_TOKENS if max_tokens is None else max_tokens
         try:
             response = self._create_message(prompt, ceiling, system)
+        except anthropic.RateLimitError as exc:
+            msg = f"Anthropic API call rate-limited: {type(exc).__name__}"
+            raise ProviderRateLimitError(
+                msg, retry_after=_retry_after_seconds(exc)
+            ) from None
         except anthropic.AnthropicError as exc:
             msg = f"Anthropic API call failed: {type(exc).__name__}"
             raise RuntimeError(msg) from None
@@ -691,6 +751,11 @@ class OpenAIProvider:
         ceiling = self.MAX_TOKENS if max_tokens is None else max_tokens
         try:
             response = self._create_chat(prompt, ceiling, system)
+        except openai.RateLimitError as exc:
+            msg = f"OpenAI API call rate-limited: {type(exc).__name__}"
+            raise ProviderRateLimitError(
+                msg, retry_after=_retry_after_seconds(exc)
+            ) from None
         except openai.OpenAIError as exc:
             msg = f"OpenAI API call failed: {type(exc).__name__}"
             raise RuntimeError(msg) from None
@@ -927,6 +992,11 @@ class GeminiProvider:
         try:
             response = self._generate(prompt, ceiling, system)
         except errors.APIError as exc:
+            if getattr(exc, "code", None) == _HTTP_TOO_MANY_REQUESTS:
+                msg = f"Gemini API call rate-limited: {type(exc).__name__}"
+                raise ProviderRateLimitError(
+                    msg, retry_after=_retry_after_seconds(exc)
+                ) from None
             msg = f"Gemini API call failed: {type(exc).__name__}"
             raise RuntimeError(msg) from None
         return Completion(

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -926,6 +926,62 @@ class TestClassify:
 
     @patch.object(LLMClassifier, "_invoke_llm")
     @patch("creek.classify.llm.time.sleep")
+    def test_rate_limited_retry_honors_server_backoff(
+        self,
+        mock_sleep: MagicMock,
+        mock_call: MagicMock,
+    ) -> None:
+        """A 429 with Retry-After sleeps the server's hint, not the fixed delay."""
+        from creek.classify.llm.providers import ProviderRateLimitError
+
+        mock_call.side_effect = [
+            ProviderRateLimitError("rate-limited", retry_after=7.5),
+            _VALID_YAML_RESPONSE,
+        ]
+        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
+        result = classifier.classify(_make_fragment())
+        assert result.frequency.primary == Frequency.F3
+        mock_sleep.assert_called_once_with(7.5)
+
+    @patch.object(LLMClassifier, "_invoke_llm")
+    @patch("creek.classify.llm.time.sleep")
+    def test_rate_limited_retry_without_hint_uses_fixed_delay(
+        self,
+        mock_sleep: MagicMock,
+        mock_call: MagicMock,
+    ) -> None:
+        """A 429 without Retry-After falls back to the fixed retry delay."""
+        from creek.classify.llm.providers import ProviderRateLimitError
+
+        mock_call.side_effect = [
+            ProviderRateLimitError("rate-limited"),
+            _VALID_YAML_RESPONSE,
+        ]
+        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
+        result = classifier.classify(_make_fragment())
+        assert result.frequency.primary == Frequency.F3
+        mock_sleep.assert_called_once_with(classifier.RETRY_DELAY)
+
+    @patch.object(LLMClassifier, "_invoke_llm")
+    @patch("creek.classify.llm.time.sleep")
+    def test_rate_limit_hint_below_fixed_delay_is_clamped(
+        self,
+        mock_sleep: MagicMock,
+        mock_call: MagicMock,
+    ) -> None:
+        """A Retry-After shorter than the fixed delay never speeds retries up."""
+        from creek.classify.llm.providers import ProviderRateLimitError
+
+        mock_call.side_effect = [
+            ProviderRateLimitError("rate-limited", retry_after=0.1),
+            _VALID_YAML_RESPONSE,
+        ]
+        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
+        classifier.classify(_make_fragment())
+        mock_sleep.assert_called_once_with(classifier.RETRY_DELAY)
+
+    @patch.object(LLMClassifier, "_invoke_llm")
+    @patch("creek.classify.llm.time.sleep")
     def test_returns_unchanged_after_all_retries(
         self,
         mock_sleep: MagicMock,
@@ -1471,6 +1527,34 @@ class TestAnthropicProviderCall:
         assert kwargs["messages"] == [
             {"role": "user", "content": "hello prompt"},
         ]
+
+    def test_rate_limit_surfaces_retry_after(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A vendor 429 maps to ProviderRateLimitError carrying Retry-After."""
+        import anthropic
+
+        from creek.classify.llm.providers import ProviderRateLimitError
+
+        _set_anthropic_env(monkeypatch)
+        response = httpx.Response(
+            429,
+            headers={"retry-after": "3.5"},
+            request=httpx.Request("POST", "https://api.anthropic.com"),
+        )
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = anthropic.RateLimitError(
+            "secret request payload", response=response, body=None
+        )
+        with patch("anthropic.Anthropic", return_value=mock_client):
+            provider = AnthropicProvider(LLMConfig(provider="anthropic"))
+            with pytest.raises(ProviderRateLimitError) as exc:
+                provider.call("prompt")
+        assert exc.value.retry_after == 3.5
+        assert "secret" not in str(exc.value)
+        # Still a RuntimeError, so every existing retry/except path catches it.
+        assert isinstance(exc.value, RuntimeError)
 
     def test_call_concatenates_multiple_text_blocks(
         self,

--- a/creek-tools/tests/test_gemini_provider.py
+++ b/creek-tools/tests/test_gemini_provider.py
@@ -216,6 +216,47 @@ class TestGeminiComplete:
         assert "APIError" in message
         assert "secret" not in message
 
+    def test_rate_limit_surfaces_retry_after(self, gemini_env: None) -> None:
+        """A vendor 429 maps to ProviderRateLimitError carrying Retry-After."""
+        import httpx
+        from google.genai import errors
+
+        from creek.classify.llm.providers import ProviderRateLimitError
+
+        response = httpx.Response(
+            429,
+            headers={"retry-after": "11"},
+            request=httpx.Request("POST", "https://generativelanguage.googleapis.com"),
+        )
+        client = MagicMock()
+        client.models.generate_content.side_effect = errors.APIError(
+            429, {"error": {"message": "secret request payload"}}, response
+        )
+        with patch("google.genai.Client", return_value=client):
+            provider = GeminiProvider(LLMConfig(provider="gemini"))
+            with pytest.raises(ProviderRateLimitError) as exc:
+                provider.complete("p")
+        assert exc.value.retry_after == 11.0
+        assert "secret" not in str(exc.value)
+
+    def test_rate_limit_without_response_has_no_retry_after(
+        self, gemini_env: None
+    ) -> None:
+        """A 429 with no response headers still maps, with ``retry_after=None``."""
+        from google.genai import errors
+
+        from creek.classify.llm.providers import ProviderRateLimitError
+
+        client = MagicMock()
+        client.models.generate_content.side_effect = errors.APIError(
+            429, {"error": {"message": "rate limited"}}
+        )
+        with patch("google.genai.Client", return_value=client):
+            provider = GeminiProvider(LLMConfig(provider="gemini"))
+            with pytest.raises(ProviderRateLimitError) as exc:
+                provider.complete("p")
+        assert exc.value.retry_after is None
+
 
 def test_gemini_end_to_end_classify(gemini_env: None) -> None:
     """A mocked end-to-end classify via provider=gemini returns a Completion."""

--- a/creek-tools/tests/test_openai_provider.py
+++ b/creek-tools/tests/test_openai_provider.py
@@ -199,6 +199,51 @@ class TestOpenAIComplete:
         assert "OpenAIError" in message
         assert "secret" not in message
 
+    def test_rate_limit_surfaces_retry_after(self, openai_env: None) -> None:
+        """A vendor 429 maps to ProviderRateLimitError carrying Retry-After."""
+        import httpx
+        import openai
+
+        from creek.classify.llm.providers import ProviderRateLimitError
+
+        response = httpx.Response(
+            429,
+            headers={"retry-after": "7"},
+            request=httpx.Request("POST", "https://api.openai.com"),
+        )
+        client = MagicMock()
+        client.chat.completions.create.side_effect = openai.RateLimitError(
+            "secret request payload", response=response, body=None
+        )
+        with patch("openai.OpenAI", return_value=client):
+            provider = OpenAIProvider(LLMConfig(provider="openai"))
+            with pytest.raises(ProviderRateLimitError) as exc:
+                provider.complete("p")
+        assert exc.value.retry_after == 7.0
+        assert "secret" not in str(exc.value)
+
+    def test_rate_limit_without_header_has_no_retry_after(
+        self, openai_env: None
+    ) -> None:
+        """A 429 without Retry-After still maps, with ``retry_after=None``."""
+        import httpx
+        import openai
+
+        from creek.classify.llm.providers import ProviderRateLimitError
+
+        response = httpx.Response(
+            429, request=httpx.Request("POST", "https://api.openai.com")
+        )
+        client = MagicMock()
+        client.chat.completions.create.side_effect = openai.RateLimitError(
+            "m", response=response, body=None
+        )
+        with patch("openai.OpenAI", return_value=client):
+            provider = OpenAIProvider(LLMConfig(provider="openai"))
+            with pytest.raises(ProviderRateLimitError) as exc:
+                provider.complete("p")
+        assert exc.value.retry_after is None
+
     def test_complete_uses_api_base_when_set(self, openai_env: None) -> None:
         """``config.api_base`` is passed to the SDK client as ``base_url``."""
         client = _make_mock_openai_client("x")


### PR DESCRIPTION
## Summary
- **(a) Bug fix — rate-limit handling is no longer lossy.** Each cloud provider (Anthropic / OpenAI / Gemini) now maps its vendor 429 to a new `ProviderRateLimitError` — a `RuntimeError` subclass so every existing except path keeps catching it — carrying only `retry_after: float | None` extracted from the response's `Retry-After` header. The redaction contract is preserved: the message is still just the provider name + exception type, never request state. The classifier's retry loop honors the hint with `max(retry_after, RETRY_DELAY)` (a server hint never speeds retries up below the baseline; a missing or HTTP-date header degrades to the fixed delay). Ollama is untouched: its httpx errors were never flattened, so they already carry their headers.
- **(b) Caching asymmetry documented**: README's provider section now states that Anthropic gets the explicit ephemeral `cache_control` block, OpenAI relies on vendor automatic prompt caching, and Gemini sends the prefix plain — repeated static prefixes bill differently per provider. (Wiring Gemini explicit caching was the issue's optional branch; deferred.)
- **(c) Streaming limitation documented**: the abstraction is non-streaming by design; a token-streaming UX would need a protocol extension.

## Test plan
- New tests (Red-first): per-provider 429 → `ProviderRateLimitError` with `retry_after` extracted (Anthropic 3.5s / OpenAI 7s / Gemini 11s, built from real SDK exception types over `httpx.Response`), the no-header and no-response cases mapping with `retry_after=None`, message redaction asserted on every path, and three orchestrator tests pinning the backoff behavior (honors 7.5s hint; falls back to `RETRY_DELAY` without a hint; clamps a 0.1s hint up to `RETRY_DELAY`).
- `./scripts/check-all.sh` exits 0 (12/12).

Closes #625
Refs #603
