### PR TITLE
fix(ci): grant scan wrappers the token scopes the reusable core requests

### DIFF
--- a/.github/workflows/scan-bugs.yml
+++ b/.github/workflows/scan-bugs.yml
@@ -19,6 +19,13 @@ on:
 
 jobs:
   run:
+    # A reusable workflow may not request more GITHUB_TOKEN scopes than its
+    # caller grants; the repo default is read-only, so grant the core's needs
+    # here (contents: read / issues: write / id-token: write) explicitly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
     uses: ./.github/workflows/_claude-scan.yml
     with:
       scan_name: bugs

--- a/.github/workflows/scan-complexity.yml
+++ b/.github/workflows/scan-complexity.yml
@@ -19,6 +19,13 @@ on:
 
 jobs:
   run:
+    # A reusable workflow may not request more GITHUB_TOKEN scopes than its
+    # caller grants; the repo default is read-only, so grant the core's needs
+    # here (contents: read / issues: write / id-token: write) explicitly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
     uses: ./.github/workflows/_claude-scan.yml
     with:
       scan_name: complexity

--- a/.github/workflows/scan-coverage.yml
+++ b/.github/workflows/scan-coverage.yml
@@ -19,6 +19,13 @@ on:
 
 jobs:
   run:
+    # A reusable workflow may not request more GITHUB_TOKEN scopes than its
+    # caller grants; the repo default is read-only, so grant the core's needs
+    # here (contents: read / issues: write / id-token: write) explicitly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
     uses: ./.github/workflows/_claude-scan.yml
     with:
       scan_name: coverage

--- a/.github/workflows/scan-dead-code.yml
+++ b/.github/workflows/scan-dead-code.yml
@@ -19,6 +19,13 @@ on:
 
 jobs:
   run:
+    # A reusable workflow may not request more GITHUB_TOKEN scopes than its
+    # caller grants; the repo default is read-only, so grant the core's needs
+    # here (contents: read / issues: write / id-token: write) explicitly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
     uses: ./.github/workflows/_claude-scan.yml
     with:
       scan_name: dead-code

--- a/.github/workflows/scan-deps.yml
+++ b/.github/workflows/scan-deps.yml
@@ -19,6 +19,13 @@ on:
 
 jobs:
   run:
+    # A reusable workflow may not request more GITHUB_TOKEN scopes than its
+    # caller grants; the repo default is read-only, so grant the core's needs
+    # here (contents: read / issues: write / id-token: write) explicitly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
     uses: ./.github/workflows/_claude-scan.yml
     with:
       scan_name: deps

--- a/.github/workflows/scan-docs.yml
+++ b/.github/workflows/scan-docs.yml
@@ -19,6 +19,13 @@ on:
 
 jobs:
   run:
+    # A reusable workflow may not request more GITHUB_TOKEN scopes than its
+    # caller grants; the repo default is read-only, so grant the core's needs
+    # here (contents: read / issues: write / id-token: write) explicitly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
     uses: ./.github/workflows/_claude-scan.yml
     with:
       scan_name: docs

--- a/.github/workflows/scan-mutation.yml
+++ b/.github/workflows/scan-mutation.yml
@@ -19,6 +19,13 @@ on:
 
 jobs:
   run:
+    # A reusable workflow may not request more GITHUB_TOKEN scopes than its
+    # caller grants; the repo default is read-only, so grant the core's needs
+    # here (contents: read / issues: write / id-token: write) explicitly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
     uses: ./.github/workflows/_claude-scan.yml
     with:
       scan_name: mutation

--- a/.github/workflows/scan-perf.yml
+++ b/.github/workflows/scan-perf.yml
@@ -19,6 +19,13 @@ on:
 
 jobs:
   run:
+    # A reusable workflow may not request more GITHUB_TOKEN scopes than its
+    # caller grants; the repo default is read-only, so grant the core's needs
+    # here (contents: read / issues: write / id-token: write) explicitly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
     uses: ./.github/workflows/_claude-scan.yml
     with:
       scan_name: perf

--- a/.github/workflows/scan-security.yml
+++ b/.github/workflows/scan-security.yml
@@ -19,6 +19,13 @@ on:
 
 jobs:
   run:
+    # A reusable workflow may not request more GITHUB_TOKEN scopes than its
+    # caller grants; the repo default is read-only, so grant the core's needs
+    # here (contents: read / issues: write / id-token: write) explicitly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
     uses: ./.github/workflows/_claude-scan.yml
     with:
       scan_name: security

--- a/.github/workflows/scan-todo.yml
+++ b/.github/workflows/scan-todo.yml
@@ -23,6 +23,13 @@ on:
 
 jobs:
   run:
+    # A reusable workflow may not request more GITHUB_TOKEN scopes than its
+    # caller grants; the repo default is read-only, so grant the core's needs
+    # here (contents: read / issues: write / id-token: write) explicitly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
     uses: ./.github/workflows/_claude-scan.yml
     with:
       scan_name: todo

--- a/.github/workflows/scan-types.yml
+++ b/.github/workflows/scan-types.yml
@@ -19,6 +19,13 @@ on:
 
 jobs:
   run:
+    # A reusable workflow may not request more GITHUB_TOKEN scopes than its
+    # caller grants; the repo default is read-only, so grant the core's needs
+    # here (contents: read / issues: write / id-token: write) explicitly.
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
     uses: ./.github/workflows/_claude-scan.yml
     with:
       scan_name: types


### PR DESCRIPTION
## Summary
All 11 core-based scan wrappers startup_failed on every trigger (cron + hopper dispatch) since the #792 port: a reusable workflow may not request more GITHUB_TOKEN scopes than its caller grants, the repo default is read-only, and the wrappers declared no permissions. This grants contents:read / issues:write / id-token:write at the caller job level, matching _claude-scan.yml's declared needs. scan-groom/deslop are standalone and unaffected.

Note: the same latent break exists in the well-worn-tools template.

## Test plan
- yaml parse + actionlint clean on all wrappers
- After merge: workflow_dispatch a scan and confirm it reaches the job (validated live below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)