### PR TITLE
fix(mcp): require TLS for non-loopback network binds and bound remote token lifetime

### DIFF
--- a/creek-tools/creek_mcp/remote_auth.py
+++ b/creek-tools/creek_mcp/remote_auth.py
@@ -13,6 +13,12 @@ scope) and exposes the authenticated identity per-call via ``get_access_token()`
 — which the server uses to stamp the consumer on the audit log and to apply the
 remote tier-ceiling cap.
 
+Verified tokens carry a **finite lifetime** (#837): ``verify_token`` stamps
+``expires_at`` at ``now + TTL`` (default 3600s) rather than issuing a
+never-expiring credential. ``CREEK_MCP_TOKEN_TTL_SECONDS`` overrides the TTL;
+a non-integer or non-positive value falls back to the default rather than
+failing open with ``expires_at=None``.
+
 Stdio (local CrawDad / Claude Code) is unaffected: no verifier is wired, so
 ``get_access_token()`` is ``None`` and calls run as before.
 """
@@ -21,6 +27,7 @@ from __future__ import annotations
 
 import hmac
 import os
+import time
 from typing import TYPE_CHECKING, Final
 
 from mcp.server.auth.provider import AccessToken, TokenVerifier
@@ -35,10 +42,41 @@ CONSUMER_TOKENS_ENV: Final[str] = "CREEK_MCP_CONSUMER_TOKENS"
 REMOTE_SCOPE: Final[str] = "creek:remote"
 """The scope every remote consumer token is granted (and the server requires)."""
 
+TOKEN_TTL_ENV: Final[str] = "CREEK_MCP_TOKEN_TTL_SECONDS"
+"""Env var overriding the verified-token lifetime in seconds (#837)."""
+
+_REMOTE_TOKEN_TTL_SECONDS: Final[int] = 3600
+"""Default lifetime of a verified bearer's ``AccessToken`` (one hour)."""
+
+# Monkeypatchable clock alias: tests pin `_now` to a fixed instant so the
+# expires_at arithmetic is exact; production keeps wall-clock time.
+_now = time.time
+
 # Non-secret placeholder URLs — this is a self-hosted resource server using bearer
 # tokens, not an OAuth authorization-server flow, but AuthSettings requires them.
 _ISSUER_URL: Final[str] = "https://creek.invalid/mcp"
 _RESOURCE_URL: Final[str] = "https://creek.invalid/mcp"
+
+
+def _token_ttl_seconds() -> int:
+    """Return the verified-token TTL in seconds, defaulting to one hour.
+
+    Reads :data:`TOKEN_TTL_ENV`; a non-integer or non-positive value falls
+    back to :data:`_REMOTE_TOKEN_TTL_SECONDS` without raising, so a
+    misconfigured environment degrades to the safe finite default instead of
+    crashing verification (or, worse, issuing a non-expiring token).
+
+    Returns:
+        The token lifetime in seconds (always > 0).
+    """
+    raw = os.environ.get(TOKEN_TTL_ENV)
+    if raw is None:
+        return _REMOTE_TOKEN_TTL_SECONDS
+    try:
+        ttl = int(raw)
+    except ValueError:
+        return _REMOTE_TOKEN_TTL_SECONDS
+    return ttl if ttl > 0 else _REMOTE_TOKEN_TTL_SECONDS
 
 
 def load_consumer_tokens(
@@ -88,6 +126,16 @@ class ConsumerTokenVerifier(TokenVerifier):
         raises ``TypeError`` on a non-ASCII ``str`` but compares cleanly on
         ``bytes``, so a non-ASCII bearer is *rejected* (returns ``None``) rather
         than crashing verification (#776).
+
+        The returned token expires ``_token_ttl_seconds()`` from now — never
+        ``expires_at=None`` — bounding how long any individually captured
+        :class:`AccessToken` (e.g. one logged or cached outside this call)
+        stays valid (#837). This does not rate-limit or expire the underlying
+        shared secret itself: the SDK's bearer middleware calls
+        ``verify_token`` fresh on every request, so a consumer that keeps
+        presenting the same ``CREEK_MCP_CONSUMER_TOKENS`` value is
+        re-verified and re-issued a fresh token indefinitely — only
+        rotating the configured secret revokes access.
         """
         supplied = token.encode("utf-8")
         matched: str | None = None
@@ -100,7 +148,7 @@ class ConsumerTokenVerifier(TokenVerifier):
             token=token,
             client_id=matched,
             scopes=[REMOTE_SCOPE],
-            expires_at=None,
+            expires_at=int(_now()) + _token_ttl_seconds(),
         )
 
 

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -14,6 +14,7 @@ point (``main``).
 from __future__ import annotations
 
 import argparse
+import ipaddress
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -651,16 +652,131 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
-        "--host", default="127.0.0.1", help="Network transport bind host."
+        "--host",
+        default="127.0.0.1",
+        help=(
+            "Network transport bind host. A non-loopback host requires "
+            "--tls-cert/--tls-key so bearer tokens never transit in cleartext."
+        ),
     )
     parser.add_argument(
         "--port", type=int, default=8000, help="Network transport bind port."
     )
+    parser.add_argument(
+        "--tls-cert",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the TLS certificate (PEM). Required together with "
+            "--tls-key when binding a non-loopback host."
+        ),
+    )
+    parser.add_argument(
+        "--tls-key",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the TLS private key (PEM). Required together with "
+            "--tls-cert when binding a non-loopback host."
+        ),
+    )
     return parser
+
+
+def _is_loopback(host: str) -> bool:
+    """Return whether *host* is a loopback bind (safe for plaintext transport).
+
+    Loopback traffic never leaves the machine, so serving bearer-token auth
+    without TLS is acceptable there — and only there.
+
+    Args:
+        host: The ``--host`` value: an IP literal or a hostname.
+
+    Returns:
+        ``True`` for loopback IPs (``127.0.0.0/8``, ``::1``) and the literal
+        ``"localhost"`` (case-insensitive); ``False`` for everything else,
+        including ``""``, wildcard binds, other hostnames, and strings that
+        do not parse as an IP address at all.
+    """
+    if host.lower() == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        # Not an IP literal (hostname, empty, garbage): assume routable.
+        return False
+
+
+def _require_transport_confidentiality(
+    parser: argparse.ArgumentParser, args: argparse.Namespace
+) -> None:
+    """Refuse network configurations that would put bearer tokens on the wire.
+
+    Enforces, in order: ``--tls-cert``/``--tls-key`` come as a pair; both
+    files exist on disk; and a non-loopback ``--host`` is only served when
+    TLS is configured. Each violation exits via :meth:`argparse.ArgumentParser.error`
+    (nonzero exit, message on stderr) *before* any socket is opened (#837).
+
+    Args:
+        parser: The CLI parser, used to report errors in argparse style.
+        args: Parsed arguments carrying ``host``, ``tls_cert``, ``tls_key``.
+    """
+    if (args.tls_cert is None) != (args.tls_key is None):
+        parser.error(
+            "--tls-cert and --tls-key are required together; supply both "
+            "(or neither, for a loopback-only bind)"
+        )
+    if args.tls_cert is not None:
+        for flag, path in (("--tls-cert", args.tls_cert), ("--tls-key", args.tls_key)):
+            if not path.exists():
+                parser.error(f"{flag}: file not found: {path}")
+        return
+    if not _is_loopback(args.host):
+        parser.error(
+            f"refusing to serve on non-loopback host {args.host!r} without TLS: "
+            "bearer tokens would transit the network in cleartext. Bind "
+            "127.0.0.1, terminate TLS in a reverse proxy, or pass "
+            "--tls-cert/--tls-key"
+        )
+
+
+def _serve_network(server: FastMCP, args: argparse.Namespace) -> None:
+    """Serve the streamable-http transport, with TLS when cert + key are given.
+
+    With ``--tls-cert``/``--tls-key`` configured, runs the server's Starlette
+    app under uvicorn with ``ssl_certfile``/``ssl_keyfile`` (mirroring the
+    SDK's own ``run_streamable_http_async`` bootstrap, plus TLS). Without
+    TLS — a loopback bind, per :func:`_require_transport_confidentiality` —
+    falls back to the SDK's plain ``run("streamable-http")``.
+
+    Args:
+        server: The built (authenticated) :class:`FastMCP` server.
+        args: Parsed arguments carrying ``host``, ``port``, ``tls_cert``,
+            ``tls_key``.
+    """
+    if args.tls_cert is not None and args.tls_key is not None:
+        # Lazy import, matching FastMCP's own transport bootstrap pattern.
+        import uvicorn
+
+        config = uvicorn.Config(
+            server.streamable_http_app(),
+            host=args.host,
+            port=args.port,
+            log_level=server.settings.log_level.lower(),
+            ssl_certfile=str(args.tls_cert),
+            ssl_keyfile=str(args.tls_key),
+        )
+        uvicorn.Server(config).run()
+    else:
+        server.run(transport="streamable-http")
 
 
 def main(argv: list[str] | None = None) -> None:
     """Run the MCP server over stdio (local) or the authenticated network transport.
+
+    The network branch is fail-closed twice over: it refuses to start without
+    per-consumer tokens (no anonymous access), and it refuses a non-loopback
+    bind unless TLS is configured (no cleartext bearer tokens, #837).
 
     Args:
         argv: Optional list of command-line arguments. When ``None``
@@ -684,10 +800,11 @@ def main(argv: list[str] | None = None) -> None:
                 f"network transport requires {CONSUMER_TOKENS_ENV} "
                 "(consumer=token pairs); refusing to serve without authentication"
             )
+        _require_transport_confidentiality(parser, args)
         server = build_server(token_verifier=ConsumerTokenVerifier(tokens))
         server.settings.host = args.host
         server.settings.port = args.port
-        server.run(transport="streamable-http")
+        _serve_network(server, args)
     else:
         build_server().run(transport="stdio")
 

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -194,7 +194,7 @@ CrawDad (FEAT-013+) treats this server's tool registry as its
 stdio child process. Set `CREEK_MCP_CONSUMER=crawdad` in the bot's
 environment so the audit trail distinguishes Discord-driven calls.
 
-## Network transport (authenticated, epic #757 / #759)
+## Network transport (authenticated, epic #757 / #759 / #837)
 
 Local consumers (Claude Code, CrawDad) speak JSON-RPC over **stdio** — the
 default, unchanged. To reach a user's per-user-VM vault from a remote
@@ -208,15 +208,28 @@ export CREEK_MCP_CONSUMER_TOKENS="adepthood=<secrets.token_hex(32)>;other=<token
 creek-tools-mcp --transport network --host 127.0.0.1 --port 8000
 ```
 
-> **⚠️ TLS is required in production — the server does not terminate it.**
-> `--transport network` speaks plain HTTP. Binding beyond loopback (e.g.
-> `--host 0.0.0.0`) **without TLS sends the bearer token in cleartext on every
-> request**, which defeats the constant-time comparison and no-anonymous-access
-> guarantees below. A bare `--host 0.0.0.0 --port 8000` is **not safe to expose
-> directly.** Production deployments MUST sit behind a **TLS-terminating reverse
-> proxy** (or use mTLS); keep the server itself bound to `127.0.0.1` and let the
-> proxy handle TLS and forward to it. The reverse proxy is also the right place
-> for rate-limiting and IP allowlisting.
+### TLS is enforced for non-loopback binds (#837)
+
+`--host` defaults to `127.0.0.1`. A **loopback** bind — `127.0.0.0/8`,
+`::1`, or the literal hostname `localhost` (case-insensitive) — may still
+serve plain HTTP, for local dev; anything else is refused unless
+`--tls-cert`/`--tls-key` are both supplied and point at existing files:
+
+```bash
+creek-tools-mcp --transport network --host 0.0.0.0 --port 8443 \
+  --tls-cert /path/to/cert.pem --tls-key /path/to/key.pem
+```
+
+With both flags set, the server serves the Starlette app directly under
+`uvicorn` with `ssl_certfile`/`ssl_keyfile` — no reverse proxy is required.
+Alternatively, keep the server bound to `127.0.0.1` (or `localhost`) and
+terminate TLS in a reverse proxy in front of it; either path keeps bearer
+tokens off the wire in cleartext. A non-loopback bind without TLS exits
+immediately with a nonzero status and an error on stderr, before any socket
+opens — no partial startup. Note that only an IP literal or the exact
+hostname `localhost` is recognised as loopback; any other hostname (even one
+that happens to resolve to `127.0.0.1`, e.g. via `/etc/hosts`) is treated as
+routable by design and requires TLS.
 
 - **No anonymous access.** Network mode refuses to start unless
   `CREEK_MCP_CONSUMER_TOKENS` is set. It holds `consumer=token` pairs,
@@ -229,6 +242,18 @@ creek-tools-mcp --transport network --host 127.0.0.1 --port 8000
   is stamped on every audit-log entry — so remote calls are attributable the
   same way `CREEK_MCP_CONSUMER` attributes stdio calls. A missing or unknown
   token is rejected `401` before any tool runs; comparison is constant-time.
+- **Bearer tokens carry a finite lifetime (#837).** Each verified bearer is
+  issued an `AccessToken` that expires `CREEK_MCP_TOKEN_TTL_SECONDS` after
+  the moment it was verified (default `3600`, i.e. one hour); an unset,
+  non-integer, or non-positive TTL value falls back to the default rather
+  than issuing a non-expiring token. In practice the SDK's bearer middleware
+  re-verifies the `Authorization` header on every request rather than
+  caching a session-scoped token, so a consumer that keeps presenting the
+  same configured `CREEK_MCP_CONSUMER_TOKENS` secret is re-verified and
+  granted a fresh `AccessToken`/`expires_at` on each call; the TTL bounds how
+  long any *individually captured* `AccessToken` (e.g. one logged or cached
+  outside the server) would remain valid, not how often the underlying
+  shared secret must be rotated.
 - **A consumer token grants remote _write_ access, by design.** A valid
   `CREEK_MCP_CONSUMER_TOKENS` entry can reach every non-purge tool at or below
   the `personal` ceiling — including the **write** tools (`creek.journal`,
@@ -340,6 +365,10 @@ an identical target page.
 - **`creek.draft` returns "LLM provider unavailable":** the server
   loads the LLM lazily so only `draft` requires it. Configure
   `ANTHROPIC_API_KEY` or a running Ollama instance.
+- **`--transport network` exits with "refusing to serve on non-loopback
+  host ... without TLS":** bind `127.0.0.1`/`localhost` for local dev, or
+  pass `--tls-cert`/`--tls-key` (both, pointing at existing files) for a
+  routable bind.
 - **Fewer mine seeds than expected:** the ceiling is filtering intimate
   fragments by design. Raise the ceiling to `intimate` or `all` only
   when the caller is authorised.

--- a/creek-tools/pyproject.toml
+++ b/creek-tools/pyproject.toml
@@ -24,6 +24,10 @@ dependencies = [
     # injection on Streamable HTTP bearer transport — reachable via
     # creek_mcp), CVE-2026-52870, CVE-2026-59950. All fixed in 1.28.1.
     "mcp>=1.28.1,<2.0.0",
+    # creek_mcp.server._serve_network drives uvicorn directly for the TLS
+    # network transport (#837), so uvicorn is a direct dependency rather than
+    # a transitive one via mcp. Floor matches the uv.lock resolution.
+    "uvicorn>=0.47.0",
     # At-rest volume key (creek.confidential): Argon2id / AES-GCM / HKDF are
     # imported unconditionally, so cryptography is a direct base dependency —
     # not left to transitive resolution via mcp -> pyjwt[crypto] (#758).

--- a/creek-tools/tests/test_mcp_remote.py
+++ b/creek-tools/tests/test_mcp_remote.py
@@ -13,21 +13,31 @@ Security properties under test:
   bearer token identifies, not the process-env default.
 - **Stdio is unchanged** — with no verifier wired, ``get_access_token()`` is
   ``None`` so the cap never engages and a local ``intimate`` call dispatches.
+- **Tokens expire** (#837) — a verified bearer carries a finite ``expires_at``
+  (default TTL 3600s; ``CREEK_MCP_TOKEN_TTL_SECONDS`` overrides; invalid values
+  fall back to the default), never ``None``.
+- **No plaintext on routable interfaces** (#837) — a non-loopback ``--host``
+  refuses to serve unless ``--tls-cert``/``--tls-key`` are configured; loopback
+  binds and stdio keep working without TLS.
 
 No real/production token material is hardcoded — every token is a test literal.
 """
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import json
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
+import uvicorn
 from mcp.server.auth.provider import AccessToken
 from mcp.server.transport_security import TransportSecuritySettings
 from starlette.testclient import TestClient
 
+from creek_mcp import remote_auth as remote_auth_mod
 from creek_mcp import server as server_mod
 from creek_mcp.audit import MCP_AUDIT_RELPATH
 from creek_mcp.remote_auth import (
@@ -405,3 +415,303 @@ def test_remote_intimate_is_refused_over_the_wire(vault: Path) -> None:
         structured = _wire_call(client, path, headers, "intimate")
     assert structured["status"] == "refused"
     assert "not reachable over the network" in structured["reason"]
+
+
+# --------------------------------------------------------------------------- #
+# Token TTL (#837): verify_token issues a finite expiry, never expires_at=None
+# --------------------------------------------------------------------------- #
+
+_TOKEN_TTL_ENV = "CREEK_MCP_TOKEN_TTL_SECONDS"
+_DEFAULT_TTL_SECONDS = 3600
+_FIXED_NOW = 1_000_000.5  # arbitrary fixed clock so expiry math is exact
+
+
+def _verified_token_at_fixed_now(monkeypatch: pytest.MonkeyPatch) -> AccessToken:
+    """Verify a known bearer with ``remote_auth._now`` pinned to :data:`_FIXED_NOW`.
+
+    ``_now`` is the design contract's monkeypatchable module-level clock alias
+    (``_now = time.time``); referencing it here is the RED trigger until #837
+    lands.
+    """
+    monkeypatch.setattr(remote_auth_mod, "_now", lambda: _FIXED_NOW)
+    verifier = ConsumerTokenVerifier({"adepthood": "secret123"})
+    token = asyncio.run(verifier.verify_token("secret123"))
+    assert token is not None
+    return token
+
+
+def test_verify_token_sets_finite_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A verified token expires at ``int(now) + 3600`` by default — never ``None``."""
+    monkeypatch.delenv(_TOKEN_TTL_ENV, raising=False)
+    token = _verified_token_at_fixed_now(monkeypatch)
+    assert isinstance(token.expires_at, int)
+    assert token.expires_at == 1_000_000 + _DEFAULT_TTL_SECONDS
+
+
+def test_token_ttl_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``CREEK_MCP_TOKEN_TTL_SECONDS`` overrides the default token lifetime."""
+    monkeypatch.setenv(_TOKEN_TTL_ENV, "900")
+    token = _verified_token_at_fixed_now(monkeypatch)
+    assert token.expires_at == 1_000_000 + 900
+
+
+@pytest.mark.parametrize("raw_ttl", ["abc", "-5", "0"])
+def test_token_ttl_invalid_env_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch, raw_ttl: str
+) -> None:
+    """A non-int or non-positive TTL env value falls back to 3600 without raising."""
+    monkeypatch.setenv(_TOKEN_TTL_ENV, raw_ttl)
+    token = _verified_token_at_fixed_now(monkeypatch)
+    assert token.expires_at == 1_000_000 + _DEFAULT_TTL_SECONDS
+
+
+# --------------------------------------------------------------------------- #
+# Transport confidentiality (#837): loopback classification + the TLS guard
+# --------------------------------------------------------------------------- #
+
+
+class _StubBuiltServer:
+    """Socket-free stand-in for a built ``FastMCP`` server.
+
+    Routed in via ``build_server`` so a guard bug fails the test as
+    ``DID NOT RAISE`` instead of binding a real port and hanging the run.
+    """
+
+    def __init__(self) -> None:
+        """Start with mutable settings and an empty run log."""
+        self.settings = SimpleNamespace(host=None, port=None)
+        self.run_calls: list[str] = []
+
+    def run(self, transport: str) -> None:
+        """Record the requested transport instead of serving."""
+        self.run_calls.append(transport)
+
+
+def _stub_build_server(monkeypatch: pytest.MonkeyPatch) -> _StubBuiltServer:
+    """Route ``server.build_server`` to a :class:`_StubBuiltServer`; return it."""
+    stub = _StubBuiltServer()
+    monkeypatch.setattr(server_mod, "build_server", lambda **_kwargs: stub)
+    return stub
+
+
+def _parsed_network_args(
+    *, host: str, port: int, tls_cert: Path | None, tls_key: Path | None
+) -> argparse.Namespace:
+    """Build the parsed-args namespace ``main`` hands to ``_serve_network``."""
+    return argparse.Namespace(
+        config=None,
+        transport="network",
+        host=host,
+        port=port,
+        tls_cert=tls_cert,
+        tls_key=tls_key,
+    )
+
+
+@pytest.mark.parametrize(
+    ("host", "expected"),
+    [
+        ("127.0.0.1", True),
+        ("127.0.0.5", True),
+        ("::1", True),
+        ("localhost", True),
+        ("0.0.0.0", False),
+        ("::", False),
+        ("192.168.1.10", False),
+        ("example.com", False),
+        ("", False),
+    ],
+)
+def test_is_loopback_helper(host: str, expected: bool) -> None:
+    """``_is_loopback`` classifies loopback binds True and routable hosts False."""
+    assert server_mod._is_loopback(host) is expected
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "192.168.1.10", "example.com"])
+def test_network_transport_refuses_routable_host_without_tls(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    host: str,
+) -> None:
+    """A routable ``--host`` without TLS exits before serving, pointing at the fix."""
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, "adepthood=secret123")
+    _stub_build_server(monkeypatch)
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--transport", "network", "--host", host])
+    assert excinfo.value.code != 0
+    err = capsys.readouterr().err
+    assert "--tls-cert" in err or "TLS" in err
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost"])
+def test_network_transport_allows_loopback_without_tls(
+    monkeypatch: pytest.MonkeyPatch, host: str
+) -> None:
+    """A loopback bind still serves plaintext — local dev is not broken by #837."""
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, "adepthood=secret123")
+    stub = _stub_build_server(monkeypatch)
+    served: list[tuple[object, argparse.Namespace]] = []
+    monkeypatch.setattr(
+        server_mod,
+        "_serve_network",
+        lambda server, args: served.append((server, args)),
+    )
+    main(["--transport", "network", "--host", host])
+    assert len(served) == 1
+    assert served[0][0] is stub
+
+
+def test_network_transport_allows_routable_host_with_tls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A routable bind with cert + key serves, and the TLS paths reach the args."""
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, "adepthood=secret123")
+    _stub_build_server(monkeypatch)
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    cert.write_text("dummy-cert")  # fixture material, not a real credential
+    key.write_text("dummy-key")
+    served: list[tuple[object, argparse.Namespace]] = []
+    monkeypatch.setattr(
+        server_mod,
+        "_serve_network",
+        lambda server, args: served.append((server, args)),
+    )
+    main(
+        [
+            "--transport",
+            "network",
+            "--host",
+            "0.0.0.0",
+            "--tls-cert",
+            str(cert),
+            "--tls-key",
+            str(key),
+        ]
+    )
+    assert len(served) == 1
+    args = served[0][1]
+    assert args.tls_cert == cert
+    assert args.tls_key == key
+
+
+def test_network_transport_rejects_tls_cert_without_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``--tls-cert`` without ``--tls-key`` is refused (both-or-neither)."""
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, "adepthood=secret123")
+    _stub_build_server(monkeypatch)
+    cert = tmp_path / "cert.pem"
+    cert.write_text("dummy-cert")  # fixture material, not a real credential
+    with pytest.raises(SystemExit) as excinfo:
+        main(
+            ["--transport", "network", "--host", "127.0.0.1", "--tls-cert", str(cert)],
+        )
+    assert excinfo.value.code != 0
+    assert "--tls-key" in capsys.readouterr().err
+
+
+def test_network_transport_rejects_missing_tls_cert_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """TLS flags pointing at nonexistent files exit with a 'file not found' error."""
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, "adepthood=secret123")
+    _stub_build_server(monkeypatch)
+    missing_cert = tmp_path / "no-cert.pem"
+    missing_key = tmp_path / "no-key.pem"
+    with pytest.raises(SystemExit) as excinfo:
+        main(
+            [
+                "--transport",
+                "network",
+                "--host",
+                "127.0.0.1",
+                "--tls-cert",
+                str(missing_cert),
+                "--tls-key",
+                str(missing_key),
+            ]
+        )
+    assert excinfo.value.code != 0
+    assert "file not found" in capsys.readouterr().err.lower()
+
+
+def test_serve_network_uses_ssl_when_tls_configured(
+    vault: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With TLS configured, ``_serve_network`` hands uvicorn the cert + key files."""
+    cert = tmp_path / "cert.pem"
+    key = tmp_path / "key.pem"
+    cert.write_text("dummy-cert")  # fixture material, not a real credential
+    key.write_text("dummy-key")
+
+    captured: dict[str, object] = {}
+
+    class _CapturingConfig:
+        """Fake ``uvicorn.Config`` recording every keyword it is built with."""
+
+        # Attributes uvicorn.run() consults post-construction, so an
+        # implementation built on uvicorn.run(...) also completes cleanly.
+        reload = False
+        should_reload = False
+        workers = 1
+        uds = None
+
+        def __init__(self, app: object, **kwargs: object) -> None:
+            """Record the app and the keyword arguments uvicorn received."""
+            captured["app"] = app
+            captured.update(kwargs)
+
+    class _IdleServer:
+        """Fake ``uvicorn.Server`` that never opens a socket."""
+
+        started = True  # uvicorn.run() exits nonzero when this is False
+
+        def __init__(self, config: object) -> None:
+            """Hold the config without acting on it."""
+            self.config = config
+
+        def run(self) -> None:
+            """No-op stand-in for the blocking serve loop."""
+
+        async def serve(self) -> None:
+            """No-op stand-in for the async serve loop."""
+
+    monkeypatch.setattr(uvicorn, "Config", _CapturingConfig)
+    monkeypatch.setattr(uvicorn, "Server", _IdleServer)
+
+    server = _network_server(vault, _WIRE_TOKEN)
+    server_mod._serve_network(
+        server,
+        _parsed_network_args(host="0.0.0.0", port=8443, tls_cert=cert, tls_key=key),
+    )
+
+    assert str(captured["ssl_certfile"]) == str(cert)
+    assert str(captured["ssl_keyfile"]) == str(key)
+
+
+def test_serve_network_plain_loopback_uses_server_run(
+    vault: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without TLS, ``_serve_network`` falls back to ``run('streamable-http')``."""
+    server = _network_server(vault, _WIRE_TOKEN)
+    runs: list[str] = []
+    monkeypatch.setattr(server, "run", lambda transport: runs.append(transport))
+    server_mod._serve_network(
+        server,
+        _parsed_network_args(host="127.0.0.1", port=8000, tls_cert=None, tls_key=None),
+    )
+    assert runs == ["streamable-http"]
+
+
+def test_default_stdio_transport_unaffected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``main([])`` still runs plain stdio — the TLS guard never engages locally."""
+    stub = _stub_build_server(monkeypatch)
+    main([])
+    assert stub.run_calls == ["stdio"]

--- a/creek-tools/uv.lock
+++ b/creek-tools/uv.lock
@@ -542,6 +542,7 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
     { name = "urllib3" },
+    { name = "uvicorn" },
 ]
 
 [package.optional-dependencies]
@@ -697,6 +698,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "types-tqdm", marker = "extra == 'dev'", specifier = ">=4.66.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
+    { name = "uvicorn", specifier = ">=0.47.0" },
     { name = "vulture", marker = "extra == 'dev'", specifier = ">=2.10" },
     { name = "xenon", marker = "extra == 'dev'", specifier = ">=0.9.0" },
 ]


### PR DESCRIPTION
## Summary

- **Fail-fast transport guard**: `--transport network` now refuses (via `parser.error`) to bind a non-loopback `--host` unless both `--tls-cert` and `--tls-key` are supplied and exist — bearer tokens no longer transit routable interfaces in cleartext. Loopback (`127.0.0.0/8`, `::1`, literal `localhost`) plaintext for local dev is unchanged; unparseable hosts and non-`localhost` hostnames fail closed (TLS required). A TLS-terminating proxy in front of a loopback bind remains supported.
- **Real TLS termination**: FastMCP's `Settings` has no SSL fields and `server.run("streamable-http")` cannot serve TLS, so the new `_serve_network()` serves `streamable_http_app()` through uvicorn with `ssl_certfile`/`ssl_keyfile` when the flags are set (uvicorn promoted from transitive to direct dependency, `>=0.47.0`, lock regenerated).
- **Bounded token lifetime**: `verify_token()` now mints `expires_at = int(_now()) + TTL` (default 3600 s; `CREEK_MCP_TOKEN_TTL_SECONDS` override, invalid/non-positive falls back) instead of `expires_at=None`; the SDK's `BearerAuthBackend` rejects expired tokens. The constant-time `hmac.compare_digest` comparison is untouched. Docs note honestly that the TTL bounds a captured `AccessToken`, not the static shared secret — rotation follow-up filed as #895.

## Test plan

- TDD: 25 new unit tests in `tests/test_mcp_remote.py` written RED first (finite/env-overridden/fallback expiry with an injectable clock; `_is_loopback` truth table incl. `0.0.0.0`, `::`, hostnames, garbage; guard refusals for routable-host-without-TLS, cert-without-key, missing files; TLS path passes `ssl_certfile`/`ssl_keyfile` to `uvicorn.Config`; loopback plaintext falls back to `server.run`; stdio regression guard), then GREEN.
- `cd creek-tools && ./scripts/check-all.sh` → 12/12 passed, 6016 tests, 93.88% branch coverage, mypy strict / ruff / xenon / bandit / interrogate / per-file gate all green.
- Gate 2.5 self-review + independent security audit: CLEAN (guard runs before any socket I/O; SDK enforces `expires_at` at `bearer_auth.py`; no secret values in error messages; #838 entropy fix slots in unaffected).

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)