### PR TITLE
docs(author): reconcile the Writing Desk surface with its actual live state (#712)

### DIFF
--- a/creek-tools/creek/author/__init__.py
+++ b/creek-tools/creek/author/__init__.py
@@ -1,11 +1,14 @@
 """Creek Writing Desk — multi-agent authoring package (FEAT-041).
 
-This package wires the author desk end-to-end with typed stubs (#455): a
-:class:`~creek.author.conductor.Conductor` drives stub specialist agents, a
-stub voice agent, and a stub reflection node to return a shaped
-:class:`~creek.author.models.AuthoredDraft`. Later FEAT-041 issues replace the
-stub bodies with real retrieval, synthesis, voicing, and judging behind the
-same seams.
+A :class:`~creek.author.conductor.Conductor` drives the desk end-to-end and
+returns a shaped :class:`~creek.author.models.AuthoredDraft`. The specialist
+agents (graph, retrieval, ontology) and the reflection node do **real,
+deterministic** work — link-graph walks, embedding retrieval, rule-based
+ontology grounding, and quality-gate judging (no LLM). The voice node renders
+**live** through the router-resolved ``generation`` provider when one is
+available (tier-routed so Intimate content stays local, #658/#661), falling back
+to a deterministic rendering otherwise. The original #455 scaffold's stubs have
+since been replaced behind the same seams.
 """
 
 from __future__ import annotations

--- a/creek-tools/creek/author/client.py
+++ b/creek-tools/creek/author/client.py
@@ -1,9 +1,11 @@
-"""Thin, mockable Anthropic client wrapper for the author desk (FEAT-041, #455).
+"""Thin, mockable provider wrapper for the author desk (FEAT-041).
 
 The Writing Desk's only seam onto the network goes through this wrapper, so
-unit tests inject a mock provider and never make a live call. The skeleton's
-specialists/voice/reflection are pure stubs and do not yet call it; issue #460
-wires it into the real Conductor.
+unit tests inject a mock provider and never make a live call. It is router-built
+and wired into the live Conductor (#460/#658): the **voice** node calls it for
+live LLM rendering when a provider is available (tier-routed by #661), falling
+back to a deterministic rendering otherwise. The graph/retrieval/ontology
+specialists and the reflection node are deterministic and do not use it.
 """
 
 from __future__ import annotations

--- a/creek-tools/creek/author/conductor.py
+++ b/creek-tools/creek/author/conductor.py
@@ -5,9 +5,11 @@ evidence, the bundles are synthesized, the voice agent renders a draft, and the
 reflection node judges it — looping on ``REVISE`` up to ``max_rounds``. A draft
 still in ``REVISE`` once the round budget is exhausted is escalated to a human
 (``ESCALATE``) rather than shipped (#473), then returned as a shaped
-:class:`~creek.author.models.AuthoredDraft`. The reflection node is a real
-deterministic judge; the remaining collaborators are typed stubs that later
-issues swap behind these same seams.
+:class:`~creek.author.models.AuthoredDraft`. The specialists (graph, retrieval,
+ontology) and the reflection node do real, deterministic work; the voice agent
+renders live through the router-resolved provider when one is available
+(tier-routed so Intimate content stays local, #658/#661), falling back to a
+deterministic rendering otherwise.
 """
 
 from __future__ import annotations
@@ -145,7 +147,7 @@ def require_supported_medium(medium: str) -> Medium:
         The validated medium literal.
 
     Raises:
-        ValueError: When *medium* is not wired in the skeleton.
+        ValueError: When *medium* is not wired in the Writing Desk.
     """
     if medium not in SUPPORTED_MEDIUMS:
         wired = ", ".join(repr(m) for m in sorted(SUPPORTED_MEDIUMS))
@@ -160,7 +162,7 @@ def require_supported_medium(medium: str) -> Medium:
 
 
 def _claims_to_provenance(claims: Sequence[EvidenceClaim]) -> list[ProvenanceEntry]:
-    """Render evidence *claims* into mock provenance entries.
+    """Render evidence *claims* into provenance entries.
 
     Args:
         claims: The claims to trace.
@@ -192,7 +194,7 @@ class Conductor:
         llm_client: Optional voice client; when set,
             :func:`build_default_conductor` threads it into the voice agent so
             the desk renders live voicing (#658). ``None`` keeps the
-            deterministic stub. The specialists and reflection node remain
+            deterministic rendering. The specialists and reflection node are
             deterministic and do not use it.
         contract: The medium contract driving this run; its reflection rubric
             is exposed to the reflection node (FEAT-041 #459).
@@ -452,7 +454,7 @@ def build_default_conductor(
     voice_client_factory: VoiceClientFactory | None = None,
     contract: MediumContract | None = None,
 ) -> Conductor:
-    """Build a conductor wired with the default stub collaborators.
+    """Build a conductor wired with the default desk collaborators.
 
     Args:
         max_rounds: Upper bound on voice/reflect rounds.
@@ -467,7 +469,7 @@ def build_default_conductor(
     return Conductor(
         # #658: thread the client into the voice agent — the only collaborator
         # that calls the LLM — so an injected client produces live voicing
-        # instead of the deterministic stub. ``None`` keeps the stub.
+        # instead of the deterministic rendering. ``None`` keeps it.
         specialists=default_specialists(),
         voice=VoiceAgent(llm_client=llm_client),
         reflection=ReflectionNode(),
@@ -497,7 +499,7 @@ def run_author(
         max_rounds: Optional override for the round bound; defaults to the
             ``author.max_author_rounds`` config default.
         llm_client: Optional voice client (#658). When supplied, the desk
-            renders live voicing; ``None`` keeps the deterministic stub.
+            renders live voicing; ``None`` keeps the deterministic rendering.
         override: The privacy admission ceiling (#660) threaded to the
             specialists; above-ceiling fragments are excluded. ``None`` =>
             ``OPEN``.

--- a/creek-tools/creek/author/models.py
+++ b/creek-tools/creek/author/models.py
@@ -3,8 +3,10 @@
 These are the shapes that flow through the author desk: specialists emit
 :class:`EvidenceClaim` records (a claim traced to its source fragments),
 the conductor aggregates them into an :class:`EvidenceBundle`, and one run
-yields an :class:`AuthoredDraft`. Real retrieval/synthesis/judging fill these
-shapes in later FEAT-041 issues; the skeleton populates them with mock data.
+yields an :class:`AuthoredDraft`. The desk's deterministic
+retrieval/synthesis/judging populate these shapes with real data; the voice
+agent fills the draft body live when a provider is available and with a
+deterministic rendering otherwise.
 """
 
 from typing import Literal
@@ -199,7 +201,7 @@ class AuthoredDraft(BaseModel):
     Attributes:
         medium: The medium the draft was authored for.
         query: The originating user query.
-        body: The drafted prose (mock text in the skeleton).
+        body: The drafted prose.
         provenance: Per-claim provenance entries, reusing the compile-layer
             :class:`~creek.compile.provenance.ProvenanceEntry` shape.
         verdict: The reflection node's verdict for this draft.

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -4211,14 +4211,19 @@ def author(
         ),
     ),
 ) -> None:
-    """Author a piece with the Creek Writing Desk (stub skeleton).
+    """Author a piece with the Creek Writing Desk.
 
-    Drives an end-to-end author desk — stub Graph/Retrieval/Ontology
-    specialists, a stub Voice agent, and a stub Reflection node — and prints a
-    shaped :class:`~creek.author.models.AuthoredDraft`. ``--dry-run`` prints the
-    plan and a stub evidence summary instead. ``book-report`` takes ``--work``
-    (the 11-Other-Authors path) instead of ``--query``; every other medium
-    requires ``--query``.
+    Drives an end-to-end author desk. The Graph, Retrieval, and Ontology
+    specialists and the Reflection node do **real, deterministic** work — a
+    link-graph walk, embedding-based retrieval, rule-based ontology grounding,
+    and quality-gate judging. The Voice node renders **live via the configured
+    ``generation`` provider** when one is available (routed by content tier so
+    Intimate stays local, #661), and falls back to a deterministic rendering when
+    no provider is configured/available. Returns a shaped
+    :class:`~creek.author.models.AuthoredDraft`. ``--dry-run`` plans and gathers
+    real evidence only (no voicing or reflection). ``book-report`` takes
+    ``--work`` (the 11-Other-Authors path) instead of ``--query``; every other
+    medium requires ``--query``.
     """
     from creek.author import SUPPORTED_MEDIUMS, build_default_conductor
     from creek.author.client import AuthorLLMClient
@@ -4251,7 +4256,7 @@ def author(
         )
         console.print(f"PLAN: {' → '.join(conductor.plan())}")
         console.print(
-            f"EVIDENCE (stub): {len(evidence.claims)} claims, "
+            f"EVIDENCE: {len(evidence.claims)} claims, "
             f"{len(evidence.all_source_fragments())} source_fragments",
         )
         return

--- a/creek-tools/tests/test_cli_author.py
+++ b/creek-tools/tests/test_cli_author.py
@@ -71,16 +71,26 @@ def test_author_command_surface_is_not_stale_stub_text() -> None:
     """
     import creek.author as author_pkg
     from creek.author import client as author_client
+    from creek.author.conductor import Conductor, build_default_conductor
     from creek.cli import author as author_cmd
 
-    for doc in (author_cmd.__doc__, author_pkg.__doc__, author_client.__doc__):
+    surfaces = (
+        author_cmd.__doc__,
+        author_pkg.__doc__,
+        author_client.__doc__,
+        Conductor.__doc__,
+        build_default_conductor.__doc__,
+    )
+    for doc in surfaces:
         assert doc is not None
         low = doc.lower()
         assert "stub skeleton" not in low
         assert "stub specialist" not in low
         assert "pure stubs" not in low
-    # The command docstring states the desk does real work.
-    assert "real" in author_cmd.__doc__.lower()
+        assert "typed stubs" not in low
+        assert "stub collaborators" not in low
+    # The command docstring states the desk does real, deterministic work.
+    assert "real, deterministic" in author_cmd.__doc__.lower()
 
 
 def test_author_run_prints_verdict(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_cli_author.py
+++ b/creek-tools/tests/test_cli_author.py
@@ -1,4 +1,4 @@
-"""CLI tests for ``creek author`` (FEAT-041 Writing Desk skeleton, #455)."""
+"""CLI tests for ``creek author`` (FEAT-041 Writing Desk)."""
 
 from __future__ import annotations
 
@@ -84,7 +84,7 @@ def test_author_command_surface_is_not_stale_stub_text() -> None:
 
 
 def test_author_run_prints_verdict(tmp_path: Path) -> None:
-    """A full (stub) run prints the verdict and a body."""
+    """A full author run prints the verdict and a body."""
     result = runner.invoke(
         app,
         ["author", "--query", "q", "--vault", str(_vault(tmp_path))],

--- a/creek-tools/tests/test_cli_author.py
+++ b/creek-tools/tests/test_cli_author.py
@@ -37,7 +37,7 @@ def _vault(tmp_path: Path) -> Path:
 
 
 def test_author_dry_run_prints_plan_and_evidence(tmp_path: Path) -> None:
-    """``--dry-run`` prints the pipeline plan and a stub evidence summary."""
+    """``--dry-run`` prints the pipeline plan and a (real) evidence summary."""
     result = runner.invoke(
         app,
         [
@@ -56,9 +56,31 @@ def test_author_dry_run_prints_plan_and_evidence(tmp_path: Path) -> None:
     assert "PLAN:" in result.output
     assert "graph" in result.output
     assert "reflect" in result.output
-    assert "EVIDENCE (stub):" in result.output
+    assert "EVIDENCE:" in result.output  # real evidence, not a stub (#712)
+    assert "(stub)" not in result.output
     assert "claims" in result.output
     assert "source_fragments" in result.output
+
+
+def test_author_command_surface_is_not_stale_stub_text() -> None:
+    """The author surface no longer mislabels the live desk as an all-stub (#712).
+
+    Graph/Retrieval/Ontology specialists + Reflection are live deterministic work;
+    Voice is live-when-a-provider-is-available. The command docstring + the
+    author package docstrings must reflect that, not the original #455 scaffold.
+    """
+    import creek.author as author_pkg
+    from creek.author import client as author_client
+    from creek.cli import author as author_cmd
+
+    for doc in (author_cmd.__doc__, author_pkg.__doc__, author_client.__doc__):
+        assert doc is not None
+        low = doc.lower()
+        assert "stub skeleton" not in low
+        assert "stub specialist" not in low
+        assert "pure stubs" not in low
+    # The command docstring states the desk does real work.
+    assert "real" in author_cmd.__doc__.lower()
 
 
 def test_author_run_prints_verdict(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Epic B (#714) skeleton. An audit of `creek/author/` found the `creek author` "stub skeleton" framing **badly stale**:

| Node | Reality |
|---|---|
| GraphSpecialist | **LIVE** — real link-graph walk (`agents.py`) |
| RetrievalSpecialist | **LIVE** — embedding-based semantic retrieval (`agents.py`) |
| OntologySpecialist | **LIVE** — rule-based frequency/phase grounding + paradox detection |
| ReflectionNode | **LIVE** — real quality-gate judging (`reflection.py`) |
| Voice node | **LIVE when a `generation` provider is available** (tier-routed, #658/#661); deterministic fallback otherwise |

So the surface lied. This makes it tell the truth:
- `creek author` command docstring rewritten to describe the real desk + the conditional live/deterministic voice path.
- `--dry-run` evidence label `"EVIDENCE (stub)"` → `"EVIDENCE"` (it's real specialist output).
- `creek/author/__init__.py` + `creek/author/client.py` module docstrings updated (drop "typed stubs (#455)" / "pure stubs … #460 wires it" — that work merged).

## Test plan
- `test_cli_author.py`: the dry-run test asserts `"EVIDENCE:"` + no `"(stub)"`; a new `test_author_command_surface_is_not_stale_stub_text` pins that the command + package docstrings no longer advertise an all-stub desk.
- Ruff/format/mypy clean; author tests pass (the 2 unrelated `test_author_run_prints_verdict` / book-report failures are the operator-env live-run cases — they fail identically on clean `main`; CI runs clean).

## Note for the epic
Since the audit shows the specialists + reflection are **already live**, the sibling issue **#721** ("complete the stub specialists") is largely moot — I'll re-scope or close it when the loop reaches it.

Refs #714
Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)