### PR TITLE
fix(security): bump mcp 1.27.1 -> 1.28.1 to clear CVE-2026-52869/-52870/-59950

### DIFF
--- a/crawdad/pyproject.toml
+++ b/crawdad/pyproject.toml
@@ -12,7 +12,9 @@ authors = [
 ]
 dependencies = [
     "discord.py>=2.3.0",
-    "mcp>=1.0.0,<2.0.0",
+    # Security: pin mcp above CVE-2026-52869 (cross-principal session
+    # injection on Streamable HTTP bearer transport). Fixed in 1.28.1.
+    "mcp>=1.28.1,<2.0.0",
     "anthropic>=0.40.0",
     "openai>=1.0",
     "google-genai>=1.0",

--- a/crawdad/tests/test_dependency_pins.py
+++ b/crawdad/tests/test_dependency_pins.py
@@ -1,0 +1,114 @@
+"""Guard tests for the ``mcp`` dependency pin (issue #862).
+
+mcp 1.27.1 carries CVE-2026-52869 — cross-principal session injection on
+the Streamable HTTP bearer-token transport (reachable on the shared
+dependency: ``creek_mcp``, whose surface this bot consumes, runs
+streamable-http with a ``TokenVerifier``). The same release also carries
+CVE-2026-52870 and CVE-2026-59950. All three are fixed in mcp 1.28.1.
+
+Two independent guards:
+
+* **pyproject floor** — the ``mcp`` specifier in ``[project].dependencies``
+  must reject anything below 1.28.1 so a future relock cannot resolve
+  back down to a vulnerable release, while keeping the ``<2.0.0``
+  ceiling intact.
+* **locked version** — ``uv.lock`` is what CI installs and what
+  pip-audit actually inspects, so the resolved ``mcp`` entry must
+  already be at or above the patched version.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.version import Version
+
+_PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+_PYPROJECT = _PACKAGE_ROOT / "pyproject.toml"
+_UV_LOCK = _PACKAGE_ROOT / "uv.lock"
+
+#: First mcp release containing the fixes for CVE-2026-52869,
+#: CVE-2026-52870, and CVE-2026-59950.
+_PATCHED_VERSION = Version("1.28.1")
+
+
+def _mcp_specifier() -> SpecifierSet:
+    """Return the ``mcp`` specifier set from ``[project].dependencies``."""
+    with _PYPROJECT.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+    dependencies: list[str] = pyproject["project"]["dependencies"]
+    for entry in dependencies:
+        requirement = Requirement(entry)
+        if requirement.name == "mcp":
+            return requirement.specifier
+    pytest.fail("mcp is not declared in [project].dependencies of pyproject.toml")
+
+
+def _locked_mcp_version() -> Version:
+    """Return the resolved ``mcp`` version pinned in ``uv.lock``."""
+    with _UV_LOCK.open("rb") as handle:
+        lock = tomllib.load(handle)
+    packages: list[dict[str, object]] = lock["package"]
+    for package in packages:
+        if package["name"] == "mcp":
+            return Version(str(package["version"]))
+    pytest.fail("mcp has no [[package]] entry in uv.lock")
+
+
+def test_mcp_floor_rejects_last_vulnerable_range() -> None:
+    """The pyproject floor excludes 1.28.0 (and everything below it).
+
+    A ``>=1.0.0`` floor would let a relock resolve to 1.27.1, which is
+    vulnerable to CVE-2026-52869 / CVE-2026-52870 / CVE-2026-59950. The
+    specifier must genuinely be ``>=1.28.1``.
+    """
+    specifier = _mcp_specifier()
+    assert "1.28.0" not in specifier, (
+        f"mcp specifier {specifier!r} admits 1.28.0; the floor must be "
+        ">=1.28.1 so relocks cannot resolve below the CVE-patched release"
+    )
+    assert "1.27.1" not in specifier, (
+        f"mcp specifier {specifier!r} admits 1.27.1, the release carrying "
+        "CVE-2026-52869 / CVE-2026-52870 / CVE-2026-59950"
+    )
+
+
+def test_mcp_ceiling_rejects_next_major() -> None:
+    """The ``<2.0.0`` ceiling survives the floor bump.
+
+    Raising the floor must not silently drop the major-version ceiling
+    that shields us from mcp 2.x breaking changes.
+    """
+    specifier = _mcp_specifier()
+    assert "2.0.0" not in specifier, (
+        f"mcp specifier {specifier!r} admits 2.0.0; the <2.0.0 ceiling "
+        "must remain in place"
+    )
+
+
+def test_mcp_floor_accepts_patched_release() -> None:
+    """The specifier accepts 1.28.1, the first CVE-patched release."""
+    specifier = _mcp_specifier()
+    assert "1.28.1" in specifier, (
+        f"mcp specifier {specifier!r} rejects 1.28.1; the patched release "
+        "itself must satisfy the pin"
+    )
+
+
+def test_locked_mcp_at_or_above_patched_release() -> None:
+    """``uv.lock`` resolves mcp to >= 1.28.1.
+
+    The lockfile is what CI installs and what pip-audit inspects; a
+    correct pyproject floor with a stale lock still ships the
+    vulnerable 1.27.1.
+    """
+    locked = _locked_mcp_version()
+    assert locked >= _PATCHED_VERSION, (
+        f"uv.lock pins mcp {locked}, below the CVE-patched "
+        f"{_PATCHED_VERSION} (CVE-2026-52869 / CVE-2026-52870 / "
+        "CVE-2026-59950); run a relock after raising the pyproject floor"
+    )

--- a/crawdad/uv.lock
+++ b/crawdad/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.13' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
     "python_full_version < '3.13'",
 ]
 
@@ -623,7 +626,7 @@ requires-dist = [
     { name = "filetype", specifier = ">=1.2.0" },
     { name = "google-genai", specifier = ">=1.0" },
     { name = "interrogate", marker = "extra == 'dev'", specifier = ">=1.7.0" },
-    { name = "mcp", specifier = ">=1.0.0,<2.0.0" },
+    { name = "mcp", specifier = ">=1.28.1,<2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "openai", specifier = ">=1.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -1178,7 +1181,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1196,9 +1199,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -20,7 +20,10 @@ dependencies = [
     "chardet>=7.4.3",
     "httpx>=0.27.0",
     "tqdm>=4.66.0",
-    "mcp>=1.0.0,<2.0.0",
+    # Security: pin mcp above CVE-2026-52869 (cross-principal session
+    # injection on Streamable HTTP bearer transport — reachable via
+    # creek_mcp), CVE-2026-52870, CVE-2026-59950. All fixed in 1.28.1.
+    "mcp>=1.28.1,<2.0.0",
     # At-rest volume key (creek.confidential): Argon2id / AES-GCM / HKDF are
     # imported unconditionally, so cryptography is a direct base dependency —
     # not left to transitive resolution via mcp -> pyjwt[crypto] (#758).

--- a/creek-tools/tests/test_dependency_pins.py
+++ b/creek-tools/tests/test_dependency_pins.py
@@ -1,0 +1,117 @@
+"""Guard tests for the ``mcp`` dependency pin (issue #862).
+
+mcp 1.27.1 carries CVE-2026-52869 — cross-principal session injection on
+the Streamable HTTP bearer-token transport. That transport is reachable
+here: ``creek_mcp`` runs streamable-http with a ``TokenVerifier``. The
+same release also carries CVE-2026-52870 and CVE-2026-59950. All three
+are fixed in mcp 1.28.1.
+
+Two independent guards:
+
+* **pyproject floor** — the ``mcp`` specifier in ``[project].dependencies``
+  must reject anything below 1.28.1 so a future ``uv lock`` relock cannot
+  resolve back down to a vulnerable release, while keeping the ``<2.0.0``
+  ceiling intact.
+* **locked version** — ``uv.lock`` is what CI installs and what pip-audit
+  actually inspects, so the resolved ``mcp`` entry must already be at or
+  above the patched version.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+from packaging.requirements import Requirement
+from packaging.version import Version
+
+if TYPE_CHECKING:
+    from packaging.specifiers import SpecifierSet
+
+_PACKAGE_ROOT = Path(__file__).resolve().parents[1]
+_PYPROJECT = _PACKAGE_ROOT / "pyproject.toml"
+_UV_LOCK = _PACKAGE_ROOT / "uv.lock"
+
+#: First mcp release containing the fixes for CVE-2026-52869,
+#: CVE-2026-52870, and CVE-2026-59950.
+_PATCHED_VERSION = Version("1.28.1")
+
+
+def _mcp_specifier() -> SpecifierSet:
+    """Return the ``mcp`` specifier set from ``[project].dependencies``."""
+    with _PYPROJECT.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+    dependencies: list[str] = pyproject["project"]["dependencies"]
+    for entry in dependencies:
+        requirement = Requirement(entry)
+        if requirement.name == "mcp":
+            return requirement.specifier
+    pytest.fail("mcp is not declared in [project].dependencies of pyproject.toml")
+
+
+def _locked_mcp_version() -> Version:
+    """Return the resolved ``mcp`` version pinned in ``uv.lock``."""
+    with _UV_LOCK.open("rb") as handle:
+        lock = tomllib.load(handle)
+    packages: list[dict[str, object]] = lock["package"]
+    for package in packages:
+        if package["name"] == "mcp":
+            return Version(str(package["version"]))
+    pytest.fail("mcp has no [[package]] entry in uv.lock")
+
+
+def test_mcp_floor_rejects_last_vulnerable_range() -> None:
+    """The pyproject floor excludes 1.28.0 (and everything below it).
+
+    A ``>=1.0.0`` floor would let a relock resolve to 1.27.1, which is
+    vulnerable to CVE-2026-52869 / CVE-2026-52870 / CVE-2026-59950. The
+    specifier must genuinely be ``>=1.28.1``.
+    """
+    specifier = _mcp_specifier()
+    assert "1.28.0" not in specifier, (
+        f"mcp specifier {specifier!r} admits 1.28.0; the floor must be "
+        ">=1.28.1 so relocks cannot resolve below the CVE-patched release"
+    )
+    assert "1.27.1" not in specifier, (
+        f"mcp specifier {specifier!r} admits 1.27.1, the release carrying "
+        "CVE-2026-52869 / CVE-2026-52870 / CVE-2026-59950"
+    )
+
+
+def test_mcp_ceiling_rejects_next_major() -> None:
+    """The ``<2.0.0`` ceiling survives the floor bump.
+
+    Raising the floor must not silently drop the major-version ceiling
+    that shields us from mcp 2.x breaking changes.
+    """
+    specifier = _mcp_specifier()
+    assert "2.0.0" not in specifier, (
+        f"mcp specifier {specifier!r} admits 2.0.0; the <2.0.0 ceiling "
+        "must remain in place"
+    )
+
+
+def test_mcp_floor_accepts_patched_release() -> None:
+    """The specifier accepts 1.28.1, the first CVE-patched release."""
+    specifier = _mcp_specifier()
+    assert "1.28.1" in specifier, (
+        f"mcp specifier {specifier!r} rejects 1.28.1; the patched release "
+        "itself must satisfy the pin"
+    )
+
+
+def test_locked_mcp_at_or_above_patched_release() -> None:
+    """``uv.lock`` resolves mcp to >= 1.28.1.
+
+    The lockfile is what CI installs and what pip-audit inspects; a
+    correct pyproject floor with a stale lock still ships the
+    vulnerable 1.27.1.
+    """
+    locked = _locked_mcp_version()
+    assert locked >= _PATCHED_VERSION, (
+        f"uv.lock pins mcp {locked}, below the CVE-patched "
+        f"{_PATCHED_VERSION} (CVE-2026-52869 / CVE-2026-52870 / "
+        "CVE-2026-59950); run a relock after raising the pyproject floor"
+    )

--- a/creek-tools/uv.lock
+++ b/creek-tools/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version >= '3.13' and python_full_version < '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'win32'",
     "python_full_version == '3.12.*'",
     "python_full_version < '3.12'",
 ]
@@ -654,7 +657,7 @@ requires-dist = [
     { name = "interrogate", marker = "extra == 'dev'", specifier = ">=1.7.0" },
     { name = "lxml-stubs", marker = "extra == 'dev'", specifier = ">=0.5.1" },
     { name = "markdownify", marker = "extra == 'documents'", specifier = ">=1.2.2" },
-    { name = "mcp", specifier = ">=1.0.0,<2.0.0" },
+    { name = "mcp", specifier = ">=1.28.1,<2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.1.0,<2.2.0" },
     { name = "numpy", marker = "extra == 'embeddings'", specifier = ">=2.4.4" },
     { name = "openai", marker = "extra == 'openai'", specifier = ">=1.0" },
@@ -758,7 +761,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/a9/3a8241c6e19483ac1f1dcf5c10238205dcb8a6e9d0d4d4709240dff28ff4/cuda_bindings-13.2.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:721104c603f059780d287969be3d194a18d0cc3b713ed9049065a1107706759d", size = 5730273, upload-time = "2026-03-11T00:12:37.18Z" },
@@ -791,34 +794,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version < '3.13' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft", marker = "(python_full_version < '3.13' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version < '3.13' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand", marker = "(python_full_version < '3.13' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver", marker = "(python_full_version < '3.13' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse", marker = "(python_full_version < '3.13' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "(python_full_version < '3.13' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version < '3.13' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx", marker = "(python_full_version < '3.13' and sys_platform == 'win32') or (python_full_version >= '3.15' and sys_platform == 'win32') or sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1670,7 +1673,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.1"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1688,9 +1691,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/83/d1efe7c2980d8a3afa476f4e3d42d53dd54c0ab94c27bee5d755b45c8b73/mcp-1.27.1.tar.gz", hash = "sha256:0f47e1820f8f8f941466b39749eb1d1839a04caddca2bc60e9d46e8a99914924", size = 608458, upload-time = "2026-05-08T16:50:12.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/73/42d9596facebdb533b7f0b86c1b0364ef350d1f8ba78b1052e8a58b48b65/mcp-1.27.1-py3-none-any.whl", hash = "sha256:1af3c4203b329430fde7a87b4fcb6392a041f5cb851fd68fc674016ab4e7c06f", size = 216260, upload-time = "2026-05-08T16:50:10.547Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -1936,7 +1939,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -1975,7 +1978,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -1987,7 +1990,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2017,9 +2020,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2031,7 +2034,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "python_full_version < '3.13' or python_full_version >= '3.15' or sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },


### PR DESCRIPTION
## Summary

Bump the `mcp` SDK from the locked `1.27.1` to `1.28.1` (latest stable on PyPI; 2.x are pre-releases) in **both** subprojects that depend on it, clearing all three pip-audit advisories carried by 1.27.1:

| ID | Alias | Fixed in | Reachable here? |
|----|-------|----------|-----------------|
| CVE-2026-52869 | GHSA-jpw9-pfvf-9f58 | 1.27.2 | **Yes** — cross-principal session injection on the Streamable HTTP bearer-token transport; `creek_mcp` runs `transport="streamable-http"` with `TokenVerifier` auth (`creek_mcp/server.py`, `creek_mcp/remote_auth.py`) |
| CVE-2026-52870 | GHSA-hvrp-rf83-w775 | 1.27.2 | No — requires the experimental tasks API (not called anywhere) |
| CVE-2026-59950 | GHSA-vj7q-gjh5-988w | 1.28.1 | No — requires the deprecated WebSocket server transport (not used) |

Changes:
- `creek-tools/pyproject.toml` + `crawdad/pyproject.toml`: raise the floor `mcp>=1.0.0,<2.0.0` → `mcp>=1.28.1,<2.0.0` with an inline security comment (mirrors the existing urllib3/idna CVE-pin convention), so future relocks cannot resolve back below the patched release.
- `creek-tools/uv.lock` + `crawdad/uv.lock`: regenerated via `uv lock` — `mcp 1.27.1 → 1.28.1` is the only package version change; the remaining lock churn is uv resolution-marker re-normalization on the torch/nvidia fork.
- New guard tests `creek-tools/tests/test_dependency_pins.py` + `crawdad/tests/test_dependency_pins.py` (TDD RED-first): assert the pyproject specifier rejects 1.27.1/1.28.0 and 2.0.0 while accepting 1.28.1, and that the resolved `uv.lock` entry is >= 1.28.1 (the lock is what CI installs and what pip-audit inspects).

Changelog review 1.27.1 → 1.28.1: 1.27.2 binds transport sessions to the authenticated principal (the CVE fix) and adds `subject`/`claims` to `AccessToken`; 1.28.0 only deprecates the WebSocket transport and experimental tasks API (neither used by `creek_mcp` or CrawDad, and warnings fire only on call — no `filterwarnings = ["error"]` configured); 1.28.1 buffers per-request StreamableHTTP streams. No breaking changes to the APIs used (`FastMCP`, `get_access_token`, `TokenVerifier`/`AuthSettings`, `ClientSession`/stdio client).

## Test plan

- [x] Guard tests written first and verified RED on 1.27.1 in both packages (floor + lock assertions failed for the right reason), GREEN after the bump + relock.
- [x] **pip-audit advisory verification (the issue's acceptance gate): after the bump, `cd creek-tools && ./scripts/security.sh` reports ZERO `mcp` advisories.** The remaining findings (pyasn1 0.6.3, setuptools 81.0.0, torch 2.12.1) are pre-existing on `main` and tracked by sibling `[scan:security]` issues — they are unchanged by this diff.
- [x] SDK behavior regression check against a pre-bump baseline: all 224 creek-tools `tests/test_mcp_*.py` tests pass identically pre- and post-bump; crawdad's 16 `test_mcp_client.py` tests pass.
- [x] `cd crawdad && ./scripts/check-all.sh` — all checks pass (504 tests, 94.57% branch coverage).
- [x] `cd creek-tools && ./scripts/check-all.sh` — 11/12 checks pass (5,981 tests, 93.85% branch coverage, per-file gate, mypy strict, ruff, complexity, docstrings). The single failing step is the Security check, whose pip-audit output now contains only the pre-existing sibling-tracked pyasn1/setuptools/torch findings — zero `mcp` lines. That failure is present on `main` today (the issue's own evidence at `38e450a` lists the same findings) and is out of this issue's scope by design.
- [x] Gate 2.5 self-review (security + dependency + test dimensions): lock hashes are genuine `uv lock` output, no suppressions (`--ignore-vuln`/`noqa`) introduced, floor/ceiling correct; the one blocker found (TC002 annotation-only import) fixed.

Closes #862
