### PR TITLE
feat(report): runnable wavelength phase-map with explicit periods + empty-dimension path (#719)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2417,9 +2417,10 @@ def _resolve_wavelength_period(period: str | None) -> tuple[str, date] | None:
 
 def _wavelength_dimension_populated(fragments: list[Fragment]) -> bool:
     """Return whether any *fragments* carry a classified wavelength phase."""
-    from creek.models import Phase as _Phase
+    # Local import: cli.py defers model imports to keep CLI startup fast.
+    from creek.models import Phase
 
-    return any(f.wavelength.phase != _Phase.UNCLASSIFIED for f in fragments)
+    return any(f.wavelength.phase != Phase.UNCLASSIFIED for f in fragments)
 
 
 def _report_wavelength(vault_path: Path, period: str | None) -> None:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2394,24 +2394,22 @@ def _resolve_wavelength_period(period: str | None) -> tuple[str, date] | None:
         date inside the target window, or ``None`` when *period* is missing or
         unparseable (the caller surfaces the error).
     """
-    from datetime import date as _date
-
-    if period in {"weekly", "monthly"}:
-        return (period, _date.today())
     if period is None:
         return None
+    if period in {"weekly", "monthly"}:
+        return (period, date.today())
     week_match = _WAVELENGTH_ISO_WEEK_RE.match(period)
     if week_match:
         year, week = int(week_match.group(1)), int(week_match.group(2))
         try:
-            return ("weekly", _date.fromisocalendar(year, week, 1))
+            return ("weekly", date.fromisocalendar(year, week, 1))
         except ValueError:
             return None
     month_match = _WAVELENGTH_MONTH_RE.match(period)
     if month_match:
         year, month = int(month_match.group(1)), int(month_match.group(2))
         try:
-            return ("monthly", _date(year, month, 1))
+            return ("monthly", date(year, month, 1))
         except ValueError:
             return None
     return None
@@ -2421,8 +2419,7 @@ def _wavelength_dimension_populated(fragments: list[Fragment]) -> bool:
     """Return whether any *fragments* carry a classified wavelength phase."""
     from creek.models import Phase as _Phase
 
-    unclassified = _Phase.UNCLASSIFIED.value
-    return any(str(f.wavelength.phase) != unclassified for f in fragments)
+    return any(f.wavelength.phase != _Phase.UNCLASSIFIED for f in fragments)
 
 
 def _report_wavelength(vault_path: Path, period: str | None) -> None:
@@ -2437,7 +2434,7 @@ def _report_wavelength(vault_path: Path, period: str | None) -> None:
     """
     from creek.generate.wavelength import (
         WavelengthTracker,
-        _load_fragments_from_vault,
+        load_fragments_from_vault,
     )
 
     resolved = _resolve_wavelength_period(period)
@@ -2449,7 +2446,7 @@ def _report_wavelength(vault_path: Path, period: str | None) -> None:
         raise typer.Exit(code=2)
     mode, anchor = resolved
 
-    fragments = _load_fragments_from_vault(vault_path)
+    fragments = load_fragments_from_vault(vault_path)
     if not _wavelength_dimension_populated(fragments):
         console.print(
             "[yellow]No wavelength phase-map written: no fragment carries a "

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -8,7 +8,7 @@ import logging
 import os
 import re
 import sys
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
@@ -2375,26 +2375,101 @@ def _report_mode_profiles(vault_path: Path) -> None:
     )
 
 
-def _report_wavelength(vault_path: Path, period: str | None) -> None:
-    """Generate weekly or monthly wavelength reports."""
+_WAVELENGTH_ISO_WEEK_RE = re.compile(r"^(\d{4})-W(\d{2})$")
+_WAVELENGTH_MONTH_RE = re.compile(r"^(\d{4})-(\d{2})$")
+
+
+def _resolve_wavelength_period(period: str | None) -> tuple[str, date] | None:
+    """Resolve a ``--period`` string to a ``(mode, anchor-date)`` pair.
+
+    Accepts the relative keywords ``weekly`` / ``monthly`` (anchored on today)
+    and explicit ``YYYY-Www`` (ISO week) / ``YYYY-MM`` (calendar month) periods,
+    so an operator can regenerate a historical phase-map deterministically.
+
+    Args:
+        period: The raw ``--period`` value.
+
+    Returns:
+        ``("weekly", anchor)`` or ``("monthly", anchor)`` where *anchor* is any
+        date inside the target window, or ``None`` when *period* is missing or
+        unparseable (the caller surfaces the error).
+    """
     from datetime import date as _date
 
-    from creek.generate.wavelength import WavelengthTracker
+    if period in {"weekly", "monthly"}:
+        return (period, _date.today())
+    if period is None:
+        return None
+    week_match = _WAVELENGTH_ISO_WEEK_RE.match(period)
+    if week_match:
+        year, week = int(week_match.group(1)), int(week_match.group(2))
+        try:
+            return ("weekly", _date.fromisocalendar(year, week, 1))
+        except ValueError:
+            return None
+    month_match = _WAVELENGTH_MONTH_RE.match(period)
+    if month_match:
+        year, month = int(month_match.group(1)), int(month_match.group(2))
+        try:
+            return ("monthly", _date(year, month, 1))
+        except ValueError:
+            return None
+    return None
 
-    if period not in {"weekly", "monthly"}:
+
+def _wavelength_dimension_populated(fragments: list[Fragment]) -> bool:
+    """Return whether any *fragments* carry a classified wavelength phase."""
+    from creek.models import Phase as _Phase
+
+    unclassified = _Phase.UNCLASSIFIED.value
+    return any(str(f.wavelength.phase) != unclassified for f in fragments)
+
+
+def _report_wavelength(vault_path: Path, period: str | None) -> None:
+    """Generate a descriptive wavelength phase-map to ``05-Wavelength/Phase-Maps/``.
+
+    Wires the deterministic :class:`WavelengthTracker` weekly/monthly generators
+    to the report surface. Supports ``--period weekly|monthly`` (today) and
+    explicit ``YYYY-Www`` / ``YYYY-MM`` periods. When no fragment carries a
+    classified wavelength phase the dimension is unpopulated, so it prints an
+    informative message instead of writing a silent empty file. Wavelength
+    output is descriptive only — it never prescribes action.
+    """
+    from creek.generate.wavelength import (
+        WavelengthTracker,
+        _load_fragments_from_vault,
+    )
+
+    resolved = _resolve_wavelength_period(period)
+    if resolved is None:
         console.print(
-            "[red]--period must be 'weekly' or 'monthly' for wavelength reports.[/red]",
+            "[red]--period must be 'weekly', 'monthly', an ISO week "
+            "(YYYY-Www), or a month (YYYY-MM) for wavelength reports.[/red]",
         )
         raise typer.Exit(code=2)
+    mode, anchor = resolved
+
+    fragments = _load_fragments_from_vault(vault_path)
+    if not _wavelength_dimension_populated(fragments):
+        console.print(
+            "[yellow]No wavelength phase-map written: no fragment carries a "
+            "classified wavelength phase. Classify the wavelength dimension "
+            "first (see #319).[/yellow]",
+        )
+        return
+
     tracker = WavelengthTracker()
-    today = _date.today()
-    if period == "weekly":
-        wavelength_path = tracker.generate_weekly_report(vault_path, week_of=today)
+    if mode == "weekly":
+        wavelength_path = tracker.generate_weekly_report(
+            vault_path, week_of=anchor, fragments=fragments
+        )
     else:
-        wavelength_path = tracker.generate_monthly_report(vault_path, month=today)
+        wavelength_path = tracker.generate_monthly_report(
+            vault_path, month=anchor, fragments=fragments
+        )
     console.print(
-        f"[bold green]Wavelength {period} report generated: "
-        f"{wavelength_path}[/bold green]",
+        f"[bold green]Wrote {wavelength_path.relative_to(vault_path)} "
+        "(descriptive; non-prescriptive)[/bold green]",
     )
 
 

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -190,7 +190,7 @@ def _safe_post(md_file: Path) -> frontmatter.Post | None:
         return None
 
 
-def _load_fragments_from_vault(vault_path: Path) -> list[Fragment]:
+def load_fragments_from_vault(vault_path: Path) -> list[Fragment]:
     """Load every classified fragment from ``01-Fragments/`` under *vault_path*.
 
     Files that fail to parse or that lack the ``type: fragment`` marker
@@ -740,7 +740,7 @@ class WavelengthTracker:
         loaded = (
             fragments
             if fragments is not None
-            else _load_fragments_from_vault(vault_path)
+            else load_fragments_from_vault(vault_path)
         )
         start = _week_start(week_of)
         end = start + timedelta(days=6)
@@ -796,7 +796,7 @@ class WavelengthTracker:
         loaded = (
             fragments
             if fragments is not None
-            else _load_fragments_from_vault(vault_path)
+            else load_fragments_from_vault(vault_path)
         )
         start, end = _month_bounds(month)
         in_window = [f for f in loaded if _fragment_in_window(f, start, end)]
@@ -1304,7 +1304,7 @@ def current_phase_summary(
     """
     anchor = today or datetime.now(tz=UTC).date()
     start = anchor - timedelta(days=window_days - 1)
-    fragments = _load_fragments_from_vault(vault_path)
+    fragments = load_fragments_from_vault(vault_path)
     fragments = select_by_policy(fragments, level_policy)
     tracker = WavelengthTracker()
     snapshot = tracker.analyze_period(fragments, start, anchor)
@@ -1354,7 +1354,7 @@ class ModeProfileGenerator:
         # enum's ``.value``s below, so the comparison stays string-to-string
         # throughout rather than mixing enum identity with string lookups.
         by_mode: dict[str, list[Fragment]] = defaultdict(list)
-        for fragment in _load_fragments_from_vault(vault_path):
+        for fragment in load_fragments_from_vault(vault_path):
             mode = str(fragment.wavelength.mode)
             if mode != Mode.UNCLASSIFIED.value:
                 by_mode[mode].append(fragment)
@@ -1427,4 +1427,5 @@ __all__ = [
     "WavelengthSnapshot",
     "WavelengthTracker",
     "current_phase_summary",
+    "load_fragments_from_vault",
 ]

--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1524,10 +1524,35 @@ def test_report_voice_command(tmp_path: Path) -> None:
     assert (vault / "07-Voice" / "confessional-profile.md").is_file()
 
 
+def _write_wavelength_fragment(vault: Path, frag_id: str) -> None:
+    """Write one fragment carrying a classified wavelength phase (#719)."""
+    from creek.models import (
+        Fragment,
+        FragmentSource,
+        Phase,
+        SourcePlatform,
+        WavelengthClassification,
+    )
+    from creek.time import now_la
+    from tests.helpers import write_fragment_file
+
+    write_fragment_file(
+        vault=vault,
+        fragment=Fragment(
+            id=frag_id,
+            title="Wavelength note",
+            source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+            authored_at=now_la(),
+            wavelength=WavelengthClassification(phase=Phase.RISING),
+        ),
+        body="A reflective entry.",
+    )
+
+
 def test_report_wavelength_weekly_command(tmp_path: Path) -> None:
-    """Test that report --type wavelength --period weekly produces a file."""
+    """report --type wavelength --period weekly writes a descriptive phase-map."""
     vault = tmp_path / "vault"
-    (vault / "01-Fragments").mkdir(parents=True, exist_ok=True)
+    _write_wavelength_fragment(vault, "frag-wavecli00001")
     result = runner.invoke(
         app,
         [
@@ -1541,14 +1566,14 @@ def test_report_wavelength_weekly_command(tmp_path: Path) -> None:
         ],
     )
     assert result.exit_code == 0, result.output
-    assert "Wavelength weekly report generated" in result.output
+    assert "non-prescriptive" in result.output.lower()
     assert list((vault / "05-Wavelength" / "Phase-Maps").glob("*.md"))
 
 
 def test_report_wavelength_monthly_command(tmp_path: Path) -> None:
-    """Test that report --type wavelength --period monthly produces a file."""
+    """report --type wavelength --period monthly writes a descriptive phase-map."""
     vault = tmp_path / "vault"
-    (vault / "01-Fragments").mkdir(parents=True, exist_ok=True)
+    _write_wavelength_fragment(vault, "frag-wavecli00002")
     result = runner.invoke(
         app,
         [
@@ -1562,7 +1587,8 @@ def test_report_wavelength_monthly_command(tmp_path: Path) -> None:
         ],
     )
     assert result.exit_code == 0, result.output
-    assert "Wavelength monthly report generated" in result.output
+    assert "non-prescriptive" in result.output.lower()
+    assert list((vault / "05-Wavelength" / "Phase-Maps").glob("*.md"))
 
 
 def test_report_wavelength_unknown_period_errors(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_cli_report_wavelength.py
+++ b/creek-tools/tests/test_cli_report_wavelength.py
@@ -1,0 +1,182 @@
+"""CLI tests for ``creek report --type wavelength`` (#719).
+
+Wires the existing descriptive :class:`WavelengthTracker` generators to the
+report surface: ``--period weekly|monthly`` (anchored on today) plus explicit
+``YYYY-Www`` / ``YYYY-MM`` periods, and an informative path when the
+``wavelength`` classification dimension is unpopulated (no silent empty file).
+Wavelength output is descriptive only — never prescriptive.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.models import (
+    Fragment,
+    FragmentSource,
+    Phase,
+    SourcePlatform,
+    WavelengthClassification,
+)
+from creek.time import now_la
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+
+def _classified_vault(vault: Path, *, classified: bool = True) -> None:
+    """Write three fragments, with or without a classified wavelength phase."""
+    phases = [Phase.RISING, Phase.PEAKING, Phase.WITHDRAWAL]
+    for i in range(3):
+        wavelength = (
+            WavelengthClassification(phase=phases[i])
+            if classified
+            else WavelengthClassification()
+        )
+        write_fragment_file(
+            vault=vault,
+            fragment=Fragment(
+                id=f"frag-wave00000{i:03d}",
+                title=f"Wave note {i}",
+                source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+                authored_at=now_la(),
+                wavelength=wavelength,
+            ),
+            body=f"Reflective entry {i}.",
+        )
+
+
+def _phase_maps(vault: Path) -> list[Path]:
+    """Return the phase-map notes written under 05-Wavelength/Phase-Maps/."""
+    pm = vault / "05-Wavelength" / "Phase-Maps"
+    return sorted(pm.glob("*.md")) if pm.exists() else []
+
+
+def test_wavelength_weekly_writes_phase_map(tmp_path: Path) -> None:
+    """``--type wavelength --period weekly`` writes a descriptive phase-map."""
+    vault = tmp_path / "vault"
+    _classified_vault(vault)
+
+    result = runner.invoke(
+        app,
+        ["report", "--type", "wavelength", "--period", "weekly", "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    pages = _phase_maps(vault)
+    assert len(pages) == 1
+    assert pages[0].name.endswith("-wavelength.md")
+    assert "wavelength" in pages[0].name
+    assert "descriptive" in result.output.lower()
+    assert "non-prescriptive" in result.output.lower()
+
+
+def test_wavelength_monthly_writes_phase_map(tmp_path: Path) -> None:
+    """``--period monthly`` writes the monthly phase-map note."""
+    vault = tmp_path / "vault"
+    _classified_vault(vault)
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "--type",
+            "wavelength",
+            "--period",
+            "monthly",
+            "--vault",
+            str(vault),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert len(_phase_maps(vault)) == 1
+
+
+def test_wavelength_explicit_iso_week_period(tmp_path: Path) -> None:
+    """An explicit ``YYYY-Www`` period names the report for that ISO week."""
+    vault = tmp_path / "vault"
+    _classified_vault(vault)
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "--type",
+            "wavelength",
+            "--period",
+            "2026-W26",
+            "--vault",
+            str(vault),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (vault / "05-Wavelength" / "Phase-Maps" / "2026-W26-wavelength.md").is_file()
+
+
+def test_wavelength_explicit_month_period(tmp_path: Path) -> None:
+    """An explicit ``YYYY-MM`` period names the report for that month."""
+    vault = tmp_path / "vault"
+    _classified_vault(vault)
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "--type",
+            "wavelength",
+            "--period",
+            "2026-06",
+            "--vault",
+            str(vault),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert (vault / "05-Wavelength" / "Phase-Maps" / "2026-06-wavelength.md").is_file()
+
+
+def test_wavelength_unpopulated_dimension_is_informative(tmp_path: Path) -> None:
+    """An unpopulated wavelength dimension prints a message and writes no file."""
+    vault = tmp_path / "vault"
+    _classified_vault(vault, classified=False)
+
+    result = runner.invoke(
+        app,
+        ["report", "--type", "wavelength", "--period", "weekly", "--vault", str(vault)],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert _phase_maps(vault) == []
+    assert "wavelength" in result.output.lower()
+    # Informative, not a silent empty file.
+    assert "no" in result.output.lower()
+
+
+def test_wavelength_invalid_period_exits_two(tmp_path: Path) -> None:
+    """An unparseable period exits 2 with a clear message."""
+    vault = tmp_path / "vault"
+    _classified_vault(vault)
+
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "--type",
+            "wavelength",
+            "--period",
+            "not-a-period",
+            "--vault",
+            str(vault),
+        ],
+    )
+
+    assert result.exit_code == 2, result.output
+    assert "period" in result.output.lower()

--- a/creek-tools/tests/test_cli_report_wavelength.py
+++ b/creek-tools/tests/test_cli_report_wavelength.py
@@ -25,13 +25,25 @@ from creek.time import now_la
 from tests.helpers import write_fragment_file
 
 if TYPE_CHECKING:
+    from datetime import datetime
     from pathlib import Path
 
 runner = CliRunner()
 
 
-def _classified_vault(vault: Path, *, classified: bool = True) -> None:
-    """Write three fragments, with or without a classified wavelength phase."""
+def _classified_vault(
+    vault: Path,
+    *,
+    classified: bool = True,
+    authored_at: datetime | None = None,
+) -> None:
+    """Write three fragments, with or without a classified wavelength phase.
+
+    *authored_at* anchors every fragment's authored date so a test can place
+    them inside a specific target window (e.g. an explicit ISO week); it
+    defaults to now.
+    """
+    when = authored_at if authored_at is not None else now_la()
     phases = [Phase.RISING, Phase.PEAKING, Phase.WITHDRAWAL]
     for i in range(3):
         wavelength = (
@@ -45,7 +57,7 @@ def _classified_vault(vault: Path, *, classified: bool = True) -> None:
                 id=f"frag-wave00000{i:03d}",
                 title=f"Wave note {i}",
                 source=FragmentSource(platform=SourcePlatform.MARKDOWN),
-                authored_at=now_la(),
+                authored_at=when,
                 wavelength=wavelength,
             ),
             body=f"Reflective entry {i}.",
@@ -100,9 +112,12 @@ def test_wavelength_monthly_writes_phase_map(tmp_path: Path) -> None:
 
 
 def test_wavelength_explicit_iso_week_period(tmp_path: Path) -> None:
-    """An explicit ``YYYY-Www`` period names the report for that ISO week."""
+    """An explicit ``YYYY-Www`` period regenerates that ISO week from its data."""
     vault = tmp_path / "vault"
-    _classified_vault(vault)
+    # Anchor the fragments inside ISO week 2026-W26 (Mon 2026-06-22) so the
+    # historical report actually aggregates them, not just names the file.
+    in_week = now_la().replace(year=2026, month=6, day=23)
+    _classified_vault(vault, authored_at=in_week)
 
     result = runner.invoke(
         app,
@@ -118,13 +133,18 @@ def test_wavelength_explicit_iso_week_period(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert (vault / "05-Wavelength" / "Phase-Maps" / "2026-W26-wavelength.md").is_file()
+    assert "non-prescriptive" in result.output.lower()
+    page = vault / "05-Wavelength" / "Phase-Maps" / "2026-W26-wavelength.md"
+    assert page.is_file()
+    # The in-window fragments make the report non-trivial, not an empty shell.
+    assert "Wave note" in page.read_text(encoding="utf-8")
 
 
 def test_wavelength_explicit_month_period(tmp_path: Path) -> None:
-    """An explicit ``YYYY-MM`` period names the report for that month."""
+    """An explicit ``YYYY-MM`` period regenerates that month from its data."""
     vault = tmp_path / "vault"
-    _classified_vault(vault)
+    in_month = now_la().replace(year=2026, month=6, day=15)
+    _classified_vault(vault, authored_at=in_month)
 
     result = runner.invoke(
         app,
@@ -140,7 +160,10 @@ def test_wavelength_explicit_month_period(tmp_path: Path) -> None:
     )
 
     assert result.exit_code == 0, result.output
-    assert (vault / "05-Wavelength" / "Phase-Maps" / "2026-06-wavelength.md").is_file()
+    assert "non-prescriptive" in result.output.lower()
+    page = vault / "05-Wavelength" / "Phase-Maps" / "2026-06-wavelength.md"
+    assert page.is_file()
+    assert "Wave note" in page.read_text(encoding="utf-8")
 
 
 def test_wavelength_unpopulated_dimension_is_informative(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_cli_report_wavelength.py
+++ b/creek-tools/tests/test_cli_report_wavelength.py
@@ -155,9 +155,8 @@ def test_wavelength_unpopulated_dimension_is_informative(tmp_path: Path) -> None
 
     assert result.exit_code == 0, result.output
     assert _phase_maps(vault) == []
-    assert "wavelength" in result.output.lower()
-    # Informative, not a silent empty file.
-    assert "no" in result.output.lower()
+    # Informative, not a silent empty file — pin to the actual message.
+    assert "no wavelength phase-map written" in result.output.lower()
 
 
 def test_wavelength_invalid_period_exits_two(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Makes the **05-Wavelength phase-maps** fully runnable from `creek report --type wavelength`. The command already drove the descriptive `WavelengthTracker` weekly/monthly generators; this closes two gaps:

1. **Unpopulated wavelength dimension → informative, not a silent empty file.** `_report_wavelength` now loads fragments once and, when no fragment carries a classified wavelength phase, prints a clear message (pointing at the #319 classification prerequisite) and writes nothing — mirroring the `mode-profiles` sibling.
2. **Explicit periods.** `--period` accepted only `weekly`/`monthly` (anchored on today). Added `YYYY-Www` (ISO week) and `YYYY-MM` (calendar month) via `_resolve_wavelength_period`, so a historical phase-map regenerates deterministically. Success output: `Wrote 05-Wavelength/Phase-Maps/<file> (descriptive; non-prescriptive)`.

Wavelength output stays **descriptive only** — never prescriptive (deliberate ontology decision). Wires the existing generators; detection/aggregation semantics unchanged.

## Test plan
New `tests/test_cli_report_wavelength.py`:
- weekly + monthly write a phase-map (descriptive / non-prescriptive message);
- explicit `2026-W26` → `2026-W26-wavelength.md`; explicit `2026-06` → `2026-06-wavelength.md`;
- unpopulated wavelength dimension → informative message, **no** file;
- unparseable period → exit 2.

Also updated the two existing `test_cli` wavelength tests, which encoded the old silent-empty-file behaviour (empty `01-Fragments`), to populate a wavelength fragment and assert the new write-path message.

`./scripts/check-all.sh`: formatting/lint/mypy-strict/complexity all green; the only failing unit tests are the pre-existing author/compost/mcp environmental cluster (operator's live Ollama + creds), proven identical on clean `origin/main` — they pass on CI.

## Scope fence
Wires the existing descriptive generators; keeps wavelength non-prescriptive.

Refs #713
Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)