### PR TITLE
chore(ralph): route chief-architect to Opus 5

### DIFF
--- a/.claude/agents/README.md
+++ b/.claude/agents/README.md
@@ -22,7 +22,7 @@ graph under a conductor is identical:
 ```
 ralph-tick (fleet ORCHESTRATOR — worker pool: reconcile · serialized-merge · lazy-sync · refill)
   └─ ralph-worker × up to 4 . L1  opus    per-issue CONDUCTOR in an isolated worktree
-       ├─ chief-architect ..... L0  fable   plan + ordered dispatch list (no code)
+       ├─ chief-architect ..... L0  opus    plan + ordered dispatch list (no code)
        ├─ test-specialist ..... L2  opus    Gate 1 RED: failing tests          ─┐
        ├─ implementation-spec.  L2  opus    Gate 1 GREEN + Refactor             │ run per
        ├─ security-specialist . L2  opus    harden auth/input/paths/secrets     │ the
@@ -62,37 +62,39 @@ specialists are leaf workers that do their own work and do not sub-delegate.
 
 ## Model tiers (strategic mix)
 
-The tiering rule is **Fable 5 for planning, Opus 5 for implementation, Sonnet 5
-for review, Haiku 4.5 for quick checks.**
+The tiering rule is **Opus 5 for planning and implementation, Sonnet 5 for
+review, Haiku 4.5 for quick checks.**
 
 > Prose names the model *family generation*; the `model:` frontmatter takes the
 > unversioned **alias** (`fable`/`opus`/`sonnet`/`haiku`), which always resolves
 > to the current model in that family. Keep the aliases in frontmatter — pinning
 > a dated ID there would rot.
 
-**Fable 5** for the one role where a better plan changes everything downstream:
-`chief-architect` (the once-per-issue design pass). Fable is ~2× Opus-tier cost
-and can run minutes-long turns — spending it once per issue on the design, and
-not on every code-writing turn, is the cheapest place to buy quality. It also
-prefers **less-prescriptive prompts** (state the goal and constraints, not
-step-by-step scaffolding), which suits a planning brief.
+**Opus 5** for planning and every code-writing role: `chief-architect` (the
+once-per-issue design pass), `ralph-worker` (the long-horizon per-issue
+conductor), `implementation-specialist` (Gate 1 GREEN + Refactor),
+`test-specialist` (Gate 1 RED), `performance-specialist` (optimization), and
+`security-specialist`.
 
-**Fable is credit-metered and can run out.** The architect role therefore
-carries an explicit **graceful fallback: on a Fable-unavailable spawn failure,
-the conductor immediately re-spawns `chief-architect` with a
-`model: opus` override and continues the tick.** A tick never blocks, and never
-skips the planning pass, because Fable credits are exhausted. See
-[`chief-architect.md`](chief-architect.md) and `scripts/ralph/PROMPT.md` step 5.
+> **Why the architect is no longer on Fable 5.** Fable is credit-metered. Once
+> credits ran out, every tick spent a *failed* spawn before falling back to
+> Opus — pure waste, and on a long run those failed spawns count against the
+> session's subagent cap. The fallback worked exactly as designed; the problem
+> was paying for it on every tick rather than occasionally. Moving the architect
+> to Opus removes the failure path entirely.
+>
+> If Fable credits are topped up and you want the planning pass back on it, set
+> `model: fable` in [`chief-architect.md`](chief-architect.md) and restore the
+> fallback contract in `scripts/ralph/PROMPT.md` step 5. Fable is ~2× Opus-tier
+> cost and prefers **less-prescriptive prompts** (state the goal and
+> constraints, not step-by-step scaffolding), which suits a planning brief —
+> spending it once per issue on design rather than on every code-writing turn
+> is the cheapest place to buy quality.
 
-**Opus 5** for every code-writing role — implementation is where model quality
-pays off directly: `ralph-worker` (the long-horizon per-issue conductor),
-`implementation-specialist` (Gate 1 GREEN + Refactor), `test-specialist`
-(Gate 1 RED), `performance-specialist` (optimization), and
-`security-specialist`. Opus 5 is un-metered relative to Fable, so the roles that
-run many turns per tick sit here. Keeping `security-specialist` on Opus is also
-a hard requirement independent of cost: Fable's safety classifiers target
-**cyber/bio** content, and legitimate hardening work can trip a false-positive
-refusal.
+Keeping `security-specialist` on Opus is a hard requirement independent of cost:
+Fable's safety classifiers target **cyber/bio** content, and legitimate
+hardening work can trip a false-positive refusal. Do not move that role to Fable
+even if the architect goes back.
 **Sonnet** for review and other well-scoped passes over bounded input:
 `code-review-orchestrator` (Gate 2.5), `documentation-specialist`.
 **Haiku** for the purely mechanical, read-only checklist walk:

--- a/.claude/agents/chief-architect.md
+++ b/.claude/agents/chief-architect.md
@@ -4,7 +4,7 @@ description: "Strategic brain of a Ralph tick. Select to architect a single back
 level: 0
 phase: Plan
 tools: Read,Grep,Glob,Task
-model: fable
+model: opus
 delegates_to: [test-specialist, implementation-specialist, security-specialist, performance-specialist, documentation-specialist, dependency-review-specialist, code-review-orchestrator]
 receives_from: []
 ---
@@ -19,12 +19,15 @@ then hand a concrete plan back to the conductor (`scripts/ralph/PROMPT.md`, run 
 `.claude/commands/ralph-tick.md`). You do **not** write code, tests, or docs —
 you read, reason, and dispatch.
 
-> **Model tier.** This role runs on **Fable 5** — the one place the fleet spends
-> the metered tier, because a better plan compounds across every specialist that
-> executes it. Fable credits can run out. When they do, the conductor re-spawns
-> this agent with a `model: opus` override (see `scripts/ralph/PROMPT.md` step 5);
-> the plan is still produced, and this contract is unchanged either way. Never
-> let the conductor skip the planning pass to route around an exhausted tier.
+> **Model tier.** This role runs on **Opus 5**, like every code-writing role in
+> the fleet. It previously ran on Fable 5 — a better plan compounds across every
+> specialist that executes it — but Fable is credit-metered, and once credits
+> were exhausted every tick paid for a failed spawn before falling back. See
+> `.claude/agents/README.md` for how to move it back if credits are topped up;
+> this contract is unchanged either way. Never let the conductor skip the
+> planning pass to route around a spawn failure — if the architect cannot be
+> spawned, the conductor must say so explicitly rather than quietly improvising
+> the design.
 
 ## Scope
 

--- a/.claude/agents/ralph-worker.md
+++ b/.claude/agents/ralph-worker.md
@@ -58,9 +58,11 @@ So, concretely:
 - Read the issue (`gh issue view "$RALPH_ISSUE" --comments`) and the house rules
   (`CLAUDE.md`, `creek-tools/CLAUDE.md`).
 - Spawn **chief-architect** for the plan + ordered dispatch list + risk flags.
-  It runs on Fable 5 (credit-metered): if the spawn fails because Fable is
-  unavailable or out of credits, re-spawn it with a `model: opus` override
-  rather than skipping the plan or designing the change yourself.
+  If the spawn fails, retry once; if it still fails, do the architecture
+  yourself and **state explicitly** in your report and the PR body that the plan
+  was not an independent architect pass. Never imply a planning pass happened
+  when it did not. A `Subagent spawn limit reached` error is terminal for the
+  session — report it and continue solo rather than retrying.
 - Run its specialists **sequentially** inside your worktree: `test-specialist`
   (Gate 1 RED) → `implementation-specialist` (Gate 1 GREEN + refactor) → only the
   cross-cutting specialists the architect flagged.

--- a/scripts/ralph/PROMPT.md
+++ b/scripts/ralph/PROMPT.md
@@ -57,11 +57,14 @@ drives Gates 3–4. The taxonomy you dispatch is mapped in
    design approach, touch-list, TDD test strategy, an **ordered dispatch list**,
    and **risk flags** (security / performance / deps / docs). You execute that
    list — you do not improvise the design.
-   **Fable fallback:** the architect runs on Fable 5, which is credit-metered.
-   If the spawn fails because Fable is unavailable or out of credits, do **not**
-   skip the planning pass and do **not** improvise the design — immediately
-   re-spawn the same `chief-architect` with an explicit `model: opus` override
-   and continue. Note the downgrade in one line in the PR body's Summary.
+   **If the architect spawn fails,** do **not** skip the planning pass and do
+   **not** improvise the design. Retry once; if it still fails, say so
+   explicitly in your report and in the PR body's Summary, then do the
+   architecture yourself and state plainly that the plan was not an independent
+   `chief-architect` pass. The failure mode to avoid is implying a planning pass
+   happened when it did not. Note that a `Subagent spawn limit reached` error is
+   terminal for the whole session — no retry or model override will clear it, so
+   report it and continue solo rather than burning attempts.
 6. **Dispatch the build.** The test- and implementation-specialists *embody* the
    `stay-green` Red→Green→Refactor discipline and `max-quality-no-shortcuts`
    (no bypasses) — that is now the TDD path; you do not separately invoke the


### PR DESCRIPTION
## Summary

Moves `chief-architect` from `model: fable` to `model: opus`, and removes the now-dead Fable fallback contract.

**Why.** Fable credits have been exhausted for the whole of the last loop session. Every tick spent a *failed* architect spawn before falling back to Opus. The fallback worked exactly as designed — no tick ever blocked or skipped its planning pass — but the loop was paying for it on every single tick rather than occasionally.

Those failed spawns also counted against the session's subagent cap, which the loop hit at **200/200**, halting it at `total_completed: 153`.

## Changes

| File | Change |
|---|---|
| `chief-architect.md` | `model: fable` → `model: opus`; tier note rewritten |
| `README.md` | Tiering rule, ASCII spawn graph, and rationale section |
| `PROMPT.md` step 5 | Fable fallback → spawn-failure honesty requirement |
| `ralph-worker.md` | Same, for the conductor's architect-spawn step |

## What replaces the fallback

The old contract said "on a Fable-unavailable spawn failure, re-spawn with `model: opus`." With no metered tier in the fleet that path is dead. It is replaced with an **honesty requirement**: if the architect cannot be spawned, retry once, then do the architecture yourself and *say so explicitly* in the report and the PR body. The failure mode worth guarding against is a conductor implying a planning pass happened when it did not — which is exactly what nearly went unnoticed on PR #990.

Both files also now record that `Subagent spawn limit reached` is **terminal for the session** — no retry or model override clears it — so workers stop burning attempts on it.

## Preserved deliberately

- **How to move the architect back to Fable** if credits are topped up, including why it suited the role (planning benefits from less-prescriptive prompts; ~2× Opus-tier cost is cheapest spent once per issue rather than on every code-writing turn).
- **`security-specialist` must never go to Fable**, independent of cost — Fable's safety classifiers target cyber/bio content and can false-positive on legitimate hardening work. Kept as a standing rule so a future re-tiering does not sweep it up.

## Verification

```
$ grep -H '^model:' .claude/agents/*.md
chief-architect.md:model: opus          ralph-worker.md:model: opus
implementation-specialist.md:model: opus  test-specialist.md:model: opus
performance-specialist.md:model: opus     security-specialist.md:model: opus
code-review-orchestrator.md:model: sonnet documentation-specialist.md:model: sonnet
dependency-review-specialist.md:model: haiku
```

No `model: fable` remains. Remaining "Fable" mentions are intentional: the alias list, the how-to-revert note, and the security-specialist warning.

Docs and agent config only — no Python touched, so neither `check-all.sh` gate applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)