### PR TITLE
fix(ralph-recap): back off between code_frequency attempts so full-repo LOC renders (#733)

### DIFF
--- a/scripts/ralph/recap.py
+++ b/scripts/ralph/recap.py
@@ -36,9 +36,11 @@ import datetime as dt
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
+from collections.abc import Callable
 from typing import Any, cast
 
 import stats
@@ -129,13 +131,18 @@ def _gh_headers(token: str) -> dict[str, str]:
     }
 
 
-def _gh_get_paged(path: str, *, token: str, params: dict[str, str], max_items: int) -> list[dict[str, Any]]:
+def _gh_get_paged(
+    path: str, *, token: str, params: dict[str, str], max_items: int
+) -> list[dict[str, Any]]:
     """GET a paginated GitHub list endpoint, stopping at max_items."""
     headers = _gh_headers(token)
     out: list[dict[str, Any]] = []
     page = 1
     while len(out) < max_items:
-        query = "&".join(f"{k}={v}" for k, v in {**params, "per_page": "100", "page": str(page)}.items())
+        query = "&".join(
+            f"{k}={v}"
+            for k, v in {**params, "per_page": "100", "page": str(page)}.items()
+        )
         url = f"{GITHUB_API}{path}?{query}"
         chunk = cast("list[dict[str, Any]]", _request_json(url, headers=headers))
         if not chunk:
@@ -152,7 +159,9 @@ def _gh_get_paged(path: str, *, token: str, params: dict[str, str], max_items: i
 # --------------------------------------------------------------------------- #
 
 
-def _gh_search_issues(query: str, *, token: str, max_items: int) -> list[dict[str, Any]]:
+def _gh_search_issues(
+    query: str, *, token: str, max_items: int
+) -> list[dict[str, Any]]:
     """Run a GitHub issue/PR search, paging up to max_items results.
 
     Search responses wrap the hits in an `items` array (unlike the list
@@ -182,11 +191,16 @@ def count_merged_total(repo: str, *, token: str) -> int:
     instead of pinning at the number of PRs we happened to pull this run.
     """
     qs = urllib.parse.urlencode({"q": f"repo:{repo} is:pr is:merged", "per_page": "1"})
-    data = cast("dict[str, Any]", _request_json(f"{GITHUB_API}/search/issues?{qs}", headers=_gh_headers(token)))
+    data = cast(
+        "dict[str, Any]",
+        _request_json(f"{GITHUB_API}/search/issues?{qs}", headers=_gh_headers(token)),
+    )
     return int(data.get("total_count", 0))
 
 
-def fetch_recent_merged_prs(repo: str, *, token: str, since: dt.date, max_prs: int) -> list[dict[str, Any]]:
+def fetch_recent_merged_prs(
+    repo: str, *, token: str, since: dt.date, max_prs: int
+) -> list[dict[str, Any]]:
     """Return PRs merged on/after `since` (newest merge first), capped at max_prs.
 
     Uses search so the window is filtered server-side; each hit carries its
@@ -195,7 +209,9 @@ def fetch_recent_merged_prs(repo: str, *, token: str, since: dt.date, max_prs: i
     """
     query = f"repo:{repo} is:pr is:merged merged:>={since.isoformat()}"
     items = _gh_search_issues(query, token=token, max_items=max_prs)
-    items.sort(key=lambda it: cast("str", it["pull_request"]["merged_at"]), reverse=True)
+    items.sort(
+        key=lambda it: cast("str", it["pull_request"]["merged_at"]), reverse=True
+    )
     return items
 
 
@@ -239,22 +255,51 @@ def fetch_pr_verdicts(repo: str, number: int, *, token: str) -> list[str]:
     return verdicts
 
 
-def fetch_repo_net_lines(repo: str, *, token: str, attempts: int = 3) -> int | None:
+def fetch_repo_net_lines(
+    repo: str,
+    *,
+    token: str,
+    attempts: int = 4,
+    sleep: Callable[[float], None] = time.sleep,
+    base_delay: float = 2.0,
+) -> int | None:
     """Return net lines of code across the whole repo via the code-frequency stats API.
 
     GitHub computes the per-week additions/deletions stats asynchronously and
-    answers 202 with an empty body on a cold cache, so retry a few times. Any
-    failure (still warming, or an HTTP/transport error) returns None so the recap
-    shows a placeholder for the full-repo figure instead of failing outright.
+    answers ``202`` with an **empty body** on a cold cache. That empty body parses
+    to ``None`` (vs an HTTP 200 returning a real list — possibly an empty ``[]``
+    for a genuinely empty history). So:
+
+    - ``None`` => still warming; wait with exponential backoff and retry, giving
+      the cache time to compute rather than firing all attempts in milliseconds.
+    - a list (rows or a genuine ``[]``) => final; sum it (``[]`` nets to 0).
+
+    Any HTTP/transport error, or exhausting the attempts while still warming,
+    returns ``None`` so the recap shows a placeholder for the full-repo figure
+    instead of failing outright.
+
+    Args:
+        repo: ``owner/name`` slug.
+        token: GitHub token.
+        attempts: Maximum fetches before giving up (default 4).
+        sleep: Delay function between attempts; injectable so tests don't sleep.
+        base_delay: First backoff in seconds; doubles each retry (2s, 4s, 8s).
+
+    Returns:
+        The repo's net lines of code, or ``None`` if the stats never warmed.
     """
     url = f"{GITHUB_API}/repos/{repo}/stats/code_frequency"
-    for _ in range(attempts):
+    for attempt in range(attempts):
         try:
             data = _request_json(url, headers=_gh_headers(token))
         except (urllib.error.HTTPError, urllib.error.URLError):
             return None
-        if data:
+        if data is not None:
             return stats.net_lines_from_code_frequency(cast("list[list[int]]", data))
+        # Empty body => HTTP 202, stats still computing. Back off before the next
+        # attempt; the final attempt skips the sleep since we give up after it.
+        if attempt < attempts - 1:
+            sleep(base_delay * (2.0**attempt))
     return None
 
 
@@ -341,8 +386,12 @@ def generate_headline(title: str, body: str) -> str:
             output_config={"effort": "low"},
             messages=[{"role": "user", "content": prompt}],
         )
-        text = "".join(block.text for block in response.content if block.type == "text").strip()
-    except Exception:  # any SDK/API failure degrades to the heuristic, never fails the recap
+        text = "".join(
+            block.text for block in response.content if block.type == "text"
+        ).strip()
+    except (
+        Exception
+    ):  # any SDK/API failure degrades to the heuristic, never fails the recap
         return _heuristic_headline(title)
     return text or _heuristic_headline(title)
 
@@ -390,7 +439,9 @@ def _open_to_merge_hours(pr: dict[str, Any]) -> float:
     return max((merged - opened).total_seconds() / 3600.0, 0.0)
 
 
-def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dict[str, Any] | None:
+def build_recap(
+    repo: str, *, token: str, max_prs: int, now: dt.datetime
+) -> dict[str, Any] | None:
     """Gather data and assemble the Discord embed payload.
 
     The headline total is the true all-time merged count; the activity and
@@ -439,14 +490,22 @@ def build_recap(repo: str, *, token: str, max_prs: int, now: dt.datetime) -> dic
     day_ago = now - dt.timedelta(hours=stats.HOURS_PER_DAY)
     latest_churn = stats.churn_totals(churn[:1])
     loc_7d = stats.churn_totals(churn)
-    loc_24h = stats.churn_totals([c for c, ts in zip(churn, merged_at) if ts >= day_ago])
+    loc_24h = stats.churn_totals(
+        [c for c, ts in zip(churn, merged_at) if ts >= day_ago]
+    )
     repo_net = fetch_repo_net_lines(repo, token=token)
 
-    headline = generate_headline(str(latest.get("title", "")), str(latest.get("body") or ""))
+    headline = generate_headline(
+        str(latest.get("title", "")), str(latest.get("body") or "")
+    )
 
     # Per-PR (this-merge) figures, kept distinct from the windowed dataset above.
     latest_ttm_hours = _open_to_merge_hours(latest)
-    latest_tick_hours = (merged_at[0] - merged_at[1]).total_seconds() / 3600.0 if len(merged_at) >= 2 else None
+    latest_tick_hours = (
+        (merged_at[0] - merged_at[1]).total_seconds() / 3600.0
+        if len(merged_at) >= 2
+        else None
+    )
 
     return _render_embed(
         repo=repo,
@@ -502,7 +561,9 @@ def _this_pr_iter_line(latest_iterations: int | None) -> str:
     return f"**{latest_iterations}** {plural} to LGTM"
 
 
-def _loc_line(loc_24h: dict[str, int], loc_7d: dict[str, int], repo_net: int | None) -> str:
+def _loc_line(
+    loc_24h: dict[str, int], loc_7d: dict[str, int], repo_net: int | None
+) -> str:
     """Lines-of-code churn over the 24h and 7d windows, plus the full-repo net."""
 
     def churn(totals: dict[str, int]) -> str:
@@ -562,11 +623,27 @@ def _render_embed(
         {"name": BLANK, "value": BLANK, "inline": False},
         {"name": THIS_PR_HEADER, "value": BLANK, "inline": False},
         {"name": "🔓 Unlock", "value": f"*{headline}*", "inline": False},
-        {"name": "🔗 Link", "value": f"[#{pr_number} — {latest.get('title', '')}]({pr_url})", "inline": False},
+        {
+            "name": "🔗 Link",
+            "value": f"[#{pr_number} — {latest.get('title', '')}]({pr_url})",
+            "inline": False,
+        },
         {"name": "🧮 Footprint", "value": footprint, "inline": True},
-        {"name": "🔁 Review iterations", "value": _this_pr_iter_line(latest_iterations), "inline": True},
-        {"name": "⏱️ Time for review", "value": _this_pr_review_line(latest_ttm_hours), "inline": True},
-        {"name": "🔄 Tick length", "value": _this_pr_tick_line(latest_tick_hours), "inline": True},
+        {
+            "name": "🔁 Review iterations",
+            "value": _this_pr_iter_line(latest_iterations),
+            "inline": True,
+        },
+        {
+            "name": "⏱️ Time for review",
+            "value": _this_pr_review_line(latest_ttm_hours),
+            "inline": True,
+        },
+        {
+            "name": "🔄 Tick length",
+            "value": _this_pr_tick_line(latest_tick_hours),
+            "inline": True,
+        },
         {"name": BLANK, "value": BLANK, "inline": False},
         {"name": LOOP_HEADER, "value": BLANK, "inline": False},
         {"name": "🔥 Busiest day (7d)", "value": busy_line, "inline": True},
@@ -575,7 +652,11 @@ def _render_embed(
             "value": f"{int(rate['last_24h'])} in 24h · {int(rate['last_7_days'])} in 7d · **{total_merged}** all-time",
             "inline": True,
         },
-        {"name": "📈 LoC", "value": _loc_line(loc_24h, loc_7d, repo_net), "inline": False},
+        {
+            "name": "📈 LoC",
+            "value": _loc_line(loc_24h, loc_7d, repo_net),
+            "inline": False,
+        },
         {
             "name": "⚡ Merge rate",
             "value": f"**{rate['per_hour']:.2f}**/hr (24h) · {rate['per_day']:.1f}/day (7d)",
@@ -616,7 +697,9 @@ def post_to_discord(channel_id: str, token: str, payload: dict[str, Any]) -> Non
         "Content-Type": "application/json",
         "User-Agent": "DiscordBot (ralph-recap, 1.0)",
     }
-    _request_json(url, headers=headers, method="POST", body=json.dumps(payload).encode("utf-8"))
+    _request_json(
+        url, headers=headers, method="POST", body=json.dumps(payload).encode("utf-8")
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -638,14 +721,18 @@ def _gather(repo: str, gh_token: str, max_prs: int) -> dict[str, Any] | None:
 def _deliver(channel_id: str | None, payload: dict[str, Any]) -> None:
     """Post the payload to Discord, mapping failures to RecapError."""
     if not channel_id:
-        raise RecapError("RALPH_CHANNEL_ID (or --channel-id) is required to post", code=2)
+        raise RecapError(
+            "RALPH_CHANNEL_ID (or --channel-id) is required to post", code=2
+        )
     discord_token = os.environ.get("DISCORD_BOT_TOKEN")
     if not discord_token:
         raise RecapError("DISCORD_BOT_TOKEN is required to post", code=2)
     try:
         post_to_discord(channel_id, discord_token, payload)
     except urllib.error.HTTPError as exc:
-        raise RecapError(f"Discord API request failed: {exc.code} {exc.reason}") from exc
+        raise RecapError(
+            f"Discord API request failed: {exc.code} {exc.reason}"
+        ) from exc
     except urllib.error.URLError as exc:
         raise RecapError(f"network failure talking to Discord: {exc.reason}") from exc
 
@@ -671,11 +758,17 @@ def _run(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="owner/repo slug")
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "--repo", default=os.environ.get("GITHUB_REPOSITORY"), help="owner/repo slug"
+    )
     parser.add_argument("--channel-id", default=os.environ.get("RALPH_CHANNEL_ID"))
     parser.add_argument("--max-prs", type=int, default=DEFAULT_MAX_PRS)
-    parser.add_argument("--dry-run", action="store_true", help="print the embed instead of posting")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="print the embed instead of posting"
+    )
     args = parser.parse_args(argv)
     try:
         return _run(args)

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -75,7 +75,12 @@ def test_iterations_before_lgtm_none_when_never_lgtm() -> None:
 
 def test_merge_rate_empty() -> None:
     rate = rs.merge_rate([], now=_at(27))
-    assert rate == {"last_24h": 0.0, "per_hour": 0.0, "last_7_days": 0.0, "per_day": 0.0}
+    assert rate == {
+        "last_24h": 0.0,
+        "per_hour": 0.0,
+        "last_7_days": 0.0,
+        "per_day": 0.0,
+    }
 
 
 def test_merge_rate_last_24h_per_hour() -> None:
@@ -116,12 +121,18 @@ def test_time_to_merge_stats() -> None:
 
 def test_merge_intervals_hours_returns_consecutive_gaps() -> None:
     # 09:00, 12:00, 15:00 -> two 3-hour gaps.
-    assert rs.merge_intervals_hours([_at(27, 9), _at(27, 12), _at(27, 15)]) == [3.0, 3.0]
+    assert rs.merge_intervals_hours([_at(27, 9), _at(27, 12), _at(27, 15)]) == [
+        3.0,
+        3.0,
+    ]
 
 
 def test_merge_intervals_hours_sorts_before_diffing() -> None:
     # Newest-first input (as the recap holds it) still yields positive gaps.
-    assert rs.merge_intervals_hours([_at(27, 15), _at(27, 9), _at(27, 12)]) == [3.0, 3.0]
+    assert rs.merge_intervals_hours([_at(27, 15), _at(27, 9), _at(27, 12)]) == [
+        3.0,
+        3.0,
+    ]
 
 
 def test_merge_intervals_hours_empty_below_two_merges() -> None:
@@ -207,17 +218,24 @@ def test_busiest_day_none_when_empty() -> None:
 
 
 def _issue(number: int, *, labels: list[str], is_pr: bool = False) -> dict[str, Any]:
-    issue: dict[str, Any] = {"number": number, "labels": [{"name": name} for name in labels]}
+    issue: dict[str, Any] = {
+        "number": number,
+        "labels": [{"name": name} for name in labels],
+    }
     if is_pr:
         issue["pull_request"] = {"url": f"https://example/{number}"}
     return issue
 
 
-def _patch_issues(monkeypatch: pytest.MonkeyPatch, issues: list[dict[str, Any]]) -> None:
+def _patch_issues(
+    monkeypatch: pytest.MonkeyPatch, issues: list[dict[str, Any]]
+) -> None:
     monkeypatch.setattr(recap, "_gh_get_paged", lambda *a, **k: issues)
 
 
-def test_count_open_backlog_excludes_prs_and_labelled_issues(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_count_open_backlog_excludes_prs_and_labelled_issues(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv("RALPH_EXCLUDE_LABELS", raising=False)
     issues = [
         _issue(1, labels=[]),  # counted
@@ -230,7 +248,9 @@ def test_count_open_backlog_excludes_prs_and_labelled_issues(monkeypatch: pytest
     assert recap.count_open_backlog("owner/repo", token="t") == 2
 
 
-def test_count_open_backlog_respects_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_count_open_backlog_respects_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setenv("RALPH_EXCLUDE_LABELS", "deferred")
     issues = [
         _issue(1, labels=["epic"]),  # no longer excluded (override drops "epic")
@@ -244,8 +264,12 @@ def test_count_open_backlog_respects_env_override(monkeypatch: pytest.MonkeyPatc
 # ---------- count_merged_total ----------
 
 
-def test_count_merged_total_reads_search_total_count(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: {"total_count": 723, "items": []})
+def test_count_merged_total_reads_search_total_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        recap, "_request_json", lambda *a, **k: {"total_count": 723, "items": []}
+    )
     assert recap.count_merged_total("owner/repo", token="t") == 723
 
 
@@ -253,17 +277,25 @@ def test_count_merged_total_reads_search_total_count(monkeypatch: pytest.MonkeyP
 
 
 def _hit(number: int, *, merged: str, created: str) -> dict[str, Any]:
-    return {"number": number, "created_at": created, "pull_request": {"merged_at": merged}}
+    return {
+        "number": number,
+        "created_at": created,
+        "pull_request": {"merged_at": merged},
+    }
 
 
-def test_fetch_recent_merged_prs_sorts_newest_merge_first(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fetch_recent_merged_prs_sorts_newest_merge_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     hits = [
         _hit(1, merged="2026-06-25T00:00:00Z", created="2026-06-24T00:00:00Z"),
         _hit(2, merged="2026-06-27T00:00:00Z", created="2026-06-26T00:00:00Z"),
         _hit(3, merged="2026-06-26T00:00:00Z", created="2026-06-25T00:00:00Z"),
     ]
     monkeypatch.setattr(recap, "_gh_search_issues", lambda *a, **k: hits)
-    out = recap.fetch_recent_merged_prs("owner/repo", token="t", since=_at(20).date(), max_prs=200)
+    out = recap.fetch_recent_merged_prs(
+        "owner/repo", token="t", since=_at(20).date(), max_prs=200
+    )
     assert [pr["number"] for pr in out] == [2, 3, 1]
 
 
@@ -285,11 +317,17 @@ def test_open_to_merge_hours_clamps_negative_to_zero() -> None:
 
 
 def test_pr_churn_reads_detail_fields(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(recap, "fetch_pr_detail", lambda *a, **k: {"additions": 12, "deletions": 4, "changed_files": 3})
+    monkeypatch.setattr(
+        recap,
+        "fetch_pr_detail",
+        lambda *a, **k: {"additions": 12, "deletions": 4, "changed_files": 3},
+    )
     assert recap._pr_churn("owner/repo", 1, token="t") == (12, 4, 3)
 
 
-def test_pr_churn_degrades_to_zero_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_pr_churn_degrades_to_zero_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import urllib.error
 
     def _boom(*_a: Any, **_k: Any) -> dict[str, Any]:
@@ -302,18 +340,64 @@ def test_pr_churn_degrades_to_zero_on_http_error(monkeypatch: pytest.MonkeyPatch
 # ---------- fetch_repo_net_lines ----------
 
 
-def test_fetch_repo_net_lines_sums_code_frequency(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: [[1, 100, -40], [2, 20, -5]])
+def test_fetch_repo_net_lines_sums_code_frequency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        recap, "_request_json", lambda *a, **k: [[1, 100, -40], [2, 20, -5]]
+    )
     assert recap.fetch_repo_net_lines("owner/repo", token="t") == 75
 
 
-def test_fetch_repo_net_lines_none_when_stats_still_warming(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fetch_repo_net_lines_none_when_stats_still_warming(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     # A 202 from GitHub yields an empty body (None); retries exhaust to None.
     monkeypatch.setattr(recap, "_request_json", lambda *a, **k: None)
-    assert recap.fetch_repo_net_lines("owner/repo", token="t", attempts=2) is None
+    assert (
+        recap.fetch_repo_net_lines(
+            "owner/repo", token="t", attempts=2, sleep=lambda _d: None
+        )
+        is None
+    )
 
 
-def test_fetch_repo_net_lines_none_on_http_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_fetch_repo_net_lines_retries_warming_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # GitHub answers 202/empty (None) on a cold cache, then real rows once warm.
+    # The fix waits with backoff between attempts instead of firing instantly.
+    calls = {"n": 0}
+    rows = [[1, 100, -40], [2, 20, -5]]  # net 75
+
+    def _resp(*_a: Any, **_k: Any) -> object:
+        calls["n"] += 1
+        return None if calls["n"] < 3 else rows
+
+    monkeypatch.setattr(recap, "_request_json", _resp)
+    slept: list[float] = []
+    result = recap.fetch_repo_net_lines(
+        "owner/repo", token="t", attempts=4, sleep=slept.append
+    )
+    assert result == 75  # the retry now succeeds once the cache warms
+    assert calls["n"] == 3  # two warming 202s, then the real rows
+    assert slept == [2.0, 4.0]  # exponential backoff between the failed attempts
+
+
+def test_fetch_repo_net_lines_empty_history_is_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A genuinely empty history (HTTP 200 with []) is final (net 0), NOT a
+    # warming 202 to retry — distinguishable from the empty-body None case.
+    monkeypatch.setattr(recap, "_request_json", lambda *a, **k: [])
+    slept: list[float] = []
+    assert recap.fetch_repo_net_lines("owner/repo", token="t", sleep=slept.append) == 0
+    assert slept == []  # returned immediately; no retry/backoff
+
+
+def test_fetch_repo_net_lines_none_on_http_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     import urllib.error
 
     def _boom(*_a: Any, **_k: Any) -> object:
@@ -346,7 +430,9 @@ def test_loc_line_renders_three_windows() -> None:
     loc_24h = {"additions": 1200, "deletions": 300, "net": 900, "files": 5}
     loc_7d = {"additions": 8400, "deletions": 1600, "net": 6800, "files": 40}
     line = recap._loc_line(loc_24h, loc_7d, 124_500)
-    assert line == "+1,200 / -300 (24h) · +8,400 / -1,600 (7d) · 124,500 net (full repo)"
+    assert (
+        line == "+1,200 / -300 (24h) · +8,400 / -1,600 (7d) · 124,500 net (full repo)"
+    )
 
 
 def test_loc_line_placeholder_when_repo_net_unavailable() -> None:
@@ -359,11 +445,16 @@ def test_loc_line_placeholder_when_repo_net_unavailable() -> None:
 
 
 def test_heuristic_headline_strips_conventional_prefix() -> None:
-    assert recap._heuristic_headline("feat(backend): add the energy ledger") == "add the energy ledger"
+    assert (
+        recap._heuristic_headline("feat(backend): add the energy ledger")
+        == "add the energy ledger"
+    )
 
 
 def test_heuristic_headline_clips_to_ten_words() -> None:
-    headline = recap._heuristic_headline("one two three four five six seven eight nine ten eleven")
+    headline = recap._heuristic_headline(
+        "one two three four five six seven eight nine ten eleven"
+    )
     assert headline == "one two three four five six seven eight nine ten"
 
 
@@ -403,7 +494,9 @@ class _FakeAnthropic:
         return _FakeAnthropic._Client()
 
 
-def test_generate_headline_uses_sdk_and_passes_low_effort(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_generate_headline_uses_sdk_and_passes_low_effort(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     fake = _FakeAnthropic()
     _FakeAnthropic.last_kwargs = {}
     monkeypatch.setattr(recap, "_anthropic_mod", fake)
@@ -416,21 +509,33 @@ def test_generate_headline_uses_sdk_and_passes_low_effort(monkeypatch: pytest.Mo
     assert _FakeAnthropic.last_kwargs["output_config"] == {"effort": "low"}
 
 
-def test_generate_headline_falls_back_when_no_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_generate_headline_falls_back_when_no_api_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(recap, "_anthropic_mod", _FakeAnthropic())
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
 
-    assert recap.generate_headline("feat: add energy ledger", "Body") == "add energy ledger"
+    assert (
+        recap.generate_headline("feat: add energy ledger", "Body")
+        == "add energy ledger"
+    )
 
 
-def test_generate_headline_falls_back_when_sdk_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_generate_headline_falls_back_when_sdk_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.setattr(recap, "_anthropic_mod", None)
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # pragma: allowlist secret
 
-    assert recap.generate_headline("feat: add energy ledger", "Body") == "add energy ledger"
+    assert (
+        recap.generate_headline("feat: add energy ledger", "Body")
+        == "add energy ledger"
+    )
 
 
-def test_generate_headline_falls_back_on_sdk_error(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_generate_headline_falls_back_on_sdk_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     class _Boom:
         def Anthropic(self) -> object:  # noqa: N802 - mirrors the SDK's class name
             raise RuntimeError("api down")
@@ -438,4 +543,7 @@ def test_generate_headline_falls_back_on_sdk_error(monkeypatch: pytest.MonkeyPat
     monkeypatch.setattr(recap, "_anthropic_mod", _Boom())
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")  # pragma: allowlist secret
 
-    assert recap.generate_headline("feat: add energy ledger", "Body") == "add energy ledger"
+    assert (
+        recap.generate_headline("feat: add energy ledger", "Body")
+        == "add energy ledger"
+    )


### PR DESCRIPTION
## Summary
The Discord recap's `📈 LoC` field showed a blank `—` for the full-repo total. Root cause: GitHub's `/stats/code_frequency` answers **HTTP 202 with an empty body** while it computes the stats on a cold cache. `_request_json` parses that empty body to `None`, and `fetch_repo_net_lines` retried on falsy `data` with **no delay** — so all three attempts fired within milliseconds, before the cache could warm, and the function returned `None` every time → `—`.

### Fix (scoped to `fetch_repo_net_lines` + its tests)
- **Exponential backoff between attempts** (2s, 4s, 8s) so a cold 202 has time to warm. The delay function is an injectable parameter (`sleep=time.sleep`) so tests don't actually sleep. `attempts` 3 → 4.
- **Explicit 202 vs empty-history handling**: an empty body (`None`) means "still warming → back off and retry"; an HTTP 200 returning a list (rows **or** a genuine `[]`) is final and summed (`[]` nets to 0). The `data is not None` check makes the intent explicit instead of relying on the falsy-data coincidence — so a legitimately empty-history repo is distinguishable from a not-yet-computed cache.
- **Graceful fallback preserved**: exhausting the attempts (or any HTTP/transport error) still returns `None` → the placeholder, so a slow stats API never crashes the recap.

The 24h/7d per-PR churn fields (`fetch_pr_detail`, `stats.churn_totals`) are untouched.

## Test plan
`scripts/ralph/test_recap_stats.py` (51 pass, fast — `sleep` patched):
- **NEW** `test_fetch_repo_net_lines_retries_warming_then_succeeds`: two warming 202s (`None`) then real rows → correct net **75**, asserting the retry happened (3 calls) and backoff fired (`[2.0, 4.0]`).
- **NEW** `test_fetch_repo_net_lines_empty_history_is_zero`: a genuine `[]` → **0** with **no** retry/backoff.
- Existing all-warming → `None` and HTTP-error → `None` paths kept green (warming test now passes a no-op `sleep`).

ruff + ruff-format clean on both files. (recap.py lives in `scripts/ralph/`, outside the creek-tools `check-all.sh` scope; CI's tree-wide ruff + the recap suite cover it. A pre-existing mypy note on the optional-`anthropic` import shim is unrelated and identical on `main`.)

Closes #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)