### PR TITLE
fix(fill): prove creek fill idempotency on a real vault + fix unnamed-digest non-idempotency (#736)

### DIFF
--- a/creek-tools/creek/generate/unnamed.py
+++ b/creek-tools/creek/generate/unnamed.py
@@ -518,8 +518,7 @@ def _upsert_history_entry(
         prior.get(key) == new_entry.get(key) for key in _HISTORY_DATA_KEYS
     ):
         # Copy rather than mutate the caller's dict (no surprising side-effect).
-        new_entry = {
-            **new_entry,
+        new_entry = new_entry | {
             "generated_at": prior.get("generated_at", new_entry["generated_at"]),
         }
     merged = [e for e in entries if e.get("week_start") != week]

--- a/creek-tools/creek/generate/unnamed.py
+++ b/creek-tools/creek/generate/unnamed.py
@@ -43,7 +43,6 @@ from creek.models import Fragment
 from creek.time import effective_authored_at, effective_authored_date
 
 if TYPE_CHECKING:
-    from datetime import date
     from pathlib import Path
 
     from creek.link.embeddings import EmbeddingLinker
@@ -83,6 +82,10 @@ class _HistoryEntry:
         Returns:
             Dictionary with all history entry fields.
         """
+        # ``generated_at`` is stamped live here (not stored on the dataclass) so
+        # a genuinely new/changed week records when it was written; an unchanged
+        # week's stamp is preserved by ``_upsert_history_entry`` to stay
+        # byte-idempotent.
         return {
             "week_start": self.week_start,
             "fragment_count": self.fragment_count,
@@ -514,7 +517,11 @@ def _upsert_history_entry(
     if prior is not None and all(
         prior.get(key) == new_entry.get(key) for key in _HISTORY_DATA_KEYS
     ):
-        new_entry["generated_at"] = prior.get("generated_at", new_entry["generated_at"])
+        # Copy rather than mutate the caller's dict (no surprising side-effect).
+        new_entry = {
+            **new_entry,
+            "generated_at": prior.get("generated_at", new_entry["generated_at"]),
+        }
     merged = [e for e in entries if e.get("week_start") != week]
     merged.append(new_entry)
     merged.sort(key=lambda e: str(e.get("week_start", "")))

--- a/creek-tools/creek/generate/unnamed.py
+++ b/creek-tools/creek/generate/unnamed.py
@@ -32,10 +32,11 @@ import itertools
 import json
 import logging
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import frontmatter
+import yaml
 from pydantic import ValidationError
 
 from creek.models import Fragment
@@ -91,6 +92,46 @@ class _HistoryEntry:
         }
 
 
+def _stable_digest_generated(
+    path: Path,
+    body: str,
+    week_start_iso: str,
+    week_end_iso: str,
+) -> str:
+    """Return the ``generated`` stamp for a digest, idempotent across re-runs.
+
+    Reuses the existing digest's ``generated`` value when its body and week
+    bounds are unchanged, so re-running the report writes byte-identical output
+    instead of bumping a fresh wall-clock timestamp. Returns a current UTC
+    timestamp when there is no prior digest or its content differs.
+
+    Args:
+        path: Target digest file (may not yet exist).
+        body: The freshly rendered digest body.
+        week_start_iso: ISO date of the week's Monday.
+        week_end_iso: ISO date of the week's Sunday.
+
+    Returns:
+        An ISO-8601 timestamp string for the ``generated`` frontmatter field.
+    """
+    if path.exists():
+        try:
+            existing = frontmatter.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError, yaml.YAMLError):
+            existing = None
+        if (
+            existing is not None
+            # frontmatter normalises trailing whitespace on round-trip, so
+            # compare stripped bodies (the rewrite below renders identically).
+            and existing.content.strip() == body.strip()
+            and existing.get("week_start") == week_start_iso
+            and existing.get("week_end") == week_end_iso
+            and isinstance(existing.get("generated"), str)
+        ):
+            return str(existing["generated"])
+    return datetime.now(tz=UTC).isoformat()
+
+
 class UnnamedDigestGenerator:
     """Generate weekly digest notes for the ``10-Liminal/Unnamed/`` folder.
 
@@ -142,7 +183,7 @@ class UnnamedDigestGenerator:
         all_unnamed = self.load_unnamed_fragments(vault_path)
         this_week = self.filter_fragments_in_week(all_unnamed, week_start)
         clusters = self.detect_unnamed_clusters(this_week)
-        previous = self._load_history(vault_path)
+        previous = self._load_history(vault_path, week_start)
         body = self._render_body(
             vault_path,
             this_week,
@@ -344,14 +385,19 @@ class UnnamedDigestGenerator:
         iso_year, iso_week, _ = week_start.isocalendar()
         filename = f"{iso_year}-W{iso_week:02d}.md"
         week_end = week_start + timedelta(days=_WEEK_LENGTH_DAYS - 1)
+        digest_path = digests_dir / filename
         post = frontmatter.Post(
             content=body,
             type="unnamed-digest",
             week_start=week_start.isoformat(),
             week_end=week_end.isoformat(),
-            generated=datetime.now(tz=UTC).isoformat(),
+            # Reuse the prior stamp when nothing else changed so a re-run is
+            # byte-idempotent (a fresh wall-clock stamp every run would otherwise
+            # rewrite an unchanged digest).
+            generated=_stable_digest_generated(
+                digest_path, body, week_start.isoformat(), week_end.isoformat()
+            ),
         )
-        digest_path = digests_dir / filename
         digest_path.write_text(frontmatter.dumps(post), encoding="utf-8")
         return digest_path
 
@@ -367,38 +413,33 @@ class UnnamedDigestGenerator:
         """
         return vault_path.joinpath(*_HISTORY_SUBPATH)
 
-    def _load_history(self, vault_path: Path) -> _HistoryEntry | None:
-        """Load the most recent history entry, if any.
+    def _load_history(self, vault_path: Path, before: date) -> _HistoryEntry | None:
+        """Load the most recent history entry for a week strictly before *before*.
+
+        Excluding the current week is what keeps a re-run idempotent: the run
+        records the current week in history, so without this filter a second
+        ``generate`` would read its own entry back as the "previous week" and
+        rewrite the digest's growth section.
 
         Args:
             vault_path: Path to the root of the Obsidian vault.
+            before: The current week's Monday; only earlier weeks are considered.
 
         Returns:
-            The last recorded :class:`_HistoryEntry`, or ``None`` when
-            the history file is missing or empty.
+            The most recent prior-week :class:`_HistoryEntry`, or ``None`` when
+            no earlier week was recorded.
         """
-        path = self._history_path(vault_path)
-        if not path.exists():
+        entries = _read_history_entries(self._history_path(vault_path))
+        cutoff = before.isoformat()
+        prior = [e for e in entries if str(e.get("week_start", "")) < cutoff]
+        if not prior:
             return None
-        raw = path.read_text(encoding="utf-8").strip()
-        if not raw:
-            return None
-        try:
-            entries = json.loads(raw)
-        except json.JSONDecodeError:
-            logger.warning(
-                "Corrupt unnamed history at %s; treating as no prior data",
-                path,
-            )
-            return None
-        if not entries:
-            return None
-        last = entries[-1]
+        last = max(prior, key=lambda e: str(e.get("week_start", "")))
         return _HistoryEntry(
             week_start=str(last.get("week_start", "")),
-            fragment_count=int(last.get("fragment_count", 0)),
-            total_unnamed=int(last.get("total_unnamed", 0)),
-            cluster_count=int(last.get("cluster_count", 0)),
+            fragment_count=int(str(last.get("fragment_count", 0))),
+            total_unnamed=int(str(last.get("total_unnamed", 0))),
+            cluster_count=int(str(last.get("cluster_count", 0))),
         )
 
     def _append_history(
@@ -406,7 +447,7 @@ class UnnamedDigestGenerator:
         vault_path: Path,
         entry: _HistoryEntry,
     ) -> None:
-        """Append *entry* to the history log.
+        """Record *entry*, upserting this week's row so a re-run stays idempotent.
 
         Args:
             vault_path: Path to the root of the Obsidian vault.
@@ -414,23 +455,70 @@ class UnnamedDigestGenerator:
         """
         path = self._history_path(vault_path)
         path.parent.mkdir(parents=True, exist_ok=True)
-        entries: list[dict[str, object]] = []
-        if path.exists():
-            raw = path.read_text(encoding="utf-8").strip()
-            if raw:
-                try:
-                    entries = json.loads(raw)
-                except json.JSONDecodeError:
-                    logger.warning(
-                        "Corrupt unnamed history at %s; overwriting with fresh log",
-                        path,
-                    )
-                    entries = []
-        entries.append(entry.to_dict())
-        path.write_text(json.dumps(entries, indent=2), encoding="utf-8")
+        merged = _upsert_history_entry(_read_history_entries(path), entry.to_dict())
+        path.write_text(json.dumps(merged, indent=2), encoding="utf-8")
 
 
 # ---- Module-level helpers ----
+
+
+_HISTORY_DATA_KEYS = ("fragment_count", "total_unnamed", "cluster_count")
+"""History fields whose equality means a week's data is unchanged (so its
+``generated_at`` stamp is preserved on a re-run, keeping the log byte-stable)."""
+
+
+def _read_history_entries(path: Path) -> list[dict[str, object]]:
+    """Return the unnamed-history JSON as a list of entry dicts.
+
+    Yields an empty list when the file is missing, empty, corrupt, or not a JSON
+    list — the same fail-soft behaviour both the read and append paths relied on.
+
+    Args:
+        path: The history JSON path.
+
+    Returns:
+        The recorded entries, or an empty list.
+    """
+    if not path.exists():
+        return []
+    raw = path.read_text(encoding="utf-8").strip()
+    if not raw:
+        return []
+    try:
+        loaded = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Corrupt unnamed history at %s; treating as no prior data", path)
+        return []
+    return loaded if isinstance(loaded, list) else []
+
+
+def _upsert_history_entry(
+    entries: list[dict[str, object]],
+    new_entry: dict[str, object],
+) -> list[dict[str, object]]:
+    """Return *entries* with *new_entry*'s week replaced (not duplicated), sorted.
+
+    When the prior row for the same week carries identical data fields, its
+    ``generated_at`` stamp is preserved so a re-run leaves the history file
+    byte-identical (idempotent).
+
+    Args:
+        entries: Existing history rows.
+        new_entry: The row to upsert (keyed by ``week_start``).
+
+    Returns:
+        The merged, week-sorted list of rows.
+    """
+    week = new_entry.get("week_start")
+    prior = next((e for e in entries if e.get("week_start") == week), None)
+    if prior is not None and all(
+        prior.get(key) == new_entry.get(key) for key in _HISTORY_DATA_KEYS
+    ):
+        new_entry["generated_at"] = prior.get("generated_at", new_entry["generated_at"])
+    merged = [e for e in entries if e.get("week_start") != week]
+    merged.append(new_entry)
+    merged.sort(key=lambda e: str(e.get("week_start", "")))
+    return merged
 
 
 def _load_fragment(md_file: Path) -> Fragment | None:

--- a/creek-tools/tests/test_cli_fill_idempotency.py
+++ b/creek-tools/tests/test_cli_fill_idempotency.py
@@ -1,0 +1,133 @@
+"""Real-vault (un-mocked) idempotency audit for ``creek fill`` (#736).
+
+``test_cli_fill.py`` covers orchestration with every step mocked; this proves the
+docstring claim that *"a second ``creek fill`` is a clean no-op"* end-to-end:
+build a real scaffolded vault with classified fragments, run the actual pipeline
+steps twice, and assert every markdown note is byte-for-byte identical on the
+second run. The conftest sentence-transformer mock is deterministic within a
+process (seeded by ``hash(text)``), so embeddings are stable across both runs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.models import (
+    Fragment,
+    FragmentSource,
+    Frequency,
+    FrequencyClassification,
+    Phase,
+    SourcePlatform,
+    WavelengthClassification,
+)
+from creek.time import now_la
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+_TOP_LEVEL = (
+    "00-Creek-Meta",
+    "01-Fragments",
+    "02-Threads",
+    "03-Eddies",
+    "04-Praxis",
+    "05-Wavelength",
+    "06-Frequencies",
+    "07-Voice",
+    "08-Decisions",
+    "09-Reference",
+    "10-Liminal",
+)
+_FREQ_SUBDIRS = (
+    "F1-Agency",
+    "F2-Receptivity",
+    "F3-Self-Love-Power",
+    "F4-Community-Love",
+    "F5-Achievism",
+    "F6-Pluralism",
+    "F7-Integration",
+    "F8-True-Self",
+    "F9-Unity",
+    "F10-Emptiness",
+)
+
+
+def _scaffold(tmp_path: Path) -> Path:
+    """Create a full vault folder tree the fill generators write into."""
+    vault = tmp_path / "vault"
+    for folder in _TOP_LEVEL:
+        (vault / folder).mkdir(parents=True)
+    for sub in _FREQ_SUBDIRS:
+        (vault / "06-Frequencies" / sub).mkdir()
+    return vault
+
+
+def _seed(vault: Path) -> None:
+    """Write classified fragments that populate several fill-managed folders."""
+    base = now_la() - timedelta(days=1)
+    # Three F5 fragments within the window → a thread + frequency/wavelength data.
+    for i in range(3):
+        write_fragment_file(
+            vault=vault,
+            fragment=Fragment(
+                id=f"frag-fill00000{i:03d}",
+                title=f"Achievism note {i}",
+                source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+                authored_at=base,
+                frequency=FrequencyClassification(primary=Frequency.F5),
+                wavelength=WavelengthClassification(phase=Phase.RISING),
+            ),
+            body=f"Shared achievism theme, entry {i}.",
+        )
+    # A cross-source, far-dated fragment (synchronicity candidate material).
+    write_fragment_file(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-fill000aa1",
+            title="a different lens on the same idea",
+            source=FragmentSource(platform=SourcePlatform.DISCORD),
+            authored_at=datetime(2025, 1, 5, tzinfo=UTC),
+            frequency=FrequencyClassification(primary=Frequency.F6),
+            wavelength=WavelengthClassification(phase=Phase.WITHDRAWAL),
+        ),
+        body="Shared achievism theme, a later echo.",
+    )
+
+
+def _markdown_digest(vault: Path) -> dict[str, str]:
+    """Map each markdown note's vault-relative path to a sha256 of its bytes."""
+    return {
+        str(p.relative_to(vault)): hashlib.sha256(p.read_bytes()).hexdigest()
+        for p in sorted(vault.rglob("*.md"))
+        if not p.name.startswith(".")
+    }
+
+
+def test_second_creek_fill_is_byte_stable(tmp_path: Path) -> None:
+    """A second ``creek fill`` mutates no markdown note (real, un-mocked steps)."""
+    vault = _scaffold(tmp_path)
+    _seed(vault)
+
+    first = runner.invoke(app, ["fill", "--vault", str(vault)])
+    assert first.exit_code == 0, first.output
+    snapshot = _markdown_digest(vault)
+    assert snapshot, "expected the first fill to populate markdown notes"
+
+    second = runner.invoke(app, ["fill", "--vault", str(vault)])
+    assert second.exit_code == 0, second.output
+    after = _markdown_digest(vault)
+
+    assert set(after) == set(snapshot), (
+        f"second fill added/removed notes: {set(after) ^ set(snapshot)}"
+    )
+    changed = [path for path, digest in snapshot.items() if after.get(path) != digest]
+    assert not changed, f"second fill rewrote notes (not idempotent): {changed}"

--- a/creek-tools/tests/test_unnamed_digest.py
+++ b/creek-tools/tests/test_unnamed_digest.py
@@ -535,6 +535,39 @@ class TestGenerateWeeklyDigest:
         assert history[0]["fragment_count"] == 1
         assert history[0]["total_unnamed"] == 1
 
+    def test_regenerating_same_week_is_byte_idempotent(
+        self,
+        generator: UnnamedDigestGenerator,
+        vault: Path,
+    ) -> None:
+        """Re-running the same week rewrites neither the digest nor the history.
+
+        Guards two non-idempotency sources fixed for #736: the wall-clock
+        ``generated`` stamp (now preserved when content is unchanged) and the
+        self-referential growth section (history now excludes the current week
+        and upserts its row instead of appending a duplicate).
+        """
+        week_start = _week_start()
+        _write_unnamed_fragment(
+            vault,
+            "alpha",
+            created=datetime.combine(week_start, datetime.min.time(), tzinfo=UTC),
+        )
+        history_path = (
+            vault / "00-Creek-Meta" / "Processing-Log" / "unnamed-history.json"
+        )
+
+        first = generator.generate_weekly_digest(vault, week_start)
+        digest_bytes = first.read_bytes()
+        history_bytes = history_path.read_bytes()
+
+        second = generator.generate_weekly_digest(vault, week_start)
+
+        assert second == first
+        assert second.read_bytes() == digest_bytes  # digest unchanged on re-run
+        assert history_path.read_bytes() == history_bytes  # history did not grow
+        assert len(json.loads(history_path.read_text(encoding="utf-8"))) == 1
+
     def test_reports_growth_against_previous_week(
         self,
         generator: UnnamedDigestGenerator,

--- a/creek-tools/tests/test_unnamed_digest.py
+++ b/creek-tools/tests/test_unnamed_digest.py
@@ -686,3 +686,66 @@ class TestRenderFragmentsSectionBucketsByAuthoredAt:
         assert "- Created: 2025-06-01" in section
         # The shared wall-clock ingest date must never leak in.
         assert ingest_moment.date().isoformat() not in section
+
+
+# ---- _stable_digest_generated ----
+
+
+class TestStableDigestGenerated:
+    """Unit coverage for the digest's idempotent ``generated`` stamp."""
+
+    def test_no_existing_file_stamps_now(self, tmp_path: Path) -> None:
+        """With no prior digest the helper returns a fresh ISO timestamp."""
+        from creek.generate.unnamed import _stable_digest_generated
+
+        out = _stable_digest_generated(
+            tmp_path / "2026-W07.md", "body", "2026-02-09", "2026-02-15"
+        )
+        assert out.endswith("+00:00")
+
+    def test_unchanged_content_preserves_prior_stamp(self, tmp_path: Path) -> None:
+        """An unchanged digest reuses its recorded stamp (byte-idempotent)."""
+        from creek.generate.unnamed import _stable_digest_generated
+
+        path = tmp_path / "2026-W07.md"
+        path.write_text(
+            frontmatter.dumps(
+                frontmatter.Post(
+                    content="body",
+                    week_start="2026-02-09",
+                    week_end="2026-02-15",
+                    generated="2020-01-01T00:00:00+00:00",
+                )
+            ),
+            encoding="utf-8",
+        )
+        out = _stable_digest_generated(path, "body", "2026-02-09", "2026-02-15")
+        assert out == "2020-01-01T00:00:00+00:00"
+
+    def test_changed_body_restamps(self, tmp_path: Path) -> None:
+        """A changed body discards the old stamp for a fresh one."""
+        from creek.generate.unnamed import _stable_digest_generated
+
+        path = tmp_path / "2026-W07.md"
+        path.write_text(
+            frontmatter.dumps(
+                frontmatter.Post(
+                    content="old body",
+                    week_start="2026-02-09",
+                    week_end="2026-02-15",
+                    generated="2020-01-01T00:00:00+00:00",
+                )
+            ),
+            encoding="utf-8",
+        )
+        out = _stable_digest_generated(path, "new body", "2026-02-09", "2026-02-15")
+        assert out != "2020-01-01T00:00:00+00:00"
+
+    def test_unreadable_file_restamps(self, tmp_path: Path) -> None:
+        """An undecodable prior digest is treated as absent, not a crash."""
+        from creek.generate.unnamed import _stable_digest_generated
+
+        path = tmp_path / "2026-W07.md"
+        path.write_bytes(b"\xff\xfe not valid utf-8")
+        out = _stable_digest_generated(path, "body", "2026-02-09", "2026-02-15")
+        assert out.endswith("+00:00")


### PR DESCRIPTION
## Summary
Delivers **#736's headline deliverable**: a real-vault, **un-mocked** byte-stability audit of `creek fill`. `test_cli_fill.py` mocks every step, so the docstring claim *"a second `creek fill` is a clean no-op"* was never proven end-to-end. The new audit builds a real scaffolded vault with classified fragments, runs the actual pipeline steps twice, and asserts every markdown note is byte-for-byte identical on the second run.

**The audit surfaced a genuine non-idempotency** in the unnamed weekly digest — a second fill rewrote `10-Liminal/Unnamed/Digests/<week>.md` and its history log. Three causes, all fixed in `creek/generate/unnamed.py`:

1. **Digest `generated` stamp** was a fresh wall-clock timestamp every run → `_stable_digest_generated` now preserves the prior stamp when the body + week bounds are unchanged.
2. **Self-referential growth section** — the digest read the unnamed-history log the *same run* had just updated, so run 2 saw its own entry as the "previous week". `_load_history` now takes the current week and returns only a strictly-earlier one.
3. **History log** appended a duplicate row each run and stamped a fresh per-row `generated_at` → now upserts by week and preserves `generated_at` when the week's data is unchanged. Extracted `_read_history_entries` + `_upsert_history_entry` (DRYs the load/append paths and keeps `_append_history` under the complexity gate).

## Test plan
- `tests/test_cli_fill_idempotency.py::test_second_creek_fill_is_byte_stable` — real vault, `creek fill` twice, asserts every `.md` note is byte-identical (sha256 snapshot). This is the headline.
- `tests/test_unnamed_digest.py::test_regenerating_same_week_is_byte_idempotent` — generator-level lock: the digest file and the history JSON are both byte-stable on a re-run, and the history keeps exactly one row per week.
- All 40 existing unnamed-digest tests stay green.

`./scripts/check-all.sh`: formatting/lint/mypy-strict/complexity/refurb/tryceratops all green; the only failing unit tests are the pre-existing author/compost/mcp environmental cluster (operator's live Ollama + creds), identical on clean `origin/main`; they pass on CI.

## Scope
This is **deliverable 1 of #736** (the idempotency audit + the bug it surfaced). **Deliverable 2 — the quality-aware overwrite dialog** (method-fidelity ladder, provenance extension, `fill` overwrite decision + `--upgrade` flag, Intimate-never-cloud preserved) — remains #736's tracked scope; see the [split note on #736](https://github.com/Geoffe-Ga/Creek-Vault/issues/736). Refs (does not close) #736.

Refs #720
Refs #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)