### PR TITLE
fix(config): bound LLMConfig.batch_size at ge=1 (#809)

### DIFF
--- a/creek-tools/creek/config.py
+++ b/creek-tools/creek/config.py
@@ -160,8 +160,12 @@ class LLMConfig(BaseModel):
     secret; ``None`` means no trust anchor is configured and the provider fails
     closed. See ADR-0006."""
 
-    batch_size: int = 50
-    """Number of items to process per LLM batch call."""
+    batch_size: int = Field(default=50, ge=1)
+    """Number of items to process per LLM batch call.
+
+    Must be at least 1: a value below 1 would feed ``encode(batch_size=0)`` in
+    the embeddings pass (``creek/link/embeddings.py``) and process nothing, so
+    the misconfig fails fast at load time instead of silently doing no work."""
 
     max_concurrent: int = Field(default=5, ge=1)
     """Maximum number of concurrent LLM requests.

--- a/creek-tools/tests/test_config.py
+++ b/creek-tools/tests/test_config.py
@@ -75,6 +75,25 @@ class TestLLMConfig:
         cfg = LLMConfig(max_concurrent=1)
         assert cfg.max_concurrent == 1
 
+    def test_batch_size_rejects_zero(self) -> None:
+        """A zero batch would feed ``encode(batch_size=0)`` and process nothing."""
+        with pytest.raises(
+            ValueError, match=r"batch_size[\s\S]*greater than or equal to 1"
+        ):
+            LLMConfig(batch_size=0)
+
+    def test_batch_size_rejects_negative(self) -> None:
+        """A negative batch size is nonsensical, not just unhelpful."""
+        with pytest.raises(
+            ValueError, match=r"batch_size[\s\S]*greater than or equal to 1"
+        ):
+            LLMConfig(batch_size=-10)
+
+    def test_batch_size_allows_one(self) -> None:
+        """1 is the inclusive lower bound — one item per batch is legal."""
+        cfg = LLMConfig(batch_size=1)
+        assert cfg.batch_size == 1
+
 
 class TestEmbeddingsConfig:
     """Tests for EmbeddingsConfig model."""


### PR DESCRIPTION
## Summary
- Mirror the just-merged #808 `max_concurrent` bound onto `LLMConfig.batch_size`: `Field(default=50, ge=1)`, so a sub-1 value fails fast with a clear `ValidationError` at config-load instead of feeding `encode(batch_size=0)` in the embeddings pass and silently processing nothing.
- Config-layer only; no behavior change for valid configs.

## Test plan
- Added boundary tests in `tests/test_config.py` alongside the #808 tests: `batch_size=0` and `batch_size=-10` raise `ValidationError` naming `batch_size`; `batch_size=1` is accepted (RED confirmed before the fix, GREEN after).
- `cd creek-tools && ./scripts/check-all.sh` exits 0 (5964 passed, coverage 93.86%).

Closes #809
Refs #808
