### PR TITLE
fix(author): stop the HARD privacy gate missing punctuation-edged verbatim leaks (#939)

### DIFF
--- a/creek-tools/creek/author/checks.py
+++ b/creek-tools/creek/author/checks.py
@@ -215,6 +215,15 @@ paraphrase and shorter snippets are left to the semantic judge (#474).
 
 _WHITESPACE_RE = re.compile(r"\s+")
 
+_WORD_CHAR_RE = re.compile(r"\w")
+r"""Matches a single word character, testing whether an edge can carry a boundary.
+
+A ``\b`` anchor asserts a word/non-word *transition*, so it can never hold on an
+edge whose own character is already punctuation — as a whole fragment body's
+first/last character usually is (#939). :func:`_is_verbatim_leak` uses this to
+apply a boundary assertion to exactly the edges where one is meaningful.
+"""
+
 
 def _is_verbatim_leak(protected: str, body: str) -> bool:
     """Return whether *protected* appears in *body* as a substantive phrase.
@@ -224,7 +233,10 @@ def _is_verbatim_leak(protected: str, body: str) -> bool:
     * the protected snippet must be at least :data:`_MIN_PROTECTED_LEAK_WORDS`
       words long (a single common word/phrase is too coincidence-prone for a
       HARD gate), and
-    * it must match on word boundaries, so it cannot match inside a larger word.
+    * it must not be glued into a larger word. The boundary is asserted only on
+      an edge whose own character is a word character, so a snippet that starts
+      or ends with punctuation is still detected rather than silently missed
+      (#939).
 
     Whitespace is normalised on both sides first, so a reflowed line break in
     the draft cannot hide an otherwise-verbatim leak.
@@ -240,7 +252,14 @@ def _is_verbatim_leak(protected: str, body: str) -> bool:
         return False
     normalized_protected = _WHITESPACE_RE.sub(" ", protected).strip()
     normalized_body = _WHITESPACE_RE.sub(" ", body)
-    pattern = rf"\b{re.escape(normalized_protected)}\b"
+    # The word-count guard above makes the snippet non-empty here, so its edge
+    # characters are safe to index. Assert a boundary only where one can hold:
+    # a `\b` on a punctuation edge never matches when the draft's adjacent
+    # character is also punctuation or a string end, which let an exact
+    # reproduction of a protected body slip through the HARD gate (#939).
+    prefix = r"(?<!\w)" if _WORD_CHAR_RE.match(normalized_protected[0]) else ""
+    suffix = r"(?!\w)" if _WORD_CHAR_RE.match(normalized_protected[-1]) else ""
+    pattern = f"{prefix}{re.escape(normalized_protected)}{suffix}"
     return re.search(pattern, normalized_body) is not None
 
 

--- a/creek-tools/tests/test_reflection.py
+++ b/creek-tools/tests/test_reflection.py
@@ -752,3 +752,51 @@ def test_privacy_open_tier_punctuated_body_does_not_flag(tmp_path: Path) -> None
     result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
 
     assert not any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_privacy_punctuation_led_secret_glued_at_its_word_tail_does_not_flag(
+    tmp_path: Path,
+) -> None:
+    """A punctuation-led secret glued onto a word at its tail does not flag.
+
+    Isolates the trailing boundary assertion (#939): the snippet opens on a
+    quote, so the leading assertion is dropped and cannot mask the result. Its
+    last character is a word character, so that edge must keep its assertion
+    and refuse a match that runs straight into the next word.
+    """
+    secret = '"I never told anyone what really happened'
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = 'She wrote: "I never told anyone what really happenedX'
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    assert not any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_privacy_punctuated_leak_finding_is_high_and_names_the_fragment(
+    tmp_path: Path,
+) -> None:
+    """The punctuation-edged leak finding keeps HIGH severity and full detail.
+
+    Pins the payload of the finding this fix restores (#939) so a downgrade of
+    the HARD privacy gate's severity, or a message that stops naming the
+    offending fragment and its tier, cannot pass silently.
+    """
+    secret = "I cheated on my partner last spring."
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = "Here is the leak: I cheated on my partner last spring. That is all."
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    finding = next(f for f in result.findings if f.dimension == "privacy_compliance")
+    assert finding.severity == "HIGH"
+    assert "frag-a" in finding.message
+    assert "intimate" in finding.message

--- a/creek-tools/tests/test_reflection.py
+++ b/creek-tools/tests/test_reflection.py
@@ -554,3 +554,201 @@ def test_conductor_escalates_on_exhaustion(tmp_path: Path) -> None:
 
     assert draft.rounds == 2
     assert draft.verdict == "ESCALATE"
+
+
+def test_privacy_leak_flags_when_protected_body_ends_with_period(
+    tmp_path: Path,
+) -> None:
+    """A leak whose protected body ends in a period must still flag (#939).
+
+    The verbatim matcher wraps the escaped snippet in unconditional word-boundary
+    anchors. A trailing anchor can never assert after a period, so an exact,
+    word-for-word disclosure of an INTIMATE fragment passes the HARD privacy
+    gate in silence.
+    """
+    secret = "I cheated on my partner last spring."
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = "Here is the leak: I cheated on my partner last spring. That is all."
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    assert any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_privacy_leak_flags_when_protected_body_starts_with_a_quote(
+    tmp_path: Path,
+) -> None:
+    """A leak whose protected body opens on a quote mark must still flag (#939).
+
+    A leading word-boundary anchor cannot assert when the protected snippet's
+    first character is punctuation and the draft precedes it with a space, so a
+    quoted INTIMATE passage is reproduced verbatim with no privacy finding.
+    """
+    secret = '"I never told anyone what really happened'
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = 'She wrote: "I never told anyone what really happened in her diary.'
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    assert any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_privacy_leak_flags_when_protected_body_is_punctuated_on_both_edges(
+    tmp_path: Path,
+) -> None:
+    """A leak punctuated on both edges must still flag (#939).
+
+    Both word-boundary anchors fail at once here, and a fully quoted sentence is
+    the most common real shape for a confession, so the HARD gate is completely
+    blind to an exact reproduction of the INTIMATE fragment.
+    """
+    secret = '"I lied to my therapist repeatedly."'
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = 'The note read: "I lied to my therapist repeatedly." Yikes.'
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    assert any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_privacy_leak_flags_when_leading_punctuation_abuts_a_word_character(
+    tmp_path: Path,
+) -> None:
+    """A leak opening on an em dash glued to a word must keep flagging (#939).
+
+    Regression guard against the naive repair: the leading/trailing boundary
+    assertion must be dropped when the protected snippet's own edge character is
+    punctuation, otherwise this leak regresses (#939). Swapping the anchors for
+    unconditional lookarounds would fail here because the em dash abuts a word
+    character in the draft. Un-spaced em dashes are ordinary prose, so this is a
+    real disclosure path, not a synthetic one.
+    """
+    secret = "—the affair nobody knows about"  # leading em dash, U+2014
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = "He said—the affair nobody knows about, quietly."
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    assert any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_privacy_leak_flags_when_trailing_punctuation_abuts_a_word_character(
+    tmp_path: Path,
+) -> None:
+    """A leak ending on a period glued to the next word must keep flagging (#939).
+
+    Regression guard against the naive repair: the leading/trailing boundary
+    assertion must be dropped when the protected snippet's own edge character is
+    punctuation, otherwise this leak regresses (#939). An unconditional trailing
+    lookahead would reject this match because the sentence-final period runs
+    straight into the following word.
+    """
+    secret = "I told a lie about the money."
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = "It reads I told a lie about the money.Then it stops."
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    assert any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_privacy_punctuated_secret_glued_inside_a_word_does_not_flag(
+    tmp_path: Path,
+) -> None:
+    """A punctuated secret glued onto a word at its word-char edge does not flag.
+
+    The snippet's first character is a word character, so that edge keeps its
+    boundary assertion even once the trailing one is dropped: the phrase is not
+    bounded here and must stay unflagged both before and after the fix (#939).
+    """
+    secret = "I cheated on my partner last spring."
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = "xI cheated on my partner last spring."
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    assert not any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_privacy_paraphrase_of_punctuated_secret_does_not_flag(tmp_path: Path) -> None:
+    """A paraphrase of a punctuated INTIMATE secret raises no privacy finding.
+
+    Loosening the boundary assertions must not turn the deterministic verbatim
+    check into a fuzzy one. Paraphrase is out of deterministic scope and belongs
+    to the semantic judge (#474); it stays that way under #939.
+    """
+    secret = "I cheated on my partner last spring."
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = "He was unfaithful to his partner sometime in the spring."
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    assert not any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_privacy_short_punctuated_secret_does_not_flag(tmp_path: Path) -> None:
+    """A sub-threshold punctuated secret stays unflagged.
+
+    The four-word short-circuit still fires first, so loosening the boundaries
+    does not widen the HARD gate for short, generic snippets that can co-occur
+    with innocuous prose by coincidence (#939).
+    """
+    secret = "I cheated badly."  # 3 words — below _MIN_PROTECTED_LEAK_WORDS
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.INTIMATE)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = "The confession was blunt: I cheated badly. Nothing more."
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    assert not any(f.dimension == "privacy_compliance" for f in result.findings)
+
+
+def test_privacy_open_tier_punctuated_body_does_not_flag(tmp_path: Path) -> None:
+    """An OPEN cited fragment quoted verbatim raises no privacy finding.
+
+    The tier-rank guard runs before the verbatim matcher, so a fragment sitting
+    at the contract's own ceiling is not over-tier and the loosened boundaries
+    cannot turn ordinary quotation of publishable material into a leak (#939).
+    """
+    secret = "I published this openly last spring."
+    _seed_fragment(tmp_path, "frag-a", secret, tier=PrivacyTier.OPEN)
+    evidence = EvidenceBundle(
+        claims=[EvidenceClaim(claim="a claim", source_fragments=["frag-a"])]
+    )
+    contract = MediumContract(medium="research", default_privacy_tier=PrivacyTier.OPEN)
+    body = "Here it is: I published this openly last spring."
+
+    result = ReflectionNode().review(body, evidence, contract=contract, vault=tmp_path)
+
+    assert not any(f.dimension == "privacy_compliance" for f in result.findings)


### PR DESCRIPTION
## Summary

`_is_verbatim_leak` (`creek/author/checks.py`) wrapped the escaped protected body in unconditional `\b` anchors:

```python
pattern = rf"\b{re.escape(normalized_protected)}\b"
```

The escaped needle is a **whole vault fragment body**. A `\b` can only assert a word/non-word *transition*, so when the body's own first or last character is punctuation — a `.`, `?`, `"`, `)`, i.e. virtually every real sentence — and the draft's adjacent character is also punctuation or a string end, no boundary exists. `re.search` returns `None`, `check_privacy_compliance` raises no finding, and an **exact verbatim reproduction of an INTIMATE or PERSONAL fragment publishes past the deterministic HARD privacy gate in silence**. Reproduced at HEAD:

| protected body | old result |
| --- | --- |
| `I cheated on my partner last spring.` | `False` — **leak missed** |
| `I cheated on my partner last spring` | `True` — caught |

The fix asserts a boundary **only on an edge whose own character is a word character**:

```python
prefix = r"(?<!\w)" if _WORD_CHAR_RE.match(normalized_protected[0]) else ""
suffix = r"(?!\w)" if _WORD_CHAR_RE.match(normalized_protected[-1]) else ""
pattern = f"{prefix}{re.escape(normalized_protected)}{suffix}"
```

### Why not the unconditional `(?<!\w)…(?!\w)` the issue suggests

The issue (and the architect's first plan) proposed unconditional lookarounds on both edges. I built both patterns and ran them over a matrix of punctuation-edge cases: **the unconditional form is a partial fix that trades one fail-open for another.** It regresses three leak paths `\b` currently catches — precisely the cases where the snippet's punctuation edge abuts a *word* character in the draft, which is where `\b` happened to work:

| protected | draft | `\b` (old) | uncond. lookaround | conditional (this PR) |
| --- | --- | --- | --- | --- |
| `…last spring.` | `…last spring. That is all.` | ❌ miss | ✅ | ✅ |
| `—the affair nobody knows about` | `He said—the affair nobody knows about,` | ✅ | ❌ **regression** | ✅ |
| `I told a lie about the money.` | `…the money.Then it stops.` | ✅ | ❌ **regression** | ✅ |
| `private session notes record` | `Xprivate session notes recordY` | ✅ no flag | ✅ no flag | ✅ no flag |

Un-spaced em dashes are ordinary prose (and LLM prose loves them), so the em-dash row is a real disclosure path, not a synthetic one. The conditional form is a **strict superset** of the old behaviour: identical for word-char-edged snippets, additionally matching punctuation-edged ones, never rejecting anything `\b` accepted. Two tests pin the regression cases so the naive rewrite cannot land later.

### Direction-of-risk / false-positive analysis

A `privacy_compliance` finding is **not** a hard block — `ReflectionNode.review` maps any finding to a `REVISE` verdict (`reflection.py`); the conductor owns retries and the exhaustion→`ESCALATE` policy. So a false positive costs a revise round, while the bug being fixed costs an unredacted intimate disclosure. Even so the negatives are pinned as firmly as the positives: a mid-word substring, a paraphrase, a sub-threshold snippet, an at-ceiling OPEN fragment, and both the leading- and trailing-edge glue cases all assert **no** finding.

`_MIN_PROTECTED_LEAK_WORDS` is **4** and is left unchanged — it is adequate. It short-circuits on whitespace token count, which is orthogonal to edge punctuation; the loosening only affects snippets whose first/last char is non-word, and for those the punctuation must *also* appear literally in the draft, making a ≥4-word match *less* coincidence-prone, not more. Behaviour for every word-char-edged snippet is bit-identical to before.

### `\b` + `re.escape` sweep (`creek/` and `creek_mcp/`)

Nine other sites use this construction. I enumerated the actual runtime values: `classify/rules.py:457`, `author/checks.py:332`, `generate/voice.py:739`, `generate/ai_style/features.py:115` all escape **fixed module-level vocabulary constants** with zero punctuation-edged entries (verified programmatically) — not affected. `generate/cohesion.py:155,158`, `generate/jargon.py:89` and `generate/lexicon.py:287` escape caller-supplied ontology/lexicon vocabulary, and `author/checks.py:478` escapes a pipeline-derived `author_slug`; none is a privacy fail-open, but a punctuation-edged configured term would silently never match. Filed as a follow-up rather than widening this PR. **This site was the only one escaping arbitrary user prose, and the only privacy gate.**

## Test plan

- `cd creek-tools && ./scripts/check-all.sh` → **12/12 checks pass, 0 failed; 6546 passed, 30 deselected; 94.00% total branch coverage; per-file gate 218 files ≥80%.**
- 11 new tests in `tests/test_reflection.py`, all through the public `ReflectionNode().review` path (no private imports, matching the file's convention). RED before the fix:
  ```
  FAILED test_privacy_leak_flags_when_protected_body_ends_with_period - assert False
  FAILED test_privacy_leak_flags_when_protected_body_starts_with_a_quote - assert False
  FAILED test_privacy_leak_flags_when_protected_body_is_punctuated_on_both_edges - assert False
  3 failed, 34 passed
  ```
  after the fix: `39 passed`.
- Mutation-checked by hand — every mutant dies:
  | mutant | killed by |
  | --- | --- |
  | `prefix = ""` | `test_privacy_punctuated_secret_glued_inside_a_word_does_not_flag` |
  | `suffix = ""` | `test_privacy_punctuation_led_secret_glued_at_its_word_tail_does_not_flag` |
  | unconditional `(?<!\w)…(?!\w)` | the two `…abuts_a_word_character` tests |

  The suffix mutant survived the first round — Gate 2.5 review caught it (every trailing-edge case was already blocked by the *leading* assertion), and the third commit adds the isolating test plus a pin on the finding's `HIGH` severity and message content.
- Test-integrity: `git diff --numstat origin/main HEAD` → `creek-tools/tests/test_reflection.py 246 / 0` — **zero deleted lines**; no existing test, fixture, helper or literal was modified. No `# noqa`, `# type: ignore`, `# pylint: disable`, skip marker, threshold change or `--no-verify` anywhere in the diff.

Closes #939

🤖 Generated with [Claude Code](https://claude.com/claude-code)