### PR TITLE
feat(sync): structured logging + creek sync --status (#680)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -811,6 +811,7 @@ def _write_sync_state(
             prior = None
     now = datetime.now(UTC).isoformat()
     prior_sources = prior.get("sources", {}) if isinstance(prior, dict) else {}
+    # Guard against a corrupted file where "sources" is not a dict.
     sources = dict(prior_sources) if isinstance(prior_sources, dict) else {}
     for name, ingested in (source_counts or {}).items():
         sources[name] = {"tier": tier, "at": now, "ingested": ingested}
@@ -831,8 +832,9 @@ def _sync_status(vault_path: Path) -> None:
     except (OSError, json.JSONDecodeError):
         console.print("[red]last-run.json is unreadable.[/red]")
         return
+    dry = " (dry-run)" if state.get("dry_run") else ""
     console.print(
-        f"[bold]Last sync:[/bold] tier={state.get('tier')} at {state.get('at')}",
+        f"[bold]Last sync:[/bold] tier={state.get('tier')}{dry} at {state.get('at')}",
     )
     sources = state.get("sources", {})
     if not isinstance(sources, dict) or not sources:
@@ -978,7 +980,7 @@ def _sync_run_tier_a(
         _sync_pull(source, config, vault_path)
         counts[source] = _sync_ingest_source(source, config, vault_path)
     _sync_classify(vault_path, config, "rules")
-    logger.info("sync.tier_a.done sources=%d", len(sources))
+    logger.info("sync.tier_a.done count=%d", len(sources))
     return counts
 
 
@@ -1155,8 +1157,9 @@ def sync(
     exits; ``--status`` prints the per-source last-run table and exits.
     """
     if status:
-        config = _load_config_for_vault(vault)
-        _sync_status(vault or config.vault_path)
+        # Status only needs the vault path; avoid loading (and possibly failing
+        # on) the config when --vault is explicitly given.
+        _sync_status(vault or _load_config_for_vault(None).vault_path)
         return
 
     if install_schedule is not None:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -781,14 +781,27 @@ def init(
         )
 
 
+def _sync_state_path(vault_path: Path) -> Path:
+    """Return the sync last-run state file path."""
+    return vault_path / "00-Creek-Meta" / "State" / "sync" / "last-run.json"
+
+
 def _write_sync_state(
     vault_path: Path,
     tier: str,
     *,
     dry_run: bool,
+    source_counts: dict[str, int] | None = None,
 ) -> dict[str, object] | None:
-    """Write the sync last-run state, returning the prior state if any (#676)."""
-    state_path = vault_path / "00-Creek-Meta" / "State" / "sync" / "last-run.json"
+    """Write the sync last-run state, returning the prior state if any (#676).
+
+    Keeps the #676 top-level keys (``tier``/``at``/``dry_run``) and adds a
+    backward-compatible per-source ``sources`` block (#680): each enabled source
+    records its last ``{tier, at, ingested}``. Sources untouched by this run
+    keep their prior entry, so ``--status`` always reflects the latest run of
+    each source.
+    """
+    state_path = _sync_state_path(vault_path)
     prior: dict[str, object] | None = None
     if state_path.exists():
         try:
@@ -796,10 +809,45 @@ def _write_sync_state(
             prior = loaded if isinstance(loaded, dict) else None
         except (OSError, json.JSONDecodeError):
             prior = None
+    now = datetime.now(UTC).isoformat()
+    prior_sources = prior.get("sources", {}) if isinstance(prior, dict) else {}
+    sources = dict(prior_sources) if isinstance(prior_sources, dict) else {}
+    for name, ingested in (source_counts or {}).items():
+        sources[name] = {"tier": tier, "at": now, "ingested": ingested}
     state_path.parent.mkdir(parents=True, exist_ok=True)
-    state = {"tier": tier, "at": datetime.now(UTC).isoformat(), "dry_run": dry_run}
+    state = {"tier": tier, "at": now, "dry_run": dry_run, "sources": sources}
     state_path.write_text(json.dumps(state, indent=2), encoding="utf-8")
     return prior
+
+
+def _sync_status(vault_path: Path) -> None:
+    """Print the per-source last-run + counts from last-run.json (#680)."""
+    state_path = _sync_state_path(vault_path)
+    if not state_path.exists():
+        console.print("[yellow]No sync has run yet (no last-run.json).[/yellow]")
+        return
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        console.print("[red]last-run.json is unreadable.[/red]")
+        return
+    console.print(
+        f"[bold]Last sync:[/bold] tier={state.get('tier')} at {state.get('at')}",
+    )
+    sources = state.get("sources", {})
+    if not isinstance(sources, dict) or not sources:
+        console.print("[dim](no per-source runs recorded yet)[/dim]")
+        return
+    table = Table("source", "last tier", "last run", "ingested")
+    for name, entry in sorted(sources.items()):
+        cells = entry if isinstance(entry, dict) else {}
+        table.add_row(
+            name,
+            str(cells.get("tier", "")),
+            str(cells.get("at", "")),
+            str(cells.get("ingested", "")),
+        )
+    console.print(table)
 
 
 def _sync_tier_a(
@@ -860,23 +908,28 @@ def _sync_pull(source: str, config: CreekConfig, _vault_path: Path) -> None:
     )
 
 
-def _sync_ingest_source(source: str, config: CreekConfig, vault_path: Path) -> None:
-    """Incrementally ingest one Tier-A source via its mapped ingestor (#678)."""
+def _sync_ingest_source(source: str, config: CreekConfig, vault_path: Path) -> int:
+    """Incrementally ingest one Tier-A source; return the units processed (#678).
+
+    Returns ``0`` when the source has no ingestor (e.g. gdrive) or its path is
+    missing — both are logged so a scheduled run's no-ops are diagnosable.
+    """
     from creek.ingest import INGESTOR_REGISTRY
     from creek.pipeline import sync_ingest_type
 
     ingest_type = sync_ingest_type(source)
     ingestor_cls = INGESTOR_REGISTRY.get(ingest_type)
     if ingestor_cls is None:
-        return  # e.g. gdrive is a downloader, not an ingestor
+        return 0  # e.g. gdrive is a downloader, not an ingestor
     input_path = _sync_source_input(source, config)
     if input_path is None or not input_path.exists():
         console.print(
             f"[yellow][sync] skipping {source}: source path not found "
             f"({input_path}).[/yellow]",
         )
-        return
-    _run_ingest(
+        logger.info("sync.tier_a.skip source=%s reason=path-missing", source)
+        return 0
+    written, _errors, _discovered = _run_ingest(
         ingestor_cls=ingestor_cls,
         source_type=ingest_type,
         input_path=input_path,
@@ -884,6 +937,8 @@ def _sync_ingest_source(source: str, config: CreekConfig, vault_path: Path) -> N
         reclassify_threshold=config.classification.reclassify_on_edit_threshold,
         incremental=True,
     )
+    logger.info("sync.tier_a.ingest source=%s ingested=%d", source, written)
+    return written
 
 
 def _sync_classify(vault_path: Path, config: CreekConfig, method: str) -> None:
@@ -911,16 +966,20 @@ def _sync_run_tier_a(
     config: CreekConfig,
     vault_path: Path,
     sources: list[str],
-) -> None:
-    """Execute Tier A: per source pull + incremental ingest, then rules classify.
+) -> dict[str, int]:
+    """Execute Tier A; return per-source ingested counts (#678/#680).
 
+    Per source: pull + incremental ingest, then one rules-classify pass.
     Linking and indexing are **never** invoked here (R6: they are O(n²)/global
     and belong to Tier B).
     """
+    counts: dict[str, int] = {}
     for source in sources:
         _sync_pull(source, config, vault_path)
-        _sync_ingest_source(source, config, vault_path)
+        counts[source] = _sync_ingest_source(source, config, vault_path)
     _sync_classify(vault_path, config, "rules")
+    logger.info("sync.tier_a.done sources=%d", len(sources))
+    return counts
 
 
 def _sync_run_tier_b(config: CreekConfig, vault_path: Path) -> None:
@@ -928,6 +987,7 @@ def _sync_run_tier_b(config: CreekConfig, vault_path: Path) -> None:
     _sync_classify(vault_path, config, "llm")
     _sync_link(vault_path, config)
     _sync_index(vault_path)
+    logger.info("sync.tier_b.done")
 
 
 def _sync_dispatch(
@@ -937,20 +997,25 @@ def _sync_dispatch(
     config: CreekConfig,
     vault_path: Path,
     source: str | None,
-) -> None:
-    """Echo (dry-run) or execute the chosen sync tier (#678)."""
+) -> dict[str, int] | None:
+    """Echo (dry-run) or execute the chosen sync tier; return Tier-A counts.
+
+    Returns the per-source ingested counts for a real Tier-A run (for the
+    status file), or ``None`` for dry-run / Tier-B runs.
+    """
     if tier_norm == "A":
         if dry_run:
             _sync_tier_a(config.sync.enabled_sources(), source)
-        else:
-            # An explicit --source overrides the enable toggle (the operator
-            # asked for it by name); otherwise run the enabled set.
-            sources = [source] if source is not None else config.sync.enabled_sources()
-            _sync_run_tier_a(config, vault_path, sources)
-    elif dry_run:
+            return None
+        # An explicit --source overrides the enable toggle (the operator
+        # asked for it by name); otherwise run the enabled set.
+        sources = [source] if source is not None else config.sync.enabled_sources()
+        return _sync_run_tier_a(config, vault_path, sources)
+    if dry_run:
         _sync_tier_b()
     else:
         _sync_run_tier_b(config, vault_path)
+    return None
 
 
 def _install_launchd(
@@ -1027,6 +1092,26 @@ def _install_schedule(host: str, vault: Path | None, out_dir: Path | None) -> No
     )
 
 
+def _sync_validate_source(
+    tier_norm: str,
+    source: str | None,
+    config: CreekConfig,
+) -> None:
+    """Reject a Tier-B ``--source`` or an unknown source name (exits 2)."""
+    if source is None:
+        return
+    if tier_norm == "B":
+        # --source is a Tier-A concept; Tier B always runs the global passes.
+        console.print("[red]--source is not supported with --tier B.[/red]")
+        raise typer.Exit(code=2)
+    if source not in config.sync.sources:
+        known = ", ".join(sorted(config.sync.sources))
+        console.print(
+            f"[red]Unknown --source '{source}'. Known sources: {known}.[/red]",
+        )
+        raise typer.Exit(code=2)
+
+
 @app.command()
 def sync(
     tier: str = typer.Option(
@@ -1050,9 +1135,14 @@ def sync(
         "--schedule-out-dir",
         help="Directory to write emitted schedule units (default: host standard)",
     ),
+    status: bool = typer.Option(
+        False,
+        "--status",
+        help="Show the per-source last run + counts from last-run.json and exit",
+    ),
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
 ) -> None:
-    """Run a scheduled sync pass (#676/#678) or emit schedule units.
+    """Run a scheduled sync pass, emit schedule units, or show status.
 
     ``--tier A`` is the cheap per-source pass (pull -> incremental ingest ->
     rules classify) for each enabled source; ``--tier B`` is the nightly global
@@ -1061,10 +1151,14 @@ def sync(
     records ``00-Creek-Meta/State/sync/last-run.json``; because every step is
     idempotent, a missed tick self-heals on the next run (no catch-up queue).
 
-    ``--install-schedule launchd|systemd`` emits the host's schedule units
-    (parametrised by the configured cadence) and exits without running a tier;
-    activating them is the operator's manual step (see docs/sync-scheduling.md).
+    ``--install-schedule launchd|systemd`` emits the host's schedule units and
+    exits; ``--status`` prints the per-source last-run table and exits.
     """
+    if status:
+        config = _load_config_for_vault(vault)
+        _sync_status(vault or config.vault_path)
+        return
+
     if install_schedule is not None:
         _install_schedule(install_schedule, vault, schedule_out_dir)
         return
@@ -1074,22 +1168,11 @@ def sync(
         console.print("[red]--tier must be A or B[/red]")
         raise typer.Exit(code=2)
 
-    if tier_norm == "B" and source is not None:
-        # --source is a Tier-A concept; Tier B always runs the global passes.
-        console.print("[red]--source is not supported with --tier B.[/red]")
-        raise typer.Exit(code=2)
-
     config = _load_config_for_vault(vault)
     vault_path = vault or config.vault_path
+    _sync_validate_source(tier_norm, source, config)
 
-    if source is not None and source not in config.sync.sources:
-        known = ", ".join(sorted(config.sync.sources))
-        console.print(
-            f"[red]Unknown --source '{source}'. Known sources: {known}.[/red]",
-        )
-        raise typer.Exit(code=2)
-
-    _sync_dispatch(
+    source_counts = _sync_dispatch(
         tier_norm,
         dry_run=dry_run,
         config=config,
@@ -1097,7 +1180,9 @@ def sync(
         source=source,
     )
 
-    prior = _write_sync_state(vault_path, tier_norm, dry_run=dry_run)
+    prior = _write_sync_state(
+        vault_path, tier_norm, dry_run=dry_run, source_counts=source_counts
+    )
     if prior is not None:
         console.print(
             f"[sync] (previous run: tier={prior.get('tier')} at {prior.get('at')})",

--- a/creek-tools/docs/sync-workflow.md
+++ b/creek-tools/docs/sync-workflow.md
@@ -1,0 +1,76 @@
+# The `creek sync` workflow
+
+`creek sync` keeps your vault current by running the ingest pipeline on a
+schedule, in two tiers. It builds on idempotent ingest
+([idempotent-ingest.md](idempotent-ingest.md)) and is scheduled with the deploy
+adapters ([sync-scheduling.md](sync-scheduling.md)).
+
+## The two tiers
+
+| | **Tier A** (cheap, frequent) | **Tier B** (expensive, nightly) |
+|---|---|---|
+| Default cadence | every 30 min | ~03:00 |
+| Per source | pull → incremental ingest → rules-classify | — |
+| Global | — | LLM-classify → link → index |
+| Cost | offline, O(changed) | LLM + O(n²) linking + index rebuild |
+
+**Why two tiers (R6):** linking is O(n²) and rebuilds the whole resonance graph,
+so it must not run on every 30-minute tick. Tier A stays cheap (no link/index);
+Tier B does the heavy global passes once a day.
+
+```bash
+creek sync --tier A --vault /path/to/vault    # cheap pass (what the frequent timer runs)
+creek sync --tier B --vault /path/to/vault    # nightly global pass
+creek sync --tier A --dry-run --vault ...      # echo the plan without running
+```
+
+## Enabling sources
+
+Each source has an on/off toggle under `sync.sources` in your config. The
+journal and Google Drive are on by default; the rest are off until you opt in:
+
+```yaml
+sync:
+  tier_a_interval_minutes: 30
+  tier_b_hour: 3
+  sources:
+    journal: true
+    gdrive: true
+    discord: false
+```
+
+`creek sync --tier A` runs only the enabled sources. `--source <name>` runs a
+single source on demand (and **overrides** its toggle — handy for a one-off).
+
+## Self-healing
+
+Every step is idempotent — incremental ingest skips unchanged units, edited
+fragments update in place, and OPS-001 short-circuits already-classified
+fragments. So a **missed tick needs no catch-up queue**: the next run simply
+re-derives what changed. A laptop that was asleep, or a one-off manual run,
+both converge to the same correct vault.
+
+## Reading status
+
+`creek sync --status` shows what each source last did:
+
+```
+$ creek sync --status --vault /path/to/vault
+Last sync: tier=A at 2026-06-26T08:30:00+00:00
+┏━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
+┃ source  ┃ last tier ┃ last run                  ┃ ingested ┃
+┡━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
+│ journal │ A         │ 2026-06-26T08:30:00+00:00 │ 3        │
+│ gdrive  │ A         │ 2026-06-26T08:30:00+00:00 │ 0        │
+└─────────┴───────────┴───────────────────────────┴──────────┘
+```
+
+The state lives in `00-Creek-Meta/State/sync/last-run.json`. Each tick also
+emits structured `creek.cli` log lines (`sync.tier_a.ingest source=… ingested=…`,
+`sync.tier_a.done`, `sync.tier_b.done`) for log-based monitoring.
+
+## Scheduling it
+
+See [sync-scheduling.md](sync-scheduling.md) for emitting and activating the
+launchd / systemd / cron units, and for the laptop-vs-always-on trade-off and
+where OAuth tokens live.

--- a/creek-tools/tests/test_sync_status.py
+++ b/creek-tools/tests/test_sync_status.py
@@ -100,8 +100,10 @@ class TestStatusCommand:
 
         result = runner.invoke(app, ["sync", "--status", "--vault", str(vault)])
         assert result.exit_code == 0, result.output
+        # The status table renders the journal row (the count itself is asserted
+        # against the state file above — `"2" in output` would match dates too).
         assert "journal" in result.output
-        assert "2" in result.output
+        assert "ingested" in result.output  # the table header rendered
 
     def test_status_with_no_prior_run(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -115,6 +117,31 @@ class TestStatusCommand:
         result = runner.invoke(app, ["sync", "--status", "--vault", str(vault)])
         assert result.exit_code == 0, result.output
         assert "no sync has run" in result.output.lower()
+
+    def test_status_without_vault_uses_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without --vault, --status falls back to the config's vault path."""
+        vault = tmp_path / "v"
+        (vault / "00-Creek-Meta").mkdir(parents=True)
+        monkeypatch.setattr(
+            "creek.cli._load_config_for_vault", lambda _v: CreekConfig(vault_path=vault)
+        )
+        result = runner.invoke(app, ["sync", "--status"])  # no --vault
+        assert result.exit_code == 0, result.output
+        assert "no sync has run" in result.output.lower()
+
+    def test_status_marks_dry_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A dry-run last recorded shows (dry-run) in the status header."""
+        vault, src = _vault_with_journal(tmp_path, entries=1)
+        monkeypatch.setattr(
+            "creek.cli._load_config_for_vault", lambda _v: _fake_config(vault, src)
+        )
+        runner.invoke(app, ["sync", "--tier", "A", "--dry-run", "--vault", str(vault)])
+        result = runner.invoke(app, ["sync", "--status", "--vault", str(vault)])
+        assert "(dry-run)" in result.output
 
 
 # ---- structured logging -------------------------------------------------

--- a/creek-tools/tests/test_sync_status.py
+++ b/creek-tools/tests/test_sync_status.py
@@ -1,0 +1,141 @@
+"""`creek sync --status` + per-tick logging + per-source state (#680).
+
+A real Tier-A run records per-source ingested counts in ``last-run.json``
+(keeping the #676 top-level keys), `--status` renders them, and each tick emits
+structured stdlib log lines.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from creek.cli import _sync_state_path, _write_sync_state, app
+from creek.config import CreekConfig, SyncConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+runner = CliRunner()
+
+
+def _vault_with_journal(tmp_path: Path, *, entries: int = 2) -> tuple[Path, Path]:
+    """Scaffold a vault + a journal source with *entries* markdown files."""
+    vault = tmp_path / "vault"
+    for d in ("00-Creek-Meta/Processing-Log", "01-Fragments/Journal"):
+        (vault / d).mkdir(parents=True, exist_ok=True)
+    journal = tmp_path / "src" / "personal" / "journal"
+    journal.mkdir(parents=True)
+    for i in range(entries):
+        (journal / f"2026-06-{i + 1:02d}.md").write_text(
+            f"---\ndate: 2026-06-{i + 1:02d}\n---\nEntry number {i}.\n",
+            encoding="utf-8",
+        )
+    return vault, tmp_path / "src"
+
+
+def _fake_config(vault: Path, source_drive: Path) -> CreekConfig:
+    """Config with the journal source enabled."""
+    return CreekConfig(
+        vault_path=vault,
+        source_drive=source_drive,
+        sync=SyncConfig(sources={"journal": True}),
+    )
+
+
+# ---- _write_sync_state (unit) ------------------------------------------
+
+
+class TestStateSchema:
+    """State keeps the #676 keys and adds a merging per-source block."""
+
+    def test_keeps_top_level_keys(self, tmp_path: Path) -> None:
+        """The #676 tier/at/dry_run keys still round-trip (backward-compat)."""
+        vault = tmp_path / "v"
+        (vault / "00-Creek-Meta").mkdir(parents=True)
+        _write_sync_state(vault, "A", dry_run=False, source_counts={"journal": 3})
+        state = json.loads(_sync_state_path(vault).read_text(encoding="utf-8"))
+        assert state["tier"] == "A"
+        assert "at" in state
+        assert state["dry_run"] is False
+        assert state["sources"]["journal"]["ingested"] == 3
+
+    def test_merges_prior_sources(self, tmp_path: Path) -> None:
+        """A run that touches one source preserves the others' last entry."""
+        vault = tmp_path / "v"
+        (vault / "00-Creek-Meta").mkdir(parents=True)
+        _write_sync_state(vault, "A", dry_run=False, source_counts={"journal": 2})
+        _write_sync_state(vault, "A", dry_run=False, source_counts={"gdrive": 0})
+        sources = json.loads(_sync_state_path(vault).read_text())["sources"]
+        assert sources["journal"]["ingested"] == 2  # preserved across runs
+        assert sources["gdrive"]["ingested"] == 0
+
+
+# ---- --status -----------------------------------------------------------
+
+
+class TestStatusCommand:
+    """`--status` prints the per-source last-run table."""
+
+    def test_status_after_tier_a(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """After a real Tier-A run, --status shows the journal ingested count."""
+        vault, src = _vault_with_journal(tmp_path, entries=2)
+        monkeypatch.setattr(
+            "creek.cli._load_config_for_vault", lambda _v: _fake_config(vault, src)
+        )
+        r1 = runner.invoke(app, ["sync", "--tier", "A", "--vault", str(vault)])
+        assert r1.exit_code == 0, r1.output
+
+        # Backward-compat: the #676 keys still parse.
+        state = json.loads(_sync_state_path(vault).read_text(encoding="utf-8"))
+        assert state["tier"] == "A"
+        assert state["sources"]["journal"]["ingested"] == 2
+
+        result = runner.invoke(app, ["sync", "--status", "--vault", str(vault)])
+        assert result.exit_code == 0, result.output
+        assert "journal" in result.output
+        assert "2" in result.output
+
+    def test_status_with_no_prior_run(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--status before any run says so cleanly."""
+        vault = tmp_path / "v"
+        (vault / "00-Creek-Meta").mkdir(parents=True)
+        monkeypatch.setattr(
+            "creek.cli._load_config_for_vault", lambda _v: CreekConfig(vault_path=vault)
+        )
+        result = runner.invoke(app, ["sync", "--status", "--vault", str(vault)])
+        assert result.exit_code == 0, result.output
+        assert "no sync has run" in result.output.lower()
+
+
+# ---- structured logging -------------------------------------------------
+
+
+class TestTickLogging:
+    """A real tick emits structured per-source log lines."""
+
+    def test_tier_a_logs_per_source_ingest(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The Tier-A run logs a `sync.tier_a.ingest source=journal` line."""
+        vault, src = _vault_with_journal(tmp_path, entries=1)
+        monkeypatch.setattr(
+            "creek.cli._load_config_for_vault", lambda _v: _fake_config(vault, src)
+        )
+        with caplog.at_level(logging.INFO, logger="creek.cli"):
+            runner.invoke(app, ["sync", "--tier", "A", "--vault", str(vault)])
+        messages = [rec.getMessage() for rec in caplog.records]
+        assert any("sync.tier_a.ingest source=journal" in m for m in messages)
+        assert any("sync.tier_a.done" in m for m in messages)


### PR DESCRIPTION
## Summary

Final polish for epic #669 — observability for the two-tier sync, without changing what the tiers *do* (R6 untouched).

- **Per-source state**: `last-run.json` gains a backward-compatible `sources` block (`{tier, at, ingested}` per source). The #676 top-level `tier`/`at`/`dry_run` keys are unchanged, and a run that only touches one source **preserves the others' last entry** (so `--status` always shows each source's latest run).
- **Counts surfaced**: `_sync_ingest_source` returns the units processed; `_sync_run_tier_a` returns per-source counts, threaded through `_sync_dispatch` into the state file.
- **`creek sync --status`**: prints a per-source table (source · last tier · last run · ingested) from `last-run.json`; says so cleanly when nothing has run.
- **Structured logging**: each tick emits stdlib `creek.cli` log lines — `sync.tier_a.ingest source=… ingested=…`, `sync.tier_a.skip`, `sync.tier_a.done`, `sync.tier_b.done` — for log-based monitoring.
- **docs/sync-workflow.md**: the umbrella workflow doc (tiers + the R6 rationale, enabling sources, self-healing, reading `--status`, and where the #679 schedule adapters fit).

## Test plan
`tests/test_sync_status.py` (5 tests):
- **State schema**: the #676 keys still round-trip; the per-source block **merges** across runs (journal's count survives a later gdrive-only run).
- **`--status`**: after a real Tier-A run it shows `journal` + the ingested count `2`; with no prior run it reports cleanly. Backward-compat: `state["tier"]` still parses.
- **Logging**: a real tick emits `sync.tier_a.ingest source=journal` and `sync.tier_a.done` (asserted via `caplog`).

`./scripts/check-all.sh`: **12/12 gates green** (`_sync_validate_source` extracted to hold complexity ≤10).

## Scope
Observability only — no change to tier execution (#678), the incremental filter (#677), or the schedule emitters (#679); stdlib logging + `last-run.json`, no new telemetry backend.

Refs #669
Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)