### PR TITLE
fix(clean): stop broken-link false positives on heading-anchor links

### DIFF
--- a/creek-tools/creek/clean/hygiene.py
+++ b/creek-tools/creek/clean/hygiene.py
@@ -143,9 +143,14 @@ def _parse_datetime(value: object) -> datetime | None:
 
 
 _WIKILINK_PATTERN: re.Pattern[str] = re.compile(
-    r"\[\[([^\]|]+?)(?:\|[^\]]+?)?\]\]",
+    r"\[\[([^\]|#]+?)(?:[#|][^\]]*?)?\]\]",
 )
-"""Matches Obsidian wiki-links like ``[[Target]]`` or ``[[Target|Alias]]``."""
+"""Matches Obsidian wiki-links, capturing only the file portion of the target.
+
+Heading anchors (``[[Note#Heading]]``) and aliases (``[[Note|alias]]``) are
+excluded from the captured target, and same-file anchors (``[[#Heading]]``)
+produce no target at all — they name no file to resolve (issue #835).
+"""
 
 _RELATIVE_LINK_PATTERN: re.Pattern[str] = re.compile(
     r"\[([^\]]*)\]\((?!#)([^)]+)\)",
@@ -191,11 +196,15 @@ def _list_all_md_files(vault_path: Path) -> list[Path]:
 def _extract_wikilinks(content: str) -> list[str]:
     """Extract wiki-link targets from markdown content.
 
+    Targets are the file portions only: heading anchors and aliases are
+    stripped by the pattern, and same-file anchor links (``[[#Heading]]``)
+    yield no target (issue #835).
+
     Args:
         content: Raw markdown text.
 
     Returns:
-        List of wiki-link target strings.
+        List of wiki-link target strings (file portions only).
     """
     return _WIKILINK_PATTERN.findall(content)
 
@@ -220,21 +229,27 @@ def _extract_relative_links(content: str) -> list[str]:
     """Extract relative (local file) link targets from markdown content.
 
     The raw target captured by the pattern may carry an optional title
-    suffix (``path "title"``); only the URL portion is considered. External
-    targets (URLs with a scheme, or protocol-relative ``//host`` targets)
-    are excluded, since they are not local file references.
+    suffix (``path "title"``); only the URL portion is considered. Anchor
+    (``#section``) and query (``?raw=1``) suffixes are stripped — Obsidian
+    links like ``[text](file.md#section)`` target the file portion — and a
+    target that is empty after stripping names no file, so it is skipped
+    (issue #835). External targets (URLs with a scheme, or protocol-relative
+    ``//host`` targets) are excluded, since they are not local file
+    references.
 
     Args:
         content: Raw markdown text.
 
     Returns:
-        List of relative link target strings, with external URLs removed.
+        List of relative link target strings (file portions only), with
+        external URLs removed.
     """
     targets: list[str] = []
     for match in _RELATIVE_LINK_PATTERN.findall(content):
         # A markdown link target may be ``path "optional title"``; the URL
-        # is the first whitespace-delimited token.
+        # is the first whitespace-delimited token, cut at any anchor/query.
         target = match[1].strip().split(maxsplit=1)[0] if match[1].strip() else ""
+        target = target.partition("#")[0].partition("?")[0]
         if not target or _is_external_target(target):
             continue
         targets.append(target)

--- a/creek-tools/tests/test_hygiene.py
+++ b/creek-tools/tests/test_hygiene.py
@@ -199,6 +199,26 @@ class TestOrphanScanner:
         result_loose = scanner_loose.scan(vault)
         assert len(result_loose.orphan_paths) == 0
 
+    def test_anchor_wikilink_counts_in_link_graph(self, tmp_path: Path) -> None:
+        """An anchor wikilink connects both endpoints in the link graph (#835).
+
+        Fragment ``a`` links to ``b`` only via ``[[b#Section]]``; the anchor
+        must not hide the connection, so ``a`` has an outgoing link and ``b``
+        has an incoming link — neither is an orphan.
+        """
+        vault = _make_vault(tmp_path)
+        old = datetime.now(tz=UTC) - timedelta(days=60)
+        _write_fragment(vault, "b", created=old)
+        _write_fragment(
+            vault,
+            "a",
+            content="See [[b#Section]] for context.",
+            created=old,
+        )
+        scanner = OrphanScanner(age_days=30)
+        result = scanner.scan(vault)
+        assert result.orphan_paths == []
+
 
 # ---------------------------------------------------------------------------
 # StaleReviewScanner tests
@@ -415,6 +435,54 @@ class TestBrokenLinkScanner:
         # Must not raise; the unresolvable target is treated as not-a-file.
         assert result.total_broken == 0
 
+    def test_heading_anchor_wikilink_not_broken(self, tmp_path: Path) -> None:
+        """A ``[[b#Section]]`` link to an existing file is not broken (#835)."""
+        vault = _make_vault(tmp_path)
+        _write_fragment(vault, "b", content="Target with a heading.")
+        _write_fragment(vault, "a", content="See [[b#Section]] for details.")
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        assert result.total_broken == 0
+
+    def test_same_file_anchor_wikilink_not_broken(self, tmp_path: Path) -> None:
+        """A same-file anchor link like ``[[#Heading]]`` is not broken (#835)."""
+        vault = _make_vault(tmp_path)
+        _write_fragment(vault, "self-anchor", content="Jump to [[#Heading]] above.")
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        assert result.total_broken == 0
+
+    def test_heading_anchor_wikilink_with_alias_not_broken(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A ``[[b#Section|display]]`` link to an existing file is not broken (#835)."""
+        vault = _make_vault(tmp_path)
+        _write_fragment(vault, "b", content="Target with a heading.")
+        _write_fragment(vault, "a", content="See [[b#Section|display]] here.")
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        assert result.total_broken == 0
+
+    def test_relative_link_with_anchor_not_broken(self, tmp_path: Path) -> None:
+        """A relative link with a heading anchor to an existing file is fine (#835)."""
+        vault = _make_vault(tmp_path)
+        _write_fragment(vault, "b", content="Target content.")
+        _write_fragment(vault, "a", content="See [text](b.md#Section) for more.")
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        assert result.total_broken == 0
+
+    def test_missing_target_with_anchor_still_broken(self, tmp_path: Path) -> None:
+        """A ``[[missing#Section]]`` link to no file reports ``[[missing]]`` (#835)."""
+        vault = _make_vault(tmp_path)
+        _write_fragment(vault, "a", content="See [[missing#Section]] here.")
+        scanner = BrokenLinkScanner()
+        result = scanner.scan(vault)
+        assert result.total_broken == 1
+        broken_targets = next(iter(result.broken_links.values()))
+        assert broken_targets == ["[[missing]]"]
+
 
 # ---------------------------------------------------------------------------
 # DuplicateScanner tests
@@ -625,3 +693,30 @@ class TestLinkExtraction:
 
         content = "[x]( https://example.com/y)"
         assert _extract_relative_links(content) == []
+
+    def test_extract_wikilinks_strips_heading_anchor(self) -> None:
+        """Heading anchors are stripped from wiki-link targets (#835).
+
+        ``[[b#Section]]`` yields ``b``, ``[[Note#H|alias]]`` yields ``Note``,
+        and a same-file anchor like ``[[#Self]]`` yields no target at all.
+        """
+        from creek.clean.hygiene import _extract_wikilinks
+
+        content = "See [[b#Section]] and [[Note#H|alias]] and [[#Self]]."
+        assert _extract_wikilinks(content) == ["b", "Note"]
+        # A '#' inside the alias (after the pipe) must not affect the target,
+        # and a nested heading path keeps only the file portion.
+        assert _extract_wikilinks("[[Target|Display#thing]]") == ["Target"]
+        assert _extract_wikilinks("[[Note#H1#H2]]") == ["Note"]
+
+    def test_extract_relative_links_strips_anchor_and_query(self) -> None:
+        """Anchor and query suffixes are stripped from relative targets (#835).
+
+        The URL token is cut at the first ``#`` or ``?``; a target that is
+        empty after stripping (query-only) is skipped entirely.
+        """
+        from creek.clean.hygiene import _extract_relative_links
+
+        content = "[x](b.md#Section) and [y](c.md?raw=1)"
+        assert _extract_relative_links(content) == ["b.md", "c.md"]
+        assert _extract_relative_links("[q](?query)") == []


### PR DESCRIPTION
## Summary
- `_WIKILINK_PATTERN` in `creek/clean/hygiene.py` now excludes `#` from the captured target (byte-identical to the proven pattern in `creek/lint/checks/orphan_compiled.py`), so `[[Note#Heading]]` / `[[Note#H|alias]]` resolve to `Note` and same-file anchors (`[[#Heading]]`) yield no target — no more false "broken" reports for valid Obsidian anchor links.
- `_extract_relative_links` strips the URL token at the first `#`/`?` before the empty/external checks, so `[text](file.md#section)` resolves `file.md` and query-only targets are skipped; broken targets are now reported in stripped form (`[[missing]]`, `missing.md`).
- Side benefit via the shared helper: `OrphanScanner`'s link graph now counts anchored links as edges for both endpoints, so a fragment whose only connection is `[[b#Section]]` is no longer misreported as an orphan.

## Test plan
- TDD: 8 new tests (RED-verified before the fix, all referencing #835) across `TestBrokenLinkScanner` (anchor/alias/same-file/relative-anchor not broken; `[[missing#Section]]` still broken and reported as `[[missing]]`), `TestLinkExtraction` (anchor/query stripping, hash-inside-alias, nested `#H1#H2` heading paths), and `TestOrphanScanner` (anchored link counts in the graph).
- `cd creek-tools && ./scripts/check-all.sh` → 12/12 checks passed, 6048 tests green, coverage 93.90% (branch), per-file gate green.

## Possible follow-up (not implemented, out of scope)
- Heading-aware validation: verify the `#Heading` actually exists in the target note. Cheap to bolt onto the scanner later, but it changes the check's cost profile (reading target files), so it is left as a follow-up.
- `creek/generate/state.py:133` carries its own anchor-naive copy of the wikilink pattern (different consumer, eddy-field rendering, no false-positive path found); candidate for a shared-constant de-dup if a third consumer appears.

Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)