### PR TITLE
feat(voice): scope the voice fingerprint to audience-facing documents (#633)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1473,8 +1473,13 @@ def _report_fingerprint(vault_path: Path) -> None:
         save_fingerprint,
     )
 
-    config = load_config().ai_style
-    fingerprint = build_fingerprint(vault_path, config)
+    full_config = load_config()
+    config = full_config.ai_style
+    fingerprint = build_fingerprint(
+        vault_path,
+        config,
+        audience_weighting=full_config.voice_audience_weighting,
+    )
     if fingerprint.fragment_count == 0:
         console.print(
             "[yellow]No voice fingerprint built: no self-authored "

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -1162,6 +1162,25 @@ def _default_representativeness_authority() -> dict[str, float]:
     return {"self": 1.0, "endorsed": 0.9, "aspirational": 0.6, "reference": 0.3}
 
 
+def _default_platform_authority() -> dict[str, float]:
+    """Default per-``source.platform`` voice-authority multipliers (#633).
+
+    Audience-facing platforms (essays, Substack posts) outrank private ones
+    (journals, DMs, chats) so the voice fingerprint is built primarily from how
+    the user writes *for an audience* rather than their texting average. Missing
+    platforms fall back to ``1.0`` so a new platform never silently zeroes out.
+    """
+    return {
+        "essay": 2.0,
+        "substack": 2.0,
+        "journal": 0.1,
+        "messages": 0.4,
+        "discord": 0.4,
+        "chatgpt": 0.3,
+        "claude": 0.3,
+    }
+
+
 class VoiceAudienceWeightingConfig(BaseModel):
     """Graduated audience-authority weighting for the voice proxy.
 
@@ -1184,6 +1203,16 @@ class VoiceAudienceWeightingConfig(BaseModel):
         default_factory=_default_representativeness_authority,
     )
     """Multiplier per ``representativeness`` value (missing default to 1.0)."""
+
+    platform_authority: dict[str, float] = Field(
+        default_factory=_default_platform_authority,
+    )
+    """Multiplier per ``source.platform`` (missing platforms default to 1.0).
+
+    The reliable audience signal: audience-facing platforms (essay, substack)
+    outweigh private ones (journal, DMs, chat). Used to scope the voice
+    fingerprint to audience-facing documents (#633) on top of the
+    privacy/representativeness factors."""
 
 
 class CreekConfig(BaseSettings):

--- a/creek-tools/creek/generate/ai_style/fingerprint.py
+++ b/creek-tools/creek/generate/ai_style/fingerprint.py
@@ -28,7 +28,7 @@ from creek.generate.ai_style.model import FeatureStat, VoiceFingerprint
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from creek.config import AIStyleConfig
+    from creek.config import AIStyleConfig, VoiceAudienceWeightingConfig
 
 logger = logging.getLogger(__name__)
 
@@ -106,22 +106,65 @@ def _user_text(platform: str, body: str) -> str | None:
     return body.strip() or None
 
 
+def _audience_factor(
+    metadata: dict[str, object],
+    platform: str,
+    weighting: VoiceAudienceWeightingConfig | None,
+) -> float:
+    """Return the audience-authority multiplier for a fragment's frontmatter.
+
+    Combines the reliable ``source.platform`` signal (audience-facing essays
+    outrank private journals/DMs/chats) with the per-``privacy_tier`` and
+    per-``representativeness`` factors, scoping the voice fingerprint to how the
+    user writes *for an audience* (#633). Returns ``1.0`` (no scoping) when
+    *weighting* is absent or disabled, so the historical flat-average path is
+    preserved. Missing values fall back to ``1.0`` so a new enum member never
+    silently zeroes a fragment.
+
+    Args:
+        metadata: The fragment's frontmatter mapping.
+        platform: The fragment's ``source.platform``.
+        weighting: The audience-weighting config, or ``None`` to disable scoping.
+
+    Returns:
+        A non-negative multiplier applied on top of the platform authorship
+        weight.
+    """
+    if weighting is None or not weighting.enabled:
+        return 1.0
+    privacy = weighting.privacy_tier_authority.get(
+        str(metadata.get("privacy_tier", "unclassified")),
+        1.0,
+    )
+    representativeness = weighting.representativeness_authority.get(
+        str(metadata.get("representativeness", "self")),
+        1.0,
+    )
+    platform_authority = weighting.platform_authority.get(platform, 1.0)
+    return privacy * representativeness * platform_authority
+
+
 def _eligible_texts(
     vault_path: Path,
     config: AIStyleConfig,
     *,
     include_intimate: bool,
+    audience_weighting: VoiceAudienceWeightingConfig | None = None,
 ) -> list[tuple[float, str]]:
     """Collect ``(weight, user_text)`` pairs for self-authored fragments.
 
     Applies the authorship filter (self-authored only; conversation
     user-turn only) and the privacy policy (intimate excluded unless
-    *include_intimate*).
+    *include_intimate*). When *audience_weighting* is supplied, each fragment's
+    weight is additionally multiplied by its audience-authority factor so
+    audience-facing documents dominate the fingerprint (#633).
 
     Args:
         vault_path: Vault root.
         config: AI-style configuration (authorship weights).
         include_intimate: When ``True``, intimate-tier fragments are kept.
+        audience_weighting: When supplied and enabled, scope the fingerprint to
+            audience-facing documents; ``None`` keeps the flat-average path.
 
     Returns:
         One ``(weight, text)`` pair per eligible fragment.
@@ -149,6 +192,7 @@ def _eligible_texts(
             platform,
             config.authorship_default_weight,
         )
+        weight *= _audience_factor(post.metadata, platform, audience_weighting)
         if weight > 0.0:
             out.append((weight, text))
     return out
@@ -159,23 +203,34 @@ def build_fingerprint(
     config: AIStyleConfig,
     *,
     include_intimate: bool = False,
+    audience_weighting: VoiceAudienceWeightingConfig | None = None,
 ) -> VoiceFingerprint:
     """Build a :class:`VoiceFingerprint` from the user's own vault writing.
 
     Each feature in :data:`FINGERPRINT_FEATURES` is measured per eligible
-    fragment and combined into a platform-weighted mean — so journals and
-    posts shape the baseline more than the noisier conversation user-turns.
+    fragment and combined into a weighted mean. When *audience_weighting* is
+    supplied, audience-facing documents (essays, Substack) dominate over private
+    journals/DMs/chats, so the fingerprint encodes the user's audience-facing
+    voice rather than their texting average (#633). Omitting it preserves the
+    historical platform-only weighting.
 
     Args:
         vault_path: Vault root.
         config: AI-style configuration.
         include_intimate: When ``True``, include intimate-tier fragments.
+        audience_weighting: When supplied and enabled, scope the fingerprint to
+            audience-facing documents; ``None`` keeps the flat-average path.
 
     Returns:
         A fingerprint whose ``fragment_count`` is the number of eligible
         fragments; empty when none qualify.
     """
-    texts = _eligible_texts(vault_path, config, include_intimate=include_intimate)
+    texts = _eligible_texts(
+        vault_path,
+        config,
+        include_intimate=include_intimate,
+        audience_weighting=audience_weighting,
+    )
     if not texts:
         return VoiceFingerprint(features={}, fragment_count=0)
 

--- a/creek-tools/tests/test_voice_fingerprint_audience_scoping.py
+++ b/creek-tools/tests/test_voice_fingerprint_audience_scoping.py
@@ -49,9 +49,17 @@ def _write_fragment(
     )
 
 
-def _em_dash_rate(vault: Path, **kwargs: object) -> float:
+def _em_dash_rate(
+    vault: Path,
+    *,
+    audience_weighting: VoiceAudienceWeightingConfig | None = None,
+) -> float:
     """Build a fingerprint and return its em_dash_density rate (0.0 if absent)."""
-    fp = build_fingerprint(vault, AIStyleConfig(), **kwargs)  # type: ignore[arg-type]
+    fp = build_fingerprint(
+        vault,
+        AIStyleConfig(),
+        audience_weighting=audience_weighting,
+    )
     stat = fp.features.get("em_dash_density")
     return stat.rate if stat is not None else 0.0
 

--- a/creek-tools/tests/test_voice_fingerprint_audience_scoping.py
+++ b/creek-tools/tests/test_voice_fingerprint_audience_scoping.py
@@ -1,0 +1,101 @@
+"""Voice fingerprint scoped to audience-facing documents (#633).
+
+The fingerprint historically averaged ALL self-authored fragments — journals,
+DMs, chats — weighted only by platform, so it encoded the user's *texting
+average* rather than their *audience-facing voice*. These tests pin the new
+behaviour: when an audience-weighting config is supplied, audience-facing
+platforms (essay/substack) dominate the fingerprint over private ones
+(journal), and the un-scoped default path is unchanged (backward compatible).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from creek.config import AIStyleConfig, VoiceAudienceWeightingConfig
+from creek.generate.ai_style.fingerprint import build_fingerprint
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Equal-length bodies; the essay uses em-dashes, the journal uses none, so the
+# em_dash_density feature isolates which fragment shaped the fingerprint.
+_ESSAY_BODY = "alpha—beta—gamma—delta—epsilon zeta eta theta iota kappa"
+_JOURNAL_BODY = "alpha beta gamma delta epsilon zeta eta theta iota kappa"
+
+
+def _write_fragment(
+    vault: Path,
+    name: str,
+    *,
+    platform: str,
+    body: str,
+    privacy_tier: str = "unclassified",
+    representativeness: str = "self",
+) -> None:
+    """Write a minimal self-authored fragment markdown file into *vault*."""
+    frag_dir = vault / "01-Fragments"
+    frag_dir.mkdir(parents=True, exist_ok=True)
+    meta = {
+        "source": {"author": "self", "platform": platform},
+        "privacy_tier": privacy_tier,
+        "representativeness": representativeness,
+    }
+    (frag_dir / name).write_text(
+        "---\n" + yaml.safe_dump(meta, sort_keys=True) + "---\n\n" + body,
+        encoding="utf-8",
+    )
+
+
+def _em_dash_rate(vault: Path, **kwargs: object) -> float:
+    """Build a fingerprint and return its em_dash_density rate (0.0 if absent)."""
+    fp = build_fingerprint(vault, AIStyleConfig(), **kwargs)  # type: ignore[arg-type]
+    stat = fp.features.get("em_dash_density")
+    return stat.rate if stat is not None else 0.0
+
+
+def test_audience_facing_fragment_dominates_equal_length_journal(
+    tmp_path: Path,
+) -> None:
+    """With audience weighting, the essay's em-dashes dominate over the journal."""
+    vault = tmp_path / "vault"
+    _write_fragment(vault, "essay.md", platform="essay", body=_ESSAY_BODY)
+    _write_fragment(vault, "journal.md", platform="journal", body=_JOURNAL_BODY)
+
+    scoped = _em_dash_rate(vault, audience_weighting=VoiceAudienceWeightingConfig())
+    unscoped = _em_dash_rate(vault)
+
+    # Scoping up-weights the em-dash-bearing essay and down-weights the journal,
+    # so the fingerprint's em-dash rate rises strictly above the flat average.
+    assert scoped > unscoped > 0.0
+
+    # And it lands close to the essay-only rate (journal heavily down-weighted).
+    essay_only = tmp_path / "essay_only"
+    _write_fragment(essay_only, "essay.md", platform="essay", body=_ESSAY_BODY)
+    essay_rate = _em_dash_rate(essay_only)
+    assert scoped >= 0.9 * essay_rate
+
+
+def test_default_path_unchanged_without_audience_weighting(tmp_path: Path) -> None:
+    """Omitting audience_weighting preserves the historical flat-average path."""
+    vault = tmp_path / "vault"
+    _write_fragment(vault, "essay.md", platform="essay", body=_ESSAY_BODY)
+    _write_fragment(vault, "journal.md", platform="journal", body=_JOURNAL_BODY)
+
+    # Disabled weighting must equal the no-weighting default (both = flat average).
+    disabled = _em_dash_rate(
+        vault,
+        audience_weighting=VoiceAudienceWeightingConfig(enabled=False),
+    )
+    default = _em_dash_rate(vault)
+    assert disabled == default
+
+
+def test_platform_authority_default_prefers_audience_facing() -> None:
+    """The default platform-authority ranks audience-facing above private."""
+    weighting = VoiceAudienceWeightingConfig()
+    essay = weighting.platform_authority.get("essay", 1.0)
+    journal = weighting.platform_authority.get("journal", 1.0)
+    assert essay > journal


### PR DESCRIPTION
## Summary
- Scope the **voice** fingerprint to audience-facing documents: add `platform_authority` to `VoiceAudienceWeightingConfig` and an optional `audience_weighting` kwarg to `build_fingerprint`/`_eligible_texts` that folds a per-fragment audience factor (**platform × privacy_tier × representativeness**) into the weight. Audience-facing platforms (essay, substack) dominate the fingerprint over private journals/DMs/chats — fixing the dilution that made the fingerprint encode the user's *texting average* (em-dash 0.39/1000 claimed vs ~8/1000 in real essays).
- Default path (no weighting) preserves the historical flat-average behaviour — backward compatible.
- Wire `creek report --type fingerprint` to pass `config.voice_audience_weighting`.
- **Knowledge/retrieval corpus untouched** — only the voice fingerprint is scoped; all docs still feed lore/retrieval.

## Test plan
- New `tests/test_voice_fingerprint_audience_scoping.py`: an essay-platform fragment dominates an equal-length journal fragment in the fingerprint; the default/disabled path is unchanged (backward compat); the `platform_authority` default prefers audience-facing.
- `./scripts/check-all.sh` → 12/12 green.

Closes #633
Refs #632
