### PR TITLE
feat(author): tier-filter the Writing Desk retrieval against the privacy ceiling (#660)

### DIFF
--- a/creek-tools/creek/author/agents.py
+++ b/creek-tools/creek/author/agents.py
@@ -25,6 +25,7 @@ from creek.author.models import (
     OntologyParadox,
     WalkStats,
 )
+from creek.classify.privacy_filter import PrivacyTierOverride, tier_within_override
 from creek.classify.rules import RuleClassifier
 from creek.classify.weighted import WeightedDimension
 from creek.generate.paradox import OPPOSITE_CONFIDENCE_PAIRS, OPPOSITE_PHASE_PAIRS
@@ -68,8 +69,18 @@ class Specialist(Protocol):
 
     name: str
 
-    def gather(self, query: str, vault: Path) -> EvidenceBundle:
-        """Return structured evidence for *query* drawn from *vault*."""
+    def gather(
+        self,
+        query: str,
+        vault: Path,
+        *,
+        override: PrivacyTierOverride | None = None,
+    ) -> EvidenceBundle:
+        """Return structured evidence for *query* drawn from *vault*.
+
+        *override* is the privacy admission ceiling (#660): fragments above it
+        are excluded from the evidence. ``None`` defaults to ``OPEN``.
+        """
         ...
 
 
@@ -80,12 +91,21 @@ def _load_config(vault: Path) -> CreekConfig:
     return load_config(resolve_config_path(vault, None), warn_on_missing=False)
 
 
-def _load_corpus(vault: Path) -> list[tuple[Fragment, str]]:
-    """Return ``(fragment, body)`` records across the corpus subtrees."""
+def _load_corpus(
+    vault: Path,
+    override: PrivacyTierOverride | None = None,
+) -> list[tuple[Fragment, str]]:
+    """Return ``(fragment, body)`` records across the corpus subtrees.
+
+    Fragments whose ``privacy_tier`` exceeds *override* are excluded (#660), so
+    above-ceiling content never enters ranking, the link graph, or the evidence.
+    ``override`` of ``None`` defaults to ``OPEN`` (the most restrictive).
+    """
     records: list[tuple[Fragment, str]] = []
     for sub in _CORPUS_SUBDIRS:
         for _path, fragment, body, _meta in iter_vault_fragments(vault / sub):
-            records.append((fragment, body))
+            if tier_within_override(fragment.privacy_tier, override):
+                records.append((fragment, body))
     return records
 
 
@@ -232,16 +252,23 @@ class RetrievalSpecialist:
             self._cache_vault = vault
         return self._cache
 
-    def gather(self, query: str, vault: Path) -> EvidenceBundle:
+    def gather(
+        self,
+        query: str,
+        vault: Path,
+        *,
+        override: PrivacyTierOverride | None = None,
+    ) -> EvidenceBundle:
         """Return the top-``retrieval_top_k`` fragments most relevant to *query*.
 
         Degrades to an empty bundle when the corpus is empty or the embedding
         model is unavailable, so the desk never crashes on a thin/offline vault.
         The persisted embeddings cache is loaded once and used to skip
-        re-embedding fragments whose text is unchanged.
+        re-embedding fragments whose text is unchanged. Fragments above
+        *override* are excluded from the corpus (#660).
         """
         config = _load_config(vault)
-        corpus = _load_corpus(vault)
+        corpus = _load_corpus(vault, override)
         if not corpus:
             return EvidenceBundle()
         linker = self._get_linker(config)
@@ -357,14 +384,22 @@ class GraphSpecialist:
 
     name = "graph"
 
-    def gather(self, query: str, vault: Path) -> EvidenceBundle:
+    def gather(
+        self,
+        query: str,
+        vault: Path,
+        *,
+        override: PrivacyTierOverride | None = None,
+    ) -> EvidenceBundle:
         """Walk the link graph from a query-matched seed within the config bounds.
 
         The walk respects ``author.graph_breadth_bound`` / ``graph_depth_bound``
-        and reports its reach in ``walk_stats``.
+        and reports its reach in ``walk_stats``. Fragments above *override* are
+        excluded from the corpus before the graph is built (#660), so the walk
+        never traverses or surfaces above-ceiling content.
         """
         config = _load_config(vault)
-        corpus = _load_corpus(vault)
+        corpus = _load_corpus(vault, override)
         by_id = {fragment.id: fragment for fragment, _ in corpus}
         if not by_id:
             return EvidenceBundle(walk_stats=WalkStats())
@@ -738,22 +773,30 @@ class OntologySpecialist:
 
     name = "ontology"
 
-    def gather(self, query: str, vault: Path) -> EvidenceBundle:
+    def gather(
+        self,
+        query: str,
+        vault: Path,
+        *,
+        override: PrivacyTierOverride | None = None,
+    ) -> EvidenceBundle:
         """Return canonical ontological analysis grounded in corpus fragments.
 
         Degrades to an empty bundle when the corpus is empty so the desk never
         crashes on a thin vault. When the corpus is non-empty it always emits
-        at least one claim, traced to the scanned fragments.
+        at least one claim, traced to the scanned fragments. Fragments above
+        *override* are excluded from the corpus (#660).
 
         Args:
             query: The user query (unused — analysis is corpus-wide).
             vault: The vault to scan.
+            override: The privacy admission ceiling; ``None`` defaults to OPEN.
 
         Returns:
             An :class:`EvidenceBundle` carrying the analysis and a grounded
             summary claim, or an empty bundle for an empty corpus.
         """
-        corpus = _load_corpus(vault)
+        corpus = _load_corpus(vault, override)
         if not corpus:
             return EvidenceBundle()
         signals = [

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from creek.author.client import AuthorLLMClient
+    from creek.classify.privacy_filter import PrivacyTierOverride
     from creek.config import AIStyleConfig
     from creek.generate.ai_style.model import VoiceFingerprint
     from creek.models import MediumContract
@@ -190,17 +191,29 @@ class Conductor:
         """Return the ordered pipeline step names for display/dry-run."""
         return [s.name for s in self.specialists] + list(_DOWNSTREAM_STEPS)
 
-    def gather_evidence(self, query: str, vault: Path) -> EvidenceBundle:
+    def gather_evidence(
+        self,
+        query: str,
+        vault: Path,
+        *,
+        override: PrivacyTierOverride | None = None,
+    ) -> EvidenceBundle:
         """Run the specialist roster then the synthesize step.
 
         Args:
             query: The user query.
             vault: The vault the specialists read from.
+            override: The privacy admission ceiling (#660) threaded to every
+                specialist so above-ceiling fragments never enter the evidence.
+                ``None`` defaults to ``OPEN``.
 
         Returns:
             The synthesized :class:`EvidenceBundle`.
         """
-        bundles = [specialist.gather(query, vault) for specialist in self.specialists]
+        bundles = [
+            specialist.gather(query, vault, override=override)
+            for specialist in self.specialists
+        ]
         return self.synthesize(bundles)
 
     def synthesize(self, bundles: Sequence[EvidenceBundle]) -> EvidenceBundle:
@@ -291,13 +304,22 @@ class Conductor:
             return (ai_style, None)
         return (ai_style, fingerprint)
 
-    def run(self, *, medium: str, query: str, vault: Path) -> AuthoredDraft:
+    def run(
+        self,
+        *,
+        medium: str,
+        query: str,
+        vault: Path,
+        override: PrivacyTierOverride | None = None,
+    ) -> AuthoredDraft:
         """Run the full author pipeline and return a shaped draft.
 
         Args:
             medium: The requested medium (only ``research`` is wired).
             query: The user query.
             vault: The vault to author from.
+            override: The privacy admission ceiling (#660); above-ceiling
+                fragments are excluded from the evidence. ``None`` => ``OPEN``.
 
         Returns:
             The :class:`AuthoredDraft` with mock provenance and a verdict. A
@@ -308,7 +330,7 @@ class Conductor:
             ValueError: When *medium* is unsupported.
         """
         validated = require_supported_medium(medium)
-        evidence = self.gather_evidence(query, vault)
+        evidence = self.gather_evidence(query, vault, override=override)
         rubric = self.contract.reflection_rubric if self.contract else None
         # Voice-fidelity is wired from the owner's persisted fingerprint (#506):
         # loaded once before the loop. When no fingerprint has been built the
@@ -398,6 +420,7 @@ def run_author(
     vault: Path,
     max_rounds: int | None = None,
     llm_client: AuthorLLMClient | None = None,
+    override: PrivacyTierOverride | None = None,
 ) -> AuthoredDraft:
     """Author *query* for *medium* against *vault* with the default desk.
 
@@ -409,6 +432,9 @@ def run_author(
             ``author.max_author_rounds`` config default.
         llm_client: Optional voice client (#658). When supplied, the desk
             renders live voicing; ``None`` keeps the deterministic stub.
+        override: The privacy admission ceiling (#660) threaded to the
+            specialists; above-ceiling fragments are excluded. ``None`` =>
+            ``OPEN``.
 
     Returns:
         The shaped :class:`AuthoredDraft`.
@@ -422,7 +448,7 @@ def run_author(
         max_rounds=rounds,
         llm_client=llm_client,
         contract=contract,
-    ).run(medium=medium, query=query, vault=vault)
+    ).run(medium=medium, query=query, vault=vault, override=override)
     return _enforce_chat_ceiling(draft)
 
 
@@ -438,7 +464,13 @@ class AuthorPlan(TypedDict):
     evidence: dict[str, int]
 
 
-def plan_author(*, medium: str, query: str, vault: Path) -> AuthorPlan:
+def plan_author(
+    *,
+    medium: str,
+    query: str,
+    vault: Path,
+    override: PrivacyTierOverride | None = None,
+) -> AuthorPlan:
     """Return the pipeline plan + evidence summary without authoring (dry run).
 
     A lightweight preview for ``creek author --dry-run`` and the MCP verb's
@@ -449,6 +481,8 @@ def plan_author(*, medium: str, query: str, vault: Path) -> AuthorPlan:
         medium: The requested medium.
         query: The user query.
         vault: The vault to gather evidence from.
+        override: The privacy admission ceiling (#660); above-ceiling fragments
+            are excluded from the previewed evidence. ``None`` => ``OPEN``.
 
     Returns:
         An :class:`AuthorPlan` with the step plan and evidence counts.
@@ -459,7 +493,7 @@ def plan_author(*, medium: str, query: str, vault: Path) -> AuthorPlan:
     require_supported_medium(medium)
     contract = load_medium_contract(medium, vault)
     conductor = build_default_conductor(max_rounds=1, contract=contract)
-    evidence = conductor.gather_evidence(query, vault)
+    evidence = conductor.gather_evidence(query, vault, override=override)
     return {
         "plan": conductor.plan(),
         "evidence": {

--- a/creek-tools/creek/classify/privacy_filter.py
+++ b/creek-tools/creek/classify/privacy_filter.py
@@ -96,6 +96,46 @@ def _allows_full_personal_body(override: PrivacyTierOverride | None) -> bool:
     )
 
 
+_TIER_RANK: dict[PrivacyTier, int] = {
+    PrivacyTier.OPEN: 0,
+    PrivacyTier.UNCLASSIFIED: 0,
+    PrivacyTier.PERSONAL: 1,
+    PrivacyTier.INTIMATE: 2,
+}
+
+_OVERRIDE_RANK: dict[PrivacyTierOverride, int] = {
+    PrivacyTierOverride.OPEN: 0,
+    PrivacyTierOverride.PERSONAL: 1,
+    PrivacyTierOverride.INTIMATE: 2,
+    PrivacyTierOverride.ALL: 3,
+}
+
+
+def tier_within_override(
+    tier: PrivacyTier,
+    override: PrivacyTierOverride | None,
+) -> bool:
+    """Return whether a *tier* fragment is admitted under *override* (hard cutoff).
+
+    Unlike :func:`filter_fragments` — which *summarises* ``PERSONAL`` bodies and
+    only drops ``INTIMATE`` — this is a strict rank cutoff that **excludes**
+    anything above the override entirely. The Writing Desk needs its evidence to
+    omit above-ceiling fragments outright (#660), not carry summaries. ``None``
+    defaults to ``OPEN`` (the most restrictive); ``ALL`` admits every tier.
+
+    Args:
+        tier: The fragment's privacy tier.
+        override: The admission ceiling, or ``None`` for ``OPEN``.
+
+    Returns:
+        ``True`` when the fragment may enter the evidence.
+    """
+    effective = override or PrivacyTierOverride.OPEN
+    if effective is PrivacyTierOverride.ALL:
+        return True
+    return _TIER_RANK[tier] <= _OVERRIDE_RANK[effective]
+
+
 def filter_fragments_by_tier(
     fragments: Iterable[tuple[Fragment, str]],
     *,

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -3252,6 +3252,15 @@ def author(
             vault_path,
             override=override,
         )
+        # #660: an elevated --include-tier admits above-OPEN fragments into the
+        # evidence; record that operator decision in the privacy audit (no-op
+        # for None/OPEN). Mirrors the other --include-tier callers.
+        _audit_privacy_override_if_needed(
+            vault_path=vault_path,
+            command="author",
+            override=override,
+            fragment_ids=evidence.all_source_fragments(),
+        )
         console.print(f"PLAN: {' → '.join(conductor.plan())}")
         console.print(
             f"EVIDENCE (stub): {len(evidence.claims)} claims, "
@@ -3280,6 +3289,16 @@ def author(
         query=effective_query,
         vault=vault_path,
         override=override,
+    )
+    # #660: audit the elevated access using the fragments actually cited in the
+    # draft's provenance (no-op for None/OPEN).
+    _audit_privacy_override_if_needed(
+        vault_path=vault_path,
+        command="author",
+        override=override,
+        fragment_ids=[
+            fid for entry in draft_result.provenance for fid in entry.fragment_ids
+        ],
     )
     console.print(
         f"medium={draft_result.medium} verdict={draft_result.verdict} "

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -3213,6 +3213,15 @@ def author(
             "the vault's author.max_author_rounds config (3)."
         ),
     ),
+    include_tier: str | None = typer.Option(
+        None,
+        "--include-tier",
+        help=(
+            "Privacy ceiling for retrieved evidence: open (default) / personal "
+            "/ intimate / all. Fragments above the ceiling are excluded from "
+            "the desk's evidence (#660)."
+        ),
+    ),
 ) -> None:
     """Author a piece with the Creek Writing Desk (stub skeleton).
 
@@ -3232,11 +3241,17 @@ def author(
     config = _load_config_for_vault(vault)
     vault_path = _resolve_vault(vault if vault is not None else config.vault_path)
     rounds = max_rounds if max_rounds is not None else config.author.max_author_rounds
+    # #660: the privacy ceiling for retrieved evidence (default OPEN).
+    override = _parse_include_tier(include_tier)
 
     if dry_run:
         # The dry run only plans + gathers evidence; no voicing, so no client.
         conductor = build_default_conductor(max_rounds=rounds)
-        evidence = conductor.gather_evidence(effective_query, vault_path)
+        evidence = conductor.gather_evidence(
+            effective_query,
+            vault_path,
+            override=override,
+        )
         console.print(f"PLAN: {' → '.join(conductor.plan())}")
         console.print(
             f"EVIDENCE (stub): {len(evidence.claims)} claims, "
@@ -3260,7 +3275,12 @@ def author(
     draft_result = build_default_conductor(
         max_rounds=rounds,
         llm_client=voice_client,
-    ).run(medium=medium, query=effective_query, vault=vault_path)
+    ).run(
+        medium=medium,
+        query=effective_query,
+        vault=vault_path,
+        override=override,
+    )
     console.print(
         f"medium={draft_result.medium} verdict={draft_result.verdict} "
         f"rounds={draft_result.rounds} provenance={len(draft_result.provenance)}",

--- a/creek-tools/creek_mcp/tools/author.py
+++ b/creek-tools/creek_mcp/tools/author.py
@@ -16,7 +16,7 @@ from creek.author import plan_author, require_supported_medium, run_author
 from creek.author.client import AuthorLLMClient
 from creek.config import load_config
 from creek_mcp.audit import MCPAuditLog
-from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tier_ceiling import TierCeiling, to_privacy_override
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -53,9 +53,9 @@ def _draft_response(
         "status": "ok",
         "tool": TOOL_NAME,
         "tier_ceiling": tier_ceiling.value,
-        # Explicit so callers never mistake the echo for enforcement; flips to
-        # True when tier-filtered retrieval lands with the real specialists (#463).
-        "tier_ceiling_enforced": False,
+        # #660: the specialists tier-filter retrieval against the ceiling, so
+        # the echo now reflects real enforcement.
+        "tier_ceiling_enforced": True,
         "dry_run": False,
         "medium": draft.medium,
         "query": draft.query,
@@ -84,8 +84,10 @@ def author_tool(
 
     Mirrors the ``creek author`` CLI args. Delegates to ``run_author`` (or
     ``plan_author`` when ``dry_run`` is set); the verb adds no desk logic. The
-    caller's privacy ceiling is recorded and echoed across the boundary (real
-    tier-filtered retrieval arrives with the real specialists, #463).
+    caller's privacy ceiling is recorded **and enforced** (#660): it is
+    converted to a :class:`~creek.classify.privacy_filter.PrivacyTierOverride`
+    and threaded to the specialists, which exclude above-ceiling fragments from
+    the evidence.
 
     Args:
         vault_path: The vault to author from.
@@ -101,9 +103,9 @@ def author_tool(
         ``claims``) or — for ``dry_run`` — the plan + evidence summary. An
         unsupported medium yields ``status: error`` with a ``reason``.
     """
-    # Privacy gap (#463): the ceiling is recorded and echoed across the
-    # boundary, but the current stub specialists do not yet tier-filter
-    # retrieval. Real enforcement lands with the real Graph/Retrieval agents.
+    # #660: the ceiling is enforced — converted to a PrivacyTierOverride below
+    # and threaded into the specialists, which exclude above-ceiling fragments
+    # from the retrieved evidence.
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
         args={
@@ -126,14 +128,22 @@ def author_tool(
     # downstream validation error, ...) must surface as a structured envelope,
     # never an unhandled exception across the MCP boundary. This mirrors the
     # broad boundary catch the other MCP write tools use (e.g. purge).
+    # #660: enforce the ceiling by converting it to the core privacy override
+    # threaded into the specialists.
+    override = to_privacy_override(privacy_tier_ceiling)
     try:
         if dry_run:
-            plan = plan_author(medium=medium, query=query, vault=vault_path)
+            plan = plan_author(
+                medium=medium,
+                query=query,
+                vault=vault_path,
+                override=override,
+            )
             return {
                 "status": "ok",
                 "tool": TOOL_NAME,
                 "tier_ceiling": privacy_tier_ceiling.value,
-                "tier_ceiling_enforced": False,
+                "tier_ceiling_enforced": True,
                 "dry_run": True,
                 "medium": medium,
                 "query": query,
@@ -155,6 +165,7 @@ def author_tool(
             vault=vault_path,
             max_rounds=max_rounds,
             llm_client=voice_client,
+            override=override,
         )
     except Exception as exc:
         return _error_response(

--- a/creek-tools/tests/test_author_tier_filter.py
+++ b/creek-tools/tests/test_author_tier_filter.py
@@ -1,0 +1,99 @@
+"""Writing Desk tier-filters retrieval against the privacy override (#660).
+
+#463 shipped the real Graph/Retrieval agents but not the tier-filtering its own
+comments promised. These tests pin that a fragment whose ``privacy_tier``
+exceeds the run's override is **absent** from the evidence, while one at/below it
+is present — and that the override threads from the conductor.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.author.agents import GraphSpecialist
+from creek.author.conductor import build_default_conductor
+from creek.classify.privacy_filter import PrivacyTierOverride
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from creek.author.models import EvidenceBundle
+
+
+def _seed(
+    vault: Path,
+    frag_id: str,
+    title: str,
+    *,
+    tier: str | None = None,
+    body: str = "body",
+) -> None:
+    """Write a minimal fragment file, optionally with a ``privacy_tier``."""
+    folder = vault / "01-Fragments" / "Notes"
+    folder.mkdir(parents=True, exist_ok=True)
+    tier_line = f"privacy_tier: {tier}\n" if tier else ""
+    (folder / f"{frag_id}.md").write_text(
+        f'---\ntype: fragment\nid: {frag_id}\ntitle: "{title}"\n'
+        f"source:\n  platform: journal\n  author: self\n{tier_line}---\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def _ids(bundle: EvidenceBundle) -> set[str]:
+    return {f for c in bundle.claims for f in c.source_fragments}
+
+
+def test_graph_specialist_excludes_above_override(tmp_path: Path) -> None:
+    """Default (OPEN) drops an INTIMATE fragment; ALL keeps it.
+
+    The open fragment links to the intimate one, so the walk *would* reach it —
+    the tier filter is what keeps it out of the evidence.
+    """
+    _seed(tmp_path, "frag-open", "Open note about q", body="[[frag-int]] body")
+    _seed(tmp_path, "frag-int", "Intimate note about q", tier="intimate")
+
+    default = GraphSpecialist().gather("q", tmp_path)
+    assert "frag-int" not in _ids(default)
+    assert "frag-open" in _ids(default)
+
+    everything = GraphSpecialist().gather(
+        "q",
+        tmp_path,
+        override=PrivacyTierOverride.ALL,
+    )
+    assert "frag-int" in _ids(everything)
+
+
+def test_personal_excluded_under_open_admitted_under_personal(
+    tmp_path: Path,
+) -> None:
+    """A PERSONAL fragment is gated by the override rank, not summarised."""
+    _seed(tmp_path, "frag-open", "Open about q", body="[[frag-pers]] body")
+    _seed(tmp_path, "frag-pers", "Personal about q", tier="personal")
+
+    under_open = GraphSpecialist().gather("q", tmp_path)
+    assert "frag-pers" not in _ids(under_open)
+
+    under_personal = GraphSpecialist().gather(
+        "q",
+        tmp_path,
+        override=PrivacyTierOverride.PERSONAL,
+    )
+    assert "frag-pers" in _ids(under_personal)
+
+
+def test_gather_evidence_threads_override(tmp_path: Path) -> None:
+    """The conductor passes the override down to the specialists."""
+    _seed(tmp_path, "frag-open", "Open about q")
+    _seed(tmp_path, "frag-int", "Intimate about q", tier="intimate")
+
+    conductor = build_default_conductor(max_rounds=1)
+    default = conductor.gather_evidence("q", tmp_path)
+    assert "frag-int" not in _ids(default)
+
+    everything = conductor.gather_evidence(
+        "q",
+        tmp_path,
+        override=PrivacyTierOverride.ALL,
+    )
+    assert "frag-int" in _ids(everything)

--- a/creek-tools/tests/test_cli_privacy.py
+++ b/creek-tools/tests/test_cli_privacy.py
@@ -234,3 +234,41 @@ def test_skills_help_mentions_include_tier() -> None:
     result = runner.invoke(app, ["skills", "generate", "--help"])
     assert result.exit_code == 0
     assert "--include-tier" in _plain(result.output)
+
+
+def test_author_with_include_tier_writes_audit(tmp_path: Path) -> None:
+    """``creek author --include-tier intimate`` writes a privacy audit entry (#660)."""
+    vault = _make_mining_vault(tmp_path)
+
+    result = runner.invoke(
+        app,
+        [
+            "author",
+            "--vault",
+            str(vault),
+            "--query",
+            "what is the thread about",
+            "--include-tier",
+            "intimate",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    audit_path = vault / PRIVACY_AUDIT_RELPATH
+    assert audit_path.exists()
+    entries = list(AuditLog(audit_path).read())
+    assert any(
+        e["command"] == "author" and e["include_tier"] == "intimate" for e in entries
+    )
+
+
+def test_author_default_writes_no_audit(tmp_path: Path) -> None:
+    """Default ``creek author`` (OPEN ceiling) writes no privacy audit entry."""
+    vault = _make_mining_vault(tmp_path)
+
+    result = runner.invoke(
+        app,
+        ["author", "--vault", str(vault), "--query", "what is the thread about"],
+    )
+    assert result.exit_code == 0, result.output
+    assert not (vault / PRIVACY_AUDIT_RELPATH).exists()

--- a/creek-tools/tests/test_mcp_tools.py
+++ b/creek-tools/tests/test_mcp_tools.py
@@ -418,8 +418,8 @@ def test_author_tool_returns_draft_envelope(vault: Path) -> None:
     assert result["body"].strip()
     assert result["dry_run"] is False
     assert result["rounds"] >= 1
-    # The echo is explicitly marked non-enforcing until #463 lands.
-    assert result["tier_ceiling_enforced"] is False
+    # #660: the ceiling is now enforced — the specialists tier-filter retrieval.
+    assert result["tier_ceiling_enforced"] is True
 
 
 def test_author_tool_rejects_unknown_medium(vault: Path) -> None:

--- a/creek-tools/tests/test_privacy_filter.py
+++ b/creek-tools/tests/test_privacy_filter.py
@@ -20,6 +20,7 @@ from creek.classify.privacy_filter import (
     override_elevates,
     parse_include_tier,
     record_privacy_override,
+    tier_within_override,
 )
 from creek.models import (
     Authorship,
@@ -230,3 +231,26 @@ def test_parse_include_tier_handles_known_and_unknown() -> None:
     assert parse_include_tier("ALL") is PrivacyTierOverride.ALL
     with pytest.raises(ValueError, match="--include-tier"):
         parse_include_tier("nope")
+
+
+@pytest.mark.parametrize(
+    ("tier", "override", "expected"),
+    [
+        (PrivacyTier.OPEN, PrivacyTierOverride.OPEN, True),
+        (PrivacyTier.UNCLASSIFIED, PrivacyTierOverride.OPEN, True),
+        (PrivacyTier.PERSONAL, PrivacyTierOverride.OPEN, False),
+        (PrivacyTier.INTIMATE, PrivacyTierOverride.OPEN, False),
+        (PrivacyTier.PERSONAL, PrivacyTierOverride.PERSONAL, True),
+        (PrivacyTier.INTIMATE, PrivacyTierOverride.PERSONAL, False),
+        (PrivacyTier.INTIMATE, PrivacyTierOverride.INTIMATE, True),
+        (PrivacyTier.INTIMATE, PrivacyTierOverride.ALL, True),
+        (PrivacyTier.INTIMATE, None, False),  # None defaults to OPEN
+    ],
+)
+def test_tier_within_override(
+    tier: PrivacyTier,
+    override: PrivacyTierOverride | None,
+    expected: bool,
+) -> None:
+    """The hard rank cutoff admits a tier iff it is at/below the override (#660)."""
+    assert tier_within_override(tier, override) is expected


### PR DESCRIPTION
## Summary
Closes the privacy gap #463 *named* but never delivered: the Writing Desk's Graph/Retrieval/Ontology specialists now **tier-filter** their evidence against the run's privacy ceiling — a fragment whose `privacy_tier` exceeds the ceiling is **excluded** from the `EvidenceBundle` (never ranked, walked, or scanned).

- **Core, layering-clean**: adds `tier_within_override(tier, override)` to `creek/classify/privacy_filter.py` — a hard rank cutoff (excludes above-ceiling), distinct from `filter_fragments` (which *summarises* PERSONAL). It uses the core `PrivacyTierOverride`, so `creek/author` gains **no `creek_mcp` dependency**.
- **Threaded end to end**: `_load_corpus` filters by the override; the `Specialist` protocol + all three `gather` methods, `Conductor.gather_evidence`/`run`, `run_author`, and `plan_author` all take and forward `override` (default `OPEN`).
- **MCP enforcement (the actual gap)**: `author_tool` converts `privacy_tier_ceiling` → override via `to_privacy_override`, threads it, and flips `tier_ceiling_enforced` to `True` for the draft and dry-run envelopes. The stale `#463` comments are corrected. Error envelopes keep `enforced=False` (no retrieval ran).
- **CLI**: adds `--include-tier` (parity with `creek draft`), default `OPEN`.

## Test plan
- `tests/test_author_tier_filter.py` (new): the GraphSpecialist excludes an INTIMATE fragment under the default OPEN ceiling but includes it under ALL; a PERSONAL fragment is gated by rank (excluded under OPEN, admitted under PERSONAL); the conductor threads the override.
- Updated `test_mcp_tools.py`: the success-draft envelope now reports `tier_ceiling_enforced: True` (error envelopes unchanged).
- `./scripts/check-all.sh` green (12/12): 5532+ passed, 93.82% coverage.

Closes #660
