### PR TITLE
fix(mcp): enforce the read-side tier ceiling on creek.reflect entry_ref

### DIFF
--- a/creek-tools/creek_mcp/tools/reflect.py
+++ b/creek-tools/creek_mcp/tools/reflect.py
@@ -7,8 +7,14 @@ grounded in retrieval over their corpus. Distinct from the essay-shaped
 ``draft``/``author``/``mine`` surface; this is the reflection surface Adepthood's
 journal needs.
 
-Three guarantees this module enforces:
+Four guarantees this module enforces:
 
+- **The ceiling is enforced on read (#846).** An ``entry_ref`` resolves a vault
+  fragment the caller did not supply, so its classified tier is checked against
+  the caller's ``privacy_tier_ceiling`` before anything is done with its text: an
+  above-ceiling fragment is refused outright rather than reflected. Raw inline
+  ``content`` is the caller's own text and carries no classification, so it is
+  never gated here.
 - **INTIMATE never egresses.** The LLM callable is obtained from a *tier-keyed
   factory* (``llm_factory(tier)``). The production factory resolves through
   :class:`creek.classify.llm.router.ModelRouter`, whose
@@ -18,11 +24,12 @@ Three guarantees this module enforces:
   only derives the routing tier and hands it over. The routing tier is the
   **more sensitive** of the entry's own classified ``privacy_tier`` (when it came
   from a vault fragment via ``entry_ref``) and the ceiling-derived tier — so an
-  INTIMATE fragment routes local even under a low ceiling. Raw inline ``content``
-  carries no classification, so there the guarantee is bounded by the caller's
-  declared ceiling (a caller cannot mark intimate content ``open`` and also have
-  it treated as intimate without classifying it first). Both fail closed to
-  INTIMATE on anything unrecognised.
+  admitted INTIMATE fragment still routes local under a broader ceiling, which is
+  defense in depth behind the read-side gate above. Raw inline ``content`` carries
+  no classification, so there the guarantee is bounded by the caller's declared
+  ceiling (a caller cannot mark intimate content ``open`` and also have it treated
+  as intimate without classifying it first). Both fail closed to INTIMATE on
+  anything unrecognised.
 - **Quotes are verbatim.** Every returned ``quote`` is validated to be a
   substring of the entry (whitespace-normalised). Model-supplied spans that are
   not are dropped — the client re-anchors verbatim quotes to character offsets
@@ -44,7 +51,12 @@ from typing import TYPE_CHECKING, Any, Protocol
 from creek.care.guardrail import CARE_POLICY, CARE_SIGNAL
 from creek.models import PrivacyTier
 from creek_mcp.audit import MCPAuditLog
-from creek_mcp.tier_ceiling import TierCeiling, refusal_response, to_privacy_override
+from creek_mcp.tier_ceiling import (
+    TierCeiling,
+    refusal_response,
+    tier_allowed,
+    to_privacy_override,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -110,11 +122,37 @@ def _routing_tier(ceiling: TierCeiling, entry_tier: PrivacyTier | None) -> Priva
 
     Failing closed: an unrecognised ceiling, or an *entry_tier* outside the known
     ranks, routes as INTIMATE (local-only).
+
+    An above-ceiling *entry_tier* is now refused upstream by
+    :func:`_above_ceiling` before this function ever runs (#846), so in practice
+    this only reconciles an *admitted* ``entry_ref`` (or raw ``content``, which
+    has no *entry_tier*) against the ceiling. It stays in place as defense in
+    depth — the load-bearing INTIMATE-never-egresses guarantee — and must not be
+    removed.
     """
     ceiling_tier = _CEILING_ROUTING_TIER.get(ceiling, PrivacyTier.INTIMATE)
     if entry_tier is None:
         return ceiling_tier
     return max(ceiling_tier, entry_tier, key=_sensitivity)
+
+
+def _above_ceiling(entry_tier: PrivacyTier | None, ceiling: TierCeiling) -> bool:
+    """Return whether a resolved entry's classified tier exceeds *ceiling*.
+
+    Delegates the rank comparison to :func:`creek_mcp.tier_ceiling.tier_allowed`,
+    the canonical read-side admission predicate, so this tool cannot drift from
+    the rest of the MCP surface.
+
+    Args:
+        entry_tier: The entry's classified ``privacy_tier``, or ``None`` for raw
+            inline ``content`` — which carries no classification and is the
+            caller's own text, so it is never above the ceiling.
+        ceiling: The caller's declared ceiling.
+
+    Returns:
+        ``True`` when the entry must be refused rather than reflected.
+    """
+    return entry_tier is not None and not tier_allowed(entry_tier, ceiling)
 
 
 def _normalise(text: str) -> str:
@@ -237,9 +275,21 @@ def _resolve_entry(
     Raw *content* carries no classification, so its tier is ``None`` and the
     caller falls back to the ceiling. An *entry_ref* is resolved to a fragment
     markdown file under ``01-Fragments``; its body becomes the entry **and its
-    persisted ``privacy_tier`` becomes the routing tier** — this is what stops an
-    INTIMATE fragment being reflected through a cloud model under a low ceiling.
-    A blank result yields ``("", None)``, which the caller turns into a refusal.
+    persisted ``privacy_tier`` becomes both the admission tier and the routing
+    tier** — the caller checks the admission tier against the ceiling via
+    :func:`_above_ceiling` (#846) before doing anything else with the text, and
+    separately folds it into :func:`_routing_tier` so an admitted INTIMATE
+    fragment still routes local. A fragment with the ``privacy_tier`` key
+    missing entirely fails closed to INTIMATE (:func:`_fragment_tier`) — but
+    that only fires for hand-edited or legacy files. A normally
+    pipeline-written, not-yet-classified fragment carries an *explicit*
+    ``privacy_tier: unclassified`` (the ``Fragment`` model default,
+    serialised by every write), which ranks as open and is admitted at any
+    ceiling; that is a separate, deliberate policy owned by
+    ``creek_mcp.tier_ceiling._TIER_RANK`` and
+    :func:`creek.classify.privacy_filter.tier_of`, not by this fail-closed
+    path. A blank result yields ``("", None)``, which the caller turns into
+    a refusal.
     """
     if content and content.strip():
         return content, None
@@ -280,18 +330,34 @@ def reflect_tool(
             defaults to the corpus retrieval specialist.
         care_guard: ``(entry) -> reason | None``; a non-``None`` reason escalates
             to a human and skips the model entirely (#753 seam).
-        privacy_tier_ceiling: The ceiling; gates corpus admission and, via
-            :func:`_routing_tier`, the local-vs-cloud routing tier.
+        privacy_tier_ceiling: The ceiling; gates admission of the *entry itself*
+            when it came from an ``entry_ref`` (see :func:`_above_ceiling`),
+            corpus admission for grounding retrieval, and — via
+            :func:`_routing_tier` — the local-vs-cloud routing tier.
         consumer: Free-form consumer id for the audit log.
         max_notes: Cap on returned notes.
 
     Returns:
         ``{status, tool, tier_ceiling, ...}`` — ``ok`` with ``notes`` (+ optional
-        ``essay``), ``escalate`` with a ``reason``, or a structured refusal. Each
-        ``notes[].quote`` is a verified verbatim span of the entry; the optional
-        ``essay`` is free model prose and is **not** grounding-checked, flagged by
-        ``essay_grounded: False`` so a client never treats it as grounded.
+        ``essay``), ``escalate`` with a ``reason``, or a structured ``refused``
+        response for one of: no *entry_ref*/*content* resolves to text
+        (``"entry_ref not found"`` / ``"no entry content supplied"``); the
+        *entry_ref*'s classified tier exceeds *privacy_tier_ceiling*
+        (``"entry_ref tier exceeds ceiling"``, #846 — see :func:`_above_ceiling`);
+        or the LLM provider is unavailable/raises (``"reflection unavailable:
+        ..."``). Each ``notes[].quote`` is a verified verbatim span of the entry;
+        the optional ``essay`` is free model prose and is **not**
+        grounding-checked, flagged by ``essay_grounded: False`` so a client never
+        treats it as grounded.
     """
+    # Logged unconditionally, above the ceiling gate below, so a refused
+    # above-ceiling attempt is still recorded (tool, ceiling, consumer,
+    # has_entry_ref, timestamp) — this is the only append for this call; no
+    # second append happens on refusal. The probed entry_ref itself and the
+    # call's outcome are deliberately NOT logged, so this record cannot
+    # answer "did consumer X read fragment F?" in either direction: a
+    # probing consumer shows up as an elevated rate of has_entry_ref calls,
+    # never as a named target.
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
         args={"has_entry_ref": entry_ref is not None},
@@ -304,6 +370,36 @@ def reflect_tool(
         reason = "entry_ref not found" if entry_ref else "no entry content supplied"
         return refusal_response(
             tool=TOOL_NAME, ceiling=privacy_tier_ceiling, reason=reason
+        )
+
+    # The read-side ceiling gate (#846). It sits *above* the care seam on
+    # purpose: an ``escalate`` response is a one-bit oracle telling a caller who
+    # is not admitted to this fragment that it carries acute-distress markers.
+    # Care still runs for every raw-``content`` call and every within-ceiling
+    # ``entry_ref`` — only unadmitted reads skip it, and they skip the model too.
+    if _above_ceiling(entry_tier, privacy_tier_ceiling):
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            # Unlike ``save``'s refusal, this reason does NOT echo the offending
+            # tier. There the tier came from the caller's own input, so echoing
+            # it tells them nothing new; here it is derived from content the
+            # caller is not admitted to, so echoing it would turn the refusal
+            # into a tier-classification oracle over the corpus.
+            #
+            # ACCEPTED RESIDUAL RISK: keeping this reason distinct from
+            # "entry_ref not found" is itself a coarse existence-and-rank oracle
+            # across repeated probes (refused at ``open`` implies tier >=
+            # personal; refused at ``personal`` implies intimate). Accepted
+            # because fragment ids are unguessable (``frag-`` + 12 hex), are only
+            # learnable from content already admitted to the caller, and each
+            # probe costs a vault scan — while the distinct not-found reason is
+            # what makes a legitimate client's bug debuggable. If the two reasons
+            # are ever unified, the scan must be equalised too: the not-found
+            # path parses every fragment file whereas this path early-returns at
+            # the match, so the timing difference would preserve the oracle as a
+            # side channel.
+            reason="entry_ref tier exceeds ceiling",
         )
 
     if care_guard is not None:

--- a/creek-tools/tests/test_mcp_reflect.py
+++ b/creek-tools/tests/test_mcp_reflect.py
@@ -4,14 +4,22 @@ The tool takes one journal entry plus a privacy-tier ceiling and returns
 ``{notes: [{quote, kind, note}], essay?}`` grounded in the user's corpus. The
 contract this suite pins, in order of stakes:
 
-1. **INTIMATE never egresses** — the LLM callable is obtained from a tier-keyed
+1. **The ceiling is enforced on read (#846)** — an ``entry_ref`` whose
+   classified tier exceeds the caller's ``privacy_tier_ceiling`` is refused
+   *before* the care guard and the model, with the tier-neutral reason
+   ``"entry_ref tier exceeds ceiling"``; not one span of that fragment may
+   appear in the response. Raw inline ``content`` is the caller's own text and
+   is never gated; a fragment carrying no ``privacy_tier`` fails closed.
+2. **INTIMATE never egresses** — the LLM callable is obtained from a tier-keyed
    factory; an INTIMATE entry must request the factory with
    ``PrivacyTier.INTIMATE`` (the router then forces local), and an
    ``IntimateRoutingError`` must surface as a structured refusal, never a crash
-   or a cloud call.
-2. **Quotes are verbatim** — every returned ``quote`` is a substring of the
+   or a cloud call. Pinned end-to-end through ``reflect_tool``, plus directly on
+   ``_routing_tier`` for the defense-in-depth fold-in that the #846 gate above
+   it makes unreachable from the public API.
+3. **Quotes are verbatim** — every returned ``quote`` is a substring of the
    input; model-supplied spans that are not are dropped, never trusted.
-3. Corpus-grounded retrieval, audit logging, read-only wrt the corpus, clean
+4. Corpus-grounded retrieval, audit logging, read-only wrt the corpus, clean
    degradation with no provider, and the care seam (#753).
 
 The LLM and retrieval are injected — no live calls.
@@ -22,12 +30,14 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
+import pytest
+
 from creek.care.guardrail import CARE_SIGNAL
 from creek.classify.llm.router import IntimateRoutingError
 from creek.models import PrivacyTier
 from creek_mcp.audit import MCP_AUDIT_RELPATH
-from creek_mcp.tier_ceiling import TierCeiling
-from creek_mcp.tools.reflect import TOOL_NAME, reflect_tool
+from creek_mcp.tier_ceiling import TierCeiling, to_privacy_override
+from creek_mcp.tools.reflect import TOOL_NAME, _routing_tier, reflect_tool
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -39,21 +49,32 @@ _ENTRY = (
 
 
 class _RecordingFactory:
-    """A tier-keyed LLM factory that records the tier it was asked for.
+    """A tier-keyed LLM factory recording the tier *and prompt* it was given.
 
     Mirrors the production factory's shape ``(PrivacyTier) -> (str) -> str`` so
     a test can assert which tier drove routing without a live provider.
+
+    ``prompt`` captures what actually crossed to the model, which the response
+    alone cannot show: a regression that folded above-ceiling fragment text
+    into the prompt while leaving the returned notes clean would egress that
+    text to the provider and still look correct from the outside.
     """
 
     def __init__(self, response: str) -> None:
-        """Store the canned LLM response and init the recorded tier."""
+        """Store the canned LLM response and init the recorded tier + prompt."""
         self.response = response
         self.asked_tier: PrivacyTier | None = None
+        self.prompt: str | None = None
 
     def __call__(self, tier: PrivacyTier):
-        """Record *tier* and return a constant LLM callable."""
+        """Record *tier* and return an LLM callable that records its prompt."""
         self.asked_tier = tier
-        return lambda prompt: self.response
+
+        def _llm(prompt: str) -> str:
+            self.prompt = prompt
+            return self.response
+
+        return _llm
 
 
 def _notes_payload(*notes: dict[str, str], essay: str | None = None) -> str:
@@ -82,6 +103,27 @@ def _audit(vault: Path) -> list[dict[str, object]]:
     log = vault / MCP_AUDIT_RELPATH
     assert log.exists()
     return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
+def _write_fragment(
+    vault: Path, frag_id: str, body: str, tier: str | None = None
+) -> None:
+    """Write a fragment markdown file that an ``entry_ref`` can resolve.
+
+    Args:
+        vault: Vault root as created by :func:`_vault`.
+        frag_id: The ``id`` front-matter value, i.e. the ``entry_ref`` to pass.
+        body: The fragment body, which becomes the entry being reflected on.
+        tier: The ``privacy_tier`` front-matter value. ``None`` omits the key
+            entirely, which the tool must treat as INTIMATE (fail closed) —
+            distinct from an explicit ``"unclassified"``.
+    """
+    frag_dir = vault / "01-Fragments" / "Notes"
+    frag_dir.mkdir(parents=True, exist_ok=True)
+    tier_line = "" if tier is None else f"privacy_tier: {tier}\n"
+    (frag_dir / f"{frag_id}.md").write_text(
+        f"---\nid: {frag_id}\n{tier_line}---\n{body}\n", encoding="utf-8"
+    )
 
 
 # --- 1. INTIMATE-never-cloud routing -------------------------------------------------
@@ -225,7 +267,14 @@ def test_no_verbatim_notes_yields_empty_status(tmp_path: Path) -> None:
 
 
 def test_retrieval_is_grounded_in_the_entry_and_ceiling(tmp_path: Path) -> None:
-    """Retrieval is called with the entry text and a ceiling-derived override."""
+    """Retrieval is called with the entry text and *this* ceiling's override.
+
+    The override is asserted to equal ``to_privacy_override(PERSONAL)``, not
+    merely to be non-``None``: grounding retrieval is the second read path into
+    the corpus, so passing the wrong (broader) override would pull
+    above-ceiling fragments into the prompt while every other assertion here
+    still held.
+    """
     seen: dict[str, object] = {}
 
     def _recording_retrieve(query: str, vault: Path, override: object) -> list[str]:
@@ -242,7 +291,7 @@ def test_retrieval_is_grounded_in_the_entry_and_ceiling(tmp_path: Path) -> None:
         privacy_tier_ceiling=TierCeiling.PERSONAL,
     )
     assert seen["query"] == _ENTRY
-    assert seen["override"] is not None
+    assert seen["override"] == to_privacy_override(TierCeiling.PERSONAL)
 
 
 def test_reflect_is_audit_logged(tmp_path: Path) -> None:
@@ -321,14 +370,15 @@ def test_reflect_is_read_only_wrt_corpus(tmp_path: Path) -> None:
 
 
 def test_entry_ref_resolves_a_fragment_body(tmp_path: Path) -> None:
-    """An ``entry_ref`` loads the fragment's body as the entry to reflect on."""
+    """An ``entry_ref`` loads the fragment's body as the entry to reflect on.
+
+    The fixture is classified ``open`` so this stays a pure resolution test:
+    under the #846 read-side gate an *untiered* fragment fails closed to
+    INTIMATE and would be refused before resolution could be observed.
+    """
     vault = _vault(tmp_path)
-    frag_dir = vault / "01-Fragments" / "Notes"
-    frag_dir.mkdir(parents=True)
     body = "the garden grew while I slept"
-    (frag_dir / "f.md").write_text(
-        f"---\nid: frag-xyz\n---\n{body}\n", encoding="utf-8"
-    )
+    _write_fragment(vault, "frag-xyz", body, tier="open")
     factory = _RecordingFactory(
         _notes_payload({"quote": body, "kind": "reframe", "note": "yours"})
     )
@@ -391,34 +441,6 @@ def test_unparseable_response_yields_no_notes(tmp_path: Path) -> None:
     assert result["notes"] == []
 
 
-def test_entry_ref_intimate_fragment_routes_local_despite_open_ceiling(
-    tmp_path: Path,
-) -> None:
-    """An INTIMATE fragment routes at INTIMATE even under an OPEN ceiling (#751 review).
-
-    The routing tier follows the entry's *actual* classified ``privacy_tier``,
-    never the (possibly lower) caller-declared ceiling — so genuinely intimate
-    journal content can never be reflected through a cloud model.
-    """
-    vault = _vault(tmp_path)
-    frag_dir = vault / "01-Fragments" / "Notes"
-    frag_dir.mkdir(parents=True)
-    body = "the garden grew while I slept"
-    (frag_dir / "f.md").write_text(
-        f"---\nid: frag-intimate\nprivacy_tier: intimate\n---\n{body}\n",
-        encoding="utf-8",
-    )
-    factory = _RecordingFactory(_notes_payload())
-    reflect_tool(
-        vault_path=vault,
-        entry_ref="frag-intimate",
-        llm_factory=factory,
-        retrieve=_no_retrieval,
-        privacy_tier_ceiling=TierCeiling.OPEN,
-    )
-    assert factory.asked_tier is PrivacyTier.INTIMATE
-
-
 def test_malformed_yaml_response_does_not_crash(tmp_path: Path) -> None:
     """A non-JSON, non-YAML response degrades to no notes (catches YAMLError)."""
     result = reflect_tool(
@@ -442,3 +464,467 @@ def test_entry_ref_not_found_has_a_distinct_reason(tmp_path: Path) -> None:
     )
     assert result["status"] == "refused"
     assert result["reason"] == "entry_ref not found"
+
+
+# --- Read-side tier ceiling (#846) ---------------------------------------------------
+
+# A phrase that appears nowhere else, so its presence in a response can only mean
+# the fragment body leaked through the gate.
+_INTIMATE_BODY = "the ultramarine dovecote unlatched at midnight"
+_INTIMATE_SPAN = "ultramarine dovecote"
+_REFUSAL_REASON = "entry_ref tier exceeds ceiling"
+
+
+class _RecordingGuard:
+    """A care guard that records being consulted and always flags distress.
+
+    Lets a test tell "the guard declined" apart from "the guard was never
+    asked", which is exactly what pinning the ceiling-before-care order needs.
+    """
+
+    def __init__(self) -> None:
+        """Init the consultation counter."""
+        self.calls = 0
+
+    def __call__(self, text: str) -> str | None:
+        """Record the consultation and flag *text* as acute distress."""
+        del text
+        self.calls += 1
+        return "acute_distress_markers"
+
+
+def test_entry_ref_above_ceiling_is_refused_not_reflected(tmp_path: Path) -> None:
+    """An INTIMATE ``entry_ref`` under an OPEN ceiling leaks nothing (#846).
+
+    The caller declared ``privacy_tier_ceiling=open``; the fragment is
+    classified ``intimate``. Reflecting it hands that caller *verified-verbatim*
+    spans of intimate content in ``notes[].quote`` plus free model prose in
+    ``essay`` — the exact leak #846 reports. The refusal must land before the
+    model, and no span of the body may survive anywhere in the response.
+
+    The audit assertion pins ordering, not logging: ``reflect_tool`` appends to
+    the MCP audit log *above* the gate, which is the only reason a refused read
+    is auditable at all. A refactor that moved the append below
+    ``_resolve_entry`` would silently stop recording exactly the attempts an
+    operator most needs to see — probes at fragments the caller is not admitted
+    to — with no other test failing. The count is pinned alongside it because
+    ``reflect.py`` promises *exactly one* append per call: a refusal-path
+    append added "for visibility" would make refused reads distinguishable
+    from admitted ones by record count alone, re-opening the read oracle the
+    tier-neutral reason closes.
+    """
+    vault = _vault(tmp_path)
+    _write_fragment(vault, "frag-intimate", _INTIMATE_BODY, tier="intimate")
+    factory = _RecordingFactory(
+        _notes_payload(
+            {"quote": _INTIMATE_BODY, "kind": "fear", "note": "a tender read"},
+            essay=f"You wrote that {_INTIMATE_BODY}.",
+        )
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-intimate",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert _INTIMATE_SPAN not in json.dumps(result), "intimate content egressed"
+    assert result["status"] == "refused"
+    assert result["tool"] == TOOL_NAME
+    assert result["reason"] == _REFUSAL_REASON
+    assert factory.asked_tier is None  # the model was never reached
+    # The refused attempt is still audited — the append sits above the gate —
+    # and exactly once: the refusal path adds no second record.
+    entries = _audit(vault)
+    assert len(entries) == 1
+    last = entries[-1]
+    assert last["tool"] == TOOL_NAME
+    assert last["args_summary"] == {"has_entry_ref": True}
+
+
+def test_personal_entry_ref_is_refused_under_open_ceiling(tmp_path: Path) -> None:
+    """A PERSONAL fragment is refused under an OPEN ceiling.
+
+    Pins the gate as a *rank comparison* against the ceiling rather than an
+    INTIMATE-only special case: ``personal`` outranks ``open``, so it refuses
+    with the same tier-neutral reason.
+    """
+    vault = _vault(tmp_path)
+    body = "the ledger of small refusals I keep"
+    _write_fragment(vault, "frag-personal", body, tier="personal")
+    factory = _RecordingFactory(
+        _notes_payload({"quote": body, "kind": "pattern", "note": "yours"})
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-personal",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "refused"
+    assert result["reason"] == _REFUSAL_REASON
+    assert factory.asked_tier is None
+
+
+def test_personal_entry_ref_is_allowed_under_personal_ceiling(tmp_path: Path) -> None:
+    """Equal rank is admitted: a PERSONAL fragment under a PERSONAL ceiling reflects.
+
+    The other side of the gate. An over-broad check that refused equal-rank
+    entries would silently break reflection for its primary caller, so the
+    admitted path asserts real notes came back, not merely a non-refusal.
+    """
+    vault = _vault(tmp_path)
+    body = "the ledger of small refusals I keep"
+    _write_fragment(vault, "frag-personal", body, tier="personal")
+    factory = _RecordingFactory(
+        _notes_payload({"quote": body, "kind": "pattern", "note": "yours"})
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-personal",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "ok"
+    assert result["notes"][0]["quote"] == body
+
+
+def test_intimate_entry_ref_is_allowed_under_intimate_ceiling_and_routes_local(
+    tmp_path: Path,
+) -> None:
+    """An admitted INTIMATE fragment still routes at ``PrivacyTier.INTIMATE``.
+
+    Replaces the former
+    ``test_entry_ref_intimate_fragment_routes_local_despite_open_ceiling``:
+    under #846 a *low*-ceiling call on an INTIMATE fragment is refused
+    outright, which is strictly stronger than "it routes local". The
+    routes-local guarantee still has to hold for the calls that *are* admitted,
+    so it is pinned here at the ceiling that admits them.
+    """
+    vault = _vault(tmp_path)
+    _write_fragment(vault, "frag-intimate", _INTIMATE_BODY, tier="intimate")
+    factory = _RecordingFactory(
+        _notes_payload({"quote": _INTIMATE_BODY, "kind": "fear", "note": "yours"})
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-intimate",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.INTIMATE,
+    )
+    assert result["status"] == "ok"
+    assert factory.asked_tier is PrivacyTier.INTIMATE
+
+
+@pytest.mark.parametrize(
+    ("ceiling", "entry_tier", "expected"),
+    [
+        # The fold-in proper: the entry outranks the ceiling, so the entry wins.
+        (TierCeiling.OPEN, PrivacyTier.INTIMATE, PrivacyTier.INTIMATE),
+        (TierCeiling.OPEN, PrivacyTier.PERSONAL, PrivacyTier.PERSONAL),
+        (TierCeiling.PERSONAL, PrivacyTier.INTIMATE, PrivacyTier.INTIMATE),
+        # The ceiling wins when it is the more sensitive of the two...
+        (TierCeiling.INTIMATE, PrivacyTier.OPEN, PrivacyTier.INTIMATE),
+        (TierCeiling.ALL, PrivacyTier.OPEN, PrivacyTier.INTIMATE),
+        # ...and on a rank tie, which keeps ``unclassified`` from downgrading
+        # the routing tier below the ceiling's own.
+        (TierCeiling.OPEN, PrivacyTier.UNCLASSIFIED, PrivacyTier.OPEN),
+        # Raw inline ``content`` has no classification: the ceiling alone routes.
+        (TierCeiling.OPEN, None, PrivacyTier.OPEN),
+        (TierCeiling.PERSONAL, None, PrivacyTier.PERSONAL),
+        (TierCeiling.INTIMATE, None, PrivacyTier.INTIMATE),
+        # ``ALL`` admits intimate content, so it must route as INTIMATE.
+        (TierCeiling.ALL, None, PrivacyTier.INTIMATE),
+    ],
+)
+def test_routing_tier_takes_the_more_sensitive_of_entry_and_ceiling(
+    ceiling: TierCeiling, entry_tier: PrivacyTier | None, expected: PrivacyTier
+) -> None:
+    """``_routing_tier`` routes at the more sensitive of entry tier and ceiling.
+
+    Asserted against the helper directly rather than through
+    :func:`reflect_tool`, and that is the whole point. Since the #846 gate
+    refuses every ``entry_ref`` whose classified tier exceeds the ceiling, no
+    call through the public API can still reach ``_routing_tier`` with an
+    above-ceiling *entry_tier*: every admitted ``entry_tier`` is by
+    construction ``<= _CEILING_ROUTING_TIER[ceiling]``, so through the tool the
+    fold-in is behaviourally identical to ``return ceiling_tier``. Every
+    end-to-end test in this file would therefore still pass if the ``max`` were
+    "simplified" away.
+
+    The fold-in is nonetheless the load-bearing INTIMATE-never-egresses
+    guarantee that ``reflect.py`` says must not be removed: it is the layer
+    that keeps an INTIMATE entry off a cloud provider if the read-side gate
+    above it ever regresses, is reordered, or is bypassed by a future caller
+    that resolves a fragment without going through the gate. Defense in depth
+    is unreachable by construction from outside; only a direct test can
+    falsify it.
+
+    Args:
+        ceiling: The caller's declared ceiling.
+        entry_tier: The entry's classified tier, or ``None`` for raw content.
+        expected: The tier the router must be asked for.
+    """
+    assert _routing_tier(ceiling, entry_tier) is expected
+
+
+def test_intimate_entry_ref_is_allowed_under_all_ceiling(tmp_path: Path) -> None:
+    """``ALL`` admits every tier, so an INTIMATE ``entry_ref`` reflects under it.
+
+    ``ALL`` sits above ``INTIMATE`` in the ceiling ranking and short-circuits
+    :func:`creek_mcp.tier_ceiling.tier_allowed` to ``True``; the gate must not
+    turn that into an off-by-one refusal.
+    """
+    vault = _vault(tmp_path)
+    _write_fragment(vault, "frag-intimate", _INTIMATE_BODY, tier="intimate")
+    factory = _RecordingFactory(
+        _notes_payload({"quote": _INTIMATE_BODY, "kind": "fear", "note": "yours"})
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-intimate",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert result["status"] == "ok"
+
+
+def test_explicitly_unclassified_entry_ref_is_allowed_under_open_ceiling(
+    tmp_path: Path,
+) -> None:
+    """An explicit ``privacy_tier: unclassified`` is admitted at the OPEN ceiling.
+
+    ``unclassified`` shares rank 0 with ``open`` in the canonical ranking, so a
+    fragment that was *classified as* unclassified is admissible to the most
+    restrictive ceiling. Paired with the fail-closed test below.
+    """
+    vault = _vault(tmp_path)
+    body = "a note I never got round to sorting"
+    _write_fragment(vault, "frag-unclassified", body, tier="unclassified")
+    factory = _RecordingFactory(
+        _notes_payload({"quote": body, "kind": "pattern", "note": "yours"})
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-unclassified",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    assert result["notes"][0]["quote"] == body
+
+
+@pytest.mark.parametrize("ceiling", [TierCeiling.OPEN, TierCeiling.PERSONAL])
+def test_untiered_entry_ref_is_refused_fail_closed(
+    tmp_path: Path, ceiling: TierCeiling
+) -> None:
+    """A fragment with **no** ``privacy_tier`` key is refused (fail closed).
+
+    Both ceilings are exercised because the OPEN case alone under-pins the
+    default: at OPEN *any* fail-closed value above rank 0 refuses, so a
+    weakening of ``_fragment_tier`` from INTIMATE to PERSONAL would slip
+    through. The PERSONAL ceiling admits ``personal`` and refuses only
+    ``intimate``, so it is what actually pins the default at the
+    most-restrictive tier.
+
+    Deliberately paired with
+    :func:`test_explicitly_unclassified_entry_ref_is_allowed_under_open_ceiling`:
+    an *explicit* ``unclassified`` is a classification decision and ranks 0,
+    whereas a *missing* key means the fragment was never classified at all.
+    ``_fragment_tier`` treats that as INTIMATE, so the gate must refuse it.
+
+    Scope, stated precisely: this fail-closed covers fragments missing the key
+    *entirely* — hand-edited, legacy, or otherwise not written by the pipeline.
+    It is **not** the guard for a half-ingested vault: ``creek/vault/writer.py``
+    serialises via ``model_dump(mode="json")`` and ``Fragment.privacy_tier``
+    defaults to ``PrivacyTier.UNCLASSIFIED``, so every pipeline-written
+    pre-classification fragment carries an *explicit* ``privacy_tier:
+    unclassified``, which ranks 0 and is admitted at the OPEN ceiling (the test
+    above). Those fragments are governed by the separate, systemic
+    "``unclassified`` ranks as open" policy in :mod:`creek_mcp.tier_ceiling` /
+    :mod:`creek.classify.privacy_filter` — deliberate, and out of scope here.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+        ceiling: A ceiling that must refuse the untiered fragment. ``PERSONAL``
+            is the discriminating case; ``OPEN`` keeps the original coverage.
+    """
+    vault = _vault(tmp_path)
+    _write_fragment(vault, "frag-untiered", _INTIMATE_BODY)
+    factory = _RecordingFactory(
+        _notes_payload({"quote": _INTIMATE_BODY, "kind": "fear", "note": "yours"})
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-untiered",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=ceiling,
+    )
+    assert _INTIMATE_SPAN not in json.dumps(result), "unclassified content egressed"
+    assert result["status"] == "refused"
+    assert result["reason"] == _REFUSAL_REASON
+    assert factory.asked_tier is None
+
+
+def test_unrecognised_entry_ref_tier_is_refused_fail_closed(tmp_path: Path) -> None:
+    """A ``privacy_tier`` value outside the vocabulary is refused (fail closed).
+
+    The third state of the tier field, distinct from both neighbours above: the
+    key is *present* but carries a value this build cannot parse — a hand edit,
+    a typo, or a vocabulary from a newer schema. ``_fragment_tier`` reaches its
+    ``except ValueError`` arm, which must yield INTIMATE: an unknown
+    classification says nothing about sensitivity, so admitting it would hand
+    out the one fragment whose tier nobody can vouch for.
+
+    The ceiling is ``PERSONAL`` rather than ``OPEN`` on purpose — it admits
+    ``personal`` and refuses only ``intimate``, so it pins the ``except`` arm at
+    the most-restrictive tier instead of merely "something above open".
+    """
+    vault = _vault(tmp_path)
+    _write_fragment(vault, "frag-bogus-tier", _INTIMATE_BODY, tier="not-a-tier")
+    factory = _RecordingFactory(
+        _notes_payload({"quote": _INTIMATE_BODY, "kind": "fear", "note": "yours"})
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-bogus-tier",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert _INTIMATE_SPAN not in json.dumps(result), "unparseable-tier content egressed"
+    assert result["status"] == "refused"
+    assert result["reason"] == _REFUSAL_REASON
+    assert factory.asked_tier is None
+
+
+def test_raw_content_is_never_gated_by_the_ceiling(tmp_path: Path) -> None:
+    """Raw inline ``content`` is the caller's own text and is never gated.
+
+    The read-side gate exists to stop a caller *reading corpus fragments* above
+    their ceiling. Text they supplied in the call is already in their hands, so
+    gating it would refuse every ordinary journal reflection.
+    """
+    factory = _RecordingFactory(
+        _notes_payload(
+            {"quote": "the garden grew while I slept", "kind": "reframe", "note": "y"}
+        )
+    )
+    result = reflect_tool(
+        vault_path=_vault(tmp_path),
+        content=_ENTRY,
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    assert "reason" not in result  # never refused
+    assert factory.asked_tier is PrivacyTier.OPEN
+
+
+def test_content_wins_over_entry_ref_and_is_not_a_ceiling_bypass(
+    tmp_path: Path,
+) -> None:
+    """Supplying both ``content`` and ``entry_ref`` reads the fragment not at all.
+
+    ``_resolve_entry`` returns ``(content, None)`` the moment ``content`` is
+    non-blank, so a call carrying *both* an inline entry and an ``entry_ref``
+    pointed at an above-ceiling fragment never opens that fragment: there is no
+    ``entry_tier``, the gate correctly does not fire, and nothing of the
+    fragment can reach the response or the model.
+
+    This pins the precedence as a **non-bypass**, not merely as a convenience.
+    Its shape is exactly what an attempted bypass would look like — pair a
+    harmless ``content`` with an ``entry_ref`` above your ceiling and see what
+    comes back. The safety therefore rests on ``content`` short-circuiting the
+    read *before* the fragment is loaded; an "improvement" that resolved
+    ``entry_ref`` first (or merged the two) would turn this call into the leak
+    #846 closed, and routing would follow an unread fragment's tier.
+
+    The prompt is asserted alongside the response because the response alone
+    only shows what came *back*. A merge that appended the fragment's text to
+    the prompt while leaving ``entry_tier`` at ``None`` would egress intimate
+    content to the provider — the leak in full — and still return clean,
+    verbatim-checked notes drawn from the inline entry.
+    """
+    vault = _vault(tmp_path)
+    _write_fragment(vault, "frag-intimate", _INTIMATE_BODY, tier="intimate")
+    factory = _RecordingFactory(
+        _notes_payload(
+            {"quote": "the garden grew while I slept", "kind": "reframe", "note": "y"}
+        )
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        content=_ENTRY,
+        entry_ref="frag-intimate",
+        llm_factory=factory,
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    # The fragment was never read, so not a span of it can appear.
+    assert _INTIMATE_SPAN not in json.dumps(result), "intimate content egressed"
+    assert result["notes"][0]["quote"] == "the garden grew while I slept"
+    # Nor could it reach the model: the prompt carries only the inline entry.
+    assert factory.prompt is not None
+    assert _INTIMATE_SPAN not in factory.prompt, "intimate content reached the model"
+    assert _ENTRY in factory.prompt  # the caller's own text is what was sent
+    # Routed by the ceiling, not by the unread fragment's INTIMATE tier.
+    assert factory.asked_tier is PrivacyTier.OPEN
+
+
+def test_care_guard_is_not_consulted_for_an_above_ceiling_entry(
+    tmp_path: Path,
+) -> None:
+    """The ceiling is checked *before* the care guard, which never runs (#846).
+
+    Ordering is load-bearing. If care ran first, an unadmitted caller would get
+    ``status: "escalate"`` instead of ``"refused"`` — a one-bit oracle telling
+    them that a fragment they are not allowed to read carries acute-distress
+    markers. The gate must therefore sit above the care seam, and the guard
+    must not even be handed the entry text.
+    """
+    vault = _vault(tmp_path)
+    _write_fragment(vault, "frag-intimate", _INTIMATE_BODY, tier="intimate")
+    guard = _RecordingGuard()
+    result = reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-intimate",
+        llm_factory=_RecordingFactory(_notes_payload()),
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        care_guard=guard,
+    )
+    assert result["status"] == "refused"
+    assert result["reason"] == _REFUSAL_REASON
+    assert guard.calls == 0
+
+
+def test_care_guard_still_runs_for_an_admitted_entry_ref(tmp_path: Path) -> None:
+    """An admitted ``entry_ref`` still passes through the care boundary (#753).
+
+    The #846 gate must not disable the care seam: with a ceiling that admits
+    the fragment, a firing guard escalates with the structured care signal
+    rather than reflecting.
+    """
+    vault = _vault(tmp_path)
+    _write_fragment(vault, "frag-intimate", _INTIMATE_BODY, tier="intimate")
+    guard = _RecordingGuard()
+    result = reflect_tool(
+        vault_path=vault,
+        entry_ref="frag-intimate",
+        llm_factory=_RecordingFactory(_notes_payload()),
+        retrieve=_no_retrieval,
+        privacy_tier_ceiling=TierCeiling.INTIMATE,
+        care_guard=guard,
+    )
+    assert result["status"] == "escalate"
+    assert result["care_signal"] == CARE_SIGNAL
+    assert guard.calls == 1


### PR DESCRIPTION
## Summary

`creek.reflect` resolved an `entry_ref` to a vault fragment's body **and** its classified `privacy_tier`, then used that tier for exactly one thing: picking the LLM routing tier. It never compared the tier to the caller's `privacy_tier_ceiling`. Since every returned `notes[].quote` is a *verified verbatim substring* of the entry, a caller at `ceiling=open` who passed the id of an INTIMATE fragment received literal spans of that intimate content — plus a free-prose `essay` written over it.

This was reachable over the network. `server.py` caps remote consumers at `_REMOTE_ADMITTED_CEILINGS = PERSONAL` precisely so intimate content is unreachable remotely (#759); reflect's `entry_ref` path walked around that cap. The contract doc has promised the opposite all along — *"Reads above the ceiling are refused… a rank comparison applied uniformly to reads and writes"* (`docs/decisions/2026-06-30-adepthood-creek-mcp-contract.md`) — so this is a spec-conformance bug, not a semantics change.

### The fix

A single read-side admission gate. New module-level `_above_ceiling` delegates the rank comparison to `creek_mcp.tier_ceiling.tier_allowed` — the canonical read-side predicate, so reflect cannot drift from the rest of the MCP surface — and `reflect_tool` returns the standard `refusal_response` when it fires. Raw inline `content` is never gated: it resolves to `entry_tier is None`, carries no classification, and is the caller's own text.

Three placement decisions, each load-bearing:

| Placement | Why |
|---|---|
| **After** the unconditional `MCPAuditLog` append | A refused probe stays audited. No second append on refusal, and the fragment id is deliberately not logged — so probing surfaces as a *rate* of `has_entry_ref` calls per consumer, not as named targets. Both choices are now recorded in a comment rather than being incidental. |
| **After** the `"entry_ref not found"` refusal | Keeps that distinct, pinned, debuggable reason intact. |
| **Before** the `care_guard` seam | An `escalate` response is a one-bit oracle telling a caller who may not read a fragment that it carries acute-distress markers. Care still runs for every raw-`content` call and every within-ceiling `entry_ref`, so no legitimate care pathway is lost — a client that *wrote* an entry necessarily holds a ceiling that admits it. |

The refusal reason does **not** echo the offending tier, diverging from `save.py` on purpose: there the tier came from the caller's own input; here it is derived from content they are not admitted to, so echoing it would be a tier-classification oracle. The residual coarse oracle in the not-found-vs-above-ceiling split is documented as accepted risk, with the note that unifying the two reasons would also require equalising the vault scan or the timing difference would preserve it as a side channel.

`_fragment_tier` and `_routing_tier` are unchanged. The routing fold-in is now unreachable-by-construction through the public API (every admitted `entry_tier` is at or below the ceiling-derived tier), so it is pinned by a **direct unit test** rather than deleted — it remains defense in depth if the gate is ever reordered or bypassed.

### Two existing tests changed — neither to make a metric pass

- `test_entry_ref_resolves_a_fragment_body` — its fixture had no `privacy_tier` key and would now fail closed, so it declares `privacy_tier: open`. Intent untouched.
- `test_entry_ref_intimate_fragment_routes_local_despite_open_ceiling` — asserted a scenario that is now refused *before* the LLM factory is ever built, making `factory.asked_tier is PrivacyTier.INTIMATE` unreachable-by-construction. Replaced by the same guarantee at an admitting ceiling. Refusal is strictly stronger than routing local.

## Test plan

`cd creek-tools && ./scripts/check-all.sh` → **exit 0** (12 passed / 0 failed; 6083 tests; 93.91% aggregate branch coverage; per-file gate, mypy strict, pylint, bandit, refurb, tryceratops, interrogate, complexity all clean).

Gate 1 was genuinely RED first — 4 failures against unfixed `reflect.py`, the headline one asserting the intimate span was absent from `json.dumps(result)` so the failure names the leak itself rather than a status mismatch.

New coverage:

- **The leak** — INTIMATE fragment at `ceiling=open` is refused; no span of the body appears anywhere in the serialized result; the LLM factory is never asked.
- **Rank, not a special case** — PERSONAL refused under OPEN; PERSONAL admitted under PERSONAL; INTIMATE admitted under INTIMATE (and still routes local) and under ALL.
- **Fail-closed** — a fragment with no `privacy_tier` key, and one with an unparseable value, are both refused; each asserted at `ceiling=personal` as well as `open`, so weakening `_fragment_tier`'s default from INTIMATE to PERSONAL would fail.
- **Non-bypass** — supplying `content` *and* `entry_ref` together: the fragment is never read, the span appears in neither the result nor the recorded prompt, and routing follows the ceiling.
- **Ordering** — `care_guard` is not consulted for an above-ceiling entry, yet still fires for an admitted one; and exactly one audit record is written for a refused call (a refusal-path append would make refused reads distinguishable by record count).
- **Defense in depth** — `_routing_tier` parametrized directly across 10 cases, including the ties and the `None` entry tier, so collapsing it to `return ceiling_tier` fails.

Gate 2.5 self-review (implementation + test + security dimensions, plus a dedicated prior security pass) found no residual egress path and returned one blocker — the missing direct `_routing_tier` test — which is fixed here along with every non-blocking nit.

## Out of scope, already tracked

- #847 — unguarded `frontmatter.load` in `_resolve_entry`.
- #848 — `creek.compile`'s unenforced write-side tier ceiling.

Two further findings from the security pass have no issue yet and are worth filing: `creek/vault/writer.py`'s `_clear_classification` keeps `privacy_tier` across a material body rewrite (a stale-tier admission path straight through this new gate), and `tier_allowed`'s bare `_TIER_RANK[tier]` subscript would `KeyError` rather than fail closed if a `PrivacyTier` member were ever added without updating the map.

Closes #846

🤖 Generated with [Claude Code](https://claude.com/claude-code)
