### PR TITLE
feat(llm): Intimate-never-cloud enforcement at the routing chokepoint (#647)

### DIFF
--- a/creek-tools/creek/classify/llm/router.py
+++ b/creek-tools/creek/classify/llm/router.py
@@ -1,26 +1,59 @@
 """The model router: resolve ``(stage, tier) -> LLMConfig`` (#642).
 
-``ModelRouter`` is the single chokepoint through which every LLM call site will
-resolve which provider+model to use for a given pipeline stage. This skeleton
-(#645) resolves each stage to its configured :class:`~creek.config.LLMConfig`,
-falling back to the routing ``default``. The ``Intimate``-never-cloud
-enforcement is wired into :meth:`resolve` in #647 (the ``tier`` argument is
-accepted now so the signature is stable); the Writing Desk role map
-(:meth:`resolve_role`) lands in #648.
+``ModelRouter`` is the single chokepoint through which every LLM call site
+resolves which provider+model to use for a given pipeline stage, and the single
+place the ``Intimate``-never-cloud privacy invariant is enforced (#647): an
+``Intimate``-tier fragment is redirected off any cloud provider to the local
+``default`` (with a WARNING), or — when even ``default`` is cloud — refused
+loudly via :class:`IntimateRoutingError`. Call sites must never re-check the
+tier themselves; they pass it to :meth:`resolve` and trust the result.
 
 Construction accepts either a :class:`~creek.config.LLMRoutingConfig` (the
 per-stage shape) or a bare :class:`~creek.config.LLMConfig` (treated as the sole
 ``default``), so call sites can adopt the router before the config type changes.
+The Writing Desk role map (:meth:`resolve_role`) lands in #648.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
+from creek.classify.llm.providers import build_provider, provider_is_cloud
 from creek.config import LLMConfig, LLMRoutingConfig
+from creek.models import PrivacyTier
 
 if TYPE_CHECKING:
-    from creek.models import PrivacyTier
+    from creek.classify.llm.base import LLMProvider
+
+logger = logging.getLogger(__name__)
+
+
+class IntimateRoutingError(RuntimeError):
+    """Raised when an ``Intimate`` fragment cannot be routed to any local model.
+
+    The router redirects ``Intimate``-tier work off cloud providers to the local
+    ``default``; this is raised only when ``default`` is *also* a cloud provider,
+    so there is no safe local backend — failing loudly is preferable to silently
+    egressing intimate content.
+
+    Attributes:
+        stage_provider: The cloud provider the stage was configured with.
+    """
+
+    def __init__(self, stage_provider: str) -> None:
+        """Build the error naming the offending provider and the remedy.
+
+        Args:
+            stage_provider: The cloud provider configured for the stage.
+        """
+        self.stage_provider = stage_provider
+        super().__init__(
+            f"Intimate-tier fragment cannot route to cloud provider "
+            f"{stage_provider!r}, and llm.default is also cloud, so there is no "
+            "local backend to fall back to. Set llm.default to a local provider "
+            "(e.g. ollama) to process Intimate-tier content.",
+        )
 
 
 class ModelRouter:
@@ -45,21 +78,75 @@ class ModelRouter:
         )
 
     def resolve(self, stage: str, tier: PrivacyTier | None = None) -> LLMConfig:
-        """Return the :class:`LLMConfig` for *stage*.
+        """Return the :class:`LLMConfig` for *stage*, honoring the tier gate.
 
         Args:
             stage: The pipeline stage (``default`` / ``classification`` /
                 ``generation`` / ``frontend``); unknown stages fall back to the
                 routing ``default``.
-            tier: The fragment's privacy tier. Accepted now for signature
-                stability; the ``Intimate``-never-cloud redirect is enforced
-                here in #647. Until then it has no effect.
+            tier: The fragment's privacy tier. When ``Intimate`` and the stage
+                resolves to a cloud provider, the result is redirected to the
+                local ``default`` (see :meth:`_enforce_local_for_intimate`).
 
         Returns:
             The resolved config, ready for
             :func:`~creek.classify.llm.providers.build_provider`.
+
+        Raises:
+            IntimateRoutingError: When *tier* is ``Intimate``, the stage is
+                cloud, and no local ``default`` exists to redirect to.
         """
-        # Issue #647: enforce Intimate-never-cloud here (redirect to local +
-        # WARN; raise IntimateRoutingError if even ``default`` is cloud).
-        _ = tier
-        return self.routing.for_stage(stage)
+        return self._enforce_local_for_intimate(self.routing.for_stage(stage), tier)
+
+    def provider_for(
+        self,
+        stage: str,
+        tier: PrivacyTier | None = None,
+    ) -> LLMProvider:
+        """Build the provider for *stage* (and *tier*) via the factory.
+
+        Args:
+            stage: The pipeline stage.
+            tier: The fragment's privacy tier (see :meth:`resolve`).
+
+        Returns:
+            A constructed :class:`~creek.classify.llm.base.LLMProvider` — a local
+            one whenever the tier gate redirected an ``Intimate`` fragment.
+        """
+        return build_provider(self.resolve(stage, tier))
+
+    def _enforce_local_for_intimate(
+        self,
+        cfg: LLMConfig,
+        tier: PrivacyTier | None,
+    ) -> LLMConfig:
+        """Apply the ``Intimate``-never-cloud rule — the ONLY tier gate (#647).
+
+        Non-``Intimate`` tiers (and ``None``) pass through unchanged. An
+        ``Intimate`` fragment bound for a cloud provider is redirected to the
+        local ``default`` with a single WARNING; if ``default`` is itself cloud,
+        :class:`IntimateRoutingError` is raised rather than emitting a cloud
+        call.
+
+        Args:
+            cfg: The stage's resolved config.
+            tier: The fragment's privacy tier.
+
+        Returns:
+            *cfg* unchanged, or the local ``default`` when redirecting.
+
+        Raises:
+            IntimateRoutingError: When no local backend exists to redirect to.
+        """
+        if tier != PrivacyTier.INTIMATE or not provider_is_cloud(cfg.provider):
+            return cfg
+        local = self.routing.for_stage("default")
+        if provider_is_cloud(local.provider):
+            raise IntimateRoutingError(stage_provider=cfg.provider)
+        logger.warning(
+            "Intimate-tier fragment: redirecting cloud provider %r to local %r "
+            "(cloud egress refused at the routing chokepoint).",
+            cfg.provider,
+            local.provider,
+        )
+        return local

--- a/creek-tools/tests/test_intimate_routing.py
+++ b/creek-tools/tests/test_intimate_routing.py
@@ -1,0 +1,86 @@
+"""Intimate-never-cloud enforcement at the routing chokepoint (#647).
+
+The non-negotiable privacy invariant: an ``Intimate``-tier fragment must never
+route to a cloud provider. Enforced in exactly one place —
+``ModelRouter._enforce_local_for_intimate`` — which redirects to the local
+``default`` (with a WARNING) or, if even ``default`` is cloud, raises loudly.
+These tests assert on *provider construction*, not just a returned string, so a
+regression that re-enables cloud egress fails the guard.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from creek.classify.llm.providers import AnthropicProvider, OllamaProvider
+from creek.classify.llm.router import IntimateRoutingError, ModelRouter
+from creek.config import LLMRoutingConfig
+from creek.models import PrivacyTier
+
+
+def _router(**stages: dict[str, str]) -> ModelRouter:
+    """Build a router from a per-stage mapping of ``{stage: {provider: ...}}``."""
+    return ModelRouter(LLMRoutingConfig.model_validate(stages))
+
+
+class TestIntimateNeverRoutesToCloud:
+    """The named guard + its enforcement semantics."""
+
+    def test_intimate_tier_never_routes_to_cloud(self) -> None:
+        """Intimate + a cloud-configured stage resolves to the local default."""
+        router = _router(
+            default={"provider": "ollama", "model": "qwen3:8b"},
+            generation={"provider": "anthropic", "model": "claude-sonnet-4-6"},
+        )
+        resolved = router.resolve("generation", PrivacyTier.INTIMATE)
+        # Redirected to the local default — NOT the configured anthropic.
+        assert resolved.provider == "ollama"
+        # And constructing the provider yields a LOCAL one — no cloud egress.
+        provider = router.provider_for("generation", PrivacyTier.INTIMATE)
+        assert isinstance(provider, OllamaProvider)
+        assert not isinstance(provider, AnthropicProvider)
+
+    def test_warns_on_redirect(self, caplog: pytest.LogCaptureFixture) -> None:
+        """The redirect emits one WARNING for the audit trail."""
+        router = _router(
+            default={"provider": "ollama"},
+            generation={"provider": "anthropic"},
+        )
+        with caplog.at_level(logging.WARNING):
+            router.resolve("generation", PrivacyTier.INTIMATE)
+        assert any(
+            record.levelno == logging.WARNING and "intimate" in record.message.lower()
+            for record in caplog.records
+        )
+
+    def test_raises_when_even_default_is_cloud(self) -> None:
+        """No safe local exists → fail loudly rather than silently egress."""
+        router = _router(
+            default={"provider": "anthropic"},
+            generation={"provider": "anthropic"},
+        )
+        with pytest.raises(IntimateRoutingError):
+            router.resolve("generation", PrivacyTier.INTIMATE)
+
+    def test_non_intimate_honors_configured_cloud(self) -> None:
+        """OPEN/PERSONAL/None still route to the configured cloud provider."""
+        router = _router(
+            default={"provider": "ollama"},
+            generation={"provider": "anthropic"},
+        )
+        assert router.resolve("generation", PrivacyTier.OPEN).provider == "anthropic"
+        assert router.resolve("generation", PrivacyTier.PERSONAL).provider == (
+            "anthropic"
+        )
+        # The contrapositive of the guard: WITHOUT the Intimate tier the cloud
+        # provider IS returned — proving the redirect is tier-gated, not blanket.
+        assert router.resolve("generation").provider == "anthropic"
+
+    def test_intimate_on_local_stage_is_unchanged(self) -> None:
+        """Intimate + an already-local stage needs no redirect."""
+        router = _router(default={"provider": "ollama"})
+        assert router.resolve("classification", PrivacyTier.INTIMATE).provider == (
+            "ollama"
+        )

--- a/creek-tools/tests/test_model_router.py
+++ b/creek-tools/tests/test_model_router.py
@@ -105,13 +105,23 @@ class TestModelRouter:
         assert router.resolve("generation").provider == "anthropic"
         assert router.resolve("classification").provider == "ollama"
 
-    def test_tier_arg_is_accepted_but_not_yet_enforced(self) -> None:
-        """The tier arg is part of the signature now; enforcement is #647."""
-        router = ModelRouter(LLMConfig(provider="anthropic"))
-        # Skeleton: tier does not yet redirect (the Intimate chokepoint is #647).
-        assert router.resolve("generation", PrivacyTier.INTIMATE).provider == (
-            "anthropic"
+    def test_tier_gates_intimate_off_cloud(self) -> None:
+        """The tier arg now enforces Intimate-never-cloud (#647).
+
+        Full enforcement semantics live in ``test_intimate_routing.py``; this
+        pins that the router's own ``resolve`` honors the tier.
+        """
+        router = ModelRouter(
+            LLMRoutingConfig.model_validate(
+                {
+                    "default": {"provider": "ollama"},
+                    "generation": {"provider": "anthropic"},
+                },
+            ),
         )
+        # Non-intimate keeps the cloud provider; Intimate redirects to local.
+        assert router.resolve("generation").provider == "anthropic"
+        assert router.resolve("generation", PrivacyTier.INTIMATE).provider == "ollama"
 
     def test_resolve_returns_an_llmconfig(self) -> None:
         """The resolved value is an ``LLMConfig`` ready for ``build_provider``."""


### PR DESCRIPTION
## Summary
Lands the epic's non-negotiable privacy invariant: **`Intimate`-tier fragments never route to a cloud provider**, enforced at the single `ModelRouter` chokepoint.

- Wires the previously-inert `tier` arg into `ModelRouter.resolve`. `_enforce_local_for_intimate` (the **one and only** place tier gates the provider) redirects an `Intimate` fragment off any cloud stage to the local `default` **with a WARNING**; if even `default` is cloud, it raises **`IntimateRoutingError`** rather than emitting a cloud call.
- Uses the existing `provider_is_cloud` — no new cloud/local list. Adds `provider_for(stage, tier)` so callers can build the (tier-gated) provider directly.
- Call sites pass the tier and trust the result; they must never re-check tier (a second gate would be a bypass surface — per the design §3).

## Test plan
- `tests/test_intimate_routing.py` (new): the named guard `test_intimate_tier_never_routes_to_cloud` **asserts on provider construction** (Intimate + anthropic stage → builds an `OllamaProvider`, never `AnthropicProvider`); WARNING-on-redirect; `IntimateRoutingError` when even `default` is cloud; non-Intimate honors the configured cloud provider (the tier-gated contrapositive — proving the redirect isn't blanket); Intimate on an already-local stage is unchanged.
- Updated the #645 placeholder test to pin that enforcement is now active.
- Verified the guard fails loudly when the rule is removed (the prior inert behavior trips it).
- `grep` confirms the Intimate rule appears in exactly one place (`router.py`).
- `./scripts/check-all.sh` green (12/12).

Refs #642
Closes #647
