### PR TITLE
fix(compost): make CompostTracker timezone-safe on both comparison sides

### DIFF
--- a/creek-tools/creek/generate/compost.py
+++ b/creek-tools/creek/generate/compost.py
@@ -19,7 +19,7 @@ import logging
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
 
 import frontmatter
@@ -33,7 +33,7 @@ from creek.models import (
     Thread,
     ThreadStatus,
 )
-from creek.time import effective_authored_at
+from creek.time import effective_authored_at, ensure_aware, now_la
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -178,8 +178,14 @@ class CompostTracker:
             project_min_fragments: Minimum fragment count for a project
                 (tag) to be tracked. Defaults to 2.
             now: Reference "now" for age calculations. Defaults to
-                :func:`datetime.now` (timezone-naive). Useful for
-                deterministic tests.
+                :func:`creek.time.now_la` — tz-aware, America/Los_Angeles
+                — so the dates stamped on compost notes and the overview
+                report follow the same calendar as the rest of the vault
+                (issue #938; a UTC-derived clock ran a day ahead of LA
+                for the last several hours of every LA day). A naive
+                value passed here is still accepted and read as an LA
+                wall-clock reading, keeping existing callers working.
+                Useful for deterministic tests.
             similarity_fn: Closure mapping a text string to its maximum
                 cosine similarity against the compost exemplar set
                 (see :mod:`creek.generate.compost_embedding`). When
@@ -207,7 +213,7 @@ class CompostTracker:
         self.dormancy_days = dormancy_days
         self.project_gap_days = project_gap_days
         self.project_min_fragments = project_min_fragments
-        self._now = now or datetime.now(tz=UTC).replace(tzinfo=None)
+        self._now = ensure_aware(now) if now is not None else now_la()
         self._similarity_fn = similarity_fn
         self._verifier = verifier
         self._embedding_threshold = embedding_threshold
@@ -408,13 +414,27 @@ class CompostTracker:
         frags: list[Fragment],
         cutoff: datetime,
     ) -> CompostCandidate | None:
-        """Return a project candidate for *tag*, or ``None`` if still active."""
+        """Return a project candidate for *tag*, or ``None`` if still active.
+
+        Both sides of the silence comparison are timezone-aware before
+        they meet: ``cutoff`` derives from the aware clock, and each
+        fragment timestamp is passed through
+        :func:`creek.time.ensure_aware`. A vault mixing naive and aware
+        fragment timestamps — the ordinary result of round-tripping
+        frontmatter without an offset — therefore ranks and compares
+        instead of raising ``TypeError`` (issue #938; the underlying
+        model-level normalisation is issue #976).
+        """
         if len(frags) < self.project_min_fragments:
             return None
         # FEAT-031: measure silence against the authored-date precedence
         # so a project whose fragments were merely *ingested* recently
         # but authored long ago is still recognised as silent.
-        last_seen = max(effective_authored_at(frag) for frag in frags)
+        # ``max`` compares its own candidates, so the normalisation has to
+        # happen inside the generator rather than around it: without it a
+        # single naive timestamp in the group raises before ``cutoff`` is
+        # ever consulted.
+        last_seen = max(ensure_aware(effective_authored_at(frag)) for frag in frags)
         if last_seen >= cutoff:
             return None
         days = (self._now - last_seen).days

--- a/creek-tools/creek/time.py
+++ b/creek-tools/creek/time.py
@@ -5,7 +5,9 @@ timestamp the pipeline produces is normalised to America/Los_Angeles.
 Bare :func:`datetime.now` calls leak the host timezone (or, worse,
 produce naive datetimes that fail to compare against tz-aware ones with
 ``TypeError``), so production code routes through :func:`now_la` /
-:func:`today_la` instead.
+:func:`today_la` instead. :func:`ensure_aware` is the repair valve for
+values that arrive from outside that discipline — persisted frontmatter,
+legacy callers — making them safe to compare without moving the clock.
 
 The constant :data:`LA_TZ` is re-exported from
 :mod:`creek.ingest.base` to preserve the historical import path while
@@ -33,6 +35,47 @@ def now_la() -> datetime:
 def today_la() -> date:
     """Return today's date as observed in America/Los_Angeles."""
     return now_la().date()
+
+
+def ensure_aware(value: datetime) -> datetime:
+    """Return *value* guaranteed comparable against other aware datetimes.
+
+    Comparing a naive datetime with a tz-aware one raises ``TypeError:
+    can't compare offset-naive and offset-aware datetimes``, which is the
+    failure mode this module exists to prevent. Callers that mix a
+    pipeline-generated clock with timestamps read back off disk route
+    through this helper first.
+
+    The contract is deliberately asymmetric:
+
+    * **Aware in, untouched out.** The instant, the ``tzinfo`` object and
+      the microseconds all survive — no normalisation to LA or UTC.
+      A fragment authored in Sydney keeps its Sydney rendering, matching
+      the promise :func:`effective_authored_at` already makes to callers
+      that display source-local time.
+    * **Naive in, LA attached — never converted.** Every wall-clock field
+      is preserved; only the missing offset is filled in. LA is the
+      right assumption because the ontology (§8.3) normalises every
+      timestamp this pipeline writes to LA, so a naive value is an LA
+      wall-clock reading that lost its offset in transit — typically
+      through YAML frontmatter serialised without one. Converting rather
+      than attaching would shift such a value by the LA offset and could
+      move it across a day boundary.
+
+    Args:
+        value: A datetime that may be naive or timezone-aware.
+
+    Returns:
+        *value* unchanged when it is already aware, otherwise the same
+        wall clock anchored to :data:`LA_TZ`.
+    """
+    # ``datetime.utcoffset()`` returns ``None`` for exactly the values
+    # CPython treats as naive when comparing: ``tzinfo is None``, plus the
+    # rarer ``tzinfo`` whose own ``utcoffset`` yields ``None``. Both need
+    # the anchor, so test the offset rather than ``tzinfo`` itself.
+    if value.utcoffset() is not None:
+        return value
+    return value.replace(tzinfo=LA_TZ)
 
 
 def effective_authored_at(fragment: Fragment) -> datetime:

--- a/creek-tools/tests/test_cli_fill.py
+++ b/creek-tools/tests/test_cli_fill.py
@@ -9,17 +9,20 @@ compost step, and the summary reports real per-folder counts.
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from typer.testing import CliRunner
 
 import creek.cli as cli_mod
+import creek.time as creek_time
 from creek.cli import app
 from creek.generate import compost as compost_mod
 from creek.generate import indexes as indexes_mod
 from creek.link import link_engine
 
 if TYPE_CHECKING:
+    from datetime import tzinfo
     from pathlib import Path
 
     import pytest
@@ -158,6 +161,90 @@ def test_fill_with_compost_appends_compost_step(
 
     assert result.exit_code == 0, result.output
     assert calls == [*_EXPECTED_ORDER, "compost/report"]
+
+
+# ---- Issue #938: the compost report is dated on the LA calendar -----------
+
+_LA_AHEAD_UTC_INSTANT = datetime(2026, 7, 29, 6, 0, tzinfo=UTC)
+"""One absolute instant whose UTC and LA calendar dates disagree.
+
+06:00 UTC on 2026-07-29 is 23:00 PDT on 2026-07-28. A clock reading the UTC
+calendar stamps ``2026-07-29``; a clock reading LA stamps ``2026-07-28``.
+Freezing here turns issue #938's date bug from "true for about seven hours a
+day" into a deterministic assertion.
+"""
+
+
+class _FrozenDatetime(datetime):
+    """A ``datetime`` frozen at :data:`_LA_AHEAD_UTC_INSTANT`.
+
+    Deliberately timezone-agnostic, unlike the narrower stub in
+    ``tests/test_time.py``: it answers ``now(tz=...)`` with the one fixed
+    instant expressed in whatever zone it is handed, and asserts nothing
+    about which zone that is. The buggy implementation asks for UTC and the
+    fixed one asks for America/Los_Angeles — both have to run through this
+    stub, or the test would be measuring the patch instead of the behaviour.
+    """
+
+    @classmethod
+    def now(cls, tz: tzinfo | None = None) -> datetime:
+        """Return the frozen instant, expressed in *tz*.
+
+        Args:
+            tz: Target timezone. ``None`` yields the naive UTC reading,
+                matching :meth:`datetime.now`'s own default.
+
+        Returns:
+            The single frozen moment, converted into *tz*.
+        """
+        if tz is None:
+            return _LA_AHEAD_UTC_INSTANT.replace(tzinfo=None)
+        return _LA_AHEAD_UTC_INSTANT.astimezone(tz)
+
+
+def test_fill_with_compost_dates_the_report_on_the_la_calendar(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``creek fill --with-compost`` stamps the LA date, never the UTC one.
+
+    Runs the **real** ``CompostTracker`` — every other test in this module
+    stubs it out — against a clock frozen at 23:00 PDT on 2026-07-28, which
+    is already 2026-07-29 in UTC. Both module-level ``datetime`` names are
+    replaced with the same stub: ``creek.generate.compost.datetime``, which
+    the buggy ``datetime.now(tz=UTC).replace(tzinfo=None)`` calls, and
+    ``creek.time.datetime``, which ``now_la()`` calls. Patching both is what
+    makes the failure a genuine date mismatch rather than an artefact of
+    which module happened to be frozen.
+
+    Args:
+        tmp_path: Pytest temporary directory used as the vault root.
+        monkeypatch: Fixture used to stub the steps and freeze the clock.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    calls: list[str] = []
+
+    # ``_install_recorders`` swaps in a fake tracker; capture the real class
+    # first and put it back, so this test exercises production compost code
+    # while every other fill step stays stubbed.
+    real_tracker = compost_mod.CompostTracker
+    _install_recorders(monkeypatch, calls)
+    monkeypatch.setattr(compost_mod, "CompostTracker", real_tracker)
+    # Both clocks are frozen to the same instant, and both with raising=True:
+    # the RED failure has to be a real date mismatch, not a typo in a module
+    # path silently tolerated. Contract for the fix: ``creek.generate.compost``
+    # must keep ``datetime`` bound at module scope (not moved under
+    # ``TYPE_CHECKING``) so this patch point survives.
+    monkeypatch.setattr(compost_mod, "datetime", _FrozenDatetime, raising=True)
+    monkeypatch.setattr(creek_time, "datetime", _FrozenDatetime, raising=True)
+
+    result = runner.invoke(app, ["fill", "--vault", str(vault), "--with-compost"])
+
+    assert result.exit_code == 0, result.output
+    report = vault / "10-Liminal" / "Compost" / "_Compost-Report.md"
+    text = report.read_text(encoding="utf-8")
+    generated = [ln for ln in text.splitlines() if ln.startswith("generated:")]
+    assert generated == ["generated: 2026-07-28"]
 
 
 # ---- Issue #876: the untiered-fragment hint -------------------------------

--- a/creek-tools/tests/test_compost.py
+++ b/creek-tools/tests/test_compost.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from datetime import date, datetime, timedelta
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 import frontmatter
 import pytest
@@ -38,6 +39,7 @@ from creek.models import (
     ThreadStatus,
     VoiceClassification,
 )
+from creek.time import today_la
 
 
 class _StubVerifier:
@@ -936,3 +938,225 @@ class TestProjectCandidateNote:
         tracker = CompostTracker()
         # Detection on empty inputs should not error and must return empty.
         assert tracker.detect_compost_candidates([], []) == []
+
+
+# ---- Issue #938: the clock must be tz-aware -------------------------------
+#
+# ``CompostTracker.__init__`` was the only place in ``creek/`` that stripped
+# tzinfo off a datetime. Two consequences, both live crashes:
+#
+#   1. the naive clock cannot be compared against a tz-aware fragment
+#      (``TypeError: can't compare offset-naive and offset-aware datetimes``),
+#      and every fragment built from model defaults is tz-aware; and
+#   2. ``self._now.date()`` reads the *UTC* calendar, so for the seven-odd
+#      hours a day that UTC runs a day ahead of LA, compost notes and the
+#      compost report are stamped with tomorrow's date in a vault whose
+#      every other timestamp is LA-normalised.
+#
+# Normalising only the clock fixes neither the reverse pairing (aware clock,
+# naive fragment) nor the ``max()`` over a tag whose fragments mix both, so
+# the tests below pin all three call sites.
+
+_LA_ZONE = ZoneInfo("America/Los_Angeles")
+"""Explicit LA zone for these tests — never the host ``TZ``."""
+
+_TZ_PROJECT_TAG = "greenhouse"
+"""Tag the timezone tests group their fragments under."""
+
+
+def _tz_fragment(
+    *,
+    frag_id: str,
+    title: str,
+    ingested: datetime,
+    tags: list[str],
+) -> Fragment:
+    """Build a tagged fragment whose ``ingested`` value is stored verbatim.
+
+    Deliberately separate from :func:`_fragment`, which mirrors ``created``
+    into ``ingested`` precisely so the legacy tests stay on naive
+    timestamps. These tests need to choose naive *or* tz-aware per
+    fragment — including mixing both inside one tag group — so they need a
+    builder that takes ``ingested`` directly and leaves ``authored_at``
+    unset, letting ``effective_authored_at`` fall through to it.
+
+    Args:
+        frag_id: Fragment id.
+        title: Fragment title.
+        ingested: Exact value stored on ``ingested`` (and ``created``);
+            may be naive or tz-aware.
+        tags: Tags the fragment carries — project grouping keys off these.
+
+    Returns:
+        A minimal :class:`Fragment` suitable for project-silence detection.
+    """
+    return Fragment(
+        id=frag_id,
+        title=title,
+        source=FragmentSource(platform=SourcePlatform.JOURNAL),
+        created=ingested,
+        ingested=ingested,
+        frequency=FrequencyClassification(primary=Frequency.F5),
+        tags=tags,
+    )
+
+
+class TestTimezoneAwareClock:
+    """The compost clock must compare against any fragment (issue #938)."""
+
+    def _frags(self, moments: list[datetime]) -> list[Fragment]:
+        """Build one fragment per supplied ``ingested`` moment, all one tag.
+
+        Args:
+            moments: The ``ingested`` timestamps, in order.
+
+        Returns:
+            Fragments ``frag-tz-0`` … ``frag-tz-N``, all tagged
+            ``greenhouse`` so project grouping fires.
+        """
+        return [
+            _tz_fragment(
+                frag_id=f"frag-tz-{index}",
+                title=f"Greenhouse notes {index}",
+                ingested=moment,
+                tags=[_TZ_PROJECT_TAG],
+            )
+            for index, moment in enumerate(moments)
+        ]
+
+    def _assert_single_project_candidate(
+        self,
+        candidates: list[CompostCandidate],
+    ) -> None:
+        """Assert the run produced exactly the expected project candidate.
+
+        Asserting the whole candidate — not merely "no exception" — is what
+        makes these tests survive a fix that swallows the ``TypeError``
+        instead of resolving it.
+
+        Args:
+            candidates: The full result of ``detect_compost_candidates``.
+        """
+        assert [c.source_id for c in candidates] == [_TZ_PROJECT_TAG]
+        candidate = candidates[0]
+        assert candidate.source_type == "project"
+        assert candidate.title == _TZ_PROJECT_TAG
+        assert candidate.fragment_ids == ["frag-tz-0", "frag-tz-1", "frag-tz-2"]
+
+    def test_default_clock_handles_tz_aware_fragments(self) -> None:
+        """A default-clock tracker survives tz-aware fragments.
+
+        This is the crash as reported: no ``now=`` argument, fragments
+        whose ``ingested`` is tz-aware (the shape every default-constructed
+        Fragment has), and ``TypeError`` out of the ``last_seen >= cutoff``
+        comparison. The fragments sit in 2020 so the expected verdict holds
+        no matter when the suite runs.
+        """
+        aware = [
+            datetime(2020, 1, 1, 12, 0, tzinfo=_LA_ZONE) + timedelta(days=offset)
+            for offset in range(3)
+        ]
+        tracker = CompostTracker(project_gap_days=30, project_min_fragments=3)
+        candidates = tracker.detect_compost_candidates([], self._frags(aware))
+        self._assert_single_project_candidate(candidates)
+
+    def test_aware_clock_handles_naive_fragments(self) -> None:
+        """An explicitly tz-aware clock survives naive fragments.
+
+        The mirror image of the reported crash, and the reason normalising
+        the *default clock* alone is not a fix: naive ``ingested`` values
+        are a real production input (any fragment round-tripped through
+        YAML without an offset), so the comparison has to be safe from
+        whichever side the naive value arrives on.
+        """
+        naive = [
+            datetime(2020, 1, 1, 12, 0) + timedelta(days=offset) for offset in range(3)
+        ]
+        tracker = CompostTracker(
+            now=datetime(2026, 4, 1, 12, 0, tzinfo=_LA_ZONE),
+            project_gap_days=30,
+            project_min_fragments=3,
+        )
+        candidates = tracker.detect_compost_candidates([], self._frags(naive))
+        self._assert_single_project_candidate(candidates)
+
+    def test_naive_clock_handles_tz_aware_fragments(self) -> None:
+        """An explicitly *naive* ``now=`` keeps working against aware fragments.
+
+        Callers that already pass a naive reference — every legacy test in
+        this module, and any downstream script doing the same — must not be
+        broken by the fix. Their clock is interpreted as LA wall time.
+        """
+        aware = [
+            datetime(2020, 1, 1, 12, 0, tzinfo=_LA_ZONE) + timedelta(days=offset)
+            for offset in range(3)
+        ]
+        tracker = CompostTracker(
+            now=datetime(2026, 4, 1, 12, 0),
+            project_gap_days=30,
+            project_min_fragments=3,
+        )
+        candidates = tracker.detect_compost_candidates([], self._frags(aware))
+        self._assert_single_project_candidate(candidates)
+
+    def test_mixed_naive_and_aware_fragments_under_one_tag(self) -> None:
+        """One tag may carry both naive and tz-aware fragments.
+
+        This is the third crash site and the one a clock-only fix cannot
+        reach: ``max(effective_authored_at(frag) for frag in frags)`` raises
+        while ranking the group, before ``self._now`` is consulted at all.
+        The third fragment is Sydney-anchored so the group also spans two
+        real zones, not just "aware vs naive".
+        """
+        mixed = [
+            datetime(2020, 1, 1, 12, 0),
+            datetime(2020, 1, 2, 12, 0, tzinfo=_LA_ZONE),
+            datetime(2020, 1, 3, 12, 0, tzinfo=ZoneInfo("Australia/Sydney")),
+        ]
+        tracker = CompostTracker(
+            now=datetime(2026, 4, 1, 12, 0, tzinfo=_LA_ZONE),
+            project_gap_days=30,
+            project_min_fragments=3,
+        )
+        candidates = tracker.detect_compost_candidates([], self._frags(mixed))
+        self._assert_single_project_candidate(candidates)
+
+    def test_default_clock_is_tz_aware_and_la(self, vault_path: Path) -> None:
+        """The default clock stamps the LA date on a note, not the UTC one.
+
+        Asserted through the public filename rather than ``_now`` so the
+        test pins behaviour rather than internals. A UTC wall clock files
+        the note under tomorrow's date for the roughly seven hours a day
+        that UTC leads LA; ``tests/test_cli_fill.py`` carries the frozen,
+        always-deterministic version of this assertion.
+
+        The LA calendar is sampled either side of the call and the result
+        accepted against both readings, so a run that straddles LA
+        midnight cannot produce a false failure. Bracketing rather than
+        freezing keeps this test honest about the *real* default clock:
+        it would still fail against a UTC-derived one, which is off by a
+        whole day for hours at a time and so can never fall inside a
+        bracket that is at most one day wide.
+
+        Args:
+            vault_path: Vault fixture with the Compost subtree present.
+        """
+        # ``before`` is sampled ahead of construction because that is when
+        # the tracker latches its clock; ``after`` trails the write. The
+        # bracket therefore provably contains the instant the filename was
+        # derived from.
+        before = today_la()
+        tracker = CompostTracker()
+        candidate = CompostCandidate(
+            source_type="project",
+            source_id=_TZ_PROJECT_TAG,
+            title=_TZ_PROJECT_TAG,
+            reason="Project silent for 400 days",
+            fragment_ids=["frag-tz-0"],
+        )
+        path = tracker.create_compost_note(candidate, vault_path)
+        after = today_la()
+        assert path.name in {
+            f"{before.isoformat()}-{_TZ_PROJECT_TAG}.md",
+            f"{after.isoformat()}-{_TZ_PROJECT_TAG}.md",
+        }

--- a/creek-tools/tests/test_time.py
+++ b/creek-tools/tests/test_time.py
@@ -34,6 +34,7 @@ from creek.time import (
     LA_TZ,
     effective_authored_at,
     effective_authored_date,
+    ensure_aware,
     now_la,
     today_la,
 )
@@ -262,6 +263,80 @@ class TestEffectiveAuthoredDate:
             ingested=ingested,
         )
         assert effective_authored_date(frag) == ingested.date()
+
+
+class TestEnsureAware:
+    """``ensure_aware`` makes any datetime safe to compare (issue #938).
+
+    The helper exists because comparing a naive datetime against a
+    tz-aware one raises ``TypeError: can't compare offset-naive and
+    offset-aware datetimes``. Its contract is deliberately asymmetric:
+
+    * naive in → *attach* America/Los_Angeles, keeping the wall clock;
+    * aware in → return untouched, zone and all.
+
+    The second half matters as much as the first: a fragment whose
+    ``authored_at`` came off a Sydney source must keep its Sydney
+    rendering, exactly as ``effective_authored_at`` already promises.
+    """
+
+    def test_naive_input_gets_the_la_timezone(self) -> None:
+        """A naive input comes back anchored to America/Los_Angeles."""
+        result = ensure_aware(datetime(2026, 7, 28, 23, 0, 0, 123456))
+        assert result.tzinfo is not None
+        assert result.utcoffset() == ZoneInfo("America/Los_Angeles").utcoffset(result)
+
+    def test_naive_input_keeps_its_wall_clock_fields(self) -> None:
+        """The helper *attaches* a zone; it must not convert the wall clock.
+
+        Converting instead of attaching would shift 23:00 on the 28th to
+        16:00 (or 06:00 the next day, depending on direction) and silently
+        move fragments across day boundaries — the very class of bug that
+        issue #938 is about.
+        """
+        result = ensure_aware(datetime(2026, 7, 28, 23, 0, 0, 123456))
+        assert (result.year, result.month, result.day) == (2026, 7, 28)
+        assert (result.hour, result.minute, result.second) == (23, 0, 0)
+        assert result.microsecond == 123456
+
+    def test_already_aware_non_la_input_is_returned_unchanged(self) -> None:
+        """A Sydney-anchored datetime survives with its zone intact.
+
+        Mirrors ``TestEffectiveAuthoredAt.test_preserves_timezone_of_authored_at``:
+        no silent normalisation to LA or UTC, because callers downstream
+        render the source's local time.
+        """
+        sydney = ZoneInfo("Australia/Sydney")
+        moment = datetime(2024, 3, 15, 8, 30, 45, 123456, tzinfo=sydney)
+        result = ensure_aware(moment)
+        assert result == moment
+        assert result.tzinfo == sydney
+        assert result.hour == 8
+        assert result.microsecond == 123456
+
+    def test_already_aware_utc_input_is_returned_unchanged(self) -> None:
+        """A UTC-anchored datetime is passed straight through."""
+        moment = datetime(2026, 5, 24, 6, 0, 0, 654321, tzinfo=UTC)
+        result = ensure_aware(moment)
+        assert result == moment
+        assert result.tzinfo == UTC
+        assert result.hour == 6
+        assert result.microsecond == 654321
+
+    def test_result_is_always_comparable_with_now_la(self) -> None:
+        """The invariant that actually matters: comparisons never raise.
+
+        Both operand orders are exercised because Python dispatches to the
+        *left* operand's ``__lt__`` first — an implementation that only
+        normalised one side would still explode half the time.
+        """
+        past = ensure_aware(datetime(2020, 1, 1, 12, 0))
+        future = ensure_aware(datetime(2099, 1, 1, 12, 0))
+        reference = now_la()
+        assert past < reference
+        assert future >= reference
+        assert reference >= past
+        assert reference < future
 
 
 @pytest.mark.parametrize("tz_env", ["UTC", "Asia/Tokyo", "America/New_York"])


### PR DESCRIPTION
## Summary

`CompostTracker`'s default clock was `datetime.now(tz=UTC).replace(tzinfo=None)` — the **only** place in `creek/` that *stripped* tzinfo, against a house convention of attaching it everywhere else (`pipeline.py:105`, `cli.py:337`, `clean/validator.py:329`, `ingest/base.py:326`, `ingest/gdrive.py:420,711`, `clean/hygiene.py:394`, `link/embeddings.py:653`). Two distinct defects followed.

**1. The `TypeError`.** Project-silence detection raised `TypeError: can't compare offset-naive and offset-aware datetimes` — at **two independent sites**, only one of which #938 identified:

- `compost.py:418` — `last_seen >= cutoff`
- `compost.py:417` — inside `max()` itself, while ranking a tag group whose fragments mix naive and aware timestamps, **before `self._now` is ever consulted**

**2. A UTC/LA calendar bug reachable in production today.** `self._now.date()` was the *UTC* date, feeding the compost-note filename (`:471`), the report's `generated:` frontmatter (`:570`), and the thread-dormancy `today` (`:267`). For the ~7 hours a day that UTC leads LA, `creek fill --with-compost` stamped an LA-normalised vault with **tomorrow's date**. Measured live: `datetime.now(tz=UTC).replace(tzinfo=None).date()` = `2026-07-29` while `now_la().date()` = `2026-07-28`.

### Why the issue's proposed one-liner is not the fix

#938 proposed `self._now = now or now_la()`. I ran it: that **relocates** the crash rather than fixing it. `Fragment` has no timezone validator, so `Fragment.model_validate` on frontmatter serialised without an offset yields a **naive** `ingested` — verified by execution. Naive and aware fragments are therefore both real production inputs, and an aware clock against naive fragments raises the identical `TypeError`. The `max()` site is unreachable by any clock-only change.

### The fix

New `creek.time.ensure_aware()`, applied to **both sides** of every comparison:

- **aware in → returned untouched** — instant, `tzinfo` object and microseconds all survive, so a Sydney-sourced `authored_at` keeps its Sydney rendering (the contract `effective_authored_at` already promises)
- **naive in → `LA_TZ` *attached***, wall clock intact. Attaching rather than converting is precisely what keeps values off day boundaries. LA because `creek/time.py` mandates LA normalisation (ontology §8.3), so a naive value here is an LA wall clock that lost its offset in transit.

It tests awareness via `value.utcoffset() is not None` rather than `tzinfo is not None` — CPython's own definition, which also covers a `tzinfo` whose `utcoffset()` returns `None`.

**Backward compatibility** (an explicit #938 constraint): an explicitly-passed **naive** `now=` still works and is read as an LA wall clock. ~10 existing tests rely on this. Day-count arithmetic is provably unchanged — CPython short-circuits comparison and subtraction when both operands share a `tzinfo` object, and `ZoneInfo` is interned. Verified: a 100-day span straddling a DST boundary yields exactly 100 days both naive and LA-aware.

### Which of the three explanations for `.replace(tzinfo=None)` was true

**Explanation 2, decisively** — `effective_authored_at` does *not* always return aware, so the strip was load-bearing against real inputs and deleting it alone moves the crash. Explanation 1 was true but *not* load-bearing: the tests do inject a naive `now`, and `tests/test_compost.py`'s `_fragment` docstring openly admits it mirrors naive `created` into `ingested` because otherwise "silence calculations against a naive `self._now` would raise" — but no *production* caller injects `now` at all, so the strip existed to keep the fixtures self-consistent, never for a production reason.

### Scope notes

- `detect_compost_candidates` has **no production caller today** (only `generate_compost_report` is wired, via `creek fill --with-compost`), so the `TypeError` is latent until #882 wires the detector — but it is public exported API, and defect 2 above *is* live on the wired path.
- The model-level root cause — `Fragment` accepting naive timestamps, which leaves the same latent crash in the temporal linker, eddies, threads, synchronicity and wavelength — is deliberately **out of scope** and filed as **#976**. `tests/test_time.py::test_result_is_always_tz_aware` currently asserts an invariant that does not hold; #976 covers making it non-vacuous.
- Evidence bearing on **#955** posted there: the two sites produce the *same instant* from the same `st_mtime` and differ only in rendering, so #955 is cosmetic **until** something calls `.date()` on the value — which is exactly defect 2's bug class. Recommendation recorded: prefer `LA_TZ`. Not fixed here.
- `creek/pipeline.py::_as_aware` (UTC semantics, different domain) deliberately left alone.

## Test plan

TDD: all tests written and proven RED before implementation.

**RED signatures observed** (against `36a4e4f`):
- `TypeError: can't compare offset-naive and offset-aware datetimes` at `compost.py:418` × 3 — default clock + aware fragments; aware clock + naive fragments; naive clock + aware fragments
- the same `TypeError` at `compost.py:417` × 1 — mixed naive/aware under one tag, inside `max()`
- `AssertionError: ['generated: 2026-07-29'] == ['generated: 2026-07-28']` — end-to-end through `creek fill --with-compost`
- `ImportError: cannot import name 'ensure_aware' from 'creek.time'`

**11 new tests**, all timezone-independent:
- `tests/test_time.py::TestEnsureAware` (5) — naive→LA attach, wall-clock fields preserved, Sydney and UTC passthrough unchanged, comparability with `now_la()` in both operand orders
- `tests/test_compost.py::TestTimezoneAwareClock` (5) — the four crash paths, each asserting the **full expected candidate** rather than "no exception" (so a fix that swallowed the `TypeError` would not pass); the mixed-tag test spans two real zones (LA + Sydney), not merely naive-vs-aware
- `tests/test_cli_fill.py::test_fill_with_compost_dates_the_report_on_the_la_calendar` (1) — runs the **real** `CompostTracker` through `creek fill --with-compost` with both `creek.generate.compost.datetime` and `creek.time.datetime` frozen to one instant whose UTC and LA dates disagree (`2026-07-29T06:00Z` = `2026-07-28T23:00-07:00`)

**Timezone independence:** every datetime literal carries an explicit `tzinfo`; fixed past instants (2020) are used where the verdict must not depend on run date; the one live-clock test brackets `today_la()` either side of the call so it cannot flake across LA midnight. No test reads the `TZ` env var. No new dependency (`freezegun`/`time-machine` deliberately not added).

**Mutation-checked:** I reverted the clock to its old buggy form and confirmed the frozen e2e test fails with the exact date mismatch — it is a genuine detector, not a tautology.

**Gate 2:** `cd creek-tools && ./scripts/check-all.sh` → **12 passed / 0 failed**, **6535 tests passed**, **93.99% branch coverage**, per-file gate clean (218 files ≥80%), mypy strict clean, ruff clean, complexity clean. No suppressions of any kind.

**Gate 2.5:** `code-review-orchestrator` verdict **CLEAN**, no blockers. Its one MINOR nit (a theoretical LA-midnight flake) is fixed in this branch.

**Test integrity:** `git diff --numstat origin/main` shows **0 deleted lines** across all three test files (`+75`, `+224`, `+87`). No existing test, assertion, fixture, or explicit `tzinfo`/`TZ` setting was modified or removed.

Closes #938
Refs #976, #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)