### PR TITLE
fix(mcp): route creek.draft through ModelRouter with a source-derived tier

### DIFF
--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -68,6 +68,7 @@ if TYPE_CHECKING:
     from creek.compile.engine import CompileLLM
     from creek.models import PrivacyTier
     from creek_mcp.tools.compile import CompileLLMFactory
+    from creek_mcp.tools.draft import DraftLLMFactory
     from creek_mcp.tools.reflect import _LLM, _LLMFactory
 
 SERVER_NAME = "creek-tools-mcp"
@@ -155,31 +156,47 @@ def _consumer_from_env() -> str:
     return os.environ.get("CREEK_MCP_CONSUMER", "unknown")
 
 
-def _build_draft_llm() -> Callable[[str], str]:
-    """Return the production LLM callable, mirroring ``creek draft``.
+def _build_draft_llm(tier: PrivacyTier) -> Callable[[str], str]:
+    """Return the draft-side LLM callable, routed for *tier* (#958).
 
-    Imported lazily so an absent LLM provider only fails the ``draft``
-    invocation, not the whole server startup. ``state``/``lint``/``mine``
-    must remain callable on hosts without an Anthropic key or running
-    Ollama.
+    Mirrors :func:`_build_compile_llm`: the ``generation`` stage is resolved
+    through the config's :class:`~creek.classify.llm.router.ModelRouter`, so
+    an INTIMATE draft is forced onto the local ``default`` model — or the
+    router raises ``IntimateRoutingError`` rather than egressing the source
+    ids and titles the draft prompt carries. Nothing here re-checks the tier
+    or picks a provider: ``draft_tool`` derives the routing tier from the
+    seed's source fragments and this hands it to the one chokepoint that owns
+    the decision.
+
+    Lazy imports keep the server bootable with no provider configured — only
+    a ``creek.draft`` call then fails, and it fails as a structured refusal.
+    ``state``/``lint``/``mine`` stay callable on hosts with neither an
+    Anthropic key nor a running Ollama.
+
+    Args:
+        tier: The routing tier ``draft_tool`` computed from the caller's
+            ceiling and the seed's source fragments' own classifications.
+
+    Returns:
+        A prompt → completion-text callable bound to the resolved provider.
+
+    Raises:
+        RuntimeError: When the resolved provider is unavailable, or — as
+            :class:`~creek.classify.llm.router.IntimateRoutingError`, a
+            subclass — when intimate content has no local backend to fall
+            back to. ``draft_tool`` turns either into a refusal.
     """
-    from creek.classify.llm import LLMClassifier
+    from creek.classify.llm.providers import build_provider
 
-    config = load_config()
-    # ``config.llm`` is an ``LLMRoutingConfig``; ``LLMClassifier`` declares a
-    # plain ``LLMConfig``. Correcting the type here means choosing a concrete
-    # per-stage model inline — which is precisely the decision
-    # :class:`~creek.classify.llm.router.ModelRouter` owns, and doing it here
-    # would stand up a second provider path with no Intimate-never-cloud gate
-    # on it. Left suppressed until #958 rewires this tool through the router.
-    classifier = LLMClassifier(config.llm)  # type: ignore[arg-type]  # Issue #958
-    if not classifier.available:
+    cfg = load_config().model_router.resolve("generation", tier)
+    provider = build_provider(cfg)
+    if not provider.available:
         msg = (
-            "LLM provider unavailable; cannot generate draft. "
+            "LLM provider unavailable for draft. "
             "Check Ollama or ANTHROPIC_API_KEY configuration."
         )
         raise RuntimeError(msg)
-    return classifier.invoke_prompt
+    return lambda prompt: provider.complete(prompt).text
 
 
 def _build_compile_llm(tier: PrivacyTier) -> CompileLLM:
@@ -254,7 +271,7 @@ def _build_reflect_llm_factory() -> _LLMFactory:
 def build_server(
     *,
     vault_path: Path | None = None,
-    draft_llm_factory: Callable[[], Callable[[str], str]] | None = None,
+    draft_llm_factory: DraftLLMFactory | None = None,
     compile_llm_factory: CompileLLMFactory | None = None,
     reflect_llm_factory: Callable[[], _LLMFactory] | None = None,
     token_verifier: TokenVerifier | None = None,
@@ -265,9 +282,10 @@ def build_server(
         vault_path: Override vault root. Defaults to
             ``load_config().vault_path`` so the MCP surface honours the
             same configuration as the CLI.
-        draft_llm_factory: Optional factory for the draft LLM. The
-            factory is invoked lazily so only ``creek.draft`` needs an
-            LLM provider.
+        draft_llm_factory: Optional tier-keyed factory for the draft LLM —
+            ``factory(tier)``. Passed straight to ``creek.draft``, which
+            invokes it lazily (and only once it knows which seed it is
+            drafting), so only ``creek.draft`` needs an LLM provider.
         compile_llm_factory: Optional tier-keyed factory for the compile
             LLM — ``factory(tier)``. Passed straight to ``creek.compile``,
             which invokes it lazily (and only after its source-tier gate),
@@ -416,7 +434,7 @@ def build_server(
         """Generate an essay draft from a mined idea."""
         return draft_tool(
             vault_path=vault,
-            llm=factory(),
+            llm_factory=factory,
             privacy_tier_ceiling=privacy_tier_ceiling,
             phase=phase,
             index=index,

--- a/creek-tools/creek_mcp/source_tiers.py
+++ b/creek-tools/creek_mcp/source_tiers.py
@@ -1,0 +1,163 @@
+"""Shared, fail-closed source-tier survey for the MCP tools (#958).
+
+This is the **one place** an MCP tool reads a fragment's classified
+privacy tier in order to route an LLM call, so two tools can never
+disagree about the same file. ``creek.compile`` (#848/#928) and
+``creek.draft`` (#958) both name a set of source fragments, both put
+those fragments' ids and titles into a prompt, and both must therefore
+answer "how sensitive is this call?" the same way. A divergence would
+mean one tool egressing a fragment the other keeps local — which is not
+a cosmetic inconsistency but a leak.
+
+The walk deliberately goes through
+:func:`creek.vault.reader.iter_vault_fragments` — the same loader
+``creek.compile.engine._load_fragments_for_compile`` uses — so the set of
+files this survey inspects and the set the compile engine would actually
+roll up are identical *by construction*. A bespoke ``frontmatter.load``
+scan would diverge: :func:`creek.vault.reader.try_load_fragment` rejects
+files whose ``type`` is not ``fragment`` and files that fail
+:class:`~creek.models.Fragment` schema validation, both of which a raw
+scan happily reads. That divergence would create a class of file one side
+sees and the other does not — precisely the bug class the compile gate
+exists to prevent. A file the shared loader skips (unreadable,
+non-fragment, schema-invalid) is invisible to every caller here, and so
+fails closed to whatever the caller does with an unresolved id.
+
+Nothing in this module decides *admission*, and nothing here refuses: it
+only reports tiers and reduces them. Refusing on them, and choosing what
+an *empty* id list means, stay with the callers
+(:mod:`creek_mcp.tier_ceiling`, :mod:`creek_mcp.tools.compile`,
+:mod:`creek_mcp.tools.draft`).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from creek.models import PrivacyTier
+from creek.vault.reader import iter_vault_fragments
+from creek_mcp.tier_ceiling import tier_sensitivity
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from pathlib import Path
+
+    from creek.models import Fragment
+
+
+def fragment_tier(fragment: Fragment, raw: dict[str, object]) -> PrivacyTier:
+    """Return *fragment*'s tier, failing closed when the key is absent.
+
+    :class:`~creek.models.Fragment` defaults a *missing* ``privacy_tier``
+    to ``unclassified``, which ranks alongside ``open`` and so would be
+    admitted at every ceiling. Reading the tier off the model alone
+    would therefore fail **open** on exactly the file whose tier nobody
+    can vouch for — a hand-edited or legacy fragment. The raw
+    frontmatter is consulted because it is the only place the two cases
+    are still distinguishable once the model has applied its default.
+
+    This mirrors :func:`creek_mcp.tools.reflect._fragment_tier` (#847)
+    and :func:`creek.classify.privacy_filter.tier_of`, both of which
+    treat an absent tier as ``intimate``. Every MCP tool must agree with
+    them: two MCP tools that disagree about the same file is precisely the
+    divergence this module's shared-loader design exists to prevent.
+
+    A fragment carrying an *explicit* ``privacy_tier: unclassified`` —
+    what every pipeline-written, not-yet-classified fragment has — is
+    untouched here and stays admitted at any ceiling. That ranking is
+    deliberate policy owned by ``creek_mcp.tier_ceiling._TIER_RANK``
+    (#923), not by this fail-closed path.
+
+    Args:
+        fragment: The validated fragment as loaded by the shared reader.
+        raw: The file's raw frontmatter, before model defaults applied.
+
+    Returns:
+        ``PrivacyTier.INTIMATE`` when ``privacy_tier`` is absent from
+        *raw*, else the fragment's own classified tier.
+    """
+    if "privacy_tier" not in raw:
+        return PrivacyTier.INTIMATE
+    return fragment.privacy_tier
+
+
+def source_tiers(vault_path: Path, fragment_ids: Iterable[str]) -> list[PrivacyTier]:
+    """Return the tiers of the *fragment_ids* that resolve, in one vault walk.
+
+    Exactly one pass of :func:`creek.vault.reader.iter_vault_fragments`
+    over ``<vault>/01-Fragments``, filtered by an id **set** so a caller
+    naming a thousand ids still pays one walk of the corpus rather than a
+    thousand.
+
+    **The walk never short-circuits, and that property is load-bearing.**
+    ``iter_vault_fragments`` materialises the whole directory into a list
+    before returning, so the rglob + parse cost is paid in full before the
+    filter below runs at all; the filter then runs to completion,
+    collecting every requested fragment's tier before the caller decides
+    anything. The cost of a call is therefore uniform *by construction*,
+    not by accident of iteration order — which is what stops
+    ``creek.compile``'s deliberately content-free above-ceiling refusal
+    (``creek_mcp.tools.compile._ABOVE_CEILING_REASON``) from leaking
+    *where* the offending fragment sits through timing. Contrast
+    ``creek_mcp.tools.reflect._resolve_entry``, which walks a raw lazy
+    ``rglob`` and returns at the match: a genuine timing channel, which
+    the comment there correctly records. Switching this function to a lazy
+    loader would open that same channel for every caller at once, so it
+    must be re-analysed here before it is done.
+
+    Args:
+        vault_path: Vault root; fragments are read from ``01-Fragments``.
+        fragment_ids: The ids whose tiers the caller needs. Duplicates
+            collapse, and an id that does not resolve is simply absent
+            from the result rather than an error — what "missing" means is
+            the caller's policy, not this module's.
+
+    Returns:
+        One :class:`~creek.models.PrivacyTier` per *resolved* id, in vault
+        walk order. The list is shorter than *fragment_ids* whenever an id
+        does not resolve, and an **empty list is ambiguous**: it means
+        either "nothing was asked for" or "nothing asked for resolved".
+        Those two cases must route differently, so a caller that cannot
+        tell them apart from the result alone has to separate them before
+        calling (``creek.draft``) or fail closed to
+        :attr:`~creek.models.PrivacyTier.INTIMATE` (``creek.compile``).
+    """
+    requested = set(fragment_ids)
+    return [
+        fragment_tier(fragment, raw)
+        for _path, fragment, _body, raw in iter_vault_fragments(
+            vault_path / "01-Fragments",
+        )
+        if fragment.id in requested
+    ]
+
+
+def max_source_tier(tiers: Iterable[PrivacyTier]) -> PrivacyTier:
+    """Return the most sensitive tier in *tiers*, failing closed when empty.
+
+    The fail-closed reduction over a :func:`source_tiers` result, kept
+    here rather than repeated at each call site. Both callers were
+    spelling out the same ``max(..., key=tier_sensitivity,
+    default=INTIMATE)`` — and a reduction that two tools write
+    separately is a reduction two tools can come to disagree about,
+    which is the whole failure mode this module exists to prevent.
+
+    Sensitivity is ranked by :func:`creek_mcp.tier_ceiling.tier_sensitivity`,
+    the single ranking the MCP surface uses for both admission and
+    routing, so "most sensitive" cannot mean one thing here and another
+    at the gate.
+
+    Args:
+        tiers: The resolved tiers, typically straight from
+            :func:`source_tiers`.
+
+    Returns:
+        The most sensitive tier present, or
+        :attr:`~creek.models.PrivacyTier.INTIMATE` when *tiers* is empty.
+        Empty means no requested id resolved, and with no evidence about
+        what a call would carry the safe assumption is the worst one. A
+        caller for which "empty" can also mean "nothing was asked for"
+        must separate that case out *before* calling — see
+        :func:`creek_mcp.tools.draft._source_routing_tier`.
+    """
+    return max(tiers, key=tier_sensitivity, default=PrivacyTier.INTIMATE)

--- a/creek-tools/creek_mcp/tools/compile.py
+++ b/creek-tools/creek_mcp/tools/compile.py
@@ -54,14 +54,12 @@ import hashlib
 from typing import TYPE_CHECKING, Any, Final, NamedTuple, Protocol, cast
 
 from creek.compile.engine import TARGET_KINDS, compile_to_vault
-from creek.models import PrivacyTier
-from creek.vault.reader import iter_vault_fragments
 from creek_mcp.audit import MCPAuditLog
+from creek_mcp.source_tiers import max_source_tier, source_tiers
 from creek_mcp.tier_ceiling import (
     TierCeiling,
     refusal_response,
     routing_tier,
-    tier_sensitivity,
     write_tier_allowed,
 )
 
@@ -69,7 +67,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from creek.compile.engine import CompileLLM
-    from creek.models import CompileTargetKind, Fragment
+    from creek.models import CompileTargetKind, PrivacyTier
 
 TOOL_NAME = "creek.compile"
 
@@ -90,18 +88,15 @@ TOOL_NAME = "creek.compile"
 #   from a single admitted parent id a caller can enumerate every child id with
 #   no knowledge of the content. The id space around known content IS sweepable;
 #   only a blind sweep of the full 48-bit space is infeasible.
-# - *Probe cost does NOT leak where the offending fragment sits.* Worth stating
-#   because the symmetry is accidental and a refactor could destroy it:
-#   ``iter_vault_fragments`` materialises the whole directory into a list before
-#   returning, so the rglob + parse cost is paid in full before
-#   ``_survey_sources``'s loop begins. The loop no longer short-circuits
-#   at all — it runs to completion, collecting every requested fragment's tier
-#   before anything is decided — so the probe cost is now uniform *by
-#   construction* rather than resting on that accident. Unlike
-#   ``reflect.py::_resolve_entry``, which walks a raw lazy ``rglob`` and returns
-#   at the match — a genuine timing channel that comment correctly records. If
-#   this gate is ever switched to a lazy loader (see the load-once follow-up),
-#   that channel appears here too and must be re-analysed.
+# - *Probe cost does NOT leak where the offending fragment sits.* The walk that
+#   makes that true left this module with the code it describes (#958): it is
+#   now ``creek_mcp.source_tiers.source_tiers``, whose docstring carries the
+#   full analysis — the loader materialises the whole directory before
+#   returning and the id filter runs to completion, so the cost of a probe is
+#   uniform *by construction* rather than resting on an accident of iteration
+#   order. The reasoning moved rather than being dropped because the property
+#   is now shared: switching that one function to a lazy loader would re-open
+#   the timing channel here and in ``creek.draft`` at the same time.
 #
 # Accepted because the real control is the audit trail, not id entropy: every
 # True probe appends a ``creek.compile`` entry distinguishable from a success
@@ -141,46 +136,11 @@ def _fingerprint(path: Path) -> str | None:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _tier_of(fragment: Fragment, raw: dict[str, object]) -> PrivacyTier:
-    """Return *fragment*'s tier, failing closed when the key is absent.
-
-    :class:`~creek.models.Fragment` defaults a *missing* ``privacy_tier``
-    to ``unclassified``, which ranks alongside ``open`` and so would be
-    admitted at every ceiling. Reading the tier off the model alone
-    would therefore fail **open** on exactly the file whose tier nobody
-    can vouch for — a hand-edited or legacy fragment. The raw
-    frontmatter is consulted because it is the only place the two cases
-    are still distinguishable once the model has applied its default.
-
-    This mirrors :func:`creek_mcp.tools.reflect._fragment_tier` (#847)
-    and :func:`creek.classify.privacy_filter.tier_of`, both of which
-    treat an absent tier as ``intimate``. Compile must agree with them:
-    two MCP tools that disagree about the same file is precisely the
-    divergence this module's shared-loader design exists to prevent.
-
-    A fragment carrying an *explicit* ``privacy_tier: unclassified`` —
-    what every pipeline-written, not-yet-classified fragment has — is
-    untouched here and stays admitted at any ceiling. That ranking is
-    deliberate policy owned by ``creek_mcp.tier_ceiling._TIER_RANK``
-    (#923), not by this fail-closed path.
-
-    Args:
-        fragment: The validated fragment as loaded by the shared reader.
-        raw: The file's raw frontmatter, before model defaults applied.
-
-    Returns:
-        ``PrivacyTier.INTIMATE`` when ``privacy_tier`` is absent from
-        *raw*, else the fragment's own classified tier.
-    """
-    if "privacy_tier" not in raw:
-        return PrivacyTier.INTIMATE
-    return fragment.privacy_tier
-
-
 class _SourceGate(NamedTuple):
     """The two signals one walk over the requested source fragments yields.
 
-    Both are derived from the same :func:`_tier_of` reading of the same
+    Both are derived from the same
+    :func:`creek_mcp.source_tiers.fragment_tier` reading of the same
     file, so admission and routing can never disagree about a fragment.
 
     Attributes:
@@ -271,17 +231,13 @@ def _survey_sources(
         names the rank. That invariant is the one new leak surface returning
         the pair creates, so it is stated here rather than left implied.
     """
-    requested = set(fragment_ids)
-    tiers = [
-        _tier_of(fragment, raw)
-        for _path, fragment, _body, raw in iter_vault_fragments(
-            vault_path / "01-Fragments",
-        )
-        if fragment.id in requested
-    ]
+    # Both signals come off one shared survey (#958) so ``creek.compile`` and
+    # ``creek.draft`` can never read the same file's tier two different ways —
+    # and the fail-closed reduction is shared for the same reason.
+    tiers = source_tiers(vault_path, fragment_ids)
     return _SourceGate(
         above_ceiling=any(not write_tier_allowed(tier, ceiling) for tier in tiers),
-        max_tier=max(tiers, key=tier_sensitivity, default=PrivacyTier.INTIMATE),
+        max_tier=max_source_tier(tiers),
     )
 
 

--- a/creek-tools/creek_mcp/tools/draft.py
+++ b/creek-tools/creek_mcp/tools/draft.py
@@ -1,8 +1,69 @@
 """``creek.draft`` MCP tool — generate an essay draft from a mined idea.
 
-The wrapper accepts an injectable ``llm`` callable so tests can
-exercise it without hitting a real model. In production the server
-bootstrap injects the same Ollama/Anthropic adapter the CLI uses.
+The wrapper accepts an injectable, **tier-keyed** ``llm_factory`` so
+tests can exercise it without hitting a real model. In production the
+server bootstrap injects a factory that resolves the provider through
+:class:`creek.classify.llm.router.ModelRouter`, so an intimate draft is
+forced onto the local model — or refused — instead of egressing (#958).
+This module never picks a provider itself; it derives the routing tier
+and hands it over.
+
+Four properties of that routing rule, none of them visible at the call
+site, all of them load-bearing:
+
+- **The tier is derived from the seed's *source fragments* only.** The
+  ``## Threads`` and ``## Eddies`` prompt sections render compiled-page
+  bodies and frontmatter descriptions with **no tier filtering at all**
+  (``creek.generate.drafts.DraftGenerator._compose_thread_section`` /
+  ``._compose_eddy_section``, fed by
+  :func:`creek.generate.drafts._load_threads_by_id` /
+  :func:`creek.generate.drafts._load_eddies_by_id`), so whatever reaches
+  the model through those sections does **not** raise the routing tier.
+  That is a pre-existing residual in the #931 family, deliberately out
+  of scope for #958, and stated here rather than left for the next
+  reader to rediscover.
+- **The ceiling alone is not sufficient** — which is the whole reason
+  the sources are surveyed at all.
+  :func:`creek.generate.drafts._render_fragment_section` emits
+  ``### {fid}: {fragment.title}`` unconditionally, and under an ``open``
+  ceiling :func:`creek.classify.privacy_filter.filter_fragments_by_tier`
+  replaces a *personal* fragment's body with
+  ``[Personal-tier summary: {title}]`` rather than dropping the fragment
+  — so a personal fragment's id and title reach the prompt even though
+  its body was redacted. Routing on ``routing_tier(ceiling, None)``
+  would hand those to the cloud ``generation`` stage on the caller's
+  say-so. ``intimate`` fragments, by contrast, are dropped outright at
+  ceilings below intimate, so the personal case is the one that makes
+  the survey necessary.
+- **The derived tier never leaves this module.** It must not appear in
+  any response, refusal reason, or audit payload: echoing it would hand
+  the caller a per-call tier-classification oracle over the corpus — the
+  same invariant :mod:`creek_mcp.tools.compile` documents for its
+  ``max_tier``. The audit append records only the caller's own declared
+  ceiling, and an ``ok`` response carries no tier at all.
+
+  One narrow exception, stated rather than left implied because the
+  claim above would otherwise be false: when the router refuses, the
+  refusal reason is
+  :class:`~creek.classify.llm.router.IntimateRoutingError`'s own message,
+  which names the word "Intimate" and the configured cloud provider.
+  That is a one-bit signal, and an *ambiguous* one — the fail-closed
+  default routes a named-but-unresolved id as ``INTIMATE`` too, so the
+  message cannot distinguish "a source really is intimate" from "an id
+  did not resolve". It is also unreachable on any correctly-configured
+  vault: it fires only when ``generation`` **and** ``default`` are both
+  cloud, i.e. when no intimate content could be processed at all. This
+  is the same residual ``creek.compile`` already accepts for the same
+  error, and it is deliberately not widened here.
+- **ACCEPTED RESIDUAL RISK (#876/#923).** An *explicit*
+  ``privacy_tier: unclassified`` ranks cloud-eligible via
+  :func:`creek_mcp.tier_ceiling.tier_sensitivity`, while
+  ``filter_fragments_by_tier`` treats the same value as *personal* for
+  redaction. Such a fragment is therefore redacted as personal yet
+  routed as open. The asymmetry is pre-existing, is owned by
+  ``creek_mcp.tier_ceiling._TIER_RANK``, and is shared with
+  ``creek.compile``; it is not repaired here, because a fix belongs in
+  the one ranking both tools read rather than in this wrapper.
 """
 
 from __future__ import annotations
@@ -11,16 +72,20 @@ from typing import TYPE_CHECKING, Any, Protocol
 
 from creek.generate.drafts import DraftGenerator
 from creek.generate.mining import IdeaMiner
-from creek.models import Phase
+from creek.models import Phase, PrivacyTier
 from creek_mcp.audit import MCPAuditLog
+from creek_mcp.source_tiers import max_source_tier, source_tiers
 from creek_mcp.tier_ceiling import (
     TierCeiling,
     refusal_response,
+    routing_tier,
     to_privacy_override,
 )
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from creek.generate.mining import IdeaSeed
 
 TOOL_NAME = "creek.draft"
 
@@ -38,10 +103,85 @@ class _DraftLLM(Protocol):
         """Return the completion for *prompt*."""
 
 
+class DraftLLMFactory(Protocol):
+    """Tier-keyed builder for the prompt → draft-body LLM client.
+
+    ``factory(tier)`` returns the client for a call carrying *tier*
+    content. The production factory resolves through
+    :class:`creek.classify.llm.router.ModelRouter`, so an ``INTIMATE``
+    draft is forced onto the local model — or refused — rather than
+    egressing (#958); this module never picks a provider itself, it only
+    derives the routing tier (:func:`_source_routing_tier`) and hands it
+    over.
+
+    The factory is invoked lazily so an unconfigured LLM provider only
+    fails an actual ``creek.draft`` invocation, not server startup — and
+    not at all on the paths that return before a prompt exists (no idea
+    seeds, out-of-range index). The server bootstrap supplies a
+    production factory; tests pass a stub.
+    """
+
+    def __call__(self, tier: PrivacyTier) -> _DraftLLM: ...
+
+
+def _source_routing_tier(
+    vault_path: Path, idea: IdeaSeed, ceiling: TierCeiling
+) -> PrivacyTier:
+    """Return the tier this draft's LLM call must be keyed with (#958).
+
+    Split out of :func:`draft_tool` to keep that function within the
+    complexity budget, and because the empty-sources branch below needs
+    more justification than a call site can carry.
+
+    **An empty ``source_fragments`` is not the same as "nothing
+    resolved".** The distinction has to be made *before* the survey runs,
+    because :func:`creek_mcp.source_tiers.source_tiers` returns an empty
+    list for both cases and the two must route differently:
+
+    - ``source_fragments == ()`` means there is no vault content in this
+      prompt at all. ``UNEXPLORED_ONTOLOGY`` is the only seed strategy
+      that produces it (``creek.generate.mining._seed_from_ontology_tuple``),
+      and it is also the only one with empty ``threads`` *and* empty
+      ``eddies`` — its title and description are built purely from
+      ontology enum labels. Failing closed to ``INTIMATE`` here would
+      push every unexplored-ontology draft onto the local model for no
+      privacy gain whatsoever, so the ceiling alone decides.
+    - Sources were named but none resolved: fail closed to ``INTIMATE``,
+      mirroring ``creek_mcp.tools.compile._survey_sources``. With no
+      evidence about what the call would carry, the safe assumption is
+      the worst one.
+
+    Reconciliation goes through the shared
+    :func:`creek_mcp.tier_ceiling.routing_tier` rather than a bespoke
+    ``max``: it takes the more sensitive of the ceiling-derived tier and
+    the content tier, which is what makes the result uncheatable from
+    outside. A caller can neither declare a low ceiling to win cloud
+    routing for personal sources, nor pick low-tier sources to win it
+    under a broad ceiling.
+
+    Args:
+        vault_path: Vault root; source fragments are read from
+            ``01-Fragments`` by the shared survey.
+        idea: The mined seed about to be drafted. Only its
+            ``source_fragments`` are consulted — see the module docstring
+            for why its ``threads`` / ``eddies`` do not raise the tier.
+        ceiling: The caller's declared ceiling.
+
+    Returns:
+        The :class:`~creek.models.PrivacyTier` to key the LLM factory
+        with. It is a routing signal only and **must never** be echoed
+        back to the caller in any form.
+    """
+    if not idea.source_fragments:
+        return routing_tier(ceiling, None)
+    tiers = source_tiers(vault_path, idea.source_fragments)
+    return routing_tier(ceiling, max_source_tier(tiers))
+
+
 def draft_tool(
     *,
     vault_path: Path,
-    llm: _DraftLLM,
+    llm_factory: DraftLLMFactory,
     skills_root: Path | None = None,
     privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
     phase: str = "unclassified",
@@ -53,6 +193,32 @@ def draft_tool(
     The full draft body never enters the response so tier violations
     cannot leak via MCP — callers follow up with ``creek.state.read``
     or open the saved file directly to inspect the body.
+
+    Args:
+        llm_factory: Tier-keyed builder for the draft LLM client;
+            ``llm_factory(tier)`` returns it. Invoked lazily, and only
+            once the seed to be drafted is known, so neither the "no idea
+            seeds" nor the out-of-range-index path spends a provider
+            handshake (or a cloud credential) on a call that never
+            drafts. The tier is the more sensitive of
+            *privacy_tier_ceiling* and the seed's source fragments' own
+            classifications, so the production factory's router forces an
+            intimate draft onto the local model (#958).
+        privacy_tier_ceiling: The caller's ceiling. It bounds which
+            fragments the generator may render (via
+            :func:`creek_mcp.tier_ceiling.to_privacy_override`) *and*
+            contributes to the routing tier, but it is a floor rather
+            than the whole answer — see the module docstring.
+
+    Returns:
+        ``{status, tool, tier_ceiling, ...}`` — ``ok`` with the saved
+        ``draft_path``, ``empty`` when mining surfaced no seeds, or a
+        structured ``refused`` response for an out-of-range *index*, an
+        unavailable provider, the router's
+        :class:`~creek.classify.llm.router.IntimateRoutingError` when
+        intimate sources have no local backend to fall back to, or a
+        generator ``RuntimeError``. No refusal reason names a fragment or
+        its tier.
     """
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
@@ -80,6 +246,24 @@ def draft_tool(
             reason=f"index {index} out of range (0..{len(seeds) - 1})",
         )
     idea = seeds[index]
+    # Deriving the tier and building the client sit here — below both
+    # non-drafting exits, above anything that touches a model — so a call that
+    # produces no prompt never reaches a provider.
+    tier = _source_routing_tier(vault_path, idea, privacy_tier_ceiling)
+    try:
+        llm = llm_factory(tier)
+    except RuntimeError as exc:
+        # ``IntimateRoutingError`` is a ``RuntimeError`` subclass, so this is
+        # what turns "intimate content and no local backend configured" into a
+        # structured refusal rather than an exception across the MCP boundary
+        # (#958). A plainly unavailable provider takes the same path. Kept as
+        # its own narrow ``try`` so ``generator`` below cannot be
+        # possibly-unbound.
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=privacy_tier_ceiling,
+            reason=str(exc),
+        )
     generator = DraftGenerator(
         llm=llm,
         skills_root=skills_dir,

--- a/creek-tools/tests/test_classify_engine.py
+++ b/creek-tools/tests/test_classify_engine.py
@@ -1307,7 +1307,7 @@ def test_run_classify_assigns_the_exact_privacy_tier_per_fragment(
 def test_run_classify_never_persists_unclassified_tier(tmp_path: Path) -> None:
     """No file under ``01-Fragments`` retains ``privacy_tier: unclassified``.
 
-    The #934 pin. ``creek_mcp.tools.compile._tier_of`` and
+    The #934 pin. ``creek_mcp.source_tiers.fragment_tier`` and
     ``creek_mcp.tools.reflect._fragment_tier`` fail closed to INTIMATE only
     when the ``privacy_tier`` key is **absent**; an *explicit*
     ``unclassified`` is admitted at every ceiling. So a vault full of

--- a/creek-tools/tests/test_mcp_read_gate.py
+++ b/creek-tools/tests/test_mcp_read_gate.py
@@ -414,7 +414,7 @@ def registered_tools(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Tool
         (vault / sub).mkdir(parents=True, exist_ok=True)
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     tools = asyncio.run(server.list_tools())
     return {tool.name: tool for tool in tools}

--- a/creek-tools/tests/test_mcp_remote.py
+++ b/creek-tools/tests/test_mcp_remote.py
@@ -225,7 +225,7 @@ def test_remote_call_above_personal_is_refused_before_dispatch(
     )
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     result = _structured(
         asyncio.run(server.call_tool("creek.wheel", {"privacy_tier_ceiling": ceiling}))
@@ -247,7 +247,7 @@ def test_remote_call_at_or_below_personal_dispatches(
     )
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     result = _structured(
         asyncio.run(server.call_tool("creek.wheel", {"privacy_tier_ceiling": ceiling}))
@@ -266,7 +266,7 @@ def test_remote_call_is_audited_under_token_consumer(
     )
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     asyncio.run(server.call_tool("creek.wheel", {"privacy_tier_ceiling": "open"}))
 
@@ -287,7 +287,7 @@ def test_local_stdio_call_is_not_capped(
     monkeypatch.setattr(server_mod, "_current_access_token", lambda: None)
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     result = _structured(
         asyncio.run(
@@ -322,7 +322,7 @@ def test_streamable_http_rejects_unauthenticated_request(vault: Path) -> None:
     """A POST with no / wrong bearer is refused 401 before any tool runs."""
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
         token_verifier=ConsumerTokenVerifier({"adepthood": "secret123"}),
     )
     client = TestClient(server.streamable_http_app())
@@ -358,7 +358,7 @@ def _network_server(vault: Path, token: str) -> FastMCP:
     """
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
         token_verifier=ConsumerTokenVerifier({"adepthood": token}),
     )
     server.settings.transport_security = TransportSecuritySettings(

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -16,7 +16,7 @@ from creek_mcp.remote_auth import CONSUMER_TOKENS_ENV
 from creek_mcp.server import SERVER_NAME, build_server
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
 
@@ -78,7 +78,7 @@ def test_build_server_returns_fastmcp_instance(vault: Path) -> None:
     """The bootstrap returns a configured :class:`FastMCP` instance."""
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     assert server.name == SERVER_NAME
 
@@ -87,7 +87,7 @@ def test_build_server_registers_all_tools(vault: Path) -> None:
     """All FEAT-010 read + FEAT-011 write tools surface via ``list_tools``."""
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     tools = asyncio.run(server.list_tools())
     names = {tool.name for tool in tools}
@@ -103,7 +103,7 @@ def test_call_tool_handshake_reflects_registered_tools(vault: Path) -> None:
     """
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     registered = {tool.name for tool in asyncio.run(server.list_tools())}
     result = asyncio.run(
@@ -132,7 +132,7 @@ def test_call_tool_reflect_returns_verbatim_notes(vault: Path) -> None:
     payload = '{"notes": [' + note + "]}"
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
         reflect_llm_factory=lambda: lambda tier: lambda prompt: payload,
     )
     result = asyncio.run(
@@ -156,7 +156,7 @@ def test_call_tool_reflect_escalates_on_acute_distress(vault: Path) -> None:
     """
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
         reflect_llm_factory=lambda: lambda tier: lambda prompt: '{"notes": []}',
     )
     result = asyncio.run(
@@ -181,7 +181,7 @@ def test_call_tool_journal_ingests_entry_idempotently(vault: Path) -> None:
     """
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     payload = {
         "content": "A registered journal entry.",
@@ -209,7 +209,7 @@ def test_call_tool_wheel_returns_complete_frequency_balance(vault: Path) -> None
     """
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     result = asyncio.run(
         server.call_tool("creek.wheel", {"privacy_tier_ceiling": "open"}),
@@ -230,7 +230,7 @@ def test_call_tool_save_through_mcp(vault: Path) -> None:
         (vault.joinpath(*relparts)).mkdir(parents=True, exist_ok=True)
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     result = asyncio.run(
         server.call_tool(
@@ -258,7 +258,7 @@ def test_every_tool_requires_privacy_tier_ceiling_parameter(vault: Path) -> None
     """
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     tools = asyncio.run(server.list_tools())
     for tool in tools:
@@ -274,7 +274,7 @@ def test_purge_tools_require_auth_token_parameter(vault: Path) -> None:
     """FEAT-012: every ``creek.purge.*`` tool exposes an ``auth_token`` slot."""
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     tools = asyncio.run(server.list_tools())
     purge_tools = [t for t in tools if t.name.startswith("creek.purge.")]
@@ -294,7 +294,7 @@ def test_call_tool_state_read_through_mcp(vault: Path) -> None:
     )
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     result = asyncio.run(
         server.call_tool("creek.state.read", {"privacy_tier_ceiling": "open"}),
@@ -309,7 +309,7 @@ def test_call_tool_state_render_through_mcp(vault: Path) -> None:
     """The render path is reachable via ``call_tool``."""
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     result = asyncio.run(
         server.call_tool(
@@ -325,7 +325,7 @@ def test_call_tool_lint_through_mcp(vault: Path) -> None:
     """The lint path is reachable via ``call_tool`` and returns ``checks``."""
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     result = asyncio.run(
         server.call_tool("creek.lint", {"privacy_tier_ceiling": "open"}),
@@ -339,7 +339,7 @@ def test_call_tool_mine_through_mcp(vault: Path) -> None:
     """The mine path is reachable via ``call_tool``."""
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     result = asyncio.run(
         server.call_tool(
@@ -355,7 +355,7 @@ def test_call_tool_draft_through_mcp(vault: Path) -> None:
     """The draft path is reachable via ``call_tool``."""
     server = build_server(
         vault_path=vault,
-        draft_llm_factory=lambda: lambda prompt: "ignored",
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
     )
     result = asyncio.run(
         server.call_tool(
@@ -378,55 +378,20 @@ def test_build_server_falls_back_to_load_config(
         vault_path = vault
 
     monkeypatch.setattr("creek_mcp.server.load_config", lambda: _StubConfig())
-    server = build_server(draft_llm_factory=lambda: lambda prompt: "x")
+    server = build_server(draft_llm_factory=lambda tier: lambda prompt: "x")
     assert server.name == SERVER_NAME
 
 
-def test_build_draft_llm_raises_when_classifier_unavailable(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The production factory bubbles a clear error when no LLM is reachable."""
-    from creek_mcp import server as server_module
-
-    class _UnavailableClassifier:
-        available = False
-
-        def __init__(self, _config: object) -> None:
-            pass
-
-        def invoke_prompt(self, prompt: str) -> str:  # pragma: no cover
-            return ""
-
-    monkeypatch.setattr(
-        "creek.classify.llm.LLMClassifier",
-        _UnavailableClassifier,
-    )
-    with pytest.raises(RuntimeError, match="LLM provider unavailable"):
-        server_module._build_draft_llm()
-
-
-def test_build_draft_llm_returns_invoke_prompt_when_available(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """When the classifier reports ``available``, the factory returns the callable."""
-    from creek_mcp import server as server_module
-
-    class _AvailableClassifier:
-        available = True
-
-        def __init__(self, _config: object) -> None:
-            pass
-
-        def invoke_prompt(self, prompt: str) -> str:
-            return "drafted body"
-
-    monkeypatch.setattr(
-        "creek.classify.llm.LLMClassifier",
-        _AvailableClassifier,
-    )
-    llm = server_module._build_draft_llm()
-    assert callable(llm)
-    assert llm("hi") == "drafted body"
+# The two ``_build_draft_llm`` unit tests that used to sit here monkeypatched
+# ``creek.classify.llm.LLMClassifier`` with a stub accepting any config, then
+# called the untiered ``_build_draft_llm()``. That stub is what hid #958: the
+# real ``LLMClassifier`` reads ``.provider`` off the ``LLMRoutingConfig`` it is
+# handed and raises ``AttributeError`` on every production call, and the
+# router's Intimate-never-cloud gate was never in the path at all. Both
+# properties they claimed to pin ("returns a usable callable when the provider
+# is available" / "raises a clear RuntimeError when it is not") are asserted
+# against the *routed* factory by
+# ``test_build_draft_llm_routes_by_tier_then_degrades`` below.
 
 
 def test_main_invokes_server_run(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -753,6 +718,174 @@ def test_build_server_wires_the_production_compile_llm_factory(
     # An ``open`` ceiling over ``open`` sources routes to the cloud
     # ``generation`` stage — the router ran, and did not over-restrict.
     assert spy.provider_names == ["anthropic"]
+
+
+# --------------------------------------------------------------------------- #
+# Draft LLM: tier-routed production factory + real wiring (#958)
+# --------------------------------------------------------------------------- #
+
+
+def _open_source_seed(frag_id: str) -> object:
+    """Return an ``IdeaSeed`` whose single source fragment is *frag_id*."""
+    from creek.generate.mining import IdeaSeed, MiningStrategy
+
+    return IdeaSeed(
+        strategy=MiningStrategy.THREAD_TERMINUS,
+        title="Wired seed",
+        source_fragments=(frag_id,),
+        threads=(),
+        eddies=(),
+        frequency_affinity=(),
+        brief_description="brief",
+        score=0.5,
+    )
+
+
+def _patch_draft_miner(monkeypatch: pytest.MonkeyPatch, seed: object) -> None:
+    """Force ``draft_tool``'s ``IdeaMiner`` to surface exactly *seed*.
+
+    A bare fixture vault legitimately mines zero seeds, which would let
+    ``creek.draft`` answer ``status="empty"`` before the LLM factory is ever
+    consulted — and a provider assertion would then pass vacuously.
+    """
+    monkeypatch.setattr(
+        "creek_mcp.tools.draft.IdeaMiner",
+        lambda **kwargs: type(
+            "_Miner",
+            (),
+            {"mine_all": lambda self, vault_path, *, current_phase: [seed]},
+        )(),
+    )
+
+
+def test_build_draft_llm_routes_by_tier_then_degrades(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The draft factory is tier-keyed and honours the router (#958).
+
+    Mirrors :func:`test_build_compile_llm_routes_by_tier_then_degrades`
+    against a *real* :class:`~creek.classify.llm.router.ModelRouter`, so the
+    ``Intimate``-never-cloud redirect under test is the production one and
+    not a stub's opinion.
+
+    Three properties, each of which the pre-fix ``_build_draft_llm``
+    violates: it takes no tier at all, it builds straight from
+    ``load_config().llm`` (never touching the router or ``build_provider``),
+    and it hands that ``LLMRoutingConfig`` to ``LLMClassifier``, which reads
+    ``.provider`` off it — so every production ``creek.draft`` call raises
+    ``AttributeError: 'LLMRoutingConfig' object has no attribute 'provider'``
+    and the tool is dead by accident rather than routed by design.
+    """
+    from creek.models import PrivacyTier
+    from creek_mcp import server as server_mod
+
+    monkeypatch.setattr(server_mod, "load_config", _split_routing_config)
+    spy = _ProviderSpy(text="drafted")
+    _patch_build_provider(monkeypatch, spy)
+
+    # INTIMATE: the cloud ``generation`` stage is redirected to local default.
+    assert server_mod._build_draft_llm(PrivacyTier.INTIMATE)("p") == "drafted"
+    assert spy.provider_names == ["ollama"]
+
+    # OPEN: no redirect, and the ``generation`` stage (not ``default``) wins.
+    assert server_mod._build_draft_llm(PrivacyTier.OPEN)("p") == "drafted"
+    assert spy.provider_names == ["ollama", "anthropic"]
+    assert spy.prompts == ["p", "p"]
+
+    unavailable = _ProviderSpy(available=False)
+    _patch_build_provider(monkeypatch, unavailable)
+    with pytest.raises(RuntimeError) as excinfo:
+        server_mod._build_draft_llm(PrivacyTier.OPEN)
+    assert "unavailable" in str(excinfo.value).lower()
+
+
+def test_build_server_wires_the_production_draft_llm_factory(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``creek.draft`` works with no ``draft_llm_factory`` injected (#958).
+
+    This is the test that would have caught #958. Every other server test
+    injects ``draft_llm_factory``, which is exactly what hid a production
+    factory that raises ``AttributeError`` on its ``LLMClassifier(config.llm)``
+    line — the registered tool was never once exercised against the code path
+    real clients take. So the injection point is deliberately left empty:
+    ``build_server`` must fall back to its own factory, that factory must go
+    through :class:`~creek.classify.llm.router.ModelRouter`, and the tool must
+    complete end to end through the registered FastMCP handler.
+
+    The miner and the generator are stubbed so the call is *guaranteed* to
+    reach the factory. Without that, a bare fixture vault answers
+    ``status="empty"`` (no seeds) or a ``refused`` envelope from the generator
+    scaffolding, the factory is never invoked, and every provider assertion
+    below would hold vacuously while the production path stayed dead.
+    """
+    from creek.generate.drafts import Draft
+    from creek_mcp import server as server_mod
+
+    _write_open_fragment(vault, "frag-open")
+    _patch_draft_miner(monkeypatch, _open_source_seed("frag-open"))
+    monkeypatch.setattr(server_mod, "load_config", _split_routing_config)
+    spy = _ProviderSpy(text="drafted body")
+    _patch_build_provider(monkeypatch, spy)
+
+    recorded: list[Callable[[str], str]] = []
+
+    class _RecordingGenerator:
+        """A ``DraftGenerator`` stand-in recording the llm it was built with."""
+
+        def __init__(self, *, llm: Callable[[str], str], **kwargs: object) -> None:
+            """Record *llm*; the remaining generator options are irrelevant."""
+            del kwargs
+            self._llm = llm
+            recorded.append(llm)
+
+        def generate_draft(self, idea: object, *, vault_path: Path) -> Draft:
+            """Call the recorded llm once and return a minimal draft."""
+            del idea, vault_path
+            self._llm("draft prompt")
+            return Draft(
+                title="Wired seed",
+                body="drafted body",
+                idea_strategy="thread_terminus",
+                source_fragments=("frag-open",),
+                threads=(),
+                eddies=(),
+                skill_stack=(),
+                prompt="draft prompt",
+                generated_date=datetime(2026, 5, 11, tzinfo=UTC),
+            )
+
+        def save_draft(self, draft: Draft, vault_path: Path) -> Path:
+            """Persist a placeholder file so the tool can report its path."""
+            del draft
+            target = vault_path / "07-Voice" / "Drafts" / "2026-05-11-wired.md"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("body", encoding="utf-8")
+            return target
+
+    monkeypatch.setattr("creek_mcp.tools.draft.DraftGenerator", _RecordingGenerator)
+
+    server = build_server(vault_path=vault)
+    result = asyncio.run(
+        server.call_tool(
+            "creek.draft",
+            {"privacy_tier_ceiling": "open", "phase": "unclassified", "index": 0},
+        ),
+    )
+
+    structured = _structured(result)
+    assert structured["status"] == "ok"
+    assert structured["draft_path"] == "07-Voice/Drafts/2026-05-11-wired.md"
+    # An ``open`` ceiling over ``open`` sources routes to the cloud
+    # ``generation`` stage — the router ran, and did not over-restrict.
+    assert spy.provider_names == ["anthropic"]
+    # ...and the callable the generator was handed is the routed provider's,
+    # not some other object that merely happens to be callable.
+    assert spy.prompts == ["draft prompt"]
+    assert len(recorded) == 1
+    assert recorded[0]("second prompt") == "drafted body"
+    assert spy.prompts == ["draft prompt", "second prompt"]
 
 
 # --------------------------------------------------------------------------- #

--- a/creek-tools/tests/test_mcp_tools.py
+++ b/creek-tools/tests/test_mcp_tools.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import frontmatter
 import pytest
 
+from creek.models import PrivacyTier
 from creek_mcp.audit import MCP_AUDIT_RELPATH
 from creek_mcp.tier_ceiling import TierCeiling
 from creek_mcp.tools.author import author_tool
@@ -19,7 +20,7 @@ from creek_mcp.tools.state import state_render_tool
 from creek_mcp.tools.state_read import state_read_tool
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
     from pathlib import Path
 
 
@@ -260,7 +261,7 @@ def test_draft_returns_empty_when_no_seeds(vault: Path) -> None:
     """No seeds → structured empty (not a crash, not a refusal)."""
     result = draft_tool(
         vault_path=vault,
-        llm=lambda prompt: "ignored",
+        llm_factory=lambda tier: lambda prompt: "ignored",
         phase="rising",
     )
     assert result["status"] == "empty"
@@ -271,7 +272,7 @@ def test_draft_writes_audit_entry_for_empty_seed_path(vault: Path) -> None:
     """Audit happens even when the draft cannot proceed (empty seeds)."""
     draft_tool(
         vault_path=vault,
-        llm=lambda prompt: "ignored",
+        llm_factory=lambda tier: lambda prompt: "ignored",
         phase="rising",
         consumer="crawdad",
     )
@@ -325,7 +326,7 @@ def test_draft_success_path_saves_file(
     monkeypatch.setattr("creek_mcp.tools.draft.DraftGenerator", _StubGenerator)
     result = draft_tool(
         vault_path=vault,
-        llm=lambda prompt: "drafted",
+        llm_factory=lambda tier: lambda prompt: "drafted",
         phase="rising",
     )
     assert result["status"] == "ok"
@@ -359,7 +360,7 @@ def test_draft_refuses_when_llm_returns_empty(
     monkeypatch.setattr("creek_mcp.tools.draft.DraftGenerator", _BrokenGenerator)
     result = draft_tool(
         vault_path=vault,
-        llm=lambda prompt: "",
+        llm_factory=lambda tier: lambda prompt: "",
         phase="rising",
     )
     assert result["status"] == "refused"
@@ -388,13 +389,457 @@ def test_draft_refuses_for_out_of_range_index(
     )
     result = draft_tool(
         vault_path=vault,
-        llm=lambda prompt: "x",
+        llm_factory=lambda tier: lambda prompt: "x",
         phase="rising",
         index=99,
     )
     assert result["status"] == "refused"
     assert result["tool"] == "creek.draft"
     assert "out of range" in result["reason"]
+
+
+# ---------------------------------------------------------------------------
+# draft — LLM routing tier (#958)
+# ---------------------------------------------------------------------------
+
+
+class _TierRecordingFactory:
+    """A ``draft_tool`` ``llm_factory`` recording the routing tier it was handed.
+
+    Doubles as the LLM callable it returns, so one object captures both the
+    tier the tool derived (local-vs-cloud routing) and the prompt text that
+    actually reached the model.
+    """
+
+    def __init__(self, body: str = "drafted") -> None:
+        """Start with empty recordings and the canned completion *body*."""
+        self.tiers: list[PrivacyTier] = []
+        self.prompts: list[str] = []
+        self._body = body
+
+    def __call__(self, tier: PrivacyTier) -> Callable[[str], str]:
+        """Record *tier* and return the recording LLM callable."""
+        self.tiers.append(tier)
+        return self._complete
+
+    def _complete(self, prompt: str) -> str:
+        """Record *prompt* and return the canned body."""
+        self.prompts.append(prompt)
+        return self._body
+
+
+def _seed_with_sources(source_fragments: tuple[str, ...]) -> object:
+    """Return an ``IdeaSeed`` naming *source_fragments* as its only sources."""
+    from creek.generate.mining import IdeaSeed, MiningStrategy
+
+    return IdeaSeed(
+        strategy=MiningStrategy.THREAD_TERMINUS,
+        title="Routing seed",
+        source_fragments=source_fragments,
+        threads=(),
+        eddies=(),
+        frequency_affinity=(),
+        brief_description="brief",
+        score=0.5,
+    )
+
+
+def _unexplored_ontology_seed() -> object:
+    """Return the real ``UNEXPLORED_ONTOLOGY`` seed shape: no vault content.
+
+    ``creek/generate/mining.py::_seed_from_ontology_tuple`` (line 1511) builds
+    the title and description purely from ontology enum labels and leaves
+    ``source_fragments`` / ``threads`` / ``eddies`` empty (line 1529), so no
+    fragment, thread, or eddy text reaches the prompt at all.
+    """
+    from creek.generate.mining import IdeaSeed, MiningStrategy
+
+    return IdeaSeed(
+        strategy=MiningStrategy.UNEXPLORED_ONTOLOGY,
+        title="Unexplored: F1 / rising / structural / plain / micro",
+        source_fragments=(),
+        threads=(),
+        eddies=(),
+        frequency_affinity=(),
+        brief_description="a corner you have never inhabited",
+        score=1.0,
+    )
+
+
+def _patch_miner(monkeypatch: pytest.MonkeyPatch, seed: object) -> None:
+    """Force ``draft_tool``'s ``IdeaMiner`` to surface exactly *seed*."""
+    monkeypatch.setattr(
+        "creek_mcp.tools.draft.IdeaMiner",
+        lambda **kwargs: type(
+            "_M",
+            (),
+            {"mine_all": lambda self, vault_path, *, current_phase: [seed]},
+        )(),
+    )
+
+
+def _patch_generator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub ``DraftGenerator`` so routing tests never touch the skill tree.
+
+    The stub still *calls* the llm it was handed once, so a factory that was
+    invoked but whose result was dropped on the floor is still distinguishable
+    from one that was genuinely wired into generation.
+    """
+    from creek.generate.drafts import Draft
+
+    class _Generator:
+        """Minimal generator returning a fixed draft and saving a stub file."""
+
+        def __init__(self, *, llm: Callable[[str], str], **kwargs: object) -> None:
+            """Record the llm callable; other generator options are ignored."""
+            del kwargs
+            self._llm = llm
+
+        def generate_draft(self, idea: object, *, vault_path: Path) -> Draft:
+            """Call the llm once and return a fixed draft."""
+            del idea, vault_path
+            self._llm("stub prompt")
+            return Draft(
+                title="Routing seed",
+                body="drafted",
+                idea_strategy="thread_terminus",
+                source_fragments=(),
+                threads=(),
+                eddies=(),
+                skill_stack=(),
+                prompt="stub prompt",
+                generated_date=datetime(2026, 5, 11, tzinfo=UTC),
+            )
+
+        def save_draft(self, draft: Draft, vault_path: Path) -> Path:
+            """Write a placeholder draft file and return its path."""
+            del draft
+            target = vault_path / "07-Voice" / "Drafts" / "2026-05-11-routing.md"
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("body", encoding="utf-8")
+            return target
+
+    monkeypatch.setattr("creek_mcp.tools.draft.DraftGenerator", _Generator)
+
+
+def test_draft_routes_personal_sources_above_the_open_ceiling(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``personal`` source outranks an ``open`` ceiling for LLM routing.
+
+    ``creek/generate/drafts.py::_render_fragment_section`` (line 2604) emits
+    ``### {fid}: {fragment.title}`` unconditionally, and at an ``open``
+    ceiling ``filter_fragments_by_tier`` replaces a personal body with
+    ``[Personal-tier summary: {title}]`` rather than dropping the fragment —
+    so the personal fragment's id *and* title reach the prompt even though its
+    body was redacted. The ceiling-derived tier alone therefore understates
+    what reaches the model: an implementation that routed on
+    ``routing_tier(ceiling, None)`` would hand personal titles to the cloud
+    ``generation`` stage on the caller's say-so. The tier must be the more
+    sensitive of the ceiling and the sources' own classifications.
+    """
+    _write_fragment(
+        vault,
+        frag_id="frag-personal",
+        title="Personal note",
+        privacy_tier="personal",
+    )
+    _patch_miner(monkeypatch, _seed_with_sources(("frag-personal",)))
+    _patch_generator(monkeypatch)
+    factory = _TierRecordingFactory()
+
+    result = draft_tool(
+        vault_path=vault,
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        phase="rising",
+    )
+
+    assert result["status"] == "ok"
+    assert factory.tiers == [PrivacyTier.PERSONAL]
+    assert factory.prompts == ["stub prompt"]
+
+
+def test_draft_prompt_carries_the_personal_title_at_an_open_ceiling(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The payload check behind the routing rule: the real prompt carries it.
+
+    The sibling routing test asserts what ``draft_tool`` *intends*; this one
+    drives the **real** :class:`~creek.generate.drafts.DraftGenerator` and
+    asserts on the bytes that actually reach the model. Under an ``open``
+    ceiling the personal fragment is not dropped — its body is swapped for
+    ``[Personal-tier summary: {title}]`` and rendered under a
+    ``### {id}: {title}`` heading — so the personal fragment's title is in the
+    prompt string verbatim. Without this, the routing rule rests on a reading
+    of the code rather than on its output.
+    """
+    _write_fragment(
+        vault,
+        frag_id="frag-personal",
+        title="Personal note about my marriage",
+        privacy_tier="personal",
+        body="the private body that must not appear",
+    )
+    _patch_miner(monkeypatch, _seed_with_sources(("frag-personal",)))
+    skills_root = vault / "empty-skills"
+    skills_root.mkdir()
+    factory = _TierRecordingFactory(body="drafted body")
+
+    result = draft_tool(
+        vault_path=vault,
+        llm_factory=factory,
+        skills_root=skills_root,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        phase="rising",
+    )
+
+    assert result["status"] == "ok"
+    assert len(factory.prompts) == 1
+    prompt = factory.prompts[0]
+    assert "Personal note about my marriage" in prompt
+    assert "[Personal-tier summary: " in prompt
+    assert "the private body that must not appear" not in prompt
+    assert factory.tiers == [PrivacyTier.PERSONAL]
+
+
+def test_draft_routes_intimate_sources_local_under_an_all_ceiling(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ``intimate`` source routes INTIMATE, which the router forces local.
+
+    ``ALL`` already maps to ``INTIMATE`` via ``CEILING_ROUTING_TIER``, so this
+    pins the whole chain end to end: the tool must key the factory with a
+    :class:`~creek.models.PrivacyTier` at all (the pre-fix factory takes no
+    tier), and it must be the intimate one so
+    :class:`~creek.classify.llm.router.ModelRouter` redirects the cloud
+    ``generation`` stage onto the local ``default`` — or refuses.
+    """
+    _write_fragment(
+        vault,
+        frag_id="frag-intimate",
+        title="Intimate note",
+        privacy_tier="intimate",
+    )
+    _patch_miner(monkeypatch, _seed_with_sources(("frag-intimate",)))
+    _patch_generator(monkeypatch)
+    factory = _TierRecordingFactory()
+
+    result = draft_tool(
+        vault_path=vault,
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.ALL,
+        phase="rising",
+    )
+
+    assert result["status"] == "ok"
+    assert factory.tiers == [PrivacyTier.INTIMATE]
+
+
+def test_draft_fails_closed_when_no_named_source_resolves(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A seed whose named sources do not resolve routes INTIMATE, not OPEN.
+
+    Mirrors ``compile``'s ``max(..., default=PrivacyTier.INTIMATE)``: with no
+    evidence about what the call would carry, the safe assumption is the worst
+    one. The vault deliberately holds an unrelated ``open`` fragment, so an
+    implementation that took the maximum over *every* fragment in the vault
+    (rather than over the seed's named sources) would answer ``OPEN`` here and
+    fail — as would one that treated "no tiers found" as tier zero.
+    """
+    _write_fragment(
+        vault,
+        frag_id="frag-other",
+        title="Unrelated",
+        privacy_tier="open",
+    )
+    _patch_miner(monkeypatch, _seed_with_sources(("frag-missing",)))
+    _patch_generator(monkeypatch)
+    factory = _TierRecordingFactory()
+
+    result = draft_tool(
+        vault_path=vault,
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        phase="rising",
+    )
+
+    assert result["status"] == "ok"
+    assert factory.tiers == [PrivacyTier.INTIMATE]
+
+
+def test_draft_routes_a_sourceless_seed_by_the_ceiling_alone(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ``UNEXPLORED_ONTOLOGY`` seed routes by its ceiling, not fail-closed.
+
+    ``source_fragments == ()`` is not "no tiers resolved" — it is "there is no
+    vault content in this prompt at all". ``mining.py::_seed_from_ontology_tuple``
+    builds that seed's title and description purely from ontology enum labels,
+    so forcing INTIMATE here would push every unexplored-ontology draft onto
+    the local model for no privacy gain whatsoever. The distinction is exactly
+    the ``content_tier is None`` branch of
+    :func:`creek_mcp.tier_ceiling.routing_tier`, and it is the one case where
+    the ``no ids resolved`` fail-closed rule must *not* fire.
+
+    The vault holds an intimate fragment the seed does not name, so an
+    implementation that scanned the vault instead of the seed's sources would
+    answer INTIMATE and fail.
+    """
+    _write_fragment(
+        vault,
+        frag_id="frag-intimate",
+        title="Intimate note",
+        privacy_tier="intimate",
+    )
+    _patch_miner(monkeypatch, _unexplored_ontology_seed())
+    _patch_generator(monkeypatch)
+    factory = _TierRecordingFactory()
+
+    result = draft_tool(
+        vault_path=vault,
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        phase="rising",
+    )
+
+    assert result["status"] == "ok"
+    assert factory.tiers == [PrivacyTier.OPEN]
+
+
+def test_draft_fails_closed_when_a_source_fragment_has_no_privacy_tier(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A source whose frontmatter omits ``privacy_tier`` routes INTIMATE.
+
+    :class:`~creek.models.Fragment` defaults a *missing* ``privacy_tier`` to
+    ``unclassified``, which ranks alongside ``open`` — so reading the tier off
+    the validated model alone fails **open** on exactly the file nobody can
+    vouch for (a hand-edited or legacy fragment). The raw frontmatter is the
+    only place the two cases are still distinguishable, which is why
+    the shared ``fragment_tier`` consults it; draft must agree with compile
+    rather than route the same file two different ways.
+    """
+    metadata = {
+        "type": "fragment",
+        "id": "frag-untiered",
+        "title": "Untiered note",
+        "created": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "ingested": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "F1", "secondary": []},
+        "eddies": [],
+    }
+    (vault / "01-Fragments" / "Notes" / "frag-untiered.md").write_text(
+        frontmatter.dumps(frontmatter.Post(content="body text", **metadata)),
+        encoding="utf-8",
+    )
+    _patch_miner(monkeypatch, _seed_with_sources(("frag-untiered",)))
+    _patch_generator(monkeypatch)
+    factory = _TierRecordingFactory()
+
+    result = draft_tool(
+        vault_path=vault,
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        phase="rising",
+    )
+
+    assert result["status"] == "ok"
+    assert factory.tiers == [PrivacyTier.INTIMATE]
+
+
+def test_draft_refuses_when_the_router_has_no_local_backend(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``IntimateRoutingError`` becomes a refusal, not an MCP transport error.
+
+    The router raises it — a ``RuntimeError`` subclass — when intimate content
+    hits a cloud stage and ``llm.default`` is also cloud, so there is no local
+    backend to redirect to. That must cross the MCP boundary as the same
+    structured ``refused`` envelope every other draft failure uses; letting it
+    propagate turns an operator misconfiguration into an unhandled exception
+    for the client. The reason must also name no fragment id: the caller
+    learns the provider is misconfigured, not which of their fragments is
+    intimate.
+    """
+    from creek.classify.llm.router import IntimateRoutingError
+
+    _write_fragment(
+        vault,
+        frag_id="frag-intimate",
+        title="Intimate note",
+        privacy_tier="intimate",
+    )
+    _patch_miner(monkeypatch, _seed_with_sources(("frag-intimate",)))
+    _patch_generator(monkeypatch)
+
+    def _explode(tier: PrivacyTier) -> Callable[[str], str]:
+        """Refuse to build a provider, as the router does with no local stage."""
+        del tier
+        raise IntimateRoutingError(stage_provider="anthropic")
+
+    result = draft_tool(
+        vault_path=vault,
+        llm_factory=_explode,
+        privacy_tier_ceiling=TierCeiling.ALL,
+        phase="rising",
+    )
+
+    assert result["status"] == "refused"
+    assert result["tool"] == "creek.draft"
+    assert result["tier_ceiling"] == "all"
+    assert "no local backend" in result["reason"]
+    assert "frag-intimate" not in result["reason"]
+
+
+def test_draft_does_not_build_a_provider_when_it_cannot_draft(
+    vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Neither non-drafting exit path may build an LLM provider.
+
+    Both the "no idea seeds" empty response and the out-of-range-index refusal
+    return before any prompt exists, so invoking the factory would spend a
+    provider handshake (and, on a cloud stage, an API credential) on a call
+    that never drafts. Today's ``draft_tool`` takes an already-built ``llm``
+    and the server hands it ``factory()`` eagerly in the handler
+    (``server.py:419``), so both paths pay that cost unconditionally — this
+    test pins the laziness the tier-keyed factory makes possible.
+    """
+    invocations: list[PrivacyTier] = []
+
+    def _must_not_run(tier: PrivacyTier) -> Callable[[str], str]:
+        """Record the call and fail: nothing here should reach a provider."""
+        invocations.append(tier)
+        msg = "llm_factory must not be invoked when no draft is produced"
+        raise AssertionError(msg)
+
+    empty = draft_tool(
+        vault_path=vault,
+        llm_factory=_must_not_run,
+        phase="rising",
+    )
+    assert empty["status"] == "empty"
+
+    _patch_miner(monkeypatch, _seed_with_sources(("frag-1",)))
+    refused = draft_tool(
+        vault_path=vault,
+        llm_factory=_must_not_run,
+        phase="rising",
+        index=99,
+    )
+    assert refused["status"] == "refused"
+    assert "out of range" in refused["reason"]
+    assert invocations == []
 
 
 def test_author_tool_returns_draft_envelope(vault: Path) -> None:

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -1724,7 +1724,7 @@ def test_compile_routing_fails_closed_when_privacy_tier_key_is_absent(
     covers the *admission* side of the same file. ``ceiling=all`` admits the
     hand-edited / legacy fragment, so the routing tier is the only thing
     standing between its title and a cloud provider;
-    ``creek_mcp.tools.compile._tier_of`` reports ``INTIMATE`` for it and the
+    ``creek_mcp.source_tiers.fragment_tier`` reports ``INTIMATE`` for it and the
     factory must be keyed with exactly that.
     """
     _write_fragment_without_tier(vault, frag_id="frag-legacy")


### PR DESCRIPTION
## Summary

`creek_mcp/server.py::_build_draft_llm` built its LLM with `LLMClassifier(config.llm)`, **bypassing `ModelRouter`** — the single chokepoint that enforces the Intimate-never-cloud invariant (#647). The path was dead only *by accident*: `config.llm` is an `LLMRoutingConfig`, so every production `creek.draft` call raised `AttributeError: 'LLMRoutingConfig' object has no attribute 'provider'`. Reproduced at `origin/main`:

```
type(config.llm) = LLMRoutingConfig   has .provider? False
creek_mcp.server._build_draft_llm() -> AttributeError: 'LLMRoutingConfig' object has no attribute 'provider'
```

PR #967 deliberately left `# type: ignore[arg-type]  # Issue #958` there rather than "correcting" the type, because doing so inline would have stood up a second provider path with no tier gate on it. **This PR therefore does not silence the error — it rewires the tool through the router**, mirroring what #963 did for `creek.compile`. `LLMClassifier` and the suppression disappear as a *consequence*, not as the goal.

### The tier passed to `resolve()`, and why

```python
if not idea.source_fragments:                          # no vault content in this prompt
    return routing_tier(ceiling, None)                 # ceiling-derived tier alone
tiers = source_tiers(vault_path, idea.source_fragments)
return routing_tier(ceiling, max_source_tier(tiers))   # fails closed to INTIMATE when empty
```

`routing_tier` (the helper #963 introduced, reused here rather than re-derived) takes the **more sensitive** of the ceiling-derived tier and the sources' own classifications, so no declaration a caller can make buys cloud routing for sensitive content.

**The ceiling alone is provably insufficient.** `creek/generate/drafts.py::_render_fragment_section` emits `### {fid}: {fragment.title}` *unconditionally*, and at an `open` ceiling `filter_fragments_by_tier` replaces a personal body with `[Personal-tier summary: {title}]` rather than dropping the fragment. Verified against the real payload, not the intent — an `open`-ceiling draft over a `personal` source produces a prompt that contains the personal fragment's **title** and the redaction stub, but not its body. (`intimate` fragments *are* dropped outright below an intimate ceiling, so personal is the case that makes the survey necessary.)

The two empty cases route differently, and the distinction is made **before** the survey runs because `source_tiers` returns `[]` for both:
- `source_fragments == ()` → ceiling alone. Only `UNEXPLORED_ONTOLOGY` produces this, and it is also the only strategy with empty `threads` *and* `eddies` — its title/description are built purely from ontology enum labels. Failing closed here would push every unexplored-ontology draft onto the local model for no privacy gain.
- named but none resolved → `INTIMATE`. With no evidence about what the call carries, the safe assumption is the worst one (mirrors `compile`).

### Shared survey

The fail-closed tier read is extracted to `creek_mcp/source_tiers.py` (`fragment_tier`, `source_tiers`, `max_source_tier`) and shared with `creek.compile`, so two tools can never read the same file's tier two different ways. `_survey_sources` remains a symbol in `creek_mcp.tools.compile` because `read_gate.py` pins it as that tool's `gate_symbol`. `compile`'s uniform-probe-cost analysis moved with the walk it describes. **`creek.compile`'s tests are unmodified and green — that is the parity evidence the extraction is behaviour-preserving.**

## Test plan

`cd creek-tools && ./scripts/check-all.sh` → **12/12 checks pass, 6586 passed, 93.98% branch coverage.**

Gate 1 RED first; the exact pre-fix failures were `TypeError: _build_draft_llm() takes 0 positional arguments but 1 was given` and, through the registered FastMCP handler, `ToolError: Error executing tool creek.draft: 'LLMRoutingConfig' object has no attribute 'provider'`.

Anti-vacuity was the priority — a test asserting "draft refuses intimate content" passes trivially while the path is still dead. Verified independently of the test suite, with a **real `ModelRouter`** and only the provider builder spied:

| case | routing tier | resolved provider |
|---|---|---|
| intimate source, `ceiling=open` | `intimate` | **ollama** (local) |
| *same case pre-fix* (`routing_tier(open, None)`) | `open` | **anthropic** (cloud egress) |
| `privacy_tier` key absent | `intimate` | ollama |
| named id does not resolve | `intimate` | ollama |
| sourceless seed (vault holds an intimate fragment) | `open` | anthropic |
| personal source, `ceiling=open` | `personal` | anthropic |
| intimate + cloud-only config | — | `status="refused"` |

Row 1 vs row 2 is the point: the survey changes behaviour in the leak direction, so it is load-bearing rather than decorative.

Also asserted: `ok` responses echo no derived tier; the audit payload records only the caller's own declared ceiling; the refusal names no fragment id; and neither the empty-seeds path nor the out-of-range-index path ever invokes the factory.

Added `tests/test_mcp_server.py::test_build_server_wires_the_production_draft_llm_factory` — no factory injected, driven through the registered handler. Every prior draft test injected one, which is exactly what let a production factory that raises on its first line go unnoticed.

**Two tests were removed and replaced, called out explicitly so it is not mistaken for test tampering:** `test_build_draft_llm_raises_when_classifier_unavailable` and `test_build_draft_llm_returns_invoke_prompt_when_available` monkeypatched `LLMClassifier` with a stub whose `__init__(self, _config)` accepted anything — that stub *is* what hid #958, and keeping them would have forced the fix to retain `LLMClassifier(config.llm)`. Both properties they asserted are re-asserted against the routed factory by `test_build_draft_llm_routes_by_tier_then_degrades`, which additionally pins tier-keying, the Intimate redirect, and `generation`-stage precedence. All other test changes are a mechanical `llm=` → `llm_factory=lambda tier:` signature migration with **zero assertion changes**.

## Reachability of related issues (please read)

- **#931 — materially more reachable, by design of this fix.** `creek.draft` over MCP was *totally* dead before this PR. Making it live activates latent holes behind it: the `## Threads` / `## Eddies` prompt sections render compiled-page bodies and frontmatter descriptions with **no tier filtering at all**, and they do **not** raise the routing tier. That is stated plainly in `draft.py`'s module docstring rather than left for the next reader, and it is the strongest argument for the conservative fail-closed branches above. Out of scope here; belongs with #931.
- **#962 — not more reachable.** The CLI's untiered `resolve("generation")` is untouched. It does, however, become the *last* unrouted `generation` resolve once this lands.
- **#964 — not more reachable** by this change, but if reflect grounding is ever activated it would feed titles into prompts through the same channel; worth re-triaging together with #931.
- Accepted residual, unchanged from `compile`: an *explicit* `privacy_tier: unclassified` routes cloud-eligible via `_TIER_RANK` (#923) while `filter_fragments_by_tier` treats it as personal for redaction (#876). Not repaired here — a fix belongs in the one ranking both tools read.

Closes #958