### PR TITLE
docs(classify): note pool width sums all tier widths for single-tier runs

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -393,6 +393,13 @@ def _build_classify_throttle(
     single classifier — the shared-instance / single-provider case — this
     collapses to exactly the pre-#783 single-stage width (no regression).
 
+    Note that the pool width sums **all** distinct classifiers' ``max_concurrent``
+    up front, even when a run contains fragments for only one tier (e.g. an
+    all-OPEN vault with a configured-but-unused local Intimate route still gets
+    ``cloud_width + local_width`` threads). Those extra threads sit idle rather
+    than oversubscribe any provider — harmless, but worth knowing if the
+    thread count ever surprises someone profiling (#799).
+
     Args:
         tier_classifiers: The per-tier classifier set, or ``None`` for the
             rules path (which runs serially with no provider to throttle).


### PR DESCRIPTION
## Summary

- Add a one-line-intent docstring note to `_build_classify_throttle` in `creek-tools/creek/classify/classify_engine.py`: the outer pool width is the **sum** of every distinct classifier's `max_concurrent` even when a run contains fragments for only one tier (e.g. an all-OPEN vault with a configured-but-unused local Intimate route still gets `cloud_width + local_width` threads).
- Clarifies that those extra threads sit idle — harmless, no oversubscription — but can surprise someone profiling thread counts.
- Docs-only; no behavior change.

## Test plan

- `cd creek-tools && ./scripts/check-all.sh` → exit 0 (5961 passed, coverage 93.86%, interrogate/docstring gate green).

Closes #801
Refs #799