### PR TITLE
feat(mcp): creek.reflect — anchored Higher-Self margin notes (#751)

### DIFF
--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -37,6 +37,7 @@ from creek_mcp.tools import (
     purge_source_tool,
     purge_vault_tool,
     redact_scan_tool,
+    reflect_tool,
     report_tool,
     save_tool,
     skills_refresh_tool,
@@ -47,6 +48,9 @@ from creek_mcp.tools.draft import draft_tool
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from creek.models import PrivacyTier
+    from creek_mcp.tools.reflect import _LLM, _LLMFactory
 
 SERVER_NAME = "creek-tools-mcp"
 
@@ -97,11 +101,40 @@ def _build_compile_llm() -> Callable[[str], str]:
     return _engine_default_llm(load_config().llm)
 
 
+def _build_reflect_llm_factory() -> _LLMFactory:
+    """Return a tier-keyed LLM factory for ``creek.reflect``.
+
+    The returned ``factory(tier)`` resolves the ``generation`` stage through the
+    config's :class:`~creek.classify.llm.router.ModelRouter` for *tier*, so an
+    INTIMATE reflection is forced onto the local ``default`` model (or the router
+    raises ``IntimateRoutingError`` rather than egressing). Lazy imports keep the
+    server bootable without a provider — only a ``creek.reflect`` call then fails,
+    surfacing as a structured refusal.
+    """
+    from creek.classify.llm.providers import build_provider
+
+    router = load_config().model_router
+
+    def _factory(tier: PrivacyTier) -> _LLM:
+        cfg = router.resolve("generation", tier)
+        provider = build_provider(cfg)
+        if not provider.available:
+            msg = (
+                "LLM provider unavailable for reflection. "
+                "Check Ollama or ANTHROPIC_API_KEY configuration."
+            )
+            raise RuntimeError(msg)
+        return lambda prompt: provider.complete(prompt).text
+
+    return _factory
+
+
 def build_server(
     *,
     vault_path: Path | None = None,
     draft_llm_factory: Callable[[], Callable[[str], str]] | None = None,
     compile_llm_factory: Callable[[], Callable[[str], str]] | None = None,
+    reflect_llm_factory: Callable[[], _LLMFactory] | None = None,
 ) -> FastMCP:
     """Construct a :class:`FastMCP` instance with all FEAT-010/011 tools.
 
@@ -115,12 +148,16 @@ def build_server(
         compile_llm_factory: Optional factory for the compile LLM.
             Invoked lazily so only ``creek.compile`` needs an LLM
             provider.
+        reflect_llm_factory: Optional thunk returning the tier-keyed LLM
+            factory for ``creek.reflect``. Invoked lazily per call so only
+            ``creek.reflect`` needs an LLM provider.
     """
     server: FastMCP = FastMCP(SERVER_NAME)
     vault = _resolve_vault(vault_path)
     consumer = _consumer_from_env()
     factory = draft_llm_factory or _build_draft_llm
     compile_factory = compile_llm_factory or _build_compile_llm
+    reflect_factory = reflect_llm_factory or _build_reflect_llm_factory
 
     @server.tool(name="creek.handshake")
     async def _handshake(
@@ -132,6 +169,22 @@ def build_server(
             vault_path=vault,
             capabilities=sorted(tool.name for tool in tools),
             server_name=SERVER_NAME,
+            privacy_tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.reflect")
+    def _reflect(
+        content: str | None = None,
+        entry_ref: str | None = None,
+        privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    ) -> dict[str, Any]:
+        """Return anchored Higher-Self margin notes on a single journal entry."""
+        return reflect_tool(
+            vault_path=vault,
+            llm_factory=reflect_factory(),
+            content=content,
+            entry_ref=entry_ref,
             privacy_tier_ceiling=privacy_tier_ceiling,
             consumer=consumer,
         )

--- a/creek-tools/creek_mcp/tools/__init__.py
+++ b/creek-tools/creek_mcp/tools/__init__.py
@@ -17,6 +17,7 @@ from creek_mcp.tools.purge import (
     purge_vault_tool,
 )
 from creek_mcp.tools.redact import redact_scan_tool
+from creek_mcp.tools.reflect import reflect_tool
 from creek_mcp.tools.report import report_tool
 from creek_mcp.tools.save import save_tool
 from creek_mcp.tools.skills import skills_refresh_tool
@@ -39,6 +40,7 @@ __all__ = [
     "purge_source_tool",
     "purge_vault_tool",
     "redact_scan_tool",
+    "reflect_tool",
     "report_tool",
     "save_tool",
     "skills_refresh_tool",

--- a/creek-tools/creek_mcp/tools/reflect.py
+++ b/creek-tools/creek_mcp/tools/reflect.py
@@ -282,7 +282,10 @@ def reflect_tool(
 
     Returns:
         ``{status, tool, tier_ceiling, ...}`` — ``ok`` with ``notes`` (+ optional
-        ``essay``), ``escalate`` with a ``reason``, or a structured refusal.
+        ``essay``), ``escalate`` with a ``reason``, or a structured refusal. Each
+        ``notes[].quote`` is a verified verbatim span of the entry; the optional
+        ``essay`` is free model prose and is **not** grounding-checked, flagged by
+        ``essay_grounded: False`` so a client never treats it as grounded.
     """
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
@@ -334,6 +337,9 @@ def reflect_tool(
         "tier_ceiling": privacy_tier_ceiling.value,
         "routed_tier": tier.value,
         "notes": notes,
+        # ``essay`` is free model prose and is NOT verbatim/grounding-checked the
+        # way ``notes[].quote`` is — a client must not treat it as grounded.
+        "essay_grounded": False,
     }
     if essay is not None:
         result["essay"] = essay

--- a/creek-tools/creek_mcp/tools/reflect.py
+++ b/creek-tools/creek_mcp/tools/reflect.py
@@ -1,0 +1,300 @@
+"""``creek.reflect`` MCP tool — anchored Higher-Self margin notes (#751).
+
+Takes one journal entry (raw ``content`` or an ``entry_ref`` fragment id) plus a
+privacy-tier ceiling and returns ``{notes: [{quote, kind, note}], essay?}`` —
+warm, second-person, anti-guru reflections that mirror the user's own wisdom,
+grounded in retrieval over their corpus. Distinct from the essay-shaped
+``draft``/``author``/``mine`` surface; this is the reflection surface Adepthood's
+journal needs.
+
+Three guarantees this module enforces:
+
+- **INTIMATE never egresses.** The LLM callable is obtained from a *tier-keyed
+  factory* (``llm_factory(tier)``). The production factory resolves through
+  :class:`creek.classify.llm.router.ModelRouter`, whose
+  ``_enforce_local_for_intimate`` chokepoint redirects an INTIMATE call to the
+  local ``default`` model — or raises :class:`IntimateRoutingError` rather than
+  egressing. This module never picks a provider or re-checks the tier itself; it
+  only derives the routing tier (failing closed to INTIMATE) and hands it over.
+- **Quotes are verbatim.** Every returned ``quote`` is validated to be a
+  substring of the entry (whitespace-normalised). Model-supplied spans that are
+  not are dropped — the client re-anchors verbatim quotes to character offsets
+  itself, so a hallucinated span must never reach it.
+- **Care boundary (#753).** A ``care_guard`` seam is injected; when it flags the
+  entry, the tool escalates and never calls the model. The real guard lands in
+  #753; until then the seam is unset (no gating) but wired.
+
+The LLM and retrieval are injected so the tool is unit-testable with no live
+calls; ``build_server`` supplies the production factory + retrieval.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol
+
+from creek.classify.llm.router import IntimateRoutingError
+from creek.models import PrivacyTier
+from creek_mcp.audit import MCPAuditLog
+from creek_mcp.tier_ceiling import TierCeiling, refusal_response, to_privacy_override
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+TOOL_NAME = "creek.reflect"
+
+_DEFAULT_MAX_NOTES = 6
+_ALLOWED_KINDS = {"reframe", "fear", "longing", "value", "pattern", "tension", "gift"}
+
+
+class _LLM(Protocol):
+    """A prompt-completion callable returning the model's raw text."""
+
+    def __call__(self, prompt: str) -> str:
+        """Return the completion for *prompt*."""
+
+
+class _LLMFactory(Protocol):
+    """Builds a tier-routed LLM callable; INTIMATE is forced local by the router."""
+
+    def __call__(self, tier: PrivacyTier) -> _LLM:
+        """Return an LLM callable routed for *tier* (may raise to refuse)."""
+
+
+# A retrieval callable: ``(query, vault, override) -> grounding snippets``.
+_Retrieve = "Callable[[str, Path, object], list[str]]"
+# A care guard: ``(entry_text) -> escalation reason or None``.
+_CareGuard = "Callable[[str], str | None]"
+
+# ``ALL`` admits intimate content, so a reflection under it must route as INTIMATE.
+_CEILING_ROUTING_TIER: dict[TierCeiling, PrivacyTier] = {
+    TierCeiling.OPEN: PrivacyTier.OPEN,
+    TierCeiling.PERSONAL: PrivacyTier.PERSONAL,
+    TierCeiling.INTIMATE: PrivacyTier.INTIMATE,
+    TierCeiling.ALL: PrivacyTier.INTIMATE,
+}
+
+
+def _routing_tier(ceiling: TierCeiling) -> PrivacyTier:
+    """Map a ceiling to the routing tier, failing closed to INTIMATE.
+
+    The router's cloud gate keys on :class:`PrivacyTier`, never on
+    :class:`TierCeiling`, so the ceiling is translated to the most-sensitive
+    tier it admits. An unrecognised ceiling routes as INTIMATE (local-only).
+    """
+    return _CEILING_ROUTING_TIER.get(ceiling, PrivacyTier.INTIMATE)
+
+
+def _normalise(text: str) -> str:
+    """Collapse runs of whitespace so quote matching tolerates LLM reflow."""
+    return " ".join(text.split())
+
+
+def _is_verbatim(quote: str, entry: str) -> bool:
+    """Return whether *quote* appears in *entry* (whitespace-normalised)."""
+    needle = _normalise(quote)
+    return bool(needle) and needle in _normalise(entry)
+
+
+def _parse_notes(response_text: str) -> tuple[list[dict[str, Any]], str | None]:
+    """Parse the model response into raw notes + an optional essay.
+
+    Strips a single code fence, then parses JSON (falling back to a YAML
+    safe-load for fenced YAML), and reads ``notes`` / ``essay``. Any structural
+    problem degrades to ``([], None)`` rather than raising — a malformed model
+    turn yields no notes, never a crash or unvalidated output.
+    """
+    import json
+
+    text = response_text.strip()
+    if text.startswith("```"):
+        lines = text.splitlines()
+        text = "\n".join(lines[1:-1] if len(lines) >= 2 else lines)
+        text = text.removesuffix("```")
+    try:
+        data = json.loads(text)
+    except (ValueError, TypeError):
+        try:
+            import yaml
+
+            data = yaml.safe_load(text)
+        except (ValueError, TypeError):
+            return [], None
+    if not isinstance(data, dict):
+        return [], None
+    raw_notes = data.get("notes")
+    notes = (
+        [n for n in raw_notes if isinstance(n, dict)]
+        if isinstance(raw_notes, list)
+        else []
+    )
+    essay = data.get("essay")
+    return notes, essay if isinstance(essay, str) and essay.strip() else None
+
+
+def _clean_notes(
+    raw_notes: list[dict[str, Any]], entry: str, *, max_notes: int
+) -> list[dict[str, str]]:
+    """Keep only well-formed notes whose quote is a verbatim entry substring.
+
+    A surviving note carries exactly ``quote`` / ``kind`` / ``note``; the kind is
+    constrained to the known vocabulary (unknown kinds fall back to ``pattern``).
+    """
+    cleaned: list[dict[str, str]] = []
+    for note in raw_notes:
+        quote, kind, body = note.get("quote"), note.get("kind"), note.get("note")
+        if not isinstance(quote, str) or not isinstance(body, str) or not body.strip():
+            continue
+        if not _is_verbatim(quote, entry):
+            continue
+        safe_kind = (
+            kind if isinstance(kind, str) and kind in _ALLOWED_KINDS else "pattern"
+        )
+        cleaned.append({"quote": quote, "kind": safe_kind, "note": body})
+        if len(cleaned) >= max_notes:
+            break
+    return cleaned
+
+
+def _build_prompt(entry: str, grounding: list[str]) -> str:
+    """Compose the margin-note prompt from the entry and grounding snippets."""
+    sources = "\n\n".join(f"- {snippet}" for snippet in grounding) or "(none)"
+    kinds = ", ".join(sorted(_ALLOWED_KINDS))
+    schema = (
+        'Return JSON: {"notes": [{"quote": <verbatim span copied from the ENTRY>, '
+        '"kind": <one of: ' + kinds + '>, "note": <a few warm sentences>}]}. '
+        "Every quote MUST be copied verbatim from the ENTRY."
+    )
+    return (
+        "You are the writer's own Higher Self leaving warm, second-person margin "
+        "notes on their journal entry. Mirror their wisdom back; never advise from "
+        "above, never diagnose, never console with platitudes. Ground every note in "
+        "their own words and the source fragments below.\n\n"
+        + schema
+        + f"\n\nSOURCE FRAGMENTS:\n{sources}\n\nENTRY:\n{entry}"
+    )
+
+
+def _resolve_entry(content: str | None, entry_ref: str | None, vault_path: Path) -> str:
+    """Return the entry text from raw *content* or a fragment *entry_ref*.
+
+    ``entry_ref`` is resolved to a fragment markdown file under ``01-Fragments``;
+    its body becomes the entry. A blank result (no usable source) yields ``""``,
+    which the caller turns into a refusal.
+    """
+    if content and content.strip():
+        return content
+    if entry_ref:
+        import frontmatter
+
+        for path in (vault_path / "01-Fragments").rglob("*.md"):
+            post = frontmatter.load(path)
+            if str(post.metadata.get("id", "")) == entry_ref:
+                body: str = post.content
+                return body
+    return ""
+
+
+def reflect_tool(
+    *,
+    vault_path: Path,
+    llm_factory: _LLMFactory,
+    content: str | None = None,
+    entry_ref: str | None = None,
+    retrieve: Callable[[str, Path, object], list[str]] | None = None,
+    care_guard: Callable[[str], str | None] | None = None,
+    privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    consumer: str = "unknown",
+    max_notes: int = _DEFAULT_MAX_NOTES,
+) -> dict[str, Any]:
+    """Return anchored Higher-Self margin notes for a single journal entry.
+
+    Args:
+        vault_path: Vault root (for retrieval grounding + the audit log).
+        llm_factory: Tier-keyed LLM builder; ``llm_factory(tier)`` returns the
+            completion callable. The production factory routes INTIMATE local.
+        content: The raw entry text. Mutually exclusive-ish with *entry_ref*;
+            *content* wins when both are given.
+        entry_ref: A fragment id whose body is the entry, when *content* is
+            absent.
+        retrieve: ``(query, vault, override) -> snippets`` grounding source;
+            defaults to the corpus retrieval specialist.
+        care_guard: ``(entry) -> reason | None``; a non-``None`` reason escalates
+            to a human and skips the model entirely (#753 seam).
+        privacy_tier_ceiling: The ceiling; gates corpus admission and, via
+            :func:`_routing_tier`, the local-vs-cloud routing tier.
+        consumer: Free-form consumer id for the audit log.
+        max_notes: Cap on returned notes.
+
+    Returns:
+        ``{status, tool, tier_ceiling, ...}`` — ``ok`` with ``notes`` (+ optional
+        ``essay``), ``escalate`` with a ``reason``, or a structured refusal.
+    """
+    MCPAuditLog(vault_path).append(
+        tool=TOOL_NAME,
+        args={"has_entry_ref": entry_ref is not None},
+        tier_ceiling=privacy_tier_ceiling,
+        consumer=consumer,
+    )
+
+    entry = _resolve_entry(content, entry_ref, vault_path)
+    if not entry.strip():
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason="no entry content supplied",
+        )
+
+    if care_guard is not None:
+        reason = care_guard(entry)
+        if reason:
+            return {
+                "status": "escalate",
+                "tool": TOOL_NAME,
+                "tier_ceiling": privacy_tier_ceiling.value,
+                "reason": reason,
+            }
+
+    tier = _routing_tier(privacy_tier_ceiling)
+    override = to_privacy_override(privacy_tier_ceiling)
+    grounder = retrieve if retrieve is not None else _default_retrieve
+    grounding = grounder(entry, vault_path, override)
+
+    try:
+        llm = llm_factory(tier)
+        response_text = llm(_build_prompt(entry, grounding))
+    except (IntimateRoutingError, RuntimeError) as exc:
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason=f"reflection unavailable: {type(exc).__name__}",
+        )
+
+    raw_notes, essay = _parse_notes(response_text)
+    notes = _clean_notes(raw_notes, entry, max_notes=max_notes)
+    result: dict[str, Any] = {
+        "status": "ok" if notes else "empty",
+        "tool": TOOL_NAME,
+        "tier_ceiling": privacy_tier_ceiling.value,
+        "routed_tier": tier.value,
+        "notes": notes,
+    }
+    if essay is not None:
+        result["essay"] = essay
+    return result
+
+
+def _default_retrieve(query: str, vault_path: Path, override: object) -> list[str]:
+    """Production grounding: top corpus fragments related to *query*.
+
+    Lazily imports the author retrieval specialist so the server still boots
+    when its (heavier) deps are unavailable; any retrieval failure degrades to
+    no grounding rather than failing the reflection.
+    """
+    try:
+        from creek.author.agents import RetrievalSpecialist
+
+        bundle = RetrievalSpecialist().gather(query, vault_path, override=override)
+        return [claim.text for claim in bundle.claims]
+    except Exception:
+        return []

--- a/creek-tools/creek_mcp/tools/reflect.py
+++ b/creek-tools/creek_mcp/tools/reflect.py
@@ -15,7 +15,14 @@ Three guarantees this module enforces:
   ``_enforce_local_for_intimate`` chokepoint redirects an INTIMATE call to the
   local ``default`` model — or raises :class:`IntimateRoutingError` rather than
   egressing. This module never picks a provider or re-checks the tier itself; it
-  only derives the routing tier (failing closed to INTIMATE) and hands it over.
+  only derives the routing tier and hands it over. The routing tier is the
+  **more sensitive** of the entry's own classified ``privacy_tier`` (when it came
+  from a vault fragment via ``entry_ref``) and the ceiling-derived tier — so an
+  INTIMATE fragment routes local even under a low ceiling. Raw inline ``content``
+  carries no classification, so there the guarantee is bounded by the caller's
+  declared ceiling (a caller cannot mark intimate content ``open`` and also have
+  it treated as intimate without classifying it first). Both fail closed to
+  INTIMATE on anything unrecognised.
 - **Quotes are verbatim.** Every returned ``quote`` is validated to be a
   substring of the entry (whitespace-normalised). Model-supplied spans that are
   not are dropped — the client re-anchors verbatim quotes to character offsets
@@ -61,11 +68,6 @@ class _LLMFactory(Protocol):
         """Return an LLM callable routed for *tier* (may raise to refuse)."""
 
 
-# A retrieval callable: ``(query, vault, override) -> grounding snippets``.
-_Retrieve = "Callable[[str, Path, object], list[str]]"
-# A care guard: ``(entry_text) -> escalation reason or None``.
-_CareGuard = "Callable[[str], str | None]"
-
 # ``ALL`` admits intimate content, so a reflection under it must route as INTIMATE.
 _CEILING_ROUTING_TIER: dict[TierCeiling, PrivacyTier] = {
     TierCeiling.OPEN: PrivacyTier.OPEN,
@@ -74,15 +76,43 @@ _CEILING_ROUTING_TIER: dict[TierCeiling, PrivacyTier] = {
     TierCeiling.ALL: PrivacyTier.INTIMATE,
 }
 
+# Sensitivity rank for picking the more-restrictive of two tiers (mirrors the
+# canonical ranking in :mod:`creek_mcp.tier_ceiling`): open/unclassified < personal
+# < intimate. An unranked value is treated as the most sensitive (fail closed).
+_TIER_SENSITIVITY: dict[PrivacyTier, int] = {
+    PrivacyTier.OPEN: 0,
+    PrivacyTier.UNCLASSIFIED: 0,
+    PrivacyTier.PERSONAL: 1,
+    PrivacyTier.INTIMATE: 2,
+}
 
-def _routing_tier(ceiling: TierCeiling) -> PrivacyTier:
-    """Map a ceiling to the routing tier, failing closed to INTIMATE.
+
+def _sensitivity(tier: PrivacyTier) -> int:
+    """Return the routing sensitivity of *tier*, defaulting to the most restrictive."""
+    return _TIER_SENSITIVITY.get(tier, _TIER_SENSITIVITY[PrivacyTier.INTIMATE])
+
+
+def _routing_tier(ceiling: TierCeiling, entry_tier: PrivacyTier | None) -> PrivacyTier:
+    """Pick the routing tier — never below the entry's *actual* classification.
 
     The router's cloud gate keys on :class:`PrivacyTier`, never on
-    :class:`TierCeiling`, so the ceiling is translated to the most-sensitive
-    tier it admits. An unrecognised ceiling routes as INTIMATE (local-only).
+    :class:`TierCeiling`. Two signals are reconciled by taking the **more
+    sensitive**:
+
+    - *entry_tier* — the entry's own classified ``privacy_tier`` when it came
+      from a vault fragment (``None`` for raw inline ``content``, which carries
+      no classification). This is the load-bearing signal: an INTIMATE fragment
+      must route local even if the caller declared a lower ceiling.
+    - the *ceiling*-derived tier (its most-sensitive admitted tier), which is the
+      only signal available for raw ``content``.
+
+    Failing closed: an unrecognised ceiling, or an *entry_tier* outside the known
+    ranks, routes as INTIMATE (local-only).
     """
-    return _CEILING_ROUTING_TIER.get(ceiling, PrivacyTier.INTIMATE)
+    ceiling_tier = _CEILING_ROUTING_TIER.get(ceiling, PrivacyTier.INTIMATE)
+    if entry_tier is None:
+        return ceiling_tier
+    return max(ceiling_tier, entry_tier, key=_sensitivity)
 
 
 def _normalise(text: str) -> str:
@@ -106,6 +136,8 @@ def _parse_notes(response_text: str) -> tuple[list[dict[str, Any]], str | None]:
     """
     import json
 
+    import yaml
+
     text = response_text.strip()
     if text.startswith("```"):
         lines = text.splitlines()
@@ -115,10 +147,11 @@ def _parse_notes(response_text: str) -> tuple[list[dict[str, Any]], str | None]:
         data = json.loads(text)
     except (ValueError, TypeError):
         try:
-            import yaml
-
             data = yaml.safe_load(text)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, yaml.YAMLError):
+            # ``yaml.YAMLError`` (ScannerError/ParserError) is NOT a ValueError,
+            # so it must be caught explicitly or malformed YAML would crash the
+            # tool across the MCP boundary, breaking the never-raises contract.
             return [], None
     if not isinstance(data, dict):
         return [], None
@@ -175,15 +208,37 @@ def _build_prompt(entry: str, grounding: list[str]) -> str:
     )
 
 
-def _resolve_entry(content: str | None, entry_ref: str | None, vault_path: Path) -> str:
-    """Return the entry text from raw *content* or a fragment *entry_ref*.
+def _fragment_tier(metadata: dict[str, Any]) -> PrivacyTier:
+    """Return a fragment's classified ``privacy_tier``, failing closed to INTIMATE.
 
-    ``entry_ref`` is resolved to a fragment markdown file under ``01-Fragments``;
-    its body becomes the entry. A blank result (no usable source) yields ``""``,
-    which the caller turns into a refusal.
+    Mirrors :func:`creek.classify.privacy_filter.tier_of`: a recognised value
+    (including ``unclassified``) is honoured; anything unrecognised — or a
+    missing field — is treated as the most-restrictive tier so an unknown
+    classification is never routed to a cloud provider.
+    """
+    raw = metadata.get("privacy_tier")
+    if raw is None:
+        return PrivacyTier.INTIMATE
+    try:
+        return PrivacyTier(str(raw))
+    except ValueError:
+        return PrivacyTier.INTIMATE
+
+
+def _resolve_entry(
+    content: str | None, entry_ref: str | None, vault_path: Path
+) -> tuple[str, PrivacyTier | None]:
+    """Return the entry text plus its *classified* tier (``None`` for raw content).
+
+    Raw *content* carries no classification, so its tier is ``None`` and the
+    caller falls back to the ceiling. An *entry_ref* is resolved to a fragment
+    markdown file under ``01-Fragments``; its body becomes the entry **and its
+    persisted ``privacy_tier`` becomes the routing tier** — this is what stops an
+    INTIMATE fragment being reflected through a cloud model under a low ceiling.
+    A blank result yields ``("", None)``, which the caller turns into a refusal.
     """
     if content and content.strip():
-        return content
+        return content, None
     if entry_ref:
         import frontmatter
 
@@ -191,8 +246,8 @@ def _resolve_entry(content: str | None, entry_ref: str | None, vault_path: Path)
             post = frontmatter.load(path)
             if str(post.metadata.get("id", "")) == entry_ref:
                 body: str = post.content
-                return body
-    return ""
+                return body, _fragment_tier(post.metadata)
+    return "", None
 
 
 def reflect_tool(
@@ -237,25 +292,24 @@ def reflect_tool(
         consumer=consumer,
     )
 
-    entry = _resolve_entry(content, entry_ref, vault_path)
+    entry, entry_tier = _resolve_entry(content, entry_ref, vault_path)
     if not entry.strip():
+        reason = "entry_ref not found" if entry_ref else "no entry content supplied"
         return refusal_response(
-            tool=TOOL_NAME,
-            ceiling=privacy_tier_ceiling,
-            reason="no entry content supplied",
+            tool=TOOL_NAME, ceiling=privacy_tier_ceiling, reason=reason
         )
 
     if care_guard is not None:
-        reason = care_guard(entry)
-        if reason:
+        care_reason = care_guard(entry)
+        if care_reason:
             return {
                 "status": "escalate",
                 "tool": TOOL_NAME,
                 "tier_ceiling": privacy_tier_ceiling.value,
-                "reason": reason,
+                "reason": care_reason,
             }
 
-    tier = _routing_tier(privacy_tier_ceiling)
+    tier = _routing_tier(privacy_tier_ceiling, entry_tier)
     override = to_privacy_override(privacy_tier_ceiling)
     grounder = retrieve if retrieve is not None else _default_retrieve
     grounding = grounder(entry, vault_path, override)

--- a/creek-tools/creek_mcp/tools/reflect.py
+++ b/creek-tools/creek_mcp/tools/reflect.py
@@ -39,7 +39,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Protocol
 
-from creek.classify.llm.router import IntimateRoutingError
 from creek.models import PrivacyTier
 from creek_mcp.audit import MCPAuditLog
 from creek_mcp.tier_ceiling import TierCeiling, refusal_response, to_privacy_override
@@ -317,7 +316,10 @@ def reflect_tool(
     try:
         llm = llm_factory(tier)
         response_text = llm(_build_prompt(entry, grounding))
-    except (IntimateRoutingError, RuntimeError) as exc:
+    except RuntimeError as exc:
+        # Covers a missing/unavailable provider AND ``IntimateRoutingError``
+        # (a RuntimeError subclass) — the router raises the latter rather than
+        # egressing intimate content when no local backend exists.
         return refusal_response(
             tool=TOOL_NAME,
             ceiling=privacy_tier_ceiling,

--- a/creek-tools/tests/test_mcp_reflect.py
+++ b/creek-tools/tests/test_mcp_reflect.py
@@ -116,6 +116,19 @@ def test_open_ceiling_requests_the_open_tier(tmp_path: Path) -> None:
     assert factory.asked_tier is PrivacyTier.OPEN
 
 
+def test_personal_ceiling_requests_the_personal_tier(tmp_path: Path) -> None:
+    """A PERSONAL ceiling routes at the PERSONAL tier (pins the middle mapping)."""
+    factory = _RecordingFactory(_notes_payload())
+    reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert factory.asked_tier is PrivacyTier.PERSONAL
+
+
 def test_all_ceiling_fails_closed_to_intimate_routing(tmp_path: Path) -> None:
     """``ALL`` admits intimate content, so routing must fail closed to INTIMATE."""
     factory = _RecordingFactory(_notes_payload())

--- a/creek-tools/tests/test_mcp_reflect.py
+++ b/creek-tools/tests/test_mcp_reflect.py
@@ -359,3 +359,56 @@ def test_unparseable_response_yields_no_notes(tmp_path: Path) -> None:
         privacy_tier_ceiling=TierCeiling.OPEN,
     )
     assert result["notes"] == []
+
+
+def test_entry_ref_intimate_fragment_routes_local_despite_open_ceiling(
+    tmp_path: Path,
+) -> None:
+    """An INTIMATE fragment routes at INTIMATE even under an OPEN ceiling (#751 review).
+
+    The routing tier follows the entry's *actual* classified ``privacy_tier``,
+    never the (possibly lower) caller-declared ceiling — so genuinely intimate
+    journal content can never be reflected through a cloud model.
+    """
+    vault = _vault(tmp_path)
+    frag_dir = vault / "01-Fragments" / "Notes"
+    frag_dir.mkdir(parents=True)
+    body = "the garden grew while I slept"
+    (frag_dir / "f.md").write_text(
+        f"---\nid: frag-intimate\nprivacy_tier: intimate\n---\n{body}\n",
+        encoding="utf-8",
+    )
+    factory = _RecordingFactory(_notes_payload())
+    reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-intimate",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert factory.asked_tier is PrivacyTier.INTIMATE
+
+
+def test_malformed_yaml_response_does_not_crash(tmp_path: Path) -> None:
+    """A non-JSON, non-YAML response degrades to no notes (catches YAMLError)."""
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=_RecordingFactory("{notes: [oops, unbalanced"),
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["notes"] == []
+
+
+def test_entry_ref_not_found_has_a_distinct_reason(tmp_path: Path) -> None:
+    """A missing ``entry_ref`` refuses with a debuggable, distinct reason."""
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        entry_ref="does-not-exist",
+        llm_factory=_RecordingFactory(_notes_payload()),
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "refused"
+    assert result["reason"] == "entry_ref not found"

--- a/creek-tools/tests/test_mcp_reflect.py
+++ b/creek-tools/tests/test_mcp_reflect.py
@@ -1,0 +1,361 @@
+"""``creek.reflect`` MCP tool — anchored Higher-Self margin notes (#751).
+
+The tool takes one journal entry plus a privacy-tier ceiling and returns
+``{notes: [{quote, kind, note}], essay?}`` grounded in the user's corpus. The
+contract this suite pins, in order of stakes:
+
+1. **INTIMATE never egresses** — the LLM callable is obtained from a tier-keyed
+   factory; an INTIMATE entry must request the factory with
+   ``PrivacyTier.INTIMATE`` (the router then forces local), and an
+   ``IntimateRoutingError`` must surface as a structured refusal, never a crash
+   or a cloud call.
+2. **Quotes are verbatim** — every returned ``quote`` is a substring of the
+   input; model-supplied spans that are not are dropped, never trusted.
+3. Corpus-grounded retrieval, audit logging, read-only wrt the corpus, clean
+   degradation with no provider, and the care seam (#753).
+
+The LLM and retrieval are injected — no live calls.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from creek.classify.llm.router import IntimateRoutingError
+from creek.models import PrivacyTier
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.reflect import TOOL_NAME, reflect_tool
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_ENTRY = (
+    "I keep circling the same fear: that if I rest, everything I built quietly "
+    "falls apart. But today I noticed the garden grew while I slept."
+)
+
+
+class _RecordingFactory:
+    """A tier-keyed LLM factory that records the tier it was asked for.
+
+    Mirrors the production factory's shape ``(PrivacyTier) -> (str) -> str`` so
+    a test can assert which tier drove routing without a live provider.
+    """
+
+    def __init__(self, response: str) -> None:
+        """Store the canned LLM response and init the recorded tier."""
+        self.response = response
+        self.asked_tier: PrivacyTier | None = None
+
+    def __call__(self, tier: PrivacyTier):
+        """Record *tier* and return a constant LLM callable."""
+        self.asked_tier = tier
+        return lambda prompt: self.response
+
+
+def _notes_payload(*notes: dict[str, str], essay: str | None = None) -> str:
+    """Render an LLM JSON response carrying *notes* (and an optional essay)."""
+    payload: dict[str, Any] = {"notes": list(notes)}
+    if essay is not None:
+        payload["essay"] = essay
+    return json.dumps(payload)
+
+
+def _vault(tmp_path: Path) -> Path:
+    """Create a minimal Creek vault dir."""
+    vault = tmp_path / "vault"
+    (vault / "00-Creek-Meta").mkdir(parents=True)
+    return vault
+
+
+def _no_retrieval(query: str, vault: Path, override: object) -> list[str]:
+    """A retrieval stub returning no grounding fragments."""
+    del query, vault, override
+    return []
+
+
+def _audit(vault: Path) -> list[dict[str, object]]:
+    """Return parsed MCP audit-log entries under *vault*."""
+    log = vault / MCP_AUDIT_RELPATH
+    assert log.exists()
+    return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
+# --- 1. INTIMATE-never-cloud routing -------------------------------------------------
+
+
+def test_intimate_ceiling_requests_the_intimate_tier_from_the_factory(
+    tmp_path: Path,
+) -> None:
+    """An INTIMATE ceiling must drive the factory with ``PrivacyTier.INTIMATE``."""
+    factory = _RecordingFactory(
+        _notes_payload({"quote": "I rest", "kind": "fear", "note": "ok"})
+    )
+    reflect_tool(
+        vault_path=_vault(tmp_path),
+        content="I rest sometimes.",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.INTIMATE,
+    )
+    assert factory.asked_tier is PrivacyTier.INTIMATE
+
+
+def test_open_ceiling_requests_the_open_tier(tmp_path: Path) -> None:
+    """An OPEN ceiling routes at the OPEN tier (cloud allowed)."""
+    factory = _RecordingFactory(_notes_payload())
+    reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert factory.asked_tier is PrivacyTier.OPEN
+
+
+def test_all_ceiling_fails_closed_to_intimate_routing(tmp_path: Path) -> None:
+    """``ALL`` admits intimate content, so routing must fail closed to INTIMATE."""
+    factory = _RecordingFactory(_notes_payload())
+    reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert factory.asked_tier is PrivacyTier.INTIMATE
+
+
+def test_intimate_routing_error_becomes_a_refusal_not_a_crash(tmp_path: Path) -> None:
+    """If the router refuses to route INTIMATE locally, reflect refuses cleanly."""
+
+    def _raising_factory(tier: PrivacyTier):
+        raise IntimateRoutingError("default is cloud")
+
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content="something tender",
+        llm_factory=_raising_factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.INTIMATE,
+    )
+    assert result["status"] == "refused"
+    assert result["tool"] == TOOL_NAME
+
+
+# --- 2. Verbatim-quote validation ----------------------------------------------------
+
+
+def test_only_verbatim_quotes_survive(tmp_path: Path) -> None:
+    """A note whose quote is not a substring of the entry is dropped."""
+    factory = _RecordingFactory(
+        _notes_payload(
+            {
+                "quote": "the garden grew while I slept",
+                "kind": "reframe",
+                "note": "yours",
+            },
+            {"quote": "a line the model invented", "kind": "reframe", "note": "nope"},
+        )
+    )
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    quotes = [n["quote"] for n in result["notes"]]
+    assert "the garden grew while I slept" in quotes
+    assert "a line the model invented" not in quotes
+
+
+def test_note_shape_is_quote_kind_note(tmp_path: Path) -> None:
+    """Each surviving note exposes exactly the contracted keys."""
+    factory = _RecordingFactory(
+        _notes_payload(
+            {"quote": "the garden grew while I slept", "kind": "reframe", "note": "y"}
+        )
+    )
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    note = result["notes"][0]
+    assert set(note) == {"quote", "kind", "note"}
+
+
+def test_no_verbatim_notes_yields_empty_status(tmp_path: Path) -> None:
+    """If every quote is hallucinated, the tool returns no notes (not garbage)."""
+    factory = _RecordingFactory(
+        _notes_payload({"quote": "entirely invented", "kind": "x", "note": "y"})
+    )
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["notes"] == []
+
+
+# --- 3. Grounding, audit, care, degradation ------------------------------------------
+
+
+def test_retrieval_is_grounded_in_the_entry_and_ceiling(tmp_path: Path) -> None:
+    """Retrieval is called with the entry text and a ceiling-derived override."""
+    seen: dict[str, object] = {}
+
+    def _recording_retrieve(query: str, vault: Path, override: object) -> list[str]:
+        seen["query"] = query
+        seen["override"] = override
+        return ["a related fragment"]
+
+    factory = _RecordingFactory(_notes_payload())
+    reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=factory,
+        retrieve=_recording_retrieve,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert seen["query"] == _ENTRY
+    assert seen["override"] is not None
+
+
+def test_reflect_is_audit_logged(tmp_path: Path) -> None:
+    """The call appends one audit entry tagged with the tool + consumer."""
+    vault = _vault(tmp_path)
+    reflect_tool(
+        vault_path=vault,
+        content=_ENTRY,
+        llm_factory=_RecordingFactory(_notes_payload()),
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="adepthood",
+    )
+    last = _audit(vault)[-1]
+    assert last["tool"] == TOOL_NAME
+    assert last["consumer"] == "adepthood"
+
+
+def test_care_guard_escalation_skips_the_llm(tmp_path: Path) -> None:
+    """When the care guard flags the entry, reflect escalates and skips the LLM."""
+    factory = _RecordingFactory(_notes_payload())
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content="a hard entry",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        care_guard=lambda text: "crisis markers present",
+    )
+    assert result["status"] == "escalate"
+    assert "reason" in result
+    assert factory.asked_tier is None  # the LLM was never reached
+
+
+def test_empty_content_is_refused(tmp_path: Path) -> None:
+    """No content and no entry_ref is a structured refusal, not a crash."""
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content="   ",
+        llm_factory=_RecordingFactory(_notes_payload()),
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] in {"refused", "empty"}
+
+
+def test_reflect_is_read_only_wrt_corpus(tmp_path: Path) -> None:
+    """Only the audit log is written; no fragments are created."""
+    vault = _vault(tmp_path)
+    before = {p for p in vault.rglob("*") if p.is_file()}
+    reflect_tool(
+        vault_path=vault,
+        content=_ENTRY,
+        llm_factory=_RecordingFactory(_notes_payload()),
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    created = {p for p in vault.rglob("*") if p.is_file()} - before
+    assert all("audit" in str(p) for p in created)
+
+
+def test_entry_ref_resolves_a_fragment_body(tmp_path: Path) -> None:
+    """An ``entry_ref`` loads the fragment's body as the entry to reflect on."""
+    vault = _vault(tmp_path)
+    frag_dir = vault / "01-Fragments" / "Notes"
+    frag_dir.mkdir(parents=True)
+    body = "the garden grew while I slept"
+    (frag_dir / "f.md").write_text(
+        f"---\nid: frag-xyz\n---\n{body}\n", encoding="utf-8"
+    )
+    factory = _RecordingFactory(
+        _notes_payload({"quote": body, "kind": "reframe", "note": "yours"})
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-xyz",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    assert result["notes"][0]["quote"] == body
+
+
+def test_fenced_json_response_is_parsed(tmp_path: Path) -> None:
+    """A response wrapped in a ```json fence is unwrapped and parsed."""
+    inner = _notes_payload(
+        {"quote": "the garden grew while I slept", "kind": "reframe", "note": "y"}
+    )
+    factory = _RecordingFactory(f"```json\n{inner}\n```")
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+
+
+def test_yaml_response_falls_back_from_json(tmp_path: Path) -> None:
+    """A non-JSON but valid-YAML response is parsed via the YAML fallback + essay."""
+    yaml_text = (
+        "notes:\n"
+        "  - quote: the garden grew while I slept\n"
+        "    kind: reframe\n"
+        "    note: a gentle truth\n"
+        "essay: A short reflection.\n"
+    )
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=_RecordingFactory(yaml_text),
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    assert result["essay"] == "A short reflection."
+
+
+def test_unparseable_response_yields_no_notes(tmp_path: Path) -> None:
+    """A response that is neither JSON nor a YAML mapping degrades to no notes."""
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=_RecordingFactory("- just\n- a\n- list"),
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["notes"] == []

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 EXPECTED_TOOLS = {
     "creek.handshake",
+    "creek.reflect",
     "creek.state.read",
     "creek.state.render",
     "creek.lint",
@@ -105,6 +106,33 @@ def test_call_tool_handshake_reflects_registered_tools(vault: Path) -> None:
     assert set(structured["capabilities"]) == registered  # type: ignore[arg-type]
     for expected in ("creek.handshake", "creek.ingest", "creek.classify"):
         assert expected in structured["capabilities"]  # type: ignore[operator]
+
+
+def test_call_tool_reflect_returns_verbatim_notes(vault: Path) -> None:
+    """End-to-end: ``creek.reflect`` returns verbatim-quoted notes (injected factory).
+
+    The tier-keyed LLM factory is injected (no live provider); the registered
+    tool wires it through ``reflect_tool``, whose verbatim-quote guard keeps only
+    spans copied from the entry.
+    """
+    entry = "I rest sometimes and the work survives."
+    note = '{"quote": "I rest sometimes", "kind": "reframe", "note": "Yours."}'
+    payload = '{"notes": [' + note + "]}"
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+        reflect_llm_factory=lambda: lambda tier: lambda prompt: payload,
+    )
+    result = asyncio.run(
+        server.call_tool(
+            "creek.reflect",
+            {"content": entry, "privacy_tier_ceiling": "open"},
+        ),
+    )
+    structured = _structured(result)
+    assert structured["status"] == "ok"
+    assert structured["tool"] == "creek.reflect"
+    assert structured["notes"][0]["quote"] == "I rest sometimes"  # type: ignore[index]
 
 
 def test_call_tool_save_through_mcp(vault: Path) -> None:
@@ -400,3 +428,56 @@ def test_main_without_config_flag_leaves_env_var_untouched(
     server_module.main([])
 
     assert CONFIG_PATH_ENV_VAR not in os.environ
+
+
+def test_build_reflect_llm_factory_routes_then_degrades(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The reflect factory returns a working callable, and raises when no provider.
+
+    Exercises the production INTIMATE-routing seam without a live model: the
+    router + provider are stubbed so both the available path (a usable callable)
+    and the unavailable path (a clean ``RuntimeError`` the tool turns into a
+    refusal) are covered.
+    """
+    from creek.models import PrivacyTier
+    from creek_mcp import server as server_mod
+
+    class _Cfg:
+        provider = "ollama"
+        model = "m"
+
+    class _Router:
+        def resolve(self, stage: str, tier: object) -> _Cfg:
+            return _Cfg()
+
+    class _Config:
+        model_router = _Router()
+
+    monkeypatch.setattr(server_mod, "load_config", lambda: _Config())
+
+    class _Completion:
+        text = "reflected"
+
+    class _Provider:
+        available = True
+
+        def complete(self, prompt: str) -> _Completion:
+            return _Completion()
+
+    monkeypatch.setattr(
+        "creek.classify.llm.providers.build_provider",
+        lambda cfg: _Provider(),
+    )
+    factory = server_mod._build_reflect_llm_factory()
+    assert factory(PrivacyTier.OPEN)("p") == "reflected"
+
+    class _Unavailable:
+        available = False
+
+    monkeypatch.setattr(
+        "creek.classify.llm.providers.build_provider",
+        lambda cfg: _Unavailable(),
+    )
+    with pytest.raises(RuntimeError):
+        server_mod._build_reflect_llm_factory()(PrivacyTier.OPEN)


### PR DESCRIPTION
## Summary

Adds a read-only **`creek.reflect`** MCP tool — the reflection surface Adepthood's journal needs. It takes one journal entry (raw `content` or an `entry_ref` fragment id) + a privacy-tier ceiling and returns `{notes: [{quote, kind, note}], essay?}`: warm, second-person, anti-guru notes that mirror the user's own wisdom, grounded in retrieval over their corpus. Distinct from the essay-shaped `draft`/`author`/`mine`.

Part of epic #748.

## Three guarantees (the security-critical core)

1. **INTIMATE never egresses.** The LLM is obtained from a *tier-keyed factory* `llm_factory(tier)`. The production factory (`_build_reflect_llm_factory`) resolves the `generation` stage through the config's `ModelRouter`, whose `_enforce_local_for_intimate` chokepoint forces an INTIMATE call onto the local `default` — or raises `IntimateRoutingError`, which the tool turns into a structured refusal rather than a crash or a cloud call. The tool **derives the routing tier from the ceiling, failing closed to INTIMATE** (`ALL → INTIMATE`); it never hand-picks a provider or re-checks the tier. Tested with a recording factory asserting the exact tier per ceiling, plus the refusal path.
2. **Quotes are verbatim.** Every returned `quote` is validated as a whitespace-normalised substring of the entry; model-invented spans are dropped. So the client can re-anchor verbatim quotes to character offsets itself (mirrors `adepthood#953`) and a hallucinated span never reaches it.
3. **Care boundary (#753).** An injectable `care_guard` seam escalates (and skips the model) when it flags the entry — wired now; the real guard lands in #753 per "coordinate with the care-guardrail issue".

Also: read-only wrt the corpus, audit-logged like every tool, and degrades to a clean refusal when no provider is available (server still boots).

## Files

- `creek_mcp/tools/reflect.py` — the tool: tier derivation, ceiling→override for retrieval admission, verbatim-quote validation, fenced-JSON/YAML parse with safe degradation, care seam, audit, refusals.
- `creek_mcp/server.py` — registers `creek.reflect` + the lazy production tier-keyed factory; new `reflect_llm_factory` build_server param for injection.
- `creek_mcp/tools/__init__.py` — export.

## Test plan (TDD, no live calls)

- `tests/test_mcp_reflect.py` (16): tier-per-ceiling routing (OPEN/INTIMATE/ALL→INTIMATE), `IntimateRoutingError`→refused, verbatim drop vs keep + empty-on-all-hallucinated, note shape, grounding query+override, audit w/ consumer, care escalation skips the LLM, empty-content refusal, read-only, `entry_ref` fragment resolution, fenced-JSON + YAML-fallback + unparseable parsing.
- `tests/test_mcp_server.py`: `creek.reflect` in `EXPECTED_TOOLS`; `call_tool` end-to-end returning verbatim notes; `_build_reflect_llm_factory` route-then-degrade (router + provider stubbed).
- Coverage: `reflect.py` 89.8%, `server.py` 86.3% (both > 80% gate). ruff / refurb / mypy --strict clean.
- `./scripts/check-all.sh`: all gates pass except the unit-test/coverage step, whose only failures are the 8 pre-existing author-desk environmental tests (green in CI).

Closes #751
Refs #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)