### PR TITLE
feat(voice): real audience-facing classifier wired into voice scoping (#634)

### DIFF
--- a/creek-tools/creek/classify/audience.py
+++ b/creek-tools/creek/classify/audience.py
@@ -1,0 +1,228 @@
+"""Audience-facing classifier — tag whether a fragment was written for readers.
+
+The voice fingerprint (#633) historically inferred "is this audience-facing?"
+from one signal: ``source.platform``. That is too lightweight to tell an essay
+from a casual ``OPEN`` Discord post — both can share a platform, and a long
+structured journal export looks nothing like a one-line chat reply. This module
+adds a real **audience axis** (:data:`~creek.models.Audience`:
+``audience-facing`` | ``private`` | ``mixed``) by combining several robust,
+documented signals rather than a single keyword/platform grep:
+
+* **platform / medium** — published surfaces (essay, Substack) lean
+  audience-facing; journals, chats and DMs lean private.
+* **explicit writing kind** — :class:`~creek.models.SourceKind.WRITING` set by
+  the Substack ingester is a strong audience-facing vote.
+* **privacy tier** — ``OPEN`` corroborates audience-facing; ``INTIMATE`` /
+  ``PERSONAL`` corroborate private.
+* **structure** — headings, block quotations and genuine length are how
+  long-form *for readers* differs from a casual blip; very short bodies read as
+  private chatter.
+
+The signals are summed into a score and thresholded; the per-signal weights and
+thresholds are named constants below so the heuristic is auditable. An optional
+LLM-assisted pass (the :class:`AudienceLLMAssist` seam, consistent with
+``classify --method llm``) can refine the verdict when the heuristic lands on
+``mixed`` — the rules path is the default and needs no provider.
+
+This axis scopes VOICE only: it never gates the knowledge/retrieval corpus.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Protocol
+
+from creek.models import (
+    PrivacyTier,
+    SourceKind,
+    SourcePlatform,
+)
+
+if TYPE_CHECKING:
+    from creek.models import Audience, Fragment
+
+
+# --- Per-signal weights (positive = audience-facing, negative = private) ----
+
+_PLATFORM_SCORE: dict[SourcePlatform, int] = {
+    SourcePlatform.ESSAY: 5,
+    SourcePlatform.SUBSTACK: 5,
+    SourcePlatform.JOURNAL: -3,
+    SourcePlatform.CLAUDE: -2,
+    SourcePlatform.CHATGPT: -2,
+    SourcePlatform.DISCORD: -1,
+    SourcePlatform.EMAIL: -1,
+}
+"""How strongly each platform votes audience-facing (+) or private (-).
+
+Published surfaces (essay, Substack) score above :data:`_AUDIENCE_FACING_AT`
+on their own so a deliberately-published short post stays audience-facing even
+after the short-body penalty — the platform *is* the audience signal. Unmapped
+platforms (markdown notes, documents, OCR, …) contribute ``0`` so the
+structural signals decide them rather than a guess."""
+
+_WRITING_KIND_SCORE = 3
+"""Bonus when ``source.kind`` is :class:`SourceKind.WRITING` (published)."""
+
+_PRIVACY_SCORE: dict[PrivacyTier, int] = {
+    PrivacyTier.OPEN: 1,
+    PrivacyTier.PERSONAL: -1,
+    PrivacyTier.INTIMATE: -3,
+}
+"""Privacy tier as a corroborating audience signal (UNCLASSIFIED → 0)."""
+
+_HEADING_RE = re.compile(r"^#{1,6}\s+\S", re.MULTILINE)
+_BLOCKQUOTE_RE = re.compile(r"^>\s+\S", re.MULTILINE)
+
+_STRUCTURE_HEADING_SCORE = 1
+"""Bonus when the body carries Markdown section headings."""
+
+_STRUCTURE_BLOCKQUOTE_SCORE = 1
+"""Bonus when the body quotes sources (block quotations)."""
+
+_LONG_FORM_WORDS = 300
+"""Word count at or above which a body reads as deliberate long-form."""
+
+_LONG_FORM_SCORE = 1
+"""Bonus for clearing :data:`_LONG_FORM_WORDS`."""
+
+_SHORT_WORDS = 40
+"""Word count below which a body reads as a casual, private blip."""
+
+_SHORT_PENALTY = -2
+"""Penalty for a body under :data:`_SHORT_WORDS` words."""
+
+# --- Decision thresholds on the summed score --------------------------------
+
+_AUDIENCE_FACING_AT = 3
+"""Score at or above which the verdict is ``audience-facing``."""
+
+_PRIVATE_AT = -2
+"""Score at or below which the verdict is ``private``."""
+
+
+class AudienceLLMAssist(Protocol):
+    """Optional LLM refinement seam for the audience classifier.
+
+    Mirrors the ``classify --method llm`` pattern: a provider-backed pass that
+    can sharpen the heuristic verdict. Only consulted when the heuristic is
+    uncertain (``mixed``), so a confident rules answer never spends a call.
+    """
+
+    def refine(
+        self,
+        fragment: Fragment,
+        content: str,
+        heuristic: Audience,
+    ) -> Audience:
+        """Return a (possibly revised) audience for an ambiguous fragment."""
+        ...  # pragma: no cover  # Protocol stub
+
+
+class AudienceClassifier:
+    """Assign the :data:`~creek.models.Audience` axis from layered signals.
+
+    Deterministic and idempotent: the same fragment + body always yields the
+    same verdict, so re-running ``creek classify`` never churns the axis.
+
+    Attributes:
+        llm_assist: Optional :class:`AudienceLLMAssist` consulted only when the
+            heuristic verdict is ``mixed``. ``None`` (the default) keeps the
+            classifier pure-rules and provider-free.
+    """
+
+    def __init__(self, *, llm_assist: AudienceLLMAssist | None = None) -> None:
+        """Initialise the classifier.
+
+        Args:
+            llm_assist: Optional LLM refinement seam (see
+                :class:`AudienceLLMAssist`). Defaults to ``None`` — rules only.
+        """
+        self.llm_assist = llm_assist
+
+    def score(self, fragment: Fragment, content: str = "") -> int:
+        """Return the summed audience score for *fragment* (+ = audience-facing).
+
+        Args:
+            fragment: The fragment whose metadata supplies platform / kind /
+                privacy signals.
+            content: The raw Markdown body, scanned for structure and length.
+                Callers must pass it explicitly — :class:`Fragment` does not
+                carry the body.
+
+        Returns:
+            An integer; positive leans audience-facing, negative leans private.
+        """
+        total = 0
+        total += _PLATFORM_SCORE.get(SourcePlatform(fragment.source.platform), 0)
+        if SourceKind(fragment.source.kind) == SourceKind.WRITING:
+            total += _WRITING_KIND_SCORE
+        total += _PRIVACY_SCORE.get(PrivacyTier(fragment.privacy_tier), 0)
+        total += self._structure_score(content)
+        return total
+
+    @staticmethod
+    def _structure_score(content: str) -> int:
+        """Return the structure/length contribution to the audience score."""
+        score = 0
+        if _HEADING_RE.search(content):
+            score += _STRUCTURE_HEADING_SCORE
+        if _BLOCKQUOTE_RE.search(content):
+            score += _STRUCTURE_BLOCKQUOTE_SCORE
+        words = len(content.split())
+        if words >= _LONG_FORM_WORDS:
+            score += _LONG_FORM_SCORE
+        elif words < _SHORT_WORDS:
+            score += _SHORT_PENALTY
+        return score
+
+    def classify_audience(self, fragment: Fragment, content: str = "") -> Audience:
+        """Return the audience axis for *fragment*.
+
+        Thresholds the summed :meth:`score`: at or above
+        :data:`_AUDIENCE_FACING_AT` → ``audience-facing``; at or below
+        :data:`_PRIVATE_AT` → ``private``; otherwise ``mixed``. When the verdict
+        is ``mixed`` and an :class:`AudienceLLMAssist` is configured, the seam
+        is consulted for a refined answer.
+
+        Args:
+            fragment: The fragment to classify.
+            content: Raw Markdown body (see :meth:`score`).
+
+        Returns:
+            The assigned :data:`~creek.models.Audience`.
+        """
+        total = self.score(fragment, content)
+        if total >= _AUDIENCE_FACING_AT:
+            return "audience-facing"
+        if total <= _PRIVATE_AT:
+            return "private"
+        if self.llm_assist is not None:
+            return self.llm_assist.refine(fragment, content, "mixed")
+        return "mixed"
+
+    @staticmethod
+    def enforce_audience(fragment: Fragment, audience: Audience) -> Fragment:
+        """Return a copy of *fragment* with ``audience`` set to *audience*.
+
+        Args:
+            fragment: The fragment to update. Not mutated.
+            audience: The audience axis to apply.
+
+        Returns:
+            A new :class:`Fragment` carrying the assigned audience.
+        """
+        return fragment.model_copy(update={"audience": audience})
+
+    def classify_and_enforce(self, fragment: Fragment, content: str = "") -> Fragment:
+        """Classify *fragment* and return a copy carrying the verdict.
+
+        Args:
+            fragment: The fragment to classify and update.
+            content: Raw Markdown body (see :meth:`score`).
+
+        Returns:
+            A new :class:`Fragment` with its ``audience`` axis set.
+        """
+        audience = self.classify_audience(fragment, content)
+        return self.enforce_audience(fragment, audience)

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING
 import frontmatter
 import yaml
 
+from creek.classify.audience import AudienceClassifier
 from creek.classify.constants import (
     CLASSIFICATION_METHOD_KEY,
     CLASSIFICATION_REASONING_KEY,
@@ -208,6 +209,7 @@ def run_classify(
         return ClassifySummary(0, 0, 0, 0, 0, ())
 
     rules = RuleClassifier()
+    audience = AudienceClassifier()
     llm = LLMClassifier(config=config.llm) if method == "llm" else None
     if llm is not None and not llm.available:
         # Refuse to iterate when the provider is unreachable so the
@@ -248,6 +250,7 @@ def run_classify(
             method=method,
             force=force,
             rules=rules,
+            audience=audience,
             llm=llm,
             classification_config=config.classification,
             counts=counts,
@@ -307,6 +310,7 @@ def _process_file(
     method: str,
     force: bool,
     rules: RuleClassifier,
+    audience: AudienceClassifier,
     llm: LLMClassifier | None,
     classification_config: ClassificationConfig,
     counts: _RunCounts,
@@ -321,6 +325,9 @@ def _process_file(
         method: ``"rules"`` or ``"llm"``.
         force: Whether to overwrite previously-classified fragments.
         rules: Shared :class:`RuleClassifier` instance.
+        audience: Shared :class:`AudienceClassifier`; stamps the #634
+            audience axis on every (re)classified fragment, deterministically,
+            regardless of method.
         llm: Shared :class:`LLMClassifier` (when ``method == "llm"``).
         classification_config: Full FEAT-023-aware classification config.
             Drives both the LLM-vs-rules threshold and the
@@ -363,6 +370,11 @@ def _process_file(
         confidence_threshold=classification_config.confidence_threshold,
         weighted_classification=classification_config.weighted_classification,
     )
+
+    # Stamp the #634 audience axis on every (re)classified fragment. It is a
+    # deterministic heuristic independent of the frequency/phase method above,
+    # so it runs on both the rules and LLM paths and stays idempotent.
+    new_fragment = audience.classify_and_enforce(new_fragment, body)
 
     # FEAT-023 wire-up (issue #318): when ``classification.reatomize`` is
     # True we run the orchestrator on the root fragment and persist any

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -1181,6 +1181,19 @@ def _default_platform_authority() -> dict[str, float]:
     }
 
 
+def _default_audience_authority() -> dict[str, float]:
+    """Default per-``audience``-axis voice-authority multipliers (#634).
+
+    The primary audience signal once the FEAT/#634 audience classifier has
+    run: a fragment explicitly classified ``audience-facing`` dominates the
+    voice fingerprint, ``private`` material is strongly down-weighted, and
+    ``mixed`` (the unclassified default and the ambiguous verdict) is neutral
+    at ``1.0`` so legacy vaults keep relying on the platform heuristic until
+    they are re-classified. Missing values fall back to ``1.0``.
+    """
+    return {"audience-facing": 2.0, "private": 0.1, "mixed": 1.0}
+
+
 class VoiceAudienceWeightingConfig(BaseModel):
     """Graduated audience-authority weighting for the voice proxy.
 
@@ -1213,6 +1226,18 @@ class VoiceAudienceWeightingConfig(BaseModel):
     outweigh private ones (journal, DMs, chat). Used to scope the voice
     fingerprint to audience-facing documents (#633) on top of the
     privacy/representativeness factors."""
+
+    audience_authority: dict[str, float] = Field(
+        default_factory=_default_audience_authority,
+    )
+    """Multiplier per persisted ``audience`` axis (missing default to 1.0).
+
+    The primary audience signal once the #634 classifier has tagged fragments:
+    ``audience-facing`` content dominates the fingerprint, ``private`` is
+    down-weighted, ``mixed`` stays neutral. Layered on top of the #633
+    platform/privacy/representativeness factors so an unclassified vault
+    (every fragment ``mixed`` → 1.0) still falls back to the platform
+    heuristic, while a classified vault is scoped by the real axis."""
 
 
 class CreekConfig(BaseSettings):

--- a/creek-tools/creek/generate/ai_style/fingerprint.py
+++ b/creek-tools/creek/generate/ai_style/fingerprint.py
@@ -113,12 +113,14 @@ def _audience_factor(
 ) -> float:
     """Return the audience-authority multiplier for a fragment's frontmatter.
 
-    Combines the reliable ``source.platform`` signal (audience-facing essays
-    outrank private journals/DMs/chats) with the per-``privacy_tier`` and
-    per-``representativeness`` factors, scoping the voice fingerprint to how the
-    user writes *for an audience* (#633). Returns ``1.0`` (no scoping) when
-    *weighting* is absent or disabled, so the historical flat-average path is
-    preserved. Missing values fall back to ``1.0`` so a new enum member never
+    The primary signal is the persisted ``audience`` axis from the #634
+    classifier (``audience-facing`` dominates, ``private`` is down-weighted,
+    ``mixed`` is neutral). It is layered on top of the #633 existing-signal
+    heuristic — ``source.platform``, ``privacy_tier`` and ``representativeness``
+    — which still carries an unclassified vault (every fragment ``mixed`` →
+    ``1.0``) until the audience classifier has run. Returns ``1.0`` (no scoping)
+    when *weighting* is absent or disabled, so the historical flat-average path
+    is preserved. Missing values fall back to ``1.0`` so a new enum member never
     silently zeroes a fragment.
 
     Args:
@@ -132,6 +134,10 @@ def _audience_factor(
     """
     if weighting is None or not weighting.enabled:
         return 1.0
+    audience = weighting.audience_authority.get(
+        str(metadata.get("audience", "mixed")),
+        1.0,
+    )
     privacy = weighting.privacy_tier_authority.get(
         str(metadata.get("privacy_tier", "unclassified")),
         1.0,
@@ -141,7 +147,7 @@ def _audience_factor(
         1.0,
     )
     platform_authority = weighting.platform_authority.get(platform, 1.0)
-    return privacy * representativeness * platform_authority
+    return audience * privacy * representativeness * platform_authority
 
 
 def _eligible_texts(

--- a/creek-tools/creek/models.py
+++ b/creek-tools/creek/models.py
@@ -436,10 +436,23 @@ their own interests, or a co-author."""
 Representativeness = Literal["self", "endorsed", "aspirational", "reference"]
 """How closely an author's material stands for the vault owner's own views."""
 
+Audience = Literal["audience-facing", "private", "mixed"]
+"""Attribution axis (#634): was this fragment written *for an audience*?
+
+``audience-facing`` — essays, Substack posts, published long-form: the
+register the voice proxy should imitate. ``private`` — journals, DMs,
+casual chat: real but not the public voice. ``mixed`` — the safe default
+before classification and the verdict when signals are ambiguous. This axis
+is orthogonal to :data:`Representativeness` (who the words belong to) and to
+:class:`PrivacyTier` (who may see them); it scopes VOICE only and never
+gates the knowledge/retrieval corpus.
+"""
+
 # Derive the allowed-value sets from the Literal types so they can never drift
 # out of sync when a new kind/representativeness is added.
 _AUTHOR_KINDS: frozenset[str] = frozenset(get_args(AuthorKind))
 _REPRESENTATIVENESS: frozenset[str] = frozenset(get_args(Representativeness))
+_AUDIENCES: frozenset[str] = frozenset(get_args(Audience))
 
 
 def _warn_fail_closed(
@@ -727,6 +740,11 @@ class Fragment(BaseModel):
     # never crashes a vault scan (matching :class:`AuthorManifest`).
     voice_weight: float = 1.0
     representativeness: Representativeness = "self"
+    # Attribution axis (#634): whether the fragment was written for an
+    # audience. Defaults to ``mixed`` so every pre-#634 fragment is neutral
+    # until the audience classifier runs — additive and backward-compatible,
+    # and fails closed to ``mixed`` so a corrupt value never crashes a scan.
+    audience: Audience = "mixed"
     created: datetime = Field(default_factory=now_la)
     ingested: datetime = Field(default_factory=now_la)
     # Timestamp the source itself records (a Substack post's publish
@@ -783,6 +801,15 @@ class Fragment(BaseModel):
             return value
         _warn_fail_closed("Fragment representativeness", value, "self")
         return "self"
+
+    @field_validator("audience", mode="before")
+    @classmethod
+    def _coerce_audience(cls, value: object) -> str:
+        """Fail closed to ``mixed`` for an unrecognised ``audience`` value."""
+        if isinstance(value, str) and value in _AUDIENCES:
+            return value
+        _warn_fail_closed("Fragment audience", value, "mixed")
+        return "mixed"
 
     # BUG-009: the ``[prop-decorator]`` suppression below is a known
     # mypy / Pydantic-v2 limitation when stacking ``@computed_field``

--- a/creek-tools/tests/test_audience.py
+++ b/creek-tools/tests/test_audience.py
@@ -1,0 +1,175 @@
+"""Tests for the AudienceClassifier (#634).
+
+The audience axis tags whether a fragment was written *for an audience*
+(``audience-facing``), kept *private*, or is ambiguous (``mixed``). These tests
+pin the two acceptance cases — a casual OPEN chat is NOT audience-facing, a
+Substack essay IS — plus the layered signals, the fail-closed default, the
+optional LLM seam, and idempotency.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from creek.classify.audience import AudienceClassifier, AudienceLLMAssist
+from creek.models import (
+    Audience,
+    Authorship,
+    Fragment,
+    FragmentSource,
+    PrivacyTier,
+    SourceKind,
+    SourcePlatform,
+    synthetic_fragment_id,
+)
+
+_CASUAL_CHAT = "lol yeah that works, see you then"
+_ESSAY_BODY = (
+    "# On Equanimity\n\n"
+    "There is a particular quiet that arrives only after the storm has had "
+    "its say. I have learned to wait for it rather than chase it.\n\n"
+    "> The wound is the place where the Light enters you.\n~ Rumi\n\n"
+) + ("Each paragraph turns the same stone to a new face. " * 60)
+
+
+def _make_fragment(
+    *,
+    platform: SourcePlatform = SourcePlatform.OTHER,
+    kind: SourceKind = SourceKind.UNCLASSIFIED,
+    privacy_tier: PrivacyTier = PrivacyTier.UNCLASSIFIED,
+    channel: str | None = None,
+    author: Authorship = Authorship.SELF,
+) -> Fragment:
+    """Build a deterministic Fragment for audience tests."""
+    return Fragment(
+        id=synthetic_fragment_id(),
+        title="A note",
+        source=FragmentSource(
+            platform=platform,
+            kind=kind,
+            channel=channel,
+            author=author,
+        ),
+        privacy_tier=privacy_tier,
+        created=datetime(2026, 4, 1, tzinfo=UTC),
+        ingested=datetime(2026, 4, 1, tzinfo=UTC),
+    )
+
+
+class TestClassifyAudience:
+    """``classify_audience`` maps layered signals to the audience axis."""
+
+    def test_substack_essay_is_audience_facing(self) -> None:
+        """A published Substack essay is the canonical audience-facing case."""
+        classifier = AudienceClassifier()
+        frag = _make_fragment(
+            platform=SourcePlatform.SUBSTACK,
+            kind=SourceKind.WRITING,
+            privacy_tier=PrivacyTier.OPEN,
+        )
+        assert classifier.classify_audience(frag, _ESSAY_BODY) == "audience-facing"
+
+    def test_casual_open_chat_is_not_audience_facing(self) -> None:
+        """A short OPEN Discord blip is private, not audience-facing."""
+        classifier = AudienceClassifier()
+        frag = _make_fragment(
+            platform=SourcePlatform.DISCORD,
+            privacy_tier=PrivacyTier.OPEN,
+            channel="general",
+        )
+        verdict = classifier.classify_audience(frag, _CASUAL_CHAT)
+        assert verdict == "private"
+        assert verdict != "audience-facing"
+
+    def test_journal_is_private(self) -> None:
+        """An intimate journal entry is firmly private."""
+        classifier = AudienceClassifier()
+        frag = _make_fragment(
+            platform=SourcePlatform.JOURNAL,
+            privacy_tier=PrivacyTier.INTIMATE,
+        )
+        assert classifier.classify_audience(frag, "today I felt raw") == "private"
+
+    def test_essay_platform_alone_is_audience_facing(self) -> None:
+        """The essay platform is a strong enough signal on its own."""
+        classifier = AudienceClassifier()
+        frag = _make_fragment(platform=SourcePlatform.ESSAY)
+        assert classifier.classify_audience(frag, "short but published") == (
+            "audience-facing"
+        )
+
+    def test_long_structured_note_is_audience_facing(self) -> None:
+        """Long-form with headings + quotation reads as audience-facing."""
+        classifier = AudienceClassifier()
+        frag = _make_fragment(platform=SourcePlatform.MARKDOWN)
+        assert classifier.classify_audience(frag, _ESSAY_BODY) == "audience-facing"
+
+    def test_neutral_medium_length_note_is_mixed(self) -> None:
+        """An unmapped platform with no strong signal stays mixed."""
+        classifier = AudienceClassifier()
+        frag = _make_fragment(platform=SourcePlatform.MARKDOWN)
+        body = "A handful of ordinary sentences. " * 12
+        assert classifier.classify_audience(frag, body) == "mixed"
+
+
+class TestLLMSeam:
+    """The optional LLM seam refines only the ambiguous ``mixed`` verdict."""
+
+    def test_seam_consulted_on_mixed(self) -> None:
+        """A configured assist can resolve a ``mixed`` heuristic verdict."""
+
+        class _Assist:
+            def refine(
+                self,
+                fragment: Fragment,
+                content: str,
+                heuristic: Audience,
+            ) -> Audience:
+                assert heuristic == "mixed"
+                return "audience-facing"
+
+        assist: AudienceLLMAssist = _Assist()
+        classifier = AudienceClassifier(llm_assist=assist)
+        frag = _make_fragment(platform=SourcePlatform.MARKDOWN)
+        body = "A handful of ordinary sentences. " * 12
+        assert classifier.classify_audience(frag, body) == "audience-facing"
+
+    def test_seam_not_consulted_when_confident(self) -> None:
+        """A confident heuristic verdict never spends an LLM call."""
+
+        class _Boom:
+            def refine(
+                self,
+                fragment: Fragment,
+                content: str,
+                heuristic: Audience,
+            ) -> Audience:
+                raise AssertionError("seam must not be called when confident")
+
+        classifier = AudienceClassifier(llm_assist=_Boom())
+        frag = _make_fragment(
+            platform=SourcePlatform.SUBSTACK,
+            kind=SourceKind.WRITING,
+        )
+        assert classifier.classify_audience(frag, _ESSAY_BODY) == "audience-facing"
+
+
+class TestEnforceAndIdempotency:
+    """``classify_and_enforce`` stamps the axis without mutating the input."""
+
+    def test_classify_and_enforce_sets_axis(self) -> None:
+        """The returned copy carries the verdict; the original is untouched."""
+        classifier = AudienceClassifier()
+        frag = _make_fragment(platform=SourcePlatform.ESSAY)
+        assert frag.audience == "mixed"
+        result = classifier.classify_and_enforce(frag, "published")
+        assert result.audience == "audience-facing"
+        assert frag.audience == "mixed"
+
+    def test_idempotent(self) -> None:
+        """Re-running on the stamped fragment yields the same axis."""
+        classifier = AudienceClassifier()
+        frag = _make_fragment(platform=SourcePlatform.JOURNAL)
+        once = classifier.classify_and_enforce(frag, "private musing")
+        twice = classifier.classify_and_enforce(once, "private musing")
+        assert once.audience == twice.audience == "private"

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -1092,3 +1092,63 @@ def test_run_classify_rules_does_not_construct_llm(
 
     mock_cls.assert_not_called()
     assert summary.classified == 1
+
+
+def _audience_of(path: Path) -> str:
+    """Return the persisted ``audience`` axis from a fragment file."""
+    return str(frontmatter.load(str(path)).metadata.get("audience"))
+
+
+def test_run_classify_stamps_audience_axis(tmp_path: Path) -> None:
+    """``creek classify`` persists the #634 audience axis to frontmatter."""
+    vault = tmp_path / "vault"
+    essay = Fragment(
+        id="frag-essay00000001",
+        title="published essay",
+        source=FragmentSource(platform=SourcePlatform.ESSAY),
+    )
+    essay_path = _write_fragment(
+        vault=vault,
+        fragment=essay,
+        body="# Heading\n\n" + ("a deliberate published sentence. " * 80),
+    )
+    journal = Fragment(
+        id="frag-journal0001",
+        title="private musing",
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+    )
+    journal_path = _write_fragment(
+        vault=vault,
+        fragment=journal,
+        body="today I felt raw and small",
+    )
+
+    run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    assert _audience_of(essay_path) == "audience-facing"
+    assert _audience_of(journal_path) == "private"
+
+
+def test_run_classify_audience_axis_is_idempotent(tmp_path: Path) -> None:
+    """A second rules pass leaves the audience axis unchanged."""
+    vault = tmp_path / "vault"
+    essay = Fragment(
+        id="frag-essay00000002",
+        title="published essay",
+        source=FragmentSource(platform=SourcePlatform.ESSAY),
+    )
+    path = _write_fragment(
+        vault=vault,
+        fragment=essay,
+        body="# Heading\n\n" + ("a deliberate published sentence. " * 80),
+    )
+
+    run_classify(vault_path=vault, config=CreekConfig(), method="rules", force=False)
+    first = _audience_of(path)
+    run_classify(vault_path=vault, config=CreekConfig(), method="rules", force=True)
+    assert _audience_of(path) == first == "audience-facing"

--- a/creek-tools/tests/test_voice_fingerprint_audience_scoping.py
+++ b/creek-tools/tests/test_voice_fingerprint_audience_scoping.py
@@ -34,15 +34,18 @@ def _write_fragment(
     body: str,
     privacy_tier: str = "unclassified",
     representativeness: str = "self",
+    audience: str | None = None,
 ) -> None:
     """Write a minimal self-authored fragment markdown file into *vault*."""
     frag_dir = vault / "01-Fragments"
     frag_dir.mkdir(parents=True, exist_ok=True)
-    meta = {
+    meta: dict[str, object] = {
         "source": {"author": "self", "platform": platform},
         "privacy_tier": privacy_tier,
         "representativeness": representativeness,
     }
+    if audience is not None:
+        meta["audience"] = audience
     (frag_dir / name).write_text(
         "---\n" + yaml.safe_dump(meta, sort_keys=True) + "---\n\n" + body,
         encoding="utf-8",
@@ -107,3 +110,43 @@ def test_platform_authority_default_prefers_audience_facing() -> None:
     essay = weighting.platform_authority.get("essay", 1.0)
     journal = weighting.platform_authority.get("journal", 1.0)
     assert essay > journal
+
+
+def test_persisted_audience_axis_drives_scoping(tmp_path: Path) -> None:
+    """The #634 ``audience`` axis up-weights audience-facing over private.
+
+    Both fragments share a platform/privacy/representativeness so only the
+    classified ``audience`` axis differs — proving the fingerprint consumes the
+    real axis, not just the #633 platform heuristic.
+    """
+    vault = tmp_path / "vault"
+    _write_fragment(
+        vault,
+        "facing.md",
+        platform="markdown",
+        body=_ESSAY_BODY,
+        audience="audience-facing",
+    )
+    _write_fragment(
+        vault,
+        "private.md",
+        platform="markdown",
+        body=_JOURNAL_BODY,
+        audience="private",
+    )
+
+    scoped = _em_dash_rate(vault, audience_weighting=VoiceAudienceWeightingConfig())
+    unscoped = _em_dash_rate(vault)
+
+    # The audience-facing (em-dash-bearing) fragment dominates once the axis is
+    # consumed, lifting the rate above the flat average of the two.
+    assert scoped > unscoped > 0.0
+
+
+def test_audience_authority_default_prefers_audience_facing() -> None:
+    """The default audience-authority ranks audience-facing above private."""
+    weighting = VoiceAudienceWeightingConfig()
+    facing = weighting.audience_authority.get("audience-facing", 1.0)
+    private = weighting.audience_authority.get("private", 1.0)
+    mixed = weighting.audience_authority.get("mixed", 1.0)
+    assert facing > mixed > private


### PR DESCRIPTION
## Summary
- Adds a real **audience axis** to `Fragment` (`audience`: `audience-facing | private | mixed`), replacing the grep/platform-only signal the voice fingerprint relied on.
- New `AudienceClassifier` (`creek/classify/audience.py`) scores each fragment from **layered, documented signals** — platform/medium, `SourceKind.WRITING`, privacy tier, and body structure (headings, block quotation, genuine length) — thresholded into the axis. Named-constant weights keep the heuristic auditable; an optional `AudienceLLMAssist` seam (consistent with `classify --method llm`) refines only the ambiguous `mixed` verdict.
- Wired into `creek classify` (both `rules` and `llm` methods), deterministic and idempotent, persisting the axis to frontmatter.
- The voice fingerprint now consumes the persisted axis via a new `audience_authority` weight on `VoiceAudienceWeightingConfig`, **layered on** the #633 platform heuristic — an unclassified vault (every fragment `mixed` → 1.0) still falls back to it; a classified vault is scoped by the real axis.
- **Constraint honored:** knowledge/retrieval corpus unchanged; this axis scopes VOICE only.

## Test plan
- `tests/test_audience.py` — unit: Substack essay → `audience-facing`; casual OPEN Discord blip → `private` (the two acceptance cases); journal → `private`; essay-platform-alone; long structured note; neutral note → `mixed`; the LLM seam (consulted on `mixed`, skipped when confident); enforce-without-mutation + idempotency.
- `tests/test_classify_engine.py` — integration: `run_classify` stamps the axis into frontmatter (essay→audience-facing, journal→private) and is idempotent across a `--force` re-run.
- `tests/test_voice_fingerprint_audience_scoping.py` — the persisted `audience` axis drives scoping with platform/privacy held equal, plus the `audience_authority` default ordering.
- `./scripts/check-all.sh` green (12/12): 5468 passed, 93.82% coverage.

Closes #634
Refs #632
