### PR TITLE
sweep(mcp): machine-checked read-posture manifest for the tier-ceiling surface

### DIFF
--- a/creek-tools/creek_mcp/read_gate.py
+++ b/creek-tools/creek_mcp/read_gate.py
@@ -296,12 +296,18 @@ TOOL_POSTURES: dict[str, ToolPosture] = {
         rationale=_COUNTS_ONLY_RATIONALE,
     ),
     "creek.redact.scan": ToolPosture(
-        posture=ReadPosture.CALLER_NAMED_PATHS,
+        posture=ReadPosture.UNGATED_KNOWN_GAP,
         rationale=(
-            "The caller names the path, which resolve_within_vault confines "
-            "to the vault; findings carry counts, line numbers and salted "
-            "hashes, never the matched text."
+            "The caller names the path and resolve_within_vault confines it to "
+            "the vault, and no matched text is returned — but the confinement "
+            "is to the whole vault, not to the FEAT-027 staging subtree, and "
+            "the tier is never consulted. An open-ceiling caller pointed at "
+            "01-Fragments gets back the filenames of intimate fragments, which "
+            "are slugified titles, plus which PII types each contains. This "
+            "posture was CALLER_NAMED_PATHS until the #932 review; the name "
+            "was true and the conclusion drawn from it was not (#972)."
         ),
+        gap_issue=972,
     ),
     "creek.save": ToolPosture(
         posture=ReadPosture.NO_UNSUPPLIED_READ,

--- a/creek-tools/creek_mcp/read_gate.py
+++ b/creek-tools/creek_mcp/read_gate.py
@@ -1,0 +1,426 @@
+"""Read-surface posture manifest + the two canonical ceiling gates (#932).
+
+:data:`TOOL_POSTURES` is the audit record this issue asked for: one entry per
+registered MCP tool, stating how that tool relates to the caller's
+``privacy_tier_ceiling``. A tool either enforces the ceiling through a named
+gate (``GATED``), returns nothing the caller did not supply
+(``NO_UNSUPPLIED_READ``), reads only paths the caller named
+(``CALLER_NAMED_PATHS``), returns count-shaped metadata rather than content
+(``METADATA_ONLY``), is gated by an elevated auth token instead
+(``AUTH_TOKEN``), or does not honour the ceiling at all and says so against a
+tracking issue (``UNGATED_KNOWN_GAP``). The record is worth keeping because a
+tool nobody triaged is otherwise indistinguishable, to a reader of the
+surface, from a tool somebody decided needs no gate.
+
+**Gate ordering.** The discipline is worked out at length in
+:mod:`creek_mcp.tools.reflect`, around its ceiling gate and the comment blocks
+either side of it. It is restated — not copied — here, because every adopter
+of the primitives below inherits it:
+
+1. Audit-log the attempt first and unconditionally, recording only ``has_*``
+   booleans. Never the probed target id and never the outcome, so the trail
+   cannot answer "did consumer X read fragment F?" in either direction; a
+   probing consumer shows up as a rate, never as a named target.
+2. Resolve the target and answer *not found* before anything else touches it.
+3. Run the ceiling gate **above** every derived-signal seam — care guards,
+   grounding retrieval, the model. Any signal downstream of the gate is a
+   one-bit oracle about content the caller is not admitted to: an
+   ``escalate`` response tells an unadmitted caller that the fragment carries
+   acute-distress markers just as surely as returning the body would.
+4. Keep the refusal reason generic (:data:`GENERIC_ABOVE_CEILING_REASON`) and
+   never echo the resolved tier. That tier was derived from content the
+   caller cannot read, so echoing it — in the reason or in an extra key added
+   "for debugging" — turns every refusal into a tier-classification oracle
+   over the corpus.
+5. Only *after* admission derive :func:`creek_mcp.tier_ceiling.routing_tier`
+   to key a model call.
+
+**Why these primitives have no production caller yet.** That is a decision,
+not an oversight. ``creek.reflect`` and ``creek.compile`` are deliberately
+*not* retrofitted onto :func:`refuse_above_ceiling`: their refusal reasons and
+ordering comments are tool-specific and load-bearing. Reflect's "ACCEPTED
+RESIDUAL RISK" block documents exactly why its reason must stay distinct from
+``entry_ref not found`` — including the timing-equalisation caveat that would
+have to be handled if the two were ever unified — and folding it into a shared
+reason would delete that reasoning along with the behaviour. The primitives
+exist so the four filed gaps (#968/#969/#970/#971) can be closed by *adoption*
+rather than by each tool re-deriving the policy, and so that a *new* tool
+finds an already-gated corpus walk on the path of least resistance.
+
+:data:`TOOL_POSTURES` is verified by ``tests/test_mcp_read_gate.py``, which
+fails if an entry lies: the manifest must match ``server.list_tools()``
+exactly, a ``GATED`` claim is checked against a real call site in the named
+module, a gap must name a positive issue that the tool's own source mentions,
+and a tool recorded as a gap must not already call a primitive below.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from creek.classify.privacy_filter import filter_fragments_by_tier
+from creek.vault.reader import iter_vault_fragments
+from creek_mcp.tier_ceiling import refusal_response, tier_allowed, to_privacy_override
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from creek.models import Fragment, PrivacyTier
+    from creek_mcp.tier_ceiling import TierCeiling
+
+_FRAGMENTS_SUBDIR = "01-Fragments"
+
+GENERIC_ABOVE_CEILING_REASON = "resolved content exceeds the declared tier ceiling"
+"""The one refusal reason for an above-ceiling read.
+
+Deliberately names no tier and no fragment. It has to be identical across
+every above-ceiling tier at a given ceiling, or the refusal itself ranks the
+content the caller was not admitted to.
+"""
+
+
+class ReadPosture(StrEnum):
+    """How a tool relates to the caller's ``privacy_tier_ceiling``.
+
+    Attributes:
+        NO_UNSUPPLIED_READ: Returns nothing the caller did not supply, so
+            there is no unadmitted content for a ceiling to gate.
+        CALLER_NAMED_PATHS: Reads only vault paths the caller named, and
+            returns no matched content from them.
+        GATED: Enforces the ceiling through the ``gate_module`` /
+            ``gate_symbol`` pair recorded alongside it.
+        METADATA_ONLY: Returns counts, check names and other count-shaped
+            summaries rather than fragment bodies or titles.
+        AUTH_TOKEN: Takes no ceiling at all; gated fail-closed by an elevated
+            token instead, because it destroys content rather than reading it.
+        UNGATED_KNOWN_GAP: Reads vault content without honouring the ceiling.
+            A tracked, reproduced gap — ``gap_issue`` names the issue.
+    """
+
+    NO_UNSUPPLIED_READ = "no-unsupplied-read"
+    CALLER_NAMED_PATHS = "caller-named-paths"
+    GATED = "gated"
+    METADATA_ONLY = "metadata-only"
+    AUTH_TOKEN = "auth-token"
+    UNGATED_KNOWN_GAP = "ungated-known-gap"
+
+
+@dataclass(frozen=True)
+class ToolPosture:
+    """One tool's recorded read posture.
+
+    Attributes:
+        posture: The tool's :class:`ReadPosture`.
+        rationale: The specific, checkable fact that justifies *posture* —
+            this is the audit record, and it is meant to be read against the
+            tool's source rather than taken on trust.
+        gate_module: Dotted path of the module holding the gate. Set on
+            ``GATED`` entries only.
+        gate_symbol: Name of the gate callable within *gate_module*. Set on
+            ``GATED`` entries only.
+        gap_issue: Issue tracking an unenforced ceiling — required on every
+            ``UNGATED_KNOWN_GAP`` entry, and also carried by ``creek.journal``
+            whose gap is on its update-in-place path rather than a read.
+    """
+
+    posture: ReadPosture
+    rationale: str
+    gate_module: str | None = None
+    gate_symbol: str | None = None
+    gap_issue: int | None = None
+
+
+CANONICAL_GATE_PRIMITIVES: frozenset[str] = frozenset(
+    {"refuse_above_ceiling", "iter_admitted_fragments"}
+)
+"""The two ways a tool may satisfy the ceiling without inventing a third.
+
+Consumed as *strings* by the manifest's AST checks, so these names and the
+callables defined below have to stay in step; the test resolves each one back
+to an attribute of this module.
+"""
+
+
+_COUNTS_ONLY_RATIONALE = (
+    "Returns counts only and produces no new tiered content; the ceiling is "
+    "audited for the trail, not enforced."
+)
+
+_PURGE_RATIONALE = (
+    "Destroys vault content rather than returning it, so it takes no "
+    "privacy_tier_ceiling at all and is gated fail-closed by "
+    "CREEK_MCP_ELEVATED_TOKEN."
+)
+
+
+TOOL_POSTURES: dict[str, ToolPosture] = {
+    "creek.handshake": ToolPosture(
+        posture=ReadPosture.NO_UNSUPPLIED_READ,
+        rationale=(
+            "Returns tool names, the contract and ontology versions and the "
+            "tier model itself — no vault content of any kind."
+        ),
+    ),
+    "creek.reflect": ToolPosture(
+        posture=ReadPosture.GATED,
+        rationale=(
+            "An entry_ref resolves a fragment the caller did not supply; "
+            "_above_ceiling refuses it before the care seam, the grounding "
+            "retrieval, or the model (#846)."
+        ),
+        gate_module="creek_mcp.tools.reflect",
+        gate_symbol="_above_ceiling",
+    ),
+    "creek.compile": ToolPosture(
+        posture=ReadPosture.GATED,
+        rationale=(
+            "Source fragment_ids name fragments the caller did not supply; "
+            "_survey_sources ranks every one of them with write_tier_allowed "
+            "and compile_tool refuses the whole call on its above_ceiling flag, "
+            "before the LLM or the compiled-page write (#848)."
+        ),
+        gate_module="creek_mcp.tools.compile",
+        gate_symbol="_survey_sources",
+    ),
+    "creek.wheel": ToolPosture(
+        posture=ReadPosture.GATED,
+        rationale=(
+            "Converts the ceiling to a PrivacyTierOverride and threads it "
+            "into the corpus walk via tier_within_override, so above-ceiling "
+            "fragments never enter the frequency tally."
+        ),
+        gate_module="creek_mcp.tools.wheel",
+        gate_symbol="to_privacy_override",
+    ),
+    "creek.mine": ToolPosture(
+        posture=ReadPosture.GATED,
+        rationale=(
+            "Converts the ceiling to a PrivacyTierOverride and threads it "
+            "into IdeaMiner's corpus walk, so above-ceiling fragments are "
+            "excluded at the source."
+        ),
+        gate_module="creek_mcp.tools.mine",
+        gate_symbol="to_privacy_override",
+    ),
+    "creek.draft": ToolPosture(
+        posture=ReadPosture.GATED,
+        rationale=(
+            "Converts the ceiling to a PrivacyTierOverride and threads it "
+            "into DraftGenerator's corpus walk, so above-ceiling fragments "
+            "are excluded at the source."
+        ),
+        gate_module="creek_mcp.tools.draft",
+        gate_symbol="to_privacy_override",
+    ),
+    "creek.author": ToolPosture(
+        posture=ReadPosture.GATED,
+        rationale=(
+            "Converts the ceiling to a PrivacyTierOverride and threads it "
+            "into the Writing Desk specialists (#660), so above-ceiling "
+            "fragments never reach the evidence."
+        ),
+        gate_module="creek_mcp.tools.author",
+        gate_symbol="to_privacy_override",
+    ),
+    "creek.report": ToolPosture(
+        posture=ReadPosture.UNGATED_KNOWN_GAP,
+        rationale=(
+            "The ceiling is audited and echoed but never converted or "
+            "threaded: creek/generate/{tags,lexicon,decisions,wavelength}.py "
+            "contain no tier filtering at all, so report_type='tags' at "
+            "ceiling=open writes an intimate fragment's tags into "
+            "00-Creek-Meta/Tag-Garden.md. Reproduced (#968)."
+        ),
+        gap_issue=968,
+    ),
+    "creek.state.read": ToolPosture(
+        posture=ReadPosture.UNGATED_KNOWN_GAP,
+        rationale=(
+            "Returns 00-Creek-Meta/State/latest.md verbatim at any ceiling. "
+            "The artifact records no ceiling of its own, so it may have been "
+            "rendered at ceiling=all and be read back at ceiling=open (#969)."
+        ),
+        gap_issue=969,
+    ),
+    "creek.state.render": ToolPosture(
+        posture=ReadPosture.UNGATED_KNOWN_GAP,
+        rationale=(
+            "Walks the whole vault through StateReportGenerator, which "
+            "threads no override, and returns the rendered content. Its one "
+            "fragment-derived section is safe by default "
+            "(phase_filtered_seeds with override=None, which ranks as "
+            "ceiling=open); the eddy/thread/liminal title sections are "
+            "unfiltered and unfilterable — Eddy and Thread carry no "
+            "privacy_tier (#969)."
+        ),
+        gap_issue=969,
+    ),
+    "creek.skills.refresh": ToolPosture(
+        posture=ReadPosture.UNGATED_KNOWN_GAP,
+        rationale=(
+            "SkillTreeGenerator hardcodes an intimate exclusion but the "
+            "ceiling is never threaded, so personal bodies pass unsummarised "
+            "at ceiling=open — looser than every sibling generation tool "
+            "(#971)."
+        ),
+        gap_issue=971,
+    ),
+    "creek.journal": ToolPosture(
+        posture=ReadPosture.NO_UNSUPPLIED_READ,
+        rationale=(
+            "The entry body is the caller's own, and write_tier_allowed gates "
+            "the tier it creates; but the idempotent update-in-place "
+            "overwrites the fragment an external_id already maps to without "
+            "consulting that fragment's tier (#970)."
+        ),
+        gap_issue=970,
+    ),
+    "creek.lint": ToolPosture(
+        posture=ReadPosture.METADATA_ONLY,
+        rationale=(
+            "The checks read fragment frontmatter (paradox, unnamed and "
+            "orphan-compiled scan 01-Fragments), never bodies; the MCP "
+            "response returns only check names, count-shaped summaries and "
+            "len(findings). Titles live in findings, which is never returned."
+        ),
+    ),
+    "creek.link": ToolPosture(
+        posture=ReadPosture.METADATA_ONLY,
+        rationale=_COUNTS_ONLY_RATIONALE,
+    ),
+    "creek.classify": ToolPosture(
+        posture=ReadPosture.METADATA_ONLY,
+        rationale=_COUNTS_ONLY_RATIONALE,
+    ),
+    "creek.redact.scan": ToolPosture(
+        posture=ReadPosture.CALLER_NAMED_PATHS,
+        rationale=(
+            "The caller names the path, which resolve_within_vault confines "
+            "to the vault; findings carry counts, line numbers and salted "
+            "hashes, never the matched text."
+        ),
+    ),
+    "creek.save": ToolPosture(
+        posture=ReadPosture.NO_UNSUPPLIED_READ,
+        rationale=(
+            "The content is the caller's own; write_tier_allowed gates the "
+            "tier the call would create."
+        ),
+    ),
+    "creek.ingest": ToolPosture(
+        posture=ReadPosture.NO_UNSUPPLIED_READ,
+        rationale=(
+            "The content is the caller's own — a source path they supplied — "
+            "and write_tier_allowed gates the tier the call would create."
+        ),
+    ),
+    "creek.purge.fragment": ToolPosture(
+        posture=ReadPosture.AUTH_TOKEN,
+        rationale=_PURGE_RATIONALE,
+    ),
+    "creek.purge.source": ToolPosture(
+        posture=ReadPosture.AUTH_TOKEN,
+        rationale=_PURGE_RATIONALE,
+    ),
+    "creek.purge.classifications": ToolPosture(
+        posture=ReadPosture.AUTH_TOKEN,
+        rationale=_PURGE_RATIONALE,
+    ),
+    "creek.purge.daterange": ToolPosture(
+        posture=ReadPosture.AUTH_TOKEN,
+        rationale=_PURGE_RATIONALE,
+    ),
+    "creek.purge.vault": ToolPosture(
+        posture=ReadPosture.AUTH_TOKEN,
+        rationale=(
+            f"{_PURGE_RATIONALE} It additionally requires a matching "
+            "confirm_vault_path."
+        ),
+    ),
+}
+"""Every registered MCP tool's read posture — the #932 audit record."""
+
+
+def refuse_above_ceiling(
+    *,
+    tool: str,
+    content_tier: PrivacyTier | None,
+    ceiling: TierCeiling,
+) -> dict[str, object] | None:
+    """Return the canonical refusal for above-ceiling content, or ``None``.
+
+    Admission is delegated wholesale to
+    :func:`creek_mcp.tier_ceiling.tier_allowed`, never re-derived: a second,
+    private ranking inside the read gate is how two halves of the MCP surface
+    end up disagreeing about whether a fragment is readable. Delegation also
+    inherits the fail-closed handling of an unrecognised tier, which ranks
+    with the most sensitive tier rather than the least.
+
+    Args:
+        tool: The registered tool name, echoed in the refusal.
+        content_tier: The resolved tier of content the caller did *not*
+            supply, or ``None`` when the text came from the caller inline and
+            so carries no classification to compare. ``None`` is never above
+            the ceiling — refusing it would mean refusing callers their own
+            words.
+        ceiling: The caller's declared ceiling.
+
+    Returns:
+        ``None`` when the content is admitted, so a call site reads as an
+        early return on a non-``None`` result. Otherwise the four-key
+        :func:`creek_mcp.tier_ceiling.refusal_response` payload carrying
+        :data:`GENERIC_ABOVE_CEILING_REASON` — and nothing else. Anything
+        further would be derived from content the caller is not admitted to.
+    """
+    if content_tier is None or tier_allowed(content_tier, ceiling):
+        return None
+    return refusal_response(
+        tool=tool,
+        ceiling=ceiling,
+        reason=GENERIC_ABOVE_CEILING_REASON,
+    )
+
+
+def iter_admitted_fragments(
+    vault_path: Path,
+    ceiling: TierCeiling,
+) -> Iterator[tuple[Path, Fragment, str]]:
+    """Yield the vault's fragments as admitted under *ceiling*.
+
+    The tier policy is not implemented here. The ceiling is converted by
+    :func:`creek_mcp.tier_ceiling.to_privacy_override` and handed to
+    :func:`creek.classify.privacy_filter.filter_fragments_by_tier`, which owns
+    the one implementation of the Ontology §13.2 promise: intimate content is
+    dropped outright, personal content contributes a title-only summary. The
+    body yielded is always the *filtered* body, so an adopting tool cannot
+    reach the raw text by accident.
+
+    Each pair is filtered on its own rather than as one sequence. The filter
+    takes ``(fragment, body)`` and drops the path, and it also drops whole
+    fragments, so re-pairing its shorter output with the walk by position
+    would attribute one fragment's body to another fragment's path. It is a
+    stateless per-pair generator, so one-at-a-time application is identical in
+    behaviour and keeps the path attached by construction.
+
+    Args:
+        vault_path: Vault root; fragments are read from ``01-Fragments``.
+        ceiling: The caller's declared ceiling.
+
+    Yields:
+        ``(path, fragment, body)`` in the shared reader's sorted order. A
+        vault with no ``01-Fragments`` directory yields nothing: the
+        freshly-initialised case is empty, not an error, and every adopting
+        tool inherits that.
+    """
+    override = to_privacy_override(ceiling)
+    for path, fragment, body, _raw in iter_vault_fragments(
+        vault_path / _FRAGMENTS_SUBDIR,
+    ):
+        for admitted, admitted_body in filter_fragments_by_tier(
+            [(fragment, body)],
+            override=override,
+        ):
+            yield path, admitted, admitted_body

--- a/creek-tools/creek_mcp/tools/journal.py
+++ b/creek-tools/creek_mcp/tools/journal.py
@@ -17,6 +17,16 @@ Tier is honored end-to-end: the tier is written into the staged entry's
 frontmatter (which the markdown ingestor carries onto the fragment), and the
 write-side ceiling refuses an entry whose tier exceeds the caller's ceiling — so
 an INTIMATE entry is stored intimate and never admitted under a lower ceiling.
+
+The idempotent update-in-place has a gap this guarantee does not cover
+(#970): overwriting the fragment an existing ``external_id`` already maps to
+replaces whatever body is there **without consulting that fragment's own
+tier**. Reproduced: a caller at ``ceiling=open`` replaced the body of a
+fragment persisted at ``privacy_tier: intimate``. The persisted tier itself
+was not downgraded — the escalate-only privacy merge held — but the intimate
+body was destroyed. Contrast ``creek.purge.*``, which requires
+``CREEK_MCP_ELEVATED_TOKEN`` for exactly this kind of destruction; this path
+requires only the caller's own (lower) ceiling.
 """
 
 from __future__ import annotations

--- a/creek-tools/creek_mcp/tools/lint.py
+++ b/creek-tools/creek_mcp/tools/lint.py
@@ -24,10 +24,19 @@ def lint_tool(
 ) -> dict[str, Any]:
     """Run the unified lint pass and persist a markdown report.
 
-    Lint reads only compiled-layer metadata (eddies, threads, tag
-    indexes, paradoxes) so the tier ceiling does not gate any fragment
-    bodies — but the parameter is still required per FEAT-010 to keep
-    tool signatures uniform.
+    "Lint reads only compiled-layer metadata" is not true: the paradox
+    check loads ``Fragment.model_validate(post.metadata)`` straight out of
+    ``01-Fragments`` and ``10-Liminal`` (``creek/lint/checks/paradox.py``),
+    and the unnamed / orphan-compiled checks also scan ``01-Fragments``.
+    What actually keeps this tool ceiling-agnostic is narrower and holds up
+    better: those checks read fragment *frontmatter*, never bodies, and
+    this tool's response returns only ``name``, a count-shaped ``summary``,
+    and ``len(findings)`` — verified against every ``CheckResult``
+    construction under ``creek/lint/checks/``. The title- and path-bearing
+    strings live in ``findings``, which this tool never returns. The
+    written markdown report *does* embed titles and paths, but it is a
+    vault-internal artifact no MCP tool reads back. The ceiling parameter
+    is still required per FEAT-010 to keep tool signatures uniform.
     """
     resolved_checks = list(checks) if checks is not None else None
     MCPAuditLog(vault_path).append(

--- a/creek-tools/creek_mcp/tools/redact.py
+++ b/creek-tools/creek_mcp/tools/redact.py
@@ -14,6 +14,20 @@ no matched text and no file body content leaves the tool.
 FEAT-027 introduces this tool so CrawDad can run the safety pass on
 Discord attachments staged under ``00-Creek-Meta/Inbound/`` before any
 ``creek.ingest`` call is dispatched.
+
+Read-side posture (#972): "no matched text leaves the tool" is true and is
+not sufficient. ``resolve_within_vault`` confines *input_path* to the whole
+vault rather than to the staging subtree above, and the tier is never
+consulted, so an ``open``-ceiling caller may aim the scan at
+``01-Fragments``. What comes back is the *filename* of every matching
+fragment — and Creek fragment filenames are slugified titles — together
+with the PII types and line numbers each contains. Reproduced: a fragment
+at ``privacy_tier: intimate`` surfaced as
+``01-Fragments/Notes/my-affair-with-dana.md`` at ``ceiling=open``.
+Separately, ``report_markdown`` is built by
+:meth:`~creek.redact.scanner.RedactionScanner.generate_markdown_summary`
+and bypasses the vault-relative rendering :func:`_finding_to_dict` applies,
+so it emits absolute filesystem paths despite that function's docstring.
 """
 
 from __future__ import annotations

--- a/creek-tools/creek_mcp/tools/report.py
+++ b/creek-tools/creek_mcp/tools/report.py
@@ -10,6 +10,21 @@ decision-signalling fragments, #581), ``rhetorical-patterns``
 deferred to the CLI because they need date arithmetic the MCP shape
 should not own. The wrapper writes one audit entry per invocation
 including ``created_path`` for the resulting report file(s).
+
+Read-side posture (#968): the ceiling is audited and echoed but never
+converted or threaded — ``to_privacy_override`` is never called here.
+Four of the six generators (``creek/generate/{tags,lexicon,decisions,
+wavelength}.py``) contain no tier filtering whatsoever;
+``creek/generate/voice.py`` is the only one with an ``allow_intimate``
+filter. Reproduced: ``report_type="tags"`` at ``ceiling=open`` wrote an
+``intimate`` fragment's tag verbatim into
+``00-Creek-Meta/Tag-Garden.md`` and
+``00-Creek-Meta/Processing-Log/tag-history.json``. The exposure is
+write-side, not read-side: this tool returns only ``report_paths``,
+never content, and no MCP tool reads an arbitrary vault file back — so
+a low-ceiling caller cannot read the leaked artifact *through MCP*.
+What it causes instead is above-ceiling content distilled into an
+unlabelled vault file.
 """
 
 from __future__ import annotations

--- a/creek-tools/creek_mcp/tools/skills.py
+++ b/creek-tools/creek_mcp/tools/skills.py
@@ -31,10 +31,19 @@ def skills_refresh_tool(
 ) -> dict[str, Any]:
     """Regenerate the voice-skill tree and return the written paths.
 
-    The generator already excludes ``intimate`` exemplars so the
-    operation is safe at any ceiling. The skill tree always lands under
-    ``<vault>/creek-skills``; the MCP surface does not expose an
-    override (the CLI flag is the right tool for that).
+    ``intimate`` exemplars are excluded — but by a hardcode in the
+    generator, not by the caller's ceiling: ``_is_snapshot_fragment`` in
+    ``creek/generate/skills.py`` defaults ``allow_intimate=False``, and
+    this tool never passes ``allow_intimate=True``. The ceiling itself is
+    never threaded (``to_privacy_override`` is never called here), so a
+    ``personal`` fragment contributes its *full body* at ``ceiling=open``
+    — looser than every sibling generation tool: ``creek.mine``,
+    ``creek.draft``, and ``creek.author`` all route through
+    ``filter_fragments_by_tier``, where a personal fragment at ``open``
+    contributes a title-only summary instead. Output lands in the
+    untiered ``<vault>/creek-skills`` directory; the MCP surface does not
+    expose an override (the CLI flag is the right tool for that).
+    Tracked by #971.
     """
     output = vault_path / _SKILLS_RELDIR
     written = SkillTreeGenerator().generate_all_skills(vault_path, output)

--- a/creek-tools/creek_mcp/tools/state.py
+++ b/creek-tools/creek_mcp/tools/state.py
@@ -29,6 +29,19 @@ def state_render_tool(
 
     The rendered file lives under ``00-Creek-Meta/State/<iso-week>.md``;
     ``latest.md`` is refreshed atomically by the underlying generator.
+
+    Walks the whole vault through ``StateReportGenerator``, which accepts
+    no privacy override, and returns the rendered content — the ceiling
+    is audited and echoed but never threaded into the walk (#969). Its
+    one fragment-derived section, ``section_suggested_questions``, is
+    safe by default: it calls ``phase_filtered_seeds`` with
+    ``override=None``, which ``filter_fragments_by_tier`` treats as
+    equivalent to ``open`` — intimate dropped, personal bodies
+    summarised. The eddy/thread/liminal *title* sections are unfiltered,
+    and unfilterable today: ``Eddy`` and ``Thread`` in ``creek/models.py``
+    carry no ``privacy_tier`` field at all. Tracked together with
+    ``creek.state.read`` under #969, because the fix is one design —
+    tier-stamped state artifacts — spanning both sides.
     """
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,

--- a/creek-tools/creek_mcp/tools/state_read.py
+++ b/creek-tools/creek_mcp/tools/state_read.py
@@ -26,12 +26,16 @@ def state_read_tool(
 ) -> dict[str, Any]:
     """Return the latest audit-report bytes plus tool metadata.
 
-    The audit report aggregates eddy/thread/synchronicity *titles* —
-    it never embeds fragment bodies — so the tier-ceiling enforcement
-    here is the gate on whether the report itself can be returned at
-    all, not a body-level filter. A missing report yields a structured
-    "no report yet" status rather than a crash so a fresh vault stays
-    usable.
+    Returns ``00-Creek-Meta/State/latest.md`` verbatim at *any* ceiling:
+    the ceiling is audited and echoed here, never consulted (#969). The
+    artifact records no ceiling of its own, so it may have been rendered
+    by a caller at ``ceiling=all`` (or by the CLI with
+    ``--include-tier all``) and then be read back at ``open`` — a
+    cross-ceiling cache, not a body-level filter. What the audit report
+    does still bound is scope, not tier: it aggregates
+    eddy/thread/synchronicity *titles* and counts, never fragment
+    bodies. A missing report yields a structured "no report yet" status
+    rather than a crash so a fresh vault stays usable.
     """
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -128,13 +128,22 @@ Every registered tool's relationship to the caller's ceiling is now a
 machine-checked audit record: `creek_mcp/read_gate.py`'s `TOOL_POSTURES`
 names one of six postures per tool, verified against the live server
 surface and, for `GATED` entries, against a real call site in the
-named module. The sweep's key result: no unaudited tool leaks
-above-ceiling content into its MCP *response*. The remaining exposure
-is write-side — a tool **acts on** content above the caller's ceiling
-(#968, #970) rather than handing it back to the caller who asked. That
-asymmetry is also why the ceiling language elsewhere on this page reads
-entirely in read-back terms ("omitted", "returned as a title-only
-stub") — those survived the #932 audit unrevised.
+named module, and for the rest against a runtime canary probe.
+
+Most of what the sweep found is **write-side**: a tool *acts on* content
+above the caller's ceiling (#968, #970, #971) rather than handing it
+back. That is a shape the ceiling language elsewhere on this page does
+not describe — it is written entirely in read-back terms ("omitted",
+"returned as a title-only stub"), which is why those gaps survived.
+
+One read-side leak was found, and it is worth stating how: the sweep
+first concluded there were none, having probed the tools that walk the
+corpus themselves. `creek.redact.scan` was set aside as "the caller
+named the path" — true, and not sufficient. Its path confinement is to
+the whole vault rather than to the FEAT-027 staging subtree, and it
+returns matching *filenames*, which are slugified fragment titles
+(#972). A posture whose name is accurate can still license a wrong
+conclusion; that is what the machine-checked manifest is for.
 
 ### Elevated-authorization model (FEAT-012)
 

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -63,10 +63,10 @@ real desk. Only the `research` medium is wired — any other `medium` returns
 | `creek.ingest`          | `source_type`, `input_path`                                 | Default ingest tier is `personal`; `ceiling=open` is refused.     |
 | `creek.classify`        | `method` (`rules`\|`llm`), `force`                          | Rewrites in place; no new tier produced — any ceiling permitted.  |
 | `creek.link`            | `method` (`embeddings`\|`temporal`\|`eddies`), `rebuild`    | Links existing artefacts in place — any ceiling permitted.        |
-| `creek.report`          | `report_type` (`tags`\|`voice`)                             | Renders a vault-state report — any ceiling permitted.             |
-| `creek.skills.refresh`  | none beyond `ceiling`                                       | Voice-skill tree regen; intimate exemplars already excluded.      |
+| `creek.report`          | `report_type` (`tags`\|`voice`\|`decisions`\|`lexicon`\|`rhetorical-patterns`\|`mode-profiles`) | Ceiling is recorded but not enforced — known gap #968; see "Read-side posture (#932)" below. |
+| `creek.skills.refresh`  | none beyond `ceiling`                                       | Voice-skill tree regen; intimate exemplars excluded by a generator hardcode, not by the ceiling — `personal` bodies pass unsummarised at `ceiling=open` (known gap #971). |
 | `creek.compile`         | `fragment_ids`, `target_kind`, `target_id`, `target_title`  | Gates the *source* fragments' tier, not the compiled page's tier — a source above `ceiling` refuses the whole call (#848). Idempotent per FEAT-003; no-op re-runs do not log a duplicate. |
-| `creek.journal`         | `content`, `external_id`, `timestamp?`, `tier?`             | Stages an Adepthood entry then ledger-ingests it (#754); `external_id` is the idempotency key and `tier` defaults to `open`. The entry's tier is honored — a ceiling that would not admit it is refused. |
+| `creek.journal`         | `content`, `external_id`, `timestamp?`, `tier?`             | Stages an Adepthood entry then ledger-ingests it (#754); `external_id` is the idempotency key and `tier` defaults to `open`. The entry's tier is honored — a ceiling that would not admit it is refused. The tier of the fragment an existing `external_id` already maps to is **not** consulted before the update-in-place overwrites it (known gap #970). |
 
 ### Purge tools (FEAT-012, elevated authorization required)
 
@@ -121,6 +121,20 @@ source fragment's tier exceeds `ceiling`, the whole call is refused
 before the compile LLM is invoked or the page is written — so an
 intimate fragment can never be laundered into an open-tier compiled
 page. The refusal is audited but names no fragment ids and no tiers.
+
+### Read-side posture (#932)
+
+Every registered tool's relationship to the caller's ceiling is now a
+machine-checked audit record: `creek_mcp/read_gate.py`'s `TOOL_POSTURES`
+names one of six postures per tool, verified against the live server
+surface and, for `GATED` entries, against a real call site in the
+named module. The sweep's key result: no unaudited tool leaks
+above-ceiling content into its MCP *response*. The remaining exposure
+is write-side — a tool **acts on** content above the caller's ceiling
+(#968, #970) rather than handing it back to the caller who asked. That
+asymmetry is also why the ceiling language elsewhere on this page reads
+entirely in read-back terms ("omitted", "returned as a title-only
+stub") — those survived the #932 audit unrevised.
 
 ### Elevated-authorization model (FEAT-012)
 

--- a/creek-tools/tests/test_mcp_read_gate.py
+++ b/creek-tools/tests/test_mcp_read_gate.py
@@ -1,0 +1,976 @@
+"""Structural guardrails for the MCP read surface's tier gates (#932).
+
+``creek_mcp.read_gate`` is a *manifest plus two primitives*. The manifest
+(:data:`~creek_mcp.read_gate.TOOL_POSTURES`) records, for every registered MCP
+tool, how that tool relates to the caller's ``privacy_tier_ceiling``: it either
+enforces the ceiling through a named gate, never reads unsupplied content, is
+gated by an elevated auth token instead, or has a **known, tracked gap**. The
+primitives (:func:`~creek_mcp.read_gate.refuse_above_ceiling` and
+:func:`~creek_mcp.read_gate.iter_admitted_fragments`) are the two canonical
+ways a tool may satisfy the ceiling, so gaps can be closed by adoption rather
+than by re-deriving the policy per tool.
+
+A manifest is only worth having if it cannot lie. Five layers keep it honest:
+
+(a) **Surface completeness** — the manifest covers exactly the live tool list,
+    derived from ``server.list_tools()`` rather than a second hardcoded copy,
+    so a newly registered tool has to be triaged rather than silently
+    inheriting "no posture recorded".
+(b) **Ceiling-parameter presence** — every non-``AUTH_TOKEN`` tool exposes
+    ``privacy_tier_ceiling``; the five ``creek.purge.*`` tools deliberately do
+    not (see ``docs/mcp.md`` §"Purge tools deliberately do not accept a
+    privacy_tier_ceiling"), and that asymmetry is pinned in both directions.
+(c) **Anti-lying** — a ``GATED`` claim is verified against the implementation:
+    the named symbol must exist in the named module *and* be called there.
+(d) **Anti-whitewash** — a gap entry must name a positive tracking issue, and
+    the tool's own module must mention that issue number, so a reader of the
+    module learns the gap exists without consulting the manifest.
+(e) **Anti-rot** — a tool recorded as an ungated gap must not already call a
+    canonical gate primitive.
+
+Injection drill (each step is expected to turn exactly one layer red):
+
+1. Add a ``@server.tool(name="creek.dummy")`` to ``build_server`` → layer (a)
+   fails.
+2. Point a ``GATED`` entry's ``gate_symbol`` at a nonexistent name → layer (c)
+   fails.
+3. Drop the ``gap_issue`` from an ``UNGATED_KNOWN_GAP`` entry → layer (d)
+   fails.
+
+Deliberately absent: any runtime probe asserting that a known gap *still
+leaks*. Such a test passes because the bug exists and breaks when it is fixed.
+The gap issues (#968/#969/#970/#971) each carry their own runtime-probe
+acceptance criterion.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import importlib
+import inspect
+import json
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, cast
+
+import frontmatter
+import pytest
+
+from creek.models import PrivacyTier
+from creek_mcp.read_gate import (
+    CANONICAL_GATE_PRIMITIVES,
+    GENERIC_ABOVE_CEILING_REASON,
+    TOOL_POSTURES,
+    ReadPosture,
+    iter_admitted_fragments,
+    refuse_above_ceiling,
+)
+from creek_mcp.server import build_server
+from creek_mcp.tier_ceiling import TierCeiling, refusal_response
+
+if TYPE_CHECKING:
+    from pathlib import Path
+    from types import ModuleType
+
+    from mcp.types import Tool
+
+
+# ---------------------------------------------------------------------------
+# Pinned expectations
+#
+# The tool-name list is NOT duplicated here — layer (a) derives it from the
+# live server. What is pinned below is the *posture* of the tools whose posture
+# is load-bearing, so a later edit that silently downgrades a real gate to
+# METADATA_ONLY (or upgrades a tracked gap to a gate it never grew) fails.
+# ---------------------------------------------------------------------------
+
+_EXPECTED_TOOL_COUNT = 23
+
+_EXPECTED_PRIMITIVES = frozenset({"refuse_above_ceiling", "iter_admitted_fragments"})
+
+_PINNED_GATE_ROWS = [
+    ("creek.reflect", "creek_mcp.tools.reflect", "_above_ceiling"),
+    ("creek.compile", "creek_mcp.tools.compile", "_sources_above_ceiling"),
+    ("creek.wheel", "creek_mcp.tools.wheel", "to_privacy_override"),
+    ("creek.mine", "creek_mcp.tools.mine", "to_privacy_override"),
+    ("creek.draft", "creek_mcp.tools.draft", "to_privacy_override"),
+    ("creek.author", "creek_mcp.tools.author", "to_privacy_override"),
+]
+
+_PINNED_GAPS = {
+    "creek.report": 968,
+    "creek.state.read": 969,
+    "creek.state.render": 969,
+    "creek.skills.refresh": 971,
+}
+
+_PINNED_JOURNAL_GAP_ISSUE = 970
+
+_PINNED_AUTH_TOKEN_TOOLS = [
+    "creek.purge.fragment",
+    "creek.purge.source",
+    "creek.purge.classifications",
+    "creek.purge.daterange",
+    "creek.purge.vault",
+]
+
+# Tool name → implementing module, for the tools whose posture note has to be
+# read out of their own source (layers (d) and (e)). ``GATED`` entries carry
+# their module in the manifest itself and are resolved from there.
+_TOOL_MODULES = {
+    "creek.report": "creek_mcp.tools.report",
+    "creek.state.read": "creek_mcp.tools.state_read",
+    "creek.state.render": "creek_mcp.tools.state",
+    "creek.skills.refresh": "creek_mcp.tools.skills",
+    "creek.journal": "creek_mcp.tools.journal",
+}
+
+
+# ---------------------------------------------------------------------------
+# Manifest-derived parameter sets
+# ---------------------------------------------------------------------------
+
+_GATED_TOOLS = sorted(
+    name for name, entry in TOOL_POSTURES.items() if entry.posture is ReadPosture.GATED
+)
+_UNGATED_GAP_TOOLS = sorted(
+    name
+    for name, entry in TOOL_POSTURES.items()
+    if entry.posture is ReadPosture.UNGATED_KNOWN_GAP
+)
+_GAP_ISSUE_TOOLS = sorted(
+    name for name, entry in TOOL_POSTURES.items() if entry.gap_issue is not None
+)
+_CEILING_TOOLS = sorted(
+    name
+    for name, entry in TOOL_POSTURES.items()
+    if entry.posture is not ReadPosture.AUTH_TOKEN
+)
+_AUTH_TOKEN_TOOLS = sorted(
+    name
+    for name, entry in TOOL_POSTURES.items()
+    if entry.posture is ReadPosture.AUTH_TOKEN
+)
+
+
+# ---------------------------------------------------------------------------
+# Fragment-body canaries — unmistakable if they ever surface where they must
+# not. Plain sentinels rather than realistic prose so a leak cannot be excused
+# as "that phrase could have come from anywhere".
+# ---------------------------------------------------------------------------
+
+_OPEN_BODY = "CANARY-OPEN-BODY-5c04"
+_PERSONAL_BODY = "CANARY-PERSONAL-BODY-2b71"
+_INTIMATE_BODY = "CANARY-INTIMATE-BODY-9f3a"
+_PERSONAL_TITLE = "Personal note"
+_PERSONAL_SUMMARY = f"[Personal-tier summary: {_PERSONAL_TITLE}]"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _call_name(node: ast.Call) -> str | None:
+    """Resolve a call's callee to a bare symbol name.
+
+    Args:
+        node: The call node to inspect.
+
+    Returns:
+        ``func.id`` for a direct call (``gate(x)``), ``func.attr`` for a
+        qualified one (``mod.gate(x)``), or ``None`` when the callee is a
+        dynamic expression no static reader can name.
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _calls_symbol(module: ModuleType, symbol: str) -> bool:
+    """Return whether *module* contains a call to *symbol*.
+
+    Deliberately looks for a *call*, not a definition or an import: a module
+    can import (or even define) a gate and never invoke it, which is exactly
+    the failure mode layers (c) and (e) exist to detect.
+
+    Args:
+        module: The imported tool module to scan.
+        symbol: The callee name to look for.
+
+    Returns:
+        ``True`` when at least one call site names *symbol*.
+    """
+    tree = ast.parse(inspect.getsource(module))
+    return any(
+        isinstance(node, ast.Call) and _call_name(node) == symbol
+        for node in ast.walk(tree)
+    )
+
+
+def _module_path_for(tool: str) -> str:
+    """Return the dotted path of the module implementing *tool*.
+
+    ``GATED`` entries name their module in the manifest; everything else is
+    resolved through :data:`_TOOL_MODULES`, since the tool-name → file-name
+    mapping is not mechanical (``creek.state.read`` lives in ``state_read.py``,
+    ``creek.skills.refresh`` in ``skills.py``).
+
+    Args:
+        tool: The registered MCP tool name.
+
+    Returns:
+        The dotted module path.
+    """
+    entry = TOOL_POSTURES[tool]
+    if entry.gate_module is not None:
+        return entry.gate_module
+    path = _TOOL_MODULES.get(tool)
+    assert path is not None, (
+        f"{tool} carries a read-posture note that must be checked against its "
+        "own source, but this test cannot tell which module implements it. "
+        f"Add {tool!r} to _TOOL_MODULES in this file."
+    )
+    return path
+
+
+def _import_tool_module(tool: str) -> ModuleType:
+    """Import and return the module implementing *tool*.
+
+    Args:
+        tool: The registered MCP tool name.
+
+    Returns:
+        The imported module object.
+    """
+    return importlib.import_module(_module_path_for(tool))
+
+
+def _write_fragment(
+    vault: Path,
+    *,
+    frag_id: str,
+    title: str,
+    body: str,
+    privacy_tier: str,
+) -> Path:
+    """Write one classified fragment under ``01-Fragments/Notes``.
+
+    Args:
+        vault: Vault root.
+        frag_id: Fragment id, also used as the file stem.
+        title: Fragment title — what a personal-tier summary is built from.
+        body: Markdown body (a canary string in these tests).
+        privacy_tier: The fragment's ``privacy_tier`` front-matter value.
+
+    Returns:
+        The path the fragment was written to.
+    """
+    metadata = {
+        "type": "fragment",
+        "id": frag_id,
+        "title": title,
+        "created": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "ingested": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "F1", "secondary": []},
+        "privacy_tier": privacy_tier,
+        "eddies": [],
+    }
+    target = vault / "01-Fragments" / "Notes" / f"{frag_id}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _admitted_by_id(vault: Path, ceiling: TierCeiling) -> dict[str, tuple[Path, str]]:
+    """Return ``{fragment_id: (path, body)}`` for everything admitted at *ceiling*.
+
+    Args:
+        vault: Vault root.
+        ceiling: The caller's declared ceiling.
+
+    Returns:
+        A mapping keyed by fragment id, so a *dropped* fragment shows up as a
+        missing key rather than an off-by-one in a list comparison.
+    """
+    return {
+        fragment.id: (path, body)
+        for path, fragment, body in iter_admitted_fragments(vault, ceiling)
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def registered_tools(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Tool]:
+    """Return the live MCP tool surface keyed by tool name.
+
+    Built once per module from a throwaway vault: the schemas are derived from
+    the tool signatures at registration time, so nothing here depends on vault
+    contents. Module-scoped because these tests read the surface and never
+    mutate it.
+    """
+    vault = tmp_path_factory.mktemp("read-gate-surface")
+    for sub in ("00-Creek-Meta/audit", "01-Fragments/Notes", "creek-skills"):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda: lambda prompt: "ignored",
+    )
+    tools = asyncio.run(server.list_tools())
+    return {tool.name: tool for tool in tools}
+
+
+@pytest.fixture
+def seeded_vault(tmp_path: Path) -> Path:
+    """Return a vault holding one open, one personal and one intimate fragment.
+
+    Each body is a distinct canary so a tier-filter regression is visible as a
+    specific string in a specific place, not as a count that happens to differ.
+    """
+    _write_fragment(
+        tmp_path,
+        frag_id="frag-open",
+        title="Open note",
+        body=_OPEN_BODY,
+        privacy_tier="open",
+    )
+    _write_fragment(
+        tmp_path,
+        frag_id="frag-personal",
+        title=_PERSONAL_TITLE,
+        body=_PERSONAL_BODY,
+        privacy_tier="personal",
+    )
+    _write_fragment(
+        tmp_path,
+        frag_id="frag-intimate",
+        title="Intimate note",
+        body=_INTIMATE_BODY,
+        privacy_tier="intimate",
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Layer (a) — surface completeness
+# ---------------------------------------------------------------------------
+
+
+def test_tool_postures_cover_every_registered_tool(
+    registered_tools: dict[str, Tool],
+) -> None:
+    """The manifest matches the live tool surface exactly, in both directions.
+
+    Derived from ``server.list_tools()`` rather than a second hardcoded list,
+    so the only way to add an MCP tool is to state, in
+    ``creek_mcp.read_gate.TOOL_POSTURES``, how it relates to the caller's
+    ceiling. "Nobody wrote a posture down" is the state this whole module
+    exists to make impossible — an untriaged tool is indistinguishable from a
+    tool somebody decided needs no gate.
+
+    The reverse direction matters too: a manifest entry for a tool that no
+    longer exists is a claim about nothing, and it inflates the apparent
+    coverage of the surface.
+    """
+    manifest = set(TOOL_POSTURES)
+    live = set(registered_tools)
+    untriaged = live - manifest
+    stale = manifest - live
+    assert not untriaged, (
+        f"MCP tool(s) registered with no read posture: {sorted(untriaged)}. "
+        "Triage each one in creek_mcp.read_gate.TOOL_POSTURES: name the gate "
+        "it calls (GATED), record it as NO_UNSUPPLIED_READ / "
+        "CALLER_NAMED_PATHS / METADATA_ONLY / AUTH_TOKEN with a rationale, or "
+        "file a gap issue and record it as UNGATED_KNOWN_GAP with gap_issue."
+    )
+    assert not stale, (
+        "TOOL_POSTURES claims a posture for unregistered tool(s): "
+        f"{sorted(stale)}. Delete the entry, or restore the tool."
+    )
+    assert live == manifest
+
+
+def test_registered_tool_count_is_pinned(registered_tools: dict[str, Tool]) -> None:
+    """The MCP surface is 23 tools; growing it is a deliberate act.
+
+    A bare count is a cheap tripwire against the one edit the set-equality test
+    above cannot see: adding a tool *and* a matching posture entry in a single
+    change, where the posture was chosen to make the test quiet rather than to
+    describe the tool. Bumping this number forces the author to look at the
+    surface as a whole.
+    """
+    assert len(registered_tools) == _EXPECTED_TOOL_COUNT
+    assert len(TOOL_POSTURES) == _EXPECTED_TOOL_COUNT
+
+
+@pytest.mark.parametrize(("tool", "module", "symbol"), _PINNED_GATE_ROWS)
+def test_pinned_gate_claims_are_not_downgraded(
+    tool: str,
+    module: str,
+    symbol: str,
+) -> None:
+    """The tools that really enforce the ceiling keep saying so.
+
+    Without this pin, a future edit could quietly relabel a genuinely gated
+    tool as ``METADATA_ONLY`` — which reads as "no gate needed" — and every
+    other layer would still pass, because the anti-lying checks only fire on
+    entries that *claim* a gate. Pinning the exact ``(module, symbol)`` pair
+    additionally stops the claim from being redirected at some other callable
+    that happens to be invoked nearby.
+    """
+    entry = TOOL_POSTURES[tool]
+    assert entry.posture is ReadPosture.GATED, (
+        f"{tool} was recorded as {entry.posture.value!r}, but it enforces the "
+        f"ceiling through {module}.{symbol}. Downgrading its posture hides a "
+        "real gate from every reader of the manifest."
+    )
+    assert (entry.gate_module, entry.gate_symbol) == (module, symbol)
+
+
+@pytest.mark.parametrize(("tool", "issue"), sorted(_PINNED_GAPS.items()))
+def test_pinned_gaps_keep_their_posture_and_issue(tool: str, issue: int) -> None:
+    """The known-ungated tools stay labelled as gaps against their own issues.
+
+    These four read vault content without honouring the caller's ceiling. The
+    posture is the honest record of that, and the issue number is the promise
+    that someone is on the hook for it. Relabelling either one — without the
+    code changing — converts a tracked gap into an invisible one.
+    """
+    entry = TOOL_POSTURES[tool]
+    assert entry.posture is ReadPosture.UNGATED_KNOWN_GAP, (
+        f"{tool} was recorded as {entry.posture.value!r}, but it reads vault "
+        f"content without honouring the ceiling — a gap tracked by #{issue}. "
+        "If the gap is genuinely closed, point the entry at the gate that "
+        "closed it (GATED) rather than relabelling the posture."
+    )
+    assert entry.gap_issue == issue
+
+
+def test_journal_is_pinned_as_no_unsupplied_read() -> None:
+    """``creek.journal`` never returns content the caller did not supply.
+
+    Its posture is ``NO_UNSUPPLIED_READ`` rather than a gate: the write-side is
+    guarded by ``write_tier_allowed``, and the read-side gap it still carries
+    (#970) is recorded on the same entry. Pinning both together keeps the two
+    halves of that story from drifting apart — a reader must not be able to
+    conclude "journal has no gap" from the posture alone.
+    """
+    entry = TOOL_POSTURES["creek.journal"]
+    assert entry.posture is ReadPosture.NO_UNSUPPLIED_READ
+    assert entry.gap_issue == _PINNED_JOURNAL_GAP_ISSUE
+
+
+@pytest.mark.parametrize("tool", _PINNED_AUTH_TOKEN_TOOLS)
+def test_purge_tools_are_pinned_as_auth_token(tool: str) -> None:
+    """The five ``creek.purge.*`` tools are token-gated, not tier-gated.
+
+    Purge is not tier-scoped — it destroys vault content rather than reading it
+    — so it is gated fail-closed by ``CREEK_MCP_ELEVATED_TOKEN`` instead. The
+    posture must say ``AUTH_TOKEN`` and not something ceiling-shaped, because
+    layer (b) reads this field to decide whether the *absence* of a
+    ``privacy_tier_ceiling`` parameter is deliberate or a bug.
+    """
+    assert TOOL_POSTURES[tool].posture is ReadPosture.AUTH_TOKEN
+
+
+# ---------------------------------------------------------------------------
+# Layer (b) — ceiling-parameter presence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool", _CEILING_TOOLS)
+def test_non_auth_token_tools_accept_a_privacy_tier_ceiling(
+    tool: str,
+    registered_tools: dict[str, Tool],
+) -> None:
+    """Every tool that is not token-gated exposes ``privacy_tier_ceiling``.
+
+    The ceiling is the caller's *only* handle on how much of the vault a call
+    may reach. A tool that does not accept it cannot be asked to restrict
+    itself, and the remote cap in ``_BoundedFastMCP.call_tool`` silently reads
+    ``OPEN`` for it. Driven off the manifest rather than a name prefix, so the
+    invariant is tied to the posture a human recorded.
+    """
+    schema = registered_tools[tool].inputSchema
+    assert "privacy_tier_ceiling" in schema["properties"], (
+        f"{tool} has posture {TOOL_POSTURES[tool].posture.value!r} but exposes "
+        "no privacy_tier_ceiling parameter. Either add the parameter or "
+        "justify the omission with an AUTH_TOKEN posture."
+    )
+
+
+@pytest.mark.parametrize("tool", _AUTH_TOKEN_TOOLS)
+def test_auth_token_tools_expose_no_privacy_tier_ceiling(
+    tool: str,
+    registered_tools: dict[str, Tool],
+) -> None:
+    """Token-gated tools deliberately do **not** take a ceiling.
+
+    Documented in ``docs/mcp.md`` §"Purge tools deliberately do not accept a
+    privacy_tier_ceiling". The asymmetry is asserted rather than merely skipped
+    because adding the parameter here would be actively misleading: it would
+    advertise a tier gate that ``creek_mcp.tools.purge`` does not implement,
+    inviting a caller to believe ``ceiling=open`` limits what a purge destroys.
+    """
+    schema = registered_tools[tool].inputSchema
+    assert "privacy_tier_ceiling" not in schema["properties"], (
+        f"{tool} is AUTH_TOKEN-gated but now advertises a "
+        "privacy_tier_ceiling. A ceiling parameter nobody enforces is worse "
+        "than none; see docs/mcp.md."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer (c) — GATED claims verified against the implementation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool", _GATED_TOOLS)
+def test_gated_entries_declare_both_module_and_symbol(tool: str) -> None:
+    """A ``GATED`` claim is only checkable if it names where to look.
+
+    ``gate_module`` and ``gate_symbol`` are what turn "this tool is gated" from
+    an assertion into a verifiable statement; a ``GATED`` entry missing either
+    one would make layers (c) below vacuously pass.
+    """
+    entry = TOOL_POSTURES[tool]
+    assert entry.gate_module is not None, f"{tool} claims GATED with no module"
+    assert entry.gate_symbol is not None, f"{tool} claims GATED with no symbol"
+
+
+def test_non_gated_entries_declare_no_gate() -> None:
+    """Only ``GATED`` entries carry gate coordinates.
+
+    A leftover ``gate_symbol`` on a downgraded entry would read, to a human
+    skimming the manifest, as evidence of a gate that the posture itself
+    disclaims — and it would be checked by nothing.
+    """
+    for name, entry in TOOL_POSTURES.items():
+        if entry.posture is ReadPosture.GATED:
+            continue
+        assert entry.gate_module is None, (
+            f"{name} is {entry.posture.value!r} but names gate module "
+            f"{entry.gate_module!r}"
+        )
+        assert entry.gate_symbol is None, (
+            f"{name} is {entry.posture.value!r} but names gate symbol "
+            f"{entry.gate_symbol!r}"
+        )
+
+
+@pytest.mark.parametrize("tool", _GATED_TOOLS)
+def test_gated_tools_expose_their_named_gate_symbol(tool: str) -> None:
+    """The named gate exists in the named module.
+
+    The cheapest way for the manifest to lie is to name a gate that was
+    renamed, moved, or never existed. Importing the module and asking for the
+    attribute catches that on the next test run instead of at the next audit.
+    """
+    entry = TOOL_POSTURES[tool]
+    module = _import_tool_module(tool)
+    assert entry.gate_symbol is not None
+    assert hasattr(module, entry.gate_symbol), (
+        f"{tool} claims to be gated by {entry.gate_module}."
+        f"{entry.gate_symbol}, but that module has no such attribute. "
+        "Either the gate moved (update the manifest) or it is gone (the tool "
+        "is no longer gated and the posture is now a lie)."
+    )
+
+
+@pytest.mark.parametrize("tool", _GATED_TOOLS)
+def test_gated_tools_actually_call_their_named_gate_symbol(tool: str) -> None:
+    """The named gate is *invoked*, not merely importable.
+
+    A gate that exists but is never called protects nothing, and this is the
+    realistic decay path: a refactor moves the call out of the request path
+    while the helper — and its docstring, and the manifest entry pointing at it
+    — survive untouched. The AST walk requires a real call site, so an import,
+    a re-export, or a mention in a comment cannot satisfy it.
+    """
+    entry = TOOL_POSTURES[tool]
+    module = _import_tool_module(tool)
+    assert entry.gate_symbol is not None
+    assert _calls_symbol(module, entry.gate_symbol), (
+        f"{tool} claims to be gated by {entry.gate_symbol}, but "
+        f"{entry.gate_module} never calls it. A gate that is not invoked on "
+        "the request path enforces nothing."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer (d) — gap-entry integrity
+# ---------------------------------------------------------------------------
+
+
+def test_every_ungated_gap_declares_a_tracking_issue() -> None:
+    """``UNGATED_KNOWN_GAP`` without an issue is an *unknown* gap.
+
+    The posture's whole claim is that the gap is tracked. Dropping
+    ``gap_issue`` keeps the reassuring word "KNOWN" while removing the only
+    thing that makes it true, and it also exempts the entry from the
+    module-mention check below.
+    """
+    for tool in _UNGATED_GAP_TOOLS:
+        entry = TOOL_POSTURES[tool]
+        assert entry.gap_issue is not None, (
+            f"{tool} is recorded as a known gap with no tracking issue. File "
+            "one and record its number in gap_issue, or pick a posture that "
+            "does not promise the gap is tracked."
+        )
+
+
+@pytest.mark.parametrize("tool", _GAP_ISSUE_TOOLS)
+def test_gap_issue_numbers_are_positive_integers(tool: str) -> None:
+    """A tracking issue is a positive integer, not a placeholder.
+
+    Guards the obvious escape hatches — ``0``, ``-1``, or a bool sneaking
+    through ``int`` — that would satisfy a bare "is not None" check while
+    pointing at no issue anyone can open.
+    """
+    issue = TOOL_POSTURES[tool].gap_issue
+    assert isinstance(issue, int)
+    assert not isinstance(issue, bool)
+    assert issue > 0
+
+
+@pytest.mark.parametrize("tool", _GAP_ISSUE_TOOLS)
+def test_gap_issues_are_named_in_their_own_tool_module(tool: str) -> None:
+    """The tool's own source names the issue tracking its gap.
+
+    The manifest is a file most readers of ``creek_mcp/tools/report.py`` will
+    never open. Requiring the literal ``#<issue>`` in the module itself means
+    the person editing the tool learns about the gap where they already are,
+    and cannot extend the tool believing its reads are ceiling-filtered.
+    """
+    issue = TOOL_POSTURES[tool].gap_issue
+    assert issue is not None
+    source = inspect.getsource(_import_tool_module(tool))
+    assert f"#{issue}" in source, (
+        f"{_module_path_for(tool)} does not mention #{issue}. Add a posture "
+        "note to the module docstring naming the gap and its issue, so a "
+        "reader of the tool learns the ceiling is not enforced there."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layer (e) — drift protection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tool", _UNGATED_GAP_TOOLS)
+def test_ungated_gap_tools_do_not_call_a_canonical_gate_primitive(tool: str) -> None:
+    """A tool recorded as an ungated gap must not already use a canonical gate.
+
+    This is the anti-rot direction. When someone closes one of these gaps by
+    adopting :func:`~creek_mcp.read_gate.refuse_above_ceiling` or
+    :func:`~creek_mcp.read_gate.iter_admitted_fragments`, this test fails until
+    they also flip the posture to ``GATED`` — so the manifest cannot rot into
+    advertising a gap that was fixed months ago, which would send an auditor
+    hunting a hole that is not there and leave a real gate unverified by layer
+    (c).
+
+    Scoped deliberately to the two *new* primitives and not to
+    ``tier_allowed``/``write_tier_allowed``: ``creek.journal`` legitimately
+    calls ``write_tier_allowed`` for its write-side gate while still carrying a
+    read-side gap, so keying off the older helpers would make this test
+    unsatisfiable for an honest entry.
+    """
+    module = _import_tool_module(tool)
+    for primitive in sorted(CANONICAL_GATE_PRIMITIVES):
+        assert not _calls_symbol(module, primitive), (
+            f"{tool} is recorded as an ungated known gap "
+            f"(#{TOOL_POSTURES[tool].gap_issue}) but {_module_path_for(tool)} "
+            f"already calls {primitive}. If the gap is closed, change the "
+            "posture to GATED and name the gate; if it is not, this call is "
+            "misleading."
+        )
+
+
+def test_canonical_gate_primitives_name_the_exported_callables() -> None:
+    """The primitive names are the two callables this module actually exports.
+
+    :data:`~creek_mcp.read_gate.CANONICAL_GATE_PRIMITIVES` is consumed as
+    *strings* by the AST walk above, so a typo or a rename would silently
+    weaken layer (e) into scanning for a symbol nothing can ever call.
+    Resolving each name back to a callable on the module closes that loop.
+    """
+    read_gate = importlib.import_module("creek_mcp.read_gate")
+    assert CANONICAL_GATE_PRIMITIVES == _EXPECTED_PRIMITIVES
+    for primitive in CANONICAL_GATE_PRIMITIVES:
+        assert callable(getattr(read_gate, primitive))
+
+
+# ---------------------------------------------------------------------------
+# ``refuse_above_ceiling`` — the refusal primitive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("tier", "ceiling"),
+    [
+        (PrivacyTier.OPEN, TierCeiling.OPEN),
+        (PrivacyTier.UNCLASSIFIED, TierCeiling.OPEN),
+        (PrivacyTier.OPEN, TierCeiling.PERSONAL),
+        (PrivacyTier.PERSONAL, TierCeiling.PERSONAL),
+        (PrivacyTier.INTIMATE, TierCeiling.INTIMATE),
+        (PrivacyTier.PERSONAL, TierCeiling.ALL),
+        (PrivacyTier.INTIMATE, TierCeiling.ALL),
+    ],
+)
+def test_refuse_above_ceiling_admits_content_within_the_ceiling(
+    tier: PrivacyTier,
+    ceiling: TierCeiling,
+) -> None:
+    """Admitted content produces no refusal — ``None`` means "carry on".
+
+    The rows mirror ``tier_allowed``'s matrix because this primitive must
+    *delegate* to it rather than re-deriving admission. A second, private
+    ranking inside the read gate is exactly how two parts of the MCP surface
+    end up disagreeing about whether a fragment is readable.
+
+    ``unclassified`` at ``ceiling=open`` is included on purpose: the MCP-side
+    ranking admits it (``creek_mcp.tier_ceiling._TIER_RANK``), which differs
+    from the reader-caution ranking in ``creek.classify.privacy_filter`` — a
+    deliberate, documented split that this primitive must not quietly
+    re-decide.
+    """
+    assert (
+        refuse_above_ceiling(tool="creek.reflect", content_tier=tier, ceiling=ceiling)
+        is None
+    )
+
+
+@pytest.mark.parametrize("ceiling", list(TierCeiling))
+def test_refuse_above_ceiling_passes_raw_caller_content(ceiling: TierCeiling) -> None:
+    """``content_tier=None`` is never above the ceiling, at any ceiling.
+
+    ``None`` is what a tool has when the caller supplied the text inline: it
+    carries no classification and it is the caller's own words, so refusing it
+    would mean refusing callers access to what they just typed. Mirrors
+    ``creek_mcp.tools.reflect._above_ceiling``, which this primitive
+    generalises. Parametrised over every ceiling so the ``None`` short-circuit
+    cannot be implemented as a quirk of one branch.
+    """
+    assert (
+        refuse_above_ceiling(tool="creek.reflect", content_tier=None, ceiling=ceiling)
+        is None
+    )
+
+
+def test_refuse_above_ceiling_returns_the_canonical_refusal_payload() -> None:
+    """An above-ceiling read yields exactly the shared refusal dict.
+
+    Equality against ``refusal_response(...)`` — rather than a spot-check of
+    ``status`` — pins the whole payload: the same four keys every other MCP
+    refusal uses, no extras, and the fixed generic reason. An extra key here
+    would be a new, unreviewed channel out of the gate.
+    """
+    response = refuse_above_ceiling(
+        tool="creek.reflect",
+        content_tier=PrivacyTier.INTIMATE,
+        ceiling=TierCeiling.OPEN,
+    )
+    assert response == refusal_response(
+        tool="creek.reflect",
+        ceiling=TierCeiling.OPEN,
+        reason=GENERIC_ABOVE_CEILING_REASON,
+    )
+
+
+@pytest.mark.parametrize(
+    ("tier", "ceiling"),
+    [
+        (PrivacyTier.PERSONAL, TierCeiling.OPEN),
+        (PrivacyTier.INTIMATE, TierCeiling.OPEN),
+        (PrivacyTier.INTIMATE, TierCeiling.PERSONAL),
+    ],
+)
+def test_refuse_above_ceiling_never_echoes_the_content_tier(
+    tier: PrivacyTier,
+    ceiling: TierCeiling,
+) -> None:
+    """The refusal leaks no bit about the tier of content the caller cannot read.
+
+    This is the load-bearing property, and the reason
+    ``creek_mcp/tools/reflect.py`` carries the comment block at lines 403-431:
+    the offending tier is derived from content the caller is *not* admitted to,
+    so echoing it turns every refusal into a tier-classification oracle over
+    the corpus — probe an id, read the tier back out of the error.
+
+    Asserted against the serialised response rather than the ``reason`` field
+    alone, because the leak is just as real in an extra ``content_tier`` key
+    added "for debugging". The refusal must be indistinguishable across every
+    above-ceiling tier at a given ceiling.
+    """
+    response = refuse_above_ceiling(
+        tool="creek.reflect", content_tier=tier, ceiling=ceiling
+    )
+    assert response is not None
+    serialised = json.dumps(response)
+    assert tier.value not in serialised, (
+        f"the refusal for {tier.value!r} content at ceiling {ceiling.value!r} "
+        f"echoes the content tier: {serialised}. That is a one-bit oracle over "
+        "content the caller is not admitted to."
+    )
+    assert set(response) == {"status", "tool", "tier_ceiling", "reason"}
+    assert response["reason"] == GENERIC_ABOVE_CEILING_REASON
+
+
+def test_generic_above_ceiling_reason_names_no_tier() -> None:
+    """The fixed reason string mentions no privacy tier at all.
+
+    The oracle test above compares against the tier that was actually passed;
+    this one closes the remaining hole, where a well-meaning reason like
+    "personal or intimate content was excluded" would be tier-free for the
+    *offending* tier while still narrowing the corpus for an attacker.
+    """
+    for tier in PrivacyTier:
+        assert tier.value not in GENERIC_ABOVE_CEILING_REASON, (
+            f"GENERIC_ABOVE_CEILING_REASON names the {tier.value!r} tier: "
+            f"{GENERIC_ABOVE_CEILING_REASON!r}"
+        )
+
+
+def test_refuse_above_ceiling_fails_closed_on_an_unrecognised_tier() -> None:
+    """An unrecognised tier is handled as ``intimate``, never as ``open``.
+
+    A tier value the ranking has never heard of is a tier nobody can vouch for.
+    ``tier_sensitivity`` ranks it with ``intimate``, so it must be refused
+    everywhere ``intimate`` is refused (``open`` and ``personal``) and admitted
+    only where ``intimate`` is admitted.
+
+    The admitted rows are asserted as *equality with ``intimate``'s outcome*
+    rather than as a flat "refused at every ceiling but ``all``". That keeps
+    the test honest about delegation: making this primitive stricter than
+    ``tier_allowed`` would give the read gate a private admission rule that can
+    drift from the predicate the rest of the MCP surface uses, and drift is the
+    failure this module exists to prevent. The unknown value must also never
+    appear in the refusal — an unrecognised tier is still content the caller
+    cannot read.
+    """
+    unknown = cast("PrivacyTier", "not-a-tier")
+    for ceiling in (TierCeiling.OPEN, TierCeiling.PERSONAL):
+        response = refuse_above_ceiling(
+            tool="creek.reflect", content_tier=unknown, ceiling=ceiling
+        )
+        assert response is not None, (
+            f"an unrecognised tier was admitted at ceiling {ceiling.value!r}; "
+            "unknown tiers must fail closed with intimate"
+        )
+        assert "not-a-tier" not in json.dumps(response)
+    for ceiling in (TierCeiling.INTIMATE, TierCeiling.ALL):
+        as_unknown = refuse_above_ceiling(
+            tool="creek.reflect", content_tier=unknown, ceiling=ceiling
+        )
+        as_intimate = refuse_above_ceiling(
+            tool="creek.reflect",
+            content_tier=PrivacyTier.INTIMATE,
+            ceiling=ceiling,
+        )
+        assert as_intimate is None
+        assert as_unknown == as_intimate
+
+
+# ---------------------------------------------------------------------------
+# ``iter_admitted_fragments`` — the corpus-walk primitive
+# ---------------------------------------------------------------------------
+
+
+def test_iter_admitted_fragments_drops_intimate_at_the_open_ceiling(
+    seeded_vault: Path,
+) -> None:
+    """At ``ceiling=open`` an intimate fragment is not yielded at all.
+
+    Not yielded — not yielded-with-an-empty-body, not yielded-as-a-stub. A
+    caller at the open ceiling must not learn that the fragment exists, since
+    its id and title are themselves content above the ceiling. The canary
+    assertion covers the sloppier failure where the fragment is filtered out of
+    the ids but its body still rides along in some other slot.
+    """
+    admitted = _admitted_by_id(seeded_vault, TierCeiling.OPEN)
+    assert "frag-intimate" not in admitted
+    assert set(admitted) == {"frag-open", "frag-personal"}
+    blob = json.dumps({key: value[1] for key, value in admitted.items()})
+    assert _INTIMATE_BODY not in blob
+
+
+def test_iter_admitted_fragments_summarises_personal_at_the_open_ceiling(
+    seeded_vault: Path,
+) -> None:
+    """At ``ceiling=open`` a personal fragment yields a title-only summary.
+
+    This is the Ontology §13.2 promise, delegated to
+    ``creek.classify.privacy_filter.filter_fragments_by_tier`` via
+    ``to_privacy_override``: personal content contributes that it exists and
+    what it is called, never its body. Exact string equality against
+    ``_summarize_personal``'s output — a substring or truthiness check would
+    pass for a body that merely *starts* with the summary.
+
+    The open fragment's full body is asserted in the same test so a filter that
+    summarised everything (trivially leak-free, and useless) cannot pass.
+    """
+    admitted = _admitted_by_id(seeded_vault, TierCeiling.OPEN)
+    assert admitted["frag-personal"][1].strip() == _PERSONAL_SUMMARY
+    assert _PERSONAL_BODY not in admitted["frag-personal"][1]
+    assert admitted["frag-open"][1].strip() == _OPEN_BODY
+
+
+def test_iter_admitted_fragments_yields_the_fragment_path(
+    seeded_vault: Path,
+) -> None:
+    """Each yielded triple carries the path the fragment was loaded from.
+
+    Callers need the path to attribute, re-read, or link the fragment; a
+    primitive that yields the right bodies against the wrong paths would have
+    every tier assertion above still pass.
+    """
+    admitted = _admitted_by_id(seeded_vault, TierCeiling.ALL)
+    notes = seeded_vault / "01-Fragments" / "Notes"
+    assert admitted["frag-open"][0] == notes / "frag-open.md"
+    assert admitted["frag-personal"][0] == notes / "frag-personal.md"
+    assert admitted["frag-intimate"][0] == notes / "frag-intimate.md"
+
+
+def test_iter_admitted_fragments_yields_full_bodies_at_the_all_ceiling(
+    seeded_vault: Path,
+) -> None:
+    """At ``ceiling=all`` every fragment is yielded with its full body.
+
+    The permissive direction has to be pinned too: a gate that drops everything
+    is not a gate, it is an outage, and it would satisfy every leak assertion
+    in this file. ``all`` is the explicit operator override, so nothing is
+    dropped and nothing is summarised.
+    """
+    admitted = _admitted_by_id(seeded_vault, TierCeiling.ALL)
+    assert set(admitted) == {"frag-open", "frag-personal", "frag-intimate"}
+    assert admitted["frag-open"][1].strip() == _OPEN_BODY
+    assert admitted["frag-personal"][1].strip() == _PERSONAL_BODY
+    assert admitted["frag-intimate"][1].strip() == _INTIMATE_BODY
+    blob = json.dumps({key: value[1] for key, value in admitted.items()})
+    assert "[Personal-tier summary" not in blob
+
+
+@pytest.mark.parametrize("ceiling", list(TierCeiling))
+def test_iter_admitted_fragments_tolerates_a_missing_fragments_directory(
+    tmp_path: Path,
+    ceiling: TierCeiling,
+) -> None:
+    """A vault with no ``01-Fragments`` yields nothing instead of crashing.
+
+    This is the new-user and freshly-``creek init``-ed case. Every tool that
+    adopts this primitive inherits its empty-vault behaviour, so raising here
+    would turn "you have no fragments yet" into a tool-wide error at every
+    ceiling.
+    """
+    assert list(iter_admitted_fragments(tmp_path, ceiling)) == []

--- a/creek-tools/tests/test_mcp_read_gate.py
+++ b/creek-tools/tests/test_mcp_read_gate.py
@@ -90,7 +90,12 @@ _EXPECTED_PRIMITIVES = frozenset({"refuse_above_ceiling", "iter_admitted_fragmen
 
 _PINNED_GATE_ROWS = [
     ("creek.reflect", "creek_mcp.tools.reflect", "_above_ceiling"),
-    ("creek.compile", "creek_mcp.tools.compile", "_sources_above_ceiling"),
+    # NB: issue #932's "prior art" section names ``_sources_above_ceiling``.
+    # No such symbol exists — ``creek_mcp/tools/compile.py`` defines
+    # ``_survey_sources``, which returns a ``_SourceGate`` the caller branches
+    # on. Pinned to the real name; the wrong one would have made layer (c) a
+    # permanent, uninformative failure.
+    ("creek.compile", "creek_mcp.tools.compile", "_survey_sources"),
     ("creek.wheel", "creek_mcp.tools.wheel", "to_privacy_override"),
     ("creek.mine", "creek_mcp.tools.mine", "to_privacy_override"),
     ("creek.draft", "creek_mcp.tools.draft", "to_privacy_override"),

--- a/creek-tools/tests/test_mcp_read_gate.py
+++ b/creek-tools/tests/test_mcp_read_gate.py
@@ -1,4 +1,4 @@
-"""Structural guardrails for the MCP read surface's tier gates (#932).
+"""Structural and behavioural guardrails for the MCP read surface's tier gates (#932).
 
 ``creek_mcp.read_gate`` is a *manifest plus two primitives*. The manifest
 (:data:`~creek_mcp.read_gate.TOOL_POSTURES`) records, for every registered MCP
@@ -10,7 +10,7 @@ primitives (:func:`~creek_mcp.read_gate.refuse_above_ceiling` and
 ways a tool may satisfy the ceiling, so gaps can be closed by adoption rather
 than by re-deriving the policy per tool.
 
-A manifest is only worth having if it cannot lie. Five layers keep it honest:
+A manifest is only worth having if it cannot lie. Six layers keep it honest:
 
 (a) **Surface completeness** — the manifest covers exactly the live tool list,
     derived from ``server.list_tools()`` rather than a second hardcoded copy,
@@ -27,6 +27,20 @@ A manifest is only worth having if it cannot lie. Five layers keep it honest:
     module learns the gap exists without consulting the manifest.
 (e) **Anti-rot** — a tool recorded as an ungated gap must not already call a
     canonical gate primitive.
+(f) **Runtime canary probe** — every ``GATED`` tool is *called for real* at
+    ``ceiling=open`` against a vault holding an ``intimate`` fragment whose
+    title, body and tags each carry a unique sentinel, and the sentinel must
+    appear nowhere in the JSON-serialised response. Driven off a manifest of
+    its own (:data:`_RUNTIME_PROBES` / :data:`_PROBE_EXEMPT`) so a newly
+    ``GATED`` tool must either grow a probe or record a justified exemption —
+    the same forcing function as layer (a), one level deeper.
+
+Layer (f) exists because layers (a)-(e) are **structural**. Between them they
+prove that a gate is declared in the manifest, exists in the named module, and
+is invoked there. None of that can prove the gate is the *only* path to the
+corpus: a second, ungated read added alongside the still-present, still-called
+gate satisfies every structural check. Only calling the tool and looking at
+what comes back can see that, which is what (f) does.
 
 Injection drill (each step is expected to turn exactly one layer red):
 
@@ -36,6 +50,22 @@ Injection drill (each step is expected to turn exactly one layer red):
    fails.
 3. Drop the ``gap_issue`` from an ``UNGATED_KNOWN_GAP`` entry → layer (d)
    fails.
+4. In ``creek_mcp/tools/wheel.py``, leave the ``to_privacy_override(...)`` gate
+   call exactly where it is and *additionally* return every raw fragment body
+   from ``wheel_tool``::
+
+       "unclassified": counts.get(Frequency.UNCLASSIFIED, 0),
+       "leak": [
+           b
+           for _p, _f, b, _m in iter_vault_fragments(vault_path / _FRAGMENTS_SUBDIR)
+       ],
+
+   → layer (f) fails, and **only** layer (f). This mutation was run against
+   the file before (f) existed: 101 passed here, 8 passed in
+   ``tests/test_mcp_wheel.py``, nothing caught it. Layers (a)-(e) stay green
+   by construction — the manifest still names ``to_privacy_override``, the
+   symbol still exists, and the AST walk still finds a call site — which is
+   precisely the blind spot (f) covers.
 
 Deliberately absent: any runtime probe asserting that a known gap *still
 leaks*. Such a test passes because the bug exists and breaks when it is fixed.
@@ -51,7 +81,7 @@ import importlib
 import inspect
 import json
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import frontmatter
 import pytest
@@ -67,8 +97,13 @@ from creek_mcp.read_gate import (
 )
 from creek_mcp.server import build_server
 from creek_mcp.tier_ceiling import TierCeiling, refusal_response
+from creek_mcp.tools.compile import _ABOVE_CEILING_REASON, compile_tool
+from creek_mcp.tools.mine import mine_tool
+from creek_mcp.tools.reflect import reflect_tool
+from creek_mcp.tools.wheel import wheel_tool
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
     from types import ModuleType
 
@@ -107,6 +142,13 @@ _PINNED_GAPS = {
     "creek.state.read": 969,
     "creek.state.render": 969,
     "creek.skills.refresh": 971,
+    # Recorded as CALLER_NAMED_PATHS until the #932 Gate-2.5 review. The name
+    # was accurate — the caller does name the path — but the confinement is to
+    # the whole vault, not the FEAT-027 staging subtree, so an open-ceiling
+    # caller aimed at 01-Fragments gets back intimate fragments' filenames,
+    # which are slugified titles. Pinned so the posture cannot drift back to a
+    # reassuring label while the behaviour is unchanged.
+    "creek.redact.scan": 972,
 }
 
 _PINNED_JOURNAL_GAP_ISSUE = 970
@@ -123,6 +165,7 @@ _PINNED_AUTH_TOKEN_TOOLS = [
 # read out of their own source (layers (d) and (e)). ``GATED`` entries carry
 # their module in the manifest itself and are resolved from there.
 _TOOL_MODULES = {
+    "creek.redact.scan": "creek_mcp.tools.redact",
     "creek.report": "creek_mcp.tools.report",
     "creek.state.read": "creek_mcp.tools.state_read",
     "creek.state.render": "creek_mcp.tools.state",
@@ -195,23 +238,58 @@ def _call_name(node: ast.Call) -> str | None:
     return None
 
 
+def _discarded_calls(tree: ast.AST) -> set[int]:
+    """Return the ids of call nodes whose result is thrown away.
+
+    A bare expression statement — ``_above_ceiling(tier, ceiling)`` on a line
+    of its own — is a call whose value nothing consumes. Python allows it and
+    the AST is indistinguishable from a real gate at the ``ast.Call`` level,
+    which is how a "call-and-discard" edit can leave the declared gate present,
+    imported, and syntactically invoked while it decides nothing.
+
+    Args:
+        tree: The parsed module.
+
+    Returns:
+        ``id()`` of every :class:`ast.Call` sitting directly under an
+        :class:`ast.Expr` statement. Identity rather than equality because AST
+        nodes are unhashable and two structurally identical calls at different
+        sites are genuinely different call sites.
+    """
+    return {
+        id(node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call)
+    }
+
+
 def _calls_symbol(module: ModuleType, symbol: str) -> bool:
-    """Return whether *module* contains a call to *symbol*.
+    """Return whether *module* calls *symbol* and uses the result.
 
     Deliberately looks for a *call*, not a definition or an import: a module
     can import (or even define) a gate and never invoke it, which is exactly
     the failure mode layers (c) and (e) exist to detect.
+
+    Calls whose result is discarded do not count. Requiring the value to be
+    consumed — by a condition, an assignment, a comparison, a return — is what
+    separates a gate from a gesture: replacing
+    ``if _above_ceiling(t, c): return refusal_response(...)`` with a bare
+    ``_above_ceiling(t, c)`` and falling through leaves a call site that
+    refuses nothing, and this check is the reason that edit cannot pass.
 
     Args:
         module: The imported tool module to scan.
         symbol: The callee name to look for.
 
     Returns:
-        ``True`` when at least one call site names *symbol*.
+        ``True`` when at least one *load-bearing* call site names *symbol*.
     """
     tree = ast.parse(inspect.getsource(module))
+    discarded = _discarded_calls(tree)
     return any(
-        isinstance(node, ast.Call) and _call_name(node) == symbol
+        isinstance(node, ast.Call)
+        and _call_name(node) == symbol
+        and id(node) not in discarded
         for node in ast.walk(tree)
     )
 
@@ -261,6 +339,7 @@ def _write_fragment(
     title: str,
     body: str,
     privacy_tier: str,
+    tags: list[str] | None = None,
 ) -> Path:
     """Write one classified fragment under ``01-Fragments/Notes``.
 
@@ -270,11 +349,14 @@ def _write_fragment(
         title: Fragment title — what a personal-tier summary is built from.
         body: Markdown body (a canary string in these tests).
         privacy_tier: The fragment's ``privacy_tier`` front-matter value.
+        tags: Optional Obsidian tags. ``None`` — the default — omits the key
+            entirely rather than writing an empty list, so front matter written
+            by the callers that predate layer (f) is byte-identical to before.
 
     Returns:
         The path the fragment was written to.
     """
-    metadata = {
+    metadata: dict[str, Any] = {
         "type": "fragment",
         "id": frag_id,
         "title": title,
@@ -285,6 +367,8 @@ def _write_fragment(
         "privacy_tier": privacy_tier,
         "eddies": [],
     }
+    if tags is not None:
+        metadata["tags"] = tags
     target = vault / "01-Fragments" / "Notes" / f"{frag_id}.md"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(
@@ -979,3 +1063,414 @@ def test_iter_admitted_fragments_tolerates_a_missing_fragments_directory(
     ceiling.
     """
     assert list(iter_admitted_fragments(tmp_path, ceiling)) == []
+
+
+# ---------------------------------------------------------------------------
+# Layer (f) — runtime canary probe
+#
+# Everything above is static: it reads the manifest, the tool schemas, and the
+# tools' source. That is enough to prove a gate is declared, exists and is
+# called — and no more. A second read of the corpus, added *alongside* an
+# untouched gate call, is invisible to all of it. What follows calls each
+# GATED tool for real and looks at what comes back.
+# ---------------------------------------------------------------------------
+
+# Sentinels in the same unmistakable style as the bodies above, but distinct
+# values: these travel through four different tools, and a collision with the
+# iter_admitted_fragments canaries would make a failure ambiguous about which
+# fixture leaked.
+_RUNTIME_OPEN_CANARY = "CANARY-RUNTIME-OPEN-4e8b"
+_RUNTIME_INTIMATE_CANARY = "CANARY-RUNTIME-INTIMATE-7d21"
+
+# The ids are deliberately canary-free. ``creek.reflect`` and ``creek.compile``
+# are *given* these ids by the caller, so echoing one back is not a leak; only
+# the content behind it is. Keeping the sentinel out of the id means a probe
+# failure can only mean "the tool reached the content".
+_RUNTIME_OPEN_ID = "frag-runtime-open"
+_RUNTIME_INTIMATE_ID = "frag-runtime-intimate"
+
+# ``creek_mcp/tools/reflect.py`` inlines this string at its #846 gate rather
+# than naming a constant, so it is repeated here. Asserted (rather than a bare
+# ``status == "refused"``) because reflect has a second refusal — "entry_ref
+# not found" — and a probe that accepted either would go green if reflect
+# simply stopped resolving the fragment, which proves nothing about the gate.
+_REFLECT_ABOVE_CEILING_REASON = "entry_ref tier exceeds ceiling"
+
+_PROBE_EXEMPT: dict[str, str] = {
+    "creek.draft": (
+        "draft_tool needs a DraftGenerator driven over a deployed skills tree; "
+        "on a bare fixture it answers from generator scaffolding "
+        "(status='empty' / a RuntimeError refusal) before the response shape a "
+        "probe wants to inspect exists, so a canary-free result would be "
+        "evidence about the scaffolding, not about the ceiling. Its corpus "
+        "walk is IdeaMiner(privacy_override=to_privacy_override(ceiling)) — "
+        "byte-for-byte the walk creek.mine is probed through below — so the "
+        "read path is covered even though draft's own envelope is not."
+    ),
+    "creek.author": (
+        "author_tool calls load_config() and drives the Writing Desk, and it "
+        "wraps that whole span in `except Exception` returning status='error'. "
+        "On any unconfigured-provider or missing-contract failure it therefore "
+        "returns an envelope with no corpus content in it at all, so the "
+        "canary assertion would pass for the wrong reason — the desk never "
+        "started. A real probe needs a configured desk and belongs beside the "
+        "other author tests."
+    ),
+}
+"""``GATED`` tools that cannot be probed *here*, each with the reason why.
+
+Read these as claims, not as boilerplate: an exemption is the one way a
+``GATED`` tool escapes layer (f), so a reason that does not survive being
+checked against the tool's source is a hole in the layer.
+"""
+
+
+def _forbidden_llm_factory(tier: PrivacyTier) -> Any:
+    """Fail loudly instead of returning an LLM — the gate must never reach here.
+
+    Both probed write-side tools build their model client *below* the ceiling
+    gate, so on an above-ceiling request this factory must not be invoked at
+    all. A stub that quietly returned ``"{}"`` would let a broken gate look
+    clean: the tool would call the model, get nothing quotable back, and answer
+    with a canary-free envelope. Raising turns that same path into a failure
+    that names what happened.
+
+    Args:
+        tier: The routing tier the tool derived — reported in the message
+            because *which* tier reached the factory is the first thing a
+            reader will want.
+
+    Returns:
+        Never returns.
+
+    Raises:
+        AssertionError: Always. Neither ``reflect_tool`` (catches
+            ``RuntimeError``) nor ``compile_tool`` (catches ``ValueError`` /
+            ``RuntimeError``) swallows it, so it surfaces as a test failure
+            rather than as a structured refusal.
+    """
+    msg = (
+        "the ceiling gate let an above-ceiling read through to the model: an "
+        f"LLM client was built for tier {tier!r} on a request the tool was "
+        "supposed to refuse before reaching any provider"
+    )
+    raise AssertionError(msg)
+
+
+def _probe_wheel(vault: Path) -> dict[str, Any]:
+    """Call ``creek.wheel`` at the open ceiling over the canary vault.
+
+    Args:
+        vault: The seeded canary vault.
+
+    Returns:
+        The tool's response envelope.
+    """
+    return wheel_tool(vault_path=vault, privacy_tier_ceiling=TierCeiling.OPEN)
+
+
+def _probe_mine(vault: Path) -> dict[str, Any]:
+    """Call ``creek.mine`` at the open ceiling, unbounded.
+
+    ``limit=0`` returns *every* seed. A default-limited call could hide a leak
+    behind truncation — the probe would then be asserting on the first ten
+    seeds rather than on the tool's whole output.
+
+    Args:
+        vault: The seeded canary vault.
+
+    Returns:
+        The tool's response envelope.
+    """
+    return mine_tool(
+        vault_path=vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        limit=0,
+    )
+
+
+def _probe_reflect(vault: Path) -> dict[str, Any]:
+    """Call ``creek.reflect`` at the open ceiling on the intimate canary.
+
+    ``care_guard=None`` keeps the #753 seam out of the picture: this probe is
+    about the #846 read gate, and the gate sits above the care seam precisely
+    so an unadmitted caller cannot reach it.
+
+    Args:
+        vault: The seeded canary vault.
+
+    Returns:
+        The tool's response envelope.
+    """
+    return reflect_tool(
+        vault_path=vault,
+        llm_factory=_forbidden_llm_factory,
+        entry_ref=_RUNTIME_INTIMATE_ID,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        care_guard=None,
+    )
+
+
+def _probe_compile(vault: Path) -> dict[str, Any]:
+    """Call ``creek.compile`` at the open ceiling over the intimate canary.
+
+    The target metadata is deliberately sentinel-free: ``target_id`` and
+    ``target_title`` are the caller's own strings, so a response echoing them
+    would say nothing about the corpus and would only blur the assertion.
+
+    Args:
+        vault: The seeded canary vault.
+
+    Returns:
+        The tool's response envelope.
+    """
+    return compile_tool(
+        vault_path=vault,
+        fragment_ids=[_RUNTIME_INTIMATE_ID],
+        target_kind="thread",
+        target_id="thread-runtime-probe",
+        target_title="Runtime probe target",
+        llm_factory=_forbidden_llm_factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+
+_RUNTIME_PROBES: dict[str, Callable[[Path], dict[str, Any]]] = {
+    "creek.wheel": _probe_wheel,
+    "creek.mine": _probe_mine,
+    "creek.reflect": _probe_reflect,
+    "creek.compile": _probe_compile,
+}
+"""``GATED`` tool → a callable that invokes it at ``ceiling=open``.
+
+Each probe is callable with no live provider, no config file and no skills
+tree, so layer (f) stays a unit test.
+"""
+
+
+@pytest.fixture
+def canary_vault(tmp_path: Path) -> Path:
+    """Return a vault holding one ``open`` and one ``intimate`` canary fragment.
+
+    Each fragment carries its sentinel in **three** places — ``title``, body and
+    ``tags`` — so a tool that leaks only titles (an index-shaped response), only
+    tags (a tag-garden-shaped one) or only bodies is caught by the same
+    assertion. The ``open`` fragment is not decoration: it is the positive
+    control, and the per-tool tests below assert it *is* reachable, so a tool
+    that returned nothing at all could not pass layer (f) by being empty.
+    """
+    _write_fragment(
+        tmp_path,
+        frag_id=_RUNTIME_OPEN_ID,
+        title=f"Open canary {_RUNTIME_OPEN_CANARY}",
+        body=f"Open canary body {_RUNTIME_OPEN_CANARY}",
+        privacy_tier="open",
+        tags=[_RUNTIME_OPEN_CANARY],
+    )
+    _write_fragment(
+        tmp_path,
+        frag_id=_RUNTIME_INTIMATE_ID,
+        title=f"Intimate canary {_RUNTIME_INTIMATE_CANARY}",
+        body=f"Intimate canary body {_RUNTIME_INTIMATE_CANARY}",
+        privacy_tier="intimate",
+        tags=[_RUNTIME_INTIMATE_CANARY],
+    )
+    return tmp_path
+
+
+def test_every_gated_tool_is_probed_or_explicitly_exempt() -> None:
+    """Each ``GATED`` tool is either runtime-probed or exempt, never neither.
+
+    This is layer (a)'s forcing function applied one level down. Hand-listing
+    the probed tools and leaving the rest silently unprobed would let a newly
+    ``GATED`` tool inherit "structurally verified, behaviourally unchecked" —
+    which is exactly the state the wheel mutation exploited. Driving the
+    parametrisation off :data:`_RUNTIME_PROBES` while asserting its union with
+    :data:`_PROBE_EXEMPT` covers the manifest means the choice has to be made
+    out loud.
+
+    Disjointness is asserted too: a tool in both dicts would carry an
+    exemption reason nobody reads and a probe nobody knows is authoritative.
+    So is the reverse direction — an entry for a tool that is no longer
+    ``GATED`` is a claim about nothing, and it inflates the apparent depth of
+    this layer.
+    """
+    probed = set(_RUNTIME_PROBES)
+    exempt = set(_PROBE_EXEMPT)
+    gated = set(_GATED_TOOLS)
+    both = probed & exempt
+    assert not both, (
+        f"tool(s) both probed and exempt: {sorted(both)}. An exemption is a "
+        "statement that no probe is possible here; a probe refutes it."
+    )
+    unchecked = gated - probed - exempt
+    assert not unchecked, (
+        "GATED tool(s) with no runtime probe and no exemption: "
+        f"{sorted(unchecked)}. Add a probe to _RUNTIME_PROBES, or record in "
+        "_PROBE_EXEMPT the specific reason this tool cannot be called here. "
+        "Layers (a)-(e) only prove the gate is declared and invoked — they "
+        "cannot see a second, ungated read next to it."
+    )
+    stale = (probed | exempt) - gated
+    assert not stale, (
+        "_RUNTIME_PROBES/_PROBE_EXEMPT name non-GATED tool(s): "
+        f"{sorted(stale)}. Delete the entry, or restore the tool's gate."
+    )
+    assert (probed | exempt) == gated
+
+
+@pytest.mark.parametrize("tool", sorted(_PROBE_EXEMPT))
+def test_probe_exemptions_are_specific_to_their_tool(tool: str) -> None:
+    """An exemption reason names the tool it excuses and says something.
+
+    The only escape hatch out of layer (f) is a string, so the string has to
+    carry weight. Requiring it to mention the tool's own module leaf rules out
+    a reason copy-pasted from a sibling entry (the failure mode that turns two
+    exemptions into one unexamined one), and the length floor rules out
+    ``"n/a"`` and ``"TODO"``. Neither check can judge whether the reason is
+    *true* — that is a reviewer's job, and the reasons are written to be read
+    as claims about the tool's source.
+    """
+    reason = _PROBE_EXEMPT[tool]
+    module = TOOL_POSTURES[tool].gate_module
+    assert module is not None
+    leaf = module.rsplit(".", maxsplit=1)[-1]
+    assert leaf in reason, (
+        f"{tool}'s probe exemption never mentions {leaf!r}, the module it is "
+        f"excusing: {reason!r}. A reason that does not name the tool cannot "
+        "be checked against it."
+    )
+    assert len(reason) >= 60, (
+        f"{tool}'s probe exemption is too short to be a reason: {reason!r}. "
+        "State what specifically makes the tool unprobeable here."
+    )
+
+
+@pytest.mark.parametrize("tool", sorted(_RUNTIME_PROBES))
+def test_gated_tools_leak_no_above_ceiling_content_at_the_open_ceiling(
+    tool: str,
+    canary_vault: Path,
+) -> None:
+    """A ``GATED`` tool called at ``ceiling=open`` never returns intimate content.
+
+    The behavioural half of the manifest, and the only layer that can see a
+    *parallel* read path. Layers (a)-(e) verify that the declared gate exists
+    and is called; a leak added next to that call — a second
+    ``iter_vault_fragments`` walk whose output is spliced into the response —
+    leaves every one of them green.
+
+    Asserted against ``json.dumps(response, default=str)`` rather than against
+    named keys: the leak is just as real one level down, in a nested
+    ``seeds[].source_fragments`` entry or a debugging key nobody reviewed, and
+    a key-by-key check would only ever cover the shape that exists today.
+    ``default=str`` keeps a ``Path`` or an enum from turning a leak into a
+    ``TypeError``.
+
+    The response is checked for a ``tool`` echo as well, so a probe that
+    silently returned ``{}`` — from an exception swallowed somewhere, or a tool
+    that stopped reading the vault entirely — cannot pass this assertion by
+    having nothing in it. The per-tool tests below carry the stronger positive
+    controls.
+    """
+    response = _RUNTIME_PROBES[tool](canary_vault)
+    assert response["tool"] == tool
+    serialised = json.dumps(response, default=str)
+    entry = TOOL_POSTURES[tool]
+    assert _RUNTIME_INTIMATE_CANARY not in serialised, (
+        f"{tool} reached content above the caller's ceiling: the intimate "
+        f"canary {_RUNTIME_INTIMATE_CANARY!r} appears in its response at "
+        f"privacy_tier_ceiling=open.\n\n{serialised}\n\n"
+        f"Note what this does NOT mean: {entry.gate_module}.{entry.gate_symbol} "
+        "is still declared in TOOL_POSTURES and still called on the request "
+        "path — layers (c) and (e) are green. The leak is a *second*, ungated "
+        f"route to the corpus inside {entry.gate_module}. Find that route and "
+        "remove it; adding another gate call leaves the first one standing."
+    )
+
+
+def test_wheel_probe_still_counts_the_fragment_it_is_admitted_to(
+    canary_vault: Path,
+) -> None:
+    """``creek.wheel``'s probe is not passing by returning an empty wheel.
+
+    The fixture holds two ``F1`` fragments, one ``open`` and one ``intimate``.
+    At ``ceiling=open`` exactly one must be tallied: ``0`` would mean the
+    corpus walk never ran (and the leak assertion above would be vacuous),
+    ``2`` would mean the intimate fragment was counted — which is itself a leak,
+    a one-bit disclosure that a fragment exists at that frequency, even though
+    no body came back with it.
+
+    Wheel returns counts and never any fragment text, so the count *is* the
+    reachability evidence for the ``open`` canary; there is no string of it in
+    the response to assert on.
+    """
+    response = _probe_wheel(canary_vault)
+    assert response["status"] == "ok"
+    assert response["total_classified"] == 1
+    assert response["wheel"]["F1"]["count"] == 1
+
+
+def test_mine_probe_still_reaches_the_admitted_corpus(canary_vault: Path) -> None:
+    """``creek.mine``'s probe is not passing by returning zero seeds.
+
+    On this minimal fixture — no threads, no eddies, no liminal folder, no
+    synchronicities, and ``phase="unclassified"`` skipping the wavelength
+    strategy — the only strategy that fires is unexplored-ontology, whose seeds
+    are coordinates in classification space and carry no fragment-derived text.
+    So mine offers no *string* positive control here; the fragment-level one
+    lives on the wheel probe above.
+
+    What it does offer is a walk-level one, and it is exact:
+    ``mine_unexplored_ontology`` runs with ``require_corpus=True`` and returns
+    ``[]`` when the ceiling-filtered snapshot holds no fragments at all. A
+    non-zero ``total`` therefore proves the corpus walk ran *and* admitted the
+    ``open`` fragment. Had the tier filter been broken in the "drop everything"
+    direction — leak-free and useless — this assertion would fail.
+    """
+    response = _probe_mine(canary_vault)
+    assert response["status"] == "ok"
+    assert response["total"] > 0
+
+
+def test_reflect_probe_refuses_rather_than_merely_staying_quiet(
+    canary_vault: Path,
+) -> None:
+    """``creek.reflect`` *refuses* the above-ceiling ``entry_ref`` (#846).
+
+    Absence of the canary is necessary but not sufficient here. Reflect could
+    resolve the intimate fragment, hand it to the model, and answer
+    ``status="ok"`` with zero verbatim-validated notes — a canary-free response
+    that has already egressed the entry. The gate's contract is a refusal, so
+    the refusal is what is asserted.
+
+    The reason is pinned too, not just the status: reflect's other refusal is
+    ``"entry_ref not found"``, and a change that stopped resolving the fragment
+    would satisfy a bare ``status == "refused"`` while telling us nothing about
+    the ceiling.
+    """
+    response = _probe_reflect(canary_vault)
+    assert response["status"] == "refused"
+    assert response["reason"] == _REFLECT_ABOVE_CEILING_REASON
+    assert response["tier_ceiling"] == TierCeiling.OPEN.value
+
+
+def test_compile_probe_refuses_rather_than_merely_staying_quiet(
+    canary_vault: Path,
+) -> None:
+    """``creek.compile`` *refuses* the above-ceiling source fragment (#848).
+
+    Same argument as reflect's probe, with a sharper edge: compile's leak is
+    not primarily its response but the page it writes. A tool that compiled the
+    intimate fragment into ``02-Threads`` and returned only a path would be
+    canary-free in the envelope and have laundered intimate content into an
+    artifact every ``open``-ceiling read tool then serves.
+
+    Pinned against the module's own ``_ABOVE_CEILING_REASON`` rather than a
+    literal, because compile's other refusals (unknown ``target_kind``, empty
+    ``fragment_ids``, the engine's not-found ``ValueError``) are also
+    ``status="refused"`` and none of them would mean the gate fired.
+    """
+    response = _probe_compile(canary_vault)
+    assert response["status"] == "refused"
+    assert response["reason"] == _ABOVE_CEILING_REASON
+    assert response["tier_ceiling"] == TierCeiling.OPEN.value


### PR DESCRIPTION
## Summary

Issue #932 asked for a sweep: audit every MCP tool that reads vault fragments the caller did **not** supply inline, confirm each checks the resolved tier against `privacy_tier_ceiling`, and — the part that actually pays — build a guardrail so the next such tool fails the suite until it is triaged.

**The audit record is now code.** `creek_mcp/read_gate.py` carries `TOOL_POSTURES`: one entry per registered MCP tool, each naming its gate or justifying why the ceiling cannot be reached. `tests/test_mcp_read_gate.py` verifies it in six layers, so the manifest cannot lie.

Five gaps were found and **filed, not fixed inline** (per the issue author's own instruction): #968, #969, #970, #971, #972.

### The tool-by-tool table

The surface was enumerated from `build_server()` at runtime via `await server.list_tools()` — 23 tools — not from the issue's candidate list, which was incomplete (it omitted `classify`, `state.render`, `skills.refresh`, `redact.scan`, `handshake`, and the five `purge.*`).

| Tool | Reads unsupplied vault content? | Gate / why not reachable | Verdict |
|---|---|---|---|
| `creek.reflect` | yes (`entry_ref`) | `_above_ceiling`, ordered above the care seam | done (#846) |
| `creek.compile` | yes (`fragment_ids`) | `_survey_sources` + `write_tier_allowed` | done (#848) |
| `creek.wheel` | yes | `to_privacy_override` → `tier_within_override` | gated |
| `creek.mine` | yes | override → `IdeaMiner` → `filter_fragments_by_tier` | gated |
| `creek.draft` | yes | same override → `IdeaMiner` **and** `DraftGenerator` | gated |
| `creek.author` | yes | override → `run_author`/`plan_author` (#660) | gated |
| `creek.report` | **yes** | **none** — ceiling audited and echoed, never converted | **gap → #968** |
| `creek.state.read` | **yes** (cached artifact) | **none**, and the docstring asserted one | **gap → #969** |
| `creek.state.render` | **yes** | **none**; generator takes no override | **gap → #969** |
| `creek.skills.refresh` | yes | partial: intimate excluded by generator hardcode; ceiling never threaded | **gap → #971** |
| `creek.redact.scan` | **yes** (caller-named, unconfined) | path confined to the *whole vault*, tier never consulted | **gap → #972** |
| `creek.journal` | read: no | write: update-in-place ignores the existing fragment's tier | **gap → #970** |
| `creek.lint` | yes — **frontmatter only** | response returns only name + count-shaped summary + `len(findings)`; titles live in `findings`, never returned | metadata-only |
| `creek.link`, `creek.classify` | yes | counts only; no new tiered content | metadata-only |
| `creek.handshake` | no | tool names + versions | n/a |
| `creek.save`, `creek.ingest` | no | caller's content; `write_tier_allowed` gates the created tier | write gate |
| `creek.purge.*` (5) | no | no ceiling param by design; `CREEK_MCP_ELEVATED_TOKEN` | auth-token |

### What the sweep actually found

Most of the remaining exposure is **write-side** — a tool *acts on* content above the caller's ceiling rather than handing it back. That shape is invisible to `docs/mcp.md`'s ceiling language, which is written entirely in read-back terms ("omitted", "returned as a title-only stub"). That is why these survived.

Reproduced, not inferred:
- `creek.report(report_type="tags")` at `ceiling=open` wrote an **intimate** fragment's tag verbatim into `00-Creek-Meta/Tag-Garden.md` and `Processing-Log/tag-history.json`. Four of six report generators contain zero tier filtering.
- `creek.journal` at `ceiling=open` **destroyed the body** of a fragment persisted at `privacy_tier: intimate`. The tier itself was not downgraded (the escalate-only merge held) — the content was.
- `creek.redact.scan` at `ceiling=open`, aimed at `01-Fragments`, returned `01-Fragments/Notes/my-affair-with-dana.md`. Creek filenames are slugified titles.

### Two corrections to the brief I was given

1. **#932's "prior art" section names `_sources_above_ceiling`. No such symbol exists** — `compile.py` defines `_survey_sources`, which returns a `_SourceGate` the caller branches on. Its docstring explains it is *deliberately* not named as a predicate, so renaming it would reintroduce the bug that comment prevents. Pinned to the real name.
2. **This PR overturns its own conclusion.** It initially concluded no unaudited tool leaks above-ceiling content into an MCP *response*, having probed the tools that walk the corpus themselves. `creek.redact.scan` was set aside as "the caller named the path" — true, and not sufficient. Gate-2.5 review caught it; `docs/mcp.md` no longer makes the claim.

### Proof the guardrail is not vacuous

Six mutations injected, each run, each reverted. Working tree verified clean after every one.

| # | Mutation | Result |
|---|---|---|
| 1 | Added `@server.tool(name="creek.dummy")` reading a fragment by id and returning its body, no tier check | **2 fail** (a) |
| 2 | Pointed reflect's `gate_symbol` at a nonexistent name | **3 fail** (c) |
| 3 | Kept the symbol, removed the `if _above_ceiling(...)` call site | **1 fail** (c) |
| 4 | Removed `gap_issue=968` | **2 fail** (d) |
| 5 | **wheel keeps its gate call and adds a parallel ungated read** | **1 fail** (f) |
| 6 | **call-and-discard**: bare `_above_ceiling(t, c)`, fall through | **3 fail** (c)+(f) |

Mutations 5 and 6 are the ones that matter. Before this PR's final commit, **both passed all 101 tests — and mutation 5 also passed `tests/test_mcp_wheel.py`.** Structural checks prove a gate is declared, exists, and is invoked; they cannot prove it is the *only* path to the corpus, and they cannot tell a decision from a gesture. Layer (f) (runtime canary probe, manifest-driven coverage) and the `_calls_symbol` load-bearing-value check close those. `creek.draft` and `creek.author` are probe-exempt with written reasons, which is why the (c) fix matters independently — mutation 6 was verified against `creek.author` specifically.

### Deliberately not done

- No behaviour change to any tool. Every non-test edit outside `read_gate.py` is inside a docstring or markdown.
- `reflect` and `compile` are **not** retrofitted onto the new primitives. Their refusal reasons and ordering are tool-specific and load-bearing — reflect's ACCEPTED RESIDUAL RISK block documents why its reason must stay distinct from `entry_ref not found`, including a timing-equalisation caveat that would have to be handled if they were ever unified. Recorded in the module docstring as a decision.
- Not re-filed: #958, #962, #931, #964, #961, #928, #923.
- Not filed: `creek.link` writing cross-tier wikilinks (core-pipeline, adjacent to #931); `Eddy`/`Thread` having no `privacy_tier` (folded into #969, since it is the same fix).

### Docstrings corrected against their tracking issues, not softened

Four asserted ceiling behaviour the code does not implement — the literal #846/#848 signature:
- `state_read.py`: *"the tier-ceiling enforcement here is the gate"* — there is none (#969).
- `skills.py`: *"safe at any ceiling"* — intimate is excluded by a generator hardcode; personal bodies pass unsummarised (#971).
- `lint.py`: *"reads only compiled-layer metadata"* — `paradox`/`unnamed`/`orphan-compiled` read `01-Fragments`. **No issue filed**: the conclusion holds for a better reason, independently verified against all 13 `CheckResult` constructions.
- `report.py` and `journal.py` said nothing at all, which is how their gaps survived.

Also filed a note on #969 that `tests/test_mcp_tools.py:116::test_state_read_does_not_embed_fragment_bodies` is **vacuous** — it hand-writes `latest.md` as a fixed 3-line string, so its assertion is true by construction with or without a gate. A test asserting the ceiling property, beside a docstring asserting it, over code implementing neither.

## Test plan

- `./scripts/check-all.sh` → **12/12 passed**, 6521 tests, 93.99% branch coverage, `read_gate.py` 90.38% per-file. Run with credentials stripped.
- `tests/test_mcp_read_gate.py` → 116 passed (Gate 1 RED confirmed first: `ModuleNotFoundError: No module named 'creek_mcp.read_gate'`).
- Test integrity: `git diff --numstat origin/main -- creek-tools/tests/` → `1476 0` — one new file, **zero deletions, no existing test touched**. One post-RED rewrite by the test specialist was diffed and accepted: it removed no assertion and *added* one (`assert as_intimate is None`, making an equality comparison non-vacuous).

Closes #932
