### PR TITLE
feat(llm): writing_desk role→model map resolving through the router (#648)

### DIFF
--- a/creek-tools/creek/classify/llm/router.py
+++ b/creek-tools/creek/classify/llm/router.py
@@ -98,6 +98,30 @@ class ModelRouter:
         """
         return self._enforce_local_for_intimate(self.routing.for_stage(stage), tier)
 
+    def resolve_role(self, role: str, tier: PrivacyTier | None = None) -> LLMConfig:
+        """Return the :class:`LLMConfig` for a Writing Desk *role* (#648).
+
+        Resolution falls back: the ``writing_desk`` role entry → the
+        ``generation`` stage → the routing ``default``. The same
+        ``Intimate``-never-cloud gate as :meth:`resolve` is applied, so every
+        subagent role inherits the privacy guarantee with no extra tier check.
+
+        Args:
+            role: The subagent role (e.g. ``outliner`` / ``voice_drafter``).
+            tier: The fragment's privacy tier (see :meth:`resolve`).
+
+        Returns:
+            The resolved config for *role*.
+
+        Raises:
+            IntimateRoutingError: When *tier* is ``Intimate``, the role is
+                cloud, and no local ``default`` exists to redirect to.
+        """
+        cfg = self.routing.writing_desk.get(role) or self.routing.for_stage(
+            "generation",
+        )
+        return self._enforce_local_for_intimate(cfg, tier)
+
     def provider_for(
         self,
         stage: str,

--- a/creek-tools/tests/test_writing_desk_routing.py
+++ b/creek-tools/tests/test_writing_desk_routing.py
@@ -1,0 +1,74 @@
+"""Writing Desk role->model routing through the chokepoint (#648).
+
+``ModelRouter.resolve_role`` resolves a subagent role (outliner, voice_drafter,
+…) to an ``LLMConfig`` via the fallback chain role -> ``generation`` stage ->
+``default``, reusing the #647 Intimate-never-cloud gate so every role inherits
+the privacy guarantee for free.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from creek.classify.llm.router import IntimateRoutingError, ModelRouter
+from creek.config import LLMRoutingConfig
+from creek.models import PrivacyTier
+
+
+def _router(**llm: object) -> ModelRouter:
+    return ModelRouter(LLMRoutingConfig.model_validate(llm))
+
+
+class TestResolveRoleFallback:
+    """role -> generation -> default."""
+
+    def test_configured_role_wins(self) -> None:
+        """A role with its own entry resolves to that provider."""
+        router = _router(
+            default={"provider": "ollama"},
+            generation={"provider": "anthropic"},
+            writing_desk={"voice_drafter": {"provider": "openai", "model": "gpt-5.4"}},
+        )
+        assert router.resolve_role("voice_drafter").provider == "openai"
+
+    def test_unset_role_falls_back_to_generation(self) -> None:
+        """A role with no entry uses the generation stage."""
+        router = _router(
+            default={"provider": "ollama"},
+            generation={"provider": "anthropic"},
+            writing_desk={"voice_drafter": {"provider": "openai"}},
+        )
+        assert router.resolve_role("outliner").provider == "anthropic"
+
+    def test_unset_role_no_generation_falls_back_to_default(self) -> None:
+        """With neither a role entry nor a generation stage, default applies."""
+        router = _router(default={"provider": "ollama"})
+        assert router.resolve_role("researcher").provider == "ollama"
+
+
+class TestRoleInheritsIntimateGate:
+    """Roles route through the same #647 chokepoint."""
+
+    def test_intimate_role_redirects_to_local(self) -> None:
+        """An Intimate fragment on a cloud role redirects to the local default."""
+        router = _router(
+            default={"provider": "ollama"},
+            writing_desk={"voice_drafter": {"provider": "anthropic"}},
+        )
+        assert router.resolve_role("voice_drafter").provider == "anthropic"
+        assert (
+            router.resolve_role(
+                "voice_drafter",
+                PrivacyTier.INTIMATE,
+            ).provider
+            == "ollama"
+        )
+
+    def test_intimate_role_raises_when_default_is_cloud(self) -> None:
+        """No local fallback for a role either -> fail loudly."""
+        router = _router(
+            default={"provider": "anthropic"},
+            writing_desk={"voice_drafter": {"provider": "openai"}},
+        )
+        with pytest.raises(IntimateRoutingError):
+            router.resolve_role("voice_drafter", PrivacyTier.INTIMATE)


### PR DESCRIPTION
## Summary
- Adds `ModelRouter.resolve_role(role, tier)` — resolves a Writing Desk subagent role (outliner, researcher, fact_checker, structure_editor, variant_generator, voice_drafter, voice_line_editor) to an `LLMConfig` via the fallback chain **role → `generation` stage → `default`**.
- Reuses the #647 `_enforce_local_for_intimate` gate, so **every role inherits the `Intimate`-never-cloud guarantee** with no second tier check (still exactly one chokepoint).
- The `writing_desk` schema field already exists (added in #645); this wires its resolution. **No `author/` call site is rewired** — that is #649.

## Test plan
- `tests/test_writing_desk_routing.py` (new): configured role wins; unset role → generation; unset role + no generation → default; an Intimate fragment on a cloud role redirects to local; a cloud-only config raises `IntimateRoutingError` for a role too.
- `./scripts/check-all.sh` green (12/12).

Refs #643
Closes #648
