### PR TITLE
feat(ingest): incremental --since/ledger-driven ingest (#677)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -511,7 +511,7 @@ def _parse_since_arg(text: str) -> datetime:
     try:
         parsed = datetime.fromisoformat(text)
     except ValueError:
-        from creek.lint.runner import parse_since
+        from creek.lint import parse_since  # public re-export of runner.parse_since
 
         try:
             return parse_since(text)
@@ -535,6 +535,7 @@ def _should_skip_unit(
     """Return whether incremental mode should skip this unchanged unit (#677)."""
     if not filtering:
         return False
+    # Deferred import: creek.pipeline pulls heavy stage deps; keep CLI startup light.
     from creek.pipeline import unit_is_changed
 
     record = _ledger_record(ledger, fragment)
@@ -637,7 +638,8 @@ def _run_ingest(
             continue
         _record_in_ledger(ledger, parsed, assembled.fragment)
         written += 1
-        # "created"/"updated" are counted; "unchanged" is an idempotent no-op.
+        # Tally every action (created/updated/unchanged); only created/updated
+        # are surfaced in the summary line — "unchanged" is an idempotent no-op.
         counts[action] = counts.get(action, 0) + 1
 
     tombed = _tomb_missing_units(

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -500,6 +500,48 @@ def _tomb_missing_units(
     return tombed
 
 
+def _parse_since_arg(text: str) -> datetime:
+    """Parse a ``--since`` argument as an ISO timestamp or a duration (#677).
+
+    Accepts an ISO-8601 timestamp (e.g. ``2026-06-25T00:00:00``, as the ledger
+    records ``last_seen``) or a ``creek lint``-style duration (``7d``, ``1w``,
+    ``1mo``). Naive ISO timestamps are treated as UTC. Exits with code 2 on an
+    unparseable value.
+    """
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        from creek.lint.runner import parse_since
+
+        try:
+            return parse_since(text)
+        except ValueError as exc:
+            console.print(
+                f"[red]Invalid --since {text!r}: expected an ISO timestamp "
+                "(2026-06-25T00:00:00) or a duration (7d, 1w, 1mo).[/red]",
+            )
+            raise typer.Exit(code=2) from exc
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
+def _should_skip_unit(
+    *,
+    filtering: bool,
+    ledger: SourceLedger | None,
+    parsed: ParsedFragment,
+    fragment: Fragment,
+    since: datetime | None,
+) -> bool:
+    """Return whether incremental mode should skip this unchanged unit (#677)."""
+    if not filtering:
+        return False
+    from creek.pipeline import unit_is_changed
+
+    record = _ledger_record(ledger, fragment)
+    content_hash = ledger.content_hash(parsed.content) if ledger is not None else ""
+    return not unit_is_changed(parsed.timestamp, content_hash, record, since)
+
+
 def _run_ingest(
     *,
     ingestor_cls: type[Ingestor],
@@ -508,6 +550,8 @@ def _run_ingest(
     vault_path: Path,
     reclassify_threshold: float = 0.0,
     print_summary: bool = False,
+    since: datetime | None = None,
+    incremental: bool = False,
 ) -> tuple[int, list[str], int]:
     """Run a single ingestor and persist its output to the vault.
 
@@ -521,6 +565,11 @@ def _run_ingest(
             (the default, used by tests/internal callers) always preserves.
         print_summary: When ``True``, print a created/updated/tombed summary
             line (the ``creek ingest`` surface; #675).
+        since: Incremental cutoff (#677). When set, only units newer than this
+            timestamp are processed; older units are skipped.
+        incremental: Ledger-driven incremental mode (#677). When ``True`` and
+            *since* is ``None``, units whose ledger content-hash is unchanged
+            are skipped. Ignored for sources without a ledger.
 
     Returns:
         Tuple of ``(written_count, errors, discovered)`` where ``errors`` is a
@@ -541,11 +590,12 @@ def _run_ingest(
 
     ingest_result = ingestor_cls().ingest(input_path)
     ledger = _ledger_for_source(source_type, vault_path)
+    filtering = since is not None or incremental
 
     errors: list[str] = [f"[{source_type}] {err}" for err in ingest_result.errors]
     written = 0
-    created = 0
-    updated = 0
+    skipped = 0
+    counts: dict[str, int] = {}
     seen_keys: set[str] = set()
     for parsed in ingest_result.fragments:
         try:
@@ -558,8 +608,19 @@ def _run_ingest(
             continue
         _attach_origin_key(ledger, parsed, assembled.fragment, vault_path)
         origin_key = assembled.fragment.source.origin_key
+        # Record the key as seen BEFORE any incremental skip, so an unchanged
+        # unit is never mistaken for a deleted one and tombed (#674/#677).
         if origin_key is not None:
             seen_keys.add(origin_key)
+        if _should_skip_unit(
+            filtering=filtering,
+            ledger=ledger,
+            parsed=parsed,
+            fragment=assembled.fragment,
+            since=since,
+        ):
+            skipped += 1
+            continue
         try:
             action = _write_fragment_idempotent(
                 ledger,
@@ -576,19 +637,17 @@ def _run_ingest(
             continue
         _record_in_ledger(ledger, parsed, assembled.fragment)
         written += 1
-        if action == "created":
-            created += 1
-        elif action == "updated":
-            updated += 1
-        # "unchanged" is an idempotent no-op — excluded from both counters.
+        # "created"/"updated" are counted; "unchanged" is an idempotent no-op.
+        counts[action] = counts.get(action, 0) + 1
 
     tombed = _tomb_missing_units(
         ledger, writer, input_path, seen_keys, errors, source_type
     )
     if print_summary:
         console.print(
-            f"[dim]Ingest summary: {created} created, {updated} updated, "
-            f"{tombed} tombed[/dim]",
+            f"[dim]Ingest summary: {counts.get('created', 0)} created, "
+            f"{counts.get('updated', 0)} updated, {tombed} tombed, "
+            f"{skipped} skipped[/dim]",
         )
     return written, errors, ingest_result.discovered
 
@@ -943,6 +1002,22 @@ def ingest(
             "fragments (likely an unrecognized export format)."
         ),
     ),
+    since: str | None = typer.Option(
+        None,
+        "--since",
+        help=(
+            "Incremental: only process units newer than this ISO timestamp "
+            "(e.g. 2026-06-25T00:00:00) or duration (e.g. 7d, 1w)."
+        ),
+    ),
+    incremental: bool = typer.Option(
+        False,
+        "--incremental",
+        help=(
+            "Incremental: skip units whose content is unchanged vs the ledger "
+            "(ledger-driven; overridden by --since)."
+        ),
+    ),
 ) -> None:
     """Ingest a specific source type into the vault.
 
@@ -986,6 +1061,8 @@ def ingest(
         assume_yes=yes,
     )
 
+    since_dt = _parse_since_arg(since) if since is not None else None
+
     written, errors, discovered = _run_ingest(
         ingestor_cls=ingestor_cls,
         source_type=type,
@@ -993,6 +1070,8 @@ def ingest(
         vault_path=vault_path,
         reclassify_threshold=config.classification.reclassify_on_edit_threshold,
         print_summary=True,
+        since=since_dt,
+        incremental=incremental,
     )
 
     console.print(f"[bold green]Ingested {written} fragment(s).[/bold green]")

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -27,6 +27,7 @@ The pipeline runs in three named passes (FEAT-005):
 
 import logging
 import uuid
+from datetime import UTC, datetime
 from pathlib import Path
 
 from pydantic import BaseModel, Field
@@ -44,6 +45,7 @@ from creek.consent import ConsentManager
 from creek.generate.indexes import IndexGenerator
 from creek.ingest import INGESTOR_REGISTRY
 from creek.ingest.base import IngestedFragment, assemble_ingested_fragment
+from creek.ingest.ledger import LedgerRecord
 from creek.link.linker import LinkingPipeline
 from creek.models import Fragment, Frequency
 from creek.redact.scanner import RedactionScanner
@@ -86,6 +88,46 @@ def resolve_tier_b_plan() -> list[str]:
     link + index rebuilds. Returned as an ordered list of step strings.
     """
     return ["classify --method llm", "link", "index"]
+
+
+def _as_aware(value: datetime) -> datetime:
+    """Return *value* as an aware datetime, assuming UTC when naive."""
+    return value if value.tzinfo is not None else value.replace(tzinfo=UTC)
+
+
+def unit_is_changed(
+    timestamp: datetime,
+    content_hash: str,
+    record: LedgerRecord | None,
+    since: datetime | None,
+) -> bool:
+    """Return whether a source unit should be (re)processed by incremental ingest.
+
+    Two cursors, used by the two incremental modes (#677):
+
+    * ``since`` given (``creek ingest --since``): a unit is changed when its
+      timestamp is strictly newer than the cutoff (mtime-style, generalising
+      the Drive mtime-skip to every file source). Naive timestamps are treated
+      as UTC.
+    * ``since`` is ``None`` (``--incremental``, ledger-driven): a unit is
+      changed when the ledger has no record for it, or its recorded
+      ``content_hash`` differs from *content_hash* — so a touch-without-edit
+      (same hash) is still skipped.
+
+    Args:
+        timestamp: The source unit's timestamp (fragment mtime/authored time).
+        content_hash: SHA-256 of the unit's current content.
+        record: The prior ledger record for this unit, or ``None``.
+        since: Explicit cutoff datetime, or ``None`` for ledger-driven mode.
+
+    Returns:
+        ``True`` when the unit should be processed; ``False`` to skip it.
+    """
+    if since is not None:
+        return _as_aware(timestamp) > _as_aware(since)
+    if record is not None:
+        return record.content_hash != content_hash
+    return True
 
 
 class RedactionRequiredError(RuntimeError):

--- a/creek-tools/tests/test_ingest_incremental.py
+++ b/creek-tools/tests/test_ingest_incremental.py
@@ -207,3 +207,37 @@ class TestIncrementalIngest:
 
         _ingest(vault, journal, print_summary=True)  # no flags
         assert "0 skipped" in capsys.readouterr().out
+
+    def test_incremental_on_fresh_vault_processes_all(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """--incremental on a vault with no prior ledger processes everything."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        _two_entries(journal)
+        _ingest(vault, journal, incremental=True, print_summary=True)
+        out = capsys.readouterr().out
+        assert "2 created" in out
+        assert "0 skipped" in out
+
+    def test_since_takes_priority_over_incremental(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """With both flags, --since (mtime) wins over the ledger hash check."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        _two_entries(journal)
+        _ingest(vault, journal)  # populate ledger
+        capsys.readouterr()
+
+        # Both flags + a far-future cutoff: --since wins, so all are skipped
+        # (the ledger-hash path would also skip unchanged units, but this pins
+        # the documented priority: mtime-only when --since is set).
+        _ingest(
+            vault,
+            journal,
+            since=datetime(2099, 1, 1, tzinfo=UTC),
+            incremental=True,
+            print_summary=True,
+        )
+        assert "2 skipped" in capsys.readouterr().out

--- a/creek-tools/tests/test_ingest_incremental.py
+++ b/creek-tools/tests/test_ingest_incremental.py
@@ -1,0 +1,209 @@
+"""Incremental ingest — ``--since`` + ledger-driven ``--incremental`` (#677).
+
+Only source units whose mtime (``--since``) or content-hash (``--incremental``,
+ledger-driven) changed are processed; unchanged units are skipped. With neither
+flag, every unit is processed (backward-compatible).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+import typer
+
+from creek.cli import _parse_since_arg, _run_ingest
+from creek.ingest import INGESTOR_REGISTRY
+from creek.ingest.ledger import LedgerRecord
+from creek.pipeline import unit_is_changed
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Scaffold a minimal vault."""
+    vault = tmp_path / "vault"
+    for d in (
+        "00-Creek-Meta/Processing-Log",
+        "01-Fragments/Journal",
+        "10-Liminal/Orphaned",
+        "personal/journal",
+    ):
+        (vault / d).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _ingest(
+    vault: Path,
+    target: Path,
+    *,
+    since: datetime | None = None,
+    incremental: bool = False,
+    print_summary: bool = False,
+) -> tuple[int, list[str], int]:
+    """Run the markdown ingestor with optional incremental cursors."""
+    return _run_ingest(
+        ingestor_cls=INGESTOR_REGISTRY["markdown"],
+        source_type="markdown",
+        input_path=target,
+        vault_path=vault,
+        since=since,
+        incremental=incremental,
+        print_summary=print_summary,
+    )
+
+
+def _two_entries(journal: Path) -> None:
+    """Write two journal entries."""
+    (journal / "a.md").write_text(
+        "---\ndate: 2026-06-01\n---\nAlpha.\n", encoding="utf-8"
+    )
+    (journal / "b.md").write_text(
+        "---\ndate: 2026-06-02\n---\nBeta.\n", encoding="utf-8"
+    )
+
+
+# ---- unit_is_changed (pure) --------------------------------------------
+
+
+class TestUnitIsChanged:
+    """The incremental change predicate across both cursor modes."""
+
+    def test_since_newer_is_changed(self) -> None:
+        """A unit newer than the cutoff is processed."""
+        assert unit_is_changed(
+            datetime(2026, 6, 2, tzinfo=UTC),
+            "h",
+            None,
+            datetime(2026, 6, 1, tzinfo=UTC),
+        )
+
+    def test_since_older_is_skipped(self) -> None:
+        """A unit at/older than the cutoff is skipped."""
+        assert not unit_is_changed(
+            datetime(2026, 6, 1, tzinfo=UTC),
+            "h",
+            None,
+            datetime(2026, 6, 2, tzinfo=UTC),
+        )
+
+    def test_since_naive_timestamp_assumed_utc(self) -> None:
+        """A naive timestamp is compared as UTC, not rejected."""
+        assert unit_is_changed(
+            datetime(2026, 6, 2), "h", None, datetime(2026, 6, 1, tzinfo=UTC)
+        )
+
+    def test_ledger_hash_differs_is_changed(self) -> None:
+        """Without a cutoff, a differing content hash is a change."""
+        rec = LedgerRecord("k", "frag-a", "oldhash", "t")
+        assert unit_is_changed(datetime(2026, 6, 1, tzinfo=UTC), "newhash", rec, None)
+
+    def test_ledger_hash_same_is_skipped(self) -> None:
+        """Without a cutoff, an unchanged content hash is skipped."""
+        rec = LedgerRecord("k", "frag-a", "samehash", "t")
+        assert not unit_is_changed(
+            datetime(2026, 6, 1, tzinfo=UTC), "samehash", rec, None
+        )
+
+    def test_new_unit_no_record_is_changed(self) -> None:
+        """A unit with no prior ledger record is always processed."""
+        assert unit_is_changed(datetime(2026, 6, 1, tzinfo=UTC), "h", None, None)
+
+
+# ---- _parse_since_arg ---------------------------------------------------
+
+
+class TestParseSinceArg:
+    """--since accepts an ISO timestamp or a duration."""
+
+    def test_iso_timestamp(self) -> None:
+        """An ISO timestamp parses to an aware UTC datetime."""
+        assert _parse_since_arg("2026-06-25T00:00:00") == datetime(
+            2026, 6, 25, tzinfo=UTC
+        )
+
+    def test_duration_falls_back_to_parse_since(self) -> None:
+        """A duration string parses to a datetime in the past."""
+        result = _parse_since_arg("7d")
+        assert isinstance(result, datetime)
+        assert result < datetime.now(tz=UTC)
+
+    def test_invalid_exits(self) -> None:
+        """An unparseable value exits non-zero."""
+        with pytest.raises(typer.Exit):
+            _parse_since_arg("not-a-date!!")
+
+
+# ---- End-to-end incremental --------------------------------------------
+
+
+class TestIncrementalIngest:
+    """Through the ingest seam, only changed units are processed."""
+
+    def test_incremental_skips_unchanged_by_hash(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Editing one of two entries processes only it; the other is skipped."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        _two_entries(journal)
+        _ingest(vault, journal)  # populate the ledger
+        capsys.readouterr()
+
+        # Edit only a.md.
+        (journal / "a.md").write_text(
+            "---\ndate: 2026-06-01\n---\nAlpha revised.\n", encoding="utf-8"
+        )
+        _ingest(vault, journal, incremental=True, print_summary=True)
+        out = capsys.readouterr().out
+        assert "1 updated" in out  # a.md changed
+        assert "1 skipped" in out  # b.md unchanged by hash
+
+    def test_since_future_skips_all(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A far-future cutoff skips every unit regardless of timestamp source."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        _two_entries(journal)
+        _ingest(
+            vault, journal, since=datetime(2099, 1, 1, tzinfo=UTC), print_summary=True
+        )
+        out = capsys.readouterr().out
+        assert "0 created" in out
+        assert "2 skipped" in out
+
+    def test_since_overrides_ledger_default(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A past --since cutoff processes unchanged units (no hash-skip)."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        _two_entries(journal)
+        _ingest(vault, journal)  # populate ledger
+        capsys.readouterr()
+
+        # Re-ingest UNCHANGED with a past cutoff: the since-path processes both
+        # (skipped=0), where the ledger-default would have hash-skipped them.
+        _ingest(
+            vault,
+            journal,
+            since=datetime(2000, 1, 1, tzinfo=UTC),
+            print_summary=True,
+        )
+        assert "0 skipped" in capsys.readouterr().out
+
+    def test_no_flags_processes_all(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """Without incremental flags, nothing is skipped (backward-compatible)."""
+        vault = _make_vault(tmp_path)
+        journal = vault / "personal" / "journal"
+        _two_entries(journal)
+        _ingest(vault, journal)  # populate ledger
+        capsys.readouterr()
+
+        _ingest(vault, journal, print_summary=True)  # no flags
+        assert "0 skipped" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

Makes `creek ingest` incremental (epic #669) so only changed source units are processed, generalising the Drive mtime-skip to every file source. Two cursor modes:

- **`--since <iso|duration>`** — process only units newer than the cutoff (mtime-style). Accepts an ISO timestamp (`2026-06-25T00:00:00`, as the ledger records `last_seen` — so `creek sync` can pass it directly) or a `creek lint`-style duration (`7d`, `1w`). Naive timestamps are treated as UTC.
- **`--incremental`** (ledger-driven, no `--since`) — skip units whose ledger content-hash is unchanged, so a touch-without-edit is still a no-op.

With **neither flag, behaviour is unchanged** (all units processed) — fully backward-compatible with every Epic A test.

### Key correctness detail
A unit's `origin_key` is added to `seen_keys` **before** the incremental skip — so a skipped (unchanged) unit is never mistaken for a deleted one and tombed by the #674 gone-set logic. The ingest summary gains a `… skipped` count.

## Test plan
`tests/test_ingest_incremental.py` (13 tests):
- **`unit_is_changed`** (pure): since newer/older, naive-timestamp-as-UTC, ledger hash differs/same, new-unit-no-record.
- **`_parse_since_arg`**: ISO timestamp, duration fallback, invalid → exits.
- **End-to-end**: edit one of two entries → `--incremental` processes 1, skips 1; far-future `--since` skips all; past `--since` overrides the ledger default (processes unchanged, skipped=0); no flags → nothing skipped.

`./scripts/check-all.sh`: **12/12 gates green** (complexity held by extracting `_should_skip_unit`).

## Scope
Only makes `creek ingest` itself incremental. No real tiered `creek sync` execution (#678), schedule emission (#679), or status polish (#680). Does not touch the writer dedup contract or Epic A's ledger-write path.

Refs #669
Closes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)