### PR TITLE
feat(threads/eddies): alias bulk-page titles so wiki-links resolve (#730)

### DIFF
--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -758,7 +758,14 @@ class VaultWriter:
         """
         status_folder = str(thread.status).capitalize()
         target_dir = self.vault_path / "02-Threads" / status_folder
-        return self._write_model(thread, target_dir, body=_render_thread_body(thread))
+        return self._write_model(
+            thread,
+            target_dir,
+            body=_render_thread_body(thread),
+            # Alias the bare title so fragments' ``[[<title>]]`` thread links
+            # resolve to the date-prefixed page filename in stock Obsidian.
+            extra_frontmatter={"aliases": [thread.title]},
+        )
 
     def write_eddy(self, eddy: Eddy) -> Path:
         """Write an Eddy to 03-Eddies/.
@@ -773,7 +780,14 @@ class VaultWriter:
             Path to the written (or existing duplicate) markdown file.
         """
         target_dir = self.vault_path / "03-Eddies"
-        return self._write_model(eddy, target_dir, body=_render_eddy_body(eddy))
+        return self._write_model(
+            eddy,
+            target_dir,
+            body=_render_eddy_body(eddy),
+            # Alias the bare title so fragments' ``[[<title>]]`` eddy links
+            # resolve to the date-prefixed page filename in stock Obsidian.
+            extra_frontmatter={"aliases": [eddy.title]},
+        )
 
     def write_praxis(self, praxis: Praxis) -> Path:
         """Write a Praxis to 04-Praxis/{type}/.
@@ -861,6 +875,7 @@ class VaultWriter:
         target_dir: Path,
         *,
         body: str = "",
+        extra_frontmatter: dict[str, object] | None = None,
     ) -> Path:
         """Serialise a model to markdown with YAML frontmatter and write to disk.
 
@@ -873,6 +888,10 @@ class VaultWriter:
             model: The Pydantic model to serialise.
             target_dir: The vault directory to write the file to.
             body: Markdown body to render below the frontmatter block.
+            extra_frontmatter: Optional non-model keys merged into the YAML
+                frontmatter (e.g. ``aliases`` so an Obsidian ``[[Title]]`` link
+                resolves to a ``{date}-{title}`` filename). Keys here override
+                model-dumped keys of the same name.
 
         Returns:
             Path to the written (or existing duplicate) file.
@@ -896,6 +915,10 @@ class VaultWriter:
             base_name = self._compute_base_name(model)
 
             data = model.model_dump(mode="json")
+            if extra_frontmatter:
+                # Non-model frontmatter (e.g. ``aliases`` so an Obsidian
+                # ``[[Title]]`` link resolves to a ``{date}-{title}`` filename).
+                data.update(extra_frontmatter)
             post = frontmatter.Post(content=body, **data)
             content = frontmatter.dumps(post)
 

--- a/creek-tools/tests/test_link_threads_pages.py
+++ b/creek-tools/tests/test_link_threads_pages.py
@@ -136,6 +136,13 @@ def test_fragment_thread_links_target_written_pages(tmp_path: Path) -> None:
     page_titles = {
         str(frontmatter.load(p).metadata.get("title", "")) for p in _thread_pages(vault)
     }
+    # Every page also aliases its bare title, so a fragment's ``[[<title>]]``
+    # link resolves to the ``{date}-<title>.md`` filename in stock Obsidian.
+    page_aliases: set[str] = set()
+    for page in _thread_pages(vault):
+        page_aliases.update(
+            str(a) for a in frontmatter.load(page).metadata.get("aliases", [])
+        )
 
     linked_titles: set[str] = set()
     for frag_file in (vault / "01-Fragments").rglob("*.md"):
@@ -146,6 +153,9 @@ def test_fragment_thread_links_target_written_pages(tmp_path: Path) -> None:
     assert linked_titles, "expected fragments to carry threads: wiki-links"
     assert linked_titles <= page_titles, (
         f"thread links {linked_titles - page_titles} have no page with that title"
+    )
+    assert linked_titles <= page_aliases, (
+        f"thread links {linked_titles - page_aliases} do not resolve to a page alias"
     )
 
 

--- a/creek-tools/tests/test_vault_writer.py
+++ b/creek-tools/tests/test_vault_writer.py
@@ -496,6 +496,23 @@ class TestWriteThread:
         assert "id: thread-test001" in content
         assert "type: thread" in content
 
+    def test_write_thread_aliases_title_for_link_resolution(
+        self,
+        writer: VaultWriter,
+        sample_thread: Thread,
+    ) -> None:
+        """The page aliases its bare title so ``[[<title>]]`` resolves.
+
+        The bulk threads linker writes ``[[Test Active Thread]]`` onto member
+        fragments, while the page lands at ``{date}-Test-Active-Thread.md``; the
+        ``aliases`` entry bridges that gap for stock-Obsidian link resolution.
+        """
+        import frontmatter
+
+        result = writer.write_thread(sample_thread)
+        post = frontmatter.loads(result.read_text(encoding="utf-8"))
+        assert sample_thread.title in post.get("aliases", [])
+
 
 # ---- write_eddy ----
 
@@ -523,6 +540,23 @@ class TestWriteEddy:
         content = result.read_text(encoding="utf-8")
         assert "id: eddy-test0001" in content
         assert "type: eddy" in content
+
+    def test_write_eddy_aliases_title_for_link_resolution(
+        self,
+        writer: VaultWriter,
+        sample_eddy: Eddy,
+    ) -> None:
+        """The page aliases its bare title so ``[[<title>]]`` resolves.
+
+        Symmetric with threads: the eddies linker writes ``[[Test Eddy
+        Cluster]]`` onto fragments while the file is ``{date}-Test-Eddy-
+        Cluster.md``; the ``aliases`` entry makes the link resolve.
+        """
+        import frontmatter
+
+        result = writer.write_eddy(sample_eddy)
+        post = frontmatter.loads(result.read_text(encoding="utf-8"))
+        assert sample_eddy.title in post.get("aliases", [])
 
 
 # ---- write_praxis ----


### PR DESCRIPTION
## Summary
The bulk linkers write thread/eddy pages at a `{date}-{title}` filename (e.g. `02-Threads/Active/2026-06-25-Thread-Member.md`), but the wiki-links written onto member fragments are the bare `[[Thread Member]]` / `[[Eddy Title]]`. In stock Obsidian those don't byte-match the filename, so the links rendered unresolved. (Surfaced as a documented follow-up during #718.)

**Fix — option 1 (emit `aliases:`), the cleaner of the two options in the issue:**
- `VaultWriter._write_model` gains an optional `extra_frontmatter` param (non-model keys merged into the YAML frontmatter).
- `write_thread` and `write_eddy` now pass `aliases=[<title>]`, so each page aliases its bare title. Obsidian resolves `[[Title]]` to the date-prefixed file via the alias.

Applied **symmetrically** to both linkers. No change to detection semantics or to the wiki-link text. Idempotent: the alias is written once on first create; the id-dedup path returns the existing page untouched.

## Test plan
- `test_write_thread_aliases_title_for_link_resolution` / `test_write_eddy_aliases_title_for_link_resolution` (`test_vault_writer.py`): each page's `aliases` contains its bare title — the symmetric mechanism.
- `test_fragment_thread_links_target_written_pages` (`test_link_threads_pages.py`) strengthened: it now asserts every fragment `threads:` wiki-link resolves to a page **alias** (end-to-end, not just a matching page title). The eddies path shares the identical `write_eddy` machinery covered by the writer-level test.

`./scripts/check-all.sh` green on all real gates (the only failing unit tests are the pre-existing author/compost/mcp environmental cluster — operator's live Ollama + creds — identical on clean `origin/main`; they pass on CI). The `aliases` addition broke no existing thread/eddy frontmatter tests.

## Scope fence
Reuses the existing writer; does not change detection semantics. Applied to both threads and eddies for consistency.

Refs #713
Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)