### PR TITLE
feat(care): care guardrail across the voice path — no med advice; crisis → human (#753)

### DIFF
--- a/creek-tools/creek/author/voice.py
+++ b/creek-tools/creek/author/voice.py
@@ -25,6 +25,7 @@ from creek.author.skills import (
     find_voice_core,
     read_skill,
 )
+from creek.care.guardrail import CARE_POLICY
 from creek.generate.ontology_glossary import GLOSS_STEER
 
 if TYPE_CHECKING:
@@ -155,7 +156,9 @@ def _split_voice_prompt(
         (``""`` when the vault carries none); ``dynamic`` is the evidence block
         followed by the ask block.
     """
-    static = "\n\n".join(part for part in _skill_sections(vault, evidence) if part)
+    static = "\n\n".join(
+        [CARE_POLICY, *(part for part in _skill_sections(vault, evidence) if part)]
+    )
     dynamic = "\n\n".join(
         part
         for part in (_evidence_section(evidence), _ask_section(query, medium, contract))

--- a/creek-tools/creek/care/__init__.py
+++ b/creek-tools/creek/care/__init__.py
@@ -1,0 +1,11 @@
+"""Cross-cutting care-boundary policy for Creek's voice-generating tools (#753).
+
+Houses the shared medication/care policy woven into every voice prompt and the
+conservative acute-distress detector that backs the reflect care seam. Lives in
+``creek/`` (not ``creek_mcp/``) so the core generators (draft / author / compile)
+can import it without depending on the MCP layer.
+"""
+
+from creek.care.guardrail import CARE_POLICY, CARE_SIGNAL, acute_distress_guard
+
+__all__ = ["CARE_POLICY", "CARE_SIGNAL", "acute_distress_guard"]

--- a/creek-tools/creek/care/guardrail.py
+++ b/creek-tools/creek/care/guardrail.py
@@ -43,6 +43,11 @@ CARE_POLICY: Final[str] = (
 # ("the deadline is killing me"), so ordinary dark/reflective journaling does
 # not trip the guard. Biased toward false negatives by design — Adepthood runs
 # the primary acute pre-check; this is Creek's safe-by-construction backstop.
+#
+# This matches ONLY these literal patterns — it is NOT a comprehensive classifier.
+# Paraphrase ("gonna kill myself"), typos, and non-English phrasing slip through
+# by design; do not mistake this backstop for the primary defense. Broadening it
+# is fine, but the safety guarantee rests on the primary pre-check, not this set.
 _ACUTE_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
     re.compile(r"\bkill(?:ing)?\s+myself\b", re.IGNORECASE),
     re.compile(r"\b(?:end|ending|take|taking)\s+my\s+(?:own\s+)?life\b", re.IGNORECASE),

--- a/creek-tools/creek/care/guardrail.py
+++ b/creek-tools/creek/care/guardrail.py
@@ -1,0 +1,93 @@
+"""Care boundary: medication policy + acute-distress detector (#753).
+
+Creek's voice-generating tools (``creek.reflect`` / ``draft`` / ``author`` /
+``compile``) must be safe **by construction** — not only when a careful client
+(Adepthood) runs its own pre-check — because other consumers (CrawDad) call the
+same surface. This module is the single source of that safety:
+
+- :data:`CARE_POLICY` — prose woven into every voice prompt. It forbids advising
+  the writer to change/stop/reduce psychiatric medication (deferring to them and
+  their prescriber), tells the model to point toward human + professional support
+  on acute distress rather than counsel as a chatbot, and to keep its ordinary
+  non-directive voice — explicitly *not* pathologizing honest, dark, or
+  reflective writing.
+- :func:`acute_distress_guard` — a deliberately narrow, **acute-only** detector
+  that returns a stable reason code on first-person, imminent self-harm /
+  suicidal *intent* (not affect), else ``None``. It is a backstop, biased toward
+  false negatives so ordinary reflective journaling is never flagged.
+- :data:`CARE_SIGNAL` — the structured "reach a human" envelope a tool returns
+  instead of model prose when the guard fires; it never dead-ends.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Final
+
+CARE_POLICY: Final[str] = (
+    "CARE BOUNDARY (non-negotiable): You are not a clinician or a crisis "
+    "service. Never advise the writer to start, stop, reduce, or change any "
+    "psychiatric medication or treatment — those decisions belong to them and "
+    "their prescriber, and you defer to that relationship. If the writing shows "
+    "acute distress or risk of harm, do not try to counsel them through it as a "
+    "chatbot; gently point them toward a trusted person and professional support. "
+    "Otherwise hold your ordinary warm, non-directive voice and do NOT pathologize "
+    "honest, dark, grieving, or reflective writing — bleakness is not an emergency."
+)
+"""Policy text woven into every voice-generating prompt (the prompt-level half)."""
+
+
+# Acute, first-person, imminent self-harm / suicidal-INTENT phrasings only.
+# Deliberately narrow: these match stated intent or a plan, never affect words
+# ("hopeless", "exhausted", "grief", "thinking about death") or hyperbole
+# ("the deadline is killing me"), so ordinary dark/reflective journaling does
+# not trip the guard. Biased toward false negatives by design — Adepthood runs
+# the primary acute pre-check; this is Creek's safe-by-construction backstop.
+_ACUTE_PATTERNS: Final[tuple[re.Pattern[str], ...]] = (
+    re.compile(r"\bkill(?:ing)?\s+myself\b", re.IGNORECASE),
+    re.compile(r"\b(?:end|ending|take|taking)\s+my\s+(?:own\s+)?life\b", re.IGNORECASE),
+    re.compile(r"\bgoing\s+to\s+(?:kill|hurt|harm)\s+myself\b", re.IGNORECASE),
+    re.compile(r"\bcommit(?:ting)?\s+suicide\b", re.IGNORECASE),
+)
+
+_ACUTE_REASON: Final[str] = "acute_distress_markers"
+
+
+def acute_distress_guard(text: str) -> str | None:
+    """Return a reason code for acute self-harm intent, else ``None``.
+
+    Matches only narrow, first-person imminent-intent phrasings (see
+    :data:`_ACUTE_PATTERNS`); affect, grief, and reflection on death are
+    deliberately not matched. Returns the stable code ``"acute_distress_markers"``
+    — never the matched text — so the signal is privacy- and audit-safe.
+
+    Args:
+        text: The journal entry / candidate content.
+
+    Returns:
+        ``"acute_distress_markers"`` when an acute-intent pattern matches, else
+        ``None``.
+    """
+    return _ACUTE_REASON if any(p.search(text) for p in _ACUTE_PATTERNS) else None
+
+
+CARE_SIGNAL: Final[dict[str, Any]] = {
+    "kind": "acute_distress",
+    "message": (
+        "This sounds urgent and heavy, and you deserve real human support right "
+        "now — more than a chatbot can give. Please reach out to someone you "
+        "trust, or contact a crisis service. You are not alone in this."
+    ),
+    "resources": [
+        {
+            "name": "988 Suicide & Crisis Lifeline (US)",
+            "contact": "Call or text 988",
+        },
+        {
+            "name": "Find a Helpline (international directory)",
+            "contact": "https://findahelpline.com",
+        },
+    ],
+}
+"""Structured "reach a human" signal returned in place of model prose on acute
+distress (the response-level half). Clients render it; it never dead-ends."""

--- a/creek-tools/creek/compile/engine.py
+++ b/creek-tools/creek/compile/engine.py
@@ -30,6 +30,7 @@ from typing import TYPE_CHECKING
 import frontmatter
 
 from creek.audit import AuditLog
+from creek.care.guardrail import CARE_POLICY
 from creek.compile.provenance import ProvenanceEntry, merge_provenance
 from creek.hierarchy import (
     LevelPolicy,
@@ -345,6 +346,7 @@ def _build_prompt(
     """
     lookup: dict[str, Fragment] = by_id or {f.id: f for f, _ in pairs}
     sections: list[str] = [
+        CARE_POLICY,
         f"You are compiling a {target_kind} note titled {target_title!r}.",
         "Return JSON with two arrays: 'claims' (each having 'id', 'text', "
         "'fragment_ids') and 'paradoxes' (each having 'description', "

--- a/creek-tools/creek/generate/drafts.py
+++ b/creek-tools/creek/generate/drafts.py
@@ -35,6 +35,7 @@ import frontmatter
 import yaml
 from pydantic import ValidationError
 
+from creek.care.guardrail import CARE_POLICY
 from creek.classify.privacy_filter import (
     PrivacyTierOverride,
     filter_fragments_by_tier,
@@ -1126,7 +1127,7 @@ class DraftGenerator:
         before the ``## Ask`` block so the LLM sees the recombination
         instruction as the last thing before its task.
         """
-        parts: list[str] = []
+        parts: list[str] = [CARE_POLICY]
         if self.voice_core:
             parts.append(f"## Voice core\n{self.voice_core.strip()}")
         if self.style_preamble:
@@ -2036,7 +2037,7 @@ class DraftGenerator:
         heading and body so the section appears in the draft even when
         the vault has nothing to retrieve.
         """
-        parts: list[str] = []
+        parts: list[str] = [CARE_POLICY]
         if self.voice_core:
             parts.append(f"## Voice core\n{self.voice_core.strip()}")
         if self.style_preamble:

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -181,11 +181,14 @@ def build_server(
         privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
     ) -> dict[str, Any]:
         """Return anchored Higher-Self margin notes on a single journal entry."""
+        from creek.care.guardrail import acute_distress_guard
+
         return reflect_tool(
             vault_path=vault,
             llm_factory=reflect_factory(),
             content=content,
             entry_ref=entry_ref,
+            care_guard=acute_distress_guard,
             privacy_tier_ceiling=privacy_tier_ceiling,
             consumer=consumer,
         )

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 
 from mcp.server.fastmcp import FastMCP
 
+from creek.care.guardrail import acute_distress_guard
 from creek.config import CONFIG_PATH_ENV_VAR, load_config
 from creek_mcp.tier_ceiling import TierCeiling
 from creek_mcp.tools import (
@@ -181,8 +182,6 @@ def build_server(
         privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
     ) -> dict[str, Any]:
         """Return anchored Higher-Self margin notes on a single journal entry."""
-        from creek.care.guardrail import acute_distress_guard
-
         return reflect_tool(
             vault_path=vault,
             llm_factory=reflect_factory(),

--- a/creek-tools/creek_mcp/tools/reflect.py
+++ b/creek-tools/creek_mcp/tools/reflect.py
@@ -28,8 +28,10 @@ Three guarantees this module enforces:
   not are dropped — the client re-anchors verbatim quotes to character offsets
   itself, so a hallucinated span must never reach it.
 - **Care boundary (#753).** A ``care_guard`` seam is injected; when it flags the
-  entry, the tool escalates and never calls the model. The real guard lands in
-  #753; until then the seam is unset (no gating) but wired.
+  entry, the tool escalates (returning the structured ``CARE_SIGNAL`` pointing to
+  human support) and never calls the model. The production guard is
+  :func:`creek.care.guardrail.acute_distress_guard`, threaded in by
+  ``build_server``; the seam stays injectable so tests can substitute their own.
 
 The LLM and retrieval are injected so the tool is unit-testable with no live
 calls; ``build_server`` supplies the production factory + retrieval.

--- a/creek-tools/creek_mcp/tools/reflect.py
+++ b/creek-tools/creek_mcp/tools/reflect.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Protocol
 
+from creek.care.guardrail import CARE_POLICY, CARE_SIGNAL
 from creek.models import PrivacyTier
 from creek_mcp.audit import MCPAuditLog
 from creek_mcp.tier_ceiling import TierCeiling, refusal_response, to_privacy_override
@@ -198,7 +199,9 @@ def _build_prompt(entry: str, grounding: list[str]) -> str:
         "Every quote MUST be copied verbatim from the ENTRY."
     )
     return (
-        "You are the writer's own Higher Self leaving warm, second-person margin "
+        CARE_POLICY
+        + "\n\n"
+        + "You are the writer's own Higher Self leaving warm, second-person margin "
         "notes on their journal entry. Mirror their wisdom back; never advise from "
         "above, never diagnose, never console with platitudes. Ground every note in "
         "their own words and the source fragments below.\n\n"
@@ -309,6 +312,7 @@ def reflect_tool(
                 "tool": TOOL_NAME,
                 "tier_ceiling": privacy_tier_ceiling.value,
                 "reason": care_reason,
+                "care_signal": CARE_SIGNAL,
             }
 
     tier = _routing_tier(privacy_tier_ceiling, entry_tier)

--- a/creek-tools/tests/test_care_guardrail.py
+++ b/creek-tools/tests/test_care_guardrail.py
@@ -1,0 +1,62 @@
+"""Care guardrail — medication policy + acute-distress detector (#753).
+
+Two halves:
+
+- ``CARE_POLICY`` — the prompt-level policy woven into every voice-generating
+  prompt: never advise changing/stopping psychiatric medication; defer to the
+  user + their prescriber; point to human support on acute distress; keep the
+  ordinary non-directive voice and do not pathologize dark/reflective writing.
+- ``acute_distress_guard`` — a conservative, **acute-only** detector returning a
+  stable reason code on imminent self-harm/suicidal intent and ``None`` for
+  ordinary dark journaling. Biased toward false negatives so reflective writing
+  is never flagged.
+"""
+
+from __future__ import annotations
+
+from creek.care.guardrail import CARE_POLICY, CARE_SIGNAL, acute_distress_guard
+
+
+def test_care_policy_covers_medication_and_deferral() -> None:
+    """The policy explicitly addresses medication and defers to the prescriber."""
+    text = CARE_POLICY.lower()
+    assert "medication" in text
+    assert "prescriber" in text
+
+
+def test_care_policy_preserves_non_pathologizing_voice() -> None:
+    """The policy tells the model not to pathologize ordinary dark writing."""
+    assert "pathologize" in CARE_POLICY.lower()
+
+
+def test_acute_distress_guard_fires_on_imminent_intent() -> None:
+    """Stated, first-person imminent self-harm intent returns the reason code."""
+    for entry in (
+        "I am going to kill myself tonight.",
+        "I've decided to end my life.",
+        "i'm going to hurt myself now",
+        "I keep thinking about committing suicide and have a plan.",
+    ):
+        assert acute_distress_guard(entry) == "acute_distress_markers", entry
+
+
+def test_acute_distress_guard_does_not_pathologize_ordinary_dark_writing() -> None:
+    """Affect and reflection — even bleak — must NOT trip the guard."""
+    for entry in (
+        "I feel hopeless and exhausted lately.",
+        "I keep thinking about death and impermanence.",
+        "This grief is so heavy I can barely move.",
+        "Sometimes I just want it all to stop for a while.",
+        "The deadline is killing me.",
+        "",
+    ):
+        assert acute_distress_guard(entry) is None, entry
+
+
+def test_care_signal_points_to_human_and_professional_support() -> None:
+    """The structured care signal names human + professional support, not a bot."""
+    assert CARE_SIGNAL["kind"] == "acute_distress"
+    assert isinstance(CARE_SIGNAL["message"], str) and CARE_SIGNAL["message"]
+    resources = CARE_SIGNAL["resources"]
+    assert isinstance(resources, list) and resources
+    assert all("name" in r and "contact" in r for r in resources)

--- a/creek-tools/tests/test_care_guardrail_weave.py
+++ b/creek-tools/tests/test_care_guardrail_weave.py
@@ -1,0 +1,47 @@
+"""The care policy is woven into every voice-generating prompt (#753).
+
+AC #1 — "a shared guardrail is applied to every voice-generating prompt" — is
+pinned here by asserting :data:`CARE_POLICY` is present in the prompt each voice
+tool builds: ``creek.reflect``, ``creek.compile``, and ``creek.author``
+(``creek.draft`` is covered in ``test_drafts.py`` where its fixtures live).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from creek.author.models import EvidenceBundle, EvidenceClaim
+from creek.author.voice import VoiceAgent
+from creek.care.guardrail import CARE_POLICY
+from creek.classify.llm.completion import AnthropicCompletion
+from creek.compile.engine import _build_prompt as compile_build_prompt
+from creek_mcp.tools.reflect import _build_prompt as reflect_build_prompt
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_reflect_prompt_carries_the_care_policy() -> None:
+    """``creek.reflect``'s margin-note prompt leads with the care policy."""
+    assert CARE_POLICY in reflect_build_prompt("an entry", [])
+
+
+def test_compile_prompt_carries_the_care_policy() -> None:
+    """``creek.compile``'s prompt leads with the care policy."""
+    prompt = compile_build_prompt([], target_kind="eddy", target_title="Title")
+    assert CARE_POLICY in prompt
+
+
+def test_author_voice_system_prompt_carries_the_care_policy(tmp_path: Path) -> None:
+    """``creek.author``'s cached voice system prompt carries the care policy."""
+    client = MagicMock()
+    client.complete_with_usage.return_value = AnthropicCompletion(
+        text="voiced", usage={"cache_read_input_tokens": 0}
+    )
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a grounded claim", source_fragments=["f1"])]
+    )
+    VoiceAgent(llm_client=client).render("q", evidence, tmp_path, medium="research")
+    static = client.complete_with_usage.call_args.kwargs["system"]
+    assert CARE_POLICY in static

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -474,6 +474,22 @@ class TestGenerateDraft:
         assert CARE_POLICY in captured["prompt"]  # #753: care policy woven in
         assert seed.title in captured["prompt"]
 
+    def test_bare_section_prompt_weaves_care_policy(
+        self,
+        skills_root: Path,
+    ) -> None:
+        """The source-less section path also carries the care policy (#753)."""
+        captured: dict[str, str] = {}
+
+        def llm(prompt: str) -> str:
+            captured["prompt"] = prompt
+            return "Section body."
+
+        gen = DraftGenerator(llm=llm, skills_root=skills_root, voice_core="Core voice.")
+        section = OutlineSection(heading="A heading", level=2, body="some body")
+        gen._compose_bare_section(section, None)
+        assert CARE_POLICY in captured["prompt"]
+
     def test_raises_when_llm_returns_empty(
         self,
         vault: Path,

--- a/creek-tools/tests/test_drafts.py
+++ b/creek-tools/tests/test_drafts.py
@@ -10,6 +10,7 @@ import frontmatter
 import pytest
 import yaml
 
+from creek.care.guardrail import CARE_POLICY
 from creek.config import AIStyleConfig
 from creek.generate.ai_style.model import FeatureStat, VoiceFingerprint
 from creek.generate.drafts import (
@@ -470,6 +471,7 @@ class TestGenerateDraft:
         assert "frequencies/F1.SKILL.md" in draft.skill_stack
         assert "Core voice." in captured["prompt"]
         assert "A line." in captured["prompt"]
+        assert CARE_POLICY in captured["prompt"]  # #753: care policy woven in
         assert seed.title in captured["prompt"]
 
     def test_raises_when_llm_returns_empty(

--- a/creek-tools/tests/test_mcp_reflect.py
+++ b/creek-tools/tests/test_mcp_reflect.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
+from creek.care.guardrail import CARE_SIGNAL
 from creek.classify.llm.router import IntimateRoutingError
 from creek.models import PrivacyTier
 from creek_mcp.audit import MCP_AUDIT_RELPATH
@@ -274,6 +275,22 @@ def test_care_guard_escalation_skips_the_llm(tmp_path: Path) -> None:
     assert result["status"] == "escalate"
     assert "reason" in result
     assert factory.asked_tier is None  # the LLM was never reached
+
+
+def test_escalation_carries_the_structured_care_signal(tmp_path: Path) -> None:
+    """Escalation never dead-ends: it returns the human-support care signal (#753)."""
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content="a hard entry",
+        llm_factory=_RecordingFactory(_notes_payload()),
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        care_guard=lambda text: "acute_distress_markers",
+    )
+    assert result["status"] == "escalate"
+    assert result["care_signal"] == CARE_SIGNAL
+    assert result["care_signal"]["kind"] == "acute_distress"
+    assert result["care_signal"]["resources"]  # points to human/professional support
 
 
 def test_empty_content_is_refused(tmp_path: Path) -> None:

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -136,6 +136,32 @@ def test_call_tool_reflect_returns_verbatim_notes(vault: Path) -> None:
     assert structured["notes"][0]["quote"] == "I rest sometimes"  # type: ignore[index]
 
 
+def test_call_tool_reflect_escalates_on_acute_distress(vault: Path) -> None:
+    """The registered ``creek.reflect`` wires the real care guard (#753).
+
+    Acute-distress content must escalate with the structured care signal and
+    never reach the (injected) LLM — proving ``server.py`` threads
+    ``acute_distress_guard`` into ``reflect_tool``.
+    """
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+        reflect_llm_factory=lambda: lambda tier: lambda prompt: '{"notes": []}',
+    )
+    result = asyncio.run(
+        server.call_tool(
+            "creek.reflect",
+            {
+                "content": "I am going to kill myself tonight.",
+                "privacy_tier_ceiling": "open",
+            },
+        ),
+    )
+    structured = _structured(result)
+    assert structured["status"] == "escalate"
+    assert structured["care_signal"]["kind"] == "acute_distress"  # type: ignore[index]
+
+
 def test_call_tool_wheel_returns_complete_frequency_balance(vault: Path) -> None:
     """End-to-end: ``creek.wheel`` returns a complete F1-F10 balance map.
 


### PR DESCRIPTION
## Summary

Makes Creek's voice-generating tools safe **by construction** — not only when a careful client (Adepthood) runs its own pre-check — because other consumers (CrawDad) call the same surface. This is the care boundary `creek.reflect`'s seam (#751) was built to receive.

Part of epic #748. Mirrors `adepthood#887/#890`.

## The shared care module — `creek/care/guardrail.py`

Placed in `creek/` (not `creek_mcp/`) so the core generators import it without a dependency inversion.

- **`CARE_POLICY`** — prose woven into every voice prompt: never advise starting/stopping/reducing psychiatric medication (defer to the user + their prescriber); on acute distress, point to human + professional support rather than counsel as a chatbot; otherwise keep the ordinary non-directive voice and **do not pathologize** honest, dark, grieving, or reflective writing.
- **`acute_distress_guard`** — a deliberately **narrow, acute-only** detector. It matches a small curated set of first-person imminent self-harm / suicidal *intent* phrasings, and **never** affect/grief/reflection-on-death ("I feel hopeless", "thinking about death") or hyperbole ("the deadline is killing me"). Returns a stable reason code, never the matched text. **Biased toward false negatives** so reflective journaling is never flagged — Adepthood runs the primary pre-check; this is the safe-by-construction backstop.
- **`CARE_SIGNAL`** — the structured "reach a human" envelope returned in place of model prose; it never dead-ends.

## Wiring (all four voice prompts + the reflect detector)

- `CARE_POLICY` woven into: `reflect._build_prompt`, draft `_compose_prompt` + `_compose_bare_section`, author voice `static` (cached system prompt), compile `_build_prompt`. (No shared prompt builder exists, so four sites.)
- `acute_distress_guard` threaded into the registered `creek.reflect` (the live-journal-entry surface); the escalate response now carries `care_signal`. *(draft/author/compile generate from the already-classified corpus, not a fresh user signal, so the policy text is their appropriate protection; reflect is the surface that needs the acute escalation.)*

## Test plan (TDD)

- `tests/test_care_guardrail.py` (5): policy covers medication/prescriber + non-pathologizing; acute fires on imminent intent; **ordinary dark writing + hyperbole + empty → None** (the key safety property); care-signal shape.
- `tests/test_care_guardrail_weave.py` (3): `CARE_POLICY` present in the reflect, compile, and author (system) prompts; draft covered by an added assertion in `test_drafts.py`.
- `tests/test_mcp_reflect.py`: escalation carries the structured `care_signal` (never dead-ends).
- `tests/test_mcp_server.py`: the registered `creek.reflect` escalates on acute content with the care signal and never reaches the (injected) LLM — proves `server.py` threads the real guard.
- Coverage: `guardrail.py` 100%. ruff / refurb / mypy --strict clean. No import cycles.
- `./scripts/check-all.sh`: all gates pass except the unit-test/coverage step, whose only failures are the 8 pre-existing author-desk environmental tests (green in CI).

> Note on scope: the detector is intentionally minimal (a backstop). The medication policy in every prompt is the primary, always-on guardrail; the acute detector adds the human-pointer escalation on the one surface that takes a raw live entry.

Closes #753
Refs #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)