### PR TITLE
fix(mcp): scope creek.redact.scan to the staging subtree and render paths as scanned (#972)

### DIFF
--- a/creek-tools/creek_mcp/read_gate.py
+++ b/creek-tools/creek_mcp/read_gate.py
@@ -92,6 +92,25 @@ refuses, on ``refuse_above_ceiling``. Read that as #1068's compile/reflect
 reasoning one level up: read's target is not caller-*named*, but it is
 caller-*addressed* and singular, which is the property that decides.
 
+#972 closed ``creek.redact.scan`` one step further out again: by narrowing the
+tool's *domain* rather than filtering its output. There was nothing to filter.
+The scan is a regex pass over bytes that opens no front matter, so it holds no
+tier for any file it names, and the leak was the filename itself — Creek
+fragment filenames are slugified titles. Its gate therefore decides *where*:
+the FEAT-027 staging subtree at every ceiling, because that is the one call
+CrawDad makes and it makes it at whatever ceiling the channel is configured
+for — ``personal`` unless an operator mapped that channel, ``open`` where one
+did — so the subtree has to be admitted at the lowest of them; everything else
+in the vault ranked as ``intimate``, because for all this tool knows it is.
+``refuse_above_ceiling`` was deliberately not adopted, for a sharper reason
+than ``report``'s: :data:`GENERIC_ABOVE_CEILING_REASON` asserts that *resolved
+content* exceeds the ceiling, which would be false here — nothing was resolved
+and nothing was ranked — and useless to a CrawDad operator, whose only
+actionable fact is where they pointed the scan. The gap also had a second half
+no gate could have closed, and it belongs to the same lesson: the response
+rendered a symlinked child under its target's name, so the scope fix is paired
+with a single as-scanned path renderer every field goes through.
+
 :data:`TOOL_POSTURES` is verified by ``tests/test_mcp_read_gate.py``, which
 fails if an entry lies: the manifest must match ``server.list_tools()``
 exactly, a ``GATED`` claim is checked against a real call site in the named
@@ -429,18 +448,71 @@ TOOL_POSTURES: dict[str, ToolPosture] = {
         rationale=_COUNTS_ONLY_RATIONALE,
     ),
     "creek.redact.scan": ToolPosture(
-        posture=ReadPosture.UNGATED_KNOWN_GAP,
+        posture=ReadPosture.GATED,
         rationale=(
-            "The caller names the path and resolve_within_vault confines it to "
-            "the vault, and no matched text is returned — but the confinement "
-            "is to the whole vault, not to the FEAT-027 staging subtree, and "
-            "the tier is never consulted. An open-ceiling caller pointed at "
-            "01-Fragments gets back the filenames of intimate fragments, which "
-            "are slugified titles, plus which PII types each contains. This "
-            "posture was CALLER_NAMED_PATHS until the #932 review; the name "
-            "was true and the conclusion drawn from it was not (#972)."
+            "Closed by narrowing the tool's domain, not by filtering its "
+            "output: the scan is a regex pass over bytes that reads no "
+            "per-file privacy_tier at all, so it has nothing to rank a "
+            "fragment with. _refuse_outside_scan_scope admits the FEAT-027 "
+            "staging subtree 00-Creek-Meta/Inbound/ at every ceiling — "
+            "CrawDad's safety pass runs there at the channel's configured "
+            "ceiling, personal by default and open only where an operator "
+            "mapped that channel (crawdad/crawdad/bot.py::_channel_tier), so "
+            "it has to keep working at the lowest of them — and ranks every "
+            "other in-vault target as if it held intimate content, so only "
+            "ceiling=intimate or all admits it. Consequence to know: that is "
+            "why a personal-ceiling caller cannot scan 09-Reference/ either — "
+            "the tool cannot tell it from 01-Fragments. Ordering is "
+            "load-bearing: the gate sits ABOVE the existence check, because "
+            "'input_path not found' versus a successful scan is a one-bit "
+            "existence oracle over every slugified fragment title in the "
+            "vault. Below ceiling=intimate all three out-of-scope answers are "
+            "now the same fixed string, derived from the caller's own "
+            "input_path and their own declared ceiling and echoing no tier, "
+            "no counts and no path: the file that is there, the name that is "
+            "nothing, and the symlink that resolves off the vault — which "
+            "resolve_within_vault necessarily catches ABOVE the gate, having "
+            "no resolved path to hand it, and which therefore collapses onto "
+            "the same reason in _outside_vault_reason rather than being "
+            "reordered under it. So for a caller the ceiling does not admit "
+            "vault-wide, the refusal is an oracle for neither existence nor "
+            "rank. The precise 'resolves outside the vault root' message "
+            "survives at ceiling=intimate and all, where it discloses nothing "
+            "the caller could not already read and a dangling link — a stale "
+            "sync folder, a moved drive — is the operator's one actionable "
+            "diagnostic. "
+            "refuse_above_ceiling was deliberately not adopted because its "
+            "generic reason asserts that resolved content was ranked, which "
+            "nothing here ever was. Deliberate divergence from rule 1 above: "
+            "the audit entry DOES record the probed target. It records the "
+            "caller's own input_path string and not the resolved path — which "
+            "for a staged symlink would be an intimate fragment's path — "
+            "because 'where did consumer X aim the scanner' is the actionable "
+            "fact about a security tool, and the string was already the "
+            "caller's. The second, independent half: every path in the "
+            "response — findings, the report_markdown headings CrawDad posts "
+            "verbatim into a channel, and the input_path echo — is "
+            "vault-relative through the single helper _vault_relative, and "
+            "rendered as scanned rather than as resolved, because a renderer "
+            "that resolved first let a symlink staged under Inbound/ disclose "
+            "an intimate fragment's slugified title from inside the admitted "
+            "subtree (#972). The echo is the one exception — it renders the "
+            "already-resolved target — and it is safe only because the gate "
+            "refuses an out-of-scope symlink before there is anything to "
+            "echo. Residuals to know: RedactionScanner.scan_batch still "
+            "follows symlinked children, so such a target's PII types and "
+            "line numbers are still disclosed even though its path no longer "
+            "is, and it counts toward statistics.files_scanned whether or not "
+            "it yields a finding, which is an existence-and-readability bit "
+            "about the target on top of the finding detail (#1087) — bounded "
+            "to symlinked FILES, since rglob does not descend into symlinked "
+            "directories and scan_batch keeps only is_file() children, so a "
+            "link to 01-Fragments/ staged as a directory yields nothing; and "
+            "existence probing *within* Inbound/ still works, which is the "
+            "tool's job rather than a leak."
         ),
-        gap_issue=972,
+        gate_module="creek_mcp.tools.redact",
+        gate_symbol="_refuse_outside_scan_scope",
     ),
     "creek.save": ToolPosture(
         posture=ReadPosture.NO_UNSUPPLIED_READ,

--- a/creek-tools/creek_mcp/server.py
+++ b/creek-tools/creek_mcp/server.py
@@ -512,7 +512,12 @@ def build_server(
         input_path: str,
         privacy_tier_ceiling: TierCeiling = TierCeiling.OPEN,
     ) -> dict[str, Any]:
-        """Read-only PII / secret scan over a vault-relative directory (FEAT-027)."""
+        """Read-only PII / secret scan of the FEAT-027 staging subtree.
+
+        Scoped to ``00-Creek-Meta/Inbound/``, which every ceiling admits. The
+        scan reads no per-file privacy tier, so any other vault path is ranked
+        as intimate content and needs privacy_tier_ceiling=intimate or all.
+        """
         return redact_scan_tool(
             vault_path=vault,
             input_path=input_path,

--- a/creek-tools/creek_mcp/tools/redact.py
+++ b/creek-tools/creek_mcp/tools/redact.py
@@ -7,43 +7,135 @@ a markdown summary suitable for embedding in a Discord reply.
 
 The tool is **read-only**: it never writes to the scanned files and
 never invokes the redactor. ``--apply`` lives behind the CLI for a
-deliberate human-driven step. The default tier is :data:`TierCeiling.OPEN`
-because the scan only reports counts + line numbers + salted hashes —
-no matched text and no file body content leaves the tool.
+deliberate human-driven step, and no matched text ever leaves the tool —
+findings carry counts, line numbers and salted hashes only.
 
 FEAT-027 introduces this tool so CrawDad can run the safety pass on
 Discord attachments staged under ``00-Creek-Meta/Inbound/`` before any
 ``creek.ingest`` call is dispatched.
 
-Read-side posture (#972): "no matched text leaves the tool" is true and is
-not sufficient. ``resolve_within_vault`` confines *input_path* to the whole
-vault rather than to the staging subtree above, and the tier is never
-consulted, so an ``open``-ceiling caller may aim the scan at
-``01-Fragments``. What comes back is the *filename* of every matching
-fragment — and Creek fragment filenames are slugified titles — together
-with the PII types and line numbers each contains. Reproduced: a fragment
-at ``privacy_tier: intimate`` surfaced as
+**Scope, not a per-file tier filter (#972).** The scan is a regex pass over
+bytes: it opens no front matter and reads no ``privacy_tier`` from anything
+it walks, so it has nothing to rank a fragment *with*. The gate
+(:func:`_refuse_outside_scan_scope`) therefore decides *where* the tool may
+look rather than *what* it may report, in two parts. The staging subtree
+above is admitted at **every** ceiling — it is the reason the tool exists,
+and CrawDad's safety pass runs there at the channel's configured ceiling
+(``crawdad/crawdad/bot.py::_channel_tier``): ``personal`` by default and
+``open`` only for a channel an operator explicitly mapped to it, so
+admission has to hold at the lowest of them. Every other in-vault target is
+ranked as if it held ``intimate`` content, because for all this tool knows
+it does, so only ``ceiling=intimate`` or ``all`` admits it. That is coarser
+than a tier filter on purpose: ``resolve_within_vault`` confines
+*input_path* to the whole vault, which is true and insufficient, since the
+vault is where the fragments are and a finding names the file it came from
+— and Creek fragment filenames are slugified titles. Reproduced before the
+gate: a fragment at ``privacy_tier: intimate`` surfaced as
 ``01-Fragments/Notes/my-affair-with-dana.md`` at ``ceiling=open``.
-Separately, ``report_markdown`` is built by
-:meth:`~creek.redact.scanner.RedactionScanner.generate_markdown_summary`
-and bypasses the vault-relative rendering :func:`_finding_to_dict` applies,
-so it emits absolute filesystem paths despite that function's docstring.
+
+The gate sits **above** the existence check, and that ordering is
+load-bearing. Below it, ``"input_path not found: …"`` versus a successful
+scan is a one-bit existence oracle over every slugified title in the vault:
+a caller who cannot read ``01-Fragments`` could still ask, one filename at
+a time, what is in it. The refusal is derived only from the caller's own
+*input_path* and their own declared ceiling, so it carries the canonical
+four keys and nothing else — a ``statistics`` block reporting
+``files_scanned: 0`` would put the same differential back in a tidier
+wrapper.
+
+One refusal necessarily sits *above* the gate rather than below it:
+``resolve_within_vault`` answers ``None`` for a path that lands off the
+vault, and there is no resolved path left for the gate to measure. Moving
+the gate up instead would measure an uncollapsed ``../`` traversal against
+the staging subtree *by name*, which is the one thing resolution is there
+to prevent — so the arm stays where it is and its *reason* varies instead.
+:func:`_outside_vault_reason` is that decision, and the oracle it closes.
+
+**Every path is rendered as scanned**, bar one documented echo.
+:func:`_vault_relative` is the single owner of ``findings[].file_path``, of
+the ``### `…``` headings inside ``report_markdown`` (the field CrawDad posts
+verbatim into a Discord channel), and of the response's own ``input_path``
+echo, so a reviewer who checks one has checked all three. It never resolves
+the path it renders, which is the second and independent half of the
+disclosure:
+:meth:`~creek.redact.scanner.RedactionScanner.scan_batch` reaches its
+children through ``rglob``, which yields symlinks unresolved, so a resolving
+renderer reported a link staged at ``00-Creek-Meta/Inbound/ch1/sneaky.md``
+under its *target's* name — an intimate fragment's slugified title, at
+``ceiling=open``, out of a scan the scope gate correctly admitted. The echo
+is the exception, and it is an exception only in wording: it renders
+``resolved``, which :func:`~creek_mcp.path_confinement.resolve_within_vault`
+has already followed, so it is as-*resolved*. Nothing leaks through it
+because the only target ever echoed is one the scope gate admitted — a
+symlink out of the staging subtree is refused above the echo, never renamed
+by it.
+
+Residual, tracked by **#1087**: ``scan_batch`` still *follows* symlinked
+children, so such a target's PII types and line numbers are still reported
+even though its path no longer is — and it counts toward ``files_scanned``
+whether or not it yields a finding, so the residual carries an
+existence-and-readability bit about the target as well as finding detail.
+It is bounded to symlinked **files**: ``rglob`` does not descend into
+symlinked directories and ``scan_batch`` keeps only ``is_file()`` children,
+so a link to ``01-Fragments/`` staged as a directory yields nothing at all.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
 
 from creek.config import load_config
+from creek.models import PrivacyTier
 from creek.redact.scanner import RedactionMatch, RedactionScanner, ScanSummary
 from creek_mcp.audit import MCPAuditLog
 from creek_mcp.path_confinement import resolve_within_vault
-from creek_mcp.tier_ceiling import TierCeiling, refusal_response
-
-if TYPE_CHECKING:
-    from pathlib import Path
+from creek_mcp.tier_ceiling import TierCeiling, refusal_response, tier_allowed
 
 TOOL_NAME = "creek.redact.scan"
+
+_STAGING_SUBDIR = Path("00-Creek-Meta/Inbound")
+"""The FEAT-027 staging subtree — the one scope admitted at every ceiling."""
+
+_OUT_OF_SCOPE_REASON = (
+    "creek.redact.scan is scoped to the 00-Creek-Meta/Inbound/ staging "
+    "subtree, which every ceiling admits; the scan reads no per-file privacy "
+    "tier, so any other vault path is ranked as intimate content and needs a "
+    "ceiling of intimate or all."
+)
+"""The one refusal reason for an out-of-scope target.
+
+*One*, deliberately: :func:`_outside_vault_reason` routes a path that
+resolves off the vault here too whenever the caller is not admitted
+vault-wide, since such a path is outside the staging subtree as surely as an
+ordinary fragment is.
+
+Fixed, in the same spirit as
+:data:`creek_mcp.read_gate.GENERIC_ABOVE_CEILING_REASON` and for the
+opposite reason: that one names no tier because the tier was derived from
+content the caller cannot read, while this one names the rule outright
+because nothing here was derived from anything — the rule is a property of
+the *caller's own* path and ceiling, and it is the single fact a CrawDad
+operator can act on. Nothing is interpolated into it, so the refusals for a
+target that exists, one that does not, and one whose symlink leads off the
+vault entirely are byte-identical.
+"""
+
+_OUTSIDE_VAULT_PLACEHOLDER = "<path outside vault>"
+"""Rendering for a path :func:`_vault_relative` cannot express vault-relative.
+
+Rendering is the last thing that happens to a path, so its fallback arm is
+where a "cannot happen" case would become the disclosure the scope gate
+exists to prevent — the arm it replaces returned the absolute path, in full,
+precisely when something unexpected had happened.
+
+The value has to survive a ``str(Path(...))`` round trip unchanged, because
+:func:`_relativised_summary` carries it as a :class:`~pathlib.Path` into
+:meth:`~creek.redact.scanner.RedactionScanner.generate_markdown_summary`:
+the empty string would come back as ``"."`` and a leading slash would come
+back looking absolute.
+"""
 
 
 def redact_scan_tool(
@@ -56,19 +148,26 @@ def redact_scan_tool(
     """Scan *input_path* for sensitive data and return a structured report.
 
     Args:
-        vault_path: Vault root used for path validation and audit logging.
-        input_path: Directory to scan; may be absolute or relative to the
-            vault root. The path must resolve *inside* the vault to
-            prevent the MCP surface from scanning arbitrary disk content.
-        privacy_tier_ceiling: Caller's tier ceiling. Recorded in the
-            audit entry; the scan never returns matched text so the
-            ceiling does not gate the body.
+        vault_path: Vault root used for path validation, scope resolution,
+            path rendering and audit logging.
+        input_path: Directory or file to scan; may be absolute or relative
+            to the vault root. The path must resolve *inside* the vault and
+            *within the scan's scope* — see :func:`_refuse_outside_scan_scope`
+            for what the ceiling decides and what it cannot, and
+            :func:`_outside_vault_reason` for why failing the first of those
+            two looks, to an un-admitted caller, exactly like failing the
+            second.
+        privacy_tier_ceiling: Caller's tier ceiling. Recorded in the audit
+            entry, and the admission half of the scope gate.
         consumer: Identifier of the calling client (recorded in audit).
 
     Returns:
-        A dict with ``status`` (``ok`` / ``empty`` / ``refused``), the
-        scan statistics, a list of findings (hash + location + severity
-        — never the matched text), and a human-readable markdown summary.
+        A dict with ``status`` (``ok`` / ``empty`` / ``refused``), the scan
+        statistics, a list of findings (hash + location + severity — never
+        the matched text), and a human-readable markdown summary. Every path
+        in it is vault-relative and rendered as scanned, except the
+        ``input_path`` echo, which renders the already-resolved target — see
+        the module docstring for why that is safe here and not in general.
     """
     MCPAuditLog(vault_path).append(
         tool=TOOL_NAME,
@@ -79,14 +178,24 @@ def redact_scan_tool(
 
     resolved = resolve_within_vault(vault_path, input_path)
     if resolved is None:
+        # Stays above the scope gate, which has no resolved path to measure
+        # here; the reason varies instead. See _outside_vault_reason.
         return refusal_response(
             tool=TOOL_NAME,
             ceiling=privacy_tier_ceiling,
-            reason=(
-                f"input_path {input_path!r} resolves outside the vault root; "
-                "the scan tool only operates on vault-relative paths."
-            ),
+            reason=_outside_vault_reason(input_path, privacy_tier_ceiling),
         )
+
+    # Above the existence check on purpose: the two answers below it differ
+    # per target, and that difference is an existence oracle over slugified
+    # fragment titles. See the module docstring.
+    out_of_scope = _refuse_outside_scan_scope(
+        resolved=resolved,
+        vault_path=vault_path,
+        ceiling=privacy_tier_ceiling,
+    )
+    if out_of_scope is not None:
+        return out_of_scope
 
     if not resolved.exists():
         return refusal_response(
@@ -104,40 +213,235 @@ def redact_scan_tool(
     else:
         summary = scanner.scan_batch(resolved)
 
-    status = "empty" if not summary.matches else "ok"
+    scanned = _relativised_summary(summary, vault_path)
+    status = "empty" if not scanned.matches else "ok"
     return {
         "status": status,
         "tool": TOOL_NAME,
         "tier_ceiling": privacy_tier_ceiling.value,
-        "input_path": str(resolved.relative_to(vault_path)),
+        "input_path": _vault_relative(resolved, vault_path),
         "statistics": {
-            "files_scanned": summary.files_scanned,
-            "files_skipped_binary": summary.files_skipped_binary,
-            "files_skipped_extension": summary.files_skipped_extension,
-            "total_findings": len(summary.matches),
+            "files_scanned": scanned.files_scanned,
+            "files_skipped_binary": scanned.files_skipped_binary,
+            "files_skipped_extension": scanned.files_skipped_extension,
+            "total_findings": len(scanned.matches),
         },
-        "findings": [_finding_to_dict(m, vault_path) for m in summary.matches],
-        "report_markdown": scanner.generate_markdown_summary(summary),
+        "findings": [_finding_to_dict(match) for match in scanned.matches],
+        "report_markdown": scanner.generate_markdown_summary(scanned),
     }
 
 
-def _finding_to_dict(match: RedactionMatch, vault_path: Path) -> dict[str, Any]:
+def _admitted_vault_wide(ceiling: TierCeiling) -> bool:
+    """Return ``True`` when *ceiling* admits every in-vault target.
+
+    The one admission question this tool asks, written once because two
+    refusal arms need the same answer and a second copy is how they drift
+    apart: the scope gate below, and the off-vault arm above it that must not
+    be more precise than the gate would have been. The scan reads no
+    per-file tier, so everything outside the staging subtree is ranked as if
+    it held ``intimate`` content — which makes "admitted to that rank" and
+    "admitted to the whole vault" the same predicate rather than two.
+
+    Args:
+        ceiling: The caller's declared ceiling.
+
+    Returns:
+        ``True`` for ``intimate`` and ``all``, decided by
+        :func:`~creek_mcp.tier_ceiling.tier_allowed` so this module grows no
+        private copy of the ranking the rest of the surface uses.
+    """
+    return tier_allowed(PrivacyTier.INTIMATE, ceiling)
+
+
+def _outside_vault_reason(input_path: str, ceiling: TierCeiling) -> str:
+    """Return the refusal reason for an *input_path* that resolves off the vault.
+
+    Two reasons, because the precise one is an oracle for a caller who is not
+    admitted vault-wide. Escaping the vault is reachable from *inside* it: a
+    symlink parked at ``01-Fragments/Notes/x.md`` pointing at another disk
+    resolves out and takes this arm, while the ordinary file beside it and
+    the name of a file that does not exist at all both take the scope gate's.
+    A distinguishable message here therefore answers "is the path you named
+    an outward link?" about a subtree the gate refuses to say anything about
+    — one guessed slugified title at a time, which is the same probe the gate
+    was placed above the existence check to stop. Collapsing onto
+    :data:`_OUT_OF_SCOPE_REASON` gives up nothing true: whatever resolves off
+    the vault is, by definition, outside the staging subtree.
+
+    Withheld rather than deleted. At ``intimate`` or ``all`` the caller is
+    already admitted to every in-vault target the precise message could
+    distinguish this one from, so it discloses nothing there — and it is the
+    only actionable fact in the refusal, because a link into a stale sync
+    folder or a moved drive is *broken*, not out of scope, and "out of scope"
+    would send an operator looking for a permissions problem they do not have.
+
+    The price, worth stating because CrawDad pays it by default: its channels
+    run at ``personal`` unless mapped, so a misconfigured staging root reaches
+    a CrawDad operator as the out-of-scope rule rather than as "off the
+    vault". The audit trail still records the ``input_path`` the call aimed
+    at, and a local operator can reproduce the precise message at
+    ``ceiling=intimate``.
+
+    Args:
+        input_path: The caller's own path string. Interpolated into the
+            precise message only; the collapsed one is fixed text, so the
+            refusals for an outward link, an ordinary out-of-scope file and
+            a path that names nothing are byte-identical.
+        ceiling: The caller's declared ceiling.
+
+    Returns:
+        The precise outside-the-vault message when *ceiling* admits the whole
+        vault, and :data:`_OUT_OF_SCOPE_REASON` when it does not.
+    """
+    # Deliberately less precise than the arm below, on the argument above —
+    # not an oversight to be tightened back up without reading it.
+    if not _admitted_vault_wide(ceiling):
+        return _OUT_OF_SCOPE_REASON
+    return (
+        f"input_path {input_path!r} resolves outside the vault root; "
+        "the scan tool only operates on vault-relative paths."
+    )
+
+
+def _refuse_outside_scan_scope(
+    *,
+    resolved: Path,
+    vault_path: Path,
+    ceiling: TierCeiling,
+) -> dict[str, Any] | None:
+    """Return the out-of-scope refusal for *resolved*, or ``None`` to admit.
+
+    Admission is decided by *where* the target is and never by what is in it,
+    because the scan opens no front matter and so has no per-file tier to
+    consult. The staging subtree is admitted unconditionally; every other
+    in-vault target is admitted only to a caller
+    :func:`_admitted_vault_wide` clears, which is where that ranking is
+    written down — once, for this arm and for the off-vault arm above it.
+
+    Args:
+        resolved: *input_path* as returned by
+            :func:`~creek_mcp.path_confinement.resolve_within_vault` — already
+            confined to the vault and already symlink-resolved, which is what
+            stops a link parked under ``Inbound/`` naming its way into scope.
+            Matched with :meth:`~pathlib.Path.is_relative_to` rather than a
+            string prefix, so ``Inbound-other/`` is not mistaken for a child
+            and the subtree root itself still counts.
+        vault_path: Vault root. Resolved here so a root reached through a
+            symlinked component still matches its own staging subtree.
+        ceiling: The caller's declared ceiling.
+
+    Returns:
+        ``None`` when the scan may proceed, so a call site reads as an early
+        return on a non-``None`` result. Otherwise the canonical four-key
+        :func:`~creek_mcp.tier_ceiling.refusal_response` carrying
+        :data:`_OUT_OF_SCOPE_REASON` — and nothing else. Anything further
+        would be derived from a subtree the caller was just refused.
+    """
+    if resolved.is_relative_to(vault_path.resolve() / _STAGING_SUBDIR):
+        return None
+    if _admitted_vault_wide(ceiling):
+        return None
+    return refusal_response(
+        tool=TOOL_NAME,
+        ceiling=ceiling,
+        reason=_OUT_OF_SCOPE_REASON,
+    )
+
+
+def _vault_relative(path: Path, vault_path: Path) -> str:
+    """Render *path* **as scanned**, relative to the vault root.
+
+    *path* is deliberately not resolved. ``rglob`` yields symlinked children
+    unresolved, so resolving here reports a link staged under ``Inbound/``
+    beneath its target's name — the disclosure described in the module
+    docstring, arriving through a scan the scope gate correctly admitted. The
+    path a finding names must be the path the scanner opened.
+
+    The vault *root* is resolved, because that is what every scanned path
+    descends from: they are all built from
+    :func:`~creek_mcp.path_confinement.resolve_within_vault`'s already-resolved
+    output. Comparing them against an unresolved root is what raised an
+    unhandled ``ValueError`` out of the MCP boundary for any vault whose root
+    has a symlinked component — ``/tmp`` on macOS, or a synced folder reached
+    through a link.
+
+    Args:
+        path: A path the scan produced, or the scan target itself. The
+            latter arrives already resolved from
+            :func:`~creek_mcp.path_confinement.resolve_within_vault`, so the
+            response's ``input_path`` echo is strictly as-*resolved* rather
+            than as-scanned — safe only because the scope gate refuses an
+            out-of-scope symlink before there is anything to echo.
+        vault_path: Vault root, as the caller supplied it.
+
+    Returns:
+        The vault-relative rendering, or :data:`_OUTSIDE_VAULT_PLACEHOLDER`
+        when *path* cannot be expressed relative to the root at all — never
+        the absolute path.
+    """
+    try:
+        return str(path.relative_to(vault_path.resolve()))
+    except ValueError:
+        return _OUTSIDE_VAULT_PLACEHOLDER
+
+
+def _relativised_summary(summary: ScanSummary, vault_path: Path) -> ScanSummary:
+    """Return *summary* with every match's ``file_path`` rendered for the caller.
+
+    One relativised summary feeds both renderings of the response —
+    ``findings`` via :func:`_finding_to_dict` and ``report_markdown`` via
+    :meth:`~creek.redact.scanner.RedactionScanner.generate_markdown_summary`
+    — so the two cannot name the same file in two different ways, which is
+    what they did before #972: one vault-relative, the other absolute.
+
+    Never hand the result to
+    :meth:`~creek.redact.scanner.RedactionScanner.generate_review_queue`: it
+    calls ``extract_context(fm.file_path)`` and would reopen a vault-relative
+    path against the process cwd. For the same reason the CLI
+    (``creek/redact/cli_commands.py``) keeps rendering absolute paths, and
+    that is deliberate rather than an oversight — a local operator needs real
+    paths, and ``--apply`` reopens the files named in the summary it is given.
+
+    Args:
+        summary: The scan result, holding absolute on-disk paths.
+        vault_path: Vault root the paths are rendered against.
+
+    Returns:
+        A new :class:`~creek.redact.scanner.ScanSummary` carrying the same
+        matches and the same three file counters, with each ``file_path``
+        replaced by its :func:`_vault_relative` rendering.
+    """
+    rendered = [
+        match.model_copy(
+            update={"file_path": Path(_vault_relative(match.file_path, vault_path))},
+        )
+        for match in summary.matches
+    ]
+    return replace(summary, matches=rendered)
+
+
+def _finding_to_dict(match: RedactionMatch) -> dict[str, Any]:
     """Convert a :class:`RedactionMatch` into a JSON-friendly dict.
 
-    The ``file_path`` is rendered relative to the vault root so the
-    Discord reply does not leak absolute filesystem paths.
+    ``file_path`` is emitted verbatim: *match* has already been through
+    :func:`_relativised_summary`, which is what finally made this docstring's
+    long-standing claim — that findings are rendered relative to the vault
+    root, so the Discord reply leaks no absolute filesystem paths — true of
+    ``report_markdown`` as well as of ``findings``.
+
+    Args:
+        match: One finding from the relativised summary.
+
+    Returns:
+        The finding's location, type, severity and salted hash. Never the
+        matched text.
     """
     from creek.redact.patterns import PATTERN_METADATA
 
     info = PATTERN_METADATA.get(match.match_type)
     severity = info.severity if info else "unknown"
-    try:
-        rel = match.file_path.resolve().relative_to(vault_path.resolve())
-        path_str = str(rel)
-    except ValueError:
-        path_str = str(match.file_path)
     return {
-        "file_path": path_str,
+        "file_path": str(match.file_path),
         "line_number": match.line_number,
         "match_type": match.match_type,
         "severity": severity,

--- a/creek-tools/docs/mcp.md
+++ b/creek-tools/docs/mcp.md
@@ -41,6 +41,7 @@ cross-repo contract is
 | `creek.lint`          | Run the unified hygiene lint pass (FEAT-008).              |
 | `creek.mine`          | Surface essay seeds from the compiled vault layer.         |
 | `creek.draft`         | Draft an essay from a mined idea (requires an LLM).        |
+| `creek.redact.scan`   | Regex-scan a path for secrets/PII (FEAT-027); scoped to `00-Creek-Meta/Inbound/` at every ceiling, `intimate`/`all` elsewhere in the vault (#972). |
 
 #### The two `creek.state.*` tools gate in different shapes (#969)
 
@@ -126,6 +127,47 @@ artefacts in the operator's vault and break `latest.md` as the documented
 session-start context. `creek.state.render`'s default ceiling is `open`, so a
 **bare MCP render narrows `latest.md` for everyone**, including subsequent CLI
 reads. A caller that wants the richer report re-renders at the broader ceiling.
+
+#### `creek.redact.scan` is scoped, not tier-filtered (#972)
+
+The scan is a regex pass over bytes: it opens no front matter and reads no
+`privacy_tier` from anything it walks, so it has nothing to rank a fragment
+*with*. Its gate (`_refuse_outside_scan_scope`) therefore decides *where*
+the tool may look, in two parts. `00-Creek-Meta/Inbound/` — the FEAT-027
+staging subtree, where CrawDad stages Discord attachments before
+`creek.ingest` runs — is admitted at **every** ceiling, because that is the
+one call CrawDad makes, and it runs the safety pass there at the channel's
+own configured ceiling (`personal` by default, `open` only where an operator
+explicitly mapped that channel — `crawdad/crawdad/bot.py::_channel_tier`),
+so admission has to hold at the lowest of them. Every other in-vault target
+— `09-Reference/` as much as `01-Fragments/` — is ranked as if it held
+`intimate` content, because for all the scan knows it does; only
+`ceiling=intimate` or `all` admits it.
+
+That escape hatch doubles as the recovery path. A local stdio caller at
+`ceiling=intimate`/`all` can scan any vault path, and a bad path there gets
+the precise "resolves outside the vault root" diagnostic rather than the
+generic out-of-scope refusal. A **remote** consumer token is capped at
+`ceiling=personal` (see "INTIMATE is never reachable remotely" below), so it
+can never reach that escape — the whole-vault scan is a local-operator
+capability only.
+
+Two residuals are accepted rather than closed by this fix. **Existence
+probing within `Inbound/` still works** — a caller can still ask whether a
+given staged filename is there — and that is the tool's job, not a leak.
+**`RedactionScanner.scan_batch` still follows symlinked files** it walks
+into, so a symlink staged under `Inbound/` still discloses its target's PII
+types, line numbers, and whether it exists at all (it still counts toward
+`statistics.files_scanned`) — even though the fix stops the response from
+disclosing the target's *path* — tracked by #1087. `rglob` does not descend
+into symlinked *directories*, which bounds the residual to symlinked files.
+
+One deployment knob is worth flagging on top of the fix itself: CrawDad's
+staging root is a configurable `staging_subpath`
+(`AttachmentConfig`, default `00-Creek-Meta/Inbound`), not a hardcoded
+constant, so an operator who points it elsewhere gets a subtree the scan's
+hardcoded scope does not recognise as admitted-at-every-ceiling — a real
+deployment gap, tracked by #1088.
 
 ### Author tools (FEAT-041)
 
@@ -298,11 +340,28 @@ guard against a write this gate now refuses.
 One read-side leak was found, and it is worth stating how: the sweep
 first concluded there were none, having probed the tools that walk the
 corpus themselves. `creek.redact.scan` was set aside as "the caller
-named the path" — true, and not sufficient. Its path confinement is to
+named the path" — true, and not sufficient. Its path confinement was to
 the whole vault rather than to the FEAT-027 staging subtree, and it
-returns matching *filenames*, which are slugified fragment titles
-(#972). A posture whose name is accurate can still license a wrong
+returned matching *filenames*, which are slugified fragment titles — the
+filename was the content — plus which PII types and line numbers each one
+carried (#972). A posture whose name is accurate can still license a wrong
 conclusion; that is what the machine-checked manifest is for.
+
+The fix taught a second lesson on top of the first: narrowing *where* a
+tool may look only closes the caller-visible half of a leak like this one.
+`00-Creek-Meta/Inbound/` is now admitted at every ceiling and every other
+vault path is ranked as intimate, because the scan reads no per-file tier
+— but scoping alone would not have stopped a symlink staged under
+`Inbound/` from disclosing its target's slugified title from *inside* the
+admitted subtree. Closing that took a separate look at *how* paths are
+rendered: every finding and the markdown summary CrawDad posts to Discord
+now go through one renderer that names a path **as scanned**, never as
+resolved — because `RedactionScanner.scan_batch` yields symlinked children
+unresolved, and a renderer that resolved first reported such a symlink
+under its target's name, out of a scan the scope fix alone would still
+have admitted. See "`creek.redact.scan` is scoped, not tier-filtered" under
+Read tools above for the full shape of the fix, including the two residuals
+it accepts.
 
 ### Elevated-authorization model (FEAT-012)
 

--- a/creek-tools/docs/redaction.md
+++ b/creek-tools/docs/redaction.md
@@ -4,6 +4,8 @@
 
 > Redaction is one defensive layer; it does not encrypt the vault and it cannot detect every secret format. Read the [threat model](security/threat-model.md) for the full picture of what Creek does and does not protect against.
 
+This page covers the `creek redact` CLI. For the read-only MCP tool version of the scan (`creek.redact.scan`, the one CrawDad's Discord safety pass calls), see [mcp.md](mcp.md).
+
 ## The three modes
 
 `creek redact` is dispatched by exactly one of `--scan`, `--apply`, or `--review`. Mixing them is an error.

--- a/creek-tools/tests/test_mcp_read_gate.py
+++ b/creek-tools/tests/test_mcp_read_gate.py
@@ -86,6 +86,7 @@ from typing import TYPE_CHECKING, Any, cast
 import frontmatter
 import pytest
 
+from creek.config import CreekConfig
 from creek.models import PrivacyTier
 from creek_mcp.read_gate import (
     CANONICAL_GATE_PRIMITIVES,
@@ -100,6 +101,7 @@ from creek_mcp.tier_ceiling import TierCeiling, refusal_response
 from creek_mcp.tools.compile import _ABOVE_CEILING_REASON, compile_tool
 from creek_mcp.tools.journal import journal_ingest_tool
 from creek_mcp.tools.mine import mine_tool
+from creek_mcp.tools.redact import _OUT_OF_SCOPE_REASON, redact_scan_tool
 from creek_mcp.tools.reflect import reflect_tool
 from creek_mcp.tools.report import report_tool
 from creek_mcp.tools.state import state_render_tool
@@ -176,17 +178,32 @@ _PINNED_GATE_ROWS = [
     # the behaviour from drifting apart — the property the deleted
     # ``test_journal_is_pinned_as_no_unsupplied_read`` used to hold.
     ("creek.journal", "creek_mcp.tools.journal", "refuse_above_ceiling"),
+    # #972 closed the redact gap, and this row is a re-point of the same kind
+    # #968/#969/#970 made. The gap entry it replaces was recorded as
+    # CALLER_NAMED_PATHS until the #932 review: the caller *does* name the
+    # path, which was true and insufficient, because ``resolve_within_vault``
+    # confines that path to the whole vault and a finding names the file it
+    # came from — and Creek fragment filenames are slugified titles, so an
+    # open-ceiling caller aimed at 01-Fragments read intimate titles off the
+    # response.
+    #
+    # It closed by **scope** plus an as-scanned path renderer, not by adopting
+    # either canonical primitive, so layer (e) has nothing to say about it and
+    # layers (c)/(f) carry the weight. ``_refuse_outside_scan_scope`` admits
+    # the FEAT-027 staging subtree at every ceiling and ranks every other
+    # in-vault target as intimate, because the scan is a regex pass over bytes
+    # that reads no per-file tiers and therefore has nothing to rank a
+    # fragment *with*. ``refuse_above_ceiling`` was deliberately NOT adopted
+    # for exactly that reason: it would carry GENERIC_ABOVE_CEILING_REASON —
+    # "resolved content exceeds the declared tier ceiling" — which claims the
+    # tool ranked content it never opened, and tells a CrawDad operator
+    # nothing about the one thing they can act on, which is where they pointed
+    # the scan. Same call #968 made for creek.report, one step further out.
+    ("creek.redact.scan", "creek_mcp.tools.redact", "_refuse_outside_scan_scope"),
 ]
 
 _PINNED_GAPS = {
     "creek.skills.refresh": 971,
-    # Recorded as CALLER_NAMED_PATHS until the #932 Gate-2.5 review. The name
-    # was accurate — the caller does name the path — but the confinement is to
-    # the whole vault, not the FEAT-027 staging subtree, so an open-ceiling
-    # caller aimed at 01-Fragments gets back intimate fragments' filenames,
-    # which are slugified titles. Pinned so the posture cannot drift back to a
-    # reassuring label while the behaviour is unchanged.
-    "creek.redact.scan": 972,
 }
 
 _PINNED_AUTH_TOKEN_TOOLS = [
@@ -384,18 +401,29 @@ def _write_fragment(
     body: str,
     privacy_tier: str,
     tags: list[str] | None = None,
+    file_stem: str | None = None,
 ) -> Path:
     """Write one classified fragment under ``01-Fragments/Notes``.
 
     Args:
         vault: Vault root.
-        frag_id: Fragment id, also used as the file stem.
+        frag_id: Fragment id, and by default the file stem too.
         title: Fragment title — what a personal-tier summary is built from.
         body: Markdown body (a canary string in these tests).
         privacy_tier: The fragment's ``privacy_tier`` front-matter value.
         tags: Optional Obsidian tags. ``None`` — the default — omits the key
             entirely rather than writing an empty list, so front matter written
             by the callers that predate layer (f) is byte-identical to before.
+        file_stem: Filename stem, when it must differ from *frag_id*. Added for
+            :func:`_seed_redact_canaries`, whose whole point is a sentinel that
+            lives in the **filename** — Creek fragment filenames are slugified
+            titles, and ``creek.redact.scan`` reports the file a finding came
+            from. Defaults to *frag_id*, so every caller that predates it
+            writes byte-identical front matter to the same path as before. The
+            two are kept separable rather than folded together because a
+            canary in an *id* would be echoed back legitimately by
+            ``creek.reflect`` and ``creek.compile``, which are handed the id by
+            the caller — see :data:`_RUNTIME_INTIMATE_ID`.
 
     Returns:
         The path the fragment was written to.
@@ -413,7 +441,7 @@ def _write_fragment(
     }
     if tags is not None:
         metadata["tags"] = tags
-    target = vault / "01-Fragments" / "Notes" / f"{frag_id}.md"
+    target = vault / "01-Fragments" / "Notes" / f"{file_stem or frag_id}.md"
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text(
         frontmatter.dumps(frontmatter.Post(content=body, **metadata)),
@@ -1593,6 +1621,99 @@ def _probe_journal(vault: Path) -> dict[str, Any]:
     return _journal_overwrite_at_open(vault)
 
 
+_REDACT_PII_LINE = "Reach me at someone@example.com any time."
+"""One real ``email`` match, so a redact scan of the file yields findings.
+
+``creek.redact.scan`` reports nothing about a file it finds nothing in, so a
+carrier with no PII in it would never appear in the response at all and the
+canary assertions below would hold over an empty findings list.
+"""
+
+_REDACT_SCAN_TARGET = "01-Fragments"
+"""The out-of-scope subtree ``_probe_redact_scan`` aims at."""
+
+_REDACT_STAGING_TARGET = "00-Creek-Meta/Inbound"
+"""The FEAT-027 staging subtree, admitted at every ceiling."""
+
+
+def _seed_redact_canaries(vault: Path) -> None:
+    """Give the redact probe carriers whose sentinels live in **filenames**.
+
+    ``canary_vault`` is structurally blind to this leak class, in exactly the
+    way :func:`_seed_state_carriers`' docstring warns about. Two independent
+    reasons, and either one alone would make the probe vacuous:
+
+    * The fixture's file stems come from ``frag_id``
+      (``frag-runtime-intimate``), and the sentinels live in the ``title``,
+      the body and the ``tags``. ``creek.redact.scan`` returns none of those
+      three — it returns the *path* of each file a pattern matched in, plus a
+      line number and a salted hash — so no canary is anywhere it could
+      surface.
+    * The fixture's fragments carry no PII, so the scanner matches nothing in
+      them and reports them not at all.
+
+    Run the probe over the bare fixture and it comes back canary-free whether
+    or not any gate exists, which is a green layer (f) that proves nothing.
+
+    So this seeds two carriers of the shape the tool actually reports. (a) An
+    ``intimate`` fragment whose **file stem** carries
+    :data:`_RUNTIME_INTIMATE_CANARY` and whose body carries a real email
+    match — the thing an ``open``-ceiling caller must not be able to name,
+    and a faithful model of the real leak, since Creek fragment filenames are
+    slugified titles. (b) A staged file under ``00-Creek-Meta/Inbound/`` whose
+    file stem carries :data:`_RUNTIME_OPEN_CANARY` and whose body carries the
+    same match — the positive control, asserted *present* by the probe's own
+    test so a gate broken in the refuse-everything direction cannot pass by
+    returning nothing.
+
+    Both bodies are deliberately canary-free: the scan never returns matched
+    text, so a sentinel in a body could not surface even through a completely
+    ungated tool, and its absence from the response would be evidence about
+    nothing.
+
+    Args:
+        vault: The seeded canary vault, mutated in place.
+    """
+    _write_fragment(
+        vault,
+        frag_id="frag-redact-intimate",
+        title="Intimate redact carrier",
+        body=_REDACT_PII_LINE,
+        privacy_tier="intimate",
+        file_stem=f"redact-carrier-{_RUNTIME_INTIMATE_CANARY}",
+    )
+    staged = vault / "00-Creek-Meta" / "Inbound" / "ch1"
+    staged.mkdir(parents=True, exist_ok=True)
+    (staged / f"attachment-{_RUNTIME_OPEN_CANARY}.md").write_text(
+        f"{_REDACT_PII_LINE}\n",
+        encoding="utf-8",
+    )
+
+
+def _probe_redact_scan(vault: Path) -> dict[str, Any]:
+    """Aim ``creek.redact.scan`` at ``01-Fragments`` from the open ceiling.
+
+    The scope gate answers above ``load_config()`` — and above the existence
+    check, so the refusal cannot be used as an existence oracle over slugified
+    filenames — which is what keeps layer (f) a unit test: no config file, no
+    provider, no skills tree. The audit log is appended before the gate, by
+    design, and creates its own parent directory, so the bare fixture needs no
+    ``00-Creek-Meta`` of its own.
+
+    Args:
+        vault: The seeded canary vault.
+
+    Returns:
+        The tool's response envelope.
+    """
+    _seed_redact_canaries(vault)
+    return redact_scan_tool(
+        vault_path=vault,
+        input_path=_REDACT_SCAN_TARGET,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+
 def _fragment_bytes(vault: Path) -> dict[Path, bytes]:
     """Return every fragment file under ``01-Fragments`` mapped to its bytes.
 
@@ -1619,6 +1740,7 @@ _RUNTIME_PROBES: dict[str, Callable[[Path], dict[str, Any]]] = {
     "creek.state.render": _probe_state_render,
     "creek.state.read": _probe_state_read,
     "creek.journal": _probe_journal,
+    "creek.redact.scan": _probe_redact_scan,
 }
 """``GATED`` tool → a callable that invokes it at ``ceiling=open``.
 
@@ -2070,3 +2192,104 @@ def test_journal_probe_refuses_and_leaves_the_fragment_bytes_untouched(
         "extra key is derived from a fragment the caller was not admitted to — "
         f"including the id it resolved.\n\n{response}"
     )
+
+
+def test_redact_scan_probe_refuses_and_is_not_vacuous(
+    canary_vault: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``creek.redact.scan``'s leak *is* its response, unlike its neighbours (#972).
+
+    Worth stating plainly, because the three tests above it all exist to say
+    the opposite. ``creek.report``'s and ``creek.state.render``'s evidence is
+    the artifact they write, and ``creek.journal``'s is the fragment bytes it
+    overwrites; for all three, the shared assertion in
+    ``test_gated_tools_leak_no_above_ceiling_content_at_the_open_ceiling``
+    passes vacuously or contingently. Here the artifact and the envelope are
+    the same object: the tool's entire output is a list of the files it
+    matched in, and CrawDad posts ``report_markdown`` straight into a Discord
+    channel. So the shared layer-(f) assertion is genuinely load-bearing for
+    this tool — **provided** the seeded carrier puts a sentinel somewhere the
+    response can reach, which is why :func:`_seed_redact_canaries` puts it in
+    a filename rather than in a title, a tag or a body.
+
+    Four things are pinned, and the middle two are the ones that make the
+    first mean anything:
+
+    (a) The open-ceiling probe refuses, with the reason pinned to the module's
+        own ``_OUT_OF_SCOPE_REASON``. A bare ``status == "refused"`` would
+        also pass if the tool merely stopped resolving paths — it has a
+        "not found" refusal too, and at ``ceiling=intimate``/``all`` an
+        "outside the vault" one as well, and neither would say anything about
+        scope. Below that ceiling those two collapse into this same fixed
+        string on purpose (the Gate-2.5 review's M1: a distinguishable
+        off-vault message is an oracle for "there is an outward symlink at
+        exactly this path"), which is what makes the reason pin here a
+        statement about scope rather than about resolution.
+    (b) The *same* ``01-Fragments`` scan at ``ceiling=all`` returns
+        ``status="ok"`` and its serialised response contains the intimate
+        canary. This is the sharpest anti-vacuity control available anywhere
+        in layer (f): it proves the sentinel was genuinely reachable through
+        this exact call, so the open refusal is what withheld it rather than a
+        fixture that never carried it.
+    (c) A scan of ``00-Creek-Meta/Inbound`` at ``ceiling=open`` still returns
+        findings naming the staged canary. FEAT-027 is the reason this tool
+        exists; CrawDad calls it at the channel's configured ceiling —
+        ``personal`` by default, ``open`` where a channel is mapped to it —
+        so admission has to hold at the lowest of them, and a scope gate that
+        refused everything would satisfy (a) perfectly while breaking the only
+        production caller.
+    (d) The vault root appears in none of the three responses — the second
+        half of #972, where ``report_markdown`` rendered absolute paths and
+        leaked the operator's home directory alongside the filename.
+
+    ``load_config`` is stubbed for the admitted calls; the refused one returns
+    above it.
+    """
+    monkeypatch.setattr(
+        "creek_mcp.tools.redact.load_config",
+        lambda: CreekConfig(),
+    )
+    vault_root = str(canary_vault.resolve())
+
+    refused = _probe_redact_scan(canary_vault)
+    assert refused["status"] == "refused"
+    assert refused["reason"] == _OUT_OF_SCOPE_REASON, (
+        "creek.redact.scan refused for some reason other than scope, so this "
+        "probe is evidence that the tool stopped working rather than that it "
+        f"started enforcing anything.\n\n{refused}"
+    )
+    assert refused["tier_ceiling"] == TierCeiling.OPEN.value
+
+    admitted = redact_scan_tool(
+        vault_path=canary_vault,
+        input_path=_REDACT_SCAN_TARGET,
+        privacy_tier_ceiling=TierCeiling.ALL,
+    )
+    assert admitted["status"] == "ok"
+    assert _RUNTIME_INTIMATE_CANARY in json.dumps(admitted, default=str), (
+        "the same 01-Fragments scan at ceiling=all did not surface the "
+        "intimate carrier's filename, so the open-ceiling refusal above "
+        "withheld nothing and every canary assertion in layer (f) is vacuous "
+        f"for this tool.\n\n{admitted}"
+    )
+
+    staged = redact_scan_tool(
+        vault_path=canary_vault,
+        input_path=_REDACT_STAGING_TARGET,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+    assert staged["status"] == "ok"
+    assert _RUNTIME_OPEN_CANARY in json.dumps(staged, default=str), (
+        "the FEAT-027 staging subtree is no longer scannable at ceiling=open. "
+        "That is the one call CrawDad makes, and a scope gate that refuses it "
+        f"has replaced a disclosure with an outage.\n\n{staged}"
+    )
+
+    for response in (refused, admitted, staged):
+        assert vault_root not in json.dumps(response, default=str), (
+            "a creek.redact.scan response embeds the vault root, leaking the "
+            "operator's home directory into whatever CrawDad posts next.\n\n"
+            f"{response}"
+        )

--- a/creek-tools/tests/test_mcp_redact.py
+++ b/creek-tools/tests/test_mcp_redact.py
@@ -3,23 +3,127 @@
 Covers: an empty staging dir, findings present, findings absent, refusal
 for paths outside the vault, refusal for missing paths, audit logging,
 and scanning a single file (not a directory).
+
+#972 adds the other half of the story. Every test above scans under
+``00-Creek-Meta/Inbound/`` — the only subtree FEAT-027 ever asked for — so
+none of them can see what the tool does when a caller aims it somewhere
+else. What it does is answer: an ``open``-ceiling caller pointed at
+``01-Fragments`` gets back the *filenames* of intimate fragments, and Creek
+fragment filenames are slugified titles, so the filename **is** the
+payload. The tests added below pin the two things that close it: the scope
+gate (:func:`~creek_mcp.tools.redact._refuse_outside_scan_scope`) and the
+single fail-closed relativiser
+(:func:`~creek_mcp.tools.redact._vault_relative`) that every path in the
+response is rendered through. Six of the original seven are deliberately
+unchanged, and they double as the FEAT-027 regression: the staging subtree
+must stay admitted at every ceiling, or CrawDad's safety pass stops
+working. The seventh,
+:func:`test_scan_refuses_absolute_path_outside_vault`, keeps its
+confinement assertion and gives up its *wording* assertion, because the
+scope gate subsumes it: an un-admitted caller must not be able to tell an
+outside-the-vault path from an in-vault out-of-scope one, and the reason
+why is written out there.
 """
 
 from __future__ import annotations
 
 import json
+import re
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 
 from creek.config import CreekConfig
 from creek_mcp.audit import MCP_AUDIT_RELPATH
-from creek_mcp.tier_ceiling import TierCeiling
-from creek_mcp.tools.redact import redact_scan_tool
+from creek_mcp.tier_ceiling import TierCeiling, refusal_response
+from creek_mcp.tools.redact import (
+    _OUT_OF_SCOPE_REASON,
+    _OUTSIDE_VAULT_PLACEHOLDER,
+    _vault_relative,
+    redact_scan_tool,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-    from pathlib import Path
+
+_TOOL_NAME = "creek.redact.scan"
+"""The registered tool name, echoed by every response this file inspects.
+
+Spelled out rather than imported from the module under test: the refusal
+payloads below are compared for *equality*, and an equality assertion built
+out of the implementation's own constants can only ever agree with itself.
+"""
+
+_STAGING_ROOT = "00-Creek-Meta/Inbound"
+"""The FEAT-027 staging subtree: the one scope admitted at every ceiling."""
+
+_FRAGMENTS_ROOT = "01-Fragments"
+"""The classified corpus: in the vault, out of the scan's scope."""
+
+_OUTWARD_LINK_RELPATH = f"{_FRAGMENTS_ROOT}/Notes/escape.md"
+"""Where :func:`_plant_outward_symlink` parks a link pointing off the vault.
+
+Spelled as an ordinary fragment path because that is the point: the string a
+caller sends says nothing about whether the file behind it is a link, so any
+difference in the answer is a fact about the vault rather than about the
+request.
+"""
+
+_PII_LINE = "Reach me at someone@example.com any time.\n"
+"""One real ``email`` match, so a scan of the file yields ``status="ok"``.
+
+Findings are what make the path-rendering assertions non-vacuous — a file
+with nothing in it produces no ``### `path``` heading to inspect.
+"""
+
+_INTIMATE_FRONT_MATTER = "---\ntype: fragment\nprivacy_tier: intimate\n---\n\n"
+"""Front matter marking a seeded file as intimate.
+
+The scan reads no per-file tiers — that is precisely why the gate treats
+every out-of-scope target as if it held intimate content — so this is
+documentation of the scenario rather than an input to the gate.
+"""
+
+_FILENAME_CANARY = "CANARY-REDACT-TITLE-8f14"
+"""Sentinel carried in a fragment's **file stem**, never in its body.
+
+A plain sentinel rather than realistic prose, so a leak cannot be excused as
+"that phrase could have come from anywhere". It lives in the filename
+because that is where this tool's leak is: bodies are only ever reported as
+salted hashes, and the tool was already careful about those.
+"""
+
+_OUTSIDE_CANARY = "CANARY-REDACT-OUTSIDE-3b90"
+"""Sentinel for the components of a path the relativiser cannot render.
+
+Every component of the probe path in
+:func:`test_an_unrenderable_path_falls_back_to_a_non_disclosing_placeholder`
+carries it, so "no component of the input survived into the placeholder"
+cannot be satisfied — or falsified — by an accidental substring collision
+with ordinary English wording.
+"""
+
+_HEADING_PATTERN = re.compile(r"^### `(?P<path>.+)`$", re.MULTILINE)
+"""Matches ``generate_markdown_summary``'s per-file headings.
+
+Anchored on the backticks so the ``### By Severity`` heading in the same
+document is not mistaken for a path.
+"""
+
+_ADMITTED_SCANS = [
+    *((_STAGING_ROOT, ceiling) for ceiling in TierCeiling),
+    (_FRAGMENTS_ROOT, TierCeiling.INTIMATE),
+    (_FRAGMENTS_ROOT, TierCeiling.ALL),
+]
+"""Every ``(input_path, ceiling)`` pair the scope gate admits.
+
+Both halves matter: the staging subtree is admitted at *every* ceiling
+(FEAT-027), and the rest of the vault is admitted only where
+``tier_allowed(INTIMATE, ceiling)`` holds. A path-rendering test that
+covered only the first half would leave the response shape unchecked on
+exactly the scans that carry fragment filenames.
+"""
 
 
 @pytest.fixture
@@ -40,6 +144,83 @@ def _read_audit(vault: Path) -> list[dict[str, object]]:
     if not path.exists():
         return []
     return [json.loads(line) for line in path.read_text().splitlines() if line]
+
+
+def _write_pii_file(target: Path, *, front_matter: str = "") -> Path:
+    """Write a scannable markdown file carrying exactly one real PII match.
+
+    Args:
+        target: Destination path; parents are created.
+        front_matter: Optional YAML block prepended to the body. Staged
+            attachments carry none; seeded fragments carry
+            :data:`_INTIMATE_FRONT_MATTER`.
+
+    Returns:
+        The path written, so a caller can symlink to it.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(f"{front_matter}{_PII_LINE}", encoding="utf-8")
+    return target
+
+
+def _plant_outward_symlink(vault: Path, tmp_path: Path) -> str:
+    """Park a symlink at :data:`_OUTWARD_LINK_RELPATH` pointing off the vault.
+
+    This is the third branch of the out-of-scope story, and the only one that
+    leaves the tool through ``resolve_within_vault``'s ``None`` arm:
+    resolution follows the link, lands outside the root, and so never reaches
+    the scope gate at all.
+
+    Args:
+        vault: Vault root the *link* is planted inside.
+        tmp_path: pytest's per-test directory, which is also the vault root.
+            The link's target is written to a **sibling** of it, so "outside
+            the vault" is true by construction rather than by a hard-coded
+            path a later fixture change could quietly move back inside.
+
+    Returns:
+        The vault-relative ``input_path`` naming the link, so a caller sends
+        an ordinary-looking fragment path and nothing else.
+    """
+    target = _write_pii_file(tmp_path.parent / "off-vault" / "target.md")
+    link = vault / _OUTWARD_LINK_RELPATH
+    link.parent.mkdir(parents=True, exist_ok=True)
+    link.symlink_to(target)
+    return _OUTWARD_LINK_RELPATH
+
+
+def _markdown_headings(report_markdown: str) -> list[str]:
+    """Return the file paths ``report_markdown`` renders as ``### `…``` headings.
+
+    Args:
+        report_markdown: The tool's markdown summary.
+
+    Returns:
+        One string per rendered file section, in document order. This is the
+        field CrawDad posts verbatim into a Discord channel
+        (``crawdad/crawdad/bot.py::_format_scan_section``), so it is the
+        surface an absolute path escapes through.
+    """
+    return _HEADING_PATTERN.findall(report_markdown)
+
+
+@pytest.fixture
+def scannable_vault(vault: Path) -> Path:
+    """Seed one PII-bearing file in the staging subtree and one under ``01-Fragments``.
+
+    Two carriers, because every assertion below needs both directions at
+    once: the staged file is the positive control that keeps FEAT-027 alive,
+    and the fragment is the thing an ``open``-ceiling caller must not be able
+    to name. The fragment's *file stem* carries :data:`_FILENAME_CANARY`
+    while its body does not, which is what makes "the canary appeared in the
+    response" mean "a filename leaked" and nothing else.
+    """
+    _write_pii_file(vault / "00-Creek-Meta" / "Inbound" / "ch1" / "msg" / "staged.md")
+    _write_pii_file(
+        vault / "01-Fragments" / "Notes" / f"my-{_FILENAME_CANARY}-note.md",
+        front_matter=_INTIMATE_FRONT_MATTER,
+    )
+    return vault
 
 
 def test_scan_returns_empty_when_no_findings(vault: Path) -> None:
@@ -94,7 +275,35 @@ def test_scan_refuses_absolute_path_outside_vault(
     vault: Path,
     tmp_path: Path,
 ) -> None:
-    """Paths outside the vault root are refused, never scanned."""
+    """Paths outside the vault root are refused, never scanned.
+
+    The confinement property is unchanged and is what the four-key equality
+    below states: no ``statistics`` block, no ``findings``, nothing derived
+    from *outside* at all, so the path is refused without being opened.
+
+    What changed is the **wording**, and it changed for a reason worth
+    recording here rather than in the commit message. This test used to assert
+    ``"outside the vault" in result["reason"]``, which pinned a second,
+    distinguishable refusal shape for an un-admitted caller: an in-vault
+    target they are not scoped to answers :data:`_OUT_OF_SCOPE_REASON`, while
+    a target that escapes the vault answered a different message with their
+    own path interpolated into it. That difference is reachable from *inside*
+    the vault — a symlink under ``01-Fragments/`` whose target is elsewhere on
+    disk resolves out and takes the escape arm — so the pair was an oracle: a
+    caller refused ``01-Fragments`` could still ask, one slugified title at a
+    time, which of them are outward links.
+    :func:`test_out_of_scope_refusals_are_indistinguishable_from_an_outward_symlink`
+    is the reproduction; this test is the same rule stated on the plainest
+    possible target.
+
+    The precise message is not deleted, only withheld: it survives at
+    ``ceiling=intimate`` and ``all``, where the caller was already admitted to
+    everything and it is the one operationally useful diagnostic. That is
+    pinned by
+    :func:`test_an_outward_symlink_still_reports_precisely_at_an_admitting_ceiling`,
+    and without it this test could be satisfied by dropping the message
+    outright.
+    """
     outside = tmp_path.parent / "elsewhere"
     outside.mkdir(exist_ok=True)
     result = redact_scan_tool(
@@ -102,8 +311,15 @@ def test_scan_refuses_absolute_path_outside_vault(
         input_path=str(outside),
         privacy_tier_ceiling=TierCeiling.OPEN,
     )
-    assert result["status"] == "refused"
-    assert "outside the vault" in result["reason"]
+    assert result == refusal_response(
+        tool=_TOOL_NAME,
+        ceiling=TierCeiling.OPEN,
+        reason=_OUT_OF_SCOPE_REASON,
+    ), (
+        "an open-ceiling caller can tell an outside-the-vault path from an "
+        "in-vault out-of-scope one by the refusal alone, so the refusal "
+        f"discriminates on something the caller was not admitted to.\n\n{result}"
+    )
 
 
 def test_scan_refuses_missing_path(vault: Path) -> None:
@@ -167,3 +383,629 @@ def test_scan_accepts_absolute_path_inside_vault(vault: Path) -> None:
     )
     assert result["status"] == "empty"
     assert result["input_path"].startswith("00-Creek-Meta/Inbound/")
+
+
+# ---------------------------------------------------------------------------
+# Scope, not a per-file tier filter (#972)
+#
+# The scan reads no per-file tiers — it is a regex pass over bytes — so it has
+# nothing to rank a fragment with. The gate therefore decides *where*, not
+# *what*: the FEAT-027 staging subtree is admitted at every ceiling, and every
+# other in-vault target is ranked as if it held intimate content, because for
+# all this tool knows it does.
+# ---------------------------------------------------------------------------
+
+
+def test_scan_refuses_the_fragments_subtree_at_the_open_ceiling(
+    scannable_vault: Path,
+) -> None:
+    """An ``open``-ceiling caller cannot aim the scan at the classified corpus.
+
+    The whole of #972 in one call. ``resolve_within_vault`` confines
+    *input_path* to the vault, which is true and insufficient: the vault is
+    where the fragments are, and a finding names the file it came from.
+
+    Asserted as **equality** with the canonical four-key payload rather than
+    as ``status == "refused"``, because the specific thing that must not come
+    back is a ``statistics`` block. A refusal carrying ``files_scanned: 0``
+    would be a differential oracle in a tidier wrapper — the caller learns
+    nothing from a scan they were refused, unless the refusal itself counts
+    the files it declined to scan.
+
+    ``_OUT_OF_SCOPE_REASON`` is imported rather than spelled out, following
+    the ``_ABOVE_CEILING_REASON`` precedent in ``tests/test_mcp_read_gate.py``:
+    the reason is a fixed module constant precisely so it cannot grow an
+    interpolated copy of the caller's path, and a literal here would let the
+    constant drift while the test kept passing against the old wording.
+    """
+    result = redact_scan_tool(
+        vault_path=scannable_vault,
+        input_path=_FRAGMENTS_ROOT,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+
+    assert result == refusal_response(
+        tool=_TOOL_NAME,
+        ceiling=TierCeiling.OPEN,
+        reason=_OUT_OF_SCOPE_REASON,
+    ), (
+        "creek.redact.scan's out-of-scope refusal is not the canonical "
+        "four-key payload. Every extra key is derived from a subtree the "
+        f"caller was refused.\n\n{result}"
+    )
+
+
+def test_scan_refuses_out_of_scope_paths_identically_whether_or_not_they_exist(
+    vault: Path,
+) -> None:
+    """The refusal is not an existence oracle over slugified fragment titles.
+
+    Today the two calls below differ: the absent path answers ``refused`` /
+    ``"input_path not found: …"`` and the present one answers ``ok``. That
+    difference is the whole attack — a caller who cannot read a fragment can
+    still ask "is there one called ``my-affair-with-dana``?" and read the
+    answer off the status line, one slugified title at a time.
+
+    Closing it is what forces the gate to sit **above** the existence check
+    rather than below it, and asserting the two responses are ``==`` is what
+    pins that ordering: a gate placed after ``resolved.exists()`` would
+    produce two different refusals and still look like a fix.
+
+    The ``refused`` assertion at the end guards the degenerate direction —
+    two identical ``ok`` responses would also be equal.
+    """
+    probe = "01-Fragments/Notes/my-secret-thing.md"
+
+    absent = redact_scan_tool(
+        vault_path=vault,
+        input_path=probe,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+    _write_pii_file(
+        vault / "01-Fragments" / "Notes" / "my-secret-thing.md",
+        front_matter=_INTIMATE_FRONT_MATTER,
+    )
+    present = redact_scan_tool(
+        vault_path=vault,
+        input_path=probe,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+    )
+
+    assert absent == present, (
+        "creek.redact.scan answers differently for an out-of-scope path that "
+        "exists and one that does not, so the refusal is a one-bit oracle "
+        "over fragment filenames — which are slugified titles.\n\n"
+        f"absent:  {absent}\npresent: {present}"
+    )
+    assert absent["status"] == "refused"
+
+
+def test_out_of_scope_refusals_are_indistinguishable_from_an_outward_symlink(
+    scannable_vault: Path,
+    tmp_path: Path,
+) -> None:
+    """One refusal, three targets: the un-admitted caller learns nothing.
+
+    The sibling test above closed the *existence* half of the oracle by
+    moving the scope gate above ``resolved.exists()``. It could not see this
+    half, because a third arm sits **above** the gate entirely: when
+    ``resolve_within_vault`` returns ``None``, ``redact_scan_tool`` refuses
+    with its own path-interpolated "resolves outside the vault root" message
+    before scope is ever consulted. So an ``open``-ceiling caller aiming at
+    ``01-Fragments/Notes/`` today gets two answers, not one:
+
+    * ``plain.md`` (an ordinary file) and ``absent.md`` (nothing there at all)
+      both answer :data:`_OUT_OF_SCOPE_REASON` — already indistinguishable;
+    * ``escape.md`` (a symlink whose target is off the vault) answers the
+      outside-the-vault message instead.
+
+    The third is the branch that fails today, and it is an oracle in its own
+    right: a caller who is not admitted to ``01-Fragments`` at all learns
+    that there is an outward link at exactly the path they named. It also
+    falsifies the manifest rationale in ``creek_mcp/read_gate.py``, which
+    claims this refusal "is neither an existence nor a rank oracle".
+
+    Asserted as three-way equality rather than as three reason strings,
+    because the refusal payload carries no path at all once the arms agree —
+    there is then nothing left for the responses to differ *in*, and equality
+    is the only assertion that says so without enumerating the fields.
+
+    The second assertion pins **which** way they collapsed. Equality alone
+    would also be satisfied by routing the in-vault targets into the
+    outside-the-vault message, which is the wrong direction: that message
+    interpolates the caller's own path and asserts something about the
+    filesystem, while :data:`_OUT_OF_SCOPE_REASON` is fixed text that is true
+    of all three — a path escaping the vault is by definition outside the
+    staging subtree.
+    """
+    _write_pii_file(
+        scannable_vault / _FRAGMENTS_ROOT / "Notes" / "plain.md",
+        front_matter=_INTIMATE_FRONT_MATTER,
+    )
+    outward = _plant_outward_symlink(scannable_vault, tmp_path)
+
+    present, absent, escaping = [
+        redact_scan_tool(
+            vault_path=scannable_vault,
+            input_path=probe,
+            privacy_tier_ceiling=TierCeiling.OPEN,
+            consumer="crawdad",
+        )
+        for probe in (
+            f"{_FRAGMENTS_ROOT}/Notes/plain.md",
+            f"{_FRAGMENTS_ROOT}/Notes/absent.md",
+            outward,
+        )
+    ]
+
+    assert present == absent == escaping, (
+        "creek.redact.scan answers an out-of-scope path differently when it "
+        "happens to be a symlink pointing off the vault, so the refusal tells "
+        "an un-admitted caller which fragment paths are outward links.\n\n"
+        f"present:  {present}\nabsent:   {absent}\nescaping: {escaping}"
+    )
+    assert escaping == refusal_response(
+        tool=_TOOL_NAME,
+        ceiling=TierCeiling.OPEN,
+        reason=_OUT_OF_SCOPE_REASON,
+    ), (
+        "the three refusals agree on the wrong message: the outside-the-vault "
+        "wording interpolates the caller's path and asserts a fact about the "
+        "filesystem, where the out-of-scope reason is fixed text that is true "
+        f"of every one of them.\n\n{escaping}"
+    )
+
+
+@pytest.mark.parametrize("ceiling", [TierCeiling.INTIMATE, TierCeiling.ALL])
+def test_an_outward_symlink_still_reports_precisely_at_an_admitting_ceiling(
+    scannable_vault: Path,
+    tmp_path: Path,
+    ceiling: TierCeiling,
+) -> None:
+    """The collapse is scoped to callers who were not admitted to everything.
+
+    Without this test the one above it is satisfiable by deleting the
+    outside-the-vault message from the tool entirely, which would trade an
+    oracle for an outage of a different kind: the operator running their own
+    safety pass over their own vault would be told "out of scope" about a path
+    that is not out of scope, it is *gone* — a link into a stale sync folder,
+    a moved drive, a broken restore. That diagnostic is the one actionable
+    fact in the whole refusal and it costs nothing here, because a caller at
+    ``intimate`` or ``all`` is already admitted to every in-vault target the
+    precise message could distinguish this one from.
+
+    Parametrised over exactly the two ceilings ``tier_allowed(INTIMATE, …)``
+    admits, matching
+    :func:`test_scan_admits_the_fragments_subtree_at_intimate_and_all`, so the
+    boundary between the two behaviours is the same predicate the gate uses
+    rather than a second, private copy of it.
+
+    The inequality against :data:`_OUT_OF_SCOPE_REASON` is asserted alongside
+    the substring: a reason that managed to contain "outside the vault" *and*
+    equal the out-of-scope text would mean the two messages had been merged,
+    which is the collapse this test exists to forbid.
+    """
+    outward = _plant_outward_symlink(scannable_vault, tmp_path)
+
+    result = redact_scan_tool(
+        vault_path=scannable_vault,
+        input_path=outward,
+        privacy_tier_ceiling=ceiling,
+    )
+
+    assert result["status"] == "refused"
+    assert result["reason"] != _OUT_OF_SCOPE_REASON, (
+        f"at ceiling={ceiling.value!r} the caller is admitted to every "
+        "in-vault target, so collapsing the outside-the-vault refusal into "
+        "the out-of-scope one withholds nothing and costs the operator their "
+        f"one actionable diagnostic.\n\n{result}"
+    )
+    assert "outside the vault" in result["reason"], (
+        "an admitting ceiling no longer reports that the path resolved off "
+        f"the vault.\n\n{result}"
+    )
+
+
+def test_scan_refuses_a_staged_symlink_whose_target_is_out_of_scope(
+    scannable_vault: Path,
+) -> None:
+    """A symlink parked in the staging dir cannot smuggle the scan out of scope.
+
+    ``resolve_within_vault`` resolves the caller's path before returning it,
+    so the gate sees the real target rather than the staging-shaped name the
+    caller used. That is the property being pinned: a gate that matched on
+    the *input string* instead would admit this call, and staging is a
+    directory CrawDad writes attachments into — a caller who can stage a file
+    can stage a symlink.
+    """
+    sneaky = scannable_vault / "00-Creek-Meta" / "Inbound" / "sneaky"
+    sneaky.symlink_to(scannable_vault / _FRAGMENTS_ROOT, target_is_directory=True)
+
+    result = redact_scan_tool(
+        vault_path=scannable_vault,
+        input_path="00-Creek-Meta/Inbound/sneaky",
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+
+    assert result == refusal_response(
+        tool=_TOOL_NAME,
+        ceiling=TierCeiling.OPEN,
+        reason=_OUT_OF_SCOPE_REASON,
+    ), (
+        "a symlink under 00-Creek-Meta/Inbound/ pointed the scan at "
+        f"01-Fragments and the gate admitted it.\n\n{result}"
+    )
+
+
+def test_a_sibling_prefix_directory_is_not_mistaken_for_the_staging_subtree(
+    vault: Path,
+) -> None:
+    """``00-Creek-Meta/InboundX/`` is a sibling of the staging dir, not a child.
+
+    A regression pin rather than a reproduction: this passes today and is
+    expected to. ``_refuse_outside_scan_scope``'s docstring claims that
+    matching with :meth:`~pathlib.Path.is_relative_to` "rather than a string
+    prefix" is what keeps ``Inbound-other/`` from being mistaken for a child,
+    and that claim had no test — so the cheapest possible "simplification",
+    ``str(resolved).startswith(str(staging))``, would have kept every other
+    test in this file green while admitting the directory below at
+    ``ceiling=open``.
+
+    The target is derived from :data:`_STAGING_ROOT` with one character
+    appended, so a future move of the staging subtree carries its own
+    near-miss with it instead of leaving this test aimed at a path that no
+    longer neighbours anything.
+
+    Seeded with a PII file so an admitting implementation would answer
+    ``status="ok"`` with a finding in it, rather than an empty scan that could
+    be mistaken for a refusal at a glance.
+    """
+    near_miss = f"{_STAGING_ROOT}X"
+    _write_pii_file(vault / near_miss / "leak.md")
+
+    result = redact_scan_tool(
+        vault_path=vault,
+        input_path=near_miss,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+
+    assert result == refusal_response(
+        tool=_TOOL_NAME,
+        ceiling=TierCeiling.OPEN,
+        reason=_OUT_OF_SCOPE_REASON,
+    ), (
+        f"{near_miss!r} shares a string prefix with the staging subtree but "
+        "is not inside it, and the scope gate admitted it — so containment is "
+        f"being decided on characters rather than on path components.\n\n{result}"
+    )
+
+
+@pytest.mark.parametrize("as_absolute", [False, True])
+def test_the_vault_root_itself_is_out_of_scope(
+    scannable_vault: Path,
+    as_absolute: bool,
+) -> None:
+    """The widest version of #972: aim the scan at everything.
+
+    The second untested half of ``_refuse_outside_scan_scope``'s containment
+    claim, and like the sibling-prefix case it passes today. The docstring
+    records that "the subtree root itself still counts" as inside; the
+    converse — that the *vault* root does not count as inside the staging
+    subtree, even though the staging subtree is inside it — is the direction
+    that matters, because a vault-root scan sweeps ``01-Fragments`` wholesale
+    and returns the slugified title of every fragment with a stray email
+    address in it. Any containment check written the wrong way round, or a
+    gate that special-cased "the target contains the staging dir", would open
+    it.
+
+    Both spellings are exercised because ``resolve_within_vault`` reaches the
+    root through two different branches — ``"."`` is joined under the resolved
+    root, an absolute path is taken as given — and only one of them would be
+    covered by testing either alone.
+
+    :func:`scannable_vault` seeds a PII-bearing intimate fragment under
+    ``01-Fragments/Notes/``, so an admitting implementation would return
+    :data:`_FILENAME_CANARY` here instead of the empty scan that would make
+    this assertion cheap.
+    """
+    input_path = str(scannable_vault) if as_absolute else "."
+
+    result = redact_scan_tool(
+        vault_path=scannable_vault,
+        input_path=input_path,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+
+    assert result == refusal_response(
+        tool=_TOOL_NAME,
+        ceiling=TierCeiling.OPEN,
+        reason=_OUT_OF_SCOPE_REASON,
+    ), (
+        "an open-ceiling caller scanned the vault root, which contains the "
+        "staging subtree and everything else — 01-Fragments included — so the "
+        f"scope gate admitted the whole corpus in one call.\n\n{result}"
+    )
+
+
+@pytest.mark.parametrize("ceiling", list(TierCeiling))
+def test_scan_admits_the_staging_subtree_at_every_ceiling(
+    scannable_vault: Path,
+    ceiling: TierCeiling,
+) -> None:
+    """FEAT-027 survives the fix, at the lowest ceiling as well as the highest.
+
+    This is #972's recoverability criterion, executed rather than asserted in
+    prose. CrawDad runs the safety pass on Discord attachments staged under
+    ``00-Creek-Meta/Inbound/`` before dispatching ``creek.ingest``, and it
+    calls at ``ceiling=open``. A scope gate that refused everything would
+    satisfy every leak assertion in this file and break the one caller the
+    tool was built for.
+
+    Parametrised over all four ceilings so the admission cannot be
+    implemented as a quirk of one branch — the staging subtree is admitted
+    because of *where* it is, not because of what the caller declared.
+    """
+    result = redact_scan_tool(
+        vault_path=scannable_vault,
+        input_path=_STAGING_ROOT,
+        privacy_tier_ceiling=ceiling,
+        consumer="crawdad",
+    )
+
+    assert result["status"] == "ok"
+    assert result["statistics"]["total_findings"] >= 1
+    assert result["input_path"] == _STAGING_ROOT
+
+
+@pytest.mark.parametrize("ceiling", [TierCeiling.INTIMATE, TierCeiling.ALL])
+def test_scan_admits_the_fragments_subtree_at_intimate_and_all(
+    scannable_vault: Path,
+    ceiling: TierCeiling,
+) -> None:
+    """The corpus is out of *scope*, not out of *reach*.
+
+    Without this test the open-ceiling refusal above is vacuous: a tool that
+    refused ``01-Fragments`` at every ceiling would pass it while making the
+    operator's own safety pass over their own vault impossible. The scan
+    ranks an unranked target as intimate, so ``tier_allowed(INTIMATE, …)``
+    decides — which is exactly ``intimate`` and ``all``, the two ceilings a
+    remote consumer token can never send (#1082).
+    """
+    result = redact_scan_tool(
+        vault_path=scannable_vault,
+        input_path=_FRAGMENTS_ROOT,
+        privacy_tier_ceiling=ceiling,
+    )
+
+    assert result["status"] == "ok"
+    assert result["statistics"]["total_findings"] >= 1
+    assert result["input_path"] == _FRAGMENTS_ROOT
+
+
+def test_scan_at_the_open_ceiling_returns_no_intimate_filename_canary(
+    scannable_vault: Path,
+) -> None:
+    """The issue's acceptance criterion, probed at the tool boundary.
+
+    Asserted against ``json.dumps(result, default=str)`` rather than against
+    ``findings[].file_path``, because #972 reproduced in **two** fields that
+    disagreed with each other: ``findings`` rendered a vault-relative path
+    and ``report_markdown`` rendered an absolute one. A key-by-key check
+    would have covered whichever field the author happened to think of, and
+    ``report_markdown`` is the field CrawDad posts into a Discord channel.
+
+    The canary lives in the fragment's file stem and nowhere else (see
+    :func:`scannable_vault`), so a hit here can only mean the tool named a
+    file the caller was not admitted to.
+    """
+    result = redact_scan_tool(
+        vault_path=scannable_vault,
+        input_path=_FRAGMENTS_ROOT,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+
+    serialised = json.dumps(result, default=str)
+    assert _FILENAME_CANARY not in serialised, (
+        "creek.redact.scan returned an intimate fragment's filename to an "
+        "open-ceiling caller. Creek filenames are slugified titles, so this "
+        f"is the title.\n\n{serialised}"
+    )
+
+
+@pytest.mark.parametrize(("input_path", "ceiling"), _ADMITTED_SCANS)
+def test_report_markdown_paths_are_vault_relative_at_every_admitted_ceiling(
+    scannable_vault: Path,
+    input_path: str,
+    ceiling: TierCeiling,
+) -> None:
+    """``report_markdown`` renders no absolute path and no vault root.
+
+    ``_finding_to_dict``'s docstring has always claimed paths are "rendered
+    relative to the vault root so the Discord reply does not leak absolute
+    filesystem paths". ``report_markdown`` is built by
+    ``generate_markdown_summary`` and never went through that function, so
+    the claim was true of one field and false of the other — and it is the
+    false one CrawDad posts verbatim into a channel.
+
+    Both directions are asserted because they fail independently: a heading
+    can be non-absolute and still contain the vault root (a relative path
+    built from the wrong base), and the vault root can be absent from a
+    heading that is still absolute (a differently-rooted temp path). The
+    non-empty check keeps the whole test from passing over a summary with no
+    findings in it.
+    """
+    result = redact_scan_tool(
+        vault_path=scannable_vault,
+        input_path=input_path,
+        privacy_tier_ceiling=ceiling,
+        consumer="crawdad",
+    )
+    report = result["report_markdown"]
+    headings = _markdown_headings(report)
+
+    assert headings, (
+        f"the {input_path!r} scan at ceiling={ceiling.value!r} rendered no "
+        f"file sections, so this test asserts nothing.\n\n{report}"
+    )
+    absolute = [heading for heading in headings if Path(heading).is_absolute()]
+    assert absolute == [], (
+        "report_markdown renders absolute filesystem paths, which CrawDad "
+        "posts into a Discord channel verbatim — leaking the operator's home "
+        f"directory along with the filename.\n\n{absolute}"
+    )
+    assert str(scannable_vault.resolve()) not in report, (
+        "report_markdown embeds the vault root. Every path in the response "
+        "must go through _vault_relative, which renders the path as scanned "
+        f"and relative to the vault.\n\n{report}"
+    )
+
+
+@pytest.mark.parametrize(("input_path", "ceiling"), _ADMITTED_SCANS)
+def test_findings_and_report_markdown_render_the_same_paths(
+    scannable_vault: Path,
+    input_path: str,
+    ceiling: TierCeiling,
+) -> None:
+    """One relativiser owns every path in the response, so the two fields agree.
+
+    The invariant, rather than a second copy of the previous test's
+    assertions: ``findings[].file_path`` and the ``### `…``` headings are two
+    renderings of the same set of files, so they must be the same set of
+    strings. Today they are not — one is vault-relative and the other
+    absolute — which is the #846/#848 signature of a guardrail applied on one
+    path out of two.
+
+    Set equality is what makes this survive the fix rather than merely
+    describing it: any future field that renders paths differently from its
+    sibling fails here, without this test knowing anything about how either
+    one is built.
+    """
+    result = redact_scan_tool(
+        vault_path=scannable_vault,
+        input_path=input_path,
+        privacy_tier_ceiling=ceiling,
+        consumer="crawdad",
+    )
+    finding_paths = {str(finding["file_path"]) for finding in result["findings"]}
+    heading_paths = set(_markdown_headings(result["report_markdown"]))
+
+    assert finding_paths, (
+        f"the {input_path!r} scan at ceiling={ceiling.value!r} produced no "
+        "findings, so this test asserts nothing"
+    )
+    assert finding_paths == heading_paths, (
+        "findings[].file_path and report_markdown's headings name the same "
+        "files in two different renderings, so a reviewer checking one "
+        "learns nothing about the other.\n\n"
+        f"findings: {sorted(finding_paths)}\nheadings: {sorted(heading_paths)}"
+    )
+
+
+def test_a_symlinked_child_renders_as_its_staged_path_not_its_target(
+    scannable_vault: Path,
+) -> None:
+    """A staged symlink is reported as the staged path it was scanned as.
+
+    ``_finding_to_dict`` calls ``match.file_path.resolve()`` before
+    relativising. For a symlinked child of the staging dir that resolves the
+    link, so a scan confined to ``00-Creek-Meta/Inbound`` reports
+    ``01-Fragments/Notes/<slugified intimate title>.md`` — the exact
+    disclosure the scope gate above exists to prevent, arriving through a
+    scan the gate correctly admitted. The fix is that the relativiser renders
+    the path **as scanned** and never resolves it.
+
+    Deliberately *not* asserted: that ``sneaky.md`` appears in the response.
+    #1087 may stop scanning symlinked children altogether, and this test must
+    survive that decision either way; the positive control for "the staging
+    subtree is still scanned" is
+    ``test_scan_admits_the_staging_subtree_at_every_ceiling``.
+    """
+    staged = scannable_vault / "00-Creek-Meta" / "Inbound" / "ch1" / "sneaky.md"
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    staged.symlink_to(
+        scannable_vault / _FRAGMENTS_ROOT / "Notes" / f"my-{_FILENAME_CANARY}-note.md",
+    )
+
+    result = redact_scan_tool(
+        vault_path=scannable_vault,
+        input_path=_STAGING_ROOT,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+
+    serialised = json.dumps(result, default=str)
+    assert _FILENAME_CANARY not in serialised, (
+        "a scan confined to the staging subtree reported a symlink's target "
+        "under 01-Fragments, disclosing an intimate fragment's slugified "
+        f"title at ceiling=open.\n\n{serialised}"
+    )
+    assert str(scannable_vault.resolve()) not in serialised, (
+        f"the response embeds the vault root.\n\n{serialised}"
+    )
+
+
+def test_an_unrenderable_path_falls_back_to_a_non_disclosing_placeholder(
+    tmp_path: Path,
+) -> None:
+    """The relativiser fails closed on a path it cannot express vault-relative.
+
+    Rendering is the last thing that happens to a path, so its fallback arm
+    is where a "shouldn't happen" case turns into the disclosure the whole
+    gate was built to stop. ``_finding_to_dict``'s current fallback is
+    ``str(match.file_path)`` — the absolute path, in full, precisely when
+    something unexpected happened.
+
+    Asserted twice: the exact placeholder constant, and the absence of every
+    component of the input. The second is the one that matters, because a
+    placeholder that helpfully appended the offending filename would satisfy
+    the first if the constant were written to include it. Every component of
+    the probe path is sentinel-shaped so that a plausible English placeholder
+    cannot collide with one by accident.
+    """
+    outside = Path(f"/{_OUTSIDE_CANARY}-dir/{_OUTSIDE_CANARY}-secret-thing.md")
+
+    rendered = _vault_relative(outside, tmp_path)
+
+    assert rendered == _OUTSIDE_VAULT_PLACEHOLDER
+    for part in outside.parts[1:]:
+        assert part not in rendered, (
+            f"the fallback placeholder discloses {part!r} from a path it "
+            f"could not render: {rendered!r}"
+        )
+
+
+def test_scan_accepts_a_vault_root_with_a_symlinked_component(vault: Path) -> None:
+    """A vault reached through a symlink is scanned, not crashed on.
+
+    ``redact_scan_tool`` renders ``input_path`` with
+    ``resolved.relative_to(vault_path)`` where ``resolved`` has been resolved
+    and ``vault_path`` has not, so any vault root containing a symlinked
+    component raises an unhandled ``ValueError`` straight out of the MCP
+    boundary. This is not exotic: ``/tmp`` is a symlink to ``/private/tmp``
+    on macOS, and a vault under a synced or home-relative link hits it too.
+
+    Constructed explicitly rather than relying on the platform, so the test
+    means the same thing on every CI runner. The ``vault`` fixture is taken
+    only for its stubbed ``load_config``; the root actually passed to the
+    tool is the symlink.
+    """
+    real = vault / "real-vault"
+    _write_pii_file(real / "00-Creek-Meta" / "Inbound" / "ch1" / "staged.md")
+    linked = vault / "linked-vault"
+    linked.symlink_to(real, target_is_directory=True)
+
+    result = redact_scan_tool(
+        vault_path=linked,
+        input_path=_STAGING_ROOT,
+        privacy_tier_ceiling=TierCeiling.OPEN,
+        consumer="crawdad",
+    )
+
+    assert result["status"] == "ok"
+    assert result["input_path"] == _STAGING_ROOT
+    assert result["statistics"]["total_findings"] >= 1


### PR DESCRIPTION
## Summary

- **Scopes `creek.redact.scan` instead of tier-filtering it.** `00-Creek-Meta/Inbound/` — the FEAT-027 staging subtree — is admitted at **every** ceiling; every other in-vault path is ranked as if it held `intimate` content, because the scan reads no per-file privacy tier at all, and so needs `ceiling=intimate`/`all`. The gate sits **above** the existence check, so `refused` vs `not found` is no longer an existence oracle over slugified fragment titles.
- **Gives one fail-closed helper ownership of every path in the response** (`input_path`, `findings[].file_path`, `report_markdown`), rendering each **as scanned** and vault-relative. It deliberately never calls `.resolve()` on a match path.
- **Moves the read-gate posture from `UNGATED_KNOWN_GAP`(#972) to `GATED`**, adopting neither canonical primitive, and adds the runtime canary probe that forcing function requires.

## The leak, and why the obvious fix was the wrong one

At `privacy_tier_ceiling=open` a caller could aim the scan at `01-Fragments` and get back intimate fragments' **filenames**. Creek fragment filenames are slugified titles, so the filename *is* the content — the tool's own defence ("no matched text leaves the tool") was true and insufficient. Reproduced by execution before the fix:

```
"file_path": "01-Fragments/Notes/my-affair-with-dana.md", "match_type": "email"
### `/private/var/…/vault/01-Fragments/Notes/my-affair-with-dana.md`
refused | input_path not found: 01-Fragments/Notes/my-secret-other-thing.md
```

Three leaks in that output: the slugified title, an absolute path leaking the operator's home directory (CrawDad posts `report_markdown` verbatim into a Discord channel), and an existence oracle — a caller could probe *any* guessed fragment title and read the answer off `refused` vs `ok`.

**A per-file tier filter was rejected** in favour of the issue's preferred scoping, for four reasons:

1. Files under `Inbound/` are pre-ingest raw attachments with **no `privacy_tier` frontmatter at all**, so any fail-closed per-file reader ranks them `intimate` and refuses the entire FEAT-027 use case. You would carve `Inbound/` out anyway — scoping by a longer road, plus a fourth tier reader while #1079 already tracks two existing ones disagreeing.
2. Exclusion leaves the `files_scanned` differential oracle the issue names.
3. A silently filtered scan under-reports, so a *redaction* tool would be lying about comprehensiveness.
4. The refusal now shipped is derived **only** from the caller's own `input_path` and their own declared ceiling — never from vault content — so it echoes no tier and is neither an existence nor a rank oracle.

## Scoping alone would not have closed it

`_finding_to_dict` resolved each match path before relativising, and `scan_batch`'s `rglob` yields symlinked children **unresolved**. So a staged symlink inside the admitted subtree rendered its target's slugified title. Reproduced at `ceiling=open` before the fix, and this is why the second half of the change is not path hygiene:

```
00-Creek-Meta/Inbound/ch1/sneaky.md -> 01-Fragments/Notes/my-affair-with-dana.md
  before: "file_path": "01-Fragments/Notes/my-affair-with-dana.md"
  after:  "file_path": "00-Creek-Meta/Inbound/ch1/sneaky.md"
```

## Why not `refuse_above_ceiling`

`GENERIC_ABOVE_CEILING_REASON` — "resolved content exceeds the declared tier ceiling" — asserts that content was ranked. This gate ranks no content; it ranks the caller's own requested path. Adopting the primitive would have shipped a false statement and told a CrawDad operator nothing actionable. Same call #968 made for `creek.report`: what the manifest checks is that the named gate exists and decides something, not which of two shapes it takes.

One consequence for reviewers: **the issue's acceptance criterion that "layer (e) will fail until the posture moves" does not hold as written.** Layer (e) only fires when a *gap-labelled* tool calls a canonical primitive, and this fix calls neither. What actually failed until the posture moved is `test_pinned_gaps_keep_their_posture_and_issue`; after the move, layers (c) and (f) check the claim harder than (e) would have.

## Accepted residuals (both recorded in the manifest rationale)

- Existence probing **within** `Inbound/` still works — that is the tool's job.
- `RedactionScanner.scan_batch` still follows symlinked **files**, so an out-of-scope target's PII types, line numbers and its `files_scanned` bit are still disclosed even though its path is not. Bounded — `rglob` does not descend into symlinked *directories*. Tracked by #1087.

## Out of scope, filed rather than fixed

- **#1087** — `scan_batch` follows symlinked files out of the scan root; the SEC-003 guard covers `--apply`/`--review`, not the scan walk.
- **#1088** — CrawDad's configurable `attachments.staging_subpath` can fall outside this tool's canonical scope, silently disabling the safety pass.
- **#1089** — a NUL byte in a caller-supplied path raises an unhandled `ValueError` out of the shared `resolve_within_vault` (pre-existing; `creek.ingest` shares it).

Also noted, not filed: `generate_markdown_summary` renders `` ### `{path}` ``, so a filename containing a backtick or newline could break the Discord code span. Not reachable through the one production path — CrawDad sanitises staged names to `[A-Za-z0-9._-]` — so no issue was opened.

## Test plan

Gate 1 was genuine RED→GREEN, re-demonstrated after an interruption by stashing only the production files: the two test modules then fail at collection, and the pre-fix behaviour reproduces (slugified title in `findings`, absolute path in `report_markdown`, `not found` existence oracle). Restored → 167 pass.

- `cd creek-tools && ./scripts/check-all.sh` → **12 passed / 0 failed**. `creek_mcp/tools/redact.py` at **100%** coverage.
  (Locally, 5 `consent-missing` tests fail unless `CREEK_CLOUD_CONSENT` is stripped from the environment — confirmed unrelated: they pass with the operator's real credential vars unset, both before and after this change.)
- `pytest tests/test_mcp_redact.py tests/test_mcp_read_gate.py` → **167 passed**.
- **Executed by hand, not read off a comparator:**
  - `01-Fragments` @ `open` → the canonical four-key refusal, no `findings`, no `statistics`.
  - Out-of-scope paths that exist, do not exist, and are symlinks resolving off the vault → **byte-identical** responses.
  - `00-Creek-Meta/Inbound` → `ok` with findings at **all four** ceilings (the issue's recoverability criterion).
  - `01-Fragments` @ `all` → `ok`, renders the intimate filename, so the `open` refusal withholds something real.
  - No absolute path in any response field, at any ceiling.
- New tests worth naming: `test_out_of_scope_refusals_are_indistinguishable_from_an_outward_symlink`, `test_scan_refuses_out_of_scope_paths_identically_whether_or_not_they_exist`, `test_a_symlinked_child_renders_as_its_staged_path_not_its_target`, `test_findings_and_report_markdown_render_the_same_paths` (the "one code path owns it" invariant — the #846/#848 signature, machine-checked), `test_scan_admits_the_staging_subtree_at_every_ceiling`, and layer (f)'s `test_redact_scan_probe_refuses_and_is_not_vacuous`.
- The layer (f) probe seeds its canary in a **filename**: `canary_vault` takes its file stems from `frag_id` and its fragments carry no PII, so the shared fixture is structurally blind to this leak class. The probe's anti-vacuity control is the same scan at `ceiling=all` returning the canary.

## Process notes

- Plan by `chief-architect`; specialists dispatched per its list (test → implementation → security → documentation). No spawn failed, so every pass named here really happened.
- A `security-specialist` pass at Gate 2.5 found one real oracle — a distinguishable "resolves outside the vault root" message that told an un-admitted caller *"there is an outward symlink at exactly this path"* — plus three factual errors in the new rationale prose (most notably "CrawDad calls it at `ceiling=open`"; it calls at the channel's configured ceiling, `personal` by default). All fixed, each via a failing test first where behaviour changed.
- `creek_mcp/server.py` is touched for one reason only: its `list_tools()` description advertised "over a vault-relative directory", which this fix narrows. The ceiling was **already** wired through to the tool at HEAD — this was the same root cause as #1037/#1068/#1078/#1084 (a ceiling received and ignored), not a wiring gap.

Closes #972
Refs #932, #846, #848
