### PR TITLE
fix(mcp): enforce creek.compile's documented write-side tier ceiling

### DIFF
--- a/creek-tools/creek_mcp/tools/compile.py
+++ b/creek-tools/creek_mcp/tools/compile.py
@@ -1,8 +1,34 @@
 """``creek.compile`` MCP tool — roll fragments into a compiled page.
 
-Wraps :func:`creek.compile.engine.compile_to_vault` (FEAT-003). The
-write-side tier-ceiling rule applies: a caller cannot create a compiled
-page whose source fragments include a tier they could not read.
+Wraps :func:`creek.compile.engine.compile_to_vault` (FEAT-003).
+
+Four guarantees this module enforces (#848 — before that fix the first
+of them was asserted in this docstring and implemented nowhere):
+
+- **The write-side ceiling is checked against the *source* tiers, before
+  any state-affecting step.** Compile's variant of the FEAT-011 write-side
+  rule gates the classified tiers of the fragments being rolled up
+  rather than the tier of the page being created: a caller cannot
+  compile a page out of fragments they *named* and could not read.
+  (Only the named ids are checked — an admitted fragment's own
+  ``structural_path`` ancestry is not, which is a tracked follow-up.)
+  The check runs
+  ahead of any LLM client being built, any page being written, and any
+  paradox being logged — the three places the source ids would
+  otherwise escape (enumerated in :func:`compile_tool`).
+- **The refusal names nothing.** It carries the fixed
+  :data:`_ABOVE_CEILING_REASON`: no ids, no titles, no tiers, not even a
+  count of how many sources were above the ceiling.
+- **The refusal is audited, while the argument-validation refusals are
+  not.** An attempted ceiling violation is an operator-relevant signal;
+  a typo'd ``target_kind`` is not. This mirrors ``save`` / ``journal``
+  and is a deliberate departure from ``reflect``, which appends
+  unconditionally at the top of the call — :func:`compile_tool`
+  explains why compile cannot do the same.
+- **The gate and the engine share one fragment loader.** Both read the
+  vault through :func:`creek.vault.reader.iter_vault_fragments`, so the
+  two can never disagree about which files exist or which of them are
+  fragments (see :func:`_sources_above_ceiling`).
 
 **Idempotency semantics (audit-dedup only).** The wrapper fingerprints
 the target file after each compile and stamps the hash under
@@ -20,18 +46,62 @@ Engine-side LLM-call dedup is tracked separately as a follow-up.
 from __future__ import annotations
 
 import hashlib
-from typing import TYPE_CHECKING, Any, Protocol, cast
+from typing import TYPE_CHECKING, Any, Final, Protocol, cast
 
 from creek.compile.engine import TARGET_KINDS, compile_to_vault
+from creek.models import PrivacyTier
+from creek.vault.reader import iter_vault_fragments
 from creek_mcp.audit import MCPAuditLog
-from creek_mcp.tier_ceiling import TierCeiling, refusal_response
+from creek_mcp.tier_ceiling import (
+    TierCeiling,
+    refusal_response,
+    write_tier_allowed,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from creek.models import CompileTargetKind
+    from creek.models import CompileTargetKind, Fragment
 
 TOOL_NAME = "creek.compile"
+
+# The above-ceiling refusal reason is a fixed string naming no fragment id, no
+# title, no tier, and no count. Echoing the offending ids would turn a single
+# call into a bulk tier-classification oracle — submit 100 ids, learn 100 tiers
+# in one round trip. A count would be nearly as useful to an attacker: it makes
+# group testing *exact*, so a caller could binary-search a batch knowing
+# precisely how many above-ceiling ids each half holds.
+#
+# ACCEPTED RESIDUAL RISK: a bare boolean is still a group-testing oracle — a
+# caller who resubmits subsets of a batch identifies every above-ceiling id in
+# O(k log n) calls. Two things that argument must NOT lean on:
+#
+# - *Id unguessability is not a control here.* Ids are deterministic
+#   (``creek.ingest.base.generate_fragment_id`` hashes source+timestamp+content;
+#   ``generate_child_fragment_id`` hashes ``f"{parent_id}:{level}:{index}"``), so
+#   from a single admitted parent id a caller can enumerate every child id with
+#   no knowledge of the content. The id space around known content IS sweepable;
+#   only a blind sweep of the full 48-bit space is infeasible.
+# - *Probe cost does NOT leak where the offending fragment sits.* Worth stating
+#   because the symmetry is accidental and a refactor could destroy it:
+#   ``iter_vault_fragments`` materialises the whole directory into a list before
+#   returning, so the rglob + parse cost is paid in full before
+#   ``_sources_above_ceiling``'s loop begins. The early ``return True`` therefore
+#   short-circuits only in-memory iteration, not the I/O. Unlike
+#   ``reflect.py::_resolve_entry``, which walks a raw lazy ``rglob`` and returns
+#   at the match — a genuine timing channel that comment correctly records. If
+#   this gate is ever switched to a lazy loader (see the load-once follow-up),
+#   that channel appears here too and must be re-analysed.
+#
+# Accepted because the real control is the audit trail, not id entropy: every
+# True probe appends a ``creek.compile`` entry distinguishable from a success
+# (no ``created_path``, no ``affected_fragment_ids``), so a sweep is detectable
+# by rate. Noting the attacker's counter honestly — appending one known-missing
+# id makes the negative half fall through to the engine's not-found refusal,
+# which is NOT audited, so only positive probes are logged. Accepted also
+# because *some* distinguishable refusal is required for a legitimate client's
+# bug to be debuggable at all.
+_ABOVE_CEILING_REASON: Final[str] = "source fragments exceed tier ceiling"
 
 
 class CompileLLMFactory(Protocol):
@@ -50,6 +120,105 @@ def _fingerprint(path: Path) -> str | None:
     if not path.exists():
         return None
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _tier_of(fragment: Fragment, raw: dict[str, object]) -> PrivacyTier:
+    """Return *fragment*'s tier, failing closed when the key is absent.
+
+    :class:`~creek.models.Fragment` defaults a *missing* ``privacy_tier``
+    to ``unclassified``, which ranks alongside ``open`` and so would be
+    admitted at every ceiling. Reading the tier off the model alone
+    would therefore fail **open** on exactly the file whose tier nobody
+    can vouch for — a hand-edited or legacy fragment. The raw
+    frontmatter is consulted because it is the only place the two cases
+    are still distinguishable once the model has applied its default.
+
+    This mirrors :func:`creek_mcp.tools.reflect._fragment_tier` (#847)
+    and :func:`creek.classify.privacy_filter.tier_of`, both of which
+    treat an absent tier as ``intimate``. Compile must agree with them:
+    two MCP tools that disagree about the same file is precisely the
+    divergence this module's shared-loader design exists to prevent.
+
+    A fragment carrying an *explicit* ``privacy_tier: unclassified`` —
+    what every pipeline-written, not-yet-classified fragment has — is
+    untouched here and stays admitted at any ceiling. That ranking is
+    deliberate policy owned by ``creek_mcp.tier_ceiling._TIER_RANK``
+    (#923), not by this fail-closed path.
+
+    Args:
+        fragment: The validated fragment as loaded by the shared reader.
+        raw: The file's raw frontmatter, before model defaults applied.
+
+    Returns:
+        ``PrivacyTier.INTIMATE`` when ``privacy_tier`` is absent from
+        *raw*, else the fragment's own classified tier.
+    """
+    if "privacy_tier" not in raw:
+        return PrivacyTier.INTIMATE
+    return fragment.privacy_tier
+
+
+def _sources_above_ceiling(
+    vault_path: Path, fragment_ids: list[str], ceiling: TierCeiling
+) -> bool:
+    """Return whether any requested source fragment's tier exceeds *ceiling*.
+
+    The vault is walked through
+    :func:`creek.vault.reader.iter_vault_fragments` — the exact function
+    :func:`creek.compile.engine._load_fragments_for_compile` calls — so the set
+    of files this gate inspects and the set the engine would compile are
+    identical *by construction*. A bespoke ``frontmatter.load`` walk would
+    diverge: :func:`creek.vault.reader.try_load_fragment` rejects files whose
+    ``type`` is not ``fragment`` and files that fail ``Fragment`` schema
+    validation, both of which a raw scan happily reads. That divergence would
+    create a class of file one side sees and the other does not — precisely the
+    bug class this gate exists to prevent. A file the shared loader skips
+    (unreadable, non-fragment, schema-invalid) is invisible to gate and engine
+    alike, and so fails closed to the engine's "not found".
+
+    That parity is by construction but not instantaneous: the gate walks the
+    vault, returns, and the engine then walks it again. A concurrent writer that
+    *raises* a fragment's tier inside that window (``creek classify``, the
+    ``creek.classify`` MCP tool, a text editor) would be compiled under the
+    pre-write tier. The window is not caller-controlled and closing it means
+    handing the loaded fragments to the engine — an engine signature change,
+    tracked as a follow-up along with eliminating the duplicated walk.
+
+    Admission is decided by :func:`creek_mcp.tier_ceiling.write_tier_allowed`
+    rather than the :func:`~creek_mcp.tier_ceiling.tier_allowed` it delegates
+    to. The two are behaviourally identical today, but this is a *write* tool
+    enforcing the FEAT-011 write-side rule, and keeping every write gate on one
+    predicate (``save.py``, ``journal.py``, here) means ``grep
+    write_tier_allowed`` enumerates them all — and any future divergence
+    between the read-side and write-side rules lands compile on the correct
+    side automatically. For the same reason there is deliberately no
+    ``ceiling is TierCeiling.ALL`` fast path: a second route to the answer
+    would silently desync if ``ALL``'s semantics ever changed.
+
+    Args:
+        vault_path: Vault root; fragments are read from ``01-Fragments``.
+        fragment_ids: The ids the caller asked to compile. An id with no
+            matching fragment in the vault is **not** a violation — it falls
+            through to the engine's ``ValueError("Fragment(s) not found in
+            vault: ...")`` so a legitimate caller still learns the id does not
+            resolve.
+        ceiling: The caller's declared ceiling.
+
+    Returns:
+        ``True`` when at least one requested fragment is above *ceiling*.
+        Deliberately a bare bool — the offending ids never leave this function;
+        see :data:`_ABOVE_CEILING_REASON` for why.
+    """
+    requested = set(fragment_ids)
+    for _path, fragment, _body, raw in iter_vault_fragments(
+        vault_path / "01-Fragments",
+    ):
+        if fragment.id in requested and not write_tier_allowed(
+            _tier_of(fragment, raw),
+            ceiling,
+        ):
+            return True
+    return False
 
 
 def compile_tool(
@@ -72,7 +241,25 @@ def compile_tool(
     Args:
         llm_factory: Zero-argument callable returning the compile LLM
             client. Invoked lazily so the LLM provider only matters
-            when this tool is actually called.
+            when this tool is actually called — and not at all when the
+            source-tier gate refuses.
+        privacy_tier_ceiling: The caller's ceiling. Compile's variant of
+            the FEAT-011 write-side rule gates the *source* fragments'
+            classified tiers, not the tier of the content created (which
+            is what ``save`` gates): rolling an ``intimate`` fragment
+            into a compiled page under ``ceiling=open`` is refused,
+            because the page, its provenance, and the compile prompt
+            would each carry content the caller cannot read.
+
+    Returns:
+        ``{status, tool, tier_ceiling, ...}`` — ``ok`` with the written
+        ``compiled_path``, ``noop`` when a re-run reproduced the stored
+        hash, or a structured ``refused`` response for one of: an
+        unknown *target_kind*; an empty *fragment_ids*; a source
+        fragment above *privacy_tier_ceiling*
+        (:data:`_ABOVE_CEILING_REASON`, #848 — the only refusal that is
+        audited); or an engine ``ValueError`` / ``RuntimeError``, such
+        as a fragment id that does not resolve in the vault.
     """
     if target_kind not in TARGET_KINDS:
         return refusal_response(
@@ -88,6 +275,69 @@ def compile_tool(
             tool=TOOL_NAME,
             ceiling=privacy_tier_ceiling,
             reason="fragment_ids must be non-empty",
+        )
+
+    # The write-side source-tier gate (#848). Its position is load-bearing in
+    # both directions.
+    #
+    # It sits *below* the two argument-validation refusals above because
+    # neither ordering leaks — those checks read only caller-supplied input and
+    # touch no vault state, so they can answer nothing about the corpus. The
+    # tiebreaker is cost asymmetry: this gate is a full ``01-Fragments`` walk,
+    # so gating first would let any caller force a 35k-file parse with a
+    # syntactically invalid call.
+    #
+    # It sits *above* everything that follows, because each of those steps
+    # hands the source fragments somewhere the caller is not admitted to:
+    #
+    # - ``llm_factory()`` is evaluated as an *argument* to ``compile_to_vault``
+    #   below, and the prompt the engine builds emits ``id:`` and ``title:``
+    #   for every source unconditionally (``_fragment_excerpt_for_prompt``
+    #   redacts only the *body*) to a provider that is **not** tier-routed.
+    #   That is the primary egress breach.
+    # - ``compile_to_vault`` writes the compiled page — carrying per-claim
+    #   provenance that names the source ids — into ``02-Threads`` /
+    #   ``03-Eddies`` / ``06-Frequencies``, pages any ``open``-ceiling read
+    #   tool then serves: intimate ids laundered into open-tier artifacts.
+    # - ``_append_paradox_log`` writes LLM-authored text plus the source ids to
+    #   ``00-Creek-Meta/Processing-Log/paradoxes-during-compile.jsonl``.
+    # - the hash marker further below: a refused call must leave zero
+    #   idempotency state behind.
+    #
+    # The gate also deliberately wins over the engine's missing-id
+    # ``ValueError``. Were it the other way round, a caller could pair one
+    # above-ceiling id with a batch of guesses and read back from the
+    # "not found" list which of those guesses exist.
+    #
+    # This refusal is audited while the two argument-validation refusals above
+    # are not, mirroring ``save_tool`` / ``journal_ingest_tool``: an attempted
+    # ceiling violation is an operator-relevant signal, a malformed call is
+    # not. That is a deliberate departure from ``reflect_tool``, which appends
+    # unconditionally at the top of the function. Appending unconditionally
+    # here would append on *every* compile including no-ops, breaking
+    # ``test_compile_writes_audit_then_noop_on_re_run`` — the FEAT-011
+    # acceptance test asserting exactly one ``creek.compile`` entry across two
+    # calls. Compile's audit contract is "one entry per materially-new page",
+    # not "one entry per call".
+    #
+    # The audited args carry no source content: ``summarise_args`` collapses
+    # ``fragment_ids`` to ``{"count": N}``, and ``affected_fragment_ids`` — the
+    # one field the log persists verbatim — is omitted, as are ``created_path``
+    # and ``created_tier`` (nothing was created). ``target_title`` is omitted
+    # too: caller free text, irrelevant to a refusal.
+    if _sources_above_ceiling(vault_path, fragment_ids, privacy_tier_ceiling):
+        MCPAuditLog(vault_path).append(
+            tool=TOOL_NAME,
+            args={
+                "target_kind": target_kind,
+                "target_id": target_id,
+                "fragment_ids": list(fragment_ids),
+            },
+            tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+        )
+        return refusal_response(
+            tool=TOOL_NAME, ceiling=privacy_tier_ceiling, reason=_ABOVE_CEILING_REASON
         )
 
     kind = cast("CompileTargetKind", target_kind)

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -65,7 +65,7 @@ real desk. Only the `research` medium is wired — any other `medium` returns
 | `creek.link`            | `method` (`embeddings`\|`temporal`\|`eddies`), `rebuild`    | Links existing artefacts in place — any ceiling permitted.        |
 | `creek.report`          | `report_type` (`tags`\|`voice`)                             | Renders a vault-state report — any ceiling permitted.             |
 | `creek.skills.refresh`  | none beyond `ceiling`                                       | Voice-skill tree regen; intimate exemplars already excluded.      |
-| `creek.compile`         | `fragment_ids`, `target_kind`, `target_id`, `target_title`  | Idempotent per FEAT-003; no-op re-runs do not log a duplicate.    |
+| `creek.compile`         | `fragment_ids`, `target_kind`, `target_id`, `target_title`  | Gates the *source* fragments' tier, not the compiled page's tier — a source above `ceiling` refuses the whole call (#848). Idempotent per FEAT-003; no-op re-runs do not log a duplicate. |
 | `creek.journal`         | `content`, `external_id`, `timestamp?`, `tier?`             | Stages an Adepthood entry then ledger-ingests it (#754); `external_id` is the idempotency key and `tier` defaults to `open`. The entry's tier is honored — a ceiling that would not admit it is refused. |
 
 ### Purge tools (FEAT-012, elevated authorization required)
@@ -103,6 +103,14 @@ rather than silently downgraded — the body never lands in the vault
 and the audit entry records the refusal without the body. The same
 gate applies to `creek.ingest` because the default ingestor tier is
 `personal`.
+
+`creek.compile` (#848) gates on the opposite side: the tier that
+matters is the classified tier of the *source* fragments being rolled
+up, not the tier of the compiled page being created. If any requested
+source fragment's tier exceeds `ceiling`, the whole call is refused
+before the compile LLM is invoked or the page is written — so an
+intimate fragment can never be laundered into an open-tier compiled
+page. The refusal is audited but names no fragment ids and no tiers.
 
 ### Elevated-authorization model (FEAT-012)
 

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -16,12 +16,17 @@ from typing import TYPE_CHECKING
 import frontmatter
 import pytest
 
+from creek.compile.engine import PARADOX_LOG_RELPATH
 from creek.models import PrivacyTier
 from creek.save import TARGET_SUBDIRS
-from creek_mcp.audit import MCP_AUDIT_RELPATH, MCPAuditLog
+from creek_mcp.audit import (
+    MCP_AUDIT_RELPATH,
+    MCPAuditLog,
+    verify_mcp_audit_chain,
+)
 from creek_mcp.tier_ceiling import TierCeiling, write_tier_allowed
 from creek_mcp.tools.classify import classify_tool
-from creek_mcp.tools.compile import compile_tool
+from creek_mcp.tools.compile import _ABOVE_CEILING_REASON, compile_tool
 from creek_mcp.tools.ingest import ingest_tool
 from creek_mcp.tools.link import link_tool
 from creek_mcp.tools.report import report_tool
@@ -937,6 +942,478 @@ def test_compile_propagates_engine_errors_as_refusal(
     )
     assert result["status"] == "refused"
     assert "engine boom" in result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# compile — write-side source-tier ceiling (issue #848)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingLLMFactory:
+    """Compile LLM factory that records how many times it was invoked.
+
+    Issue #848's gate must refuse *before* the LLM client is built,
+    because the compile prompt is the egress surface: it carries source
+    fragment ids and titles to a possibly-cloud provider. A ``status ==
+    "refused"`` assertion alone cannot prove that. The pre-fix wrapper
+    evaluates ``llm_factory()`` as an argument *inside* the ``try``
+    around ``compile_to_vault``, so any factory that raises
+    ``ValueError``/``RuntimeError`` produces a refusal even with no gate
+    at all. Counting invocations separates "refused by the ceiling
+    gate" from "blew up on the way to the engine".
+    """
+
+    def __init__(self) -> None:
+        """Start with a zero invocation count."""
+        self.calls = 0
+
+    def __call__(self) -> object:
+        """Record one invocation and return a deterministic stub LLM."""
+        self.calls += 1
+        return lambda _prompt: "{}"
+
+
+def test_compile_refuses_intimate_source_under_open_ceiling(vault: Path) -> None:
+    """An ``intimate`` source fragment is refused at ``ceiling=open``.
+
+    Acceptance test for issue #848: the ``creek_mcp.tools.compile``
+    module docstring promises a caller cannot create a compiled page
+    whose source fragments include a tier they could not read.
+    """
+    _write_fragment(vault, frag_id="frag-sealed", privacy_tier="intimate")
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-sealed"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=_noop_llm_factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "refused"
+    assert result["reason"] == _ABOVE_CEILING_REASON
+
+
+def test_compile_refusal_never_invokes_the_llm_factory(vault: Path) -> None:
+    """The above-ceiling refusal never builds the compile LLM client.
+
+    This is the load-bearing egress assertion for issue #848: source
+    fragment ids and titles reach the (possibly cloud) provider through
+    the compile prompt, so the gate is only real if the factory is
+    never called. See :class:`_RecordingLLMFactory` for why a refusal
+    status on its own would be a false green.
+    """
+    _write_fragment(vault, frag_id="frag-sealed", privacy_tier="intimate")
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-sealed"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert result["reason"] == _ABOVE_CEILING_REASON
+    assert factory.calls == 0
+
+
+def test_compile_refusal_writes_no_page_no_paradox_log_no_hash_marker(
+    vault: Path,
+) -> None:
+    """An above-ceiling refusal leaves no on-disk trace of the sources.
+
+    The stub LLM returns a payload that *would* produce both a compiled
+    page (with provenance naming the intimate fragment) and a paradox
+    log entry, so each missing artefact is evidence the engine never
+    ran rather than evidence it ran and found nothing to write.
+    """
+    frag_id = "frag-sealed"
+    _write_fragment(vault, frag_id=frag_id, privacy_tier="intimate")
+    payload = json.dumps(
+        {
+            "claims": [{"id": "c1", "text": "A claim.", "fragment_ids": [frag_id]}],
+            "paradoxes": [
+                {"description": "A tension.", "fragment_ids": [frag_id]},
+            ],
+        },
+    )
+
+    def _leaky_factory() -> object:
+        """Return a stub LLM that would emit a page body and a paradox."""
+        return lambda _prompt: payload
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=[frag_id],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=_leaky_factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert result["reason"] == _ABOVE_CEILING_REASON
+    assert not (vault / "02-Threads" / "Active" / "thread-x.md").exists()
+    assert not (vault / PARADOX_LOG_RELPATH).exists()
+    assert not (vault / "00-Creek-Meta" / "audit" / "compile-thread-x.hash").exists()
+
+
+def test_compile_refusal_is_audited_without_ids_or_tiers(vault: Path) -> None:
+    """The refusal is audited, but the audit row names no source content.
+
+    One ``creek.compile`` entry records *that* a ceiling violation was
+    attempted (operators need the signal) while the write-side fields
+    stay absent and ``fragment_ids`` collapses to the count that
+    :func:`creek_mcp.audit.summarise_args` produces for any list — so
+    the log cannot become a side channel for the ids, titles, or tier
+    of content the caller was refused.
+    """
+    frag_id = "frag-sealed"
+    _write_fragment(vault, frag_id=frag_id, privacy_tier="intimate")
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=[frag_id],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=_noop_llm_factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "refused"
+    assert result["reason"] == _ABOVE_CEILING_REASON
+
+    entries = [e for e in _read_audit(vault) if e["tool"] == "creek.compile"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry["args_summary"]["fragment_ids"] == {"count": 1}
+    assert "affected_fragment_ids" not in entry
+    assert "created_path" not in entry
+    assert "created_tier" not in entry
+
+    raw = (vault / MCP_AUDIT_RELPATH).read_text(encoding="utf-8")
+    assert frag_id not in raw
+    assert f"Title {frag_id}" not in raw
+    assert "intimate" not in raw
+
+    # The refusal append must leave the hash chain intact — a tamper-evident
+    # log that the refusal path could silently break would be worse than none.
+    verify_mcp_audit_chain(vault)
+
+
+@pytest.mark.parametrize(
+    "fragment_ids",
+    [
+        ["frag-open", "frag-sealed"],
+        ["frag-sealed", "frag-open"],
+    ],
+    ids=["above-ceiling-last", "above-ceiling-first"],
+)
+def test_compile_refuses_when_above_ceiling_source_is_not_first(
+    vault: Path,
+    fragment_ids: list[str],
+) -> None:
+    """One above-ceiling source refuses the whole call, at any position.
+
+    The gate must scan every requested fragment, not just the head of
+    the list. Both assertions are position-independent (invocation
+    count and the reason constant) so the test says nothing about
+    filesystem traversal order or fragment file naming.
+    """
+    _write_fragment(vault, frag_id="frag-open", privacy_tier="open")
+    _write_fragment(vault, frag_id="frag-sealed", privacy_tier="intimate")
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=fragment_ids,
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert result["reason"] == _ABOVE_CEILING_REASON
+    assert factory.calls == 0
+
+
+@pytest.mark.parametrize(
+    ("privacy_tier", "ceiling", "allowed"),
+    [
+        ("open", TierCeiling.OPEN, True),
+        ("personal", TierCeiling.OPEN, False),
+        ("personal", TierCeiling.PERSONAL, True),
+        ("intimate", TierCeiling.PERSONAL, False),
+        ("intimate", TierCeiling.INTIMATE, True),
+        ("intimate", TierCeiling.ALL, True),
+    ],
+)
+def test_compile_source_tier_ceiling_matrix(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    privacy_tier: str,
+    ceiling: TierCeiling,
+    allowed: bool,
+) -> None:
+    """Source-tier admission mirrors :func:`write_tier_allowed` exactly.
+
+    The allowed rows assert the factory *was* invoked, so a future
+    short-circuit elsewhere in the wrapper cannot masquerade as the
+    gate passing; the refused rows assert the ceiling reason and a
+    never-invoked factory.
+    """
+    _write_fragment(vault, frag_id="frag-src", privacy_tier=privacy_tier)
+    target_path = vault / "02-Threads" / "Active" / "thread-x.md"
+
+    def _stub_compile(**_kw: object) -> object:
+        """Write a placeholder target page instead of running the engine."""
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        if not target_path.exists():
+            target_path.write_text("# Thread X\n\nclaim\n", encoding="utf-8")
+        return target_path
+
+    if allowed:
+        monkeypatch.setattr("creek_mcp.tools.compile.compile_to_vault", _stub_compile)
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-src"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=ceiling,
+    )
+
+    if allowed:
+        assert result["status"] == "ok"
+        assert factory.calls == 1
+    else:
+        assert result["status"] == "refused"
+        assert result["reason"] == _ABOVE_CEILING_REASON
+        assert factory.calls == 0
+
+
+def test_compile_admits_unclassified_source_at_open_ceiling(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ``unclassified`` source is admitted at ``ceiling=open``.
+
+    This pins existing, deliberate policy rather than proposing new
+    policy: ``creek_mcp.tier_ceiling._TIER_RANK`` ranks ``unclassified``
+    alongside ``open`` (rank 0), and every ceiling comparison in the MCP
+    surface inherits that. Issue #923 owns any change to the ranking; if
+    it lands, update ``_TIER_RANK`` and this test together — do not
+    weaken the ceiling gate here.
+    """
+    _write_fragment(vault, frag_id="frag-src", privacy_tier="unclassified")
+    target_path = vault / "02-Threads" / "Active" / "thread-x.md"
+
+    def _stub_compile(**_kw: object) -> object:
+        """Write a placeholder target page instead of running the engine."""
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        if not target_path.exists():
+            target_path.write_text("# Thread X\n\nclaim\n", encoding="utf-8")
+        return target_path
+
+    monkeypatch.setattr("creek_mcp.tools.compile.compile_to_vault", _stub_compile)
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-src"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "ok"
+    assert factory.calls == 1
+
+
+def _write_fragment_without_tier(vault: Path, *, frag_id: str) -> None:
+    """Write a fragment whose frontmatter omits ``privacy_tier`` entirely.
+
+    Distinct from ``_write_fragment(..., privacy_tier="unclassified")``:
+    that writes the key *explicitly*, which is what every
+    pipeline-written fragment carries. Omitting the key is the
+    hand-edited / legacy-vault case, where the tier is unknown rather
+    than known-to-be-unclassified.
+    """
+    metadata = {
+        "type": "fragment",
+        "id": frag_id,
+        "title": f"Title {frag_id}",
+        "created": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "ingested": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "F1", "secondary": []},
+        "eddies": [],
+    }
+    target = vault / "01-Fragments" / "Notes" / f"{frag_id}.md"
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content="Body text.", **metadata)),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("ceiling", "allowed"),
+    [
+        (TierCeiling.OPEN, False),
+        (TierCeiling.PERSONAL, False),
+        (TierCeiling.INTIMATE, True),
+        (TierCeiling.ALL, True),
+    ],
+)
+def test_compile_fails_closed_when_privacy_tier_key_is_absent(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    ceiling: TierCeiling,
+    allowed: bool,
+) -> None:
+    """A fragment with no ``privacy_tier`` key is treated as ``intimate``.
+
+    The :class:`~creek.models.Fragment` model defaults a *missing*
+    ``privacy_tier`` to ``unclassified``, which ranks 0 and would be
+    admitted at every ceiling — so reading the tier off the model alone
+    fails **open** on exactly the hand-edited or legacy file whose tier
+    nobody can vouch for.
+
+    ``creek.reflect`` already refuses that file closed to ``intimate``
+    (``creek_mcp.tools.reflect._fragment_tier``, #847), mirroring
+    :func:`creek.classify.privacy_filter.tier_of`. Compile must agree:
+    two MCP tools that disagree about the same file is the divergence
+    the shared-loader design exists to prevent. Contrast
+    :func:`test_compile_admits_unclassified_source_at_open_ceiling`,
+    where the key is present and explicitly ``unclassified``.
+    """
+    _write_fragment_without_tier(vault, frag_id="frag-legacy")
+    target_path = vault / "02-Threads" / "Active" / "thread-x.md"
+
+    def _stub_compile(**_kw: object) -> object:
+        """Write a placeholder target page instead of running the engine."""
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        if not target_path.exists():
+            target_path.write_text("# Thread X\n\nclaim\n", encoding="utf-8")
+        return target_path
+
+    if allowed:
+        monkeypatch.setattr("creek_mcp.tools.compile.compile_to_vault", _stub_compile)
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-legacy"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=ceiling,
+    )
+
+    if allowed:
+        assert result["status"] == "ok"
+        assert factory.calls == 1
+    else:
+        assert result["status"] == "refused"
+        assert result["reason"] == _ABOVE_CEILING_REASON
+        assert factory.calls == 0
+
+
+def test_compile_missing_fragment_id_still_reports_not_found(vault: Path) -> None:
+    """A nonexistent id keeps the engine's "not found" refusal.
+
+    Runs the real engine with nothing above the ceiling in the vault:
+    the new gate must let the call through so the caller still learns
+    the id does not exist, instead of the ceiling check swallowing
+    every unresolvable id behind a generic refusal.
+    """
+    _write_fragment(vault, frag_id="frag-open", privacy_tier="open")
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-open", "frag-missing"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert "not found" in result["reason"]
+    assert "frag-missing" in result["reason"]
+    assert result["reason"] != _ABOVE_CEILING_REASON
+    assert factory.calls == 1
+
+
+def test_compile_above_ceiling_wins_over_missing_id(vault: Path) -> None:
+    """A ceiling violation is reported ahead of any missing-id error.
+
+    Deliberate ordering: if the not-found error won, a caller holding
+    ``ceiling=open`` could pair one above-ceiling id with a batch of
+    guesses and read back which of the guesses exist. The ceiling
+    refusal reveals nothing about the rest of the request.
+    """
+    _write_fragment(vault, frag_id="frag-sealed", privacy_tier="intimate")
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-sealed", "frag-missing"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert result["reason"] == _ABOVE_CEILING_REASON
+    assert "not found" not in result["reason"]
+    assert factory.calls == 0
+
+
+def test_compile_reports_unknown_target_kind_even_with_above_ceiling_sources(
+    vault: Path,
+) -> None:
+    """Cheap argument validation runs before the vault-walking gate.
+
+    An unknown ``target_kind`` is rejected on its own terms even when
+    the request also names an above-ceiling fragment, so a typo never
+    costs a full fragment scan and the caller gets the actionable
+    message.
+    """
+    _write_fragment(vault, frag_id="frag-sealed", privacy_tier="intimate")
+    factory = _RecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-sealed"],
+        target_kind="not-a-kind",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert "unknown target_kind" in result["reason"]
+    assert result["reason"] != _ABOVE_CEILING_REASON
+    assert factory.calls == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`creek.compile`'s module docstring claimed *"a caller cannot create a compiled page whose source fragments include a tier they could not read"* — but `compile_tool` never loaded the source fragments' tiers, never called `write_tier_allowed`, and never passed the ceiling into `compile_to_vault`. The ceiling was used only to echo unrelated validation refusals and to stamp the audit entry.

With `ceiling=open`, a caller could compile INTIMATE fragment ids. The call returned `status="ok"` and wrote a page, sending intimate ids and titles into three places at once: the compiled page's provenance, the paradox log, and the compile LLM prompt — which is **not** tier-routed.

This adds the gate the docstring already promised.

### Design

**`_sources_above_ceiling`** walks the vault through `iter_vault_fragments` — deliberately the *same* loader `compile_to_vault` uses — so the set of files the gate inspects and the set the engine compiles are identical by construction. A bespoke `frontmatter.load` scan would diverge (the shared reader rejects `type != fragment` and schema failures that a raw scan reads happily), and that divergence is the exact bug class this gate exists to prevent. Admission goes through `write_tier_allowed`, mirroring `save_tool` / `journal_ingest_tool`.

**Gate ordering is the substance**, following the read-side precedent set by #846 / PR #921 in `reflect.py`:

- It sits *below* the `target_kind` and empty-`fragment_ids` checks. Neither order leaks — those read only caller-supplied input and touch no vault state — so the tiebreaker is cost asymmetry: a full `01-Fragments` walk should not be reachable from a syntactically invalid call.
- It sits *above* everything after it, each of which is a distinct egress: `llm_factory()` is evaluated as an *argument* to the engine call and the prompt emits `id:`/`title:` unconditionally (`_fragment_excerpt_for_prompt` redacts only the body); the engine writes per-claim provenance naming the source ids into `02-Threads`/`03-Eddies`/`06-Frequencies`, which any open-ceiling read tool then serves; `_append_paradox_log` records them too; and the hash marker must not leave idempotency state behind on a refused call.
- The ceiling refusal deliberately wins over the engine's missing-id error, so a caller cannot pair one above-ceiling id with a batch of guesses and read back which guesses exist.

**Refusals are not a config oracle.** `_ABOVE_CEILING_REASON` is a fixed constant naming no ids, titles, tiers, or even a count — echoing which ids were above-ceiling would turn a single call into a bulk tier-classification oracle over the corpus. The `ACCEPTED RESIDUAL RISK` comment records what remains (a bare boolean is still a group-testing oracle) and rests the argument on the audit trail rather than on id entropy, because ids are deterministic and child ids are enumerable from a known parent.

**Two deliberate departures from #846**, both documented in the code:

1. *The refusal audits at the refusal site, not unconditionally at the top of the call.* `reflect` appends unconditionally; doing that here would append on every compile including no-ops, breaking the FEAT-011 acceptance test that asserts exactly one `creek.compile` entry across two calls. Compile's audit contract is "one entry per materially-new page", not "one per call". This follows `save`/`journal` instead.
2. *No `TierCeiling.ALL` fast path.* One route through `write_tier_allowed` only; a second would silently desync if `ALL`'s semantics changed.

**`_tier_of` fails closed.** A fragment file with *no* `privacy_tier` key would otherwise be defaulted by the model to `unclassified` (rank 0, admitted at every ceiling) — failing open on exactly the hand-edited or legacy file whose tier nobody can vouch for. `creek.reflect` already refuses that file closed to INTIMATE, and two MCP tools disagreeing about the same file is the divergence the shared-loader design exists to prevent. A fragment carrying an *explicit* `privacy_tier: unclassified` is untouched and stays admitted — that ranking is deliberate policy owned by `_TIER_RANK` (#923), and a test pins it so any change is deliberate.

## Test plan

- `cd creek-tools && ./scripts/check-all.sh` → **exit 0**, 12/12 checks, 6118 tests passed, aggregate coverage 93.92%, `creek_mcp/tools/compile.py` per-file 90.67% (gate 80%), ruff lint+format clean, mypy strict clean. No suppressions added.
- Verified genuine RED before implementing: 9 of the new tests failed against the unfixed code, each on the bug itself.

11 new tests in `tests/test_mcp_write_tools.py`:

- Acceptance: intimate source at `ceiling=open` is refused.
- **The LLM factory is never invoked on refusal** — the load-bearing egress assertion. Note the trap this avoids: `llm_factory()` is evaluated *inside* the pre-existing `try/except (ValueError, RuntimeError)`, so a test using a *raising* factory would see `status="refused"` even with no gate at all. Every test uses a counting `_RecordingLLMFactory` instead, and the allowed cases assert `calls == 1` so an unrelated short-circuit cannot masquerade as the gate passing.
- Refusal leaves no page, no paradox log, no hash marker — with a stub whose payload *would* produce both a page and a paradox, so each absent artifact is positive evidence the engine never ran.
- Refusal is audited with no ids, titles, or tiers — asserted against the raw `mcp.jsonl` bytes, and the hash chain still verifies.
- Above-ceiling source at any list position (both orderings parametrized; assertions are position-independent, so nothing depends on filesystem traversal order).
- Full tier/ceiling matrix mirroring `write_tier_allowed`.
- Missing `privacy_tier` key fails closed across all four ceilings.
- Explicit `unclassified` stays admitted at `open` (pins existing policy, points at #923).
- Missing ids still report "not found"; a ceiling violation outranks a missing id; unknown `target_kind` still wins over the gate.

The four pre-existing compile tests are untouched and green.

## Follow-ups filed (deliberately out of scope)

- #928 — the compile LLM is not tier-routed, so an *admitted* intimate source under a local `intimate`/`all` ceiling can still egress its title.
- #929 — `_build_compile_llm` imports a nonexistent `_default_llm`; MCP compile raises `ImportError` rather than a structured refusal.
- #930 — `01-Fragments` is walked twice per compile; loading once closes a TOCTOU window and halves the I/O (needs an engine signature change).
- #931 — `structural_path` ancestry can carry an above-ceiling parent's title in via an admitted child.
- #932 — sweep every MCP tool that reads unsupplied vault fragments for the same gate.
- #933 — correct the same residual-risk wording in `reflect.py`.

Closes #848