### PR TITLE
fix(mcp): gate creek.journal's update-in-place on the overwritten fragment's tier (#970)

### DIFF
--- a/creek-tools/creek_mcp/read_gate.py
+++ b/creek-tools/creek_mcp/read_gate.py
@@ -36,12 +36,20 @@ of the primitives below inherits it:
    to key a model call.
 
 **Who calls these primitives, and why the rest still do not.**
-:func:`refuse_above_ceiling` has exactly one production caller:
-``creek_mcp.tools.state_read``, which adopted it in #969. That adoption is the
+:func:`refuse_above_ceiling` has two production callers.
+``creek_mcp.tools.state_read`` adopted it in #969, and that adoption is the
 shape the primitives were written for — the tool addresses a *single* cached
 artifact, so there is nothing to partially admit, and its refusal has no
 tool-specific story to tell. It gets the generic reason, the four-key payload
 and the no-tier-echo rule for free rather than re-deriving any of them.
+``creek_mcp.tools.journal`` adopted it in #970 on the same property one step
+further out: it is a *write* gate asking a read question. Its idempotent
+update-in-place would overwrite the one fragment an ``external_id`` resolves
+to, and the rule is that you may only overwrite what you could have read — so
+admission is decided by ``tier_allowed`` through this primitive, not by
+``write_tier_allowed``, which ranks the incoming entry and knows nothing about
+the fragment on disk. Caller-addressed and singular again: you cannot
+overwrite half a body, so there is nothing to partially admit.
 
 The other refusing tools are deliberately *not* retrofitted.
 ``creek.reflect`` and ``creek.compile`` keep their own refusal reasons and
@@ -159,8 +167,9 @@ class ToolPosture:
         gate_symbol: Name of the gate callable within *gate_module*. Set on
             ``GATED`` entries only.
         gap_issue: Issue tracking an unenforced ceiling — required on every
-            ``UNGATED_KNOWN_GAP`` entry, and also carried by ``creek.journal``
-            whose gap is on its update-in-place path rather than a read.
+            ``UNGATED_KNOWN_GAP`` entry, and set on nothing else. It was also
+            carried by ``creek.journal`` until #970 gated its update-in-place
+            path; that entry is now ``GATED`` and names its gate instead.
     """
 
     posture: ReadPosture
@@ -347,14 +356,44 @@ TOOL_POSTURES: dict[str, ToolPosture] = {
         gap_issue=971,
     ),
     "creek.journal": ToolPosture(
-        posture=ReadPosture.NO_UNSUPPLIED_READ,
+        posture=ReadPosture.GATED,
         rationale=(
-            "The entry body is the caller's own, and write_tier_allowed gates "
-            "the tier it creates; but the idempotent update-in-place "
-            "overwrites the fragment an external_id already maps to without "
-            "consulting that fragment's tier (#970)."
+            "The entry body is the caller's own and write_tier_allowed gates "
+            "the tier it creates, but the idempotent update-in-place destroys "
+            "the fragment an external_id already maps to — so it refuses on "
+            "THAT fragment's current vault tier: you may only overwrite what "
+            "you could have read (#970). A write gate asking a read question, "
+            "hence refuse_above_ceiling (tier_allowed) rather than "
+            "write_tier_allowed; the target is caller-addressed and singular, "
+            "and you cannot overwrite half a body. Ordering is load-bearing: "
+            "the gate sits ABOVE _stage_entry, because the staged copy under "
+            "00-Creek-Meta/adepthood/journal/ has no escalate-only ratchet, so "
+            "a gate placed below staging would return a correct refusal over "
+            "an already-destroyed staged entry whose privacy_tier had been "
+            "rewritten downward. Two fail-closed rules, not one: no ledger "
+            "record at all passes content_tier=None and CREATES (creation must "
+            "keep working at every ceiling), while a ledger record whose "
+            "fragment does not resolve reduces max_source_tier([]) to intimate "
+            "and is refused — so any divergence from the writer's own id index "
+            "fails safe. Consequence to know: PurgeEngine leaves a dangling "
+            "ledger record (#1080), so a purged id is refused below "
+            "ceiling=intimate until it is re-sent by an admitted caller — a "
+            "LOCAL stdio caller only, since a remote consumer token is capped "
+            "at ceiling=personal and can never send ceiling=intimate/all "
+            "(#1082 tracks a possible content-hash carve-out for the "
+            "unchanged-resend case). Accepted residual: the refusal is an "
+            "existence-AND-rank oracle, matching reflect's own honesty "
+            "standard for its analogous oracle. No stronger than the "
+            "pre-existing action: created|updated bit on the existence "
+            "question those two share; the rank bit — 'above your ceiling' — "
+            "is new, and is the price of refusing at all. It is deliberately "
+            "blurred, not a clean tier read: every fail-closed unresolvable "
+            "case (purged, orphaned, schema-invalid, deleted out of band) "
+            "collapses into the identical refusal as a genuine above-ceiling "
+            "fragment, so refused means 'above your ceiling OR unresolvable'."
         ),
-        gap_issue=970,
+        gate_module="creek_mcp.tools.journal",
+        gate_symbol="refuse_above_ceiling",
     ),
     "creek.lint": ToolPosture(
         posture=ReadPosture.METADATA_ONLY,

--- a/creek-tools/creek_mcp/tools/journal.py
+++ b/creek-tools/creek_mcp/tools/journal.py
@@ -18,15 +18,99 @@ frontmatter (which the markdown ingestor carries onto the fragment), and the
 write-side ceiling refuses an entry whose tier exceeds the caller's ceiling — so
 an INTIMATE entry is stored intimate and never admitted under a lower ceiling.
 
-The idempotent update-in-place has a gap this guarantee does not cover
-(#970): overwriting the fragment an existing ``external_id`` already maps to
-replaces whatever body is there **without consulting that fragment's own
-tier**. Reproduced: a caller at ``ceiling=open`` replaced the body of a
-fragment persisted at ``privacy_tier: intimate``. The persisted tier itself
-was not downgraded — the escalate-only privacy merge held — but the intimate
-body was destroyed. Contrast ``creek.purge.*``, which requires
-``CREEK_MCP_ELEVATED_TOKEN`` for exactly this kind of destruction; this path
-requires only the caller's own (lower) ceiling.
+**The update-in-place path is gated too, on the tier of what it would destroy
+(#970): you may only overwrite what you could have read.** The write-side
+``write_tier_allowed`` check ranks the *incoming* entry and says nothing about
+the fragment an existing ``external_id`` already maps to, so a caller at
+``ceiling=open`` used to replace the body of a fragment persisted at
+``privacy_tier: intimate``. The persisted tier survived (the escalate-only
+privacy merge held) but the intimate body did not. Contrast ``creek.purge.*``,
+which requires ``CREEK_MCP_ELEVATED_TOKEN`` for exactly this kind of
+destruction; this path requires only the caller's own (lower) ceiling.
+:func:`_refuse_unadmitted_overwrite` closes that, and the question it asks —
+"could this caller have *read* the thing it is about to destroy?" — is a read
+question, which is why it goes through
+:func:`creek_mcp.read_gate.refuse_above_ceiling` (and so ``tier_allowed``)
+rather than through ``write_tier_allowed``.
+
+Gate ordering, all of it load-bearing:
+
+1. malformed calls (blank ``content``/``external_id``, unknown ``tier``) refuse
+   without an audit entry — there is no meaningful tier to record yet;
+2. ``write_tier_allowed`` on the *incoming* tier — audited, then refused;
+3. the overwrite gate on the tier of the *resolved existing* fragment —
+   audited, then refused;
+4. **only then** :func:`_stage_entry`, which before #970 ran first. Moving it
+   below the gate is the half of this fix that is easy to miss: the staged
+   copy under ``00-Creek-Meta/adepthood/journal/`` has no escalate-only
+   ratchet, so a gate added *after* the staging write returns a correct
+   refusal over an already-destroyed staged entry — body replaced and
+   ``privacy_tier`` rewritten *downward*. It is the worse loss of the two,
+   since the fragment at least keeps its tier through the privacy merge.
+
+Two fail-closed rules, deliberately distinct — collapsing them breaks one:
+
+* **no ledger record at all** → ``content_tier=None``, which the primitive
+  admits by contract. This is creation, and it must keep working at every
+  ceiling; failing closed here would make the ordinary Adepthood write path
+  unusable below the tier of whatever the vault happens to hold.
+* **a ledger record whose fragment does not resolve** (purged, deleted out of
+  band, schema-invalid, or tombed into ``10-Liminal/Orphaned`` where the
+  ``01-Fragments`` walk cannot see it) →
+  :func:`creek.classify.privacy_filter.max_source_tier` reduces the empty tier
+  set to ``INTIMATE``, so the overwrite is refused below ``ceiling=intimate``.
+  Every divergence between this gate's locator and the writer's own id index
+  therefore fails in the safe direction. Note ``PurgeEngine.purge_fragment``
+  leaves a dangling ledger record (#1080), so this branch is reachable in
+  normal operation; recovery is one broader call, not a ledger hand-edit —
+  true only for a **local stdio** caller, per the consequence below.
+
+Consequence to know: that recovery does not exist for a remote consumer.
+``_BoundedFastMCP.call_tool`` caps every remote request at
+``ceiling=personal`` (``docs/mcp.md`` §"INTIMATE is never reachable
+remotely"), so a remote caller can never even *request*
+``ceiling=intimate``/``all``. Because ``creek classify``'s privacy pass is
+escalate-only, once a journal fragment reaches ``intimate`` a remote
+consumer — and Adepthood, the primary journal producer, IS a remote
+consumer — can never send that ``external_id`` again: not to edit it, and
+not even as an unchanged idempotent re-sync, because this gate sits above
+the ``record.content_hash != new_hash`` comparison in
+:func:`creek.ingest.pipeline.write_fragment_idempotent`. This is the
+correct, intended security behaviour, not a bug; #1082 tracks a possible
+content-hash carve-out for the unchanged-resend case specifically — left
+for a later design pass, not implemented here.
+
+ACCEPTED RESIDUAL RISK: the refusal is an existence-*and-rank* oracle — "an
+above-ceiling fragment exists at this external_id" — matching the honesty
+standard :mod:`creek_mcp.tools.reflect`'s own ACCEPTED RESIDUAL RISK block
+sets for its analogous oracle. It is no *stronger* than the pre-existing
+``action: created|updated`` bit on the existence question those two bits
+share over the same caller-owned id namespace; the *rank* bit — "the
+fragment at this id is above your ceiling" — is new, and is the price of
+refusing at all rather than silently corrupting. It is also deliberately
+**blurred**: every fail-closed unresolvable case (purged, tombed into
+``10-Liminal/Orphaned``, schema-invalid, deleted out of band) collapses
+into the identical refusal as a genuine above-ceiling fragment, so
+``refused`` does not read as a clean tier — it means "above your ceiling
+OR unresolvable". Option (b) from
+#970 — making the refusal indistinguishable from a write failure — was
+considered and rejected on the merits: it would have to answer either
+``"ingest failed: …"`` (a lie the audit trail then carries) or ``status="ok"``
+(worse — the caller believes the entry is stored, stops retrying, and silently
+loses its own data). It does not even work, because the refusal returns before
+staging, before a full ``MarkdownIngestor`` run and before a fragment write, so
+the latency gap is enormous and ``reflect``'s timing-equalisation caveat would
+apply with far more force than it does there.
+
+The fix is **preventive only**: a body already clobbered by the pre-#970
+behaviour survives nowhere (provenance records hashes and paths, not content).
+Operator recovery for an already-clobbered vault is documented in
+``docs/mcp.md`` — re-send the original entry at ``ceiling=intimate``/``all``
+from a **local stdio** caller (Adepthood cannot do this step itself: it is a
+remote consumer capped at ``ceiling=personal``, per the consequence above),
+or restore from a vault-level backup. A pre-image backup is deliberately NOT
+taken: it would mint a second plaintext copy of intimate content, i.e. a new
+leak surface, to guard against a write this gate now refuses.
 """
 
 from __future__ import annotations
@@ -39,11 +123,13 @@ from typing import TYPE_CHECKING, Any
 
 import frontmatter
 
+from creek.classify.privacy_filter import max_source_tier, source_tiers
 from creek.ingest.journal_staging import JOURNAL_STAGING_RELDIR
 from creek.ingest.markdown import MarkdownIngestor
 from creek.ingest.pipeline import derive_source_key, ledger_for_source, run_ingest
 from creek.models import PrivacyTier
 from creek_mcp.audit import MCPAuditLog
+from creek_mcp.read_gate import refuse_above_ceiling
 from creek_mcp.tier_ceiling import TierCeiling, refusal_response, write_tier_allowed
 
 if TYPE_CHECKING:
@@ -82,11 +168,23 @@ def _safe_stem(external_id: str) -> str:
     return f"{slug}-{digest}" if slug else digest
 
 
+def _staged_path(vault_path: Path, external_id: str) -> Path:
+    """Return the stable staged markdown path *external_id* maps to.
+
+    Pure — it computes, and never creates. Split out of :func:`_stage_entry`
+    (#970) because the overwrite gate has to derive the ledger source key
+    *before* deciding whether the caller may write anything at all, and a
+    "compute the path" helper that also writes the file would make that
+    ordering impossible to express.
+    """
+    return vault_path / _JOURNAL_INBOX / f"{_safe_stem(external_id)}.md"
+
+
 def _stage_entry(
     vault_path: Path, external_id: str, content: str, timestamp: str, tier: PrivacyTier
 ) -> Path:
     """Write the entry to its stable staged markdown path and return it."""
-    staged = vault_path / _JOURNAL_INBOX / f"{_safe_stem(external_id)}.md"
+    staged = _staged_path(vault_path, external_id)
     staged.parent.mkdir(parents=True, exist_ok=True)
     post = frontmatter.Post(
         content,
@@ -105,6 +203,110 @@ def _resolve_fragment_id(vault_path: Path, staged: Path) -> str | None:
         return None
     record = ledger.get(derive_source_key(str(staged), vault_path))
     return record.fragment_id if record is not None else None
+
+
+def _existing_tier(vault_path: Path, fragment_id: str) -> PrivacyTier:
+    """Return the CURRENT vault tier of *fragment_id*, failing closed.
+
+    Read out of the vault rather than off the staged entry's frontmatter or
+    the caller's own ``tier`` argument: both of those are stale the moment
+    ``creek classify`` escalates the fragment, and a caller-supplied tier is
+    not a gate at all. The shared
+    :func:`creek.classify.privacy_filter.source_tiers` walk is used so this
+    gate inspects exactly the files the rest of the pipeline treats as
+    fragments; :func:`~creek.classify.privacy_filter.max_source_tier` then
+    reduces, returning ``INTIMATE`` for an id that resolves to nothing. With
+    no evidence about what the id holds, the safe assumption is the worst one.
+
+    The shared walk also costs the same whatever it finds — it materialises
+    the whole directory before filtering and never short-circuits at the match
+    — so the refusal cannot leak *where* the protected fragment sits through
+    timing. That property is documented on ``source_tiers`` itself and is a
+    reason not to swap in a bespoke lazy scan for speed.
+
+    Args:
+        vault_path: Vault root.
+        fragment_id: The id the source ledger resolved for this entry.
+
+    Returns:
+        The fragment's current tier, or ``INTIMATE`` when the id resolves to
+        no readable fragment.
+    """
+    return max_source_tier(source_tiers(vault_path, [fragment_id]))
+
+
+def _refuse_unadmitted_overwrite(
+    vault_path: Path, external_id: str, ceiling: TierCeiling
+) -> dict[str, Any] | None:
+    """Refuse an update that would destroy content *ceiling* cannot read (#970).
+
+    This is a write gate legitimately adopting a *read* primitive. The target
+    is caller-addressed and singular — one ``external_id`` resolves to exactly
+    one fragment — which is the property
+    :mod:`creek_mcp.read_gate` says decides between refusing and excluding:
+    there is nothing to partially admit, because you cannot overwrite half a
+    body. And the question being asked really is a read question ("could this
+    caller have read what it is about to overwrite?"), so admission is decided
+    by ``tier_allowed`` via the primitive rather than by ``write_tier_allowed``.
+
+    Args:
+        vault_path: Vault root.
+        external_id: The caller's idempotency key.
+        ceiling: The caller's admission ceiling.
+
+    Returns:
+        ``None`` when the overwrite is admitted — including when the id maps
+        to no ledger record at all, which is a *creation* and must keep
+        working at every ceiling. Otherwise the canonical four-key refusal,
+        which names neither the resolved fragment nor its tier.
+    """
+    staged = _staged_path(vault_path, external_id)
+    existing_id = _resolve_fragment_id(vault_path, staged)
+    existing = None if existing_id is None else _existing_tier(vault_path, existing_id)
+    return refuse_above_ceiling(
+        tool=TOOL_NAME,
+        content_tier=existing,
+        ceiling=ceiling,
+    )
+
+
+def _validated_entry_tier(
+    *, content: str, external_id: str, tier: str, ceiling: TierCeiling
+) -> PrivacyTier | dict[str, Any]:
+    """Return the parsed entry tier, or the refusal a malformed call earns.
+
+    Malformed calls refuse **without** an audit entry, mirroring
+    ``save_tool``/``ingest_tool``: there is no meaningful tier to record yet.
+    Both admission gates and the success path do audit, since the audit trail
+    is how a privacy-tier violation would be investigated.
+
+    Args:
+        content: The journal entry body.
+        external_id: The caller's idempotency key.
+        tier: The caller's declared tier, as the raw string it arrived as.
+        ceiling: The caller's admission ceiling, echoed in a refusal.
+
+    Returns:
+        The parsed :class:`~creek.models.PrivacyTier`, or a structured refusal
+        naming which malformation was found. The two reasons stay distinct
+        and specific: neither is derived from vault content, so neither is an
+        oracle, and a client whose call is simply wrong deserves to be told
+        which way it is wrong.
+    """
+    if not content.strip() or not external_id.strip():
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=ceiling,
+            reason="content and external_id are required",
+        )
+    try:
+        return PrivacyTier(tier)
+    except ValueError:
+        return refusal_response(
+            tool=TOOL_NAME,
+            ceiling=ceiling,
+            reason=f"unknown tier {tier!r}",
+        )
 
 
 def _action_of(result: IngestRunResult) -> str:
@@ -137,34 +339,36 @@ def journal_ingest_tool(
         timestamp: ISO-8601 entry time; defaults to now (UTC) when absent.
         tier: The entry's privacy tier (``open``/``personal``/``intimate``).
         privacy_tier_ceiling: The caller's admission ceiling — an entry whose
-            tier exceeds it is refused, not downgraded.
+            tier exceeds it is refused, not downgraded, and so is an update
+            that would overwrite a fragment the ceiling could not read.
         consumer: Free-form consumer id for the audit log.
+        run: Ingest-runner seam; production passes ``None`` and gets
+            :func:`creek.ingest.pipeline.run_ingest`.
 
     Returns:
         ``{status, tool, tier_ceiling, external_id, fragment_id, action, tier}``
         on success (``action`` ∈ ``created``/``updated``/``unchanged``), or a
-        structured refusal.
+        structured refusal — the canonical four-key one carrying
+        :data:`~creek_mcp.read_gate.GENERIC_ABOVE_CEILING_REASON`, naming
+        neither the protected fragment nor its tier, when the overwrite gate
+        fires (#970).
     """
-    # Malformed calls (blank content/id, unknown tier) refuse without an audit
-    # entry, mirroring save_tool/ingest_tool — there is no meaningful tier to
-    # record yet. The tier-ceiling refusal and success DO audit (below), since
-    # the audit trail is how a privacy-tier violation would be investigated.
-    if not content.strip() or not external_id.strip():
-        return refusal_response(
-            tool=TOOL_NAME,
-            ceiling=privacy_tier_ceiling,
-            reason="content and external_id are required",
-        )
-    try:
-        entry_tier = PrivacyTier(tier)
-    except ValueError:
-        return refusal_response(
-            tool=TOOL_NAME,
-            ceiling=privacy_tier_ceiling,
-            reason=f"unknown tier {tier!r}",
-        )
+    entry_tier = _validated_entry_tier(
+        content=content,
+        external_id=external_id,
+        tier=tier,
+        ceiling=privacy_tier_ceiling,
+    )
+    # A non-tier answer is the refusal a malformed call earned; from here down
+    # ``entry_tier`` is narrowed to the parsed tier.
+    if not isinstance(entry_tier, PrivacyTier):
+        return entry_tier
 
     audit_args = {"external_id": external_id[:64], "tier": tier}
+    # Gate 1 — the INCOMING tier. Deliberately kept on write_tier_allowed
+    # rather than folded into the read primitive below, so ``grep
+    # write_tier_allowed`` still enumerates every write-side create gate on
+    # the surface (compile's argument).
     if not write_tier_allowed(entry_tier, privacy_tier_ceiling):
         MCPAuditLog(vault_path).append(
             tool=TOOL_NAME,
@@ -178,8 +382,35 @@ def journal_ingest_tool(
             reason=f"entry tier {entry_tier.value} exceeds the ceiling",
         )
 
-    ts = timestamp or datetime.now(UTC).isoformat()
-    staged = _stage_entry(vault_path, external_id, content, ts, entry_tier)
+    # Gate 2 — the tier of what an update would DESTROY (#970). It sits above
+    # the staging write below it, so a refusal leaves the staged entry intact
+    # as well as the fragment; _stage_entry used to run before all of this.
+    # The refusal audit carries the caller's own arguments and nothing else:
+    # no created_tier, no affected_fragment_ids, no created_path. The resolved
+    # fragment id and the protected tier must not enter the trail, which is
+    # served onward through other surfaces — read_gate's rule 1 is "never the
+    # probed target id and never the outcome", and that binds these bytes
+    # exactly as it binds the response.
+    if (
+        refusal := _refuse_unadmitted_overwrite(
+            vault_path, external_id, privacy_tier_ceiling
+        )
+    ) is not None:
+        MCPAuditLog(vault_path).append(
+            tool=TOOL_NAME,
+            args=audit_args,
+            tier_ceiling=privacy_tier_ceiling,
+            consumer=consumer,
+        )
+        return refusal
+
+    staged = _stage_entry(
+        vault_path,
+        external_id,
+        content,
+        timestamp or datetime.now(UTC).isoformat(),
+        entry_tier,
+    )
     runner = run if run is not None else run_ingest
     try:
         result = runner(

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -151,7 +151,7 @@ real desk. Only the `research` medium is wired — any other `medium` returns
 | `creek.report`          | `report_type` (`tags`\|`voice`\|`decisions`\|`lexicon`\|`rhetorical-patterns`\|`mode-profiles`) | Ceiling is enforced on the *inputs* of all six generators (#968): a note enters the artifact only if its raw front matter is within `ceiling`, and a missing `privacy_tier` fails closed to `intimate`. Consequence for `tags`: the Tag Garden scans five directories, and the four beyond `01-Fragments` hold note types with no `privacy_tier` field at all, so **a ceiling-filtered tag garden is fragment-derived only**. `tag-history.json` entries record the `tier_ceiling` they were taken under, and growth is only ever compared between entries at the same ceiling. |
 | `creek.skills.refresh`  | none beyond `ceiling`                                       | Voice-skill tree regen; intimate exemplars excluded by a generator hardcode, not by the ceiling — `personal` bodies pass unsummarised at `ceiling=open` (known gap #971). |
 | `creek.compile`         | `fragment_ids`, `target_kind`, `target_id`, `target_title`  | Gates the *source* fragments' tier, not the compiled page's tier — a source above `ceiling` refuses the whole call (#848). Idempotent per FEAT-003; no-op re-runs do not log a duplicate. |
-| `creek.journal`         | `content`, `external_id`, `timestamp?`, `tier?`             | Stages an Adepthood entry then ledger-ingests it (#754); `external_id` is the idempotency key and `tier` defaults to `open`. The entry's tier is honored — a ceiling that would not admit it is refused. The tier of the fragment an existing `external_id` already maps to is **not** consulted before the update-in-place overwrites it (known gap #970). |
+| `creek.journal`         | `content`, `external_id`, `timestamp?`, `tier?`             | Stages an Adepthood entry then ledger-ingests it (#754); `external_id` is the idempotency key and `tier` defaults to `open`. Two gates, in this order. (1) The *incoming* entry's tier is honored — a ceiling that would not admit it is refused, never downgraded. (2) An `external_id` that already maps to a fragment is an **update-in-place**, so the tier of the fragment it would destroy is ranked too: **you may only overwrite what you could have read** (#970). That second gate reads the fragment's *current* vault tier (not the caller's declared tier, not the staged copy's stamp) and refuses through the shared `read_gate.refuse_above_ceiling`, so the refusal names neither the fragment nor its tier. It sits **above** staging, so a refusal leaves the staged entry under `00-Creek-Meta/adepthood/journal/` untouched as well. Fail-closed rules: an `external_id` with no ledger record at all is a plain **creation** and still works at every ceiling; an `external_id` whose ledger record points at a fragment that no longer resolves ranks as `intimate` and is refused below `ceiling=intimate` — recovery is one re-send at a broader ceiling from a **local stdio** caller only (remote consumers cannot; see "INTIMATE is never reachable remotely" and the consequence spelled out under "Read-side posture" below), not a ledger hand-edit. |
 
 ### Purge tools (FEAT-012, elevated authorization required)
 
@@ -236,6 +236,64 @@ a guarantee, so the evidence for it is likewise the bytes under
 `00-Creek-Meta/State`. `creek.state.read` is the counterpart on the read side
 and the **first production adopter** of `read_gate.refuse_above_ceiling`; both
 are documented above under "Read tools".
+
+`creek.journal` was the sharpest of the write-side gaps, the last to close
+(#970), and the **second adopter** of `refuse_above_ceiling` — the first that
+is a *write* gate. It did not merely act on above-ceiling content: its
+idempotent update-in-place *destroyed* it, replacing the body of the fragment
+an `external_id` already mapped to without ever ranking that fragment's tier.
+No read-back wording covered that, and its response envelope was clean either
+way, which is why the gap survived a response-level sweep. The rule it now
+enforces is **you may only overwrite what you could have read**, which is a
+read question — hence the read primitive, and hence `tier_allowed` rather than
+`write_tier_allowed` (that one still gates the incoming entry's own tier,
+above it). Because remote consumers are capped at `personal` (see "INTIMATE is
+never reachable remotely" below), the crisp consequence is this: **a remote
+consumer token can no longer destroy an `intimate` journal fragment.** Before
+the fix it could — `creek.journal` is a write tool a consumer token reaches,
+and overwriting an entry required only the caller's own, lower ceiling, while
+the equivalent destruction through `creek.purge.*` demands
+`CREEK_MCP_ELEVATED_TOKEN`.
+
+**Consequence to know: that same cap means a remote consumer can never touch
+an `intimate` journal `external_id` again, period** — not to edit it, and not
+even to re-send it unchanged. `creek classify`'s privacy pass is
+escalate-only, so once an entry reaches `intimate` the overwrite gate refuses
+every call below `ceiling=intimate`, and the gate sits above the
+`record.content_hash != new_hash` comparison in `write_fragment_idempotent`,
+so an unchanged idempotent re-sync is refused identically to a genuine edit.
+Adepthood, the primary journal producer, is itself a remote consumer, so this
+is the single operational consequence of #970 most likely to bite in
+production — the earlier "recovery is one re-send" language elsewhere on this
+page holds only for a **local stdio** caller. #1082 tracks a possible
+content-hash carve-out that would let an unchanged re-send through below
+`ceiling=intimate`; that is a design decision for a later architecture pass,
+not implemented here.
+
+**Recovering an already-clobbered vault.** The fix is *preventive only*. A
+body overwritten by the pre-#970 behaviour survives nowhere in the vault:
+provenance records hashes and paths, not content. In order of preference:
+
+1. **Re-send at `ceiling=intimate`/`all`, from a local stdio caller.**
+   Adepthood is the system of record for the original content, but it cannot
+   perform this step itself — it is a remote consumer, and remote requests
+   are capped at `ceiling=personal` (see "INTIMATE is never reachable
+   remotely" below), so it can never request `ceiling=intimate`/`all`. An
+   operator with local stdio access re-sends the original entry with the
+   same `external_id` at that ceiling. The body is restored, and the
+   fragment's persisted `intimate` tier is preserved by the escalate-only
+   privacy merge — re-sending never downgrades a tier.
+2. **Vault-level backup** — Obsidian's file recovery, `git`, or Time Machine
+   on the vault directory.
+3. **Scope the damage** from `00-Creek-Meta/audit/mcp.jsonl`: look for
+   `creek.journal` entries whose `args_summary.external_id` matches and whose
+   `tier_ceiling` is below the affected fragment's tier. The refusal audit
+   records only the caller's own arguments, so the trail shows attempts and
+   ceilings, never which fragment was behind an id.
+
+There is deliberately **no pre-image backup** taken before an update. It would
+mint a second plaintext copy of intimate content — a new leak surface — to
+guard against a write this gate now refuses.
 
 One read-side leak was found, and it is worth stating how: the sweep
 first concluded there were none, having probed the tools that walk the
@@ -420,7 +478,12 @@ routable by design and requires TLS.
   is intentional (Adepthood writes journal entries remotely), so treat each
   token as a write-capable credential — a meaningfully larger attack surface
   than "remote read-only." Purge tools stay gated separately by
-  `CREEK_MCP_ELEVATED_TOKEN` (a per-consumer bearer alone cannot purge).
+  `CREEK_MCP_ELEVATED_TOKEN` (a per-consumer bearer alone cannot purge). The
+  one *destructive* path a consumer token could reach without the elevated
+  token is now closed: `creek.journal`'s update-in-place refuses to overwrite a
+  fragment above the caller's ceiling (#970), and remote callers are capped at
+  `personal`, so a remote consumer can no longer destroy an `intimate` journal
+  fragment.
 - **INTIMATE is never reachable remotely.** The boundary caps a remote
   caller at `personal`: a request for a `privacy_tier_ceiling` above it
   (`intimate` / `all`, or any unrecognised value) is **refused before

--- a/creek-tools/tests/test_mcp_journal.py
+++ b/creek-tools/tests/test_mcp_journal.py
@@ -7,7 +7,10 @@ idempotency and edit-in-place guarantees are exercised end-to-end, not mocked:
 - editing an entry (same external id, new content) rewrites in place (same id,
   no orphaned duplicate);
 - tier is honored (an INTIMATE entry lands intimate; it is refused under a lower
-  ceiling, never downgraded).
+  ceiling, never downgraded);
+- the update-in-place path honours the tier of the fragment it would *overwrite*,
+  not just the tier of the incoming entry — you may only overwrite what you could
+  have read (#970).
 """
 
 from __future__ import annotations
@@ -16,10 +19,13 @@ import json
 from typing import TYPE_CHECKING
 
 import frontmatter
+import pytest
 
+from creek.models import PrivacyTier
 from creek.purge import PurgeEngine
 from creek_mcp.audit import MCP_AUDIT_RELPATH
-from creek_mcp.tier_ceiling import TierCeiling
+from creek_mcp.read_gate import GENERIC_ABOVE_CEILING_REASON
+from creek_mcp.tier_ceiling import TierCeiling, tier_allowed
 from creek_mcp.tools.journal import TOOL_NAME, journal_ingest_tool
 
 if TYPE_CHECKING:
@@ -50,6 +56,76 @@ def _audit(vault: Path) -> list[dict[str, object]]:
     log = vault / MCP_AUDIT_RELPATH
     assert log.exists()
     return [json.loads(line) for line in log.read_text().splitlines() if line.strip()]
+
+
+# The #970 overwrite-gate fixtures. Two sentinels, deliberately disjoint from
+# every tier word, so an assertion about "intimate" and an assertion about the
+# protected plaintext can never accidentally satisfy each other.
+_SECRET = "synthetic-tender-secret-970"
+_BENIGN = "benign-open-replacement-970"
+
+
+def _staged(vault: Path) -> list[Path]:
+    """Return all staged entries under ``00-Creek-Meta/adepthood/journal``."""
+    return sorted((vault / "00-Creek-Meta" / "adepthood" / "journal").rglob("*.md"))
+
+
+def _leaking_files(vault: Path, needle: str) -> list[Path]:
+    """Return every markdown file anywhere under *vault* containing *needle*."""
+    return [
+        path
+        for path in sorted(vault.rglob("*.md"))
+        if needle in path.read_text(encoding="utf-8")
+    ]
+
+
+def _seed_intimate(vault: Path, external_id: str) -> dict[str, object]:
+    """Create one INTIMATE entry carrying ``_SECRET`` under the broadest ceiling.
+
+    Args:
+        vault: Vault root.
+        external_id: The idempotency key the later overwrite attempt reuses.
+
+    Returns:
+        The tool's success response, asserted to be a fresh creation so a
+        later ``refused`` cannot be mistaken for "there was nothing there".
+    """
+    result = journal_ingest_tool(
+        vault_path=vault,
+        content=f"a tender confession {_SECRET}",
+        external_id=external_id,
+        timestamp=_TS,
+        tier="intimate",
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert result["status"] == "ok"
+    assert result["action"] == "created"
+    return result
+
+
+def _overwrite_at_open(vault: Path, external_id: str) -> dict[str, object]:
+    """Re-send *external_id* as benign OPEN-tier text under an OPEN ceiling.
+
+    The incoming tier is ``open``, so the pre-existing ``write_tier_allowed``
+    gate admits it — this call is only ever refused by a gate that consults
+    the tier of the fragment being *overwritten*.
+
+    Args:
+        vault: Vault root.
+        external_id: The idempotency key of the entry to overwrite.
+
+    Returns:
+        The tool's raw response dict.
+    """
+    return journal_ingest_tool(
+        vault_path=vault,
+        content=f"{_BENIGN} nothing to see here",
+        external_id=external_id,
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="adepthood",
+    )
 
 
 def test_entry_becomes_a_journal_fragment(tmp_path: Path) -> None:
@@ -161,6 +237,31 @@ def test_empty_content_is_refused(tmp_path: Path) -> None:
         privacy_tier_ceiling=TierCeiling.PERSONAL,
     )
     assert result["status"] == "refused"
+
+
+def test_unknown_tier_is_refused_before_anything_is_written(tmp_path: Path) -> None:
+    """An unrecognised ``tier`` refuses with its own reason, staging nothing.
+
+    The malformed-call gate sits above both admission gates, so the refusal
+    must name the malformation — a caller whose argument is simply wrong needs
+    to be told which way, and nothing here is derived from vault content — and
+    it must leave no fragment, no staged entry and no audit entry behind: at
+    this point there is no meaningful tier to record.
+    """
+    vault = _vault(tmp_path)
+    result = journal_ingest_tool(
+        vault_path=vault,
+        content="an entry",
+        external_id="adep-bad-tier",
+        timestamp=_TS,
+        tier="not-a-tier",
+        privacy_tier_ceiling=TierCeiling.PERSONAL,
+    )
+    assert result["status"] == "refused"
+    assert "unknown tier" in str(result["reason"])
+    assert _fragments(vault) == []
+    assert _staged(vault) == []
+    assert not (vault / MCP_AUDIT_RELPATH).exists()
 
 
 def test_journal_success_audit_records_tier_and_fragment(tmp_path: Path) -> None:
@@ -328,3 +429,361 @@ def test_staging_path_unchanged(tmp_path: Path) -> None:
     assert str(source["origin_key"]) == (
         f"00-Creek-Meta/adepthood/journal/{staged[0].name}"
     )
+
+
+def test_update_of_an_above_ceiling_fragment_is_refused(tmp_path: Path) -> None:
+    """An OPEN-ceiling caller may not overwrite an INTIMATE fragment (#970).
+
+    The issue's verbatim reproduction. ``external_id`` is the idempotency key,
+    so the second call is an update-in-place: it destroys the intimate body it
+    maps to while satisfying ``write_tier_allowed`` on its own ``open`` tier.
+    The rule being pinned is *you may only overwrite what you could have
+    read*, so the refusal is the canonical read-gate refusal.
+
+    The refusal must also name no tier. It carries
+    :data:`~creek_mcp.read_gate.GENERIC_ABOVE_CEILING_REASON` verbatim and
+    nothing derived from the protected fragment — no ``fragment_id``, no tier
+    echoed anywhere in the payload — because a refusal that ranks the content
+    it withheld is a tier-classification oracle over the corpus (#969, rule 4).
+    """
+    vault = _vault(tmp_path)
+    _seed_intimate(vault, "e1")
+
+    result = _overwrite_at_open(vault, "e1")
+
+    assert result["status"] == "refused"
+    assert result["reason"] == GENERIC_ABOVE_CEILING_REASON
+    assert "fragment_id" not in result
+    assert "intimate" not in json.dumps(result)
+
+
+def test_refused_update_leaves_the_fragment_bytes_untouched(tmp_path: Path) -> None:
+    """The refused overwrite changes not one byte of the protected fragment.
+
+    Byte-level rather than response-level on purpose. A JSON-response
+    assertion is structurally incapable of catching a write-side leak: on
+    #968 a response-level guardrail passed 5/5 while six generators went on
+    leaking to disk. The evidence for #970 is the bytes, so this asserts
+    ``read_bytes()`` equality across the refused call, that the intimate
+    plaintext and its tier stamp both survive, and that the refused caller's
+    own text landed in **no** markdown file anywhere under the vault.
+    """
+    vault = _vault(tmp_path)
+    _seed_intimate(vault, "e2")
+    fragment = _fragments(vault)[0]
+    before = fragment.read_bytes()
+
+    result = _overwrite_at_open(vault, "e2")
+
+    # The disk evidence is asserted first, deliberately: it is what the
+    # response-shaped assertion below cannot see.
+    assert fragment.read_bytes() == before
+    post = _load(fragment)
+    assert _SECRET in post.content
+    assert post.metadata["privacy_tier"] == "intimate"
+    assert _leaking_files(vault, _BENIGN) == []
+    assert result["status"] == "refused"
+
+
+def test_refused_update_leaves_the_staged_entry_untouched(tmp_path: Path) -> None:
+    """The refused overwrite changes not one byte of the STAGED entry either.
+
+    **This test must fail if the gate is added without moving ``_stage_entry``
+    below it.** ``_stage_entry`` currently runs before anything else, so the
+    staged copy under ``00-Creek-Meta/adepthood/journal/`` is rewritten before
+    a refusal could be returned — and it is the worse loss of the two: the
+    fragment keeps its tier stamp through the escalate-only privacy merge,
+    while the staged file has no ratchet at all, so its ``privacy_tier`` is
+    rewritten *downward* and its intimate body replaced outright.
+    """
+    vault = _vault(tmp_path)
+    _seed_intimate(vault, "e3")
+    staged = _staged(vault)[0]
+    before = staged.read_bytes()
+
+    result = _overwrite_at_open(vault, "e3")
+
+    # Staging order is the thing under test, so the staged bytes are asserted
+    # ahead of the response: a gate bolted on above ``_stage_entry`` returns a
+    # correct refusal over an already-destroyed staged entry.
+    assert staged.read_bytes() == before
+    staged_post = _load(staged)
+    assert _SECRET in staged_post.content
+    assert staged_post.metadata["privacy_tier"] == "intimate"
+    assert result["status"] == "refused"
+
+
+def test_refused_update_is_audited_without_naming_the_fragment(tmp_path: Path) -> None:
+    """The refused overwrite IS audited, and the entry names no protected thing.
+
+    An attempted ceiling violation is an operator-relevant signal, so it gets
+    a trail — the tool, the ceiling and the caller's *own* arguments. What it
+    must not get is anything resolved from the fragment it was refused:
+    ``created_tier`` and ``affected_fragment_ids`` stay absent-or-empty, and
+    neither the protected fragment's id nor its tier appears anywhere in the
+    serialised entry. The audit artifact is served onward through other
+    surfaces, so read_gate's rule 1 — never the probed target id, never the
+    outcome — applies to these bytes exactly as it does to the response.
+    """
+    vault = _vault(tmp_path)
+    seeded = _seed_intimate(vault, "e4")
+
+    assert _overwrite_at_open(vault, "e4")["status"] == "refused"
+
+    last = _audit(vault)[-1]
+    assert last["tool"] == TOOL_NAME
+    assert last["tier_ceiling"] == "open"
+    assert last["consumer"] == "adepthood"
+    assert last["args_summary"] == {"external_id": "e4", "tier": "open"}
+    assert not last.get("created_tier")
+    assert not last.get("affected_fragment_ids")
+    serialised = json.dumps(last)
+    assert str(seeded["fragment_id"]) not in serialised
+    assert "intimate" not in serialised
+
+
+def test_creating_a_new_entry_at_a_low_ceiling_still_works(tmp_path: Path) -> None:
+    """A FRESH external id at ceiling=open still creates (#970 non-regression).
+
+    The gate is about *overwriting* a fragment the caller could not read. An
+    id that maps to nothing has nothing to protect, so it must not fail
+    closed — that would make the ordinary Adepthood write path unusable at
+    every ceiling below the tier of whatever the vault happens to hold.
+    """
+    vault = _vault(tmp_path)
+
+    result = journal_ingest_tool(
+        vault_path=vault,
+        content="a plainly public note",
+        external_id="e5-fresh",
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert result["status"] == "ok"
+    assert result["action"] == "created"
+    assert len(_fragments(vault)) == 1
+
+
+def test_within_ceiling_update_still_works(tmp_path: Path) -> None:
+    """Editing an OPEN fragment at ceiling=open still updates in place (#970).
+
+    The overwrite gate admits what the caller could have read, so the ordinary
+    edit-in-place loop at a matching ceiling is untouched: same id, new body,
+    no orphaned duplicate.
+    """
+    vault = _vault(tmp_path)
+    created = journal_ingest_tool(
+        vault_path=vault,
+        content="the original public wording",
+        external_id="e6",
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert created["action"] == "created"
+
+    edited = journal_ingest_tool(
+        vault_path=vault,
+        content="the revised, longer public wording of the same entry",
+        external_id="e6",
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert edited["status"] == "ok"
+    assert edited["action"] == "updated"
+    assert edited["fragment_id"] == created["fragment_id"]
+    assert len(_fragments(vault)) == 1
+    assert "revised" in _load(_fragments(vault)[0]).content
+
+
+@pytest.mark.parametrize("ceiling", [TierCeiling.INTIMATE, TierCeiling.ALL])
+def test_intimate_entry_stays_updatable_at_an_admitted_ceiling(
+    tmp_path: Path,
+    ceiling: TierCeiling,
+) -> None:
+    """An INTIMATE entry is still editable by a caller admitted to read it.
+
+    Recoverability, proved rather than reasoned about: a prior lane nearly
+    shipped a "fail closed to the most restrictive tier" fix that made
+    entries permanently un-updatable, which is a one-way ratchet into
+    permanent burial. So the path back is exercised at both admitting
+    ceilings — the update succeeds, the new body is on disk, and the
+    fragment's ``privacy_tier`` is **still intimate** (the escalate-only
+    merge must not be traded away for the new gate). The final leg re-pins
+    that widening the gate for an admitted caller did not reopen it for an
+    unadmitted one.
+
+    Args:
+        tmp_path: pytest temp dir.
+        ceiling: An admitting ceiling for intimate content.
+    """
+    vault = _vault(tmp_path)
+    _seed_intimate(vault, "e7")
+
+    edited = journal_ingest_tool(
+        vault_path=vault,
+        content=f"a revised tender confession {_SECRET}",
+        external_id="e7",
+        timestamp=_TS,
+        tier="intimate",
+        privacy_tier_ceiling=ceiling,
+    )
+
+    assert edited["status"] == "ok"
+    assert edited["action"] == "updated"
+    assert len(_fragments(vault)) == 1
+    post = _load(_fragments(vault)[0])
+    assert "revised" in post.content
+    assert post.metadata["privacy_tier"] == "intimate"
+
+    # Admitting the admitted caller must not admit the unadmitted one.
+    assert _overwrite_at_open(vault, "e7")["status"] == "refused"
+
+
+def test_gate_reads_the_vault_tier_not_the_staged_stamp(tmp_path: Path) -> None:
+    """The gate ranks the fragment's CURRENT vault tier, not a stale stamp.
+
+    The discriminator. An entry created at ``open`` is escalated in the vault
+    the way ``creek classify`` would escalate it — the fragment's frontmatter
+    only, leaving the staged copy's stamp reading ``open`` and the caller
+    still self-declaring ``open``. Any implementation that consults the
+    caller-supplied tier, or the staged file's stale stamp, admits this call;
+    only one that reads the fragment's present tier out of the vault refuses
+    it. A caller-supplied tier is not a gate.
+    """
+    vault = _vault(tmp_path)
+    created = journal_ingest_tool(
+        vault_path=vault,
+        content="a note that later turns out to be tender",
+        external_id="e8",
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    assert created["action"] == "created"
+
+    fragment = _fragments(vault)[0]
+    escalated = frontmatter.load(fragment)
+    escalated.metadata["privacy_tier"] = "intimate"
+    fragment.write_text(frontmatter.dumps(escalated), encoding="utf-8")
+    # The staged stamp is deliberately left stale at ``open`` — that plus the
+    # caller's own ``tier="open"`` is what makes this the discriminator.
+    assert _load(_staged(vault)[0]).metadata["privacy_tier"] == "open"
+    before = fragment.read_bytes()
+
+    result = _overwrite_at_open(vault, "e8")
+
+    assert fragment.read_bytes() == before
+    assert _leaking_files(vault, _BENIGN) == []
+    assert result["status"] == "refused"
+    assert result["reason"] == GENERIC_ABOVE_CEILING_REASON
+
+
+@pytest.mark.parametrize(
+    ("existing_tier", "ceiling", "admitted"),
+    [
+        (PrivacyTier.PERSONAL, TierCeiling.OPEN, False),
+        (PrivacyTier.PERSONAL, TierCeiling.PERSONAL, True),
+        (PrivacyTier.UNCLASSIFIED, TierCeiling.OPEN, False),
+        (PrivacyTier.UNCLASSIFIED, TierCeiling.PERSONAL, True),
+        (PrivacyTier.INTIMATE, TierCeiling.PERSONAL, False),
+        (PrivacyTier.OPEN, TierCeiling.OPEN, True),
+    ],
+)
+def test_overwrite_admission_tracks_the_ranking_at_every_tier(
+    tmp_path: Path,
+    existing_tier: PrivacyTier,
+    ceiling: TierCeiling,
+    admitted: bool,
+) -> None:
+    """The gate admits exactly what a *read* at *ceiling* would have admitted.
+
+    The other #970 tests drive the two extremes — an ``intimate`` fragment
+    against an ``open`` ceiling, and the recovery ceilings that re-admit it.
+    This one walks the middle of the ranking, because "you may only overwrite
+    what you could have read" is a claim about the whole table and not just
+    its corners. ``personal`` is the tier a remote consumer actually operates
+    at, and ``unclassified`` is the one every freshly-ingested fragment
+    carries before ``creek classify`` runs — it ranks *with* ``personal``
+    rather than with ``open`` (#961), so an ``open`` ceiling must refuse it.
+
+    The existing fragment's tier is set on disk rather than through the
+    creating call's own ``tier`` argument, so the assertion is about the tier
+    the gate reads out of the vault and not about what the seeding caller
+    declared.
+
+    Args:
+        tmp_path: pytest temp dir.
+        existing_tier: The tier the fragment carries in the vault.
+        ceiling: The overwriting caller's declared ceiling.
+        admitted: Whether ``tier_allowed`` admits that pairing.
+    """
+    vault = _vault(tmp_path)
+    journal_ingest_tool(
+        vault_path=vault,
+        content="a note whose tier is decided on disk below",
+        external_id="e10",
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    fragment = _fragments(vault)[0]
+    post = frontmatter.load(fragment)
+    post.metadata["privacy_tier"] = existing_tier.value
+    fragment.write_text(frontmatter.dumps(post), encoding="utf-8")
+    before = fragment.read_bytes()
+
+    result = journal_ingest_tool(
+        vault_path=vault,
+        content=f"{_BENIGN} replacement body",
+        external_id="e10",
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=ceiling,
+    )
+
+    assert tier_allowed(existing_tier, ceiling) is admitted, (
+        "the expectation table has drifted from the shared ranking; fix the "
+        "table, not the gate"
+    )
+    if admitted:
+        assert result["status"] == "ok"
+        assert _BENIGN in _load(fragment).content
+    else:
+        assert result["status"] == "refused"
+        assert result["reason"] == GENERIC_ABOVE_CEILING_REASON
+        assert fragment.read_bytes() == before
+        assert _leaking_files(vault, _BENIGN) == []
+
+
+def test_a_ledger_record_whose_fragment_is_gone_fails_closed(tmp_path: Path) -> None:
+    """An external id the ledger maps to a missing fragment fails closed (#970).
+
+    With the fragment gone there is no tier to rank, and no evidence about
+    what the id used to hold — so the reduction over an empty tier set is
+    ``INTIMATE`` and an OPEN-ceiling overwrite is refused. That must not be a
+    permanent burial of the id: the same call under ``ceiling=all`` is
+    admitted, so the recovery path is one broader call rather than a
+    hand-edit of the ledger.
+    """
+    vault = _vault(tmp_path)
+    _seed_intimate(vault, "e9")
+    _fragments(vault)[0].unlink()
+
+    refused = _overwrite_at_open(vault, "e9")
+    assert refused["status"] == "refused"
+    assert refused["reason"] == GENERIC_ABOVE_CEILING_REASON
+
+    admitted = journal_ingest_tool(
+        vault_path=vault,
+        content=f"{_BENIGN} re-sent by an admitted caller",
+        external_id="e9",
+        timestamp=_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert admitted["status"] == "ok"

--- a/creek-tools/tests/test_mcp_read_gate.py
+++ b/creek-tools/tests/test_mcp_read_gate.py
@@ -98,6 +98,7 @@ from creek_mcp.read_gate import (
 from creek_mcp.server import build_server
 from creek_mcp.tier_ceiling import TierCeiling, refusal_response
 from creek_mcp.tools.compile import _ABOVE_CEILING_REASON, compile_tool
+from creek_mcp.tools.journal import journal_ingest_tool
 from creek_mcp.tools.mine import mine_tool
 from creek_mcp.tools.reflect import reflect_tool
 from creek_mcp.tools.report import report_tool
@@ -160,6 +161,21 @@ _PINNED_GATE_ROWS = [
     # caller-*addressed* and singular, which is the property that matters.
     ("creek.state.read", "creek_mcp.tools.state_read", "refuse_above_ceiling"),
     ("creek.state.render", "creek_mcp.tools.state", "to_privacy_override"),
+    # #970 closed the journal gap, and this row is a *re-point* of the same
+    # kind #968 made for ``report`` and #969 made for the two ``state.*``
+    # entries: the entry moves from a gap claim to a gate claim layers (c),
+    # (e) and (f) can check, rather than being deleted. ``creek.journal``'s
+    # gap was never on its *response* — the entry body is the caller's own —
+    # but on its idempotent update-in-place, which overwrote whatever fragment
+    # an ``external_id`` already mapped to without ranking that fragment's
+    # tier. It now refuses on the rule *you may only overwrite what you could
+    # have read*, which is a read question, so it goes through
+    # ``refuse_above_ceiling`` (and thus ``tier_allowed``) rather than through
+    # the write-side ``write_tier_allowed`` that still gates the incoming
+    # entry's own tier. Pinning the exact pair is what keeps the posture and
+    # the behaviour from drifting apart — the property the deleted
+    # ``test_journal_is_pinned_as_no_unsupplied_read`` used to hold.
+    ("creek.journal", "creek_mcp.tools.journal", "refuse_above_ceiling"),
 ]
 
 _PINNED_GAPS = {
@@ -172,8 +188,6 @@ _PINNED_GAPS = {
     # reassuring label while the behaviour is unchanged.
     "creek.redact.scan": 972,
 }
-
-_PINNED_JOURNAL_GAP_ISSUE = 970
 
 _PINNED_AUTH_TOKEN_TOOLS = [
     "creek.purge.fragment",
@@ -581,18 +595,27 @@ def test_pinned_gaps_keep_their_posture_and_issue(tool: str, issue: int) -> None
     assert entry.gap_issue == issue
 
 
-def test_journal_is_pinned_as_no_unsupplied_read() -> None:
-    """``creek.journal`` never returns content the caller did not supply.
+def test_journal_carries_no_residual_gap_issue() -> None:
+    """``creek.journal``'s posture and its story stay in step (#970).
 
-    Its posture is ``NO_UNSUPPLIED_READ`` rather than a gate: the write-side is
-    guarded by ``write_tier_allowed``, and the read-side gap it still carries
-    (#970) is recorded on the same entry. Pinning both together keeps the two
-    halves of that story from drifting apart — a reader must not be able to
-    conclude "journal has no gap" from the posture alone.
+    The other half of the re-point recorded in :data:`_PINNED_GATE_ROWS`,
+    which pins the gate itself. What is pinned *here* is the property the
+    deleted ``test_journal_is_pinned_as_no_unsupplied_read`` held before the
+    gap closed: a reader must not be able to draw the wrong conclusion about
+    journal from the manifest alone. That test said "the posture is
+    reassuring, so the gap must be recorded next to it"; with the gap closed,
+    the same intent inverts — a leftover ``gap_issue`` on a now-``GATED``
+    entry would advertise a hole that is not there, send an auditor hunting
+    #970 in a module that fixed it, and (via ``_GAP_ISSUE_TOOLS``) keep
+    demanding the tool's own source still mention the issue as an open gap.
     """
     entry = TOOL_POSTURES["creek.journal"]
-    assert entry.posture is ReadPosture.NO_UNSUPPLIED_READ
-    assert entry.gap_issue == _PINNED_JOURNAL_GAP_ISSUE
+    assert entry.posture is ReadPosture.GATED
+    assert entry.gap_issue is None, (
+        "creek.journal is GATED by the #970 overwrite gate but still names a "
+        f"gap issue (#{entry.gap_issue}). Drop gap_issue, or explain in the "
+        "rationale what remains ungated."
+    )
 
 
 @pytest.mark.parametrize("tool", _PINNED_AUTH_TOKEN_TOOLS)
@@ -1233,6 +1256,17 @@ _RUNTIME_INTIMATE_ID = "frag-runtime-intimate"
 # simply stopped resolving the fragment, which proves nothing about the gate.
 _REFLECT_ABOVE_CEILING_REASON = "entry_ref tier exceeds ceiling"
 
+# ``creek.journal``'s probe writes its own entry (see ``_seed_journal_canary``),
+# so it needs an idempotency key and a stable timestamp. The key is deliberately
+# canary-free: it is the caller's own string and the tool echoes it back on
+# success, so a sentinel in it would make a leak assertion ambiguous.
+_JOURNAL_PROBE_EXTERNAL_ID = "runtime-probe-journal-970"
+_JOURNAL_PROBE_TS = datetime(2026, 5, 1, tzinfo=UTC).isoformat()
+# The refused caller's *own* text. It must reach no file in the vault: a
+# refusal that still staged or wrote this body would be the #970 bug with a
+# tidier response.
+_JOURNAL_REPLACEMENT_CANARY = "CANARY-RUNTIME-JOURNAL-REPLACEMENT-3a6c"
+
 _PROBE_EXEMPT: dict[str, str] = {
     "creek.draft": (
         "draft_tool needs a DraftGenerator driven over a deployed skills tree; "
@@ -1490,6 +1524,92 @@ def _probe_state_read(vault: Path) -> dict[str, Any]:
     )
 
 
+def _seed_journal_canary(vault: Path) -> None:
+    """Ingest one ``intimate`` journal entry the later overwrite attempt targets.
+
+    The probe has to create its own entry rather than reuse the fixture's
+    fragments: ``creek.journal``'s gate resolves its target through the
+    **source ledger**, keyed on the staged entry's stable path, so a fragment
+    that was never ingested through this tool has no ledger record and the
+    call would be a plain creation. ``canary_vault`` is a bare fragment vault,
+    so the meta subtree is created first — the same reason
+    :func:`_probe_report` creates ``00-Creek-Meta``, widened to the layout
+    ``tests/test_mcp_journal.py`` gives the real ingest.
+
+    Seeded at ``ceiling=all`` so the intimate entry is genuinely admitted and
+    genuinely stored — the probe below then attempts to destroy it from
+    ``ceiling=open``.
+
+    Args:
+        vault: The seeded canary vault, mutated in place.
+    """
+    for sub in ("00-Creek-Meta/State", "00-Creek-Meta/audit"):
+        (vault / sub).mkdir(parents=True, exist_ok=True)
+    seeded = journal_ingest_tool(
+        vault_path=vault,
+        content=f"Intimate journal canary body {_RUNTIME_INTIMATE_CANARY}",
+        external_id=_JOURNAL_PROBE_EXTERNAL_ID,
+        timestamp=_JOURNAL_PROBE_TS,
+        tier="intimate",
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert seeded["status"] == "ok"
+    assert seeded["action"] == "created"
+
+
+def _journal_overwrite_at_open(vault: Path) -> dict[str, Any]:
+    """Re-send the seeded ``external_id`` as ``open`` text at ``ceiling=open``.
+
+    The incoming tier is ``open``, so the pre-existing ``write_tier_allowed``
+    gate admits it; only a gate that ranks the tier of the fragment being
+    *overwritten* refuses this call.
+
+    Args:
+        vault: The seeded canary vault.
+
+    Returns:
+        The tool's response envelope.
+    """
+    return journal_ingest_tool(
+        vault_path=vault,
+        content=f"Open replacement body {_JOURNAL_REPLACEMENT_CANARY}",
+        external_id=_JOURNAL_PROBE_EXTERNAL_ID,
+        timestamp=_JOURNAL_PROBE_TS,
+        tier="open",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+
+def _probe_journal(vault: Path) -> dict[str, Any]:
+    """Seed an intimate entry, then attempt to overwrite it at ``ceiling=open``.
+
+    Args:
+        vault: The seeded canary vault.
+
+    Returns:
+        The tool's response envelope for the overwrite attempt.
+    """
+    _seed_journal_canary(vault)
+    return _journal_overwrite_at_open(vault)
+
+
+def _fragment_bytes(vault: Path) -> dict[Path, bytes]:
+    """Return every fragment file under ``01-Fragments`` mapped to its bytes.
+
+    Args:
+        vault: Vault root.
+
+    Returns:
+        ``{path: bytes}``. A mapping rather than a list so a file that
+        appeared, vanished or moved shows up as a changed key rather than as
+        an off-by-one in a positional comparison.
+    """
+    return {
+        path: path.read_bytes()
+        for path in sorted((vault / "01-Fragments").rglob("*.md"))
+    }
+
+
 _RUNTIME_PROBES: dict[str, Callable[[Path], dict[str, Any]]] = {
     "creek.wheel": _probe_wheel,
     "creek.mine": _probe_mine,
@@ -1498,6 +1618,7 @@ _RUNTIME_PROBES: dict[str, Callable[[Path], dict[str, Any]]] = {
     "creek.report": _probe_report,
     "creek.state.render": _probe_state_render,
     "creek.state.read": _probe_state_read,
+    "creek.journal": _probe_journal,
 }
 """``GATED`` tool → a callable that invokes it at ``ceiling=open``.
 
@@ -1872,4 +1993,80 @@ def test_state_read_probe_refuses_rather_than_merely_staying_quiet(
         "creek.state.read's refusal carries keys beyond the canonical four. "
         "Every extra key on a refusal is derived from content the caller was "
         f"not admitted to.\n\n{response}"
+    )
+
+
+def test_journal_probe_refuses_and_leaves_the_fragment_bytes_untouched(
+    canary_vault: Path,
+) -> None:
+    """``creek.journal``'s evidence is the fragment bytes, not the envelope (#970).
+
+    The shared assertion in
+    ``test_gated_tools_leak_no_above_ceiling_content_at_the_open_ceiling``
+    passes **vacuously** for this tool. ``creek.journal``'s gate answers with
+    the canonical four-key refusal, which carries no content at all — so its
+    envelope is canary-free at ``ceiling=open`` whether or not the ceiling is
+    enforced, and it was canary-free for the whole life of the gap. Worse, the
+    *unfixed* tool answered ``status="ok"`` with a fragment id and no canary
+    either. The envelope check still earns its place as a tripwire against a
+    future response shape that does carry content, but presenting a green
+    layer (f) as evidence that this write path is gated is exactly the #968
+    blind spot: there, a response-level guardrail passed 5/5 while all six
+    report generators went on leaking to disk.
+
+    The evidence that means anything is the bytes on disk, so the fragment
+    files are snapshotted across the refused call and compared. Three
+    directions are pinned: the protected bytes are identical, the intimate
+    canary and its ``intimate`` stamp both survive, and the refused caller's
+    own replacement text reached **no** markdown file anywhere in the vault —
+    the staged copy under ``00-Creek-Meta/adepthood/journal/`` included, which
+    is what makes the gate's position above ``_stage_entry`` checkable here.
+    The seeded canary is asserted present first, as the positive control:
+    without it every exclusion below would hold over a vault where nothing was
+    ever written.
+    """
+    fixture_fragments = set(_fragment_bytes(canary_vault))
+    _seed_journal_canary(canary_vault)
+    before = _fragment_bytes(canary_vault)
+    # Identified as "the file that was not there before the seed" rather than
+    # by directory or by canary match: the fixture's own intimate fragment
+    # carries the same sentinel, and the journal routing directory is an
+    # implementation detail this test has no reason to pin.
+    seeded = sorted(set(before) - fixture_fragments)
+    assert len(seeded) == 1, (
+        "the journal probe's intimate entry is not on disk as exactly one new "
+        f"fragment, so every assertion below is vacuous: {seeded}"
+    )
+    assert _RUNTIME_INTIMATE_CANARY in before[seeded[0]].decode("utf-8")
+
+    response = _journal_overwrite_at_open(canary_vault)
+
+    assert _fragment_bytes(canary_vault) == before, (
+        "creek.journal's update-in-place rewrote an intimate fragment for a "
+        "caller at privacy_tier_ceiling=open. The response envelope carries "
+        "no content either way, so nothing in layer (f)'s shared canary sweep "
+        "could have caught this."
+    )
+    protected = frontmatter.load(seeded[0])
+    assert _RUNTIME_INTIMATE_CANARY in protected.content
+    assert protected.metadata["privacy_tier"] == "intimate"
+    leaked = [
+        path
+        for path in sorted(canary_vault.rglob("*.md"))
+        if _JOURNAL_REPLACEMENT_CANARY in path.read_text(encoding="utf-8")
+    ]
+    assert leaked == [], (
+        "the refused caller's own text was written to the vault anyway: "
+        f"{leaked}. A refusal returned above _stage_entry writes nothing; one "
+        "returned below it leaves a staged entry whose privacy_tier has "
+        "already been rewritten downward."
+    )
+    assert response == refusal_response(
+        tool="creek.journal",
+        ceiling=TierCeiling.OPEN,
+        reason=GENERIC_ABOVE_CEILING_REASON,
+    ), (
+        "creek.journal's refusal carries keys beyond the canonical four. Every "
+        "extra key is derived from a fragment the caller was not admitted to — "
+        f"including the id it resolved.\n\n{response}"
     )


### PR DESCRIPTION
## Summary

- **Gates `creek.journal`'s idempotent update-in-place on the tier of the fragment it would destroy** (#970): you may only overwrite what you could have read. `write_tier_allowed` ranked only the *incoming* entry, so a caller at `ceiling=open` could replace the body of a fragment persisted at `privacy_tier: intimate` — content it was never admitted to read. `creek.purge.*` demands `CREEK_MCP_ELEVATED_TOKEN` for exactly this kind of destruction; this path required only the caller's own, lower ceiling.
- **Moves `_stage_entry` below the gate.** This is the half of the fix that is easy to miss: staging used to run *first*, and the staged copy under `00-Creek-Meta/adepthood/journal/` has no escalate-only ratchet — so a gate bolted on after it returns a correct refusal over an already-destroyed staged entry whose `privacy_tier` has been rewritten *downward*. Reproduced before the fix; pinned by a byte-level test after it.
- **Flips `creek.journal`'s read-gate posture from `UNGATED`-with-`gap_issue=970` to `GATED`**, making it the second production adopter of `read_gate.refuse_above_ceiling` and the first that is a *write* gate — the question it asks ("could this caller have read what it is about to destroy?") is a read question, hence `tier_allowed` via the primitive rather than `write_tier_allowed`, which still gates the incoming tier above it.

### Design notes worth a reviewer's attention

**The gate keys on the existing fragment's CURRENT vault tier** — via the shared `source_tiers` + `max_source_tier` survey — never on the caller's declared `tier` and never on the staged copy's stamp. Both of those are stale the moment `creek classify` escalates a fragment, and a caller-supplied tier is not a gate at all. `test_gate_reads_the_vault_tier_not_the_staged_stamp` is the discriminator: it escalates the fragment on disk only, leaving the staged stamp and the caller's declaration both reading `open`.

**Two fail-closed rules, deliberately distinct — collapsing them breaks one.** No ledger record at all → `content_tier=None` → **admit**, because that is a *creation* and creation must keep working at every ceiling. A ledger record whose fragment does not resolve (purged, deleted out of band, schema-invalid, or tombed into `10-Liminal/Orphaned` where the `01-Fragments` walk cannot see it) → `max_source_tier([])` → `intimate` → **refuse**. Every divergence between this gate's locator and the writer's own id index therefore fails in the safe direction.

**Nothing becomes permanently un-updatable.** The `privacy_tier` ratchet is escalate-only in this codebase, so a fix that could bury an entry would be worse than the bug. No refusal is persisted; an `intimate` entry stays updatable at `ceiling=intimate`/`all`, proved by a parametrised test rather than reasoned about from the comparator.

**The refusal names nothing.** It carries `GENERIC_ABOVE_CEILING_REASON` and the four-key payload — no fragment id, no tier — because a refusal that ranks the content it withheld is a tier-classification oracle. The refusal audit carries the caller's own arguments only: no `created_tier`, no `affected_fragment_ids`. The accepted residual (an existence-*and-rank* oracle, deliberately blurred against the unresolvable cases) is written up in `journal.py`'s docstring in the style of `reflect.py`'s block.

**Recoverability of an already-clobbered vault: there is none, and the docs now say so.** The overwritten body survives nowhere — provenance records hashes and paths, not content. `docs/mcp.md` documents the operator path (re-send from the Adepthood-held original via a local stdio caller, vault backup, audit-log forensics) and states plainly that no pre-image backup is taken, deliberately: it would mint a second plaintext copy of intimate content.

### Verification is on the bytes, not the response

The read-gate guardrail's layer (f) asserts on the JSON response and is **structurally incapable** of catching this class — on #968 it passed 5/5 while all six report generators leaked to disk. `creek.journal`'s refusal envelope is canary-free whether or not the ceiling is enforced, so its layer-(f) entry passes *vacuously*. It is still added (as a tripwire against a future response shape that carries content), but the real evidence is a companion test asserting the fragment's bytes are unchanged, and its docstring says exactly that.

## Test plan

- `./scripts/check-all.sh` → **12/12 checks passed**, 6815 tests, **94.05%** branch coverage, per-file gate green (219 files ≥80%).
- `tests/test_mcp_journal.py` + `tests/test_mcp_read_gate.py` → **156 passed**.
- pylint **9.69** (≥9.0), xenon `--max-absolute B` clean, interrogate **97.7%** (≥95%).
- Gate 1 RED was verified failing first: 8 failed / 14 passed, with the two byte-level tests failing on **disk-byte inequality** (the staged-file diff landing at the `privacy_tier: intimate` → `open` frontmatter downgrade), not on response shape.

New tests (9 for the gate, plus a malformed-input guard and the read-gate probe pair):

| test | what it pins |
|---|---|
| `test_update_of_an_above_ceiling_fragment_is_refused` | the issue's verbatim reproduction; generic reason, no tier echoed |
| `test_refused_update_leaves_the_fragment_bytes_untouched` | `read_bytes()` equality + the caller's text in **no** `.md` anywhere |
| `test_refused_update_leaves_the_staged_entry_untouched` | fails if the gate is added without moving `_stage_entry` |
| `test_refused_update_is_audited_without_naming_the_fragment` | audit carries caller args only, by **exact equality** |
| `test_creating_a_new_entry_at_a_low_ceiling_still_works` | legitimate creation does not regress |
| `test_within_ceiling_update_still_works` | ordinary edits do not regress |
| `test_intimate_entry_stays_updatable_at_an_admitted_ceiling` | recoverability at `intimate`/`all`, and the tier stamp survives |
| `test_gate_reads_the_vault_tier_not_the_staged_stamp` | rejects any impl reading the caller's tier or the stale stamp |
| `test_a_ledger_record_whose_fragment_is_gone_fails_closed` | fail-closed **and** its recovery at `ceiling=all` |
| `test_overwrite_admission_tracks_the_ranking_at_every_tier` | the middle of the ranking, incl. `unclassified` (#961) |
| `test_journal_probe_refuses_and_leaves_the_fragment_bytes_untouched` | layer (f)'s vacuity for this tool, with bytes as the real evidence |

`test_resend_after_purge_restages_cleanly` is unmodified and still passes.

**Mutation-tested.** Neutering the gate (forcing it to resolve no existing
fragment) turns **11** of these tests red, including all three refusal legs of
the ranking table — so the suite fails for the right reason rather than
passing by construction.

### Manual verification

Reproduced the original bug and confirmed the overwritten intimate body survives nowhere in the vault; confirmed the staged copy was clobbered *and* tier-downgraded; measured the gate's cost (linear, ~3.4s at 35k fragments — filed, not fixed); and confirmed empirically that an unchanged idempotent re-send at the remote cap (`ceiling=personal`) is refused once a fragment is escalated to `intimate`, while local `ceiling=all` still succeeds.

## Process notes

Planned by an independent `chief-architect` pass; built by `test-specialist` → `implementation-specialist`; reviewed by `security-specialist` (no BLOCKER, no MAJOR) and `code-review-orchestrator` (**CLEAN**). Three of those specialists ran without a shell in their session and could not execute their own verification, so **every result quoted above was run and observed by the conductor**, not taken on report.

The one substantive review nit — no coverage of the *middle* of the tier ranking — was closed by adding `test_overwrite_admission_tracks_the_ranking_at_every_tier`, written by the conductor rather than a further specialist pass.

Two prose claims this PR originally introduced were found overstated by the security review and corrected before push: "recovery is one broader call" (true only for a *local stdio* caller — remote consumers are capped at `personal`) and "strictly weaker" of the residual oracle (it is no stronger on the *existence* question, but the rank bit is new).

## Follow-ups filed (not fixed here)

- #1080 — `PurgeEngine` leaves a dangling `SourceLedger` record pointing at the purged fragment. Latent before; this gate makes it observable, and it fails closed.
- #1081 — this gate costs a full `01-Fragments` walk per update (~3.4s at 35k, measured). The obvious speedup must not reintroduce the positional timing channel the non-short-circuiting walk exists to prevent.
- #1082 — remote consumers lose idempotent re-sync on entries escalated to `intimate`. Correct security behaviour; whether to carve out the unchanged-content case is a design decision.
- #1083 — `VaultWriter.update_fragment` rewrites the id-index's target without verifying the located file's own `id` (pre-existing; defense-in-depth).

Closes #970
Refs #932, #848, #754, #969, #968
