### PR TITLE
fix(quality): bring creek_mcp under mypy, bandit and pylint (#925)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,9 @@ jobs:
         run: ruff format --check .
 
       - name: Run Pylint (CI-002)
-        # ./scripts/pylint.sh runs `python -m pylint creek/` with the
-        # configured --fail-under threshold and optionally writes a JSON
-        # snapshot. Same script the local check-all.sh runs, so a
+        # ./scripts/pylint.sh runs `python -m pylint creek/ creek_mcp/`
+        # with the configured --fail-under threshold and optionally writes
+        # a JSON snapshot. Same script the local check-all.sh runs, so a
         # developer who passes locally cannot fail this gate (CI-004).
         env:
           PYLINT_FAIL_UNDER: ${{ env.PYLINT_FAIL_UNDER }}
@@ -92,7 +92,7 @@ jobs:
 
       - name: Run MyPy type checking (CI-001)
         # Project-wide strict mode is configured in pyproject.toml; the
-        # script runs `mypy creek/` so local and CI agree.
+        # script runs `mypy creek/ creek_mcp/` so local and CI agree.
         run: ./scripts/typecheck.sh
 
       - name: Run Refurb (STYLE-001 modernisation gate)
@@ -114,11 +114,16 @@ jobs:
       - name: Run Bandit security scan
         # The first invocation only produces the JSON artifact and is
         # intentionally non-gating (`|| true`). The SECOND invocation
-        # is the real gate: `bandit -r creek/ -ll` exits non-zero on
-        # any medium-or-above finding, with no escape hatch.
+        # is the real gate: `bandit -r creek/ creek_mcp/ -ll` exits
+        # non-zero on any medium-or-above finding, with no escape hatch.
+        #
+        # This step inlines bandit rather than calling
+        # creek-tools/scripts/security.sh, so the target list here must be
+        # kept in sync with that script by hand (issue #925 added
+        # creek_mcp/ to both).
         run: |
-          bandit -r creek/ -f json -o reports/bandit-report.json || true
-          bandit -r creek/ -ll
+          bandit -r creek/ creek_mcp/ -f json -o reports/bandit-report.json || true
+          bandit -r creek/ creek_mcp/ -ll
 
       - name: Run pip-audit dependency check
         # Documented CVE in build/install tooling. Excluded with a

--- a/creek-tools/.pre-commit-config.yaml
+++ b/creek-tools/.pre-commit-config.yaml
@@ -130,7 +130,7 @@ repos:
     exclude: \.secrets\.baseline$
 # Local hook: pylint as a CI-aligned gate (CI-002 / CI-004). Runs only
 # on staged Python files so it stays fast; CI runs the full --fail-under
-# pass over creek/.
+# pass over creek/ and creek_mcp/.
 - repo: local
   hooks:
   - id: pylint-fast
@@ -151,7 +151,9 @@ repos:
     # --rcfile (pylint warned and fell back to defaults anyway). The
     # CLI --fail-under is the actual enforcement contract.
     args: [--fail-under=9.0]
-    files: ^creek-tools/creek/
+    # Both first-party packages, and only those — tests/ stays out
+    # (issue #925 added creek_mcp/).
+    files: ^creek-tools/(creek|creek_mcp)/
 ci:
   autofix_commit_msg: 'style: auto-fix by pre-commit hooks'
   autoupdate_commit_msg: 'chore: update pre-commit hooks'

--- a/creek-tools/CLAUDE.md
+++ b/creek-tools/CLAUDE.md
@@ -405,9 +405,10 @@ All code must meet these standards before merging to main:
 
 #### Linting and Formatting
 - **Ruff**: lint + format, configured in `pyproject.toml` (no `|| true`).
-- **Pylint**: ≥9.0 (`pylint creek/ --fail-under=9.0`, in CI and
-  `lint-extended.sh`; CI-002).
-- **Bandit**: zero medium-or-above findings (`bandit -r creek/ -ll`).
+- **Pylint**: ≥9.0 (`pylint creek/ creek_mcp/ --fail-under=9.0`, in CI
+  and `lint-extended.sh`; CI-002).
+- **Bandit**: zero medium-or-above findings
+  (`bandit -r creek/ creek_mcp/ -ll`).
 - **pip-audit**: zero vulnerabilities except documented unfixable
   CVEs in `scripts/security.sh` and `.github/workflows/ci.yml`
   (DEP-003).

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -166,7 +166,13 @@ def _build_draft_llm() -> Callable[[str], str]:
     from creek.classify.llm import LLMClassifier
 
     config = load_config()
-    classifier = LLMClassifier(config.llm)
+    # ``config.llm`` is an ``LLMRoutingConfig``; ``LLMClassifier`` declares a
+    # plain ``LLMConfig``. Correcting the type here means choosing a concrete
+    # per-stage model inline — which is precisely the decision
+    # :class:`~creek.classify.llm.router.ModelRouter` owns, and doing it here
+    # would stand up a second provider path with no Intimate-never-cloud gate
+    # on it. Left suppressed until #958 rewires this tool through the router.
+    classifier = LLMClassifier(config.llm)  # type: ignore[arg-type]  # Issue #958
     if not classifier.available:
         msg = (
             "LLM provider unavailable; cannot generate draft. "

--- a/creek-tools/creek_mcp/tools/draft.py
+++ b/creek-tools/creek_mcp/tools/draft.py
@@ -26,7 +26,16 @@ TOOL_NAME = "creek.draft"
 
 
 class _DraftLLM(Protocol):
-    def __call__(self, prompt: str) -> str: ...
+    """A prompt-completion callable returning the draft body."""
+
+    # Positional-only (`/`) to match the canonical
+    # :data:`creek.generate.drafts.DraftLLM` alias, which is a bare
+    # ``Callable[[str], ...]`` and therefore names no parameter;
+    # ``DraftGenerator`` likewise calls ``self._llm(prompt)`` positionally.
+    # Without the `/` this Protocol would demand a keyword every real
+    # implementor is free not to offer — do not drop it.
+    def __call__(self, prompt: str, /) -> str:
+        """Return the completion for *prompt*."""
 
 
 def draft_tool(

--- a/creek-tools/creek_mcp/tools/reflect.py
+++ b/creek-tools/creek_mcp/tools/reflect.py
@@ -70,6 +70,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
 
+    from creek.classify.privacy_filter import PrivacyTierOverride
+
 logger = logging.getLogger(__name__)
 
 TOOL_NAME = "creek.reflect"
@@ -334,7 +336,7 @@ def reflect_tool(
     llm_factory: _LLMFactory,
     content: str | None = None,
     entry_ref: str | None = None,
-    retrieve: Callable[[str, Path, object], list[str]] | None = None,
+    retrieve: Callable[[str, Path, PrivacyTierOverride], list[str]] | None = None,
     care_guard: Callable[[str], str | None] | None = None,
     privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
     consumer: str = "unknown",
@@ -474,7 +476,9 @@ def reflect_tool(
     return result
 
 
-def _default_retrieve(query: str, vault_path: Path, override: object) -> list[str]:
+def _default_retrieve(
+    query: str, vault_path: Path, override: PrivacyTierOverride
+) -> list[str]:
     """Production grounding: top corpus fragments related to *query*.
 
     Lazily imports the author retrieval specialist so the server still boots
@@ -485,6 +489,15 @@ def _default_retrieve(query: str, vault_path: Path, override: object) -> list[st
         from creek.author.agents import RetrievalSpecialist
 
         bundle = RetrievalSpecialist().gather(query, vault_path, override=override)
-        return [claim.text for claim in bundle.claims]
+        # ``EvidenceClaim`` carries ``claim``, not ``text``, so this access has
+        # always raised and been swallowed below: production grounding has
+        # never actually run. Renaming the attribute switches it on, and what
+        # it would then feed the prompt is corpus fragment *titles*
+        # (``_fragment_claim`` sets ``claim=fragment.title``) — grounding on
+        # titles rather than bodies is an undecided design question that needs
+        # its own privacy tests. Suppressed rather than "fixed" so bringing
+        # this package under mypy does not quietly turn that egress on; #964
+        # owns the decision.
+        return [claim.text for claim in bundle.claims]  # type: ignore[attr-defined]  # Issue #964
     except Exception:
         return []

--- a/creek-tools/scripts/lint-extended.sh
+++ b/creek-tools/scripts/lint-extended.sh
@@ -72,8 +72,12 @@ run_or_skip() {
 
 echo "=== Extended Lint Suite ==="
 
+# Only pylint targets creek_mcp/ so far (issue #925). refurb,
+# tryceratops, vulture and interrogate stay on creek/ until their
+# creek_mcp backlog is groomed — widening them here would fail this
+# suite on findings nobody has triaged yet.
 run_or_skip "pylint"      pylint        \
-    pylint creek/ --fail-under="$PYLINT_FAIL_UNDER"
+    pylint creek/ creek_mcp/ --fail-under="$PYLINT_FAIL_UNDER"
 run_or_skip "refurb"      refurb        \
     refurb creek/
 run_or_skip "tryceratops" tryceratops   \

--- a/creek-tools/scripts/pylint.sh
+++ b/creek-tools/scripts/pylint.sh
@@ -66,7 +66,11 @@ echo "=== Pylint (--fail-under=$FAIL_UNDER) ==="
 # Gating run. Run via `python -m pylint` so the same interpreter that
 # has the project deps installed runs the linter — same hygiene
 # applied to typecheck.sh and test.sh.
-python -m pylint creek/ --output-format=colorized --fail-under="$FAIL_UNDER"
+#
+# Targets both first-party packages: creek/ (pipeline + CLI) and
+# creek_mcp/ (MCP server, auth, token policy, path confinement), which
+# was outside the target list until issue #925.
+python -m pylint creek/ creek_mcp/ --output-format=colorized --fail-under="$FAIL_UNDER"
 
 # Optional JSON snapshot (informational artifact only). The gating
 # decision was already made by the previous command; if pylint exits
@@ -74,7 +78,8 @@ python -m pylint creek/ --output-format=colorized --fail-under="$FAIL_UNDER"
 # via stderr but not propagated.
 if [[ -n "$JSON_OUTPUT" ]]; then
     mkdir -p "$(dirname "$JSON_OUTPUT")"
-    if ! python -m pylint creek/ --output-format=json > "$JSON_OUTPUT" 2>/dev/null; then
+    if ! python -m pylint creek/ creek_mcp/ --output-format=json \
+        > "$JSON_OUTPUT" 2>/dev/null; then
         echo "  ⚠ pylint JSON snapshot failed; see $JSON_OUTPUT" >&2
     fi
 fi

--- a/creek-tools/scripts/security.sh
+++ b/creek-tools/scripts/security.sh
@@ -62,15 +62,20 @@ echo "=== Security Checks (Bandit) ==="
 
 # Run Bandit.
 #
-# Severity threshold ``-ll`` (medium-or-above) matches both
-# .github/workflows/ci.yml and the CLAUDE.md §6.1 policy
-# ("Bandit: zero medium-or-above findings"). Aligning local with CI
-# closes the GAP-007 parity gap — a clean ``check-all.sh`` pass means
-# CI agrees on the same severity scope.
+# Both the target list and the severity threshold ``-ll``
+# (medium-or-above) match .github/workflows/ci.yml, and the threshold
+# also matches the CLAUDE.md §6.1 policy ("Bandit: zero medium-or-above
+# findings"). Aligning local with CI closes the GAP-007 parity gap — a
+# clean ``check-all.sh`` pass means CI agrees on the same scope.
+#
+# The targets cover creek_mcp/ (MCP server, auth, token policy, path
+# confinement) as well as creek/ since issue #925. CI does NOT call this
+# script — it inlines its own bandit step — so the two target lists must
+# be kept in sync by hand.
 if $VERBOSE; then
     echo "Running Bandit security scanner (medium-or-above)..."
 fi
-bandit -r creek/ -ll || { echo "✗ Bandit found issues" >&2; exit 1; }
+bandit -r creek/ creek_mcp/ -ll || { echo "✗ Bandit found issues" >&2; exit 1; }
 
 echo "=== Dependency Vulnerability Check (pip-audit) ==="
 

--- a/creek-tools/scripts/typecheck.sh
+++ b/creek-tools/scripts/typecheck.sh
@@ -58,7 +58,12 @@ if command -v mypy &> /dev/null; then
     # dependencies installed runs the type checker. This avoids
     # "Cannot find implementation" noise when mypy is installed via
     # pipx/uv into a different site-packages.
-    python -m mypy creek/ || {
+    #
+    # Both first-party packages are checked: creek/ (pipeline + CLI) and
+    # creek_mcp/ (MCP server, auth, token policy, path confinement).
+    # creek_mcp/ was outside the target list until issue #925 — keep the
+    # two of them together here and in .github/workflows/ci.yml.
+    python -m mypy creek/ creek_mcp/ || {
         echo "✗ Type checking failed" >&2
         exit 1
     }

--- a/creek-tools/tests/test_scanner_coverage.py
+++ b/creek-tools/tests/test_scanner_coverage.py
@@ -1,0 +1,310 @@
+"""Static-analysis scanners must cover ``creek_mcp/``, not only ``creek/``.
+
+Issue #925: ``scripts/typecheck.sh``, ``scripts/security.sh``,
+``scripts/pylint.sh``, ``scripts/lint-extended.sh``, the CI "Run Bandit
+security scan" step and the ``pylint-fast`` pre-commit hook each aim their
+tool at ``creek/`` alone. The entire ``creek_mcp/`` package -- the MCP
+server plus its auth, token-policy and path-confinement code -- is therefore
+never type-checked, security-scanned or lint-gated. These tests are the gate
+contract that keeps every one of those invocations widened.
+
+They also carry anti-weakening guards: the widened scan must not be made to
+pass by trading away Bandit's ``-ll`` severity threshold, Pylint's
+``--fail-under`` score threshold, or by re-excluding ``creek_mcp`` from
+``pyproject.toml``'s Bandit/MyPy configuration.
+
+Command lines are read with shell and YAML comments stripped first. Several
+of these files quote the very command they invoke inside an explanatory
+comment (``typecheck.sh`` line 57, ``pylint.sh`` line 66, ``ci.yml`` line
+117), so a naive substring scan would assert against prose rather than
+against the command that actually runs.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+CREEK_TOOLS_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = CREEK_TOOLS_DIR.parent
+SCRIPTS_DIR = CREEK_TOOLS_DIR / "scripts"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+PRE_COMMIT_CONFIG = CREEK_TOOLS_DIR / ".pre-commit-config.yaml"
+PYPROJECT = CREEK_TOOLS_DIR / "pyproject.toml"
+
+# ``\bcreek\b`` deliberately does NOT match inside ``creek_mcp`` (``_`` is a
+# word character), so the two probes are independent and either spelling of
+# the widened target (``creek/ creek_mcp/`` or ``creek creek_mcp``) passes.
+_CREEK_TARGET = re.compile(r"\bcreek\b")
+_CREEK_MCP_TARGET = re.compile(r"\bcreek_mcp\b")
+
+# Captures the numeric default out of ``FAIL_UNDER="${PYLINT_FAIL_UNDER:-9.0}"``
+# without pinning the exact string, so a reformat is fine but a lowered
+# threshold is not.
+_FAIL_UNDER_DEFAULT = re.compile(
+    r'FAIL_UNDER="\$\{PYLINT_FAIL_UNDER:-([0-9]+(?:\.[0-9]+)?)\}"'
+)
+
+# MyPy settings that would silently switch checking back off for a module.
+# Mapping is ``setting -> value that disables checking``.
+_MYPY_DISABLING_SETTINGS: dict[str, Any] = {
+    "ignore_errors": True,
+    "follow_imports": "skip",
+    "disallow_untyped_defs": False,
+    "check_untyped_defs": False,
+}
+
+
+def _non_comment_lines(script: Path) -> list[str]:
+    """Return the lines of ``script`` that are not shell comments.
+
+    A line whose left-stripped form starts with ``#`` is a comment and is
+    dropped, so prose that quotes a command cannot satisfy an assertion
+    about the command that actually executes.
+    """
+    return [
+        line
+        for line in script.read_text(encoding="utf-8").splitlines()
+        if not line.lstrip().startswith("#")
+    ]
+
+
+def _command_lines(script: Path, pattern: str) -> list[str]:
+    """Return non-comment lines of ``script`` matching ``pattern``."""
+    regex = re.compile(pattern)
+    return [line.strip() for line in _non_comment_lines(script) if regex.search(line)]
+
+
+def _assert_targets_both_packages(lines: list[str], source: str) -> None:
+    """Assert every command line in ``lines`` names ``creek`` and ``creek_mcp``."""
+    for line in lines:
+        assert _CREEK_TARGET.search(line), (
+            f"{source}: invocation lost its `creek/` target: {line!r}"
+        )
+        assert _CREEK_MCP_TARGET.search(line), (
+            f"{source}: invocation does not scan `creek_mcp/` (issue #925): {line!r}"
+        )
+
+
+def _as_list(value: Any) -> list[str]:
+    """Normalise a TOML scalar-or-list field to a list of strings."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    return [str(item) for item in value]
+
+
+def _ci_steps() -> list[dict[str, Any]]:
+    """Return every step of every job in the root CI workflow."""
+    workflow: dict[str, Any] = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    steps: list[dict[str, Any]] = []
+    for job in workflow["jobs"].values():
+        steps.extend(job.get("steps", []))
+    return steps
+
+
+def _ci_bandit_run_lines() -> list[str]:
+    """Return the ``bandit`` command lines of the CI Bandit step.
+
+    Parsing via ``yaml.safe_load`` drops the step's explanatory comment,
+    which itself quotes ``bandit -r creek/ -ll``.
+    """
+    bandit_steps = [step for step in _ci_steps() if "Bandit" in str(step.get("name"))]
+    assert len(bandit_steps) == 1, (
+        f"expected exactly one CI step named for Bandit, found {len(bandit_steps)}"
+    )
+    run_block = str(bandit_steps[0]["run"])
+    return [
+        line.strip()
+        for line in run_block.splitlines()
+        if line.strip().startswith("bandit")
+    ]
+
+
+def _pylint_fast_hook() -> dict[str, Any] | None:
+    """Return the local ``pylint-fast`` pre-commit hook, or ``None``."""
+    config: dict[str, Any] = yaml.safe_load(
+        PRE_COMMIT_CONFIG.read_text(encoding="utf-8")
+    )
+    for repo in config["repos"]:
+        for hook in repo.get("hooks", []):
+            if hook.get("id") == "pylint-fast":
+                return dict(hook)
+    return None
+
+
+def _pylint_fast_files_regex() -> re.Pattern[str]:
+    """Return the compiled ``files`` regex of the ``pylint-fast`` hook."""
+    hook = _pylint_fast_hook()
+    assert hook is not None, "no `pylint-fast` hook in .pre-commit-config.yaml"
+    files = hook.get("files")
+    assert files, "`pylint-fast` hook has no `files` filter to assert on"
+    return re.compile(str(files))
+
+
+def _pyproject() -> dict[str, Any]:
+    """Return the parsed ``creek-tools/pyproject.toml``."""
+    with PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def test_scanner_config_files_all_exist() -> None:
+    """Guard the path constants so no other test can pass vacuously."""
+    for path in (
+        SCRIPTS_DIR / "typecheck.sh",
+        SCRIPTS_DIR / "security.sh",
+        SCRIPTS_DIR / "pylint.sh",
+        SCRIPTS_DIR / "lint-extended.sh",
+        CI_WORKFLOW,
+        PRE_COMMIT_CONFIG,
+        PYPROJECT,
+    ):
+        assert path.is_file(), f"expected scanner config at {path}"
+    assert (CREEK_TOOLS_DIR / "creek_mcp").is_dir(), (
+        "creek_mcp/ package is missing; the widening these tests pin is moot"
+    )
+
+
+def test_typecheck_script_runs_mypy_over_creek_mcp() -> None:
+    """scripts/typecheck.sh must type-check creek_mcp/ as well as creek/."""
+    script = SCRIPTS_DIR / "typecheck.sh"
+    lines = _command_lines(script, r"python -m mypy")
+    assert lines, "no `python -m mypy` invocation found in scripts/typecheck.sh"
+    _assert_targets_both_packages(lines, "scripts/typecheck.sh")
+
+
+def test_security_script_scans_creek_mcp_with_bandit() -> None:
+    """scripts/security.sh must run Bandit over creek_mcp/ as well as creek/."""
+    script = SCRIPTS_DIR / "security.sh"
+    lines = _command_lines(script, r"bandit -r")
+    assert lines, "no `bandit -r` invocation found in scripts/security.sh"
+    _assert_targets_both_packages(lines, "scripts/security.sh")
+
+
+def test_ci_bandit_step_scans_creek_mcp() -> None:
+    """CI runs Bandit inline, not via security.sh, so it must widen too."""
+    lines = _ci_bandit_run_lines()
+    assert len(lines) >= 2, (
+        f"expected the JSON-artifact and gating bandit invocations, got {lines!r}"
+    )
+    _assert_targets_both_packages(lines, "ci.yml Run Bandit security scan")
+
+
+def test_pylint_script_lints_creek_mcp() -> None:
+    """Both pylint invocations in scripts/pylint.sh must include creek_mcp/."""
+    script = SCRIPTS_DIR / "pylint.sh"
+    lines = _command_lines(script, r"python -m pylint")
+    assert len(lines) >= 2, (
+        f"expected the gating and JSON-snapshot pylint runs, got {lines!r}"
+    )
+    _assert_targets_both_packages(lines, "scripts/pylint.sh")
+
+
+def test_lint_extended_script_lints_creek_mcp() -> None:
+    """scripts/lint-extended.sh's pylint target line must include creek_mcp/."""
+    script = SCRIPTS_DIR / "lint-extended.sh"
+    lines = _command_lines(script, r"^\s*pylint\s")
+    assert lines, "no `pylint <target>` line found in scripts/lint-extended.sh"
+    _assert_targets_both_packages(lines, "scripts/lint-extended.sh")
+
+
+def test_pre_commit_pylint_hook_matches_creek_mcp_files() -> None:
+    """The pylint-fast hook's `files` regex must select creek_mcp/ sources."""
+    pattern = _pylint_fast_files_regex()
+    assert pattern.search("creek-tools/creek_mcp/server.py"), (
+        f"pylint-fast `files` regex {pattern.pattern!r} skips creek_mcp/ "
+        "(issue #925)"
+    )
+
+
+def test_pre_commit_pylint_hook_still_matches_creek_and_skips_tests() -> None:
+    """Widening the pylint-fast hook must not lose creek/ or pull in tests/."""
+    pattern = _pylint_fast_files_regex()
+    assert pattern.search("creek-tools/creek/cli.py"), (
+        f"pylint-fast `files` regex {pattern.pattern!r} stopped matching creek/"
+    )
+    assert not pattern.search("creek-tools/tests/test_x.py"), (
+        f"pylint-fast `files` regex {pattern.pattern!r} now sweeps in tests/"
+    )
+
+
+def test_bandit_gate_keeps_medium_severity_threshold() -> None:
+    """Widening Bandit must not drop the `-ll` medium-or-above gate."""
+    script_gate = [
+        line
+        for line in _command_lines(SCRIPTS_DIR / "security.sh", r"bandit -r")
+        if "|| true" not in line
+    ]
+    assert len(script_gate) == 1, (
+        f"expected exactly one gating bandit line in security.sh, got {script_gate!r}"
+    )
+    assert "-ll" in script_gate[0], (
+        f"security.sh bandit gate lost its `-ll` threshold: {script_gate[0]!r}"
+    )
+
+    ci_gate = [line for line in _ci_bandit_run_lines() if "|| true" not in line]
+    assert len(ci_gate) == 1, (
+        f"expected exactly one gating bandit line in ci.yml, got {ci_gate!r}"
+    )
+    assert "-ll" in ci_gate[0], (
+        f"ci.yml bandit gate lost its `-ll` threshold: {ci_gate[0]!r}"
+    )
+
+
+def test_pylint_gate_keeps_fail_under_threshold() -> None:
+    """Widening Pylint must not drop or lower the --fail-under score gate."""
+    script = SCRIPTS_DIR / "pylint.sh"
+    gating = [
+        line
+        for line in _command_lines(script, r"python -m pylint")
+        if "--output-format=json" not in line
+    ]
+    assert len(gating) == 1, (
+        f"expected exactly one gating pylint line in pylint.sh, got {gating!r}"
+    )
+    assert "--fail-under" in gating[0], (
+        f"pylint.sh gate no longer passes --fail-under: {gating[0]!r}"
+    )
+
+    match = _FAIL_UNDER_DEFAULT.search("\n".join(_non_comment_lines(script)))
+    assert match is not None, (
+        "could not read the PYLINT_FAIL_UNDER default out of scripts/pylint.sh"
+    )
+    assert float(match.group(1)) >= 9.0, (
+        f"pylint --fail-under default dropped below 9.0: {match.group(1)}"
+    )
+
+
+def test_pyproject_bandit_config_does_not_exclude_creek_mcp() -> None:
+    """A widened Bandit CLI target must not be undone by exclude_dirs."""
+    bandit_config = _pyproject()["tool"]["bandit"]
+    excluded = _as_list(bandit_config.get("exclude_dirs"))
+    offenders = [entry for entry in excluded if "creek_mcp" in entry]
+    assert not offenders, (
+        f"[tool.bandit] exclude_dirs re-excludes creek_mcp: {offenders!r}"
+    )
+
+
+def test_pyproject_mypy_config_does_not_disable_creek_mcp() -> None:
+    """A widened MyPy CLI target must not be undone by an exclude/override."""
+    mypy_config = _pyproject()["tool"]["mypy"]
+
+    excluded = [
+        entry for entry in _as_list(mypy_config.get("exclude")) if "creek_mcp" in entry
+    ]
+    assert not excluded, f"[tool.mypy] exclude re-excludes creek_mcp: {excluded!r}"
+
+    for override in mypy_config.get("overrides", []):
+        modules = _as_list(override.get("module"))
+        if not any("creek_mcp" in module for module in modules):
+            continue
+        for setting, disabling_value in _MYPY_DISABLING_SETTINGS.items():
+            assert override.get(setting, None) != disabling_value, (
+                f"[[tool.mypy.overrides]] for {modules!r} disables checking "
+                f"via {setting}={disabling_value!r}"
+            )

--- a/creek-tools/tests/test_scanner_coverage.py
+++ b/creek-tools/tests/test_scanner_coverage.py
@@ -10,8 +10,10 @@ contract that keeps every one of those invocations widened.
 
 They also carry anti-weakening guards: the widened scan must not be made to
 pass by trading away Bandit's ``-ll`` severity threshold, Pylint's
-``--fail-under`` score threshold, or by re-excluding ``creek_mcp`` from
-``pyproject.toml``'s Bandit/MyPy configuration.
+``--fail-under`` score threshold, by re-excluding ``creek_mcp`` from
+``pyproject.toml``'s Bandit/MyPy configuration, or by naming ``creek_mcp``
+as a target and then carving it back out with an ``--exclude`` /
+``--ignore-paths`` flag on the same command line.
 
 Command lines are read with shell and YAML comments stripped first. Several
 of these files quote the very command they invoke inside an explanatory
@@ -23,6 +25,7 @@ against the command that actually runs.
 from __future__ import annotations
 
 import re
+import shlex
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -47,6 +50,16 @@ _CREEK_MCP_TARGET = re.compile(r"\bcreek_mcp\b")
 # threshold is not.
 _FAIL_UNDER_DEFAULT = re.compile(
     r'FAIL_UNDER="\$\{PYLINT_FAIL_UNDER:-([0-9]+(?:\.[0-9]+)?)\}"'
+)
+
+# Flags that carve a path back out of an already-widened target list, as
+# spelled by mypy (``--exclude``), pylint (``--ignore``/``--ignore-paths``/
+# ``--ignore-patterns``) and bandit (``-x``/``--exclude``). Naming
+# ``creek_mcp`` on the command line is necessary but not sufficient: an
+# ``--exclude 'creek_mcp/remote_auth\.py'`` would satisfy every
+# word-presence probe above while switching the scan back off.
+_EXCLUSION_FLAGS = frozenset(
+    {"--exclude", "-x", "--ignore", "--ignore-paths", "--ignore-patterns"}
 )
 
 # MyPy settings that would silently switch checking back off for a module.
@@ -77,6 +90,37 @@ def _command_lines(script: Path, pattern: str) -> list[str]:
     """Return non-comment lines of ``script`` matching ``pattern``."""
     regex = re.compile(pattern)
     return [line.strip() for line in _non_comment_lines(script) if regex.search(line)]
+
+
+def _exclusion_values(command: str) -> list[str]:
+    """Return every value passed to a path-exclusion flag in ``command``.
+
+    Handles both ``--exclude value`` and ``--exclude=value`` spellings. A
+    trailing shell line-continuation backslash is stripped first so
+    :func:`shlex.split` does not choke on a dangling escape.
+    """
+    values: list[str] = []
+    tokens = shlex.split(command.rstrip().rstrip("\\"))
+    for index, token in enumerate(tokens):
+        flag, separator, inline = token.partition("=")
+        if flag not in _EXCLUSION_FLAGS:
+            continue
+        if separator:
+            values.append(inline)
+        elif index + 1 < len(tokens):
+            values.append(tokens[index + 1])
+    return values
+
+
+def _all_scanner_invocations() -> list[str]:
+    """Return every gating mypy/bandit/pylint command line under test."""
+    return [
+        *_command_lines(SCRIPTS_DIR / "typecheck.sh", r"python -m mypy"),
+        *_command_lines(SCRIPTS_DIR / "security.sh", r"bandit -r"),
+        *_command_lines(SCRIPTS_DIR / "pylint.sh", r"python -m pylint"),
+        *_command_lines(SCRIPTS_DIR / "lint-extended.sh", r"^\s*pylint\s"),
+        *_ci_bandit_run_lines(),
+    ]
 
 
 def _assert_targets_both_packages(lines: list[str], source: str) -> None:
@@ -217,8 +261,7 @@ def test_pre_commit_pylint_hook_matches_creek_mcp_files() -> None:
     """The pylint-fast hook's `files` regex must select creek_mcp/ sources."""
     pattern = _pylint_fast_files_regex()
     assert pattern.search("creek-tools/creek_mcp/server.py"), (
-        f"pylint-fast `files` regex {pattern.pattern!r} skips creek_mcp/ "
-        "(issue #925)"
+        f"pylint-fast `files` regex {pattern.pattern!r} skips creek_mcp/ (issue #925)"
     )
 
 
@@ -278,6 +321,28 @@ def test_pylint_gate_keeps_fail_under_threshold() -> None:
     assert float(match.group(1)) >= 9.0, (
         f"pylint --fail-under default dropped below 9.0: {match.group(1)}"
     )
+
+
+def test_scanner_targets_are_not_carved_back_out_by_exclusions() -> None:
+    """Naming creek_mcp must not be undone by an --exclude/--ignore flag.
+
+    Every other assertion here only checks that ``creek_mcp`` appears
+    somewhere on the command line, which a re-narrowing edit such as
+    ``mypy creek/ creek_mcp/ --exclude 'creek_mcp/remote_auth\\.py'`` would
+    still satisfy -- the excluded path contains the word too. This closes
+    that loophole for all three scanners at once.
+    """
+    invocations = _all_scanner_invocations()
+    assert len(invocations) >= 6, (
+        f"expected every scanner invocation to be collected, got {invocations!r}"
+    )
+    for command in invocations:
+        offenders = [
+            value for value in _exclusion_values(command) if "creek_mcp" in value
+        ]
+        assert not offenders, (
+            f"invocation excludes part of creek_mcp again: {offenders!r} in {command!r}"
+        )
 
 
 def test_pyproject_bandit_config_does_not_exclude_creek_mcp() -> None:


### PR DESCRIPTION
## Summary

`creek_mcp/` — the network-facing package (MCP server, bearer auth, remote auth, token policy, path confinement, audit log, 20 tool modules) — was excluded from **mypy, bandit and pylint**. Not by any config exclusion: every invocation simply passed `creek/` as its only CLI target. This PR widens all three to `creek/ creek_mcp/` at every surface and pins that with a gate-contract test.

This is not hygiene. PR #963 ran a standalone `mypy creek_mcp/` and went 7 errors → 4; one of the three it eliminated was `server.py:185: has no attribute "_default_llm"; maybe "default_llm"?` — mypy would have caught #929, a production path that had **never worked**, at authoring time for free.

### How each scanner was scoped, before → after

| Scanner | Before | After |
|---|---|---|
| mypy | `scripts/typecheck.sh` → `python -m mypy creek/` | `creek/ creek_mcp/` |
| bandit (local) | `scripts/security.sh` → `bandit -r creek/ -ll` | `creek/ creek_mcp/`, `-ll` kept |
| bandit (CI) | `ci.yml` **inlines** `bandit -r creek/ …` — does *not* call the script | both lines widened |
| pylint (gate) | `scripts/pylint.sh` → `python -m pylint creek/` ×2 (gating + JSON) | both widened |
| pylint (extended) | `scripts/lint-extended.sh` → `pylint creek/` | widened |
| pylint (pre-commit) | `pylint-fast` hook `files: ^creek-tools/creek/` | `^creek-tools/(creek\|creek_mcp)/` |

There was **no** `[tool.bandit] exclude_dirs` entry, mypy `exclude`, or per-module override for `creek_mcp` — the target argument was the whole mechanism.

**CI parity was the trap.** mypy and pylint reach CI through `./scripts/typecheck.sh` and `./scripts/pylint.sh`, so the script edits propagate. The bandit step **inlines** its own `bandit -r` and never calls `scripts/security.sh`, so widening the script alone would have been local-only. Both `ci.yml` bandit lines were edited, and both files now carry a comment saying the two target lists are hand-synced. No other workflow gates on these three scanners.

The pre-commit `mypy` and `bandit` hooks are staged-file-typed with no `files:` filter, so they already covered `creek_mcp` — only `pylint-fast` needed widening.

### Findings the widening surfaced, and how each was routed

bandit at `-ll`: **clean**, zero changes. (Two sub-threshold `B105` false positives exist — an env-var *name* constant and a refusal *message* string — both below the gate, so no `nosec` was added.)
pylint: **9.69/10** combined vs 9.70 for `creek/` alone, threshold 9.0. Zero changes.
mypy: exactly **4** pre-existing errors.

| # | Finding | Route | Why |
|---|---|---|---|
| 1 | `tools/reflect.py` — `override: object` passed to `gather(override: PrivacyTierOverride \| None)` `[arg-type]` | **Fixed** | Annotation-only. Narrowed the `retrieve` seam and `_default_retrieve`'s parameter to `PrivacyTierOverride`; the call site already passes `to_privacy_override(...)`, which returns non-optional. Zero runtime effect; Callable params are contravariant, so every existing `override: object` test stub stays assignable. |
| 2 | `tools/reflect.py:501` — `EvidenceClaim` has no attribute `text` `[attr-defined]` | **Suppressed → #964** | Genuine bug: this has always raised and been swallowed, so production `creek.reflect` grounding has **never run**. But fixing it *activates* a path that feeds corpus fragment **titles** into the LLM prompt (`_fragment_claim` sets `claim=fragment.title`) — the title-egress channel #962/#931 document. And the right fix is ambiguous: the docstrings promise "top corpus fragments" while `gather` returns title-only claims. Titles-vs-bodies is a design decision needing its own privacy tests. |
| 3 | `server.py:169` — `LLMClassifier(config.llm)` where `config.llm` is `LLMRoutingConfig` `[arg-type]` | **Suppressed → #958** | The documented #958 defect. It fails closed *by accident* (`AttributeError` before egress). Correcting the type converts a dead path into a live one that bypasses `ModelRouter`, the Intimate-never-cloud chokepoint. Routing it properly is #958's scope. |
| 4 | `server.py:413` — `draft_tool(llm=…)`: `Callable[[str], str]` vs `_DraftLLM` Protocol `[arg-type]` | **Fixed** | `_DraftLLM.__call__` declared a *named* `prompt` param, so no plain callable satisfied it — `build_server` could not pass the production `_build_draft_llm()` result at all. Made positional-only (`prompt: str, /`) to match the canonical `DraftLLM = Callable[[str], …]` alias; `DraftGenerator` calls `self._llm(prompt)` positionally. Pure typing; the Protocol becomes strictly *more* permissive to implementors. |

Both suppressions use the sanctioned escape hatch — a **specific** error code plus a real, open tracking issue plus prose — per `max-quality-no-shortcuts`. No bare ignore, no per-file ignore, no `exclude` entry, no lowered threshold.

### Deliberately out of scope, filed rather than done

- **#965** — `creek_mcp/` is still excluded from xenon, interrogate, refurb, tryceratops and vulture, four of which are hard gates. Measured: interrogate would **pass** for free (98.1%); xenon fails on one block already tracked as #826; refurb 4 findings; tryceratops 7. Filed with the evidence and a suggested order.
- **#966** — `creek_mcp/remote_auth.py:195-196` carry two `# type: ignore[arg-type]` with no issue reference (`AuthSettings` URL fields are pydantic `AnyHttpUrl`; the constants are `str`). They predate this PR and were already enforced by the pre-commit mypy hook, so they are orthogonal — left untouched to keep a scanner-scoping PR out of network-auth code.

`creek-tools/CLAUDE.md` §6.1 documents both widened commands as policy, so it was updated to match.

## Test plan

New `creek-tools/tests/test_scanner_coverage.py` (13 tests) is the gate contract. It **failed RED** on exactly the six widening surfaces before the fix and passes after.

It parses rather than string-scrapes, because `typecheck.sh`, `pylint.sh` and `ci.yml` each quote the command they run inside an explanatory comment — a naive substring scan would assert against prose:
- shell scripts: comment lines stripped, then *every* matching invocation line must name both packages (and the match count is asserted non-zero, so a rename cannot make it vacuous);
- `ci.yml` and `.pre-commit-config.yaml` via `yaml.safe_load`; `pyproject.toml` via `tomllib`;
- the `pylint-fast` `files` regex is asserted **by behaviour** — compiled, then probed against a `creek_mcp/` path, a `creek/` path and a `tests/` path — so any equivalent spelling passes and a re-narrowing fails.

Anti-weakening guards (these pass before *and* after, by design): bandit's `-ll` survives on the gating line in both `security.sh` and `ci.yml`; pylint's `--fail-under` survives and its default parses as a float `>= 9.0`; `pyproject.toml` does not re-exclude `creek_mcp` via `[tool.bandit] exclude_dirs`, a mypy `exclude`, or a checking-disabling mypy override.

One more guard came out of self-review. Every other assertion only checks that `creek_mcp` appears *somewhere* on the command line — which `mypy creek/ creek_mcp/ --exclude 'creek_mcp/remote_auth\.py'` would also satisfy, since the excluded path contains the word too. So `test_scanner_targets_are_not_carved_back_out_by_exclusions` `shlex`-splits every scanner invocation and asserts no `--exclude` / `-x` / `--ignore` / `--ignore-paths` / `--ignore-patterns` value names `creek_mcp`. Verified non-vacuous by temporarily injecting exactly that flag into `typecheck.sh`: that one test failed, the other 12 passed, and it went green again on revert.

Verified locally (venv provisioned, credentials stripped):
- `./scripts/check-all.sh` → **exit 0, 12/12 passed**
- tests **6388 → 6401** (+13, exactly the new file); **zero** tests lost
- coverage **94.00%** (unchanged), per-file gate passed
- `mypy creek/ creek_mcp/` → Success, 0 errors, **219** source files (was 190)
- pylint combined **9.69/10**; `bandit -r creek/ creek_mcp/ -ll` → no issues
- `git diff --numstat origin/main -- creek-tools/tests/` → `375 0` for the one new file; **no pre-existing test file touched, zero deletions**
- `creek_mcp/tools/reflect.py:501` is 98 chars and clears E501 via ruff's trailing-pragma exemption. Confirmed empirically rather than assumed: two byte-identical-length 98-char lines, one ending in `# type: ignore[...]` and one in an ordinary comment — ruff passes the first and reports `E501 Line too long (98 > 88)` on the second.

Closes #925
Refs #826, #929, #958, #962, #963, #964, #965, #966
