### PR TITLE
feat(report): error on unknown --type instead of a silent no-op (#716)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Literal, cast
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 from creek.classify.privacy_filter import (
@@ -2689,13 +2690,16 @@ def report(
     if type == "wavelength":
         _report_wavelength(vault_path, period)
         return
-    # Unknown/missing type: fail loudly with the valid list rather than silently
-    # no-op (#716). The list is derived from the dispatch table (+ the
-    # special-cased ``wavelength``) so it never drifts from the real handlers.
+    # Unknown/missing type: fail loudly with the valid list, not a no-op (#716).
     valid = ", ".join([*_REPORT_DISPATCH, "wavelength"])
-    console.print(
-        f"[red]Unknown report type {type!r}. Valid types: {valid}.[/red]",
-    )
+    if type is None:
+        console.print(f"[red]--type is required. Valid types: {valid}.[/red]")
+    else:
+        # escape the operator-supplied value so it can't inject Rich markup.
+        console.print(
+            f"[red]Unknown report type '{escape(str(type))}'. "
+            f"Valid types: {valid}.[/red]",
+        )
     raise typer.Exit(code=2)
 
 

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2689,10 +2689,14 @@ def report(
     if type == "wavelength":
         _report_wavelength(vault_path, period)
         return
+    # Unknown/missing type: fail loudly with the valid list rather than silently
+    # no-op (#716). The list is derived from the dispatch table (+ the
+    # special-cased ``wavelength``) so it never drifts from the real handlers.
+    valid = ", ".join([*_REPORT_DISPATCH, "wavelength"])
     console.print(
-        f"[bold green]Would report: type={type}, "
-        f"period={period}, vault={vault_path}[/bold green]",
+        f"[red]Unknown report type {type!r}. Valid types: {valid}.[/red]",
     )
+    raise typer.Exit(code=2)
 
 
 @app.command()

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1244,9 +1244,7 @@ def _report_vault(tmp_path: Path) -> Path:
 def test_report_unknown_type_errors(tmp_path: Path) -> None:
     """`report --type <unknown>` errors with the valid list, not a no-op (#716)."""
     vault = _report_vault(tmp_path)
-    result = runner.invoke(
-        app, ["report", "--type", "paradoxx", "--vault", str(vault)]
-    )
+    result = runner.invoke(app, ["report", "--type", "paradoxx", "--vault", str(vault)])
     assert result.exit_code != 0, result.output
     assert "paradoxx" in result.output  # names the bad type
     assert "decisions" in result.output  # lists real valid types
@@ -1266,9 +1264,7 @@ def test_report_known_type_still_dispatches(tmp_path: Path) -> None:
     """A valid --type still runs its handler (no regression) (#716)."""
     vault = _report_vault(tmp_path)
     (vault / "10-Liminal" / "Unnamed").mkdir(parents=True, exist_ok=True)
-    result = runner.invoke(
-        app, ["report", "--type", "unnamed", "--vault", str(vault)]
-    )
+    result = runner.invoke(app, ["report", "--type", "unnamed", "--vault", str(vault)])
     assert result.exit_code == 0, result.output
 
 

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1233,6 +1233,45 @@ def test_report_unnamed_command(tmp_path: Path) -> None:
     assert (vault / "10-Liminal" / "Unnamed" / "Digests").is_dir()
 
 
+def _report_vault(tmp_path: Path) -> Path:
+    """Minimal vault for a report-command invocation."""
+    vault = tmp_path / "vault"
+    for d in ("00-Creek-Meta", "00-Creek-Meta/Processing-Log", "01-Fragments"):
+        (vault / d).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def test_report_unknown_type_errors(tmp_path: Path) -> None:
+    """`report --type <unknown>` errors with the valid list, not a no-op (#716)."""
+    vault = _report_vault(tmp_path)
+    result = runner.invoke(
+        app, ["report", "--type", "paradoxx", "--vault", str(vault)]
+    )
+    assert result.exit_code != 0, result.output
+    assert "paradoxx" in result.output  # names the bad type
+    assert "decisions" in result.output  # lists real valid types
+    assert "unnamed" in result.output
+    assert "Would report" not in result.output  # the silent no-op is gone
+
+
+def test_report_missing_type_errors(tmp_path: Path) -> None:
+    """`report` with no --type errors the same helpful way (#716)."""
+    vault = _report_vault(tmp_path)
+    result = runner.invoke(app, ["report", "--vault", str(vault)])
+    assert result.exit_code != 0, result.output
+    assert "Would report" not in result.output
+
+
+def test_report_known_type_still_dispatches(tmp_path: Path) -> None:
+    """A valid --type still runs its handler (no regression) (#716)."""
+    vault = _report_vault(tmp_path)
+    (vault / "10-Liminal" / "Unnamed").mkdir(parents=True, exist_ok=True)
+    result = runner.invoke(
+        app, ["report", "--type", "unnamed", "--vault", str(vault)]
+    )
+    assert result.exit_code == 0, result.output
+
+
 def test_report_decisions_no_candidates_is_friendly(tmp_path: Path) -> None:
     """``report --type decisions`` with no signalling fragments is friendly (#581).
 
@@ -1496,7 +1535,7 @@ def test_report_wavelength_unknown_period_errors(tmp_path: Path) -> None:
 
 
 def test_report_command() -> None:
-    """Test that report command runs with required args."""
+    """An unrecognised report type (`summary`) errors with the valid list (#716)."""
     result = runner.invoke(
         app,
         [
@@ -1509,7 +1548,9 @@ def test_report_command() -> None:
             "/fake/vault",
         ],
     )
-    assert result.exit_code == 0
+    assert result.exit_code == 2
+    assert "summary" in result.output
+    assert "Would report" not in result.output
 
 
 def test_review_help() -> None:

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1245,7 +1245,7 @@ def test_report_unknown_type_errors(tmp_path: Path) -> None:
     """`report --type <unknown>` errors with the valid list, not a no-op (#716)."""
     vault = _report_vault(tmp_path)
     result = runner.invoke(app, ["report", "--type", "paradoxx", "--vault", str(vault)])
-    assert result.exit_code != 0, result.output
+    assert result.exit_code == 2, result.output  # Unix invalid-argument convention
     assert "paradoxx" in result.output  # names the bad type
     assert "decisions" in result.output  # lists real valid types
     assert "unnamed" in result.output
@@ -1253,10 +1253,12 @@ def test_report_unknown_type_errors(tmp_path: Path) -> None:
 
 
 def test_report_missing_type_errors(tmp_path: Path) -> None:
-    """`report` with no --type errors the same helpful way (#716)."""
+    """`report` with no --type errors with a human-readable message (#716)."""
     vault = _report_vault(tmp_path)
     result = runner.invoke(app, ["report", "--vault", str(vault)])
-    assert result.exit_code != 0, result.output
+    assert result.exit_code == 2, result.output
+    assert "--type is required" in result.output  # not a leaked Python "None"
+    assert "None" not in result.output
     assert "Would report" not in result.output
 
 


### PR DESCRIPTION
## Summary
First (skeleton) issue of the **vault prod-readiness fill-pipeline epic** (#713).

`creek report --type <unknown>` (and a missing `--type`) printed `"Would report: type=X, period=…, vault=…"` and exited **0** — masking typos and unwired types (e.g. `--type paradox` looked like it worked but did nothing). It now **errors with the valid-type list** (derived from `_REPORT_DISPATCH` + the special-cased `wavelength`, so it never drifts from the real handlers) and exits **2**. Known types dispatch unchanged.

This makes the report surface honest before later epic issues add real `--type` handlers (#711 paradox/synchronicity, #719 wavelength).

## Test plan
- `tests/test_cli.py`: unknown `--type` → exit 2 + the bad type + valid list, no `"Would report"`; missing `--type` → same; a known type (`unnamed`) still dispatches; updated the pre-existing `test_report_command` (which asserted the old no-op for the unknown type `summary`) to the new error contract.
- Report tests green; ruff + format + mypy clean.

> **Note for reviewers / CI:** local check-all on the author's machine shows ~10 unrelated failures (author / compost-credentials / `test_ollama_live_smoke`) caused by a configured environment (real `ANTHROPIC_API_KEY` + `CREEK_CLOUD_CONSENT` set, live Ollama running). They fail identically on clean `main` and are environmental — CI runs without those and is the source of truth. This diff only touches the `report` command.

Refs #713
Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)