### PR TITLE
fix(redact): stop leaking a high-entropy secret remainder on apply

### DIFF
--- a/creek-tools/creek/redact/redactor.py
+++ b/creek-tools/creek/redact/redactor.py
@@ -5,10 +5,32 @@ The :class:`Redactor` re-scans content to locate match positions (since
 and replaces each hit with a ``[REDACTED:type]`` marker.
 
 Replacement is a single pass over the *original* content: every in-scope
-pattern is matched against the untouched text, truly overlapping spans
+detector — the regex patterns *and* the generic high-entropy detector
+alike — is matched against the untouched text, truly overlapping spans
 are unioned, and the merged spans are spliced out right-to-left. Because
-no pattern ever anchors on partially redacted text, a ``--scan`` finding
-cannot survive a ``--apply`` step (Issue #832).
+no detector ever anchors on partially redacted text, a ``--scan`` finding
+cannot survive a ``--apply`` step (Issue #832). Keeping the entropy
+detector inside that same union is what stops a regex match that covers
+only *part* of a high-entropy run from leaving the remainder — now too
+short for the detector to re-find — in cleartext (Issue #909).
+
+That union alone is not sufficient, because the entropy detector only
+fires when the *whole* run clears the confidence-derived threshold: a
+key with a low-entropy tail (or any operator who raises
+``min_confidence`` to cut false positives) would reopen the same leak.
+So spans are also **snapped to token boundaries** before merging — a
+span whose edge falls strictly inside a ``HIGH_ENTROPY_CANDIDATE`` run
+is widened to that run's edge, making the fix boundary-driven rather
+than threshold-driven. Runs the operator explicitly allowlisted are
+excluded from snapping: user intent wins, and a regex match inside such
+a run still redacts its own span unwidened.
+
+A consequence worth stating plainly: ``--apply`` may therefore redact
+slightly **more** than ``--scan`` reported, because snapping widens on
+token shape rather than on a reported finding. That asymmetry is
+deliberate, fail-closed behaviour — a missed secret is unrecoverable
+once written, whereas over-redaction is visible in the output and
+fixable via ``false_positive_allowlist``.
 
 Redaction logs are written as JSON with a session salt in the header so
 that hashes can be correlated within a session but not reversed.
@@ -70,6 +92,36 @@ class _MergedSpan(NamedTuple):
     start: int
     end: int
     contributors: list[_Span]
+
+
+_Run = tuple[int, int]
+"""Half-open ``(start, end)`` offsets of one high-entropy candidate run."""
+
+
+def _snap_one(span: _Span, runs: list[_Run]) -> _Span:
+    """Widen *span* to the boundaries of any candidate run it bisects.
+
+    A boundary is only moved when the span's edge falls *strictly*
+    inside a run, so a span already flush with a run boundary — or one
+    that fully contains the run — is returned unchanged. The pattern
+    name and collection order are preserved verbatim so the merged
+    span's marker selection is unaffected.
+
+    Args:
+        span: The match span to snap.
+        runs: Half-open offsets of the candidate runs to snap against.
+
+    Returns:
+        The span, widened to whole-token boundaries where it bisected a
+        run; otherwise an equal copy of the input.
+    """
+    start, end = span.start, span.end
+    for run_start, run_end in runs:
+        if run_start < span.start < run_end:
+            start = run_start
+        if run_start < span.end < run_end:
+            end = run_end
+    return _Span(start, end, span.pattern_name, span.order)
 
 
 def _severity_rank(pattern_name: str) -> int:
@@ -202,12 +254,37 @@ class Redactor:
 
         Re-scans *content* against the configured patterns (since matched
         text is never stored in :class:`RedactionMatch`) in a single pass
-        over the original text: every in-scope pattern is matched against
+        over the original text: every in-scope detector is matched against
         the untouched content, truly overlapping spans are unioned, and
         each merged region is replaced by the marker of its most severe
-        contributor. This guarantees scan/apply parity — a ``--scan``
-        finding cannot survive ``--apply``, because no pattern ever
-        anchors on already-redacted text (Issue #832).
+        contributor. This guarantees scan/apply parity — when
+        *pattern_types* is not narrowed, a ``--scan`` finding cannot
+        survive ``--apply``, because no detector ever anchors on
+        already-redacted text (Issue #832). Narrowing *pattern_types*
+        deliberately takes the excluded detectors out of scope, so their
+        findings are left untouched by design.
+
+        The generic high-entropy detector participates in that *same*
+        single-pass union rather than running as a post-pass over the
+        spliced output. Otherwise a regex match covering only part of a
+        high-entropy run would splice its marker over that part and leave
+        a remainder too short for ``HIGH_ENTROPY_CANDIDATE`` to re-match,
+        leaking the tail of a secret in cleartext (Issue #909).
+
+        Because that union still depends on the *combined* run clearing
+        the entropy threshold, spans are additionally snapped to token
+        boundaries by :meth:`_snap_to_candidate_runs`: any span edge
+        falling strictly inside a ``HIGH_ENTROPY_CANDIDATE`` run is
+        pushed out to that run's edge, so no contiguous token is ever
+        left half-redacted regardless of how ``min_confidence`` is
+        tuned. Allowlisted runs are exempt — an explicitly allowlisted
+        token is never widened onto.
+
+        Snapping is shape-driven, so ``--apply`` may redact slightly
+        **more** than ``--scan`` reported. That is deliberate,
+        fail-closed behaviour: a missed secret is unrecoverable once
+        written, while over-redaction is visible and fixable by
+        allowlisting the affected token.
 
         Args:
             content: The text to redact.
@@ -226,12 +303,47 @@ class Redactor:
             patterns_to_use = self._patterns
 
         spans = self._collect_spans(content, patterns_to_use)
-        content = self._splice_markers(content, _merge_spans(spans))
-
         if self._should_apply_high_entropy(pattern_types):
-            content = self._replace_high_entropy(content)
+            spans.extend(self._collect_high_entropy_spans(content, len(spans)))
+            spans = self._snap_to_candidate_runs(content, spans)
 
-        return content
+        return self._splice_markers(content, _merge_spans(spans))
+
+    def _snap_to_candidate_runs(
+        self,
+        content: str,
+        spans: list[_Span],
+    ) -> list[_Span]:
+        """Widen every span that bisects a contiguous high-entropy run.
+
+        The entropy detector only emits a span when the *whole* run
+        clears :func:`~creek.redact.scanner.entropy_threshold`, so a
+        low-entropy tail appended to a secret (or any threshold raised
+        via :pyattr:`RedactionConfig.min_confidence`) would otherwise
+        leave part of a single contiguous token in cleartext after a
+        regex matched only its prefix. Snapping makes the fix
+        boundary-driven instead of threshold-driven (Issue #909).
+
+        Runs on the false-positive allowlist are excluded, so an
+        explicitly allowlisted token is never widened onto — user intent
+        wins. A regex match *inside* such a run still redacts its own
+        span, just unwidened.
+
+        Args:
+            content: The original, untouched text the spans index into.
+            spans: Match spans collected against that content.
+
+        Returns:
+            The spans with bisecting edges pushed out to whole-token
+            boundaries; overlaps this creates are absorbed by
+            :func:`_merge_spans`.
+        """
+        runs: list[_Run] = [
+            (candidate.start(), candidate.end())
+            for candidate in HIGH_ENTROPY_CANDIDATE.finditer(content)
+            if not self._is_allowlisted(candidate.group())
+        ]
+        return [_snap_one(span, runs) for span in spans]
 
     def _collect_spans(
         self,
@@ -297,28 +409,58 @@ class Redactor:
             return True
         return HIGH_ENTROPY_PATTERN_NAME in pattern_types
 
-    def _replace_high_entropy(self, content: str) -> str:
-        """Replace high-entropy substrings with the configured marker.
+    def _collect_high_entropy_spans(
+        self,
+        content: str,
+        start_order: int,
+    ) -> list[_Span]:
+        """Locate high-entropy substrings as spans on the original content.
 
-        Mirrors :meth:`creek.redact.scanner.RedactionScanner._scan_high_entropy`
-        so a `--scan` finding cannot survive a `--apply` step. The shared
-        ``HIGH_ENTROPY_CANDIDATE`` regex and ``shannon_entropy`` helper
-        keep both paths in lockstep.
+        The gating mirrors
+        :meth:`creek.redact.scanner.RedactionScanner._scan_high_entropy`
+        exactly — the shared ``HIGH_ENTROPY_CANDIDATE`` regex, the same
+        allowlist check, and the same
+        :func:`~creek.redact.scanner.entropy_threshold` derived from
+        :pyattr:`RedactionConfig.min_confidence` — so a ``--scan`` finding
+        cannot survive a ``--apply`` step. ``post_validate`` is
+        deliberately *not* consulted: no validator is registered for
+        ``high_entropy_string`` (it would return ``True`` unconditionally)
+        and ``_scan_high_entropy`` does not call it either, so calling it
+        here would both diverge from the scanner and add a
+        permanently-true branch.
+
+        Offsets are taken against the whole *content* — never per line —
+        so the spans can be unioned with the regex spans that
+        :meth:`_collect_spans` produced (Issue #909).
+
+        Args:
+            content: The original, untouched text.
+            start_order: Collection order to continue from, so entropy
+                spans keep :attr:`_Span.order` globally unique against the
+                already-collected regex spans and the marker tie-break
+                stays deterministic.
+
+        Returns:
+            Spans for every candidate that is not allowlisted and whose
+            Shannon entropy clears the configured threshold.
         """
-        marker = self.config.replacement_template.format(
-            name=HIGH_ENTROPY_PATTERN_NAME,
-        )
         threshold = entropy_threshold(self.config.min_confidence)
-
-        def _replacer(m: re.Match[str]) -> str:
-            text = m.group()
+        spans: list[_Span] = []
+        for candidate in HIGH_ENTROPY_CANDIDATE.finditer(content):
+            text = candidate.group()
             if self._is_allowlisted(text):
-                return text
+                continue
             if shannon_entropy(text) < threshold:
-                return text
-            return marker
-
-        return HIGH_ENTROPY_CANDIDATE.sub(_replacer, content)
+                continue
+            spans.append(
+                _Span(
+                    candidate.start(),
+                    candidate.end(),
+                    HIGH_ENTROPY_PATTERN_NAME,
+                    start_order + len(spans),
+                )
+            )
+        return spans
 
     def log_redactions(
         self,

--- a/creek-tools/docs/redaction.md
+++ b/creek-tools/docs/redaction.md
@@ -81,12 +81,37 @@ The structured queue at `<source>/.creek-redactions/queue.json` is what `--apply
 
 For every queued match:
 
-1. Replaces the match with the marker rendered from `RedactionConfig.replacement_template` (default `[REDACTED:{name}]`; `{name}` is the pattern key — e.g. `credit_card`, `ipv4`, `high_entropy_string`).
+1. Replaces the match with the marker rendered from
+   `RedactionConfig.replacement_template` (default `[REDACTED:{name}]`;
+   `{name}` is the pattern key — e.g. `credit_card`, `ipv4`,
+   `high_entropy_string`). Matches that truly overlap — including ones the
+   generic high-entropy detector finds — are unioned into a single region
+   and replaced as one, labelled with the most severe contributing
+   pattern's name; an AWS key with a high-entropy tail is removed whole as
+   `[REDACTED:api_key]` rather than leaving the tail in cleartext. Before
+   merging, any match whose start or end falls strictly inside a
+   contiguous high-entropy candidate run (base64url-ish, 20+ characters)
+   is widened out to that run's edge, so a match can never bisect one
+   token. This holds regardless of `min_confidence`: without it, a
+   low-entropy tail glued to a secret (e.g. an AWS key followed by a run
+   of the same character) would evade the entropy detector entirely and
+   leak in cleartext. Strings on `false_positive_allowlist` are exempt
+   from this widening — a regex match inside such a string still redacts
+   only its own span.
 2. Marks the queue entry as `applied: true` and stamps the timestamp.
 3. Refuses to write through symlinks (path-traversal guard): before any
    file is read or rewritten the source tree is walked and the run is
    aborted if any descendant symlink resolves outside the source root.
    The same guard is applied to `creek redact --review`.
+
+Because of that widening, `--apply` may redact slightly **more** than
+`--scan` reported — the marker can extend past the reported match to the
+end of the surrounding token. Concretely: a 20-character API key glued
+directly to a longer token is removed whole as a single
+`[REDACTED:api_key]`, not left half-redacted. This is deliberate,
+fail-closed behaviour — a missed secret is unrecoverable once written,
+whereas over-redaction is visible in the output and fixable by adding the
+token to `false_positive_allowlist`.
 
 `--dry-run` walks the queue without modifying any source file — useful for sanity-checking a big batch before committing.
 

--- a/creek-tools/tests/test_properties_redaction.py
+++ b/creek-tools/tests/test_properties_redaction.py
@@ -1,9 +1,8 @@
 """Property-based tests for ``creek.redact.redactor.Redactor``.
 
-Redaction must be idempotent and additive: applying it twice yields the
-same output as once, and the redacted output never contains the
-``[REDACTED:type]`` marker shapes that the redactor would itself
-produce. Hypothesis fuzzes inputs that mix arbitrary text with
+Redaction must be idempotent: applying it twice yields the same output
+as once, so a marker the redactor emitted is never itself rewritten on a
+later pass. Hypothesis fuzzes inputs that mix arbitrary text with
 recognisable secrets to exercise these contracts on the patch logic.
 """
 
@@ -145,15 +144,19 @@ def test_digit_glued_email_is_left_intact_but_bounded_email_is_redacted() -> Non
 def test_high_entropy_email_local_part_redacted_whole_no_fragment() -> None:
     """An email with a high-entropy local part is redacted as one whole email.
 
-    The named ``email`` pass runs before the high-entropy detector, so the
+    The ``email`` match and the high-entropy candidate (the local part)
+    are both collected against the *original* content and unioned, so the
     whole address is replaced and no high-entropy fragment of it is left
-    behind — the failure mode #435's title warned about.
+    behind — the failure mode #435's title warned about. The union is
+    labelled ``email`` because both patterns are severity "medium" and
+    the tie-break picks the widest contributing span (#909).
+
+    Equality on the full string is deliberate: substring checks cannot
+    tell "redacted whole" from "redacted with a surviving remainder".
     """
     redactor = _make_redactor()
     out = redactor.redact_content("key aB3xY7zQ9mK2pL5nR8vT4wd@example.com end")
-    assert "aB3xY7zQ9mK2pL5nR8vT4wd" not in out
-    assert "@example.com" not in out
-    assert "[REDACTED:email]" in out
+    assert out == "key [REDACTED:email] end"
 
 
 @_PROFILE

--- a/creek-tools/tests/test_redact.py
+++ b/creek-tools/tests/test_redact.py
@@ -2108,7 +2108,11 @@ class TestRedactorHighEntropy:
     """`Redactor.redact_content` must apply the high-entropy detector too."""
 
     def test_redactor_replaces_high_entropy_secret(self) -> None:
-        """A high-entropy hex secret must be replaced by the redactor."""
+        """A high-entropy hex secret must be replaced by the redactor.
+
+        Asserts the exact full output: a substring check would pass even
+        if part of the secret leaked alongside the marker (Issue #909).
+        """
         from creek.config import RedactionConfig as CfgCls
 
         secret = "a3f1c8b2e9d74105fb6c2e8a91d34c70"
@@ -2119,11 +2123,14 @@ class TestRedactorHighEntropy:
         # Bare line — avoids env_secret picking up `token = …` first.
         out = redactor.redact_content(secret)
 
-        assert secret not in out
-        assert "[REDACTED:high_entropy_string]" in out
+        assert out == "[REDACTED:high_entropy_string]"
 
     def test_redactor_high_entropy_respects_allowlist(self) -> None:
-        """An allowlisted high-entropy substring must not be replaced."""
+        """An allowlisted high-entropy substring must not be replaced.
+
+        Asserts the exact full output, so a partial rewrite around the
+        allowlisted text cannot slip through (Issue #909).
+        """
         from creek.config import RedactionConfig as CfgCls
 
         secret = "a3f1c8b2e9d74105fb6c2e8a91d34c70"
@@ -2133,11 +2140,14 @@ class TestRedactorHighEntropy:
 
         out = redactor.redact_content(secret)
 
-        assert secret in out
-        assert "REDACTED" not in out
+        assert out == secret
 
     def test_redactor_high_entropy_respects_min_confidence(self) -> None:
-        """A low-entropy string must survive even at min_confidence=0."""
+        """A low-entropy string must survive at min_confidence=1.0.
+
+        Asserts the exact full output rather than containment, so a
+        partial redaction of the run would fail (Issue #909).
+        """
         from creek.config import RedactionConfig as CfgCls
 
         # Predictable, repeating content.
@@ -2148,7 +2158,7 @@ class TestRedactorHighEntropy:
 
         out = redactor.redact_content(low_entropy)
 
-        assert low_entropy in out
+        assert out == low_entropy
 
 
 # ---------------------------------------------------------------------------
@@ -2310,3 +2320,392 @@ class TestPatternOrderLeak:
         assert "hunter2secret" not in result
         assert "example" not in result
         assert "hunter" not in result
+
+
+# ---------------------------------------------------------------------------
+# High-entropy detector overlapping a regex pattern (Issue #909)
+# ---------------------------------------------------------------------------
+
+# Synthetic secret shapes, composed from parts so the leak geometry stays
+# explicit: a documented AWS example key (covered by `api_key`, severity
+# "critical") glued to a high-entropy remainder that only the
+# `high_entropy_string` detector (severity "medium") covers.
+_AWS_EXAMPLE_KEY = "AKIAIOSFODNN7EXAMPLE"  # pragma: allowlist secret
+_ENTROPY_TAIL = "Zq7Wp3Rf9Tk2Ng"  # pragma: allowlist secret
+_KEY_THEN_TAIL = f"{_AWS_EXAMPLE_KEY}{_ENTROPY_TAIL}"
+_TAIL_THEN_KEY = f"{_ENTROPY_TAIL}{_AWS_EXAMPLE_KEY}"
+_HEX_SECRET = "a3f1c8b2e9d74105fb6c2e8a91d34c70"  # pragma: allowlist secret
+_REPEATING_RUN = "ababababababababababab"
+# 24 chars drawn uniformly from an 8-symbol alphabet, so the Shannon
+# entropy is exactly log2(8) = 3.0 bits/char: below the default 3.7
+# threshold (min_confidence=0.6) but above the 2.5 floor
+# (min_confidence=0.0). That window is what makes it a gating probe.
+_SUB_THRESHOLD_RUN = "abcdefghabcdefghabcdefgh"
+_ENTROPIC_EMAIL = "aB3xY7zQ9mK2pL5nR8vT4wd@example.com"  # pragma: allowlist secret
+# A deliberately *predictable* tail: 14 repeats of one character. Glued to
+# `_AWS_EXAMPLE_KEY` the combined 34-char run measures 3.1446 bits/char —
+# BELOW the default 3.7 threshold — so the entropy detector contributes no
+# span at all and only token-boundary snapping can keep the tail covered.
+_LOW_ENTROPY_TAIL = "a" * 14
+_KEY_THEN_LOW_ENTROPY_TAIL = f"{_AWS_EXAMPLE_KEY}{_LOW_ENTROPY_TAIL}"
+
+
+class TestHighEntropyOverlapLeak:
+    """Entropy hits must union with regex spans on the ORIGINAL text (#909).
+
+    Issue #832 made the *regular* patterns collect spans against the
+    untouched content, merge overlaps, and splice markers in one pass.
+    The generic high-entropy detector was left as a post-pass over the
+    ALREADY-MUTATED text, so when a regex match only partially covers a
+    high-entropy run the uncovered remainder is no longer ≥20 contiguous
+    base64url chars and silently survives in cleartext.
+
+    Concretely, ``_AWS_EXAMPLE_KEY`` glued to ``_ENTROPY_TAIL`` returns
+    the ``api_key`` marker followed by the 14-char tail in cleartext.
+    Every core assertion here compares the **complete** returned string
+    with ``==``: a ``not in`` assertion on the key alone passes while the
+    bug is live, which is exactly how this shipped.
+    """
+
+    def test_entropy_tail_after_api_key_fully_redacted(self) -> None:
+        """A trailing high-entropy remainder must not survive (RED at HEAD).
+
+        The merged span is labelled by its most severe contributor, so the
+        marker is ``api_key`` (critical), never ``high_entropy_string``
+        (medium).
+        """
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(_KEY_THEN_TAIL)
+
+        assert result == "[REDACTED:api_key]"
+        assert "[REDACTED:high_entropy_string]" not in result
+
+    def test_sub_threshold_entropy_tail_after_api_key_still_redacted(self) -> None:
+        """A sub-threshold tail of the SAME token must not leak (RED at HEAD).
+
+        ``_KEY_THEN_LOW_ENTROPY_TAIL`` is one contiguous 34-char
+        ``HIGH_ENTROPY_CANDIDATE`` run whose Shannon entropy is
+        **3.145 bits/char — BELOW the default 3.7 threshold**
+        (``min_confidence=0.6``). The entropy detector therefore does not
+        fire at all, so span-unioning alone cannot cover the remainder:
+        only **token-boundary snapping** — widening the ``api_key`` match
+        outward to the enclosing run's boundaries — keeps the tail from
+        leaking.
+
+        At HEAD this returns ``[REDACTED:api_key]aaaaaaaaaaaaaa``: 14
+        characters of the very token a *critical* ``api_key`` detector
+        fired on survive in cleartext.
+        """
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(_KEY_THEN_LOW_ENTROPY_TAIL)
+
+        assert result == "[REDACTED:api_key]"
+
+    def test_entropy_tail_redacted_at_max_confidence(self) -> None:
+        """The fix must not be contingent on a tuning knob (RED at HEAD).
+
+        This pins **threshold-independence**. At ``min_confidence=1.0``
+        the entropy threshold is 4.5 bits/char and ``_KEY_THEN_TAIL``
+        measures 4.5725 — it clears by **0.07 bits**. That margin is
+        luck, not design: nudge the tail's alphabet, the ceiling, or the
+        confidence mapping and the union silently stops firing.
+
+        A P1 secret-leak fix must hold at *every* confidence setting, so
+        the covering mechanism has to be token-boundary snapping (a
+        structural property of the matched run) rather than an entropy
+        score that happens to land on the right side of a threshold.
+        """
+        config = RedactionConfig(min_confidence=1.0)
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(_KEY_THEN_TAIL)
+
+        assert result == "[REDACTED:api_key]"
+
+    def test_entropy_tail_redacted_with_surrounding_text(self) -> None:
+        """Surrounding plain words are preserved exactly (RED at HEAD).
+
+        Pins that the union splice is positional — it removes the whole
+        overlapping region and nothing else.
+        """
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(f"prefix {_KEY_THEN_TAIL} suffix")
+
+        assert result == "prefix [REDACTED:api_key] suffix"
+
+    def test_entropy_prefix_before_api_key_fully_redacted(self) -> None:
+        """A *leading* high-entropy remainder must not survive (RED at HEAD).
+
+        The mirror image of the trailing case: at HEAD the output is
+        ``Zq7Wp3Rf9Tk2Ng[REDACTED:api_key]``. This pins that the fix is a
+        span union, not a "swallow the following characters" hack.
+        """
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(_TAIL_THEN_KEY)
+
+        assert result == "[REDACTED:api_key]"
+
+    def test_multiline_content_keeps_following_lines(self) -> None:
+        """The union must stop at the newline it never matched (RED at HEAD).
+
+        ``redact_content`` sees whole content while the scanner works
+        line by line; this pins that widening the merged span does not
+        swallow the line break or the inert text after it.
+        """
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(f"{_KEY_THEN_TAIL}\nplain text\n")
+
+        assert result == "[REDACTED:api_key]\nplain text\n"
+
+    def test_scan_apply_parity_for_overlapping_entropy_match(
+        self, tmp_path: Path
+    ) -> None:
+        """Every scan finding must be gone after apply (RED at HEAD).
+
+        This is the Issue #832 invariant restored for the entropy
+        detector: the scan reports both ``api_key`` and
+        ``high_entropy_string``, so an apply must leave no cleartext
+        fragment of either behind.
+
+        The apply step redacts ``test_file.read_text()`` rather than the
+        in-memory constant, so the parity claim genuinely round-trips
+        through the same bytes the scanner read off disk.
+
+        Args:
+            tmp_path: pytest-provided temporary directory.
+        """
+        test_file = tmp_path / "entropy_leak.txt"
+        test_file.write_text(_KEY_THEN_TAIL)
+
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        matches = scanner.scan_file(test_file)
+        match_types = {match.match_type for match in matches}
+        assert {"api_key", "high_entropy_string"}.issubset(match_types)
+
+        redactor = Redactor(config=config, salt=scanner.salt)
+        result = redactor.redact_content(test_file.read_text())
+
+        assert result == "[REDACTED:api_key]"
+
+    def test_bare_high_entropy_hex_secret_redacted_whole(self) -> None:
+        """A lone high-entropy run is still redacted whole (non-regression).
+
+        Entropy ≈3.95 bits/char clears the default 3.7 threshold, and no
+        regex pattern overlaps, so the detector must fire on its own.
+        """
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(_HEX_SECRET)
+
+        assert result == "[REDACTED:high_entropy_string]"
+
+    def test_allowlisted_high_entropy_secret_survives_verbatim(self) -> None:
+        """The allowlist still suppresses entropy hits (non-regression).
+
+        The allowlist check must survive the move from a regex-``sub``
+        replacer to a span collector.
+        """
+        config = RedactionConfig(false_positive_allowlist=[_HEX_SECRET])
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(_HEX_SECRET)
+
+        assert result == _HEX_SECRET
+
+    def test_allowlisted_run_not_snapped(self) -> None:
+        """An allowlisted run is never widened — explicit user intent wins.
+
+        This documents a deliberate carve-out in the token-boundary
+        snapping rule, with exact bytes so nobody can "tidy" it away.
+        ``_KEY_THEN_TAIL`` is the whole 34-char run *and* the allowlist
+        entry, so the entropy detector skips it and the snapping step
+        must leave its boundaries alone.
+
+        A regex match *inside* an allowlisted run still redacts its own
+        span, though: the caller allowlisted the run, not the
+        ``api_key`` hit within it. The exact expected output is therefore
+        ``"[REDACTED:api_key]Zq7Wp3Rf9Tk2Ng"`` — marker for the 20-char
+        AWS key, and the 14-char tail left verbatim by request.
+
+        The inverse failure is what this guards: a snapping rule that
+        ignored the allowlist would widen the ``api_key`` span to the
+        full run and swallow bytes the user explicitly excused.
+        """
+        config = RedactionConfig(false_positive_allowlist=[_KEY_THEN_TAIL])
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(_KEY_THEN_TAIL)
+
+        assert result == f"[REDACTED:api_key]{_ENTROPY_TAIL}"
+
+    def test_repeating_run_survives_at_max_confidence(self) -> None:
+        """A predictable run is left intact at min_confidence=1.0.
+
+        Non-regression: entropy 1.0 bits/char is far below the 4.5
+        bits/char threshold that ``min_confidence=1.0`` demands.
+        """
+        config = RedactionConfig(min_confidence=1.0)
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(_REPEATING_RUN)
+
+        assert result == _REPEATING_RUN
+
+    def test_sub_threshold_run_redacted_at_min_confidence_zero(self) -> None:
+        """The threshold must still come from config (non-regression).
+
+        ``_SUB_THRESHOLD_RUN`` sits at exactly 3.0 bits/char: inert at the
+        default 3.7 threshold, flagged at the 2.5 floor that
+        ``min_confidence=0.0`` selects. If a refactor hard-coded the
+        threshold or dropped the config read, this test fails.
+        """
+        config = RedactionConfig(min_confidence=0.0)
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(_SUB_THRESHOLD_RUN)
+
+        assert result == "[REDACTED:high_entropy_string]"
+
+    def test_sub_threshold_run_inert_at_default_confidence(self) -> None:
+        """The same run is inert at the default threshold (non-regression).
+
+        Pairs with the test above to bracket the 3.0 bits/char probe from
+        both sides, so a threshold regression cannot hide behind a value
+        that happens to be flagged either way.
+        """
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(_SUB_THRESHOLD_RUN)
+
+        assert result == _SUB_THRESHOLD_RUN
+
+    def test_pattern_types_without_entropy_detector_leaves_tail(self) -> None:
+        """A narrowed ``pattern_types`` intentionally leaves the tail.
+
+        Non-regression, and deliberately NOT a leak: the caller excluded
+        ``high_entropy_string`` from scope, so the remainder is out of
+        scope by request. Do NOT "fix" this to ``[REDACTED:api_key]`` —
+        that would make the ``pattern_types`` filter a lie. The
+        whole-string redaction is pinned by the sibling test that passes
+        ``high_entropy_string`` explicitly.
+        """
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(_KEY_THEN_TAIL, pattern_types=["api_key"])
+
+        assert result == f"[REDACTED:api_key]{_ENTROPY_TAIL}"
+
+    def test_pattern_types_with_entropy_detector_redacts_whole_span(self) -> None:
+        """The detector-only name works inside ``pattern_types`` (RED at HEAD).
+
+        ``high_entropy_string`` lives in ``PATTERN_METADATA`` but is
+        excluded from ``REDACTION_PATTERNS``, so it is absent from
+        ``Redactor._patterns``; naming it must still bring the detector
+        into scope and union its span with the ``api_key`` match.
+
+        Opting the detector in explicitly did not save the tail at HEAD
+        either: the old code spliced the regex span first and only then
+        ran the entropy pass over the already-mutated text, so the
+        remainder leaked exactly as in the unfiltered case.
+        """
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(
+            _KEY_THEN_TAIL,
+            pattern_types=["api_key", "high_entropy_string"],
+        )
+
+        assert result == "[REDACTED:api_key]"
+
+    def test_equal_severity_tie_break_prefers_widest_span(self) -> None:
+        """Equal-severity overlaps fall to the widest span (non-regression).
+
+        ``email`` and ``high_entropy_string`` are both "medium", and the
+        entropy candidate (the local part) is strictly narrower than the
+        email match, so the merged region must carry the ``email``
+        marker.
+        """
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        result = redactor.redact_content(f"key {_ENTROPIC_EMAIL} end")
+
+        assert result == "key [REDACTED:email] end"
+
+    def test_overlapping_redaction_is_idempotent(self) -> None:
+        """Re-redacting redacted output is a no-op (non-regression).
+
+        The marker text itself must not look like a secret to any
+        pattern, whatever the union logic produced on the first pass.
+        """
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        once = redactor.redact_content(_KEY_THEN_TAIL)
+
+        assert redactor.redact_content(once) == once
+
+    def test_markers_are_inert_for_every_pattern_name(self) -> None:
+        """Every replacement marker must survive a re-redaction unchanged.
+
+        Marker inertness is not a comfortable margin — it sits on a
+        **0.016-bit cliff**. ``[REDACTED:email_password_combo]`` contains
+        the run ``email_password_combo``, which is exactly 20 characters
+        (the ``HIGH_ENTROPY_CANDIDATE`` floor) at exactly **3.6842
+        bits/char** against the default **3.7** threshold. Any change
+        that widens a span outward to a candidate run, nudges the
+        entropy threshold, renames a pattern, or adds a pattern name of
+        20+ base64url characters can tip a marker over that edge — and
+        then the marker itself is re-detected as a secret and rewritten
+        into a nested ``[REDACTED:[REDACTED:...]]``.
+
+        Asserting on the complete string for *every* name in
+        ``PATTERN_METADATA`` makes that cliff visible the moment someone
+        steps off it, rather than one release later in a corrupted
+        vault.
+
+        Deliberately **not** parametrised over ``min_confidence=0.0``:
+        that genuinely fails today (the 2.5 floor flags the 3.6842-bit
+        run) for a pre-existing reason outside the scope of #909, filed
+        as a separate follow-up.
+        """
+        from creek.redact.patterns import PATTERN_METADATA
+
+        config = RedactionConfig()
+        scanner = RedactionScanner(config=config)
+        redactor = Redactor(config=config, salt=scanner.salt)
+
+        for name in PATTERN_METADATA:
+            marker = f"[REDACTED:{name}]"
+            assert redactor.redact_content(marker) == marker


### PR DESCRIPTION
## Summary

Fixes a P1 secret leak in `creek redact --apply`.

`Redactor.redact_content` spliced the regex-pattern markers first and only then ran the generic high-entropy detector as a *post-pass over the already-mutated text*. When a regex match covered only part of a longer high-entropy run, the marker replaced that part and the remainder was left shorter than the `HIGH_ENTROPY_CANDIDATE` `{20,}` floor, so the detector could no longer re-find it. `AKIAIOSFODNN7EXAMPLEZq7Wp3Rf9Tk2Ng` redacted to `[REDACTED:api_key]Zq7Wp3Rf9Tk2Ng` — a 14-char cleartext tail of a secret that `--scan` had correctly flagged as `high_entropy_string`. This is the exact CLI `--apply` path: `_apply_redactions` calls `redact_content` with no `pattern_types`.

Two changes, both in `creek/redact/redactor.py`:

1. **The entropy detector joins the span union.** `_replace_high_entropy` (a `re.sub` post-pass) is replaced by `_collect_high_entropy_spans`, which locates candidates against the **original** content and emits `_Span` entries that flow through the existing `_merge_spans` union and one right-to-left splice. Gating is unchanged and still mirrors `RedactionScanner._scan_high_entropy` exactly — same shared `HIGH_ENTROPY_CANDIDATE` object, same allowlist, same `entropy_threshold(min_confidence)`.

2. **Token-boundary snapping**, which is what makes the fix hold. Step 1 alone is *threshold-dependent*, and that is the same bug in a new dress: the union only fires when the whole combined run clears the entropy threshold. `AKIAIOSFODNN7EXAMPLE` + `"a"*14` measures 3.145 bits/char against the 3.7 default, so no entropy span is emitted at all and the output was still `[REDACTED:api_key]aaaaaaaaaaaaaa` — 14 chars of the same contiguous token a *critical* detector had matched. Worse, the reported fixture clears `min_confidence=1.0`'s 4.5 threshold by only 0.07 bits, so an operator raising that knob to cut false positives silently reopened the bug. `_snap_to_candidate_runs` now widens any span whose start or end falls **strictly inside** a candidate run out to that run's boundary, before merging. A match can no longer bisect a contiguous token, and the guarantee never consults the threshold. Runs whose exact text is in `false_positive_allowlist` are never widened — explicit user intent wins.

Because snapping widens, `--apply` may now redact slightly **more** than `--scan` reported. That is deliberate: a missed secret is unrecoverable once written, whereas over-redaction is visible and fixable.

**Relationship to PR #902 (issue #832):** this is #902's fix being *incomplete*, not a regression of it. #902 introduced the span-union pipeline for the regular patterns, and its own PR body records the carve-out verbatim — "The high-entropy detector stays an unchanged second pass." That exemption is exactly the hole #909 falls through. The `email_password_combo` leak #902 fixed is a different symptom (regex-vs-regex anchor destruction); this is detector-vs-regex partial overlap. Same root class, same structural remedy, now applied to the last detector left outside the union.

Public API unchanged. `patterns.py`, `scanner.py`, and the CLI/file layers are untouched; `redact --apply` still operates on fragment bodies only.

## Test plan

- New `TestHighEntropyOverlapLeak` (18 tests), written RED-first and verified against real implementations rather than asserted:
  - Against **HEAD**: 8 fail.
  - Against the **intermediate** (span union, no snapping): exactly **1** fails — `test_sub_threshold_entropy_tail_after_api_key_still_redacted`. So the snapping is load-bearing, not decorative.
  - Against the **final** implementation: all 18 pass.
- Every core assertion compares the **complete** returned string with `==`, never `secret not in out`. A containment assertion passes while this bug is live — that is exactly how it shipped — so the three pre-existing `TestRedactorHighEntropy` tests and the #435 property test were tightened from containment to full-output equality too. No assertion was removed: each replacement equality strictly subsumes the containment checks it replaced, and one docstring that claimed `min_confidence=0` was corrected to match its body's `1.0`.
- Threshold gating is bracketed from both sides by a 24-char probe at exactly 3.0 bits/char — inert at the 3.7 default, redacted at the 2.5 floor `min_confidence=0.0` selects — so a refactor that hard-coded or dropped the config read fails. Threshold-independence of the fix itself is pinned at `min_confidence=1.0`.
- `test_markers_are_inert_for_every_pattern_name` guards a real 0.016-bit cliff: `email_password_combo` is a 20-char run at 3.6842 bits/char against the 3.7 default.
- Scan/apply parity re-probed by hand across ten overlap geometries (leading tail, trailing tail, hyphen-joined, space-separated, low-entropy tail, `token=` prefix, card/ipv4 adjacency, `email:password`). In every case where `scan_file` reports `high_entropy_string`, the full run is gone from the applied output.
- All 278 redaction tests pass (`test_redact.py`, `test_properties_redaction.py`, `test_cli_redact.py`, `test_mcp_redact.py`, `test_redact_audit.py`).
- `cd creek-tools && ./scripts/check-all.sh` exits 0 — 12/12 checks, 6315 tests, 93.93% coverage, per-file gate green.
- Security-specialist audit of the snapping mechanism: **no blockers, no majors**. Confirmed no span can end strictly inside a non-allowlisted run; the allowlist carve-out cannot be turned into a leak amplifier (it keys on the whole maximal run, so a benign string cannot suppress an overlapping secret); snapping cannot widen across a newline (the candidate class excludes every character `str.splitlines()` treats as a boundary); and marker mislabeling can only ever go *upward* in severity, never downward.

Follow-ups filed rather than scope-creeping this P1: #945 (markers rewritten into nested markers at low `min_confidence` — pre-existing, distinct) and #946 (prose over-redaction from snapping, the O(spans × runs) cost, and allowlist documentation).

Closes #909
