### PR TITLE
fix(compile): reject non-object claim/paradox elements at the parse boundary

### DIFF
--- a/creek-tools/creek/compile/engine.py
+++ b/creek-tools/creek/compile/engine.py
@@ -127,7 +127,8 @@ def compile_fragments(
 
     Raises:
         ValueError: If *target_kind* is not one of the supported
-            compiled-page surfaces.
+            compiled-page surfaces, or if the LLM payload's ``claims``
+            or ``paradoxes`` are not arrays of JSON objects.
     """
     _validate_target_kind(target_kind)
     pairs = list(fragments_with_bodies)
@@ -455,6 +456,9 @@ def _parse_llm_payload(raw: str) -> dict[str, list[dict[str, object]]]:
     if not isinstance(claims, list) or not isinstance(paradoxes, list):
         msg = "Compile LLM payload claims/paradoxes must be arrays."
         raise ValueError(msg)  # noqa: TRY004  # ValueError unifies all LLM-payload schema errors with the JSONDecodeError branch above.
+    if any(not isinstance(item, dict) for item in (*claims, *paradoxes)):
+        msg = "Compile LLM payload claims/paradoxes must contain JSON objects."
+        raise ValueError(msg)
     return {"claims": list(claims), "paradoxes": list(paradoxes)}
 
 

--- a/creek-tools/tests/test_compile.py
+++ b/creek-tools/tests/test_compile.py
@@ -726,6 +726,140 @@ def test_compile_fragments_rejects_non_array_claims() -> None:
         )
 
 
+def test_compile_fragments_rejects_string_claim_elements() -> None:
+    """Bare-string ``claims`` elements are rejected at the parse boundary.
+
+    An LLM returning ``{"claims": ["insight one"]}`` — prose strings
+    where claim objects belong — cleared the list-shape check and then
+    crashed downstream in ``_filter_valid_claims`` with
+    ``AttributeError: 'str' object has no attribute 'get'``. Element
+    types are part of the payload schema, so the rejection belongs at
+    the parse boundary with the other schema errors.
+    """
+    frag = _make_fragment(frag_id="frag-aaa")
+    bad = json.dumps({"claims": ["insight one", "insight two"], "paradoxes": []})
+    llm, _ = _make_llm([bad])
+    with pytest.raises(ValueError, match="must contain JSON objects"):
+        compile_fragments(
+            [(frag, "body")],
+            llm=llm,
+            target_kind="thread",
+            target_id="t",
+            target_title="T",
+        )
+
+
+def test_compile_fragments_rejects_string_paradox_elements() -> None:
+    """Bare-string ``paradoxes`` elements fail under the same guard.
+
+    ``_payload_to_paradox_entries`` calls ``item.get`` exactly the way
+    the claim filter does, so a string paradox crashes identically.
+    Well-formed claims must not rescue a payload whose paradoxes are
+    malformed — both arrays are validated, not just the first one.
+    """
+    frag = _make_fragment(frag_id="frag-aaa")
+    bad = json.dumps(
+        {
+            "claims": [{"id": "c1", "text": "X", "fragment_ids": ["frag-aaa"]}],
+            "paradoxes": ["they contradict"],
+        },
+    )
+    llm, _ = _make_llm([bad])
+    with pytest.raises(ValueError, match="must contain JSON objects"):
+        compile_fragments(
+            [(frag, "body")],
+            llm=llm,
+            target_kind="thread",
+            target_id="t",
+            target_title="T",
+        )
+
+
+def test_compile_fragments_rejects_mixed_claim_elements() -> None:
+    """One bad element rejects the whole payload; the good claim is not kept.
+
+    Whole-payload rejection is the deliberate design decision here, and
+    this test is where it is encoded. The alternative — silently
+    dropping the bad element and compiling the survivors — would let a
+    truncated or prose-contaminated response write a compiled page whose
+    body is wiped down to just the title while stale provenance survives
+    in frontmatter. A quietly corrupted note is worse than a loud
+    failure the operator can retry, so the parser refuses the payload
+    whole rather than salvaging part of it.
+
+    This is distinct from ``_filter_valid_claims``, which keeps its
+    silent-drop semantics for structurally valid claim objects that are
+    merely incomplete (see
+    ``test_compile_fragments_skips_claim_with_missing_id``).
+    """
+    frag = _make_fragment(frag_id="frag-aaa")
+    payload: dict[str, object] = {
+        "claims": [
+            {"id": "c1", "text": "X", "fragment_ids": ["frag-aaa"]},
+            "a bare string",
+        ],
+        "paradoxes": [],
+    }
+    llm, _ = _make_llm([json.dumps(payload)])
+    with pytest.raises(ValueError, match="must contain JSON objects"):
+        compile_fragments(
+            [(frag, "body")],
+            llm=llm,
+            target_kind="thread",
+            target_id="t",
+            target_title="T",
+        )
+
+
+def test_compile_to_vault_leaves_existing_page_untouched_on_string_claims(
+    vault: Path,
+) -> None:
+    """A malformed re-compile aborts before it touches the page on disk.
+
+    ``compile_to_vault`` parses the LLM payload before ``_write_compiled_page``
+    runs, so a schema violation on a re-run must leave the previously
+    compiled page byte-identical. This pins the conservative
+    abort-before-write contract and guards against any future slide
+    toward drop-the-bad-element-and-continue, which would rewrite the
+    page with a hollowed-out body.
+    """
+    frag = _make_fragment(frag_id="frag-aaa")
+    _write_fragment_to_vault(vault, frag, "body")
+    good = _llm_response(
+        claims=[
+            {
+                "id": "claim-001",
+                "text": "Stable claim.",
+                "fragment_ids": ["frag-aaa"],
+            },
+        ],
+    )
+    bad = json.dumps({"claims": ["insight one"], "paradoxes": []})
+    llm, _ = _make_llm([good, bad])
+
+    target = compile_to_vault(
+        fragment_ids=["frag-aaa"],
+        vault_path=vault,
+        target_kind="thread",
+        target_id="thread-untouched",
+        target_title="Untouched",
+        llm=llm,
+    )
+    before = target.read_text(encoding="utf-8")
+    assert "Stable claim." in before
+
+    with pytest.raises(ValueError, match="must contain JSON objects"):
+        compile_to_vault(
+            fragment_ids=["frag-aaa"],
+            vault_path=vault,
+            target_kind="thread",
+            target_id="thread-untouched",
+            target_title="Untouched",
+            llm=llm,
+        )
+    assert target.read_text(encoding="utf-8") == before
+
+
 def test_compile_fragments_skips_claim_with_missing_id() -> None:
     """Claims with a missing or empty ``id`` are dropped before body render.
 


### PR DESCRIPTION
## Summary

`_parse_llm_payload` (`creek/compile/engine.py`) validated that `claims` and `paradoxes` were *lists* but never validated their *element* types. A well-formed-JSON payload of the wrong shape — e.g. `{"claims": ["insight one"], "paradoxes": []}`, which any model can emit — parsed cleanly and then crashed downstream in `_filter_valid_claims` with `AttributeError: 'str' object has no attribute 'get'`. String *paradox* elements crashed identically in `_payload_to_paradox_entries`. Nothing wraps those calls, so the `AttributeError` escaped `compile_fragments` as a raw traceback instead of the `ValueError` the tolerant-JSON machinery exists to produce — and `creek_mcp/tools/compile.py` catches `(ValueError, RuntimeError)` to build a structured refusal but **not** `AttributeError`, so the bug left an MCP tool unhandled.

The fix adds one guard at the parse boundary:

```python
if any(not isinstance(item, dict) for item in (*claims, *paradoxes)):
    msg = "Compile LLM payload claims/paradoxes must contain JSON objects."
    raise ValueError(msg)
```

### The design decision

Two shapes were considered — validate at the parse boundary (**reject the whole payload**), or make `_filter_valid_claims` skip non-dict elements (**drop the bad ones and proceed**). These differ in product behaviour, so the choice is stated explicitly:

**Chosen: reject the whole payload.**

- **Category.** `_parse_llm_payload` owns payload *schema* validation and already rejects a wrong-typed container with `ValueError`. `_filter_valid_claims` is a *render-safety* filter — its docstring says it exists so `_render_body` does not emit a broken `[^]` footnote — for claims that are structurally valid but incomplete. A bare-string element means the model ignored the schema outright, which belongs in the reject tier, not the drop tier. **`_filter_valid_claims` is unchanged**, and the two existing tests that pin its silent-drop semantics (`test_compile_fragments_skips_claim_with_missing_id`, `test_compile_fragments_skips_empty_claim_text`) still pass untouched — that is the proof this stayed consistent rather than inventing a third behaviour.
- **Blast radius of the alternative.** A model that emits one string claim emitted a *list* of strings, so dropping bad elements realistically leaves zero claims. `compile_to_vault` calls `_write_compiled_page` unconditionally, `page.body` is rendered fresh from the surviving claims, and `merge_provenance` with an empty new list *preserves* existing entries. So a re-compile would rewrite the page with the body hollowed down to `# Title` while stale provenance survived in the frontmatter — an internally inconsistent note, reported as success. `creek/compile/__init__.py` names exactly that hazard: per-claim provenance is "non-negotiable … lossy compression here [is] a load-bearing risk for voice fidelity."
- **Conservatism.** Today that payload already aborts before any write (the `AttributeError` fires first), so this changes only the exception *type*, never what gets written.

**User-visible consequence:** a compile whose LLM emits off-schema elements now fails with `ValueError: Compile LLM payload claims/paradoxes must contain JSON objects.` The MCP `creek.compile` tool surfaces that as a structured refusal instead of an unhandled exception. `creek/cli.py` does not catch `ValueError` either, so `creek compile` still shows a traceback — just a semantically correct one (pre-existing gap, filed as a follow-up). No page is written and no existing page is modified; the operator retries.

**`paradoxes` are covered too.** The issue focused on claims, but line 455 validates both arrays together and `_payload_to_paradox_entries` has the identical `item.get` crash with no filter of its own, so the single guard covers both and a test pins each independently.

## Test plan

Gate 1 RED first. All four new tests go through the **public** `compile_fragments` / `compile_to_vault`, not `_parse_llm_payload` directly — at HEAD a direct unit test on the parser would *pass* (it returns successfully), so it would not reproduce the bug at all. The defect only manifests across the parse to filter boundary.

Confirmed RED before implementation — `E AttributeError: 'str' object has no attribute 'get'` at `creek/compile/engine.py:205`, on all four:

- `test_compile_fragments_rejects_string_claim_elements` — the issue's literal reproduction.
- `test_compile_fragments_rejects_string_paradox_elements` — well-formed claims must not rescue malformed paradoxes.
- `test_compile_fragments_rejects_mixed_claim_elements` — one good claim plus one bare string; asserts the **whole** payload is rejected rather than the good claim surviving. This is where the design decision is encoded.
- `test_compile_to_vault_leaves_existing_page_untouched_on_string_claims` — compiles a page, captures its bytes, re-compiles with a string-claims payload, asserts the raise **and** byte-identity on disk. Pins the abort-before-write contract and guards against any future slide toward drop-and-continue.

Test file diff is **+134 / -0** — purely additive, no existing test or assertion modified.

Runtime edge-case probe of the guard: string / `null` / nested-list / numeric elements all rejected; `{}`, missing keys, and `"claims": null` still tolerated as `[]` (pre-existing `or []` behaviour, unchanged).

Gate 2: `cd creek-tools && ./scripts/check-all.sh` exits **0** — 6555 unit tests pass, coverage **93.99%**. Tryceratops passes with **no `# noqa: TRY004`** on the new raise: TRY004's detector only matches a bare `isinstance` as the `if` test and does not walk into generator expressions. Verified in both directions — the new raise without a noqa is clean, while stripping the two *existing* noqas on lines 452/457 does produce TRY004 errors. Adding a dead suppression there would itself violate the noqa hygiene rule. `radon` puts `_parse_llm_payload` at B(6) to B(8); `xenon --max-absolute B` passes with headroom.

Gate 2.5: independent `code-review-orchestrator` pass over the diff — verdict **CLEAN**, zero blockers.

## Non-blocking notes from review (not fixed here)

- `(*claims, *paradoxes)` materialises the concatenated tuple before `any()` short-circuits. Harmless at LLM-payload sizes; `itertools.chain` would restore true laziness if this line is ever touched again.
- `decoded.get("claims") or []` still coerces any *falsy* wrong-typed value (`0`, `""`, `False`) to `[]`, slipping past both the container check and this new guard. Pre-existing and out of scope; filed as a follow-up.

Closes #941