### PR TITLE
fix(purge): scrub heading-suffixed wikilinks on fragment purge

### DIFF
--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -1219,7 +1219,12 @@ def _build_source_path_matcher(
 
 
 def _build_wikilink_pattern(title: str) -> re.Pattern[str]:
-    """Build a regex matching ``[[title]]`` and ``[[title|alias]]``.
+    """Build a regex matching every wikilink form targeting ``title``.
+
+    Matches ``[[title]]`` and ``[[title|alias]]``, plus heading
+    (``[[title#Heading]]``), block-reference (``[[title#^id]]``), and
+    heading+alias (``[[title#Heading|alias]]``) variants, so a purge
+    removes all links that leak the title.
 
     Args:
         title: The target title to match exactly.
@@ -1228,7 +1233,7 @@ def _build_wikilink_pattern(title: str) -> re.Pattern[str]:
         A compiled regex pattern.
     """
     escaped = re.escape(title)
-    return re.compile(rf"\[\[{escaped}(?:\|[^\]]*)?\]\]")
+    return re.compile(rf"\[\[{escaped}(?:#[^\]|]*)?(?:\|[^\]]*)?\]\]")
 
 
 def _build_provenance_pattern(fragment_id: str) -> re.Pattern[str]:

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -289,6 +289,73 @@ def test_fragment_purge_removes_wikilinks(tmp_path: Path) -> None:
     assert "[[Beta]]" in post.content
 
 
+@pytest.mark.parametrize(
+    "link",
+    [
+        "[[Alpha#Heading]]",
+        "[[Alpha#Heading|alias]]",
+        "[[Alpha#^blk01]]",
+        "[[Alpha#]]",
+    ],
+)
+def test_fragment_purge_removes_heading_wikilinks(tmp_path: Path, link: str) -> None:
+    """Heading/block-suffixed wiki-links to the purged title are scrubbed (#833)."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    linker = _write_fragment(vault, "frag-B", "Beta", body=f"See {link} today.")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-A")
+
+    assert result.wikilinks_removed == 1
+    post = frontmatter.load(str(linker))
+    assert link not in post.content
+    assert "Alpha" not in post.content
+
+
+def test_fragment_purge_removes_all_wikilink_variants(tmp_path: Path) -> None:
+    """A mixed body loses every Alpha link variant while [[Beta]] survives (#833)."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    linker = _write_fragment(
+        vault,
+        "frag-B",
+        "Beta",
+        body=(
+            "See [[Alpha]] and [[Alpha|a]] and [[Alpha#H]] "
+            "and [[Alpha#H|a]] and [[Beta]]."
+        ),
+    )
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-A")
+
+    assert result.wikilinks_removed == 4
+    post = frontmatter.load(str(linker))
+    assert "Alpha" not in post.content
+    assert "[[Beta]]" in post.content
+
+
+def test_fragment_purge_leaves_prefix_titled_wikilinks(tmp_path: Path) -> None:
+    """Links to a longer title sharing the purged prefix are untouched (#833)."""
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    linker = _write_fragment(
+        vault,
+        "frag-B",
+        "Beta",
+        body="See [[AlphaBeta]] and [[AlphaBeta#H]].",
+    )
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-A")
+
+    assert result.wikilinks_removed == 0
+    post = frontmatter.load(str(linker))
+    assert "[[AlphaBeta]]" in post.content
+    assert "[[AlphaBeta#H]]" in post.content
+
+
 def test_fragment_purge_decrements_thread_counts(tmp_path: Path) -> None:
     """Threads referenced in the fragment have fragment_count decremented."""
     vault = _make_vault(tmp_path)


### PR DESCRIPTION
## Summary
- `_build_wikilink_pattern` now accepts an optional heading/block-reference segment, so `[[Title#Heading]]`, `[[Title#^id]]`, `[[Title#Heading|alias]]`, and `[[Title#]]` wikilinks are scrubbed on purge instead of leaking the purged title (RTBF gap), and `PurgeResult.wikilinks_removed` counts them correctly.
- The fix lands at the single pattern chokepoint shared by both purge entry points (`purge_fragment` and `_purge_single`), so every purge path is covered; a regression guard pins that prefix titles (`[[AlphaBeta]]`, `[[AlphaBeta#H]]`) are still untouched when purging "Alpha".
- Security leak-vector review of the purge path came back clean in scope; the pre-existing case-fold variant leak was filed separately as #903 (out of scope here, as are #845 and #835).

## Test plan
- TDD: added `test_fragment_purge_removes_heading_wikilinks` (4 parametrized variants), `test_fragment_purge_removes_all_wikilink_variants` (mixed body, count == 4, `[[Beta]]` survives), and `test_fragment_purge_leaves_prefix_titled_wikilinks` — the leak tests failed RED against the old pattern, then went GREEN with the fix.
- `cd creek-tools && ./scripts/check-all.sh` → exit 0 (12/12 checks; 6034 tests passed, coverage 93.90%, per-file gate green).

Closes #833