### PR TITLE
fix(ralph): classify "no checks registered yet" as pending in pr-ready.sh

### DIFF
--- a/scripts/ralph/pr-ready.sh
+++ b/scripts/ralph/pr-ready.sh
@@ -7,7 +7,7 @@
 #
 #   ready            LGTM (fresh) + CI green + up-to-date with main  → merge now
 #   behind           LGTM (fresh) + CI green but mergeStateStatus BEHIND → sync first
-#   pending          CI still running → wait for a later wake
+#   pending          CI still running (or no checks registered yet) → wait for a later wake
 #   ci-failed        CI has a failing/errored check → Step 2 (ci-debugging)
 #   awaiting-review  no fresh LGTM verdict (missing, stale, or non-LGTM) → wait / Step 2
 #
@@ -16,7 +16,9 @@
 # grep never matched and a still-running CI was read as settled — a false READY
 # that could merge a PR with pending/failing checks. CI state here is keyed off
 # the `gh pr checks` EXIT CODE, which is authoritative: 0 = all passed, 8 = some
-# pending, anything else = failure. No text parsing of the checks table at all.
+# pending, anything else = failure. No text parsing of the checks table at all —
+# with one deliberate exception: a stderr *signature* match (not table parsing)
+# for gh's no-checks-yet exit-1 case, which is reclassified from failure to pending.
 #
 # Stale-verdict guard: a review verdict only counts when it was posted AFTER the
 # PR's HEAD commit. An LGTM from before the latest push is stale (it reviewed
@@ -28,6 +30,13 @@ set -euo pipefail
 # `gh pr checks` exit code that means "checks still pending" (gh's documented
 # contract: 0 = pass, 8 = pending, other = failure).
 readonly CHECKS_PENDING_EC=8
+
+# gh also exits 1 (a "failure") with this case-insensitive stderr substring when a
+# PR has no check runs registered yet: `no checks reported on the '<branch>' branch`.
+# That is a not-yet-started PR, not a failed one, so it must classify as `pending`.
+# We never pass `--required`, so gh's `--required` variant ("no required checks
+# reported...", which this substring would NOT match) never arises here.
+readonly NO_CHECKS_SIG='no checks reported'
 
 die() { echo "pr-ready: $1" >&2; exit 2; }
 
@@ -61,11 +70,21 @@ gh_args=("$pr" ${repo_args[@]+"${repo_args[@]}"})
 
 # --- CI state from the exit code, not the text table -----------------------
 ci_ec=0
-gh pr checks "${gh_args[@]}" >/dev/null 2>&1 || ci_ec=$?
+# `2>&1 >/dev/null`: route stderr into the capture, then drop stdout — so ci_err
+# holds gh's stderr (e.g. the no-checks-yet message) while the checks table is
+# discarded. The `|| ci_ec=$?` guard absorbs gh's non-zero exit under `set -e`.
+ci_err="$(gh pr checks "${gh_args[@]}" 2>&1 >/dev/null)" || ci_ec=$?
 if [[ "$ci_ec" -eq "$CHECKS_PENDING_EC" ]]; then
   echo "pending"; exit 0
 elif [[ "$ci_ec" -ne 0 ]]; then
-  echo "ci-failed"; exit 0
+  # No check runs registered yet (gh exits non-zero with a "no checks
+  # reported" stderr) is a not-yet-started PR, not a failure → pending.
+  if printf '%s' "$ci_err" | grep -qi "$NO_CHECKS_SIG"; then
+    echo "pending"
+  else
+    echo "ci-failed"
+  fi
+  exit 0
 fi
 
 # --- CI is green: check mergeability + a FRESH LGTM verdict -----------------

--- a/scripts/ralph/test_pr_ready.sh
+++ b/scripts/ralph/test_pr_ready.sh
@@ -27,7 +27,12 @@ BIN="$WORK/bin"
 mkdir -p "$BIN"
 
 # Arg-aware fake gh. Behaviour is driven by env vars the test sets per case:
-#   CHECKS_EC     — exit code `gh pr checks` should return (0 green / 8 pending / other failed)
+#   CHECKS_EC        — exit code `gh pr checks` should return (0 green / 8 pending / other failed)
+#   CHECKS_NO_CHECKS — when "1", `gh pr checks` fails with the exact stderr gh
+#                      emits when NO check runs are registered yet on the
+#                      branch ("no checks reported on the '<branch>' branch"),
+#                      exit 1. This must classify as `pending`, not `ci-failed`
+#                      — CI just hasn't started, not failed.
 #   MERGE_STATE   — mergeStateStatus (CLEAN / BEHIND / ...)
 #   HEAD_DATE     — RFC3339 committedDate of the PR HEAD commit
 #   VERDICT       — the "<createdAt>|<isLGTM>" scalar the verdict jq resolves to
@@ -41,7 +46,12 @@ cat > "$BIN/gh" <<'STUB'
 #!/usr/bin/env bash
 args="$*"
 case "$args" in
-  *"pr checks"*)            exit "${CHECKS_EC:-0}" ;;
+  *"pr checks"*)
+    if [[ "${CHECKS_NO_CHECKS:-0}" == "1" ]]; then
+      echo "no checks reported on the 'feature-x' branch" >&2
+      exit 1
+    fi
+    exit "${CHECKS_EC:-0}" ;;
   *"--json mergeStateStatus"*) printf '%s|%s\n' "${MERGE_STATE:-CLEAN}" "${HEAD_DATE:-}" ;;
   *"--json comments"*)
     if [[ -n "${COMMENTS_JSON:-}" ]]; then
@@ -70,6 +80,10 @@ check "missing PR number exits 2" "2" "$rc"
 # --- pending: gh pr checks exit 8 is NEVER ready (the core bug) -------------
 check "exit 8 → pending" "pending" \
   "$(CHECKS_EC=8 run 100)"
+
+# --- pending: no checks registered yet (exit 1 + the gh "no checks reported"
+# stderr signature) is CI-hasn't-started, not CI-failed ----------------------
+check "exit 1 + 'no checks reported' stderr → pending" "pending" "$(CHECKS_NO_CHECKS=1 run 100)"
 
 # --- CI failure surfaced: non-0/non-8 exit → ci-failed ---------------------
 check "exit 1 → ci-failed" "ci-failed" \


### PR DESCRIPTION
## Summary
- `scripts/ralph/pr-ready.sh` classified a PR with **no check runs registered yet** as `ci-failed` — because `gh pr checks` exits 1 (like a real failure) with the stderr `no checks reported on the '<branch>' branch` seconds after a push. That misrouted a fine, not-yet-started PR into the ci-debugging path instead of `pending`.
- The script now captures gh's stderr and, on any non-zero/non-8 exit, emits `pending` when it carries the case-insensitive `no checks reported` signature; genuine failures (any other non-zero exit) stay `ci-failed`. The exit-8/exit-0 paths, single-token output contract, and bash 3.2 (macOS) compatibility are unchanged.

## Test plan
- Extended `scripts/ralph/test_pr_ready.sh`'s fake `gh` with a `CHECKS_NO_CHECKS` mode (exit 1 + the real `no checks reported` stderr) and a case asserting `pending`; the retained `exit 1 → ci-failed` / `exit 2 → ci-failed` cases are the regression guard that discrimination keys on stderr content, not the shared exit code.
- `bash scripts/ralph/test_pr_ready.sh` → 15 passed, 0 failed.
- `bash scripts/ralph/test_fleet.sh` and `bash scripts/ralph/test_pick_next.sh` → green (all three ralph suites CI runs via `ralph-fleet-tests.yml`).
- `shellcheck scripts/ralph/pr-ready.sh` → clean.
- `cd creek-tools && ./scripts/check-all.sh` → exit 0 (12/12 quality checks passed; scripts/ralph-only change, Python suite untouched).

Closes #794
