### PR TITLE
feat(ralph): per-lane hot watch — platform-aware wakes cut PR latency to seconds

### DIFF
--- a/.claude/commands/ralph-tick.md
+++ b/.claude/commands/ralph-tick.md
@@ -200,8 +200,9 @@ Then act on `$STATUS`:
   already exists in this repo and `pick-next.sh` already excludes it at
   issue-pick time; this is the PR-side half.
 - **`pending`** / **`awaiting-review`** — CI is still running or no fresh LGTM
-  verdict exists yet. Leave the lane; its Step 5 subscription wakes you when CI
-  or the verdict changes. **Exception — missing review usually means a merge
+  verdict exists yet. Leave the lane; its Step 5 wake (webhook subscription on
+  remote, `watch-pr.sh` background watcher on local) fires when CI or the
+  verdict changes. **Exception — missing review usually means a merge
   conflict:** if the verdict never arrives and the `claude-review` check is
   absent from the rollup entirely, check
   `gh pr view N --json mergeable,mergeStateStatus` FIRST. A `CONFLICTING`/`DIRTY`
@@ -240,7 +241,7 @@ reuses the existing branch):
   the worktree — reproduce locally, fix the root cause (failing test first),
   re-clear Gate 2/2.5, push.
 - **In progress** (CI running, or verdict not yet posted): do nothing — this
-  lane's PR subscription (Step 5) wakes you when it changes.
+  lane's Step 5 wake (subscription or background watcher) fires when it changes.
 - **`dependencies` PRs** (from `dependabot-to-ralph-issue.yml`): these are
   **adopted, never built** — the lane attaches to Dependabot's own existing
   branch instead of a fresh worktree branch:
@@ -318,30 +319,63 @@ labelled, so `release` its worktree (`scripts/ralph/fleet.sh release "$N"`) so
 the slot refills on the next wake; a `pr_opened` worker leaves its worktree in
 Gate 3/4.
 
-### Step 5 — Arm per-lane wakes, then end the turn
+### Step 5 — Arm per-lane wakes (platform-aware), then end the turn
 
 You want a wake the moment **any single lane** changes — not a barrier that waits
-for all of them. Arrange, in this order of preference:
+for all of them. **Background workers** already wake you on their own completion
+— nothing to arm for a lane that's still building. For lanes in Gate 3/4 (an
+open PR waiting on CI or the verdict), what you arm depends on which platform
+this session runs on. Detect it once per wake: the
+`mcp__github__subscribe_pr_activity` tool **exists** in a remote/mobile Claude
+Code session and **does not exist** in a local terminal session.
 
-1. **Background workers** already wake you on their own completion — nothing to
-   arm for a lane that's still building.
-2. **Per-PR webhook subscriptions** for every in-flight PR, so any one PR's CI
+**REMOTE (webhook-capable) session:**
+
+1. **Per-PR webhook subscriptions** for every in-flight PR, so any one PR's CI
    failure or new review verdict wakes you independently:
    ```
    mcp__github__subscribe_pr_activity  (owner, repo, pullNumber)   # once per open PR
    ```
    Comment and CI-failure events arrive as `<github-webhook-activity>` and wake
-   this session; a verdict comment wakes you directly. `subscribe_pr_activity` is
-   **idempotent** — re-subscribing an already-watched PR every wake is safe and
-   does not stack subscriptions, so just (re)subscribe every open PR each wake.
-   Unsubscribe a PR once it merges/closes.
-3. **`ScheduleWakeup` fallback** (~1200–1800s): webhooks do **not** deliver CI
-   *success*, `behind→ready` transitions, or merges, so keep one modest fallback
-   armed to re-poll Step 0–4 for any lane that quietly went green or up-to-date.
-   A lane going **stale** is invisible to webhooks entirely — a sibling's merge
-   moves `main`, which pushes every other lane's `behind_by` above `0` while
-   emitting no event at all on those lanes' PRs — so this fallback is the only
-   thing that ever notices it.
+   this session; a verdict comment wakes you directly. Webhooks never deliver CI
+   *success* — but this repo's `iteration-trigger.yml` converts a fully-green CI
+   + posted verdict into an owner-authored PR **comment**, which IS delivered, so
+   even the green transition usually arrives as a webhook here.
+   `subscribe_pr_activity` is **idempotent** — re-subscribing an already-watched
+   PR every wake is safe and does not stack subscriptions, so just (re)subscribe
+   every open PR each wake. Unsubscribe a PR once it merges/closes.
+2. **ADAPTIVE `ScheduleWakeup` fallback** — pick the interval from the pool's
+   shape this wake:
+   - **Any lane has an open PR in CI/review** (`pending`/`awaiting-review`, or
+     freshly pushed): arm a **short** fallback, ~180s. Webhooks drop, deliver no
+     `behind→ready` transition or merge, and a sibling's merge silently pushes
+     every other lane's `behind_by` above `0` with no event on those lanes' PRs
+     — the short fallback bounds all of those blind spots to ~3 minutes.
+   - **Every lane is still building (or the pool is empty)**: nothing is
+     mid-flight for a webhook or a poll to catch — keep the long fallback,
+     ~1200–1800s, as the safety net.
+
+**LOCAL (terminal) session — no webhook MCP exists:**
+
+1. **Launch a hot watcher per in-flight PR as a background task, every wake:**
+   ```bash
+   scripts/ralph/watch-pr.sh "$PR_NUM"        # Bash tool, run_in_background: true
+   ```
+   A background task's exit re-invokes this session, and the watcher exits —
+   printing `WATCH <PR> <token>` — the moment `pr-ready.sh`'s token leaves
+   `pending`/`awaiting-review` (or `gone` when the PR merges/closes, or
+   `timeout <last-token>` at ~30 min). **The watcher's exit IS the per-lane
+   wake** — seconds after the verdict or CI settles, instead of the full
+   fallback sleep. Its pidfile (`/tmp/ralph-watch-<repo>-<PR>.pid`) makes
+   relaunching **idempotent**: a duplicate exits immediately with
+   `already-watching`, so just launch one for every in-flight PR each wake
+   without bookkeeping.
+2. **`ScheduleWakeup` long fallback** (~1200–1800s) stays armed as the safety
+   net — it covers a killed watcher, a reboot, and anything else that slips
+   past the pidfiles.
+
+On **either** platform: **never foreground-block on a lane** — no foreground
+`sleep`, no foreground `watch-pr.sh`, no waiting on a subscription in-turn.
 
 Then **end the turn.** Do not run a Monitor that waits for all lanes to be
 terminal — that is the barrier this design removes. Each independent wake re-runs

--- a/.claude/skills/await-claude-review/SKILL.md
+++ b/.claude/skills/await-claude-review/SKILL.md
@@ -19,7 +19,7 @@ description: >-
   status polling (use `pull_request_read` directly).
 metadata:
   author: Geoff
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # Await Claude Review
@@ -89,6 +89,16 @@ This comment is not authored by `claude[bot]` — it's authored by the human use
 **Currency check still applies.** The trigger fires on a `workflow_run` for a specific HEAD SHA, but the comment may arrive minutes after the push. Use the standard `created_at >= headPushedAt` guard before treating it as authoritative for the current HEAD.
 
 **Cap awareness.** The workflow caps itself at 10 self-posts per PR (it counts prior `<!-- iteration-trigger -->` markers). If you don't get a wake event after the eleventh push, the trigger has gone silent — fall back to checking the underlying claude-review comment directly via `get_comments`.
+
+**Dropped-webhook bound.** Webhooks can drop; callers that arm a periodic fallback (e.g. the Ralph orchestrator's adaptive short `ScheduleWakeup`, ~180s while any PR is in CI/review) bound that failure mode to ~3 minutes instead of a full long-fallback sleep.
+
+## Local Sessions (No Webhook MCP)
+
+A **local terminal** Claude Code session has no `mcp__github__subscribe_pr_activity` tool at all — no `<github-webhook-activity>` event will ever arrive, and Steps 1–3 below cannot run as written. The substitute keeps the same event semantics by exploiting the one wake primitive local sessions do have: **a background Bash task's exit re-invokes the session**, so a process that exits exactly when the verdict/CI state settles IS the wake.
+
+- **Preferred (repos that ship it, like this one):** launch the per-lane hot watcher as a background task — `scripts/ralph/watch-pr.sh <PR>` (`run_in_background: true`) — and end the turn. It polls `scripts/ralph/pr-ready.sh` and exits printing `WATCH <PR> <token>` the moment the token leaves `pending`/`awaiting-review` (verdict landed, CI failed, lane went stale, PR merged/closed, or ~30 min timeout). Its pidfile makes relaunching idempotent (`already-watching`), and every wait outcome exits 0. On wake, route the token exactly as a webhook event: `ready`/verdict tokens → Step 4's currency check; `ci-failed` → Step 5.
+- **Fallback (no watcher script):** run `gh pr checks <PR> --watch` plus a verdict poll (`gh pr view <PR> --json comments` filtered by the canonical regex) as a background task that exits when either settles — same shape, hand-rolled.
+- **Never foreground-sleep or poll in-turn.** The webhook prohibition on polling is about *foreground* waiting; a background watcher whose exit is the wake is the local-session equivalent of subscribing and ending the turn.
 
 ## Instructions
 
@@ -196,7 +206,7 @@ Don't. The subscription does not deliver CI passes. Wait on the comment event di
 
 ### Error: Tempted to poll with `sleep` or `Bash run_in_background`
 
-Don't. The session is woken by `<github-webhook-activity>`. Polling burns time and conflicts with the harness's wake mechanism. Subscribe and end the turn.
+In a webhook-capable session: don't. The session is woken by `<github-webhook-activity>`. Polling burns time and conflicts with the harness's wake mechanism. Subscribe and end the turn. (In a **local** session, where no webhook exists, a background watcher whose exit is the wake — see "Local Sessions (No Webhook MCP)" — is the sanctioned substitute; the prohibition is on *foreground* sleeping/polling.)
 
 ### Error: Webhook arrives but `get_comments` shows no matching verdict
 

--- a/.github/workflows/ralph-fleet-tests.yml
+++ b/.github/workflows/ralph-fleet-tests.yml
@@ -1,7 +1,7 @@
 name: Ralph Fleet Tests
 
 # Shell-test suite for the Ralph fleet mechanics under scripts/ralph/ (fleet.sh,
-# pick-next.sh, pr-ready.sh). These scripts live outside tests/, so the main
+# pick-next.sh, pr-ready.sh, watch-pr.sh). These scripts live outside tests/, so the main
 # `pytest`-based CI job doesn't cover them — this workflow keeps the parallel
 # worktree fleet, the picker's parallel-awareness, and the PR-readiness
 # classifier honest. (The Discord recap's pure stats math is a separate
@@ -23,7 +23,7 @@ permissions:
 
 jobs:
   fleet-tests:
-    name: Fleet + picker + pr-ready shell tests
+    name: Fleet + picker + pr-ready + watch-pr shell tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -36,10 +36,11 @@ jobs:
       - name: Shellcheck the ralph scripts
         run: shellcheck --severity=warning scripts/ralph/*.sh
 
-      - name: Run fleet + picker + pr-ready shell tests
+      - name: Run fleet + picker + pr-ready + watch-pr shell tests
         run: |
           git config --global user.email ci@example.com
           git config --global user.name ci
           bash scripts/ralph/test_fleet.sh
           bash scripts/ralph/test_pick_next.sh
           bash scripts/ralph/test_pr_ready.sh
+          bash scripts/ralph/test_watch_pr.sh

--- a/scripts/ralph/FLEET.md
+++ b/scripts/ralph/FLEET.md
@@ -90,13 +90,18 @@ On each wake it:
 4. **Refills every open slot** — while `fleet.sh free > 0` and `pick-next.sh`
    yields a compatible issue, `assign` (or, for a `dependencies` issue already
    riding a bot PR, `adopt`) a worktree and launch a `ralph-worker`.
-5. **Arms per-lane wakes** — background workers wake it on their own completion;
-   each in-flight PR is `subscribe_pr_activity`-subscribed so its CI/verdict wakes
-   it independently; a modest `ScheduleWakeup` backstops the CI-success /
-   `behind→green` transitions the webhook doesn't deliver. **A lane going stale
-   is invisible to webhooks entirely** — `main` moving emits no event on the
-   lane's own PR — so this periodic fallback wake is the *only* thing that
-   ever notices it. Then it ends the turn.
+5. **Arms per-lane wakes (platform-aware)** — background workers wake it on
+   their own completion regardless of platform. On a **remote/webhook-capable**
+   session, each in-flight PR is `subscribe_pr_activity`-subscribed and an
+   **adaptive** `ScheduleWakeup` backstops the transitions webhooks don't
+   deliver: ~180s while any lane's PR is in CI/review (bounding a dropped
+   webhook, a `behind→ready` flip, or a sibling-merge staleness — all
+   event-less — to ~3 minutes), the long ~1200–1800s fallback when every lane
+   is still building. On a **local terminal** session (no webhook MCP), it
+   launches `scripts/ralph/watch-pr.sh <PR>` as a background task per
+   in-flight PR — pidfile-idempotent, and the watcher's exit (the moment
+   `pr-ready.sh`'s token settles) IS the wake — with the long fallback kept
+   as the safety net. Then it ends the turn.
 
 **Workers are background tasks.** Each `ralph-worker` is launched with
 `run_in_background: true` and **never awaited** — launch, end the turn, and let its
@@ -176,7 +181,7 @@ rather than reading as "no hold."
 
 ## Tests
 
-Three offline suites cover the fleet, all run in CI by
+Four offline suites cover the fleet, all run in CI by
 `.github/workflows/ralph-fleet-tests.yml` on any `scripts/ralph/**` change —
 which also runs `shellcheck --severity=warning scripts/ralph/*.sh` first.
 (`creek-tools/scripts/lint-extended.sh` only shellchecks `scripts/*.sh`
@@ -212,11 +217,19 @@ pre-commit hook alone, i.e. not at all for anyone who bypassed it.)
   and gives it no `name:` override, because this classifier matches the review
   check by that literal string and an override would silently wedge every
   Dependabot lane at `awaiting-review` forever.
+- `scripts/ralph/test_watch_pr.sh` stubs `pr-ready.sh` (a sequence-driven fake
+  next to a copy of the script under test) and `gh`, and exercises the local
+  per-lane hot watcher: pidfile idempotence (`already-watching` on a live pid,
+  takeover of a stale/garbage one, removal on exit), settling on the first
+  token outside `pending`/`awaiting-review`, `gone` on a merged/closed PR,
+  `timeout <last-token>` at the deadline, and that transient `pr-ready.sh` /
+  `gh` failures never kill the watcher — every wait outcome exits 0.
 
 ```bash
 bash scripts/ralph/test_fleet.sh
 bash scripts/ralph/test_pick_next.sh
 bash scripts/ralph/test_pr_ready.sh
+bash scripts/ralph/test_watch_pr.sh
 ```
 
 ## Failure modes and how they're handled

--- a/scripts/ralph/test_watch_pr.sh
+++ b/scripts/ralph/test_watch_pr.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# scripts/ralph/test_watch_pr.sh
+#
+# Offline tests for watch-pr.sh — the per-lane hot watch a LOCAL orchestrator
+# session launches as a background task per in-flight PR (ralph-tick.md Step 5).
+# The watcher polls pr-ready.sh and exits — which IS the wake — the moment the
+# token leaves the in-flight set {pending, awaiting-review}, the PR merges or
+# closes (`gone`), or TIMEOUT elapses. Like test_pr_ready.sh, everything runs
+# against stubs: a fake, sequence-driven `pr-ready.sh` placed NEXT TO a copy of
+# the script under test (watch-pr.sh resolves its sibling by dirname), and a
+# fake `gh` on PATH for the merged/closed probe.
+#
+# The dimensions pinned here:
+#
+#   idempotence     a LIVE pidfile → `already-watching`, exit 0, and pr-ready
+#                   is never consulted; a STALE pidfile (dead or garbage pid)
+#                   is taken over; the pidfile is removed again on exit.
+#   settle          pending→ready exits on the first non-in-flight token, and
+#                   every non-in-flight token (behind, ci-failed, …) counts —
+#                   each is a state the orchestrator acts on.
+#   gone            a MERGED or CLOSED PR ends the watch with `gone`, checked
+#                   before pr-ready so a closed lane never spins in the poll.
+#   timeout         TIMEOUT prints `timeout <last-token>` (or `unknown` when
+#                   no poll ever classified) and exits 0 — wait outcomes are
+#                   NEVER non-zero; only usage errors exit 2.
+#   error tolerance a pr-ready tooling failure (exit 2, empty stdout) or a
+#                   failed `gh` state lookup keeps the loop alive — transient
+#                   GitHub weather must not kill the watcher or fake a wake.
+#
+# Run:  bash scripts/ralph/test_watch_pr.sh
+set -euo pipefail
+
+SRC="$(cd "$(dirname "$0")" && pwd)/watch-pr.sh"
+PASS=0
+FAIL=0
+
+ok()  { PASS=$((PASS + 1)); printf '  ok  - %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf 'FAIL  - %s\n' "$1"; }
+check() { # check <desc> <expected> <actual>
+  if [[ "$2" == "$3" ]]; then ok "$1"; else bad "$1 (expected '$2', got '$3')"; fi
+}
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+BIN="$WORK/bin"
+RALPH="$WORK/ralph"
+PIDDIR="$WORK/pids"
+STATE="$WORK/state"
+mkdir -p "$BIN" "$RALPH" "$PIDDIR" "$STATE"
+
+# The script under test, next to its stubbed sibling: watch-pr.sh finds
+# pr-ready.sh by its own dirname, so a copy alongside a fake is the seam.
+cp "$SRC" "$RALPH/watch-pr.sh"
+chmod +x "$RALPH/watch-pr.sh"
+
+# Sequence-driven fake pr-ready.sh. TOKENS is a comma-separated script of
+# answers, one per call (the last repeats forever); the literal `ERR` plays a
+# tooling failure — exit 2, NOTHING on stdout — exactly pr-ready.sh's contract.
+# A counter file exposes how many polls actually happened.
+cat > "$RALPH/pr-ready.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+count_file="$STATE_DIR/ready-calls"
+n="$(cat "$count_file" 2>/dev/null || echo 0)"
+n=$((n + 1))
+echo "$n" > "$count_file"
+IFS=',' read -ra toks <<< "${TOKENS:-pending}"
+idx=$((n - 1))
+[[ "$idx" -lt "${#toks[@]}" ]] || idx=$(( ${#toks[@]} - 1 ))
+tok="${toks[$idx]}"
+[[ "$tok" != "ERR" ]] || exit 2
+printf '%s\n' "$tok"
+STUB
+chmod +x "$RALPH/pr-ready.sh"
+
+# Fake gh for the merged/closed probe. STATES scripts `pr view --json state`
+# answers the same way (last repeats; default OPEN); GH_STATE_EC plays a failed
+# lookup (rate limit, dead network) — non-zero, nothing on stdout.
+cat > "$BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *"pr view"*"--json state"*)
+    if [[ "${GH_STATE_EC:-0}" -ne 0 ]]; then exit "${GH_STATE_EC}"; fi
+    count_file="$STATE_DIR/gh-state-calls"
+    n="$(cat "$count_file" 2>/dev/null || echo 0)"
+    n=$((n + 1))
+    echo "$n" > "$count_file"
+    IFS=',' read -ra sts <<< "${STATES:-OPEN}"
+    idx=$((n - 1))
+    [[ "$idx" -lt "${#sts[@]}" ]] || idx=$(( ${#sts[@]} - 1 ))
+    printf '%s\n' "${sts[$idx]}" ;;
+  *) echo '' ;;
+esac
+STUB
+chmod +x "$BIN/gh"
+
+# run_watch <PR> [INTERVAL] [TIMEOUT] — state dir keyed by PR number (each case
+# uses a distinct PR), because run_watch executes inside a command substitution
+# and a shell variable set there would never reach the parent's assertions.
+# Fast polls (0.1s) keep the whole suite in seconds. cwd is $WORK (no git repo)
+# so the pidfile slug exercises the no-origin fallback path too.
+run_watch() {
+  local sdir="$STATE/case-$1"
+  mkdir -p "$sdir"
+  ( cd "$WORK" &&
+    PATH="$BIN:$PATH" STATE_DIR="$sdir" RALPH_WATCH_PIDDIR="$PIDDIR" \
+    "$RALPH/watch-pr.sh" "$1" "${2:-0.1}" "${3:-30}" 2>/dev/null )
+}
+polls() { cat "$STATE/case-$1/ready-calls" 2>/dev/null || echo 0; }
+
+# --- usage errors are the ONLY non-zero exits ------------------------------
+rc=0
+PATH="$BIN:$PATH" "$RALPH/watch-pr.sh" >/dev/null 2>&1 || rc=$?
+check "missing PR number exits 2" "2" "$rc"
+
+rc=0
+PATH="$BIN:$PATH" "$RALPH/watch-pr.sh" abc >/dev/null 2>&1 || rc=$?
+check "non-numeric PR exits 2" "2" "$rc"
+
+rc=0
+PATH="$BIN:$PATH" "$RALPH/watch-pr.sh" 100 nope >/dev/null 2>&1 || rc=$?
+check "non-numeric INTERVAL exits 2" "2" "$rc"
+
+rc=0
+PATH="$BIN:$PATH" "$RALPH/watch-pr.sh" 100 1 1.5 >/dev/null 2>&1 || rc=$?
+check "fractional TIMEOUT exits 2" "2" "$rc"
+
+# --- settle: exit on the first token OUTSIDE {pending, awaiting-review} -----
+rc=0
+out="$(TOKENS="pending,pending,ready" run_watch 100)" || rc=$?
+check "pending,pending,ready → WATCH ready" "WATCH 100 ready" "$out"
+check "settle exits 0" "0" "$rc"
+check "settle polled exactly 3 times" "3" "$(polls 100)"
+
+out="$(TOKENS="awaiting-review,ci-failed" run_watch 101)"
+check "awaiting-review is in-flight; ci-failed wakes" "WATCH 101 ci-failed" "$out"
+
+# behind / optout / ready-unreviewed all leave the in-flight set immediately —
+# each is orchestrator-actionable (sync, hands-off, report), so each is a wake.
+out="$(TOKENS="behind" run_watch 102)"
+check "behind wakes on the first poll" "WATCH 102 behind" "$out"
+check "behind case polled exactly once" "1" "$(polls 102)"
+
+out="$(TOKENS="optout" run_watch 103)"
+check "optout wakes" "WATCH 103 optout" "$out"
+
+out="$(TOKENS="ready-unreviewed" run_watch 104)"
+check "ready-unreviewed wakes" "WATCH 104 ready-unreviewed" "$out"
+
+# --- gone: a merged/closed PR ends the watch --------------------------------
+rc=0
+out="$(TOKENS="pending" STATES="OPEN,MERGED" run_watch 105)" || rc=$?
+check "PR merging mid-watch → gone" "WATCH 105 gone" "$out"
+check "gone exits 0" "0" "$rc"
+
+out="$(TOKENS="ready" STATES="CLOSED" run_watch 106)"
+check "already-closed PR → gone" "WATCH 106 gone" "$out"
+check "closed PR never even polls pr-ready" "0" "$(polls 106)"
+
+# --- timeout: exit 0, carrying the last classified token --------------------
+rc=0
+out="$(TOKENS="pending" run_watch 107 0.2 1)" || rc=$?
+check "timeout prints last token" "WATCH 107 timeout pending" "$out"
+check "timeout exits 0" "0" "$rc"
+
+# Never classified at all (every poll a tooling failure) → `unknown`.
+out="$(TOKENS="ERR" run_watch 108 0.2 1)"
+check "timeout with no classification → unknown" "WATCH 108 timeout unknown" "$out"
+
+# --- error tolerance: transient failures never kill the watcher -------------
+rc=0
+out="$(TOKENS="ERR,ERR,ready" run_watch 109)" || rc=$?
+check "pr-ready failures are tolerated → ready" "WATCH 109 ready" "$out"
+check "tolerated failures still exit 0" "0" "$rc"
+check "kept polling through the failures" "3" "$(polls 109)"
+
+out="$(TOKENS="ready" GH_STATE_EC=1 run_watch 110)"
+check "failed gh state lookup is tolerated → ready" "WATCH 110 ready" "$out"
+
+# --- pidfile idempotence ----------------------------------------------------
+# A LIVE watcher (this test's own pid) already owns PR 111 → the duplicate
+# reports `already-watching` without a single poll. This is what lets the
+# orchestrator blindly (re)launch a watcher per in-flight PR on every wake.
+slug_pidfile() { # slug_pidfile <PR> — the pidfile path watch-pr.sh derives in $WORK
+  local slug
+  slug="$(basename "$WORK" | tr -c 'A-Za-z0-9_-' '-' | tr -s '-' | sed 's/-$//')"
+  printf '%s\n' "$PIDDIR/ralph-watch-$slug-$1.pid"
+}
+
+echo "$$" > "$(slug_pidfile 111)"
+rc=0
+out="$(TOKENS="ready" run_watch 111)" || rc=$?
+check "live pidfile → already-watching" "WATCH 111 already-watching" "$out"
+check "already-watching exits 0" "0" "$rc"
+check "already-watching never polls" "0" "$(polls 111)"
+check "live pidfile is left alone" "$$" "$(cat "$(slug_pidfile 111)")"
+rm -f "$(slug_pidfile 111)"
+
+# A STALE pidfile (its pid is dead) is taken over, and the watcher removes the
+# pidfile again on exit — no permanent lock from a crashed session or reboot.
+( : ) & dead_pid=$!
+wait "$dead_pid" 2>/dev/null || true
+echo "$dead_pid" > "$(slug_pidfile 112)"
+out="$(TOKENS="ready" run_watch 112)"
+check "stale (dead-pid) pidfile is taken over" "WATCH 112 ready" "$out"
+if [[ -e "$(slug_pidfile 112)" ]]; then
+  bad "pidfile removed on exit"
+else
+  ok "pidfile removed on exit"
+fi
+
+# Garbage in the pidfile is stale too — never a permanent already-watching.
+echo "not-a-pid" > "$(slug_pidfile 113)"
+out="$(TOKENS="ready" run_watch 113)"
+check "garbage pidfile is taken over" "WATCH 113 ready" "$out"
+
+# --- summary ---------------------------------------------------------------
+echo
+echo "watch-pr tests: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/scripts/ralph/watch-pr.sh
+++ b/scripts/ralph/watch-pr.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# scripts/ralph/watch-pr.sh
+#
+# Per-lane hot watch for LOCAL orchestrator sessions (ralph-tick.md Step 5).
+# A remote/mobile session gets woken by `subscribe_pr_activity` webhooks the
+# moment a lane's verdict or CI failure lands; a local terminal session has no
+# webhook MCP at all, so before this script it slept the full ScheduleWakeup
+# fallback (~20–30 min) past every one of those events. On BOTH platforms a
+# background Bash task's exit re-invokes the session — so a process that exits
+# exactly when a lane leaves its in-flight state IS a per-lane wake, and this
+# script is that process: the orchestrator launches one per in-flight PR as a
+# background task, ends the turn, and the first lane to settle wakes it.
+#
+# It polls `scripts/ralph/pr-ready.sh <PR>` (the single authoritative
+# classifier — never a rollup grep) every INTERVAL seconds and exits the moment
+# the token leaves the IN-FLIGHT set {pending, awaiting-review}; every other
+# token (ready, ready-unreviewed, behind, ci-failed, optout) is a state the
+# orchestrator acts on, so it is worth a wake. Output is exactly one line:
+#
+#   WATCH <PR> already-watching     another live watcher owns this PR (pidfile)
+#   WATCH <PR> <token>              the lane settled; <token> is pr-ready.sh's
+#   WATCH <PR> gone                 the PR merged or closed while watching
+#   WATCH <PR> timeout <last-token> TIMEOUT elapsed with the lane still in flight
+#
+# EVERY wait outcome exits 0 — like pr-ready.sh, a non-zero exit means a
+# usage/tooling error at startup, never a verdict about the PR. In particular a
+# transient pr-ready.sh failure (rate limit, 5xx, expired token — it exits 2
+# with nothing on stdout) must NOT kill the watcher: dying there would convert
+# GitHub weather into a spurious wake plus a lane nobody is watching, so the
+# loop tolerates it, keeps the last good token, and polls again.
+#
+# IDEMPOTENT BY PIDFILE: the orchestrator (re)launches watchers for every
+# in-flight PR on every wake without bookkeeping. A live pidfile at
+# $RALPH_WATCH_PIDDIR/ralph-watch-<reposlug>-<PR>.pid (default /tmp) makes the
+# duplicate exit 0 immediately with `already-watching` — a no-op wake — while a
+# stale pidfile (dead pid, e.g. after a reboot) is simply taken over.
+#
+# Usage:  watch-pr.sh <PR_NUMBER> [INTERVAL=30] [TIMEOUT=1800]
+set -euo pipefail
+
+readonly DEFAULT_INTERVAL=30
+readonly DEFAULT_TIMEOUT=1800
+
+# pr-ready.sh's in-flight tokens — the ONLY two on which the lane is genuinely
+# "wait for GitHub". Everything else it prints calls for orchestrator action.
+readonly -a IN_FLIGHT_TOKENS=(pending awaiting-review)
+
+# `gh pr view --json state` values that mean the PR no longer exists to watch.
+readonly MERGED_STATE="MERGED"
+readonly CLOSED_STATE="CLOSED"
+
+die() { echo "watch-pr: $1" >&2; exit 2; }
+
+pr="${1-}"
+interval="${2:-$DEFAULT_INTERVAL}"
+timeout="${3:-$DEFAULT_TIMEOUT}"
+[[ "$pr" =~ ^[0-9]+$ ]] ||
+  die "usage: watch-pr.sh <PR_NUMBER> [INTERVAL=$DEFAULT_INTERVAL] [TIMEOUT=$DEFAULT_TIMEOUT]"
+# Fractional INTERVALs are legal (GNU sleep accepts them; the tests use them),
+# but TIMEOUT stays an integer because the deadline math is whole epoch seconds.
+[[ "$interval" =~ ^[0-9]+(\.[0-9]+)?$ ]] || die "INTERVAL must be a number, got '$interval'"
+[[ "$timeout" =~ ^[0-9]+$ ]] || die "TIMEOUT must be an integer number of seconds, got '$timeout'"
+
+READY="$(cd "$(dirname "$0")" && pwd)/pr-ready.sh"
+[[ -x "$READY" ]] || die "cannot find pr-ready.sh next to this script ($READY)"
+
+# One watcher per repo per PR. The slug comes from the origin URL so two clones
+# of DIFFERENT repos never share a pidfile; a clone with no origin falls back to
+# its directory name. Sanitized to [A-Za-z0-9_-] so the slug can never smuggle
+# path separators into the pidfile path.
+repo_slug() {
+  local url slug
+  url="$(git config --get remote.origin.url 2>/dev/null || true)"
+  if [[ -n "$url" ]]; then
+    slug="${url%/}"; slug="${slug%.git}"
+    slug="$(basename "$slug")"
+  else
+    slug="$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")"
+  fi
+  printf '%s\n' "$slug" | tr -c 'A-Za-z0-9_-' '-' | tr -s '-' | sed 's/-$//'
+}
+
+pidfile="${RALPH_WATCH_PIDDIR:-/tmp}/ralph-watch-$(repo_slug)-${pr}.pid"
+
+if [[ -f "$pidfile" ]]; then
+  old_pid="$(cat "$pidfile" 2>/dev/null || true)"
+  if [[ "$old_pid" =~ ^[0-9]+$ ]] && kill -0 "$old_pid" 2>/dev/null; then
+    echo "WATCH $pr already-watching"
+    exit 0
+  fi
+  # Dead pid → stale file (a rebooted machine, a killed session). Take over.
+fi
+echo "$$" > "$pidfile"
+trap 'rm -f "$pidfile"' EXIT
+
+in_flight() { # in_flight <token> — is this a keep-waiting token?
+  local t
+  for t in "${IN_FLIGHT_TOKENS[@]}"; do
+    [[ "$1" == "$t" ]] && return 0
+  done
+  return 1
+}
+
+start="$(date +%s)"
+last_token="unknown"
+
+while :; do
+  # A merged/closed PR would sit in the poll forever (pr-ready.sh classifies
+  # open work, not absence), so the terminal states are checked explicitly.
+  # The lookup failing is the same transient weather as a pr-ready failure —
+  # keep looping, never die.
+  state="$(gh pr view "$pr" --json state --jq '.state' 2>/dev/null || true)"
+  if [[ "$state" == "$MERGED_STATE" || "$state" == "$CLOSED_STATE" ]]; then
+    echo "WATCH $pr gone"
+    exit 0
+  fi
+
+  # `|| true` twice over: pr-ready.sh exits 2 on a tooling error (with nothing
+  # on stdout), and under `set -e` an unguarded call would kill the watcher —
+  # exactly the die-on-transient-failure this script exists to avoid.
+  token="$(bash "$READY" "$pr" 2>/dev/null || true)"
+  if [[ -n "$token" ]]; then
+    last_token="$token"
+    if ! in_flight "$token"; then
+      echo "WATCH $pr $token"
+      exit 0
+    fi
+  fi
+
+  now="$(date +%s)"
+  if (( now - start >= timeout )); then
+    echo "WATCH $pr timeout $last_token"
+    exit 0
+  fi
+  sleep "$interval"
+done


### PR DESCRIPTION
## Problem

The orchestrator's Step 5 wake policy was written for one platform and paid for it on both:

- **Local terminal sessions have no webhook MCP at all** — `mcp__github__subscribe_pr_activity` simply does not exist there. Every verdict, CI failure, and merge landed mid-sleep and waited out the full ~1200–1800s `ScheduleWakeup` fallback. With four lanes cycling through review, that fallback sleep *was* the loop's latency.
- **Remote sessions** have webhooks, but webhooks never deliver CI success, `behind→ready` flips, or sibling-merge staleness (a merge moves `main` and emits no event on any other lane's PR) — and webhooks occasionally drop. A single long fallback bounded all of those blind spots at ~30 minutes.

The platform truth that fixes the local half: **a background Bash task's exit re-invokes the session**, so a process that exits exactly when a lane settles IS a per-lane wake.

## Design

**`scripts/ralph/watch-pr.sh <PR> [INTERVAL=30] [TIMEOUT=1800]`** (new) — the hot watcher a local session launches as a background task per in-flight PR. It polls `pr-ready.sh` (the single authoritative classifier — never a rollup grep) and exits 0 printing exactly one line:

| Output | Meaning |
| --- | --- |
| `WATCH <PR> already-watching` | a live watcher already owns this PR (pidfile `/tmp/ralph-watch-<reposlug>-<PR>.pid`) — relaunching every wake is idempotent, no bookkeeping |
| `WATCH <PR> <token>` | the token left the in-flight set `{pending, awaiting-review}` — `ready`, `ready-unreviewed`, `behind`, `ci-failed`, and `optout` are all orchestrator-actionable, so each is a wake |
| `WATCH <PR> gone` | the PR merged/closed while watching |
| `WATCH <PR> timeout <last-token>` | TIMEOUT elapsed still in flight |

Wait outcomes are **never non-zero** (exit 2 = usage/tooling error only, matching `pr-ready.sh`'s contract), and transient `pr-ready.sh`/`gh` failures keep the loop alive — GitHub weather must not kill a watcher or fake a wake. Stale pidfiles (dead or garbage pid) are taken over; the pidfile is removed on exit.

**`ralph-tick.md` Step 5** is now platform-aware:
- **REMOTE**: subscribe every in-flight PR (idempotent, every wake) + an **adaptive** fallback — ~180s while any lane's PR is in CI/review, the long ~1200–1800s one when every lane is still building. The short fallback bounds every webhook blind spot (drop, green flip, staleness) to ~3 minutes. Notes that this repo's `iteration-trigger.yml` converts full-green CI + verdict into a delivered *comment*, so even the green transition usually arrives as a webhook here.
- **LOCAL**: launch `watch-pr.sh` per in-flight PR as a background task every wake; the watcher's exit is the wake; the long fallback stays as safety net.
- Either platform: never foreground-block on a lane.

**`FLEET.md`** arms-wakes item summarizes the same policy; **`await-claude-review/SKILL.md`** gains a "Local Sessions (No Webhook MCP)" section (background watcher via `watch-pr.sh`, or `gh pr checks --watch` + verdict poll as a background task; same event semantics; never foreground sleep) and scopes its anti-polling troubleshooting entry to webhook-capable sessions.

## Testing

- **`scripts/ralph/test_watch_pr.sh`** (new): offline stub harness mirroring `test_pr_ready.sh` — a sequence-driven fake `pr-ready.sh` next to a copy of the script under test, a fake `gh` on PATH. 30 assertions pin pidfile idempotence (live / stale / garbage / removed-on-exit), settling on every non-in-flight token, `gone` on merged and already-closed PRs (checked before the poll), `timeout <last-token>` and `timeout unknown`, error tolerance through consecutive tooling failures, and that only usage errors exit non-zero. Runs in ~3s.
- Wired into `.github/workflows/ralph-fleet-tests.yml`, whose existing `shellcheck --severity=warning scripts/ralph/*.sh` step covers both new files via its glob.
- Local gate results: `shellcheck` clean at full severity on both new scripts; all four ralph suites green (`test_fleet.sh` 85, `test_pick_next.sh` 24, `test_pr_ready.sh` 82, `test_watch_pr.sh` 30); pre-commit hooks (whitespace/EOF/yaml/shellcheck/secrets/conventional-commit) pass on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8WUrXkNnVvPK14EtmEjxg)_