### PR TITLE
feat(classify): per-tier classification routing — Intimate stays local (#666)

### DIFF
--- a/.claude/skills/model-setup/SKILL.md
+++ b/.claude/skills/model-setup/SKILL.md
@@ -151,17 +151,31 @@ loudly with `IntimateRoutingError` rather than egressing. **Explain this; never
 ask the user to enforce it.** Keep `default` local (`ollama`) so the redirect
 always has somewhere safe to land.
 
-## Known gap — per-tier classification routing (do NOT promise it)
+## Per-tier classification routing (shipped, #666)
 
-Assignment #1 wants "Haiku for non-Intimate, local for Intimate" in one classify
-run. **This is not yet wired.** Every classification call site resolves the stage
-with **no tier** (`resolve("classification")`, tier `None`), so the chokepoint
-never fires per fragment during classification. Configure `classification` to a
-single safe local model (`qwen3:8b`) and **say so honestly** — the per-fragment
-tier threading is the same work the author-desk issues **#660** (tier-filter
-retrieval) and **#661** (route the voice call by content tier) did for voicing;
-classification needs the analogous wiring before a tier split is possible. Do
-**not** write a config that pretends to split classification by tier.
+Assignment #1 — "Haiku for non-Intimate, local for Intimate" in one classify
+run — **is wired** as of #666. `creek classify --method llm` routes each fragment
+by its `privacy_tier` through the same `ModelRouter` chokepoint: an `Intimate`
+fragment is classified by the local `default` even when `classification` is a
+cloud model, while non-`Intimate` fragments use the configured `classification`
+model. So this config does exactly what it says:
+
+```yaml
+llm:
+  default:        { provider: ollama,    model: qwen3:8b }       # Intimate-safe
+  classification: { provider: anthropic, model: claude-haiku-4-5 }
+```
+
+If `classification` is cloud **and** `default` is also cloud, an `Intimate`
+fragment fails loudly with `IntimateRoutingError` — deferred until an Intimate
+fragment is actually reached, so an all-cloud run with no Intimate content still
+classifies. This mirrors the author-desk precedent (**#660** tier-filter
+retrieval, **#661** route the voice call by content tier).
+
+**Still tier-less (follow-up #706):** the `creek process` pipeline classify loop
+and the `draft` / `calibrate` classifier builds resolve `classification` with no
+tier. So the per-tier guarantee is complete for `creek classify` but not yet for
+`creek process` — don't promise per-tier classification on the pipeline path.
 
 ## "Five assignments, four listed"
 

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -47,6 +47,8 @@ from creek.classify.constants import (
     RULES_METHOD,
 )
 from creek.classify.llm import LLMClassifier
+from creek.classify.llm.router import IntimateRoutingError
+from creek.classify.privacy_filter import _tier_of
 from creek.classify.reatomize import (
     ClassificationTree,
     Classifier,
@@ -178,6 +180,95 @@ class _RunCounts:
     errors: list[str] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class _TierClassifiers:
+    """Per-tier LLM classifiers for one classify run (#666).
+
+    ``non_intimate`` serves OPEN / PERSONAL / UNCLASSIFIED fragments with the
+    configured ``classification`` provider; ``intimate`` serves INTIMATE
+    fragments, redirected off any cloud provider to a local one by the
+    :class:`~creek.classify.llm.router.ModelRouter` chokepoint (Intimate-never-
+    cloud, #647). The two are the **same instance** when the configured
+    ``classification`` provider is already local — the backward-compatible case.
+
+    When ``classification`` is cloud and no local ``default`` exists, the Intimate
+    route cannot be honoured: ``intimate`` is ``None`` and ``routing_error`` holds
+    the :class:`IntimateRoutingError`, **deferred** so it fires only if an actual
+    Intimate fragment is reached — a run with no Intimate content stays valid.
+    """
+
+    non_intimate: LLMClassifier
+    intimate: LLMClassifier | None
+    routing_error: IntimateRoutingError | None
+
+    def for_tier(self, tier: PrivacyTier) -> LLMClassifier:
+        """Return the classifier for *tier* — the local one for INTIMATE.
+
+        Raises:
+            IntimateRoutingError: For an INTIMATE fragment when the config has no
+                local backend to route it to (the deferred build-time error).
+        """
+        if tier is not PrivacyTier.INTIMATE:
+            return self.non_intimate
+        if self.intimate is None:
+            raise self._deferred_routing_error()
+        return self.intimate
+
+    def distinct(self) -> tuple[LLMClassifier, ...]:
+        """The unique classifiers to availability-check before iterating.
+
+        Excludes the Intimate classifier when it shares the configured instance
+        or is deferred (``None``) — the non-Intimate fail-fast is unchanged from
+        the pre-#666 single-provider check.
+        """
+        if self.intimate is None or self.intimate is self.non_intimate:
+            return (self.non_intimate,)
+        return (self.non_intimate, self.intimate)
+
+    def _deferred_routing_error(self) -> IntimateRoutingError:
+        """Return the captured deferred routing error (invariant: set here)."""
+        if self.routing_error is None:  # pragma: no cover - defensive invariant
+            msg = "Intimate route unavailable but no routing error was captured."
+            raise RuntimeError(msg)
+        return self.routing_error
+
+
+def _build_tier_classifiers(config: CreekConfig) -> _TierClassifiers:
+    """Build the per-tier classifiers via the ModelRouter chokepoint (#666).
+
+    Resolves ``classification`` tier-less for non-Intimate fragments and with
+    ``PrivacyTier.INTIMATE`` for Intimate ones, so the Intimate route is
+    redirected to a local provider. When both resolve to the same config (a local
+    ``classification`` stage), a single classifier instance is shared — identical
+    to the pre-#666 behaviour. When no local backend exists, the resulting
+    :class:`IntimateRoutingError` is captured and **deferred** (see
+    :class:`_TierClassifiers`) rather than failing a run that has no Intimate
+    content.
+
+    Args:
+        config: The loaded Creek configuration (carrying the model router).
+
+    Returns:
+        The :class:`_TierClassifiers` for this run.
+    """
+    router = config.model_router
+    non_intimate = LLMClassifier(config=router.resolve("classification"))
+    try:
+        intimate_cfg = router.resolve("classification", PrivacyTier.INTIMATE)
+    except IntimateRoutingError as exc:
+        return _TierClassifiers(
+            non_intimate=non_intimate, intimate=None, routing_error=exc
+        )
+    intimate = (
+        non_intimate
+        if intimate_cfg == non_intimate.config
+        else LLMClassifier(config=intimate_cfg)
+    )
+    return _TierClassifiers(
+        non_intimate=non_intimate, intimate=intimate, routing_error=None
+    )
+
+
 def run_classify(
     *,
     vault_path: Path,
@@ -210,22 +301,25 @@ def run_classify(
 
     rules = RuleClassifier()
     audience = AudienceClassifier()
-    # Per-stage routing (#646): the classifier uses the classification stage's
-    # resolved provider+model, not the global block.
-    classify_llm = config.model_router.resolve("classification")
-    llm = LLMClassifier(config=classify_llm) if method == "llm" else None
-    if llm is not None and not llm.available:
-        # Refuse to iterate when the provider is unreachable so the
-        # vault is never stamped with ``classification_method: llm``
-        # for fragments the LLM never actually saw. The orchestrator
-        # already logged the provider-specific reason (missing API
-        # key, missing consent env var, Ollama down) as a WARNING;
-        # we capture it here for the operator-facing message so the
-        # remediation hint is not buried in stderr.
-        raise LLMProviderUnavailableError(
-            provider=classify_llm.provider,
-            detail=_describe_llm_unavailability(classify_llm.provider),
-        )
+    # Per-stage + per-tier routing (#646/#666): non-Intimate fragments use the
+    # configured ``classification`` provider; Intimate fragments are redirected
+    # to a local provider by the ModelRouter chokepoint (Intimate-never-cloud,
+    # #647). Resolving here also fails the run loudly (IntimateRoutingError) when
+    # classification is cloud and no local default exists to route Intimate to.
+    tier_classifiers = _build_tier_classifiers(config) if method == LLM_METHOD else None
+    if tier_classifiers is not None:
+        for classifier in tier_classifiers.distinct():
+            if not classifier.available:
+                # Refuse to iterate when a provider is unreachable so the vault
+                # is never stamped with ``classification_method: llm`` for
+                # fragments the LLM never actually saw. The orchestrator already
+                # logged the provider-specific reason (missing API key, missing
+                # consent env var, Ollama down) as a WARNING; we capture it here
+                # so the remediation hint is not buried in stderr.
+                raise LLMProviderUnavailableError(
+                    provider=classifier.config.provider,
+                    detail=_describe_llm_unavailability(classifier.config.provider),
+                )
     counts = _RunCounts()
     progress_path: Path | None = None
     trace_log_path: Path | None = None
@@ -254,7 +348,7 @@ def run_classify(
             force=force,
             rules=rules,
             audience=audience,
-            llm=llm,
+            tier_classifiers=tier_classifiers,
             classification_config=config.classification,
             counts=counts,
             progress_path=progress_path,
@@ -314,7 +408,7 @@ def _process_file(
     force: bool,
     rules: RuleClassifier,
     audience: AudienceClassifier,
-    llm: LLMClassifier | None,
+    tier_classifiers: _TierClassifiers | None,
     classification_config: ClassificationConfig,
     counts: _RunCounts,
     progress_path: Path | None,
@@ -331,7 +425,9 @@ def _process_file(
         audience: Shared :class:`AudienceClassifier`; stamps the #634
             audience axis on every (re)classified fragment, deterministically,
             regardless of method.
-        llm: Shared :class:`LLMClassifier` (when ``method == "llm"``).
+        tier_classifiers: Per-tier :class:`LLMClassifier` set (when
+            ``method == "llm"``); the fragment's tier selects the provider so
+            Intimate content is classified locally (#666). ``None`` for rules.
         classification_config: Full FEAT-023-aware classification config.
             Drives both the LLM-vs-rules threshold and the
             ``reatomize`` opt-in.
@@ -356,6 +452,15 @@ def _process_file(
     if record is None:
         return
     fragment, body, raw = record
+
+    # Per-tier routing (#666): pick the classifier for this fragment's privacy
+    # tier. ``_tier_of`` fails closed to INTIMATE for an unrecognised tier, so an
+    # unknown fragment is classified locally rather than risking cloud egress.
+    llm = (
+        tier_classifiers.for_tier(_tier_of(fragment))
+        if tier_classifiers is not None
+        else None
+    )
 
     # Skip fragments whose previous run already settled the classification.
     # Tracked on distinct counters so the CLI summary can label "manual

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -48,7 +48,7 @@ from creek.classify.constants import (
 )
 from creek.classify.llm import LLMClassifier
 from creek.classify.llm.router import IntimateRoutingError
-from creek.classify.privacy_filter import _tier_of
+from creek.classify.privacy_filter import tier_of
 from creek.classify.reatomize import (
     ClassificationTree,
     Classifier,
@@ -454,10 +454,10 @@ def _process_file(
     fragment, body, raw = record
 
     # Per-tier routing (#666): pick the classifier for this fragment's privacy
-    # tier. ``_tier_of`` fails closed to INTIMATE for an unrecognised tier, so an
+    # tier. ``tier_of`` fails closed to INTIMATE for an unrecognised tier, so an
     # unknown fragment is classified locally rather than risking cloud egress.
     llm = (
-        tier_classifiers.for_tier(_tier_of(fragment))
+        tier_classifiers.for_tier(tier_of(fragment))
         if tier_classifiers is not None
         else None
     )

--- a/creek-tools/creek/classify/privacy_filter.py
+++ b/creek-tools/creek/classify/privacy_filter.py
@@ -6,6 +6,11 @@ contribute summaries (not full bodies). This module owns the *one*
 implementation of that promise so ``mine``, ``draft``, ``report``, and
 ``skills`` cannot drift out of agreement with each other.
 
+:func:`tier_of` is the shared, fail-closed tier-extraction primitive (it maps an
+unrecognised ``privacy_tier`` to ``INTIMATE``). It is also used outside
+generation — per-tier classification routing (#666) calls it to decide whether a
+fragment must be classified locally — so keep it public and behaviour-stable.
+
 The filter accepts an optional :class:`PrivacyTierOverride` representing
 the operator-supplied ``--include-tier`` flag. When the override raises
 the included tier above the default, the caller is responsible for
@@ -170,7 +175,7 @@ def filter_fragments_by_tier(
             ``--include-tier``.
     """
     for fragment, body in fragments:
-        tier = _tier_of(fragment)
+        tier = tier_of(fragment)
         if tier == PrivacyTier.INTIMATE and not _allows_intimate(override):
             continue
         if tier == PrivacyTier.PERSONAL and not _allows_full_personal_body(override):
@@ -179,7 +184,7 @@ def filter_fragments_by_tier(
         yield fragment, body
 
 
-def _tier_of(fragment: Fragment) -> PrivacyTier:
+def tier_of(fragment: Fragment) -> PrivacyTier:
     """Return the fragment's privacy tier as a :class:`PrivacyTier`.
 
     Pydantic's :class:`~creek.models.Fragment` validator constrains

--- a/creek-tools/tests/test_classify_tier_routing.py
+++ b/creek-tools/tests/test_classify_tier_routing.py
@@ -106,10 +106,13 @@ class TestPerTierRouting:
     """Intimate goes local; non-Intimate uses the configured cloud model."""
 
     def test_intimate_local_nonintimate_cloud(self, tmp_path: Path) -> None:
-        """One run: Intimate classified by ollama, Open by anthropic."""
+        """One run: only Intimate goes local; Open + Unclassified use the cloud."""
         vault = tmp_path / "vault"
         _write(vault, "frag-intimateaaa", PrivacyTier.INTIMATE)
         _write(vault, "frag-openbbbbbbb", PrivacyTier.OPEN)
+        # UNCLASSIFIED is not INTIMATE, so it routes with the non-Intimate cloud
+        # provider (same path as OPEN) — pin that contract explicitly.
+        _write(vault, "frag-unclassifd", PrivacyTier.UNCLASSIFIED)
 
         run_classify(
             vault_path=vault,
@@ -120,6 +123,7 @@ class TestPerTierRouting:
 
         assert _provider_for("frag-intimateaaa") == "ollama"  # redirected local
         assert _provider_for("frag-openbbbbbbb") == "anthropic"  # configured cloud
+        assert _provider_for("frag-unclassifd") == "anthropic"  # not Intimate → cloud
 
     def test_local_classification_is_backward_compatible(self, tmp_path: Path) -> None:
         """A local classification stage classifies every tier with that provider."""

--- a/creek-tools/tests/test_classify_tier_routing.py
+++ b/creek-tools/tests/test_classify_tier_routing.py
@@ -1,0 +1,171 @@
+"""Per-tier classification routing (#666).
+
+`creek classify --method llm` must route each fragment's classification by its
+privacy tier: an Intimate fragment is classified by a LOCAL provider (via the
+ModelRouter Intimate-never-cloud chokepoint, #647) even when the classification
+stage is a cloud model, while non-Intimate fragments use the configured model.
+
+These tests assert on which provider classified which fragment (not just a
+returned string), so a regression that lets Intimate content reach a cloud
+provider fails the guard. The LLM is faked — no network, no real provider.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.classify.classify_engine import run_classify
+from creek.classify.llm import LLMClassificationResult
+from creek.classify.llm.router import IntimateRoutingError
+from creek.config import CreekConfig, LLMConfig, LLMRoutingConfig
+from creek.models import Fragment, FragmentSource, PrivacyTier, SourcePlatform
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_BODY = "a reflection worth keeping with enough words to classify cleanly"
+
+
+@dataclass
+class _Call:
+    provider: str
+    fragment_id: str
+
+
+class _FakeClassifier:
+    """Records which provider classified which fragment; no real LLM call."""
+
+    def __init__(self, config: LLMConfig) -> None:
+        """Capture the resolved config (its ``provider`` is what we assert on)."""
+        self.config = config
+
+    @property
+    def available(self) -> bool:
+        """Always reachable — the availability gate is not under test here."""
+        return True
+
+    def classify_with_reasoning(
+        self, fragment: Fragment, content: str
+    ) -> LLMClassificationResult:
+        """Record ``(provider, fragment id)`` and echo the fragment back."""
+        _ = content
+        _CALLS.append(_Call(provider=self.config.provider, fragment_id=fragment.id))
+        return LLMClassificationResult(fragment=fragment, reasoning="")
+
+
+_CALLS: list[_Call] = []
+
+
+@pytest.fixture(autouse=True)
+def _fake_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Swap the engine's LLMClassifier for the recording fake; reset the log."""
+    _CALLS.clear()
+    monkeypatch.setattr("creek.classify.classify_engine.LLMClassifier", _FakeClassifier)
+
+
+def _config(*, classification: dict[str, str], default: dict[str, str]) -> CreekConfig:
+    """A CreekConfig whose router resolves the given classification + default."""
+    return CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(**default),
+            classification=LLMConfig(**classification),
+        )
+    )
+
+
+def _write(vault: Path, frag_id: str, tier: PrivacyTier) -> None:
+    """Write a classifiable fragment at *tier* under the vault."""
+    write_fragment_file(
+        vault=vault,
+        fragment=Fragment(
+            id=frag_id,
+            title=frag_id,
+            source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+            privacy_tier=tier,
+        ),
+        body=_BODY,
+    )
+
+
+def _provider_for(fragment_id: str) -> str:
+    """The provider that classified *fragment_id* (asserts exactly one call)."""
+    hits = [c.provider for c in _CALLS if c.fragment_id == fragment_id]
+    assert len(hits) == 1, f"expected one classify call for {fragment_id}, got {hits}"
+    return hits[0]
+
+
+_CLOUD = {"provider": "anthropic", "model": "claude-haiku-4-5"}
+_LOCAL = {"provider": "ollama", "model": "qwen3:8b"}
+
+
+class TestPerTierRouting:
+    """Intimate goes local; non-Intimate uses the configured cloud model."""
+
+    def test_intimate_local_nonintimate_cloud(self, tmp_path: Path) -> None:
+        """One run: Intimate classified by ollama, Open by anthropic."""
+        vault = tmp_path / "vault"
+        _write(vault, "frag-intimateaaa", PrivacyTier.INTIMATE)
+        _write(vault, "frag-openbbbbbbb", PrivacyTier.OPEN)
+
+        run_classify(
+            vault_path=vault,
+            config=_config(classification=_CLOUD, default=_LOCAL),
+            method="llm",
+            force=True,
+        )
+
+        assert _provider_for("frag-intimateaaa") == "ollama"  # redirected local
+        assert _provider_for("frag-openbbbbbbb") == "anthropic"  # configured cloud
+
+    def test_local_classification_is_backward_compatible(self, tmp_path: Path) -> None:
+        """A local classification stage classifies every tier with that provider."""
+        vault = tmp_path / "vault"
+        _write(vault, "frag-intimateccc", PrivacyTier.INTIMATE)
+        _write(vault, "frag-personalddd", PrivacyTier.PERSONAL)
+
+        run_classify(
+            vault_path=vault,
+            config=_config(classification=_LOCAL, default=_LOCAL),
+            method="llm",
+            force=True,
+        )
+
+        assert _provider_for("frag-intimateccc") == "ollama"
+        assert _provider_for("frag-personalddd") == "ollama"
+
+
+class TestNoLocalBackend:
+    """All-cloud config: the Intimate failure is deferred to actual Intimate work."""
+
+    def test_intimate_fragment_raises_when_no_local_backend(
+        self, tmp_path: Path
+    ) -> None:
+        """An Intimate fragment with cloud classification + cloud default raises."""
+        vault = tmp_path / "vault"
+        _write(vault, "frag-intimateeee", PrivacyTier.INTIMATE)
+
+        with pytest.raises(IntimateRoutingError):
+            run_classify(
+                vault_path=vault,
+                config=_config(classification=_CLOUD, default=_CLOUD),
+                method="llm",
+                force=True,
+            )
+
+    def test_no_intimate_fragments_still_classifies(self, tmp_path: Path) -> None:
+        """All-cloud config with no Intimate content runs fine (error deferred)."""
+        vault = tmp_path / "vault"
+        _write(vault, "frag-openeeeeeee", PrivacyTier.OPEN)
+
+        run_classify(
+            vault_path=vault,
+            config=_config(classification=_CLOUD, default=_CLOUD),
+            method="llm",
+            force=True,
+        )
+
+        assert _provider_for("frag-openeeeeeee") == "anthropic"

--- a/creek-tools/tests/test_privacy_filter.py
+++ b/creek-tools/tests/test_privacy_filter.py
@@ -135,14 +135,14 @@ def test_tier_of_unknown_string_fails_closed_to_intimate(
     """Fragments carrying an unrecognised tier string fail closed.
 
     Regression for PR #193 review (comment 4367360694 LOW): the prior
-    ``_tier_of`` did ``PrivacyTier(fragment.privacy_tier)`` with no
+    ``tier_of`` did ``PrivacyTier(fragment.privacy_tier)`` with no
     safety net, so a hand-edited or schema-migrated vault with an
     unknown tier string would crash generation flows. The new helper
     catches the :class:`ValueError`, logs a warning that names the
     fragment ID, and returns :data:`PrivacyTier.INTIMATE` so the
     fragment is excluded from the default-policy output.
     """
-    from creek.classify.privacy_filter import _tier_of
+    from creek.classify.privacy_filter import tier_of
 
     # ``model_construct`` skips Pydantic validation, allowing us to
     # plant a bogus tier value the same way a hand-edited markdown file
@@ -161,7 +161,7 @@ def test_tier_of_unknown_string_fails_closed_to_intimate(
     )
 
     with caplog.at_level("WARNING", logger="creek.classify.privacy_filter"):
-        tier = _tier_of(bogus)
+        tier = tier_of(bogus)
 
     assert tier is PrivacyTier.INTIMATE
     assert any(


### PR DESCRIPTION
## Summary

`creek classify --method llm` now routes each fragment's classification **by its privacy tier**, reusing the existing `ModelRouter` Intimate-never-cloud chokepoint (#647): an `Intimate` fragment is classified by the **local** provider even when the `classification` stage is a cloud model, while non-`Intimate` fragments use the configured model — in one run.

This also closes a real privacy hole: the `privacy_filter` only gates *generation* (Writing Desk), not classification, so today an Intimate fragment reaches whatever `classification` provider is configured (possibly cloud). #666 redirects it to local.

```yaml
llm:
  default:        { provider: ollama,    model: qwen3:8b }       # Intimate-safe
  classification: { provider: anthropic, model: claude-haiku-4-5 }
# creek classify --method llm → Intimate fragments by ollama (local),
#                                every other fragment by anthropic/haiku.
```

## Design

- **`_build_tier_classifiers`** (in `classify_engine.py`) resolves `classification` twice — tier-less (non-Intimate) and with `PrivacyTier.INTIMATE` (Intimate → local) — through the **single** chokepoint. `_TierClassifiers.for_tier` selects per fragment inside `_process_file`, keyed on `_tier_of(fragment)` which **fails closed to INTIMATE** for an unrecognised tier (unknown content is never sent to cloud).
- **No double-gating / no second tier check** — the only tier gate remains `ModelRouter._enforce_local_for_intimate`. Composes cleanly with the existing `privacy_filter`.
- **Backward compatible** — a local `classification` stage resolves both tiers to the same config → one shared classifier instance, identical to the pre-#666 path (incl. the single provider-availability fail-fast).
- **Deferred failure** — when `classification` is cloud **and** `default` is also cloud, `IntimateRoutingError` is captured at build time and raised only when an actual Intimate fragment is reached, so an all-cloud run with **no** Intimate content still classifies (this avoided breaking the existing provider-unavailable test).

## Test plan
`tests/test_classify_tier_routing.py` (faked LLM — no network; asserts on the *provider that classified each fragment*, #647 guard style):
- Intimate → ollama (local) **and** Open → anthropic (cloud) in one run.
- A local `classification` stage classifies every tier with that provider (backward compat).
- All-cloud config: an Intimate fragment raises `IntimateRoutingError`; a run with only non-Intimate fragments succeeds (deferred error).
- All 12 `./scripts/check-all.sh` gates green; the full existing classify suite (242 tests) still passes.

## Scope / follow-up
Per the issue's Goal (`creek classify --method llm`), this wires the **classify engine** (`run_classify`). The remaining tier-less sites — the `creek process` pipeline classify loop + the `draft`/`calibrate` classifier builds — are tracked as **#706** (the pipeline's eager-build-at-`__init__` complicates the deferred-error handling). So the Intimate-never-cloud guarantee is complete for `creek classify`, not yet for `creek process`.

The `/model-setup` skill's "known gap" section is updated to document this as shipped.

Closes #666
Refs #642, #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)