### PR TITLE
fix(classify): don't stamp `llm` on a failed LLM call (#744)

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -663,6 +663,13 @@ def _classify_one(
     if weighted_classification:
         return _classify_one_weighted(rule_result, body, llm.config)
     llm_result = llm.classify_with_reasoning(rule_result, content=body)
+    if not llm_result.succeeded:
+        # The LLM call failed (provider unavailable / retries exhausted) and
+        # returned the fragment unchanged. Treat it like the rules-sufficed skip
+        # so the write path stamps ``rules`` (the result that actually stands),
+        # NOT a lying ``classification_method: llm`` — and the fragment stays
+        # eligible for a later re-classify rather than being skipped (#744).
+        return llm_result.fragment, True, ""
     return llm_result.fragment, False, llm_result.reasoning
 
 

--- a/creek-tools/creek/classify/llm/orchestrator.py
+++ b/creek-tools/creek/classify/llm/orchestrator.py
@@ -55,10 +55,16 @@ class LLMClassificationResult:
             pre-FEAT-017 response shape) or the call short-circuited.
             Truncation / tier-routing is the engine's responsibility,
             not this dataclass's — the raw trace lives here.
+        succeeded: ``True`` when the LLM actually classified the
+            fragment; ``False`` when the call short-circuited (provider
+            unavailable or all retries exhausted) and ``fragment`` is the
+            input returned unchanged. Lets the engine avoid stamping
+            ``classification_method: llm`` on a failed call (#744).
     """
 
     fragment: Fragment
     reasoning: str
+    succeeded: bool = True
 
 
 class LLMClassifier:
@@ -321,7 +327,9 @@ class LLMClassifier:
                 "LLM provider unavailable — returning fragment '%s' unchanged",
                 fragment.title,
             )
-            return LLMClassificationResult(fragment=fragment, reasoning="")
+            return LLMClassificationResult(
+                fragment=fragment, reasoning="", succeeded=False
+            )
 
         prompt = self._build_prompt(fragment, content)
 
@@ -371,7 +379,7 @@ class LLMClassifier:
             self.MAX_RETRIES,
             fragment.title,
         )
-        return LLMClassificationResult(fragment=fragment, reasoning="")
+        return LLMClassificationResult(fragment=fragment, reasoning="", succeeded=False)
 
     def _retry_delay_for(self, exc: Exception) -> float:
         """Resolve the backoff before the next retry attempt.

--- a/creek-tools/tests/test_classify_failed_llm_provenance.py
+++ b/creek-tools/tests/test_classify_failed_llm_provenance.py
@@ -1,0 +1,121 @@
+"""A failed LLM classification must not be stamped ``llm`` (#744).
+
+When the provider is unavailable or all retries are exhausted, the orchestrator
+returns the fragment unchanged with ``succeeded=False``. The engine must then
+stamp the honest ``rules`` provenance (the result that actually stands) — never
+``classification_method: llm`` with a fresh ``classified_at`` — so the fragment
+stays eligible for a later re-classify instead of being skipped as "already llm".
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek.classify.classify_engine import run_classify
+from creek.classify.constants import CLASSIFICATION_PROVIDER_KEY
+from creek.classify.llm.orchestrator import LLMClassificationResult
+from creek.config import CreekConfig, LLMConfig, LLMRoutingConfig
+from creek.models import Fragment, FragmentSource, SourcePlatform
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    import pytest
+
+    from creek.config import LLMConfig as _LLMConfig
+
+
+class _FailingClassifier:
+    """Stands in for a provider whose calls all fail (returns ``succeeded=False``)."""
+
+    def __init__(self, config: _LLMConfig) -> None:
+        self.config = config
+
+    @property
+    def available(self) -> bool:
+        return True  # availability passes; the *call* fails
+
+    def classify_with_reasoning(
+        self, fragment: Fragment, content: str
+    ) -> LLMClassificationResult:
+        del content
+        return LLMClassificationResult(fragment=fragment, reasoning="", succeeded=False)
+
+
+class _SucceedingClassifier:
+    """Stands in for a provider whose calls succeed (default ``succeeded=True``)."""
+
+    def __init__(self, config: _LLMConfig) -> None:
+        self.config = config
+
+    @property
+    def available(self) -> bool:
+        return True
+
+    def classify_with_reasoning(
+        self, fragment: Fragment, content: str
+    ) -> LLMClassificationResult:
+        del content
+        return LLMClassificationResult(fragment=fragment, reasoning="ok")
+
+
+def _local_config() -> CreekConfig:
+    """A config whose classification stage is local (no env needed)."""
+    return CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(provider="ollama", model="qwen3:8b"),
+            classification=LLMConfig(provider="ollama", model="qwen3:8b"),
+        )
+    )
+
+
+def _seed(vault: Path) -> Path:
+    """Write one fragment with no classifiable keywords, return its path."""
+    write_fragment_file(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-000000fail01",
+            title="zzz",
+            source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        ),
+        body="zzz zzz zzz",
+    )
+    return next((vault / "01-Fragments").rglob("*.md"))
+
+
+def test_failed_llm_is_not_stamped_llm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed LLM call leaves the honest rules provenance, never ``llm``."""
+    monkeypatch.setattr(
+        "creek.classify.classify_engine.LLMClassifier", _FailingClassifier
+    )
+    vault = tmp_path / "vault"
+    md = _seed(vault)
+
+    run_classify(vault_path=vault, config=_local_config(), method="llm", force=True)
+
+    meta = frontmatter.load(md).metadata
+    assert meta.get("classification_method") != "llm"  # the bug: was llm
+    assert meta.get("classification_method") == "rules"
+    assert CLASSIFICATION_PROVIDER_KEY not in meta  # no provider stamp off the llm path
+
+
+def test_successful_llm_is_still_stamped_llm(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The success path is unchanged — a real classification still stamps ``llm``."""
+    monkeypatch.setattr(
+        "creek.classify.classify_engine.LLMClassifier", _SucceedingClassifier
+    )
+    vault = tmp_path / "vault"
+    md = _seed(vault)
+
+    run_classify(vault_path=vault, config=_local_config(), method="llm", force=True)
+
+    meta = frontmatter.load(md).metadata
+    assert meta.get("classification_method") == "llm"
+    assert meta.get(CLASSIFICATION_PROVIDER_KEY) == "ollama"


### PR DESCRIPTION
## Summary
A failed LLM classification was being recorded as a **successful** `llm` one. When the provider is unavailable or all retries are exhausted, the orchestrator returns the fragment unchanged — but `_finalise_fragment_write` still stamped `classification_method: llm` + a fresh `classified_at`, because `was_skipped` only covered the *confidence short-circuit* (rules sufficed), not an LLM **failure**.

**Reproduced on a real run** (`creek-demo-2026-06-07`, over-budget Anthropic key → 400 on every call): 19,848 still-unclassified fragments wore a lying `classification_method: llm` label. Because the resume-skip treats `llm` as final, a plain `classify --method llm` would then *skip* them forever.

## Fix
- `LLMClassificationResult` gains **`succeeded: bool = True`**; the two short-circuit returns in `classify_with_reasoning` (provider unavailable, retries exhausted) set it `False`.
- `_classify_one` treats a not-`succeeded` LLM result like the rules-sufficed skip, so the write path stamps the honest **`rules`** provenance (the result that actually stands) — never `llm` — and the fragment stays eligible for a later re-classify instead of being skipped.

This also makes the fragment correctly upgradeable by the new `creek fill --upgrade` (#736), and pairs with #745 (surface the API error body so the *cause* of such failures is visible).

> Note: the *weighted* classification path (`_classify_one_weighted`, off by default) is a separate dispatch and not in scope here; the over-budget repro used the standard two-step path.

## Test plan
New `tests/test_classify_failed_llm_provenance.py`:
- a failing classifier (`succeeded=False`) → the fragment is stamped `rules`, **not** `llm`, with no `classification_provider`;
- the success path is unchanged — a real classification still stamps `llm` + the provider.

`./scripts/check-all.sh`: formatting/lint/mypy-strict/refurb/complexity all green; the only failing unit tests are the pre-existing author/compost/mcp environmental consent cluster, identical on clean `origin/main`.

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)