### PR TITLE
fix(security): bump soupsieve 2.8.3 -> 2.9.1 to clear CVE-2026-49476/-49477

### DIFF
--- a/creek-tools/uv.lock
+++ b/creek-tools/uv.lock
@@ -3424,11 +3424,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.9.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/38/e12680bbe6b4f8f3d17adcaf38d26850aa756c85cf4a80e79fc12a018fe8/soupsieve-2.9.1.tar.gz", hash = "sha256:c33e6605bbc71dd628b00c632d58ae607c22bade247e52553928f83bbb75b4ba", size = 122261, upload-time = "2026-07-21T16:57:17.452Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/2c/437fe806897c2d6cfdc3ee43a18da8bf8e568530a4ae9bac781541ca9896/soupsieve-2.9.1-py3-none-any.whl", hash = "sha256:4f4477399246b7a0c720a88ca2454b11cd6bb9ae4c9d170140786e916776c14c", size = 37404, upload-time = "2026-07-21T16:57:16.421Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Relocks the transitive `soupsieve` pin in `creek-tools/uv.lock` from 2.8.3 to 2.9.1 via `uv lock --upgrade-package soupsieve`, clearing both advisories tracked in #836:
  - PYSEC-2026-3071 / CVE-2026-49476 — unbounded memory compiling large comma-separated selector lists
  - PYSEC-2026-3072 / CVE-2026-49477 — ReDoS (catastrophic backtracking) in attribute-selector parsing
- Both are fixed in 2.8.4; 2.9.1 is the latest published PyPI release (verified live via `pip index versions soupsieve`), so the relock takes the current release rather than the minimal fix.
- No code changes needed: `soupsieve` is transitive-only (`markdownify` -> `beautifulsoup4` -> `soupsieve`), there is no `pyproject.toml` constraint on it, and no first-party code imports `bs4`/`soupsieve` or calls `.select()`/`.select_one()` — per the reachability correction on the issue, the DoS paths were never reachable here; the actionable driver is that pip-audit fails the security gate.
- `crawdad/uv.lock` does not pin `soupsieve` (no bs4/markdownify there), so no change is needed in crawdad.

## Test plan
- [x] `pip-audit` (repo invocation, `--ignore-vuln PYSEC-2022-42969`): **no soupsieve advisories remain** — PYSEC-2026-3071 and PYSEC-2026-3072 are gone from the report.
- [x] `./scripts/check-all.sh`: 11/12 checks pass; all 5977 unit tests pass, coverage 93.85%, per-file gate green.
- [x] Note for the merge gate: the single failing check is the pip-audit security scan, and it fails **only** on unrelated packages — pillow, mcp, httplib2, setuptools, torch, pyasn1 — whose advisories pre-exist on `main` and are tracked in sibling `[scan:security]` issues. They are expected to remain and are NOT in scope for this PR; this PR strictly reduces the advisory set (soupsieve cleared, nothing added).
- [x] Gate 2.5 self-review (code-review-orchestrator + dependency-review-specialist): CLEAN — lockfile entry internally consistent (version/sdist/wheel hashes all 2.9.1), sole depender `beautifulsoup4 4.14.3` has no upper bound, no collateral package churn, no stale 2.8.3 references.

Closes #836

🤖 Generated with [Claude Code](https://claude.com/claude-code)