### PR TITLE
feat(author): inject a router-built voice client so the Writing Desk makes live LLM calls (#658)

### DIFF
--- a/creek-tools/creek/author/client.py
+++ b/creek-tools/creek/author/client.py
@@ -134,6 +134,48 @@ class AuthorLLMClient:
             cfg = cfg.model_copy(update={"model": author.voice_model})
         return cls(build_provider(cfg))
 
+    @classmethod
+    def for_voice_or_none(
+        cls,
+        router: ModelRouter,
+        *,
+        author: AuthorConfig | None = None,
+        tier: PrivacyTier | None = None,
+    ) -> AuthorLLMClient | None:
+        """Build the voice-drafter client, or ``None`` when it is unusable.
+
+        Resolves the ``voice_drafter`` role via :meth:`for_role` (so it inherits
+        per-stage routing and the ``Intimate``-never-cloud gate), then returns it
+        only when its provider is :attr:`available` (key + consent for a cloud
+        provider, a reachable server for Ollama). When unavailable it returns
+        ``None`` so the desk falls back to deterministic rendering rather than
+        erroring — enabling live voicing when a provider is configured while
+        preserving the historical stub behaviour otherwise (#658).
+
+        Args:
+            router: The run's :class:`ModelRouter`.
+            author: Author-subsystem config for the ``voice_model`` fallback.
+            tier: The fragment's privacy tier (gated by the chokepoint).
+
+        Returns:
+            A usable :class:`AuthorLLMClient`, or ``None``.
+
+        Raises:
+            IntimateRoutingError: Propagated from :meth:`for_role` when an
+                ``Intimate`` role is cloud with no local fallback.
+        """
+        client = cls.for_role(router, "voice_drafter", author=author, tier=tier)
+        return client if client.available else None
+
+    @property
+    def available(self) -> bool:
+        """Whether the wrapped provider can serve a call right now.
+
+        Delegates to the provider's own readiness check (API key + cloud
+        consent, or a reachable local server).
+        """
+        return self._provider.available
+
     def complete(self, prompt: str, *, max_tokens: int | None = None) -> str:
         """Return the completion text for *prompt*.
 

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -149,8 +149,11 @@ class Conductor:
         voice: The agent that renders evidence into a draft.
         reflection: The node that judges each drafted body.
         max_rounds: Upper bound on voice/reflect rounds.
-        llm_client: Optional network seam; unused by the stub collaborators
-            but injected here so issue #460 can wire real LLM calls.
+        llm_client: Optional voice client; when set,
+            :func:`build_default_conductor` threads it into the voice agent so
+            the desk renders live voicing (#658). ``None`` keeps the
+            deterministic stub. The specialists and reflection node remain
+            deterministic and do not use it.
         contract: The medium contract driving this run; its reflection rubric
             is exposed to the reflection node (FEAT-041 #459).
     """

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -376,8 +376,11 @@ def build_default_conductor(
         A ready-to-run :class:`Conductor`.
     """
     return Conductor(
+        # #658: thread the client into the voice agent — the only collaborator
+        # that calls the LLM — so an injected client produces live voicing
+        # instead of the deterministic stub. ``None`` keeps the stub.
         specialists=default_specialists(),
-        voice=VoiceAgent(),
+        voice=VoiceAgent(llm_client=llm_client),
         reflection=ReflectionNode(),
         max_rounds=max_rounds,
         llm_client=llm_client,
@@ -391,6 +394,7 @@ def run_author(
     query: str,
     vault: Path,
     max_rounds: int | None = None,
+    llm_client: AuthorLLMClient | None = None,
 ) -> AuthoredDraft:
     """Author *query* for *medium* against *vault* with the default desk.
 
@@ -400,6 +404,8 @@ def run_author(
         vault: The vault to author from.
         max_rounds: Optional override for the round bound; defaults to the
             ``author.max_author_rounds`` config default.
+        llm_client: Optional voice client (#658). When supplied, the desk
+            renders live voicing; ``None`` keeps the deterministic stub.
 
     Returns:
         The shaped :class:`AuthoredDraft`.
@@ -409,9 +415,11 @@ def run_author(
     require_supported_medium(medium)
     contract = load_medium_contract(medium, vault)
     rounds = max_rounds if max_rounds is not None else AuthorConfig().max_author_rounds
-    draft = build_default_conductor(max_rounds=rounds, contract=contract).run(
-        medium=medium, query=query, vault=vault
-    )
+    draft = build_default_conductor(
+        max_rounds=rounds,
+        llm_client=llm_client,
+        contract=contract,
+    ).run(medium=medium, query=query, vault=vault)
     return _enforce_chat_ceiling(draft)
 
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -3232,22 +3232,10 @@ def author(
     config = _load_config_for_vault(vault)
     vault_path = _resolve_vault(vault if vault is not None else config.vault_path)
     rounds = max_rounds if max_rounds is not None else config.author.max_author_rounds
-    # #658: build the router-resolved voice client for live voicing. Falls back
-    # to ``None`` (deterministic stub) when the provider is unavailable, so the
-    # command still works without a reachable/consented backend.
-    voice_client = AuthorLLMClient.for_voice_or_none(
-        config.model_router,
-        author=config.author,
-    )
-    if voice_client is None and not dry_run:
-        console.print(
-            "[dim]No LLM provider available — rendering the deterministic "
-            "stub. Configure llm.generation (and consent for a cloud provider) "
-            "for live voicing.[/dim]",
-        )
-    conductor = build_default_conductor(max_rounds=rounds, llm_client=voice_client)
 
     if dry_run:
+        # The dry run only plans + gathers evidence; no voicing, so no client.
+        conductor = build_default_conductor(max_rounds=rounds)
         evidence = conductor.gather_evidence(effective_query, vault_path)
         console.print(f"PLAN: {' → '.join(conductor.plan())}")
         console.print(
@@ -3256,7 +3244,23 @@ def author(
         )
         return
 
-    draft_result = conductor.run(medium=medium, query=effective_query, vault=vault_path)
+    # #658: build the router-resolved voice client for live voicing. Falls back
+    # to ``None`` (deterministic stub) when the provider is unavailable, so the
+    # command still works without a reachable/consented backend.
+    voice_client = AuthorLLMClient.for_voice_or_none(
+        config.model_router,
+        author=config.author,
+    )
+    if voice_client is None:
+        console.print(
+            "[dim]No LLM provider available — rendering the deterministic "
+            "stub. Configure llm.generation (and consent for a cloud provider) "
+            "for live voicing.[/dim]",
+        )
+    draft_result = build_default_conductor(
+        max_rounds=rounds,
+        llm_client=voice_client,
+    ).run(medium=medium, query=effective_query, vault=vault_path)
     console.print(
         f"medium={draft_result.medium} verdict={draft_result.verdict} "
         f"rounds={draft_result.rounds} provenance={len(draft_result.provenance)}",

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -3224,6 +3224,7 @@ def author(
     requires ``--query``.
     """
     from creek.author import SUPPORTED_MEDIUMS, build_default_conductor
+    from creek.author.client import AuthorLLMClient
 
     _validate_author_inputs(medium, query, work, SUPPORTED_MEDIUMS)
     effective_query = _compose_author_query(query, work)
@@ -3231,7 +3232,20 @@ def author(
     config = _load_config_for_vault(vault)
     vault_path = _resolve_vault(vault if vault is not None else config.vault_path)
     rounds = max_rounds if max_rounds is not None else config.author.max_author_rounds
-    conductor = build_default_conductor(max_rounds=rounds)
+    # #658: build the router-resolved voice client for live voicing. Falls back
+    # to ``None`` (deterministic stub) when the provider is unavailable, so the
+    # command still works without a reachable/consented backend.
+    voice_client = AuthorLLMClient.for_voice_or_none(
+        config.model_router,
+        author=config.author,
+    )
+    if voice_client is None and not dry_run:
+        console.print(
+            "[dim]No LLM provider available — rendering the deterministic "
+            "stub. Configure llm.generation (and consent for a cloud provider) "
+            "for live voicing.[/dim]",
+        )
+    conductor = build_default_conductor(max_rounds=rounds, llm_client=voice_client)
 
     if dry_run:
         evidence = conductor.gather_evidence(effective_query, vault_path)

--- a/creek-tools/creek_mcp/tools/author.py
+++ b/creek-tools/creek_mcp/tools/author.py
@@ -138,8 +138,24 @@ def author_tool(
                 "plan": plan["plan"],
                 "evidence": plan["evidence"],
             }
+        # #658: build the router-resolved voice client so the desk renders live
+        # voicing; ``for_voice_or_none`` returns ``None`` (deterministic stub)
+        # when the provider is unavailable, so the tool never hard-fails on a
+        # missing/unconsented backend.
+        from creek.author.client import AuthorLLMClient
+        from creek.config import load_config
+
+        config = load_config()
+        voice_client = AuthorLLMClient.for_voice_or_none(
+            config.model_router,
+            author=config.author,
+        )
         draft = run_author(
-            medium=medium, query=query, vault=vault_path, max_rounds=max_rounds
+            medium=medium,
+            query=query,
+            vault=vault_path,
+            max_rounds=max_rounds,
+            llm_client=voice_client,
         )
     except Exception as exc:
         return _error_response(

--- a/creek-tools/creek_mcp/tools/author.py
+++ b/creek-tools/creek_mcp/tools/author.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from creek.author import plan_author, require_supported_medium, run_author
+from creek.author.client import AuthorLLMClient
+from creek.config import load_config
 from creek_mcp.audit import MCPAuditLog
 from creek_mcp.tier_ceiling import TierCeiling
 
@@ -142,9 +144,6 @@ def author_tool(
         # voicing; ``for_voice_or_none`` returns ``None`` (deterministic stub)
         # when the provider is unavailable, so the tool never hard-fails on a
         # missing/unconsented backend.
-        from creek.author.client import AuthorLLMClient
-        from creek.config import load_config
-
         config = load_config()
         voice_client = AuthorLLMClient.for_voice_or_none(
             config.model_router,

--- a/creek-tools/tests/test_author_desk_wiring.py
+++ b/creek-tools/tests/test_author_desk_wiring.py
@@ -1,0 +1,161 @@
+"""Writing Desk makes live LLM calls via a router-built client (#658).
+
+Wires the gap left after #649: the conductor stored an ``llm_client`` but built
+a bare ``VoiceAgent()`` stub, and neither the CLI nor MCP built a real client.
+These tests pin: the client now reaches the VoiceAgent, ``run_author`` threads
+it, and ``AuthorLLMClient.for_voice_or_none`` routes the voice role through the
+chokepoint and degrades to ``None`` (deterministic stub) when the provider is
+unavailable.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from creek.author.client import AuthorLLMClient
+from creek.author.conductor import build_default_conductor, run_author
+from creek.classify.llm.router import ModelRouter
+from creek.config import AuthorConfig, LLMRoutingConfig
+
+if TYPE_CHECKING:
+    import pytest
+
+    from creek.config import LLMConfig
+
+
+class _FakeProvider:
+    """A provider double whose ``available`` is controllable."""
+
+    def __init__(self, *, available: bool = True) -> None:
+        self._available = available
+
+    @property
+    def available(self) -> bool:
+        return self._available
+
+    def complete(self, prompt: str, **_kw: object) -> object:
+        return type("C", (), {"text": f"voiced:{prompt}", "usage": None})()
+
+
+# --- the seam now reaches the collaborator that calls the LLM --------------
+
+
+def test_build_default_conductor_threads_client_to_voice() -> None:
+    """The injected client reaches the VoiceAgent, not just the conductor."""
+    client = AuthorLLMClient(MagicMock())
+    conductor = build_default_conductor(max_rounds=1, llm_client=client)
+    assert conductor.voice.llm_client is client
+    assert conductor.llm_client is client
+
+
+def test_build_default_conductor_none_keeps_stub() -> None:
+    """Without a client the VoiceAgent stays deterministic (client None)."""
+    conductor = build_default_conductor(max_rounds=1)
+    assert conductor.voice.llm_client is None
+
+
+def test_run_author_threads_client(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``run_author`` forwards its llm_client to build_default_conductor."""
+    captured: dict[str, object] = {}
+    fake_conductor = MagicMock()
+    fake_conductor.run.return_value = MagicMock()
+
+    def _fake_build(*, llm_client: object = None, **_kw: object) -> object:
+        captured["llm_client"] = llm_client
+        return fake_conductor
+
+    monkeypatch.setattr("creek.author.conductor.build_default_conductor", _fake_build)
+    monkeypatch.setattr(
+        "creek.author.conductor.load_medium_contract",
+        lambda _m, _v: None,
+    )
+    monkeypatch.setattr("creek.author.conductor._enforce_chat_ceiling", lambda d: d)
+
+    client = AuthorLLMClient(MagicMock())
+    run_author(medium="research", query="q", vault=MagicMock(), llm_client=client)
+    assert captured["llm_client"] is client
+
+
+# --- for_voice_or_none: routing + graceful availability --------------------
+
+
+def _capture_build(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    available: bool,
+) -> dict[str, LLMConfig]:
+    captured: dict[str, LLMConfig] = {}
+
+    def _fake_build(cfg: LLMConfig) -> _FakeProvider:
+        captured["cfg"] = cfg
+        return _FakeProvider(available=available)
+
+    monkeypatch.setattr("creek.author.client.build_provider", _fake_build)
+    return captured
+
+
+def test_for_voice_or_none_returns_client_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An available provider yields a usable client."""
+    _capture_build(monkeypatch, available=True)
+    router = ModelRouter(
+        LLMRoutingConfig.model_validate({"generation": {"provider": "anthropic"}}),
+    )
+    client = AuthorLLMClient.for_voice_or_none(router)
+    assert client is not None
+    assert client.available
+
+
+def test_for_voice_or_none_returns_none_when_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unavailable provider degrades to None (deterministic stub)."""
+    _capture_build(monkeypatch, available=False)
+    router = ModelRouter(
+        LLMRoutingConfig.model_validate({"generation": {"provider": "anthropic"}}),
+    )
+    assert AuthorLLMClient.for_voice_or_none(router) is None
+
+
+def test_for_voice_or_none_uses_writing_desk_role_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two-backend config: the voice client uses the configured role provider."""
+    captured = _capture_build(monkeypatch, available=True)
+    router = ModelRouter(
+        LLMRoutingConfig.model_validate(
+            {
+                "default": {"provider": "ollama"},
+                "writing_desk": {"voice_drafter": {"provider": "anthropic"}},
+            },
+        ),
+    )
+    AuthorLLMClient.for_voice_or_none(router, author=AuthorConfig())
+    assert captured["cfg"].provider == "anthropic"
+
+
+def test_for_voice_or_none_intimate_stays_local(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An Intimate tier redirects the voice role to the local default."""
+    from creek.models import PrivacyTier
+
+    captured = _capture_build(monkeypatch, available=True)
+    router = ModelRouter(
+        LLMRoutingConfig.model_validate(
+            {
+                "default": {"provider": "ollama"},
+                "writing_desk": {"voice_drafter": {"provider": "anthropic"}},
+            },
+        ),
+    )
+    AuthorLLMClient.for_voice_or_none(router, tier=PrivacyTier.INTIMATE)
+    assert captured["cfg"].provider == "ollama"  # redirected off the cloud role
+
+
+def test_available_delegates_to_provider() -> None:
+    """``AuthorLLMClient.available`` reflects the wrapped provider."""
+    assert AuthorLLMClient(_FakeProvider(available=True)).available
+    assert not AuthorLLMClient(_FakeProvider(available=False)).available


### PR DESCRIPTION
## Summary
Closes the gap left after #649: the Writing Desk now makes **live LLM calls** when a provider is available, instead of always running the deterministic stub.

- **Root cause fixed:** `build_default_conductor` stored the `llm_client` on the `Conductor` but constructed a bare `VoiceAgent()` — so the client never reached the only collaborator that calls the LLM (the voice agent). It now threads `VoiceAgent(llm_client=...)`. `run_author` gains an `llm_client` param and forwards it.
- **`AuthorLLMClient.for_voice_or_none(router, *, author, tier)`** resolves the `voice_drafter` role through `ModelRouter` (per-stage routing **+ the `Intimate`-never-cloud chokepoint**) and returns `None` when the provider isn't available — so the desk **degrades to the deterministic stub instead of erroring** on a missing/unconsented backend. Adds `AuthorLLMClient.available`.
- **Both production paths wired:** `creek author` (CLI) and the `creek.author` MCP tool build the client via `for_voice_or_none` and inject it. Live voicing when a provider is configured/reachable; deterministic otherwise (with a console note on the CLI).

## Scope / follow-on
The desk authors from a **query** (not a single fragment), so per-fragment tier isn't available at the entry point — `tier` is threaded as `None` for now; real per-fragment tier routing is **#463**. The `Intimate` guarantee is structurally carried (`for_voice_or_none` gates on `tier`, tested) and fires the moment #463 supplies a tier.

## Test plan
- `tests/test_author_desk_wiring.py` (new): the client reaches the `VoiceAgent` (and `None` keeps the stub); `run_author` forwards it; `for_voice_or_none` returns a client when available / `None` when not; a two-backend config uses the configured role provider; an `Intimate` tier redirects the voice role to the local default; `available` delegates to the provider.
- Existing CLI/MCP author tests still pass (graceful fallback to deterministic when no provider).
- `./scripts/check-all.sh` green (12/12): 5530 passed, 93.83% coverage.

Closes #658
