### PR TITLE
ci: post a loud PR comment when code-review.yml self-skips (#793)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -118,9 +118,43 @@ jobs:
             # claude-code-action self-skips (anti-tamper) on any PR that edits this
             # workflow file, so there is no review to post — that is expected and
             # must not fail the check (the workflow change is reviewed manually).
-            if gh pr diff "$PR_NUMBER" -R "$REPO" --name-only \
-                 | grep -qx '.github/workflows/code-review.yml'; then
+            # Assign first, then grep a herestring: a `gh … | grep -q` PIPELINE
+            # trips pipefail (grep -q exits on first match, gh dies with SIGPIPE
+            # 141, and the pipeline reports non-zero on a MATCH). If gh itself
+            # fails, set -e fails the step loudly — never a silent green.
+            changed_files=$(gh pr diff "$PR_NUMBER" -R "$REPO" --name-only)
+            if grep -qxF '.github/workflows/code-review.yml' <<<"$changed_files"; then
+              # This is the workflow-edited self-skip path: the required check must
+              # stay green (exit 0) so branch protection does not dead-lock, but a
+              # missing review must be LOUD — not a silent no-op. Post an explicit
+              # PR comment (in addition to the ::warning::) so it shows in the PR
+              # timeline. The body is a fully STATIC string (no interpolation of any
+              # PR-controlled data → no injection surface) and deliberately carries
+              # NO "## Verdict:"/"**Verdict:**" line, so the merge-critical
+              # line-anchored verdict parsers (iteration-trigger.yml, pr-ready.sh)
+              # never mistake it for a real verdict. (The word "verdict" appears
+              # mid-line only; a bare-substring analytics parser could still count
+              # it — harmless recap noise, never a gate.)
               echo "::warning::This PR edits the review workflow, so the action self-skips — no automated verdict; review manually."
+              # Idempotency: on `synchronize` this step re-runs per push, so dedup on
+              # the stable HTML marker. jq does the containment test in one command
+              # substitution (no `grep -q` pipeline → no SIGPIPE). Matching purely on
+              # the marker (not the comment author) is the robust dedup choice; even
+              # if someone pre-posts the marker to suppress the warning it is
+              # harmless — there is still no verdict comment, so the PR stays
+              # awaiting-review.
+              marker_count=$(gh pr view "$PR_NUMBER" -R "$REPO" --json comments \
+                --jq '[.comments[].body | select(. != null and contains("<!-- review-self-skip -->"))] | length')
+              if [ "$marker_count" -eq 0 ]; then
+                # Build the body from static literals via printf so the marker sits
+                # on its own top line with no leading indentation (avoids markdown
+                # treating an indented second line as a code block). No PR-controlled
+                # data is interpolated, so there is no injection surface.
+                self_skip_body=$(printf '%s\n%s\n' \
+                  '<!-- review-self-skip -->' \
+                  '⚠️ This PR edits the review workflow — no automated verdict; manual review required.')
+                gh pr comment "$PR_NUMBER" -R "$REPO" --body "$self_skip_body"
+              fi
               exit 0
             fi
             echo "::error::Claude review produced no structured output — failing so it is re-run, never a silent no-review."


### PR DESCRIPTION
## Summary
- Hardens `code-review.yml`'s anti-tamper self-skip path so a PR that edits the review workflow no longer produces a **silently green** required check with no posted comment. The self-skip path now also posts an explicit, static PR comment (`⚠️ This PR edits the review workflow — no automated verdict; manual review required.`) carrying a stable `<!-- review-self-skip -->` marker, so the absence of an automated review is loud and visible in the PR timeline. The check still `exit 0`s (branch protection must not dead-lock) and the normal-path `## Verdict:` contract is untouched byte-for-byte.
- The posted comment is idempotent — a jq marker-count dedups `synchronize` re-runs (with a `select(. != null ...)` null-body guard) so re-pushes don't spam one comment per push — and fully static (no PR-controlled interpolation → no injection surface; no `## Verdict:`/`**Verdict:**` line → cannot be mistaken for a real verdict by the line-anchored merge-critical parsers `iteration-trigger.yml` / `pr-ready.sh`).
- Replaces the `gh … | grep -q` pipeline with an assignment + herestring `grep -qxF` to eliminate the `set -euo pipefail`/SIGPIPE gotcha (grep -q exiting on first match could make the pipeline report non-zero on a *match* and fall through to the wrong branch); a real `gh` failure now fails the step **red** rather than falling through to a silent green.

## Test plan
Workflow YAML has no unit-test harness, so Gate 1 was adapted:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/code-review.yml'))"` — parses.
- `actionlint .github/workflows/code-review.yml` — zero findings (its shellcheck pass covers the `run:` block).
- Hand-traced all five shell paths under `set -euo pipefail`: (a) structured output present → normal `## Verdict:` path unchanged; (b) empty + workflow edited + no marker → warning + comment posted + `exit 0`; (c) empty + workflow edited + marker present → warning + no duplicate + `exit 0`; (d) empty + workflow not edited → `::error::` + `exit 1`; (e) any `gh` failure → step fails red.
- `cd creek-tools && ./scripts/check-all.sh` → exit 0 (all 12 checks; 5958 tests pass; coverage 93.86%).
- Gate 2.5: security-specialist (SECURE TO SHIP) and code-review-orchestrator (CLEAN) reviewed the diff.

## Note on the review verdict for this PR
This PR itself edits `code-review.yml`, so the automated Claude review will **self-skip** on it — that is the exact behavior being hardened, and the new self-skip warning comment appearing here is the live acceptance test. The orchestrator will request an `@claude`-mention review as the authoritative verdict.

Non-blocking follow-up surfaced in Gate 2.5 (could not be filed — issue-create was denied by the environment): `scripts/ralph/stats.py::normalize_verdict` is a bare `"VERDICT" in upper` substring matcher, so the new comment's mid-line "verdict" would log a phantom `COMMENTS` in the analytics recap only (never a gate; merge-critical parsers are already line-anchored and unaffected). Recommend line-anchoring `normalize_verdict` in a separate change.

Closes #793
