### PR TITLE
perf(classify): make llm.max_concurrent effective (engine loop was serial)

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -28,7 +28,10 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
+from functools import partial
 from pathlib import Path  # noqa: TC003  # no issue: runtime dataclass field
 from typing import TYPE_CHECKING
 
@@ -77,7 +80,7 @@ _PROCESSING_LOG_SUBDIR = ("00-Creek-Meta", "Processing-Log")
 """Per-vault subdirectory carrying the LLM progress + trace logs."""
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
     from creek.config import ClassificationConfig, CreekConfig, LLMConfig
 
@@ -308,19 +311,7 @@ def run_classify(
     # #647). Resolving here also fails the run loudly (IntimateRoutingError) when
     # classification is cloud and no local default exists to route Intimate to.
     tier_classifiers = build_tier_classifiers(config) if method == LLM_METHOD else None
-    if tier_classifiers is not None:
-        for classifier in tier_classifiers.distinct():
-            if not classifier.available:
-                # Refuse to iterate when a provider is unreachable so the vault
-                # is never stamped with ``classification_method: llm`` for
-                # fragments the LLM never actually saw. The orchestrator already
-                # logged the provider-specific reason (missing API key, missing
-                # consent env var, Ollama down) as a WARNING; we capture it here
-                # so the remediation hint is not buried in stderr.
-                raise LLMProviderUnavailableError(
-                    provider=classifier.config.provider,
-                    detail=_describe_llm_unavailability(classifier.config.provider),
-                )
+    _assert_classifiers_available(tier_classifiers)
     counts = _RunCounts()
     progress_path: Path | None = None
     trace_log_path: Path | None = None
@@ -342,20 +333,33 @@ def run_classify(
         VaultWriter(vault_path=vault_path) if reatomize_enabled else None
     )
 
-    for md_file in sorted(fragments_root.rglob("*.md")):
-        _process_file(
-            md_file=md_file,
-            method=method,
-            force=force,
-            rules=rules,
-            audience=audience,
-            tier_classifiers=tier_classifiers,
-            classification_config=config.classification,
-            counts=counts,
-            progress_path=progress_path,
-            trace_log_path=trace_log_path,
-            vault_writer=vault_writer,
-        )
+    files = sorted(fragments_root.rglob("*.md"))
+    process_one = partial(
+        _process_file,
+        method=method,
+        force=force,
+        rules=rules,
+        audience=audience,
+        tier_classifiers=tier_classifiers,
+        classification_config=config.classification,
+        counts=counts,
+        progress_path=progress_path,
+        trace_log_path=trace_log_path,
+        vault_writer=vault_writer,
+        lock=threading.Lock(),
+    )
+
+    # Concurrency (#764): the per-fragment LLM call is network-bound, so running
+    # files through a thread pool sized by the classification stage's
+    # ``max_concurrent`` lets the calls overlap — previously this loop was serial
+    # and the knob had no effect. Re-atomization keeps a single shared writer, and
+    # the rules path is local CPU with no I/O to overlap, so both stay serial.
+    workers = (
+        config.llm.for_stage("classification").max_concurrent
+        if method == LLM_METHOD and vault_writer is None
+        else 1
+    )
+    _dispatch_files(files, process_one, workers=workers)
 
     return ClassifySummary(
         total=counts.total,
@@ -402,9 +406,60 @@ def _record_if_preserved(
     return False
 
 
-def _process_file(
+def _assert_classifiers_available(tier_classifiers: TierClassifiers | None) -> None:
+    """Raise if any per-tier classifier's provider is unreachable (#666).
+
+    Refuses to iterate when a provider is unreachable so the vault is never
+    stamped with ``classification_method: llm`` for fragments the LLM never saw.
+    The orchestrator already logged the provider-specific reason (missing key,
+    missing consent, Ollama down) as a WARNING; this surfaces the remediation
+    hint instead of burying it in stderr.
+
+    Args:
+        tier_classifiers: The per-tier classifier set, or ``None`` for rules.
+
+    Raises:
+        LLMProviderUnavailableError: When a configured provider is unavailable.
+    """
+    if tier_classifiers is None:
+        return
+    for classifier in tier_classifiers.distinct():
+        if not classifier.available:
+            raise LLMProviderUnavailableError(
+                provider=classifier.config.provider,
+                detail=_describe_llm_unavailability(classifier.config.provider),
+            )
+
+
+def _dispatch_files(
+    files: list[Path],
+    process_one: Callable[[Path], None],
     *,
+    workers: int,
+) -> None:
+    """Run *process_one* over *files* — concurrently when ``workers > 1`` (#764).
+
+    A thread pool sized by *workers* lets the network-bound per-fragment LLM
+    calls overlap; ``workers == 1`` preserves the original strictly-serial loop.
+    The map is drained so every file completes (and any error surfaces) before
+    returning.
+
+    Args:
+        files: Fragment files to process, in order.
+        process_one: Callback classifying and writing one file.
+        workers: Thread-pool width (1 = serial).
+    """
+    if workers > 1:
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            list(executor.map(process_one, files))
+    else:
+        for md_file in files:
+            process_one(md_file)
+
+
+def _process_file(
     md_file: Path,
+    *,
     method: str,
     force: bool,
     rules: RuleClassifier,
@@ -415,6 +470,7 @@ def _process_file(
     progress_path: Path | None,
     trace_log_path: Path | None,
     vault_writer: VaultWriter | None,
+    lock: threading.Lock,
 ) -> None:
     """Classify a single fragment file and update ``counts`` in place.
 
@@ -445,31 +501,45 @@ def _process_file(
         vault_writer: Shared :class:`VaultWriter` for persisting
             FEAT-023 children. ``None`` when re-atomization is not
             enabled for this run.
+        lock: Guards the shared-state sections (``counts`` mutation, the
+            progress/trace-log appends, and the re-atomization writer) so this
+            function is safe to run on many worker threads at once. The
+            expensive, network-bound classify call runs *outside* the lock so
+            calls from different threads overlap — the fix for #764. An
+            uncontended lock is passed on the serial path.
     """
-    record = _load_classifiable_fragment(
-        md_file=md_file,
-        counts=counts,
-    )
-    if record is None:
-        return
-    fragment, body, raw = record
+    with lock:
+        record = _load_classifiable_fragment(
+            md_file=md_file,
+            counts=counts,
+        )
+        if record is None:
+            return
+        fragment, body, raw = record
 
-    # Per-tier routing (#666): pick the classifier for this fragment's privacy
-    # tier. ``tier_of`` fails closed to INTIMATE for an unrecognised tier, so an
-    # unknown fragment is classified locally rather than risking cloud egress.
-    llm = (
-        tier_classifiers.for_tier(tier_of(fragment))
-        if tier_classifiers is not None
-        else None
-    )
+        # Per-tier routing (#666): pick the classifier for this fragment's
+        # privacy tier. ``tier_of`` fails closed to INTIMATE for an unrecognised
+        # tier, so an unknown fragment is classified locally rather than risking
+        # cloud egress.
+        llm = (
+            tier_classifiers.for_tier(tier_of(fragment))
+            if tier_classifiers is not None
+            else None
+        )
 
-    # Skip fragments whose previous run already settled the classification.
-    # Tracked on distinct counters so the CLI summary can label "manual
-    # preserved" and "previously LLM-classified preserved" honestly
-    # (issue #321).
-    if not force and _record_if_preserved(raw, counts):
-        return
+        # Skip fragments whose previous run already settled the classification.
+        # Tracked on distinct counters so the CLI summary can label "manual
+        # preserved" and "previously LLM-classified preserved" honestly
+        # (issue #321).
+        if not force and _record_if_preserved(raw, counts):
+            return
 
+    # The provider call is the expensive, network-bound step (#764). It runs
+    # WITHOUT the lock so calls from different worker threads overlap — that is
+    # what makes ``max_concurrent`` effective. The classifiers are pre-warmed
+    # (their availability was checked before the loop) and read-only during the
+    # run, and each fragment is an independent input, so concurrent calls are
+    # safe.
     new_fragment, was_skipped, reasoning = _classify_one(
         fragment=fragment,
         body=body,
@@ -485,39 +555,42 @@ def _process_file(
     # so it runs on both the rules and LLM paths and stays idempotent.
     new_fragment = audience.classify_and_enforce(new_fragment, body)
 
-    # FEAT-023 wire-up (issue #318): when ``classification.reatomize`` is
-    # True we run the orchestrator on the root fragment and persist any
-    # newly-derived child fragments. The root's frontmatter still flows
-    # through the existing write path below so the per-run provenance
-    # stamps (method, classified_at, reasoning) stay consistent with the
-    # non-reatomize code path.
-    if vault_writer is not None and not was_skipped:
-        _maybe_reatomize_and_persist(
-            root_fragment=new_fragment,
-            body=body,
-            rules=rules,
-            llm=llm,
-            classification_config=classification_config,
-            vault_writer=vault_writer,
-            counts=counts,
-        )
+    with lock:
+        # FEAT-023 wire-up (issue #318): when ``classification.reatomize`` is
+        # True we run the orchestrator on the root fragment and persist any
+        # newly-derived child fragments. The root's frontmatter still flows
+        # through the existing write path below so the per-run provenance
+        # stamps (method, classified_at, reasoning) stay consistent with the
+        # non-reatomize code path. (Re-atomization runs serially — see
+        # run_classify — so the shared VaultWriter is never touched concurrently.)
+        if vault_writer is not None and not was_skipped:
+            _maybe_reatomize_and_persist(
+                root_fragment=new_fragment,
+                body=body,
+                rules=rules,
+                llm=llm,
+                classification_config=classification_config,
+                vault_writer=vault_writer,
+                counts=counts,
+            )
 
-    _finalise_fragment_write(
-        md_file=md_file,
-        new_fragment=new_fragment,
-        body=body,
-        raw=raw,
-        reasoning=reasoning,
-        method=method,
-        # The fragment's tier picked the classifier (#666); record its provider
-        # so a later quality-aware run can rank local-LLM vs cloud-LLM. Only an
-        # actual ``llm`` write keeps it (the writer clears it otherwise).
-        provider=llm.config.provider if llm is not None else None,
-        was_skipped=was_skipped,
-        counts=counts,
-        progress_path=progress_path,
-        trace_log_path=trace_log_path,
-    )
+        _finalise_fragment_write(
+            md_file=md_file,
+            new_fragment=new_fragment,
+            body=body,
+            raw=raw,
+            reasoning=reasoning,
+            method=method,
+            # The fragment's tier picked the classifier (#666); record its
+            # provider so a later quality-aware run can rank local-LLM vs
+            # cloud-LLM. Only an actual ``llm`` write keeps it (the writer
+            # clears it otherwise).
+            provider=llm.config.provider if llm is not None else None,
+            was_skipped=was_skipped,
+            counts=counts,
+            progress_path=progress_path,
+            trace_log_path=trace_log_path,
+        )
 
 
 def _load_classifiable_fragment(

--- a/creek-tools/creek/classify/llm/orchestrator.py
+++ b/creek-tools/creek/classify/llm/orchestrator.py
@@ -111,6 +111,15 @@ class LLMClassifier:
     def _provider(self) -> LLMProvider:
         """Lazily build and cache the configured provider.
 
+        Thread-safety: this is an unlocked check-then-set on
+        ``self._provider_instance`` (and ``.available`` memoises similarly), so a
+        classifier **must be pre-warmed serially before any concurrent use** —
+        call :attr:`available` (or ``_provider()``) once on the main thread
+        first. The concurrent classify path (#764) relies on
+        ``_assert_classifiers_available`` doing exactly that before spinning up
+        worker threads; a future concurrent caller that skips that pre-warm would
+        reintroduce a double-build data race here.
+
         Returns:
             The cached :class:`LLMProvider` instance.
 

--- a/creek-tools/tests/test_classify_concurrency.py
+++ b/creek-tools/tests/test_classify_concurrency.py
@@ -1,0 +1,181 @@
+"""`creek classify --method llm` honours ``max_concurrent`` (#764).
+
+The engine's classify loop was serial — every fragment's (network-bound) LLM
+call ran one after another, so raising ``max_concurrent`` did nothing and a
+full-vault backfill took hours instead of minutes. These tests pin the fix:
+
+- with ``max_concurrent = N`` the engine runs N fragments' classify calls
+  **concurrently** (proven deterministically with a ``threading.Barrier`` of N
+  parties — a serial loop can never trip it, only overlapping calls can);
+- with ``max_concurrent = 1`` it stays strictly serial (backward-compatible);
+- concurrent runs are still correct: every fragment is classified and counted
+  exactly once (no lost ``counts`` updates).
+
+The LLM is faked — no network, no real provider.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+
+from creek.classify.classify_engine import run_classify
+from creek.classify.llm import LLMClassificationResult
+from creek.config import CreekConfig, LLMConfig, LLMRoutingConfig
+from creek.models import Fragment, FragmentSource, PrivacyTier, SourcePlatform
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Long enough that rules leave it UNCLASSIFIED, so the LLM path actually runs.
+_BODY = "a reflection worth keeping with enough words to classify cleanly"
+_CLOUD = {"provider": "anthropic", "model": "claude-haiku-4-5"}
+_LOCAL = {"provider": "ollama", "model": "qwen3:8b"}
+
+
+class _Probe:
+    """Observes concurrency of the faked classify calls.
+
+    With ``parties`` set, callers rendezvous on a barrier — if fewer than
+    ``parties`` calls are ever in flight at once (a serial loop), the barrier
+    times out and ``serialized`` is set. Without it, a short sleep makes overlap
+    observable via ``max_active``.
+    """
+
+    def __init__(self, parties: int | None = None, timeout: float = 10.0) -> None:
+        """Arm the probe with an optional N-party rendezvous barrier."""
+        self._barrier = threading.Barrier(parties, timeout=timeout) if parties else None
+        self._lock = threading.Lock()
+        self.active = 0
+        self.max_active = 0
+        self.serialized = False
+
+    def enter(self) -> None:
+        """Record one in-flight call and rendezvous / dwell to expose overlap."""
+        with self._lock:
+            self.active += 1
+            self.max_active = max(self.max_active, self.active)
+        if self._barrier is not None:
+            try:
+                self._barrier.wait()
+            except threading.BrokenBarrierError:
+                self.serialized = True
+        else:
+            time.sleep(0.15)
+        with self._lock:
+            self.active -= 1
+
+
+class _ProbingClassifier:
+    """Fake ``LLMClassifier`` that reports concurrency through :data:`probe`."""
+
+    probe: _Probe | None = None
+
+    def __init__(self, config: LLMConfig) -> None:
+        """Capture the resolved config (its ``max_concurrent`` drives the pool)."""
+        self.config = config
+
+    @property
+    def available(self) -> bool:
+        """Always reachable — availability is not under test here."""
+        return True
+
+    def classify_with_reasoning(
+        self, fragment: Fragment, content: str
+    ) -> LLMClassificationResult:
+        """Register the call with the probe and echo the fragment back."""
+        _ = content
+        assert _ProbingClassifier.probe is not None
+        _ProbingClassifier.probe.enter()
+        return LLMClassificationResult(fragment=fragment, reasoning="")
+
+
+@pytest.fixture(autouse=True)
+def _fake_llm(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Swap the engine's ``LLMClassifier`` for the concurrency-probing fake."""
+    _ProbingClassifier.probe = None
+    monkeypatch.setattr(
+        "creek.classify.classify_engine.LLMClassifier", _ProbingClassifier
+    )
+
+
+def _config(max_concurrent: int) -> CreekConfig:
+    """A config whose classification stage carries *max_concurrent*."""
+    return CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(**_LOCAL),
+            classification=LLMConfig(**_CLOUD, max_concurrent=max_concurrent),
+        )
+    )
+
+
+def _write_fragments(vault: Path, count: int) -> None:
+    """Write *count* classifiable, rules-unclassified OPEN fragments."""
+    for i in range(count):
+        write_fragment_file(
+            vault=vault,
+            fragment=Fragment(
+                id=f"frag-concurrency{i:02d}",
+                title=f"frag-concurrency{i:02d}",
+                source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+                privacy_tier=PrivacyTier.OPEN,
+            ),
+            body=_BODY,
+        )
+
+
+def test_llm_classify_runs_calls_concurrently(tmp_path: Path) -> None:
+    """With ``max_concurrent = 4``, four classify calls overlap in flight."""
+    vault = tmp_path / "vault"
+    _write_fragments(vault, 4)
+    _ProbingClassifier.probe = _Probe(parties=4)
+
+    summary = run_classify(
+        vault_path=vault, config=_config(4), method="llm", force=True
+    )
+
+    probe = _ProbingClassifier.probe
+    assert not probe.serialized, "classify ran serially — barrier never tripped"
+    assert probe.max_active == 4  # all four in flight at once
+    assert summary.total == 4
+    assert summary.classified == 4  # every fragment counted once, no lost updates
+
+
+def test_max_concurrent_one_is_serial(tmp_path: Path) -> None:
+    """With ``max_concurrent = 1`` the loop stays strictly serial (unchanged)."""
+    vault = tmp_path / "vault"
+    _write_fragments(vault, 3)
+    _ProbingClassifier.probe = _Probe()  # sleep-based overlap detection
+
+    summary = run_classify(
+        vault_path=vault, config=_config(1), method="llm", force=True
+    )
+
+    assert _ProbingClassifier.probe.max_active == 1  # never more than one in flight
+    assert summary.classified == 3
+
+
+def test_concurrent_run_classifies_every_fragment(tmp_path: Path) -> None:
+    """A wide run over more fragments than workers still classifies them all."""
+    vault = tmp_path / "vault"
+    _write_fragments(vault, 12)
+    _ProbingClassifier.probe = _Probe()  # sleep probe; just checking correctness
+
+    summary = run_classify(
+        vault_path=vault, config=_config(4), method="llm", force=True
+    )
+
+    assert summary.total == 12
+    assert summary.classified == 12
+    assert _ProbingClassifier.probe.max_active >= 2  # genuinely overlapped
+    # Every file carries the llm provenance stamp.
+    stamped = [
+        p
+        for p in (vault / "01-Fragments").rglob("*.md")
+        if "classification_method: llm" in p.read_text(encoding="utf-8")
+    ]
+    assert len(stamped) == 12

--- a/creek-tools/tests/test_classify_concurrency.py
+++ b/creek-tools/tests/test_classify_concurrency.py
@@ -22,9 +22,15 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+import creek.classify.classify_engine as engine
 from creek.classify.classify_engine import run_classify
 from creek.classify.llm import LLMClassificationResult
-from creek.config import CreekConfig, LLMConfig, LLMRoutingConfig
+from creek.config import (
+    ClassificationConfig,
+    CreekConfig,
+    LLMConfig,
+    LLMRoutingConfig,
+)
 from creek.models import Fragment, FragmentSource, PrivacyTier, SourcePlatform
 from tests.helpers import write_fragment_file
 
@@ -103,13 +109,14 @@ def _fake_llm(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-def _config(max_concurrent: int) -> CreekConfig:
+def _config(max_concurrent: int, *, reatomize: bool = False) -> CreekConfig:
     """A config whose classification stage carries *max_concurrent*."""
     return CreekConfig(
         llm=LLMRoutingConfig(
             default=LLMConfig(**_LOCAL),
             classification=LLMConfig(**_CLOUD, max_concurrent=max_concurrent),
-        )
+        ),
+        classification=ClassificationConfig(reatomize=reatomize),
     )
 
 
@@ -156,6 +163,27 @@ def test_max_concurrent_one_is_serial(tmp_path: Path) -> None:
     )
 
     assert _ProbingClassifier.probe.max_active == 1  # never more than one in flight
+    assert summary.classified == 3
+
+
+def test_reatomize_forces_serial_even_with_high_max_concurrent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-atomization keeps the loop serial (shared VaultWriter) despite mc>1."""
+    # Stub the re-atomization tail so only the pool-width invariant is exercised.
+    monkeypatch.setattr(engine, "_maybe_reatomize_and_persist", lambda **_: None)
+    vault = tmp_path / "vault"
+    _write_fragments(vault, 3)
+    _ProbingClassifier.probe = _Probe()  # sleep probe
+
+    summary = run_classify(
+        vault_path=vault,
+        config=_config(4, reatomize=True),
+        method="llm",
+        force=True,
+    )
+
+    assert _ProbingClassifier.probe.max_active == 1  # serialized by the writer guard
     assert summary.classified == 3
 
 


### PR DESCRIPTION
## Summary

`creek classify --method llm` throughput was independent of `llm.max_concurrent` (5→12 workers gave no change; a ~21k-fragment backfill ran ~18–24h instead of the ~3h the Haiku latency budget predicts).

**Root cause — a correction to the issue's hypothesis.** The issue guessed GIL-serialized per-fragment CPU (local embeddings). Reading the code, that's not it: the LLM classify path does **no** local embedding, and few-shot selection is `@lru_cache`d. The real cause is simpler — **`run_classify` iterated fragments in a plain serial `for md_file in rglob(...)` loop and never used a thread pool.** The `ThreadPoolExecutor` in `batch.py`'s `run_batch` is a *separate* code path the engine doesn't call. So `max_concurrent` had no effect because the loop was single-threaded, not because of the GIL. At ~3–4s/fragment (Haiku two-step reasoning prompt) run serially, that's exactly the observed 15–20/min.

## Fix
Drive the engine loop through a `ThreadPoolExecutor` sized by the classification stage's `max_concurrent`:
- the network-bound provider call (`_classify_one`) runs **outside** a lock, so calls from different worker threads genuinely overlap — that's what makes the knob effective;
- the cheap shared-state sections (`counts` mutation, progress/trace-log appends) run **under a `threading.Lock`**, so counts stay exact under concurrency (no lost updates);
- classifiers are pre-warmed by the existing pre-loop availability check, so concurrent first-access doesn't race on the lazy provider build;
- **re-atomization** (shared `VaultWriter`) and the **rules** path (local CPU, no I/O to overlap) stay serial;
- in-flight requests are bounded by `max_concurrent`, so there's no request burst (no new 429 risk).

Extracted `_dispatch_files` + `_assert_classifiers_available` so `run_classify` stays under the complexity gate.

## Test plan
`tests/test_classify_concurrency.py` (3 cases, LLM faked — no network):
- **Concurrency proven deterministically:** a `threading.Barrier(4)` inside the faked classify call — with `max_concurrent=4` the four calls rendezvous (barrier trips, `max_active==4`); a serial loop can *never* trip it (it would time out). This is the direct regression guard for the bug.
- **`max_concurrent=1` stays strictly serial** (`max_active==1`) — backward-compatible.
- **Correctness under concurrency:** a wide run over 12 fragments with 4 workers classifies and counts every fragment exactly once, and each file carries the `classification_method: llm` stamp.

Local `./scripts/check-all.sh`: ruff/format/mypy/pylint/refurb/tryceratops/complexity/security clean; existing classify-engine / tier-routing / resume / interrupt suites green (56 pass). (The 8 author-desk credential-dependent failures are the known local-only set green in CI.)

Closes #764