### PR TITLE
feat(sync): run real Tier A/B pipelines with per-source toggles (#678)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -834,13 +834,14 @@ def _sync_source_input(source: str, config: CreekConfig) -> Path | None:
     return config.source_drive / rel
 
 
-def _sync_pull(source: str, config: CreekConfig, vault_path: Path) -> None:
+def _sync_pull(source: str, config: CreekConfig, _vault_path: Path) -> None:
     """Pull a remote source into staging (Tier A, #678).
 
     Only Google Drive has a pull step today (it mirrors files into a local
     staging directory via the existing read-only downloader); local sources
     such as the journal are already on disk and no-op here. Connector
-    generalisation is a later epic.
+    generalisation is a later epic. (``_vault_path`` is unused but kept so all
+    step helpers share a uniform ``(source, config, vault_path)`` shape.)
     """
     if source != "gdrive":
         return
@@ -870,6 +871,10 @@ def _sync_ingest_source(source: str, config: CreekConfig, vault_path: Path) -> N
         return  # e.g. gdrive is a downloader, not an ingestor
     input_path = _sync_source_input(source, config)
     if input_path is None or not input_path.exists():
+        console.print(
+            f"[yellow][sync] skipping {source}: source path not found "
+            f"({input_path}).[/yellow]",
+        )
         return
     _run_ingest(
         ingestor_cls=ingestor_cls,
@@ -935,10 +940,12 @@ def _sync_dispatch(
 ) -> None:
     """Echo (dry-run) or execute the chosen sync tier (#678)."""
     if tier_norm == "A":
-        sources = [source] if source is not None else config.sync.enabled_sources()
         if dry_run:
             _sync_tier_a(config.sync.enabled_sources(), source)
         else:
+            # An explicit --source overrides the enable toggle (the operator
+            # asked for it by name); otherwise run the enabled set.
+            sources = [source] if source is not None else config.sync.enabled_sources()
             _sync_run_tier_a(config, vault_path, sources)
     elif dry_run:
         _sync_tier_b()
@@ -952,7 +959,9 @@ def sync(
         "A", "--tier", help="A (cheap, per-source) or B (nightly)"
     ),
     source: str | None = typer.Option(
-        None, "--source", help="Limit a Tier-A run to a single source"
+        None,
+        "--source",
+        help="Limit a Tier-A run to one source (explicitly overrides its toggle)",
     ),
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Echo the plan without executing (current default)"

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -823,6 +823,129 @@ def _sync_tier_b() -> None:
     console.print(f"[sync] plan: {' -> '.join(resolve_tier_b_plan())}")
 
 
+# ---- creek sync: real tier execution (#678) ----------------------------
+
+
+def _sync_source_input(source: str, config: CreekConfig) -> Path | None:
+    """Resolve the local input path for a Tier-A source, or ``None`` (#678)."""
+    rel = getattr(config.sources, source, None)
+    if not isinstance(rel, str):
+        return None
+    return config.source_drive / rel
+
+
+def _sync_pull(source: str, config: CreekConfig, vault_path: Path) -> None:
+    """Pull a remote source into staging (Tier A, #678).
+
+    Only Google Drive has a pull step today (it mirrors files into a local
+    staging directory via the existing read-only downloader); local sources
+    such as the journal are already on disk and no-op here. Connector
+    generalisation is a later epic.
+    """
+    if source != "gdrive":
+        return
+    from creek.ingest.gdrive import GoogleApiDriveClient, GoogleDriveDownloader
+
+    client = GoogleApiDriveClient(config.google_drive)
+    if not client.is_available():
+        console.print(
+            "[yellow][sync] Google Drive libraries unavailable; skipping pull."
+            "[/yellow]",
+        )
+        return
+    staging = config.source_drive / config.google_drive.staging_dir
+    GoogleDriveDownloader(client=client, config=config.google_drive).download_all(
+        staging,
+    )
+
+
+def _sync_ingest_source(source: str, config: CreekConfig, vault_path: Path) -> None:
+    """Incrementally ingest one Tier-A source via its mapped ingestor (#678)."""
+    from creek.ingest import INGESTOR_REGISTRY
+    from creek.pipeline import sync_ingest_type
+
+    ingest_type = sync_ingest_type(source)
+    ingestor_cls = INGESTOR_REGISTRY.get(ingest_type)
+    if ingestor_cls is None:
+        return  # e.g. gdrive is a downloader, not an ingestor
+    input_path = _sync_source_input(source, config)
+    if input_path is None or not input_path.exists():
+        return
+    _run_ingest(
+        ingestor_cls=ingestor_cls,
+        source_type=ingest_type,
+        input_path=input_path,
+        vault_path=vault_path,
+        reclassify_threshold=config.classification.reclassify_on_edit_threshold,
+        incremental=True,
+    )
+
+
+def _sync_classify(vault_path: Path, config: CreekConfig, method: str) -> None:
+    """Run a classify pass for a sync tier (#678)."""
+    from creek.classify.classify_engine import run_classify
+
+    run_classify(vault_path=vault_path, config=config, method=method, force=False)
+
+
+def _sync_link(vault_path: Path, config: CreekConfig) -> None:
+    """Run the embeddings linker — Tier B only (R6, #678)."""
+    from creek.link.link_engine import run_link
+
+    run_link(vault_path=vault_path, config=config, method="embeddings", rebuild=False)
+
+
+def _sync_index(vault_path: Path) -> None:
+    """Regenerate index notes — Tier B only (R6, #678)."""
+    from creek.generate.indexes import IndexGenerator
+
+    IndexGenerator(vault_path=vault_path).generate_all()
+
+
+def _sync_run_tier_a(
+    config: CreekConfig,
+    vault_path: Path,
+    sources: list[str],
+) -> None:
+    """Execute Tier A: per source pull + incremental ingest, then rules classify.
+
+    Linking and indexing are **never** invoked here (R6: they are O(n²)/global
+    and belong to Tier B).
+    """
+    for source in sources:
+        _sync_pull(source, config, vault_path)
+        _sync_ingest_source(source, config, vault_path)
+    _sync_classify(vault_path, config, "rules")
+
+
+def _sync_run_tier_b(config: CreekConfig, vault_path: Path) -> None:
+    """Execute Tier B globally: llm classify -> link -> index (#678)."""
+    _sync_classify(vault_path, config, "llm")
+    _sync_link(vault_path, config)
+    _sync_index(vault_path)
+
+
+def _sync_dispatch(
+    tier_norm: str,
+    *,
+    dry_run: bool,
+    config: CreekConfig,
+    vault_path: Path,
+    source: str | None,
+) -> None:
+    """Echo (dry-run) or execute the chosen sync tier (#678)."""
+    if tier_norm == "A":
+        sources = [source] if source is not None else config.sync.enabled_sources()
+        if dry_run:
+            _sync_tier_a(config.sync.enabled_sources(), source)
+        else:
+            _sync_run_tier_a(config, vault_path, sources)
+    elif dry_run:
+        _sync_tier_b()
+    else:
+        _sync_run_tier_b(config, vault_path)
+
+
 @app.command()
 def sync(
     tier: str = typer.Option(
@@ -836,25 +959,19 @@ def sync(
     ),
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
 ) -> None:
-    """Plan a scheduled sync pass (#676 -- dry-run skeleton).
+    """Run a scheduled sync pass (#676/#678).
 
-    ``--tier A`` resolves the cheap per-source plan (pull -> incremental ingest
-    -> rules classify) for each enabled source; ``--tier B`` resolves the
-    nightly global plan (LLM classify -> link -> index). This skeleton only
-    **echoes** the ordered plan and records
-    ``00-Creek-Meta/State/sync/last-run.json`` -- real pulling/ingesting/
-    scheduling land in later issues (#677-#680).
+    ``--tier A`` is the cheap per-source pass (pull -> incremental ingest ->
+    rules classify) for each enabled source; ``--tier B`` is the nightly global
+    pass (LLM classify -> link -> index). Linking and indexing run only in Tier
+    B (R6). ``--dry-run`` echoes the ordered plan without executing. Every run
+    records ``00-Creek-Meta/State/sync/last-run.json``; because every step is
+    idempotent, a missed tick self-heals on the next run (no catch-up queue).
     """
     tier_norm = tier.upper()
     if tier_norm not in {"A", "B"}:
         console.print("[red]--tier must be A or B[/red]")
         raise typer.Exit(code=2)
-    if not dry_run:
-        # Real execution lands in #678; until then every run plans only.
-        console.print(
-            "[yellow][sync] skeleton supports planning only; running as dry-run."
-            "[/yellow]",
-        )
 
     if tier_norm == "B" and source is not None:
         # --source is a Tier-A concept; Tier B always runs the global passes.
@@ -871,19 +988,21 @@ def sync(
         )
         raise typer.Exit(code=2)
 
-    if tier_norm == "A":
-        _sync_tier_a(config.sync.enabled_sources(), source)
-    else:
-        _sync_tier_b()
+    _sync_dispatch(
+        tier_norm,
+        dry_run=dry_run,
+        config=config,
+        vault_path=vault_path,
+        source=source,
+    )
 
-    prior = _write_sync_state(vault_path, tier_norm, dry_run=True)
+    prior = _write_sync_state(vault_path, tier_norm, dry_run=dry_run)
     if prior is not None:
         console.print(
             f"[sync] (previous run: tier={prior.get('tier')} at {prior.get('at')})",
         )
-    console.print(
-        f"[sync] last-run.json: wrote tier={tier_norm} (skeleton; no units processed)",
-    )
+    mode = "planned" if dry_run else "ran"
+    console.print(f"[sync] {mode} tier={tier_norm}; wrote last-run.json")
 
 
 @app.command()

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -65,6 +65,11 @@ _SYNC_INGEST_TYPE: dict[str, str] = {
 }
 
 
+def sync_ingest_type(source: str) -> str:
+    """Return the ingestor type a ``creek sync`` source routes to (#676)."""
+    return _SYNC_INGEST_TYPE.get(source, source)
+
+
 def resolve_tier_a_plan(source: str) -> list[str]:
     """Return the ordered Tier-A subcommand plan for *source* (#676).
 
@@ -73,7 +78,7 @@ def resolve_tier_a_plan(source: str) -> list[str]:
     ordered list of human-readable step strings) — the skeleton command echoes
     it; real execution lands in a later issue.
     """
-    ingest_type = _SYNC_INGEST_TYPE.get(source, source)
+    ingest_type = sync_ingest_type(source)
     return [
         "pull",
         f"ingest --type {ingest_type} --since <ledger>",

--- a/creek-tools/tests/test_sync.py
+++ b/creek-tools/tests/test_sync.py
@@ -113,7 +113,9 @@ class TestSyncCommand:
     def test_tier_a_lists_enabled_sources_only(self, tmp_path: Path) -> None:
         """Default-enabled journal+gdrive appear; off-by-default discord does not."""
         vault = _make_vault(tmp_path)
-        result = runner.invoke(app, ["sync", "--tier", "A", "--vault", str(vault)])
+        result = runner.invoke(
+            app, ["sync", "--tier", "A", "--dry-run", "--vault", str(vault)]
+        )
         assert result.exit_code == 0, result.output
         assert "journal" in result.output
         assert "gdrive" in result.output
@@ -123,7 +125,17 @@ class TestSyncCommand:
         """--source limits Tier A to a single source."""
         vault = _make_vault(tmp_path)
         result = runner.invoke(
-            app, ["sync", "--tier", "A", "--source", "journal", "--vault", str(vault)]
+            app,
+            [
+                "sync",
+                "--tier",
+                "A",
+                "--source",
+                "journal",
+                "--dry-run",
+                "--vault",
+                str(vault),
+            ],
         )
         assert result.exit_code == 0, result.output
         assert "ingest --type markdown" in result.output
@@ -158,8 +170,10 @@ class TestSyncCommand:
     def test_second_run_reports_previous(self, tmp_path: Path) -> None:
         """A second run echoes the prior recorded run."""
         vault = _make_vault(tmp_path)
-        runner.invoke(app, ["sync", "--tier", "A", "--vault", str(vault)])
-        result = runner.invoke(app, ["sync", "--tier", "B", "--vault", str(vault)])
+        runner.invoke(app, ["sync", "--tier", "A", "--dry-run", "--vault", str(vault)])
+        result = runner.invoke(
+            app, ["sync", "--tier", "B", "--dry-run", "--vault", str(vault)]
+        )
         assert result.exit_code == 0, result.output
         assert "previous run" in result.output.lower()
         assert _state(vault)["tier"] == "B"

--- a/creek-tools/tests/test_sync_exec.py
+++ b/creek-tools/tests/test_sync_exec.py
@@ -18,6 +18,7 @@ from creek.cli import (
     _sync_ingest_source,
     _sync_link,
     _sync_pull,
+    _sync_source_input,
     app,
 )
 from creek.config import CreekConfig, SyncConfig
@@ -123,6 +124,29 @@ class TestTierOrchestration:
         )
         assert calls == []
 
+    def test_explicit_source_overrides_disabled_toggle(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An explicit --source runs even when that source is toggled off."""
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(tmp_path / "v", tmp_path / "src", {"discord": False})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+
+        result = runner.invoke(
+            app,
+            [
+                "sync",
+                "--tier",
+                "A",
+                "--source",
+                "discord",
+                "--vault",
+                str(tmp_path / "v"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert calls == ["pull:discord", "ingest:discord", "classify:rules"]
+
 
 # ---- Step helper delegation --------------------------------------------
 
@@ -203,6 +227,15 @@ class TestStepHelpers:
         _sync_ingest_source("journal", cfg, tmp_path / "v")
         assert seen["incremental"] is True
         assert seen["source_type"] == "markdown"
+        assert seen["vault_path"] == tmp_path / "v"
+
+    def test_source_input_resolution(self, tmp_path: Path) -> None:
+        """_sync_source_input joins source_drive + the configured relative path."""
+        src = tmp_path / "src"
+        cfg = _fake_config(tmp_path / "v", src, {})
+        assert _sync_source_input("journal", cfg) == src / "personal" / "journal"
+        # A name that is not a SourcePaths attribute resolves to None.
+        assert _sync_source_input("not_a_real_source", cfg) is None
 
 
 # ---- Real Tier-A idempotency -------------------------------------------

--- a/creek-tools/tests/test_sync_exec.py
+++ b/creek-tools/tests/test_sync_exec.py
@@ -1,0 +1,237 @@
+"""Real Tier-A / Tier-B execution for ``creek sync`` (#678).
+
+Tier A runs, per enabled source, pull -> incremental ingest -> rules classify
+and NEVER links/indexes (R6). Tier B runs the global llm-classify -> link ->
+index. ``--dry-run`` still only echoes the plan. Because every step is
+idempotent, a re-run produces no duplicates.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from creek.cli import (
+    _sync_classify,
+    _sync_index,
+    _sync_ingest_source,
+    _sync_link,
+    _sync_pull,
+    app,
+)
+from creek.config import CreekConfig, SyncConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+runner = CliRunner()
+
+
+def _fake_config(
+    vault: Path,
+    source_drive: Path,
+    sources: dict[str, bool],
+) -> CreekConfig:
+    """Build a config with the given vault, source drive, and sync toggles."""
+    return CreekConfig(
+        vault_path=vault,
+        source_drive=source_drive,
+        sync=SyncConfig(sources=sources),
+    )
+
+
+def _spy_steps(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Replace the sync step helpers with recorders; return the call log."""
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "creek.cli._sync_pull", lambda s, _c, _v: calls.append(f"pull:{s}")
+    )
+    monkeypatch.setattr(
+        "creek.cli._sync_ingest_source", lambda s, _c, _v: calls.append(f"ingest:{s}")
+    )
+    monkeypatch.setattr(
+        "creek.cli._sync_classify", lambda _v, _c, m: calls.append(f"classify:{m}")
+    )
+    monkeypatch.setattr("creek.cli._sync_link", lambda _v, _c: calls.append("link"))
+    monkeypatch.setattr("creek.cli._sync_index", lambda _v: calls.append("index"))
+    return calls
+
+
+# ---- Orchestration (spied steps) ---------------------------------------
+
+
+class TestTierOrchestration:
+    """Tier runners call the right steps in order, honouring R6."""
+
+    def test_tier_a_runs_cheap_chain_and_never_links(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tier A is pull -> ingest -> rules-classify; no link/index (R6)."""
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(tmp_path / "v", tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+
+        result = runner.invoke(
+            app, ["sync", "--tier", "A", "--vault", str(tmp_path / "v")]
+        )
+        assert result.exit_code == 0, result.output
+        assert calls == ["pull:fakesrc", "ingest:fakesrc", "classify:rules"]
+        assert "link" not in calls
+        assert "index" not in calls
+
+    def test_tier_b_runs_global_chain(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Tier B is llm-classify -> link -> index."""
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(tmp_path / "v", tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+
+        result = runner.invoke(
+            app, ["sync", "--tier", "B", "--vault", str(tmp_path / "v")]
+        )
+        assert result.exit_code == 0, result.output
+        assert calls == ["classify:llm", "link", "index"]
+
+    def test_disabled_source_is_skipped(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A toggled-off source is never pulled or ingested."""
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(
+            tmp_path / "v", tmp_path / "src", {"journal": True, "discord": False}
+        )
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+
+        runner.invoke(app, ["sync", "--tier", "A", "--vault", str(tmp_path / "v")])
+        assert "pull:journal" in calls
+        assert "pull:discord" not in calls
+
+    def test_dry_run_does_not_execute(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--dry-run echoes the plan and runs no step helpers."""
+        calls = _spy_steps(monkeypatch)
+        cfg = _fake_config(tmp_path / "v", tmp_path / "src", {"fakesrc": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+
+        runner.invoke(
+            app, ["sync", "--tier", "A", "--dry-run", "--vault", str(tmp_path / "v")]
+        )
+        assert calls == []
+
+
+# ---- Step helper delegation --------------------------------------------
+
+
+class TestStepHelpers:
+    """Each step helper delegates to the right engine entry point."""
+
+    def test_classify_delegates_with_method(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_sync_classify calls run_classify with the given method."""
+        seen: dict[str, object] = {}
+        monkeypatch.setattr(
+            "creek.classify.classify_engine.run_classify",
+            lambda **kw: seen.update(kw),
+        )
+        _sync_classify(tmp_path, _fake_config(tmp_path, tmp_path, {}), "rules")
+        assert seen["method"] == "rules"
+        assert seen["force"] is False
+
+    def test_link_delegates_embeddings(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_sync_link calls run_link with the embeddings method."""
+        seen: dict[str, object] = {}
+        monkeypatch.setattr(
+            "creek.link.link_engine.run_link", lambda **kw: seen.update(kw)
+        )
+        _sync_link(tmp_path, _fake_config(tmp_path, tmp_path, {}))
+        assert seen["method"] == "embeddings"
+
+    def test_index_delegates_generate_all(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """_sync_index builds an IndexGenerator and generates all notes."""
+        log: list[object] = []
+
+        class _FakeIG:
+            def __init__(self, vault_path: Path) -> None:
+                log.append(vault_path)
+
+            def generate_all(self) -> list[Path]:
+                log.append("generate_all")
+                return []
+
+        monkeypatch.setattr("creek.generate.indexes.IndexGenerator", _FakeIG)
+        _sync_index(tmp_path)
+        assert "generate_all" in log
+
+    def test_pull_non_gdrive_is_noop(self, tmp_path: Path) -> None:
+        """A local source has no pull step."""
+        _sync_pull("journal", _fake_config(tmp_path, tmp_path, {}), tmp_path)
+
+    def test_pull_gdrive_unavailable_skips(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """gdrive pull skips cleanly when the optional libs are unavailable."""
+        from creek.ingest.gdrive import GoogleApiDriveClient
+
+        monkeypatch.setattr(GoogleApiDriveClient, "is_available", lambda _self: False)
+        _sync_pull("gdrive", _fake_config(tmp_path, tmp_path, {}), tmp_path)
+
+    def test_ingest_source_gdrive_is_noop(self, tmp_path: Path) -> None:
+        """gdrive is a downloader, not an ingestor — ingest step no-ops."""
+        _sync_ingest_source("gdrive", _fake_config(tmp_path, tmp_path, {}), tmp_path)
+
+    def test_ingest_source_journal_runs_incremental(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The journal source ingests incrementally from its source path."""
+        seen: dict[str, object] = {}
+        monkeypatch.setattr(
+            "creek.cli._run_ingest", lambda **kw: seen.update(kw) or (0, [], 0)
+        )
+        src = tmp_path / "src"
+        (src / "personal" / "journal").mkdir(parents=True)
+        cfg = _fake_config(tmp_path / "v", src, {"journal": True})
+        _sync_ingest_source("journal", cfg, tmp_path / "v")
+        assert seen["incremental"] is True
+        assert seen["source_type"] == "markdown"
+
+
+# ---- Real Tier-A idempotency -------------------------------------------
+
+
+class TestTierAIdempotent:
+    """A real Tier-A run (offline: ingest + rules-classify) is idempotent."""
+
+    def test_rerun_produces_no_duplicates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Re-running Tier A on unchanged journal source writes no duplicate."""
+        vault = tmp_path / "vault"
+        for d in ("00-Creek-Meta/Processing-Log", "01-Fragments/Journal"):
+            (vault / d).mkdir(parents=True, exist_ok=True)
+        journal = tmp_path / "src" / "personal" / "journal"
+        journal.mkdir(parents=True)
+        (journal / "day.md").write_text(
+            "---\ndate: 2026-06-26\n---\nA journal entry today.\n", encoding="utf-8"
+        )
+        cfg = _fake_config(vault, tmp_path / "src", {"journal": True})
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+
+        r1 = runner.invoke(app, ["sync", "--tier", "A", "--vault", str(vault)])
+        assert r1.exit_code == 0, r1.output
+        before = len(list((vault / "01-Fragments").rglob("*.md")))
+        assert before == 1
+
+        r2 = runner.invoke(app, ["sync", "--tier", "A", "--vault", str(vault)])
+        assert r2.exit_code == 0, r2.output
+        after = len(list((vault / "01-Fragments").rglob("*.md")))
+        assert after == before  # idempotent self-heal, no duplicates


### PR DESCRIPTION
## Summary

Turns the `creek sync` dry-run skeleton (#676) into a real executor (epic #669), wiring in the now-incremental ingest (#677) and the existing classify/link/index engines.

- **Tier A**, per enabled source: `pull → incremental ingest → rules classify`. **Linking and indexing are never invoked here** — R6: they are O(n²)/global and belong to Tier B.
- **Tier B**, global: `llm classify → link → index`.
- `--dry-run` still echoes the plan; per-source enable toggles honoured; `last-run.json` records the real `dry_run` flag.

### Self-healing / idempotency
Every step is idempotent, so a missed or forced re-run needs no catch-up queue: incremental ingest skips unchanged units (#677), `update_fragment` dedups, and OPS-001 short-circuits already-classified fragments — no duplicates, no double-LLM-spend.

### Wiring
Step helpers reuse existing engines, kept thin and individually testable: `_sync_pull` (gdrive downloader / local no-op), `_sync_ingest_source` (incremental `_run_ingest`), `_sync_classify` (`run_classify`), `_sync_link` (`run_link`), `_sync_index` (`IndexGenerator`). `pipeline.sync_ingest_type` exposes the source→ingestor map; `_sync_dispatch` holds the command's complexity ≤10.

## Test plan
`tests/test_sync_exec.py` (12 tests):
- **Orchestration** (spied steps): Tier A = `pull→ingest→classify:rules` with **no link/index** (R6 guard); Tier B = `classify:llm→link→index`; a disabled source is never pulled/ingested; `--dry-run` runs no step helpers.
- **Step delegation**: each helper calls the right engine (`run_classify` method, `run_link` embeddings, `IndexGenerator.generate_all`, gdrive-unavailable skip, gdrive ingest no-op, journal ingest with `incremental=True`).
- **Real idempotency E2E**: a real offline Tier-A run (ingest + rules-classify) on a journal source, twice → **one fragment, no duplicates**.
- `tests/test_sync.py`: existing plan-echo tests updated to `--dry-run` (non-dry-run now executes).

`./scripts/check-all.sh`: **12/12 gates green**.

## Scope
No schedule-file emission (#679), no `--status`/structured logging (#680). Doesn't change the #677 filter or Epic A ledger semantics.

Refs #669
Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)