### PR TITLE
fix(mcp): tier-route the creek.compile LLM through ModelRouter (#928, #929)

### DIFF
--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -65,7 +65,9 @@ if TYPE_CHECKING:
     from mcp.server.auth.provider import AccessToken, TokenVerifier
     from mcp.types import ContentBlock
 
+    from creek.compile.engine import CompileLLM
     from creek.models import PrivacyTier
+    from creek_mcp.tools.compile import CompileLLMFactory
     from creek_mcp.tools.reflect import _LLM, _LLMFactory
 
 SERVER_NAME = "creek-tools-mcp"
@@ -174,17 +176,45 @@ def _build_draft_llm() -> Callable[[str], str]:
     return classifier.invoke_prompt
 
 
-def _build_compile_llm() -> Callable[[str], str]:
-    """Return the compile-side LLM callable, mirroring ``creek compile``.
+def _build_compile_llm(tier: PrivacyTier) -> CompileLLM:
+    """Return the compile-side LLM callable, routed for *tier* (#928/#929).
 
-    Lazy import so the server still boots when the LLM provider is not
-    configured; only ``creek.compile`` then fails. Calls into the CLI's
-    private factory rather than re-deriving the configuration so the
-    behaviour stays in lock-step with ``creek compile``.
+    Mirrors :func:`_build_reflect_llm_factory`'s inner factory: the
+    ``generation`` stage is resolved through the config's
+    :class:`~creek.classify.llm.router.ModelRouter`, so an INTIMATE compile is
+    forced onto the local ``default`` model — or the router raises
+    ``IntimateRoutingError`` rather than egressing the source titles the
+    compile prompt carries. Nothing here re-checks the tier or picks a
+    provider: ``compile_tool`` derives the routing tier and this hands it to
+    the one chokepoint that owns the decision.
+
+    Lazy imports keep the server bootable with no provider configured — only a
+    ``creek.compile`` call then fails, and it fails as a structured refusal.
+
+    Args:
+        tier: The routing tier ``compile_tool`` computed from the caller's
+            ceiling and the source fragments' own classifications.
+
+    Returns:
+        A prompt → completion-text callable bound to the resolved provider.
+
+    Raises:
+        RuntimeError: When the resolved provider is unavailable, or — as
+            :class:`~creek.classify.llm.router.IntimateRoutingError`, a
+            subclass — when intimate content has no local backend to fall
+            back to. ``compile_tool`` turns either into a refusal.
     """
-    from creek.compile.engine import _default_llm as _engine_default_llm
+    from creek.classify.llm.providers import build_provider
 
-    return _engine_default_llm(load_config().llm)
+    cfg = load_config().model_router.resolve("generation", tier)
+    provider = build_provider(cfg)
+    if not provider.available:
+        msg = (
+            "LLM provider unavailable for compile. "
+            "Check Ollama or ANTHROPIC_API_KEY configuration."
+        )
+        raise RuntimeError(msg)
+    return lambda prompt: provider.complete(prompt).text
 
 
 def _build_reflect_llm_factory() -> _LLMFactory:
@@ -219,7 +249,7 @@ def build_server(
     *,
     vault_path: Path | None = None,
     draft_llm_factory: Callable[[], Callable[[str], str]] | None = None,
-    compile_llm_factory: Callable[[], Callable[[str], str]] | None = None,
+    compile_llm_factory: CompileLLMFactory | None = None,
     reflect_llm_factory: Callable[[], _LLMFactory] | None = None,
     token_verifier: TokenVerifier | None = None,
 ) -> FastMCP:
@@ -232,9 +262,10 @@ def build_server(
         draft_llm_factory: Optional factory for the draft LLM. The
             factory is invoked lazily so only ``creek.draft`` needs an
             LLM provider.
-        compile_llm_factory: Optional factory for the compile LLM.
-            Invoked lazily so only ``creek.compile`` needs an LLM
-            provider.
+        compile_llm_factory: Optional tier-keyed factory for the compile
+            LLM — ``factory(tier)``. Passed straight to ``creek.compile``,
+            which invokes it lazily (and only after its source-tier gate),
+            so only ``creek.compile`` needs an LLM provider.
         reflect_llm_factory: Optional thunk returning the tier-keyed LLM
             factory for ``creek.reflect``. Invoked lazily per call so only
             ``creek.reflect`` needs an LLM provider.

--- a/creek-tools/creek_mcp/tier_ceiling.py
+++ b/creek-tools/creek_mcp/tier_ceiling.py
@@ -5,6 +5,16 @@ content above the ceiling is omitted or returned as a title-only stub.
 The four ceiling values mirror
 :class:`creek.classify.privacy_filter.PrivacyTierOverride` so the MCP
 surface and ``--include-tier`` stay in lock-step.
+
+Two distinct questions are answered here, both off the same ranking:
+
+- *admission* — :func:`tier_allowed` / :func:`write_tier_allowed`: may this
+  content be read (or created) under the caller's ceiling at all?
+- *routing* — :func:`routing_tier`: given that it was admitted, which
+  :class:`~creek.models.PrivacyTier` must the LLM call be keyed with so
+  :class:`creek.classify.llm.router.ModelRouter` applies the
+  ``Intimate``-never-cloud gate (#928)? Every tool that hands content to a
+  model derives its tier here rather than deciding for itself.
 """
 
 from __future__ import annotations
@@ -47,6 +57,10 @@ _CEILING_TO_OVERRIDE = {
 }
 
 
+# The one sensitivity ranking in the MCP surface: open/unclassified <
+# personal < intimate. Both the admission predicates and the routing helpers
+# read it through :func:`tier_sensitivity` so a tier can never rank one way
+# for "may I read this?" and another for "where may I send it?".
 _TIER_RANK = {
     PrivacyTier.OPEN: 0,
     PrivacyTier.UNCLASSIFIED: 0,
@@ -61,6 +75,66 @@ _CEILING_RANK = {
     TierCeiling.INTIMATE: 2,
     TierCeiling.ALL: 3,
 }
+
+
+# The most sensitive tier each ceiling admits, i.e. the tier a call made under
+# it must be *routed* as. ``ALL`` admits intimate content by definition, so a
+# call under it routes INTIMATE whether or not this particular request happens
+# to carry any.
+CEILING_ROUTING_TIER: dict[TierCeiling, PrivacyTier] = {
+    TierCeiling.OPEN: PrivacyTier.OPEN,
+    TierCeiling.PERSONAL: PrivacyTier.PERSONAL,
+    TierCeiling.INTIMATE: PrivacyTier.INTIMATE,
+    TierCeiling.ALL: PrivacyTier.INTIMATE,
+}
+
+
+def tier_sensitivity(tier: PrivacyTier) -> int:
+    """Return the routing/admission rank of *tier*, failing closed.
+
+    Args:
+        tier: The tier to rank.
+
+    Returns:
+        ``0`` for ``open`` and ``unclassified``, ``1`` for ``personal``,
+        ``2`` for ``intimate``. A tier the ranking has never heard of is a
+        tier nobody can vouch for, so it ranks *with* ``intimate`` rather
+        than defaulting to ``0`` and being routed to a cloud provider.
+    """
+    return _TIER_RANK.get(tier, _TIER_RANK[PrivacyTier.INTIMATE])
+
+
+def routing_tier(ceiling: TierCeiling, content_tier: PrivacyTier | None) -> PrivacyTier:
+    """Return the tier an LLM call must be keyed with (#928).
+
+    The router's cloud gate keys on :class:`~creek.models.PrivacyTier`, never
+    on :class:`TierCeiling`, so every tool that hands content to a model
+    reconciles the two available signals here by taking the **more
+    sensitive**: the content's own classification, and the ceiling the caller
+    declared (itself a statement about what the call is permitted to reach).
+
+    Taking the maximum is what makes the result uncheatable from the outside:
+    a caller can neither declare a low ceiling to win cloud routing for
+    intimate content, nor supply low-tier content to win it under a broad
+    ceiling.
+
+    Args:
+        ceiling: The caller's declared ceiling.
+        content_tier: The classified tier of the content being sent, or
+            ``None`` when there is nothing classified to reconcile against
+            (raw caller-supplied text). ``None`` must not be read as "tier
+            zero" — it falls back to the ceiling-derived tier.
+
+    Returns:
+        The more sensitive of the ceiling-derived tier and *content_tier*.
+        An unrecognised ceiling — like an unrecognised tier (see
+        :func:`tier_sensitivity`) — fails closed to
+        :attr:`~creek.models.PrivacyTier.INTIMATE`, i.e. local-only.
+    """
+    ceiling_tier = CEILING_ROUTING_TIER.get(ceiling, PrivacyTier.INTIMATE)
+    if content_tier is None:
+        return ceiling_tier
+    return max(ceiling_tier, content_tier, key=tier_sensitivity)
 
 
 def to_privacy_override(ceiling: TierCeiling) -> PrivacyTierOverride:
@@ -78,11 +152,13 @@ def tier_allowed(tier: PrivacyTier, ceiling: TierCeiling) -> bool:
 
     ``ALL`` admits every tier (including ``unclassified``); other
     ceilings compare by rank so ``PERSONAL`` admits ``open`` +
-    ``personal`` but rejects ``intimate``.
+    ``personal`` but rejects ``intimate``. The rank comes from
+    :func:`tier_sensitivity`, so an unrecognised tier is refused rather
+    than raising across the MCP boundary.
     """
     if ceiling is TierCeiling.ALL:
         return True
-    return _TIER_RANK[tier] <= _CEILING_RANK[ceiling]
+    return tier_sensitivity(tier) <= _CEILING_RANK[ceiling]
 
 
 def write_tier_allowed(write_tier: PrivacyTier, ceiling: TierCeiling) -> bool:

--- a/creek-tools/creek_mcp/tools/compile.py
+++ b/creek-tools/creek_mcp/tools/compile.py
@@ -15,7 +15,12 @@ of them was asserted in this docstring and implemented nowhere):
   The check runs
   ahead of any LLM client being built, any page being written, and any
   paradox being logged — the three places the source ids would
-  otherwise escape (enumerated in :func:`compile_tool`).
+  otherwise escape (enumerated in :func:`compile_tool`). And when that
+  client *is* built, it is built **for the routing tier** — the more
+  sensitive of the ceiling and the admitted sources — so the source
+  titles the prompt carries reach a model only through
+  :class:`creek.classify.llm.router.ModelRouter`'s
+  ``Intimate``-never-cloud chokepoint (#928).
 - **The refusal names nothing.** It carries the fixed
   :data:`_ABOVE_CEILING_REASON`: no ids, no titles, no tiers, not even a
   count of how many sources were above the ceiling.
@@ -28,7 +33,7 @@ of them was asserted in this docstring and implemented nowhere):
 - **The gate and the engine share one fragment loader.** Both read the
   vault through :func:`creek.vault.reader.iter_vault_fragments`, so the
   two can never disagree about which files exist or which of them are
-  fragments (see :func:`_sources_above_ceiling`).
+  fragments (see :func:`_survey_sources`).
 
 **Idempotency semantics (audit-dedup only).** The wrapper fingerprints
 the target file after each compile and stamps the hash under
@@ -46,7 +51,7 @@ Engine-side LLM-call dedup is tracked separately as a follow-up.
 from __future__ import annotations
 
 import hashlib
-from typing import TYPE_CHECKING, Any, Final, Protocol, cast
+from typing import TYPE_CHECKING, Any, Final, NamedTuple, Protocol, cast
 
 from creek.compile.engine import TARGET_KINDS, compile_to_vault
 from creek.models import PrivacyTier
@@ -55,12 +60,15 @@ from creek_mcp.audit import MCPAuditLog
 from creek_mcp.tier_ceiling import (
     TierCeiling,
     refusal_response,
+    routing_tier,
+    tier_sensitivity,
     write_tier_allowed,
 )
 
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from creek.compile.engine import CompileLLM
     from creek.models import CompileTargetKind, Fragment
 
 TOOL_NAME = "creek.compile"
@@ -86,8 +94,10 @@ TOOL_NAME = "creek.compile"
 #   because the symmetry is accidental and a refactor could destroy it:
 #   ``iter_vault_fragments`` materialises the whole directory into a list before
 #   returning, so the rglob + parse cost is paid in full before
-#   ``_sources_above_ceiling``'s loop begins. The early ``return True`` therefore
-#   short-circuits only in-memory iteration, not the I/O. Unlike
+#   ``_survey_sources``'s loop begins. The loop no longer short-circuits
+#   at all — it runs to completion, collecting every requested fragment's tier
+#   before anything is decided — so the probe cost is now uniform *by
+#   construction* rather than resting on that accident. Unlike
 #   ``reflect.py::_resolve_entry``, which walks a raw lazy ``rglob`` and returns
 #   at the match — a genuine timing channel that comment correctly records. If
 #   this gate is ever switched to a lazy loader (see the load-once follow-up),
@@ -105,14 +115,23 @@ _ABOVE_CEILING_REASON: Final[str] = "source fragments exceed tier ceiling"
 
 
 class CompileLLMFactory(Protocol):
-    """Zero-argument callable returning the prompt → JSON-text LLM client.
+    """Tier-keyed builder for the prompt → JSON-text LLM client.
+
+    ``factory(tier)`` returns the client for a call carrying *tier*
+    content. The production factory resolves through
+    :class:`creek.classify.llm.router.ModelRouter`, so an ``INTIMATE``
+    tier is forced onto the local model — or refused — rather than
+    egressing (#928); this module never picks a provider itself, it only
+    derives the routing tier (:func:`creek_mcp.tier_ceiling.routing_tier`)
+    and hands it over.
 
     The factory is invoked lazily so an unconfigured LLM provider only
-    fails the ``creek.compile`` invocation, not server startup. The
-    server bootstrap supplies a production factory; tests pass a stub.
+    fails the ``creek.compile`` invocation, not server startup — and not
+    at all when the source-tier gate refuses. The server bootstrap
+    supplies a production factory; tests pass a stub.
     """
 
-    def __call__(self) -> object: ...
+    def __call__(self, tier: PrivacyTier) -> CompileLLM: ...
 
 
 def _fingerprint(path: Path) -> str | None:
@@ -158,10 +177,31 @@ def _tier_of(fragment: Fragment, raw: dict[str, object]) -> PrivacyTier:
     return fragment.privacy_tier
 
 
-def _sources_above_ceiling(
+class _SourceGate(NamedTuple):
+    """The two signals one walk over the requested source fragments yields.
+
+    Both are derived from the same :func:`_tier_of` reading of the same
+    file, so admission and routing can never disagree about a fragment.
+
+    Attributes:
+        above_ceiling: Whether at least one requested fragment sits above
+            the caller's ceiling, i.e. whether the call must be refused.
+        max_tier: The most sensitive tier among the requested fragments
+            that resolved — what the LLM call must be routed as.
+    """
+
+    above_ceiling: bool
+    max_tier: PrivacyTier
+
+
+def _survey_sources(
     vault_path: Path, fragment_ids: list[str], ceiling: TierCeiling
-) -> bool:
-    """Return whether any requested source fragment's tier exceeds *ceiling*.
+) -> _SourceGate:
+    """Survey the requested source fragments: admission decision + routing tier.
+
+    Deliberately *not* named as a predicate. It returns a
+    :class:`_SourceGate`, not a bool, so ``if _survey_sources(...)`` would be
+    vacuously true; the caller must branch on ``.above_ceiling`` explicitly.
 
     The vault is walked through
     :func:`creek.vault.reader.iter_vault_fragments` — the exact function
@@ -205,20 +245,35 @@ def _sources_above_ceiling(
         ceiling: The caller's declared ceiling.
 
     Returns:
-        ``True`` when at least one requested fragment is above *ceiling*.
-        Deliberately a bare bool — the offending ids never leave this function;
-        see :data:`_ABOVE_CEILING_REASON` for why.
+        A :class:`_SourceGate`. Its ``above_ceiling`` is ``True`` when at least
+        one requested fragment is above *ceiling*; its ``max_tier`` is the most
+        sensitive tier among the requested fragments that resolved, failing
+        closed to ``INTIMATE`` when *none* of them did — with no evidence about
+        what the call would carry, the safe assumption is the worst one.
+
+        The *refusal decision* is still deliberately a bare bool: the offending
+        ids never leave this function; see :data:`_ABOVE_CEILING_REASON` for
+        why. ``max_tier`` is returned alongside it solely to key the LLM router
+        (#928) and **must never appear in any response, refusal reason, or
+        audit payload** — echoing it would hand the caller exactly the per-call
+        tier-classification oracle :data:`_ABOVE_CEILING_REASON` exists to
+        prevent, and would be strictly worse than the bare bool: the bool says
+        only "something you named is above your ceiling", while ``max_tier``
+        names the rank. That invariant is the one new leak surface returning
+        the pair creates, so it is stated here rather than left implied.
     """
     requested = set(fragment_ids)
-    for _path, fragment, _body, raw in iter_vault_fragments(
-        vault_path / "01-Fragments",
-    ):
-        if fragment.id in requested and not write_tier_allowed(
-            _tier_of(fragment, raw),
-            ceiling,
-        ):
-            return True
-    return False
+    tiers = [
+        _tier_of(fragment, raw)
+        for _path, fragment, _body, raw in iter_vault_fragments(
+            vault_path / "01-Fragments",
+        )
+        if fragment.id in requested
+    ]
+    return _SourceGate(
+        above_ceiling=any(not write_tier_allowed(tier, ceiling) for tier in tiers),
+        max_tier=max(tiers, key=tier_sensitivity, default=PrivacyTier.INTIMATE),
+    )
 
 
 def compile_tool(
@@ -239,10 +294,13 @@ def compile_tool(
     every call; see the module docstring for the idempotency scope.
 
     Args:
-        llm_factory: Zero-argument callable returning the compile LLM
-            client. Invoked lazily so the LLM provider only matters
-            when this tool is actually called — and not at all when the
-            source-tier gate refuses.
+        llm_factory: Tier-keyed builder for the compile LLM client;
+            ``llm_factory(tier)`` returns it. Invoked lazily so the LLM
+            provider only matters when this tool is actually called — and
+            not at all when the source-tier gate refuses. The tier is the
+            more sensitive of *privacy_tier_ceiling* and the sources'
+            own classifications, so the production factory's router
+            forces an intimate compile onto the local model (#928).
         privacy_tier_ceiling: The caller's ceiling. Compile's variant of
             the FEAT-011 write-side rule gates the *source* fragments'
             classified tiers, not the tier of the content created (which
@@ -259,7 +317,10 @@ def compile_tool(
         fragment above *privacy_tier_ceiling*
         (:data:`_ABOVE_CEILING_REASON`, #848 — the only refusal that is
         audited); or an engine ``ValueError`` / ``RuntimeError``, such
-        as a fragment id that does not resolve in the vault.
+        as a fragment id that does not resolve in the vault, an
+        unavailable provider, or the router's
+        :class:`~creek.classify.llm.router.IntimateRoutingError` when
+        intimate sources have no local backend to fall back to.
     """
     if target_kind not in TARGET_KINDS:
         return refusal_response(
@@ -290,11 +351,16 @@ def compile_tool(
     # It sits *above* everything that follows, because each of those steps
     # hands the source fragments somewhere the caller is not admitted to:
     #
-    # - ``llm_factory()`` is evaluated as an *argument* to ``compile_to_vault``
-    #   below, and the prompt the engine builds emits ``id:`` and ``title:``
-    #   for every source unconditionally (``_fragment_excerpt_for_prompt``
-    #   redacts only the *body*) to a provider that is **not** tier-routed.
-    #   That is the primary egress breach.
+    # - ``llm_factory(tier)`` is evaluated as an *argument* to
+    #   ``compile_to_vault`` below, and the prompt the engine builds emits
+    #   ``id:`` and ``title:`` for every source unconditionally
+    #   (``_fragment_excerpt_for_prompt`` redacts only the *body*). That
+    #   provider is now tier-routed — the factory is keyed with the routing
+    #   tier, so an admitted intimate source is forced onto the local model
+    #   or refused (#928). Routing is not admission, though: sending a
+    #   fragment the caller may not read to a *local* model still hands it
+    #   to a summariser they were never admitted to, and the compiled page
+    #   that summary lands in is the leak. So the gate must still win.
     # - ``compile_to_vault`` writes the compiled page — carrying per-claim
     #   provenance that names the source ids — into ``02-Threads`` /
     #   ``03-Eddies`` / ``06-Frequencies``, pages any ``open``-ceiling read
@@ -325,7 +391,8 @@ def compile_tool(
     # one field the log persists verbatim — is omitted, as are ``created_path``
     # and ``created_tier`` (nothing was created). ``target_title`` is omitted
     # too: caller free text, irrelevant to a refusal.
-    if _sources_above_ceiling(vault_path, fragment_ids, privacy_tier_ceiling):
+    gate = _survey_sources(vault_path, fragment_ids, privacy_tier_ceiling)
+    if gate.above_ceiling:
         MCPAuditLog(vault_path).append(
             tool=TOOL_NAME,
             args={
@@ -341,6 +408,13 @@ def compile_tool(
         )
 
     kind = cast("CompileTargetKind", target_kind)
+    # The more sensitive of the ceiling and the admitted sources, so no
+    # declaration a caller can make buys cloud routing for intimate content:
+    # a low ceiling loses to the sources' own tiers, and low-tier sources lose
+    # to a high ceiling. Built here rather than by the factory because only the
+    # wrapper has seen both signals — and only *after* the gate above, so a
+    # refused call never reaches a provider at all.
+    tier = routing_tier(privacy_tier_ceiling, gate.max_tier)
     try:
         written = compile_to_vault(
             fragment_ids=list(fragment_ids),
@@ -348,7 +422,7 @@ def compile_tool(
             target_kind=kind,
             target_id=target_id,
             target_title=target_title,
-            llm=llm_factory(),
+            llm=llm_factory(tier),
         )
     except (ValueError, RuntimeError) as exc:
         return refusal_response(

--- a/creek-tools/creek_mcp/tools/compile.py
+++ b/creek-tools/creek_mcp/tools/compile.py
@@ -241,7 +241,16 @@ def _survey_sources(
             matching fragment in the vault is **not** a violation — it falls
             through to the engine's ``ValueError("Fragment(s) not found in
             vault: ...")`` so a legitimate caller still learns the id does not
-            resolve.
+            resolve. One deployment-dependent exception: when *no* requested id
+            resolves, ``max_tier`` fails closed to ``INTIMATE`` (below), and
+            ``llm_factory(tier)`` is evaluated as a call *argument* to
+            ``compile_to_vault`` — so it runs before the engine's not-found
+            check. On a vault whose ``generation`` **and** ``default`` stages
+            are both cloud, the router's ``IntimateRoutingError`` therefore
+            wins over the not-found message. That is safe (it fails closed and
+            names no id) and it is not caller-influenced — it depends on the
+            operator's model config, not on the request — but the not-found
+            refusal is not guaranteed under that one configuration.
         ceiling: The caller's declared ceiling.
 
     Returns:

--- a/creek-tools/creek_mcp/tools/reflect.py
+++ b/creek-tools/creek_mcp/tools/reflect.py
@@ -61,6 +61,7 @@ from creek_mcp.audit import MCPAuditLog
 from creek_mcp.tier_ceiling import (
     TierCeiling,
     refusal_response,
+    routing_tier,
     tier_allowed,
     to_privacy_override,
 )
@@ -91,30 +92,6 @@ class _LLMFactory(Protocol):
         """Return an LLM callable routed for *tier* (may raise to refuse)."""
 
 
-# ``ALL`` admits intimate content, so a reflection under it must route as INTIMATE.
-_CEILING_ROUTING_TIER: dict[TierCeiling, PrivacyTier] = {
-    TierCeiling.OPEN: PrivacyTier.OPEN,
-    TierCeiling.PERSONAL: PrivacyTier.PERSONAL,
-    TierCeiling.INTIMATE: PrivacyTier.INTIMATE,
-    TierCeiling.ALL: PrivacyTier.INTIMATE,
-}
-
-# Sensitivity rank for picking the more-restrictive of two tiers (mirrors the
-# canonical ranking in :mod:`creek_mcp.tier_ceiling`): open/unclassified < personal
-# < intimate. An unranked value is treated as the most sensitive (fail closed).
-_TIER_SENSITIVITY: dict[PrivacyTier, int] = {
-    PrivacyTier.OPEN: 0,
-    PrivacyTier.UNCLASSIFIED: 0,
-    PrivacyTier.PERSONAL: 1,
-    PrivacyTier.INTIMATE: 2,
-}
-
-
-def _sensitivity(tier: PrivacyTier) -> int:
-    """Return the routing sensitivity of *tier*, defaulting to the most restrictive."""
-    return _TIER_SENSITIVITY.get(tier, _TIER_SENSITIVITY[PrivacyTier.INTIMATE])
-
-
 def _routing_tier(ceiling: TierCeiling, entry_tier: PrivacyTier | None) -> PrivacyTier:
     """Pick the routing tier — never below the entry's *actual* classification.
 
@@ -138,11 +115,13 @@ def _routing_tier(ceiling: TierCeiling, entry_tier: PrivacyTier | None) -> Priva
     has no *entry_tier*) against the ceiling. It stays in place as defense in
     depth — the load-bearing INTIMATE-never-egresses guarantee — and must not be
     removed.
+
+    The reconciliation itself lives in
+    :func:`creek_mcp.tier_ceiling.routing_tier`, shared with ``creek.compile``
+    (#928); this wrapper keeps the reflect-specific reasoning above attached to
+    the call site that depends on it.
     """
-    ceiling_tier = _CEILING_ROUTING_TIER.get(ceiling, PrivacyTier.INTIMATE)
-    if entry_tier is None:
-        return ceiling_tier
-    return max(ceiling_tier, entry_tier, key=_sensitivity)
+    return routing_tier(ceiling, entry_tier)
 
 
 def _above_ceiling(entry_tier: PrivacyTier | None, ceiling: TierCeiling) -> bool:

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import os
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+import frontmatter
 import pytest
 
 from creek_mcp.auth import ELEVATED_TOKEN_ENV
@@ -565,6 +567,192 @@ def test_build_reflect_llm_factory_routes_then_degrades(
     )
     with pytest.raises(RuntimeError):
         server_mod._build_reflect_llm_factory()(PrivacyTier.OPEN)
+
+
+# --------------------------------------------------------------------------- #
+# Compile LLM: tier-routed production factory (#928) + real wiring (#929)
+# --------------------------------------------------------------------------- #
+
+
+class _CompletionStub:
+    """A provider completion exposing only the ``.text`` field callers read."""
+
+    def __init__(self, text: str) -> None:
+        """Store the completion *text*."""
+        self.text = text
+
+
+class _ProviderSpy:
+    """A ``build_provider`` stand-in recording the configs it was handed.
+
+    Doubles as the provider it returns so one object covers construction
+    (which resolved config the router produced) and use (which prompts were
+    completed). ``available`` mirrors the real provider flag so the
+    degraded path can be exercised without a live backend.
+    """
+
+    def __init__(self, *, available: bool = True, text: str = "{}") -> None:
+        """Start with empty recordings, the given availability and response."""
+        self.configs: list[object] = []
+        self.prompts: list[str] = []
+        self.available = available
+        self.text = text
+
+    def build(self, config: object) -> _ProviderSpy:
+        """Record *config* and return this spy as the constructed provider."""
+        self.configs.append(config)
+        return self
+
+    def complete(self, prompt: str) -> _CompletionStub:
+        """Record *prompt* and return the canned completion."""
+        self.prompts.append(prompt)
+        return _CompletionStub(self.text)
+
+    @property
+    def provider_names(self) -> list[object]:
+        """Return the ``provider`` of every recorded config, in call order."""
+        return [getattr(config, "provider", None) for config in self.configs]
+
+
+def _patch_build_provider(monkeypatch: pytest.MonkeyPatch, spy: _ProviderSpy) -> None:
+    """Route every ``build_provider`` import path through *spy*.
+
+    The factory is reachable as ``creek.classify.llm.providers.build_provider``
+    (the router/reflect import) and via the ``creek.classify.llm`` re-export
+    (what :func:`creek.compile.engine.default_llm` imports), so both names are
+    patched and the spy records whichever path production actually takes.
+    """
+    monkeypatch.setattr("creek.classify.llm.providers.build_provider", spy.build)
+    monkeypatch.setattr("creek.classify.llm.build_provider", spy.build)
+
+
+def _split_routing_config() -> object:
+    """Return a config stub whose ``default`` is local and ``generation`` cloud.
+
+    The two stages deliberately disagree so a resolved ``ollama`` proves the
+    ``Intimate``-never-cloud redirect ran, while a resolved ``anthropic``
+    proves the ``generation`` stage (not the ``default``) was consulted.
+    """
+    from creek.classify.llm.router import ModelRouter
+    from creek.config import LLMConfig, LLMRoutingConfig
+
+    routing = LLMRoutingConfig(
+        default=LLMConfig(provider="ollama"),
+        generation=LLMConfig(provider="anthropic"),
+    )
+
+    class _Config:
+        """Minimal ``CreekConfig`` stand-in exposing the LLM routing surface."""
+
+        llm = routing
+        model_router = ModelRouter(routing)
+
+    return _Config()
+
+
+def _write_open_fragment(vault: Path, frag_id: str) -> None:
+    """Write one ``open``-tier fragment under ``01-Fragments/Notes``."""
+    metadata = {
+        "type": "fragment",
+        "id": frag_id,
+        "title": f"Title {frag_id}",
+        "created": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "ingested": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "F1", "secondary": []},
+        "privacy_tier": "open",
+        "eddies": [],
+    }
+    target = vault / "01-Fragments" / "Notes" / f"{frag_id}.md"
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content="Body text.", **metadata)),
+        encoding="utf-8",
+    )
+
+
+def test_build_compile_llm_routes_by_tier_then_degrades(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The compile factory is tier-keyed and honours the router (#928/#929).
+
+    Mirrors :func:`test_build_reflect_llm_factory_routes_then_degrades`, but
+    against a *real* :class:`~creek.classify.llm.router.ModelRouter` so the
+    ``Intimate``-never-cloud redirect under test is the production one and
+    not a stub's opinion.
+
+    Three properties, each of which the pre-fix ``_build_compile_llm``
+    violates: it takes no tier at all, it builds straight from
+    ``load_config().llm`` (never touching the router), and it imports a name
+    (``creek.compile.engine._default_llm``) that does not exist — so every
+    production ``creek.compile`` call raises ``ImportError``.
+    """
+    from creek.models import PrivacyTier
+    from creek_mcp import server as server_mod
+
+    monkeypatch.setattr(server_mod, "load_config", _split_routing_config)
+    spy = _ProviderSpy(text="compiled")
+    _patch_build_provider(monkeypatch, spy)
+
+    # INTIMATE: the cloud ``generation`` stage is redirected to local default.
+    assert server_mod._build_compile_llm(PrivacyTier.INTIMATE)("p") == "compiled"
+    assert spy.provider_names == ["ollama"]
+
+    # OPEN: no redirect, and the ``generation`` stage (not ``default``) wins.
+    assert server_mod._build_compile_llm(PrivacyTier.OPEN)("p") == "compiled"
+    assert spy.provider_names == ["ollama", "anthropic"]
+    assert spy.prompts == ["p", "p"]
+
+    unavailable = _ProviderSpy(available=False)
+    _patch_build_provider(monkeypatch, unavailable)
+    with pytest.raises(RuntimeError) as excinfo:
+        server_mod._build_compile_llm(PrivacyTier.OPEN)
+    assert "unavailable" in str(excinfo.value).lower()
+
+
+def test_build_server_wires_the_production_compile_llm_factory(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``creek.compile`` works with no ``compile_llm_factory`` injected (#929).
+
+    This is the test that would have caught #929. Every existing compile
+    test injects ``compile_llm_factory``, which is exactly what hid a
+    production factory that raises ``ImportError`` on its first line — the
+    registered tool was never once exercised against the code path real
+    clients take.
+
+    So the injection point is deliberately left empty: ``build_server`` must
+    fall back to its own factory, and the tool must complete end to end
+    through the registered FastMCP handler.
+    """
+    from creek_mcp import server as server_mod
+
+    _write_open_fragment(vault, "frag-open")
+    monkeypatch.setattr(server_mod, "load_config", _split_routing_config)
+    spy = _ProviderSpy()
+    _patch_build_provider(monkeypatch, spy)
+
+    server = build_server(vault_path=vault)
+    result = asyncio.run(
+        server.call_tool(
+            "creek.compile",
+            {
+                "fragment_ids": ["frag-open"],
+                "target_kind": "thread",
+                "target_id": "thread-x",
+                "target_title": "Thread X",
+                "privacy_tier_ceiling": "open",
+            },
+        ),
+    )
+
+    structured = _structured(result)
+    assert structured["status"] == "ok"
+    assert structured["compiled_path"] == "02-Threads/Active/thread-x.md"
+    assert (vault / "02-Threads" / "Active" / "thread-x.md").exists()
+    # An ``open`` ceiling over ``open`` sources routes to the cloud
+    # ``generation`` stage — the router ran, and did not over-restrict.
+    assert spy.provider_names == ["anthropic"]
 
 
 # --------------------------------------------------------------------------- #

--- a/creek-tools/tests/test_mcp_tier_ceiling.py
+++ b/creek-tools/tests/test_mcp_tier_ceiling.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import pytest
 
 from creek.classify.privacy_filter import PrivacyTierOverride
 from creek.models import PrivacyTier
 from creek_mcp.tier_ceiling import (
+    CEILING_ROUTING_TIER,
     TierCeiling,
     TierCeilingViolationError,
     refusal_response,
+    routing_tier,
     tier_allowed,
+    tier_sensitivity,
     to_privacy_override,
 )
 
@@ -84,3 +89,112 @@ def test_tier_ceiling_violation_is_exception() -> None:
     """The violation error is raisable and catchable in tool wrappers."""
     with pytest.raises(TierCeilingViolationError):
         raise TierCeilingViolationError("test")
+
+
+# ---------------------------------------------------------------------------
+# Routing-tier helpers (#928) — shared by reflect and compile
+# ---------------------------------------------------------------------------
+
+
+def test_ceiling_routing_tier_maps_every_ceiling() -> None:
+    """Every ceiling has a routing tier, and ``all`` routes as ``intimate``.
+
+    ``ALL -> INTIMATE`` is the load-bearing row: ``all`` admits intimate
+    content by definition, so a call made under it must be routed as though
+    intimate content is present whether or not this particular request
+    happens to carry any. The equality is against the whole dict (not a
+    lookup per row) so a silently *added* ceiling cannot slip through
+    unmapped.
+    """
+    assert CEILING_ROUTING_TIER == {
+        TierCeiling.OPEN: PrivacyTier.OPEN,
+        TierCeiling.PERSONAL: PrivacyTier.PERSONAL,
+        TierCeiling.INTIMATE: PrivacyTier.INTIMATE,
+        TierCeiling.ALL: PrivacyTier.INTIMATE,
+    }
+    assert set(CEILING_ROUTING_TIER) == set(TierCeiling)
+
+
+@pytest.mark.parametrize(
+    ("tier", "expected"),
+    [
+        (PrivacyTier.OPEN, 0),
+        (PrivacyTier.UNCLASSIFIED, 0),
+        (PrivacyTier.PERSONAL, 1),
+        (PrivacyTier.INTIMATE, 2),
+    ],
+)
+def test_tier_sensitivity_ranks(tier: PrivacyTier, expected: int) -> None:
+    """Sensitivity ranks ``open``/``unclassified`` < ``personal`` < ``intimate``."""
+    assert tier_sensitivity(tier) == expected
+
+
+def test_tier_sensitivity_unknown_tier_fails_closed() -> None:
+    """An unranked tier value is treated as the most sensitive one.
+
+    A tier the ranking has never heard of is a tier nobody can vouch for, so
+    it must rank *with* ``intimate`` rather than default to 0 and be routed
+    to a cloud provider. Asserted against the literal rank as well as
+    ``intimate``'s, so lowering the fallback cannot pass by coincidence.
+    """
+    unknown = cast("PrivacyTier", "not-a-tier")
+    assert tier_sensitivity(unknown) == 2
+    assert tier_sensitivity(unknown) == tier_sensitivity(PrivacyTier.INTIMATE)
+
+
+@pytest.mark.parametrize(
+    ("ceiling", "content_tier", "expected"),
+    [
+        (TierCeiling.OPEN, PrivacyTier.OPEN, PrivacyTier.OPEN),
+        (TierCeiling.OPEN, PrivacyTier.UNCLASSIFIED, PrivacyTier.OPEN),
+        (TierCeiling.OPEN, PrivacyTier.PERSONAL, PrivacyTier.PERSONAL),
+        (TierCeiling.OPEN, PrivacyTier.INTIMATE, PrivacyTier.INTIMATE),
+        (TierCeiling.PERSONAL, PrivacyTier.OPEN, PrivacyTier.PERSONAL),
+        (TierCeiling.PERSONAL, PrivacyTier.INTIMATE, PrivacyTier.INTIMATE),
+        (TierCeiling.INTIMATE, PrivacyTier.OPEN, PrivacyTier.INTIMATE),
+        (TierCeiling.ALL, PrivacyTier.OPEN, PrivacyTier.INTIMATE),
+        (TierCeiling.ALL, PrivacyTier.UNCLASSIFIED, PrivacyTier.INTIMATE),
+    ],
+)
+def test_routing_tier_picks_the_more_sensitive_signal(
+    ceiling: TierCeiling,
+    content_tier: PrivacyTier,
+    expected: PrivacyTier,
+) -> None:
+    """The routing tier is the more sensitive of ceiling-derived and content.
+
+    Both directions are covered: rows where the content is more sensitive
+    than the ceiling (an ``intimate`` fragment under ``ceiling=open``) and
+    rows where the ceiling is more sensitive than the content (an ``open``
+    fragment under ``ceiling=all``). Dropping either term breaks a row.
+    """
+    assert routing_tier(ceiling, content_tier) is expected
+
+
+@pytest.mark.parametrize(
+    ("ceiling", "expected"),
+    [
+        (TierCeiling.OPEN, PrivacyTier.OPEN),
+        (TierCeiling.PERSONAL, PrivacyTier.PERSONAL),
+        (TierCeiling.INTIMATE, PrivacyTier.INTIMATE),
+        (TierCeiling.ALL, PrivacyTier.INTIMATE),
+    ],
+)
+def test_routing_tier_without_content_tier_uses_the_ceiling(
+    ceiling: TierCeiling,
+    expected: PrivacyTier,
+) -> None:
+    """``content_tier=None`` (no classified content) falls back to the ceiling.
+
+    ``None`` is what a caller has when there is nothing classified to
+    reconcile against — raw inline ``content`` in ``creek.reflect``. It must
+    not be read as "tier zero".
+    """
+    assert routing_tier(ceiling, None) is expected
+
+
+def test_routing_tier_unknown_ceiling_fails_closed() -> None:
+    """An unrecognised ceiling routes ``intimate`` — local-only."""
+    unknown = cast("TierCeiling", "not-a-ceiling")
+    assert routing_tier(unknown, None) is PrivacyTier.INTIMATE
+    assert routing_tier(unknown, PrivacyTier.OPEN) is PrivacyTier.INTIMATE

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -16,7 +16,9 @@ from typing import TYPE_CHECKING
 import frontmatter
 import pytest
 
+from creek.classify.llm.router import ModelRouter
 from creek.compile.engine import PARADOX_LOG_RELPATH
+from creek.config import LLMConfig, LLMRoutingConfig
 from creek.models import PrivacyTier
 from creek.save import TARGET_SUBDIRS
 from creek_mcp.audit import (
@@ -74,12 +76,13 @@ def _write_fragment(
     frag_id: str,
     body: str = "Body text.",
     privacy_tier: str = "open",
+    title: str | None = None,
 ) -> None:
     """Write a minimal fragment under ``01-Fragments/Notes`` for compile tests."""
     metadata = {
         "type": "fragment",
         "id": frag_id,
-        "title": f"Title {frag_id}",
+        "title": title or f"Title {frag_id}",
         "created": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
         "ingested": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
         "source": {"platform": "journal", "author": "self"},
@@ -831,7 +834,7 @@ def test_skills_refresh_writes_audit_entry(vault: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _noop_llm_factory() -> object:
+def _noop_llm_factory(tier: PrivacyTier) -> object:
     """Return a deterministic stub LLM for compile-tool tests."""
     return lambda _prompt: "{}"
 
@@ -889,7 +892,7 @@ def test_compile_writes_audit_then_noop_on_re_run(
         "creek_mcp.tools.compile.compile_to_vault",
         _stub_compile,
     )
-    stub_factory = lambda: lambda _prompt: "{}"  # noqa: E731
+    stub_factory = lambda tier: lambda _prompt: "{}"  # noqa: E731
 
     first = compile_tool(
         vault_path=vault,
@@ -937,7 +940,7 @@ def test_compile_propagates_engine_errors_as_refusal(
         target_kind="thread",
         target_id="thread-x",
         target_title="Thread X",
-        llm_factory=lambda: lambda _prompt: "{}",
+        llm_factory=lambda tier: lambda _prompt: "{}",
         privacy_tier_ceiling=TierCeiling.OPEN,
     )
     assert result["status"] == "refused"
@@ -967,7 +970,7 @@ class _RecordingLLMFactory:
         """Start with a zero invocation count."""
         self.calls = 0
 
-    def __call__(self) -> object:
+    def __call__(self, tier: PrivacyTier) -> object:
         """Record one invocation and return a deterministic stub LLM."""
         self.calls += 1
         return lambda _prompt: "{}"
@@ -1042,7 +1045,7 @@ def test_compile_refusal_writes_no_page_no_paradox_log_no_hash_marker(
         },
     )
 
-    def _leaky_factory() -> object:
+    def _leaky_factory(tier: PrivacyTier) -> object:
         """Return a stub LLM that would emit a page body and a paradox."""
         return lambda _prompt: payload
 
@@ -1414,6 +1417,417 @@ def test_compile_reports_unknown_target_kind_even_with_above_ceiling_sources(
     assert "unknown target_kind" in result["reason"]
     assert result["reason"] != _ABOVE_CEILING_REASON
     assert factory.calls == 0
+
+
+# ---------------------------------------------------------------------------
+# compile — tier-routed LLM factory (issues #928 / #929)
+# ---------------------------------------------------------------------------
+
+
+class _CompletionStub:
+    """A provider completion exposing only the ``.text`` field callers read."""
+
+    def __init__(self, text: str) -> None:
+        """Store the completion *text*."""
+        self.text = text
+
+
+class _ProviderSpy:
+    """A ``build_provider`` stand-in that records configs *and* prompts.
+
+    It doubles as the provider it hands back, so one object captures both
+    halves of the egress path: *which*
+    :class:`~creek.config.LLMConfig` the router resolved (i.e. the
+    ``Intimate``-never-cloud decision) and *what text* actually reached the
+    backend. Asserting only the first would leave "the prompt is harmless
+    anyway" unproven; asserting only the second would leave the routing
+    unproven.
+    """
+
+    def __init__(self, *, available: bool = True, text: str = "{}") -> None:
+        """Start with empty recordings, the given availability and response."""
+        self.configs: list[LLMConfig] = []
+        self.prompts: list[str] = []
+        self.available = available
+        self.text = text
+
+    def build(self, config: LLMConfig) -> _ProviderSpy:
+        """Record *config* and return this spy as the constructed provider."""
+        self.configs.append(config)
+        return self
+
+    def complete(self, prompt: str) -> _CompletionStub:
+        """Record *prompt* and return the canned completion."""
+        self.prompts.append(prompt)
+        return _CompletionStub(self.text)
+
+    @property
+    def provider_names(self) -> list[str]:
+        """Return the ``provider`` of every recorded config, in call order."""
+        return [config.provider for config in self.configs]
+
+
+class _RoutingConfigStub:
+    """A minimal ``CreekConfig`` stand-in carrying a *real* routing config.
+
+    Exposes both ``llm`` (the raw :class:`~creek.config.LLMRoutingConfig`)
+    and ``model_router`` (a real
+    :class:`~creek.classify.llm.router.ModelRouter` over it), so the
+    ``Intimate``-never-cloud decision exercised by these tests is the
+    production one no matter which of the two the server's factory reads.
+    Nothing about the tier gate is stubbed.
+    """
+
+    def __init__(self, *, default: str, generation: str) -> None:
+        """Build the two-stage routing config and its router."""
+        self.llm = LLMRoutingConfig(
+            default=LLMConfig(provider=default),
+            generation=LLMConfig(provider=generation),
+        )
+        self.model_router = ModelRouter(self.llm)
+
+
+def _patch_build_provider(monkeypatch: pytest.MonkeyPatch, spy: _ProviderSpy) -> None:
+    """Route every ``build_provider`` import path through *spy*.
+
+    The provider factory is reachable under two names —
+    ``creek.classify.llm.providers.build_provider`` (what the router and
+    ``creek_mcp.server._build_reflect_llm_factory`` import) and the
+    ``creek.classify.llm`` re-export (what
+    :func:`creek.compile.engine.default_llm` imports). Both are patched so
+    the recorded config is the one the production path actually used,
+    whichever import it takes.
+    """
+    monkeypatch.setattr("creek.classify.llm.providers.build_provider", spy.build)
+    monkeypatch.setattr("creek.classify.llm.build_provider", spy.build)
+
+
+class _TierRecordingLLMFactory:
+    """Compile LLM factory recording the tier it was keyed with, per call.
+
+    Distinct from :class:`_RecordingLLMFactory`, which counts invocations to
+    prove the #848 gate refused *before* the client was built. This one pins
+    *what* the wrapper computed as the routing tier, which is the whole of
+    issue #928: a factory invoked with the wrong tier egresses exactly as
+    badly as one invoked when it should not have been.
+
+    ``tiers`` is typed to admit ``None`` so a regression that passes no tier
+    (or an explicit ``None``, which
+    :meth:`~creek.classify.llm.router.ModelRouter.resolve` treats as "no tier
+    gate") is caught by an assertion rather than silently ranking as
+    non-intimate.
+    """
+
+    def __init__(self) -> None:
+        """Start with no recorded tiers."""
+        self.tiers: list[PrivacyTier | None] = []
+
+    def __call__(self, tier: PrivacyTier) -> object:
+        """Record *tier* and return a deterministic stub LLM."""
+        self.tiers.append(tier)
+        return lambda _prompt: "{}"
+
+
+_INTIMATE_TITLE = "Sealed Confession Marker"
+_INTIMATE_BODY = "The intimate body text that must never leave this machine."
+
+
+def test_compile_routes_intimate_sources_to_the_local_provider(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mixed-tier compile: the real router forces the real prompt onto ollama.
+
+    The flagship regression for #928 (compile bypasses ``ModelRouter``) and
+    #929 (the production factory does not import). Nothing is stubbed at the
+    seam under test: ``creek_mcp.server._build_compile_llm`` *is* the
+    factory, a real :class:`~creek.classify.llm.router.ModelRouter` resolves
+    the ``generation`` stage, and only ``build_provider`` is replaced — by a
+    spy that records what it was handed.
+
+    The ceiling is ``intimate``, so the #848 gate *admits* the intimate
+    source: this is the live-egress case, not the refusal case.
+
+    The prompt assertion is the point. ``creek.compile.engine._build_prompt``
+    emits ``title:`` for every source unconditionally, and
+    ``_fragment_excerpt_for_prompt`` redacts only the *body* — putting the
+    title straight back into the body line as
+    ``[Intimate-tier summary: <title>]``. An intimate fragment's title is
+    therefore live egress payload. It may reach a local model; it must never
+    reach the cloud one.
+    """
+    from creek_mcp import server as server_mod
+
+    _write_fragment(vault, frag_id="frag-open", privacy_tier="open")
+    _write_fragment(
+        vault,
+        frag_id="frag-int",
+        body=_INTIMATE_BODY,
+        privacy_tier="intimate",
+        title=_INTIMATE_TITLE,
+    )
+    spy = _ProviderSpy()
+    _patch_build_provider(monkeypatch, spy)
+    monkeypatch.setattr(
+        server_mod,
+        "load_config",
+        lambda: _RoutingConfigStub(default="ollama", generation="anthropic"),
+    )
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-open", "frag-int"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=server_mod._build_compile_llm,
+        privacy_tier_ceiling=TierCeiling.INTIMATE,
+    )
+
+    # (a) the real ``_enforce_local_for_intimate`` ran: the cloud
+    # ``generation`` config was replaced by the local ``default``.
+    assert spy.provider_names == ["ollama"]
+    # (b) the payload that would have egressed is real, not hypothetical.
+    assert len(spy.prompts) == 1
+    assert _INTIMATE_TITLE in spy.prompts[0]
+    assert _INTIMATE_BODY not in spy.prompts[0]
+    # (c) routing correctly does not break the ordinary success path.
+    assert result["status"] == "ok"
+
+
+@pytest.mark.parametrize(
+    ("sources", "ceiling", "expected_tier"),
+    [
+        (
+            (("frag-open", "open"),),
+            TierCeiling.OPEN,
+            PrivacyTier.OPEN,
+        ),
+        (
+            (("frag-open", "open"), ("frag-pers", "personal")),
+            TierCeiling.PERSONAL,
+            PrivacyTier.PERSONAL,
+        ),
+        (
+            (("frag-open", "open"),),
+            TierCeiling.INTIMATE,
+            PrivacyTier.INTIMATE,
+        ),
+        (
+            (("frag-open", "open"), ("frag-int", "intimate")),
+            TierCeiling.INTIMATE,
+            PrivacyTier.INTIMATE,
+        ),
+        (
+            (("frag-open", "open"),),
+            TierCeiling.ALL,
+            PrivacyTier.INTIMATE,
+        ),
+        (
+            (("frag-open", "open"), ("frag-pers", "personal")),
+            TierCeiling.ALL,
+            PrivacyTier.INTIMATE,
+        ),
+    ],
+    ids=[
+        "open-ceiling-open-source",
+        "personal-ceiling-personal-source",
+        "intimate-ceiling-open-sources-only",
+        "intimate-ceiling-intimate-source",
+        "all-ceiling-open-sources-only",
+        "all-ceiling-personal-source",
+    ],
+)
+def test_compile_keys_the_llm_factory_with_the_routing_tier(
+    vault: Path,
+    sources: tuple[tuple[str, str], ...],
+    ceiling: TierCeiling,
+    expected_tier: PrivacyTier,
+) -> None:
+    """The factory is keyed with the more sensitive of ceiling and sources.
+
+    Pins the routing table for #928. Two rows carry the defense-in-depth
+    argument that mirrors ``creek_mcp.tools.reflect._routing_tier``: an
+    ``intimate`` ceiling over nothing but ``open`` sources, and an ``all``
+    ceiling over the same, both route ``INTIMATE`` — because the ceiling the
+    caller declared is itself a statement about what the call is permitted
+    to reach, and ``all`` admits intimate content by definition.
+
+    The factory must be invoked exactly once (a second build is a second
+    provider handshake, and on a re-resolve could pick a different backend)
+    and never with ``None``, which
+    :meth:`~creek.classify.llm.router.ModelRouter.resolve` treats as "apply
+    no tier gate at all" — the precise shape of the #928 bug.
+    """
+    for frag_id, privacy_tier in sources:
+        _write_fragment(vault, frag_id=frag_id, privacy_tier=privacy_tier)
+    factory = _TierRecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=[frag_id for frag_id, _ in sources],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=ceiling,
+    )
+
+    assert result["status"] == "ok"
+    assert factory.tiers == [expected_tier]
+    assert None not in factory.tiers
+
+
+def test_compile_routing_fails_closed_when_no_source_id_resolves(
+    vault: Path,
+) -> None:
+    """An unresolvable request routes ``INTIMATE`` and still says "not found".
+
+    Two halves, and both matter. The routing half is the only row in the
+    #928 table where the *source* term strictly dominates the ceiling term:
+    with nothing found in the vault there is no evidence about what the call
+    would carry, so the max-source tier fails closed to ``INTIMATE`` even
+    under ``ceiling=open``.
+
+    The UX half guards the fix's blast radius: routing local must not turn
+    the engine's ordinary not-found refusal into a generic one. A caller
+    with a typo'd id still learns which id does not resolve — and learns it
+    from the engine, not from the ceiling gate (hence the explicit
+    inequality against :data:`_ABOVE_CEILING_REASON`).
+    """
+    factory = _TierRecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-missing"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert factory.tiers == [PrivacyTier.INTIMATE]
+    assert result["status"] == "refused"
+    assert "not found" in result["reason"]
+    assert "frag-missing" in result["reason"]
+    assert result["reason"] != _ABOVE_CEILING_REASON
+
+
+def test_compile_routing_fails_closed_when_privacy_tier_key_is_absent(
+    vault: Path,
+) -> None:
+    """A fragment with no ``privacy_tier`` key routes as ``INTIMATE``.
+
+    The routing counterpart to
+    :func:`test_compile_fails_closed_when_privacy_tier_key_is_absent`, which
+    covers the *admission* side of the same file. ``ceiling=all`` admits the
+    hand-edited / legacy fragment, so the routing tier is the only thing
+    standing between its title and a cloud provider;
+    ``creek_mcp.tools.compile._tier_of`` reports ``INTIMATE`` for it and the
+    factory must be keyed with exactly that.
+    """
+    _write_fragment_without_tier(vault, frag_id="frag-legacy")
+    factory = _TierRecordingLLMFactory()
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-legacy"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+
+    assert result["status"] == "ok"
+    assert factory.tiers == [PrivacyTier.INTIMATE]
+
+
+def test_compile_refuses_when_intimate_has_no_local_backend(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``IntimateRoutingError`` surfaces as a refusal, not a transport crash.
+
+    When *both* ``default`` and ``generation`` are cloud there is nowhere
+    safe to send intimate content, and the router raises rather than
+    egressing. ``IntimateRoutingError`` subclasses ``RuntimeError``, which
+    ``compile_tool`` already catches, so the caller must get the ordinary
+    structured refusal.
+
+    Everything except the routing decision is wired to *succeed* — the
+    provider spy reports ``available`` and returns parseable JSON — so a
+    refusal here can only have come from the router. The reason string is
+    pinned to the router's own wording because a provider-unavailability
+    ``RuntimeError`` also becomes ``status="refused"``, and a bare status
+    assertion could not tell the two apart.
+    """
+    from creek_mcp import server as server_mod
+
+    _write_fragment(vault, frag_id="frag-int", privacy_tier="intimate")
+    spy = _ProviderSpy()
+    _patch_build_provider(monkeypatch, spy)
+    monkeypatch.setattr(
+        server_mod,
+        "load_config",
+        lambda: _RoutingConfigStub(default="anthropic", generation="anthropic"),
+    )
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-int"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=server_mod._build_compile_llm,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+
+    assert result["status"] == "refused"
+    assert "cannot route to cloud provider" in result["reason"]
+    assert "anthropic" in result["reason"]
+    # No provider was ever constructed, so nothing could have egressed.
+    assert spy.configs == []
+    assert spy.prompts == []
+    # A refused call leaves no page and no idempotency state behind.
+    assert not (vault / "02-Threads" / "Active" / "thread-x.md").exists()
+    assert not (vault / "00-Creek-Meta" / "audit" / "compile-thread-x.hash").exists()
+
+
+def test_compile_above_ceiling_refusal_gains_no_tier_field(vault: Path) -> None:
+    """Routing must not add a tier-derived field to the refusal or its audit row.
+
+    Anti-oracle guard for #928. The above-ceiling refusal deliberately names
+    nothing — see :data:`_ABOVE_CEILING_REASON` — and the computed routing
+    tier is exactly the kind of field a well-meaning implementation would
+    add "for debuggability". Echoing it would turn one refused call into the
+    bulk tier-classification oracle that constant exists to prevent, so the
+    key sets are pinned exactly rather than merely spot-checked.
+    """
+    _write_fragment(vault, frag_id="frag-sealed", privacy_tier="intimate")
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-sealed"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=_noop_llm_factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert set(result) == {"status", "tool", "tier_ceiling", "reason"}
+    assert result["status"] == "refused"
+    assert result["reason"] == _ABOVE_CEILING_REASON
+
+    entries = [e for e in _read_audit(vault) if e["tool"] == "creek.compile"]
+    assert len(entries) == 1
+    entry = entries[0]
+    assert {key for key in entry if "tier" in key} == {"tier_ceiling"}
+    args_summary = entry["args_summary"]
+    assert isinstance(args_summary, dict)
+    assert {key for key in args_summary if "tier" in key} == set()
 
 
 # ---------------------------------------------------------------------------

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -1795,6 +1795,58 @@ def test_compile_refuses_when_intimate_has_no_local_backend(
     assert not (vault / "00-Creek-Meta" / "audit" / "compile-thread-x.hash").exists()
 
 
+def test_compile_routing_refusal_can_preempt_the_not_found_refusal(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With an all-cloud config, a zero-resolving compile refuses on routing.
+
+    Pins the one deployment-dependent seam in ``_survey_sources``'s
+    contract. ``llm_factory(tier)`` is evaluated as a call *argument* to
+    ``compile_to_vault``, so Python runs it before the engine can report
+    "Fragment(s) not found". When no requested id resolves, ``max_tier``
+    fails closed to ``INTIMATE``; if ``default`` and ``generation`` are
+    both cloud, the router refuses first and its message — not the
+    not-found one — reaches the caller.
+
+    Documented rather than fixed because it fails closed and names no id,
+    and because it turns on the operator's model config, not on anything
+    the caller sends. The test exists so a refactor that reorders the
+    argument evaluation has to do so deliberately. Contrast
+    :func:`test_compile_routing_fails_closed_when_no_source_id_resolves`,
+    which pins the ordinary local-default case where the caller *does*
+    still get the not-found message.
+    """
+    from creek_mcp import server as server_mod
+
+    spy = _ProviderSpy()
+    _patch_build_provider(monkeypatch, spy)
+    monkeypatch.setattr(
+        server_mod,
+        "load_config",
+        lambda: _RoutingConfigStub(default="anthropic", generation="anthropic"),
+    )
+
+    result = compile_tool(
+        vault_path=vault,
+        fragment_ids=["frag-does-not-exist"],
+        target_kind="thread",
+        target_id="thread-x",
+        target_title="Thread X",
+        llm_factory=server_mod._build_compile_llm,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "refused"
+    assert "cannot route to cloud provider" in result["reason"]
+    # The routing refusal preempted the engine's not-found message.
+    assert "not found" not in result["reason"]
+    # The refusal still names no fragment id, and nothing was ever built.
+    assert "frag-does-not-exist" not in result["reason"]
+    assert spy.configs == []
+    assert spy.prompts == []
+
+
 def test_compile_above_ceiling_refusal_gains_no_tier_field(vault: Path) -> None:
     """Routing must not add a tier-derived field to the refusal or its audit row.
 


### PR DESCRIPTION
## Summary

`creek.compile` on the MCP surface had two entangled defects. Fixing either alone would have been wrong, so both land here.

- **#929** — `creek_mcp/server.py:185` imported `_default_llm`, but `creek/compile/engine.py:516` defines `default_llm` (no underscore). Every production invocation raised `ImportError`. Tests never caught it because `server.py:257` lets them inject `compile_llm_factory` — factory injection is exactly what hid the bug.
- **#928** — the same line passed `load_config().llm` (an `LLMRoutingConfig`, which has no `.provider`) straight into the provider factory, bypassing `ModelRouter`, the Intimate-never-cloud chokepoint.

**Why one PR:** the broken import was the *only* thing preventing the unrouted egress. Correcting the symbol name in isolation would have converted a dead path into a live, router-bypassing one — shipping the leak the breakage was accidentally suppressing. This path has never worked in any form; #929 was never a one-character fix.

### What egresses

`_build_prompt` emits `id:` and `title:` for **every** source unconditionally; `_fragment_excerpt_for_prompt` redacts only the *body*, replacing it with `[Intimate-tier summary: {title}]` — putting the title straight back. So intimate **titles** are live egress payload, exactly as the issue says.

### The fix

`_build_compile_llm(tier)` resolves the `generation` stage via `ModelRouter.resolve(stage, tier)`. Empirically, `tier=None` returns the cloud provider and only `tier=INTIMATE` triggers `_enforce_local_for_intimate` — so passing a tier is the whole ballgame.

`compile_tool` keys the factory with **the more sensitive of** the caller's ceiling and the maximum tier across admitted sources:

| ceiling | sources | routes to |
|---|---|---|
| OPEN | all open | cloud |
| PERSONAL | open+personal | cloud |
| INTIMATE / ALL | open only | **local** |
| INTIMATE / ALL | any intimate | **local** |
| any | no `privacy_tier` key | **local** (fails closed) |
| any | zero ids resolve | **local** (fails closed) |

Taking the max is what makes it uncheatable: a low declared ceiling loses to the sources' own tiers, and low-tier sources lose to a high ceiling. No declaration a remote consumer can make buys cloud routing for intimate content.

This mirrors `reflect._routing_tier`, whose docstring calls the ceiling term "defense in depth ... must not be removed". That reconciliation is promoted into public `creek_mcp.tier_ceiling.routing_tier` and now **shared** by reflect and compile, so the two MCP surfaces cannot drift on the privacy rule — and it collapses a duplicated tier ranking.

The tier is computed in the **existing** #848 gate walk (`_sources_above_ceiling` → `_survey_sources`, returning a `_SourceGate`), so there is **no extra vault I/O** — important at 35k fragments. The early `return True` is gone, which makes the probe-cost uniformity that the #848 comment called "accidental" true by construction. `max_tier` never enters any response, refusal, or audit payload; echoing it would create a per-call tier-classification oracle strictly worse than the documented bare-bool one, and there is a regression test pinning that.

## Test plan

Gate 2: `./scripts/check-all.sh` → **exit 0**, 6388 passed, coverage 94.00% (baseline on `main` was 6354 passed, also exit 0).

Because `creek_mcp/` is outside the static-analysis net (`scripts/typecheck.sh:61` runs `mypy creek/` only — per #925, and *that exclusion is why both defects survived*), I ran `python -m mypy creek_mcp/` by hand: **7 errors → 4**. The three eliminated are precisely this bug (`server.py:185 has no attribute "_default_llm"; maybe "default_llm"?`, the `no-any-return` beside it, and compile.py's `object` arg-type). The 4 remaining are pre-existing and out of scope. `typecheck.sh` is deliberately unchanged — that is #925's scope.

Key tests:
- `test_compile_routes_intimate_sources_to_the_local_provider` — the flagship. Mixed tiers (intimate among open) at a ceiling that **admits** intimate, so it is the live-egress case, not the refusal case. Nothing is stubbed at the seam under test: the real `_build_compile_llm` is the factory, a **real `ModelRouter`** resolves the stage, and only `build_provider` is spied. Asserts the resolved provider is local **and** that the intimate title is genuinely in the prompt that reached it (and the body is not). A single-tier compile could not pin this.
- `test_compile_keys_the_llm_factory_with_the_routing_tier` — 6-way matrix; asserts exactly one call with the exact tier, and never `None`.
- `test_build_server_wires_the_production_compile_llm_factory` — builds the server **omitting** `compile_llm_factory` entirely. This is the test that would have caught #929.
- Fail-closed pins for absent `privacy_tier` and zero-resolving ids; `IntimateRoutingError` → structured refusal; and an anti-oracle guard that the refusal gains no tier-derived field.

Gate 2.5 self-review returned **CLEAN** with no blockers. Its one nit — the source-gate docstring overstated its not-found guarantee — is fixed in the third commit, with a test pinning the argument-evaluation ordering.

## Notes

- Test integrity: exactly **6** deleted lines across all test files, every one verified signature-only (adding the `tier` parameter to stub factories) plus one additive `title=` kwarg. Assertion counts rose 162→191, 59→69, 4→13. Reflect's tests are **unmodified and green**, which is the proof the shared-helper extraction changed no behavior.
- Out of scope, filed separately: **#962** — `creek compile` on the **CLI** (`cli.py:2477`) calls `resolve("generation")` with no tier, so the same gate is a no-op there. It needs the engine-signature change already tracked as a follow-up, and the threat model differs (vault owner vs. remote consumer).
- **#931** (persisted `structural_path` can carry an unrequested intimate ancestor's title into the prompt) is a real residual this PR does **not** close.
- Added evidence to **#958**: `creek.draft` is broken the same way (`AttributeError: 'LLMRoutingConfig' object has no attribute 'provider'`) and latently suppresses the same unrouted egress — so it needs the same both-at-once treatment.

Closes #928
Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)