### PR TITLE
fix(purge): remove staged journal entry body on fragment and vault purge

### DIFF
--- a/creek-tools/creek/ingest/journal_staging.py
+++ b/creek-tools/creek/ingest/journal_staging.py
@@ -1,0 +1,28 @@
+"""Single source of truth for the Adepthood journal staging directory (#845).
+
+The ``creek.journal`` MCP tool (``creek_mcp/tools/journal.py``) stages each
+Adepthood entry's full body as a markdown file under this vault-relative
+directory so the ledger-backed markdown ingest picks it up, and the purge
+engine (``creek/purge/engine.py``) follows a purged fragment's
+``source.origin_key`` back here to delete that staged plaintext — the RTBF
+sweep is scoped to exactly this directory. Both sides import the constant
+from this module so the two paths can never silently drift apart; it lives
+on the ``creek`` side because the layering rule is that ``creek_mcp``
+imports ``creek``, never the reverse.
+
+Relocating this path is a breaking change: the source ledger keys staged
+entries by it, so a move without a ledger migration would orphan every
+existing staged entry.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+JOURNAL_STAGING_RELDIR = Path("00-Creek-Meta/adepthood/journal")
+"""Vault-relative staging dir for Adepthood journal entry bodies.
+
+The ``journal`` path segment makes the markdown ingestor classify staged
+entries as ``SourcePlatform.JOURNAL``; the ``adepthood`` segment identifies
+the source in each fragment's ``source.origin_key``.
+"""

--- a/creek-tools/creek/purge/audit.py
+++ b/creek-tools/creek/purge/audit.py
@@ -89,6 +89,12 @@ class PurgeAuditEntry(BaseModel):
             ``saved_from.intimate_body_pointer`` (GAP-012). Zero for
             notes that carry no pointer, dry-runs count what *would* be
             removed, and an already-missing stub does not increment it.
+        journal_staged_removed: Number of staged journal source files
+            deleted under ``00-Creek-Meta/adepthood/journal/`` because
+            the fragment they produced was purged, or because a
+            whole-vault purge swept the staging dir (issue #845). Zero
+            for fragments with no ``source.origin_key``; dry-runs count
+            what *would* be removed.
         operator: Who performed the purge.
         dry_run: Whether the purge was a dry-run preview.
         phase: GAP-002 discriminator. ``"intent"`` is written before
@@ -119,6 +125,7 @@ class PurgeAuditEntry(BaseModel):
     embeddings_removed: int = 0
     provenance_scrubbed: int = 0
     intimate_stubs_removed: int = 0
+    journal_staged_removed: int = 0
     operator: str = _DEFAULT_OPERATOR
     dry_run: bool = False
 
@@ -152,6 +159,7 @@ def _coerce_legacy_entry(raw: dict[str, Any]) -> dict[str, Any]:
     upgraded.setdefault("embeddings_removed", 0)
     upgraded.setdefault("provenance_scrubbed", 0)
     upgraded.setdefault("intimate_stubs_removed", 0)
+    upgraded.setdefault("journal_staged_removed", 0)
     # GAP-002 fields take their schema defaults via Pydantic when
     # absent, so we leave them out here rather than fabricating a
     # phase / operation_id that doesn't correspond to anything on disk.
@@ -320,6 +328,7 @@ class PurgeAuditLog:
             "embeddings_removed": 0,
             "provenance_scrubbed": 0,
             "intimate_stubs_removed": 0,
+            "journal_staged_removed": 0,
             "operator": "system",
             "dry_run": False,
             "migrated_entries": migrated_count,

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING
 import frontmatter
 from pydantic import BaseModel, Field
 
+from creek.ingest.journal_staging import JOURNAL_STAGING_RELDIR
 from creek.purge.audit import PurgeAuditEntry, PurgeAuditLog, PurgeOutcomeStatus
 
 if TYPE_CHECKING:
@@ -168,6 +169,12 @@ class PurgeResult(BaseModel):
             deleted under ``10-Liminal/Compost/intimate-stubs/`` because
             a purged note carried a ``saved_from.intimate_body_pointer``
             at them (GAP-012). Counted-only in a dry run.
+        journal_staged_removed: Number of staged journal source files
+            deleted under ``00-Creek-Meta/adepthood/journal/`` because
+            the fragment they produced was purged (issue #845). The
+            staged file holds the entry's full plaintext body, so
+            leaving it behind would defeat the RTBF request.
+            Counted-only in a dry run.
     """
 
     operation: str
@@ -184,6 +191,7 @@ class PurgeResult(BaseModel):
     embeddings_removed: int = 0
     provenance_scrubbed: int = 0
     intimate_stubs_removed: int = 0
+    journal_staged_removed: int = 0
 
 
 class PurgeEngine:
@@ -262,6 +270,7 @@ class PurgeEngine:
                 eddy_ids,
             )
             self._purge_intimate_stub(post, result)
+            self._purge_journal_staged_entry(post, result)
             if not self.dry_run:
                 frag_file.unlink()
             result.embeddings_removed = self._purge_cache_for(
@@ -502,6 +511,7 @@ class PurgeEngine:
                     continue
                 self._wipe_folder_contents(folder_path, result)
             result.fragments_affected = len(result.deleted_files)
+            self._wipe_journal_staging(result)
             result.embeddings_removed = self._delete_cache_file()
 
         return self._run_audited(result, body)
@@ -619,6 +629,7 @@ class PurgeEngine:
             eddy_ids,
         )
         self._purge_intimate_stub(post, result)
+        self._purge_journal_staged_entry(post, result)
         if not self.dry_run:
             frag_file.unlink()
 
@@ -686,6 +697,88 @@ class PurgeEngine:
         if isinstance(pointer, str) and pointer.strip():
             return pointer
         return None
+
+    def _purge_journal_staged_entry(
+        self,
+        post: frontmatter.Post,
+        result: PurgeResult,
+    ) -> None:
+        """Sweep the staged journal body a purged fragment points at (#845).
+
+        ``creek.journal`` (the MCP tool) stages each Adepthood entry's
+        full body as a markdown file under
+        ``00-Creek-Meta/adepthood/journal/`` and records that
+        vault-relative path in the fragment's ``source.origin_key``. A
+        scoped purge that deletes the fragment must follow that key and
+        delete the staged file too, or the full — often intimate —
+        entry body survives the right-to-be-forgotten request.
+
+        The method is defensive, mirroring :meth:`_purge_intimate_stub`:
+        a missing or empty key, an already-deleted staged file, and a
+        key that resolves outside the vault root are all no-ops rather
+        than errors. A second containment guard additionally scopes
+        deletion to the staging directory itself, so a hand-edited or
+        malicious ``origin_key`` (``../x``, ``01-Fragments/other.md``)
+        can never steer a delete at an arbitrary vault file.
+
+        Args:
+            post: Frontmatter of the fragment being purged.
+            result: Result accumulator; ``journal_staged_removed`` is
+                incremented for each staged file actually removed (or
+                that would be removed in a dry run).
+        """
+        origin_key = _extract_source_origin_key(post)
+        if not origin_key:
+            return
+        staged_path = (self.vault_path / origin_key).resolve()
+        vault_root = self.vault_path.resolve()
+        if not staged_path.is_relative_to(vault_root):
+            logger.warning(
+                "Ignoring source.origin_key %r that resolves outside the vault root %s",
+                origin_key,
+                vault_root,
+            )
+            return
+        staging_root = (self.vault_path / JOURNAL_STAGING_RELDIR).resolve()
+        if not staged_path.is_relative_to(staging_root):
+            logger.warning(
+                "Ignoring source.origin_key %r that resolves outside "
+                "the journal staging dir %s",
+                origin_key,
+                staging_root,
+            )
+            return
+        if not staged_path.is_file():
+            return
+        result.journal_staged_removed += 1
+        if not self.dry_run:
+            staged_path.unlink(missing_ok=True)
+
+    def _wipe_journal_staging(self, result: PurgeResult) -> None:
+        """Wipe every staged journal entry body during a vault purge (#845).
+
+        ``purge_vault`` deliberately preserves ``00-Creek-Meta/``
+        (config marker, audit log), so the content-folder wipe never
+        reaches the staged journal bodies under
+        ``00-Creek-Meta/adepthood/journal/`` — they must be swept
+        explicitly or full entry plaintext survives a whole-vault RTBF
+        request. Staged files are source material, not fragments, so
+        they are counted on ``journal_staged_removed`` only — never
+        appended to ``deleted_files`` and never inflating
+        ``fragments_affected``.
+
+        Args:
+            result: Result accumulator; ``journal_staged_removed`` is
+                incremented per staged file removed (or counted-only in
+                a dry run).
+        """
+        staging_dir = self.vault_path / JOURNAL_STAGING_RELDIR
+        if not staging_dir.is_dir():
+            return
+        for staged_file in sorted(staging_dir.iterdir()):
+            result.journal_staged_removed += 1
+            if not self.dry_run:
+                staged_file.unlink()
 
     def _find_fragment_by_id(
         self,
@@ -1071,6 +1164,7 @@ class PurgeEngine:
             embeddings_removed=result.embeddings_removed,
             provenance_scrubbed=result.provenance_scrubbed,
             intimate_stubs_removed=result.intimate_stubs_removed,
+            journal_staged_removed=result.journal_staged_removed,
             dry_run=result.dry_run,
             phase="outcome",
             operation_id=operation_id,
@@ -1165,6 +1259,26 @@ def _extract_source_original_file(post: frontmatter.Post) -> str | None:
     if isinstance(source, dict):
         original = source.get("original_file")
         return str(original) if original is not None else None
+    return None
+
+
+def _extract_source_origin_key(post: frontmatter.Post) -> str | None:
+    """Extract the ``source.origin_key`` string from frontmatter (#845).
+
+    ``origin_key`` is the vault-relative source-ledger key the ingest
+    pipeline records on each fragment; for journal fragments it names
+    the staged full-body file under ``00-Creek-Meta/adepthood/journal/``.
+
+    Args:
+        post: Parsed frontmatter post.
+
+    Returns:
+        The origin key, or ``None`` when missing.
+    """
+    source = post.get("source")
+    if isinstance(source, dict):
+        origin_key = source.get("origin_key")
+        return str(origin_key) if origin_key is not None else None
     return None
 
 

--- a/creek-tools/creek_mcp/tools/journal.py
+++ b/creek-tools/creek_mcp/tools/journal.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any
 
 import frontmatter
 
+from creek.ingest.journal_staging import JOURNAL_STAGING_RELDIR
 from creek.ingest.markdown import MarkdownIngestor
 from creek.ingest.pipeline import derive_source_key, ledger_for_source, run_ingest
 from creek.models import PrivacyTier
@@ -46,10 +47,10 @@ if TYPE_CHECKING:
 
 TOOL_NAME = "creek.journal"
 _SOURCE_TYPE = "markdown"
-# A stable per-vault home for staged Adepthood entries. The ``journal`` segment
-# makes the markdown ingestor classify them as SourcePlatform.JOURNAL; the
-# ``adepthood`` segment identifies the source in each fragment's origin_key.
-_JOURNAL_INBOX = Path("00-Creek-Meta/adepthood/journal")
+# A stable per-vault home for staged Adepthood entries — the shared constant
+# keeps this tool and the purge engine's RTBF staged-entry sweep pointed at
+# the same directory (#845). Aliased so the rest of the module reads unchanged.
+_JOURNAL_INBOX = JOURNAL_STAGING_RELDIR
 # Where JOURNAL-platform fragments are routed by the writer — recorded as the
 # audit ``created_path`` (mirrors ingest_tool's dir-level created_path).
 _FRAGMENT_ROUTING_DIR = Path("01-Fragments/Journal")

--- a/creek-tools/tests/test_mcp_journal.py
+++ b/creek-tools/tests/test_mcp_journal.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 import frontmatter
 
+from creek.purge import PurgeEngine
 from creek_mcp.audit import MCP_AUDIT_RELPATH
 from creek_mcp.tier_ceiling import TierCeiling
 from creek_mcp.tools.journal import TOOL_NAME, journal_ingest_tool
@@ -256,3 +257,74 @@ def test_ingest_failure_is_refused_and_audited(tmp_path: Path) -> None:
     assert last["tool"] == TOOL_NAME
     assert last["args_summary"]["tier"] == "personal"
     assert last["created_tier"] == "personal"
+
+
+def test_resend_after_purge_restages_cleanly(tmp_path: Path) -> None:
+    """RTBF then re-send: purge removes the staged body; re-ingest restages (#845).
+
+    The staged plaintext under ``00-Creek-Meta/adepthood/journal/`` must
+    be gone right after the purge (the RTBF core), and re-sending the
+    SAME external id + content afterwards must land the fragment AND the
+    staged file again at their stable paths — a purge must not poison
+    the idempotency key.
+    """
+    vault = _vault(tmp_path)
+    secret = "synthetic-intimate-secret-845"
+
+    def _send() -> dict[str, object]:
+        """Ingest the same intimate entry (stable external id + content)."""
+        return journal_ingest_tool(
+            vault_path=vault,
+            content=f"a tender entry {secret}",
+            external_id="adep-845",
+            timestamp=_TS,
+            tier="intimate",
+            privacy_tier_ceiling=TierCeiling.INTIMATE,
+        )
+
+    first = _send()
+    assert first["status"] == "ok"
+    staged_dir = vault / "00-Creek-Meta" / "adepthood" / "journal"
+    staged = sorted(staged_dir.glob("*.md"))
+    assert len(staged) == 1
+    assert secret in staged[0].read_text(encoding="utf-8")
+
+    PurgeEngine(vault).purge_fragment(str(first["fragment_id"]))
+
+    # The RTBF core (#845): the staged plaintext body is gone right
+    # after the purge, before any re-send.
+    assert not staged[0].exists()
+    assert _fragments(vault) == []
+
+    resent = _send()
+    assert resent["status"] == "ok"
+    assert len(_fragments(vault)) == 1  # the fragment exists again
+    assert staged[0].exists()  # restaged at the same stable path
+
+
+def test_staging_path_unchanged(tmp_path: Path) -> None:
+    """The staging dir is pinned at ``00-Creek-Meta/adepthood/journal/`` (#845).
+
+    Regression pin: the purge engine's staging-dir containment guard
+    and the source ledger both key on this path — relocating the
+    constant without a ledger migration would orphan every existing
+    staged entry. May already pass; that is the point.
+    """
+    vault = _vault(tmp_path)
+    result = journal_ingest_tool(
+        vault_path=vault,
+        content="a steady entry",
+        external_id="adep-846",
+        timestamp=_TS,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "ok"
+    staged = sorted((vault / "00-Creek-Meta" / "adepthood" / "journal").glob("*.md"))
+    assert len(staged) == 1
+    post = _load(_fragments(vault)[0])
+    source = post.metadata["source"]
+    assert isinstance(source, dict)
+    # The ledger key recorded on the fragment names the same staging path.
+    assert str(source["origin_key"]) == (
+        f"00-Creek-Meta/adepthood/journal/{staged[0].name}"
+    )

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -582,6 +582,244 @@ def test_fragment_purge_intimate_stub_outside_vault_skipped(
 
 
 # ---------------------------------------------------------------------------
+# Engine tests — journal staged-entry sweep (#845)
+# ---------------------------------------------------------------------------
+
+_JOURNAL_STAGING_DIR = "00-Creek-Meta/adepthood/journal"
+"""Where ``journal_ingest_tool`` stages full entry bodies (the ledger key root)."""
+
+_JOURNAL_SECRET = "synthetic-intimate-secret-845"
+"""Synthetic marker standing in for intimate body content — never real data."""
+
+
+def _write_journal_fragment_with_staged(
+    vault: Path,
+    frag_id: str,
+    title: str,
+    *,
+    origin_key: str | None = None,
+    write_staged: bool = True,
+) -> tuple[Path, Path]:
+    """Write a journal fragment plus the staged plaintext entry it points at.
+
+    Mirrors what ``journal_ingest_tool`` leaves on disk (#845): the
+    fragment lands under ``01-Fragments/Journal/`` with frontmatter
+    ``source.origin_key`` naming the staged full-body markdown file
+    under ``00-Creek-Meta/adepthood/journal/``. The staged body carries
+    :data:`_JOURNAL_SECRET` so tests can assert the plaintext is really
+    gone from the vault after a purge.
+
+    Args:
+        vault: Vault root.
+        frag_id: Fragment ID for the fragment's frontmatter.
+        title: Fragment title (also the staged file's stem by default).
+        origin_key: Vault-relative pointer recorded in the fragment's
+            ``source.origin_key``. Defaults to the canonical staging
+            path for *title*.
+        write_staged: When ``False``, record the pointer but do not
+            create the staged file on disk.
+
+    Returns:
+        Tuple of ``(fragment_path, staged_path)``.
+    """
+    key = origin_key or f"{_JOURNAL_STAGING_DIR}/{title}.md"
+    staged_path = vault / key
+    if write_staged:
+        staged_path.parent.mkdir(parents=True, exist_ok=True)
+        staged_post = frontmatter.Post(
+            content=f"The full journal body. {_JOURNAL_SECRET}\n",
+            privacy_tier="intimate",
+            source_id=title,
+        )
+        staged_path.write_text(frontmatter.dumps(staged_post), encoding="utf-8")
+
+    frag_path = vault / "01-Fragments" / "Journal" / f"{title}.md"
+    frag_post = frontmatter.Post(
+        content="A journal fragment summary.\n",
+        id=frag_id,
+        title=title,
+        type="fragment",
+        source={
+            "platform": "journal",
+            "origin_key": key,
+            "original_file": str(staged_path),
+        },
+        threads=[],
+        eddies=[],
+        privacy_tier="intimate",
+    )
+    frag_path.parent.mkdir(parents=True, exist_ok=True)
+    frag_path.write_text(frontmatter.dumps(frag_post), encoding="utf-8")
+    return frag_path, staged_path
+
+
+def _vault_files_containing_secret(vault: Path) -> list[Path]:
+    """Return every vault markdown file whose text still carries the secret.
+
+    Walks the whole vault (not just ``01-Fragments``) because the RTBF
+    contract is vault-wide: after a purge, :data:`_JOURNAL_SECRET` must
+    appear in **no** file anywhere under the vault root.
+
+    Args:
+        vault: Vault root to walk.
+
+    Returns:
+        Offending paths — empty when the purge honored the RTBF request.
+    """
+    return [
+        md_file
+        for md_file in sorted(vault.rglob("*.md"))
+        if _JOURNAL_SECRET in md_file.read_text(encoding="utf-8")
+    ]
+
+
+def test_fragment_purge_removes_journal_staged_entry(tmp_path: Path) -> None:
+    """Purging a journal fragment deletes its staged plaintext body (#845)."""
+    vault = _make_vault(tmp_path)
+    frag, staged = _write_journal_fragment_with_staged(vault, "frag-J", "entry-one")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-J")
+
+    assert result.journal_staged_removed == 1
+    assert not frag.exists()
+    assert not staged.exists()
+    # The RTBF core: the intimate body survives NOWHERE under the vault.
+    assert _vault_files_containing_secret(vault) == []
+
+
+def test_source_purge_removes_journal_staged_entry(tmp_path: Path) -> None:
+    """``purge_source("journal")`` sweeps the staged entry too (#845).
+
+    Pins the ``_purge_single`` path — source-scoped purges must follow
+    ``source.origin_key`` exactly like the single-fragment path does.
+    """
+    vault = _make_vault(tmp_path)
+    _frag, staged = _write_journal_fragment_with_staged(vault, "frag-J", "entry-one")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source("journal")
+
+    assert result.fragments_affected == 1
+    assert result.journal_staged_removed == 1
+    assert not staged.exists()
+    assert _vault_files_containing_secret(vault) == []
+
+
+def test_vault_purge_removes_journal_staged_entries(tmp_path: Path) -> None:
+    """``purge_vault`` wipes the staging dir; counters stay honest (#845).
+
+    Both staged bodies must be gone and counted on
+    ``journal_staged_removed`` — but staged files are *not* fragments,
+    so ``fragments_affected`` must match a twin vault that never had
+    them.
+    """
+    vault = _make_vault(tmp_path)
+    _frag_a, staged_a = _write_journal_fragment_with_staged(
+        vault,
+        "frag-J1",
+        "entry-one",
+    )
+    _frag_b, staged_b = _write_journal_fragment_with_staged(
+        vault,
+        "frag-J2",
+        "entry-two",
+    )
+    twin = _make_vault(tmp_path / "twin")
+    for twin_id, twin_title in [("frag-J1", "entry-one"), ("frag-J2", "entry-two")]:
+        _write_journal_fragment_with_staged(
+            twin,
+            twin_id,
+            twin_title,
+            write_staged=False,
+        )
+
+    result = PurgeEngine(vault).purge_vault(VAULT_PURGE_CONFIRMATION)
+    twin_result = PurgeEngine(twin).purge_vault(VAULT_PURGE_CONFIRMATION)
+
+    assert result.journal_staged_removed == 2
+    assert not staged_a.exists()
+    assert not staged_b.exists()
+    assert _vault_files_containing_secret(vault) == []
+    # Staged files never inflate the fragment count.
+    assert result.fragments_affected == twin_result.fragments_affected
+
+
+def test_journal_staged_dry_run_preserves(tmp_path: Path) -> None:
+    """Dry-run counts the staged entry it would delete but leaves it on disk."""
+    vault = _make_vault(tmp_path)
+    frag, staged = _write_journal_fragment_with_staged(vault, "frag-J", "entry-one")
+
+    frag_result = PurgeEngine(vault, dry_run=True).purge_fragment("frag-J")
+
+    assert frag_result.journal_staged_removed == 1
+    assert frag.exists()
+    assert staged.exists()
+
+    vault_result = PurgeEngine(vault, dry_run=True).purge_vault(
+        VAULT_PURGE_CONFIRMATION,
+    )
+
+    assert vault_result.journal_staged_removed == 1
+    assert staged.exists()
+
+
+def test_journal_staged_pointer_outside_vault_skipped(tmp_path: Path) -> None:
+    """Escaping or out-of-scope ``origin_key`` pointers are never followed.
+
+    Containment is two guards (#845): the pointer must resolve inside
+    the vault root AND inside ``00-Creek-Meta/adepthood/journal/``. A
+    pointer escaping the vault and a pointer at a vault file outside
+    the staging dir must both survive, each with a zero counter.
+    """
+    vault = _make_vault(tmp_path)
+    # Variant 1: the pointer escapes the vault root entirely.
+    frag_out, outside = _write_journal_fragment_with_staged(
+        vault,
+        "frag-out",
+        "escapee",
+        origin_key="../outside-secret.md",
+    )
+
+    result_out = PurgeEngine(vault).purge_fragment("frag-out")
+
+    assert result_out.journal_staged_removed == 0
+    assert not frag_out.exists()
+    assert outside.exists()
+    assert _JOURNAL_SECRET in outside.read_text(encoding="utf-8")
+
+    # Variant 2: the pointer stays inside the vault but outside the
+    # staging dir (staging-dir scope guard).
+    frag_in, decoy = _write_journal_fragment_with_staged(
+        vault,
+        "frag-in",
+        "decoyed",
+        origin_key="01-Fragments/other.md",
+    )
+
+    result_in = PurgeEngine(vault).purge_fragment("frag-in")
+
+    assert result_in.journal_staged_removed == 0
+    assert not frag_in.exists()
+    assert decoy.exists()
+    assert _JOURNAL_SECRET in decoy.read_text(encoding="utf-8")
+
+
+def test_journal_purge_audit_records_count(tmp_path: Path) -> None:
+    """The outcome audit entry reports ``journal_staged_removed`` (#845)."""
+    vault = _make_vault(tmp_path)
+    _write_journal_fragment_with_staged(vault, "frag-J", "entry-one")
+    engine = PurgeEngine(vault)
+
+    engine.purge_fragment("frag-J")
+
+    entries = PurgeAuditLog(vault).read()
+    intent, outcome = entries
+    assert intent.journal_staged_removed == 0
+    assert outcome.journal_staged_removed == 1
+
+
+# ---------------------------------------------------------------------------
 # Engine tests — purge_source
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- RTBF gap (P1): purging a JOURNAL-platform fragment — or running `purge_vault` — left the staged plaintext entry body (including `tier=intimate` content) on disk under `00-Creek-Meta/adepthood/journal/`, because the purge engine only touches the numbered content folders and preserves `00-Creek-Meta`.
- `PurgeEngine` now follows the purged fragment's `source.origin_key` to its staged source file and unlinks it, behind a double containment guard (resolved path must be inside the vault root AND inside the journal staging dir — a `../`, absolute, symlinked, or out-of-scope pointer is a warned no-op). Wired into `purge_fragment` and the shared `_purge_single` (source / source-path / daterange); `purge_vault` sweeps the staging directory wholesale. New `journal_staged_removed` counter on `PurgeResult` and the purge audit trail; counted-only in dry runs (mirrors the GAP-012 intimate-stub pattern).
- The staging path constant moved to `creek/ingest/journal_staging.py` as the single source of truth (`creek_mcp` imports `creek`, never the reverse). Ledger keying and idempotency are untouched: a purged entry re-sent with the same external id re-stages and re-creates its fragment cleanly (pinned by test).

## Test plan
- TDD: 7 failing tests written first (fragment/source/vault purge sweeps, dry-run preservation, escape-pointer guards, audit count, resend-after-purge idempotency) plus a staging-path regression pin — all green after the fix; synthetic fixture strings only, no real intimate content.
- Live repro script confirmed the leak at HEAD (`purge_fragment` left the staged body) and confirmed zero leaked files vault-wide after the fix.
- `cd creek-tools && ./scripts/check-all.sh` → 12/12 passed (6056 tests, 93.90% branch coverage, per-file gate green).
- Security-specialist review of the deletion path: CLEAN (containment guards before unlink, symlink escape defeated by `.resolve()`, dry-run safe, no content logging, layering intact). Gate 2.5 consolidated review: CLEAN.

Closes #845

🤖 Generated with [Claude Code](https://claude.com/claude-code)