### PR TITLE
feat(discord): bot message-capture path for servers/channels (#687)

### DIFF
--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -896,5 +896,7 @@ class CrawDadClient(discord.Client):
             return
         try:
             await self._message_capture.on_message(message)
-        except OSError:
-            _LOGGER.exception("bot-capture write failed; continuing command path")
+        except Exception:
+            # Best-effort capture: any failure (bad message shape, disk error)
+            # is logged and swallowed so it can never break the command path.
+            _LOGGER.exception("bot-capture failed; continuing command path")

--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from crawdad.attachments import _AttachmentLike
+    from crawdad.capture import MessageCapture
     from crawdad.composer import SonnetComposer
     from crawdad.config import CrawDadConfig
     from crawdad.mcp_client import MCPClient
@@ -777,6 +778,7 @@ class CrawDadClient(discord.Client):
         pending_batches: PendingBatchStore | None = None,
         workflow_lister: Callable[[], list[str]] | None = None,
         workflow_runner: WorkflowRunner | None = None,
+        message_capture: MessageCapture | None = None,
         intents: discord.Intents | None = None,
     ) -> None:
         """Store config + agent-loop components; init the parent ``Client``.
@@ -820,6 +822,7 @@ class CrawDadClient(discord.Client):
         self._loop_runner = loop_runner
         self._pending_batches = pending_batches
         self._workflow_runner = workflow_runner
+        self._message_capture = message_capture
         self.tree = app_commands.CommandTree(self)
         if loop_runner is not None:
             # discord.py's ``CommandTree.command`` signature is wider than
@@ -858,10 +861,11 @@ class CrawDadClient(discord.Client):
         _LOGGER.info("crawdad connected as %s", self.user)
 
     async def on_message(self, message: discord.Message) -> None:
-        """Forward Discord messages to :func:`handle_message`."""
+        """Capture the message (best-effort), then forward to :func:`handle_message`."""
         if self.user is None:
             _LOGGER.debug("on_message before client ready; dropping event")
             return
+        await self._capture_message(message)
         await handle_message(
             cast("_MessageLike", message),
             config=self._config,
@@ -877,3 +881,20 @@ class CrawDadClient(discord.Client):
             pending_batches=self._pending_batches,
             workflow_runner=self._workflow_runner,
         )
+
+    async def _capture_message(self, message: discord.Message) -> None:
+        """Append the message to the bot-capture log, never disturbing commands.
+
+        No-op when capture is disabled. The bot's own messages are skipped (it
+        would only re-capture its own replies). A capture write failure is logged
+        and swallowed — capture is best-effort and must never break the command
+        path (#687).
+        """
+        if self._message_capture is None:
+            return
+        if self.user is not None and message.author.id == self.user.id:
+            return
+        try:
+            await self._message_capture.on_message(message)
+        except OSError:
+            _LOGGER.exception("bot-capture write failed; continuing command path")

--- a/crawdad/crawdad/capture.py
+++ b/crawdad/crawdad/capture.py
@@ -83,15 +83,20 @@ def _reference_id(message: _MessageLike) -> str | None:
 
 
 def _channel_label(channel: object) -> str:
-    """A filesystem-safe channel folder name (``name`` if present, else id).
+    """A filesystem-safe channel folder name (``name`` if usable, else id).
 
     Discord text-channel names are already restricted, but path separators are
-    stripped defensively so a channel folder can never escape the capture root.
+    stripped and a bare ``.`` / ``..`` name is refused (falling back to the
+    channel id) so a channel folder can never escape the capture root — even
+    from a mocked channel or if Discord's naming rules ever loosen.
     """
     name = getattr(channel, "name", None)
     raw = name if isinstance(name, str) and name.strip() else None
-    label = (raw or str(getattr(channel, "id", "unknown"))).replace("/", "_")
-    return label.replace("\\", "_").strip() or "unknown"
+    fallback = str(getattr(channel, "id", "unknown"))
+    label = (raw or fallback).replace("/", "_").replace("\\", "_").strip()
+    if not label or label in {".", ".."}:
+        return fallback or "unknown"
+    return label
 
 
 def _record_for(message: _MessageLike) -> dict[str, object]:
@@ -117,7 +122,14 @@ class MessageCapture:
     """
 
     def __init__(self, capture_dir: Path) -> None:
-        """Bind the capture root; per-channel seen-id sets load lazily from disk."""
+        """Bind the capture root; per-channel seen-id sets load lazily from disk.
+
+        ``_seen`` caches every captured message id per channel for the bot's
+        lifetime — fine for the personal-use deployment target; a very high
+        volume server running for months could grow it to tens of thousands of
+        ids per channel, at which point a bounded/evicting cache would be worth
+        adding.
+        """
         self._dir = capture_dir
         self._seen: dict[str, set[str]] = {}
 

--- a/crawdad/crawdad/capture.py
+++ b/crawdad/crawdad/capture.py
@@ -1,0 +1,193 @@
+"""Live Discord message capture for the bot-capture ingest path (#687).
+
+CrawDad logs each message in the servers/channels it is in to
+``<capture_dir>/<channel>/<date>.jsonl`` — one JSON object per line in the
+lowercase Discord message schema the creek ``DiscordIngestor`` already reads::
+
+    {"id": "...", "timestamp": "ISO8601", "content": "...",
+     "author": {"name": "..."}, "reference": {"messageId": "..."}}
+
+Tier-A ingest (Epic B's ``creek sync``) reshapes the capture dir into the
+Data-Package layout and ingests it with **no parser rewrite**. A bot **cannot**
+read DMs (a hard Discord API limit), so this path covers only channels the bot
+is in; DMs are the opt-in user-token exporter's job (#686).
+
+The bot token lives in the **environment only**; capture adds no new secret
+surface. Discord message ids are stable, so appending the same message twice is
+a no-op (the writer skips a known id) and a backfill that overlaps the live
+stream is idempotent both here and at ingest.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class _AuthorLike(Protocol):
+    """The author bits we read — ``name`` always, ``display_name`` if present."""
+
+    @property
+    def name(self) -> str: ...  # pragma: no cover - protocol stub
+
+
+@runtime_checkable
+class _MessageLike(Protocol):
+    """Structural view of ``discord.Message`` covering the bits capture reads."""
+
+    @property
+    def id(self) -> int: ...  # pragma: no cover - protocol stub
+
+    @property
+    def content(self) -> str: ...  # pragma: no cover - protocol stub
+
+    @property
+    def created_at(self) -> datetime: ...  # pragma: no cover - protocol stub
+
+    @property
+    def author(self) -> _AuthorLike: ...  # pragma: no cover - protocol stub
+
+    @property
+    def channel(self) -> object: ...  # pragma: no cover - protocol stub
+
+
+@runtime_checkable
+class _BackfillChannel(Protocol):
+    """A channel that can replay its history for gap-filling backfill."""
+
+    def history(
+        self, *, after: datetime | None, oldest_first: bool
+    ) -> AsyncIterator[_MessageLike]: ...  # pragma: no cover - protocol stub
+
+
+def _author_name(message: _MessageLike) -> str:
+    """The display name if the author has one, else the plain name."""
+    display = getattr(message.author, "display_name", "")
+    return display or message.author.name
+
+
+def _reference_id(message: _MessageLike) -> str | None:
+    """The replied-to message id, if this message is a reply."""
+    ref = getattr(message, "reference", None)
+    ref_id = getattr(ref, "message_id", None) if ref is not None else None
+    return str(ref_id) if ref_id is not None else None
+
+
+def _channel_label(channel: object) -> str:
+    """A filesystem-safe channel folder name (``name`` if present, else id).
+
+    Discord text-channel names are already restricted, but path separators are
+    stripped defensively so a channel folder can never escape the capture root.
+    """
+    name = getattr(channel, "name", None)
+    raw = name if isinstance(name, str) and name.strip() else None
+    label = (raw or str(getattr(channel, "id", "unknown"))).replace("/", "_")
+    return label.replace("\\", "_").strip() or "unknown"
+
+
+def _record_for(message: _MessageLike) -> dict[str, object]:
+    """Build the lowercase-schema JSON record for *message*."""
+    record: dict[str, object] = {
+        "id": str(message.id),
+        "timestamp": message.created_at.isoformat(),
+        "content": message.content,
+        "author": {"name": _author_name(message)},
+    }
+    ref_id = _reference_id(message)
+    if ref_id is not None:
+        record["reference"] = {"messageId": ref_id}
+    return record
+
+
+class MessageCapture:
+    """Append-only JSONL capture of Discord messages, idempotent on message id.
+
+    One instance serves the bot's lifetime. ``on_message`` tails the live stream;
+    ``backfill`` replays a channel's ``history`` to fill the gap since the last
+    captured message. Both skip ids already on disk, so overlap is a clean no-op.
+    """
+
+    def __init__(self, capture_dir: Path) -> None:
+        """Bind the capture root; per-channel seen-id sets load lazily from disk."""
+        self._dir = capture_dir
+        self._seen: dict[str, set[str]] = {}
+
+    async def on_message(self, message: _MessageLike) -> None:
+        """Append one live message to ``<channel>/<date>.jsonl`` (id-idempotent)."""
+        self._append(message)
+
+    async def backfill(self, channel: _BackfillChannel) -> None:
+        """Replay *channel*'s history since the last capture; append the gap.
+
+        The pull is bounded by the latest captured timestamp for the channel
+        (an optimisation); id-dedup makes any overlap with the live stream safe.
+        """
+        label = _channel_label(channel)
+        after = self._latest_timestamp(label)
+        async for message in channel.history(after=after, oldest_first=True):
+            self._append(message)
+
+    def _append(self, message: _MessageLike) -> None:
+        """Write *message* as a JSON line, skipping a message id already seen."""
+        label = _channel_label(message.channel)
+        msg_id = str(message.id)
+        seen = self._seen_ids(label)
+        if msg_id in seen:
+            return
+        date = message.created_at.date().isoformat()
+        path = self._dir / label / f"{date}.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(_record_for(message)) + "\n")
+        seen.add(msg_id)
+
+    def _seen_ids(self, channel: str) -> set[str]:
+        """The set of message ids already captured for *channel* (cached)."""
+        if channel not in self._seen:
+            self._seen[channel] = {
+                str(rec["id"])
+                for rec in self._iter_records(channel)
+                if isinstance(rec.get("id"), str)
+            }
+        return self._seen[channel]
+
+    def _latest_timestamp(self, channel: str) -> datetime | None:
+        """The newest captured ``timestamp`` for *channel*, or ``None`` if empty."""
+        latest: datetime | None = None
+        for rec in self._iter_records(channel):
+            raw = rec.get("timestamp")
+            if not isinstance(raw, str):
+                continue
+            try:
+                parsed = datetime.fromisoformat(raw)
+            except ValueError:
+                continue
+            if latest is None or parsed > latest:
+                latest = parsed
+        return latest
+
+    def _iter_records(self, channel: str) -> Iterator[dict[str, object]]:
+        """Yield every parsed JSON record under ``<capture_dir>/<channel>/``."""
+        channel_dir = self._dir / channel
+        if not channel_dir.is_dir():
+            return
+        for jsonl in sorted(channel_dir.glob("*.jsonl")):
+            for line in jsonl.read_text(encoding="utf-8").splitlines():
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    obj = json.loads(stripped)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict):
+                    yield obj

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from crawdad.bot import CrawDadClient
+from crawdad.capture import MessageCapture
 from crawdad.composer import SonnetComposer
 from crawdad.config import (
     composer_model_for,
@@ -138,8 +139,20 @@ def run_bot(config: CrawDadConfig) -> None:
         pending_batches=pending_batches,
         workflow_lister=_build_workflow_lister(workflow_registry),
         workflow_runner=workflow_runner,
+        message_capture=_build_message_capture(config),
     )
     client.run(config.discord_bot_token)
+
+
+def _build_message_capture(config: CrawDadConfig) -> MessageCapture | None:
+    """Build the bot-capture writer when enabled, else ``None`` (#687).
+
+    The capture dir is the vault-relative ``capture_subpath`` joined onto the
+    vault root, mirroring where creek's Tier-A ingest reads.
+    """
+    if not config.capture_enabled:
+        return None
+    return MessageCapture(capture_dir=config.vault_path / config.capture_subpath)
 
 
 def _build_workflow_lister(

--- a/crawdad/crawdad/config.py
+++ b/crawdad/crawdad/config.py
@@ -405,6 +405,39 @@ class CrawDadConfig(BaseModel):
     max_loop_rounds: int = Field(default=MAX_LOOP_ROUNDS, ge=1, le=50)
     """Operator override for the FEAT-015 agent-loop round cap."""
 
+    capture_enabled: bool = Field(default=False)
+    """Bot-capture toggle (#687) — OFF by default; opt-in per deployment.
+
+    When ``True`` the bot logs each message in the servers/channels it is in to
+    ``<vault>/<capture_subpath>/<channel>/<date>.jsonl`` for Tier-A ingest. The
+    bot cannot read DMs (a hard Discord API limit), so this covers channels only.
+    """
+
+    capture_subpath: Path = Field(default=Path("discord-capture"))
+    """Vault-relative dir the bot-capture writer appends to (#687).
+
+    Mirrors the creek-side ``DiscordSourceConfig.capture_subpath`` default so the
+    bot writes exactly where Tier-A ingest reads. Must stay inside the vault.
+    """
+
+    @field_validator("capture_subpath")
+    @classmethod
+    def _refuse_absolute_capture_subpath(cls, value: Path) -> Path:
+        """Refuse absolute / ``..`` capture paths — must stay in the vault (#687)."""
+        if value.is_absolute():
+            msg = (
+                f"capture_subpath {value!r} must be vault-relative; "
+                "absolute paths could escape the vault root."
+            )
+            raise ValueError(msg)
+        if ".." in value.parts:
+            msg = (
+                f"capture_subpath {value!r} must not contain '..'; "
+                "parent-directory segments could escape the vault root."
+            )
+            raise ValueError(msg)
+        return value
+
     @field_validator("allowed_user_ids", "allowed_channel_ids")
     @classmethod
     def _non_empty(cls, value: tuple[int, ...]) -> tuple[int, ...]:

--- a/crawdad/tests/test_bot_capture.py
+++ b/crawdad/tests/test_bot_capture.py
@@ -162,6 +162,28 @@ async def test_capture_failure_does_not_break_commands(
     assert handled == [400]  # command path survived the capture failure
 
 
+async def test_non_oserror_capture_failure_is_swallowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-OSError (e.g. a bad message shape) also never breaks commands."""
+    handled: list[int] = []
+
+    async def _fake_handle(message: _MessageLike, **_kwargs: object) -> None:
+        handled.append(message.id)
+
+    monkeypatch.setattr("crawdad.bot.handle_message", _fake_handle)
+
+    class _BrokenCapture(MessageCapture):
+        async def on_message(self, message: _MessageLike) -> None:
+            raise ValueError("unexpected message shape")
+
+    client = _client(tmp_path, _BrokenCapture(capture_dir=tmp_path / "cap"))
+
+    await client.on_message(_message(msg_id=401, author_id=111))
+
+    assert handled == [401]  # the broadened catch kept the command path alive
+
+
 async def test_on_message_before_ready_drops_event(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/crawdad/tests/test_bot_capture.py
+++ b/crawdad/tests/test_bot_capture.py
@@ -1,0 +1,203 @@
+"""Bot-capture wiring on ``CrawDadClient.on_message`` (#687).
+
+Proves capture runs alongside — and never disturbs — the command path: a
+non-self message is captured *and* forwarded to ``handle_message``; the bot's
+own messages are skipped; a capture write failure is swallowed so commands still
+run; and the CLI builds the writer only when capture is enabled.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from crawdad import cli
+from crawdad.bot import CrawDadClient
+from crawdad.capture import MessageCapture
+from crawdad.config import CrawDadConfig
+
+if TYPE_CHECKING:
+    from crawdad.capture import _MessageLike
+
+
+@dataclass
+class _FakeUser:
+    id: int
+    name: str = "someone"
+
+
+@dataclass
+class _FakeChannel:
+    name: str
+    id: int = 1
+
+
+@dataclass
+class _FakeMessage:
+    id: int
+    content: str
+    created_at: datetime
+    author: _FakeUser
+    channel: _FakeChannel
+    attachments: list[object] = field(default_factory=list)
+
+
+_BOT_USER_ID = 999
+
+
+class _ReadyClient(CrawDadClient):
+    """A client that reports itself as connected (``user`` is set)."""
+
+    @property
+    def user(self) -> _FakeUser:  # type: ignore[override]  # Issue #687: test-only ready stub
+        """Pretend the gateway handshake finished so ``on_message`` proceeds."""
+        return _FakeUser(id=_BOT_USER_ID)
+
+
+def _config(tmp_path: Path, *, capture_enabled: bool = False) -> CrawDadConfig:
+    """A minimal valid bot config rooted at *tmp_path*."""
+    return CrawDadConfig(
+        discord_bot_token="t",
+        vault_path=tmp_path,
+        allowed_user_ids=[111],
+        allowed_channel_ids=[999],
+        capture_enabled=capture_enabled,
+    )
+
+
+def _message(*, msg_id: int, author_id: int) -> _FakeMessage:
+    """A fake discord message carrying both capture + author fields."""
+    return _FakeMessage(
+        id=msg_id,
+        content="a thoughtful note worth keeping in the vault",
+        created_at=datetime.fromisoformat("2026-06-26T10:00:00").replace(tzinfo=UTC),
+        author=_FakeUser(id=author_id, name="Ada"),
+        channel=_FakeChannel(name="general"),
+    )
+
+
+def _client(tmp_path: Path, capture: MessageCapture | None) -> _ReadyClient:
+    """Construct a ready test client wired with *capture*."""
+    return _ReadyClient(
+        config=_config(tmp_path),
+        session_state=None,
+        message_capture=capture,
+    )
+
+
+async def test_captures_and_forwards_to_command_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-self message is captured AND forwarded to handle_message."""
+    handled: list[int] = []
+
+    async def _fake_handle(message: _MessageLike, **_kwargs: object) -> None:
+        handled.append(message.id)
+
+    monkeypatch.setattr("crawdad.bot.handle_message", _fake_handle)
+    capture = MessageCapture(capture_dir=tmp_path / "discord-capture")
+    client = _client(tmp_path, capture)
+
+    await client.on_message(_message(msg_id=100, author_id=111))
+
+    assert handled == [100]  # command path still fires
+    captured = tmp_path / "discord-capture" / "general" / "2026-06-26.jsonl"
+    assert captured.is_file()  # and the message was captured
+
+
+async def test_skips_the_bots_own_messages(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The bot does not capture its own replies."""
+    monkeypatch.setattr("crawdad.bot.handle_message", _noop_handle)
+    capture = MessageCapture(capture_dir=tmp_path / "discord-capture")
+    client = _client(tmp_path, capture)
+
+    await client.on_message(_message(msg_id=200, author_id=_BOT_USER_ID))
+
+    assert not (tmp_path / "discord-capture").exists()
+
+
+async def test_no_capture_configured_is_inert(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With capture disabled, on_message just forwards (no dir written)."""
+    handled: list[int] = []
+
+    async def _fake_handle(message: _MessageLike, **_kwargs: object) -> None:
+        handled.append(message.id)
+
+    monkeypatch.setattr("crawdad.bot.handle_message", _fake_handle)
+    client = _client(tmp_path, capture=None)
+
+    await client.on_message(_message(msg_id=300, author_id=111))
+
+    assert handled == [300]
+    assert not (tmp_path / "discord-capture").exists()
+
+
+async def test_capture_failure_does_not_break_commands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A capture OSError is swallowed; the command path still runs."""
+    handled: list[int] = []
+
+    async def _fake_handle(message: _MessageLike, **_kwargs: object) -> None:
+        handled.append(message.id)
+
+    monkeypatch.setattr("crawdad.bot.handle_message", _fake_handle)
+
+    class _BrokenCapture(MessageCapture):
+        async def on_message(self, message: _MessageLike) -> None:
+            raise OSError("disk full")
+
+    client = _client(tmp_path, _BrokenCapture(capture_dir=tmp_path / "cap"))
+
+    await client.on_message(_message(msg_id=400, author_id=111))
+
+    assert handled == [400]  # command path survived the capture failure
+
+
+async def test_on_message_before_ready_drops_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Before the client is ready (user is None), on_message no-ops."""
+    handled: list[int] = []
+
+    async def _fake_handle(message: _MessageLike, **_kwargs: object) -> None:
+        handled.append(message.id)
+
+    monkeypatch.setattr("crawdad.bot.handle_message", _fake_handle)
+    # Plain CrawDadClient: user is None until connected.
+    client = CrawDadClient(
+        config=_config(tmp_path),
+        session_state=None,
+        message_capture=MessageCapture(capture_dir=tmp_path / "cap"),
+    )
+
+    await client.on_message(_message(msg_id=500, author_id=111))
+
+    assert handled == []  # dropped before ready
+    assert not (tmp_path / "cap").exists()
+
+
+async def _noop_handle(message: _MessageLike, **_kwargs: object) -> None:
+    """A handle_message stand-in that does nothing."""
+
+
+class TestBuildMessageCapture:
+    """The CLI builds the capture writer only when capture is enabled."""
+
+    def test_enabled_builds_writer_at_vault_subpath(self, tmp_path: Path) -> None:
+        """Enabled -> a MessageCapture rooted at vault/capture_subpath."""
+        config = _config(tmp_path, capture_enabled=True)
+        capture = cli._build_message_capture(config)
+        assert isinstance(capture, MessageCapture)
+
+    def test_disabled_returns_none(self, tmp_path: Path) -> None:
+        """Disabled (the default) -> no capture writer."""
+        assert cli._build_message_capture(_config(tmp_path)) is None

--- a/crawdad/tests/test_capture.py
+++ b/crawdad/tests/test_capture.py
@@ -1,0 +1,242 @@
+"""Tests for ``crawdad.capture`` — the bot-capture JSONL writer (#687).
+
+Driven entirely by a **fake message stream** — no live Discord connection. Proves
+a live message is appended to the correct ``<channel>/<date>.jsonl``, that
+``backfill`` fills the gap via ``channel.history()`` and overlaps dedupe by
+stable message id, and that the captured lines carry the lowercase schema creek's
+``DiscordIngestor`` reads.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from crawdad.capture import MessageCapture
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+    from pathlib import Path
+
+
+@dataclass
+class _FakeAuthor:
+    name: str
+    display_name: str = ""
+
+
+@dataclass
+class _FakeChannel:
+    name: str
+    id: int = 1
+
+
+@dataclass
+class _FakeReference:
+    message_id: int
+
+
+@dataclass
+class _FakeMessage:
+    id: int
+    content: str
+    created_at: datetime
+    author: _FakeAuthor
+    channel: _FakeChannel
+    reference: _FakeReference | None = None
+
+
+@dataclass
+class _FakeHistoryChannel:
+    name: str
+    history_messages: list[_FakeMessage]
+    id: int = 1
+
+    def history(
+        self, *, after: datetime | None, oldest_first: bool
+    ) -> AsyncIterator[_FakeMessage]:
+        """Replay the canned history (the fake ignores *after*; ingest dedupes)."""
+        assert oldest_first is True
+        messages = self.history_messages
+
+        async def _gen() -> AsyncIterator[_FakeMessage]:
+            for message in messages:
+                yield message
+
+        return _gen()
+
+
+def _message(
+    *,
+    msg_id: int,
+    content: str,
+    ts: str,
+    channel: str = "general",
+    author: str = "Ada",
+    reference: int | None = None,
+) -> _FakeMessage:
+    """Build a fake discord-message-shaped object."""
+    return _FakeMessage(
+        id=msg_id,
+        content=content,
+        created_at=datetime.fromisoformat(ts).replace(tzinfo=UTC),
+        author=_FakeAuthor(name=author),
+        channel=_FakeChannel(name=channel),
+        reference=(
+            _FakeReference(message_id=reference) if reference is not None else None
+        ),
+    )
+
+
+def _read_jsonl(path: Path) -> list[dict[str, object]]:
+    """Parse a captured JSONL file into a list of records."""
+    return [
+        json.loads(line)
+        for line in path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+class TestOnMessage:
+    """Live messages append to ``<channel>/<date>.jsonl`` in the creek schema."""
+
+    async def test_appends_lowercase_schema(self, tmp_path: Path) -> None:
+        """A captured message carries id/timestamp/content/author."""
+        capture = MessageCapture(capture_dir=tmp_path / "discord-capture")
+        await capture.on_message(
+            _message(msg_id=100, content="hi", ts="2026-06-26T10:00:00")
+        )
+
+        path = tmp_path / "discord-capture" / "general" / "2026-06-26.jsonl"
+        records = _read_jsonl(path)
+        assert len(records) == 1
+        assert records[0]["id"] == "100"
+        assert records[0]["content"] == "hi"
+        assert records[0]["author"] == {"name": "Ada"}
+        assert records[0]["timestamp"].startswith("2026-06-26T10:00:00")
+
+    async def test_reply_records_reference(self, tmp_path: Path) -> None:
+        """A reply captures the replied-to message id for the parser."""
+        capture = MessageCapture(capture_dir=tmp_path / "cap")
+        await capture.on_message(
+            _message(msg_id=101, content="re", ts="2026-06-26T10:01:00", reference=100)
+        )
+        record = _read_jsonl(tmp_path / "cap" / "general" / "2026-06-26.jsonl")[0]
+        assert record["reference"] == {"messageId": "100"}
+
+    async def test_duplicate_id_is_skipped(self, tmp_path: Path) -> None:
+        """The same message id twice writes only one line (idempotent)."""
+        capture = MessageCapture(capture_dir=tmp_path / "cap")
+        msg = _message(msg_id=100, content="hi", ts="2026-06-26T10:00:00")
+        await capture.on_message(msg)
+        await capture.on_message(msg)
+        records = _read_jsonl(tmp_path / "cap" / "general" / "2026-06-26.jsonl")
+        assert len(records) == 1
+
+    async def test_display_name_preferred(self, tmp_path: Path) -> None:
+        """A member's display name wins over the bare account name."""
+        capture = MessageCapture(capture_dir=tmp_path / "cap")
+        msg = _FakeMessage(
+            id=1,
+            content="x is a thoughtful note worth keeping",
+            created_at=datetime.fromisoformat("2026-06-26T10:00:00").replace(
+                tzinfo=UTC
+            ),
+            author=_FakeAuthor(name="ada#1", display_name="Ada Lovelace"),
+            channel=_FakeChannel(name="general"),
+        )
+        await capture.on_message(msg)
+        record = _read_jsonl(tmp_path / "cap" / "general" / "2026-06-26.jsonl")[0]
+        assert record["author"] == {"name": "Ada Lovelace"}
+
+    async def test_channel_name_with_separator_sanitised(self, tmp_path: Path) -> None:
+        """A path separator in a channel name cannot escape the capture root."""
+        capture = MessageCapture(capture_dir=tmp_path / "cap")
+        msg = _message(msg_id=1, content="hi", ts="2026-06-26T10:00:00", channel="a/b")
+        await capture.on_message(msg)
+        assert (tmp_path / "cap" / "a_b" / "2026-06-26.jsonl").is_file()
+
+
+class TestBackfill:
+    """Backfill replays channel history and overlaps dedupe by message id."""
+
+    async def test_fills_gap_and_overlap_is_idempotent(self, tmp_path: Path) -> None:
+        """Backfill appends the earlier message; the live dup is a no-op."""
+        capture = MessageCapture(capture_dir=tmp_path / "cap")
+        # Live stream already captured id 100.
+        await capture.on_message(
+            _message(msg_id=100, content="hi", ts="2026-06-26T10:00:00")
+        )
+        channel = _FakeHistoryChannel(
+            name="general",
+            history_messages=[
+                _message(msg_id=98, content="earlier", ts="2026-06-26T09:58:00"),
+                _message(msg_id=100, content="hi", ts="2026-06-26T10:00:00"),  # dup
+            ],
+        )
+
+        await capture.backfill(channel)
+
+        records = _read_jsonl(tmp_path / "cap" / "general" / "2026-06-26.jsonl")
+        ids = sorted(str(r["id"]) for r in records)
+        assert ids == ["100", "98"]  # gap filled once; the duplicate skipped
+
+    async def test_tolerates_malformed_and_odd_lines(self, tmp_path: Path) -> None:
+        """Blank/malformed/non-dict lines and bad timestamps are skipped, not fatal."""
+        cap_dir = tmp_path / "cap"
+        channel_dir = cap_dir / "general"
+        channel_dir.mkdir(parents=True)
+        (channel_dir / "2026-06-26.jsonl").write_text(
+            "\n"  # blank line
+            "{not valid json}\n"  # malformed
+            + json.dumps({"id": "1", "timestamp": 123, "content": "x"})  # non-str ts
+            + "\n"
+            + json.dumps(
+                {"id": "2", "timestamp": "not-a-date", "content": "y"}
+            )  # bad iso
+            + "\n"
+            + json.dumps(["not", "a", "dict"])  # non-dict record
+            + "\n"
+            + json.dumps(
+                {"id": "3", "timestamp": "2026-06-26T10:00:00+00:00", "content": "z"}
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        capture = MessageCapture(capture_dir=cap_dir)
+        channel = _FakeHistoryChannel(
+            name="general",
+            history_messages=[
+                _message(msg_id=3, content="z", ts="2026-06-26T10:00:00"),  # seen
+                _message(msg_id=4, content="new note", ts="2026-06-26T11:00:00"),
+            ],
+        )
+        await capture.backfill(channel)
+
+        text = (channel_dir / "2026-06-26.jsonl").read_text(encoding="utf-8")
+        assert text.count('"id": "3"') == 1  # already captured -> not re-appended
+        assert '"id": "4"' in text  # the genuinely new message is appended
+
+    async def test_backfill_seeds_from_existing_capture(self, tmp_path: Path) -> None:
+        """A fresh instance loads already-captured ids from disk (no re-append)."""
+        cap_dir = tmp_path / "cap"
+        first = MessageCapture(capture_dir=cap_dir)
+        await first.on_message(
+            _message(msg_id=100, content="hi", ts="2026-06-26T10:00:00")
+        )
+
+        # A brand-new instance must see id 100 as already captured.
+        second = MessageCapture(capture_dir=cap_dir)
+        channel = _FakeHistoryChannel(
+            name="general",
+            history_messages=[
+                _message(msg_id=100, content="hi", ts="2026-06-26T10:00:00"),
+            ],
+        )
+        await second.backfill(channel)
+
+        records = _read_jsonl(cap_dir / "general" / "2026-06-26.jsonl")
+        assert len(records) == 1  # no duplicate from the second instance

--- a/crawdad/tests/test_capture.py
+++ b/crawdad/tests/test_capture.py
@@ -53,12 +53,14 @@ class _FakeHistoryChannel:
     name: str
     history_messages: list[_FakeMessage]
     id: int = 1
+    received_after: datetime | None = None
 
     def history(
         self, *, after: datetime | None, oldest_first: bool
     ) -> AsyncIterator[_FakeMessage]:
-        """Replay the canned history (the fake ignores *after*; ingest dedupes)."""
+        """Record the *after* cursor, then replay the canned history."""
         assert oldest_first is True
+        self.received_after = after
         messages = self.history_messages
 
         async def _gen() -> AsyncIterator[_FakeMessage]:
@@ -158,6 +160,25 @@ class TestOnMessage:
         await capture.on_message(msg)
         assert (tmp_path / "cap" / "a_b" / "2026-06-26.jsonl").is_file()
 
+    async def test_parent_traversal_channel_name_falls_back_to_id(
+        self, tmp_path: Path
+    ) -> None:
+        """A ``..`` channel name writes under the channel id, never the parent."""
+        capture = MessageCapture(capture_dir=tmp_path / "cap" / "root")
+        msg = _FakeMessage(
+            id=1,
+            content="a note worth keeping in the vault",
+            created_at=datetime.fromisoformat("2026-06-26T10:00:00").replace(
+                tzinfo=UTC
+            ),
+            author=_FakeAuthor(name="Ada"),
+            channel=_FakeChannel(name="..", id=4242),
+        )
+        await capture.on_message(msg)
+        # Written under the id folder inside the root — not the escaped parent.
+        assert (tmp_path / "cap" / "root" / "4242" / "2026-06-26.jsonl").is_file()
+        assert not (tmp_path / "cap" / "2026-06-26.jsonl").exists()
+
 
 class TestBackfill:
     """Backfill replays channel history and overlaps dedupe by message id."""
@@ -182,6 +203,36 @@ class TestBackfill:
         records = _read_jsonl(tmp_path / "cap" / "general" / "2026-06-26.jsonl")
         ids = sorted(str(r["id"]) for r in records)
         assert ids == ["100", "98"]  # gap filled once; the duplicate skipped
+
+    async def test_backfill_passes_latest_timestamp_as_after(
+        self, tmp_path: Path
+    ) -> None:
+        """Backfill bounds the history pull at the newest captured timestamp."""
+        capture = MessageCapture(capture_dir=tmp_path / "cap")
+        await capture.on_message(
+            _message(msg_id=10, content="older", ts="2026-06-26T09:00:00")
+        )
+        await capture.on_message(
+            _message(msg_id=11, content="newer", ts="2026-06-26T10:30:00")
+        )
+        channel = _FakeHistoryChannel(name="general", history_messages=[])
+
+        await capture.backfill(channel)
+
+        assert channel.received_after == datetime.fromisoformat(
+            "2026-06-26T10:30:00"
+        ).replace(tzinfo=UTC)
+
+    async def test_backfill_after_is_none_when_channel_empty(
+        self, tmp_path: Path
+    ) -> None:
+        """With nothing captured yet, backfill pulls the full history (after=None)."""
+        capture = MessageCapture(capture_dir=tmp_path / "cap")
+        channel = _FakeHistoryChannel(name="general", history_messages=[])
+
+        await capture.backfill(channel)
+
+        assert channel.received_after is None
 
     async def test_tolerates_malformed_and_odd_lines(self, tmp_path: Path) -> None:
         """Blank/malformed/non-dict lines and bad timestamps are skipped, not fatal."""

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -1466,12 +1466,30 @@ class DiscordSourceConfig(BaseModel):
     bot_capture: DiscordModeToggle = Field(default_factory=DiscordModeToggle)
     """Bot message capture for servers/channels — off by default."""
 
+    capture_subpath: str = "discord-capture"
+    """Vault-relative dir the bot-capture path writes and Tier-A ingest reads (#687).
+
+    The bot appends ``<capture_subpath>/<channel>/<date>.jsonl`` (relative to the
+    vault root) in the lowercase Discord message schema the ``DiscordIngestor``
+    already reads; ``creek sync`` reshapes it into the Data-Package layout. Must
+    be vault-relative — never absolute, never parent-traversing."""
+
     @field_validator("exporter_binary")
     @classmethod
     def _validate_exporter_binary(cls, value: str | None) -> str | None:
         """Require an absolute path so the binary resolves predictably (#686)."""
         if value is not None and not Path(value).is_absolute():
             msg = f"exporter_binary must be an absolute path, got {value!r}."
+            raise ValueError(msg)
+        return value
+
+    @field_validator("capture_subpath")
+    @classmethod
+    def _validate_capture_subpath(cls, value: str) -> str:
+        """Refuse absolute or parent-traversing capture paths — stay in vault (#687)."""
+        path = Path(value)
+        if path.is_absolute() or ".." in path.parts:
+            msg = f"capture_subpath must be vault-relative, got {value!r}."
             raise ValueError(msg)
         return value
 

--- a/creek-tools/creek/ingest/discord.py
+++ b/creek-tools/creek/ingest/discord.py
@@ -28,8 +28,10 @@ import logging
 import re
 import shutil
 from datetime import datetime, timedelta
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 from creek.clean.filters.discord import DiscordFilter, DiscordFilterConfig
 from creek.ingest.base import (

--- a/creek-tools/creek/ingest/discord.py
+++ b/creek-tools/creek/ingest/discord.py
@@ -804,9 +804,7 @@ def stage_capture_as_data_package(capture_dir: Path, staging_dir: Path) -> None:
         channel = channel_dir.name
         out_dir = staging_dir / "messages" / channel
         out_dir.mkdir(parents=True, exist_ok=True)
-        (out_dir / "messages.json").write_text(
-            json.dumps(messages), encoding="utf-8"
-        )
+        (out_dir / "messages.json").write_text(json.dumps(messages), encoding="utf-8")
         (out_dir / "channel.json").write_text(
             json.dumps({"id": channel, "name": channel}), encoding="utf-8"
         )
@@ -831,7 +829,10 @@ def ingest_capture_dir(capture_dir: Path, vault: Path) -> int:
     from creek.vault.writer import VaultWriter
 
     # Stable, deterministic staging path (not a random tempdir) so the
-    # source-path-derived fragment id stays constant across runs.
+    # source-path-derived fragment id stays constant across runs. A kill between
+    # the rmtree and ingest leaves an empty/partial staging dir and writes zero
+    # fragments — self-healing: the next run re-stages from the intact capture
+    # dir, so a one-off "0 fragments" in the logs is not data loss.
     staging = vault / "00-Creek-Meta" / "State" / "discord" / "capture-staging"
     if staging.exists():
         shutil.rmtree(staging)

--- a/creek-tools/creek/ingest/discord.py
+++ b/creek-tools/creek/ingest/discord.py
@@ -26,11 +26,10 @@ from __future__ import annotations
 import json
 import logging
 import re
+import shutil
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from pathlib import Path
+from typing import Any
 
 from creek.clean.filters.discord import DiscordFilter, DiscordFilterConfig
 from creek.ingest.base import (
@@ -734,3 +733,113 @@ class DiscordIngestor(Ingestor):
         if authored_at is not None:
             frontmatter_dict["authored_at"] = authored_at.isoformat()
         return frontmatter_dict
+
+
+# ---- Bot-capture consumption (#687) ----
+#
+# The CrawDad bot-capture path logs each message to
+# ``<capture_dir>/<channel>/<date>.jsonl`` — one JSON object per line in the
+# lowercase message schema this ingestor already reads (``id`` / ``timestamp`` /
+# ``content`` / ``author`` / optional ``reference``). To consume it without a
+# parser rewrite, the helpers below reshape the capture dir into the
+# Data-Package layout (``messages/<channel>/messages.json`` + ``channel.json``)
+# that :meth:`DiscordIngestor.discover` expects.
+
+
+def _capture_sort_key(message: dict[str, Any]) -> str:
+    """Chronological sort key — the ISO-8601 ``timestamp`` (UTC, so lexical)."""
+    return str(message.get("timestamp", ""))
+
+
+def _read_capture_messages(channel_dir: Path) -> list[dict[str, Any]]:
+    """Read every JSONL line under one capture channel dir, deduped and sorted.
+
+    Discord message ids are stable, so a line repeated across the live stream
+    and a backfill collapses to one message (keyed by id). Returns the messages
+    sorted chronologically by ``timestamp`` so reply/time grouping stays correct.
+
+    Args:
+        channel_dir: A ``<capture_dir>/<channel>/`` directory of ``*.jsonl``.
+
+    Returns:
+        The deduped, chronologically sorted message dicts.
+    """
+    by_id: dict[str, dict[str, Any]] = {}
+    for jsonl in sorted(channel_dir.glob("*.jsonl")):
+        for line in jsonl.read_text(encoding="utf-8").splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                obj = json.loads(stripped)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed capture line in %s", jsonl)
+                continue
+            if isinstance(obj, dict) and obj.get("id"):
+                by_id[str(obj["id"])] = obj
+    return sorted(by_id.values(), key=_capture_sort_key)
+
+
+def stage_capture_as_data_package(capture_dir: Path, staging_dir: Path) -> None:
+    """Reshape a ``discord-capture/`` dir into the Data-Package layout (#687).
+
+    Writes ``staging_dir/messages/<channel>/messages.json`` (deduped by stable
+    message id, chronologically sorted) plus a ``channel.json`` so the existing
+    :class:`DiscordIngestor` reads the captured messages with no parser rewrite.
+
+    Args:
+        capture_dir: The ``<vault>/discord-capture`` root the bot appends to.
+        staging_dir: A scratch dir to materialise the Data-Package layout into.
+    """
+    if not capture_dir.is_dir():
+        return
+    for channel_dir in sorted(capture_dir.iterdir()):
+        if not channel_dir.is_dir():
+            continue
+        messages = _read_capture_messages(channel_dir)
+        if not messages:
+            continue
+        channel = channel_dir.name
+        out_dir = staging_dir / "messages" / channel
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "messages.json").write_text(
+            json.dumps(messages), encoding="utf-8"
+        )
+        (out_dir / "channel.json").write_text(
+            json.dumps({"id": channel, "name": channel}), encoding="utf-8"
+        )
+
+
+def ingest_capture_dir(capture_dir: Path, vault: Path) -> int:
+    """Stage + ingest a bot-capture dir into *vault*; return fragments written.
+
+    Idempotent: the messages stage into a **stable** vault-relative path, so the
+    ``frag-<sha>`` id (which hashes the staged source path) is identical across
+    runs. Combined with stable Discord message ids, re-running over an
+    overlapping capture writes no duplicate fragments.
+
+    Args:
+        capture_dir: The ``<vault>/discord-capture`` root the bot appends to.
+        vault: The Creek vault to write fragments into.
+
+    Returns:
+        The number of fragments written this run.
+    """
+    from creek.ingest.base import assemble_ingested_fragment
+    from creek.vault.writer import VaultWriter
+
+    # Stable, deterministic staging path (not a random tempdir) so the
+    # source-path-derived fragment id stays constant across runs.
+    staging = vault / "00-Creek-Meta" / "State" / "discord" / "capture-staging"
+    if staging.exists():
+        shutil.rmtree(staging)
+    staging.mkdir(parents=True, exist_ok=True)
+    stage_capture_as_data_package(capture_dir, staging)
+    result = DiscordIngestor().ingest(staging)
+    writer = VaultWriter(vault_path=vault)
+    count = 0
+    for parsed in result.fragments:
+        assembled = assemble_ingested_fragment(parsed)
+        writer.write_fragment(assembled.fragment, body=assembled.body)
+        count += 1
+    return count

--- a/creek-tools/tests/test_ingest_bot_capture.py
+++ b/creek-tools/tests/test_ingest_bot_capture.py
@@ -42,7 +42,9 @@ def _capture_line(*, msg_id: str, ts: str, content: str) -> str:
     )
 
 
-def _write_capture(capture_dir: Path, channel: str, date: str, lines: list[str]) -> None:
+def _write_capture(
+    capture_dir: Path, channel: str, date: str, lines: list[str]
+) -> None:
     """Append capture *lines* to ``<capture_dir>/<channel>/<date>.jsonl``."""
     path = capture_dir / channel / f"{date}.jsonl"
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -93,7 +95,9 @@ class TestStageCaptureAsDataPackage:
             "general",
             "2026-06-26",
             [
-                _capture_line(msg_id="100", ts="2026-06-26T10:00:00+00:00", content="hi"),
+                _capture_line(
+                    msg_id="100", ts="2026-06-26T10:00:00+00:00", content="hi"
+                ),
                 _capture_line(
                     msg_id="098", ts="2026-06-26T09:58:00+00:00", content="earlier"
                 ),

--- a/creek-tools/tests/test_ingest_bot_capture.py
+++ b/creek-tools/tests/test_ingest_bot_capture.py
@@ -1,0 +1,185 @@
+"""Tier-A consumption of the bot-capture dir (#687).
+
+The CrawDad bot appends ``discord-capture/<channel>/<date>.jsonl`` in the
+lowercase Discord message schema. These tests prove the creek side reshapes that
+dir into the Data-Package layout and ingests it via the existing
+``DiscordIngestor`` — with no parser rewrite — and that a backfill that overlaps
+the live stream is idempotent at ingest (stable message ids).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from creek.config import DiscordSourceConfig
+from creek.ingest.discord import (
+    ingest_capture_dir,
+    stage_capture_as_data_package,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Scaffold the minimal vault folders the writer needs."""
+    vault = tmp_path / "vault"
+    for d in ("00-Creek-Meta/Processing-Log", "01-Fragments/Messages"):
+        (vault / d).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _capture_line(*, msg_id: str, ts: str, content: str) -> str:
+    """One JSONL line in the schema CrawDad's MessageCapture writes."""
+    return json.dumps(
+        {
+            "id": msg_id,
+            "timestamp": ts,
+            "content": content,
+            "author": {"name": "Ada"},
+        }
+    )
+
+
+def _write_capture(capture_dir: Path, channel: str, date: str, lines: list[str]) -> None:
+    """Append capture *lines* to ``<capture_dir>/<channel>/<date>.jsonl``."""
+    path = capture_dir / channel / f"{date}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _fragments(vault: Path) -> list[Path]:
+    """Every fragment markdown file under 01-Fragments."""
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+class TestCaptureSubpathConfig:
+    """The capture dir is a vault-relative, traversal-safe config field."""
+
+    def test_default_is_discord_capture(self) -> None:
+        """The bot-capture dir defaults to ``discord-capture``."""
+        assert DiscordSourceConfig().capture_subpath == "discord-capture"
+
+    def test_absolute_path_rejected(self) -> None:
+        """An absolute capture path is refused (must stay in the vault)."""
+        try:
+            DiscordSourceConfig(capture_subpath="/etc/discord")
+        except ValueError as exc:
+            assert "vault-relative" in str(exc)
+        else:  # pragma: no cover - the assertion above is the contract
+            msg = "expected ValueError for absolute capture_subpath"
+            raise AssertionError(msg)
+
+    def test_parent_traversal_rejected(self) -> None:
+        """A ``..``-traversing capture path is refused."""
+        try:
+            DiscordSourceConfig(capture_subpath="../escape")
+        except ValueError as exc:
+            assert "vault-relative" in str(exc)
+        else:  # pragma: no cover - the assertion above is the contract
+            msg = "expected ValueError for parent-traversing capture_subpath"
+            raise AssertionError(msg)
+
+
+class TestStageCaptureAsDataPackage:
+    """Reshaping the capture dir produces the Data-Package layout the parser reads."""
+
+    def test_reshapes_deduped_and_sorted(self, tmp_path: Path) -> None:
+        """Lines across files dedupe by id and sort chronologically."""
+        capture = tmp_path / "discord-capture"
+        _write_capture(
+            capture,
+            "general",
+            "2026-06-26",
+            [
+                _capture_line(msg_id="100", ts="2026-06-26T10:00:00+00:00", content="hi"),
+                _capture_line(
+                    msg_id="098", ts="2026-06-26T09:58:00+00:00", content="earlier"
+                ),
+                _capture_line(  # duplicate id (live stream + backfill overlap)
+                    msg_id="100", ts="2026-06-26T10:00:00+00:00", content="hi"
+                ),
+            ],
+        )
+        staging = tmp_path / "staging"
+        stage_capture_as_data_package(capture, staging)
+
+        messages_file = staging / "messages" / "general" / "messages.json"
+        messages = json.loads(messages_file.read_text(encoding="utf-8"))
+        assert [m["id"] for m in messages] == ["098", "100"]  # deduped + sorted
+        channel = json.loads(
+            (staging / "messages" / "general" / "channel.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert channel["name"] == "general"
+
+    def test_missing_capture_dir_is_noop(self, tmp_path: Path) -> None:
+        """A non-existent capture dir reshapes to nothing (no crash)."""
+        staging = tmp_path / "staging"
+        stage_capture_as_data_package(tmp_path / "absent", staging)
+        assert not (staging / "messages").exists()
+
+
+class TestIngestCaptureDir:
+    """End-to-end: a capture dir becomes vault fragments, idempotently."""
+
+    def test_ingests_messages(self, tmp_path: Path) -> None:
+        """A captured message lands as a fragment in the vault."""
+        vault = _make_vault(tmp_path)
+        capture = tmp_path / "discord-capture"
+        _write_capture(
+            capture,
+            "general",
+            "2026-06-26",
+            [
+                _capture_line(
+                    msg_id="100",
+                    ts="2026-06-26T10:00:00+00:00",
+                    content="a private reflection worth keeping in the vault",
+                )
+            ],
+        )
+
+        written = ingest_capture_dir(capture, vault)
+
+        assert written > 0
+        assert len(_fragments(vault)) == written
+
+    def test_overlapping_rerun_is_idempotent(self, tmp_path: Path) -> None:
+        """A second ingest over an overlapping capture writes no duplicate."""
+        vault = _make_vault(tmp_path)
+        capture = tmp_path / "discord-capture"
+        _write_capture(
+            capture,
+            "general",
+            "2026-06-26",
+            [
+                _capture_line(
+                    msg_id="100",
+                    ts="2026-06-26T10:00:00+00:00",
+                    content="a private reflection worth keeping in the vault",
+                )
+            ],
+        )
+        ingest_capture_dir(capture, vault)
+        before = len(_fragments(vault))
+        assert before > 0
+
+        # Backfill re-captures the same id into a later file; ingest again.
+        _write_capture(
+            capture,
+            "general",
+            "2026-06-27",
+            [
+                _capture_line(
+                    msg_id="100",
+                    ts="2026-06-26T10:00:00+00:00",
+                    content="a private reflection worth keeping in the vault",
+                )
+            ],
+        )
+        ingest_capture_dir(capture, vault)
+
+        assert len(_fragments(vault)) == before  # stable id -> no duplicate


### PR DESCRIPTION
## Summary

Adds the clean, ToS-safe **bot-capture** ingest path (Epic D): CrawDad logs each message in the servers/channels it is in, and creek's Tier-A ingest consumes it via the existing `DiscordIngestor` **with no parser rewrite**.

A bot **cannot read DMs** (a hard Discord API limit), so this path covers only channels the bot is in — DMs remain the opt-in user-token exporter's job (#686). The bot token stays in the **environment only**; capture adds no new secret surface.

### Crawdad side
- **`MessageCapture`** (`crawdad/capture.py`) appends each message to `discord-capture/<channel>/<date>.jsonl` in the lowercase Discord message schema the creek ingestor already reads. Idempotent on stable message id; a `channel.history()` **backfill** fills the gap since the last capture and is overlap-safe.
- `CrawDadConfig` gains `capture_enabled` (**off by default**) + a vault-relative, traversal-safe `capture_subpath`. The CLI builds the writer only when enabled.
- `on_message` captures **best-effort** — skips the bot's own messages, swallows a write error — *before* forwarding to `handle_message`, so the command/slash-command path is never disturbed.

### Creek side
- `DiscordSourceConfig.capture_subpath` (vault-relative, validated).
- `stage_capture_as_data_package` + `ingest_capture_dir` reshape the capture dir into the Data-Package layout the `DiscordIngestor` reads, deduping by stable id into a **stable staging path** so re-ingest writes no duplicate fragments.

The cross-subproject contract is the JSON line schema (crawdad writes it, creek reads it); tests on both sides pin it. **Crawdad does not import creek** — the dependency boundary is preserved.

## Test plan
- `crawdad/tests/test_capture.py` — fake message stream: append in lowercase schema, reply reference, duplicate-id skip, display-name preference, channel-name sanitisation, backfill gap-fill + overlap idempotency, seed-from-disk, malformed-line tolerance.
- `crawdad/tests/test_bot_capture.py` — `on_message` captures **and** forwards to the command path; skips the bot's own messages; inert when disabled; a capture `OSError` is swallowed so commands still run; pre-ready drop; CLI `_build_message_capture` gate.
- `creek-tools/tests/test_ingest_bot_capture.py` — config validation; reshape dedupes + sorts; end-to-end ingest; overlapping re-run is idempotent (stable fragment ids).
- Both subprojects' `./scripts/check-all.sh` pass locally (creek + crawdad gates, incl. coverage ≥90%, mypy strict, complexity, bandit).

## Notes
- Scope-fenced per the issue: no DM exporter (#686), no Data Package helper/docs (#688), no `DiscordIngestor` parser rewrite, no scheduling (Epic B's `creek sync` drives Tier-A ingest of the capture dir). The three-mode comparison doc is #688.
- Live `channel.history()` auto-backfill wiring into `on_ready` is intentionally left to the operator/`creek sync` trigger — `backfill` is exposed and tested as public API.

Refs #671
Closes #687

🤖 Generated with [Claude Code](https://claude.com/claude-code)