### PR TITLE
feat(mcp): creek.wheel — per-frequency balance read for the Map (#752)

### DIFF
--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -43,6 +43,7 @@ from creek_mcp.tools import (
     skills_refresh_tool,
     state_read_tool,
     state_render_tool,
+    wheel_tool,
 )
 from creek_mcp.tools.draft import draft_tool
 
@@ -185,6 +186,17 @@ def build_server(
             llm_factory=reflect_factory(),
             content=content,
             entry_ref=entry_ref,
+            privacy_tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.wheel")
+    def _wheel(
+        privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    ) -> dict[str, Any]:
+        """Return a per-frequency balance read of the corpus for the Map."""
+        return wheel_tool(
+            vault_path=vault,
             privacy_tier_ceiling=privacy_tier_ceiling,
             consumer=consumer,
         )

--- a/creek-tools/creek_mcp/tools/__init__.py
+++ b/creek-tools/creek_mcp/tools/__init__.py
@@ -23,6 +23,7 @@ from creek_mcp.tools.save import save_tool
 from creek_mcp.tools.skills import skills_refresh_tool
 from creek_mcp.tools.state import state_render_tool
 from creek_mcp.tools.state_read import state_read_tool
+from creek_mcp.tools.wheel import wheel_tool
 
 __all__ = [
     "author_tool",
@@ -46,4 +47,5 @@ __all__ = [
     "skills_refresh_tool",
     "state_read_tool",
     "state_render_tool",
+    "wheel_tool",
 ]

--- a/creek-tools/creek_mcp/tools/wheel.py
+++ b/creek-tools/creek_mcp/tools/wheel.py
@@ -1,0 +1,110 @@
+"""``creek.wheel`` MCP tool — per-frequency balance read for the Map (#752).
+
+Exposes a *balance-shaped* read of the classified corpus: how full or thin each
+APTITUDE frequency is, so Adepthood's Map can render the wheel of wholeness
+rather than a linear ladder. Every frequency F1-F10 is always present (thin ones
+at zero) and each carries a normalised ``share`` so the client can draw balance,
+not ranking.
+
+Read-only and LLM-free. The ``privacy_tier_ceiling`` is enforced for real (unlike
+``creek.report``): above-ceiling fragments are excluded from the tally via
+``tier_within_override``. An empty (new-user) vault yields a complete all-zero
+wheel with no special-casing — :func:`iter_vault_fragments` returns ``[]`` for a
+missing directory.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from typing import TYPE_CHECKING, Any
+
+from creek.classify.privacy_filter import tier_within_override
+from creek.generate.indexes import CANONICAL_FREQUENCY_NAMES
+from creek.models import Frequency
+from creek.vault.reader import iter_vault_fragments
+from creek_mcp.audit import MCPAuditLog
+from creek_mcp.tier_ceiling import TierCeiling, to_privacy_override
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from creek.classify.privacy_filter import PrivacyTierOverride
+
+TOOL_NAME = "creek.wheel"
+_FRAGMENTS_SUBDIR = "01-Fragments"
+
+
+def _frequency_counts(
+    vault_path: Path, override: PrivacyTierOverride
+) -> Counter[Frequency]:
+    """Tally fragments by primary frequency, excluding above-ceiling content.
+
+    ``Fragment.frequency.primary`` is a bare string at runtime
+    (``use_enum_values=True``), so it is coerced back to :class:`Frequency`;
+    anything unrecognised falls into :attr:`Frequency.UNCLASSIFIED` (fail closed
+    to "not a real frequency" rather than guessing a bucket).
+    """
+    counts: Counter[Frequency] = Counter()
+    for _path, fragment, _body, _meta in iter_vault_fragments(
+        vault_path / _FRAGMENTS_SUBDIR
+    ):
+        if not tier_within_override(fragment.privacy_tier, override):
+            continue
+        try:
+            freq = Frequency(fragment.frequency.primary)
+        except ValueError:
+            freq = Frequency.UNCLASSIFIED
+        counts[freq] += 1
+    return counts
+
+
+def wheel_tool(
+    *,
+    vault_path: Path,
+    privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Return a per-frequency balance map over the (ceiling-filtered) corpus.
+
+    Args:
+        vault_path: Vault root.
+        privacy_tier_ceiling: Admission ceiling — fragments above it are excluded
+            from the tally.
+        consumer: Free-form consumer id for the audit log.
+
+    Returns:
+        ``{status, tool, tier_ceiling, total_classified, unclassified, wheel}``
+        where ``wheel`` is an ordered ``{F1..F10: {name, count, share}}`` map.
+        ``share`` is the fraction of *classified* fragments at that frequency
+        (``0.0`` for every frequency when the corpus is empty).
+    """
+    MCPAuditLog(vault_path).append(
+        tool=TOOL_NAME,
+        args={},
+        tier_ceiling=privacy_tier_ceiling,
+        consumer=consumer,
+        created_path=None,
+        created_tier=None,
+        affected_fragment_ids=[],
+    )
+
+    override = to_privacy_override(privacy_tier_ceiling)
+    counts = _frequency_counts(vault_path, override)
+    classified = sum(counts.get(code, 0) for code in CANONICAL_FREQUENCY_NAMES)
+
+    wheel = {
+        code.value: {
+            "name": CANONICAL_FREQUENCY_NAMES[code],
+            "count": counts.get(code, 0),
+            "share": (counts.get(code, 0) / classified) if classified else 0.0,
+        }
+        for code in CANONICAL_FREQUENCY_NAMES
+    }
+    return {
+        "status": "ok",
+        "tool": TOOL_NAME,
+        "tier_ceiling": privacy_tier_ceiling.value,
+        "total_classified": classified,
+        "unclassified": counts.get(Frequency.UNCLASSIFIED, 0),
+        "wheel": wheel,
+    }

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 EXPECTED_TOOLS = {
     "creek.handshake",
     "creek.reflect",
+    "creek.wheel",
     "creek.state.read",
     "creek.state.render",
     "creek.lint",
@@ -133,6 +134,26 @@ def test_call_tool_reflect_returns_verbatim_notes(vault: Path) -> None:
     assert structured["status"] == "ok"
     assert structured["tool"] == "creek.reflect"
     assert structured["notes"][0]["quote"] == "I rest sometimes"  # type: ignore[index]
+
+
+def test_call_tool_wheel_returns_complete_frequency_balance(vault: Path) -> None:
+    """End-to-end: ``creek.wheel`` returns a complete F1-F10 balance map.
+
+    Even with an empty corpus the wheel is present and all-zero (the new-user
+    case), proving the read-only aggregation is reachable through the registry.
+    """
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    result = asyncio.run(
+        server.call_tool("creek.wheel", {"privacy_tier_ceiling": "open"}),
+    )
+    structured = _structured(result)
+    assert structured["status"] == "ok"
+    assert structured["tool"] == "creek.wheel"
+    assert list(structured["wheel"].keys()) == [f"F{n}" for n in range(1, 11)]  # type: ignore[union-attr]
+    assert structured["total_classified"] == 0
 
 
 def test_call_tool_save_through_mcp(vault: Path) -> None:

--- a/creek-tools/tests/test_mcp_wheel.py
+++ b/creek-tools/tests/test_mcp_wheel.py
@@ -1,0 +1,156 @@
+"""``creek.wheel`` MCP tool — per-frequency balance read for the Map (#752).
+
+Returns a per-frequency fullness map over the classified corpus — every
+frequency F1-F10 present (thin ones at zero), framed as **balance, not
+ranking**. Deterministic, ceiling-filtered, audit-logged, read-only, and
+graceful on an empty (new-user) vault.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.wheel import TOOL_NAME, wheel_tool
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_ALL_CODES = [f"F{n}" for n in range(1, 11)]
+
+
+def _seed_dirs(vault: Path) -> None:
+    """Create the folders the loader + audit log expect."""
+    for sub in ("00-Creek-Meta/audit", "01-Fragments/Notes"):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+
+
+def _write_fragment(
+    vault: Path,
+    *,
+    frag_id: str,
+    primary: str = "F1",
+    privacy_tier: str = "open",
+) -> None:
+    """Write a minimal classified fragment under ``01-Fragments/Notes``."""
+    metadata = {
+        "type": "fragment",
+        "id": frag_id,
+        "title": "Note",
+        "created": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "ingested": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": primary, "secondary": []},
+        "privacy_tier": privacy_tier,
+        "eddies": [],
+    }
+    target = vault / "01-Fragments" / "Notes" / f"{frag_id}.md"
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content="body text", **metadata)),
+        encoding="utf-8",
+    )
+
+
+def _audit(vault: Path) -> list[dict[str, object]]:
+    """Return parsed MCP audit-log entries under *vault*."""
+    log = vault / MCP_AUDIT_RELPATH
+    assert log.exists()
+    return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
+def test_wheel_includes_every_frequency_even_thin_ones(tmp_path: Path) -> None:
+    """All F1-F10 appear; a frequency with no fragments is present at zero."""
+    _seed_dirs(tmp_path)
+    _write_fragment(tmp_path, frag_id="a", primary="F1")
+    _write_fragment(tmp_path, frag_id="b", primary="F1")
+    _write_fragment(tmp_path, frag_id="c", primary="F3")
+
+    result = wheel_tool(vault_path=tmp_path)
+
+    assert result["status"] == "ok"
+    assert result["tool"] == TOOL_NAME
+    assert list(result["wheel"].keys()) == _ALL_CODES  # complete + ordered F1→F10
+    assert result["wheel"]["F1"]["count"] == 2
+    assert result["wheel"]["F3"]["count"] == 1
+    assert result["wheel"]["F7"]["count"] == 0  # thin frequency still present
+    assert result["wheel"]["F1"]["name"] == "Agency"
+
+
+def test_wheel_shares_are_balance_fractions(tmp_path: Path) -> None:
+    """``share`` is a normalised balance fraction over the classified total."""
+    _seed_dirs(tmp_path)
+    _write_fragment(tmp_path, frag_id="a", primary="F1")
+    _write_fragment(tmp_path, frag_id="b", primary="F1")
+    _write_fragment(tmp_path, frag_id="c", primary="F5")
+
+    wheel = wheel_tool(vault_path=tmp_path)["wheel"]
+
+    assert wheel["F1"]["share"] == 2 / 3
+    assert wheel["F5"]["share"] == 1 / 3
+    assert wheel["F2"]["share"] == 0.0
+    assert sum(cell["share"] for cell in wheel.values()) == 1.0
+
+
+def test_empty_vault_yields_all_zeros(tmp_path: Path) -> None:
+    """A new-user vault returns a complete all-zero wheel, not an error."""
+    _seed_dirs(tmp_path)
+    result = wheel_tool(vault_path=tmp_path)
+    assert result["status"] == "ok"
+    assert result["total_classified"] == 0
+    assert list(result["wheel"].keys()) == _ALL_CODES
+    assert all(
+        cell["count"] == 0 and cell["share"] == 0.0 for cell in result["wheel"].values()
+    )
+
+
+def test_ceiling_excludes_above_ceiling_fragments(tmp_path: Path) -> None:
+    """An INTIMATE fragment is counted only when the ceiling admits it."""
+    _seed_dirs(tmp_path)
+    _write_fragment(tmp_path, frag_id="open", primary="F1", privacy_tier="open")
+    _write_fragment(tmp_path, frag_id="intimate", primary="F8", privacy_tier="intimate")
+
+    open_wheel = wheel_tool(vault_path=tmp_path, privacy_tier_ceiling=TierCeiling.OPEN)
+    assert open_wheel["wheel"]["F8"]["count"] == 0  # intimate excluded under OPEN
+    assert open_wheel["total_classified"] == 1
+
+    full_wheel = wheel_tool(
+        vault_path=tmp_path, privacy_tier_ceiling=TierCeiling.INTIMATE
+    )
+    assert full_wheel["wheel"]["F8"]["count"] == 1  # admitted under INTIMATE
+    assert full_wheel["total_classified"] == 2
+
+
+def test_unclassified_fragments_are_counted_separately(tmp_path: Path) -> None:
+    """An unclassified fragment lands in ``unclassified``, not in any F bucket."""
+    _seed_dirs(tmp_path)
+    _write_fragment(tmp_path, frag_id="a", primary="F1")
+    _write_fragment(tmp_path, frag_id="u", primary="unclassified")
+
+    result = wheel_tool(vault_path=tmp_path)
+    assert result["unclassified"] == 1
+    assert result["total_classified"] == 1
+    assert sum(cell["count"] for cell in result["wheel"].values()) == 1
+
+
+def test_wheel_is_audit_logged(tmp_path: Path) -> None:
+    """The read is audit-logged with the tool name and consumer."""
+    _seed_dirs(tmp_path)
+    wheel_tool(vault_path=tmp_path, consumer="adepthood")
+    last = _audit(tmp_path)[-1]
+    assert last["tool"] == TOOL_NAME
+    assert last["consumer"] == "adepthood"
+
+
+def test_wheel_is_read_only(tmp_path: Path) -> None:
+    """Only the audit log is written; the corpus is untouched."""
+    _seed_dirs(tmp_path)
+    _write_fragment(tmp_path, frag_id="a", primary="F2")
+    before = {p for p in tmp_path.rglob("*") if p.is_file()}
+    wheel_tool(vault_path=tmp_path)
+    created = {p for p in tmp_path.rglob("*") if p.is_file()} - before
+    assert all("audit" in str(p) for p in created)


### PR DESCRIPTION
## Summary

Adds a read-only, LLM-free **`creek.wheel`** MCP tool — the balance read Adepthood's Map needs to render the wheel of wholeness (which frequencies are full, which thin) from the classified corpus, rather than a linear ladder.

Part of epic #748.

## What it returns

```jsonc
{
  "status": "ok", "tool": "creek.wheel", "tier_ceiling": "open",
  "total_classified": 42, "unclassified": 3,
  "wheel": {
    "F1": { "name": "Agency", "count": 9, "share": 0.214 },
    "F2": { "name": "Receptivity", "count": 0, "share": 0.0 },
    "...": "... through F10 ..."
  }
}
```

## Design notes

- **Complete + balance-framed:** the result is built by iterating all of F1–F10 (via `CANONICAL_FREQUENCY_NAMES`), so every frequency is present in `F1→F10` order — a thin frequency shows `count: 0`, not absence. Each carries a normalised `share` of the classified total, so the client draws balance, not ranking.
- **Empty/new-user vault:** `iter_vault_fragments` returns `[]` for a missing dir, so an empty corpus yields a complete all-zero wheel — no special-casing.
- **Ceiling enforced for real:** unlike `creek.report` (which only echoes the ceiling), `wheel` converts it via `to_privacy_override` and passes it to the tally, so above-ceiling fragments are excluded (`tier_within_override`).
- **`use_enum_values=True` gotcha handled:** `fragment.frequency.primary` is a bare string at runtime, coerced back to `Frequency` (unrecognised → `UNCLASSIFIED`, counted separately, never guessed into a bucket).
- Audit-logged like every tool; read-only wrt the corpus.

## Test plan (TDD)

- `tests/test_mcp_wheel.py` (7): complete map including thin frequencies + names; balance shares summing to 1.0; empty-vault all-zeros; ceiling excludes an INTIMATE fragment under OPEN and admits it under INTIMATE; unclassified counted separately (not in any F bucket); audit-logged; read-only.
- `tests/test_mcp_server.py`: `creek.wheel` in `EXPECTED_TOOLS`; `call_tool` end-to-end returns the complete F1–F10 map (all-zero on the empty fixture).
- Coverage: `wheel.py` 86.8% (> 80% gate). ruff / refurb / mypy --strict clean.
- `./scripts/check-all.sh`: all gates pass except the unit-test/coverage step, whose only failures are the 8 pre-existing author-desk environmental tests (green in CI).

Closes #752
Refs #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)