### PR TITLE
docs(skills): remap scan-issue-writer examples to the creek stack

### DIFF
--- a/.claude/skills/scan-issue-writer/SKILL.md
+++ b/.claude/skills/scan-issue-writer/SKILL.md
@@ -83,15 +83,16 @@ number. A clean scan reports zero created and that is a success.
 
 ## Examples
 
-### Example 1 — Perf scan finds an N+1
-Title: `[scan:perf] N+1 query loading marginalia in entries.list_for_user`
-Labels: `P2,scan:perf,agent-ready`. Body cites the SQLAlchemy echo log,
-`file:line` at the scanned SHA, and a `selectinload` before/after sketch.
+### Example 1 — Perf scan finds an unbatched embedding call
+Title: `[scan:perf] Unbatched generate_embedding() call in fragment loop`
+Labels: `P2,scan:perf,agent-ready`. Body cites the per-fragment loop,
+`file:line` at the scanned SHA, and a `generate_embedding` →
+`generate_embeddings` batch before/after sketch.
 
 ### Example 2 — Dedupe hit
-`[scan:dead-code] unused export parseAmount in lib/billing.ts` is already
-open as #412 → add a comment: "Still present at `<SHA>`; vulture confidence
-100%." No new issue is created.
+`[scan:dead-code] unused helper _legacy_link_summary in creek_mcp/tools/link.py`
+is already open as #412 → add a comment: "Still present at `<SHA>`; vulture
+confidence 100%." No new issue is created.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Remap the two worked examples in `.claude/skills/scan-issue-writer/SKILL.md` from the sibling repo's stack (a SQLAlchemy N+1 echo-log finding; a TypeScript `parseAmount in lib/billing.ts` dead-code hit) to creek-native equivalents.
- Example 1 is now an unbatched `EmbeddingLinker.generate_embedding` per-fragment loop in `creek/link/embeddings.py`, with the batch `generate_embeddings` as the before/after sketch (both real methods).
- Example 2 is now a vulture dead-code dedupe hit for an unused helper in the real handler module `creek_mcp/tools/link.py`. Illustrative only — no process-step, contract, or length changes to the skill.

## Test plan
- `grep -riE 'sqlalchemy|typescript|billing\.ts|npm' .claude/skills/scan-issue-writer/` returns nothing (issue acceptance check).
- `cd creek-tools && ./scripts/check-all.sh` exits 0 (all 12 checks passed; docs-only, no Python touched).
- Gate 2.5 self-review (code-review-orchestrator): flagged an initial phantom-symbol reference; corrected so the dead-code example names no live symbol and cites a real module path.

Closes #795
