### PR TITLE
refactor(discord): dedupe ExporterConnector._ingest into write_fragments (#705)

### DIFF
--- a/creek-tools/creek/ingest/discord.py
+++ b/creek-tools/creek/ingest/discord.py
@@ -811,14 +811,16 @@ def stage_capture_as_data_package(capture_dir: Path, staging_dir: Path) -> None:
         )
 
 
-def _write_fragments(result: IngestResult, vault: Path) -> list[Path]:
+def write_fragments(result: IngestResult, vault: Path) -> list[Path]:
     """Assemble + write every parsed fragment; return the written vault paths.
 
-    Shared by the bot-capture and Data-Package ingest paths. This **always**
-    writes each fragment — it does not skip existing files — but the path is
-    deterministic (``frag-<sha>``), so re-writing an already-present fragment
-    overwrites the same file in place. Callers that need a "new only" count diff
-    the returned paths against a pre-run snapshot (see
+    The shared writer for all three Discord ingest paths — bot-capture
+    (:func:`ingest_capture_dir`), Data Package (:func:`run_discord_data_package`),
+    and the user-token exporter (:meth:`ExporterConnector._ingest`). This
+    **always** writes each fragment — it does not skip existing files — but the
+    path is deterministic (``frag-<sha>``), so re-writing an already-present
+    fragment overwrites the same file in place. Callers that need a "new only"
+    count diff the returned paths against a pre-run snapshot (see
     :func:`run_discord_data_package`).
 
     Args:
@@ -864,7 +866,7 @@ def ingest_capture_dir(capture_dir: Path, vault: Path) -> int:
         shutil.rmtree(staging)
     staging.mkdir(parents=True, exist_ok=True)
     stage_capture_as_data_package(capture_dir, staging)
-    return len(_write_fragments(DiscordIngestor().ingest(staging), vault))
+    return len(write_fragments(DiscordIngestor().ingest(staging), vault))
 
 
 def run_discord_data_package(vault: Path, package: Path) -> int:
@@ -889,7 +891,7 @@ def run_discord_data_package(vault: Path, package: Path) -> int:
     """
     fragments_root = vault / "01-Fragments"
     before = set(fragments_root.rglob("*.md")) if fragments_root.is_dir() else set()
-    written = _write_fragments(DiscordIngestor().ingest(package), vault)
+    written = write_fragments(DiscordIngestor().ingest(package), vault)
     # New = distinct written paths that did not pre-exist. `set(written)` also
     # collapses any duplicate path emitted within a single run, so a fragment is
     # counted at most once.

--- a/creek-tools/creek/ingest/discord_dispatch.py
+++ b/creek-tools/creek/ingest/discord_dispatch.py
@@ -287,15 +287,9 @@ class ExporterConnector:
 
     def _ingest(self, staging: Path) -> None:
         """Ingest the staged Data Package via the existing DiscordIngestor."""
-        from creek.ingest.base import assemble_ingested_fragment
-        from creek.ingest.discord import DiscordIngestor
-        from creek.vault.writer import VaultWriter
+        from creek.ingest.discord import DiscordIngestor, write_fragments
 
-        writer = VaultWriter(vault_path=self._vault)
-        result = DiscordIngestor().ingest(staging)
-        for parsed in result.fragments:
-            assembled = assemble_ingested_fragment(parsed)
-            writer.write_fragment(assembled.fragment, body=assembled.body)
+        write_fragments(DiscordIngestor().ingest(staging), self._vault)
 
     def load_cursor(self) -> str | None:
         """Return the persisted ``--after`` cursor, or ``None`` if unset."""


### PR DESCRIPTION
## Summary

Follow-up from #688's review. `ExporterConnector._ingest` (`creek/ingest/discord_dispatch.py`) inlined the same assemble→write loop that #688 extracted into `creek.ingest.discord._write_fragments` — it was the last remaining copy. This reuses the shared helper and **promotes it to the public `write_fragments`**, so the cross-module call is an explicit public dependency rather than a private (`_`-prefixed) import across module boundaries (the concern the #666 review raised about `_tier_of`).

- `_ingest` now calls `write_fragments(DiscordIngestor().ingest(staging), self._vault)`.
- `_write_fragments` → `write_fragments`; the two in-module callers (`ingest_capture_dir`, `run_discord_data_package`) are updated; the docstring now names all three Discord ingest paths (bot-capture, Data Package, exporter).

## Test plan
Pure refactor — no behaviour change. The existing suites cover `_ingest` end-to-end and pass unchanged: `test_discord_exporter.py`, `test_ingest_bot_capture.py`, `test_ingest_data_package_helper.py`, `test_discord_dispatch.py` (35 tests). `./scripts/check-all.sh` green (12/12 gates).

Closes #705
Refs #671, #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)