### PR TITLE
fix(vault): re-derive privacy_tier on material fragment rewrite (#922)

### DIFF
--- a/creek-tools/creek/vault/writer.py
+++ b/creek-tools/creek/vault/writer.py
@@ -36,6 +36,7 @@ from creek.models import (
     Authorship,
     DecisionStatus,
     PraxisType,
+    PrivacyTier,
     SourcePlatform,
 )
 from creek.vault.authors import (
@@ -81,6 +82,12 @@ _PLATFORM_SUBFOLDER: dict[str, str] = {
 
 # Destination for soft-tombed fragments whose source unit has vanished (#674).
 _ORPHANED_RELPARTS: tuple[str, ...] = ("10-Liminal", "Orphaned")
+
+# Frontmatter key holding the serialised ``Fragment.voice_proxy_eligible``
+# computed field (BUG-009). It is derived from ``privacy_tier`` +
+# ``source.author``, so any code path that rewrites the tier on disk owes this
+# key a refresh or the snapshot goes stale (#922).
+_VOICE_PROXY_ELIGIBLE_KEY: str = "voice_proxy_eligible"
 
 # Map an AuthorManifest.author_kind -> the fragment's Authorship axis (#470).
 # Any unrecognised kind (the manifest already fails closed to ``human_source``)
@@ -425,6 +432,124 @@ def _clear_classification(post: frontmatter.Post) -> None:
         post.metadata.pop(key, None)
 
 
+def _tier_on_disk(raw: object) -> PrivacyTier:
+    """Parse a frontmatter ``privacy_tier`` value, failing closed to INTIMATE.
+
+    Mirrors :func:`creek.classify.privacy_filter.tier_of` and
+    ``creek_mcp.tools.reflect._fragment_tier``: a value this build does not
+    recognise is a value nobody can vouch for, so it is treated as the
+    most-restrictive tier rather than allowed to raise (which would abort an
+    otherwise-valid in-place rewrite) or to fall through to ``open`` (which
+    would expose the body). The legacy ``"public"`` spelling is still accepted
+    — :meth:`creek.models.PrivacyTier._missing_` maps it to ``OPEN`` (INC-003).
+
+    Args:
+        raw: The frontmatter value, exactly as read from disk.
+
+    Returns:
+        The parsed tier, or ``INTIMATE`` when the value is unrecognised.
+    """
+    try:
+        return PrivacyTier(str(raw))
+    except ValueError:
+        logger.warning(
+            "Fragment file carries unrecognised privacy_tier %r; treating as "
+            "INTIMATE while re-tiering an edited body. Re-run `creek classify` "
+            "to assign a recognised tier.",
+            raw,
+        )
+        return PrivacyTier.INTIMATE
+
+
+def _retier_after_rewrite(
+    post: frontmatter.Post,
+    fragment: Fragment,
+    body: str,
+) -> None:
+    """Re-derive ``privacy_tier`` from the *new* body after a material edit (#922).
+
+    :func:`_clear_classification` drops the classification keys so the next
+    pass revisits the fragment, but ``privacy_tier`` is not one of them — it
+    would keep describing the body that was just overwritten. A fragment
+    rewritten from an essay into recovery content therefore kept its ``open``
+    tier and stayed admissible to an OPEN-ceiling MCP caller until someone
+    happened to re-run a privacy pass.
+
+    The policy mirrors :func:`creek.classify.privacy_pass.apply_tier` exactly,
+    expressed in frontmatter terms rather than model terms:
+
+    * The candidate comes from
+      :class:`~creek.classify.privacy.PrivacyClassifier`, which is pure
+      keyword/platform heuristics — no LLM call, no network, no config — so
+      re-tiering on every material edit is free.
+    * When the frontmatter still owes a tier
+      (:func:`~creek.classify.privacy_pass.needs_tier`: key absent, or present
+      but ``unclassified``) the candidate is taken outright; there is no
+      decision to escalate against.
+    * Otherwise the candidate is merged
+      :func:`~creek.classify.privacy_pass.escalate`-only against the tier **on
+      disk**, so an operator's ``intimate`` survives a benign rewrite. The
+      merge base must be the on-disk value, *not* ``tier_of(fragment)``: the
+      fragment the ingest pipeline hands us is freshly constructed and still
+      carries the model's ``unclassified`` default, which ranks *below*
+      ``open`` in ``privacy_pass._ESCALATION_RANK`` — escalating against it
+      would silently discard the operator's decision.
+    * ``voice_proxy_eligible`` is recomputed from the merged tier and the
+      fragment's authorship. It is a *derived* field
+      (:attr:`creek.models.Fragment.voice_proxy_eligible`, BUG-009) whose
+      on-disk copy is only a serialised snapshot, so leaving it alone would
+      strand a stale ``true`` on a now-intimate fragment and feed it straight
+      into voice-proxy generation.
+
+    Why re-derive, rather than either cheaper move that suggests itself:
+
+    * **Stamping a blanket ``intimate`` on every material rewrite is
+      permanent.** :func:`~creek.classify.privacy_pass.needs_tier` returns
+      ``False`` for any explicit non-``unclassified`` tier, so no ordinary
+      classify pass revisits it, and even ``creek classify --force`` merges
+      through :func:`~creek.classify.privacy_pass.escalate`, which never
+      lowers a tier. Nothing in the package downgrades ``privacy_tier`` — the
+      purge engine explicitly excludes the key — so a blanket stamp would bury
+      every edited fragment at ``intimate`` forever, with a hand edit of the
+      frontmatter the only way back out.
+    * **Resetting to ``unclassified`` is a no-op for exposure.**
+      ``creek_mcp.tier_ceiling`` ranks ``UNCLASSIFIED`` at the same level as
+      ``OPEN``, so a reset fragment stays admissible at an OPEN ceiling —
+      exactly the leak this exists to close.
+
+    Re-deriving avoids both: the tier always describes the current body, and
+    the escalate-only merge preserves operator curation.
+
+    Args:
+        post: Loaded frontmatter of the file being rewritten. Its metadata is
+            mutated in place; the caller writes the post back.
+        fragment: The fragment being re-ingested, supplying the platform and
+            authorship axes the classifier keys on. Never mutated.
+        body: The new markdown body, scanned for recovery keywords.
+    """
+    # Deferred import for the same load-time cycle documented on
+    # `_clear_classification`: `creek.classify.classify_engine` imports
+    # `VaultWriter` from this module.
+    from creek.classify.privacy import PrivacyClassifier
+    from creek.classify.privacy_pass import PRIVACY_TIER_KEY, escalate, needs_tier
+
+    # Mirrors `apply_tier`'s shape: assign outright when nothing is on record,
+    # otherwise merge escalate-only. The ternary short-circuits, so the
+    # subscript is only reached on the branch that proved the key is present.
+    assigning = needs_tier(post.metadata)
+    candidate = PrivacyClassifier().classify_tier(fragment, content=body)
+    tier = (
+        candidate
+        if assigning
+        else escalate(_tier_on_disk(post.metadata[PRIVACY_TIER_KEY]), candidate)
+    )
+    post.metadata[PRIVACY_TIER_KEY] = tier.value
+    post.metadata[_VOICE_PROXY_ELIGIBLE_KEY] = (
+        tier is not PrivacyTier.INTIMATE
+        and Authorship(fragment.source.author) is Authorship.SELF
+    )
+
+
 def _apply_other_author_attribution(
     fragment: Fragment,
     manifest: AuthorManifest,
@@ -628,6 +753,15 @@ class VaultWriter:
         trivial edit (ratio at/above the threshold) preserves classifications.
         The default ``0.0`` never flags — every edit preserves.
 
+        A material change also re-derives ``privacy_tier`` (and the
+        ``voice_proxy_eligible`` flag computed from it) from the **new** body
+        via :func:`_retier_after_rewrite` (#922). Unlike the classification
+        keys, the tier cannot simply be cleared and left for the next pass:
+        while it is stale it still governs read-side admission, so a fragment
+        rewritten into intimate content would stay visible at an OPEN ceiling
+        in the meantime. The re-derivation is escalate-only against the tier
+        already on disk, so it never lowers an operator's decision.
+
         Returns ``None`` when no file is mapped to ``fragment.id`` (e.g. the
         file was removed out of band), so the caller can fall back to a fresh
         :meth:`write_fragment`.
@@ -638,7 +772,8 @@ class VaultWriter:
             body: The new markdown body to write below the preserved
                 frontmatter.
             reclassify_threshold: Body-similarity floor below which the edit is
-                material and classifications are cleared for re-classification.
+                material — classifications are cleared for re-classification and
+                the privacy tier is re-derived from the new body.
 
         Returns:
             Path to the rewritten file, or ``None`` when no existing file
@@ -652,6 +787,7 @@ class VaultWriter:
             post = frontmatter.load(str(existing))
             if _is_material_change(post.content, body, reclassify_threshold):
                 _clear_classification(post)
+                _retier_after_rewrite(post, fragment, body)
             post.content = body
             _atomic_write_text(existing, frontmatter.dumps(post))
             # Record the in-place edit in the provenance log too, so the audit

--- a/creek-tools/docs/idempotent-ingest.md
+++ b/creek-tools/docs/idempotent-ingest.md
@@ -57,6 +57,15 @@ to warrant re-classification:
   `classification_method` / `classified_at` / `classification_reasoning` are
   cleared so the next `creek classify` pass re-does **only that fragment**
   (cooperating with OPS-001 — no global `--force`).
+- A material edit additionally **re-derives `privacy_tier`** (and the
+  `voice_proxy_eligible` flag computed from it) from the *new* body (#922).
+  The tier cannot simply be cleared and left for the next pass the way the
+  classification keys are: while it is stale it still governs read-side
+  admission, so a fragment rewritten into intimate content would stay visible
+  to an `open`-ceiling reader in the meantime. The new tier comes from the
+  deterministic, LLM-free privacy heuristic and is merged **escalate-only**
+  against the tier already on disk — a rewrite can raise a tier but never
+  lower one, so an operator's `intimate` survives a benign rewrite.
 
 The threshold is the config knob
 `classification.reclassify_on_edit_threshold` (default `0.9`, range `0.0–1.0`).

--- a/creek-tools/tests/test_ingest_reclassify_threshold.py
+++ b/creek-tools/tests/test_ingest_reclassify_threshold.py
@@ -386,3 +386,28 @@ class TestMaterialRewriteRetiers:
         post = frontmatter.load(str(path))
         assert post["privacy_tier"] == _INTIMATE
         assert tier_allowed(_fragment_tier(post.metadata), TierCeiling.OPEN) is False
+
+    def test_unrecognised_disk_tier_fails_closed_to_intimate(
+        self, tmp_path: Path
+    ) -> None:
+        """An unparseable on-disk tier is read as ``intimate``, not ``open``.
+
+        Frontmatter is hand-editable and forward-dated vaults may carry tier
+        spellings this build has never heard of. ``_tier_on_disk`` refuses to
+        guess: an unrecognised value is one nobody can vouch for, so the merge
+        base becomes ``intimate`` and the escalate-only merge can only hold
+        there. The rewrite body is deliberately *benign* — the classifier's
+        candidate for it is ``open``, so the only route to an ``intimate``
+        result is the fail-closed parse of ``"bogus-tier"``. A recovery-keyword
+        body would have passed on the candidate alone and proved nothing.
+        """
+        vault = _make_vault(tmp_path)
+        frag, path = self._seed(vault, _ESSAY_SEED, tier="bogus-tier")
+
+        VaultWriter(vault_path=vault).update_fragment(
+            frag, _ESSAY_REWRITE_BENIGN, reclassify_threshold=0.9
+        )
+
+        post = frontmatter.load(str(path))
+        assert post["privacy_tier"] == _INTIMATE
+        assert tier_allowed(_fragment_tier(post.metadata), TierCeiling.OPEN) is False

--- a/creek-tools/tests/test_ingest_reclassify_threshold.py
+++ b/creek-tools/tests/test_ingest_reclassify_threshold.py
@@ -13,10 +13,13 @@ from typing import TYPE_CHECKING
 
 import frontmatter
 
+from creek import models
 from creek.cli import _run_ingest
 from creek.ingest import INGESTOR_REGISTRY
 from creek.models import Fragment, FragmentSource, SourcePlatform
 from creek.vault.writer import VaultWriter
+from creek_mcp.tier_ceiling import TierCeiling, tier_allowed
+from creek_mcp.tools.reflect import _fragment_tier
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -192,3 +195,194 @@ class TestIngestSummary:
         entry.unlink()
         _ingest(vault, journal, print_summary=True)
         assert "0 created, 0 updated, 1 tombed" in capsys.readouterr().out
+
+
+# ---- Material rewrite re-derives the privacy tier (#922) ----------------
+
+# Tiers as they are serialised into frontmatter. Derived from the enum rather
+# than hand-written literals so renaming a tier value breaks these tests
+# loudly instead of silently comparing against a stale string.
+_OPEN = models.PrivacyTier.OPEN.value
+_INTIMATE = models.PrivacyTier.INTIMATE.value
+_UNCLASSIFIED = models.PrivacyTier.UNCLASSIFIED.value
+
+# Bodies for the ESSAY fixture. Their lengths are load-bearing twice over:
+#
+# * ``difflib``'s ratio is bounded above by
+#   ``2 * min(len_a, len_b) / (len_a + len_b)``. The seed is 174 chars and
+#   each rewrite is ~60, so that bound is ~0.5 — below the 0.9 threshold no
+#   matter what the two texts happen to share. Materiality is guaranteed by
+#   construction, not estimated from a sample diff.
+# * Every body stays under 200 chars so ``SequenceMatcher``'s ``autojunk``
+#   heuristic — which discards "popular" elements once the second sequence
+#   reaches 200, and on character sequences that means nearly every letter —
+#   never fires and depresses the trivial-edit ratio below the threshold.
+_ESSAY_SEED = (
+    "An essay on morning pages: three longhand sheets written before the "
+    "day can argue back, no editing until the third page is full, because "
+    "boredom is what quiets the performer."
+)
+_ESSAY_REWRITE_BENIGN = "A short field guide to bread: flour, water, salt, patience."
+_ESSAY_REWRITE_INTIMATE = (
+    "Tonight I wrote about my relapse and what sobriety costs me now."
+)
+# A typo-scale append (ratio 348/367 ~= 0.948, above the 0.9 threshold) that
+# nonetheless drags in the recovery keyword "sponsor": a trivial edit must not
+# re-tier at all, so the keyword must stay inert here.
+_ESSAY_TRIVIAL_KEYWORD = _ESSAY_SEED + " My sponsor agreed."
+
+
+class TestMaterialRewriteRetiers:
+    """A material in-place rewrite re-derives ``privacy_tier`` from the new body.
+
+    ``update_fragment`` cleared the classification keys on a material edit but
+    left ``privacy_tier`` describing the OLD body (#922), so a fragment
+    rewritten into intimate content kept an ``open`` tier and stayed
+    admissible to an OPEN-ceiling MCP caller. The tier must be re-derived from
+    the new body with the deterministic, LLM-free ``PrivacyClassifier`` and
+    merged escalate-only against the tier already on disk.
+    """
+
+    def _seed(
+        self,
+        vault: Path,
+        body: str,
+        *,
+        tier: str,
+        voice_proxy_eligible: bool | None = None,
+    ) -> tuple[Fragment, Path]:
+        """Write a self-authored ESSAY fragment and force its on-disk tier.
+
+        A self-authored ESSAY is the cleanest two-way fixture: a benign body
+        falls through to the ESSAY rule (``open``) while a body carrying a
+        recovery keyword trips the first rule (``intimate``). The title is
+        deliberately keyword-free — the classifier scans title + body.
+        """
+        frag = Fragment(
+            id="frag-tier01",
+            title="Morning Pages",
+            source=FragmentSource(
+                platform=SourcePlatform.ESSAY,
+                author=models.Authorship.SELF,
+            ),
+        )
+        VaultWriter(vault_path=vault).write_fragment(frag, body=body)
+        path = _journal_files(vault)[0]
+        overlay: dict[str, object] = {"privacy_tier": tier}
+        if voice_proxy_eligible is not None:
+            overlay["voice_proxy_eligible"] = voice_proxy_eligible
+        _set_frontmatter(path, **overlay)
+        return frag, path
+
+    def test_rewrite_into_recovery_content_is_refused_at_open_ceiling(
+        self, tmp_path: Path
+    ) -> None:
+        """A rewrite into recovery content re-tiers to intimate AND is refused.
+
+        The frontmatter value is only half the invariant; the read-side
+        ceiling is what actually protects the user, so this asserts the
+        rewritten fragment is inadmissible to an OPEN-ceiling MCP caller.
+        """
+        vault = _make_vault(tmp_path)
+        frag, path = self._seed(vault, _ESSAY_SEED, tier=_OPEN)
+
+        VaultWriter(vault_path=vault).update_fragment(
+            frag, _ESSAY_REWRITE_INTIMATE, reclassify_threshold=0.9
+        )
+
+        post = frontmatter.load(str(path))
+        assert post["privacy_tier"] == _INTIMATE
+        assert tier_allowed(_fragment_tier(post.metadata), TierCeiling.OPEN) is False
+
+    def test_rewrite_into_benign_content_stays_open(self, tmp_path: Path) -> None:
+        """A benign rewrite keeps ``open`` — no blanket blackout on every edit.
+
+        Re-tiering must derive the tier from the new body, not pessimistically
+        bury every materially-edited fragment at the most restrictive tier.
+        """
+        vault = _make_vault(tmp_path)
+        frag, path = self._seed(vault, _ESSAY_SEED, tier=_OPEN)
+
+        VaultWriter(vault_path=vault).update_fragment(
+            frag, _ESSAY_REWRITE_BENIGN, reclassify_threshold=0.9
+        )
+
+        post = frontmatter.load(str(path))
+        assert post["privacy_tier"] == _OPEN
+        assert tier_allowed(_fragment_tier(post.metadata), TierCeiling.OPEN) is True
+
+    def test_rewrite_never_downgrades_an_intimate_tier(self, tmp_path: Path) -> None:
+        """Escalate-only: a benign rewrite cannot lower ``intimate`` on disk.
+
+        The merge base is the tier *on disk*, not the in-memory fragment's
+        (which still carries the ``unclassified`` pipeline default), so an
+        operator's restrictive decision survives a full-body rewrite.
+        """
+        vault = _make_vault(tmp_path)
+        frag, path = self._seed(vault, _ESSAY_SEED, tier=_INTIMATE)
+
+        VaultWriter(vault_path=vault).update_fragment(
+            frag, _ESSAY_REWRITE_BENIGN, reclassify_threshold=0.9
+        )
+
+        post = frontmatter.load(str(path))
+        assert post["privacy_tier"] == _INTIMATE
+        assert tier_allowed(_fragment_tier(post.metadata), TierCeiling.OPEN) is False
+
+    def test_trivial_edit_leaves_the_tier_untouched(self, tmp_path: Path) -> None:
+        """An at/above-threshold edit does not re-tier, keyword or not.
+
+        Re-tiering is bound to the same materiality gate as clearing the
+        classification keys: a typo-scale edit changes nothing, even when the
+        appended text would have classified INTIMATE on its own.
+        """
+        vault = _make_vault(tmp_path)
+        frag, path = self._seed(vault, _ESSAY_SEED, tier=_OPEN)
+
+        VaultWriter(vault_path=vault).update_fragment(
+            frag, _ESSAY_TRIVIAL_KEYWORD, reclassify_threshold=0.9
+        )
+
+        post = frontmatter.load(str(path))
+        assert post["privacy_tier"] == _OPEN
+        assert post["voice_proxy_eligible"] is True
+
+    def test_rewrite_refreshes_derived_voice_proxy_eligible(
+        self, tmp_path: Path
+    ) -> None:
+        """The derived eligibility flag follows the re-derived tier down.
+
+        ``voice_proxy_eligible`` is a computed field of ``privacy_tier`` and
+        ``source.author``; leaving a stale ``true`` on an intimate fragment
+        would feed it straight into voice-proxy generation.
+        """
+        vault = _make_vault(tmp_path)
+        frag, path = self._seed(
+            vault, _ESSAY_SEED, tier=_OPEN, voice_proxy_eligible=True
+        )
+
+        VaultWriter(vault_path=vault).update_fragment(
+            frag, _ESSAY_REWRITE_INTIMATE, reclassify_threshold=0.9
+        )
+
+        post = frontmatter.load(str(path))
+        assert post["voice_proxy_eligible"] is False
+
+    def test_untiered_fragment_gets_a_tier_assigned_outright(
+        self, tmp_path: Path
+    ) -> None:
+        """``unclassified`` on disk means "no decision yet" — take the candidate.
+
+        This is the ``needs_tier`` branch: there is nothing to escalate
+        against, so the fresh verdict is written as-is rather than merged.
+        """
+        vault = _make_vault(tmp_path)
+        frag, path = self._seed(vault, _ESSAY_SEED, tier=_UNCLASSIFIED)
+
+        VaultWriter(vault_path=vault).update_fragment(
+            frag, _ESSAY_REWRITE_INTIMATE, reclassify_threshold=0.9
+        )
+
+        post = frontmatter.load(str(path))
+        assert post["privacy_tier"] == _INTIMATE
+        assert tier_allowed(_fragment_tier(post.metadata), TierCeiling.OPEN) is False


### PR DESCRIPTION
## Summary

`VaultWriter.update_fragment` — the idempotent in-place re-ingest path — cleared a fragment's classification provenance keys on a material rewrite but left `privacy_tier` describing the body that had just been overwritten. Every read-side ceiling check keys on that persisted tier (`creek_mcp/tools/reflect.py::_fragment_tier` → `_above_ceiling`, `creek/classify/privacy_filter.py::tier_of`, `creek_mcp/tier_ceiling.py::tier_allowed`), so a fragment rewritten from an essay into intimate content but still carrying `privacy_tier: open` was admitted straight through the #846 gate to an OPEN-ceiling caller, including a remote one.

The fix re-derives the tier **from the new body** on the material branch, merges it **escalate-only** against the tier on disk, and refreshes the derived `voice_proxy_eligible` key.

### Which of the issue's three options — and why none of them, quite

The issue offered three options and steered toward option 1 (reset to the most restrictive tier). I verified both obvious options are traps by executing the relevant code in this worktree, not just reading it:

**Option 1 (blanket `privacy_tier: intimate`) is not "over-refuse until the next classify pass" — it is permanent and irreversible.**
- `privacy_pass.needs_tier` returns `False` for any explicit non-`unclassified` tier, so no ordinary classify pass ever revisits it (`needs_tier({"privacy_tier": "intimate"})` → `False`).
- Even `creek classify --force` merges through `privacy_pass.escalate`, which never lowers a tier: `escalate(INTIMATE, OPEN)` → `intimate`.
- Nothing in the package downgrades `privacy_tier` — `creek/purge/engine.py`'s `_CLASSIFICATION_RESET_FIELDS` explicitly excludes it.

So a blanket reset would bury **every materially edited fragment at `intimate` forever**, recoverable only by hand-editing vault YAML. On a continuous-ingest vault where journal entries get edited routinely, that progressively buries the corpus. That is a worse bug than the one being fixed, and it is *not* contingent on classifier availability — the ratchet, not the classifier, is what traps it.

**Option 2 (reset to `unclassified`) is a genuine no-op for exposure.** `creek_mcp/tier_ceiling.py::_TIER_RANK` maps `UNCLASSIFIED` to `0`, identical to `OPEN`; `tier_allowed(UNCLASSIFIED, TierCeiling.OPEN)` returns `True`. Same trap as #876.

**Option 3** (gate reads on `classified_at` consistency) spreads the fix across every read site instead of fixing it at the one write site that creates the staleness.

**What this PR does instead:** re-derive the tier from the new body using the existing `PrivacyClassifier.classify_tier`, then merge escalate-only against the on-disk tier. This is the only option that is both fail-closed *and* self-healing:
- the tier always describes the **current** body, so there is no staleness window at all;
- it costs **no LLM call** — `PrivacyClassifier` is pure keyword/platform heuristics, no network, no cloud consent, no Ollama;
- escalate-only preserves operator curation (a manual `intimate` survives a benign rewrite);
- crucially, it does **not** pessimistically bury benign edits, so there is no availability loss.

### On the availability cost the issue asked about

Because the tier is derived rather than blanket-stamped, the permanent-invisibility failure mode does not arise for benign rewrites — a rewritten essay stays `open` and stays visible (pinned by `test_rewrite_into_benign_content_stays_open`). Re-tiering needs no classifier infrastructure, so a host with no cloud consent and no reachable Ollama behaves identically.

One residual, inherited from repo-wide policy rather than introduced here: the escalate-only merge means a fragment that was legitimately `intimate` and is later rewritten into genuinely open content stays `intimate` until an operator edits the frontmatter. That is the same never-auto-downgrade rule `privacy_pass` already enforces everywhere, and lowering is the one direction that leaks.

### Deliberately out of scope

`creek_mcp/tier_ceiling.py::_TIER_RANK[UNCLASSIFIED] = 0` diverges from `creek/classify/privacy_filter.py::_TIER_RANK[UNCLASSIFIED] = 1`, which #876 raised to rank with `PERSONAL` on the reader side. The MCP ceiling is also a reader-side gate, so this looks like a #876 straggler rather than a deliberate policy — but the issue explicitly scopes it out, and it is pinned by deliberate tests (`tests/test_mcp_tier_ceiling.py:51`, `tests/test_mcp_reflect.py:698`, `tests/test_mcp_write_tools.py:1205`). Filed separately; not touched here.

## Changes

- `creek/vault/writer.py` — new `_tier_on_disk` (fail-closed frontmatter tier parse, mirroring `tier_of`/`_fragment_tier`) and `_retier_after_rewrite`, called on the material branch only. Deferred imports, matching the load-time cycle already documented on `_clear_classification` (`classify_engine` imports `VaultWriter`). The escalate base is the **on-disk** tier, never `tier_of(fragment)` — the ingest pipeline hands over a freshly built `Fragment` still carrying the model's `unclassified` default, which ranks *below* `open` in `_ESCALATION_RANK`, so escalating against it would silently discard an operator's `intimate`.
- `docs/idempotent-ingest.md` — documents the re-derivation, the LLM-free heuristic, and the escalate-only merge.

## Test plan

7 new tests in `tests/test_ingest_reclassify_threshold.py::TestMaterialRewriteRetiers`. Every re-tiering test asserts the **read-side ceiling behaviour** (`tier_allowed(_fragment_tier(post.metadata), TierCeiling.OPEN)`), not just the frontmatter string — that is the assertion that actually protects the invariant.

RED before the fix (3), verified by running them:
- `test_rewrite_into_recovery_content_is_refused_at_open_ceiling` — `AssertionError: assert 'open' == 'intimate'`
- `test_rewrite_refreshes_derived_voice_proxy_eligible`
- `test_untiered_fragment_gets_a_tier_assigned_outright`

Guard tests (pinning what must *not* change):
- `test_rewrite_into_benign_content_stays_open` — no blanket blackout
- `test_rewrite_never_downgrades_an_intimate_tier` — escalate-only; also pins the on-disk merge base
- `test_trivial_edit_leaves_the_tier_untouched` — a typo-scale edit does not re-tier even when the appended text carries a recovery keyword
- `test_unrecognised_disk_tier_fails_closed_to_intimate` — covers the fail-closed parse arm with a *benign* rewrite, so the only route to `intimate` is the fail-closed parse

Materiality is guaranteed by construction: difflib's ratio is bounded above by `2*min(la,lb)/(la+lb)`, and the fixture lengths put that bound near 0.5, well below the 0.9 threshold.

**Gate 2** (`creek-tools/scripts/check-all.sh`, the creek-tools gate — the diff does not touch `crawdad/`): **12/12 checks passed**, 6357 tests passed, **93.99%** branch coverage. Full unit suite separately: 6382 passed, 5 skipped, **0 failures — no fixture fallout**, which is itself a consequence of the design: a body-derived, escalate-only merge has far less blast radius than a blanket tier reset would have had.

**Gate 2.5**: `code-review-orchestrator` over the full diff — verdict **CLEAN**, no blockers. It independently confirmed the on-disk merge base, the short-circuit safety of the `post.metadata[PRIVACY_TIER_KEY]` subscript, the `voice_proxy_eligible` formula matching the model's computed field, and that no other write path (`creek/save/writer.py`, `creek/purge/engine.py`, `creek/ingest/refresh.py`) rewrites a body while leaving a stale tier.

Closes #922
