### PR TITLE
feat(mcp): creek.journal — Adepthood entry → fragment via shared ingest pipeline (#754)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -53,13 +53,11 @@ if TYPE_CHECKING:
         SeedSpec,
     )
     from creek.generate.mining import MiningRunReport
-    from creek.ingest.base import Ingestor, ParsedFragment
+    from creek.ingest.base import Ingestor
     from creek.ingest.discord_dispatch import DiscordMode
-    from creek.ingest.ledger import LedgerRecord, SourceLedger
     from creek.link.link_engine import LinkSummary
     from creek.models import CompileTargetKind, Fragment, Frequency, Mode, Phase
     from creek.purge import PurgeEngine, PurgeResult
-    from creek.vault.writer import VaultWriter
 
 
 _INCLUDE_TIER_HELP = (
@@ -315,194 +313,6 @@ def _resolve_ingestor(type_name: str) -> type[Ingestor]:
     return cls
 
 
-def _derive_source_key(source_path: str, vault_path: Path) -> str:
-    """Return a stable vault-relative ``source_key`` for a source file (#672).
-
-    Prefers the path relative to the vault root (the stable identity a
-    re-ingested edit is matched on); falls back to the bare filename when the
-    source lives outside the vault.
-    """
-    candidate = Path(source_path)
-    try:
-        return candidate.resolve().relative_to(vault_path.resolve()).as_posix()
-    except ValueError:
-        return candidate.name
-
-
-def _ledger_for_source(source_type: str, vault_path: Path) -> SourceLedger | None:
-    """Load the source ledger for mutable sources, else ``None`` (#672).
-
-    Only the markdown (journal) source is ledger-wired in this skeleton;
-    append-only event sources keep their content-hashed ids untouched.
-    """
-    if source_type != "markdown":
-        return None
-    from creek.ingest.ledger import SourceLedger
-
-    return SourceLedger.load(vault_path, source=source_type)
-
-
-def _attach_origin_key(
-    ledger: SourceLedger | None,
-    parsed: ParsedFragment,
-    fragment: Fragment,
-    vault_path: Path,
-) -> None:
-    """Stamp the fragment's ``source.origin_key`` before it is written (#672)."""
-    if ledger is None:
-        return
-    fragment.source.origin_key = _derive_source_key(parsed.source_path, vault_path)
-
-
-def _record_in_ledger(
-    ledger: SourceLedger | None,
-    parsed: ParsedFragment,
-    fragment: Fragment,
-) -> None:
-    """Record the written fragment in the source ledger (no-op skeleton, #672)."""
-    if ledger is None or fragment.source.origin_key is None:
-        return
-    ledger.record(
-        fragment.source.origin_key,
-        fragment.id,
-        ledger.content_hash(parsed.content),
-    )
-
-
-def _ledger_record(
-    ledger: SourceLedger | None,
-    fragment: Fragment,
-) -> LedgerRecord | None:
-    """Return the prior ledger record for this fragment's source unit (#673)."""
-    if ledger is None:
-        return None
-    origin_key = fragment.source.origin_key
-    if origin_key is None:
-        return None
-    return ledger.get(origin_key)
-
-
-def _restore_tombed(
-    writer: VaultWriter,
-    fragment: Fragment,
-    record: LedgerRecord,
-    body: str,
-    new_hash: str,
-    reclassify_threshold: float,
-) -> Path | None:
-    """Un-tomb a re-appeared source unit and apply its body (#674).
-
-    Reuses the preserved fragment id and moves the tombed fragment back into
-    its routing directory. Only when the content actually changed does it
-    rewrite the body in place — an unchanged re-appearance restores without a
-    redundant write. Returns ``None`` when no tombed file maps to the id, so
-    the caller falls back to a fresh write under the preserved id.
-    """
-    fragment.id = record.fragment_id
-    restored = writer.restore_fragment(fragment)
-    if restored is None:
-        return None
-    if new_hash == record.content_hash:
-        return restored
-    updated = writer.update_fragment(
-        fragment, body, reclassify_threshold=reclassify_threshold
-    )
-    return updated if updated is not None else restored
-
-
-def _write_fragment_idempotent(
-    ledger: SourceLedger | None,
-    writer: VaultWriter,
-    parsed: ParsedFragment,
-    fragment: Fragment,
-    body: str,
-    reclassify_threshold: float,
-) -> str:
-    """Write or update the fragment; return ``"created"`` or ``"updated"``.
-
-    When the ledger already maps this source unit to a fragment and the
-    content has *changed*, reuse that fragment id and rewrite it in place
-    (preserving classifications/links, flagging re-classification on a material
-    change per *reclassify_threshold*). Unchanged content falls through to the
-    normal write, where the deterministic id makes it an idempotent no-op. A
-    new unit (no prior ledger record) is written fresh and reported as created.
-    """
-    record = _ledger_record(ledger, fragment)
-    # `record is not None` guarantees `ledger is not None` (_ledger_record
-    # returns None for a missing ledger); the explicit guard narrows for mypy.
-    if record is None or ledger is None:
-        writer.write_fragment(fragment, body=body)
-        return "created"
-    new_hash = ledger.content_hash(parsed.content)
-    if record.tombed:
-        restored = _restore_tombed(
-            writer, fragment, record, body, new_hash, reclassify_threshold
-        )
-        if restored is None:
-            # Tombstone lost out of band: recreate under the preserved id.
-            writer.write_fragment(fragment, body=body)
-        return "updated"
-    if record.content_hash != new_hash:
-        fragment.id = record.fragment_id
-        updated = writer.update_fragment(
-            fragment, body, reclassify_threshold=reclassify_threshold
-        )
-        if updated is None:
-            # File gone out of band: recreate under the preserved id.
-            writer.write_fragment(fragment, body=body)
-        return "updated"
-    # Known unit, content unchanged: idempotent no-op (the deterministic id
-    # dedups the write). Reported as unchanged so it never inflates the
-    # updated counter in the ingest summary.
-    writer.write_fragment(fragment, body=body)
-    return "unchanged"
-
-
-def _tomb_missing_units(
-    ledger: SourceLedger | None,
-    writer: VaultWriter,
-    input_path: Path,
-    seen_keys: set[str],
-    errors: list[str],
-    source_type: str,
-) -> int:
-    """Soft-tomb ledgered units absent from a full-source pass (#674).
-
-    Only a directory (full-source) input computes a gone set; a single-file
-    ``--input`` run never tombs — that guards the incremental epic from
-    tombing every other unit when re-ingesting one file.
-
-    A tomb that fails on I/O is collected into *errors* (matching the
-    per-fragment write path) and the unit is left live in the ledger so the
-    next full-source pass retries it, rather than crashing the whole run.
-
-    Returns the number of units actually tombed.
-    """
-    if ledger is None or not input_path.is_dir():
-        return 0
-    tombed = 0
-    for source_key in sorted(ledger.live_keys() - seen_keys):
-        record = ledger.get(source_key)
-        if record is None:
-            continue
-        try:
-            writer.tomb_fragment(record.fragment_id)
-        except (OSError, KeyError) as exc:
-            errors.append(
-                f"[{source_type}] failed to tomb {record.fragment_id}: {exc}",
-            )
-            continue
-        ledger.record(
-            source_key,
-            record.fragment_id,
-            record.content_hash,
-            last_seen=record.last_seen,
-            tombed=True,
-        )
-        tombed += 1
-    return tombed
-
-
 def _parse_since_arg(text: str) -> datetime:
     """Parse a ``--since`` argument as an ISO timestamp or a duration (#677).
 
@@ -525,25 +335,6 @@ def _parse_since_arg(text: str) -> datetime:
             )
             raise typer.Exit(code=2) from exc
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
-
-
-def _should_skip_unit(
-    *,
-    filtering: bool,
-    ledger: SourceLedger | None,
-    parsed: ParsedFragment,
-    fragment: Fragment,
-    since: datetime | None,
-) -> bool:
-    """Return whether incremental mode should skip this unchanged unit (#677)."""
-    if not filtering:
-        return False
-    # Deferred import: creek.pipeline pulls heavy stage deps; keep CLI startup light.
-    from creek.pipeline import unit_is_changed
-
-    record = _ledger_record(ledger, fragment)
-    content_hash = ledger.content_hash(parsed.content) if ledger is not None else ""
-    return not unit_is_changed(parsed.timestamp, content_hash, record, since)
 
 
 def _run_ingest(
@@ -583,78 +374,29 @@ def _run_ingest(
     Raises:
         typer.Exit: With code ``1`` when the vault cannot be opened.
     """
-    from creek.ingest.base import assemble_ingested_fragment
-    from creek.vault.writer import VaultWriter
+    from creek.ingest.pipeline import run_ingest
 
     try:
-        writer = VaultWriter(vault_path=vault_path)
+        result = run_ingest(
+            ingestor_cls=ingestor_cls,
+            source_type=source_type,
+            input_path=input_path,
+            vault_path=vault_path,
+            reclassify_threshold=reclassify_threshold,
+            since=since,
+            incremental=incremental,
+        )
     except FileNotFoundError as exc:
         console.print(f"[red]Vault unavailable: {exc}[/red]")
         raise typer.Exit(code=1) from exc
 
-    ingest_result = ingestor_cls().ingest(input_path)
-    ledger = _ledger_for_source(source_type, vault_path)
-    filtering = since is not None or incremental
-
-    errors: list[str] = [f"[{source_type}] {err}" for err in ingest_result.errors]
-    written = 0
-    skipped = 0
-    counts: dict[str, int] = {}
-    seen_keys: set[str] = set()
-    for parsed in ingest_result.fragments:
-        try:
-            assembled = assemble_ingested_fragment(parsed)
-        except (KeyError, ValueError) as exc:
-            errors.append(
-                f"[{source_type}] failed to assemble fragment from "
-                f"{parsed.source_path}: {exc}",
-            )
-            continue
-        _attach_origin_key(ledger, parsed, assembled.fragment, vault_path)
-        origin_key = assembled.fragment.source.origin_key
-        # Record the key as seen BEFORE any incremental skip, so an unchanged
-        # unit is never mistaken for a deleted one and tombed (#674/#677).
-        if origin_key is not None:
-            seen_keys.add(origin_key)
-        if _should_skip_unit(
-            filtering=filtering,
-            ledger=ledger,
-            parsed=parsed,
-            fragment=assembled.fragment,
-            since=since,
-        ):
-            skipped += 1
-            continue
-        try:
-            action = _write_fragment_idempotent(
-                ledger,
-                writer,
-                parsed,
-                assembled.fragment,
-                assembled.body,
-                reclassify_threshold,
-            )
-        except (OSError, KeyError) as exc:
-            errors.append(
-                f"[{source_type}] failed to write {assembled.fragment.id}: {exc}",
-            )
-            continue
-        _record_in_ledger(ledger, parsed, assembled.fragment)
-        written += 1
-        # Tally every action (created/updated/unchanged); only created/updated
-        # are surfaced in the summary line — "unchanged" is an idempotent no-op.
-        counts[action] = counts.get(action, 0) + 1
-
-    tombed = _tomb_missing_units(
-        ledger, writer, input_path, seen_keys, errors, source_type
-    )
     if print_summary:
         console.print(
-            f"[dim]Ingest summary: {counts.get('created', 0)} created, "
-            f"{counts.get('updated', 0)} updated, {tombed} tombed, "
-            f"{skipped} skipped[/dim]",
+            f"[dim]Ingest summary: {result.created} created, "
+            f"{result.updated} updated, {result.tombed} tombed, "
+            f"{result.skipped} skipped[/dim]",
         )
-    return written, errors, ingest_result.discovered
+    return result.written, result.errors, result.discovered
 
 
 def _warn_if_discovered_but_empty(

--- a/creek-tools/creek/ingest/pipeline.py
+++ b/creek-tools/creek/ingest/pipeline.py
@@ -1,0 +1,361 @@
+"""Shared, UI-agnostic ingest pipeline: ledger-backed idempotent writes (#754).
+
+This is the single source of truth for turning an ingestor's parsed output into
+vault fragments *idempotently* — the ledger + ``write_fragment_idempotent`` +
+tomb machinery that makes re-ingesting a source a no-op and an *edited* mutable
+unit an update-in-place (preserving the fragment id and its classifications)
+rather than an orphaned duplicate.
+
+It was lifted out of ``creek.cli`` so both the ``creek ingest`` CLI and the
+``creek.journal`` MCP tool call the *same* code (the CLI keeps a thin wrapper for
+its typer.Exit / summary-print behavior). Nothing here imports typer, rich, or
+``creek_mcp`` — it raises plain exceptions and returns a structured result, so
+any surface can drive it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from creek.ingest.base import assemble_ingested_fragment
+
+if TYPE_CHECKING:
+    from datetime import datetime
+    from pathlib import Path
+
+    from creek.ingest.base import Ingestor, ParsedFragment
+    from creek.ingest.ledger import LedgerRecord, SourceLedger
+    from creek.models import Fragment
+    from creek.vault.writer import VaultWriter
+
+
+@dataclass(frozen=True)
+class IngestRunResult:
+    """Structured outcome of :func:`run_ingest` (UI-agnostic).
+
+    Attributes:
+        written: Units written or updated (created + updated + unchanged).
+        errors: Human-readable ``[<source_type>] …`` error strings.
+        discovered: How many inputs the ingestor's ``discover()`` found.
+        created / updated / unchanged: Per-action tallies of the idempotent write.
+        tombed: Ledgered units soft-tombed because a full-source pass no longer
+            saw them.
+        skipped: Units skipped by incremental/``since`` filtering.
+    """
+
+    written: int
+    errors: list[str]
+    discovered: int
+    created: int
+    updated: int
+    unchanged: int
+    tombed: int
+    skipped: int
+
+
+def derive_source_key(source_path: str, vault_path: Path) -> str:
+    """Return a stable vault-relative ``source_key`` for a source file (#672).
+
+    Prefers the path relative to the vault root (the stable identity a
+    re-ingested edit is matched on); falls back to the bare filename when the
+    source lives outside the vault.
+    """
+    from pathlib import Path as _Path
+
+    candidate = _Path(source_path)
+    try:
+        return candidate.resolve().relative_to(vault_path.resolve()).as_posix()
+    except ValueError:
+        return candidate.name
+
+
+def ledger_for_source(source_type: str, vault_path: Path) -> SourceLedger | None:
+    """Load the source ledger for mutable sources, else ``None`` (#672).
+
+    Only the markdown (journal) source is ledger-wired; append-only event
+    sources keep their content-hashed ids untouched.
+    """
+    if source_type != "markdown":
+        return None
+    from creek.ingest.ledger import SourceLedger
+
+    return SourceLedger.load(vault_path, source=source_type)
+
+
+def attach_origin_key(
+    ledger: SourceLedger | None,
+    parsed: ParsedFragment,
+    fragment: Fragment,
+    vault_path: Path,
+) -> None:
+    """Stamp the fragment's ``source.origin_key`` before it is written (#672)."""
+    if ledger is None:
+        return
+    fragment.source.origin_key = derive_source_key(parsed.source_path, vault_path)
+
+
+def record_in_ledger(
+    ledger: SourceLedger | None,
+    parsed: ParsedFragment,
+    fragment: Fragment,
+) -> None:
+    """Record the written fragment in the source ledger (#672)."""
+    if ledger is None or fragment.source.origin_key is None:
+        return
+    ledger.record(
+        fragment.source.origin_key,
+        fragment.id,
+        ledger.content_hash(parsed.content),
+    )
+
+
+def ledger_record(
+    ledger: SourceLedger | None,
+    fragment: Fragment,
+) -> LedgerRecord | None:
+    """Return the prior ledger record for this fragment's source unit (#673)."""
+    if ledger is None:
+        return None
+    origin_key = fragment.source.origin_key
+    if origin_key is None:
+        return None
+    return ledger.get(origin_key)
+
+
+def restore_tombed(
+    writer: VaultWriter,
+    fragment: Fragment,
+    record: LedgerRecord,
+    body: str,
+    new_hash: str,
+    reclassify_threshold: float,
+) -> Path | None:
+    """Un-tomb a re-appeared source unit and apply its body (#674).
+
+    Reuses the preserved fragment id and moves the tombed fragment back into
+    its routing directory. Only when the content actually changed does it
+    rewrite the body in place — an unchanged re-appearance restores without a
+    redundant write. Returns ``None`` when no tombed file maps to the id, so
+    the caller falls back to a fresh write under the preserved id.
+    """
+    fragment.id = record.fragment_id
+    restored = writer.restore_fragment(fragment)
+    if restored is None:
+        return None
+    if new_hash == record.content_hash:
+        return restored
+    updated = writer.update_fragment(
+        fragment, body, reclassify_threshold=reclassify_threshold
+    )
+    return updated if updated is not None else restored
+
+
+def write_fragment_idempotent(
+    ledger: SourceLedger | None,
+    writer: VaultWriter,
+    parsed: ParsedFragment,
+    fragment: Fragment,
+    body: str,
+    reclassify_threshold: float,
+) -> str:
+    """Write or update the fragment; return ``"created"``/``"updated"``/``"unchanged"``.
+
+    When the ledger already maps this source unit to a fragment and the
+    content has *changed*, reuse that fragment id and rewrite it in place
+    (preserving classifications/links, flagging re-classification on a material
+    change per *reclassify_threshold*). Unchanged content falls through to the
+    normal write, where the deterministic id makes it an idempotent no-op. A
+    new unit (no prior ledger record) is written fresh and reported as created.
+    """
+    record = ledger_record(ledger, fragment)
+    # `record is not None` guarantees `ledger is not None` (ledger_record
+    # returns None for a missing ledger); the explicit guard narrows for mypy.
+    if record is None or ledger is None:
+        writer.write_fragment(fragment, body=body)
+        return "created"
+    new_hash = ledger.content_hash(parsed.content)
+    if record.tombed:
+        restored = restore_tombed(
+            writer, fragment, record, body, new_hash, reclassify_threshold
+        )
+        if restored is None:
+            # Tombstone lost out of band: recreate under the preserved id.
+            writer.write_fragment(fragment, body=body)
+        return "updated"
+    if record.content_hash != new_hash:
+        fragment.id = record.fragment_id
+        updated = writer.update_fragment(
+            fragment, body, reclassify_threshold=reclassify_threshold
+        )
+        if updated is None:
+            # File gone out of band: recreate under the preserved id.
+            writer.write_fragment(fragment, body=body)
+        return "updated"
+    # Known unit, content unchanged: idempotent no-op (the deterministic id
+    # dedups the write). Reported as unchanged so it never inflates the
+    # updated counter in the ingest summary.
+    writer.write_fragment(fragment, body=body)
+    return "unchanged"
+
+
+def tomb_missing_units(
+    ledger: SourceLedger | None,
+    writer: VaultWriter,
+    input_path: Path,
+    seen_keys: set[str],
+    errors: list[str],
+    source_type: str,
+) -> int:
+    """Soft-tomb ledgered units absent from a full-source pass (#674).
+
+    Only a directory (full-source) input computes a gone set; a single-file
+    input never tombs — that guards the incremental epic from tombing every
+    other unit when re-ingesting one file.
+
+    A tomb that fails on I/O is collected into *errors* and the unit is left
+    live in the ledger so the next full-source pass retries it, rather than
+    crashing the whole run. Returns the number of units actually tombed.
+    """
+    if ledger is None or not input_path.is_dir():
+        return 0
+    tombed = 0
+    for source_key in sorted(ledger.live_keys() - seen_keys):
+        record = ledger.get(source_key)
+        if record is None:
+            continue
+        try:
+            writer.tomb_fragment(record.fragment_id)
+        except (OSError, KeyError) as exc:
+            errors.append(
+                f"[{source_type}] failed to tomb {record.fragment_id}: {exc}",
+            )
+            continue
+        ledger.record(
+            source_key,
+            record.fragment_id,
+            record.content_hash,
+            last_seen=record.last_seen,
+            tombed=True,
+        )
+        tombed += 1
+    return tombed
+
+
+def should_skip_unit(
+    *,
+    filtering: bool,
+    ledger: SourceLedger | None,
+    parsed: ParsedFragment,
+    fragment: Fragment,
+    since: datetime | None,
+) -> bool:
+    """Return whether incremental mode should skip this unchanged unit (#677)."""
+    if not filtering:
+        return False
+    # Deferred import: creek.pipeline pulls heavy stage deps; keep import light.
+    from creek.pipeline import unit_is_changed
+
+    record = ledger_record(ledger, fragment)
+    content_hash = ledger.content_hash(parsed.content) if ledger is not None else ""
+    return not unit_is_changed(parsed.timestamp, content_hash, record, since)
+
+
+def run_ingest(
+    *,
+    ingestor_cls: type[Ingestor],
+    source_type: str,
+    input_path: Path,
+    vault_path: Path,
+    reclassify_threshold: float = 0.0,
+    since: datetime | None = None,
+    incremental: bool = False,
+) -> IngestRunResult:
+    """Run one ingestor and persist its output idempotently to the vault.
+
+    UI-agnostic core of ``creek ingest``: no printing, no typer.Exit. A missing
+    vault raises :class:`FileNotFoundError` (from :class:`VaultWriter`) for the
+    caller to translate.
+
+    Args:
+        ingestor_cls: Concrete :class:`Ingestor` subclass to run.
+        source_type: Registry key, used to prefix error messages (and to select
+            the ledger — only ``"markdown"`` is ledger-backed).
+        input_path: Source directory or file to ingest.
+        vault_path: Vault root for :class:`VaultWriter`.
+        reclassify_threshold: Body-similarity floor below which a materially
+            edited unit is flagged for re-classification (#675).
+        since: Incremental cutoff (#677) — only units newer than this are kept.
+        incremental: Ledger-driven incremental mode (#677).
+
+    Returns:
+        An :class:`IngestRunResult` with the write tallies and any errors.
+    """
+    from creek.vault.writer import VaultWriter
+
+    writer = VaultWriter(vault_path=vault_path)
+
+    ingest_result = ingestor_cls().ingest(input_path)
+    ledger = ledger_for_source(source_type, vault_path)
+    filtering = since is not None or incremental
+
+    errors: list[str] = [f"[{source_type}] {err}" for err in ingest_result.errors]
+    written = 0
+    skipped = 0
+    counts: dict[str, int] = {}
+    seen_keys: set[str] = set()
+    for parsed in ingest_result.fragments:
+        try:
+            assembled = assemble_ingested_fragment(parsed)
+        except (KeyError, ValueError) as exc:
+            errors.append(
+                f"[{source_type}] failed to assemble fragment from "
+                f"{parsed.source_path}: {exc}",
+            )
+            continue
+        attach_origin_key(ledger, parsed, assembled.fragment, vault_path)
+        origin_key = assembled.fragment.source.origin_key
+        # Record the key as seen BEFORE any incremental skip, so an unchanged
+        # unit is never mistaken for a deleted one and tombed (#674/#677).
+        if origin_key is not None:
+            seen_keys.add(origin_key)
+        if should_skip_unit(
+            filtering=filtering,
+            ledger=ledger,
+            parsed=parsed,
+            fragment=assembled.fragment,
+            since=since,
+        ):
+            skipped += 1
+            continue
+        try:
+            action = write_fragment_idempotent(
+                ledger,
+                writer,
+                parsed,
+                assembled.fragment,
+                assembled.body,
+                reclassify_threshold,
+            )
+        except (OSError, KeyError) as exc:
+            errors.append(
+                f"[{source_type}] failed to write {assembled.fragment.id}: {exc}",
+            )
+            continue
+        record_in_ledger(ledger, parsed, assembled.fragment)
+        written += 1
+        counts[action] = counts.get(action, 0) + 1
+
+    tombed = tomb_missing_units(
+        ledger, writer, input_path, seen_keys, errors, source_type
+    )
+    return IngestRunResult(
+        written=written,
+        errors=errors,
+        discovered=ingest_result.discovered,
+        created=counts.get("created", 0),
+        updated=counts.get("updated", 0),
+        unchanged=counts.get("unchanged", 0),
+        tombed=tombed,
+        skipped=skipped,
+    )

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -29,6 +29,7 @@ from creek_mcp.tools import (
     compile_tool,
     handshake_tool,
     ingest_tool,
+    journal_ingest_tool,
     link_tool,
     lint_tool,
     mine_tool,
@@ -199,6 +200,25 @@ def build_server(
         """Return a per-frequency balance read of the corpus for the Map."""
         return wheel_tool(
             vault_path=vault,
+            privacy_tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+        )
+
+    @server.tool(name="creek.journal")
+    def _journal(
+        content: str,
+        external_id: str,
+        timestamp: str | None = None,
+        tier: str = "open",
+        privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    ) -> dict[str, Any]:
+        """Ingest one Adepthood journal entry as a vault fragment (idempotent)."""
+        return journal_ingest_tool(
+            vault_path=vault,
+            content=content,
+            external_id=external_id,
+            timestamp=timestamp,
+            tier=tier,
             privacy_tier_ceiling=privacy_tier_ceiling,
             consumer=consumer,
         )

--- a/creek-tools/creek_mcp/tools/__init__.py
+++ b/creek-tools/creek_mcp/tools/__init__.py
@@ -6,6 +6,7 @@ from creek_mcp.tools.compile import compile_tool
 from creek_mcp.tools.draft import draft_tool
 from creek_mcp.tools.handshake import handshake_tool
 from creek_mcp.tools.ingest import ingest_tool
+from creek_mcp.tools.journal import journal_ingest_tool
 from creek_mcp.tools.link import link_tool
 from creek_mcp.tools.lint import lint_tool
 from creek_mcp.tools.mine import mine_tool
@@ -32,6 +33,7 @@ __all__ = [
     "draft_tool",
     "handshake_tool",
     "ingest_tool",
+    "journal_ingest_tool",
     "link_tool",
     "lint_tool",
     "mine_tool",

--- a/creek-tools/creek_mcp/tools/journal.py
+++ b/creek-tools/creek_mcp/tools/journal.py
@@ -43,6 +43,9 @@ _SOURCE_TYPE = "markdown"
 # makes the markdown ingestor classify them as SourcePlatform.JOURNAL; the
 # ``adepthood`` segment identifies the source in each fragment's origin_key.
 _JOURNAL_INBOX = Path("00-Creek-Meta/adepthood/journal")
+# Where JOURNAL-platform fragments are routed by the writer — recorded as the
+# audit ``created_path`` (mirrors ingest_tool's dir-level created_path).
+_FRAGMENT_ROUTING_DIR = Path("01-Fragments/Journal")
 _SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
@@ -118,13 +121,10 @@ def journal_ingest_tool(
         on success (``action`` ∈ ``created``/``updated``/``unchanged``), or a
         structured refusal.
     """
-    MCPAuditLog(vault_path).append(
-        tool=TOOL_NAME,
-        args={"external_id": external_id[:64], "has_timestamp": timestamp is not None},
-        tier_ceiling=privacy_tier_ceiling,
-        consumer=consumer,
-    )
-
+    # Malformed calls (blank content/id, unknown tier) refuse without an audit
+    # entry, mirroring save_tool/ingest_tool — there is no meaningful tier to
+    # record yet. The tier-ceiling refusal and success DO audit (below), since
+    # the audit trail is how a privacy-tier violation would be investigated.
     if not content.strip() or not external_id.strip():
         return refusal_response(
             tool=TOOL_NAME,
@@ -139,7 +139,15 @@ def journal_ingest_tool(
             ceiling=privacy_tier_ceiling,
             reason=f"unknown tier {tier!r}",
         )
+
+    audit_args = {"external_id": external_id[:64], "tier": tier}
     if not write_tier_allowed(entry_tier, privacy_tier_ceiling):
+        MCPAuditLog(vault_path).append(
+            tool=TOOL_NAME,
+            args=audit_args,
+            tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+        )
         return refusal_response(
             tool=TOOL_NAME,
             ceiling=privacy_tier_ceiling,
@@ -166,12 +174,22 @@ def journal_ingest_tool(
             reason=f"ingest failed: {result.errors[0]}",
         )
 
+    fragment_id = _resolve_fragment_id(vault_path, staged)
+    MCPAuditLog(vault_path).append(
+        tool=TOOL_NAME,
+        args=audit_args,
+        tier_ceiling=privacy_tier_ceiling,
+        consumer=consumer,
+        created_path=str(_FRAGMENT_ROUTING_DIR),
+        created_tier=entry_tier.value,
+        affected_fragment_ids=[fragment_id] if fragment_id else [],
+    )
     return {
         "status": "ok",
         "tool": TOOL_NAME,
         "tier_ceiling": privacy_tier_ceiling.value,
         "external_id": external_id,
-        "fragment_id": _resolve_fragment_id(vault_path, staged),
+        "fragment_id": fragment_id,
         "action": _action_of(result),
         "tier": entry_tier.value,
     }

--- a/creek-tools/creek_mcp/tools/journal.py
+++ b/creek-tools/creek_mcp/tools/journal.py
@@ -1,0 +1,177 @@
+"""``creek.journal`` MCP tool — Adepthood journal entry → fragment (#754).
+
+Lets an Adepthood journal entry (raw content + timestamp + tier + a STABLE
+external id) flow into the vault as a fragment so it is classified, linked, and
+available to ``reflect``/``wheel`` — reusing the existing ledger-backed markdown
+ingest rather than a parallel pipeline.
+
+Idempotency + edit-in-place come for free from the shared
+:func:`creek.ingest.pipeline.run_ingest`: the entry is staged as a markdown file
+at a **stable path derived from the external id** (under a ``…/journal/…`` dir so
+it is classified as :class:`~creek.models.SourcePlatform.JOURNAL`), so the source
+ledger keys on that stable path. Re-sending the same entry is a no-op; an edited
+entry with the same external id rewrites the fragment in place (preserving its id
+and classifications), never orphaning a duplicate.
+
+Tier is honored end-to-end: the tier is written into the staged entry's
+frontmatter (which the markdown ingestor carries onto the fragment), and the
+write-side ceiling refuses an entry whose tier exceeds the caller's ceiling — so
+an INTIMATE entry is stored intimate and never admitted under a lower ceiling.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import frontmatter
+
+from creek.ingest.markdown import MarkdownIngestor
+from creek.ingest.pipeline import derive_source_key, ledger_for_source, run_ingest
+from creek.models import PrivacyTier
+from creek_mcp.audit import MCPAuditLog
+from creek_mcp.tier_ceiling import TierCeiling, refusal_response, write_tier_allowed
+
+if TYPE_CHECKING:
+    from creek.ingest.pipeline import IngestRunResult
+
+TOOL_NAME = "creek.journal"
+_SOURCE_TYPE = "markdown"
+# A stable per-vault home for staged Adepthood entries. The ``journal`` segment
+# makes the markdown ingestor classify them as SourcePlatform.JOURNAL; the
+# ``adepthood`` segment identifies the source in each fragment's origin_key.
+_JOURNAL_INBOX = Path("00-Creek-Meta/adepthood/journal")
+_SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+def _safe_stem(external_id: str) -> str:
+    """Return a filesystem-safe, stable stem for *external_id*.
+
+    The mapping is deterministic so the same external id always resolves to the
+    same staged path (hence the same ledger source-key → idempotent).
+    """
+    stem = _SLUG_RE.sub("-", external_id).strip("-")
+    return stem or "entry"
+
+
+def _stage_entry(
+    vault_path: Path, external_id: str, content: str, timestamp: str, tier: PrivacyTier
+) -> Path:
+    """Write the entry to its stable staged markdown path and return it."""
+    staged = vault_path / _JOURNAL_INBOX / f"{_safe_stem(external_id)}.md"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    post = frontmatter.Post(
+        content,
+        privacy_tier=tier.value,
+        date=timestamp,
+        source_id=external_id,
+    )
+    staged.write_text(frontmatter.dumps(post), encoding="utf-8")
+    return staged
+
+
+def _resolve_fragment_id(vault_path: Path, staged: Path) -> str | None:
+    """Return the fragment id the ledger mapped this staged entry to."""
+    ledger = ledger_for_source(_SOURCE_TYPE, vault_path)
+    if ledger is None:
+        return None
+    record = ledger.get(derive_source_key(str(staged), vault_path))
+    return record.fragment_id if record is not None else None
+
+
+def _action_of(result: IngestRunResult) -> str:
+    """Collapse the single-entry run tally into one action word."""
+    if result.created:
+        return "created"
+    if result.updated:
+        return "updated"
+    return "unchanged"
+
+
+def journal_ingest_tool(
+    *,
+    vault_path: Path,
+    content: str,
+    external_id: str,
+    timestamp: str | None = None,
+    tier: str = "open",
+    privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
+    consumer: str = "unknown",
+) -> dict[str, Any]:
+    """Ingest one Adepthood journal entry as a vault fragment (idempotently).
+
+    Args:
+        vault_path: Vault root.
+        content: The journal entry body.
+        external_id: The Adepthood-side stable id — the idempotency key. The same
+            id updates in place; a new id creates a new fragment.
+        timestamp: ISO-8601 entry time; defaults to now (UTC) when absent.
+        tier: The entry's privacy tier (``open``/``personal``/``intimate``).
+        privacy_tier_ceiling: The caller's admission ceiling — an entry whose
+            tier exceeds it is refused, not downgraded.
+        consumer: Free-form consumer id for the audit log.
+
+    Returns:
+        ``{status, tool, tier_ceiling, external_id, fragment_id, action, tier}``
+        on success (``action`` ∈ ``created``/``updated``/``unchanged``), or a
+        structured refusal.
+    """
+    MCPAuditLog(vault_path).append(
+        tool=TOOL_NAME,
+        args={"external_id": external_id[:64], "has_timestamp": timestamp is not None},
+        tier_ceiling=privacy_tier_ceiling,
+        consumer=consumer,
+    )
+
+    if not content.strip() or not external_id.strip():
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason="content and external_id are required",
+        )
+    try:
+        entry_tier = PrivacyTier(tier)
+    except ValueError:
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason=f"unknown tier {tier!r}",
+        )
+    if not write_tier_allowed(entry_tier, privacy_tier_ceiling):
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason=f"entry tier {entry_tier.value} exceeds the ceiling",
+        )
+
+    ts = timestamp or datetime.now(UTC).isoformat()
+    staged = _stage_entry(vault_path, external_id, content, ts, entry_tier)
+    try:
+        result = run_ingest(
+            ingestor_cls=MarkdownIngestor,
+            source_type=_SOURCE_TYPE,
+            input_path=staged,
+            vault_path=vault_path,
+        )
+    except FileNotFoundError:
+        return refusal_response(
+            tool=TOOL_NAME, ceiling=privacy_tier_ceiling, reason="vault unavailable"
+        )
+    if result.errors:
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason=f"ingest failed: {result.errors[0]}",
+        )
+
+    return {
+        "status": "ok",
+        "tool": TOOL_NAME,
+        "tier_ceiling": privacy_tier_ceiling.value,
+        "external_id": external_id,
+        "fragment_id": _resolve_fragment_id(vault_path, staged),
+        "action": _action_of(result),
+        "tier": entry_tier.value,
+    }

--- a/creek-tools/creek_mcp/tools/journal.py
+++ b/creek-tools/creek_mcp/tools/journal.py
@@ -21,6 +21,7 @@ an INTIMATE entry is stored intimate and never admitted under a lower ceiling.
 
 from __future__ import annotations
 
+import hashlib
 import re
 from datetime import UTC, datetime
 from pathlib import Path
@@ -35,7 +36,13 @@ from creek_mcp.audit import MCPAuditLog
 from creek_mcp.tier_ceiling import TierCeiling, refusal_response, write_tier_allowed
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from creek.ingest.pipeline import IngestRunResult
+
+    # The ingest runner seam — production is ``run_ingest``; tests inject a stub
+    # to exercise the failure path.
+    _Runner = Callable[..., IngestRunResult]
 
 TOOL_NAME = "creek.journal"
 _SOURCE_TYPE = "markdown"
@@ -50,13 +57,18 @@ _SLUG_RE = re.compile(r"[^A-Za-z0-9._-]+")
 
 
 def _safe_stem(external_id: str) -> str:
-    """Return a filesystem-safe, stable stem for *external_id*.
+    """Return a filesystem-safe, *collision-free*, stable stem for *external_id*.
 
-    The mapping is deterministic so the same external id always resolves to the
-    same staged path (hence the same ledger source-key → idempotent).
+    A readable slug prefix aids debugging, but the trailing hash of the RAW
+    external id is what guarantees the mapping is injective — two distinct ids
+    that slug to the same string (e.g. ``"a/b"`` and ``"a-b"``) still get
+    distinct stems, so the idempotency key never collides. Deterministic, so the
+    same external id always resolves to the same staged path (hence the same
+    ledger source-key → idempotent re-send / edit-in-place).
     """
-    stem = _SLUG_RE.sub("-", external_id).strip("-")
-    return stem or "entry"
+    slug = _SLUG_RE.sub("-", external_id).strip("-")[:80]
+    digest = hashlib.sha256(external_id.encode("utf-8")).hexdigest()[:12]
+    return f"{slug}-{digest}" if slug else digest
 
 
 def _stage_entry(
@@ -102,6 +114,7 @@ def journal_ingest_tool(
     tier: str = "open",
     privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
     consumer: str = "unknown",
+    run: _Runner | None = None,
 ) -> dict[str, Any]:
     """Ingest one Adepthood journal entry as a vault fragment (idempotently).
 
@@ -156,8 +169,9 @@ def journal_ingest_tool(
 
     ts = timestamp or datetime.now(UTC).isoformat()
     staged = _stage_entry(vault_path, external_id, content, ts, entry_tier)
+    runner = run if run is not None else run_ingest
     try:
-        result = run_ingest(
+        result = runner(
             ingestor_cls=MarkdownIngestor,
             source_type=_SOURCE_TYPE,
             input_path=staged,
@@ -168,6 +182,15 @@ def journal_ingest_tool(
             tool=TOOL_NAME, ceiling=privacy_tier_ceiling, reason="vault unavailable"
         )
     if result.errors:
+        # Content was staged and tier-allowed but the write failed — audit the
+        # attempt (with its tier) so the failure leaves a trace, like ingest_tool.
+        MCPAuditLog(vault_path).append(
+            tool=TOOL_NAME,
+            args=audit_args,
+            tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+            created_tier=entry_tier.value,
+        )
         return refusal_response(
             tool=TOOL_NAME,
             ceiling=privacy_tier_ceiling,

--- a/creek-tools/tests/test_mcp_journal.py
+++ b/creek-tools/tests/test_mcp_journal.py
@@ -76,14 +76,18 @@ def test_entry_becomes_a_journal_fragment(tmp_path: Path) -> None:
 def test_resending_the_same_entry_is_idempotent(tmp_path: Path) -> None:
     """Same external id + same content → one fragment, same id, no duplicate."""
     vault = _vault(tmp_path)
-    args = {
-        "content": "A steady entry.",
-        "external_id": "adep-002",
-        "timestamp": _TS,
-        "privacy_tier_ceiling": TierCeiling.PERSONAL,
-    }
-    first = journal_ingest_tool(vault_path=vault, **args)  # type: ignore[arg-type]
-    second = journal_ingest_tool(vault_path=vault, **args)  # type: ignore[arg-type]
+
+    def _send() -> dict[str, object]:
+        return journal_ingest_tool(
+            vault_path=vault,
+            content="A steady entry.",
+            external_id="adep-002",
+            timestamp=_TS,
+            privacy_tier_ceiling=TierCeiling.PERSONAL,
+        )
+
+    first = _send()
+    second = _send()
     assert len(_fragments(vault)) == 1  # no duplicate
     assert second["fragment_id"] == first["fragment_id"]
     assert second["action"] == "unchanged"

--- a/creek-tools/tests/test_mcp_journal.py
+++ b/creek-tools/tests/test_mcp_journal.py
@@ -158,17 +158,38 @@ def test_empty_content_is_refused(tmp_path: Path) -> None:
     assert result["status"] == "refused"
 
 
-def test_journal_is_audit_logged(tmp_path: Path) -> None:
-    """The ingest is audit-logged with the tool name and consumer."""
+def test_journal_success_audit_records_tier_and_fragment(tmp_path: Path) -> None:
+    """The success audit records the tier and the fragment it wrote (#754 review)."""
     vault = _vault(tmp_path)
-    journal_ingest_tool(
+    result = journal_ingest_tool(
         vault_path=vault,
         content="an entry",
         external_id="adep-007",
         timestamp=_TS,
+        tier="personal",
         privacy_tier_ceiling=TierCeiling.PERSONAL,
         consumer="adepthood",
     )
     last = _audit(vault)[-1]
     assert last["tool"] == TOOL_NAME
     assert last["consumer"] == "adepthood"
+    assert last["args_summary"]["tier"] == "personal"
+    assert last["created_tier"] == "personal"
+    assert last["affected_fragment_ids"] == [result["fragment_id"]]
+
+
+def test_refused_intimate_attempt_is_audited_with_tier(tmp_path: Path) -> None:
+    """A refused INTIMATE attempt is audited (with its tier) so it is investigable."""
+    vault = _vault(tmp_path)
+    journal_ingest_tool(
+        vault_path=vault,
+        content="tender",
+        external_id="adep-008",
+        timestamp=_TS,
+        tier="intimate",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="adepthood",
+    )
+    last = _audit(vault)[-1]
+    assert last["tool"] == TOOL_NAME
+    assert last["args_summary"]["tier"] == "intimate"  # the attempted tier is recorded

--- a/creek-tools/tests/test_mcp_journal.py
+++ b/creek-tools/tests/test_mcp_journal.py
@@ -1,0 +1,174 @@
+"""``creek.journal`` MCP tool — Adepthood journal entry → fragment (#754).
+
+Drives the REAL ledger-backed ingest (`run_ingest`) against a temp vault, so the
+idempotency and edit-in-place guarantees are exercised end-to-end, not mocked:
+
+- re-sending the same external id is a no-op (one fragment, same id);
+- editing an entry (same external id, new content) rewrites in place (same id,
+  no orphaned duplicate);
+- tier is honored (an INTIMATE entry lands intimate; it is refused under a lower
+  ceiling, never downgraded).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import frontmatter
+
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.journal import TOOL_NAME, journal_ingest_tool
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_TS = "2026-06-20T10:00:00+00:00"
+
+
+def _vault(tmp_path: Path) -> Path:
+    """Create the minimum vault layout the writer + ledger + audit need."""
+    for sub in ("00-Creek-Meta/State", "00-Creek-Meta/audit", "01-Fragments"):
+        (tmp_path / sub).mkdir(parents=True, exist_ok=True)
+    return tmp_path
+
+
+def _fragments(vault: Path) -> list[Path]:
+    """Return all fragment files under 01-Fragments."""
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+def _load(path: Path) -> frontmatter.Post:
+    """Load a fragment file's frontmatter + body."""
+    return frontmatter.load(path)
+
+
+def _audit(vault: Path) -> list[dict[str, object]]:
+    """Return parsed MCP audit-log entries."""
+    log = vault / MCP_AUDIT_RELPATH
+    assert log.exists()
+    return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
+def test_entry_becomes_a_journal_fragment(tmp_path: Path) -> None:
+    """An entry is ingested as one JOURNAL-platform fragment carrying its tier."""
+    vault = _vault(tmp_path)
+    result = journal_ingest_tool(
+        vault_path=vault,
+        content="Today I rested and the work survived.",
+        external_id="adep-001",
+        timestamp=_TS,
+        tier="personal",
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "ok"
+    assert result["tool"] == TOOL_NAME
+    assert result["action"] == "created"
+    assert result["fragment_id"]
+    frags = _fragments(vault)
+    assert len(frags) == 1
+    post = _load(frags[0])
+    assert post.metadata["privacy_tier"] == "personal"
+    assert str(post.metadata["source"]["platform"]) == "journal"
+
+
+def test_resending_the_same_entry_is_idempotent(tmp_path: Path) -> None:
+    """Same external id + same content → one fragment, same id, no duplicate."""
+    vault = _vault(tmp_path)
+    args = {
+        "content": "A steady entry.",
+        "external_id": "adep-002",
+        "timestamp": _TS,
+        "privacy_tier_ceiling": TierCeiling.PERSONAL,
+    }
+    first = journal_ingest_tool(vault_path=vault, **args)  # type: ignore[arg-type]
+    second = journal_ingest_tool(vault_path=vault, **args)  # type: ignore[arg-type]
+    assert len(_fragments(vault)) == 1  # no duplicate
+    assert second["fragment_id"] == first["fragment_id"]
+    assert second["action"] == "unchanged"
+
+
+def test_editing_an_entry_updates_in_place(tmp_path: Path) -> None:
+    """Same external id + new content → same fragment id, body updated, no orphan."""
+    vault = _vault(tmp_path)
+    first = journal_ingest_tool(
+        vault_path=vault,
+        content="The original wording.",
+        external_id="adep-003",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    edited = journal_ingest_tool(
+        vault_path=vault,
+        content="The revised, longer wording of the same entry.",
+        external_id="adep-003",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert len(_fragments(vault)) == 1  # updated in place, not orphaned
+    assert edited["fragment_id"] == first["fragment_id"]
+    assert edited["action"] == "updated"
+    assert "revised" in _load(_fragments(vault)[0]).content
+
+
+def test_intimate_entry_is_refused_under_a_lower_ceiling(tmp_path: Path) -> None:
+    """An INTIMATE entry is refused (not downgraded) under an OPEN ceiling."""
+    vault = _vault(tmp_path)
+    result = journal_ingest_tool(
+        vault_path=vault,
+        content="something tender",
+        external_id="adep-004",
+        timestamp=_TS,
+        tier="intimate",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "refused"
+    assert _fragments(vault) == []  # nothing written
+
+
+def test_intimate_entry_is_stored_intimate_under_an_intimate_ceiling(
+    tmp_path: Path,
+) -> None:
+    """An INTIMATE entry admitted under an intimate ceiling lands intimate."""
+    vault = _vault(tmp_path)
+    result = journal_ingest_tool(
+        vault_path=vault,
+        content="a tender private entry",
+        external_id="adep-005",
+        timestamp=_TS,
+        tier="intimate",
+        privacy_tier_ceiling=TierCeiling.INTIMATE,
+    )
+    assert result["status"] == "ok"
+    assert result["tier"] == "intimate"
+    assert _load(_fragments(vault)[0]).metadata["privacy_tier"] == "intimate"
+
+
+def test_empty_content_is_refused(tmp_path: Path) -> None:
+    """A blank entry is a structured refusal, not a crash or an empty fragment."""
+    vault = _vault(tmp_path)
+    result = journal_ingest_tool(
+        vault_path=vault,
+        content="   ",
+        external_id="adep-006",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "refused"
+
+
+def test_journal_is_audit_logged(tmp_path: Path) -> None:
+    """The ingest is audit-logged with the tool name and consumer."""
+    vault = _vault(tmp_path)
+    journal_ingest_tool(
+        vault_path=vault,
+        content="an entry",
+        external_id="adep-007",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+        consumer="adepthood",
+    )
+    last = _audit(vault)[-1]
+    assert last["tool"] == TOOL_NAME
+    assert last["consumer"] == "adepthood"

--- a/creek-tools/tests/test_mcp_journal.py
+++ b/creek-tools/tests/test_mcp_journal.py
@@ -193,3 +193,62 @@ def test_refused_intimate_attempt_is_audited_with_tier(tmp_path: Path) -> None:
     last = _audit(vault)[-1]
     assert last["tool"] == TOOL_NAME
     assert last["args_summary"]["tier"] == "intimate"  # the attempted tier is recorded
+
+
+def test_slug_colliding_external_ids_stay_distinct(tmp_path: Path) -> None:
+    """Distinct external ids that slugify identically stay distinct (#754 review).
+
+    ``"a/b"`` and ``"a-b"`` both slug to ``a-b``; the stable stem's id hash keeps
+    them apart, so the idempotency key never collides.
+    """
+    vault = _vault(tmp_path)
+    first = journal_ingest_tool(
+        vault_path=vault,
+        content="entry A",
+        external_id="a/b",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    second = journal_ingest_tool(
+        vault_path=vault,
+        content="entry B",
+        external_id="a-b",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert first["fragment_id"] != second["fragment_id"]
+    assert len(_fragments(vault)) == 2
+
+
+def test_ingest_failure_is_refused_and_audited(tmp_path: Path) -> None:
+    """A failure inside run_ingest refuses AND leaves an audit trace (#754 review)."""
+    from creek.ingest.pipeline import IngestRunResult
+
+    def _failing_runner(**_kwargs: object) -> IngestRunResult:
+        return IngestRunResult(
+            written=0,
+            errors=["boom"],
+            discovered=1,
+            created=0,
+            updated=0,
+            unchanged=0,
+            tombed=0,
+            skipped=0,
+        )
+
+    vault = _vault(tmp_path)
+    result = journal_ingest_tool(
+        vault_path=vault,
+        content="an entry",
+        external_id="adep-009",
+        timestamp=_TS,
+        tier="personal",
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+        consumer="adepthood",
+        run=_failing_runner,
+    )
+    assert result["status"] == "refused"
+    last = _audit(vault)[-1]
+    assert last["tool"] == TOOL_NAME
+    assert last["args_summary"]["tier"] == "personal"
+    assert last["created_tier"] == "personal"

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -20,6 +20,7 @@ EXPECTED_TOOLS = {
     "creek.handshake",
     "creek.reflect",
     "creek.wheel",
+    "creek.journal",
     "creek.state.read",
     "creek.state.render",
     "creek.lint",
@@ -160,6 +161,34 @@ def test_call_tool_reflect_escalates_on_acute_distress(vault: Path) -> None:
     structured = _structured(result)
     assert structured["status"] == "escalate"
     assert structured["care_signal"]["kind"] == "acute_distress"  # type: ignore[index]
+
+
+def test_call_tool_journal_ingests_entry_idempotently(vault: Path) -> None:
+    """End-to-end: ``creek.journal`` ingests an entry as a fragment, idempotently.
+
+    Re-sending the same external id through the registered tool yields the same
+    fragment id and no duplicate — proving the ledger-backed path is wired.
+    """
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    payload = {
+        "content": "A registered journal entry.",
+        "external_id": "adep-srv-1",
+        "timestamp": "2026-06-20T10:00:00+00:00",
+        "privacy_tier_ceiling": "personal",
+    }
+    first = _structured(
+        asyncio.run(server.call_tool("creek.journal", payload)),
+    )
+    second = _structured(
+        asyncio.run(server.call_tool("creek.journal", payload)),
+    )
+    assert first["status"] == "ok"
+    assert first["tool"] == "creek.journal"
+    assert second["fragment_id"] == first["fragment_id"]
+    assert len(sorted((vault / "01-Fragments").rglob("*.md"))) == 1
 
 
 def test_call_tool_wheel_returns_complete_frequency_balance(vault: Path) -> None:


### PR DESCRIPTION
## Summary

Lets an Adepthood journal entry (content + timestamp + tier + a **stable external id**) flow into the vault as a fragment — classified, linked, available to `reflect`/`wheel` — by **reusing** the ledger-backed markdown ingest, not a parallel pipeline. This is the last drainable child of epic #748.

## Approach: lift a shared module (per the chosen design)

The idempotency + edit-in-place engine (ledger + `write_fragment_idempotent` + tomb machinery) lived only in `creek/cli.py`, which the MCP layer must not import. So:

- **New `creek/ingest/pipeline.py`** holds that machinery, lifted verbatim and decoupled — it raises plain exceptions and returns a structured `IngestRunResult`, no typer/console/MCP coupling. Single source of truth.
- **`creek/cli.py`'s `_run_ingest` is now a thin wrapper** (typer.Exit + summary print) delegating to `pipeline.run_ingest`. **Behavior is identical:** all 47 ledger/idempotency/tomb/incremental tests pass unchanged, and the `from creek.cli import _run_ingest` test seam is preserved.

## The tool

- **Idempotent + edit-in-place, for free.** The entry is staged as markdown at a stable path derived from the external id (`00-Creek-Meta/adepthood/journal/<id>.md`). The `journal/` segment makes the ingestor classify it as `SourcePlatform.JOURNAL`; the stable path is the ledger source-key. Re-sending the same external id is a no-op; an **edited** entry updates in place (same fragment id, no orphan). Verified end-to-end against a real vault, not mocked.
- **Tier honored end-to-end.** The tier rides the entry frontmatter onto the fragment; the write-side ceiling **refuses** an entry whose tier exceeds the caller's ceiling — an INTIMATE entry is stored intimate, never downgraded.
- Audit-logged; returns `{status, fragment_id, action, tier, external_id}` (`action` ∈ created/updated/unchanged).

## Test plan (TDD)

- `tests/test_mcp_journal.py` (7, real vault + real `run_ingest`): entry → JOURNAL fragment carrying its tier; **idempotent re-send** (same id, one fragment); **edit-in-place** (same id, body updated, no duplicate); INTIMATE refused under an OPEN ceiling; INTIMATE stored intimate under an intimate ceiling; empty refused; audit-logged.
- `tests/test_mcp_server.py`: `creek.journal` in `EXPECTED_TOOLS`; `call_tool` idempotency end-to-end (re-send → same fragment id, one file).
- **Regression:** the full `test_ingest_*` / ledger suite passes unchanged (the CLI now delegates to the lifted module) — this is the key safety check for the refactor.
- Coverage: `pipeline.py` 86.1% / `journal.py` 85.9% (> 80% gate). ruff / refurb / mypy --strict clean; no import cycles.
- `./scripts/check-all.sh`: all gates pass except the unit-test/coverage step, whose only failures are the 8 pre-existing author-desk environmental tests (green in CI).

Closes #754
Refs #748

🤖 Generated with [Claude Code](https://claude.com/claude-code)