### PR TITLE
fix(crawdad): forward canonical cloud consent + all provider keys to MCP

### DIFF
--- a/crawdad/crawdad/mcp_client.py
+++ b/crawdad/crawdad/mcp_client.py
@@ -29,15 +29,29 @@ from mcp.client.stdio import (
 )
 from pydantic import BaseModel, ConfigDict
 
+from crawdad.config import _PROVIDER_KEY_ENV
+
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Mapping
 
 _LOGGER = logging.getLogger("crawdad.mcp_client")
 
 #: Credential env vars the stdio SDK scrubs but the in-MCP cloud tools need.
-#: ``CREEK_ANTHROPIC_CONSENT`` gates cloud egress, so it is forwarded only when
-#: explicitly set in CrawDad's own environment (opt-in). See issue #549.
-_FORWARDED_ENV_VARS: Final = ("ANTHROPIC_API_KEY", "CREEK_ANTHROPIC_CONSENT")
+#: The provider API keys are derived from :data:`crawdad.config._PROVIDER_KEY_ENV`
+#: so adding a provider there forwards its key automatically — issue #918 exists
+#: because #610 added openai/gemini and this tuple was left Anthropic-only.
+#: Two consent gates follow: ``CREEK_CLOUD_CONSENT`` is the canonical,
+#: provider-neutral name and ``CREEK_ANTHROPIC_CONSENT`` its deprecated
+#: back-compat alias. Both are spelled as literals here — they mirror
+#: creek-tools' ``creek/classify/llm/consent.py`` rather than importing it,
+#: because CrawDad must not take a Python dependency on creek-tools. Consent is
+#: opt-in: each name is forwarded only when explicitly set in CrawDad's own
+#: environment. See issues #549 and #918.
+_FORWARDED_ENV_VARS: Final[tuple[str, ...]] = (
+    *_PROVIDER_KEY_ENV.values(),
+    "CREEK_CLOUD_CONSENT",
+    "CREEK_ANTHROPIC_CONSENT",
+)
 
 
 def _subprocess_env(source: Mapping[str, str]) -> dict[str, str]:
@@ -45,10 +59,19 @@ def _subprocess_env(source: Mapping[str, str]) -> dict[str, str]:
 
     The stdio SDK launches the server with a scrubbed environment limited to
     a small safe allowlist (:func:`get_default_environment`). That allowlist
-    drops ``ANTHROPIC_API_KEY``, so in-MCP cloud tools
-    (``draft``/``author``/``mine``/``classify``) silently fall back to
-    non-cloud behaviour — issue #549. Re-add the forwarded credential vars
-    that are present (and non-empty) in *source* on top of the safe defaults.
+    drops both the provider API keys and the cloud-consent vars, so an
+    in-MCP tool that would otherwise reach a cloud provider silently
+    degrades to non-cloud behaviour even though the operator consented —
+    issues #549 and #918. Re-add the :data:`_FORWARDED_ENV_VARS` that are
+    present (and non-empty) in *source* on top of the safe defaults.
+
+    Forwarding consent is *not* a tier decision. Which content may reach a
+    cloud provider stays the MCP server's call: creek-tools routes through
+    its own ``ModelRouter`` chokepoint, which keeps Intimate-tier content
+    local regardless of what this function forwards.
+
+    Forwarding is opt-in in both directions: only names actually set in
+    *source* are re-added, and nothing outside the allowlist is ever copied.
 
     Args:
         source: The parent environment to forward credentials from, normally
@@ -56,7 +79,7 @@ def _subprocess_env(source: Mapping[str, str]) -> dict[str, str]:
 
     Returns:
         The SDK safe-default environment augmented with any forwarded
-        credentials. Absent or blank credentials are omitted entirely so the
+        credentials. Absent or blank values are omitted entirely so the
         subprocess never sees an empty value.
     """
     env = dict(get_default_environment())

--- a/crawdad/tests/test_mcp_client.py
+++ b/crawdad/tests/test_mcp_client.py
@@ -202,3 +202,80 @@ async def test_connect_passes_forwarded_env_to_subprocess(
         await session.list_tools()
 
     assert captured["env"]["ANTHROPIC_API_KEY"] == "sk-connect-test"
+
+
+# --- Issue #918: canonical cloud consent + tri-provider keys ---
+
+
+def test_forwarded_env_vars_pin_exact_allowlist() -> None:
+    """The allowlist is exactly the five documented names, with no duplicates.
+
+    The names are spelled as literals on purpose: importing
+    ``crawdad.config._PROVIDER_KEY_ENV`` would make this assertion follow the
+    source instead of pinning it. The length check catches a derivation that
+    emits a name twice.
+    """
+    assert set(mcp_client._FORWARDED_ENV_VARS) == {
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "CREEK_CLOUD_CONSENT",
+        "CREEK_ANTHROPIC_CONSENT",
+    }
+    assert len(mcp_client._FORWARDED_ENV_VARS) == 5
+
+
+def test_subprocess_env_forwards_cloud_consent() -> None:
+    """The canonical ``CREEK_CLOUD_CONSENT`` gate reaches the subprocess."""
+    env = mcp_client._subprocess_env({"CREEK_CLOUD_CONSENT": "1"})
+
+    assert env["CREEK_CLOUD_CONSENT"] == "1"
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY"],
+)
+def test_subprocess_env_forwards_each_provider_key(name: str) -> None:
+    """Every provider key CrawDad supports is forwarded, not just Anthropic's."""
+    env = mcp_client._subprocess_env({name: f"key-for-{name}"})
+
+    assert env[name] == f"key-for-{name}"
+
+
+def test_subprocess_env_forwards_both_consent_vars_independently() -> None:
+    """The canonical consent name is added alongside the legacy alias.
+
+    Both must survive with their own values: adding
+    ``CREEK_CLOUD_CONSENT`` must not displace ``CREEK_ANTHROPIC_CONSENT``
+    for operators still setting the older name.
+    """
+    env = mcp_client._subprocess_env(
+        {
+            "CREEK_CLOUD_CONSENT": "cloud-yes",
+            "CREEK_ANTHROPIC_CONSENT": "anthropic-yes",
+        },
+    )
+
+    assert env["CREEK_CLOUD_CONSENT"] == "cloud-yes"
+    assert env["CREEK_ANTHROPIC_CONSENT"] == "anthropic-yes"
+
+
+def test_subprocess_env_omits_absent_new_vars() -> None:
+    """An empty source env yields no entry for any of the newly added names."""
+    env = mcp_client._subprocess_env({})
+
+    assert "CREEK_CLOUD_CONSENT" not in env
+    assert "OPENAI_API_KEY" not in env
+    assert "GOOGLE_API_KEY" not in env
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["CREEK_CLOUD_CONSENT", "OPENAI_API_KEY", "GOOGLE_API_KEY"],
+)
+def test_subprocess_env_treats_blank_new_vars_as_unset(name: str) -> None:
+    """A blank value is omitted entirely rather than forwarded as an empty string."""
+    env = mcp_client._subprocess_env({name: ""})
+
+    assert name not in env


### PR DESCRIPTION
## Summary

CrawDad forwarded only the **legacy** cloud-consent variable to the MCP subprocess, so an operator who granted consent the documented way had it silently scrubbed.

The stdio MCP SDK launches `creek-tools-mcp` with a scrubbed environment (`get_default_environment()`); only names in `_FORWARDED_ENV_VARS` are re-added. That tuple was `("ANTHROPIC_API_KEY", "CREEK_ANTHROPIC_CONSENT")`, leaving two gaps:

- **`CREEK_CLOUD_CONSENT` was dropped.** It is the canonical, provider-neutral consent variable (`creek/classify/llm/consent.py:21`) and the name the CLI and the `model-setup` / `crawdad-launch` skills all tell operators to set. Only its deprecated alias survived the scrub, so the documented consent flow was broken end-to-end.
- **`OPENAI_API_KEY` / `GOOGLE_API_KEY` were never forwarded.** #610 added the tri-provider surface, but this Anthropic-only tuple from #549 was never generalized, so non-Anthropic providers hit the same silent degradation.

I verified both claims against the code before implementing, and reproduced the drop directly against pre-fix `_subprocess_env`:

```
ANTHROPIC_API_KEY forwarded? True
OPENAI_API_KEY forwarded? False
GOOGLE_API_KEY forwarded? False
CREEK_CLOUD_CONSENT forwarded? False
```

The provider keys are now **derived** from `config._PROVIDER_KEY_ENV` so a fourth provider forwards automatically rather than recreating exactly this drift; the two consent names stay literals mirrored from creek-tools, since CrawDad must not take a Python dependency on it. A test pins the allowlist to five *literal* names, so any change to that dict fails loudly instead of silently widening what crosses into the subprocess.

Exact-match, opt-in, and blank-omitted semantics are unchanged: only names actually set in the source env are copied, nothing outside the allowlist is ever forwarded, and no value is logged.

## Did this enable an unguarded egress path?

This fix has the "restore a documented flow that is silently broken" shape, which can turn a *dead* path into a *live but unguarded* one. I audited the four in-MCP cloud tools that consent unlocks before shipping:

| Tool | Tier enforcement independent of consent? |
|---|---|
| `creek.classify` | **Yes** — `classify_engine.py:390-393` resolves per-tier through `ModelRouter`; the tier is stamped by a local, no-LLM pass *before* the provider is chosen, and `tier_of` fails closed to `INTIMATE`. |
| `creek.author` | **Yes** — `creek/author/client.py:122` resolves via `router.resolve_role(role, tier)`, with the tier derived from the fragments actually cited. |
| `creek.mine` | **N/A** — makes no LLM call at all. |
| `creek.draft` | **No** — see below. |

`provider_is_cloud` is provider-agnostic (anthropic/openai/gemini all `is_cloud=True`), so the newly forwarded OpenAI/Gemini keys open **no** provider-specific tier gap on the router-enforced paths.

`creek.draft` is the exception: `creek_mcp/server.py:156-174` builds its LLM client with no router, stage, or tier, so Intimate-never-cloud is never consulted there. It currently fails closed only *by accident* (an unrelated `AttributeError` — `CreekConfig.llm` is an `LLMRoutingConfig`, which has no `.provider`), which means this PR does **not** make it live. Filed as **#958**, kept out of scope here. That issue flags explicitly that naively fixing the `AttributeError` without adding the router would open a live intimate-to-cloud path, and that the root-cause blind spot is `scripts/typecheck.sh:61` running `mypy creek/` only, never `creek_mcp/`.

## Test plan

Gate run: **`crawdad/scripts/check-all.sh`** — the correct gate for this lane. `creek-tools/scripts/check-all.sh` does not cover `crawdad/`, and this diff touches no creek-tools file, so it was not run.

- **7/7 checks pass** (lint, format, type check, security, docstrings, complexity, tests) — **536 passed**, branch coverage **94.59%**.
- Ran with `ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GOOGLE_API_KEY` / `CREEK_CLOUD_CONSENT` / `CREEK_ANTHROPIC_CONSENT` stripped from the environment. This matters here specifically: the tests are *about* env forwarding, so ambient real values could make an assertion pass for the wrong reason. Every test builds its source env as an explicit dict literal and never reads `os.environ`.
- 6 new tests (26 in `test_mcp_client.py`), added as an appended section — **0 deletions**, all 16 pre-existing tests untouched and passing. Verified RED before implementing: 5 failures (`AssertionError` on the allowlist set; `KeyError` on `CREEK_CLOUD_CONSENT`, `OPENAI_API_KEY`, `GOOGLE_API_KEY`).
- Coverage pins both directions: absent and blank values stay omitted, unlisted vars stay dropped, and the legacy `CREEK_ANTHROPIC_CONSENT` alias still forwards independently of the canonical name.

Plan produced by `chief-architect` on Opus (Fable credits exhausted; downgraded per the fallback path).

Closes #918
Refs #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)