### PR TITLE
feat(llm): per-stage LLMRoutingConfig + ModelRouter skeleton (#645)

### DIFF
--- a/creek-tools/creek/classify/llm/router.py
+++ b/creek-tools/creek/classify/llm/router.py
@@ -1,0 +1,65 @@
+"""The model router: resolve ``(stage, tier) -> LLMConfig`` (#642).
+
+``ModelRouter`` is the single chokepoint through which every LLM call site will
+resolve which provider+model to use for a given pipeline stage. This skeleton
+(#645) resolves each stage to its configured :class:`~creek.config.LLMConfig`,
+falling back to the routing ``default``. The ``Intimate``-never-cloud
+enforcement is wired into :meth:`resolve` in #647 (the ``tier`` argument is
+accepted now so the signature is stable); the Writing Desk role map
+(:meth:`resolve_role`) lands in #648.
+
+Construction accepts either a :class:`~creek.config.LLMRoutingConfig` (the
+per-stage shape) or a bare :class:`~creek.config.LLMConfig` (treated as the sole
+``default``), so call sites can adopt the router before the config type changes.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.config import LLMConfig, LLMRoutingConfig
+
+if TYPE_CHECKING:
+    from creek.models import PrivacyTier
+
+
+class ModelRouter:
+    """Resolve a pipeline stage (and fragment tier) to an :class:`LLMConfig`.
+
+    Attributes:
+        routing: The normalised per-stage routing config.
+    """
+
+    def __init__(self, routing: LLMRoutingConfig | LLMConfig) -> None:
+        """Build a router from a routing config or a single flat config.
+
+        Args:
+            routing: A :class:`LLMRoutingConfig`, or a bare :class:`LLMConfig`
+                which is wrapped as the routing ``default`` (every stage then
+                resolves to it).
+        """
+        self.routing: LLMRoutingConfig = (
+            routing
+            if isinstance(routing, LLMRoutingConfig)
+            else LLMRoutingConfig(default=routing)
+        )
+
+    def resolve(self, stage: str, tier: PrivacyTier | None = None) -> LLMConfig:
+        """Return the :class:`LLMConfig` for *stage*.
+
+        Args:
+            stage: The pipeline stage (``default`` / ``classification`` /
+                ``generation`` / ``frontend``); unknown stages fall back to the
+                routing ``default``.
+            tier: The fragment's privacy tier. Accepted now for signature
+                stability; the ``Intimate``-never-cloud redirect is enforced
+                here in #647. Until then it has no effect.
+
+        Returns:
+            The resolved config, ready for
+            :func:`~creek.classify.llm.providers.build_provider`.
+        """
+        # Issue #647: enforce Intimate-never-cloud here (redirect to local +
+        # WARN; raise IntimateRoutingError if even ``default`` is cloud).
+        _ = tier
+        return self.routing.for_stage(stage)

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -158,6 +158,89 @@ class LLMConfig(BaseModel):
         return value
 
 
+_LLM_SCALAR_STAGES = ("default", "classification", "generation", "frontend")
+"""Stages that resolve to a single :class:`LLMConfig` (``writing_desk`` is a
+role *map*, handled separately by the router in #648)."""
+
+
+class LLMRoutingConfig(BaseModel):
+    """Per-stage LLM routing (#642), backward-compatible with a flat block.
+
+    A vault's ``llm:`` block is accepted in two shapes:
+
+    * **legacy flat** — ``{provider, model, …}`` (an :class:`LLMConfig`) is
+      promoted to ``default`` so every stage resolves to it (pre-#642
+      behaviour, and the shape an env override ``CREEK_LLM='{"provider":…}'``
+      produces);
+    * **per-stage map** — ``{default, classification, generation, frontend,
+      writing_desk}``.
+
+    Unset scalar stages fall back to :attr:`default`; :attr:`default` itself
+    falls back to a plain :class:`LLMConfig` (local Ollama). The per-stage
+    *resolution* and the ``Intimate``-never-cloud rule live in
+    :class:`~creek.classify.llm.router.ModelRouter`, not here — this model only
+    holds and normalises the config.
+    """
+
+    default: LLMConfig = Field(default_factory=LLMConfig)
+    """The fallback config for any stage without its own entry."""
+
+    classification: LLMConfig | None = None
+    """Override for the classification stage; ``None`` falls back to default."""
+
+    generation: LLMConfig | None = None
+    """Override for the generation stage; ``None`` falls back to default."""
+
+    frontend: LLMConfig | None = None
+    """Reserved for the OpenClaw frontend (schema-only until it lands, #642)."""
+
+    writing_desk: dict[str, LLMConfig] = Field(default_factory=dict)
+    """Writing Desk role -> model map (resolved by the router in #648)."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_flat(cls, data: object) -> object:
+        """Promote a legacy flat ``LLMConfig`` (or its mapping) to ``default``.
+
+        A bare :class:`LLMConfig` instance — e.g.
+        ``CreekConfig(llm=LLMConfig(...))`` — or a flat mapping carrying any
+        :class:`LLMConfig` field with no per-stage key is the old single-block
+        shape; wrap it as ``{"default": <it>}`` so it keeps working unchanged.
+
+        Args:
+            data: The raw input to validation (mapping, ``LLMConfig``, or other).
+
+        Returns:
+            ``data`` unchanged, or ``{"default": data}`` when it is a legacy
+            flat block.
+        """
+        if isinstance(data, LLMConfig):
+            return {"default": data}
+        if not isinstance(data, dict):
+            return data
+        stage_keys = {*_LLM_SCALAR_STAGES, "writing_desk"}
+        legacy_keys = set(LLMConfig.model_fields)
+        keys = set(data)
+        if keys & legacy_keys and not (keys & stage_keys):
+            return {"default": data}
+        return data
+
+    def for_stage(self, stage: str) -> LLMConfig:
+        """Return the :class:`LLMConfig` for *stage*, falling back to default.
+
+        Args:
+            stage: A scalar stage name (``default`` / ``classification`` /
+                ``generation`` / ``frontend``). Any other value (including a
+                role name or a typo) safely resolves to :attr:`default`.
+
+        Returns:
+            The stage's configured :class:`LLMConfig`, or :attr:`default`.
+        """
+        if stage in _LLM_SCALAR_STAGES:
+            return getattr(self, stage) or self.default
+        return self.default
+
+
 class EmbeddingsConfig(BaseModel):
     """Embedding model configuration.
 

--- a/creek-tools/tests/test_model_router.py
+++ b/creek-tools/tests/test_model_router.py
@@ -1,0 +1,119 @@
+"""Per-stage LLM routing schema + ModelRouter skeleton (#645).
+
+The skeleton is purely additive: ``LLMRoutingConfig`` parses either the legacy
+flat ``llm`` block (promoted to ``default``) or a per-stage map, and
+``ModelRouter`` resolves ``(stage, tier) -> LLMConfig`` — every stage falling
+back to ``default``. No call site is rewired here (that is #646); the tier arg
+is accepted but not yet enforced (that is #647).
+"""
+
+from __future__ import annotations
+
+from creek.classify.llm.router import ModelRouter
+from creek.config import LLMConfig, LLMRoutingConfig
+from creek.models import PrivacyTier
+
+# --- LLMRoutingConfig schema + backward compatibility ----------------------
+
+
+class TestLLMRoutingConfigBackCompat:
+    """A legacy flat block is accepted and promoted to ``default``."""
+
+    def test_flat_dict_promoted_to_default(self) -> None:
+        """A legacy flat mapping becomes ``{default: <it>}``."""
+        routing = LLMRoutingConfig.model_validate(
+            {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+        )
+        assert routing.default.provider == "anthropic"
+        assert routing.default.model == "claude-sonnet-4-6"
+        assert routing.classification is None
+
+    def test_llmconfig_instance_promoted_to_default(self) -> None:
+        """An ``LLMConfig`` instance (e.g. ``CreekConfig(llm=LLMConfig(...))``)."""
+        routing = LLMRoutingConfig.model_validate(
+            LLMConfig(provider="anthropic", model="x"),
+        )
+        assert routing.default.provider == "anthropic"
+
+    def test_json_string_flat_round_trips(self) -> None:
+        """The working env override shape ``CREEK_LLM='{"provider":…}'``."""
+        routing = LLMRoutingConfig.model_validate_json('{"provider": "anthropic"}')
+        assert routing.default.provider == "anthropic"
+
+    def test_empty_defaults_to_local_ollama(self) -> None:
+        """No config at all yields the local default."""
+        routing = LLMRoutingConfig()
+        assert routing.default.provider == "ollama"
+
+
+class TestLLMRoutingConfigPerStage:
+    """The per-stage map parses and ``for_stage`` falls back to ``default``."""
+
+    def _routing(self) -> LLMRoutingConfig:
+        return LLMRoutingConfig.model_validate(
+            {
+                "default": {"provider": "ollama", "model": "qwen3:8b"},
+                "generation": {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+                "writing_desk": {"outliner": {"provider": "ollama", "model": "q"}},
+            },
+        )
+
+    def test_per_stage_parses_independently(self) -> None:
+        """Each configured stage keeps its own provider."""
+        routing = self._routing()
+        assert routing.for_stage("generation").provider == "anthropic"
+        assert routing.for_stage("default").provider == "ollama"
+
+    def test_unset_stage_falls_back_to_default(self) -> None:
+        """A stage with no entry resolves to ``default``."""
+        routing = self._routing()
+        assert routing.for_stage("classification").provider == "ollama"
+        assert routing.for_stage("frontend").provider == "ollama"
+
+    def test_writing_desk_map_is_parsed(self) -> None:
+        """The reserved ``writing_desk`` role map parses (wired in #648)."""
+        routing = self._routing()
+        assert routing.writing_desk["outliner"].provider == "ollama"
+
+    def test_unknown_stage_resolves_to_default(self) -> None:
+        """An unrecognised stage name is safe — resolves to ``default``."""
+        routing = self._routing()
+        assert routing.for_stage("nonsense").provider == "ollama"
+
+
+# --- ModelRouter ------------------------------------------------------------
+
+
+class TestModelRouter:
+    """``ModelRouter`` resolves ``(stage, tier) -> LLMConfig``."""
+
+    def test_from_flat_llmconfig_every_stage_is_default(self) -> None:
+        """Constructed from a single LLMConfig, every stage resolves to it."""
+        router = ModelRouter(LLMConfig(provider="ollama", model="qwen3:8b"))
+        assert router.resolve("classification").provider == "ollama"
+        assert router.resolve("generation").model == "qwen3:8b"
+
+    def test_from_routing_config_resolves_per_stage(self) -> None:
+        """Constructed from a routing config, stages resolve independently."""
+        routing = LLMRoutingConfig.model_validate(
+            {
+                "default": {"provider": "ollama"},
+                "generation": {"provider": "anthropic"},
+            },
+        )
+        router = ModelRouter(routing)
+        assert router.resolve("generation").provider == "anthropic"
+        assert router.resolve("classification").provider == "ollama"
+
+    def test_tier_arg_is_accepted_but_not_yet_enforced(self) -> None:
+        """The tier arg is part of the signature now; enforcement is #647."""
+        router = ModelRouter(LLMConfig(provider="anthropic"))
+        # Skeleton: tier does not yet redirect (the Intimate chokepoint is #647).
+        assert router.resolve("generation", PrivacyTier.INTIMATE).provider == (
+            "anthropic"
+        )
+
+    def test_resolve_returns_an_llmconfig(self) -> None:
+        """The resolved value is an ``LLMConfig`` ready for ``build_provider``."""
+        router = ModelRouter(LLMConfig(provider="ollama"))
+        assert isinstance(router.resolve("default"), LLMConfig)


### PR DESCRIPTION
## Summary
- Adds `LLMRoutingConfig` (config.py) — the per-stage `llm` schema: `default` / `classification` / `generation` / `frontend` + a reserved `writing_desk` role map. A `model_validator` promotes a **legacy flat block** (an `LLMConfig`, its mapping, or the `CREEK_LLM='{...}'` env shape) to `default`, so existing configs keep working unchanged. `for_stage()` falls back to `default`.
- Adds `ModelRouter` (classify/llm/router.py) — `resolve(stage, tier=None) -> LLMConfig`, constructible from an `LLMRoutingConfig` **or** a bare `LLMConfig` (wrapped as `default`).
- **Purely additive**: `CreekConfig.llm` is unchanged (still `LLMConfig`); no call site is rewired. The type swap + per-stage call-site routing is #646; the `Intimate`-never-cloud enforcement (the accepted-but-inert `tier` arg) is #647.

## Test plan
- `tests/test_model_router.py` (new, 12 cases): legacy-flat promotion (dict, `LLMConfig` instance, and `CREEK_LLM`-style JSON), per-stage parsing, `for_stage` fallback (incl. unknown stage), and `ModelRouter` resolution from both construction shapes + the inert tier arg.
- `./scripts/check-all.sh` green (12/12): 5494 passed, 93.82% coverage, no regressions (additive only).

Refs #642
Closes #645
