### PR TITLE
fix(deps): bump httplib2 0.31.2 -> 0.32.0 for CVE-2026-59939

### DIFF
--- a/creek-tools/uv.lock
+++ b/creek-tools/uv.lock
@@ -1096,14 +1096,14 @@ wheels = [
 
 [[package]]
 name = "httplib2"
-version = "0.31.2"
+version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyparsing" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/f5/ccf58de92d61e3ad921119668f54ed36ca1d0cf5dcc5c1657dfb164fd78b/httplib2-0.32.0.tar.gz", hash = "sha256:48a0ef30a42db65d8f3399045e1d09ab0ba66e3b9efc360d07f80ea55d286025", size = 254283, upload-time = "2026-06-26T10:13:56.265Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
+    { url = "https://files.pythonhosted.org/packages/33/a0/550eec327e5f5c7b732531c489f5307efec41f047b0d703bd4ca1e5ad2db/httplib2-0.32.0-py3-none-any.whl", hash = "sha256:dc6705cacdf3fb0a2aba7629fa33c90fd93e30035db0c157325826be177e4816", size = 93148, upload-time = "2026-06-26T10:13:54.985Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Relocks `httplib2` from 0.31.2 to 0.32.0 in `creek-tools/uv.lock` to remediate **CVE-2026-59939** / **PYSEC-2026-3444** (GHSA-j5g9-f88f-gfj3): unbounded decompression of `Content-Encoding: gzip`/`deflate` response bodies leading to OOM, reachable via the gdrive ingestion stack (`google-api-python-client` -> `google-auth-httplib2` -> `httplib2`).
- Transitive-only dependency: no `pyproject.toml` constraint exists (correctly left unpinned), and `crawdad/` does not depend on httplib2. The diff is the 6-line lock entry only (`uv lock --upgrade-package httplib2`).
- 0.32.0 is the latest release on PyPI and the advisory fix version for **both** httplib2 advisories (PYSEC-2026-3444 is the PYSEC alias of CVE-2026-59939, per issue #861's audit) — verified post-bump that **pip-audit reports ZERO httplib2 advisories**.

## Test plan
- `uv lock --upgrade-package httplib2` + `uv sync --all-extras` — clean, minimal diff.
- `pip-audit` after the bump: **no httplib2 findings**. Remaining findings (mcp 1.27.1, pyasn1 0.6.3, setuptools 81.0.0, torch 2.12.1) are pre-existing on `main` and tracked by sibling scan issues — explicitly out of scope for this PR.
- gdrive ingestion tests: 166 passed.
- `./scripts/check-all.sh`: 5977 tests passed, coverage 93.85%, all checks green except the security step, which fails only on the pre-existing sibling-tracked advisories above (zero httplib2).
- Gate 2.5 dependency review: CLEAN (hashes well-formed, no stale 0.31.2 refs, httplib2 dep list unchanged, consumers untouched).

Closes #844

🤖 Generated with [Claude Code](https://claude.com/claude-code)