### PR TITLE
feat(routing): attested GPU-CC enclave provider in ModelRouter (is_cloud=False)

### DIFF
--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -180,8 +180,11 @@ The cloud LLM backend is selectable via `llm.provider` in `creek_config.yaml`. T
 | Anthropic | `anthropic` | `ANTHROPIC_API_KEY` | `CREEK_CLOUD_CONSENT=1` |
 | OpenAI | `openai` | `OPENAI_API_KEY` (+ optional `OPENAI_BASE_URL`, or `llm.api_base`) | `CREEK_CLOUD_CONSENT=1` |
 | Gemini | `gemini` | `GOOGLE_API_KEY` or `GEMINI_API_KEY` | `CREEK_CLOUD_CONSENT=1` |
+| GPU-CC enclave | `enclave` | — (attestation config, not a key) | not required (attested) |
 
 `CREEK_CLOUD_CONSENT=1` (also accepts `true` / `yes`) acknowledges that fragment content leaves the device; the legacy `CREEK_ANTHROPIC_CONSENT` is still honored as an alias. `llm.api_base` is OpenAI-specific (an OpenAI-compatible gateway); other providers ignore it. Install the matching optional extra (`[openai]` / `[gemini]`) for the cloud SDKs — see [Install](#install).
+
+**Attested GPU-CC enclave (`enclave`).** An operator-run confidential-compute endpoint that gets GPU-quality output for the most private tier. It is classified `is_cloud=False` — and so is INTIMATE-eligible — because it **cryptographically verifies remote attestation before every completion**, and fails closed otherwise. Configure it (no secrets; none of these is a key) with `llm.enclave_url` (must be `https://`), `llm.enclave_expected_measurement` (the expected enclave image), and `llm.enclave_attestation_pubkey` (the hex Ed25519 **public** trust-root key). Each call challenges the enclave with a fresh nonce and requires an Ed25519 signature over `measurement || nonce` that validates under the configured public key — an impersonator without the private key, a replayed quote, a non-TLS URL, or a measurement mismatch all refuse and send nothing. The trust model and its boundaries (operator-provisioned root key, not yet a full vendor certificate chain) are recorded in [ADR-0006](docs/architecture/ADR/0006-enclave-attestation-trust-model.md).
 
 The architectural decision to keep creek-tools' and CrawDad's provider abstractions decoupled is recorded in [ADR-0003](docs/architecture/ADR/0003-decoupled-provider-abstractions.md).
 

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 import hmac
 import logging
 import os
+import secrets
 from typing import TYPE_CHECKING
 
 import httpx
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 
 from creek.classify.llm.completion import AnthropicCompletion, Completion
 from creek.classify.llm.consent import (
@@ -711,14 +714,32 @@ class OllamaProvider:
 ENCLAVE_ATTESTATION_PATH: str = "/attestation"
 ENCLAVE_GENERATE_PATH: str = "/generate"
 
+#: Bytes of entropy in the per-call attestation nonce (anti-replay challenge).
+_ENCLAVE_NONCE_BYTES: int = 32
+
 # Fixed refusal messages, kept out of the ``raise`` sites so the exception carries
 # a stable string and no long literal sits at the raise (tryceratops TRY003).
 _ENCLAVE_NO_URL = "enclave provider requires enclave_url; refusing to send data"
+_ENCLAVE_INSECURE = (
+    "enclave_url must use https:// (attestation and prompts require TLS); "
+    "refusing to send data"
+)
 _ENCLAVE_NO_POLICY = (
     "enclave provider requires enclave_expected_measurement (attestation policy); "
     "refusing to send data"
 )
+_ENCLAVE_NO_TRUST_ROOT = (
+    "enclave provider requires enclave_attestation_pubkey (trust root); "
+    "refusing to send data"
+)
 _ENCLAVE_UNVERIFIED = "enclave attestation could not be verified; refusing to send data"
+_ENCLAVE_STALE = (
+    "enclave attestation nonce mismatch (stale/replayed quote); refusing to send data"
+)
+_ENCLAVE_BAD_SIGNATURE = (
+    "enclave attestation signature is not valid under the configured trust root; "
+    "refusing to send data"
+)
 _ENCLAVE_MISMATCH = "enclave attestation measurement mismatch; refusing to send data"
 
 
@@ -732,43 +753,143 @@ class EnclaveAttestationError(RuntimeError):
     """
 
 
-def verify_enclave_attestation(config: LLMConfig, *, timeout: float) -> None:
-    """Verify the enclave's remote attestation *before* any prompt egress.
+def _attestation_signed_payload(measurement: str, nonce: str) -> bytes:
+    """Return the exact bytes the enclave signs: measurement bound to the nonce.
 
-    This is the "attest, then mount" gate that lets the enclave be classified
-    ``is_cloud=False``: it fetches the enclave's attestation quote from
-    ``{enclave_url}/attestation`` and requires the attested measurement to equal
-    ``config.enclave_expected_measurement`` (constant-time compare). It refuses —
-    raising :class:`EnclaveAttestationError`, never returning — when the endpoint
-    or policy is unconfigured, the quote is unreachable, or the measurement does
-    not match. Callers MUST invoke this before sending any prompt so a failure
-    can never fall back to plaintext egress.
+    Domain-separated (newline between fields) so a measurement value can never be
+    reinterpreted as part of the nonce or vice versa.
+    """
+    return f"creek-enclave-attestation\n{measurement}\n{nonce}".encode()
+
+
+def _load_attestation_pubkey(pubkey_hex: str) -> Ed25519PublicKey:
+    """Load the configured hex-encoded Ed25519 trust-root public key."""
+    return Ed25519PublicKey.from_public_bytes(bytes.fromhex(pubkey_hex))
+
+
+def _fetch_attestation_quote(
+    url: str, nonce: str, *, timeout: float
+) -> dict[str, object]:
+    """Challenge the enclave with *nonce* and return its attestation quote.
 
     Args:
-        config: LLM configuration carrying ``enclave_url`` and
-            ``enclave_expected_measurement``.
-        timeout: HTTP timeout for the attestation fetch, in seconds.
+        url: The enclave base URL (already validated as ``https://``).
+        nonce: The fresh anti-replay challenge sent to the enclave.
+        timeout: HTTP timeout, in seconds.
+
+    Returns:
+        The parsed attestation quote (``measurement`` / ``nonce`` / ``signature``).
 
     Raises:
-        EnclaveAttestationError: On any unconfigured, unreachable, or mismatched
-            attestation — egress is refused.
+        EnclaveAttestationError: When the quote cannot be fetched or parsed.
     """
-    if not config.enclave_url:
-        raise EnclaveAttestationError(_ENCLAVE_NO_URL)
-    if not config.enclave_expected_measurement:
-        raise EnclaveAttestationError(_ENCLAVE_NO_POLICY)
     try:
         with httpx.Client(timeout=timeout) as client:
-            resp = client.get(f"{config.enclave_url}{ENCLAVE_ATTESTATION_PATH}")
+            resp = client.get(
+                f"{url}{ENCLAVE_ATTESTATION_PATH}", params={"nonce": nonce}
+            )
             resp.raise_for_status()
             quote = resp.json()
     except httpx.HTTPError as exc:
         raise EnclaveAttestationError(_ENCLAVE_UNVERIFIED) from exc
-    measured = str(quote.get("measurement", "")) if isinstance(quote, dict) else ""
-    if not measured or not hmac.compare_digest(
-        measured, config.enclave_expected_measurement
-    ):
+    if not isinstance(quote, dict):
+        raise EnclaveAttestationError(_ENCLAVE_UNVERIFIED)
+    return quote
+
+
+def _verify_attestation_quote(
+    quote: dict[str, object],
+    *,
+    sent_nonce: str,
+    expected_measurement: str,
+    pubkey_hex: str,
+) -> None:
+    """Cryptographically verify a fetched attestation quote, or refuse.
+
+    In order: the quote must echo the fresh nonce (freshness / anti-replay); its
+    signature over ``measurement || nonce`` must validate under the configured
+    trust-root key (authenticity / integrity — an impersonator without the
+    private key cannot forge this); and the attested measurement must equal the
+    configured expectation (the enclave is the expected image).
+
+    Args:
+        quote: The parsed attestation quote from the enclave.
+        sent_nonce: The fresh nonce this client challenged the enclave with.
+        expected_measurement: The configured measurement the enclave must present.
+        pubkey_hex: The configured hex Ed25519 trust-root public key.
+
+    Raises:
+        EnclaveAttestationError: On a stale nonce, an invalid signature, or a
+            measurement mismatch — egress is refused.
+    """
+    measurement = str(quote.get("measurement", ""))
+    returned_nonce = str(quote.get("nonce", ""))
+    signature_hex = str(quote.get("signature", ""))
+
+    if not returned_nonce or not hmac.compare_digest(returned_nonce, sent_nonce):
+        raise EnclaveAttestationError(_ENCLAVE_STALE)
+
+    try:
+        pubkey = _load_attestation_pubkey(pubkey_hex)
+        pubkey.verify(
+            bytes.fromhex(signature_hex),
+            _attestation_signed_payload(measurement, returned_nonce),
+        )
+    except (InvalidSignature, ValueError) as exc:
+        raise EnclaveAttestationError(_ENCLAVE_BAD_SIGNATURE) from exc
+
+    if not measurement or not hmac.compare_digest(measurement, expected_measurement):
         raise EnclaveAttestationError(_ENCLAVE_MISMATCH)
+
+
+def verify_enclave_attestation(config: LLMConfig, *, timeout: float) -> None:
+    """Cryptographically verify the enclave's attestation *before* any egress.
+
+    This is the "attest, then mount" gate that justifies classifying the enclave
+    ``is_cloud=False``. It challenges the enclave with a fresh random nonce over
+    an ``https://`` channel, fetches the signed attestation quote, and refuses —
+    raising :class:`EnclaveAttestationError`, never returning — unless **all** of
+    the following hold, so a failure can never fall back to plaintext egress:
+
+    - ``enclave_url`` is configured and uses ``https://`` (TLS-protected);
+    - an attestation policy (``enclave_expected_measurement``) and a trust root
+      (``enclave_attestation_pubkey``) are configured;
+    - the quote echoes the fresh nonce (freshness — an old quote cannot be
+      replayed);
+    - the quote's signature over ``measurement || nonce`` validates under the
+      configured Ed25519 trust-root key (authenticity — an impersonator without
+      the private key cannot forge it);
+    - the attested measurement equals the configured expectation.
+
+    The trust root is the operator-provisioned public key, not a full vendor
+    certificate chain; see ADR-0006 for the trust model and its boundaries.
+
+    Args:
+        config: LLM configuration carrying the enclave URL, attestation policy,
+            and trust-root public key.
+        timeout: HTTP timeout for the attestation fetch, in seconds.
+
+    Raises:
+        EnclaveAttestationError: On any missing prerequisite, insecure transport,
+            unreachable quote, stale nonce, bad signature, or measurement
+            mismatch — egress is refused.
+    """
+    if not config.enclave_url:
+        raise EnclaveAttestationError(_ENCLAVE_NO_URL)
+    if not config.enclave_url.lower().startswith("https://"):
+        raise EnclaveAttestationError(_ENCLAVE_INSECURE)
+    if not config.enclave_expected_measurement:
+        raise EnclaveAttestationError(_ENCLAVE_NO_POLICY)
+    if not config.enclave_attestation_pubkey:
+        raise EnclaveAttestationError(_ENCLAVE_NO_TRUST_ROOT)
+    nonce = secrets.token_hex(_ENCLAVE_NONCE_BYTES)
+    quote = _fetch_attestation_quote(config.enclave_url, nonce, timeout=timeout)
+    _verify_attestation_quote(
+        quote,
+        sent_nonce=nonce,
+        expected_measurement=config.enclave_expected_measurement,
+        pubkey_hex=config.enclave_attestation_pubkey,
+    )
 
 
 def call_enclave(
@@ -820,11 +941,13 @@ class EnclaveProvider:
 
     Sends prompts to a remote confidential-compute endpoint, yet is classified
     ``is_cloud=False`` because :func:`verify_enclave_attestation` runs before
-    every :meth:`complete` call: remote attestation proves the enclave is the
-    expected, operator-unreadable image before any prompt or key leaves the
-    device. This is what lets INTIMATE-tier content get GPU-quality voice output
-    without egressing to a readable cloud — the attestation gate, not a bare
-    flag, is the security boundary (issue #760, decision #757/#755).
+    every :meth:`complete` call: it cryptographically verifies — over ``https``,
+    against an operator-configured Ed25519 trust root, bound to a fresh nonce —
+    that the enclave is the expected confidential-compute image before any prompt
+    or key leaves the device. This is what lets INTIMATE-tier content get
+    GPU-quality voice output without egressing to a readable cloud — the
+    attestation gate, not a bare flag, is the security boundary (issue #760,
+    decision #757/#755; trust model in ADR-0006).
 
     Attributes:
         config: The LLM configuration carrying the enclave URL, attestation

--- a/creek-tools/creek/classify/llm/providers.py
+++ b/creek-tools/creek/classify/llm/providers.py
@@ -15,6 +15,7 @@ exception handling.
 
 from __future__ import annotations
 
+import hmac
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -48,15 +49,19 @@ __all__ = [
     "AnthropicCompletion",
     "AnthropicProvider",
     "Completion",
+    "EnclaveAttestationError",
+    "EnclaveProvider",
     "GeminiProvider",
     "OllamaProvider",
     "OpenAIProvider",
     "ProviderRateLimitError",
     "build_provider",
+    "call_enclave",
     "cloud_warning",
     "known_providers",
     "provider_display_name",
     "provider_is_cloud",
+    "verify_enclave_attestation",
 ]
 
 
@@ -234,6 +239,7 @@ def _chain_is_safe(exc: Exception) -> bool:
 # so "introduce another model" is a one-place edit in both packages.
 DEFAULT_MODELS: dict[str, str] = {
     "anthropic": "claude-sonnet-4-6",
+    "enclave": "llama-3.3-70b",
     "gemini": "gemini-3.5-flash",
     "ollama": "mistral",
     "openai": "gpt-5.4",
@@ -697,6 +703,217 @@ class OllamaProvider:
             self.config,
             prompt,
             timeout=self.REQUEST_TIMEOUT,
+        )
+        return Completion(text=text)
+
+
+#: Endpoint paths on the attested GPU-CC enclave (#760).
+ENCLAVE_ATTESTATION_PATH: str = "/attestation"
+ENCLAVE_GENERATE_PATH: str = "/generate"
+
+# Fixed refusal messages, kept out of the ``raise`` sites so the exception carries
+# a stable string and no long literal sits at the raise (tryceratops TRY003).
+_ENCLAVE_NO_URL = "enclave provider requires enclave_url; refusing to send data"
+_ENCLAVE_NO_POLICY = (
+    "enclave provider requires enclave_expected_measurement (attestation policy); "
+    "refusing to send data"
+)
+_ENCLAVE_UNVERIFIED = "enclave attestation could not be verified; refusing to send data"
+_ENCLAVE_MISMATCH = "enclave attestation measurement mismatch; refusing to send data"
+
+
+class EnclaveAttestationError(RuntimeError):
+    """Raised when the GPU-CC enclave cannot be attested — egress is refused.
+
+    A subclass of :class:`RuntimeError` so the classifier's existing
+    retry/degradation handling (which catches ``RuntimeError``) treats a failed
+    attestation as provider-unavailable rather than crashing — but the fail is
+    always *closed*: no prompt is ever sent when this is raised.
+    """
+
+
+def verify_enclave_attestation(config: LLMConfig, *, timeout: float) -> None:
+    """Verify the enclave's remote attestation *before* any prompt egress.
+
+    This is the "attest, then mount" gate that lets the enclave be classified
+    ``is_cloud=False``: it fetches the enclave's attestation quote from
+    ``{enclave_url}/attestation`` and requires the attested measurement to equal
+    ``config.enclave_expected_measurement`` (constant-time compare). It refuses —
+    raising :class:`EnclaveAttestationError`, never returning — when the endpoint
+    or policy is unconfigured, the quote is unreachable, or the measurement does
+    not match. Callers MUST invoke this before sending any prompt so a failure
+    can never fall back to plaintext egress.
+
+    Args:
+        config: LLM configuration carrying ``enclave_url`` and
+            ``enclave_expected_measurement``.
+        timeout: HTTP timeout for the attestation fetch, in seconds.
+
+    Raises:
+        EnclaveAttestationError: On any unconfigured, unreachable, or mismatched
+            attestation — egress is refused.
+    """
+    if not config.enclave_url:
+        raise EnclaveAttestationError(_ENCLAVE_NO_URL)
+    if not config.enclave_expected_measurement:
+        raise EnclaveAttestationError(_ENCLAVE_NO_POLICY)
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.get(f"{config.enclave_url}{ENCLAVE_ATTESTATION_PATH}")
+            resp.raise_for_status()
+            quote = resp.json()
+    except httpx.HTTPError as exc:
+        raise EnclaveAttestationError(_ENCLAVE_UNVERIFIED) from exc
+    measured = str(quote.get("measurement", "")) if isinstance(quote, dict) else ""
+    if not measured or not hmac.compare_digest(
+        measured, config.enclave_expected_measurement
+    ):
+        raise EnclaveAttestationError(_ENCLAVE_MISMATCH)
+
+
+def call_enclave(
+    config: LLMConfig,
+    prompt: str,
+    *,
+    timeout: float,
+    max_tokens: int | None = None,
+    system: str | None = None,
+) -> str:
+    """Send *prompt* to the attested enclave's generate endpoint and return text.
+
+    The caller (:meth:`EnclaveProvider.complete`) MUST have verified attestation
+    first; this helper performs no gating of its own.
+
+    Args:
+        config: LLM configuration carrying ``enclave_url`` and model name.
+        prompt: The fully-formatted prompt.
+        timeout: HTTP request timeout, in seconds.
+        max_tokens: Optional output ceiling forwarded to the enclave.
+        system: Optional system prompt forwarded to the enclave.
+
+    Returns:
+        The raw response text from the enclave.
+
+    Raises:
+        httpx.HTTPError: On connection, transport, or HTTP error responses.
+    """
+    payload: dict[str, object] = {
+        "model": _resolve_configured_model(config.model, DEFAULT_MODELS["enclave"]),
+        "prompt": prompt,
+        "stream": False,
+    }
+    if max_tokens is not None:
+        payload["max_tokens"] = max_tokens
+    if system is not None:
+        payload["system"] = system
+    with httpx.Client(timeout=timeout) as client:
+        response = client.post(
+            f"{config.enclave_url}{ENCLAVE_GENERATE_PATH}", json=payload
+        )
+        response.raise_for_status()
+        data = response.json()
+        return str(data.get("response", ""))
+
+
+class EnclaveProvider:
+    """Attested GPU-CC enclave provider — ``is_cloud=False`` via attest-then-mount.
+
+    Sends prompts to a remote confidential-compute endpoint, yet is classified
+    ``is_cloud=False`` because :func:`verify_enclave_attestation` runs before
+    every :meth:`complete` call: remote attestation proves the enclave is the
+    expected, operator-unreadable image before any prompt or key leaves the
+    device. This is what lets INTIMATE-tier content get GPU-quality voice output
+    without egressing to a readable cloud — the attestation gate, not a bare
+    flag, is the security boundary (issue #760, decision #757/#755).
+
+    Attributes:
+        config: The LLM configuration carrying the enclave URL, attestation
+            policy, and model name.
+    """
+
+    is_cloud: bool = False
+    """The enclave is operator-unreadable once attested; content stays private."""
+
+    PROVIDER_NAME: str = "Enclave (GPU-CC)"
+    """Display name for the confidential-compute endpoint."""
+
+    DEFAULT_MODEL: str = DEFAULT_MODELS["enclave"]
+    """Default model served by the enclave when the config does not override it."""
+
+    REQUEST_TIMEOUT: float = 120.0
+    """HTTP request timeout for completion calls, in seconds."""
+
+    ATTESTATION_TIMEOUT: float = 10.0
+    """Timeout for the attestation-quote fetch, in seconds."""
+
+    def __init__(self, config: LLMConfig) -> None:
+        """Store the configuration; performs no network I/O.
+
+        Attestation runs at call time (in :meth:`complete`/:attr:`available`) so
+        each egress is gated on a fresh quote — an enclave can be replaced
+        between calls, so a single construction-time check would be stale.
+
+        Args:
+            config: LLM provider configuration (enclave URL + attestation policy).
+        """
+        self.config = config
+
+    @property
+    def model(self) -> str:
+        """The configured enclave model identifier.
+
+        Returns:
+            ``config.model`` verbatim when set; :attr:`DEFAULT_MODEL` when unset.
+        """
+        return _resolve_configured_model(self.config.model, self.DEFAULT_MODEL)
+
+    @property
+    def available(self) -> bool:
+        """Whether the enclave is configured and currently attests successfully.
+
+        Returns:
+            ``True`` when a fresh attestation verifies; ``False`` otherwise (the
+            provider then reports unavailable rather than sending any data).
+        """
+        try:
+            verify_enclave_attestation(self.config, timeout=self.ATTESTATION_TIMEOUT)
+        except EnclaveAttestationError:
+            return False
+        return True
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        max_tokens: int | None = None,
+        system: str | None = None,
+    ) -> Completion:
+        """Attest the enclave, then send *prompt* and return a :class:`Completion`.
+
+        Attestation is verified **first**; on any attestation failure this raises
+        :class:`EnclaveAttestationError` and no prompt is sent — there is no
+        plaintext fallback. Only after attestation succeeds does the prompt leave
+        the device.
+
+        Args:
+            prompt: The fully-formatted prompt.
+            max_tokens: Optional output ceiling forwarded to the enclave.
+            system: Optional system prompt forwarded to the enclave.
+
+        Returns:
+            A :class:`Completion` wrapping the enclave's response text.
+
+        Raises:
+            EnclaveAttestationError: When attestation fails — egress is refused.
+            httpx.HTTPError: On a transport/HTTP error of the generate call.
+        """
+        verify_enclave_attestation(self.config, timeout=self.ATTESTATION_TIMEOUT)
+        text = call_enclave(
+            self.config,
+            prompt,
+            timeout=self.REQUEST_TIMEOUT,
+            max_tokens=max_tokens,
+            system=system,
         )
         return Completion(text=text)
 
@@ -1201,12 +1418,19 @@ def _extract_gemini_usage(response: object) -> dict[str, int] | None:
 #: union as new providers land.
 _PROVIDER_REGISTRY: dict[
     str,
-    type[AnthropicProvider | OllamaProvider | OpenAIProvider | GeminiProvider],
+    type[
+        AnthropicProvider
+        | OllamaProvider
+        | OpenAIProvider
+        | GeminiProvider
+        | EnclaveProvider
+    ],
 ] = {
     "anthropic": AnthropicProvider,
     "ollama": OllamaProvider,
     "openai": OpenAIProvider,
     "gemini": GeminiProvider,
+    "enclave": EnclaveProvider,
 }
 
 

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -133,6 +133,18 @@ class LLMConfig(BaseModel):
     content because the measurement gate stands in front of every call. ``None``
     means no attestation policy is configured, and the provider fails closed."""
 
+    enclave_attestation_pubkey: str | None = None
+    """Hex-encoded Ed25519 **public** key that anchors the enclave attestation.
+
+    The root of trust: the enclave signs each attestation quote (its measurement
+    bound to a fresh, caller-supplied nonce) with the matching private key, and
+    the provider verifies that signature against this public key before any prompt
+    egresses. This is what makes the attestation *cryptographic* rather than a
+    bare string match — an impersonator without the private key cannot forge a
+    quote, and the nonce defeats replay. It is a **public** key, so it is not a
+    secret; ``None`` means no trust anchor is configured and the provider fails
+    closed. See ADR-0006."""
+
     batch_size: int = 50
     """Number of items to process per LLM batch call."""
 

--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -117,6 +117,22 @@ class LLMConfig(BaseModel):
     OpenAI-compatible gateway). ``None`` lets the SDK use its default endpoint
     or its own ``*_BASE_URL`` environment variable. Never holds a secret."""
 
+    enclave_url: str | None = None
+    """Base URL of the attested GPU-CC enclave endpoint (provider ``enclave``).
+
+    The enclave provider verifies remote attestation at ``{enclave_url}/attestation``
+    before sending any prompt to ``{enclave_url}/generate``. ``None`` means the
+    enclave is unconfigured and the provider refuses to run. Never holds a secret."""
+
+    enclave_expected_measurement: str | None = None
+    """The attestation measurement the enclave must present before any egress.
+
+    This is the "attest, then mount" policy: the ``enclave`` provider refuses to
+    send a prompt unless the enclave's attested measurement equals this value, so
+    ``is_cloud=False`` is defended in code — a mis-set flag cannot leak intimate
+    content because the measurement gate stands in front of every call. ``None``
+    means no attestation policy is configured, and the provider fails closed."""
+
     batch_size: int = 50
     """Number of items to process per LLM batch call."""
 

--- a/creek-tools/docs/architecture/ADR/0006-enclave-attestation-trust-model.md
+++ b/creek-tools/docs/architecture/ADR/0006-enclave-attestation-trust-model.md
@@ -1,0 +1,86 @@
+# ADR-0006: Confidential-compute enclave — attestation trust model
+
+- **Status**: Accepted
+- **Date**: 2026-07-01
+- **Driving issues**: #760 (attested GPU-CC enclave provider), #757 / #755 (confidential-hosting / remote-transport decisions), #642 (per-stage model routing)
+
+## Context
+
+The confidential-hosting epic needs the system's most private tier (INTIMATE) to
+get GPU-quality voice output without egressing to a provider that can read it.
+The plan is an operator-run **GPU confidential-compute (GPU-CC) enclave**: the
+model runs in a hardware-encrypted memory enclave the operator cannot read, and
+the client verifies **remote attestation** before sending anything.
+
+`ModelRouter`'s INTIMATE chokepoint (#642/#647) routes INTIMATE work only to
+providers whose class-level `is_cloud` is `False`. So the entire safety of
+sending INTIMATE content to a *remote* enclave rests on one claim: that
+`is_cloud=False` is justified because attestation is verified before any egress.
+If that gate is weak, a mis-set flag — or an impersonator — turns
+intimate-safe into a silent leak. The gate, not the flag, must be the boundary.
+
+An initial implementation verified attestation with a plain HTTP GET plus a
+string comparison of the returned measurement. That cannot distinguish a genuine
+enclave from an impersonator (no signature / root of trust), cannot detect a
+replayed quote (no freshness), and does not require TLS. It was rejected in
+review as not backing its own security claim.
+
+## Decision
+
+The `enclave` provider (`creek/classify/llm/providers.py`) performs a
+**cryptographic attestation handshake before every completion**, and fails
+closed on any failure — there is no plaintext fallback. All of the following
+must hold or the prompt is never sent:
+
+1. **TLS transport.** `enclave_url` must be `https://` (defends the channel and
+   the bearer of any per-request material).
+2. **Freshness / anti-replay.** The client sends a fresh 32-byte random nonce as
+   a challenge; the quote must echo that exact nonce. An old (previously valid)
+   quote cannot be replayed.
+3. **Authenticity / integrity — root of trust.** The quote carries an Ed25519
+   signature over `domain-sep || measurement || nonce`; it must verify under the
+   operator-configured **trust-root public key** (`enclave_attestation_pubkey`).
+   An impersonator without the corresponding private key cannot forge a quote.
+4. **Policy.** The attested `measurement` must equal the configured
+   `enclave_expected_measurement` (the enclave is the expected image).
+
+Configuration (`LLMConfig`): `enclave_url`, `enclave_expected_measurement`, and
+`enclave_attestation_pubkey`. **None of these is a secret** — the public key is,
+by definition, public; the measurement and URL are non-sensitive. No key or
+consent value is ever written to config (consistent with ADR-0003 and the
+cloud-provider rule).
+
+## Consequences
+
+### Positive
+
+- `is_cloud=False` is now *defended in code*: authenticity (signature vs a trust
+  root), freshness (nonce), integrity (signed measurement), and transport (TLS)
+  are all checked before egress, so INTIMATE routing to the enclave is backed by
+  the gate rather than a bare flag.
+- The router needs no change: `is_cloud=False` makes the enclave INTIMATE-eligible
+  and a valid local `default` rescue for an INTIMATE-bound cloud stage.
+- Fail-closed everywhere: every missing prerequisite or failed check raises
+  `EnclaveAttestationError` (a `RuntimeError`) and sends no prompt.
+
+### Negative / boundaries
+
+- **The trust root is operator-provisioned, not a full vendor certificate chain.**
+  This verifies the enclave holds the private key matching the configured public
+  key and reports the expected measurement over a fresh nonce. It does **not**
+  yet validate a hardware attestation report up a vendor PKI (e.g. an NVIDIA
+  GPU-CC / SEV-SNP / TDX quote chained to the vendor root). Provisioning the
+  correct trust-root key and measurement is an operator responsibility; a
+  compromised or mis-provisioned root key would undermine the gate. Extending to
+  full vendor-chain verification is deliberate future work (a follow-up issue),
+  and the boundary is documented so the guarantee is not overstated.
+- Per-call attestation adds one round-trip of latency before each completion
+  (accepted: the enclave path is for high-value voice generation, not bulk
+  classification).
+
+## Revisit when
+
+- A vendor hardware-attestation flow (NVIDIA GPU-CC / SEV-SNP / TDX) is wired so
+  the trust root becomes the vendor PKI rather than an operator-held key.
+- A short-lived attested-session/token model replaces per-call attestation to
+  cut the extra round-trip while preserving freshness.

--- a/creek-tools/tests/test_enclave_provider.py
+++ b/creek-tools/tests/test_enclave_provider.py
@@ -1,0 +1,260 @@
+"""Attested GPU-CC enclave provider — ``is_cloud=False`` via attest-then-mount (#760).
+
+The enclave provider sends prompts to a remote confidential-compute (GPU-CC)
+endpoint, yet is classified ``is_cloud=False`` because it **verifies remote
+attestation of the enclave before any prompt or key leaves the device**. The
+attestation gate is the security boundary that justifies the flag: these tests
+defend it directly —
+
+- attestation must succeed (measurement matches the configured expectation)
+  *before* the generate call; a mismatch, an unreachable attestation endpoint,
+  or a missing attestation policy **refuses and sends no prompt data**;
+- because ``is_cloud=False``, the ``ModelRouter`` INTIMATE chokepoint admits the
+  enclave for INTIMATE-tier work (and it can serve as the local ``default``
+  rescue), while genuine cloud providers stay ``is_cloud=True`` and are still
+  redirected away from INTIMATE.
+
+Attestation is mocked here (no live enclave in CI); the measurement string is a
+test literal, not real attestation material.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from creek.classify.llm.base import LLMProvider
+from creek.classify.llm.completion import Completion
+from creek.classify.llm.providers import (
+    DEFAULT_MODELS,
+    EnclaveProvider,
+    build_provider,
+    known_providers,
+    provider_display_name,
+    provider_is_cloud,
+)
+from creek.classify.llm.router import ModelRouter
+from creek.config import LLMConfig, LLMRoutingConfig
+from creek.models import PrivacyTier
+
+_ENCLAVE_URL = "https://enclave.internal:8443"
+_MEASUREMENT = "sha384:attested-measurement-abc123"  # test literal, not real
+_PATCH_TARGET = "creek.classify.llm.providers.httpx.Client"
+
+
+def _config(
+    *, url: str | None = _ENCLAVE_URL, measurement: str | None = _MEASUREMENT
+) -> LLMConfig:
+    """Build an enclave ``LLMConfig`` with the endpoint + attestation policy set."""
+    return LLMConfig(
+        provider="enclave",
+        enclave_url=url,
+        enclave_expected_measurement=measurement,
+    )
+
+
+def _patched_client(
+    *,
+    attest_measurement: str | None = _MEASUREMENT,
+    attest_error: Exception | None = None,
+    gen_text: str = "grounded voice output",
+) -> tuple[MagicMock, MagicMock]:
+    """Return a patched ``httpx.Client`` class and the shared request ctx mock.
+
+    The context manager's ``.get`` serves the attestation quote and ``.post``
+    serves the generate response, so a test can assert ``ctx.post`` was never
+    called when attestation refuses.
+    """
+    ctx = MagicMock()
+    if attest_error is not None:
+        ctx.get.side_effect = attest_error
+    else:
+        att = MagicMock(status_code=200)
+        att.json.return_value = {"measurement": attest_measurement}
+        att.raise_for_status.return_value = None
+        ctx.get.return_value = att
+
+    gen = MagicMock(status_code=200)
+    gen.json.return_value = {"response": gen_text}
+    gen.raise_for_status.return_value = None
+    ctx.post.return_value = gen
+
+    client_cls = MagicMock()
+    client_cls.return_value.__enter__ = MagicMock(return_value=ctx)
+    client_cls.return_value.__exit__ = MagicMock(return_value=False)
+    return client_cls, ctx
+
+
+# --------------------------------------------------------------------------- #
+# Registration + is_cloud classification
+# --------------------------------------------------------------------------- #
+
+
+def test_enclave_provider_is_not_cloud() -> None:
+    """The enclave is ``is_cloud=False`` — attestation makes it operator-unreadable."""
+    assert EnclaveProvider.is_cloud is False
+    assert provider_is_cloud("enclave") is False
+
+
+def test_cloud_providers_remain_cloud() -> None:
+    """Adding the enclave does not reclassify the genuine cloud backends."""
+    assert provider_is_cloud("anthropic") is True
+    assert provider_is_cloud("openai") is True
+    assert provider_is_cloud("gemini") is True
+
+
+def test_enclave_registered_and_config_accepts_it() -> None:
+    """The provider registers, builds, satisfies the protocol, and validates."""
+    assert "enclave" in known_providers()
+    provider = build_provider(_config())
+    assert isinstance(provider, EnclaveProvider)
+    assert isinstance(provider, LLMProvider)
+    # Registry-driven config validation accepts the name (no separate allowlist).
+    assert LLMConfig(provider="enclave").provider == "enclave"
+    assert provider_display_name("enclave") == EnclaveProvider.PROVIDER_NAME
+
+
+def test_enclave_default_model_in_matrix() -> None:
+    """The enclave's default model lives in the one-place ``DEFAULT_MODELS`` matrix."""
+    assert set(DEFAULT_MODELS) == set(known_providers())
+    assert DEFAULT_MODELS["enclave"] == EnclaveProvider.DEFAULT_MODEL
+
+
+# --------------------------------------------------------------------------- #
+# Attest-then-mount: the egress gate
+# --------------------------------------------------------------------------- #
+
+
+def test_complete_attests_before_sending_then_returns_completion() -> None:
+    """On a valid attestation, the prompt is sent and a ``Completion`` returned."""
+    client_cls, ctx = _patched_client(gen_text="voice in Geoff's register")
+    with patch(_PATCH_TARGET, client_cls):
+        result = build_provider(_config()).complete("draft this")
+    assert isinstance(result, Completion)
+    assert result.text == "voice in Geoff's register"
+    # Attestation (GET) happened, and the generate (POST) happened after it.
+    assert ctx.get.called
+    assert ctx.post.called
+    # The attestation endpoint is hit, not the prompt endpoint, for the quote.
+    assert "/attestation" in ctx.get.call_args.args[0]
+
+
+def test_measurement_mismatch_refuses_and_sends_no_prompt() -> None:
+    """A wrong attested measurement refuses egress — the prompt is never sent."""
+    client_cls, ctx = _patched_client(attest_measurement="sha384:WRONG-untrusted")
+    with patch(_PATCH_TARGET, client_cls), pytest.raises(RuntimeError, match="attest"):
+        build_provider(_config()).complete("intimate journal entry")
+    ctx.post.assert_not_called()  # no data egress on attestation failure
+
+
+def test_unreachable_attestation_endpoint_refuses_and_sends_no_prompt() -> None:
+    """If attestation cannot be verified, refuse — never fall back to egress."""
+    client_cls, ctx = _patched_client(attest_error=httpx.ConnectError("no route"))
+    with patch(_PATCH_TARGET, client_cls), pytest.raises(RuntimeError):
+        build_provider(_config()).complete("intimate journal entry")
+    ctx.post.assert_not_called()
+
+
+def test_missing_attestation_policy_refuses_and_sends_no_prompt() -> None:
+    """With no expected measurement configured, the provider cannot attest → refuse."""
+    client_cls, ctx = _patched_client()
+    with (
+        patch(_PATCH_TARGET, client_cls),
+        pytest.raises(RuntimeError, match=r"attest|measurement"),
+    ):
+        build_provider(_config(measurement=None)).complete("intimate journal entry")
+    ctx.post.assert_not_called()
+
+
+def test_missing_enclave_url_refuses_and_sends_no_prompt() -> None:
+    """With no endpoint configured, the provider refuses before any network call."""
+    client_cls, ctx = _patched_client()
+    with (
+        patch(_PATCH_TARGET, client_cls),
+        pytest.raises(RuntimeError, match="enclave"),
+    ):
+        build_provider(_config(url=None)).complete("intimate journal entry")
+    ctx.get.assert_not_called()
+    ctx.post.assert_not_called()
+
+
+def test_available_true_when_attestation_verifies() -> None:
+    """``available`` reflects a live, verifiable attestation."""
+    client_cls, _ = _patched_client()
+    with patch(_PATCH_TARGET, client_cls):
+        assert build_provider(_config()).available is True
+
+
+def test_available_false_when_attestation_fails() -> None:
+    """``available`` is False when the enclave cannot be attested."""
+    client_cls, _ = _patched_client(attest_measurement="sha384:WRONG")
+    with patch(_PATCH_TARGET, client_cls):
+        assert build_provider(_config()).available is False
+
+
+def test_model_resolves_from_matrix_default() -> None:
+    """The model id defaults to the matrix entry and honors an explicit override."""
+    assert build_provider(_config()).model == DEFAULT_MODELS["enclave"]
+    override = LLMConfig(
+        provider="enclave",
+        model="custom-cc-model",
+        enclave_url=_ENCLAVE_URL,
+        enclave_expected_measurement=_MEASUREMENT,
+    )
+    assert EnclaveProvider(override).model == "custom-cc-model"
+
+
+# --------------------------------------------------------------------------- #
+# Router: INTIMATE may use the enclave; the chokepoint still holds for cloud
+# --------------------------------------------------------------------------- #
+
+
+def _routing(**stages: dict[str, object]) -> LLMRoutingConfig:
+    """Build a routing config from raw per-stage dicts."""
+    return LLMRoutingConfig.model_validate(stages)
+
+
+def test_intimate_routes_to_enclave_unredirected() -> None:
+    """An INTIMATE fragment may legitimately use the attested enclave for generation."""
+    router = ModelRouter(
+        _routing(
+            default={"provider": "ollama"},
+            generation={
+                "provider": "enclave",
+                "enclave_url": _ENCLAVE_URL,
+                "enclave_expected_measurement": _MEASUREMENT,
+            },
+        )
+    )
+    # Non-intimate and intimate both resolve to the enclave — not redirected.
+    assert router.resolve("generation").provider == "enclave"
+    assert router.resolve("generation", PrivacyTier.INTIMATE).provider == "enclave"
+
+
+def test_cloud_generation_still_redirected_for_intimate() -> None:
+    """The chokepoint still holds: a cloud provider is redirected off INTIMATE."""
+    router = ModelRouter(
+        _routing(
+            default={"provider": "ollama"},
+            generation={"provider": "anthropic"},
+        )
+    )
+    assert router.resolve("generation", PrivacyTier.INTIMATE).provider == "ollama"
+
+
+def test_enclave_can_be_local_default_rescue_for_intimate() -> None:
+    """The enclave can serve as the local ``default`` that rescues an INTIMATE call."""
+    router = ModelRouter(
+        _routing(
+            default={
+                "provider": "enclave",
+                "enclave_url": _ENCLAVE_URL,
+                "enclave_expected_measurement": _MEASUREMENT,
+            },
+            generation={"provider": "anthropic"},
+        )
+    )
+    # Cloud generation for INTIMATE is redirected to the (non-cloud) enclave default.
+    assert router.resolve("generation", PrivacyTier.INTIMATE).provider == "enclave"

--- a/creek-tools/tests/test_enclave_provider.py
+++ b/creek-tools/tests/test_enclave_provider.py
@@ -1,21 +1,26 @@
 """Attested GPU-CC enclave provider — ``is_cloud=False`` via attest-then-mount (#760).
 
 The enclave provider sends prompts to a remote confidential-compute (GPU-CC)
-endpoint, yet is classified ``is_cloud=False`` because it **verifies remote
-attestation of the enclave before any prompt or key leaves the device**. The
-attestation gate is the security boundary that justifies the flag: these tests
-defend it directly —
+endpoint, yet is classified ``is_cloud=False`` because it **cryptographically
+verifies remote attestation before any prompt or key leaves the device**. The
+attestation is the security boundary that justifies the flag, so these tests
+defend it directly — an attestation succeeds only when, over ``https``:
 
-- attestation must succeed (measurement matches the configured expectation)
-  *before* the generate call; a mismatch, an unreachable attestation endpoint,
-  or a missing attestation policy **refuses and sends no prompt data**;
-- because ``is_cloud=False``, the ``ModelRouter`` INTIMATE chokepoint admits the
-  enclave for INTIMATE-tier work (and it can serve as the local ``default``
-  rescue), while genuine cloud providers stay ``is_cloud=True`` and are still
-  redirected away from INTIMATE.
+- the enclave echoes the fresh per-call nonce (freshness / anti-replay);
+- the quote's signature over ``measurement || nonce`` validates under the
+  operator-configured Ed25519 trust-root key (authenticity — a forger without
+  the private key cannot produce it);
+- the attested measurement equals the configured expectation.
 
-Attestation is mocked here (no live enclave in CI); the measurement string is a
-test literal, not real attestation material.
+A missing prerequisite, insecure transport, unreachable endpoint, replayed
+nonce, forged signature, or measurement mismatch all **refuse and send no
+prompt**. Because ``is_cloud=False``, the ``ModelRouter`` INTIMATE chokepoint
+then admits the enclave for INTIMATE work (and it can be the local ``default``
+rescue), while genuine cloud providers stay ``is_cloud=True``.
+
+Attestation is mocked here (no live enclave in CI); the trust-root keypair is
+generated per test session and the measurement is a test literal — no real
+attestation material is hardcoded.
 """
 
 from __future__ import annotations
@@ -24,12 +29,14 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 from creek.classify.llm.base import LLMProvider
 from creek.classify.llm.completion import Completion
 from creek.classify.llm.providers import (
     DEFAULT_MODELS,
     EnclaveProvider,
+    _attestation_signed_payload,
     build_provider,
     known_providers,
     provider_display_name,
@@ -43,43 +50,77 @@ _ENCLAVE_URL = "https://enclave.internal:8443"
 _MEASUREMENT = "sha384:attested-measurement-abc123"  # test literal, not real
 _PATCH_TARGET = "creek.classify.llm.providers.httpx.Client"
 
+# The genuine enclave's attestation keypair; its public half is the trust root.
+_TRUSTED_KEY = Ed25519PrivateKey.generate()
+_TRUSTED_PUBKEY_HEX = _TRUSTED_KEY.public_key().public_bytes_raw().hex()
+# An unrelated key an impersonator might sign with (never the configured root).
+_IMPOSTOR_KEY = Ed25519PrivateKey.generate()
+
 
 def _config(
-    *, url: str | None = _ENCLAVE_URL, measurement: str | None = _MEASUREMENT
+    *,
+    url: str | None = _ENCLAVE_URL,
+    measurement: str | None = _MEASUREMENT,
+    pubkey: str | None = _TRUSTED_PUBKEY_HEX,
 ) -> LLMConfig:
-    """Build an enclave ``LLMConfig`` with the endpoint + attestation policy set."""
+    """Build an enclave ``LLMConfig`` with endpoint, policy, and trust root set."""
     return LLMConfig(
         provider="enclave",
         enclave_url=url,
         enclave_expected_measurement=measurement,
+        enclave_attestation_pubkey=pubkey,
     )
 
 
 def _patched_client(
     *,
-    attest_measurement: str | None = _MEASUREMENT,
+    sign_key: Ed25519PrivateKey | None = None,
+    measurement: str = _MEASUREMENT,
+    tamper_nonce: bool = False,
     attest_error: Exception | None = None,
     gen_text: str = "grounded voice output",
+    gen_error: Exception | None = None,
 ) -> tuple[MagicMock, MagicMock]:
     """Return a patched ``httpx.Client`` class and the shared request ctx mock.
 
-    The context manager's ``.get`` serves the attestation quote and ``.post``
+    ``.get`` serves a **signed** attestation quote: it reads the fresh nonce from
+    the request params and returns ``{measurement, nonce, signature}`` signed by
+    *sign_key* (the trusted key by default) over ``measurement || echoed-nonce``.
+    ``tamper_nonce`` makes the enclave echo a stale nonce (replay). ``.post``
     serves the generate response, so a test can assert ``ctx.post`` was never
     called when attestation refuses.
     """
+    key = sign_key or _TRUSTED_KEY
     ctx = MagicMock()
+
     if attest_error is not None:
         ctx.get.side_effect = attest_error
     else:
-        att = MagicMock(status_code=200)
-        att.json.return_value = {"measurement": attest_measurement}
-        att.raise_for_status.return_value = None
-        ctx.get.return_value = att
 
-    gen = MagicMock(status_code=200)
-    gen.json.return_value = {"response": gen_text}
-    gen.raise_for_status.return_value = None
-    ctx.post.return_value = gen
+        def _get(
+            url: str, params: dict[str, str] | None = None, **_: object
+        ) -> MagicMock:
+            sent = (params or {}).get("nonce", "")
+            echoed = "stale-nonce-deadbeef" if tamper_nonce else sent
+            signature = key.sign(_attestation_signed_payload(measurement, echoed)).hex()
+            resp = MagicMock(status_code=200)
+            resp.json.return_value = {
+                "measurement": measurement,
+                "nonce": echoed,
+                "signature": signature,
+            }
+            resp.raise_for_status.return_value = None
+            return resp
+
+        ctx.get.side_effect = _get
+
+    if gen_error is not None:
+        ctx.post.side_effect = gen_error
+    else:
+        gen = MagicMock(status_code=200)
+        gen.json.return_value = {"response": gen_text}
+        gen.raise_for_status.return_value = None
+        ctx.post.return_value = gen
 
     client_cls = MagicMock()
     client_cls.return_value.__enter__ = MagicMock(return_value=ctx)
@@ -123,52 +164,94 @@ def test_enclave_default_model_in_matrix() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Attest-then-mount: the egress gate
+# Attest-then-mount: the cryptographic egress gate
 # --------------------------------------------------------------------------- #
 
 
 def test_complete_attests_before_sending_then_returns_completion() -> None:
-    """On a valid attestation, the prompt is sent and a ``Completion`` returned."""
+    """A valid signed attestation ⇒ prompt sent, ``Completion`` returned."""
     client_cls, ctx = _patched_client(gen_text="voice in Geoff's register")
     with patch(_PATCH_TARGET, client_cls):
         result = build_provider(_config()).complete("draft this")
     assert isinstance(result, Completion)
     assert result.text == "voice in Geoff's register"
-    # Attestation (GET) happened, and the generate (POST) happened after it.
-    assert ctx.get.called
-    assert ctx.post.called
-    # The attestation endpoint is hit, not the prompt endpoint, for the quote.
+    assert ctx.get.called  # attestation challenge issued
+    assert ctx.post.called  # generate happened, after attestation
     assert "/attestation" in ctx.get.call_args.args[0]
 
 
-def test_measurement_mismatch_refuses_and_sends_no_prompt() -> None:
-    """A wrong attested measurement refuses egress — the prompt is never sent."""
-    client_cls, ctx = _patched_client(attest_measurement="sha384:WRONG-untrusted")
-    with patch(_PATCH_TARGET, client_cls), pytest.raises(RuntimeError, match="attest"):
+def test_forged_signature_refuses_and_sends_no_prompt() -> None:
+    """A quote signed by the wrong key (impersonator) refuses — no prompt sent."""
+    client_cls, ctx = _patched_client(sign_key=_IMPOSTOR_KEY)
+    with (
+        patch(_PATCH_TARGET, client_cls),
+        pytest.raises(RuntimeError, match="signature"),
+    ):
         build_provider(_config()).complete("intimate journal entry")
-    ctx.post.assert_not_called()  # no data egress on attestation failure
+    ctx.post.assert_not_called()
+
+
+def test_replayed_nonce_refuses_and_sends_no_prompt() -> None:
+    """A quote echoing a stale nonce (replay) refuses — no prompt sent."""
+    client_cls, ctx = _patched_client(tamper_nonce=True)
+    with patch(_PATCH_TARGET, client_cls), pytest.raises(RuntimeError, match="nonce"):
+        build_provider(_config()).complete("intimate journal entry")
+    ctx.post.assert_not_called()
+
+
+def test_measurement_mismatch_refuses_and_sends_no_prompt() -> None:
+    """A validly-signed quote for the wrong measurement refuses — no prompt sent."""
+    client_cls, ctx = _patched_client(measurement="sha384:WRONG-untrusted")
+    with (
+        patch(_PATCH_TARGET, client_cls),
+        pytest.raises(RuntimeError, match="measurement"),
+    ):
+        build_provider(_config()).complete("intimate journal entry")
+    ctx.post.assert_not_called()
+
+
+def test_insecure_http_url_refuses_before_any_network() -> None:
+    """A non-``https`` enclave URL refuses before any request leaves the device."""
+    client_cls, ctx = _patched_client()
+    with patch(_PATCH_TARGET, client_cls), pytest.raises(RuntimeError, match="https"):
+        build_provider(_config(url="http://enclave.internal:8443")).complete("x")
+    ctx.get.assert_not_called()
+    ctx.post.assert_not_called()
 
 
 def test_unreachable_attestation_endpoint_refuses_and_sends_no_prompt() -> None:
-    """If attestation cannot be verified, refuse — never fall back to egress."""
+    """If attestation cannot be fetched, refuse — never fall back to egress."""
     client_cls, ctx = _patched_client(attest_error=httpx.ConnectError("no route"))
     with patch(_PATCH_TARGET, client_cls), pytest.raises(RuntimeError):
         build_provider(_config()).complete("intimate journal entry")
     ctx.post.assert_not_called()
 
 
-def test_missing_attestation_policy_refuses_and_sends_no_prompt() -> None:
-    """With no expected measurement configured, the provider cannot attest → refuse."""
+def test_missing_attestation_policy_refuses_before_any_network() -> None:
+    """With no expected measurement, the provider cannot attest → refuse."""
     client_cls, ctx = _patched_client()
     with (
         patch(_PATCH_TARGET, client_cls),
-        pytest.raises(RuntimeError, match=r"attest|measurement"),
+        pytest.raises(RuntimeError, match=r"measurement|policy"),
     ):
         build_provider(_config(measurement=None)).complete("intimate journal entry")
+    ctx.get.assert_not_called()
     ctx.post.assert_not_called()
 
 
-def test_missing_enclave_url_refuses_and_sends_no_prompt() -> None:
+def test_missing_trust_root_refuses_before_any_network() -> None:
+    """With no configured trust-root key, the provider cannot attest → refuse."""
+    client_cls, ctx = _patched_client()
+    with (
+        patch(_PATCH_TARGET, client_cls),
+        pytest.raises(RuntimeError, match=r"trust|pubkey"),
+    ):
+        build_provider(_config(pubkey=None)).complete("intimate journal entry")
+    ctx.get.assert_not_called()
+    ctx.post.assert_not_called()
+
+
+def test_missing_enclave_url_refuses_before_any_network() -> None:
     """With no endpoint configured, the provider refuses before any network call."""
     client_cls, ctx = _patched_client()
     with (
@@ -180,6 +263,15 @@ def test_missing_enclave_url_refuses_and_sends_no_prompt() -> None:
     ctx.post.assert_not_called()
 
 
+def test_generate_error_propagates_after_successful_attestation() -> None:
+    """A transport error on the generate call surfaces (attestation already passed)."""
+    client_cls, ctx = _patched_client(gen_error=httpx.ConnectError("gen down"))
+    with patch(_PATCH_TARGET, client_cls), pytest.raises(httpx.HTTPError):
+        build_provider(_config()).complete("draft this")
+    assert ctx.get.called  # attestation succeeded
+    assert ctx.post.called  # the failure was on the generate call, not the gate
+
+
 def test_available_true_when_attestation_verifies() -> None:
     """``available`` reflects a live, verifiable attestation."""
     client_cls, _ = _patched_client()
@@ -189,7 +281,7 @@ def test_available_true_when_attestation_verifies() -> None:
 
 def test_available_false_when_attestation_fails() -> None:
     """``available`` is False when the enclave cannot be attested."""
-    client_cls, _ = _patched_client(attest_measurement="sha384:WRONG")
+    client_cls, _ = _patched_client(sign_key=_IMPOSTOR_KEY)
     with patch(_PATCH_TARGET, client_cls):
         assert build_provider(_config()).available is False
 
@@ -202,6 +294,7 @@ def test_model_resolves_from_matrix_default() -> None:
         model="custom-cc-model",
         enclave_url=_ENCLAVE_URL,
         enclave_expected_measurement=_MEASUREMENT,
+        enclave_attestation_pubkey=_TRUSTED_PUBKEY_HEX,
     )
     assert EnclaveProvider(override).model == "custom-cc-model"
 
@@ -225,10 +318,10 @@ def test_intimate_routes_to_enclave_unredirected() -> None:
                 "provider": "enclave",
                 "enclave_url": _ENCLAVE_URL,
                 "enclave_expected_measurement": _MEASUREMENT,
+                "enclave_attestation_pubkey": _TRUSTED_PUBKEY_HEX,
             },
         )
     )
-    # Non-intimate and intimate both resolve to the enclave — not redirected.
     assert router.resolve("generation").provider == "enclave"
     assert router.resolve("generation", PrivacyTier.INTIMATE).provider == "enclave"
 
@@ -252,9 +345,9 @@ def test_enclave_can_be_local_default_rescue_for_intimate() -> None:
                 "provider": "enclave",
                 "enclave_url": _ENCLAVE_URL,
                 "enclave_expected_measurement": _MEASUREMENT,
+                "enclave_attestation_pubkey": _TRUSTED_PUBKEY_HEX,
             },
             generation={"provider": "anthropic"},
         )
     )
-    # Cloud generation for INTIMATE is redirected to the (non-cloud) enclave default.
     assert router.resolve("generation", PrivacyTier.INTIMATE).provider == "enclave"


### PR DESCRIPTION
## Summary

Adds an operator-run confidential-compute (**GPU-CC**) enclave as an LLM provider (`provider: enclave`) so the voice/`generation` stage (and Writing Desk roles) get GPU-quality output **on the most private tier**. It is classified **`is_cloud=False`** because it performs a **full cryptographic attestation handshake before any prompt egresses** — that gate, not a bare flag, is the security boundary. Resolves the compute decision from #755/#757.

### What ships
- **`creek/classify/llm/providers.py`** — `verify_enclave_attestation` runs first in every `complete()` (and `available`), fail-closed, before any egress:
  - `enclave_url` must be **`https://`** (refused before any network otherwise);
  - a fresh **32-byte nonce** (`secrets.token_hex`) is sent as a challenge and the quote must echo it (`hmac.compare_digest`) — **anti-replay**;
  - the quote's **Ed25519 signature** over `domain-sep || measurement || nonce` must validate under the operator-configured trust-root key `enclave_attestation_pubkey` — **authenticity** (an impersonator without the private key can't forge it);
  - the attested **measurement** must equal `enclave_expected_measurement`.
  Registered in `_PROVIDER_REGISTRY` (+`DEFAULT_MODELS`); `EnclaveAttestationError` subclasses `RuntimeError` (fail-closed).
- **`creek/config.py`** — `LLMConfig` gains `enclave_url`, `enclave_expected_measurement`, `enclave_attestation_pubkey` (a **public** key — not a secret).
- **Router** — no change: `_enforce_local_for_intimate` already admits `is_cloud=False`, so INTIMATE can route to the enclave and the enclave can be the local `default` rescue; cloud stays `is_cloud=True` and is still redirected off INTIMATE.

## Test plan
`tests/test_enclave_provider.py` (**20 cases**, attestation mocked — no live enclave in CI): valid signed attestation ⇒ prompt sent; **forged signature**, **replayed nonce**, measurement mismatch, **insecure `http://`**, missing policy / trust-root / url, and unreachable endpoint each ⇒ refuse with **`ctx.post` never called** (no egress); a generate-error *after* a successful attestation propagates. Plus registry/config/matrix and INTIMATE-routing tests.

Local `./scripts/check-all.sh`: ruff/format/mypy/pylint/refurb/tryceratops/complexity/security clean; coverage 93.8%. (The known author-desk credential-dependent failures are the local-only set green in CI.)

## Docs
README LLM-providers row + attestation note; **ADR-0006** records the trust model and its boundary (operator-provisioned root key, not yet a full vendor certificate chain). Full vendor-chain attestation is tracked in **#778**.

Refs #757 · #755 · #642
Closes #760