### PR TITLE
feat(mcp): creek.handshake — capability + version negotiation (#750)

### DIFF
--- a/creek-tools/creek_mcp/contract.py
+++ b/creek-tools/creek_mcp/contract.py
@@ -1,0 +1,26 @@
+"""Versioned identifiers for the Adepthood ↔ Creek MCP contract (#749 / #750).
+
+These constants are the runtime source of the version strings published in
+``docs/decisions/2026-06-30-adepthood-creek-mcp-contract.md`` and surfaced by
+:func:`creek_mcp.tools.handshake.handshake_tool` so a connecting client can
+negotiate compatibility before any read or write.
+
+Bump :data:`CONTRACT_VERSION` when the tool surface or its semantics change;
+bump :data:`ONTOLOGY_VERSION` when the shared APTITUDE-frequency / Wavelength-phase
+vocabulary changes (it is dated to the last canonical change — the frequency
+naming decision, ``docs/decisions/2026-05-23-frequency-naming.md``).
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+CONTRACT_VERSION: Final[str] = "0.1.0"
+"""Semantic version of the Adepthood ↔ Creek MCP contract (draft)."""
+
+ONTOLOGY_VERSION: Final[str] = "aptitude-wavelength/2026-05-23"
+"""Pinned version of the shared frequency/phase vocabulary.
+
+Dated to the canonical frequency-naming decision. A mismatch in this string
+between client and server means "renegotiate the contract".
+"""

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -26,6 +26,7 @@ from creek_mcp.tools import (
     author_tool,
     classify_tool,
     compile_tool,
+    handshake_tool,
     ingest_tool,
     link_tool,
     lint_tool,
@@ -120,6 +121,19 @@ def build_server(
     consumer = _consumer_from_env()
     factory = draft_llm_factory or _build_draft_llm
     compile_factory = compile_llm_factory or _build_compile_llm
+
+    @server.tool(name="creek.handshake")
+    async def _handshake(
+        privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    ) -> dict[str, Any]:
+        """Negotiate vault presence, versions, tier model, and capabilities."""
+        tools = await server.list_tools()
+        return handshake_tool(
+            vault_path=vault,
+            capabilities=sorted(tool.name for tool in tools),
+            privacy_tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+        )
 
     @server.tool(name="creek.state.read")
     def _state_read(

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -131,6 +131,7 @@ def build_server(
         return handshake_tool(
             vault_path=vault,
             capabilities=sorted(tool.name for tool in tools),
+            server_name=SERVER_NAME,
             privacy_tier_ceiling=privacy_tier_ceiling,
             consumer=consumer,
         )

--- a/creek-tools/creek_mcp/tools/__init__.py
+++ b/creek-tools/creek_mcp/tools/__init__.py
@@ -4,6 +4,7 @@ from creek_mcp.tools.author import author_tool
 from creek_mcp.tools.classify import classify_tool
 from creek_mcp.tools.compile import compile_tool
 from creek_mcp.tools.draft import draft_tool
+from creek_mcp.tools.handshake import handshake_tool
 from creek_mcp.tools.ingest import ingest_tool
 from creek_mcp.tools.link import link_tool
 from creek_mcp.tools.lint import lint_tool
@@ -27,6 +28,7 @@ __all__ = [
     "classify_tool",
     "compile_tool",
     "draft_tool",
+    "handshake_tool",
     "ingest_tool",
     "link_tool",
     "lint_tool",

--- a/creek-tools/creek_mcp/tools/handshake.py
+++ b/creek-tools/creek_mcp/tools/handshake.py
@@ -1,0 +1,98 @@
+"""``creek.handshake`` MCP tool — capability & version negotiation (#750).
+
+A connecting client (the Adepthood app) calls this first to learn, in one
+round-trip: whether a Creek vault is present, which contract and ontology
+versions the server speaks, the privacy-tier model, and the list of tools
+actually registered. The call is read-only and LLM-free, so it works on any
+host and on a fresh (or absent) vault — the negotiation must succeed before the
+client knows whether anything else will.
+
+The capability list is supplied by the caller (``build_server`` passes the live
+``server.list_tools()`` names) rather than hardcoded here, so it cannot drift
+from the tools actually registered.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from creek.models import PrivacyTier
+from creek_mcp.audit import MCPAuditLog
+from creek_mcp.contract import CONTRACT_VERSION, ONTOLOGY_VERSION
+from creek_mcp.tier_ceiling import TierCeiling
+
+TOOL_NAME = "creek.handshake"
+SERVER_NAME = "creek-tools-mcp"
+"""Mirrors ``creek_mcp.server.SERVER_NAME``; duplicated to avoid a circular import
+(``server`` imports this module)."""
+
+_CREEK_MARKER = Path("00-Creek-Meta")
+TRANSPORT = "stdio"
+
+
+def _content_tiers() -> list[str]:
+    """Return the privacy tiers content can hold, least- to most-restricted.
+
+    Derived from :class:`~creek.models.PrivacyTier` (minus ``unclassified``) so
+    the advertised tier model tracks the real enum: ``open``, ``personal``,
+    ``intimate``.
+    """
+    return [t.value for t in PrivacyTier if t is not PrivacyTier.UNCLASSIFIED]
+
+
+def handshake_tool(
+    *,
+    vault_path: Path,
+    capabilities: list[str],
+    privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Negotiate vault presence, versions, tier model, and capability list.
+
+    Audit-logs the call like every other tool (the only side effect — the
+    audit substrate creates its own directory on first write), then returns a
+    body-free negotiation envelope. ``available`` is computed *before* the audit
+    append so a fresh vault still reports ``False`` rather than being flipped
+    ``True`` by the audit directory the append creates.
+
+    Args:
+        vault_path: Vault root. Presence of ``00-Creek-Meta`` under it
+            determines ``available``.
+        capabilities: The tool names the server actually registered — supplied
+            by ``build_server`` so the list cannot drift.
+        privacy_tier_ceiling: The ceiling the caller declared; recorded and
+            echoed. Handshake returns no fragment content, so the ceiling does
+            not gate anything here, but it is audited like every other call.
+        consumer: Free-form consumer identifier (e.g. ``"adepthood"``), recorded
+            in the audit log.
+
+    Returns:
+        A dict with at least ``available``, ``contract_version``,
+        ``ontology_version``, ``tiers``, and ``capabilities``, plus the
+        ``tier_model``, ``transport``, and ``server`` name for the client.
+    """
+    available = (vault_path / _CREEK_MARKER).is_dir()
+    MCPAuditLog(vault_path).append(
+        tool=TOOL_NAME,
+        args={},
+        tier_ceiling=privacy_tier_ceiling,
+        consumer=consumer,
+    )
+    return {
+        "status": "ok",
+        "tool": TOOL_NAME,
+        "tier_ceiling": privacy_tier_ceiling.value,
+        "server": SERVER_NAME,
+        "transport": TRANSPORT,
+        "available": available,
+        "contract_version": CONTRACT_VERSION,
+        "ontology_version": ONTOLOGY_VERSION,
+        "tiers": _content_tiers(),
+        "tier_model": {
+            "ceilings": [ceiling.value for ceiling in TierCeiling],
+            "default": TierCeiling.OPEN.value,
+            "intimate_never_egresses": True,
+        },
+        "capabilities": capabilities.copy(),
+    }

--- a/creek-tools/creek_mcp/tools/handshake.py
+++ b/creek-tools/creek_mcp/tools/handshake.py
@@ -23,10 +23,6 @@ from creek_mcp.contract import CONTRACT_VERSION, ONTOLOGY_VERSION
 from creek_mcp.tier_ceiling import TierCeiling
 
 TOOL_NAME = "creek.handshake"
-SERVER_NAME = "creek-tools-mcp"
-"""Mirrors ``creek_mcp.server.SERVER_NAME``; duplicated to avoid a circular import
-(``server`` imports this module)."""
-
 _CREEK_MARKER = Path("00-Creek-Meta")
 TRANSPORT = "stdio"
 
@@ -45,6 +41,7 @@ def handshake_tool(
     *,
     vault_path: Path,
     capabilities: list[str],
+    server_name: str,
     privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
     consumer: str = "unknown",
 ) -> dict[str, Any]:
@@ -61,6 +58,8 @@ def handshake_tool(
             determines ``available``.
         capabilities: The tool names the server actually registered — supplied
             by ``build_server`` so the list cannot drift.
+        server_name: The MCP server's name, injected by ``build_server`` (its
+            ``SERVER_NAME``) so this module need not duplicate the literal.
         privacy_tier_ceiling: The ceiling the caller declared; recorded and
             echoed. Handshake returns no fragment content, so the ceiling does
             not gate anything here, but it is audited like every other call.
@@ -83,7 +82,7 @@ def handshake_tool(
         "status": "ok",
         "tool": TOOL_NAME,
         "tier_ceiling": privacy_tier_ceiling.value,
-        "server": SERVER_NAME,
+        "server": server_name,
         "transport": TRANSPORT,
         "available": available,
         "contract_version": CONTRACT_VERSION,

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -17,6 +17,21 @@ interactively will appear to hang, which is correct.
 
 ## Tools
 
+### Handshake (epic #748)
+
+| Tool              | Purpose                                                                   |
+|-------------------|---------------------------------------------------------------------------|
+| `creek.handshake` | Negotiate vault presence, contract/ontology versions, tier model, and the live capability list. |
+
+A connecting client (the Adepthood app) calls `creek.handshake` first. It is
+read-only and needs no LLM provider, so the negotiation succeeds on any host and
+even on a fresh/absent vault. It returns at least `available`,
+`contract_version`, `ontology_version`, `tiers` (`open`/`personal`/`intimate`),
+and `capabilities` (the names of the tools actually registered), plus the
+`tier_model` and `transport`. Versions come from `creek_mcp/contract.py`; the
+cross-repo contract is
+[`docs/decisions/2026-06-30-adepthood-creek-mcp-contract.md`](../../docs/decisions/2026-06-30-adepthood-creek-mcp-contract.md).
+
 ### Read tools (FEAT-010)
 
 | Tool                  | Purpose                                                    |

--- a/creek-tools/tests/test_handshake.py
+++ b/creek-tools/tests/test_handshake.py
@@ -1,0 +1,102 @@
+"""``creek.handshake`` MCP tool — capability/version negotiation (#750).
+
+A connecting client (Adepthood) calls ``creek.handshake`` first to learn, in one
+round-trip: whether a Creek vault is present, the contract + ontology versions
+the server speaks, the privacy-tier model, and the list of registered tools. The
+call must be read-only, audit-logged, and work with no LLM provider configured.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+from creek_mcp.contract import CONTRACT_VERSION, ONTOLOGY_VERSION
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.handshake import TOOL_NAME, handshake_tool
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_CAPS = ["creek.classify", "creek.handshake", "creek.ingest"]
+
+
+def _vault(tmp_path: Path, *, creek: bool) -> Path:
+    """Create a vault dir, optionally with the ``00-Creek-Meta`` marker."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    if creek:
+        (vault / "00-Creek-Meta").mkdir()
+    return vault
+
+
+def test_handshake_reports_the_required_fields(tmp_path: Path) -> None:
+    """The response carries the contract-mandated keys and pinned versions."""
+    vault = _vault(tmp_path, creek=True)
+    result = handshake_tool(vault_path=vault, capabilities=_CAPS, consumer="adepthood")
+    for key in (
+        "available",
+        "contract_version",
+        "ontology_version",
+        "tiers",
+        "capabilities",
+    ):
+        assert key in result, key
+    assert result["tool"] == TOOL_NAME
+    assert result["contract_version"] == CONTRACT_VERSION
+    assert result["ontology_version"] == ONTOLOGY_VERSION
+    assert result["tiers"] == ["open", "personal", "intimate"]
+
+
+def test_capabilities_echo_the_registered_tool_list(tmp_path: Path) -> None:
+    """``capabilities`` reflects the tool names handed in (the live registry)."""
+    vault = _vault(tmp_path, creek=True)
+    result = handshake_tool(vault_path=vault, capabilities=_CAPS)
+    assert result["capabilities"] == _CAPS
+
+
+def test_available_true_when_creek_vault_present(tmp_path: Path) -> None:
+    """A vault with the ``00-Creek-Meta`` marker reports ``available=True``."""
+    vault = _vault(tmp_path, creek=True)
+    assert handshake_tool(vault_path=vault, capabilities=_CAPS)["available"] is True
+
+
+def test_available_false_when_no_creek_structure(tmp_path: Path) -> None:
+    """A bare directory with no Creek marker reports ``available=False``."""
+    vault = _vault(tmp_path, creek=False)
+    assert handshake_tool(vault_path=vault, capabilities=_CAPS)["available"] is False
+
+
+def test_handshake_is_audit_logged_with_consumer(tmp_path: Path) -> None:
+    """The call appends one audit entry tagged with the tool and consumer."""
+    vault = _vault(tmp_path, creek=True)
+    handshake_tool(vault_path=vault, capabilities=_CAPS, consumer="adepthood")
+    log = vault / MCP_AUDIT_RELPATH
+    assert log.exists()
+    entries = [
+        json.loads(line) for line in log.read_text().splitlines() if line.strip()
+    ]
+    assert entries[-1]["tool"] == TOOL_NAME
+    assert entries[-1]["consumer"] == "adepthood"
+
+
+def test_handshake_honours_the_tier_ceiling_in_its_audit(tmp_path: Path) -> None:
+    """The supplied ceiling is recorded and echoed, not silently dropped."""
+    vault = _vault(tmp_path, creek=True)
+    result = handshake_tool(
+        vault_path=vault,
+        capabilities=_CAPS,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["tier_ceiling"] == "personal"
+
+
+def test_handshake_is_read_only(tmp_path: Path) -> None:
+    """Only the audit log is created; no vault content is written."""
+    vault = _vault(tmp_path, creek=True)
+    before = {p for p in vault.rglob("*") if p.is_file()}
+    handshake_tool(vault_path=vault, capabilities=_CAPS)
+    created = {p for p in vault.rglob("*") if p.is_file()} - before
+    assert created, "expected the audit log to be written"
+    assert all("audit" in str(p) for p in created)

--- a/creek-tools/tests/test_handshake.py
+++ b/creek-tools/tests/test_handshake.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 _CAPS = ["creek.classify", "creek.handshake", "creek.ingest"]
+_SERVER = "creek-tools-mcp"
 
 
 def _vault(tmp_path: Path, *, creek: bool) -> Path:
@@ -31,10 +32,32 @@ def _vault(tmp_path: Path, *, creek: bool) -> Path:
     return vault
 
 
+def _call(vault: Path, **overrides: object) -> dict[str, object]:
+    """Invoke ``handshake_tool`` with the standard test defaults.
+
+    ``capabilities`` and ``server_name`` are injected by ``build_server`` in
+    production; the helper supplies stand-ins so each test overrides only the
+    field it exercises.
+    """
+    kwargs: dict[str, object] = {
+        "vault_path": vault,
+        "capabilities": _CAPS,
+        "server_name": _SERVER,
+    }
+    kwargs.update(overrides)
+    return handshake_tool(**kwargs)  # type: ignore[arg-type]
+
+
+def _audit_entries(vault: Path) -> list[dict[str, object]]:
+    """Return the parsed MCP audit-log entries under *vault*."""
+    log = vault / MCP_AUDIT_RELPATH
+    assert log.exists()
+    return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
 def test_handshake_reports_the_required_fields(tmp_path: Path) -> None:
     """The response carries the contract-mandated keys and pinned versions."""
-    vault = _vault(tmp_path, creek=True)
-    result = handshake_tool(vault_path=vault, capabilities=_CAPS, consumer="adepthood")
+    result = _call(_vault(tmp_path, creek=True), consumer="adepthood")
     for key in (
         "available",
         "contract_version",
@@ -44,6 +67,7 @@ def test_handshake_reports_the_required_fields(tmp_path: Path) -> None:
     ):
         assert key in result, key
     assert result["tool"] == TOOL_NAME
+    assert result["server"] == _SERVER
     assert result["contract_version"] == CONTRACT_VERSION
     assert result["ontology_version"] == ONTOLOGY_VERSION
     assert result["tiers"] == ["open", "personal", "intimate"]
@@ -51,52 +75,43 @@ def test_handshake_reports_the_required_fields(tmp_path: Path) -> None:
 
 def test_capabilities_echo_the_registered_tool_list(tmp_path: Path) -> None:
     """``capabilities`` reflects the tool names handed in (the live registry)."""
-    vault = _vault(tmp_path, creek=True)
-    result = handshake_tool(vault_path=vault, capabilities=_CAPS)
-    assert result["capabilities"] == _CAPS
+    assert _call(_vault(tmp_path, creek=True))["capabilities"] == _CAPS
 
 
 def test_available_true_when_creek_vault_present(tmp_path: Path) -> None:
     """A vault with the ``00-Creek-Meta`` marker reports ``available=True``."""
-    vault = _vault(tmp_path, creek=True)
-    assert handshake_tool(vault_path=vault, capabilities=_CAPS)["available"] is True
+    assert _call(_vault(tmp_path, creek=True))["available"] is True
 
 
 def test_available_false_when_no_creek_structure(tmp_path: Path) -> None:
     """A bare directory with no Creek marker reports ``available=False``."""
-    vault = _vault(tmp_path, creek=False)
-    assert handshake_tool(vault_path=vault, capabilities=_CAPS)["available"] is False
+    assert _call(_vault(tmp_path, creek=False))["available"] is False
 
 
 def test_handshake_is_audit_logged_with_consumer(tmp_path: Path) -> None:
     """The call appends one audit entry tagged with the tool and consumer."""
     vault = _vault(tmp_path, creek=True)
-    handshake_tool(vault_path=vault, capabilities=_CAPS, consumer="adepthood")
-    log = vault / MCP_AUDIT_RELPATH
-    assert log.exists()
-    entries = [
-        json.loads(line) for line in log.read_text().splitlines() if line.strip()
-    ]
-    assert entries[-1]["tool"] == TOOL_NAME
-    assert entries[-1]["consumer"] == "adepthood"
+    _call(vault, consumer="adepthood")
+    last = _audit_entries(vault)[-1]
+    assert last["tool"] == TOOL_NAME
+    assert last["consumer"] == "adepthood"
 
 
-def test_handshake_honours_the_tier_ceiling_in_its_audit(tmp_path: Path) -> None:
-    """The supplied ceiling is recorded and echoed, not silently dropped."""
+def test_handshake_records_the_ceiling_in_its_audit_and_echoes_it(
+    tmp_path: Path,
+) -> None:
+    """The supplied ceiling is both echoed in the response and written to the log."""
     vault = _vault(tmp_path, creek=True)
-    result = handshake_tool(
-        vault_path=vault,
-        capabilities=_CAPS,
-        privacy_tier_ceiling=TierCeiling.PERSONAL,
-    )
+    result = _call(vault, privacy_tier_ceiling=TierCeiling.PERSONAL)
     assert result["tier_ceiling"] == "personal"
+    assert _audit_entries(vault)[-1]["tier_ceiling"] == "personal"
 
 
 def test_handshake_is_read_only(tmp_path: Path) -> None:
     """Only the audit log is created; no vault content is written."""
     vault = _vault(tmp_path, creek=True)
     before = {p for p in vault.rglob("*") if p.is_file()}
-    handshake_tool(vault_path=vault, capabilities=_CAPS)
+    _call(vault)
     created = {p for p in vault.rglob("*") if p.is_file()} - before
     assert created, "expected the audit log to be written"
     assert all("audit" in str(p) for p in created)

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from creek_mcp.contract import CONTRACT_VERSION, ONTOLOGY_VERSION
 from creek_mcp.server import SERVER_NAME, build_server
 
 if TYPE_CHECKING:
@@ -16,6 +17,7 @@ if TYPE_CHECKING:
 
 
 EXPECTED_TOOLS = {
+    "creek.handshake",
     "creek.state.read",
     "creek.state.render",
     "creek.lint",
@@ -77,6 +79,32 @@ def test_build_server_registers_all_tools(vault: Path) -> None:
     tools = asyncio.run(server.list_tools())
     names = {tool.name for tool in tools}
     assert names == EXPECTED_TOOLS
+
+
+def test_call_tool_handshake_reflects_registered_tools(vault: Path) -> None:
+    """End-to-end: ``creek.handshake`` negotiates versions + the live tool list.
+
+    Its ``capabilities`` must equal the names of the tools actually registered
+    (not a hardcoded list), proving the #750 acceptance criterion through the
+    registered async handler rather than only the unit-level helper.
+    """
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    registered = {tool.name for tool in asyncio.run(server.list_tools())}
+    result = asyncio.run(
+        server.call_tool("creek.handshake", {"privacy_tier_ceiling": "open"}),
+    )
+    structured = _structured(result)
+    assert structured["status"] == "ok"
+    assert structured["available"] is True
+    assert structured["contract_version"] == CONTRACT_VERSION
+    assert structured["ontology_version"] == ONTOLOGY_VERSION
+    assert structured["tiers"] == ["open", "personal", "intimate"]
+    assert set(structured["capabilities"]) == registered  # type: ignore[arg-type]
+    for expected in ("creek.handshake", "creek.ingest", "creek.classify"):
+        assert expected in structured["capabilities"]  # type: ignore[operator]
 
 
 def test_call_tool_save_through_mcp(vault: Path) -> None:

--- a/docs/decisions/2026-06-30-adepthood-creek-mcp-contract.md
+++ b/docs/decisions/2026-06-30-adepthood-creek-mcp-contract.md
@@ -80,31 +80,37 @@ not this version.
 
 | Capability Adepthood depends on | Status | MCP tool | Tracking |
 |---|---|---|---|
-| Handshake / capabilities (+ contract & ontology version, tier model) | **Planned** | `creek.handshake` | [#750](https://github.com/Geoffe-Ga/Creek-Vault/issues/750) |
+| Handshake / capabilities (+ contract & ontology version, tier model) | **Exists** | `creek.handshake` | [#750](https://github.com/Geoffe-Ga/Creek-Vault/issues/750) |
 | Ingest — journal entry → fragment | **Exists** (generic) + dedicated path *planned* | `creek.ingest` | [#754](https://github.com/Geoffe-Ga/Creek-Vault/issues/754) (Adepthood-journal path) |
 | Classify a fragment | **Exists** | `creek.classify` | — |
 | Reflect — Higher-Self margin notes on one entry | **Planned** | `creek.reflect` | [#751](https://github.com/Geoffe-Ga/Creek-Vault/issues/751) |
 | Wheel — per-frequency balance read for the Map | **Planned** | `creek.wheel` | [#752](https://github.com/Geoffe-Ga/Creek-Vault/issues/752) |
 | Tier ceiling — INTIMATE never egresses | **Exists** | (parameter on every tool) | — |
 
-### Handshake / capabilities — *Planned* (#750)
+### Handshake / capabilities — *Exists* (#750)
 
-A no-side-effect tool that lets a consumer discover, in one call: the
-**contract version** (`0.1.0`), the **ontology version**
-(`aptitude-wavelength/2026-05-23`), the list of available tools with their
-shapes, and the **tier model** (the `TierCeiling` values and the
-INTIMATE-never-egresses guarantee). Adepthood calls this first to confirm both
-sides speak the same contract before any read/write. Proposed return shape:
+A read-only, LLM-free tool that lets a consumer discover, in one call: whether a
+vault is present (`available`), the **contract version** (`0.1.0`, from
+`creek_mcp/contract.py`), the **ontology version**
+(`aptitude-wavelength/2026-05-23`), the **tier model** (the `TierCeiling`
+ceilings and the INTIMATE-never-egresses guarantee), and the **capabilities**
+list — the names of the tools actually registered, sourced live from
+`server.list_tools()` so it cannot drift. Adepthood calls this first to confirm
+both sides speak the same contract before any read/write. Return shape:
 
 ```jsonc
 {
+  "status": "ok",
+  "tool": "creek.handshake",
   "server": "creek-tools-mcp",
+  "transport": "stdio",
+  "available": true,
   "contract_version": "0.1.0",
   "ontology_version": "aptitude-wavelength/2026-05-23",
-  "transport": "stdio",
+  "tiers": ["open", "personal", "intimate"],
   "tier_model": { "ceilings": ["open", "personal", "intimate", "all"],
                   "default": "open", "intimate_never_egresses": true },
-  "tools": ["creek.ingest", "creek.classify", "creek.reflect", "creek.wheel", "..."]
+  "capabilities": ["creek.classify", "creek.handshake", "creek.ingest", "..."]
 }
 ```
 


### PR DESCRIPTION
## Summary

Adds a read-only, LLM-free **`creek.handshake`** MCP tool so a connecting client (the Adepthood app) can negotiate compatibility before any read/write — implementing the capability that #749's contract documented as *Planned*. It returns whether a vault is present, the contract + ontology versions, the tier model, and the **live** capability list.

Part of epic #748 (Adepthood MCP handshake).

## What it returns

```jsonc
{
  "status": "ok", "tool": "creek.handshake", "server": "creek-tools-mcp",
  "transport": "stdio", "available": true,
  "contract_version": "0.1.0",
  "ontology_version": "aptitude-wavelength/2026-05-23",
  "tiers": ["open", "personal", "intimate"],
  "tier_model": { "ceilings": ["open","personal","intimate","all"], "default": "open", "intimate_never_egresses": true },
  "capabilities": ["creek.classify", "creek.handshake", "creek.ingest", "..."]
}
```

## Design notes

- **`creek_mcp/contract.py`** — `CONTRACT_VERSION` / `ONTOLOGY_VERSION` constants are the single runtime source of the version strings published in the #749 contract doc (the "promote to a code constant" the doc anticipated).
- **Capabilities can't drift** — the registered handler is `async` and sources the list from the live `server.list_tools()`, so it always equals the tools actually registered (asserted end-to-end in `test_mcp_server.py`).
- **`available` computed before the audit append** — the audit substrate creates `00-Creek-Meta/audit/` on first write, so checking the marker first keeps a fresh/absent vault honestly reporting `available: false`.
- **Tier model from the real enum** — `tiers` is derived from `PrivacyTier` (minus `unclassified`), not hardcoded.
- Read-only and audit-logged like every other tool; works with no LLM provider configured (AC).

## Test plan (TDD)

- `tests/test_handshake.py` (7): required fields + pinned versions, capabilities echo, `available` true/false, audit-logged with consumer, ceiling echoed, read-only (only the audit log is written).
- `tests/test_mcp_server.py`: `creek.handshake` registered (added to `EXPECTED_TOOLS`); integration via `call_tool` asserting `capabilities == {registered tool names}` and includes handshake/ingest/classify.
- Docs: added to `docs/mcp.md`; status flipped Planned→Exists in `docs/decisions/2026-06-30-adepthood-creek-mcp-contract.md`.
- `./scripts/check-all.sh`: all gates pass except the unit-test/coverage step, whose only failures are the 8 pre-existing author-desk/mcp environmental tests (green in CI). My 7 handshake tests + the new server integration test pass; ruff/mypy/refurb/interrogate/complexity clean.

Closes #750
Refs #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)