### PR TITLE
feat(discord): opt-in user-token DM exporter connector (#686)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1221,7 +1221,9 @@ def _run_discord_exporter(
         TokenMissingError,
     )
 
-    runner = SubprocessExporterRunner(binary)
+    runner = SubprocessExporterRunner(
+        binary, timeout_seconds=config.discord.exporter_timeout_seconds
+    )
     try:
         ExporterConnector(config.discord, runner, vault_path).run()
     except TokenMissingError as exc:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -1207,31 +1207,56 @@ def _parse_discord_mode(mode: str) -> DiscordMode:
         raise typer.Exit(code=2) from None
 
 
-@app.command()
-def discord(
-    mode: str = typer.Option(
-        ..., "--mode", help="data_package | exporter | bot_capture"
-    ),
-    dry_run: bool = typer.Option(
-        False, "--dry-run", help="Echo the plan (the only behaviour in the skeleton)"
-    ),
-    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+def _run_discord_exporter(
+    config: CreekConfig,
+    vault_path: Path,
+    binary: str,
 ) -> None:
-    """Dispatch a Discord ingest mode (#685 — skeleton stub).
+    """Run the real opt-in DM exporter connector (#686)."""
+    import subprocess
 
-    Resolves the selected ``--mode`` against the configured Discord toggles and
-    echoes its pull-then-ingest plan. Performs **no network I/O**: the real
-    exporter, bot-capture, and Data Package paths land in #686/#687/#688. The
-    ``exporter`` mode is opt-in (off by default) and prints a Terms-of-Service
-    caveat on use. The Discord token lives in the environment, never in config.
-    """
     from creek.ingest.discord_dispatch import (
+        ExporterConnector,
+        SubprocessExporterRunner,
+        TokenMissingError,
+    )
+
+    runner = SubprocessExporterRunner(binary)
+    try:
+        ExporterConnector(config.discord, runner, vault_path).run()
+    except TokenMissingError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    except subprocess.CalledProcessError as exc:
+        console.print(f"[red]Discord exporter failed: {exc}[/red]")
+        raise typer.Exit(code=1) from exc
+    console.print("[green][discord] exporter run complete; staged + ingested.[/green]")
+
+
+def _dispatch_discord(
+    selected: DiscordMode,
+    config: CreekConfig,
+    vault_path: Path,
+    *,
+    dry_run: bool,
+) -> None:
+    """Run the real exporter, or echo the stub plan for the selected mode (#686)."""
+    from creek.ingest.discord_dispatch import (
+        DiscordMode,
         ModeDisabledError,
         resolve_discord_handler,
     )
 
-    selected = _parse_discord_mode(mode)
-    config = _load_config_for_vault(vault)
+    binary = config.discord.exporter_binary
+    if (
+        selected is DiscordMode.EXPORTER
+        and config.discord.exporter.enabled
+        and binary
+        and not dry_run
+    ):
+        _run_discord_exporter(config, vault_path, binary)
+        return
+
     try:
         handler = resolve_discord_handler(selected, config.discord)
     except ModeDisabledError as exc:
@@ -1243,8 +1268,34 @@ def discord(
         console.print(line)
     if not dry_run:
         console.print(
-            "[dim][discord] skeleton: stub only — no pull/ingest performed yet.[/dim]",
+            "[dim][discord] echo only — set discord.exporter_binary to run the "
+            "exporter, or run #687/#688 paths.[/dim]",
         )
+
+
+@app.command()
+def discord(
+    mode: str = typer.Option(
+        ..., "--mode", help="data_package | exporter | bot_capture"
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Echo the plan without running"
+    ),
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+) -> None:
+    """Dispatch a Discord ingest mode (#685/#686).
+
+    Resolves ``--mode`` against the configured Discord toggles. When
+    ``exporter`` is enabled and ``discord.exporter_binary`` is set (and not
+    ``--dry-run``), runs the real opt-in user-token DM exporter; otherwise
+    echoes the mode's plan. The ``exporter`` mode is opt-in (off by default) and
+    prints a Terms-of-Service caveat. The Discord token lives in the
+    environment, never in config (bot capture is #687; Data Package is #688).
+    """
+    selected = _parse_discord_mode(mode)
+    config = _load_config_for_vault(vault)
+    vault_path = vault or config.vault_path
+    _dispatch_discord(selected, config, vault_path, dry_run=dry_run)
 
 
 @app.command()

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -1453,6 +1453,12 @@ class DiscordSourceConfig(BaseModel):
     exporter: DiscordModeToggle = Field(default_factory=DiscordModeToggle)
     """User-token exporter — OFF by default (decision #3); ToS-caveated."""
 
+    exporter_binary: str | None = None
+    """Path to the operator-provided user-token exporter binary (#686).
+
+    Non-secret. The exporter is invoked read-only with the Discord token passed
+    via the environment only, never on the command line or in this config."""
+
     bot_capture: DiscordModeToggle = Field(default_factory=DiscordModeToggle)
     """Bot message capture for servers/channels — off by default."""
 

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -1454,13 +1454,26 @@ class DiscordSourceConfig(BaseModel):
     """User-token exporter — OFF by default (decision #3); ToS-caveated."""
 
     exporter_binary: str | None = None
-    """Path to the operator-provided user-token exporter binary (#686).
+    """Absolute path to the operator-provided user-token exporter binary (#686).
 
     Non-secret. The exporter is invoked read-only with the Discord token passed
     via the environment only, never on the command line or in this config."""
 
+    exporter_timeout_seconds: int = Field(default=600, ge=1)
+    """Hard timeout for the exporter subprocess so a hung binary cannot block
+    the run indefinitely (#686)."""
+
     bot_capture: DiscordModeToggle = Field(default_factory=DiscordModeToggle)
     """Bot message capture for servers/channels — off by default."""
+
+    @field_validator("exporter_binary")
+    @classmethod
+    def _validate_exporter_binary(cls, value: str | None) -> str | None:
+        """Require an absolute path so the binary resolves predictably (#686)."""
+        if value is not None and not Path(value).is_absolute():
+            msg = f"exporter_binary must be an absolute path, got {value!r}."
+            raise ValueError(msg)
+        return value
 
 
 class CreekConfig(BaseSettings):

--- a/creek-tools/creek/ingest/discord_dispatch.py
+++ b/creek-tools/creek/ingest/discord_dispatch.py
@@ -177,8 +177,9 @@ class ExporterRunner(Protocol):
     def run(self, *, argv: list[str], token: str, out_dir: Path) -> None:
         """Run the exporter with *argv*, staging Data-Package JSON into *out_dir*.
 
-        The token is passed out-of-band (not in *argv*) so it never lands in a
-        logged command line.
+        The caller creates *out_dir* before calling; implementations may assume
+        it exists. The token is passed out-of-band (not in *argv*) so it never
+        lands in a logged command line.
         """
 
 
@@ -187,19 +188,28 @@ class SubprocessExporterRunner:
 
     The binary is invoked with a fixed argument list (``shell=False``) and the
     Discord token supplied via the child process environment — never on the
-    command line — so it cannot leak into process listings or logs.
+    command line — so it cannot leak into process listings or logs. A *timeout*
+    bounds a hung binary.
     """
 
-    def __init__(self, binary: str) -> None:
-        """Bind to the operator-provided exporter binary path."""
+    def __init__(self, binary: str, *, timeout_seconds: int = 600) -> None:
+        """Bind to the operator-provided exporter binary path + a timeout."""
         self._binary = binary
+        self._timeout_seconds = timeout_seconds
 
     def run(self, *, argv: list[str], token: str, out_dir: Path) -> None:
-        """Run ``<binary> <argv...>`` with the token in the child env only."""
-        out_dir.mkdir(parents=True, exist_ok=True)
+        """Run ``<binary> <argv...>`` with the token in the child env only.
+
+        *out_dir* is created by the caller (the connector) before this runs.
+        """
         env = os.environ | {_TOKEN_ENV_VAR: token}
         # Fixed argv (no shell, no untrusted interpolation); token via env only.
-        subprocess.run([self._binary, *argv], check=True, env=env)
+        subprocess.run(
+            [self._binary, *argv],
+            check=True,
+            env=env,
+            timeout=self._timeout_seconds,
+        )
 
 
 class ExporterConnector:

--- a/creek-tools/creek/ingest/discord_dispatch.py
+++ b/creek-tools/creek/ingest/discord_dispatch.py
@@ -12,15 +12,40 @@ lives in the **environment only** — never in config, never echoed or logged.
 
 from __future__ import annotations
 
+import json
+import logging
+import os
+import subprocess
+from datetime import UTC, datetime
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from rich.console import Console
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from creek.config import DiscordSourceConfig
 
 console = Console()
+logger = logging.getLogger(__name__)
+
+_TOKEN_ENV_VAR = "DISCORD_USER_TOKEN"
+_EPOCH_CURSOR = "1970-01-01T00:00:00+00:00"
+
+
+def announce_exporter_caveat() -> None:
+    """Print the user-token exporter's Terms-of-Service caveat (#685/#686).
+
+    Short lines keep each phrase intact regardless of terminal width.
+    """
+    console.print("[yellow][discord] DM exporter caveat:[/yellow]")
+    console.print("[yellow]- A user token drives your account.[/yellow]")
+    console.print("[yellow]- The Discord Terms of Service prohibit this.[/yellow]")
+    console.print("[yellow]- The real stake is account suspension.[/yellow]")
+    console.print(
+        "[yellow]- Use it read-only, for your own DMs, at a low rate.[/yellow]",
+    )
 
 
 class DiscordMode(StrEnum):
@@ -88,17 +113,8 @@ class ExporterHandler(DiscordHandler):
     mode = DiscordMode.EXPORTER
 
     def announce(self) -> None:
-        """Print the Terms-of-Service caveat before any (future) export.
-
-        Short lines keep each asserted phrase intact (no terminal-width wrap).
-        """
-        console.print("[yellow][discord] DM exporter caveat:[/yellow]")
-        console.print("[yellow]- A user token drives your account.[/yellow]")
-        console.print("[yellow]- The Discord Terms of Service prohibit this.[/yellow]")
-        console.print("[yellow]- The real stake is account suspension.[/yellow]")
-        console.print(
-            "[yellow]- Use it read-only, for your own DMs, at a low rate.[/yellow]",
-        )
+        """Print the Terms-of-Service caveat before any (future) export."""
+        announce_exporter_caveat()
 
     def plan(self) -> list[str]:
         """Echo the exporter plan."""
@@ -145,3 +161,139 @@ def resolve_discord_handler(
         msg = f"Discord mode {mode.value!r} is disabled; enable it in config."
         raise ModeDisabledError(msg)
     return _HANDLERS[mode]()
+
+
+# ---- Real opt-in user-token DM exporter connector (#686) ---------------
+
+
+class TokenMissingError(RuntimeError):
+    """Raised when the exporter is enabled but the token env var is unset."""
+
+
+@runtime_checkable
+class ExporterRunner(Protocol):
+    """Mockable seam over the operator-provided user-token exporter binary."""
+
+    def run(self, *, argv: list[str], token: str, out_dir: Path) -> None:
+        """Run the exporter with *argv*, staging Data-Package JSON into *out_dir*.
+
+        The token is passed out-of-band (not in *argv*) so it never lands in a
+        logged command line.
+        """
+
+
+class SubprocessExporterRunner:
+    """Shell out to an operator-provided exporter binary, read-only (#686).
+
+    The binary is invoked with a fixed argument list (``shell=False``) and the
+    Discord token supplied via the child process environment — never on the
+    command line — so it cannot leak into process listings or logs.
+    """
+
+    def __init__(self, binary: str) -> None:
+        """Bind to the operator-provided exporter binary path."""
+        self._binary = binary
+
+    def run(self, *, argv: list[str], token: str, out_dir: Path) -> None:
+        """Run ``<binary> <argv...>`` with the token in the child env only."""
+        out_dir.mkdir(parents=True, exist_ok=True)
+        env = os.environ | {_TOKEN_ENV_VAR: token}
+        # Fixed argv (no shell, no untrusted interpolation); token via env only.
+        subprocess.run([self._binary, *argv], check=True, env=env)
+
+
+class ExporterConnector:
+    """Opt-in user-token DM exporter -> stage -> ingest, incrementally (#686).
+
+    Runs only when ``exporter`` mode is enabled (else raises). Prints the ToS
+    caveat, reads the token from the environment (never config/logs), invokes
+    the exporter ``--after <cursor> --scope dms-only --read-only`` into a local
+    staging dir, ingests the staged Data-Package JSON via the existing
+    ``DiscordIngestor`` (append-only, idempotent on Discord's stable ids), and
+    advances a persisted cursor so a re-run resumes rather than re-exports.
+    """
+
+    def __init__(
+        self,
+        config: DiscordSourceConfig,
+        runner: ExporterRunner,
+        vault: Path,
+        *,
+        cursor_path: Path | None = None,
+        token_env_var: str = _TOKEN_ENV_VAR,
+    ) -> None:
+        """Bind config, the (mockable) exporter runner, vault, and cursor file."""
+        self._config = config
+        self._runner = runner
+        self._vault = vault
+        self._token_env_var = token_env_var
+        self._cursor_path = cursor_path or (
+            vault / "00-Creek-Meta" / "State" / "discord" / "cursor.json"
+        )
+
+    def run(self, after_cursor: str | None = None) -> None:
+        """Export since *after_cursor* (or the persisted cursor), stage, ingest.
+
+        Raises:
+            ExporterDisabledError: When exporter mode is off (no work done).
+            TokenMissingError: When the token env var is unset.
+        """
+        if not self._config.exporter.enabled:
+            msg = "Discord exporter mode is disabled; it is opt-in and OFF by default."
+            raise ExporterDisabledError(msg)
+        announce_exporter_caveat()
+        token = os.environ.get(self._token_env_var)
+        if not token:
+            msg = (
+                f"{self._token_env_var} is not set. The Discord token is read "
+                "from the environment only, never from config."
+            )
+            raise TokenMissingError(msg)
+
+        cursor = after_cursor or self.load_cursor() or _EPOCH_CURSOR
+        staging = self._vault / "discord-export"
+        staging.mkdir(parents=True, exist_ok=True)
+        argv = [
+            "--after",
+            cursor,
+            "--scope",
+            "dms-only",
+            "--read-only",
+            "--output",
+            str(staging),
+        ]
+        # Log the plan WITHOUT the token (it is passed out-of-band to the runner).
+        logger.info("discord.exporter run after=%s scope=dms-only read-only", cursor)
+        self._runner.run(argv=argv, token=token, out_dir=staging)
+        self._ingest(staging)
+        self.save_cursor(datetime.now(UTC).isoformat())
+
+    def _ingest(self, staging: Path) -> None:
+        """Ingest the staged Data Package via the existing DiscordIngestor."""
+        from creek.ingest.base import assemble_ingested_fragment
+        from creek.ingest.discord import DiscordIngestor
+        from creek.vault.writer import VaultWriter
+
+        writer = VaultWriter(vault_path=self._vault)
+        result = DiscordIngestor().ingest(staging)
+        for parsed in result.fragments:
+            assembled = assemble_ingested_fragment(parsed)
+            writer.write_fragment(assembled.fragment, body=assembled.body)
+
+    def load_cursor(self) -> str | None:
+        """Return the persisted ``--after`` cursor, or ``None`` if unset."""
+        if not self._cursor_path.exists():
+            return None
+        try:
+            data = json.loads(self._cursor_path.read_text(encoding="utf-8"))
+            cursor = data.get("cursor") if isinstance(data, dict) else None
+        except (OSError, json.JSONDecodeError):
+            return None
+        return cursor if isinstance(cursor, str) else None
+
+    def save_cursor(self, cursor: str) -> None:
+        """Persist the ``--after`` cursor atomically (no secrets)."""
+        self._cursor_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._cursor_path.with_name(self._cursor_path.name + ".tmp")
+        tmp.write_text(json.dumps({"cursor": cursor}), encoding="utf-8")
+        os.replace(tmp, self._cursor_path)

--- a/creek-tools/tests/test_discord_exporter.py
+++ b/creek-tools/tests/test_discord_exporter.py
@@ -198,3 +198,63 @@ class TestSubprocessExporterRunner:
         env = captured["env"]
         assert isinstance(env, dict)
         assert env["DISCORD_USER_TOKEN"] == "secret-zzz"
+
+
+class TestDiscordExporterCli:
+    """`creek discord --mode exporter` routes to the connector vs. the echo stub."""
+
+    def test_enabled_with_binary_runs_connector(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Enabled exporter + binary (no --dry-run) calls the real connector."""
+        from typer.testing import CliRunner
+
+        from creek.cli import app
+        from creek.config import CreekConfig
+
+        called: list[str] = []
+        monkeypatch.setattr(
+            "creek.cli._run_discord_exporter",
+            lambda _c, _v, binary: called.append(binary),
+        )
+        cfg = CreekConfig(
+            discord=DiscordSourceConfig(
+                exporter={"enabled": True}, exporter_binary="/abs/exporter"
+            )
+        )
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+
+        result = CliRunner().invoke(
+            app, ["discord", "--mode", "exporter", "--vault", str(tmp_path)]
+        )
+        assert result.exit_code == 0, result.output
+        assert called == ["/abs/exporter"]
+
+    def test_dry_run_echoes_not_runs_connector(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """--dry-run echoes the plan and does NOT invoke the connector."""
+        from typer.testing import CliRunner
+
+        from creek.cli import app
+        from creek.config import CreekConfig
+
+        called: list[str] = []
+        monkeypatch.setattr(
+            "creek.cli._run_discord_exporter",
+            lambda _c, _v, binary: called.append(binary),
+        )
+        cfg = CreekConfig(
+            discord=DiscordSourceConfig(
+                exporter={"enabled": True}, exporter_binary="/abs/exporter"
+            )
+        )
+        monkeypatch.setattr("creek.cli._load_config_for_vault", lambda _v: cfg)
+
+        result = CliRunner().invoke(
+            app,
+            ["discord", "--mode", "exporter", "--dry-run", "--vault", str(tmp_path)],
+        )
+        assert result.exit_code == 0, result.output
+        assert called == []  # dry-run -> stub echo, connector not called
+        assert "exporter" in result.output.lower()

--- a/creek-tools/tests/test_discord_exporter.py
+++ b/creek-tools/tests/test_discord_exporter.py
@@ -1,0 +1,200 @@
+"""Opt-in user-token DM exporter connector (#686).
+
+Tested with a fake exporter — no real network, no real token. Proves: off by
+default, caveat on enable, token from env (never logged), incremental
+``--after`` + your-DMs-only + read-only flags, staged JSON ingested, cursor
+advanced, and a re-run is idempotent.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.config import DiscordSourceConfig
+from creek.ingest.discord_dispatch import (
+    ExporterConnector,
+    ExporterDisabledError,
+    SubprocessExporterRunner,
+    TokenMissingError,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_CURSOR = "2026-06-25T00:00:00+00:00"
+
+
+def _write_data_package(out_dir: Path) -> None:
+    """Write a minimal one-DM Data Package the DiscordIngestor can read."""
+    channel = out_dir / "messages" / "chan1"
+    channel.mkdir(parents=True, exist_ok=True)
+    (channel / "channel.json").write_text(
+        json.dumps({"id": "chan1", "name": "Direct Message with Ada"}),
+        encoding="utf-8",
+    )
+    (channel / "messages.json").write_text(
+        json.dumps(
+            [
+                {
+                    "id": "m1",
+                    "timestamp": "2026-06-26T10:00:00+00:00",
+                    "content": "a private reflection worth keeping",
+                    "author": {"name": "me"},
+                },
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+
+class FakeExporter:
+    """Records its invocation and stages a Data Package (no network)."""
+
+    def __init__(self) -> None:
+        """Initialise capture fields."""
+        self.argv: list[str] | None = None
+        self.token: str | None = None
+        self.out_dir: Path | None = None
+        self.scope: str | None = None
+        self.read_only: bool = False
+
+    def run(self, *, argv: list[str], token: str, out_dir: Path) -> None:
+        """Capture the call and stage the sample DM export."""
+        self.argv = argv
+        self.token = token
+        self.out_dir = out_dir
+        self.scope = argv[argv.index("--scope") + 1] if "--scope" in argv else None
+        self.read_only = "--read-only" in argv
+        _write_data_package(out_dir)
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Scaffold a vault the connector can ingest into."""
+    vault = tmp_path / "vault"
+    for d in ("00-Creek-Meta/Processing-Log", "01-Fragments/Messages"):
+        (vault / d).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _fragments(vault: Path) -> list[Path]:
+    """Every fragment written under 01-Fragments."""
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+class TestExporterConnector:
+    """The connector exports incrementally, ingests, and advances the cursor."""
+
+    def test_incremental_readonly_dms_only(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Token from env (never logged); scoped+read-only flags; staged+ingested."""
+        monkeypatch.setenv("DISCORD_USER_TOKEN", "secret-xyz")
+        fake = FakeExporter()
+        cfg = DiscordSourceConfig(exporter={"enabled": True})
+        vault = _make_vault(tmp_path)
+        connector = ExporterConnector(cfg, runner=fake, vault=vault)
+
+        with caplog.at_level(logging.INFO):
+            connector.run(after_cursor=_CURSOR)
+
+        assert fake.token == "secret-xyz"
+        assert "secret-xyz" not in caplog.text  # token never logged
+        assert "--after" in fake.argv
+        assert _CURSOR in fake.argv
+        assert fake.scope == "dms-only"
+        assert fake.read_only is True
+        assert len(_fragments(vault)) > 0  # staged JSON was ingested
+        cursor = connector.load_cursor()
+        assert cursor is not None
+        assert cursor > _CURSOR  # advanced past the input window
+
+    def test_refuses_when_disabled(self, tmp_path: Path) -> None:
+        """A disabled exporter raises before any work."""
+        connector = ExporterConnector(
+            DiscordSourceConfig(), runner=FakeExporter(), vault=tmp_path
+        )
+        with pytest.raises(ExporterDisabledError):
+            connector.run()
+
+    def test_requires_token(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An enabled exporter with no token env var raises TokenMissingError."""
+        monkeypatch.delenv("DISCORD_USER_TOKEN", raising=False)
+        cfg = DiscordSourceConfig(exporter={"enabled": True})
+        connector = ExporterConnector(
+            cfg, runner=FakeExporter(), vault=_make_vault(tmp_path)
+        )
+        with pytest.raises(TokenMissingError):
+            connector.run()
+
+    def test_prints_tos_caveat_on_run(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Running the (enabled) exporter prints the ToS caveat."""
+        monkeypatch.setenv("DISCORD_USER_TOKEN", "x")
+        cfg = DiscordSourceConfig(exporter={"enabled": True})
+        ExporterConnector(cfg, runner=FakeExporter(), vault=_make_vault(tmp_path)).run(
+            after_cursor=_CURSOR
+        )
+        out = capsys.readouterr().out
+        assert "Discord Terms of Service" in out
+        assert "read-only" in out
+
+    def test_rerun_is_idempotent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A second run (persisted cursor, same messages) writes no duplicate."""
+        monkeypatch.setenv("DISCORD_USER_TOKEN", "x")
+        cfg = DiscordSourceConfig(exporter={"enabled": True})
+        vault = _make_vault(tmp_path)
+
+        ExporterConnector(cfg, runner=FakeExporter(), vault=vault).run(
+            after_cursor=_CURSOR
+        )
+        before = len(_fragments(vault))
+        assert before > 0
+
+        # New instance resumes from the persisted cursor; same export, same ids.
+        ExporterConnector(cfg, runner=FakeExporter(), vault=vault).run()
+        assert len(_fragments(vault)) == before  # idempotent (stable ids)
+
+
+class TestSubprocessExporterRunner:
+    """The real runner passes the token via env, never on the command line."""
+
+    def test_token_via_env_not_argv(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The token reaches the child env; the argv carries no secret."""
+        captured: dict[str, object] = {}
+
+        def _fake_run(cmd: list[str], **kwargs: object) -> None:
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env")
+
+        monkeypatch.setattr("creek.ingest.discord_dispatch.subprocess.run", _fake_run)
+        runner = SubprocessExporterRunner("/usr/local/bin/exporter")
+        runner.run(
+            argv=["--after", _CURSOR, "--read-only"],
+            token="secret-zzz",
+            out_dir=tmp_path,
+        )
+
+        cmd = captured["cmd"]
+        assert cmd[0] == "/usr/local/bin/exporter"
+        assert "--read-only" in cmd
+        assert "secret-zzz" not in cmd  # token never on the command line
+        env = captured["env"]
+        assert isinstance(env, dict)
+        assert env["DISCORD_USER_TOKEN"] == "secret-zzz"


### PR DESCRIPTION
## Summary

Replaces the #685 exporter stub with the **real opt-in user-token DM exporter** (epic #671). It runs **only when exporter mode is enabled** (else raises), behind the Terms-of-Service caveat — because a bot can't read DMs and the operator's traffic is mostly DMs (decision #3).

- **`ExporterConnector`** — reads the Discord token from `DISCORD_USER_TOKEN` in the **environment only** (never config, never logged); invokes the exporter `--after <cursor> --scope dms-only --read-only --output <staging>` via a **mockable runner seam**; ingests the staged Data-Package JSON through the existing `DiscordIngestor` (append-only, idempotent on Discord's stable message ids); and **advances a persisted `--after` cursor** so a re-run resumes rather than re-exports.
- **`SubprocessExporterRunner`** — shells out to an operator-provided binary with a fixed argv (`shell=False`) and the token in the **child process env only** — never on the command line (so it can't leak into process listings or logs).
- **`announce_exporter_caveat()`** — the ToS caveat, shared by the stub handler and the connector.
- **config**: `DiscordSourceConfig.exporter_binary` (non-secret path). **cli**: `discord --mode exporter` runs the connector when enabled + binary configured (else echoes the plan), via `_dispatch_discord` / `_run_discord_exporter`.

### Security / ToS
Token is env-only and never appears in argv or logs (asserted). The exporter is **off by default**, prints the caveat on run, and is invoked **your-DMs-only**, **read-only**. The persisted cursor stores only a timestamp.

## Test plan
`tests/test_discord_exporter.py` (6 tests, fake exporter — no network/token):
- incremental run: token from env, **absent from `caplog`**, `--after <cursor>` + `--scope dms-only` + `--read-only` flags asserted, staged JSON **ingested** (fragments > 0), cursor **advanced** past the input window;
- **off-by-default** refusal (`ExporterDisabledError`); **token-missing** (`TokenMissingError`); **caveat printed** on run; **re-run idempotent** (same ids → no duplicate);
- `SubprocessExporterRunner`: token reaches the child **env**, never the **argv**.

`./scripts/check-all.sh`: **12/12 gates green**.

## Scope
No bot-capture (#687), no Data Package helper+docs (#688); no `DiscordIngestor` parser change; no vendoring/downloading of an exporter (operator-provided binary via the mockable seam); no scheduling (Epic B's `creek sync` calls this on a timer).

Refs #671
Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)