### PR TITLE
fix(classify): surface the LLM provider's error cause, not a bare type (#745)

### DIFF
--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -206,6 +206,27 @@ def _error_detail(exc: Exception) -> str:
     return f" (HTTP {status}): {collapsed}"
 
 
+def _chain_is_safe(exc: Exception) -> bool:
+    """Whether the SDK error may remain as the wrapped ``RuntimeError.__cause__``.
+
+    True only for 4xx client errors — the same tier whose ``message``
+    :func:`_error_detail` already surfaces, so the chain exposes nothing the
+    message does not. For 5xx / unknown errors the body is deliberately
+    withheld, so the caller suppresses the chain (``raise … from None``) to keep
+    that redaction airtight even if a future caller logs with
+    ``logging.exception`` / ``exc_info=True`` (which would otherwise render
+    ``__cause__``).
+
+    Args:
+        exc: The vendor SDK exception.
+
+    Returns:
+        ``True`` when *exc* carries a 4xx status, else ``False``.
+    """
+    status = _error_status(exc)
+    return status is not None and _CLIENT_ERROR_MIN <= status < _SERVER_ERROR_MIN
+
+
 # Per-provider default model IDs. This matrix is the ONLY place model literals
 # live in the package — provider classes read their ``DEFAULT_MODEL`` from it
 # and other modules read the resolved value, never a literal (enforced by
@@ -346,9 +367,11 @@ class AnthropicProvider:
             The concatenated text content of the API response.
 
         Raises:
-            RuntimeError: If the SDK raises any ``AnthropicError``; the
-                original exception is re-raised as ``RuntimeError`` with
-                its type name to avoid leaking sensitive request state.
+            RuntimeError: If the SDK raises any ``AnthropicError``; re-raised
+                as ``RuntimeError`` with the exception type name and, for 4xx
+                client errors, the API's own error message (see
+                :func:`_error_detail`). 5xx / unknown bodies are withheld and
+                their exception chain suppressed to avoid leaking request state.
         """
         return self.call_with_metadata(prompt).text
 
@@ -416,9 +439,11 @@ class AnthropicProvider:
             and the SDK's token :attr:`~AnthropicCompletion.usage` when present.
 
         Raises:
-            RuntimeError: If the SDK raises any ``AnthropicError``; the
-                original exception is re-raised as ``RuntimeError`` with
-                its type name to avoid leaking sensitive request state.
+            RuntimeError: If the SDK raises any ``AnthropicError``; re-raised
+                as ``RuntimeError`` with the exception type name and, for 4xx
+                client errors, the API's own error message (see
+                :func:`_error_detail`). 5xx / unknown bodies are withheld and
+                their exception chain suppressed to avoid leaking request state.
         """
         import anthropic
 
@@ -433,7 +458,7 @@ class AnthropicProvider:
         except anthropic.AnthropicError as exc:
             detail = _error_detail(exc)
             msg = f"Anthropic API call failed: {type(exc).__name__}{detail}"
-            raise RuntimeError(msg) from exc
+            raise RuntimeError(msg) from (exc if _chain_is_safe(exc) else None)
         stop_reason = getattr(response, "stop_reason", None) or "end_turn"
         return AnthropicCompletion(
             text=_extract_anthropic_text(response),
@@ -810,7 +835,10 @@ class OpenAIProvider:
 
         Raises:
             RuntimeError: If the SDK raises any ``OpenAIError``; re-raised with
-                only the exception type name so no request state leaks.
+                the exception type name and, for 4xx client errors, the API's
+                own error message (see :func:`_error_detail`). 5xx / unknown
+                bodies are withheld and their chain suppressed so no request
+                state leaks.
         """
         import openai
 
@@ -824,7 +852,7 @@ class OpenAIProvider:
             ) from None
         except openai.OpenAIError as exc:
             msg = f"OpenAI API call failed: {type(exc).__name__}{_error_detail(exc)}"
-            raise RuntimeError(msg) from exc
+            raise RuntimeError(msg) from (exc if _chain_is_safe(exc) else None)
         return Completion(
             text=_extract_openai_text(response),
             stop_reason=_map_openai_stop_reason(response),
@@ -1050,7 +1078,10 @@ class GeminiProvider:
 
         Raises:
             RuntimeError: If the SDK raises any ``APIError``; re-raised with
-                only the exception type name so no request state leaks.
+                the exception type name and, for 4xx client errors, the API's
+                own error message (see :func:`_error_detail`). 5xx / unknown
+                bodies are withheld and their chain suppressed so no request
+                state leaks.
         """
         from google.genai import errors
 
@@ -1064,7 +1095,7 @@ class GeminiProvider:
                     msg, retry_after=_retry_after_seconds(exc)
                 ) from None
             msg = f"Gemini API call failed: {type(exc).__name__}{_error_detail(exc)}"
-            raise RuntimeError(msg) from exc
+            raise RuntimeError(msg) from (exc if _chain_is_safe(exc) else None)
         return Completion(
             text=_extract_gemini_text(response),
             stop_reason=_map_gemini_stop_reason(response),

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -141,6 +141,71 @@ def _retry_after_seconds(exc: object) -> float | None:
         return None
 
 
+_ERROR_DETAIL_MAX_CHARS: int = 500
+"""Cap on the API error message surfaced in a wrapped ``RuntimeError``."""
+
+_CLIENT_ERROR_MIN: int = 400
+"""Inclusive lower bound of the HTTP client-error (4xx) range."""
+
+_SERVER_ERROR_MIN: int = 500
+"""Exclusive upper bound of the 4xx range / start of the 5xx server range."""
+
+
+def _error_status(exc: Exception) -> int | None:
+    """Return the integer HTTP status of a provider SDK error, if it exposes one.
+
+    Reads ``status_code`` (Anthropic / OpenAI) then ``code`` (Gemini); anything
+    non-integer (or absent) yields ``None`` so callers fail closed to the most
+    redacted form.
+
+    Args:
+        exc: The vendor SDK exception.
+
+    Returns:
+        The HTTP status as an ``int``, or ``None`` when unavailable.
+    """
+    status = getattr(exc, "status_code", None)
+    if status is None:
+        status = getattr(exc, "code", None)
+    return status if isinstance(status, int) else None
+
+
+def _error_detail(exc: Exception) -> str:
+    """Return a redaction-safe detail string for a provider SDK error.
+
+    Two tiers, by HTTP status:
+
+    - **4xx client errors** — the API's own ``message`` is surfaced (collapsed
+      and length-capped) after the status. A 4xx message is an API-side
+      description of what is wrong with the *request or account* — "credit
+      balance too low", an invalid model id, a bad parameter — never the prompt
+      or fragment content, and never the API key (which lives only in request
+      headers). This is what turns an opaque ``BadRequestError`` into an
+      actionable cause.
+    - **5xx / unknown** — status only (or nothing). Server-error bodies are
+      opaque and may carry unredacted internals, so they stay redacted.
+
+    Args:
+        exc: The vendor SDK exception.
+
+    Returns:
+        A suffix ready to append after the exception type name — one of
+        ``" (HTTP <s>): <message>"``, ``" (HTTP <s>)"``, or ``""``.
+    """
+    status = _error_status(exc)
+    if status is None:
+        return ""
+    if not _CLIENT_ERROR_MIN <= status < _SERVER_ERROR_MIN:
+        return f" (HTTP {status})"
+    message = getattr(exc, "message", None)
+    if not isinstance(message, str) or not message.strip():
+        return f" (HTTP {status})"
+    collapsed = " ".join(message.split())
+    if len(collapsed) > _ERROR_DETAIL_MAX_CHARS:
+        collapsed = collapsed[:_ERROR_DETAIL_MAX_CHARS] + "…"
+    return f" (HTTP {status}): {collapsed}"
+
+
 # Per-provider default model IDs. This matrix is the ONLY place model literals
 # live in the package — provider classes read their ``DEFAULT_MODEL`` from it
 # and other modules read the resolved value, never a literal (enforced by
@@ -366,8 +431,9 @@ class AnthropicProvider:
                 msg, retry_after=_retry_after_seconds(exc)
             ) from None
         except anthropic.AnthropicError as exc:
-            msg = f"Anthropic API call failed: {type(exc).__name__}"
-            raise RuntimeError(msg) from None
+            detail = _error_detail(exc)
+            msg = f"Anthropic API call failed: {type(exc).__name__}{detail}"
+            raise RuntimeError(msg) from exc
         stop_reason = getattr(response, "stop_reason", None) or "end_turn"
         return AnthropicCompletion(
             text=_extract_anthropic_text(response),
@@ -757,8 +823,8 @@ class OpenAIProvider:
                 msg, retry_after=_retry_after_seconds(exc)
             ) from None
         except openai.OpenAIError as exc:
-            msg = f"OpenAI API call failed: {type(exc).__name__}"
-            raise RuntimeError(msg) from None
+            msg = f"OpenAI API call failed: {type(exc).__name__}{_error_detail(exc)}"
+            raise RuntimeError(msg) from exc
         return Completion(
             text=_extract_openai_text(response),
             stop_reason=_map_openai_stop_reason(response),
@@ -997,8 +1063,8 @@ class GeminiProvider:
                 raise ProviderRateLimitError(
                     msg, retry_after=_retry_after_seconds(exc)
                 ) from None
-            msg = f"Gemini API call failed: {type(exc).__name__}"
-            raise RuntimeError(msg) from None
+            msg = f"Gemini API call failed: {type(exc).__name__}{_error_detail(exc)}"
+            raise RuntimeError(msg) from exc
         return Completion(
             text=_extract_gemini_text(response),
             stop_reason=_map_gemini_stop_reason(response),

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -1628,6 +1628,73 @@ class TestAnthropicProviderCall:
             provider.call("prompt")
         assert "sk-test-not-real" not in str(exc_info.value)
 
+    def test_call_4xx_surfaces_api_message_not_just_type(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The motivating case (#745): a budget 400 surfaces its actionable cause.
+
+        A real ``BadRequestError`` carrying the credit-balance message must
+        propagate that message (and the status) through ``call`` — not just the
+        opaque ``BadRequestError`` type — while never exposing the API key.
+        """
+        import anthropic
+        import httpx
+
+        _set_anthropic_env(monkeypatch)
+        credit_msg = (
+            "Your credit balance is too low to access the Anthropic API. "
+            "Please go to Plans & Billing to upgrade or purchase credits."
+        )
+        response = httpx.Response(
+            400, request=httpx.Request("POST", "https://api.anthropic.com")
+        )
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = anthropic.BadRequestError(
+            message=credit_msg, response=response, body=None
+        )
+        with (
+            patch("anthropic.Anthropic", return_value=mock_client),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            AnthropicProvider(LLMConfig(provider="anthropic")).call("prompt")
+        message = str(exc_info.value)
+        assert "credit balance is too low" in message  # the actionable cause
+        assert "HTTP 400" in message
+        assert "sk-test-not-real" not in message  # key never leaks
+
+    def test_call_5xx_withholds_body_and_suppresses_chain(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A 5xx body is withheld AND its exception chain suppressed (#745).
+
+        For server errors the message is opaque and may carry internals, so it
+        is redacted to status-only. Crucially the chain is also suppressed
+        (``__cause__ is None``) so the withheld body cannot resurface via a
+        future ``logging.exception`` / ``exc_info=True`` call.
+        """
+        import anthropic
+        import httpx
+
+        _set_anthropic_env(monkeypatch)
+        response = httpx.Response(
+            500, request=httpx.Request("POST", "https://api.anthropic.com")
+        )
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = anthropic.InternalServerError(
+            message="secret internal detail", response=response, body=None
+        )
+        with (
+            patch("anthropic.Anthropic", return_value=mock_client),
+            pytest.raises(RuntimeError) as exc_info,
+        ):
+            AnthropicProvider(LLMConfig(provider="anthropic")).call("prompt")
+        message = str(exc_info.value)
+        assert "secret internal detail" not in message  # body withheld
+        assert "HTTP 500" in message  # status only
+        assert exc_info.value.__cause__ is None  # chain suppressed
+
     def test_client_cached_across_calls(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/creek-tools/tests/test_gemini_provider.py
+++ b/creek-tools/tests/test_gemini_provider.py
@@ -216,6 +216,40 @@ class TestGeminiComplete:
         assert "APIError" in message
         assert "secret" not in message
 
+    def test_complete_4xx_surfaces_api_message(self, gemini_env: None) -> None:
+        """A 4xx surfaces Gemini's own error message (the actionable cause; #745)."""
+        from google.genai import errors
+
+        client = MagicMock()
+        client.models.generate_content.side_effect = errors.APIError(
+            400, {"error": {"message": "quota exceeded for this project"}}
+        )
+        with patch("google.genai.Client", return_value=client):
+            provider = GeminiProvider(LLMConfig(provider="gemini"))
+            with pytest.raises(RuntimeError) as exc:
+                provider.complete("p")
+        message = str(exc.value)
+        assert "quota exceeded" in message
+        assert "HTTP 400" in message
+
+    def test_complete_5xx_withholds_body_and_suppresses_chain(
+        self, gemini_env: None
+    ) -> None:
+        """A 5xx is status-only; its chain is suppressed (no body via `__cause__`)."""
+        from google.genai import errors
+
+        client = MagicMock()
+        client.models.generate_content.side_effect = errors.APIError(
+            503, {"error": {"message": "secret internal detail"}}
+        )
+        with patch("google.genai.Client", return_value=client):
+            provider = GeminiProvider(LLMConfig(provider="gemini"))
+            with pytest.raises(RuntimeError) as exc:
+                provider.complete("p")
+        assert "secret internal detail" not in str(exc.value)
+        assert "HTTP 503" in str(exc.value)
+        assert exc.value.__cause__ is None
+
     def test_rate_limit_surfaces_retry_after(self, gemini_env: None) -> None:
         """A vendor 429 maps to ProviderRateLimitError carrying Retry-After."""
         import httpx

--- a/creek-tools/tests/test_openai_provider.py
+++ b/creek-tools/tests/test_openai_provider.py
@@ -199,6 +199,48 @@ class TestOpenAIComplete:
         assert "OpenAIError" in message
         assert "secret" not in message
 
+    def test_complete_4xx_surfaces_api_message(self, openai_env: None) -> None:
+        """A 4xx surfaces OpenAI's own error message (the actionable cause; #745)."""
+        import httpx
+        import openai
+
+        response = httpx.Response(
+            400, request=httpx.Request("POST", "https://api.openai.com")
+        )
+        client = MagicMock()
+        client.chat.completions.create.side_effect = openai.BadRequestError(
+            message="You exceeded your current quota", response=response, body=None
+        )
+        with patch("openai.OpenAI", return_value=client):
+            provider = OpenAIProvider(LLMConfig(provider="openai"))
+            with pytest.raises(RuntimeError) as exc:
+                provider.complete("p")
+        message = str(exc.value)
+        assert "exceeded your current quota" in message
+        assert "HTTP 400" in message
+
+    def test_complete_5xx_withholds_body_and_suppresses_chain(
+        self, openai_env: None
+    ) -> None:
+        """A 5xx is status-only; its chain is suppressed (no body via `__cause__`)."""
+        import httpx
+        import openai
+
+        response = httpx.Response(
+            503, request=httpx.Request("POST", "https://api.openai.com")
+        )
+        client = MagicMock()
+        client.chat.completions.create.side_effect = openai.InternalServerError(
+            message="secret internal detail", response=response, body=None
+        )
+        with patch("openai.OpenAI", return_value=client):
+            provider = OpenAIProvider(LLMConfig(provider="openai"))
+            with pytest.raises(RuntimeError) as exc:
+                provider.complete("p")
+        assert "secret internal detail" not in str(exc.value)
+        assert "HTTP 503" in str(exc.value)
+        assert exc.value.__cause__ is None
+
     def test_rate_limit_surfaces_retry_after(self, openai_env: None) -> None:
         """A vendor 429 maps to ProviderRateLimitError carrying Retry-After."""
         import httpx

--- a/creek-tools/tests/test_provider_error_detail.py
+++ b/creek-tools/tests/test_provider_error_detail.py
@@ -17,7 +17,11 @@ prompt / fragment content appear.
 
 from __future__ import annotations
 
-from creek.classify.llm.providers import _error_detail, _error_status
+from creek.classify.llm.providers import (
+    _chain_is_safe,
+    _error_detail,
+    _error_status,
+)
 
 
 class _FakeError(Exception):
@@ -86,3 +90,14 @@ def test_non_string_message_falls_back_to_status_only() -> None:
     err = _FakeError("ignored", status_code=400)
     err.message = None  # type: ignore[assignment]  # simulate an SDK with no message
     assert _error_detail(err) == " (HTTP 400)"
+
+
+def test_chain_is_safe_only_for_4xx() -> None:
+    """The exception chain may be kept only for 4xx (whose body we surface)."""
+    assert _chain_is_safe(_FakeError("c", status_code=400)) is True
+    assert _chain_is_safe(_FakeError("c", code=404)) is True
+    assert _chain_is_safe(_FakeError("c", status_code=499)) is True
+    # 5xx and unknown withhold the body, so the chain must be suppressed.
+    assert _chain_is_safe(_FakeError("c", status_code=500)) is False
+    assert _chain_is_safe(_FakeError("c", status_code=503)) is False
+    assert _chain_is_safe(_FakeError("c")) is False

--- a/creek-tools/tests/test_provider_error_detail.py
+++ b/creek-tools/tests/test_provider_error_detail.py
@@ -94,10 +94,10 @@ def test_non_string_message_falls_back_to_status_only() -> None:
 
 def test_chain_is_safe_only_for_4xx() -> None:
     """The exception chain may be kept only for 4xx (whose body we surface)."""
-    assert _chain_is_safe(_FakeError("c", status_code=400)) is True
-    assert _chain_is_safe(_FakeError("c", code=404)) is True
-    assert _chain_is_safe(_FakeError("c", status_code=499)) is True
+    assert _chain_is_safe(_FakeError("c", status_code=400))
+    assert _chain_is_safe(_FakeError("c", code=404))
+    assert _chain_is_safe(_FakeError("c", status_code=499))
     # 5xx and unknown withhold the body, so the chain must be suppressed.
-    assert _chain_is_safe(_FakeError("c", status_code=500)) is False
-    assert _chain_is_safe(_FakeError("c", status_code=503)) is False
-    assert _chain_is_safe(_FakeError("c")) is False
+    assert not _chain_is_safe(_FakeError("c", status_code=500))
+    assert not _chain_is_safe(_FakeError("c", status_code=503))
+    assert not _chain_is_safe(_FakeError("c"))

--- a/creek-tools/tests/test_provider_error_detail.py
+++ b/creek-tools/tests/test_provider_error_detail.py
@@ -1,0 +1,88 @@
+"""The wrapped provider error must name the cause, without leaking secrets (#745).
+
+A cloud provider that fails surfaces a plain ``RuntimeError`` so the
+orchestrator's retry loop stays provider-agnostic. Before #745 that message
+carried only the exception *type* (``BadRequestError``), which hid the real
+cause — a budget/credit 400 looked identical to a malformed-request 400, so a
+whole vault's worth of "over budget" failures read as an opaque wall of
+``BadRequestError``.
+
+#745 surfaces the API's own error *message* for **4xx client errors** (the
+API-side description of what is wrong with the request or account — billing,
+auth, model id, params), while keeping **5xx / unknown** errors status-only,
+because server-error bodies are opaque and the providers deliberately redact
+anything that could echo request state. In no case may the API key or the
+prompt / fragment content appear.
+"""
+
+from __future__ import annotations
+
+from creek.classify.llm.providers import _error_detail, _error_status
+
+
+class _FakeError(Exception):
+    """A stand-in SDK error exposing the attributes the helpers read."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        code: int | None = None,
+    ) -> None:
+        """Store the message and whichever status attribute the SDK would set."""
+        super().__init__(message)
+        self.message = message
+        if status_code is not None:
+            self.status_code = status_code
+        if code is not None:
+            self.code = code
+
+
+_CREDIT_MESSAGE = (
+    "Your credit balance is too low to access the Anthropic API. "
+    "Please go to Plans & Billing to upgrade or purchase credits."
+)
+
+
+def test_4xx_surfaces_the_api_message() -> None:
+    """A 400's API message (the real cause) is surfaced after the status."""
+    detail = _error_detail(_FakeError(_CREDIT_MESSAGE, status_code=400))
+    assert "HTTP 400" in detail
+    assert "credit balance is too low" in detail
+
+
+def test_gemini_style_code_attribute_is_read() -> None:
+    """Gemini exposes the status as ``code`` rather than ``status_code``."""
+    assert _error_status(_FakeError("nope", code=404)) == 404
+    detail = _error_detail(_FakeError("model not found", code=404))
+    assert "HTTP 404" in detail
+    assert "model not found" in detail
+
+
+def test_5xx_stays_status_only() -> None:
+    """A server error is opaque — status only, message withheld."""
+    detail = _error_detail(
+        _FakeError("internal detail that may echo state", status_code=503)
+    )
+    assert detail == " (HTTP 503)"
+    assert "internal detail" not in detail
+
+
+def test_unknown_status_yields_no_detail() -> None:
+    """With no usable status the helper falls closed to the empty (type-only) form."""
+    assert _error_detail(_FakeError("secret request payload")) == ""
+
+
+def test_long_message_is_capped() -> None:
+    """An over-long 4xx message is truncated with an ellipsis."""
+    detail = _error_detail(_FakeError("x" * 1000, status_code=400))
+    assert detail.endswith("…")
+    assert len(detail) < 600
+
+
+def test_non_string_message_falls_back_to_status_only() -> None:
+    """A 4xx whose ``message`` is not a usable string degrades to status only."""
+    err = _FakeError("ignored", status_code=400)
+    err.message = None  # type: ignore[assignment]  # simulate an SDK with no message
+    assert _error_detail(err) == " (HTTP 400)"


### PR DESCRIPTION
## Summary

A failed cloud classification wrapped the SDK error as a `RuntimeError` carrying only the exception **type** — `BadRequestError` — which hid the real cause. Anthropic delivers an over-budget failure as a **400** whose message is *"Your credit balance is too low to access the Anthropic API…"*, identical in class to a malformed-request 400. So a whole vault's worth of budget failures read as an opaque wall of `BadRequestError` with no hint that the fix was *billing*.

This is the companion fix to #744 (which stopped stamping `llm` on a failed call). Together: a budget failure now both **names its cause** and **stays eligible for re-classify**.

## What changed

`creek/classify/llm/providers.py` — `_error_detail(exc)` now appends a redaction-safe detail keyed on HTTP status, and the three cloud `complete()` error blocks (Anthropic / OpenAI / Gemini) use it and re-raise `from exc`:

| Status | Surfaced |
|---|---|
| **4xx** client error | `(HTTP <s>): <API message>` — the API-side description of what's wrong with the request or account (billing, auth, model id, params), whitespace-collapsed and capped at 500 chars |
| **5xx / unknown** | status-only (`(HTTP <s>)`) or nothing — server bodies are opaque and stay redacted |

### Why the 4xx/5xx split (and not "show everything")

The providers **deliberately redact** the SDK error body (`test_complete_redacts_sdk_errors`) because a response body *can* echo request state. The split preserves that intent:

- A **4xx** `message` is an API-side description of the request/account — it is not your prompt or fragment content, and the API key lives only in request headers, never in the error message.
- A **5xx** body is opaque server internals → stays redacted.

This also keeps the existing redaction tests green: OpenAI's injects a status-less base error (→ status-only) and Gemini's injects a **503** (→ status-only), so neither surfaces its `"secret request payload"` probe.

## Example

Before:
```
Anthropic API call failed: BadRequestError
```
After:
```
Anthropic API call failed: BadRequestError (HTTP 400): Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.
```

## Test plan

- New `tests/test_provider_error_detail.py` (6 cases): 4xx surfaces the API message; Gemini's `code` attribute path; 5xx withholds the message (status-only); unknown status → empty (type-only) form; over-long message capped with `…`; non-string `message` → status-only.
- All existing provider/classify redaction tests pass unchanged (248 passed locally across `test_provider_error_detail`, `test_gemini_provider`, `test_openai_provider`, `test_classify`).
- `ruff` + `mypy --strict` clean.

> Note: 8 author-desk/mcp/compost tests fail **only** on the author's local machine (a pre-existing local-environment artifact — verified identical at clean `origin/main` HEAD `1088d88`, whose CI/CD Pipeline run is green). They are independent of this change and pass in CI.

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)