### PR TITLE
feat(ci): add Ralph Discord recap + weekly de-slopify audit

### DIFF
--- a/.claude/skills/de-slopify/SKILL.md
+++ b/.claude/skills/de-slopify/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: de-slopify
+description: >-
+  Audit the codebase for sloppy, amateurish, or AI-generated low-quality code —
+  bugs, code smells, dead/stubbed/orphaned code, duplication, poor architecture,
+  needless verbosity, comment slop, type-safety erosion, and weak tests — then
+  file corroborated findings as Ralph-ready GitHub issues (and decomposed epics
+  for big work). Use when the user says "de-slop", "deslopify", "run the slop
+  detector", "find code smells", "audit code quality", "find dead code", "weekly
+  code quality scan", "bullshit detector", or when the weekly de-slop GitHub
+  Action runs. Findings must be corroborated by two independent signals before
+  filing — null findings are a valid result. Do NOT use for implementing fixes
+  (Ralph / continue-epic does that), for reviewing a specific PR diff (use
+  comprehensive-pr-review), for fixing CI failures (use ci-debugging), or for
+  triaging a backlog of existing issues (use backlog-grooming).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# De-Slopify — The Comprehensive Bullshit Detector
+
+A reusable, scheduled code-quality auditor. It hunts the whole codebase for
+**evidence** of slop — bugs, code smell, dead/stubbed/orphaned code,
+duplication, poor architecture, verbosity, comment noise, type erosion, weak
+tests, security candidates — **corroborates** each finding against two
+independent signals, and files only the survivors as GitHub issues that the
+local **Ralph** loop picks up autonomously. Big problems become **epics** with
+decomposed sub-issues.
+
+Its prime directive: **precision over recall.** A false positive wastes an
+autonomous implementation cycle (or worse, "fixes" correct code into broken
+code), so a finding that can't be corroborated is dropped. **A run that files
+nothing because the code is clean is a success.**
+
+## Two principles that decide whether a run is any good
+
+1. **Linters are table stakes, not the audit.** This repo already passes ruff,
+   mypy (strict), radon, xenon, bandit, and interrogate in pre-commit and CI on
+   every commit. Anything those tools gate is *already enforced* and **cannot be a
+   finding** — never report a complexity grade, a lint rule, or a type error as
+   slop. The evidence bundle from `collect-evidence.sh` is dominated by exactly
+   that output; treat it as a *map of where to look*, not as findings. Your
+   entire value is the slop linters are **blind to**.
+2. **The high-value families require reading code, not parsing tool JSON.**
+   Dead/stubbed/orphaned code, duplication, bad architecture, lying feature
+   flags, needless verbosity, comment slop, AI-generated tells, and weak/
+   coverage-theater tests do not show up in a linter report. A 5-minute,
+   single-threaded scan of tool output will conclude "clean" and miss all of
+   them. **You must do the reading pass in Step 4.**
+
+## The three references (read them — they are the substance)
+
+| File | What it gives you |
+|------|-------------------|
+| `references/slop-taxonomy.md` | The exhaustive field guide: 13 families of slop (Correctness, Bloaters, OO-abusers, Change-preventers, Dispensables, Couplers/Architecture, Naming/Comments, Verbosity, Type-safety, Testing, Security, Deps/Config, **AI-slop-specific**), each with tells, corroboration hints, a severity rubric, and an explicit NOT-slop guard list. |
+| `references/detection-playbook.md` | The Two-Signal Rule, the toolbox→category map, grep recipes, the weekly run procedure, and the precision calibration. |
+| `references/issue-templates.md` | Standalone-finding and epic templates, the exact labels Ralph's picker honors, `gh` filing recipes, and the pre-file checklist. |
+
+`scripts/collect-evidence.sh` runs the read-only toolbox and writes a complete
+evidence bundle to the scratchpad.
+
+## Instructions
+
+### Step 1 — Orient
+
+Read the house rules so findings respect intent, not a generic ideal:
+`CLAUDE.md`, `AGENTS.md`, and skim `prompts/github-issues/README.md` for what's
+already planned. Then read all three references above (at minimum the taxonomy
+and playbook). Understand the NOT-slop guard list before you flag anything.
+
+### Step 2 — Collect evidence (read-only)
+
+```bash
+EVID=$(bash .claude/skills/de-slopify/scripts/collect-evidence.sh | tail -1)
+```
+
+This runs ruff, vulture, radon, mypy, bandit, interrogate, pip-audit, and
+detect-secrets over the Python source (`creek-tools/creek`, `creek-tools/
+creek_mcp`, `crawdad/crawdad`); the grep heuristics; and git churn — capturing
+each into `$EVID`. It never modifies files and never aborts on a tool error. Read
+`$EVID/README.txt`, then work through every output file. Supplement with
+targeted `Grep`/`Read` as candidates emerge.
+
+### Step 3 — Triage candidates against the guard list
+
+For each candidate from the evidence bundle, **first discard** anything in the
+NOT-slop list (`slop-taxonomy.md`): generated code, Alembic migrations,
+`package-lock.json`, justified suppressions (with a linked issue), framework
+boilerplate (Pydantic/SQLModel/React Navigation), test fixtures, self-evident
+constants, deliberate repo conventions, and unmeasured "could be faster" claims.
+
+### Step 4 — The reading pass (fan-out) — DO NOT SKIP
+
+This is the step that finds the slop linters cannot see, and the step the first
+audit skipped. Do not conclude "clean" without it.
+
+Fan out with the **Task tool**: spawn one subagent per feature area so the whole
+codebase is actually read in parallel, not skimmed by one thread. A good split:
+
+- one subagent per creek pipeline stage (`creek-tools/creek/{ingest,classify,
+  link,author,generate,...}/*`) — these are the real feature areas,
+- one for the MCP server surface (`creek-tools/creek_mcp/*`),
+- one for the crawdad Discord bot (`crawdad/crawdad/*`, incl. `llm/` and
+  `builtin_workflows/`),
+- one for the shared/util/config grab-bags (prime duplication + dead-code sites).
+
+Give each subagent the **full 13-family taxonomy** (`slop-taxonomy.md`) and this
+brief: *read the actual source in your area and return corroborated candidates
+for every family, with file:line evidence — focus on what linters miss: dead/
+stubbed/orphaned code, duplication (here and against the rest of the repo),
+architecture/layering violations, lying flags, verbosity, comment slop, AI-slop
+tells, and weak tests. Ignore anything ruff/mypy/radon/eslint already gates.*
+
+Use the `$EVID` bundle's churn and largest-file lists to prioritize. Collect all
+subagent candidates before corroborating.
+
+### Step 5 — Corroborate each survivor (the gate)
+
+Apply the **Two-Signal Rule** (`detection-playbook.md`): no finding survives
+without **two independent signals, at least one concrete and reproducible.**
+
+- For any **correctness/bug** claim (taxonomy Family 0, and Family 12 "confident
+  wrongness"): **write and run a reproducing test** in a throwaway location. If
+  it does not reproduce, **drop it.** Never file a bug on reasoning alone.
+- For dead code: a tool hit (vulture/eslint) **and** a grep proving zero inbound
+  references *including* dynamic dispatch, FastAPI routes, DI, and pytest
+  fixtures. vulture alone is not enough — it false-positives on dynamic use.
+- For everything else: tool/static signal + structural proof or a reading that
+  explains the defect in terms of intent.
+
+Classify each survivor by family and assign a severity (Critical/High/Medium/
+Low) from the rubric. When corroboration is shaky, **downgrade or drop.**
+
+### Step 6 — Cluster, then dedup against the backlog
+
+Group corroborated findings by area/theme. A cluster needing coordinated
+multi-file change is an **epic**; standalone findings are single issues. Bundle
+many Low findings in one file into a single tidy-up issue — don't flood the
+backlog.
+
+Then, for every cluster/finding, search existing issues and skip duplicates:
+
+```bash
+gh issue list --state open --search "in:title <keywords>" --json number,title
+gh search issues --repo geoffe-ga/creek-vault "<keywords>" --state open
+```
+
+### Step 7 — File the work (Ralph-ready)
+
+Follow `references/issue-templates.md` exactly. The labels matter — Ralph's
+picker (`scripts/ralph/pick-next.sh`) skips `epic`/`blocked`/`needs-spec` and
+works everything else lowest-number-first.
+
+- **Standalone finding** → Template A, normal labels (no excluded label), sized
+  ≤ ~300 net LoC / ≤ 5 files. Paste the corroborating evidence into the body.
+- **Epic** → Template B with the `epic` label (Ralph skips the umbrella), plus
+  sub-issues via Template A in dependency order. If the decomposition needs more
+  than ~3 sub-issues, **invoke the `triage-and-plan` skill** to do it properly —
+  don't hand-roll a sprawling epic. Mark dependent sub-issues `blocked` and note
+  `Depends on #N`.
+
+Create any missing labels first (`gh label create ...`). Write issue bodies to
+files in the scratchpad and file with `--body-file` (never inline strings).
+
+### Step 8 — Report (with a coverage ledger)
+
+Emit a concise run summary: counts by severity, what was filed (with issue
+numbers/links), what was **dropped and why** (failed corroboration / guard
+list), and what was **deduped**.
+
+Then add a **coverage ledger** — a table with one row per taxonomy family (all
+13) recording which areas/files you examined for it and the verdict
+(clean / candidates / filed). This is how a reader verifies the whole taxonomy
+was actually traversed in the reading pass, not assumed clean:
+
+```
+| Family | Areas examined | Verdict |
+|--------|----------------|---------|
+| 0 Correctness | routers/*, domain/energy.py | clean |
+| 3 Dispensables | services/, frontend/features/Habits | 2 filed (#812, #813) |
+| ... | ... | ... |
+```
+
+If nothing met the bar, say so plainly — *"No corroborated slop this run —
+codebase is clean against the taxonomy"* — but the ledger must still show the
+13 families were each looked at. A clean verdict with an empty ledger means the
+reading pass was skipped; that is a failed run, not a clean one.
+
+## What this skill must never do
+
+- File a finding it could not corroborate with two independent signals.
+- File a correctness/bug claim without a reproducing test.
+- Implement fixes itself — it only files work; Ralph/`continue-epic` implements.
+- Modify tracked files, weaken a quality gate, or commit anything.
+- Touch generated code, migrations, lockfiles, or justified suppressions.
+- Create duplicate issues, or flood the backlog with low-value nits.
+- File a stylistic opinion that contradicts CLAUDE.md/AGENTS.md conventions.
+
+## Examples
+
+### Example 1 — Weekly scheduled run (the primary path)
+
+The `weekly-deslop` GitHub Action fires (or the user says "run the slop
+detector"). Collect evidence → triage → **fan-out reading pass** → corroborate →
+cluster → dedup → file → report-with-ledger. vulture + grep prove
+`legacy_streak()` has zero callers → file one `dead-code`/`priority-medium`
+issue. A reading subagent finds `HabitsScreen` mixes data-fetching, formatting,
+and 4 unrelated render responsibilities (something radon's complexity grade does
+*not* describe) → file a `refactor` **epic** with sub-issues (via
+`triage-and-plan`). A suspected N+1 can't be confirmed without a query-count
+log → **dropped** and noted in the report. Net: 1 issue, 1 epic (5 sub-issues),
+3 dropped, 2 deduped — plus a 13-row coverage ledger in the job summary.
+
+### Example 2 — Clean run
+
+Evidence bundle yields only candidates that fail the guard list (a `# noqa`
+with a linked issue, framework boilerplate, deliberate test-fixture
+duplication). Nothing corroborates into a real finding. Report:
+*"No corroborated slop this run."* File nothing.
+
+### Example 3 — A "lying" feature flag (high-value find)
+
+grep finds an `ENCRYPTION_AT_REST_ENABLED` flag and a docstring promising
+encryption (signal 1); reading the model layer shows the column is written as
+plaintext with no encrypt hook (signal 2). Corroborated and high-severity — the
+code advertises a guarantee it doesn't deliver. File an `audit-destub`-style
+epic to make it real (encrypt-on-write, key rotation, migration), mirroring the
+existing `prompts/github-issues/audit-destub-05b-*.md` precedent.
+
+## Troubleshooting
+
+### A tool is missing in CI / locally
+`collect-evidence.sh` skips absent tools and notes it. Install the dev deps
+(`pip install -e "creek-tools/.[all,dev]"`, ideally inside a `.venv`) for the
+full toolbox; proceed with whatever is available otherwise.
+
+### Worried about false positives
+Re-read the Two-Signal Rule and the NOT-slop guard list. When unsure, drop the
+finding. Precision is the whole point — a missed smell costs nothing this week;
+a bogus issue costs an autonomous implementation cycle.
+
+### The backlog is filling with too many issues
+Bundle Low-severity findings per file/area into single tidy-up issues, raise the
+corroboration bar, and prefer a few ironclad high-value issues over many maybes.
+
+### Ralph isn't picking up a filed issue
+Check labels against `scripts/ralph/pick-next.sh`: an excluded label
+(`epic`/`blocked`/`needs-spec`/etc.) or an open PR already referencing it will
+make the picker skip it. Epics are skipped by design; their sub-issues are not.

--- a/.claude/skills/de-slopify/references/detection-playbook.md
+++ b/.claude/skills/de-slopify/references/detection-playbook.md
@@ -1,0 +1,207 @@
+# Detection Playbook — Evidence, Corroboration, and the No-False-Positive Gate
+
+The taxonomy (`slop-taxonomy.md`) says *what* to look for. This playbook says
+*how to find it with evidence* and — critically — *how to prove a finding is
+real before it becomes work*. The entire value of this skill collapses if it
+files plausible-but-wrong findings, because Ralph will autonomously implement
+them. **A false positive is worse than a missed finding.**
+
+---
+
+## The Two-Signal Rule (the core discipline)
+
+> **No finding is filed unless it is corroborated by at least two independent
+> signals, at least one of which is concrete and reproducible.**
+
+The signal classes, strongest first:
+
+1. **Reproducing artifact** — a failing test, a stack trace, a query-count log,
+   a `tsc`/`mypy` error, an import that doesn't resolve. *Strongest.* For any
+   **correctness/bug** claim (Family 0, Family 12 "confident wrongness"), a
+   reproducing artifact is **mandatory** — never file a bug on reasoning alone.
+2. **Static-analysis hit** — a tool flags the exact line(s): ruff, mypy,
+   vulture, radon/xenon, bandit, eslint, detect-secrets, pip-audit, an
+   import-cycle scan, a duplication scan.
+3. **Structural proof** — a grep/graph result showing the claim: zero inbound
+   references (dead code), N identical token-runs across files (duplication),
+   a recurring field triple (data clump), a flag whose claim has no
+   implementing code path.
+4. **Reviewer reading** — an agent reads the code and explains the defect in
+   terms of intent. *Never sufficient alone* — it must confirm a 1–3 signal,
+   and for bugs it must be backed by signal #1.
+
+**Examples of valid corroboration:**
+
+- *Dead function:* vulture flags it (signal 2) **and** grep finds zero callers
+  including dynamic/string/route references (signal 3). ✅
+- *God function:* radon grades it `D` (signal 2) **and** a reading shows ≥3
+  distinct responsibilities (signal 4). ✅
+- *Off-by-one:* a written test fails at the boundary (signal 1) **and** the
+  reading explains why (signal 4). ✅
+- *Duplicated block:* duplication scan finds it (signal 2/3) **and** the diff
+  shows the blocks are semantically identical (signal 4). ✅
+
+**Examples that DO NOT clear the gate (drop them):**
+
+- "This function looks too long." — one soft signal, no tool, no responsibility
+  analysis. ❌
+- "This is probably an N+1." — no query-count artifact. ❌
+- "This might be a race condition." — no reproducing test or rigorous argument
+  plus a concrete interleaving. ❌
+- vulture flags a symbol that is actually a FastAPI route handler / pytest
+  fixture / dynamically dispatched — the grep refutes it. ❌ (This is why
+  vulture alone is never enough.)
+
+When in doubt, **don't file it.** Null findings are a valid, healthy outcome.
+
+---
+
+## The toolbox (already in this repo)
+
+Everything below is already installed via `backend/requirements-dev.txt`,
+`.pre-commit-config.yaml`, and `frontend/package.json`. `collect-evidence.sh`
+runs the read-only subset and writes a report to the scratchpad.
+
+### Backend (Python)
+
+| Tool | Finds | Invocation (from `backend/`) |
+|------|-------|------------------------------|
+| **ruff** (`select=ALL`) | bugs (`B`,`BLE`,`RUF`), simplifications (`SIM`), complexity (`PLR`), datetimes (`DTZ`), dead imports (`F401`) | `ruff check src --output-format=json` |
+| **vulture** | dead code: unused funcs/classes/vars/imports | `vulture src --min-confidence 80` |
+| **radon** | cyclomatic complexity + maintainability index | `radon cc src -s -n C` / `radon mi src -s` |
+| **xenon** | complexity grade gate | `xenon src --max-absolute B --max-average A` |
+| **mypy** (strict) | type holes, `Any` creep, unreachable code | `mypy src` |
+| **bandit** | security smells (injection, weak crypto, asserts) | `bandit -r src -f json` |
+| **interrogate** | docstring coverage gaps | `interrogate src -v` |
+| **pip-audit** | vulnerable dependencies | `pip-audit -r requirements.txt` |
+| **detect-secrets** | hardcoded secrets | `detect-secrets scan` |
+| **git** | churn / hotspots / commented-out code | `git log --format= --name-only \| sort \| uniq -c \| sort -rn` |
+
+### Frontend (TypeScript / React Native)
+
+| Tool | Finds | Invocation (from `frontend/`) |
+|------|-------|-------------------------------|
+| **eslint** (sonarjs + unicorn) | cognitive complexity, duplication, dead code, footguns | `npx eslint . -f json` |
+| **tsc** (strict) | type holes, `any`, unreachable, hallucinated APIs | `npx tsc --noEmit` |
+| **jest --coverage** | coverage gaps (then judge assertion quality) | `npx jest --coverage` |
+| **grep/ripgrep** | `@ts-ignore`, `any`, `TODO`, commented code, AI-tells | see grep recipes below |
+
+### Cross-cutting grep recipes
+
+Run these read-only; each hit is a *candidate* needing a second signal.
+
+```bash
+# Stubs / hollow implementations
+rg -n "NotImplementedError|not implemented|return None\s*#\s*TODO|throw new Error\(['\"]not implemented" backend/src frontend/src
+# AI-tell comments
+rg -n "In a real implementation|placeholder|for now|as an AI|should probably|FIXME|HACK|XXX" backend/src frontend/src
+# Debt markers
+rg -n "TODO|FIXME|HACK" backend/src frontend/src
+# Escape hatches without an issue reference
+rg -n "type: ignore|@ts-ignore|eslint-disable|# noqa" backend/src frontend/src
+# Swallowed exceptions
+rg -n "except (Exception|BaseException)?:\s*$" -U backend/src
+rg -n "catch\s*\([^)]*\)\s*\{\s*\}" frontend/src
+# Commented-out code (heuristic: lines that are commented statements)
+rg -n "^\s*#\s*(def |class |return |if |for |import )" backend/src
+# Magic numbers (review, don't auto-file)
+rg -n "[^_a-zA-Z0-9.]\d{3,}" backend/src
+```
+
+---
+
+## Category → detection → corroboration map
+
+For each taxonomy family, the primary tool and the required second signal.
+
+| Family | Primary signal | Required second signal |
+|--------|----------------|------------------------|
+| 0. Correctness/bugs | ruff `B`/`BLE`/`RUF`, eslint, reading | **a failing test that reproduces it** (mandatory) |
+| 1. Bloaters | radon CC / eslint cognitive-complexity | reading confirms multiple responsibilities |
+| 2. OO abusers | reading / grep `isinstance` ladders | confirm a cleaner construct fits |
+| 3. Dispensables — dead | vulture / eslint no-unused | grep proves zero inbound refs (incl. dynamic) |
+| 3. Dispensables — dup | duplication scan (`jscpd`-style / eslint sonar) | diff confirms semantic identity, ≥2 sites |
+| 3. Dispensables — stub | grep stub markers | confirm callers depend on it (else it's dead) |
+| 4. Change-preventers | git churn / shotgun trace | confirm scatter across files for one change |
+| 5. Couplers/arch | import-cycle scan / layering grep | confirm the edge crosses a layer wrongly |
+| 6. Naming/comments | comment-density / grep | reading confirms zero added information |
+| 7. Verbosity | ruff `SIM`, reading | confirm an idiomatic shorter form exists |
+| 8. Type safety | mypy / tsc / grep escape-hatches | confirm a real type is knowable / no issue ref |
+| 9. Testing | jest/pytest coverage + mutation reasoning | confirm a logic flip would survive |
+| 10. Security | bandit / detect-secrets / pip-audit | confirm input reaches sink / secret is live |
+| 11. Deps/config | grep imports vs manifest | confirm zero use / real conflict |
+| 12. AI-slop | grep AI-tells / dup vs existing helper | reproducing artifact (bugs) or grep of the real helper |
+
+---
+
+## What is already enforced — never file it
+
+The repo runs ruff (`select=ALL`), mypy (strict), radon/xenon, bandit, eslint
+(sonarjs+unicorn), and tsc in pre-commit **and** CI. Anything those gate cannot
+reach `main`, so it is **not a finding**:
+
+- complexity grades (radon CC/MI, xenon) — already gated at A/B,
+- ruff/eslint lint rules and formatting,
+- mypy/tsc type errors,
+- bandit's high-confidence security rules.
+
+If the only signal for a candidate is one of these tools agreeing with itself,
+**drop it.** Those tools are the *map* (where to look), not the *findings*. The
+findings come from reading the code for what the tools are blind to. A run whose
+"findings" are all linter-shaped is a failed run — that was the failure mode of
+the first audit.
+
+## The weekly run procedure
+
+1. **Snapshot.** Run `scripts/collect-evidence.sh` → a consolidated evidence
+   report in the scratchpad (all tool JSON + grep hits + churn + reading
+   targets). Treat the linter JSON as a map, per the rule above.
+2. **Triage candidates.** Parse the report into candidate findings. Discard
+   anything in the "NOT slop" guard list (`slop-taxonomy.md`) — generated code,
+   migrations, justified suppressions, framework boilerplate, test fixtures —
+   and anything already enforced by the gates above.
+3. **Reading pass (fan-out) — the core of the audit.** Spawn one `Task`
+   subagent per feature area (each backend router, `domain/`, `services/`, the
+   models/schemas pair, each `frontend/src/features/*`, and the util/config
+   grab-bags). Hand each the full taxonomy and have it **read the actual
+   source** and return corroborated candidates for the linter-invisible
+   families: dead/stubbed/orphaned code, duplication (local and repo-wide),
+   architecture/layering violations, lying flags, verbosity, comment slop,
+   AI-slop tells, weak tests. Prioritize by the churn / largest-file lists in
+   the bundle. **Do not skip this for a single-threaded skim — that produces the
+   false "clean".**
+4. **Corroborate each survivor** against the Two-Signal Rule. For correctness
+   candidates, *write and run the reproducing test* in a throwaway location
+   (do not commit it — the implementing issue will own the real test). If it
+   doesn't reproduce, drop it.
+5. **Cluster.** Group corroborated findings by area/theme. A cluster that needs
+   coordinated, multi-file change becomes an **epic**; standalone findings
+   become single issues. Many Low findings in one file = one tidy-up issue.
+6. **Dedup against the backlog.** For every cluster/finding, search existing
+   open issues (`gh issue list`, `gh search issues`) and recent closed ones.
+   If it already exists, skip (optionally add a corroborating comment). Never
+   file a duplicate.
+7. **Size & file.** Apply `issue-templates.md`. Respect the ~200–300 LoC
+   sizing; split anything bigger into an epic + sub-issues in dependency order.
+8. **Report with a coverage ledger.** Emit a run summary (counts by severity,
+   what was filed, dropped and why, deduped) **plus a 13-row table — one per
+   taxonomy family — naming the areas examined and the verdict.** The ledger
+   proves the reading pass actually traversed the taxonomy. A clean verdict with
+   no ledger means the reading pass was skipped — that is a failed run, not a
+   clean one.
+
+---
+
+## Calibration: precision over recall
+
+This detector is tuned for **precision**. It is acceptable — expected, even —
+to miss real slop in a given week. It is **not** acceptable to file a finding
+that wastes an autonomous implementation cycle on a non-problem or, worse,
+"fixes" correct code into broken code.
+
+- If a finding's corroboration is shaky, **downgrade or drop it**.
+- If a "fix" would be opinionated/stylistic against repo convention, **drop it**.
+- If the evidence is a single tool hit with a known false-positive profile
+  (vulture on dynamic dispatch, magic-number grep on HTTP codes), **drop it**
+  unless a second signal confirms.
+- Prefer **few, ironclad, high-value** issues over a long list of maybes.

--- a/.claude/skills/de-slopify/references/issue-templates.md
+++ b/.claude/skills/de-slopify/references/issue-templates.md
@@ -1,0 +1,195 @@
+# Issue & Epic Templates — Filing De-Slop Work the Backlog Can Consume
+
+Findings become GitHub issues that **Ralph** picks up autonomously
+(`scripts/ralph/pick-next.sh`). To be picked up correctly, issues must follow
+the label and shape conventions below. Get this wrong and Ralph either ignores
+real work or tries to implement an epic as a single PR.
+
+---
+
+## How the Ralph picker treats labels (must-know)
+
+From `scripts/ralph/pick-next.sh`:
+
+- **Picks** the lowest-numbered open issue with **none** of these labels:
+  `epic wontfix duplicate invalid question blocked needs-spec future-work
+  do-not-auto-merge in-progress`.
+- An issue already referenced by an open PR's `Closes/Fixes/Resolves #N` is
+  treated as in-flight and skipped.
+
+**Consequences for de-slop filing:**
+
+- A **standalone finding** = a normal issue with **no** excluded label → Ralph
+  works it. ✅
+- An **epic** must carry the `epic` label → Ralph skips the umbrella and works
+  its decomposed sub-issues instead. ✅
+- A sub-issue that depends on an unbuilt predecessor should carry `blocked` (or
+  `needs-spec`) until its predecessor merges, so Ralph doesn't start it out of
+  order. The 10-tick `backlog-grooming` pass (or you, next run) removes the
+  label once the predecessor is done. Note the dependency as `Depends on #N` in
+  the body regardless.
+
+---
+
+## Standard labels this skill uses
+
+Create any that don't exist (`gh label create <name> --color <hex> --description ...`).
+
+| Label | Meaning | Color |
+|-------|---------|-------|
+| `de-slop` | Filed by the weekly de-slopify detector | `#5319e7` |
+| `epic` | Umbrella issue; Ralph skips, works sub-issues | `#3e4b9e` |
+| `priority-critical` / `priority-high` / `priority-medium` / `priority-low` | Severity from the rubric | red→grey |
+| `backend` / `frontend` / `full-stack` | Scope | tool-matched |
+| `bug` | Family 0 / 12 correctness finding (has a reproducing test) | `#d73a4a` |
+| `dead-code` | Family 3 dispensable | `#cfd3d7` |
+| `refactor` | Bloaters / couplers / verbosity | `#fbca04` |
+| `tech-debt` | Architecture / change-preventers | `#e99695` |
+| `security` | Family 10 (work itself defers to the `security` skill) | `#b60205` |
+| `tests` | Family 9 testing slop | `#0e8a16` |
+| `blocked` / `needs-spec` | Not ready for autonomous pickup | `#000000` |
+
+Keep labels minimal per issue: one severity + one scope + one category + `de-slop`.
+
+---
+
+## Template A — Standalone finding (single, atomic, Ralph-ready)
+
+Mirror the established `prompts/github-issues/*.md` shape so it's actionable
+without a single clarifying question. Title is imperative and specific.
+
+```markdown
+# <imperative title> (e.g. "Remove dead `legacy_streak()` and its orphaned test")
+
+**Labels:** `de-slop`, `<scope>`, `<category>`, `priority-<level>`
+**Detected by:** weekly de-slopify run <YYYY-MM-DD>
+**Severity:** <Critical|High|Medium|Low>
+
+## Problem
+<2-3 sentences. What's wrong, where. Cite file:line. State the taxonomy family.>
+**Current state:** <concrete observation>
+
+## Evidence (corroboration)
+- Signal 1: <reproducing artifact — test output / tsc error / query count / tool JSON>
+- Signal 2: <independent signal — grep result / second tool / reading>
+<Paste the minimal proof. This is what makes the finding trustworthy.>
+
+## Scope
+<1-2 sentences bounding what this covers and explicitly what it does NOT.>
+
+## Tasks
+1. <specific, actionable step with file paths>
+2. <...>
+
+## Acceptance Criteria
+- [ ] <testable, binary criterion tied to the evidence above>
+- [ ] No existing tests break; coverage stays ≥ 90%.
+- [ ] All pre-commit hooks pass (`pre-commit run --all-files`).
+
+## Files to Create/Modify
+| File | Action |
+|------|--------|
+| `path/to/file.py` | Modify / Delete / Create |
+```
+
+**Rule:** a standalone issue should be ~50–300 net LoC and touch ≤ ~5 files. If
+it's bigger, it's an epic.
+
+---
+
+## Template B — Epic (umbrella for coordinated, multi-issue work)
+
+Use when a corroborated problem needs more than one PR's worth of change
+(e.g. "decompose the 600-line `HabitsScreen`", "unify three divergent error
+contracts", "destub the aspirational encryption feature"). Mirrors the existing
+`prompts/github-issues/phase-*-epic.md` and `audit-destub` shape.
+
+```markdown
+# <Epic title> (e.g. "De-Slop: Decompose the HabitsScreen god-component")
+
+**Labels:** `de-slop`, `epic`, `<scope>`, `priority-<level>`
+**Detected by:** weekly de-slopify run <YYYY-MM-DD>
+
+## Why this is an epic
+<The corroborated problem and why it can't be one atomic PR. Cite evidence.>
+
+## Evidence (corroboration)
+<The tool output / metrics / reading that proves the problem is real.>
+
+## Target end state
+<What "done" looks like across all sub-issues — the architecture after.>
+
+## Decomposition (sub-issues, in dependency order)
+1. #<n> — <sub-issue title> — ~<LoC> — depends on: none
+2. #<n> — <sub-issue title> — ~<LoC> — depends on: #<prev>
+...
+
+## Dependency graph
+```
+sub-1 ──▶ sub-2 ──▶ sub-4
+   └────▶ sub-3 ────┘
+```
+
+## Non-goals
+<What this epic explicitly does not attempt.>
+```
+
+Then create each sub-issue with **Template A**, link them to the epic body, and
+(if GitHub sub-issues are available) attach them via `gh sub-issue` / the REST
+sub-issues API. Mark dependents `blocked` per the picker rule above.
+
+> The `triage-and-plan` skill is the heavy machinery for decomposing a large
+> area into a well-ordered epic of ~300-LoC issues. **Invoke it** when an epic
+> needs more than ~3 sub-issues — don't hand-roll a sprawling decomposition.
+
+---
+
+## `gh` filing recipes (file-based bodies, never inline strings)
+
+Write the body to a temp file in the scratchpad, then file it. This avoids shell
+quoting bugs and matches the repo's `git-workflow` convention.
+
+```bash
+SCRATCH="${SCRATCHPAD:-/tmp}"; BODY="$SCRATCH/deslop-issue.md"
+
+# Standalone finding
+cat > "$BODY" <<'EOF'
+## Problem
+...
+EOF
+gh issue create \
+  --title "Remove dead legacy_streak() and its orphaned test" \
+  --label de-slop --label backend --label dead-code --label priority-medium \
+  --body-file "$BODY"
+
+# Epic (capture its number to link sub-issues)
+EPIC_URL=$(gh issue create --title "De-Slop: Decompose HabitsScreen" \
+  --label de-slop --label epic --label frontend --label priority-high \
+  --body-file "$SCRATCH/deslop-epic.md")
+EPIC_NUM="${EPIC_URL##*/}"
+
+# Sub-issue referencing the epic
+gh issue create --title "Extract useHabits hook from HabitsScreen" \
+  --label de-slop --label frontend --label refactor --label priority-high \
+  --body-file "$SCRATCH/deslop-sub-1.md"   # body contains "Refs #$EPIC_NUM"
+```
+
+Dedup before every create:
+
+```bash
+gh issue list --state open --search "in:title <keywords>" --json number,title
+gh search issues --repo geoffe-ga/creek-vault "<keywords>" --state open
+```
+
+---
+
+## Filing checklist (every issue, before `gh issue create`)
+
+- [ ] Corroborated by ≥2 signals; evidence pasted into the body.
+- [ ] Not a duplicate of an open or recently-closed issue.
+- [ ] Not in the "NOT slop" guard list.
+- [ ] Correct labels: severity + scope + category + `de-slop` (+ `epic` if umbrella).
+- [ ] Title is imperative and specific; body is actionable without questions.
+- [ ] Sized right (standalone ≤ ~300 LoC / ≤ 5 files; else epic + sub-issues).
+- [ ] Dependencies noted (`Depends on #N`) and dependents labeled `blocked`.
+- [ ] Acceptance criteria are testable and tie back to the evidence.

--- a/.claude/skills/de-slopify/references/slop-taxonomy.md
+++ b/.claude/skills/de-slopify/references/slop-taxonomy.md
@@ -1,0 +1,270 @@
+# The Slop Taxonomy — An Exhaustive Field Guide to Sloppy and Amateurish Code
+
+This is the reference catalog the `de-slopify` skill scans against. It is the
+distilled answer to the question *"what does sloppy, amateurish, AI-generated,
+or otherwise low-quality code actually look like?"* — organized so a reviewer
+(human or agent) can systematically hunt for each species.
+
+It synthesizes several established sources and adapts them to Adepthood's
+FastAPI + React Native stack:
+
+- **Fowler & Beck**, *Refactoring* (2nd ed., 2018) — the canonical 22 smells,
+  grouped into Bloaters, OO-Abusers, Change-Preventers, Dispensables, Couplers.
+- **Mäntylä & Lassenius**, *Bad Code Smells Taxonomy* — the academic expansion.
+- **Robert C. Martin**, *Clean Code* — the heuristics (G1–G36, N1–N7, etc.).
+- **SonarSource / SonarQube** rule families — reliability, maintainability,
+  security-hotspot, cognitive-complexity.
+- **AI-slop literature (2024–2026)** — the failure modes specific to
+  LLM/agent-generated code (architectural drift, duplicated blocks, confident
+  wrongness, ceremonial comments, hallucinated APIs).
+
+> **How to use it.** Each entry has: a *name*, a *tell* (how it presents), and a
+> *corroboration hint* (what second signal makes it real vs. a false alarm).
+> Nothing here is filed as work on its own — see `detection-playbook.md` for the
+> evidence-and-corroboration gate every finding must pass.
+
+---
+
+## Family 0 — Correctness & Latent Bugs (the highest-value class)
+
+Slop that is not merely ugly but *wrong*. These get the highest severity because
+they cause incidents, not just friction.
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Off-by-one / boundary error** | `<=` vs `<`, `range(n)` vs `range(n+1)`, slice fence-posts | Write the failing test at the boundary value; if it fails, real. |
+| **Swallowed exception** | `except Exception: pass`, `catch {}`, `.catch(() => {})` with no rethrow/log | grep for bare excepts; confirm the error path is reachable and silently lost. |
+| **Broad except clause** | `except Exception:` / `except:` masking specific failures | ruff `BLE001`; confirm a narrower type exists. |
+| **Mutable default argument** | `def f(x=[])`, `def f(x={})` | ruff `B006`; trivially real. |
+| **Resource leak** | file/socket/session opened without `with`/`finally`/`close()` | trace the handle; confirm no context manager. |
+| **Async footgun** | un-awaited coroutine, blocking call in async path, `asyncio.run` in a running loop | ruff `RUF006`, `ASYNC*`; confirm with a runtime trace or test. |
+| **Race / shared-state mutation** | module-level mutable state mutated per-request; non-atomic check-then-act | concurrency reasoning + a stress test; corroborate, don't guess. |
+| **Floating-point / money in float** | currency or energy points stored as `float` | confirm rounding drift is observable. |
+| **Timezone-naive datetime** | `datetime.now()` without tz, naïve/aware mixing | ruff `DTZ*`; confirm comparison across tz. |
+| **TOCTOU / idempotency hole** | check-then-act without a lock or unique constraint; missing idempotency key TTL | reproduce the double-submit. |
+| **Unvalidated boundary input** | request body trusted without schema/length/range checks | confirm no Pydantic validator / no zod-equivalent. |
+| **Incorrect null/undefined handling** | `if (x)` truthiness bugs (`0`, `""`, `false`), `Optional` deref without guard | type-narrowing analysis + test. |
+| **SQL/ORM N+1 or missing filter** | query in a loop; `.all()` then filter in Python; missing tenant/user filter | log query count; the missing-filter case is also a security bug. |
+| **Wrong comparison** | `==` on objects/NaN, `is` on small ints/strings by luck, `assert` for control flow | confirm semantics differ from intent. |
+| **Silent type coercion** | implicit `str`↔`int`, JS `==`, truthy coercion | eslint `eqeqeq`; confirm a coercion path. |
+
+---
+
+## Family 1 — Bloaters (code that grew too big to reason about)
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Long Method / Function** | 50+ lines, scrolls past a screen, many responsibilities | radon CC grade ≥ C **and** a reviewer reading confirms multiple jobs. |
+| **Large Class / God Object** | a class/module that knows or does everything | LoC + fan-in/fan-out; confirm distinct responsibilities. |
+| **Long Parameter List** | 4+ positional params, especially booleans | ruff `PLR0913`; confirm a param object is natural. |
+| **Data Clumps** | the same 3+ fields travel together everywhere | grep the recurring tuple; confirm ≥3 call sites. |
+| **Primitive Obsession** | strings/ints where a value object belongs (ids, money, enums-as-strings) | confirm invariants are re-checked everywhere. |
+| **Long message chain / Train wreck** | `a.b().c().d().e()` | confirm Law-of-Demeter violation, not a fluent builder. |
+| **Combinatorial flag explosion** | functions whose behavior forks on many boolean params | count branches; confirm callers pass varied combos. |
+| **Deeply nested code** | 4+ levels of indentation, arrow-shaped code | cognitive-complexity / radon; confirm guard clauses would flatten it. |
+
+---
+
+## Family 2 — OO / Structure Abusers
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Switch/if-elif on type** | repeated `isinstance`/`type ==` ladders | confirm polymorphism or a dispatch table fits. |
+| **Refused Bequest** | subclass ignores/overrides most of parent | confirm the inheritance is wrong, not partial. |
+| **Temporary Field** | object field only set in some flows, null otherwise | trace lifecycle; confirm it's conditional state. |
+| **Alternative Classes, Different Interfaces** | two classes do the same job with different method names | confirm interchangeability. |
+| **Inappropriate Intimacy** | two modules reach into each other's privates | confirm tight coupling across a boundary. |
+| **Feature Envy** | a method uses another object's data more than its own | confirm the method belongs elsewhere. |
+| **Middle Man** | a class that only delegates | confirm it adds no value. |
+| **Hub-and-spoke god module** | everything imports one util grab-bag | import graph fan-in; confirm it should be split. |
+
+---
+
+## Family 3 — Dispensables (code that should not exist)
+
+This family is the heart of "de-slopping." It is where dead, stubbed, orphaned,
+and duplicated code lives.
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Dead code** | unreachable branches, unused functions/classes/vars, unused imports | **vulture** (Python) / **eslint+ts** (frontend) **and** a grep proving zero references (incl. dynamic/string refs, routers, DI). |
+| **Commented-out code** | blocks of `# old impl ...` / `// ...` left in | grep; trivially real — delete, git remembers. |
+| **Stubbed / hollow implementation** | `raise NotImplementedError`, `pass`, `return None  # TODO`, `return []` placeholder, `throw new Error('not implemented')`, a function whose body is a single `...` | grep + confirm it's referenced as if real (a stub nobody calls is dead code; a stub callers depend on is a **lie** — higher severity). |
+| **Fake/aspirational feature flag** | a flag/docstring/comment claiming a guarantee the code doesn't deliver (e.g. "encrypted at rest" with plaintext writes) | trace the claim to the implementation; confirm the gap. This is the `audit-destub` pattern — see that epic. |
+| **Orphaned code** | files/modules nothing imports; routes never mounted; assets never referenced; tests for deleted features | dependency graph + grep; confirm zero inbound edges. |
+| **Duplicated code** | copy-pasted blocks, parallel near-identical functions | structural duplication scan + diff the blocks; confirm ≥ N tokens identical across ≥2 sites. |
+| **Speculative generality** | abstractions/params/hooks "for the future" with one caller | confirm a single implementation/caller; YAGNI. |
+| **Lazy class** | a class/module that doesn't pull its weight | confirm it can be inlined. |
+| **Data class (anemic)** | a bag of fields with no behavior where behavior belongs | confirm logic is scattered across users. |
+| **Dead config / deps** | declared dependencies never imported; env vars never read; settings never used | grep usage of each; confirm zero references. |
+| **Redundant test** | tests asserting framework behavior, tautologies, `assert True`, snapshot-only with no logic | confirm it would survive a logic mutation (see mutation-testing). |
+
+---
+
+## Family 4 — Change-Preventers (code that makes change expensive)
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Divergent Change** | one module changed for many unrelated reasons | git churn + confirm distinct change-reasons in history. |
+| **Shotgun Surgery** | one logical change forces edits in many files | trace a representative change; confirm scatter. |
+| **Parallel inheritance hierarchies** | adding a subclass here forces one there | confirm the lock-step. |
+| **Implicit cross-layer coupling** | frontend type silently depends on backend shape with no shared contract | confirm a schema mismatch is possible. |
+
+---
+
+## Family 5 — Couplers & Architecture
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Circular dependency** | module A imports B imports A | import-graph cycle detection; trivially real once found. |
+| **Layering violation** | router does DB access directly; domain imports web framework; model imports a router | confirm the dependency crosses a layer the wrong way. |
+| **Business logic in the wrong tier** | validation/energy/streak math inside a route handler or a React component | confirm it belongs in `domain/`. |
+| **Leaky abstraction** | callers must know internal details to use a thing safely | confirm the contract is insufficient. |
+| **Global mutable singleton** | module-level caches/state mutated across requests | confirm request-to-request bleed. |
+| **Missing seam / untestable design** | logic that can't be tested without network/clock/db because it hard-codes them | confirm no injection point exists. |
+| **Inconsistent error contract** | endpoints return errors in different shapes/status codes | diff error responses across routers. |
+| **Architectural drift (AI-era)** | the same concept implemented 3 ways because each was generated fresh | find the divergent implementations; confirm they should be one. |
+
+---
+
+## Family 6 — Naming, Readability & Comment Slop
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Meaningless names** | `data`, `data2`, `tmp`, `obj`, `foo`, `handleStuff`, `x1` | confirm the name doesn't reveal intent. |
+| **Misleading names** | name says one thing, code does another; `get_*` that mutates | confirm semantic mismatch (a real bug risk). |
+| **Inconsistent vocabulary** | `fetch`/`get`/`load`/`retrieve` for the same concept | confirm same operation, different words. |
+| **Ceremonial / restating comments** | `# increment i by 1` above `i += 1`; `// constructor`; docstrings that restate the signature | grep comment-to-code ratio; confirm zero added information. |
+| **Stale / lying comments** | comment describes behavior the code no longer has | confirm divergence from code. |
+| **Banner / ASCII-art noise** | `#########` dividers, decorative boxes | cosmetic; bundle, don't file alone. |
+| **Over-explaining the obvious** | paragraph docstring on a one-line getter | confirm verbosity without value. |
+| **AI-tell comments** | "Note: this is a placeholder", "In a real implementation...", "This should probably...", "As an AI..." | grep; these flag unfinished/uncertain code — pair with the code they describe. |
+| **Commented apologies / TODO/FIXME/HACK/XXX** | debt markers left in tree | grep; triage each — actionable now ⇒ file it. |
+
+---
+
+## Family 7 — Verbosity & Needless Complexity
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Reinventing the stdlib** | hand-rolled `groupby`, manual `dict.get` chains, custom date math | confirm a standard/idiomatic one-liner exists. |
+| **Yoda / redundant conditionals** | `if x == True`, `if len(xs) > 0`, `return True if c else False`, `x if x else y` | ruff `SIM*`; trivially real. |
+| **Unnecessary intermediate variables / indirection** | single-use vars, wrapper functions that only call one thing | confirm inlining clarifies. |
+| **Defensive over-checking** | re-validating invariants already guaranteed; double null-checks | confirm the guard is unreachable. |
+| **Premature / cargo-cult optimization** | micro-opts that obscure intent with no measured need | confirm no profiling justified it. |
+| **Verbose boilerplate that a helper would kill** | the same 6-line try/except/log repeated everywhere | confirm a decorator/util fits. |
+| **Wall-of-code config** | giant literal dicts/objects that should be data files | confirm it belongs in config/fixtures. |
+| **Over-abstraction** | factories-of-factories, 5 layers to do one thing | confirm fewer layers suffice. |
+
+---
+
+## Family 8 — Type-Safety & Contract Erosion
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Escape hatches** | `# type: ignore`, `// @ts-ignore`, `// eslint-disable`, `# noqa`, `cast(Any, ...)` without justification | grep; confirm no linked issue justifies it (CLAUDE.md bans unjustified ones). |
+| **`Any` / `unknown` creep** | `Any` params/returns, `as any`, untyped dicts crossing boundaries | mypy/tsc; confirm a real type is knowable. |
+| **Loose assertions** | `as Foo` casts that bypass checks, non-null `!` operator overuse | confirm the cast can be wrong at runtime. |
+| **Frontend/backend shape drift** | TS type and Pydantic schema for the same payload disagree | diff the two; confirm a field/optionality mismatch. |
+| **Missing annotations** | public functions without signatures (where strict mode allows) | mypy/tsc strict gaps. |
+
+---
+
+## Family 9 — Testing Slop
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Coverage theater** | high % but assertions are weak/absent | mutation testing — does a logic flip survive? |
+| **Tests that never fail** | `assert True`, asserting mocks were called but not outcomes, snapshot-only | confirm no behavioral assertion. |
+| **Over-mocking** | mocking the unit under test; testing the mock | confirm the real behavior isn't exercised. |
+| **Missing edge/error-path tests** | only happy path covered | coverage of error branches; confirm gaps. |
+| **Flaky tests** | time/order/network dependent | confirm nondeterminism source. |
+| **Commented-out / skipped tests** | `@pytest.mark.skip`, `xit`, `it.skip` without an issue ref | grep; CLAUDE.md requires a justification. |
+
+---
+
+## Family 10 — Security & Safety Slop
+
+(Defer deep work to the `security` skill; this catalog only flags candidates.)
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Hardcoded secret/credential** | API keys, tokens, passwords in source | detect-secrets / gitleaks; confirm it's a live secret shape. |
+| **Injection vector** | string-built SQL, `eval`, `exec`, shell with user input, `dangerouslySetInnerHTML` | bandit / eslint; confirm user input reaches the sink. |
+| **Missing authz check** | endpoint mutates another user's data without ownership check | trace the handler; confirm no guard. |
+| **Permissive CORS / wildcard** | `allow_origins=["*"]` with credentials | confirm config. |
+| **Weak crypto / homemade auth** | md5/sha1 for passwords, custom token signing | confirm the primitive. |
+| **Sensitive data in logs** | logging tokens, PII, journal contents | grep log calls near sensitive fields. |
+| **Vulnerable dependency** | pinned dep with a known CVE | pip-audit / npm audit (defer fix to `cve-remediation`). |
+
+---
+
+## Family 11 — Dependency, Build & Config Hygiene
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Unused dependency** | declared in requirements/package.json, never imported | grep imports; confirm zero use. |
+| **Phantom dependency** | imported but not declared | confirm import without a manifest entry. |
+| **Duplicate / conflicting config** | two tools configured for the same job, contradicting | confirm overlap. |
+| **Magic numbers / strings** | unexplained literals (`* 86400`, `0.7`, status codes) | confirm a named constant adds meaning. |
+| **Environment-coupled code** | hard-coded localhost/paths/ports | confirm it breaks outside dev. |
+| **Copy-pasted config drift** | the same setting set differently in N places | diff the values. |
+
+---
+
+## Family 12 — AI-Slop-Specific Patterns (2024–2026)
+
+LLM/agent-generated code has characteristic failure modes worth hunting
+explicitly. (Sources: AI-slop research catalogs; SpecDetect4AI; empirical
+studies of LLM-generated code.)
+
+| Smell | The tell | Corroboration hint |
+|-------|----------|--------------------|
+| **Confident wrongness** | plausible code that compiles and reads well but is subtly incorrect | only filed with a reproducing test — never on vibes. |
+| **Hallucinated API / import** | calls to functions/params/endpoints that don't exist | tsc/mypy/import error; trivially real if it doesn't resolve. |
+| **Reinvented existing helper** | a fresh utility duplicating one already in the repo | grep for the existing helper; confirm overlap. |
+| **Ceremonial scaffolding** | elaborate structure (interfaces, abstract bases) around trivial logic | confirm the ceremony exceeds the need. |
+| **Explanatory-comment spam** | every line narrated; docstrings restating types | comment density metric. |
+| **"In a real implementation" stubs** | placeholder bodies with apologetic comments | grep AI-tell phrases. |
+| **Inconsistent-with-house-style** | code that ignores the repo's established patterns (e.g. not using `Depends(get_session)`) | compare to the canonical pattern in CLAUDE.md. |
+| **Defensive sludge** | redundant try/except, re-checking guaranteed invariants, belt-and-suspenders nobody asked for | confirm unreachable defenses. |
+| **Over-broad error handling that hides bugs** | catch-all that turns a crash into a wrong-but-silent result | confirm a real failure is masked. |
+
+---
+
+## Severity rubric
+
+Assign each corroborated finding a severity. This maps to issue labels and to
+how aggressively Ralph should pick it up.
+
+| Severity | Definition | Examples |
+|----------|------------|----------|
+| **Critical** | Causes data loss, security breach, or user-facing breakage now | live secret, missing authz, injection, swallowed error on a write path, a stub callers depend on |
+| **High** | Latent correctness bug, architectural debt that compounds, lying feature flag | off-by-one behind a flag, N+1 on a hot path, circular dep, frontend/backend shape drift |
+| **Medium** | Maintainability tax, real dead/duplicated code, weak tests | god function, duplicated block, coverage theater, dead module |
+| **Low** | Readability, naming, comment slop, cosmetic verbosity | ceremonial comments, meaningless names, redundant conditionals |
+
+**Bundling rule:** many Low findings in one file/area = one tidy-up issue, not
+twenty. Don't death-by-a-thousand-issues the backlog.
+
+---
+
+## What is explicitly NOT slop (false-positive guards)
+
+The detector must *not* file these. Treating them as findings is itself slop.
+
+- **Intentional, documented simplicity** — a small function is not a "lazy class."
+- **Justified suppressions** — a `# type: ignore[...]` or `// eslint-disable`
+  with a linked issue and a real reason is allowed by CLAUDE.md. Leave it.
+- **Test fixtures and factories** — duplication and "magic" values in tests are
+  often deliberate and readable.
+- **Generated code / vendored files / migrations** — Alembic migrations,
+  `package-lock.json`, build output. Out of scope.
+- **Framework-required boilerplate** — Pydantic models, SQLModel tables, React
+  Navigation config have irreducible shape.
+- **Domain constants that are self-explanatory** — `status_code=404`, `HTTP_200`.
+- **Style the repo has deliberately chosen** — match CLAUDE.md/AGENTS.md, not a
+  generic ideal.
+- **Speculative "could be faster"** without a measurement — premature.
+- **Anything you can't corroborate** — if the second signal isn't there, it's a
+  hypothesis, not a finding. Drop it.

--- a/.claude/skills/de-slopify/scripts/collect-evidence.sh
+++ b/.claude/skills/de-slopify/scripts/collect-evidence.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# collect-evidence.sh — read-only slop-evidence collector for the de-slopify skill.
+#
+# Runs the repo's existing static-analysis toolbox plus grep heuristics and
+# writes every raw result into an output directory. It NEVER modifies tracked
+# files and NEVER fails the run because a single tool is missing or unhappy —
+# each tool's exit status is captured, not propagated, so the agent always gets
+# a complete evidence bundle to corroborate against.
+#
+# Usage:
+#   scripts/collect-evidence.sh [OUTPUT_DIR]
+#
+# OUTPUT_DIR defaults to "$SCRATCHPAD/deslop-evidence" if SCRATCHPAD is set,
+# else a mktemp dir. The chosen directory is printed on the last line so a
+# caller can capture it:  EVID=$(scripts/collect-evidence.sh | tail -1)
+#
+# Exit codes: 0 always (collection is best-effort). 2 only on a setup error
+# (no git repo / cannot create output dir).
+
+set -uo pipefail
+
+# --- locate the repo root (this script lives in .claude/skills/de-slopify/scripts) ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+if [[ ! -d "$REPO_ROOT/.git" ]]; then
+  echo "collect-evidence: not a git repo at $REPO_ROOT" >&2
+  exit 2
+fi
+cd "$REPO_ROOT" || exit 2
+
+# --- output dir ---
+OUT="${1:-${SCRATCHPAD:+$SCRATCHPAD/deslop-evidence}}"
+if [[ -z "$OUT" ]]; then
+  OUT="$(mktemp -d)"
+fi
+if ! mkdir -p "$OUT"; then
+  echo "collect-evidence: cannot create output dir $OUT" >&2
+  exit 2
+fi
+
+# Python source roots in this monorepo (only the ones that exist are scanned).
+# creek-tools is a flat-layout package (creek/, creek_mcp/), and crawdad is the
+# Discord-bot subproject (crawdad/crawdad/). There is no frontend.
+PY_DIRS=()
+for d in creek-tools/creek creek-tools/creek_mcp crawdad/crawdad; do
+  [[ -d "$d" ]] && PY_DIRS+=("$d")
+done
+# Shared tool config + dependency manifest live under creek-tools.
+PY_CONFIG="creek-tools/pyproject.toml"
+PY_REQS="creek-tools/requirements.txt"
+
+log() { echo ">>> $*" >&2; }
+
+# Activate the project venv if present (so backend tools resolve).
+if [[ -f .venv/bin/activate ]]; then
+  # shellcheck disable=SC1091
+  source .venv/bin/activate
+fi
+
+# run <outfile> <cmd...> — run a tool, capture stdout+stderr and exit code,
+# never abort the script. Skips gracefully if the binary is absent.
+run() {
+  local out="$1"; shift
+  local bin="$1"
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "SKIPPED: $bin not installed" >"$OUT/$out"
+    log "skip $bin (not installed)"
+    return 0
+  fi
+  log "run $*"
+  if "$@" >"$OUT/$out" 2>&1; then
+    echo "[exit 0]" >>"$OUT/$out"
+  else
+    echo "[exit $?]" >>"$OUT/$out"
+  fi
+  return 0
+}
+
+# ----------------------------------------------------------------------------
+# Python — read-only analysis (creek-tools + crawdad)
+# ----------------------------------------------------------------------------
+if [[ ${#PY_DIRS[@]} -gt 0 ]]; then
+  run ruff.json            ruff check "${PY_DIRS[@]}" --config="$PY_CONFIG" --output-format=json
+  run vulture.txt          vulture "${PY_DIRS[@]}" --min-confidence 80
+  run radon-cc.txt         radon cc "${PY_DIRS[@]}" -s -n C
+  run radon-mi.txt         radon mi "${PY_DIRS[@]}" -s
+  run mypy.txt             mypy "${PY_DIRS[@]}" --config-file="$PY_CONFIG"
+  run bandit.json          bandit -r "${PY_DIRS[@]}" -f json -c "$PY_CONFIG"
+  run interrogate.txt      interrogate "${PY_DIRS[@]}" -v
+  run pip-audit.txt        pip-audit -r "$PY_REQS"
+  run detect-secrets.txt   detect-secrets scan "${PY_DIRS[@]}"
+fi
+
+# ----------------------------------------------------------------------------
+# Cross-cutting grep heuristics (candidates only — need a 2nd signal)
+# ----------------------------------------------------------------------------
+GREP_BIN="grep"
+GREP_FLAGS=(-rnE)
+if command -v rg >/dev/null 2>&1; then
+  GREP_BIN="rg"
+  GREP_FLAGS=(-n)
+fi
+SEARCH_PATHS=("${PY_DIRS[@]}")
+
+greps() {
+  local out="$1" pat="$2"
+  if [[ ${#SEARCH_PATHS[@]} -eq 0 ]]; then return 0; fi
+  "$GREP_BIN" "${GREP_FLAGS[@]}" "$pat" "${SEARCH_PATHS[@]}" >"$OUT/$out" 2>/dev/null \
+    || echo "(no matches)" >"$OUT/$out"
+}
+
+greps grep-stubs.txt        'NotImplementedError|not implemented|throw new Error\(.?not implemented|return None\s*#\s*TODO|\bpass\s*#\s*(stub|placeholder)'
+greps grep-ai-tells.txt     'In a real implementation|real implementation|placeholder|for now|as an AI|should probably'
+greps grep-debt.txt         'TODO|FIXME|HACK|XXX'
+greps grep-escape-hatch.txt 'type: ?ignore|@ts-ignore|@ts-nocheck|eslint-disable|# ?noqa|cast\(Any'
+greps grep-swallow.txt      'except (Exception|BaseException)?\s*:|catch\s*\([^)]*\)\s*\{\s*\}|\.catch\(\(\)\s*=>\s*\{?\s*\}?\)'
+greps grep-commented.txt    '^\s*#\s*(def |class |return |if |for |while |import |from )'
+greps grep-any.txt          ':\s*any\b|<any>|as any'
+
+# Git churn / hotspots (top 30 most-changed files in the last 90 days).
+if command -v git >/dev/null 2>&1; then
+  git log --since="90 days ago" --format= --name-only 2>/dev/null \
+    | grep -E '^(creek-tools|crawdad)/' \
+    | sort | uniq -c | sort -rn | head -30 >"$OUT/churn.txt" 2>/dev/null \
+    || echo "(churn unavailable)" >"$OUT/churn.txt"
+fi
+
+# Reading targets: the largest source files by line count. These — together
+# with churn.txt — are where the reading pass should start, because size and
+# change-frequency are where bloaters, duplication, and god-objects accumulate.
+{
+  echo "# Largest source files (LoC) — prime reading-pass targets"
+  if [[ ${#SEARCH_PATHS[@]} -gt 0 ]]; then
+    find "${SEARCH_PATHS[@]}" -type f \
+      -name '*.py' \
+      -not -path '*/node_modules/*' -print0 2>/dev/null \
+      | xargs -0 wc -l 2>/dev/null | sort -rn | sed '/ total$/d' | head -30
+  fi
+} >"$OUT/reading-targets.txt"
+
+# ----------------------------------------------------------------------------
+# Manifest
+# ----------------------------------------------------------------------------
+{
+  echo "# De-Slop Evidence Bundle"
+  echo "Repo:    $REPO_ROOT"
+  echo "Out:     $OUT"
+  echo
+  echo "## Files"
+  ls -1 "$OUT" | sed 's/^/  - /'
+  echo
+  echo "Each *.json / *.txt holds raw tool or grep output. Every entry is a"
+  echo "CANDIDATE only — apply the Two-Signal Rule from detection-playbook.md"
+  echo "before filing anything. Tool exit codes are appended as [exit N]."
+  echo
+  echo "## IMPORTANT — this bundle is a MAP, not the findings"
+  echo "The linter outputs (ruff/mypy/radon/bandit/eslint/tsc) are TABLE STAKES:"
+  echo "the repo already passes them in pre-commit and CI, so they cannot be"
+  echo "findings. Do NOT file complexity grades, lint rules, or type errors."
+  echo "Use churn.txt + reading-targets.txt to drive a Task fan-out that READS"
+  echo "the source for what linters cannot see (dead/stubbed/orphaned code,"
+  echo "duplication, architecture, lying flags, verbosity, comment slop, AI"
+  echo "tells, weak tests). That reading pass is the actual audit."
+} >"$OUT/README.txt"
+
+log "evidence collected in $OUT"
+echo "$OUT"

--- a/.github/workflows/ralph-recap-tests.yml
+++ b/.github/workflows/ralph-recap-tests.yml
@@ -1,0 +1,35 @@
+name: Ralph Recap Tests
+
+# Unit tests for the Ralph recap tooling (scripts/ralph/). The recap scripts
+# live outside backend/, so the backend-scoped lint/coverage gates don't cover
+# them — this workflow keeps the pure stats math and the backlog filter honest.
+
+on:
+  push:
+    paths:
+      - "scripts/ralph/**"
+      - ".github/workflows/ralph-recap-tests.yml"
+  pull_request:
+    paths:
+      - "scripts/ralph/**"
+      - ".github/workflows/ralph-recap-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  recap-tests:
+    name: Recap unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run recap tests
+        run: python -m pytest scripts/ralph -q

--- a/.github/workflows/ralph-recap.yml
+++ b/.github/workflows/ralph-recap.yml
@@ -1,0 +1,50 @@
+name: Ralph Recap
+
+# Posts a Ralph tick-loop recap to Discord every time a pull request is merged.
+#
+# Required configuration in the repo:
+#   secret   DISCORD_BOT_TOKEN  - bot token with Send Messages on the channel
+#   secret   RALPH_CHANNEL_ID   - target Discord channel ID (all digits)
+#   secret   ANTHROPIC_API_KEY  - optional; enables the Claude-written headline
+#
+# Each value is read from `secrets` first, falling back to a same-named repo
+# `vars` entry, so it resolves whether you store it as a Secret or a Variable.
+#
+# The built-in GITHUB_TOKEN supplies the merge history (read-only). See
+# scripts/ralph/RECAP.md for setup, the metric definitions, and tuning.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  recap:
+    name: Post merge recap
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Anthropic SDK (for the headline)
+        # Pinned floor guarantees the installed SDK supports output_config /
+        # effort (used by generate_headline); a fresh install resolves to the
+        # newest release in range.
+        run: pip install 'anthropic>=0.69,<1'
+
+      - name: Post Ralph recap to Discord
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISCORD_BOT_TOKEN: ${{ secrets.DISCORD_BOT_TOKEN || vars.DISCORD_BOT_TOKEN }}
+          RALPH_CHANNEL_ID: ${{ secrets.RALPH_CHANNEL_ID || vars.RALPH_CHANNEL_ID }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || vars.ANTHROPIC_API_KEY }}
+        run: |
+          python scripts/ralph/recap.py --repo "${{ github.repository }}"

--- a/.github/workflows/weekly-deslop.yml
+++ b/.github/workflows/weekly-deslop.yml
@@ -1,0 +1,151 @@
+name: Weekly De-Slop
+
+# Runs the `de-slopify` skill on a schedule: a comprehensive, evidence-based
+# code-quality audit that files corroborated findings as Ralph-ready GitHub
+# issues (and decomposed epics for large work). It NEVER writes to the repo —
+# the job's GITHUB_TOKEN is `contents: read` / `issues: write`, so the only
+# durable output is new issues. False positives are the enemy: the skill files
+# nothing it cannot corroborate with two independent signals, and a clean run
+# (zero issues) is a valid, expected outcome.
+#
+# Trigger: every Sunday 00:00 America/Los_Angeles, or manually via the Actions
+# tab.
+#
+# Required configuration:
+#   secret  CLAUDE_CODE_OAUTH_TOKEN  - same token the other Claude workflows use.
+
+on:
+  schedule:
+    # Sundays at 08:00 UTC == Sunday 00:00 PST (midnight Pacific). GitHub cron is
+    # UTC with no DST handling, so during PDT (summer) this lands at 01:00 PT.
+    # GitHub may also delay scheduled runs under load.
+    - cron: "0 8 * * 0"
+  workflow_dispatch:
+    inputs:
+      focus:
+        description: "Optional area to focus the audit on (e.g. 'creek-tools/creek/classify', 'crawdad'). Blank = whole repo."
+        required: false
+        default: ""
+
+# Avoid overlapping audits.
+concurrency:
+  group: weekly-deslop
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  # OIDC token for the claude action's auth exchange (mirrors claude.yml).
+  id-token: write
+
+jobs:
+  deslop:
+    name: Detect slop and file backlog issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository (full history for churn analysis)
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Full history so git-churn / hotspot detection has signal.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install creek-tools toolbox (read-only analyzers)
+        run: |
+          python -m venv .venv
+          # shellcheck disable=SC1091
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          # Editable install of creek-tools with all + dev extras provisions the
+          # read-only analyzers the evidence collector runs (ruff, mypy, radon,
+          # xenon, bandit[toml], vulture, interrogate, pip-audit, detect-secrets).
+          pip install -e "creek-tools/.[all,dev]"
+
+      - name: Run de-slopify audit
+        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0  # v1.0.158
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Surface the agent's transcript in the run log so the audit is
+          # auditable: you can verify the skill was invoked and the whole
+          # taxonomy traversed. Safe on a private repo with read-only contents.
+          show_full_output: true
+
+          # The skill files issues via gh; expose the analyzers it relies on.
+          # Security boundary is the job's GITHUB_TOKEN (contents: read /
+          # issues: write) — Claude cannot push code, only open issues.
+          #
+          # --model opus: this is a judgment-heavy audit (architecture,
+          #   duplication, AI-slop, verbosity) — Sonnet, the action default,
+          #   ran the first audit too leniently. Opus does the deep reading.
+          # --max-turns 240: a real reading pass fans out across every feature
+          #   area; the lean 80-turn budget bailed out after a shallow scan.
+          claude_args: >-
+            --allowed-tools "Bash,Read,Grep,Glob,Write,Skill,Task"
+            --model opus
+            --max-turns 240
+
+          prompt: |
+            Run a comprehensive weekly code-quality audit of this repository
+            using the `de-slopify` skill. Invoke the skill and follow its
+            instructions exactly.
+
+            Focus area (blank means the whole repo): "${{ github.event.inputs.focus }}"
+
+            Linters are TABLE STAKES, not the audit. This repo already passes
+            ruff, mypy (strict), radon, xenon, bandit, and interrogate in
+            pre-commit and CI on every commit, so anything those tools gate is
+            ALREADY enforced
+            and CANNOT be a finding — do not report complexity grades, lint
+            rules, or type errors as slop. Your value is the slop those tools
+            are blind to: dead/stubbed/orphaned code, duplication, bad
+            architecture and layering violations, lying feature flags, needless
+            verbosity, comment slop, AI-generated tells, and weak/coverage-
+            theater tests. Finding those requires READING THE CODE, not parsing
+            tool JSON. The evidence bundle is a starting map, not the territory.
+
+            Mandatory reading pass (this is what was skipped last time): after
+            collecting evidence, fan out with the Task tool — spawn a subagent
+            per feature area (the creek-tools/creek pipeline stages — ingestion,
+            classification, linking, voice — plus creek_mcp and the crawdad
+            Discord bot) that actually READS the source against the full
+            13-family taxonomy in references/slop-taxonomy.md and reports
+            corroborated candidates. Do not conclude "clean" from a 5-minute
+            single-threaded scan of linter output.
+
+            Hard requirements (the skill enforces these — do not deviate):
+            - Corroborate every finding with TWO independent signals before
+              filing. For any correctness/bug claim, write and run a reproducing
+              test first; if it does not reproduce, DROP the finding.
+            - Discard everything in the skill's NOT-slop guard list (generated
+              code, migrations, lockfiles, justified suppressions, framework
+              boilerplate, test fixtures, deliberate conventions).
+            - Dedup against existing open and recently-closed issues before
+              filing anything (`gh issue list`, `gh search issues`).
+            - File standalone findings as Ralph-ready issues (Template A) and
+              large coordinated work as an `epic`-labeled umbrella with
+              decomposed sub-issues (Template B); use the `triage-and-plan`
+              skill when an epic needs more than ~3 sub-issues.
+            - Create any missing labels first. Write issue bodies to files and
+              file with `gh issue create --body-file`.
+            - A run that files NOTHING because the code is clean is a SUCCESS.
+              Do not invent work to look productive.
+
+            End by writing a concise run summary to the GitHub Actions job
+            summary — append it to the file at $GITHUB_STEP_SUMMARY (e.g.
+            `cat >> "$GITHUB_STEP_SUMMARY"`) — containing: counts by severity,
+            issues/epics filed (with numbers), findings dropped and why,
+            findings deduped, AND a coverage ledger: a table with one row per
+            taxonomy family (all 13) listing which areas/files you examined for
+            it and the verdict (clean / candidates / filed). The ledger is how
+            we verify the whole taxonomy was actually traversed rather than
+            assumed clean. This is the durable record, linked to the workflow
+            run, and never touches the issue tracker. A clean run (nothing
+            filed) writes "codebase is clean against the taxonomy this week" to
+            the job summary and files NO issue. Only open a separate `de-slop` +
+            `report` issue when at least one finding was filed — never on a clean
+            run (a weekly report issue every Monday would flood the tracker).

--- a/scripts/ralph/RECAP.md
+++ b/scripts/ralph/RECAP.md
@@ -1,0 +1,176 @@
+# Ralph Discord Recap
+
+Whenever a PR merges, this posts a clean Discord embed in two blocks —
+`————THIS PR————` (the just-merged PR: its unlock headline, link, footprint,
+review iterations, review time, and tick length) and `————THE LOOP————` (the
+rolling/all-time figures: busiest day, PRs merged, lines of code, merge rate,
+review iterations, review time, tick length, and backlog remaining). Within each
+block, multi-window stats run smallest window first (24h → 7d → all-time).
+
+A "Ralph tick loop" is the autonomous loop driven by `/loop /ralph-tick` (see
+`.claude/commands/ralph-tick.md`): each tick opens a PR, iterates against the
+Claude reviewer's `Verdict:` comment until LGTM, merges, and moves to the next
+backlog issue. This tool turns that merge history into a recap.
+
+Adapted from the `discord-ralph-recap` skill in
+[`Geoffe-Ga/well-worn-tools` PR #14](https://github.com/Geoffe-Ga/well-worn-tools/pull/14).
+
+## Files
+
+```
+scripts/ralph/
+├── recap.py             # I/O shell: fetch GitHub data, generate headline, post embed
+├── stats.py             # pure, unit-tested statistics math
+├── test_recap_stats.py  # tests for stats.py + the backlog filter
+└── RECAP.md             # this file
+.github/workflows/
+├── ralph-recap.yml        # fires on every merged PR → posts the recap
+└── ralph-recap-tests.yml  # runs the unit tests on changes under scripts/ralph/
+```
+
+## What you need
+
+- `DISCORD_BOT_TOKEN` (repo **secret**) — a Discord bot token. The bot must be
+  in the server with **View Channel** + **Send Messages** on the target channel.
+- `RALPH_CHANNEL_ID` (repo **secret** or **variable**) — the target channel's
+  numeric ID (Developer Mode → right-click channel → Copy Channel ID). The
+  workflow reads `secrets` first and falls back to `vars`, so either store works.
+- A GitHub token — in Actions the built-in `GITHUB_TOKEN` is enough
+  (`contents: read`, `pull-requests: read`, `issues: read`).
+- `ANTHROPIC_API_KEY` (repo **secret**, optional) — enables the Claude-written
+  ten-word headline. Without it the headline falls back to a cleaned PR title
+  and nothing else changes.
+
+## Setup
+
+The workflow is keyed on `pull_request: types: [closed]`, gated to merges with
+`if: github.event.pull_request.merged == true`. (`closed` fires on both merge
+and plain close; the guard keeps it to real merges. A `push: branches: [main]`
+trigger would wrongly fire on hotfixes and reverts too.)
+
+Wire the secrets once (`RALPH_CHANNEL_ID` can be a `gh variable set` instead —
+the workflow accepts either):
+
+```bash
+gh secret set DISCORD_BOT_TOKEN
+gh secret set RALPH_CHANNEL_ID    # or: gh variable set RALPH_CHANNEL_ID --body "1234..."
+gh secret set ANTHROPIC_API_KEY   # optional, for the headline
+```
+
+The next merged PR triggers the first recap. Each post is self-contained — no
+state is stored between runs; every recap is recomputed from the live history.
+
+## Dry-run / one-off from the terminal
+
+`--dry-run` prints the embed JSON instead of posting it:
+
+```bash
+DISCORD_BOT_TOKEN=unused RALPH_CHANNEL_ID=unused \
+GITHUB_TOKEN="$(gh auth token)" \
+python scripts/ralph/recap.py --repo Geoffe-Ga/adepthood --dry-run
+```
+
+Drop `--dry-run` (with a real `DISCORD_BOT_TOKEN` / `RALPH_CHANNEL_ID`) to post
+once manually — handy for backfilling after enabling the bot mid-campaign.
+
+## Metric definitions
+
+All math is pure and unit-tested in `stats.py`; all I/O is in `recap.py`.
+
+The headline **PRs merged** total is all-time; the activity and quality stats
+below cover a trailing **7-day window** (`RECENT_WINDOW_DAYS`) so they move with
+recent work instead of being diluted by a frozen lifetime average. The window is
+fetched via the search API (`is:pr is:merged merged:>=<date>`), capped at
+`--max-prs` (default 200) as a safety bound on a burst day.
+
+- **PRs merged** — "in 24h" and "in 7d" counts from the window, then the true
+  cumulative all-time count from the search API (`total_count`), which is
+  independent of any per-run fetch cap (smallest window first).
+- **LoC** — lines-of-code churn as `+additions / -deletions` over the trailing
+  24h and 7d windows (summed from each window PR's detail call), then the
+  **full-repo net** from GitHub's code-frequency stats API
+  (`/stats/code_frequency`, additions − deletions across all history). The stats
+  endpoint warms asynchronously and answers 202 on a cold cache, so the full-repo
+  figure retries a few times and falls back to "—" if still unavailable.
+- **Merge rate** — rolling windows: merges in the last 24h as **per-hour**, and
+  merges in the last 7 days as **per-day**. Fixed-width windows move every recap
+  and decay toward zero when the loop idles. The 7-day per-day figure (steadier
+  than the 24h one) is what the backlog ETA is built on.
+- **Review iterations before LGTM** (7d) — per merged PR in the window, issue
+  comments are read oldest-first and a comment counts as a verdict only if it
+  contains `VERDICT` (case-insensitive), matching `iteration-trigger.yml`. The
+  count is the number of non-LGTM verdicts preceding the first LGTM. PRs that
+  never reached an LGTM verdict are excluded. The embed shows avg rounds,
+  first-try-clean %, worst, and the sample size `n`.
+- **Time to merge · opened → merged** (7d) — `merged_at - created_at` per PR:
+  the review/merge window. Clamped to zero so clock skew can't go negative.
+  Median, fastest, slowest. (A PR's first-commit timestamp is deliberately not
+  used: for single-commit squash PRs the commit is authored seconds before the
+  PR opens, so "first commit → merge" collapses to this same window.)
+- **Tick cadence · merge → merge** (7d) — the gap between consecutive merges
+  (`stats.merge_intervals_hours`). For a sequential loop this is the closest
+  proxy for how long each tick actually took end to end (pick → code → review →
+  merge), since commit timestamps only mark when work was committed, not begun.
+  Median, fastest, slowest; reads "not enough merges in the window yet" below two
+  merges.
+- **Backlog remaining and ETA** — `open_items / per_day` as days and a date.
+  When the rate is zero the ETA reads "unknown (stalled)"; an empty backlog
+  reads "backlog clear".
+- **Busiest day** (7d) — the UTC calendar day in the window with the most merges.
+
+The embed groups fields into two labelled blocks so a single merge's numbers are
+never confused with the dataset-wide ones. The `————THIS PR————` block holds:
+
+- **Unlock** — the ten-word "what this merge unlocked" headline (see below).
+- **Link** — the PR number, title, and URL.
+- **Footprint** — additions/deletions/changed-files for the just-merged PR (the
+  list endpoint omits diff stats, so it's fetched via the single-PR detail
+  endpoint).
+- **Review iterations** — this PR's own rounds before its first LGTM verdict
+  (`0` reads "clean first try"; a PR merged without an LGTM verdict says so).
+- **Time for review** — this PR's own `opened → merged` window.
+- **Tick length** — the gap from the previous merge, the per-PR analogue of the
+  tick cadence (`first tracked merge` when there is no prior merge in the window).
+
+- **The ten-word headline** — `generate_headline` asks `claude-opus-4-8`
+  (effort `low`) for a plain-language headline of what the latest merge
+  unlocked, and degrades to the cleaned PR title on any SDK/API absence or
+  error, so the recap never fails on the headline.
+
+## adepthood-specific tuning
+
+The **backlog count is the metric most worth checking**, and this port already
+adapts it. `count_open_backlog` counts open issues (PRs excluded) minus any
+issue bearing one of the picker's exclude labels — epics, `blocked`,
+`needs-spec`, `do-not-auto-merge`, etc. — so the ETA reflects what
+`scripts/ralph/pick-next.sh` would actually pick up, not every open card. The
+exclude set defaults to the same list as the picker and honors the same
+`RALPH_EXCLUDE_LABELS` env var; set it (space-separated) to override, or to an
+empty string to count every open issue.
+
+If the reviewer ever phrases verdicts differently from the `Verdict:` line that
+`claude-code-review.yml` posts, update `normalize_verdict` in `stats.py`.
+
+## Tests
+
+```bash
+python -m pytest scripts/ralph -q
+```
+
+CI runs the same suite via `.github/workflows/ralph-recap-tests.yml` on any
+change under `scripts/ralph/`.
+
+## Troubleshooting
+
+- **Discord 401 Unauthorized** — wrong/revoked token. Use the **bot** token
+  (Bot tab), and don't prefix it with `Bot ` (the script adds that).
+- **Discord 403 Forbidden** — the bot isn't in the server, or lacks View
+  Channel / Send Messages on `RALPH_CHANNEL_ID`.
+- **Discord 404 Not Found** — `RALPH_CHANNEL_ID` is wrong. It's an all-digits
+  snowflake (Copy Channel ID), not the channel name.
+- **Headline is just the PR title** — `ANTHROPIC_API_KEY` is unset or the SDK
+  isn't installed (the workflow installs it).
+- **"no LGTM verdicts found yet"** — no merged PR has a Claude review comment
+  containing a `Verdict` line yet.
+- **ETA "unknown (stalled)"** — no merges in the window, so no rate to
+  extrapolate; resolves once merges resume.

--- a/scripts/ralph/recap.py
+++ b/scripts/ralph/recap.py
@@ -1,0 +1,688 @@
+#!/usr/bin/env python3
+"""Post a Ralph tick-loop recap to Discord whenever a PR is merged.
+
+Reads two environment variables for delivery:
+
+    DISCORD_BOT_TOKEN   Bot token (sent as `Authorization: Bot <token>`).
+    RALPH_CHANNEL_ID    Snowflake ID of the channel to post the recap into.
+
+and uses a GitHub token (GITHUB_TOKEN / GH_TOKEN) plus the repo slug
+(--repo or $GITHUB_REPOSITORY) to gather the merge history. If ANTHROPIC_API_KEY
+is present, the most-recently-merged PR gets a ten-word "what this unlocked"
+headline from Claude; otherwise a plain heuristic headline is used.
+
+This is meant to run from a GitHub Actions workflow keyed on
+`pull_request: closed` (filtered to merged PRs) — see
+`.github/workflows/ralph-recap.yml` — but it runs fine locally too:
+
+    DISCORD_BOT_TOKEN=... RALPH_CHANNEL_ID=... GITHUB_TOKEN=... \
+        python scripts/ralph/recap.py --repo Geoffe-Ga/adepthood --dry-run
+
+`--dry-run` prints the rendered embed as JSON instead of posting it.
+
+The backlog count mirrors `scripts/ralph/pick-next.sh`: open issues bearing any
+of the picker's exclude labels (epics, blocked, etc.) are not part of Ralph's
+real workload, so they are dropped from the ETA. Override the label set with the
+same `RALPH_EXCLUDE_LABELS` env var the picker uses.
+
+The statistics math lives in stats.py (pure, unit-tested); this module is the
+I/O shell around it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, cast
+
+import stats
+
+# Optional dependency: only needed for the Claude-written headline. Imported at
+# module top level so the rest of the recap works even when it is absent.
+try:
+    import anthropic as _anthropic_mod
+except ImportError:
+    _anthropic_mod = None
+
+
+class RecapError(Exception):
+    """A user-facing failure with an associated process exit code."""
+
+    def __init__(self, message: str, code: int = 1) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+GITHUB_API = "https://api.github.com"
+DISCORD_API = "https://discord.com/api/v10"
+# Discord embed accent — a Ralph-purple.
+EMBED_COLOR = 0x7C3AED
+# Zero-width space — a non-empty Discord field value that renders as blank, used
+# to turn a field into a header-only line.
+BLANK = "​"
+# Section headers. Discord can't size text, so uppercase flanked by four em-dashes
+# on each side is what makes these read as section breaks rather than another bold
+# field label. No emoji, no window qualifier — just the section name.
+_RULE = "—" * 4
+THIS_PR_HEADER = f"{_RULE}THIS PR{_RULE}"
+LOOP_HEADER = f"{_RULE}THE LOOP{_RULE}"
+# The windowed stats (iterations, time-to-merge, tick cadence, busiest day) cover
+# this trailing span so they move with recent activity, not a frozen all-time average.
+RECENT_WINDOW_DAYS = 7
+# Safety cap on PRs analyzed per run: each window PR costs one extra API call
+# (its verdicts), so bound a burst day rather than fan out unbounded.
+DEFAULT_MAX_PRS = 200
+HEADLINE_MODEL = "claude-opus-4-8"
+
+# Issues carrying any of these labels are not part of Ralph's real backlog, so
+# they are excluded from the open-issue count behind the ETA. Kept in sync with
+# the default exclude set in `scripts/ralph/pick-next.sh`.
+DEFAULT_EXCLUDE_LABELS = (
+    "epic",
+    "wontfix",
+    "duplicate",
+    "invalid",
+    "question",
+    "blocked",
+    "needs-spec",
+    "future-work",
+    "do-not-auto-merge",
+    "in-progress",
+)
+
+
+# --------------------------------------------------------------------------- #
+# HTTP helpers
+# --------------------------------------------------------------------------- #
+
+
+def _request_json(
+    url: str,
+    *,
+    headers: dict[str, str],
+    method: str = "GET",
+    body: bytes | None = None,
+) -> object:
+    """Perform an HTTP request and parse a JSON response body.
+
+    Returns the parsed JSON (typed as `object`; callers cast). Raises
+    urllib.error.HTTPError / URLError on transport or HTTP failures.
+    """
+    request = urllib.request.Request(url, data=body, headers=headers, method=method)
+    with urllib.request.urlopen(request) as response:
+        raw = response.read().decode("utf-8")
+    return json.loads(raw) if raw else None
+
+
+def _gh_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "ralph-recap",
+    }
+
+
+def _gh_get_paged(path: str, *, token: str, params: dict[str, str], max_items: int) -> list[dict[str, Any]]:
+    """GET a paginated GitHub list endpoint, stopping at max_items."""
+    headers = _gh_headers(token)
+    out: list[dict[str, Any]] = []
+    page = 1
+    while len(out) < max_items:
+        query = "&".join(f"{k}={v}" for k, v in {**params, "per_page": "100", "page": str(page)}.items())
+        url = f"{GITHUB_API}{path}?{query}"
+        chunk = cast("list[dict[str, Any]]", _request_json(url, headers=headers))
+        if not chunk:
+            break
+        out.extend(chunk)
+        if len(chunk) < 100:
+            break
+        page += 1
+    return out[:max_items]
+
+
+# --------------------------------------------------------------------------- #
+# GitHub data gathering
+# --------------------------------------------------------------------------- #
+
+
+def _gh_search_issues(query: str, *, token: str, max_items: int) -> list[dict[str, Any]]:
+    """Run a GitHub issue/PR search, paging up to max_items results.
+
+    Search responses wrap the hits in an `items` array (unlike the list
+    endpoints used by `_gh_get_paged`), so this has its own pager.
+    """
+    headers = _gh_headers(token)
+    out: list[dict[str, Any]] = []
+    page = 1
+    while len(out) < max_items:
+        qs = urllib.parse.urlencode({"q": query, "per_page": "100", "page": str(page)})
+        url = f"{GITHUB_API}/search/issues?{qs}"
+        data = cast("dict[str, Any]", _request_json(url, headers=headers))
+        items = cast("list[dict[str, Any]]", data.get("items", []))
+        if not items:
+            break
+        out.extend(items)
+        if len(items) < 100:
+            break
+        page += 1
+    return out[:max_items]
+
+
+def count_merged_total(repo: str, *, token: str) -> int:
+    """Return the true all-time count of merged PRs via the search API.
+
+    Independent of any per-run fetch cap, so the headline total keeps climbing
+    instead of pinning at the number of PRs we happened to pull this run.
+    """
+    qs = urllib.parse.urlencode({"q": f"repo:{repo} is:pr is:merged", "per_page": "1"})
+    data = cast("dict[str, Any]", _request_json(f"{GITHUB_API}/search/issues?{qs}", headers=_gh_headers(token)))
+    return int(data.get("total_count", 0))
+
+
+def fetch_recent_merged_prs(repo: str, *, token: str, since: dt.date, max_prs: int) -> list[dict[str, Any]]:
+    """Return PRs merged on/after `since` (newest merge first), capped at max_prs.
+
+    Uses search so the window is filtered server-side; each hit carries its
+    `pull_request.merged_at` and `created_at`, which is all the windowed stats
+    need without a per-PR detail call.
+    """
+    query = f"repo:{repo} is:pr is:merged merged:>={since.isoformat()}"
+    items = _gh_search_issues(query, token=token, max_items=max_prs)
+    items.sort(key=lambda it: cast("str", it["pull_request"]["merged_at"]), reverse=True)
+    return items
+
+
+def fetch_pr_detail(repo: str, number: int, *, token: str) -> dict[str, Any]:
+    """Fetch a single PR (carries additions/deletions/changed_files)."""
+    url = f"{GITHUB_API}/repos/{repo}/pulls/{number}"
+    return cast("dict[str, Any]", _request_json(url, headers=_gh_headers(token)))
+
+
+def _pr_churn(repo: str, number: int, *, token: str) -> tuple[int, int, int]:
+    """Return one PR's (additions, deletions, changed_files) from its detail.
+
+    The search/list endpoints omit diff stats, so each PR needs its own detail
+    call. A transport failure on a single PR degrades to a zero tuple rather than
+    failing the whole recap — the LoC sums simply skip that PR's churn.
+    """
+    try:
+        detail = fetch_pr_detail(repo, number, token=token)
+    except (urllib.error.HTTPError, urllib.error.URLError):
+        return (0, 0, 0)
+    return (
+        int(detail.get("additions", 0)),
+        int(detail.get("deletions", 0)),
+        int(detail.get("changed_files", 0)),
+    )
+
+
+def fetch_pr_verdicts(repo: str, number: int, *, token: str) -> list[str]:
+    """Return the ordered list of normalized Claude verdicts on one PR."""
+    comments = _gh_get_paged(
+        f"/repos/{repo}/issues/{number}/comments",
+        token=token,
+        params={"sort": "created", "direction": "asc"},
+        max_items=100,
+    )
+    verdicts: list[str] = []
+    for comment in comments:
+        verdict = stats.normalize_verdict(str(comment.get("body", "")))
+        if verdict is not None:
+            verdicts.append(verdict)
+    return verdicts
+
+
+def fetch_repo_net_lines(repo: str, *, token: str, attempts: int = 3) -> int | None:
+    """Return net lines of code across the whole repo via the code-frequency stats API.
+
+    GitHub computes the per-week additions/deletions stats asynchronously and
+    answers 202 with an empty body on a cold cache, so retry a few times. Any
+    failure (still warming, or an HTTP/transport error) returns None so the recap
+    shows a placeholder for the full-repo figure instead of failing outright.
+    """
+    url = f"{GITHUB_API}/repos/{repo}/stats/code_frequency"
+    for _ in range(attempts):
+        try:
+            data = _request_json(url, headers=_gh_headers(token))
+        except (urllib.error.HTTPError, urllib.error.URLError):
+            return None
+        if data:
+            return stats.net_lines_from_code_frequency(cast("list[list[int]]", data))
+    return None
+
+
+def _excluded_labels() -> set[str]:
+    """Return the label set that disqualifies an issue from the backlog count.
+
+    Mirrors `scripts/ralph/pick-next.sh`: defaults to the housekeeping/deferred
+    markers, overridable via the same `RALPH_EXCLUDE_LABELS` env var (a
+    space-separated list). An empty override counts every open issue.
+    """
+    raw = os.environ.get("RALPH_EXCLUDE_LABELS")
+    if raw is None:
+        return set(DEFAULT_EXCLUDE_LABELS)
+    return {label for label in raw.split() if label}
+
+
+def count_open_backlog(repo: str, *, token: str, max_items: int = 1000) -> int:
+    """Count open issues that are real, unblocked Ralph work — the backlog.
+
+    Excludes pull requests (which the issues endpoint returns too) and any issue
+    bearing an excluded label, so the ETA reflects what the picker would
+    actually pick up rather than every open card.
+    """
+    issues = _gh_get_paged(
+        f"/repos/{repo}/issues",
+        token=token,
+        params={"state": "open"},
+        max_items=max_items,
+    )
+    excluded = _excluded_labels()
+    backlog = 0
+    for issue in issues:
+        if "pull_request" in issue:
+            continue
+        names = {str(label.get("name", "")) for label in issue.get("labels", [])}
+        if names & excluded:
+            continue
+        backlog += 1
+    return backlog
+
+
+# --------------------------------------------------------------------------- #
+# Headline generation
+# --------------------------------------------------------------------------- #
+
+
+def _heuristic_headline(title: str) -> str:
+    """Fallback ten-word headline: the cleaned PR title, clipped to ten words."""
+    cleaned = title.strip()
+    for prefix in ("feat:", "feat(", "fix:", "chore:", "refactor:", "docs:"):
+        if cleaned.lower().startswith(prefix):
+            # split on the first ":" if present; a prefix with no colon (rare)
+            # leaves the title unchanged since split returns the whole string.
+            cleaned = cleaned.split(":", 1)[-1].strip()
+            break
+    words = cleaned.split()
+    return " ".join(words[:10]) if words else "Latest change merged into the tick loop"
+
+
+def generate_headline(title: str, body: str) -> str:
+    """Ask Claude for a ten-word "what this unlocked" headline.
+
+    Falls back to a heuristic if the Anthropic SDK or API key is unavailable, so
+    the recap never fails just because the headline can't be generated.
+    """
+    if _anthropic_mod is None or not os.environ.get("ANTHROPIC_API_KEY"):
+        return _heuristic_headline(title)
+
+    prompt = (
+        "A pull request was just merged into an autonomous coding loop. "
+        "Write a single headline of at most ten words describing what merging "
+        "this PR has unlocked or newly made possible for the project. Lead with "
+        "the capability or outcome, not the implementation. Plain language only: "
+        "no buzzwords, no 'leverage'/'robust'/'seamless'/'synergy', no jargon "
+        "soup, no trailing punctuation. Return only the headline.\n\n"
+        f"PR title: {title}\n\n"
+        f"PR description:\n{body[:4000]}"
+    )
+    try:
+        client = _anthropic_mod.Anthropic()
+        response = client.messages.create(
+            model=HEADLINE_MODEL,
+            max_tokens=256,
+            output_config={"effort": "low"},
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = "".join(block.text for block in response.content if block.type == "text").strip()
+    except Exception:  # any SDK/API failure degrades to the heuristic, never fails the recap
+        return _heuristic_headline(title)
+    return text or _heuristic_headline(title)
+
+
+# --------------------------------------------------------------------------- #
+# Recap assembly
+# --------------------------------------------------------------------------- #
+
+
+def _fmt_hours(hours: float) -> str:
+    if hours < 1:
+        return f"{round(hours * 60)}m"
+    if hours < 48:
+        return f"{hours:.1f}h"
+    return f"{hours / 24:.1f}d"
+
+
+def _fmt_eta(estimate: dict[str, object]) -> str:
+    if not estimate["known"]:
+        return "unknown (loop is stalled — no recent merges)"
+    days = cast("float | None", estimate["days_remaining"])
+    if days is None or days <= 0:
+        return "backlog clear 🎉"
+    eta = cast("dt.datetime", estimate["eta"])
+    return f"~{days:.1f} days (≈ {eta.date().isoformat()})"
+
+
+def _pr_merged_at(pr: dict[str, Any]) -> dt.datetime:
+    """Parse a search hit's merge timestamp from its `pull_request` block."""
+    return stats.parse_iso(cast("str", pr["pull_request"]["merged_at"]))
+
+
+def _open_to_merge_hours(pr: dict[str, Any]) -> float:
+    """Hours from a PR opening to its merge — the review/merge window.
+
+    Clamped to zero so clock skew can never produce a negative duration. A PR's
+    commit timestamps are deliberately not used here: for single-commit squash
+    PRs the commit is authored seconds before the PR opens, so "first commit ->
+    merge" collapses to this same window. The genuine end-to-end work duration is
+    captured by the merge-to-merge tick cadence instead (see
+    `stats.merge_intervals_hours`).
+    """
+    merged = _pr_merged_at(pr)
+    opened = stats.parse_iso(cast("str", pr["created_at"]))
+    return max((merged - opened).total_seconds() / 3600.0, 0.0)
+
+
+def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dict[str, Any] | None:
+    """Gather data and assemble the Discord embed payload.
+
+    The headline total is the true all-time merged count; the activity and
+    quality stats (rate, iterations, time-to-merge, tick cadence, busiest day)
+    cover the trailing `RECENT_WINDOW_DAYS` so they move with recent work. Returns
+    None when there are no merged PRs yet (nothing to recap).
+    """
+    total_merged = count_merged_total(repo, token=token)
+    since = (now - dt.timedelta(days=RECENT_WINDOW_DAYS)).date()
+    window = fetch_recent_merged_prs(repo, token=token, since=since, max_prs=max_prs)
+    if not window:
+        return None
+
+    merged_at = [_pr_merged_at(pr) for pr in window]
+
+    # One pass over the window collects both review rounds (from verdicts) and
+    # churn (from PR detail) per PR. window[0] is the just-merged PR, so its own
+    # figures fall out of index 0 without a second fetch.
+    iterations: list[int] = []
+    churn: list[tuple[int, int, int]] = []
+    latest_iterations: int | None = None
+    for index, pr in enumerate(window):
+        verdicts = fetch_pr_verdicts(repo, int(pr["number"]), token=token)
+        rounds = stats.iterations_before_lgtm(verdicts)
+        if rounds is not None:
+            iterations.append(rounds)
+        if index == 0:
+            latest_iterations = rounds
+        churn.append(_pr_churn(repo, int(pr["number"]), token=token))
+
+    open_to_merge = [_open_to_merge_hours(pr) for pr in window]
+    intervals = stats.merge_intervals_hours(merged_at)
+
+    latest = window[0]
+
+    rate = stats.merge_rate(merged_at, now=now)
+    ttm = stats.time_to_merge_stats(open_to_merge)
+    tick = stats.time_to_merge_stats(intervals)
+    iters = stats.iteration_stats(iterations)
+    open_items = count_open_backlog(repo, token=token)
+    estimate = stats.estimate_remaining(open_items, rate["per_day"], now=now)
+    busy = stats.busiest_day(merged_at)
+
+    # Footprint is the just-merged PR; the loop's LoC sums the 7d window (the whole
+    # fetched set) and the 24h slice of it, with the full-repo net from the stats API.
+    day_ago = now - dt.timedelta(hours=stats.HOURS_PER_DAY)
+    latest_churn = stats.churn_totals(churn[:1])
+    loc_7d = stats.churn_totals(churn)
+    loc_24h = stats.churn_totals([c for c, ts in zip(churn, merged_at) if ts >= day_ago])
+    repo_net = fetch_repo_net_lines(repo, token=token)
+
+    headline = generate_headline(str(latest.get("title", "")), str(latest.get("body") or ""))
+
+    # Per-PR (this-merge) figures, kept distinct from the windowed dataset above.
+    latest_ttm_hours = _open_to_merge_hours(latest)
+    latest_tick_hours = (merged_at[0] - merged_at[1]).total_seconds() / 3600.0 if len(merged_at) >= 2 else None
+
+    return _render_embed(
+        repo=repo,
+        latest=latest,
+        headline=headline,
+        total_merged=total_merged,
+        rate=rate,
+        ttm=ttm,
+        tick=tick,
+        iters=iters,
+        estimate=estimate,
+        latest_churn=latest_churn,
+        loc_24h=loc_24h,
+        loc_7d=loc_7d,
+        repo_net=repo_net,
+        busy=busy,
+        latest_iterations=latest_iterations,
+        latest_ttm_hours=latest_ttm_hours,
+        latest_tick_hours=latest_tick_hours,
+        now=now,
+    )
+
+
+def _stat_line(summary: dict[str, float]) -> str:
+    """Render a median/fastest/slowest duration summary, or a gap-data notice."""
+    if summary["slowest"] <= 0:
+        return "not enough merges in the window yet"
+    return (
+        f"median **{_fmt_hours(summary['median'])}** · "
+        f"fastest {_fmt_hours(summary['fastest'])} · slowest {_fmt_hours(summary['slowest'])}"
+    )
+
+
+def _this_pr_review_line(latest_ttm_hours: float) -> str:
+    """The just-merged PR's own open → merge review window."""
+    return f"**{_fmt_hours(latest_ttm_hours)}** open → merge"
+
+
+def _this_pr_tick_line(latest_tick_hours: float | None) -> str:
+    """The just-merged PR's full tick — the gap since the previous merge."""
+    if latest_tick_hours is None:
+        return "first tracked merge"
+    return f"**{_fmt_hours(latest_tick_hours)}** since the previous merge"
+
+
+def _this_pr_iter_line(latest_iterations: int | None) -> str:
+    """Review rounds the just-merged PR took before its first LGTM verdict."""
+    if latest_iterations is None:
+        return "merged without an LGTM verdict"
+    if latest_iterations == 0:
+        return "**0** rounds · clean first try"
+    plural = "round" if latest_iterations == 1 else "rounds"
+    return f"**{latest_iterations}** {plural} to LGTM"
+
+
+def _loc_line(loc_24h: dict[str, int], loc_7d: dict[str, int], repo_net: int | None) -> str:
+    """Lines-of-code churn over the 24h and 7d windows, plus the full-repo net."""
+
+    def churn(totals: dict[str, int]) -> str:
+        return f"+{totals['additions']:,} / -{totals['deletions']:,}"
+
+    full_repo = f"{repo_net:,} net" if repo_net is not None else "—"
+    return f"{churn(loc_24h)} (24h) · {churn(loc_7d)} (7d) · {full_repo} (full repo)"
+
+
+def _render_embed(
+    *,
+    repo: str,
+    latest: dict[str, Any],
+    headline: str,
+    total_merged: int,
+    rate: dict[str, float],
+    ttm: dict[str, float],
+    tick: dict[str, float],
+    iters: dict[str, float],
+    estimate: dict[str, object],
+    latest_churn: dict[str, int],
+    loc_24h: dict[str, int],
+    loc_7d: dict[str, int],
+    repo_net: int | None,
+    busy: tuple[str, int] | None,
+    latest_iterations: int | None,
+    latest_ttm_hours: float,
+    latest_tick_hours: float | None,
+    now: dt.datetime,
+) -> dict[str, Any]:
+    """Turn computed stats into a Discord embed payload (one message).
+
+    Fields are split into two labelled blocks: the just-merged PR ("This PR")
+    and the rolling/all-time loop figures ("The loop"), so a single merge's
+    numbers are never confused with the dataset-wide ones. Within each block,
+    multi-window stats run smallest window first (24h → 7d → all-time).
+    """
+    pr_number = int(latest["number"])
+    pr_url = str(latest.get("html_url", f"https://github.com/{repo}/pull/{pr_number}"))
+
+    clean_pct = round(iters["clean_merge_rate"] * 100)
+    iter_line = (
+        f"**{iters['mean']:.1f}** avg rounds to LGTM · "
+        f"**{clean_pct}%** first-try clean · "
+        f"worst **{int(iters['max'])}** (n={int(iters['sample'])})"
+        if iters["sample"]
+        else "no LGTM verdicts in the last 7d"
+    )
+
+    busy_line = f"{busy[1]} merges on {busy[0]}" if busy else "—"
+    footprint = f"+{latest_churn['additions']} / -{latest_churn['deletions']} across {latest_churn['files']} file(s)"
+
+    fields = [
+        # A blank field is a Discord spacer; it puts a padding line above each
+        # section header so the blocks breathe instead of butting up against the
+        # field before them.
+        {"name": BLANK, "value": BLANK, "inline": False},
+        {"name": THIS_PR_HEADER, "value": BLANK, "inline": False},
+        {"name": "🔓 Unlock", "value": f"*{headline}*", "inline": False},
+        {"name": "🔗 Link", "value": f"[#{pr_number} — {latest.get('title', '')}]({pr_url})", "inline": False},
+        {"name": "🧮 Footprint", "value": footprint, "inline": True},
+        {"name": "🔁 Review iterations", "value": _this_pr_iter_line(latest_iterations), "inline": True},
+        {"name": "⏱️ Time for review", "value": _this_pr_review_line(latest_ttm_hours), "inline": True},
+        {"name": "🔄 Tick length", "value": _this_pr_tick_line(latest_tick_hours), "inline": True},
+        {"name": BLANK, "value": BLANK, "inline": False},
+        {"name": LOOP_HEADER, "value": BLANK, "inline": False},
+        {"name": "🔥 Busiest day (7d)", "value": busy_line, "inline": True},
+        {
+            "name": "📦 PRs merged",
+            "value": f"{int(rate['last_24h'])} in 24h · {int(rate['last_7_days'])} in 7d · **{total_merged}** all-time",
+            "inline": True,
+        },
+        {"name": "📈 LoC", "value": _loc_line(loc_24h, loc_7d, repo_net), "inline": False},
+        {
+            "name": "⚡ Merge rate",
+            "value": f"**{rate['per_hour']:.2f}**/hr (24h) · {rate['per_day']:.1f}/day (7d)",
+            "inline": True,
+        },
+        {"name": "🔁 Review iterations (7d)", "value": iter_line, "inline": False},
+        {"name": "⏱️ Time for review (7d)", "value": _stat_line(ttm), "inline": False},
+        {"name": "🔄 Tick length (7d)", "value": _stat_line(tick), "inline": False},
+        {
+            "name": "🗺️ Backlog remaining",
+            "value": f"**{estimate['open_items']}** open · ETA {_fmt_eta(estimate)}",
+            "inline": True,
+        },
+    ]
+
+    embed = {
+        "title": f"🤖 Ralph Recap — {repo}",
+        "url": f"https://github.com/{repo}/pulls?q=is%3Apr+is%3Amerged",
+        "description": f"Another tick landed. Here's where the loop stands as of <t:{int(now.timestamp())}:R>.",
+        "color": EMBED_COLOR,
+        "fields": fields,
+        "footer": {"text": "Ralph tick loop · recap fires on every merge"},
+        "timestamp": now.isoformat(),
+    }
+    return {"embeds": [embed]}
+
+
+# --------------------------------------------------------------------------- #
+# Discord delivery
+# --------------------------------------------------------------------------- #
+
+
+def post_to_discord(channel_id: str, token: str, payload: dict[str, Any]) -> None:
+    """Post the recap payload to a Discord channel as a bot."""
+    url = f"{DISCORD_API}/channels/{channel_id}/messages"
+    headers = {
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+        "User-Agent": "DiscordBot (ralph-recap, 1.0)",
+    }
+    _request_json(url, headers=headers, method="POST", body=json.dumps(payload).encode("utf-8"))
+
+
+# --------------------------------------------------------------------------- #
+# Entry point
+# --------------------------------------------------------------------------- #
+
+
+def _gather(repo: str, gh_token: str, max_prs: int) -> dict[str, Any] | None:
+    """Build the recap payload, mapping network failures to RecapError."""
+    now = dt.datetime.now(dt.timezone.utc)
+    try:
+        return build_recap(repo, token=gh_token, max_prs=max_prs, now=now)
+    except urllib.error.HTTPError as exc:
+        raise RecapError(f"GitHub API request failed: {exc.code} {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise RecapError(f"network failure talking to GitHub: {exc.reason}") from exc
+
+
+def _deliver(channel_id: str | None, payload: dict[str, Any]) -> None:
+    """Post the payload to Discord, mapping failures to RecapError."""
+    if not channel_id:
+        raise RecapError("RALPH_CHANNEL_ID (or --channel-id) is required to post", code=2)
+    discord_token = os.environ.get("DISCORD_BOT_TOKEN")
+    if not discord_token:
+        raise RecapError("DISCORD_BOT_TOKEN is required to post", code=2)
+    try:
+        post_to_discord(channel_id, discord_token, payload)
+    except urllib.error.HTTPError as exc:
+        raise RecapError(f"Discord API request failed: {exc.code} {exc.reason}") from exc
+    except urllib.error.URLError as exc:
+        raise RecapError(f"network failure talking to Discord: {exc.reason}") from exc
+
+
+def _run(args: argparse.Namespace) -> int:
+    if not args.repo:
+        raise RecapError("--repo or $GITHUB_REPOSITORY is required", code=2)
+    gh_token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if not gh_token:
+        raise RecapError("GITHUB_TOKEN (or GH_TOKEN) is required", code=2)
+
+    payload = _gather(str(args.repo), gh_token, int(args.max_prs))
+    if payload is None:
+        print("No merged PRs yet — nothing to recap.")
+        return 0
+    if args.dry_run:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    _deliver(args.channel_id, payload)
+    print(f"Posted Ralph recap to channel {args.channel_id}.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="owner/repo slug")
+    parser.add_argument("--channel-id", default=os.environ.get("RALPH_CHANNEL_ID"))
+    parser.add_argument("--max-prs", type=int, default=DEFAULT_MAX_PRS)
+    parser.add_argument("--dry-run", action="store_true", help="print the embed instead of posting")
+    args = parser.parse_args(argv)
+    try:
+        return _run(args)
+    except RecapError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return exc.code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ralph/stats.py
+++ b/scripts/ralph/stats.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Pure statistics helpers for the Ralph tick-loop recap.
+
+Everything in this module is side-effect free: it takes already-fetched data
+(lists of timestamps, verdict sequences, churn tuples) and returns plain
+dicts/numbers. `recap.py` does all the GitHub / Discord / Anthropic I/O and
+hands the data here. Keeping the math pure makes it unit-testable without a
+network.
+
+A "Ralph tick loop" is an autonomous agent that grinds a backlog one issue at
+a time: each tick opens a PR, iterates against the Claude reviewer's verdict
+until LGTM, merges, and moves to the next backlog item. These helpers turn the
+merge history into the numbers a human wants to see in a recap.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections import Counter
+
+# A Claude reviewer verdict, normalized. The reviewer posts a comment ending in
+# a `Verdict:` line; we collapse it to one of these three tokens.
+LGTM = "LGTM"
+CHANGES_REQUESTED = "CHANGES_REQUESTED"
+COMMENTS = "COMMENTS"
+
+ISO_NO_TZ = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def parse_iso(timestamp: str) -> dt.datetime:
+    """Parse a GitHub ISO-8601 timestamp into an aware UTC datetime.
+
+    GitHub stamps end in `Z`; `datetime.fromisoformat` only learned to accept
+    that in 3.11, so normalize it for 3.10 support.
+    """
+    return dt.datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+
+
+def normalize_verdict(raw: str) -> str | None:
+    """Collapse a Claude review comment body to a single verdict token.
+
+    Returns None when the body carries no recognizable verdict line, so callers
+    can ignore non-review comments. The check mirrors the grep ladder in
+    `iteration-trigger.yml`: CHANGES_REQUESTED wins over a bare LGTM mention so
+    a comment that says "this is not yet LGTM, changes requested" is counted as
+    a change request.
+    """
+    upper = raw.upper()
+    if "VERDICT" not in upper:
+        return None
+    if "CHANGES_REQUESTED" in upper or "CHANGES REQUESTED" in upper:
+        return CHANGES_REQUESTED
+    if "LGTM" in upper:
+        return LGTM
+    return COMMENTS
+
+
+def iterations_before_lgtm(verdicts: list[str]) -> int | None:
+    """Count review rounds a PR took before its first LGTM.
+
+    `verdicts` is the ordered list of normalized verdicts for one PR. The result
+    is the number of non-LGTM verdicts that preceded the first LGTM — i.e. how
+    many times the loop had to go back and address feedback. Returns None if the
+    PR never reached an LGTM verdict (it was merged on human judgment, or the
+    reviewer only left COMMENTS), so it can be excluded from the average.
+    """
+    for index, verdict in enumerate(verdicts):
+        if verdict == LGTM:
+            return index
+    return None
+
+
+def _mean(values: list[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
+
+
+def _median(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2
+
+
+HOURS_PER_DAY = 24.0
+DAYS_PER_WEEK = 7.0
+
+
+def merge_rate(merged_at: list[dt.datetime], *, now: dt.datetime) -> dict[str, float]:
+    """Compute merge throughput over fixed rolling windows.
+
+    Reports activity over the trailing 24 hours (as merges-per-hour) and the
+    trailing 7 days (as merges-per-day). Fixed-width windows mean every recap
+    moves with the latest data instead of being diluted by a frozen all-time
+    span, and an idle loop decays toward zero rather than showing a stale
+    average. The 7-day per-day figure (steadier than the 24h one) is what the
+    backlog ETA is built on.
+    """
+    if not merged_at:
+        return {"last_24h": 0.0, "per_hour": 0.0, "last_7_days": 0.0, "per_day": 0.0}
+
+    day_ago = now - dt.timedelta(hours=HOURS_PER_DAY)
+    week_ago = now - dt.timedelta(days=DAYS_PER_WEEK)
+    last_24h = sum(1 for ts in merged_at if ts >= day_ago)
+    last_7 = sum(1 for ts in merged_at if ts >= week_ago)
+
+    return {
+        "last_24h": float(last_24h),
+        "per_hour": last_24h / HOURS_PER_DAY,
+        "last_7_days": float(last_7),
+        "per_day": last_7 / DAYS_PER_WEEK,
+    }
+
+
+def time_to_merge_stats(durations_hours: list[float]) -> dict[str, float]:
+    """Summarize a list of PR durations (hours) as mean/median/fastest/slowest.
+
+    Used for both the open-to-merge window and the merge-to-merge tick cadence —
+    it is just a five-number summary over whatever durations it is handed.
+    """
+    if not durations_hours:
+        return {"mean": 0.0, "median": 0.0, "fastest": 0.0, "slowest": 0.0}
+    return {
+        "mean": _mean(durations_hours),
+        "median": _median(durations_hours),
+        "fastest": min(durations_hours),
+        "slowest": max(durations_hours),
+    }
+
+
+def merge_intervals_hours(merged_at: list[dt.datetime]) -> list[float]:
+    """Hours between each consecutive pair of merges — the per-tick cadence.
+
+    Sorts the merge timestamps ascending and returns the gap, in hours, between
+    each merge and the one before it (so n merges yield n-1 intervals; fewer than
+    two merges yield an empty list). For a sequential loop this is the closest
+    available proxy for how long each tick actually took end to end — pick, code,
+    review, merge — because a PR's own commit timestamps only mark when work was
+    committed, not when it began.
+    """
+    if len(merged_at) < 2:
+        return []
+    ordered = sorted(merged_at)
+    return [(ordered[i] - ordered[i - 1]).total_seconds() / 3600.0 for i in range(1, len(ordered))]
+
+
+def iteration_stats(per_pr: list[int]) -> dict[str, float]:
+    """Summarize iteration counts across PRs that reached LGTM.
+
+    `per_pr` is the list of `iterations_before_lgtm` results (Nones already
+    filtered out). `clean_merge_rate` is the share of PRs that landed LGTM with
+    zero feedback rounds — a proxy for how often the loop nails it first try.
+    """
+    if not per_pr:
+        return {"mean": 0.0, "median": 0.0, "max": 0.0, "clean_merge_rate": 0.0, "sample": 0.0}
+    floats = [float(n) for n in per_pr]
+    clean = sum(1 for n in per_pr if n == 0)
+    return {
+        "mean": _mean(floats),
+        "median": _median(floats),
+        "max": float(max(per_pr)),
+        "clean_merge_rate": clean / len(per_pr),
+        "sample": float(len(per_pr)),
+    }
+
+
+def estimate_remaining(open_items: int, per_day: float, *, now: dt.datetime) -> dict[str, object]:
+    """Project how long the backlog will take at the current merge rate.
+
+    Returns the remaining-item count, estimated days left, and an ETA date.
+    When the rate is zero (no merges yet, or a fully stalled loop) the estimate
+    is unknown rather than infinite.
+    """
+    if open_items <= 0:
+        return {"open_items": 0, "days_remaining": 0.0, "eta": now, "known": True}
+    if per_day <= 0:
+        return {"open_items": open_items, "days_remaining": None, "eta": None, "known": False}
+
+    days_remaining = open_items / per_day
+    eta = now + dt.timedelta(days=days_remaining)
+    return {"open_items": open_items, "days_remaining": days_remaining, "eta": eta, "known": True}
+
+
+def churn_totals(churn: list[tuple[int, int, int]]) -> dict[str, int]:
+    """Sum (additions, deletions, changed_files) tuples across merged PRs."""
+    additions = sum(c[0] for c in churn)
+    deletions = sum(c[1] for c in churn)
+    files = sum(c[2] for c in churn)
+    return {
+        "additions": additions,
+        "deletions": deletions,
+        "net": additions - deletions,
+        "files": files,
+    }
+
+
+def net_lines_from_code_frequency(weeks: list[list[int]]) -> int:
+    """Sum GitHub's weekly code-frequency rows into the repo's net lines of code.
+
+    Each row is `[unix_week, additions, deletions]` and GitHub reports deletions
+    as a negative number, so the running net is just additions and deletions added
+    straight across every week. Returns 0 for an empty history.
+    """
+    return sum(int(week[1]) + int(week[2]) for week in weeks)
+
+
+def busiest_day(merged_at: list[dt.datetime]) -> tuple[str, int] | None:
+    """Return the (ISO date, count) of the day with the most merges, or None."""
+    if not merged_at:
+        return None
+    counter: Counter[str] = Counter(ts.date().isoformat() for ts in merged_at)
+    day, count = counter.most_common(1)[0]
+    return day, count

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -1,0 +1,441 @@
+"""Tests for the Ralph recap: pure stats helpers and the backlog count.
+
+Run from the repo root with:
+
+    python -m pytest scripts/ralph -q
+
+`stats.py` is pure and tested directly. `recap.py` is the I/O shell; only its
+adepthood-specific backlog filtering is unit-tested here (network calls are
+monkeypatched), since everything else is a thin wrapper over `stats`.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+import pytest
+
+import recap
+import stats as rs
+
+UTC = dt.timezone.utc
+
+
+def _at(day: int, hour: int = 12) -> dt.datetime:
+    return dt.datetime(2026, 6, day, hour, tzinfo=UTC)
+
+
+# ---------- parse_iso ----------
+
+
+def test_parse_iso_handles_trailing_z() -> None:
+    parsed = rs.parse_iso("2026-06-27T08:30:00Z")
+    assert parsed == dt.datetime(2026, 6, 27, 8, 30, tzinfo=UTC)
+
+
+# ---------- normalize_verdict ----------
+
+
+def test_normalize_verdict_returns_none_without_verdict_line() -> None:
+    assert rs.normalize_verdict("Looks great, merging!") is None
+
+
+def test_normalize_verdict_detects_lgtm() -> None:
+    assert rs.normalize_verdict("Nice work.\nVerdict: LGTM") == rs.LGTM
+
+
+def test_normalize_verdict_changes_requested_beats_lgtm_mention() -> None:
+    body = "This is not yet LGTM.\nVerdict: CHANGES_REQUESTED"
+    assert rs.normalize_verdict(body) == rs.CHANGES_REQUESTED
+
+
+def test_normalize_verdict_defaults_to_comments() -> None:
+    assert rs.normalize_verdict("Some notes.\nVerdict: COMMENTS") == rs.COMMENTS
+
+
+# ---------- iterations_before_lgtm ----------
+
+
+def test_iterations_before_lgtm_counts_rounds() -> None:
+    verdicts = [rs.CHANGES_REQUESTED, rs.COMMENTS, rs.LGTM]
+    assert rs.iterations_before_lgtm(verdicts) == 2
+
+
+def test_iterations_before_lgtm_zero_for_clean_merge() -> None:
+    assert rs.iterations_before_lgtm([rs.LGTM]) == 0
+
+
+def test_iterations_before_lgtm_none_when_never_lgtm() -> None:
+    assert rs.iterations_before_lgtm([rs.CHANGES_REQUESTED, rs.COMMENTS]) is None
+
+
+# ---------- merge_rate ----------
+
+
+def test_merge_rate_empty() -> None:
+    rate = rs.merge_rate([], now=_at(27))
+    assert rate == {"last_24h": 0.0, "per_hour": 0.0, "last_7_days": 0.0, "per_day": 0.0}
+
+
+def test_merge_rate_last_24h_per_hour() -> None:
+    # Two merges within 24h of `now` (27th 06:00 and 12:00); one is older.
+    merged = [_at(26, 5), _at(27, 6), _at(27, 12)]
+    rate = rs.merge_rate(merged, now=_at(27, 12))
+    assert rate["last_24h"] == 2.0
+    assert rate["per_hour"] == 2.0 / 24.0
+
+
+def test_merge_rate_last_7_days_per_day() -> None:
+    # Two merges within 7 days of the 28th; the 1st is outside the window.
+    merged = [_at(1), _at(25), _at(27)]
+    rate = rs.merge_rate(merged, now=_at(28))
+    assert rate["last_7_days"] == 2.0
+    assert rate["per_day"] == 2.0 / 7.0
+
+
+def test_merge_rate_drops_stale_all_time_keys() -> None:
+    rate = rs.merge_rate([_at(27)], now=_at(27))
+    assert "total" not in rate
+    assert "span_days" not in rate
+
+
+# ---------- time_to_merge_stats ----------
+
+
+def test_time_to_merge_stats() -> None:
+    out = rs.time_to_merge_stats([1.0, 3.0, 5.0])
+    assert out["median"] == 3.0
+    assert out["fastest"] == 1.0
+    assert out["slowest"] == 5.0
+    assert out["mean"] == 3.0
+
+
+# ---------- merge_intervals_hours ----------
+
+
+def test_merge_intervals_hours_returns_consecutive_gaps() -> None:
+    # 09:00, 12:00, 15:00 -> two 3-hour gaps.
+    assert rs.merge_intervals_hours([_at(27, 9), _at(27, 12), _at(27, 15)]) == [3.0, 3.0]
+
+
+def test_merge_intervals_hours_sorts_before_diffing() -> None:
+    # Newest-first input (as the recap holds it) still yields positive gaps.
+    assert rs.merge_intervals_hours([_at(27, 15), _at(27, 9), _at(27, 12)]) == [3.0, 3.0]
+
+
+def test_merge_intervals_hours_empty_below_two_merges() -> None:
+    assert rs.merge_intervals_hours([]) == []
+    assert rs.merge_intervals_hours([_at(27, 9)]) == []
+
+
+# ---------- iteration_stats ----------
+
+
+def test_iteration_stats_clean_merge_rate() -> None:
+    out = rs.iteration_stats([0, 0, 2, 4])
+    assert out["clean_merge_rate"] == 0.5
+    assert out["max"] == 4.0
+    assert out["sample"] == 4.0
+
+
+def test_iteration_stats_empty() -> None:
+    out = rs.iteration_stats([])
+    assert out["sample"] == 0.0
+
+
+# ---------- estimate_remaining ----------
+
+
+def test_estimate_remaining_projects_eta() -> None:
+    est = rs.estimate_remaining(10, 2.0, now=_at(1))
+    assert est["known"] is True
+    assert est["days_remaining"] == 5.0
+    assert est["eta"] == _at(6)
+
+
+def test_estimate_remaining_unknown_when_rate_zero() -> None:
+    est = rs.estimate_remaining(10, 0.0, now=_at(1))
+    assert est["known"] is False
+    assert est["days_remaining"] is None
+
+
+def test_estimate_remaining_clear_backlog() -> None:
+    est = rs.estimate_remaining(0, 2.0, now=_at(1))
+    assert est["open_items"] == 0
+    assert est["days_remaining"] == 0.0
+
+
+# ---------- churn_totals ----------
+
+
+def test_churn_totals_sums_and_nets() -> None:
+    out = rs.churn_totals([(10, 3, 2), (5, 5, 1)])
+    assert out["additions"] == 15
+    assert out["deletions"] == 8
+    assert out["net"] == 7
+    assert out["files"] == 3
+
+
+# ---------- net_lines_from_code_frequency ----------
+
+
+def test_net_lines_from_code_frequency_sums_signed_weeks() -> None:
+    # GitHub reports deletions as negatives: (100-30) + (50-10) = 110.
+    weeks = [[1_700_000_000, 100, -30], [1_700_600_000, 50, -10]]
+    assert rs.net_lines_from_code_frequency(weeks) == 110
+
+
+def test_net_lines_from_code_frequency_empty_is_zero() -> None:
+    assert rs.net_lines_from_code_frequency([]) == 0
+
+
+# ---------- busiest_day ----------
+
+
+def test_busiest_day_picks_max() -> None:
+    merged = [_at(20), _at(20), _at(21)]
+    result = rs.busiest_day(merged)
+    assert result == ("2026-06-20", 2)
+
+
+def test_busiest_day_none_when_empty() -> None:
+    assert rs.busiest_day([]) is None
+
+
+# ---------- count_open_backlog (adepthood adaptation) ----------
+
+
+def _issue(number: int, *, labels: list[str], is_pr: bool = False) -> dict[str, Any]:
+    issue: dict[str, Any] = {"number": number, "labels": [{"name": name} for name in labels]}
+    if is_pr:
+        issue["pull_request"] = {"url": f"https://example/{number}"}
+    return issue
+
+
+def _patch_issues(monkeypatch: pytest.MonkeyPatch, issues: list[dict[str, Any]]) -> None:
+    monkeypatch.setattr(recap, "_gh_get_paged", lambda *a, **k: issues)
+
+
+def test_count_open_backlog_excludes_prs_and_labelled_issues(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("RALPH_EXCLUDE_LABELS", raising=False)
+    issues = [
+        _issue(1, labels=[]),  # counted
+        _issue(2, labels=["enhancement"]),  # counted
+        _issue(3, labels=["epic"]),  # excluded by label
+        _issue(4, labels=["blocked", "enhancement"]),  # excluded by label
+        _issue(5, labels=[], is_pr=True),  # excluded as a PR
+    ]
+    _patch_issues(monkeypatch, issues)
+    assert recap.count_open_backlog("owner/repo", token="t") == 2
+
+
+def test_count_open_backlog_respects_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("RALPH_EXCLUDE_LABELS", "deferred")
+    issues = [
+        _issue(1, labels=["epic"]),  # no longer excluded (override drops "epic")
+        _issue(2, labels=["deferred"]),  # excluded by override
+        _issue(3, labels=[]),  # counted
+    ]
+    _patch_issues(monkeypatch, issues)
+    assert recap.count_open_backlog("owner/repo", token="t") == 2
+
+
+# ---------- count_merged_total ----------
+
+
+def test_count_merged_total_reads_search_total_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: {"total_count": 723, "items": []})
+    assert recap.count_merged_total("owner/repo", token="t") == 723
+
+
+# ---------- fetch_recent_merged_prs ----------
+
+
+def _hit(number: int, *, merged: str, created: str) -> dict[str, Any]:
+    return {"number": number, "created_at": created, "pull_request": {"merged_at": merged}}
+
+
+def test_fetch_recent_merged_prs_sorts_newest_merge_first(monkeypatch: pytest.MonkeyPatch) -> None:
+    hits = [
+        _hit(1, merged="2026-06-25T00:00:00Z", created="2026-06-24T00:00:00Z"),
+        _hit(2, merged="2026-06-27T00:00:00Z", created="2026-06-26T00:00:00Z"),
+        _hit(3, merged="2026-06-26T00:00:00Z", created="2026-06-25T00:00:00Z"),
+    ]
+    monkeypatch.setattr(recap, "_gh_search_issues", lambda *a, **k: hits)
+    out = recap.fetch_recent_merged_prs("owner/repo", token="t", since=_at(20).date(), max_prs=200)
+    assert [pr["number"] for pr in out] == [2, 3, 1]
+
+
+# ---------- _open_to_merge_hours ----------
+
+
+def test_open_to_merge_hours_measures_open_to_merge_window() -> None:
+    pr = _hit(1, merged="2026-06-27T12:00:00Z", created="2026-06-27T10:00:00Z")
+    assert recap._open_to_merge_hours(pr) == 2.0
+
+
+def test_open_to_merge_hours_clamps_negative_to_zero() -> None:
+    # Clock skew (merge stamped before open) must not produce a negative window.
+    pr = _hit(1, merged="2026-06-27T10:00:00Z", created="2026-06-27T12:00:00Z")
+    assert recap._open_to_merge_hours(pr) == 0.0
+
+
+# ---------- _pr_churn ----------
+
+
+def test_pr_churn_reads_detail_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "fetch_pr_detail", lambda *a, **k: {"additions": 12, "deletions": 4, "changed_files": 3})
+    assert recap._pr_churn("owner/repo", 1, token="t") == (12, 4, 3)
+
+
+def test_pr_churn_degrades_to_zero_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error
+
+    def _boom(*_a: Any, **_k: Any) -> dict[str, Any]:
+        raise urllib.error.URLError("network down")
+
+    monkeypatch.setattr(recap, "fetch_pr_detail", _boom)
+    assert recap._pr_churn("owner/repo", 1, token="t") == (0, 0, 0)
+
+
+# ---------- fetch_repo_net_lines ----------
+
+
+def test_fetch_repo_net_lines_sums_code_frequency(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: [[1, 100, -40], [2, 20, -5]])
+    assert recap.fetch_repo_net_lines("owner/repo", token="t") == 75
+
+
+def test_fetch_repo_net_lines_none_when_stats_still_warming(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A 202 from GitHub yields an empty body (None); retries exhaust to None.
+    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: None)
+    assert recap.fetch_repo_net_lines("owner/repo", token="t", attempts=2) is None
+
+
+def test_fetch_repo_net_lines_none_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    import urllib.error
+
+    def _boom(*_a: Any, **_k: Any) -> object:
+        raise urllib.error.HTTPError("u", 500, "err", {}, None)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(recap, "_request_json", _boom)
+    assert recap.fetch_repo_net_lines("owner/repo", token="t") is None
+
+
+# ---------- this-PR display lines ----------
+
+
+def test_this_pr_iter_line_variants() -> None:
+    assert recap._this_pr_iter_line(None) == "merged without an LGTM verdict"
+    assert recap._this_pr_iter_line(0) == "**0** rounds · clean first try"
+    assert recap._this_pr_iter_line(1) == "**1** round to LGTM"
+    assert recap._this_pr_iter_line(3) == "**3** rounds to LGTM"
+
+
+def test_this_pr_tick_line_handles_first_merge() -> None:
+    assert recap._this_pr_tick_line(None) == "first tracked merge"
+    assert recap._this_pr_tick_line(0.5) == "**30m** since the previous merge"
+
+
+def test_this_pr_review_line_formats_window() -> None:
+    assert recap._this_pr_review_line(2.0) == "**2.0h** open → merge"
+
+
+def test_loc_line_renders_three_windows() -> None:
+    loc_24h = {"additions": 1200, "deletions": 300, "net": 900, "files": 5}
+    loc_7d = {"additions": 8400, "deletions": 1600, "net": 6800, "files": 40}
+    line = recap._loc_line(loc_24h, loc_7d, 124_500)
+    assert line == "+1,200 / -300 (24h) · +8,400 / -1,600 (7d) · 124,500 net (full repo)"
+
+
+def test_loc_line_placeholder_when_repo_net_unavailable() -> None:
+    totals = {"additions": 0, "deletions": 0, "net": 0, "files": 0}
+    line = recap._loc_line(totals, totals, None)
+    assert line.endswith("— (full repo)")
+
+
+# ---------- _heuristic_headline ----------
+
+
+def test_heuristic_headline_strips_conventional_prefix() -> None:
+    assert recap._heuristic_headline("feat(backend): add the energy ledger") == "add the energy ledger"
+
+
+def test_heuristic_headline_clips_to_ten_words() -> None:
+    headline = recap._heuristic_headline("one two three four five six seven eight nine ten eleven")
+    assert headline == "one two three four five six seven eight nine ten"
+
+
+def test_heuristic_headline_blank_title_falls_back() -> None:
+    assert recap._heuristic_headline("   ") == "Latest change merged into the tick loop"
+
+
+# ---------- generate_headline ----------
+
+
+class _Block:
+    def __init__(self, text: str, kind: str = "text") -> None:
+        self.text = text
+        self.type = kind
+
+
+class _Response:
+    def __init__(self, blocks: list[_Block]) -> None:
+        self.content = blocks
+
+
+class _FakeAnthropic:
+    """Minimal stand-in for the anthropic SDK that records create() kwargs."""
+
+    last_kwargs: dict[str, Any] = {}
+
+    class _Client:
+        def __init__(self) -> None:
+            self.messages = _FakeAnthropic._Messages()
+
+    class _Messages:
+        def create(self, **kwargs: Any) -> _Response:
+            _FakeAnthropic.last_kwargs = kwargs
+            return _Response([_Block("Energy ledger now powers daily streaks")])
+
+    def Anthropic(self) -> "_FakeAnthropic._Client":  # noqa: N802 - mirrors the SDK's class name
+        return _FakeAnthropic._Client()
+
+
+def test_generate_headline_uses_sdk_and_passes_low_effort(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeAnthropic()
+    _FakeAnthropic.last_kwargs = {}
+    monkeypatch.setattr(recap, "_anthropic_mod", fake)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # pragma: allowlist secret
+
+    headline = recap.generate_headline("feat: add energy ledger", "Body text")
+
+    assert headline == "Energy ledger now powers daily streaks"
+    assert _FakeAnthropic.last_kwargs["model"] == recap.HEADLINE_MODEL
+    assert _FakeAnthropic.last_kwargs["output_config"] == {"effort": "low"}
+
+
+def test_generate_headline_falls_back_when_no_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "_anthropic_mod", _FakeAnthropic())
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    assert recap.generate_headline("feat: add energy ledger", "Body") == "add energy ledger"
+
+
+def test_generate_headline_falls_back_when_sdk_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(recap, "_anthropic_mod", None)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # pragma: allowlist secret
+
+    assert recap.generate_headline("feat: add energy ledger", "Body") == "add energy ledger"
+
+
+def test_generate_headline_falls_back_on_sdk_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _Boom:
+        def Anthropic(self) -> object:  # noqa: N802 - mirrors the SDK's class name
+            raise RuntimeError("api down")
+
+    monkeypatch.setattr(recap, "_anthropic_mod", _Boom())
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # pragma: allowlist secret
+
+    assert recap.generate_headline("feat: add energy ledger", "Body") == "add energy ledger"


### PR DESCRIPTION
Ports the Ralph Discord notification suite and the de-slopify code-quality action from [geoffe-ga/adepthood](https://github.com/geoffe-ga/adepthood), adapting the repo-specific pieces to the creek-tools monorepo layout.

## Ralph Discord recap (merge-triggered, unchanged from source)
Posts a tick-loop recap embed to Discord on every merged PR. Repo-agnostic — pulled as-is.

- `.github/workflows/ralph-recap.yml` — fires on `pull_request: closed` (merged only)
- `.github/workflows/ralph-recap-tests.yml` — runs the recap unit tests
- `scripts/ralph/recap.py` — I/O shell (GitHub history → stats → Discord embed)
- `scripts/ralph/stats.py` — pure, unit-tested stats math
- `scripts/ralph/test_recap_stats.py` — 49 tests
- `scripts/ralph/RECAP.md` — setup + metric docs

## De-slopify audit (weekly, adapted to this repo)
Read-only code-quality auditor that files corroborated findings as GitHub issues. Never writes to the repo (`contents: read` / `issues: write`).

- `.github/workflows/weekly-deslop.yml` — **rescheduled to Sunday 00:00 PT** (`cron: 0 8 * * 0`); dropped the Node/`frontend` setup; toolbox install rewired to `pip install -e creek-tools/.[all,dev]`
- `.claude/skills/de-slopify/**` — skill + 3 references + `collect-evidence.sh`, with the evidence collector rewired to scan `creek-tools/creek`, `creek-tools/creek_mcp`, `crawdad/crawdad` (was `backend/src` + `frontend/src`); dedup search, reading-pass fan-out targets, and install hints repointed at `geoffe-ga/creek-vault`

## Required configuration
Set in repo Settings → Secrets and variables → Actions (each Ralph value resolves as a Secret *or* a Variable):

- `DISCORD_BOT_TOKEN` (required) — bot token with Send Messages on the channel
- `RALPH_CHANNEL_ID` (required) — target channel ID
- `ANTHROPIC_API_KEY` (optional) — enables the Claude-written PR headline
- `CLAUDE_CODE_OAUTH_TOKEN` (required for de-slop) — same token the existing `claude.yml` uses

`GITHUB_TOKEN` is provided automatically.

## Scope note
The broader Ralph *autonomous-loop* driver (`pick-next.sh`, `PROMPT.md`, `state.json`, iteration workflow) was intentionally not pulled — neither feature depends on it. The recap only reads merge history; de-slop files issues whose label conventions are embedded in the skill's `issue-templates.md`.

## Validation
- 49 Ralph unit tests pass locally
- Shell (`bash -n`), Python (`py_compile`), and YAML parse all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JGw8fqNJ4iLt1VNiwxwyJK)_