### PR TITLE
refactor(ingest): extract RemoteSourceConnector protocol (Drive conforms) (#683)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2804,7 +2804,7 @@ def gdrive(
         staging if staging is not None else Path(config.google_drive.staging_dir)
     )
 
-    from creek.ingest.gdrive import GoogleApiDriveClient, GoogleDriveDownloader
+    from creek.ingest.gdrive import GoogleApiDriveClient, build_drive_connector
 
     client = GoogleApiDriveClient(config.google_drive)
     if not client.is_available():
@@ -2815,9 +2815,13 @@ def gdrive(
         )
         raise typer.Exit(code=1)
 
-    downloader = GoogleDriveDownloader(client=client, config=config.google_drive)
+    # Route the download through the source-agnostic connector (#683); fetch_to
+    # delegates to download_all, so observable behaviour is unchanged.
+    connector = build_drive_connector(
+        config.google_drive, client=client, staging=staging_dir
+    )
     try:
-        result = downloader.download_all(staging_dir)
+        result = connector.fetch_to(staging_dir)
     except Exception as exc:
         # Drive surface includes GoogleApiUnavailableError (missing
         # optional deps), HttpError (quota / rate limit / revoked

--- a/creek-tools/creek/ingest/connectors.py
+++ b/creek-tools/creek/ingest/connectors.py
@@ -1,0 +1,86 @@
+"""Source-agnostic remote-connector protocol (#683 / SPEC R4).
+
+A ``RemoteSourceConnector`` is a **read-only** pull adapter for a remote
+source: it reports availability, lists the files that changed since a cursor,
+and fetches them into a local staging directory (where the regular ingestors
+then pick them up via ``route_to_ingestor``). It does **not** ingest, and by
+construction exposes no write/update/delete surface.
+
+Google Drive is the reference implementation (``creek.ingest.gdrive``); future
+sources (Substack, Notion, an RSS feed, a prose git repo) implement the same
+three methods and reuse the stage -> route -> ingest machinery. The persisted
+cursor (tying ``list_changed_since`` to Epic A's ledger) is wired in #684; here
+the cursor is a thin parameter over the existing staging-mtime skip.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from datetime import datetime
+    from pathlib import Path
+
+
+@runtime_checkable
+class RemoteFile(Protocol):
+    """Structural descriptor for one remote file.
+
+    The concrete :class:`creek.ingest.gdrive.DriveFile` conforms to this
+    without inheritance — any connector's file type that carries these
+    read-only attributes satisfies the contract.
+    """
+
+    @property
+    def id(self) -> str:
+        """Stable remote id (used to fetch the file)."""
+
+    @property
+    def name(self) -> str:
+        """File name as the remote reports it."""
+
+    @property
+    def modified_time(self) -> datetime:
+        """Remote last-modified timestamp (drives the incremental skip)."""
+
+    @property
+    def size(self) -> int:
+        """File size in bytes (0 for export-only/native files)."""
+
+    @property
+    def parent_path(self) -> str:
+        """Slash-separated logical parent path, mirrored under staging."""
+
+
+@runtime_checkable
+class RemoteSourceConnector(Protocol):
+    """Read-only pull connector for a remote source (#683).
+
+    By construction there is **no** write/update/delete method — a connector
+    only reads and downloads. Implementations adapt an existing client; the
+    protocol is what the future sync machinery depends on.
+    """
+
+    def is_available(self) -> bool:
+        """Report whether the backend can serve requests (capability only).
+
+        Never reads or returns credentials — presence/capability only.
+        """
+
+    def list_changed_since(self, cursor: object) -> Sequence[RemoteFile]:
+        """Return the files changed since *cursor* (the incremental set).
+
+        *cursor* of ``None`` means "everything not already current in staging"
+        — the first-pass case. After :meth:`fetch_to` stages the files, a
+        second call with the same cursor yields nothing (the staging mtime
+        skip). The persisted-ledger cursor lands in #684.
+        """
+
+    def fetch_to(self, staging: Path) -> object:
+        """Download the changed files into *staging*, returning a result.
+
+        The return is the implementation's own result object (e.g. Drive's
+        ``DownloadResult``); callers route the staged files through
+        ``route_to_ingestor``.
+        """

--- a/creek-tools/creek/ingest/gdrive.py
+++ b/creek-tools/creek/ingest/gdrive.py
@@ -1040,6 +1040,23 @@ class GoogleDriveDownloader:
             errors=tuple(errors),
         )
 
+    def changed_files(self, staging_dir: Path) -> list[DriveFile]:
+        """Return Drive files not already up-to-date in *staging_dir* (#683).
+
+        The incremental set surfaced via the connector's
+        ``list_changed_since`` — the same staging-mtime predicate
+        :meth:`download_all` uses to skip unchanged files, expressed as a
+        standalone listing (no download side effects).
+        """
+        return [
+            drive_file
+            for drive_file in self.list_files()
+            if not self._is_up_to_date(
+                self._target_path(drive_file, staging_dir),
+                drive_file,
+            )
+        ]
+
     def _resolve(self, file_id: str) -> DriveFile:
         """Return the :class:`DriveFile` for *file_id* from the cached listing."""
         if self._listing_cache is None:
@@ -1134,6 +1151,61 @@ class GoogleDriveDownloader:
         return target.with_name(target.stem + suffix)
 
 
+# ---- RemoteSourceConnector adapter (#683) ------------------------------
+
+
+class GoogleDriveConnector:
+    """Adapt the read-only Drive downloader to ``RemoteSourceConnector`` (#683).
+
+    Wraps a :class:`GoogleDriveDownloader` (and its staging directory) so Drive
+    satisfies the source-agnostic connector contract without changing any
+    download behaviour. ``list_changed_since`` reuses the downloader's
+    staging-mtime skip; ``fetch_to`` delegates to ``download_all``.
+    """
+
+    def __init__(self, downloader: GoogleDriveDownloader, staging: Path) -> None:
+        """Bind the connector to a downloader and its staging directory."""
+        self._downloader = downloader
+        self._staging = staging
+
+    def is_available(self) -> bool:
+        """Report whether the optional Drive libraries are installed."""
+        return self._downloader.client.is_available()
+
+    def list_changed_since(self, cursor: object = None) -> list[DriveFile]:
+        """Return Drive files not yet current in staging (the changed set).
+
+        *cursor* is reserved for the persisted-ledger wiring in #684; today the
+        change set is driven entirely by the staging-mtime skip, so ``cursor``
+        of ``None`` (first pass) and a subsequent same-cursor call differ only
+        because :meth:`fetch_to` stamped the staged files in between.
+        """
+        del cursor  # mtime-driven for now; persisted cursor lands in #684
+        return self._downloader.changed_files(self._staging)
+
+    def fetch_to(self, staging: Path) -> DownloadResult:
+        """Download the changed files into *staging* (delegates to download_all)."""
+        return self._downloader.download_all(staging)
+
+
+def build_drive_connector(
+    config: GoogleDriveConfig,
+    *,
+    client: DriveClient | None = None,
+    staging: Path | None = None,
+) -> GoogleDriveConnector:
+    """Build a Drive :class:`GoogleDriveConnector` from *config* (#683).
+
+    Uses the provided *client* (or a fresh :class:`GoogleApiDriveClient`) and
+    *staging* (or ``config.staging_dir``). The returned object satisfies the
+    :class:`~creek.ingest.connectors.RemoteSourceConnector` protocol.
+    """
+    drive_client = client if client is not None else GoogleApiDriveClient(config)
+    downloader = GoogleDriveDownloader(client=drive_client, config=config)
+    resolved_staging = staging if staging is not None else Path(config.staging_dir)
+    return GoogleDriveConnector(downloader, resolved_staging)
+
+
 __all__ = [
     "GOOGLE_DOCS_MIME",
     "GOOGLE_SHEETS_MIME",
@@ -1143,6 +1215,8 @@ __all__ = [
     "DriveFile",
     "GoogleApiDriveClient",
     "GoogleApiUnavailableError",
+    "GoogleDriveConnector",
     "GoogleDriveDownloader",
+    "build_drive_connector",
     "route_to_ingestor",
 ]

--- a/creek-tools/tests/test_gdrive_downloader.py
+++ b/creek-tools/tests/test_gdrive_downloader.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from creek.config import GoogleDriveConfig
+from creek.ingest.connectors import RemoteSourceConnector
 from creek.ingest.gdrive import (
     GOOGLE_DOCS_MIME,
     GOOGLE_SHEETS_MIME,
@@ -17,6 +18,7 @@ from creek.ingest.gdrive import (
     GoogleApiDriveClient,
     GoogleApiUnavailableError,
     GoogleDriveDownloader,
+    build_drive_connector,
     route_to_ingestor,
 )
 
@@ -1267,6 +1269,58 @@ class TestAstReadOnlyAudit:
         )
         with pytest.raises(AssertionError, match="delete"):
             _audit_no_write_calls(sample)
+
+
+class TestRemoteSourceConnector:
+    """Drive conforms to RemoteSourceConnector, behaviour-preservingly (#683)."""
+
+    def test_drive_satisfies_protocol(self, tmp_path: Path) -> None:
+        """The built Drive connector is a RemoteSourceConnector."""
+        stub = StubDriveClient(
+            files=[_file(fid="a", name="a.md", mime="text/markdown")],
+            media={"a": b"hi"},
+        )
+        connector = build_drive_connector(
+            GoogleDriveConfig(), client=stub, staging=tmp_path
+        )
+        assert isinstance(connector, RemoteSourceConnector)
+
+    def test_is_available_reflects_client(self, tmp_path: Path) -> None:
+        """is_available delegates to the underlying client."""
+        connector = build_drive_connector(
+            GoogleDriveConfig(), client=StubDriveClient(files=[]), staging=tmp_path
+        )
+        assert connector.is_available() is True
+
+    def test_list_changed_since_matches_mtime_skip(self, tmp_path: Path) -> None:
+        """cursor=None lists all; after fetch_to the same cursor yields none."""
+        files = [
+            _file(fid="a", name="a.md", mime="text/markdown"),
+            _file(fid="b", name="b.md", mime="text/markdown"),
+        ]
+        stub = StubDriveClient(files=files, media={"a": b"A", "b": b"B"})
+        connector = build_drive_connector(
+            GoogleDriveConfig(), client=stub, staging=tmp_path
+        )
+
+        changed = connector.list_changed_since(cursor=None)
+        assert [f.id for f in changed] == ["a", "b"]
+
+        connector.fetch_to(tmp_path)  # stage them, stamping mtime
+        assert connector.list_changed_since(cursor=None) == []  # mtime skip
+
+    def test_fetch_to_stages_and_returns_result(self, tmp_path: Path) -> None:
+        """fetch_to downloads the file and returns the DownloadResult."""
+        stub = StubDriveClient(
+            files=[_file(fid="a", name="a.md", mime="text/markdown")],
+            media={"a": b"hello"},
+        )
+        connector = build_drive_connector(
+            GoogleDriveConfig(), client=stub, staging=tmp_path
+        )
+        result = connector.fetch_to(tmp_path)
+        assert len(result.downloaded) == 1
+        assert (tmp_path / "a.md").read_bytes() == b"hello"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Generalises the bespoke Drive client into a reusable, **source-agnostic connector contract** (epic #670, SPEC R4), with Drive as the reference implementation and **no observable behaviour change**.

- **`creek/ingest/connectors.py`** — `RemoteSourceConnector` protocol (`is_available` / `list_changed_since(cursor)` / `fetch_to(staging)`) + a `RemoteFile` structural descriptor (`DriveFile` conforms without inheritance). Read-only by construction — there is no write/update/delete method.
- **`gdrive.py`** — `GoogleDriveConnector` adapter + `build_drive_connector` factory; `GoogleDriveDownloader.changed_files(staging)` exposes the incremental set using the **same staging-mtime predicate** `download_all` already uses. `download_all` is left **untouched** — `fetch_to` delegates to it, so download/skip behaviour is byte-identical.
- **cli** — `gdrive --download` routes through the connector (`fetch_to` → `download_all`); CLI output unchanged.

`cursor` is mtime-driven for now (the persisted-ledger cursor is #684). No second connector is built.

> **Note on ordering:** this issue's stated predecessor is **#682** (the live Drive OAuth validation), which I've left for you since it requires interactive Google login I can't perform. #683 is a pure internal refactor guarded by the existing stub-based download tests, so it's safe to land independently — but the live end-to-end validation of #682 is still worth doing when you can authorise.

## Test plan
`tests/test_gdrive_downloader.py` (4 new tests): Drive `isinstance(connector, RemoteSourceConnector)`; `is_available` delegates to the client; `list_changed_since(cursor=None)` lists all then **yields nothing after `fetch_to`** (the legacy mtime skip, behaviour-preserving); `fetch_to` stages the file and returns the `DownloadResult`. The existing `--download`/`--check`/`--revoke` and download/skip tests are unchanged and green.

`./scripts/check-all.sh`: **12/12 gates green** (passed first try).

## Scope
Behaviour-preserving refactor only. No cursor-to-ledger persistence (#684), no second connector, no change to `download_all`'s accounting.

Refs #670
Closes #683

🤖 Generated with [Claude Code](https://claude.com/claude-code)