### PR TITLE
perf(classify): size the classify pool per-tier via per-provider semaphores (#783)

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -30,6 +30,7 @@ import json
 import logging
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path  # noqa: TC003  # no issue: runtime dataclass field
@@ -333,6 +334,20 @@ def run_classify(
         VaultWriter(vault_path=vault_path) if reatomize_enabled else None
     )
 
+    # Concurrency (#764/#783): the per-fragment LLM call is network-bound, so
+    # running files through a thread pool lets the calls overlap — previously
+    # this loop was serial and ``max_concurrent`` had no effect. Each distinct
+    # provider gets its OWN bounded semaphore sized by its own stage's
+    # ``max_concurrent``: INTIMATE fragments route to a local provider (#666),
+    # which must not inherit the cloud stage's width (#783). The outer pool is
+    # sized as the SUM of the distinct providers' widths so both tiers can
+    # saturate their own cap at the same time without oversubscribing either.
+    # Re-atomization shares one writer, so it stays serial (workers forced to 1);
+    # the rules path builds no throttle and also stays serial.
+    throttle, workers = _build_classify_throttle(tier_classifiers)
+    if vault_writer is not None:
+        workers = 1
+
     files = sorted(fragments_root.rglob("*.md"))
     process_one = partial(
         _process_file,
@@ -346,18 +361,8 @@ def run_classify(
         progress_path=progress_path,
         trace_log_path=trace_log_path,
         vault_writer=vault_writer,
+        throttle=throttle,
         lock=threading.Lock(),
-    )
-
-    # Concurrency (#764): the per-fragment LLM call is network-bound, so running
-    # files through a thread pool sized by the classification stage's
-    # ``max_concurrent`` lets the calls overlap — previously this loop was serial
-    # and the knob had no effect. Re-atomization keeps a single shared writer, and
-    # the rules path is local CPU with no I/O to overlap, so both stay serial.
-    workers = (
-        config.llm.for_stage("classification").max_concurrent
-        if method == LLM_METHOD and vault_writer is None
-        else 1
     )
     _dispatch_files(files, process_one, workers=workers)
 
@@ -372,6 +377,70 @@ def run_classify(
         # underlying list and reach into completed-run state.
         errors=tuple(counts.errors),
     )
+
+
+def _build_classify_throttle(
+    tier_classifiers: TierClassifiers | None,
+) -> tuple[dict[int, threading.BoundedSemaphore], int]:
+    """Size the classify pool and build per-provider concurrency permits (#783).
+
+    Each distinct classifier (non-Intimate vs the local Intimate route, #666)
+    gets its own :class:`threading.BoundedSemaphore` sized by that classifier's
+    ``max_concurrent``, keyed by ``id(classifier)`` so a fragment's resolved
+    classifier maps to its own permit. The pool width is the **sum** of the
+    distinct widths, so both tiers can run at their own cap simultaneously
+    without either oversubscribing its provider. When ``distinct()`` returns a
+    single classifier — the shared-instance / single-provider case — this
+    collapses to exactly the pre-#783 single-stage width (no regression).
+
+    Args:
+        tier_classifiers: The per-tier classifier set, or ``None`` for the
+            rules path (which runs serially with no provider to throttle).
+
+    Returns:
+        ``(throttle, workers)``: the ``id(classifier) -> semaphore`` map and the
+        summed pool width. ``({}, 1)`` for the rules path.
+    """
+    if tier_classifiers is None:
+        return {}, 1
+    throttle: dict[int, threading.BoundedSemaphore] = {}
+    workers = 0
+    for classifier in tier_classifiers.distinct():
+        max_concurrent = classifier.config.max_concurrent
+        throttle[id(classifier)] = threading.BoundedSemaphore(max_concurrent)
+        workers += max_concurrent
+    return throttle, workers
+
+
+@contextmanager
+def _classify_permit(
+    throttle: dict[int, threading.BoundedSemaphore],
+    llm: LLMClassifier | None,
+) -> Iterator[None]:
+    """Hold the resolved classifier's concurrency permit for the classify call.
+
+    Wraps only the leaf ``_classify_one`` call (#783): the permit is acquired
+    OUTSIDE the shared ``lock`` — exactly where the expensive provider call
+    already runs unlocked (#764) — and released on the way out, including on
+    exception. When there is no matching semaphore (the rules path, where
+    ``llm`` is ``None``, or a provider with no registered permit) this yields
+    without throttling.
+
+    Args:
+        throttle: The ``id(classifier) -> semaphore`` map from
+            :func:`_build_classify_throttle`.
+        llm: The classifier resolved for this fragment's tier, or ``None`` on
+            the rules path.
+
+    Yields:
+        ``None`` while the permit (if any) is held.
+    """
+    semaphore = throttle.get(id(llm)) if llm is not None else None
+    if semaphore is None:
+        yield
+        return
+    with semaphore:
+        yield
 
 
 def _record_if_preserved(
@@ -470,6 +539,7 @@ def _process_file(
     progress_path: Path | None,
     trace_log_path: Path | None,
     vault_writer: VaultWriter | None,
+    throttle: dict[int, threading.BoundedSemaphore],
     lock: threading.Lock,
 ) -> None:
     """Classify a single fragment file and update ``counts`` in place.
@@ -501,12 +571,19 @@ def _process_file(
         vault_writer: Shared :class:`VaultWriter` for persisting
             FEAT-023 children. ``None`` when re-atomization is not
             enabled for this run.
+        throttle: Per-provider concurrency permits keyed by
+            ``id(classifier)`` (#783). The classifier resolved for this
+            fragment's tier acquires its own bounded semaphore around the
+            classify call, so a mixed-tier vault never applies the cloud
+            stage's width to the local Intimate provider. Empty on the rules
+            path (no provider to throttle).
         lock: Guards the shared-state sections (``counts`` mutation, the
             progress/trace-log appends, and the re-atomization writer) so this
             function is safe to run on many worker threads at once. The
-            expensive, network-bound classify call runs *outside* the lock so
-            calls from different threads overlap — the fix for #764. An
-            uncontended lock is passed on the serial path.
+            expensive, network-bound classify call runs *outside* the lock — and
+            under the resolved provider's permit — so calls from different
+            threads overlap up to each provider's own cap (the fix for
+            #764/#783). An uncontended lock is passed on the serial path.
     """
     with lock:
         record = _load_classifiable_fragment(
@@ -536,19 +613,23 @@ def _process_file(
 
     # The provider call is the expensive, network-bound step (#764). It runs
     # WITHOUT the lock so calls from different worker threads overlap — that is
-    # what makes ``max_concurrent`` effective. The classifiers are pre-warmed
-    # (their availability was checked before the loop) and read-only during the
-    # run, and each fragment is an independent input, so concurrent calls are
-    # safe.
-    new_fragment, was_skipped, reasoning = _classify_one(
-        fragment=fragment,
-        body=body,
-        method=method,
-        rules=rules,
-        llm=llm,
-        confidence_threshold=classification_config.confidence_threshold,
-        weighted_classification=classification_config.weighted_classification,
-    )
+    # what makes ``max_concurrent`` effective — but UNDER the resolved provider's
+    # own bounded semaphore (#783), so the local Intimate provider is capped by
+    # its own width, not the cloud stage's. The permit wraps only this leaf call
+    # (never the locked write block below) and is released even on error. The
+    # classifiers are pre-warmed (their availability was checked before the loop)
+    # and read-only during the run, and each fragment is an independent input, so
+    # concurrent calls are safe.
+    with _classify_permit(throttle, llm):
+        new_fragment, was_skipped, reasoning = _classify_one(
+            fragment=fragment,
+            body=body,
+            method=method,
+            rules=rules,
+            llm=llm,
+            confidence_threshold=classification_config.confidence_threshold,
+            weighted_classification=classification_config.weighted_classification,
+        )
 
     # Stamp the #634 audience axis on every (re)classified fragment. It is a
     # deterministic heuristic independent of the frequency/phase method above,

--- a/creek-tools/tests/test_classify_concurrency.py
+++ b/creek-tools/tests/test_classify_concurrency.py
@@ -1,15 +1,32 @@
-"""`creek classify --method llm` honours ``max_concurrent`` (#764).
+"""`creek classify --method llm` sizes its worker pool per classifier (#764, #783).
 
 The engine's classify loop was serial — every fragment's (network-bound) LLM
 call ran one after another, so raising ``max_concurrent`` did nothing and a
-full-vault backfill took hours instead of minutes. These tests pin the fix:
+full-vault backfill took hours instead of minutes (#764). Making the loop
+concurrent surfaced a second bug (#783): INTIMATE fragments are redirected to
+a local provider by
+:class:`~creek.classify.classify_engine.TierClassifiers` (#666), but the
+executor pool was sized by only the non-Intimate ``classification`` stage's
+``max_concurrent`` — so a mixed-tier vault applied the cloud stage's width to
+local-model calls too, oversubscribing the local provider.
+
+These tests pin both fixes:
 
 - with ``max_concurrent = N`` the engine runs N fragments' classify calls
   **concurrently** (proven deterministically with a ``threading.Barrier`` of N
   parties — a serial loop can never trip it, only overlapping calls can);
 - with ``max_concurrent = 1`` it stays strictly serial (backward-compatible);
 - concurrent runs are still correct: every fragment is classified and counted
-  exactly once (no lost ``counts`` updates).
+  exactly once (no lost ``counts`` updates);
+- INTIMATE-tier (local-provider) calls are capped by the local stage's own
+  ``max_concurrent``, never by the cloud ``classification`` stage's width
+  (#783), and the two tiers' caps are independent — a run can genuinely
+  saturate the cloud knob while staying under a smaller local one;
+- a single shared classifier (the pre-#666/#783 backward-compatible shape,
+  where Intimate and non-Intimate resolve to the same provider) still sizes
+  the pool by that one config's ``max_concurrent`` — unchanged from #764;
+- when no local backend exists to route Intimate fragments to, the run still
+  succeeds as long as the vault holds none (the routing error stays deferred).
 
 The LLM is faked — no network, no real provider.
 """
@@ -18,7 +35,7 @@ from __future__ import annotations
 
 import threading
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import pytest
 
@@ -77,12 +94,20 @@ class _Probe:
 
 
 class _ProbingClassifier:
-    """Fake ``LLMClassifier`` that reports concurrency through :data:`probe`."""
+    """Fake ``LLMClassifier`` that reports concurrency through per-provider probes.
 
-    probe: _Probe | None = None
+    :class:`~creek.classify.classify_engine.TierClassifiers` (#666) constructs
+    one instance per resolved provider config (non-Intimate vs Intimate), so a
+    single class-level probe cannot tell cloud calls apart from local ones.
+    Instead, each instance looks up its probe by ``self.config.provider`` —
+    letting a mixed-tier test assert on cloud and local concurrency
+    independently (#783).
+    """
+
+    probes: ClassVar[dict[str, _Probe]] = {}
 
     def __init__(self, config: LLMConfig) -> None:
-        """Capture the resolved config (its ``max_concurrent`` drives the pool)."""
+        """Capture the resolved config; its ``provider`` selects this call's probe."""
         self.config = config
 
     @property
@@ -93,17 +118,20 @@ class _ProbingClassifier:
     def classify_with_reasoning(
         self, fragment: Fragment, content: str
     ) -> LLMClassificationResult:
-        """Register the call with the probe and echo the fragment back."""
+        """Register the call against this instance's provider-keyed probe."""
         _ = content
-        assert _ProbingClassifier.probe is not None
-        _ProbingClassifier.probe.enter()
+        probe = _ProbingClassifier.probes.get(self.config.provider)
+        assert probe is not None, (
+            f"no probe registered for provider {self.config.provider!r}"
+        )
+        probe.enter()
         return LLMClassificationResult(fragment=fragment, reasoning="")
 
 
 @pytest.fixture(autouse=True)
 def _fake_llm(monkeypatch: pytest.MonkeyPatch) -> None:
     """Swap the engine's ``LLMClassifier`` for the concurrency-probing fake."""
-    _ProbingClassifier.probe = None
+    _ProbingClassifier.probes = {}
     monkeypatch.setattr(
         "creek.classify.classify_engine.LLMClassifier", _ProbingClassifier
     )
@@ -120,16 +148,80 @@ def _config(max_concurrent: int, *, reatomize: bool = False) -> CreekConfig:
     )
 
 
-def _write_fragments(vault: Path, count: int) -> None:
-    """Write *count* classifiable, rules-unclassified OPEN fragments."""
+def _config_mixed(
+    *, cloud_max_concurrent: int, local_max_concurrent: int
+) -> CreekConfig:
+    """Cloud ``classification`` and local ``default`` stages, independently sized.
+
+    The two stages resolve to distinct providers (anthropic vs ollama), so
+    :class:`~creek.classify.classify_engine.TierClassifiers` builds two
+    distinct classifier instances — the shape #783 must size two independent
+    concurrency caps for.
+    """
+    return CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(**_LOCAL, max_concurrent=local_max_concurrent),
+            classification=LLMConfig(**_CLOUD, max_concurrent=cloud_max_concurrent),
+        ),
+        classification=ClassificationConfig(),
+    )
+
+
+def _config_single_provider(max_concurrent: int) -> CreekConfig:
+    """Both stages resolve to the same local config (pre-#666 backward-compat shape).
+
+    ``classification`` is left unset so it falls back to ``default``; the
+    Intimate route also resolves to that same local config (already local, so
+    the ``ModelRouter`` never redirects it) — ``TierClassifiers.distinct()``
+    returns exactly one classifier, the original #764 single-provider case.
+    """
+    return CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(**_LOCAL, max_concurrent=max_concurrent),
+        ),
+        classification=ClassificationConfig(),
+    )
+
+
+def _config_cloud_only(*, classification_max_concurrent: int) -> CreekConfig:
+    """Cloud ``classification`` AND cloud ``default`` — Intimate route deferred.
+
+    With no local backend to redirect Intimate content to, ``TierClassifiers``
+    captures the :class:`~creek.classify.llm.router.IntimateRoutingError`
+    instead of raising immediately (#666) — a run with no Intimate fragments
+    must still succeed, sized by the sole (non-Intimate) classifier.
+    """
+    return CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(**_CLOUD),
+            classification=LLMConfig(
+                **_CLOUD, max_concurrent=classification_max_concurrent
+            ),
+        ),
+        classification=ClassificationConfig(),
+    )
+
+
+def _write_fragments(
+    vault: Path,
+    count: int,
+    *,
+    tier: PrivacyTier = PrivacyTier.OPEN,
+    prefix: str = "frag-concurrency",
+) -> None:
+    """Write *count* classifiable, rules-unclassified fragments at *tier*.
+
+    ``prefix`` keeps fragment IDs distinct when a single vault mixes multiple
+    tiers within one test.
+    """
     for i in range(count):
         write_fragment_file(
             vault=vault,
             fragment=Fragment(
-                id=f"frag-concurrency{i:02d}",
-                title=f"frag-concurrency{i:02d}",
+                id=f"{prefix}{i:02d}",
+                title=f"{prefix}{i:02d}",
                 source=FragmentSource(platform=SourcePlatform.MARKDOWN),
-                privacy_tier=PrivacyTier.OPEN,
+                privacy_tier=tier,
             ),
             body=_BODY,
         )
@@ -139,13 +231,13 @@ def test_llm_classify_runs_calls_concurrently(tmp_path: Path) -> None:
     """With ``max_concurrent = 4``, four classify calls overlap in flight."""
     vault = tmp_path / "vault"
     _write_fragments(vault, 4)
-    _ProbingClassifier.probe = _Probe(parties=4)
+    _ProbingClassifier.probes["anthropic"] = _Probe(parties=4)
 
     summary = run_classify(
         vault_path=vault, config=_config(4), method="llm", force=True
     )
 
-    probe = _ProbingClassifier.probe
+    probe = _ProbingClassifier.probes["anthropic"]
     assert not probe.serialized, "classify ran serially — barrier never tripped"
     assert probe.max_active == 4  # all four in flight at once
     assert summary.total == 4
@@ -156,13 +248,13 @@ def test_max_concurrent_one_is_serial(tmp_path: Path) -> None:
     """With ``max_concurrent = 1`` the loop stays strictly serial (unchanged)."""
     vault = tmp_path / "vault"
     _write_fragments(vault, 3)
-    _ProbingClassifier.probe = _Probe()  # sleep-based overlap detection
+    _ProbingClassifier.probes["anthropic"] = _Probe()  # sleep-based overlap detection
 
     summary = run_classify(
         vault_path=vault, config=_config(1), method="llm", force=True
     )
 
-    assert _ProbingClassifier.probe.max_active == 1  # never more than one in flight
+    assert _ProbingClassifier.probes["anthropic"].max_active == 1  # never >1 in flight
     assert summary.classified == 3
 
 
@@ -174,7 +266,7 @@ def test_reatomize_forces_serial_even_with_high_max_concurrent(
     monkeypatch.setattr(engine, "_maybe_reatomize_and_persist", lambda **_: None)
     vault = tmp_path / "vault"
     _write_fragments(vault, 3)
-    _ProbingClassifier.probe = _Probe()  # sleep probe
+    _ProbingClassifier.probes["anthropic"] = _Probe()  # sleep probe
 
     summary = run_classify(
         vault_path=vault,
@@ -183,7 +275,7 @@ def test_reatomize_forces_serial_even_with_high_max_concurrent(
         force=True,
     )
 
-    assert _ProbingClassifier.probe.max_active == 1  # serialized by the writer guard
+    assert _ProbingClassifier.probes["anthropic"].max_active == 1  # serialized
     assert summary.classified == 3
 
 
@@ -191,7 +283,7 @@ def test_concurrent_run_classifies_every_fragment(tmp_path: Path) -> None:
     """A wide run over more fragments than workers still classifies them all."""
     vault = tmp_path / "vault"
     _write_fragments(vault, 12)
-    _ProbingClassifier.probe = _Probe()  # sleep probe; just checking correctness
+    _ProbingClassifier.probes["anthropic"] = _Probe()  # sleep probe; correctness only
 
     summary = run_classify(
         vault_path=vault, config=_config(4), method="llm", force=True
@@ -199,7 +291,8 @@ def test_concurrent_run_classifies_every_fragment(tmp_path: Path) -> None:
 
     assert summary.total == 12
     assert summary.classified == 12
-    assert _ProbingClassifier.probe.max_active >= 2  # genuinely overlapped
+    probe = _ProbingClassifier.probes["anthropic"]
+    assert probe.max_active >= 2  # genuinely overlapped
     # Every file carries the llm provenance stamp.
     stamped = [
         p
@@ -207,3 +300,125 @@ def test_concurrent_run_classifies_every_fragment(tmp_path: Path) -> None:
         if "classification_method: llm" in p.read_text(encoding="utf-8")
     ]
     assert len(stamped) == 12
+
+
+def test_intimate_calls_capped_by_local_max_concurrent_not_cloud(
+    tmp_path: Path,
+) -> None:
+    """INTIMATE fragments must not inherit the cloud stage's width (#783).
+
+    Local ``default`` max_concurrent=2; cloud ``classification``
+    max_concurrent=8. Every fragment here is INTIMATE, so every classify call
+    routes to the LOCAL classifier (#666). Sizing the pool by only the cloud
+    stage's width — today's bug — lets local calls run far wider than 2; peak
+    in-flight LOCAL calls must never exceed the local knob.
+    """
+    vault = tmp_path / "vault"
+    _write_fragments(vault, 6, tier=PrivacyTier.INTIMATE, prefix="frag-intimate")
+    _ProbingClassifier.probes["ollama"] = _Probe()  # sleep-based max-active counter
+
+    summary = run_classify(
+        vault_path=vault,
+        config=_config_mixed(cloud_max_concurrent=8, local_max_concurrent=2),
+        method="llm",
+        force=True,
+    )
+
+    local_probe = _ProbingClassifier.probes["ollama"]
+    assert local_probe.max_active <= 2, (
+        f"local (ollama) calls peaked at {local_probe.max_active} in flight — "
+        "the cloud classification stage's max_concurrent=8 leaked into the "
+        "local provider's concurrency cap"
+    )
+    assert summary.total == 6
+    assert summary.classified == 6
+
+
+def test_cloud_and_local_tiers_saturate_independently(tmp_path: Path) -> None:
+    """The cloud and local caps are independent, not collapsed to ``min()`` (#783).
+
+    Mixing 3 OPEN (cloud) and 4 INTIMATE (local) fragments: the cloud
+    classifier must genuinely reach its own max_concurrent=3 (a Barrier
+    proves overlap, not just "didn't crash"), while the local classifier —
+    sharing the same run — never exceeds its own, smaller, max_concurrent=2.
+    A naive fix that shares one semaphore sized at ``min(3, 2) == 2`` for both
+    would cap the cloud side at 2 too and the ``Barrier(3)`` below would time
+    out instead.
+    """
+    vault = tmp_path / "vault"
+    _write_fragments(vault, 3, tier=PrivacyTier.OPEN, prefix="frag-cloud")
+    _write_fragments(vault, 4, tier=PrivacyTier.INTIMATE, prefix="frag-intimate")
+    _ProbingClassifier.probes["anthropic"] = _Probe(parties=3)
+    _ProbingClassifier.probes["ollama"] = _Probe()  # sleep-based max-active counter
+
+    summary = run_classify(
+        vault_path=vault,
+        config=_config_mixed(cloud_max_concurrent=3, local_max_concurrent=2),
+        method="llm",
+        force=True,
+    )
+
+    cloud_probe = _ProbingClassifier.probes["anthropic"]
+    local_probe = _ProbingClassifier.probes["ollama"]
+    assert not cloud_probe.serialized, "cloud calls ran serially — barrier not tripped"
+    assert cloud_probe.max_active == 3  # all three cloud calls genuinely overlapped
+    assert local_probe.max_active <= 2  # local cap held despite the wider cloud knob
+    assert summary.total == 7
+    assert summary.classified == 7
+
+
+def test_single_shared_classifier_pool_width_unchanged(tmp_path: Path) -> None:
+    """A single shared classifier (pre-#666 shape) behaves exactly like #764.
+
+    When ``classification`` falls back to ``default`` and the Intimate route
+    resolves to that same local config, ``TierClassifiers.distinct()`` returns
+    one classifier — the pool must still be sized by (and capped at) that
+    single config's ``max_concurrent``, with no regression from the #783
+    per-tier plumbing.
+    """
+    vault = tmp_path / "vault"
+    _write_fragments(vault, 6, tier=PrivacyTier.OPEN, prefix="frag-single")
+    _ProbingClassifier.probes["ollama"] = _Probe()  # sleep-based max-active counter
+
+    summary = run_classify(
+        vault_path=vault,
+        config=_config_single_provider(max_concurrent=3),
+        method="llm",
+        force=True,
+    )
+
+    probe = _ProbingClassifier.probes["ollama"]
+    assert probe.max_active <= 3  # never exceeds the single config's own knob
+    assert probe.max_active >= 2  # genuinely overlapped, not accidentally serial
+    assert summary.total == 6
+    assert summary.classified == 6
+
+
+def test_deferred_intimate_route_runs_with_no_intimate_fragments(
+    tmp_path: Path,
+) -> None:
+    """No local backend to route Intimate to is fine when nothing is Intimate.
+
+    Both ``classification`` and ``default`` are cloud, so
+    ``TierClassifiers.intimate`` is ``None`` and the routing error is
+    deferred (#666). The vault holds only OPEN fragments, so the deferred
+    error never fires and the pool is sized by the sole (non-Intimate)
+    classifier alone.
+    """
+    vault = tmp_path / "vault"
+    _write_fragments(vault, 4, tier=PrivacyTier.OPEN, prefix="frag-deferred")
+    _ProbingClassifier.probes["anthropic"] = _Probe(parties=4)
+
+    summary = run_classify(
+        vault_path=vault,
+        config=_config_cloud_only(classification_max_concurrent=4),
+        method="llm",
+        force=True,
+    )
+
+    probe = _ProbingClassifier.probes["anthropic"]
+    assert not probe.serialized, "classify ran serially — barrier never tripped"
+    assert probe.max_active == 4
+    assert summary.total == 4
+    assert summary.classified == 4
+    assert summary.errors == ()


### PR DESCRIPTION
## Summary
- `creek classify --method llm` sized its single thread pool by the non-Intimate `classification` stage's `max_concurrent` (#764), so a mixed-tier vault applied the cloud width to the local provider serving INTIMATE fragments — oversubscribing it.
- Now the outer pool is sized as the **sum** of the distinct classifiers' `max_concurrent`, and each fragment's leaf classify call is guarded by a `threading.BoundedSemaphore` owned by its resolved provider (keyed by classifier identity). Each provider is capped by its own knob regardless of pool width; both tiers saturate independently and the local path is never oversubscribed by the cloud knob.
- When `TierClassifiers.distinct()` returns a single classifier (all-cloud, all-local, or deferred-intimate) the pool width collapses to the exact pre-#783 value — regression-identical. Reatomize and rules paths stay strictly serial. The semaphore guards only the leaf call (outside the shared lock, released on exception), so it never nests with the lock and is never held during the vault write.

## Test plan
- Added four mixed-tier tests to `tests/test_classify_concurrency.py` (extending the #764 instrumented-classifier fixtures, now keyed per-provider): local-tier calls capped by the local knob not the cloud knob; cloud + local tiers saturating independently (a `Barrier` kills a naive `min()`-based fix); single-shared-classifier pool width unchanged; deferred-intimate route runs with no intimate fragments. Confirmed the two cap tests fail RED against current `main` for the right reason, then GREEN after the fix.
- `env -u ANTHROPIC_API_KEY -u CREEK_CLOUD_CONSENT -u CREEK_ANTHROPIC_CONSENT ./scripts/check-all.sh` — all 12 checks pass (mypy strict, ruff, pylint, refurb, tryceratops, interrogate, bandit, complexity, 5958 tests, coverage 93.86%, per-file gate).

## Note (out-of-scope follow-up)
Self-review flagged that `LLMConfig.max_concurrent` (`config.py`) has no `Field(ge=1)` lower bound: a `max_concurrent: 0` misconfig would now build `BoundedSemaphore(0)` and hang on `acquire()` (previously harmless serial). Left out of scope for this issue; worth a hardening follow-up to reject `max_concurrent < 1` at config load.

Closes #783
