### PR TITLE
feat(classify): per-tier classification routing for the creek process pipeline (#706)

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -181,7 +181,7 @@ class _RunCounts:
 
 
 @dataclass(frozen=True)
-class _TierClassifiers:
+class TierClassifiers:
     """Per-tier LLM classifiers for one classify run (#666).
 
     ``non_intimate`` serves OPEN / PERSONAL / UNCLASSIFIED fragments with the
@@ -233,7 +233,7 @@ class _TierClassifiers:
         return self.routing_error
 
 
-def _build_tier_classifiers(config: CreekConfig) -> _TierClassifiers:
+def build_tier_classifiers(config: CreekConfig) -> TierClassifiers:
     """Build the per-tier classifiers via the ModelRouter chokepoint (#666).
 
     Resolves ``classification`` tier-less for non-Intimate fragments and with
@@ -242,21 +242,21 @@ def _build_tier_classifiers(config: CreekConfig) -> _TierClassifiers:
     ``classification`` stage), a single classifier instance is shared — identical
     to the pre-#666 behaviour. When no local backend exists, the resulting
     :class:`IntimateRoutingError` is captured and **deferred** (see
-    :class:`_TierClassifiers`) rather than failing a run that has no Intimate
+    :class:`TierClassifiers`) rather than failing a run that has no Intimate
     content.
 
     Args:
         config: The loaded Creek configuration (carrying the model router).
 
     Returns:
-        The :class:`_TierClassifiers` for this run.
+        The :class:`TierClassifiers` for this run.
     """
     router = config.model_router
     non_intimate = LLMClassifier(config=router.resolve("classification"))
     try:
         intimate_cfg = router.resolve("classification", PrivacyTier.INTIMATE)
     except IntimateRoutingError as exc:
-        return _TierClassifiers(
+        return TierClassifiers(
             non_intimate=non_intimate, intimate=None, routing_error=exc
         )
     intimate = (
@@ -264,7 +264,7 @@ def _build_tier_classifiers(config: CreekConfig) -> _TierClassifiers:
         if intimate_cfg == non_intimate.config
         else LLMClassifier(config=intimate_cfg)
     )
-    return _TierClassifiers(
+    return TierClassifiers(
         non_intimate=non_intimate, intimate=intimate, routing_error=None
     )
 
@@ -306,7 +306,7 @@ def run_classify(
     # to a local provider by the ModelRouter chokepoint (Intimate-never-cloud,
     # #647). Resolving here also fails the run loudly (IntimateRoutingError) when
     # classification is cloud and no local default exists to route Intimate to.
-    tier_classifiers = _build_tier_classifiers(config) if method == LLM_METHOD else None
+    tier_classifiers = build_tier_classifiers(config) if method == LLM_METHOD else None
     if tier_classifiers is not None:
         for classifier in tier_classifiers.distinct():
             if not classifier.available:
@@ -408,7 +408,7 @@ def _process_file(
     force: bool,
     rules: RuleClassifier,
     audience: AudienceClassifier,
-    tier_classifiers: _TierClassifiers | None,
+    tier_classifiers: TierClassifiers | None,
     classification_config: ClassificationConfig,
     counts: _RunCounts,
     progress_path: Path | None,

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -37,7 +37,8 @@ from creek.audit.yield_summary import (
     format_yield_line,
     write_yield_summary,
 )
-from creek.classify.llm import LLMClassifier
+from creek.classify.classify_engine import build_tier_classifiers
+from creek.classify.privacy_filter import tier_of
 from creek.classify.review import ReviewQueueGenerator
 from creek.classify.rules import RuleClassifier
 from creek.config import CreekConfig
@@ -217,7 +218,8 @@ class Pipeline:
         config: The Creek configuration governing all subsystems.
         scanner: The redaction scanner for PII detection.
         rule_classifier: Keyword-based classifier.
-        llm_classifier: LLM-based classifier stub.
+        tier_classifiers: Per-tier LLM classifiers (#666/#706) — the fragment's
+            privacy tier selects the provider so Intimate stays local.
         review_generator: Review queue generator for uncertain fragments.
         linking_pipeline: Orchestrator for all four linking stages.
         consent_manager: Optional consent manager for gating processing.
@@ -239,7 +241,7 @@ class Pipeline:
             no_llm: When ``True``, skip Pass 3 (LLM classification)
                 entirely. The deterministic and local-model passes still
                 run; the run summary records ``no_llm: true`` and the
-                pipeline never invokes ``llm_classifier.classify`` —
+                pipeline never invokes the LLM classifier —
                 guaranteeing zero network egress along the LLM path.
                 The flag wins over ``LLMConfig.provider`` so passing
                 ``no_llm=True`` with ``provider: anthropic`` is safe.
@@ -249,9 +251,12 @@ class Pipeline:
         self.no_llm = no_llm
         self.scanner = RedactionScanner(config=config.redaction)
         self.rule_classifier = RuleClassifier()
-        self.llm_classifier = LLMClassifier(
-            config=config.model_router.resolve("classification"),
-        )
+        # Per-tier routing (#666/#706): each fragment is classified by the
+        # provider its privacy tier resolves to — Intimate stays local even when
+        # ``classification`` is cloud. Building here is safe with any config:
+        # build_tier_classifiers defers IntimateRoutingError (it never raises at
+        # construction), so a rules-only or all-cloud ``process`` run is fine.
+        self.tier_classifiers = build_tier_classifiers(config)
         self.review_generator = ReviewQueueGenerator(config=config.classification)
         self.linking_pipeline = LinkingPipeline(
             config=config.embeddings,
@@ -528,7 +533,8 @@ class Pipeline:
             if self._needs_llm(frag, item.body):
                 result.residue += 1
                 if not self.no_llm:
-                    frag = self.llm_classifier.classify(frag, content=item.body)
+                    classifier = self.tier_classifiers.for_tier(tier_of(frag))
+                    frag = classifier.classify(frag, content=item.body)
             else:
                 result.deterministic_classified += 1
             classified.append(IngestedFragment(fragment=frag, body=item.body))

--- a/creek-tools/tests/test_pipeline.py
+++ b/creek-tools/tests/test_pipeline.py
@@ -22,6 +22,8 @@ from creek.pipeline import Pipeline, PipelineResult
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from creek.models import PrivacyTier
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -149,10 +151,10 @@ class TestPipelineInit:
         pipeline = Pipeline(config=config)
         assert pipeline.rule_classifier is not None
 
-    def test_creates_llm_classifier(self, config):
-        """Test that Pipeline initialises an LLMClassifier."""
+    def test_creates_tier_classifiers(self, config):
+        """Test that Pipeline initialises the per-tier classifiers (#706)."""
         pipeline = Pipeline(config=config)
-        assert pipeline.llm_classifier is not None
+        assert pipeline.tier_classifiers.non_intimate is not None
 
     def test_creates_review_generator(self, config):
         """Test that Pipeline initialises a ReviewQueueGenerator."""
@@ -945,7 +947,9 @@ class TestPipelineClassificationGating:
                 "confidence_score",
                 return_value=0.95,
             ),
-            patch.object(pipeline.llm_classifier, "classify") as mock_llm,
+            patch.object(
+                pipeline.tier_classifiers.non_intimate, "classify"
+            ) as mock_llm,
         ):
             pipeline._run_classification([item], vault_path, PipelineResult())
 
@@ -974,7 +978,7 @@ class TestPipelineClassificationGating:
                 return_value=0.1,
             ),
             patch.object(
-                pipeline.llm_classifier,
+                pipeline.tier_classifiers.non_intimate,
                 "classify",
                 side_effect=lambda f, content="": f,
             ) as mock_llm,
@@ -995,7 +999,7 @@ class TestPipelineClassificationGating:
                 side_effect=lambda f, content="": f,
             ),
             patch.object(
-                pipeline.llm_classifier,
+                pipeline.tier_classifiers.non_intimate,
                 "classify",
                 side_effect=lambda f, content="": f,
             ) as mock_llm,
@@ -1017,8 +1021,85 @@ class TestPipelineClassificationGating:
                 "classify",
                 side_effect=lambda f, content="": f,
             ),
-            patch.object(pipeline.llm_classifier, "classify") as mock_llm,
+            patch.object(
+                pipeline.tier_classifiers.non_intimate, "classify"
+            ) as mock_llm,
         ):
             pipeline._run_classification([item], vault_path, PipelineResult())
 
         mock_llm.assert_not_called()
+
+
+class TestPipelineTierRouting:
+    """`creek process` classifies each fragment by its privacy tier (#706).
+
+    Closes the Intimate-never-cloud gap for the pipeline: an Intimate fragment is
+    classified by the local provider even when ``classification`` is cloud.
+    """
+
+    @staticmethod
+    def _cloud_classification_local_default() -> CreekConfig:
+        """Config with a cloud ``classification`` stage + a local ``default``."""
+        from creek.config import LLMConfig, LLMRoutingConfig
+
+        return CreekConfig(
+            llm=LLMRoutingConfig(
+                default=LLMConfig(provider="ollama", model="qwen3:8b"),
+                classification=LLMConfig(
+                    provider="anthropic", model="claude-haiku-4-5"
+                ),
+            )
+        )
+
+    @staticmethod
+    def _ingested(frag_id: str, tier: PrivacyTier):
+        """An IngestedFragment at *tier* with a known id."""
+        from creek.ingest.base import IngestedFragment
+        from creek.models import Fragment, FragmentSource, SourcePlatform
+
+        fragment = Fragment(
+            id=frag_id,
+            title=frag_id,
+            source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+            privacy_tier=tier,
+        )
+        return IngestedFragment(fragment=fragment, body="a note worth classifying")
+
+    def test_intimate_routes_local_nonintimate_cloud(self, vault_path, monkeypatch):
+        """Intimate → the local classifier; Open → the configured cloud one."""
+        from creek.models import PrivacyTier
+
+        pipeline = Pipeline(config=self._cloud_classification_local_default())
+        # Cloud classification + local default → the tier classifiers are distinct.
+        assert (
+            pipeline.tier_classifiers.intimate
+            is not pipeline.tier_classifiers.non_intimate
+        )
+        # Force the LLM path: rules leave each fragment unclassified.
+        monkeypatch.setattr(
+            pipeline.rule_classifier, "classify", lambda f, content="": f
+        )
+
+        seen: dict[str, list[str]] = {"local": [], "cloud": []}
+        monkeypatch.setattr(
+            pipeline.tier_classifiers.intimate,
+            "classify",
+            lambda f, content="": (seen["local"].append(f.id), f)[1],
+        )
+        monkeypatch.setattr(
+            pipeline.tier_classifiers.non_intimate,
+            "classify",
+            lambda f, content="": (seen["cloud"].append(f.id), f)[1],
+        )
+
+        pipeline._run_classification(
+            [
+                self._ingested("frag-intimatexx", PrivacyTier.INTIMATE),
+                self._ingested("frag-openxxxxxxx", PrivacyTier.OPEN),
+            ],
+            vault_path,
+            PipelineResult(),
+        )
+
+        assert seen["local"] == ["frag-intimatexx"]  # Intimate → local provider
+        assert seen["cloud"] == ["frag-openxxxxxxx"]  # non-Intimate → cloud provider

--- a/creek-tools/tests/test_pipeline_no_llm.py
+++ b/creek-tools/tests/test_pipeline_no_llm.py
@@ -94,7 +94,9 @@ class TestNoLLMFlagSkipsLLMClassifier:
                 "classify",
                 side_effect=lambda f, content="": f,
             ),
-            patch.object(pipeline.llm_classifier, "classify") as mock_llm,
+            patch.object(
+                pipeline.tier_classifiers.non_intimate, "classify"
+            ) as mock_llm,
         ):
             pipeline._run_classification([item], vault_path, PipelineResult())
 
@@ -116,7 +118,7 @@ class TestNoLLMFlagSkipsLLMClassifier:
                 side_effect=lambda f, content="": f,
             ),
             patch.object(
-                pipeline.llm_classifier,
+                pipeline.tier_classifiers.non_intimate,
                 "classify",
                 side_effect=lambda f, content="": f,
             ) as mock_llm,
@@ -142,7 +144,9 @@ class TestNoLLMOverridesAnthropicProvider:
                 "classify",
                 side_effect=lambda f, content="": f,
             ),
-            patch.object(pipeline.llm_classifier, "classify") as mock_llm,
+            patch.object(
+                pipeline.tier_classifiers.non_intimate, "classify"
+            ) as mock_llm,
         ):
             pipeline._run_classification([item], vault_path, PipelineResult())
 


### PR DESCRIPTION
## Summary

Extends #666's per-tier classification routing to the `creek process` **pipeline**, closing the Intimate-never-cloud gap for that path — until now the pipeline classified every fragment with the configured `classification` provider (cloud included), even Intimate ones.

- **Promotes** the #666 helpers `_TierClassifiers`/`_build_tier_classifiers` to the public `TierClassifiers`/`build_tier_classifiers` (the reuse #706 anticipated).
- **`Pipeline.__init__`** builds `tier_classifiers` instead of a single `LLMClassifier`; the classify loop routes each fragment via `for_tier(tier_of(frag))`. Safe for any config: `build_tier_classifiers` **defers** `IntimateRoutingError` (it never raises at construction), so a rules-only or all-cloud `process` run still constructs, and `no_llm` short-circuits before any routing — which is exactly the concern I'd flagged when filing this follow-up, now resolved by the deferred design.

## Test plan
- New `TestPipelineTierRouting`: with a cloud `classification` + local `default`, the two tier classifiers are distinct instances; one `_run_classification` pass routes the Intimate fragment to the **local** classifier and the Open fragment to the **cloud** one (asserts on which instance saw which fragment id).
- Existing `test_pipeline.py` / `test_pipeline_no_llm.py` updated to the `tier_classifiers.non_intimate` handle (default config shares one instance, so it's the correct patch target; `no_llm` still short-circuits).
- `./scripts/check-all.sh` green (12/12 gates).

## Scope
Per-tier *classification* routing applies to the pipeline (the real gap). The other two `resolve("classification")` sites are functionally different and documented as out of scope:
- **`calibrate`** classifies a synthetic benchmark *fixture*, not real Intimate vault content.
- **`draft`**'s `classifier` is an **LLM client for generation** (`invoke_prompt`), not per-fragment classification — draft's content-tier routing is #661/conductor's job.

With this, the Intimate-never-cloud guarantee is complete for both `creek classify` and `creek process`.

Closes #706
Refs #647, #666

🤖 Generated with [Claude Code](https://claude.com/claude-code)