### PR TITLE
ci(deps): align claude-code-action SHA pin across workflows

### DIFF
--- a/.github/workflows/_claude-scan.yml
+++ b/.github/workflows/_claude-scan.yml
@@ -105,7 +105,7 @@ jobs:
           done
 
       - name: Run Claude scan
-        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0  # v1.0.158
+        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e  # v1.0.162
         env:
           # The scan-issue-writer skill files issues via gh; the action injects
           # GITHUB_TOKEN, but gh reads GH_TOKEN — bind it to the job token whose

--- a/.github/workflows/scan-groom.yml
+++ b/.github/workflows/scan-groom.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 50
 
       - name: Run backlog grooming
-        uses: anthropics/claude-code-action@521136812280ae7ef256e06045655b9da02793f0  # v1.0.158
+        uses: anthropics/claude-code-action@6c0083bb7289c31716797a039b6367b3079cc46e  # v1.0.162
         env:
           GH_TOKEN: ${{ github.token }}
         with:


### PR DESCRIPTION
## Summary
- Bump `_claude-scan.yml` and `scan-groom.yml` from the v1.0.158 SHA (`521136…`) to the v1.0.162 SHA (`6c0083bb…`) already used by `claude.yml`, `code-review.yml`, and `deslop.yml`, updating their trailing `# v1.0.162` version comments to match.
- `code-review.yml` is intentionally left untouched (already on 1.0.162) to avoid triggering its review self-skip.
- Every workflow now resolves the same `anthropics/claude-code-action` revision.

## Test plan
- `grep -h 'claude-code-action@' .github/workflows/*.yml | sort -u` yields exactly one line (one SHA).
- `python3 -c "import yaml; yaml.safe_load(open(f))"` on both touched files parses OK.
- `cd creek-tools && ./scripts/check-all.sh` exits 0 (all 12 checks pass; 5958 tests pass; coverage 93.86%).

Closes #796
