### PR TITLE
refactor: centralize Discord text contracts

### DIFF
--- a/crawdad/crawdad/bot.py
+++ b/crawdad/crawdad/bot.py
@@ -37,6 +37,10 @@ from crawdad.consent import (
     classify_followup_message,
     format_type_question,
 )
+from crawdad.discord_text import (
+    _MCP_UNAVAILABLE_REPLY,
+    _truncate_for_discord,
+)
 from crawdad.history import ConversationHistory
 from crawdad.loop import run_one_turn
 from crawdad.mcp_client import MCPUnavailableError
@@ -61,9 +65,6 @@ _LOGGER = logging.getLogger("crawdad.bot")
 _STATE_UNAVAILABLE_REPLY = (
     "no audit report yet — run `creek state` in the vault and try again."
 )
-_MCP_UNAVAILABLE_REPLY = "creek-tools is unreachable; try again in a moment."
-_DISCORD_REPLY_LIMIT = 1900
-
 # FEAT-027: name of the MCP tool the bot invokes for the safety pass on
 # Discord attachments. Sourced from
 # ``creek_mcp.tools.redact.TOOL_NAME``; duplicated here so the bot has
@@ -729,13 +730,6 @@ def _resolve_skills(
     if registry is not None:
         return registry.stack
     return fallback or _empty_skills()
-
-
-def _truncate_for_discord(text: str) -> str:
-    """Cap reply at Discord's soft limit so very long composer outputs land."""
-    if len(text) <= _DISCORD_REPLY_LIMIT:
-        return text
-    return text[: _DISCORD_REPLY_LIMIT - 3] + "..."
 
 
 def render_state_unavailable_reply(error: StateUnavailableError) -> str:

--- a/crawdad/crawdad/cli.py
+++ b/crawdad/crawdad/cli.py
@@ -23,6 +23,7 @@ from crawdad.config import (
     router_model_for,
 )
 from crawdad.consent import PendingBatchStore
+from crawdad.discord_text import _truncate_for_discord
 from crawdad.history import ConversationHistory
 from crawdad.intents import ToolInfo
 from crawdad.llm import build_async_provider
@@ -42,18 +43,6 @@ if TYPE_CHECKING:
     from crawdad.state import SessionState
 
 _LOGGER = logging.getLogger("crawdad.cli")
-
-# Discord's regular message + slash-follow-up text body is capped at 2000
-# characters. Truncate well below the wire limit so the truncation marker
-# always fits and we leave headroom for accidental whitespace.
-_DISCORD_REPLY_LIMIT = 1900
-
-
-def _truncate_for_discord(text: str) -> str:
-    """Cap *text* at Discord's soft limit with an ellipsis marker if needed."""
-    if len(text) <= _DISCORD_REPLY_LIMIT:
-        return text
-    return text[: _DISCORD_REPLY_LIMIT - 3] + "..."
 
 
 def main(argv: Sequence[str] | None = None) -> None:

--- a/crawdad/crawdad/discord_text.py
+++ b/crawdad/crawdad/discord_text.py
@@ -1,0 +1,11 @@
+"""Shared Discord text limits and soft-error messages."""
+
+_DISCORD_REPLY_LIMIT = 1900
+_MCP_UNAVAILABLE_REPLY = "creek-tools is unreachable; try again in a moment."
+
+
+def _truncate_for_discord(text: str) -> str:
+    """Cap *text* at Discord's soft limit with an ellipsis marker if needed."""
+    if len(text) <= _DISCORD_REPLY_LIMIT:
+        return text
+    return text[: _DISCORD_REPLY_LIMIT - 3] + "..."

--- a/crawdad/crawdad/loop.py
+++ b/crawdad/crawdad/loop.py
@@ -63,6 +63,7 @@ from pydantic import BaseModel, ConfigDict
 
 from crawdad.composer import ComposerFailureError, mentions_paradox
 from crawdad.config import MAX_LOOP_ROUNDS
+from crawdad.discord_text import _MCP_UNAVAILABLE_REPLY
 from crawdad.dispatcher import (
     IntentDispatcher,
     ToolResult,
@@ -93,7 +94,6 @@ _UNKNOWN_INTENT_REPLY = (
     "I tried to use a tool I don't have. Try a different question, or check "
     "`creek-tools` for the available tool surface."
 )
-_MCP_UNAVAILABLE_REPLY = "creek-tools is unreachable; try again in a moment."
 _COMPOSER_FAILURE_REPLY = (
     "I'm having trouble composing right now — try again in a moment."
 )

--- a/crawdad/crawdad/slash_commands.py
+++ b/crawdad/crawdad/slash_commands.py
@@ -34,17 +34,13 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any, Protocol
 
+from crawdad.discord_text import _MCP_UNAVAILABLE_REPLY
 from crawdad.mcp_client import MCPUnavailableError
 
 if TYPE_CHECKING:
     from crawdad.config import CrawDadConfig
 
 _LOGGER = logging.getLogger("crawdad.slash_commands")
-
-# The documented soft-error shown when the desk / creek-tools MCP surface is
-# unreachable. Mirrors ``crawdad.loop._MCP_UNAVAILABLE_REPLY``
-# so the author routes degrade with the same wording as the agent loop.
-_MCP_UNAVAILABLE_REPLY = "creek-tools is unreachable; try again in a moment."
 
 # A callable that drives one turn of the FEAT-015 loop and returns the
 # user-facing reply string. The CLI builds one by closing over the

--- a/crawdad/tests/test_cli.py
+++ b/crawdad/tests/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 
 from crawdad import cli
 from crawdad.config import CrawDadConfig
+from crawdad.discord_text import _DISCORD_REPLY_LIMIT
 
 
 @pytest.fixture
@@ -352,7 +353,7 @@ async def test_loop_runner_truncates_long_replies(
     assert runner is not None
     reply = await runner("anything")
     assert len(reply) < len(long_reply)
-    assert len(reply) <= cli._DISCORD_REPLY_LIMIT
+    assert len(reply) <= _DISCORD_REPLY_LIMIT
     assert reply.endswith("...")
 
 
@@ -716,7 +717,7 @@ async def test_build_workflow_runner_returns_composed_reply(
     registry = WorkflowRegistry(vault_path=tmp_path)
 
     async def _ok(**_kwargs: Any) -> str:
-        return "x" * (cli._DISCORD_REPLY_LIMIT + 50)
+        return "x" * (_DISCORD_REPLY_LIMIT + 50)
 
     monkeypatch.setattr(cli, "run_workflow_and_compose", _ok)
 
@@ -730,4 +731,4 @@ async def test_build_workflow_runner_returns_composed_reply(
     assert runner is not None
     reply = await runner("wavelength-checkin", {})
     assert reply.endswith("...")
-    assert len(reply) <= cli._DISCORD_REPLY_LIMIT
+    assert len(reply) <= _DISCORD_REPLY_LIMIT

--- a/crawdad/tests/test_discord_text.py
+++ b/crawdad/tests/test_discord_text.py
@@ -1,0 +1,59 @@
+"""Tests for the shared Discord text contracts."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from crawdad.discord_text import (
+    _DISCORD_REPLY_LIMIT,
+    _MCP_UNAVAILABLE_REPLY,
+    _truncate_for_discord,
+)
+
+
+def test_truncation_keeps_the_existing_wire_contract() -> None:
+    """The shared helper preserves the old cap and marker."""
+    assert (
+        _MCP_UNAVAILABLE_REPLY == "creek-tools is unreachable; try again in a moment."
+    )
+    assert _truncate_for_discord("ok") == "ok"
+    reply = _truncate_for_discord("x" * (_DISCORD_REPLY_LIMIT + 1))
+    assert len(reply) == _DISCORD_REPLY_LIMIT
+    assert reply.endswith("...")
+
+
+def test_shared_symbols_have_one_definition() -> None:
+    """A second copy in a production module must fail this guard."""
+    source_root = Path(__file__).parents[1] / "crawdad"
+    definitions = {
+        "_DISCORD_REPLY_LIMIT": 0,
+        "_MCP_UNAVAILABLE_REPLY": 0,
+        "_truncate_for_discord": 0,
+    }
+    for path in source_root.glob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Assign, ast.AnnAssign, ast.FunctionDef)):
+                targets = (
+                    node.targets
+                    if isinstance(node, ast.Assign)
+                    else [node.target]
+                    if isinstance(node, ast.AnnAssign)
+                    else [node]
+                )
+                for target in targets:
+                    name = (
+                        target.id
+                        if isinstance(target, ast.Name)
+                        else target.name
+                        if isinstance(target, ast.FunctionDef)
+                        else None
+                    )
+                    if name in definitions:
+                        definitions[name] += 1
+    assert definitions == {
+        "_DISCORD_REPLY_LIMIT": 1,
+        "_MCP_UNAVAILABLE_REPLY": 1,
+        "_truncate_for_discord": 1,
+    }


### PR DESCRIPTION
## Summary

- centralize the Discord reply cap and MCP-unavailable text in `crawdad.discord_text`
- update bot, CLI, loop, and slash command callers without changing values or behavior
- add a source-level guard against duplicate definitions and retarget the CLI truncation tests

Closes #1061

## Validation

- `.venv/Scripts/ruff.exe check ...` passed
- `.venv/Scripts/ruff.exe format --check ...` passed
- `.venv/Scripts/mypy.exe crawdad/discord_text.py crawdad/bot.py crawdad/cli.py crawdad/loop.py crawdad/slash_commands.py` passed
- `.venv/Scripts/python.exe -m pytest -o addopts='' tests/test_discord_text.py tests/test_cli.py -q` passed: 24 tests
- `.venv/Scripts/python.exe -m bandit -q -r crawdad/discord_text.py` passed
- `git diff --check` passed

The focused bot and CLI run also exposed three pre-existing Windows path-separator assertions in attachment tests. They are unrelated to this refactor. The repository has no checked-in pre-commit config, so that command could not be run.

AI-assisted contribution. I reviewed the diff and test output manually.