### PR TITLE
fix(purge): stop a scoped purge silently skipping an undecodable fragment

### DIFF
--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -37,6 +37,7 @@ from datetime import UTC, date, datetime
 from typing import TYPE_CHECKING
 
 import frontmatter
+import yaml
 from pydantic import BaseModel, Field
 
 from creek.ingest.journal_staging import JOURNAL_STAGING_RELDIR
@@ -123,6 +124,29 @@ must tolerate nested-list entries (or skip purged drafts). The
 regression test ``test_purged_marker_reparses_as_nested_list_in_yaml``
 pins this trade-off so a future marker swap has to update the test and
 this docstring together.
+"""
+
+_FRONTMATTER_LOAD_ERRORS: tuple[type[Exception], ...] = (
+    OSError,
+    TypeError,
+    ValueError,
+    yaml.YAMLError,
+)
+"""Exceptions a hand-edited or corrupt vault file raises out of ``frontmatter.load``.
+
+Widens the house ``(OSError, ValueError, yaml.YAMLError)`` tuple with
+``TypeError``, which is load-bearing here and must never be dropped:
+``frontmatter.load`` splats the parsed metadata as
+``Post(content, handler, **metadata)``, so frontmatter carrying a
+non-string key — a bare YAML date like ``2024-05-01: note``, a realistic
+hand-edited-vault case — parses to a ``datetime.date`` key and raises a
+plain ``TypeError: keywords must be strings`` that the house tuple
+misses (precedent: PR #927 / issue #847).
+
+``UnicodeDecodeError`` is a ``ValueError`` subclass and is therefore
+covered deliberately: a file whose *body* carries non-UTF-8 bytes fails
+at read time, before its (possibly byte-clean ASCII) frontmatter block
+is ever parsed.
 """
 
 
@@ -453,7 +477,7 @@ class PurgeEngine:
         def body() -> None:
             """Run the date-range destructive ops, mutating ``result``."""
             for frag_file in self._list_fragment_files():
-                post = self._load_frontmatter(frag_file)
+                post = self._load_frontmatter_for_match(frag_file)
                 if post is None:
                     continue
                 created = _coerce_date(post.get("created"))
@@ -793,7 +817,7 @@ class PurgeEngine:
             Tuple of ``(path, post)`` or ``(None, None)`` if not found.
         """
         for frag_file in self._list_fragment_files():
-            post = self._load_frontmatter(frag_file)
+            post = self._load_frontmatter_for_match(frag_file)
             if post is not None and post.get("id") == fragment_id:
                 return frag_file, post
         return None, None
@@ -812,7 +836,7 @@ class PurgeEngine:
         """
         matches: list[tuple[Path, frontmatter.Post]] = []
         for frag_file in self._list_fragment_files():
-            post = self._load_frontmatter(frag_file)
+            post = self._load_frontmatter_for_match(frag_file)
             if post is None:
                 continue
             if _extract_source_platform(post) == source_type:
@@ -841,7 +865,7 @@ class PurgeEngine:
         predicate = _build_source_path_matcher(source_path, match=match)
         matches: list[tuple[Path, frontmatter.Post]] = []
         for frag_file in self._list_fragment_files():
-            post = self._load_frontmatter(frag_file)
+            post = self._load_frontmatter_for_match(frag_file)
             if post is None:
                 continue
             original_file = _extract_source_original_file(post)
@@ -871,18 +895,114 @@ class PurgeEngine:
         return sorted(self.vault_path.rglob("*.md"))
 
     def _load_frontmatter(self, path: Path) -> frontmatter.Post | None:
-        """Read a frontmatter post from disk, tolerating bad files.
+        """Read a frontmatter post byte-faithfully, tolerating bad files.
+
+        The **write-safe** loader, for the callers that rewrite the post
+        in place (``purge_classifications`` and :meth:`_decrement_counts`
+        both do ``frontmatter.dumps`` + ``write_text``). A file this
+        cannot decode is skipped rather than salvaged, because re-encoding
+        a lossy read would overwrite the operator's original bytes during
+        a non-destructive metadata reset. Callers that only ever
+        ``unlink`` the file must use :meth:`_load_frontmatter_for_match`.
 
         Args:
             path: Path to a markdown file.
 
         Returns:
-            Parsed :class:`frontmatter.Post`, or ``None`` on failure.
+            Parsed :class:`frontmatter.Post`, or ``None`` when the file
+            cannot be read or parsed.
         """
         try:
             return frontmatter.load(str(path))
-        except Exception:
-            logger.debug("Unable to parse frontmatter in %s", path)
+        except _FRONTMATTER_LOAD_ERRORS as exc:
+            # Log the exception *type* only: yaml.MarkedYAMLError
+            # stringifies with the offending source snippet, which would
+            # copy vault content into the log.
+            logger.warning(
+                "Unable to parse frontmatter in %s (%s); leaving it untouched",
+                path,
+                type(exc).__name__,
+            )
+            return None
+
+    def _load_frontmatter_for_match(self, path: Path) -> frontmatter.Post | None:
+        """Read a post for a *delete decision only* — never write it back.
+
+        The returned :class:`frontmatter.Post` may be **lossy**: when the
+        file is not valid UTF-8, its body is re-read with
+        ``errors="replace"`` so every offending byte becomes U+FFFD.
+        Writing such a post back to disk would destroy the operator's
+        original bytes, so this loader exists solely to decide whether a
+        file matches the purge criteria before it is ``unlink``-ed. The
+        rewrite paths use :meth:`_load_frontmatter` instead.
+
+        The lossy read is safe for that one job because a purge match is
+        a function of *frontmatter metadata* only — ``id``,
+        ``source.platform``, ``source.original_file``, ``created`` — and
+        never of the body. Replacing bad body bytes therefore cannot
+        change the outcome; it can only stop a matching fragment from
+        escaping the purge with its private body intact, which is the
+        right-to-be-forgotten failure this exists to close (#910).
+
+        Args:
+            path: Path to a markdown file.
+
+        Returns:
+            Parsed :class:`frontmatter.Post` — lossy in the body when the
+            file was not valid UTF-8 — or ``None`` when the frontmatter
+            cannot be parsed at all. ``None`` means "matches nothing", so
+            an unreadable file is left on disk rather than deleted.
+        """
+        try:
+            return frontmatter.load(str(path))
+        except UnicodeDecodeError:
+            # Degrading to a lossy read on an RTBF-critical path is an
+            # operator-visible event, so name the file at WARNING.
+            logger.warning(
+                "Body of %s is not valid UTF-8; re-reading it lossily to test it "
+                "against the purge criteria (the file itself is never rewritten)",
+                path,
+            )
+            return self._load_frontmatter_lossily(path)
+        except _FRONTMATTER_LOAD_ERRORS as exc:
+            # Type name only — never str(exc); see _load_frontmatter.
+            logger.warning(
+                "Unable to parse frontmatter in %s (%s); leaving it untouched",
+                path,
+                type(exc).__name__,
+            )
+            return None
+
+    def _load_frontmatter_lossily(self, path: Path) -> frontmatter.Post | None:
+        """Re-read an undecodable file, replacing its bad bytes with U+FFFD.
+
+        The retry half of :meth:`_load_frontmatter_for_match`, and subject
+        to the same prohibition: the returned post's content is lossy and
+        must never be written back to disk.
+
+        Args:
+            path: Path to a markdown file that failed to decode as UTF-8.
+
+        Returns:
+            Parsed :class:`frontmatter.Post` with invalid bytes replaced,
+            or ``None`` when the file is *also* unparseable as
+            frontmatter and so can match no purge criteria.
+        """
+        try:
+            # Go through the file object rather than decoding bytes and
+            # calling ``frontmatter.loads``: ``frontmatter.load`` is itself
+            # ``open(...)`` + ``loads(text)``, so this keeps it the single
+            # parse entry point and preserves universal-newline handling,
+            # leaving a CRLF vault file identical on both paths.
+            with path.open(encoding="utf-8", errors="replace") as handle:
+                return frontmatter.load(handle)
+        except _FRONTMATTER_LOAD_ERRORS as exc:
+            # Both undecodable *and* unparseable: no criteria can match.
+            logger.warning(
+                "Unable to parse frontmatter in %s (%s); leaving it untouched",
+                path,
+                type(exc).__name__,
+            )
             return None
 
     def _scrub_references(
@@ -959,11 +1079,26 @@ class PurgeEngine:
 
         Returns:
             A ``(wikilinks_removed, provenance_scrubbed)`` count pair for
-            this file. ``(0, 0)`` when the file cannot be read.
+            this file. ``(0, 0)`` when the file cannot be read or is not
+            valid UTF-8.
         """
         try:
             text = md_file.read_text(encoding="utf-8")
-        except OSError:
+        except (OSError, UnicodeDecodeError) as exc:
+            # Skipping is the only safe response to an undecodable file:
+            # this method writes ``text`` back, so an ``errors="replace"``
+            # read here would persist U+FFFD over the operator's bytes.
+            # A reference living inside such a file therefore survives
+            # unscrubbed: an accepted trade-off, since the alternative is
+            # corrupting the file — and far better than raising, which
+            # would abort the purge before the target is even unlinked.
+            # Type name only, never str(exc): the message can quote file
+            # content (possibly the very secret being purged).
+            logger.warning(
+                "Skipping unreadable file during reference scrub: %s (%s)",
+                md_file,
+                type(exc).__name__,
+            )
             return 0, 0
         wiki_count = prov_count = 0
         if wiki_pattern is not None:

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -9,6 +9,7 @@ corpora per test.
 from __future__ import annotations
 
 import json
+import logging
 import re
 from datetime import UTC, date, datetime, timedelta
 from typing import TYPE_CHECKING
@@ -237,6 +238,99 @@ def _write_eddy(
     )
     target.write_text(frontmatter.dumps(post), encoding="utf-8")
     return target
+
+
+# ---------------------------------------------------------------------------
+# Undecodable-body fixtures (#910)
+# ---------------------------------------------------------------------------
+
+_UNDECODABLE_BYTES = b"\xff\xfe"
+"""Raw bytes that are not valid UTF-8 anywhere in a byte stream (#910).
+
+Injected into fragment *bodies* only. A file carrying these bytes makes
+``frontmatter.load`` raise ``UnicodeDecodeError`` at read time — before
+the (perfectly well-formed, byte-clean ASCII) YAML frontmatter block is
+ever parsed.
+"""
+
+_UNDECODABLE_SECRET = "synthetic-undecodable-secret-910"
+"""Synthetic marker standing in for private body content — never real data."""
+
+
+def _write_fragment_with_undecodable_body(
+    vault: Path,
+    frag_id: str,
+    title: str,
+    *,
+    platform: str = "claude",
+    subfolder: str = "Conversations",
+    created: datetime | None = None,
+    threads: list[str] | None = None,
+    eddies: list[str] | None = None,
+    secret: str = _UNDECODABLE_SECRET,
+) -> tuple[Path, bytes]:
+    """Write a house-schema fragment whose *body* is not valid UTF-8 (#910).
+
+    Builds the fragment through :func:`_write_fragment` so the
+    frontmatter matches the house schema exactly, then re-writes the
+    file with :data:`_UNDECODABLE_BYTES` appended to the body. Because
+    the injection happens strictly after the closing ``---`` delimiter,
+    the YAML frontmatter block stays byte-clean ASCII — that is
+    precisely the class under test: well-formed metadata, undecodable
+    body.
+
+    Args:
+        vault: Vault root.
+        frag_id: Fragment ID.
+        title: Fragment title (also the filename stem).
+        platform: Source platform recorded in ``source.platform``.
+        subfolder: Subfolder under ``01-Fragments/``.
+        created: Optional creation datetime (for date-range matching).
+        threads: Optional list of thread IDs the fragment belongs to.
+        eddies: Optional list of eddy IDs.
+        secret: Marker text embedded in the body so tests can prove the
+            private content really left the vault.
+
+    Returns:
+        Tuple of ``(path, exact_bytes_written)`` so callers can assert
+        byte-for-byte equality after a purge that must not touch it.
+    """
+    path = _write_fragment(
+        vault,
+        frag_id,
+        title,
+        platform=platform,
+        subfolder=subfolder,
+        created=created,
+        threads=threads,
+        eddies=eddies,
+        body=f"Body carrying {secret} here.",
+    )
+    raw = path.read_bytes() + _UNDECODABLE_BYTES + b"\n"
+    path.write_bytes(raw)
+    return path, raw
+
+
+def _vault_files_containing_bytes(vault: Path, needle: bytes) -> list[Path]:
+    """Return every vault markdown file whose *bytes* still carry *needle*.
+
+    The byte-level sibling of :func:`_vault_files_containing_secret`,
+    which cannot be reused here: it decodes with
+    ``read_text(encoding="utf-8")`` and would itself raise
+    ``UnicodeDecodeError`` on the very fixtures under test (#910).
+
+    Args:
+        vault: Vault root to walk.
+        needle: Byte sequence that must survive nowhere under the vault.
+
+    Returns:
+        Offending paths — empty when the purge honored the RTBF request.
+    """
+    return [
+        md_file
+        for md_file in sorted(vault.rglob("*.md"))
+        if needle in md_file.read_bytes()
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -3001,3 +3095,369 @@ def test_purge_single_walks_vault_once_per_fragment(
 
     # Two fragments purged → at most one walk each.
     assert calls <= 2
+
+
+# ---------------------------------------------------------------------------
+# Engine tests — fragments whose body is not valid UTF-8 (#910)
+# ---------------------------------------------------------------------------
+
+
+def test_source_purge_deletes_fragment_with_undecodable_body(
+    tmp_path: Path,
+) -> None:
+    """A matching fragment with an undecodable body is really deleted (#910).
+
+    The headline RTBF failure: ``frontmatter.load`` raises
+    ``UnicodeDecodeError`` on the body even though the frontmatter is
+    well-formed ASCII, the engine treats the unreadable load as "skip
+    this file", and the matching fragment survives with its private
+    body on disk.
+    """
+    vault = _make_vault(tmp_path)
+    frag, _raw = _write_fragment_with_undecodable_body(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source("claude")
+
+    assert result.fragments_affected == 1
+    assert not frag.exists()
+    # The RTBF core: the private body survives NOWHERE under the vault.
+    assert _vault_files_containing_bytes(vault, _UNDECODABLE_SECRET.encode()) == []
+
+
+def test_source_purge_audit_records_the_undecodable_deletion(
+    tmp_path: Path,
+) -> None:
+    """The outcome entry counts the undecodable fragment it deleted (#910).
+
+    The "reports success" half of the bug: today the outcome line says
+    ``status="complete"`` with ``fragments_deleted=0`` and an empty
+    ``affected_fragments``, so the compliance record claims a clean
+    purge while the fragment is still on disk.
+    """
+    vault = _make_vault(tmp_path)
+    _write_fragment_with_undecodable_body(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault)
+
+    engine.purge_source("claude")
+
+    entries = PurgeAuditLog(vault).read()
+    assert len(entries) == 2
+    intent, outcome = entries
+    assert intent.phase == "intent"
+    assert outcome.phase == "outcome"
+    assert outcome.status == "complete"
+    assert outcome.operation == "source"
+    assert outcome.criteria == {"source_type": "claude"}
+    assert outcome.affected_fragments == ["frag-A"]
+    assert outcome.fragments_deleted == 1
+
+
+def test_fragment_purge_finds_fragment_with_undecodable_body(
+    tmp_path: Path,
+) -> None:
+    """``purge_fragment`` locates a fragment whose body is undecodable (#910).
+
+    Pins ``_find_fragment_by_id``: an unreadable load there makes the
+    targeted single-fragment purge report "not found".
+    """
+    vault = _make_vault(tmp_path)
+    frag, _raw = _write_fragment_with_undecodable_body(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-A")
+
+    assert result.fragments_affected == 1
+    assert not frag.exists()
+    assert _vault_files_containing_bytes(vault, _UNDECODABLE_SECRET.encode()) == []
+
+
+def test_source_path_purge_deletes_fragment_with_undecodable_body(
+    tmp_path: Path,
+) -> None:
+    """``purge_source_path`` deletes an undecodable-bodied match (#910).
+
+    ``_write_fragment`` records ``source.original_file`` as
+    ``"<frag_id>.json"``, so ``"frag-A.json"`` is the exact path the
+    seeded fragment carries. Pins ``_fragments_from_source_path``.
+    """
+    vault = _make_vault(tmp_path)
+    frag, _raw = _write_fragment_with_undecodable_body(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source_path("frag-A.json", match="exact")
+
+    assert result.fragments_affected == 1
+    assert not frag.exists()
+    assert _vault_files_containing_bytes(vault, _UNDECODABLE_SECRET.encode()) == []
+
+
+def test_daterange_purge_deletes_fragment_with_undecodable_body(
+    tmp_path: Path,
+) -> None:
+    """A date-range purge deletes an in-range undecodable fragment (#910).
+
+    Pins ``purge_daterange``'s inline frontmatter load: skipping the
+    file means its ``created`` date is never even compared.
+    """
+    vault = _make_vault(tmp_path)
+    frag, _raw = _write_fragment_with_undecodable_body(
+        vault,
+        "frag-A",
+        "Alpha",
+        created=datetime(2024, 6, 1, tzinfo=UTC),
+    )
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_daterange(date(2024, 5, 1), date(2024, 12, 31))
+
+    assert result.fragments_affected == 1
+    assert not frag.exists()
+    assert _vault_files_containing_bytes(vault, _UNDECODABLE_SECRET.encode()) == []
+
+
+def test_source_purge_leaves_undecodable_nonmatching_fragment_intact(
+    tmp_path: Path,
+) -> None:
+    """Failing closed must not over-delete a non-matching fragment (#910).
+
+    The undecodable fragment belongs to ``discord``, so a ``claude``
+    purge must leave it byte-for-byte untouched — including through the
+    vault-wide wiki-link/provenance scrub walk that visits it while
+    deleting the matching fragment.
+    """
+    vault = _make_vault(tmp_path)
+    keeper = _write_fragment(vault, "frag-A", "Alpha", platform="claude")
+    other, other_bytes = _write_fragment_with_undecodable_body(
+        vault,
+        "frag-B",
+        "Bravo",
+        platform="discord",
+        subfolder="Messages",
+    )
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source("claude")
+
+    assert result.fragments_affected == 1
+    assert not keeper.exists()
+    assert other.exists()
+    assert other.read_bytes() == other_bytes
+
+
+def test_source_purge_skips_file_with_no_parseable_frontmatter(
+    tmp_path: Path,
+) -> None:
+    """Unreadable garbage under ``01-Fragments/`` is skipped, not deleted (#910).
+
+    "Fail closed" means *match* the fragments whose metadata is sound
+    even when the body is undecodable — it must never mean "delete
+    everything the parser cannot read". A delimiter-less file does not
+    raise: ``python-frontmatter`` parses it as empty metadata, so it
+    exposes none of the criteria surfaces (``source.platform`` here)
+    and matches nothing. Either way it must survive intact.
+    """
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha", platform="claude")
+    garbage = vault / "01-Fragments" / "Conversations" / "garbage.md"
+    garbage_bytes = b"\xff\xfe not yaml at all"
+    garbage.write_bytes(garbage_bytes)
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source("claude")
+
+    assert result.fragments_affected == 1
+    assert not frag.exists()
+    assert garbage.exists()
+    assert garbage.read_bytes() == garbage_bytes
+
+
+def test_source_purge_skips_undecodable_file_with_malformed_yaml(
+    tmp_path: Path,
+) -> None:
+    """A file that is neither decodable nor parseable is left on disk (#910).
+
+    Pins the retry half of the frontmatter load: the invalid bytes make
+    the strict read raise ``UnicodeDecodeError``, and the unterminated
+    YAML flow sequence makes the lossy re-read raise as well, so *both*
+    arms run and the engine ends up with no metadata at all. A file the
+    engine cannot read matches no purge criteria, so it survives intact.
+
+    This is the deliberate boundary of "fail closed". Failing closed
+    resolves ambiguity *within* the criteria — that is exactly what the
+    lossy re-read buys: a fragment whose metadata is sound still gets
+    matched despite an undecodable body. It does not license deleting
+    files by absence of evidence, which on a *scoped* purge would be
+    unbounded collateral loss. The operator's total-RTBF hammer,
+    ``purge_vault``, still reaches such files, because it wipes folder
+    contents without ever parsing frontmatter.
+    """
+    vault = _make_vault(tmp_path)
+    frag = _write_fragment(vault, "frag-A", "Alpha", platform="claude")
+    unreadable = vault / "01-Fragments" / "Conversations" / "unreadable.md"
+    raw = b"---\ntitle: [unclosed \xff\xfe\n---\nsecret body\n"
+    unreadable.write_bytes(raw)
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source("claude")
+
+    assert result.fragments_affected == 1
+    assert not frag.exists()
+    assert unreadable.exists()
+    assert unreadable.read_bytes() == raw
+
+
+def test_classifications_purge_does_not_corrupt_undecodable_fragment(
+    tmp_path: Path,
+) -> None:
+    """The classification rewrite path must never re-encode a bad file (#910).
+
+    This test is GREEN today **on purpose** — it is a regression guard,
+    not a dead test. ``purge_classifications`` rewrites fragments in
+    place via ``frontmatter.dumps`` + ``write_text``. If anyone makes
+    the frontmatter helper this path uses lossy (``errors="replace"``),
+    every undecodable byte would be silently rewritten as U+FFFD over
+    the operator's original file — data loss. The byte-equality
+    assertion fails the instant that happens.
+    """
+    vault = _make_vault(tmp_path)
+    frag, raw = _write_fragment_with_undecodable_body(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_classifications()
+
+    assert result.classifications_reset == 0
+    assert frag.read_bytes() == raw
+
+
+def test_decrement_counts_does_not_corrupt_undecodable_thread_file(
+    tmp_path: Path,
+) -> None:
+    """A thread file with an undecodable body survives a purge intact (#910).
+
+    ``_decrement_counts`` is the second in-place rewrite path. An
+    unreadable thread file must be skipped (count not decremented)
+    rather than crashing the purge or being re-encoded lossily, while
+    the fragment itself is still deleted.
+    """
+    vault = _make_vault(tmp_path)
+    thread = _write_thread(vault, "thread-1", "Waves", fragment_count=3)
+    thread_bytes = thread.read_bytes() + _UNDECODABLE_BYTES + b"\n"
+    thread.write_bytes(thread_bytes)
+    frag = _write_fragment(vault, "frag-A", "Alpha", threads=["thread-1"])
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-A")
+
+    assert result.fragments_affected == 1
+    assert not frag.exists()
+    assert result.threads_updated == 0
+    assert thread.read_bytes() == thread_bytes
+
+
+def test_source_purge_survives_two_undecodable_matching_fragments(
+    tmp_path: Path,
+) -> None:
+    """Two undecodable matches are both deleted without raising (#910).
+
+    Once matching stops skipping these files, deleting the first one
+    walks the vault to scrub references — and that walk now reaches the
+    *second* undecodable file. Pins that the scrub tolerates it instead
+    of aborting the purge half-done.
+    """
+    vault = _make_vault(tmp_path)
+    first, _first_raw = _write_fragment_with_undecodable_body(vault, "frag-A", "Alpha")
+    second, _second_raw = _write_fragment_with_undecodable_body(
+        vault,
+        "frag-B",
+        "Bravo",
+    )
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source("claude")
+
+    assert result.fragments_affected == 2
+    assert not first.exists()
+    assert not second.exists()
+    assert _vault_files_containing_bytes(vault, _UNDECODABLE_SECRET.encode()) == []
+    outcome = PurgeAuditLog(vault).read()[-1]
+    assert outcome.status == "complete"
+    assert outcome.fragments_deleted == 2
+    assert sorted(outcome.affected_fragments) == ["frag-A", "frag-B"]
+
+
+def test_purge_tolerates_bare_yaml_date_key_without_crashing(
+    tmp_path: Path,
+) -> None:
+    """A bare YAML date key raises ``TypeError``, which must stay tolerated.
+
+    ``2024-05-01: note`` parses to a ``datetime.date`` *key*, and
+    ``frontmatter`` then splats the mapping as keyword arguments —
+    ``TypeError: keywords must be strings``. GREEN today; it guards the
+    narrowing of the engine's bare ``except Exception`` so nobody drops
+    ``TypeError`` from the tolerated tuple (precedent: PR #927 /
+    issue #847). The odd file contributes zero resets while a normal
+    sibling still resets.
+    """
+    vault = _make_vault(tmp_path)
+    odd = vault / "01-Fragments" / "Conversations" / "odd.md"
+    odd_text = "---\n2024-05-01: note\n---\nbody\n"
+    odd.write_text(odd_text, encoding="utf-8")
+    _write_fragment(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_classifications()
+
+    assert result.classifications_reset == 1
+    assert result.affected_fragment_ids == ["frag-A"]
+    assert odd.read_text(encoding="utf-8") == odd_text
+
+
+def test_purge_tolerates_malformed_yaml_without_crashing(
+    tmp_path: Path,
+) -> None:
+    """Genuinely invalid YAML frontmatter is skipped, not deleted (#910).
+
+    An unterminated flow sequence raises ``yaml.YAMLError``. GREEN
+    today; it pins ``yaml.YAMLError`` into the tolerated-error tuple
+    that replaces the bare ``except Exception``, and pins that a file
+    the engine cannot classify is left alone rather than purged.
+    """
+    vault = _make_vault(tmp_path)
+    broken = vault / "01-Fragments" / "Conversations" / "broken.md"
+    broken_text = "---\ntitle: [unclosed\n---\nA body with no links.\n"
+    broken.write_text(broken_text, encoding="utf-8")
+    frag = _write_fragment(vault, "frag-A", "Alpha", platform="claude")
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_source("claude")
+
+    assert result.fragments_affected == 1
+    assert not frag.exists()
+    assert broken.exists()
+    assert broken.read_text(encoding="utf-8") == broken_text
+
+
+def test_source_purge_warns_when_fragment_body_is_undecodable(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An undecodable body is a WARNING, not a debug whisper (#910).
+
+    Silently degrading to a lossy read on an RTBF-critical path is an
+    operator-visible event: the log must name the offending file so it
+    can be inspected. Asserts on level and path only — never on wording.
+    """
+    vault = _make_vault(tmp_path)
+    frag, _raw = _write_fragment_with_undecodable_body(vault, "frag-A", "Alpha")
+    engine = PurgeEngine(vault)
+
+    with caplog.at_level(logging.WARNING, logger="creek.purge.engine"):
+        engine.purge_source("claude")
+
+    naming_the_file = [
+        record
+        for record in caplog.records
+        if record.levelno == logging.WARNING and str(frag) in record.getMessage()
+    ]
+    assert len(naming_the_file) >= 1


### PR DESCRIPTION
## Summary

A fragment that matched a scoped purge could survive it, with its private body intact, while the audit recorded a successful purge. That defeats the right-to-be-forgotten guarantee, so this is a P1 correctness fix.

`PurgeEngine._load_frontmatter` swallowed every exception and returned `None`, and every scoped purge reads `None` as "skip this file". `frontmatter.load` raises `UnicodeDecodeError` on a file whose **body** carries non-UTF-8 bytes **even when its YAML frontmatter block is well-formed ASCII** — so a genuinely matching fragment was dropped with only a `logger.debug` line.

Live-reproduced on `main` before the fix, and again after:

```
# before                          # after
fragments_affected: 0             fragments_affected: 1
file still exists: True           file still exists: False
```

### The design: split the loader by write-safety

The helper was doing two different jobs for two classes of caller, and that collision is the bug.

| Caller class | Sites | What it does with the post |
|---|---|---|
| **Delete-decision** | `_find_fragment_by_id`, `_fragments_from_source`, `_fragments_from_source_path`, `purge_daterange` | reads `id`/`platform`/`original_file`/`created`, then `unlink()`s the file |
| **Rewrite** | `purge_classifications`, `_decrement_counts` | `frontmatter.dumps(post)` + `write_text` |

An `errors="replace"` read is exactly right for the first group and **catastrophic** for the second — it would persist U+FFFD over the operator's original bytes during a *non-destructive* metadata reset. So:

- **`_load_frontmatter_for_match`** (new, lossy) serves the four delete-decision sites. Strict read first; on `UnicodeDecodeError` it warns and re-reads through `path.open(encoding="utf-8", errors="replace")`. Its docstring opens by forbidding write-back, and no code path can write it.
- **`_load_frontmatter`** (body unchanged, strict) keeps the two rewrite sites. Two tests assert **byte-identity** on those paths and fail the instant anyone makes the shared loader lossy.

The lossy read is safe for that one job because a purge match is a function of frontmatter metadata only, never of the body. Replacing bad body bytes cannot change the outcome — it can only stop a matching fragment from escaping.

Chose two named helpers over a `lossy: bool` flag deliberately: a boolean trap on a destructive path is worse than two names, and two names make the call-site audit a single `grep`.

### Supporting changes

- Bare `except Exception` → shared `_FRONTMATTER_LOAD_ERRORS = (OSError, TypeError, ValueError, yaml.YAMLError)`. **`TypeError` is load-bearing** and must never be dropped: `frontmatter.load` splats metadata as `Post(content, handler, **metadata)`, so a bare YAML date key raises a plain `TypeError` the house `(OSError, ValueError, yaml.YAMLError)` tuple misses (precedent: #847 / PR #927). `UnicodeDecodeError` is a `ValueError` subclass, so **arm order is load-bearing** — it is caught ahead of the tuple.
- Every new warning logs `type(exc).__name__` **only** — never `str(exc)`, `exc_info`, or `logger.exception`. `yaml.MarkedYAMLError` stringifies with the offending source snippet, which would copy the very secret being purged into the log (house rule from PR #927).
- `_scrub_one_file` widens `except OSError` → `except (OSError, UnicodeDecodeError)`. This is a **minimal necessity, not scope creep**: before this change `purge_source` with only undecodable matches walked nothing, but now it matches them, and `_scrub_references` walks every vault `.md` — so a second undecodable file would raise out of `body()`, `_run_audited` would write `status="partial"` and re-raise, and the target would **never be unlinked** (unlink follows the scrub in `_purge_single`). That would convert a silent under-delete into a loud one, which does not satisfy the goal. It deliberately does **not** get an `errors="replace"` read: it writes `text` back, so a lossy read there would recreate the corruption bug in a second location.

### Where fail-closed stops

Per the operator constraint from PR #947 (#909), fail closed rather than open. The lossy re-read *dissolves* the ambiguity rather than resolving it toward deletion, so there is no residual "matches but undecidable" class.

A file that can be **neither decoded nor parsed** exposes no criteria surface at all and is left on disk. Deleting it under a *scoped* purge would be purging by absence of evidence — unbounded collateral loss in a vault that may hold many malformed notes. `purge_vault` remains the backstop: it wipes folder contents without ever parsing frontmatter, so the total-RTBF hammer still reaches those files (verified). And the residual skips are no longer silent — WARNING, not debug.

### Notes for the reviewer

- `frontmatter.load` is itself `open(fd, "r", encoding=...)` + `loads(text)`, so the lossy path goes through the **file object** rather than decoding bytes and calling `frontmatter.loads`. That keeps `frontmatter.load` the single parse entry point and preserves universal-newline handling — a CRLF vault file behaves identically on both paths (verified).
- Keeping the strict helper on `frontmatter.load` also keeps `test_load_frontmatter_handles_unreadable_file`, which monkeypatches that symbol, meaningful and **untouched**.
- The test diff is **purely additive**: 458 insertions, **zero deletions**. No pre-existing test was modified.

### Scope

#926 owns operator-facing *reporting* of silently-skipped files and is untouched — no new `PurgeResult` field, counter, summary object, or lint surface. This PR is the correctness half only.

Filed as follow-ups, not fixed here:
- **#948** — a reference inside an undecodable file is now skipped rather than crashing, so it survives unscrubbed; needs a byte-level scrub, since `errors="replace"` there would corrupt.
- **#949** — `fragment_count` drifts when a thread/eddy file is undecodable (pre-existing; preferable to corrupting it).
- **#950** — three pre-existing findings from the Gate 2.5 security review, in `_purge_intimate_stub` and `_run_audited`; none in code this PR touches.

## Test plan

15 new tests in `tests/test_purge.py`.

**10 fail before this change** (verified RED, then GREEN):
- Wrong counts / surviving files on all five scoped paths — `purge_source`, `purge_fragment`, `purge_source_path`, `purge_daterange`, and the audit record (`fragments_deleted == 1`, `affected_fragments == ["frag-A"]` while `status == "complete"` — the "reports success" half).
- A real `UnicodeDecodeError` out of `_scrub_one_file` on three (non-matching sibling, garbage file, undecodable thread file).
- A missing WARNING record on one (asserts level + path substring only, never wording).

**5 green-today regression guards**, each documented as such in its docstring:
- Two assert **byte-identity** on the rewrite paths (`purge_classifications`, `_decrement_counts`) — these fail the instant anyone makes the shared loader lossy.
- Two pin `TypeError` (bare YAML date key) and `yaml.YAMLError` (unterminated flow sequence) in the tolerated tuple.
- Two pin **no-over-deletion**: a non-matching undecodable file and a file that is both undecodable *and* unparseable both survive with identical bytes.

Test-quality guards: no assertion depends on file-visit order — `rglob` yields `os.scandir` order (hash-ordered on APFS), and an order-dependent test can false-green against this exact bug. The new byte-level `_vault_files_containing_bytes` helper is used instead of the existing `_vault_files_containing_secret`, which strict-decodes and would itself raise on these fixtures.

**Gate 2:** `cd creek-tools && ./scripts/check-all.sh` → exit 0, 12/12 checks, 6332 tests pass, aggregate coverage 93.95%, per-file gate clean. `creek/purge/engine.py` at 94.57% with every newly added line covered.

**Gate 2.5:** `code-review-orchestrator` (incl. an independent security pass over the RTBF deletion path) returned **CLEAN** — no blockers. The three security findings it surfaced are pre-existing in untouched code and are filed as #950.

Closes #910
