### PR TITLE
fix(classify): run AudienceClassifier in creek process (#937)

### DIFF
--- a/creek-tools/creek/pipeline.py
+++ b/creek-tools/creek/pipeline.py
@@ -37,6 +37,7 @@ from creek.audit.yield_summary import (
     format_yield_line,
     write_yield_summary,
 )
+from creek.classify.audience import AudienceClassifier
 from creek.classify.classify_engine import build_tier_classifiers
 from creek.classify.praxis_pass import apply_praxis
 from creek.classify.privacy import PrivacyClassifier
@@ -223,6 +224,9 @@ class Pipeline:
         rule_classifier: Keyword-based classifier.
         privacy_classifier: Assigns each fragment's privacy tier before the
             per-tier router reads it (#876).
+        audience_classifier: Stamps the #634 audience axis on every fragment
+            this pipeline classifies (#937), because the classify engine is
+            not the only writer of that axis.
         tier_classifiers: Per-tier LLM classifiers (#666/#706) — the fragment's
             privacy tier selects the provider so Intimate stays local.
         review_generator: Review queue generator for uncertain fragments.
@@ -260,6 +264,12 @@ class Pipeline:
         # so without this the per-tier router below saw "not INTIMATE" for
         # every fragment and shipped journal entries to the cloud.
         self.privacy_classifier = PrivacyClassifier()
+        # Issue #937: the classify engine is not the only writer of the #634
+        # audience axis, and ``creek process`` never calls it — so this entry
+        # point needs its own instance or every fragment it ingests keeps the
+        # model default. Built bare, exactly as the engine builds it: the rules
+        # path needs no provider, which keeps ``process --no-llm`` egress-free.
+        self.audience_classifier = AudienceClassifier()
         # Per-tier routing (#666/#706): each fragment is classified by the
         # provider its privacy tier resolves to — Intimate stays local even when
         # ``classification`` is cloud. Building here is safe with any config:
@@ -525,6 +535,15 @@ class Pipeline:
         router reads that tier to keep Intimate content off cloud
         providers and a freshly-ingested fragment carries none.
 
+        Every fragment is also stamped with the #634 audience axis once the
+        tier is known (#937). ``creek process`` never calls the classify
+        engine, so without this every one-shot-processed fragment keeps
+        ``audience: mixed`` — which the voice fingerprint reads as neutral
+        (``_audience_factor``), so the user's audience-facing writing never
+        earns its weight and their private writing is never discounted. The
+        pass runs after the tier because the score reads it, and it is
+        deterministic and idempotent, so re-processing never churns the axis.
+
         Every fragment is likewise scored for praxis potential once the
         classifiers are done (#877). ``creek process`` never calls the
         classify engine, so without this the one-shot command would leave
@@ -571,6 +590,13 @@ class Pipeline:
                     frag = classifier.classify(frag, content=item.body)
             else:
                 result.deterministic_classified += 1
+            # Issue #937: stamp the #634 audience axis here, after ``apply_tier``
+            # above — the score reads ``privacy_tier``, and a fragment still
+            # ``unclassified`` contributes nothing, so an earlier call would
+            # return a different verdict than ``creek classify`` does. This
+            # placement mirrors the engine's (classify -> audience -> praxis)
+            # so the two entry points agree fragment for fragment.
+            frag = self.audience_classifier.classify_and_enforce(frag, item.body)
             # Issue #877: score the praxis axis last, so the escalate-only
             # merge sees whatever the optional LLM dispatch above produced.
             frag = apply_praxis(frag, item.body)

--- a/creek-tools/tests/test_pipeline.py
+++ b/creek-tools/tests/test_pipeline.py
@@ -1375,3 +1375,168 @@ class TestPipelinePraxisPass:
         # The rest of the same response *did* land, so the assertion above
         # cannot be passing because the LLM was never consulted.
         assert on_disk["frag-praxispipe04"]["frequency"]["primary"] == "F3"
+
+
+class TestPipelineAudiencePass:
+    """``creek process`` stamps the ``audience`` axis too (issue #937).
+
+    The #634 audience classifier reached production wired into
+    :mod:`creek.classify.classify_engine` alone. ``creek process`` never
+    calls that engine — it ingests and classifies in one shot — so every
+    fragment that entered a vault through the one-shot command kept the
+    :class:`~creek.models.Fragment` model default ``audience: mixed``,
+    which on disk is indistinguishable from a fragment the classifier
+    genuinely weighed and found ambiguous.
+
+    That default is not inert. The voice fingerprint reads the persisted
+    axis in
+    :func:`creek.generate.ai_style.fingerprint._audience_factor`, which
+    multiplies audience-facing material by ``2.0`` and private material
+    by ``0.1``. ``mixed`` is neither, so a process-built vault weighs a
+    published essay and a 3 a.m. journal entry at exactly the same
+    authority: the fingerprint learns the average instead of the voice.
+    Nothing raises and nothing is logged, which is how this same
+    wired-into-one-caller defect got through twice before — #876 (privacy
+    tiers) and #877 (praxis potential).
+    """
+
+    @staticmethod
+    def _ingested(
+        frag_id: str,
+        title: str,
+        body: str,
+        platform: str,
+        kind: str = "unclassified",
+    ):
+        """An IngestedFragment whose metadata drives the audience score.
+
+        Args:
+            frag_id: Fragment id (the assertion key).
+            title: Fragment title.
+            body: Markdown body the audience heuristic scans for
+                headings, block quotations and word count.
+            platform: ``SourcePlatform`` value — the heaviest audience
+                signal (essay/Substack positive, journal negative).
+            kind: ``SourceKind`` value; ``writing`` is a further
+                audience-facing vote. Defaults to ``unclassified``.
+
+        Returns:
+            The assembled :class:`~creek.ingest.base.IngestedFragment`.
+        """
+        from creek.ingest.base import IngestedFragment
+        from creek.models import (
+            Authorship,
+            Fragment,
+            FragmentSource,
+            SourceKind,
+            SourcePlatform,
+        )
+
+        fragment = Fragment(
+            id=frag_id,
+            title=title,
+            source=FragmentSource(
+                platform=SourcePlatform(platform),
+                author=Authorship.SELF,
+                kind=SourceKind(kind),
+            ),
+        )
+        return IngestedFragment(fragment=fragment, body=body)
+
+    def test_no_llm_run_stamps_the_audience_axis(self, vault_path: Path) -> None:
+        """A published essay and a private blip land on opposite axes.
+
+        ``no_llm=True`` guarantees Pass 3 never runs, so the verdict
+        provably comes from the free, local, deterministic heuristic in
+        :class:`creek.classify.audience.AudienceClassifier` with zero
+        egress — the point of #634 being a rules axis with an *optional*
+        LLM seam rather than one more mandatory model call.
+
+        Two fragments with two *distinct* expected outcomes, so an
+        implementation that stamps a single value over everything cannot
+        pass. The expected values follow the classifier's own published
+        weights: the essay sums platform ``+5``, ``kind: writing`` ``+3``,
+        tier ``open`` ``+1`` and heading/blockquote/long-form ``+3`` to
+        ``+12`` (``>= 3`` → ``audience-facing``); the short journal entry
+        sums platform ``-3``, tier ``intimate`` ``-3`` and the
+        under-40-word penalty ``-2`` to ``-8`` (``<= -2`` → ``private``).
+        """
+        pipeline = Pipeline(config=CreekConfig(), no_llm=True)
+
+        classified = pipeline._run_classification(
+            [
+                self._ingested(
+                    "frag-audiencepipe01",
+                    "On equanimity",
+                    "# On equanimity\n\n> The wound is where the light enters.\n\n"
+                    + "Each paragraph turns the same stone to a new face. " * 60,
+                    "essay",
+                    kind="writing",
+                ),
+                self._ingested(
+                    "frag-audiencepipe02",
+                    "Tuesday",
+                    "felt wrung out today. couldn't say why. went to bed early.",
+                    "journal",
+                ),
+            ],
+            vault_path,
+            PipelineResult(),
+        )
+
+        assert {
+            item.fragment.id: str(item.fragment.audience) for item in classified
+        } == {
+            "frag-audiencepipe01": "audience-facing",
+            "frag-audiencepipe02": "private",
+        }
+
+    def test_audience_is_scored_after_the_privacy_tier_is_stamped(
+        self, vault_path: Path
+    ) -> None:
+        """The audience pass must sit after ``apply_tier``, not before it.
+
+        :meth:`creek.classify.audience.AudienceClassifier.score` reads
+        ``fragment.privacy_tier`` (``creek/classify/audience.py:160``,
+        ``_PRIVACY_SCORE``) and a freshly-ingested fragment carries none,
+        so where the call lands inside ``_run_classification`` is
+        load-bearing — exactly as it is for the #876 tier-before-router
+        pin above. ``apply_tier`` runs at ``creek/pipeline.py:579``.
+
+        This fixture is engineered so the two orderings disagree. With
+        the tier stamped first the entry is ``intimate``, so the score is
+        journal ``-3``, privacy ``-3``, structure ``+3`` (heading,
+        blockquote, >= 300 words) = ``-3``, which is ``<= -2`` →
+        ``private``. Hoist the audience call above ``apply_tier`` and the
+        tier is still ``unclassified``, contributing ``0``: the score is
+        ``0``, which clears neither threshold → ``mixed``, and this test
+        fails. That is the whole reason it exists — a later refactor that
+        reorders the two passes cannot land silently.
+        """
+        paragraph = (
+            "I keep circling the same question about how the work fits the "
+            "life and the life fits the work, and every pass over it turns "
+            "up one more thing I had not noticed the time before. "
+        )
+        body = (
+            "# The long way round\n\n"
+            "> Not all those who wander are lost.\n\n"
+            + paragraph * 20
+            + "\n\n- [ ] write this up properly\n\nI will come back to it.\n"
+        )
+        pipeline = Pipeline(config=CreekConfig(), no_llm=True)
+
+        classified = pipeline._run_classification(
+            [
+                self._ingested(
+                    "frag-audiencepipe03",
+                    "The long way round",
+                    body,
+                    "journal",
+                ),
+            ],
+            vault_path,
+            PipelineResult(),
+        )
+
+        assert str(classified[0].fragment.audience) == "private"

--- a/creek-tools/tests/test_process_classify_parity.py
+++ b/creek-tools/tests/test_process_classify_parity.py
@@ -1,0 +1,255 @@
+"""``creek process`` and ``creek classify`` must agree on every axis.
+
+Creek has two ways to get a classified fragment into a vault:
+``creek process`` (ingest + classify in one shot, via
+:class:`creek.pipeline.Pipeline`) and ``creek classify`` (classify what
+is already on disk, via :func:`creek.classify.classify_engine.run_classify`).
+They share the individual classifiers but **not** the code that calls
+them, so a new axis wired into only one of the two orchestrators leaves
+the other silently stamping the model default. That has now happened
+three times: #876 (``privacy_tier``), #877 (``praxis_potential``) and
+#937 (``audience``). This module is the *class* detector for that
+defect — it fails automatically on a fourth instance, without anyone
+remembering to extend a list of axes.
+
+**The invariant.** "Byte-identical frontmatter" is what one would like
+to say, and it is false as literally worded: ``run_classify`` adds
+``classification_method`` and ``classified_at``, which are not
+:class:`~creek.models.Fragment` model fields at all (see
+``_write_fragment``, ``creek/classify/classify_engine.py:1564-1583``),
+and YAML key ordering plus timestamp round-tripping make a bytes
+comparison meaningless anyway. The true, stronger, testable contract is:
+
+    For a vault written by ``creek process`` with ``no_llm=True`` from
+    freshly-ingested, untiered fragments, a subsequent ``creek classify
+    --method rules --force`` changes **no ``Fragment`` model field**. The
+    only frontmatter delta is the *addition* of ``classification_method``
+    and ``classified_at``.
+
+**Preconditions**, each of which the test establishes deliberately:
+
+1. ``no_llm=True`` on the process side and ``--method rules`` on the
+   classify side. With ``--force``, a rules re-run would legitimately
+   overwrite LLM-derived ``frequency`` / ``wavelength`` / ``voice``, so
+   the invariant is scoped to the deterministic path where both
+   orchestrators are supposed to compute the same answer from the same
+   inputs. An LLM-vs-rules disagreement is not this defect class.
+2. Fragments enter **untiered**. An ingester-supplied ``privacy_tier``
+   lower than the heuristic's would be escalated by ``--force``, and the
+   resulting delta would be correct behaviour rather than a wiring hole.
+3. Compare *parsed metadata*, not bytes — see above.
+
+The comparison is over the whole parsed frontmatter dict minus a small
+documented exclusion set, never a hand-enumerated list of axes. That is
+what makes the next unwired axis fail here on its own.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import frontmatter
+import pytest
+
+from creek.classify.classify_engine import run_classify
+from creek.config import CreekConfig
+from creek.ingest.base import IngestedFragment
+from creek.models import (
+    Authorship,
+    Fragment,
+    FragmentSource,
+    PraxisPotential,
+    PrivacyTier,
+    SourcePlatform,
+)
+from creek.pipeline import Pipeline, PipelineResult
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Vault folders the pipeline and the classify engine both expect to exist.
+VAULT_DIRS: list[str] = [
+    "00-Creek-Meta/Processing-Log",
+    "01-Fragments/Journal",
+    "01-Fragments/Notes",
+    "01-Fragments/Unsorted",
+]
+
+_CLASSIFY_ONLY_KEYS = frozenset({"classification_method", "classified_at"})
+"""The only non-``Fragment`` keys a rules classify run adds to frontmatter.
+
+``_write_fragment`` (``creek/classify/classify_engine.py:1564-1583``)
+starts from the raw on-disk mapping, overlays ``fragment.model_dump()``,
+then stamps exactly these two provenance keys. The two sibling
+provenance keys are *not* additions on this path: ``classification_provider``
+and ``classification_reasoning`` are explicitly popped for anything other
+than an ``llm`` write with a provider and a non-empty trace
+(``classify_engine.py:1572-1579``). Everything else in the mapping comes
+from the ``Fragment`` model, which is precisely what must not move.
+"""
+
+_RICH_PARAGRAPH = (
+    "I keep circling the same question about how the work fits the "
+    "life and the life fits the work, and every pass over it turns "
+    "up one more thing I had not noticed the time before. "
+)
+
+_RICH_BODY = (
+    "# The long way round\n\n"
+    "> Not all those who wander are lost.\n\n"
+    + _RICH_PARAGRAPH * 20
+    + "\n\n- [ ] write this up properly\n\nI will come back to it.\n"
+)
+"""A body that drives every deterministic axis off its model default.
+
+Self-authored journal prose: the privacy heuristic reads ``intimate``,
+the task checkbox makes the praxis pass read ``explicit``, and the
+audience heuristic sums journal ``-3`` + intimate ``-3`` + structure
+``+3`` (heading, blockquote, >= 300 words) to ``-3`` → ``private``.
+"""
+
+_NEUTRAL_BODY = "a plain note about the walk to the shops and the weather " * 6
+"""A body that leaves the axes near their defaults (tier ``personal``,
+audience ``mixed``), so the parity check covers the boring case too."""
+
+
+@pytest.fixture()
+def vault_path(tmp_path: Path) -> Path:
+    """Create a minimal Obsidian vault structure under tmp_path.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+
+    Returns:
+        The vault root, with the folders both orchestrators require.
+    """
+    vault = tmp_path / "vault"
+    for directory in VAULT_DIRS:
+        (vault / directory).mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _ingested(frag_id: str, title: str, body: str, platform: str) -> IngestedFragment:
+    """Build a freshly-ingested, untiered fragment bundle.
+
+    Carries no ``privacy_tier``, ``praxis_potential`` or ``audience`` of
+    its own — every axis is left at the model default so the process run
+    is the thing that assigns them (precondition 2 in the module
+    docstring).
+
+    Args:
+        frag_id: Fragment id; the key both snapshots are compared on.
+        title: Fragment title.
+        body: Markdown body the deterministic classifiers score.
+        platform: ``SourcePlatform`` value for the fragment's source.
+
+    Returns:
+        The assembled :class:`~creek.ingest.base.IngestedFragment`.
+    """
+    fragment = Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(
+            platform=SourcePlatform(platform),
+            author=Authorship.SELF,
+        ),
+    )
+    return IngestedFragment(fragment=fragment, body=body)
+
+
+def _snapshot(vault: Path) -> dict[str, dict[str, object]]:
+    """Return every fragment's parsed frontmatter, keyed by fragment id.
+
+    Keyed by ``id`` rather than by path or iteration order: ``rglob`` is
+    unsorted, and ``creek classify`` is free to rewrite a file in place
+    under a name this test must not depend on. The walk itself is sorted
+    for a deterministic failure ordering.
+
+    Args:
+        vault: Vault root to snapshot.
+
+    Returns:
+        Mapping of fragment id to a copy of its frontmatter mapping.
+    """
+    return {
+        str(post.metadata["id"]): dict(post.metadata)
+        for post in (
+            frontmatter.load(str(path))
+            for path in sorted((vault / "01-Fragments").rglob("*.md"))
+        )
+    }
+
+
+def test_rules_classify_after_process_changes_no_fragment_field(
+    vault_path: Path,
+) -> None:
+    """A rules re-classify of a processed vault moves no model field.
+
+    This is the #876 / #877 / #937 defect class expressed as one
+    assertion pair. Half one pins that every shared key is unchanged;
+    half two pins that the only *new* keys are the two provenance stamps
+    in :data:`_CLASSIFY_ONLY_KEYS`. Neither half names an axis, so an
+    axis wired into ``run_classify`` but not into
+    :meth:`creek.pipeline.Pipeline._run_classification` fails here
+    without any test being updated.
+
+    ``result.errors == []`` and the classify summary's own counts are
+    asserted first: a silent vault-write failure, or a classify run that
+    matched zero files, would otherwise make the parity comparison pass
+    over an empty or half-written vault.
+
+    The off-default guard on the rich fixture is the other anti-vacuity
+    check. If a future edit blunted that body into something the
+    heuristics leave at ``unclassified`` / ``none`` / ``mixed``, both
+    snapshots would agree at the defaults and the parity assertion would
+    be testing nothing. On today's RED run this guard is the first thing
+    to fail, because ``creek process`` never stamps ``audience`` — which
+    is the bug.
+    """
+    items = [
+        _ingested("frag-parityrich01", "The long way round", _RICH_BODY, "journal"),
+        _ingested("frag-parityneut01", "Walking notes", _NEUTRAL_BODY, "markdown"),
+    ]
+    pipeline = Pipeline(config=CreekConfig(), no_llm=True)
+    result = PipelineResult()
+
+    classified = pipeline._run_classification(items, vault_path, result)
+    pipeline._write_to_vault(classified, vault_path, result)
+
+    assert result.errors == []
+
+    before = _snapshot(vault_path)
+    assert set(before) == {"frag-parityrich01", "frag-parityneut01"}
+
+    rich = before["frag-parityrich01"]
+    assert (
+        rich["privacy_tier"],
+        rich["praxis_potential"],
+        rich["audience"],
+    ) == (
+        PrivacyTier.INTIMATE.value,
+        PraxisPotential.EXPLICIT.value,
+        "private",
+    )
+
+    summary = run_classify(
+        vault_path=vault_path,
+        config=CreekConfig(),
+        method="rules",
+        force=True,
+    )
+
+    assert summary.errors == ()
+    assert summary.total == len(items)
+
+    after = _snapshot(vault_path)
+    assert set(after) == set(before)
+
+    for frag_id, before_meta in before.items():
+        after_meta = after[frag_id]
+        assert {
+            key: value
+            for key, value in after_meta.items()
+            if key not in _CLASSIFY_ONLY_KEYS
+        } == before_meta
+        assert set(after_meta) - set(before_meta) == _CLASSIFY_ONLY_KEYS


### PR DESCRIPTION
## Summary

`AudienceClassifier` (the #634 audience axis) was wired into `creek/classify/classify_engine.py` but had **zero** references in `creek/pipeline.py`. So `creek classify` stamped the axis and `creek process` silently left every fragment at the `Fragment` model default `audience: mixed` — which on disk is indistinguishable from a fragment the classifier genuinely weighed and found ambiguous. Which command the user happened to run decided whether the field was populated at all.

That default is not inert. `_default_audience_authority` (`creek/config.py:1432`) weights `audience-facing` at **2.0** and `private` at **0.1**; `mixed` is **1.0**, neither. So a process-built vault weighs a published essay and a 3 a.m. journal entry at identical authority, and the voice fingerprint learns the average instead of the voice — silently, with nothing raised and nothing logged.

Third instance of one defect class, after #876 (`PrivacyClassifier`) and #877 (`praxis_potential`). Unlike both predecessors it needed no new policy module: `AudienceClassifier.classify_and_enforce` already existed and was proven in the engine, so this is a **missing call, not a missing producer**.

`creek/pipeline.py`, +26/−0:
- `AudienceClassifier()` built once in `Pipeline.__init__`, bare — exactly as `classify_engine.py:439` builds it. No `llm_assist`, so the rules path needs no provider and `process --no-llm` stays egress-free.
- One unconditional `frag = self.audience_classifier.classify_and_enforce(frag, item.body)` in `_run_classification`, after `apply_tier` and the maybe-LLM dispatch, before `apply_praxis` — mirroring the engine's `_classify_one` → audience → `apply_praxis` order.

Ordering is load-bearing and is pinned by a test: `AudienceClassifier.score` reads `fragment.privacy_tier` (`creek/classify/audience.py:160`), so hoisting the call above `apply_tier` would score every fresh fragment against `unclassified` and return different verdicts than `creek classify` does.

## The invariant question — settled, with evidence

The issue asked whether `creek process` and `creek classify` should produce **byte-identical frontmatter**. **As literally worded, no** — and I would rather pin the true contract than assert one that isn't true:

- `run_classify` adds `classification_method` and `classified_at`, which are not `Fragment` model fields at all (`_write_fragment`, `classify_engine.py:1564-1583`).
- YAML key ordering and timestamp round-tripping make a bytes comparison meaningless regardless.

The true, stronger, testable contract — and the one this PR asserts:

> For a vault written by `creek process --no-llm` from freshly-ingested, untiered fragments, a subsequent `creek classify --method rules --force` changes **no `Fragment` model field**. The only frontmatter delta is the *addition* of `classification_method` and `classified_at`.

I measured this both ways with a guard-free probe over three fragments (essay / journal / markdown):

- On `origin/main` @ f72dfa7 the complete delta was `audience` on all three (`mixed` → `audience-facing` / `private` / `private`), plus the two provenance keys. **Nothing else moved** — `privacy_tier`, `praxis_potential`, `frequency`, `wavelength`, `voice`, `voice_proxy_eligible` were already identical. The invariant already held for #876 and #877; `audience` was the last hole.
- With this fix the delta is **exactly** the two provenance keys.

`tests/test_process_classify_parity.py` pins it. The comparison is over the **whole parsed frontmatter dict minus a documented two-key exclusion set** — it names no axis — so a *fourth* classifier wired into one entry point and not the other fails this test automatically, without anyone remembering to extend a list. That is the point of the issue, and it is why this PR is larger than the two-line fix it could have been.

Preconditions are established deliberately in the test and documented in its module docstring: `no_llm=True` + `--method rules` (with `--force`, a rules re-run would legitimately overwrite LLM-derived `frequency`/`wavelength`/`voice` — an LLM-vs-rules disagreement is not this defect class); fragments enter untiered; parsed metadata, not bytes.

## The third call site — checked, and it needs nothing

#876 touched `cli.py`, `pipeline.py` and `creek_mcp/tools/classify.py`, so I checked the MCP surface rather than silently fixing two of three:

- `creek_mcp/tools/classify.py` **wires no classifier**. It calls `run_classify`, which already stamps audience, so it is correct by delegation. Its #876/#877 changes only surfaced *counts* (`privacy_tiers_assigned`, `praxis_marked`). I deliberately added no `audience_marked` count: unlike those two, audience is stamped unconditionally on every (re)classified fragment rather than escalate-only, so the count would always equal `classified` and carry no information.
- No MCP tool wraps `Pipeline` — there is exactly one construction site, `creek/cli.py:1152` (the `process` command).
- `creek/vault/writer.py::_retier_after_rewrite` (#922) re-derives only `privacy_tier` on a material edit; a stale `audience` there awaits the next classify pass exactly as a stale `frequency` does. Pre-existing uniform posture, not a #937 hole.

## Follow-up filed: #974

While verifying the invariant I found a genuine **fourth** instance of this defect class, and reproduced it:

`creek/pipeline.py` never calls `privacy_pass.reassess`, which the engine runs at `classify_engine.py:919-920`. A self-authored fragment the model reads as confessional + conviction ends:

- via `creek classify --method llm` → `privacy_tier: intimate`, `voice_proxy_eligible: false`
- via `creek process` → `privacy_tier: personal`, `voice_proxy_eligible: **true**`

So intimate content ingested through the one-shot command stays voice-proxy eligible and admissible to a PERSONAL-ceiling MCP caller. That is security-adjacent and deliberately **not** fixed here for scope discipline — filed as **#974** with the reproduction.

## Test plan

- `./scripts/check-all.sh` → **exit 0**, 12/12 checks, **6524 passed**, **93.99%** branch coverage, per-file gate green (218 files ≥ 80%).
- `./scripts/test.sh --all` (integration + e2e) → **6549 passed, 5 skipped** (all env-gated: no Ollama, no API keys). **Zero fixture fallout** — no existing test needed changing, unlike #876.
- Gate 1 RED proven before the fix, with the exact failures:
  - `test_no_llm_run_stamps_the_audience_axis` — `{'…pipe01': 'mixed', '…pipe02': 'mixed'}` != `{'…pipe01': 'audience-facing', '…pipe02': 'private'}`
  - `test_audience_is_scored_after_the_privacy_tier_is_stamped` — `assert 'mixed' == 'private'`
  - `test_rules_classify_after_process_changes_no_fragment_field` — `('intimate', 'explicit', 'mixed')` != `('intimate', 'explicit', 'private')`
- Test integrity: `git diff --numstat origin/main -- tests/` = **165/0 and 255/0 — zero deletions**. No existing test was modified, reformatted or removed; `tests/test_pipeline.py` is a pure append.
- Regressions explicitly re-run green: `TestPipelineTierRouting::test_untiered_journal_fragment_routes_local_and_gets_a_tier` (#876 tier→router ordering), `TestPipelinePraxisPass` (#877 escalate-only chokepoint), all of `tests/test_classify_engine.py` and `tests/test_audience.py`.
- Complexity unchanged: `_run_classification` stays **B (6)**; the new statement is unconditional.
- No bypasses: no `# noqa`, no `# type: ignore`, no skip marker, no threshold change, no deleted test or code.

New tests:
- `tests/test_pipeline.py::TestPipelineAudiencePass` — a two-outcome stamping test (essay → `audience-facing`, short journal → `private`, so a stamp-everything implementation cannot pass) and an ordering pin whose fixture returns `private` only when the tier is stamped first, and `mixed` if the call is hoisted.
- `tests/test_process_classify_parity.py` — the cross-entry-point invariant above.

Closes #937
Refs #634, #876, #877, #974
