### PR TITLE
perf(link): top-k/ANN resonance discovery for scale (#722)

### DIFF
--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -294,6 +294,19 @@ class EmbeddingsConfig(BaseModel):
     similarity_threshold: float = 0.75
     """Minimum cosine similarity for linking fragments."""
 
+    resonance_method: Literal["exact", "topk"] = "exact"
+    """Resonance-discovery strategy (#722).
+
+    ``exact`` (default) emits every above-``similarity_threshold`` pair — the
+    validated, exhaustive path. ``topk`` keeps only each fragment's
+    ``resonance_top_k`` most-similar above-threshold neighbours, bounding the
+    edge set to O(n·k) for large vaults; its output is always a subset of the
+    exact path's edges.
+    """
+
+    resonance_top_k: int = Field(default=10, ge=1)
+    """Per-fragment neighbour cap for ``resonance_method = "topk"`` (#722)."""
+
     cache_dir: str | None = None
     """Local directory for caching downloaded models."""
 

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -295,7 +295,7 @@ class EmbeddingsConfig(BaseModel):
     """Minimum cosine similarity for linking fragments."""
 
     resonance_method: Literal["exact", "topk"] = "exact"
-    """Resonance-discovery strategy (#722).
+    """Resonance-discovery strategy.
 
     ``exact`` (default) emits every above-``similarity_threshold`` pair — the
     validated, exhaustive path. ``topk`` keeps only each fragment's
@@ -305,7 +305,7 @@ class EmbeddingsConfig(BaseModel):
     """
 
     resonance_top_k: int = Field(default=10, ge=1)
-    """Per-fragment neighbour cap for ``resonance_method = "topk"`` (#722)."""
+    """Per-fragment neighbour cap when ``resonance_method = "topk"``."""
 
     cache_dir: str | None = None
     """Local directory for caching downloaded models."""

--- a/creek-tools/creek/link/embeddings.py
+++ b/creek-tools/creek/link/embeddings.py
@@ -757,8 +757,8 @@ class EmbeddingLinker:
 
         # ``exact`` (default) emits every above-threshold pair; ``topk`` keeps
         # only each fragment's k best neighbours. Both compute similarities one
-        # row-block at a time via vectorized matmul (never the full NxN matrix;
-        # OPS-004 / #596) and emit pairs in ascending ``(i, j)`` index order.
+        # row-block at a time via vectorized matmul (never the full NxN matrix)
+        # and emit pairs in ascending ``(i, j)`` index order.
         if self.config.resonance_method == "topk":
             resonances, suppressed = self._resonances_topk(
                 ids=ids,

--- a/creek-tools/creek/link/embeddings.py
+++ b/creek-tools/creek/link/embeddings.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
     from pathlib import Path
 
+    import numpy as np
+    from numpy.typing import NDArray
     from sentence_transformers import SentenceTransformer as SentenceTransformerType
 
     from creek.config import EmbeddingsConfig
@@ -351,6 +353,44 @@ def _level_for(fid: str, fragments: Mapping[str, Fragment]) -> FragmentLevel:
     if frag is None:
         return _DEFAULT_LEVEL
     return frag.level
+
+
+def _top_k_neighbours(
+    row: NDArray[np.float32],
+    i: int,
+    threshold: float,
+    top_k: int,
+) -> list[int]:
+    """Return the indices of fragment *i*'s top-*top_k* above-*threshold* neighbours.
+
+    Excludes ``i`` itself (cosine self-similarity is 1.0). Uses
+    :func:`numpy.argpartition` to select the *top_k* largest among the
+    above-threshold candidates in O(c) rather than fully sorting the row, where
+    *c* is the candidate count. The returned indices are unordered — the caller
+    re-sorts the final edge list into the canonical ``(i, j)`` order.
+
+    Args:
+        row: Cosine similarities of fragment *i* against every fragment.
+        i: The query fragment's index (excluded from its own neighbours).
+        threshold: Minimum similarity for a neighbour to qualify.
+        top_k: Maximum neighbours to keep.
+
+    Returns:
+        Up to *top_k* neighbour indices, each with ``row[idx] >= threshold``.
+    """
+    import numpy as np  # lazy: numpy lives in the [embeddings] extra
+
+    candidates = np.nonzero(row >= threshold)[0]
+    candidates = candidates[candidates != i]
+    if candidates.size == 0:
+        return []
+    if candidates.size > top_k:
+        candidate_sims = row[candidates]
+        keep = np.argpartition(candidate_sims, candidates.size - top_k)[
+            candidates.size - top_k :
+        ]
+        candidates = candidates[keep]
+    return [int(idx) for idx in candidates]
 
 
 def _is_hierarchy_suppressed(
@@ -710,15 +750,64 @@ class EmbeddingLinker:
         levels = _level_lookup(ids, fragments)
         threshold = self.config.similarity_threshold
 
+        # ``exact`` (default) emits every above-threshold pair; ``topk`` keeps
+        # only each fragment's k best neighbours (#722). Both compute
+        # similarities one row-block at a time via vectorized matmul (never the
+        # full NxN matrix; OPS-004 / #596) and emit pairs in ascending
+        # ``(i, j)`` index order.
+        if self.config.resonance_method == "topk":
+            resonances, suppressed = self._resonances_topk(
+                ids=ids,
+                normalized=normalized,
+                threshold=threshold,
+                top_k=self.config.resonance_top_k,
+                ancestors=ancestors,
+                sibling_positions=sibling_positions,
+                levels=levels,
+                sibling_skip_window=sibling_skip_window,
+            )
+        else:
+            resonances, suppressed = self._resonances_exact(
+                ids=ids,
+                normalized=normalized,
+                threshold=threshold,
+                ancestors=ancestors,
+                sibling_positions=sibling_positions,
+                levels=levels,
+                sibling_skip_window=sibling_skip_window,
+            )
+
+        if suppressed:
+            logger.info(
+                "Suppressed %d hierarchy-trivial resonance(s) "
+                "(ancestor/descendant or adjacent siblings within %d)",
+                suppressed,
+                sibling_skip_window,
+            )
+        logger.info("Found %d resonance(s)", len(resonances))
+        return resonances
+
+    def _resonances_exact(
+        self,
+        *,
+        ids: list[str],
+        normalized: NDArray[np.float32],
+        threshold: float,
+        ancestors: dict[str, frozenset[str]],
+        sibling_positions: dict[str, tuple[str, int]],
+        levels: dict[str, FragmentLevel],
+        sibling_skip_window: int,
+    ) -> tuple[list[Resonance], int]:
+        """Exact all-pairs path: emit every above-*threshold* pair (i < j).
+
+        Computes the upper triangle one row-block at a time so peak memory is
+        ``block_rows x N`` rather than the full matrix. Returns the resonances
+        and the count suppressed by hierarchy rules.
+        """
+        import numpy as np  # lazy: numpy lives in the [embeddings] extra
+
         resonances: list[Resonance] = []
         suppressed = 0
-        # Resonance discovery compares every pair, but similarities are computed
-        # one block of rows at a time via vectorized matmul (never materializing
-        # the full NxN matrix) and thresholded with numpy, so only
-        # above-threshold pairs reach Python. Peak memory is block_rows x N,
-        # which scales to ≥50k fragments — unlike the old full-matrix +
-        # itertools.combinations loop (OPS-004 / #596). Pairs are still emitted
-        # in ascending ``(i, j)`` index order.
         n = len(ids)
         for start in range(0, n, _RESONANCE_BLOCK_ROWS):
             stop = min(start + _RESONANCE_BLOCK_ROWS, n)
@@ -748,13 +837,64 @@ class EmbeddingLinker:
                         ),
                     )
             del block_sims
+        return resonances, suppressed
 
-        if suppressed:
-            logger.info(
-                "Suppressed %d hierarchy-trivial resonance(s) "
-                "(ancestor/descendant or adjacent siblings within %d)",
-                suppressed,
-                sibling_skip_window,
+    def _resonances_topk(
+        self,
+        *,
+        ids: list[str],
+        normalized: NDArray[np.float32],
+        threshold: float,
+        top_k: int,
+        ancestors: dict[str, frozenset[str]],
+        sibling_positions: dict[str, tuple[str, int]],
+        levels: dict[str, FragmentLevel],
+        sibling_skip_window: int,
+    ) -> tuple[list[Resonance], int]:
+        """Top-k path: keep each fragment's *top_k* best above-*threshold* neighbours.
+
+        Bounds the edge set to O(n·k). Each directed (i -> neighbour) pick is
+        folded to its undirected ``(i < j)`` form and de-duplicated, so the
+        output is always a subset of the exact path's edges; the final list is
+        sorted into the same ascending ``(i, j)`` order the exact path emits.
+        Returns the resonances and the hierarchy-suppressed count.
+        """
+        n = len(ids)
+        seen: set[tuple[int, int]] = set()
+        picked: list[tuple[int, int, float]] = []
+        suppressed = 0
+        for start in range(0, n, _RESONANCE_BLOCK_ROWS):
+            stop = min(start + _RESONANCE_BLOCK_ROWS, n)
+            block_sims = normalized[start:stop] @ normalized.T
+            for local_index, i in enumerate(range(start, stop)):
+                row = block_sims[local_index]
+                for j in _top_k_neighbours(row, i, threshold, top_k):
+                    lo, hi = (i, j) if i < j else (j, i)
+                    if (lo, hi) in seen:
+                        continue
+                    seen.add((lo, hi))
+                    if _is_hierarchy_suppressed(
+                        ids[lo],
+                        ids[hi],
+                        ancestors=ancestors,
+                        sibling_positions=sibling_positions,
+                        sibling_skip_window=sibling_skip_window,
+                    ):
+                        suppressed += 1
+                        continue
+                    picked.append((lo, hi, float(row[j])))
+            del block_sims
+        # Tuples sort lexicographically; (lo, hi) keys are unique (deduped via
+        # ``seen``), so this yields ascending (i, j) order without a key.
+        picked.sort()
+        resonances = [
+            Resonance(
+                fragment_a_id=ids[lo],
+                fragment_b_id=ids[hi],
+                similarity=sim,
+                from_level=levels[ids[lo]],
+                to_level=levels[ids[hi]],
             )
-        logger.info("Found %d resonance(s)", len(resonances))
-        return resonances
+            for lo, hi, sim in picked
+        ]
+        return resonances, suppressed

--- a/creek-tools/creek/link/embeddings.py
+++ b/creek-tools/creek/link/embeddings.py
@@ -369,6 +369,11 @@ def _top_k_neighbours(
     *c* is the candidate count. The returned indices are unordered — the caller
     re-sorts the final edge list into the canonical ``(i, j)`` order.
 
+    Tie-breaking is implementation-defined: ``argpartition`` is not stable, so
+    when more than *top_k* candidates share the same similarity, which of the
+    tied neighbours fall inside the cap is unspecified (and may differ across
+    numpy versions). Edges above the cut are always exact and above threshold.
+
     Args:
         row: Cosine similarities of fragment *i* against every fragment.
         i: The query fragment's index (excluded from its own neighbours).
@@ -751,10 +756,9 @@ class EmbeddingLinker:
         threshold = self.config.similarity_threshold
 
         # ``exact`` (default) emits every above-threshold pair; ``topk`` keeps
-        # only each fragment's k best neighbours (#722). Both compute
-        # similarities one row-block at a time via vectorized matmul (never the
-        # full NxN matrix; OPS-004 / #596) and emit pairs in ascending
-        # ``(i, j)`` index order.
+        # only each fragment's k best neighbours. Both compute similarities one
+        # row-block at a time via vectorized matmul (never the full NxN matrix;
+        # OPS-004 / #596) and emit pairs in ascending ``(i, j)`` index order.
         if self.config.resonance_method == "topk":
             resonances, suppressed = self._resonances_topk(
                 ids=ids,

--- a/creek-tools/tests/test_topk_resonance.py
+++ b/creek-tools/tests/test_topk_resonance.py
@@ -10,18 +10,41 @@ plus a scale test proving the O(n·k) bound.
 from __future__ import annotations
 
 import math
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
 
 from creek.config import EmbeddingsConfig
 from creek.link.embeddings import EmbeddingLinker
+from creek.models import Fragment, FragmentSource, SourcePlatform
+
+if TYPE_CHECKING:
+    from creek.models import FragmentLevel
 
 
 def _fan(degrees: float) -> list[float]:
     """Return a 2-D unit vector at *degrees* from the x-axis."""
     radians = math.radians(degrees)
     return [math.cos(radians), math.sin(radians)]
+
+
+def _hier_fragment(
+    fid: str,
+    *,
+    parent_id: str | None = None,
+    child_ids: list[str] | None = None,
+    level: FragmentLevel = "document",
+) -> Fragment:
+    """Build a Fragment with explicit hierarchy fields for suppression tests."""
+    return Fragment(
+        id=fid,
+        title=fid,
+        source=FragmentSource(platform=SourcePlatform.CLAUDE),
+        parent_id=parent_id,
+        child_ids=child_ids or [],
+        level=level,
+    )
 
 
 # A fan where cosine similarity = cos(angle gap). Gaps widen (4°,6°,8°) so there
@@ -36,7 +59,9 @@ _FAN_EMBEDDINGS = {
 }
 
 
-def _pairs(linker: EmbeddingLinker, embeddings: dict[str, list[float]]) -> list:
+def _pairs(
+    linker: EmbeddingLinker, embeddings: dict[str, list[float]]
+) -> list[tuple[str, str]]:
     """Return resonance edges as ``(a_id, b_id)`` tuples."""
     return [
         (r.fragment_a_id, r.fragment_b_id) for r in linker.find_resonances(embeddings)
@@ -109,6 +134,49 @@ def test_topk_preserves_ascending_index_order() -> None:
     )
     pairs = _pairs(linker, _FAN_EMBEDDINGS)
     assert pairs == sorted(pairs)
+
+
+def test_topk_suppresses_hierarchy_trivial_pairs() -> None:
+    """A parent/child pair is never emitted by the top-k path either.
+
+    Exercises the ``suppressed`` branch in ``_resonances_topk``: the two
+    fragments are identical (cosine 1.0, so each is the other's top neighbour),
+    but they are ancestor/descendant, so FEAT-024 suppression must drop the edge
+    — matching the exact path.
+    """
+    linker = EmbeddingLinker(
+        config=EmbeddingsConfig(
+            similarity_threshold=0.5,
+            resonance_method="topk",
+            resonance_top_k=5,
+        ),
+    )
+    fragments = {
+        "p": _hier_fragment("p", child_ids=["c1"], level="document"),
+        "c1": _hier_fragment("c1", parent_id="p", level="paragraph"),
+    }
+    embeddings = {"p": [1.0, 0.0], "c1": [1.0, 0.0]}
+
+    assert linker.find_resonances(embeddings, fragments) == []
+
+
+def test_topk_edge_count_is_bounded_small() -> None:
+    """A CI-visible bound check: edges never exceed n·k (the core guarantee)."""
+    n, k = 60, 3
+    rng = np.random.default_rng(13)
+    vectors = rng.standard_normal((n, 8)).astype(np.float32)
+    embeddings = {f"f{i:03d}": vectors[i].tolist() for i in range(n)}
+
+    linker = EmbeddingLinker(
+        config=EmbeddingsConfig(
+            similarity_threshold=0.0,  # every pair qualifies
+            resonance_method="topk",
+            resonance_top_k=k,
+        ),
+    )
+    resonances = linker.find_resonances(embeddings)
+
+    assert 0 < len(resonances) <= n * k
 
 
 @pytest.mark.slow

--- a/creek-tools/tests/test_topk_resonance.py
+++ b/creek-tools/tests/test_topk_resonance.py
@@ -1,0 +1,134 @@
+"""Top-k nearest-neighbour resonance discovery (#722).
+
+The exact all-pairs path stays the default; ``resonance_method = "topk"`` keeps
+only each fragment's ``resonance_top_k`` best above-threshold neighbours,
+bounding the edge set to O(n·k). These tests use a deterministic angular fan of
+unit vectors (no similarity ties) so each fragment's top-k is hand-verifiable,
+plus a scale test proving the O(n·k) bound.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from creek.config import EmbeddingsConfig
+from creek.link.embeddings import EmbeddingLinker
+
+
+def _fan(degrees: float) -> list[float]:
+    """Return a 2-D unit vector at *degrees* from the x-axis."""
+    radians = math.radians(degrees)
+    return [math.cos(radians), math.sin(radians)]
+
+
+# A fan where cosine similarity = cos(angle gap). Gaps widen (4°,6°,8°) so there
+# are no ties, making each fragment's ranked neighbours unambiguous. F4 is 90°
+# away from everything, so it never resonates above a 0.95 threshold.
+_FAN_EMBEDDINGS = {
+    "F0": _fan(0),
+    "F1": _fan(4),
+    "F2": _fan(10),
+    "F3": _fan(18),
+    "F4": _fan(90),
+}
+
+
+def _pairs(linker: EmbeddingLinker, embeddings: dict[str, list[float]]) -> list:
+    """Return resonance edges as ``(a_id, b_id)`` tuples."""
+    return [
+        (r.fragment_a_id, r.fragment_b_id) for r in linker.find_resonances(embeddings)
+    ]
+
+
+def test_exact_is_the_default_method() -> None:
+    """A fresh EmbeddingsConfig uses the exact all-pairs path."""
+    assert EmbeddingsConfig().resonance_method == "exact"
+
+
+def test_exact_emits_every_above_threshold_pair() -> None:
+    """The exact path links all four near-axis fragments pairwise."""
+    linker = EmbeddingLinker(config=EmbeddingsConfig(similarity_threshold=0.95))
+    pairs = _pairs(linker, _FAN_EMBEDDINGS)
+    assert pairs == [
+        ("F0", "F1"),
+        ("F0", "F2"),
+        ("F0", "F3"),
+        ("F1", "F2"),
+        ("F1", "F3"),
+        ("F2", "F3"),
+    ]
+
+
+def test_topk_k1_keeps_each_fragments_single_best_neighbour() -> None:
+    """With k=1 every fragment keeps only its closest above-threshold neighbour."""
+    linker = EmbeddingLinker(
+        config=EmbeddingsConfig(
+            similarity_threshold=0.95,
+            resonance_method="topk",
+            resonance_top_k=1,
+        ),
+    )
+    # F0→F1, F1→F0, F2→F1, F3→F2 (each its nearest); deduped + (i<j)-ordered.
+    assert _pairs(linker, _FAN_EMBEDDINGS) == [
+        ("F0", "F1"),
+        ("F1", "F2"),
+        ("F2", "F3"),
+    ]
+
+
+def test_topk_output_is_a_subset_of_the_exact_path() -> None:
+    """Top-k edges are a strict subset of the exact edges (the weakest dropped)."""
+    exact = EmbeddingLinker(config=EmbeddingsConfig(similarity_threshold=0.95))
+    topk = EmbeddingLinker(
+        config=EmbeddingsConfig(
+            similarity_threshold=0.95,
+            resonance_method="topk",
+            resonance_top_k=2,
+        ),
+    )
+    exact_pairs = set(_pairs(exact, _FAN_EMBEDDINGS))
+    topk_pairs = set(_pairs(topk, _FAN_EMBEDDINGS))
+
+    assert topk_pairs <= exact_pairs
+    assert len(topk_pairs) < len(exact_pairs)
+    # k=2 drops only F0↔F3 (each prefers two closer neighbours).
+    assert exact_pairs - topk_pairs == {("F0", "F3")}
+
+
+def test_topk_preserves_ascending_index_order() -> None:
+    """Top-k edges are emitted in the same ascending (i, j) order as exact."""
+    linker = EmbeddingLinker(
+        config=EmbeddingsConfig(
+            similarity_threshold=0.95,
+            resonance_method="topk",
+            resonance_top_k=2,
+        ),
+    )
+    pairs = _pairs(linker, _FAN_EMBEDDINGS)
+    assert pairs == sorted(pairs)
+
+
+@pytest.mark.slow
+def test_topk_edge_count_is_bounded_at_scale() -> None:
+    """Top-k caps the edge set at O(n·k) even when every pair is above threshold."""
+    n, k = 800, 5
+    rng = np.random.default_rng(20260629)
+    vectors = rng.standard_normal((n, 16)).astype(np.float32)
+    embeddings = {f"f{i:04d}": vectors[i].tolist() for i in range(n)}
+
+    linker = EmbeddingLinker(
+        config=EmbeddingsConfig(
+            similarity_threshold=0.0,  # every pair qualifies → exact would be O(n²)
+            resonance_method="topk",
+            resonance_top_k=k,
+        ),
+    )
+    resonances = linker.find_resonances(embeddings)
+
+    # Each of n fragments contributes at most k directed picks; undirected
+    # dedup only shrinks that, so the bound is n·k (vs ~n²/2 for exact).
+    assert len(resonances) <= n * k
+    assert len(resonances) > 0

--- a/creek-tools/tests/test_topk_resonance.py
+++ b/creek-tools/tests/test_topk_resonance.py
@@ -1,4 +1,4 @@
-"""Top-k nearest-neighbour resonance discovery (#722).
+"""Top-k nearest-neighbour resonance discovery.
 
 The exact all-pairs path stays the default; ``resonance_method = "topk"`` keeps
 only each fragment's ``resonance_top_k`` best above-threshold neighbours,
@@ -169,7 +169,9 @@ def test_topk_edge_count_is_bounded_small() -> None:
 
     linker = EmbeddingLinker(
         config=EmbeddingsConfig(
-            similarity_threshold=0.0,  # every pair qualifies
+            # A wide-open gate: every non-negatively-similar pair qualifies, so
+            # the top-k cap (not the threshold) is what bounds the output.
+            similarity_threshold=0.0,
             resonance_method="topk",
             resonance_top_k=k,
         ),
@@ -181,7 +183,13 @@ def test_topk_edge_count_is_bounded_small() -> None:
 
 @pytest.mark.slow
 def test_topk_edge_count_is_bounded_at_scale() -> None:
-    """Top-k caps the edge set at O(n·k) even when every pair is above threshold."""
+    """Top-k caps the edge set at O(n·k) at a larger N than the routine gate.
+
+    ``test_topk_edge_count_is_bounded_small`` is the always-on CI guard for the
+    bound; this ``slow``-marked variant exercises a bigger N for extra
+    confidence. The ``slow`` marker is descriptive — ``addopts`` does not
+    auto-deselect it, and at n=800 it is still a sub-second numpy test.
+    """
     n, k = 800, 5
     rng = np.random.default_rng(20260629)
     vectors = rng.standard_normal((n, 16)).astype(np.float32)
@@ -189,7 +197,9 @@ def test_topk_edge_count_is_bounded_at_scale() -> None:
 
     linker = EmbeddingLinker(
         config=EmbeddingsConfig(
-            similarity_threshold=0.0,  # every pair qualifies → exact would be O(n²)
+            # Wide-open gate (every non-negative-cosine pair qualifies) so exact
+            # would be ~O(n²); only the top-k cap keeps the output bounded.
+            similarity_threshold=0.0,
             resonance_method="topk",
             resonance_top_k=k,
         ),


### PR DESCRIPTION
## Summary
Adds a config-gated **top-k nearest-neighbour** resonance path so `EmbeddingLinker.find_resonances` scales past ~35k fragments without the O(n²) all-pairs edge blowup — while keeping the exact all-pairs path as the validated default.

- **Config:** `EmbeddingsConfig` gains `resonance_method` (`exact` | `topk`, default `exact`) and `resonance_top_k` (default 10). The exact path is unchanged and stays the default until `topk` is validated on a real vault.
- **Algorithm:** `topk` keeps each fragment's *k* most-similar above-threshold neighbours via an **exact blocked `numpy.argpartition` per row block** — no new dependency, reusing the #596 block-matmul so peak memory stays `block_rows × N` (never the full N×N matrix). Each directed (i → neighbour) pick is folded to its undirected `(i < j)` form and de-duplicated, so the output is always a **subset** of the exact path's edges, emitted in the same ascending `(i, j)` order. Bounds the edge set to **O(n·k)**.
- **Invariants preserved:** FEAT-024 hierarchy suppression and the `Resonance` record shape are identical to the exact path for the pairs both emit.
- **Refactor:** the exact inner loop is extracted to `_resonances_exact` alongside the new `_resonances_topk`; `_top_k_neighbours` selects per row. Behaviour-preserving — all 257 existing embeddings/link/config tests pass unchanged.

I chose **exact blocked top-k over an ANN library (FAISS/hnswlib)**: it adds no heavy optional dependency, stays exact (no recall loss), and reuses the existing memory-bounded block-matmul. ANN remains a future option behind an optional extra if k-NN recall ever needs sub-linear scaling.

## Test plan
New `tests/test_topk_resonance.py` (deterministic angular fan of unit vectors — no similarity ties — so each fragment's top-k is hand-verifiable):
- `exact` is the default method; the exact path emits all six pairwise edges;
- k=1 keeps each fragment's single best neighbour (`{(F0,F1),(F1,F2),(F2,F3)}`);
- top-k output is a strict **subset** of the exact edges (k=2 drops only the weakest, F0↔F3);
- top-k preserves ascending `(i, j)` order;
- `@pytest.mark.slow` scale test: n=800, k=5, threshold 0 (every pair qualifies) → edge count bounded by **n·k** (vs ~n²/2 for exact).

`./scripts/check-all.sh`: formatting/lint/refurb/mypy-strict/complexity all green; the only failing unit tests are the pre-existing author/compost/mcp environmental cluster (operator's live Ollama + creds), proven identical on clean `origin/main` — they pass on CI.

## Scope fence
Resonance-discovery path only — no change to embedding generation, the cache format, or what a resonance means. Local-only; no new dependency.

Refs #715
Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)