### PR TITLE
fix(classify): give praxis_potential a producer so 04-Praxis and 08-Decisions are reachable

### DIFF
--- a/creek-tools/creek/classify/classify_engine.py
+++ b/creek-tools/creek/classify/classify_engine.py
@@ -57,6 +57,42 @@ call it:
   non-``unclassified`` tier on disk also survives any non-``--force``
   run untouched: the operator's decision outranks the heuristic.
 
+Praxis pass (issue #877)
+------------------------
+
+Every fragment this run actually (re-)classifies also leaves the engine
+carrying a scored :class:`~creek.models.PraxisPotential`. Before #877 the
+field had a default and **no producer at all**, so the three consumers
+gated on ``explicit`` (:mod:`creek.generate.decisions`,
+:mod:`creek.generate.mining`, :mod:`creek.generate.compost`) were
+structurally unreachable. The policy lives in
+:mod:`creek.classify.praxis_pass`; the engine only decides *when*:
+
+* **After the classifier, before the privacy reassess.** Running after
+  :func:`_classify_one` means the escalate-only merge already sees any
+  LLM verdict, and running before :func:`~creek.classify.privacy_pass.reassess`
+  keeps the #876 privacy reassess as the last mutation before the write.
+  It must NOT be hoisted into :func:`_prepare_fragment`: that would put
+  it between the tier assignment and
+  :meth:`TierClassifiers.for_tier`, where the #876 ordering above is
+  load-bearing security.
+* **NOT on the preserved short-circuit** — a deliberate departure from
+  the tier precedent one section up. :func:`_write_tier_only` makes a
+  narrow, auditable promise ("changing ONLY the privacy-tier fields")
+  that is itself load-bearing when reviewing the #876 path, and the
+  justification for the tier exception does not transfer: an untiered
+  fragment is a live cloud-egress hole, whereas a missing praxis verdict
+  is a missing feature. So an ``llm``/``manual``-stamped vault backfills
+  this axis only under an explicit ``creek classify --method llm
+  --force``. ``creek fill`` surfaces the outstanding count and names that
+  command's token cost (:func:`creek.cli._hint_praxis_backfill`).
+* **Escalate-only.** A rules re-run can raise ``none`` to ``explicit``
+  but can never demote a verdict the LLM or the operator put on record.
+
+:attr:`ClassifySummary.praxis_marked` reports how many fragments the run
+actually raised — the observability that was missing when this field had
+an invisible (in fact absent) producer.
+
 Known residual (not fixable by ordering)
 ----------------------------------------
 
@@ -104,6 +140,7 @@ from creek.classify.constants import (
 )
 from creek.classify.llm import LLMClassifier
 from creek.classify.llm.router import IntimateRoutingError
+from creek.classify.praxis_pass import apply_praxis
 from creek.classify.privacy import PrivacyClassifier
 from creek.classify.privacy_filter import tier_of
 from creek.classify.privacy_pass import (
@@ -150,6 +187,9 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterator
 
     from creek.config import ClassificationConfig, CreekConfig, LLMConfig
+
+    # Annotation-only: the praxis verdict is compared, never constructed here.
+    from creek.models import PraxisPotential
 
 logger = logging.getLogger(__name__)
 
@@ -233,6 +273,16 @@ class ClassifySummary:
             This counts the decision, not the bytes: a fragment whose
             subsequent write fails is counted here *and* reported on
             :attr:`errors`.
+        praxis_marked: Fragments this run raised to a stronger
+            :class:`~creek.models.PraxisPotential` (issue #877) — almost
+            always ``none`` → ``explicit`` from the keyword pass. The
+            pass is escalate-only and idempotent, so a second run over an
+            unchanged vault reports ``0``. Fragments the resume
+            short-circuit preserved are **not** counted: they are not
+            given a praxis verdict at all without ``--force`` (see the
+            module docstring). Like :attr:`privacy_tiers_assigned` this
+            counts the decision, not the bytes — a fragment whose write
+            then fails is counted here *and* reported on :attr:`errors`.
     """
 
     total: int
@@ -241,10 +291,11 @@ class ClassifySummary:
     preserved_llm: int
     skipped_high_confidence: int
     errors: tuple[str, ...]
-    # Appended last, with a default, so the positional
+    # Appended last, with defaults, so the positional
     # ``ClassifySummary(0, 0, 0, 0, 0, ())`` construction below still
     # compiles unchanged.
     privacy_tiers_assigned: int = 0
+    praxis_marked: int = 0
 
 
 @dataclass
@@ -261,6 +312,7 @@ class _RunCounts:
     preserved_llm: int = 0
     skipped: int = 0
     privacy_tiers_assigned: int = 0
+    praxis_marked: int = 0
     errors: list[str] = field(default_factory=list)
 
 
@@ -459,6 +511,7 @@ def run_classify(
         # underlying list and reach into completed-run state.
         errors=tuple(counts.errors),
         privacy_tiers_assigned=counts.privacy_tiers_assigned,
+        praxis_marked=counts.praxis_marked,
     )
 
 
@@ -563,6 +616,29 @@ def _record_if_preserved(
         counts.preserved_llm += 1
         return True
     return False
+
+
+def _record_praxis(
+    before: PraxisPotential,
+    fragment: Fragment,
+    counts: _RunCounts,
+) -> None:
+    """Tally a fragment whose praxis verdict this run raised (issue #877).
+
+    Kept as its own function so the ``if`` lives here rather than in
+    :func:`_process_file`, whose cyclomatic complexity is already at its
+    working ceiling. Comparing before/after is safe precisely because
+    :func:`~creek.classify.praxis_pass.apply_praxis` is escalate-only:
+    the values can only ever differ upwards, so this counts real work and
+    never churn.
+
+    Args:
+        before: The verdict the fragment carried before the praxis pass.
+        fragment: The fragment after the pass.
+        counts: Mutable per-run counters; mutated in place.
+    """
+    if fragment.praxis_potential != before:
+        counts.praxis_marked += 1
 
 
 def _assert_classifiers_available(tier_classifiers: TierClassifiers | None) -> None:
@@ -825,6 +901,16 @@ def _process_file(
     # so it runs on both the rules and LLM paths and stays idempotent.
     new_fragment = audience.classify_and_enforce(new_fragment, body)
 
+    # #877: score the praxis axis from the free keyword pass. Unconditional
+    # by design — the purity of ``apply_praxis`` absorbs the decision (it
+    # returns the same object when nothing escalates), so this adds no
+    # branch to this function. It runs AFTER ``_classify_one`` so the
+    # escalate-only merge already sees any LLM verdict, and BEFORE the
+    # reassess below so the #876 privacy pass stays the last mutation
+    # before the write.
+    praxis_before = new_fragment.praxis_potential
+    new_fragment = apply_praxis(new_fragment, body)
+
     # #876: classification may have hardened the fragment's voice signals
     # (confessional + conviction is one of the INTIMATE triggers), which the
     # pre-pass could not see. Take the stricter of the two verdicts —
@@ -834,6 +920,8 @@ def _process_file(
         new_fragment = reassess(new_fragment, body, classifier=privacy)
 
     with lock:
+        _record_praxis(praxis_before, new_fragment, counts)
+
         # FEAT-023 wire-up (issue #318): when ``classification.reatomize`` is
         # True we run the orchestrator on the root fragment and persist any
         # newly-derived child fragments. The root's frontmatter still flows

--- a/creek-tools/creek/classify/llm/orchestrator.py
+++ b/creek-tools/creek/classify/llm/orchestrator.py
@@ -20,6 +20,7 @@ from creek.classify.llm.batch import run_batch
 from creek.classify.llm.calibration import _apply_wavelength
 from creek.classify.llm.parsing import (
     _apply_frequency,
+    _apply_praxis,
     _apply_voice,
     _split_reasoning_and_yaml,
     validate_response,
@@ -33,6 +34,7 @@ from creek.classify.llm.providers import (
     provider_display_name,
     provider_is_cloud,
 )
+from creek.models import PraxisPotential
 
 if TYPE_CHECKING:
     from creek.classify.llm.base import LLMProvider
@@ -270,7 +272,9 @@ class LLMClassifier:
             data: Parsed classification dict from ``validate_response``.
 
         Returns:
-            A new fragment with updated classification fields.
+            A new fragment with updated classification fields — or
+            **the same object** when the response carried nothing that
+            changed it, which callers read as "this run marked nothing".
         """
         updates: dict[str, object] = {}
         _apply_frequency(data, updates)
@@ -280,6 +284,14 @@ class LLMClassifier:
             unclassified_threshold=self.config.unclassified_threshold,
         )
         _apply_voice(data, updates)
+        # Issue #877: ``praxis_potential`` is monotone, so the merge needs
+        # the verdict the fragment already carries — a model answering
+        # ``latent`` for an ``explicit`` fragment must lose. ``_apply_praxis``
+        # routes that through ``praxis_pass.escalate``. The
+        # ``PraxisPotential(...)`` coercion is required because
+        # ``Fragment.model_config`` sets ``use_enum_values=True``, so the
+        # attribute is a plain ``str`` at runtime.
+        _apply_praxis(data, updates, PraxisPotential(fragment.praxis_potential))
         if not updates:
             return fragment
         return fragment.model_copy(update=updates)

--- a/creek-tools/creek/classify/llm/parsing.py
+++ b/creek-tools/creek/classify/llm/parsing.py
@@ -18,11 +18,13 @@ from typing import TypeVar
 
 import yaml
 
+from creek.classify.praxis_pass import PRAXIS_POTENTIAL_KEY, escalate
 from creek.models import (
     Confidence,
     Dosage,
     Frequency,
     FrequencyClassification,
+    PraxisPotential,
     VoiceClassification,
     VoiceRegister,
 )
@@ -52,7 +54,7 @@ otherwise bloat fragment frontmatter on disk. See issue #319.
 
 
 _ALLOWED_TOP_LEVEL_KEYS: frozenset[str] = frozenset(
-    {"frequency", "wavelength", "voice", "confidence_scores"},
+    {"frequency", "wavelength", "voice", "confidence_scores", "praxis"},
 )
 """Top-level keys recognised in a documented LLM classification response.
 
@@ -60,9 +62,16 @@ Mirrors the sections in
 :data:`creek.classify.llm.prompts.CLASSIFICATION_PROMPT`.
 ``confidence_scores`` was added by FEAT-017 to carry per-dimension
 self-reported confidence for the default-unclassified bias on Mode /
-Orientation / Dosage. Update both when adding a new section —
-:func:`validate_response` will otherwise reject the LLM's output as
-unexpected.
+Orientation / Dosage. ``praxis`` was added by issue #877 to carry the
+``latent`` verdict no keyword heuristic can produce. Update both when
+adding a new section — :func:`validate_response` will otherwise reject
+the LLM's output as unexpected.
+
+This allow-list is the SEC-004 injection boundary, so it is widened one
+key at a time and never to a :class:`~creek.models.Fragment` field name:
+``privacy_tier`` in particular stays rejected, or a successful prompt
+injection could talk the classifier into re-tiering intimate content as
+``open``.
 """
 
 
@@ -75,7 +84,14 @@ _YAML_FENCE_RE: re.Pattern[str] = re.compile(
 _YAML_HEAD_RE: re.Pattern[str] = re.compile(
     r"^(frequency|wavelength|voice):", re.MULTILINE
 )
-"""Match the start of an unfenced YAML payload (a documented top-level key)."""
+"""Match the start of an unfenced YAML payload (a documented top-level key).
+
+Deliberately NOT widened with ``praxis`` (issue #877): the schema lists
+``praxis`` last, so it can never be the *first* key of a payload, and
+adding an alternative here would let a stray line of reasoning prose
+beginning ``praxis:`` be mistaken for the start of the YAML — unrelated
+risk for zero benefit.
+"""
 
 
 def _split_reasoning_and_yaml(response: str) -> tuple[str, str]:
@@ -224,9 +240,10 @@ def validate_response(response_text: str) -> dict[str, object]:
     ``yaml.safe_load_all`` so a multi-document stream — a classic
     LLM-output-spoofing payload — is detected explicitly rather
     than silently swallowing the first document. Top-level keys
-    outside the documented schema (``frequency``, ``wavelength``,
-    ``voice``) are also rejected so a successful injection cannot
-    smuggle in fields like ``privacy_tier`` (see SEC-004).
+    outside the documented schema (see
+    :data:`_ALLOWED_TOP_LEVEL_KEYS`) are also rejected so a
+    successful injection cannot smuggle in fields like
+    ``privacy_tier`` (see SEC-004).
 
     Args:
         response_text: Raw YAML text from the LLM.
@@ -284,6 +301,62 @@ def _apply_frequency(
         primary=primary,
         secondary=secondary,
     )
+
+
+def _apply_praxis(
+    data: dict[str, object],
+    updates: dict[str, object],
+    current: PraxisPotential,
+) -> None:
+    """Extract the praxis-potential verdict from parsed data (issue #877).
+
+    The LLM can only ever *raise* this axis, and "raise" is measured
+    against *the verdict the fragment already carries* — not merely
+    against ``none``. The merge therefore runs through the single
+    canonical :func:`creek.classify.praxis_pass.escalate`, which takes the
+    higher of the two on ``none < latent < explicit``. Refusing to write
+    only when the parsed value is ``none`` would not be enough: ``latent``
+    is also weaker than ``explicit``, and a model answering ``latent`` for
+    a fragment already at ``explicit`` would demote it. Nothing downstream
+    can repair that — the keyword heuristic
+    (:func:`creek.classify.praxis_pass.detect`) re-derives from the body
+    and only ever proposes ``explicit`` or ``none``, so a verdict that
+    came from judgment rather than keywords keeps the demotion to disk.
+
+    The escalating direction still stands: ``latent`` over ``none`` and
+    ``explicit`` over ``latent`` are both written. ``latent`` is the
+    verdict this branch exists for — no regular expression can see "there
+    is a practice hiding in here that the author has not named".
+
+    An unchanged verdict must write **no key at all**, because
+    :meth:`~creek.classify.llm.orchestrator.LLMClassifier._apply_classification`
+    returns the input fragment itself when ``updates`` is empty. Writing
+    the merged value back whenever the model merely agrees would allocate
+    a fresh model copy per fragment and blur the "did this run change
+    anything?" signal callers read from object identity.
+
+    Args:
+        data: Parsed LLM response.
+        updates: Dict to populate with the praxis update. Left untouched
+            unless the merge raised the axis above *current*.
+        current: The verdict already recorded on the fragment. The merge
+            never returns anything weaker than this.
+    """
+    section = data.get("praxis")
+    if not isinstance(section, dict):
+        return
+    potential = _parse_enum(
+        section.get("potential"),
+        PraxisPotential,
+        PraxisPotential.NONE,
+    )
+    merged = escalate(current, potential)
+    if merged is current:
+        return
+    # ``.value`` because ``Fragment`` uses ``use_enum_values=True`` but
+    # ``model_copy`` — which consumes this dict — bypasses that coercion,
+    # and YAML's SafeDumper cannot represent a bare StrEnum member.
+    updates[PRAXIS_POTENTIAL_KEY] = merged.value
 
 
 def _apply_voice(

--- a/creek-tools/creek/classify/llm/prompts.py
+++ b/creek-tools/creek/classify/llm/prompts.py
@@ -131,6 +131,11 @@ instructional, raw, conversational
 
 9. **Confidence**: musing, exploring, forming, settled, conviction
 
+10. **Praxis Potential**: explicit, latent, none — does this fragment state an
+    actionable insight, a practice, or a decision-in-progress? Use ``explicit``
+    when the fragment names something to *do*; ``latent`` when a practice is
+    implied but never stated outright; ``none`` otherwise.
+
 A few labelled examples (do not include these in your YAML output):
 
 {examples}
@@ -139,8 +144,9 @@ Two-step protocol (FEAT-017):
 
 Step 1 — Reason briefly. Walk through which frequency this most resonates
 with and why, then which phase, then which mode, orientation, and dosage,
-which color and descriptor follow from those, and finally the voice
-register. Two to four short sentences total.
+which color and descriptor follow from those, then the voice register,
+and finally whether the fragment carries any praxis potential. Two to
+four short sentences total.
 
 Step 2 — Emit your classification as valid YAML inside a fenced
 ```yaml ... ``` block. **You MUST emit the full ``wavelength:`` block
@@ -169,6 +175,8 @@ confidence_scores:
   mode: 0.7
   orientation: 0.7
   dosage: 0.7
+praxis:
+  potential: none
 ```
 
 If a dimension is genuinely unclear, set ``unclassified`` rather than
@@ -203,6 +211,13 @@ because models follow the explicit YAML far more reliably than the
 bullet-point list above it. Drop a field from the schema and the
 classifier silently regresses to the pre-fix state where every
 fragment had ``wavelength.color: unclassified``.
+
+Issue #877: the ``praxis`` section is listed **last** in the schema, and
+:data:`creek.classify.llm.parsing._YAML_HEAD_RE` is deliberately not
+widened to recognise it — a key that can never lead a payload does not
+belong in the unfenced-payload head pattern. Every literal ``{``/``}``
+added to this template must be doubled: it is consumed by ``str.format``
+in :func:`build_classification_prompt`.
 """
 
 

--- a/creek-tools/creek/classify/praxis_pass.py
+++ b/creek-tools/creek/classify/praxis_pass.py
@@ -1,0 +1,301 @@
+"""Pure policy functions for the praxis-potential pass (issue #877).
+
+:attr:`creek.models.Fragment.praxis_potential` shipped with a default of
+``none`` and **zero production writers**, so all three consumers that gate
+on ``explicit`` — :mod:`creek.generate.decisions`,
+:mod:`creek.generate.mining` and :mod:`creek.generate.compost` — were
+structurally unreachable: ``04-Praxis`` and ``08-Decisions`` could never
+be populated. This module is the shared, side-effect-free policy layer
+that both writers — the ``creek classify`` engine and the ``creek
+process`` pipeline — call to close that hole:
+
+* :func:`detect` — score a body and return ``explicit`` or ``none``.
+* :func:`escalate` — merge two verdicts, never lowering.
+* :func:`apply_praxis` — stamp the merged verdict onto a fragment.
+
+Three rules hold across every function here.
+
+**Never lower a verdict.** :func:`escalate` takes the higher of the two
+candidates, so a rules re-run over a vault the LLM (or the operator)
+already marked ``explicit`` cannot quietly undo that judgment. The pass
+is therefore idempotent, which matters because ``creek classify`` is
+re-run over the whole vault routinely.
+
+The LLM path reaches the same invariant through the same function:
+:func:`creek.classify.llm.parsing._apply_praxis` merges the model's
+answer against the fragment's recorded verdict with :func:`escalate`, and
+since it is the *only* writer of ``latent`` (see below), :func:`escalate`
+is the single chokepoint every producer of this axis passes through.
+Guarding a writer against ``none`` alone is **not** sufficient and was
+the original bug: ``latent`` is weaker than ``explicit`` too, and this
+heuristic cannot repair such a demotion — :func:`detect` re-derives from
+the body and can only ever propose ``explicit`` or ``none``, so a verdict
+that came from judgment rather than keywords keeps the demotion to disk.
+
+**Precision over recall.** The heuristic is free and runs over every
+fragment, so a signal set that over-fires does not fix the bug — it
+floods mining, compost and the decisions report with noise, which is
+strictly worse than the current silence. Hence :data:`_EXPLICIT_AT` is
+2: one *strong* marker (a task checkbox, a ``Decision:`` line), or two
+*distinct* moderate first-person commitments. A single bare "I will"
+never fires. Scoring is presence-based over distinct patterns rather
+than occurrence-counting — see :func:`detect`.
+
+**Never emit ``latent``.** "There is a practice hiding in here that the
+author has not named" is a judgment no regular expression can make, and
+a heuristic that guessed at it would poison the one signal the LLM path
+exists to provide. ``latent`` therefore reaches a fragment only through
+:func:`creek.classify.llm.parsing._apply_praxis`.
+
+Known residuals
+---------------
+
+* **Preserved fragments need ``--force``.** The classify engine runs this
+  pass only on fragments it actually (re-)classifies; the OPS-001 resume
+  short-circuit's narrow writer
+  (:func:`creek.classify.classify_engine._write_tier_only`) is
+  deliberately *not* widened to carry praxis. So a vault already stamped
+  ``classification_method: llm``/``manual`` backfills this axis only
+  under an explicit, paid ``creek classify --method llm --force``. That
+  is the opposite call from the #876 privacy tier, and on purpose: an
+  untiered fragment is a live cloud-egress hole, whereas a missing praxis
+  verdict is a missing feature, and silently rewriting the praxis axis of
+  every already-curated fragment in a mature vault is not something to do
+  without being asked. ``creek fill`` surfaces the outstanding count (see
+  :func:`creek.cli._hint_praxis_backfill`).
+* **The weighted path is heuristic-only.**
+  :func:`creek.classify.weighted.classify_weighted` carries its own
+  prompt and its own top-level key allow-list, so on that path praxis
+  comes from :func:`detect` alone and never from the model.
+
+Security note: these patterns are matched against unbounded,
+attacker-influenced fragment bodies. Every one of them is linear-time —
+no nested quantifiers — and all are compiled once at import rather than
+per fragment, because this table is applied to all 35,330 bodies of the
+demo vault on every run.
+
+No vault, no I/O, no LLM: everything here is a pure function of the
+fragment and its body.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Final
+
+from creek.models import PraxisPotential
+
+if TYPE_CHECKING:
+    from creek.models import Fragment
+
+
+PRAXIS_POTENTIAL_KEY: Final[str] = "praxis_potential"
+"""Frontmatter key carrying a fragment's :class:`~creek.models.PraxisPotential`."""
+
+
+_STRONG_WEIGHT: Final[int] = 2
+"""Score for a marker that is decisive on its own.
+
+A task checkbox or a ``Decision:`` label is not prose *about* action —
+it is the author writing action down in a dedicated form. One is enough.
+"""
+
+_MODERATE_WEIGHT: Final[int] = 1
+"""Score for a first-person commitment, which needs corroboration.
+
+"I will call the dentist" appears in a substantial fraction of every chat
+log ever written. Alone it says nothing; alongside a *different* such
+marker it starts to look like the fragment is about doing something.
+"""
+
+_EXPLICIT_AT: Final[int] = 2
+"""Score at or above which :func:`detect` returns ``explicit``.
+
+Equivalently: one strong marker, or two distinct moderate ones. Lowering
+this to 1 is the single change that would turn the heuristic from a fix
+into a noise generator.
+"""
+
+
+_SENTENCE_START: Final[str] = r"(?:^[ \t]*|(?<=[.!?])[ \t]+)"
+"""Anchor matching the start of a line or of a sentence within a line.
+
+Anchoring is what separates a commitment from reported speech. "He said
+I should call the dentist and that I will regret it" carries two
+first-person lookalikes and would score the full threshold under an
+unanchored search; anchored, it scores zero. Real prose also routinely
+puts two sentences on one line, so a line-start-only anchor would miss
+the commitments that matter — hence the sentence-boundary alternative.
+
+Both branches use ``[ \\t]`` rather than ``\\s`` so neither can consume a
+newline and blur one line's anchor into the next.
+"""
+
+
+_APOSTROPHE_CLASS: Final[str] = "['" + chr(0x2019) + "]"
+"""Regex character class matching a straight or typographic apostrophe.
+
+Exported chat logs carry both ("I'm" and its curly-quoted twin). The
+curly one is built with :func:`chr` rather than pasted so this file stays
+pure ASCII — a literal curly quote is indistinguishable from a straight
+one in a code review, which is exactly how a pattern silently stops
+matching half its inputs.
+"""
+
+
+def _anchored(phrase: str) -> re.Pattern[str]:
+    """Compile *phrase* anchored to a line or sentence start.
+
+    Args:
+        phrase: A case-insensitive regular-expression fragment naming one
+            moderate marker (e.g. ``r"i will\\b"``).
+
+    Returns:
+        The compiled pattern, multiline and case-insensitive.
+    """
+    return re.compile(
+        _SENTENCE_START + phrase,
+        re.MULTILINE | re.IGNORECASE,
+    )
+
+
+_PRAXIS_SIGNALS: Final[dict[re.Pattern[str], int]] = {
+    # --- Strong: the author has written the action down as an artefact. ---
+    # A line-initial markdown task checkbox: "- [ ]", "* [x]", indented or
+    # not. Mid-line, "see the list - [ ] item" is prose, so the line anchor
+    # is load-bearing, and the marker must be blank/x/X — "- [z]" is not a
+    # checkbox.
+    re.compile(r"^[ \t]*[-*][ \t]*\[[ xX]\][ \t]", re.MULTILINE): _STRONG_WEIGHT,
+    # A line-initial label heading a decision or a practice. Line-anchored
+    # for the same reason: "The decision: …, was made in April" is
+    # narration, and without the anchor every retrospective sentence
+    # mentioning a decision would stamp its fragment ``explicit``.
+    re.compile(
+        r"^[ \t]*(?:decision|praxis|next step|action item)s?[ \t]*:",
+        re.MULTILINE | re.IGNORECASE,
+    ): _STRONG_WEIGHT,
+    # --- Moderate: first-person commitment; needs a distinct companion. ---
+    # ``praxis_potential`` records the *owner's* commitments, so each of
+    # these is pinned to "I"/"we". Second- and third-person lookalikes
+    # ("you should", "it will", "they will") are the single largest class
+    # of false positive in a personal corpus full of chat logs, and the
+    # trailing ``\b`` also keeps "I shouldn't" from reading as "I should".
+    _anchored(r"i should\b"): _MODERATE_WEIGHT,
+    _anchored(r"i will\b"): _MODERATE_WEIGHT,
+    _anchored(r"i need to\b"): _MODERATE_WEIGHT,
+    _anchored(rf"i{_APOSTROPHE_CLASS}m going to\b"): _MODERATE_WEIGHT,
+    _anchored(r"next time (?:i|we)\b"): _MODERATE_WEIGHT,
+    _anchored(r"from now on\b"): _MODERATE_WEIGHT,
+    _anchored(r"the practice is\b"): _MODERATE_WEIGHT,
+}
+"""Body patterns that evidence praxis, mapped to their weight.
+
+Compiled once at import: this table is applied to every body in the
+vault, so a per-call ``re.compile`` is the difference between a free pass
+and a measurable one. Keep every pattern linear-time (see the module
+docstring's security note).
+"""
+
+
+_RANK: Final[dict[PraxisPotential, int]] = {
+    PraxisPotential.NONE: 0,
+    PraxisPotential.LATENT: 1,
+    PraxisPotential.EXPLICIT: 2,
+}
+"""Strength ordering for :func:`escalate` — higher wins a merge.
+
+Deliberately a separate table from
+:data:`creek.classify.privacy_pass._ESCALATION_RANK`, not a shared
+"pick the bigger enum" helper: that one ranks a different enum on a
+different question ("which of two candidate privacy labels is the
+stronger claim?") and carries an ``unclassified`` sentinel that has to
+sort *below* every real tier. ``PraxisPotential`` has no such sentinel —
+``none`` is a real verdict, not the absence of one — so folding the two
+together would mean explaining away a rank that does not exist here.
+"""
+
+
+def detect(fragment: Fragment, body: str) -> PraxisPotential:
+    """Score *body* against the signal table and return a verdict.
+
+    Scoring is **presence-based over distinct patterns**, not
+    occurrence-counting: each pattern contributes its weight at most
+    once, however often it matches. Two repetitions of one idiom ("I
+    should x. I should y.") are a verbal tic, not a second piece of
+    evidence, so that body scores 1 and stays ``none``; two *different*
+    moderate markers score 2 and reach ``explicit``.
+
+    Never returns ``latent`` — see the module docstring.
+
+    Args:
+        fragment: The fragment being scored. Not read: praxis is a
+            body-only axis (a title never states a commitment), and the
+            parameter exists so this signature stays parallel with
+            :func:`apply_praxis` and with
+            :meth:`~creek.classify.privacy.PrivacyClassifier.classify_tier`.
+        body: The fragment's markdown body.
+
+    Returns:
+        ``EXPLICIT`` when the score reaches :data:`_EXPLICIT_AT`,
+        otherwise ``NONE``.
+    """
+    _ = fragment
+    score = sum(
+        weight for pattern, weight in _PRAXIS_SIGNALS.items() if pattern.search(body)
+    )
+    if score >= _EXPLICIT_AT:
+        return PraxisPotential.EXPLICIT
+    return PraxisPotential.NONE
+
+
+def escalate(
+    current: PraxisPotential,
+    candidate: PraxisPotential,
+) -> PraxisPotential:
+    """Return the stronger of *current* and *candidate*.
+
+    The merge is symmetric in its arguments by construction (each rank
+    maps to exactly one verdict, so equal ranks mean equal verdicts).
+    That matters: an asymmetric merge would let the *caller's* argument
+    order decide whether an ``explicit`` fragment gets demoted back to
+    ``none`` — the one direction this function exists to make impossible.
+
+    Args:
+        current: The verdict already recorded on the fragment.
+        candidate: The verdict just derived.
+
+    Returns:
+        Whichever verdict ranks higher on ``none < latent < explicit``.
+    """
+    if _RANK[candidate] > _RANK[current]:
+        return candidate
+    return current
+
+
+def apply_praxis(fragment: Fragment, body: str) -> Fragment:
+    """Stamp the merged praxis verdict on *fragment*, escalate-only.
+
+    Args:
+        fragment: The fragment to mark. Never mutated.
+        body: The fragment's markdown body — the signals are body-only,
+            and the :class:`~creek.models.Fragment` model does not carry
+            the body.
+
+    Returns:
+        The fragment carrying the merged verdict — **the same object**
+        when nothing escalated, matching
+        :func:`creek.classify.privacy_pass.reassess`'s contract. Callers
+        detect "did this run mark anything?" by comparing before/after,
+        and this runs over every fragment in the vault, so an
+        unconditional copy would both blur that signal and allocate a
+        fresh model per fragment for nothing.
+    """
+    current = PraxisPotential(fragment.praxis_potential)
+    merged = escalate(current, detect(fragment, body))
+    if merged is current:
+        return fragment
+    # ``.value`` because ``Fragment`` uses ``use_enum_values=True`` but
+    # ``model_copy`` bypasses that coercion: consumers compare
+    # ``str(frag.praxis_potential) == PraxisPotential.EXPLICIT.value``, and
+    # YAML's SafeDumper cannot represent a bare StrEnum member.
+    return fragment.model_copy(update={PRAXIS_POTENTIAL_KEY: merged.value})

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -26,7 +26,7 @@ from creek.classify.privacy_filter import (
 )
 from creek.config import AIStyleConfig, load_config, resolve_config_path
 from creek.consent import ConsentManager
-from creek.models import PrivacyTier
+from creek.models import PraxisPotential, PrivacyTier
 from creek.pipeline import (
     Pipeline,
     RedactionRequiredError,
@@ -1710,7 +1710,10 @@ def classify(
         # Issue #876: tier assignment is orthogonal to the classification
         # method — preserved fragments get one too — so it is reported as
         # its own count rather than folded into "classified".
-        f"{summary.privacy_tiers_assigned} privacy tier(s) assigned"
+        f"{summary.privacy_tiers_assigned} privacy tier(s) assigned, "
+        # Issue #877: same reasoning for the praxis axis — it is the only
+        # visible evidence that the field has a producer at all.
+        f"{summary.praxis_marked} praxis marked"
         ").[/bold green]",
     )
     if summary.errors:
@@ -2100,7 +2103,92 @@ def _detect_classify_upgrade(
     )
 
 
-def _count_untiered_fragments(vault_path: Path) -> int:
+@dataclass(frozen=True)
+class _FillGapCounts:
+    """What one walk of the vault found for ``creek fill``'s hints.
+
+    Both gap detectors need the same expensive thing — every fragment's
+    frontmatter *and* body, parsed. Bundling their answers lets
+    :func:`_scan_fill_gaps` pay for that walk once on a 35k-fragment
+    vault instead of once per hint.
+
+    Attributes:
+        untiered: Fragments still carrying no privacy tier (#876).
+        praxis_backfillable: Fragments the free praxis heuristic can
+            prove are ``explicit`` while the disk still says ``none``
+            (#877).
+    """
+
+    untiered: int
+    praxis_backfillable: int
+
+
+def _scan_fill_gaps(vault_path: Path) -> _FillGapCounts:
+    """Walk the vault once and count both classes of fill-time gap.
+
+    The praxis detector deserves a note, because the two obvious choices
+    are both wrong. It cannot be "the ``praxis_potential`` key is absent"
+    — ``Fragment.model_dump`` always writes it — and it must not be "the
+    value is ``none``", because most fragments genuinely are ``none``, so
+    that nag would be permanent and instantly ignored. The one shape that
+    *proves* work is outstanding is this: the free keyword heuristic says
+    ``explicit`` while the disk still says ``none``. That is positive
+    evidence the fragment was classified before the field had a producer,
+    it costs zero tokens to compute, and it goes quiet the moment the
+    operator acts on it.
+
+    The imports are function-local (like the rest of this module's) so a
+    bare ``creek --help`` never pays to import the classification stack.
+
+    Args:
+        vault_path: Vault root.
+
+    Returns:
+        The :class:`_FillGapCounts` for this vault; all zeroes when there
+        is no ``01-Fragments`` directory at all.
+    """
+    from creek.classify.praxis_pass import detect
+    from creek.classify.privacy_pass import needs_tier
+    from creek.vault.reader import iter_vault_fragments
+
+    untiered = 0
+    backfillable = 0
+    for _path, fragment, body, raw in iter_vault_fragments(
+        vault_path / "01-Fragments",
+    ):
+        if needs_tier(raw):
+            untiered += 1
+        recorded_none = str(fragment.praxis_potential) == PraxisPotential.NONE.value
+        if recorded_none and detect(fragment, body) is PraxisPotential.EXPLICIT:
+            backfillable += 1
+    return _FillGapCounts(untiered=untiered, praxis_backfillable=backfillable)
+
+
+def _scan_fill_gaps_quietly(vault_path: Path) -> _FillGapCounts | None:
+    """Run :func:`_scan_fill_gaps`, swallowing any failure.
+
+    The shared scan is an optimisation, not a step: if it fails, each
+    hint below still falls back to its own scan and reports its own
+    failure through its own guard, so one broken hint can never silence
+    the other.
+
+    Args:
+        vault_path: Vault root.
+
+    Returns:
+        The counts, or ``None`` when the walk raised.
+    """
+    try:
+        return _scan_fill_gaps(vault_path)
+    except Exception as exc:
+        logger.warning("fill: shared fragment-gap scan failed: %s", exc)
+        return None
+
+
+def _count_untiered_fragments(
+    vault_path: Path,
+    scan: _FillGapCounts | None = None,
+) -> int:
     """Count fragments under *vault_path* that still carry no privacy tier.
 
     "Untiered" is both on-disk shapes a fragment that has never been
@@ -2112,24 +2200,46 @@ def _count_untiered_fragments(vault_path: Path) -> int:
 
     Args:
         vault_path: Vault root.
+        scan: An already-completed :func:`_scan_fill_gaps` result to read
+            the answer out of. Omit it to walk the vault here.
 
     Returns:
         The number of untiered fragments; ``0`` when the vault has no
         ``01-Fragments`` directory at all.
     """
-    from creek.classify.privacy_pass import needs_tier
-    from creek.vault.reader import iter_vault_fragments
-
-    return sum(
-        1
-        for _path, _fragment, _body, raw in iter_vault_fragments(
-            vault_path / "01-Fragments",
-        )
-        if needs_tier(raw)
-    )
+    if scan is None:
+        scan = _scan_fill_gaps(vault_path)
+    return scan.untiered
 
 
-def _hint_untiered_fragments(vault_path: Path) -> None:
+def _count_praxis_backfillable_fragments(
+    vault_path: Path,
+    scan: _FillGapCounts | None = None,
+) -> int:
+    """Count fragments whose praxis verdict a ``--force`` run would raise.
+
+    See :func:`_scan_fill_gaps` for why "the heuristic proves ``explicit``
+    but the disk says ``none``", and not "the value is ``none``", is the
+    gap worth reporting (issue #877).
+
+    Args:
+        vault_path: Vault root.
+        scan: An already-completed :func:`_scan_fill_gaps` result to read
+            the answer out of. Omit it to walk the vault here.
+
+    Returns:
+        The number of backfillable fragments; ``0`` when the vault has no
+        ``01-Fragments`` directory at all.
+    """
+    if scan is None:
+        scan = _scan_fill_gaps(vault_path)
+    return scan.praxis_backfillable
+
+
+def _hint_untiered_fragments(
+    vault_path: Path,
+    scan: _FillGapCounts | None = None,
+) -> None:
     """Print the ``creek classify`` nudge when untiered fragments remain.
 
     Best-effort and advisory, exactly like the classify-upgrade probe it
@@ -2139,9 +2249,10 @@ def _hint_untiered_fragments(vault_path: Path) -> None:
 
     Args:
         vault_path: Vault root.
+        scan: The shared vault walk, when one already succeeded.
     """
     try:
-        untiered = _count_untiered_fragments(vault_path)
+        untiered = _count_untiered_fragments(vault_path, scan)
     except Exception as exc:
         logger.warning("fill: skipping untiered-fragment hint: %s", exc)
         return
@@ -2152,6 +2263,41 @@ def _hint_untiered_fragments(vault_path: Path) -> None:
         "(privacy_tier absent or `unclassified`); they are gated like "
         "`personal`, so they contribute summaries only. "
         "Run `creek classify` to assign real tiers.[/dim]",
+    )
+
+
+def _hint_praxis_backfill(
+    vault_path: Path,
+    scan: _FillGapCounts | None = None,
+) -> None:
+    """Print the backfill nudge when praxis verdicts are provably missing.
+
+    Own guard, own warning: sharing the untiered hint's ``try`` would let
+    one failing scan silently suppress the other hint too. Silent at
+    zero, so a vault the operator has already backfilled never nags.
+
+    Reports a **count only** — never a fragment id or a body excerpt.
+    Naming either would turn an advisory line into an unaudited
+    disclosure of vault content through stdout (the config-oracle rule,
+    #846 / #848).
+
+    Args:
+        vault_path: Vault root.
+        scan: The shared vault walk, when one already succeeded.
+    """
+    try:
+        backfillable = _count_praxis_backfillable_fragments(vault_path, scan)
+    except Exception as exc:
+        logger.warning("fill: skipping praxis-backfill hint: %s", exc)
+        return
+    if backfillable == 0:
+        return
+    console.print(
+        f"[dim][fill] {backfillable} fragment(s) show explicit praxis signals "
+        "but are recorded as `praxis_potential: none` (classified before the "
+        "field had a producer). Run `creek classify --method llm --force` to "
+        "backfill — that re-sends those fragments to the configured provider "
+        "and costs tokens.[/dim]",
     )
 
 
@@ -2180,11 +2326,15 @@ def _maybe_upgrade_classification(
     silently egresses): it only prints a hint. ``--upgrade`` applies the upgrade
     without a prompt; an interactive TTY prompts ``[y/N]`` (default No).
 
-    The #876 untiered-fragment hint fires first, ahead of every early return:
-    the vault that most needs it (rules-classified, no LLM reachable, every
-    fragment untiered) is exactly the one where there is no upgrade to offer.
+    The #876 untiered-fragment hint and the #877 praxis-backfill hint fire
+    first, ahead of every early return: the vault that most needs them
+    (rules-classified, no LLM reachable, every fragment untiered) is exactly
+    the one where there is no upgrade to offer. Both read one shared vault
+    walk so ``creek fill`` parses every fragment once, not once per hint.
     """
-    _hint_untiered_fragments(vault_path)
+    gaps = _scan_fill_gaps_quietly(vault_path)
+    _hint_untiered_fragments(vault_path, gaps)
+    _hint_praxis_backfill(vault_path, gaps)
     try:
         offer = _detect_classify_upgrade(vault_path, config)
     except Exception as exc:

--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -38,6 +38,7 @@ from creek.audit.yield_summary import (
     write_yield_summary,
 )
 from creek.classify.classify_engine import build_tier_classifiers
+from creek.classify.praxis_pass import apply_praxis
 from creek.classify.privacy import PrivacyClassifier
 from creek.classify.privacy_filter import tier_of
 from creek.classify.privacy_pass import PRIVACY_TIER_KEY, apply_tier
@@ -524,6 +525,14 @@ class Pipeline:
         router reads that tier to keep Intimate content off cloud
         providers and a freshly-ingested fragment carries none.
 
+        Every fragment is likewise scored for praxis potential once the
+        classifiers are done (#877). ``creek process`` never calls the
+        classify engine, so without this the one-shot command would leave
+        every fragment it ingests at ``praxis_potential: none`` and keep
+        ``04-Praxis`` / ``08-Decisions`` unreachable for anyone who uses
+        it. The pass is escalate-only, so running it after the optional
+        LLM dispatch cannot undo a ``latent`` verdict the model produced.
+
         Classification operates on the inner :class:`Fragment`; the body
         is preserved unchanged on the returned :class:`IngestedFragment`.
 
@@ -562,6 +571,9 @@ class Pipeline:
                     frag = classifier.classify(frag, content=item.body)
             else:
                 result.deterministic_classified += 1
+            # Issue #877: score the praxis axis last, so the escalate-only
+            # merge sees whatever the optional LLM dispatch above produced.
+            frag = apply_praxis(frag, item.body)
             classified.append(IngestedFragment(fragment=frag, body=item.body))
 
         self.review_generator.generate_queue(

--- a/creek-tools/creek_mcp/tools/classify.py
+++ b/creek-tools/creek_mcp/tools/classify.py
@@ -94,5 +94,10 @@ def classify_tool(
         # tier. Surfaced separately from ``classified`` because the tier
         # pass also runs on fragments the resume short-circuit preserved.
         "privacy_tiers_assigned": summary.privacy_tiers_assigned,
+        # Issue #877: how many fragments this run raised to a stronger
+        # praxis potential. Surfaced for the same reason as the tier count
+        # — the field previously had no producer at all, and a silent
+        # producer is how that bug survived.
+        "praxis_marked": summary.praxis_marked,
         "errors": list(summary.errors),
     }

--- a/creek-tools/docs/decisions.md
+++ b/creek-tools/docs/decisions.md
@@ -42,6 +42,19 @@ The frontmatter follows `creek.models.Decision`: `id`, `title`, `status`, `opene
 
 A fragment matching both strategies produces a single candidate scored **0.9**.
 
+Every input to the Pattern strategy now has a producer. `confidence` and the
+frequencies come from `creek classify` (rules or LLM); `praxis_potential` was
+added a producer by issue #877 — `creek.classify.praxis_pass.detect` scores the
+body for task checkboxes, `Decision:`-style labels and first-person commitments,
+and the LLM response schema carries a `praxis:` section that can additionally
+report `latent`. Before #877 the field defaulted to `none` and nothing ever
+changed it, so this strategy could never fire and `08-Decisions/` stayed empty
+no matter what the vault contained. The pass is escalate-only, and it runs only
+on fragments a run actually (re-)classifies: a vault already stamped
+`classification_method: llm` backfills the axis under
+`creek classify --method llm --force`, and `creek fill` reports the outstanding
+count.
+
 Each candidate captures `wavelength_phase_at_detection` and the active `frequency_context` so the eventual Decision note can preserve the felt-sense of when the question first surfaced.
 
 ---

--- a/creek-tools/tests/test_classify.py
+++ b/creek-tools/tests/test_classify.py
@@ -24,6 +24,7 @@ from creek.classify.llm import (
     _strip_code_fences,
 )
 from creek.classify.llm import LLMClassifier as LLMClassifierDirect
+from creek.classify.llm.parsing import _apply_praxis
 from creek.classify.review import ReviewQueueGenerator as ReviewQueueGeneratorDirect
 from creek.classify.rules import (
     CONFIDENCE_SIGNALS,
@@ -45,6 +46,7 @@ from creek.models import (
     Mode,
     Orientation,
     Phase,
+    PraxisPotential,
     SourcePlatform,
     VoiceClassification,
     VoiceRegister,
@@ -70,6 +72,30 @@ def _make_fragment(
         id="frag-000000000003",
         title=title,
         source=FragmentSource(platform=platform),
+    )
+
+
+def _make_praxis_fragment(potential: PraxisPotential) -> Fragment:
+    """Create a Fragment that already carries a praxis verdict (issue #877).
+
+    :func:`_make_fragment` always yields the model default, ``none`` — the
+    *weakest* verdict on the monotone ``none < latent < explicit`` scale.
+    Any assertion built on it is therefore structurally blind to a
+    demotion, because there is no higher verdict left to lose.
+
+    ``.value`` is used because ``Fragment`` sets ``use_enum_values=True``
+    but ``model_copy`` bypasses that coercion, so passing the bare
+    StrEnum member would store something a plain-``str`` consumer (and
+    YAML's SafeDumper) does not see the same way.
+
+    Args:
+        potential: The praxis verdict already recorded on the fragment.
+
+    Returns:
+        A Fragment identical to :func:`_make_fragment`'s but at *potential*.
+    """
+    return _make_fragment().model_copy(
+        update={"praxis_potential": potential.value},
     )
 
 
@@ -2813,3 +2839,438 @@ class TestInvokePromptWithMetadata:
         completion = classifier.invoke_prompt_with_metadata("prompt", max_tokens=512)
         assert completion.text == "cut"
         assert completion.stop_reason == "max_tokens"
+
+
+# ---- Praxis potential: LLM schema + prompt (issue #877) ----
+
+
+_PRAXIS_YAML_RESPONSE: str = """\
+frequency:
+  primary: F3
+praxis:
+  potential: explicit
+"""
+"""A documented response carrying the new ``praxis`` section."""
+
+_LATENT_PRAXIS_RESPONSE: str = _VALID_YAML_RESPONSE + "praxis:\n  potential: latent\n"
+"""A full response whose praxis verdict is the *middle* one, ``latent``.
+
+Appended to :data:`_VALID_YAML_RESPONSE` so the other sections still land
+— an end-to-end praxis assertion is worthless if the call could have
+short-circuited before applying anything.
+"""
+
+_EXPLICIT_PRAXIS_RESPONSE: str = (
+    _VALID_YAML_RESPONSE + "praxis:\n  potential: explicit\n"
+)
+"""A full response whose praxis verdict is the strongest one."""
+
+
+class TestValidatePraxisSection:
+    """``praxis`` joins the documented top-level schema (issue #877)."""
+
+    def test_accepts_a_praxis_section(self) -> None:
+        """A response with ``praxis:`` validates rather than being rejected.
+
+        ``praxis`` has to join ``_ALLOWED_TOP_LEVEL_KEYS`` in lockstep with
+        the prompt: :func:`validate_response` rejects *any* undocumented
+        top-level key, so a model that obeys the new prompt would
+        otherwise have its entire response thrown away (and the fragment
+        left unclassified) on every call.
+        """
+        classifier = LLMClassifier(config=LLMConfig())
+
+        result = classifier.validate_response(_PRAXIS_YAML_RESPONSE)
+
+        assert result["praxis"] == {"potential": "explicit"}
+
+    def test_still_rejects_privacy_tier(self) -> None:
+        """SEC-004 regression: widening the schema must not widen it to privacy.
+
+        The allow-list exists so a successful prompt injection cannot
+        smuggle in a field like ``privacy_tier`` and talk the classifier
+        into re-tiering intimate content as ``open``. Adding ``praxis``
+        is a one-key change; this pins that the *rest* of the allow-list
+        is unchanged, including on a payload that also carries the
+        newly-legal ``praxis`` section.
+        """
+        classifier = LLMClassifier(config=LLMConfig())
+        bogus = "praxis:\n  potential: explicit\nprivacy_tier: open\n"
+
+        with pytest.raises(ValueError, match="top-level"):
+            classifier.validate_response(bogus)
+
+    def test_still_rejects_other_undocumented_keys(self) -> None:
+        """An unrelated smuggled key is still refused after the widening."""
+        classifier = LLMClassifier(config=LLMConfig())
+        bogus = "praxis:\n  potential: explicit\nvoice_proxy_eligible: true\n"
+
+        with pytest.raises(ValueError, match="top-level"):
+            classifier.validate_response(bogus)
+
+
+class TestApplyPraxisSection:
+    """``_apply_praxis`` translates the LLM's verdict onto the fragment."""
+
+    def test_applies_explicit(self) -> None:
+        """``praxis.potential: explicit`` lands on the fragment."""
+        from creek.models import PraxisPotential
+
+        classifier = LLMClassifier(config=LLMConfig())
+        data: dict[str, object] = {"praxis": {"potential": "explicit"}}
+
+        result = classifier._apply_classification(_make_fragment(), data)
+
+        assert str(result.praxis_potential) == PraxisPotential.EXPLICIT.value
+
+    def test_applies_latent(self) -> None:
+        """``latent`` is the LLM-only verdict — it must survive the parser.
+
+        The free keyword heuristic deliberately never emits ``latent``
+        ("there is a practice hiding in here that the author has not
+        named" is not something a regex can see), so this branch is the
+        *only* way a fragment can ever reach ``praxis_potential: latent``.
+        """
+        from creek.models import PraxisPotential
+
+        classifier = LLMClassifier(config=LLMConfig())
+        data: dict[str, object] = {"praxis": {"potential": "latent"}}
+
+        result = classifier._apply_classification(_make_fragment(), data)
+
+        assert str(result.praxis_potential) == PraxisPotential.LATENT.value
+
+    def test_unknown_value_writes_nothing(self) -> None:
+        """A junk ``potential`` leaves the fragment object untouched.
+
+        Unknown values fall back to ``none``, and ``none`` writes no
+        update key at all — so a garbage response cannot demote a
+        fragment the heuristic already marked ``explicit``.
+        """
+        classifier = LLMClassifier(config=LLMConfig())
+        frag = _make_fragment()
+        data: dict[str, object] = {"praxis": {"potential": "somewhat-maybe"}}
+
+        assert classifier._apply_classification(frag, data) is frag
+
+    def test_explicit_none_writes_nothing(self) -> None:
+        """``praxis.potential: none`` is a no-op, not a demotion.
+
+        The LLM can only ever *raise* this axis. The engine runs the free
+        heuristic before the LLM call, so a model answering ``none`` on a
+        fragment whose body carries a task checkbox must not undo the
+        heuristic's ``explicit``.
+        """
+        classifier = LLMClassifier(config=LLMConfig())
+        frag = _make_fragment()
+        data: dict[str, object] = {"praxis": {"potential": "none"}}
+
+        assert classifier._apply_classification(frag, data) is frag
+
+    def test_non_dict_praxis_section_is_ignored(self) -> None:
+        """A scalar where the nested section belongs must not raise."""
+        classifier = LLMClassifier(config=LLMConfig())
+        frag = _make_fragment()
+        data: dict[str, object] = {"praxis": "explicit"}
+
+        assert classifier._apply_classification(frag, data) is frag
+
+    def test_absent_praxis_section_is_ignored(self) -> None:
+        """A response without ``praxis`` leaves the axis alone."""
+        classifier = LLMClassifier(config=LLMConfig())
+        frag = _make_fragment()
+        data: dict[str, object] = {"frequency": {"primary": "F3"}}
+
+        result = classifier._apply_classification(frag, data)
+
+        assert result.praxis_potential == frag.praxis_potential
+
+    def test_praxis_applies_alongside_the_other_sections(self) -> None:
+        """Praxis does not displace frequency / voice in the same response."""
+        from creek.models import PraxisPotential
+
+        classifier = LLMClassifier(config=LLMConfig())
+        data: dict[str, object] = {
+            "frequency": {"primary": "F3", "secondary": ["F5"]},
+            "voice": {"voice_register": "analytical", "confidence": "forming"},
+            "praxis": {"potential": "explicit"},
+        }
+
+        result = classifier._apply_classification(_make_fragment(), data)
+
+        assert result.frequency.primary == Frequency.F3
+        assert result.voice.confidence == Confidence.FORMING
+        assert str(result.praxis_potential) == PraxisPotential.EXPLICIT.value
+
+
+class TestApplyPraxisIsEscalateOnly:
+    """``_apply_praxis`` merges against the verdict the fragment already has.
+
+    The axis is monotone — ``none < latent < explicit``, and nothing may
+    lower it (see :mod:`creek.classify.praxis_pass`). That invariant is a
+    property of the *merge*, so the helper has to be told what the
+    fragment currently carries; refusing to write only when the parsed
+    value is ``none`` is not sufficient, because ``latent`` is also
+    weaker than ``explicit``.
+
+    Every case below drives ``_apply_praxis`` directly and asserts on the
+    ``updates`` dict rather than on a returned Fragment, because "writes
+    no key at all" is the contract: ``_apply_classification`` returns the
+    fragment untouched precisely when ``updates`` is empty, so writing
+    the merged value back unconditionally would be a behaviour change in
+    its own right.
+    """
+
+    def test_latent_never_demotes_an_explicit_fragment(self) -> None:
+        """``latent`` over a recorded ``explicit`` writes nothing.
+
+        The blocker's direct regression test. A model answering ``latent``
+        for a fragment already at ``explicit`` — from an earlier LLM run,
+        or from an operator's hand edit — is offering a *weaker* verdict.
+        The heuristic pass that runs afterwards cannot repair the damage:
+        it re-derives from the body and only ever proposes ``explicit`` or
+        ``none``, so a fragment whose ``explicit`` came from judgment
+        rather than keywords keeps the demotion all the way to disk.
+        """
+        updates: dict[str, object] = {}
+
+        _apply_praxis(
+            {"praxis": {"potential": "latent"}},
+            updates,
+            PraxisPotential.EXPLICIT,
+        )
+
+        assert updates == {}
+
+    def test_explicit_raises_a_latent_fragment(self) -> None:
+        """``explicit`` over a recorded ``latent`` writes ``explicit``.
+
+        The escalating direction of the same merge: ``latent`` is the
+        weaker verdict, so the model's stronger answer wins.
+        """
+        updates: dict[str, object] = {}
+
+        _apply_praxis(
+            {"praxis": {"potential": "explicit"}},
+            updates,
+            PraxisPotential.LATENT,
+        )
+
+        assert updates == {"praxis_potential": "explicit"}
+
+    def test_latent_raises_a_none_fragment(self) -> None:
+        """``latent`` over ``none`` still writes ``latent``.
+
+        Guards the fix against over-correcting into "never write anything
+        but ``explicit``". ``latent`` is the entire reason the LLM praxis
+        section exists — the free keyword heuristic can never emit it —
+        so a merge that dropped it would silently delete the feature.
+        """
+        updates: dict[str, object] = {}
+
+        _apply_praxis(
+            {"praxis": {"potential": "latent"}},
+            updates,
+            PraxisPotential.NONE,
+        )
+
+        assert updates == {"praxis_potential": "latent"}
+
+    def test_an_unchanged_explicit_verdict_writes_no_key(self) -> None:
+        """Re-confirming ``explicit`` is a no-op, not a rewrite.
+
+        ``_apply_classification`` returns the input Fragment unchanged
+        only when ``updates`` is empty; writing the merged value back
+        whenever the model agrees would allocate a fresh model copy per
+        fragment and blur the "did this run change anything?" signal
+        callers read from object identity.
+        """
+        updates: dict[str, object] = {}
+
+        _apply_praxis(
+            {"praxis": {"potential": "explicit"}},
+            updates,
+            PraxisPotential.EXPLICIT,
+        )
+
+        assert updates == {}
+
+    def test_an_unchanged_latent_verdict_writes_no_key(self) -> None:
+        """The same no-op contract holds at the middle rank."""
+        updates: dict[str, object] = {}
+
+        _apply_praxis(
+            {"praxis": {"potential": "latent"}},
+            updates,
+            PraxisPotential.LATENT,
+        )
+
+        assert updates == {}
+
+    def test_none_from_the_model_never_demotes_explicit(self) -> None:
+        """``none`` over ``explicit`` writes nothing.
+
+        Pinned against a fragment that is actually at ``explicit`` — the
+        pre-existing coverage only ever started from the model default,
+        where ``none`` is a no-op for free.
+        """
+        updates: dict[str, object] = {}
+
+        _apply_praxis(
+            {"praxis": {"potential": "none"}},
+            updates,
+            PraxisPotential.EXPLICIT,
+        )
+
+        assert updates == {}
+
+    def test_unparseable_garbage_never_demotes_explicit(self) -> None:
+        """An unrecognised value falls back to ``none`` and still writes nothing."""
+        updates: dict[str, object] = {}
+
+        _apply_praxis(
+            {"praxis": {"potential": "somewhat-maybe"}},
+            updates,
+            PraxisPotential.EXPLICIT,
+        )
+
+        assert updates == {}
+
+    def test_the_written_value_is_a_plain_string(self) -> None:
+        """The update carries ``.value``, not the StrEnum member itself.
+
+        ``Fragment`` sets ``use_enum_values=True``, but ``model_copy``
+        bypasses that coercion — so a bare member would reach the vault
+        writer, where YAML's SafeDumper cannot represent it. ``type(...)
+        is str`` rather than ``isinstance`` / ``==`` on purpose: a
+        ``PraxisPotential`` member passes both of those.
+        """
+        updates: dict[str, object] = {}
+
+        _apply_praxis(
+            {"praxis": {"potential": "explicit"}},
+            updates,
+            PraxisPotential.NONE,
+        )
+
+        assert updates["praxis_potential"] == "explicit"
+        assert type(updates["praxis_potential"]) is str
+
+    def test_apply_classification_feeds_the_fragments_own_verdict(self) -> None:
+        """The orchestrator is the call site that must supply ``current``.
+
+        ``_apply_praxis`` can only refuse a demotion if it is told what
+        the fragment already carries, and ``_apply_classification`` is its
+        only production caller. ``Fragment.model_config`` sets
+        ``use_enum_values=True``, so ``fragment.praxis_potential`` is a
+        plain ``str`` at runtime and has to be coerced back to a
+        ``PraxisPotential`` on the way in — this pins that wiring, which
+        the direct-call tests above cannot see.
+        """
+        classifier = LLMClassifier(config=LLMConfig())
+        frag = _make_praxis_fragment(PraxisPotential.EXPLICIT)
+        data: dict[str, object] = {"praxis": {"potential": "latent"}}
+
+        result = classifier._apply_classification(frag, data)
+
+        assert str(result.praxis_potential) == PraxisPotential.EXPLICIT.value
+        assert result is frag
+
+
+class TestClassifyPreservesAPriorPraxisVerdict:
+    """A whole ``classify`` call must never lower ``praxis_potential`` (#877).
+
+    The end-to-end counterpart to
+    :class:`TestApplyPraxisIsEscalateOnly`: prompt, stubbed provider,
+    response split, schema validation and application all run, and no
+    private helper is touched. This is the shape of test that would have
+    caught the demotion before review — the unit tests around
+    ``_apply_praxis`` all started from the model default and so had no
+    higher verdict to lose.
+    """
+
+    @patch.object(LLMClassifier, "_invoke_llm")
+    def test_a_latent_answer_leaves_an_explicit_fragment_explicit(
+        self,
+        mock_call: MagicMock,
+    ) -> None:
+        """The model's weaker verdict loses to the one already on record."""
+        mock_call.return_value = _LATENT_PRAXIS_RESPONSE
+        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
+        frag = _make_praxis_fragment(PraxisPotential.EXPLICIT)
+
+        result = classifier.classify(frag)
+
+        assert str(result.praxis_potential) == PraxisPotential.EXPLICIT.value
+        # The rest of the same response *did* land, so the assertion above
+        # cannot be passing because the call short-circuited.
+        assert result.frequency.primary == Frequency.F3
+
+    @patch.object(LLMClassifier, "_invoke_llm")
+    def test_a_latent_answer_still_raises_a_none_fragment(
+        self,
+        mock_call: MagicMock,
+    ) -> None:
+        """A fragment at the default ``none`` still reaches ``latent``.
+
+        The LLM section exists to produce exactly this verdict, so the
+        escalate-only merge must not cost us the raise.
+        """
+        mock_call.return_value = _LATENT_PRAXIS_RESPONSE
+        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
+
+        result = classifier.classify(_make_praxis_fragment(PraxisPotential.NONE))
+
+        assert str(result.praxis_potential) == PraxisPotential.LATENT.value
+
+    @patch.object(LLMClassifier, "_invoke_llm")
+    def test_an_explicit_answer_raises_a_latent_fragment(
+        self,
+        mock_call: MagicMock,
+    ) -> None:
+        """The escalating direction survives the full call too."""
+        mock_call.return_value = _EXPLICIT_PRAXIS_RESPONSE
+        classifier = _make_classifier_available(LLMClassifier(config=LLMConfig()))
+
+        result = classifier.classify(_make_praxis_fragment(PraxisPotential.LATENT))
+
+        assert str(result.praxis_potential) == PraxisPotential.EXPLICIT.value
+
+
+class TestPraxisPrompt:
+    """The prompt must ask for the axis the parser now accepts."""
+
+    def test_prompt_renders_without_a_format_error(self) -> None:
+        """``CLASSIFICATION_PROMPT`` still survives ``str.format``.
+
+        The template is consumed by ``str.format`` (prompts.py:286), so a
+        single stray literal ``{`` or ``}`` added while editing the YAML
+        schema block raises ``KeyError`` / ``IndexError`` / ``ValueError``
+        on *every* classification call. That failure is invisible in a
+        static read of the diff, so it is pinned here.
+        """
+        classifier = LLMClassifier(config=LLMConfig())
+
+        prompt = classifier._build_prompt(_make_fragment(title="ok"), content="body")
+
+        assert "ok" in prompt
+        assert "body" in prompt
+
+    def test_prompt_names_the_praxis_dimension(self) -> None:
+        """The dimension list names praxis and its three legal values."""
+        prompt_lower = CLASSIFICATION_PROMPT.lower()
+
+        assert "praxis" in prompt_lower
+        assert "explicit" in prompt_lower
+        assert "latent" in prompt_lower
+
+    def test_prompt_yaml_example_includes_the_praxis_section(self) -> None:
+        """The YAML schema example must show the nested ``potential`` key.
+
+        Same lesson as issue #319: models follow the explicit YAML block
+        far more reliably than the prose above it. Without ``praxis:`` /
+        ``potential:`` in the example, the model never emits the section
+        and the LLM half of #877 silently regresses to never firing.
+        """
+        assert "praxis:" in CLASSIFICATION_PROMPT
+        assert "potential:" in CLASSIFICATION_PROMPT

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -1869,3 +1869,313 @@ def test_tier_only_write_failure_lands_on_errors_without_aborting(
     assert "frag-tierio-fail1" in summary.errors[0]
     # The run continued: the other fragment still got its real tier.
     assert _tier_map(vault)["frag-tierio-ok001"] == "personal"
+
+
+# ---- Praxis-potential pass (issue #877) ------------------------------------
+#
+# Same discipline as the #876 tier block above: seed fragments with known
+# ids, read the whole tree back off disk, and assert an explicit
+# ``{fragment_id: praxis_potential}`` mapping. ``rglob`` does not sort, so
+# never index into its output — a positional assertion can false-green
+# against the live bug (before #877 every fragment in the 35k-fragment demo
+# vault read ``praxis_potential: none``, so "the first file says none" was
+# trivially true for the *wrong* reason).
+
+_PRAXIS_SIGNAL_BODY = "notes from the week ahead\n- [ ] book the boiler service"
+"""A body carrying exactly one strong praxis marker (a task checkbox).
+
+Deliberately free of frequency / phase / voice keywords so the rule
+classifier's other axes cannot move and confuse the assertion, and free of
+recovery keywords so the #876 tier heuristic stays driven by the platform.
+"""
+
+
+def _praxis_map(vault: Path) -> dict[str, str]:
+    """Return ``{fragment_id: praxis_potential}`` read back off disk.
+
+    Reads EVERY markdown file under ``01-Fragments`` (recursively) and keys
+    the result by fragment id, so the assertion is independent of
+    filesystem iteration order.
+    """
+    out: dict[str, str] = {}
+    for path in (vault / "01-Fragments").rglob("*.md"):
+        meta = frontmatter.load(str(path)).metadata
+        if meta.get("type") != "fragment":
+            continue
+        out[str(meta["id"])] = str(meta.get("praxis_potential", "<absent>"))
+    return out
+
+
+def test_run_classify_rules_stamps_praxis_potential(tmp_path: Path) -> None:
+    """A ``--method rules`` run writes ``praxis_potential`` to disk (AC-1, #877).
+
+    The bug: ``Fragment.praxis_potential`` defaulted to ``none`` and *no*
+    pipeline stage ever set it, so the three consumers gated on
+    ``explicit`` (``generate/decisions.py``, ``generate/mining.py``,
+    ``generate/compost.py``) were structurally unreachable and
+    ``04-Praxis`` / ``08-Decisions`` could never be populated.
+
+    Three fragments covering three distinct outcomes — raised, left alone,
+    and already-decided — so the mapping cannot pass by stamping
+    everything alike.
+    """
+    from creek.models import Authorship, PraxisPotential
+
+    vault = tmp_path / "vault"
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-praxis-sig01",
+            title="Week notes",
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                author=Authorship.SELF,
+            ),
+        ),
+        body=_PRAXIS_SIGNAL_BODY,
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-praxis-none1",
+            title="Week notes",
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                author=Authorship.SELF,
+            ),
+        ),
+        body=_TIER_NEUTRAL_BODY,
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-praxis-keep1",
+            title="Week notes",
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                author=Authorship.SELF,
+            ),
+            praxis_potential=PraxisPotential.EXPLICIT,
+        ),
+        body=_TIER_NEUTRAL_BODY,
+    )
+    # Precondition: nothing is ``explicit`` by accident of the fixture
+    # writer, and the signal-bearing fragment really does start at ``none``.
+    assert _praxis_map(vault)["frag-praxis-sig01"] == "none"
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    assert _praxis_map(vault) == {
+        "frag-praxis-sig01": "explicit",  # the checkbox fired
+        "frag-praxis-none1": "none",  # a plain note stays none
+        "frag-praxis-keep1": "explicit",  # never demoted by a signal-free run
+    }
+    # Only the genuine raise is counted; re-affirming an existing
+    # ``explicit`` is not work the operator needs reported.
+    assert summary.praxis_marked == 1
+
+
+def test_second_run_marks_no_praxis_and_changes_none(tmp_path: Path) -> None:
+    """The praxis pass is idempotent: run two reports zero marks.
+
+    ``classified_at`` is legitimately re-stamped on the non-preserved
+    path, so a byte comparison would be meaningless; the durable contract
+    is that the id→praxis mapping is identical and the counter reports
+    zero work the second time.
+    """
+    from creek.models import Authorship
+
+    vault = tmp_path / "vault"
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-praxis-idem1",
+            title="Week notes",
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                author=Authorship.SELF,
+            ),
+        ),
+        body=_PRAXIS_SIGNAL_BODY,
+    )
+
+    first = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+    after_first = _praxis_map(vault)
+
+    second = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=False,
+    )
+
+    assert first.praxis_marked == 1
+    assert second.praxis_marked == 0
+    assert after_first == {"frag-praxis-idem1": "explicit"}
+    assert _praxis_map(vault) == after_first
+
+
+@pytest.mark.parametrize(
+    ("force", "expected_praxis", "expected_marked"),
+    [(False, "none", 0), (True, "explicit", 1)],
+)
+def test_preserved_fragment_gets_praxis_only_under_force(
+    tmp_path: Path,
+    force: bool,
+    expected_praxis: str,
+    expected_marked: int,
+) -> None:
+    """A preserved ``llm``-stamped fragment gains praxis only with ``--force``.
+
+    Deliberate asymmetry with the #876 tier pass. ``_write_tier_only`` is
+    the narrow writer used on the OPS-001 resume short-circuit, and it is
+    **not** widened to carry praxis: the tier exception exists because an
+    untiered fragment is a live privacy hole, whereas a missing praxis
+    verdict is a missing feature. Widening that writer would rewrite the
+    praxis axis of every already-curated fragment in a mature vault
+    without the operator asking.
+
+    The tier still lands on the same run, which is what proves the
+    short-circuit was genuinely taken rather than the fragment quietly
+    reclassified.
+    """
+    from creek.models import Authorship
+
+    vault = tmp_path / "vault"
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-praxis-prsv1",
+            title="Morning pages",
+            source=FragmentSource(
+                platform=SourcePlatform.JOURNAL,
+                author=Authorship.SELF,
+            ),
+        ),
+        body=_PRAXIS_SIGNAL_BODY,
+        method="llm",
+    )
+
+    summary = run_classify(
+        vault_path=vault,
+        config=CreekConfig(),
+        method="rules",
+        force=force,
+    )
+
+    assert _praxis_map(vault) == {"frag-praxis-prsv1": expected_praxis}
+    assert _tier_map(vault) == {"frag-praxis-prsv1": "intimate"}
+    assert summary.praxis_marked == expected_marked
+    assert summary.preserved_llm == (0 if force else 1)
+
+
+def test_praxis_pass_runs_after_the_router_reads_the_tier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adding the praxis pass must not disturb the #876 tier→router ordering.
+
+    The #876 ordering is load-bearing security, not style: the per-tier
+    router calls ``tier_of(fragment)`` to honour Intimate-never-cloud
+    (#666 / ADR-0003), so the privacy tier has to be assigned in
+    ``_prepare_fragment`` — before ``TierClassifiers.for_tier`` — and
+    above the resume short-circuit. The praxis pass belongs *after* the
+    classifier returns (it reads the same body the classifier saw, and
+    must not delay the tier), so this test asserts BOTH facts on one run:
+    the recorded ``{fragment_id: provider}`` map is still correct, and the
+    praxis verdict still landed.
+
+    It exists so a future agent cannot "simplify" by hoisting the praxis
+    pass into ``_prepare_fragment`` and, in the process, sliding the
+    privacy pass below the router.
+    """
+    from creek.config import LLMConfig, LLMRoutingConfig
+    from creek.models import Authorship
+
+    calls: dict[str, str] = {}
+
+    class _RecordingClassifier:
+        """Records which provider was handed which fragment; never calls out."""
+
+        def __init__(self, config: LLMConfig) -> None:
+            """Capture the resolved config — its ``provider`` is the assertion."""
+            self.config = config
+
+        @property
+        def available(self) -> bool:
+            """Always reachable; the availability gate is not under test."""
+            return True
+
+        def classify_with_reasoning(
+            self,
+            fragment: Fragment,
+            content: str = "",
+        ) -> LLMClassificationResult:
+            """Record ``id -> provider`` and echo the fragment back unchanged."""
+            _ = content
+            assert fragment.id not in calls, f"classified {fragment.id} twice"
+            calls[fragment.id] = self.config.provider
+            return LLMClassificationResult(fragment=fragment, reasoning="")
+
+    monkeypatch.setattr(
+        "creek.classify.classify_engine.LLMClassifier",
+        _RecordingClassifier,
+    )
+
+    vault = tmp_path / "vault"
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-order-journl",
+            title="Morning pages",
+            source=FragmentSource(
+                platform=SourcePlatform.JOURNAL,
+                author=Authorship.SELF,
+            ),
+        ),
+        body=_PRAXIS_SIGNAL_BODY,
+    )
+    _write_fragment(
+        vault=vault,
+        fragment=Fragment(
+            id="frag-order-essay1",
+            title="On public transit",
+            source=FragmentSource(
+                platform=SourcePlatform.ESSAY,
+                author=Authorship.SELF,
+            ),
+        ),
+        body=_TIER_NEUTRAL_BODY,
+    )
+    # Precondition: this really is the FIRST pass over both fragments.
+    assert set(_tier_map(vault).values()) == {"unclassified"}
+    assert set(_praxis_map(vault).values()) == {"none"}
+
+    config = CreekConfig(
+        llm=LLMRoutingConfig(
+            default=LLMConfig(provider="ollama", model="qwen3:8b"),
+            classification=LLMConfig(provider="anthropic", model="claude-haiku-4-5"),
+        ),
+    )
+    config.classification.confidence_threshold = 1.0  # force the LLM path
+
+    run_classify(vault_path=vault, config=config, method="llm", force=False)
+
+    assert calls == {
+        "frag-order-journl": "ollama",  # Intimate → redirected to local
+        "frag-order-essay1": "anthropic",  # non-Intimate → configured cloud
+    }
+    assert _praxis_map(vault) == {
+        "frag-order-journl": "explicit",
+        "frag-order-essay1": "none",
+    }

--- a/creek-tools/tests/test_classify_praxis_e2e.py
+++ b/creek-tools/tests/test_classify_praxis_e2e.py
@@ -1,0 +1,222 @@
+"""End-to-end reachability of ``08-Decisions/`` via praxis (issue #877).
+
+The unit suites pin each half of the fix in isolation. This suite pins the
+thing the operator actually cares about: that a fragment carrying real
+deliberation signals, run through the shipped CLI, ends up producing a
+Decision note — a folder that was **structurally unreachable** before #877.
+
+Why it was unreachable: ``DecisionDetector._detect_pattern``
+(``creek/generate/decisions.py``) requires all three of
+``praxis_potential == "explicit"``, ``voice.confidence == "exploring"``, and
+an ``{F1, F4}`` or ``{F1, F5}`` frequency overlap. Nothing in the pipeline
+ever wrote ``praxis_potential``, so the first condition was false for 100%
+of the 35,330-fragment demo vault and the pattern strategy could never
+fire. Only the *keyword* strategy — a title-substring match — could ever
+produce a Decision note.
+
+Which is exactly the trap this test is built to avoid. The fixture title
+contains **none** of ``DECISION_KEYWORDS``, so the keyword strategy cannot
+fire; the note asserted below can only exist if the pattern strategy ran,
+and the pattern strategy can only run if ``praxis_potential`` was actually
+written. Assertions on ``detection_method`` make that explicit rather than
+implicit.
+
+Everything here is deterministic and local: the rules classifier only, no
+LLM, no network, no mocks.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.generate.decisions import DECISION_KEYWORDS
+from creek.models import Authorship, Fragment, FragmentSource, SourcePlatform
+from tests.helpers import write_fragment_file
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+runner = CliRunner()
+
+_FRAGMENT_ID = "frag-praxis-e2e01"
+
+_TITLE = "Winter boiler notes"
+"""A title that matches no ``DECISION_KEYWORDS`` — pinned by a test below.
+
+``DecisionDetector._detect_keywords`` matches against the *title only*. A
+title carrying "considering" or "should i" would produce a Decision note
+through the keyword strategy alone, false-greening this suite even with the
+#877 bug fully present.
+"""
+
+_DELIBERATION_BODY = (
+    "Exploring the survival math again: safety first, "
+    "then a strategy for the winter.\n"
+    "- [ ] book the boiler service before October"
+)
+"""A body engineered to trip all three ``_detect_pattern`` conditions.
+
+Scoring is deliberate, not incidental (``RuleClassifier``: title x3, first
+paragraph x2, body x1; there is no blank line, so the whole thing is the
+first paragraph and every match counts double):
+
+* **F1 primary** — ``survival`` + ``safety`` = 2 matches x2 = 4, clearing
+  ``PRIMARY_THRESHOLD`` (3) and uniquely top-scoring.
+* **F5 secondary** — ``strategy`` = 1 match x2 = 2, clearing
+  ``SECONDARY_THRESHOLD`` (2). Together: the ``{F1, F5}`` deliberation pair.
+* **``exploring`` confidence** — ``exploring`` = 1 match x2 = 2, clearing
+  ``SECONDARY_THRESHOLD``, with every other confidence bucket at 0 (note
+  the careful absence of "this is", "maybe", "might", "clearly", … which
+  would otherwise outrank or tie it).
+* **``explicit`` praxis** — the line-initial task checkbox is a single
+  strong (weight-2) marker, which reaches ``_EXPLICIT_AT`` on its own.
+"""
+
+
+def _seed(vault: Path) -> Path:
+    """Write the single deliberation fragment into *vault*.
+
+    Written with **no** ``classification_method`` stamp, so the OPS-001 /
+    issue-#321 resume short-circuit does not preserve it — otherwise the
+    run would skip the fragment entirely and the praxis pass would never
+    see it.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        Path to the seeded fragment file.
+    """
+    return write_fragment_file(
+        vault=vault,
+        fragment=Fragment(
+            id=_FRAGMENT_ID,
+            title=_TITLE,
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                author=Authorship.SELF,
+            ),
+        ),
+        body=_DELIBERATION_BODY,
+    )
+
+
+def _active_decision_notes(vault: Path) -> list[Path]:
+    """Return every markdown note under ``08-Decisions/Active/``.
+
+    Sorted so the list is stable; ``Path.glob`` yields in filesystem
+    order, which is hash-ordered on APFS.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        Sorted list of decision-note paths (empty when the folder is
+        absent).
+    """
+    active = vault / "08-Decisions" / "Active"
+    if not active.exists():
+        return []
+    return sorted(active.glob("*.md"))
+
+
+def test_fixture_title_matches_no_decision_keyword() -> None:
+    """The fixture title must not trip the keyword detection strategy.
+
+    Guards the whole suite: if a future edit renames the fixture to
+    something containing "considering" or "the question is", every
+    assertion below would still pass while testing nothing about #877.
+    """
+    lowered = _TITLE.lower()
+    assert not [keyword for keyword in DECISION_KEYWORDS if keyword in lowered]
+
+
+@pytest.mark.integration
+def test_classify_then_report_produces_a_pattern_detected_decision(
+    tmp_path: Path,
+) -> None:
+    """``creek classify`` → ``creek report`` yields one pattern Decision note.
+
+    The full #877 payload, through the shipped CLI, with the rules
+    classifier only:
+
+    1. Before the run the fragment reads ``praxis_potential: none`` and no
+       Decision note exists — the pre-#877 steady state of a whole vault.
+    2. ``creek classify --method rules`` writes ``explicit`` to disk (plus
+       the F1/F5 frequencies and ``exploring`` confidence the pattern
+       strategy also needs).
+    3. ``creek report --type decisions`` now produces exactly one note,
+       and its ``detection_method`` is ``"pattern"`` — not ``"keyword"``,
+       which is the only strategy that could ever fire before the fix.
+    """
+    vault = tmp_path / "vault"
+    path = _seed(vault)
+
+    # 1. Pre-state: the bug's signature, and no decisions reachable.
+    before = frontmatter.load(str(path)).metadata
+    assert before["praxis_potential"] == "none"
+    assert _active_decision_notes(vault) == []
+
+    empty = runner.invoke(app, ["report", "--type", "decisions", "--vault", str(vault)])
+    assert empty.exit_code == 0, empty.output
+    assert _active_decision_notes(vault) == [], (
+        "a Decision note appeared before classification — the fixture is "
+        "firing through some path other than praxis_potential"
+    )
+
+    # 2. Classification stamps every axis the pattern strategy reads.
+    classified = runner.invoke(
+        app,
+        ["classify", "--method", "rules", "--vault", str(vault)],
+    )
+    assert classified.exit_code == 0, classified.output
+
+    after = frontmatter.load(str(path)).metadata
+    assert after["praxis_potential"] == "explicit"
+    assert after["frequency"]["primary"] == "F1"
+    assert "F5" in after["frequency"]["secondary"]
+    assert after["voice"]["confidence"] == "exploring"
+
+    # 3. …and 08-Decisions is finally reachable.
+    reported = runner.invoke(
+        app,
+        ["report", "--type", "decisions", "--vault", str(vault)],
+    )
+    assert reported.exit_code == 0, reported.output
+
+    notes = _active_decision_notes(vault)
+    assert len(notes) == 1, f"expected exactly one decision note, got {notes}"
+    note = frontmatter.load(str(notes[0])).metadata
+    assert note["detection_method"] == "pattern"
+    assert note["title"] == _TITLE
+
+
+@pytest.mark.integration
+def test_report_decisions_is_idempotent_after_the_praxis_pass(
+    tmp_path: Path,
+) -> None:
+    """A second ``creek report`` run adds no duplicate note.
+
+    ``creek fill`` runs the decisions report on every invocation. Now that
+    the pattern strategy can actually fire, a non-idempotent writer would
+    grow one duplicate note per fill — so the existing
+    already-captured-fragment guard is re-pinned against the newly-live
+    code path.
+    """
+    vault = tmp_path / "vault"
+    _seed(vault)
+    runner.invoke(app, ["classify", "--method", "rules", "--vault", str(vault)])
+
+    for _ in range(2):
+        result = runner.invoke(
+            app,
+            ["report", "--type", "decisions", "--vault", str(vault)],
+        )
+        assert result.exit_code == 0, result.output
+
+    assert len(_active_decision_notes(vault)) == 1

--- a/creek-tools/tests/test_cli_fill.py
+++ b/creek-tools/tests/test_cli_fill.py
@@ -8,6 +8,7 @@ compost step, and the summary reports real per-folder counts.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from typer.testing import CliRunner
@@ -316,3 +317,196 @@ def test_fill_summary_reports_folder_counts(
     assert result.exit_code == 0, result.output
     assert "02-Threads 2" in result.output
     assert "08-Decisions 1" in result.output
+
+
+# ---- Issue #877: the praxis-backfill hint ---------------------------------
+#
+# The gap detector cannot be "the ``praxis_potential`` key is absent"
+# (``Fragment.model_dump`` always writes it) and cannot be "the value is
+# ``none``" (most fragments genuinely ARE none, so that nag would be
+# permanent and instantly ignored). It is the one shape that proves work is
+# outstanding: **the free keyword heuristic says ``explicit`` but the disk
+# says ``none``.** Self-limiting, costs zero tokens to compute, and goes
+# quiet the moment the operator acts on it.
+
+_PRAXIS_SIGNAL_BODY = "notes from the week ahead\n- [ ] book the boiler service"
+"""A body carrying one strong praxis marker (a task checkbox)."""
+
+_PRAXIS_QUIET_BODY = "a plain note about the walk to the shops and the weather"
+"""A body carrying no praxis marker at all."""
+
+
+def _seed_praxis_fragment(
+    vault: Path,
+    frag_id: str,
+    *,
+    body: str,
+    praxis: str,
+) -> None:
+    """Write a fragment with a chosen body and ``praxis_potential`` value.
+
+    Built from a literal frontmatter template so the on-disk value is
+    exactly what the test names, independent of ``Fragment`` defaults. A
+    real ``privacy_tier`` is stamped so the sibling #876 untiered hint
+    stays silent and cannot pollute the captured output.
+
+    Args:
+        vault: Vault root.
+        frag_id: Fragment id (also the file stem).
+        body: Markdown body the praxis heuristic scores.
+        praxis: The ``praxis_potential`` value already on disk.
+    """
+    folder = vault / "01-Fragments" / "Notes"
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / f"{frag_id}.md").write_text(
+        f'---\ntype: fragment\nid: {frag_id}\ntitle: "A note"\n'
+        f"source:\n  platform: markdown\n  author: self\n"
+        f"privacy_tier: open\npraxis_potential: {praxis}\n---\n{body}\n",
+        encoding="utf-8",
+    )
+
+
+def test_count_praxis_backfillable_counts_only_provable_gaps(
+    tmp_path: Path,
+) -> None:
+    """Only "signals present but disk says none" counts as backfillable.
+
+    Four fragments spanning four distinct states so the count cannot be
+    right by accident:
+
+    * signals + ``none`` — the real gap, the only one counted;
+    * signals + ``explicit`` — already backfilled, nothing owed;
+    * signals + ``latent`` — a verdict is on record, so not a gap;
+    * no signals + ``none`` — genuinely has no praxis potential.
+
+    Counting the last two would make the hint permanent, which is the
+    failure mode this detector was designed around.
+    """
+    from creek.cli import _count_praxis_backfillable_fragments
+
+    vault = tmp_path / "vault"
+    _seed_praxis_fragment(vault, "frag-gap", body=_PRAXIS_SIGNAL_BODY, praxis="none")
+    _seed_praxis_fragment(
+        vault, "frag-done", body=_PRAXIS_SIGNAL_BODY, praxis="explicit"
+    )
+    _seed_praxis_fragment(
+        vault, "frag-latent", body=_PRAXIS_SIGNAL_BODY, praxis="latent"
+    )
+    _seed_praxis_fragment(vault, "frag-quiet", body=_PRAXIS_QUIET_BODY, praxis="none")
+
+    assert _count_praxis_backfillable_fragments(vault) == 1
+
+
+def test_count_praxis_backfillable_is_zero_without_a_fragments_dir(
+    tmp_path: Path,
+) -> None:
+    """A vault with no ``01-Fragments`` counts zero rather than exploding."""
+    from creek.cli import _count_praxis_backfillable_fragments
+
+    assert _count_praxis_backfillable_fragments(tmp_path / "empty-vault") == 0
+
+
+def test_fill_hints_when_praxis_can_be_backfilled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The hint reports the count, and names the command and its cost.
+
+    Printed ahead of the ``offer is None`` early return, like the #876
+    untiered hint it sits beside, so it still fires on the vault that most
+    needs it (fully classified, no LLM upgrade to offer).
+
+    It reports a **count only**. Naming a fragment id or quoting a body
+    excerpt would turn an advisory line into an unaudited disclosure of
+    vault content through stdout, which the config-oracle rule (#846 /
+    #848) forbids — so both are asserted absent.
+    """
+    from creek.cli import _maybe_upgrade_classification
+
+    monkeypatch.setattr(cli_mod, "_detect_classify_upgrade", lambda *_a: None)
+    vault = tmp_path / "vault"
+    _seed_praxis_fragment(vault, "frag-gap", body=_PRAXIS_SIGNAL_BODY, praxis="none")
+    _seed_praxis_fragment(vault, "frag-quiet", body=_PRAXIS_QUIET_BODY, praxis="none")
+
+    _maybe_upgrade_classification(
+        vault,
+        cli_mod._load_config_for_vault(vault),
+        upgrade=False,
+    )
+
+    out = capsys.readouterr().out
+    assert "praxis" in out.lower()
+    assert "1" in out
+    # The remedy is named, and so is its price: --force re-sends those
+    # fragments to the configured provider and bills for the tokens.
+    assert "--force" in out
+    assert "token" in out.lower()
+    # …and nothing about the fragment itself leaks.
+    assert "frag-gap" not in out
+    assert "boiler" not in out
+
+
+def test_praxis_hint_is_silent_when_every_signal_is_already_explicit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A backfilled vault gets no hint — the nag must not be permanent.
+
+    The vault here is the steady state after one ``creek classify`` run:
+    every fragment the heuristic can prove is already ``explicit``, and
+    the rest genuinely are ``none``. Any implementation that keys off
+    "value == none" would print here forever and train the operator to
+    ignore the line.
+    """
+    from creek.cli import _maybe_upgrade_classification
+
+    monkeypatch.setattr(cli_mod, "_detect_classify_upgrade", lambda *_a: None)
+    vault = tmp_path / "vault"
+    _seed_praxis_fragment(
+        vault, "frag-done", body=_PRAXIS_SIGNAL_BODY, praxis="explicit"
+    )
+    _seed_praxis_fragment(vault, "frag-quiet", body=_PRAXIS_QUIET_BODY, praxis="none")
+
+    _maybe_upgrade_classification(
+        vault,
+        cli_mod._load_config_for_vault(vault),
+        upgrade=False,
+    )
+
+    assert "praxis" not in capsys.readouterr().out.lower()
+
+
+def test_praxis_hint_failure_never_crashes_fill(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A broken praxis count is swallowed by its own best-effort guard.
+
+    The hint is advisory; an unreadable fragment must not abort ``creek
+    fill`` before any step runs, exactly as the classify-upgrade probe
+    (#736) and the untiered hint (#876) already behave.
+
+    Contract note for the implementation: the hint must call the
+    module-level ``_count_praxis_backfillable_fragments`` (this test
+    patches it there) and log its own WARNING naming ``praxis``, rather
+    than sharing the untiered hint's guard — otherwise one failing scan
+    silently suppresses the other hint too.
+    """
+    from creek.cli import _maybe_upgrade_classification
+
+    def _boom(*_a: object) -> int:
+        raise OSError("unreadable fragment")
+
+    monkeypatch.setattr(cli_mod, "_count_praxis_backfillable_fragments", _boom)
+    monkeypatch.setattr(cli_mod, "_detect_classify_upgrade", lambda *_a: None)
+
+    with caplog.at_level(logging.WARNING):
+        # Must not raise.
+        _maybe_upgrade_classification(
+            tmp_path, cli_mod._load_config_for_vault(tmp_path), upgrade=False
+        )
+
+    assert any("praxis" in record.getMessage().lower() for record in caplog.records)

--- a/creek-tools/tests/test_pipeline.py
+++ b/creek-tools/tests/test_pipeline.py
@@ -1186,3 +1186,192 @@ class TestPipelineTierRouting:
             "frag-pipeessay01": PrivacyTier.OPEN,
             "frag-pipedmchan1": PrivacyTier.PERSONAL,
         }
+
+
+class TestPipelinePraxisPass:
+    """``creek process`` stamps ``praxis_potential`` too (issue #877).
+
+    ``creek classify`` is not the only way fragments enter the vault:
+    ``creek process`` ingests and classifies in one shot and never calls
+    the classify engine. Fixing only the engine would leave every
+    freshly-processed fragment at ``praxis_potential: none``, so
+    ``04-Praxis`` / ``08-Decisions`` would stay unreachable for anyone who
+    uses the one-shot command.
+    """
+
+    @staticmethod
+    def _ingested(frag_id: str, body: str):
+        """An IngestedFragment with a known id and a chosen body.
+
+        Args:
+            frag_id: Fragment id (the assertion key).
+            body: Markdown body the praxis heuristic scores.
+
+        Returns:
+            The assembled :class:`~creek.ingest.base.IngestedFragment`.
+        """
+        from creek.ingest.base import IngestedFragment
+        from creek.models import Authorship, Fragment, FragmentSource, SourcePlatform
+
+        fragment = Fragment(
+            id=frag_id,
+            title="Week notes",
+            source=FragmentSource(
+                platform=SourcePlatform.MARKDOWN,
+                author=Authorship.SELF,
+            ),
+        )
+        return IngestedFragment(fragment=fragment, body=body)
+
+    def test_no_llm_run_stamps_praxis_on_a_signal_bearing_fragment(
+        self, vault_path: Path
+    ) -> None:
+        """A task checkbox in the body reaches ``explicit`` with zero egress.
+
+        ``no_llm=True`` guarantees Pass 3 never runs, so this asserts the
+        praxis verdict is produced by the free, local, deterministic
+        heuristic — the whole point of #877 being a keyword pass rather
+        than another LLM dimension.
+
+        Two fragments with two distinct expected outcomes so a
+        stamp-everything implementation cannot pass.
+        """
+        from creek.models import PraxisPotential
+
+        pipeline = Pipeline(config=CreekConfig(), no_llm=True)
+
+        classified = pipeline._run_classification(
+            [
+                self._ingested(
+                    "frag-praxispipe01",
+                    "notes from the week ahead\n- [ ] book the boiler service",
+                ),
+                self._ingested(
+                    "frag-praxispipe02",
+                    "a plain note about the walk to the shops and the weather",
+                ),
+            ],
+            vault_path,
+            PipelineResult(),
+        )
+
+        assert {
+            item.fragment.id: str(item.fragment.praxis_potential) for item in classified
+        } == {
+            "frag-praxispipe01": PraxisPotential.EXPLICIT.value,
+            "frag-praxispipe02": PraxisPotential.NONE.value,
+        }
+
+    def test_praxis_pass_never_demotes_an_llm_verdict(self, vault_path: Path) -> None:
+        """A fragment already ``latent`` is not reset to ``none`` by the pass.
+
+        The pipeline runs the heuristic over every fragment, including
+        re-processed ones that already carry an LLM verdict the keyword
+        table cannot reproduce. The merge is escalate-only.
+        """
+        from creek.ingest.base import IngestedFragment
+        from creek.models import (
+            Authorship,
+            Fragment,
+            FragmentSource,
+            PraxisPotential,
+            SourcePlatform,
+        )
+
+        pipeline = Pipeline(config=CreekConfig(), no_llm=True)
+        item = IngestedFragment(
+            fragment=Fragment(
+                id="frag-praxispipe03",
+                title="Week notes",
+                source=FragmentSource(
+                    platform=SourcePlatform.MARKDOWN,
+                    author=Authorship.SELF,
+                ),
+                praxis_potential=PraxisPotential.LATENT,
+            ),
+            body="a plain note about the walk to the shops and the weather",
+        )
+
+        classified = pipeline._run_classification([item], vault_path, PipelineResult())
+
+        assert str(classified[0].fragment.praxis_potential) == (
+            PraxisPotential.LATENT.value
+        )
+
+    def test_llm_answer_never_demotes_an_explicit_fragment_on_disk(
+        self, vault_path: Path
+    ) -> None:
+        """A model answering ``latent`` cannot lower a recorded ``explicit``.
+
+        The sibling test above runs with ``no_llm=True``, so it exercises
+        only :func:`creek.classify.praxis_pass.apply_praxis`'s own
+        escalate-only merge and proves nothing about the LLM path. This
+        one drives the real path: the rules leave the fragment
+        unclassified, the stubbed provider answers ``praxis.potential:
+        latent`` for a fragment already at ``explicit``, and the
+        heuristic pass that runs afterwards cannot repair the demotion —
+        the body carries no keyword signal, so ``detect`` can only
+        propose ``none``.
+
+        Asserted on what reached the vault, keyed by fragment id (never by
+        ``rglob`` order, which is unsorted), because the demotion's real
+        cost is a rewritten file.
+        """
+        import frontmatter
+
+        from creek.classify.llm import LLMClassifier
+        from creek.ingest.base import IngestedFragment
+        from creek.models import (
+            Authorship,
+            Fragment,
+            FragmentSource,
+            PraxisPotential,
+            SourcePlatform,
+        )
+
+        response = "frequency:\n  primary: F3\npraxis:\n  potential: latent\n"
+        pipeline = Pipeline(config=CreekConfig())
+        item = IngestedFragment(
+            fragment=Fragment(
+                id="frag-praxispipe04",
+                title="Week notes",
+                source=FragmentSource(
+                    platform=SourcePlatform.MARKDOWN,
+                    author=Authorship.SELF,
+                ),
+                praxis_potential=PraxisPotential.EXPLICIT,
+            ),
+            body="a plain note about the walk to the shops and the weather",
+        )
+        result = PipelineResult()
+
+        with (
+            # Rules leaving the frequency unclassified is what routes the
+            # fragment to Pass 3 at all.
+            patch.object(
+                pipeline.rule_classifier,
+                "classify",
+                side_effect=lambda f, content="": f,
+            ),
+            patch.object(LLMClassifier, "_check_availability", return_value=True),
+            patch.object(LLMClassifier, "_invoke_llm", return_value=response),
+        ):
+            classified = pipeline._run_classification([item], vault_path, result)
+
+        pipeline._write_to_vault(classified, vault_path, result)
+
+        on_disk = {
+            post["id"]: post
+            for post in (
+                frontmatter.load(str(path))
+                for path in (vault_path / "01-Fragments").rglob("*.md")
+            )
+        }
+
+        assert result.errors == []
+        assert on_disk["frag-praxispipe04"]["praxis_potential"] == (
+            PraxisPotential.EXPLICIT.value
+        )
+        # The rest of the same response *did* land, so the assertion above
+        # cannot be passing because the LLM was never consulted.
+        assert on_disk["frag-praxispipe04"]["frequency"]["primary"] == "F3"

--- a/creek-tools/tests/test_praxis_pass.py
+++ b/creek-tools/tests/test_praxis_pass.py
@@ -1,0 +1,458 @@
+"""Pure policy functions for the praxis-potential pass (issue #877).
+
+``creek.classify.praxis_pass`` is the shared, side-effect-free policy
+layer that the classify engine and the ``creek process`` pipeline both
+call so a fragment never reaches ``04-Praxis`` / ``08-Decisions``
+generation still carrying the default ``praxis_potential: none``.
+
+Before #877 **no** pipeline stage ever wrote the field, so all three
+consumers that gate on ``explicit``
+(:mod:`creek.generate.decisions`, :mod:`creek.generate.mining`,
+:mod:`creek.generate.compost`) were structurally unreachable — 100% of
+the 35,330-fragment demo vault read ``praxis_potential: none``.
+
+The three functions under test:
+
+* :func:`detect` — score a body and return ``explicit`` or ``none``.
+* :func:`escalate` — merge two verdicts, never lowering.
+* :func:`apply_praxis` — stamp the merged verdict onto a fragment.
+
+The governing contract is **precision over recall**. The heuristic is
+free and runs over every fragment in the vault, so a signal set that
+over-fires does not "fix" the bug — it floods mining, compost and the
+decisions report with noise that is strictly worse than the current
+silence. Hence :data:`_EXPLICIT_AT` = 2: one *strong* marker (a task
+checkbox, a ``Decision:`` line) or *two distinct* moderate first-person
+commitments. A single bare "I will" must never fire.
+
+The heuristic also never emits ``latent``: "this could become a
+practice" is a judgment only the LLM can make (see
+:func:`creek.classify.llm.parsing._apply_praxis`).
+
+No vault, no I/O, no LLM: every case here is a direct call.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from creek.classify.praxis_pass import (
+    _EXPLICIT_AT,
+    _PRAXIS_SIGNALS,
+    PRAXIS_POTENTIAL_KEY,
+    apply_praxis,
+    detect,
+    escalate,
+)
+from creek.models import (
+    Fragment,
+    FragmentSource,
+    PraxisPotential,
+    SourcePlatform,
+)
+
+_NEUTRAL_BODY = "a plain note about the weather and the walk to the shops"
+"""A body carrying no praxis signal at all — the ``none`` control."""
+
+_STRONG_BODIES: tuple[str, ...] = (
+    "- [ ] call the dentist",
+    "* [ ] call the dentist",
+    "- [x] called the dentist",
+    "- [X] called the dentist",
+    "  - [ ] call the dentist",
+    "Decision: move the standup to Tuesday",
+    "Decisions: move the standup to Tuesday",
+    "Praxis: ten minutes of silence before the first meeting",
+    "Next step: call the dentist",
+    "Next steps: call the dentist",
+    "Action item: call the dentist",
+    "Action items: call the dentist",
+)
+"""Bodies carrying exactly ONE strong (weight-2) marker each."""
+
+_MODERATE_BODIES: tuple[str, ...] = (
+    "I should call the dentist.",
+    "I will call the dentist.",
+    "I need to call the dentist.",
+    "I'm going to call the dentist.",
+    "Next time I book the appointment earlier.",
+    "Next time we book the appointment earlier.",
+    "From now on the standup starts at ten.",
+    "The practice is ten minutes of silence.",
+)
+"""Bodies carrying exactly ONE moderate (weight-1) marker each."""
+
+_NEAR_MISS_BODIES: tuple[str, ...] = (
+    "You should call the dentist.",
+    "It will rain tomorrow.",
+    "They will call the dentist.",
+    "She should call the dentist.",
+    "We should probably eat something.",
+)
+"""Second-person / third-person lookalikes that must NOT fire.
+
+``praxis_potential`` records the *owner's* commitments. Advice aimed at
+someone else, and predictions about the world, are the single largest
+class of false positive in a personal corpus full of chat logs.
+"""
+
+
+def _fragment(
+    *,
+    frag_id: str = "frag-praxisunit01",
+    title: str = "A note",
+    potential: PraxisPotential = PraxisPotential.NONE,
+) -> Fragment:
+    """Build a fragment with just the axis :mod:`praxis_pass` reads.
+
+    Args:
+        frag_id: Fragment id.
+        title: Fragment title (never scored — the signals are body-only).
+        potential: The praxis potential already recorded on the fragment.
+
+    Returns:
+        The assembled :class:`~creek.models.Fragment`.
+    """
+    return Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=SourcePlatform.MARKDOWN),
+        praxis_potential=potential,
+    )
+
+
+class TestSignalTable:
+    """The signal table is the whole policy; pin its documented shape."""
+
+    def test_praxis_potential_key_names_a_real_fragment_field(self) -> None:
+        """The exported key must match the field the writers serialise.
+
+        Every consumer reads ``praxis_potential`` off frontmatter. A
+        typo'd constant would stamp a *new* key and leave the real field
+        at its default, reproducing the #877 bug while looking fixed.
+        """
+        assert PRAXIS_POTENTIAL_KEY == "praxis_potential"
+        assert PRAXIS_POTENTIAL_KEY in Fragment.model_fields
+
+    def test_signals_are_precompiled_patterns(self) -> None:
+        """Patterns are compiled once at import, not per fragment.
+
+        This table is applied to every body in a 35k-fragment vault; a
+        per-call ``re.compile`` is the difference between a free pass and
+        a measurable one.
+        """
+        assert _PRAXIS_SIGNALS, "the signal table must not be empty"
+        for pattern in _PRAXIS_SIGNALS:
+            assert isinstance(pattern, re.Pattern)
+
+    def test_only_two_documented_weights_exist(self) -> None:
+        """Weights are exactly 1 (moderate) and 2 (strong) — both present."""
+        weights = set(_PRAXIS_SIGNALS.values())
+        assert weights == {1, 2}
+
+    def test_explicit_threshold_is_two(self) -> None:
+        """``_EXPLICIT_AT`` is 2: one strong marker, or two moderate hits.
+
+        Lowering this to 1 is the single change that would turn the
+        heuristic from a fix into a noise generator, so it is pinned
+        explicitly rather than left implicit in the behavioural tests.
+        """
+        assert _EXPLICIT_AT == 2
+
+
+class TestDetectStrongSignals:
+    """One strong marker (weight 2) is enough on its own."""
+
+    @pytest.mark.parametrize("body", _STRONG_BODIES)
+    def test_single_strong_marker_is_explicit(self, body: str) -> None:
+        """Each documented strong marker reaches the threshold alone."""
+        assert detect(_fragment(), body) is PraxisPotential.EXPLICIT
+
+    def test_strong_marker_fires_on_a_later_line(self) -> None:
+        """The line anchor is per-line, not per-body (``re.MULTILINE``).
+
+        Real notes bury the checkbox under a paragraph of prose; a
+        body-start anchor would miss essentially every real fragment.
+        """
+        body = "Some notes about the week ahead.\n\n- [ ] call the dentist"
+        assert detect(_fragment(), body) is PraxisPotential.EXPLICIT
+
+    def test_checkbox_must_start_the_line(self) -> None:
+        """A mid-line ``- [ ]`` is prose, not a task."""
+        assert detect(_fragment(), "see the list - [ ] item") is PraxisPotential.NONE
+
+    def test_checkbox_marker_must_be_blank_or_x(self) -> None:
+        """``- [z]`` is not a task checkbox and must not score."""
+        assert detect(_fragment(), "- [z] not a checkbox") is PraxisPotential.NONE
+
+    def test_label_must_start_the_line(self) -> None:
+        """``The decision: …`` mid-sentence is narration, not a heading.
+
+        Without the line anchor, every retrospective sentence that
+        mentions a decision would stamp the fragment ``explicit``.
+        """
+        body = "The decision: move the standup to Tuesday, was made in April."
+        assert detect(_fragment(), body) is PraxisPotential.NONE
+
+
+class TestDetectModerateSignals:
+    """Moderate markers (weight 1) need company before they fire."""
+
+    @pytest.mark.parametrize("body", _MODERATE_BODIES)
+    def test_one_moderate_hit_alone_stays_none(self, body: str) -> None:
+        """A lone first-person commitment is NOT enough — the core contract.
+
+        This is the most important assertion in the file. "I will call
+        the dentist" appears in a substantial fraction of every chat log
+        ever written; firing on it would mark most of the vault
+        ``explicit`` and drown ``04-Praxis`` / ``08-Decisions`` in noise.
+        Precision beats recall: the bug being fixed is "nothing ever
+        fires", and the failure mode being avoided is "everything does".
+        """
+        assert detect(_fragment(), body) is PraxisPotential.NONE
+
+    @pytest.mark.parametrize(
+        ("first", "second"),
+        [
+            ("I should call the dentist.", "From now on the standup starts at ten."),
+            ("I need to sleep earlier.", "Next time I book the appointment earlier."),
+            ("I will send the note.", "The practice is ten minutes of silence."),
+            ("I'm going to stretch daily.", "Next time we book the room first."),
+        ],
+    )
+    def test_two_distinct_moderate_hits_are_explicit(
+        self,
+        first: str,
+        second: str,
+    ) -> None:
+        """Two different weight-1 markers sum to the threshold."""
+        assert detect(_fragment(), f"{first}\n{second}") is PraxisPotential.EXPLICIT
+
+    def test_one_idiom_repeated_is_still_a_single_signal(self) -> None:
+        """Scoring counts distinct patterns, not occurrences of one pattern.
+
+        Two repetitions of the same idiom are a verbal tic, not a second
+        piece of evidence. Under occurrence-counting this body would
+        score 2 and reach ``explicit``, which would mark ``explicit``
+        every chat log where the author says "I should" twice — the
+        over-firing failure mode the threshold exists to prevent.
+        """
+        body = "I should call the dentist.\nI should book the boiler service."
+
+        assert detect(_fragment(), body) is PraxisPotential.NONE
+
+    def test_moderate_marker_must_be_anchored_to_a_sentence_start(self) -> None:
+        """Mid-sentence "I should" / "I will" are reported speech, not commitment.
+
+        Two unanchored lookalikes in one line: an implementation that
+        matched them anywhere in the body would score 2 and return
+        ``explicit``, which is exactly the over-firing this test forbids.
+        """
+        body = "He said I should call the dentist and that I will regret it."
+        assert detect(_fragment(), body) is PraxisPotential.NONE
+
+    def test_moderate_marker_fires_after_a_sentence_boundary(self) -> None:
+        """A commitment starting a new sentence mid-line still counts.
+
+        Paired with the anchoring test above, this pins the anchor as
+        "sentence or line start" rather than "line start only" — prose
+        fragments routinely carry two sentences per line.
+        """
+        body = "The week got away from me. I should call the dentist. "
+        body += "From now on the standup starts at ten."
+        assert detect(_fragment(), body) is PraxisPotential.EXPLICIT
+
+
+class TestDetectNegatives:
+    """What the heuristic must stay quiet about."""
+
+    @pytest.mark.parametrize("body", _NEAR_MISS_BODIES)
+    def test_near_miss_phrasings_never_fire(self, body: str) -> None:
+        """Second/third-person lookalikes score zero."""
+        assert detect(_fragment(), body) is PraxisPotential.NONE
+
+    def test_neutral_body_is_none(self) -> None:
+        """A plain note carries no praxis potential."""
+        assert detect(_fragment(), _NEUTRAL_BODY) is PraxisPotential.NONE
+
+    def test_empty_body_is_none(self) -> None:
+        """An empty body cannot be scored and must not crash."""
+        assert detect(_fragment(), "") is PraxisPotential.NONE
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            *_STRONG_BODIES,
+            *_MODERATE_BODIES,
+            *_NEAR_MISS_BODIES,
+            _NEUTRAL_BODY,
+            "",
+            "Maybe I could start meditating one of these days.",
+        ],
+    )
+    def test_heuristic_never_emits_latent(self, body: str) -> None:
+        """``latent`` is an LLM judgment; the keyword pass may not guess it.
+
+        ``latent`` means "there is a practice hiding in here that the
+        author has not named". No regex can see that, and a heuristic
+        that guessed it would poison the one signal the LLM path exists
+        to provide.
+        """
+        assert detect(_fragment(), body) is not PraxisPotential.LATENT
+
+
+class TestEscalate:
+    """``escalate`` returns the higher of two verdicts — the full matrix."""
+
+    @pytest.mark.parametrize(
+        ("current", "candidate", "expected"),
+        [
+            (PraxisPotential.NONE, PraxisPotential.NONE, PraxisPotential.NONE),
+            (PraxisPotential.NONE, PraxisPotential.LATENT, PraxisPotential.LATENT),
+            (PraxisPotential.NONE, PraxisPotential.EXPLICIT, PraxisPotential.EXPLICIT),
+            (PraxisPotential.LATENT, PraxisPotential.NONE, PraxisPotential.LATENT),
+            (PraxisPotential.LATENT, PraxisPotential.LATENT, PraxisPotential.LATENT),
+            (
+                PraxisPotential.LATENT,
+                PraxisPotential.EXPLICIT,
+                PraxisPotential.EXPLICIT,
+            ),
+            (PraxisPotential.EXPLICIT, PraxisPotential.NONE, PraxisPotential.EXPLICIT),
+            (
+                PraxisPotential.EXPLICIT,
+                PraxisPotential.LATENT,
+                PraxisPotential.EXPLICIT,
+            ),
+            (
+                PraxisPotential.EXPLICIT,
+                PraxisPotential.EXPLICIT,
+                PraxisPotential.EXPLICIT,
+            ),
+        ],
+    )
+    def test_escalate_matrix(
+        self,
+        current: PraxisPotential,
+        candidate: PraxisPotential,
+        expected: PraxisPotential,
+    ) -> None:
+        """none < latent < explicit; the winner is always the higher side."""
+        assert escalate(current, candidate) is expected
+
+    def test_escalate_is_symmetric_in_its_arguments(self) -> None:
+        """Argument order cannot decide whether a verdict is lowered.
+
+        A non-symmetric merge would let the caller's argument order
+        silently demote an ``explicit`` fragment back to ``none`` — the
+        one direction :func:`escalate` exists to make impossible.
+        """
+        ladder = (
+            PraxisPotential.NONE,
+            PraxisPotential.LATENT,
+            PraxisPotential.EXPLICIT,
+        )
+        for left in ladder:
+            for right in ladder:
+                assert escalate(left, right) is escalate(right, left)
+
+
+class TestApplyPraxis:
+    """``apply_praxis`` stamps the merged verdict, escalate-only."""
+
+    def test_stamps_explicit_on_a_signal_bearing_body(self) -> None:
+        """A checkbox body lifts a default fragment to ``explicit``."""
+        result = apply_praxis(_fragment(), "- [ ] call the dentist")
+
+        assert PraxisPotential(result.praxis_potential) is PraxisPotential.EXPLICIT
+
+    def test_stored_value_is_a_plain_string(self) -> None:
+        """The stored value is ``"explicit"``, not a bare enum member.
+
+        ``Fragment.model_config`` sets ``use_enum_values=True``, but
+        ``model_copy`` bypasses that coercion — and every consumer
+        compares ``str(frag.praxis_potential) ==
+        PraxisPotential.EXPLICIT.value`` (see
+        ``creek/generate/decisions.py:307``). Storing the member rather
+        than its ``.value`` also hands ``yaml.SafeDumper`` something it
+        cannot represent on the tier-only write path.
+        """
+        result = apply_praxis(_fragment(), "- [ ] call the dentist")
+
+        assert type(result.praxis_potential) is str
+        assert result.praxis_potential == PraxisPotential.EXPLICIT.value
+        assert str(result.praxis_potential) == PraxisPotential.EXPLICIT.value
+
+    def test_returns_the_same_object_when_nothing_escalates(self) -> None:
+        """No escalation means no copy — identity, not just equality.
+
+        The engine counts "praxis marked" by comparing before/after, and
+        the pipeline runs this over every fragment in the vault. An
+        unconditional ``model_copy`` would both blur that counter and
+        allocate a fresh model per fragment for nothing.
+        """
+        fragment = _fragment()
+
+        assert apply_praxis(fragment, _NEUTRAL_BODY) is fragment
+
+    def test_returns_the_same_object_when_already_explicit(self) -> None:
+        """An already-``explicit`` fragment with a neutral body is untouched."""
+        fragment = _fragment(potential=PraxisPotential.EXPLICIT)
+
+        assert apply_praxis(fragment, _NEUTRAL_BODY) is fragment
+
+    def test_never_demotes_an_explicit_fragment(self) -> None:
+        """A body with no signals cannot lower a verdict already on record.
+
+        The LLM (or the operator) may have set ``explicit`` from evidence
+        the keyword table cannot see; a later rules run must not undo it.
+        """
+        fragment = _fragment(potential=PraxisPotential.EXPLICIT)
+
+        result = apply_praxis(fragment, _NEUTRAL_BODY)
+
+        assert PraxisPotential(result.praxis_potential) is PraxisPotential.EXPLICIT
+
+    def test_never_demotes_a_latent_fragment(self) -> None:
+        """``latent`` survives a rules pass that finds nothing."""
+        fragment = _fragment(potential=PraxisPotential.LATENT)
+
+        result = apply_praxis(fragment, _NEUTRAL_BODY)
+
+        assert PraxisPotential(result.praxis_potential) is PraxisPotential.LATENT
+
+    def test_raises_latent_to_explicit(self) -> None:
+        """A ``latent`` fragment whose body carries a task becomes ``explicit``."""
+        fragment = _fragment(potential=PraxisPotential.LATENT)
+
+        result = apply_praxis(fragment, "- [ ] call the dentist")
+
+        assert PraxisPotential(result.praxis_potential) is PraxisPotential.EXPLICIT
+
+    def test_is_idempotent(self) -> None:
+        """Applying twice equals applying once, and the second call is a no-op.
+
+        ``creek classify`` is re-run over the whole vault routinely; a
+        pass that kept producing new objects (or new values) on every run
+        would churn every file's frontmatter forever.
+        """
+        body = "- [ ] call the dentist"
+        once = apply_praxis(_fragment(), body)
+
+        twice = apply_praxis(once, body)
+
+        assert twice is once
+        assert twice.model_dump(mode="json") == once.model_dump(mode="json")
+
+    def test_touches_no_other_fragment_field(self) -> None:
+        """Only ``praxis_potential`` moves — the rest round-trips unchanged."""
+        fragment = _fragment()
+
+        result = apply_praxis(fragment, "- [ ] call the dentist")
+
+        before = fragment.model_dump(mode="json")
+        after = result.model_dump(mode="json")
+        assert after.pop(PRAXIS_POTENTIAL_KEY) == PraxisPotential.EXPLICIT.value
+        assert before.pop(PRAXIS_POTENTIAL_KEY) == PraxisPotential.NONE.value
+        assert after == before


### PR DESCRIPTION
## Summary

`Fragment.praxis_potential` shipped with a default of `none` and **zero production writers**. All three consumers gate on `explicit` — `generate/decisions.py:307`, `generate/mining.py:1114`, `generate/compost.py:119` — so decision detection, praxis-chain mining and compost's praxis check were structurally unreachable. 100% of the 35,330-fragment demo vault reads `praxis_potential: none`; `creek report --type decisions` reports "no new decision candidates found"; `04-Praxis/` and `08-Decisions/` hold only `.gitkeep`. Same folder-without-producer shape as #584, and the same shape as #876 — whose `privacy_pass.py` this change deliberately mirrors.

**Policy lives in the new pure `creek/classify/praxis_pass.py`.** A table-driven, precompiled signal set (strong, weight 2: a markdown task checkbox, a line-initial `Decision:`/`Praxis:`/`Next step:`/`Action item:` label; moderate, weight 1: sentence- or line-anchored first-person commitments) plus a monotone `none < latent < explicit` merge.

The threshold is the substance. `_EXPLICIT_AT = 2` means one strong marker or two *distinct* moderate ones, so a bare "I will" never fires. Over-firing would not fix this bug — it would flood mining, compost and the decisions report with noise, which is strictly worse than the current silence. Scoring is presence-based over distinct patterns: a repeated idiom is a verbal tic, not a second piece of evidence. Anchoring is what rejects reported speech ("he said I should… and that I will…") and the second/third-person lookalikes that dominate a chat-log corpus.

**The heuristic never emits `latent`.** "There is a practice hiding in here that the author has not named" is a judgment no regular expression can make, so `latent` reaches a fragment only through the new `praxis:` section in the LLM response schema and prompt.

**`escalate` is the single chokepoint for every producer, and it never lowers.** The LLM's verdict merges against the verdict the fragment *already carries*, not merely against `none`. Refusing to write only on `none` is not enough: `latent` is also weaker than `explicit`, and nothing downstream could repair such a demotion, because the keyword pass re-derives from the body and only ever proposes `explicit` or `none` — so a verdict that came from judgment rather than keywords would keep the demotion to disk. (This was caught at self-review; the regression test asserts on frontmatter read back off disk.)

**Ordering is load-bearing.** The pass runs in `_process_file` *after* `_classify_one` (so the merge already sees any LLM verdict) and *before* the #876 `reassess` (so the privacy pass stays the last mutation before the write). `_prepare_fragment` is byte-identical to `9af26cc`: the tier is still assigned before `TierClassifiers.for_tier` reads it and above the OPS-001 short-circuit. A regression test now pins that, so a future change cannot hoist praxis into that window and slide the privacy pass below the router.

**`_write_tier_only` is deliberately not widened** — a departure from the #876 precedent, not an oversight. That writer's narrow promise ("changing ONLY the privacy-tier fields") is itself load-bearing when reviewing the #876 path, and the justification does not transfer: an untiered fragment is a live cloud-egress hole, whereas a missing praxis verdict is a missing feature, and silently rewriting the praxis axis of every already-curated fragment in a mature vault is not something to do unasked. So an `llm`/`manual`-stamped vault backfills only under an explicit, paid `--force`.

**`creek fill` surfaces the outstanding count and names that command's token cost.** The gap is detected as "the free heuristic proves `explicit` while the disk says `none`" — positive evidence a producer never ran, zero tokens to compute, and self-limiting. "Value == `none`" would have nagged forever (most fragments genuinely are `none`); "key absent" can never fire, because `model_dump` always writes the key. Both fill hints share one vault walk, so `creek fill` still parses the 35k-fragment vault once.

**Security.** SEC-004 is intact: the allow-list gains exactly `praxis`, a *section* name and not a `Fragment` field name, and `privacy_tier` stays rejected. `_YAML_HEAD_RE` is deliberately not widened. Every signal pattern is linear-time (no nested quantifiers) and compiled once at import, because it runs over unbounded, attacker-influenced bodies. The fill hint reports a **count only** — never a fragment id or body excerpt (config-oracle rule, #846/#848).

`ClassifySummary.praxis_marked` and the `creek.classify` MCP payload report what each run raised. A silent producer is how this bug survived.

### Known limitations (documented in `praxis_pass.py`)

- Fragments the resume short-circuit preserves get no praxis verdict without `--force`; `creek fill` reports the count.
- `creek/classify/weighted.py` carries its own prompt and allow-list, so on the weighted path praxis comes from the heuristic only and the model can never contribute `latent`.

### Follow-up observed, not fixed here

`creek/pipeline.py::_classify_fragments` never calls `AudienceClassifier` — the identical shape of hole for the #634 audience axis. `creek classify` stamps it; `creek process` does not. Out of scope for #877.

## Test plan

- `./scripts/check-all.sh` → **exit 0**, 12/12 checks. mypy strict clean, ruff clean, xenon clean, pylint 9.70, refurb + tryceratops clean, aggregate coverage **93.93%**, per-file gate 217 files >= 80%.
- Full suite including the `integration` and `e2e` markers: **6326 passed, 5 skipped** (the 5 are live-API / Ollama smoke tests with no credentials locally).
- Baseline on the base commit `9af26cc` was independently confirmed exit 0 with 0 failures before any edit, so every failure seen during this change was real.
- New `tests/test_praxis_pass.py` — each signal in isolation; **one moderate hit alone stays `none`** (the anti-noise contract); a repeated single idiom stays `none` (presence-based scoring); near-misses (`you should`, `it will`, `they will`) do not fire; `escalate` never lowers across the full matrix; `apply_praxis` returns the *same object* when nothing escalates; idempotence; empty body; the stored value is a plain `str`.
- New `tests/test_classify_praxis_e2e.py` (integration) — rules classifier only, no LLM, no network: a seeded fragment goes `creek classify --method rules` → `praxis_potential: explicit` on disk → `creek report --type decisions` → exactly one note under `08-Decisions/Active/` with `detection_method: pattern`. The fixture title deliberately contains **no** `DECISION_KEYWORDS`, so the keyword strategy cannot make the test pass without the new field.
- `tests/test_classify_engine.py` — a rules run stamps `explicit`; a neutral fragment stays `none`; an already-`explicit` fragment is never demoted; `summary.praxis_marked` counts only raises; and the **#876 ordering regression test** (tier assigned before the router; preserved fragments still tier-only-written, praxis untouched without `--force`).
- `tests/test_classify.py` — `validate_response` accepts `praxis` and **still rejects `privacy_tier`**; `_apply_praxis` escalate-only matrix; `latent` over `explicit` writes nothing, end to end through `classify()`; the prompt renders through `str.format` without a `KeyError`.
- `tests/test_pipeline.py` — `creek process` stamps praxis on both the no-LLM and the LLM path, and an LLM `latent` answer never demotes an `explicit` fragment on disk.
- `tests/test_cli_fill.py` — the backfill count fires only on provable gaps, is zero without `01-Fragments`, names the `--force` cost, is **silent when there is nothing to backfill**, and an unreadable fragment warns without aborting `fill`.

Closes #877
