### PR TITLE
feat(ingest): update mutable-source fragments in place on edit (#673)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -45,10 +45,11 @@ if TYPE_CHECKING:
     )
     from creek.generate.mining import MiningRunReport
     from creek.ingest.base import Ingestor, ParsedFragment
-    from creek.ingest.ledger import SourceLedger
+    from creek.ingest.ledger import LedgerRecord, SourceLedger
     from creek.link.link_engine import LinkSummary
     from creek.models import CompileTargetKind, Fragment, Frequency, Mode, Phase
     from creek.purge import PurgeEngine, PurgeResult
+    from creek.vault.writer import VaultWriter
 
 
 _INCLUDE_TIER_HELP = (
@@ -358,6 +359,47 @@ def _record_in_ledger(
     )
 
 
+def _ledger_record(
+    ledger: SourceLedger | None,
+    fragment: Fragment,
+) -> LedgerRecord | None:
+    """Return the prior ledger record for this fragment's source unit (#673)."""
+    if ledger is None:
+        return None
+    origin_key = fragment.source.origin_key
+    if origin_key is None:
+        return None
+    return ledger.get(origin_key)
+
+
+def _write_fragment_idempotent(
+    ledger: SourceLedger | None,
+    writer: VaultWriter,
+    parsed: ParsedFragment,
+    fragment: Fragment,
+    body: str,
+) -> Path:
+    """Write the fragment, or update the existing one in place on edit (#673).
+
+    When the ledger already maps this source unit to a fragment and the
+    content has *changed*, reuse that fragment id and rewrite it in place
+    (preserving classifications/links). Unchanged content falls through to
+    the normal write, where the deterministic id makes it an idempotent
+    no-op. A new unit is written fresh.
+    """
+    record = _ledger_record(ledger, fragment)
+    if (
+        record is not None
+        and ledger is not None
+        and record.content_hash != ledger.content_hash(parsed.content)
+    ):
+        fragment.id = record.fragment_id
+        updated = writer.update_fragment(fragment, body)
+        if updated is not None:
+            return updated
+    return writer.write_fragment(fragment, body=body)
+
+
 def _run_ingest(
     *,
     ingestor_cls: type[Ingestor],
@@ -406,7 +448,13 @@ def _run_ingest(
             continue
         _attach_origin_key(ledger, parsed, assembled.fragment, vault_path)
         try:
-            writer.write_fragment(assembled.fragment, body=assembled.body)
+            _write_fragment_idempotent(
+                ledger,
+                writer,
+                parsed,
+                assembled.fragment,
+                assembled.body,
+            )
         except (OSError, KeyError) as exc:
             errors.append(
                 f"[{source_type}] failed to write {assembled.fragment.id}: {exc}",

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -390,6 +390,9 @@ def _write_fragment_idempotent(
     record = _ledger_record(ledger, fragment)
     if (
         record is not None
+        # `ledger is not None` is guaranteed when record is not None
+        # (_ledger_record returns None for a missing ledger); kept for mypy
+        # narrowing of the `ledger.content_hash` call below.
         and ledger is not None
         and record.content_hash != ledger.content_hash(parsed.content)
     ):
@@ -448,7 +451,9 @@ def _run_ingest(
             continue
         _attach_origin_key(ledger, parsed, assembled.fragment, vault_path)
         try:
-            _write_fragment_idempotent(
+            # The written/updated path is intentionally unused — callers only
+            # need the written count and error list.
+            _ = _write_fragment_idempotent(
                 ledger,
                 writer,
                 parsed,

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -554,6 +554,54 @@ class VaultWriter:
         target_dir = self.vault_path / "01-Fragments" / subfolder
         return self._write_model(fragment, target_dir, body=body)
 
+    def _fragment_target_dir(self, fragment: Fragment) -> Path:
+        """Return the vault directory a fragment routes to (#673).
+
+        Mirrors :meth:`write_fragment`: a borrowed fragment
+        (``source.author_slug`` set) lives under ``11-Other-Authors/<slug>/``;
+        a native fragment routes by source platform into
+        ``01-Fragments/<subfolder>/``.
+        """
+        slug = fragment.source.author_slug
+        if slug:
+            return self.vault_path / OTHER_AUTHORS_DIR / slug
+        subfolder = _PLATFORM_SUBFOLDER[str(fragment.source.platform)]
+        return self.vault_path / "01-Fragments" / subfolder
+
+    def update_fragment(self, fragment: Fragment, body: str) -> Path | None:
+        """Rewrite an existing fragment's body in place, or return ``None``.
+
+        Locates the file already mapped to ``fragment.id`` (via the per-dir
+        id index) and rewrites **only its body**, preserving the on-disk
+        frontmatter verbatim — id, classifications (OPS-001), resonance links,
+        and ``source.origin_key``. This is the changed-branch of idempotent
+        mutable-source ingest (#673): an edited journal entry updates the same
+        fragment instead of minting a new id and orphaning the old one.
+
+        Returns ``None`` when no file is mapped to ``fragment.id`` (e.g. the
+        file was removed out of band), so the caller can fall back to a fresh
+        :meth:`write_fragment`.
+
+        Args:
+            fragment: The fragment whose id locates the existing file and
+                whose platform/slug routes the lookup directory.
+            body: The new markdown body to write below the preserved
+                frontmatter.
+
+        Returns:
+            Path to the rewritten file, or ``None`` when no existing file
+            maps to the id.
+        """
+        target_dir = self._fragment_target_dir(fragment)
+        with self._lock:
+            existing = self._find_existing_locked(fragment.id, target_dir)
+            if existing is None:
+                return None
+            post = frontmatter.load(str(existing))
+            post.content = body
+            _atomic_write_text(existing, frontmatter.dumps(post))
+        return existing
+
     def write_thread(self, thread: Thread) -> Path:
         """Write a Thread to 02-Threads/{status}/.
 

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -540,6 +540,7 @@ class VaultWriter:
         Returns:
             Path to the written (or existing duplicate) markdown file.
         """
+        target_dir = self._fragment_target_dir(fragment)
         slug = fragment.source.author_slug
         if slug:
             # The helper returns a stamped copy, so the caller's Fragment is
@@ -547,20 +548,17 @@ class VaultWriter:
             # attribution (#470).
             manifest = load_author_manifest_or_default(self.vault_path, slug)
             stamped = _apply_other_author_attribution(fragment, manifest)
-            target_dir = self.vault_path / OTHER_AUTHORS_DIR / slug
             return self._write_model(stamped, target_dir, body=body)
-        platform = fragment.source.platform
-        subfolder = _PLATFORM_SUBFOLDER[str(platform)]
-        target_dir = self.vault_path / "01-Fragments" / subfolder
         return self._write_model(fragment, target_dir, body=body)
 
     def _fragment_target_dir(self, fragment: Fragment) -> Path:
         """Return the vault directory a fragment routes to (#673).
 
-        Mirrors :meth:`write_fragment`: a borrowed fragment
-        (``source.author_slug`` set) lives under ``11-Other-Authors/<slug>/``;
-        a native fragment routes by source platform into
-        ``01-Fragments/<subfolder>/``.
+        The single source of truth for fragment routing, used by both
+        :meth:`write_fragment` and :meth:`update_fragment`: a borrowed
+        fragment (``source.author_slug`` set) lives under
+        ``11-Other-Authors/<slug>/``; a native fragment routes by source
+        platform into ``01-Fragments/<subfolder>/``.
         """
         slug = fragment.source.author_slug
         if slug:
@@ -600,6 +598,9 @@ class VaultWriter:
             post = frontmatter.load(str(existing))
             post.content = body
             _atomic_write_text(existing, frontmatter.dumps(post))
+            # Record the in-place edit in the provenance log too, so the audit
+            # trail captures subsequent rewrites — not just the original write.
+            self._log_provenance_locked(fragment.id, fragment.type, existing)
         return existing
 
     def write_thread(self, thread: Thread) -> Path:

--- a/creek-tools/tests/test_ingest_update_in_place.py
+++ b/creek-tools/tests/test_ingest_update_in_place.py
@@ -103,6 +103,27 @@ class TestUpdateFragment:
         writer = VaultWriter(vault_path=vault)
         assert writer.update_fragment(ghost, body="x") is None
 
+    def test_target_dir_routes_native_and_borrowed(self, tmp_path: Path) -> None:
+        """Routing is the single source of truth for native + borrowed authors."""
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        native = Fragment(
+            id="frag-n",
+            title="N",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        borrowed = Fragment(
+            id="frag-b",
+            title="B",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL, author_slug="ada"),
+        )
+        assert writer._fragment_target_dir(native) == (
+            vault / "01-Fragments" / "Journal"
+        )
+        assert writer._fragment_target_dir(borrowed) == (
+            vault / "11-Other-Authors" / "ada"
+        )
+
 
 # ---- End-to-end: ledger-driven changed branch --------------------------
 
@@ -118,7 +139,8 @@ class TestEditedJournalUpdatesInPlace:
             "---\ndate: 2026-06-26\n---\nFirst draft of today.\n",
             encoding="utf-8",
         )
-        _ingest(vault, entry)
+        _, errors, _ = _ingest(vault, entry)
+        assert errors == []
 
         files = _journal_files(vault)
         assert len(files) == 1
@@ -131,7 +153,8 @@ class TestEditedJournalUpdatesInPlace:
             "---\ndate: 2026-06-26\n---\nSecond, revised draft of today.\n",
             encoding="utf-8",
         )
-        _ingest(vault, entry)
+        _, errors, _ = _ingest(vault, entry)
+        assert errors == []
 
         files_after = _journal_files(vault)
         assert len(files_after) == 1  # no duplicate, no orphan
@@ -161,3 +184,45 @@ class TestEditedJournalUpdatesInPlace:
         files = _journal_files(vault)
         assert len(files) == 1
         assert frontmatter.load(str(files[0]))["id"] == first
+
+    def test_edit_after_out_of_band_delete_recreates_with_preserved_id(
+        self, tmp_path: Path
+    ) -> None:
+        """If the vault fragment vanished, an edit re-creates it with the same id.
+
+        Exercises the ``update_fragment → None`` fallback: the ledger still maps
+        the source unit to its id, the file is gone, and the changed-branch must
+        fall back to a fresh write under the *preserved* id (not a new one).
+        """
+        vault = _make_vault(tmp_path)
+        entry = vault / "personal" / "journal" / "2026-06-26.md"
+        entry.write_text(
+            "---\ndate: 2026-06-26\n---\nFirst draft.\n",
+            encoding="utf-8",
+        )
+        _, errors, _ = _ingest(vault, entry)
+        assert errors == []
+        original_id = frontmatter.load(str(_journal_files(vault)[0]))["id"]
+
+        # The vault fragment disappears out of band (the ledger still knows it).
+        _journal_files(vault)[0].unlink()
+        assert _journal_files(vault) == []
+
+        # Edit the source and re-ingest -> fallback write under the preserved id.
+        entry.write_text(
+            "---\ndate: 2026-06-26\n---\nRewritten after loss.\n",
+            encoding="utf-8",
+        )
+        _, errors, _ = _ingest(vault, entry)
+        assert errors == []
+
+        files = _journal_files(vault)
+        assert len(files) == 1
+        post = frontmatter.load(str(files[0]))
+        assert post["id"] == original_id  # preserved id, not a new hash
+        assert "Rewritten after loss" in post.content
+
+        ledger = SourceLedger.load(vault, source="markdown")
+        rec = ledger.get("personal/journal/2026-06-26.md")
+        assert rec is not None
+        assert rec.fragment_id == original_id

--- a/creek-tools/tests/test_ingest_update_in_place.py
+++ b/creek-tools/tests/test_ingest_update_in_place.py
@@ -1,0 +1,163 @@
+"""Update-in-place for edited mutable source units (#673).
+
+When a markdown (journal) source unit with an existing ``source_key`` is
+re-ingested with *changed* content, the existing fragment is rewritten in
+place — same fragment id, classifications and links preserved — instead of a
+new fragment being minted and the old one orphaned (SPEC R1, decision #1).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.cli import _run_ingest
+from creek.ingest import INGESTOR_REGISTRY
+from creek.ingest.ledger import SourceLedger
+from creek.models import Fragment, FragmentSource, SourcePlatform
+from creek.vault.writer import VaultWriter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Scaffold a minimal vault for ingest + update."""
+    vault = tmp_path / "vault"
+    for d in (
+        "00-Creek-Meta/Processing-Log",
+        "01-Fragments/Journal",
+        "01-Fragments/Notes",
+        "personal/journal",
+    ):
+        (vault / d).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _ingest(vault: Path, entry: Path) -> tuple[int, list[str], int]:
+    """Run the markdown ingestor through the real ``_run_ingest`` seam."""
+    return _run_ingest(
+        ingestor_cls=INGESTOR_REGISTRY["markdown"],
+        source_type="markdown",
+        input_path=entry,
+        vault_path=vault,
+    )
+
+
+def _journal_files(vault: Path) -> list[Path]:
+    """Every fragment file written under ``01-Fragments``."""
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+def _set_frontmatter(path: Path, **fields: object) -> None:
+    """Overlay extra frontmatter keys onto an existing fragment file."""
+    post = frontmatter.load(str(path))
+    for key, value in fields.items():
+        post[key] = value
+    path.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+# ---- VaultWriter.update_fragment (unit) --------------------------------
+
+
+class TestUpdateFragment:
+    """In-place body rewrite preserves frontmatter; missing file -> None."""
+
+    def _seed(self, vault: Path) -> Fragment:
+        """Write one native journal fragment and return its model."""
+        frag = Fragment(
+            id="frag-fixed001",
+            title="Day",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        VaultWriter(vault_path=vault).write_fragment(frag, body="original body")
+        return frag
+
+    def test_update_rewrites_body_preserving_frontmatter(self, tmp_path: Path) -> None:
+        """The body changes; id and on-disk classification survive."""
+        vault = _make_vault(tmp_path)
+        frag = self._seed(vault)
+        path = _journal_files(vault)[0]
+        _set_frontmatter(path, classification_method="llm", tags=["insight"])
+
+        writer = VaultWriter(vault_path=vault)
+        updated = writer.update_fragment(frag, body="revised body")
+
+        assert updated == path  # same file, in place
+        post = frontmatter.load(str(path))
+        assert "revised body" in post.content
+        assert "original body" not in post.content
+        assert post["id"] == "frag-fixed001"
+        assert post["classification_method"] == "llm"
+        assert post["tags"] == ["insight"]
+
+    def test_update_returns_none_when_no_existing_file(self, tmp_path: Path) -> None:
+        """Updating an id with no mapped file returns None (caller falls back)."""
+        vault = _make_vault(tmp_path)
+        ghost = Fragment(
+            id="frag-missing99",
+            title="Ghost",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        writer = VaultWriter(vault_path=vault)
+        assert writer.update_fragment(ghost, body="x") is None
+
+
+# ---- End-to-end: ledger-driven changed branch --------------------------
+
+
+class TestEditedJournalUpdatesInPlace:
+    """An edited journal entry updates the same fragment, not a duplicate."""
+
+    def test_edit_updates_same_fragment_id(self, tmp_path: Path) -> None:
+        """Editing a journal entry preserves id + classifications, no orphan."""
+        vault = _make_vault(tmp_path)
+        entry = vault / "personal" / "journal" / "2026-06-26.md"
+        entry.write_text(
+            "---\ndate: 2026-06-26\n---\nFirst draft of today.\n",
+            encoding="utf-8",
+        )
+        _ingest(vault, entry)
+
+        files = _journal_files(vault)
+        assert len(files) == 1
+        original_id = frontmatter.load(str(files[0]))["id"]
+        # Simulate prior classification work that must survive the edit.
+        _set_frontmatter(files[0], classification_method="llm", tags=["insight"])
+
+        # Edit the SAME source unit (same source_key), new content.
+        entry.write_text(
+            "---\ndate: 2026-06-26\n---\nSecond, revised draft of today.\n",
+            encoding="utf-8",
+        )
+        _ingest(vault, entry)
+
+        files_after = _journal_files(vault)
+        assert len(files_after) == 1  # no duplicate, no orphan
+        post = frontmatter.load(str(files_after[0]))
+        assert post["id"] == original_id  # id preserved
+        assert "revised draft" in post.content  # body updated
+        assert post["classification_method"] == "llm"  # OPS-001 preserved
+        assert post["tags"] == ["insight"]  # tags preserved
+
+        ledger = SourceLedger.load(vault, source="markdown")
+        rec = ledger.get("personal/journal/2026-06-26.md")
+        assert rec is not None
+        assert rec.fragment_id == original_id  # ledger still maps to same id
+
+    def test_unchanged_reingest_remains_noop(self, tmp_path: Path) -> None:
+        """Re-ingesting identical content writes no duplicate and no rewrite."""
+        vault = _make_vault(tmp_path)
+        entry = vault / "personal" / "journal" / "2026-06-26.md"
+        entry.write_text(
+            "---\ndate: 2026-06-26\n---\nStable content.\n",
+            encoding="utf-8",
+        )
+        _ingest(vault, entry)
+        first = frontmatter.load(str(_journal_files(vault)[0]))["id"]
+        _ingest(vault, entry)
+
+        files = _journal_files(vault)
+        assert len(files) == 1
+        assert frontmatter.load(str(files[0]))["id"] == first


### PR DESCRIPTION
## Summary

The headline correctness fix of epic #668: an **edited journal entry now updates the same fragment** instead of minting a new content-hashed id and orphaning the old one (SPEC §2.2 root cause, R1 changed-branch, decision #1 = update in place). Makes the #672 ledger load-bearing.

### What's here
- **`VaultWriter.update_fragment(fragment, body)`** — locates the file already mapped to `fragment.id` (via the per-dir id index) and rewrites **only its body** through the existing atomic temp+`os.replace` primitive, preserving the on-disk frontmatter verbatim: id, classifications (OPS-001), resonance links, `source.origin_key`. Returns `None` when no file maps to the id, so the caller falls back to a fresh write. Extracts `_fragment_target_dir`, shared with `write_fragment`.
- **`_run_ingest` changed-branch** (`_write_fragment_idempotent`): when the ledger maps this source unit to a fragment and the content hash *changed*, reuse that `fragment_id` and update in place; unchanged content falls through to the normal write where the deterministic id makes it an idempotent no-op; a new unit is written fresh. The ledger records the new content hash.

## Test plan
`tests/test_ingest_update_in_place.py` (4 tests):
- **Writer unit:** `update_fragment` rewrites the body while preserving id + on-disk `classification_method`/`tags`; returns `None` when no file maps to the id.
- **End-to-end (the headline invariant):** ingest a journal entry → stamp a classification → edit the file → re-ingest ⇒ **still one fragment, same id, body updated, `classification_method`/`tags` preserved, ledger still maps to the same id**.
- Unchanged re-ingest remains a no-op.

`./scripts/check-all.sh`: **12/12 gates green** (mypy strict, complexity ≤10, per-file coverage).

## Scope
No orphan/tomb detection (a vanished `source_key` is #674); no material-change reclassify threshold or ingest summary (#675 — updates here always preserve classifications); append-only sources and `generate_fragment_id` untouched.

Refs #668
Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)