### PR TITLE
feat(sync): scaffold creek sync command (tier A/B dry-run skeleton) (#676)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import functools
+import json
 import logging
 import os
 import re
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
@@ -23,7 +25,12 @@ from creek.classify.privacy_filter import (
 from creek.config import AIStyleConfig, load_config, resolve_config_path
 from creek.consent import ConsentManager
 from creek.models import PrivacyTier
-from creek.pipeline import Pipeline, RedactionRequiredError
+from creek.pipeline import (
+    Pipeline,
+    RedactionRequiredError,
+    resolve_tier_a_plan,
+    resolve_tier_b_plan,
+)
 from creek.save import SaveTarget
 
 logger = logging.getLogger(__name__)
@@ -713,11 +720,13 @@ def init(
         )
 
 
-def _write_sync_state(vault_path: Path, tier: str) -> dict[str, object] | None:
+def _write_sync_state(
+    vault_path: Path,
+    tier: str,
+    *,
+    dry_run: bool,
+) -> dict[str, object] | None:
     """Write the sync last-run state, returning the prior state if any (#676)."""
-    import json
-    from datetime import UTC, datetime
-
     state_path = vault_path / "00-Creek-Meta" / "State" / "sync" / "last-run.json"
     prior: dict[str, object] | None = None
     if state_path.exists():
@@ -727,7 +736,7 @@ def _write_sync_state(vault_path: Path, tier: str) -> dict[str, object] | None:
         except (OSError, json.JSONDecodeError):
             prior = None
     state_path.parent.mkdir(parents=True, exist_ok=True)
-    state = {"tier": tier, "at": datetime.now(UTC).isoformat(), "dry_run": True}
+    state = {"tier": tier, "at": datetime.now(UTC).isoformat(), "dry_run": dry_run}
     state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
     return prior
 
@@ -736,9 +745,7 @@ def _sync_tier_a(
     enabled_sources: list[str],
     source: str | None,
 ) -> None:
-    """Echo the Tier-A per-source plan (#676 dry-run skeleton)."""
-    from creek.pipeline import resolve_tier_a_plan
-
+    """Echo the Tier-A per-source plan (dry-run skeleton)."""
     sources = [source] if source is not None else enabled_sources
     console.print(
         f"[sync] tier=A (dry-run) enabled sources: "
@@ -750,9 +757,7 @@ def _sync_tier_a(
 
 
 def _sync_tier_b() -> None:
-    """Echo the Tier-B global plan (#676 dry-run skeleton)."""
-    from creek.pipeline import resolve_tier_b_plan
-
+    """Echo the Tier-B global plan (dry-run skeleton)."""
     console.print("[sync] tier=B (dry-run) global passes")
     console.print(f"[sync] plan: {' -> '.join(resolve_tier_b_plan())}")
 
@@ -790,6 +795,11 @@ def sync(
             "[/yellow]",
         )
 
+    if tier_norm == "B" and source is not None:
+        # --source is a Tier-A concept; Tier B always runs the global passes.
+        console.print("[red]--source is not supported with --tier B.[/red]")
+        raise typer.Exit(code=2)
+
     config = _load_config_for_vault(vault)
     vault_path = vault or config.vault_path
 
@@ -805,7 +815,7 @@ def sync(
     else:
         _sync_tier_b()
 
-    prior = _write_sync_state(vault_path, tier_norm)
+    prior = _write_sync_state(vault_path, tier_norm, dry_run=True)
     if prior is not None:
         console.print(
             f"[sync] (previous run: tier={prior.get('tier')} at {prior.get('at')})",

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -713,6 +713,108 @@ def init(
         )
 
 
+def _write_sync_state(vault_path: Path, tier: str) -> dict[str, object] | None:
+    """Write the sync last-run state, returning the prior state if any (#676)."""
+    import json
+    from datetime import UTC, datetime
+
+    state_path = vault_path / "00-Creek-Meta" / "State" / "sync" / "last-run.json"
+    prior: dict[str, object] | None = None
+    if state_path.exists():
+        try:
+            loaded = json.loads(state_path.read_text(encoding="utf-8"))
+            prior = loaded if isinstance(loaded, dict) else None
+        except (OSError, json.JSONDecodeError):
+            prior = None
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state = {"tier": tier, "at": datetime.now(UTC).isoformat(), "dry_run": True}
+    state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+    return prior
+
+
+def _sync_tier_a(
+    enabled_sources: list[str],
+    source: str | None,
+) -> None:
+    """Echo the Tier-A per-source plan (#676 dry-run skeleton)."""
+    from creek.pipeline import resolve_tier_a_plan
+
+    sources = [source] if source is not None else enabled_sources
+    console.print(
+        f"[sync] tier=A (dry-run) enabled sources: "
+        f"{', '.join(sources) if sources else '(none)'}",
+    )
+    for name in sources:
+        plan = " -> ".join(resolve_tier_a_plan(name))
+        console.print(f"[sync] plan ({name}): {plan}")
+
+
+def _sync_tier_b() -> None:
+    """Echo the Tier-B global plan (#676 dry-run skeleton)."""
+    from creek.pipeline import resolve_tier_b_plan
+
+    console.print("[sync] tier=B (dry-run) global passes")
+    console.print(f"[sync] plan: {' -> '.join(resolve_tier_b_plan())}")
+
+
+@app.command()
+def sync(
+    tier: str = typer.Option(
+        "A", "--tier", help="A (cheap, per-source) or B (nightly)"
+    ),
+    source: str | None = typer.Option(
+        None, "--source", help="Limit a Tier-A run to a single source"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Echo the plan without executing (current default)"
+    ),
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+) -> None:
+    """Plan a scheduled sync pass (#676 -- dry-run skeleton).
+
+    ``--tier A`` resolves the cheap per-source plan (pull -> incremental ingest
+    -> rules classify) for each enabled source; ``--tier B`` resolves the
+    nightly global plan (LLM classify -> link -> index). This skeleton only
+    **echoes** the ordered plan and records
+    ``00-Creek-Meta/State/sync/last-run.json`` -- real pulling/ingesting/
+    scheduling land in later issues (#677-#680).
+    """
+    tier_norm = tier.upper()
+    if tier_norm not in {"A", "B"}:
+        console.print("[red]--tier must be A or B[/red]")
+        raise typer.Exit(code=2)
+    if not dry_run:
+        # Real execution lands in #678; until then every run plans only.
+        console.print(
+            "[yellow][sync] skeleton supports planning only; running as dry-run."
+            "[/yellow]",
+        )
+
+    config = _load_config_for_vault(vault)
+    vault_path = vault or config.vault_path
+
+    if source is not None and source not in config.sync.sources:
+        known = ", ".join(sorted(config.sync.sources))
+        console.print(
+            f"[red]Unknown --source '{source}'. Known sources: {known}.[/red]",
+        )
+        raise typer.Exit(code=2)
+
+    if tier_norm == "A":
+        _sync_tier_a(config.sync.enabled_sources(), source)
+    else:
+        _sync_tier_b()
+
+    prior = _write_sync_state(vault_path, tier_norm)
+    if prior is not None:
+        console.print(
+            f"[sync] (previous run: tier={prior.get('tier')} at {prior.get('at')})",
+        )
+    console.print(
+        f"[sync] last-run.json: wrote tier={tier_norm} (skeleton; no units processed)",
+    )
+
+
 @app.command()
 def process(
     source: Path | None = typer.Option(None, help="Source directory to process"),

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -1380,6 +1380,47 @@ class VoiceAudienceWeightingConfig(BaseModel):
     heuristic, while a classified vault is scoped by the real axis."""
 
 
+def _default_sync_sources() -> dict[str, bool]:
+    """Default per-source enable toggles for ``creek sync`` (#676).
+
+    The journal and Google Drive are the regularly-updated sources enabled
+    by default; the rest are present-but-off so an operator opts in per source.
+    """
+    return {
+        "journal": True,
+        "gdrive": True,
+        "discord": False,
+        "chatgpt": False,
+        "claude": False,
+        "essays": False,
+    }
+
+
+class SyncConfig(BaseModel):
+    """Scheduling configuration for ``creek sync`` (#676 / SPEC R3).
+
+    Holds the per-source enable toggles and the two-tier cadence. The cadence
+    values are config-tunable (decision #5) even though the skeleton command
+    does not schedule anything yet — a later issue emits the launchd/systemd
+    units that read them.
+    """
+
+    tier_a_interval_minutes: int = Field(default=30, ge=1)
+    """How often the cheap Tier-A pass (pull → incremental ingest → rules
+    classify) should run, in minutes (default 30)."""
+
+    tier_b_hour: int = Field(default=3, ge=0, le=23)
+    """Local hour (0-23) for the nightly Tier-B pass (LLM classify -> link ->
+    index); default 3 (~03:00)."""
+
+    sources: dict[str, bool] = Field(default_factory=_default_sync_sources)
+    """Per-source enable toggles; only enabled sources are pulled in Tier A."""
+
+    def enabled_sources(self) -> list[str]:
+        """Return the enabled source names in stable (sorted) order."""
+        return sorted(name for name, on in self.sources.items() if on)
+
+
 class CreekConfig(BaseSettings):
     """Top-level Creek configuration.
 
@@ -1459,6 +1500,9 @@ class CreekConfig(BaseSettings):
 
     sources: SourcePaths = Field(default_factory=SourcePaths)
     """Source data path mappings."""
+
+    sync: SyncConfig = Field(default_factory=SyncConfig)
+    """Scheduling config for ``creek sync`` — per-source toggles + cadence."""
 
     @field_validator("timezone")
     @classmethod

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -52,7 +52,7 @@ from creek.vault.writer import VaultWriter
 logger = logging.getLogger(__name__)
 
 
-# Map a ``creek sync`` source name -> the ingestor type it routes to (#676).
+# Map a ``creek sync`` source name -> the ingestor type it routes to.
 _SYNC_INGEST_TYPE: dict[str, str] = {
     "journal": "markdown",
     "gdrive": "gdrive",

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -52,6 +52,42 @@ from creek.vault.writer import VaultWriter
 logger = logging.getLogger(__name__)
 
 
+# Map a ``creek sync`` source name -> the ingestor type it routes to (#676).
+_SYNC_INGEST_TYPE: dict[str, str] = {
+    "journal": "markdown",
+    "gdrive": "gdrive",
+    "discord": "discord",
+    "chatgpt": "chatgpt",
+    "claude": "claude",
+    "essays": "substack",
+}
+
+
+def resolve_tier_a_plan(source: str) -> list[str]:
+    """Return the ordered Tier-A subcommand plan for *source* (#676).
+
+    Tier A is the cheap, per-source pass: pull the source, incrementally
+    ingest it, then run the offline rules classifier. This is a *plan* (an
+    ordered list of human-readable step strings) — the skeleton command echoes
+    it; real execution lands in a later issue.
+    """
+    ingest_type = _SYNC_INGEST_TYPE.get(source, source)
+    return [
+        "pull",
+        f"ingest --type {ingest_type} --since <ledger>",
+        "classify --method rules",
+    ]
+
+
+def resolve_tier_b_plan() -> list[str]:
+    """Return the ordered Tier-B subcommand plan (#676).
+
+    Tier B is the nightly, global pass: LLM classification then the expensive
+    link + index rebuilds. Returned as an ordered list of step strings.
+    """
+    return ["classify --method llm", "link", "index"]
+
+
 class RedactionRequiredError(RuntimeError):
     """Raised when ``creek process`` finds unresolved redaction matches.
 

--- a/creek-tools/tests/test_sync.py
+++ b/creek-tools/tests/test_sync.py
@@ -1,0 +1,145 @@
+"""Skeleton ``creek sync`` command — dry-run plan + state round-trip (#676).
+
+Tier A is the cheap per-source pass (pull → incremental ingest → rules
+classify); Tier B is the nightly global pass (LLM classify → link → index).
+This skeleton only echoes the ordered plan and round-trips
+``00-Creek-Meta/State/sync/last-run.json`` — no real execution.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.config import SyncConfig
+from creek.pipeline import resolve_tier_a_plan, resolve_tier_b_plan
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Scaffold a vault root with the meta dir."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _state(vault: Path) -> dict[str, object]:
+    """Load the sync last-run state file."""
+    path = vault / "00-Creek-Meta" / "State" / "sync" / "last-run.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+# ---- Plan resolvers (unit) ---------------------------------------------
+
+
+class TestPlanResolvers:
+    """The tier plans are ordered and route sources to ingest types."""
+
+    def test_tier_a_plan_order_and_routing(self) -> None:
+        """Tier A is pull -> ingest --type <t> --since -> rules classify."""
+        plan = resolve_tier_a_plan("journal")
+        assert plan[0] == "pull"
+        assert plan[1] == "ingest --type markdown --since <ledger>"
+        assert plan[2] == "classify --method rules"
+        assert "link" not in " ".join(plan)
+
+    def test_tier_a_unknown_source_routes_to_itself(self) -> None:
+        """An unmapped source name is used as its own ingest type."""
+        assert "ingest --type custom --since <ledger>" in resolve_tier_a_plan("custom")
+
+    def test_tier_b_plan_is_global_order(self) -> None:
+        """Tier B is the nightly global llm-classify -> link -> index."""
+        assert resolve_tier_b_plan() == ["classify --method llm", "link", "index"]
+
+
+# ---- SyncConfig ---------------------------------------------------------
+
+
+class TestSyncConfig:
+    """Per-source toggles + cadence."""
+
+    def test_enabled_sources_sorted_and_filtered(self) -> None:
+        """Only enabled sources are returned, in sorted order."""
+        cfg = SyncConfig(sources={"journal": True, "gdrive": False, "discord": True})
+        assert cfg.enabled_sources() == ["discord", "journal"]
+
+    def test_default_cadence(self) -> None:
+        """The default cadence matches decision #5 (30 min / 03:00)."""
+        cfg = SyncConfig()
+        assert cfg.tier_a_interval_minutes == 30
+        assert cfg.tier_b_hour == 3
+        assert cfg.sources["journal"] is True
+        assert cfg.sources["discord"] is False
+
+
+# ---- CLI: creek sync ----------------------------------------------------
+
+
+class TestSyncCommand:
+    """The dry-run command echoes the plan and round-trips run state."""
+
+    def test_tier_a_plan_and_state_roundtrip(self, tmp_path: Path) -> None:
+        """Tier A resolves the cheap per-source sequence; state records tier A."""
+        vault = _make_vault(tmp_path)
+        result = runner.invoke(
+            app, ["sync", "--tier", "A", "--dry-run", "--vault", str(vault)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "classify --method rules" in result.output
+        assert "ingest --type markdown" in result.output  # journal -> markdown
+        assert "link" not in result.output
+        assert "index" not in result.output
+        assert _state(vault)["tier"] == "A"
+
+    def test_tier_b_global_plan(self, tmp_path: Path) -> None:
+        """Tier B prints the global passes and records tier B."""
+        vault = _make_vault(tmp_path)
+        result = runner.invoke(
+            app, ["sync", "--tier", "B", "--dry-run", "--vault", str(vault)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "classify --method llm" in result.output
+        assert "link" in result.output
+        assert "index" in result.output
+        assert _state(vault)["tier"] == "B"
+
+    def test_tier_a_lists_enabled_sources_only(self, tmp_path: Path) -> None:
+        """Default-enabled journal+gdrive appear; off-by-default discord does not."""
+        vault = _make_vault(tmp_path)
+        result = runner.invoke(app, ["sync", "--tier", "A", "--vault", str(vault)])
+        assert result.exit_code == 0, result.output
+        assert "journal" in result.output
+        assert "gdrive" in result.output
+        assert "ingest --type discord" not in result.output
+
+    def test_source_filter_limits_to_one(self, tmp_path: Path) -> None:
+        """--source limits Tier A to a single source."""
+        vault = _make_vault(tmp_path)
+        result = runner.invoke(
+            app, ["sync", "--tier", "A", "--source", "journal", "--vault", str(vault)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "ingest --type markdown" in result.output
+        assert "ingest --type gdrive" not in result.output
+
+    def test_invalid_tier_errors(self, tmp_path: Path) -> None:
+        """An unknown tier exits non-zero."""
+        vault = _make_vault(tmp_path)
+        result = runner.invoke(app, ["sync", "--tier", "Z", "--vault", str(vault)])
+        assert result.exit_code != 0
+        assert "tier" in result.output.lower()
+
+    def test_unknown_source_errors(self, tmp_path: Path) -> None:
+        """An unknown --source exits non-zero."""
+        vault = _make_vault(tmp_path)
+        result = runner.invoke(
+            app, ["sync", "--tier", "A", "--source", "nope", "--vault", str(vault)]
+        )
+        assert result.exit_code != 0

--- a/creek-tools/tests/test_sync.py
+++ b/creek-tools/tests/test_sync.py
@@ -137,9 +137,29 @@ class TestSyncCommand:
         assert "tier" in result.output.lower()
 
     def test_unknown_source_errors(self, tmp_path: Path) -> None:
-        """An unknown --source exits non-zero."""
+        """An unknown --source exits non-zero with a source-specific message."""
         vault = _make_vault(tmp_path)
         result = runner.invoke(
             app, ["sync", "--tier", "A", "--source", "nope", "--vault", str(vault)]
         )
         assert result.exit_code != 0
+        assert "source" in result.output.lower()
+
+    def test_tier_b_with_source_errors(self, tmp_path: Path) -> None:
+        """--source is rejected with Tier B (it is a Tier-A concept)."""
+        vault = _make_vault(tmp_path)
+        result = runner.invoke(
+            app,
+            ["sync", "--tier", "B", "--source", "journal", "--vault", str(vault)],
+        )
+        assert result.exit_code != 0
+        assert "source" in result.output.lower()
+
+    def test_second_run_reports_previous(self, tmp_path: Path) -> None:
+        """A second run echoes the prior recorded run."""
+        vault = _make_vault(tmp_path)
+        runner.invoke(app, ["sync", "--tier", "A", "--vault", str(vault)])
+        result = runner.invoke(app, ["sync", "--tier", "B", "--vault", str(vault)])
+        assert result.exit_code == 0, result.output
+        assert "previous run" in result.output.lower()
+        assert _state(vault)["tier"] == "B"


### PR DESCRIPTION
## Summary

First child of epic #669 (incremental ingest + scheduler). Adds the `creek sync` command as a **dry-run skeleton**: it resolves and echoes the ordered plan for the chosen tier, reads the enabled sources from config, and round-trips `00-Creek-Meta/State/sync/last-run.json`. No real pulling, ingesting, classifying, or scheduling yet (those are #677–#680).

### What's here
- **`SyncConfig`** (config): per-source enable toggles (journal + gdrive on by default; discord/chat off), and the config-tunable cadence `tier_a_interval_minutes=30` / `tier_b_hour=3` (decision #5). `enabled_sources()` returns the on sources, sorted.
- **Plan resolvers** (pipeline): `resolve_tier_a_plan(source)` → `["pull", "ingest --type <t> --since <ledger>", "classify --method rules"]` with a source→ingest-type map (journal→markdown, gdrive→gdrive, …); `resolve_tier_b_plan()` → `["classify --method llm", "link", "index"]`.
- **`creek sync`** (cli): `--tier A|B`, `--source <s>`, `--dry-run`, `--vault`. Tier A echoes a per-enabled-source plan; Tier B echoes the global passes. Validates tier and source; writes/reads the run-state file.

### Example
```
$ creek sync --tier A --dry-run --vault <vault>
[sync] tier=A (dry-run) enabled sources: gdrive, journal
[sync] plan (gdrive): pull -> ingest --type gdrive --since <ledger> -> classify --method rules
[sync] plan (journal): pull -> ingest --type markdown --since <ledger> -> classify --method rules
[sync] last-run.json: wrote tier=A (skeleton; no units processed)
```

## Test plan
`tests/test_sync.py` (11 tests): plan-resolver order + source routing; `SyncConfig.enabled_sources()` filtering + default cadence; CLI Tier-A plan + state round-trip; Tier-B global plan; enabled-sources-only listing; `--source` filter; invalid tier and unknown source both exit non-zero. `./scripts/check-all.sh`: **12/12 gates green**.

## Scope
Dry-run/echo only — no real incremental filtering (#677), tiered execution (#678), schedule emission (#679), or status polish (#680). Does not touch ingest/classify/link/index internals.

Refs #669
Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)