### PR TITLE
fix(mcp): enforce 32-char entropy floor on CREEK_MCP_ELEVATED_TOKEN

### DIFF
--- a/creek-tools/creek_mcp/auth.py
+++ b/creek-tools/creek_mcp/auth.py
@@ -11,12 +11,24 @@ relative to the input length, so an attacker cannot probe the secret
 through repeated calls. The :mod:`creek_mcp.auth` test module asserts
 via an AST walk that ``is_elevated`` contains no ``==``/``!=`` on the
 hot path; the rule is mechanical, not stylistic.
+
+The configured token must also clear the shared 32-character floor in
+:data:`creek_mcp.token_policy.MIN_TOKEN_LEN` (#907) — a guessable secret
+must not guard irreversible destruction. :func:`creek_mcp.server.main`
+turns a weak token into a loud startup error, but the check is repeated
+here because it is the only chokepoint that covers embedders calling
+:func:`creek_mcp.server.build_server` directly, which bypasses startup
+entirely. Here the deny is **silent**: ``is_elevated`` returns ``False``
+rather than raising or explaining, so a possibly-hostile caller is handed
+no oracle about the server's configuration.
 """
 
 from __future__ import annotations
 
 import hmac
 import os
+
+from creek_mcp.token_policy import meets_min_length
 
 ELEVATED_TOKEN_ENV = "CREEK_MCP_ELEVATED_TOKEN"
 """Env var the server reads at startup to learn the expected token."""
@@ -25,14 +37,37 @@ ELEVATED_TOKEN_ENV = "CREEK_MCP_ELEVATED_TOKEN"
 def is_elevated(provided_token: str | None) -> bool:
     """Return ``True`` when *provided_token* matches the configured secret.
 
-    The gate fails closed when either side is missing: an absent or
-    empty ``CREEK_MCP_ELEVATED_TOKEN`` denies every call, and a missing
-    client token cannot accidentally match an empty server token. Only
-    a non-empty server token combined with a constant-time match
-    against the client value returns ``True``.
+    The gate fails closed three ways. An absent or empty
+    ``CREEK_MCP_ELEVATED_TOKEN`` denies every call, and a missing client
+    token cannot accidentally match an empty server token. A *configured*
+    token below :data:`creek_mcp.token_policy.MIN_TOKEN_LEN` characters
+    also denies every call (#907): a secret weak enough to guess is not
+    allowed to authorize vault destruction, even on an exact match. Only
+    a strong server token combined with a constant-time match against the
+    client value returns ``True``.
+
+    Only the *server's* token is measured. The client-supplied value is
+    never length-checked: it is attacker-controlled, so measuring it
+    proves nothing and only risks another signal leaking back out.
+
+    The weak-configuration deny is silent — this function returns a
+    ``bool`` and never raises, both to avoid disclosing server
+    configuration to the caller and because
+    :func:`creek_mcp.tools.purge._gate` does not catch: an exception here
+    would escape into the FastMCP tool surface and skip the audit entry
+    every purge call is required to write.
+
+    Args:
+        provided_token: The ``auth_token`` the caller presented, if any.
+
+    Returns:
+        ``True`` only when a floor-clearing server token is configured
+        and the caller's token matches it exactly.
     """
     expected = os.environ.get(ELEVATED_TOKEN_ENV, "")
     if not expected or not provided_token:
+        return False
+    if not meets_min_length(expected):
         return False
     return hmac.compare_digest(
         expected.encode("utf-8"),

--- a/creek-tools/creek_mcp/remote_auth.py
+++ b/creek-tools/creek_mcp/remote_auth.py
@@ -38,6 +38,8 @@ from typing import TYPE_CHECKING, Final
 from mcp.server.auth.provider import AccessToken, TokenVerifier
 from mcp.server.auth.settings import AuthSettings
 
+from creek_mcp.token_policy import require_min_length
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -52,9 +54,6 @@ TOKEN_TTL_ENV: Final[str] = "CREEK_MCP_TOKEN_TTL_SECONDS"
 
 _REMOTE_TOKEN_TTL_SECONDS: Final[int] = 3600
 """Default lifetime of a verified bearer's ``AccessToken`` (one hour)."""
-
-_MIN_TOKEN_LEN: Final[int] = 32
-"""Minimum consumer-token length — the ``secrets.token_urlsafe(32)`` floor (#838)."""
 
 # Monkeypatchable clock alias: tests pin `_now` to a fixed instant so the
 # expires_at arithmetic is exact; production keeps wall-clock time.
@@ -88,10 +87,12 @@ def _token_ttl_seconds() -> int:
 
 
 def _validated_token(name: str, token: str) -> str:
-    """Return *token* if it clears :data:`_MIN_TOKEN_LEN`, else raise (#838).
+    """Return *token* if it clears the shared length floor, else raise (#838).
 
-    The error names the consumer and the observed/required lengths and gives
-    the rotation recipe — it never echoes the token value itself.
+    Delegates to :func:`creek_mcp.token_policy.require_min_length`, which the
+    elevated-token gate shares (#907), so both surfaces enforce one number
+    with one wording. The error names the consumer and the observed/required
+    lengths and gives the rotation recipe — it never echoes the token itself.
 
     Args:
         name: The consumer the token belongs to (already stripped).
@@ -101,16 +102,10 @@ def _validated_token(name: str, token: str) -> str:
         The token, unchanged, when it meets the minimum length.
 
     Raises:
-        ValueError: If the token is shorter than :data:`_MIN_TOKEN_LEN`.
+        ValueError: If the token is shorter than
+            :data:`creek_mcp.token_policy.MIN_TOKEN_LEN`.
     """
-    if len(token) < _MIN_TOKEN_LEN:
-        msg = (
-            f"consumer {name!r} token is {len(token)} chars, below the "
-            f"{_MIN_TOKEN_LEN}-char minimum; rotate it with "
-            'python -c "import secrets; print(secrets.token_urlsafe(32))"'
-        )
-        raise ValueError(msg)
-    return token
+    return require_min_length(f"consumer {name!r} token", token)
 
 
 def load_consumer_tokens(
@@ -121,7 +116,8 @@ def load_consumer_tokens(
     Format: ``adepthood=<token>;other=<token>``. Blank entries and entries
     without a token are skipped. Returns an empty dict when unset — the caller
     treats "no tokens configured" as "network mode not permitted" (no anonymous
-    access). A *present* token shorter than :data:`_MIN_TOKEN_LEN` characters
+    access). A *present* token shorter than
+    :data:`creek_mcp.token_policy.MIN_TOKEN_LEN` characters
     is refused outright (#838); generate compliant tokens with
     ``python -c "import secrets; print(secrets.token_urlsafe(32))"``.
 
@@ -133,8 +129,8 @@ def load_consumer_tokens(
 
     Raises:
         ValueError: If a configured token is shorter than
-            :data:`_MIN_TOKEN_LEN` characters. The message names the consumer
-            and lengths but never the token value.
+            :data:`creek_mcp.token_policy.MIN_TOKEN_LEN` characters. The
+            message names the consumer and lengths but never the token value.
     """
     raw = (environ if environ is not None else os.environ).get(CONSUMER_TOKENS_ENV, "")
     tokens: dict[str, str] = {}

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -24,6 +24,7 @@ from mcp.server.fastmcp import FastMCP
 
 from creek.care.guardrail import acute_distress_guard
 from creek.config import CONFIG_PATH_ENV_VAR, load_config
+from creek_mcp.auth import ELEVATED_TOKEN_ENV
 from creek_mcp.remote_auth import (
     CONSUMER_TOKENS_ENV,
     ConsumerTokenVerifier,
@@ -31,6 +32,7 @@ from creek_mcp.remote_auth import (
     remote_auth_settings,
 )
 from creek_mcp.tier_ceiling import TierCeiling, refusal_response
+from creek_mcp.token_policy import require_min_length
 from creek_mcp.tools import (
     author_tool,
     classify_tool,
@@ -771,14 +773,43 @@ def _serve_network(server: FastMCP, args: argparse.Namespace) -> None:
         server.run(transport="streamable-http")
 
 
+def _require_strong_elevated_token(parser: argparse.ArgumentParser) -> None:
+    """Refuse to start when the elevated token is configured but too weak (#907).
+
+    ``CREEK_MCP_ELEVATED_TOKEN`` gates irreversible ``creek.purge.*``
+    calls, so a guessable value is a startup failure rather than a quietly
+    weak gate. An *absent or empty* value is not an error: that is the
+    supported "purge disabled" posture, under which
+    :func:`creek_mcp.auth.is_elevated` already denies every call.
+
+    Applies to both transports — the token is read from the environment
+    at call time, not from the wire — so it is checked before the
+    transport branch and before any server is built.
+
+    Args:
+        parser: The CLI parser, used to report errors in argparse style
+            (usage on stderr, exit code 2).
+    """
+    configured = os.environ.get(ELEVATED_TOKEN_ENV, "")
+    if not configured:
+        return
+    try:
+        require_min_length(ELEVATED_TOKEN_ENV, configured)
+    except ValueError as exc:
+        # Mirrors the #838 consumer-token treatment: exit with the rotation
+        # recipe (never the token value) rather than serve a weak gate.
+        parser.error(str(exc))
+
+
 def main(argv: list[str] | None = None) -> None:
     """Run the MCP server over stdio (local) or the authenticated network transport.
 
-    The network branch is fail-closed three times over: it refuses to start
-    without per-consumer tokens (no anonymous access), it refuses a configured
-    token below the minimum-strength floor (#838), and it refuses a
-    non-loopback bind unless TLS is configured (no cleartext bearer
-    tokens, #837).
+    Startup is fail-closed four times over. On *every* transport it refuses
+    an elevated token below the minimum-strength floor (#907). The network
+    branch additionally refuses to start without per-consumer tokens (no
+    anonymous access), refuses a configured consumer token below the same
+    floor (#838), and refuses a non-loopback bind unless TLS is configured
+    (no cleartext bearer tokens, #837).
 
     Args:
         argv: Optional list of command-line arguments. When ``None``
@@ -792,6 +823,8 @@ def main(argv: list[str] | None = None) -> None:
         if not args.config.exists():
             parser.error(f"--config: file not found: {args.config}")
         os.environ[CONFIG_PATH_ENV_VAR] = str(args.config.resolve())
+
+    _require_strong_elevated_token(parser)
 
     if args.transport == "network":
         try:

--- a/creek-tools/creek_mcp/token_policy.py
+++ b/creek-tools/creek_mcp/token_policy.py
@@ -1,0 +1,87 @@
+"""Single source of truth for the MCP bearer-secret entropy floor (#907).
+
+Two independent auth surfaces guard the MCP boundary with shared secrets
+read from the environment:
+
+* :data:`creek_mcp.auth.ELEVATED_TOKEN_ENV` — gates irreversible
+  ``creek.purge.*`` vault destruction (#907).
+* :data:`creek_mcp.remote_auth.CONSUMER_TOKENS_ENV` — gates the network
+  transport per remote consumer (#838).
+
+Both must clear the *same* minimum length, stated in one place so neither
+can drift: a floor that lives in two modules is a floor that eventually
+holds in only one. This module is deliberately stdlib-only and imports
+nothing from :mod:`creek_mcp`, so either surface can depend on it without
+creating an import cycle.
+
+The rejection message is equally shared: it names the offending setting,
+the observed length, the required length, and the rotation recipe — and
+never the token value, because startup errors land in logs, terminals,
+and process supervisors.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+MIN_TOKEN_LEN: Final[int] = 32
+"""Minimum length of any configured MCP bearer secret.
+
+The ``secrets.token_urlsafe(32)`` floor: 32 characters of the rotation
+recipe's output, shared by the elevated gate (#907) and the per-consumer
+tokens (#838).
+"""
+
+_ROTATION_RECIPE: Final[str] = (
+    'python -c "import secrets; print(secrets.token_urlsafe(32))"'
+)
+"""The one-liner operators are told to run when a secret is refused."""
+
+
+def meets_min_length(token: str) -> bool:
+    """Return whether *token* clears :data:`MIN_TOKEN_LEN`.
+
+    The predicate form for callers that must not raise — notably
+    :func:`creek_mcp.auth.is_elevated`, which fails closed silently so a
+    hostile caller learns nothing about the server's configuration.
+
+    Args:
+        token: The configured secret to measure. The empty string (an
+            unconfigured setting) never clears the floor.
+
+    Returns:
+        ``True`` when the token is at least :data:`MIN_TOKEN_LEN`
+        characters long, else ``False``.
+    """
+    return len(token) >= MIN_TOKEN_LEN
+
+
+def require_min_length(subject: str, token: str) -> str:
+    """Return *token* unchanged when it clears the floor, else raise.
+
+    The raising form for load- and startup-time validation, where a weak
+    secret should be a loud operator-facing failure rather than a quietly
+    weak gate.
+
+    Args:
+        subject: What the token is, phrased to read as the subject of
+            "<subject> is N chars, below the ...". Callers pass the
+            setting or identity the operator must fix (for example
+            ``"CREEK_MCP_ELEVATED_TOKEN"`` or ``"consumer 'x' token"``).
+        token: The configured secret to measure.
+
+    Returns:
+        The token, byte-for-byte unchanged, when it meets the minimum.
+
+    Raises:
+        ValueError: If the token is shorter than :data:`MIN_TOKEN_LEN`.
+            The message names *subject*, the observed length, the
+            required length, and the rotation recipe — never the token.
+    """
+    if not meets_min_length(token):
+        msg = (
+            f"{subject} is {len(token)} chars, below the "
+            f"{MIN_TOKEN_LEN}-char minimum; rotate it with {_ROTATION_RECIPE}"
+        )
+        raise ValueError(msg)
+    return token

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -121,14 +121,27 @@ Operational rules:
   therefore returns `status="refused"` — there is no Discord command
   surface that could accidentally destroy vault content.
 - **The developer's Claude Code can be configured with the token.**
-  Generate one with high entropy:
+  Generate one with high entropy — this is the same recipe the startup
+  check prints if the configured token is too weak:
   ```bash
-  python -c "import secrets; print(secrets.token_hex(32))"
+  python -c "import secrets; print(secrets.token_urlsafe(32))"
   ```
   Add `"CREEK_MCP_ELEVATED_TOKEN": "<generated-token>"` to the `env`
   block of `.mcp.json` (alongside `CREEK_MCP_CONSUMER`). Treat the
   token like any other vault secret — keep it out of public dotfiles
   and shared shells.
+- **The token must be at least 32 characters (#907).** A configured
+  value below the floor aborts server startup on *both* transports with
+  the rotation recipe on stderr (the token value itself is never
+  printed), and — for embedders that bypass `main` — is denied silently
+  by the gate itself. Leaving `CREEK_MCP_ELEVATED_TOKEN` unset remains
+  fully supported: that is the "purge disabled" posture, not an error.
+- **Breaking change for operators upgrading (#907).** This floor is
+  new: a server that starts fine today with a `CREEK_MCP_ELEVATED_TOKEN`
+  under 32 characters will refuse to start the next time it is launched
+  — on both transports — with no grace period, warning-only mode, or
+  opt-out. If you rely on `creek.purge.*`, rotate the token with the
+  recipe above *before* upgrading.
 - **`creek.purge.vault` requires both the token AND
   `confirm_vault_path`.** The confirmation must match the resolved
   absolute path of the target vault, mirroring the CLI's interactive
@@ -141,7 +154,7 @@ Operational rules:
 
 Example `.mcp.json` for a Claude Code instance configured for
 destructive ops (replace the token with a freshly generated one — the
-sample shown here is high-entropy hex from `secrets.token_hex(32)` and
+sample shown here is high-entropy from `secrets.token_urlsafe(32)` and
 must not be reused):
 
 ```json
@@ -151,7 +164,7 @@ must not be reused):
       "command": "creek-tools-mcp",
       "env": {
         "CREEK_MCP_CONSUMER": "claude-code",
-        "CREEK_MCP_ELEVATED_TOKEN": "REPLACE_WITH_secrets.token_hex(32)"
+        "CREEK_MCP_ELEVATED_TOKEN": "REPLACE_WITH_secrets.token_urlsafe(32)"
       }
     }
   }
@@ -237,6 +250,9 @@ routable by design and requires TLS.
   config), mirroring the `CREEK_MCP_ELEVATED_TOKEN` precedent. Generate each
   token as high-entropy hex — `secrets.token_hex(32)` — so a token is never
   guessable; the constant-time comparison only matters against a strong secret.
+  A configured token below 32 characters is refused at startup, the same
+  floor `CREEK_MCP_ELEVATED_TOKEN` now enforces (#907) — both surfaces share
+  one minimum defined once in `creek_mcp/token_policy.py`.
 - **Per-consumer identity.** Each request must present its bearer token
   (`Authorization: Bearer <token>`). The token maps to a consumer name that
   is stamped on every audit-log entry — so remote calls are attributable the

--- a/creek-tools/tests/test_mcp_auth.py
+++ b/creek-tools/tests/test_mcp_auth.py
@@ -20,6 +20,11 @@ if TYPE_CHECKING:
     import pytest
 
 
+# 40 chars — clears the 32-char floor (#907). Low-entropy test literal,
+# not a real credential.
+_STRONG_TOKEN = "elevated-test-token-" + "a" * 20
+
+
 def test_is_elevated_returns_false_when_env_unset(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -41,7 +46,7 @@ def test_is_elevated_returns_false_when_provided_token_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Missing client token fails closed even when env token is configured."""
-    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", "super-secret")
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", _STRONG_TOKEN)
     assert auth.is_elevated(None) is False
     assert auth.is_elevated("") is False
 
@@ -50,7 +55,7 @@ def test_is_elevated_returns_false_for_mismatched_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A non-matching client token is rejected."""
-    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", "super-secret")
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", _STRONG_TOKEN)
     assert auth.is_elevated("not-the-secret") is False
 
 
@@ -58,8 +63,8 @@ def test_is_elevated_returns_true_for_matching_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A correct client token unlocks elevated tools."""
-    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", "super-secret")
-    assert auth.is_elevated("super-secret") is True
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", _STRONG_TOKEN)
+    assert auth.is_elevated(_STRONG_TOKEN) is True
 
 
 def test_is_elevated_uses_hmac_compare_digest(
@@ -71,7 +76,7 @@ def test_is_elevated_uses_hmac_compare_digest(
     monkey-patches ``hmac.compare_digest`` and asserts ``is_elevated``
     calls it with the expected and actual tokens as bytes.
     """
-    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", "super-secret")
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", _STRONG_TOKEN)
     calls: list[tuple[object, object]] = []
 
     def _spy(a: object, b: object) -> bool:
@@ -79,11 +84,42 @@ def test_is_elevated_uses_hmac_compare_digest(
         return a == b  # only inside the test spy, never inside auth.py
 
     monkeypatch.setattr(auth.hmac, "compare_digest", _spy)
-    assert auth.is_elevated("super-secret") is True
+    assert auth.is_elevated(_STRONG_TOKEN) is True
     assert calls, "is_elevated must route through hmac.compare_digest"
     expected, actual = calls[0]
-    assert expected == b"super-secret"
-    assert actual == b"super-secret"
+    assert expected == _STRONG_TOKEN.encode("utf-8")
+    assert actual == _STRONG_TOKEN.encode("utf-8")
+
+
+def test_is_elevated_denies_sub_minimum_configured_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A weak *server* secret denies even an exact match, silently (#907).
+
+    Defense in depth behind the startup check: if a sub-32-char
+    ``CREEK_MCP_ELEVATED_TOKEN`` ever reaches a running process, the gate
+    refuses to authorize anything — a guessable secret must not guard
+    irreversible vault destruction. The deny is silent: ``is_elevated``
+    returns a ``bool`` rather than raising, so no configuration detail
+    (not even "the server secret is weak") reaches the caller.
+    """
+    # 31 chars — one under the floor. Test literal, not a real credential.
+    weak_token = "weak-elevated-" + "a" * 17
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", weak_token)
+    assert auth.is_elevated(weak_token) is False
+
+
+def test_is_elevated_accepts_exact_boundary_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured token of exactly 32 chars sits on the floor and authorizes.
+
+    Guards the length comparison against an off-by-one (``<=`` instead of
+    ``<``) that would reject the very tokens the rotation recipe produces.
+    """
+    boundary_token = "a" * 32  # test literal, not a real credential
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", boundary_token)
+    assert auth.is_elevated(boundary_token) is True
 
 
 def test_auth_module_source_uses_compare_digest_not_equality() -> None:

--- a/creek-tools/tests/test_mcp_purge.py
+++ b/creek-tools/tests/test_mcp_purge.py
@@ -31,7 +31,9 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 
-ELEVATED_TOKEN = "test-elevated-secret"
+# 41 chars — clears the 32-char floor (#907). Low-entropy test literal,
+# not a real credential.
+ELEVATED_TOKEN = "test-elevated-secret-" + "a" * 20
 
 
 @pytest.fixture
@@ -463,8 +465,12 @@ def test_crawdad_consumer_cannot_purge(
     elevated token. The vault must remain intact after such a call —
     this test stands in for the FEAT's "CrawDad cannot purge anything"
     fixture-vault regression.
+
+    The server-side token must clear the 32-char floor (#907): with a weak
+    secret configured the refusal would be right for the *wrong* reason
+    (weak server config, not CrawDad's missing token).
     """
-    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", "kept-secret")
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", ELEVATED_TOKEN)
     result = purge_vault_tool(
         vault_path=vault,
         confirm_vault_path=str(vault),
@@ -473,3 +479,39 @@ def test_crawdad_consumer_cannot_purge(
     )
     assert result["status"] == "refused"
     assert (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+
+
+def test_purge_refused_when_configured_token_is_sub_minimum(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A weak server secret disarms purge entirely, without leaking why (#907).
+
+    The caller presents the exact configured token *and* the correct
+    ``confirm_vault_path`` — the only thing wrong is that the operator's
+    secret is 31 characters. The purge must be refused, the vault left
+    intact, and the refusal audited. The caller-visible ``reason`` must
+    stay the generic elevated-authorization refusal: telling a hostile
+    caller "the server secret is 31 chars" would be a configuration
+    oracle handed out for free.
+    """
+    # 31 chars — one under the floor. Test literal, not a real credential.
+    weak_token = "weak-elevated-" + "a" * 17
+    monkeypatch.setenv("CREEK_MCP_ELEVATED_TOKEN", weak_token)
+
+    result = purge_vault_tool(
+        vault_path=vault,
+        confirm_vault_path=str(vault),
+        auth_token=weak_token,  # an exact match against the weak secret
+        consumer="claude-code",
+    )
+
+    assert result["status"] == "refused"
+    assert (vault / "01-Fragments" / "Notes" / "frag-001.md").exists()
+    entries = _audit_entries(vault)
+    assert len(entries) == 1
+    assert entries[0]["tool"] == "creek.purge.vault"
+    reason = str(result["reason"])
+    assert "32" not in reason  # no config oracle: never disclose the floor
+    assert "chars" not in reason  # nor the observed length
+    assert weak_token not in reason  # nor, obviously, the token itself

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -8,12 +8,20 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from creek_mcp.auth import ELEVATED_TOKEN_ENV
 from creek_mcp.contract import CONTRACT_VERSION, ONTOLOGY_VERSION
+from creek_mcp.remote_auth import CONSUMER_TOKENS_ENV
 from creek_mcp.server import SERVER_NAME, build_server
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
+
+
+# Low-entropy test literals, not real credentials.
+_WEAK_ELEVATED_TOKEN = "weak-" + "a" * 6  # 11 chars, under the 32-char floor
+_BOUNDARY_ELEVATED_TOKEN = "a" * 32  # exactly on the floor
+_STRONG_CONSUMER_TOKEN = "server-test-consumer-" + "b" * 22  # 43 chars
 
 
 EXPECTED_TOOLS = {
@@ -557,3 +565,149 @@ def test_build_reflect_llm_factory_routes_then_degrades(
     )
     with pytest.raises(RuntimeError):
         server_mod._build_reflect_llm_factory()(PrivacyTier.OPEN)
+
+
+# --------------------------------------------------------------------------- #
+# Elevated-token minimum-length floor at startup (#907)
+# --------------------------------------------------------------------------- #
+
+
+def test_main_rejects_short_elevated_token_on_stdio(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A sub-minimum elevated token aborts stdio startup before any tool exists.
+
+    ``CREEK_MCP_ELEVATED_TOKEN`` guards irreversible ``creek.purge.*``
+    calls, so a guessable value must be a loud startup failure — not a
+    quietly weak gate. Stubbing ``build_server`` with an exploding
+    callable proves the refusal happens *before* the purge tools are
+    ever registered or reachable.
+    """
+    from creek_mcp import server as server_module
+
+    monkeypatch.setenv(ELEVATED_TOKEN_ENV, _WEAK_ELEVATED_TOKEN)
+    monkeypatch.delenv(CONSUMER_TOKENS_ENV, raising=False)
+
+    def _explode() -> object:  # pragma: no cover - asserts non-invocation
+        msg = "build_server must not run with a weak elevated token"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(server_module, "build_server", _explode)
+
+    with pytest.raises(SystemExit) as excinfo:
+        server_module.main([])
+
+    assert excinfo.value.code == 2  # argparse parser.error convention
+    err = capsys.readouterr().err
+    assert ELEVATED_TOKEN_ENV in err  # the offending setting is named
+    assert "11" in err  # the observed length
+    assert "32" in err  # the enforced minimum
+    assert "secrets.token_urlsafe(32)" in err  # the rotation recipe
+    assert _WEAK_ELEVATED_TOKEN not in err  # NEVER echo the token value
+
+
+def test_main_rejects_short_elevated_token_on_network_transport(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The elevated-token check runs before the transport branch, so network too.
+
+    Consumer tokens are valid here; only the elevated token is weak. The
+    *elevated* message must be what surfaces, proving the check precedes
+    the network branch rather than riding along inside it.
+    """
+    from creek_mcp import server as server_module
+
+    monkeypatch.setenv(ELEVATED_TOKEN_ENV, _WEAK_ELEVATED_TOKEN)
+    monkeypatch.setenv(CONSUMER_TOKENS_ENV, f"adepthood={_STRONG_CONSUMER_TOKEN}")
+
+    def _explode(**_kwargs: object) -> object:  # pragma: no cover - non-invocation
+        msg = "build_server must not run with a weak elevated token"
+        raise AssertionError(msg)
+
+    def _no_serve(server: object, args: object) -> None:  # pragma: no cover
+        msg = "_serve_network must not run with a weak elevated token"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(server_module, "build_server", _explode)
+    monkeypatch.setattr(server_module, "_serve_network", _no_serve)
+
+    with pytest.raises(SystemExit) as excinfo:
+        server_module.main(["--transport", "network", "--host", "127.0.0.1"])
+
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert ELEVATED_TOKEN_ENV in err  # the elevated complaint, not the consumer one
+    assert "adepthood" not in err  # the consumer token is fine; not the subject
+    assert "32" in err  # the enforced minimum
+    assert "secrets.token_urlsafe(32)" in err  # the rotation recipe
+    assert _WEAK_ELEVATED_TOKEN not in err  # NEVER echo the token value
+
+
+def test_main_starts_with_compliant_elevated_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A token of exactly 32 chars sits on the floor and startup proceeds."""
+    from creek_mcp import server as server_module
+
+    monkeypatch.setenv(ELEVATED_TOKEN_ENV, _BOUNDARY_ELEVATED_TOKEN)
+    monkeypatch.delenv(CONSUMER_TOKENS_ENV, raising=False)
+
+    runs: list[str] = []
+
+    class _StubServer:
+        def run(self, transport: str) -> None:
+            runs.append(transport)
+
+    monkeypatch.setattr(server_module, "build_server", lambda: _StubServer())
+    server_module.main([])
+
+    assert runs == ["stdio"]
+
+
+def test_main_starts_when_elevated_token_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An absent elevated token is the supported 'purge disabled' posture.
+
+    No token configured means every ``creek.purge.*`` call already fails
+    closed in :func:`creek_mcp.auth.is_elevated`; refusing to boot would
+    break every operator who never wanted purge enabled.
+    """
+    from creek_mcp import server as server_module
+
+    monkeypatch.delenv(ELEVATED_TOKEN_ENV, raising=False)
+    monkeypatch.delenv(CONSUMER_TOKENS_ENV, raising=False)
+
+    runs: list[str] = []
+
+    class _StubServer:
+        def run(self, transport: str) -> None:
+            runs.append(transport)
+
+    monkeypatch.setattr(server_module, "build_server", lambda: _StubServer())
+    server_module.main([])
+
+    assert runs == ["stdio"]
+
+
+def test_main_treats_empty_elevated_token_as_unconfigured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty elevated token is 'unset', not 'zero chars, too short'."""
+    from creek_mcp import server as server_module
+
+    monkeypatch.setenv(ELEVATED_TOKEN_ENV, "")
+    monkeypatch.delenv(CONSUMER_TOKENS_ENV, raising=False)
+
+    runs: list[str] = []
+
+    class _StubServer:
+        def run(self, transport: str) -> None:
+            runs.append(transport)
+
+    monkeypatch.setattr(server_module, "build_server", lambda: _StubServer())
+    server_module.main([])
+
+    assert runs == ["stdio"]

--- a/creek-tools/tests/test_mcp_token_policy.py
+++ b/creek-tools/tests/test_mcp_token_policy.py
@@ -1,0 +1,57 @@
+"""Tests for the shared MCP token-strength policy (#907).
+
+``CREEK_MCP_ELEVATED_TOKEN`` gates irreversible ``creek.purge.*`` vault
+destruction, yet it carried no minimum-length floor while the *lower*-value
+per-consumer bearer tokens already enforced one (#838). :mod:`creek_mcp.token_policy`
+is the single stdlib-only home for that floor, so both auth surfaces enforce
+the same number with the same wording — and neither can echo a secret back
+while complaining about it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from creek_mcp.token_policy import (
+    MIN_TOKEN_LEN,
+    meets_min_length,
+    require_min_length,
+)
+
+
+def test_min_token_len_is_thirty_two() -> None:
+    """The floor is exactly 32 characters — pinned against silent weakening."""
+    assert MIN_TOKEN_LEN == 32
+
+
+def test_meets_min_length_at_boundary() -> None:
+    """32 chars clears the floor; 31 chars and the empty string do not."""
+    assert meets_min_length("a" * 32) is True
+    assert meets_min_length("a" * 31) is False
+    assert meets_min_length("") is False
+
+
+def test_require_min_length_returns_token_unchanged() -> None:
+    """A compliant token round-trips byte-for-byte, not normalised or truncated."""
+    # 45 chars, low entropy: test literal, not a real credential.
+    token = "policy-test-strong-token-" + "a" * 20
+    assert require_min_length("elevated token", token) == token
+
+
+def test_require_min_length_rejects_short_token_without_echoing_it() -> None:
+    """A sub-minimum token raises, naming everything except the token value.
+
+    The message must be actionable (which setting, how short, how long it
+    must be, how to rotate it) while never printing the secret itself —
+    startup errors land in logs, terminals, and process supervisors.
+    """
+    # 12 chars, low entropy: test literal, not a real credential.
+    weak = "weak-" + "b" * 7
+    with pytest.raises(ValueError) as excinfo:
+        require_min_length("elevated token", weak)
+    message = str(excinfo.value)
+    assert "elevated token" in message  # the subject is named
+    assert "12" in message  # the observed length
+    assert "32" in message  # the enforced minimum
+    assert "secrets.token_urlsafe(32)" in message  # the rotation recipe
+    assert weak not in message  # NEVER echo the token value


### PR DESCRIPTION
## Summary

`CREEK_MCP_ELEVATED_TOKEN` gates the five `creek.purge.*` tools — including `creek.purge.vault`, the single most destructive operation in the system — but `is_elevated` accepted **any** non-empty value. Meanwhile the *lower-value* per-consumer bearer tokens have enforced a 32-char minimum since #838. The higher-value secret was held to the weaker standard, and `auth_token` is a caller-supplied tool argument with no throttle, so a short operator-chosen token was online-guessable by a network-authenticated consumer.

The floor now lives in exactly one place:

- **New `creek_mcp/token_policy.py`** — `MIN_TOKEN_LEN = 32`, the rotation recipe, and the rejection wording, exposed as `meets_min_length` (predicate) and `require_min_length` (raising). Stdlib-only and imports nothing from `creek_mcp`, so both auth surfaces can depend on it without a cycle.
- **`remote_auth._validated_token`** delegates to it; `_MIN_TOKEN_LEN` is deleted. The consumer-token `ValueError` message is **byte-identical** to before, so the unmodified `tests/test_mcp_remote.py` is a regression fence on that.
- **`server.main`** gains `_require_strong_elevated_token`, called *before* the transport branch so **both** stdio and network abort via `parser.error(...)` (exit 2), naming the env var, the observed length, the 32 floor, and the rotation recipe — never the token value. An absent or empty token is still **not** an error: that is the supported "purge disabled" posture.
- **`auth.is_elevated`** denies a sub-floor *configured* token **silently**. It keeps its `-> bool` signature and never raises, because `tools/purge.py::_gate` does not catch and an escaping exception would skip the audit entry every purge call is required to write. Silent also means a hostile caller gets no oracle distinguishing "wrong token" from "server misconfigured". Only the **server's** value is measured; the attacker-supplied one never is. This is the chokepoint covering embedders who call `build_server()` directly and bypass startup.

**`tools/purge.py` is deliberately untouched.** The caller-visible refusal reason stays generic for the same no-oracle reason — telling a possibly-hostile remote caller "the server secret is 11 chars" would narrow a brute-force search against the very secret this hardens. The operator's actionable signal is the startup error on stderr.

### Breaking change

A server running a sub-32-char `CREEK_MCP_ELEVATED_TOKEN` today will **refuse to start** on next launch, on both transports. Rotate with `python -c "import secrets; print(secrets.token_urlsafe(32))"`. There is no grace period, warning-only mode, or opt-out — either would reintroduce exactly the weakness being closed. Called out in `docs/mcp.md`.

## Test plan

Written RED first, then GREEN.

- **New `tests/test_mcp_token_policy.py`** — pins `MIN_TOKEN_LEN == 32` against silent weakening; boundary behavior at 32/31/empty; compliant token returned unchanged; and that the `ValueError` names the subject, the observed length, the floor, and the recipe while **never** echoing the token.
- **`tests/test_mcp_auth.py`** — `test_is_elevated_denies_sub_minimum_configured_token` is the crux: a 31-char server secret with an **exact match** supplied must still return `False` (and returning a bool proves it does not raise). `test_is_elevated_accepts_exact_boundary_token` fences the off-by-one at exactly 32. The AST walk banning `==`/`!=` inside `is_elevated` is unmodified and still passes.
- **`tests/test_mcp_purge.py`** — `test_purge_refused_when_configured_token_is_sub_minimum` calls `purge_vault_tool` with a correct `confirm_vault_path` and the exact (weak) token, then asserts `refused`, the fragment survives on disk, a refusal entry landed in the audit log, and the refusal reason contains neither `32`, `chars`, nor the token value.
- **`tests/test_mcp_server.py`** — startup rejection on stdio *and* on `--transport network` (the latter with valid consumer tokens set, proving the elevated check fires *first*); `build_server` is stubbed to raise if invoked, proving refusal happens before any purge tool is reachable. Three regression-fence cases assert compliant / unset / empty all still start normally.
- Repaired short test literals that would otherwise have passed for the wrong reason — notably `test_crawdad_consumer_cannot_purge`, which with an 11-char server secret would have been refused because the *server* was weak rather than because CrawDad has no token.

`cd creek-tools && ./scripts/check-all.sh` → exit 0: 12/12 checks, 6068 tests passed, aggregate branch coverage 93.90%, per-file gate green, `creek_mcp/token_policy.py` and `creek_mcp/auth.py` both at 100%.

Closes #907

🤖 Generated with [Claude Code](https://claude.com/claude-code)
