### PR TITLE
feat(ingest): material-change reclassify threshold + ingest summary (#675)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -378,6 +378,7 @@ def _restore_tombed(
     record: LedgerRecord,
     body: str,
     new_hash: str,
+    reclassify_threshold: float,
 ) -> Path | None:
     """Un-tomb a re-appeared source unit and apply its body (#674).
 
@@ -393,7 +394,9 @@ def _restore_tombed(
         return None
     if new_hash == record.content_hash:
         return restored
-    updated = writer.update_fragment(fragment, body)
+    updated = writer.update_fragment(
+        fragment, body, reclassify_threshold=reclassify_threshold
+    )
     return updated if updated is not None else restored
 
 
@@ -403,31 +406,39 @@ def _write_fragment_idempotent(
     parsed: ParsedFragment,
     fragment: Fragment,
     body: str,
-) -> Path:
-    """Write the fragment, or update the existing one in place on edit (#673).
+    reclassify_threshold: float,
+) -> str:
+    """Write or update the fragment; return ``"created"`` or ``"updated"``.
 
     When the ledger already maps this source unit to a fragment and the
     content has *changed*, reuse that fragment id and rewrite it in place
-    (preserving classifications/links). Unchanged content falls through to
-    the normal write, where the deterministic id makes it an idempotent
-    no-op. A new unit is written fresh.
+    (preserving classifications/links, flagging re-classification on a material
+    change per *reclassify_threshold*). Unchanged content falls through to the
+    normal write, where the deterministic id makes it an idempotent no-op. A
+    new unit (no prior ledger record) is written fresh and reported as created.
     """
     record = _ledger_record(ledger, fragment)
     # `record is not None` guarantees `ledger is not None` (_ledger_record
     # returns None for a missing ledger); the explicit guard narrows for mypy.
     if record is None or ledger is None:
-        return writer.write_fragment(fragment, body=body)
+        writer.write_fragment(fragment, body=body)
+        return "created"
     new_hash = ledger.content_hash(parsed.content)
     if record.tombed:
-        restored = _restore_tombed(writer, fragment, record, body, new_hash)
+        restored = _restore_tombed(
+            writer, fragment, record, body, new_hash, reclassify_threshold
+        )
         if restored is not None:
-            return restored
+            return "updated"
     elif record.content_hash != new_hash:
         fragment.id = record.fragment_id
-        updated = writer.update_fragment(fragment, body)
+        updated = writer.update_fragment(
+            fragment, body, reclassify_threshold=reclassify_threshold
+        )
         if updated is not None:
-            return updated
-    return writer.write_fragment(fragment, body=body)
+            return "updated"
+    writer.write_fragment(fragment, body=body)
+    return "updated"
 
 
 def _tomb_missing_units(
@@ -437,7 +448,7 @@ def _tomb_missing_units(
     seen_keys: set[str],
     errors: list[str],
     source_type: str,
-) -> None:
+) -> int:
     """Soft-tomb ledgered units absent from a full-source pass (#674).
 
     Only a directory (full-source) input computes a gone set; a single-file
@@ -447,9 +458,12 @@ def _tomb_missing_units(
     A tomb that fails on I/O is collected into *errors* (matching the
     per-fragment write path) and the unit is left live in the ledger so the
     next full-source pass retries it, rather than crashing the whole run.
+
+    Returns the number of units actually tombed.
     """
     if ledger is None or not input_path.is_dir():
-        return
+        return 0
+    tombed = 0
     for source_key in sorted(ledger.live_keys() - seen_keys):
         record = ledger.get(source_key)
         if record is None:
@@ -468,6 +482,8 @@ def _tomb_missing_units(
             last_seen=record.last_seen,
             tombed=True,
         )
+        tombed += 1
+    return tombed
 
 
 def _run_ingest(
@@ -476,6 +492,8 @@ def _run_ingest(
     source_type: str,
     input_path: Path,
     vault_path: Path,
+    reclassify_threshold: float = 0.0,
+    print_summary: bool = False,
 ) -> tuple[int, list[str], int]:
     """Run a single ingestor and persist its output to the vault.
 
@@ -484,6 +502,11 @@ def _run_ingest(
         source_type: Registry key, used to prefix error messages.
         input_path: Source directory or file to ingest.
         vault_path: Vault root for :class:`VaultWriter`.
+        reclassify_threshold: Body-similarity floor below which a materially
+            edited mutable unit is flagged for re-classification (#675). ``0.0``
+            (the default, used by tests/internal callers) always preserves.
+        print_summary: When ``True``, print a created/updated/tombed summary
+            line (the ``creek ingest`` surface; #675).
 
     Returns:
         Tuple of ``(written_count, errors, discovered)`` where ``errors`` is a
@@ -507,6 +530,8 @@ def _run_ingest(
 
     errors: list[str] = [f"[{source_type}] {err}" for err in ingest_result.errors]
     written = 0
+    created = 0
+    updated = 0
     seen_keys: set[str] = set()
     for parsed in ingest_result.fragments:
         try:
@@ -522,14 +547,13 @@ def _run_ingest(
         if origin_key is not None:
             seen_keys.add(origin_key)
         try:
-            # The written/updated path is intentionally unused — callers only
-            # need the written count and error list.
-            _ = _write_fragment_idempotent(
+            action = _write_fragment_idempotent(
                 ledger,
                 writer,
                 parsed,
                 assembled.fragment,
                 assembled.body,
+                reclassify_threshold,
             )
         except (OSError, KeyError) as exc:
             errors.append(
@@ -538,8 +562,19 @@ def _run_ingest(
             continue
         _record_in_ledger(ledger, parsed, assembled.fragment)
         written += 1
+        if action == "created":
+            created += 1
+        else:
+            updated += 1
 
-    _tomb_missing_units(ledger, writer, input_path, seen_keys, errors, source_type)
+    tombed = _tomb_missing_units(
+        ledger, writer, input_path, seen_keys, errors, source_type
+    )
+    if print_summary:
+        console.print(
+            f"[dim]Ingest summary: {created} created, {updated} updated, "
+            f"{tombed} tombed[/dim]",
+        )
     return written, errors, ingest_result.discovered
 
 
@@ -836,6 +871,8 @@ def ingest(
         source_type=type,
         input_path=input,
         vault_path=vault_path,
+        reclassify_threshold=config.classification.reclassify_on_edit_threshold,
+        print_summary=True,
     )
 
     console.print(f"[bold green]Ingested {written} fragment(s).[/bold green]")

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -428,17 +428,24 @@ def _write_fragment_idempotent(
         restored = _restore_tombed(
             writer, fragment, record, body, new_hash, reclassify_threshold
         )
-        if restored is not None:
-            return "updated"
-    elif record.content_hash != new_hash:
+        if restored is None:
+            # Tombstone lost out of band: recreate under the preserved id.
+            writer.write_fragment(fragment, body=body)
+        return "updated"
+    if record.content_hash != new_hash:
         fragment.id = record.fragment_id
         updated = writer.update_fragment(
             fragment, body, reclassify_threshold=reclassify_threshold
         )
-        if updated is not None:
-            return "updated"
+        if updated is None:
+            # File gone out of band: recreate under the preserved id.
+            writer.write_fragment(fragment, body=body)
+        return "updated"
+    # Known unit, content unchanged: idempotent no-op (the deterministic id
+    # dedups the write). Reported as unchanged so it never inflates the
+    # updated counter in the ingest summary.
     writer.write_fragment(fragment, body=body)
-    return "updated"
+    return "unchanged"
 
 
 def _tomb_missing_units(
@@ -564,8 +571,9 @@ def _run_ingest(
         written += 1
         if action == "created":
             created += 1
-        else:
+        elif action == "updated":
             updated += 1
+        # "unchanged" is an idempotent no-op — excluded from both counters.
 
     tombed = _tomb_missing_units(
         ledger, writer, input_path, seen_keys, errors, source_type

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -382,6 +382,18 @@ class ClassificationConfig(BaseModel):
     confidence_threshold: float = 0.7
     """Minimum confidence score for automatic classification."""
 
+    reclassify_on_edit_threshold: float = Field(default=0.9, ge=0.0, le=1.0)
+    """Body-similarity floor below which an edited mutable source unit is
+    flagged for re-classification (#675 / SPEC R1).
+
+    When a journal/markdown fragment is updated in place, its body is compared
+    to the prior version (``difflib`` ratio in ``[0, 1]``). At/above this
+    threshold the edit is *trivial* (typo, whitespace) and classifications are
+    preserved; below it the change is *material* and the fragment's
+    ``classification_method`` is cleared so the next classify pass re-does only
+    that fragment (cooperating with OPS-001, no global ``--force``). ``0.0``
+    disables flagging (always preserve)."""
+
     auto_classify_sources: list[str] = Field(
         default_factory=lambda: ["claude", "chatgpt", "discord"],
     )

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -17,6 +17,7 @@ Obsidian-compatible markdown files with YAML frontmatter. It handles:
 from __future__ import annotations
 
 import contextlib
+import difflib
 import json
 import logging
 import os
@@ -390,6 +391,35 @@ def _atomic_write_text(path: Path, content: str) -> None:
                 tmp_path.unlink()
 
 
+def _is_material_change(old_body: str, new_body: str, threshold: float) -> bool:
+    """Return ``True`` when an edit changed the body materially (#675).
+
+    A positive *threshold* compares old vs new body with ``difflib``; a
+    similarity ratio below the threshold is a material change. A non-positive
+    threshold never flags (every edit is treated as trivial).
+    """
+    if threshold <= 0.0:
+        return False
+    ratio = difflib.SequenceMatcher(None, old_body, new_body).ratio()
+    return ratio < threshold
+
+
+def _clear_classification(post: frontmatter.Post) -> None:
+    """Drop classification frontmatter so OPS-001 re-classifies on next pass."""
+    from creek.classify.constants import (
+        CLASSIFICATION_METHOD_KEY,
+        CLASSIFICATION_REASONING_KEY,
+        CLASSIFIED_AT_KEY,
+    )
+
+    for key in (
+        CLASSIFICATION_METHOD_KEY,
+        CLASSIFIED_AT_KEY,
+        CLASSIFICATION_REASONING_KEY,
+    ):
+        post.metadata.pop(key, None)
+
+
 def _apply_other_author_attribution(
     fragment: Fragment,
     manifest: AuthorManifest,
@@ -569,15 +599,29 @@ class VaultWriter:
         subfolder = _PLATFORM_SUBFOLDER[str(fragment.source.platform)]
         return self.vault_path / "01-Fragments" / subfolder
 
-    def update_fragment(self, fragment: Fragment, body: str) -> Path | None:
+    def update_fragment(
+        self,
+        fragment: Fragment,
+        body: str,
+        *,
+        reclassify_threshold: float = 0.0,
+    ) -> Path | None:
         """Rewrite an existing fragment's body in place, or return ``None``.
 
         Locates the file already mapped to ``fragment.id`` (via the per-dir
         id index) and rewrites **only its body**, preserving the on-disk
-        frontmatter verbatim — id, classifications (OPS-001), resonance links,
-        and ``source.origin_key``. This is the changed-branch of idempotent
+        frontmatter — id, classifications (OPS-001), resonance links, and
+        ``source.origin_key``. This is the changed-branch of idempotent
         mutable-source ingest (#673): an edited journal entry updates the same
         fragment instead of minting a new id and orphaning the old one.
+
+        When *reclassify_threshold* is positive (#675) the new body is compared
+        to the prior one; a **material** change (``difflib`` ratio below the
+        threshold) clears the fragment's ``classification_method`` /
+        ``classified_at`` / ``classification_reasoning`` so the next classify
+        pass re-does only this fragment (OPS-001, no global ``--force``). A
+        trivial edit (ratio at/above the threshold) preserves classifications.
+        The default ``0.0`` never flags — every edit preserves.
 
         Returns ``None`` when no file is mapped to ``fragment.id`` (e.g. the
         file was removed out of band), so the caller can fall back to a fresh
@@ -588,6 +632,8 @@ class VaultWriter:
                 whose platform/slug routes the lookup directory.
             body: The new markdown body to write below the preserved
                 frontmatter.
+            reclassify_threshold: Body-similarity floor below which the edit is
+                material and classifications are cleared for re-classification.
 
         Returns:
             Path to the rewritten file, or ``None`` when no existing file
@@ -599,6 +645,8 @@ class VaultWriter:
             if existing is None:
                 return None
             post = frontmatter.load(str(existing))
+            if _is_material_change(post.content, body, reclassify_threshold):
+                _clear_classification(post)
             post.content = body
             _atomic_write_text(existing, frontmatter.dumps(post))
             # Record the in-place edit in the provenance log too, so the audit

--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -406,6 +406,11 @@ def _is_material_change(old_body: str, new_body: str, threshold: float) -> bool:
 
 def _clear_classification(post: frontmatter.Post) -> None:
     """Drop classification frontmatter so OPS-001 re-classifies on next pass."""
+    # Deferred import: `creek.classify.classify_engine` imports `VaultWriter`
+    # from this module, so a module-level import of `creek.classify.constants`
+    # here would close a load-time cycle. The constants are pure `Final[str]`;
+    # extracting them to a dependency-free module would let this move to the top
+    # (tracked as a follow-up).
     from creek.classify.constants import (
         CLASSIFICATION_METHOD_KEY,
         CLASSIFICATION_REASONING_KEY,

--- a/creek-tools/docs/idempotent-ingest.md
+++ b/creek-tools/docs/idempotent-ingest.md
@@ -1,0 +1,76 @@
+# Idempotent ingest of mutable sources
+
+Creek keeps the vault current with **mutable** sources — the ones you edit
+repeatedly, like the Obsidian journal — without minting duplicate fragments or
+leaving orphans behind. This is epic #668 (SPEC R1).
+
+## The model
+
+Fragment ids are content-addressed (`frag-sha256(source:timestamp:content)`),
+so *append-only* sources (Discord/ChatGPT/Claude/Substack exports) are naturally
+idempotent: the same message always hashes to the same id. But a **mutable
+document** changes content under a stable identity (the file), so a pure
+content-hash id would mint a new fragment on every edit and orphan the old one.
+
+To fix that, each mutable source unit carries a stable **`source_key`** and is
+tracked in a per-source **ledger**:
+
+- **`source.origin_key`** — frontmatter field holding the vault-relative path of
+  the source unit (e.g. `personal/journal/2026-06-26.md`). This is the stable
+  identity an edit is matched on, distinct from the content-hash id.
+- **Ledger** — append-only JSONL at
+  `00-Creek-Meta/State/ingest/<source>.jsonl` mapping
+  `source_key → {fragment_id, content_hash, last_seen, tombed}`. The latest line
+  per key wins on load; malformed/partial rows are skipped.
+
+Today the markdown (journal) source is ledger-wired; append-only event sources
+keep their content-hash ids untouched.
+
+## What happens on ingest
+
+For each source unit, the ledger drives an **unchanged / changed / gone**
+decision:
+
+| Case | Detection | Behaviour |
+|------|-----------|-----------|
+| **unchanged** | content hash matches the ledger | idempotent no-op (deterministic id dedups the write) |
+| **changed** | same `source_key`, new content hash | **update in place** — the existing fragment is rewritten under its preserved id, keeping classifications and resonance links |
+| **gone** | a ledgered `source_key` is absent from a full-source pass | **soft-tomb** — the fragment moves to `10-Liminal/Orphaned/` and is marked `lifecycle: orphaned` (never hard-deleted) |
+| **re-added** | a tombed `source_key` reappears | **restore** — the tombed fragment is moved back and un-marked under its preserved id |
+
+### Full-source vs single-file
+
+The **gone** branch only runs on a *full-source directory* pass (the whole
+journal folder is scanned). A single-file `creek ingest --input <file>` run never
+tombs anything — it only does the unchanged/changed branch for that one unit.
+This guards against a targeted re-ingest accidentally tombing every other unit.
+
+## Re-classify on material edits
+
+When an in-place update happens, Creek decides whether the edit is large enough
+to warrant re-classification:
+
+- The new body is compared to the prior body (a `difflib` similarity ratio).
+- **Trivial** edit (ratio ≥ threshold — a typo, whitespace) → classifications
+  and tags are **preserved**.
+- **Material** edit (ratio < threshold — a real rewrite) → the fragment's
+  `classification_method` / `classified_at` / `classification_reasoning` are
+  cleared so the next `creek classify` pass re-does **only that fragment**
+  (cooperating with OPS-001 — no global `--force`).
+
+The threshold is the config knob
+`classification.reclassify_on_edit_threshold` (default `0.9`, range `0.0–1.0`).
+Set it to `0.0` to always preserve classifications across edits.
+
+## Summary output
+
+`creek ingest` prints a one-line summary of what changed:
+
+```
+Ingest summary: 3 created, 1 updated, 1 tombed
+```
+
+- **created** — source units with no prior ledger record (new fragments).
+- **updated** — units that already had a ledger record (in-place updates,
+  restores, and unchanged no-ops).
+- **tombed** — units soft-tombed this run because their source vanished.

--- a/creek-tools/docs/idempotent-ingest.md
+++ b/creek-tools/docs/idempotent-ingest.md
@@ -71,6 +71,7 @@ Ingest summary: 3 created, 1 updated, 1 tombed
 ```
 
 - **created** — source units with no prior ledger record (new fragments).
-- **updated** — units that already had a ledger record (in-place updates,
-  restores, and unchanged no-ops).
+- **updated** — units whose content changed (in-place updates and restores).
+  Unchanged re-ingests are idempotent no-ops and are **not** counted here, so
+  the summary reflects only what actually changed.
 - **tombed** — units soft-tombed this run because their source vanished.

--- a/creek-tools/tests/test_ingest_reclassify_threshold.py
+++ b/creek-tools/tests/test_ingest_reclassify_threshold.py
@@ -23,6 +23,9 @@ if TYPE_CHECKING:
 
     import pytest
 
+# difflib ratios vs _TRIVIAL: _TYPO ~0.99 (one dropped char, well above 0.9);
+# _MATERIAL ~0.27 (a full rewrite, well below 0.9). The wide margins keep the
+# tests robust to small threshold changes.
 _TRIVIAL = "A reflection on quiet mornings and slow pours of coffee at dawn."
 _TYPO = "A reflection on quiet morning and slow pours of coffee at dawn."
 _MATERIAL = "Thunderous chaos erupted across the crowded city streets at noon."
@@ -174,6 +177,10 @@ class TestIngestSummary:
         entry.write_text("---\ndate: 2026-06-26\n---\nFirst entry.\n", encoding="utf-8")
         _ingest(vault, journal, print_summary=True)
         assert "1 created, 0 updated, 0 tombed" in capsys.readouterr().out
+
+        # Re-run with NO changes: an unchanged no-op must not inflate any counter.
+        _ingest(vault, journal, print_summary=True)
+        assert "0 created, 0 updated, 0 tombed" in capsys.readouterr().out
 
         entry.write_text(
             "---\ndate: 2026-06-26\n---\nFirst entry, now meaningfully revised.\n",

--- a/creek-tools/tests/test_ingest_reclassify_threshold.py
+++ b/creek-tools/tests/test_ingest_reclassify_threshold.py
@@ -1,0 +1,187 @@
+"""Material-change reclassify threshold + ingest summary (#675).
+
+On an in-place update, a *trivial* edit (body similarity at/above the
+configured threshold) preserves classifications; a *material* edit (below the
+threshold) clears ``classification_method`` so the next classify pass re-does
+only that fragment (OPS-001, no global ``--force``). ``creek ingest`` prints a
+created/updated/tombed summary.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.cli import _run_ingest
+from creek.ingest import INGESTOR_REGISTRY
+from creek.models import Fragment, FragmentSource, SourcePlatform
+from creek.vault.writer import VaultWriter
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+_TRIVIAL = "A reflection on quiet mornings and slow pours of coffee at dawn."
+_TYPO = "A reflection on quiet morning and slow pours of coffee at dawn."
+_MATERIAL = "Thunderous chaos erupted across the crowded city streets at noon."
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Scaffold a minimal vault."""
+    vault = tmp_path / "vault"
+    for d in (
+        "00-Creek-Meta/Processing-Log",
+        "01-Fragments/Journal",
+        "10-Liminal/Orphaned",
+        "personal/journal",
+    ):
+        (vault / d).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _journal_files(vault: Path) -> list[Path]:
+    """Live fragment files under ``01-Fragments``."""
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+def _set_frontmatter(path: Path, **fields: object) -> None:
+    """Overlay extra frontmatter keys onto an existing fragment file."""
+    post = frontmatter.load(str(path))
+    for key, value in fields.items():
+        post[key] = value
+    path.write_text(frontmatter.dumps(post), encoding="utf-8")
+
+
+def _ingest(
+    vault: Path,
+    target: Path,
+    *,
+    threshold: float = 0.0,
+    print_summary: bool = False,
+) -> tuple[int, list[str], int]:
+    """Run the markdown ingestor with an explicit reclassify threshold."""
+    return _run_ingest(
+        ingestor_cls=INGESTOR_REGISTRY["markdown"],
+        source_type="markdown",
+        input_path=target,
+        vault_path=vault,
+        reclassify_threshold=threshold,
+        print_summary=print_summary,
+    )
+
+
+# ---- Writer materiality (unit) -----------------------------------------
+
+
+class TestUpdateMateriality:
+    """update_fragment clears classification only on a material change."""
+
+    def _seed(self, vault: Path, body: str) -> Fragment:
+        frag = Fragment(
+            id="frag-mat01",
+            title="Day",
+            source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        )
+        VaultWriter(vault_path=vault).write_fragment(frag, body=body)
+        path = _journal_files(vault)[0]
+        _set_frontmatter(
+            path,
+            classification_method="llm",
+            classified_at="2026-01-01T00:00:00+00:00",
+            classification_reasoning="prior reasoning",
+        )
+        return frag
+
+    def test_material_change_clears_classification(self, tmp_path: Path) -> None:
+        """A below-threshold rewrite drops the classification keys."""
+        vault = _make_vault(tmp_path)
+        frag = self._seed(vault, _TRIVIAL)
+        VaultWriter(vault_path=vault).update_fragment(
+            frag, _MATERIAL, reclassify_threshold=0.9
+        )
+        post = frontmatter.load(str(_journal_files(vault)[0]))
+        assert "classification_method" not in post.metadata
+        assert "classified_at" not in post.metadata
+        assert "classification_reasoning" not in post.metadata
+
+    def test_trivial_change_preserves_classification(self, tmp_path: Path) -> None:
+        """An at/above-threshold edit keeps the classification keys."""
+        vault = _make_vault(tmp_path)
+        frag = self._seed(vault, _TRIVIAL)
+        VaultWriter(vault_path=vault).update_fragment(
+            frag, _TYPO, reclassify_threshold=0.9
+        )
+        post = frontmatter.load(str(_journal_files(vault)[0]))
+        assert post["classification_method"] == "llm"
+
+    def test_zero_threshold_always_preserves(self, tmp_path: Path) -> None:
+        """The default 0.0 threshold never clears, even on a big change."""
+        vault = _make_vault(tmp_path)
+        frag = self._seed(vault, _TRIVIAL)
+        VaultWriter(vault_path=vault).update_fragment(frag, _MATERIAL)
+        post = frontmatter.load(str(_journal_files(vault)[0]))
+        assert post["classification_method"] == "llm"
+
+
+# ---- End-to-end threshold gate -----------------------------------------
+
+
+class TestReclassifyThresholdEndToEnd:
+    """Through the ingest seam, trivial preserves and material reclassifies."""
+
+    def test_trivial_preserves_material_reclassifies(self, tmp_path: Path) -> None:
+        """A typo keeps tags; a rewrite clears classification_method."""
+        vault = _make_vault(tmp_path)
+        entry = vault / "personal" / "journal" / "2026-06-26.md"
+        entry.write_text(f"---\ndate: 2026-06-26\n---\n{_TRIVIAL}\n", encoding="utf-8")
+        _ingest(vault, entry, threshold=0.9)
+        path = _journal_files(vault)[0]
+        frag_id = frontmatter.load(str(path))["id"]
+        _set_frontmatter(path, classification_method="llm")
+
+        # Trivial edit -> preserved.
+        entry.write_text(f"---\ndate: 2026-06-26\n---\n{_TYPO}\n", encoding="utf-8")
+        _ingest(vault, entry, threshold=0.9)
+        assert (
+            frontmatter.load(str(_journal_files(vault)[0]))["classification_method"]
+            == "llm"
+        )
+
+        # Material edit -> cleared (flagged for re-classification).
+        entry.write_text(f"---\ndate: 2026-06-26\n---\n{_MATERIAL}\n", encoding="utf-8")
+        _ingest(vault, entry, threshold=0.9)
+        post = frontmatter.load(str(_journal_files(vault)[0]))
+        assert post["id"] == frag_id  # still the same fragment
+        assert "classification_method" not in post.metadata
+
+
+# ---- Ingest summary -----------------------------------------------------
+
+
+class TestIngestSummary:
+    """The created/updated/tombed summary reports correct counts."""
+
+    def test_summary_counts(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """First ingest creates; an edit updates; a delete tombs."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        entry = journal / "2026-06-26.md"
+
+        entry.write_text("---\ndate: 2026-06-26\n---\nFirst entry.\n", encoding="utf-8")
+        _ingest(vault, journal, print_summary=True)
+        assert "1 created, 0 updated, 0 tombed" in capsys.readouterr().out
+
+        entry.write_text(
+            "---\ndate: 2026-06-26\n---\nFirst entry, now meaningfully revised.\n",
+            encoding="utf-8",
+        )
+        _ingest(vault, journal, print_summary=True)
+        assert "0 created, 1 updated, 0 tombed" in capsys.readouterr().out
+
+        entry.unlink()
+        _ingest(vault, journal, print_summary=True)
+        assert "0 created, 0 updated, 1 tombed" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

The finisher for epic #668. Two behaviours + docs:

1. **Material-change reclassify threshold.** After #673/#674 an in-place update *always* preserved classifications. Now, when a journal fragment is updated, the new body is compared to the prior one (`difflib` ratio):
   - **trivial** edit (ratio ≥ threshold — typo/whitespace) → classifications preserved;
   - **material** edit (ratio < threshold — a real rewrite) → `classification_method`/`classified_at`/`classification_reasoning` cleared, so the next `creek classify` re-does **only that fragment** (cooperating with OPS-001, no global `--force`).
   - Knob: `classification.reclassify_on_edit_threshold` (default `0.9`, range `0–1`; `0.0` = always preserve).
2. **Ingest summary.** `creek ingest` prints `Ingest summary: N created, M updated, K tombed`.
3. **Docs.** `docs/idempotent-ingest.md` documents the whole surface: `source.origin_key`, the ledger, unchanged/changed/gone, full-source-vs-single-file, the threshold, and the summary.

### Backward-compatibility note
`update_fragment(..., reclassify_threshold=0.0)` and `_run_ingest(..., reclassify_threshold=0.0)` default to **0.0 = always preserve**, so every existing #672/#673/#674 test (which calls these directly) is unaffected. Only the real `creek ingest` command passes the config's `0.9`.

## Test plan
`tests/test_ingest_reclassify_threshold.py` (5 tests):
- **Writer unit:** material change clears the 3 classification keys; trivial change preserves; the `0.0` default never clears.
- **End-to-end:** through the ingest seam, a typo preserves `classification_method` while a rewrite clears it (same fragment id throughout).
- **Summary:** `capsys` asserts `1 created → 1 updated → 1 tombed` across create/edit/delete.

`./scripts/check-all.sh`: **12/12 gates green**.

## Scope
Only gates the re-classify decision + adds the summary + docs. No re-open of update-in-place (#673) or tomb (#674) mechanics; no global re-classify/`--force`; no `--since`/`creek sync` (later epic); append-only sources untouched.

Refs #668
Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)