### PR TITLE
feat(llm): resolve author Writing Desk roles through the router (#649)

### DIFF
--- a/creek-tools/creek/author/client.py
+++ b/creek-tools/creek/author/client.py
@@ -14,7 +14,13 @@ from creek.classify.llm.providers import Completion, build_provider
 
 if TYPE_CHECKING:
     from creek.classify.llm.base import LLMProvider
+    from creek.classify.llm.router import ModelRouter
     from creek.config import AuthorConfig, LLMConfig
+    from creek.models import PrivacyTier
+
+_VOICE_ROLES = frozenset({"voice_drafter", "voice_line_editor"})
+"""Writing Desk roles whose model the legacy ``AuthorConfig.voice_model``
+field falls back to (#474) when the role has no ``writing_desk`` entry (#649)."""
 
 
 def resolve_voice_model(author: AuthorConfig, llm: LLMConfig) -> str | None:
@@ -77,6 +83,49 @@ class AuthorLLMClient:
             config if model is None else config.model_copy(update={"model": model})
         )
         return cls(build_provider(effective))
+
+    @classmethod
+    def for_role(
+        cls,
+        router: ModelRouter,
+        role: str,
+        *,
+        author: AuthorConfig | None = None,
+        tier: PrivacyTier | None = None,
+    ) -> AuthorLLMClient:
+        """Build a client for a Writing Desk *role* via the router (#649).
+
+        Resolves the role's provider+model through
+        :meth:`~creek.classify.llm.router.ModelRouter.resolve_role` — so the
+        role inherits the per-stage routing **and** the ``Intimate``-never-cloud
+        chokepoint. Precedence for the voice roles (decision #2): an explicit
+        ``writing_desk`` entry wins; otherwise the legacy
+        :attr:`AuthorConfig.voice_model` fills the model id; otherwise the
+        generation/default model stands. Non-voice roles have no legacy field.
+
+        Args:
+            router: The run's :class:`ModelRouter`.
+            role: The subagent role (e.g. ``outliner`` / ``voice_drafter``).
+            author: Author-subsystem config carrying the legacy per-agent model
+                overrides; ``None`` skips the legacy fallback.
+            tier: The fragment's privacy tier (gated by the chokepoint).
+
+        Returns:
+            An :class:`AuthorLLMClient` wrapping the role's resolved provider.
+
+        Raises:
+            IntimateRoutingError: Propagated from ``resolve_role`` when an
+                ``Intimate`` role is cloud with no local fallback.
+        """
+        cfg = router.resolve_role(role, tier)
+        if (
+            author is not None
+            and role in _VOICE_ROLES
+            and role not in router.routing.writing_desk
+            and author.voice_model is not None
+        ):
+            cfg = cfg.model_copy(update={"model": author.voice_model})
+        return cls(build_provider(cfg))
 
     def complete(self, prompt: str, *, max_tokens: int | None = None) -> str:
         """Return the completion text for *prompt*.

--- a/creek-tools/creek/author/client.py
+++ b/creek-tools/creek/author/client.py
@@ -118,8 +118,15 @@ class AuthorLLMClient:
                 ``Intimate`` role is cloud with no local fallback.
         """
         cfg = router.resolve_role(role, tier)
+        # If the Intimate gate redirected this role to a different (local)
+        # provider, the legacy cloud ``voice_model`` id must NOT override the
+        # local model — that would build an incoherent provider+model pair and
+        # muddy the privacy redirect. Only apply voice_model when no redirect
+        # happened (provider unchanged vs the ungated resolution).
+        redirected = cfg.provider != router.resolve_role(role).provider
         if (
-            author is not None
+            not redirected
+            and author is not None
             and role in _VOICE_ROLES
             and role not in router.routing.writing_desk
             and author.voice_model is not None

--- a/creek-tools/tests/test_author_role_routing.py
+++ b/creek-tools/tests/test_author_role_routing.py
@@ -1,0 +1,146 @@
+"""Author Writing Desk roles resolve through the router (#649).
+
+``AuthorLLMClient.for_role`` resolves a subagent role through the
+``ModelRouter`` — inheriting per-stage routing and the #647 Intimate gate — with
+the legacy ``AuthorConfig.voice_model`` as the fallback for the voice roles
+(decision #2: an explicit ``writing_desk`` entry wins).
+
+Note: the desk's conductor/specialists are still stubs (the LLM path is an
+injected seam; #460 wires the real consumer), so these tests pin the resolution
+layer #460 will consume, capturing the ``LLMConfig`` handed to the factory.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from creek.author.client import AuthorLLMClient, resolve_voice_model
+from creek.classify.llm.router import IntimateRoutingError, ModelRouter
+from creek.config import AuthorConfig, LLMConfig, LLMRoutingConfig
+from creek.models import PrivacyTier
+
+
+@pytest.fixture
+def captured_config(monkeypatch: pytest.MonkeyPatch) -> dict[str, LLMConfig]:
+    """Capture the ``LLMConfig`` ``for_role`` hands to ``build_provider``."""
+    captured: dict[str, LLMConfig] = {}
+
+    def _fake_build(cfg: LLMConfig) -> object:
+        captured["cfg"] = cfg
+        return object()
+
+    monkeypatch.setattr("creek.author.client.build_provider", _fake_build)
+    return captured
+
+
+def _router() -> ModelRouter:
+    return ModelRouter(
+        LLMRoutingConfig.model_validate(
+            {
+                "default": {"provider": "ollama", "model": "qwen3:8b"},
+                "generation": {"provider": "anthropic", "model": "claude-sonnet-4-6"},
+                "writing_desk": {
+                    "outliner": {"provider": "ollama", "model": "qwen3:8b"},
+                    "voice_drafter": {"provider": "openai", "model": "gpt-5.4"},
+                },
+            },
+        ),
+    )
+
+
+class TestForRoleResolution:
+    """``for_role`` honors the role map, fallbacks, and voice_model precedence."""
+
+    def test_writing_desk_entry_wins(
+        self,
+        captured_config: dict[str, LLMConfig],
+    ) -> None:
+        """A configured role uses its own provider+model."""
+        AuthorLLMClient.for_role(_router(), "voice_drafter")
+        assert captured_config["cfg"].provider == "openai"
+        assert captured_config["cfg"].model == "gpt-5.4"
+
+    def test_unset_role_falls_back_to_generation(
+        self,
+        captured_config: dict[str, LLMConfig],
+    ) -> None:
+        """A role with no entry uses the generation stage."""
+        AuthorLLMClient.for_role(_router(), "fact_checker")
+        assert captured_config["cfg"].provider == "anthropic"
+
+    def test_voice_model_fills_unset_voice_role(
+        self,
+        captured_config: dict[str, LLMConfig],
+    ) -> None:
+        """Legacy voice_model fills the model for an unset voice role."""
+        router = ModelRouter(
+            LLMRoutingConfig.model_validate(
+                {"generation": {"provider": "anthropic", "model": "claude-sonnet-4-6"}},
+            ),
+        )
+        author = AuthorConfig(voice_model="claude-opus-4-8")
+        AuthorLLMClient.for_role(router, "voice_line_editor", author=author)
+        assert captured_config["cfg"].provider == "anthropic"
+        assert captured_config["cfg"].model == "claude-opus-4-8"
+
+    def test_explicit_role_beats_voice_model(
+        self,
+        captured_config: dict[str, LLMConfig],
+    ) -> None:
+        """An explicit writing_desk.voice_drafter wins over voice_model."""
+        author = AuthorConfig(voice_model="claude-opus-4-8")
+        AuthorLLMClient.for_role(_router(), "voice_drafter", author=author)
+        assert captured_config["cfg"].model == "gpt-5.4"  # role map, not voice_model
+
+    def test_voice_model_not_applied_to_non_voice_role(
+        self,
+        captured_config: dict[str, LLMConfig],
+    ) -> None:
+        """voice_model is a voice-role fallback only — not for e.g. researcher."""
+        router = ModelRouter(
+            LLMRoutingConfig.model_validate(
+                {"generation": {"provider": "anthropic", "model": "claude-sonnet-4-6"}},
+            ),
+        )
+        author = AuthorConfig(voice_model="claude-opus-4-8")
+        AuthorLLMClient.for_role(router, "researcher", author=author)
+        assert captured_config["cfg"].model == "claude-sonnet-4-6"  # not voice_model
+
+
+class TestForRoleInheritsIntimateGate:
+    """Roles route through the #647 chokepoint."""
+
+    def test_intimate_role_redirects_to_local(
+        self,
+        captured_config: dict[str, LLMConfig],
+    ) -> None:
+        """An Intimate fragment on a cloud role builds the local provider."""
+        AuthorLLMClient.for_role(_router(), "voice_drafter", tier=PrivacyTier.INTIMATE)
+        assert captured_config["cfg"].provider == "ollama"  # redirected from openai
+
+    def test_intimate_role_raises_without_local_default(self) -> None:
+        """No local fallback → fail loudly (no client built)."""
+        router = ModelRouter(
+            LLMRoutingConfig.model_validate(
+                {
+                    "default": {"provider": "anthropic"},
+                    "writing_desk": {"voice_drafter": {"provider": "openai"}},
+                },
+            ),
+        )
+        with pytest.raises(IntimateRoutingError):
+            AuthorLLMClient.for_role(
+                router,
+                "voice_drafter",
+                tier=PrivacyTier.INTIMATE,
+            )
+
+
+class TestLegacyResolveVoiceModel:
+    """The legacy resolver is unchanged (back-compat)."""
+
+    def test_voice_model_wins_then_llm_model(self) -> None:
+        """resolve_voice_model still returns voice_model or the llm fallback."""
+        llm = LLMConfig(provider="anthropic", model="claude-sonnet-4-6")
+        assert resolve_voice_model(AuthorConfig(voice_model="x"), llm) == "x"
+        assert resolve_voice_model(AuthorConfig(), llm) == "claude-sonnet-4-6"

--- a/creek-tools/tests/test_author_role_routing.py
+++ b/creek-tools/tests/test_author_role_routing.py
@@ -118,6 +118,37 @@ class TestForRoleInheritsIntimateGate:
         AuthorLLMClient.for_role(_router(), "voice_drafter", tier=PrivacyTier.INTIMATE)
         assert captured_config["cfg"].provider == "ollama"  # redirected from openai
 
+    def test_intimate_redirect_does_not_keep_cloud_voice_model(
+        self,
+        captured_config: dict[str, LLMConfig],
+    ) -> None:
+        """A redirected voice role must not carry a cloud voice_model id.
+
+        Regression: the voice_model override used to apply AFTER the Intimate
+        gate, yielding an incoherent provider=ollama + model=<cloud id>. The
+        redirect must win — local provider AND local model.
+        """
+        router = ModelRouter(
+            LLMRoutingConfig.model_validate(
+                {
+                    "default": {"provider": "ollama", "model": "qwen3:8b"},
+                    "generation": {
+                        "provider": "anthropic",
+                        "model": "claude-sonnet-4-6",
+                    },
+                },
+            ),
+        )
+        author = AuthorConfig(voice_model="claude-opus-4-8")
+        AuthorLLMClient.for_role(
+            router,
+            "voice_line_editor",
+            author=author,
+            tier=PrivacyTier.INTIMATE,
+        )
+        assert captured_config["cfg"].provider == "ollama"
+        assert captured_config["cfg"].model == "qwen3:8b"  # NOT the cloud voice_model
+
     def test_intimate_role_raises_without_local_default(self) -> None:
         """No local fallback → fail loudly (no client built)."""
         router = ModelRouter(


### PR DESCRIPTION
## Summary
- Adds `AuthorLLMClient.for_role(router, role, *, author, tier)` — resolves a Writing Desk subagent role through `ModelRouter.resolve_role`, so each role inherits **per-stage routing** and the **#647 `Intimate`-never-cloud chokepoint** with no extra tier check.
- **Precedence (approved decision #2):** an explicit `writing_desk.<role>` entry wins; otherwise the legacy `AuthorConfig.voice_model` fills the model id for the voice roles (`voice_drafter` / `voice_line_editor`); otherwise the generation/default model stands. Non-voice roles have no legacy fallback. Legacy `resolve_voice_model` is unchanged (back-compat preserved).

## Scope note (important)
The FEAT-041 desk's conductor/specialists are still **stubs** — the LLM path is an injected `llm_client` seam that defaults to a deterministic stub, and the real consumer is the *unfinished* #460. So there are no live author call sites to rewire today. This PR delivers the **router-aware role resolution** #460 will consume, with the resolution layer fully tested (the integration test captures the `LLMConfig` handed to the factory per role).

## Test plan
- `tests/test_author_role_routing.py` (new): writing_desk entry wins; unset role → generation; voice_model fills an unset voice role; explicit role beats voice_model; voice_model NOT applied to non-voice roles; Intimate redirects a cloud role to local; cloud-only config raises `IntimateRoutingError`; legacy `resolve_voice_model` unchanged.
- `./scripts/check-all.sh` green (12/12).

Refs #643
Closes #649
