### PR TITLE
refactor(compost): make the LLM compost verifier provider-neutral (#667)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -5086,25 +5086,32 @@ def _run_compost_calibration(
 def _build_compost_verifier(config: CreekConfig) -> SupportsVerifyCompost | None:
     """Construct the production LLM verifier, or ``None`` if it can't be built.
 
-    ``creek compost calibrate`` runs in environments where the
-    Anthropic credentials may or may not be present; rather than fail
-    loud, fall back to embedding-only scoring with a console note so
-    the operator can re-run with the verifier once credentials are in
-    place.
+    ``creek compost calibrate`` runs in environments where the configured
+    ``generation`` provider's credentials (or local host) may or may not be
+    present; rather than fail loud, fall back to embedding-only scoring with a
+    console note so the operator can re-run with the verifier once the provider
+    is ready.
     """
-    from creek.classify.llm import AnthropicProvider
+    from creek.classify.llm import build_provider
     from creek.generate.compost_verifier import LLMCompostVerifier
 
-    # Per-stage routing (#646): resolve the generation stage so the verifier
-    # uses the generation model. The verifier itself is still Anthropic-specific
-    # (it calls the Anthropic-only ``.call``); making it fully provider-neutral
-    # is a follow-up. Feeding the resolved config keeps the credential-fallback
-    # behaviour (AnthropicProvider raises without a key → embedding-only).
+    # Provider-neutral (#667): build the configured ``generation`` provider
+    # (#646) and gate on availability so any backend (Ollama / OpenAI / Gemini /
+    # Anthropic) degrades the same way. A cloud provider validates its env in the
+    # constructor and may raise (build_provider contract); a local provider
+    # constructs but reports ``available is False`` when its host is down — both
+    # fall back to embedding-only scoring.
     try:
-        provider = AnthropicProvider(config=config.model_router.resolve("generation"))
+        provider = build_provider(config.model_router.resolve("generation"))
     except RuntimeError as exc:
         console.print(
             f"[yellow]Skipping LLM verifier — provider unavailable: {exc}[/yellow]",
+        )
+        return None
+    if not provider.available:
+        console.print(
+            "[yellow]Skipping LLM verifier — provider prerequisites unmet "
+            "(missing key/consent, or local host unreachable).[/yellow]",
         )
         return None
     return LLMCompostVerifier(provider=provider)

--- a/creek-tools/creek/generate/compost_verifier.py
+++ b/creek-tools/creek/generate/compost_verifier.py
@@ -24,7 +24,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
-    from creek.classify.llm import AnthropicProvider
+    from creek.classify.llm.base import LLMProvider
 
 logger = logging.getLogger(__name__)
 
@@ -61,8 +61,8 @@ class SupportsVerifyCompost(Protocol):
     """Subset of verifier surface the compost tracker needs.
 
     Any object exposing :meth:`verify` with this signature is accepted
-    by :class:`creek.generate.compost.CompostTracker`. Real verifier
-    wraps :class:`creek.classify.llm.AnthropicProvider`; tests pass a
+    by :class:`creek.generate.compost.CompostTracker`. The real verifier
+    wraps any :class:`creek.classify.llm.base.LLMProvider`; tests pass a
     deterministic stub.
     """
 
@@ -125,21 +125,24 @@ def _parse_verifier_response(text: str) -> CompostVerifierResult:
 
 
 class LLMCompostVerifier:
-    """Default :class:`SupportsVerifyCompost` impl backed by Anthropic.
+    """Default :class:`SupportsVerifyCompost` impl, provider-neutral (#667).
 
-    Wraps an :class:`creek.classify.llm.AnthropicProvider` and parses
-    the three-line response format defined by ``_PROMPT_TEMPLATE``.
-    Reuses the existing classify infrastructure rather than building
-    a parallel transport layer.
+    Wraps any :class:`creek.classify.llm.base.LLMProvider` (Ollama / OpenAI /
+    Gemini / Anthropic) and parses the three-line response format defined by
+    ``_PROMPT_TEMPLATE``. Reuses the existing classify provider abstraction
+    rather than building a parallel transport layer.
     """
 
-    def __init__(self, provider: AnthropicProvider) -> None:
+    def __init__(self, provider: LLMProvider) -> None:
         """Initialise the verifier.
 
         Args:
-            provider: A constructed :class:`AnthropicProvider`. Caller
-                is responsible for handling the ``ANTHROPIC_API_KEY``
-                and ``CREEK_ANTHROPIC_CONSENT`` env-var preconditions.
+            provider: A constructed :class:`LLMProvider`. The caller builds it
+                via the model router's ``generation`` stage and is responsible
+                for the provider's env-var preconditions (the
+                :func:`creek.cli._build_compost_verifier` builder gates on
+                ``provider.available`` so an unready provider degrades to
+                embedding-only scoring).
         """
         self._provider = provider
 
@@ -158,5 +161,5 @@ class LLMCompostVerifier:
             routes to review rather than being dropped.
         """
         prompt = _PROMPT_TEMPLATE.format(title=title.strip() or "(untitled)", body=body)
-        response = self._provider.call(prompt)
+        response = self._provider.complete(prompt).text
         return _parse_verifier_response(response)

--- a/creek-tools/tests/test_compost_verifier.py
+++ b/creek-tools/tests/test_compost_verifier.py
@@ -1,15 +1,22 @@
 """Tests for ``creek.generate.compost_verifier`` (FEAT-018 stage 2).
 
-Covers response parsing and the :class:`LLMCompostVerifier` adapter
-that wraps :class:`creek.classify.llm.AnthropicProvider`. The
-:class:`AnthropicProvider` is stubbed with a minimal fake to keep the
-unit test free of network and env-var prerequisites.
+Covers response parsing and the :class:`LLMCompostVerifier` adapter, which is
+**provider-neutral** (#667): it drives any :class:`creek.classify.llm.base.LLMProvider`
+through ``complete(prompt).text``. The provider is stubbed with a minimal fake
+that conforms to the protocol, keeping the unit test free of network and env-var
+prerequisites. The ``_build_compost_verifier`` CLI builder is exercised for its
+available / unavailable degradation paths.
 """
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import pytest
 
+from creek.classify.llm.completion import Completion
+from creek.cli import _build_compost_verifier
+from creek.config import CreekConfig
 from creek.generate.compost_verifier import (
     CompostVerdict,
     CompostVerifierResult,
@@ -17,18 +24,47 @@ from creek.generate.compost_verifier import (
     _parse_verifier_response,
 )
 
+if TYPE_CHECKING:
+    from creek.classify.llm.base import LLMProvider
+
+_DEFAULT_RESPONSE = "VERDICT: yes\nREASONING: ok"
+
 
 class _FakeProvider:
-    """Stand-in for :class:`AnthropicProvider` exposing only ``call``."""
+    """A minimal :class:`LLMProvider` conformer — no network, no env vars."""
 
-    def __init__(self, response: str) -> None:
-        self.response = response
-        self.calls: list[str] = []
+    is_cloud = False
 
-    def call(self, prompt: str) -> str:
-        """Record the prompt and return the canned response."""
-        self.calls.append(prompt)
-        return self.response
+    def __init__(
+        self, response: str = _DEFAULT_RESPONSE, *, available: bool = True
+    ) -> None:
+        """Capture the canned completion text and the availability to report."""
+        self._response = response
+        self._available = available
+        self.prompts: list[str] = []
+
+    @property
+    def model(self) -> str:
+        """The resolved model identifier (constant for the fake)."""
+        return "fake-model"
+
+    @property
+    def available(self) -> bool:
+        """Whether the fake reports its prerequisites as met."""
+        return self._available
+
+    def complete(
+        self, prompt: str, *, max_tokens: int | None = None, system: str | None = None
+    ) -> Completion:
+        """Record the prompt and return the canned completion."""
+        _ = (max_tokens, system)
+        self.prompts.append(prompt)
+        return Completion(text=self._response)
+
+
+def _as_provider(fake: _FakeProvider) -> LLMProvider:
+    """Bind the fake to the protocol type (it conforms structurally)."""
+    return fake
 
 
 class TestParseVerifierResponse:
@@ -89,12 +125,12 @@ class TestParseVerifierResponse:
 
 
 class TestLLMCompostVerifier:
-    """End-to-end behaviour of the LLM-backed verifier."""
+    """End-to-end behaviour of the provider-neutral verifier."""
 
     def test_verify_returns_parsed_result(self) -> None:
-        """``verify`` sends a prompt and returns the parsed response."""
+        """``verify`` drives the provider via ``complete`` and parses the result."""
         provider = _FakeProvider("VERDICT: yes\nREASONING: clear release")
-        verifier = LLMCompostVerifier(provider)  # type: ignore[arg-type]
+        verifier = LLMCompostVerifier(_as_provider(provider))
         result = verifier.verify(title="Letting go", body="It's over.")
         assert isinstance(result, CompostVerifierResult)
         assert result.verdict == CompostVerdict.YES
@@ -103,26 +139,62 @@ class TestLLMCompostVerifier:
     def test_verify_includes_title_and_body_in_prompt(self) -> None:
         """The prompt embeds both fields verbatim for verifier context."""
         provider = _FakeProvider("VERDICT: no\nREASONING: x")
-        verifier = LLMCompostVerifier(provider)  # type: ignore[arg-type]
+        verifier = LLMCompostVerifier(_as_provider(provider))
         verifier.verify(title="My title", body="My body text.")
-        assert len(provider.calls) == 1
-        sent = provider.calls[0]
+        assert len(provider.prompts) == 1
+        sent = provider.prompts[0]
         assert "My title" in sent
         assert "My body text." in sent
 
     def test_verify_handles_empty_title(self) -> None:
         """An empty title is replaced with a placeholder so the prompt is valid."""
         provider = _FakeProvider("VERDICT: yes\nREASONING: ok")
-        verifier = LLMCompostVerifier(provider)  # type: ignore[arg-type]
+        verifier = LLMCompostVerifier(_as_provider(provider))
         verifier.verify(title="", body="body")
-        assert "(untitled)" in provider.calls[0]
+        assert "(untitled)" in provider.prompts[0]
 
     def test_malformed_response_routes_to_ambiguous(self) -> None:
         """A malformed LLM response yields AMBIGUOUS without raising."""
         provider = _FakeProvider("hello there friend")
-        verifier = LLMCompostVerifier(provider)  # type: ignore[arg-type]
+        verifier = LLMCompostVerifier(_as_provider(provider))
         result = verifier.verify(title="t", body="b")
         assert result.verdict == CompostVerdict.AMBIGUOUS
+
+
+class TestBuildCompostVerifier:
+    """``_build_compost_verifier`` is provider-neutral and degrades gracefully."""
+
+    def test_returns_verifier_when_provider_available(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An available (non-Anthropic) provider yields a working verifier."""
+        fake = _FakeProvider("VERDICT: no\nREASONING: keep")
+        monkeypatch.setattr("creek.classify.llm.build_provider", lambda _c: fake)
+
+        verifier = _build_compost_verifier(CreekConfig())
+
+        assert isinstance(verifier, LLMCompostVerifier)
+        # Drives the configured provider through the neutral ``complete`` path.
+        assert verifier.verify(title="t", body="b").verdict == CompostVerdict.NO
+        assert fake.prompts
+
+    def test_none_when_build_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A cloud provider that raises (no key) degrades to embedding-only."""
+
+        def _raise(_c: object) -> _FakeProvider:
+            msg = "ANTHROPIC_API_KEY not set"
+            raise RuntimeError(msg)
+
+        monkeypatch.setattr("creek.classify.llm.build_provider", _raise)
+        assert _build_compost_verifier(CreekConfig()) is None
+
+    def test_none_when_provider_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A local provider that constructs but is unreachable degrades too."""
+        fake = _FakeProvider(available=False)
+        monkeypatch.setattr("creek.classify.llm.build_provider", lambda _c: fake)
+        assert _build_compost_verifier(CreekConfig()) is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

The compost-calibration verifier was pinned to Anthropic — `_build_compost_verifier` constructed `AnthropicProvider` and `LLMCompostVerifier` called the Anthropic-only `.call`. This makes it honor the configured `generation` provider (Ollama / OpenAI / Gemini / Anthropic), mirroring the #646 `default_llm` migration.

- **`LLMCompostVerifier`** — widen `provider` to the `LLMProvider` protocol; replace `.call(prompt)` with the provider-neutral `.complete(prompt).text`.
- **`cli._build_compost_verifier`** — build via `build_provider(config.model_router.resolve("generation"))` and gate on `provider.available` (skip + console note) instead of catching an `AnthropicProvider` construction error. The **credential-fallback is preserved**: per the `build_provider` contract, a cloud backend validates its env in the constructor and *may raise* without a key, while a local backend constructs but reports `available is False` when its host is down — **both** degrade to embedding-only scoring with a console note.

## Test plan
`tests/test_compost_verifier.py`:
- `_FakeProvider` now fully conforms to the `LLMProvider` protocol (`is_cloud`/`model`/`available`/`complete`), so the old `# type: ignore[arg-type]` is gone; the verifier drives it through `complete`.
- New `TestBuildCompostVerifier`: an available (non-Anthropic) provider → a working verifier driven via `complete`; `build_provider` raising `RuntimeError` (no key) → `None`; a constructed-but-unavailable provider → `None`.
- All 87 compost tests pass; `./scripts/check-all.sh` green (12/12 gates, incl. mypy strict on the protocol conformance).

## Notes
This is part of the swappable-providers line (#603): the compost stage is the last sync path that hard-coded Anthropic. No behaviour change for an Anthropic-configured `generation` stage; the fallback semantics are unchanged for the missing-key case and newly extended to local providers.

Closes #667
Refs #603, #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)