### PR TITLE
fix(security): floor pyasn1 at 0.6.4 to clear CVE-2026-59885/-59886

### DIFF
--- a/crawdad/pyproject.toml
+++ b/crawdad/pyproject.toml
@@ -54,6 +54,19 @@ dev = [
 requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.uv]
+# constraint-dependencies floor transitive packages that pip-audit
+# flagged (DEP-003). A constraint tightens resolution *if* the package
+# is in the graph without adding it as a direct dependency, so a future
+# `uv lock` cannot silently regress onto a vulnerable version.
+constraint-dependencies = [
+    # Security: pin pyasn1 above CVE-2026-59885 (quadratic OID-arc
+    # decode DoS) and CVE-2026-59886 (REAL-exponent big-int DoS) —
+    # transitive via google-genai → google-auth → pyasn1-modules.
+    # Both fixed in 0.6.4 (#867).
+    "pyasn1>=0.6.4",
+]
+
 [tool.setuptools.packages.find]
 include = ["crawdad", "crawdad.*"]
 

--- a/crawdad/tests/test_dependency_pins.py
+++ b/crawdad/tests/test_dependency_pins.py
@@ -1,20 +1,37 @@
-"""Guard tests for the ``mcp`` dependency pin (issue #862).
+"""Guard tests for security-motivated dependency pins.
 
-mcp 1.27.1 carries CVE-2026-52869 — cross-principal session injection on
-the Streamable HTTP bearer-token transport (reachable on the shared
-dependency: ``creek_mcp``, whose surface this bot consumes, runs
-streamable-http with a ``TokenVerifier``). The same release also carries
-CVE-2026-52870 and CVE-2026-59950. All three are fixed in mcp 1.28.1.
+Each pin here answers specific CVEs; the tests guard both the declared
+floor and the resolved lock so a future relock cannot regress onto a
+vulnerable release.
 
-Two independent guards:
+``mcp`` (issue #862): mcp 1.27.1 carries CVE-2026-52869 —
+cross-principal session injection on the Streamable HTTP bearer-token
+transport (reachable on the shared dependency: ``creek_mcp``, whose
+surface this bot consumes, runs streamable-http with a
+``TokenVerifier``). The same release also carries CVE-2026-52870 and
+CVE-2026-59950. All three are fixed in mcp 1.28.1. mcp is a direct
+dependency, so its floor lives in ``[project].dependencies`` (with the
+``<2.0.0`` ceiling intact).
 
-* **pyproject floor** — the ``mcp`` specifier in ``[project].dependencies``
-  must reject anything below 1.28.1 so a future relock cannot resolve
-  back down to a vulnerable release, while keeping the ``<2.0.0``
-  ceiling intact.
+``pyasn1`` (issue #867): pyasn1 0.6.3 carries CVE-2026-59885
+(quadratic-time OID-arc decoding — a DoS on hostile BER/DER input) and
+CVE-2026-59886 (unbounded big-int construction from REAL exponents —
+also a DoS). Both are fixed in pyasn1 0.6.4. pyasn1 is transitive-only:
+it enters this graph via google-genai → google-auth → pyasn1-modules
+and is never imported directly, so its floor lives in
+``[tool.uv].constraint-dependencies`` rather than
+``[project].dependencies`` — a uv constraint tightens resolution when
+the package is already in the graph without declaring a dependency we
+never import (precedent: creek-tools' pyjwt>=2.13.0 constraint,
+DEP-003).
+
+Two independent guards per package:
+
+* **pyproject floor** — the declared specifier must reject the last
+  vulnerable release so a future relock cannot resolve back down to it.
 * **locked version** — ``uv.lock`` is what CI installs and what
-  pip-audit actually inspects, so the resolved ``mcp`` entry must
-  already be at or above the patched version.
+  pip-audit actually inspects, so the resolved entry must already be
+  at or above the patched version.
 """
 
 from __future__ import annotations
@@ -34,6 +51,10 @@ _UV_LOCK = _PACKAGE_ROOT / "uv.lock"
 #: First mcp release containing the fixes for CVE-2026-52869,
 #: CVE-2026-52870, and CVE-2026-59950.
 _PATCHED_VERSION = Version("1.28.1")
+
+#: First pyasn1 release containing the fixes for CVE-2026-59885 and
+#: CVE-2026-59886.
+_PYASN1_PATCHED_VERSION = Version("0.6.4")
 
 
 def _mcp_specifier() -> SpecifierSet:
@@ -57,6 +78,47 @@ def _locked_mcp_version() -> Version:
         if package["name"] == "mcp":
             return Version(str(package["version"]))
     pytest.fail("mcp has no [[package]] entry in uv.lock")
+
+
+def _pyasn1_constraint_specifier() -> SpecifierSet:
+    """Return the ``pyasn1`` specifier from uv constraint-dependencies.
+
+    Reads ``[tool.uv].constraint-dependencies`` in ``pyproject.toml``,
+    the home for floors on transitive-only packages (DEP-003).
+
+    Returns:
+        The specifier set attached to the ``pyasn1`` constraint entry.
+        Fails the calling test if the ``[tool.uv]`` table or the
+        ``pyasn1`` entry is absent.
+    """
+    with _PYPROJECT.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+    constraints: list[str] = (
+        pyproject.get("tool", {}).get("uv", {}).get("constraint-dependencies", [])
+    )
+    for entry in constraints:
+        requirement = Requirement(entry)
+        if requirement.name == "pyasn1":
+            return requirement.specifier
+    pytest.fail(
+        "pyasn1 has no entry in [tool.uv].constraint-dependencies of pyproject.toml"
+    )
+
+
+def _locked_pyasn1_version() -> Version:
+    """Return the resolved ``pyasn1`` version pinned in ``uv.lock``.
+
+    Returns:
+        The ``pyasn1`` version resolved in the lockfile. Fails the
+        calling test if the lock has no ``pyasn1`` package entry.
+    """
+    with _UV_LOCK.open("rb") as handle:
+        lock = tomllib.load(handle)
+    packages: list[dict[str, object]] = lock["package"]
+    for package in packages:
+        if package["name"] == "pyasn1":
+            return Version(str(package["version"]))
+    pytest.fail("pyasn1 has no [[package]] entry in uv.lock")
 
 
 def test_mcp_floor_rejects_last_vulnerable_range() -> None:
@@ -111,4 +173,44 @@ def test_locked_mcp_at_or_above_patched_release() -> None:
         f"uv.lock pins mcp {locked}, below the CVE-patched "
         f"{_PATCHED_VERSION} (CVE-2026-52869 / CVE-2026-52870 / "
         "CVE-2026-59950); run a relock after raising the pyproject floor"
+    )
+
+
+def test_pyasn1_floor_rejects_last_vulnerable_release() -> None:
+    """The constraint excludes 0.6.3, the last vulnerable release.
+
+    pyasn1 0.6.3 carries CVE-2026-59885 (quadratic OID-arc decode DoS)
+    and CVE-2026-59886 (REAL-exponent big-int DoS). The constraint must
+    genuinely be ``>=0.6.4`` so a relock cannot resolve back onto it.
+    """
+    specifier = _pyasn1_constraint_specifier()
+    assert "0.6.3" not in specifier, (
+        f"pyasn1 constraint {specifier!r} admits 0.6.3, the release "
+        "carrying CVE-2026-59885 / CVE-2026-59886; the floor must be "
+        ">=0.6.4"
+    )
+
+
+def test_pyasn1_floor_accepts_patched_release() -> None:
+    """The constraint accepts 0.6.4, the first CVE-patched release."""
+    specifier = _pyasn1_constraint_specifier()
+    assert "0.6.4" in specifier, (
+        f"pyasn1 constraint {specifier!r} rejects 0.6.4; the patched "
+        "release itself must satisfy the constraint"
+    )
+
+
+def test_locked_pyasn1_at_or_above_patched_release() -> None:
+    """``uv.lock`` resolves pyasn1 to >= 0.6.4.
+
+    The lockfile is what CI installs and what pip-audit inspects; a
+    correct constraint floor with a stale lock still ships the
+    vulnerable 0.6.3.
+    """
+    locked = _locked_pyasn1_version()
+    assert locked >= _PYASN1_PATCHED_VERSION, (
+        f"uv.lock pins pyasn1 {locked}, below the CVE-patched "
+        f"{_PYASN1_PATCHED_VERSION} (CVE-2026-59885 / CVE-2026-59886); "
+        "pip-audit inspects the lock, so relock after adding the "
+        "constraint"
     )

--- a/crawdad/uv.lock
+++ b/crawdad/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[manifest]
+constraints = [{ name = "pyasn1", specifier = ">=0.6.4" }]
+
 [[package]]
 name = "aiohappyeyeballs"
 version = "2.6.2"
@@ -1558,11 +1561,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -154,6 +154,11 @@ constraint-dependencies = [
     "pip>=26.1.2",
     "setuptools>=78.1.1",
     "wheel>=0.47.0",
+    # Security: pin pyasn1 above CVE-2026-59885 (quadratic OID-arc
+    # decode DoS) and CVE-2026-59886 (REAL-exponent big-int DoS) —
+    # transitive-only via the gdrive extra → google-auth →
+    # pyasn1-modules. Both fixed in 0.6.4 (#867).
+    "pyasn1>=0.6.4",
 ]
 
 [tool.setuptools.packages.find]

--- a/creek-tools/tests/test_dependency_pins.py
+++ b/creek-tools/tests/test_dependency_pins.py
@@ -1,20 +1,36 @@
-"""Guard tests for the ``mcp`` dependency pin (issue #862).
+"""Guard tests for security-motivated dependency pins.
 
-mcp 1.27.1 carries CVE-2026-52869 — cross-principal session injection on
-the Streamable HTTP bearer-token transport. That transport is reachable
-here: ``creek_mcp`` runs streamable-http with a ``TokenVerifier``. The
-same release also carries CVE-2026-52870 and CVE-2026-59950. All three
-are fixed in mcp 1.28.1.
+Each pin here answers specific CVEs; the tests guard both the declared
+floor and the resolved lock so a future relock cannot regress onto a
+vulnerable release.
 
-Two independent guards:
+``mcp`` (issue #862): mcp 1.27.1 carries CVE-2026-52869 —
+cross-principal session injection on the Streamable HTTP bearer-token
+transport. That transport is reachable here: ``creek_mcp`` runs
+streamable-http with a ``TokenVerifier``. The same release also carries
+CVE-2026-52870 and CVE-2026-59950. All three are fixed in mcp 1.28.1.
+mcp is a direct dependency, so its floor lives in
+``[project].dependencies`` (with the ``<2.0.0`` ceiling intact).
 
-* **pyproject floor** — the ``mcp`` specifier in ``[project].dependencies``
-  must reject anything below 1.28.1 so a future ``uv lock`` relock cannot
-  resolve back down to a vulnerable release, while keeping the ``<2.0.0``
-  ceiling intact.
-* **locked version** — ``uv.lock`` is what CI installs and what pip-audit
-  actually inspects, so the resolved ``mcp`` entry must already be at or
-  above the patched version.
+``pyasn1`` (issue #867): pyasn1 0.6.3 carries CVE-2026-59885
+(quadratic-time OID-arc decoding — a DoS on hostile BER/DER input) and
+CVE-2026-59886 (unbounded big-int construction from REAL exponents —
+also a DoS). Both are fixed in pyasn1 0.6.4. pyasn1 is transitive-only:
+it enters this graph via the ``gdrive`` extra → google-auth →
+pyasn1-modules and is never imported directly, so its floor lives in
+``[tool.uv].constraint-dependencies`` rather than
+``[project].dependencies`` — a uv constraint tightens resolution when
+the package is already in the graph without declaring a dependency we
+never import (precedent: the pyjwt>=2.13.0 constraint, DEP-003).
+
+Two independent guards per package:
+
+* **pyproject floor** — the declared specifier must reject the last
+  vulnerable release so a future ``uv lock`` relock cannot resolve
+  back down to it.
+* **locked version** — ``uv.lock`` is what CI installs and what
+  pip-audit actually inspects, so the resolved entry must already be
+  at or above the patched version.
 """
 
 from __future__ import annotations
@@ -38,6 +54,10 @@ _UV_LOCK = _PACKAGE_ROOT / "uv.lock"
 #: CVE-2026-52870, and CVE-2026-59950.
 _PATCHED_VERSION = Version("1.28.1")
 
+#: First pyasn1 release containing the fixes for CVE-2026-59885 and
+#: CVE-2026-59886.
+_PYASN1_PATCHED_VERSION = Version("0.6.4")
+
 
 def _mcp_specifier() -> SpecifierSet:
     """Return the ``mcp`` specifier set from ``[project].dependencies``."""
@@ -60,6 +80,47 @@ def _locked_mcp_version() -> Version:
         if package["name"] == "mcp":
             return Version(str(package["version"]))
     pytest.fail("mcp has no [[package]] entry in uv.lock")
+
+
+def _pyasn1_constraint_specifier() -> SpecifierSet:
+    """Return the ``pyasn1`` specifier from uv constraint-dependencies.
+
+    Reads ``[tool.uv].constraint-dependencies`` in ``pyproject.toml``,
+    the home for floors on transitive-only packages (DEP-003).
+
+    Returns:
+        The specifier set attached to the ``pyasn1`` constraint entry.
+        Fails the calling test if the ``[tool.uv]`` table or the
+        ``pyasn1`` entry is absent.
+    """
+    with _PYPROJECT.open("rb") as handle:
+        pyproject = tomllib.load(handle)
+    constraints: list[str] = (
+        pyproject.get("tool", {}).get("uv", {}).get("constraint-dependencies", [])
+    )
+    for entry in constraints:
+        requirement = Requirement(entry)
+        if requirement.name == "pyasn1":
+            return requirement.specifier
+    pytest.fail(
+        "pyasn1 has no entry in [tool.uv].constraint-dependencies of pyproject.toml"
+    )
+
+
+def _locked_pyasn1_version() -> Version:
+    """Return the resolved ``pyasn1`` version pinned in ``uv.lock``.
+
+    Returns:
+        The ``pyasn1`` version resolved in the lockfile. Fails the
+        calling test if the lock has no ``pyasn1`` package entry.
+    """
+    with _UV_LOCK.open("rb") as handle:
+        lock = tomllib.load(handle)
+    packages: list[dict[str, object]] = lock["package"]
+    for package in packages:
+        if package["name"] == "pyasn1":
+            return Version(str(package["version"]))
+    pytest.fail("pyasn1 has no [[package]] entry in uv.lock")
 
 
 def test_mcp_floor_rejects_last_vulnerable_range() -> None:
@@ -114,4 +175,44 @@ def test_locked_mcp_at_or_above_patched_release() -> None:
         f"uv.lock pins mcp {locked}, below the CVE-patched "
         f"{_PATCHED_VERSION} (CVE-2026-52869 / CVE-2026-52870 / "
         "CVE-2026-59950); run a relock after raising the pyproject floor"
+    )
+
+
+def test_pyasn1_floor_rejects_last_vulnerable_release() -> None:
+    """The constraint excludes 0.6.3, the last vulnerable release.
+
+    pyasn1 0.6.3 carries CVE-2026-59885 (quadratic OID-arc decode DoS)
+    and CVE-2026-59886 (REAL-exponent big-int DoS). The constraint must
+    genuinely be ``>=0.6.4`` so a relock cannot resolve back onto it.
+    """
+    specifier = _pyasn1_constraint_specifier()
+    assert "0.6.3" not in specifier, (
+        f"pyasn1 constraint {specifier!r} admits 0.6.3, the release "
+        "carrying CVE-2026-59885 / CVE-2026-59886; the floor must be "
+        ">=0.6.4"
+    )
+
+
+def test_pyasn1_floor_accepts_patched_release() -> None:
+    """The constraint accepts 0.6.4, the first CVE-patched release."""
+    specifier = _pyasn1_constraint_specifier()
+    assert "0.6.4" in specifier, (
+        f"pyasn1 constraint {specifier!r} rejects 0.6.4; the patched "
+        "release itself must satisfy the constraint"
+    )
+
+
+def test_locked_pyasn1_at_or_above_patched_release() -> None:
+    """``uv.lock`` resolves pyasn1 to >= 0.6.4.
+
+    The lockfile is what CI installs and what pip-audit inspects; a
+    correct constraint floor with a stale lock still ships the
+    vulnerable 0.6.3.
+    """
+    locked = _locked_pyasn1_version()
+    assert locked >= _PYASN1_PATCHED_VERSION, (
+        f"uv.lock pins pyasn1 {locked}, below the CVE-patched "
+        f"{_PYASN1_PATCHED_VERSION} (CVE-2026-59885 / CVE-2026-59886); "
+        "pip-audit inspects the lock, so relock after adding the "
+        "constraint"
     )

--- a/creek-tools/uv.lock
+++ b/creek-tools/uv.lock
@@ -15,6 +15,7 @@ resolution-markers = [
 constraints = [
     { name = "cryptography", specifier = ">=48.0.0" },
     { name = "pip", specifier = ">=26.1.2" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "setuptools", specifier = ">=78.1.1" },
     { name = "wheel", specifier = ">=0.47.0" },
@@ -2452,11 +2453,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Floors `pyasn1` at **0.6.4** (latest PyPI release, verified live; fixes **CVE-2026-59885** quadratic OID-arc decode DoS and **CVE-2026-59886** REAL-exponent big-int DoS) in both packages. pyasn1 is transitive-only (creek-tools: `gdrive` extra → google-auth → pyasn1-modules; crawdad: google-genai → google-auth → pyasn1-modules), so the floor lives in `[tool.uv].constraint-dependencies` per the pyjwt/DEP-003 precedent — creek-tools appends to its existing constraint list; crawdad gains the table.
- Relocked both `uv.lock` files: pyasn1 0.6.3 → 0.6.4 only, zero unrelated churn (verified in the diff).
- TDD guard tests (3 per package) added to each `tests/test_dependency_pins.py`: constraint floor rejects 0.6.3, accepts 0.6.4, and locked version >= 0.6.4 — a future relock cannot silently regress below the patched release.

## Test plan
- **RED first**: all 6 new guard tests failed before the constraint/relock (no constraint entry; locks pinned 0.6.3).
- **GREEN**: after the pin + relock, `pytest tests/test_dependency_pins.py` passes 7/7 in creek-tools and 7/7 in crawdad (mcp guards intact).
- gdrive ingestion suite against pyasn1 0.6.4: `pytest tests/test_gdrive_doctor.py tests/test_gdrive_downloader.py tests/test_google_drive_filter.py` — **136 passed**.
- `cd crawdad && ./scripts/check-all.sh` — **exit 0**.
- `cd creek-tools && ./scripts/check-all.sh` — every step green (5980 unit tests passed, coverage/per-file/complexity/docstrings/lint/mypy/pylint all pass) except the pip-audit step, whose **only** remaining rows are the pre-existing `setuptools 81.0.0` (PYSEC-2026-3447) and `torch 2.12.1` (PYSEC-2025-194) advisories tracked in #861 — present at the base commit and untouched by this diff.
- **pyasn1-advisories-gone verification (explicit)**: `./scripts/security.sh` pip-audit output now contains **zero pyasn1 rows** (previously two: CVE-2026-59885 and CVE-2026-59886 at 0.6.3).

Closes #867