### PR TITLE
fix(mcp): confine creek.ingest input_path to the vault root (#819)

### DIFF
--- a/creek-tools/creek_mcp/path_confinement.py
+++ b/creek-tools/creek_mcp/path_confinement.py
@@ -1,0 +1,56 @@
+"""Shared vault-root path confinement for the MCP tool surface.
+
+MCP tools accept an *input_path* string from an untrusted caller. To stop
+the surface from reading or ingesting arbitrary disk content, every tool
+that touches a caller-supplied path routes it through
+:func:`resolve_within_vault`, which confines the path to the vault root.
+
+The confinement contract:
+
+* An absolute path is accepted only if it resolves *inside* the vault.
+* A relative path is joined under the resolved vault root (never the
+  process cwd) before resolution.
+* Resolution collapses ``..`` segments and follows symlinks, so neither a
+  ``..`` traversal nor an in-vault symlink pointing outside can escape.
+* Paths that resolve outside the vault return ``None`` for the caller to
+  turn into a structured refusal.
+
+Existence is intentionally *not* checked here (``resolve(strict=False)``
+semantics) so callers can distinguish an outside-the-vault refusal from a
+not-found refusal with their own, clearer messages.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_within_vault(vault_path: Path, input_path: str) -> Path | None:
+    """Return *input_path* resolved inside *vault_path*, or ``None`` if outside.
+
+    Accepts either an absolute path inside the vault or a vault-relative
+    path. Uses ``Path.resolve(strict=False)`` so non-existent staging
+    directories still validate; existence is checked separately by the
+    caller so it can emit a clean ``not found`` message instead of a
+    silent ``None`` collapse.
+
+    Args:
+        vault_path: Vault root the path must resolve inside of.
+        input_path: Caller-supplied path; absolute or relative to the
+            vault root.
+
+    Returns:
+        The resolved absolute path when it lies inside the vault, or
+        ``None`` when it escapes (after collapsing ``..`` and following
+        symlinks).
+    """
+    vault_resolved = vault_path.resolve()
+    candidate = Path(input_path)
+    if not candidate.is_absolute():
+        candidate = vault_resolved / candidate
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(vault_resolved)
+    except ValueError:
+        return None
+    return resolved

--- a/creek-tools/creek_mcp/tools/ingest.py
+++ b/creek-tools/creek_mcp/tools/ingest.py
@@ -15,6 +15,7 @@ from creek.ingest import INGESTOR_REGISTRY, assemble_ingested_fragment
 from creek.models import PrivacyTier
 from creek.vault.writer import VaultWriter
 from creek_mcp.audit import MCPAuditLog
+from creek_mcp.path_confinement import resolve_within_vault
 from creek_mcp.tier_ceiling import (
     TierCeiling,
     refusal_response,
@@ -39,6 +40,22 @@ def ingest_tool(
     callers with ``ceiling=open`` cannot run an ingest because the
     fragments would exceed the ceiling. The wrapper refuses *before*
     touching the source file so no side effects occur on rejection.
+
+    Args:
+        vault_path: Vault root used for path validation and audit logging.
+        source_type: Registry key selecting the ingestor to run.
+        input_path: Source to ingest; may be absolute or relative to the
+            vault root. The path must resolve *inside* the vault to prevent
+            the MCP surface from ingesting arbitrary disk content. Refusals
+            are checked in order: tier ceiling, unknown ``source_type``,
+            path confinement, then existence.
+        privacy_tier_ceiling: Caller's tier ceiling; the personal-tier
+            default is refused when the ceiling is lower.
+        consumer: Identifier of the calling client (recorded in audit).
+
+    Returns:
+        A dict with ``status`` (``ok`` / ``refused``), the count and ids of
+        written fragments, and any per-fragment errors.
     """
     if not write_tier_allowed(DEFAULT_INGEST_TIER, privacy_tier_ceiling):
         MCPAuditLog(vault_path).append(
@@ -62,8 +79,17 @@ def ingest_tool(
             ceiling=privacy_tier_ceiling,
             reason=f"unknown source_type {source_type!r}",
         )
-    source = Path(input_path)
-    if not source.exists():
+    resolved = resolve_within_vault(vault_path, input_path)
+    if resolved is None:
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason=(
+                f"input_path {input_path!r} resolves outside the vault root; "
+                "the ingest tool only operates on vault-relative paths."
+            ),
+        )
+    if not resolved.exists():
         return refusal_response(
             tool=TOOL_NAME,
             ceiling=privacy_tier_ceiling,
@@ -71,7 +97,7 @@ def ingest_tool(
         )
 
     writer = VaultWriter(vault_path=vault_path)
-    ingest_result = ingestor_cls().ingest(source)
+    ingest_result = ingestor_cls().ingest(resolved)
     written_ids: list[str] = []
     errors: list[str] = list(ingest_result.errors)
     for parsed in ingest_result.fragments:

--- a/creek-tools/creek_mcp/tools/redact.py
+++ b/creek-tools/creek_mcp/tools/redact.py
@@ -18,13 +18,16 @@ Discord attachments staged under ``00-Creek-Meta/Inbound/`` before any
 
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from creek.config import load_config
 from creek.redact.scanner import RedactionMatch, RedactionScanner, ScanSummary
 from creek_mcp.audit import MCPAuditLog
+from creek_mcp.path_confinement import resolve_within_vault
 from creek_mcp.tier_ceiling import TierCeiling, refusal_response
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 TOOL_NAME = "creek.redact.scan"
 
@@ -60,7 +63,7 @@ def redact_scan_tool(
         consumer=consumer,
     )
 
-    resolved = _resolve_within_vault(vault_path, input_path)
+    resolved = resolve_within_vault(vault_path, input_path)
     if resolved is None:
         return refusal_response(
             tool=TOOL_NAME,
@@ -102,27 +105,6 @@ def redact_scan_tool(
         "findings": [_finding_to_dict(m, vault_path) for m in summary.matches],
         "report_markdown": scanner.generate_markdown_summary(summary),
     }
-
-
-def _resolve_within_vault(vault_path: Path, input_path: str) -> Path | None:
-    """Return *input_path* resolved inside *vault_path*, or ``None`` if outside.
-
-    Accepts either an absolute path inside the vault or a vault-relative
-    path. Uses ``Path.resolve(strict=False)`` so non-existent staging
-    directories still validate (existence is checked separately so the
-    caller gets a clean ``input_path not found`` message instead of a
-    silent ``None`` collapse).
-    """
-    vault_resolved = vault_path.resolve()
-    candidate = Path(input_path)
-    if not candidate.is_absolute():
-        candidate = vault_resolved / candidate
-    resolved = candidate.resolve()
-    try:
-        resolved.relative_to(vault_resolved)
-    except ValueError:
-        return None
-    return resolved
 
 
 def _finding_to_dict(match: RedactionMatch, vault_path: Path) -> dict[str, Any]:

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -9,6 +9,7 @@ tier-ceiling enforcement helper, and the audit-log write-side fields
 from __future__ import annotations
 
 import json
+import os
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -348,6 +349,165 @@ def test_ingest_writes_fragments_and_audit(
     assert last["affected_fragment_ids"] == ["frag-stub-1"]
     # Ensure the unused IngestedFragment alias does not cause import warnings.
     assert stub_fragment is not None
+
+
+# ---------------------------------------------------------------------------
+# ingest — vault path confinement (issue #819)
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_refuses_absolute_path_outside_vault(vault: Path) -> None:
+    """An absolute ``input_path`` resolving outside the vault root is refused."""
+    outside = vault.parent / "outside.md"
+    outside.write_text("# outside\n", encoding="utf-8")
+    result = ingest_tool(
+        vault_path=vault,
+        source_type="markdown",
+        input_path=str(outside),
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "refused"
+    assert "outside the vault root" in result["reason"]
+    assert not any((vault / "01-Fragments").rglob("*.md"))
+
+
+def test_ingest_refuses_dot_dot_traversal_outside_vault(vault: Path) -> None:
+    """A ``..``-relative ``input_path`` that escapes the vault is refused.
+
+    Proves the confinement check resolves the path (collapsing ``..``)
+    before comparing it against the vault root.
+    """
+    outside = vault.parent / "escape.md"
+    outside.write_text("# escape\n", encoding="utf-8")
+    result = ingest_tool(
+        vault_path=vault,
+        source_type="markdown",
+        input_path=str(vault / ".." / "escape.md"),
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "refused"
+    assert "outside the vault root" in result["reason"]
+    assert not any((vault / "01-Fragments").rglob("*.md"))
+
+
+def test_ingest_refuses_symlink_escaping_vault(vault: Path) -> None:
+    """A symlink inside the vault pointing outside it is refused.
+
+    Proves the confinement check follows symlinks (via ``resolve()``)
+    rather than trusting the in-vault-looking literal path.
+    """
+    outside = vault.parent / "secret.md"
+    outside.write_text("# secret\n", encoding="utf-8")
+    link = vault / "link-to-secret.md"
+    os.symlink(outside, link)
+    result = ingest_tool(
+        vault_path=vault,
+        source_type="markdown",
+        input_path=str(link),
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "refused"
+    assert "outside the vault root" in result["reason"]
+    assert not any((vault / "01-Fragments").rglob("*.md"))
+
+
+def test_ingest_confinement_refusal_skips_ingestor_invocation(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Confinement is checked before any ingestor touches the source file."""
+
+    class _RaisingIngestor:
+        def ingest(self, _input: object) -> object:
+            raise AssertionError("should not be reached")
+
+    monkeypatch.setattr(
+        "creek_mcp.tools.ingest.INGESTOR_REGISTRY",
+        {"markdown": _RaisingIngestor},
+    )
+    outside = vault.parent / "untouched.md"
+    outside.write_text("# untouched\n", encoding="utf-8")
+
+    result = ingest_tool(
+        vault_path=vault,
+        source_type="markdown",
+        input_path=str(outside),
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "refused"
+    assert "outside the vault root" in result["reason"]
+
+
+def test_ingest_relative_input_path_resolves_against_vault(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A relative ``input_path`` is resolved against the vault root, not cwd."""
+
+    class _StubResult:
+        def __init__(self) -> None:
+            self.fragments: list[object] = ["stub-parsed"]
+            self.errors: list[str] = []
+
+    class _StubIngestor:
+        def ingest(self, _input: object) -> object:
+            return _StubResult()
+
+    def _stub_assemble(_parsed: object) -> object:
+        return type(
+            "_A",
+            (),
+            {
+                "fragment": type("_F", (), {"id": "frag-stub-rel"})(),
+                "body": "stub body",
+            },
+        )()
+
+    class _StubWriter:
+        def __init__(self, *, vault_path: object) -> None:
+            self.vault_path = vault_path
+
+        def write_fragment(self, fragment: object, *, body: str) -> None:
+            del fragment, body
+
+    monkeypatch.setattr(
+        "creek_mcp.tools.ingest.INGESTOR_REGISTRY",
+        {"markdown": _StubIngestor},
+    )
+    monkeypatch.setattr(
+        "creek_mcp.tools.ingest.assemble_ingested_fragment",
+        _stub_assemble,
+    )
+    monkeypatch.setattr("creek_mcp.tools.ingest.VaultWriter", _StubWriter)
+
+    (vault / "input.md").write_text("# stub\n", encoding="utf-8")
+    result = ingest_tool(
+        vault_path=vault,
+        source_type="markdown",
+        input_path="input.md",
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "ok"
+    assert result["written"] == 1
+
+
+def test_ingest_tier_ceiling_checked_before_confinement(vault: Path) -> None:
+    """The tier-ceiling gate refuses before the confinement check runs.
+
+    ``ceiling=open`` against the personal-tier default must fail on
+    ``"exceeds ceiling"`` even for an outside-the-vault path, proving
+    the ceiling gate still fires first.
+    """
+    outside = vault.parent / "outside-ceiling.md"
+    outside.write_text("# outside\n", encoding="utf-8")
+    result = ingest_tool(
+        vault_path=vault,
+        source_type="markdown",
+        input_path=str(outside),
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "refused"
+    assert "exceeds ceiling" in result["reason"]
 
 
 # ---------------------------------------------------------------------------

--- a/creek-tools/tests/test_path_confinement.py
+++ b/creek-tools/tests/test_path_confinement.py
@@ -1,0 +1,64 @@
+"""Unit tests for the shared vault-root path-confinement helper (issue #819).
+
+``resolve_within_vault`` is the single source of truth guarding every MCP
+tool that accepts a caller-supplied ``input_path`` (``creek.ingest``,
+``creek.redact.scan``). These focused tests exercise the function directly
+so a regression localizes here instead of surfacing only through a tool
+wrapper's integration test.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from creek_mcp.path_confinement import resolve_within_vault
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_absolute_path_inside_vault_is_accepted(tmp_path: Path) -> None:
+    """An absolute path under the vault resolves to that same canonical path."""
+    target = tmp_path / "staging" / "note.md"
+    resolved = resolve_within_vault(tmp_path, str(target))
+    assert resolved == target.resolve()
+
+
+def test_relative_path_binds_to_vault_not_cwd(tmp_path: Path) -> None:
+    """A relative path is joined under the vault root, never the process cwd."""
+    resolved = resolve_within_vault(tmp_path, "staging/note.md")
+    assert resolved == (tmp_path / "staging" / "note.md").resolve()
+
+
+def test_vault_root_itself_is_accepted(tmp_path: Path) -> None:
+    """The vault root resolves to itself and is inside the vault."""
+    assert resolve_within_vault(tmp_path, str(tmp_path)) == tmp_path.resolve()
+
+
+def test_absolute_path_outside_vault_is_rejected(tmp_path: Path) -> None:
+    """An absolute path outside the vault returns ``None``."""
+    assert resolve_within_vault(tmp_path, str(tmp_path.parent / "outside.md")) is None
+
+
+def test_dot_dot_traversal_is_rejected(tmp_path: Path) -> None:
+    """A ``..`` sequence that escapes the vault is collapsed then rejected."""
+    assert resolve_within_vault(tmp_path, str(tmp_path / ".." / "escape.md")) is None
+
+
+def test_symlink_escaping_vault_is_rejected(tmp_path: Path) -> None:
+    """A symlink inside the vault pointing outside it is followed then rejected."""
+    outside = tmp_path.parent / "secret.md"
+    outside.write_text("# secret\n", encoding="utf-8")
+    link = tmp_path / "link-to-secret.md"
+    os.symlink(outside, link)
+    assert resolve_within_vault(tmp_path, str(link)) is None
+
+
+def test_symlink_staying_inside_vault_is_accepted(tmp_path: Path) -> None:
+    """A symlink whose target is inside the vault resolves to that target."""
+    inside = tmp_path / "real.md"
+    inside.write_text("# real\n", encoding="utf-8")
+    link = tmp_path / "link-to-real.md"
+    os.symlink(inside, link)
+    assert resolve_within_vault(tmp_path, str(link)) == inside.resolve()


### PR DESCRIPTION
## Summary
- Close an arbitrary-host-file-read vector: `creek.ingest` built `Path(input_path)` from the raw client string and handed it to the ingestor, so a remote MCP consumer could read any host file into the vault (the tier-ceiling check was the only gate).
- Route `input_path` through a new shared `creek_mcp/path_confinement.py:resolve_within_vault` helper — resolves the path (collapsing `..`, following symlinks) and refuses anything outside the vault root. The check runs after the tier-ceiling and unknown-`source_type` gates and before existence; the *resolved* path (not the raw string) is what gets existence-checked and ingested, so there is no re-derivation/TOCTOU gap.
- Extract that confinement logic as the single source of truth and refactor `creek.redact.scan` to import it (deleting its private duplicate) so the two consumers can never drift.

## Test plan
- New `tests/test_path_confinement.py` — dedicated unit tests for the SSOT helper: in-vault absolute/relative/vault-root accepted; absolute-outside, `..`-traversal, and escaping-symlink rejected; in-vault symlink accepted.
- New confinement tests in `tests/test_mcp_write_tools.py` — `creek.ingest` refuses absolute-outside / `..`-traversal / escaping-symlink paths, does not invoke the ingestor on a confinement refusal, treats a relative `input_path` as vault-relative, and still checks the tier-ceiling gate first.
- `cd creek-tools && ./scripts/check-all.sh` green except the pre-existing `pip-audit` failure (transitive CVEs in pillow/pyasn1/setuptools/soupsieve/torch, red on all branches, tracked in #861 — unrelated; this change touches no dependencies).

## Security follow-ups (deliberately out of scope, to keep this fix minimal)
- Audit the confinement-refusal branch specifically (an out-of-vault `input_path` is an attempted arbitrary-file-read probe worth logging for forensics), while leaving not-found / unknown-source silent.
- Pre-existing (not introduced here): `redact_scan_tool`'s ok-path calls `resolved.relative_to(vault_path)` against the *unresolved* `vault_path`; if a caller ever passes an unresolved vault root this raises rather than returning a structured response (fails closed). Worth a tracking ticket.

Closes #819