### PR TITLE
feat(author): route the desk voice call by the retrieved content tier (#661)

### DIFF
--- a/creek-tools/creek/author/agents.py
+++ b/creek-tools/creek/author/agents.py
@@ -36,7 +36,15 @@ from creek.link.embeddings import (
     embeddings_cache_path,
     fragment_embedding_text,
 )
-from creek.models import Confidence, Dosage, Frequency, Mode, Phase, VoiceRegister
+from creek.models import (
+    Confidence,
+    Dosage,
+    Frequency,
+    Mode,
+    Phase,
+    PrivacyTier,
+    VoiceRegister,
+)
 from creek.vault.reader import iter_vault_fragments
 
 if TYPE_CHECKING:
@@ -107,6 +115,29 @@ def _load_corpus(
             if tier_within_override(fragment.privacy_tier, override):
                 records.append((fragment, body))
     return records
+
+
+def fragment_tier_map(
+    vault: Path,
+    override: PrivacyTierOverride | None = None,
+) -> dict[str, PrivacyTier]:
+    """Return a ``{fragment_id: privacy_tier}`` map for the admitted corpus (#661).
+
+    Built from the same override-filtered corpus the specialists gather from, so
+    the desk can derive a run's *content tier* (the most-sensitive tier actually
+    in the evidence) and route the voice call accordingly.
+
+    Args:
+        vault: Vault root.
+        override: The privacy admission ceiling (matches the gather override).
+
+    Returns:
+        A mapping of admitted fragment id to its :class:`PrivacyTier`.
+    """
+    return {
+        fragment.id: fragment.privacy_tier
+        for fragment, _ in _load_corpus(vault, override)
+    }
 
 
 def _fragment_claim(fragment: Fragment) -> EvidenceClaim:

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -16,7 +16,7 @@ import logging
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Protocol, TypedDict, cast
 
-from creek.author.agents import Specialist, default_specialists
+from creek.author.agents import Specialist, default_specialists, fragment_tier_map
 from creek.author.contracts import CHAT_MAX_CHARS, load_medium_contract
 from creek.author.models import (
     AuthoredDraft,
@@ -30,9 +30,10 @@ from creek.author.models import (
 from creek.author.reflection import ReflectionNode
 from creek.author.voice import VoiceAgent
 from creek.compile.provenance import ProvenanceEntry
+from creek.models import PrivacyTier
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
     from pathlib import Path
 
     from creek.author.client import AuthorLLMClient
@@ -41,7 +42,40 @@ if TYPE_CHECKING:
     from creek.generate.ai_style.model import VoiceFingerprint
     from creek.models import MediumContract
 
+    #: A callable that builds the voice client for a run's content tier (#661).
+    VoiceClientFactory = Callable[[PrivacyTier | None], "AuthorLLMClient | None"]
+
 logger = logging.getLogger(__name__)
+
+
+def _content_tier(
+    evidence: EvidenceBundle,
+    vault: Path,
+    override: PrivacyTierOverride | None,
+) -> PrivacyTier | None:
+    """Return the most-sensitive tier among the evidence's fragments (#661).
+
+    The voice call sends the evidence to the LLM, so its routing tier is the
+    highest ``privacy_tier`` actually cited. ``INTIMATE`` outranks ``PERSONAL``
+    outranks ``OPEN``; ``None`` when the evidence cites no known fragment.
+
+    Args:
+        evidence: The gathered evidence.
+        vault: Vault root (to look up fragment tiers).
+        override: The admission ceiling used when gathering (same corpus view).
+
+    Returns:
+        The content tier, or ``None`` for empty/untraceable evidence.
+    """
+    tier_map = fragment_tier_map(vault, override)
+    tiers = {
+        tier_map[fid] for fid in evidence.all_source_fragments() if fid in tier_map
+    }
+    for tier in (PrivacyTier.INTIMATE, PrivacyTier.PERSONAL, PrivacyTier.OPEN):
+        if tier in tiers:
+            return tier
+    return None
+
 
 #: Mediums the conductor will run. ``research``/``chat``/``essay``/
 #: ``research-piece``/``book-report``/``how-to`` are all wired — ``how-to``
@@ -73,8 +107,13 @@ class VoiceRenderer(Protocol):
         *,
         medium: Medium | None = None,
         contract: MediumContract | None = None,
+        client: AuthorLLMClient | None = None,
     ) -> str:
-        """Return draft prose for *query* from *evidence* (in the owner's voice)."""
+        """Return draft prose for *query* from *evidence* (in the owner's voice).
+
+        *client* (#661) overrides the agent's own client for this render — the
+        conductor passes the tier-routed voice client; ``None`` falls back.
+        """
         ...
 
 
@@ -167,9 +206,16 @@ class Conductor:
         *,
         max_rounds: int,
         llm_client: AuthorLLMClient | None = None,
+        voice_client_factory: VoiceClientFactory | None = None,
         contract: MediumContract | None = None,
     ) -> None:
         """Store collaborators, the round bound, and the medium contract.
+
+        Args:
+            voice_client_factory: When set (#661), the conductor builds the
+                voice client *after* gathering evidence, passing the run's
+                content tier so the ``Intimate``-never-cloud chokepoint fires on
+                the actual content. Takes precedence over a static *llm_client*.
 
         Raises:
             ValueError: When *max_rounds* is below 1 — the voice/reflect loop
@@ -185,6 +231,7 @@ class Conductor:
         self.reflection = reflection
         self.max_rounds = max_rounds
         self.llm_client = llm_client
+        self.voice_client_factory = voice_client_factory
         self.contract = contract
 
     def plan(self) -> list[str]:
@@ -331,6 +378,15 @@ class Conductor:
         """
         validated = require_supported_medium(medium)
         evidence = self.gather_evidence(query, vault, override=override)
+        # #661: route the voice call by the evidence's content tier so Intimate
+        # content is redirected to a local provider by the chokepoint. The
+        # factory (built per content tier) takes precedence over a static client.
+        if self.voice_client_factory is not None:
+            voice_client = self.voice_client_factory(
+                _content_tier(evidence, vault, override),
+            )
+        else:
+            voice_client = self.llm_client
         rubric = self.contract.reflection_rubric if self.contract else None
         # Voice-fidelity is wired from the owner's persisted fingerprint (#506):
         # loaded once before the loop. When no fingerprint has been built the
@@ -345,7 +401,12 @@ class Conductor:
         for attempt in range(1, self.max_rounds + 1):
             rounds = attempt
             body = self.voice.render(
-                query, evidence, vault, medium=validated, contract=self.contract
+                query,
+                evidence,
+                vault,
+                medium=validated,
+                contract=self.contract,
+                client=voice_client,
             )
             result = self.reflection.review(
                 body,
@@ -388,6 +449,7 @@ def build_default_conductor(
     *,
     max_rounds: int,
     llm_client: AuthorLLMClient | None = None,
+    voice_client_factory: VoiceClientFactory | None = None,
     contract: MediumContract | None = None,
 ) -> Conductor:
     """Build a conductor wired with the default stub collaborators.
@@ -395,6 +457,8 @@ def build_default_conductor(
     Args:
         max_rounds: Upper bound on voice/reflect rounds.
         llm_client: Optional network seam passed through to the conductor.
+        voice_client_factory: Optional tier-aware voice-client factory (#661);
+            takes precedence over a static *llm_client*.
         contract: Optional medium contract passed through to the conductor.
 
     Returns:
@@ -409,6 +473,7 @@ def build_default_conductor(
         reflection=ReflectionNode(),
         max_rounds=max_rounds,
         llm_client=llm_client,
+        voice_client_factory=voice_client_factory,
         contract=contract,
     )
 
@@ -420,6 +485,7 @@ def run_author(
     vault: Path,
     max_rounds: int | None = None,
     llm_client: AuthorLLMClient | None = None,
+    voice_client_factory: VoiceClientFactory | None = None,
     override: PrivacyTierOverride | None = None,
 ) -> AuthoredDraft:
     """Author *query* for *medium* against *vault* with the default desk.
@@ -447,6 +513,7 @@ def run_author(
     draft = build_default_conductor(
         max_rounds=rounds,
         llm_client=llm_client,
+        voice_client_factory=voice_client_factory,
         contract=contract,
     ).run(medium=medium, query=query, vault=vault, override=override)
     return _enforce_chat_ceiling(draft)

--- a/creek-tools/creek/author/voice.py
+++ b/creek-tools/creek/author/voice.py
@@ -72,6 +72,7 @@ class VoiceAgent:
         *,
         medium: Medium | None = None,
         contract: MediumContract | None = None,
+        client: AuthorLLMClient | None = None,
     ) -> str:
         """Render *evidence* into draft prose for *query* in the owner's voice.
 
@@ -84,6 +85,9 @@ class VoiceAgent:
                 (research = light touch).
             contract: The medium contract whose ``structure`` orders the
                 grounded evidence in the prompt.
+            client: A per-render client override (#661) — the conductor passes
+                the tier-routed voice client here. ``None`` falls back to the
+                agent's own :attr:`llm_client`.
 
         Returns:
             The voiced draft body. The LLM output when a client and vault are
@@ -93,11 +97,12 @@ class VoiceAgent:
         # Reset first so a deterministic render never leaks a prior LLM call's
         # usage if this agent instance is reused (#474 review).
         self.last_usage = None
+        effective_client = client if client is not None else self.llm_client
         deterministic = _deterministic_body(query, evidence)
-        if self.llm_client is None or vault is None:
+        if effective_client is None or vault is None:
             return deterministic
         static, dynamic = _split_voice_prompt(query, evidence, vault, medium, contract)
-        completion = self.llm_client.complete_with_usage(dynamic, system=static)
+        completion = effective_client.complete_with_usage(dynamic, system=static)
         self.last_usage = completion.usage
         voiced = completion.text.strip()
         return voiced or deterministic

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -3268,14 +3268,18 @@ def author(
         )
         return
 
-    # #658: build the router-resolved voice client for live voicing. Falls back
-    # to ``None`` (deterministic stub) when the provider is unavailable, so the
-    # command still works without a reachable/consented backend.
-    voice_client = AuthorLLMClient.for_voice_or_none(
-        config.model_router,
-        author=config.author,
-    )
-    if voice_client is None:
+    # #658/#661: build the router-resolved voice client *per the run's content
+    # tier* so live voicing of Intimate content is redirected to a local
+    # provider by the chokepoint. The factory falls back to ``None``
+    # (deterministic stub) when the provider is unavailable.
+    def _voice_client(tier: PrivacyTier | None) -> AuthorLLMClient | None:
+        return AuthorLLMClient.for_voice_or_none(
+            config.model_router,
+            author=config.author,
+            tier=tier,
+        )
+
+    if _voice_client(None) is None:
         console.print(
             "[dim]No LLM provider available — rendering the deterministic "
             "stub. Configure llm.generation (and consent for a cloud provider) "
@@ -3283,7 +3287,7 @@ def author(
         )
     draft_result = build_default_conductor(
         max_rounds=rounds,
-        llm_client=voice_client,
+        voice_client_factory=_voice_client,
     ).run(
         medium=medium,
         query=effective_query,

--- a/creek-tools/creek_mcp/tools/author.py
+++ b/creek-tools/creek_mcp/tools/author.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from creek.author import AuthoredDraft
+    from creek.models import PrivacyTier
 
 TOOL_NAME = "creek.author"
 
@@ -150,21 +151,28 @@ def author_tool(
                 "plan": plan["plan"],
                 "evidence": plan["evidence"],
             }
-        # #658: build the router-resolved voice client so the desk renders live
-        # voicing; ``for_voice_or_none`` returns ``None`` (deterministic stub)
-        # when the provider is unavailable, so the tool never hard-fails on a
-        # missing/unconsented backend.
+        # #658/#661: build the router-resolved voice client per the run's content
+        # tier so live voicing of Intimate content is redirected to a local
+        # provider by the chokepoint. ``for_voice_or_none`` returns ``None``
+        # (deterministic stub) when the provider is unavailable, so the tool
+        # never hard-fails on a missing/unconsented backend.
         config = load_config()
-        voice_client = AuthorLLMClient.for_voice_or_none(
-            config.model_router,
-            author=config.author,
-        )
+        router = config.model_router
+        author_config = config.author
+
+        def _voice_client(tier: PrivacyTier | None) -> AuthorLLMClient | None:
+            return AuthorLLMClient.for_voice_or_none(
+                router,
+                author=author_config,
+                tier=tier,
+            )
+
         draft = run_author(
             medium=medium,
             query=query,
             vault=vault_path,
             max_rounds=max_rounds,
-            llm_client=voice_client,
+            voice_client_factory=_voice_client,
             override=override,
         )
     except Exception as exc:

--- a/creek-tools/tests/test_author_tier_filter.py
+++ b/creek-tools/tests/test_author_tier_filter.py
@@ -97,3 +97,50 @@ def test_gather_evidence_threads_override(tmp_path: Path) -> None:
         override=PrivacyTierOverride.ALL,
     )
     assert "frag-int" in _ids(everything)
+
+
+def test_conductor_routes_voice_by_content_tier(tmp_path: Path) -> None:
+    """The voice-client factory receives the evidence's content tier (#661).
+
+    With an INTIMATE fragment admitted (override=ALL), the factory is called
+    with INTIMATE so the chokepoint can redirect the voice call to local.
+    """
+    from creek.author.conductor import build_default_conductor
+    from creek.models import PrivacyTier
+
+    _seed(tmp_path, "frag-int", "Intimate note about q", tier="intimate")
+
+    seen: dict[str, object] = {}
+
+    def _factory(tier: object) -> None:
+        seen["tier"] = tier
+        return None  # deterministic render; we only assert the tier threaded
+
+    build_default_conductor(max_rounds=1, voice_client_factory=_factory).run(
+        medium="research",
+        query="q",
+        vault=tmp_path,
+        override=PrivacyTierOverride.ALL,
+    )
+    assert seen["tier"] == PrivacyTier.INTIMATE
+
+
+def test_content_tier_open_when_no_sensitive_evidence(tmp_path: Path) -> None:
+    """With only OPEN/unclassified evidence, the factory gets a non-INTIMATE tier."""
+    from creek.author.conductor import build_default_conductor
+    from creek.models import PrivacyTier
+
+    _seed(tmp_path, "frag-open", "Open note about q")
+
+    seen: dict[str, object] = {}
+
+    def _factory(tier: object) -> None:
+        seen["tier"] = tier
+        return None
+
+    build_default_conductor(max_rounds=1, voice_client_factory=_factory).run(
+        medium="research",
+        query="q",
+        vault=tmp_path,
+    )
+    assert seen["tier"] != PrivacyTier.INTIMATE

--- a/creek-tools/tests/test_voice_fidelity_wiring.py
+++ b/creek-tools/tests/test_voice_fidelity_wiring.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
 
     import pytest
 
+    from creek.author.client import AuthorLLMClient
     from creek.author.models import EvidenceBundle, Medium
     from creek.models import MediumContract
 
@@ -88,9 +89,10 @@ class _FixedVoice:
         *,
         medium: Medium | None = None,
         contract: MediumContract | None = None,
+        client: AuthorLLMClient | None = None,
     ) -> str:
         """Return the fixed body, ignoring the query and evidence."""
-        del query, evidence, vault, medium, contract
+        del query, evidence, vault, medium, contract, client
         return self._body
 
 


### PR DESCRIPTION
## Summary
Closes the #658 deferral: the desk's voice LLM call now routes by the **sensitivity of the content it voices**, so `Intimate` evidence is redirected to a local provider by the chokepoint instead of the hardcoded `tier=None`.

- `_content_tier(evidence, vault, override)` — the most-sensitive `privacy_tier` among the cited fragments, via a new `agents.fragment_tier_map` over the same override-filtered corpus (#660).
- The `Conductor` gains a `voice_client_factory` (`tier → AuthorLLMClient | None`) that takes precedence over a static `llm_client`. `Conductor.run` computes the content tier **after** gathering and builds the voice client for it, passed to `VoiceAgent.render` via a new per-render `client` override (type-safe — added to the `VoiceRenderer` protocol). Threaded through `build_default_conductor` and `run_author`.
- CLI and MCP build the factory (`for_voice_or_none(router, author, tier=...)`) instead of a static client, so an `Intimate` seed keeps the voice call local while `Open` content still uses the configured cloud model.

## Test plan
- `tests/test_author_tier_filter.py`: the conductor passes the evidence's content tier to the factory — `INTIMATE` when an intimate fragment is admitted (override=ALL), non-`INTIMATE` for open-only evidence.
- Updated `_FixedVoice` in `test_voice_fidelity_wiring.py` for the new `render(client=...)` protocol param.
- `./scripts/check-all.sh` green (12/12): 5570 passed.

Closes #661
