### PR TITLE
feat(ingest): persisted connector cursor + contract test + docs (#684)

### DIFF
--- a/creek-tools/creek/ingest/connectors.py
+++ b/creek-tools/creek/ingest/connectors.py
@@ -8,9 +8,11 @@ construction exposes no write/update/delete surface.
 
 Google Drive is the reference implementation (``creek.ingest.gdrive``); future
 sources (Substack, Notion, an RSS feed, a prose git repo) implement the same
-three methods and reuse the stage -> route -> ingest machinery. The persisted
-cursor (tying ``list_changed_since`` to Epic A's ledger) is wired in #684; here
-the cursor is a thin parameter over the existing staging-mtime skip.
+methods and reuse the stage -> route -> ingest machinery. ``list_changed_since``
+is incremental against a **persisted cursor** (a durable, non-secret bookmark
+such as the last-seen modified time) so a fresh process or a new host resumes
+correctly — :meth:`RemoteSourceConnector.load_cursor` /
+:meth:`RemoteSourceConnector.save_cursor` read and advance it.
 """
 
 from __future__ import annotations
@@ -71,10 +73,10 @@ class RemoteSourceConnector(Protocol):
     def list_changed_since(self, cursor: object) -> Sequence[RemoteFile]:
         """Return the files changed since *cursor* (the incremental set).
 
-        *cursor* of ``None`` means "everything not already current in staging"
-        — the first-pass case. After :meth:`fetch_to` stages the files, a
-        second call with the same cursor yields nothing (the staging mtime
-        skip). The persisted-ledger cursor lands in #684.
+        *cursor* (as :meth:`load_cursor` returns) of ``None`` means the first
+        pass — everything. After :meth:`fetch_to` + :meth:`save_cursor`, the
+        reloaded cursor excludes the already-fetched files, so the next call
+        returns only what is genuinely new.
         """
 
     def fetch_to(self, staging: Path) -> object:

--- a/creek-tools/creek/ingest/connectors.py
+++ b/creek-tools/creek/ingest/connectors.py
@@ -84,3 +84,20 @@ class RemoteSourceConnector(Protocol):
         ``DownloadResult``); callers route the staged files through
         ``route_to_ingestor``.
         """
+
+    def load_cursor(self) -> object:
+        """Return the persisted incremental cursor, or ``None`` if none (#684).
+
+        The cursor is a durable bookmark (e.g. the last-seen modified time) so a
+        fresh process or a new host resumes incrementally — it is *not* tied to
+        in-process state. It stores only non-secret bookkeeping, never
+        credentials.
+        """
+
+    def save_cursor(self, fetched: Sequence[RemoteFile]) -> None:
+        """Advance the persisted cursor past *fetched* (#684).
+
+        Called after a successful :meth:`fetch_to`; subsequent
+        :meth:`list_changed_since` calls against the reloaded cursor exclude the
+        already-fetched files.
+        """

--- a/creek-tools/creek/ingest/gdrive.py
+++ b/creek-tools/creek/ingest/gdrive.py
@@ -1194,6 +1194,9 @@ class GoogleDriveConnector:
         if cursor is None:
             return self._downloader.list_files()
         threshold = datetime.fromisoformat(str(cursor))
+        # Strict ">": files exactly at the cursor were fetched on the pass that
+        # set it. A true tie at the newest modified_time is astronomically
+        # unlikely given Drive's timestamp precision.
         return [
             drive_file
             for drive_file in self._downloader.list_files()
@@ -1205,30 +1208,38 @@ class GoogleDriveConnector:
         return self._downloader.download_all(staging)
 
     def load_cursor(self) -> str | None:
-        """Return the persisted cursor timestamp, or ``None`` if unset (#684)."""
+        """Return the persisted cursor timestamp, or ``None`` if unset/invalid.
+
+        Any read failure, non-string value, or non-ISO timestamp (e.g. a
+        hand-edited cursor file) falls back to ``None`` — a full re-scan —
+        rather than raising later in :meth:`list_changed_since`.
+        """
         if not self._cursor_path.exists():
             return None
         try:
             data = json.loads(self._cursor_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
+            cursor = data.get("cursor") if isinstance(data, dict) else None
+            if not isinstance(cursor, str):
+                return None
+            datetime.fromisoformat(cursor)  # validate shape only
+        except (OSError, json.JSONDecodeError, ValueError):
             return None
-        cursor = data.get("cursor") if isinstance(data, dict) else None
-        return cursor if isinstance(cursor, str) else None
+        return cursor
 
     def save_cursor(self, fetched: Sequence[DriveFile]) -> None:
         """Advance the persisted cursor to the newest *fetched* modified_time.
 
         An empty *fetched* leaves the cursor untouched (nothing newer was
-        seen). Stores only the timestamp — no credentials.
+        seen). Written atomically (temp + ``os.replace``) and storing only the
+        timestamp — no credentials.
         """
         if not fetched:
             return
         newest = max(item.modified_time for item in fetched)
         self._cursor_path.parent.mkdir(parents=True, exist_ok=True)
-        self._cursor_path.write_text(
-            json.dumps({"cursor": newest.isoformat()}),
-            encoding="utf-8",
-        )
+        tmp = self._cursor_path.with_name(self._cursor_path.name + ".tmp")
+        tmp.write_text(json.dumps({"cursor": newest.isoformat()}), encoding="utf-8")
+        os.replace(tmp, self._cursor_path)
 
 
 def build_drive_connector(

--- a/creek-tools/creek/ingest/gdrive.py
+++ b/creek-tools/creek/ingest/gdrive.py
@@ -48,6 +48,8 @@ from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 import httpx
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from creek.config import GoogleDriveConfig
 
 
@@ -1159,33 +1161,74 @@ class GoogleDriveConnector:
 
     Wraps a :class:`GoogleDriveDownloader` (and its staging directory) so Drive
     satisfies the source-agnostic connector contract without changing any
-    download behaviour. ``list_changed_since`` reuses the downloader's
-    staging-mtime skip; ``fetch_to`` delegates to ``download_all``.
+    download behaviour. ``fetch_to`` delegates to ``download_all`` (whose own
+    staging-mtime skip is unchanged); ``list_changed_since`` is driven by a
+    **persisted cursor** (#684) — the last-seen Drive ``modified_time`` — so a
+    fresh process or new host resumes incrementally. The cursor stores only a
+    timestamp, never a credential.
     """
 
-    def __init__(self, downloader: GoogleDriveDownloader, staging: Path) -> None:
-        """Bind the connector to a downloader and its staging directory."""
+    def __init__(
+        self,
+        downloader: GoogleDriveDownloader,
+        staging: Path,
+        cursor_path: Path,
+    ) -> None:
+        """Bind the connector to a downloader, staging dir, and cursor file."""
         self._downloader = downloader
         self._staging = staging
+        self._cursor_path = cursor_path
 
     def is_available(self) -> bool:
         """Report whether the optional Drive libraries are installed."""
         return self._downloader.client.is_available()
 
     def list_changed_since(self, cursor: object = None) -> list[DriveFile]:
-        """Return Drive files not yet current in staging (the changed set).
+        """Return Drive files modified strictly after *cursor* (#684).
 
-        *cursor* is reserved for the persisted-ledger wiring in #684; today the
-        change set is driven entirely by the staging-mtime skip, so ``cursor``
-        of ``None`` (first pass) and a subsequent same-cursor call differ only
-        because :meth:`fetch_to` stamped the staged files in between.
+        *cursor* is an ISO-8601 timestamp string (as :meth:`load_cursor`
+        returns) or ``None`` for the first pass (everything). After
+        :meth:`fetch_to` + :meth:`save_cursor`, the reloaded cursor equals the
+        newest fetched ``modified_time``, so the next call returns nothing new.
         """
-        del cursor  # mtime-driven for now; persisted cursor lands in #684
-        return self._downloader.changed_files(self._staging)
+        if cursor is None:
+            return self._downloader.list_files()
+        threshold = datetime.fromisoformat(str(cursor))
+        return [
+            drive_file
+            for drive_file in self._downloader.list_files()
+            if drive_file.modified_time > threshold
+        ]
 
     def fetch_to(self, staging: Path) -> DownloadResult:
         """Download the changed files into *staging* (delegates to download_all)."""
         return self._downloader.download_all(staging)
+
+    def load_cursor(self) -> str | None:
+        """Return the persisted cursor timestamp, or ``None`` if unset (#684)."""
+        if not self._cursor_path.exists():
+            return None
+        try:
+            data = json.loads(self._cursor_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        cursor = data.get("cursor") if isinstance(data, dict) else None
+        return cursor if isinstance(cursor, str) else None
+
+    def save_cursor(self, fetched: Sequence[DriveFile]) -> None:
+        """Advance the persisted cursor to the newest *fetched* modified_time.
+
+        An empty *fetched* leaves the cursor untouched (nothing newer was
+        seen). Stores only the timestamp — no credentials.
+        """
+        if not fetched:
+            return
+        newest = max(item.modified_time for item in fetched)
+        self._cursor_path.parent.mkdir(parents=True, exist_ok=True)
+        self._cursor_path.write_text(
+            json.dumps({"cursor": newest.isoformat()}),
+            encoding="utf-8",
+        )
 
 
 def build_drive_connector(
@@ -1193,17 +1236,24 @@ def build_drive_connector(
     *,
     client: DriveClient | None = None,
     staging: Path | None = None,
+    cursor_path: Path | None = None,
 ) -> GoogleDriveConnector:
-    """Build a Drive :class:`GoogleDriveConnector` from *config* (#683).
+    """Build a Drive :class:`GoogleDriveConnector` from *config* (#683/#684).
 
-    Uses the provided *client* (or a fresh :class:`GoogleApiDriveClient`) and
-    *staging* (or ``config.staging_dir``). The returned object satisfies the
-    :class:`~creek.ingest.connectors.RemoteSourceConnector` protocol.
+    Uses the provided *client* (or a fresh :class:`GoogleApiDriveClient`),
+    *staging* (or ``config.staging_dir``), and *cursor_path* (or
+    ``<staging>/.creek-connector-cursor.json``). The returned object satisfies
+    the :class:`~creek.ingest.connectors.RemoteSourceConnector` protocol.
     """
     drive_client = client if client is not None else GoogleApiDriveClient(config)
     downloader = GoogleDriveDownloader(client=drive_client, config=config)
     resolved_staging = staging if staging is not None else Path(config.staging_dir)
-    return GoogleDriveConnector(downloader, resolved_staging)
+    resolved_cursor = (
+        cursor_path
+        if cursor_path is not None
+        else resolved_staging / ".creek-connector-cursor.json"
+    )
+    return GoogleDriveConnector(downloader, resolved_staging, resolved_cursor)
 
 
 __all__ = [

--- a/creek-tools/docs/connectors/adding-a-remote-connector.md
+++ b/creek-tools/docs/connectors/adding-a-remote-connector.md
@@ -1,0 +1,92 @@
+# Adding a new remote connector
+
+Creek pulls remote sources through a small, **read-only** abstraction:
+`RemoteSourceConnector` (`creek/ingest/connectors.py`). Google Drive is the
+reference implementation (`creek/ingest/gdrive.py`); this guide shows how to add
+the next one (Substack, Notion, Readwise, an RSS feed, a prose git repo …).
+
+A connector **stages** files; it does **not** ingest. After `fetch_to` drops
+files into a staging directory, the regular ingest pipeline picks them up via
+`route_to_ingestor` (by extension). The connector never classifies, links, or
+writes fragments.
+
+## The contract
+
+Implement these five methods:
+
+```python
+class MySourceConnector:
+    def is_available(self) -> bool:
+        """Can the backend serve requests? Capability only — never reads or
+        returns a credential."""
+
+    def list_changed_since(self, cursor):
+        """Return the files changed since `cursor` (an opaque, persisted
+        bookmark). `cursor=None` means the first pass (everything)."""
+
+    def fetch_to(self, staging):
+        """Download the changed files into `staging`. Returns a result object;
+        callers route the staged files through `route_to_ingestor`."""
+
+    def load_cursor(self):
+        """Return the persisted cursor, or None if there is none yet."""
+
+    def save_cursor(self, fetched):
+        """Advance the persisted cursor past `fetched` (called after a
+        successful fetch_to)."""
+```
+
+`RemoteSourceConnector` is a `runtime_checkable` Protocol, so structural
+conformance is enough — no inheritance required. A connector that exposes these
+methods satisfies `isinstance(conn, RemoteSourceConnector)`.
+
+### Read-only by construction
+
+The protocol has **no** `update`/`delete`/`trash`/`copy`/`create` method, and
+your connector must not add one. A connector reads and downloads; it never
+writes back to the source.
+
+### The cursor
+
+`list_changed_since(cursor)` is *incremental against a persisted cursor*, not
+just in-process state — so a fresh process or a new host resumes correctly. The
+cursor is whatever durable bookmark fits the source:
+
+- **Drive** persists the newest `modified_time` it has fetched and returns files
+  newer than it.
+- A **timestamped API** (Substack, Notion) would persist a `since` timestamp.
+- A **git repo** would persist the last commit SHA.
+
+Store the cursor as **non-secret bookkeeping only** (a timestamp, id, or hash) —
+see the secrets rule below.
+
+## Secrets — read from env/disk only, never persist or log
+
+This is non-negotiable:
+
+- A connector reads OAuth tokens / API keys **from disk or the environment**,
+  per the existing `GoogleDriveConfig` pattern. **Never inline a secret into
+  config or code.**
+- **Never echo or log** a token, refresh token, client secret, or API key. Any
+  status output is presence-only (`is_available` reports capability, not the
+  credential).
+- The persisted **cursor stores only bookkeeping** (`last_seen`/ids/hashes) —
+  never a credential.
+
+## Prove it with the contract test
+
+`tests/test_remote_connector_contract.py` is parametrised over connector
+factories. Add your factory to `_FACTORIES` and the whole contract runs against
+it for free:
+
+```python
+def _make_my_connector(*, staging):
+    return MySourceConnector(...)
+
+_FACTORIES = [_make_drive_connector, _make_my_connector]
+```
+
+The contract asserts: the connector conforms to the protocol, `is_available`
+never raises, and `list_changed_since` is **idempotent against an advanced
+cursor** (after `fetch_to` + `save_cursor`, the reloaded cursor yields nothing
+new — including across a brand-new instance).

--- a/creek-tools/tests/test_gdrive_downloader.py
+++ b/creek-tools/tests/test_gdrive_downloader.py
@@ -1323,6 +1323,26 @@ class TestRemoteSourceConnector:
         assert len(result.downloaded) == 1
         assert (tmp_path / "a.md").read_bytes() == b"hello"
 
+    def test_corrupt_cursor_falls_back_to_full_scan(self, tmp_path: Path) -> None:
+        """A non-JSON or non-ISO cursor file degrades to a full scan, not a crash."""
+        cursor_path = tmp_path / "c.json"
+        stub = StubDriveClient(
+            files=[_file(fid="a", name="a.md", mime="text/markdown")],
+            media={"a": b"A"},
+        )
+        connector = build_drive_connector(
+            GoogleDriveConfig(), client=stub, staging=tmp_path, cursor_path=cursor_path
+        )
+
+        cursor_path.write_text("not json at all", encoding="utf-8")
+        assert connector.load_cursor() is None
+
+        cursor_path.write_text('{"cursor": "not-a-date"}', encoding="utf-8")
+        assert connector.load_cursor() is None  # valid JSON, invalid ISO
+        # list_changed_since(None) is a full scan — no ValueError.
+        changed = connector.list_changed_since(cursor=connector.load_cursor())
+        assert [f.id for f in changed] == ["a"]
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/creek-tools/tests/test_gdrive_downloader.py
+++ b/creek-tools/tests/test_gdrive_downloader.py
@@ -1292,8 +1292,8 @@ class TestRemoteSourceConnector:
         )
         assert connector.is_available() is True
 
-    def test_list_changed_since_matches_mtime_skip(self, tmp_path: Path) -> None:
-        """cursor=None lists all; after fetch_to the same cursor yields none."""
+    def test_list_changed_since_advances_with_cursor(self, tmp_path: Path) -> None:
+        """cursor=None lists all; after save_cursor the reloaded cursor yields none."""
         files = [
             _file(fid="a", name="a.md", mime="text/markdown"),
             _file(fid="b", name="b.md", mime="text/markdown"),
@@ -1303,11 +1303,12 @@ class TestRemoteSourceConnector:
             GoogleDriveConfig(), client=stub, staging=tmp_path
         )
 
-        changed = connector.list_changed_since(cursor=None)
+        changed = connector.list_changed_since(cursor=connector.load_cursor())
         assert [f.id for f in changed] == ["a", "b"]
 
-        connector.fetch_to(tmp_path)  # stage them, stamping mtime
-        assert connector.list_changed_since(cursor=None) == []  # mtime skip
+        connector.fetch_to(tmp_path)
+        connector.save_cursor(changed)
+        assert connector.list_changed_since(cursor=connector.load_cursor()) == []
 
     def test_fetch_to_stages_and_returns_result(self, tmp_path: Path) -> None:
         """fetch_to downloads the file and returns the DownloadResult."""

--- a/creek-tools/tests/test_remote_connector_contract.py
+++ b/creek-tools/tests/test_remote_connector_contract.py
@@ -110,3 +110,13 @@ class TestRemoteConnectorContract:
 
         second = make_connector(staging=tmp_path)
         assert list(second.list_changed_since(cursor=second.load_cursor())) == []
+
+    def test_save_cursor_empty_is_noop(
+        self,
+        make_connector: ConnectorFactory,
+        tmp_path: Path,
+    ) -> None:
+        """Saving an empty fetch set leaves the cursor unset."""
+        conn = make_connector(staging=tmp_path)
+        conn.save_cursor([])
+        assert conn.load_cursor() is None

--- a/creek-tools/tests/test_remote_connector_contract.py
+++ b/creek-tools/tests/test_remote_connector_contract.py
@@ -1,0 +1,112 @@
+"""Reusable contract any ``RemoteSourceConnector`` must satisfy (#684).
+
+Parametrised over connector factories — Drive is the only implementation today,
+but a future connector (Substack/Notion/RSS) added to ``_FACTORIES`` is held to
+the same contract for free.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.config import GoogleDriveConfig
+from creek.ingest.connectors import RemoteSourceConnector
+from creek.ingest.gdrive import DriveFile, build_drive_connector
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    ConnectorFactory = Callable[..., RemoteSourceConnector]
+
+
+class _StubClient:
+    """Minimal in-memory Drive client for the contract (one markdown file)."""
+
+    def __init__(self) -> None:
+        """Seed a single markdown file with media bytes."""
+        self._file = DriveFile(
+            id="x",
+            name="x.md",
+            mime_type="text/markdown",
+            modified_time=datetime(2026, 4, 1, tzinfo=UTC),
+            size=2,
+            parent_path="",
+        )
+
+    def is_available(self) -> bool:
+        """Stub is always available."""
+        return True
+
+    def list_files(self) -> list[DriveFile]:
+        """Return the canned one-file listing."""
+        return [self._file]
+
+    def download_to(
+        self,
+        file_id: str,
+        destination: Path,
+        *,
+        export_mime: str | None = None,
+    ) -> None:
+        """Write canned bytes (the contract only needs a successful fetch)."""
+        del file_id, export_mime
+        destination.write_bytes(b"hi")
+
+
+def _make_drive_connector(*, staging: Path) -> RemoteSourceConnector:
+    """Factory: a Drive connector wired to the stub client + a cursor file."""
+    return build_drive_connector(
+        GoogleDriveConfig(),
+        client=_StubClient(),
+        staging=staging,
+        cursor_path=staging / "cursor.json",
+    )
+
+
+_FACTORIES = [_make_drive_connector]
+
+
+@pytest.mark.parametrize("make_connector", _FACTORIES)
+class TestRemoteConnectorContract:
+    """Every connector must satisfy this contract."""
+
+    def test_conforms_to_protocol(
+        self,
+        make_connector: ConnectorFactory,
+        tmp_path: Path,
+    ) -> None:
+        """The connector is a RemoteSourceConnector and is_available never raises."""
+        conn = make_connector(staging=tmp_path)
+        assert isinstance(conn, RemoteSourceConnector)
+        assert conn.is_available() in (True, False)
+
+    def test_cursor_makes_listing_idempotent(
+        self,
+        make_connector: ConnectorFactory,
+        tmp_path: Path,
+    ) -> None:
+        """After fetch + save_cursor, the reloaded cursor yields no changes."""
+        conn = make_connector(staging=tmp_path)
+        first = list(conn.list_changed_since(cursor=conn.load_cursor()))
+        assert first  # a fresh cursor surfaces the initial file(s)
+        conn.fetch_to(tmp_path)
+        conn.save_cursor(first)
+        assert list(conn.list_changed_since(cursor=conn.load_cursor())) == []
+
+    def test_cursor_persists_across_instances(
+        self,
+        make_connector: ConnectorFactory,
+        tmp_path: Path,
+    ) -> None:
+        """A brand-new instance resumes from the persisted cursor."""
+        first = make_connector(staging=tmp_path)
+        changed = list(first.list_changed_since(cursor=first.load_cursor()))
+        first.fetch_to(tmp_path)
+        first.save_cursor(changed)
+
+        second = make_connector(staging=tmp_path)
+        assert list(second.list_changed_since(cursor=second.load_cursor())) == []


### PR DESCRIPTION
## Summary

Finishes epic #670: makes the `RemoteSourceConnector` incremental against a **durable cursor** (not just in-process/staging mtime), codifies the abstraction with a reusable contract test, and documents how to add the next remote source.

- **Protocol**: `load_cursor()` / `save_cursor(fetched)` added to `RemoteSourceConnector`. The cursor is a persisted, non-secret bookmark — so a fresh process or a new host resumes incrementally.
- **Drive**: `GoogleDriveConnector` persists the newest fetched `modified_time` to `<staging>/.creek-connector-cursor.json`; `list_changed_since(cursor)` returns files newer than the cursor (`None` = first pass = all). **`download_all` and `creek gdrive --download` are unchanged** — the cursor governs the connector's *listing* API; the download keeps its own staging-mtime skip.
- **`tests/test_remote_connector_contract.py`**: a reusable, **parametrised** contract any connector must pass — conforms to the protocol, `is_available` never raises, `list_changed_since` is idempotent against an advanced cursor, and the cursor **persists across brand-new instances**. Drive passes it.
- **docs/connectors/adding-a-remote-connector.md**: the five-method contract, the read-only rule, cursor semantics per source type, and the **secrets-from-env-only** rule (cursor stores only timestamps/ids/hashes, never credentials).

## Test plan
- New contract suite (parametrised, 3 cases × Drive) + a cursor-persistence/advance test on `GoogleDriveConnector`. The #683 behaviour test is updated to the cursor API (`cursor=None` now means "all"; the second pass uses the saved cursor).
- `creek gdrive --download`/`--check`/`--revoke` and download/skip tests unchanged and green.
- `./scripts/check-all.sh`: **12/12 gates green** (first try).

## Scope
Consumes the abstraction read-only. No second connector (follow-up epic), no change to Epic A's ledger format, no scheduling change. The cursor is a connector-local download bookmark, distinct from Epic A's fragment ledger.

Refs #670
Closes #684

🤖 Generated with [Claude Code](https://claude.com/claude-code)