### PR TITLE
fix(redact): stop leaking password half of email:password combos on apply

### DIFF
--- a/creek-tools/creek/redact/redactor.py
+++ b/creek-tools/creek/redact/redactor.py
@@ -4,6 +4,12 @@ The :class:`Redactor` re-scans content to locate match positions (since
 :class:`RedactionMatch` intentionally does **not** store the matched text)
 and replaces each hit with a ``[REDACTED:type]`` marker.
 
+Replacement is a single pass over the *original* content: every in-scope
+pattern is matched against the untouched text, truly overlapping spans
+are unioned, and the merged spans are spliced out right-to-left. Because
+no pattern ever anchors on partially redacted text, a ``--scan`` finding
+cannot survive a ``--apply`` step (Issue #832).
+
 Redaction logs are written as JSON with a session salt in the header so
 that hashes can be correlated within a session but not reversed.
 """
@@ -11,10 +17,10 @@ that hashes can be correlated within a session but not reversed.
 import json
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 from creek.config import RedactionConfig
-from creek.redact.patterns import REDACTION_PATTERNS
+from creek.redact.patterns import PATTERN_METADATA, REDACTION_PATTERNS
 from creek.redact.scanner import (
     HIGH_ENTROPY_CANDIDATE,
     HIGH_ENTROPY_PATTERN_NAME,
@@ -23,6 +29,122 @@ from creek.redact.scanner import (
     post_validate,
     shannon_entropy,
 )
+
+_SEVERITY_RANKS: dict[str, int] = {
+    "critical": 0,
+    "high": 1,
+    "medium": 2,
+    "low": 3,
+}
+"""Marker-selection rank per metadata severity (lower = more severe)."""
+
+_UNKNOWN_SEVERITY_RANK: int = len(_SEVERITY_RANKS)
+"""Rank for patterns without metadata — sorts below every known severity."""
+
+
+class _Span(NamedTuple):
+    """A single pattern match located against the original content.
+
+    Attributes:
+        start: Offset of the first matched character.
+        end: Offset one past the last matched character.
+        pattern_name: The pattern key that produced the match.
+        order: Collection order, used as the final marker tie-break.
+    """
+
+    start: int
+    end: int
+    pattern_name: str
+    order: int
+
+
+class _MergedSpan(NamedTuple):
+    """A maximal union of truly overlapping match spans.
+
+    Attributes:
+        start: Offset where the merged region begins.
+        end: Offset one past the merged region's last character.
+        contributors: The individual matches folded into this region.
+    """
+
+    start: int
+    end: int
+    contributors: list[_Span]
+
+
+def _severity_rank(pattern_name: str) -> int:
+    """Rank a pattern for marker selection (lower = more severe).
+
+    Args:
+        pattern_name: The pattern key to rank.
+
+    Returns:
+        The rank of the pattern's metadata severity, or
+        :data:`_UNKNOWN_SEVERITY_RANK` when the pattern (e.g. a custom
+        one) has no metadata entry.
+    """
+    info = PATTERN_METADATA.get(pattern_name)
+    if info is None:
+        return _UNKNOWN_SEVERITY_RANK
+    return _SEVERITY_RANKS.get(info.severity, _UNKNOWN_SEVERITY_RANK)
+
+
+def _merge_spans(spans: list[_Span]) -> list[_MergedSpan]:
+    """Union truly overlapping spans into maximal merged regions.
+
+    Spans that merely touch (one starting exactly where the previous
+    ends) stay separate so adjacent distinct findings keep their own
+    markers; only genuine overlap (``start < previous end``) merges.
+
+    Args:
+        spans: Match spans collected against the original content.
+
+    Returns:
+        Non-overlapping merged spans ordered by start offset.
+    """
+    merged: list[_MergedSpan] = []
+    for span in sorted(spans, key=lambda s: s.start):
+        if merged and span.start < merged[-1].end:
+            last = merged[-1]
+            merged[-1] = _MergedSpan(
+                start=last.start,
+                end=max(last.end, span.end),
+                contributors=[*last.contributors, span],
+            )
+        else:
+            merged.append(_MergedSpan(span.start, span.end, [span]))
+    return merged
+
+
+def _select_marker_name(contributors: list[_Span]) -> str:
+    """Choose which pattern name labels a merged span's marker.
+
+    The most severe contributing pattern wins; ties fall to the widest
+    individual span, then to whichever match was collected first.
+
+    Args:
+        contributors: The matches folded into one merged span.
+
+    Returns:
+        The winning pattern name for the replacement marker.
+    """
+
+    def _key(span: _Span) -> tuple[int, int, int]:
+        """Build the sort key selecting the winning contributor via ``min``.
+
+        Args:
+            span: A contributing span to rank.
+
+        Returns:
+            Tuple of severity rank, negated width, and collection order.
+        """
+        return (
+            _severity_rank(span.pattern_name),
+            span.start - span.end,
+            span.order,
+        )
+
+    return min(contributors, key=_key).pattern_name
 
 
 class Redactor:
@@ -79,8 +201,13 @@ class Redactor:
         """Replace sensitive data in *content* with ``[REDACTED:type]`` markers.
 
         Re-scans *content* against the configured patterns (since matched
-        text is never stored in :class:`RedactionMatch`) and substitutes
-        each hit that is not on the allowlist.
+        text is never stored in :class:`RedactionMatch`) in a single pass
+        over the original text: every in-scope pattern is matched against
+        the untouched content, truly overlapping spans are unioned, and
+        each merged region is replaced by the marker of its most severe
+        contributor. This guarantees scan/apply parity — a ``--scan``
+        finding cannot survive ``--apply``, because no pattern ever
+        anchors on already-redacted text (Issue #832).
 
         Args:
             content: The text to redact.
@@ -98,13 +225,60 @@ class Redactor:
         else:
             patterns_to_use = self._patterns
 
-        for name, pattern in patterns_to_use.items():
-            marker = self.config.replacement_template.format(name=name)
-            content = self._replace_pattern(content, pattern, marker, name)
+        spans = self._collect_spans(content, patterns_to_use)
+        content = self._splice_markers(content, _merge_spans(spans))
 
         if self._should_apply_high_entropy(pattern_types):
             content = self._replace_high_entropy(content)
 
+        return content
+
+    def _collect_spans(
+        self,
+        content: str,
+        patterns: dict[str, re.Pattern[str]],
+    ) -> list[_Span]:
+        """Locate every non-allowlisted, validated match in *content*.
+
+        Args:
+            content: The original, untouched text.
+            patterns: In-scope mapping of pattern name to compiled regex.
+
+        Returns:
+            Spans for every match that survives the allowlist and the
+            pattern-specific post-validator (e.g. Luhn for
+            ``credit_card``), in collection order.
+        """
+        spans: list[_Span] = []
+        for name, pattern in patterns.items():
+            for match in pattern.finditer(content):
+                text = match.group()
+                if self._is_allowlisted(text):
+                    continue
+                if not post_validate(name, text):
+                    continue
+                spans.append(_Span(match.start(), match.end(), name, len(spans)))
+        return spans
+
+    def _splice_markers(self, content: str, merged: list[_MergedSpan]) -> str:
+        """Replace each merged span in *content* with its winning marker.
+
+        Splices right-to-left so earlier offsets stay valid while later
+        regions are rewritten.
+
+        Args:
+            content: The original text the spans were collected against.
+            merged: Non-overlapping merged spans, ordered by start.
+
+        Returns:
+            Content with every merged span replaced by a marker.
+        """
+        for span in reversed(merged):
+            marker = self.config.replacement_template.format(
+                name=_select_marker_name(span.contributors),
+            )
+            start, end = span.start, span.end
+            content = content[:start] + marker + content[end:]
         return content
 
     def _should_apply_high_entropy(
@@ -145,47 +319,6 @@ class Redactor:
             return marker
 
         return HIGH_ENTROPY_CANDIDATE.sub(_replacer, content)
-
-    def _replace_pattern(
-        self,
-        content: str,
-        pattern: re.Pattern[str],
-        marker: str,
-        pattern_name: str,
-    ) -> str:
-        """Replace all occurrences of *pattern* in *content* with *marker*.
-
-        Skips allowlisted matches and matches that fail the
-        pattern-specific post-validator (e.g. Luhn for ``credit_card``)
-        so they remain in the output.
-
-        Args:
-            content: Source text.
-            pattern: Compiled regex to search for.
-            marker: Replacement string (e.g. ``[REDACTED:ssn]``).
-            pattern_name: The pattern key, used to dispatch
-                post-validators that filter false positives.
-
-        Returns:
-            Content with non-allowlisted matches replaced.
-        """
-
-        def _replacer(m: re.Match[str]) -> str:
-            """Return the marker unless the match is allowlisted or invalid.
-
-            Args:
-                m: Regex match object.
-
-            Returns:
-                The marker string or the original match text.
-            """
-            if self._is_allowlisted(m.group()):
-                return m.group()
-            if not post_validate(pattern_name, m.group()):
-                return m.group()
-            return marker
-
-        return pattern.sub(_replacer, content)
 
     def log_redactions(
         self,

--- a/creek-tools/tests/test_redact.py
+++ b/creek-tools/tests/test_redact.py
@@ -2186,3 +2186,127 @@ class TestHighEntropyRegexSourceOfTruth:
         from creek.redact.scanner import HIGH_ENTROPY_CANDIDATE
 
         assert HIGH_ENTROPY_CANDIDATE is PATTERN_METADATA["high_entropy_string"].pattern
+
+
+# ---------------------------------------------------------------------------
+# Sequential pattern-order redaction leaks (Issue #832)
+# ---------------------------------------------------------------------------
+
+
+class TestPatternOrderLeak:
+    """Overlapping matches must all be redacted from ORIGINAL content (Issue #832).
+
+    ``Redactor.redact_content`` applies patterns sequentially and mutates
+    the content in place, so an earlier pattern (``email``) can destroy
+    the text a later, higher-severity pattern (``email_password_combo``)
+    needs to match — leaving the password half in cleartext. These tests
+    pin the required behavior: every match found against the original
+    content must be redacted in the output, with no cleartext gaps.
+    """
+
+    def test_email_password_combo_password_not_leaked_on_apply(self) -> None:
+        """The password half of an email:password combo must never survive."""
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        content = "login user@example.com:hunter2secret here"
+        result = redactor.redact_content(content)
+
+        assert "hunter2secret" not in result
+        assert "user@example.com" not in result
+
+    def test_email_password_combo_uses_combo_marker(self) -> None:
+        """An email:password combo should carry the combo marker, not email's."""
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        content = "login user@example.com:hunter2secret here"
+        result = redactor.redact_content(content)
+
+        assert "[REDACTED:email_password_combo]" in result
+        assert "[REDACTED:email]:hunter2secret" not in result
+
+    def test_apply_removes_every_scan_finding_parity(self, tmp_path: Path) -> None:
+        """Every finding reported by a scan must be removed by an apply."""
+        content = (
+            "creds user@example.com:hunter2secret\n"
+            "contact other@example.com\n"
+            "ssn 123-45-6789\n"
+        )
+        test_file = tmp_path / "leaks.txt"
+        test_file.write_text(content)
+
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        matches = scanner.scan_file(test_file)
+        match_types = {match.match_type for match in matches}
+        assert "email_password_combo" in match_types
+
+        redactor = Redactor(config=config, salt=scanner.salt)
+        result = redactor.redact_content(content)
+
+        assert "hunter2secret" not in result
+        assert "user@example.com" not in result
+        assert "other@example.com" not in result
+        assert "123-45-6789" not in result
+
+    def test_standalone_email_still_marked_email(self) -> None:
+        """A bare email with no password suffix keeps the email marker."""
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        content = "contact test@example.com"
+        result = redactor.redact_content(content)
+
+        assert "test@example.com" not in result
+        assert "[REDACTED:email]" in result
+
+    def test_allowlisted_email_inside_combo_still_redacts_password(self) -> None:
+        """Allowlisting the bare email must not spare the combo's password."""
+        config = RedactionConfig(
+            false_positive_allowlist=["user@example.com"],
+        )
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        content = "user@example.com:hunter2secret"
+        result = redactor.redact_content(content)
+
+        assert "hunter2secret" not in result
+
+    def test_custom_composite_pattern_not_leaked(self) -> None:
+        """A custom composite pattern must redact despite built-in overlap."""
+        combo_re = r"\b[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}::[^\s]+"
+        config = RedactionConfig(
+            custom_patterns={"email_token_combo": combo_re},
+        )
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        content = "user@example.com::tok_supersecret99"
+        result = redactor.redact_content(content)
+
+        assert "tok_supersecret99" not in result
+
+    def test_partial_overlap_union_redacted(self) -> None:
+        """Partially overlapping matches must be redacted as one full union."""
+        config = RedactionConfig(
+            custom_patterns={"tail_secret": r"com hunter[^\s]+"},
+        )
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        # Against the ORIGINAL content, `email` matches [0:16)
+        # ("user@example.com") and `tail_secret` matches [13:30)
+        # ("com hunter2secret") — a genuine partial, non-containment
+        # overlap on "com". No fragment of either match may survive.
+        content = "user@example.com hunter2secret"
+        result = redactor.redact_content(content)
+
+        assert "user@example.com" not in result
+        assert "hunter2secret" not in result
+        assert "example" not in result
+        assert "hunter" not in result


### PR DESCRIPTION
## Summary
- Fixes a P1 privacy bug: `Redactor.redact_content` applied patterns sequentially with in-place mutation, so the `email` pattern destroyed the anchor of the critical `email_password_combo` pattern and the password half of `user@example.com:hunter2secret` survived `--apply` in cleartext (while `--scan` correctly flagged it).
- Rewrites the replacement loop as a span-based single pass over the original content: collect spans from every in-scope pattern (allowlist + `post_validate` filtered), merge truly overlapping spans into unions, label each union with its highest-severity contributor (tie: widest span, then collection order), splice right-to-left. The high-entropy detector stays an unchanged second pass. Scan/apply parity is now a structural invariant — including for custom composite patterns, which reordering `PATTERN_METADATA` could never protect.
- Public API unchanged; `patterns.py`, `scanner.py`, and the CLI/file layers untouched; the removed `_replace_pattern` had no remaining references.

## Test plan
- New `TestPatternOrderLeak` class (7 tests) written RED-first: 5 failed at HEAD (password leak, combo marker, scan/apply parity, custom composite leak, partial-overlap union), 2 regression guards (standalone email marker, allowlisted-email-inside-combo). All green after the fix.
- All 260 redaction tests pass (`test_redact.py`, `test_properties_redaction.py`, `test_cli_redact.py`, `test_mcp_redact.py`, `test_redact_audit.py`).
- `cd creek-tools && ./scripts/check-all.sh` exits 0 (6028 tests; coverage, per-file, docstring, complexity, mypy strict, ruff all green).
- Security-specialist review of the rewritten pipeline: CLEAN; three minor pre-existing advisories filed as follow-ups #899, #900, #901.

Closes #832