### PR TITLE
fix(crawdad): dispatch intents bundled with compose=true instead of dropping them

### DIFF
--- a/crawdad/crawdad/intents.py
+++ b/crawdad/crawdad/intents.py
@@ -64,11 +64,16 @@ class Intent(BaseModel):
 class RouterResponse(BaseModel):
     """The exact JSON shape Haiku must emit — no prose, no extras.
 
-    FEAT-015 adds the ``compose`` flag: when ``True`` (or when
-    ``intents`` is empty) the loop terminates router iteration and
-    invokes the Sonnet composer. The pair ``{intents: [], compose:
-    true}`` is the canonical "I have enough context; compose now"
-    signal.
+    FEAT-015 adds the ``compose`` flag: it ends router iteration, so the
+    Sonnet composer produces the reply for this round. An empty
+    ``intents`` list ends iteration too. The pair ``{intents: [],
+    compose: true}`` is the canonical "I have enough context; compose
+    now" signal.
+
+    ``compose`` and ``intents`` are independent: a response may carry
+    both, and the loop then dispatches those intents *before* composing
+    rather than discarding them (#915). The router prompt invites this
+    shape by asking for the intent "BEFORE setting ``compose: true``".
     """
 
     model_config = ConfigDict(frozen=True)

--- a/crawdad/crawdad/loop.py
+++ b/crawdad/crawdad/loop.py
@@ -10,7 +10,7 @@ Sonnet composer. The loop's contract:
        ▼  ── ROUND N ──┐
     router.extract_intents
        │
-       ├─ compose=True or intents=[] ─► composer.compose ─► reply
+       ├─ intents=[] ─► composer.compose ─► reply
        │
        └─ intents non-empty
               │
@@ -19,13 +19,23 @@ Sonnet composer. The loop's contract:
               │
               ▼
           dispatcher.dispatch(intents)  →  aggregate ToolResults
+              │                            + record the ``tool`` turn
               │
-              ▼
+              ├─ compose=True ─► composer.compose ─► reply
+              │
+              └─ compose=False ─► ROUND N+1 ──┘
        (loop until ``max_rounds`` rounds; the next attempt is refused)
+
+``compose`` is read *after* the dispatch, not before it: the router is
+prompted to emit its intents and set ``compose: true`` in the same
+response once it has everything it needs, so a bundled round must run
+the tools it asked for and then compose within that same round (#915).
+Only an *empty* intent list short-circuits straight to the composer.
 
 The cap defaults to :data:`MAX_LOOP_ROUNDS` (5) and can be raised or
 lowered per deployment via the ``max_loop_rounds`` key in
-``crawdad.yaml`` (FEAT-036, bounded ``[1, 50]``).
+``crawdad.yaml`` (FEAT-036, bounded ``[1, 50]``). The cap is reached
+only when the router keeps returning intents with ``compose=false``.
 
 Side-effects: the loop appends ``user`` and ``assistant`` turns to the
 shared :class:`ConversationHistory` (the source the next router pass
@@ -173,7 +183,8 @@ class AgentLoop:
                 _LOGGER.warning("router parse error mid-loop: %s", exc)
                 return LoopOutcome(kind="router_parse_error", reply=_ROUTER_PARSE_REPLY)
 
-            if response.compose or not response.intents:
+            # Nothing to dispatch: go straight to the composer.
+            if not response.intents:
                 break
 
             try:
@@ -186,6 +197,14 @@ class AgentLoop:
                 return LoopOutcome(kind="mcp_unavailable", reply=_MCP_UNAVAILABLE_REPLY)
             aggregated.extend(results)
             self._record_tool_round(results)
+
+            # Intents bundled with compose=true (#915): the tools above
+            # have now run, so this round composes rather than costing an
+            # extra router pass. Recording the round above keeps history
+            # identical to the two-round path — the break below guarantees
+            # no second router pass, so there is no duplicate turn.
+            if response.compose:
+                break
         else:
             # Exhausted max_rounds without the router setting compose=true.
             _LOGGER.warning(

--- a/crawdad/tests/test_loop.py
+++ b/crawdad/tests/test_loop.py
@@ -675,6 +675,195 @@ async def test_loop_run_workflow_intent_invokes_workflow_runner(
     assert tool_results[0].body == "workflow phase-transitions done"
 
 
+async def test_loop_dispatches_run_workflow_bundled_with_compose(
+    state: SessionState, skills: VoiceSkillStack
+) -> None:
+    """#915: intents bundled with ``compose=true`` must still be dispatched.
+
+    The router prompt tells Haiku to emit the intent *before* setting
+    ``compose: true``, and ``test_router.py`` pins that bundled single
+    object as the canonical well-behaved reply. The loop must therefore
+    dispatch this round's intents and *then* compose, rather than
+    breaking out before dispatch and silently dropping the work.
+    """
+    from crawdad.intents import RUN_WORKFLOW_INTENT_TYPE
+
+    runner_calls: list[tuple[str, dict[str, str]]] = []
+
+    async def _workflow_runner(name: str, inputs: dict[str, str]) -> str:
+        runner_calls.append((name, inputs))
+        return f"workflow {name} done"
+
+    router = _ScriptedRouter(
+        [
+            RouterResponse(
+                intents=[
+                    Intent(
+                        type=RUN_WORKFLOW_INTENT_TYPE,
+                        args={
+                            "name": "phase-transitions",
+                            "inputs": {"topic": "spirals"},
+                        },
+                    )
+                ],
+                compose=True,
+            )
+        ]
+    )
+    composer = _ScriptedComposer("composed reply")
+    loop = AgentLoop(
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(_ScriptedSession()),  # type: ignore[arg-type]
+        known_tools=(),
+        history=ConversationHistory(),
+        session_state=state,
+        skills=skills,
+        workflow_runner=_workflow_runner,
+    )
+
+    outcome = await loop.run("run the phase-transitions workflow on spirals")
+
+    # The effect: the workflow actually ran with the router's arguments.
+    assert runner_calls == [("phase-transitions", {"topic": "spirals"})]
+    # Exactly one router pass — the bundled round both dispatches and
+    # composes; it does not cost an extra trip through the router.
+    assert len(router.calls) == 1
+    tool_results = composer.calls[0]["tool_results"]
+    assert len(tool_results) == 1
+    assert tool_results[0].intent_type == RUN_WORKFLOW_INTENT_TYPE
+    assert tool_results[0].body == "workflow phase-transitions done"
+    # Parity with the two-round path: the round was recorded in history.
+    composer_history = composer.calls[0]["history"].as_list()
+    assert any(
+        entry.role not in {"user", "assistant"}
+        and "workflow phase-transitions done" in entry.content
+        for entry in composer_history
+    )
+    assert outcome.kind == "composed"
+
+
+async def test_loop_activate_register_bundled_with_compose_switches_stack(
+    state: SessionState, tmp_path: Path
+) -> None:
+    """#915: a register switch bundled with ``compose=true`` still switches.
+
+    Same drop as the workflow case, but the silence is worse: the reply
+    is composed with the *old* voice stack, so the user sees an answer
+    that reads as if the register request was never made.
+    """
+    from crawdad.intents import ACTIVATE_REGISTER_INTENT_TYPE
+    from crawdad.skill_loader import (
+        SkillStackRegistry,
+        VoiceSkillStack,
+        load_skills_for_session,
+    )
+
+    skills_dir = tmp_path / "creek-skills"
+    (skills_dir / "voice-core").mkdir(parents=True)
+    (skills_dir / "voice-core" / "SKILL.md").write_text(
+        "voice core body", encoding="utf-8"
+    )
+    (skills_dir / "registers").mkdir()
+    (skills_dir / "registers" / "analytic.SKILL.md").write_text(
+        "# Analytic register\nPrecise, taxonomy-leaning.",
+        encoding="utf-8",
+    )
+
+    initial = load_skills_for_session(vault_path=tmp_path, state=None)
+    registry = SkillStackRegistry(stack=initial, vault_path=tmp_path, state=None)
+
+    router = _ScriptedRouter(
+        [
+            RouterResponse(
+                intents=[
+                    Intent(
+                        type=ACTIVATE_REGISTER_INTENT_TYPE,
+                        args={"register": "analytic"},
+                    )
+                ],
+                compose=True,
+            )
+        ]
+    )
+    composer = _ScriptedComposer("switched")
+    loop = AgentLoop(
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(_ScriptedSession()),  # type: ignore[arg-type]
+        known_tools=(),
+        history=ConversationHistory(),
+        session_state=state,
+        skills=VoiceSkillStack(skills=()),
+        skill_registry=registry,
+    )
+
+    outcome = await loop.run("use the analytic voice")
+
+    # The effect: the registry really swapped stacks, and the composer
+    # was handed the switched-to stack — not the pre-switch one.
+    assert registry.stack is not initial
+    assert any("Analytic" in body for body in registry.stack.bodies())
+    assert composer.calls[0]["skills"] is registry.stack
+    assert len(router.calls) == 1
+    assert outcome.kind == "composed"
+
+
+async def test_loop_bundled_compose_round_composes_at_max_rounds_one(
+    state: SessionState, skills: VoiceSkillStack
+) -> None:
+    """#915: the bundled round dispatches *and* composes within one round.
+
+    Guards against a ``continue``-shaped fix that dispatches and then
+    spins the loop for another router pass: with ``max_rounds=1`` such a
+    fix would exhaust the cap and return ``too_deep`` instead of the
+    composed reply the user asked for.
+    """
+    from crawdad.intents import RUN_WORKFLOW_INTENT_TYPE
+
+    runner_calls: list[tuple[str, dict[str, str]]] = []
+
+    async def _workflow_runner(name: str, inputs: dict[str, str]) -> str:
+        runner_calls.append((name, inputs))
+        return f"workflow {name} done"
+
+    router = _ScriptedRouter(
+        [
+            RouterResponse(
+                intents=[
+                    Intent(
+                        type=RUN_WORKFLOW_INTENT_TYPE,
+                        args={
+                            "name": "phase-transitions",
+                            "inputs": {"topic": "spirals"},
+                        },
+                    )
+                ],
+                compose=True,
+            )
+        ]
+    )
+    composer = _ScriptedComposer("composed reply")
+    loop = AgentLoop(
+        router=router,  # type: ignore[arg-type]
+        composer=composer,  # type: ignore[arg-type]
+        mcp_client=_ScriptedMCPClient(_ScriptedSession()),  # type: ignore[arg-type]
+        known_tools=(),
+        history=ConversationHistory(),
+        session_state=state,
+        skills=skills,
+        max_rounds=1,
+        workflow_runner=_workflow_runner,
+    )
+
+    outcome = await loop.run("run the phase-transitions workflow on spirals")
+
+    assert outcome.kind == "composed"
+    assert outcome.reply == "composed reply"
+    assert runner_calls == [("phase-transitions", {"topic": "spirals"})]
+    assert composer.calls
+
+
 async def test_loop_records_user_and_assistant_turns(
     state: SessionState, skills: VoiceSkillStack
 ) -> None:


### PR DESCRIPTION
## Summary

`AgentLoop.run` dropped **every intent that arrived in the same router response as `compose=true`** — silently. The guard at `crawdad/crawdad/loop.py:176` was one conditional making two different decisions:

```python
if response.compose or not response.intents:
    break
```

It broke out of the round loop *before* dispatching, so the dispatcher was never called, `aggregated` stayed `[]`, and the composer produced a generic reply as if nothing had been requested. `/crawdad workflow` phrasing and natural-language register switches silently no-opped.

**The dropped shape is not hypothetical.** `router.py:117-138` instructs Haiku to emit the intent *"BEFORE setting `compose: true`"* — which a model routinely satisfies inside one JSON object — and `tests/test_router.py:311-355` / `:358-396` pin exactly that bundled single object as the canonical well-behaved reply for both `run_workflow` and `activate_register`, asserting the intent is present **and** `response.compose is True`. The loop discarded precisely what the router's own tests sanctioned. Paradox routing escaped the bug only because `_maybe_route_paradox` re-injects a dropped `creek.save`; `run_workflow` and `activate_register` have no such fallback.

The guard now splits the two decisions it was conflating: an empty intent list breaks without dispatching (nothing to do), while `compose` dispatches first and breaks after. The bundled round still calls `_record_tool_round`, so its history is byte-identical to the two-round path; the `break` immediately after guarantees no second router pass and therefore no duplicate `tool` turn.

Notes on the edges:

- **`for/else` / `too_deep` untouched.** The cap is now reached only when the router returns non-empty intents with `compose=false` for every round — exactly what its log message already claimed. `max_rounds=1` with a bundled response composes rather than falling through to `too_deep` (the `break` fires at the end of iteration 0); that case has its own test, since it is where a `continue`-shaped fix would regress.
- **Complexity is net zero, deliberately.** radon counts boolean operators, so the removed `if A or B` was +2 and the two replacement conditionals are also +2. `AgentLoop.run` stays at **B (10)** — measured before and after — which is exactly the `xenon --max-absolute B` ceiling. A `_run_rounds` extraction was prepared as a contingency and proved unnecessary.
- **One intentional behavior change:** a bundled round can now surface `unknown_intent` / `mcp_unavailable` where the old code silently composed. That is the correct direction — the silent drop was the bug.
- **Docs that sanctioned the bug were corrected.** `loop.py`'s module flow diagram and `RouterResponse`'s docstring both stated the buggy contract verbatim (`compose=True or intents=[] ─► composer.compose`). That false normative statement is why the bug survived review, so both were rewritten to match the implementation.

## Test plan

Three tests added to `crawdad/tests/test_loop.py` (pure addition — **189 insertions, 0 deletions**; no existing test modified, reordered, or deleted, verified by hash across the implementation run).

Because the failure mode is a *silent* no-op, every test asserts the **effect**, never "no exception raised". All three were confirmed RED against the unfixed code first:

| Test | RED failure before the fix |
|---|---|
| `test_loop_dispatches_run_workflow_bundled_with_compose` | `assert runner_calls == [...]` → `AssertionError: assert [] == [('phase-transitions', {'topic': 'spirals'})]` — the workflow runner was never called |
| `test_loop_activate_register_bundled_with_compose_switches_stack` | `assert registry.stack is not initial` → failed; the registry was never mutated, so the register never switched |
| `test_loop_bundled_compose_round_composes_at_max_rounds_one` | `assert runner_calls == [...]` → `[]`, at `max_rounds=1` |

The third test is the reason effect-assertions matter: `outcome.kind == "composed"` **passed against the live bug** on the line directly above the failure. Asserting the call survived would have proved nothing.

Supporting assertions: `len(router.calls) == 1` (the bundled round costs no extra router pass), the composer receives exactly one `ToolResult` with the right `intent_type` and `body`, a non-`user`/`assistant` history turn carries that body (history parity with the two-round path), and `composer.calls[0]["skills"] is registry.stack` (the composer got the switched-*to* stack).

Gate results, run the way the **CrawDad Quality** CI job does (`cd crawdad && ./scripts/check-all.sh` — note the `creek-tools` gate does *not* cover this subproject):

- **Baseline on `origin/main`:** exit 0, 507 passed, 94.57% branch coverage.
- **After the change:** exit 0, all 7 checks green, **510 passed** (507 + 3 new), **94.58%** branch coverage.
- Both arms of the new `if response.compose:` are covered — the `True` side by the three new tests, the `False` side by the existing multi-round aggregation and cap tests.

Gate 2.5 self-review returned **CLEAN** with no blockers.

Closes #915
