### PR TITLE
feat(voice): discerning scrub — per-user polarity + signature reinforcement (#635)

### DIFF
--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -975,6 +975,16 @@ class AIStyleConfig(BaseModel):
     Rates are per-1000-words, so ``0.5`` means "half an occurrence per
     thousand words above the user's own rate"."""
 
+    signature_polarity_threshold: float = Field(default=3.0, ge=0.0)
+    """Per-1000-words rate at or above which a feature is treated as one of
+    *this user's* signatures, deriving its polarity per-user (#635): the
+    concern flips from over-use (``avoid``) to under-use (``signature``), so a
+    draft that strips a feature the user characteristically employs raises
+    voice distance instead of lowering it. Below this rate the feature keeps
+    its declared (avoid) polarity. Never-legitimate artifacts (tells with
+    ``margin == 0.0``: placeholder dates, fabricated citations) are exempt and
+    stay ``avoid`` regardless of the user's measured rate."""
+
     min_fingerprint_fragments: int = Field(default=5, ge=1)
     """Below this many user-authored fragments the fingerprint is treated
     as thin: divergence contributions are softened toward the generic

--- a/creek-tools/creek/generate/ai_style/discourse.py
+++ b/creek-tools/creek/generate/ai_style/discourse.py
@@ -204,3 +204,26 @@ COMM_BOILERPLATE = register(
         margin=_STRUCTURE_MARGIN,
     ),
 )
+
+# --- Signature tell (#635): an authentic feature to reinforce, not scrub ---
+# Declared ``signature`` because its natural concern is *under*-use: a draft
+# that flattens the user's punchy single-sentence-paragraph rhythm into dense
+# blocks has lost their voice. Per-user polarity derivation still governs it —
+# it only fires as a signature once the user's own one-line-fragment rate
+# clears the signature threshold, so it never penalises a writer who does not
+# use the rhythm.
+ONE_LINE_FRAGMENT = register(
+    Tell(
+        id="one_line_fragment",
+        category="discourse",
+        feature_key="one_line_fragment_density",
+        handling="surface",
+        polarity="signature",
+        description="Short single-sentence paragraphs (the punchy one-line beat).",
+        caveat="A signature rhythm, not a defect: flagged only when you "
+        "characteristically use it and a draft strips it out.",
+        measure=features.one_line_fragment_density,
+        # Under-use has no single location; a doc-level finding is emitted.
+        locate=lambda _text: [],
+    ),
+)

--- a/creek-tools/creek/generate/ai_style/features.py
+++ b/creek-tools/creek/generate/ai_style/features.py
@@ -429,7 +429,42 @@ def comm_boilerplate_density(text: str) -> float:
     return rate_per_kwords(len(COMM_BOILERPLATE_RE.findall(text)), text)
 
 
+_PARAGRAPH_SPLIT_RE = re.compile(r"\n\s*\n")
+_ONE_LINE_MAX_WORDS = 20
+"""Word ceiling for a paragraph to count as a punchy one-line fragment.
+
+A single-line paragraph longer than this reads as a normal (merely
+un-wrapped) paragraph, not the short standalone beat the signature
+captures."""
+
+
+def one_line_fragment_density(text: str) -> float:
+    """Return short single-line paragraphs per 1000 words (#635 signature).
+
+    Counts blank-line-delimited paragraphs that are a single line of at most
+    :data:`_ONE_LINE_MAX_WORDS` words — the user's punchy single-sentence-
+    paragraph rhythm. An authentic signature: previously unmeasured, so it was
+    neither protected from scrubbing nor reinforced. Pure and deterministic.
+
+    Args:
+        text: The body of text to measure.
+
+    Returns:
+        One-line-fragment occurrences per 1000 words.
+    """
+    paragraphs = _PARAGRAPH_SPLIT_RE.split(text.strip())
+    one_liners = sum(
+        1
+        for para in paragraphs
+        if (stripped := para.strip())
+        and "\n" not in stripped
+        and len(stripped.split()) <= _ONE_LINE_MAX_WORDS
+    )
+    return rate_per_kwords(one_liners, text)
+
+
 FINGERPRINT_FEATURES: dict[str, Extractor] = {
+    "one_line_fragment_density": one_line_fragment_density,
     "em_dash_density": em_dash_density,
     "curly_quote_density": curly_quote_density,
     "ai_vocab_density": ai_vocab_density,

--- a/creek-tools/creek/generate/ai_style/features.py
+++ b/creek-tools/creek/generate/ai_style/features.py
@@ -464,7 +464,6 @@ def one_line_fragment_density(text: str) -> float:
 
 
 FINGERPRINT_FEATURES: dict[str, Extractor] = {
-    "one_line_fragment_density": one_line_fragment_density,
     "em_dash_density": em_dash_density,
     "curly_quote_density": curly_quote_density,
     "ai_vocab_density": ai_vocab_density,
@@ -484,6 +483,7 @@ FINGERPRINT_FEATURES: dict[str, Extractor] = {
     "didactic_disclaimer_density": didactic_disclaimer_density,
     "section_summary_density": section_summary_density,
     "comm_boilerplate_density": comm_boilerplate_density,
+    "one_line_fragment_density": one_line_fragment_density,
 }
 """The feature_key -> extractor map the fingerprint measures over the
 user's corpus. Detector tells (FEAT-040.3 through .7) query these same

--- a/creek-tools/creek/generate/ai_style/scanner.py
+++ b/creek-tools/creek/generate/ai_style/scanner.py
@@ -18,7 +18,7 @@ from creek.generate.ai_style.distance import (
     voice_distance,
 )
 from creek.generate.ai_style.model import Finding, ScanReport, Span
-from creek.generate.ai_style.tells import get_tells
+from creek.generate.ai_style.tells import effective_polarity, get_tells
 
 if TYPE_CHECKING:
     from creek.config import AIStyleConfig
@@ -125,6 +125,61 @@ def _findings_for(
     ]
 
 
+def _score_tell(
+    tell: Tell,
+    text: str,
+    *,
+    fingerprint: VoiceFingerprint,
+    config: AIStyleConfig,
+) -> tuple[float, FeatureContribution, list[Finding]]:
+    """Score one tell against the draft, deriving per-user polarity (#635).
+
+    Args:
+        tell: The tell to score.
+        text: The draft text.
+        fingerprint: The user's voice fingerprint.
+        config: The AI-style configuration.
+
+    Returns:
+        ``(delta, contribution, findings)`` — the raw draft-minus-user delta
+        (for the report's ``deltas``), this feature's distance contribution,
+        and any findings the tell fired (empty when inert or within margin).
+    """
+    draft_rate = tell.measure(text)
+    user_rate = _resolve_user_rate(tell, fingerprint)
+    delta = draft_rate - user_rate
+    threshold = (
+        config.signature_polarity_threshold
+        if tell.signature_threshold is None
+        else tell.signature_threshold
+    )
+    polarity = effective_polarity(tell, user_rate, signature_threshold=threshold)
+    # ``None`` => the tell is inert for this user (a signature feature they do
+    # not employ): zero contribution, no finding — never fires spuriously.
+    magnitude = (
+        0.0
+        if polarity is None
+        else bad_direction_magnitude(polarity, draft_rate, user_rate)
+    )
+    contribution = FeatureContribution(
+        feature_key=tell.feature_key,
+        weight=config.weight_for(category=tell.category, feature_key=tell.feature_key),
+        magnitude=magnitude,
+    )
+    margin = config.default_margin if tell.margin is None else tell.margin
+    findings: list[Finding] = []
+    if polarity is not None and magnitude > margin:
+        direction: Direction = "over" if polarity == "avoid" else "under"
+        findings = _findings_for(
+            tell,
+            text,
+            draft_rate=draft_rate,
+            user_rate=user_rate,
+            direction=direction,
+        )
+    return delta, contribution, findings
+
+
 def scan(
     text: str,
     *,
@@ -166,37 +221,17 @@ def scan(
     for tell in get_tells(config.enabled_categories):
         if not tell.applies_in(context):
             continue
-        draft_rate = tell.measure(text)
-        user_rate = _resolve_user_rate(tell, fingerprint)
-        deltas[tell.feature_key] = draft_rate - user_rate
-        magnitude = bad_direction_magnitude(
-            tell.polarity,
-            draft_rate,
-            user_rate,
+        # Per-user polarity derivation (#635) lives in the helper to keep this
+        # loop — and scan()'s complexity — flat.
+        delta, contribution, tell_findings = _score_tell(
+            tell,
+            text,
+            fingerprint=fingerprint,
+            config=config,
         )
-        weight = config.weight_for(
-            category=tell.category,
-            feature_key=tell.feature_key,
-        )
-        contributions.append(
-            FeatureContribution(
-                feature_key=tell.feature_key,
-                weight=weight,
-                magnitude=magnitude,
-            ),
-        )
-        margin = config.default_margin if tell.margin is None else tell.margin
-        if magnitude > margin:
-            direction: Direction = "over" if tell.polarity == "avoid" else "under"
-            findings.extend(
-                _findings_for(
-                    tell,
-                    text,
-                    draft_rate=draft_rate,
-                    user_rate=user_rate,
-                    direction=direction,
-                ),
-            )
+        deltas[tell.feature_key] = delta
+        contributions.append(contribution)
+        findings.extend(tell_findings)
 
     distance = voice_distance(contributions, softening=softening)
     return ScanReport(

--- a/creek-tools/creek/generate/ai_style/tells.py
+++ b/creek-tools/creek/generate/ai_style/tells.py
@@ -90,7 +90,17 @@ class Tell:
         margin: Optional per-tell divergence margin overriding the config
             default. ``0.0`` means "any divergence in the bad direction
             fires" (use for features that are never legitimate, like
-            placeholder text).
+            placeholder text). A ``0.0`` margin also locks the tell's
+            polarity (it can never become a per-user signature).
+        lock_polarity: When ``True``, the tell keeps its declared
+            :attr:`polarity` regardless of the user's measured rate — the
+            per-user signature derivation (#635) is skipped. Defaults to
+            ``False``; a ``margin`` of ``0.0`` locks polarity implicitly too,
+            so never-legitimate artifacts need not set this.
+        signature_threshold: Optional per-tell override for the rate at or
+            above which the user is deemed to *characteristically* use this
+            feature (so under-use becomes the concern). ``None`` falls back to
+            ``AIStyleConfig.signature_polarity_threshold``.
         measure: ``measure(text) -> float`` returning the draft's rate.
         locate: ``locate(text) -> list[Span]`` returning occurrence spans
             for findings. Empty list yields a single doc-level finding.
@@ -110,7 +120,23 @@ class Tell:
     locate: Callable[[str], list[Span]]
     generic_prior: float = 0.0
     margin: float | None = None
+    lock_polarity: bool = False
+    signature_threshold: float | None = None
     contexts: frozenset[str] | None = None
+
+    def polarity_is_locked(self) -> bool:
+        """Return whether this tell's polarity is exempt from #635 derivation.
+
+        Never-legitimate artifacts are intrinsic ``avoid`` tells: a fabricated
+        DOI or a placeholder date can never be one of the user's signatures, so
+        they are exempt from per-user polarity derivation. These are exactly
+        the tells pinned with a ``0.0`` margin (any over-use fires), plus any
+        tell that opts out explicitly via :attr:`lock_polarity`.
+
+        Returns:
+            ``True`` when the declared :attr:`polarity` must be used as-is.
+        """
+        return self.lock_polarity or self.margin == 0.0
 
     def applies_in(self, context: str) -> bool:
         """Return whether this tell runs in the given scan *context*.
@@ -122,6 +148,51 @@ class Tell:
             ``True`` when the tell is context-agnostic or lists *context*.
         """
         return self.contexts is None or context in self.contexts
+
+
+def effective_polarity(
+    tell: Tell,
+    user_rate: float,
+    *,
+    signature_threshold: float,
+) -> Polarity | None:
+    """Return *tell*'s polarity for this user, derived from their rate (#635).
+
+    Polarity is derived per-user rather than fixed at registration, but with
+    discernment — the declared :attr:`Tell.polarity` gates *which* derivation
+    applies, so the AI-tell catalog is never wholesale-reinforced (a
+    triad-loving writer should not have triad padding *reinforced*, only
+    tolerated):
+
+    * **avoid** tells (the AI-tell catalog) always stay ``avoid``. Over-use is
+      the only concern; the existing vault-relative suppression (a draft below
+      the user's rate scores ``0``) is unchanged.
+    * **signature** tells (genuine authentic-voice features, e.g. the one-line
+      rhythm) derive per-user: at or above ``signature_threshold`` the user
+      characteristically employs it → ``signature`` (under-use raises voice
+      distance, reinforcing the voice); below the threshold the tell is
+      **inert** (``None``) — the user does not use it, so neither over- nor
+      under-use is *their* concern, and it never fires spuriously on a draft
+      that happens to use the feature.
+
+    Never-legitimate artifacts (:meth:`Tell.polarity_is_locked`) are exempt and
+    always return their declared polarity.
+
+    Args:
+        tell: The tell whose effective polarity is wanted.
+        user_rate: The user's measured rate for the feature (or generic prior).
+        signature_threshold: The rate at or above which the feature counts as a
+            user signature (a per-tell override or the config default).
+
+    Returns:
+        ``"avoid"`` / ``"signature"`` to score with that polarity, or ``None``
+        when the tell is inert for this user (no contribution, no finding).
+    """
+    if tell.polarity_is_locked():
+        return tell.polarity
+    if tell.polarity == "signature":
+        return "signature" if user_rate >= signature_threshold else None
+    return "avoid"
 
 
 TELL_REGISTRY: dict[str, Tell] = {}

--- a/creek-tools/tests/generate/ai_style/test_features.py
+++ b/creek-tools/tests/generate/ai_style/test_features.py
@@ -202,4 +202,6 @@ def test_registry_exposes_all_extractors() -> None:
     assert "em_dash_density" in FINGERPRINT_FEATURES
     assert FINGERPRINT_FEATURES["ai_vocab_density"] is ai_vocab_density
     assert FINGERPRINT_FEATURES["concrete_density"] is concrete_density
-    assert len(FINGERPRINT_FEATURES) == 19
+    # #635 added the one-line-fragment signature extractor.
+    assert "one_line_fragment_density" in FINGERPRINT_FEATURES
+    assert len(FINGERPRINT_FEATURES) == 20

--- a/creek-tools/tests/generate/ai_style/test_signature_polarity.py
+++ b/creek-tools/tests/generate/ai_style/test_signature_polarity.py
@@ -1,0 +1,164 @@
+"""Per-user polarity derivation + one-line-fragment signature (#635).
+
+The scrub must reinforce authentic signatures, not sand them off. These tests
+pin: (1) polarity is derived per-user — a feature the user characteristically
+uses becomes a ``signature`` so stripping it RAISES voice distance; (2) the new
+one-line-fragment extractor; (3) existing avoid-tell behaviour and the
+curly-quote/em-dash typography protection are preserved.
+"""
+
+from __future__ import annotations
+
+from creek.config import AIStyleConfig
+from creek.generate.ai_style import scan
+from creek.generate.ai_style.features import one_line_fragment_density
+from creek.generate.ai_style.model import FeatureStat, VoiceFingerprint
+from creek.generate.ai_style.sanitize_typography import normalize_typography
+from creek.generate.ai_style.tells import (
+    PLACEHOLDER_DATE,
+    TELL_REGISTRY,
+    effective_polarity,
+)
+
+_KEY = "one_line_fragment_density"
+
+# A punchy draft: short single-sentence paragraphs, the user's signature beat.
+_PUNCHY = (
+    "I went down to the water.\n\nIt was cold.\n\nI stayed anyway.\n\nThe light moved."
+)
+# The same content flattened into one dense block — the signature stripped out.
+_FLATTENED = (
+    "I went down to the water and it was cold but I stayed anyway while the "
+    "light moved across the surface in the way it always does at that hour."
+)
+
+
+def _fingerprint(**rates: float) -> VoiceFingerprint:
+    """Build a non-thin fingerprint with the given per-feature rates."""
+    return VoiceFingerprint(
+        features={k: FeatureStat(rate=v, support=50) for k, v in rates.items()},
+        fragment_count=50,
+    )
+
+
+def _finding(report, tell_id: str):
+    """Return the first finding for *tell_id*, or ``None``."""
+    return next((f for f in report.findings if f.tell_id == tell_id), None)
+
+
+# --- effective_polarity (unit) ---------------------------------------------
+
+
+class TestEffectivePolarity:
+    """Polarity is derived from the user's rate, with locked artifacts exempt."""
+
+    def test_heavy_user_makes_signature(self) -> None:
+        """A rate at/above threshold flips the concern to under-use."""
+        tell = TELL_REGISTRY[_KEY.replace("_density", "")]  # "one_line_fragment"
+        assert effective_polarity(tell, 9.0, signature_threshold=3.0) == "signature"
+
+    def test_avoid_tell_never_reinforced(self) -> None:
+        """An AI-tell stays ``avoid`` even when the user over-uses it."""
+        tell = TELL_REGISTRY["negative_parallelism"]
+        assert effective_polarity(tell, 0.0, signature_threshold=3.0) == "avoid"
+        # Heavy use does NOT reinforce a catalog tell (no triad-padding revival).
+        assert effective_polarity(tell, 900.0, signature_threshold=3.0) == "avoid"
+
+    def test_signature_tell_inert_below_threshold(self) -> None:
+        """A signature feature the user does not employ is inert (no firing)."""
+        tell = TELL_REGISTRY["one_line_fragment"]
+        assert effective_polarity(tell, 0.0, signature_threshold=3.0) is None
+
+    def test_never_legitimate_tell_is_locked(self) -> None:
+        """A margin-0 artifact stays ``avoid`` even at a huge user rate."""
+        assert PLACEHOLDER_DATE.polarity_is_locked()
+        assert (
+            effective_polarity(PLACEHOLDER_DATE, 999.0, signature_threshold=3.0)
+            == "avoid"
+        )
+
+
+# --- one_line_fragment_density extractor (acceptance #2) -------------------
+
+
+class TestOneLineFragmentDensity:
+    """The new signature extractor counts short single-line paragraphs."""
+
+    def test_counts_short_one_liners(self) -> None:
+        """Several short single-line paragraphs yield a positive rate."""
+        assert one_line_fragment_density(_PUNCHY) > 0.0
+
+    def test_flattened_block_scores_zero(self) -> None:
+        """One dense multi-line-free block is not a one-line-fragment rhythm."""
+        assert one_line_fragment_density(_FLATTENED) == 0.0
+
+    def test_long_single_line_paragraph_not_counted(self) -> None:
+        """A single line over the word ceiling is a paragraph, not a beat."""
+        long_line = " ".join(["word"] * 40)
+        assert one_line_fragment_density(long_line) == 0.0
+
+
+# --- scanner regression (acceptance #1) ------------------------------------
+
+
+class TestSignatureReinforcement:
+    """Stripping a user's over-used signature raises voice distance."""
+
+    def test_stripping_signature_raises_distance(self) -> None:
+        """A flattened draft diverges *more* than a punchy one for a punchy user."""
+        fp = _fingerprint(**{_KEY: 12.0})
+        config = AIStyleConfig()
+
+        punchy = scan(_PUNCHY, fingerprint=fp, config=config)
+        flattened = scan(_FLATTENED, fingerprint=fp, config=config)
+
+        # The flattened draft under-uses the signature, so it is the divergent
+        # one — the whole point of #635.
+        assert flattened.voice_distance > punchy.voice_distance
+        under = _finding(flattened, "one_line_fragment")
+        assert under is not None
+        assert under.direction == "under"
+        # And the matching punchy draft is not flagged for the signature.
+        assert _finding(punchy, "one_line_fragment") is None
+
+    def test_derivation_gated_by_threshold(self) -> None:
+        """Raise the threshold above the user's rate and the flip does not happen."""
+        fp = _fingerprint(**{_KEY: 12.0})
+        # Threshold above the user's 12.0 rate => feature is not a signature,
+        # so under-use is harmless and nothing fires (old avoid behaviour).
+        config = AIStyleConfig(signature_polarity_threshold=100.0)
+        flattened = scan(_FLATTENED, fingerprint=fp, config=config)
+        assert _finding(flattened, "one_line_fragment") is None
+
+
+# --- existing protections preserved (acceptance #3) ------------------------
+
+
+class TestExistingProtectionsPreserved:
+    """Avoid-tell firing and typography protection still work under derivation."""
+
+    def test_avoid_tell_still_fires_for_non_signature_user(self) -> None:
+        """A user who avoids a feature still gets over-use flagged."""
+        fp = _fingerprint(negative_parallelism_density=0.0)
+        text = "It's not only fast, but also cheap. It's not a bug, it's a feature."
+        report = scan(text, fingerprint=fp, config=AIStyleConfig())
+        firing = _finding(report, "negative_parallelism")
+        assert firing is not None
+        assert firing.direction == "over"
+
+    def test_curly_quotes_straightened_when_user_avoids_them(self) -> None:
+        """Typography normalisation still strips curly quotes off-grain."""
+        fp = _fingerprint(curly_quote_density=0.0)
+        out = normalize_typography(
+            "She said “hello” to me.",
+            fingerprint=fp,
+            config=AIStyleConfig(),
+        )
+        assert "“" not in out and "”" not in out
+
+    def test_curly_quotes_preserved_when_user_uses_them(self) -> None:
+        """A user whose voice uses curly quotes keeps them untouched."""
+        fp = _fingerprint(curly_quote_density=20.0)
+        original = "She said “hello” to me."
+        out = normalize_typography(original, fingerprint=fp, config=AIStyleConfig())
+        assert out == original

--- a/creek-tools/tests/generate/ai_style/test_signature_polarity.py
+++ b/creek-tools/tests/generate/ai_style/test_signature_polarity.py
@@ -17,6 +17,7 @@ from creek.generate.ai_style.sanitize_typography import normalize_typography
 from creek.generate.ai_style.tells import (
     PLACEHOLDER_DATE,
     TELL_REGISTRY,
+    Tell,
     effective_polarity,
 )
 
@@ -53,9 +54,37 @@ class TestEffectivePolarity:
     """Polarity is derived from the user's rate, with locked artifacts exempt."""
 
     def test_heavy_user_makes_signature(self) -> None:
-        """A rate at/above threshold flips the concern to under-use."""
-        tell = TELL_REGISTRY[_KEY.replace("_density", "")]  # "one_line_fragment"
+        """A rate above threshold flips the concern to under-use."""
+        tell = TELL_REGISTRY["one_line_fragment"]
         assert effective_polarity(tell, 9.0, signature_threshold=3.0) == "signature"
+
+    def test_threshold_boundary_is_inclusive(self) -> None:
+        """``user_rate == threshold`` counts as a signature (``>=``, not ``>``)."""
+        tell = TELL_REGISTRY["one_line_fragment"]
+        assert effective_polarity(tell, 3.0, signature_threshold=3.0) == "signature"
+
+    def test_lock_polarity_flag_forces_declared(self) -> None:
+        """An explicit ``lock_polarity`` keeps declared polarity below threshold.
+
+        Covers the ``lock_polarity=True`` branch independently of the
+        ``margin == 0.0`` branch: without the lock this signature tell would be
+        inert (``None``) at a sub-threshold rate.
+        """
+        locked = Tell(
+            id="_test_locked_signature",
+            category="rhetorical",
+            feature_key="_test_locked",
+            handling="surface",
+            polarity="signature",
+            description="test",
+            caveat="test",
+            measure=lambda _text: 0.0,
+            locate=lambda _text: [],
+            lock_polarity=True,
+        )
+        assert locked.margin is None
+        assert locked.polarity_is_locked()
+        assert effective_polarity(locked, 0.0, signature_threshold=3.0) == "signature"
 
     def test_avoid_tell_never_reinforced(self) -> None:
         """An AI-tell stays ``avoid`` even when the user over-uses it."""


### PR DESCRIPTION
## Summary
Closes the last child of the voice epic — the **discerning** scrub: reinforce authentic signatures, scrub only genuine AI tells, no scrubbing without discernment.

- **Per-user polarity derivation** (`effective_polarity`, `scanner.py`): polarity is no longer fixed at registration. A tell *declared* as a reinforceable signature flips to an under-use concern once the user's own fingerprint rate clears `signature_polarity_threshold` (new `AIStyleConfig` knob, default 3.0/1k). So a draft that **strips a feature the user characteristically uses raises `voice_distance`** instead of lowering it. Below threshold such a tell is **inert** (no spurious firing on drafts that happen to use it).
- **Discernment, not wholesale flipping**: the AI-tell catalog (`avoid`) is never reinforced — a triad-loving writer's padding is *tolerated* (existing vault-relative suppression), never *revived*. Never-legitimate artifacts (`margin == 0.0`: placeholder dates, fabricated citations) are locked to `avoid`.
- **New signature extractor** `one_line_fragment_density` (`features.py`): measures the punchy single-sentence-paragraph rhythm — previously unmeasured, so neither protected nor reinforced — registered as a `signature` tell (`discourse.py`).
- `scan()` factored into `_score_tell` to keep complexity ≤ 10.
- Knowledge/retrieval corpus untouched; VOICE-scoping only.

## Test plan
- `tests/generate/ai_style/test_signature_polarity.py` (new): derivation unit cases (signature flip, avoid-never-reinforced, inert-below-threshold, locked artifact); the new extractor; the **acceptance #1 regression** (stripping an over-used signature raises distance + emits an `under` finding; matching draft does not; threshold gates the flip); **acceptance #3 regressions** (an avoid tell still fires `over` for a non-signature user; curly quotes straightened off-grain but preserved when the user uses them).
- Updated `test_features.py` for the 20th extractor.
- `./scripts/check-all.sh` green (12/12): 5505 passed, ≥90% coverage, complexity ≤10.

Closes #635
Refs #632
