### PR TITLE
feat(index): standalone `creek index` to regenerate index notes (#717)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2149,6 +2149,30 @@ def _format_link_summary(summary: LinkSummary) -> str:
     return f"[bold green]{body}[/bold green]"
 
 
+@app.command()
+def index(
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+) -> None:
+    """Regenerate the Dataview index notes without running the full pipeline.
+
+    Runs only the index stage: rebuilds the per-frequency indexes under
+    ``06-Frequencies/``, the master thread index, the eddy map, and the temporal
+    and source indexes from whatever fragments and threads already live in the
+    vault. Deterministic and local — no ingest, redact, classify, link, or LLM —
+    so operators who added fragments or re-linked can refresh the indexes in
+    place instead of re-running all of ``process``. Re-running overwrites each
+    note with identical content (idempotent).
+    """
+    from creek.generate.indexes import IndexGenerator
+
+    vault_path = _resolve_vault(vault)
+    generated = IndexGenerator(vault_path=vault_path).generate_all()
+    rel = ", ".join(str(path.relative_to(vault_path)) for path in generated)
+    console.print(
+        f"[bold green]Wrote {len(generated)} index note(s): {rel}[/bold green]",
+    )
+
+
 @app.command(name="compile")
 def compile_(
     fragment_id: str = typer.Argument(..., help="Source fragment ID to roll up"),

--- a/creek-tools/tests/test_cli_index.py
+++ b/creek-tools/tests/test_cli_index.py
@@ -1,0 +1,96 @@
+"""CLI tests for ``creek index`` (standalone index regeneration, #717)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+_TOP_LEVEL = (
+    "00-Creek-Meta",
+    "01-Fragments",
+    "02-Threads",
+    "03-Eddies",
+    "04-Praxis",
+    "05-Wavelength",
+    "06-Frequencies",
+    "07-Voice",
+    "08-Decisions",
+    "09-Reference",
+    "10-Liminal",
+)
+
+_FREQ_SUBDIRS = (
+    "F1-Agency",
+    "F2-Receptivity",
+    "F3-Self-Love-Power",
+    "F4-Community-Love",
+    "F5-Achievism",
+    "F6-Pluralism",
+    "F7-Integration",
+    "F8-True-Self",
+    "F9-Unity",
+    "F10-Emptiness",
+)
+
+
+@pytest.fixture()
+def vault(tmp_path: Path) -> Path:
+    """Create a scaffolded vault with the folders the index generator writes to."""
+    for folder in _TOP_LEVEL:
+        (tmp_path / folder).mkdir()
+    for subdir in _FREQ_SUBDIRS:
+        (tmp_path / "06-Frequencies" / subdir).mkdir()
+    return tmp_path
+
+
+def test_index_writes_all_index_notes(vault: Path) -> None:
+    """``creek index`` writes the Dataview index notes and reports them."""
+    result = runner.invoke(app, ["index", "--vault", str(vault)])
+
+    assert result.exit_code == 0, result.output
+    # The four named non-frequency indexes plus a representative frequency index.
+    assert (vault / "02-Threads" / "Thread-Index.md").is_file()
+    assert (vault / "03-Eddies" / "Eddy-Map.md").is_file()
+    assert (vault / "00-Creek-Meta" / "Temporal-Index.md").is_file()
+    assert (vault / "00-Creek-Meta" / "Source-Index.md").is_file()
+    assert (vault / "06-Frequencies" / "F1-Agency" / "F1-Index.md").is_file()
+    # Reports the count and at least one written path.
+    assert "Wrote" in result.output
+    assert "Thread-Index.md" in result.output
+
+
+def test_index_is_idempotent(vault: Path) -> None:
+    """Re-running ``creek index`` overwrites in place with identical bytes."""
+    first = runner.invoke(app, ["index", "--vault", str(vault)])
+    assert first.exit_code == 0, first.output
+
+    written = sorted(vault.rglob("*-Index.md")) + sorted(vault.rglob("Eddy-Map.md"))
+    snapshot = {p: p.read_bytes() for p in written}
+    assert snapshot, "expected index notes to have been written"
+
+    second = runner.invoke(app, ["index", "--vault", str(vault)])
+    assert second.exit_code == 0, second.output
+
+    for path, original in snapshot.items():
+        assert path.read_bytes() == original, f"{path} changed on re-run"
+
+
+def test_index_reports_count_matching_written_files(vault: Path) -> None:
+    """The reported count equals the number of index notes actually on disk."""
+    result = runner.invoke(app, ["index", "--vault", str(vault)])
+    assert result.exit_code == 0, result.output
+
+    on_disk = {
+        *vault.rglob("*-Index.md"),
+        *vault.rglob("Eddy-Map.md"),
+    }
+    assert f"Wrote {len(on_disk)} index note" in result.output


### PR DESCRIPTION
## Summary
Adds a standalone `creek index --vault <path>` command that regenerates the Dataview index notes **without** running the full `process` pipeline (no ingest/redact/classify/link/LLM).

It reuses the existing `IndexGenerator.generate_all()` — the same generator the pipeline's index stage calls — so it produces identical output with no parallel implementation. The command regenerates:
- `02-Threads/Thread-Index.md`
- `03-Eddies/Eddy-Map.md`
- `06-Frequencies/F{1-10}-Index.md`
- `00-Creek-Meta/Temporal-Index.md` + `Source-Index.md`

and prints the count + written paths. Deterministic, local, idempotent (re-run overwrites in place with identical bytes).

**Motivation:** operators who add fragments or re-link previously had to re-run all of `process` just to refresh indexes; `creek index` errored.

## Test plan
New `tests/test_cli_index.py`:
- `test_index_writes_all_index_notes` — command writes the expected index notes into a scaffolded fixture vault, exit 0, reports a count + path.
- `test_index_is_idempotent` — re-run is a clean no-op (same bytes for every index note).
- `test_index_reports_count_matching_written_files` — the reported count equals the index notes actually on disk.

`./scripts/check-all.sh` green (the only local failures are the pre-existing author/compost/mcp environmental cluster — live Ollama on :11434 + operator creds — proven identical on clean `origin/main` with this branch stashed; they pass on CI).

## Scope fence
Exposes the existing generator as a command; does **not** change what the indexes contain or how they're computed.

Refs #713
Closes #717

🤖 Generated with [Claude Code](https://claude.com/claude-code)