### PR TITLE
fix(mcp): reject remote consumer tokens shorter than 32 chars at load

### DIFF
--- a/creek-tools/creek_mcp/remote_auth.py
+++ b/creek-tools/creek_mcp/remote_auth.py
@@ -19,6 +19,11 @@ never-expiring credential. ``CREEK_MCP_TOKEN_TTL_SECONDS`` overrides the TTL;
 a non-integer or non-positive value falls back to the default rather than
 failing open with ``expires_at=None``.
 
+Configured tokens must clear a **minimum-length floor** (#838): a token in
+``CREEK_MCP_CONSUMER_TOKENS`` shorter than 32 characters is refused at load
+time so a guessable secret never guards the wire. Generate compliant tokens
+with ``python -c "import secrets; print(secrets.token_urlsafe(32))"``.
+
 Stdio (local CrawDad / Claude Code) is unaffected: no verifier is wired, so
 ``get_access_token()`` is ``None`` and calls run as before.
 """
@@ -47,6 +52,9 @@ TOKEN_TTL_ENV: Final[str] = "CREEK_MCP_TOKEN_TTL_SECONDS"
 
 _REMOTE_TOKEN_TTL_SECONDS: Final[int] = 3600
 """Default lifetime of a verified bearer's ``AccessToken`` (one hour)."""
+
+_MIN_TOKEN_LEN: Final[int] = 32
+"""Minimum consumer-token length — the ``secrets.token_urlsafe(32)`` floor (#838)."""
 
 # Monkeypatchable clock alias: tests pin `_now` to a fixed instant so the
 # expires_at arithmetic is exact; production keeps wall-clock time.
@@ -79,6 +87,32 @@ def _token_ttl_seconds() -> int:
     return ttl if ttl > 0 else _REMOTE_TOKEN_TTL_SECONDS
 
 
+def _validated_token(name: str, token: str) -> str:
+    """Return *token* if it clears :data:`_MIN_TOKEN_LEN`, else raise (#838).
+
+    The error names the consumer and the observed/required lengths and gives
+    the rotation recipe — it never echoes the token value itself.
+
+    Args:
+        name: The consumer the token belongs to (already stripped).
+        token: The configured token (already stripped, non-empty).
+
+    Returns:
+        The token, unchanged, when it meets the minimum length.
+
+    Raises:
+        ValueError: If the token is shorter than :data:`_MIN_TOKEN_LEN`.
+    """
+    if len(token) < _MIN_TOKEN_LEN:
+        msg = (
+            f"consumer {name!r} token is {len(token)} chars, below the "
+            f"{_MIN_TOKEN_LEN}-char minimum; rotate it with "
+            'python -c "import secrets; print(secrets.token_urlsafe(32))"'
+        )
+        raise ValueError(msg)
+    return token
+
+
 def load_consumer_tokens(
     environ: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
@@ -87,20 +121,27 @@ def load_consumer_tokens(
     Format: ``adepthood=<token>;other=<token>``. Blank entries and entries
     without a token are skipped. Returns an empty dict when unset — the caller
     treats "no tokens configured" as "network mode not permitted" (no anonymous
-    access).
+    access). A *present* token shorter than :data:`_MIN_TOKEN_LEN` characters
+    is refused outright (#838); generate compliant tokens with
+    ``python -c "import secrets; print(secrets.token_urlsafe(32))"``.
 
     Args:
         environ: Environment mapping (defaults to :data:`os.environ`).
 
     Returns:
         A ``{consumer: token}`` mapping.
+
+    Raises:
+        ValueError: If a configured token is shorter than
+            :data:`_MIN_TOKEN_LEN` characters. The message names the consumer
+            and lengths but never the token value.
     """
     raw = (environ if environ is not None else os.environ).get(CONSUMER_TOKENS_ENV, "")
     tokens: dict[str, str] = {}
     for entry in raw.split(";"):
         name, sep, token = entry.strip().partition("=")
         if sep and name.strip() and token.strip():
-            tokens[name.strip()] = token.strip()
+            tokens[name.strip()] = _validated_token(name.strip(), token.strip())
     return tokens
 
 

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -774,9 +774,11 @@ def _serve_network(server: FastMCP, args: argparse.Namespace) -> None:
 def main(argv: list[str] | None = None) -> None:
     """Run the MCP server over stdio (local) or the authenticated network transport.
 
-    The network branch is fail-closed twice over: it refuses to start without
-    per-consumer tokens (no anonymous access), and it refuses a non-loopback
-    bind unless TLS is configured (no cleartext bearer tokens, #837).
+    The network branch is fail-closed three times over: it refuses to start
+    without per-consumer tokens (no anonymous access), it refuses a configured
+    token below the minimum-strength floor (#838), and it refuses a
+    non-loopback bind unless TLS is configured (no cleartext bearer
+    tokens, #837).
 
     Args:
         argv: Optional list of command-line arguments. When ``None``
@@ -792,7 +794,12 @@ def main(argv: list[str] | None = None) -> None:
         os.environ[CONFIG_PATH_ENV_VAR] = str(args.config.resolve())
 
     if args.transport == "network":
-        tokens = load_consumer_tokens()
+        try:
+            tokens = load_consumer_tokens()
+        except ValueError as exc:
+            # A configured token is below the minimum-strength floor (#838):
+            # exit with the rotation recipe rather than serve a weak secret.
+            parser.error(str(exc))
         if not tokens:
             # No anonymous access: refuse to expose the vault without per-consumer
             # tokens, rather than serving unauthenticated.

--- a/creek-tools/tests/test_mcp_remote.py
+++ b/creek-tools/tests/test_mcp_remote.py
@@ -19,6 +19,10 @@ Security properties under test:
 - **No plaintext on routable interfaces** (#837) — a non-loopback ``--host``
   refuses to serve unless ``--tls-cert``/``--tls-key`` are configured; loopback
   binds and stdio keep working without TLS.
+- **Weak tokens are refused at startup** (#838) — a configured consumer token
+  shorter than 32 chars fails ``load_consumer_tokens`` (and the network
+  transport, via ``parser.error``) with a rotation recipe that names the
+  consumer and lengths but never echoes the token value.
 
 No real/production token material is hardcoded — every token is a test literal.
 """
@@ -85,6 +89,11 @@ def _fake_token(consumer: str) -> AccessToken:
     )
 
 
+# 43 chars — clears the 32-char minimum (#838). Low-entropy test literal,
+# not a real credential.
+_STRONG_TOKEN = "unit-test-strong-token-" + "a" * 20
+
+
 # --------------------------------------------------------------------------- #
 # load_consumer_tokens — parsing
 # --------------------------------------------------------------------------- #
@@ -92,17 +101,51 @@ def _fake_token(consumer: str) -> AccessToken:
 
 def test_load_consumer_tokens_parses_pairs() -> None:
     """Well-formed ``consumer=token`` pairs parse into a map."""
-    env = {CONSUMER_TOKENS_ENV: "adepthood=secret123;crawdad=tok456"}
+    adepthood_token = "adepthood-strong-token-" + "a" * 20  # 43 chars, test literal
+    crawdad_token = "crawdad-strong-token-" + "b" * 20  # 41 chars, test literal
+    env = {CONSUMER_TOKENS_ENV: f"adepthood={adepthood_token};crawdad={crawdad_token}"}
     assert load_consumer_tokens(env) == {
-        "adepthood": "secret123",
-        "crawdad": "tok456",
+        "adepthood": adepthood_token,
+        "crawdad": crawdad_token,
     }
 
 
 def test_load_consumer_tokens_skips_blank_and_tokenless_entries() -> None:
     """Blank segments and ``name=`` entries with no token are dropped."""
-    env = {CONSUMER_TOKENS_ENV: " adepthood = secret123 ; ; missing= ;=orphan"}
-    assert load_consumer_tokens(env) == {"adepthood": "secret123"}
+    env = {CONSUMER_TOKENS_ENV: f" adepthood = {_STRONG_TOKEN} ; ; missing= ;=orphan"}
+    assert load_consumer_tokens(env) == {"adepthood": _STRONG_TOKEN}
+
+
+def test_load_consumer_tokens_rejects_sub_minimum_token() -> None:
+    """A present token shorter than 32 chars raises, naming everything but the token."""
+    env = {CONSUMER_TOKENS_ENV: "adepthood=hunter2"}  # 7 chars, test literal
+    with pytest.raises(ValueError, match="adepthood") as excinfo:
+        load_consumer_tokens(env)
+    message = str(excinfo.value)
+    assert "'adepthood'" in message  # consumer named via repr
+    assert "7" in message  # observed length of the rejected token
+    assert "32" in message  # the enforced minimum
+    assert "secrets.token_urlsafe(32)" in message  # the rotation recipe
+    assert "hunter2" not in message  # NEVER echo the token value
+
+
+def test_load_consumer_tokens_accepts_minimum_length_token() -> None:
+    """A token at or above the 32-char minimum is accepted and returned intact."""
+    env = {CONSUMER_TOKENS_ENV: f"adepthood={_STRONG_TOKEN}"}
+    assert load_consumer_tokens(env) == {"adepthood": _STRONG_TOKEN}
+
+
+def test_load_consumer_tokens_accepts_exact_boundary_token() -> None:
+    """A token of exactly 32 chars sits on the floor and is accepted."""
+    boundary_token = "a" * 32
+    env = {CONSUMER_TOKENS_ENV: f"adepthood={boundary_token}"}
+    assert load_consumer_tokens(env) == {"adepthood": boundary_token}
+
+
+def test_load_consumer_tokens_skips_blanks_without_raising() -> None:
+    """Blank and bare ``name=`` entries stay silently skipped, not length-checked."""
+    env = {CONSUMER_TOKENS_ENV: f";;missing=;=orphan;adepthood={_STRONG_TOKEN}"}
+    assert load_consumer_tokens(env) == {"adepthood": _STRONG_TOKEN}
 
 
 def test_load_consumer_tokens_empty_when_unset() -> None:
@@ -534,7 +577,7 @@ def test_network_transport_refuses_routable_host_without_tls(
     host: str,
 ) -> None:
     """A routable ``--host`` without TLS exits before serving, pointing at the fix."""
-    monkeypatch.setenv(CONSUMER_TOKENS_ENV, "adepthood=secret123")
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, f"adepthood={_STRONG_TOKEN}")
     _stub_build_server(monkeypatch)
     with pytest.raises(SystemExit) as excinfo:
         main(["--transport", "network", "--host", host])
@@ -543,12 +586,29 @@ def test_network_transport_refuses_routable_host_without_tls(
     assert "--tls-cert" in err or "TLS" in err
 
 
+def test_network_transport_rejects_short_token_with_recipe(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A sub-minimum token exits 2 with the rotation recipe, never the token."""
+    # 7-char test literal, well under the 32-char minimum.
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, "adepthood=hunter2")
+    _stub_build_server(monkeypatch)
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--transport", "network", "--host", "127.0.0.1"])
+    assert excinfo.value.code == 2  # argparse parser.error convention
+    err = capsys.readouterr().err
+    assert "adepthood" in err  # the offending consumer is named
+    assert "secrets.token_urlsafe(32)" in err  # the rotation recipe
+    assert "hunter2" not in err  # NEVER echo the token value
+
+
 @pytest.mark.parametrize("host", ["127.0.0.1", "::1", "localhost"])
 def test_network_transport_allows_loopback_without_tls(
     monkeypatch: pytest.MonkeyPatch, host: str
 ) -> None:
     """A loopback bind still serves plaintext — local dev is not broken by #837."""
-    monkeypatch.setenv(CONSUMER_TOKENS_ENV, "adepthood=secret123")
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, f"adepthood={_STRONG_TOKEN}")
     stub = _stub_build_server(monkeypatch)
     served: list[tuple[object, argparse.Namespace]] = []
     monkeypatch.setattr(
@@ -565,7 +625,7 @@ def test_network_transport_allows_routable_host_with_tls(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """A routable bind with cert + key serves, and the TLS paths reach the args."""
-    monkeypatch.setenv(CONSUMER_TOKENS_ENV, "adepthood=secret123")
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, f"adepthood={_STRONG_TOKEN}")
     _stub_build_server(monkeypatch)
     cert = tmp_path / "cert.pem"
     key = tmp_path / "key.pem"
@@ -601,7 +661,7 @@ def test_network_transport_rejects_tls_cert_without_key(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """``--tls-cert`` without ``--tls-key`` is refused (both-or-neither)."""
-    monkeypatch.setenv(CONSUMER_TOKENS_ENV, "adepthood=secret123")
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, f"adepthood={_STRONG_TOKEN}")
     _stub_build_server(monkeypatch)
     cert = tmp_path / "cert.pem"
     cert.write_text("dummy-cert")  # fixture material, not a real credential
@@ -619,7 +679,7 @@ def test_network_transport_rejects_missing_tls_cert_file(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     """TLS flags pointing at nonexistent files exit with a 'file not found' error."""
-    monkeypatch.setenv(CONSUMER_TOKENS_ENV, "adepthood=secret123")
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, f"adepthood={_STRONG_TOKEN}")
     _stub_build_server(monkeypatch)
     missing_cert = tmp_path / "no-cert.pem"
     missing_key = tmp_path / "no-key.pem"


### PR DESCRIPTION
## Summary
- `load_consumer_tokens` now enforces a minimum-length floor (`_MIN_TOKEN_LEN = 32`, matching the `secrets.token_urlsafe(32)` recipe) on every `CREEK_MCP_CONSUMER_TOKENS` entry, raising `ValueError` that names the consumer and observed length — never the token value — and embeds the generation recipe.
- `main()`'s network branch surfaces that `ValueError` via `parser.error(...)`, so operators get a clean exit-2 message instead of a traceback; the server now fails closed on weak tokens as well as missing tokens and missing TLS.
- Docstrings (module + loader + `main()`) document the floor and the `python -c "import secrets; print(secrets.token_urlsafe(32))"` generation recipe. The constant-time `verify_token` compare and blank-entry skip semantics are unchanged; rate-limiting/lockout and secret rotation (#895) remain separately tracked.

## Test plan
- New unit tests: sub-minimum token raises with consumer name/length/minimum/recipe and never echoes the token; ≥32-char and exactly-32-char tokens accepted intact; blank/`name=` entries still skipped without raising; `main --transport network` with a short token exits 2 with the recipe on stderr and no token leak.
- Updated 7 existing tests to a 43-char `_STRONG_TOKEN` constant so they keep asserting their original behavior; `ConsumerTokenVerifier` direct-instantiation tests intentionally untouched (validation is load-time only).
- `cd creek-tools && ./scripts/check-all.sh` — 12/12 checks pass, 6021 tests green, coverage 93.89%.

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)