### PR TITLE
feat(discord): Discord source config + mode dispatch skeleton (#685)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
     )
     from creek.generate.mining import MiningRunReport
     from creek.ingest.base import Ingestor, ParsedFragment
+    from creek.ingest.discord_dispatch import DiscordMode
     from creek.ingest.ledger import LedgerRecord, SourceLedger
     from creek.link.link_engine import LinkSummary
     from creek.models import CompileTargetKind, Fragment, Frequency, Mode, Phase
@@ -1192,6 +1193,58 @@ def sync(
         )
     mode = "planned" if dry_run else "ran"
     console.print(f"[sync] {mode} tier={tier_norm}; wrote last-run.json")
+
+
+def _parse_discord_mode(mode: str) -> DiscordMode:
+    """Parse a ``--mode`` string into a :class:`DiscordMode`, or exit 2 (#685)."""
+    from creek.ingest.discord_dispatch import DiscordMode
+
+    try:
+        return DiscordMode(mode)
+    except ValueError:
+        valid = ", ".join(m.value for m in DiscordMode)
+        console.print(f"[red]Unknown --mode '{mode}'. Valid: {valid}.[/red]")
+        raise typer.Exit(code=2) from None
+
+
+@app.command()
+def discord(
+    mode: str = typer.Option(
+        ..., "--mode", help="data_package | exporter | bot_capture"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Echo the plan (the only behaviour in the skeleton)"
+    ),
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+) -> None:
+    """Dispatch a Discord ingest mode (#685 — skeleton stub).
+
+    Resolves the selected ``--mode`` against the configured Discord toggles and
+    echoes its pull-then-ingest plan. Performs **no network I/O**: the real
+    exporter, bot-capture, and Data Package paths land in #686/#687/#688. The
+    ``exporter`` mode is opt-in (off by default) and prints a Terms-of-Service
+    caveat on use. The Discord token lives in the environment, never in config.
+    """
+    from creek.ingest.discord_dispatch import (
+        ModeDisabledError,
+        resolve_discord_handler,
+    )
+
+    selected = _parse_discord_mode(mode)
+    config = _load_config_for_vault(vault)
+    try:
+        handler = resolve_discord_handler(selected, config.discord)
+    except ModeDisabledError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=2) from exc
+
+    handler.announce()
+    for line in handler.plan():
+        console.print(line)
+    if not dry_run:
+        console.print(
+            "[dim][discord] skeleton: stub only — no pull/ingest performed yet.[/dim]",
+        )
 
 
 @app.command()

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -1421,6 +1421,42 @@ class SyncConfig(BaseModel):
         return sorted(name for name, on in self.sources.items() if on)
 
 
+class DiscordModeToggle(BaseModel):
+    """On/off toggle for one Discord ingest mode (#685)."""
+
+    enabled: bool = False
+    """Whether this mode is enabled. Opt-in per mode."""
+
+
+class DiscordSourceConfig(BaseModel):
+    """How Discord content reaches the vault — three explicit modes (#685).
+
+    A bot **cannot** read DMs (Discord API limit), so the modes differ by
+    coverage and compliance (SPEC R5, decision #3):
+
+    * ``data_package`` — ingest a manually-downloaded Data Package. The clean,
+      ToS-compliant fallback; on by default.
+    * ``exporter`` — a user-token exporter (DMs + servers). **Off by default**;
+      enabling it is a ToS-caveated, opt-in choice.
+    * ``bot_capture`` — a bot logging the servers/channels it is in. Clean, but
+      cannot see DMs. Off by default.
+
+    Config holds only the mode toggles — the Discord token lives in the
+    environment, never here.
+    """
+
+    data_package: DiscordModeToggle = Field(
+        default_factory=lambda: DiscordModeToggle(enabled=True),
+    )
+    """The clean Data Package fallback — enabled by default."""
+
+    exporter: DiscordModeToggle = Field(default_factory=DiscordModeToggle)
+    """User-token exporter — OFF by default (decision #3); ToS-caveated."""
+
+    bot_capture: DiscordModeToggle = Field(default_factory=DiscordModeToggle)
+    """Bot message capture for servers/channels — off by default."""
+
+
 class CreekConfig(BaseSettings):
     """Top-level Creek configuration.
 
@@ -1503,6 +1539,9 @@ class CreekConfig(BaseSettings):
 
     sync: SyncConfig = Field(default_factory=SyncConfig)
     """Scheduling config for ``creek sync`` — per-source toggles + cadence."""
+
+    discord: DiscordSourceConfig = Field(default_factory=DiscordSourceConfig)
+    """Discord ingest mode toggles (data_package | exporter | bot_capture)."""
 
     @field_validator("timezone")
     @classmethod

--- a/creek-tools/creek/ingest/discord_dispatch.py
+++ b/creek-tools/creek/ingest/discord_dispatch.py
@@ -1,0 +1,147 @@
+"""Discord ingest-mode dispatch — skeleton stubs (#685).
+
+Resolves a configured Discord mode (``data_package`` | ``exporter`` |
+``bot_capture``) to a handler that echoes the pull-then-ingest plan. **No
+network, no exporter binary, no bot capture** — those are issues #686/#687/#688.
+
+A bot cannot read DMs (Discord API limit), so the three modes differ by coverage
+and compliance (SPEC R5, decision #3). The ``exporter`` mode is OFF by default
+and prints a Terms-of-Service caveat on enable. The Discord token (user or bot)
+lives in the **environment only** — never in config, never echoed or logged.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+
+if TYPE_CHECKING:
+    from creek.config import DiscordSourceConfig
+
+console = Console()
+
+
+class DiscordMode(StrEnum):
+    """The three explicit Discord ingest modes."""
+
+    DATA_PACKAGE = "data_package"
+    EXPORTER = "exporter"
+    BOT_CAPTURE = "bot_capture"
+
+
+class ModeDisabledError(RuntimeError):
+    """Raised when a Discord mode is selected but disabled in config."""
+
+
+class ExporterDisabledError(ModeDisabledError):
+    """Raised specifically when the (opt-in) exporter mode is disabled."""
+
+
+class DiscordHandler:
+    """Base stub handler: echoes a plan, performs no I/O (#685)."""
+
+    mode: DiscordMode
+
+    def plan(self) -> list[str]:
+        """Return the ordered plan lines this mode *would* perform."""
+        raise NotImplementedError
+
+    def announce(self) -> None:
+        """Print any pre-run notice (e.g. the exporter ToS caveat)."""
+
+
+class DataPackageHandler(DiscordHandler):
+    """Stub for the clean Data Package import path (#685)."""
+
+    mode = DiscordMode.DATA_PACKAGE
+
+    def plan(self) -> list[str]:
+        """Echo the Data Package ingest plan."""
+        return [
+            "[discord] mode=data_package (clean fallback: a downloaded export)",
+            "[discord] would ingest discord-export/ via the DiscordIngestor",
+            "[discord] no network performed (skeleton stub)",
+        ]
+
+
+class BotCaptureHandler(DiscordHandler):
+    """Stub for the bot message-capture path (servers/channels, #685)."""
+
+    mode = DiscordMode.BOT_CAPTURE
+
+    def plan(self) -> list[str]:
+        """Echo the bot-capture plan."""
+        return [
+            "[discord] mode=bot_capture (clean: servers/channels the bot is in)",
+            "[discord] would append discord-capture/<channel>/<date>.jsonl "
+            "via on_message",
+            "[discord] would backfill via channel.history(); Tier-A ingest consumes it",
+            "[discord] no network performed (skeleton stub)",
+        ]
+
+
+class ExporterHandler(DiscordHandler):
+    """Stub for the opt-in user-token exporter path (DMs, #685)."""
+
+    mode = DiscordMode.EXPORTER
+
+    def announce(self) -> None:
+        """Print the Terms-of-Service caveat before any (future) export.
+
+        Short lines keep each asserted phrase intact (no terminal-width wrap).
+        """
+        console.print("[yellow][discord] DM exporter caveat:[/yellow]")
+        console.print("[yellow]- A user token drives your account.[/yellow]")
+        console.print("[yellow]- The Discord Terms of Service prohibit this.[/yellow]")
+        console.print("[yellow]- The real stake is account suspension.[/yellow]")
+        console.print(
+            "[yellow]- Use it read-only, for your own DMs, at a low rate.[/yellow]",
+        )
+
+    def plan(self) -> list[str]:
+        """Echo the exporter plan."""
+        return [
+            "[discord] mode=exporter (opt-in: user-token export incl. DMs)",
+            "[discord] would run the exporter --after <cursor> into discord-export/",
+            "[discord] then ingest via the DiscordIngestor",
+            "[discord] no network performed (skeleton stub)",
+        ]
+
+
+_HANDLERS: dict[DiscordMode, type[DiscordHandler]] = {
+    DiscordMode.DATA_PACKAGE: DataPackageHandler,
+    DiscordMode.EXPORTER: ExporterHandler,
+    DiscordMode.BOT_CAPTURE: BotCaptureHandler,
+}
+
+
+def resolve_discord_handler(
+    mode: DiscordMode,
+    config: DiscordSourceConfig,
+) -> DiscordHandler:
+    """Return the stub handler for *mode*, or raise if it is disabled (#685).
+
+    Args:
+        mode: The selected Discord ingest mode.
+        config: The Discord source config carrying the per-mode toggles.
+
+    Returns:
+        The mode's stub :class:`DiscordHandler`.
+
+    Raises:
+        ExporterDisabledError: When *mode* is ``EXPORTER`` and it is off.
+        ModeDisabledError: When any other mode is selected but disabled.
+    """
+    toggle = getattr(config, mode.value)
+    if not toggle.enabled:
+        if mode is DiscordMode.EXPORTER:
+            msg = (
+                "Discord exporter mode is disabled. It is opt-in and OFF by "
+                "default; enable it explicitly to use it."
+            )
+            raise ExporterDisabledError(msg)
+        msg = f"Discord mode {mode.value!r} is disabled; enable it in config."
+        raise ModeDisabledError(msg)
+    return _HANDLERS[mode]()

--- a/creek-tools/tests/test_discord_dispatch.py
+++ b/creek-tools/tests/test_discord_dispatch.py
@@ -1,0 +1,134 @@
+"""Discord ingest-mode dispatch skeleton (#685).
+
+Each mode resolves to a stub handler that echoes a plan; the exporter is OFF by
+default and prints a Terms-of-Service caveat on enable. No handler performs
+network I/O.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.config import DiscordSourceConfig
+from creek.ingest.discord_dispatch import (
+    DiscordMode,
+    ExporterDisabledError,
+    ModeDisabledError,
+    resolve_discord_handler,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+# ---- Config defaults ----------------------------------------------------
+
+
+class TestDiscordConfigDefaults:
+    """The exporter is off by default; the Data Package fallback is on."""
+
+    def test_exporter_off_by_default(self) -> None:
+        """Decision #3: the user-token exporter defaults OFF."""
+        cfg = DiscordSourceConfig()
+        assert cfg.exporter.enabled is False
+
+    def test_data_package_on_by_default(self) -> None:
+        """The clean Data Package fallback is available by default."""
+        assert DiscordSourceConfig().data_package.enabled is True
+
+    def test_bot_capture_off_by_default(self) -> None:
+        """Bot capture is opt-in."""
+        assert DiscordSourceConfig().bot_capture.enabled is False
+
+
+# ---- resolve_discord_handler -------------------------------------------
+
+
+class TestResolveHandler:
+    """Mode resolution gates on the toggle; no handler does network I/O."""
+
+    def test_exporter_disabled_refuses(self) -> None:
+        """Resolving the disabled exporter raises (no pull attempted)."""
+        with pytest.raises(ExporterDisabledError):
+            resolve_discord_handler(DiscordMode.EXPORTER, DiscordSourceConfig())
+
+    def test_disabled_mode_raises_mode_disabled(self) -> None:
+        """A disabled non-exporter mode raises ModeDisabledError."""
+        cfg = DiscordSourceConfig(bot_capture={"enabled": False})
+        with pytest.raises(ModeDisabledError):
+            resolve_discord_handler(DiscordMode.BOT_CAPTURE, cfg)
+
+    def test_enabled_exporter_announces_tos_caveat(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """An enabled exporter announces the full ToS caveat."""
+        cfg = DiscordSourceConfig(exporter={"enabled": True})
+        handler = resolve_discord_handler(DiscordMode.EXPORTER, cfg)
+        handler.announce()
+        out = capsys.readouterr().out
+        assert "Discord Terms of Service" in out
+        assert "account suspension" in out
+        assert "your own DMs" in out
+        assert "read-only" in out
+
+    def test_each_mode_resolves_and_plans_without_network(self) -> None:
+        """data_package + bot_capture resolve and echo a plan (no I/O)."""
+        cfg = DiscordSourceConfig(
+            data_package={"enabled": True}, bot_capture={"enabled": True}
+        )
+        for mode in (DiscordMode.DATA_PACKAGE, DiscordMode.BOT_CAPTURE):
+            handler = resolve_discord_handler(mode, cfg)
+            plan = handler.plan()
+            assert plan  # echoes a plan
+            assert any("no network performed" in line for line in plan)
+
+
+# ---- CLI: creek discord --mode -----------------------------------------
+
+
+class TestDiscordCommand:
+    """The CLI resolves the mode and echoes the plan; errors exit non-zero."""
+
+    def test_bot_capture_dispatch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """bot_capture (enabled) echoes its plan and the no-network note."""
+        from creek.config import CreekConfig
+
+        cfg = CreekConfig(discord=DiscordSourceConfig(bot_capture={"enabled": True}))
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+        result = runner.invoke(
+            app, ["discord", "--mode", "bot_capture", "--vault", str(tmp_path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "mode=bot_capture" in result.output
+        assert "no network performed" in result.output
+
+    def test_exporter_disabled_exits_nonzero(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The default-off exporter mode exits non-zero (not run)."""
+        from creek.config import CreekConfig
+
+        monkeypatch.setattr(
+            "creek.cli._load_config_for_vault", lambda _v: CreekConfig()
+        )
+        result = runner.invoke(
+            app, ["discord", "--mode", "exporter", "--vault", str(tmp_path)]
+        )
+        assert result.exit_code != 0
+        assert "exporter" in result.output.lower()
+
+    def test_unknown_mode_exits_nonzero(self, tmp_path: Path) -> None:
+        """An unknown mode is rejected before any config use."""
+        result = runner.invoke(
+            app, ["discord", "--mode", "telepathy", "--vault", str(tmp_path)]
+        )
+        assert result.exit_code != 0
+        assert "mode" in result.output.lower()


### PR DESCRIPTION
## Summary

First child of epic #671 (**Discord without downloads**). Lands the seams as **stubs** — no network, no exporter binary, no bot capture (those are #686/#687/#688).

A bot **cannot read DMs** (Discord API limit), so the three ingest modes differ by coverage and compliance (SPEC R5, decision #3 — your traffic is mostly DMs):

- **`data_package`** — ingest a manually-downloaded Data Package. The clean, ToS-compliant fallback; **on by default**.
- **`exporter`** — a user-token exporter (covers DMs + servers). **OFF by default**; enabling it is a ToS-caveated, opt-in choice.
- **`bot_capture`** — a bot logging the servers/channels it's in. Clean, but can't see DMs. Off by default.

### What's here
- **config**: `DiscordSourceConfig` (three `DiscordModeToggle`s). Config holds only the mode toggles — **the Discord token lives in the environment, never in config**.
- **`creek/ingest/discord_dispatch.py`**: `DiscordMode` (StrEnum), three stub handlers each echoing a pull-then-ingest plan with **no I/O**, `resolve_discord_handler` gating on the toggle (`ExporterDisabledError` / `ModeDisabledError`), and the exporter's **Terms-of-Service caveat** printed on enable.
- **cli**: `creek discord --mode <mode> [--dry-run]` resolves the mode and echoes the plan; an unknown or disabled mode exits non-zero.

## Test plan
`tests/test_discord_dispatch.py` (10 tests): exporter off / data_package on / bot_capture off by default; disabled exporter raises `ExporterDisabledError` (no pull); a disabled mode raises `ModeDisabledError`; an enabled exporter announces the **full ToS caveat** (`Discord Terms of Service`, `account suspension`, `your own DMs`, `read-only`); each mode's plan echoes and notes "no network performed"; and the CLI dispatch (bot_capture echoes, disabled exporter exits non-zero, unknown mode exits non-zero).

`./scripts/check-all.sh`: **12/12 gates green**.

## Scope
Skeleton/stubs only — no real exporter (#686), bot-capture writer/backfill (#687), or Data Package helper+docs (#688); no `DiscordIngestor` parser change; no scheduling.

Refs #671
Closes #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)