### PR TITLE
test(mcp): over-the-wire valid-bearer happy-path through real middleware

### DIFF
--- a/creek-tools/tests/test_mcp_remote.py
+++ b/creek-tools/tests/test_mcp_remote.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 from mcp.server.auth.provider import AccessToken
+from mcp.server.transport_security import TransportSecuritySettings
 from starlette.testclient import TestClient
 
 from creek_mcp import server as server_mod
@@ -275,3 +276,122 @@ def test_streamable_http_rejects_unauthenticated_request(vault: Path) -> None:
         headers={**headers, "Authorization": "Bearer wrong"},
     )
     assert bad_token.status_code == 401
+
+
+# --------------------------------------------------------------------------- #
+# Over-the-wire happy path: a valid bearer drives a full tools/call through the
+# REAL streamable-http + auth middleware (not a monkeypatched context var).
+# --------------------------------------------------------------------------- #
+
+_WIRE_TOKEN = "over-the-wire-consumer-secret"  # fake test literal, not a real key
+
+
+def _network_server(vault: Path, token: str) -> object:
+    """Build a network server; disable DNS-rebinding host-check for the in-test host.
+
+    The host validation is a separate concern from the auth path under test here,
+    and TestClient's synthetic ``testserver`` host would otherwise be rejected
+    before the request reaches the auth middleware.
+    """
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+        token_verifier=ConsumerTokenVerifier({"adepthood": token}),
+    )
+    server.settings.transport_security = TransportSecuritySettings(
+        enable_dns_rebinding_protection=False
+    )
+    return server
+
+
+def _sse_result(body: str) -> dict[str, object]:
+    """Extract the JSON-RPC ``result`` from a streamable-http SSE response body."""
+    payloads = [
+        line[len("data:") :].strip()
+        for line in body.splitlines()
+        if line.startswith("data:")
+    ]
+    return json.loads(payloads[-1])["result"]  # type: ignore[no-any-return]
+
+
+def _open_authenticated_session(
+    client: TestClient, path: str, token: str
+) -> dict[str, str]:
+    """Run the MCP ``initialize`` handshake; return headers carrying the session id."""
+    base = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+    }
+    init = client.post(
+        path,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0"},
+            },
+        },
+        headers=base,
+    )
+    assert init.status_code == 200
+    headers = {**base, "mcp-session-id": init.headers["mcp-session-id"]}
+    ack = client.post(
+        path,
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+        headers=headers,
+    )
+    assert ack.status_code == 202
+    return headers
+
+
+def _wire_call(
+    client: TestClient, path: str, headers: dict[str, str], ceiling: str
+) -> dict[str, object]:
+    """Invoke ``creek.wheel`` over the wire at *ceiling*; return the structured part."""
+    resp = client.post(
+        path,
+        json={
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {
+                "name": "creek.wheel",
+                "arguments": {"privacy_tier_ceiling": ceiling},
+            },
+        },
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    result = _sse_result(resp.text)
+    return result["structuredContent"]  # type: ignore[index, return-value]
+
+
+def test_authenticated_tools_call_dispatches_over_the_wire(vault: Path) -> None:
+    """A valid bearer + open ceiling dispatches a real tools/call through middleware."""
+    server = _network_server(vault, _WIRE_TOKEN)
+    path = server.settings.streamable_http_path  # type: ignore[attr-defined]
+    with TestClient(server.streamable_http_app()) as client:  # type: ignore[attr-defined]
+        headers = _open_authenticated_session(client, path, _WIRE_TOKEN)
+        structured = _wire_call(client, path, headers, "open")
+    assert structured["tool"] == "creek.wheel"  # dispatched, not refused
+    assert structured.get("status") != "refused"
+
+
+def test_remote_intimate_is_refused_over_the_wire(vault: Path) -> None:
+    """The ceiling cap engages on the *real* auth path: remote intimate is refused.
+
+    ``get_access_token()`` is populated by the SDK's ``RequireAuthMiddleware`` from
+    the verified bearer — no monkeypatch — so ``_BoundedFastMCP.call_tool`` refuses
+    the over-ceiling request end-to-end, exactly as it would in production.
+    """
+    server = _network_server(vault, _WIRE_TOKEN)
+    path = server.settings.streamable_http_path  # type: ignore[attr-defined]
+    with TestClient(server.streamable_http_app()) as client:  # type: ignore[attr-defined]
+        headers = _open_authenticated_session(client, path, _WIRE_TOKEN)
+        structured = _wire_call(client, path, headers, "intimate")
+    assert structured["status"] == "refused"
+    assert "not reachable over the network" in structured["reason"]

--- a/creek-tools/tests/test_mcp_remote.py
+++ b/creek-tools/tests/test_mcp_remote.py
@@ -42,6 +42,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
 
+    from mcp.server.fastmcp import FastMCP
+
 
 @pytest.fixture
 def vault(tmp_path: Path) -> Iterator[Path]:
@@ -286,7 +288,7 @@ def test_streamable_http_rejects_unauthenticated_request(vault: Path) -> None:
 _WIRE_TOKEN = "over-the-wire-consumer-secret"  # fake test literal, not a real key
 
 
-def _network_server(vault: Path, token: str) -> object:
+def _network_server(vault: Path, token: str) -> FastMCP:
     """Build a network server; disable DNS-rebinding host-check for the in-test host.
 
     The host validation is a separate concern from the auth path under test here,
@@ -373,8 +375,8 @@ def _wire_call(
 def test_authenticated_tools_call_dispatches_over_the_wire(vault: Path) -> None:
     """A valid bearer + open ceiling dispatches a real tools/call through middleware."""
     server = _network_server(vault, _WIRE_TOKEN)
-    path = server.settings.streamable_http_path  # type: ignore[attr-defined]
-    with TestClient(server.streamable_http_app()) as client:  # type: ignore[attr-defined]
+    path = server.settings.streamable_http_path
+    with TestClient(server.streamable_http_app()) as client:
         headers = _open_authenticated_session(client, path, _WIRE_TOKEN)
         structured = _wire_call(client, path, headers, "open")
     assert structured["tool"] == "creek.wheel"  # dispatched, not refused
@@ -389,8 +391,8 @@ def test_remote_intimate_is_refused_over_the_wire(vault: Path) -> None:
     the over-ceiling request end-to-end, exactly as it would in production.
     """
     server = _network_server(vault, _WIRE_TOKEN)
-    path = server.settings.streamable_http_path  # type: ignore[attr-defined]
-    with TestClient(server.streamable_http_app()) as client:  # type: ignore[attr-defined]
+    path = server.settings.streamable_http_path
+    with TestClient(server.streamable_http_app()) as client:
         headers = _open_authenticated_session(client, path, _WIRE_TOKEN)
         structured = _wire_call(client, path, headers, "intimate")
     assert structured["status"] == "refused"


### PR DESCRIPTION
## Summary

Follow-up from the #773 COMMENTS review on #759. Previously the authenticated **happy path** and the remote **ceiling cap** were only verified via direct `server.call_tool(...)` with a monkeypatched `_current_access_token` — bypassing the SDK's real auth middleware. This adds two tests that drive a full authenticated `tools/call` through `streamable_http_app()` via `TestClient`, so the **real `RequireAuthMiddleware`** runs in-process.

## Test plan
`tests/test_mcp_remote.py` (2 new cases; the LLM/vault are stubbed, no network):
- **`test_authenticated_tools_call_dispatches_over_the_wire`** — runs the MCP `initialize` → `notifications/initialized` → `tools/call` handshake with a **valid bearer** and an `open` ceiling; asserts `creek.wheel` dispatches end-to-end (`structuredContent.tool == "creek.wheel"`, not refused).
- **`test_remote_intimate_is_refused_over_the_wire`** — the same authenticated path with an `intimate` ceiling is **refused by `_BoundedFastMCP` end-to-end**. `get_access_token()` is populated by the real middleware from the verified token (no monkeypatch), so this proves the cap engages on the production path, not just via a patched context var.

Implementation note: DNS-rebinding host validation (a concern separate from auth) is disabled for the in-test `TestClient` host so requests reach the auth middleware; the 401 rejection tests already cover the unauthenticated paths.

Local `./scripts/check-all.sh`: ruff/format/mypy/pylint/refurb/tryceratops/complexity/security clean; `test_mcp_remote.py` passes (19). (The 8 author-desk credential-dependent failures are the known local-only set green in CI.)

Refs #757
Closes #775