### PR TITLE
chore(agents): retier subagent models (opus=plan, sonnet=review, fable=implement, haiku=checks)

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -21,15 +21,15 @@ graph under a conductor is identical:
 
 ```
 ralph-tick (fleet ORCHESTRATOR — worker pool: reconcile · serialized-merge · lazy-sync · refill)
-  └─ ralph-worker × up to 4 . L1  opus    per-issue CONDUCTOR in an isolated worktree
-       ├─ chief-architect ..... L0  fable   plan + ordered dispatch list (no code)
-       ├─ test-specialist ..... L2  sonnet  Gate 1 RED: failing tests          ─┐
-       ├─ implementation-spec.  L2  opus    Gate 1 GREEN + Refactor             │ run per
+  └─ ralph-worker × up to 4 . L1  fable   per-issue CONDUCTOR in an isolated worktree
+       ├─ chief-architect ..... L0  opus    plan + ordered dispatch list (no code)
+       ├─ test-specialist ..... L2  fable   Gate 1 RED: failing tests          ─┐
+       ├─ implementation-spec.  L2  fable   Gate 1 GREEN + Refactor             │ run per
        ├─ security-specialist . L2  opus    harden auth/input/paths/secrets     │ the
-       ├─ performance-spec. ... L2  sonnet  profile/optimize hot paths          │ architect's
+       ├─ performance-spec. ... L2  fable   profile/optimize hot paths          │ architect's
        ├─ documentation-spec. . L2  sonnet  docstrings/READMEs/ADRs             │ dispatch
        ├─ dependency-review ... L2  haiku   deps/pins/licenses (read-only)      │ list
-       └─ code-review-orch. ... L1  opus    Gate 2.5 pre-push self-review      ─┘
+       └─ code-review-orch. ... L1  sonnet  Gate 2.5 pre-push self-review      ─┘
 ```
 
 **The tree above is the spawn graph: each conductor (`ralph-worker`, or
@@ -62,25 +62,28 @@ specialists are leaf workers that do their own work and do not sub-delegate.
 
 ## Model tiers (strategic mix)
 
-**Fable** for the single hardest-reasoning, long-horizon role: `chief-architect`.
-Planning is the highest-leverage decision in a tick — one wrong design compounds
-across every specialist that executes it — so the architect runs on Anthropic's
-most capable model. Fable is ~2× Opus-tier cost and can run minutes-long turns,
-which is acceptable for a once-per-issue planning pass but **not** for scoped
-worker roles. Two Fable caveats shape the fleet: its safety classifiers target
-**cyber/bio** content (so the code-writing `security-specialist` stays on **Opus**,
-never Fable — legitimate hardening work can trip a false-positive refusal), and it
-prefers **less-prescriptive prompts** (state the goal and constraints; the
-architect's Output Contract is a format spec, not step-by-step scaffolding).
+The tiering rule is **Opus for planning, Sonnet for review, Fable for
+implementation, Haiku for quick checks.**
 
-**Opus** where judgment drives quality:
-`implementation-specialist` (production code is the core quality lever),
-`security-specialist` (threat modeling — and deliberately kept off Fable per the
-caveat above), `code-review-orchestrator` (synthesis).
-**Sonnet** for well-scoped roles guided by an explicit plan: `test-specialist`,
-`performance-specialist`, `documentation-specialist`. **Haiku** for the
-purely mechanical, read-only checklist walk: `dependency-review-specialist`
-(pins/lockfile/license checks need no deep reasoning — spend the cheaper tier).
+**Fable** for the code-writing roles — implementation is where model quality
+pays off directly: `ralph-worker` (the long-horizon per-issue conductor),
+`implementation-specialist` (Gate 1 GREEN + Refactor), `test-specialist`
+(Gate 1 RED), `performance-specialist` (optimization). Fable is ~2× Opus-tier
+cost and can run minutes-long turns — worth it on the roles that produce the
+production diff. Two Fable caveats still shape the fleet: its safety
+classifiers target **cyber/bio** content (so the code-writing
+`security-specialist` stays on **Opus**, never Fable — legitimate hardening
+work can trip a false-positive refusal), and it prefers **less-prescriptive
+prompts** (state the goal and constraints, not step-by-step scaffolding).
+
+**Opus** for planning: `chief-architect` (the once-per-issue design pass) —
+plus `security-specialist`, an implementation role deliberately kept off Fable
+per the caveat above.
+**Sonnet** for review and other well-scoped passes over bounded input:
+`code-review-orchestrator` (Gate 2.5), `documentation-specialist`.
+**Haiku** for the purely mechanical, read-only checklist walk:
+`dependency-review-specialist` (pins/lockfile/license checks need no deep
+reasoning — spend the cheaper tier).
 
 ## Gate → agent invocation matrix
 

--- a/.claude/agents/chief-architect.md
+++ b/.claude/agents/chief-architect.md
@@ -4,7 +4,7 @@ description: "Strategic brain of a Ralph tick. Select to architect a single back
 level: 0
 phase: Plan
 tools: Read,Grep,Glob,Task
-model: fable
+model: opus
 delegates_to: [test-specialist, implementation-specialist, security-specialist, performance-specialist, documentation-specialist, dependency-review-specialist, code-review-orchestrator]
 receives_from: []
 ---

--- a/.claude/agents/code-review-orchestrator.md
+++ b/.claude/agents/code-review-orchestrator.md
@@ -4,7 +4,7 @@ description: "Gate 2.5 — the pre-push self-review. Routes a working-tree diff 
 level: 1
 phase: Cleanup
 tools: Read,Grep,Glob,Task
-model: opus
+model: sonnet
 delegates_to: [test-specialist, implementation-specialist, security-specialist, performance-specialist, documentation-specialist, dependency-review-specialist]
 receives_from: [chief-architect]
 ---
@@ -17,7 +17,7 @@ local checks (Gate 2) pass and before the conductor pushes, you review the diff 
 defects are caught *here* — not in CI (Gate 3) or by the Claude PR reviewer
 (Gate 4). You analyze the change, route each relevant dimension to its specialist
 **in review mode**, then consolidate their findings into one report. Reasoning
-runs on Opus — synthesis and conflict resolution are judgment work.
+runs on Sonnet — review is a well-scoped pass over a bounded diff.
 
 ## Scope
 
@@ -50,8 +50,8 @@ Route only the dimensions the diff actually touches — no redundant reviews.
 1. Read the diff (`git diff` against the merge base) and the architect's risk
    flags.
 2. **Primary path — review the applicable dimensions yourself** against each
-   specialist's checklist (above) and the shared constraints. You run on Opus
-   precisely so a single agent can carry every dimension. **Enhancement:** where
+   specialist's checklist (above) and the shared constraints. A single agent
+   carries every dimension by default. **Enhancement:** where
    the runtime supports nested spawning, you *may* fan out a specialist in review
    mode per dimension (in parallel, read-only) for deeper coverage — but do not
    depend on it; the Ralph conductor spawns sub-agents, and a tick's review must

--- a/.claude/agents/implementation-specialist.md
+++ b/.claude/agents/implementation-specialist.md
@@ -4,7 +4,7 @@ description: "Gate 1 GREEN + Refactor — writes the production code that makes 
 level: 2
 phase: Implementation,Cleanup
 tools: Read,Write,Edit,Grep,Glob
-model: opus
+model: fable
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
 ---
@@ -16,7 +16,7 @@ Level 2 leaf worker who owns **Gate 1 GREEN** and the **Refactor** step: write t
 smallest, cleanest production code that makes the test-specialist's failing tests
 pass while meeting every threshold, then refactor for clarity without breaking
 green. You are the primary lever on "best code possible," so the work runs on
-Opus. You also serve as the **correctness/maintainability reviewer**.
+Fable. You also serve as the **correctness/maintainability reviewer**.
 
 ## Scope
 

--- a/.claude/agents/performance-specialist.md
+++ b/.claude/agents/performance-specialist.md
@@ -4,7 +4,7 @@ description: "Profiles and optimizes performance-sensitive code — O(n²) pairw
 level: 2
 phase: Implementation,Cleanup
 tools: Read,Write,Edit,Grep,Glob
-model: sonnet
+model: fable
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
 ---

--- a/.claude/agents/ralph-worker.md
+++ b/.claude/agents/ralph-worker.md
@@ -4,7 +4,7 @@ description: "One parallel worker of the Ralph fleet. Select to drive a SINGLE a
 level: 1
 phase: Build
 tools: Read,Write,Edit,Grep,Glob,Bash,Task
-model: opus
+model: fable
 delegates_to: [chief-architect, test-specialist, implementation-specialist, security-specialist, performance-specialist, documentation-specialist, dependency-review-specialist, code-review-orchestrator]
 receives_from: []
 ---

--- a/.claude/agents/test-specialist.md
+++ b/.claude/agents/test-specialist.md
@@ -4,7 +4,7 @@ description: "Gate 1 RED — writes the failing tests that specify a behavior be
 level: 2
 phase: Test
 tools: Read,Write,Edit,Grep,Glob
-model: sonnet
+model: fable
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
 ---


### PR DESCRIPTION
## Summary
Applies the new model-tiering rule across the Ralph subagent fleet: **Opus for planning, Sonnet for review, Fable for implementation, Haiku for quick checks.**

| Agent | Before | After |
|---|---|---|
| chief-architect | fable | **opus** |
| code-review-orchestrator | opus | **sonnet** |
| implementation-specialist | opus | **fable** |
| test-specialist | sonnet | **fable** |
| performance-specialist | sonnet | **fable** |
| ralph-worker | opus | **fable** |
| security-specialist | opus | opus (unchanged) |
| documentation-specialist | sonnet | sonnet (unchanged) |
| dependency-review-specialist | haiku | haiku (unchanged) |

Deliberate exceptions to the rule:
- **security-specialist stays on Opus** — Fable's cyber-content safety classifiers can false-positive-refuse legitimate hardening work (documented caveat in the agents README).
- **documentation-specialist stays on Sonnet** — docs writing is a well-scoped pass, not core implementation.

Also updates the fleet diagram and the "Model tiers" rationale section in `.claude/agents/README.md` and the in-body model mentions in the affected agent files so prose matches frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)