### PR TITLE
fix(mcp): activate creek.reflect's grounding on ceiling-bounded titles (#964)

### DIFF
--- a/creek-tools/creek_mcp/read_gate.py
+++ b/creek-tools/creek_mcp/read_gate.py
@@ -167,9 +167,13 @@ TOOL_POSTURES: dict[str, ToolPosture] = {
     "creek.reflect": ToolPosture(
         posture=ReadPosture.GATED,
         rationale=(
-            "An entry_ref resolves a fragment the caller did not supply; "
-            "_above_ceiling refuses it before the care seam, the grounding "
-            "retrieval, or the model (#846)."
+            "Two unsupplied reads, under two gates. (1) An entry_ref resolves "
+            "a fragment the caller did not supply; _above_ceiling refuses it "
+            "before the care seam, the grounding retrieval, or the model "
+            "(#846). (2) The grounding corpus walk, live since #964, is gated "
+            "by to_privacy_override -> tier_within_override's hard rank cutoff "
+            "inside RetrievalSpecialist: only within-ceiling fragments are "
+            "admitted, and they contribute their titles only."
         ),
         gate_module="creek_mcp.tools.reflect",
         gate_symbol="_above_ceiling",

--- a/creek-tools/creek_mcp/tools/reflect.py
+++ b/creek-tools/creek_mcp/tools/reflect.py
@@ -3,9 +3,12 @@
 Takes one journal entry (raw ``content`` or an ``entry_ref`` fragment id) plus a
 privacy-tier ceiling and returns ``{notes: [{quote, kind, note}], essay?}`` —
 warm, second-person, anti-guru reflections that mirror the user's own wisdom,
-grounded in retrieval over their corpus. Distinct from the essay-shaped
-``draft``/``author``/``mine`` surface; this is the reflection surface Adepthood's
-journal needs.
+grounded in the *titles* of the ceiling-admitted corpus fragments nearest the
+entry (titles only, never body text). That grounding has been live only since
+#964: before it, the default grounder raised into a silent ``except`` and every
+reflection was ungrounded. Distinct from the essay-shaped
+``draft``/``author``/``mine`` surface; this is the reflection surface
+Adepthood's journal needs.
 
 Four guarantees this module enforces:
 
@@ -46,8 +49,10 @@ structured dict rather than raising: a malformed or unreadable file under
 malformed model turn degrades to no notes. No parse error crosses the MCP
 boundary.
 
-The LLM and retrieval are injected so the tool is unit-testable with no live
-calls; ``build_server`` supplies the production factory + retrieval.
+The LLM and retrieval are both injectable seams so the tool is unit-testable
+with no live calls. ``build_server`` supplies the production LLM factory and
+leaves ``retrieve`` unset, so production grounding is :func:`_default_retrieve`
+— the ceiling-bounded title retrieval described above.
 """
 
 from __future__ import annotations
@@ -358,8 +363,12 @@ def reflect_tool(
             *content* wins when both are given.
         entry_ref: A fragment id whose body is the entry, when *content* is
             absent.
-        retrieve: ``(query, vault, override) -> snippets`` grounding source;
-            defaults to the corpus retrieval specialist.
+        retrieve: ``(query, vault, override) -> grounding lines`` source. The
+            default (:func:`_default_retrieve`) returns ceiling-bounded corpus
+            fragment **titles**, never body text. An injected callable
+            *replaces* the default outright — the two are never merged — so a
+            deployment wanting richer grounding owns its own admission
+            filtering.
         care_guard: ``(entry) -> reason | None``; a non-``None`` reason escalates
             to a human and skips the model entirely (#753 seam).
         privacy_tier_ceiling: The ceiling; gates admission of the *entry itself*
@@ -485,25 +494,91 @@ def reflect_tool(
 def _default_retrieve(
     query: str, vault_path: Path, override: PrivacyTierOverride
 ) -> list[str]:
-    """Production grounding: top corpus fragments related to *query*.
+    """Production grounding: the *titles* of the corpus fragments nearest *query*.
 
-    Lazily imports the author retrieval specialist so the server still boots
-    when its (heavier) deps are unavailable; any retrieval failure degrades to
-    no grounding rather than failing the reflection.
+    Returns the titles of the top ``author.retrieval_top_k`` (default 5) corpus
+    fragments semantically nearest *query*, drawn from ``01-Fragments``,
+    ``09-Reference`` and ``11-Other-Authors``. The author retrieval specialist
+    is imported lazily so the server still boots when its (heavier) deps are
+    unavailable.
+
+    **Titles, not bodies — and that is the decision, not an accident.** Three
+    reasons, recorded because "grounding" reads like it ought to mean body text:
+
+    - :func:`_build_prompt` validates every returned ``notes[].quote`` as a
+      verbatim span of the *entry*, never of a source, so grounding supplies
+      thematic context and is structurally unquotable — titles serve that role.
+    - Bodies would mean changing ``creek.author.agents._fragment_claim``, whose
+      "one assertion, one short sentence" contract is shared by
+      ``GraphSpecialist`` and the Writing Desk's citation and leak-gate
+      machinery.
+    - :func:`reflect_tool`'s ``retrieve=`` is an injectable seam, so the
+      *default* is deliberately the conservative one; a deployment wanting
+      richer grounding supplies its own callable.
+
+    **The ceiling invariant.** ``creek.author.agents._load_corpus`` applies
+    ``tier_within_override`` — a **hard rank cutoff** — so an above-ceiling
+    fragment contributes *nothing*: no title, no body, no id. This is
+    explicitly NOT ``filter_fragments_by_tier``'s summarise-the-body path,
+    which is the shape #931/#1032 found leaking titles for fragments whose
+    bodies policy had already dropped. Verified admitted sets: ``open`` admits
+    ``open`` only; ``personal`` admits ``open`` + ``personal`` +
+    ``unclassified``; ``intimate`` and ``all`` admit all four.
+
+    **The routing consequence.** The most sensitive tier that can reach the
+    prompt is therefore bounded by the ceiling, and :func:`reflect_tool` keys
+    the model with :func:`creek_mcp.tier_ceiling.routing_tier`, whose
+    ceiling-derived floor is the most sensitive tier that ceiling admits. So
+    the routing tier always dominates every retrieved fragment's tier, and
+    intimate titles can only be retrieved under a ceiling that already forces
+    INTIMATE (local-only) routing. Pinned by
+    ``test_routing_tier_dominates_every_retrieved_fragment_tier``.
+
+    **The cost, honestly.** Each call constructs a fresh
+    ``RetrievalSpecialist``, so it parses the corpus and loads the embeddings
+    parquet per call, and live-embeds any fragment whose cached
+    ``content_hash`` is stale or missing — on a cold cache, that is the whole
+    admitted corpus. Tracked by #1034; the ``except Exception`` below does not
+    bound it, because slowness is not an exception.
+
+    A known asymmetry: a fragment with **no** ``privacy_tier`` key at all is
+    admitted here from ``ceiling=personal`` (the ``Fragment`` model default is
+    ``unclassified``), while :func:`_fragment_tier` fails that same file closed
+    to INTIMATE as an *entry*. Tracked by #1033.
+
+    Args:
+        query: The entry text to retrieve against.
+        vault_path: Vault root whose corpus subtrees are searched.
+        override: The ceiling-derived admission override, applied as a hard
+            cutoff inside the corpus walk.
+
+    Returns:
+        Fragment titles, most relevant first — ``[]`` when retrieval fails.
     """
     try:
         from creek.author.agents import RetrievalSpecialist
 
         bundle = RetrievalSpecialist().gather(query, vault_path, override=override)
-        # ``EvidenceClaim`` carries ``claim``, not ``text``, so this access has
-        # always raised and been swallowed below: production grounding has
-        # never actually run. Renaming the attribute switches it on, and what
-        # it would then feed the prompt is corpus fragment *titles*
-        # (``_fragment_claim`` sets ``claim=fragment.title``) — grounding on
-        # titles rather than bodies is an undecided design question that needs
-        # its own privacy tests. Suppressed rather than "fixed" so bringing
-        # this package under mypy does not quietly turn that egress on; #964
-        # owns the decision.
-        return [claim.text for claim in bundle.claims]  # type: ignore[attr-defined]  # Issue #964
-    except Exception:
+        return [claim.claim for claim in bundle.claims]
+    except Exception as exc:
+        # This log line is the #964 remedy. The attribute this comprehension
+        # reads was wrong for the entire life of the feature, so grounding
+        # raised on every production call and every reflection was ungrounded —
+        # undetected precisely because this swallow was silent. The log is what
+        # makes the next such failure findable.
+        #
+        # The catch stays broad on purpose: ``RetrievalSpecialist.gather``
+        # reaches ``load_config``, a full corpus parse and the
+        # sentence-transformer model load, so its failure surface is open-ended
+        # (ImportError, OSError, yaml errors, pydantic ``ValidationError``,
+        # model-load failures) and none of it may cross the MCP boundary.
+        #
+        # Log the exception's *type name only* — never ``str(exc)``,
+        # ``exc_info``, or ``logger.exception``, for the reason given at
+        # ``_resolve_entry`` above: these are the same user-managed corpus
+        # files, and ``yaml.MarkedYAMLError`` stringifies with the offending
+        # source snippet, so the message text would write tier-unknown vault
+        # content into a log that carries no tier and is not covered by the
+        # ceiling.
+        logger.debug("Grounding degraded to none (%s)", type(exc).__name__)
         return []

--- a/creek-tools/tests/test_mcp_reflect.py
+++ b/creek-tools/tests/test_mcp_reflect.py
@@ -22,6 +22,15 @@ contract this suite pins, in order of stakes:
 4. Corpus-grounded retrieval, audit logging, read-only wrt the corpus, clean
    degradation with no provider, the care seam (#753), and tolerance of
    malformed fragment frontmatter under ``01-Fragments`` (#847).
+5. **The default (production) grounder actually grounds (#964)** — every other
+   test in this file injects a ``retrieve=`` stub, so the retrieval
+   ``build_server`` really wires had zero coverage and silently returned no
+   grounding at all. The final section drives that path with no ``retrieve=``:
+   it feeds the prompt corpus fragment **titles** (never bodies), admits
+   exactly the within-ceiling corpus and leaves no trace of anything above it,
+   routes at a tier dominating every fragment it retrieved, and on a retrieval
+   failure degrades to ``(none)`` while logging the exception's *type name*
+   only.
 
 The LLM and retrieval are injected — no live calls.
 """
@@ -29,20 +38,27 @@ The LLM and retrieval are injected — no live calls.
 from __future__ import annotations
 
 import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import frontmatter
 import pytest
 
+from creek.author.agents import RetrievalSpecialist
 from creek.care.guardrail import CARE_SIGNAL
 from creek.classify.llm.router import IntimateRoutingError
 from creek.models import PrivacyTier
+from creek_mcp import tier_ceiling
 from creek_mcp.audit import MCP_AUDIT_RELPATH
 from creek_mcp.tier_ceiling import TierCeiling, to_privacy_override
 from creek_mcp.tools.reflect import TOOL_NAME, _routing_tier, reflect_tool
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from creek.author.models import EvidenceBundle
 
 _ENTRY = (
     "I keep circling the same fear: that if I rest, everything I built quietly "
@@ -1427,3 +1443,553 @@ def test_nonstring_frontmatter_key_is_skipped_not_crashed(tmp_path: Path) -> Non
     )
     assert result["status"] == "refused"
     assert result["reason"] == "entry_ref not found"
+
+
+# --- Default (production) grounding retrieval (#964) ------------------------------
+
+# Every test above injects ``retrieve=``, so ``_default_retrieve`` — the grounder
+# ``build_server`` actually wires — has never been executed by this suite. Nothing
+# below passes ``retrieve=`` (except the last test, whose subject *is* the seam),
+# so these drive the production path end to end.
+
+# A verbatim span of ``_ENTRY``, so the canned response survives ``_clean_notes``
+# and the call lands on ``status: "ok"``. Reused wherever a test needs to tell
+# "grounding degraded" apart from "the whole call degraded".
+_GROUNDED_QUOTE = "the garden grew while I slept"
+
+# The literal ``_build_prompt`` renders when the grounding list is empty — i.e.
+# exactly what #964 shipped for every production reflection.
+_NO_GROUNDING = "(none)"
+
+# Grounding supplied by an injected stub, distinct from every corpus sentinel.
+_INJECTED_SNIPPET = "INJECTED-GROUNDING-0d5e"
+
+# A vault-content-shaped marker carried in a retrieval exception's *message*.
+_RETRIEVAL_FAILURE_SENTINEL = "VAULT-SECRET-4c19"
+
+
+@dataclass(frozen=True)
+class _CorpusSentinels:
+    """The three markers identifying one corpus-fixture fragment in a prompt.
+
+    Title, body and id are deliberately distinct, mutually non-substring
+    strings that appear nowhere in :data:`_ENTRY`. That is what lets an
+    assertion say *which* of the three reached the model: a title/body mix-up
+    (the whole subject of #964 — grounding feeds titles, not bodies) and a
+    stray id both become impossible to miss rather than silently equivalent.
+    """
+
+    frag_id: str
+    title: str
+    body: str
+
+
+#: One corpus fixture per ``privacy_tier``, keyed by the tier's front-matter
+#: value. Four entries on purpose: ``author.retrieval_top_k`` defaults to 5, so
+#: nothing here is ever truncated by the top-k slice and "admitted" is exactly
+#: set-equal to "retrieved".
+_CORPUS: dict[str, _CorpusSentinels] = {
+    "open": _CorpusSentinels(
+        frag_id="frag-corpus-open-9f2a",
+        title="TITLE-OPEN-9f2a",
+        body="BODY-OPEN-3c71",
+    ),
+    "personal": _CorpusSentinels(
+        frag_id="frag-corpus-personal-5b8d",
+        title="TITLE-PERSONAL-5b8d",
+        body="BODY-PERSONAL-1a46",
+    ),
+    "unclassified": _CorpusSentinels(
+        frag_id="frag-corpus-unclassified-2e93",
+        title="TITLE-UNCLASSIFIED-2e93",
+        body="BODY-UNCLASSIFIED-7d05",
+    ),
+    "intimate": _CorpusSentinels(
+        frag_id="frag-corpus-intimate-8c4f",
+        title="TITLE-INTIMATE-8c4f",
+        body="BODY-INTIMATE-6b29",
+    ),
+}
+
+_SOURCES_MARKER = "SOURCE FRAGMENTS:\n"
+_ENTRY_MARKER = "\n\nENTRY:\n"
+
+
+def _source_section(prompt: str) -> str:
+    """Return only the ``SOURCE FRAGMENTS`` block of *prompt*.
+
+    **Every grounding assertion in this section runs against this slice, never
+    against the raw prompt**, and both directions of that matter:
+
+    * a bare ``title in prompt`` can pass off the ``ENTRY:`` block (or the
+      schema preamble) and report grounding that never happened;
+    * a bare ``body not in prompt`` can fail off the ``ENTRY:`` block whenever
+      the entry legitimately quotes the same words.
+
+    Slicing first makes each assertion mean what it says. The one deliberate
+    exception is :func:`_assert_tier_left_no_trace`, which asserts *absence*
+    from the whole prompt — nothing above the ceiling may reach the provider by
+    any route, grounding block or not.
+
+    Args:
+        prompt: The full prompt recorded by :class:`_RecordingFactory`.
+
+    Returns:
+        The text between the ``SOURCE FRAGMENTS:`` header and the ``ENTRY:``
+        header — ``"(none)"`` when the grounding list was empty.
+    """
+    assert _SOURCES_MARKER in prompt, "prompt carries no SOURCE FRAGMENTS block"
+    after = prompt.split(_SOURCES_MARKER, 1)[1]
+    assert _ENTRY_MARKER in after, "SOURCE FRAGMENTS block is never terminated"
+    return after.split(_ENTRY_MARKER, 1)[0]
+
+
+def _write_corpus_fragment(
+    vault: Path,
+    *,
+    frag_id: str,
+    title: str,
+    body: str,
+    privacy_tier: str,
+) -> None:
+    """Write a fragment the *retrieval corpus* can actually see.
+
+    **Do not "de-duplicate" this against :func:`_write_fragment`.** They look
+    alike and are not interchangeable. ``_write_fragment`` writes only ``id``
+    and ``privacy_tier``, which is all an ``entry_ref`` lookup needs — that path
+    reads front matter directly. Corpus retrieval goes through
+    ``creek.vault.reader.try_load_fragment``, which returns ``None`` for any
+    file without ``type: fragment`` and for anything the ``Fragment`` model
+    rejects. A ``_write_fragment`` file is therefore **invisible** to
+    ``_load_corpus``, so a grounding test built on it would run against an empty
+    corpus and pass vacuously — the exact false green that let #964 sit
+    undetected. This writer mirrors the full, model-valid recipe instead.
+
+    Args:
+        vault: Vault root as created by :func:`_vault`.
+        frag_id: The fragment ``id`` (also the file stem).
+        title: The fragment ``title`` — what ``_fragment_claim`` turns into an
+            ``EvidenceClaim.claim``, i.e. what grounding is made of.
+        body: The markdown body, which grounding must *not* carry.
+        privacy_tier: The ``privacy_tier`` front-matter value.
+    """
+    stamp = datetime(2026, 5, 1, tzinfo=UTC).isoformat()
+    metadata: dict[str, Any] = {
+        "type": "fragment",
+        "id": frag_id,
+        "title": title,
+        "created": stamp,
+        "ingested": stamp,
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "F1", "secondary": []},
+        "privacy_tier": privacy_tier,
+        "eddies": [],
+    }
+    target = vault / "01-Fragments" / "Notes" / f"{frag_id}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
+        encoding="utf-8",
+    )
+
+
+def _write_tiered_corpus(vault: Path) -> None:
+    """Write every :data:`_CORPUS` fixture — one fragment per privacy tier.
+
+    Args:
+        vault: Vault root as created by :func:`_vault`.
+    """
+    for tier, sentinels in _CORPUS.items():
+        _write_corpus_fragment(
+            vault,
+            frag_id=sentinels.frag_id,
+            title=sentinels.title,
+            body=sentinels.body,
+            privacy_tier=tier,
+        )
+
+
+def _tiers_grounded_in(prompt: str) -> set[str]:
+    """Return the tiers whose corpus fixture reached *prompt*'s grounding block.
+
+    ORDERING HAZARD, and why this returns a *set*. The conftest's autouse
+    sentence-transformer mock seeds each vector from ``hash(text)``, which
+    Python randomises per process, so the similarity ranking of these fixtures
+    differs run to run. Nothing here may assert on order or index; membership is
+    the only stable observable. It is also the one that matters: the contract is
+    *which* fragments are admitted, not what order they came back in.
+
+    Args:
+        prompt: The full prompt recorded by :class:`_RecordingFactory`.
+
+    Returns:
+        The subset of :data:`_CORPUS` keys whose ``title`` appears in the
+        grounding block.
+    """
+    sources = _source_section(prompt)
+    return {tier for tier, marks in _CORPUS.items() if marks.title in sources}
+
+
+def _assert_tier_left_no_trace(prompt: str, tier: str) -> None:
+    """Assert nothing of the *tier* corpus fixture appears anywhere in *prompt*.
+
+    Checked against the **whole** prompt rather than :func:`_source_section`,
+    unlike every positive assertion here. An above-ceiling fragment crossing to
+    the provider is a leak wherever in the prompt it lands, so restricting this
+    to the grounding block would let a future "helpful context" section egress
+    it while the suite stayed green.
+
+    All three markers are checked because they fail differently: a *title* means
+    the ceiling filter admitted the fragment outright, a *body* means grounding
+    switched from titles to bodies (the design question #964 settles), and an
+    *id* means attribution metadata leaked without any prose to explain it.
+
+    Args:
+        prompt: The full prompt recorded by :class:`_RecordingFactory`.
+        tier: The :data:`_CORPUS` key that must be absent.
+    """
+    marks = _CORPUS[tier]
+    assert marks.title not in prompt, f"{tier} fragment title reached the model"
+    assert marks.body not in prompt, f"{tier} fragment body reached the model"
+    assert marks.frag_id not in prompt, f"{tier} fragment id reached the model"
+
+
+def _patch_gather_to_raise(monkeypatch: pytest.MonkeyPatch, exc: Exception) -> None:
+    """Make every :meth:`RetrievalSpecialist.gather` call raise *exc*.
+
+    Patches the class attribute rather than the module binding because
+    ``_default_retrieve`` imports ``RetrievalSpecialist`` lazily *inside* its own
+    body: it resolves the same class object this patch mutates, so the
+    substitution is picked up without reaching into the tool's import machinery.
+
+    Args:
+        monkeypatch: The builtin pytest fixture; restores the real ``gather``.
+        exc: The exception instance every ``gather`` call raises.
+    """
+
+    def _raise(*args: Any, **kwargs: Any) -> EvidenceBundle:
+        """Raise *exc* instead of gathering evidence."""
+        raise exc
+
+    monkeypatch.setattr(RetrievalSpecialist, "gather", _raise)
+
+
+def test_default_grounding_feeds_fragment_titles_not_bodies(tmp_path: Path) -> None:
+    """The production grounder retrieves, and what it retrieves is titles (#964).
+
+    The anti-vacuity test for this whole section, and the direct regression for
+    #964: ``_default_retrieve`` read ``claim.text`` off an ``EvidenceClaim``
+    that carries ``claim``, so it raised ``AttributeError`` into a bare
+    ``except`` and every production reflection was grounded on ``(none)``.
+    Nothing in the response shows that — only the prompt does.
+
+    Both halves are load-bearing. The grounding block must be the fragment's
+    **title**, asserted by exact equality so the rendering (``"- " + claim``)
+    is pinned rather than merely "the title is in there somewhere"; and the
+    fragment **body** must appear nowhere in the prompt at all, because
+    ``EvidenceClaim`` could just as easily have been made to carry body text,
+    and grounding on bodies would push whole corpus fragments to the provider on
+    every call.
+    """
+    vault = _vault(tmp_path)
+    marks = _CORPUS["open"]
+    _write_corpus_fragment(
+        vault,
+        frag_id=marks.frag_id,
+        title=marks.title,
+        body=marks.body,
+        privacy_tier="open",
+    )
+    factory = _RecordingFactory(
+        _notes_payload({"quote": _GROUNDED_QUOTE, "kind": "reframe", "note": "yours"})
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        content=_ENTRY,
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    prompt = factory.prompt
+    assert prompt is not None
+    sources = _source_section(prompt)
+    assert sources != _NO_GROUNDING, "production grounding retrieved nothing (#964)"
+    assert sources == f"- {marks.title}"
+    assert marks.body not in prompt, "grounding carried the body, not the title"
+
+
+@pytest.mark.parametrize(
+    ("ceiling", "expected_tiers"),
+    [
+        (TierCeiling.OPEN, {"open"}),
+        (TierCeiling.PERSONAL, {"open", "personal", "unclassified"}),
+        (TierCeiling.INTIMATE, {"open", "personal", "unclassified", "intimate"}),
+        (TierCeiling.ALL, {"open", "personal", "unclassified", "intimate"}),
+    ],
+)
+def test_grounding_admits_exactly_the_within_ceiling_corpus(
+    tmp_path: Path, ceiling: TierCeiling, expected_tiers: set[str]
+) -> None:
+    """Production grounding admits the within-ceiling corpus — no more, no less.
+
+    Switching ``_default_retrieve`` on (#964) opens a *second* read path into
+    the vault, alongside the ``entry_ref`` resolution the #846 gate guards. This
+    one is not gated by tier at the tool: it relies entirely on the ceiling
+    being converted to a ``PrivacyTierOverride`` and handed to
+    ``RetrievalSpecialist.gather``, which drops above-override fragments inside
+    ``_load_corpus``. That is the only thing standing between an ``open``-ceiling
+    caller and the intimate half of their corpus, so it is pinned per ceiling.
+
+    Asserted as **set equality**, not as a leak check, so an *omission* fails as
+    loudly as a leak: a filter tightened to "open only" would silently strip
+    real grounding from every personal-tier caller, and a leak-only assertion
+    would call that a pass. The excluded fragments then get the stronger
+    whole-prompt check via :func:`_assert_tier_left_no_trace`.
+
+    ``ALL`` and ``INTIMATE`` deliberately share an expectation: ``ALL`` is a
+    ceiling, not a tier, and must not admit anything ``INTIMATE`` does not.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+        ceiling: The caller's declared ceiling.
+        expected_tiers: The :data:`_CORPUS` keys whose titles must ground the
+            prompt at *ceiling* — exactly those, and no others.
+    """
+    vault = _vault(tmp_path)
+    _write_tiered_corpus(vault)
+    factory = _RecordingFactory(
+        _notes_payload({"quote": _GROUNDED_QUOTE, "kind": "reframe", "note": "yours"})
+    )
+    reflect_tool(
+        vault_path=vault,
+        content=_ENTRY,
+        llm_factory=factory,
+        privacy_tier_ceiling=ceiling,
+    )
+    prompt = factory.prompt
+    assert prompt is not None
+    assert _tiers_grounded_in(prompt) == expected_tiers
+    for tier in _CORPUS:
+        if tier not in expected_tiers:
+            _assert_tier_left_no_trace(prompt, tier)
+
+
+@pytest.mark.parametrize(
+    ("ceiling", "expected_routed"),
+    [
+        (TierCeiling.OPEN, PrivacyTier.OPEN),
+        (TierCeiling.PERSONAL, PrivacyTier.PERSONAL),
+        (TierCeiling.INTIMATE, PrivacyTier.INTIMATE),
+        (TierCeiling.ALL, PrivacyTier.INTIMATE),
+    ],
+)
+def test_routing_tier_dominates_every_retrieved_fragment_tier(
+    tmp_path: Path, ceiling: TierCeiling, expected_routed: PrivacyTier
+) -> None:
+    """Whatever grounding pulled in, the routing tier is at least as sensitive.
+
+    This is the INTIMATE-never-egresses guarantee restated for the read path
+    #964 switches on. Retrieval widens what crosses to the provider from "the
+    caller's own entry" to "titles drawn from their corpus", so the routing tier
+    must dominate the most sensitive fragment *actually retrieved* — otherwise a
+    ceiling that admits intimate fragments into grounding while routing at a
+    cloud-eligible tier would egress them.
+
+    Two assertions, deliberately redundant, because each catches what the other
+    cannot:
+
+    (a) the hard-coded expected :class:`PrivacyTier` per ceiling, which fails if
+        ``_CEILING_ROUTING_TIER`` is ever retuned — the table is a policy
+        decision and a silent change to it must not pass;
+    (b) the inequality itself, derived from the tiers whose titles actually
+        reached the prompt rather than restated from the table above, so it
+        still holds if a *new* tier is added to the vocabulary and the fixtures
+        grow to match, and it fails if the admission filter and the routing
+        table ever drift apart.
+
+    (b) would be vacuous over an empty retrieval set — which is precisely the
+    #964 state — so a non-empty grounding set is asserted first.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+        ceiling: The caller's declared ceiling.
+        expected_routed: The tier the factory must be asked for.
+    """
+    vault = _vault(tmp_path)
+    _write_tiered_corpus(vault)
+    factory = _RecordingFactory(
+        _notes_payload({"quote": _GROUNDED_QUOTE, "kind": "reframe", "note": "yours"})
+    )
+    reflect_tool(
+        vault_path=vault,
+        content=_ENTRY,
+        llm_factory=factory,
+        privacy_tier_ceiling=ceiling,
+    )
+    asked = factory.asked_tier
+    assert asked is not None, "the model was never reached"
+    assert asked is expected_routed
+    prompt = factory.prompt
+    assert prompt is not None
+    grounded = _tiers_grounded_in(prompt)
+    assert grounded, "no grounding reached the prompt (#964): (b) would be vacuous"
+    assert tier_ceiling.tier_sensitivity(asked) >= max(
+        tier_ceiling.tier_sensitivity(PrivacyTier(tier)) for tier in grounded
+    )
+
+
+def test_above_ceiling_fragment_contributes_nothing_not_even_a_title(
+    tmp_path: Path,
+) -> None:
+    """An intimate corpus fragment leaves no residue at an ``open`` ceiling.
+
+    Distinct from the residue #931/#1032 found on the compile/structural paths,
+    and the distinction is structural rather than lucky. Those paths run
+    ``filter_fragments_by_tier``, which *keeps* an above-ceiling fragment as a
+    summarised stub — so its title survives by design and the leak is the
+    surviving stub. Grounding retrieval does not go near that: ``_load_corpus``
+    applies ``tier_within_override``, a hard rank cutoff that drops the record
+    entirely before ranking, so there is no summarise-the-body step and nothing
+    can survive it. This test pins that *by construction* property, so a future
+    "reuse the compile filter here for consistency" refactor — which would look
+    like a tidy-up and would import the residue wholesale — fails loudly.
+
+    The ``open`` fragment is not decoration: it is the control that proves
+    grounding ran at all. Without it the intimate absences would hold trivially
+    under the #964 bug, and the test would be a permanent false green.
+    """
+    vault = _vault(tmp_path)
+    _write_tiered_corpus(vault)
+    factory = _RecordingFactory(
+        _notes_payload({"quote": _GROUNDED_QUOTE, "kind": "reframe", "note": "yours"})
+    )
+    reflect_tool(
+        vault_path=vault,
+        content=_ENTRY,
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    prompt = factory.prompt
+    assert prompt is not None
+    # The control: grounding really ran, so the absences below mean something.
+    assert _CORPUS["open"].title in _source_section(prompt)
+    _assert_tier_left_no_trace(prompt, "intimate")
+
+
+def test_retrieval_failure_degrades_to_no_grounding(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A retrieval failure costs the reflection its grounding, not its answer.
+
+    Grounding is an enhancement; the entry is the subject. A corpus whose
+    embedding model is missing, whose cache is corrupt, or whose fragments fail
+    to load must not turn an ordinary journal reflection into a refusal — so
+    ``_default_retrieve`` swallows the failure and returns no snippets.
+
+    Pinned on both sides: the envelope is a normal ``ok`` (never ``refused``),
+    *and* the grounding block is exactly ``(none)``. The second half is what
+    stops a future "degrade to whatever we had" from shipping partial or stale
+    grounding out of a half-failed retrieval.
+
+    That broad ``except`` is also what hid #964 for the entire life of the
+    feature, which is why the degradation must stay observable — see
+    :func:`test_retrieval_failure_logs_the_exception_type_not_its_message`.
+    """
+    vault = _vault(tmp_path)
+    _write_tiered_corpus(vault)
+    _patch_gather_to_raise(monkeypatch, RuntimeError("embedding backend unavailable"))
+    factory = _RecordingFactory(
+        _notes_payload({"quote": _GROUNDED_QUOTE, "kind": "reframe", "note": "yours"})
+    )
+    result = reflect_tool(
+        vault_path=vault,
+        content=_ENTRY,
+        llm_factory=factory,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "ok"
+    assert result["notes"][0]["quote"] == _GROUNDED_QUOTE
+    prompt = factory.prompt
+    assert prompt is not None
+    assert _source_section(prompt) == _NO_GROUNDING
+
+
+def test_retrieval_failure_logs_the_exception_type_not_its_message(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The silent degradation must leave a trace — a *type name*, never a message.
+
+    #964 is a bug that ran in production for the whole life of the feature
+    precisely because ``except Exception: return []`` says nothing. Every
+    reflection was ungrounded and no operator could tell. A DEBUG line naming
+    the exception type is what makes the next such failure findable.
+
+    Naming only ``type(exc).__name__`` is not fastidiousness, it is the same
+    rule ``_resolve_entry`` already follows at ``reflect.py:326-331``:
+    ``yaml.MarkedYAMLError`` stringifies *with the offending source snippet*, so
+    ``str(exc)``, ``exc_info=True`` or ``logger.exception`` would write
+    tier-unknown vault content into a log file that carries no tier and is not
+    covered by the ceiling. The failure paths here are the same corpus files, so
+    the same rule applies — and a retrieval exception can just as easily carry a
+    fragment's text in its message.
+
+    Asserted both ways round: the type name must be present (a silent swallow
+    fails) and the message sentinel absent (a chatty log fails).
+    """
+    vault = _vault(tmp_path)
+    _write_tiered_corpus(vault)
+    _patch_gather_to_raise(monkeypatch, RuntimeError(_RETRIEVAL_FAILURE_SENTINEL))
+    factory = _RecordingFactory(
+        _notes_payload({"quote": _GROUNDED_QUOTE, "kind": "reframe", "note": "yours"})
+    )
+    with caplog.at_level(logging.DEBUG, logger="creek_mcp.tools.reflect"):
+        result = reflect_tool(
+            vault_path=vault,
+            content=_ENTRY,
+            llm_factory=factory,
+            privacy_tier_ceiling=TierCeiling.PERSONAL,
+        )
+    assert result["status"] == "ok"
+    assert "RuntimeError" in caplog.text, "the degradation was swallowed silently"
+    assert _RETRIEVAL_FAILURE_SENTINEL not in caplog.text, "exception message logged"
+
+
+def test_injected_retrieve_bypasses_the_default_grounder(tmp_path: Path) -> None:
+    """An injected ``retrieve=`` still wins outright over the default grounder.
+
+    The seam every other test in this file depends on. ``reflect_tool`` picks
+    ``_default_retrieve`` only when ``retrieve is None``, and switching the
+    default on (#964) is exactly the change that could turn that into a merge —
+    grounding from both sources — without any existing test noticing, since they
+    all run against empty vaults where the default contributes nothing anyway.
+
+    Asserted with a populated corpus, so "the default did not also run" is a
+    real observation rather than a tautology, and by exact equality on the
+    grounding block: the injected snippet is not merely *present*, it is the
+    *only* thing there.
+    """
+    vault = _vault(tmp_path)
+    _write_tiered_corpus(vault)
+    calls: list[str] = []
+
+    def _stub_retrieve(query: str, vault_arg: Path, override: object) -> list[str]:
+        """Record the call and return one sentinel grounding snippet."""
+        del vault_arg, override
+        calls.append(query)
+        return [_INJECTED_SNIPPET]
+
+    factory = _RecordingFactory(
+        _notes_payload({"quote": _GROUNDED_QUOTE, "kind": "reframe", "note": "yours"})
+    )
+    reflect_tool(
+        vault_path=vault,
+        content=_ENTRY,
+        llm_factory=factory,
+        retrieve=_stub_retrieve,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert calls == [_ENTRY]
+    prompt = factory.prompt
+    assert prompt is not None
+    assert _source_section(prompt) == f"- {_INJECTED_SNIPPET}"
+    assert _tiers_grounded_in(prompt) == set()


### PR DESCRIPTION
## Summary

`creek_mcp/tools/reflect.py::_default_retrieve` read `EvidenceClaim.text`. The model carries `claim`, not `text`, so the comprehension raised `AttributeError` into a bare `except Exception: return []`. `build_server` wires `reflect_tool` with no `retrieve=`, so **every production `creek.reflect` call has been ungrounded since the tool shipped**, while the module docstring advertised reflections "grounded in retrieval over their corpus". Third never-worked path found in `creek_mcp/` after #929 (compile) and #958 (draft), all three surfaced by widening mypy in #925.

Verified before touching anything — `_default_retrieve` returns `[]` at every ceiling:

```
open -> []   personal -> []   intimate -> []   all -> []
```

### The design decision: titles, not bodies or excerpts

The one-character fix makes it *run*; it does not settle what "grounding" should mean here. It should be **titles**, and that is a decision rather than a default-to-whatever-the-code-does:

1. **Grounding is structurally unquotable.** `_clean_notes` validates every returned `notes[].quote` as a verbatim span of the **entry**, never of a source. Grounding's only job is to tell the model which themes recur in this person's corpus. Titles do that; bodies would add egress without adding a quotable surface.
2. **Bodies would mean changing `_fragment_claim`**, whose "one assertion, one short sentence" contract is shared by `GraphSpecialist` and the Writing Desk's citation and leak-gate machinery. A body excerpt is not an assertion. That is a Writing-Desk-wide semantic change wearing a reflect-shaped costume.
3. **`retrieve=` is an injectable seam.** The *default* is where the conservative choice belongs; a deployment wanting richer grounding supplies its own callable (which replaces the default outright — the two are never merged).

### This is not the #931 / #1032 title-egress hazard

That was the sharpest question in the brief, and the answer is structural rather than lucky. #931/#1032 concern a fragment whose body policy already **dropped or summarised** still contributing its title — the residue of `filter_fragments_by_tier`'s summarise-the-body path (`[Intimate-tier summary: {title}]`, `structural_path`). Grounding retrieval never goes near that. `_load_corpus` applies `tier_within_override`, a **hard rank cutoff** that drops the record before ranking, so an above-ceiling fragment contributes **nothing**: no title, no body, no id. There is no summarise step for a title to survive.

`test_above_ceiling_fragment_contributes_nothing_not_even_a_title` pins that by construction, so a future "reuse the compile filter here for consistency" refactor — which would look like a tidy-up and would import the residue wholesale — fails loudly.

### The activated path is tier-routed, and here is the proof

The brief asked whether activation puts content through a resolve that is not tier-keyed. It does not, and the invariant is now pinned rather than argued. Measured on this code, one fragment per tier:

| ceiling | titles reaching the prompt | routed tier |
|---|---|---|
| `open` | open | `OPEN` |
| `personal` | open, personal, unclassified | `PERSONAL` |
| `intimate` | open, personal, unclassified, intimate | `INTIMATE` |
| `all` | open, personal, unclassified, intimate | `INTIMATE` |

Retrieval is bounded by `to_privacy_override(ceiling)`; `routing_tier`'s ceiling-derived **floor** is the most sensitive tier that same ceiling admits. So the routing tier always dominates every retrieved fragment, and **intimate titles are only reachable under a ceiling that already forces INTIMATE local-only routing**. `test_routing_tier_dominates_every_retrieved_fragment_tier` asserts both the table (so a `CEILING_ROUTING_TIER` retune fails here, where the grounding consequence lives) and the inequality *derived from the tiers whose titles actually reached the prompt* — so it survives a new tier being added, and it guards against the two halves drifting apart.

### The silent swallow

`except Exception: return []` is what hid this for the feature's whole life. It now logs the exception's **type name only** — never `str(exc)`, `exc_info`, or `logger.exception`, per the `_resolve_entry` precedent at `reflect.py:326-331`: `yaml.MarkedYAMLError` stringifies *with the offending source snippet*, which would write tier-unknown vault content into a log that carries no tier and is not covered by the ceiling. The catch stays broad on purpose — `gather` reaches `load_config`, a full corpus parse and the sentence-transformer load.

The `# type: ignore[attr-defined]  # Issue #964` suppression is removed as a **consequence** of the fix, not to satisfy `warn_unused_ignores`.

### Read-posture manifest (#973)

The guardrail did **not** fire, and the brief's expectation that it might is worth correcting: `_probe_reflect` calls reflect with an above-ceiling `entry_ref`, which refuses before grounding runs — and a grounding leak egresses to the **provider**, not into the response layer (f) inspects. So layer (f) is structurally unable to see this path. I filed that as **#1036** rather than papering over it.

What did change is the manifest **rationale**, deliberately: `creek.reflect` now has *two* unsupplied reads under *two* gates. `posture`, `gate_module` and `gate_symbol` are byte-identical and still true.

## Test plan

- `./scripts/check-all.sh` -> exit 0. **6637 passed** (baseline 6624), **94.01%** branch coverage (baseline 93.99%), 12/12 checks. Credentials stripped from the environment.
- **Gate 1 RED verified before the fix**: 11 failing invocations, every one on an empty `(none)` grounding block or the missing degradation log — `assert '(none)' != '(none)'` — never on a fixture or import error.
- **13 new tests**, none of which pass `retrieve=` (except the one whose subject *is* the seam). All assert on `_RecordingFactory.prompt`, not the response: a grounding leak egresses to the provider and leaves the returned notes clean.
- **Mutation-tested, both mutants killed:**
  - disable `tier_within_override`'s ceiling cutoff -> **5 failures**, including the derived routing inequality;
  - leak `fragment.id` into `_fragment_claim`'s rendering -> **1 failure**, caught by the exact-equality assertion on the rendered grounding line.
- **Test-integrity**: `git diff --numstat origin/main HEAD -- creek-tools/tests/` is `566 0` — **zero deletions**. `tests/test_mcp_reflect.py` sha256 `9c06cba46b9982ad9ee37616a31388f00e481ea3893622968957469429e90404`, unchanged from the RED commit through Gate 2.5.
- No `# noqa`, no `# type: ignore`, no skips, no threshold changes anywhere in the diff.

### The trap that would have made this whole suite vacuous

`tests/test_mcp_reflect.py`'s existing `_write_fragment` writes only `id` + `privacy_tier` and **no `type: fragment`**, so `try_load_fragment` returns `None` and the file is **invisible** to `_load_corpus`. Reusing it for corpus fixtures would have run every new assertion against an empty corpus and passed vacuously — the exact false green that let #964 survive. `_write_corpus_fragment` is a separate, model-valid writer whose docstring says why it must never be merged with its lookalike.

Every "nothing leaked" assertion carries a positive control (the `open` fixture must be present), so none of them can pass by the corpus being empty.

## Filed, not fixed

Three findings, deliberately out of scope because each has a blast radius beyond this issue:

- **#1033** — `_load_corpus` fails **open** on a *missing* `privacy_tier` key (the `Fragment` model default is `unclassified`), while `reflect._fragment_tier` and `privacy_filter.fragment_tier` both fail **closed** to INTIMATE on the same file. Reproduced. Activation puts both readings inside one tool: the same untiered fragment is refused as an `entry_ref` at `ceiling=personal` yet contributes its title as grounding there. Pre-existing since #660; the fix changes `creek.author`, `creek.mine`, `creek.draft` and `creek.wheel` too.
- **#1034** — grounding constructs a fresh `RetrievalSpecialist` per call, so it re-parses the corpus and re-loads the embeddings parquet every time, and live-embeds anything whose cached `content_hash` is stale. On a cold cache that is the whole admitted corpus. The `except Exception` does not bound it — slowness is not an exception. Documented honestly in the docstring.
- **#1036** — read_gate layer (f) asserts on the *response*, so it cannot see a prompt-side leak, and `_probe_reflect` refuses before the second corpus read. `creek.compile` is in the same position.

Also noted by review and *not* filed, because it is unreachable by construction: `tier_within_override` uses a bare `_TIER_RANK[tier]` lookup rather than the fail-closed `.get(..., INTIMATE)` its sibling `tier_sensitivity` uses. `PrivacyTier` has exactly the four members the table covers, and if it ever did raise, `_default_retrieve`'s broad catch degrades grounding to `[]` — it fails safe. Worth mentioning only because this PR is what makes that lookup execute in production for the first time.

Closes #964
Refs #925, #929, #931, #958, #962, #973, #1032
