### PR TITLE
fix(ralph): line-anchor normalize_verdict so recap ignores prose "verdict"

### DIFF
--- a/scripts/ralph/stats.py
+++ b/scripts/ralph/stats.py
@@ -16,6 +16,7 @@ merge history into the numbers a human wants to see in a recap.
 from __future__ import annotations
 
 import datetime as dt
+import re
 from collections import Counter
 
 # A Claude reviewer verdict, normalized. The reviewer posts a comment ending in
@@ -23,6 +24,15 @@ from collections import Counter
 LGTM = "LGTM"
 CHANGES_REQUESTED = "CHANGES_REQUESTED"
 COMMENTS = "COMMENTS"
+
+# Anchors a genuine verdict LINE (heading- and bold-prefix tolerant) so a stray
+# mention of "verdict" in prose does not false-positive. Mirrors pr-ready.sh's
+# VERDICT_RE (its line 64) and must be kept in sync with it; single backslashes
+# here because — unlike pr-ready.sh — this pattern is not spliced into a jq
+# string literal.
+_VERDICT_LINE_RE = re.compile(
+    r"^\s*(?:#{1,6}\s+|\*\*)?verdict[:*\s]", re.IGNORECASE | re.MULTILINE
+)
 
 ISO_NO_TZ = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -39,18 +49,21 @@ def parse_iso(timestamp: str) -> dt.datetime:
 def normalize_verdict(raw: str) -> str | None:
     """Collapse a Claude review comment body to a single verdict token.
 
-    Returns None when the body carries no recognizable verdict line, so callers
-    can ignore non-review comments. The check mirrors the grep ladder in
-    `iteration-trigger.yml`: CHANGES_REQUESTED wins over a bare LGTM mention so
-    a comment that says "this is not yet LGTM, changes requested" is counted as
-    a change request.
+    Returns None when the body carries no genuine verdict LINE, so callers can
+    ignore non-review comments (a stray "verdict" mentioned mid-prose does not
+    count). Line-anchoring mirrors pr-ready.sh's VERDICT_RE. When several verdict
+    lines exist (the reviewer re-verdicted after another pass), the LAST one
+    wins: we scan from its start to end-of-body and apply the precedence
+    CHANGES_REQUESTED beats a bare LGTM mention, so "this is not yet LGTM,
+    changes requested" is counted as a change request.
     """
-    upper = raw.upper()
-    if "VERDICT" not in upper:
+    matches = list(_VERDICT_LINE_RE.finditer(raw))
+    if not matches:
         return None
-    if "CHANGES_REQUESTED" in upper or "CHANGES REQUESTED" in upper:
+    region = raw[matches[-1].start() :].upper()
+    if "CHANGES_REQUESTED" in region or "CHANGES REQUESTED" in region:
         return CHANGES_REQUESTED
-    if "LGTM" in upper:
+    if "LGTM" in region:
         return LGTM
     return COMMENTS
 

--- a/scripts/ralph/test_recap_stats.py
+++ b/scripts/ralph/test_recap_stats.py
@@ -54,6 +54,34 @@ def test_normalize_verdict_defaults_to_comments() -> None:
     assert rs.normalize_verdict("Some notes.\nVerdict: COMMENTS") == rs.COMMENTS
 
 
+def test_normalize_verdict_ignores_mid_line_prose_mention() -> None:
+    # Issue #803: a bare substring match on "VERDICT" false-positives on prose
+    # that merely mentions the word without a genuine Verdict line (as in PR
+    # #802's self-skip warning comment). No verdict line -> None.
+    body = (
+        "Heads up: the loop will self-skip so no verdict will be posted for "
+        "this PR by the author."
+    )
+    assert rs.normalize_verdict(body) is None
+
+
+def test_normalize_verdict_detects_markdown_heading_prefix() -> None:
+    assert rs.normalize_verdict("## Verdict: LGTM") == rs.LGTM
+
+
+def test_normalize_verdict_detects_bold_prefix() -> None:
+    assert rs.normalize_verdict("**Verdict:** COMMENTS") == rs.COMMENTS
+
+
+def test_normalize_verdict_legacy_header_with_token_on_next_line() -> None:
+    assert rs.normalize_verdict("## Verdict\n✅ LGTM") == rs.LGTM
+
+
+def test_normalize_verdict_last_verdict_line_wins() -> None:
+    body = "Verdict: CHANGES_REQUESTED\n\nAfter another pass:\n## Verdict: LGTM"
+    assert rs.normalize_verdict(body) == rs.LGTM
+
+
 # ---------- iterations_before_lgtm ----------
 
 


### PR DESCRIPTION
## Summary
- Line-anchor `scripts/ralph/stats.py::normalize_verdict` so the recap extracts a verdict only from a genuine Verdict **line** (mirroring `pr-ready.sh`'s `VERDICT_RE`), instead of a bare `"VERDICT" in upper` substring match.
- Fixes the phantom `COMMENTS` that mid-line prose containing the word "verdict" (e.g. PR #802's self-skip warning comment) logged in the analytics recap. Scans from the last verdict line to end-of-body and keeps the existing `CHANGES_REQUESTED > LGTM > COMMENTS` precedence; public signature unchanged.
- Analytics-only — merge-critical parsers were already line-anchored and are unaffected.

## Test plan
- `python -m pytest scripts/ralph -q` — 56 passed (5 new normalize_verdict cases: mid-line prose → None, `## Verdict: LGTM`, `**Verdict:** COMMENTS`, legacy `## Verdict\n✅ LGTM` header form, and last-verdict-line-wins).
- `mypy --strict scripts/ralph/stats.py` — clean.
- `cd creek-tools && ./scripts/check-all.sh` — exit 0 (12/12 checks).

Closes #803
Refs #802
