### PR TITLE
harden(mcp): verify_token rejects non-ASCII bearer; document purge ceiling no-op

### DIFF
--- a/creek-tools/creek_mcp/remote_auth.py
+++ b/creek-tools/creek_mcp/remote_auth.py
@@ -83,11 +83,16 @@ class ConsumerTokenVerifier(TokenVerifier):
         """Return the consumer's :class:`AccessToken` for a valid token, else ``None``.
 
         Iterates the whole map with constant-time compares (never a dict lookup)
-        so verification time does not depend on which token was supplied.
+        so verification time does not depend on which token was supplied. The
+        operands are compared as **UTF-8 bytes**, not ``str``: ``compare_digest``
+        raises ``TypeError`` on a non-ASCII ``str`` but compares cleanly on
+        ``bytes``, so a non-ASCII bearer is *rejected* (returns ``None``) rather
+        than crashing verification (#776).
         """
+        supplied = token.encode("utf-8")
         matched: str | None = None
         for consumer, known in self._tokens.items():
-            if hmac.compare_digest(token, known):
+            if hmac.compare_digest(supplied, known.encode("utf-8")):
                 matched = consumer
         if matched is None:
             return None

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -109,7 +109,16 @@ class _BoundedFastMCP(FastMCP):
     async def call_tool(
         self, name: str, arguments: dict[str, Any]
     ) -> Sequence[ContentBlock] | dict[str, Any]:
-        """Refuse over-ceiling remote calls, else dispatch normally."""
+        """Refuse over-ceiling remote calls, else dispatch normally.
+
+        Note: this ceiling gate is a **no-op for the ``creek.purge.*`` tools** —
+        they declare no ``privacy_tier_ceiling`` parameter, so ``arguments.get``
+        below always falls back to ``OPEN`` (admitted) for them. That is
+        intentional: purge is not tier-scoped and is instead gated, fail-closed,
+        by ``CREEK_MCP_ELEVATED_TOKEN`` (see ``creek_mcp.auth.is_elevated`` and the
+        purge tools), which a per-consumer bearer alone does not satisfy. Do not
+        rely on this gate for purge protection.
+        """
         if _current_access_token() is not None:
             raw = arguments.get("privacy_tier_ceiling", TierCeiling.OPEN.value)
             try:

--- a/creek-tools/tests/test_mcp_remote.py
+++ b/creek-tools/tests/test_mcp_remote.py
@@ -126,6 +126,14 @@ def test_verify_token_rejects_against_empty_map() -> None:
     assert asyncio.run(verifier.verify_token("anything")) is None
 
 
+def test_verify_token_rejects_non_ascii_bearer_cleanly() -> None:
+    """A non-ASCII bearer is rejected (``None``), never a ``TypeError`` (#776)."""
+    verifier = ConsumerTokenVerifier({"adepthood": "secret123"})
+    # hmac.compare_digest raises TypeError on a non-ASCII str; the byte-compare
+    # must reject cleanly instead of crashing verification.
+    assert asyncio.run(verifier.verify_token("nön-ascii-tökén")) is None
+
+
 # --------------------------------------------------------------------------- #
 # _effective_consumer — per-consumer identity
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Two small robustness/clarity items from the #773 COMMENTS review on #759.

- **Non-ASCII bearer (LOW):** `ConsumerTokenVerifier.verify_token` compared `str` operands with `hmac.compare_digest`, which **raises `TypeError` on a non-ASCII `str`** — so a non-ASCII bearer crashed verification instead of being rejected. Fixed by comparing **UTF-8 bytes** (`compare_digest` on `bytes` never raises): a non-ASCII bearer now compares unequal and cleanly returns `None`. The constant-time property is preserved.
- **Purge ceiling no-op:** added a docstring note on `_BoundedFastMCP.call_tool` explaining that the remote ceiling gate is a **no-op for the `creek.purge.*` tools** — they declare no `privacy_tier_ceiling`, so `arguments.get(..., OPEN)` always admits them. That's intentional: purge is gated fail-closed by `CREEK_MCP_ELEVATED_TOKEN` (not by the tier ceiling), which a per-consumer bearer alone doesn't satisfy. The comment prevents a future refactor from assuming the gate protects purge.

## Test plan
`tests/test_mcp_remote.py`: **`test_verify_token_rejects_non_ascii_bearer_cleanly`** — a non-ASCII bearer returns `None` (not a `TypeError`). Existing valid/invalid/empty-map verifier tests still pass.

Local `./scripts/check-all.sh`: ruff/format/mypy/pylint/refurb/tryceratops/complexity/security clean; `test_mcp_remote.py` + `test_mcp_server.py` pass. (The 8 author-desk credential-dependent failures are the known local-only set green in CI.)

Refs #757
Closes #776