### PR TITLE
feat(llm): route classification + generation through ModelRouter (#646)

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -210,7 +210,10 @@ def run_classify(
 
     rules = RuleClassifier()
     audience = AudienceClassifier()
-    llm = LLMClassifier(config=config.llm) if method == "llm" else None
+    # Per-stage routing (#646): the classifier uses the classification stage's
+    # resolved provider+model, not the global block.
+    classify_llm = config.model_router.resolve("classification")
+    llm = LLMClassifier(config=classify_llm) if method == "llm" else None
     if llm is not None and not llm.available:
         # Refuse to iterate when the provider is unreachable so the
         # vault is never stamped with ``classification_method: llm``
@@ -220,8 +223,8 @@ def run_classify(
         # we capture it here for the operator-facing message so the
         # remediation hint is not buried in stderr.
         raise LLMProviderUnavailableError(
-            provider=config.llm.provider,
-            detail=_describe_llm_unavailability(config.llm.provider),
+            provider=classify_llm.provider,
+            detail=_describe_llm_unavailability(classify_llm.provider),
         )
     counts = _RunCounts()
     progress_path: Path | None = None

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -887,24 +887,26 @@ def _preflight_cloud_consent(config: CreekConfig) -> None:
     )
 
     # Per-stage routing (#646): a cloud provider configured for ANY stage
-    # (not just the global default) requires consent — check them all.
-    provider = next(
+    # (not just the global default) requires consent — check them all, and name
+    # the offending stage so the operator looks at the right config key.
+    cloud_stage = next(
         (
-            cfg.provider.strip().lower()
-            for cfg in config.llm.all_configs()
+            (label, cfg.provider.strip().lower())
+            for label, cfg in config.llm.iter_stage_configs()
             if provider_is_cloud(cfg.provider.strip().lower())
         ),
         None,
     )
-    if provider is None:
+    if cloud_stage is None:
         return
     if has_cloud_consent():
         return
+    stage_label, provider = cloud_stage
     name = provider_display_name(provider)
     console.print(
-        f"[red]{name} provider selected in creek_config.yaml "
-        f"(llm.provider: {provider}), but cloud classification requires "
-        "explicit consent.[/red]",
+        f"[red]{name} provider configured for the '{stage_label}' LLM stage "
+        f"in creek_config.yaml (llm.{stage_label}.provider: {provider}), but "
+        "cloud processing requires explicit consent.[/red]",
     )
     console.print(
         f"[yellow]Set [bold]{CLOUD_CONSENT_ENV}=1[/bold] "

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -886,8 +886,17 @@ def _preflight_cloud_consent(config: CreekConfig) -> None:
         provider_is_cloud,
     )
 
-    provider = config.llm.provider.strip().lower()
-    if not provider_is_cloud(provider):
+    # Per-stage routing (#646): a cloud provider configured for ANY stage
+    # (not just the global default) requires consent — check them all.
+    provider = next(
+        (
+            cfg.provider.strip().lower()
+            for cfg in config.llm.all_configs()
+            if provider_is_cloud(cfg.provider.strip().lower())
+        ),
+        None,
+    )
+    if provider is None:
         return
     if has_cloud_consent():
         return
@@ -1142,7 +1151,7 @@ def _run_calibration_cli(
         raise typer.Exit(code=2)
 
     config = _load_config_for_vault(vault)
-    classifier = LLMClassifier(config=config.llm)
+    classifier = LLMClassifier(config=config.model_router.resolve("classification"))
     report = run_calibration(classifier, load_fixture(resolved))
     console.print(report.render())
 
@@ -1296,7 +1305,7 @@ def compile_(
         target_kind=kind,
         target_id=target_id,
         target_title=target_title,
-        llm=default_llm(config.llm),
+        llm=default_llm(config.model_router.resolve("generation")),
     )
     console.print(
         f"[bold green]Compiled {fragment_id} -> {written}[/bold green]",
@@ -2498,7 +2507,7 @@ def _build_draft_llm(max_tokens: int | None = None) -> DraftLLM:
     effective_max_tokens = (
         max_tokens if max_tokens is not None else config.draft.max_tokens
     )
-    classifier = LLMClassifier(config.llm)
+    classifier = LLMClassifier(config.model_router.resolve("classification"))
     if not classifier.available:
         console.print(
             "[red]LLM provider unavailable; cannot generate draft. "
@@ -2597,7 +2606,7 @@ def _build_ontology_detector(vault: Path | None) -> OntologyDetector:
     config = _load_config_for_vault(vault)
 
     def _detect(prompt: str) -> PromptOntology:
-        return detect_ontology(prompt, config.llm)
+        return detect_ontology(prompt, config.model_router.resolve("classification"))
 
     return _detect
 
@@ -4092,8 +4101,13 @@ def _build_compost_verifier(config: CreekConfig) -> SupportsVerifyCompost | None
     from creek.classify.llm import AnthropicProvider
     from creek.generate.compost_verifier import LLMCompostVerifier
 
+    # Per-stage routing (#646): resolve the generation stage so the verifier
+    # uses the generation model. The verifier itself is still Anthropic-specific
+    # (it calls the Anthropic-only ``.call``); making it fully provider-neutral
+    # is a follow-up. Feeding the resolved config keeps the credential-fallback
+    # behaviour (AnthropicProvider raises without a key → embedding-only).
     try:
-        provider = AnthropicProvider(config=config.llm)
+        provider = AnthropicProvider(config=config.model_router.resolve("generation"))
     except RuntimeError as exc:
         console.print(
             f"[yellow]Skipping LLM verifier — provider unavailable: {exc}[/yellow]",

--- a/creek-tools/creek/compile/engine.py
+++ b/creek-tools/creek/compile/engine.py
@@ -512,16 +512,25 @@ def _resolve_target_path(
 
 
 def default_llm(config: LLMConfig) -> CompileLLM:
-    """Return the default cloud LLM client for the CLI entry point.
+    """Return the generation LLM client for the CLI entry point.
 
-    Tests monkeypatch this hook to inject a deterministic stub. The
-    production path constructs an Anthropic client lazily so the import
-    cost (and the API-key check) stays out of the unit-test surface.
+    Tests monkeypatch this hook to inject a deterministic stub. The production
+    path builds the provider lazily via the factory (#646) so the generation
+    stage honors the configured provider (Anthropic, Ollama, …) rather than
+    being hard-wired to Anthropic; the import cost (and any API-key check) stays
+    out of the unit-test surface.
     """
-    from creek.classify.llm import AnthropicProvider
+    from creek.classify.llm import build_provider
 
-    provider = AnthropicProvider(config)
-    return provider.call
+    provider = build_provider(config)
+
+    def _complete(prompt: str) -> str:
+        # ``complete`` is the provider-neutral protocol method (every provider
+        # implements it); ``.call`` is Anthropic-only, so routing to Ollama/etc.
+        # must go through ``complete`` to stay backend-agnostic (#646).
+        return provider.complete(prompt).text
+
+    return _complete
 
 
 def _load_existing_provenance(target_path: Path) -> list[ProvenanceEntry]:

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -12,12 +12,15 @@ file — they must come from environment variables.
 import logging
 import os
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 from zoneinfo import ZoneInfo
 
 import yaml
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+if TYPE_CHECKING:
+    from creek.classify.llm.router import ModelRouter
 
 logger = logging.getLogger(__name__)
 
@@ -239,6 +242,23 @@ class LLMRoutingConfig(BaseModel):
         if stage in _LLM_SCALAR_STAGES:
             return getattr(self, stage) or self.default
         return self.default
+
+    def all_configs(self) -> list[LLMConfig]:
+        """Return every distinct :class:`LLMConfig` this routing can resolve.
+
+        Used by the cloud-consent preflight so a cloud provider configured for
+        *any* stage (not just ``default``) is caught before the run starts.
+
+        Returns:
+            ``default`` plus each set scalar-stage override and every
+            ``writing_desk`` role config.
+        """
+        configs = [self.default]
+        for stage in _LLM_SCALAR_STAGES:
+            if stage != "default" and (cfg := getattr(self, stage)) is not None:
+                configs.append(cfg)
+        configs.extend(self.writing_desk.values())
+        return configs
 
 
 class EmbeddingsConfig(BaseModel):
@@ -1354,8 +1374,10 @@ class CreekConfig(BaseSettings):
     timezone: str = "America/Los_Angeles"
     """IANA timezone for timestamp normalisation."""
 
-    llm: LLMConfig = Field(default_factory=LLMConfig)
-    """LLM provider settings."""
+    llm: LLMRoutingConfig = Field(default_factory=LLMRoutingConfig)
+    """Per-stage LLM routing (#642). A legacy flat ``llm`` block is promoted to
+    ``default`` by :class:`LLMRoutingConfig`, so existing configs keep working;
+    resolve a stage's provider+model via :attr:`model_router`."""
 
     embeddings: EmbeddingsConfig = Field(default_factory=EmbeddingsConfig)
     """Embedding model settings."""
@@ -1431,6 +1453,18 @@ class CreekConfig(BaseSettings):
             msg = f"Invalid timezone: {v}"
             raise ValueError(msg) from exc
         return v
+
+    @property
+    def model_router(self) -> "ModelRouter":
+        """Return a :class:`~creek.classify.llm.router.ModelRouter` for this run.
+
+        The single resolver every LLM call site uses to map a pipeline stage
+        (and, from #647, a fragment tier) to a provider+model. Imported lazily
+        to avoid a config<->router import cycle.
+        """
+        from creek.classify.llm.router import ModelRouter
+
+        return ModelRouter(self.llm)
 
 
 def load_config(

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -11,6 +11,7 @@ file — they must come from environment variables.
 
 import logging
 import os
+from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 from zoneinfo import ZoneInfo
@@ -20,6 +21,8 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from creek.classify.llm.router import ModelRouter
 
 logger = logging.getLogger(__name__)
@@ -243,6 +246,23 @@ class LLMRoutingConfig(BaseModel):
             return getattr(self, stage) or self.default
         return self.default
 
+    def iter_stage_configs(self) -> "Iterator[tuple[str, LLMConfig]]":
+        """Yield ``(stage_label, LLMConfig)`` for every configured stage.
+
+        ``default`` first, then each set scalar-stage override, then every
+        ``writing_desk`` role (labelled ``writing_desk.<role>``). The label lets
+        callers name the offending stage in messages.
+
+        Yields:
+            ``(label, config)`` pairs across all configured stages.
+        """
+        yield "default", self.default
+        for stage in _LLM_SCALAR_STAGES:
+            if stage != "default" and (cfg := getattr(self, stage)) is not None:
+                yield stage, cfg
+        for role, cfg in self.writing_desk.items():
+            yield f"writing_desk.{role}", cfg
+
     def all_configs(self) -> list[LLMConfig]:
         """Return every distinct :class:`LLMConfig` this routing can resolve.
 
@@ -253,12 +273,7 @@ class LLMRoutingConfig(BaseModel):
             ``default`` plus each set scalar-stage override and every
             ``writing_desk`` role config.
         """
-        configs = [self.default]
-        for stage in _LLM_SCALAR_STAGES:
-            if stage != "default" and (cfg := getattr(self, stage)) is not None:
-                configs.append(cfg)
-        configs.extend(self.writing_desk.values())
-        return configs
+        return [cfg for _, cfg in self.iter_stage_configs()]
 
 
 class EmbeddingsConfig(BaseModel):
@@ -1454,13 +1469,14 @@ class CreekConfig(BaseSettings):
             raise ValueError(msg) from exc
         return v
 
-    @property
+    @cached_property
     def model_router(self) -> "ModelRouter":
         """Return a :class:`~creek.classify.llm.router.ModelRouter` for this run.
 
         The single resolver every LLM call site uses to map a pipeline stage
         (and, from #647, a fragment tier) to a provider+model. Imported lazily
-        to avoid a config<->router import cycle.
+        to avoid a config<->router import cycle, and cached so the several call
+        sites in one command share one router instance.
         """
         from creek.classify.llm.router import ModelRouter
 

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -166,7 +166,9 @@ class Pipeline:
         self.no_llm = no_llm
         self.scanner = RedactionScanner(config=config.redaction)
         self.rule_classifier = RuleClassifier()
-        self.llm_classifier = LLMClassifier(config=config.llm)
+        self.llm_classifier = LLMClassifier(
+            config=config.model_router.resolve("classification"),
+        )
         self.review_generator = ReviewQueueGenerator(config=config.classification)
         self.linking_pipeline = LinkingPipeline(
             config=config.embeddings,

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -952,7 +952,7 @@ def test_run_classify_llm_unavailable_message_names_provider(
         body="content",
     )
     config = CreekConfig()
-    config.llm.provider = "anthropic"
+    config.llm.default.provider = "anthropic"
 
     with (
         patch.object(

--- a/creek-tools/tests/test_compile.py
+++ b/creek-tools/tests/test_compile.py
@@ -910,27 +910,31 @@ def test_str_list_drops_non_list_inputs_from_llm() -> None:
 
 
 def test_default_llm_returns_callable(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The CLI entry point's LLM factory wraps the Anthropic provider."""
+    """The CLI entry point's LLM factory routes through ``build_provider`` (#646).
+
+    No longer hard-wired to Anthropic: ``default_llm`` builds the configured
+    provider via the factory and drives it through the provider-neutral
+    ``complete`` method.
+    """
     from creek.compile import engine as engine_module
+    from creek.config import LLMConfig
 
     captured: dict[str, object] = {}
 
     class _StubProvider:
-        def __init__(self, config: object) -> None:
-            captured["config"] = config
+        def complete(self, prompt: str, **_kw: object) -> object:
+            return type("C", (), {"text": f"echo:{prompt}"})()
 
-        def call(self, prompt: str) -> str:
-            return f"echo:{prompt}"
+    def _fake_build(config: object) -> _StubProvider:
+        captured["config"] = config
+        return _StubProvider()
 
-    monkeypatch.setattr(
-        "creek.classify.llm.AnthropicProvider",
-        _StubProvider,
-    )
-    sentinel = object()
-    llm = engine_module.default_llm(sentinel)
+    monkeypatch.setattr("creek.classify.llm.build_provider", _fake_build)
+    config = LLMConfig(provider="ollama")
+    llm = engine_module.default_llm(config)
     assert callable(llm)
     assert llm("hi") == "echo:hi"
-    assert captured["config"] is sentinel
+    assert captured["config"] is config
 
 
 def test_cli_compile_unknown_target_kind_exits_2(vault: Path) -> None:

--- a/creek-tools/tests/test_config.py
+++ b/creek-tools/tests/test_config.py
@@ -20,6 +20,7 @@ from creek.config import (
     HygieneConfig,
     LinkingConfig,
     LLMConfig,
+    LLMRoutingConfig,
     MarkdownCleaningConfig,
     OCRConfig,
     QualityConfig,
@@ -470,8 +471,10 @@ class TestCreekConfig:
         assert cfg.vault_path == Path(".")
         assert cfg.source_drive == Path(".")
         assert cfg.timezone == "America/Los_Angeles"
-        # Nested models should exist with their own defaults
-        assert isinstance(cfg.llm, LLMConfig)
+        # Nested models should exist with their own defaults. ``llm`` is now a
+        # per-stage LLMRoutingConfig (#646) whose ``default`` is an LLMConfig.
+        assert isinstance(cfg.llm, LLMRoutingConfig)
+        assert isinstance(cfg.llm.default, LLMConfig)
         assert isinstance(cfg.embeddings, EmbeddingsConfig)
         assert isinstance(cfg.ocr, OCRConfig)
         assert isinstance(cfg.linking, LinkingConfig)
@@ -540,11 +543,11 @@ class TestLoadConfig:
         cfg = load_config(config_file)
         assert cfg.vault_path == Path("/home/user/vault")
         assert cfg.timezone == "America/New_York"
-        assert cfg.llm.provider == "anthropic"
-        assert cfg.llm.model == "claude-3"
+        assert cfg.llm.default.provider == "anthropic"
+        assert cfg.llm.default.model == "claude-3"
         assert cfg.embeddings.similarity_threshold == 0.85
         # Unspecified fields keep defaults
-        assert cfg.llm.batch_size == 50
+        assert cfg.llm.default.batch_size == 50
 
     def test_loads_empty_yaml(self, tmp_path: Path) -> None:
         """load_config() should handle an empty YAML file gracefully."""
@@ -700,7 +703,7 @@ class TestGenerateDefaultConfig:
         cfg = load_config(output)
         assert cfg.vault_path == Path(".")
         assert cfg.timezone == "America/Los_Angeles"
-        assert cfg.llm.provider == "ollama"
+        assert cfg.llm.default.provider == "ollama"
         assert cfg.embeddings.model == "all-MiniLM-L6-v2"
         assert cfg.google_drive.scopes == [
             "https://www.googleapis.com/auth/drive.readonly"
@@ -757,7 +760,7 @@ class TestGenerateDefaultConfig:
 
         cfg = load_config(output)
         # The comment is informational — provider default still ollama.
-        assert cfg.llm.provider == "ollama"
+        assert cfg.llm.default.provider == "ollama"
 
 
 class TestVoiceConfigRoundtrip:

--- a/creek-tools/tests/test_per_stage_routing.py
+++ b/creek-tools/tests/test_per_stage_routing.py
@@ -1,0 +1,110 @@
+"""Per-stage routing wired into CreekConfig + call sites (#646).
+
+#645 added ``LLMRoutingConfig`` + ``ModelRouter`` as standalone machinery.
+This issue makes ``CreekConfig.llm`` a ``LLMRoutingConfig`` and routes every LLM
+call site through ``CreekConfig.model_router`` — so classification and generation
+can use different providers in one run, while a legacy flat ``llm`` block keeps
+working unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.classify.llm.providers import OllamaProvider, build_provider
+from creek.classify.llm.router import ModelRouter
+from creek.compile.engine import default_llm
+from creek.config import CreekConfig, LLMConfig
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class TestCreekConfigRouting:
+    """``CreekConfig.llm`` is per-stage; ``model_router`` resolves it."""
+
+    def test_model_router_is_a_router(self) -> None:
+        """The property hands back a ModelRouter over the config's routing."""
+        config = CreekConfig()
+        assert isinstance(config.model_router, ModelRouter)
+
+    def test_per_stage_config_resolves_distinct_providers(self) -> None:
+        """classification -> ollama and generation -> anthropic in one config."""
+        config = CreekConfig.model_validate(
+            {
+                "llm": {
+                    "default": {"provider": "ollama", "model": "qwen3:8b"},
+                    "classification": {"provider": "ollama", "model": "qwen3:8b"},
+                    "generation": {
+                        "provider": "anthropic",
+                        "model": "claude-sonnet-4-6",
+                    },
+                },
+            },
+        )
+        router = config.model_router
+        assert router.resolve("classification").provider == "ollama"
+        assert router.resolve("generation").provider == "anthropic"
+
+    def test_legacy_flat_block_feeds_every_stage(self) -> None:
+        """A pre-#642 flat ``llm`` block resolves identically for all stages."""
+        config = CreekConfig.model_validate(
+            {"llm": {"provider": "anthropic", "model": "claude-sonnet-4-6"}},
+        )
+        router = config.model_router
+        assert router.resolve("classification").provider == "anthropic"
+        assert router.resolve("generation").provider == "anthropic"
+        assert config.llm.default.model == "claude-sonnet-4-6"
+
+    def test_llmconfig_instance_still_accepted(self) -> None:
+        """``CreekConfig(llm=LLMConfig(...))`` keeps working (promoted to default)."""
+        config = CreekConfig(llm=LLMConfig(provider="anthropic"))
+        assert config.model_router.resolve("generation").provider == "anthropic"
+
+
+class TestPreflightEnumeratesStages:
+    """The consent preflight must see a cloud provider in ANY stage."""
+
+    def test_all_configs_includes_every_stage(self) -> None:
+        """``all_configs`` surfaces default + scalar stages + writing_desk."""
+        config = CreekConfig.model_validate(
+            {
+                "llm": {
+                    "default": {"provider": "ollama"},
+                    "generation": {"provider": "anthropic"},
+                    "writing_desk": {"voice_drafter": {"provider": "openai"}},
+                },
+            },
+        )
+        providers = {cfg.provider for cfg in config.llm.all_configs()}
+        assert providers == {"ollama", "anthropic", "openai"}
+
+
+class TestGenerationFollowsConfig:
+    """``default_llm`` routes via the factory, not hard-wired Anthropic (#646)."""
+
+    def test_factory_routes_generation_provider(self) -> None:
+        """The factory the generation path uses honors the configured provider."""
+        # build_provider(ollama) needs no API key/consent — proving generation
+        # is no longer hard-wired to Anthropic.
+        provider = build_provider(LLMConfig(provider="ollama", model="qwen3:8b"))
+        assert isinstance(provider, OllamaProvider)
+
+    def test_default_llm_completes_via_provider_neutral_protocol(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``default_llm`` drives the provider's ``complete`` (not ``.call``)."""
+
+        class _FakeProvider:
+            def complete(self, prompt: str, **_kw: object) -> object:
+                return type("C", (), {"text": f"echo:{prompt}"})()
+
+        # Patch the factory at its source so the lazy import inside default_llm
+        # resolves to the fake (no network, no Anthropic hard-wire).
+        monkeypatch.setattr(
+            "creek.classify.llm.build_provider",
+            lambda _config: _FakeProvider(),
+        )
+        call = default_llm(LLMConfig(provider="ollama"))
+        assert call("hi") == "echo:hi"

--- a/creek-tools/tests/test_per_stage_routing.py
+++ b/creek-tools/tests/test_per_stage_routing.py
@@ -9,15 +9,13 @@ working unchanged.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import pytest
+import typer
 
 from creek.classify.llm.providers import OllamaProvider, build_provider
 from creek.classify.llm.router import ModelRouter
 from creek.compile.engine import default_llm
 from creek.config import CreekConfig, LLMConfig
-
-if TYPE_CHECKING:
-    import pytest
 
 
 class TestCreekConfigRouting:
@@ -78,6 +76,42 @@ class TestPreflightEnumeratesStages:
         )
         providers = {cfg.provider for cfg in config.llm.all_configs()}
         assert providers == {"ollama", "anthropic", "openai"}
+
+    def test_preflight_exits_on_cloud_in_nondefault_stage(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A cloud provider on a NON-default stage still triggers the gate."""
+        from creek import cli as cli_module
+
+        monkeypatch.delenv("CREEK_CLOUD_CONSENT", raising=False)
+        monkeypatch.delenv("CREEK_ANTHROPIC_CONSENT", raising=False)
+        config = CreekConfig.model_validate(
+            {
+                "llm": {
+                    "default": {"provider": "ollama"},
+                    "classification": {"provider": "anthropic"},
+                },
+            },
+        )
+        with pytest.raises(typer.Exit) as exc:
+            cli_module._preflight_cloud_consent(config)
+        assert exc.value.exit_code == 1
+
+    def test_preflight_noops_when_every_stage_is_local(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """All-local stages never gate, even without consent set."""
+        from creek import cli as cli_module
+
+        monkeypatch.delenv("CREEK_CLOUD_CONSENT", raising=False)
+        monkeypatch.delenv("CREEK_ANTHROPIC_CONSENT", raising=False)
+        config = CreekConfig.model_validate(
+            {"llm": {"default": {"provider": "ollama"}}},
+        )
+        # Must not raise.
+        cli_module._preflight_cloud_consent(config)
 
 
 class TestGenerationFollowsConfig:

--- a/creek-tools/tests/test_pipeline_no_llm.py
+++ b/creek-tools/tests/test_pipeline_no_llm.py
@@ -132,7 +132,7 @@ class TestNoLLMOverridesAnthropicProvider:
     def test_no_llm_wins_over_anthropic_provider(self, vault_path: Path) -> None:
         """An Anthropic-configured pipeline still skips Pass 3 with no_llm."""
         config = CreekConfig()
-        config.llm.provider = "anthropic"
+        config.llm.default.provider = "anthropic"
         pipeline = Pipeline(config=config, no_llm=True)
         item = _make_ingested()
 
@@ -368,7 +368,7 @@ class TestNoLLMNoNetworkEgress:
         # set the provider so a regression that ignores the flag would
         # surface as a NetworkBlockedError on first availability check.
         config = CreekConfig()
-        config.llm.provider = "anthropic"
+        config.llm.default.provider = "anthropic"
         pipeline = Pipeline(config=config, no_llm=True)
         result = pipeline.run(source_path=source_path, vault_path=vault_path)
 


### PR DESCRIPTION
## Summary
- Makes `CreekConfig.llm` a `LLMRoutingConfig` and adds `CreekConfig.model_router` (lazy import — avoids the config↔router cycle). Every LLM call site now resolves its provider+model through `ModelRouter` instead of reading `config.llm` directly, so **classification and generation can use different providers in one `creek process` run**.
- **Routed sites**: `pipeline.py`, `cli.py` (classify/review), `classify_engine.py` → `resolve("classification")`; `cli.py` compile/draft → `resolve("generation")`. Per the approved design's stage-fold: ontology-detection → classification, compost → generation.
- **Preflight** (`_preflight_cloud_consent`) now checks **every** stage for a cloud provider (new `LLMRoutingConfig.all_configs()`), not just the global default — so a cloud provider configured for any stage still requires consent.
- `default_llm` builds via the factory and drives the **provider-neutral `complete()`**, so generation honors the configured provider rather than hard-wired Anthropic.
- **Backward compatible**: a legacy flat `llm` block (or `CreekConfig(llm=LLMConfig(...))`) is promoted to `default` and feeds every stage unchanged.
- The `tier` arg flows to `resolve()` but is still inert — the `Intimate`-never-cloud enforcement is #647.

## Scope notes
- The compost verifier still uses the Anthropic-only `.call`, so it stays on `AnthropicProvider` (fed the resolved generation config); full provider-neutrality there is a follow-up.
- `grep -rn "config\.llm\." creek/` confirms no direct reads remain outside the router.

## Test plan
- `tests/test_per_stage_routing.py` (new): per-stage distinct providers, legacy-flat feeds every stage, `LLMConfig`-instance back-compat, `all_configs` enumerates every stage for the preflight, and `default_llm` routing via the factory/`complete`.
- Updated `test_config.py` / `test_compile.py` / `test_pipeline_no_llm.py` / `test_classify_engine.py` for the `LLMRoutingConfig` type + the factory-based `default_llm`.
- `./scripts/check-all.sh` green (12/12): 5500 passed, 93.81% coverage.

Refs #642
Closes #646
