### PR TITLE
fix(mcp): gate creek.report's six generators on the caller's tier ceiling (#968)

### DIFF
--- a/creek-tools/creek/classify/privacy_filter.py
+++ b/creek-tools/creek/classify/privacy_filter.py
@@ -32,6 +32,12 @@ an explicit ``unclassified`` only in the raw frontmatter — is ``INTIMATE``),
 :func:`max_source_tier` (the reduction over the tiers a call would carry,
 ``INTIMATE`` when empty).
 
+:func:`raw_privacy_tier` and :func:`within_ceiling` (#968) are the
+raw-frontmatter siblings of that pair, for generation flows that never build a
+:class:`~creek.models.Fragment` at all. They live here, and not in a new
+module, for the same reason everything above does: a tier reader somewhere
+else is a tier opinion the others can drift from.
+
 The last three moved here from ``creek_mcp.source_tiers`` in #962, which they
 emptied, so that module is gone and this is now the single home for the
 survey. They had to move because :mod:`creek.compile.engine` derives its own
@@ -74,7 +80,7 @@ from creek.models import PrivacyTier
 from creek.vault.reader import iter_vault_fragments
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Iterator
+    from collections.abc import Iterable, Iterator, Mapping
 
     from creek.models import Fragment
 
@@ -369,6 +375,96 @@ def fragment_tier(fragment: Fragment, raw: dict[str, object]) -> PrivacyTier:
     if "privacy_tier" not in raw:
         return PrivacyTier.INTIMATE
     return fragment.privacy_tier
+
+
+def raw_privacy_tier(raw: Mapping[str, object]) -> PrivacyTier:
+    """Return a vault note's tier read straight off raw frontmatter, failing closed.
+
+    The raw-frontmatter sibling of :func:`fragment_tier`, and deliberately
+    *not* a merge with it. ``fragment_tier`` needs a validated
+    :class:`~creek.models.Fragment`, and the report generators #968 had to
+    gate do not all have one:
+    :class:`creek.generate.tags.TagGardenGenerator` builds no model at
+    all — ``_extract_tags`` is a bare ``frontmatter.load`` — and it scans
+    four directories (``02-Threads``, ``03-Eddies``, ``04-Praxis``,
+    ``08-Decisions``) whose note types have no ``privacy_tier`` field in
+    their models in the first place. Asking those files for a ``Fragment``
+    would mean inventing one.
+
+    The two readers are pinned equal for every fragment by
+    ``tests/test_mcp_report_tier_ceiling.py``'s
+    ``test_raw_and_model_tier_readers_agree_on_every_fragment``, walking the
+    shared vault loader tier by tier. That pin is what stops this reader
+    becoming the third, diverging tier opinion the module docstring above
+    warns about — "two tools that disagree about the same file" is a bug
+    class, not a style question, and an assertion is the only thing that
+    keeps two deliberate implementations honest about agreeing.
+
+    A *missing* key resolves to ``INTIMATE`` rather than to the model's
+    ``unclassified`` default, and the distinction is the whole point. An
+    explicit ``unclassified`` ranks with ``personal`` (#876/#961), so it is
+    *admitted* at ``ceiling=personal``; reading a missing key through the
+    model would therefore fail open relative to what the file actually says.
+    A hand-edited or legacy note with no key at all carries less assurance
+    than a pipeline-written one that says ``unclassified`` out loud.
+
+    Args:
+        raw: The note's raw frontmatter, before any model defaults are
+            applied. ``frontmatter.Post.metadata`` satisfies this directly.
+
+    Returns:
+        ``PrivacyTier.INTIMATE`` when ``privacy_tier`` is absent, ``None``,
+        empty, or a string the enum does not recognise; otherwise the
+        declared tier.
+    """
+    value = raw.get("privacy_tier")
+    if value is None or value == "":
+        return PrivacyTier.INTIMATE
+    try:
+        return PrivacyTier(str(value))
+    except ValueError:
+        logger.warning(
+            "Vault note carries unrecognised privacy_tier %r; "
+            "treating as INTIMATE for fail-closed filtering. "
+            "Re-run `creek classify` to assign a recognised tier.",
+            value,
+        )
+        return PrivacyTier.INTIMATE
+
+
+def within_ceiling(raw: Mapping[str, object], override: PrivacyTierOverride) -> bool:
+    """Return whether the note described by *raw* is admitted under *override*.
+
+    The admission gate the six ``creek report`` generators share (#968).
+    It reduces to :func:`tier_within_override` — the **hard rank cutoff** —
+    rather than to :func:`filter_fragments_by_tier`, and that choice is not
+    incidental:
+
+    * Three of the six generators (``tags``, ``decisions``, ``mode-profiles``)
+      never read a body at all. They read frontmatter ``tags`` / ``id``, the
+      ``title``, and ``wavelength.mode``. Summarising a ``PERSONAL`` *body*
+      there is a literal no-op — a gesture, not a gate — while the title and
+      tags it does read would sail straight through.
+    * For the three that do read bodies (``voice``, ``lexicon``,
+      ``rhetorical-patterns``) summarisation is worse than useless: the
+      ``"[Personal-tier summary: <title>]"`` stub would be written into
+      ``### Sample Passages`` as a *voice exemplar*, leaking the title and
+      poisoning the voice corpus with a synthetic sentence in nobody's voice.
+
+    A report must omit. Note this gate is additive to, not a replacement for,
+    the ``allow_intimate`` consent gate in :mod:`creek.generate.voice`:
+    admission is ``allow_intimate`` **and** ``within_ceiling``.
+
+    Args:
+        raw: The note's raw frontmatter, as loaded by the caller.
+        override: The admission ceiling. ``PrivacyTierOverride.ALL`` admits
+            everything, which is what "no ceiling declared" means for the
+            library's existing callers.
+
+    Returns:
+        ``True`` when the note may contribute to the artifact being written.
+    """
+    return tier_within_override(raw_privacy_tier(raw), override)
 
 
 def max_source_tier(tiers: Iterable[PrivacyTier]) -> PrivacyTier:

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -67,6 +67,22 @@ _INCLUDE_TIER_HELP = (
     "<vault>/00-Creek-Meta/audit/privacy.jsonl."
 )
 
+# ``report`` needs its own wording because the flag runs the other way here
+# (#968). Everywhere else ``--include-tier`` *widens* an already-restrictive
+# default; on ``report`` an absent flag means **unfiltered**, and the flag
+# narrows. That is the same reasoning already written at ``creek compile``
+# below: the CLI operator *is* the vault owner, so there is no caller
+# declaration to reconcile against and no ceiling to default to. Making an
+# absent flag mean ``open`` would silently delete most of an existing
+# operator's tag garden — a data-loss bug wearing a privacy fix's costume.
+_REPORT_INCLUDE_TIER_HELP = (
+    "Privacy-tier ceiling for the report's vault scan: open, personal, "
+    "intimate, or all. Omitting the flag leaves the scan unfiltered (the CLI "
+    "operator is the vault owner), so this flag NARROWS what the generated "
+    "artifact may contain. Elevated values are recorded in "
+    "<vault>/00-Creek-Meta/audit/privacy.jsonl."
+)
+
 
 def _parse_include_tier(value: str | None) -> PrivacyTierOverride | None:
     """Parse --include-tier and exit 2 with a clear error on bad values."""
@@ -1981,16 +1997,20 @@ def _build_fill_steps(
             vault_path=vault_path, config=config, method=method, rebuild=False
         )
 
+    # ``creek fill`` has no ``--include-tier`` of its own, and an absent flag
+    # means unfiltered on the report surface (#968), so every step states
+    # ``ALL`` rather than inheriting a default nobody typed.
+    unfiltered = PrivacyTierOverride.ALL
     steps: list[tuple[str, Callable[[], object]]] = [
         ("link/embeddings", _link("embeddings")),
         ("link/temporal", _link("temporal")),
         ("link/eddies", _link("eddies")),
         ("link/threads", _link("threads")),
-        ("report/decisions", lambda: _report_decisions(vault_path)),
-        ("report/unnamed", lambda: _report_unnamed(vault_path)),
-        ("report/paradox", lambda: _report_paradox(vault_path)),
-        ("report/synchronicity", lambda: _report_synchronicity(vault_path)),
-        ("report/mode-profiles", lambda: _report_mode_profiles(vault_path)),
+        ("report/decisions", lambda: _report_decisions(vault_path, unfiltered)),
+        ("report/unnamed", lambda: _report_unnamed(vault_path, unfiltered)),
+        ("report/paradox", lambda: _report_paradox(vault_path, unfiltered)),
+        ("report/synchronicity", lambda: _report_synchronicity(vault_path, unfiltered)),
+        ("report/mode-profiles", lambda: _report_mode_profiles(vault_path, unfiltered)),
         ("report/wavelength", lambda: _report_wavelength(vault_path, "weekly")),
         ("index", lambda: IndexGenerator(vault_path=vault_path).generate_all()),
     ]
@@ -2511,16 +2531,35 @@ def compile_(
     )
 
 
-def _report_tags(vault_path: Path) -> None:
-    """Generate the tag-garden report."""
+def _report_tags(vault_path: Path, override: PrivacyTierOverride) -> None:
+    """Generate the tag-garden report.
+
+    Args:
+        vault_path: Vault root.
+        override: Tier ceiling for the scan (#968). Note the garden is
+            fragment-derived only below ``intimate``: the four non-fragment
+            scan directories hold note types with no ``privacy_tier``.
+    """
     from creek.generate.tags import TagGardenGenerator
 
-    path = TagGardenGenerator(vault_path=vault_path).generate_garden()
+    path = TagGardenGenerator(
+        vault_path=vault_path,
+        override=override,
+    ).generate_garden()
     console.print(f"[bold green]Tag Garden generated: {path}[/bold green]")
 
 
-def _report_unnamed(vault_path: Path) -> None:
-    """Generate the weekly unnamed-fragment digest."""
+def _report_unnamed(vault_path: Path, override: PrivacyTierOverride) -> None:
+    """Generate the weekly unnamed-fragment digest.
+
+    Args:
+        vault_path: Vault root.
+        override: Unused. ``unnamed`` is not exposed over MCP and is outside
+            #968's scope; the parameter exists only to satisfy
+            :data:`_REPORT_DISPATCH`'s uniform signature.
+    """
+    del override  # not MCP-exposed; out of #968's scope, not half-wired.
+
     from datetime import date as _date
     from datetime import timedelta as _timedelta
 
@@ -2538,11 +2577,20 @@ def _report_unnamed(vault_path: Path) -> None:
     )
 
 
-def _report_voice(vault_path: Path) -> None:
-    """Generate per-register voice profiles, if exemplars exist."""
+def _report_voice(vault_path: Path, override: PrivacyTierOverride) -> None:
+    """Generate per-register voice profiles, if exemplars exist.
+
+    Args:
+        vault_path: Vault root.
+        override: Tier ceiling for the exemplar walk (#968). Additive to the
+            collector's ``allow_intimate`` consent gate, never a replacement
+            for it.
+    """
     from creek.generate.voice import VoiceProfileGenerator
 
-    profile_paths = VoiceProfileGenerator().generate_all_profiles(vault_path)
+    profile_paths = VoiceProfileGenerator(override=override).generate_all_profiles(
+        vault_path,
+    )
     if not profile_paths:
         console.print(
             "[yellow]No voice profiles generated: "
@@ -2556,17 +2604,22 @@ def _report_voice(vault_path: Path) -> None:
     )
 
 
-def _report_decisions(vault_path: Path) -> None:
+def _report_decisions(vault_path: Path, override: PrivacyTierOverride) -> None:
     """Generate draft Decision notes from decision-signalling fragments (#581).
 
     Scans the vault's fragments for decision signals and writes a draft note per
     *new* candidate to ``08-Decisions/Active/``; re-running is idempotent (a
     fragment already captured by a note is skipped). Prints a friendly message
     when there are no new candidates.
+
+    Args:
+        vault_path: Vault root.
+        override: Tier ceiling for the fragment walk (#968). A written note's
+            filename and ``title:`` are a source fragment's title verbatim.
     """
     from creek.generate.decisions import generate_decisions
 
-    written_paths = generate_decisions(vault_path)
+    written_paths = generate_decisions(vault_path, override=override)
     if not written_paths:
         console.print(
             "[yellow]No decision notes generated: "
@@ -2580,17 +2633,22 @@ def _report_decisions(vault_path: Path) -> None:
     )
 
 
-def _report_lexicon(vault_path: Path) -> None:
+def _report_lexicon(vault_path: Path, override: PrivacyTierOverride) -> None:
     """Generate the voice lexicon glossary + metaphor index (#580).
 
     Collects the vault's voice exemplars (sharing the voice report's eligibility
     gate), builds a :class:`~creek.generate.lexicon.Lexicon`, and persists it to
     ``07-Voice/Lexicon/``. Mirrors ``_report_voice``'s friendly "no qualifying
     exemplars" message when the corpus is empty.
+
+    Args:
+        vault_path: Vault root.
+        override: Tier ceiling for the exemplar walk (#968). Borrowed-term
+            entries record the whole surrounding sentence verbatim.
     """
     from creek.generate.lexicon import generate_lexicon
 
-    lexicon, written_paths = generate_lexicon(vault_path)
+    lexicon, written_paths = generate_lexicon(vault_path, override=override)
     if lexicon is None or not written_paths:
         console.print(
             "[yellow]No lexicon generated: no qualifying exemplars found.[/yellow]",
@@ -2604,17 +2662,28 @@ def _report_lexicon(vault_path: Path) -> None:
     )
 
 
-def _report_rhetorical_patterns(vault_path: Path) -> None:
+def _report_rhetorical_patterns(
+    vault_path: Path,
+    override: PrivacyTierOverride,
+) -> None:
     """Persist per-register rhetorical-pattern notes (#582).
 
     Writes the ontology's "### Rhetorical Moves" section per voice register to
     ``07-Voice/Rhetorical-Patterns/``, reusing the voice subsystem's existing
     move detection. Mirrors ``_report_voice``'s friendly "no qualifying
     exemplars" message when the corpus is empty.
+
+    Args:
+        vault_path: Vault root.
+        override: Tier ceiling for the exemplar walk (#968). The notes hold
+            only integer counts, but *which* per-register files exist is
+            itself derived from who entered the corpus.
     """
     from creek.generate.voice import VoiceProfileGenerator
 
-    written_paths = VoiceProfileGenerator().generate_rhetorical_patterns(vault_path)
+    written_paths = VoiceProfileGenerator(
+        override=override,
+    ).generate_rhetorical_patterns(vault_path)
     if not written_paths:
         console.print(
             "[yellow]No rhetorical patterns written: "
@@ -2628,15 +2697,23 @@ def _report_rhetorical_patterns(vault_path: Path) -> None:
     )
 
 
-def _report_mode_profiles(vault_path: Path) -> None:
+def _report_mode_profiles(vault_path: Path, override: PrivacyTierOverride) -> None:
     """Generate per-mode wavelength profiles to 05-Wavelength/Mode-Profiles/ (#583).
 
     Writes one note per engagement mode that has fragments; prints a friendly
     message when no fragment carries a classified mode.
+
+    Args:
+        vault_path: Vault root.
+        override: Tier ceiling for the fragment walk (#968). A mode profile
+            lists sample fragment titles.
     """
     from creek.generate.wavelength import ModeProfileGenerator
 
-    written_paths = ModeProfileGenerator().generate_mode_profiles(vault_path)
+    written_paths = ModeProfileGenerator().generate_mode_profiles(
+        vault_path,
+        override=override,
+    )
     if not written_paths:
         console.print(
             "[yellow]No mode profiles written: "
@@ -2746,8 +2823,17 @@ def _report_wavelength(vault_path: Path, period: str | None) -> None:
     )
 
 
-def _report_fingerprint(vault_path: Path) -> None:
-    """Build and persist the voice fingerprint (FEAT-040.2)."""
+def _report_fingerprint(vault_path: Path, override: PrivacyTierOverride) -> None:
+    """Build and persist the voice fingerprint (FEAT-040.2).
+
+    Args:
+        vault_path: Vault root.
+        override: Unused. ``fingerprint`` is not exposed over MCP and is
+            outside #968's scope; the parameter exists only to satisfy
+            :data:`_REPORT_DISPATCH`'s uniform signature.
+    """
+    del override  # not MCP-exposed; out of #968's scope, not half-wired.
+
     from creek.config import load_config
     from creek.generate.ai_style.fingerprint import (
         build_fingerprint,
@@ -3019,13 +3105,21 @@ def voice_authenticity(
         console.print(report.summary_line(), markup=False)
 
 
-def _report_paradox(vault_path: Path) -> None:
+def _report_paradox(vault_path: Path, override: PrivacyTierOverride) -> None:
     """Write Paradox notes for contradictory fragment pairs (#711).
 
     Wires the implemented ``ParadoxDetector`` to a runnable command: scans the
     vault for contradictory pairs and writes one neutral note per paradox into
     ``10-Liminal/Paradoxes/``. Idempotent; deterministic (no LLM).
+
+    Args:
+        vault_path: Vault root.
+        override: Unused. ``paradox`` is not exposed over MCP and is outside
+            #968's scope; the parameter exists only to satisfy
+            :data:`_REPORT_DISPATCH`'s uniform signature.
     """
+    del override  # not MCP-exposed; out of #968's scope, not half-wired.
+
     from creek.generate.paradox import generate_paradoxes
 
     config = _load_config_for_vault(vault_path)
@@ -3042,14 +3136,22 @@ def _report_paradox(vault_path: Path) -> None:
     )
 
 
-def _report_synchronicity(vault_path: Path) -> None:
+def _report_synchronicity(vault_path: Path, override: PrivacyTierOverride) -> None:
     """Write Synchronicity notes for surprising cross-source resonances (#711).
 
     Wires the implemented ``SynchronicityDetector`` to a runnable command: loads
     embeddings, computes resonances, filters for cross-source >0.9-similarity
     >30-day pairs, and writes one note per pair into
     ``10-Liminal/Synchronicities/``. Idempotent; deterministic (no LLM).
+
+    Args:
+        vault_path: Vault root.
+        override: Unused. ``synchronicity`` is not exposed over MCP and is
+            outside #968's scope; the parameter exists only to satisfy
+            :data:`_REPORT_DISPATCH`'s uniform signature.
     """
+    del override  # not MCP-exposed; out of #968's scope, not half-wired.
+
     from creek.generate.synchronicity import generate_synchronicities
 
     config = _load_config_for_vault(vault_path)
@@ -3066,7 +3168,7 @@ def _report_synchronicity(vault_path: Path) -> None:
     )
 
 
-_REPORT_DISPATCH: dict[str, Callable[[Path], None]] = {
+_REPORT_DISPATCH: dict[str, Callable[[Path, PrivacyTierOverride], None]] = {
     "tags": _report_tags,
     "unnamed": _report_unnamed,
     "voice": _report_voice,
@@ -3088,7 +3190,7 @@ def report(
     include_tier: str | None = typer.Option(
         None,
         "--include-tier",
-        help=_INCLUDE_TIER_HELP,
+        help=_REPORT_INCLUDE_TIER_HELP,
     ),
 ) -> None:
     """Generate reports on vault state.
@@ -3115,7 +3217,10 @@ def report(
 
     handler = _REPORT_DISPATCH.get(type or "")
     if handler is not None:
-        handler(vault_path)
+        # An absent ``--include-tier`` means *unfiltered* here, not ``open``
+        # (#968) — see ``_REPORT_INCLUDE_TIER_HELP``. On ``report`` the flag
+        # narrows rather than widens.
+        handler(vault_path, override or PrivacyTierOverride.ALL)
         return
     if type == "wavelength":
         _report_wavelength(vault_path, period)

--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -3208,6 +3208,16 @@ def report(
     config = _load_config_for_vault(vault)
     vault_path = vault or config.vault_path
     override = _parse_include_tier(include_tier)
+    # NB (#968): this audits the *flag*, not the effective ceiling, so a bare
+    # ``creek report`` — which now scans unfiltered — writes no privacy-override
+    # entry while a typed ``--include-tier open``, the narrowest scan there is,
+    # writes one. ``report``'s inverted polarity is what makes the shared
+    # ``override_elevates`` helper read backwards here. Deliberately left alone
+    # in this change and tracked separately: auditing the resolved ceiling here
+    # fires before ``--type`` is validated, turning the #716 unknown-type exit-2
+    # into an OSError on an unwritable vault path
+    # (``tests/test_cli.py::test_report_command``), so the fix is a reordering
+    # plus an audit-volume decision, not a one-line swap.
     _audit_privacy_override_if_needed(
         vault_path=vault_path,
         command=f"report.{type}" if type else "report",

--- a/creek-tools/creek/generate/decisions.py
+++ b/creek-tools/creek/generate/decisions.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING
 import frontmatter
 import yaml
 
+from creek.classify.privacy_filter import PrivacyTierOverride, within_ceiling
 from creek.models import (
     Decision,
     DecisionCandidate,
@@ -1036,7 +1037,11 @@ def _existing_decision_fragment_ids(vault_path: Path) -> set[str]:
     return seen
 
 
-def generate_decisions(vault_path: Path) -> list[Path]:
+def generate_decisions(
+    vault_path: Path,
+    *,
+    override: PrivacyTierOverride = PrivacyTierOverride.ALL,
+) -> list[Path]:
     """Detect decision candidates across the vault and write new notes (#581).
 
     Loads fragments via :func:`creek.vault.reader.iter_vault_fragments` (the
@@ -1047,6 +1052,18 @@ def generate_decisions(vault_path: Path) -> list[Path]:
 
     Args:
         vault_path: Root of the Obsidian vault.
+        override: Tier ceiling (#968), applied to each fragment's *raw*
+            frontmatter — which the shared reader already yields, so no
+            second read is introduced. Defaults to
+            :attr:`~creek.classify.privacy_filter.PrivacyTierOverride.ALL`,
+            meaning "no ceiling declared" — a genuine no-op for callers that
+            predate #968, and safe because both production report surfaces
+            state an override explicitly (pinned by
+            ``tests/test_mcp_report_tier_ceiling.py``'s
+            ``test_production_report_callers_always_state_an_override``).
+            The stakes here are unusually concrete: a generated note's
+            ``title:`` frontmatter *and* its filename are a source
+            fragment's title verbatim.
 
     Returns:
         Paths of the newly written Decision notes; empty when there are no new
@@ -1054,9 +1071,10 @@ def generate_decisions(vault_path: Path) -> list[Path]:
     """
     fragments = [
         fragment
-        for _path, fragment, _body, _raw in iter_vault_fragments(
+        for _path, fragment, _body, raw in iter_vault_fragments(
             vault_path / "01-Fragments",
         )
+        if within_ceiling(raw, override)
     ]
     detector = DecisionDetector()
     already = _existing_decision_fragment_ids(vault_path)

--- a/creek-tools/creek/generate/lexicon.py
+++ b/creek-tools/creek/generate/lexicon.py
@@ -34,6 +34,8 @@ from typing import TYPE_CHECKING
 
 import frontmatter
 
+from creek.classify.privacy_filter import PrivacyTierOverride
+
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
@@ -743,7 +745,11 @@ class LexiconGenerator:
         return "\n".join(lines)
 
 
-def generate_lexicon(vault_path: Path) -> tuple[Lexicon | None, list[Path]]:
+def generate_lexicon(
+    vault_path: Path,
+    *,
+    override: PrivacyTierOverride = PrivacyTierOverride.ALL,
+) -> tuple[Lexicon | None, list[Path]]:
     """Collect the voice corpus, build the lexicon, and persist it (#580).
 
     Reuses :meth:`creek.generate.voice.VoiceExemplarCollector.collect_all_exemplars`
@@ -758,6 +764,18 @@ def generate_lexicon(vault_path: Path) -> tuple[Lexicon | None, list[Path]]:
 
     Args:
         vault_path: Root of the Obsidian vault.
+        override: Tier ceiling for the corpus walk (#968), forwarded to the
+            collector. Defaults to
+            :attr:`~creek.classify.privacy_filter.PrivacyTierOverride.ALL`,
+            meaning "no ceiling declared" — a genuine no-op for callers that
+            predate #968. The default is safe because both production surfaces
+            state an override explicitly, which
+            ``tests/test_mcp_report_tier_ceiling.py``'s
+            ``test_production_report_callers_always_state_an_override``
+            enforces structurally. This matters more here than elsewhere:
+            ``_build_borrowed_terms`` records the *whole surrounding sentence*
+            verbatim, so an admitted body lands in ``glossary.md`` byte for
+            byte.
 
     Returns:
         ``(lexicon, written_paths)``. When the vault has no qualifying
@@ -766,7 +784,9 @@ def generate_lexicon(vault_path: Path) -> tuple[Lexicon | None, list[Path]]:
     """
     from creek.generate.voice import VoiceExemplarCollector, VoicePatternExtractor
 
-    exemplars = VoiceExemplarCollector().collect_all_exemplars(vault_path)
+    exemplars = VoiceExemplarCollector(override=override).collect_all_exemplars(
+        vault_path,
+    )
     if not exemplars:
         return None, []
     patterns = VoicePatternExtractor().extract_patterns([e.body for e in exemplars])

--- a/creek-tools/creek/generate/tags.py
+++ b/creek-tools/creek/generate/tags.py
@@ -6,6 +6,19 @@ co-occurrence analysis, and provides maintenance recommendations.
 
 History is persisted to ``00-Creek-Meta/Processing-Log/tag-history.json``
 for temporal growth tracking across scans.
+
+Tier ceiling (#968): the scan admits a note only when
+:func:`creek.classify.privacy_filter.within_ceiling` says its *raw*
+frontmatter is within the caller's :class:`~creek.classify.privacy_filter.
+PrivacyTierOverride`. Four of the five :data:`_SCAN_DIRS` hold note types
+(``Thread``, ``Eddy``, ``Praxis``, ``Decision``) that carry no ``privacy_tier``
+field at all, so the fail-closed read ranks them ``intimate`` and a
+ceiling-filtered garden is **fragment-derived only**. That is the honest
+answer rather than a convenient one: those note types are derived from
+fragments and untierable by construction — ``generate_decisions`` writes
+``08-Decisions/Active/*.md`` whose ``title:`` *is* a source fragment's title
+verbatim — so scanning them at ``ceiling=open`` would read back content a
+``ceiling=all`` run had distilled there.
 """
 
 from __future__ import annotations
@@ -19,6 +32,8 @@ from difflib import SequenceMatcher
 from typing import TYPE_CHECKING
 
 import frontmatter
+
+from creek.classify.privacy_filter import PrivacyTierOverride, within_ceiling
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -58,6 +73,9 @@ _BROAD_TAG_THRESHOLD: int = 100
 _SIMILAR_DISTANCE_MAX: float = 0.8
 """Minimum SequenceMatcher ratio to consider two tags similar (merge candidate)."""
 
+_TIER_CEILING_KEY: str = "tier_ceiling"
+"""History-entry key recording the ceiling a scan was taken under (#968)."""
+
 
 def _build_note(front: dict[str, str], body: str) -> str:
     """Build a markdown note with YAML frontmatter and body content.
@@ -73,6 +91,40 @@ def _build_note(front: dict[str, str], body: str) -> str:
     lines.extend(f"{key}: {value}" for key, value in front.items())
     lines.extend(("---", "", body))
     return "\n".join(lines)
+
+
+def _latest_counts_for(
+    history: list[dict[str, object]],
+    override: PrivacyTierOverride,
+) -> dict[str, int] | None:
+    """Return the newest history entry's counts taken at *override*'s ceiling.
+
+    Growth is only meaningful between two scans of the *same* corpus. Two runs
+    at different ceilings surveyed two different corpora, so comparing them
+    produces figures that are not merely imprecise but meaningless: every tag
+    the wider ceiling admits reads as brand new, and every tag the narrower one
+    dropped reads as a collapse.
+
+    Legacy entries written before #968 carry no :data:`_TIER_CEILING_KEY` and
+    are therefore *non-comparable* rather than assumed unfiltered — the ceiling
+    they were taken under is simply not recorded, and guessing it is the same
+    category error one level down.
+
+    Args:
+        history: Parsed ``tag-history.json`` entries, oldest first.
+        override: The ceiling the current scan is running under.
+
+    Returns:
+        The most recent matching entry's ``tag_counts``, or ``None`` when no
+        entry was taken at this ceiling.
+    """
+    for entry in reversed(history):
+        if entry.get(_TIER_CEILING_KEY) != override.value:
+            continue
+        counts = entry.get("tag_counts")
+        if isinstance(counts, dict):
+            return counts
+    return None
 
 
 @dataclass
@@ -97,15 +149,32 @@ class TagGardenGenerator:
     Attributes:
         vault_path: Path to the root of the Obsidian vault.
         history_path: Path to the tag history JSON file.
+        override: The tier ceiling the scan admits notes under (#968).
     """
 
-    def __init__(self, vault_path: Path) -> None:
+    def __init__(
+        self,
+        vault_path: Path,
+        *,
+        override: PrivacyTierOverride = PrivacyTierOverride.ALL,
+    ) -> None:
         """Initialize the TagGardenGenerator with a vault path.
 
         Args:
             vault_path: Path to the root of the Obsidian vault directory.
+            override: Tier ceiling for the scan. Defaults to
+                :attr:`~creek.classify.privacy_filter.PrivacyTierOverride.ALL`,
+                meaning "no ceiling declared" — a genuine no-op for every
+                caller that predates #968, which is what keeps this a privacy
+                fix rather than a fixture migration. The default is safe
+                because both production surfaces (``creek_mcp.tools.report``
+                and ``creek.cli``) always pass an explicit value, a property
+                ``tests/test_mcp_report_tier_ceiling.py``'s
+                ``test_production_report_callers_always_state_an_override``
+                enforces structurally.
         """
         self.vault_path = vault_path
+        self.override = override
         self.history_path = (
             vault_path / "00-Creek-Meta" / "Processing-Log" / "tag-history.json"
         )
@@ -114,7 +183,9 @@ class TagGardenGenerator:
         """Scan vault frontmatter and count all tag occurrences.
 
         Reads markdown files from fragment, thread, eddy, praxis, and
-        decision directories, extracting tags from YAML frontmatter.
+        decision directories, extracting tags from YAML frontmatter. Notes
+        above :attr:`override` contribute nothing — see the module docstring
+        for why that makes a filtered garden fragment-derived only.
 
         Returns:
             TagScanResult with tag counts and fragment-to-tag mappings.
@@ -127,7 +198,9 @@ class TagGardenGenerator:
             if not dir_path.is_dir():
                 continue
             for md_file in dir_path.rglob("*.md"):
-                ft = self._extract_tags(md_file)
+                ft = self._extract_tags(md_file, self.override)
+                if ft is None:
+                    continue
                 for tag in ft.tags:
                     tag_counts[tag] += 1
                     tag_fragments[tag].append(ft.fragment_id)
@@ -295,16 +368,29 @@ class TagGardenGenerator:
     # ---- Private helpers ----
 
     @staticmethod
-    def _extract_tags(md_file: Path) -> _FragmentTags:
+    def _extract_tags(
+        md_file: Path,
+        override: PrivacyTierOverride,
+    ) -> _FragmentTags | None:
         """Extract tags and ID from a markdown file's frontmatter.
+
+        The gate reads the *raw* frontmatter rather than a validated model:
+        four of the five :data:`_SCAN_DIRS` hold note types that have no
+        ``privacy_tier`` field to validate, and no ``Fragment`` is ever built
+        here at all.
 
         Args:
             md_file: Path to the markdown file.
+            override: The tier ceiling this scan admits under.
 
         Returns:
-            _FragmentTags with the file's ID and tag list.
+            _FragmentTags with the file's ID and tag list, or ``None`` when
+            the note's tier is above *override* — in which case not even its
+            id reaches the tally.
         """
         post = frontmatter.load(str(md_file))
+        if not within_ceiling(post.metadata, override):
+            return None
         raw_id = post.get("id", md_file.stem)
         frag_id: str = raw_id if isinstance(raw_id, str) else md_file.stem
         tags_raw = post.get("tags", [])
@@ -312,21 +398,30 @@ class TagGardenGenerator:
         return _FragmentTags(fragment_id=frag_id, tags=tags)
 
     def _load_previous_counts(self) -> dict[str, int] | None:
-        """Load the most recent tag counts from history.
+        """Load the most recent tag counts taken at this scan's ceiling.
 
         Returns:
-            Previous tag counts dict, or None if no history exists.
+            Previous tag counts dict, or ``None`` when no history entry was
+            recorded at :attr:`override`'s ceiling — see
+            :func:`_latest_counts_for` for why a mismatched entry is skipped
+            rather than reused.
         """
         if not self.history_path.exists():
             return None
-        history = json.loads(self.history_path.read_text(encoding="utf-8"))
+        history: list[dict[str, object]] = json.loads(
+            self.history_path.read_text(encoding="utf-8"),
+        )
         if not history:
             return None
-        latest: dict[str, int] = history[-1]["tag_counts"]
-        return latest
+        return _latest_counts_for(history, self.override)
 
     def _save_history(self, scan: TagScanResult) -> None:
         """Append current scan to the tag history file.
+
+        The entry records the ceiling it was taken under (#968). This file is
+        append-only, so an entry written at one ceiling is read back by every
+        later run: without the ceiling stated, a count is uninterpretable and
+        a later run would silently compare across corpora.
 
         Args:
             scan: The current tag scan result to persist.
@@ -340,6 +435,7 @@ class TagGardenGenerator:
         entry: dict[str, object] = {
             "timestamp": datetime.now(tz=UTC).isoformat(),
             "tag_counts": scan.tag_counts,
+            _TIER_CEILING_KEY: self.override.value,
         }
         history.append(entry)
 

--- a/creek-tools/creek/generate/voice.py
+++ b/creek-tools/creek/generate/voice.py
@@ -13,10 +13,17 @@ body texts to extract sentence structure, paragraph structure, transition
 patterns, metaphor families, rhetorical moves, vocabulary fingerprint, and
 punctuation habits.
 
-The collector is deliberately conservative about privacy: ``intimate``
-tier fragments are excluded by default and only included when the caller
-explicitly opts in. Saved exemplars include a per-register summary note
-recording the breakdown of confidence levels.
+The collector is deliberately conservative about privacy, and two
+independent gates say so. ``allow_intimate`` is a **consent** gate: the
+voice proxy is opt-in even at ``--include-tier intimate``
+(``creek/templates/skills/privacy-tier.SKILL.md:47``). ``override`` is a
+**ceiling** gate (#968): the caller's declared
+:class:`~creek.classify.privacy_filter.PrivacyTierOverride`, applied to each
+note's raw frontmatter via
+:func:`~creek.classify.privacy_filter.within_ceiling`. They are additive by
+design — admission is ``allow_intimate`` *and* ``within_ceiling`` — and must
+not be "simplified" into one. Saved exemplars include a per-register summary
+note recording the breakdown of confidence levels.
 """
 
 from __future__ import annotations
@@ -39,6 +46,7 @@ import frontmatter
 import yaml
 from pydantic import ValidationError
 
+from creek.classify.privacy_filter import PrivacyTierOverride, within_ceiling
 from creek.config import VoiceAudienceWeightingConfig
 from creek.models import (
     Confidence,
@@ -302,14 +310,19 @@ def _iter_exemplars_from_jsonl(jsonl_path: Path) -> Iterator[Exemplar]:
 
 def _load_fragment_with_body(
     md_file: Path,
-) -> tuple[Fragment, str] | None:
-    """Parse *md_file* into a Fragment and return it with its body text.
+) -> tuple[Fragment, str, dict[str, object]] | None:
+    """Parse *md_file* into a Fragment and return it with body and raw frontmatter.
+
+    The raw frontmatter is returned alongside the validated model because the
+    ceiling gate (#968) must read the tier *before* Pydantic applies its
+    ``unclassified`` default: a missing key and an explicit ``unclassified``
+    are indistinguishable on the model, and they must rank differently.
 
     Args:
         md_file: Markdown file to read.
 
     Returns:
-        A ``(fragment, body)`` pair, or ``None`` when the file is not a
+        A ``(fragment, body, raw)`` triple, or ``None`` when the file is not a
         valid fragment record (unreadable, wrong type, or invalid
         frontmatter).
     """
@@ -326,7 +339,7 @@ def _load_fragment_with_body(
     except ValidationError:
         logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
         return None
-    return fragment, post.content
+    return fragment, post.content, metadata
 
 
 class VoiceExemplarCollector:
@@ -345,7 +358,11 @@ class VoiceExemplarCollector:
         min_per_register: Minimum exemplars expected per register; below
             this threshold the collector emits a warning.
         allow_intimate: When ``True``, fragments tagged ``intimate``
-            participate in collection. Defaults to ``False``.
+            participate in collection. Defaults to ``False``. A *consent*
+            gate, not a ceiling one — see :attr:`override`.
+        override: The caller's tier ceiling (#968). Additive to
+            :attr:`allow_intimate`: a fragment is collected only when both
+            admit it.
     """
 
     def __init__(
@@ -354,6 +371,7 @@ class VoiceExemplarCollector:
         max_per_register: int = DEFAULT_MAX_PER_REGISTER,
         min_per_register: int = DEFAULT_MIN_PER_REGISTER,
         allow_intimate: bool = False,
+        override: PrivacyTierOverride = PrivacyTierOverride.ALL,
         audience_weighting: VoiceAudienceWeightingConfig | None = None,
     ) -> None:
         """Initialise the collector.
@@ -364,7 +382,20 @@ class VoiceExemplarCollector:
             min_per_register: Minimum exemplars per register before a
                 warning is emitted. Must be at least 1.
             allow_intimate: Whether to include ``intimate`` privacy tier
-                fragments. Defaults to ``False``.
+                fragments. Defaults to ``False``. This is the FEAT opt-in
+                for the voice proxy, which
+                ``creek/templates/skills/privacy-tier.SKILL.md:47`` requires
+                "even with ``--include-tier intimate``" — so it is *not*
+                superseded by *override* and the two must stay separate.
+            override: Tier ceiling for the corpus walk (#968). Defaults to
+                :attr:`~creek.classify.privacy_filter.PrivacyTierOverride.ALL`,
+                meaning "no ceiling declared", so adding it is a genuine
+                no-op for every caller that predates #968. The default is
+                safe because both production report surfaces state an
+                override explicitly, which
+                ``tests/test_mcp_report_tier_ceiling.py``'s
+                ``test_production_report_callers_always_state_an_override``
+                enforces structurally.
             audience_weighting: Graduated audience-authority multipliers
                 applied during ranking. Defaults to the standard weighting,
                 which keeps a uniform-audience vault's relative ranking
@@ -391,6 +422,7 @@ class VoiceExemplarCollector:
         self.max_per_register = max_per_register
         self.min_per_register = min_per_register
         self.allow_intimate = allow_intimate
+        self.override = override
         self._audience_weighting = audience_weighting or VoiceAudienceWeightingConfig()
         self._records: dict[str, _ExemplarRecord] = {}
 
@@ -402,8 +434,10 @@ class VoiceExemplarCollector:
         Fragments are kept when their ``voice.confidence`` is ``settled``
         or ``conviction`` and their ``voice.register`` is set. Intimate
         privacy tier fragments are filtered out unless
-        :attr:`allow_intimate` is ``True``. Each register key in the
-        returned dict is always present; empty registers map to ``[]``.
+        :attr:`allow_intimate` is ``True``, and every fragment must
+        additionally sit within :attr:`override` (#968). Each register key
+        in the returned dict is always present; empty registers map to
+        ``[]``.
 
         Args:
             vault_path: Path to the root of the Obsidian vault.
@@ -429,7 +463,12 @@ class VoiceExemplarCollector:
             loaded = _load_fragment_with_body(md_file)
             if loaded is None:
                 continue
-            fragment, body = loaded
+            fragment, body, raw = loaded
+            # Ceiling gate (#968), above the consent gate: an above-ceiling
+            # fragment must not reach the corpus even when the operator has
+            # opted the voice proxy in to intimate content.
+            if not within_ceiling(raw, self.override):
+                continue
             register = self._eligible_register(fragment)
             if register is None:
                 continue
@@ -447,11 +486,12 @@ class VoiceExemplarCollector:
 
         Shares the eligibility gate with :meth:`collect_exemplars` (``settled``
         or ``conviction`` confidence, a set register, intimate filtered unless
-        :attr:`allow_intimate`, ``11-Other-Authors`` excluded) but returns a
-        flat :class:`Exemplar` list — fragment paired with its on-disk body —
-        rather than per-register ``Fragment`` buckets. Consumers that need the
-        whole voice corpus as one unit (e.g. the lexicon) use this so they share
-        a single source of truth for *which* fragments count as exemplars.
+        :attr:`allow_intimate`, within :attr:`override`, ``11-Other-Authors``
+        excluded) but returns a flat :class:`Exemplar` list — fragment paired
+        with its on-disk body — rather than per-register ``Fragment`` buckets.
+        Consumers that need the whole voice corpus as one unit (e.g. the
+        lexicon) use this so they share a single source of truth for *which*
+        fragments count as exemplars.
 
         Args:
             vault_path: Path to the root of the Obsidian vault.
@@ -469,14 +509,28 @@ class VoiceExemplarCollector:
             loaded = _load_fragment_with_body(md_file)
             if loaded is None:
                 continue
-            fragment, body = loaded
+            fragment, body, raw = loaded
+            # Ceiling gate (#968) — see collect_exemplars for why it sits
+            # above the consent gate rather than folded into it.
+            if not within_ceiling(raw, self.override):
+                continue
             if self._eligible_register(fragment) is None:
                 continue
             exemplars.append(Exemplar(fragment=fragment, body=body))
         return exemplars
 
     def _eligible_register(self, fragment: Fragment) -> str | None:
-        """Return the fragment's register if it qualifies, else ``None``."""
+        """Return the fragment's register if it qualifies, else ``None``.
+
+        This answers the *consent* question only (``allow_intimate``, plus
+        confidence / voice-weight / register eligibility). The *ceiling*
+        question is asked separately by
+        :func:`~creek.classify.privacy_filter.within_ceiling` at each walk,
+        because it needs the raw frontmatter this method never sees. Do not
+        collapse the two: one is the operator's opt-in to voice-proxy
+        training, the other is the caller's declared ceiling, and a fragment
+        needs both.
+        """
         return _eligible_register(fragment, allow_intimate=self.allow_intimate)
 
     def _warn_below_minimum(self, buckets: dict[str, list[Fragment]]) -> None:
@@ -1686,6 +1740,7 @@ class VoiceProfileGenerator:
         min_exemplars: int = _DEFAULT_MIN_EXEMPLARS_PER_PROFILE,
         collector: VoiceExemplarCollector | None = None,
         extractor: VoicePatternExtractor | None = None,
+        override: PrivacyTierOverride = PrivacyTierOverride.ALL,
         audience_weighting: VoiceAudienceWeightingConfig | None = None,
     ) -> None:
         """Initialise the generator.
@@ -1697,10 +1752,29 @@ class VoiceProfileGenerator:
                 Must be at least 1 and no greater than ``max_exemplars``.
             collector: Optional :class:`VoiceExemplarCollector` used by
                 :meth:`generate_all_profiles`. Defaults to a collector
-                configured with the same exemplar bounds.
+                configured with the same exemplar bounds. **An injected
+                collector keeps its own** ``override``: it is a fully
+                configured object the caller built deliberately, and
+                silently overwriting one of its privacy settings from a
+                sibling argument would be the more surprising behaviour.
             extractor: Optional :class:`VoicePatternExtractor` used by
                 :meth:`generate_all_profiles`. Defaults to a plain
                 extractor.
+            override: Tier ceiling for the corpus walk (#968), forwarded
+                into the *default* collector only (see *collector*).
+                Defaults to
+                :attr:`~creek.classify.privacy_filter.PrivacyTierOverride.ALL`,
+                meaning "no ceiling declared", so it is a genuine no-op for
+                callers that predate #968. The default is safe because both
+                production report surfaces state an override explicitly,
+                which ``tests/test_mcp_report_tier_ceiling.py``'s
+                ``test_production_report_callers_always_state_an_override``
+                enforces structurally. The value is *not* stored on the
+                generator: :meth:`_stream_into` reads it back off
+                ``self._collector`` so there is exactly one storage location
+                and an injected collector cannot be contradicted.
+            audience_weighting: Graduated audience-authority multipliers
+                applied during ranking.
 
         Raises:
             ValueError: If either bound is less than 1, or if
@@ -1721,6 +1795,7 @@ class VoiceProfileGenerator:
         self._collector = collector or VoiceExemplarCollector(
             max_per_register=max_exemplars,
             min_per_register=min_exemplars,
+            override=override,
             audience_weighting=self._audience_weighting,
         )
         self._extractor = extractor or VoicePatternExtractor()
@@ -1977,7 +2052,12 @@ class VoiceProfileGenerator:
         register_paths: dict[str, Path],
         register_handles: dict[str, _JsonlWriter],
     ) -> None:
-        """Walk *fragments_dir* and append eligible exemplars to JSONL files."""
+        """Walk *fragments_dir* and append eligible exemplars to JSONL files.
+
+        Both privacy settings are read back off ``self._collector`` rather
+        than duplicated onto the generator, so an injected collector governs
+        this walk exactly as it governs the collector's own (#968).
+        """
         for md_file in sorted(fragments_dir.rglob("*.md")):
             # Defensive path gate (Issue #466): skip borrowed / AI-authored
             # content under ``11-Other-Authors`` so it never reaches the
@@ -1987,7 +2067,11 @@ class VoiceProfileGenerator:
             loaded = _load_fragment_with_body(md_file)
             if loaded is None:
                 continue
-            fragment, body = loaded
+            fragment, body, raw = loaded
+            # Ceiling gate (#968), additive to the allow_intimate consent
+            # gate below — see ``VoiceExemplarCollector._eligible_register``.
+            if not within_ceiling(raw, self._collector.override):
+                continue
             register = _eligible_register(
                 fragment,
                 allow_intimate=self._collector.allow_intimate,
@@ -2008,7 +2092,7 @@ class VoiceProfileGenerator:
             )
             # Drop the local body reference before the next iteration
             # so the per-iteration peak is bounded by a single fragment.
-            del body, fragment, loaded
+            del body, fragment, raw, loaded
 
     def _rank_exemplars(self, exemplars: list[Exemplar]) -> list[Exemplar]:
         """Rank *exemplars* by the same quality heuristic as the collector.

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -23,6 +23,7 @@ import frontmatter
 import yaml
 from pydantic import ValidationError
 
+from creek.classify.privacy_filter import PrivacyTierOverride, within_ceiling
 from creek.hierarchy import LevelPolicy, select_by_policy
 from creek.models import Dosage, Fragment, Frequency, Mode, Phase
 from creek.time import effective_authored_date
@@ -191,12 +192,35 @@ def _safe_post(md_file: Path) -> frontmatter.Post | None:
         return None
 
 
-def load_fragments_from_vault(vault_path: Path) -> list[Fragment]:
+def load_fragments_from_vault(
+    vault_path: Path,
+    *,
+    override: PrivacyTierOverride = PrivacyTierOverride.ALL,
+) -> list[Fragment]:
     """Load every classified fragment from ``01-Fragments/`` under *vault_path*.
 
     Files that fail to parse or that lack the ``type: fragment`` marker
     are silently skipped. Returns an empty list when the folder is
     absent.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+        override: Tier ceiling (#968), applied to each file's *raw*
+            frontmatter — which this loader already has in hand, and which
+            is the only place a missing ``privacy_tier`` is still
+            distinguishable from the model's ``unclassified`` default.
+            Defaults to
+            :attr:`~creek.classify.privacy_filter.PrivacyTierOverride.ALL`,
+            meaning "no ceiling declared", so the three non-report callers
+            in this module and ``creek report --type wavelength`` are
+            byte-identical to before. The default is safe because both
+            production report surfaces state an override explicitly, which
+            ``tests/test_mcp_report_tier_ceiling.py``'s
+            ``test_production_report_callers_always_state_an_override``
+            enforces structurally.
+
+    Returns:
+        Every admitted fragment, in sorted on-disk order.
     """
     root = vault_path / "01-Fragments"
     if not root.exists():
@@ -208,6 +232,8 @@ def load_fragments_from_vault(vault_path: Path) -> list[Fragment]:
             continue
         metadata = dict(post.metadata)
         if metadata.get("type") != "fragment":
+            continue
+        if not within_ceiling(metadata, override):
             continue
         try:
             fragments.append(Fragment.model_validate(metadata))
@@ -1358,11 +1384,27 @@ class ModeProfileGenerator:
     an unclassified corpus produces no files at all (#583).
     """
 
-    def generate_mode_profiles(self, vault_path: Path) -> list[Path]:
+    def generate_mode_profiles(
+        self,
+        vault_path: Path,
+        *,
+        override: PrivacyTierOverride = PrivacyTierOverride.ALL,
+    ) -> list[Path]:
         """Write one profile note per non-empty engagement mode.
 
         Args:
             vault_path: Path to the root of the Obsidian vault.
+            override: Tier ceiling (#968), forwarded to
+                :func:`load_fragments_from_vault`. Defaults to
+                :attr:`~creek.classify.privacy_filter.PrivacyTierOverride.ALL`,
+                meaning "no ceiling declared" — a genuine no-op for callers
+                that predate #968, and safe because both production report
+                surfaces state an override explicitly (pinned by
+                ``tests/test_mcp_report_tier_ceiling.py``'s
+                ``test_production_report_callers_always_state_an_override``).
+                A mode profile lists sample fragment *titles*, so an
+                unfiltered walk publishes above-ceiling titles into
+                ``05-Wavelength/Mode-Profiles/``.
 
         Returns:
             Paths written, in canonical :class:`~creek.models.Mode` order; empty
@@ -1374,7 +1416,7 @@ class ModeProfileGenerator:
         # enum's ``.value``s below, so the comparison stays string-to-string
         # throughout rather than mixing enum identity with string lookups.
         by_mode: dict[str, list[Fragment]] = defaultdict(list)
-        for fragment in load_fragments_from_vault(vault_path):
+        for fragment in load_fragments_from_vault(vault_path, override=override):
             mode = str(fragment.wavelength.mode)
             if mode != Mode.UNCLASSIFIED.value:
                 by_mode[mode].append(fragment)

--- a/creek-tools/creek/lint/checks/tags.py
+++ b/creek-tools/creek/lint/checks/tags.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime  # noqa: TC003  # used at runtime as a parameter type
 from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
 
+from creek.classify.privacy_filter import PrivacyTierOverride
 from creek.generate.tags import TagGardenGenerator
 from creek.lint._result import CheckResult
 
@@ -12,7 +13,14 @@ from creek.lint._result import CheckResult
 def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
     """Scan vault tags and surface orphans + merge candidates."""
     del since
-    scan = TagGardenGenerator(vault_path=vault_path).scan_tags()
+    # Stated explicitly rather than inherited (#968): an orphan-tag check must
+    # survey the whole vault or it reports "no orphan tags" about a vault that
+    # has them. Safe to keep unfiltered because ``creek.lint``'s read posture is
+    # METADATA_ONLY — ``findings`` never leave the process over MCP.
+    scan = TagGardenGenerator(
+        vault_path=vault_path,
+        override=PrivacyTierOverride.ALL,
+    ).scan_tags()
     orphans = sorted(tag for tag, count in scan.tag_counts.items() if count == 1)
     findings = [f"- `{tag}` (single use; not auto-deleted)" for tag in orphans]
     summary = (

--- a/creek-tools/creek_mcp/read_gate.py
+++ b/creek-tools/creek_mcp/read_gate.py
@@ -312,7 +312,17 @@ TOOL_POSTURES: dict[str, ToolPosture] = {
             "The checks read fragment frontmatter (paradox, unnamed and "
             "orphan-compiled scan 01-Fragments), never bodies; the MCP "
             "response returns only check names, count-shaped summaries and "
-            "len(findings). Titles live in findings, which is never returned."
+            "len(findings). Titles live in findings, which is never returned. "
+            "The posture is about the *response* only: the lint run also "
+            "writes a markdown report under 00-Creek-Meta/Processing-Log/ "
+            "that does embed above-ceiling titles and tag names, and the "
+            "tags check deliberately surveys the whole vault "
+            "(creek/lint/checks/tags.py passes PrivacyTierOverride.ALL) so it "
+            "cannot report 'no orphan tags' about a vault that has them. That "
+            "artifact is unreachable through MCP today, which is the same "
+            "argument #968 disproved for creek.report's Tag-Garden.md — it "
+            "holds here only while nothing serves Processing-Log/ back, so "
+            "read it against #969's state-artifact gap rather than alone."
         ),
     ),
     "creek.link": ToolPosture(

--- a/creek-tools/creek_mcp/read_gate.py
+++ b/creek-tools/creek_mcp/read_gate.py
@@ -43,9 +43,25 @@ RESIDUAL RISK" block documents exactly why its reason must stay distinct from
 ``entry_ref not found`` — including the timing-equalisation caveat that would
 have to be handled if the two were ever unified — and folding it into a shared
 reason would delete that reasoning along with the behaviour. The primitives
-exist so the four filed gaps (#968/#969/#970/#971) can be closed by *adoption*
-rather than by each tool re-deriving the policy, and so that a *new* tool
-finds an already-gated corpus walk on the path of least resistance.
+exist so a filed gap can be closed by *adoption* rather than by each tool
+re-deriving the policy, and so that a *new* tool finds an already-gated corpus
+walk on the path of least resistance.
+
+**Adoption is not the only honest way to close a gap, and #968 is the worked
+example.** ``creek.report`` is now ``GATED`` without adopting either
+primitive, deliberately. ``refuse_above_ceiling`` *refuses*, and the issue's
+explicit anti-goal forbids refusing ``creek.report``: that breaks every
+legitimate caller and makes the reports unreachable rather than tier-correct,
+so the inputs are filtered instead. ``iter_admitted_fragments`` summarises
+``PERSONAL`` bodies rather than dropping them — a title-only stub written into
+a voice profile's ``### Sample Passages`` leaks the title and poisons the
+corpus — and it reads the tier through the validated
+:class:`~creek.models.Fragment`, so it fails open on a *missing*
+``privacy_tier`` key. ``creek.report`` therefore joins ``wheel``, ``mine``,
+``draft`` and ``author``, all ``GATED`` on
+:func:`creek_mcp.tier_ceiling.to_privacy_override` without adopting either
+primitive. What the manifest checks is that the named gate exists and decides
+something, not which of two shapes it takes.
 
 :data:`TOOL_POSTURES` is verified by ``tests/test_mcp_read_gate.py``, which
 fails if an entry lies: the manifest must match ``server.list_tools()``
@@ -230,15 +246,23 @@ TOOL_POSTURES: dict[str, ToolPosture] = {
         gate_symbol="to_privacy_override",
     ),
     "creek.report": ToolPosture(
-        posture=ReadPosture.UNGATED_KNOWN_GAP,
+        posture=ReadPosture.GATED,
         rationale=(
-            "The ceiling is audited and echoed but never converted or "
-            "threaded: creek/generate/{tags,lexicon,decisions,wavelength}.py "
-            "contain no tier filtering at all, so report_type='tags' at "
-            "ceiling=open writes an intimate fragment's tags into "
-            "00-Creek-Meta/Tag-Garden.md. Reproduced (#968)."
+            "Converts the ceiling with to_privacy_override and threads it "
+            "into all six generators (tags, voice, lexicon, decisions, "
+            "rhetorical-patterns, mode-profiles), each of which admits a note "
+            "only when within_ceiling clears tier_within_override's hard rank "
+            "cutoff against the file's *raw* frontmatter — so a missing "
+            "privacy_tier fails closed to intimate rather than to the model's "
+            "unclassified default (#968). The gap was write-side: the "
+            "response carries only report_paths, so the evidence was always "
+            "the artifact bytes. Consequence to know: TagGardenGenerator's "
+            "four non-fragment scan directories hold note types with no "
+            "privacy_tier field, so a ceiling-filtered tag garden is "
+            "fragment-derived only."
         ),
-        gap_issue=968,
+        gate_module="creek_mcp.tools.report",
+        gate_symbol="to_privacy_override",
     ),
     "creek.state.read": ToolPosture(
         posture=ReadPosture.UNGATED_KNOWN_GAP,

--- a/creek-tools/creek_mcp/tools/report.py
+++ b/creek-tools/creek_mcp/tools/report.py
@@ -11,20 +11,43 @@ deferred to the CLI because they need date arithmetic the MCP shape
 should not own. The wrapper writes one audit entry per invocation
 including ``created_path`` for the resulting report file(s).
 
-Read-side posture (#968): the ceiling is audited and echoed but never
-converted or threaded — ``to_privacy_override`` is never called here.
-Four of the six generators (``creek/generate/{tags,lexicon,decisions,
-wavelength}.py``) contain no tier filtering whatsoever;
-``creek/generate/voice.py`` is the only one with an ``allow_intimate``
-filter. Reproduced: ``report_type="tags"`` at ``ceiling=open`` wrote an
-``intimate`` fragment's tag verbatim into
-``00-Creek-Meta/Tag-Garden.md`` and
-``00-Creek-Meta/Processing-Log/tag-history.json``. The exposure is
-write-side, not read-side: this tool returns only ``report_paths``,
-never content, and no MCP tool reads an arbitrary vault file back — so
-a low-ceiling caller cannot read the leaked artifact *through MCP*.
-What it causes instead is above-ceiling content distilled into an
-unlabelled vault file.
+Tier ceiling (#968, closed). ``privacy_tier_ceiling`` is converted here by
+:func:`creek_mcp.tier_ceiling.to_privacy_override` and threaded into **all
+six** generators, each of which admits a note only when
+:func:`creek.classify.privacy_filter.within_ceiling` says its *raw*
+frontmatter clears :func:`~creek.classify.privacy_filter.tier_within_override`'s
+hard rank cutoff. A missing ``privacy_tier`` key fails closed to
+``intimate``: the model would default it to ``unclassified``, which ranks
+with ``personal`` and would be *admitted* at ``ceiling=personal``.
+
+What #968 closed was **write-side, not read-side**, and that framing is why
+the gap survived two earlier sweeps. This tool returns only
+``report_paths`` — never a tag, a title, or a body — so its response envelope
+was canary-free at ``ceiling=open`` for the whole life of the bug and no
+response-level test could ever have caught it. The evidence lives only in the
+bytes of the artifacts a call writes; the reproduction was an ``intimate``
+fragment's tag appearing verbatim in ``00-Creek-Meta/Tag-Garden.md`` *and* in
+the append-only ``00-Creek-Meta/Processing-Log/tag-history.json``. That is
+also why ``tag-history.json`` entries now record the ``tier_ceiling`` they
+were taken under: counts from two different ceilings survey two different
+corpora and are not comparable.
+
+One consequence must be printed on the tin: ``TagGardenGenerator`` scans five
+directories, and the four beyond ``01-Fragments`` (``02-Threads``,
+``03-Eddies``, ``04-Praxis``, ``08-Decisions``) hold note types with no
+``privacy_tier`` field at all, so the fail-closed read ranks them
+``intimate``. **A ceiling-filtered tag garden is fragment-derived only.**
+Those notes are derived from fragments and untierable by construction — a
+Decision note's ``title:`` is a source fragment's title verbatim — so reading
+them at ``ceiling=open`` would hand back what a ``ceiling=all`` run distilled
+there.
+
+Neither canonical read-gate primitive fits, and both were considered:
+``refuse_above_ceiling`` *refuses*, which would make the reports unreachable
+rather than tier-correct, and ``iter_admitted_fragments`` summarises
+``personal`` bodies rather than dropping them (a summary stub written into
+``### Sample Passages`` is a leak with extra steps) while reading the tier
+through the validated model, which fails open on a missing key.
 """
 
 from __future__ import annotations
@@ -37,7 +60,7 @@ from creek.generate.tags import TagGardenGenerator
 from creek.generate.voice import VoiceProfileGenerator
 from creek.generate.wavelength import ModeProfileGenerator
 from creek_mcp.audit import MCPAuditLog
-from creek_mcp.tier_ceiling import TierCeiling, refusal_response
+from creek_mcp.tier_ceiling import TierCeiling, refusal_response, to_privacy_override
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -65,6 +88,9 @@ def report_tool(
     Reports iterate vault content internally rather than operating on a
     caller-supplied fragment list, so ``affected_fragment_ids`` is the
     empty list and ``created_path`` carries the rendered file location.
+    The ceiling is converted once, below the ``report_type`` refusal, and
+    threaded into every branch — the refusal comes first so an unsupported
+    type is answered without touching the vault at all.
     """
     if report_type not in _VALID_TYPES:
         return refusal_response(
@@ -75,23 +101,34 @@ def report_tool(
                 f"available via MCP: {', '.join(_VALID_TYPES)}"
             ),
         )
+    override = to_privacy_override(privacy_tier_ceiling)
     if report_type == "tags":
         written_paths = [
-            TagGardenGenerator(vault_path=vault_path).generate_garden(),
+            TagGardenGenerator(
+                vault_path=vault_path,
+                override=override,
+            ).generate_garden(),
         ]
     elif report_type == "lexicon":
-        _lexicon, written_paths = generate_lexicon(vault_path)
+        _lexicon, written_paths = generate_lexicon(vault_path, override=override)
     elif report_type == "decisions":
-        written_paths = generate_decisions(vault_path)
+        written_paths = generate_decisions(vault_path, override=override)
     elif report_type == "rhetorical-patterns":
         written_paths = list(
-            VoiceProfileGenerator().generate_rhetorical_patterns(vault_path),
+            VoiceProfileGenerator(override=override).generate_rhetorical_patterns(
+                vault_path,
+            ),
         )
     elif report_type == "mode-profiles":
-        written_paths = list(ModeProfileGenerator().generate_mode_profiles(vault_path))
+        written_paths = list(
+            ModeProfileGenerator().generate_mode_profiles(
+                vault_path,
+                override=override,
+            ),
+        )
     else:
         written_paths = list(
-            VoiceProfileGenerator().generate_all_profiles(vault_path),
+            VoiceProfileGenerator(override=override).generate_all_profiles(vault_path),
         )
     relative_paths = [str(p.relative_to(vault_path)) for p in written_paths]
     MCPAuditLog(vault_path).append(

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -63,7 +63,7 @@ real desk. Only the `research` medium is wired — any other `medium` returns
 | `creek.ingest`          | `source_type`, `input_path`                                 | Default ingest tier is `personal`; `ceiling=open` is refused.     |
 | `creek.classify`        | `method` (`rules`\|`llm`), `force`                          | Rewrites in place; no new tier produced — any ceiling permitted.  |
 | `creek.link`            | `method` (`embeddings`\|`temporal`\|`eddies`), `rebuild`    | Links existing artefacts in place — any ceiling permitted.        |
-| `creek.report`          | `report_type` (`tags`\|`voice`\|`decisions`\|`lexicon`\|`rhetorical-patterns`\|`mode-profiles`) | Ceiling is recorded but not enforced — known gap #968; see "Read-side posture (#932)" below. |
+| `creek.report`          | `report_type` (`tags`\|`voice`\|`decisions`\|`lexicon`\|`rhetorical-patterns`\|`mode-profiles`) | Ceiling is enforced on the *inputs* of all six generators (#968): a note enters the artifact only if its raw front matter is within `ceiling`, and a missing `privacy_tier` fails closed to `intimate`. Consequence for `tags`: the Tag Garden scans five directories, and the four beyond `01-Fragments` hold note types with no `privacy_tier` field at all, so **a ceiling-filtered tag garden is fragment-derived only**. `tag-history.json` entries record the `tier_ceiling` they were taken under, and growth is only ever compared between entries at the same ceiling. |
 | `creek.skills.refresh`  | none beyond `ceiling`                                       | Voice-skill tree regen; intimate exemplars excluded by a generator hardcode, not by the ceiling — `personal` bodies pass unsummarised at `ceiling=open` (known gap #971). |
 | `creek.compile`         | `fragment_ids`, `target_kind`, `target_id`, `target_title`  | Gates the *source* fragments' tier, not the compiled page's tier — a source above `ceiling` refuses the whole call (#848). Idempotent per FEAT-003; no-op re-runs do not log a duplicate. |
 | `creek.journal`         | `content`, `external_id`, `timestamp?`, `tier?`             | Stages an Adepthood entry then ledger-ingests it (#754); `external_id` is the idempotency key and `tier` defaults to `open`. The entry's tier is honored — a ceiling that would not admit it is refused. The tier of the fragment an existing `external_id` already maps to is **not** consulted before the update-in-place overwrites it (known gap #970). |
@@ -131,10 +131,19 @@ surface and, for `GATED` entries, against a real call site in the
 named module, and for the rest against a runtime canary probe.
 
 Most of what the sweep found is **write-side**: a tool *acts on* content
-above the caller's ceiling (#968, #970, #971) rather than handing it
+above the caller's ceiling (#970, #971) rather than handing it
 back. That is a shape the ceiling language elsewhere on this page does
 not describe — it is written entirely in read-back terms ("omitted",
 "returned as a title-only stub"), which is why those gaps survived.
+
+`creek.report` was the third of those and is now closed (#968): the ceiling
+is converted with `to_privacy_override` and threaded into all six
+generators, which filter their *inputs* through
+`creek.classify.privacy_filter.within_ceiling`. Keep the write-side framing
+in mind when reading that fix — `report_tool` returns only `report_paths`,
+so its response envelope was clean at `ceiling=open` for the whole life of
+the bug and no response-level test could have caught it. The evidence was
+always the bytes of the artifact the call wrote.
 
 One read-side leak was found, and it is worth stating how: the sweep
 first concluded there were none, having probed the tools that walk the

--- a/creek-tools/tests/test_mcp_read_gate.py
+++ b/creek-tools/tests/test_mcp_read_gate.py
@@ -100,6 +100,7 @@ from creek_mcp.tier_ceiling import TierCeiling, refusal_response
 from creek_mcp.tools.compile import _ABOVE_CEILING_REASON, compile_tool
 from creek_mcp.tools.mine import mine_tool
 from creek_mcp.tools.reflect import reflect_tool
+from creek_mcp.tools.report import report_tool
 from creek_mcp.tools.wheel import wheel_tool
 
 if TYPE_CHECKING:
@@ -135,10 +136,16 @@ _PINNED_GATE_ROWS = [
     ("creek.mine", "creek_mcp.tools.mine", "to_privacy_override"),
     ("creek.draft", "creek_mcp.tools.draft", "to_privacy_override"),
     ("creek.author", "creek_mcp.tools.author", "to_privacy_override"),
+    # #968 closed the report gap. The entry is *re-pointed* at the gate that
+    # closed it rather than relabelled: report_tool now converts the ceiling
+    # with ``to_privacy_override`` and threads the result into all six
+    # generators, so the honest record is a GATED claim layers (c) and (e) can
+    # check — which is exactly what the failure message on
+    # ``test_pinned_gaps_keep_their_posture_and_issue`` asks for.
+    ("creek.report", "creek_mcp.tools.report", "to_privacy_override"),
 ]
 
 _PINNED_GAPS = {
-    "creek.report": 968,
     "creek.state.read": 969,
     "creek.state.render": 969,
     "creek.skills.refresh": 971,
@@ -1345,11 +1352,35 @@ def _probe_compile(vault: Path) -> dict[str, Any]:
     )
 
 
+def _probe_report(vault: Path) -> dict[str, Any]:
+    """Call ``creek.report`` (``tags``) at the open ceiling over the canary vault.
+
+    ``tags`` is the report type the #968 reproduction used and the only one that
+    reaches all five of ``TagGardenGenerator``'s scan directories.
+    ``generate_garden`` writes ``00-Creek-Meta/Tag-Garden.md`` without creating
+    its parent, and ``canary_vault`` is a bare fragment vault, so the probe
+    creates the meta folder first.
+
+    Args:
+        vault: The seeded canary vault.
+
+    Returns:
+        The tool's response envelope.
+    """
+    (vault / "00-Creek-Meta").mkdir(parents=True, exist_ok=True)
+    return report_tool(
+        vault_path=vault,
+        report_type="tags",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+
 _RUNTIME_PROBES: dict[str, Callable[[Path], dict[str, Any]]] = {
     "creek.wheel": _probe_wheel,
     "creek.mine": _probe_mine,
     "creek.reflect": _probe_reflect,
     "creek.compile": _probe_compile,
+    "creek.report": _probe_report,
 }
 """``GATED`` tool → a callable that invokes it at ``ceiling=open``.
 
@@ -1518,6 +1549,58 @@ def test_wheel_probe_still_counts_the_fragment_it_is_admitted_to(
     assert response["status"] == "ok"
     assert response["total_classified"] == 1
     assert response["wheel"]["F1"]["count"] == 1
+
+
+def test_report_probe_leaves_no_canary_in_the_artifact_it_writes(
+    canary_vault: Path,
+) -> None:
+    """``creek.report``'s leak is the file it writes, not the dict it returns.
+
+    The shared assertion in
+    ``test_gated_tools_leak_no_above_ceiling_content_at_the_open_ceiling`` is
+    **structurally vacuous for this tool**. ``report_tool`` returns
+    ``report_paths`` and nothing else — never a tag, a title, or a body — so its
+    envelope is canary-free at ``ceiling=open`` whether or not the ceiling is
+    enforced, and it was canary-free for the whole life of #968. The envelope
+    check still earns its place as a tripwire against a future response shape
+    that *does* carry content, but it is not evidence about this gap.
+
+    The only evidence that means anything lives in the bytes of the artifacts
+    the call writes, and #968 reproduced against **two** of them, so both are
+    asserted: the regenerated ``Tag-Garden.md`` and the append-only
+    ``tag-history.json``, where a wrongly-admitted tag would persist across
+    every later run.
+
+    The ``open`` canary is asserted *present* as the positive control, so the
+    tool cannot pass by writing an empty garden — which a gate broken in the
+    drop-everything direction would do: leak-free, and useless.
+    """
+    response = _probe_report(canary_vault)
+    assert response["status"] == "ok"
+
+    garden_path = canary_vault / "00-Creek-Meta" / "Tag-Garden.md"
+    history_path = (
+        canary_vault / "00-Creek-Meta" / "Processing-Log" / "tag-history.json"
+    )
+    garden = garden_path.read_text(encoding="utf-8")
+    history = history_path.read_text(encoding="utf-8")
+
+    assert _RUNTIME_INTIMATE_CANARY not in garden, (
+        "creek.report distilled an intimate fragment's tag into "
+        f"00-Creek-Meta/Tag-Garden.md at privacy_tier_ceiling=open. The "
+        "response envelope was clean — it always is — so nothing above this "
+        f"line could have caught it.\n\n{garden}"
+    )
+    assert _RUNTIME_INTIMATE_CANARY not in history, (
+        "creek.report recorded an intimate fragment's tag in "
+        "00-Creek-Meta/Processing-Log/tag-history.json at "
+        "privacy_tier_ceiling=open. This file is append-only: an entry written "
+        f"at the wrong ceiling stays in the vault.\n\n{history}"
+    )
+    assert _RUNTIME_OPEN_CANARY in garden, (
+        "creek.report wrote a tag garden with no admitted tag in it, so the "
+        f"exclusion assertions above are vacuous.\n\n{garden}"
+    )
 
 
 def test_mine_probe_still_reaches_the_admitted_corpus(canary_vault: Path) -> None:

--- a/creek-tools/tests/test_mcp_read_gate.py
+++ b/creek-tools/tests/test_mcp_read_gate.py
@@ -1587,7 +1587,7 @@ def test_report_probe_leaves_no_canary_in_the_artifact_it_writes(
 
     assert _RUNTIME_INTIMATE_CANARY not in garden, (
         "creek.report distilled an intimate fragment's tag into "
-        f"00-Creek-Meta/Tag-Garden.md at privacy_tier_ceiling=open. The "
+        "00-Creek-Meta/Tag-Garden.md at privacy_tier_ceiling=open. The "
         "response envelope was clean — it always is — so nothing above this "
         f"line could have caught it.\n\n{garden}"
     )

--- a/creek-tools/tests/test_mcp_report_tier_ceiling.py
+++ b/creek-tools/tests/test_mcp_report_tier_ceiling.py
@@ -1,0 +1,1575 @@
+"""``creek.report`` must honour the caller's tier ceiling in what it *writes* (#968).
+
+``report_tool`` accepts a ``privacy_tier_ceiling``, audits it and echoes it, but
+at the time these tests were written it never converted it and never threaded
+it into any of the six generators it fans out to. The consequence is not a
+read-side leak — the tool returns only ``report_paths``, never content — it is
+**above-ceiling content distilled into an unlabelled vault artifact** that every
+later reader treats as ordinary vault material.
+
+That shapes every assertion here: *nothing* in this module asserts on
+``report_tool``'s return value as evidence of exclusion. A test that did would
+have passed against the unfixed code and proved nothing. The evidence is always
+the bytes of the file the call wrote.
+
+Two properties of the existing generators had to be designed around, and both
+are the difference between a real test and a vacuous one:
+
+1. ``voice``, ``lexicon`` and ``rhetorical-patterns`` already drop ``intimate``
+   fragments via ``creek.generate.voice._eligible_register(allow_intimate=False)``.
+   An *intimate* canary in those fixtures would have been excluded by the
+   pre-existing filter and the test would have gone green without the ceiling
+   being enforced at all. Their above-ceiling canary is therefore ``personal``.
+2. ``rhetorical-patterns`` writes **no fragment-derived text** — three integer
+   counts and nothing else — so a substring sweep over its artifact passes for
+   free. Its gate is pinned by file-set (the above-ceiling fragment's register
+   note must not exist) and by count identity across ceilings instead.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib
+import inspect
+import json
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import frontmatter
+import pytest
+from typer.testing import CliRunner
+
+from creek.classify.privacy_filter import PrivacyTierOverride
+from creek.cli import app
+from creek.models import PrivacyTier
+from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tools.report import report_tool
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+    from pathlib import Path
+    from types import ModuleType
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Canaries
+#
+# Plain sentinels rather than realistic prose: a leak cannot then be excused as
+# "that phrase could have come from anywhere". Restricted to ``[A-Za-z0-9-]``
+# because ``creek.generate.decisions._sanitize_title`` strips everything else
+# out of the filename it derives from a fragment title.
+# ---------------------------------------------------------------------------
+
+_OPEN_CANARY = "CANARY-RPT-OPEN-3a71"
+"""Below every ceiling under test — the mandatory positive control."""
+
+_INTIMATE_CANARY = "CANARY-RPT-INTIMATE-8c4e"
+"""Above ``ceiling=open`` for ``tags`` / ``decisions`` / ``mode-profiles``."""
+
+_PERSONAL_CANARY = "CANARY-RPT-PERSONAL-1f95"
+"""Above ``ceiling=open`` for the three voice-corpus reports (see module doc)."""
+
+_NOTIER_CANARY = "CANARY-RPT-NOTIER-6b02"
+"""Carried by a fragment whose front matter has no ``privacy_tier`` key at all."""
+
+
+# Bodies for the voice-corpus fixture. ``sangha`` and ``dharma`` are members of
+# ``creek.generate.lexicon.TRADITION_GLOSSARIES["buddhist"]``, and
+# ``LexiconGenerator._build_borrowed_terms`` records the *whole surrounding
+# sentence* verbatim with no occurrence threshold — the cheapest way to get a
+# fragment's own prose copied into ``glossary.md`` byte for byte.
+_OPEN_VOICE_BODY = (
+    f"The sangha of {_OPEN_CANARY} gathers, and yet the room stays quiet."
+)
+_PERSONAL_VOICE_BODY = (
+    f"The dharma of {_PERSONAL_CANARY} is quiet, but also loud. "
+    "As I mentioned, it returns."
+)
+
+# The exact rhetorical-move tally ``_OPEN_VOICE_BODY`` produces: one paradox
+# construction ("and yet") and nothing else. Pinned as values rather than as a
+# bare "the two files match" so a gate that silently emptied the analytical
+# register would fail here too.
+_EXPECTED_ANALYTICAL_MOVES = {
+    "Self-deprecation before insight": 0,
+    "Paradox constructions": 1,
+    "Callbacks to earlier points": 0,
+}
+
+_MOVE_LINE_RE = re.compile(r"^- (?P<label>[^:\n]+): (?P<count>\d+)\.$", re.MULTILINE)
+"""Matches one ``- <label>: <n>.`` line of ``_format_rhetorical_moves`` output."""
+
+
+# ---------------------------------------------------------------------------
+# Vault-building helpers
+#
+# Kept in this file rather than conftest.py: every fixture here is shaped around
+# one specific generator's admission conditions, and moving them to shared scope
+# would invite a later edit to "simplify" one of those conditions away.
+# ---------------------------------------------------------------------------
+
+
+def _new_vault(root: Path, name: str) -> Path:
+    """Create an empty vault skeleton under *root* and return its path.
+
+    ``TagGardenGenerator.generate_garden`` writes ``00-Creek-Meta/Tag-Garden.md``
+    without creating its parent directory, so the meta folder is part of the
+    skeleton rather than something each caller remembers.
+
+    Args:
+        root: Directory the vault is created inside (typically ``tmp_path``).
+        name: Vault directory name, so one test can build several vaults.
+
+    Returns:
+        The vault root.
+    """
+    vault = root / name
+    (vault / "00-Creek-Meta").mkdir(parents=True, exist_ok=True)
+    (vault / "01-Fragments" / "Notes").mkdir(parents=True, exist_ok=True)
+    return vault
+
+
+def _write_note(
+    vault: Path,
+    relpath: str,
+    metadata: dict[str, Any],
+    body: str,
+) -> Path:
+    """Write one markdown note with YAML front matter into the vault.
+
+    Args:
+        vault: Vault root.
+        relpath: Vault-relative destination path.
+        metadata: Front-matter mapping, written verbatim — a key omitted here
+            is a key genuinely absent from the file, which is the distinction
+            the fail-closed tier read depends on.
+        body: Markdown body.
+
+    Returns:
+        The path written.
+    """
+    target = vault / relpath
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _fragment_metadata(
+    *,
+    frag_id: str,
+    title: str,
+    privacy_tier: str | None,
+    tags: list[str] | None = None,
+    mode: str | None = None,
+    register: str | None = None,
+    confidence: str = "settled",
+) -> dict[str, Any]:
+    """Build fragment front matter, omitting keys the caller did not ask for.
+
+    Args:
+        frag_id: Fragment id.
+        title: Fragment title — the carrier for the ``decisions`` and
+            ``mode-profiles`` canaries.
+        privacy_tier: The declared tier, or ``None`` to omit the key entirely.
+            ``None`` is not the same as ``"unclassified"``: the model defaults a
+            missing key to ``unclassified``, and only the raw front matter can
+            still tell the two apart.
+        tags: Obsidian tags — the carrier for the ``tags`` canaries.
+        mode: Wavelength engagement mode; set to make the fragment visible to
+            ``mode-profiles``.
+        register: Voice register; set to make the fragment exemplar-eligible.
+        confidence: Voice confidence. Must be ``settled`` or ``conviction`` for
+            ``_eligible_register`` to admit the fragment.
+
+    Returns:
+        A front-matter mapping ready for :func:`_write_note`.
+    """
+    meta: dict[str, Any] = {
+        "type": "fragment",
+        "id": frag_id,
+        "title": title,
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "F5", "secondary": []},
+    }
+    if privacy_tier is not None:
+        meta["privacy_tier"] = privacy_tier
+    if tags is not None:
+        meta["tags"] = tags
+    if mode is not None:
+        meta["wavelength"] = {"phase": "rising", "mode": mode}
+    if register is not None:
+        meta["voice"] = {"voice_register": register, "confidence": confidence}
+    return meta
+
+
+def _build_tags_vault(root: Path) -> Path:
+    """Seed one ``open`` and one ``intimate`` fragment, each with a tag canary.
+
+    Args:
+        root: Directory the vault is created inside.
+
+    Returns:
+        The vault root.
+    """
+    vault = _new_vault(root, "tags-vault")
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-open.md",
+        _fragment_metadata(
+            frag_id="frag-open",
+            title="Open note",
+            privacy_tier="open",
+            tags=[_OPEN_CANARY],
+        ),
+        "Open body.",
+    )
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-intimate.md",
+        _fragment_metadata(
+            frag_id="frag-intimate",
+            title="Intimate note",
+            privacy_tier="intimate",
+            tags=[_INTIMATE_CANARY],
+        ),
+        "Intimate body.",
+    )
+    return vault
+
+
+def _build_decisions_vault(root: Path) -> Path:
+    """Seed two decision-signalling fragments, one ``open`` and one ``intimate``.
+
+    Both titles open with ``"Should I"`` so ``DecisionDetector._detect_keywords``
+    flags them; the canary rides in the title, which ends up verbatim in the
+    generated note's filename *and* its ``title:`` front matter.
+    ``08-Decisions/Active/`` is deliberately left absent so the idempotency skip
+    in ``_existing_decision_fragment_ids`` cannot suppress either note.
+
+    Args:
+        root: Directory the vault is created inside.
+
+    Returns:
+        The vault root.
+    """
+    vault = _new_vault(root, "decisions-vault")
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-open.md",
+        _fragment_metadata(
+            frag_id="frag-open",
+            title=f"Should I keep {_OPEN_CANARY}",
+            privacy_tier="open",
+        ),
+        "Open body.",
+    )
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-intimate.md",
+        _fragment_metadata(
+            frag_id="frag-intimate",
+            title=f"Should I keep {_INTIMATE_CANARY}",
+            privacy_tier="intimate",
+        ),
+        "Intimate body.",
+    )
+    return vault
+
+
+def _build_mode_profiles_vault(root: Path) -> Path:
+    """Seed two ``express``-mode fragments, one ``open`` and one ``intimate``.
+
+    Both share the same mode on purpose: ``05-Wavelength/Mode-Profiles/express.md``
+    is then written at *every* ceiling, so "the above-ceiling title is absent"
+    cannot be satisfied by the note simply not existing.
+
+    Args:
+        root: Directory the vault is created inside.
+
+    Returns:
+        The vault root.
+    """
+    vault = _new_vault(root, "mode-profiles-vault")
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-open.md",
+        _fragment_metadata(
+            frag_id="frag-open",
+            title=f"Express note {_OPEN_CANARY}",
+            privacy_tier="open",
+            mode="express",
+        ),
+        "Open body.",
+    )
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-intimate.md",
+        _fragment_metadata(
+            frag_id="frag-intimate",
+            title=f"Express note {_INTIMATE_CANARY}",
+            privacy_tier="intimate",
+            mode="express",
+        ),
+        "Intimate body.",
+    )
+    return vault
+
+
+def _build_voice_vault(root: Path) -> Path:
+    """Seed two exemplar-eligible fragments in *different* registers.
+
+    The above-ceiling fragment is ``personal``, not ``intimate``: the voice
+    corpus already excludes ``intimate`` regardless of the ceiling, so an
+    intimate canary here would prove nothing (see the module docstring).
+
+    The registers are segregated — ``open`` is ``analytical``, ``personal`` is
+    ``confessional`` — so ``rhetorical-patterns``, which writes no
+    fragment-derived text at all, can still be pinned by which per-register
+    files exist.
+
+    Args:
+        root: Directory the vault is created inside.
+
+    Returns:
+        The vault root.
+    """
+    vault = _new_vault(root, "voice-vault")
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-open-voice.md",
+        _fragment_metadata(
+            frag_id="frag-open-voice",
+            title="Open exemplar",
+            privacy_tier="open",
+            register="analytical",
+        ),
+        _OPEN_VOICE_BODY,
+    )
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-personal-voice.md",
+        _fragment_metadata(
+            frag_id="frag-personal-voice",
+            title="Personal exemplar",
+            privacy_tier="personal",
+            register="confessional",
+        ),
+        _PERSONAL_VOICE_BODY,
+    )
+    return vault
+
+
+def _build_eddy_vault(root: Path) -> Path:
+    """Seed an ``open`` fragment plus a tagged eddy note under ``03-Eddies``.
+
+    ``TagGardenGenerator`` scans five directories, not one. An eddy carries no
+    ``privacy_tier`` of its own but its tags are derived from its member
+    fragments, so it is a second, independent route for the same leak.
+
+    Args:
+        root: Directory the vault is created inside.
+
+    Returns:
+        The vault root.
+    """
+    vault = _new_vault(root, "eddy-vault")
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-open.md",
+        _fragment_metadata(
+            frag_id="frag-open",
+            title="Open note",
+            privacy_tier="open",
+            tags=[_OPEN_CANARY],
+        ),
+        "Open body.",
+    )
+    _write_note(
+        vault,
+        "03-Eddies/eddy-canary.md",
+        {
+            "type": "eddy",
+            "id": "eddy-canary",
+            "title": "Canary eddy",
+            "tags": [_INTIMATE_CANARY],
+        },
+        "Eddy body.",
+    )
+    return vault
+
+
+def _build_untiered_vault(root: Path) -> Path:
+    """Seed a fragment with **no** ``privacy_tier`` key beside an ``open`` one.
+
+    Args:
+        root: Directory the vault is created inside.
+
+    Returns:
+        The vault root.
+    """
+    vault = _new_vault(root, "untiered-vault")
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-open.md",
+        _fragment_metadata(
+            frag_id="frag-open",
+            title="Open note",
+            privacy_tier="open",
+            tags=[_OPEN_CANARY],
+        ),
+        "Open body.",
+    )
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-notier.md",
+        _fragment_metadata(
+            frag_id="frag-notier",
+            title="Untiered note",
+            privacy_tier=None,
+            tags=[_NOTIER_CANARY],
+        ),
+        "Untiered body.",
+    )
+    return vault
+
+
+# ---------------------------------------------------------------------------
+# Artifact inspection helpers
+# ---------------------------------------------------------------------------
+
+
+def _artifact_files(vault: Path, roots: tuple[str, ...]) -> list[Path]:
+    """Return every file beneath the given vault-relative artifact *roots*.
+
+    Args:
+        vault: Vault root.
+        roots: Vault-relative directories (or files) the report writes into.
+
+    Returns:
+        Sorted list of existing files. Absent roots contribute nothing, so a
+        report that wrote no artifact yields an empty list rather than raising —
+        the positive-control assertions are what catch that case.
+    """
+    out: list[Path] = []
+    for root in roots:
+        base = vault / root
+        if not base.exists():
+            continue
+        if base.is_file():
+            out.append(base)
+            continue
+        out.extend(sorted(p for p in base.rglob("*") if p.is_file()))
+    return out
+
+
+def _artifact_blob(vault: Path, roots: tuple[str, ...]) -> str:
+    """Return every artifact's vault-relative path and text, concatenated.
+
+    Paths are included alongside contents because one of the six reports —
+    ``decisions`` — puts the fragment title verbatim into the *filename*. A
+    contents-only sweep would miss it entirely.
+
+    Args:
+        vault: Vault root.
+        roots: Vault-relative artifact roots.
+
+    Returns:
+        One string covering every artifact path and body.
+    """
+    parts: list[str] = []
+    for path in _artifact_files(vault, roots):
+        parts.append(str(path.relative_to(vault)))
+        parts.append(path.read_text(encoding="utf-8", errors="replace"))
+    return "\n".join(parts)
+
+
+def _snapshot(vault: Path) -> dict[Path, bytes]:
+    """Return the full byte contents of every file in the vault.
+
+    Bytes rather than ``(mtime_ns, size)``: a report that rewrites a file with
+    same-length content inside one filesystem timestamp tick would look
+    unchanged to a stat-based snapshot, and "unchanged" is exactly the state
+    this snapshot is used to rule out.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        Mapping of path to contents.
+    """
+    return {p: p.read_bytes() for p in vault.rglob("*") if p.is_file()}
+
+
+def _changed_files(vault: Path, before: dict[Path, bytes]) -> list[Path]:
+    """Return every file that is new or whose bytes differ from *before*.
+
+    Args:
+        vault: Vault root.
+        before: A :func:`_snapshot` taken before the call under test.
+
+    Returns:
+        Sorted list of new-or-modified files.
+    """
+    return sorted(
+        p
+        for p in vault.rglob("*")
+        if p.is_file() and before.get(p) != p.read_bytes()
+    )
+
+
+def _new_tags_section(garden: str) -> str:
+    """Return the ``### New Tags`` block of a rendered Tag Garden.
+
+    Args:
+        garden: The full ``Tag-Garden.md`` text.
+
+    Returns:
+        The text between ``### New Tags`` and the next ``## `` heading, or the
+        empty string when the section is absent.
+    """
+    marker = "### New Tags"
+    start = garden.find(marker)
+    if start == -1:
+        return ""
+    rest = garden[start + len(marker) :]
+    end = rest.find("\n## ")
+    return rest if end == -1 else rest[:end]
+
+
+def _move_counts(note: str) -> dict[str, int]:
+    """Parse the ``### Rhetorical Moves`` counts out of a register note.
+
+    Args:
+        note: The full text of a ``07-Voice/Rhetorical-Patterns/<register>.md``.
+
+    Returns:
+        Mapping of move label to its integer count.
+    """
+    return {
+        match.group("label"): int(match.group("count"))
+        for match in _MOVE_LINE_RE.finditer(note)
+    }
+
+
+# ---------------------------------------------------------------------------
+# The six report types, described once
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ReportCase:
+    """One report type plus everything needed to judge what it wrote.
+
+    Attributes:
+        report_type: The ``report_type`` argument to ``report_tool``.
+        build: Builds this report's fixture vault under a given root.
+        above_canary: The sentinel carried by the above-ceiling fragment.
+        below_canary: The sentinel carried by the below-ceiling fragment, or
+            ``None`` for ``rhetorical-patterns``, whose artifact contains no
+            fragment-derived text for a substring check to find.
+        artifact_roots: Vault-relative roots this report writes into.
+        positive_glob: A vault-relative glob that must match at least one file
+            at ``ceiling=open`` — the proof the generator ran at all.
+        forbidden_glob: A vault-relative glob that must match nothing at
+            ``ceiling=open`` and something at ``ceiling=all``, or ``None`` when
+            the report writes a single ceiling-independent file.
+    """
+
+    report_type: str
+    build: Callable[[Path], Path]
+    above_canary: str
+    below_canary: str | None
+    artifact_roots: tuple[str, ...]
+    positive_glob: str
+    forbidden_glob: str | None
+
+
+_CASES: tuple[_ReportCase, ...] = (
+    _ReportCase(
+        report_type="tags",
+        build=_build_tags_vault,
+        above_canary=_INTIMATE_CANARY,
+        below_canary=_OPEN_CANARY,
+        artifact_roots=("00-Creek-Meta",),
+        positive_glob="00-Creek-Meta/Tag-Garden.md",
+        forbidden_glob=None,
+    ),
+    _ReportCase(
+        report_type="decisions",
+        build=_build_decisions_vault,
+        above_canary=_INTIMATE_CANARY,
+        below_canary=_OPEN_CANARY,
+        artifact_roots=("08-Decisions",),
+        positive_glob="08-Decisions/Active/*.md",
+        forbidden_glob=None,
+    ),
+    _ReportCase(
+        report_type="mode-profiles",
+        build=_build_mode_profiles_vault,
+        above_canary=_INTIMATE_CANARY,
+        below_canary=_OPEN_CANARY,
+        artifact_roots=("05-Wavelength",),
+        positive_glob="05-Wavelength/Mode-Profiles/express.md",
+        forbidden_glob=None,
+    ),
+    _ReportCase(
+        report_type="voice",
+        build=_build_voice_vault,
+        above_canary=_PERSONAL_CANARY,
+        below_canary=_OPEN_CANARY,
+        artifact_roots=("07-Voice",),
+        positive_glob="07-Voice/analytical-profile.md",
+        forbidden_glob="07-Voice/confessional-profile.md",
+    ),
+    _ReportCase(
+        report_type="lexicon",
+        build=_build_voice_vault,
+        above_canary=_PERSONAL_CANARY,
+        below_canary=_OPEN_CANARY,
+        artifact_roots=("07-Voice/Lexicon",),
+        positive_glob="07-Voice/Lexicon/glossary.md",
+        forbidden_glob=None,
+    ),
+    _ReportCase(
+        report_type="rhetorical-patterns",
+        build=_build_voice_vault,
+        above_canary=_PERSONAL_CANARY,
+        below_canary=None,
+        artifact_roots=("07-Voice/Rhetorical-Patterns",),
+        positive_glob="07-Voice/Rhetorical-Patterns/analytical.md",
+        forbidden_glob="07-Voice/Rhetorical-Patterns/confessional.md",
+    ),
+)
+"""Every report type ``creek.report`` exposes, in ``_VALID_TYPES`` order."""
+
+_CASE_IDS = [case.report_type for case in _CASES]
+
+_CASE_BY_TYPE = {case.report_type: case for case in _CASES}
+
+
+# ---------------------------------------------------------------------------
+# T1 / T2 — exclusion in both directions, with positive controls
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_CASE_IDS)
+def test_report_at_open_ceiling_excludes_above_ceiling_content(
+    case: _ReportCase,
+    tmp_path: Path,
+) -> None:
+    """No report writes above-ceiling content into its artifact at ``open``.
+
+    Asserted against the artifact bytes and the artifact *paths*, never against
+    ``report_tool``'s response. The response carries only ``report_paths``, so a
+    response-level assertion is satisfied by the unfixed code and proves
+    nothing; the leak has always been the file.
+
+    The below-ceiling canary is asserted *present* in the same test, and that is
+    not decoration: without it, a generator that filtered everything out — or
+    crashed into writing an empty file — would satisfy the exclusion assertion
+    perfectly while being an outage rather than a gate.
+
+    ``rhetorical-patterns`` has no below-ceiling substring to assert (its
+    artifact is three integers), so its positive control is the file-set: the
+    ``open`` fragment's register note must exist while the ``personal``
+    fragment's must not.
+
+    Args:
+        case: The report type under test and its fixture.
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = case.build(tmp_path)
+    result = report_tool(
+        vault_path=vault,
+        report_type=case.report_type,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+
+    blob = _artifact_blob(vault, case.artifact_roots)
+    assert case.above_canary not in blob, (
+        f"report_type={case.report_type!r} at privacy_tier_ceiling=open wrote "
+        f"the above-ceiling sentinel {case.above_canary!r} into "
+        f"{case.artifact_roots}. The response was clean — it always is — so the "
+        f"only place this shows up is the artifact:\n\n{blob}"
+    )
+    assert list(vault.glob(case.positive_glob)), (
+        f"report_type={case.report_type!r} wrote nothing matching "
+        f"{case.positive_glob!r} at ceiling=open, so the exclusion assertion "
+        "above is vacuous. A gate that drops everything is an outage."
+    )
+    if case.below_canary is not None:
+        assert case.below_canary in blob, (
+            f"report_type={case.report_type!r} dropped the below-ceiling "
+            f"sentinel {case.below_canary!r} at ceiling=open. Admitted content "
+            "must still reach the artifact."
+        )
+    if case.forbidden_glob is not None:
+        assert not list(vault.glob(case.forbidden_glob)), (
+            f"report_type={case.report_type!r} wrote "
+            f"{case.forbidden_glob!r} at ceiling=open. That file exists only "
+            "because an above-ceiling fragment was admitted to the corpus, "
+            "even though the file's own contents name no fragment."
+        )
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_CASE_IDS)
+def test_report_at_all_ceiling_admits_everything(
+    case: _ReportCase,
+    tmp_path: Path,
+) -> None:
+    """``ceiling=all`` is the explicit override: nothing is filtered out.
+
+    The permissive direction has to be pinned as hard as the restrictive one.
+    Every assertion in the test above is satisfied by a generator that writes an
+    empty artifact at every ceiling, so without this test "the ceiling is
+    enforced" and "the report is broken" are indistinguishable.
+
+    Args:
+        case: The report type under test and its fixture.
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = case.build(tmp_path)
+    result = report_tool(
+        vault_path=vault,
+        report_type=case.report_type,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert result["status"] == "ok"
+
+    blob = _artifact_blob(vault, case.artifact_roots)
+    assert case.above_canary in blob, (
+        f"report_type={case.report_type!r} at ceiling=all dropped "
+        f"{case.above_canary!r}. ALL is the operator's explicit override; "
+        "filtering under it is a regression, not caution."
+    )
+    if case.below_canary is not None:
+        assert case.below_canary in blob
+    assert list(vault.glob(case.positive_glob))
+    if case.forbidden_glob is not None:
+        assert list(vault.glob(case.forbidden_glob)), (
+            f"report_type={case.report_type!r} at ceiling=all did not write "
+            f"{case.forbidden_glob!r}, so the file-set assertion at ceiling=open "
+            "could be passing because the file is never written at all."
+        )
+
+
+def test_rhetorical_pattern_counts_are_identical_across_ceilings(
+    tmp_path: Path,
+) -> None:
+    """The admitted register's counts do not move when the ceiling widens.
+
+    ``rhetorical-patterns`` is the one report whose artifact contains no
+    fragment-derived string, so a canary sweep over it is structurally vacuous.
+    Two properties replace it: the file-set assertions in the two tests above,
+    and this one — the numbers in ``analytical.md`` must be byte-identical at
+    ``ceiling=open`` and ``ceiling=all``.
+
+    That is what rules out the subtler failure the file-set check cannot see: an
+    above-ceiling fragment being folded into an *admitted* register's corpus,
+    which would leave the file names unchanged and only shift the counts.
+
+    The expected tally is pinned by value as well as by equality, so a
+    generator that emptied the analytical corpus (making both files trivially
+    equal at zero) fails here.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    open_vault = _build_voice_vault(tmp_path / "open-ceiling")
+    all_vault = _build_voice_vault(tmp_path / "all-ceiling")
+    report_tool(
+        vault_path=open_vault,
+        report_type="rhetorical-patterns",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    report_tool(
+        vault_path=all_vault,
+        report_type="rhetorical-patterns",
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    relpath = "07-Voice/Rhetorical-Patterns/analytical.md"
+    at_open = (open_vault / relpath).read_text(encoding="utf-8")
+    at_all = (all_vault / relpath).read_text(encoding="utf-8")
+    assert _move_counts(at_open) == _EXPECTED_ANALYTICAL_MOVES
+    assert _move_counts(at_all) == _EXPECTED_ANALYTICAL_MOVES
+
+
+# ---------------------------------------------------------------------------
+# T3 — the second artifact the #968 reproduction named
+# ---------------------------------------------------------------------------
+
+
+def _read_history(vault: Path) -> tuple[str, list[dict[str, Any]]]:
+    """Return the raw text and parsed entries of ``tag-history.json``.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        ``(raw_text, entries)``.
+    """
+    path = vault / "00-Creek-Meta" / "Processing-Log" / "tag-history.json"
+    raw = path.read_text(encoding="utf-8")
+    entries: list[dict[str, Any]] = json.loads(raw)
+    return raw, entries
+
+
+def test_tag_history_excludes_above_ceiling_tags_and_records_its_ceiling(
+    tmp_path: Path,
+) -> None:
+    """``tag-history.json`` is a second artifact and needs its own assertions.
+
+    The #968 reproduction found the intimate tag in *two* files. ``Tag-Garden.md``
+    is regenerated from scratch each run, but the history file is append-only —
+    an entry written at the wrong ceiling stays in the vault forever, and every
+    later run reads it back. Asserting on the garden alone would leave that
+    persistent copy unexamined.
+
+    Both the parsed counts and the raw file text are checked, because "absent
+    from ``tag_counts``" would still hold if the tag survived in some other key.
+    The recorded ``tier_ceiling`` is what makes the entry interpretable at all:
+    a count taken under one ceiling is not comparable to a count taken under
+    another.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = _build_tags_vault(tmp_path)
+    report_tool(
+        vault_path=vault,
+        report_type="tags",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    raw, entries = _read_history(vault)
+    newest = entries[-1]
+    assert _INTIMATE_CANARY not in newest["tag_counts"]
+    assert newest["tag_counts"][_OPEN_CANARY] == 1
+    assert _INTIMATE_CANARY not in raw, (
+        "the intimate tag survives somewhere in tag-history.json:\n\n" + raw
+    )
+    assert newest["tier_ceiling"] == "open"
+
+
+def test_tag_history_does_not_compare_growth_across_ceilings(
+    tmp_path: Path,
+) -> None:
+    """Growth is only ever measured against an entry taken at the same ceiling.
+
+    Two runs at different ceilings survey two different corpora. Comparing one
+    against the other produces growth figures that are not merely imprecise but
+    meaningless — every tag the wider ceiling admits reads as brand new, and
+    every tag the narrower one dropped reads as a collapse.
+
+    The discriminating assertion is about the **open** canary, not the intimate
+    one. After a second run at ``ceiling=all``, the intimate tag is new under
+    either behaviour (nothing had ever counted it). The open tag is new *only*
+    if the ``open``-ceiling entry was correctly rejected as a comparison
+    baseline — had it been used, the open tag would have been seen before and
+    would not appear under "New Tags" at all.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = _build_tags_vault(tmp_path)
+    report_tool(
+        vault_path=vault,
+        report_type="tags",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    report_tool(
+        vault_path=vault,
+        report_type="tags",
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    _raw, entries = _read_history(vault)
+    assert [entry["tier_ceiling"] for entry in entries] == ["open", "all"]
+
+    garden = (vault / "00-Creek-Meta" / "Tag-Garden.md").read_text(encoding="utf-8")
+    new_tags = _new_tags_section(garden)
+    assert _INTIMATE_CANARY in new_tags
+    assert _OPEN_CANARY in new_tags, (
+        "the ceiling=all run treated the earlier ceiling=open entry as its "
+        "growth baseline, so a tag that was only ever counted under a narrower "
+        "ceiling no longer reads as new. Growth across mixed ceilings is not a "
+        "comparison, it is a category error.\n\n" + garden
+    )
+
+
+# ---------------------------------------------------------------------------
+# T4 — a missing key is not an "unclassified" key
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("ceiling", "admitted"),
+    [
+        (TierCeiling.OPEN, False),
+        (TierCeiling.PERSONAL, False),
+        (TierCeiling.INTIMATE, True),
+    ],
+    ids=["open", "personal", "intimate"],
+)
+def test_fragment_with_no_privacy_tier_key_fails_closed_to_intimate(
+    tmp_path: Path,
+    ceiling: TierCeiling,
+    admitted: bool,
+) -> None:
+    """A fragment with no ``privacy_tier`` key at all ranks as ``intimate``.
+
+    **The ``personal`` row is the load-bearing one, and it is why this test
+    exists.** ``Fragment`` defaults a *missing* ``privacy_tier`` to
+    ``unclassified``, and ``unclassified`` ranks with ``personal`` (#876/#961) —
+    so an implementation that read the tier off the validated model instead of
+    the raw front matter would refuse this fragment at ``open`` and *admit* it at
+    ``personal``. Both implementations pass an ``open``-only assertion. Only the
+    ``personal`` row tells them apart.
+
+    A file with no key at all carries less assurance than a pipeline-written one
+    that at least says ``unclassified`` out loud, which is why the raw read has
+    to fail all the way closed rather than to ``personal``.
+
+    The ``open``-tier fragment is present at every ceiling as the positive
+    control, so "excluded" cannot be satisfied by an empty garden.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+        ceiling: The ceiling the report is run at.
+        admitted: Whether the untiered fragment's tag should appear.
+    """
+    vault = _build_untiered_vault(tmp_path)
+    report_tool(
+        vault_path=vault,
+        report_type="tags",
+        privacy_tier_ceiling=ceiling,
+    )
+    garden = (vault / "00-Creek-Meta" / "Tag-Garden.md").read_text(encoding="utf-8")
+    assert _OPEN_CANARY in garden
+    assert (_NOTIER_CANARY in garden) is admitted, (
+        f"a fragment with no privacy_tier key was "
+        f"{'excluded from' if admitted else 'admitted to'} the tag garden at "
+        f"ceiling={ceiling.value!r}. A missing key must fail closed to "
+        "intimate, not default to the model's 'unclassified'.\n\n" + garden
+    )
+
+
+# ---------------------------------------------------------------------------
+# T5 — the four non-fragment scan directories
+# ---------------------------------------------------------------------------
+
+
+def test_tag_garden_excludes_untiered_eddy_tags_at_the_open_ceiling(
+    tmp_path: Path,
+) -> None:
+    """``03-Eddies`` is scanned too, and an eddy has no tier of its own.
+
+    ``TagGardenGenerator`` walks five directories — ``01-Fragments``,
+    ``02-Threads``, ``03-Eddies``, ``04-Praxis``, ``08-Decisions`` — with a raw
+    ``frontmatter.load`` and no ``Fragment`` model in sight. Gating only the
+    fragment directory would leave four open routes to the same artifact, and an
+    eddy's tags are *derived from its member fragments*, so this is not a
+    hypothetical route: it is the same tags arriving by a different file.
+
+    Note what this pins: because those note types carry no ``privacy_tier``, the
+    fail-closed read ranks them ``intimate`` and they are dropped below
+    ``ceiling=intimate``. That is a real design choice with a real cost, and
+    asserting it here makes it checkable rather than a matter of taste.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = _build_eddy_vault(tmp_path)
+    report_tool(
+        vault_path=vault,
+        report_type="tags",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    garden = (vault / "00-Creek-Meta" / "Tag-Garden.md").read_text(encoding="utf-8")
+    assert _OPEN_CANARY in garden
+    assert _INTIMATE_CANARY not in garden, (
+        "an eddy note under 03-Eddies carried an above-ceiling tag into "
+        "Tag-Garden.md at ceiling=open. Gating 01-Fragments alone leaves four "
+        f"other scan directories ungated.\n\n{garden}"
+    )
+
+
+def test_tag_garden_includes_untiered_eddy_tags_at_the_all_ceiling(
+    tmp_path: Path,
+) -> None:
+    """The eddy route is not simply severed — ``ceiling=all`` still sees it.
+
+    The companion to the test above. Dropping every non-fragment note
+    unconditionally would satisfy that assertion and quietly gut the tag garden
+    for the operator who explicitly asked for everything.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = _build_eddy_vault(tmp_path)
+    report_tool(
+        vault_path=vault,
+        report_type="tags",
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    garden = (vault / "00-Creek-Meta" / "Tag-Garden.md").read_text(encoding="utf-8")
+    assert _OPEN_CANARY in garden
+    assert _INTIMATE_CANARY in garden
+
+
+# ---------------------------------------------------------------------------
+# T6 — mutation resistance: the gate's *return value* must decide something
+# ---------------------------------------------------------------------------
+
+
+class _InvertingGate:
+    """A ``within_ceiling`` stand-in that returns the opposite verdict.
+
+    Wraps the real predicate and negates it, counting calls. Two distinct
+    mutations die against it:
+
+    * a generator that *calls* the gate and discards its result is unaffected by
+      inversion, so its artifact still holds the below-ceiling content and the
+      inverted expectation fails;
+    * a generator that stopped calling the gate leaves ``call_count`` at zero.
+
+    Attributes:
+        call_count: How many times the gate was invoked.
+    """
+
+    def __init__(
+        self,
+        real: Callable[[Mapping[str, object], PrivacyTierOverride], bool],
+    ) -> None:
+        """Store the real gate and zero the counter.
+
+        Args:
+            real: The genuine ``within_ceiling`` implementation.
+        """
+        self._real = real
+        self.call_count = 0
+
+    def __call__(
+        self,
+        raw: Mapping[str, object],
+        override: PrivacyTierOverride,
+    ) -> bool:
+        """Return the negation of the real verdict.
+
+        Args:
+            raw: The file's raw front matter.
+            override: The admission ceiling.
+
+        Returns:
+            ``not within_ceiling(raw, override)``.
+        """
+        self.call_count += 1
+        return not self._real(raw, override)
+
+
+_GATE_CALL_SITES = [
+    pytest.param("tags", "creek.generate.tags", id="tags"),
+    pytest.param("voice", "creek.generate.voice", id="voice"),
+    pytest.param("lexicon", "creek.generate.voice", id="lexicon"),
+    pytest.param("decisions", "creek.generate.decisions", id="decisions"),
+    pytest.param("mode-profiles", "creek.generate.wavelength", id="wavelength"),
+]
+"""``(report_type, module whose ``within_ceiling`` the walk actually calls)``.
+
+``lexicon`` is the odd row and deliberately so: ``generate_lexicon`` owns no
+vault walk of its own — it delegates to
+``creek.generate.voice.VoiceExemplarCollector.collect_all_exemplars`` — so the
+gate is patched in ``creek.generate.voice`` while the call is driven through
+``report_type="lexicon"``. Patching ``creek.generate.lexicon`` instead would
+patch a name nothing calls, and the test would pass while the walk stayed
+ungated. Between them the five rows cover all five generator modules.
+"""
+
+
+@pytest.mark.parametrize(("report_type", "module"), _GATE_CALL_SITES)
+def test_report_generators_act_on_the_gate_verdict_not_just_call_it(
+    report_type: str,
+    module: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inverting the gate must invert the artifact.
+
+    Everything else in this file can be satisfied by a generator that invokes
+    ``within_ceiling`` on the request path and then ignores what it said — the
+    call site exists, the import exists, an AST walk finds it, and the artifact
+    is whatever it always was. Only replacing the gate with one that answers
+    *backwards* can tell "consulted" from "obeyed".
+
+    Both halves are asserted. The inverted artifact must now carry the
+    above-ceiling sentinel and must have lost the below-ceiling one — which
+    fails for a generator that discards the verdict — and ``call_count`` must be
+    non-zero, which fails for a generator that stopped consulting the gate at
+    all.
+
+    Args:
+        report_type: The report driving the walk.
+        module: The module whose ``within_ceiling`` name is patched.
+        tmp_path: pytest's per-test temporary directory.
+        monkeypatch: pytest's patching fixture.
+    """
+    # Imported here rather than at module scope so the artifact-level tests
+    # above fail on the leak itself rather than on a collection-time ImportError
+    # while the new privacy_filter API is still absent.
+    from creek.classify.privacy_filter import within_ceiling
+
+    case = _CASE_BY_TYPE[report_type]
+    vault = case.build(tmp_path)
+    spy = _InvertingGate(within_ceiling)
+    monkeypatch.setattr(f"{module}.within_ceiling", spy)
+
+    report_tool(
+        vault_path=vault,
+        report_type=report_type,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    blob = _artifact_blob(vault, case.artifact_roots)
+
+    assert spy.call_count > 0, (
+        f"{module}.within_ceiling was never called while generating "
+        f"report_type={report_type!r}. A gate off the request path enforces "
+        "nothing."
+    )
+    assert case.above_canary in blob, (
+        f"inverting {module}.within_ceiling did not change what "
+        f"report_type={report_type!r} wrote: {case.above_canary!r} is still "
+        "absent. The generator calls the gate and discards its verdict.\n\n"
+        f"{blob}"
+    )
+    if case.below_canary is not None:
+        assert case.below_canary not in blob, (
+            f"inverting {module}.within_ceiling left {case.below_canary!r} in "
+            f"the artifact, so the verdict is not what decides admission.\n\n"
+            f"{blob}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T7 — mutation resistance: a parallel, ungated read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_CASE_IDS)
+def test_no_file_the_report_touches_carries_above_ceiling_content(
+    case: _ReportCase,
+    tmp_path: Path,
+) -> None:
+    """Every file the call created or modified is swept, not a named list.
+
+    The artifact-level tests above look where we already know to look. This one
+    derives its file list from the filesystem — everything whose bytes differ
+    from a pre-call snapshot — so it also covers an artifact nobody anticipated,
+    a debug dump, a cache, and a second ungated walk spliced into an existing
+    generator whose declared output looks unchanged.
+
+    Paths are checked as well as contents because ``decisions`` writes the
+    fragment title into the *filename*: a bytes-only sweep would walk straight
+    past it.
+
+    ``rhetorical-patterns`` writes no fragment-derived text, so its byte sweep
+    is vacuous by construction; the ``forbidden_glob`` assertion is what carries
+    that row, and it is stated here rather than left implied.
+
+    Args:
+        case: The report type under test and its fixture.
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = case.build(tmp_path)
+    before = _snapshot(vault)
+    report_tool(
+        vault_path=vault,
+        report_type=case.report_type,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    changed = _changed_files(vault, before)
+    assert list(vault.glob(case.positive_glob)), (
+        f"report_type={case.report_type!r} produced no artifact at "
+        "ceiling=open, so this sweep has nothing to sweep."
+    )
+    needle = case.above_canary.encode("utf-8")
+    for path in changed:
+        rel = str(path.relative_to(vault))
+        assert case.above_canary not in rel, (
+            f"report_type={case.report_type!r} created {rel!r} — the "
+            "above-ceiling sentinel is in the file name."
+        )
+        assert needle not in path.read_bytes(), (
+            f"report_type={case.report_type!r} wrote the above-ceiling "
+            f"sentinel {case.above_canary!r} into {rel!r}. This file was found "
+            "by diffing the vault, not from a list of expected artifacts, so a "
+            "second ungated read cannot hide behind an unchanged declared "
+            "output."
+        )
+    if case.forbidden_glob is not None:
+        assert not list(vault.glob(case.forbidden_glob)), (
+            f"report_type={case.report_type!r} created "
+            f"{case.forbidden_glob!r}, which exists only if an above-ceiling "
+            "fragment entered the corpus."
+        )
+
+
+# ---------------------------------------------------------------------------
+# T8 — the two tier readers must agree
+# ---------------------------------------------------------------------------
+
+
+def _build_every_tier_vault(root: Path) -> Path:
+    """Seed one fragment per :class:`PrivacyTier` plus one with no key.
+
+    Args:
+        root: Directory the vault is created inside.
+
+    Returns:
+        The vault root.
+    """
+    vault = _new_vault(root, "every-tier-vault")
+    for tier in PrivacyTier:
+        _write_note(
+            vault,
+            f"01-Fragments/Notes/frag-{tier.value}.md",
+            _fragment_metadata(
+                frag_id=f"frag-{tier.value}",
+                title=f"{tier.value} note",
+                privacy_tier=tier.value,
+            ),
+            f"{tier.value} body.",
+        )
+    _write_note(
+        vault,
+        "01-Fragments/Notes/frag-nokey.md",
+        _fragment_metadata(
+            frag_id="frag-nokey",
+            title="No key note",
+            privacy_tier=None,
+        ),
+        "No key body.",
+    )
+    return vault
+
+
+def test_raw_and_model_tier_readers_agree_on_every_fragment(
+    tmp_path: Path,
+) -> None:
+    """The new raw reader must not become a third, diverging tier opinion.
+
+    ``creek/classify/privacy_filter.py`` already carries two fail-closed tier
+    reads — ``tier_of`` (unrecognised value) and ``fragment_tier`` (absent key) —
+    and its own docstring names the failure mode a third one invites: "two tools
+    that disagree about the same file". ``raw_privacy_tier`` is that third
+    reader, so its agreement with ``fragment_tier`` is asserted rather than
+    assumed, fragment by fragment, over the shared vault loader both would
+    actually see.
+
+    The no-key fragment is checked separately and explicitly: it is the one case
+    where agreeing on ``INTIMATE`` is the whole point, and where a reader that
+    consulted the model would answer ``unclassified`` instead.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    from creek.classify.privacy_filter import fragment_tier, raw_privacy_tier
+    from creek.vault.reader import iter_vault_fragments
+
+    vault = _build_every_tier_vault(tmp_path)
+    loaded = iter_vault_fragments(vault / "01-Fragments")
+    by_id = {fragment.id: (fragment, raw) for _p, fragment, _b, raw in loaded}
+    assert set(by_id) == {
+        "frag-open",
+        "frag-personal",
+        "frag-intimate",
+        "frag-unclassified",
+        "frag-nokey",
+    }
+    for frag_id, (fragment, raw) in sorted(by_id.items()):
+        assert raw_privacy_tier(raw) == fragment_tier(fragment, raw), (
+            f"the two fail-closed tier readers disagree about {frag_id!r}: "
+            f"raw_privacy_tier says {raw_privacy_tier(raw)!r}, fragment_tier "
+            f"says {fragment_tier(fragment, raw)!r}"
+        )
+    nokey_fragment, nokey_raw = by_id["frag-nokey"]
+    assert raw_privacy_tier(nokey_raw) is PrivacyTier.INTIMATE
+    assert fragment_tier(nokey_fragment, nokey_raw) is PrivacyTier.INTIMATE
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param({}, PrivacyTier.INTIMATE, id="key-absent"),
+        pytest.param({"privacy_tier": None}, PrivacyTier.INTIMATE, id="none"),
+        pytest.param({"privacy_tier": ""}, PrivacyTier.INTIMATE, id="empty"),
+        pytest.param(
+            {"privacy_tier": "not-a-tier"},
+            PrivacyTier.INTIMATE,
+            id="unrecognised",
+        ),
+        pytest.param({"privacy_tier": "open"}, PrivacyTier.OPEN, id="open"),
+        pytest.param(
+            {"privacy_tier": "personal"},
+            PrivacyTier.PERSONAL,
+            id="personal",
+        ),
+        pytest.param(
+            {"privacy_tier": "intimate"},
+            PrivacyTier.INTIMATE,
+            id="intimate",
+        ),
+        pytest.param(
+            {"privacy_tier": "unclassified"},
+            PrivacyTier.UNCLASSIFIED,
+            id="unclassified",
+        ),
+    ],
+)
+def test_raw_privacy_tier_fails_closed_on_anything_it_cannot_read(
+    raw: dict[str, object],
+    expected: PrivacyTier,
+) -> None:
+    """Every unreadable ``privacy_tier`` resolves to ``intimate``, never ``open``.
+
+    Four distinct ways of saying nothing — the key absent, an explicit ``None``,
+    an empty string, and a value the enum has never heard of — must all land on
+    the most restrictive tier. They are listed separately because they arrive
+    from different places: a hand-edited note, a YAML ``privacy_tier:`` with no
+    value, a template that wrote an empty field, and a future schema this build
+    predates.
+
+    An explicit ``unclassified`` is deliberately *not* folded in with them: it
+    is what every pipeline-written, not-yet-classified fragment carries, and it
+    ranks with ``personal`` by policy (#876) rather than by failure.
+
+    Args:
+        raw: Raw front matter to read.
+        expected: The tier the reader must return.
+    """
+    from creek.classify.privacy_filter import raw_privacy_tier
+
+    assert raw_privacy_tier(raw) is expected
+
+
+# ---------------------------------------------------------------------------
+# T10 — the CLI surface
+# ---------------------------------------------------------------------------
+
+
+def test_cli_report_include_tier_open_excludes_above_ceiling_tags(
+    tmp_path: Path,
+) -> None:
+    """``creek report --type tags --include-tier open`` filters the garden.
+
+    ``report_tool`` is not the only production caller: the CLI reaches the same
+    six generators through ``_REPORT_DISPATCH``, and a fix threaded only through
+    MCP would leave ``--include-tier`` on ``report`` as a flag that is parsed,
+    audited, and then ignored.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = _build_tags_vault(tmp_path)
+    result = runner.invoke(
+        app,
+        [
+            "report",
+            "--type",
+            "tags",
+            "--vault",
+            str(vault),
+            "--include-tier",
+            "open",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    garden = (vault / "00-Creek-Meta" / "Tag-Garden.md").read_text(encoding="utf-8")
+    assert _OPEN_CANARY in garden
+    assert _INTIMATE_CANARY not in garden, (
+        "creek report --include-tier open wrote an intimate fragment's tag "
+        f"into the Tag Garden:\n\n{garden}"
+    )
+
+
+def test_cli_report_without_include_tier_stays_unfiltered(tmp_path: Path) -> None:
+    """A bare ``creek report --type tags`` keeps its pre-#968 behaviour.
+
+    The new generator parameters default to ``PrivacyTierOverride.ALL``, i.e.
+    unfiltered, so that adding them is a genuine no-op for every existing
+    caller. That promise is worth asserting rather than assuming: an operator
+    who never passed ``--include-tier`` and suddenly finds half their tag garden
+    missing has been handed a silent data-loss bug wearing a privacy fix's
+    costume.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = _build_tags_vault(tmp_path)
+    result = runner.invoke(
+        app,
+        ["report", "--type", "tags", "--vault", str(vault)],
+    )
+    assert result.exit_code == 0, result.output
+    garden = (vault / "00-Creek-Meta" / "Tag-Garden.md").read_text(encoding="utf-8")
+    assert _OPEN_CANARY in garden
+    assert _INTIMATE_CANARY in garden, (
+        "creek report with no --include-tier flag now filters the tag garden. "
+        "The flag's absence must mean 'unchanged', not 'open'."
+    )
+
+
+# ---------------------------------------------------------------------------
+# T11 — the production call sites must state their intent
+# ---------------------------------------------------------------------------
+
+
+_OVERRIDE_CALL_NAMES = frozenset(
+    {
+        "TagGardenGenerator",
+        "generate_lexicon",
+        "generate_decisions",
+        "generate_mode_profiles",
+        "generate_all_profiles",
+        "generate_rhetorical_patterns",
+        "VoiceProfileGenerator",
+    },
+)
+"""Callables whose new privacy parameter must never be left at its default."""
+
+_OVERRIDE_CALLER_MODULES = [
+    "creek_mcp.tools.report",
+    "creek.cli",
+]
+"""The two production surfaces that fan out to the six report generators."""
+
+
+def _call_name(node: ast.Call) -> str | None:
+    """Resolve a call's callee to a bare symbol name.
+
+    Mirrors ``tests/test_mcp_read_gate.py``'s helper of the same name rather
+    than importing it: a private helper in another test module is not an API,
+    and duplicating six lines is cheaper than coupling two guardrails together.
+
+    Args:
+        node: The call node to inspect.
+
+    Returns:
+        ``func.id`` for a direct call, ``func.attr`` for a qualified one, or
+        ``None`` when the callee is a dynamic expression.
+    """
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _states_override(node: ast.Call) -> bool:
+    """Return whether *node* names an ``override`` at its own or its receiver's call.
+
+    Two shapes carry the override, and both are legitimate:
+
+    * ``generate_decisions(vault, override=override)`` — the parameter is on the
+      function itself;
+    * ``VoiceProfileGenerator(override=override).generate_all_profiles(vault)`` —
+      the parameter is on the constructor, and the method that consumes the
+      corpus takes none. Requiring ``override=`` on ``generate_all_profiles``
+      itself would force an API the design does not have.
+
+    Args:
+        node: The call node to inspect.
+
+    Returns:
+        ``True`` when an ``override`` keyword is stated at this call or at the
+        constructor call the method is invoked on.
+    """
+    if any(keyword.arg == "override" for keyword in node.keywords):
+        return True
+    func = node.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Call):
+        return _states_override(func.value)
+    return False
+
+
+def _guarded_calls(module: ModuleType) -> list[tuple[str, int, bool]]:
+    """Return ``(name, lineno, states_override)`` for every guarded call site.
+
+    Args:
+        module: The imported production module to scan.
+
+    Returns:
+        One tuple per call to a name in :data:`_OVERRIDE_CALL_NAMES`.
+    """
+    tree = ast.parse(inspect.getsource(module))
+    found: list[tuple[str, int, bool]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node)
+        if name in _OVERRIDE_CALL_NAMES:
+            assert name is not None
+            found.append((name, node.lineno, _states_override(node)))
+    return found
+
+
+@pytest.mark.parametrize("dotted", _OVERRIDE_CALLER_MODULES)
+def test_production_report_callers_always_state_an_override(dotted: str) -> None:
+    """Neither production surface may fall back to the unfiltered default.
+
+    Every new parameter defaults to ``PrivacyTierOverride.ALL`` — unfiltered —
+    because that is the only default that keeps the change a no-op for the
+    library's existing callers and their existing tests. A defaulted privacy
+    parameter is safe exactly while every production caller states its intent
+    out loud, and *this* is the test that makes that true rather than hoped-for.
+    Without it, threading the ceiling through five of the six branches and
+    forgetting the sixth reads, at the call site, as ordinary working code.
+
+    The check is structural on purpose. It cannot tell whether the value passed
+    is the *right* one — the behavioural tests above do that — but it is the
+    only thing that catches a new branch added months from now that simply omits
+    the keyword.
+
+    Args:
+        dotted: The production module to parse.
+    """
+    module = importlib.import_module(dotted)
+    calls = _guarded_calls(module)
+    assert calls, (
+        f"{dotted} contains no call to any of {sorted(_OVERRIDE_CALL_NAMES)}, "
+        "so this guardrail is scanning for symbols nothing invokes. Either the "
+        "report fan-out moved, or the names in _OVERRIDE_CALL_NAMES are stale."
+    )
+    silent = [(name, lineno) for name, lineno, stated in calls if not stated]
+    assert not silent, (
+        f"{dotted} calls a report generator without stating an override: "
+        f"{silent}. The parameter defaults to PrivacyTierOverride.ALL "
+        "(unfiltered), so an omitted keyword is not a neutral omission — it is "
+        "the ceiling being silently discarded at that call site."
+    )
+
+
+def test_every_guarded_symbol_is_actually_called_somewhere() -> None:
+    """The guarded-name list describes real call sites, not aspirations.
+
+    The per-module test above is only as strong as its name list. A typo, a
+    rename, or a symbol that was never called by either surface would leave an
+    entry that can never fail — and the per-module assertion would still pass on
+    the strength of the other six. Asserting the union across both surfaces
+    covers every name closes that hole.
+    """
+    called: set[str] = set()
+    for dotted in _OVERRIDE_CALLER_MODULES:
+        module = importlib.import_module(dotted)
+        called.update(name for name, _lineno, _stated in _guarded_calls(module))
+    missing = _OVERRIDE_CALL_NAMES - called
+    assert not missing, (
+        f"_OVERRIDE_CALL_NAMES lists {sorted(missing)}, which neither "
+        f"{' nor '.join(_OVERRIDE_CALLER_MODULES)} calls. An entry no call site "
+        "matches is an assertion about nothing."
+    )

--- a/creek-tools/tests/test_mcp_report_tier_ceiling.py
+++ b/creek-tools/tests/test_mcp_report_tier_ceiling.py
@@ -40,7 +40,6 @@ import frontmatter
 import pytest
 from typer.testing import CliRunner
 
-from creek.classify.privacy_filter import PrivacyTierOverride
 from creek.cli import app
 from creek.models import PrivacyTier
 from creek_mcp.tier_ceiling import TierCeiling
@@ -50,6 +49,8 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
     from pathlib import Path
     from types import ModuleType
+
+    from creek.classify.privacy_filter import PrivacyTierOverride
 
 runner = CliRunner()
 
@@ -517,9 +518,7 @@ def _changed_files(vault: Path, before: dict[Path, bytes]) -> list[Path]:
         Sorted list of new-or-modified files.
     """
     return sorted(
-        p
-        for p in vault.rglob("*")
-        if p.is_file() and before.get(p) != p.read_bytes()
+        p for p in vault.rglob("*") if p.is_file() and before.get(p) != p.read_bytes()
     )
 
 
@@ -731,6 +730,17 @@ def test_report_at_all_ceiling_admits_everything(
     empty artifact at every ceiling, so without this test "the ceiling is
     enforced" and "the report is broken" are indistinguishable.
 
+    ``rhetorical-patterns`` is exempt from the substring half, and it has to be:
+    its artifact is three integer counts, so *neither* sentinel is findable in
+    it by a sweep — in either direction. A ``ceiling=all`` assertion that the
+    above-ceiling canary is present would be false by construction rather than
+    by regression. Its permissive-direction evidence is the ``forbidden_glob``
+    assertion at the end of this test (the above-ceiling fragment's register
+    note must exist at ``ceiling=all``) plus
+    :func:`test_rhetorical_pattern_counts_are_identical_across_ceilings`.
+    ``below_canary is None`` is the flag for that case — it marks the artifact,
+    not the tier, which is why it gates both sentinels here.
+
     Args:
         case: The report type under test and its fixture.
         tmp_path: pytest's per-test temporary directory.
@@ -744,12 +754,12 @@ def test_report_at_all_ceiling_admits_everything(
     assert result["status"] == "ok"
 
     blob = _artifact_blob(vault, case.artifact_roots)
-    assert case.above_canary in blob, (
-        f"report_type={case.report_type!r} at ceiling=all dropped "
-        f"{case.above_canary!r}. ALL is the operator's explicit override; "
-        "filtering under it is a regression, not caution."
-    )
     if case.below_canary is not None:
+        assert case.above_canary in blob, (
+            f"report_type={case.report_type!r} at ceiling=all dropped "
+            f"{case.above_canary!r}. ALL is the operator's explicit override; "
+            "filtering under it is a regression, not caution."
+        )
         assert case.below_canary in blob
     assert list(vault.glob(case.positive_glob))
     if case.forbidden_glob is not None:
@@ -952,7 +962,7 @@ def test_fragment_with_no_privacy_tier_key_fails_closed_to_intimate(
     garden = (vault / "00-Creek-Meta" / "Tag-Garden.md").read_text(encoding="utf-8")
     assert _OPEN_CANARY in garden
     assert (_NOTIER_CANARY in garden) is admitted, (
-        f"a fragment with no privacy_tier key was "
+        "a fragment with no privacy_tier key was "
         f"{'excluded from' if admitted else 'admitted to'} the tag garden at "
         f"ceiling={ceiling.value!r}. A missing key must fail closed to "
         "intimate, not default to the model's 'unclassified'.\n\n" + garden
@@ -1079,7 +1089,7 @@ _GATE_CALL_SITES = [
     pytest.param("decisions", "creek.generate.decisions", id="decisions"),
     pytest.param("mode-profiles", "creek.generate.wavelength", id="wavelength"),
 ]
-"""``(report_type, module whose ``within_ceiling`` the walk actually calls)``.
+"""``report_type`` → the module whose ``within_ceiling`` the walk really calls.
 
 ``lexicon`` is the odd row and deliberately so: ``generate_lexicon`` owns no
 vault walk of its own — it delegates to
@@ -1149,7 +1159,7 @@ def test_report_generators_act_on_the_gate_verdict_not_just_call_it(
     if case.below_canary is not None:
         assert case.below_canary not in blob, (
             f"inverting {module}.within_ceiling left {case.below_canary!r} in "
-            f"the artifact, so the verdict is not what decides admission.\n\n"
+            "the artifact, so the verdict is not what decides admission.\n\n"
             f"{blob}"
         )
 

--- a/creek-tools/tests/test_mcp_report_tier_ceiling.py
+++ b/creek-tools/tests/test_mcp_report_tier_ceiling.py
@@ -1322,6 +1322,27 @@ def test_raw_and_model_tier_readers_agree_on_every_fragment(
             PrivacyTier.INTIMATE,
             id="unrecognised",
         ),
+        # YAML front matter is operator-editable, so the value need not be a
+        # string at all. These rows exist because the implementation reaches
+        # the enum through ``PrivacyTier(str(value))``: dropping that ``str()``
+        # wrap would still raise for a list and a dict, but the row that really
+        # bites is ``["open"]`` — a one-character YAML slip (``privacy_tier:``
+        # followed by an indented ``- open``) which must fail closed rather
+        # than be talked into ``open`` by some future normalisation.
+        pytest.param({"privacy_tier": ["open"]}, PrivacyTier.INTIMATE, id="list"),
+        pytest.param(
+            {"privacy_tier": {"tier": "open"}},
+            PrivacyTier.INTIMATE,
+            id="mapping",
+        ),
+        pytest.param({"privacy_tier": 0}, PrivacyTier.INTIMATE, id="int"),
+        pytest.param({"privacy_tier": False}, PrivacyTier.INTIMATE, id="bool"),
+        # Casing and whitespace are not silently repaired. ``creek classify``
+        # writes the canonical lowercase value; anything else is a note nobody
+        # can vouch for, and guessing what an operator meant is how a gate
+        # becomes negotiable.
+        pytest.param({"privacy_tier": "OPEN"}, PrivacyTier.INTIMATE, id="uppercase"),
+        pytest.param({"privacy_tier": " open"}, PrivacyTier.INTIMATE, id="padded"),
         pytest.param({"privacy_tier": "open"}, PrivacyTier.OPEN, id="open"),
         pytest.param(
             {"privacy_tier": "personal"},

--- a/creek-tools/tests/test_mcp_write_tools.py
+++ b/creek-tools/tests/test_mcp_write_tools.py
@@ -662,11 +662,22 @@ def test_report_tags_writes_audit_entry(vault: Path) -> None:
 
 
 def test_report_decisions_generates_note(vault: Path) -> None:
-    """The ``decisions`` report now generates a real Decision note (#581)."""
+    """The ``decisions`` report now generates a real Decision note (#581).
+
+    The fixture states ``privacy_tier: open`` explicitly since #968. It used to
+    omit the key, and an omitted key now fails closed to ``intimate``
+    (``creek.classify.privacy_filter.raw_privacy_tier``) rather than falling
+    back to the model's ``unclassified`` default, so at ``ceiling=open`` the
+    fragment would never reach the detector. The tier is fixture bookkeeping
+    here — this test is about *whether a Decision note is written*, and the
+    ceiling behaviour it now depends on is pinned by
+    ``tests/test_mcp_report_tier_ceiling.py``.
+    """
     frags = vault / "01-Fragments" / "Notes"
     frags.mkdir(parents=True, exist_ok=True)
     (frags / "frag-decide50.md").write_text(
         '---\ntype: fragment\nid: frag-decide50\ntitle: "Should I switch frameworks"\n'
+        "privacy_tier: open\n"
         "source:\n  platform: journal\n  author: self\n---\nbody\n",
         encoding="utf-8",
     )
@@ -694,11 +705,17 @@ def test_report_decisions_no_candidates_returns_empty_paths(vault: Path) -> None
 
 
 def test_report_rhetorical_patterns_generates(vault: Path) -> None:
-    """The ``rhetorical-patterns`` report writes a per-register note (#582)."""
+    """The ``rhetorical-patterns`` report writes a per-register note (#582).
+
+    ``privacy_tier: open`` is stated explicitly since #968 — see
+    ``test_report_decisions_generates_note`` for why an omitted key no longer
+    reaches an ``open``-ceiling report.
+    """
     frags = vault / "01-Fragments" / "Notes"
     frags.mkdir(parents=True, exist_ok=True)
     (frags / "ex-1.md").write_text(
         '---\ntype: fragment\nid: ex-1\ntitle: "T"\n'
+        "privacy_tier: open\n"
         "source:\n  platform: journal\n  author: self\n"
         "voice:\n  voice_register: confessional\n  confidence: conviction\n"
         "---\nThe truth is we rise; as I said before, we rise.\n",
@@ -729,11 +746,17 @@ def test_report_rhetorical_patterns_no_exemplars_returns_empty_paths(
 
 
 def test_report_mode_profiles_generates(vault: Path) -> None:
-    """The ``mode-profiles`` report writes a per-mode note (#583)."""
+    """The ``mode-profiles`` report writes a per-mode note (#583).
+
+    ``privacy_tier: open`` is stated explicitly since #968 — see
+    ``test_report_decisions_generates_note`` for why an omitted key no longer
+    reaches an ``open``-ceiling report.
+    """
     frags = vault / "01-Fragments" / "Notes"
     frags.mkdir(parents=True, exist_ok=True)
     (frags / "m1.md").write_text(
         '---\ntype: fragment\nid: m1\ntitle: "Building momentum"\n'
+        "privacy_tier: open\n"
         "source:\n  platform: journal\n  author: self\n"
         "wavelength:\n  mode: express\n  phase: rising\n"
         "frequency:\n  primary: F3\n---\nbody\n",
@@ -779,7 +802,18 @@ def _seed_voice_exemplar(vault: Path, frag_id: str, body: str) -> None:
 
 
 def test_report_lexicon_generates_glossary(vault: Path) -> None:
-    """The ``lexicon`` report now generates a real glossary (#580), not a stub."""
+    """The ``lexicon`` report now generates a real glossary (#580), not a stub.
+
+    Called at ``ceiling=personal`` since #968, and the fixture's
+    ``privacy_tier: personal`` is deliberately **not** downgraded to make it
+    pass. The glossary quotes exemplar sentences verbatim, so a personal-tier
+    exemplar reaching it at ``ceiling=open`` is precisely the leak #968 closed;
+    a caller entitled to that exemplar is one that declares ``personal``. This
+    test's subject is whether a glossary is produced at all, and the tier
+    behaviour it now depends on is pinned by
+    ``tests/test_mcp_report_tier_ceiling.py::test_report_at_open_ceiling_excludes_above_ceiling_content``
+    (the ``lexicon`` row), which asserts the opposite outcome at ``open``.
+    """
     _seed_voice_exemplar(
         vault,
         "ex-1",
@@ -788,7 +822,7 @@ def test_report_lexicon_generates_glossary(vault: Path) -> None:
     result = report_tool(
         vault_path=vault,
         report_type="lexicon",
-        privacy_tier_ceiling=TierCeiling.OPEN,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
         consumer="crawdad",
     )
     assert result["status"] == "ok"

--- a/creek-tools/tests/test_tag_garden.py
+++ b/creek-tools/tests/test_tag_garden.py
@@ -503,11 +503,28 @@ class TestGenerateGarden:
         generator: TagGardenGenerator,
         vault: Path,
     ) -> None:
-        """generate_garden loads previous scan for growth detection."""
+        """generate_garden loads previous scan for growth detection.
+
+        The seeded entry states ``tier_ceiling`` since #968. A history entry is
+        only a valid growth baseline for a scan taken at the *same* ceiling, and
+        a legacy entry that records none is skipped as non-comparable — so
+        without the key this test would still pass while exercising none of the
+        growth path, because ``python`` also appears in the unconditional "All
+        Tags" table. ``"all"`` is what the ``generator`` fixture runs at
+        (``TagGardenGenerator``'s default ``PrivacyTierOverride.ALL``).
+
+        The assertion is on the "Rapidly Growing" row rather than on the bare
+        tag name, for the same reason: only that row can distinguish "the
+        baseline was loaded and compared" from "the tag exists".
+        """
         # Write initial history
         history_path = vault / "00-Creek-Meta" / "Processing-Log" / "tag-history.json"
         initial_history = [
-            {"tag_counts": {"python": 2}, "timestamp": "2026-01-01T00:00:00"},
+            {
+                "tag_counts": {"python": 2},
+                "timestamp": "2026-01-01T00:00:00",
+                "tier_ceiling": "all",
+            },
         ]
         history_path.write_text(
             json.dumps(initial_history),
@@ -524,6 +541,7 @@ class TestGenerateGarden:
         content = path.read_text(encoding="utf-8")
         # python grew from 2 to 4 (100% growth), should appear in growing section
         assert "python" in content
+        assert "| python | 2 | 4 | +100% |" in content
 
     def test_renders_clusters_in_output(
         self,


### PR DESCRIPTION
## Summary

`creek.report` accepted a `privacy_tier_ceiling`, wrote it to the audit log and echoed it in the response — and never converted or threaded it. All six generators walked the vault unfiltered, so at `ceiling=open` an intimate fragment's tags, titles and body text were distilled verbatim into untiered, git-tracked, Obsidian-readable vault artifacts.

**The leak is write-side.** `report_tool` returns only `report_paths`, so the response envelope was canary-free for the entire life of the bug — no response-level test could ever have caught it, and the existing runtime probe in `tests/test_mcp_read_gate.py` passes for `creek.report` at HEAD *unfixed*. The evidence is the artifact bytes. Reproduced at `0f7689a` on all six report types:

| `report_type` | artifact | above-ceiling content that reached it |
|---|---|---|
| `tags` | `00-Creek-Meta/Tag-Garden.md`, `00-Creek-Meta/Processing-Log/tag-history.json` | tag strings + `[[fragment_id]]` links |
| `decisions` | `08-Decisions/Active/*.md` | fragment title verbatim, in the filename *and* the `title:` frontmatter |
| `mode-profiles` | `05-Wavelength/Mode-Profiles/*.md` | `- {title} ({id})` |
| `voice` | `07-Voice/<register>-profile.md` | **verbatim exemplar bodies** |
| `lexicon` | `07-Voice/Lexicon/glossary.md` | **verbatim source sentences** |
| `rhetorical-patterns` | `07-Voice/Rhetorical-Patterns/<register>.md` | aggregate counts only — but the note's *existence* discloses the register |

### The fix

- Two primitives in `creek/classify/privacy_filter.py` (its docstring already declares it the single home for tier filtering in generation flows): `raw_privacy_tier(raw)` reads the tier straight off **raw frontmatter**, failing closed to `INTIMATE` on a missing key rather than to the model's `unclassified` default — the #1033 failure mode, and the reason `iter_admitted_fragments` was not adopted. `within_ceiling(raw, override)` applies `tier_within_override`'s hard rank cutoff.
- A keyword-only `override` on all six generator entry points; `report_tool` converts via `to_privacy_override` and threads it into every branch; `creek/cli.py` threads `--include-tier` through `_REPORT_DISPATCH`.
- **Exclude, not refuse**, per the issue's explicit anti-goal. `creek.report` names no target — it is a corpus walk like `creek.wheel` and `creek.mine`, both of which filter and neither of which refuses. `creek.compile` and `creek.reflect` refuse because their targets are *caller-named*; reflect *excludes* from its grounding corpus walk, which is the matching precedent.
- `tag-history.json` entries now record the `tier_ceiling` they were taken under, and growth is only compared between entries at the same ceiling. Counts from two ceilings survey two corpora.
- `creek_mcp/read_gate.py`'s `creek.report` posture moves `UNGATED_KNOWN_GAP` → `GATED`, **pointed at the gate that closed it** (`creek_mcp.tools.report` / `to_privacy_override`), not relabelled.

### Consequence stated on the tin

`TagGardenGenerator` scans five directories. The four beyond `01-Fragments` hold note types (`Thread`, `Eddy`, `Praxis`, `Decision`) that carry a `tags` field and **no `privacy_tier` field at all**, so they fail closed to `INTIMATE` and are excluded below `ceiling=intimate`. **A ceiling-filtered tag garden is fragment-derived only.** That is the right answer rather than a limitation: those notes are derived from fragments and untierable by construction — a Decision note's `title:` *is* a source fragment's title verbatim — so reading them at `ceiling=open` would hand back what a `ceiling=all` run distilled there. Stated in the module docstring, the manifest rationale and `docs/mcp.md`.

### Two things I checked that turned out otherwise

- The claim that `creek link --method eddies` copies member fragments' tags onto eddy notes is **false** — `EddyDetector._build_eddy` sets no tags. The real derived-content route is the eddy *title* (built from member fragments' content words) and, most concretely, the `08-Decisions` notes this very report writes. The rationale in the code says that, not the unverified version.
- The default is `PrivacyTierOverride.ALL` (unfiltered), which is a genuine no-op for every pre-existing caller and keeps this a privacy fix rather than a nine-file fixture migration. It is safe because `report_tool`'s own ceiling defaults to the *strictest* `TierCeiling.OPEN`, so `ALL` is unreachable from the MCP boundary without an explicit widen — and because a new AST guardrail asserts both production surfaces state an `override=` at every call site.

## Test plan

47 new tests in `tests/test_mcp_report_tier_ceiling.py` (+1606), plus additions to `tests/test_mcp_read_gate.py`. Every exclusion assertion is on **written artifact bytes**, never on the return value, and every one has a paired positive control so it cannot pass by the generator writing nothing.

- **Per-type exclusion + admission** across all six types at `ceiling=open` and `ceiling=all`. The above-ceiling canary is `personal` (not `intimate`) for `voice`/`lexicon`/`rhetorical-patterns`, because `allow_intimate=False` already excluded intimate there — an intimate canary would have passed vacuously.
- **Mutation resistance, call-and-discard**: an *inverting* `within_ceiling` is monkeypatched per generator module; the artifact must flip. A generator that calls the gate and ignores its verdict is unaffected by inversion and fails.
- **Mutation resistance, parallel ungated read**: the vault is byte-snapshotted before the call and every new-or-modified file is swept afterwards. The file list comes from the filesystem diff, so an unanticipated artifact is caught too.
- **Fail-closed**: a fragment with *no* `privacy_tier` key is excluded at `open` **and at `personal`** — the `personal` row is the load-bearing one, since the model's `unclassified` default ranks with `personal` and would be admitted. Plus `raw_privacy_tier` pinned against list/mapping/int/bool/casing/whitespace values.
- **Reader agreement**: `raw_privacy_tier` == `fragment_tier` for every fragment the shared loader returns, so the new reader cannot become the divergence `privacy_filter`'s docstring warns about.
- **The vacuity is stated, not hidden**: a new test in `tests/test_mcp_read_gate.py` asserts on `Tag-Garden.md` and `tag-history.json` and documents that the shared envelope probe is structurally vacuous for this tool.
- Five pre-existing tests adjusted, all *additively*: three fixtures gained `privacy_tier: open`; the lexicon test's call moved `open` → `personal` with its `personal` fixture deliberately **not** downgraded; `test_loads_previous_history` gained a `tier_ceiling` key and a **stronger** assertion. Across all four touched test files there are 8 deleted lines — one `_PINNED_GAPS` entry (the move the guardrail's own failure message demands), six docstring first-lines preserved verbatim in their expanded replacements, and one reformatted fixture literal. **No test and no assertion was deleted or weakened.**

Gate 2: `./scripts/check-all.sh` → 12/12, 6690 passed, 94.02% branch coverage, per-file gate clean. Gate 2.5: independent `code-review-orchestrator` pass → `CLEAN`, no blockers; its three nits are addressed or documented in-code with the reason.

Closes #968
Refs #932, #848, #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)