### PR TITLE
feat(ci/de-slop): make the weekly audit exhaustive over the whole codebase (#732)

### DIFF
--- a/.claude/skills/de-slopify/SKILL.md
+++ b/.claude/skills/de-slopify/SKILL.md
@@ -77,9 +77,13 @@ EVID=$(bash .claude/skills/de-slopify/scripts/collect-evidence.sh | tail -1)
 
 This runs ruff, vulture, radon, mypy, bandit, interrogate, pip-audit, and
 detect-secrets over the Python source (`creek-tools/creek`, `creek-tools/
-creek_mcp`, `crawdad/crawdad`); the grep heuristics; and git churn — capturing
-each into `$EVID`. It never modifies files and never aborts on a tool error. Read
-`$EVID/README.txt`, then work through every output file. Supplement with
+creek_mcp`, `crawdad/crawdad`); the grep heuristics; git churn; and a complete
+`source-inventory.txt` enumerating **every** source file under the audited roots
+(the authoritative denominator for the Step 8 coverage ledger) — capturing each
+into `$EVID`. It never modifies files and never aborts on a tool error. Read
+`$EVID/README.txt`, then work through every output file. Treat
+`source-inventory.txt` as the full set the Step 4 reading pass must cover;
+churn.txt and reading-targets.txt only order where to start. Supplement with
 targeted `Grep`/`Read` as candidates emerge.
 
 ### Step 3 — Triage candidates against the guard list
@@ -95,25 +99,41 @@ constants, deliberate repo conventions, and unmeasured "could be faster" claims.
 This is the step that finds the slop linters cannot see, and the step the first
 audit skipped. Do not conclude "clean" without it.
 
-Fan out with the **Task tool**: spawn one subagent per feature area so the whole
-codebase is actually read in parallel, not skimmed by one thread. A good split:
+**Coverage is exhaustive, not sampled.** `$EVID/source-inventory.txt` is the
+authoritative, COMPLETE list of source files (one `<loc> <lang> <path>` per
+line). **Every file in it must be assigned to exactly one reading subagent — no
+file may be left unread.** churn.txt and reading-targets.txt only *order* the
+work (where to start within a partition); they are never the set of files to
+read. A clean verdict is only legitimate when every inventory file was actually
+read against the full taxonomy (see the Step 8 ledger).
+
+Fan out with the **Task tool**: **partition the whole `source-inventory.txt`**
+across subagents so the entire codebase is read in parallel, not skimmed by one
+thread. Partition by feature area for coherence, but the union of the partitions
+must equal the inventory — track assigned files so none is dropped:
 
 - one subagent per creek pipeline stage (`creek-tools/creek/{ingest,classify,
   link,author,generate,...}/*`) — these are the real feature areas,
 - one for the MCP server surface (`creek-tools/creek_mcp/*`),
 - one for the crawdad Discord bot (`crawdad/crawdad/*`, incl. `llm/` and
   `builtin_workflows/`),
-- one for the shared/util/config grab-bags (prime duplication + dead-code sites).
+- one for the shared/util/config grab-bags (prime duplication + dead-code sites),
+- one (or more) for **every remaining inventory file** not claimed above —
+  small, stable, low-churn modules and the `scripts/` shell tooling included, so
+  nothing hides simply because it is small or hasn't changed in 90 days.
 
-Give each subagent the **full 13-family taxonomy** (`slop-taxonomy.md`) and this
-brief: *read the actual source in your area and return corroborated candidates
-for every family, with file:line evidence — focus on what linters miss: dead/
+Give each subagent the **full 13-family taxonomy** (`slop-taxonomy.md`), the
+explicit list of inventory paths it owns, and this brief: *read the actual
+source of every file assigned to you and return corroborated candidates for
+every family, with file:line evidence — focus on what linters miss: dead/
 stubbed/orphaned code, duplication (here and against the rest of the repo),
 architecture/layering violations, lying flags, verbosity, comment slop, AI-slop
 tells, and weak tests. Ignore anything ruff/mypy/radon/eslint already gates.*
 
-Use the `$EVID` bundle's churn and largest-file lists to prioritize. Collect all
-subagent candidates before corroborating.
+Use churn.txt + reading-targets.txt only to order the reading within a partition
+(start with the hot/large files); they do NOT bound which files you read — the
+inventory does. Collect all subagent candidates, and the per-subagent list of
+files actually read, before corroborating.
 
 ### Step 5 — Corroborate each survivor (the gate)
 
@@ -169,10 +189,33 @@ Emit a concise run summary: counts by severity, what was filed (with issue
 numbers/links), what was **dropped and why** (failed corroboration / guard
 list), and what was **deduped**.
 
-Then add a **coverage ledger** — a table with one row per taxonomy family (all
+Then add **two ledgers**.
+
+**(a) File-coverage ledger — proves exhaustiveness.** Reconcile the reading pass
+against `$EVID/source-inventory.txt`: report `examined` vs `total` files and list
+any **deliberately excluded** files explicitly with a justification (generated
+code, vendored deps, lockfiles — only the NOT-slop guard-list categories). The
+identity that must hold for a clean verdict is:
+
+```
+examined == total − justified-exclusions
+```
+
+Show it as a short reconciliation, e.g.:
+
+```
+File coverage: 253 examined + 2 excluded (generated: _pb2.py; vendored) = 255 total ✓
+Unreached: none
+```
+
+If any inventory file was **not** read, list those files under `Unreached:` —
+the run is then **partial**, not clean, and the summary must say so rather than
+claim the codebase is clean.
+
+**(b) Taxonomy-family ledger** — a table with one row per taxonomy family (all
 13) recording which areas/files you examined for it and the verdict
-(clean / candidates / filed). This is how a reader verifies the whole taxonomy
-was actually traversed in the reading pass, not assumed clean:
+(clean / candidates / filed). This verifies the whole taxonomy was actually
+traversed, not assumed clean:
 
 ```
 | Family | Areas examined | Verdict |
@@ -182,10 +225,12 @@ was actually traversed in the reading pass, not assumed clean:
 | ... | ... | ... |
 ```
 
-If nothing met the bar, say so plainly — *"No corroborated slop this run —
-codebase is clean against the taxonomy"* — but the ledger must still show the
-13 families were each looked at. A clean verdict with an empty ledger means the
-reading pass was skipped; that is a failed run, not a clean one.
+A clean verdict — *"No corroborated slop this run — codebase is clean against
+the taxonomy"* — is only legitimate when **both** the file-coverage ledger shows
+`examined == total − justified-exclusions` (no `Unreached` files) **and** the
+family ledger shows all 13 families were looked at. A clean claim from a partial
+file pass, or with an empty family ledger, means the reading pass was incomplete;
+that is a failed run, not a clean one — report what was not reached instead.
 
 ## What this skill must never do
 

--- a/.claude/skills/de-slopify/scripts/collect-evidence.sh
+++ b/.claude/skills/de-slopify/scripts/collect-evidence.sh
@@ -102,6 +102,14 @@ if command -v rg >/dev/null 2>&1; then
 fi
 SEARCH_PATHS=("${PY_DIRS[@]}")
 
+# Inventory roots: the COMPLETE audited surface (Python packages + shell
+# tooling). The reading pass must cover every file under these — churn and size
+# only choose where to START, never the set to read.
+INVENTORY_PATHS=("${PY_DIRS[@]}")
+for d in creek-tools/scripts crawdad/scripts scripts; do
+  [[ -d "$d" ]] && INVENTORY_PATHS+=("$d")
+done
+
 greps() {
   local out="$1" pat="$2"
   if [[ ${#SEARCH_PATHS[@]} -eq 0 ]]; then return 0; fi
@@ -117,7 +125,31 @@ greps grep-swallow.txt      'except (Exception|BaseException)?\s*:|catch\s*\([^)
 greps grep-commented.txt    '^\s*#\s*(def |class |return |if |for |while |import |from )'
 greps grep-any.txt          ':\s*any\b|<any>|as any'
 
-# Git churn / hotspots (top 30 most-changed files in the last 90 days).
+# Source inventory: the COMPLETE set of files the reading pass must cover — the
+# authoritative denominator for the coverage ledger. One line per file, no
+# headers, so ``wc -l < source-inventory.txt`` is the exact total. churn.txt and
+# reading-targets.txt below are ONLY ordering hints (where to start); they are
+# never the set of files to read.
+{
+  if [[ ${#INVENTORY_PATHS[@]} -gt 0 ]]; then
+    find "${INVENTORY_PATHS[@]}" -type f \( -name '*.py' -o -name '*.sh' \) \
+      -not -path '*/node_modules/*' -not -path '*/.venv/*' -print0 2>/dev/null \
+      | sort -z \
+      | while IFS= read -r -d '' f; do
+          loc="$(wc -l <"$f" 2>/dev/null | tr -d ' ')"
+          case "$f" in
+            *.py) lang="python" ;;
+            *.sh) lang="shell" ;;
+            *)    lang="other" ;;
+          esac
+          printf '%s\t%s\t%s\n' "${loc:-0}" "$lang" "$f"
+        done
+  fi
+} >"$OUT/source-inventory.txt"
+
+# Git churn / hotspots — an ORDERING HINT ONLY (top 30 most-changed files in the
+# last 90 days). It says where to START reading, never which files to read; the
+# full set is source-inventory.txt.
 if command -v git >/dev/null 2>&1; then
   git log --since="90 days ago" --format= --name-only 2>/dev/null \
     | grep -E '^(creek-tools|crawdad)/' \
@@ -125,11 +157,13 @@ if command -v git >/dev/null 2>&1; then
     || echo "(churn unavailable)" >"$OUT/churn.txt"
 fi
 
-# Reading targets: the largest source files by line count. These — together
-# with churn.txt — are where the reading pass should start, because size and
-# change-frequency are where bloaters, duplication, and god-objects accumulate.
+# Reading-START hints: the largest source files by line count. Together with
+# churn.txt these are where the reading pass should START (size and change-
+# frequency are where bloaters, duplication, and god-objects accumulate) — but
+# they only ORDER the pass; every file in source-inventory.txt must still be
+# read regardless of size or churn.
 {
-  echo "# Largest source files (LoC) — prime reading-pass targets"
+  echo "# Largest source files (LoC) — reading-pass START hints, NOT the read set"
   if [[ ${#SEARCH_PATHS[@]} -gt 0 ]]; then
     find "${SEARCH_PATHS[@]}" -type f \
       -name '*.py' \
@@ -147,7 +181,9 @@ fi
   echo "Out:     $OUT"
   echo
   echo "## Files"
-  ls -1 "$OUT" | sed 's/^/  - /'
+  for f in "$OUT"/*; do
+    [[ -e "$f" ]] && echo "  - $(basename "$f")"
+  done
   echo
   echo "Each *.json / *.txt holds raw tool or grep output. Every entry is a"
   echo "CANDIDATE only — apply the Two-Signal Rule from detection-playbook.md"
@@ -157,10 +193,20 @@ fi
   echo "The linter outputs (ruff/mypy/radon/bandit/eslint/tsc) are TABLE STAKES:"
   echo "the repo already passes them in pre-commit and CI, so they cannot be"
   echo "findings. Do NOT file complexity grades, lint rules, or type errors."
-  echo "Use churn.txt + reading-targets.txt to drive a Task fan-out that READS"
-  echo "the source for what linters cannot see (dead/stubbed/orphaned code,"
-  echo "duplication, architecture, lying flags, verbosity, comment slop, AI"
-  echo "tells, weak tests). That reading pass is the actual audit."
+  echo
+  echo "## Reading pass — cover EVERY file (exhaustive, not sampled)"
+  echo "source-inventory.txt is the AUTHORITATIVE, COMPLETE set of source files"
+  echo "(one '<loc> <lang> <path>' per line; total = wc -l). The reading fan-out"
+  echo "MUST partition this whole inventory across subagents so every file is"
+  echo "assigned to exactly one reader. churn.txt + reading-targets.txt only"
+  echo "ORDER the pass (where to start); they are NOT the set of files to read."
+  echo "A run may report 'clean against the taxonomy' ONLY when the coverage"
+  echo "ledger shows examined == total - justified-exclusions; otherwise it must"
+  echo "report which files were not reached. The reading pass (dead/stubbed/"
+  echo "orphaned code, duplication, architecture, lying flags, verbosity, comment"
+  echo "slop, AI tells, weak tests) is the actual audit."
+  printf 'Inventory size: %s file(s)\n' \
+    "$(wc -l <"$OUT/source-inventory.txt" 2>/dev/null | tr -d ' ')"
 } >"$OUT/README.txt"
 
 log "evidence collected in $OUT"

--- a/.github/workflows/weekly-deslop.yml
+++ b/.github/workflows/weekly-deslop.yml
@@ -82,12 +82,17 @@ jobs:
           # --model opus: this is a judgment-heavy audit (architecture,
           #   duplication, AI-slop, verbosity) — Sonnet, the action default,
           #   ran the first audit too leniently. Opus does the deep reading.
-          # --max-turns 240: a real reading pass fans out across every feature
-          #   area; the lean 80-turn budget bailed out after a shallow scan.
+          # --max-turns 300: the reading pass now PARTITIONS the full
+          #   source-inventory.txt (every file, ~250+) across feature-area
+          #   subagents plus a catch-all for the long tail, then reconciles a
+          #   file-coverage ledger (examined vs total). The extra catch-all
+          #   partition and the reconciliation step need headroom over the prior
+          #   240; the partition is deterministic (no re-reading), so 300 is a
+          #   modest bump, not an open-ended one.
           claude_args: >-
             --allowed-tools "Bash,Read,Grep,Glob,Write,Skill,Task"
             --model opus
-            --max-turns 240
+            --max-turns 300
 
           prompt: |
             Run a comprehensive weekly code-quality audit of this repository
@@ -108,14 +113,22 @@ jobs:
             theater tests. Finding those requires READING THE CODE, not parsing
             tool JSON. The evidence bundle is a starting map, not the territory.
 
-            Mandatory reading pass (this is what was skipped last time): after
-            collecting evidence, fan out with the Task tool — spawn a subagent
-            per feature area (the creek-tools/creek pipeline stages — ingestion,
-            classification, linking, voice — plus creek_mcp and the crawdad
-            Discord bot) that actually READS the source against the full
-            13-family taxonomy in references/slop-taxonomy.md and reports
-            corroborated candidates. Do not conclude "clean" from a 5-minute
-            single-threaded scan of linter output.
+            Mandatory EXHAUSTIVE reading pass: after collecting evidence, the
+            bundle's `source-inventory.txt` lists EVERY source file under the
+            audited roots. Fan out with the Task tool and PARTITION THE WHOLE
+            INVENTORY across subagents so every file is assigned to exactly one
+            reader — partition by feature area (the creek-tools/creek pipeline
+            stages — ingestion, classification, linking, voice — plus creek_mcp
+            and the crawdad Discord bot), AND add a catch-all subagent for every
+            remaining inventory file (small, stable, low-churn modules and the
+            scripts/ shell tooling) so nothing is skipped because it is small or
+            hasn't changed recently. Each subagent READS its assigned files
+            against the full 13-family taxonomy in references/slop-taxonomy.md and
+            returns corroborated candidates plus the list of files it actually
+            read. churn.txt / reading-targets.txt only ORDER the reading (where to
+            start); they never bound which files are read — the inventory does.
+            Do NOT conclude "clean" from a sampled hotspot scan: a clean verdict
+            requires that every inventory file was read (see the coverage ledger).
 
             Hard requirements (the skill enforces these — do not deviate):
             - Corroborate every finding with TWO independent signals before
@@ -139,13 +152,23 @@ jobs:
             summary — append it to the file at $GITHUB_STEP_SUMMARY (e.g.
             `cat >> "$GITHUB_STEP_SUMMARY"`) — containing: counts by severity,
             issues/epics filed (with numbers), findings dropped and why,
-            findings deduped, AND a coverage ledger: a table with one row per
-            taxonomy family (all 13) listing which areas/files you examined for
-            it and the verdict (clean / candidates / filed). The ledger is how
-            we verify the whole taxonomy was actually traversed rather than
-            assumed clean. This is the durable record, linked to the workflow
-            run, and never touches the issue tracker. A clean run (nothing
-            filed) writes "codebase is clean against the taxonomy this week" to
-            the job summary and files NO issue. Only open a separate `de-slop` +
-            `report` issue when at least one finding was filed — never on a clean
-            run (a weekly report issue every Monday would flood the tracker).
+            findings deduped, AND TWO ledgers:
+            (a) a FILE-COVERAGE ledger reconciling the reading pass against
+            `source-inventory.txt` — report examined vs total files and list any
+            deliberately excluded files with a justification (only NOT-slop
+            guard-list categories: generated code, vendored, lockfiles). It must
+            show `examined == total − justified-exclusions`; if any inventory
+            file was not read, list those under "Unreached" and the run is
+            PARTIAL, not clean;
+            (b) a taxonomy ledger: one row per family (all 13) listing which
+            areas/files you examined and the verdict (clean / candidates / filed).
+            The ledgers are how we verify the whole codebase AND the whole
+            taxonomy were actually traversed rather than assumed clean. This is
+            the durable record, linked to the workflow run, and never touches the
+            issue tracker. A clean run may write "codebase is clean against the
+            taxonomy this week" ONLY when the file-coverage ledger shows full
+            coverage (no Unreached files) and the taxonomy ledger covers all 13
+            families; a partial pass instead reports what was not reached. A clean
+            run files NO issue. Only open a separate `de-slop` + `report` issue
+            when at least one finding was filed — never on a clean run (a weekly
+            report issue every Monday would flood the tracker).


### PR DESCRIPTION
## Summary
The weekly de-slop audit claimed to "hunt the whole codebase," but its reading pass was seeded from two **top-30** lists (churn over 90 days + largest `.py` files), so older, stable, and smaller files were never assigned to a reader. A "clean" run only meant the sampled hotspots looked clean. This makes whole-codebase coverage **structural, not aspirational**.

### Changes
- **`collect-evidence.sh`** — emits a new **`source-inventory.txt`**: every `.py`/`.sh` under the audited roots (creek packages + `scripts/` shell tooling) as `<loc> <lang> <path>`, one per line — the authoritative denominator for the coverage ledger. `churn.txt` and `reading-targets.txt` are relabelled as **ordering hints** (where to *start*), never the set to read. The README documents the exhaustive-coverage contract and prints the inventory size. (Also fixed a pre-existing `SC2012` so the script is shellcheck-clean at default severity — no suppression.)
- **`SKILL.md`** — Step 4's Task fan-out must now **partition the full inventory** across subagents (every file assigned to exactly one reader, including a catch-all for the long tail of small/stable modules); churn/size only order *within* a partition. Step 8 gains a **file-coverage ledger** reconciling `examined` vs `total` (`examined == total − justified-exclusions`); a "clean" verdict is legitimate only on full coverage, otherwise the run is **partial** and must report the `Unreached` files. Step 2 notes the new inventory.
- **`weekly-deslop.yml`** — the prompt now requires the exhaustive partition + the reconciled file-coverage ledger and explicitly forbids concluding "clean" from a sampled hotspot scan. `--max-turns` 240 → **300** for the extra catch-all partition + reconciliation (deterministic partition, so a modest bounded bump — reasoning in the comment).

### Scope fence honored
This changes **file coverage**, not the detection rules: the Two-Signal corroboration rule, the NOT-slop guard list, and the "linters are table stakes / never file lint-gated findings" policy are all untouched — exhaustive coverage must not become a false-positive firehose.

## Test plan
- `shellcheck collect-evidence.sh` — clean at default severity.
- `actionlint weekly-deslop.yml` — clean; YAML parses.
- **Dry-run** `collect-evidence.sh <out>`: `source-inventory.txt` enumerates **255** files, including tiny ones the largest-30 list misses — e.g. a 3-line `creek/__init__.py` and 8-line `scripts/*.sh` — confirmed **not** present in `reading-targets.txt` (largest-30) yet **present** in the inventory. This is the DoD's "covers files that are neither in the churn top-30 nor the largest-30."
- No Python touched, so the creek + CrawDad CI matrices are unaffected.

## DoD
- [x] `collect-evidence.sh` emits a full `source-inventory.txt`; shellcheck clean.
- [x] `SKILL.md` Step 4 partitions the full inventory; Step 8 ledger reconciles examined vs total and only declares clean on full coverage.
- [x] `weekly-deslop.yml` prompt requires exhaustive coverage + the reconciled ledger.
- [x] Dry-run shows the inventory covers files outside churn-30 and largest-30.

Closes #732

🤖 Generated with [Claude Code](https://claude.com/claude-code)