### PR TITLE
harden(confidential): bounds-check untrusted KDF params on vault load

### DIFF
--- a/creek-tools/creek/confidential/keyvault.py
+++ b/creek-tools/creek/confidential/keyvault.py
@@ -65,6 +65,19 @@ _ARGON2_TIME_COST: Final[int] = 3
 _ARGON2_LANES: Final[int] = 4
 _ARGON2_MEMORY_KIB: Final[int] = 64 * 1024  # 64 MiB
 
+# Accepted bounds for KDF parameters read from an UNTRUSTED on-disk vault (#771).
+# The upper bounds cap resource use so a tampered/corrupt artifact can't OOM or
+# hang the Argon2id derivation on unlock; the lower bounds reject degenerate
+# (zero / near-zero) values. Validated at load time (`from_dict`), before any
+# derivation, so an absurd ``memory_kib`` is never actually allocated. Our own
+# vaults (t=3, p=4, 64 MiB) sit comfortably inside these.
+_MIN_TIME_COST: Final[int] = 1
+_MAX_TIME_COST: Final[int] = 20
+_MIN_LANES: Final[int] = 1
+_MAX_LANES: Final[int] = 16
+_MIN_MEMORY_KIB: Final[int] = 8 * 1024  # 8 MiB
+_MAX_MEMORY_KIB: Final[int] = 1024 * 1024  # 1 GiB
+
 # AEAD associated-data domain separators — bind each wrapped copy to its purpose
 # so a ciphertext can never be swapped between the two unwrap paths.
 _AAD_PASSPHRASE: Final[bytes] = b"creek.confidential.vmk.passphrase.v1"
@@ -110,6 +123,23 @@ class _Wrapped:
         )
 
 
+def _check_kdf_bound(name: str, value: int, low: int, high: int) -> None:
+    """Reject a KDF parameter outside ``[low, high]`` — fail closed (#771).
+
+    Args:
+        name: Parameter name, echoed in the error (non-sensitive).
+        value: The value read from the untrusted vault.
+        low: Inclusive lower bound.
+        high: Inclusive upper bound.
+
+    Raises:
+        ValueError: When *value* is out of range.
+    """
+    if not low <= value <= high:
+        msg = f"{name} out of accepted range [{low}, {high}]"
+        raise ValueError(msg)
+
+
 @dataclass(frozen=True)
 class KeyVault:
     """The persisted, **ciphertext-only** key vault (no plaintext key material).
@@ -148,14 +178,30 @@ class KeyVault:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> KeyVault:
-        """Rebuild a :class:`KeyVault` from its persisted form."""
+        """Rebuild a :class:`KeyVault` from its (untrusted) persisted form.
+
+        The KDF parameters come from the on-disk artifact, which may be corrupt
+        or tampered, so they are bounds-checked **here** — before any Argon2id
+        derivation — so an absurd ``memory_kib`` can never OOM/hang the unlock
+        and a degenerate value can never weaken the derivation (#771). Out-of-
+        range parameters fail closed with a :class:`ValueError`.
+
+        Raises:
+            ValueError: If any KDF parameter is outside its accepted range.
+        """
         kdf = data["kdf"]
+        time_cost = int(kdf["time_cost"])
+        lanes = int(kdf["lanes"])
+        memory_kib = int(kdf["memory_kib"])
+        _check_kdf_bound("time_cost", time_cost, _MIN_TIME_COST, _MAX_TIME_COST)
+        _check_kdf_bound("lanes", lanes, _MIN_LANES, _MAX_LANES)
+        _check_kdf_bound("memory_kib", memory_kib, _MIN_MEMORY_KIB, _MAX_MEMORY_KIB)
         return cls(
             version=int(data["version"]),
             salt=bytes.fromhex(kdf["salt"]),
-            time_cost=int(kdf["time_cost"]),
-            lanes=int(kdf["lanes"]),
-            memory_kib=int(kdf["memory_kib"]),
+            time_cost=time_cost,
+            lanes=lanes,
+            memory_kib=memory_kib,
             passphrase_wrapped=_Wrapped.from_dict(data["passphrase_wrapped"]),
             recovery_wrapped=_Wrapped.from_dict(data["recovery_wrapped"]),
         )

--- a/creek-tools/tests/test_confidential_keyvault.py
+++ b/creek-tools/tests/test_confidential_keyvault.py
@@ -111,6 +111,42 @@ def test_tampered_ciphertext_fails_closed() -> None:
         unlock_with_passphrase(tampered, _PASSPHRASE)
 
 
+def _vault_dict_with_kdf(**overrides: int) -> dict[str, object]:
+    """A freshly-created vault's dict with KDF parameters overridden (untrusted)."""
+    data = json.loads(json.dumps(create_key_vault(_PASSPHRASE).vault.to_dict()))
+    data["kdf"].update(overrides)
+    return data
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("memory_kib", 8 * 1024 * 1024),  # 8 GiB — would OOM Argon2 on unlock
+        ("memory_kib", 0),  # degenerate
+        ("time_cost", 10_000),  # would hang the derivation
+        ("time_cost", 0),
+        ("lanes", 0),
+        ("lanes", 1_000_000),
+    ],
+)
+def test_from_dict_rejects_out_of_range_kdf_params(field: str, value: int) -> None:
+    """A tampered/corrupt vault with an out-of-range KDF param fails closed.
+
+    The bound is enforced in ``from_dict`` *before* any Argon2id derivation, so
+    an absurd ``memory_kib`` never gets allocated — no OOM, just a ``ValueError``.
+    """
+    with pytest.raises(ValueError, match=field):
+        KeyVault.from_dict(_vault_dict_with_kdf(**{field: value}))
+
+
+def test_from_dict_accepts_in_bounds_params_and_unlocks() -> None:
+    """An in-bounds vault still round-trips through ``from_dict`` and unlocks."""
+    setup = create_key_vault(_PASSPHRASE)
+    reloaded = KeyVault.from_dict(json.loads(json.dumps(setup.vault.to_dict())))
+    vmk = unlock_with_passphrase(reloaded, _PASSPHRASE)
+    assert unlock_with_recovery(reloaded, setup.recovery_key) == vmk
+
+
 def test_empty_passphrase_is_rejected() -> None:
     """An empty passphrase is refused before any key material is generated."""
     with pytest.raises(ValueError, match="passphrase"):


### PR DESCRIPTION
## Summary

Fast-follow from the #769 review (HIGH, non-blocking): `KeyVault.from_dict` (#758) read `time_cost`/`lanes`/`memory_kib` straight from the on-disk artifact and passed them to Argon2id on unlock — so a **tampered or corrupt vault** with absurd parameters (`memory_kib` in the GBs, or `0`) could **OOM/hang** the derivation.

The fix validates the KDF parameters in `from_dict` — **at parse time, before any Argon2id derivation** — so an absurd `memory_kib` is never actually allocated (the OOM threat is the allocation, not the integer). Out-of-range values **fail closed** with a `ValueError` naming the parameter and its accepted range (no secret material).

Accepted bounds (our own vaults — t3/p4/64 MiB — sit comfortably inside):
- `time_cost` ∈ [1, 20]
- `lanes` ∈ [1, 16]
- `memory_kib` ∈ [8 MiB, 1 GiB]

## Test plan
`tests/test_confidential_keyvault.py`:
- **Parametrized fail-closed:** tampered vaults with `memory_kib=8 GiB`, `memory_kib=0`, `time_cost=10_000`, `time_cost=0`, `lanes=0`, `lanes=1_000_000` each raise `ValueError` (matching the param name) via `from_dict` — **without allocating** (the bound runs before derivation, so the 8 GiB case doesn't OOM the test).
- **In-bounds still works:** a normally-generated vault round-trips through `to_dict`/`from_dict` and still unlocks by **both** the passphrase and recovery paths.

Local `./scripts/check-all.sh`: ruff/format/mypy/pylint/refurb/tryceratops/complexity/security clean; the confidential keyvault suite passes (21). (The 8 author-desk credential-dependent failures are the known local-only set green in CI.)

Refs #758
Closes #771