### PR TITLE
feat(fill): quality-aware classification overwrite + --upgrade (#736 deliverable 2)

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -565,7 +565,7 @@ def _finalise_fragment_write(
     raw: dict[str, object],
     reasoning: str,
     method: str,
-    provider: str | None,
+    provider: str | None = None,
     was_skipped: bool,
     counts: _RunCounts,
     progress_path: Path | None,

--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -38,6 +38,7 @@ import yaml
 from creek.classify.audience import AudienceClassifier
 from creek.classify.constants import (
     CLASSIFICATION_METHOD_KEY,
+    CLASSIFICATION_PROVIDER_KEY,
     CLASSIFICATION_REASONING_KEY,
     CLASSIFICATION_REASONING_MAX_CHARS,
     CLASSIFIED_AT_KEY,
@@ -508,6 +509,10 @@ def _process_file(
         raw=raw,
         reasoning=reasoning,
         method=method,
+        # The fragment's tier picked the classifier (#666); record its provider
+        # so a later quality-aware run can rank local-LLM vs cloud-LLM. Only an
+        # actual ``llm`` write keeps it (the writer clears it otherwise).
+        provider=llm.config.provider if llm is not None else None,
         was_skipped=was_skipped,
         counts=counts,
         progress_path=progress_path,
@@ -560,6 +565,7 @@ def _finalise_fragment_write(
     raw: dict[str, object],
     reasoning: str,
     method: str,
+    provider: str | None,
     was_skipped: bool,
     counts: _RunCounts,
     progress_path: Path | None,
@@ -591,6 +597,7 @@ def _finalise_fragment_write(
             method=write_method,
             raw=raw,
             reasoning=reasoning_for_frontmatter,
+            provider=provider,
         )
     except OSError as exc:
         counts.errors.append(f"failed to update {md_file}: {exc}")
@@ -974,6 +981,7 @@ def _write_fragment(
     method: str,
     raw: dict[str, object],
     reasoning: str,
+    provider: str | None = None,
 ) -> None:
     """Persist updated fragment metadata back to its file.
 
@@ -995,6 +1003,11 @@ def _write_fragment(
         reasoning: Per-FEAT-017 ``classification_reasoning`` value
             already truncated / tier-routed by :func:`_route_reasoning`.
             Empty string clears the field on disk.
+        provider: The LLM provider behind an ``llm`` classification
+            (e.g. ``anthropic`` / ``ollama``). Stamped as
+            ``classification_provider`` for ``llm`` writes so a
+            quality-aware re-run can tell local-LLM from cloud-LLM;
+            cleared for ``rules`` / ``manual`` so no stale value lingers.
     """
     new_metadata = raw.copy()
     new_metadata.update(fragment.model_dump(mode="json"))
@@ -1004,6 +1017,10 @@ def _write_fragment(
     # timestamp written to disk uses the same code path as every
     # other LA-anchored timestamp in the pipeline.
     new_metadata[CLASSIFIED_AT_KEY] = now_la().isoformat()
+    if method == LLM_METHOD and provider:
+        new_metadata[CLASSIFICATION_PROVIDER_KEY] = provider
+    else:
+        new_metadata.pop(CLASSIFICATION_PROVIDER_KEY, None)
     if reasoning:
         new_metadata[CLASSIFICATION_REASONING_KEY] = reasoning
     else:

--- a/creek-tools/creek/classify/constants.py
+++ b/creek-tools/creek/classify/constants.py
@@ -28,6 +28,11 @@ RULES_METHOD: Final[str] = "rules"
 LLM_METHOD: Final[str] = "llm"
 """``classification_method`` value emitted by the LLM classifier."""
 
+CLASSIFICATION_PROVIDER_KEY: Final[str] = "classification_provider"
+"""Frontmatter key naming the LLM provider behind an ``llm`` classification
+(e.g. ``anthropic`` / ``ollama``). Lets a quality-aware re-run tell a local-LLM
+classification apart from a cloud-LLM one; absent for ``rules`` / ``manual``."""
+
 CLASSIFICATION_REASONING_KEY: Final[str] = "classification_reasoning"
 """Frontmatter key carrying the truncated LLM reasoning trace (FEAT-017).
 

--- a/creek-tools/creek/classify/fidelity.py
+++ b/creek-tools/creek/classify/fidelity.py
@@ -1,0 +1,138 @@
+"""Classification method-fidelity ladder (#736).
+
+Single source of truth for ranking *how* a fragment was classified, and for
+computing the best method available to a vault right now. A quality-aware re-run
+(``creek fill --upgrade``) uses this to decide when re-classifying would actually
+improve an artifact rather than churn it.
+
+The ladder, lowest to highest fidelity::
+
+    unclassified < rules < local LLM < cloud LLM < manual
+
+``manual`` sits at the top so a human classification is never auto-overwritten.
+The Intimate tier's ceiling is the best **local** method — Intimate content is
+never ranked or routed to a cloud provider (the ModelRouter chokepoint enforces
+the routing; this module never proposes a cloud upgrade for Intimate).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from creek.classify.constants import LLM_METHOD, MANUAL_METHOD, RULES_METHOD
+from creek.classify.llm.providers import build_provider
+from creek.classify.llm.router import IntimateRoutingError
+from creek.models import PrivacyTier
+
+if TYPE_CHECKING:
+    from creek.config import CreekConfig, LLMConfig
+
+CLOUD_PROVIDERS: frozenset[str] = frozenset({"anthropic", "openai", "gemini"})
+"""Provider ids treated as cloud (the rung above a local LLM)."""
+
+RANK_UNCLASSIFIED: int = 0
+RANK_RULES: int = 1
+RANK_LLM_LOCAL: int = 2
+RANK_LLM_CLOUD: int = 3
+RANK_MANUAL: int = 4
+
+_RANK_LABELS: dict[int, str] = {
+    RANK_UNCLASSIFIED: "unclassified",
+    RANK_RULES: "rules",
+    RANK_LLM_LOCAL: "local LLM",
+    RANK_LLM_CLOUD: "cloud LLM",
+    RANK_MANUAL: "manual",
+}
+
+
+def provider_is_cloud(provider: str | None) -> bool:
+    """Return whether *provider* names a cloud backend."""
+    return bool(provider) and provider in CLOUD_PROVIDERS
+
+
+def rank_label(rank: int) -> str:
+    """Return a human label for a fidelity *rank*."""
+    return _RANK_LABELS.get(rank, "unknown")
+
+
+def method_rank(method: str | None, provider: str | None) -> int:
+    """Return the fidelity rank of a classification.
+
+    Args:
+        method: The ``classification_method`` value (``rules`` / ``llm`` /
+            ``manual``), or ``None`` for an unclassified fragment.
+        provider: The ``classification_provider`` value (only meaningful for
+            ``llm``); decides the local vs cloud rung.
+
+    Returns:
+        A rank from :data:`RANK_UNCLASSIFIED` to :data:`RANK_MANUAL`.
+    """
+    if method == MANUAL_METHOD:
+        return RANK_MANUAL
+    if method == LLM_METHOD:
+        return RANK_LLM_CLOUD if provider_is_cloud(provider) else RANK_LLM_LOCAL
+    if method == RULES_METHOD:
+        return RANK_RULES
+    return RANK_UNCLASSIFIED
+
+
+def _available_rank(config: LLMConfig) -> int:
+    """Return the rank an LLM stage *config* can deliver right now.
+
+    Falls back to :data:`RANK_RULES` when the provider is unavailable (no key /
+    consent for a cloud provider, or an unreachable local server) — i.e. the LLM
+    rung is only credited when a real classification could actually run.
+    """
+    is_cloud = provider_is_cloud(config.provider)
+    try:
+        available = build_provider(config).available
+    except RuntimeError:
+        # Cloud providers validate key/consent in their constructor.
+        available = False
+    if not available:
+        return RANK_RULES
+    return RANK_LLM_CLOUD if is_cloud else RANK_LLM_LOCAL
+
+
+@dataclass(frozen=True)
+class BestAvailable:
+    """The best classification rank available per tier, given config + env."""
+
+    non_intimate: int
+    intimate: int
+
+    def for_tier(self, tier: PrivacyTier) -> int:
+        """Return the best available rank for a fragment's *tier*."""
+        return self.intimate if tier == PrivacyTier.INTIMATE else self.non_intimate
+
+    def any_llm_available(self) -> bool:
+        """Whether either tier can reach an LLM rung (above plain rules)."""
+        return max(self.non_intimate, self.intimate) > RANK_RULES
+
+
+def best_available(config: CreekConfig) -> BestAvailable:
+    """Compute the best classification rank available to *config* per tier.
+
+    Resolves the ``classification`` stage through the ModelRouter exactly as
+    :func:`creek.classify.classify_engine.build_tier_classifiers` does — the
+    non-Intimate route uses the configured provider; the Intimate route is
+    redirected to a local provider, and its ceiling is capped at
+    :data:`RANK_LLM_LOCAL` so an upgrade is never proposed to cloud for Intimate.
+
+    Args:
+        config: The loaded Creek configuration (carries the model router).
+
+    Returns:
+        The :class:`BestAvailable` ranks for non-Intimate and Intimate tiers.
+    """
+    router = config.model_router
+    non_intimate = _available_rank(router.resolve("classification"))
+    try:
+        intimate_cfg = router.resolve("classification", PrivacyTier.INTIMATE)
+    except IntimateRoutingError:
+        # No local backend for Intimate → it can only be rules-classified.
+        intimate = RANK_RULES
+    else:
+        intimate = min(_available_rank(intimate_cfg), RANK_LLM_LOCAL)
+    return BestAvailable(non_intimate=non_intimate, intimate=intimate)

--- a/creek-tools/creek/classify/fidelity.py
+++ b/creek-tools/creek/classify/fidelity.py
@@ -37,23 +37,10 @@ RANK_LLM_LOCAL: int = 2
 RANK_LLM_CLOUD: int = 3
 RANK_MANUAL: int = 4
 
-_RANK_LABELS: dict[int, str] = {
-    RANK_UNCLASSIFIED: "unclassified",
-    RANK_RULES: "rules",
-    RANK_LLM_LOCAL: "local LLM",
-    RANK_LLM_CLOUD: "cloud LLM",
-    RANK_MANUAL: "manual",
-}
-
 
 def provider_is_cloud(provider: str | None) -> bool:
     """Return whether *provider* names a cloud backend."""
     return bool(provider) and provider in CLOUD_PROVIDERS
-
-
-def rank_label(rank: int) -> str:
-    """Return a human label for a fidelity *rank*."""
-    return _RANK_LABELS.get(rank, "unknown")
 
 
 def method_rank(method: str | None, provider: str | None) -> int:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -2378,7 +2378,14 @@ def _maybe_upgrade_classification(
     silently egresses): it only prints a hint. ``--upgrade`` applies the upgrade
     without a prompt; an interactive TTY prompts ``[y/N]`` (default No).
     """
-    offer = _detect_classify_upgrade(vault_path, config)
+    try:
+        offer = _detect_classify_upgrade(vault_path, config)
+    except Exception as exc:
+        # The upgrade check is best-effort: a provider/config hiccup (an
+        # unexpected build_provider error, a malformed routing block) must not
+        # crash fill before any step runs. Skip the offer and carry on.
+        logger.warning("fill: skipping classify-upgrade check: %s", exc)
+        return
     if offer is None:
         return
     if upgrade:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -8,6 +8,7 @@ import logging
 import os
 import re
 import sys
+from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
@@ -2265,6 +2266,137 @@ def _format_fill_summary(vault_path: Path) -> str:
     return "[bold green][fill] done. " + " | ".join(parts) + "[/bold green]"
 
 
+@dataclass(frozen=True)
+class _ClassifyUpgradeOffer:
+    """A quality-aware classification upgrade ``creek fill`` can offer (#736).
+
+    Attributes:
+        count: Number of ``rules``-classified fragments that a now-available
+            higher-fidelity method would improve.
+        non_intimate_label: ``provider/model`` the non-Intimate route would use.
+        intimate_label: ``provider/model`` the Intimate route would use (always
+            local — Intimate is never proposed a cloud upgrade).
+    """
+
+    count: int
+    non_intimate_label: str
+    intimate_label: str
+
+    def context(self) -> str:
+        """The bold context line printed before the prompt."""
+        return (
+            f"[yellow][fill] {self.count} fragment(s) were classified by `rules`; "
+            "a higher-fidelity method is now available "
+            f"({self.non_intimate_label} for non-Intimate; "
+            f"{self.intimate_label} for Intimate, kept local).[/yellow]"
+        )
+
+    def hint(self) -> str:
+        """The non-interactive hint (printed when no upgrade is performed)."""
+        return (
+            f"[dim][fill] {self.count} `rules`-classified fragment(s) could be "
+            f"upgraded ({self.non_intimate_label} / {self.intimate_label}); "
+            "re-run with --upgrade to apply (Intimate stays local).[/dim]"
+        )
+
+
+def _classification_route_label(config: CreekConfig, *, intimate: bool) -> str:
+    """Return a ``provider/model`` label for the classification route."""
+    from creek.classify.llm.router import IntimateRoutingError
+    from creek.models import PrivacyTier
+
+    router = config.model_router
+    try:
+        cfg = router.resolve(
+            "classification", PrivacyTier.INTIMATE if intimate else None
+        )
+    except IntimateRoutingError:
+        return "rules (no local backend)"
+    return f"{cfg.provider}/{cfg.model}" if cfg.model else cfg.provider
+
+
+def _detect_classify_upgrade(
+    vault_path: Path, config: CreekConfig
+) -> _ClassifyUpgradeOffer | None:
+    """Return an upgrade offer when ``rules`` artifacts could now do better.
+
+    A fragment is upgradeable when it was classified by ``rules`` and its tier's
+    best-available method (per the fidelity ladder) outranks ``rules`` — i.e. an
+    LLM is now reachable. Returns ``None`` when no LLM is available or no
+    ``rules`` fragment would benefit (so the offer never appears spuriously).
+    """
+    from creek.classify.constants import (
+        CLASSIFICATION_METHOD_KEY,
+        RULES_METHOD,
+    )
+    from creek.classify.fidelity import RANK_RULES, best_available
+    from creek.classify.privacy_filter import tier_of
+    from creek.vault.reader import iter_vault_fragments
+
+    best = best_available(config)
+    if not best.any_llm_available():
+        return None
+    upgradeable = 0
+    for _path, fragment, _body, raw in iter_vault_fragments(
+        vault_path / "01-Fragments"
+    ):
+        if raw.get(CLASSIFICATION_METHOD_KEY) != RULES_METHOD:
+            continue
+        if best.for_tier(tier_of(fragment)) > RANK_RULES:
+            upgradeable += 1
+    if upgradeable == 0:
+        return None
+    return _ClassifyUpgradeOffer(
+        count=upgradeable,
+        non_intimate_label=_classification_route_label(config, intimate=False),
+        intimate_label=_classification_route_label(config, intimate=True),
+    )
+
+
+def _run_classify_upgrade(vault_path: Path, config: CreekConfig) -> None:
+    """Re-classify ``rules`` fragments via the LLM, preserving manual/llm.
+
+    Runs ``classify --method llm`` WITHOUT ``--force``: the resume-skip leaves
+    ``llm``/``manual`` fragments untouched, so only the ``rules`` ones are
+    upgraded, and the per-tier ModelRouter keeps Intimate content local.
+    """
+    from creek.classify.classify_engine import run_classify
+
+    console.print(
+        "[bold green][fill] upgrading classify: rules → LLM "
+        "(non-Intimate per config; Intimate kept local) …[/bold green]"
+    )
+    run_classify(vault_path=vault_path, config=config, method="llm", force=False)
+
+
+def _maybe_upgrade_classification(
+    vault_path: Path, config: CreekConfig, *, upgrade: bool
+) -> None:
+    """Surface / apply a quality-aware classification upgrade before filling.
+
+    Non-interactive default is a safe no-op (never silently overwrites, never
+    silently egresses): it only prints a hint. ``--upgrade`` applies the upgrade
+    without a prompt; an interactive TTY prompts ``[y/N]`` (default No).
+    """
+    offer = _detect_classify_upgrade(vault_path, config)
+    if offer is None:
+        return
+    if upgrade:
+        _run_classify_upgrade(vault_path, config)
+        return
+    if not sys.stdin.isatty():
+        console.print(offer.hint())
+        return
+    console.print(offer.context())
+    if typer.confirm("Re-run classification to upgrade?", default=False):
+        _run_classify_upgrade(vault_path, config)
+    else:
+        console.print(
+            "[dim][fill] declined — existing classifications kept "
+            "(second run is a clean no-op).[/dim]"
+        )
+
+
 @app.command()
 def fill(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
@@ -2275,6 +2407,15 @@ def fill(
         False,
         "--with-compost",
         help="Also run the compost overview report (off by default).",
+    ),
+    upgrade: bool = typer.Option(
+        False,
+        "--upgrade",
+        help=(
+            "Re-classify `rules`-stamped fragments with the best LLM now "
+            "available before filling (Intimate stays local). Non-interactive "
+            "opt-in; without it a TTY is prompted and other runs are a no-op."
+        ),
     ),
 ) -> None:
     """Run the deterministic vault-population sequence in dependency order.
@@ -2301,6 +2442,11 @@ def fill(
         for index_, (label, _action) in enumerate(steps, start=1):
             console.print(f"  {index_:>2}. {label}")
         return
+
+    # Quality-aware upgrade (#736): offer/apply re-classification of `rules`
+    # fragments before the steps consume them. Safe no-op unless --upgrade or an
+    # interactive yes; the ModelRouter keeps Intimate content local.
+    _maybe_upgrade_classification(vault_path, config, upgrade=upgrade)
 
     for label, action in steps:
         console.print(f"[dim][fill] {label} …[/dim]")

--- a/creek-tools/tests/test_fidelity.py
+++ b/creek-tools/tests/test_fidelity.py
@@ -1,0 +1,119 @@
+"""Tests for the classification method-fidelity ladder (#736).
+
+Covers the per-method ranking and ``best_available`` — including the
+Intimate-never-cloud cap (Intimate is never proposed a cloud upgrade).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.classify import fidelity as fid
+from creek.config import CreekConfig, LLMConfig, LLMRoutingConfig
+from creek.models import PrivacyTier
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class _StubProvider:
+    """Minimal provider double with controllable availability + cloud flag."""
+
+    def __init__(self, *, available: bool, is_cloud: bool) -> None:
+        self.available = available
+        self.is_cloud = is_cloud
+
+
+def _config(*, classification: dict[str, str], default: dict[str, str]) -> CreekConfig:
+    """A CreekConfig whose router resolves the given classification + default."""
+    return CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(**default),
+            classification=LLMConfig(**classification),
+        )
+    )
+
+
+def test_provider_is_cloud() -> None:
+    """Only the known cloud providers are cloud; local/None are not."""
+    assert fid.provider_is_cloud("anthropic")
+    assert fid.provider_is_cloud("openai")
+    assert fid.provider_is_cloud("gemini")
+    assert not fid.provider_is_cloud("ollama")
+    assert not fid.provider_is_cloud(None)
+
+
+def test_method_rank_ladder() -> None:
+    """The ladder orders unclassified < rules < local LLM < cloud LLM < manual."""
+    assert fid.method_rank(None, None) == fid.RANK_UNCLASSIFIED
+    assert fid.method_rank("rules", None) == fid.RANK_RULES
+    assert fid.method_rank("llm", "ollama") == fid.RANK_LLM_LOCAL
+    assert fid.method_rank("llm", None) == fid.RANK_LLM_LOCAL  # unknown → local rung
+    assert fid.method_rank("llm", "anthropic") == fid.RANK_LLM_CLOUD
+    assert fid.method_rank("manual", None) == fid.RANK_MANUAL
+    # Strictly increasing.
+    assert (
+        fid.RANK_UNCLASSIFIED
+        < fid.RANK_RULES
+        < fid.RANK_LLM_LOCAL
+        < fid.RANK_LLM_CLOUD
+        < fid.RANK_MANUAL
+    )
+
+
+def test_best_available_caps_intimate_at_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A cloud classification stage gives cloud non-Intimate but local Intimate."""
+    monkeypatch.setattr(
+        fid,
+        "build_provider",
+        lambda cfg: _StubProvider(
+            available=True, is_cloud=fid.provider_is_cloud(cfg.provider)
+        ),
+    )
+    config = _config(
+        classification={"provider": "anthropic", "model": "claude-haiku-4-5"},
+        default={"provider": "ollama", "model": "qwen3:8b"},
+    )
+    best = fid.best_available(config)
+    assert best.non_intimate == fid.RANK_LLM_CLOUD
+    assert best.intimate == fid.RANK_LLM_LOCAL  # never cloud for Intimate
+    assert best.any_llm_available()
+    assert best.for_tier(PrivacyTier.INTIMATE) == fid.RANK_LLM_LOCAL
+    assert best.for_tier(PrivacyTier.OPEN) == fid.RANK_LLM_CLOUD
+
+
+def test_best_available_falls_back_to_rules_when_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unavailable cloud provider (no key/consent) credits only the rules rung."""
+    monkeypatch.setattr(
+        fid,
+        "build_provider",
+        lambda cfg: _StubProvider(available=False, is_cloud=True),
+    )
+    config = _config(
+        classification={"provider": "anthropic", "model": "x"},
+        default={"provider": "anthropic", "model": "x"},
+    )
+    best = fid.best_available(config)
+    assert best.non_intimate == fid.RANK_RULES
+    assert best.intimate == fid.RANK_RULES  # no local backend → Intimate is rules
+    assert not best.any_llm_available()
+
+
+def test_best_available_local_classification_is_local_both_tiers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local classification stage gives the local-LLM rung for both tiers."""
+    monkeypatch.setattr(
+        fid,
+        "build_provider",
+        lambda cfg: _StubProvider(available=True, is_cloud=False),
+    )
+    config = _config(
+        classification={"provider": "ollama", "model": "qwen3:8b"},
+        default={"provider": "ollama", "model": "qwen3:8b"},
+    )
+    best = fid.best_available(config)
+    assert best.non_intimate == fid.RANK_LLM_LOCAL
+    assert best.intimate == fid.RANK_LLM_LOCAL

--- a/creek-tools/tests/test_fidelity.py
+++ b/creek-tools/tests/test_fidelity.py
@@ -17,11 +17,15 @@ if TYPE_CHECKING:
 
 
 class _StubProvider:
-    """Minimal provider double with controllable availability + cloud flag."""
+    """Minimal provider double — only ``available`` is read by the fidelity probe.
 
-    def __init__(self, *, available: bool, is_cloud: bool) -> None:
+    The cloud/local rung is decided from ``config.provider`` (the configured
+    name), not the built provider, so the stub deliberately carries no
+    ``is_cloud`` flag.
+    """
+
+    def __init__(self, *, available: bool) -> None:
         self.available = available
-        self.is_cloud = is_cloud
 
 
 def _config(*, classification: dict[str, str], default: dict[str, str]) -> CreekConfig:
@@ -66,9 +70,7 @@ def test_best_available_caps_intimate_at_local(monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setattr(
         fid,
         "build_provider",
-        lambda cfg: _StubProvider(
-            available=True, is_cloud=fid.provider_is_cloud(cfg.provider)
-        ),
+        lambda cfg: _StubProvider(available=True),
     )
     config = _config(
         classification={"provider": "anthropic", "model": "claude-haiku-4-5"},
@@ -89,7 +91,7 @@ def test_best_available_falls_back_to_rules_when_unavailable(
     monkeypatch.setattr(
         fid,
         "build_provider",
-        lambda cfg: _StubProvider(available=False, is_cloud=True),
+        lambda cfg: _StubProvider(available=False),
     )
     config = _config(
         classification={"provider": "anthropic", "model": "x"},
@@ -108,7 +110,7 @@ def test_best_available_local_classification_is_local_both_tiers(
     monkeypatch.setattr(
         fid,
         "build_provider",
-        lambda cfg: _StubProvider(available=True, is_cloud=False),
+        lambda cfg: _StubProvider(available=True),
     )
     config = _config(
         classification={"provider": "ollama", "model": "qwen3:8b"},

--- a/creek-tools/tests/test_fill_upgrade.py
+++ b/creek-tools/tests/test_fill_upgrade.py
@@ -16,9 +16,14 @@ import creek.cli as cli_mod
 from creek.classify import fidelity as fid
 from creek.classify.classify_engine import _write_fragment
 from creek.classify.constants import CLASSIFICATION_PROVIDER_KEY
-from creek.cli import _detect_classify_upgrade, app
+from creek.cli import (
+    _ClassifyUpgradeOffer,
+    _detect_classify_upgrade,
+    _maybe_upgrade_classification,
+    app,
+)
 from creek.config import CreekConfig, LLMConfig, LLMRoutingConfig
-from creek.models import Fragment, FragmentSource, SourcePlatform
+from creek.models import Fragment, FragmentSource, PrivacyTier, SourcePlatform
 from tests.helpers import write_fragment_file
 
 if TYPE_CHECKING:
@@ -30,11 +35,10 @@ runner = CliRunner()
 
 
 class _StubProvider:
-    """Provider double with a controllable availability + cloud flag."""
+    """Provider double — only ``available`` is read by the fidelity probe."""
 
-    def __init__(self, *, available: bool, is_cloud: bool) -> None:
+    def __init__(self, *, available: bool) -> None:
         self.available = available
-        self.is_cloud = is_cloud
 
 
 def _cloud_config() -> CreekConfig:
@@ -52,9 +56,7 @@ def _patch_cloud_available(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         fid,
         "build_provider",
-        lambda cfg: _StubProvider(
-            available=True, is_cloud=fid.provider_is_cloud(cfg.provider)
-        ),
+        lambda cfg: _StubProvider(available=True),
     )
 
 
@@ -168,7 +170,7 @@ def test_detect_none_when_no_llm_available(
 ) -> None:
     """No offer when no LLM is reachable — rules is already the best."""
     monkeypatch.setattr(
-        fid, "build_provider", lambda cfg: _StubProvider(available=False, is_cloud=True)
+        fid, "build_provider", lambda cfg: _StubProvider(available=False)
     )
     vault = tmp_path / "vault"
     (vault / "01-Fragments").mkdir(parents=True)
@@ -197,10 +199,11 @@ def test_fill_upgrade_flag_reclassifies(
     monkeypatch.setattr(cli_mod, "_load_config_for_vault", lambda _v: _cloud_config())
     monkeypatch.setattr(cli_mod, "_build_fill_steps", lambda *a, **k: [])
     calls: list[dict[str, object]] = []
-    monkeypatch.setattr(
-        "creek.classify.classify_engine.run_classify",
-        lambda **kwargs: calls.append(kwargs),
-    )
+
+    def _record(**kwargs: object) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr("creek.classify.classify_engine.run_classify", _record)
 
     vault = _fill_vault(tmp_path)
     result = runner.invoke(app, ["fill", "--vault", str(vault), "--upgrade"])
@@ -219,14 +222,107 @@ def test_fill_non_interactive_default_is_noop(
     monkeypatch.setattr(cli_mod, "_load_config_for_vault", lambda _v: _cloud_config())
     monkeypatch.setattr(cli_mod, "_build_fill_steps", lambda *a, **k: [])
     calls: list[dict[str, object]] = []
-    monkeypatch.setattr(
-        "creek.classify.classify_engine.run_classify",
-        lambda **kwargs: calls.append(kwargs),
-    )
+
+    def _record(**kwargs: object) -> None:
+        calls.append(kwargs)
+
+    monkeypatch.setattr("creek.classify.classify_engine.run_classify", _record)
 
     vault = _fill_vault(tmp_path)
     result = runner.invoke(app, ["fill", "--vault", str(vault)])
 
     assert result.exit_code == 0, result.output
-    assert calls == []  # never silently re-classified / egressed
+    assert not calls  # never silently re-classified / egressed
     assert "--upgrade" in result.output  # surfaced the option as a hint
+
+
+# ---- Intimate-never-cloud + interactive paths ----
+
+
+def _cloud_only_config() -> CreekConfig:
+    """A config with cloud classification AND cloud default (no local backend)."""
+    return CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(provider="anthropic", model="claude-haiku-4-5"),
+            classification=LLMConfig(provider="anthropic", model="claude-haiku-4-5"),
+        )
+    )
+
+
+def test_detect_excludes_intimate_when_only_cloud_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no local backend, an Intimate rules fragment is NOT offered an upgrade.
+
+    The privacy-sensitive case: cloud is reachable but there is no local model,
+    so Intimate's best-available stays at rules (never cloud). Only the
+    non-Intimate rules fragment is counted as upgradeable.
+    """
+    _patch_cloud_available(monkeypatch)
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    for fid_, tier in (
+        ("frag-0000000open01", PrivacyTier.OPEN),
+        ("frag-000000intim01", PrivacyTier.INTIMATE),
+    ):
+        write_fragment_file(
+            vault=vault,
+            fragment=Fragment(
+                id=fid_,
+                title="t",
+                source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+                privacy_tier=tier,
+            ),
+            body="body",
+            method="rules",
+        )
+
+    offer = _detect_classify_upgrade(vault, _cloud_only_config())
+
+    assert offer is not None
+    assert offer.count == 1  # only the OPEN (non-Intimate) fragment
+
+
+def _force_tty(monkeypatch: pytest.MonkeyPatch, *, confirm: bool) -> None:
+    """Make the upgrade prompt path run, answering the confirm with *confirm*."""
+
+    class _TTY:
+        @staticmethod
+        def isatty() -> bool:
+            return True
+
+    monkeypatch.setattr(cli_mod.sys, "stdin", _TTY())
+    monkeypatch.setattr(cli_mod.typer, "confirm", lambda *_a, **_k: confirm)
+
+
+_OFFER = _ClassifyUpgradeOffer(
+    count=1, non_intimate_label="anthropic/claude-haiku-4-5", intimate_label="ollama/x"
+)
+
+
+def test_interactive_prompt_yes_runs_upgrade(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An interactive `y` answer applies the upgrade."""
+    monkeypatch.setattr(cli_mod, "_detect_classify_upgrade", lambda *_a: _OFFER)
+    _force_tty(monkeypatch, confirm=True)
+    ran: list[bool] = []
+    monkeypatch.setattr(cli_mod, "_run_classify_upgrade", lambda *_a: ran.append(True))
+
+    _maybe_upgrade_classification(tmp_path, _cloud_config(), upgrade=False)
+
+    assert ran == [True]
+
+
+def test_interactive_prompt_no_is_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An interactive `N` answer (the default) changes nothing."""
+    monkeypatch.setattr(cli_mod, "_detect_classify_upgrade", lambda *_a: _OFFER)
+    _force_tty(monkeypatch, confirm=False)
+    ran: list[bool] = []
+    monkeypatch.setattr(cli_mod, "_run_classify_upgrade", lambda *_a: ran.append(True))
+
+    _maybe_upgrade_classification(tmp_path, _cloud_config(), upgrade=False)
+
+    assert not ran

--- a/creek-tools/tests/test_fill_upgrade.py
+++ b/creek-tools/tests/test_fill_upgrade.py
@@ -326,3 +326,34 @@ def test_interactive_prompt_no_is_noop(
     _maybe_upgrade_classification(tmp_path, _cloud_config(), upgrade=False)
 
     assert not ran
+
+
+def test_upgrade_check_is_non_fatal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A detection error is swallowed — fill is never crashed by the upgrade check."""
+
+    def _boom(*_a: object) -> object:
+        raise RuntimeError("provider boom")
+
+    monkeypatch.setattr(cli_mod, "_detect_classify_upgrade", _boom)
+    ran: list[bool] = []
+    monkeypatch.setattr(cli_mod, "_run_classify_upgrade", lambda *_a: ran.append(True))
+
+    # Must not raise, even with --upgrade requested.
+    _maybe_upgrade_classification(tmp_path, _cloud_config(), upgrade=True)
+
+    assert not ran
+
+
+def test_upgrade_flag_noop_when_nothing_upgradeable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--upgrade` with no upgradeable fragments runs nothing (clean early exit)."""
+    monkeypatch.setattr(cli_mod, "_detect_classify_upgrade", lambda *_a: None)
+    ran: list[bool] = []
+    monkeypatch.setattr(cli_mod, "_run_classify_upgrade", lambda *_a: ran.append(True))
+
+    _maybe_upgrade_classification(tmp_path, _cloud_config(), upgrade=True)
+
+    assert not ran

--- a/creek-tools/tests/test_fill_upgrade.py
+++ b/creek-tools/tests/test_fill_upgrade.py
@@ -1,0 +1,232 @@
+"""Tests for the quality-aware classification upgrade in ``creek fill`` (#736).
+
+Covers the ``classification_provider`` provenance stamp, the upgrade-offer
+detection, and the three ``fill`` paths: ``--upgrade`` applies it, a
+non-interactive run is a safe no-op, and Intimate is never routed to cloud.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+from typer.testing import CliRunner
+
+import creek.cli as cli_mod
+from creek.classify import fidelity as fid
+from creek.classify.classify_engine import _write_fragment
+from creek.classify.constants import CLASSIFICATION_PROVIDER_KEY
+from creek.cli import _detect_classify_upgrade, app
+from creek.config import CreekConfig, LLMConfig, LLMRoutingConfig
+from creek.models import Fragment, FragmentSource, SourcePlatform
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+runner = CliRunner()
+
+
+class _StubProvider:
+    """Provider double with a controllable availability + cloud flag."""
+
+    def __init__(self, *, available: bool, is_cloud: bool) -> None:
+        self.available = available
+        self.is_cloud = is_cloud
+
+
+def _cloud_config() -> CreekConfig:
+    """A config whose classification stage is cloud and default is local."""
+    return CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(provider="ollama", model="qwen3:8b"),
+            classification=LLMConfig(provider="anthropic", model="claude-haiku-4-5"),
+        )
+    )
+
+
+def _patch_cloud_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make the fidelity probe see every provider as available."""
+    monkeypatch.setattr(
+        fid,
+        "build_provider",
+        lambda cfg: _StubProvider(
+            available=True, is_cloud=fid.provider_is_cloud(cfg.provider)
+        ),
+    )
+
+
+def _write_rules_fragment(vault: Path, frag_id: str) -> None:
+    """Write a fragment stamped ``classification_method: rules``."""
+    write_fragment_file(
+        vault=vault,
+        fragment=Fragment(
+            id=frag_id,
+            title="a note",
+            source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        ),
+        body="body",
+        method="rules",
+    )
+
+
+# ---- provenance stamp ----
+
+
+def test_write_fragment_stamps_provider_for_llm(tmp_path: Path) -> None:
+    """An ``llm`` write records the provider as ``classification_provider``."""
+    md = tmp_path / "frag.md"
+    md.write_text("---\ntype: fragment\n---\nbody\n", encoding="utf-8")
+    fragment = Fragment(
+        id="frag-00000000llm1",
+        title="t",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        md_file=md,
+        fragment=fragment,
+        body="body",
+        method="llm",
+        raw={"type": "fragment"},
+        reasoning="",
+        provider="anthropic",
+    )
+    assert frontmatter.load(md).metadata[CLASSIFICATION_PROVIDER_KEY] == "anthropic"
+
+
+def test_write_fragment_clears_provider_for_rules(tmp_path: Path) -> None:
+    """A ``rules`` write clears any stale ``classification_provider`` stamp."""
+    md = tmp_path / "frag.md"
+    md.write_text("---\ntype: fragment\n---\nbody\n", encoding="utf-8")
+    fragment = Fragment(
+        id="frag-00000000rul1",
+        title="t",
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+    )
+    _write_fragment(
+        md_file=md,
+        fragment=fragment,
+        body="body",
+        method="rules",
+        raw={"type": "fragment", CLASSIFICATION_PROVIDER_KEY: "anthropic"},
+        reasoning="",
+        provider=None,
+    )
+    assert CLASSIFICATION_PROVIDER_KEY not in frontmatter.load(md).metadata
+
+
+# ---- offer detection ----
+
+
+def test_detect_offers_upgrade_for_rules_with_cloud(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Rules fragments + an available LLM yield an offer counting them."""
+    _patch_cloud_available(monkeypatch)
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    _write_rules_fragment(vault, "frag-00000000rua1")
+    _write_rules_fragment(vault, "frag-00000000rua2")
+
+    offer = _detect_classify_upgrade(vault, _cloud_config())
+
+    assert offer is not None
+    assert offer.count == 2
+    assert "anthropic" in offer.non_intimate_label
+    assert "ollama" in offer.intimate_label  # Intimate route stays local
+
+
+def test_detect_none_when_already_llm_or_manual(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No offer when nothing is rules-classified."""
+    _patch_cloud_available(monkeypatch)
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    for fid_, method in (
+        ("frag-0000000manual", "manual"),
+        ("frag-00000000llm9", "llm"),
+    ):
+        write_fragment_file(
+            vault=vault,
+            fragment=Fragment(
+                id=fid_,
+                title="t",
+                source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+            ),
+            body="body",
+            method=method,
+        )
+
+    assert _detect_classify_upgrade(vault, _cloud_config()) is None
+
+
+def test_detect_none_when_no_llm_available(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No offer when no LLM is reachable — rules is already the best."""
+    monkeypatch.setattr(
+        fid, "build_provider", lambda cfg: _StubProvider(available=False, is_cloud=True)
+    )
+    vault = tmp_path / "vault"
+    (vault / "01-Fragments").mkdir(parents=True)
+    _write_rules_fragment(vault, "frag-00000000rub1")
+
+    assert _detect_classify_upgrade(vault, _cloud_config()) is None
+
+
+# ---- fill paths ----
+
+
+def _fill_vault(tmp_path: Path) -> Path:
+    """A scaffolded vault with one rules fragment, ready for ``creek fill``."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+    (vault / "01-Fragments").mkdir(parents=True)
+    _write_rules_fragment(vault, "frag-00000000fil1")
+    return vault
+
+
+def test_fill_upgrade_flag_reclassifies(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``creek fill --upgrade`` re-classifies via the LLM without force."""
+    _patch_cloud_available(monkeypatch)
+    monkeypatch.setattr(cli_mod, "_load_config_for_vault", lambda _v: _cloud_config())
+    monkeypatch.setattr(cli_mod, "_build_fill_steps", lambda *a, **k: [])
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "creek.classify.classify_engine.run_classify",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    vault = _fill_vault(tmp_path)
+    result = runner.invoke(app, ["fill", "--vault", str(vault), "--upgrade"])
+
+    assert result.exit_code == 0, result.output
+    assert len(calls) == 1
+    assert calls[0]["method"] == "llm"
+    assert calls[0]["force"] is False  # only rules upgraded; manual/llm preserved
+
+
+def test_fill_non_interactive_default_is_noop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without --upgrade (and no TTY) fill never re-classifies — just hints."""
+    _patch_cloud_available(monkeypatch)
+    monkeypatch.setattr(cli_mod, "_load_config_for_vault", lambda _v: _cloud_config())
+    monkeypatch.setattr(cli_mod, "_build_fill_steps", lambda *a, **k: [])
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "creek.classify.classify_engine.run_classify",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    vault = _fill_vault(tmp_path)
+    result = runner.invoke(app, ["fill", "--vault", str(vault)])
+
+    assert result.exit_code == 0, result.output
+    assert calls == []  # never silently re-classified / egressed
+    assert "--upgrade" in result.output  # surfaced the option as a hint


### PR DESCRIPTION
## Summary
Completes **#736** (deliverable 1, the idempotency audit, merged in #742). When a vault's fragments were classified by a *lesser* method than what is now available, `creek fill` surfaces it and can re-classify — **never** silently overwriting or egressing, and **never** routing Intimate content to cloud.

### Method-fidelity ladder — `creek/classify/fidelity.py` (single source of truth)
```
unclassified < rules < local LLM < cloud LLM < manual
```
`manual` sits at the top (never auto-overwritten). `best_available(config)` resolves the `classification` stage through the **ModelRouter** exactly as `build_tier_classifiers` does, probes provider availability (key/consent for cloud, reachable server for local), and **caps the Intimate ceiling at local-LLM** — so an upgrade is never proposed to cloud for Intimate.

### Provenance extension
Classify now stamps **`classification_provider`** (e.g. `anthropic` / `ollama`) on `llm` writes, so a quality-aware re-run can tell the local-LLM rung from the cloud-LLM rung; it's cleared for `rules`/`manual`. Threaded through the **per-tier** classifier (`_process_file` → `_finalise_fragment_write` → `_write_fragment`) so the recorded provider matches the tier that actually classified each fragment. Non-breaking: existing `rules | llm | manual` readers are untouched.

### `creek fill` overwrite decision + `--upgrade`
- `_detect_classify_upgrade` scans for `rules`-classified fragments whose **tier's** best-available method outranks `rules`; returns `None` when no LLM is reachable or nothing would benefit (the offer never appears spuriously).
- **`--upgrade`** applies it non-interactively: `run_classify --method llm` **without `--force`**, so the resume-skip preserves `manual`/`llm` and only `rules` fragments are re-done; the per-tier ModelRouter keeps Intimate local.
- An interactive TTY is prompted `[y/N]` (default **No**).
- Any other run is a **safe no-op** that only prints a hint — never silently re-classifies or egresses.

```text
$ creek fill --vault V --upgrade
[fill] upgrading classify: rules → LLM (non-Intimate per config; Intimate kept local) …
$ creek fill --vault V        # non-interactive, no flag
[fill] N rules-classified fragment(s) could be upgraded (anthropic/… / ollama/…); re-run with --upgrade to apply (Intimate stays local).
```

## Test plan
`tests/test_fidelity.py` (5) + `tests/test_fill_upgrade.py` (7):
- the ladder ranks; `best_available`'s **Intimate-never-cloud cap** and the availability→rules fallback;
- offer detection — rules+cloud → offer (counts them, labels per tier), all-`llm`/`manual` → none, no-LLM-available → none;
- the `classification_provider` stamp on `llm` writes and its clearing on `rules`;
- `fill --upgrade` triggers a **no-force** re-classify; the **non-interactive default never re-classifies** (asserts `run_classify` not called + the hint).

Lint/format/mypy-strict/refurb/complexity green; **218** targeted tests pass with the API key stripped (the tests stub the provider — no real API call, so credits/quota are irrelevant). The usual author/compost/mcp consent cluster fails only against a polluted local env and passes on CI.

## Scope fence honored
Orchestration + a quality-aware *decision* only — no generator reimplemented; classify's per-tier routing and Intimate-never-cloud are reused, not re-done; the non-interactive default never overwrites or egresses.

Closes #736
Refs #720

🤖 Generated with [Claude Code](https://claude.com/claude-code)