### PR TITLE
feat(ingest): soft-tomb orphaned fragments on source deletion (#674)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -372,6 +372,27 @@ def _ledger_record(
     return ledger.get(origin_key)
 
 
+def _restore_tombed(
+    writer: VaultWriter,
+    fragment: Fragment,
+    record: LedgerRecord,
+    body: str,
+) -> Path | None:
+    """Un-tomb a re-appeared source unit and apply its body (#674).
+
+    Reuses the preserved fragment id, moves the tombed fragment back into its
+    routing directory, then rewrites the (possibly edited) body in place.
+    Returns ``None`` when no tombed file maps to the id, so the caller falls
+    back to a fresh write under the preserved id.
+    """
+    fragment.id = record.fragment_id
+    restored = writer.restore_fragment(fragment)
+    if restored is None:
+        return None
+    updated = writer.update_fragment(fragment, body)
+    return updated if updated is not None else restored
+
+
 def _write_fragment_idempotent(
     ledger: SourceLedger | None,
     writer: VaultWriter,
@@ -388,19 +409,48 @@ def _write_fragment_idempotent(
     no-op. A new unit is written fresh.
     """
     record = _ledger_record(ledger, fragment)
-    if (
-        record is not None
-        # `ledger is not None` is guaranteed when record is not None
-        # (_ledger_record returns None for a missing ledger); kept for mypy
-        # narrowing of the `ledger.content_hash` call below.
-        and ledger is not None
-        and record.content_hash != ledger.content_hash(parsed.content)
-    ):
+    # `record is not None` guarantees `ledger is not None` (_ledger_record
+    # returns None for a missing ledger); the explicit guard narrows for mypy.
+    if record is None or ledger is None:
+        return writer.write_fragment(fragment, body=body)
+    if record.tombed:
+        restored = _restore_tombed(writer, fragment, record, body)
+        if restored is not None:
+            return restored
+    elif record.content_hash != ledger.content_hash(parsed.content):
         fragment.id = record.fragment_id
         updated = writer.update_fragment(fragment, body)
         if updated is not None:
             return updated
     return writer.write_fragment(fragment, body=body)
+
+
+def _tomb_missing_units(
+    ledger: SourceLedger | None,
+    writer: VaultWriter,
+    input_path: Path,
+    seen_keys: set[str],
+) -> None:
+    """Soft-tomb ledgered units absent from a full-source pass (#674).
+
+    Only a directory (full-source) input computes a gone set; a single-file
+    ``--input`` run never tombs — that guards the incremental epic from
+    tombing every other unit when re-ingesting one file.
+    """
+    if ledger is None or not input_path.is_dir():
+        return
+    for source_key in sorted(ledger.live_keys() - seen_keys):
+        record = ledger.get(source_key)
+        if record is None:
+            continue
+        writer.tomb_fragment(record.fragment_id)
+        ledger.record(
+            source_key,
+            record.fragment_id,
+            record.content_hash,
+            last_seen=record.last_seen,
+            tombed=True,
+        )
 
 
 def _run_ingest(
@@ -440,6 +490,7 @@ def _run_ingest(
 
     errors: list[str] = [f"[{source_type}] {err}" for err in ingest_result.errors]
     written = 0
+    seen_keys: set[str] = set()
     for parsed in ingest_result.fragments:
         try:
             assembled = assemble_ingested_fragment(parsed)
@@ -450,6 +501,9 @@ def _run_ingest(
             )
             continue
         _attach_origin_key(ledger, parsed, assembled.fragment, vault_path)
+        origin_key = assembled.fragment.source.origin_key
+        if origin_key is not None:
+            seen_keys.add(origin_key)
         try:
             # The written/updated path is intentionally unused — callers only
             # need the written count and error list.
@@ -468,6 +522,7 @@ def _run_ingest(
         _record_in_ledger(ledger, parsed, assembled.fragment)
         written += 1
 
+    _tomb_missing_units(ledger, writer, input_path, seen_keys)
     return written, errors, ingest_result.discovered
 
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -377,18 +377,22 @@ def _restore_tombed(
     fragment: Fragment,
     record: LedgerRecord,
     body: str,
+    new_hash: str,
 ) -> Path | None:
     """Un-tomb a re-appeared source unit and apply its body (#674).
 
-    Reuses the preserved fragment id, moves the tombed fragment back into its
-    routing directory, then rewrites the (possibly edited) body in place.
-    Returns ``None`` when no tombed file maps to the id, so the caller falls
-    back to a fresh write under the preserved id.
+    Reuses the preserved fragment id and moves the tombed fragment back into
+    its routing directory. Only when the content actually changed does it
+    rewrite the body in place — an unchanged re-appearance restores without a
+    redundant write. Returns ``None`` when no tombed file maps to the id, so
+    the caller falls back to a fresh write under the preserved id.
     """
     fragment.id = record.fragment_id
     restored = writer.restore_fragment(fragment)
     if restored is None:
         return None
+    if new_hash == record.content_hash:
+        return restored
     updated = writer.update_fragment(fragment, body)
     return updated if updated is not None else restored
 
@@ -413,11 +417,12 @@ def _write_fragment_idempotent(
     # returns None for a missing ledger); the explicit guard narrows for mypy.
     if record is None or ledger is None:
         return writer.write_fragment(fragment, body=body)
+    new_hash = ledger.content_hash(parsed.content)
     if record.tombed:
-        restored = _restore_tombed(writer, fragment, record, body)
+        restored = _restore_tombed(writer, fragment, record, body, new_hash)
         if restored is not None:
             return restored
-    elif record.content_hash != ledger.content_hash(parsed.content):
+    elif record.content_hash != new_hash:
         fragment.id = record.fragment_id
         updated = writer.update_fragment(fragment, body)
         if updated is not None:
@@ -430,12 +435,18 @@ def _tomb_missing_units(
     writer: VaultWriter,
     input_path: Path,
     seen_keys: set[str],
+    errors: list[str],
+    source_type: str,
 ) -> None:
     """Soft-tomb ledgered units absent from a full-source pass (#674).
 
     Only a directory (full-source) input computes a gone set; a single-file
     ``--input`` run never tombs — that guards the incremental epic from
     tombing every other unit when re-ingesting one file.
+
+    A tomb that fails on I/O is collected into *errors* (matching the
+    per-fragment write path) and the unit is left live in the ledger so the
+    next full-source pass retries it, rather than crashing the whole run.
     """
     if ledger is None or not input_path.is_dir():
         return
@@ -443,7 +454,13 @@ def _tomb_missing_units(
         record = ledger.get(source_key)
         if record is None:
             continue
-        writer.tomb_fragment(record.fragment_id)
+        try:
+            writer.tomb_fragment(record.fragment_id)
+        except (OSError, KeyError) as exc:
+            errors.append(
+                f"[{source_type}] failed to tomb {record.fragment_id}: {exc}",
+            )
+            continue
         ledger.record(
             source_key,
             record.fragment_id,
@@ -522,7 +539,7 @@ def _run_ingest(
         _record_in_ledger(ledger, parsed, assembled.fragment)
         written += 1
 
-    _tomb_missing_units(ledger, writer, input_path, seen_keys)
+    _tomb_missing_units(ledger, writer, input_path, seen_keys, errors, source_type)
     return written, errors, ingest_result.discovered
 
 

--- a/creek-tools/creek/ingest/ledger.py
+++ b/creek-tools/creek/ingest/ledger.py
@@ -36,12 +36,16 @@ class LedgerRecord:
         fragment_id: The fragment id that unit currently maps to.
         content_hash: SHA-256 of the source content at last ingest.
         last_seen: ISO-8601 timestamp of the last ingest of this unit.
+        tombed: ``True`` when the source unit has vanished and its fragment
+            was soft-tombed to ``10-Liminal/Orphaned/`` (#674). Excluded from
+            :meth:`SourceLedger.live_keys`; a re-appearance restores it.
     """
 
     source_key: str
     fragment_id: str
     content_hash: str
     last_seen: str
+    tombed: bool = False
 
 
 class SourceLedger:
@@ -123,6 +127,7 @@ class SourceLedger:
             fragment_id=fragment_id,
             content_hash=content_hash,
             last_seen=last_seen,
+            tombed=bool(data.get("tombed", False)),
         )
 
     @classmethod
@@ -143,6 +148,10 @@ class SourceLedger:
         """Return the current record for *source_key*, or ``None``."""
         return self._records.get(source_key)
 
+    def live_keys(self) -> set[str]:
+        """Return the tracked source keys that are not tombed (#674)."""
+        return {key for key, rec in self._records.items() if not rec.tombed}
+
     def __len__(self) -> int:
         """Return the number of distinct source keys tracked."""
         return len(self._records)
@@ -158,6 +167,7 @@ class SourceLedger:
         content_hash: str,
         *,
         last_seen: str | None = None,
+        tombed: bool = False,
     ) -> LedgerRecord:
         """Upsert a source unit's state, appending a line and updating memory.
 
@@ -167,6 +177,7 @@ class SourceLedger:
             content_hash: SHA-256 of the source content (see
                 :meth:`content_hash`).
             last_seen: ISO timestamp; defaults to the current UTC time.
+            tombed: Whether the unit is soft-tombed (vanished from source).
 
         Returns:
             The :class:`LedgerRecord` that was written.
@@ -176,6 +187,7 @@ class SourceLedger:
             fragment_id=fragment_id,
             content_hash=content_hash,
             last_seen=last_seen or datetime.now(UTC).isoformat(),
+            tombed=tombed,
         )
         self._records[source_key] = record
         self._append(record)
@@ -190,6 +202,7 @@ class SourceLedger:
                 "fragment_id": record.fragment_id,
                 "content_hash": record.content_hash,
                 "last_seen": record.last_seen,
+                "tombed": record.tombed,
             },
         )
         with self._path.open("a", encoding="utf-8") as handle:

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -78,6 +78,9 @@ _PLATFORM_SUBFOLDER: dict[str, str] = {
     SourcePlatform.OTHER: "Unsorted",
 }
 
+# Destination for soft-tombed fragments whose source unit has vanished (#674).
+_ORPHANED_RELPARTS: tuple[str, ...] = ("10-Liminal", "Orphaned")
+
 # Map an AuthorManifest.author_kind -> the fragment's Authorship axis (#470).
 # Any unrecognised kind (the manifest already fails closed to ``human_source``)
 # resolves to OTHER via ``.get(..., Authorship.OTHER)`` at the call site.
@@ -602,6 +605,90 @@ class VaultWriter:
             # trail captures subsequent rewrites — not just the original write.
             self._log_provenance_locked(fragment.id, fragment.type, existing)
         return existing
+
+    def _find_in_fragments_locked(self, fragment_id: str) -> Path | None:
+        """Return the live fragment file for *fragment_id* under 01-Fragments.
+
+        Caller must hold ``self._lock``. Scans each platform subfolder's id
+        index so a tomb does not need to know which subfolder a fragment
+        landed in.
+        """
+        fragments_root = self.vault_path / "01-Fragments"
+        if not fragments_root.is_dir():
+            return None
+        for subdir in sorted(p for p in fragments_root.iterdir() if p.is_dir()):
+            found = self._find_existing_locked(fragment_id, subdir)
+            if found is not None:
+                return found
+        return None
+
+    def tomb_fragment(self, fragment_id: str) -> Path | None:
+        """Soft-tomb a fragment: move it to ``10-Liminal/Orphaned/`` (#674).
+
+        Relocates the live fragment file for *fragment_id* into the orphaned
+        directory and stamps ``lifecycle: orphaned`` + ``orphaned_at`` into its
+        frontmatter, so a deleted source unit is reflected without hard-deleting
+        the fragment. Returns the tombed path, or ``None`` when no live fragment
+        maps to the id (already moved/removed).
+
+        Args:
+            fragment_id: Id of the fragment to soft-tomb.
+
+        Returns:
+            Path to the tombed file, or ``None`` if no live fragment was found.
+        """
+        orphan_dir = self.vault_path.joinpath(*_ORPHANED_RELPARTS)
+        with self._lock:
+            existing = self._find_in_fragments_locked(fragment_id)
+            if existing is None:
+                return None
+            post = frontmatter.load(str(existing))
+            post["lifecycle"] = "orphaned"
+            post["orphaned_at"] = datetime.now(UTC).isoformat()
+            orphan_dir.mkdir(parents=True, exist_ok=True)
+            dest = orphan_dir / existing.name
+            _atomic_write_text(dest, frontmatter.dumps(post))
+            existing.unlink()
+            index = self._load_index_locked(orphan_dir)
+            index[fragment_id] = dest.name
+            self._append_index_entry(orphan_dir, fragment_id, dest.name)
+            self._log_provenance_locked(fragment_id, "fragment", dest)
+        return dest
+
+    def restore_fragment(self, fragment: Fragment) -> Path | None:
+        """Un-tomb a fragment: move it back from ``10-Liminal/Orphaned/`` (#674).
+
+        Relocates the tombed file for ``fragment.id`` back to its routing
+        directory and clears the ``lifecycle``/``orphaned_at`` marker, so a
+        re-appeared source unit becomes a live fragment again under its
+        preserved id. Returns the restored path, or ``None`` when no tombed
+        file maps to the id.
+
+        Args:
+            fragment: The fragment whose id locates the tombed file and whose
+                platform/slug routes the restore destination.
+
+        Returns:
+            Path to the restored file, or ``None`` if no tombed file was found.
+        """
+        orphan_dir = self.vault_path.joinpath(*_ORPHANED_RELPARTS)
+        target_dir = self._fragment_target_dir(fragment)
+        with self._lock:
+            existing = self._find_existing_locked(fragment.id, orphan_dir)
+            if existing is None:
+                return None
+            post = frontmatter.load(str(existing))
+            post.metadata.pop("lifecycle", None)
+            post.metadata.pop("orphaned_at", None)
+            target_dir.mkdir(parents=True, exist_ok=True)
+            dest = target_dir / existing.name
+            _atomic_write_text(dest, frontmatter.dumps(post))
+            existing.unlink()
+            index = self._load_index_locked(target_dir)
+            index[fragment.id] = dest.name
+            self._append_index_entry(target_dir, fragment.id, dest.name)
+            self._log_provenance_locked(fragment.id, fragment.type, dest)
+        return dest
 
     def write_thread(self, thread: Thread) -> Path:
         """Write a Thread to 02-Threads/{status}/.

--- a/creek-tools/tests/test_ingest_orphan_tomb.py
+++ b/creek-tools/tests/test_ingest_orphan_tomb.py
@@ -1,0 +1,202 @@
+"""Soft-tomb + restore for vanished mutable source units (#674).
+
+On a *full-source* markdown ingest pass, a ledgered ``source_key`` that is no
+longer present is soft-tombed: its fragment moves to ``10-Liminal/Orphaned/``
+and is marked ``lifecycle: orphaned``. A re-run is idempotent (no re-tomb), and
+a re-added source unit restores the live fragment under its preserved id. A
+single-file ``--input`` run never tombs (guards the incremental epic).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.cli import _run_ingest
+from creek.ingest import INGESTOR_REGISTRY
+from creek.ingest.ledger import SourceLedger
+from creek.models import Fragment, FragmentSource, SourcePlatform
+from creek.vault.writer import VaultWriter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Scaffold a minimal vault for ingest + tomb/restore."""
+    vault = tmp_path / "vault"
+    for d in (
+        "00-Creek-Meta/Processing-Log",
+        "01-Fragments/Journal",
+        "01-Fragments/Notes",
+        "10-Liminal/Orphaned",
+        "personal/journal",
+    ):
+        (vault / d).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _ingest(vault: Path, target: Path) -> tuple[int, list[str], int]:
+    """Run the markdown ingestor over *target* (a dir = full-source pass)."""
+    return _run_ingest(
+        ingestor_cls=INGESTOR_REGISTRY["markdown"],
+        source_type="markdown",
+        input_path=target,
+        vault_path=vault,
+    )
+
+
+def _journal_files(vault: Path) -> list[Path]:
+    """Live fragment files under ``01-Fragments``."""
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+def _orphan_files(vault: Path) -> list[Path]:
+    """Tombed fragment files under ``10-Liminal/Orphaned``."""
+    return sorted((vault / "10-Liminal" / "Orphaned").rglob("*.md"))
+
+
+def _journal_fragment(platform: SourcePlatform = SourcePlatform.JOURNAL) -> Fragment:
+    """Build a native journal fragment with a fixed id."""
+    return Fragment(
+        id="frag-fixed01", title="Day", source=FragmentSource(platform=platform)
+    )
+
+
+# ---- Ledger tombed flag -------------------------------------------------
+
+
+class TestLedgerTombed:
+    """The ledger tracks tombed state and excludes it from live keys."""
+
+    def test_tombed_roundtrips_and_live_keys_excludes(self, tmp_path: Path) -> None:
+        """A tombed record reloads tombed and is absent from live_keys()."""
+        ledger = SourceLedger.load(tmp_path, source="markdown")
+        ledger.record("a.md", "frag-a", "h1", tombed=False)
+        ledger.record("b.md", "frag-b", "h2", tombed=True)
+
+        reloaded = SourceLedger.load(tmp_path, source="markdown")
+        rec_b = reloaded.get("b.md")
+        assert rec_b is not None
+        assert rec_b.tombed is True
+        assert reloaded.live_keys() == {"a.md"}
+
+
+# ---- Writer tomb / restore (unit) --------------------------------------
+
+
+class TestTombAndRestore:
+    """`tomb_fragment` moves+marks; `restore_fragment` moves back+clears."""
+
+    def test_tomb_moves_and_marks(self, tmp_path: Path) -> None:
+        """Tombing relocates the fragment and stamps the orphan marker."""
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        writer.write_fragment(_journal_fragment(), body="body")
+
+        tombed = writer.tomb_fragment("frag-fixed01")
+
+        assert tombed is not None
+        assert tombed.parent == vault / "10-Liminal" / "Orphaned"
+        assert _journal_files(vault) == []  # moved out of 01-Fragments
+        post = frontmatter.load(str(tombed))
+        assert post["id"] == "frag-fixed01"
+        assert post["lifecycle"] == "orphaned"
+        assert post["orphaned_at"]
+
+    def test_tomb_missing_returns_none(self, tmp_path: Path) -> None:
+        """Tombing an unmapped id is a no-op returning None."""
+        vault = _make_vault(tmp_path)
+        assert VaultWriter(vault_path=vault).tomb_fragment("frag-nope") is None
+
+    def test_restore_moves_back_and_clears_marker(self, tmp_path: Path) -> None:
+        """Restoring relocates back and removes the orphan marker."""
+        vault = _make_vault(tmp_path)
+        writer = VaultWriter(vault_path=vault)
+        frag = _journal_fragment()
+        writer.write_fragment(frag, body="body")
+        writer.tomb_fragment("frag-fixed01")
+
+        restored = writer.restore_fragment(frag)
+
+        assert restored is not None
+        assert restored.parent == vault / "01-Fragments" / "Journal"
+        assert _orphan_files(vault) == []
+        post = frontmatter.load(str(restored))
+        assert "lifecycle" not in post.metadata
+        assert "orphaned_at" not in post.metadata
+
+    def test_restore_missing_returns_none(self, tmp_path: Path) -> None:
+        """Restoring with no tombed file returns None."""
+        vault = _make_vault(tmp_path)
+        assert (
+            VaultWriter(vault_path=vault).restore_fragment(_journal_fragment()) is None
+        )
+
+
+# ---- End-to-end: delete -> tomb -> restore -----------------------------
+
+
+class TestOrphanLifecycle:
+    """A deleted journal entry is tombed, idempotently, then restored."""
+
+    def test_deleted_then_restored(self, tmp_path: Path) -> None:
+        """Delete soft-tombs; re-run is a no-op; re-add restores same id."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        entry = journal / "2026-06-26.md"
+        entry.write_text(
+            "---\ndate: 2026-06-26\n---\nToday's entry.\n", encoding="utf-8"
+        )
+        _, errors, _ = _ingest(vault, journal)
+        assert errors == []
+        frag_id = frontmatter.load(str(_journal_files(vault)[0]))["id"]
+
+        # Delete the source unit, re-run the full-source pass.
+        entry.unlink()
+        _, errors, _ = _ingest(vault, journal)
+        assert errors == []
+        assert _journal_files(vault) == []  # no longer live
+        orphans = _orphan_files(vault)
+        assert len(orphans) == 1
+        tombed = frontmatter.load(str(orphans[0]))
+        assert tombed["id"] == frag_id
+        assert tombed["lifecycle"] == "orphaned"
+
+        # Idempotent: a second run neither errors nor re-tombs.
+        _, errors, _ = _ingest(vault, journal)
+        assert errors == []
+        assert len(_orphan_files(vault)) == 1
+
+        # Re-add the source unit -> live fragment restored with same id.
+        entry.write_text(
+            "---\ndate: 2026-06-26\n---\nToday's entry, back again.\n",
+            encoding="utf-8",
+        )
+        _, errors, _ = _ingest(vault, journal)
+        assert errors == []
+        live = _journal_files(vault)
+        assert len(live) == 1
+        post = frontmatter.load(str(live[0]))
+        assert post["id"] == frag_id
+        assert "back again" in post.content
+        assert _orphan_files(vault) == []
+
+    def test_single_file_input_does_not_tomb(self, tmp_path: Path) -> None:
+        """A single-file --input run must not tomb other units (incremental guard)."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        a = journal / "2026-06-01.md"
+        b = journal / "2026-06-02.md"
+        a.write_text("---\ndate: 2026-06-01\n---\nEntry A.\n", encoding="utf-8")
+        b.write_text("---\ndate: 2026-06-02\n---\nEntry B.\n", encoding="utf-8")
+        _ingest(vault, journal)  # full-source pass: both live
+        assert len(_journal_files(vault)) == 2
+
+        # Ingest ONLY a as a single file: b is absent from this run's seen set,
+        # but a single-file input must never compute a gone set.
+        _ingest(vault, a)
+
+        assert len(_journal_files(vault)) == 2  # b untouched
+        assert _orphan_files(vault) == []

--- a/creek-tools/tests/test_ingest_orphan_tomb.py
+++ b/creek-tools/tests/test_ingest_orphan_tomb.py
@@ -22,6 +22,8 @@ from creek.vault.writer import VaultWriter
 if TYPE_CHECKING:
     from pathlib import Path
 
+    import pytest
+
 
 def _make_vault(tmp_path: Path) -> Path:
     """Scaffold a minimal vault for ingest + tomb/restore."""
@@ -200,3 +202,84 @@ class TestOrphanLifecycle:
 
         assert len(_journal_files(vault)) == 2  # b untouched
         assert _orphan_files(vault) == []
+
+    def test_reappear_with_unchanged_content_restores_without_rewrite(
+        self, tmp_path: Path
+    ) -> None:
+        """A re-added unit with identical content is restored, not rewritten."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        entry = journal / "2026-06-26.md"
+        body = "---\ndate: 2026-06-26\n---\nUnchanging entry.\n"
+        entry.write_text(body, encoding="utf-8")
+        _ingest(vault, journal)
+        frag_id = frontmatter.load(str(_journal_files(vault)[0]))["id"]
+
+        entry.unlink()
+        _ingest(vault, journal)  # tomb
+        assert len(_orphan_files(vault)) == 1
+
+        # Re-add with IDENTICAL content -> restore-only branch (no rewrite).
+        entry.write_text(body, encoding="utf-8")
+        _, errors, _ = _ingest(vault, journal)
+        assert errors == []
+        live = _journal_files(vault)
+        assert len(live) == 1
+        post = frontmatter.load(str(live[0]))
+        assert post["id"] == frag_id
+        assert "Unchanging entry" in post.content
+        assert _orphan_files(vault) == []
+
+    def test_reappear_after_orphan_file_lost_recreates_with_preserved_id(
+        self, tmp_path: Path
+    ) -> None:
+        """If the tombstone file vanished, a re-add recreates under the same id."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        entry = journal / "2026-06-26.md"
+        entry.write_text("---\ndate: 2026-06-26\n---\nOriginal.\n", encoding="utf-8")
+        _ingest(vault, journal)
+        frag_id = frontmatter.load(str(_journal_files(vault)[0]))["id"]
+
+        entry.unlink()
+        _ingest(vault, journal)  # tomb
+        # The tombstone file is lost out of band, but the ledger still says tombed.
+        _orphan_files(vault)[0].unlink()
+
+        entry.write_text("---\ndate: 2026-06-26\n---\nReborn.\n", encoding="utf-8")
+        _, errors, _ = _ingest(vault, journal)
+        assert errors == []
+        live = _journal_files(vault)
+        assert len(live) == 1
+        post = frontmatter.load(str(live[0]))
+        assert post["id"] == frag_id  # fresh write under the preserved id
+        assert "Reborn" in post.content
+        ledger = SourceLedger.load(vault, source="markdown")
+        rec = ledger.get("personal/journal/2026-06-26.md")
+        assert rec is not None
+        assert rec.tombed is False  # ledger self-corrected
+
+    def test_tomb_oserror_is_collected_not_raised(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A tomb that fails on I/O is collected as an error, not propagated."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        entry = journal / "2026-06-26.md"
+        entry.write_text("---\ndate: 2026-06-26\n---\nDoomed.\n", encoding="utf-8")
+        _ingest(vault, journal)
+
+        def _boom(_self: VaultWriter, _fragment_id: str) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(VaultWriter, "tomb_fragment", _boom)
+        entry.unlink()
+        _, errors, _ = _ingest(vault, journal)  # must not raise
+
+        assert any("failed to tomb" in e for e in errors)
+        # Tomb failed -> the fragment is left live, ledger keeps it untombed.
+        assert len(_journal_files(vault)) == 1
+        ledger = SourceLedger.load(vault, source="markdown")
+        rec = ledger.get("personal/journal/2026-06-26.md")
+        assert rec is not None
+        assert rec.tombed is False


### PR DESCRIPTION
## Summary

The "gone" branch of epic #668: when a journal entry is **deleted** and the full source is re-ingested, its fragment is **soft-tombed** to `10-Liminal/Orphaned/` (not hard-deleted), so the vault reflects the deletion. A re-added entry **restores** the live fragment under its preserved id. Re-runs are idempotent.

### What's here
- **Ledger:** `LedgerRecord.tombed` + `SourceLedger.live_keys()` — tombed units are excluded from the live set used to compute the gone diff, and `tombed` round-trips through the JSONL (defaulting `False` for older rows).
- **Writer:** `tomb_fragment` / `restore_fragment` move a fragment to/from `10-Liminal/Orphaned/` via the existing atomic temp+`os.replace` primitive, stamping/clearing `lifecycle: orphaned` + `orphaned_at`; `_find_in_fragments_locked` scans the platform subfolders so a tomb needn't know where the fragment landed. Both log provenance.
- **Orchestration (`_run_ingest`):** tracks seen `origin_key`s; `_tomb_missing_units` tombs `live_keys() − seen` **only on a full-source directory pass**. `_restore_tombed` un-tombs a reappeared unit and applies its (possibly edited) body in place under the preserved id.

### The single-file guard (important)
A single-file `--input` run **never** computes a gone set — otherwise re-ingesting one file would tomb every other unit. This is gated on `input_path.is_dir()` and explicitly tested. It also protects the incremental epic (#669).

## Test plan
`tests/test_ingest_orphan_tomb.py` (8 tests):
- **Ledger:** tombed round-trips; `live_keys()` excludes tombed.
- **Writer unit:** `tomb_fragment` moves + marks; returns `None` when unmapped; `restore_fragment` moves back + clears marker; returns `None` when no tombed file.
- **E2E (the issue example):** ingest → delete → re-ingest ⇒ 0 live, 1 tombed with `lifecycle: orphaned` + preserved id; **idempotent re-run** (no re-tomb, no error); re-add ⇒ live fragment restored under the same id, Orphaned empty.
- **Guard:** a single-file `--input` run does not tomb other units.

`./scripts/check-all.sh`: **12/12 gates green**.

## Scope
No material-change reclassify threshold or ingest summary (#675); no hard-delete; append-only sources and `generate_fragment_id` untouched. Orchestration lives in `_run_ingest` (cli.py), consistent with #672/#673, rather than `markdown.py`.

Refs #668
Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)