### PR TITLE
feat(cli): `creek fill` umbrella for the deterministic vault-population sequence (#720)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2182,6 +2182,141 @@ def index(
     )
 
 
+_FILL_SUMMARY_FOLDERS: tuple[str, ...] = (
+    "02-Threads",
+    "03-Eddies",
+    "04-Praxis",
+    "05-Wavelength",
+    "06-Frequencies",
+    "08-Decisions",
+    "09-Reference",
+    "10-Liminal",
+)
+"""Vault folders whose markdown population ``creek fill`` reports in its summary."""
+
+
+def _build_fill_steps(
+    vault_path: Path,
+    config: CreekConfig,
+    *,
+    with_compost: bool,
+) -> list[tuple[str, Callable[[], object]]]:
+    """Build the ordered ``(label, action)`` plan for ``creek fill``.
+
+    Pure orchestration: each action calls an existing step command/function in
+    dependency order — embeddings/temporal/eddies/thread-page links first (links
+    must precede the thread and eddy pages), then the deterministic reports, then
+    the index regeneration. ``--with-compost`` appends the deterministic compost
+    overview report. No generator logic lives here.
+
+    Args:
+        vault_path: Vault root.
+        config: Loaded Creek configuration (threaded into the link steps).
+        with_compost: When ``True`` append the compost overview report step.
+
+    Returns:
+        The ordered list of ``(label, zero-arg callable)`` steps.
+    """
+    from creek.generate.indexes import IndexGenerator
+    from creek.link.link_engine import run_link
+
+    def _link(method: str) -> Callable[[], object]:
+        return lambda: run_link(
+            vault_path=vault_path, config=config, method=method, rebuild=False
+        )
+
+    steps: list[tuple[str, Callable[[], object]]] = [
+        ("link/embeddings", _link("embeddings")),
+        ("link/temporal", _link("temporal")),
+        ("link/eddies", _link("eddies")),
+        ("link/threads", _link("threads")),
+        ("report/decisions", lambda: _report_decisions(vault_path)),
+        ("report/unnamed", lambda: _report_unnamed(vault_path)),
+        ("report/paradox", lambda: _report_paradox(vault_path)),
+        ("report/synchronicity", lambda: _report_synchronicity(vault_path)),
+        ("report/mode-profiles", lambda: _report_mode_profiles(vault_path)),
+        ("report/wavelength", lambda: _report_wavelength(vault_path, "weekly")),
+        ("index", lambda: IndexGenerator(vault_path=vault_path).generate_all()),
+    ]
+    if with_compost:
+        steps.append(("compost/report", lambda: _fill_compost_report(vault_path)))
+    return steps
+
+
+def _fill_compost_report(vault_path: Path) -> object:
+    """Run the deterministic compost overview report (the opt-in fill step)."""
+    from creek.generate.compost import CompostTracker
+
+    return CompostTracker().generate_compost_report(vault_path)
+
+
+def _count_markdown(folder: Path) -> int:
+    """Count non-hidden markdown files under *folder* (0 when it is absent)."""
+    if not folder.exists():
+        return 0
+    return sum(1 for p in folder.rglob("*.md") if not p.name.startswith("."))
+
+
+def _format_fill_summary(vault_path: Path) -> str:
+    """Render the per-folder population summary line for ``creek fill``."""
+    parts = [
+        f"{name} {_count_markdown(vault_path / name)}" for name in _FILL_SUMMARY_FOLDERS
+    ]
+    return "[bold green][fill] done. " + " | ".join(parts) + "[/bold green]"
+
+
+@app.command()
+def fill(
+    vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Print the plan without running any step."
+    ),
+    with_compost: bool = typer.Option(
+        False,
+        "--with-compost",
+        help="Also run the compost overview report (off by default).",
+    ),
+) -> None:
+    """Run the deterministic vault-population sequence in dependency order.
+
+    An umbrella over the existing per-generator steps: it runs the link stages
+    (embeddings, temporal, eddies, thread-pages), the deterministic reports
+    (decisions, unnamed, paradox, synchronicity, mode-profiles, wavelength), and
+    the index regeneration — so an already-classified, already-embedded vault
+    becomes prod-ready from one command. Classification and embedding are
+    preconditions, not run here.
+
+    Each step is non-fatal: a failure is logged and the sequence continues, so
+    one bad step cannot abort the rest. ``--dry-run`` prints the plan and runs
+    nothing. ``--with-compost`` appends the deterministic compost overview
+    report (the only compost vault-write currently wired). Every underlying step
+    is idempotent, so a second ``creek fill`` is a clean no-op.
+    """
+    config = _load_config_for_vault(vault)
+    vault_path = _resolve_vault(vault)
+    steps = _build_fill_steps(vault_path, config, with_compost=with_compost)
+
+    if dry_run:
+        console.print("[bold]creek fill plan (dry-run, nothing run):[/bold]")
+        for index_, (label, _action) in enumerate(steps, start=1):
+            console.print(f"  {index_:>2}. {label}")
+        return
+
+    for label, action in steps:
+        console.print(f"[dim][fill] {label} …[/dim]")
+        try:
+            action()
+        except Exception as exc:
+            # Orchestrator contract: a single failing step (missing embedding
+            # model, empty dimension, I/O error) must not abort the remaining
+            # steps. Catch broadly, log, and carry on; the final summary shows
+            # what actually populated.
+            logger.warning("fill step %s failed: %s", label, exc)
+            console.print(f"[yellow][fill] {label} failed: {exc}[/yellow]")
+
+    console.print(_format_fill_summary(vault_path))
+
+
 @app.command(name="compile")
 def compile_(
     fragment_id: str = typer.Argument(..., help="Source fragment ID to roll up"),

--- a/creek-tools/tests/test_cli_fill.py
+++ b/creek-tools/tests/test_cli_fill.py
@@ -1,0 +1,184 @@
+"""CLI tests for the ``creek fill`` umbrella command (#720).
+
+``creek fill`` is pure orchestration over already-merged steps, so these tests
+mock each underlying step and assert: the steps run in dependency order, a step
+failure is non-fatal, ``--dry-run`` runs nothing, ``--with-compost`` appends the
+compost step, and the summary reports real per-folder counts.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+import creek.cli as cli_mod
+from creek.cli import app
+from creek.generate import compost as compost_mod
+from creek.generate import indexes as indexes_mod
+from creek.link import link_engine
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+runner = CliRunner()
+
+_EXPECTED_ORDER = [
+    "link/embeddings",
+    "link/temporal",
+    "link/eddies",
+    "link/threads",
+    "report/decisions",
+    "report/unnamed",
+    "report/paradox",
+    "report/synchronicity",
+    "report/mode-profiles",
+    "report/wavelength",
+    "index",
+]
+
+
+def _install_recorders(
+    monkeypatch: pytest.MonkeyPatch,
+    calls: list[str],
+    *,
+    fail: str | None = None,
+) -> None:
+    """Replace every underlying step with a recorder appending its label."""
+
+    def rec(label: str) -> object:
+        def _step(*_a: object, **_k: object) -> None:
+            calls.append(label)
+            if label == fail:
+                msg = f"boom in {label}"
+                raise RuntimeError(msg)
+
+        return _step
+
+    monkeypatch.setattr(
+        link_engine,
+        "run_link",
+        lambda **k: rec(f"link/{k['method']}")(),
+    )
+    for name, label in (
+        ("_report_decisions", "report/decisions"),
+        ("_report_unnamed", "report/unnamed"),
+        ("_report_paradox", "report/paradox"),
+        ("_report_synchronicity", "report/synchronicity"),
+        ("_report_mode_profiles", "report/mode-profiles"),
+    ):
+        monkeypatch.setattr(cli_mod, name, rec(label))
+    monkeypatch.setattr(
+        cli_mod,
+        "_report_wavelength",
+        lambda _vault, _period: rec("report/wavelength")(),
+    )
+
+    class _FakeIndex:
+        def __init__(self, *, vault_path: Path) -> None:
+            self._vault_path = vault_path
+
+        def generate_all(self) -> list[Path]:
+            rec("index")()
+            return []
+
+    monkeypatch.setattr(indexes_mod, "IndexGenerator", _FakeIndex)
+
+    class _FakeCompost:
+        def generate_compost_report(self, vault_path: Path) -> Path:
+            rec("compost/report")()
+            return vault_path
+
+    monkeypatch.setattr(compost_mod, "CompostTracker", _FakeCompost)
+
+
+def test_fill_runs_all_steps_in_dependency_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``creek fill`` runs every step once, in the documented order."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    calls: list[str] = []
+    _install_recorders(monkeypatch, calls)
+
+    result = runner.invoke(app, ["fill", "--vault", str(vault)])
+
+    assert result.exit_code == 0, result.output
+    assert calls == _EXPECTED_ORDER
+
+
+def test_fill_step_failure_is_non_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failing step is logged and the remaining steps still run."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    calls: list[str] = []
+    _install_recorders(monkeypatch, calls, fail="report/decisions")
+
+    result = runner.invoke(app, ["fill", "--vault", str(vault)])
+
+    assert result.exit_code == 0, result.output
+    # Every step was still attempted despite the failure mid-sequence.
+    assert calls == _EXPECTED_ORDER
+    assert "report/decisions failed" in result.output
+
+
+def test_fill_dry_run_runs_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--dry-run`` prints the plan and invokes no step."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    calls: list[str] = []
+    _install_recorders(monkeypatch, calls)
+
+    result = runner.invoke(app, ["fill", "--vault", str(vault), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == []
+    assert "dry-run" in result.output.lower()
+    for label in _EXPECTED_ORDER:
+        assert label in result.output
+
+
+def test_fill_with_compost_appends_compost_step(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--with-compost`` adds the compost overview step after the core sequence."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    calls: list[str] = []
+    _install_recorders(monkeypatch, calls)
+
+    result = runner.invoke(app, ["fill", "--vault", str(vault), "--with-compost"])
+
+    assert result.exit_code == 0, result.output
+    assert calls == [*_EXPECTED_ORDER, "compost/report"]
+
+
+def test_fill_summary_reports_folder_counts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The final summary counts the markdown actually present per folder."""
+    vault = tmp_path / "vault"
+    (vault / "02-Threads" / "Active").mkdir(parents=True)
+    (vault / "02-Threads" / "Active" / "a.md").write_text("x", encoding="utf-8")
+    (vault / "02-Threads" / "Active" / "b.md").write_text("x", encoding="utf-8")
+    # A hidden index file must not be counted.
+    (vault / "02-Threads" / "Active" / ".id-index.jsonl").write_text(
+        "{}", encoding="utf-8"
+    )
+    (vault / "08-Decisions").mkdir(parents=True)
+    (vault / "08-Decisions" / "d.md").write_text("x", encoding="utf-8")
+
+    calls: list[str] = []
+    _install_recorders(monkeypatch, calls)
+
+    result = runner.invoke(app, ["fill", "--vault", str(vault)])
+
+    assert result.exit_code == 0, result.output
+    assert "02-Threads 2" in result.output
+    assert "08-Decisions 1" in result.output


### PR DESCRIPTION
## Summary
Capstone of epic #713. Adds **`creek fill --vault <path>`** — an umbrella over the existing per-generator steps that runs the deterministic, local vault-population sequence in dependency order, so an already-classified + already-embedded vault becomes prod-ready from one command instead of memorising six:

```
link/embeddings → link/temporal → link/eddies → link/threads →
report/decisions → report/unnamed → report/paradox → report/synchronicity →
report/mode-profiles → report/wavelength → index
```

**Pure orchestration** — it calls the existing step commands/functions (`run_link`, the `_report_*` handlers, `IndexGenerator`); it implements no generator logic. Links run before the thread/eddy pages they feed; classification + embedding are preconditions, not run here.

- **Non-fatal steps:** a failing step (missing embedding model, empty dimension, I/O error) is logged and the sequence continues, so one bad step can't abort the rest. A final per-folder population summary prints.
- **`--dry-run`:** prints the numbered plan and runs nothing.
- **`--with-compost`:** appends the deterministic compost overview report (`CompostTracker.generate_compost_report`). This is the only compost vault-write currently wired — the LLM compost-*detection* pass is not yet a CLI command (pre-existing gap), so it is out of scope here.
- **Idempotent:** every underlying step is idempotent (threads #718, index #717, links overwrite, reports overwrite/dedupe), so a second `creek fill` is a clean no-op.

## Test plan
New `tests/test_cli_fill.py` (mocks each underlying step):
- runs every step once in the documented dependency order;
- a step failure mid-sequence is non-fatal — all later steps still run, exit 0, the failure is reported;
- `--dry-run` invokes nothing and prints the full plan;
- `--with-compost` appends `compost/report` after the core sequence;
- the summary counts the markdown actually present per folder (and ignores hidden index files).

Also smoke-tested the real (unmocked) `creek fill --dry-run --with-compost` — the plan prints all 12 steps, confirming the live wiring imports cleanly.

`./scripts/check-all.sh`: formatting/lint/mypy-strict/tryceratops/complexity all green; the only failing unit tests are the pre-existing author/compost/mcp environmental cluster (operator's live Ollama + creds), proven identical on clean `origin/main` — they pass on CI.

## Scope fence
Orchestration only — calls existing steps, no generator logic; respects dependencies (link before threads/eddies; classify+embed are preconditions, not run by `fill`).

Refs #713
Closes #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)