### PR TITLE
fix(wavelength): normalise the unclassified sentinel so mode profiles serialise (#940)

### DIFF
--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -28,6 +28,7 @@ from creek.models import Dosage, Fragment, Frequency, Mode, Phase
 from creek.time import effective_authored_date
 
 if TYPE_CHECKING:
+    from enum import StrEnum
     from pathlib import Path
 
 
@@ -313,11 +314,30 @@ def _fragment_in_window(fragment: Fragment, start: date, end: date) -> bool:
     return start <= frag_date <= end
 
 
-def _most_common_classified(values: list[str], unclassified: str) -> str:
-    """Return the most common *values* entry, ignoring *unclassified* markers."""
+def _most_common_classified(values: list[str], unclassified: StrEnum | str) -> str:
+    """Return the most common *values* entry, ignoring *unclassified* markers.
+
+    The sentinel is normalised to a plain :class:`str` before it is
+    returned. Callers may legitimately hand over a ``StrEnum`` member
+    (``Phase.UNCLASSIFIED``) or its ``.value``: the member satisfies a
+    ``str`` annotation, compares equal to its value, and so passes mypy
+    and every comparison here unnoticed — but PyYAML has no representer
+    for the member, so returning it unchanged made the note it landed in
+    fail to serialise with ``RepresenterError`` (issue #940). Normalising
+    at the single point of return keeps that trap disarmed for every
+    caller rather than relying on each one remembering ``.value``.
+
+    Args:
+        values: Candidate markers, typically one per fragment.
+        unclassified: The marker treated as "not classified", returned
+            (as a plain ``str``) when nothing else qualifies.
+
+    Returns:
+        The most frequent classified marker, or the normalised sentinel.
+    """
     classified = [v for v in values if v and v != unclassified]
     if not classified:
-        return unclassified
+        return str(unclassified)
     counter = Counter(classified)
     return counter.most_common(1)[0][0]
 

--- a/creek-tools/tests/test_wavelength_reports.py
+++ b/creek-tools/tests/test_wavelength_reports.py
@@ -17,6 +17,7 @@ from creek.generate.wavelength import (
     PHASE_DOMAIN_MAPPINGS,
     ModeProfileGenerator,
     WavelengthTracker,
+    _most_common_classified,
 )
 from creek.models import (
     Confidence,
@@ -668,3 +669,117 @@ class TestModeProfileGenerator:
 
         assert written == []
         assert not (vault_path / "05-Wavelength" / "Mode-Profiles").exists()
+
+    def test_bucket_with_no_classified_frequency_or_phase_round_trips(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """A classified *mode* with unclassified frequency/phase still serialises.
+
+        A fragment may carry a classified engagement mode while its
+        frequency and phase remain unclassified, so a mode bucket can
+        contain nothing classified along either of those axes. The
+        dominant-value fallback must yield a plain ``str``; a raw
+        ``StrEnum`` member reaches PyYAML, which has no representer for
+        it and raises ``yaml.representer.RepresenterError`` (issue #940).
+        """
+        _seed_fragments(
+            vault_path,
+            [
+                _make_fragment(
+                    frag_id="mu1",
+                    created=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+                    mode=Mode.EXPRESS,
+                    frequency=Frequency.UNCLASSIFIED,
+                    phase=Phase.UNCLASSIFIED,
+                ),
+            ],
+        )
+
+        written = ModeProfileGenerator().generate_mode_profiles(vault_path)
+
+        assert [p.name for p in written] == ["express.md"]
+        post = frontmatter.load(str(written[0]))
+        assert post["dominant_frequency"] == Frequency.UNCLASSIFIED.value
+        assert post["dominant_phase"] == Phase.UNCLASSIFIED.value
+
+    def test_bucket_with_classified_frequency_but_unclassified_phase(
+        self,
+        vault_path: Path,
+    ) -> None:
+        """The phase axis falls back independently of the frequency axis.
+
+        Guards the half-classified bucket: were only the frequency
+        sentinel repaired, this note would still fail to serialise.
+        """
+        _seed_fragments(
+            vault_path,
+            [
+                _make_fragment(
+                    frag_id="mp1",
+                    created=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+                    mode=Mode.INHABIT,
+                    frequency=Frequency.F6,
+                    phase=Phase.UNCLASSIFIED,
+                ),
+            ],
+        )
+
+        written = ModeProfileGenerator().generate_mode_profiles(vault_path)
+
+        post = frontmatter.load(str(written[0]))
+        assert post["dominant_frequency"] == Frequency.F6.value
+        assert post["dominant_phase"] == Phase.UNCLASSIFIED.value
+
+
+class TestUnclassifiedSentinelIsPlainStr:
+    """Every dominant-value fallback must be YAML-representable (#940).
+
+    ``Frequency``/``Mode``/``Phase`` are ``StrEnum`` subclasses, so a
+    member satisfies a ``str`` annotation, compares equal to its value,
+    and passes mypy — yet PyYAML's ``SafeDumper`` has no representer for
+    it and raises ``RepresenterError`` on dump. These tests pin the
+    class of bug rather than the single instance of it.
+    """
+
+    @pytest.mark.parametrize(
+        "sentinel",
+        [
+            Frequency.UNCLASSIFIED,
+            Mode.UNCLASSIFIED,
+            Phase.UNCLASSIFIED,
+            Dosage.UNCLASSIFIED,
+            Frequency.UNCLASSIFIED.value,
+            "unclassified",
+        ],
+        ids=[
+            "frequency-member",
+            "mode-member",
+            "phase-member",
+            "dosage-member",
+            "frequency-value",
+            "bare-string",
+        ],
+    )
+    def test_fallback_returns_exact_str(self, sentinel: str) -> None:
+        """The no-classified-values fallback returns an exact ``str``.
+
+        ``type(...) is str`` rather than ``isinstance`` on purpose: a
+        ``StrEnum`` member passes ``isinstance(x, str)``, so only an
+        exact type check catches the leak.
+        """
+        result = _most_common_classified([], sentinel)
+
+        assert type(result) is str
+        assert result == "unclassified"
+
+    def test_fallback_result_is_yaml_representable(self) -> None:
+        """The fallback value survives a frontmatter round trip."""
+        result = _most_common_classified(
+            [Phase.UNCLASSIFIED.value],
+            Phase.UNCLASSIFIED,
+        )
+
+        dumped = frontmatter.dumps(frontmatter.Post(content="", phase=result))
+
+        assert frontmatter.loads(dumped)["phase"] == Phase.UNCLASSIFIED.value


### PR DESCRIPTION
## Summary

`ModeProfileGenerator._write_mode_profile` passed the **`StrEnum` members** `Frequency.UNCLASSIFIED` / `Phase.UNCLASSIFIED` as the sentinel to `_most_common_classified`, whose no-classified-values fallback returned that sentinel unchanged. The live member then reached `frontmatter.dumps`, and PyYAML — which has no representer for the enum subclass — raised:

```
yaml.representer.RepresenterError: ('cannot represent an object', <Frequency.UNCLASSIFIED: 'unclassified'>)
```

A fragment can carry a **classified engagement mode** while its frequency and phase stay unclassified, so any such mode bucket crashed the **default** `creek fill` step `report/mode-profiles` (`creek/cli.py:1985`). Reproduced at HEAD `317ea3d` before touching anything.

Neither mypy nor the happy path could see this: `StrEnum` subclasses `str`, so a member satisfies the `unclassified: str` annotation, and it compares equal to its own value, so the filter above the fallback behaves correctly. **Only the fallback return leaked a live member.**

### Fix shape chosen, and why

The issue proposed passing `.value` at the two broken call sites (option A). I chose **option B — normalise inside the helper** — after auditing every call site:

* `_most_common_classified` is module-private with **exactly four** call sites, all in `creek/generate/wavelength.py` (`:418`, `:419`, `:1381`, `:1385`). The blast radius is fully enumerable, which is the precondition for touching a shared helper.
* Option A fixes two lines and leaves the identical landmine armed for call site #5. This exact slip has already been hit and patched **three separate times** in this codebase — `creek/generate/decisions.py:207` carries a `# noqa: FURB123 # yaml.safe_dump cannot serialise StrEnum directly`, `creek/classify/classify_engine.py:1117-1119` carries a `.value` plus an explanatory comment, and `creek/generate/wavelength.py:1351-1355` carries a third. "Remember to write `.value`" demonstrably does not hold at repo scale.
* The sentinel annotation is widened to `StrEnum | str`. This states the contract honestly (callers may legitimately pass either form) and, as a side effect, keeps `str(unclassified)` a genuine conversion rather than a redundant cast — with a bare `str` annotation, `lint-refurb.sh` would flag it `FURB123` and force a suppression, which the house rules forbid. Verified empirically: refurb is clean with the union, and `from __future__ import annotations` lets the `StrEnum` import stay under `TYPE_CHECKING`.
* **The two call sites are deliberately left passing the enum members.** That keeps the normalisation path exercised end-to-end by the new integration test rather than only by a direct unit call.

No tighter type would have caught this. `str` is already technically correct for a `StrEnum` member; the type system has nothing more to say here, which is exactly why the runtime normalisation is the right lever.

### Sweep for siblings

I swept every `frontmatter.dumps` / `frontmatter.Post(` / `yaml.dump` site in `creek/` and `creek_mcp/` (27 `Post` constructions, 20 files) against all 31 `StrEnum` classes, tracing what feeds each kwarg and each `post[...] = ` / `post.metadata.update(...)` assignment.

**Result: no other reachable instance.** The vault models all set `use_enum_values=True` and the writers serialise via `.model_dump(mode="json")`, so attribute access yields plain strings; `creek/purge/engine.py`'s `_CLASSIFICATION_DEFAULTS` are plain-string literals; `flagged_frequencies` and `paradox.frequencies` are `list[str]`.

One **latent, currently-unreachable** trap found and filed separately rather than widened into this PR: `DecisionDetector.update_decision_phase` (`creek/generate/decisions.py:229-264`) takes `new_phase: str`, validates it against `_VALID_PHASES: frozenset[str]` which is built from `DecisionStatus` **members** (`:67-77`), then writes it straight to `post["status"]`. A `DecisionStatus` member would pass the membership check and crash the dump — identical shape to this bug. It has no production caller today (only tests, all passing plain strings), so it is genuinely out of scope here.

### On the class-level guard — one negative result reported honestly

I added `TestUnclassifiedSentinelIsPlainStr`, which asserts `type(result) is str` (not `isinstance` — a `StrEnum` member passes `isinstance`) across every sentinel form. **This is the real family guard:** all four call sites converge on this one return, so any future caller passing a member is covered by construction. It was RED on 5 of its 6 cases.

I also built the broader guard the brief asked for — a class sweeping *every* wavelength note writer against an all-unclassified corpus — and then **deleted it, because I proved it vacuous**: I reintroduced the bug in the helper *and* stripped `.value` from the `:418`/`:419` call sites, and all three of its tests still passed. The reason is structural: `generate_report` / `generate_weekly_report` / `generate_monthly_report` never put a `_most_common_classified` result into frontmatter (their metadata is `period` / `week` / `year` / `tags`), so a sentinel slip there renders as body text and never reaches PyYAML. It also added **zero** marginal branch coverage (`creek/generate/wavelength.py` at 93.44% with and without it). Shipping it would have been three tests that look like a safety net and catch nothing.

## Test plan

* **Gate 1 RED**, final tests against unmodified `origin/main` production code: **7 failed, 29 passed**.
  * `test_bucket_with_no_classified_frequency_or_phase_round_trips` → `yaml.representer.RepresenterError: ('cannot represent an object', <Frequency.UNCLASSIFIED: 'unclassified'>)`
  * `test_fallback_returns_exact_str[frequency|mode|phase|dosage-member]` → `AssertionError: assert <enum 'Frequency'> is str`
  * `test_fallback_result_is_yaml_representable` → same `RepresenterError`
* **Gate 1 GREEN**: 36 passed in `tests/test_wavelength_reports.py`.
* **Gate 2**: `cd creek-tools && ./scripts/check-all.sh` → **12/12 passed, 0 failed**. Full suite **6555 passed, 30 deselected**; aggregate branch coverage **93.99%** (floor 90%); per-file gate 218 files ≥ 80%. One autofixable trailing-newline formatting nit was resolved with `./scripts/fix-all.sh`. No suppressions added anywhere.

### Test-integrity audit

`git diff --numstat origin/main` → `creek-tools/tests/test_wavelength_reports.py: 115 additions, 0 deletions`. No existing test, assertion, or fixture was modified — in particular `_make_fragment`'s classification defaults are byte-identical to `origin/main`, so the all-unclassified bucket this PR exists to fix is still genuinely all-unclassified. Post-commit hash: `b3bcdfc6cd89a9ec48a8bec20b9e1aaf5f3e0179a351b360130f2223e3e2b987`.

Closes #940

🤖 Generated with [Claude Code](https://claude.com/claude-code)