### PR TITLE
fix(ralph): honor die() exit code, case-fold epic guard, lock cmd_assign (#797)

### DIFF
--- a/.github/workflows/dependabot-to-ralph-issue.yml
+++ b/.github/workflows/dependabot-to-ralph-issue.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Bridge Dependabot PRs into Ralph issues
         env:
-          # Prefer a real PAT (same convention as claude-code-review.yml and
+          # Prefer a real PAT (same convention as code-review.yml and
           # deslop.yml) so the issue/PR edits are authored by an account
           # the mobile webhook recognizes; fall back to the run's GITHUB_TOKEN.
           GH_TOKEN: ${{ secrets.GEOFFE_GA_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/iteration-trigger.yml
+++ b/.github/workflows/iteration-trigger.yml
@@ -67,7 +67,7 @@ jobs:
           fi
 
           # Find the latest Claude review comment via the deterministic
-          # "## Verdict: <verdict>" line that claude-code-review.yml appends.
+          # "## Verdict: <verdict>" line that code-review.yml appends.
           CLAUDE=$(jq -c '[.[] | select(.body | test("(^|\\n)## Verdict:"))] | last // empty' comments.json)
           if [ -z "$CLAUDE" ]; then
             echo "No Claude review yet - skipping"

--- a/scripts/ralph/fleet.sh
+++ b/scripts/ralph/fleet.sh
@@ -10,6 +10,8 @@
 # inspect, sync, and tear down those worktrees — never more than
 # `max_workers` (default 4) at a time.
 #
+# Design & concurrency model: scripts/ralph/FLEET.md
+#
 # Design contract ("optimistic parallelism, pessimistic merge"):
 #   * Parallel work is a speculation that the chosen issues are independent.
 #   * Correctness is guaranteed at MERGE time, not pick time: the orchestrator
@@ -50,9 +52,12 @@ readonly DEFAULT_MAX_WORKERS=4
 readonly WORKTREE_ROOT=".ralph/worktrees"
 readonly STATE_FILE="scripts/ralph/state.json"
 
+# Print an actionable error and exit. Callers pass the message as ONE arg and an
+# optional exit code as the second ($2) — so the code never leaks into the
+# message. Defaults to exit 1 for the common single-arg callers.
 die() {
-  echo "fleet: $*" >&2
-  exit 1
+  echo "fleet: $1" >&2
+  exit "${2:-1}"
 }
 
 # Resolve the repository root so the script works from any worktree/subdir.
@@ -162,20 +167,53 @@ cmd_path() {
   fi
 }
 
+# Acquire the assign critical-section lock via an atomic `mkdir` (no flock, so
+# macOS/bash-3.2-safe), bounded by FLEET_LOCK_TIMEOUT seconds (default 10). On
+# success installs an EXIT trap that releases the lock on EVERY later exit path —
+# the success return, a cap-refused `die`, or a fetch/worktree failure — because
+# die() calls `exit`, which fires an EXIT (not RETURN) trap. On timeout it dies
+# non-zero with an actionable stale-lock hint (a held lock is never removed here;
+# only its owner or the operator clears it).
+acquire_assign_lock() {
+  local lock="$1" timeout="${FLEET_LOCK_TIMEOUT:-10}" waited=0
+  [[ "$timeout" =~ ^[0-9]+$ ]] || timeout=10
+  while true; do
+    if mkdir "$lock" 2>/dev/null; then
+      trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+      return 0
+    fi
+    ((waited >= timeout)) && break
+    sleep 1
+    waited=$((waited + 1))
+  done
+  die "assign: could not acquire lock (stale $lock?); remove it if no assign is running" 1
+}
+
 cmd_assign() {
-  local issue="$1" slug="${2:-}" root dir branch base
+  local issue="$1" slug="${2:-}" root dir branch base lock
   [[ -n "$issue" ]] || die "assign: usage: assign <issue> <slug>"
   [[ "$issue" =~ ^[0-9]+$ ]] || die "assign: issue must be numeric, got '$issue'"
   root="$(repo_root)"
   dir="$(issue_dir "$issue")"
 
-  # Re-entrant: an existing worktree for this issue is simply reused.
+  # Re-entrant: an existing worktree for this issue is simply reused. Checked
+  # BEFORE locking so re-entry never contends on the lock.
   if [[ -d "$dir" ]]; then
     printf '%s\n' "$dir"
     return 0
   fi
 
-  # Enforce the cap only when creating a *new* worktree.
+  # Serialize the whole check-then-create below: without a lock two concurrent
+  # assigns could both pass the cap check and both add a worktree, overflowing
+  # max_workers (TOCTOU). Ensure the worktree root exists first so the lock has a
+  # home even on a cold fleet.
+  mkdir -p "$root/$WORKTREE_ROOT"
+  lock="$root/$WORKTREE_ROOT/.assign.lock"
+  acquire_assign_lock "$lock"
+
+  # Enforce the cap only when creating a *new* worktree — INSIDE the lock so the
+  # count-then-create is atomic. A refused assign calls die → exit, and the EXIT
+  # trap installed above still releases the lock.
   if [[ "$(cmd_free)" -le 0 ]]; then
     die "assign: fleet is full ($(count_active)/$(max_workers) workers active)"
   fi
@@ -185,7 +223,6 @@ cmd_assign() {
   base="origin/main"
 
   git -C "$root" fetch --quiet origin main || die "assign: could not fetch origin/main"
-  mkdir -p "$root/$WORKTREE_ROOT"
 
   if git -C "$root" show-ref --verify --quiet "refs/heads/$branch"; then
     # Branch already exists (prior tick) — attach a worktree to it.
@@ -193,6 +230,11 @@ cmd_assign() {
   else
     git -C "$root" worktree add "$dir" -b "$branch" "$base" >&2
   fi
+
+  # Success: release the lock now and clear the trap so a later exit does not try
+  # to rmdir an already-gone (or a newly re-acquired) lock.
+  rmdir "$lock" 2>/dev/null || true
+  trap - EXIT
   printf '%s\n' "$dir"
 }
 
@@ -266,7 +308,7 @@ cmd_reconcile() {
 }
 
 usage() {
-  sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+  sed -n '2,48p' "$0" | sed 's/^# \{0,1\}//'
   exit "${1:-1}"
 }
 

--- a/scripts/ralph/pick-next.sh
+++ b/scripts/ralph/pick-next.sh
@@ -186,9 +186,11 @@ has_label() {
   return 1
 }
 
-# Epic-prefixed labels of an issue (labels beginning with "epic").
+# Epic-prefixed labels of an issue (labels beginning with "epic"). Lowercased
+# BEFORE `sort -u` so the same-epic guard's `comm -12` intersection is
+# case-insensitive (e.g. "Epic-Foo" matches "epic-foo") and collates correctly.
 epic_labels() {
-  printf '%s\n' "${1//,/$'\n'}" | grep -iE '^epic' | sort -u || true
+  printf '%s\n' "${1//,/$'\n'}" | grep -iE '^epic' | tr '[:upper:]' '[:lower:]' | sort -u || true
 }
 
 # Does the candidate (labels CSV) conflict with any active issue?

--- a/scripts/ralph/test_fleet.sh
+++ b/scripts/ralph/test_fleet.sh
@@ -139,6 +139,47 @@ chmod +x "$BIN/gh"
 check "reconcile released only the merged worker" "1" "$(run count)"
 check "the open worker survived reconcile"        "105" "$(run active)"
 
+# --- die() honors an explicit exit code (rc==2) -----------------------------
+# cmd_reconcile's very first statement is `command -v gh || die "..." 2` — run
+# it with gh absent from PATH so the die call fires deterministically. Invoke
+# the running bash by absolute path ($BASH) so the interpreter is still findable
+# even though PATH is emptied (the /usr/bin/env shebang would otherwise need bash
+# on PATH); `command -v gh` is a builtin, so it works under the empty PATH.
+EMPTYBIN="$WORK/emptybin"; mkdir -p "$EMPTYBIN"
+rc=0
+(cd "$REPO" && PATH="$EMPTYBIN" "$BASH" "$FLEET" reconcile) >/dev/null 2>&1 || rc=$?
+check "die honors explicit exit code (reconcile w/o gh => 2)" "2" "$rc"
+
+# --- die() still defaults to exit 1 when no code is given --------------------
+rc=0
+run definitely-not-a-command >/dev/null 2>&1 || rc=$?
+check "die defaults to exit 1" "1" "$rc"
+
+# --- die() message excludes the exit-code arg ---------------------------------
+err="$( (cd "$REPO" && PATH="$EMPTYBIN" "$BASH" "$FLEET" reconcile) 2>&1 1>/dev/null || true )"
+check "die message excludes the exit-code arg" "fleet: reconcile: gh CLI required" "$err"
+
+# --- lock hygiene for cmd_assign ---------------------------------------------
+LOCKDIR="$REPO/.ralph/worktrees/.assign.lock"
+
+# (a) a successful assign leaves no lock dir behind.
+run assign 201 'lock cleanup' >/dev/null 2>&1
+[[ -d "$LOCKDIR" ]] && bad "assign left lock dir behind" || ok "assign releases lock on success"
+
+# (b) a refused assign (fleet full) also releases the lock (trap fires on die).
+printf '{"max_workers": 4, "parallel_enabled": false}\n' > "$REPO/scripts/ralph/state.json"
+run assign 203 'refused, lock must release' >/dev/null 2>&1 || true
+[[ -d "$LOCKDIR" ]] && bad "refused assign left lock dir behind" \
+  || ok "refused assign releases lock (trap fired on die)"
+printf '{"max_workers": 4, "parallel_enabled": true}\n' > "$REPO/scripts/ralph/state.json"
+
+# (c) a pre-existing stale lock makes assign fail fast, not hang or bypass it.
+mkdir -p "$LOCKDIR"
+rc=0
+(cd "$REPO" && FLEET_LOCK_TIMEOUT=1 "$FLEET" assign 202 'blocked by stale lock') >/dev/null 2>&1 || rc=$?
+[[ "$rc" -ne 0 ]] && ok "stale lock makes assign fail fast" || bad "stale lock did not block assign"
+rmdir "$LOCKDIR" 2>/dev/null || true
+
 # --- summary ----------------------------------------------------------------
 echo
 echo "fleet tests: $PASS passed, $FAIL failed"

--- a/scripts/ralph/test_pick_next.sh
+++ b/scripts/ralph/test_pick_next.sh
@@ -152,6 +152,14 @@ set_labels 10 "epic-foo"   # active issue shares epic-foo with candidate 11
 worktree 10
 check "same-epic candidate skipped, cross-epic picked" "12" "$(run_pick)"
 
+# 6b) Same-epic guard must be case-insensitive: "Epic-Foo" and "epic-foo" are
+#     the same epic and must still conflict.
+new_scenario epic_guard_mixed_case
+candidate 11 "Epic-Foo"; candidate 12 "epic-bar"
+set_labels 10 "epic-foo"   # active issue's epic label differs only in case from candidate 11
+worktree 10
+check "same-epic guard is case-insensitive (mixed-case skipped, cross-epic picked)" "12" "$(run_pick)"
+
 # 7) `parallelizable` overrides the same-epic guard.
 new_scenario epic_override
 candidate 11 "epic-foo,parallelizable"


### PR DESCRIPTION
## Summary
- `fleet.sh die()` now honors its documented optional second (exit-code) argument and prints only `$1`, so the code no longer leaks into the message; `reconcile`'s "gh CLI required" path exits `2` as its contract promised.
- `pick-next.sh epic_labels()` lowercases epic labels before `sort -u`, making the same-epic guard's `comm -12` intersection case-insensitive so `Epic-42` vs `epic-42` can no longer defeat it.
- `fleet.sh cmd_assign()` wraps its cap-check → `git worktree add` critical section in an atomic mkdir-based lock (macOS/bash-3.2-safe; no `flock`) to close a TOCTOU, released on every exit path via an EXIT trap.
- Fixed stale `claude-code-review.yml` comment references → `code-review.yml` in `iteration-trigger.yml` and `dependabot-to-ralph-issue.yml` (comment-only), and linked `scripts/ralph/FLEET.md` from `fleet.sh`'s header (widening `usage()`'s sed range to keep help complete).

## Test plan
- Added RED-first tests: die exit-code + message-purity + lock-hygiene checks in `test_fleet.sh`; a mixed-case epic-guard scenario in `test_pick_next.sh`. Confirmed each failed for the right reason, then went green.
- `test_fleet.sh` (31), `test_pick_next.sh` (24), `test_pr_ready.sh` (15) all pass; `test_fleet.sh` also passes under system `/bin/bash` 3.2 (bash 3.2 compatibility).
- `cd creek-tools && ./scripts/check-all.sh` exits 0 (12/12) — no Python was touched.
- Verdict from pre-push self-review: CLEAN.

Closes #797
Refs #792
