### PR TITLE
chore(ralph): route specialists to Opus 5, architect to Fable 5

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -21,12 +21,12 @@ graph under a conductor is identical:
 
 ```
 ralph-tick (fleet ORCHESTRATOR — worker pool: reconcile · serialized-merge · lazy-sync · refill)
-  └─ ralph-worker × up to 4 . L1  fable   per-issue CONDUCTOR in an isolated worktree
-       ├─ chief-architect ..... L0  opus    plan + ordered dispatch list (no code)
-       ├─ test-specialist ..... L2  fable   Gate 1 RED: failing tests          ─┐
-       ├─ implementation-spec.  L2  fable   Gate 1 GREEN + Refactor             │ run per
+  └─ ralph-worker × up to 4 . L1  opus    per-issue CONDUCTOR in an isolated worktree
+       ├─ chief-architect ..... L0  fable   plan + ordered dispatch list (no code)
+       ├─ test-specialist ..... L2  opus    Gate 1 RED: failing tests          ─┐
+       ├─ implementation-spec.  L2  opus    Gate 1 GREEN + Refactor             │ run per
        ├─ security-specialist . L2  opus    harden auth/input/paths/secrets     │ the
-       ├─ performance-spec. ... L2  fable   profile/optimize hot paths          │ architect's
+       ├─ performance-spec. ... L2  opus    profile/optimize hot paths          │ architect's
        ├─ documentation-spec. . L2  sonnet  docstrings/READMEs/ADRs             │ dispatch
        ├─ dependency-review ... L2  haiku   deps/pins/licenses (read-only)      │ list
        └─ code-review-orch. ... L1  sonnet  Gate 2.5 pre-push self-review      ─┘
@@ -62,23 +62,32 @@ specialists are leaf workers that do their own work and do not sub-delegate.
 
 ## Model tiers (strategic mix)
 
-The tiering rule is **Opus for planning, Sonnet for review, Fable for
-implementation, Haiku for quick checks.**
+The tiering rule is **Fable for planning, Opus 5 for implementation, Sonnet for
+review, Haiku for quick checks.**
 
-**Fable** for the code-writing roles — implementation is where model quality
+**Fable 5** for the one role where a better plan changes everything downstream:
+`chief-architect` (the once-per-issue design pass). Fable is ~2× Opus-tier cost
+and can run minutes-long turns — spending it once per issue on the design, and
+not on every code-writing turn, is the cheapest place to buy quality. It also
+prefers **less-prescriptive prompts** (state the goal and constraints, not
+step-by-step scaffolding), which suits a planning brief.
+
+**Fable is credit-metered and can run out.** The architect role therefore
+carries an explicit **graceful fallback: on a Fable-unavailable spawn failure,
+the conductor immediately re-spawns `chief-architect` with an
+`model: opus` override and continues the tick.** A tick never blocks, and never
+skips the planning pass, because Fable credits are exhausted. See
+[`chief-architect.md`](chief-architect.md) and `scripts/ralph/PROMPT.md` step 5.
+
+**Opus 5** for every code-writing role — implementation is where model quality
 pays off directly: `ralph-worker` (the long-horizon per-issue conductor),
 `implementation-specialist` (Gate 1 GREEN + Refactor), `test-specialist`
-(Gate 1 RED), `performance-specialist` (optimization). Fable is ~2× Opus-tier
-cost and can run minutes-long turns — worth it on the roles that produce the
-production diff. Two Fable caveats still shape the fleet: its safety
-classifiers target **cyber/bio** content (so the code-writing
-`security-specialist` stays on **Opus**, never Fable — legitimate hardening
-work can trip a false-positive refusal), and it prefers **less-prescriptive
-prompts** (state the goal and constraints, not step-by-step scaffolding).
-
-**Opus** for planning: `chief-architect` (the once-per-issue design pass) —
-plus `security-specialist`, an implementation role deliberately kept off Fable
-per the caveat above.
+(Gate 1 RED), `performance-specialist` (optimization), and
+`security-specialist`. Opus 5 is un-metered relative to Fable, so the roles that
+run many turns per tick sit here. Keeping `security-specialist` on Opus is also
+a hard requirement independent of cost: Fable's safety classifiers target
+**cyber/bio** content, and legitimate hardening work can trip a false-positive
+refusal.
 **Sonnet** for review and other well-scoped passes over bounded input:
 `code-review-orchestrator` (Gate 2.5), `documentation-specialist`.
 **Haiku** for the purely mechanical, read-only checklist walk:

--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -62,8 +62,13 @@ specialists are leaf workers that do their own work and do not sub-delegate.
 
 ## Model tiers (strategic mix)
 
-The tiering rule is **Fable for planning, Opus 5 for implementation, Sonnet for
-review, Haiku for quick checks.**
+The tiering rule is **Fable 5 for planning, Opus 5 for implementation, Sonnet 5
+for review, Haiku 4.5 for quick checks.**
+
+> Prose names the model *family generation*; the `model:` frontmatter takes the
+> unversioned **alias** (`fable`/`opus`/`sonnet`/`haiku`), which always resolves
+> to the current model in that family. Keep the aliases in frontmatter — pinning
+> a dated ID there would rot.
 
 **Fable 5** for the one role where a better plan changes everything downstream:
 `chief-architect` (the once-per-issue design pass). Fable is ~2× Opus-tier cost
@@ -74,7 +79,7 @@ step-by-step scaffolding), which suits a planning brief.
 
 **Fable is credit-metered and can run out.** The architect role therefore
 carries an explicit **graceful fallback: on a Fable-unavailable spawn failure,
-the conductor immediately re-spawns `chief-architect` with an
+the conductor immediately re-spawns `chief-architect` with a
 `model: opus` override and continues the tick.** A tick never blocks, and never
 skips the planning pass, because Fable credits are exhausted. See
 [`chief-architect.md`](chief-architect.md) and `scripts/ralph/PROMPT.md` step 5.

--- a/.claude/agents/chief-architect.md
+++ b/.claude/agents/chief-architect.md
@@ -4,7 +4,7 @@ description: "Strategic brain of a Ralph tick. Select to architect a single back
 level: 0
 phase: Plan
 tools: Read,Grep,Glob,Task
-model: opus
+model: fable
 delegates_to: [test-specialist, implementation-specialist, security-specialist, performance-specialist, documentation-specialist, dependency-review-specialist, code-review-orchestrator]
 receives_from: []
 ---
@@ -18,6 +18,13 @@ backlog issue, you decide *how* it should be built and *who* should build it,
 then hand a concrete plan back to the conductor (`scripts/ralph/PROMPT.md`, run by
 `.claude/commands/ralph-tick.md`). You do **not** write code, tests, or docs —
 you read, reason, and dispatch.
+
+> **Model tier.** This role runs on **Fable 5** — the one place the fleet spends
+> the metered tier, because a better plan compounds across every specialist that
+> executes it. Fable credits can run out. When they do, the conductor re-spawns
+> this agent with a `model: opus` override (see `scripts/ralph/PROMPT.md` step 5);
+> the plan is still produced, and this contract is unchanged either way. Never
+> let the conductor skip the planning pass to route around an exhausted tier.
 
 ## Scope
 

--- a/.claude/agents/implementation-specialist.md
+++ b/.claude/agents/implementation-specialist.md
@@ -4,7 +4,7 @@ description: "Gate 1 GREEN + Refactor — writes the production code that makes 
 level: 2
 phase: Implementation,Cleanup
 tools: Read,Write,Edit,Grep,Glob
-model: fable
+model: opus
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
 ---
@@ -16,7 +16,7 @@ Level 2 leaf worker who owns **Gate 1 GREEN** and the **Refactor** step: write t
 smallest, cleanest production code that makes the test-specialist's failing tests
 pass while meeting every threshold, then refactor for clarity without breaking
 green. You are the primary lever on "best code possible," so the work runs on
-Fable. You also serve as the **correctness/maintainability reviewer**.
+Opus 5. You also serve as the **correctness/maintainability reviewer**.
 
 ## Scope
 

--- a/.claude/agents/performance-specialist.md
+++ b/.claude/agents/performance-specialist.md
@@ -4,7 +4,7 @@ description: "Profiles and optimizes performance-sensitive code — O(n²) pairw
 level: 2
 phase: Implementation,Cleanup
 tools: Read,Write,Edit,Grep,Glob
-model: fable
+model: opus
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
 ---

--- a/.claude/agents/ralph-worker.md
+++ b/.claude/agents/ralph-worker.md
@@ -4,7 +4,7 @@ description: "One parallel worker of the Ralph fleet. Select to drive a SINGLE a
 level: 1
 phase: Build
 tools: Read,Write,Edit,Grep,Glob,Bash,Task
-model: fable
+model: opus
 delegates_to: [chief-architect, test-specialist, implementation-specialist, security-specialist, performance-specialist, documentation-specialist, dependency-review-specialist, code-review-orchestrator]
 receives_from: []
 ---
@@ -58,6 +58,9 @@ So, concretely:
 - Read the issue (`gh issue view "$RALPH_ISSUE" --comments`) and the house rules
   (`CLAUDE.md`, `creek-tools/CLAUDE.md`).
 - Spawn **chief-architect** for the plan + ordered dispatch list + risk flags.
+  It runs on Fable 5 (credit-metered): if the spawn fails because Fable is
+  unavailable or out of credits, re-spawn it with a `model: opus` override
+  rather than skipping the plan or designing the change yourself.
 - Run its specialists **sequentially** inside your worktree: `test-specialist`
   (Gate 1 RED) → `implementation-specialist` (Gate 1 GREEN + refactor) → only the
   cross-cutting specialists the architect flagged.

--- a/.claude/agents/test-specialist.md
+++ b/.claude/agents/test-specialist.md
@@ -4,7 +4,7 @@ description: "Gate 1 RED — writes the failing tests that specify a behavior be
 level: 2
 phase: Test
 tools: Read,Write,Edit,Grep,Glob
-model: fable
+model: opus
 delegates_to: []
 receives_from: [chief-architect, code-review-orchestrator]
 ---

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -57,6 +57,11 @@ drives Gates 3–4. The taxonomy you dispatch is mapped in
    design approach, touch-list, TDD test strategy, an **ordered dispatch list**,
    and **risk flags** (security / performance / deps / docs). You execute that
    list — you do not improvise the design.
+   **Fable fallback:** the architect runs on Fable 5, which is credit-metered.
+   If the spawn fails because Fable is unavailable or out of credits, do **not**
+   skip the planning pass and do **not** improvise the design — immediately
+   re-spawn the same `chief-architect` with an explicit `model: opus` override
+   and continue. Note the downgrade in one line in the PR body's Summary.
 6. **Dispatch the build.** The test- and implementation-specialists *embody* the
    `stay-green` Red→Green→Refactor discipline and `max-quality-no-shortcuts`
    (no bypasses) — that is now the TDD path; you do not separately invoke the


### PR DESCRIPTION
## Summary

- Swap the multi-agent router's model tiers: every role previously on Fable — `ralph-worker`, `test-specialist`, `implementation-specialist`, `performance-specialist` — now runs on **Opus 5**.
- Move `chief-architect` from Opus to **Fable 5**, spending the metered tier once per issue on the design pass, where a better plan compounds across every specialist that executes it.
- Add an explicit **graceful fallback**: Fable is credit-metered, so on a Fable-unavailable spawn failure the conductor re-spawns `chief-architect` with a `model: opus` override and continues. A tick never blocks, and never skips the planning pass, because credits ran out. Wired in `chief-architect.md`, `ralph-worker.md`, and `scripts/ralph/PROMPT.md` step 5.

`security-specialist` is unchanged on Opus — still a hard requirement given Fable's cyber/bio safety classifiers can false-positive on legitimate hardening work.

## Test plan

Docs/config-only change (agent frontmatter + prose); no Python touched.

- `grep -n "^model:" .claude/agents/*.md` — verified final tiers: chief-architect=fable; ralph-worker / test / implementation / performance / security=opus; code-review-orchestrator / documentation=sonnet; dependency-review=haiku.
- `grep -rniE "\bfable\b" .claude/agents/ scripts/ralph/` — every remaining mention is either the architect's own tier or the fallback contract; no stale Fable claims on the specialist roles.
- `.claude/agents/README.md` tiering section and the ASCII spawn graph updated to match the frontmatter exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
