### PR TITLE
fix(crawdad): stop false MIME mismatch when a UTF-8 char straddles the 1024-byte sample

### DIFF
--- a/crawdad/crawdad/attachments.py
+++ b/crawdad/crawdad/attachments.py
@@ -26,6 +26,7 @@ before any ``creek.ingest`` call.
 
 from __future__ import annotations
 
+import codecs
 import hashlib
 import logging
 import re
@@ -152,7 +153,9 @@ _EXTENSION_MIME_SPECS: dict[str, _ExtensionMimeSpec] = {
 # in this set are expected to be plain text, so a NUL byte or undecodable
 # bytes in the first ``_TEXT_SAMPLE_BYTES`` of the body are treated as
 # evidence that the file is actually a binary blob renamed to a text
-# extension (the polyglot case the issue calls out). The dict carries
+# extension (the polyglot case the issue calls out). One byte pattern is
+# *not* such evidence: a codepoint the sampling itself cut in half at the
+# window edge — see ``_TEXT_SAMPLE_BYTES`` and issue #916. The dict carries
 # the canonical text MIME per extension so a successful match surfaces
 # the right label (``text/markdown`` for ``.md``, ``application/json``
 # for ``.json``, etc.) instead of a generic ``text/plain`` blanket.
@@ -174,6 +177,13 @@ _TEXT_EXTENSIONS: frozenset[str] = frozenset(_TEXT_EXTENSION_TO_MIME)
 # Sample size for the text-content heuristic. One kilobyte is enough to
 # catch every common binary header (PE / ELF / OLE / PDF / ZIP) without
 # materially extending the download path's CPU cost.
+#
+# The window is a byte cut, not a character cut, so it can land in the
+# middle of a multibyte codepoint. Issue #916 pins the resulting edge
+# semantics: the sample is text iff (a) it holds no NUL byte anywhere in
+# the window, and (b) every byte decodes as UTF-8 except — when and only
+# when the body actually runs past the window — a trailing run of at most
+# three bytes forming a legal prefix of one unfinished sequence.
 _TEXT_SAMPLE_BYTES: int = 1024
 
 # Canonical MIME the text verifier uses when it has to label something
@@ -260,10 +270,24 @@ def _verify_binary_signature(suffix: str, data: bytes) -> MimeVerification:
 
 
 def _verify_text_sample(suffix: str, data: bytes) -> MimeVerification:
-    """Sample-check that *data* is plausibly UTF-8 text with no NUL bytes."""
+    """Sample-check that *data* is plausibly UTF-8 text with no NUL bytes.
+
+    The sample is a fixed-width byte window, so a multibyte codepoint can
+    straddle its edge. When — and only when — *data* actually extends past
+    the window, an unfinished-but-well-formed trailing sequence is
+    tolerated rather than read as binary (issue #916). A body that ends
+    at or before the window was never cut by us, so a dangling partial
+    there is genuine corruption and still reads as a mismatch.
+    """
     expected = _TEXT_EXTENSION_TO_MIME[suffix]
     sample = data[:_TEXT_SAMPLE_BYTES]
-    if b"\x00" in sample or not _decodes_as_utf8(sample):
+    # Strict ``>``: at exactly _TEXT_SAMPLE_BYTES the sample *is* the whole
+    # file, so nothing was cut off and no tail may be forgiven.
+    truncated = len(data) > _TEXT_SAMPLE_BYTES
+    # NUL check first, over the full raw window: NUL bytes decode as valid
+    # UTF-8, so this heuristic is independent of (and unweakened by) the
+    # truncation tolerance below.
+    if b"\x00" in sample or not _decodes_as_utf8(sample, truncated=truncated):
         return MimeVerification(
             status="mismatch",
             detected_mime=_BINARY_CANONICAL_MIME,
@@ -276,10 +300,44 @@ def _verify_text_sample(suffix: str, data: bytes) -> MimeVerification:
     )
 
 
-def _decodes_as_utf8(sample: bytes) -> bool:
-    """Return ``True`` when *sample* is fully decodable as UTF-8."""
+def _decodes_as_utf8(sample: bytes, *, truncated: bool) -> bool:
+    """Return ``True`` when *sample* decodes as UTF-8, tail cut allowance aside.
+
+    Args:
+        sample: The bytes to decode — the leading window of a larger body.
+        truncated: ``True`` when *sample* was cut out of a longer body, so
+            its final codepoint may legitimately be incomplete. ``False``
+            demands a complete decode, matching a plain
+            ``sample.decode("utf-8")``.
+
+    Returns:
+        ``True`` when every byte decodes as UTF-8, except that a
+        *truncated* sample may end in a trailing run of **at most three**
+        bytes forming a legal prefix of one unfinished sequence — issue
+        #916, where a codepoint straddling the window edge was misread as
+        a binary blob. This is a bounded allowance, not a blanket "ignore
+        the tail": the incremental decoder still raises on the first byte
+        that cannot begin or continue a valid sequence, so invalid leads,
+        bare or malformed continuations, and overlong or out-of-range
+        forms are rejected wherever the byte that disqualifies them falls
+        inside the window.
+
+        The allowance is therefore bounded by what the window can see. A
+        partial sequence whose disqualifying byte lies *past* the cut is
+        tolerated, because that byte was never inspected — a trailing
+        ``\\xed\\xa0`` passes even though it can only continue into a
+        surrogate, and a bare trailing ``\\xed`` passes too, since one
+        lead byte alone cannot yet be range-checked. The effective
+        validated prefix is
+        ``_TEXT_SAMPLE_BYTES - 3`` bytes in the worst case, which is why
+        this sits inside the false-negative surface ADR-0002 already
+        documents rather than opening a new one.
+    """
+    decoder = codecs.getincrementaldecoder("utf-8")()
     try:
-        sample.decode("utf-8")
+        # ``final=True`` flushes the decoder, so a dangling partial raises;
+        # ``final=False`` lets a legal unfinished tail stay buffered.
+        decoder.decode(sample, final=not truncated)
     except UnicodeDecodeError:
         return False
     return True

--- a/crawdad/tests/test_attachments.py
+++ b/crawdad/tests/test_attachments.py
@@ -21,6 +21,9 @@ FEAT-035 adds:
 - Unknown extension (``.xyz`` — no verifier, status="unknown").
 - ``reject_on_mime_mismatch=True`` flips soft warning into hard reject.
 - Summary surfaces the mismatch warning line for accepted-but-suspect files.
+- Multibyte UTF-8 codepoints straddling the text-sample byte boundary
+  (issue #916) still verify as ``match``, while genuinely invalid bytes
+  at that same offset still verify as ``mismatch``.
 """
 
 from __future__ import annotations
@@ -31,6 +34,7 @@ from pathlib import Path
 import pytest
 
 from crawdad.attachments import (
+    _TEXT_SAMPLE_BYTES,
     AcceptedAttachment,
     MimeVerification,
     ProcessedAttachments,
@@ -583,6 +587,206 @@ def test_verify_mime_type_invalid_utf8_under_text_extension_is_mismatch() -> Non
     assert result.expected_mime == "text/plain"
 
 
+# ---------------------------------------------------------------------------
+# Issue #916: the text sample is cut at a fixed byte offset, so a multibyte
+# UTF-8 codepoint can straddle the window edge. Truncation is not corruption
+# — the tests below pin "a split codepoint is still text" without loosening
+# the checks that catch genuinely binary or malformed bodies at that offset.
+# All boundary arithmetic derives from ``_TEXT_SAMPLE_BYTES`` so the tests
+# follow the constant if it is ever retuned.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("char", "inside_bytes"),
+    [
+        pytest.param("é", 1, id="2byte-char-1-inside-1-outside"),
+        pytest.param("文", 1, id="3byte-char-1-inside-2-outside"),
+        pytest.param("文", 2, id="3byte-char-2-inside-1-outside"),
+        pytest.param("😀", 1, id="4byte-char-1-inside-3-outside"),
+        pytest.param("😀", 2, id="4byte-char-2-inside-2-outside"),
+        pytest.param("😀", 3, id="4byte-char-3-inside-1-outside"),
+    ],
+)
+def test_verify_mime_type_multibyte_split_at_sample_boundary_is_match(
+    char: str, inside_bytes: int
+) -> None:
+    """A codepoint split across the sample edge is text, not a binary blob.
+
+    ``inside_bytes`` of the character's UTF-8 encoding land inside the
+    sampled window and the remainder falls past it, for every split of
+    every multibyte width (2, 3 and 4 bytes). The body is valid UTF-8
+    end to end, so the only reason a naive strict decode of the slice
+    fails is the cut itself — issue #916's false ``mismatch``.
+    """
+    encoded = char.encode()
+    pad = b"a" * (_TEXT_SAMPLE_BYTES - inside_bytes)
+    data = pad + encoded + b" trailing\n"
+
+    # Self-checks: fail loudly if the fixture does not actually straddle.
+    assert len(data) > _TEXT_SAMPLE_BYTES
+    assert data[:_TEXT_SAMPLE_BYTES][-inside_bytes:] == encoded[:inside_bytes]
+    # The premise: the whole payload is valid UTF-8, only the slice is cut.
+    assert data.decode("utf-8").endswith(f"{char} trailing\n")
+
+    result = verify_mime_type("notes.md", data)
+    assert result.status == "match"
+    assert result.detected_mime == "text/markdown"
+    assert result.expected_mime == "text/markdown"
+    assert result.is_mismatch is False
+
+
+def test_verify_mime_type_accented_char_at_byte_1024_boundary_is_match() -> None:
+    """Issue #916 acceptance criterion 1, spelled out verbatim.
+
+    ``verify_mime_type("notes.md", b"a" * 1023 + "é".encode() + b" more
+    text\\n").status == "match"``. The literal 1023 is intentional here
+    (every other test derives from :data:`_TEXT_SAMPLE_BYTES`) so the
+    stated criterion stays greppable against the issue text.
+    """
+    data = b"a" * 1023 + "é".encode() + b" more text\n"
+    result = verify_mime_type("notes.md", data)
+    assert result.status == "match"
+    assert result.detected_mime == "text/markdown"
+    assert result.expected_mime == "text/markdown"
+
+
+def test_verify_mime_type_truncated_utf8_tail_in_short_file_is_mismatch() -> None:
+    """Invariant: a dangling lead byte at end-of-file is still a mismatch.
+
+    The whole body fits inside the sample window, so nothing was cut by
+    sampling — the file itself ends mid-codepoint and is genuinely not
+    valid UTF-8. The #916 fix must not forgive this.
+    """
+    data = b"hello\xc3"
+    assert len(data) < _TEXT_SAMPLE_BYTES
+
+    result = verify_mime_type("notes.txt", data)
+    assert result.status == "mismatch"
+    assert result.detected_mime == "application/octet-stream"
+    assert result.expected_mime == "text/plain"
+
+
+def test_verify_mime_type_dangling_lead_byte_at_sample_size_is_mismatch() -> None:
+    """Invariant: a body of exactly ``_TEXT_SAMPLE_BYTES`` was never cut.
+
+    Adjacent pair with
+    :func:`test_verify_mime_type_complete_char_one_byte_past_sample_is_match`:
+    together they pin the off-by-one. Truncation forgiveness may only
+    apply when the body extends *past* the window (``len(data) >
+    _TEXT_SAMPLE_BYTES``), never when it ends exactly at it — here the
+    trailing ``\\xc3`` has no continuation byte anywhere in the file.
+    """
+    data = b"a" * (_TEXT_SAMPLE_BYTES - 1) + b"\xc3"
+    assert len(data) == _TEXT_SAMPLE_BYTES
+
+    result = verify_mime_type("notes.txt", data)
+    assert result.status == "mismatch"
+    assert result.detected_mime == "application/octet-stream"
+    assert result.expected_mime == "text/plain"
+
+
+def test_verify_mime_type_complete_char_one_byte_past_sample_is_match() -> None:
+    """Invariant: one byte past the window completes the codepoint.
+
+    Adjacent pair with
+    :func:`test_verify_mime_type_dangling_lead_byte_at_sample_size_is_mismatch`:
+    the same 1023 ``a``\\ s plus ``\\xc3``, but this body carries the
+    ``\\xa9`` continuation just outside the window. Same leading bytes,
+    opposite verdict — that is the ``>`` vs ``>=`` boundary.
+    """
+    data = b"a" * (_TEXT_SAMPLE_BYTES - 1) + b"\xc3\xa9"
+    assert len(data) == _TEXT_SAMPLE_BYTES + 1
+
+    result = verify_mime_type("notes.txt", data)
+    assert result.status == "match"
+    assert result.detected_mime == "text/plain"
+    assert result.expected_mime == "text/plain"
+
+
+def test_verify_mime_type_invalid_bytes_mid_sample_is_mismatch() -> None:
+    """Invariant: undecodable bytes far from the edge stay a mismatch.
+
+    ``\\xff\\xfe`` sits at offset 500 with 600 bytes of text after it —
+    nowhere near the sample boundary, so no truncation-tolerance logic
+    may excuse it.
+    """
+    data = b"a" * 500 + b"\xff\xfe" + b"a" * 600
+    assert len(data) > _TEXT_SAMPLE_BYTES
+
+    result = verify_mime_type("notes.txt", data)
+    assert result.status == "mismatch"
+    assert result.detected_mime == "application/octet-stream"
+    assert result.expected_mime == "text/plain"
+
+
+def test_verify_mime_type_invalid_bytes_at_sample_boundary_is_mismatch() -> None:
+    """Invariant: never blanket-drop the tail of the sample.
+
+    ``\\xff`` and ``\\xfe`` are not legal UTF-8 lead bytes anywhere, and
+    here they occupy the last two bytes of the window. A fix that simply
+    shaves up to three trailing bytes off the sample and re-decodes
+    would call this text — it is not.
+    """
+    data = b"a" * (_TEXT_SAMPLE_BYTES - 2) + b"\xff\xfe" + b"a" * 100
+    assert len(data) > _TEXT_SAMPLE_BYTES
+    assert data[_TEXT_SAMPLE_BYTES - 2 : _TEXT_SAMPLE_BYTES] == b"\xff\xfe"
+
+    result = verify_mime_type("notes.txt", data)
+    assert result.status == "mismatch"
+    assert result.detected_mime == "application/octet-stream"
+    assert result.expected_mime == "text/plain"
+
+
+def test_verify_mime_type_bad_continuation_at_boundary_is_mismatch() -> None:
+    """Invariant: a legal lead byte with an illegal continuation is binary.
+
+    ``\\xe6`` is a valid 3-byte lead and sits two bytes from the window
+    edge, but ``\\x28`` is not a continuation byte — the sequence is
+    malformed where it stands, not merely unfinished. Only an *unfinished
+    but well-formed* trailing sequence may be forgiven.
+    """
+    data = b"a" * (_TEXT_SAMPLE_BYTES - 2) + b"\xe6\x28" + b"a" * 100
+    assert len(data) > _TEXT_SAMPLE_BYTES
+
+    result = verify_mime_type("notes.txt", data)
+    assert result.status == "mismatch"
+    assert result.detected_mime == "application/octet-stream"
+    assert result.expected_mime == "text/plain"
+
+
+def test_verify_mime_type_nul_byte_early_in_long_file_is_mismatch() -> None:
+    """Invariant: the NUL-byte heuristic survives the #916 fix.
+
+    A NUL at offset 100 of a 2101-byte body is the disguised-binary
+    signal; UTF-8 truncation handling must not route around this check.
+    """
+    data = b"a" * 100 + b"\x00" + b"a" * 2000
+    assert len(data) > _TEXT_SAMPLE_BYTES
+
+    result = verify_mime_type("notes.txt", data)
+    assert result.status == "mismatch"
+    assert result.detected_mime == "application/octet-stream"
+    assert result.expected_mime == "text/plain"
+
+
+def test_verify_mime_type_nul_byte_at_last_sample_byte_is_mismatch() -> None:
+    """Invariant: the NUL scan still covers the final byte of the window.
+
+    The NUL sits at offset ``_TEXT_SAMPLE_BYTES - 1`` — the last byte
+    inspected. A fix that shrinks the scanned window to dodge a split
+    codepoint would stop seeing it.
+    """
+    data = b"a" * (_TEXT_SAMPLE_BYTES - 1) + b"\x00" + b"a" * 100
+    assert len(data) > _TEXT_SAMPLE_BYTES
+    assert data[_TEXT_SAMPLE_BYTES - 1] == 0
+
+    result = verify_mime_type("notes.txt", data)
+    assert result.status == "mismatch"
+    assert result.detected_mime == "application/octet-stream"
+    assert result.expected_mime == "text/plain"
+
+
 def test_verify_mime_type_unknown_extension_returns_unknown_status() -> None:
     """An extension outside both tables can't be verified — status=unknown."""
     result = verify_mime_type("weird.xyz", b"any bytes here")
@@ -713,6 +917,38 @@ async def test_process_attachment_text_polyglot_rejected_when_configured(
     assert result.accepted == ()
     assert len(result.rejected) == 1
     assert "MIME mismatch" in result.rejected[0].reason
+
+
+async def test_process_attachment_boundary_straddle_accepted_in_reject_mode(
+    tmp_path: Path,
+) -> None:
+    """Issue #916 acceptance criterion 3: valid text is not hard-rejected.
+
+    Reject mode is the strictest setting, so it is where the false
+    ``mismatch`` costs the user their file. A markdown note whose only
+    peculiarity is an accented character landing on the sample boundary
+    must be accepted, verified as ``match``, and written to staging.
+    """
+    config = AttachmentConfig(reject_on_mime_mismatch=True)
+    payload = b"a" * (_TEXT_SAMPLE_BYTES - 1) + "é".encode() + b" tail\n"
+    attachment = _FakeAttachment(
+        filename="notes.md",
+        size=len(payload),
+        payload=payload,
+    )
+    result = await process_attachments(
+        attachments=[attachment],
+        vault_path=tmp_path,
+        channel_id=1,
+        message_id=2,
+        config=config,
+    )
+    assert result.rejected == ()
+    assert len(result.accepted) == 1
+    assert result.accepted[0].mime_verification.status == "match"
+    staged = tmp_path / "00-Creek-Meta" / "Inbound" / "1" / "2" / "notes.md"
+    assert staged.exists()
+    assert staged.read_bytes() == payload
 
 
 async def test_process_attachment_unknown_extension_still_accepts(

--- a/creek-tools/docs/architecture/ADR/0002-mime-verification-library.md
+++ b/creek-tools/docs/architecture/ADR/0002-mime-verification-library.md
@@ -32,10 +32,18 @@ Python, BSD-3) for magic-byte detection on binary file types.
 
 For text-extension files (`.md`, `.markdown`, `.txt`, `.html`,
 `.htm`, `.json`, `.csv` — which have no magic byte signature) the
-verifier runs a content sample instead: the first 1 KiB must decode
-as UTF-8 and contain no NUL bytes. This catches the polyglot case the
-issue calls out (executable or other binary blob renamed to a text
-extension) without false-flagging legitimate UTF-8-encoded text.
+verifier runs a content sample instead: the first 1 KiB must contain
+no NUL byte and must decode as UTF-8. This catches the polyglot case
+the issue calls out (executable or other binary blob renamed to a
+text extension) — with one carve-out for the window's own trailing
+edge: when the body actually extends past the 1 KiB cut, a trailing
+partial codepoint (at most 3 bytes, and only when it is a legal
+prefix of one unfinished sequence) is tolerated, because that cut is
+ours, not the file's. A body that ends at or before the window gets
+no such allowance; a dangling partial there is genuine corruption and
+still reads as a mismatch. (Issue #916 found the verifier without
+this carve-out misreading legitimate UTF-8 text that happened to have
+a multibyte codepoint straddle byte 1024.)
 
 The default `allowed_extensions` list shipped in `AttachmentConfig` is
 narrowed to extensions whose content type the verifier can check:
@@ -133,6 +141,12 @@ Operators who genuinely need them can re-add the extensions in
   but not zero. A future hardening could parse a JSON file end-to-end
   for `.json`, run an HTML parser tolerantly over `.html`, etc., at
   the cost of more CPU and a wider failure surface.
+- The boundary-truncation carve-out (issue #916) accepts the last
+  ≤3 bytes of the window, when the body runs past it, as an
+  unfinished-but-well-formed sequence without fully validating them.
+  Reaching those bytes requires 1021 bytes of already-valid NUL-free
+  UTF-8 ahead of them, so this sits inside the false-negative surface
+  the bullet above already describes rather than widening it.
 - `filetype` does not ship `py.typed`, so MyPy needs an
   `ignore_missing_imports` override for the one module that imports
   it. The override is documented in `crawdad/pyproject.toml` next to


### PR DESCRIPTION
## Summary

`_verify_text_sample` sliced `data[:_TEXT_SAMPLE_BYTES]` (1024) and strict-decoded it. A multibyte UTF-8 codepoint straddling the window edge raised `UnicodeDecodeError`, which the verifier misread as "this is a binary blob" — so a perfectly valid `.md`/`.txt` came back `status="mismatch"`, `detected_mime="application/octet-stream"`. By default the user gets a spurious "MIME mismatch" warning on a good file; under `AttachmentConfig(reject_on_mime_mismatch=True)` the file is **hard-rejected at the gate** and never lands.

**Confirmed broader than filed.** The issue cites one `é` case; all **six** straddle positions reproduce — 2-byte, 3-byte CJK at both split offsets, and 4-byte emoji at all three. Since the cut is a byte cut and not a character cut, a CJK-heavy note (3 bytes/char) has roughly a **2/3** chance of landing mid-character, so a Japanese/Chinese/Korean journal attachment is more likely than not to be falsely flagged.

### The fix

Decode the sample with `codecs.getincrementaldecoder("utf-8")` and pass `final=not truncated`, where `truncated = len(data) > _TEXT_SAMPLE_BYTES`.

The strict `>` is load-bearing: at exactly 1024 bytes the sample *is* the whole file, so nothing was cut and a dangling partial there is genuine corruption that must still mismatch. `final=not truncated` collapses both modes into a single call with zero added branches — both helpers stay at cyclomatic complexity A.

**Invariant:** the sample is `match` iff (a) it holds no NUL byte anywhere in the 1024-byte window, and (b) every byte decodes as valid UTF-8 except — when and only when the body actually runs past the window — a trailing run of at most 3 bytes forming a legal prefix of one unfinished sequence.

This is a bounded allowance, not a blanket "ignore the tail". The decoder raises on invalid leads, bare or malformed continuations, and overlong or out-of-range forms wherever the disqualifying byte falls inside the window. The NUL scan still runs **first**, over all 1024 raw bytes, independent of decoding — NUL bytes decode as valid UTF-8, so reordering that check would have been a silent security regression.

### Security review

This deliberately loosens a content-sniffing validator, so it got a dedicated adversarial pass: **CLEAN**, no blockers. The strongest polyglot enabled is a blob with 1021 bytes of valid NUL-free UTF-8 followed by a legal lead byte at offsets 1021-1023. That buys zero payload capacity — the region past byte 1024 was never inspected before this change either — so it sits inside the false-negative surface ADR-0002 already documents rather than opening a new one. The effective validated prefix is 1021 bytes worst-case; ADR-0002 now records this.

Empirically verified against CPython's decoder: `\xc0\xaf`, `\xc0\x80` (overlongs), `\xed\xa0\x80` (surrogate), `\xf5…` (out of range), bare continuations and `\xfe\xff` are all **rejected**. A trailing `\xed` or `\xed\xa0` is tolerated, because the byte that would disqualify it lies past the cut and was never inspected — documented precisely in the docstring rather than glossed over.

## Test plan

- **RED proven before implementing:** 9 failed / 53 passed, `AssertionError: assert 'mismatch' == 'match'`.
- Parametrized straddle test over all six positions (2/3/4-byte at every split), each carrying self-check assertions that the codepoint *actually* straddles byte 1024 and that the payload is valid UTF-8 end to end — so a subtly-wrong fixture fails loudly instead of passing for the wrong reason.
- The acceptance criterion spelled out verbatim so it stays greppable against the issue.
- Eight negative tests, each pinning one invariant and each killing a specific weaker implementation: `1024 -> mismatch` / `1025 -> match` as an adjacent pair (the `>` vs `>=` off-by-one); `\xff\xfe` in the last 2 bytes (kills "shave 3 trailing bytes and re-decode"); `\xe6\x28` at the boundary (legal lead, illegal continuation — kills "forgive any tail"); NUL at offset 1023 (kills "shrink the NUL window"); whole-file truncated tail; invalid bytes mid-sample.
- Integration test through `process_attachments` with `reject_on_mime_mismatch=True` proving a valid boundary-straddling file is accepted and written to staging (acceptance criterion 3).
- Test diff is **+236/-0** — purely additive, byte-verified against `HEAD` at every handoff. No existing test touched.

**Gates (both subprojects, since the diff spans `crawdad/` and a `creek-tools/` ADR):**

| gate | result |
|---|---|
| `crawdad/scripts/check-all.sh` | exit 0, 7/7 checks, **526 passed**, **94.59%** coverage (baseline 510 / 94.58%) |
| `creek-tools/scripts/check-all.sh` | exit 0, 12/12 checks, **6351 passed**, **93.99%** coverage |

No `# noqa`, no `# type: ignore`, no skips, no lowered thresholds, no deleted tests, no new dependency (`codecs` is stdlib).

Closes #916

🤖 Generated with [Claude Code](https://claude.com/claude-code)