### PR TITLE
fix(ingest): derive generic fragment id from file mtime, not wall clock

### DIFF
--- a/creek-tools/README.md
+++ b/creek-tools/README.md
@@ -242,7 +242,7 @@ The ingestion pipeline currently ships **11** registered `Ingestor`s plus a read
 
 `claude`, `chatgpt`, `discord`, `code`, `document` (.docx / .pdf), `markdown`, `spreadsheet` (.xlsx / .csv), `presentation` (.pptx), `image` (with OCR), `substack` (newsletter exports), and `generic` (fallback for unknown text).
 
-`gdrive` is a downloader, not an ingestor — it stages files locally and dispatches each one to the appropriate ingestor by extension. The `other` enum value on `SourcePlatform` is reserved for downstream consumers (e.g. fragments synthesised from praxes) and has no parser.
+`gdrive` is a downloader, not an ingestor — it stages files locally and dispatches each one to the appropriate ingestor by extension. The `other` enum value on `SourcePlatform` is what the `generic` fallback ingestor writes, and it also covers downstream consumers (e.g. fragments synthesised from praxes).
 
 Each ingestor follows the same four-stage contract — `discover` → `parse` → `convert_to_markdown` → `generate_frontmatter` — and writes one fragment per logical unit (per chat thread, per sheet, per slide deck, per file). See [`docs/ingestion.md`](docs/ingestion.md) for which is right for which export.
 

--- a/creek-tools/creek/ingest/generic.py
+++ b/creek-tools/creek/ingest/generic.py
@@ -4,7 +4,7 @@ Handles files that are not claimed by any specialized ingestor (Markdown,
 ChatGPT, Claude, Discord).  Attempts text reading with multiple encoding
 strategies (UTF-8, UTF-16, Latin-1, chardet fallback), skips binary files,
 and routes unclassified content to ``01-Fragments/Unsorted/`` with
-``source.platform: "unknown"`` in frontmatter.
+``source.platform: "other"`` in frontmatter.
 
 Exports:
     GenericIngestor: Concrete ``Ingestor`` subclass for unclaimed files.
@@ -30,6 +30,7 @@ from creek.ingest.base import (
     file_modified_time,
     normalize_encoding,
 )
+from creek.models import SourcePlatform
 
 logger = logging.getLogger(__name__)
 
@@ -139,7 +140,7 @@ class GenericIngestor(Ingestor):
     Discovers all files whose extensions are not in ``_CLAIMED_EXTENSIONS``,
     attempts multi-encoding text decoding, skips binary files, and routes
     successfully parsed content to ``01-Fragments/Unsorted/`` with
-    ``source.platform: "unknown"``.
+    ``source.platform: "other"``.
     """
 
     def discover(self, source_path: Path) -> list[RawDocument]:
@@ -226,6 +227,30 @@ class GenericIngestor(Ingestor):
         on disk: those produce ``authored_at = None`` rather than
         raising.
 
+        Issue #911 — re-ingest identity contract. The mtime is stamped on
+        ``timestamp`` as well, because
+        :func:`creek.ingest.base.generate_fragment_id` hashes
+        ``timestamp.isoformat()``: keying it on ``datetime.now()`` made every
+        re-ingest of an *unchanged* file mint a fresh id and write a duplicate
+        fragment. Derived from the mtime, an unchanged file re-ingests to the
+        same deterministic id and the write is a no-op.
+
+        The mtime is used verbatim in UTC — never converted to
+        :data:`~creek.ingest.base.LA_TZ` — because the UTC offset string is
+        part of the hashed input. ``datetime.fromtimestamp(st_mtime, tz=UTC)``
+        is a pure function of the epoch float, so identity does not vary with
+        the host's tzdata, ``TZ`` env var, or DST state; rendering in LA would
+        bake ``-07:00``/``-08:00`` into the hash.
+
+        Known limitation: the generic source has no ingest ledger, so a bare
+        ``touch`` (or any edit) bumps the mtime and therefore mints a new
+        fragment rather than updating the existing one. Ledger-backed
+        update-in-place is tracked in issue #953.
+
+        The wall clock survives only as the fallback for the pathless /
+        synthetic case where ``stat()`` fails: there is no mtime to key on, so
+        ``timestamp`` is ``now`` and ``authored_at`` stays honestly ``None``.
+
         Args:
             raw: The raw document to parse.
 
@@ -244,8 +269,10 @@ class GenericIngestor(Ingestor):
         if not text.strip():
             return []
 
-        now = datetime.now(tz=LA_TZ)
+        # One stat, two uses: the same mtime is both the honest authored_at and
+        # the identity-bearing timestamp (issue #911). Kept in UTC verbatim.
         authored_at = _safe_file_mtime(raw.path)
+        timestamp = authored_at if authored_at is not None else datetime.now(tz=LA_TZ)
         return [
             ParsedFragment(
                 content=text,
@@ -255,7 +282,7 @@ class GenericIngestor(Ingestor):
                     "authored_at": authored_at,
                 },
                 source_path=str(raw.path),
-                timestamp=now,
+                timestamp=timestamp,
             )
         ]
 
@@ -282,11 +309,25 @@ class GenericIngestor(Ingestor):
     def generate_frontmatter(self, fragment: ParsedFragment) -> dict[str, Any]:
         """Generate YAML frontmatter for an unclaimed file.
 
-        Sets ``source.platform`` to ``"unknown"`` and routes to
-        ``01-Fragments/Unsorted/``. FEAT-031 (issue #335): emits
-        ``authored_at`` as an ISO string when the parse stage
-        captured the file's mtime; omits the key when the metadata
-        value is missing or ``None`` (honest absence).
+        Sets ``source.platform`` to :data:`~creek.models.SourcePlatform.OTHER`
+        (``"other"``) and routes to ``01-Fragments/Unsorted/``. Issue #911:
+        this previously emitted ``"unknown"``, which is not a
+        :class:`~creek.models.SourcePlatform` member at all, so
+        ``assemble_ingested_fragment`` raised a pydantic ``ValidationError``
+        that ``run_ingest`` swallowed into ``result.errors`` — generic
+        fragments never reached the vault. ``OTHER`` is the enum's fallback
+        member and maps to the same ``Unsorted`` subfolder, so the routing
+        target is unchanged.
+
+        FEAT-031 (issue #335): emits ``authored_at`` as an ISO string
+        when the parse stage captured the file's mtime; omits the key
+        when the metadata value is missing or ``None`` (honest absence).
+
+        ``created`` is the parse-stage ``timestamp``, i.e. the file's mtime in
+        UTC since #911. That is deliberate: :mod:`creek.time` documents that
+        ``created`` is not part of the authored-at precedence chain (all
+        time-bucketing routes through ``effective_authored_at``), and the other
+        file-based ingestors already key on mtime.
 
         Args:
             fragment: The parsed fragment.
@@ -299,7 +340,7 @@ class GenericIngestor(Ingestor):
             "type": "fragment",
             "title": title,
             "source": {
-                "platform": "unknown",
+                "platform": SourcePlatform.OTHER,
                 "original_file": fragment.source_path,
             },
             "created": fragment.timestamp.isoformat(),

--- a/creek-tools/docs/ingestion.md
+++ b/creek-tools/docs/ingestion.md
@@ -59,6 +59,14 @@ creek ingest --type code         --input ~/projects/diary     --vault ~/Obsidian
 - The OCR backend is **injectable**: swap in a different engine by implementing `creek.ingest.images.OcrEngine` and passing it to `ImageIngestor(backend=…)`. Useful for tests and for trying alternative OCR engines.
 - Confidence below `OCRConfig.min_confidence` lands the fragment in the review queue.
 
+## Generic (`generic`)
+
+- Fallback for any file whose extension no other ingestor claims (`.txt`, `.log`, plain text, and anything not in the specialized ingestors' extension sets). Binary files (detected via a null-byte / control-character heuristic) and empty or whitespace-only files are skipped — no fragment is written.
+- Routes to `01-Fragments/Unsorted/` with `source.platform: other` (`SourcePlatform.OTHER`).
+- The fragment id is derived from the file's **mtime**, not the wall-clock time you ran `creek ingest` — re-ingesting an unchanged file reuses the same mtime and therefore the same id, so the write is a genuine no-op. (Wall clock is used only as a fallback for a pathless/synthetic document where `stat()` fails.)
+- `created` and `authored_at` in the frontmatter are both the file's mtime, kept in UTC.
+- Known limitation: this source has no ingest ledger (see [Idempotency](#idempotency)), so a bare `touch` — or any edit — bumps the mtime and mints a *new* fragment rather than updating the existing one. Tracked in [#953](https://github.com/Geoffe-Ga/Creek-Vault/issues/953).
+
 ## Google Drive
 
 `creek gdrive` is a **read-only** Drive mirror. It uses OAuth, caches the refresh token at `GoogleDriveConfig.token_file` (`0o600`), and writes nothing back to Drive.
@@ -79,7 +87,9 @@ Subsequent `--download` runs are **incremental** — unchanged files are skipped
 
 ## Idempotency
 
-Every ingestor produces deterministic fragment IDs (`SHA-256(source, timestamp, content)[:12]`), so re-running `creek ingest` against the same input only writes fragments whose content has actually changed. This is what lets `creek process` be safe to run on a cron.
+Fragment IDs are deterministic — `SHA-256(source, timestamp, content)[:12]` — so identity is stable only if `timestamp` is. Every ingestor derives `timestamp` from the source itself rather than from wall clock: the message's own epoch for conversation exports (Claude/ChatGPT/Discord), and the file's own metadata (frontmatter date, creation time, or modification time, depending on the ingestor) for file-based sources. Re-running `creek ingest` against unchanged input reuses the same ids and writes nothing new, which is what lets `creek process` be safe to run on a cron.
+
+The caveat: a source keyed on mtime treats *any* filesystem touch as a change, not just a meaningful edit — see [Generic](#generic-generic) for the concrete case. Ledger-backed sources avoid this: the markdown (journal) source tracks a stable `source_key` per file in a per-source ledger and, on a changed mtime, **updates the existing fragment in place** (preserving its id, classifications, and links) instead of minting a duplicate — see [`docs/idempotent-ingest.md`](idempotent-ingest.md). `generic` doesn't have a ledger yet, so for it, mtime-keyed identity only buys "unchanged file re-ingests as a no-op," not "edited file updates in place" ([#953](https://github.com/Geoffe-Ga/Creek-Vault/issues/953)).
 
 ## AI-chat attribution (per turn)
 

--- a/creek-tools/tests/test_ingest_generic.py
+++ b/creek-tools/tests/test_ingest_generic.py
@@ -2,13 +2,16 @@
 
 Covers file discovery (excluding files claimed by specialized ingestors),
 multi-encoding parsing, binary file detection and skipping, Unsorted routing,
-and frontmatter generation with ``source.platform: "unknown"``.
+and frontmatter generation with ``source.platform: "other"``
+(:data:`creek.models.SourcePlatform.OTHER` — the enum's fallback member;
+issue #911 corrected the previously-emitted ``"unknown"``, which was not a
+member at all and made every generic fragment fail validation).
 """
 
 from __future__ import annotations
 
 import os
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from zoneinfo import ZoneInfo
 
@@ -20,6 +23,7 @@ from creek.ingest.generic import (
     _is_binary_content,
     _try_decode,
 )
+from creek.models import SourcePlatform
 
 LA_TZ = ZoneInfo("America/Los_Angeles")
 
@@ -281,16 +285,38 @@ class TestGenericIngestorParse:
         fragments = ingestor.parse(raw)
         assert fragments[0].source_path == "/fake/note.txt"
 
-    def test_parse_sets_timestamp(self, ingestor: GenericIngestor) -> None:
-        """Parsed fragment should have a timestamp."""
+    def test_parse_sets_timestamp(
+        self, ingestor: GenericIngestor, tmp_path: Path
+    ) -> None:
+        """Parsed fragment timestamp is the file's mtime in UTC (issue #911).
+
+        Previously this only asserted ``isinstance(..., datetime)``, which the
+        wall-clock ``datetime.now()`` satisfied — and that unstable value is
+        hashed into the fragment id, so every re-ingest of an unchanged file
+        minted a new id. The timestamp must be the file's stable mtime, in UTC
+        so the hashed ``isoformat()`` does not vary with the host timezone.
+
+        Retargeted from a synthetic ``/fake/note.txt`` to a real file, because
+        the mtime contract only exists when there is a file to stat; the
+        synthetic wall-clock fallback is covered by
+        ``test_parse_returns_none_authored_at_for_nonexistent_path`` and by
+        ``tests/test_ingest_generic_idempotent.py``.
+        """
+        file_path = tmp_path / "note.txt"
+        file_path.write_text("content", encoding="utf-8")
+        target = datetime(2024, 3, 15, 14, 30, 0, tzinfo=UTC)
+        os.utime(file_path, (target.timestamp(), target.timestamp()))
+
         raw = RawDocument(
-            path=Path("/fake/note.txt"),
-            content=b"content",
+            path=file_path,
+            content=file_path.read_bytes(),
             metadata={"source_type": "generic"},
             detected_encoding="utf-8",
         )
         fragments = ingestor.parse(raw)
         assert isinstance(fragments[0].timestamp, datetime)
+        assert fragments[0].timestamp == target
+        assert fragments[0].timestamp.utcoffset() == timedelta(0)
 
     def test_parse_empty_file(self, ingestor: GenericIngestor) -> None:
         """Should return empty list for empty files."""
@@ -340,8 +366,17 @@ class TestGenericIngestorConvertToMarkdown:
 class TestGenericIngestorGenerateFrontmatter:
     """Tests for GenericIngestor.generate_frontmatter method."""
 
-    def test_sets_platform_to_unknown(self, ingestor: GenericIngestor) -> None:
-        """Frontmatter source.platform should be 'unknown'."""
+    def test_sets_platform_to_other(self, ingestor: GenericIngestor) -> None:
+        """Frontmatter source.platform is the SourcePlatform fallback 'other'.
+
+        Assertion correction (issue #911): this test previously pinned
+        ``"unknown"``, which is **not** a member of
+        :class:`creek.models.SourcePlatform`. Because the unit test only
+        inspected the raw dict, the now-known-wrong expectation stayed green
+        while every real ingest raised a pydantic ``ValidationError`` in
+        ``assemble_ingested_fragment`` and silently dropped the fragment.
+        ``OTHER`` routes to the same ``01-Fragments/Unsorted/`` folder.
+        """
         fragment = ParsedFragment(
             content="content",
             metadata={"file_extension": ".txt"},
@@ -349,7 +384,8 @@ class TestGenericIngestorGenerateFrontmatter:
             timestamp=datetime(2024, 1, 15, 10, 0, 0, tzinfo=LA_TZ),
         )
         fm = ingestor.generate_frontmatter(fragment)
-        assert fm["source"]["platform"] == "unknown"
+        assert fm["source"]["platform"] == "other"
+        assert SourcePlatform(fm["source"]["platform"]) is SourcePlatform.OTHER
 
     def test_sets_type_to_fragment(self, ingestor: GenericIngestor) -> None:
         """Frontmatter type should be 'fragment'."""

--- a/creek-tools/tests/test_ingest_generic_idempotent.py
+++ b/creek-tools/tests/test_ingest_generic_idempotent.py
@@ -1,0 +1,344 @@
+"""Idempotent re-ingest for :class:`creek.ingest.generic.GenericIngestor` (#911).
+
+``GenericIngestor.parse`` stamps ``timestamp=datetime.now(tz=LA_TZ)``, and that
+timestamp is hashed into the fragment id by
+:func:`creek.ingest.base.generate_fragment_id`
+(``f"{source}:{timestamp.isoformat()}:{content}"``). Every re-ingest of an
+*unchanged* file therefore mints a brand-new id and writes a brand-new fragment
+— unbounded duplicates. The stable answer is the file's mtime, which ``parse``
+already computes for ``metadata['authored_at']`` and then throws away.
+
+A second, independent defect blocks the acceptance test:
+``generate_frontmatter`` emits ``"platform": "unknown"``, which is **not** a
+member of :class:`creek.models.SourcePlatform` (the fallback member is
+``OTHER``). ``assemble_ingested_fragment`` therefore raises a pydantic
+``ValidationError``, ``run_ingest`` swallows it into ``result.errors``, and the
+fragment is silently dropped — generic fragments have never landed in a vault.
+That is why every assertion here pins ``errors == []`` *and* an exact count: a
+naive "ingest twice, count files" test would otherwise pass vacuously on
+``0 == 0``.
+
+Clock injection: there is no freezegun/time_machine in this repo, so the module
+attribute ``creek.ingest.generic.datetime`` is monkeypatched with an
+**advancing** fake. It must advance — a frozen clock would make the buggy code
+produce equal ids and destroy the RED. Only the ``creek.ingest.generic``
+attribute is patched; ``Ingestor.ingest`` calls ``datetime.now(tz=LA_TZ)`` for
+provenance and that call is correct. No test here depends on real elapsed time.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.ingest import INGESTOR_REGISTRY, generic
+from creek.ingest.base import LA_TZ, RawDocument, assemble_ingested_fragment
+from creek.ingest.generic import GenericIngestor
+from creek.ingest.pipeline import run_ingest
+from creek.models import SourcePlatform
+from creek.vault.writer import VaultWriter
+
+if TYPE_CHECKING:
+    from datetime import tzinfo
+
+    from creek.ingest.base import ParsedFragment
+    from creek.ingest.pipeline import IngestRunResult
+
+# Fake wall-clock start + step. The step MUST be non-zero: it is the thing that
+# makes the buggy `datetime.now()` id unstable and so the thing that makes these
+# tests a real RED rather than an accident of a coarse clock.
+_CLOCK_START = datetime(2026, 5, 1, 12, 0, 0, tzinfo=UTC)
+_CLOCK_STEP = timedelta(seconds=37)
+
+# Deterministic file mtimes. These are the values the fragment timestamp (and
+# therefore the fragment id) must be derived from.
+_PINNED_MTIME = datetime(2024, 3, 15, 14, 30, 0, tzinfo=UTC)
+_LATER_MTIME = datetime(2024, 6, 1, 9, 0, 0, tzinfo=UTC)
+
+_NOTE_BODY = "Idempotent generic ingest.\n"
+
+
+# ---- Fake clock ----
+
+
+class _AdvancingClock:
+    """Stand-in for the ``datetime`` class whose ``now()`` advances each call.
+
+    Only ``now()`` is exercised by :mod:`creek.ingest.generic` at runtime (the
+    module's other ``datetime`` references are annotations, which are strings
+    under ``from __future__ import annotations``), so a minimal duck-type is
+    enough and avoids depending on a time-freezing plugin the repo does not
+    have.
+    """
+
+    def __init__(self, start: datetime, step: timedelta) -> None:
+        """Start the clock at *start*, advancing by *step* on every ``now()``."""
+        self._current = start
+        self._step = step
+        self.ticks: list[datetime] = []
+
+    def now(self, tz: tzinfo | None = None) -> datetime:
+        """Return the next tick (converted to *tz*) and advance the clock."""
+        value = self._current
+        self._current = self._current + self._step
+        if tz is not None:
+            value = value.astimezone(tz)
+        self.ticks.append(value)
+        return value
+
+
+# ---- Fixtures ----
+
+
+@pytest.fixture()
+def ingestor() -> GenericIngestor:
+    """Create a GenericIngestor instance for testing."""
+    return GenericIngestor()
+
+
+@pytest.fixture()
+def advancing_clock(monkeypatch: pytest.MonkeyPatch) -> _AdvancingClock:
+    """Patch ``creek.ingest.generic.datetime`` with the advancing fake clock.
+
+    Scoped to the ``creek.ingest.generic`` module attribute only —
+    ``creek.ingest.base`` keeps the real clock for provenance stamping.
+    """
+    clock = _AdvancingClock(start=_CLOCK_START, step=_CLOCK_STEP)
+    monkeypatch.setattr(generic, "datetime", clock)
+    return clock
+
+
+# ---- Helpers ----
+
+
+def _make_vault(tmp_path: Path) -> Path:
+    """Scaffold a minimal vault the writer can target."""
+    vault = tmp_path / "vault"
+    for d in (
+        "00-Creek-Meta/Processing-Log",
+        "01-Fragments/Unsorted",
+    ):
+        (vault / d).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _pin_mtime(path: Path, moment: datetime) -> None:
+    """Pin *path*'s atime/mtime to *moment* so its mtime is deterministic."""
+    epoch = moment.timestamp()
+    os.utime(path, (epoch, epoch))
+
+
+def _make_source_note(tmp_path: Path, moment: datetime = _PINNED_MTIME) -> Path:
+    """Write ``src/note.txt`` OUTSIDE the vault with a pinned mtime."""
+    src = tmp_path / "src"
+    src.mkdir(parents=True, exist_ok=True)
+    note = src / "note.txt"
+    note.write_text(_NOTE_BODY, encoding="utf-8")
+    _pin_mtime(note, moment)
+    return note
+
+
+def _raw_for(path: Path) -> RawDocument:
+    """Build a RawDocument for an on-disk file, as ``discover()`` would."""
+    return RawDocument(
+        path=path,
+        content=path.read_bytes(),
+        metadata={"source_type": "generic"},
+        detected_encoding="utf-8",
+    )
+
+
+def _assemble_fragment_id(ingestor: GenericIngestor, parsed: ParsedFragment) -> str:
+    """Run the convert + frontmatter stages and return the assembled fragment id."""
+    parsed.metadata["markdown"] = ingestor.convert_to_markdown(parsed)
+    parsed.metadata["frontmatter"] = ingestor.generate_frontmatter(parsed)
+    return assemble_ingested_fragment(parsed).fragment.id
+
+
+def _run_generic_ingest(vault: Path, source_dir: Path) -> IngestRunResult:
+    """Drive the real shared pipeline with the registered generic ingestor."""
+    return run_ingest(
+        ingestor_cls=INGESTOR_REGISTRY["generic"],
+        source_type="generic",
+        input_path=source_dir,
+        vault_path=vault,
+    )
+
+
+def _fragment_files(vault: Path) -> list[Path]:
+    """Return every fragment markdown file written under ``01-Fragments``."""
+    return sorted((vault / "01-Fragments").rglob("*.md"))
+
+
+def _fragment_ids(vault: Path) -> set[str]:
+    """Return the set of fragment ids written under ``01-Fragments``."""
+    return {str(frontmatter.load(str(p))["id"]) for p in _fragment_files(vault)}
+
+
+# ---- Acceptance: re-ingest is a no-op ----
+
+
+class TestGenericReingestIsIdempotent:
+    """Re-ingesting an unchanged file must not mint a second fragment (#911)."""
+
+    @pytest.mark.usefixtures("advancing_clock")
+    def test_reingest_of_unchanged_file_writes_no_duplicate(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Two full ingests of one unchanged file leave exactly one fragment.
+
+        The wall clock advances between the two runs, so this only holds if the
+        fragment id is derived from something stable (the file's mtime) rather
+        than from ``datetime.now()``.
+        """
+        vault = _make_vault(tmp_path)
+        note = _make_source_note(tmp_path)
+
+        first = _run_generic_ingest(vault, note.parent)
+        assert first.errors == []
+        assert len(_fragment_files(vault)) == 1
+        ids_after_first = _fragment_ids(vault)
+
+        second = _run_generic_ingest(vault, note.parent)
+        assert second.errors == []
+        assert len(_fragment_files(vault)) == 1
+        assert _fragment_ids(vault) == ids_after_first
+
+
+# ---- parse(): timestamp stability ----
+
+
+class TestGenericParseTimestampStability:
+    """``parse()`` must stamp a stable, mtime-derived timestamp (#911)."""
+
+    @pytest.mark.usefixtures("advancing_clock")
+    def test_parse_timestamp_is_stable_across_calls(
+        self,
+        ingestor: GenericIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """Parsing the same unchanged file twice yields one timestamp and one id."""
+        note = _make_source_note(tmp_path)
+        first = ingestor.parse(_raw_for(note))[0]
+        second = ingestor.parse(_raw_for(note))[0]
+
+        assert first.timestamp == second.timestamp
+        assert _assemble_fragment_id(ingestor, first) == _assemble_fragment_id(
+            ingestor, second
+        )
+
+    @pytest.mark.usefixtures("advancing_clock")
+    def test_parse_timestamp_equals_file_mtime_in_utc(
+        self,
+        ingestor: GenericIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """The timestamp is the file's mtime expressed in UTC, not local time.
+
+        The hashed ``timestamp.isoformat()`` must end in ``+00:00`` on every
+        host, so fragment identity is not a function of the host's tzdata or
+        DST state.
+        """
+        note = _make_source_note(tmp_path)
+        parsed = ingestor.parse(_raw_for(note))[0]
+
+        assert parsed.timestamp == _PINNED_MTIME
+        assert parsed.timestamp.utcoffset() == timedelta(0)
+        assert parsed.timestamp.isoformat().endswith("+00:00")
+
+    @pytest.mark.usefixtures("advancing_clock")
+    def test_changed_mtime_yields_new_id(
+        self,
+        ingestor: GenericIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """Identical content with a bumped mtime is a *different* fragment.
+
+        Documents the accepted trade-off of keying identity on the mtime, and
+        guards against a "fix" that simply drops the timestamp from the hash:
+        with source path and content held constant, the ids can only differ if
+        the timestamp still participates.
+        """
+        note = _make_source_note(tmp_path)
+        before = ingestor.parse(_raw_for(note))[0]
+
+        _pin_mtime(note, _LATER_MTIME)
+        after = ingestor.parse(_raw_for(note))[0]
+
+        assert before.content == after.content
+        assert before.source_path == after.source_path
+        assert before.timestamp == _PINNED_MTIME
+        assert after.timestamp == _LATER_MTIME
+        assert _assemble_fragment_id(ingestor, before) != _assemble_fragment_id(
+            ingestor, after
+        )
+
+    def test_synthetic_document_falls_back_to_wall_clock(
+        self,
+        ingestor: GenericIngestor,
+        advancing_clock: _AdvancingClock,
+    ) -> None:
+        """A RawDocument with no file behind it keeps the wall-clock fallback.
+
+        Preserving this behaviour is an explicit constraint of #911: there is
+        no mtime to key on, so ``timestamp`` is the injected ``now`` and
+        ``authored_at`` is honestly ``None``. Asserting that the two parses see
+        *different* wall-clock values also pins that the fake clock genuinely
+        advances — a frozen clock would make the duplicate-id tests vacuous.
+        """
+        raw = RawDocument(
+            path=Path("/nonexistent/synthetic/note.txt"),
+            content=b"some synthetic text",
+            metadata={"source_type": "generic"},
+            detected_encoding="utf-8",
+        )
+        first = ingestor.parse(raw)[0]
+        second = ingestor.parse(raw)[0]
+
+        assert first.timestamp == _CLOCK_START.astimezone(LA_TZ)
+        assert second.timestamp == (_CLOCK_START + _CLOCK_STEP).astimezone(LA_TZ)
+        assert second.timestamp > first.timestamp
+        assert first.metadata["authored_at"] is None
+        assert second.metadata["authored_at"] is None
+        assert advancing_clock.ticks == [first.timestamp, second.timestamp]
+
+
+# ---- generate_frontmatter(): platform must be a real SourcePlatform ----
+
+
+class TestGenericFrontmatterPlatform:
+    """``source.platform`` must be a member of ``SourcePlatform`` (#911)."""
+
+    @pytest.mark.usefixtures("advancing_clock")
+    def test_generic_frontmatter_platform_is_a_valid_source_platform(
+        self,
+        ingestor: GenericIngestor,
+        tmp_path: Path,
+    ) -> None:
+        """The emitted platform validates and still routes to Unsorted.
+
+        ``"unknown"`` is not a ``SourcePlatform`` member, so the assembled
+        fragment never validated and generic content never reached the vault.
+        The corrected value is ``SourcePlatform.OTHER``, whose routing target
+        is the unchanged ``01-Fragments/Unsorted/``.
+        """
+        vault = _make_vault(tmp_path)
+        note = _make_source_note(tmp_path)
+        parsed = ingestor.parse(_raw_for(note))[0]
+
+        fm = ingestor.generate_frontmatter(parsed)
+        assert SourcePlatform(fm["source"]["platform"]) is SourcePlatform.OTHER
+
+        parsed.metadata["markdown"] = ingestor.convert_to_markdown(parsed)
+        parsed.metadata["frontmatter"] = fm
+        assembled = assemble_ingested_fragment(parsed)
+        written = VaultWriter(vault_path=vault).write_fragment(
+            assembled.fragment, body=assembled.body
+        )
+        assert written.parent == vault / "01-Fragments" / "Unsorted"


### PR DESCRIPTION
## Summary

`GenericIngestor.parse` stamped `timestamp=datetime.now(tz=LA_TZ)`, and `generate_fragment_id` hashes `f"{source}:{timestamp.isoformat()}:{content}"`. The generic source has **no ledger** (`ledger_for_source` returns `None` for anything but `markdown`), so it relies solely on that deterministic id for dedup — and the id was not deterministic. Re-ingesting an unchanged `.txt`/`.log` minted a fresh id and wrote a brand-new fragment **on every run**: unbounded duplication. The stable mtime was already computed one line above, for `metadata['authored_at']`, and then discarded.

`parse()` now calls `_safe_file_mtime` **once** and reuses that single value for both `timestamp` and `authored_at`. The wall clock survives only as the fallback for a pathless/synthetic `RawDocument` where `stat()` fails, where `authored_at` stays honestly `None`.

### Approach: deterministic identity, not post-hoc de-duplication

Per the issue and the prior art (#672/#673 solved a similar id-derivation problem with a stable `source_key` + ledger rather than de-duplicating after the fact), the fix is at the **derivation**, not a cleanup pass. Two candidates were considered:

- **Chosen — mtime-derived timestamp.** Minimal, uses the value already computed in the same function, and matches every sibling file-based ingestor (code/spreadsheets key on mtime; markdown on file creation time; discord/chatgpt/claude on message epoch).
- **Rejected for now — wire `generic` into the `SourceLedger`.** Not a one-liner, and actively hazardous today: `derive_source_key` falls back to a **bare filename** when the source lives outside the vault, which generic sources almost always do (`~/Downloads/*.txt`, log files). Two different `notes.txt` in different folders would collide on one `source_key` and update-in-place over each other — data loss, not duplication. A non-`None` ledger also switches on `tomb_missing_units` for the source type. This needs a collision-safe `source_key` first; filed as **#953**.

### Timezone — load-bearing

The mtime is used **verbatim in UTC** and never converted to `LA_TZ`. The UTC offset string is part of the hashed `isoformat()`, so rendering in local time would bake `-07:00`/`-08:00` into fragment identity and make it a function of the host's tzdata and DST state. `file_modified_time`'s `datetime.fromtimestamp(st_mtime, tz=UTC)` is a pure function of the epoch float — identical on every machine and under every `TZ`. A test pins `utcoffset() == timedelta(0)` and the `+00:00` suffix so this can't regress.

### Blocking prerequisite included: `source.platform`

`generate_frontmatter` emitted `"platform": "unknown"`, which is **not a member of `SourcePlatform` at all** (the fallback member is `OTHER`). Every generic fragment therefore raised a pydantic `ValidationError` inside `assemble_ingested_fragment`, which `run_ingest` swallowed into `result.errors` — **generic fragments have never reached a vault.** Verified by running it against `main`.

This is a prerequisite rather than scope creep: the issue's mandated "ingest the same source twice, assert the fragment count is unchanged" test would otherwise pass **vacuously on `0 == 0`**, and would stay vacuous after a timestamp-only fix. Corrected to `SourcePlatform.OTHER`, whose routing target is the unchanged `01-Fragments/Unsorted/` (`_PLATFORM_SUBFOLDER[OTHER] == "Unsorted"`) — exactly what `generic.py`'s docstrings already promised.

### Why this matters past the duplicate count

This is an **idempotency** bug, not a disk-bloat one. Duplicated fragments are classified independently, so the same content can land at **different privacy tiers** across runs — and the merged tier gates (#846 read-side, #848 write-side, #876 the classifier) all trust that value. A source-scoped right-to-be-forgotten purge (#910) has to find *every* copy, and copies created under drifting identity are exactly what such a purge misses. Fixing the derivation is what makes those guarantees hold.

### Back-compat: no migration needed, nothing orphaned

Stated explicitly because the alternative would be silent orphaning: because `"unknown"` never validated, **there is no on-disk population of generic fragments carrying wall-clock-derived ids to migrate.** There is also nothing to migrate *from* — no ledger, no `origin_key`, so no persisted mapping of which wall-clock id came from which file. Rewriting ids in place would in any case be more destructive than the duplicates, since ids are referenced by resonance links, thread/eddy membership, the per-directory `.id-index.jsonl`, and the chained provenance log.

### Behaviour changes to note at review

- `source.platform` for generic fragments: invalid `"unknown"` → `"other"` (routing unchanged).
- `created` in generic frontmatter: parse-time wall clock → source mtime in UTC. Deliberate and more honest — `creek/time.py` documents that `created` is **not** in the authored-at precedence chain (all time-bucketing routes through `effective_authored_at`: `authored_at` → `ingested`), and other file-based ingestors already key on mtime. The only cross-fragment `.created` consumer, `atomize/aggregate.py`'s gap-minute sort, is moot here because `GenericIngestor.parse` returns exactly one fragment per file.
- Side benefit: `creek ingest --since` now actually works for the generic source. `unit_is_changed` compares `parsed.timestamp` to the cutoff ("mtime-style", per its own docstring); with a wall-clock stamp every generic unit always looked newer than any cutoff, so nothing was ever skipped.

### Known limitation (deferred, tracked)

A bare `touch` — or any edit — bumps the mtime and still mints a new id, because the generic source has no ledger. Recorded in the `parse` docstring and in `docs/ingestion.md`, and filed as **#953**.

## Test plan

Gate 1 was genuinely RED first: **7 failed / 45 passed** before the implementation, **52 passed** after. The two pre-existing tests that changed are assertion *corrections* to now-known-wrong expectations, both additive (`test_parse_sets_timestamp` retains its original `isinstance` assertion); I diffed the file against `git show HEAD:tests/test_ingest_generic.py` and byte-hashed both test files before and after the implementation run to confirm nothing was removed or weakened.

New `tests/test_ingest_generic_idempotent.py`:

- **`test_reingest_of_unchanged_file_writes_no_duplicate`** — the acceptance test. Ingests a source dir **twice** through the real `run_ingest` pipeline and asserts `errors == []` **and** exactly **1** `.md` on disk after *each* run, plus a byte-identical frontmatter `id` across runs. The `errors == []` + exact-count pair is what stops it passing vacuously on `0 == 0`. Confirmed to exercise the real production dedup path: with `ledger=None`, `write_fragment_idempotent` falls through to `writer.write_fragment`, and dedup is entirely `_write_model`'s id-index lookup.
- **`test_parse_timestamp_is_stable_across_calls`** — equal `timestamp` *and* equal assembled fragment id across two parses.
- **`test_parse_timestamp_equals_file_mtime_in_utc`** — tz-stability guard (`utcoffset() == timedelta(0)`, `isoformat()` ends `+00:00`).
- **`test_changed_mtime_yields_new_id`** — pins the accepted trade-off and guards against a "fix" that simply drops `timestamp` from the hash.
- **`test_synthetic_document_falls_back_to_wall_clock`** — preserves the pathless-`RawDocument` contract, and doubles as the guard that the injected clock genuinely **advances**.
- **`test_generic_frontmatter_platform_is_a_valid_source_platform`** — `SourcePlatform(...)` validates and the fragment still routes to `01-Fragments/Unsorted/` through the real `VaultWriter`.

Clock handling: no freezegun/time_machine in this repo, so `creek.ingest.generic.datetime` is monkeypatched with an **advancing** fake (advancing, not frozen — a frozen clock would make the *buggy* code produce equal ids and destroy the RED). Only that module attribute is patched; `Ingestor.ingest`'s provenance `datetime.now()` is left alone. No test depends on real elapsed time, and no assertion depends on filesystem visit order (`rglob` is unsorted; `_discover_directory` already wraps it in `sorted()`).

Gates:
- **Gate 2:** `cd creek-tools && ./scripts/check-all.sh` → exit 0, 12/12 checks, **6351 passed**, 93.99% coverage, per-file gate green. No suppressions, no threshold changes, no skipped or deleted tests.
- **Gate 2.5:** `code-review-orchestrator` over the full diff → **CLEAN**, zero blockers.

Closes #911
Refs #953