### PR TITLE
fix(mcp): gate creek.state.read/render on a tier-stamped state artifact (#969)

### DIFF
--- a/creek-tools/creek/cli.py
+++ b/creek-tools/creek/cli.py
@@ -3251,6 +3251,11 @@ def report(
 @app.command()
 def state(
     vault: Path | None = typer.Option(None, help="Obsidian vault path"),
+    include_tier: str | None = typer.Option(
+        None,
+        "--include-tier",
+        help=_REPORT_INCLUDE_TIER_HELP,
+    ),
 ) -> None:
     """Render ``00-Creek-Meta/State/<iso-week>.md`` audit report.
 
@@ -3258,15 +3263,40 @@ def state(
     re-runs classification, linking, or compile. It reads existing
     fragments, threads, eddies, praxis, synchronicities, and the most
     recent ``run-summary.jsonl`` line, and writes a single markdown
-    document organised in seven sections (vault summary, pre-LLM yield,
-    active eddies, active threads, surprising connections, hyperedges,
-    drift warnings). ``latest.md`` next to the ISO-week file always
-    points at the most recent report.
+    document organised in eleven sections (wavelength snapshot, vault
+    summary, pre-LLM yield, liminal watch, active eddies, active threads,
+    surprising connections, hyperedges, drift warnings, suggested
+    questions, lint summary). ``latest.md`` next to the ISO-week file
+    always points at the most recent report.
+
+    ``--include-tier`` runs the same way round as it does on ``report``
+    (#968): omitting it leaves the render **unfiltered**, because the CLI
+    operator is the vault owner, and supplying it NARROWS what the artifact may
+    contain. It is also half of the documented upgrade path for a pre-#969
+    ``latest.md``: ``creek state --include-tier open`` re-renders and
+    re-stamps so an ``open``-ceiling MCP reader stops being refused.
+
+    Privacy override audit: the entry is written only when the flag was
+    **explicitly supplied**. ``override_elevates`` answers ``True`` for
+    ``PrivacyTierOverride.ALL``, so auditing the resolved ceiling would write a
+    line on every bare ``creek state`` — the loudest possible record of the one
+    case where the operator asked for nothing.
     """
     from creek.generate.state import StateReportGenerator
 
+    override = _parse_include_tier(include_tier)
     vault_path = _resolve_vault(vault)
-    written = StateReportGenerator(vault_path=vault_path).write()
+    if include_tier is not None:
+        _audit_privacy_override_if_needed(
+            vault_path=vault_path,
+            command="state",
+            override=override,
+            fragment_ids=[],
+        )
+    written = StateReportGenerator(
+        vault_path=vault_path,
+        override=override or PrivacyTierOverride.ALL,
+    ).write()
     console.print(f"[bold green]State report written: {written}[/bold green]")
 
 

--- a/creek-tools/creek/generate/mining.py
+++ b/creek-tools/creek/generate/mining.py
@@ -1635,6 +1635,7 @@ def phase_filtered_seeds(
     *,
     n: int = DEFAULT_PHASE_FILTERED_SEEDS,
     miner: IdeaMiner | None = None,
+    snapshot: MiningSnapshot | None = None,
 ) -> list[IdeaSeed]:
     """Return up to *n* :class:`IdeaSeed` objects filtered for *phase*.
 
@@ -1653,6 +1654,22 @@ def phase_filtered_seeds(
             zero.
         miner: Optional pre-configured :class:`IdeaMiner`. Defaults to
             a fresh instance with library defaults.
+        snapshot: Optional pre-loaded :class:`MiningSnapshot`, forwarded
+            verbatim to :meth:`IdeaMiner.mine_all`, which already accepts
+            one. ``None`` (the default) leaves the miner to load its own, so
+            no existing caller's behaviour changes.
+
+            ``creek state`` supplies a snapshot it has narrowed to the
+            threads and eddies its tier ceiling admitted (#969). That
+            narrowing cannot be made here, or in
+            :func:`_load_mining_snapshot`: :class:`~creek.models.Thread` and
+            :class:`~creek.models.Eddy` carry no ``privacy_tier`` field, so a
+            raw-frontmatter gate on ``02-Threads`` / ``03-Eddies`` would have
+            no evidence to read and would fail closed on *every* thread and
+            eddy — silently deleting the thread-terminus and liminal-cross-
+            eddy strategies for every ``creek mine`` caller below
+            ``ceiling=intimate``. A caller that can derive those tiers
+            passes the result in; this module keeps its own behaviour.
 
     Returns:
         Up to *n* seeds ordered by descending score, then strategy, then
@@ -1666,7 +1683,11 @@ def phase_filtered_seeds(
     except ValueError:
         current_phase = Phase.UNCLASSIFIED
     active_miner = miner if miner is not None else IdeaMiner()
-    all_seeds = active_miner.mine_all(vault_path, current_phase=current_phase)
+    all_seeds = active_miner.mine_all(
+        vault_path,
+        current_phase=current_phase,
+        snapshot=snapshot,
+    )
     allowed = _PHASE_AWARE_STRATEGIES.get(phase_value)
     filtered = (
         all_seeds

--- a/creek-tools/creek/generate/state.py
+++ b/creek-tools/creek/generate/state.py
@@ -20,6 +20,28 @@ reads what is already on disk.
 FEAT-007 inserts a wavelength snapshot and a suggested-questions
 section between sections 1 and 2; the section-ordering contract
 pinned by tests here makes that insertion straightforward.
+
+**Tier ceiling (#969).** The generator takes an
+:class:`~creek.classify.privacy_filter.PrivacyTierOverride` and admits content
+per section against it; :meth:`StateReportGenerator.write` then stamps the
+artifact with the highest tier it actually admitted, which is what
+``creek.state.read`` compares a caller's ceiling against. Two properties of
+that design are easy to break and are stated here rather than only at the call
+sites:
+
+* The corpus is loaded **unfiltered first** and only then admitted. An eddy's
+  tier is the maximum over *all* its member fragments, so filtering before
+  deriving would resolve an eddy with one ``open`` and one ``intimate`` member
+  to ``open`` and leak its title.
+* The default is ``ALL``. ``creek state``'s operator is the vault owner, and a
+  narrower default would silently delete most of an existing operator's report
+  — a behaviour regression wearing a privacy fix's costume.
+
+The type this module takes is ``PrivacyTierOverride``, never
+``creek_mcp.tier_ceiling.TierCeiling``: ``creek`` may never import
+``creek_mcp`` (the layering rule pinned at ``creek/ingest/journal_staging.py``
+and ``creek/care/__init__.py``), so the MCP wrapper converts at its own
+boundary.
 """
 
 from __future__ import annotations
@@ -29,24 +51,47 @@ import logging
 import os
 import re
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, date, datetime
-from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
+from pathlib import Path  # plain stdlib import; no lazy benefit
+from typing import TYPE_CHECKING, TypeVar
 
 import frontmatter
 import yaml
 from pydantic import ValidationError
 
+from creek.classify.privacy_filter import (
+    PrivacyTierOverride,
+    max_source_tier,
+    raw_privacy_tier,
+    tier_of,
+    tier_within_override,
+    within_ceiling,
+)
 from creek.clean.hygiene import BrokenLinkScanner, OrphanScanner
 from creek.generate.indexes import FREQUENCY_NAMES
-from creek.generate.mining import IdeaSeed, phase_filtered_seeds
+from creek.generate.mining import (
+    IdeaMiner,
+    IdeaSeed,
+    MiningSnapshot,
+    _load_mining_snapshot,
+    phase_filtered_seeds,
+)
+from creek.generate.state_tiers import (
+    derived_link_tiers,
+    max_admitted_tier,
+    stamp_report,
+)
 from creek.generate.wavelength import (
     DEFAULT_CURRENT_PHASE_WINDOW_DAYS,
     CurrentPhaseSummary,
     current_phase_summary,
 )
 from creek.hierarchy import select_by_policy
-from creek.models import Eddy, Fragment, Frequency, Praxis, Thread
+from creek.models import Eddy, Fragment, Frequency, Praxis, PrivacyTier, Thread
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +135,9 @@ _LIMINAL_WATCH_TOP_N: int = 5
 """Cap on the number of fresh liminal items rendered **per subfolder** — see
 :meth:`StateReportGenerator.section_liminal_watch`."""
 
+_LIMINAL_ROOT: str = "10-Liminal"
+"""Vault subdirectory holding the liminal surfaces."""
+
 _LIMINAL_SUBDIRS: tuple[str, ...] = ("Unnamed", "Paradoxes")
 """Subfolders under ``10-Liminal`` that the liminal watch surfaces.
 
@@ -111,7 +159,7 @@ _FRAGMENTS_SUBDIR: str = "01-Fragments"
 _THREADS_SUBDIR: str = "02-Threads"
 _EDDIES_SUBDIR: str = "03-Eddies"
 _PRAXIS_SUBDIR: str = "04-Praxis"
-_SYNCHRONICITIES_SUBDIR: str = "10-Liminal/Synchronicities"
+_SYNCHRONICITIES_SUBDIR: str = f"{_LIMINAL_ROOT}/Synchronicities"
 _STATE_SUBPATH: tuple[str, str] = ("00-Creek-Meta", "State")
 _YIELD_RELATIVE: tuple[str, str, str] = (
     "00-Creek-Meta",
@@ -153,19 +201,70 @@ class _SynchronicityRow:
     time_gap_days: int
 
 
+@dataclass(frozen=True)
+class _TierIndex:
+    """Everything the ceiling decided, resolved once at load time (#969).
+
+    Lives on :class:`_VaultState` rather than on
+    :class:`StateReportGenerator` for two reasons. The generator already
+    carries exactly seven instance attributes, which is pylint's ``R0902``
+    ceiling, and a snapshot recording the ceiling it was taken under is the
+    semantically apt place for it anyway — the same claim the artifact stamp
+    makes about the document.
+
+    Attributes:
+        override: The ceiling the snapshot was taken under.
+        content_tiers: One tier per admitted item across every gated section
+            resolved at load time — fragments, eddies, threads, praxis and
+            liminal-watch notes. It is the base of the artifact stamp, not the
+            whole of it: :meth:`StateReportGenerator._content_tier` adds the
+            two contributions that are only knowable at render time, and
+            states there why each one is needed. A section that admits content
+            accounted for in neither place makes the stamp under-report and
+            the read gate fail open.
+        admitted_paths: ``str(path)`` of every admitted fragment file, in the
+            exact form the hygiene scanners return, so the drift section can
+            compare without re-normalising.
+        liminal: ``{subfolder: (admitted file stem, ...)}`` in render order.
+    """
+
+    override: PrivacyTierOverride = PrivacyTierOverride.ALL
+    content_tiers: tuple[PrivacyTier, ...] = ()
+    admitted_paths: frozenset[str] = frozenset()
+    liminal: dict[str, tuple[str, ...]] = field(default_factory=dict)
+
+
 @dataclass
 class _VaultState:
     """Snapshot of every collection :class:`StateReportGenerator` reads.
 
+    Every model collection below is the **admitted** slice: what survived the
+    ceiling, not what is on disk. The unfiltered corpus is deliberately not
+    retained past :func:`_load_vault_state`, so no section can reach around
+    the gate by accident.
+
     Attributes:
-        fragments: Fragment models from ``01-Fragments``.
-        threads: Thread models from ``02-Threads``.
-        eddies: Eddy models from ``03-Eddies``.
-        praxis: Praxis models from ``04-Praxis``.
+        fragments: Admitted Fragment models from ``01-Fragments``.
+        threads: Admitted Thread models from ``02-Threads``.
+        eddies: Admitted Eddy models from ``03-Eddies``.
+        praxis: Admitted Praxis models from ``04-Praxis``.
         synchronicities: Synchronicity rows from ``10-Liminal/Synchronicities``.
+            Not filtered here: a row names two fragment *ids*, and
+            :meth:`StateReportGenerator._is_leaf` already answers ``False`` for
+            an id absent from the admitted load, which fails the row closed.
         latest_yield: Most recent line of
             ``00-Creek-Meta/Processing-Log/run-summary.jsonl``, or
             ``None`` when the log is missing or empty.
+        tiers: What the ceiling decided — see :class:`_TierIndex`.
+        mining_corpus: Memoised narrowed snapshot backing
+            ``## Suggested questions``, or ``None`` before it is first built.
+            Loaded lazily rather than in :func:`_load_vault_state` because it
+            is needed only at ``ceiling=personal`` or broader and costs a
+            second vault walk. It lives here — not on
+            :class:`StateReportGenerator`, which is at pylint's seven-attribute
+            ``R0902`` limit — so both the section that renders it and the stamp
+            that must account for it read one memoised value rather than two
+            independently-built ones.
     """
 
     fragments: list[Fragment] = field(default_factory=list)
@@ -174,6 +273,53 @@ class _VaultState:
     praxis: list[Praxis] = field(default_factory=list)
     synchronicities: list[_SynchronicityRow] = field(default_factory=list)
     latest_yield: dict[str, object] | None = None
+    tiers: _TierIndex = field(default_factory=_TierIndex)
+    mining_corpus: MiningSnapshot | None = None
+
+
+@dataclass(frozen=True)
+class _FragmentLoad:
+    """The fragment corpus split by the ceiling, plus the tiers it implies.
+
+    Attributes:
+        admitted: Fragments the ceiling admits, in vault-walk order.
+        tiers: Those fragments' tiers, positionally parallel to *admitted*.
+        paths: ``str(path)`` of each admitted fragment file.
+        eddy_tiers: ``{eddy title: [member tier, ...]}`` over the **whole**
+            corpus, admitted or not — see :func:`derived_link_tiers`.
+        thread_tiers: The same, keyed by thread title.
+    """
+
+    admitted: list[Fragment]
+    tiers: list[PrivacyTier]
+    paths: frozenset[str]
+    eddy_tiers: dict[str, list[PrivacyTier]]
+    thread_tiers: dict[str, list[PrivacyTier]]
+
+    def tiers_by_id(self) -> dict[str, PrivacyTier]:
+        """Return ``{fragment id: tier}`` for the admitted slice.
+
+        Returns:
+            A lookup the hyperedge gate uses to answer both of its questions at
+            once — "did this ``derived_from`` id resolve to something admitted?"
+            and "how sensitive was it?".
+        """
+        return {
+            fragment.id: tier
+            for fragment, tier in zip(self.admitted, self.tiers, strict=True)
+        }
+
+
+_ModelT = TypeVar("_ModelT", Fragment, Thread, Eddy, Praxis)
+"""Model types :func:`_load_typed_models` can return.
+
+Constrained rather than bound so each call site gets its concrete type back;
+the previous union return forced an ``isinstance`` narrow at every caller that
+mypy could not do for itself.
+"""
+
+_LinkedT = TypeVar("_LinkedT", Thread, Eddy)
+"""Models whose tier is *derived* from the fragments naming their ``title``."""
 
 
 def _safe_post(md_file: Path) -> frontmatter.Post | None:
@@ -189,17 +335,25 @@ def _load_typed_models(
     root: Path,
     *,
     type_tag: str,
-    cls: type[Fragment] | type[Thread] | type[Eddy] | type[Praxis],
-) -> list[Fragment | Thread | Eddy | Praxis]:
+    cls: type[_ModelT],
+) -> list[_ModelT]:
     """Walk *root* and return every model whose ``type`` frontmatter matches.
 
     Files that fail YAML parsing or schema validation are skipped at
     DEBUG level rather than aborting the report — drift in a single
     fragment must not block the whole audit view.
+
+    Args:
+        root: Directory to walk recursively.
+        type_tag: Required ``type`` frontmatter value.
+        cls: Model class to validate each match against.
+
+    Returns:
+        Every validated model, in sorted on-disk order.
     """
     if not root.exists():
         return []
-    collected: list[Fragment | Thread | Eddy | Praxis] = []
+    collected: list[_ModelT] = []
     for md_file in sorted(root.rglob("*.md")):
         post = _safe_post(md_file)
         if post is None:
@@ -213,6 +367,224 @@ def _load_typed_models(
             logger.debug("Skipping invalid %s frontmatter: %s", type_tag, md_file)
             continue
     return collected
+
+
+def _read_fragment_files(
+    root: Path,
+) -> list[tuple[Path, Fragment, dict[str, object]]]:
+    """Load every ``type: fragment`` note under *root* with its raw frontmatter.
+
+    Separate from :func:`_load_typed_models` because #969 needs three things
+    the shared loader throws away: the file's path (the drift section reports
+    orphans by path), and the *raw* metadata alongside the validated model.
+    Raw is not a nicety — :class:`~creek.models.Fragment` defaults a **missing**
+    ``privacy_tier`` to ``unclassified``, which ranks with ``personal`` and is
+    admitted at ``ceiling=personal``, so reading the tier off the model alone
+    fails open relative to what the file actually says.
+
+    Args:
+        root: The ``01-Fragments`` directory.
+
+    Returns:
+        ``(path, fragment, raw frontmatter)`` per valid fragment, in sorted
+        on-disk order. Unreadable, non-fragment and schema-invalid files are
+        skipped, and so are invisible to every gate below — which fails them
+        closed, since a fragment nobody can load is a fragment nobody can vouch
+        for.
+    """
+    if not root.exists():
+        return []
+    loaded: list[tuple[Path, Fragment, dict[str, object]]] = []
+    for md_file in sorted(root.rglob("*.md")):
+        post = _safe_post(md_file)
+        if post is None:
+            continue
+        metadata = dict(post.metadata)
+        if metadata.get("type") != "fragment":
+            continue
+        try:
+            fragment = Fragment.model_validate(metadata)
+        except ValidationError:
+            logger.debug("Skipping invalid fragment frontmatter: %s", md_file)
+            continue
+        loaded.append((md_file, fragment, metadata))
+    return loaded
+
+
+def _load_fragments_admitted(
+    root: Path,
+    override: PrivacyTierOverride,
+) -> _FragmentLoad:
+    """Load the fragment corpus, derive link tiers, then apply the ceiling.
+
+    The ordering is the whole point and is not an implementation detail:
+    ``eddy_tiers`` / ``thread_tiers`` reduce over **every** fragment, admitted
+    or not, and only then is the corpus narrowed. Reversing the two would let
+    an eddy whose members are one ``open`` and one ``intimate`` fragment
+    resolve to ``open`` at ``ceiling=open`` and render its title, which is
+    leak (3) of the three #969 reproduced.
+
+    Args:
+        root: The ``01-Fragments`` directory.
+        override: The admission ceiling.
+
+    Returns:
+        A :class:`_FragmentLoad`.
+    """
+    loaded = _read_fragment_files(root)
+    eddy_tiers = derived_link_tiers(
+        (raw_privacy_tier(raw), _wikilink_targets(fragment.eddies))
+        for _path, fragment, raw in loaded
+    )
+    thread_tiers = derived_link_tiers(
+        (raw_privacy_tier(raw), _wikilink_targets(fragment.threads))
+        for _path, fragment, raw in loaded
+    )
+    admitted = [entry for entry in loaded if within_ceiling(entry[2], override)]
+    return _FragmentLoad(
+        admitted=[fragment for _path, fragment, _raw in admitted],
+        tiers=[raw_privacy_tier(raw) for _path, _fragment, raw in admitted],
+        paths=frozenset(str(path) for path, _fragment, _raw in admitted),
+        eddy_tiers=eddy_tiers,
+        thread_tiers=thread_tiers,
+    )
+
+
+def _admit_by_derived_tier(
+    models: list[_LinkedT],
+    link_tiers: dict[str, list[PrivacyTier]],
+    override: PrivacyTierOverride,
+) -> tuple[list[_LinkedT], list[PrivacyTier]]:
+    """Admit eddies / threads on the tier of the fragments that name them.
+
+    Neither model carries a ``privacy_tier`` field, so the cutoff runs against
+    a *derived* tier: the maximum over the tiers of every fragment whose
+    ``eddies`` / ``threads`` wikilinks name this title.
+    :func:`~creek.classify.privacy_filter.max_source_tier` supplies the empty
+    case, ``INTIMATE`` — an eddy no fragment names has no tier evidence at all,
+    and that includes the ``fragment_count`` fallback path in
+    :meth:`StateReportGenerator._eddy_count`, whose stored count is a number
+    rather than evidence.
+
+    Args:
+        models: Every eddy or thread loaded from disk.
+        link_tiers: ``{title: [member tier, ...]}`` from
+            :func:`_load_fragments_admitted`.
+        override: The admission ceiling.
+
+    Returns:
+        ``(admitted models, their derived tiers)``, positionally parallel.
+    """
+    admitted: list[_LinkedT] = []
+    tiers: list[PrivacyTier] = []
+    for model in models:
+        tier = max_source_tier(link_tiers.get(model.title, []))
+        if tier_within_override(tier, override):
+            admitted.append(model)
+            tiers.append(tier)
+    return admitted, tiers
+
+
+def _admit_praxis(
+    praxis: list[Praxis],
+    fragment_tiers: dict[str, PrivacyTier],
+) -> tuple[list[Praxis], list[PrivacyTier]]:
+    """Admit a praxis only when *every* source fragment survived the ceiling.
+
+    A hyperedge row renders the praxis title and the eddies its sources span,
+    both of which are derived from those sources. Admitting on "some source
+    resolved" would let a praxis whose evidence is mostly above the ceiling
+    still describe itself, so the rule is all-or-nothing.
+
+    An **empty** ``derived_from`` is excluded rather than admitted. It names no
+    evidence, so there is nothing whose tier could vouch for the title — the
+    same reasoning as :func:`_admit_by_derived_tier`'s empty case, reached one
+    step earlier because ``ALL`` would otherwise admit the fail-closed
+    ``INTIMATE`` that reduction produces.
+
+    Args:
+        praxis: Every praxis loaded from disk.
+        fragment_tiers: ``{fragment id: tier}`` over the admitted fragments.
+
+    Returns:
+        ``(admitted praxis, their derived tiers)``, positionally parallel.
+    """
+    admitted: list[Praxis] = []
+    tiers: list[PrivacyTier] = []
+    for item in praxis:
+        if not item.derived_from:
+            continue
+        if any(frag_id not in fragment_tiers for frag_id in item.derived_from):
+            continue
+        admitted.append(item)
+        tiers.append(
+            max_source_tier(fragment_tiers[frag_id] for frag_id in item.derived_from),
+        )
+    return admitted, tiers
+
+
+def _admitted_liminal_notes(
+    folder: Path,
+    override: PrivacyTierOverride,
+) -> list[tuple[str, PrivacyTier]]:
+    """Return admitted ``(file stem, tier)`` pairs under one liminal subfolder.
+
+    ``10-Liminal/Unnamed`` notes are fragments and carry ``privacy_tier``;
+    ``10-Liminal/Paradoxes`` notes are ``type: paradox`` and have no tier field
+    in their model at all. Reading the *raw* frontmatter through
+    :func:`~creek.classify.privacy_filter.within_ceiling` is what lets one gate
+    serve both: the paradox note fails closed to ``intimate`` because nobody
+    vouched for it, not because it was classified.
+
+    Sorting is unchanged from FEAT-007 and is applied before admission so the
+    displayed order does not shift with the ceiling. ``st_mtime`` is
+    best-effort — CI containers and fresh clones flatten it to the checkout
+    time — so ``p.name`` keeps the order deterministic when the primary key
+    ties.
+
+    Args:
+        folder: ``<vault>/10-Liminal/<subfolder>``.
+        override: The admission ceiling.
+
+    Returns:
+        Admitted notes, newest first.
+    """
+    if not folder.exists():
+        return []
+    files = [p for p in folder.glob("*.md") if p.is_file()]
+    files.sort(key=lambda p: (-p.stat().st_mtime, p.name))
+    admitted: list[tuple[str, PrivacyTier]] = []
+    for path in files:
+        post = _safe_post(path)
+        if post is None:
+            continue
+        raw = dict(post.metadata)
+        if within_ceiling(raw, override):
+            admitted.append((path.stem, raw_privacy_tier(raw)))
+    return admitted
+
+
+def _load_liminal_watch(
+    vault_path: Path,
+    override: PrivacyTierOverride,
+) -> tuple[dict[str, tuple[str, ...]], list[PrivacyTier]]:
+    """Collect the liminal watch's admitted stems and the tiers behind them.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+        override: The admission ceiling.
+
+    Returns:
+        ``({subfolder: (stem, ...)}, [tier, ...])``. The tiers are flattened
+        across subfolders because the stamp only ever reduces over them.
+    """
+    stems: dict[str, tuple[str, ...]] = {}
+    tiers: list[PrivacyTier] = []
+    for sub in _LIMINAL_SUBDIRS:
+        entries = _admitted_liminal_notes(vault_path / _LIMINAL_ROOT / sub, override)
+        stems[sub] = tuple(stem for stem, _tier in entries)
+        tiers.extend(tier for _stem, tier in entries)
+    return stems, tiers
 
 
 def _load_synchronicities(root: Path) -> list[_SynchronicityRow]:
@@ -281,48 +653,72 @@ def _load_latest_yield(log_path: Path) -> dict[str, object] | None:
     return payload if isinstance(payload, dict) else None
 
 
-def _load_vault_state(vault_path: Path) -> _VaultState:
-    """Snapshot every collection the report needs from *vault_path*.
+def _load_vault_state(
+    vault_path: Path,
+    override: PrivacyTierOverride,
+) -> _VaultState:
+    """Snapshot every collection the report needs, already narrowed by *override*.
 
-    The ``isinstance`` guards in each comprehension are a mypy narrow,
-    not a runtime safety check: :func:`_load_typed_models` only appends
-    after ``cls.model_validate`` succeeds, so the runtime type is
-    already correct. The guard exists because the helper's return type
-    is the union ``list[Fragment | Thread | Eddy | Praxis]``, which
-    mypy cannot narrow per-call. Removing the guards triggers
-    ``assignment`` errors under strict mode.
+    Composition only: each collection's admission rule lives in the helper
+    named beside it, so this function stays a readable statement of *what* the
+    report is a view over and the interesting decisions stay individually
+    testable.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+        override: The admission ceiling. ``ALL`` admits everything, which is
+            what "no ceiling declared" means for this module's callers.
+
+    Returns:
+        The admitted :class:`_VaultState`.
     """
-    fragments_root = vault_path / _FRAGMENTS_SUBDIR
-    threads_root = vault_path / _THREADS_SUBDIR
-    eddies_root = vault_path / _EDDIES_SUBDIR
-    praxis_root = vault_path / _PRAXIS_SUBDIR
-    fragments = [
-        f
-        for f in _load_typed_models(fragments_root, type_tag="fragment", cls=Fragment)
-        if isinstance(f, Fragment)
-    ]
-    threads = [
-        t
-        for t in _load_typed_models(threads_root, type_tag="thread", cls=Thread)
-        if isinstance(t, Thread)
-    ]
-    eddies = [
-        e
-        for e in _load_typed_models(eddies_root, type_tag="eddy", cls=Eddy)
-        if isinstance(e, Eddy)
-    ]
-    praxis = [
-        p
-        for p in _load_typed_models(praxis_root, type_tag="praxis", cls=Praxis)
-        if isinstance(p, Praxis)
-    ]
+    frags = _load_fragments_admitted(vault_path / _FRAGMENTS_SUBDIR, override)
+    threads, thread_tiers = _admit_by_derived_tier(
+        _load_typed_models(
+            vault_path / _THREADS_SUBDIR,
+            type_tag="thread",
+            cls=Thread,
+        ),
+        frags.thread_tiers,
+        override,
+    )
+    eddies, eddy_tiers = _admit_by_derived_tier(
+        _load_typed_models(
+            vault_path / _EDDIES_SUBDIR,
+            type_tag="eddy",
+            cls=Eddy,
+        ),
+        frags.eddy_tiers,
+        override,
+    )
+    praxis, praxis_tiers = _admit_praxis(
+        _load_typed_models(
+            vault_path / _PRAXIS_SUBDIR,
+            type_tag="praxis",
+            cls=Praxis,
+        ),
+        frags.tiers_by_id(),
+    )
+    liminal, liminal_tiers = _load_liminal_watch(vault_path, override)
     return _VaultState(
-        fragments=fragments,
+        fragments=frags.admitted,
         threads=threads,
         eddies=eddies,
         praxis=praxis,
         synchronicities=_load_synchronicities(vault_path / _SYNCHRONICITIES_SUBDIR),
         latest_yield=_load_latest_yield(_yield_log_path(vault_path)),
+        tiers=_TierIndex(
+            override=override,
+            content_tiers=(
+                *frags.tiers,
+                *thread_tiers,
+                *eddy_tiers,
+                *praxis_tiers,
+                *liminal_tiers,
+            ),
+            admitted_paths=frags.paths,
+            liminal=liminal,
+        ),
     )
 
 
@@ -388,6 +784,62 @@ def _level_annotation(level: str) -> str:
     return f"_Counted at: {level}._"
 
 
+def _vault_relative(path_str: str, vault_path: Path) -> str:
+    """Render a scanner-reported absolute path relative to the vault root.
+
+    ``OrphanScanner`` and ``BrokenLinkScanner`` both return ``str(path)`` for
+    paths they built from the caller's ``vault_path``, so on a normal call that
+    is an **absolute** path under the operator's home directory — which the
+    drift section rendered verbatim until #969, contradicting
+    ``docs/generation.md``'s standing claim that the artifact "does not leak an
+    operator's home directory".
+
+    This closes the drift section's half of that claim. The other half was
+    ``## Lint summary``: ``creek/lint/checks/broken_links.py`` rendered the
+    *same* scanner's absolute source into the Processing-Log artifact that
+    :meth:`StateReportGenerator.section_lint_summary` appends verbatim, and was
+    the only lint check not already using ``relative_to(vault_path)``. It does
+    now, so the claim is true of the whole document rather than of one section.
+
+    ``relative_to`` cannot raise here: every caller filters to the admitted
+    fragment paths first, and those were built from ``vault_path /
+    "01-Fragments"`` by the same lexical join the scanners use.
+
+    Args:
+        path_str: A scanner-reported path.
+        vault_path: Root of the Obsidian vault.
+
+    Returns:
+        The path relative to *vault_path*.
+    """
+    return str(Path(path_str).relative_to(vault_path))
+
+
+def _lint_summary_is_populated(sections: Iterable[str]) -> bool:
+    """Whether the rendered ``## Lint summary`` section carries a report body.
+
+    Computed as a pure function over the **rendered section strings** rather
+    than by re-asking :func:`creek.lint.latest_lint_report`, so the artifact
+    stamp cannot disagree with the document it stamps: there is no ordering
+    hazard between the section methods and the stamp, and two consecutive
+    renders provably stamp the same.
+
+    Args:
+        sections: The rendered sections, in :data:`SECTION_ORDER`.
+
+    Returns:
+        ``True`` when the lint section rendered something other than the
+        empty-state placeholder — which means an untierable verbatim copy of a
+        Processing-Log artifact is in the document and the stamp must escalate
+        to ``intimate``.
+    """
+    placeholder = _section(_HEADER_LINT_SUMMARY, [])
+    return any(
+        section.startswith(_HEADER_LINT_SUMMARY) and section != placeholder
+        for section in sections
+    )
+
+
 def _seed_as_prompt(seed: IdeaSeed) -> str:
     """Format a phase-filtered :class:`IdeaSeed` as one bullet of prompt text.
 
@@ -412,6 +864,12 @@ class StateReportGenerator:
     and returns markdown. It never invokes the classification, linking,
     or compile passes.
 
+    The tier ceiling (#969) is deliberately **not** a generator attribute: it
+    is recorded on the loaded snapshot (``self._state.tiers``), which both
+    keeps this class at pylint's seven-attribute ``R0902`` limit and states the
+    truer thing — a snapshot is only meaningful together with the ceiling it
+    was taken under.
+
     Attributes:
         vault_path: Root of the Obsidian vault.
         today: Date used to derive the ISO-week filename. Defaults to
@@ -425,6 +883,7 @@ class StateReportGenerator:
         *,
         today: date | None = None,
         current_phase: str | None = None,
+        override: PrivacyTierOverride = PrivacyTierOverride.ALL,
     ) -> None:
         """Load the vault snapshot and stash *vault_path* for later use.
 
@@ -437,10 +896,19 @@ class StateReportGenerator:
                 generator derives the phase from the vault via
                 :func:`current_phase_summary`. Tests use this hook to
                 pin phase behaviour without fabricating fragments.
+            override: Tier ceiling for every gated section (#969). Defaults
+                to :attr:`~creek.classify.privacy_filter.PrivacyTierOverride.ALL`,
+                i.e. "no ceiling declared", so every pre-#969 caller — the CLI
+                operator included, who *is* the vault owner — keeps today's
+                output. That default is safe because both production callers
+                state a ceiling explicitly: ``creek_mcp.tools.state`` converts
+                the MCP ``privacy_tier_ceiling`` (itself defaulting to the
+                strictest ``open``), and ``creek state --include-tier`` is
+                parsed straight through.
         """
         self.vault_path = vault_path
         self.today = today or datetime.now(tz=UTC).date()
-        self._state = _load_vault_state(vault_path)
+        self._state = _load_vault_state(vault_path, override)
         self._current_phase_override = current_phase
         self._wavelength_summary: CurrentPhaseSummary | None = None
         self._leaf_fragments: list[Fragment] | None = None
@@ -460,8 +928,14 @@ class StateReportGenerator:
         sentence- or paragraph-level wavelength readings would be noise
         next to whole-source phase signal.
 
+        #969: the counts survey the *admitted* corpus. A per-tier count is
+        content — ``creek.wheel`` is a frequency tally and is ``GATED`` for
+        exactly this reason — so a report that omitted every above-ceiling
+        title while printing ``Fragments observed: 100`` would still disclose
+        the existence of what the rest of it was careful to leave out.
+
         Falls back to the empty-state placeholder when the vault has no
-        classified fragments in the 28-day window.
+        admitted classified fragments in the 28-day window.
         """
         summary = self._resolve_wavelength_summary()
         if summary.fragment_count == 0:
@@ -496,15 +970,20 @@ class StateReportGenerator:
         ``2 * _LIMINAL_WATCH_TOP_N`` rows total). The per-subfolder cap
         is intentional: a quiet week in one subfolder shouldn't starve
         the other.
+
+        #969: the rendered name is a file *stem*, which for an ``Unnamed``
+        note is the operator's own words. Admission is decided at load time by
+        :func:`_admitted_liminal_notes`; the consequence worth stating is that
+        a ``Paradoxes`` note carries no ``privacy_tier`` field in its model at
+        all, so it fails closed and is dropped below ``ceiling=intimate``.
         """
         body: list[str] = []
         for sub in _LIMINAL_SUBDIRS:
-            entries = self._collect_liminal_entries(sub)
+            entries = self._state.tiers.liminal.get(sub, ())
             if not entries:
                 continue
             body.append(f"**{sub}**")
-            for name in entries[:_LIMINAL_WATCH_TOP_N]:
-                body.append(f"- {name}")
+            body.extend(f"- {name}" for name in entries[:_LIMINAL_WATCH_TOP_N])
             body.append("")
         # Drop the trailing blank line so _section's placeholder logic
         # treats a no-content result correctly.
@@ -520,11 +999,117 @@ class StateReportGenerator:
         (Bottoming Out / Diminishing / Withdrawal) surface compost and
         synchronicity prompts; Rising and Peaking surface drafting and
         mining prompts; Restoration mixes both.
+
+        #969 gates this in three ways, because the miner's own filtering is
+        neither uniform across its corpus nor sufficient on the axes it does
+        cover.
+
+        1. **The whole section is dropped below ``ceiling=personal``.** The
+           miner filters fragments through
+           :func:`~creek.classify.privacy_filter.filter_fragments_by_tier`,
+           which *summarises* a personal fragment as
+           ``[Personal-tier summary: <title>]`` rather than excluding it — so
+           at ``ceiling=open`` a personal **title** would enter the mining
+           corpus and ride out inside a prompt.
+        2. **The ceiling is handed to the miner**, so the fragment and liminal
+           halves of its corpus walk are filtered at the source.
+        3. **The corpus it walks is narrowed first** — see
+           :meth:`_mining_corpus`. Threads and eddies are *not* gated by (2)
+           at all: ``creek.generate.mining._load_typed`` takes no override, so
+           ``mine_thread_terminus`` will title a seed with a thread whose every
+           member fragment is above the ceiling.
+
+        The miner is not constructed at all below that ceiling: it walks the
+        vault and appends to ``compile-gaps.jsonl`` on the way, and an
+        artifact written under a ceiling that dropped the section would be one
+        more file to reason about for no benefit. :meth:`_mining_corpus` is
+        guarded by the same predicate for the same reason.
         """
-        phase = self._resolve_current_phase()
-        seeds = phase_filtered_seeds(self.vault_path, phase)
+        if not self._seeds_admitted():
+            return _section(_HEADER_SUGGESTED_QUESTIONS, [])
+        seeds = phase_filtered_seeds(
+            self.vault_path,
+            self._resolve_current_phase(),
+            # ``privacy_override`` here is inert, deliberately, and is kept as a
+            # belt: ``IdeaMiner._resolve_snapshot`` consults it only when
+            # ``snapshot is None``, and the snapshot below is never None. The
+            # filtering that actually happens is :meth:`_mining_corpus`'s own
+            # ``_load_mining_snapshot(privacy_override=...)`` plus the narrowing
+            # it applies afterwards. Passing it anyway means a future edit that
+            # drops the ``snapshot=`` argument degrades to the miner's own
+            # ceiling rather than to no ceiling at all.
+            miner=IdeaMiner(privacy_override=self._state.tiers.override),
+            snapshot=self._mining_corpus(),
+        )
         body = [f"- {_seed_as_prompt(seed)}" for seed in seeds]
         return _section(_HEADER_SUGGESTED_QUESTIONS, body)
+
+    def _seeds_admitted(self) -> bool:
+        """Whether ``## Suggested questions`` renders at all under the ceiling.
+
+        Read by both the section and :meth:`_content_tier`, so the document
+        and the stamp cannot disagree about whether a mining corpus was
+        consulted.
+        """
+        return tier_within_override(
+            PrivacyTier.PERSONAL,
+            self._state.tiers.override,
+        )
+
+    def _mining_corpus(self) -> MiningSnapshot:
+        """Return the mining snapshot, narrowed to what this report admitted.
+
+        Only valid once :meth:`_seeds_admitted` answers ``True``; memoised on
+        the snapshot so the section and the stamp share one corpus and one
+        vault walk.
+
+        **Threads and eddies are replaced outright** with
+        ``self._state.threads`` / ``self._state.eddies``. The narrowing has to
+        happen here rather than in :mod:`creek.generate.mining` because
+        :class:`~creek.models.Thread` and :class:`~creek.models.Eddy` carry no
+        ``privacy_tier`` field: a raw-frontmatter gate down there would have
+        no evidence to read and would fail closed on every thread and eddy,
+        silently deleting two of ``creek mine``'s strategies for every caller
+        below ``ceiling=intimate``. That is a decision about a different tool
+        with its own test suite. This generator already holds the *derived*
+        tiers — the maximum over the fragments naming each title — so it can
+        narrow precisely.
+
+        **Fragments are intersected by id** with the admitted slice. The miner
+        reads ``privacy_tier`` off the validated :class:`~creek.models.Fragment`,
+        which defaults a *missing* key to ``unclassified`` and so admits at
+        ``ceiling=personal`` a file this report's raw-frontmatter cutoff failed
+        closed to ``intimate``. Without the intersection a wavelength-window
+        seed could carry such a fragment's **title**. Note the intersection is
+        by id and not by object: the miner's copy of an admitted fragment may
+        carry a summarised body, which is stricter and is kept.
+
+        **Liminal fragments are left as the miner filtered them**, and that is
+        the one axis this report cannot narrow: they come from ``10-Liminal``
+        subfolders (notably ``Compost``) that ``_load_liminal_watch`` does not
+        walk, so there is no admitted list to intersect against. They are
+        instead accounted for on the stamp — see :meth:`_content_tier`.
+
+        Returns:
+            The snapshot to hand :func:`phase_filtered_seeds`.
+        """
+        corpus = self._state.mining_corpus
+        if corpus is None:
+            loaded = _load_mining_snapshot(
+                self.vault_path,
+                privacy_override=self._state.tiers.override,
+            )
+            admitted_ids = {fragment.id for fragment in self._state.fragments}
+            corpus = replace(
+                loaded,
+                fragments=tuple(
+                    entry for entry in loaded.fragments if entry[0].id in admitted_ids
+                ),
+                threads=tuple(self._state.threads),
+                eddies=tuple(self._state.eddies),
+            )
+            self._state.mining_corpus = corpus
+        return corpus
 
     def _resolve_wavelength_summary(self) -> CurrentPhaseSummary:
         """Compute the wavelength summary once per generator instance.
@@ -532,12 +1117,18 @@ class StateReportGenerator:
         FEAT-025: reads at ``documents`` granularity so sentence- and
         paragraph-level wavelength readings don't drown out the phase
         signal a whole-source document carries.
+
+        #969: the ceiling is threaded into
+        :func:`~creek.generate.wavelength.load_fragments_from_vault`, whose
+        raw-frontmatter cutoff #968 already implemented — so this is one
+        argument, not a subsystem change.
         """
         if self._wavelength_summary is None:
             self._wavelength_summary = current_phase_summary(
                 self.vault_path,
                 today=self.today,
                 level_policy="documents",
+                override=self._state.tiers.override,
             )
         return self._wavelength_summary
 
@@ -559,6 +1150,12 @@ class StateReportGenerator:
         Returns ``False`` for IDs that aren't loaded — a fragment we
         can't see can't be verified as a leaf, and conservatively
         excluding it keeps cross-set rollups (synchronicities) honest.
+
+        #969 makes that fail-closed answer carry the ceiling for free: the
+        loaded set is now the *admitted* set, so a synchronicity endpoint above
+        the ceiling is simply not a leaf and its row is dropped. That is why
+        ``## Surprising connections`` needed no gate of its own — adding one
+        would have been a second admission rule to keep in step with this.
         """
         self._leaves()
         leaf_ids = self._leaf_ids or frozenset()
@@ -570,32 +1167,17 @@ class StateReportGenerator:
             return self._current_phase_override
         return self._resolve_wavelength_summary().phase
 
-    def _collect_liminal_entries(self, subfolder: str) -> list[str]:
-        """Return file display names under ``10-Liminal/<subfolder>``.
-
-        Files are sorted by modification time (newest first). A missing
-        subfolder returns an empty list — the section renders the
-        placeholder only when every subfolder is empty.
-
-        Note: ``st_mtime`` is best-effort. Networked filesystems and
-        fresh checkouts (CI containers, ``git clone``) frequently flatten
-        mtimes to the checkout time, which makes the primary key a tie.
-        The secondary ``p.name`` sort key keeps the order deterministic
-        when that happens.
-        """
-        target = self.vault_path / "10-Liminal" / subfolder
-        if not target.exists():
-            return []
-        files = [p for p in target.glob("*.md") if p.is_file()]
-        files.sort(key=lambda p: (-p.stat().st_mtime, p.name))
-        return [path.stem for path in files]
-
     def section_vault_summary(self) -> str:
         """Render section 1: vault summary (counts + frequency distribution).
 
         Bypasses :func:`_section` deliberately: section 1 always has
         content (the count lines) so the empty-state placeholder is
         unreachable.
+
+        #969: every count is over the *admitted* collections, so this section
+        cannot contradict the eddy and thread sections below it, and a count
+        cannot disclose the existence of content the rest of the report
+        omitted.
         """
         state = self._state
         body = [
@@ -643,6 +1225,14 @@ class StateReportGenerator:
         a vault with eddies but no loaded fragments at all, the stored
         count is the only signal available and we fall back to it so
         the placeholder behaviour of FEAT-006 is preserved.
+
+        #969: ``self._state.eddies`` is already the admitted slice —
+        :func:`_admit_by_derived_tier` cut it off against the maximum tier of
+        the fragments naming each title, because :class:`~creek.models.Eddy`
+        carries no ``privacy_tier`` of its own. Note that the
+        ``has_leaves=False`` fallback above is reachable only for eddies that
+        cleared that cutoff, and an eddy with no member fragments has no tier
+        evidence at all, so it clears only at ``ceiling=intimate`` or broader.
         """
         leaf_counts = self._leaf_counts_by_link("eddies")
         has_leaves = bool(self._leaves())
@@ -670,6 +1260,10 @@ class StateReportGenerator:
         FEAT-025: the fragment count next to each thread is leaf-counted
         the same way as :meth:`section_active_eddies`. The sort key
         (``last_seen``) is unchanged — recency is independent of level.
+
+        #969 admits threads on the same derived tier, for the same reason:
+        a thread title is built from its member fragments and the model
+        carries no tier field.
         """
         leaf_counts = self._leaf_counts_by_link("threads")
         has_leaves = bool(self._leaves())
@@ -782,6 +1376,26 @@ class StateReportGenerator:
         ordering of sections 3-5 instead of falling back to filesystem
         order. The em-dash separator matches the convention used by the
         other list sections.
+
+        #969: ``self._state.praxis`` holds only praxis whose ``derived_from``
+        ids *all* resolved inside the admitted fragment index, and
+        :meth:`_fragment_to_eddies` intersects each of those fragments'
+        ``eddies`` wikilinks with the titles of ``self._state.eddies`` — the
+        eddies admitted on their own *derived* tier. So neither an
+        above-ceiling praxis title nor an above-ceiling eddy title can ride in
+        through this row.
+
+        The intersection deliberately happens *before* the
+        ``len(spanning) >= 2`` rank cut below, because an excluded eddy has
+        two ways to reach the artifact and both had to close: it can be
+        rendered in ``spans:``, and — worse, because it is silent — it can pad
+        the span count and thereby promote a row that would not otherwise
+        qualify. It also had a third, indirect effect: an eddy that renders
+        but is not in ``self._state.eddies`` contributes nothing to
+        ``content_tiers``, so the artifact stamp under-reported and
+        ``creek.state.read`` served the document below the tier it actually
+        carried. A section that emits above-ceiling content without
+        contributing to the stamp makes the read gate fail open.
         """
         fragment_to_eddies = self._fragment_to_eddies()
         candidates = [
@@ -804,7 +1418,30 @@ class StateReportGenerator:
         The state report appends the lint report verbatim. If no lint has
         run yet, the section still renders with the empty-state placeholder
         so the header is never silently dropped.
+
+        #969 admits the section only at ``ceiling=intimate`` or broader, and
+        the whole section or none of it. ``latest_lint_report`` returns a
+        **verbatim copy** of a ``00-Creek-Meta/Processing-Log`` artifact that
+        embeds titles and tag names, and ``creek/lint/checks/tags.py``
+        deliberately surveys the whole vault at ``PrivacyTierOverride.ALL`` so
+        it cannot report "no orphan tags" about a vault that has them. There is
+        no row-level tier to filter on, so a partially-admitted copy would be a
+        silently truncated report presented as a complete one; dropping the
+        section and saying so with the standard placeholder is the honest
+        alternative.
+
+        This closes the live caveat ``creek_mcp/read_gate.py`` records under
+        ``creek.lint``: that its Processing-Log artifact "is unreachable
+        through MCP today". ``creek state`` is the thing that serves it back.
+        Appending it verbatim is also why ``creek/lint/checks/broken_links.py``
+        had to start rendering its sources ``relative_to(vault_path)`` like
+        every sibling check: the copy arrives here unedited, so an absolute
+        path in the lint report is an absolute path in this artifact — at
+        ``ceiling=intimate`` and, since the CLI default is ``all``, on a plain
+        ``creek state``.
         """
+        if not tier_within_override(PrivacyTier.INTIMATE, self._state.tiers.override):
+            return _section(_HEADER_LINT_SUMMARY, [])
         from creek.lint import latest_lint_report
 
         body = latest_lint_report(self.vault_path)
@@ -813,28 +1450,67 @@ class StateReportGenerator:
         return _HEADER_LINT_SUMMARY + "\n\n" + body.strip()
 
     def section_drift_warnings(self) -> str:
-        """Render section 7: broken wiki-links + stale fragments."""
+        """Render section 7: broken wiki-links + stale fragments.
+
+        #969 gates this section by *source*, not by target, and renders every
+        path vault-relative.
+
+        The blanket alternative — dropping the section below
+        ``ceiling=intimate`` on the grounds that a broken link's target has no
+        note and therefore no frontmatter to tier — is true but not decisive.
+        The target string is text authored **inside** the source fragment, so
+        it carries the source's tier, and the source is gated here. Every
+        rendered row is then fully attributable to an admitted fragment, which
+        makes the gate complete rather than partial, and keeps the report's
+        most operationally useful section alive at the MCP default ceiling.
+
+        Both scanners report ``str(path)`` for absolute paths, and the drift
+        section rendered them verbatim until now — leak (1) of the three #969
+        reproduced, since an orphan's filename is its fragment's slugified
+        title. :func:`_vault_relative` closes this section's half of
+        ``docs/generation.md``'s standing "never the absolute path" claim; the
+        other half was ``## Lint summary``, and is recorded there.
+        """
+        admitted = self._state.tiers.admitted_paths
         broken = BrokenLinkScanner().scan(self.vault_path)
         orphans = OrphanScanner(age_days=_STALE_FRAGMENT_AGE_DAYS).scan(
             self.vault_path,
         )
-        body: list[str] = []
-        for source, targets in list(broken.broken_links.items())[:_TOP_N]:
-            label = ", ".join(targets)
-            body.append(f"- Broken links in `{source}`: {label}")
-        if orphans.orphan_paths:
+        # Filter first, cap second: capping the raw scan would let ten
+        # above-ceiling sources crowd out an admitted eleventh.
+        sources = [
+            (source, targets)
+            for source, targets in broken.broken_links.items()
+            if source in admitted
+        ][:_TOP_N]
+        stale = [path for path in orphans.orphan_paths if path in admitted][:_TOP_N]
+        body = [
+            f"- Broken links in `{_vault_relative(source, self.vault_path)}`: "
+            f"{', '.join(targets)}"
+            for source, targets in sources
+        ]
+        if stale:
             if body:
                 body.append("")
             body.append("**Stale fragments**")
-            for path in orphans.orphan_paths[:_TOP_N]:
-                body.append(f"- `{path}`")
+            body.extend(
+                f"- `{_vault_relative(path, self.vault_path)}`" for path in stale
+            )
         return _section(_HEADER_DRIFT_WARNINGS, body)
 
     # ---- Render and write -------------------------------------------
 
-    def render(self) -> str:
-        """Return the full markdown report in the FEAT-007 section order."""
-        sections = [
+    def _sections(self) -> list[str]:
+        """Render all eleven sections in :data:`SECTION_ORDER`.
+
+        Split out of :meth:`render` so :meth:`write` can compute the artifact
+        stamp from the *rendered strings* rather than by re-deriving what each
+        section decided — see :meth:`_content_tier`.
+
+        Returns:
+            One rendered markdown block per section.
+        """
+        return [
             self.section_wavelength_snapshot(),
             self.section_vault_summary(),
             self.section_pre_llm_yield(),
@@ -847,21 +1523,125 @@ class StateReportGenerator:
             self.section_suggested_questions(),
             self.section_lint_summary(),
         ]
+
+    def _document(self, sections: Sequence[str]) -> str:
+        """Join the header and *sections* into the full markdown document.
+
+        Args:
+            sections: Rendered sections in :data:`SECTION_ORDER`.
+
+        Returns:
+            The unstamped document.
+        """
         return self._document_header() + "\n\n" + "\n\n".join(sections) + "\n"
 
+    def _content_tier(self, sections: Sequence[str]) -> PrivacyTier:
+        """Return the highest tier the render actually admitted (#969).
+
+        The reduction runs over ``self._state.tiers.content_tiers`` — one entry
+        per admitted fragment, eddy, thread, praxis and liminal-watch note —
+        plus two additions. The drift section needs no separate contribution:
+        its rows are attributable to admitted fragments, whose tiers are
+        already in that set.
+
+        **Addition one is the suggested-questions seed corpus**, and it is
+        narrower than it looks. After :meth:`_mining_corpus` narrows the
+        snapshot, four of its five content axes are already accounted for:
+        fragments are intersected with the admitted slice, threads and eddies
+        are *replaced* by the admitted lists, and published essay titles,
+        synchronicity ids and compiled-page provenance are read by the miner
+        but never rendered — ``_seed_as_prompt`` emits only ``title`` and
+        ``brief_description``. The fifth axis is not accounted for: the
+        miner's liminal corpus walks all of ``10-Liminal`` (minus
+        ``Synchronicities``), while ``content_tiers`` covers only the two
+        subfolders :data:`_LIMINAL_SUBDIRS` names. A ``10-Liminal/Compost``
+        note therefore reaches ``## Suggested questions`` — its id is rendered
+        inside a liminal-cross-eddy prompt — with nothing to answer for it on
+        the stamp, which is the same fail-open the hyperedge intersection
+        closed. Its tier is added here instead.
+
+        That tier is read off the validated model rather than the raw
+        frontmatter, because the snapshot no longer holds the file. The
+        divergence is one case, and it does not fail open: a liminal note with
+        *no* ``privacy_tier`` key resolves to ``unclassified`` here where a raw
+        read would say ``intimate``, and
+        :func:`~creek.classify.privacy_filter.tier_sensitivity` ranks
+        ``unclassified`` *with* ``personal`` — so the stamp still refuses the
+        artifact at ``ceiling=open``, which is the only ceiling at which the
+        section did not render.
+
+        **Addition two is the lint summary**, derived from the *rendered
+        strings* rather than from a flag the section sets. A flag would create
+        an ordering hazard between the section methods and the stamp;
+        comparing against the empty-section rendering keeps that part a pure
+        function of the document. The seed corpus cannot be recovered the same
+        way — a tier is not readable back out of rendered markdown — so it
+        goes through the memoised :meth:`_mining_corpus` instead, which is
+        order-independent for the same reason a memo is: whether the section
+        built it first or this method does, both see one corpus from one walk.
+
+        By construction the result is within the render's own ceiling: every
+        contributor cleared a cutoff on its way in, and the lint summary
+        escalates to ``intimate`` only on a ceiling that already admits
+        ``intimate``.
+
+        Args:
+            sections: The rendered sections about to be written.
+
+        Returns:
+            The tier to stamp, ``OPEN`` when the render admitted nothing.
+        """
+        tiers = list(self._state.tiers.content_tiers)
+        if self._seeds_admitted():
+            tiers.extend(
+                tier_of(fragment)
+                for fragment, _body, _kind in self._mining_corpus().liminal_fragments
+            )
+        if _lint_summary_is_populated(sections):
+            tiers.append(PrivacyTier.INTIMATE)
+        return max_admitted_tier(tiers)
+
+    def render(self) -> str:
+        """Return the full markdown report in the FEAT-007 section order.
+
+        Deliberately **unstamped**: the stamp is a property of the artifact on
+        disk, not of the rendering, and every existing caller of ``render()``
+        wants the document. :meth:`write` adds it.
+        """
+        return self._document(self._sections())
+
     def write(self) -> Path:
-        """Render the report and write it under ``00-Creek-Meta/State``.
+        """Render, stamp, and write the report under ``00-Creek-Meta/State``.
 
         Also refreshes ``latest.md`` (symlink where supported, copy on
         Windows or when symlink creation fails). Returns the path of the
         ISO-week file. Re-running in the same ISO week overwrites the
         existing file.
+
+        The stamp (#969) is what turns ``latest.md`` from a cross-ceiling cache
+        into a self-describing artifact: it records the highest tier this
+        render admitted, which is what ``creek.state.read`` compares a caller's
+        ceiling against. Both write paths carry it, because ``latest.md`` is
+        the documented session-start context and therefore the file almost
+        every reader actually opens — an unstamped copy there would look like a
+        pre-#969 artifact and be refused at every ceiling below ``intimate``.
+
+        Returns:
+            The ISO-week report path.
         """
         state_dir = self.vault_path.joinpath(*_STATE_SUBPATH)
         state_dir.mkdir(parents=True, exist_ok=True)
         iso_year, iso_week, _ = self.today.isocalendar()
         target = state_dir / f"{iso_year}-W{iso_week:02d}.md"
-        target.write_text(self.render(), encoding="utf-8")
+        sections = self._sections()
+        target.write_text(
+            stamp_report(
+                self._document(sections),
+                content_tier=self._content_tier(sections),
+                override=self._state.tiers.override,
+            ),
+            encoding="utf-8",
+        )
         _refresh_latest(state_dir, target)
         return target
 
@@ -874,6 +1654,14 @@ class StateReportGenerator:
         name only, never the absolute path. If the audit file is ever
         committed or shared, this avoids leaking an operator's home
         directory into the artefact.
+
+        That was only ever true of *this* block until #969: two other places
+        put an absolute path into the same document — the drift section, which
+        rendered the hygiene scanners' paths verbatim (see
+        :func:`_vault_relative`), and the verbatim lint report appended by
+        :meth:`section_lint_summary`, whose ``broken-links`` check rendered the
+        same scanner's absolute source. Both now render vault-relative, so the
+        claim holds for the document and not merely for the header.
         """
         iso_year, iso_week, _ = self.today.isocalendar()
         generated = datetime.now(tz=UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
@@ -884,15 +1672,26 @@ class StateReportGenerator:
         )
 
     def _fragment_to_eddies(self) -> dict[str, set[str]]:
-        """Return ``{fragment_id: {eddy_title, ...}}`` from fragment frontmatter.
+        """Return ``{fragment_id: {admitted eddy title, ...}}`` from frontmatter.
 
         Named in the direction of the mapping (fragment -> eddies) to
         match Python ``dict`` semantics; ``_eddies_by_fragment`` was
         ambiguous about which side was the key.
+
+        #969: the wikilink targets are intersected with the titles of
+        ``self._state.eddies``, the eddies the ceiling admitted. Being named
+        by an admitted fragment is *not* sufficient evidence on its own — an
+        eddy with one ``open`` and one ``intimate`` member derives ``intimate``
+        and is excluded, yet its title is written in the ``open`` member's
+        frontmatter, so the unintersected union rendered it at ``ceiling=open``.
+        A target matching no admitted title is dropped rather than passed
+        through, which is the fail-closed reading: an eddy nobody admitted is
+        an eddy this report cannot name.
         """
+        admitted_titles = {eddy.title for eddy in self._state.eddies}
         mapping: dict[str, set[str]] = {}
         for fragment in self._state.fragments:
-            targets = set(_wikilink_targets(fragment.eddies))
+            targets = set(_wikilink_targets(fragment.eddies)) & admitted_titles
             if targets:
                 mapping[fragment.id] = targets
         return mapping

--- a/creek-tools/creek/generate/state_tiers.py
+++ b/creek-tools/creek/generate/state_tiers.py
@@ -1,0 +1,226 @@
+"""Tier admission and self-description for the ``creek state`` artifact (#969).
+
+``creek state`` writes a document, and until #969 that document said nothing
+about how sensitive its own contents were. ``creek.state.read`` therefore had
+nothing to compare a caller's ceiling against and served
+``00-Creek-Meta/State/latest.md`` verbatim at every ceiling. This module holds
+the two halves of the fix that are *pure* — the artifact stamp and the
+reductions the per-section gates in :mod:`creek.generate.state` need — so that
+module keeps its per-function complexity and per-file coverage budget while the
+admission decisions stay next to the sections that make them.
+
+**The stamp key is ``privacy_tier``, deliberately.** A bespoke key would have
+forced a bespoke reader, and a second tier reader is exactly the divergence
+:mod:`creek.classify.privacy_filter`'s module docstring warns about ("two tools
+that disagree about the same file"). Writing the tier under the name every
+other vault note uses means :func:`stamped_content_tier` can delegate to
+:func:`creek.classify.privacy_filter.raw_privacy_tier` verbatim, inheriting its
+fail-closed handling of a missing, empty, non-string or unrecognised value.
+#969 adds no tier reader of its own.
+
+**The stamp is three scalars and nothing else.** CrawDad keeps a report's
+``raw_markdown`` *including* its frontmatter and feeds it into prompts
+(``crawdad/crawdad/state.py``), and its bullet regex is ``^\\s*-\\s+``; a
+block-style YAML list in the stamp would be misread as a report bullet. So the
+dump is ``yaml.safe_dump(..., sort_keys=False)`` over scalar values only, which
+produces three inert ``key: value`` lines. CrawDad's ``_split_sections``
+discards everything before the first ``## ``, so the stamp is invisible to its
+section parsing as well.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import frontmatter
+import yaml
+
+from creek.classify.privacy_filter import raw_privacy_tier, tier_sensitivity
+from creek.models import PrivacyTier
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from creek.classify.privacy_filter import PrivacyTierOverride
+
+logger = logging.getLogger(__name__)
+
+
+STATE_REPORT_TYPE: str = "state-report"
+"""Value written under the stamp's ``type`` key.
+
+Chosen so a stamped report cannot be mistaken for vault content by the very
+generator that wrote it: ``creek.generate.state._load_typed_models`` admits
+only ``fragment`` / ``thread`` / ``eddy`` / ``praxis``, and
+``creek.generate.tags.TagGardenGenerator`` does not scan ``00-Creek-Meta``.
+"""
+
+TYPE_STAMP_KEY: str = "type"
+"""Frontmatter key carrying :data:`STATE_REPORT_TYPE`."""
+
+TIER_STAMP_KEY: str = "privacy_tier"
+"""Frontmatter key carrying the highest tier the render actually admitted.
+
+This is what ``creek.state.read`` compares the caller's ceiling against — not
+the ceiling the render ran under. Comparing the render ceiling would refuse a
+broad render over a narrow corpus for no reason: a report produced at
+``--include-tier all`` over a vault holding nothing above ``open`` contains
+nothing above ``open`` and must stay readable at ``ceiling=open``.
+"""
+
+CEILING_STAMP_KEY: str = "tier_ceiling"
+"""Frontmatter key recording the override the render ran under.
+
+Kept for the audit trail and deliberately *not* consulted by the read gate;
+see :data:`TIER_STAMP_KEY` for why.
+"""
+
+
+def derived_link_tiers(
+    entries: Iterable[tuple[PrivacyTier, Iterable[str]]],
+) -> dict[str, list[PrivacyTier]]:
+    """Group source tiers by the wikilink target each source names.
+
+    :class:`~creek.models.Eddy` and :class:`~creek.models.Thread` carry no
+    ``privacy_tier`` field of their own, so the only evidence about how
+    sensitive an eddy title is comes from the fragments that name it. This
+    builds that evidence, and it must be built over the **unfiltered** fragment
+    corpus: an eddy with one ``open`` and one ``intimate`` member is
+    ``intimate``, and reducing over the *already-admitted* fragments alone
+    would resolve it to ``open`` and leak the title at ``ceiling=open``.
+
+    The reduction itself is left to
+    :func:`creek.classify.privacy_filter.max_source_tier`, whose empty case
+    (``INTIMATE``) is the right answer for a target no fragment names: nobody
+    has vouched for it.
+
+    Args:
+        entries: ``(source tier, wikilink targets)`` pairs, one per fragment.
+
+    Returns:
+        ``{target: [tier, ...]}``. A target absent from the mapping had no
+        constituents at all, which the caller must read as "no evidence" rather
+        than as "no sensitivity".
+    """
+    grouped: dict[str, list[PrivacyTier]] = {}
+    for tier, targets in entries:
+        for target in targets:
+            grouped.setdefault(target, []).append(tier)
+    return grouped
+
+
+def max_admitted_tier(tiers: Iterable[PrivacyTier]) -> PrivacyTier:
+    """Return the most sensitive tier the render admitted, ``OPEN`` when none.
+
+    Ranked by :func:`creek.classify.privacy_filter.tier_sensitivity` — the same
+    reader's-caution ordering the admission cutoff uses — so "most sensitive"
+    cannot mean one thing at the gate and another on the stamp.
+
+    **The empty default is ``OPEN``, and that is the one place this reduction
+    deliberately diverges from
+    :func:`creek.classify.privacy_filter.max_source_tier`.** The two empties
+    describe different situations. ``max_source_tier``'s empty means "ids were
+    named and none of them resolved" — an absence of *knowledge* about what a
+    call would carry, so the safe assumption is the worst one. Here empty means
+    "the render admitted nothing and wrote no content-derived bytes" — which is
+    knowledge, and it is negative. Stamping such a report ``intimate`` would
+    make a freshly-initialised vault's first report unreadable at every ceiling
+    below ``intimate``: an outage on first run, and precisely what #969's
+    recoverability criterion forbids.
+
+    Args:
+        tiers: Tiers of every item the render actually put in the document.
+
+    Returns:
+        The most sensitive tier present, or
+        :attr:`~creek.models.PrivacyTier.OPEN` when *tiers* is empty.
+    """
+    return max(tiers, key=tier_sensitivity, default=PrivacyTier.OPEN)
+
+
+def stamp_report(
+    body: str,
+    *,
+    content_tier: PrivacyTier,
+    override: PrivacyTierOverride,
+) -> str:
+    """Prefix a rendered report with its self-describing YAML stamp.
+
+    The body is passed through byte for byte; only a frontmatter block is
+    prepended. Nothing in the report is re-encoded, so em-dashes, backticks and
+    ``##`` headings survive the round trip that :func:`stamped_content_tier`
+    later performs.
+
+    Args:
+        body: The rendered markdown document, unstamped.
+        content_tier: The highest tier the render admitted — see
+            :data:`TIER_STAMP_KEY`.
+        override: The ceiling the render ran under, recorded for the audit
+            trail under :data:`CEILING_STAMP_KEY`.
+
+    Returns:
+        ``---\\n<three scalar lines>\\n---\\n\\n<body>``.
+    """
+    stamp = {
+        TYPE_STAMP_KEY: STATE_REPORT_TYPE,
+        TIER_STAMP_KEY: content_tier.value,
+        CEILING_STAMP_KEY: override.value,
+    }
+    # ``sort_keys=False`` keeps type/tier/ceiling in the order a human reads
+    # them; ``default_flow_style=False`` keeps every value on its own line.
+    front = yaml.safe_dump(stamp, sort_keys=False, default_flow_style=False)
+    return f"---\n{front}---\n\n{body}"
+
+
+def stamped_content_tier(text: str) -> PrivacyTier:
+    """Read a state artifact's stamped tier, failing closed to ``INTIMATE``.
+
+    Three separate failures land on the same answer, and that identity is
+    load-bearing rather than lazy: a report with unparsable frontmatter, a
+    report with no stamp at all, and a report stamped with a value the enum
+    does not recognise are all reports nobody has vouched for. Distinguishing
+    them in the *result* would be harmless, but distinguishing them in the
+    caller's refusal would turn the gate into an oracle for whether the vault
+    holds above-ceiling content, so they are collapsed here where the reasoning
+    belongs.
+
+    The unstamped case is the pre-#969 ``latest.md``, and ``INTIMATE`` is an
+    accurate statement about it rather than a cautious one: every report written
+    before this change was rendered completely unfiltered — the equivalent of
+    ``--include-tier all``. Recovery is one command
+    (``creek.state.render``/``creek state --include-tier <t>``), and no ceiling
+    of ``all`` ever refuses it, so nothing is permanently unreachable.
+
+    :class:`ValueError` is caught alongside :class:`yaml.YAMLError`, and it is
+    not defensive padding: ``frontmatter.loads`` dispatches on *handler*, and
+    the library registers a ``JSONHandler`` whose boundary pattern is
+    ``^(?:{|})$``. An artifact whose first line is exactly ``{`` is therefore
+    routed to :func:`json.loads`, which raises :class:`json.JSONDecodeError` —
+    a ``ValueError``, not a ``yaml.YAMLError``. Catching only the latter let
+    that escape uncaught and crash ``creek_mcp.tools.state_read`` instead of
+    failing closed, which is the single outcome this function exists to
+    prevent. The two exception types are unrelated in the hierarchy, so both
+    must be named.
+
+    ``frontmatter.loads`` does already handle the other two ways a document
+    can disappoint us without raising: an artifact with no frontmatter
+    delimiters at all yields ``{}`` (which :func:`raw_privacy_tier` reads as
+    ``INTIMATE``), and a frontmatter block that parses to a list or a scalar is
+    discarded by its own ``isinstance(fm_data, dict)`` guard, yielding ``{}``
+    likewise. Neither needs an ``except``.
+
+    Args:
+        text: The artifact's full bytes, stamp included.
+
+    Returns:
+        The stamped :class:`~creek.models.PrivacyTier`, or
+        :attr:`~creek.models.PrivacyTier.INTIMATE` when the stamp is missing or
+        unreadable.
+    """
+    try:
+        metadata = frontmatter.loads(text).metadata
+    except (yaml.YAMLError, ValueError):
+        logger.debug("State artifact frontmatter is unparsable; failing closed")
+        return PrivacyTier.INTIMATE
+    return raw_privacy_tier(metadata)

--- a/creek-tools/creek/generate/wavelength.py
+++ b/creek-tools/creek/generate/wavelength.py
@@ -1322,6 +1322,7 @@ def current_phase_summary(
     today: date | None = None,
     window_days: int = DEFAULT_CURRENT_PHASE_WINDOW_DAYS,
     level_policy: LevelPolicy = "all",
+    override: PrivacyTierOverride = PrivacyTierOverride.ALL,
 ) -> CurrentPhaseSummary:
     """Return a :class:`CurrentPhaseSummary` for the trailing *window_days*.
 
@@ -1344,13 +1345,23 @@ def current_phase_summary(
             ``"all"`` (default) reproduces the pre-FEAT-025 behaviour.
             ``creek state`` passes ``"documents"`` so the snapshot is
             read at whole-source granularity.
+        override: Tier ceiling (#969), handed to
+            :func:`load_fragments_from_vault`, which already applies the
+            raw-frontmatter cutoff #968 added. Defaults to
+            :attr:`~creek.classify.privacy_filter.PrivacyTierOverride.ALL`
+            — "no ceiling declared" — so every pre-#969 caller is unchanged.
+            ``creek state`` states one explicitly, because the summary's
+            ``fragment_count`` is a per-tier count and therefore content: the
+            same one-bit disclosure ``creek.wheel``'s frequency tally is
+            ``GATED`` against. ``transitions`` renders phases and dates only,
+            so it names nothing that needs its own gate.
 
     Returns:
         A :class:`CurrentPhaseSummary`.
     """
     anchor = today or datetime.now(tz=UTC).date()
     start = anchor - timedelta(days=window_days - 1)
-    fragments = load_fragments_from_vault(vault_path)
+    fragments = load_fragments_from_vault(vault_path, override=override)
     fragments = select_by_policy(fragments, level_policy)
     tracker = WavelengthTracker()
     snapshot = tracker.analyze_period(fragments, start, anchor)

--- a/creek-tools/creek/lint/checks/broken_links.py
+++ b/creek-tools/creek/lint/checks/broken_links.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime  # noqa: TC003  # used at runtime as a parameter type
-from pathlib import Path  # noqa: TC003  # plain stdlib import; no lazy benefit
+from pathlib import Path  # used at runtime to render sources vault-relative
 
 from creek.clean.hygiene import BrokenLinkScanner
 from creek.lint._result import CheckResult
@@ -15,13 +15,29 @@ def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
     Wraps :class:`creek.clean.hygiene.BrokenLinkScanner`. The ``since``
     parameter is accepted for interface consistency but ignored — the
     scanner is already fast enough that filtering by mtime adds little.
+
+    The source is rendered **vault-relative**, matching every sibling check
+    (``compost``, ``unnamed``, ``skill_size_budget``, ``orphan_compiled``).
+    This one was the outlier: :class:`~creek.clean.hygiene.BrokenLinkScanner`
+    keys its result by ``str(path)``, which on a normal call is an absolute
+    path under the operator's home directory, and ``creek state``'s
+    ``## Lint summary`` appends this report **verbatim** at
+    ``ceiling=intimate`` or broader — including a plain ``creek state``, whose
+    default ceiling is ``all`` (#969). An absolute source here therefore put
+    ``/Users/<operator>/...`` into a committable, shareable artefact and
+    falsified the standing "no path in the artefact is absolute" claim in
+    ``docs/generation.md``.
+
+    ``relative_to`` cannot raise: the scanner builds every key from
+    ``vault_path / "01-Fragments"`` by the same lexical join used here.
     """
     del since  # interface symmetry only
     scan = BrokenLinkScanner().scan(vault_path)
     findings: list[str] = []
     for source, targets in sorted(scan.broken_links.items()):
+        relative = Path(source).relative_to(vault_path)
         for target in targets:
-            findings.append(f"- `{source}` → `{target}`")
+            findings.append(f"- `{relative}` → `{target}`")
     summary = (
         f"{scan.total_broken} broken link(s) across {scan.total_files_scanned} file(s)"
     )

--- a/creek-tools/creek/lint/checks/tags.py
+++ b/creek-tools/creek/lint/checks/tags.py
@@ -15,8 +15,13 @@ def run(vault_path: Path, *, since: datetime | None = None) -> CheckResult:
     del since
     # Stated explicitly rather than inherited (#968): an orphan-tag check must
     # survey the whole vault or it reports "no orphan tags" about a vault that
-    # has them. Safe to keep unfiltered because ``creek.lint``'s read posture is
-    # METADATA_ONLY — ``findings`` never leave the process over MCP.
+    # has them. What keeps the unfiltered survey safe is *not* that the
+    # findings stay in-process — ``creek state``'s ``## Lint summary`` appends
+    # this report verbatim (#969), so they do leave. It is that the section
+    # admits that copy whole or not at all, and only at ``ceiling=intimate``
+    # or broader: an untierable Processing-Log artefact has no row-level tier
+    # to filter on, so a partial copy would be a truncated report presented as
+    # a complete one.
     scan = TagGardenGenerator(
         vault_path=vault_path,
         override=PrivacyTierOverride.ALL,

--- a/creek-tools/creek_mcp/read_gate.py
+++ b/creek-tools/creek_mcp/read_gate.py
@@ -35,17 +35,30 @@ of the primitives below inherits it:
 5. Only *after* admission derive :func:`creek_mcp.tier_ceiling.routing_tier`
    to key a model call.
 
-**Why these primitives have no production caller yet.** That is a decision,
-not an oversight. ``creek.reflect`` and ``creek.compile`` are deliberately
-*not* retrofitted onto :func:`refuse_above_ceiling`: their refusal reasons and
-ordering comments are tool-specific and load-bearing. Reflect's "ACCEPTED
-RESIDUAL RISK" block documents exactly why its reason must stay distinct from
-``entry_ref not found`` — including the timing-equalisation caveat that would
-have to be handled if the two were ever unified — and folding it into a shared
-reason would delete that reasoning along with the behaviour. The primitives
-exist so a filed gap can be closed by *adoption* rather than by each tool
-re-deriving the policy, and so that a *new* tool finds an already-gated corpus
-walk on the path of least resistance.
+**Who calls these primitives, and why the rest still do not.**
+:func:`refuse_above_ceiling` has exactly one production caller:
+``creek_mcp.tools.state_read``, which adopted it in #969. That adoption is the
+shape the primitives were written for — the tool addresses a *single* cached
+artifact, so there is nothing to partially admit, and its refusal has no
+tool-specific story to tell. It gets the generic reason, the four-key payload
+and the no-tier-echo rule for free rather than re-deriving any of them.
+
+The other refusing tools are deliberately *not* retrofitted.
+``creek.reflect`` and ``creek.compile`` keep their own refusal reasons and
+ordering comments because those are tool-specific and load-bearing: reflect's
+"ACCEPTED RESIDUAL RISK" block documents exactly why its reason must stay
+distinct from ``entry_ref not found`` — including the timing-equalisation
+caveat that would have to be handled if the two were ever unified — and folding
+it into a shared reason would delete that reasoning along with the behaviour.
+
+:func:`iter_admitted_fragments` still has no production caller, and that too is
+a decision. Every gap closed so far needed the **hard rank cutoff**
+(``tier_within_override``) rather than this primitive's summarising filter: a
+report or a state artifact must *omit* above-ceiling content, because a
+``"[Personal-tier summary: <title>]"`` stub written into a voice profile or a
+mined prompt leaks the title it claims to be protecting. The primitive remains
+the right answer for a future tool that hands bodies to a model, and it is what
+stops such a tool re-deriving Ontology §13.2 for itself.
 
 **Adoption is not the only honest way to close a gap, and #968 is the worked
 example.** ``creek.report`` is now ``GATED`` without adopting either
@@ -62,6 +75,14 @@ corpus — and it reads the tier through the validated
 :func:`creek_mcp.tier_ceiling.to_privacy_override` without adopting either
 primitive. What the manifest checks is that the named gate exists and decides
 something, not which of two shapes it takes.
+
+#969 closed the two ``creek.state.*`` gaps and needed *both* shapes at once,
+which is the clearest statement of the rule. ``creek.state.render`` names no
+target — it is a corpus walk — so it excludes, on ``to_privacy_override``, like
+``report``. ``creek.state.read`` addresses one atomic cached artifact, so it
+refuses, on ``refuse_above_ceiling``. Read that as #1068's compile/reflect
+reasoning one level up: read's target is not caller-*named*, but it is
+caller-*addressed* and singular, which is the property that decides.
 
 :data:`TOOL_POSTURES` is verified by ``tests/test_mcp_read_gate.py``, which
 fails if an entry lies: the manifest must match ``server.list_tools()``
@@ -265,26 +286,55 @@ TOOL_POSTURES: dict[str, ToolPosture] = {
         gate_symbol="to_privacy_override",
     ),
     "creek.state.read": ToolPosture(
-        posture=ReadPosture.UNGATED_KNOWN_GAP,
+        posture=ReadPosture.GATED,
         rationale=(
-            "Returns 00-Creek-Meta/State/latest.md verbatim at any ceiling. "
-            "The artifact records no ceiling of its own, so it may have been "
-            "rendered at ceiling=all and be read back at ceiling=open (#969)."
+            "Refuses, rather than excludes, on the artifact's own privacy_tier "
+            "stamp: its target is one atomic cached artifact, so there is "
+            "nothing to partially admit — you cannot exclude half a rendered "
+            "markdown document without re-rendering it, and re-rendering is "
+            "what creek.state.render is. refuse_above_ceiling supplies the "
+            "generic reason and the four-key payload, so the refusal never "
+            "names the stamped tier. Consequence to know: a pre-#969 "
+            "latest.md carries no stamp, fails closed to intimate and is "
+            "refused below ceiling=intimate — accurate rather than cautious, "
+            "since those bytes were rendered completely unfiltered. Recovery "
+            "is one re-render, and ceiling=all admits every stamp, so no "
+            "report is permanently unreachable. A *missing* report stays "
+            "status=empty: refusing there would be a vault-emptiness oracle "
+            "in the other direction."
         ),
-        gap_issue=969,
+        gate_module="creek_mcp.tools.state_read",
+        gate_symbol="refuse_above_ceiling",
     ),
     "creek.state.render": ToolPosture(
-        posture=ReadPosture.UNGATED_KNOWN_GAP,
+        posture=ReadPosture.GATED,
         rationale=(
-            "Walks the whole vault through StateReportGenerator, which "
-            "threads no override, and returns the rendered content. Its one "
-            "fragment-derived section is safe by default "
-            "(phase_filtered_seeds with override=None, which ranks as "
-            "ceiling=open); the eddy/thread/liminal title sections are "
-            "unfiltered and unfilterable — Eddy and Thread carry no "
-            "privacy_tier (#969)."
+            "Converts the ceiling with to_privacy_override and threads it "
+            "into StateReportGenerator, which admits ten of its eleven "
+            "sections against it and stamps the written artifact with the "
+            "highest tier it admitted. The exception is Pre-LLM yield, "
+            "ungated on purpose: it renders the last line of "
+            "run-summary.jsonl — a run id, a timestamp and four integers "
+            "describing one pipeline run — which names no fragment, so there "
+            "is nothing in it to filter by. Excludes rather than refuses: the tool "
+            "names no target, so refusing would make the audit report "
+            "unreachable — #968's explicit anti-goal. The gap was write-side, "
+            "which is why it survived a response-level sweep: the evidence is "
+            "the bytes under 00-Creek-Meta/State, where three leaks were "
+            "reproduced (an orphan path carrying an intimate fragment's "
+            "slugified title, a 10-Liminal/Unnamed file stem, and an eddy "
+            "title derived from an above-ceiling member). Consequences to "
+            "know: type: paradox notes carry no privacy_tier field at all and "
+            "fail closed out of the Liminal Watch below ceiling=intimate; the "
+            "lint summary is an untierable verbatim Processing-Log copy and is "
+            "admitted whole or not at all, i.e. intimate-only; suggested "
+            "questions are dropped below ceiling=personal because the miner's "
+            "filter summarises rather than drops a personal title; and "
+            "latest.md is a single slot, so a narrow render replaces a broader "
+            "one for every later reader."
         ),
-        gap_issue=969,
+        gate_module="creek_mcp.tools.state",
+        gate_symbol="to_privacy_override",
     ),
     "creek.skills.refresh": ToolPosture(
         posture=ReadPosture.UNGATED_KNOWN_GAP,
@@ -319,10 +369,16 @@ TOOL_POSTURES: dict[str, ToolPosture] = {
             "tags check deliberately surveys the whole vault "
             "(creek/lint/checks/tags.py passes PrivacyTierOverride.ALL) so it "
             "cannot report 'no orphan tags' about a vault that has them. That "
-            "artifact is unreachable through MCP today, which is the same "
-            "argument #968 disproved for creek.report's Tag-Garden.md — it "
-            "holds here only while nothing serves Processing-Log/ back, so "
-            "read it against #969's state-artifact gap rather than alone."
+            "artifact IS served back through MCP — creek state appends it "
+            "verbatim as its ## Lint summary section — and #969 closed the "
+            "hole at that boundary rather than here: the section is now "
+            "rendered only at ceiling=intimate or broader, and its presence "
+            "escalates the state artifact's own tier stamp to intimate. The "
+            "copy is untierable row by row, so it is admitted whole or not at "
+            "all. What is left unresolved here is narrower than the caveat "
+            "this replaces: the file on disk is still written at ALL, so any "
+            "*future* surface that serves Processing-Log/ must make the same "
+            "whole-or-nothing decision creek state did."
         ),
     ),
     "creek.link": ToolPosture(

--- a/creek-tools/creek_mcp/tools/state.py
+++ b/creek-tools/creek_mcp/tools/state.py
@@ -3,6 +3,54 @@
 Mirrors ``creek state`` from the CLI. Re-rendering walks the vault, so
 callers should prefer :func:`creek_mcp.tools.state_read.state_read_tool`
 when they only need the most recent rendered output.
+
+**Posture: GATED, and it EXCLUDES rather than refuses (#969).** The tool names
+no target — it is a corpus walk, like ``report`` / ``wheel`` / ``mine`` — so
+refusing it would make the audit report unreachable, which is #968's explicit
+anti-goal. The ceiling is converted with
+:func:`~creek_mcp.tier_ceiling.to_privacy_override` and threaded into
+:class:`~creek.generate.state.StateReportGenerator`, which admits ten of its
+eleven sections against it and then stamps the written artifact with the
+highest tier it actually admitted. The eleventh, ``## Pre-LLM yield``, is
+ungated on purpose: it renders the last line of ``run-summary.jsonl`` — a run
+id, a timestamp and four integers describing one pipeline run — which names no
+fragment, so there is nothing in it to filter by.
+
+The gap this closed was **write-side**, which is why it survived a response-
+level sweep: the envelope happens to echo ``content`` today, but the durable
+evidence is the bytes under ``00-Creek-Meta/State`` — the file
+``creek.state.read``, ``creek state-budget``, a git commit and the operator's
+editor all serve. Three leaks were reproduced there: an ``intimate``
+fragment's slugified title inside an absolute orphan path, a
+``10-Liminal/Unnamed`` note's file stem, and an eddy title derived from an
+above-ceiling member fragment.
+
+Consequences worth knowing before calling this:
+
+* ``10-Liminal/Paradoxes`` notes are ``type: paradox`` and carry no
+  ``privacy_tier`` field in their model at all, so they fail closed to
+  ``intimate`` and vanish from the Liminal Watch below ``ceiling=intimate``.
+  The same is true of any hand-written note missing the key.
+* The lint summary is an untierable verbatim copy of a Processing-Log
+  artifact, so it is admitted whole or not at all — only at
+  ``ceiling=intimate`` or broader.
+* Suggested questions are dropped entirely below ``ceiling=personal``: the
+  miner's tier filter *summarises* a personal fragment as
+  ``[Personal-tier summary: <title>]`` rather than dropping it, so a personal
+  title could otherwise ride out inside a prompt. At ``personal`` and above,
+  the generator narrows the miner's corpus before handing it over — the
+  mining loaders gate fragments but not ``02-Threads`` / ``03-Eddies``, so an
+  above-ceiling thread title would otherwise reach a prompt.
+* An eddy or thread with no member fragments has no tier evidence, so it too
+  is admitted only at ``ceiling=intimate`` or broader.
+
+**Cache thrash, stated on the tin.** ``latest.md`` is a single slot shared
+across ceilings, kept single deliberately — per-ceiling filenames would
+multiply artifacts in the operator's vault and break ``latest.md`` as the
+documented session-start context. So a render at this tool's *default*
+``ceiling=open`` replaces a richer ``ceiling=all`` report for everybody,
+including later CLI readers. The ISO-week archive is untouched, and the
+broader caller recovers by re-rendering.
 """
 
 from __future__ import annotations
@@ -11,7 +59,7 @@ from typing import TYPE_CHECKING, Any
 
 from creek.generate.state import StateReportGenerator
 from creek_mcp.audit import MCPAuditLog
-from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.tier_ceiling import TierCeiling, to_privacy_override
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -28,20 +76,23 @@ def state_render_tool(
     """Re-render the audit report and return the written file path.
 
     The rendered file lives under ``00-Creek-Meta/State/<iso-week>.md``;
-    ``latest.md`` is refreshed atomically by the underlying generator.
+    ``latest.md`` is refreshed by the underlying generator and carries the
+    same tier stamp, since it is the file most readers actually open.
 
-    Walks the whole vault through ``StateReportGenerator``, which accepts
-    no privacy override, and returns the rendered content — the ceiling
-    is audited and echoed but never threaded into the walk (#969). Its
-    one fragment-derived section, ``section_suggested_questions``, is
-    safe by default: it calls ``phase_filtered_seeds`` with
-    ``override=None``, which ``filter_fragments_by_tier`` treats as
-    equivalent to ``open`` — intimate dropped, personal bodies
-    summarised. The eddy/thread/liminal *title* sections are unfiltered,
-    and unfilterable today: ``Eddy`` and ``Thread`` in ``creek/models.py``
-    carry no ``privacy_tier`` field at all. Tracked together with
-    ``creek.state.read`` under #969, because the fix is one design —
-    tier-stamped state artifacts — spanning both sides.
+    The audit entry is written first and unconditionally, recording the
+    declared ceiling and the consumer but no vault content — the ordering
+    discipline :mod:`creek_mcp.read_gate` sets out.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+        privacy_tier_ceiling: The caller's declared ceiling. Threaded into
+            every gated section of the report; see the module docstring for
+            what each ceiling excludes.
+        consumer: Identifier recorded in the MCP audit log.
+
+    Returns:
+        ``status`` / ``tool`` / ``tier_ceiling`` / ``report_path`` / ``content``,
+        where ``content`` is the stamped artifact exactly as written.
     """
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
@@ -49,7 +100,8 @@ def state_render_tool(
         tier_ceiling=privacy_tier_ceiling,
         consumer=consumer,
     )
-    written = StateReportGenerator(vault_path=vault_path).write()
+    override = to_privacy_override(privacy_tier_ceiling)
+    written = StateReportGenerator(vault_path=vault_path, override=override).write()
     return {
         "status": "ok",
         "tool": TOOL_NAME,

--- a/creek-tools/creek_mcp/tools/state_read.py
+++ b/creek-tools/creek_mcp/tools/state_read.py
@@ -4,6 +4,45 @@ This is the FEAT-010 cheap path: no re-render, no walking the vault,
 just hand back the most recent audit-report bytes. ``creek.state.render``
 in :mod:`creek_mcp.tools.state` regenerates the report; ``read`` exists
 so CrawDad's Discord turn-around stays fast.
+
+**Posture: GATED, and it REFUSES rather than excludes (#969).** The asymmetry
+with ``creek.state.render`` is deliberate. Render names no target and is a
+corpus walk, so it filters its inputs; read addresses **one atomic cached
+artifact**, and there is nothing to partially admit — you cannot exclude half a
+rendered markdown document without re-rendering it, and re-rendering is what
+``render`` is. This is the same rule #1068 applied to ``compile`` and
+``reflect`` (whose targets are caller-*named*), read one level up: read's
+target is caller-*addressed* and singular, which is the property that matters.
+
+The comparison is against the artifact's own ``privacy_tier`` stamp —
+the highest tier the render admitted — and never against the
+``tier_ceiling`` the render ran under. Comparing the latter would refuse a
+broad render over a narrow corpus for no reason: an ``all``-ceiling report
+over an all-``open`` vault contains nothing above ``open``.
+
+**A pre-#969 ``latest.md`` is unstamped, and therefore refused below
+``ceiling=intimate``.** That is accurate rather than merely cautious: every
+report written before this change was rendered completely unfiltered, i.e. at
+the equivalent of ``--include-tier all``, so ``INTIMATE`` states a fact about
+those bytes. Recovery is one command and loses nothing — ``creek.state.render``
+re-renders and re-stamps at the caller's ceiling, or ``creek state
+--include-tier open`` does the same from the CLI — and ``ceiling=all`` admits
+every stamp, including the unstamped one, so no report is ever permanently
+unreachable. Note the cache-thrash consequence recorded on ``render``:
+``latest.md`` is a single slot, so re-rendering narrower replaces the broader
+report for every other caller too.
+
+The refusal is the canonical four-key payload carrying
+:data:`~creek_mcp.read_gate.GENERIC_ABOVE_CEILING_REASON`, and it is
+byte-identical for an above-ceiling stamp and for an unstamped legacy report.
+One reason for both causes is the point: a distinguishable "this predates the
+stamp" reason would itself be an oracle for whether the vault holds
+above-ceiling content.
+
+A **missing** report stays ``status="empty"`` rather than refused. There is no
+content for a ceiling to be above, and answering ``refused`` there would be a
+vault-emptiness oracle in the other direction — as well as making a first run
+of CrawDad or ``/creek`` look like a permissions failure.
 """
 
 from __future__ import annotations
@@ -11,7 +50,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from creek.generate.state_tiers import stamped_content_tier
 from creek_mcp.audit import MCPAuditLog
+from creek_mcp.read_gate import refuse_above_ceiling
 from creek_mcp.tier_ceiling import TierCeiling
 
 _STATE_LATEST_RELPATH = Path("00-Creek-Meta/State/latest.md")
@@ -24,18 +65,30 @@ def state_read_tool(
     privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
     consumer: str = "unknown",
 ) -> dict[str, Any]:
-    """Return the latest audit-report bytes plus tool metadata.
+    """Return the latest audit-report bytes, refusing above the ceiling.
 
-    Returns ``00-Creek-Meta/State/latest.md`` verbatim at *any* ceiling:
-    the ceiling is audited and echoed here, never consulted (#969). The
-    artifact records no ceiling of its own, so it may have been rendered
-    by a caller at ``ceiling=all`` (or by the CLI with
-    ``--include-tier all``) and then be read back at ``open`` — a
-    cross-ceiling cache, not a body-level filter. What the audit report
-    does still bound is scope, not tier: it aggregates
-    eddy/thread/synchronicity *titles* and counts, never fragment
-    bodies. A missing report yields a structured "no report yet" status
-    rather than a crash so a fresh vault stays usable.
+    The ordering is the one :mod:`creek_mcp.read_gate` sets out, and each step
+    is load-bearing:
+
+    1. audit-log the attempt first and unconditionally, recording the declared
+       ceiling and consumer but never the outcome, so the trail cannot answer
+       "did consumer X read an above-ceiling report?" in either direction;
+    2. resolve the target and answer *not found* before anything else touches
+       it;
+    3. read the artifact's own tier stamp and run the ceiling gate;
+    4. only then hand back content.
+
+    Args:
+        vault_path: Root of the Obsidian vault.
+        privacy_tier_ceiling: The caller's declared ceiling, compared against
+            the artifact's stamped ``privacy_tier``.
+        consumer: Identifier recorded in the MCP audit log.
+
+    Returns:
+        ``status="ok"`` with the artifact's bytes when the stamp is within the
+        ceiling; ``status="empty"`` when no report has been rendered yet; and
+        otherwise the canonical four-key refusal, which carries no ``content``
+        key at all and never names the stamped tier.
     """
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
@@ -52,10 +105,20 @@ def state_read_tool(
             "report_path": str(_STATE_LATEST_RELPATH),
             "content": "",
         }
+    content = report_path.read_text(encoding="utf-8")
+    stamped = stamped_content_tier(content)
+    if (
+        refusal := refuse_above_ceiling(
+            tool=TOOL_NAME,
+            content_tier=stamped,
+            ceiling=privacy_tier_ceiling,
+        )
+    ) is not None:
+        return refusal
     return {
         "status": "ok",
         "tool": TOOL_NAME,
         "tier_ceiling": privacy_tier_ceiling.value,
         "report_path": str(_STATE_LATEST_RELPATH),
-        "content": report_path.read_text(encoding="utf-8"),
+        "content": content,
     }

--- a/creek-tools/docs/generation.md
+++ b/creek-tools/docs/generation.md
@@ -43,7 +43,10 @@ The `synchronicity`, `paradox`, `compost`, `unnamed`, and `tags` report types co
 
 ```bash
 creek state --vault ~/Obsidian/Creek-Vault
+creek state --vault ~/Obsidian/Creek-Vault --include-tier open
 ```
+
+`--include-tier` runs the same way round as it does on `creek report` (#968): **omitting it leaves the render unfiltered** — the CLI operator is the vault owner — and supplying it *narrows* what the artefact may contain. Only an explicitly supplied flag is recorded in `00-Creek-Meta/audit/privacy.jsonl`; a bare `creek state` writes no privacy-override entry, because `override_elevates` answers `True` for `all` and auditing the resolved ceiling would log the one case where the operator asked for nothing.
 
 The report is organised in eleven sections, in this order (FEAT-006 + FEAT-007 + FEAT-008):
 
@@ -61,7 +64,59 @@ The report is organised in eleven sections, in this order (FEAT-006 + FEAT-007 +
 
 Empty sections render an explicit `_No surfacing this week._` placeholder rather than disappearing — operators can tell at a glance whether a section had nothing to surface or whether the generator skipped it. Re-running in the same ISO week overwrites the existing file (idempotent).
 
-`latest.md` is created as a symlink where the filesystem supports it (POSIX hosts) and falls back to a copy on Windows or networked filesystems that reject `symlink(2)`. The report header renders the vault's leaf directory name only — never the absolute path — so committing or sharing the artefact does not leak an operator's home directory.
+`latest.md` is created as a symlink where the filesystem supports it (POSIX hosts) and falls back to a copy on Windows or networked filesystems that reject `symlink(2)`. No path anywhere in the artefact is absolute — the header renders the vault's leaf directory name only, section 9's drift rows are rendered vault-relative, and section 11's appended lint report is too — so committing or sharing the artefact does not leak an operator's home directory. Sections 9 and 11 are the reason that sentence used to be false, and both trace to the same scanner: `BrokenLinkScanner` and `OrphanScanner` return `str(path)`, which is absolute on a normal call. Section 9 rendered those paths verbatim, and `creek lint`'s `broken-links` check did too — which matters because section 11 appends the lint report *verbatim*, at `intimate` and above, and that includes a bare `creek state` (default ceiling `all`). Either route put an aged, unlinked `intimate` fragment's slugified title into the artefact inside a `/Users/...` path. Both are now rendered `relative_to(vault_path)`, as every other lint check already was.
+
+### What each section does at a tier ceiling (#969)
+
+Every section except **Pre-LLM yield** narrows with the ceiling, and the artefact then records the highest tier it actually admitted (see below). Read this table before choosing a ceiling — several of these exclusions are surprising the first time:
+
+| # | Section | Behaviour below the ceiling |
+|---|---------|-----------------------------|
+| 1 | Wavelength snapshot | Surveys the admitted corpus only. `Fragments observed:` is a per-tier count, and a count discloses the existence of what the rest of the report omitted. |
+| 2 | Vault summary | Same: counts and the frequency histogram are over admitted fragments, and the eddy/thread counts count *admitted* eddies and threads, so §2 cannot contradict §5/§6. |
+| 3 | Pre-LLM yield | **Ungated, deliberately.** The last line of `run-summary.jsonl` describes one pipeline *run* — a run id, a timestamp and four integers — and names no fragment, so there is nothing in it to filter by. |
+| 4 | Liminal Watch | A note is admitted only if its *raw* front matter is within the ceiling. `10-Liminal/Paradoxes/` notes are `type: paradox` and have no `privacy_tier` field in their model at all, so **they fail closed to `intimate` and disappear below `--include-tier intimate`**. Any hand-written note missing the key behaves the same way. |
+| 5 | Active eddies | `Eddy` carries no `privacy_tier`, so its tier is *derived*: the maximum over the tiers of every fragment whose `eddies` wikilinks name it. An eddy with one `open` and one `intimate` member is `intimate`. **An eddy no fragment names has no tier evidence at all and is admitted only at `intimate` or broader** — including the "no fragments loaded, fall back to the stored `fragment_count`" path. |
+| 6 | Active threads | The same rule over `threads` wikilinks. |
+| 7 | Surprising connections | A row survives only when *both* endpoint ids resolve to admitted fragments. |
+| 8 | Hyperedges | A praxis is admitted only when **every** id in its `derived_from` resolves to an admitted fragment; an empty `derived_from` names no evidence and is excluded. The spanned eddy set is then **intersected with the admitted eddies of §5** — being named by an admitted fragment is not enough, since an `open` fragment's front matter can name an eddy that derived `intimate` from a sibling member. The intersection runs before the "spans 2+ eddies" cut, so an excluded eddy can neither render in `spans:` nor pad the count that decides whether the row appears at all. |
+| 9 | Drift warnings | Broken-link sources and orphan paths are kept only when they are admitted fragment files. A broken link's *target* has no note to tier, but the target string is text authored inside the source fragment, so it carries the source's tier — which is gated. Every rendered row is attributable to an admitted fragment. |
+| 10 | Suggested questions | **The whole section is dropped below `--include-tier personal`**: the shared tier filter *summarises* a personal fragment as `[Personal-tier summary: <title>]` rather than dropping it, so at an `open` ceiling a personal title could otherwise ride out inside a prompt. At `personal` and above the miner runs under the ceiling *and* is handed a corpus this generator has already narrowed — the mining loaders gate `01-Fragments` and `10-Liminal` but take no override at all for `02-Threads` / `03-Eddies`, so a thread whose every member is above the ceiling would otherwise title a prompt. Threads and eddies are replaced with §5/§6's admitted lists; fragments are intersected by id, because the miner reads the tier off the *model* (missing key → `unclassified`) where §5's cutoff reads the raw front matter (missing key → `intimate`). |
+| 11 | Lint summary | Rendered **only at `--include-tier intimate` or broader**. It is a verbatim copy of a `00-Creek-Meta/Processing-Log/lint-*.md` artefact that embeds titles and tag names, and `creek lint`'s tag survey deliberately runs at `all` so it cannot report "no orphan tags" about a vault that has them. There is no row-level tier to filter on, so the section is admitted whole or not at all. |
+
+### The artefact stamps its own tier
+
+`write()` prefixes the report with three scalar front-matter keys:
+
+```yaml
+---
+type: state-report
+privacy_tier: <highest tier the render actually admitted>
+tier_ceiling: <the --include-tier the render ran under>
+---
+```
+
+`privacy_tier` is what `creek.state.read` compares an MCP caller's ceiling against — not `tier_ceiling`, which is recorded for the audit trail only. Comparing the render ceiling would refuse a broad render over a narrow corpus for no reason: a report produced at `--include-tier all` over a vault holding nothing above `open` contains nothing above `open` and stays readable at `open`.
+
+A report that admitted nothing stamps `open`, not `intimate`. The empty case here means "the document contains no tiered content", which is knowledge; failing closed would make a freshly-`creek init`-ed vault's first report unreadable at every ceiling below `intimate`.
+
+"Highest tier the render actually admitted" is the maximum over one entry per admitted fragment, eddy, thread, praxis and Liminal-Watch note, plus two contributions that are only knowable once the sections have rendered: the `10-Liminal` notes §10 mined from subfolders the Liminal Watch does not walk (`Compost`, chiefly), and an escalation to `intimate` whenever §11 rendered a lint report. **Every section that can emit content has to be accounted for in exactly one of those three places.** A section that emits a title without contributing a tier makes the stamp under-report, and `creek.state.read` then serves the document below the tier it actually carries — the read gate fails open. That was the shape of both bugs the #969 review found: §8 rendered an eddy that was not in §5's admitted list, and §10 titled a prompt with a thread that was not in §6's.
+
+Three scalars is a constraint, not a coincidence: CrawDad keeps a report's `raw_markdown` *including* front matter and feeds it into prompts, and its bullet regex is `^\s*-\s+`, so a block-style YAML list in the stamp would be misread as a report bullet.
+
+### Upgrading a `latest.md` written before the stamp
+
+A pre-#969 `latest.md` carries no stamp, and an unreadable or absent `privacy_tier` fails closed to `intimate`. That is *accurate* rather than merely cautious: every such report was rendered completely unfiltered, i.e. at the equivalent of `--include-tier all`.
+
+The consequence is that the next `creek.state.read` at the MCP default `ceiling=open` (CrawDad, `/creek`, `/creek phase`, `/creek wavelength`) answers `status: "refused"`. Recovery is one command and loses nothing:
+
+```bash
+creek state --vault ~/Obsidian/Creek-Vault --include-tier open
+```
+
+or an MCP `creek.state.render`, which re-renders and re-stamps at the caller's ceiling. The ISO-week archive files are untouched, and `ceiling=all` admits every stamp — including the unstamped legacy one — so no report is ever permanently unreachable.
+
+**`latest.md` is a single slot shared across ceilings**, kept single deliberately: per-ceiling filenames would multiply artefacts in the operator's vault and break `latest.md` as the documented session-start context. So an `open` render replaces a richer `all` render's report for *everybody*, including subsequent CLI reads. A caller that wants the broader report re-renders at the broader ceiling. Note that the MCP `creek.state.render` default ceiling is `open`, so a bare MCP render narrows `latest.md` for the whole vault.
 
 ### Size budget (FEAT-007)
 

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -90,7 +90,7 @@ consequence to know is a **posture split on the same file**: an `Unnamed` note
 with no `privacy_tier` key needs `ceiling=intimate` to appear in the Liminal
 Watch (read fail-closed off raw frontmatter) but only `ceiling=personal` for its
 id to reach a prompt (read through the validated model's `unclassified`
-default). Tracked as a follow-up.
+default). Tracked as #1079.
 
 `read` compares the artefact's stamped `privacy_tier` — the highest tier the
 render admitted — never the `tier_ceiling` the render ran under. Comparing the

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -36,11 +36,96 @@ cross-repo contract is
 
 | Tool                  | Purpose                                                    |
 |-----------------------|------------------------------------------------------------|
-| `creek.state.read`    | Return the latest `00-Creek-Meta/State/latest.md` content. |
-| `creek.state.render`  | Re-render the audit report (expensive).                    |
+| `creek.state.read`    | Return the latest `00-Creek-Meta/State/latest.md` content, **refusing** when the artefact's own `privacy_tier` stamp exceeds `ceiling` (#969). |
+| `creek.state.render`  | Re-render the audit report (expensive), **excluding** above-ceiling content section by section and stamping what it admitted (#969). |
 | `creek.lint`          | Run the unified hygiene lint pass (FEAT-008).              |
 | `creek.mine`          | Surface essay seeds from the compiled vault layer.         |
 | `creek.draft`         | Draft an essay from a mined idea (requires an LLM).        |
+
+#### The two `creek.state.*` tools gate in different shapes (#969)
+
+`render` **excludes**; `read` **refuses**. The asymmetry is deliberate and is
+the same rule `compile` and `reflect` follow, read one level up. `render` names
+no target — it is a corpus walk like `report` / `wheel` / `mine` — so refusing
+it would make the audit report unreachable, which is #968's explicit anti-goal.
+`read` addresses one atomic cached artefact, and there is nothing to partially
+admit: you cannot exclude half a rendered markdown document without
+re-rendering it, and re-rendering is what `render` is.
+
+`render`'s gap was **write-side**, which is why it survived earlier
+response-level sweeps: its envelope happens to echo `content`, but the durable
+evidence is the bytes under `00-Creek-Meta/State`, and three leaks were
+reproduced there — an `intimate` fragment's slugified title inside an
+**absolute** orphan path, a `10-Liminal/Unnamed` note's file stem, and an eddy
+title derived from an above-ceiling member fragment.
+
+What `render` excludes at each ceiling is tabulated in
+[`generation.md`](generation.md#what-each-section-does-at-a-tier-ceiling-969).
+The four exclusions worth knowing before you call it:
+
+* `10-Liminal/Paradoxes` notes are `type: paradox` and carry no `privacy_tier`
+  field at all, so they fail closed and vanish from the Liminal Watch below
+  `ceiling=intimate`. Any note missing the key behaves the same way.
+* The **lint summary** is a verbatim copy of a Processing-Log artefact and is
+  untierable row by row, so it is rendered only at `ceiling=intimate` or
+  broader. This closes the caveat `creek_mcp/read_gate.py` recorded under
+  `creek.lint` — `creek state` is the surface that serves that artefact back.
+* **Suggested questions** are dropped entirely below `ceiling=personal`,
+  because the shared tier filter *summarises* a personal fragment as
+  `[Personal-tier summary: <title>]` rather than dropping it, so a personal
+  title could otherwise ride out inside a mined prompt.
+* An **eddy or thread no fragment names** has no tier evidence and is admitted
+  only at `ceiling=intimate` or broader.
+
+One axis is **accounted for on the stamp rather than narrowed**, and it is worth
+knowing which. The mining corpus behind the suggested questions walks all of
+`10-Liminal` except `Synchronicities` — including `Compost`, which the Liminal
+Watch never reads — so `render` has no admitted list to narrow it against.
+Those notes' tiers are folded into the artefact's stamp instead, which means an
+untiered one pushes the stamp to `unclassified` (ranked with `personal`, #961)
+and the report is refused at `ceiling=open` — the one ceiling at which the
+section does not render anyway. Nothing identifying escapes regardless: the only
+liminal field a prompt renders is the fragment's opaque generated id. The
+consequence to know is a **posture split on the same file**: an `Unnamed` note
+with no `privacy_tier` key needs `ceiling=intimate` to appear in the Liminal
+Watch (read fail-closed off raw frontmatter) but only `ceiling=personal` for its
+id to reach a prompt (read through the validated model's `unclassified`
+default). Tracked as a follow-up.
+
+`read` compares the artefact's stamped `privacy_tier` — the highest tier the
+render admitted — never the `tier_ceiling` the render ran under. Comparing the
+latter would refuse an `all`-ceiling render over an all-`open` vault for no
+reason. The refusal is the canonical four-key payload with
+`GENERIC_ABOVE_CEILING_REASON`: no `content` key at all, and no echo of the
+stamped tier. A **missing** report stays `status: "empty"` rather than refused
+— there is no content for a ceiling to be above, and refusing there would be a
+vault-emptiness oracle in the other direction, as well as making a first run of
+CrawDad or `/creek` look like a permissions failure.
+
+#### Upgrading a `latest.md` written before #969
+
+A pre-#969 `latest.md` carries no stamp, and an absent or unreadable
+`privacy_tier` fails closed to `intimate`. That is accurate rather than
+cautious: every such report was rendered completely unfiltered, i.e. at the
+equivalent of `--include-tier all`. So the next `creek.state.read` at the
+default `ceiling=open` — CrawDad, `/creek`, `/creek phase`, `/creek wavelength`
+— returns `status: "refused"` with the generic reason, which is byte-identical
+to an above-ceiling refusal. That identity is the point: a distinguishable
+"this report predates the stamp" reason would itself be an oracle for whether
+the vault holds above-ceiling content.
+
+Recovery is one command and loses nothing: call `creek.state.render` (which
+re-renders and re-stamps at the caller's ceiling), or run `creek state
+--include-tier open` from the CLI. The ISO-week archive files are untouched,
+and `ceiling=all` admits every stamp — including the unstamped legacy one — so
+no report is ever permanently unreachable.
+
+**Cache thrash, stated on the tin.** `latest.md` is a single slot shared across
+ceilings, kept single deliberately: per-ceiling filenames would multiply
+artefacts in the operator's vault and break `latest.md` as the documented
+session-start context. `creek.state.render`'s default ceiling is `open`, so a
+**bare MCP render narrows `latest.md` for everyone**, including subsequent CLI
+reads. A caller that wants the richer report re-renders at the broader ceiling.
 
 ### Author tools (FEAT-041)
 
@@ -144,6 +229,13 @@ in mind when reading that fix — `report_tool` returns only `report_paths`,
 so its response envelope was clean at `ceiling=open` for the whole life of
 the bug and no response-level test could have caught it. The evidence was
 always the bytes of the artifact the call wrote.
+
+`creek.state.render` was the fourth, and it is the same shape (#969) — its
+envelope *does* echo `content` today, but that is a response shape rather than
+a guarantee, so the evidence for it is likewise the bytes under
+`00-Creek-Meta/State`. `creek.state.read` is the counterpart on the read side
+and the **first production adopter** of `read_gate.refuse_above_ceiling`; both
+are documented above under "Read tools".
 
 One read-side leak was found, and it is worth stating how: the sweep
 first concluded there were none, having probed the tools that walk the

--- a/creek-tools/tests/test_mcp_read_gate.py
+++ b/creek-tools/tests/test_mcp_read_gate.py
@@ -101,6 +101,8 @@ from creek_mcp.tools.compile import _ABOVE_CEILING_REASON, compile_tool
 from creek_mcp.tools.mine import mine_tool
 from creek_mcp.tools.reflect import reflect_tool
 from creek_mcp.tools.report import report_tool
+from creek_mcp.tools.state import state_render_tool
+from creek_mcp.tools.state_read import state_read_tool
 from creek_mcp.tools.wheel import wheel_tool
 
 if TYPE_CHECKING:
@@ -143,11 +145,24 @@ _PINNED_GATE_ROWS = [
     # check — which is exactly what the failure message on
     # ``test_pinned_gaps_keep_their_posture_and_issue`` asks for.
     ("creek.report", "creek_mcp.tools.report", "to_privacy_override"),
+    # #969 closed both state gaps, and they close in *different shapes* —
+    # which is why they are two rows rather than one. ``creek.state.render``
+    # names no target: it is a corpus walk like report/wheel/mine, so it
+    # EXCLUDES, converting the ceiling with ``to_privacy_override`` and
+    # threading it into StateReportGenerator's per-section gates. Refusing it
+    # would make the report unreachable, which is #968's explicit anti-goal.
+    # ``creek.state.read`` addresses one atomic cached artifact, so there is
+    # nothing to partially admit — you cannot exclude half a rendered markdown
+    # document without re-rendering it, and re-rendering is what ``render`` is
+    # — so it REFUSES on the artifact's own ``privacy_tier`` stamp via
+    # ``refuse_above_ceiling``. Same reasoning #1068 applied to compile and
+    # reflect, read one level up: read's target is not caller-*named* but it is
+    # caller-*addressed* and singular, which is the property that matters.
+    ("creek.state.read", "creek_mcp.tools.state_read", "refuse_above_ceiling"),
+    ("creek.state.render", "creek_mcp.tools.state", "to_privacy_override"),
 ]
 
 _PINNED_GAPS = {
-    "creek.state.read": 969,
-    "creek.state.render": 969,
     "creek.skills.refresh": 971,
     # Recorded as CALLER_NAMED_PATHS until the #932 Gate-2.5 review. The name
     # was accurate — the caller does name the path — but the confinement is to
@@ -546,10 +561,15 @@ def test_pinned_gate_claims_are_not_downgraded(
 def test_pinned_gaps_keep_their_posture_and_issue(tool: str, issue: int) -> None:
     """The known-ungated tools stay labelled as gaps against their own issues.
 
-    These four read vault content without honouring the caller's ceiling. The
+    These read vault content without honouring the caller's ceiling. The
     posture is the honest record of that, and the issue number is the promise
     that someone is on the hook for it. Relabelling either one — without the
     code changing — converts a tracked gap into an invisible one.
+
+    The table shrinks as gaps close: #968 took ``creek.report`` out of it and
+    #969 took the two ``creek.state.*`` entries, each *re-pointed* at the gate
+    that closed it in :data:`_PINNED_GATE_ROWS` rather than merely deleted, so
+    the claim stays checkable by layers (c) and (e) instead of disappearing.
     """
     entry = TOOL_POSTURES[tool]
     assert entry.posture is ReadPosture.UNGATED_KNOWN_GAP, (
@@ -1375,12 +1395,109 @@ def _probe_report(vault: Path) -> dict[str, Any]:
     )
 
 
+def _seed_state_carriers(vault: Path) -> None:
+    """Give the two ``creek.state.*`` probes a canary the state report can render.
+
+    ``canary_vault`` puts each sentinel in a fragment's ``title``, body and
+    ``tags``, which covers an index-shaped, a body-shaped and a tag-garden-shaped
+    response. The state report renders **none** of those three: it aggregates
+    counts, eddy/thread titles, synchronicity ids, orphan *paths* and liminal
+    file *stems*. A state probe run against the bare fixture would therefore
+    produce a canary-free report whether or not any ceiling was enforced —
+    vacuous in exactly the way ``_probe_state_read``'s docstring warns about,
+    and the reason this helper exists rather than the probe simply calling the
+    tool.
+
+    So the probe adds a carrier the report does render: a ``10-Liminal/Unnamed``
+    note whose file stem *is* the sentinel, one per tier. The ``open`` one is
+    the positive control — the render probe's own test asserts it is present in
+    the same bytes, so a gate broken in the drop-everything direction cannot
+    pass by writing an empty report.
+
+    ``00-Creek-Meta`` is created for the same reason ``_probe_report`` creates
+    it: ``canary_vault`` is a bare fragment vault and the MCP audit log writes
+    there.
+
+    Args:
+        vault: The seeded canary vault, mutated in place.
+    """
+    (vault / "00-Creek-Meta").mkdir(parents=True, exist_ok=True)
+    unnamed = vault / "10-Liminal" / "Unnamed"
+    unnamed.mkdir(parents=True, exist_ok=True)
+    for canary, tier in (
+        (_RUNTIME_OPEN_CANARY, "open"),
+        (_RUNTIME_INTIMATE_CANARY, "intimate"),
+    ):
+        stem = f"unnamed-{canary}"
+        metadata: dict[str, Any] = {
+            "type": "fragment",
+            "id": stem,
+            "title": stem,
+            "created": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+            "ingested": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+            "source": {"platform": "journal", "author": "self"},
+            "frequency": {"primary": "unclassified", "secondary": []},
+            "privacy_tier": tier,
+        }
+        (unnamed / f"{stem}.md").write_text(
+            frontmatter.dumps(frontmatter.Post(content="unnamed body", **metadata)),
+            encoding="utf-8",
+        )
+
+
+def _probe_state_render(vault: Path) -> dict[str, Any]:
+    """Call ``creek.state.render`` at the open ceiling over the canary vault.
+
+    Args:
+        vault: The seeded canary vault.
+
+    Returns:
+        The tool's response envelope.
+    """
+    _seed_state_carriers(vault)
+    return state_render_tool(
+        vault_path=vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+
+def _probe_state_read(vault: Path) -> dict[str, Any]:
+    """Render at ``ceiling=all`` first, *then* read at the open ceiling.
+
+    The render is not setup convenience — it is what makes this probe mean
+    anything. ``canary_vault`` holds no ``00-Creek-Meta/State/latest.md``, so a
+    bare ``state_read_tool`` call would return ``status="empty"`` with an empty
+    ``content``, and the shared canary assertion would pass on a vault where
+    there was never anything to leak. Rendering at ``ceiling=all`` first puts
+    the intimate canary genuinely into the artifact the read then addresses, so
+    a missing gate produces a real leak rather than a vacuous pass.
+
+    :func:`_seed_state_carriers` is the other half of that: without it the
+    ``ceiling=all`` render would itself be canary-free, because the state
+    report renders none of the three places ``canary_vault`` hides a sentinel.
+
+    Args:
+        vault: The seeded canary vault.
+
+    Returns:
+        The tool's response envelope.
+    """
+    _seed_state_carriers(vault)
+    state_render_tool(vault_path=vault, privacy_tier_ceiling=TierCeiling.ALL)
+    return state_read_tool(
+        vault_path=vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+
 _RUNTIME_PROBES: dict[str, Callable[[Path], dict[str, Any]]] = {
     "creek.wheel": _probe_wheel,
     "creek.mine": _probe_mine,
     "creek.reflect": _probe_reflect,
     "creek.compile": _probe_compile,
     "creek.report": _probe_report,
+    "creek.state.render": _probe_state_render,
+    "creek.state.read": _probe_state_read,
 }
 """``GATED`` tool → a callable that invokes it at ``ceiling=open``.
 
@@ -1667,3 +1784,92 @@ def test_compile_probe_refuses_rather_than_merely_staying_quiet(
     assert response["status"] == "refused"
     assert response["reason"] == _ABOVE_CEILING_REASON
     assert response["tier_ceiling"] == TierCeiling.OPEN.value
+
+
+def test_state_render_probe_leaves_no_canary_in_the_artifact_it_writes(
+    canary_vault: Path,
+) -> None:
+    """``creek.state.render``'s leak is the files it writes, not the dict it returns.
+
+    The shared assertion in
+    ``test_gated_tools_leak_no_above_ceiling_content_at_the_open_ceiling`` is
+    **not the evidence for this tool**. ``state_render_tool``'s envelope
+    happens to echo ``content`` today, so that assertion is not vacuous the way
+    ``creek.report``'s was — but it is contingent on a response shape, and a
+    change that dropped ``content`` (to keep the envelope small, say) would
+    silently turn it vacuous while the artifact on disk kept leaking. For a
+    write-side surface the durable evidence is the bytes on disk, and #969
+    reproduced three separate leaks in exactly those bytes.
+
+    Both artifacts are asserted, because they are two independent write paths:
+    the ISO-week file that ``write()`` renders, and ``latest.md`` — a symlink
+    where the filesystem allows one and an independent byte copy where it does
+    not, which is the file ``creek.state.read``, ``creek state-budget`` and
+    every documented session-start flow actually open.
+
+    The ``open`` canary is asserted *present* in the same bytes as the positive
+    control, so the tool cannot pass by writing an empty report — which a gate
+    broken in the drop-everything direction would do: leak-free, and useless.
+    """
+    response = _probe_state_render(canary_vault)
+    assert response["status"] == "ok"
+
+    state_dir = canary_vault / "00-Creek-Meta" / "State"
+    week_files = [p for p in sorted(state_dir.glob("*.md")) if p.name != "latest.md"]
+    assert len(week_files) == 1, (
+        f"expected exactly one ISO-week report under {state_dir}, found "
+        f"{[p.name for p in week_files]}"
+    )
+    week = week_files[0].read_text(encoding="utf-8")
+    latest = (state_dir / "latest.md").read_text(encoding="utf-8")
+
+    assert _RUNTIME_INTIMATE_CANARY not in week, (
+        "creek.state.render wrote an intimate fragment's canary into "
+        f"{week_files[0].name} at privacy_tier_ceiling=open. This is the "
+        "artifact every later reader of the vault serves, and the response "
+        f"envelope is not evidence for a write-side surface.\n\n{week}"
+    )
+    assert _RUNTIME_INTIMATE_CANARY not in latest, (
+        "creek.state.render wrote an intimate fragment's canary into "
+        "00-Creek-Meta/State/latest.md at privacy_tier_ceiling=open. This is "
+        "the documented session-start context: CrawDad, /creek and "
+        f"creek.state.read all read this file.\n\n{latest}"
+    )
+    assert _RUNTIME_OPEN_CANARY in week, (
+        "creek.state.render wrote a report with no admitted content in it, so "
+        f"the exclusion assertions above are vacuous.\n\n{week}"
+    )
+
+
+def test_state_read_probe_refuses_rather_than_merely_staying_quiet(
+    canary_vault: Path,
+) -> None:
+    """``creek.state.read`` *refuses* an above-ceiling artifact (#969).
+
+    Absence of the canary is necessary but not sufficient, the same argument
+    reflect's and compile's probes make. ``state_read_tool`` has a second
+    quiet answer — ``status="empty"`` for a vault with no rendered report — and
+    a change that stopped resolving ``latest.md`` at all would satisfy a bare
+    canary sweep while proving nothing about the ceiling. So the refusal is
+    what is asserted, and the reason is pinned to
+    :data:`~creek_mcp.read_gate.GENERIC_ABOVE_CEILING_REASON` rather than to
+    ``status`` alone.
+
+    The reason is deliberately the *generic* one, shared with every other
+    above-ceiling refusal on the surface, and it names no tier. A distinguishable
+    "this report predates the stamp" reason would itself be an oracle for
+    whether the vault holds above-ceiling content.
+    """
+    response = _probe_state_read(canary_vault)
+    assert response["status"] == "refused"
+    assert response["reason"] == GENERIC_ABOVE_CEILING_REASON
+    assert response["tier_ceiling"] == TierCeiling.OPEN.value
+    assert response == refusal_response(
+        tool="creek.state.read",
+        ceiling=TierCeiling.OPEN,
+        reason=GENERIC_ABOVE_CEILING_REASON,
+    ), (
+        "creek.state.read's refusal carries keys beyond the canonical four. "
+        "Every extra key on a refusal is derived from content the caller was "
+        f"not admitted to.\n\n{response}"
+    )

--- a/creek-tools/tests/test_mcp_server.py
+++ b/creek-tools/tests/test_mcp_server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -287,8 +288,19 @@ def test_purge_tools_require_auth_token_parameter(vault: Path) -> None:
 
 
 def test_call_tool_state_read_through_mcp(vault: Path) -> None:
-    """End-to-end: ``call_tool("creek.state.read")`` returns the report bytes."""
+    """End-to-end: ``call_tool("creek.state.read")`` returns the report bytes.
+
+    The fixture carries the ``privacy_tier: open`` stamp that
+    ``StateReportGenerator.write`` writes since #969. Only the *fixture*
+    changed: every assertion below is the one this test has always made. An
+    unstamped report now reads as ``intimate`` — ``raw_privacy_tier`` fails
+    closed on a missing key, which is an accurate statement about bytes that
+    were rendered with no ceiling at all — so leaving the fixture unstamped
+    would have quietly turned this end-to-end read-path test into a second copy
+    of the refusal test below.
+    """
     (vault / "00-Creek-Meta" / "State" / "latest.md").write_text(
+        "---\ntype: state-report\nprivacy_tier: open\ntier_ceiling: open\n---\n\n"
         "# Audit\n\nhello\n",
         encoding="utf-8",
     )
@@ -303,6 +315,32 @@ def test_call_tool_state_read_through_mcp(vault: Path) -> None:
     assert structured["status"] == "ok"
     assert structured["tool"] == "creek.state.read"
     assert "Audit" in structured["content"]  # type: ignore[operator]
+
+
+def test_call_tool_state_read_refuses_a_legacy_report_through_mcp(vault: Path) -> None:
+    """The #969 fail-closed path is reachable end to end, not just in-process.
+
+    Added alongside the test above rather than replacing its coverage: the
+    stamped-``open`` fixture there only means something if an *unstamped* report
+    is not also served. Pinning both halves on the real ``call_tool`` boundary
+    is what proves the refusal survives MCP's response serialisation — a
+    refusal that only exists inside ``state_read_tool`` would be no gate at all
+    if the transport layer re-shaped it.
+    """
+    (vault / "00-Creek-Meta" / "State" / "latest.md").write_text(
+        "# Audit\n\nhello\n",
+        encoding="utf-8",
+    )
+    server = build_server(
+        vault_path=vault,
+        draft_llm_factory=lambda tier: lambda prompt: "ignored",
+    )
+    result = asyncio.run(
+        server.call_tool("creek.state.read", {"privacy_tier_ceiling": "open"}),
+    )
+    structured = _structured(result)
+    assert structured["status"] == "refused"
+    assert "hello" not in json.dumps(structured, default=str)
 
 
 def test_call_tool_state_render_through_mcp(vault: Path) -> None:

--- a/creek-tools/tests/test_mcp_tools.py
+++ b/creek-tools/tests/test_mcp_tools.py
@@ -81,8 +81,19 @@ def vault(tmp_path: Path) -> Iterator[Path]:
 
 
 def test_state_read_returns_latest_md_content(vault: Path) -> None:
-    """``state.read`` reads ``00-Creek-Meta/State/latest.md`` verbatim."""
+    """``state.read`` reads ``00-Creek-Meta/State/latest.md`` verbatim.
+
+    The fixture carries the #969 ``privacy_tier: open`` stamp that
+    ``StateReportGenerator.write`` now writes. Before #969 an unstamped file
+    was served at every ceiling; now an *unstamped* report reads as
+    ``intimate`` (``raw_privacy_tier`` fails closed on a missing key), which is
+    an accurate statement about bytes rendered completely unfiltered. Stamping
+    the fixture keeps this test pinning what it always pinned — that admitted
+    content comes back verbatim — rather than accidentally becoming a second,
+    weaker copy of the refusal test below.
+    """
     (vault / "00-Creek-Meta" / "State" / "latest.md").write_text(
+        "---\ntype: state-report\nprivacy_tier: open\ntier_ceiling: open\n---\n\n"
         "# Audit report\n\nVault summary lives here.\n",
         encoding="utf-8",
     )
@@ -91,6 +102,28 @@ def test_state_read_returns_latest_md_content(vault: Path) -> None:
     assert result["tool"] == "creek.state.read"
     assert result["tier_ceiling"] == "open"
     assert "Audit report" in result["content"]
+
+
+def test_state_read_refuses_a_legacy_unstamped_report(vault: Path) -> None:
+    """An unstamped ``latest.md`` fails closed at the default ceiling (#969).
+
+    Added alongside — not instead of — the verbatim-read test above, because
+    the two halves have to be pinned together: "stamped ``open`` is served"
+    means nothing if "unstamped is also served".
+
+    Every ``latest.md`` written before #969 was rendered with no ceiling at
+    all, i.e. the equivalent of ``--include-tier all``. Refusing it states a
+    fact about those bytes rather than a precaution about them, and recovery is
+    one command: ``creek.state.render`` (or ``creek state --include-tier
+    open``) re-renders and re-stamps at the caller's ceiling.
+    """
+    (vault / "00-Creek-Meta" / "State" / "latest.md").write_text(
+        "# Audit report\n\nVault summary lives here.\n",
+        encoding="utf-8",
+    )
+    result = state_read_tool(vault_path=vault)
+    assert result["status"] == "refused"
+    assert "Vault summary lives here." not in json.dumps(result, default=str)
 
 
 def test_state_read_returns_empty_on_missing_report(vault: Path) -> None:
@@ -114,13 +147,64 @@ def test_state_read_writes_audit_entry(vault: Path) -> None:
     assert entry["tier_ceiling"] == "personal"
 
 
-def test_state_read_does_not_embed_fragment_bodies(vault: Path) -> None:
-    """Intimate fragment bodies must not appear in the audit report.
+def _write_liminal_unnamed(vault: Path, *, stem: str, privacy_tier: str) -> None:
+    """Write a ``10-Liminal/Unnamed`` note whose file *stem* is the sentinel.
 
-    The audit report aggregates titles + counts. A vault with an
-    ``intimate``-tier fragment must not see its body surface through
-    ``state.read`` even when the caller specifies ``ceiling=open``.
+    The Liminal Watch section renders ``path.stem`` and nothing else, so the
+    stem is the one place a sentinel can prove the rendered report reached
+    above-ceiling content. Used by the test below to get a canary into
+    ``latest.md`` through the production render path.
+
+    Args:
+        vault: Vault root.
+        stem: File stem, carrying the sentinel.
+        privacy_tier: The note's declared tier.
     """
+    target = vault / "10-Liminal" / "Unnamed" / f"{stem}.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    metadata = {
+        "type": "fragment",
+        "id": stem,
+        "title": stem,
+        "created": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "ingested": datetime(2026, 5, 1, tzinfo=UTC).isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "unclassified", "secondary": []},
+        "privacy_tier": privacy_tier,
+    }
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content="unnamed body", **metadata)),
+        encoding="utf-8",
+    )
+
+
+def test_state_read_does_not_serve_above_ceiling_content_from_latest_md(
+    vault: Path,
+) -> None:
+    """``state.read`` refuses a report whose stamp is above the caller's ceiling.
+
+    **What this replaced, and why the old test could not fail.** The previous
+    ``test_state_read_does_not_embed_fragment_bodies`` wrote an intimate
+    fragment, then **hand-wrote** ``latest.md`` as the fixed string
+    ``"# Audit report\\n\\n- Fragments: 1\\n"``, then asserted
+    ``"secret journal body" not in result["content"]``. That was true by
+    construction: nothing in ``state_read_tool`` ever read the fragment, so the
+    ``_write_fragment`` call was decorative and the assertion held whether or
+    not a gate existed. It passed for the entire life of the #969 gap.
+
+    **Why this one can fail.** The artifact is produced through the production
+    path — ``state_render_tool(..., ceiling=ALL)`` — so the canary genuinely
+    reaches ``latest.md``, which is asserted first so the setup cannot rot into
+    the same vacuity. Delete the read gate and this test fails, because the
+    canary comes back. Delete the render gate and its companion in
+    ``tests/test_state_tier_ceiling.py`` fails, because the ``open`` render
+    would carry it.
+
+    The refusal, not merely the canary's absence, is what is asserted: a change
+    that stopped resolving ``latest.md`` would return ``status="empty"`` with
+    no canary in it and prove nothing about the ceiling.
+    """
+    canary = "CANARY-STATE-READ-INTIMATE-4d16"
     _write_fragment(
         vault,
         frag_id="frag-intimate-1",
@@ -128,12 +212,24 @@ def test_state_read_does_not_embed_fragment_bodies(vault: Path) -> None:
         privacy_tier="intimate",
         body="this is a secret journal body",
     )
-    (vault / "00-Creek-Meta" / "State" / "latest.md").write_text(
-        "# Audit report\n\n- Fragments: 1\n",
+    _write_liminal_unnamed(vault, stem=f"unnamed-{canary}", privacy_tier="intimate")
+
+    state_render_tool(vault_path=vault, privacy_tier_ceiling=TierCeiling.ALL)
+    latest = (vault / "00-Creek-Meta" / "State" / "latest.md").read_text(
         encoding="utf-8",
     )
-    result = state_read_tool(vault_path=vault)
-    assert "secret journal body" not in result["content"]
+    assert canary in latest, (
+        "the ceiling=all render did not put the canary into latest.md, so the "
+        "refusal assertion below would pass on an artifact with nothing in it "
+        "to refuse — exactly the vacuity this test replaced"
+    )
+
+    result = state_read_tool(vault_path=vault, privacy_tier_ceiling=TierCeiling.OPEN)
+    assert result["status"] == "refused"
+    assert canary not in json.dumps(result, default=str), (
+        "creek.state.read served above-ceiling content from latest.md at "
+        f"privacy_tier_ceiling=open:\n\n{result}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/creek-tools/tests/test_state_tier_ceiling.py
+++ b/creek-tools/tests/test_state_tier_ceiling.py
@@ -1,0 +1,3240 @@
+"""``creek state`` must honour a tier ceiling in what it writes and serves (#969).
+
+Three leaks were reproduced at HEAD by running
+``StateReportGenerator(vault_path=v).render()`` over a temp vault with no
+ceiling anywhere:
+
+1. **Drift warnings** — an ``intimate`` fragment older than 90 days and
+   unlinked is reported by ``OrphanScanner`` as an *absolute* path whose
+   filename is the slugified title of that fragment.
+2. **Liminal Watch** — the *file stem* of a ``10-Liminal/Unnamed/`` note is
+   rendered unconditionally.
+3. **Active eddies** — an eddy whose only member fragment is above the ceiling
+   still renders its title, because ``Eddy``/``Thread`` carry no
+   ``privacy_tier`` of their own.
+
+That history shapes every assertion in this module, in the same way PR #1068
+shaped ``tests/test_mcp_report_tier_ceiling.py``:
+
+* **Nothing here treats a response envelope as evidence of exclusion.**
+  ``creek.state.render`` is a *write-side* surface. Its envelope happens to
+  echo the rendered content today, but a future shape change that dropped
+  ``content`` would silently turn every envelope assertion vacuous while the
+  artifact on disk kept leaking. Every exclusion assertion below therefore
+  reads ``<vault>/00-Creek-Meta/State/<iso-week>.md`` and ``latest.md`` back
+  off the filesystem.
+* **Every exclusion assertion is paired with a positive control.** A
+  generator that wrote an empty report would satisfy "the intimate canary is
+  absent" perfectly while being an outage rather than a gate, so an ``open``
+  canary is asserted *present* in the same bytes, and every section header in
+  :data:`~creek.generate.state.SECTION_ORDER` is asserted present too.
+* **Canaries are unmistakable sentinels**, restricted to ``[A-Za-z0-9-]`` so
+  they survive being slugified into a filename. A leak cannot then be excused
+  as "that phrase could have come from anywhere".
+
+The production surface these tests describe does not exist yet. Imports of
+symbols that #969 will add (``creek.generate.state_tiers``, the ``override``
+keyword on :class:`~creek.generate.state.StateReportGenerator`) are made
+*inside* the tests that need them rather than at module scope, so a missing
+module fails the specific tests that assert its contract instead of collapsing
+the whole file into one collection-time ``ImportError`` that hides the
+artifact-level failures — which are the interesting ones.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import frontmatter
+import pytest
+from typer.testing import CliRunner
+
+from creek.cli import app
+from creek.generate.state import (
+    EMPTY_PLACEHOLDER,
+    SECTION_ORDER,
+    StateReportGenerator,
+    _refresh_latest,
+)
+from creek.models import PrivacyTier
+from creek_mcp.read_gate import GENERIC_ABOVE_CEILING_REASON
+from creek_mcp.tier_ceiling import TierCeiling, refusal_response, to_privacy_override
+from creek_mcp.tools.state import state_render_tool
+from creek_mcp.tools.state_read import state_read_tool
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Canaries — one pair per gated section
+#
+# One shared sentinel would make every failure message ambiguous about *which*
+# section leaked, which is the single most useful fact a failure can carry
+# here. Restricted to ``[A-Za-z0-9-]`` because two of these ride in filenames.
+# ---------------------------------------------------------------------------
+
+_DRIFT_INTIMATE = "CANARY-DRIFT-INTIMATE-9f3a"
+"""Rides in the *filename* of an aged, unlinked ``intimate`` fragment.
+
+The drift leak is the slugified title in the orphan path, not a body, so the
+sentinel has to be in the path for the reproduction to be real.
+"""
+
+_DRIFT_OPEN = "CANARY-DRIFT-OPEN-4c17"
+"""Rides in the filename of an equally aged, equally unlinked ``open`` fragment."""
+
+_LIMINAL_INTIMATE = "CANARY-LIMINAL-INTIMATE-6d80"
+"""Rides in the file *stem* of a ``10-Liminal/Unnamed/`` note tiered ``intimate``."""
+
+_LIMINAL_OPEN = "CANARY-LIMINAL-OPEN-2e55"
+"""Rides in the file stem of a ``10-Liminal/Unnamed/`` note tiered ``open``."""
+
+_PARADOX_NOTIER = "CANARY-PARADOX-NOTIER-7b91"
+"""Rides in the stem of a ``type: paradox`` note carrying **no** ``privacy_tier``.
+
+``10-Liminal/Paradoxes/`` notes are not fragments and have no tier field in
+their model, so the fail-closed read (``raw_privacy_tier`` on a missing key →
+``INTIMATE``) is the only thing standing between them and an ``open`` report.
+"""
+
+_EDDY_INTIMATE = "CANARY-EDDY-INTIMATE-5a3c"
+"""Rides in the ``title`` of an eddy whose only member fragment is ``intimate``."""
+
+_EDDY_OPEN = "CANARY-EDDY-OPEN-8f2d"
+"""Rides in the ``title`` of an eddy whose only member fragment is ``open``."""
+
+_THREAD_INTIMATE = "CANARY-THREAD-INTIMATE-3b6e"
+"""Rides in the ``title`` of a thread whose only member fragment is ``intimate``."""
+
+_THREAD_OPEN = "CANARY-THREAD-OPEN-0c94"
+"""Rides in the ``title`` of a thread whose only member fragment is ``open``."""
+
+_SYNC_INTIMATE = "CANARY-SYNC-INTIMATE-1e72"
+"""Rides in the *id* of an ``intimate`` fragment named by a synchronicity row.
+
+The surprising-connections section renders endpoint ids verbatim, so the id is
+where the sentinel has to be for the row to be a real leak.
+"""
+
+_SYNC_OPEN = "CANARY-SYNC-OPEN-7a05"
+"""Rides in the id of an ``open`` fragment named by a second synchronicity row."""
+
+_HYPER_INTIMATE = "CANARY-HYPER-INTIMATE-2d41"
+"""Rides in the ``title`` of a praxis derived from an ``intimate`` fragment."""
+
+_HYPER_OPEN = "CANARY-HYPER-OPEN-6f38"
+"""Rides in the ``title`` of a praxis derived from an ``open`` fragment."""
+
+_LINT_CANARY = "CANARY-LINT-9b57"
+"""Rides in the body of a ``creek lint`` report under ``00-Creek-Meta/Processing-Log``.
+
+``latest_lint_report`` copies that file into the state report *verbatim*, and
+``creek/lint/checks/tags.py`` deliberately runs the tag survey at
+``PrivacyTierOverride.ALL`` so it can report honestly about the whole vault.
+The copy is therefore untierable: the whole section is admitted or none of it.
+"""
+
+_ALL_INTIMATE_CANARIES = (
+    _DRIFT_INTIMATE,
+    _LIMINAL_INTIMATE,
+    _PARADOX_NOTIER,
+    _EDDY_INTIMATE,
+    _THREAD_INTIMATE,
+    _SYNC_INTIMATE,
+    _HYPER_INTIMATE,
+    _LINT_CANARY,
+)
+"""Every sentinel that must not survive a render below ``ceiling=intimate``."""
+
+_ALL_OPEN_CANARIES = (
+    _DRIFT_OPEN,
+    _LIMINAL_OPEN,
+    _EDDY_OPEN,
+    _THREAD_OPEN,
+    _SYNC_OPEN,
+    _HYPER_OPEN,
+)
+"""Every sentinel that must survive a render at *any* ceiling."""
+
+
+# Click 8 + Rich split ``--include-tier`` across ANSI reset codes when stdout
+# looks like a terminal, which differs between CI and a local CliRunner. Same
+# helper, same reason, as ``tests/test_cli_privacy.py``.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mGKHF]")
+
+_STATE_RELDIR = ("00-Creek-Meta", "State")
+_LATEST_NAME = "latest.md"
+
+_STAMP_TYPE_KEY = "type"
+_STAMP_TYPE_VALUE = "state-report"
+_STAMP_TIER_KEY = "privacy_tier"
+_STAMP_CEILING_KEY = "tier_ceiling"
+"""The stamp's front-matter shape, written out as literals on purpose.
+
+Spelled here rather than imported from ``creek.generate.state_tiers`` so a
+missing module fails :func:`test_state_tiers_exports_the_stamp_key_constants`
+alone — where the contract is stated — instead of every artifact assertion in
+the file. That one test pins the constants back to these literals, so the two
+cannot drift.
+"""
+
+_STATE_MODULES = ("creek.generate.state", "creek.generate.state_tiers")
+"""Modules a state-side tier gate may legitimately be bound in.
+
+The gate helpers live in ``state_tiers`` per #969's design, but ``state.py``
+owns the per-section admission and may bind them into its own namespace with
+``from ... import``. A monkeypatch has to hit the *binding the caller uses*, so
+the mutation tests below patch the symbol in every one of these that has it and
+assert at least one patch landed.
+"""
+
+_CEILINGS = (
+    TierCeiling.OPEN,
+    TierCeiling.PERSONAL,
+    TierCeiling.INTIMATE,
+    TierCeiling.ALL,
+)
+"""Every ceiling, in ascending breadth — the axis most tests here parametrise on."""
+
+_ADMITS_INTIMATE = (TierCeiling.INTIMATE, TierCeiling.ALL)
+"""The ceilings under which an ``intimate``-derived sentinel is admitted."""
+
+
+def _plain(text: str) -> str:
+    """Return *text* with ANSI escape sequences stripped.
+
+    Args:
+        text: CLI output as captured by :class:`~typer.testing.CliRunner`.
+
+    Returns:
+        The same text with terminal styling removed, so substring assertions
+        about flag names are not defeated by a reset code in the middle of
+        ``--include-tier``.
+    """
+    return _ANSI_RE.sub("", text)
+
+
+# ---------------------------------------------------------------------------
+# Vault-building helpers
+#
+# Kept in this file rather than in conftest.py: each one is shaped around a
+# specific section's admission conditions (an orphan must be old *and*
+# unlinked; an eddy's title must equal its file stem so the wikilink resolves
+# the same way under either implementation), and moving them to shared scope
+# invites a later edit to "simplify" one of those conditions away.
+# ---------------------------------------------------------------------------
+
+
+def _write_note(
+    vault: Path,
+    relpath: str,
+    metadata: dict[str, Any],
+    body: str,
+) -> Path:
+    """Write one markdown note with YAML front matter into the vault.
+
+    Args:
+        vault: Vault root.
+        relpath: Vault-relative destination path.
+        metadata: Front-matter mapping, written verbatim — a key omitted here
+            is a key genuinely absent from the file, which is the distinction
+            the fail-closed tier read depends on.
+        body: Markdown body.
+
+    Returns:
+        The path written.
+    """
+    target = vault / relpath
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _seed_dirs(vault: Path) -> None:
+    """Create the canonical vault folder layout the state generator reads.
+
+    ``StateReportGenerator.write`` creates ``00-Creek-Meta/State`` itself, but
+    the MCP audit log and the lint read-back both assume their parents exist,
+    and a missing folder would make a section render its placeholder for the
+    wrong reason.
+
+    Args:
+        vault: Vault root.
+    """
+    for sub in (
+        "00-Creek-Meta/State",
+        "00-Creek-Meta/Processing-Log",
+        "00-Creek-Meta/audit",
+        "01-Fragments/Notes",
+        "02-Threads/Active",
+        "03-Eddies",
+        "04-Praxis/Daily",
+        "10-Liminal/Unnamed",
+        "10-Liminal/Paradoxes",
+        "10-Liminal/Synchronicities",
+    ):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+
+
+def _write_fragment(
+    vault: Path,
+    *,
+    frag_id: str,
+    privacy_tier: str | None,
+    title: str = "Note",
+    filename: str | None = None,
+    age_days: int = 3,
+    eddies: list[str] | None = None,
+    threads: list[str] | None = None,
+    body: str = "fragment body",
+) -> Path:
+    """Write one fragment under ``01-Fragments/Notes``.
+
+    Args:
+        vault: Vault root.
+        frag_id: Fragment id — also the default file stem, which matters for
+            the synchronicity canary (rendered verbatim) and the drift canary
+            (rendered as a path).
+        privacy_tier: The declared tier, or ``None`` to omit the key entirely.
+            ``None`` is not ``"unclassified"``: the model defaults a missing
+            key to ``unclassified``, and only the raw front matter still tells
+            the two apart.
+        title: Fragment title.
+        filename: Explicit file stem when it must differ from *frag_id*.
+        age_days: How old ``created`` is, relative to now. Ages are relative
+            because ``OrphanScanner`` compares against ``datetime.now`` at scan
+            time, so a hardcoded date would silently cross the 90-day staleness
+            threshold as the calendar moved and flip this fixture's meaning.
+        eddies: ``eddies`` wikilinks. A resolvable wikilink also makes the
+            fragment non-orphaned, which is how the drift fixture is kept
+            separable from the eddy fixture.
+        threads: ``threads`` wikilinks.
+        body: Markdown body.
+
+    Returns:
+        The path written.
+    """
+    when = datetime.now(tz=UTC) - timedelta(days=age_days)
+    metadata: dict[str, Any] = {
+        "type": "fragment",
+        "id": frag_id,
+        "title": title,
+        "created": when.isoformat(),
+        "ingested": when.isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "F1", "secondary": []},
+        "wavelength": {
+            "phase": "unclassified",
+            "mode": "unclassified",
+            "dosage": "unclassified",
+        },
+        "eddies": list(eddies or []),
+        "threads": list(threads or []),
+        "praxis_potential": "none",
+    }
+    if privacy_tier is not None:
+        metadata["privacy_tier"] = privacy_tier
+    stem = filename if filename is not None else frag_id
+    return _write_note(vault, f"01-Fragments/Notes/{stem}.md", metadata, body)
+
+
+def _write_eddy(vault: Path, *, title: str) -> Path:
+    """Write an eddy whose file stem is identical to its ``title``.
+
+    The equality is load-bearing. ``StateReportGenerator._leaf_counts_by_link``
+    tallies wikilink *targets* and then looks the tally up by ``eddy.title``,
+    while a tier derivation could reasonably resolve the same wikilink to the
+    eddy *file*. Making stem and title the same string means the fixture is
+    valid under either resolution, so a failure here is about the ceiling and
+    never about which of the two the implementer chose.
+
+    Args:
+        vault: Vault root.
+        title: Eddy title, also used as the file stem and the wikilink target.
+
+    Returns:
+        The path written.
+    """
+    metadata: dict[str, Any] = {
+        "type": "eddy",
+        "id": f"eddy-{title.lower()}",
+        "title": title,
+        "formed": "2026-01-01",
+        "fragment_count": 1,
+        "threads": [],
+    }
+    return _write_note(vault, f"03-Eddies/{title}.md", metadata, "")
+
+
+def _write_thread(vault: Path, *, title: str) -> Path:
+    """Write a thread whose file stem is identical to its ``title``.
+
+    Same reasoning as :func:`_write_eddy`.
+
+    Args:
+        vault: Vault root.
+        title: Thread title, also the file stem and the wikilink target.
+
+    Returns:
+        The path written.
+    """
+    metadata: dict[str, Any] = {
+        "type": "thread",
+        "id": f"thread-{title.lower()}",
+        "title": title,
+        "status": "active",
+        "first_seen": "2026-01-01",
+        "last_seen": "2026-06-01",
+        "fragment_count": 1,
+    }
+    return _write_note(vault, f"02-Threads/Active/{title}.md", metadata, "")
+
+
+def _write_praxis(
+    vault: Path,
+    *,
+    praxis_id: str,
+    title: str,
+    derived_from: list[str],
+) -> Path:
+    """Write a praxis under ``04-Praxis/Daily``.
+
+    Args:
+        vault: Vault root.
+        praxis_id: Praxis id and file stem.
+        title: Praxis title — the hyperedge canary's carrier, since the
+            hyperedge row renders ``<title> — spans: <eddies>``.
+        derived_from: Source fragment ids, whose tiers the praxis's own
+            derived tier reduces over.
+
+    Returns:
+        The path written.
+    """
+    metadata: dict[str, Any] = {
+        "type": "praxis",
+        "id": praxis_id,
+        "title": title,
+        "praxis_type": "habit",
+        "status": "proposed",
+        "derived_from": list(derived_from),
+    }
+    return _write_note(vault, f"04-Praxis/Daily/{praxis_id}.md", metadata, "")
+
+
+def _write_synchronicity(
+    vault: Path, *, sync_id: str, frag_a: str, frag_b: str
+) -> Path:
+    """Write a synchronicity row naming two fragment ids.
+
+    Args:
+        vault: Vault root.
+        sync_id: Synchronicity id and file stem.
+        frag_a: First endpoint fragment id.
+        frag_b: Second endpoint fragment id.
+
+    Returns:
+        The path written.
+    """
+    metadata: dict[str, Any] = {
+        "type": "synchronicity",
+        "id": sync_id,
+        "fragment_a_id": frag_a,
+        "fragment_b_id": frag_b,
+        "similarity": 0.95,
+        "time_gap_days": 60,
+        "source_a": "journal",
+        "source_b": "essay",
+    }
+    return _write_note(
+        vault,
+        f"10-Liminal/Synchronicities/{sync_id}.md",
+        metadata,
+        "",
+    )
+
+
+def _write_liminal_unnamed(vault: Path, *, stem: str, privacy_tier: str) -> Path:
+    """Write a ``10-Liminal/Unnamed`` note whose *stem* carries the sentinel.
+
+    The liminal watch renders ``path.stem`` and nothing else, so the stem is
+    the only place a sentinel can prove the section leaked.
+
+    Args:
+        vault: Vault root.
+        stem: File stem.
+        privacy_tier: The declared tier.
+
+    Returns:
+        The path written.
+    """
+    when = datetime.now(tz=UTC) - timedelta(days=3)
+    metadata: dict[str, Any] = {
+        "type": "fragment",
+        "id": stem,
+        "title": stem,
+        "created": when.isoformat(),
+        "ingested": when.isoformat(),
+        "source": {"platform": "journal", "author": "self"},
+        "frequency": {"primary": "unclassified", "secondary": []},
+        "privacy_tier": privacy_tier,
+    }
+    return _write_note(vault, f"10-Liminal/Unnamed/{stem}.md", metadata, "unnamed body")
+
+
+def _write_liminal_paradox(vault: Path, *, stem: str) -> Path:
+    """Write a ``10-Liminal/Paradoxes`` note with **no** ``privacy_tier`` key.
+
+    ``type: paradox`` notes have no tier field in their model at all, so this
+    is the fail-closed case: the note must be excluded below
+    ``ceiling=intimate`` because nobody has vouched for it, not because it was
+    classified.
+
+    Args:
+        vault: Vault root.
+        stem: File stem, carrying the sentinel.
+
+    Returns:
+        The path written.
+    """
+    when = datetime.now(tz=UTC) - timedelta(days=3)
+    metadata: dict[str, Any] = {
+        "type": "paradox",
+        "id": stem,
+        "title": stem,
+        "created": when.isoformat(),
+    }
+    return _write_note(
+        vault,
+        f"10-Liminal/Paradoxes/{stem}.md",
+        metadata,
+        "held tension",
+    )
+
+
+def _write_lint_report(vault: Path) -> Path:
+    """Write a ``creek lint`` report where ``latest_lint_report`` will find it.
+
+    ``LintRunner.write`` writes ``00-Creek-Meta/Processing-Log/lint-<date>.md``
+    and ``latest_lint_report`` globs ``lint-*.md``, sorts, and returns the last
+    file's text **verbatim**. The body shape is therefore irrelevant to this
+    fixture — only the path pattern is — which is exactly why the section
+    cannot be filtered row by row and must be admitted whole or not at all.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        The path written.
+    """
+    target = vault / "00-Creek-Meta" / "Processing-Log" / "lint-2026-07-01.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        "# Lint report\n\n## orphan-tags\n\n"
+        f"- Orphan tag `{_LINT_CANARY}` appears on 1 note.\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+def _write_yield_log(vault: Path) -> Path:
+    """Write one ``run-summary.jsonl`` line for the pre-LLM yield section.
+
+    The last line of that log describes a pipeline *run*: it carries no
+    fragment ids, so there is nothing in it to filter *by*. It exists in this
+    fixture so the out-of-scope section has real content, which is what makes
+    :func:`test_whole_corpus_sections_are_not_filtered_by_the_ceiling` a
+    comparison rather than two placeholders agreeing for free.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        The path written.
+    """
+    target = vault / "00-Creek-Meta" / "Processing-Log" / "run-summary.jsonl"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(
+            {
+                "run_id": "run-canary",
+                "timestamp": "2026-07-01T00:00:00+00:00",
+                "deterministic_classified": 7,
+                "local_model_processed": 2,
+                "residue": 1,
+                "no_llm": True,
+            },
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return target
+
+
+def _build_canary_vault(root: Path, name: str = "canary-state-vault") -> Path:
+    """Build one vault carrying an above/below canary pair for every gated section.
+
+    A single vault rather than seven is deliberate: the sections share one
+    corpus in production, and a fixture that isolated each one could not catch
+    a section admitting content another section already excluded (the eddy
+    whose title was derived from an excluded fragment, say). Each pair carries
+    its own sentinel so a failure still names one section.
+
+    Ages are relative to *now* because ``OrphanScanner`` compares against
+    ``datetime.now``: only the two drift fragments are old enough (200 days) to
+    be reported stale, and every other fragment is three days old so it cannot
+    drift into the drift section as the calendar moves.
+
+    Args:
+        root: Directory the vault is created inside (typically ``tmp_path``).
+        name: Vault directory name, so one test can build several vaults.
+
+    Returns:
+        The vault root.
+    """
+    vault = root / name
+    _seed_dirs(vault)
+
+    # --- Drift warnings: aged + unlinked, sentinel in the *filename* --------
+    _write_fragment(
+        vault,
+        frag_id="frag-drift-intimate",
+        filename=f"private-{_DRIFT_INTIMATE}-moment",
+        title="Private moment",
+        privacy_tier="intimate",
+        age_days=200,
+    )
+    _write_fragment(
+        vault,
+        frag_id="frag-drift-open",
+        filename=f"public-{_DRIFT_OPEN}-note",
+        title="Public note",
+        privacy_tier="open",
+        age_days=200,
+    )
+
+    # --- Liminal watch -----------------------------------------------------
+    _write_liminal_unnamed(
+        vault,
+        stem=f"unnamed-{_LIMINAL_INTIMATE}",
+        privacy_tier="intimate",
+    )
+    _write_liminal_unnamed(
+        vault,
+        stem=f"unnamed-{_LIMINAL_OPEN}",
+        privacy_tier="open",
+    )
+    _write_liminal_paradox(vault, stem=f"paradox-{_PARADOX_NOTIER}")
+
+    # --- Active eddies -----------------------------------------------------
+    intimate_eddy = f"Eddy-{_EDDY_INTIMATE}-One"
+    open_eddy = f"Eddy-{_EDDY_OPEN}-Two"
+    _write_eddy(vault, title=intimate_eddy)
+    _write_eddy(vault, title=open_eddy)
+    _write_fragment(
+        vault,
+        frag_id="frag-eddy-intimate",
+        privacy_tier="intimate",
+        eddies=[f"[[{intimate_eddy}]]"],
+    )
+    _write_fragment(
+        vault,
+        frag_id="frag-eddy-open",
+        privacy_tier="open",
+        eddies=[f"[[{open_eddy}]]"],
+    )
+
+    # --- Active threads ----------------------------------------------------
+    intimate_thread = f"Thread-{_THREAD_INTIMATE}-One"
+    open_thread = f"Thread-{_THREAD_OPEN}-Two"
+    _write_thread(vault, title=intimate_thread)
+    _write_thread(vault, title=open_thread)
+    _write_fragment(
+        vault,
+        frag_id="frag-thread-intimate",
+        privacy_tier="intimate",
+        threads=[f"[[{intimate_thread}]]"],
+    )
+    _write_fragment(
+        vault,
+        frag_id="frag-thread-open",
+        privacy_tier="open",
+        threads=[f"[[{open_thread}]]"],
+    )
+
+    # --- Surprising connections: the sentinel is the fragment *id* ----------
+    _write_fragment(
+        vault,
+        frag_id=f"frag-{_SYNC_INTIMATE}",
+        privacy_tier="intimate",
+    )
+    _write_fragment(vault, frag_id="frag-sync-partner", privacy_tier="open")
+    _write_fragment(vault, frag_id=f"frag-{_SYNC_OPEN}", privacy_tier="open")
+    _write_synchronicity(
+        vault,
+        sync_id="sync-above",
+        frag_a="frag-sync-partner",
+        frag_b=f"frag-{_SYNC_INTIMATE}",
+    )
+    _write_synchronicity(
+        vault,
+        sync_id="sync-below",
+        frag_a="frag-sync-partner",
+        frag_b=f"frag-{_SYNC_OPEN}",
+    )
+
+    # --- Hyperedges: a praxis whose sources span two eddies -----------------
+    # The four spanned eddies are deliberately sentinel-free: this row is about
+    # the praxis title, and a canary in a spanned eddy title would make a
+    # failure ambiguous between the hyperedge gate and the eddy gate.
+    #
+    # The two praxis rows get *disjoint* eddy pairs on purpose. Sharing a pair
+    # would give each shared eddy one intimate and one open member, so the
+    # below-ceiling praxis's own span would depend on whether the implementer
+    # computes the spanned set from admitted *fragments* or from admitted
+    # *eddies* — and the positive control would then be testing that choice
+    # rather than the gate.
+    for name in ("Eddy-Hyper-A-Above", "Eddy-Hyper-B-Above"):
+        _write_eddy(vault, title=name)
+    for name in ("Eddy-Hyper-A-Below", "Eddy-Hyper-B-Below"):
+        _write_eddy(vault, title=name)
+    _write_fragment(
+        vault,
+        frag_id="frag-hyper-intimate",
+        privacy_tier="intimate",
+        eddies=["[[Eddy-Hyper-A-Above]]", "[[Eddy-Hyper-B-Above]]"],
+    )
+    _write_fragment(
+        vault,
+        frag_id="frag-hyper-open",
+        privacy_tier="open",
+        eddies=["[[Eddy-Hyper-A-Below]]", "[[Eddy-Hyper-B-Below]]"],
+    )
+    _write_praxis(
+        vault,
+        praxis_id="praxis-above",
+        title=f"Praxis {_HYPER_INTIMATE} above",
+        derived_from=["frag-hyper-intimate"],
+    )
+    _write_praxis(
+        vault,
+        praxis_id="praxis-below",
+        title=f"Praxis {_HYPER_OPEN} below",
+        derived_from=["frag-hyper-open"],
+    )
+
+    # --- Pre-LLM yield -----------------------------------------------------
+    # Present so the whole-corpus sections have real content to compare across
+    # ceilings; an all-placeholder comparison would be equal for free.
+    _write_yield_log(vault)
+
+    # --- Lint summary ------------------------------------------------------
+    _write_lint_report(vault)
+    return vault
+
+
+def _build_open_only_vault(root: Path, name: str = "open-only-vault") -> Path:
+    """Build a vault whose every tiered note is ``open``.
+
+    Used by the stamp tests: a broad render over a corpus with nothing above
+    ``open`` in it must still stamp ``open``, which is the property that keeps
+    an ``all``-ceiling render readable at an ``open`` ceiling.
+
+    Args:
+        root: Directory the vault is created inside.
+        name: Vault directory name.
+
+    Returns:
+        The vault root.
+    """
+    vault = root / name
+    _seed_dirs(vault)
+    _write_fragment(vault, frag_id="frag-open-a", privacy_tier="open")
+    _write_fragment(vault, frag_id="frag-open-b", privacy_tier="open")
+    _write_liminal_unnamed(vault, stem="unnamed-open", privacy_tier="open")
+    return vault
+
+
+# ---------------------------------------------------------------------------
+# Artifact-reading helpers
+#
+# Everything below reads the *files* the call wrote. Nothing reads a response
+# envelope, for the reason set out in the module docstring.
+# ---------------------------------------------------------------------------
+
+
+def _iso_week_file(vault: Path) -> Path:
+    """Return the single ISO-week report file under ``00-Creek-Meta/State``.
+
+    Located by globbing rather than by recomputing the ISO week, because
+    ``state_render_tool`` takes no ``today`` and a test that recomputed the
+    week would break at a week boundary for reasons having nothing to do with
+    tiers.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        The ISO-week report path.
+    """
+    state_dir = vault.joinpath(*_STATE_RELDIR)
+    weeks = sorted(p for p in state_dir.glob("*.md") if p.name != _LATEST_NAME)
+    assert len(weeks) == 1, (
+        f"expected exactly one ISO-week report under {state_dir}, found "
+        f"{[p.name for p in weeks]}"
+    )
+    return weeks[0]
+
+
+def _latest_file(vault: Path) -> Path:
+    """Return ``00-Creek-Meta/State/latest.md``.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        The ``latest.md`` path (a symlink on most platforms, a copy otherwise).
+    """
+    return vault.joinpath(*_STATE_RELDIR) / _LATEST_NAME
+
+
+def _artifact_text(vault: Path) -> str:
+    """Return every state artifact's vault-relative path and text, concatenated.
+
+    Both the ISO-week file *and* ``latest.md`` are included because they are
+    two independent write paths — a symlink refresh and a copy fallback — and
+    #969's cache-thrash behaviour means a caller may read either one. Paths are
+    included alongside contents because the drift sentinel rides in a filename,
+    and a contents-only sweep would walk straight past a filename that got
+    rendered into a row.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        One string covering both artifacts' paths and bodies.
+    """
+    parts: list[str] = []
+    for path in (_iso_week_file(vault), _latest_file(vault)):
+        parts.append(str(path.relative_to(vault)))
+        parts.append(path.read_text(encoding="utf-8", errors="replace"))
+    return "\n".join(parts)
+
+
+def _report_body(vault: Path) -> str:
+    """Return the ISO-week report's markdown body with the stamp removed.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        The body ``frontmatter.loads`` recovers — identical to the pre-#969
+        rendered document if the stamp round-trips, which is what
+        :func:`test_stamped_report_body_still_round_trips` asserts.
+    """
+    raw = _iso_week_file(vault).read_text(encoding="utf-8")
+    return str(frontmatter.loads(raw).content)
+
+
+def _stamp(vault: Path, path: Path | None = None) -> dict[str, Any]:
+    """Return the YAML front-matter stamp of a written state artifact.
+
+    Args:
+        vault: Vault root.
+        path: The artifact to read, defaulting to the ISO-week file.
+
+    Returns:
+        The parsed front-matter mapping. An unstamped artifact yields ``{}``,
+        which is itself the legacy case the read gate has to fail closed on.
+    """
+    target = path if path is not None else _iso_week_file(vault)
+    return dict(frontmatter.loads(target.read_text(encoding="utf-8")).metadata)
+
+
+def _section_body(report: str, header: str) -> str:
+    """Return the text of one ``## ...`` section of a rendered report.
+
+    Args:
+        report: The full rendered markdown body.
+        header: The section header, e.g. ``"## Lint summary"``.
+
+    Returns:
+        Everything from *header* up to the next ``## `` heading, or the empty
+        string when the header is absent — which callers assert against
+        explicitly rather than silently treating as "no content".
+    """
+    start = report.find(header)
+    if start == -1:
+        return ""
+    rest = report[start + len(header) :]
+    end = rest.find("\n## ")
+    return rest if end == -1 else rest[:end]
+
+
+def _snapshot(vault: Path) -> dict[Path, bytes]:
+    """Return the full byte contents of every file in the vault.
+
+    Bytes rather than ``(mtime_ns, size)``: a render that rewrote a file with
+    same-length content inside one filesystem timestamp tick would look
+    unchanged to a stat-based snapshot, and "unchanged" is exactly the state
+    this snapshot exists to rule out.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        Mapping of path to contents.
+    """
+    return {p: p.read_bytes() for p in vault.rglob("*") if p.is_file()}
+
+
+def _changed_files(vault: Path, before: dict[Path, bytes]) -> list[Path]:
+    """Return every file that is new or whose bytes differ from *before*.
+
+    Args:
+        vault: Vault root.
+        before: A :func:`_snapshot` taken before the call under test.
+
+    Returns:
+        Sorted list of new-or-modified files.
+    """
+    return sorted(
+        p for p in vault.rglob("*") if p.is_file() and before.get(p) != p.read_bytes()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def canary_vault(tmp_path: Path) -> Path:
+    """Return the shared per-section canary vault.
+
+    Function-scoped on purpose: several tests below render into the vault, and
+    ``latest.md`` is a single slot shared across ceilings, so a module-scoped
+    fixture would let one test's render decide another test's read.
+    """
+    return _build_canary_vault(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# The per-section table
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SectionCase:
+    """One gated section of the state report and how to judge what it wrote.
+
+    Attributes:
+        header: The section header, used verbatim in failure messages so a
+            failure names the section without the reader consulting this table.
+        above_canary: The sentinel carried by content above ``ceiling=open``.
+        below_canary: The sentinel carried by admitted content, asserted
+            *present* at every ceiling, or ``None`` for the lint summary, whose
+            content is admitted whole or not at all and so has no below-ceiling
+            half to assert.
+        carrier: One line naming what the sentinel actually rides in — the
+            fact a reader needs to judge whether the fixture reproduces the
+            leak or merely resembles it.
+    """
+
+    header: str
+    above_canary: str
+    below_canary: str | None
+    carrier: str
+
+
+_SECTIONS: tuple[_SectionCase, ...] = (
+    _SectionCase(
+        header="## Liminal Watch",
+        above_canary=_LIMINAL_INTIMATE,
+        below_canary=_LIMINAL_OPEN,
+        carrier="the file stem of a 10-Liminal/Unnamed note, rendered verbatim",
+    ),
+    _SectionCase(
+        header="## Liminal Watch",
+        above_canary=_PARADOX_NOTIER,
+        below_canary=_LIMINAL_OPEN,
+        carrier=(
+            "the file stem of a 10-Liminal/Paradoxes note with no privacy_tier "
+            "key at all, which must fail closed to intimate"
+        ),
+    ),
+    _SectionCase(
+        header="## Active eddies",
+        above_canary=_EDDY_INTIMATE,
+        below_canary=_EDDY_OPEN,
+        carrier="the title of an eddy whose only member fragment is intimate",
+    ),
+    _SectionCase(
+        header="## Active threads",
+        above_canary=_THREAD_INTIMATE,
+        below_canary=_THREAD_OPEN,
+        carrier="the title of a thread whose only member fragment is intimate",
+    ),
+    _SectionCase(
+        header="## Surprising connections",
+        above_canary=_SYNC_INTIMATE,
+        below_canary=_SYNC_OPEN,
+        carrier="the id of an intimate endpoint fragment, rendered verbatim",
+    ),
+    _SectionCase(
+        header="## Hyperedges",
+        above_canary=_HYPER_INTIMATE,
+        below_canary=_HYPER_OPEN,
+        carrier="the title of a praxis derived from an intimate fragment",
+    ),
+    _SectionCase(
+        header="## Drift warnings",
+        above_canary=_DRIFT_INTIMATE,
+        below_canary=_DRIFT_OPEN,
+        carrier=(
+            "the filename of an aged, unlinked intimate fragment — the "
+            "slugified title, reported as an orphan path"
+        ),
+    ),
+    _SectionCase(
+        header="## Lint summary",
+        above_canary=_LINT_CANARY,
+        below_canary=None,
+        carrier=(
+            "a tag name inside the verbatim lint report copy, which the tags "
+            "check deliberately produced at PrivacyTierOverride.ALL"
+        ),
+    ),
+)
+"""Every section whose *identifiable* content #969 gates, in section order.
+
+Three sections are absent, and each for its own reason rather than as one
+bucket. ``## Wavelength snapshot`` and ``## Vault summary`` **are** gated —
+they narrow with the ceiling — but what they render is a count, not a
+sentinel, so they are asserted by
+:func:`test_wavelength_and_vault_summary_narrow_with_the_ceiling` instead of by
+the canary table. ``## Pre-LLM yield`` is genuinely ungated: it reports one
+pipeline run's totals and names no fragment, so there is nothing in it to
+filter by, which
+:func:`test_pre_llm_yield_is_not_filtered_by_the_ceiling` asserts.
+"""
+
+_SECTION_IDS = [
+    f"{case.header.removeprefix('## ').replace(' ', '-')}-{case.above_canary}"
+    for case in _SECTIONS
+]
+
+
+_SECTION_DISPOSITIONS: dict[str, str] = {
+    "## Wavelength snapshot": "gated-count",
+    "## Vault summary": "gated-count",
+    "## Pre-LLM yield": "ungated-run-log",
+    "## Liminal Watch": "gated-canary",
+    "## Active eddies": "gated-canary",
+    "## Active threads": "gated-canary",
+    "## Surprising connections": "gated-canary",
+    "## Hyperedges": "gated-canary",
+    "## Drift warnings": "gated-canary",
+    "## Suggested questions": "gated-dropped-below-personal",
+    "## Lint summary": "gated-canary",
+}
+"""Every section of the report and how #969 disposed of it.
+
+The forcing function that keeps the artifact stamp honest as the report grows.
+The stamp is the maximum tier the render admitted, and the read gate refuses on
+it — so a **new** section that emits above-ceiling content without contributing
+to that maximum makes the stamp under-report, and a stamp that under-reports is
+a read gate that fails open. That failure would be silent: every assertion in
+this file would still pass, because none of them knows about a section nobody
+wrote a canary for.
+
+Requiring the table to match :data:`~creek.generate.state.SECTION_ORDER`
+exactly means a new section has to be triaged **out loud** before the suite is
+green — the same discipline ``tests/test_mcp_read_gate.py`` layers (a) and (f)
+apply to a newly registered tool.
+"""
+
+
+def test_every_report_section_has_a_recorded_disposition() -> None:
+    """The disposition table covers ``SECTION_ORDER`` exactly, in both directions.
+
+    Missing entries are the dangerous direction — an untriaged section can leak
+    above the ceiling and leave the stamp under-reporting it. Stale entries are
+    checked too, because a disposition for a section that no longer exists is a
+    claim about nothing and inflates the apparent coverage of this file.
+    """
+    recorded = set(_SECTION_DISPOSITIONS)
+    actual = set(SECTION_ORDER)
+    untriaged = actual - recorded
+    assert not untriaged, (
+        f"report section(s) with no recorded #969 disposition: {sorted(untriaged)}. "
+        "Add an entry saying whether the section is gated and how. A section "
+        "nobody triaged can emit above-ceiling content without contributing to "
+        "the artifact stamp, which makes creek.state.read fail open on it."
+    )
+    stale = recorded - actual
+    assert not stale, (
+        f"_SECTION_DISPOSITIONS names section(s) that no longer exist: "
+        f"{sorted(stale)}. Delete the entry, or restore the section."
+    )
+
+
+def test_canary_table_and_disposition_table_agree() -> None:
+    """Every ``gated-canary`` section is actually canary-tested, and vice versa.
+
+    Two tables describing the same sections can drift apart, and the drift is
+    invisible: a section could be labelled ``gated-canary`` here while no row
+    of :data:`_SECTIONS` exercises it, leaving a confident-looking disposition
+    over an untested section.
+    """
+    labelled = {
+        header
+        for header, disposition in _SECTION_DISPOSITIONS.items()
+        if disposition == "gated-canary"
+    }
+    exercised = {case.header for case in _SECTIONS}
+    assert labelled == exercised, (
+        "the disposition table and the canary table disagree about which "
+        f"sections are canary-tested: labelled-only={sorted(labelled - exercised)}, "
+        f"exercised-only={sorted(exercised - labelled)}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# T1 — per-section exclusion and admission, on the artifact bytes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("case", _SECTIONS, ids=_SECTION_IDS)
+@pytest.mark.parametrize("ceiling", _CEILINGS, ids=[c.value for c in _CEILINGS])
+def test_render_admits_a_section_canary_only_at_a_ceiling_that_allows_it(
+    case: _SectionCase,
+    ceiling: TierCeiling,
+    canary_vault: Path,
+) -> None:
+    """Each gated section admits above-ceiling content at ``intimate``/``all`` only.
+
+    Asserted against the bytes of the ISO-week file **and** ``latest.md``,
+    never against ``state_render_tool``'s envelope. The envelope echoes the
+    rendered content today, but ``creek.state.render`` is a write-side surface:
+    the artifact is what a later ``creek.state.read``, ``creek state-budget``,
+    a git commit or an operator's editor will serve, and it is the artifact
+    that #969 reproduced three leaks in.
+
+    The below-ceiling canary is asserted *present* in the same bytes at every
+    ceiling, and that is not decoration: without it a generator that filtered
+    everything out — or crashed into writing an empty report — would satisfy
+    the exclusion half perfectly while being an outage rather than a gate. The
+    lint summary has no below-ceiling half (its copy is admitted whole or not
+    at all), so its non-vacuity control is the section-header sweep, which
+    proves the document was rendered in full.
+
+    Args:
+        case: The section under test and its canary pair.
+        ceiling: The ceiling the render runs under.
+        canary_vault: The shared per-section canary vault.
+    """
+    result = state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=ceiling,
+    )
+    assert result["status"] == "ok"
+    text = _artifact_text(canary_vault)
+
+    for header in SECTION_ORDER:
+        assert header in text, (
+            f"the rendered report is missing {header!r} at ceiling="
+            f"{ceiling.value}, so every canary assertion below it is vacuous"
+        )
+
+    if ceiling in _ADMITS_INTIMATE:
+        assert case.above_canary in text, (
+            f"{case.header} dropped {case.above_canary!r} at "
+            f"privacy_tier_ceiling={ceiling.value}, which admits intimate "
+            "content. The permissive direction has to be pinned as hard as "
+            "the restrictive one: a gate that drops everything is leak-free "
+            "and useless.\n\n"
+            f"Sentinel carrier: {case.carrier}."
+        )
+    else:
+        assert case.above_canary not in text, (
+            f"{case.header} wrote the above-ceiling sentinel "
+            f"{case.above_canary!r} into 00-Creek-Meta/State at "
+            f"privacy_tier_ceiling={ceiling.value}.\n\n"
+            f"Sentinel carrier: {case.carrier}.\n\n"
+            "This is an artifact-level assertion on purpose. "
+            "creek.state.render's response envelope is not evidence for a "
+            "write-side surface, and the artifact is what every later reader "
+            f"of the vault sees.\n\n{text}"
+        )
+
+    if case.below_canary is not None:
+        assert case.below_canary in text, (
+            f"{case.header} dropped the below-ceiling sentinel "
+            f"{case.below_canary!r} at privacy_tier_ceiling={ceiling.value}. "
+            "Admitted content must still reach the artifact, or the exclusion "
+            "assertion above proves nothing."
+        )
+
+
+def test_lint_summary_renders_the_placeholder_below_the_intimate_ceiling(
+    canary_vault: Path,
+) -> None:
+    """Below ``ceiling=intimate`` the lint section is empty, not merely canary-free.
+
+    ``latest_lint_report`` returns an untierable verbatim copy of a
+    Processing-Log artifact that embeds above-ceiling titles and tag names, and
+    ``creek/lint/checks/tags.py`` deliberately surveys the whole vault at
+    ``PrivacyTierOverride.ALL`` so it cannot report "no orphan tags" about a
+    vault that has them. There is no row-level filter available, so the honest
+    behaviour is to drop the section and say so with the standard placeholder
+    rather than to render a silently truncated report.
+
+    Asserting the placeholder rather than only the sentinel's absence matters
+    because a lint report with a *different* body would then be admitted while
+    this test stayed green.
+
+    This closes the live caveat ``creek_mcp/read_gate.py`` records under
+    ``creek.lint``: "it holds only while nothing serves Processing-Log/ back".
+    ``creek state`` is the thing that serves it back.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    section = _section_body(_report_body(canary_vault), "## Lint summary")
+    assert section, "the report is missing its '## Lint summary' section entirely"
+    assert EMPTY_PLACEHOLDER in section, (
+        "## Lint summary at privacy_tier_ceiling=open must render "
+        f"{EMPTY_PLACEHOLDER!r}; it rendered:\n\n{section}"
+    )
+    assert _LINT_CANARY not in section
+
+
+def test_suggested_questions_are_dropped_at_the_open_ceiling(
+    canary_vault: Path,
+) -> None:
+    """``## Suggested questions`` is empty at ``ceiling=open``, by design.
+
+    The seed corpus is mined through ``filter_fragments_by_tier``, which
+    *summarises* a personal fragment as ``[Personal-tier summary: <title>]``
+    rather than excluding it. At ``ceiling=open`` a personal **title** can
+    therefore enter the mining corpus and ride out as a prompt — exactly the
+    property ``within_ceiling``'s docstring says a report must not rely on.
+
+    Dropping the section below ``personal`` is the belt to that braces, not the
+    whole gate. It does **not**, on its own, make the seed corpus equal to the
+    hard-cutoff admitted set — an earlier draft of this docstring claimed it
+    did, and the #969 Gate-2.5 review disproved it: the miner's snapshot also
+    carries threads, eddies and liminal notes, none of which the fragment
+    cutoff touches, and a thread whose members are all above the ceiling titled
+    a seed at ``ceiling=personal``. Equality is what
+    ``StateReportGenerator._mining_corpus`` now establishes by narrowing the
+    snapshot itself; the drop below ``personal`` closes the one axis narrowing
+    cannot, because ``filter_fragments_by_tier`` summarises rather than omits.
+    ``test_suggested_questions_omit_an_above_ceiling_thread_title`` pins the
+    other half.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    section = _section_body(_report_body(canary_vault), "## Suggested questions")
+    assert section, "the report is missing its '## Suggested questions' section"
+    assert EMPTY_PLACEHOLDER in section, (
+        "## Suggested questions must render the empty placeholder at "
+        f"privacy_tier_ceiling=open; it rendered:\n\n{section}"
+    )
+
+
+def test_suggested_questions_return_above_the_open_ceiling(
+    canary_vault: Path,
+) -> None:
+    """At ``ceiling=all`` the section surfaces seeds again — the positive control.
+
+    Without this, "the ceiling is enforced" and "the section is permanently
+    broken" are indistinguishable. The mechanism is exact rather than hopeful:
+    ``phase_filtered_seeds`` runs every strategy for the ``unclassified`` phase
+    this fixture carries, and ``mine_unexplored_ontology`` runs with
+    ``require_corpus=True`` — it returns ``[]`` only when the ceiling-filtered
+    snapshot holds no fragments at all. The canary vault holds many, so a
+    non-placeholder section proves the corpus walk ran under the broad ceiling.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    section = _section_body(_report_body(canary_vault), "## Suggested questions")
+    assert section, "the report is missing its '## Suggested questions' section"
+    assert EMPTY_PLACEHOLDER not in section, (
+        "## Suggested questions rendered the empty placeholder at "
+        "privacy_tier_ceiling=all over a corpus with fragments in it, so the "
+        "open-ceiling assertion in the companion test is satisfied by an "
+        f"outage rather than by a gate:\n\n{section}"
+    )
+
+
+def test_drift_warnings_render_vault_relative_paths(canary_vault: Path) -> None:
+    """Orphan rows name a vault-relative path, never the operator's home directory.
+
+    ``docs/generation.md`` already claims "The report header renders the
+    vault's leaf directory name only — never the absolute path — so committing
+    or sharing the artefact does not leak an operator's home directory." That
+    claim was false: ``OrphanScanner`` returns ``str(path)`` for an absolute
+    path and the drift section rendered it verbatim. Rendering the path
+    vault-relative is what makes the existing documentation true, and it is
+    part of the same fix as the tier gate because the leaked string is the same
+    string — a fragment's slugified title inside an absolute path.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    body = _report_body(canary_vault)
+    relative = f"01-Fragments/Notes/public-{_DRIFT_OPEN}-note.md"
+    assert relative in body, (
+        "## Drift warnings must report an admitted orphan by its "
+        f"vault-relative path; {relative!r} is absent from:\n\n"
+        f"{_section_body(body, '## Drift warnings')}"
+    )
+    assert str(canary_vault) not in body, (
+        "the rendered report embeds the absolute vault path "
+        f"{str(canary_vault)!r}, which leaks the operator's home directory "
+        "into an artifact meant to be committable and shareable."
+    )
+
+
+def test_pre_llm_yield_is_not_filtered_by_the_ceiling(canary_vault: Path) -> None:
+    """The pre-LLM yield section reads the same at every ceiling, on purpose.
+
+    It is the one section of the eleven with genuinely nothing to filter *by*:
+    the last line of ``run-summary.jsonl`` records a pipeline **run** — a run
+    id, a timestamp and four integers — and names no fragment, id, title or
+    path. There is no tier to read and no item to drop. Its counts describe
+    work the pipeline did, not content the vault holds.
+
+    Contrast the two sections that *look* like the same class and are not — see
+    :func:`test_wavelength_and_vault_summary_narrow_with_the_ceiling`. This test
+    is asserted rather than left as prose because the instinct while closing
+    #969 is to thread the override everywhere; if a future change decides this
+    section should narrow too, it has to say so here.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(vault_path=canary_vault, privacy_tier_ceiling=TierCeiling.OPEN)
+    at_open = _report_body(canary_vault)
+    state_render_tool(vault_path=canary_vault, privacy_tier_ceiling=TierCeiling.ALL)
+    at_all = _report_body(canary_vault)
+
+    header = "## Pre-LLM yield"
+    assert _section_body(at_open, header) == _section_body(at_all, header), (
+        f"{header} differs between privacy_tier_ceiling=open and "
+        "privacy_tier_ceiling=all. It reports one pipeline run's totals and "
+        "names no fragment, so there is nothing in it to filter by."
+    )
+    assert "- Residue: 1" in _section_body(at_open, header), (
+        "the pre-LLM yield section rendered its placeholder, so the equality "
+        "assertion above compared two empty strings"
+    )
+
+
+def test_wavelength_and_vault_summary_narrow_with_the_ceiling(tmp_path: Path) -> None:
+    """The two *count* sections survey the admitted corpus, not the whole vault.
+
+    These read like whole-corpus statistics — a phase share, a fragment count,
+    a frequency histogram — and the tempting disposition is to leave them
+    unfiltered on the grounds that filtering produces a different measurement
+    rather than a safer one. This codebase has already rejected that argument
+    once. ``creek.wheel`` is a frequency **tally** and it is ``GATED``;
+    ``tests/test_mcp_read_gate.py``'s
+    ``test_wheel_probe_still_counts_the_fragment_it_is_admitted_to`` asserts it
+    counts only the fragment it is admitted to. A per-tier count is content
+    here, so ``creek.state.render`` may not ship a ``GATED`` posture while
+    printing ``Fragments: 100`` on a corpus of which 99 are above the caller's
+    ceiling. The count discloses the *existence* of what the rest of the report
+    was careful to omit.
+
+    It also keeps the artifact stamp exact rather than merely conservative: the
+    stamp is the maximum tier admitted, so a section that admits above-ceiling
+    content without contributing to the maximum makes the stamp under-report,
+    and a stamp that under-reports is a read gate that fails open.
+
+    The fixture is built here rather than shared because the assertion is a
+    count, and a count is only legible against a vault whose exact contents are
+    visible in the test that reads it: two fragments, both inside the 28-day
+    wavelength window, one ``open`` and one ``intimate``.
+
+    Args:
+        tmp_path: Pytest temporary directory.
+    """
+    vault = tmp_path / "count-vault"
+    _seed_dirs(vault)
+    _write_fragment(vault, frag_id="frag-count-open", privacy_tier="open", age_days=3)
+    _write_fragment(
+        vault,
+        frag_id="frag-count-intimate",
+        privacy_tier="intimate",
+        age_days=3,
+    )
+
+    state_render_tool(vault_path=vault, privacy_tier_ceiling=TierCeiling.OPEN)
+    at_open = _report_body(vault)
+    state_render_tool(vault_path=vault, privacy_tier_ceiling=TierCeiling.ALL)
+    at_all = _report_body(vault)
+
+    summary_open = _section_body(at_open, "## Vault summary")
+    summary_all = _section_body(at_all, "## Vault summary")
+    assert "- Fragments: 1" in summary_open, (
+        "## Vault summary counted the intimate fragment at "
+        f"privacy_tier_ceiling=open. Expected 1 of 2:\n\n{summary_open}"
+    )
+    assert "- Fragments: 2" in summary_all, (
+        "## Vault summary must count both fragments at "
+        f"privacy_tier_ceiling=all, or the assertion above is vacuous:\n\n"
+        f"{summary_all}"
+    )
+
+    wavelength_open = _section_body(at_open, "## Wavelength snapshot")
+    wavelength_all = _section_body(at_all, "## Wavelength snapshot")
+    assert "- Fragments observed: 1 " in wavelength_open, (
+        "## Wavelength snapshot observed the intimate fragment at "
+        f"privacy_tier_ceiling=open. Expected 1 of 2:\n\n{wavelength_open}"
+    )
+    assert "- Fragments observed: 2 " in wavelength_all, (
+        "## Wavelength snapshot must observe both fragments at "
+        f"privacy_tier_ceiling=all, or the assertion above is vacuous:\n\n"
+        f"{wavelength_all}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T2 — the stamp
+# ---------------------------------------------------------------------------
+
+
+def test_state_tiers_exports_the_stamp_key_constants() -> None:
+    """The new module names the stamp's shape, and names the tier key ``privacy_tier``.
+
+    The key must be ``privacy_tier`` — not a bespoke name — so the read side
+    can reuse ``creek.classify.privacy_filter.raw_privacy_tier`` **verbatim**.
+    A second tier reader is precisely the divergence that module's docstring
+    warns about ("two tools that disagree about the same file"), and #969 adds
+    none.
+
+    ``type: state-report`` matters for a different reason: ``_load_typed_models``
+    filters on ``type == "fragment"|"thread"|"eddy"|"praxis"``, so a stamped
+    report cannot be mistaken for vault content by the very generator that
+    wrote it.
+
+    This is the one test in the file that imports the new module at all. Every
+    other assertion spells the keys as literals, so a missing module fails here
+    — where the contract is stated — rather than collapsing the artifact-level
+    tests into a collection-time ``ImportError``.
+    """
+    state_tiers = importlib.import_module("creek.generate.state_tiers")
+
+    assert state_tiers.STATE_REPORT_TYPE == _STAMP_TYPE_VALUE
+    assert state_tiers.TIER_STAMP_KEY == _STAMP_TIER_KEY, (
+        "the stamp must be written under 'privacy_tier' so the read gate can "
+        "reuse raw_privacy_tier unchanged; a bespoke key would require a "
+        "second tier reader"
+    )
+    assert state_tiers.CEILING_STAMP_KEY == _STAMP_CEILING_KEY
+
+
+def test_write_stamps_the_report_with_type_tier_and_ceiling(
+    canary_vault: Path,
+) -> None:
+    """``write()`` prefixes the report with a three-key YAML stamp.
+
+    The stamp is what turns ``latest.md`` from a cross-ceiling cache into a
+    self-describing artifact. ``privacy_tier`` is the highest tier actually
+    admitted (what the read gate compares against); ``tier_ceiling`` is the
+    override the render ran under, recorded for the audit trail and
+    deliberately *not* consulted by the read gate — comparing it would refuse
+    a broad render over a narrow corpus for no reason.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    stamp = _stamp(canary_vault)
+    assert stamp[_STAMP_TYPE_KEY] == _STAMP_TYPE_VALUE
+    assert stamp[_STAMP_TIER_KEY] == PrivacyTier.INTIMATE.value, (
+        "a render at ceiling=all over a vault holding intimate content must "
+        f"stamp 'intimate'; it stamped {stamp.get(_STAMP_TIER_KEY)!r}"
+    )
+    assert stamp[_STAMP_CEILING_KEY] == to_privacy_override(TierCeiling.ALL).value
+
+
+def test_stamped_report_body_still_round_trips(canary_vault: Path) -> None:
+    """Adding the stamp must not disturb a single byte of the rendered document.
+
+    The report body is full of em-dashes, backticks and ``##`` headings, all of
+    which are YAML-adjacent enough to be worth checking rather than assuming.
+    ``frontmatter.loads`` must recover a body that still opens with the
+    document header and still carries all eleven section headers **in
+    ``SECTION_ORDER`` order** — the ordering contract FEAT-006 pinned and
+    FEAT-007 extended.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    body = _report_body(canary_vault)
+    assert body.startswith("# Creek state"), (
+        "the stamp swallowed the document header; the body now opens with "
+        f"{body[:80]!r}"
+    )
+    indices = [body.index(header) for header in SECTION_ORDER]
+    assert indices == sorted(indices), (
+        "the eleven sections are no longer in SECTION_ORDER order after "
+        f"stamping: {indices}"
+    )
+
+
+@pytest.mark.parametrize("ceiling", _CEILINGS, ids=[c.value for c in _CEILINGS])
+def test_stamped_tier_never_exceeds_the_ceiling_it_was_rendered_under(
+    ceiling: TierCeiling,
+    canary_vault: Path,
+) -> None:
+    """``privacy_tier <= tier_ceiling`` holds for every render, by construction.
+
+    Every contributor to the stamp cleared ``tier_within_override(tier,
+    override)`` on its way into the document, so the reduction over the
+    admitted set cannot exceed the override. Asserting it closes the loop: a
+    stamp higher than its own ceiling would mean content entered the report
+    that the ceiling excluded, and a stamp lower than the admitted maximum
+    would under-report the artifact's sensitivity and hand it to a reader who
+    should have been refused.
+
+    Args:
+        ceiling: The ceiling the render runs under.
+        canary_vault: The shared per-section canary vault.
+    """
+    from creek.classify.privacy_filter import tier_within_override
+
+    state_render_tool(vault_path=canary_vault, privacy_tier_ceiling=ceiling)
+    stamp = _stamp(canary_vault)
+    stamped = PrivacyTier(str(stamp[_STAMP_TIER_KEY]))
+    override = to_privacy_override(ceiling)
+    assert tier_within_override(stamped, override), (
+        f"a render at privacy_tier_ceiling={ceiling.value} stamped "
+        f"{stamped.value!r}, a tier that ceiling does not admit. The stamp is "
+        "a reduction over content that already cleared the ceiling, so this "
+        "can only mean something entered the report ungated."
+    )
+
+
+def test_broad_render_over_an_open_corpus_stamps_open(tmp_path: Path) -> None:
+    """``ceiling=all`` over a corpus with nothing above ``open`` stamps ``open``.
+
+    This is the property that makes comparing the *stamp* strictly better than
+    comparing the render ceiling, and it is load-bearing rather than incidental.
+    A report rendered at ``ceiling=all`` over a vault whose content is all
+    ``open`` contains nothing above ``open``; refusing it to an ``open``-ceiling
+    caller because of *how it was produced* would make the artifact unreadable
+    for no reason and push every caller towards re-rendering.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = _build_open_only_vault(tmp_path)
+    state_render_tool(vault_path=vault, privacy_tier_ceiling=TierCeiling.ALL)
+    assert _stamp(vault)[_STAMP_TIER_KEY] == PrivacyTier.OPEN.value, (
+        "an all-ceiling render over an all-open corpus must stamp 'open'; it "
+        f"stamped {_stamp(vault).get(_STAMP_TIER_KEY)!r}. Stamping the "
+        "*ceiling* rather than the admitted maximum makes a broad render "
+        "unreadable at a narrow ceiling for no reason."
+    )
+    served = state_read_tool(vault_path=vault, privacy_tier_ceiling=TierCeiling.OPEN)
+    assert served["status"] == "ok"
+
+
+def test_fresh_vault_report_stamps_open_not_intimate(tmp_path: Path) -> None:
+    """An empty vault's report stamps ``open`` — the ``default=OPEN`` decision.
+
+    This is the one place the stamp's reduction deliberately diverges from
+    ``creek.classify.privacy_filter.max_source_tier``, whose empty case is
+    ``INTIMATE``. The two empties mean different things. ``max_source_tier``'s
+    means "we asked for fragments and got none, so we do not know what the call
+    would carry" — absence of knowledge. Here it means "the rendered document
+    contains no tiered content" — knowledge. Stamping a fresh vault's report
+    ``intimate`` would make it unreadable at every ceiling below ``intimate``,
+    which is exactly what #969's recoverability criterion forbids.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = tmp_path / "fresh-vault"
+    _seed_dirs(vault)
+    state_render_tool(vault_path=vault, privacy_tier_ceiling=TierCeiling.OPEN)
+    assert _stamp(vault)[_STAMP_TIER_KEY] == PrivacyTier.OPEN.value, (
+        "a report over a vault with no tiered content must stamp 'open'. "
+        "Failing closed here would make a freshly-initialised vault's report "
+        "unreadable at the default ceiling, i.e. an outage on first run."
+    )
+    served = state_read_tool(vault_path=vault, privacy_tier_ceiling=TierCeiling.OPEN)
+    assert served["status"] == "ok", (
+        "a fresh vault's report is unreadable at the default ceiling, which is "
+        "an outage on first run rather than a privacy gate"
+    )
+
+
+def test_latest_md_carries_the_same_stamp_as_the_iso_week_file(
+    canary_vault: Path,
+) -> None:
+    """The symlinked ``latest.md`` and the ISO-week file stamp identically.
+
+    ``latest.md`` is the documented session-start context, so it is the file
+    almost every reader actually opens. A stamp that lived only on the
+    ISO-week file would leave the read gate looking at an unstamped artifact
+    and refusing everything.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert _stamp(canary_vault, _latest_file(canary_vault)) == _stamp(canary_vault)
+
+
+def _assert_latest_is_a_stamped_copy(vault: Path) -> None:
+    """Assert ``latest.md`` is a real file carrying the ISO-week file's stamp.
+
+    Shared by the two copy-fallback tests below, which reach the same branch of
+    ``_refresh_latest`` through two different triggers.
+
+    Args:
+        vault: Vault root, already rendered into.
+    """
+    latest = _latest_file(vault)
+    week = _iso_week_file(vault)
+    assert not latest.is_symlink(), (
+        "the copy fallback was not taken, so this test is asserting about the "
+        "symlink branch and the copy branch is unexercised"
+    )
+    assert _stamp(vault, latest) == _stamp(vault, week), (
+        "latest.md lost its stamp on the copy path. latest.md is the "
+        "documented session-start context and the file almost every reader "
+        "opens; an unstamped copy there means the read gate sees a legacy "
+        "artifact and refuses everything."
+    )
+    assert latest.read_text(encoding="utf-8") == week.read_text(encoding="utf-8")
+
+
+def test_latest_md_copy_fallback_on_windows_carries_the_stamp(
+    canary_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``os.name == "nt"`` skips the symlink and copies — with the stamp intact.
+
+    Windows lacks an unprivileged symlink path for non-developers, so
+    ``_refresh_latest`` never attempts one there. The copy writes ``latest.md``
+    as an independent file, which makes it the branch where a stamp could
+    plausibly be lost — and the branch every Windows operator is permanently
+    on, so a loss there is not an edge case for them.
+
+    The render runs **before** ``os.name`` is patched, and only
+    ``_refresh_latest`` is re-entered under the patch. Patching ``os.name`` is
+    not a local edit: there is one ``os`` module object, and
+    ``pathlib.Path(...)`` dispatches on ``os.name`` to choose ``PosixPath`` or
+    ``WindowsPath``. Holding the patch across the render therefore makes every
+    ``Path`` built from a string during it a ``WindowsPath`` on a POSIX host —
+    which blows up ``_vault_relative``'s ``relative_to`` against a POSIX vault
+    root, in a way that says nothing about either Windows or the stamp. Scoping
+    the patch to the one function whose ``os.name`` check is under test keeps
+    the failure this asserts about the copy branch.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+        monkeypatch: pytest's patching fixture.
+    """
+    written = state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    state_dir = canary_vault / "00-Creek-Meta" / "State"
+    target = canary_vault / str(written["report_path"])
+    monkeypatch.setattr("creek.generate.state.os.name", "nt")
+    _refresh_latest(state_dir, target)
+    _assert_latest_is_a_stamped_copy(canary_vault)
+
+
+def test_latest_md_copy_fallback_on_symlink_error_carries_the_stamp(
+    canary_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A filesystem that rejects symlinks falls through to the same stamped copy.
+
+    The second trigger for the copy branch, and a distinct one: some networked
+    filesystems accept the ``os.name`` check and then reject
+    ``Path.symlink_to`` with ``EPERM``. Exercised separately because the
+    Windows test never reaches the ``try`` block at all, so it cannot show that
+    the ``except OSError`` path also stamps.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+        monkeypatch: pytest's patching fixture.
+    """
+
+    def _refuse_symlink(self: Path, target: str | Path) -> None:
+        """Raise as a symlink-hostile filesystem would.
+
+        Args:
+            self: The link path being created.
+            target: The link target.
+
+        Raises:
+            OSError: Always.
+        """
+        msg = "symlink refused (test)"
+        raise OSError(msg)
+
+    monkeypatch.setattr(Path, "symlink_to", _refuse_symlink)
+    state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    _assert_latest_is_a_stamped_copy(canary_vault)
+
+
+# ---------------------------------------------------------------------------
+# T3 — ``creek.state.read`` refuses, and the refusal discloses nothing
+# ---------------------------------------------------------------------------
+
+
+def _write_latest(vault: Path, text: str) -> Path:
+    """Hand-write ``latest.md`` verbatim, bypassing the generator.
+
+    Used for the legacy and malformed-stamp cases, which by definition cannot
+    be produced by the fixed writer.
+
+    Args:
+        vault: Vault root.
+        text: Exact bytes to write.
+
+    Returns:
+        The path written.
+    """
+    target = _latest_file(vault)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text, encoding="utf-8")
+    return target
+
+
+def _stamped_latest(vault: Path, tier_value: object) -> Path:
+    """Write a ``latest.md`` stamped with an arbitrary ``privacy_tier`` value.
+
+    The value is written straight into the YAML, so a list, a mapping or a
+    ``None`` reaches the reader exactly as a hand-edited vault note would.
+
+    Args:
+        vault: Vault root.
+        tier_value: Whatever the ``privacy_tier`` key should hold.
+
+    Returns:
+        The path written.
+    """
+    metadata: dict[str, Any] = {
+        _STAMP_TYPE_KEY: _STAMP_TYPE_VALUE,
+        _STAMP_TIER_KEY: tier_value,
+        _STAMP_CEILING_KEY: "all",
+    }
+    post = frontmatter.Post(content="# Creek state\n\nbody\n", **metadata)
+    return _write_latest(vault, frontmatter.dumps(post))
+
+
+def test_state_read_refuses_an_above_ceiling_stamp_with_the_canonical_payload(
+    canary_vault: Path,
+) -> None:
+    """A stamped-``intimate`` report is refused at ``open``: four keys, no more.
+
+    ``creek.state.read`` **refuses** rather than excludes, and the asymmetry
+    with ``creek.state.render`` is deliberate. Read's target is one atomic
+    cached artifact: there is nothing to partially admit, because you cannot
+    exclude half a rendered markdown document without re-rendering it — and
+    re-rendering is what ``render`` is. Render names no target at all; it is a
+    corpus walk like ``report``/``wheel``/``mine``, and refusing it would make
+    the report unreachable, which is #968's explicit anti-goal.
+
+    The payload is compared for equality against
+    :func:`~creek_mcp.tier_ceiling.refusal_response` rather than key by key, so
+    an extra key added "for debugging" fails here. Every extra key on a refusal
+    is derived from content the caller was not admitted to.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    response = state_read_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert response == refusal_response(
+        tool="creek.state.read",
+        ceiling=TierCeiling.OPEN,
+        reason=GENERIC_ABOVE_CEILING_REASON,
+    )
+    serialised = json.dumps(response, default=str)
+    for canary in _ALL_INTIMATE_CANARIES:
+        assert canary not in serialised, (
+            f"creek.state.read returned the above-ceiling sentinel {canary!r} "
+            f"at privacy_tier_ceiling=open:\n\n{serialised}"
+        )
+
+
+@pytest.mark.parametrize(
+    "stamped",
+    ["personal", "intimate", "unclassified"],
+    ids=["personal", "intimate", "unclassified"],
+)
+def test_refusal_is_byte_identical_for_every_above_ceiling_stamp(
+    stamped: str,
+    tmp_path: Path,
+) -> None:
+    """The refusal must not rank the content the caller was refused.
+
+    A reason, a key, or even a difference in whitespace that varied with the
+    stamped tier would turn every refusal into a tier-classification oracle
+    over the artifact: a caller could learn "the report contains intimate
+    content" without being admitted to a word of it. So the refusal is asserted
+    byte-identical across every above-ceiling stamp at the same ceiling, and
+    the three tier words are asserted absent from the serialised payload
+    entirely at ``ceiling=open``, where none of them is the caller's own echo.
+
+    Args:
+        stamped: The tier stamped on ``latest.md``.
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = tmp_path / f"oracle-{stamped}"
+    _seed_dirs(vault)
+    _stamped_latest(vault, stamped)
+
+    response = state_read_tool(
+        vault_path=vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert response["status"] == "refused"
+    assert response["reason"] == GENERIC_ABOVE_CEILING_REASON
+    assert response == refusal_response(
+        tool="creek.state.read",
+        ceiling=TierCeiling.OPEN,
+        reason=GENERIC_ABOVE_CEILING_REASON,
+    ), (
+        f"the refusal for a report stamped {stamped!r} differs from the "
+        "canonical payload, so the refusal itself ranks the content the "
+        "caller was not admitted to"
+    )
+
+    serialised = json.dumps(response, default=str, sort_keys=True)
+    for word in ("personal", "intimate", "unclassified"):
+        assert word not in serialised, (
+            f"the refusal payload names the tier word {word!r} at "
+            f"privacy_tier_ceiling=open, where the caller's own echoed "
+            f"ceiling is 'open'. That is a tier oracle:\n\n{serialised}"
+        )
+
+
+def test_refusals_at_a_personal_ceiling_are_identical_across_stamps(
+    tmp_path: Path,
+) -> None:
+    """At ``ceiling=personal`` the echo is legitimate; identity is the real claim.
+
+    The word ``"personal"`` appears in this refusal because the caller supplied
+    it, so the absence check used at ``ceiling=open`` cannot be applied here.
+    What still can be — and is the stronger statement anyway — is that the
+    refusal for an ``intimate`` stamp is byte-identical to the refusal for an
+    unstamped legacy report. If the two differed, a caller could distinguish
+    "the report holds intimate content" from "the report predates the stamp"
+    without being admitted to either.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    stamped_vault = tmp_path / "personal-stamped"
+    _seed_dirs(stamped_vault)
+    _stamped_latest(stamped_vault, "intimate")
+
+    legacy_vault = tmp_path / "personal-legacy"
+    _seed_dirs(legacy_vault)
+    _write_latest(legacy_vault, "# Audit report\n\n- Fragments: 1\n")
+
+    stamped = state_read_tool(
+        vault_path=stamped_vault,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    legacy = state_read_tool(
+        vault_path=legacy_vault,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert stamped["status"] == "refused"
+    assert json.dumps(stamped, default=str, sort_keys=True) == json.dumps(
+        legacy,
+        default=str,
+        sort_keys=True,
+    ), (
+        "an above-ceiling refusal and a legacy-unstamped refusal are "
+        "distinguishable, so the pair discloses whether the vault holds "
+        "above-ceiling content"
+    )
+
+
+@pytest.mark.parametrize("ceiling", _CEILINGS, ids=[c.value for c in _CEILINGS])
+def test_legacy_unstamped_report_fails_closed(
+    ceiling: TierCeiling,
+    tmp_path: Path,
+) -> None:
+    """An unstamped ``latest.md`` is refused below ``intimate`` and served at or above.
+
+    This is *accurate* rather than merely conservative. Every ``latest.md``
+    written before #969 was rendered completely unfiltered — the equivalent of
+    ``--include-tier all`` — so ``raw_privacy_tier({}) -> INTIMATE`` states a
+    fact about those bytes rather than a precaution about them.
+
+    The upgrade path is one command and costs nothing: ``creek.state.render``
+    re-renders and re-stamps at the caller's ceiling, or ``creek state
+    --include-tier open`` does the same from the CLI. The ISO-week archive is
+    untouched either way.
+
+    Args:
+        ceiling: The caller's declared ceiling.
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = tmp_path / f"legacy-{ceiling.value}"
+    _seed_dirs(vault)
+    _write_latest(vault, "# Audit report\n\nVault summary lives here.\n")
+
+    response = state_read_tool(vault_path=vault, privacy_tier_ceiling=ceiling)
+    if ceiling in _ADMITS_INTIMATE:
+        assert response["status"] == "ok", (
+            f"an unstamped legacy report must be served at ceiling="
+            f"{ceiling.value}, which admits intimate content. Refusing it "
+            "there would make the report permanently unreachable."
+        )
+        assert "Vault summary lives here." in response["content"]
+    else:
+        assert response["status"] == "refused", (
+            f"an unstamped legacy report was served at ceiling={ceiling.value}. "
+            "Those bytes were rendered completely unfiltered, so serving them "
+            "below ceiling=intimate hands out whatever the vault held."
+        )
+        assert response["reason"] == GENERIC_ABOVE_CEILING_REASON
+
+
+@pytest.mark.parametrize(
+    ("tier_value", "admitted_at_open"),
+    [
+        pytest.param("not-a-tier", False, id="unrecognised"),
+        pytest.param("", False, id="empty"),
+        pytest.param(None, False, id="none"),
+        pytest.param(["open"], False, id="list"),
+        pytest.param({"tier": "open"}, False, id="mapping"),
+        pytest.param(0, False, id="int"),
+        pytest.param(False, False, id="bool"),
+        pytest.param("OPEN", False, id="uppercase"),
+        pytest.param(" open", False, id="padded"),
+        pytest.param("open", True, id="open"),
+    ],
+)
+def test_unreadable_stamp_values_fail_closed(
+    tier_value: object,
+    admitted_at_open: bool,
+    tmp_path: Path,
+) -> None:
+    """Every ``privacy_tier`` the reader cannot parse lands on ``intimate``.
+
+    Mirrors ``raw_privacy_tier``'s pinned rows in
+    ``tests/test_mcp_report_tier_ceiling.py`` deliberately, because the read
+    gate must *be* that reader rather than resemble it. The rows that bite are
+    the non-string ones: YAML front matter is operator-editable, and a
+    one-character slip (``privacy_tier:`` followed by an indented ``- open``)
+    produces ``["open"]``, which must fail closed rather than be talked into
+    ``open`` by some future normalisation. Casing and padding are not silently
+    repaired either — guessing what an operator meant is how a gate becomes
+    negotiable.
+
+    Args:
+        tier_value: The value written into the stamp.
+        admitted_at_open: Whether the reader must admit it at ``ceiling=open``.
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = tmp_path / "stamp-shapes"
+    _seed_dirs(vault)
+    _stamped_latest(vault, tier_value)
+
+    response = state_read_tool(
+        vault_path=vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    expected = "ok" if admitted_at_open else "refused"
+    assert response["status"] == expected, (
+        f"a report stamped privacy_tier={tier_value!r} was {response['status']!r} "
+        f"at ceiling=open; expected {expected!r}. A tier nobody can read is a "
+        "tier nobody has vouched for."
+    )
+
+
+def test_missing_report_is_empty_not_refused(tmp_path: Path) -> None:
+    """A fresh vault with no report stays usable, and discloses nothing either way.
+
+    A *missing* report is not a refusal: there is no content to be above the
+    ceiling, and answering ``refused`` there would be a vault-emptiness oracle
+    in the other direction — a caller could distinguish "you may not read this"
+    from "there is nothing to read" only by the absence of that distinction.
+    Keeping the ``empty`` branch is also what stops a first run of CrawDad or
+    ``/creek`` looking like a permissions failure.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = tmp_path / "no-report"
+    _seed_dirs(vault)
+    response = state_read_tool(
+        vault_path=vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert response["status"] == "empty"
+    assert response["content"] == ""
+
+
+# ---------------------------------------------------------------------------
+# T4 — recoverability, executed rather than read off a comparator
+# ---------------------------------------------------------------------------
+
+
+def test_render_at_all_then_read_at_all_returns_the_content(
+    canary_vault: Path,
+) -> None:
+    """The broad path works end to end: render at ``all``, read at ``all``.
+
+    The first leg of #969's recoverability criterion. Without it the refusal
+    tests above would be satisfied by a read gate that refused everything.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(vault_path=canary_vault, privacy_tier_ceiling=TierCeiling.ALL)
+    response = state_read_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert response["status"] == "ok"
+    assert _LIMINAL_INTIMATE in response["content"], (
+        "a read at ceiling=all returned a report with no above-ceiling content "
+        "in it, so the refusal at ceiling=open proves nothing about the gate"
+    )
+
+
+def test_the_same_artifact_read_at_open_is_refused_then_recovers_on_re_render(
+    canary_vault: Path,
+) -> None:
+    """One artifact, two ceilings, one command to recover — executed, not described.
+
+    The whole sequence runs for real:
+
+    1. render at ``ceiling=all`` → the artifact genuinely holds intimate content;
+    2. read at ``ceiling=open`` → refused, because the stamp says so;
+    3. render at ``ceiling=open`` → the artifact is re-rendered and re-stamped;
+    4. read at ``ceiling=open`` → ``ok``, and canary-free.
+
+    Step 3 is the documented recovery, and step 4 is the proof it works.
+    ``latest.md`` is a single slot shared across ceilings — kept single
+    deliberately, because per-ceiling filenames would multiply artifacts in the
+    operator's vault and break ``latest.md`` as the documented session-start
+    context — so the ``all`` caller's richer report is replaced here. That is
+    the cache-thrash consequence, stated on the tin and exercised.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(vault_path=canary_vault, privacy_tier_ceiling=TierCeiling.ALL)
+    refused = state_read_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert refused["status"] == "refused"
+
+    state_render_tool(vault_path=canary_vault, privacy_tier_ceiling=TierCeiling.OPEN)
+    recovered = state_read_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert recovered["status"] == "ok", (
+        "re-rendering at ceiling=open did not make the report readable at "
+        "ceiling=open, so the refusal above is not recoverable and the gate "
+        "has made the artifact unreachable"
+    )
+    for canary in _ALL_INTIMATE_CANARIES:
+        assert canary not in recovered["content"], (
+            f"the re-rendered open report still carries {canary!r}"
+        )
+    assert _DRIFT_OPEN in recovered["content"], (
+        "the re-rendered open report carries no admitted content at all, so "
+        "'recovered' means 'empty'"
+    )
+
+
+@pytest.mark.parametrize("ceiling", _CEILINGS, ids=[c.value for c in _CEILINGS])
+def test_no_render_ceiling_makes_the_report_permanently_unreachable(
+    ceiling: TierCeiling,
+    canary_vault: Path,
+) -> None:
+    """After a render at *any* ceiling, a read at ``ceiling=all`` is always ``ok``.
+
+    The safety net under every other gate in this file. ``ALL`` admits every
+    stamp, including the legacy unstamped one, so there is no sequence of calls
+    that can leave an operator locked out of their own report. If a future
+    change ever makes this fail, the gate has stopped being a filter and
+    started being a wall.
+
+    Args:
+        ceiling: The ceiling the render runs under.
+        canary_vault: The shared per-section canary vault.
+    """
+    state_render_tool(vault_path=canary_vault, privacy_tier_ceiling=ceiling)
+    response = state_read_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert response["status"] == "ok", (
+        f"a report rendered at privacy_tier_ceiling={ceiling.value} is not "
+        "readable even at ceiling=all. No render may make the report "
+        "permanently unreachable."
+    )
+    assert "# Creek state" in response["content"]
+
+
+# ---------------------------------------------------------------------------
+# T5 — mutation resistance
+# ---------------------------------------------------------------------------
+
+
+class _InvertingPredicate:
+    """A tier predicate stand-in that returns the opposite verdict.
+
+    Wraps the real predicate and negates it, counting calls. Two distinct
+    mutations die against it:
+
+    * a section that *calls* the gate and discards its result is unaffected by
+      inversion, so its artifact still holds the below-ceiling content and the
+      inverted expectation fails;
+    * a section that stopped calling the gate leaves ``call_count`` at zero.
+
+    Takes ``*args``/``**kwargs`` so one class covers both
+    ``within_ceiling(raw, override)`` and ``tier_within_override(tier,
+    override)``, and so a keyword call site is not silently missed.
+
+    Attributes:
+        call_count: How many times the predicate was invoked.
+    """
+
+    def __init__(self, real: Any) -> None:
+        """Store the real predicate and zero the counter.
+
+        Args:
+            real: The genuine predicate this stands in for.
+        """
+        self._real = real
+        self.call_count = 0
+
+    def __call__(self, *args: Any, **kwargs: Any) -> bool:
+        """Return the negation of the real verdict.
+
+        Args:
+            *args: Positional arguments forwarded verbatim.
+            **kwargs: Keyword arguments forwarded verbatim.
+
+        Returns:
+            ``not real(*args, **kwargs)``.
+        """
+        self.call_count += 1
+        return not self._real(*args, **kwargs)
+
+
+def _import_optional(dotted: str) -> ModuleType | None:
+    """Import *dotted*, returning ``None`` when the module does not exist yet.
+
+    ``creek.generate.state_tiers`` is created by #969. Treating its absence as
+    "not a binding site" rather than as an error keeps the mutation tests
+    failing on the behaviour they describe instead of on the module layout.
+
+    Args:
+        dotted: Dotted module path.
+
+    Returns:
+        The module, or ``None``.
+    """
+    try:
+        return importlib.import_module(dotted)
+    except ModuleNotFoundError:
+        return None
+
+
+def _patch_state_predicate(
+    monkeypatch: pytest.MonkeyPatch,
+    symbol: str,
+) -> tuple[_InvertingPredicate, list[str]]:
+    """Replace *symbol* with an inverting stand-in in every state module holding it.
+
+    A ``from ... import within_ceiling`` binds the callable in the *importing*
+    module's namespace, so patching ``creek.classify.privacy_filter`` would
+    change nothing the state generator can see. Patching every state-side
+    binding — and reporting which ones were found — is what makes this test
+    independent of whether #969 puts the call in ``state.py`` or
+    ``state_tiers.py``, while still failing loudly if it is in neither.
+
+    Args:
+        monkeypatch: pytest's patching fixture.
+        symbol: The predicate name to replace.
+
+    Returns:
+        The shared spy and the dotted paths it was installed into.
+    """
+    real: Any = None
+    for dotted in _STATE_MODULES:
+        module = _import_optional(dotted)
+        if module is not None and hasattr(module, symbol):
+            real = getattr(module, symbol)
+            break
+    spy = _InvertingPredicate(real)
+    patched: list[str] = []
+    for dotted in _STATE_MODULES:
+        module = _import_optional(dotted)
+        if module is not None and hasattr(module, symbol):
+            monkeypatch.setattr(module, symbol, spy)
+            patched.append(dotted)
+    return spy, patched
+
+
+_MUTATION_ROWS = [
+    pytest.param(
+        "within_ceiling",
+        _LIMINAL_INTIMATE,
+        _LIMINAL_OPEN,
+        "## Liminal Watch",
+        id="within_ceiling-liminal",
+    ),
+    pytest.param(
+        "within_ceiling",
+        _DRIFT_INTIMATE,
+        _DRIFT_OPEN,
+        "## Drift warnings",
+        id="within_ceiling-drift",
+    ),
+    pytest.param(
+        "tier_within_override",
+        _EDDY_INTIMATE,
+        _EDDY_OPEN,
+        "## Active eddies",
+        id="tier_within_override-eddies",
+    ),
+    pytest.param(
+        "tier_within_override",
+        _THREAD_INTIMATE,
+        _THREAD_OPEN,
+        "## Active threads",
+        id="tier_within_override-threads",
+    ),
+]
+"""``(predicate, above canary, below canary, section)`` rows for the inversion test.
+
+Two predicates, because #969 gates two different shapes of thing.
+``within_ceiling`` reads a note's *raw front matter* and is what the liminal
+notes and the fragment admission behind drift warnings reduce to.
+``tier_within_override`` takes an already-resolved tier and is what the
+*derived* eddy/thread tiers — reduced with ``max_source_tier`` over their
+member fragments — must be cut off against, since neither model carries a
+``privacy_tier`` field of its own.
+"""
+
+
+@pytest.mark.parametrize(
+    ("symbol", "above_canary", "below_canary", "section"),
+    _MUTATION_ROWS,
+)
+def test_state_sections_act_on_the_gate_verdict_not_just_call_it(
+    symbol: str,
+    above_canary: str,
+    below_canary: str,
+    section: str,
+    canary_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inverting the gate must invert the artifact.
+
+    Everything else in this file is satisfied by a section that invokes the
+    gate on the request path and then ignores what it said — the call site
+    exists, the import exists, an AST walk finds it, and the artifact is
+    whatever it always was. Only replacing the predicate with one that answers
+    *backwards* can tell "consulted" from "obeyed".
+
+    Three failures are distinguished, each with its own message: the predicate
+    was never bound in a state module at all; it was bound but never called; or
+    it was called and its verdict discarded.
+
+    Args:
+        symbol: The predicate name to invert.
+        above_canary: The sentinel that must *appear* once the gate is inverted.
+        below_canary: The sentinel that must *vanish* once the gate is inverted.
+        section: The section whose rows carry those sentinels.
+        canary_vault: The shared per-section canary vault.
+        monkeypatch: pytest's patching fixture.
+    """
+    spy, patched = _patch_state_predicate(monkeypatch, symbol)
+    assert patched, (
+        f"no module in {list(_STATE_MODULES)} binds {symbol!r}, so {section} "
+        "cannot be gated by it. Import the predicate into the module that owns "
+        "the section's admission decision."
+    )
+
+    state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    text = _artifact_text(canary_vault)
+
+    assert spy.call_count > 0, (
+        f"{symbol} was never called while rendering {section} at ceiling=open, "
+        f"even though it is bound in {patched}. A gate off the request path "
+        "enforces nothing."
+    )
+    assert above_canary in text, (
+        f"inverting {symbol} did not change what {section} wrote: "
+        f"{above_canary!r} is still absent from the artifact. The section "
+        "calls the gate and discards its verdict.\n\n"
+        f"{text}"
+    )
+    assert below_canary not in text, (
+        f"inverting {symbol} left {below_canary!r} in {section}, so the "
+        "verdict is not what decides admission there.\n\n"
+        f"{text}"
+    )
+
+
+def test_no_file_the_render_touches_carries_above_ceiling_content(
+    canary_vault: Path,
+) -> None:
+    """Every file the call created or modified is swept, not a named list.
+
+    The artifact-level tests above look where we already know to look. This one
+    derives its file list from the filesystem — everything whose bytes differ
+    from a pre-call snapshot — so it also covers an artifact nobody anticipated,
+    a cache, a debug dump, and a second ungated walk spliced in next to a
+    still-present, still-called gate whose declared output looks unchanged.
+    That last case is the one the structural layers of
+    ``tests/test_mcp_read_gate.py`` provably cannot see.
+
+    Paths are checked as well as contents because the drift sentinel rides in a
+    filename: a bytes-only sweep would walk straight past a file *named* after
+    an above-ceiling fragment.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    before = _snapshot(canary_vault)
+    state_render_tool(
+        vault_path=canary_vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    changed = _changed_files(canary_vault, before)
+    assert changed, (
+        "creek.state.render changed no file at all, so this sweep has nothing "
+        "to sweep and every assertion below it is vacuous"
+    )
+
+    for path in changed:
+        rel = str(path.relative_to(canary_vault))
+        for canary in _ALL_INTIMATE_CANARIES:
+            assert canary not in rel, (
+                f"creek.state.render created {rel!r} at ceiling=open — the "
+                f"above-ceiling sentinel {canary!r} is in the file name."
+            )
+            assert canary.encode("utf-8") not in path.read_bytes(), (
+                f"creek.state.render wrote the above-ceiling sentinel "
+                f"{canary!r} into {rel!r} at ceiling=open. This file was found "
+                "by diffing the vault, not from a list of expected artifacts, "
+                "so a second ungated read cannot hide behind an unchanged "
+                "declared output."
+            )
+
+    text = _artifact_text(canary_vault)
+    for canary in _ALL_OPEN_CANARIES:
+        assert canary in text, (
+            f"the admitted sentinel {canary!r} is missing from the report, so "
+            "the sweep above passed on an empty artifact"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T6 — the generator's own override keyword, and the CLI flag
+# ---------------------------------------------------------------------------
+
+
+def test_generator_defaults_to_an_unfiltered_render(canary_vault: Path) -> None:
+    """``StateReportGenerator`` with no ``override`` renders everything.
+
+    The default is ``PrivacyTierOverride.ALL`` because the library's existing
+    callers — and the CLI operator, who is the vault owner — get today's
+    behaviour unless they ask to narrow it. That matches every other
+    ``--include-tier`` surface in the CLI, whose help text already says
+    "Omitting the flag leaves the scan unfiltered ... this flag NARROWS what
+    the generated artifact may contain."
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    StateReportGenerator(vault_path=canary_vault).write()
+    text = _artifact_text(canary_vault)
+    for canary in _ALL_INTIMATE_CANARIES:
+        assert canary in text, (
+            f"an override-less render dropped {canary!r}. The default must be "
+            "unfiltered, or #969 silently narrows every existing caller."
+        )
+
+
+def test_generator_override_keyword_narrows_the_render(canary_vault: Path) -> None:
+    """``StateReportGenerator(override=OPEN)`` is the CLI's and the tool's one lever.
+
+    Both ``creek state --include-tier`` and ``creek_mcp.tools.state`` reach the
+    ceiling through this keyword, so it is pinned directly rather than only
+    through its two callers — a signature change that broke one of them would
+    otherwise show up as a confusing failure in the other.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    from creek.classify.privacy_filter import PrivacyTierOverride
+
+    StateReportGenerator(
+        vault_path=canary_vault,
+        override=PrivacyTierOverride.OPEN,
+    ).write()
+    text = _artifact_text(canary_vault)
+    for canary in _ALL_INTIMATE_CANARIES:
+        assert canary not in text, (
+            f"StateReportGenerator(override=OPEN) wrote {canary!r} into the "
+            f"artifact:\n\n{text}"
+        )
+    assert _DRIFT_OPEN in text, (
+        "the narrowed render dropped admitted content too, so the exclusion "
+        "assertions above are satisfied by an outage"
+    )
+
+
+def test_cli_state_rejects_an_unknown_include_tier(canary_vault: Path) -> None:
+    """A bogus ``--include-tier`` value exits 2 rather than falling back.
+
+    Matches ``_parse_include_tier``'s behaviour on every other generation
+    surface. Falling back to a default on an unparsable value is how a typo
+    (``--include-tier itimate``) silently becomes a broader render than the
+    operator asked for — or a narrower one they did not notice.
+
+    The *message* is asserted, not just the exit code, and that is the point:
+    a CLI that has never heard of ``--include-tier`` also exits 2, with Click's
+    "No such option". Requiring the rejected value **and** the canonical option
+    list in the output is what separates "the flag exists and refused this
+    word" from "the flag does not exist", so this test cannot go green on a
+    build where nothing was implemented.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    result = runner.invoke(
+        app,
+        ["state", "--vault", str(canary_vault), "--include-tier", "leaky"],
+    )
+    assert result.exit_code == 2, result.output
+    plain = _plain(result.output)
+    assert "leaky" in plain, (
+        "creek state exited 2 without naming the value it rejected, which is "
+        "what Click prints when the option does not exist at all: "
+        f"{plain!r}"
+    )
+    for member in ("open", "personal", "intimate", "all"):
+        assert member in plain, (
+            f"the rejection message does not offer {member!r} as a valid "
+            f"--include-tier value: {plain!r}"
+        )
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["open", "personal", "intimate", "all"],
+)
+def test_cli_state_accepts_every_override_value(value: str, tmp_path: Path) -> None:
+    """``--include-tier`` takes the same four words as every other surface.
+
+    The four values mirror :class:`~creek.classify.privacy_filter.PrivacyTierOverride`
+    exactly, so the CLI and the MCP ceiling stay in lock-step; a surface that
+    accepted three of them would make ``creek state`` the odd one out and
+    invite a per-command mental model.
+
+    Args:
+        value: The ``--include-tier`` value under test.
+        tmp_path: pytest's per-test temporary directory.
+    """
+    vault = _build_canary_vault(tmp_path, name=f"cli-{value}")
+    result = runner.invoke(
+        app,
+        ["state", "--vault", str(vault), "--include-tier", value],
+    )
+    assert result.exit_code == 0, result.output
+    assert _iso_week_file(vault).exists()
+
+
+def test_cli_state_include_tier_open_excludes_above_ceiling_content(
+    canary_vault: Path,
+) -> None:
+    """``creek state --include-tier open`` narrows the artifact it writes.
+
+    The CLI is the documented recovery path for an operator whose ``latest.md``
+    predates the stamp, so it has to produce a genuinely open report rather
+    than an open-stamped copy of an unfiltered one.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    result = runner.invoke(
+        app,
+        ["state", "--vault", str(canary_vault), "--include-tier", "open"],
+    )
+    assert result.exit_code == 0, result.output
+    text = _artifact_text(canary_vault)
+    for canary in _ALL_INTIMATE_CANARIES:
+        assert canary not in text, (
+            f"creek state --include-tier open wrote {canary!r} into "
+            f"00-Creek-Meta/State:\n\n{text}"
+        )
+    assert _DRIFT_OPEN in text
+
+
+def test_cli_state_without_include_tier_stays_unfiltered(canary_vault: Path) -> None:
+    """Omitting the flag preserves today's output, byte for byte in intent.
+
+    ``creek state`` has always rendered the whole vault, and the operator
+    running it is the vault owner. Silently narrowing the default would change
+    what an existing script produces without anybody asking for it — and would
+    make this issue a behaviour regression wearing a privacy fix's costume.
+
+    Args:
+        canary_vault: The shared per-section canary vault.
+    """
+    result = runner.invoke(app, ["state", "--vault", str(canary_vault)])
+    assert result.exit_code == 0, result.output
+    text = _artifact_text(canary_vault)
+    for canary in _ALL_INTIMATE_CANARIES:
+        assert canary in text, (
+            f"creek state with no --include-tier dropped {canary!r}; the "
+            "default must leave the render unfiltered"
+        )
+
+
+def test_cli_state_help_mentions_include_tier() -> None:
+    """``creek state --help`` advertises the flag.
+
+    A gate the operator cannot discover is a gate they will not use, and this
+    flag is half of the documented upgrade path for a pre-#969 ``latest.md``.
+    """
+    result = runner.invoke(app, ["state", "--help"])
+    assert result.exit_code == 0
+    assert "--include-tier" in _plain(result.output)
+
+
+# ---------------------------------------------------------------------------
+# T7 — three leaks the Gate-2.5 review of #969 found after T1-T6 were green
+#
+# Every one of them travels a path the tables above provably cannot reach, so
+# each is written here as a standalone test over its own vault rather than as a
+# row of _SECTIONS. The specific reason a row would not work is recorded on the
+# test that replaces it; in outline:
+#
+# * the hyperedge-span leak needs an eddy with *mixed*-tier membership, and
+#   _build_canary_vault deliberately has none (its comment says so: sharing an
+#   eddy between the two praxis rows "would give each shared eddy one intimate
+#   and one open member");
+# * the mined-thread leak needs a thread over the mining threshold
+#   (``fragment_count > DEFAULT_MIN_THREAD_FRAGMENTS``), i.e. twelve member
+#   fragments, where every fixture thread above has one;
+# * the non-YAML stamp is a property of the artifact's *format*, and the
+#   malformed-stamp parametrisation above varies a *value* underneath a
+#   well-formed YAML stamp.
+#
+# Adding any of those to the shared fixtures would change what every existing
+# row of _SECTIONS asserts, so nothing above this banner is touched.
+# ---------------------------------------------------------------------------
+
+
+# --- Blocker 1: an above-ceiling eddy title riding into ## Hyperedges -------
+
+_SPAN_EDDY_ABOVE = "CANARY-SPANEDDY-INTIMATE-4e6b"
+"""Rides in the ``title`` of an eddy with one ``open`` and one ``intimate`` member.
+
+Its derived tier is the maximum over its members — ``intimate`` — so
+``## Active eddies`` already excludes it at ``ceiling=open`` and has since T1
+went green. That is precisely what made this leak invisible: the sentinel is
+*absent* from the section that owns eddy titles while riding into
+``## Hyperedges`` inside another section's ``spans:`` list, because
+``StateReportGenerator._fragment_to_eddies`` maps each **admitted** fragment to
+every eddy its ``eddies:`` wikilinks name and never intersects that set against
+``self._state.eddies``.
+"""
+
+_SPAN_PRAXIS_BRIDGE = "CANARY-SPANPRAXIS-BRIDGE-1d5f"
+"""Rides in the ``title`` of the praxis whose spanned set carries the leak.
+
+Both of its ``derived_from`` fragments are ``open``, so the praxis itself is
+admitted at ``ceiling=open`` — the leak is not "an above-ceiling praxis was
+rendered" but "an admitted praxis printed an above-ceiling eddy's title".
+"""
+
+_SPAN_PRAXIS_CONTROL = "CANARY-SPANPRAXIS-CONTROL-9a70"
+"""Rides in the ``title`` of a praxis spanning two eddies that are *both* admitted.
+
+The non-vacuity control for the whole section. Without a second row that
+survives at ``ceiling=open``, deleting ``## Hyperedges`` outright — or gating
+the section whole the way ``## Lint summary`` is gated — would satisfy every
+exclusion assertion below while being an outage.
+"""
+
+_SPAN_EDDY_ABOVE_TITLE = f"Eddy-{_SPAN_EDDY_ABOVE}"
+"""Title *and* file stem of the mixed-tier eddy, for :func:`_write_eddy`'s reason."""
+
+_SPAN_EDDY_PLAIN_TITLE = "Eddy-Span-Plain"
+"""The bridge praxis's second, genuinely-``open`` span.
+
+Sentinel-free on purpose: it must appear in the artifact at every ceiling, so a
+canary here would be asserted both present and absent depending on the row
+doing the asserting.
+"""
+
+_SPAN_EDDY_CONTROL_TITLES = ("Eddy-Span-Control-A", "Eddy-Span-Control-B")
+"""The control praxis's two spans, both ``open``-derived and both admitted."""
+
+_SPAN_BRIDGE_TITLE = f"Praxis {_SPAN_PRAXIS_BRIDGE} bridge"
+"""Full praxis title, spelled once so fixture and expected row cannot drift."""
+
+_SPAN_CONTROL_TITLE = f"Praxis {_SPAN_PRAXIS_CONTROL} control"
+"""Full control-praxis title, for the same reason."""
+
+_SPAN_BRIDGE_ROW = (
+    f"- {_SPAN_BRIDGE_TITLE} — spans: "
+    f"{_SPAN_EDDY_ABOVE_TITLE}, {_SPAN_EDDY_PLAIN_TITLE}"
+)
+"""The exact ``## Hyperedges`` row the bridge praxis renders at ``ceiling=all``.
+
+Spelled as the whole row rather than as "the canary appears somewhere" because
+the two halves of this gate fail differently. ``section_hyperedges`` renders
+``f"- {title} — spans: {', '.join(sorted(spanning))}"``, and the sort puts
+``Eddy-C...`` before ``Eddy-S...``, so this string is exact rather than
+order-tolerant. Matching it whole is what distinguishes "the row came back at a
+broad ceiling" from "the praxis title appears in the document".
+"""
+
+_SPAN_CONTROL_ROW = (
+    f"- {_SPAN_CONTROL_TITLE} — spans: "
+    f"{_SPAN_EDDY_CONTROL_TITLES[0]}, {_SPAN_EDDY_CONTROL_TITLES[1]}"
+)
+"""The control praxis's row, which must render identically at *every* ceiling."""
+
+
+def _build_hyperedge_span_vault(root: Path) -> Path:
+    """Build a vault where one hyperedge row spans an above-ceiling eddy.
+
+    Bespoke rather than folded into :func:`_build_canary_vault` because the
+    shape it needs is the one that fixture deliberately avoids. Its hyperedge
+    comment records the choice: the two praxis rows get *disjoint* eddy pairs
+    so that no eddy ends up with one ``intimate`` and one ``open`` member.
+    A mixed-membership eddy is exactly the leak here, so reproducing it inside
+    the shared vault would change what every existing ``_SECTIONS`` row and
+    both ``## Hyperedges`` mutation rows assert.
+
+    The layout, and why each piece is load-bearing:
+
+    * ``frag-span-open-a`` (``open``) and ``frag-span-intimate-b``
+      (``intimate``) both name :data:`_SPAN_EDDY_ABOVE_TITLE`. The eddy's
+      derived tier is therefore ``intimate`` and ``## Active eddies`` drops it
+      at ``ceiling=open`` — but ``frag-span-open-a`` is *admitted*, and it is
+      the admitted fragment that carries the title into the span set.
+    * ``frag-span-open-c`` (``open``) names :data:`_SPAN_EDDY_PLAIN_TITLE`, so
+      the bridge praxis reaches two eddies and clears the ``len(spanning) >= 2``
+      cutoff at ``ceiling=all``. Once the excluded eddy is removed from the set
+      it drops to one, which is why the correct behaviour at ``ceiling=open`` is
+      that the row disappears entirely rather than reappearing with one span.
+    * ``frag-span-open-d`` (``open``) names both control eddies, giving the
+      section a row that must survive at every ceiling.
+
+    Args:
+        root: Directory the vault is created inside (typically ``tmp_path``).
+
+    Returns:
+        The vault root.
+    """
+    vault = root / "hyperedge-span-vault"
+    _seed_dirs(vault)
+    for title in (
+        _SPAN_EDDY_ABOVE_TITLE,
+        _SPAN_EDDY_PLAIN_TITLE,
+        *_SPAN_EDDY_CONTROL_TITLES,
+    ):
+        _write_eddy(vault, title=title)
+    _write_fragment(
+        vault,
+        frag_id="frag-span-open-a",
+        privacy_tier="open",
+        eddies=[f"[[{_SPAN_EDDY_ABOVE_TITLE}]]"],
+    )
+    _write_fragment(
+        vault,
+        frag_id="frag-span-intimate-b",
+        privacy_tier="intimate",
+        eddies=[f"[[{_SPAN_EDDY_ABOVE_TITLE}]]"],
+    )
+    _write_fragment(
+        vault,
+        frag_id="frag-span-open-c",
+        privacy_tier="open",
+        eddies=[f"[[{_SPAN_EDDY_PLAIN_TITLE}]]"],
+    )
+    _write_fragment(
+        vault,
+        frag_id="frag-span-open-d",
+        privacy_tier="open",
+        eddies=[f"[[{title}]]" for title in _SPAN_EDDY_CONTROL_TITLES],
+    )
+    _write_praxis(
+        vault,
+        praxis_id="praxis-span-bridge",
+        title=_SPAN_BRIDGE_TITLE,
+        derived_from=["frag-span-open-a", "frag-span-open-c"],
+    )
+    _write_praxis(
+        vault,
+        praxis_id="praxis-span-control",
+        title=_SPAN_CONTROL_TITLE,
+        derived_from=["frag-span-open-d"],
+    )
+    return vault
+
+
+@pytest.fixture
+def hyperedge_span_vault(tmp_path: Path) -> Path:
+    """Return the mixed-tier-eddy vault built by :func:`_build_hyperedge_span_vault`.
+
+    Function-scoped for the same reason :func:`canary_vault` is: the two tests
+    below render at different ceilings into the single ``latest.md`` slot, so a
+    shared instance would let one test's render decide the other's read.
+    """
+    return _build_hyperedge_span_vault(tmp_path)
+
+
+def test_hyperedges_do_not_span_an_above_ceiling_eddy_title(
+    hyperedge_span_vault: Path,
+) -> None:
+    """An excluded eddy's title must not ride into a ``spans:`` list (#969 review).
+
+    ``StateReportGenerator._fragment_to_eddies`` maps each **admitted**
+    fragment to every eddy its ``eddies:`` wikilinks name, and
+    ``section_hyperedges`` renders those targets verbatim without intersecting
+    them against ``self._state.eddies`` — the ceiling-admitted eddy list. An
+    eddy whose membership is one ``open`` fragment and one ``intimate``
+    fragment derives to ``intimate``, is correctly dropped from
+    ``## Active eddies``, and then has its title printed anyway by a hyperedge
+    row belonging to an admitted praxis. At ``ceiling=open`` the report reads:
+
+        - Praxis ... bridge — spans: Eddy-CANARY-SPANEDDY-INTIMATE-4e6b, ...
+
+    Asserted on the artifact bytes rather than on the envelope, for the reason
+    the module docstring gives: ``creek.state.render`` is a write-side surface
+    and the artifact is what every later reader of the vault sees.
+
+    Two positive controls sit underneath, and both are needed:
+
+    * the **row must be gone entirely**, not merely censored. Once the excluded
+      eddy leaves the span set the bridge praxis spans one admitted eddy, which
+      is below ``section_hyperedges``'s own ``len(spanning) >= 2`` definition of
+      a hyperedge. A row that stayed and printed ``spans: Eddy-Span-Plain``
+      would still disclose, by contradiction with that definition, that a second
+      eddy exists which the caller may not see.
+    * the **control row must still render**, or "no leak" and "no section" are
+      indistinguishable and a fix that dropped ``## Hyperedges`` whole — the way
+      ``## Lint summary`` is legitimately dropped — would pass.
+
+    Args:
+        hyperedge_span_vault: The mixed-tier-eddy vault.
+    """
+    result = state_render_tool(
+        vault_path=hyperedge_span_vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert result["status"] == "ok"
+    text = _artifact_text(hyperedge_span_vault)
+    for header in SECTION_ORDER:
+        assert header in text, (
+            f"the rendered report is missing {header!r} at ceiling=open, so "
+            "every assertion below it is vacuous"
+        )
+
+    assert _SPAN_EDDY_ABOVE not in text, (
+        f"the above-ceiling sentinel {_SPAN_EDDY_ABOVE!r} reached "
+        "00-Creek-Meta/State at privacy_tier_ceiling=open.\n\n"
+        "Sentinel carrier: the title of an eddy with one open and one "
+        "intimate member fragment, so its derived tier is intimate.\n\n"
+        "## Active eddies already excludes it — the only remaining way into "
+        "the artifact is the 'spans:' list of a ## Hyperedges row, which is "
+        "built from every eddy an admitted fragment names rather than from "
+        f"the admitted eddies.\n\n{text}"
+    )
+
+    hyperedges = _section_body(_report_body(hyperedge_span_vault), "## Hyperedges")
+    assert hyperedges, "the report is missing its '## Hyperedges' section entirely"
+    assert _SPAN_CONTROL_ROW in hyperedges, (
+        "## Hyperedges dropped the row whose two spanned eddies are both "
+        f"admitted at privacy_tier_ceiling=open. Expected {_SPAN_CONTROL_ROW!r} "
+        "in:\n\n"
+        f"{hyperedges}\n\n"
+        "Without this row the exclusion assertion above is satisfied by an "
+        "empty section rather than by a gate."
+    )
+    assert _SPAN_PRAXIS_BRIDGE not in hyperedges, (
+        "## Hyperedges still renders a row for the bridging praxis at "
+        "privacy_tier_ceiling=open. With the above-ceiling eddy removed from "
+        "its span set the praxis reaches one admitted eddy, which is below "
+        "the section's own 'spans 2+ eddies' definition, so the row must "
+        f"disappear rather than render with a single span:\n\n{hyperedges}"
+    )
+
+
+def test_hyperedges_span_the_full_eddy_pair_at_the_all_ceiling(
+    hyperedge_span_vault: Path,
+) -> None:
+    """At ``ceiling=all`` the bridging row returns, with **both** eddies named.
+
+    The permissive half of the pair above, and it has to be this exact — a gate
+    that dropped every praxis whose spans touched a mixed-tier eddy, at every
+    ceiling, would be leak-free and would also silently delete a true hyperedge
+    from the vault owner's own report. Matching :data:`_SPAN_BRIDGE_ROW` whole
+    pins the row's rendering (title, em-dash separator, sorted span list) rather
+    than merely asserting the sentinel is somewhere in the document, where
+    ``## Active eddies`` would supply it for free at this ceiling.
+
+    Args:
+        hyperedge_span_vault: The mixed-tier-eddy vault.
+    """
+    result = state_render_tool(
+        vault_path=hyperedge_span_vault,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert result["status"] == "ok"
+    hyperedges = _section_body(_report_body(hyperedge_span_vault), "## Hyperedges")
+    assert _SPAN_BRIDGE_ROW in hyperedges, (
+        "## Hyperedges must render the bridging praxis with both spanned "
+        f"eddies at privacy_tier_ceiling=all. Expected {_SPAN_BRIDGE_ROW!r} "
+        f"in:\n\n{hyperedges}\n\n"
+        "A gate that removed the row at every ceiling would satisfy the "
+        "open-ceiling test above by deleting a genuine hyperedge from the "
+        "vault owner's report."
+    )
+    assert _SPAN_CONTROL_ROW in hyperedges, (
+        "## Hyperedges dropped the all-admitted control row at "
+        f"privacy_tier_ceiling=all:\n\n{hyperedges}"
+    )
+
+
+# --- Blocker 2: an above-ceiling thread title riding into the seed miner ----
+
+_MINED_THREAD_ABOVE = "CANARY-MINEDTHREAD-INTIMATE-7c3d"
+"""Rides in the ``title`` of a thread whose every member fragment is ``intimate``.
+
+``creek.generate.mining._load_mining_snapshot`` loads ``02-Threads`` and
+``03-Eddies`` through ``_load_typed``, which takes **no** privacy override —
+only the fragment and liminal loaders are gated. ``mine_thread_terminus``
+therefore emits ``IdeaSeed(title=thread.title, ...)`` for a thread none of whose
+members the caller may see, and ``## Suggested questions`` prints that title.
+"""
+
+_MINED_THREAD_BELOW = "CANARY-MINEDTHREAD-OPEN-2f81"
+"""Rides in the title of an otherwise identical thread whose members are ``open``.
+
+The positive control. ``## Suggested questions`` is *already* dropped whole
+below ``ceiling=personal``, so an exclusion assertion at ``personal`` with no
+admitted seed to point at would be indistinguishable from the fix narrowing the
+mining snapshot's threads to the empty tuple.
+"""
+
+_MINED_THREAD_ABOVE_TITLE = f"Thread-{_MINED_THREAD_ABOVE}-Secret"
+"""Title and file stem of the above-ceiling thread."""
+
+_MINED_THREAD_BELOW_TITLE = f"Thread-{_MINED_THREAD_BELOW}-Public"
+"""Title and file stem of the admitted control thread."""
+
+_MINED_THREAD_FRAGMENT_COUNT = 12
+"""Members per thread — strictly above ``DEFAULT_MIN_THREAD_FRAGMENTS`` (10).
+
+``_mine_thread_terminus_with_diagnostic`` keeps a candidate only when
+``thread.fragment_count > self.min_thread_fragments``, so a fixture at or below
+the threshold would emit no seed at all and turn every assertion below into a
+comparison between two empty sections. The test asserts the relation rather
+than trusting this comment.
+"""
+
+
+def _write_mined_thread(
+    vault: Path,
+    *,
+    thread_id: str,
+    title: str,
+    fragment_count: int,
+) -> Path:
+    """Write an ``active`` thread over the mining threshold.
+
+    Separate from :func:`_write_thread`, which hardcodes ``fragment_count: 1``
+    — one member is below ``DEFAULT_MIN_THREAD_FRAGMENTS`` and produces no
+    thread-terminus seed, so the existing helper cannot express this fixture.
+
+    Args:
+        vault: Vault root.
+        thread_id: Thread id and, deliberately, **not** a sentinel carrier.
+            ``_seed_from_thread`` renders the id into the seed's
+            ``brief_description`` (``"Thread '<id>' has accumulated ..."``), so
+            a sentinel there would make the seed leak provable through a second
+            field and blur which one the gate has to cover. The leak under test
+            is the seed *title*.
+        title: Thread title, also the file stem so the ``threads:`` wikilink on
+            each member fragment resolves under either resolution — the same
+            reasoning :func:`_write_thread` records.
+        fragment_count: The stored count the terminus threshold is measured
+            against. It is *stored*, not recounted, so the member fragments
+            below exist to give the thread a derived tier rather than to make
+            this number true.
+
+    Returns:
+        The path written.
+    """
+    metadata: dict[str, Any] = {
+        "type": "thread",
+        "id": thread_id,
+        "title": title,
+        "status": "active",
+        "first_seen": "2026-01-01",
+        "last_seen": "2026-06-01",
+        "fragment_count": fragment_count,
+    }
+    return _write_note(vault, f"02-Threads/Active/{title}.md", metadata, "")
+
+
+def _build_mined_thread_vault(root: Path) -> Path:
+    """Build a vault with one above-ceiling and one admitted terminus thread.
+
+    One vault rather than two, for :func:`_build_canary_vault`'s stated reason:
+    the sections share a corpus in production, and separate vaults could not
+    catch the miner admitting a thread that ``## Active threads`` had already
+    excluded from the very same render.
+
+    Both threads are ``active``, carry the same ``fragment_count``, and have the
+    same number of member fragments; the *only* difference between them is the
+    ``privacy_tier`` on those members. That is what makes the pair a controlled
+    comparison rather than two fixtures that happen to differ.
+
+    Every fragment declares ``phase: unclassified`` (via :func:`_write_fragment`),
+    so ``current_phase_summary`` resolves ``unclassified``,
+    ``_PHASE_AWARE_STRATEGIES`` has no entry for it, and
+    ``phase_filtered_seeds`` applies no strategy filter — every seed competes on
+    score. A thread-terminus seed scores ``fragment_count / min_thread_fragments``
+    (``12 / 10 = 1.2``), above the ``1 / (1 + count) <= 1.0`` ceiling of the
+    unexplored-ontology strategy, so both thread seeds rank inside the
+    five-prompt cap. The section's content is therefore determined by the
+    fixture rather than by a tie-break.
+
+    Args:
+        root: Directory the vault is created inside (typically ``tmp_path``).
+
+    Returns:
+        The vault root.
+    """
+    vault = root / "mined-thread-vault"
+    _seed_dirs(vault)
+    _write_mined_thread(
+        vault,
+        thread_id="thread-mined-above",
+        title=_MINED_THREAD_ABOVE_TITLE,
+        fragment_count=_MINED_THREAD_FRAGMENT_COUNT,
+    )
+    _write_mined_thread(
+        vault,
+        thread_id="thread-mined-below",
+        title=_MINED_THREAD_BELOW_TITLE,
+        fragment_count=_MINED_THREAD_FRAGMENT_COUNT,
+    )
+    for index in range(_MINED_THREAD_FRAGMENT_COUNT):
+        _write_fragment(
+            vault,
+            frag_id=f"frag-mined-intimate-{index:02d}",
+            privacy_tier="intimate",
+            threads=[f"[[{_MINED_THREAD_ABOVE_TITLE}]]"],
+        )
+        _write_fragment(
+            vault,
+            frag_id=f"frag-mined-open-{index:02d}",
+            privacy_tier="open",
+            threads=[f"[[{_MINED_THREAD_BELOW_TITLE}]]"],
+        )
+    return vault
+
+
+@pytest.fixture
+def mined_thread_vault(tmp_path: Path) -> Path:
+    """Return the terminus-thread vault built by :func:`_build_mined_thread_vault`.
+
+    Function-scoped for :func:`canary_vault`'s reason: ``latest.md`` is one slot
+    and the two tests below render at different ceilings into it.
+    """
+    return _build_mined_thread_vault(tmp_path)
+
+
+def test_suggested_questions_omit_an_above_ceiling_thread_title(
+    mined_thread_vault: Path,
+) -> None:
+    """A thread whose every member is above the ceiling must not seed a prompt.
+
+    ``_load_mining_snapshot`` gates its fragment and liminal loaders with the
+    privacy override and then loads ``02-Threads`` / ``03-Eddies`` through
+    ``_load_typed``, which accepts no override at all. So even though
+    ``## Active threads`` correctly drops a thread whose twelve members are all
+    ``intimate`` — its derived tier is ``intimate`` — ``mine_thread_terminus``
+    still sees the thread record, and ``## Suggested questions`` renders:
+
+        - Thread-CANARY-... — Thread 't...' has accumulated 12 fragments
+          without becoming a published essay. ...
+
+    ``ceiling=personal`` is the ceiling that exposes it: the section is dropped
+    whole below ``personal`` (see
+    :func:`test_suggested_questions_are_dropped_at_the_open_ceiling`), so
+    ``open`` cannot see this and ``intimate``/``all`` legitimately admit it.
+
+    The control thread is asserted **inside the section body**, not in the
+    artifact bytes, and that distinction is load-bearing: its title also appears
+    in ``## Active threads`` at this ceiling, so a document-wide check would be
+    satisfied by that section alone and would not notice the miner going silent.
+
+    Args:
+        mined_thread_vault: The paired terminus-thread vault.
+    """
+    from creek.generate.mining import DEFAULT_MIN_THREAD_FRAGMENTS
+
+    assert _MINED_THREAD_FRAGMENT_COUNT > DEFAULT_MIN_THREAD_FRAGMENTS, (
+        "the fixture's threads no longer clear the terminus threshold "
+        f"({_MINED_THREAD_FRAGMENT_COUNT} vs "
+        f"{DEFAULT_MIN_THREAD_FRAGMENTS}), so no thread-terminus seed is "
+        "produced at any ceiling and every assertion below is vacuous"
+    )
+
+    result = state_render_tool(
+        vault_path=mined_thread_vault,
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "ok"
+    text = _artifact_text(mined_thread_vault)
+    for header in SECTION_ORDER:
+        assert header in text, (
+            f"the rendered report is missing {header!r} at ceiling=personal, "
+            "so every assertion below it is vacuous"
+        )
+
+    assert _MINED_THREAD_ABOVE not in text, (
+        f"the above-ceiling sentinel {_MINED_THREAD_ABOVE!r} reached "
+        "00-Creek-Meta/State at privacy_tier_ceiling=personal.\n\n"
+        "Sentinel carrier: the title of an active thread whose twelve member "
+        "fragments are all intimate.\n\n"
+        "## Active threads already excludes it on its derived tier — the "
+        "remaining way in is ## Suggested questions, whose miner loads "
+        "02-Threads through _load_typed, a loader that takes no privacy "
+        f"override.\n\n{text}"
+    )
+
+    section = _section_body(
+        _report_body(mined_thread_vault),
+        "## Suggested questions",
+    )
+    assert section, "the report is missing its '## Suggested questions' section"
+    assert EMPTY_PLACEHOLDER not in section, (
+        "## Suggested questions rendered the empty placeholder at "
+        "privacy_tier_ceiling=personal over a corpus with twelve admitted "
+        "fragments and an admitted terminus thread in it, so the exclusion "
+        f"assertion above is satisfied by an outage:\n\n{section}"
+    )
+    assert _MINED_THREAD_BELOW in section, (
+        f"## Suggested questions dropped {_MINED_THREAD_BELOW!r} at "
+        "privacy_tier_ceiling=personal. That thread is identical to the "
+        "excluded one in status and fragment_count and differs only in its "
+        "members' privacy_tier, so narrowing the mining snapshot must narrow "
+        f"it to the *admitted* threads, not to none:\n\n{section}"
+    )
+
+
+def test_suggested_questions_admit_the_intimate_thread_at_the_all_ceiling(
+    mined_thread_vault: Path,
+) -> None:
+    """At ``ceiling=all`` the intimate thread seeds a prompt again.
+
+    The permissive control for the narrowing above. A fix that handed the miner
+    an empty thread tuple, or dropped the thread-terminus strategy from the
+    report altogether, would be leak-free at ``personal`` and would also delete
+    the vault owner's most useful prompt from their own report at every ceiling.
+
+    Asserted on the section body rather than the artifact for the same reason
+    its companion is: at this ceiling ``## Active threads`` renders the title
+    too, so a document-wide check would prove nothing about the miner.
+
+    Args:
+        mined_thread_vault: The paired terminus-thread vault.
+    """
+    result = state_render_tool(
+        vault_path=mined_thread_vault,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert result["status"] == "ok"
+    section = _section_body(
+        _report_body(mined_thread_vault),
+        "## Suggested questions",
+    )
+    assert section, "the report is missing its '## Suggested questions' section"
+    assert _MINED_THREAD_ABOVE in section, (
+        f"## Suggested questions dropped {_MINED_THREAD_ABOVE!r} at "
+        "privacy_tier_ceiling=all, which admits intimate content. The "
+        "permissive direction has to be pinned as hard as the restrictive "
+        "one: a miner that surfaces nothing is leak-free and useless:\n\n"
+        f"{section}"
+    )
+    assert _MINED_THREAD_BELOW in section, (
+        f"## Suggested questions dropped {_MINED_THREAD_BELOW!r} at "
+        f"privacy_tier_ceiling=all:\n\n{section}"
+    )
+
+
+# --- Blocker 3: a stamp that fails to parse for a non-YAML reason -----------
+
+_JSON_FRONTMATTER_LATEST = (
+    '{\n"privacy_tier": "open",\n}\n\n# Creek state\n\nVault summary lives here.\n'
+)
+"""A ``latest.md`` whose frontmatter routes to JSON and then fails to parse.
+
+``frontmatter.loads`` picks a handler by asking each one to ``detect`` the
+text, and ``JSONHandler.FM_BOUNDARY`` is ``^(?:{|})$`` — so a document whose
+first line is exactly ``{`` is handed to ``json.loads``. The trailing comma
+makes that raise :class:`json.JSONDecodeError`, which is a
+:class:`ValueError` and **not** a :class:`yaml.YAMLError`.
+:func:`creek.generate.state_tiers.stamped_content_tier` catches only
+``yaml.YAMLError``, so at HEAD the exception escapes ``state_read_tool``
+uncaught.
+
+A vault note is operator-editable and an artifact is hand-editable, so this is
+a real shape rather than a contrived one — and the failure mode is the worst
+available: not a leak, but a crash on the read path that was supposed to be the
+gate. Fail-closed and refuse; do not raise.
+"""
+
+
+def test_state_read_fails_closed_on_a_non_yaml_frontmatter_error(
+    tmp_path: Path,
+) -> None:
+    """A stamp that raises a non-YAML parse error must refuse, not crash.
+
+    Written beside :func:`test_unreadable_stamp_values_fail_closed` rather than
+    as a row of it because that parametrisation varies the ``privacy_tier``
+    *value* underneath a well-formed YAML stamp written by
+    :func:`_stamped_latest`; this failure is about the document's *format*, and
+    ``_stamped_latest`` cannot express it.
+
+    ``stamped_content_tier`` is pinned directly as well as through the tool.
+    Going through ``state_read_tool`` alone would leave the reduction untested
+    for every other caller of the helper, and pinning the helper alone would not
+    show that the tool's ``report_path.read_text`` → ``stamped_content_tier``
+    sequence has no other unguarded step in it.
+
+    The refusal is compared for equality against the canonical payload, not
+    merely checked for ``status == "refused"``: a distinguishable
+    "this artifact would not parse" refusal would be an oracle for the vault's
+    contents in the same way a tier-naming refusal is, which is the property
+    :func:`test_refusal_is_byte_identical_for_every_above_ceiling_stamp`
+    already protects for the tier axis.
+
+    The non-vacuity control for "the reader has not simply started refusing
+    everything" is the ``open`` row of
+    :func:`test_unreadable_stamp_values_fail_closed`, which asserts a readable
+    ``open`` stamp is still served.
+
+    Args:
+        tmp_path: pytest's per-test temporary directory.
+    """
+    from creek.generate.state_tiers import stamped_content_tier
+
+    assert stamped_content_tier(_JSON_FRONTMATTER_LATEST) == PrivacyTier.INTIMATE, (
+        "stamped_content_tier must fail closed on frontmatter it cannot "
+        "parse, whatever the parser. frontmatter.loads dispatches on the "
+        "document's own opening delimiter, and only the YAML handler raises "
+        "yaml.YAMLError — a document opening with a bare '{' is routed to "
+        "json.loads, which raises json.JSONDecodeError."
+    )
+
+    vault = tmp_path / "non-yaml-stamp"
+    _seed_dirs(vault)
+    _write_latest(vault, _JSON_FRONTMATTER_LATEST)
+
+    response = state_read_tool(
+        vault_path=vault,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert response["status"] == "refused", (
+        "creek.state.read served a latest.md whose stamp cannot be parsed at "
+        "privacy_tier_ceiling=open. A stamp nobody can read is a stamp nobody "
+        "has vouched for. (At HEAD this line is not reached at all: the "
+        "JSONDecodeError escapes state_read_tool and the test errors rather "
+        f"than fails.) Got: {response!r}"
+    )
+    assert response["reason"] == GENERIC_ABOVE_CEILING_REASON
+    assert response == refusal_response(
+        tool="creek.state.read",
+        ceiling=TierCeiling.OPEN,
+        reason=GENERIC_ABOVE_CEILING_REASON,
+    ), (
+        "the refusal for an unparsable-frontmatter artifact differs from the "
+        "canonical payload, so the refusal itself distinguishes 'this would "
+        "not parse' from 'this is above your ceiling' — an oracle over the "
+        f"artifact the caller was not admitted to. Got: {response!r}"
+    )


### PR DESCRIPTION
## Summary

`creek.state.read` and `creek.state.render` accepted a `privacy_tier_ceiling`, wrote it to the audit log, echoed it in the response — and never consulted it. `read` returned `00-Creek-Meta/State/latest.md` verbatim at any ceiling; `render` walked the whole vault with no override threaded into `StateReportGenerator`.

### Three leaks, reproduced at HEAD before writing a line

Running `StateReportGenerator(vault_path=v).render()` over a temp vault, no ceiling anywhere:

| Section | What escaped |
|---|---|
| `## Drift warnings` | `` - `/Users/…/vault/01-Fragments/Notes/private-<CANARY>-moment.md` `` — an `intimate` fragment's **slugified title**, inside an **absolute** path |
| `## Liminal Watch` | `- unnamed-<CANARY>-2` — the **file stem** of a `10-Liminal/Unnamed` note |
| `## Active eddies` | `- Eddy <CANARY> One — 0 fragment(s)` — an eddy whose only member fragment is above the ceiling |

This **corrects the issue on two points.** It says "there is no demonstrated body-level leak today — the exposure is structural, at the title level, and blocked on the sub-issue below." The exposure is at title level, but it is demonstrated, and it is **not** blocked on giving `Eddy`/`Thread` a `privacy_tier`: leaks 1 and 2 are tierable today, and leak 3 is tierable by **deriving** the eddy/thread tier from its constituent fragments at render time — the issue's own stated derivation, without a model field, a pipeline change, or a vault migration. The author's probe missed leak 1 only because their fixture had no fragment older than the 90-day `_STALE_FRAGMENT_AGE_DAYS` threshold.

The absolute path is a second defect in the same rows: `docs/generation.md` already claimed the artefact "does not leak an operator's home directory". Drift rows now render vault-relative, which makes the standing claim true.

## The cross-ceiling cache — the design question, and the answer

Gating the read alone does not fix it. If `latest.md` was rendered at `ceiling=all`, refusing an `open` read is right, but an `open` read is *also* wrong to serve from a cache built at a broader ceiling.

**(a) The artifact stamps itself**, as YAML frontmatter: `type: state-report`, `privacy_tier: <highest tier admitted>`, `tier_ceiling: <override it ran under>`. The key is `privacy_tier` **deliberately**, so the read side reuses `raw_privacy_tier` verbatim — `privacy_filter`'s docstring warns that "a tier reader somewhere else is a tier opinion the others can drift from", and this change adds none. Scalars only, `yaml.safe_dump(sort_keys=False)`: CrawDad keeps `raw_markdown` including frontmatter and feeds it to prompts, and its bullet regex is `^\s*-\s+`. Verified no consumer breaks — `state-budget` measures size, CrawDad's `_split_sections` discards everything before the first `## `, and no `type:`-dispatching loader is rooted at `00-Creek-Meta`.

**(b) `render` filters at render time.** Without it a `ceiling=open` render is either a lie (stamped `open`, full of intimate-derived titles) or useless (stamped `intimate`, unreadable by the caller who asked for it).

**(c) `read` compares the stamped `privacy_tier`, not the render ceiling.** Strictly better: a report rendered at `ceiling=all` over an all-`open` vault stamps `open` and stays readable at `open`. It is also the honest question — the ceiling is a statement of intent, the stamp is a fact about the bytes.

**(d) An unstamped legacy `latest.md` fails closed — accurate, not cautious.** Every `latest.md` written before this change was rendered completely unfiltered, i.e. the equivalent of `--include-tier all`. Failing closed states a fact about those bytes.

**Upgrade path for an operator with an existing `latest.md`.** CLI: nothing changes; `creek state` re-renders and stamps on the next run. MCP/CrawDad: the first `creek.state.read` at the default `ceiling=open` (so `/creek`, `/creek phase`, `/creek wavelength`, CrawDad's check-in) returns `status: "refused"` with `GENERIC_ABOVE_CEILING_REASON` — byte-identical to a legitimately-intimate refusal, because a distinguishable "legacy" reason would itself be an oracle for whether the vault holds above-ceiling content. Recovery is one command: `creek.state.render`, or `creek state --include-tier open`. Nothing is lost: the ISO-week archive is untouched and `ceiling=all` admits every stamp, including the unstamped one, so **no report is ever permanently unreachable.** Documented in `docs/mcp.md` and both tool docstrings, not in the refusal payload, which keeps exactly its four canonical keys and no `content` key at all.

**Refuse vs exclude, split down the middle, and the split is load-bearing.** `render` **excludes** — it names no target, it is the most corpus-walking tool on the surface. `read` **refuses** — it addresses one atomic cached artifact, and you cannot admit half a rendered markdown document without re-rendering it, which is what `render` is. The asymmetry is what makes recoverability provable: `render` is the recovery path for a refused `read`, so if `render` could refuse, a vault with one intimate fragment would have a permanently unreachable report.

## Per-section disposition (all eleven, triaged out loud)

Gated: wavelength snapshot and vault summary (**counts narrow with the ceiling** — `creek.wheel` is a frequency tally and is `GATED`, so a per-tier count is content here; an unfiltered count discloses the existence of what the rest of the report omitted, and it would make the stamp under-report); liminal watch (`within_ceiling` on raw frontmatter); active eddies/threads (derived tier = max over **all** constituent fragments — the unfiltered pass is load-bearing, since filtering first would resolve a mixed-tier eddy to `open` and leak its title); synchronicities (**already fail-closed via `_is_leaf` once the fragment load narrows — verified, zero code change**, and now pinned by a test); hyperedges (every `derived_from` id must resolve, and the span set is intersected with admitted eddies); drift warnings (admitted source paths only, rendered vault-relative); suggested questions (snapshot narrowed, and dropped whole below `ceiling=personal`); lint summary (`ceiling=intimate` or broader — an untierable verbatim copy).

Ungated, deliberately: **pre-LLM yield** alone. It reports one pipeline run's totals and names no fragment, so there is nothing in it to filter *by*.

A `_SECTION_DISPOSITIONS` table asserts this covers `SECTION_ORDER` exactly, in both directions. A new section must be triaged out loud or the stamp silently under-reports and the read gate fails open.

## Layer (f) is not the evidence, and I did not treat it as one

PR #1068 proved the shared read-gate envelope probe is structurally incapable of catching a write-side leak. `creek.state.render` is write-side too. So **every exclusion assertion in the new suite is on written artifact bytes** — the ISO-week file and `latest.md`, symlink-resolved — never only the response. On top of that: a **vault-wide byte-snapshot sweep** whose file list is derived from the filesystem diff, so an unanticipated artifact or a parallel ungated write is caught; and **inverting-predicate mutation rows** per gated section, so a gate that is called and discarded fails. Every exclusion has a paired positive control, so nothing passes by writing an empty report.

Manifest posture moved `UNGATED_KNOWN_GAP` → `GATED` for both tools, re-pointed at the gates that closed them, with two new runtime probes. `_probe_state_read` renders at `ceiling=all` **first**, so the artifact genuinely holds the canary — otherwise it would be vacuous on a vault with no report.

## The known-vacuous test, replaced

`tests/test_mcp_tools.py::test_state_read_does_not_embed_fragment_bodies`.

**Before:** wrote an intimate fragment, then **hand-wrote** `latest.md` as the fixed string `"# Audit report\n\n- Fragments: 1\n"`, then asserted `"secret journal body" not in result["content"]`. True by construction — nothing in `state_read_tool` ever read the fragment, so `_write_fragment` was decorative. It could not fail whether or not a gate existed, and it passed for the entire life of the gap.

**After** (`test_state_read_does_not_serve_above_ceiling_content_from_latest_md`): the artifact is produced through the production path, `state_render_tool(..., ceiling=ALL)`; the canary reaching `latest.md` is **asserted first** so the setup cannot rot back into vacuity; then `state_read_tool(..., ceiling=OPEN)` must refuse. **Executed against unfixed HEAD it fails** with `AssertionError: assert 'ok' == 'refused'` — and the pre-assertion passes there, which is itself proof the render leaked.

## Gate 2.5 found two more leaks — of the same class — and I reproduced both

An independent `code-review-orchestrator` pass returned `FIX_REQUIRED`. It was right twice, on exactly the bug this issue is about: an above-ceiling identifier riding in through a section nobody threaded the ceiling into.

1. **`## Hyperedges`** — `_fragment_to_eddies` mapped admitted fragments to *every* eddy they named without intersecting the admitted eddies, so an eddy correctly dropped from `## Active eddies` still printed in a `spans:` list at `ceiling=open`. Reproduced: `- Bridging praxis — spans: Mixed ZZEDDYCANARY, Plain`. Worse, its tier never reached the stamp, so the report was stamped `open` and `read` served it. Fixed by intersecting before the `len(spanning) >= 2` cut. **Its docstring claimed the opposite** — a fresh instance of this issue's own defect, now made true.
2. **`## Suggested questions`** — `mining.py`'s `_load_mining_snapshot` gates fragments but loads `02-Threads`/`03-Eddies` ungated, so a thread whose members are all `intimate` titled a mined seed at `ceiling=personal`. Reproduced: `- Secret ZZTHREADCANARY — Thread 't1' has accumulated 12 fragments…`. Fixed **inside `creek state`** — `phase_filtered_seeds` gained an additive `snapshot=` passthrough, and the generator narrows the snapshot with the lists it has already admitted. Deliberately **not** fixed by gating `mining.py`'s loaders: `Thread`/`Eddy` carry no `privacy_tier`, so a raw gate there would fail closed and silently delete two mining strategies for every `creek mine` caller — a separate decision on a separate tool.

Fixing 2 surfaced two further fail-open axes: `snapshot.fragments` (the miner reads the tier off the validated model, whose missing key defaults to `unclassified`, while the report's raw reader fails closed to `intimate`) and `snapshot.liminal_fragments`. Both closed.

All three new canaries were **executed against the pre-fix files and confirmed RED**. A re-review returned **`CLEAN`**.

## Consequences stated on the tin

- **`latest.md` is a single slot shared across ceilings**, and the MCP `render` default is the strictest `ceiling=open` — so a bare MCP render *narrows* the cached report for everyone, including subsequent CLI reads. Kept deliberately: the MCP boundary defaulting strict is the security posture, and per-ceiling filenames would multiply vault artifacts and break `latest.md` as the documented session-start context.
- `10-Liminal/Paradoxes` notes are `type: paradox` with no `privacy_tier`, so they fail closed and vanish from the Liminal Watch below `ceiling=intimate`.
- The **lint summary** is intimate-only. This closes the live caveat `creek_mcp/read_gate.py` already recorded under `creek.lint` — "unreachable through MCP today … read it against #969's state-artifact gap". `creek state` **is** the surface that served it back.
- **Behaviour widening, called out because it is a loosening inside a privacy PR:** the seeds section is now mined at the render's override. At `ceiling=open` this is unchanged (the section is dropped there anyway); the widening is at `ceiling=all`.
- The mining corpus's liminal axis is **accounted for on the stamp rather than narrowed** (state has no admitted list for `10-Liminal/Compost`). Only an opaque generated id ever renders, and an untiered note pushes the stamp to `unclassified` — ranked with `personal`, so still refused at `open`. The residual posture split on the same file is documented and filed as a follow-up.
- `creek_mcp/read_gate.py`'s "Why these primitives have no production caller yet" paragraph is **rewritten**, because this change makes it false. Leaving it would have created this issue's defect in the file whose whole subject is the manifest not lying.

## Test plan

`cd creek-tools && ./scripts/check-all.sh` → **exit 0, 12/12 checks, 6794 passed, 94.02→94.04% branch coverage**, per-file gate clean (219 files ≥ 80%).

- **New:** `tests/test_state_tier_ceiling.py`, 3240 lines — per-section exclusion + admission across all four ceilings on artifact bytes; the stamp (shape, body round-trip, `privacy_tier <= tier_ceiling` over all four ceilings, all-open-at-`ALL` → `open`, fresh vault → `open`, `latest.md` across the symlink path and **both** copy-fallback triggers); refusal (canonical four keys, byte-identical across stamped tiers, no `PrivacyTier` string beyond the caller's own echo, legacy unstamped, ten malformed-stamp shapes, missing report still `empty`); **recoverability executed end to end** over all four render ceilings; mutation resistance; the filesystem-diff sweep; six CLI tests.
- **Test integrity.** Deletions vs `origin/main`: `test_mcp_read_gate.py` **3** (two `_PINNED_GAPS` rows *re-pointed* into `_PINNED_GATE_ROWS`, which is the move the manifest's own failure message demands; one docstring line whose word "four" became factually wrong when two of four entries left, replaced by a longer one). `test_mcp_server.py` **1** (a docstring first line, preserved verbatim inside its expansion). `test_mcp_tools.py` **10** (the vacuous test's body and docstring, replaced above; and one fixture line gaining the stamp — all four of that test's assertions kept byte-identical, with a new test added beside it pinning the case the fixture change vacated). `test_state_tier_ceiling.py` **0**. **No test and no assertion was deleted or weakened.** SHA-256 of every touched test file was recorded at RED and re-checked after each later phase; the implementation phases changed none of them.

Closes #969
Refs #932, #846, #848, #968, #1068, #961, #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)
