### PR TITLE
docs(agents): steer every agent session to query the knowledge graph first

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,3 +90,19 @@ Follow the 4-gate process:
 2. **Local**: `./scripts/check-all.sh` passes (exit 0)
 3. **CI**: All GitHub Actions jobs green
 4. **Review**: LGTM before merge
+
+## Knowledge Graph (graphify) — query first
+
+This repo publishes its code graph (~23k nodes) as assets on the rolling
+`knowledge-graph` GitHub Release (never committed; part of the adepthood
+federation). For ANY question about this codebase — structure, relationships,
+impact — query the graph BEFORE grep/read sweeps:
+
+- Restore once per session:
+  `gh release download knowledge-graph --pattern graph.json --dir graphify-out`
+  (or rebuild keyless: `pip install graphifyy && graphify extract . --code-only`).
+- `graphify query "<question>"` · `graphify path "A" "B"` ·
+  `graphify explain "X"` · `graphify affected "X"` (before changing X).
+- Quote each cited node's `source_location`; verify before trusting.
+- Fail-soft: if the CLI or graph is unavailable, proceed with normal file
+  tools — never stall.


### PR DESCRIPTION
Adds a compact "Knowledge Graph (graphify) — query first" section to `CLAUDE.md`, so every Claude session in this repo restores the graph from the rolling `knowledge-graph` release (~23k nodes, never committed per #860's design) and orients via `graphify query`/`path`/`explain`/`affected` before grep/read sweeps. Companion to [adepthood#2034](https://github.com/Geoffe-Ga/adepthood/pull/2034) (utilization enforcement on the hub): the federation measured a **175× query-token reduction** on the live pan-graph, but only the hub had agent steering wired. Fail-soft throughout: sessions proceed normally when the CLI or graph is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg)_