### PR TITLE
harden(confidential): passphrase-strength floor at key-vault setup

### DIFF
--- a/creek-tools/creek/confidential/keyvault.py
+++ b/creek-tools/creek/confidential/keyvault.py
@@ -50,6 +50,14 @@ _NONCE_BYTES: Final[int] = 12
 _RECOVERY_BYTES: Final[int] = 32
 """Recovery-key entropy — 256 bits of ``os.urandom``."""
 
+_MIN_PASSPHRASE_LENGTH: Final[int] = 12
+"""Minimum passphrase length accepted at setup (#770).
+
+A length floor is the cheap, dependency-free strength guard: it refuses the
+weakest passphrases without pulling in an offline strength estimator. Argon2id
+memory-hardness (below) remains the primary defence against cracking a passphrase
+that clears the floor."""
+
 # Argon2id cost parameters. Comfortably above the OWASP minimum (memory 19 MiB,
 # t=2, p=1); memory-hardness is the primary defence against offline passphrase
 # cracking. Persisted per-vault so a future increase does not lock out old vaults.
@@ -231,17 +239,19 @@ def create_key_vault(passphrase: str) -> SetupResult:
     returns; only the ciphertext-only :class:`KeyVault` should be persisted.
 
     Args:
-        passphrase: The user's passphrase. Must be non-empty.
+        passphrase: The user's passphrase. Must be at least
+            :data:`_MIN_PASSPHRASE_LENGTH` characters (this also rejects empty).
 
     Returns:
         A :class:`SetupResult` carrying the vault to persist and the recovery key
         to surface to the user exactly once.
 
     Raises:
-        ValueError: If *passphrase* is empty.
+        ValueError: If *passphrase* is shorter than the strength floor. The
+            message states only the required length, never the supplied value.
     """
-    if not passphrase:
-        msg = "passphrase must not be empty"
+    if len(passphrase) < _MIN_PASSPHRASE_LENGTH:
+        msg = f"passphrase must be at least {_MIN_PASSPHRASE_LENGTH} characters"
         raise ValueError(msg)
 
     vmk = os.urandom(_VMK_BYTES)

--- a/creek-tools/tests/test_confidential_keyvault.py
+++ b/creek-tools/tests/test_confidential_keyvault.py
@@ -117,6 +117,26 @@ def test_empty_passphrase_is_rejected() -> None:
         create_key_vault("")
 
 
+def test_short_passphrase_is_rejected_below_the_floor() -> None:
+    """A passphrase under the strength floor is refused with a non-leaking error."""
+    weak = "short11char"  # 11 chars — below the 12-char floor; a test literal
+    assert len(weak) < 12
+    with pytest.raises(ValueError, match="at least 12 characters") as excinfo:
+        create_key_vault(weak)
+    # The error states the requirement only — never the supplied passphrase.
+    assert weak not in str(excinfo.value)
+
+
+def test_at_floor_passphrase_is_accepted_and_unlocks_both_paths() -> None:
+    """A passphrase exactly at the floor is accepted; both unwrap paths still work."""
+    at_floor = "twelvechars!"  # exactly 12 chars — a test literal, not a secret
+    assert len(at_floor) == 12
+    setup = create_key_vault(at_floor)
+    vmk = unlock_with_passphrase(setup.vault, at_floor)
+    # The recovery-key path is unaffected by the passphrase floor.
+    assert unlock_with_recovery(setup.vault, setup.recovery_key) == vmk
+
+
 def test_each_setup_is_unique() -> None:
     """Two setups yield distinct VMKs, salts, and recovery keys (fresh randomness)."""
     a = create_key_vault(_PASSPHRASE)


### PR DESCRIPTION
## Summary

Fast-follow from the #769 review (HIGH, non-blocking): `create_key_vault` (`creek/confidential/keyvault.py`, #758) rejected only *empty* passphrases and accepted arbitrarily weak ones. This adds a **12-character minimum length floor** — a cheap, dependency-free strength guard. Argon2id memory-hardness remains the primary defence against cracking a passphrase that clears the floor.

- New `_MIN_PASSPHRASE_LENGTH = 12`; `create_key_vault` refuses `len(passphrase) < 12` (which also subsumes the empty case) **before any key material is generated**.
- The `ValueError` message states only the required length (`"passphrase must be at least 12 characters"`) — **never the supplied passphrase or its actual length**.
- The recovery-key path is untouched.

## Test plan
`tests/test_confidential_keyvault.py`:
- **Below-floor refused, non-leaking:** an 11-char passphrase raises `ValueError` matching `"at least 12 characters"`, and the test asserts the supplied value is **absent** from the error string.
- **At-floor accepted:** a 12-char passphrase creates the vault and **both** unwrap paths still work (`unlock_with_passphrase` == `unlock_with_recovery`), confirming the recovery path is unaffected.
- The existing empty-passphrase test still passes (empty is below the floor).
- No secret material in tests (short/at-floor literals, clearly non-secret).

Local `./scripts/check-all.sh`: ruff/format/mypy/pylint/refurb/tryceratops/complexity/security clean; the confidential keyvault suite passes (14). (The 8 author-desk credential-dependent failures are the known local-only set green in CI.)

Refs #758
Closes #770