### PR TITLE
test(liminal): CLI success-path test for report --type synchronicity (#726)

### DIFF
--- a/creek-tools/tests/test_cli.py
+++ b/creek-tools/tests/test_cli.py
@@ -1323,6 +1323,64 @@ def test_report_paradox_writes_notes(tmp_path: Path) -> None:
     assert sorted((vault / "10-Liminal" / "Paradoxes").glob("*.md"))
 
 
+def test_report_synchronicity_writes_notes(tmp_path: Path) -> None:
+    """`report --type synchronicity` writes notes + reports success (#711, #726).
+
+    Mirrors the paradox success-path test: a cross-source, >30-day pair with an
+    identical crafted embedding cache (cosine 1.0 > the 0.9 threshold) yields one
+    synchronicity note and the bold-green success message.
+    """
+    from datetime import UTC, datetime
+
+    from creek.config import EmbeddingsConfig
+    from creek.link.embeddings import (
+        CachedEmbedding,
+        EmbeddingLinker,
+        embeddings_cache_path,
+    )
+    from creek.models import Fragment, FragmentSource, SourcePlatform
+    from tests.helpers import write_fragment_file
+
+    vault = _report_vault(tmp_path)
+    pairs = (
+        ("frag-synx-cli-aa", SourcePlatform.DISCORD, datetime(2025, 1, 5, tzinfo=UTC)),
+        ("frag-synx-cli-bb", SourcePlatform.JOURNAL, datetime(2025, 4, 20, tzinfo=UTC)),
+    )
+    for fid, platform, created in pairs:
+        write_fragment_file(
+            vault=vault,
+            fragment=Fragment(
+                id=fid,
+                title="the river remembers every stone it has touched",
+                source=FragmentSource(platform=platform),
+                created=created,
+                authored_at=created,  # the gap filter reads effective_authored_at
+            ),
+            body="a near-identical meaning arriving from a different source",
+        )
+    # Identical vectors → cosine 1.0 > the 0.9 synchronicity threshold.
+    config = EmbeddingsConfig()
+    now = datetime.now(tz=UTC)
+    entries = {
+        fid: CachedEmbedding(
+            fragment_id=fid,
+            content_hash="h",
+            model_name=config.model,
+            vector=[1.0, 0.0, 0.0, 0.0],
+            computed_at=now,
+        )
+        for fid, _platform, _created in pairs
+    }
+    EmbeddingLinker(config).save_cache(entries, embeddings_cache_path(vault))
+
+    result = runner.invoke(
+        app, ["report", "--type", "synchronicity", "--vault", str(vault)]
+    )
+    assert result.exit_code == 0, result.output
+    assert "synchronicity notes generated" in result.output.lower()  # success branch
+    assert sorted((vault / "10-Liminal" / "Synchronicities").glob("*.md"))
+
+
 def test_report_decisions_no_candidates_is_friendly(tmp_path: Path) -> None:
     """``report --type decisions`` with no signalling fragments is friendly (#581).
 

--- a/creek-tools/tests/test_liminal_report_generators.py
+++ b/creek-tools/tests/test_liminal_report_generators.py
@@ -174,3 +174,20 @@ class TestGenerateSynchronicities:
             body="body",
         )
         assert generate_synchronicities(vault, EmbeddingsConfig()) == []
+
+    def test_existing_pairs_skips_unreadable_note(self, tmp_path: Path) -> None:
+        """An undecodable note is skipped by the dedup scan, not raised (#726).
+
+        ``_existing_synchronicity_pairs`` reads each note via
+        ``read_text(encoding="utf-8")``; an invalid-UTF-8 file raises
+        ``UnicodeDecodeError`` (a ``ValueError`` subclass), which the scan's
+        ``except (OSError, ValueError)`` swallows so one corrupt note cannot
+        abort the idempotency bookkeeping.
+        """
+        from creek.generate.synchronicity import _existing_synchronicity_pairs
+
+        sync_dir = tmp_path / "10-Liminal" / "Synchronicities"
+        sync_dir.mkdir(parents=True)
+        (sync_dir / "corrupt.md").write_bytes(b"\xff\xfe not valid utf-8")
+
+        assert _existing_synchronicity_pairs(tmp_path) == set()


### PR DESCRIPTION
## Summary
Follow-up from #711's review (PR #725). The **paradox** path gained a CLI success-path test (`test_report_paradox_writes_notes`), but the **synchronicity** equivalent was missing — it was only covered at the generator-unit level. This adds the parallel coverage.

- **`test_report_synchronicity_writes_notes`** (`tests/test_cli.py`): invokes `report --type synchronicity` on a crafted vault — a cross-source, >30-day pair with an identical embedding cache (cosine 1.0 > the 0.9 threshold) — and asserts exit 0, the `Synchronicity notes generated` success message, and a note under `10-Liminal/Synchronicities/`. Mirrors the paradox success-path test.
- **`test_existing_pairs_skips_unreadable_note`** (`tests/test_liminal_report_generators.py`): covers the previously-untested `except (OSError, ValueError): continue` branch in `_existing_synchronicity_pairs`. An invalid-UTF-8 note makes `read_text(encoding="utf-8")` raise `UnicodeDecodeError` (a `ValueError` subclass), proving one corrupt note can't abort the dedup/idempotency scan.

Test-only change — no production code touched.

## Test plan
Both new tests pass; `./scripts/check-all.sh` green on all real gates (the only failing unit tests are the pre-existing author/compost/mcp environmental cluster — operator's live Ollama + creds — proven identical on clean `origin/main`; they pass on CI).

Refs #713
Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)