### PR TITLE
fix(purge): stop an intimate-body pointer deleting any in-vault file

### DIFF
--- a/creek-tools/creek/purge/audit.py
+++ b/creek-tools/creek/purge/audit.py
@@ -106,8 +106,12 @@ class PurgeAuditEntry(BaseModel):
         status: For outcome entries only — ``"complete"`` if the body
             ran without raising, ``"partial"`` if it aborted partway.
             ``None`` for intent entries and for pre-GAP-002 outcomes.
-        failure_reason: Short string capturing the exception type and
-            message when ``status="partial"``; ``None`` otherwise.
+        failure_reason: The exception **type name only** (e.g.
+            ``"OSError"``) when ``status="partial"``; ``None``
+            otherwise. The message is deliberately excluded: this log
+            is preserved by every purge, so vault-derived text quoted
+            in an exception would outlive the right-to-be-forgotten
+            request that produced it.
         target: Legacy field preserved for backward compatibility on
             read; populated only when reading pre-Batch-C entries.
         count: Legacy fragment count preserved for backward compatibility

--- a/creek-tools/creek/purge/engine.py
+++ b/creek-tools/creek/purge/engine.py
@@ -657,6 +657,54 @@ class PurgeEngine:
         if not self.dry_run:
             frag_file.unlink()
 
+    def _resolve_pointer_in_vault(self, pointer: str, *, field: str) -> Path | None:
+        """Resolve a frontmatter-supplied path pointer inside the vault.
+
+        Pointers such as ``saved_from.intimate_body_pointer`` and
+        ``source.origin_key`` are vault *content*: an operator (or
+        anyone who can write one note) controls their text, so they are
+        untrusted input to a destructive path. This helper turns such a
+        pointer into an absolute path only when it is safe to follow —
+        a refusal is a no-op, never an error, per the purge engine's
+        "a missing or bad pointer is skipped" contract.
+
+        A pointer is refused when it cannot be resolved at all (an
+        embedded NUL byte makes :meth:`~pathlib.Path.resolve` raise
+        ``ValueError``; a resolution loop or unreadable component
+        raises ``OSError``) or when it resolves outside the vault root.
+        Both refusals are logged at WARNING so an ignored pointer is
+        distinguishable from a sweep that never ran.
+
+        Args:
+            pointer: Vault-relative path string taken from frontmatter.
+            field: Frontmatter field name the pointer came from, used
+                verbatim in the refusal logs so operators can grep for
+                the field that carried the bad value.
+
+        Returns:
+            The resolved absolute path, or ``None`` meaning *refuse* —
+            the caller must not follow this pointer.
+        """
+        try:
+            resolved = (self.vault_path / pointer).resolve()
+        except (OSError, ValueError):
+            logger.warning(
+                "Ignoring %s %r that cannot be resolved to a path",
+                field,
+                pointer,
+            )
+            return None
+        vault_root = self.vault_path.resolve()
+        if not resolved.is_relative_to(vault_root):
+            logger.warning(
+                "Ignoring %s %r that resolves outside the vault root %s",
+                field,
+                pointer,
+                vault_root,
+            )
+            return None
+        return resolved
+
     def _purge_intimate_stub(
         self,
         post: frontmatter.Post,
@@ -673,10 +721,19 @@ class PurgeEngine:
         right-to-be-forgotten request.
 
         The method is defensive: a missing or empty pointer, an
-        already-deleted stub, and a pointer that resolves outside the
-        vault root are all treated as no-ops rather than errors. The
-        last case prevents a hand-edited or malicious pointer
-        (``../../secret``) from steering a delete outside the vault.
+        unresolvable pointer, an already-deleted stub, and a pointer
+        that resolves outside the vault root are all treated as no-ops
+        rather than errors. A second containment guard additionally
+        scopes deletion to the canonical stub directory itself, so a
+        hand-edited or malicious pointer (``../../secret``,
+        ``00-Creek-Meta/creek_config.yaml``, or a ``..`` walk back out
+        of the stub dir) can never steer a delete at an arbitrary file.
+
+        That guard is deliberately fail-closed, with one accepted side
+        effect: a hand-authored stub parked *outside* the canonical
+        directory now survives the purge. That is the safe direction —
+        the note itself is still deleted, so the RTBF request is
+        honoured, and the operator can purge the stray file explicitly.
 
         Args:
             post: Frontmatter of the note being purged.
@@ -684,17 +741,37 @@ class PurgeEngine:
                 incremented for each stub actually removed (or that
                 would be removed in a dry run).
         """
+        # Imported inside the function to keep the RTBF purge path's
+        # module-level import surface thin: at module scope this pulls
+        # ``creek/save/__init__.py`` → ``writer.py`` →
+        # ``creek.classify.privacy_filter`` → the whole
+        # ``creek.classify.llm`` provider subtree (httpx and friends).
+        # This is NOT a circular-import workaround — nothing under
+        # ``creek/save/`` imports ``creek.purge``, so please do not
+        # "fix" it by hoisting the import to module scope.
+        from creek.save._constants import INTIMATE_STUB_RELPATH
+
         pointer = self._intimate_pointer(post)
         if not pointer:
             return
-        stub_path = (self.vault_path / pointer).resolve()
-        vault_root = self.vault_path.resolve()
-        if not stub_path.is_relative_to(vault_root):
+        stub_path = self._resolve_pointer_in_vault(
+            pointer,
+            field="intimate_body_pointer",
+        )
+        if stub_path is None:
+            return
+        stub_root = (self.vault_path / INTIMATE_STUB_RELPATH).resolve()
+        # Checked before the counter so a dry run never previews a
+        # deletion the real run would refuse. The resolved victim path
+        # is deliberately left out of the message: the pointer is
+        # attacker-controlled, so echoing what it resolved to would
+        # turn the log into a filesystem oracle.
+        if not stub_path.is_relative_to(stub_root):
             logger.warning(
                 "Ignoring intimate_body_pointer %r that resolves outside "
-                "the vault root %s",
+                "the intimate stub dir %s",
                 pointer,
-                vault_root,
+                stub_root,
             )
             return
         if not stub_path.is_file():
@@ -737,13 +814,15 @@ class PurgeEngine:
         delete the staged file too, or the full — often intimate —
         entry body survives the right-to-be-forgotten request.
 
-        The method is defensive, mirroring :meth:`_purge_intimate_stub`:
-        a missing or empty key, an already-deleted staged file, and a
-        key that resolves outside the vault root are all no-ops rather
-        than errors. A second containment guard additionally scopes
-        deletion to the staging directory itself, so a hand-edited or
-        malicious ``origin_key`` (``../x``, ``01-Fragments/other.md``)
-        can never steer a delete at an arbitrary vault file.
+        The method is defensive, and now shares that defence with
+        :meth:`_purge_intimate_stub` in both directions: a missing or
+        empty key, an unresolvable key, an already-deleted staged file,
+        and a key that resolves outside the vault root are all no-ops
+        rather than errors (see :meth:`_resolve_pointer_in_vault`). A
+        second containment guard additionally scopes deletion to the
+        staging directory itself, so a hand-edited or malicious
+        ``origin_key`` (``../x``, ``01-Fragments/other.md``) can never
+        steer a delete at an arbitrary vault file.
 
         Args:
             post: Frontmatter of the fragment being purged.
@@ -754,14 +833,11 @@ class PurgeEngine:
         origin_key = _extract_source_origin_key(post)
         if not origin_key:
             return
-        staged_path = (self.vault_path / origin_key).resolve()
-        vault_root = self.vault_path.resolve()
-        if not staged_path.is_relative_to(vault_root):
-            logger.warning(
-                "Ignoring source.origin_key %r that resolves outside the vault root %s",
-                origin_key,
-                vault_root,
-            )
+        staged_path = self._resolve_pointer_in_vault(
+            origin_key,
+            field="source.origin_key",
+        )
+        if staged_path is None:
             return
         staging_root = (self.vault_path / JOURNAL_STAGING_RELDIR).resolve()
         if not staged_path.is_relative_to(staging_root):
@@ -1194,9 +1270,18 @@ class PurgeEngine:
 
         Emits an ``intent`` entry before invoking *body*, then an
         ``outcome`` entry after — ``status="complete"`` on success,
-        ``status="partial"`` (with the exception type + message in
+        ``status="partial"`` (with the exception **type name only** in
         ``failure_reason``) when *body* raises. The exception then
         propagates so callers see the failure.
+
+        The message is deliberately dropped: the audit log is preserved
+        by every purge, including ``purge_vault``, so anything written
+        there outlives the right-to-be-forgotten request that produced
+        it — and exception text routinely quotes vault-derived content
+        (a title-derived filename in an ``OSError``, a source snippet
+        in a ``yaml.MarkedYAMLError``). The type is the forensic value;
+        the message is the leak. Callers that need the detail still get
+        it from the propagating exception.
 
         The intent entry is the engine's recovery contract: even a
         SIGKILL between the intent write and the first destructive op
@@ -1219,7 +1304,7 @@ class PurgeEngine:
         try:
             body()
         except BaseException as exc:
-            failure_reason = f"{type(exc).__name__}: {exc}"
+            failure_reason = type(exc).__name__
             self._write_outcome_audit(
                 result,
                 operation_id,
@@ -1279,8 +1364,12 @@ class PurgeEngine:
             operation_id: UUID4 hex matching the paired intent entry.
             status: ``"complete"`` if the body ran to the end, or
                 ``"partial"`` if it raised.
-            failure_reason: Short ``"<ExceptionType>: <message>"`` when
-                ``status="partial"``; ``None`` otherwise.
+            failure_reason: The exception **type name only** (e.g.
+                ``"OSError"``) when ``status="partial"``; ``None``
+                otherwise. The message is omitted because the audit log
+                survives every purge, so vault-derived text quoted in an
+                exception would outlive the right-to-be-forgotten
+                request that produced it.
 
         Raises:
             ValueError: If ``result.operation`` is not a known purge

--- a/creek-tools/docs/cleaning-and-purge.md
+++ b/creek-tools/docs/cleaning-and-purge.md
@@ -211,7 +211,7 @@ Every purge writes **two** JSONL lines to `<vault>/00-Creek-Meta/audit/purge.jso
 }
 ```
 
-If the process is killed *between* the two writes (SIGKILL, power loss, OOM kill), the intent line is on disk and the outcome line is not. An operator inspecting the log knows that vault `<id>` was being attempted at `<timestamp>` and can reconcile against the filesystem. If the body raises a Python exception, the engine writes an outcome line with `status="partial"` and a `failure_reason` field naming the exception type and message; the original exception then propagates.
+If the process is killed *between* the two writes (SIGKILL, power loss, OOM kill), the intent line is on disk and the outcome line is not. An operator inspecting the log knows that vault `<id>` was being attempted at `<timestamp>` and can reconcile against the filesystem. If the body raises a Python exception, the engine writes an outcome line with `status="partial"` and a `failure_reason` field naming only the exception type (e.g. `OSError`), never its message — the audit trail is not purgeable (see below), so a message quoting vault-derived content would outlive the very right-to-be-forgotten request that produced it; the original exception, with the full message, still propagates to the caller.
 
 `creek purge` is **not** transactional — there is no staging-directory rename pattern, so a crash partway through `_wipe_folder_contents` can still leave the filesystem half-deleted. The intent + outcome pair is the recovery contract: it tells you *what was attempted* and *how far it got*, but does not roll back. Pre-GAP-002 entries (no `phase` field) read back as `phase="outcome"` with `operation_id=""` and `status=null` for backward compatibility.
 
@@ -229,9 +229,13 @@ The outcome line's `embeddings_removed` is the real number of rows dropped from
 The outcome line also carries `intimate_stubs_removed` (GAP-012): the
 number of intimate-body stub files under
 `10-Liminal/Compost/intimate-stubs/` that the engine deleted because a
-purged note pointed at them via `saved_from.intimate_body_pointer`.
-Zero for notes that carry no pointer; a dry-run reports what *would* be
-removed without touching disk.
+purged note pointed at them via `saved_from.intimate_body_pointer`. The
+sweep is scoped to that directory: a pointer resolving anywhere else in
+the vault is refused and its target left untouched, so the pointer can
+never be used to steer a delete at an arbitrary vault file. Zero for
+notes that carry no pointer, and the counter is not incremented for a
+refused pointer either — in a dry run or a real one. A dry-run
+otherwise reports what *would* be removed without touching disk.
 
 `creek redact --apply` writes alongside it at `<vault>/00-Creek-Meta/audit/redact.jsonl`. Privacy-tier overrides (e.g. `creek mine --include-tier intimate`) write to `<vault>/00-Creek-Meta/audit/privacy.jsonl`. Operational provenance from ingestion stays at `<vault>/00-Creek-Meta/Processing-Log/provenance.jsonl` (separate location: not compliance-grade, allowed to be lossy).
 

--- a/creek-tools/docs/save.md
+++ b/creek-tools/docs/save.md
@@ -79,7 +79,12 @@ When you later delete an intimate note with a scoped `creek purge`
 (`fragment` / `source` / `daterange`), the purge engine follows the
 note's `saved_from.intimate_body_pointer` and deletes the stub too, so
 the full intimate body does not survive a right-to-be-forgotten request
-(GAP-012). See [Purge](cleaning-and-purge.md#purge-right-to-be-forgotten).
+(GAP-012) — but only when the pointer resolves inside
+`10-Liminal/Compost/intimate-stubs/`; a pointer aimed anywhere else is
+refused and nothing is deleted. Accepted side effect: a hand-authored
+stub parked outside that directory survives the purge and must be
+removed explicitly. See
+[Purge](cleaning-and-purge.md#purge-right-to-be-forgotten).
 
 ### Tier defaulting
 

--- a/creek-tools/tests/test_purge.py
+++ b/creek-tools/tests/test_purge.py
@@ -676,6 +676,450 @@ def test_fragment_purge_intimate_stub_outside_vault_skipped(
 
 
 # ---------------------------------------------------------------------------
+# Engine tests — intimate stub pointer containment (#950)
+# ---------------------------------------------------------------------------
+
+_INTIMATE_STUB_DIR = "10-Liminal/Compost/intimate-stubs"
+"""The only directory an ``intimate_body_pointer`` may delete from (#950)."""
+
+_VAULT_CONFIG_RELPATH = "00-Creek-Meta/creek_config.yaml"
+"""In-vault victim proving a hand-edited pointer is refused, not followed."""
+
+_PURGE_AUDIT_RELPATH = "00-Creek-Meta/audit/purge.jsonl"
+"""The audit log — a live in-vault file mid-purge, so a reachable victim."""
+
+_NUL_YAML_ESCAPE = r"\0"
+"""Two-character YAML escape that PyYAML decodes to a real NUL on load."""
+
+
+def _write_note_with_nul_stub_pointer(
+    vault: Path,
+    frag_id: str,
+    title: str,
+) -> Path:
+    """Hand-write an intimate note whose stub pointer holds a NUL byte.
+
+    ``frontmatter.dumps`` cannot be used here: PyYAML's emitter refuses
+    to serialise a control character, so a NUL put on a
+    :class:`frontmatter.Post` never survives the round-trip. The
+    markdown is therefore written by hand with the pointer as a
+    double-quoted YAML scalar carrying :data:`_NUL_YAML_ESCAPE`, which
+    PyYAML *decodes* back into a real NUL when the engine loads the
+    note.
+
+    Args:
+        vault: Vault root.
+        frag_id: Fragment ID for the note's frontmatter.
+        title: Note title (also the note's filename stem).
+
+    Returns:
+        Path to the written note.
+    """
+    pointer = f"{_INTIMATE_STUB_DIR}/{title}{_NUL_YAML_ESCAPE}.md"
+    note_path = vault / "01-Fragments" / "Conversations" / f"{title}.md"
+    note_path.parent.mkdir(parents=True, exist_ok=True)
+    note_path.write_text(
+        f"""---
+id: {frag_id}
+title: {title}
+type: fragment
+privacy_tier: intimate
+saved_from:
+  source_kind: answer
+  intimate_body_pointer: "{pointer}"
+---
+(intimate body withheld)
+""",
+        encoding="utf-8",
+    )
+    return note_path
+
+
+def _write_journal_fragment_with_nul_origin_key(
+    vault: Path,
+    frag_id: str,
+    title: str,
+) -> Path:
+    """Hand-write a journal fragment whose ``origin_key`` holds a NUL byte.
+
+    The ``source.origin_key`` twin of
+    :func:`_write_note_with_nul_stub_pointer`, and hand-written for the
+    same reason — PyYAML's emitter will not round-trip a NUL, so the
+    escape has to go into the file as literal YAML text.
+
+    Args:
+        vault: Vault root.
+        frag_id: Fragment ID for the fragment's frontmatter.
+        title: Fragment title (also the fragment's filename stem).
+
+    Returns:
+        Path to the written fragment.
+    """
+    key = f"{_JOURNAL_STAGING_DIR}/{title}{_NUL_YAML_ESCAPE}.md"
+    frag_path = vault / "01-Fragments" / "Journal" / f"{title}.md"
+    frag_path.parent.mkdir(parents=True, exist_ok=True)
+    frag_path.write_text(
+        f"""---
+id: {frag_id}
+title: {title}
+type: fragment
+privacy_tier: intimate
+source:
+  platform: journal
+  origin_key: "{key}"
+---
+A journal fragment summary.
+""",
+        encoding="utf-8",
+    )
+    return frag_path
+
+
+def test_fragment_purge_refuses_stub_pointer_at_vault_config(
+    tmp_path: Path,
+) -> None:
+    """A stub pointer aimed at the vault config never deletes it (#950).
+
+    ``intimate_body_pointer`` is vault *content*: an operator (or an
+    attacker who can write one note) can retarget it at any file. The
+    only containment today is "inside the vault root", which every
+    in-vault file trivially satisfies — so the pointer becomes an
+    arbitrary in-vault delete primitive driven by a purge. Deleting
+    ``creek_config.yaml`` also disarms the GAP-003 marker check that
+    guards ``purge vault``. The stub sweep must be scoped to
+    ``10-Liminal/Compost/intimate-stubs/`` and refuse anything else,
+    while still purging the note that carried the bad pointer.
+    """
+    vault = _make_vault(tmp_path)
+    config = vault / _VAULT_CONFIG_RELPATH
+    config_bytes_before = config.read_bytes()
+    note, _stub = _write_intimate_note_with_stub(
+        vault,
+        "frag-A",
+        "Alpha",
+        stub_relpath=_VAULT_CONFIG_RELPATH,
+        write_stub=False,
+    )
+    engine = PurgeEngine(vault)
+
+    result = engine.purge_fragment("frag-A")
+
+    assert config.exists()
+    assert config.read_bytes() == config_bytes_before
+    assert result.intimate_stubs_removed == 0
+    # The refusal is scoped to the stub sweep: the note itself is still
+    # purged, so the RTBF request is honoured.
+    assert not note.exists()
+
+
+def test_fragment_purge_refuses_stub_pointer_at_sibling_fragment(
+    tmp_path: Path,
+) -> None:
+    """Purging one note must not take a sibling fragment with it (#950).
+
+    The worst form of the containment bug: purging fragment A silently
+    destroys unrelated fragment B, so a single RTBF request becomes
+    collateral data loss the operator never asked for and the audit log
+    never names (B is not in ``affected_fragments``). Bravo must survive
+    byte-identical and stay independently purgeable afterwards.
+    """
+    vault = _make_vault(tmp_path)
+    bravo = _write_fragment(vault, "frag-B", "Bravo")
+    bravo_bytes_before = bravo.read_bytes()
+    note, _stub = _write_intimate_note_with_stub(
+        vault,
+        "frag-A",
+        "Alpha",
+        stub_relpath="01-Fragments/Conversations/Bravo.md",
+        write_stub=False,
+    )
+
+    result = PurgeEngine(vault).purge_fragment("frag-A")
+
+    assert result.intimate_stubs_removed == 0
+    assert not note.exists()
+    assert bravo.exists()
+    assert bravo.read_bytes() == bravo_bytes_before
+
+    # Bravo is untouched, not merely present: it is still a live
+    # fragment the engine can find and purge on its own terms.
+    second = PurgeEngine(vault).purge_fragment("frag-B")
+
+    assert second.fragments_affected == 1
+    assert not bravo.exists()
+
+
+def test_fragment_purge_refuses_stub_pointer_at_audit_log(
+    tmp_path: Path,
+) -> None:
+    """A stub pointer must not be able to erase the purge audit log (#950).
+
+    The GAP-002 ``intent`` line is written *before* the destructive
+    body, so ``00-Creek-Meta/audit/purge.jsonl`` is a live file by the
+    time the stub sweep runs — a pointer aimed at it unlinks the
+    forensic record of the very purge in flight, and the following
+    ``outcome`` append silently restarts the chain from genesis. The
+    surviving log must be the complete intent+outcome pair with an
+    intact hash chain.
+    """
+    vault = _make_vault(tmp_path)
+    note, _stub = _write_intimate_note_with_stub(
+        vault,
+        "frag-A",
+        "Alpha",
+        stub_relpath=_PURGE_AUDIT_RELPATH,
+        write_stub=False,
+    )
+
+    result = PurgeEngine(vault).purge_fragment("frag-A")
+
+    assert result.intimate_stubs_removed == 0
+    assert not note.exists()
+    log = PurgeAuditLog(vault)
+    entries = log.read()
+    assert [entry.phase for entry in entries] == ["intent", "outcome"]
+    assert entries[1].status == "complete"
+    log.verify()
+
+
+def test_fragment_purge_refuses_stub_pointer_escaping_stub_dir_via_relative_walk(
+    tmp_path: Path,
+) -> None:
+    """``..`` inside the stub dir cannot walk back out to a vault file (#950).
+
+    This is the test that proves the new guard is real containment
+    rather than a string-prefix check: the pointer *starts* with the
+    canonical stub directory and still lands on the vault config after
+    resolution. It also passes the existing vault-root guard untouched,
+    so only a guard applied to the **resolved** path stops it.
+    """
+    vault = _make_vault(tmp_path)
+    config = vault / _VAULT_CONFIG_RELPATH
+    config_bytes_before = config.read_bytes()
+    note, _stub = _write_intimate_note_with_stub(
+        vault,
+        "frag-A",
+        "Alpha",
+        stub_relpath=f"{_INTIMATE_STUB_DIR}/../../../{_VAULT_CONFIG_RELPATH}",
+        write_stub=False,
+    )
+
+    result = PurgeEngine(vault).purge_fragment("frag-A")
+
+    assert config.exists()
+    assert config.read_bytes() == config_bytes_before
+    assert result.intimate_stubs_removed == 0
+    assert not note.exists()
+
+
+def test_fragment_purge_dry_run_refuses_out_of_scope_stub_pointer(
+    tmp_path: Path,
+) -> None:
+    """A dry run must not *preview* an out-of-scope stub deletion (#950).
+
+    ``--dry-run`` is the operator's decision aid before an irreversible
+    purge. Counting a file the real run must refuse to touch both
+    overstates the blast radius and, worse, tells the operator the
+    engine considers that file in scope — so the containment guard has
+    to run before the counter, not just before the ``unlink``.
+    """
+    vault = _make_vault(tmp_path)
+    config = vault / _VAULT_CONFIG_RELPATH
+    config_bytes_before = config.read_bytes()
+    _write_intimate_note_with_stub(
+        vault,
+        "frag-A",
+        "Alpha",
+        stub_relpath=_VAULT_CONFIG_RELPATH,
+        write_stub=False,
+    )
+
+    result = PurgeEngine(vault, dry_run=True).purge_fragment("frag-A")
+
+    assert result.intimate_stubs_removed == 0
+    assert config.exists()
+    assert config.read_bytes() == config_bytes_before
+
+
+def test_refused_stub_pointer_warning_does_not_echo_resolved_target(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Refusing a pointer is logged, but without an existence oracle (#950).
+
+    Two properties at once. The refusal must be operator-visible at
+    WARNING — a silently ignored pointer is indistinguishable from a
+    sweep that never ran. And the message must not echo the *resolved*
+    victim path: the refusal is triggered by attacker-controlled
+    frontmatter, so echoing the absolute path it resolved to turns the
+    log into a filesystem oracle. Asserts on level and on the absence
+    of the resolved path only — never on wording.
+    """
+    vault = _make_vault(tmp_path)
+    _write_intimate_note_with_stub(
+        vault,
+        "frag-A",
+        "Alpha",
+        stub_relpath=_VAULT_CONFIG_RELPATH,
+        write_stub=False,
+    )
+    resolved_victim = str((vault / _VAULT_CONFIG_RELPATH).resolve())
+    engine = PurgeEngine(vault)
+
+    with caplog.at_level(logging.WARNING, logger="creek.purge.engine"):
+        engine.purge_fragment("frag-A")
+
+    refusals = [
+        record
+        for record in caplog.records
+        if record.name == "creek.purge.engine" and record.levelno == logging.WARNING
+    ]
+    assert len(refusals) >= 1
+    echoing = [
+        record for record in caplog.records if resolved_victim in record.getMessage()
+    ]
+    assert echoing == []
+
+
+def test_fragment_purge_removes_nested_intimate_stub(tmp_path: Path) -> None:
+    """A stub nested under the stub dir is still swept (#950 no-regression).
+
+    The containment guard must be a ``is_relative_to`` containment test,
+    not an exact-parent-directory comparison: ``creek save`` is free to
+    shard stubs into subdirectories, and a guard that only accepted the
+    stub root would silently start leaking every nested intimate body
+    past an RTBF request. Green before and after the fix.
+    """
+    vault = _make_vault(tmp_path)
+    note, stub = _write_intimate_note_with_stub(
+        vault,
+        "frag-A",
+        "Alpha",
+        stub_relpath=f"{_INTIMATE_STUB_DIR}/2026/Alpha.md",
+    )
+
+    result = PurgeEngine(vault).purge_fragment("frag-A")
+
+    assert result.intimate_stubs_removed == 1
+    assert not note.exists()
+    assert not stub.exists()
+
+
+def test_fragment_purge_refuses_absolute_stub_pointer(tmp_path: Path) -> None:
+    """An absolute stub pointer is refused, not followed (#950).
+
+    Pins a pathlib footgun on a deletion path: ``Path("/vault") /
+    "/etc/passwd"`` discards the left operand entirely and evaluates to
+    ``Path("/etc/passwd")``, so an absolute pointer silently escapes the
+    vault at the *join*, before any guard sees it. The vault-root
+    containment check catches it today; this test stops a future
+    refactor (e.g. swapping the join for ``os.path.join``-style
+    concatenation, or guarding the raw pointer instead of the resolved
+    path) from quietly reintroducing the escape.
+    """
+    vault = _make_vault(tmp_path)
+    outsider = tmp_path / "absolute-outsider.md"
+    outsider.write_text("not a stub\n", encoding="utf-8")
+    outsider_bytes_before = outsider.read_bytes()
+    note, _stub = _write_intimate_note_with_stub(
+        vault,
+        "frag-A",
+        "Alpha",
+        stub_relpath=str(outsider),
+        write_stub=False,
+    )
+
+    result = PurgeEngine(vault).purge_fragment("frag-A")
+
+    assert outsider.exists()
+    assert outsider.read_bytes() == outsider_bytes_before
+    assert result.intimate_stubs_removed == 0
+    assert not note.exists()
+
+
+def test_fragment_purge_stub_pointer_at_stub_root_itself_is_noop(
+    tmp_path: Path,
+) -> None:
+    """A pointer naming the stub *directory* deletes nothing (#950).
+
+    ``is_relative_to`` treats a path as relative to itself, so the
+    canonical stub root passes the containment guard on its own. Nothing
+    is removed only because the engine additionally requires the target
+    to be a regular file. That distinction is what stops a directory
+    pointer from ever reaching ``unlink``, so pin it explicitly rather
+    than leaving the safe outcome incidental.
+    """
+    vault = _make_vault(tmp_path)
+    stub_root = vault / _INTIMATE_STUB_DIR
+    stub_root.mkdir(parents=True, exist_ok=True)
+    bystander = stub_root / "Unrelated.md"
+    bystander.write_text("another intimate body\n", encoding="utf-8")
+    note, _stub = _write_intimate_note_with_stub(
+        vault,
+        "frag-A",
+        "Alpha",
+        stub_relpath=_INTIMATE_STUB_DIR,
+        write_stub=False,
+    )
+
+    result = PurgeEngine(vault).purge_fragment("frag-A")
+
+    assert result.intimate_stubs_removed == 0
+    assert stub_root.is_dir()
+    assert bystander.exists()
+    assert not note.exists()
+
+
+def test_fragment_purge_nul_byte_stub_pointer_is_noop(tmp_path: Path) -> None:
+    """A NUL byte in the stub pointer is a no-op, never an error (#950).
+
+    ``Path.resolve()`` raises :class:`ValueError` (``embedded null
+    byte``) rather than ``OSError`` for a NUL, so an unguarded resolve
+    escapes the documented "a bad pointer is a no-op" contract: the
+    exception aborts the purge body, the fragment is never unlinked,
+    and the audit closes ``status="partial"``. One byte of hostile
+    frontmatter therefore blocks the RTBF deletion it was attached to.
+    """
+    vault = _make_vault(tmp_path)
+    note = _write_note_with_nul_stub_pointer(vault, "frag-A", "Alpha")
+    loaded = frontmatter.load(str(note))
+    # Guard against a vacuous pass: the escape must really have decoded
+    # to a NUL, or this test proves nothing about NUL handling.
+    assert "\x00" in loaded["saved_from"]["intimate_body_pointer"]
+
+    result = PurgeEngine(vault).purge_fragment("frag-A")
+
+    assert result.intimate_stubs_removed == 0
+    assert not note.exists()
+    entries = PurgeAuditLog(vault).read()
+    assert [entry.phase for entry in entries] == ["intent", "outcome"]
+    assert entries[1].status == "complete"
+
+
+def test_fragment_purge_nul_byte_origin_key_is_noop(tmp_path: Path) -> None:
+    """A NUL byte in ``source.origin_key`` is a no-op, never an error (#950).
+
+    The journal-staging twin of the stub-pointer case: the same
+    unguarded ``Path.resolve()`` sits in ``_purge_journal_staged_entry``,
+    so a NUL in the origin key aborts the purge of an intimate journal
+    fragment with a bare :class:`ValueError` instead of skipping the
+    unusable key and deleting the fragment.
+    """
+    vault = _make_vault(tmp_path)
+    frag = _write_journal_fragment_with_nul_origin_key(vault, "frag-J", "entry-one")
+    loaded = frontmatter.load(str(frag))
+    assert "\x00" in loaded["source"]["origin_key"]
+
+    result = PurgeEngine(vault).purge_fragment("frag-J")
+
+    assert result.journal_staged_removed == 0
+    assert not frag.exists()
+    entries = PurgeAuditLog(vault).read()
+    assert [entry.phase for entry in entries] == ["intent", "outcome"]
+    assert entries[1].status == "complete"
+
+
+# ---------------------------------------------------------------------------
 # Engine tests — journal staged-entry sweep (#845)
 # ---------------------------------------------------------------------------
 
@@ -2578,6 +3022,13 @@ def test_purge_vault_outcome_status_partial_on_exception(
     log gets an outcome line saying what survived (intent already wrote
     what was being attempted; outcome closes the trail with the partial
     state).
+
+    ``failure_reason`` is the exception **type name only** (#950). The
+    audit log is deliberately preserved by every purge, so anything
+    written into it outlives the right-to-be-forgotten request that
+    produced it — and an exception message raised mid-wipe routinely
+    quotes vault-derived text (a path, a title, a YAML snippet). The
+    type is the whole forensic value; the message is the leak.
     """
     import shutil as shutil_mod
 
@@ -2611,7 +3062,50 @@ def test_purge_vault_outcome_status_partial_on_exception(
     assert outcome.status == "partial"
     assert intent.operation_id == outcome.operation_id
     assert outcome.failure_reason
-    assert "simulated mid-purge" in outcome.failure_reason
+    assert outcome.failure_reason == "OSError"
+    assert "simulated mid-purge" not in outcome.failure_reason
+
+
+_SYNTHETIC_EXCEPTION_MARKER = "synthetic-vault-title-950"
+"""Stands in for vault-derived text riding inside an exception message."""
+
+
+def test_partial_outcome_audit_never_writes_exception_message(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed purge must not copy exception text into the audit log (#950).
+
+    ``00-Creek-Meta/`` is deliberately preserved by every purge —
+    including ``purge vault`` — so the audit log is the one file a
+    right-to-be-forgotten request cannot reach. An exception raised
+    mid-wipe carries a message the vault supplied (``OSError`` on a
+    delete quotes the path; a YAML error quotes the offending source
+    line), and today that message is interpolated straight into
+    ``failure_reason``. The marker must therefore reach neither the
+    parsed entry nor the raw bytes on disk.
+    """
+    vault = _make_vault(tmp_path)
+    _write_fragment(vault, "frag-A", "Alpha")
+    _write_thread(vault, "thread-1", "Waves")
+
+    def leaky_rmtree(*_args: object, **_kwargs: object) -> None:
+        """Abort the wipe with vault-derived text in the message."""
+        msg = _SYNTHETIC_EXCEPTION_MARKER
+        raise OSError(msg)
+
+    monkeypatch.setattr("creek.purge.engine.shutil.rmtree", leaky_rmtree)
+
+    with pytest.raises(OSError, match=_SYNTHETIC_EXCEPTION_MARKER):
+        PurgeEngine(vault).purge_vault(VAULT_PURGE_CONFIRMATION)
+
+    entries = _entries_for_run(vault)
+    assert len(entries) == 2
+    outcome = entries[1]
+    assert outcome.status == "partial"
+    assert outcome.failure_reason == "OSError"
+    audit_text = (vault / _PURGE_AUDIT_RELPATH).read_text(encoding="utf-8")
+    assert _SYNTHETIC_EXCEPTION_MARKER not in audit_text
 
 
 def test_purge_fragment_emits_intent_then_outcome_pair(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`PurgeEngine._purge_intimate_stub` resolved `saved_from.intimate_body_pointer` and guarded it with **only** `is_relative_to(vault_root)` before calling `unlink(missing_ok=True)`. Any hand-edited pointer aimed at another path *inside* the vault — `00-Creek-Meta/creek_config.yaml`, an unrelated fragment, the audit log — passed that sole guard and the victim file was deleted. That was an arbitrary in-vault file-deletion primitive reachable today through any ordinary valid-UTF-8 fragment.

The sibling `_purge_journal_staged_entry` was already correct: it scopes deletion to the journal staging dir with a second guard. **That sibling is the model this PR follows** — no departure from its shape.

Three findings from #950, all in `creek/purge/engine.py`:

1. **Containment (the P1).** A second guard requires the **resolved** stub path to be under `10-Liminal/Compost/intimate-stubs/` (`INTIMATE_STUB_RELPATH`, the existing single source of truth). It runs *before* the counter increment, so a dry run cannot preview a deletion the real run would refuse. Guarding the resolved path means an `intimate-stubs/../../../00-Creek-Meta/creek_config.yaml` walk is refused too; using `is_relative_to` means a legitimately nested stub is still swept.
2. **NUL byte.** An embedded NUL made `Path.resolve()` raise an uncaught `ValueError` that aborted the entire purge, violating the documented "a missing or bad pointer is skipped, never an error" contract. A new shared helper `_resolve_pointer_in_vault(pointer, *, field)` owns join + resolve + vault-root guard for **both** sweeps and catches exactly `(OSError, ValueError)` around the resolve alone.
3. **Audit leak.** `_run_audited` wrote `f"{type(exc).__name__}: {exc}"` into the deliberately **non-purgeable** audit log, so vault-derived exception text (a title-derived filename, a `yaml.MarkedYAMLError` source snippet) outlived the RTBF request that produced it. Now the type name only — matching the rule #910 set for the logger on this same module. The full message still propagates on the exception, and `creek purge` does not swallow it.

**Fail closed.** Every new branch either refuses or behaves exactly as before; nothing is ever deleted that was not deleted before. One deliberate, documented side effect: a hand-authored stub parked *outside* the canonical directory now survives a purge. That is the safe direction — the note itself is still deleted, so the RTBF request is honoured, and the operator can remove the stray file explicitly.

**No config oracle.** Refusal warnings name only the raw (attacker-controlled) pointer and the caller-supplied root — never the resolved victim path — so the log cannot be turned into a filesystem existence oracle. A test pins this.

Does not touch `_load_frontmatter` / `_load_frontmatter_for_match` / `_load_frontmatter_lossily`: PR #951's write-safety split and its byte-identity tests are left fully intact.

## Test plan

Gate 1 RED was proven by data loss, not by an incidental counter — on `main` these tests fail with `00-Creek-Meta/creek_config.yaml` genuinely deleted from the vault.

12 new tests, plus one existing test strengthened:

- Refuses a pointer at the vault config, at a sibling fragment, and at the audit log (each asserts the victim survives **byte-identical**; the audit-log case also asserts the intent+outcome pair survives and `verify()` holds).
- Refuses a `..` walk back out of the stub dir — the test that proves this is resolved-path containment, not a string-prefix check.
- Dry run refuses out-of-scope pointers (counter stays 0).
- Refusal warning does not echo the resolved victim path (asserts level + absence, never wording).
- Absolute-path pointer refused — pins the `Path("/vault") / "/etc/passwd"` footgun, where the join discards the left operand entirely.
- Pointer naming the stub root itself is a no-op.
- Nested stub (`intimate-stubs/2026/Alpha.md`) still swept — green before and after, so an exact-parent-equality guard would fail it.
- NUL byte in `intimate_body_pointer` and in `source.origin_key` are both no-ops that complete the purge with `status="complete"`. Both hand-write the markdown (PyYAML's emitter will not round-trip a NUL) and assert the loaded pointer really contains `\x00` *before* purging, so they cannot pass vacuously.
- `failure_reason == "OSError"` with the message absent from the audit log file on disk (the RTBF assertion). The existing partial-outcome test was strengthened, not weakened: `assert outcome.failure_reason` is kept and a `not in` assertion added.

No test depends on `rglob` visit order.

Gate 2: `./scripts/check-all.sh` exits **0** — 12/12 checks, 6345 passed, coverage 93.97%. Gate 2.5: `code-review-orchestrator` returned **CLEAN**; its three non-blocking coverage suggestions were folded in (absolute-path and stub-root-itself tests) rather than deferred.

Closes #950

🤖 Generated with [Claude Code](https://claude.com/claude-code)