### PR TITLE
feat(mcp): network transport + per-consumer auth + boundary TierCeiling

### DIFF
--- a/creek-tools/creek_mcp/remote_auth.py
+++ b/creek-tools/creek_mcp/remote_auth.py
@@ -1,0 +1,108 @@
+"""Per-consumer bearer-token auth for the network MCP transport (#759).
+
+When ``creek-tools-mcp`` is served over the network (streamable-http), every
+request must present a bearer token that maps to a known **consumer identity** —
+there is no anonymous access. Tokens are configured in the environment only
+(never in code or the config file), one per remote consumer, mirroring the
+existing ``CREEK_MCP_ELEVATED_TOKEN`` fail-closed / constant-time precedent.
+
+The SDK's :class:`~mcp.server.auth.provider.TokenVerifier` hook does the rest:
+when a :class:`ConsumerTokenVerifier` is wired into ``FastMCP``, the SDK installs
+``RequireAuthMiddleware`` (401 on a missing/invalid token, 403 on a missing
+scope) and exposes the authenticated identity per-call via ``get_access_token()``
+— which the server uses to stamp the consumer on the audit log and to apply the
+remote tier-ceiling cap.
+
+Stdio (local CrawDad / Claude Code) is unaffected: no verifier is wired, so
+``get_access_token()`` is ``None`` and calls run as before.
+"""
+
+from __future__ import annotations
+
+import hmac
+import os
+from typing import TYPE_CHECKING, Final
+
+from mcp.server.auth.provider import AccessToken, TokenVerifier
+from mcp.server.auth.settings import AuthSettings
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+CONSUMER_TOKENS_ENV: Final[str] = "CREEK_MCP_CONSUMER_TOKENS"
+"""Env var holding ``consumer=token`` pairs, ``;``-separated (tokens never in code)."""
+
+REMOTE_SCOPE: Final[str] = "creek:remote"
+"""The scope every remote consumer token is granted (and the server requires)."""
+
+# Non-secret placeholder URLs — this is a self-hosted resource server using bearer
+# tokens, not an OAuth authorization-server flow, but AuthSettings requires them.
+_ISSUER_URL: Final[str] = "https://creek.invalid/mcp"
+_RESOURCE_URL: Final[str] = "https://creek.invalid/mcp"
+
+
+def load_consumer_tokens(
+    environ: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Parse ``CREEK_MCP_CONSUMER_TOKENS`` into a ``{consumer: token}`` map.
+
+    Format: ``adepthood=<token>;other=<token>``. Blank entries and entries
+    without a token are skipped. Returns an empty dict when unset — the caller
+    treats "no tokens configured" as "network mode not permitted" (no anonymous
+    access).
+
+    Args:
+        environ: Environment mapping (defaults to :data:`os.environ`).
+
+    Returns:
+        A ``{consumer: token}`` mapping.
+    """
+    raw = (environ if environ is not None else os.environ).get(CONSUMER_TOKENS_ENV, "")
+    tokens: dict[str, str] = {}
+    for entry in raw.split(";"):
+        name, sep, token = entry.strip().partition("=")
+        if sep and name.strip() and token.strip():
+            tokens[name.strip()] = token.strip()
+    return tokens
+
+
+class ConsumerTokenVerifier(TokenVerifier):
+    """Verifies a bearer token against the configured per-consumer token map.
+
+    Comparison is constant-time (``hmac.compare_digest``) against every known
+    token so a match leaks no timing signal about which consumer (or whether a
+    prefix) matched. A verified token yields an :class:`AccessToken` whose
+    ``client_id`` is the consumer name and whose scope is :data:`REMOTE_SCOPE`.
+    """
+
+    def __init__(self, tokens: Mapping[str, str]) -> None:
+        """Store the ``{consumer: token}`` map to verify against."""
+        self._tokens = dict(tokens)
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Return the consumer's :class:`AccessToken` for a valid token, else ``None``.
+
+        Iterates the whole map with constant-time compares (never a dict lookup)
+        so verification time does not depend on which token was supplied.
+        """
+        matched: str | None = None
+        for consumer, known in self._tokens.items():
+            if hmac.compare_digest(token, known):
+                matched = consumer
+        if matched is None:
+            return None
+        return AccessToken(
+            token=token,
+            client_id=matched,
+            scopes=[REMOTE_SCOPE],
+            expires_at=None,
+        )
+
+
+def remote_auth_settings() -> AuthSettings:
+    """Return the :class:`AuthSettings` requiring the remote scope on every call."""
+    return AuthSettings(
+        issuer_url=_ISSUER_URL,  # type: ignore[arg-type]
+        resource_server_url=_RESOURCE_URL,  # type: ignore[arg-type]
+        required_scopes=[REMOTE_SCOPE],
+    )

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -18,11 +18,18 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.fastmcp import FastMCP
 
 from creek.care.guardrail import acute_distress_guard
 from creek.config import CONFIG_PATH_ENV_VAR, load_config
-from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.remote_auth import (
+    CONSUMER_TOKENS_ENV,
+    ConsumerTokenVerifier,
+    load_consumer_tokens,
+    remote_auth_settings,
+)
+from creek_mcp.tier_ceiling import TierCeiling, refusal_response
 from creek_mcp.tools import (
     author_tool,
     classify_tool,
@@ -50,12 +57,76 @@ from creek_mcp.tools import (
 from creek_mcp.tools.draft import draft_tool
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
+
+    from mcp.server.auth.provider import AccessToken, TokenVerifier
+    from mcp.types import ContentBlock
 
     from creek.models import PrivacyTier
     from creek_mcp.tools.reflect import _LLM, _LLMFactory
 
 SERVER_NAME = "creek-tools-mcp"
+
+# Tier ceilings a REMOTE (network-authed) consumer may request. INTIMATE and ALL
+# are excluded so intimate content can never be reached over the network — the
+# load-bearing boundary of #759. Local (stdio) callers are unaffected.
+_REMOTE_ADMITTED_CEILINGS: frozenset[TierCeiling] = frozenset(
+    {TierCeiling.OPEN, TierCeiling.PERSONAL}
+)
+
+
+def _current_access_token() -> AccessToken | None:
+    """Return the current request's authenticated token, or ``None`` for stdio.
+
+    A thin, monkeypatchable wrapper over the SDK's request-scoped
+    ``get_access_token`` — non-``None`` exactly when the call arrived over the
+    authenticated network transport.
+    """
+    return get_access_token()
+
+
+def _effective_consumer(default: str) -> str:
+    """Return the per-call consumer: the authed remote ``client_id``, else *default*.
+
+    So a network call is audited under the consumer its bearer token identifies,
+    while a local stdio call keeps the process-global ``CREEK_MCP_CONSUMER``.
+    """
+    token = _current_access_token()
+    return token.client_id if token is not None else default
+
+
+class _BoundedFastMCP(FastMCP):
+    """``FastMCP`` that enforces the remote tier-ceiling cap at the one call chokepoint.
+
+    Every tool call flows through :meth:`call_tool`. When the call is remote (an
+    authenticated network request — ``_current_access_token()`` is set), a
+    requested ceiling above the remote cap (i.e. ``INTIMATE`` or ``ALL``, or any
+    unrecognised value) is refused **before dispatch**, so intimate content is
+    never even read for a remote caller. Local stdio calls (no token) pass
+    through unchanged — the default per-tool ``OPEN`` ceiling still applies.
+    """
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> Sequence[ContentBlock] | dict[str, Any]:
+        """Refuse over-ceiling remote calls, else dispatch normally."""
+        if _current_access_token() is not None:
+            raw = arguments.get("privacy_tier_ceiling", TierCeiling.OPEN.value)
+            try:
+                requested = TierCeiling(raw)
+            except ValueError:
+                requested = None
+            if requested not in _REMOTE_ADMITTED_CEILINGS:
+                return refusal_response(
+                    tool=name,
+                    ceiling=TierCeiling.OPEN,
+                    reason=(
+                        "remote consumers may not request a ceiling above "
+                        f"'{TierCeiling.PERSONAL.value}'; intimate content is not "
+                        "reachable over the network"
+                    ),
+                )
+        return await super().call_tool(name, arguments)
 
 
 def _resolve_vault(vault_path: Path | None) -> Path:
@@ -138,6 +209,7 @@ def build_server(
     draft_llm_factory: Callable[[], Callable[[str], str]] | None = None,
     compile_llm_factory: Callable[[], Callable[[str], str]] | None = None,
     reflect_llm_factory: Callable[[], _LLMFactory] | None = None,
+    token_verifier: TokenVerifier | None = None,
 ) -> FastMCP:
     """Construct a :class:`FastMCP` instance with all FEAT-010/011 tools.
 
@@ -154,8 +226,19 @@ def build_server(
         reflect_llm_factory: Optional thunk returning the tier-keyed LLM
             factory for ``creek.reflect``. Invoked lazily per call so only
             ``creek.reflect`` needs an LLM provider.
+        token_verifier: When set, the server serves the network transport
+            authenticated — every request must present a bearer token the
+            verifier accepts (no anonymous access), and remote calls are
+            capped below INTIMATE. ``None`` (the default) is the local stdio
+            server, unauthenticated as before.
     """
-    server: FastMCP = FastMCP(SERVER_NAME)
+    server: FastMCP = (
+        _BoundedFastMCP(
+            SERVER_NAME, token_verifier=token_verifier, auth=remote_auth_settings()
+        )
+        if token_verifier is not None
+        else _BoundedFastMCP(SERVER_NAME)
+    )
     vault = _resolve_vault(vault_path)
     consumer = _consumer_from_env()
     factory = draft_llm_factory or _build_draft_llm
@@ -173,7 +256,7 @@ def build_server(
             capabilities=sorted(tool.name for tool in tools),
             server_name=SERVER_NAME,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.reflect")
@@ -190,7 +273,7 @@ def build_server(
             entry_ref=entry_ref,
             care_guard=acute_distress_guard,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.wheel")
@@ -201,7 +284,7 @@ def build_server(
         return wheel_tool(
             vault_path=vault,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.journal")
@@ -220,7 +303,7 @@ def build_server(
             timestamp=timestamp,
             tier=tier,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.state.read")
@@ -231,7 +314,7 @@ def build_server(
         return state_read_tool(
             vault_path=vault,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.state.render")
@@ -242,7 +325,7 @@ def build_server(
         return state_render_tool(
             vault_path=vault,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.lint")
@@ -257,7 +340,7 @@ def build_server(
             privacy_tier_ceiling=privacy_tier_ceiling,
             checks=checks,
             since=since,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.mine")
@@ -272,7 +355,7 @@ def build_server(
             privacy_tier_ceiling=privacy_tier_ceiling,
             phase=phase,
             limit=limit,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.draft")
@@ -288,7 +371,7 @@ def build_server(
             privacy_tier_ceiling=privacy_tier_ceiling,
             phase=phase,
             index=index,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.author")
@@ -307,7 +390,7 @@ def build_server(
             max_rounds=max_rounds,
             dry_run=dry_run,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.save")
@@ -336,7 +419,7 @@ def build_server(
             saved_by=saved_by,
             full_body=full_body,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.ingest")
@@ -351,7 +434,7 @@ def build_server(
             source_type=source_type,
             input_path=input_path,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.redact.scan")
@@ -364,7 +447,7 @@ def build_server(
             vault_path=vault,
             input_path=input_path,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.classify")
@@ -379,7 +462,7 @@ def build_server(
             method=method,
             force=force,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.link")
@@ -394,7 +477,7 @@ def build_server(
             method=method,
             rebuild=rebuild,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.report")
@@ -407,7 +490,7 @@ def build_server(
             vault_path=vault,
             report_type=report_type,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.skills.refresh")
@@ -418,7 +501,7 @@ def build_server(
         return skills_refresh_tool(
             vault_path=vault,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.compile")
@@ -438,7 +521,7 @@ def build_server(
             target_title=target_title,
             llm_factory=compile_factory,
             privacy_tier_ceiling=privacy_tier_ceiling,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.purge.fragment")
@@ -453,7 +536,7 @@ def build_server(
             fragment_id=fragment_id,
             auth_token=auth_token,
             dry_run=dry_run,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.purge.source")
@@ -468,7 +551,7 @@ def build_server(
             source_type=source_type,
             auth_token=auth_token,
             dry_run=dry_run,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.purge.classifications")
@@ -481,7 +564,7 @@ def build_server(
             vault_path=vault,
             auth_token=auth_token,
             dry_run=dry_run,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.purge.daterange")
@@ -498,7 +581,7 @@ def build_server(
             end=end,
             auth_token=auth_token,
             dry_run=dry_run,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     @server.tool(name="creek.purge.vault")
@@ -513,7 +596,7 @@ def build_server(
             confirm_vault_path=confirm_vault_path,
             auth_token=auth_token,
             dry_run=dry_run,
-            consumer=consumer,
+            consumer=_effective_consumer(consumer),
         )
 
     return server
@@ -547,11 +630,28 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "tool handler picks it up regardless of cwd."
         ),
     )
+    parser.add_argument(
+        "--transport",
+        choices=("stdio", "network"),
+        default="stdio",
+        help=(
+            "stdio (default) for local consumers, or network (authenticated "
+            "streamable-http) for a remote consumer. Network mode requires "
+            f"{CONSUMER_TOKENS_ENV} (no anonymous access) and caps remote "
+            "consumers below INTIMATE."
+        ),
+    )
+    parser.add_argument(
+        "--host", default="127.0.0.1", help="Network transport bind host."
+    )
+    parser.add_argument(
+        "--port", type=int, default=8000, help="Network transport bind port."
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> None:
-    """Run the MCP server over stdio (entry point for ``creek-tools-mcp``).
+    """Run the MCP server over stdio (local) or the authenticated network transport.
 
     Args:
         argv: Optional list of command-line arguments. When ``None``
@@ -565,7 +665,22 @@ def main(argv: list[str] | None = None) -> None:
         if not args.config.exists():
             parser.error(f"--config: file not found: {args.config}")
         os.environ[CONFIG_PATH_ENV_VAR] = str(args.config.resolve())
-    build_server().run(transport="stdio")
+
+    if args.transport == "network":
+        tokens = load_consumer_tokens()
+        if not tokens:
+            # No anonymous access: refuse to expose the vault without per-consumer
+            # tokens, rather than serving unauthenticated.
+            parser.error(
+                f"network transport requires {CONSUMER_TOKENS_ENV} "
+                "(consumer=token pairs); refusing to serve without authentication"
+            )
+        server = build_server(token_verifier=ConsumerTokenVerifier(tokens))
+        server.settings.host = args.host
+        server.settings.port = args.port
+        server.run(transport="streamable-http")
+    else:
+        build_server().run(transport="stdio")
 
 
 if __name__ == "__main__":  # pragma: no cover - exercised via the entry point

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -193,6 +193,38 @@ CrawDad (FEAT-013+) treats this server's tool registry as its
 stdio child process. Set `CREEK_MCP_CONSUMER=crawdad` in the bot's
 environment so the audit trail distinguishes Discord-driven calls.
 
+## Network transport (authenticated, epic #757 / #759)
+
+Local consumers (Claude Code, CrawDad) speak JSON-RPC over **stdio** — the
+default, unchanged. To reach a user's per-user-VM vault from a remote
+Adepthood backend, the server also serves an **authenticated
+streamable-http** transport:
+
+```bash
+export CREEK_MCP_CONSUMER_TOKENS="adepthood=<opaque-token>;other=<token>"
+creek-tools-mcp --transport network --host 127.0.0.1 --port 8000
+```
+
+- **No anonymous access.** Network mode refuses to start unless
+  `CREEK_MCP_CONSUMER_TOKENS` is set. It holds `consumer=token` pairs,
+  `;`-separated; tokens live in the **environment only** (never in code or
+  config), mirroring the `CREEK_MCP_ELEVATED_TOKEN` precedent.
+- **Per-consumer identity.** Each request must present its bearer token
+  (`Authorization: Bearer <token>`). The token maps to a consumer name that
+  is stamped on every audit-log entry — so remote calls are attributable the
+  same way `CREEK_MCP_CONSUMER` attributes stdio calls. A missing or unknown
+  token is rejected `401` before any tool runs; comparison is constant-time.
+- **INTIMATE is never reachable remotely.** The boundary caps a remote
+  caller at `personal`: a request for a `privacy_tier_ceiling` above it
+  (`intimate` / `all`, or any unrecognised value) is **refused before
+  dispatch**, so intimate content is never even read for a network consumer.
+  Stdio calls are unaffected — the per-tool `open` default still applies
+  locally, and `intimate` remains reachable for the local owner.
+
+The transport is a thin wrapper around the MCP SDK's `TokenVerifier` /
+streamable-http app; the tool registry, tier-ceiling rules, and hash-chained
+audit are identical to the stdio path.
+
 ## Audit log
 
 Every tool invocation appends one entry to

--- a/creek-tools/tests/test_mcp_remote.py
+++ b/creek-tools/tests/test_mcp_remote.py
@@ -1,0 +1,277 @@
+"""Network transport + per-consumer bearer-token auth for the MCP server (#759).
+
+Security properties under test:
+
+- **No anonymous access** — the network transport refuses to start without
+  ``CREEK_MCP_CONSUMER_TOKENS``, and an unauthenticated / bad-token request over
+  the wire gets ``401`` before any tool runs.
+- **INTIMATE is never reachable remotely** — an authenticated remote caller that
+  requests a ceiling above ``personal`` (``intimate`` / ``all``, or any
+  unrecognised value) is *refused before dispatch*, so intimate content is never
+  even read for a network consumer. ``open`` / ``personal`` pass through.
+- **Per-consumer identity** — a remote call is audited under the consumer its
+  bearer token identifies, not the process-env default.
+- **Stdio is unchanged** — with no verifier wired, ``get_access_token()`` is
+  ``None`` so the cap never engages and a local ``intimate`` call dispatches.
+
+No real/production token material is hardcoded — every token is a test literal.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+from mcp.server.auth.provider import AccessToken
+from starlette.testclient import TestClient
+
+from creek_mcp import server as server_mod
+from creek_mcp.audit import MCP_AUDIT_RELPATH
+from creek_mcp.remote_auth import (
+    CONSUMER_TOKENS_ENV,
+    REMOTE_SCOPE,
+    ConsumerTokenVerifier,
+    load_consumer_tokens,
+)
+from creek_mcp.server import build_server, main
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+
+@pytest.fixture
+def vault(tmp_path: Path) -> Iterator[Path]:
+    """Yield a freshly seeded vault for the remote-transport tests."""
+    for sub in (
+        "00-Creek-Meta/State",
+        "00-Creek-Meta/audit",
+        "01-Fragments/Notes",
+        "02-Threads/Active",
+        "03-Eddies",
+        "creek-skills",
+    ):
+        (tmp_path / sub).mkdir(parents=True, exist_ok=True)
+    yield tmp_path
+
+
+def _structured(result: object) -> dict[str, object]:
+    """Pull the structured-content dict out of a FastMCP ``call_tool`` result."""
+    return result[1] if isinstance(result, tuple) else result  # type: ignore[return-value, index]
+
+
+def _fake_token(consumer: str) -> AccessToken:
+    """Build an :class:`AccessToken` as the verifier would for a valid bearer."""
+    return AccessToken(
+        token="opaque",  # test literal, not a real credential
+        client_id=consumer,
+        scopes=[REMOTE_SCOPE],
+        expires_at=None,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# load_consumer_tokens — parsing
+# --------------------------------------------------------------------------- #
+
+
+def test_load_consumer_tokens_parses_pairs() -> None:
+    """Well-formed ``consumer=token`` pairs parse into a map."""
+    env = {CONSUMER_TOKENS_ENV: "adepthood=secret123;crawdad=tok456"}
+    assert load_consumer_tokens(env) == {
+        "adepthood": "secret123",
+        "crawdad": "tok456",
+    }
+
+
+def test_load_consumer_tokens_skips_blank_and_tokenless_entries() -> None:
+    """Blank segments and ``name=`` entries with no token are dropped."""
+    env = {CONSUMER_TOKENS_ENV: " adepthood = secret123 ; ; missing= ;=orphan"}
+    assert load_consumer_tokens(env) == {"adepthood": "secret123"}
+
+
+def test_load_consumer_tokens_empty_when_unset() -> None:
+    """An unset env var yields an empty map (caller treats as 'network denied')."""
+    assert load_consumer_tokens({}) == {}
+
+
+# --------------------------------------------------------------------------- #
+# ConsumerTokenVerifier
+# --------------------------------------------------------------------------- #
+
+
+def test_verify_token_returns_access_token_for_valid_bearer() -> None:
+    """A known token resolves to its consumer's :class:`AccessToken`."""
+    verifier = ConsumerTokenVerifier({"adepthood": "secret123"})
+    token = asyncio.run(verifier.verify_token("secret123"))
+    assert token is not None
+    assert token.client_id == "adepthood"
+    assert token.scopes == [REMOTE_SCOPE]
+
+
+def test_verify_token_rejects_unknown_bearer() -> None:
+    """An unknown token yields ``None`` (401 at the middleware)."""
+    verifier = ConsumerTokenVerifier({"adepthood": "secret123"})
+    assert asyncio.run(verifier.verify_token("wrong")) is None
+
+
+def test_verify_token_rejects_against_empty_map() -> None:
+    """With no configured tokens, every bearer is rejected."""
+    verifier = ConsumerTokenVerifier({})
+    assert asyncio.run(verifier.verify_token("anything")) is None
+
+
+# --------------------------------------------------------------------------- #
+# _effective_consumer — per-consumer identity
+# --------------------------------------------------------------------------- #
+
+
+def test_effective_consumer_uses_token_client_id_when_remote(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A live access token overrides the default consumer with its client_id."""
+    monkeypatch.setattr(
+        server_mod, "_current_access_token", lambda: _fake_token("adepthood")
+    )
+    assert server_mod._effective_consumer("env-default") == "adepthood"
+
+
+def test_effective_consumer_falls_back_to_default_locally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no token (stdio), the caller-supplied default is used."""
+    monkeypatch.setattr(server_mod, "_current_access_token", lambda: None)
+    assert server_mod._effective_consumer("env-default") == "env-default"
+
+
+# --------------------------------------------------------------------------- #
+# _BoundedFastMCP.call_tool — the remote tier-ceiling boundary
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize("ceiling", ["intimate", "all", "bogus-tier"])
+def test_remote_call_above_personal_is_refused_before_dispatch(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, ceiling: str
+) -> None:
+    """A remote caller cannot request intimate/all (or a garbage tier)."""
+    monkeypatch.setattr(
+        server_mod, "_current_access_token", lambda: _fake_token("adepthood")
+    )
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    result = _structured(
+        asyncio.run(server.call_tool("creek.wheel", {"privacy_tier_ceiling": ceiling}))
+    )
+    assert result["status"] == "refused"
+    assert result["tool"] == "creek.wheel"
+    assert "not reachable over the network" in result["reason"]
+    # Refused before dispatch => nothing was audited for the tool call.
+    assert not (vault / MCP_AUDIT_RELPATH).exists()
+
+
+@pytest.mark.parametrize("ceiling", ["open", "personal"])
+def test_remote_call_at_or_below_personal_dispatches(
+    vault: Path, monkeypatch: pytest.MonkeyPatch, ceiling: str
+) -> None:
+    """open/personal are admitted for remote callers and dispatch normally."""
+    monkeypatch.setattr(
+        server_mod, "_current_access_token", lambda: _fake_token("adepthood")
+    )
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    result = _structured(
+        asyncio.run(server.call_tool("creek.wheel", {"privacy_tier_ceiling": ceiling}))
+    )
+    assert result["tool"] == "creek.wheel"
+    assert result.get("status") != "refused"
+
+
+def test_remote_call_is_audited_under_token_consumer(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dispatched remote call is audited under the bearer's consumer identity."""
+    monkeypatch.setenv("CREEK_MCP_CONSUMER", "env-default")
+    monkeypatch.setattr(
+        server_mod, "_current_access_token", lambda: _fake_token("adepthood")
+    )
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    asyncio.run(server.call_tool("creek.wheel", {"privacy_tier_ceiling": "open"}))
+
+    entries = [
+        json.loads(line)
+        for line in (vault / MCP_AUDIT_RELPATH).read_text("utf-8").splitlines()
+        if line.strip()
+    ]
+    wheel = [e for e in entries if e["tool"] == "creek.wheel"]
+    assert wheel, "expected a creek.wheel audit entry"
+    assert wheel[-1]["consumer"] == "adepthood"  # token identity, not env default
+
+
+def test_local_stdio_call_is_not_capped(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With no token (stdio), an ``intimate`` ceiling is *not* refused."""
+    monkeypatch.setattr(server_mod, "_current_access_token", lambda: None)
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    result = _structured(
+        asyncio.run(
+            server.call_tool("creek.wheel", {"privacy_tier_ceiling": "intimate"})
+        )
+    )
+    assert result["tool"] == "creek.wheel"
+    assert result.get("status") != "refused"
+
+
+# --------------------------------------------------------------------------- #
+# main() — network transport preconditions
+# --------------------------------------------------------------------------- #
+
+
+def test_network_transport_refuses_without_tokens(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``--transport network`` with no configured tokens exits (no anon access)."""
+    monkeypatch.delenv(CONSUMER_TOKENS_ENV, raising=False)
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--transport", "network"])
+    assert excinfo.value.code != 0
+
+
+# --------------------------------------------------------------------------- #
+# Over-the-wire: unauthenticated / bad-token requests get 401
+# --------------------------------------------------------------------------- #
+
+
+def test_streamable_http_rejects_unauthenticated_request(vault: Path) -> None:
+    """A POST with no / wrong bearer is refused 401 before any tool runs."""
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+        token_verifier=ConsumerTokenVerifier({"adepthood": "secret123"}),
+    )
+    client = TestClient(server.streamable_http_app())
+    path = server.settings.streamable_http_path
+    body = {"jsonrpc": "2.0", "id": 1, "method": "tools/list"}
+    headers = {"Accept": "application/json, text/event-stream"}
+
+    no_auth = client.post(path, json=body, headers=headers)
+    assert no_auth.status_code == 401
+
+    bad_token = client.post(
+        path,
+        json=body,
+        headers={**headers, "Authorization": "Bearer wrong"},
+    )
+    assert bad_token.status_code == 401


### PR DESCRIPTION
## Summary

Exposes `creek-tools-mcp` over an **authenticated streamable-http network transport** so a remote Adepthood backend can reach a user's per-user-VM vault — without weakening the privacy guarantees. Stdio remains the default for local consumers (Claude Code, CrawDad), unchanged. Resolves the transport fork (#755) with the decided option (network MCP), per operator choice: **per-consumer bearer tokens from env, remote callers capped below INTIMATE**.

### What changed
- **`creek_mcp/remote_auth.py`** (new) — `CREEK_MCP_CONSUMER_TOKENS` holds `consumer=token` pairs in the **environment only** (never in code/config). `ConsumerTokenVerifier` verifies a bearer constant-time against every known token and yields an `AccessToken` whose `client_id` is the consumer. Empty/unset ⇒ no tokens ⇒ network mode denied (no anonymous access).
- **`creek_mcp/server.py`** —
  - `_BoundedFastMCP` overrides `call_tool` as the single boundary chokepoint: when the call is **remote** (`get_access_token()` is set), a requested `privacy_tier_ceiling` above `personal` (`intimate`/`all`, or any unrecognised value) is **refused before dispatch** — intimate content is never even read for a network consumer. Local stdio calls (no token) pass through unchanged.
  - `_effective_consumer` audits each remote call under the token's consumer identity (not the process-env default).
  - `--transport network` wiring (with `--host`/`--port`) that refuses to start without configured tokens; stdio path is untouched.
- **`docs/mcp.md`** — new "Network transport" section documenting the env-only tokens, per-consumer identity, and the INTIMATE-never-remote cap.

## Test plan
`tests/test_mcp_remote.py` (17 cases) asserts the security properties:
- **No anonymous access** — `main(["--transport","network"])` with no tokens exits; over-the-wire `TestClient` POST with no / wrong bearer → `401` before any tool runs.
- **INTIMATE never reachable remotely** — a remote caller requesting `intimate`/`all`/garbage is refused before dispatch (asserted: `status == "refused"`, nothing audited); `open`/`personal` dispatch.
- **Per-consumer identity** — a dispatched remote call is audited under the bearer's consumer, overriding the env default.
- **Stdio unchanged** — with no verifier wired, a local `intimate` call is *not* capped.
- Unit coverage for `load_consumer_tokens` parsing and `ConsumerTokenVerifier.verify_token`.

Local `./scripts/check-all.sh`: lint / format / mypy / pylint / security / refurb / tryceratops / complexity clean; the new suite passes. (The 8 author-desk/credential-dependent failures are the known local-only set that is green in CI.)

Refs #757
Closes #759