### PR TITLE
feat(sync): emit launchd + systemd/cron deploy adapters (#679)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -959,7 +959,7 @@ def _install_launchd(
     hour: int,
     out_dir: Path | None,
 ) -> None:
-    """Write both launchd plists and print activation instructions (#679)."""
+    """Write both launchd plists and print activation instructions."""
     from creek.sync import render_launchd_plists
 
     plists = render_launchd_plists(
@@ -982,7 +982,7 @@ def _install_systemd(
     hour: int,
     out_dir: Path | None,
 ) -> None:
-    """Write systemd service+timer units (and print the cron alternative, #679)."""
+    """Write systemd service+timer units (and print the cron alternative)."""
     from creek.sync import render_crontab, render_systemd_units
 
     units = render_systemd_units(
@@ -1052,7 +1052,7 @@ def sync(
     ),
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
 ) -> None:
-    """Run a scheduled sync pass (#676/#678) or emit schedule units (#679).
+    """Run a scheduled sync pass (#676/#678) or emit schedule units.
 
     ``--tier A`` is the cheap per-source pass (pull -> incremental ingest ->
     rules classify) for each enabled source; ``--tier B`` is the nightly global

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -953,6 +953,80 @@ def _sync_dispatch(
         _sync_run_tier_b(config, vault_path)
 
 
+def _install_launchd(
+    vault_path: Path,
+    minutes: int,
+    hour: int,
+    out_dir: Path | None,
+) -> None:
+    """Write both launchd plists and print activation instructions (#679)."""
+    from creek.sync import render_launchd_plists
+
+    plists = render_launchd_plists(
+        vault=vault_path, tier_a_minutes=minutes, tier_b_hour=hour
+    )
+    base = out_dir or (Path.home() / "Library" / "LaunchAgents")
+    base.mkdir(parents=True, exist_ok=True)
+    tier_a = base / plists.tier_a_filename
+    tier_b = base / plists.tier_b_filename
+    tier_a.write_text(plists.tier_a, encoding="utf-8")
+    tier_b.write_text(plists.tier_b, encoding="utf-8")
+    console.print(f"# wrote {tier_a}")
+    console.print(f"# wrote {tier_b}")
+    console.print(f"# To activate: launchctl load {tier_a} && launchctl load {tier_b}")
+
+
+def _install_systemd(
+    vault_path: Path,
+    minutes: int,
+    hour: int,
+    out_dir: Path | None,
+) -> None:
+    """Write systemd service+timer units (and print the cron alternative, #679)."""
+    from creek.sync import render_crontab, render_systemd_units
+
+    units = render_systemd_units(
+        vault=vault_path, tier_a_minutes=minutes, tier_b_hour=hour
+    )
+    base = out_dir or (Path.home() / ".config" / "systemd" / "user")
+    base.mkdir(parents=True, exist_ok=True)
+    for fname, content in (
+        (units.tier_a_service_filename, units.tier_a_service),
+        (units.tier_a_timer_filename, units.tier_a_timer),
+        (units.tier_b_service_filename, units.tier_b_service),
+        (units.tier_b_timer_filename, units.tier_b_timer),
+    ):
+        (base / fname).write_text(content, encoding="utf-8")
+        console.print(f"# wrote {base / fname}")
+    console.print(
+        "# To activate: systemctl --user enable --now "
+        "creek-sync-tier-a.timer creek-sync-tier-b.timer",
+    )
+    console.print("# Or as cron (crontab -e):")
+    cron = render_crontab(vault=vault_path, tier_a_minutes=minutes, tier_b_hour=hour)
+    for line in cron.splitlines():
+        console.print(f"#   {line}")
+
+
+def _install_schedule(host: str, vault: Path | None, out_dir: Path | None) -> None:
+    """Emit schedule units for *host* (launchd|systemd), parametrised by config."""
+    if host not in {"launchd", "systemd"}:
+        console.print("[red]--install-schedule must be launchd or systemd[/red]")
+        raise typer.Exit(code=2)
+    config = _load_config_for_vault(vault)
+    vault_path = vault or config.vault_path
+    minutes = config.sync.tier_a_interval_minutes
+    hour = config.sync.tier_b_hour
+    if host == "launchd":
+        _install_launchd(vault_path, minutes, hour, out_dir)
+    else:
+        _install_systemd(vault_path, minutes, hour, out_dir)
+    console.print(
+        "# Tokens (OAuth) read from this host's keychain/env; "
+        "see docs/sync-scheduling.md",
+    )
+
+
 @app.command()
 def sync(
     tier: str = typer.Option(
@@ -966,9 +1040,19 @@ def sync(
     dry_run: bool = typer.Option(
         False, "--dry-run", help="Echo the plan without executing (current default)"
     ),
+    install_schedule: str | None = typer.Option(
+        None,
+        "--install-schedule",
+        help="Emit schedule units for a host (launchd|systemd) and exit",
+    ),
+    schedule_out_dir: Path | None = typer.Option(
+        None,
+        "--schedule-out-dir",
+        help="Directory to write emitted schedule units (default: host standard)",
+    ),
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
 ) -> None:
-    """Run a scheduled sync pass (#676/#678).
+    """Run a scheduled sync pass (#676/#678) or emit schedule units (#679).
 
     ``--tier A`` is the cheap per-source pass (pull -> incremental ingest ->
     rules classify) for each enabled source; ``--tier B`` is the nightly global
@@ -976,7 +1060,15 @@ def sync(
     B (R6). ``--dry-run`` echoes the ordered plan without executing. Every run
     records ``00-Creek-Meta/State/sync/last-run.json``; because every step is
     idempotent, a missed tick self-heals on the next run (no catch-up queue).
+
+    ``--install-schedule launchd|systemd`` emits the host's schedule units
+    (parametrised by the configured cadence) and exits without running a tier;
+    activating them is the operator's manual step (see docs/sync-scheduling.md).
     """
+    if install_schedule is not None:
+        _install_schedule(install_schedule, vault, schedule_out_dir)
+        return
+
     tier_norm = tier.upper()
     if tier_norm not in {"A", "B"}:
         console.print("[red]--tier must be A or B[/red]")

--- a/creek-tools/creek/sync/__init__.py
+++ b/creek-tools/creek/sync/__init__.py
@@ -1,0 +1,22 @@
+"""Scheduling adapters for ``creek sync`` (#679).
+
+Emits launchd / systemd / cron artifacts that run the two-tier sync on a
+schedule. These are *config artifacts* the operator installs manually — Creek
+never shells out to ``launchctl``/``systemctl``/``crontab``.
+"""
+
+from creek.sync.schedule import (
+    LaunchdPlists,
+    SystemdUnits,
+    render_crontab,
+    render_launchd_plists,
+    render_systemd_units,
+)
+
+__all__ = [
+    "LaunchdPlists",
+    "SystemdUnits",
+    "render_crontab",
+    "render_launchd_plists",
+    "render_systemd_units",
+]

--- a/creek-tools/creek/sync/schedule.py
+++ b/creek-tools/creek/sync/schedule.py
@@ -1,0 +1,191 @@
+"""Render launchd / systemd / cron schedule artifacts for ``creek sync`` (#679).
+
+Each renderer is a pure function: given a vault path and the config-tunable
+cadence (Tier-A interval in minutes, Tier-B nightly hour), it returns the unit
+file contents as strings. The CLI writes them to a host-appropriate location
+and prints activation instructions; installing them into the live system is the
+operator's manual step (SPEC decision #4 — BUILD BOTH host adapters).
+
+Tier A runs the cheap per-source pass (`creek sync --tier A`); Tier B runs the
+nightly global pass (`creek sync --tier B`). The embedded commands never contain
+`link`/`index` directly — those run inside Tier B only (R6).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# The scheduled command. ``creek`` is expected on PATH (or the operator edits
+# the absolute path into the emitted unit — noted in docs/sync-scheduling.md).
+_CREEK = "creek"
+
+
+def _tier_command(vault: Path, tier: str) -> str:
+    """Return the ``creek sync`` command line for *tier* against *vault*."""
+    return f"{_CREEK} sync --tier {tier} --vault {vault}"
+
+
+@dataclass(frozen=True)
+class LaunchdPlists:
+    """Rendered launchd plist contents for both tiers (macOS, #679)."""
+
+    tier_a: str
+    tier_b: str
+    tier_a_filename: str = "com.creek.sync.tier-a.plist"
+    tier_b_filename: str = "com.creek.sync.tier-b.plist"
+
+
+@dataclass(frozen=True)
+class SystemdUnits:
+    """Rendered systemd service+timer contents for both tiers (Linux, #679)."""
+
+    tier_a_service: str
+    tier_a_timer: str
+    tier_b_service: str
+    tier_b_timer: str
+    tier_a_service_filename: str = "creek-sync-tier-a.service"
+    tier_a_timer_filename: str = "creek-sync-tier-a.timer"
+    tier_b_service_filename: str = "creek-sync-tier-b.service"
+    tier_b_timer_filename: str = "creek-sync-tier-b.timer"
+
+
+def _plist(label: str, command: str, schedule_xml: str) -> str:
+    """Render one launchd plist with *schedule_xml* as the cadence element."""
+    program_args = "".join(
+        f"        <string>{arg}</string>\n" for arg in command.split()
+    )
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" '
+        '"http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n'
+        '<plist version="1.0">\n'
+        "  <dict>\n"
+        "    <key>Label</key>\n"
+        f"    <string>{label}</string>\n"
+        "    <key>ProgramArguments</key>\n"
+        "    <array>\n"
+        f"{program_args}"
+        "    </array>\n"
+        f"{schedule_xml}"
+        "    <key>RunAtLoad</key>\n"
+        "    <false/>\n"
+        "  </dict>\n"
+        "</plist>\n"
+    )
+
+
+def render_launchd_plists(
+    *,
+    vault: Path,
+    tier_a_minutes: int = 30,
+    tier_b_hour: int = 3,
+) -> LaunchdPlists:
+    """Render the Tier-A and Tier-B launchd plists for *vault* (#679).
+
+    Tier A uses ``StartInterval`` (the configured minutes, in seconds); Tier B
+    uses ``StartCalendarInterval`` at the configured nightly hour.
+    """
+    tier_a_schedule = (
+        f"    <key>StartInterval</key>\n    <integer>{tier_a_minutes * 60}</integer>\n"
+    )
+    tier_b_schedule = (
+        "    <key>StartCalendarInterval</key>\n"
+        "    <dict>\n"
+        "      <key>Hour</key>\n"
+        f"      <integer>{tier_b_hour}</integer>\n"
+        "      <key>Minute</key>\n"
+        "      <integer>0</integer>\n"
+        "    </dict>\n"
+    )
+    return LaunchdPlists(
+        tier_a=_plist(
+            "com.creek.sync.tier-a",
+            _tier_command(vault, "A"),
+            tier_a_schedule,
+        ),
+        tier_b=_plist(
+            "com.creek.sync.tier-b",
+            _tier_command(vault, "B"),
+            tier_b_schedule,
+        ),
+    )
+
+
+def _service(description: str, command: str) -> str:
+    """Render a oneshot systemd service that runs *command*."""
+    return (
+        "[Unit]\n"
+        f"Description={description}\n\n"
+        "[Service]\n"
+        "Type=oneshot\n"
+        f"ExecStart={command}\n"
+    )
+
+
+def _timer(description: str, on_calendar: str, unit: str) -> str:
+    """Render a systemd timer firing *unit* on the *on_calendar* schedule."""
+    return (
+        "[Unit]\n"
+        f"Description={description}\n\n"
+        "[Timer]\n"
+        f"OnCalendar={on_calendar}\n"
+        "Persistent=true\n"
+        f"Unit={unit}\n\n"
+        "[Install]\n"
+        "WantedBy=timers.target\n"
+    )
+
+
+def render_systemd_units(
+    *,
+    vault: Path,
+    tier_a_minutes: int = 30,
+    tier_b_hour: int = 3,
+) -> SystemdUnits:
+    """Render the Tier-A/B systemd service + timer units for *vault* (#679).
+
+    Tier A fires every ``tier_a_minutes`` (``OnCalendar=*:0/N``); Tier B fires
+    nightly at ``tier_b_hour`` (``OnCalendar=*-*-* HH:00:00``). ``Persistent``
+    means a missed tick (host asleep) runs on next boot — self-healing.
+    """
+    units = SystemdUnits(
+        tier_a_service=_service(
+            "Creek sync (Tier A: pull/ingest/rules-classify)",
+            _tier_command(vault, "A"),
+        ),
+        tier_a_timer=_timer(
+            "Creek sync Tier A schedule",
+            f"*:0/{tier_a_minutes}",
+            "creek-sync-tier-a.service",
+        ),
+        tier_b_service=_service(
+            "Creek sync (Tier B: llm-classify/link/index)",
+            _tier_command(vault, "B"),
+        ),
+        tier_b_timer=_timer(
+            "Creek sync Tier B schedule",
+            f"*-*-* {tier_b_hour:02d}:00:00",
+            "creek-sync-tier-b.service",
+        ),
+    )
+    return units
+
+
+def render_crontab(
+    *,
+    vault: Path,
+    tier_a_minutes: int = 30,
+    tier_b_hour: int = 3,
+) -> str:
+    """Render a two-line crontab for the Tier-A/B sync passes (#679)."""
+    tier_a = f"*/{tier_a_minutes} * * * * {_tier_command(vault, 'A')}"
+    tier_b = f"0 {tier_b_hour} * * * {_tier_command(vault, 'B')}"
+    return (
+        "# Creek sync schedule (crontab) — install with `crontab -e`\n"
+        f"{tier_a}\n"
+        f"{tier_b}\n"
+    )

--- a/creek-tools/creek/sync/schedule.py
+++ b/creek-tools/creek/sync/schedule.py
@@ -1,4 +1,4 @@
-"""Render launchd / systemd / cron schedule artifacts for ``creek sync`` (#679).
+"""Render launchd / systemd / cron schedule artifacts for ``creek sync``.
 
 Each renderer is a pure function: given a vault path and the config-tunable
 cadence (Tier-A interval in minutes, Tier-B nightly hour), it returns the unit
@@ -9,10 +9,16 @@ operator's manual step (SPEC decision #4 — BUILD BOTH host adapters).
 Tier A runs the cheap per-source pass (`creek sync --tier A`); Tier B runs the
 nightly global pass (`creek sync --tier B`). The embedded commands never contain
 `link`/`index` directly — those run inside Tier B only (R6).
+
+Vault paths may contain spaces (common on macOS, e.g. ``~/Documents/My
+Notes``): launchd receives the command as an argument *list* (one ``<string>``
+per token, so the path stays whole), while systemd ``ExecStart`` and the cron
+line *quote* the path.
 """
 
 from __future__ import annotations
 
+import html
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -24,14 +30,19 @@ if TYPE_CHECKING:
 _CREEK = "creek"
 
 
-def _tier_command(vault: Path, tier: str) -> str:
-    """Return the ``creek sync`` command line for *tier* against *vault*."""
-    return f"{_CREEK} sync --tier {tier} --vault {vault}"
+def _tier_args(vault: Path, tier: str) -> list[str]:
+    """Return the ``creek sync`` argv for *tier* (path kept as one token)."""
+    return [_CREEK, "sync", "--tier", tier, "--vault", str(vault)]
+
+
+def _tier_command_quoted(vault: Path, tier: str) -> str:
+    """Return the ``creek sync`` command line with the vault path quoted."""
+    return f'{_CREEK} sync --tier {tier} --vault "{vault}"'
 
 
 @dataclass(frozen=True)
 class LaunchdPlists:
-    """Rendered launchd plist contents for both tiers (macOS, #679)."""
+    """Rendered launchd plist contents for both tiers (macOS)."""
 
     tier_a: str
     tier_b: str
@@ -41,7 +52,7 @@ class LaunchdPlists:
 
 @dataclass(frozen=True)
 class SystemdUnits:
-    """Rendered systemd service+timer contents for both tiers (Linux, #679)."""
+    """Rendered systemd service+timer contents for both tiers (Linux)."""
 
     tier_a_service: str
     tier_a_timer: str
@@ -53,10 +64,14 @@ class SystemdUnits:
     tier_b_timer_filename: str = "creek-sync-tier-b.timer"
 
 
-def _plist(label: str, command: str, schedule_xml: str) -> str:
-    """Render one launchd plist with *schedule_xml* as the cadence element."""
+def _plist(label: str, args: list[str], schedule_xml: str) -> str:
+    """Render one launchd plist with *schedule_xml* as the cadence element.
+
+    Each argv token becomes one ``<string>`` element (so a vault path with
+    spaces stays intact), XML-escaped to stay well-formed for any path.
+    """
     program_args = "".join(
-        f"        <string>{arg}</string>\n" for arg in command.split()
+        f"        <string>{html.escape(arg)}</string>\n" for arg in args
     )
     return (
         '<?xml version="1.0" encoding="UTF-8"?>\n'
@@ -84,7 +99,7 @@ def render_launchd_plists(
     tier_a_minutes: int = 30,
     tier_b_hour: int = 3,
 ) -> LaunchdPlists:
-    """Render the Tier-A and Tier-B launchd plists for *vault* (#679).
+    """Render the Tier-A and Tier-B launchd plists for *vault*.
 
     Tier A uses ``StartInterval`` (the configured minutes, in seconds); Tier B
     uses ``StartCalendarInterval`` at the configured nightly hour.
@@ -104,12 +119,12 @@ def render_launchd_plists(
     return LaunchdPlists(
         tier_a=_plist(
             "com.creek.sync.tier-a",
-            _tier_command(vault, "A"),
+            _tier_args(vault, "A"),
             tier_a_schedule,
         ),
         tier_b=_plist(
             "com.creek.sync.tier-b",
-            _tier_command(vault, "B"),
+            _tier_args(vault, "B"),
             tier_b_schedule,
         ),
     )
@@ -146,7 +161,7 @@ def render_systemd_units(
     tier_a_minutes: int = 30,
     tier_b_hour: int = 3,
 ) -> SystemdUnits:
-    """Render the Tier-A/B systemd service + timer units for *vault* (#679).
+    """Render the Tier-A/B systemd service + timer units for *vault*.
 
     Tier A fires every ``tier_a_minutes`` (``OnCalendar=*:0/N``); Tier B fires
     nightly at ``tier_b_hour`` (``OnCalendar=*-*-* HH:00:00``). ``Persistent``
@@ -155,7 +170,7 @@ def render_systemd_units(
     units = SystemdUnits(
         tier_a_service=_service(
             "Creek sync (Tier A: pull/ingest/rules-classify)",
-            _tier_command(vault, "A"),
+            _tier_command_quoted(vault, "A"),
         ),
         tier_a_timer=_timer(
             "Creek sync Tier A schedule",
@@ -164,7 +179,7 @@ def render_systemd_units(
         ),
         tier_b_service=_service(
             "Creek sync (Tier B: llm-classify/link/index)",
-            _tier_command(vault, "B"),
+            _tier_command_quoted(vault, "B"),
         ),
         tier_b_timer=_timer(
             "Creek sync Tier B schedule",
@@ -181,9 +196,9 @@ def render_crontab(
     tier_a_minutes: int = 30,
     tier_b_hour: int = 3,
 ) -> str:
-    """Render a two-line crontab for the Tier-A/B sync passes (#679)."""
-    tier_a = f"*/{tier_a_minutes} * * * * {_tier_command(vault, 'A')}"
-    tier_b = f"0 {tier_b_hour} * * * {_tier_command(vault, 'B')}"
+    """Render a two-line crontab for the Tier-A/B sync passes."""
+    tier_a = f"*/{tier_a_minutes} * * * * {_tier_command_quoted(vault, 'A')}"
+    tier_b = f"0 {tier_b_hour} * * * {_tier_command_quoted(vault, 'B')}"
     return (
         "# Creek sync schedule (crontab) — install with `crontab -e`\n"
         f"{tier_a}\n"

--- a/creek-tools/docs/sync-scheduling.md
+++ b/creek-tools/docs/sync-scheduling.md
@@ -66,3 +66,7 @@ lines — paste them into `crontab -e`.
 > The emitted units invoke `creek` from `PATH`. If `creek` is not on the
 > scheduler's `PATH` (e.g. it lives in a `uv`/virtualenv), edit the unit to use
 > the absolute path to the `creek` binary before activating.
+
+> Vault paths containing spaces (e.g. `~/Documents/My Notes`) are handled
+> correctly: launchd passes the path as a single argument, and the systemd/cron
+> commands quote it.

--- a/creek-tools/docs/sync-scheduling.md
+++ b/creek-tools/docs/sync-scheduling.md
@@ -1,0 +1,68 @@
+# Scheduling `creek sync`
+
+`creek sync` runs the two-tier incremental pipeline (see
+[idempotent-ingest.md](idempotent-ingest.md)). To keep your vault current
+without running it by hand, schedule it on a host. Creek **emits** the schedule
+units for you; activating them is a one-time manual step (Creek never runs
+`launchctl`/`systemctl`/`crontab` for you).
+
+```bash
+creek sync --install-schedule launchd --vault /path/to/vault   # macOS laptop
+creek sync --install-schedule systemd --vault /path/to/vault   # Linux always-on box
+```
+
+Both emit a **Tier A** unit (every 30 min by default: pull → incremental ingest
+→ rules-classify) and a **Tier B** unit (nightly ~03:00: LLM-classify → link →
+index). The cadence comes from your config (`sync.tier_a_interval_minutes`,
+`sync.tier_b_hour`), so edit those before installing if you want a different
+rhythm. Pass `--schedule-out-dir <dir>` to write the units somewhere other than
+the host-standard location.
+
+## Which host?
+
+Decision #4 of the ingest SPEC is **build both** — pick per how you work:
+
+| | **Laptop (launchd)** | **Always-on mini / VPS (systemd or cron)** |
+|---|---|---|
+| Runs when | only while the laptop is awake and logged in | 24/7 |
+| Missed ticks | skipped while asleep (launchd coalesces) | `Persistent=true` runs a missed tick on next boot |
+| Best for | keeping a personal machine's journal current | Discord live-capture and anything that must not miss windows |
+| Setup | `launchctl load ~/Library/LaunchAgents/com.creek.sync.tier-*.plist` | `systemctl --user enable --now creek-sync-tier-*.timer` (or `crontab -e`) |
+
+The always-on box is recommended if you want the vault genuinely current
+around the clock — a closed laptop simply doesn't run Tier A.
+
+## Where tokens live
+
+OAuth credentials/tokens (e.g. Google Drive `credentials.json` / `token.json`)
+and any API keys/consent are read from **the environment of the host that runs
+the adapter** — never from the emitted unit files, which contain only paths and
+schedules. So:
+
+- Install the schedule on the host where the tokens already live (or copy the
+  token files there first), and ensure that host's user environment has the
+  required keys/consent set (e.g. in the shell profile the scheduler inherits).
+- Moving the schedule to a different host means moving (or re-authorising) the
+  tokens on that host too.
+
+## Activating the emitted units
+
+**launchd (macOS):**
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.creek.sync.tier-a.plist
+launchctl load ~/Library/LaunchAgents/com.creek.sync.tier-b.plist
+```
+
+**systemd (Linux, user units):**
+
+```bash
+systemctl --user enable --now creek-sync-tier-a.timer creek-sync-tier-b.timer
+```
+
+**cron (any POSIX host):** the systemd install also prints equivalent crontab
+lines — paste them into `crontab -e`.
+
+> The emitted units invoke `creek` from `PATH`. If `creek` is not on the
+> scheduler's `PATH` (e.g. it lives in a `uv`/virtualenv), edit the unit to use
+> the absolute path to the `creek` binary before activating.

--- a/creek-tools/tests/test_sync_schedule.py
+++ b/creek-tools/tests/test_sync_schedule.py
@@ -1,0 +1,179 @@
+"""Schedule-emitter tests for ``creek sync --install-schedule`` (#679).
+
+Renders launchd / systemd / cron artifacts parametrised by the config cadence,
+and verifies the emitted units are valid and embed the right ``creek sync``
+command (Tier A never contains link/index — R6).
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.config import CreekConfig
+from creek.sync import (
+    render_crontab,
+    render_launchd_plists,
+    render_systemd_units,
+)
+
+if TYPE_CHECKING:
+    import pytest
+
+runner = CliRunner()
+_VAULT = Path("/Users/me/Vault")
+
+
+# ---- launchd ------------------------------------------------------------
+
+
+class TestLaunchd:
+    """launchd plists are well-formed and carry the configured cadence."""
+
+    def test_plists_are_valid_xml(self) -> None:
+        """Both rendered plists parse as XML."""
+        plists = render_launchd_plists(vault=_VAULT)
+        ET.fromstring(plists.tier_a)
+        ET.fromstring(plists.tier_b)
+
+    def test_tier_a_interval_in_seconds(self) -> None:
+        """Tier A StartInterval is the configured minutes, in seconds."""
+        plists = render_launchd_plists(vault=_VAULT, tier_a_minutes=30)
+        assert "<key>StartInterval</key>" in plists.tier_a
+        assert "<integer>1800</integer>" in plists.tier_a  # 30 * 60
+
+    def test_tier_b_nightly_hour(self) -> None:
+        """Tier B StartCalendarInterval fires at the configured hour."""
+        plists = render_launchd_plists(vault=_VAULT, tier_b_hour=3)
+        assert "<key>StartCalendarInterval</key>" in plists.tier_b
+        assert "<key>Hour</key>\n      <integer>3</integer>" in plists.tier_b
+
+    def test_command_and_r6(self) -> None:
+        """The command targets the vault; Tier A never references link/index."""
+        plists = render_launchd_plists(vault=_VAULT)
+        assert "<string>creek</string>" in plists.tier_a
+        assert f"<string>{_VAULT}</string>" in plists.tier_a
+        assert "<string>A</string>" in plists.tier_a
+        assert "link" not in plists.tier_a
+        assert "index" not in plists.tier_a
+
+
+# ---- systemd ------------------------------------------------------------
+
+
+class TestSystemd:
+    """systemd timers carry the configured OnCalendar; services embed the cmd."""
+
+    def test_timer_uses_configured_cadence(self) -> None:
+        """Tier-A every-N-min and Tier-B nightly OnCalendar match config."""
+        units = render_systemd_units(vault=_VAULT, tier_a_minutes=30, tier_b_hour=3)
+        assert "OnCalendar=*:0/30" in units.tier_a_timer
+        assert "OnCalendar=*-*-* 03:00:00" in units.tier_b_timer
+
+    def test_service_embeds_command(self) -> None:
+        """Each service ExecStart runs the right tier against the vault."""
+        units = render_systemd_units(vault=_VAULT)
+        assert f"creek sync --tier A --vault {_VAULT}" in units.tier_a_service
+        assert f"creek sync --tier B --vault {_VAULT}" in units.tier_b_service
+
+    def test_tier_a_service_has_no_link_or_index(self) -> None:
+        """R6: the Tier-A unit never references link/index."""
+        units = render_systemd_units(vault=_VAULT)
+        assert "link" not in units.tier_a_service
+        assert "index" not in units.tier_a_service
+
+    def test_custom_cadence_is_parametrised(self) -> None:
+        """Non-default cadence values flow into the timers."""
+        units = render_systemd_units(vault=_VAULT, tier_a_minutes=15, tier_b_hour=5)
+        assert "OnCalendar=*:0/15" in units.tier_a_timer
+        assert "OnCalendar=*-*-* 05:00:00" in units.tier_b_timer
+
+
+# ---- cron ---------------------------------------------------------------
+
+
+class TestCron:
+    """The crontab lines have the right schedule and command."""
+
+    def test_crontab_schedule_and_command(self) -> None:
+        """Tier A every 30 min, Tier B nightly at hour 3, against the vault."""
+        cron = render_crontab(vault=_VAULT, tier_a_minutes=30, tier_b_hour=3)
+        assert f"*/30 * * * * creek sync --tier A --vault {_VAULT}" in cron
+        assert f"0 3 * * * creek sync --tier B --vault {_VAULT}" in cron
+
+
+# ---- CLI: --install-schedule -------------------------------------------
+
+
+class TestInstallScheduleCli:
+    """The command writes the units to the chosen directory."""
+
+    def test_launchd_writes_two_plists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`--install-schedule launchd` writes both plists and exits 0."""
+        monkeypatch.setattr(
+            "creek.cli._load_config_for_vault", lambda _v: CreekConfig()
+        )
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "sync",
+                "--install-schedule",
+                "launchd",
+                "--schedule-out-dir",
+                str(out),
+                "--vault",
+                str(tmp_path / "v"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (out / "com.creek.sync.tier-a.plist").exists()
+        assert (out / "com.creek.sync.tier-b.plist").exists()
+
+    def test_systemd_writes_four_units(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`--install-schedule systemd` writes the service+timer pair per tier."""
+        monkeypatch.setattr(
+            "creek.cli._load_config_for_vault", lambda _v: CreekConfig()
+        )
+        out = tmp_path / "out"
+        result = runner.invoke(
+            app,
+            [
+                "sync",
+                "--install-schedule",
+                "systemd",
+                "--schedule-out-dir",
+                str(out),
+                "--vault",
+                str(tmp_path / "v"),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        for fname in (
+            "creek-sync-tier-a.service",
+            "creek-sync-tier-a.timer",
+            "creek-sync-tier-b.service",
+            "creek-sync-tier-b.timer",
+        ):
+            assert (out / fname).exists()
+
+    def test_invalid_host_errors(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unknown host exits non-zero."""
+        monkeypatch.setattr(
+            "creek.cli._load_config_for_vault", lambda _v: CreekConfig()
+        )
+        result = runner.invoke(
+            app,
+            ["sync", "--install-schedule", "windows", "--vault", str(tmp_path / "v")],
+        )
+        assert result.exit_code != 0

--- a/creek-tools/tests/test_sync_schedule.py
+++ b/creek-tools/tests/test_sync_schedule.py
@@ -61,6 +61,19 @@ class TestLaunchd:
         assert "link" not in plists.tier_a
         assert "index" not in plists.tier_a
 
+    def test_vault_with_spaces_stays_one_string(self) -> None:
+        """A spaced vault path is a single <string>, not word-split."""
+        spaced = Path("/Users/me/My Notes")
+        plists = render_launchd_plists(vault=spaced)
+        assert "<string>/Users/me/My Notes</string>" in plists.tier_a
+        assert "<string>Notes</string>" not in plists.tier_a  # not split
+
+    def test_xml_special_chars_are_escaped(self) -> None:
+        """A vault path with XML metacharacters stays well-formed."""
+        plists = render_launchd_plists(vault=Path("/Users/me/A&B"))
+        ET.fromstring(plists.tier_a)
+        assert "<string>/Users/me/A&amp;B</string>" in plists.tier_a
+
 
 # ---- systemd ------------------------------------------------------------
 
@@ -75,10 +88,10 @@ class TestSystemd:
         assert "OnCalendar=*-*-* 03:00:00" in units.tier_b_timer
 
     def test_service_embeds_command(self) -> None:
-        """Each service ExecStart runs the right tier against the vault."""
+        """Each service ExecStart runs the right tier against the (quoted) vault."""
         units = render_systemd_units(vault=_VAULT)
-        assert f"creek sync --tier A --vault {_VAULT}" in units.tier_a_service
-        assert f"creek sync --tier B --vault {_VAULT}" in units.tier_b_service
+        assert f'creek sync --tier A --vault "{_VAULT}"' in units.tier_a_service
+        assert f'creek sync --tier B --vault "{_VAULT}"' in units.tier_b_service
 
     def test_tier_a_service_has_no_link_or_index(self) -> None:
         """R6: the Tier-A unit never references link/index."""
@@ -92,6 +105,14 @@ class TestSystemd:
         assert "OnCalendar=*:0/15" in units.tier_a_timer
         assert "OnCalendar=*-*-* 05:00:00" in units.tier_b_timer
 
+    def test_vault_with_spaces_is_quoted(self) -> None:
+        """A spaced vault path is quoted in ExecStart (one --vault argument)."""
+        spaced = Path("/Users/me/My Notes")
+        units = render_systemd_units(vault=spaced)
+        assert 'ExecStart=creek sync --tier A --vault "/Users/me/My Notes"' in (
+            units.tier_a_service
+        )
+
 
 # ---- cron ---------------------------------------------------------------
 
@@ -102,8 +123,13 @@ class TestCron:
     def test_crontab_schedule_and_command(self) -> None:
         """Tier A every 30 min, Tier B nightly at hour 3, against the vault."""
         cron = render_crontab(vault=_VAULT, tier_a_minutes=30, tier_b_hour=3)
-        assert f"*/30 * * * * creek sync --tier A --vault {_VAULT}" in cron
-        assert f"0 3 * * * creek sync --tier B --vault {_VAULT}" in cron
+        assert f'*/30 * * * * creek sync --tier A --vault "{_VAULT}"' in cron
+        assert f'0 3 * * * creek sync --tier B --vault "{_VAULT}"' in cron
+
+    def test_vault_with_spaces_is_quoted(self) -> None:
+        """A spaced vault path is quoted in the cron command."""
+        cron = render_crontab(vault=Path("/Users/me/My Notes"))
+        assert 'creek sync --tier A --vault "/Users/me/My Notes"' in cron
 
 
 # ---- CLI: --install-schedule -------------------------------------------
@@ -135,6 +161,27 @@ class TestInstallScheduleCli:
         assert result.exit_code == 0, result.output
         assert (out / "com.creek.sync.tier-a.plist").exists()
         assert (out / "com.creek.sync.tier-b.plist").exists()
+        # The written content targets the chosen vault.
+        plist = (out / "com.creek.sync.tier-a.plist").read_text(encoding="utf-8")
+        assert f"<string>{tmp_path / 'v'}</string>" in plist
+
+    def test_default_output_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without --schedule-out-dir, launchd plists land in ~/Library/LaunchAgents."""
+        monkeypatch.setattr(
+            "creek.cli._load_config_for_vault", lambda _v: CreekConfig()
+        )
+        home = tmp_path / "home"
+        monkeypatch.setattr("pathlib.Path.home", lambda: home)
+        result = runner.invoke(
+            app,
+            ["sync", "--install-schedule", "launchd", "--vault", str(tmp_path / "v")],
+        )
+        assert result.exit_code == 0, result.output
+        assert (
+            home / "Library" / "LaunchAgents" / "com.creek.sync.tier-a.plist"
+        ).exists()
 
     def test_systemd_writes_four_units(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Summary

Lets `creek sync` schedule itself on a host (epic #669, SPEC decision #4 — **BUILD BOTH** adapters): `creek sync --install-schedule <launchd|systemd>` emits the Tier-A and Tier-B schedule units, parametrised by the configured cadence, and prints activation instructions. Creek **never** shells out to `launchctl`/`systemctl`/`crontab` — activation is the operator's one-time manual step.

### What's here
- **`creek/sync/schedule.py`** — pure renderers (no I/O):
  - `render_launchd_plists` — Tier A `StartInterval` (minutes×60s), Tier B `StartCalendarInterval` at the configured hour.
  - `render_systemd_units` — `.service` + `.timer` per tier; `OnCalendar=*:0/30` (Tier A) and `*-*-* 03:00:00` (Tier B); `Persistent=true` so a missed tick runs on next boot (self-healing).
  - `render_crontab` — `*/30 … --tier A` and `0 3 … --tier B`.
  - All parametrised by `sync.tier_a_interval_minutes` / `sync.tier_b_hour`. Tier-A units never reference `link`/`index` (R6).
- **cli**: `--install-schedule` + `--schedule-out-dir` write the units (host-standard location or a chosen dir) and print activation + the cron alternative + the token-location note.
- **docs/sync-scheduling.md** — laptop (launchd) vs always-on (systemd/cron) trade-off, and where OAuth tokens live (on the host that runs the adapter, never in the unit files).

## Test plan
`tests/test_sync_schedule.py` (12 tests): plists parse as valid XML; Tier-A `StartInterval=1800`; Tier-B `Hour=3`; systemd `OnCalendar` for default + custom cadence; service `ExecStart` embeds `creek sync --tier A|B --vault <vault>`; **Tier-A units contain no link/index** (R6); crontab schedule+command; and the CLI writes 2 plists / 4 systemd units to `--schedule-out-dir`, with an invalid host exiting non-zero.

`./scripts/check-all.sh`: **12/12 gates green**.

## Scope
Emit-only — no shelling out to install/enable. No tier-execution change (#678), no `--status`/logging (#680).

Refs #669
Closes #679

🤖 Generated with [Claude Code](https://claude.com/claude-code)