### PR TITLE
fix(config): bound LLMConfig.max_concurrent at ge=1

### DIFF
--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -163,8 +163,12 @@ class LLMConfig(BaseModel):
     batch_size: int = 50
     """Number of items to process per LLM batch call."""
 
-    max_concurrent: int = 5
-    """Maximum number of concurrent LLM requests."""
+    max_concurrent: int = Field(default=5, ge=1)
+    """Maximum number of concurrent LLM requests.
+
+    Must be at least 1: a value below 1 would build a ``BoundedSemaphore(0)``
+    in the per-provider classify pool (PR #799) and hang forever on the first
+    ``acquire()``, so the misconfig fails fast at load time instead."""
 
     unclassified_threshold: float = Field(default=0.55, ge=0.0, le=1.0)
     """Per-dimension confidence floor below which Mode / Orientation /

--- a/creek-tools/tests/test_config.py
+++ b/creek-tools/tests/test_config.py
@@ -56,6 +56,25 @@ class TestLLMConfig:
         assert cfg.model == "claude-3"
         assert cfg.batch_size == 100
 
+    def test_max_concurrent_rejects_zero(self) -> None:
+        """Zero concurrent requests would issue no LLM calls at all."""
+        with pytest.raises(
+            ValueError, match=r"max_concurrent[\s\S]*greater than or equal to 1"
+        ):
+            LLMConfig(max_concurrent=0)
+
+    def test_max_concurrent_rejects_negative(self) -> None:
+        """A negative concurrency limit is nonsensical, not just unhelpful."""
+        with pytest.raises(
+            ValueError, match=r"max_concurrent[\s\S]*greater than or equal to 1"
+        ):
+            LLMConfig(max_concurrent=-3)
+
+    def test_max_concurrent_allows_one(self) -> None:
+        """1 is the inclusive lower bound — serial LLM operation is legal."""
+        cfg = LLMConfig(max_concurrent=1)
+        assert cfg.max_concurrent == 1
+
 
 class TestEmbeddingsConfig:
     """Tests for EmbeddingsConfig model."""


### PR DESCRIPTION
## Summary
- Add `Field(default=5, ge=1)` to `LLMConfig.max_concurrent` in `creek-tools/creek/config.py` so a `max_concurrent: 0` (or negative) misconfig fails fast at config-load with a clear `ValidationError` naming the field, instead of hanging forever on `BoundedSemaphore(0).acquire()` in the per-provider classify pool introduced by PR #799.
- Mirrors sibling knobs (`resonance_top_k`, `reatomize_max_depth`, etc.) that already use `ge=1`. Config-layer only — no behavior change for valid configs (default stays 5).
- Extends the field docstring with the semaphore-starvation rationale.

## Test plan
- Added three tests to `TestLLMConfig` in `creek-tools/tests/test_config.py`: `max_concurrent=0` and `=-3` raise a `ValidationError` whose message names `max_concurrent` and states "greater than or equal to 1"; `=1` is valid (inclusive lower bound). RED confirmed before the fix (DID NOT RAISE), GREEN after.
- `cd creek-tools && ./scripts/check-all.sh` → exit 0: all 12 checks pass, 5961 tests pass, branch coverage 93.86%.

Closes #800
Refs #799
